### PR TITLE
Replace CSS bar charts with ECharts, add multi-partition disk monitoring

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
             "command": "npx",
             "args": [
                 "-y",
-                "@modelcontextprotocol/server-filesystem",
+                "@anthropic-ai/mcp-server-filesystem@latest",
                 "/var/www/jabali",
                 "/home",
                 "/etc/nginx",
@@ -17,7 +17,7 @@
             "command": "npx",
             "args": [
                 "-y",
-                "@benborla29/mcp-server-mysql"
+                "@anthropic-ai/mcp-server-mysql@latest"
             ],
             "env": {
                 "MYSQL_HOST": "localhost",

--- a/app/Filament/Admin/Widgets/ServerChartsWidget.php
+++ b/app/Filament/Admin/Widgets/ServerChartsWidget.php
@@ -127,7 +127,7 @@ class ServerChartsWidget extends Widget
         foreach ($mounts as $line) {
             $parts = preg_split('/\s+/', $line);
             $device = $parts[0] ?? '';
-            $mount = $parts[1] ?? '';
+            $mount = stripcslashes($parts[1] ?? '');
             $fstype = $parts[2] ?? '';
 
             if (! str_starts_with($device, '/dev/') || isset($seen[$device])) {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -47,7 +47,7 @@ class AdminPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::HEAD_END,
                 fn () => $this->getOpenGraphTags($this->getAdminBrandName(), 'Server administration panel for Jabali - Manage your hosting infrastructure').
-                    \Illuminate\Support\Facades\Vite::useBuildDirectory('build')->withEntryPoints(['resources/css/app.css', 'resources/js/server-charts.js', 'resources/js/echarts.js'])->toHtml().
+                    \Illuminate\Support\Facades\Vite::useBuildDirectory('build')->withEntryPoints(['resources/css/app.css', 'resources/js/echarts.js'])->toHtml().
 $this->getRtlScript()
             )
             ->renderHook(

--- a/resources/js/echarts.js
+++ b/resources/js/echarts.js
@@ -1,18 +1,7 @@
 import * as echarts from 'echarts';
 import 'echarts/theme/shine';
-import 'echarts/theme/dark';
 
-// Override dark theme background to transparent so it works inside Filament sections
-const darkOverride = { backgroundColor: 'transparent' };
 echarts.registerTheme('jabali-dark', {
-    ...(() => {
-        // Get the dark theme and override backgroundColor
-        const tmp = document.createElement('div');
-        const chart = echarts.init(tmp, 'dark');
-        const theme = chart.getOption();
-        chart.dispose();
-        return {};
-    })(),
     darkMode: true,
     color: ['#4992ff', '#7cffb2', '#fddd60', '#ff6e76', '#58d9f9', '#05c091', '#ff8a45', '#8d48e3', '#dd79ff'],
     backgroundColor: 'transparent',

--- a/resources/views/filament/admin/widgets/server-charts.blade.php
+++ b/resources/views/filament/admin/widgets/server-charts.blade.php
@@ -47,69 +47,88 @@
     <x-filament::section compact>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4"
             x-data="{
-                instances: [],
+                charts: {},
                 get isDark() { return document.documentElement.classList.contains('dark') },
                 init() {
-                    this.$nextTick(() => {
-                        this.bar(this.$refs.cpu, {{ \Illuminate\Support\Js::from($cpuChart) }});
-                        this.bar(this.$refs.mem, {{ \Illuminate\Support\Js::from($memChart) }});
-                        this.bar(this.$refs.disk, {{ \Illuminate\Support\Js::from($diskChart) }});
-                    });
+                    this.$nextTick(() => this.buildAll());
                     new MutationObserver(() => this.rebuildAll()).observe(
                         document.documentElement, { attributes: true, attributeFilter: ['class'] }
                     );
                 },
-                rebuildAll() {
-                    this.instances.forEach(i => { i.chart.dispose(); i.build(); });
+                buildAll() {
+                    this.update(this.$refs.cpu, 'cpu', {{ \Illuminate\Support\Js::from($cpuChart) }});
+                    this.update(this.$refs.mem, 'mem', {{ \Illuminate\Support\Js::from($memChart) }});
+                    this.update(this.$refs.disk, 'disk', {{ \Illuminate\Support\Js::from($diskChart) }});
                 },
-                bar(el, d) {
-                    const build = () => {
-                        const dark = this.isDark;
-                        const chart = echarts.init(el, dark ? 'jabali-dark' : 'shine', { renderer: 'canvas' });
-                        chart.setOption({
-                            grid: { left: 4, right: 4, top: 2, bottom: 2 },
-                            xAxis: { type: 'value', max: 100, show: false },
-                            yAxis: { type: 'category', data: d.names, inverse: true, show: false },
-                            series: [{
-                                type: 'bar',
-                                barWidth: '80%',
-                                barGap: '10%',
-                                showBackground: true,
-                                backgroundStyle: { borderRadius: 0 },
-                                animationDuration: 600,
-                                data: d.values.map((v, i) => ({
-                                    value: v,
-                                    itemStyle: { color: d.colors[i], borderRadius: 0 },
-                                    label: {
-                                        show: true,
-                                        position: v > 3 ? 'insideLeft' : 'right',
-                                        fontWeight: 'normal',
-                                        fontSize: 11,
-                                        formatter: d.labels[i],
-                                    },
-                                })),
-                            }],
-                        });
-                        return chart;
+                rebuildAll() {
+                    Object.keys(this.charts).forEach(key => {
+                        const entry = this.charts[key];
+                        entry.chart.dispose();
+                        entry.chart = this.createChart(entry.el, entry.data);
+                    });
+                },
+                update(el, key, d) {
+                    if (this.charts[key]) {
+                        this.charts[key].data = d;
+                        this.updateChart(this.charts[key].chart, d);
+                    } else {
+                        this.charts[key] = { el, data: d, chart: this.createChart(el, d) };
+                    }
+                },
+                createChart(el, d) {
+                    const chart = echarts.init(el, this.isDark ? 'jabali-dark' : 'shine', { renderer: 'canvas' });
+                    chart.setOption(this.buildOption(d));
+                    return chart;
+                },
+                updateChart(chart, d) {
+                    chart.setOption(this.buildOption(d));
+                },
+                buildOption(d) {
+                    return {
+                        grid: { left: 4, right: 4, top: 2, bottom: 2 },
+                        xAxis: { type: 'value', max: 100, show: false },
+                        yAxis: { type: 'category', data: d.names, inverse: true, show: false },
+                        series: [{
+                            type: 'bar',
+                            barWidth: '80%',
+                            barGap: '10%',
+                            showBackground: true,
+                            backgroundStyle: { borderRadius: 0 },
+                            animationDuration: 600,
+                            data: d.values.map((v, i) => ({
+                                value: v,
+                                itemStyle: { color: d.colors[i], borderRadius: 0 },
+                                label: {
+                                    show: true,
+                                    position: v > 3 ? 'insideLeft' : 'right',
+                                    fontWeight: 'normal',
+                                    fontSize: 11,
+                                    formatter: d.labels[i],
+                                },
+                            })),
+                        }],
                     };
-                    const entry = { chart: build(), build };
-                    this.instances.push(entry);
                 },
             }"
+            x-init="$wire.on('$refresh', () => $nextTick(() => buildAll()))"
         >
             {{-- CPU & IO Wait --}}
-            <div class="px-4 py-3" wire:ignore>
+            <div class="px-4 py-3">
                 <div x-ref="cpu" class="h-[70px] w-full"></div>
             </div>
 
             {{-- Memory & Swap --}}
-            <div class="px-4 py-3" wire:ignore>
+            <div class="px-4 py-3">
                 <div x-ref="mem" class="h-[70px] w-full"></div>
             </div>
 
             {{-- Disk --}}
-            <div class="px-4 py-3" wire:ignore>
-                <div x-ref="disk" class="h-[70px] w-full"></div>
+            <div class="px-4 py-3">
+                @if(empty($disk))
+                    <p class="flex h-[70px] items-center text-xs opacity-60">{{ __('No disk data') }}</p>
+                @else
+                    <div x-ref="disk" class="h-[70px] w-full"></div>
+                @endif
             </div>
 
             {{-- Network --}}


### PR DESCRIPTION
## Summary
- Replaced pure-CSS server monitoring bars with ECharts for better visualization and dark mode support
- Detect all real disk partitions via `/proc/mounts` instead of only `/`
- Added `echarts` and `chartjs-plugin-datalabels` dependencies
- Updated MCP server package references and Filament boost guidelines

## Test plan
- [ ] Verify server charts render correctly in light and dark mode
- [ ] Confirm multi-partition disk usage displays all mounted partitions
- [ ] Check network stats still display properly
- [ ] Run `npm run build` and verify no Vite errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)