### PR TITLE
feat(m50): per-directory password protection

### DIFF
--- a/panel-agent/internal/commands/dirprivacy.go
+++ b/panel-agent/internal/commands/dirprivacy.go
@@ -1,0 +1,256 @@
+// M50 — per-directory password protection (cPanel "Directory Privacy").
+//
+// The panel POSTs rules + bcrypt-hashed credentials in the domain.create
+// payload. The agent writes one htpasswd file per rule under
+// /etc/jabali-panel/dir-privacy/<rule_ulid>.htpasswd (0640 root:www-data,
+// outside docroot) and the vhost template emits one
+// `location ^~ <path>/ { auth_basic <realm>; auth_basic_user_file <path>; }`
+// block per rule. Empty-cred rules get a placeholder htpasswd that can't
+// match any password so the location 401s deny-by-default.
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	dirPrivacyDir       = "/etc/jabali-panel/dir-privacy"
+	dirPrivacyFileMode  = 0o640
+	dirPrivacyDirMode   = 0o755
+	dirPrivacyGroupName = "www-data"
+)
+
+// directoryPrivacyRule mirrors the panel-side model. The htpasswd file
+// is keyed by RuleID so the agent can deterministically locate and
+// prune the per-rule file.
+type directoryPrivacyRule struct {
+	RuleID      string                       `json:"rule_id"`
+	Path        string                       `json:"path"`
+	Realm       string                       `json:"realm"`
+	Credentials []directoryPrivacyCredential `json:"credentials"`
+}
+
+// directoryPrivacyCredential carries a bcrypt hash ($2y/$2a/$2b/$2x).
+// Plaintext is never sent — the panel hashes at the API boundary so
+// neither the wire nor agent logs ever see it.
+type directoryPrivacyCredential struct {
+	Username     string `json:"username"`
+	PasswordHash string `json:"password_hash"`
+}
+
+var (
+	privacyPathAgentRE     = regexp.MustCompile(`^/[A-Za-z0-9_./-]+$`)
+	privacyUsernameAgentRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,64}$`)
+	privacyBcryptRE        = regexp.MustCompile(`^\$2[abxy]\$`)
+	privacyULIDRE          = regexp.MustCompile(`^[0-9A-HJKMNP-TV-Z]{26}$`)
+)
+
+// syncDirectoryPrivacyFiles writes the htpasswd file for every rule and
+// removes any orphaned files (rule deleted on the panel but file still
+// present on disk). On entry, rules is the full desired state for the
+// caller's domain; the orphan sweep targets only files in dirPrivacyDir
+// whose name (sans .htpasswd) appears in domainRuleIDs but not in rules.
+//
+// Returns the list of rule IDs that produced an htpasswd file so the
+// caller can render only those into the vhost.
+func syncDirectoryPrivacyFiles(rules []directoryPrivacyRule, domainRuleIDs []string) ([]string, error) {
+	if err := ensureDirPrivacyDir(); err != nil {
+		return nil, err
+	}
+	keep := make(map[string]bool, len(rules))
+	written := make([]string, 0, len(rules))
+	for i := range rules {
+		r := &rules[i]
+		if !privacyULIDRE.MatchString(r.RuleID) {
+			return nil, fmt.Errorf("dirprivacy: invalid rule id %q", r.RuleID)
+		}
+		path, err := normalisePrivacyPath(r.Path)
+		if err != nil {
+			return nil, fmt.Errorf("dirprivacy: %w", err)
+		}
+		r.Path = path
+		filePath := dirPrivacyFileForRule(r.RuleID)
+		if err := writeHtpasswd(filePath, r.Credentials); err != nil {
+			return nil, fmt.Errorf("dirprivacy: write %s: %w", filePath, err)
+		}
+		keep[r.RuleID] = true
+		written = append(written, r.RuleID)
+	}
+	// Prune orphans for *this* domain only. domainRuleIDs is the list of
+	// rule IDs panel knows about for this domain; rules is the subset we
+	// just wrote. The difference is what to delete.
+	for _, id := range domainRuleIDs {
+		if !privacyULIDRE.MatchString(id) {
+			continue
+		}
+		if keep[id] {
+			continue
+		}
+		_ = os.Remove(dirPrivacyFileForRule(id))
+	}
+	return written, nil
+}
+
+// writeHtpasswd writes `<user>:<hash>` lines for each credential, atomic
+// via tmp+rename, perms 0640, group ownership www-data so nginx can read.
+// Empty creds → placeholder line `__deny__:!` (bcrypt rejects `!`, so
+// 401 sticks).
+func writeHtpasswd(filePath string, creds []directoryPrivacyCredential) error {
+	var sb strings.Builder
+	if len(creds) == 0 {
+		sb.WriteString("__deny__:!\n")
+	} else {
+		for _, c := range creds {
+			if !privacyUsernameAgentRE.MatchString(c.Username) {
+				continue
+			}
+			if !privacyBcryptRE.MatchString(c.PasswordHash) {
+				continue
+			}
+			sb.WriteString(c.Username)
+			sb.WriteString(":")
+			sb.WriteString(c.PasswordHash)
+			sb.WriteString("\n")
+		}
+		if sb.Len() == 0 {
+			// All credentials rejected by sanitiser — preserve deny-by-default.
+			sb.WriteString("__deny__:!\n")
+		}
+	}
+	tmp := filePath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(sb.String()), dirPrivacyFileMode); err != nil {
+		return err
+	}
+	// Best-effort chown root:www-data. Fails as non-root (tests/dev)
+	// without affecting correctness — file perms 0640 still apply.
+	_ = chownWWWData(tmp)
+	return os.Rename(tmp, filePath)
+}
+
+// buildDirectoryPrivacyDirectives emits one nginx `location ^~ <path>/`
+// block per rule. ^~ is the "longest-prefix-with-no-regex-override"
+// modifier — once nginx picks this location it stops looking at regex
+// locations, which is what we want for a password-gated directory.
+//
+// Empty rules slice → empty string (zero overhead, no comment line).
+func buildDirectoryPrivacyDirectives(rules []directoryPrivacyRule) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("# M50 directory privacy (auth_basic)\n")
+	for _, r := range rules {
+		if !privacyULIDRE.MatchString(r.RuleID) {
+			continue
+		}
+		path, err := normalisePrivacyPath(r.Path)
+		if err != nil {
+			continue
+		}
+		realm := sanitisePrivacyRealm(r.Realm)
+		htpasswd := dirPrivacyFileForRule(r.RuleID)
+		sb.WriteString("    location ^~ ")
+		sb.WriteString(path)
+		sb.WriteString("/ {\n")
+		sb.WriteString("        auth_basic ")
+		sb.WriteString(strconv.Quote(realm))
+		sb.WriteString(";\n")
+		sb.WriteString("        auth_basic_user_file ")
+		sb.WriteString(htpasswd)
+		sb.WriteString(";\n")
+		sb.WriteString("    }\n")
+	}
+	return sb.String()
+}
+
+// normalisePrivacyPath ensures the path starts with /, has no .., no //,
+// no trailing slash (except root), and matches the safe charset.
+func normalisePrivacyPath(in string) (string, error) {
+	p := strings.TrimSpace(in)
+	if p == "" {
+		return "", fmt.Errorf("path required")
+	}
+	if p == "/" {
+		return "/", nil
+	}
+	if !privacyPathAgentRE.MatchString(p) {
+		return "", fmt.Errorf("path invalid charset")
+	}
+	if strings.Contains(p, "//") {
+		return "", fmt.Errorf("path contains //")
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("path contains ..")
+		}
+	}
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+		if p == "" {
+			p = "/"
+		}
+	}
+	return p, nil
+}
+
+// sanitisePrivacyRealm strips disallowed chars; falls back to "Restricted"
+// on empty/garbage input. Belt-and-braces — panel already validated.
+func sanitisePrivacyRealm(in string) string {
+	r := strings.TrimSpace(in)
+	if r == "" {
+		return "Restricted"
+	}
+	var b strings.Builder
+	for _, c := range r {
+		if c < 0x20 || c > 0x7e {
+			continue
+		}
+		if c == '"' || c == '\\' {
+			continue
+		}
+		b.WriteRune(c)
+	}
+	if b.Len() == 0 {
+		return "Restricted"
+	}
+	return b.String()
+}
+
+func dirPrivacyFileForRule(ruleID string) string {
+	return filepath.Join(dirPrivacyDir, ruleID+".htpasswd")
+}
+
+func ensureDirPrivacyDir() error {
+	if err := os.MkdirAll(dirPrivacyDir, dirPrivacyDirMode); err != nil {
+		return fmt.Errorf("dirprivacy: mkdir %s: %w", dirPrivacyDir, err)
+	}
+	// Chown directory to www-data group so nginx (which doesn't need it
+	// for reads with 0640 + group ownership on files, but does benefit
+	// from directory rx for traversal under hardened umasks) can list.
+	if err := chownWWWData(dirPrivacyDir); err != nil {
+		// Non-fatal: directory may already exist with correct perms.
+		// Fail later on the per-file chown if the group is really missing.
+		return nil //nolint:nilerr
+	}
+	return nil
+}
+
+// chownWWWData sets owner root:www-data on path. Silently no-ops if the
+// www-data group can't be resolved (test environments, exotic distros).
+func chownWWWData(path string) error {
+	grp, err := user.LookupGroup(dirPrivacyGroupName)
+	if err != nil {
+		return nil //nolint:nilerr
+	}
+	gid, err := strconv.Atoi(grp.Gid)
+	if err != nil {
+		return nil //nolint:nilerr
+	}
+	return os.Chown(path, 0, gid)
+}

--- a/panel-agent/internal/commands/dirprivacy_test.go
+++ b/panel-agent/internal/commands/dirprivacy_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalisePrivacyPath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"/secret", "/secret", false},
+		{"/a/b/c", "/a/b/c", false},
+		{"/trim/", "/trim", false},
+		{"/", "/", false},
+		{"", "", true},
+		{"no-leading-slash", "", true},
+		{"/has space", "", true},
+		{"/has//double", "", true},
+		{"/../etc/passwd", "", true},
+		{"/ok-but-dotdot/../boom", "", true},
+		{"/special$char", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalisePrivacyPath(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalisePrivacyPath(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalisePrivacyPath(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalisePrivacyPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSanitisePrivacyRealm(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "Restricted"},
+		{"Staging", "Staging"},
+		{`bad"quote`, "badquote"},
+		{`bad\back`, "badback"},
+		{"highÿascii", "highascii"},
+		{"  trim  ", "trim"},
+	}
+	for _, tc := range cases {
+		got := sanitisePrivacyRealm(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitisePrivacyRealm(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestWriteHtpasswd_EmptyCreds_DenyByDefault(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "rule.htpasswd")
+	if err := writeHtpasswd(f, nil); err != nil {
+		t.Fatalf("writeHtpasswd: %v", err)
+	}
+	got, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "__deny__:!") {
+		t.Errorf("want deny-by-default placeholder, got %q", got)
+	}
+	info, _ := os.Stat(f)
+	if info.Mode().Perm() != dirPrivacyFileMode {
+		t.Errorf("perm = %v, want %v", info.Mode().Perm(), os.FileMode(dirPrivacyFileMode))
+	}
+}
+
+func TestWriteHtpasswd_BcryptOnly(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "rule.htpasswd")
+	creds := []directoryPrivacyCredential{
+		{Username: "alice", PasswordHash: "$2y$10$abcdefghijklmnopqrstuv"},
+		{Username: "bob", PasswordHash: "$2a$12$abcdefghijklmnopqrstuv"},
+		// rejected: bad username
+		{Username: "bad user", PasswordHash: "$2y$10$abc"},
+		// rejected: not bcrypt
+		{Username: "carol", PasswordHash: "plaintext"},
+	}
+	if err := writeHtpasswd(f, creds); err != nil {
+		t.Fatalf("writeHtpasswd: %v", err)
+	}
+	got, _ := os.ReadFile(f)
+	s := string(got)
+	if !strings.Contains(s, "alice:$2y") {
+		t.Errorf("missing alice; got %q", s)
+	}
+	if !strings.Contains(s, "bob:$2a") {
+		t.Errorf("missing bob; got %q", s)
+	}
+	if strings.Contains(s, "bad user") {
+		t.Errorf("did not reject bad username: %q", s)
+	}
+	if strings.Contains(s, "carol") {
+		t.Errorf("did not reject non-bcrypt hash: %q", s)
+	}
+}
+
+func TestBuildDirectoryPrivacyDirectives(t *testing.T) {
+	rules := []directoryPrivacyRule{
+		{
+			RuleID: "01HZZZ8RMJG3K4P5N6Q7R8S9T0",
+			Path:   "/secret",
+			Realm:  "Staging",
+		},
+	}
+	got := buildDirectoryPrivacyDirectives(rules)
+	if !strings.Contains(got, `location ^~ /secret/`) {
+		t.Errorf("missing location directive: %q", got)
+	}
+	if !strings.Contains(got, `auth_basic "Staging"`) {
+		t.Errorf("missing auth_basic realm: %q", got)
+	}
+	if !strings.Contains(got, dirPrivacyDir+"/01HZZZ8RMJG3K4P5N6Q7R8S9T0.htpasswd") {
+		t.Errorf("missing htpasswd path: %q", got)
+	}
+}
+
+func TestBuildDirectoryPrivacyDirectives_RealmEscaping(t *testing.T) {
+	rules := []directoryPrivacyRule{
+		{
+			RuleID: "01HZZZ8RMJG3K4P5N6Q7R8S9T0",
+			Path:   "/x",
+			Realm:  `evil"quote`, // sanitised to evilquote
+		},
+	}
+	got := buildDirectoryPrivacyDirectives(rules)
+	if !strings.Contains(got, `auth_basic "evilquote"`) {
+		t.Errorf("realm not sanitised: %q", got)
+	}
+}
+
+func TestBuildDirectoryPrivacyDirectives_RejectsBadRule(t *testing.T) {
+	got := buildDirectoryPrivacyDirectives([]directoryPrivacyRule{
+		{RuleID: "not-a-ulid", Path: "/x", Realm: "X"},
+	})
+	if strings.Contains(got, "not-a-ulid") {
+		t.Errorf("emitted bad rule ID: %q", got)
+	}
+}
+
+func TestBuildDirectoryPrivacyDirectives_Empty(t *testing.T) {
+	if got := buildDirectoryPrivacyDirectives(nil); got != "" {
+		t.Errorf("empty rules: got %q, want \"\"", got)
+	}
+}

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -71,6 +71,15 @@ type domainCreateParams struct {
 	// `allow <cidr>;` / `deny <cidr>;` directive in priority order
 	// inside the server block.
 	IPACLs []domainIPACLRule `json:"ip_acls,omitempty"`
+
+	// M50 per-directory password protection. Each rule produces one
+	// htpasswd file under /etc/jabali-panel/dir-privacy/<rule_id>.htpasswd
+	// and one `location ^~ <path>/ { auth_basic ...; }` block inside the
+	// vhost. DirectoryPrivacyRuleIDs is the full set of rule IDs panel
+	// knows about for this domain — the agent uses it to detect orphaned
+	// htpasswd files (rule deleted on panel, file still on disk).
+	DirectoryPrivacyRules   []directoryPrivacyRule `json:"directory_privacy_rules,omitempty"`
+	DirectoryPrivacyRuleIDs []string               `json:"directory_privacy_rule_ids,omitempty"`
 }
 
 // domainIPACLRule is one allow/deny entry. CIDR is canonicalised by
@@ -153,6 +162,7 @@ server {
     {{.IndexDirective}}
 
     {{.IPACLDirectives}}
+    {{.DirectoryPrivacyDirectives}}
 
     location / {
 {{ if .HasPHP }}
@@ -272,6 +282,10 @@ type vhostData struct {
 	// string when the domain has no ACLs (zero overhead). Sits inside
 	// the server block so it applies to every location.
 	IPACLDirectives string
+	// M50 directory privacy — pre-rendered `location ^~ <path>/ {
+	// auth_basic ...; auth_basic_user_file ...; }` blocks, one per
+	// rule. Empty string when the domain has no privacy rules.
+	DirectoryPrivacyDirectives string
 	// ADR-0108 FastCGI micro-cache. All three are panel/agent-controlled
 	// (never user data). When CacheEnabled is false the template emits
 	// none of the cache/static directives → byte-identical to pre-0108.
@@ -353,7 +367,7 @@ func buildPHPValueParam(memLimit, uploadMax, postMax string, maxInputVars, maxEx
 // writeVhost generates and writes the nginx vhost configuration, then tests and reloads nginx.
 // This is the core logic shared by domain.create and domain.enable/disable.
 // If the config content is unchanged, nginx reload is skipped for efficiency.
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool) (string, error) {
 	// Generate vhost configuration
 	tmpl, err := template.New("vhost").Parse(vhostTemplate)
 	if err != nil {
@@ -372,6 +386,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		CustomDirectives:   customDirectives,
 		RateLimitDirectives: rateLimitDirectives,
 		IPACLDirectives:    ipACLDirectives,
+		DirectoryPrivacyDirectives: dirPrivacyDirectives,
 		IsEnabled:          isEnabled,
 		SSLCertPath:        sslCertPath,
 		SSLKeyPath:         sslKeyPath,
@@ -545,7 +560,16 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 
 	rateLimitDirectives := BuildRateLimitDirectives(p.DomainID, p.RateLimitRPS, p.ConnectionLimit)
 	ipACLDirectives := buildIPACLDirectives(p.IPACLs)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled)
+	// M50: write htpasswd files first; on failure, do NOT write the vhost
+	// (leaves nginx pointing at non-existent files = nginx -t fails).
+	if _, err := syncDirectoryPrivacyFiles(p.DirectoryPrivacyRules, p.DirectoryPrivacyRuleIDs); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: err.Error(),
+		}
+	}
+	dirPrivacyDirectives := buildDirectoryPrivacyDirectives(p.DirectoryPrivacyRules)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -280,6 +280,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 		deps.BWDaily = repository.NewBWDailyRepository(sharedDB)
 		deps.DomainIPACLs = repository.NewDomainIPACLRepository(sharedDB)
+		deps.DomainDirectoryPrivacy = repository.NewDomainDirectoryPrivacyRepository(sharedDB)
 		// M35: migration importers — Step 1 wires the repo only.
 		// Steps 3-7 land per-source importer code that calls these
 		// methods; admin REST + UI in Step 8. Default-off until
@@ -365,6 +366,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// agent's domain.create payload; agent renders nginx directives
 		// inside the server block.
 		rec.WithDomainIPACLs(deps.DomainIPACLs)
+		rec.WithDomainDirectoryPrivacy(deps.DomainDirectoryPrivacy)
 		// M30 (ADR-0075): backup-restore workflow rows.
 		deps.BackupJobs = repository.NewBackupJobRepository(sharedDB)
 		// M30.2 (ADR-0080): destinations + schedules. backup_copy_jobs

--- a/panel-api/internal/api/domain_directory_privacy.go
+++ b/panel-api/internal/api/domain_directory_privacy.go
@@ -1,0 +1,404 @@
+// Per-directory password protection (cPanel "Directory Privacy", M50).
+//
+// Routes (mounted under /api/v1/domains/:id/directory-privacy):
+//
+//	GET                         list rules for one domain
+//	POST                        create a rule
+//	PUT    /:rule_id             update a rule (realm only)
+//	DELETE /:rule_id             delete a rule
+//	GET    /:rule_id/credentials list credentials under a rule
+//	POST   /:rule_id/credentials add a credential (plaintext in, hashed at write)
+//	DELETE /:rule_id/credentials/:cred_id  delete a credential
+//
+// Authorization: admins read+write any; users only their own domains.
+// Cross-tenant access returns 404 (not 403) to avoid leaking domain
+// existence. Mirrors M36 IP ACL handler shape so the two surfaces stay
+// in lockstep.
+package api
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/models"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// DomainDirectoryPrivacyHandlerConfig wires the routes. Domains repo +
+// privacy repo are required; nil disables route registration.
+type DomainDirectoryPrivacyHandlerConfig struct {
+	Domains repository.DomainRepository
+	Privacy repository.DomainDirectoryPrivacyRepository
+	// Reconciler hook so a CRUD mutation kicks an immediate domain
+	// converge instead of waiting for the next 60s tick.
+	Reconcile func(domainID string)
+	// BcryptCost overrides bcrypt.DefaultCost; tests pass a low cost.
+	BcryptCost int
+}
+
+func RegisterDomainDirectoryPrivacyRoutes(g *gin.RouterGroup, cfg DomainDirectoryPrivacyHandlerConfig) {
+	if cfg.Domains == nil || cfg.Privacy == nil {
+		return
+	}
+	if cfg.BcryptCost == 0 {
+		cfg.BcryptCost = bcrypt.DefaultCost
+	}
+	h := &domainDirectoryPrivacyHandler{cfg: cfg}
+	rg := g.Group("/domains/:id/directory-privacy")
+	rg.GET("", h.listRules)
+	rg.POST("", h.createRule)
+	rg.PUT("/:rule_id", h.updateRule)
+	rg.DELETE("/:rule_id", h.deleteRule)
+	rg.GET("/:rule_id/credentials", h.listCredentials)
+	rg.POST("/:rule_id/credentials", h.createCredential)
+	rg.DELETE("/:rule_id/credentials/:cred_id", h.deleteCredential)
+}
+
+type domainDirectoryPrivacyHandler struct {
+	cfg DomainDirectoryPrivacyHandlerConfig
+}
+
+type createRuleRequest struct {
+	Path  string `json:"path" binding:"required"`
+	Realm string `json:"realm"`
+}
+
+type updateRuleRequest struct {
+	Realm string `json:"realm" binding:"required"`
+}
+
+type createCredentialRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
+// --- rules ---
+
+func (h *domainDirectoryPrivacyHandler) listRules(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rules, err := h.cfg.Privacy.ListRulesByDomain(c.Request.Context(), dom.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if rules == nil {
+		rules = []models.DomainDirectoryPrivacyRule{}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rules, "total": len(rules)})
+}
+
+func (h *domainDirectoryPrivacyHandler) createRule(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	var req createRuleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
+		return
+	}
+	path, err := validatePrivacyPath(req.Path)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	realm, err := validatePrivacyRealm(req.Realm)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	row := &models.DomainDirectoryPrivacyRule{
+		ID:       ids.NewULID(),
+		DomainID: dom.ID,
+		Path:     path,
+		Realm:    realm,
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	if err := h.cfg.Privacy.CreateRule(ctx, row); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusCreated, row)
+}
+
+func (h *domainDirectoryPrivacyHandler) updateRule(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rule, ok := h.resolveRule(c, dom.ID)
+	if !ok {
+		return
+	}
+	var req updateRuleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
+		return
+	}
+	realm, err := validatePrivacyRealm(req.Realm)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.cfg.Privacy.UpdateRule(c.Request.Context(), rule.ID, realm); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "update: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	rule.Realm = realm
+	c.JSON(http.StatusOK, rule)
+}
+
+func (h *domainDirectoryPrivacyHandler) deleteRule(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rule, ok := h.resolveRule(c, dom.ID)
+	if !ok {
+		return
+	}
+	if err := h.cfg.Privacy.DeleteRule(c.Request.Context(), rule.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusOK, gin.H{"id": rule.ID, "deleted": true})
+}
+
+// --- credentials ---
+
+func (h *domainDirectoryPrivacyHandler) listCredentials(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rule, ok := h.resolveRule(c, dom.ID)
+	if !ok {
+		return
+	}
+	rows, err := h.cfg.Privacy.ListCredentialsByRule(c.Request.Context(), rule.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if rows == nil {
+		rows = []models.DomainDirectoryPrivacyCredential{}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rows, "total": len(rows)})
+}
+
+func (h *domainDirectoryPrivacyHandler) createCredential(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rule, ok := h.resolveRule(c, dom.ID)
+	if !ok {
+		return
+	}
+	var req createCredentialRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
+		return
+	}
+	if err := validatePrivacyUsername(req.Username); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validatePrivacyPassword(req.Password); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	hash, err := auth.HashPassword(req.Password, h.cfg.BcryptCost)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "hash: " + err.Error()})
+		return
+	}
+	row := &models.DomainDirectoryPrivacyCredential{
+		ID:           ids.NewULID(),
+		RuleID:       rule.ID,
+		Username:     req.Username,
+		PasswordHash: hash,
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	if err := h.cfg.Privacy.CreateCredential(ctx, row); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusCreated, row)
+}
+
+func (h *domainDirectoryPrivacyHandler) deleteCredential(c *gin.Context) {
+	dom, ok := h.resolveDomain(c)
+	if !ok {
+		return
+	}
+	rule, ok := h.resolveRule(c, dom.ID)
+	if !ok {
+		return
+	}
+	credID := c.Param("cred_id")
+	cred, err := h.cfg.Privacy.FindCredentialByID(c.Request.Context(), credID)
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "credential_not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if cred.RuleID != rule.ID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "credential_not_found"})
+		return
+	}
+	if err := h.cfg.Privacy.DeleteCredential(c.Request.Context(), credID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete: " + err.Error()})
+		return
+	}
+	if h.cfg.Reconcile != nil {
+		h.cfg.Reconcile(dom.ID)
+	}
+	c.JSON(http.StatusOK, gin.H{"id": credID, "deleted": true})
+}
+
+// --- resolve helpers ---
+
+func (h *domainDirectoryPrivacyHandler) resolveDomain(c *gin.Context) (*models.Domain, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return nil, false
+	}
+	dom, err := h.cfg.Domains.FindByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return nil, false
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, false
+	}
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+		return nil, false
+	}
+	return dom, true
+}
+
+func (h *domainDirectoryPrivacyHandler) resolveRule(c *gin.Context, domainID string) (*models.DomainDirectoryPrivacyRule, bool) {
+	ruleID := c.Param("rule_id")
+	rule, err := h.cfg.Privacy.FindRuleByID(c.Request.Context(), ruleID)
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "rule_not_found"})
+			return nil, false
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, false
+	}
+	if rule.DomainID != domainID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "rule_not_found"})
+		return nil, false
+	}
+	return rule, true
+}
+
+// --- validators ---
+
+var privacyPathRE = regexp.MustCompile(`^/[A-Za-z0-9_./-]+$`)
+
+func validatePrivacyPath(in string) (string, error) {
+	p := strings.TrimSpace(in)
+	if p == "" {
+		return "", errBadField("path required")
+	}
+	if len(p) > 255 {
+		return "", errBadField("path too long (max 255)")
+	}
+	if p == "/" {
+		return "/", nil
+	}
+	if !privacyPathRE.MatchString(p) {
+		return "", errBadField("path must start with / and contain only [A-Za-z0-9_./-]")
+	}
+	if strings.Contains(p, "//") {
+		return "", errBadField("path must not contain //")
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return "", errBadField("path must not contain ..")
+		}
+	}
+	// Strip trailing slash for consistent storage; agent re-adds when
+	// emitting `location ^~ <path>/`.
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+		if p == "" {
+			p = "/"
+		}
+	}
+	return p, nil
+}
+
+func validatePrivacyRealm(in string) (string, error) {
+	r := strings.TrimSpace(in)
+	if r == "" {
+		r = "Restricted"
+	}
+	if len(r) > 255 {
+		return "", errBadField("realm too long (max 255)")
+	}
+	for _, c := range r {
+		if c < 0x20 || c > 0x7e {
+			return "", errBadField("realm must be printable ASCII")
+		}
+		if c == '"' || c == '\\' {
+			return "", errBadField(`realm must not contain " or \`)
+		}
+	}
+	return r, nil
+}
+
+var privacyUsernameRE = regexp.MustCompile(`^[A-Za-z0-9._-]{1,64}$`)
+
+func validatePrivacyUsername(in string) error {
+	if !privacyUsernameRE.MatchString(in) {
+		return errBadField("username must match [A-Za-z0-9._-] (1-64 chars)")
+	}
+	return nil
+}
+
+func validatePrivacyPassword(in string) error {
+	if len(in) < 8 {
+		return errBadField("password must be at least 8 characters")
+	}
+	if len(in) > 128 {
+		return errBadField("password too long (max 128)")
+	}
+	return nil
+}

--- a/panel-api/internal/api/domain_directory_privacy_test.go
+++ b/panel-api/internal/api/domain_directory_privacy_test.go
@@ -1,0 +1,112 @@
+package api
+
+import "testing"
+
+func TestValidatePrivacyPath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"/secret", "/secret", false},
+		{"/a/b/c", "/a/b/c", false},
+		{"/trim/", "/trim", false},
+		{"/", "/", false},
+		{"", "", true},
+		{"no-leading-slash", "", true},
+		{"/has space", "", true},
+		{"/has//double", "", true},
+		{"/../etc/passwd", "", true},
+		{"/dot/../boom", "", true},
+		{"/special$char", "", true},
+	}
+	for _, tc := range cases {
+		got, err := validatePrivacyPath(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("validatePrivacyPath(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("validatePrivacyPath(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("validatePrivacyPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidatePrivacyPath_LengthCap(t *testing.T) {
+	long := "/" + string(make([]byte, 255)) // 256 chars total
+	for i := 1; i < len(long); i++ {
+		long = long[:i] + "a" + long[i+1:]
+	}
+	if _, err := validatePrivacyPath(long); err == nil {
+		t.Errorf("expected error on len > 255")
+	}
+}
+
+func TestValidatePrivacyRealm(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "Restricted", false},
+		{"Staging", "Staging", false},
+		{` ok `, "ok", false},
+		{`bad"quote`, "", true},
+		{`bad\back`, "", true},
+		{"highÿascii", "", true},
+		{string(make([]byte, 256)), "", true},
+	}
+	for _, tc := range cases {
+		got, err := validatePrivacyRealm(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("validatePrivacyRealm(%q) = %q, want error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("validatePrivacyRealm(%q) error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("validatePrivacyRealm(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidatePrivacyUsername(t *testing.T) {
+	good := []string{"alice", "bob.smith", "a_b-c", "1234"}
+	for _, u := range good {
+		if err := validatePrivacyUsername(u); err != nil {
+			t.Errorf("validatePrivacyUsername(%q) error: %v", u, err)
+		}
+	}
+	bad := []string{"", "has space", "$evil", "ünicode", string(make([]byte, 65))}
+	for _, u := range bad {
+		if err := validatePrivacyUsername(u); err == nil {
+			t.Errorf("validatePrivacyUsername(%q) = nil, want error", u)
+		}
+	}
+}
+
+func TestValidatePrivacyPassword(t *testing.T) {
+	if err := validatePrivacyPassword("short"); err == nil {
+		t.Errorf("expected error on short")
+	}
+	if err := validatePrivacyPassword("12345678"); err != nil {
+		t.Errorf("8-char password rejected: %v", err)
+	}
+	long := make([]byte, 129)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if err := validatePrivacyPassword(string(long)); err == nil {
+		t.Errorf("expected error on len > 128")
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -70,6 +70,7 @@ type Deps struct {
 	StalwartAdminThrottle api.ThrottleDispatcher
 	BWDaily                   repository.BWDailyRepository
 	DomainIPACLs              repository.DomainIPACLRepository
+	DomainDirectoryPrivacy    repository.DomainDirectoryPrivacyRepository
 	MigrationJobs             repository.MigrationJobRepository
 	MigrationSizeCache        repository.MigrationAccountSizeCacheRepository
 	AutomationTokens          repository.AutomationTokenRepository
@@ -442,6 +443,19 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			api.RegisterDomainIPACLRoutes(v1, api.DomainIPACLHandlerConfig{
 				Domains:   deps.Domains,
 				ACLs:      deps.DomainIPACLs,
+				Reconcile: schedule,
+			})
+		}
+		// M50 — per-directory password protection.
+		if deps.Domains != nil && deps.DomainDirectoryPrivacy != nil {
+			var schedule func(string)
+			if deps.Reconciler != nil {
+				rec := deps.Reconciler
+				schedule = func(id string) { rec.Schedule(id) }
+			}
+			api.RegisterDomainDirectoryPrivacyRoutes(v1, api.DomainDirectoryPrivacyHandlerConfig{
+				Domains:   deps.Domains,
+				Privacy:   deps.DomainDirectoryPrivacy,
 				Reconcile: schedule,
 			})
 		}

--- a/panel-api/internal/db/migrations/000148_domain_directory_privacy.down.sql
+++ b/panel-api/internal/db/migrations/000148_domain_directory_privacy.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS domain_directory_privacy_credentials;
+DROP TABLE IF EXISTS domain_directory_privacy;

--- a/panel-api/internal/db/migrations/000148_domain_directory_privacy.up.sql
+++ b/panel-api/internal/db/migrations/000148_domain_directory_privacy.up.sql
@@ -1,0 +1,37 @@
+-- M50: per-directory password protection (cPanel "Directory Privacy").
+--
+-- One rule per (domain, path) — locks a subdirectory of the docroot
+-- behind HTTP Basic Auth with a custom realm. N credentials per rule,
+-- bcrypt-hashed at the API; agent writes a per-rule htpasswd file at
+-- /etc/jabali-panel/dir-privacy/<rule_ulid>.htpasswd and the vhost
+-- template emits `location ^~ <path>/ { auth_basic <realm>; ... }`.
+--
+-- Rule with zero credentials → agent writes a deny-all placeholder so
+-- the location still 401s (safer than silently allowing).
+
+CREATE TABLE domain_directory_privacy (
+    id          CHAR(26)        NOT NULL PRIMARY KEY,
+    domain_id   CHAR(26)        NOT NULL,
+    path        VARCHAR(255)    NOT NULL,
+    realm       VARCHAR(255)    NOT NULL DEFAULT 'Restricted',
+    created_at  DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uniq_domain_directory_privacy_path (domain_id, path),
+    INDEX idx_domain_directory_privacy_domain (domain_id),
+    CONSTRAINT fk_domain_directory_privacy_domain
+        FOREIGN KEY (domain_id) REFERENCES domains (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE domain_directory_privacy_credentials (
+    id              CHAR(26)        NOT NULL PRIMARY KEY,
+    rule_id         CHAR(26)        NOT NULL,
+    username        VARCHAR(64)     NOT NULL,
+    password_hash   VARCHAR(120)    NOT NULL,
+    created_at      DATETIME(6)     NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uniq_domain_directory_privacy_cred_user (rule_id, username),
+    INDEX idx_domain_directory_privacy_cred_rule (rule_id),
+    CONSTRAINT fk_domain_directory_privacy_cred_rule
+        FOREIGN KEY (rule_id) REFERENCES domain_directory_privacy (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/models/domain_directory_privacy.go
+++ b/panel-api/internal/models/domain_directory_privacy.go
@@ -1,0 +1,37 @@
+package models
+
+import "time"
+
+// DomainDirectoryPrivacyRule is one (domain, path) protection rule (M50).
+//
+// Realm is the WWW-Authenticate "realm" string the browser shows in
+// the login dialog. Each rule has N credentials (DomainDirectoryPrivacyCredential).
+// The agent writes /etc/jabali-panel/dir-privacy/<rule_id>.htpasswd and
+// the vhost emits `location ^~ <path>/ { auth_basic <realm>; auth_basic_user_file <file>; }`.
+type DomainDirectoryPrivacyRule struct {
+	ID        string    `gorm:"column:id;type:char(26);primaryKey" json:"id"`
+	DomainID  string    `gorm:"column:domain_id;type:char(26);not null;index:idx_domain_directory_privacy_domain" json:"domain_id"`
+	Path      string    `gorm:"column:path;type:varchar(255);not null;uniqueIndex:uniq_domain_directory_privacy_path,priority:2" json:"path"`
+	Realm     string    `gorm:"column:realm;type:varchar(255);not null;default:Restricted" json:"realm"`
+	CreatedAt time.Time `gorm:"column:created_at;type:datetime(6);not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at;type:datetime(6);not null" json:"updated_at"`
+}
+
+func (DomainDirectoryPrivacyRule) TableName() string { return "domain_directory_privacy" }
+
+// DomainDirectoryPrivacyCredential is one bcrypt-hashed user under a rule.
+//
+// PasswordHash is a bcrypt string ($2y/$2a/$2b...) — the plaintext is
+// never stored. The agent writes `<username>:<password_hash>` lines
+// into the rule's htpasswd file; nginx auth_basic supports bcrypt.
+type DomainDirectoryPrivacyCredential struct {
+	ID           string    `gorm:"column:id;type:char(26);primaryKey" json:"id"`
+	RuleID       string    `gorm:"column:rule_id;type:char(26);not null;index:idx_domain_directory_privacy_cred_rule;uniqueIndex:uniq_domain_directory_privacy_cred_user,priority:1" json:"rule_id"`
+	Username     string    `gorm:"column:username;type:varchar(64);not null;uniqueIndex:uniq_domain_directory_privacy_cred_user,priority:2" json:"username"`
+	PasswordHash string    `gorm:"column:password_hash;type:varchar(120);not null" json:"-"`
+	CreatedAt    time.Time `gorm:"column:created_at;type:datetime(6);not null" json:"created_at"`
+}
+
+func (DomainDirectoryPrivacyCredential) TableName() string {
+	return "domain_directory_privacy_credentials"
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -100,6 +100,10 @@ type Reconciler struct {
 	// agent dispatch omits the ip_acls field (no nginx directives
 	// rendered).
 	domainIPACLs repository.DomainIPACLRepository
+	// M50 per-directory password protection repo. When nil, agent
+	// dispatch omits directory_privacy_rules → no htpasswd files
+	// written, no auth_basic location blocks rendered.
+	domainDirPrivacy repository.DomainDirectoryPrivacyRepository
 	// sshKeysDispatchCache: per-user hash of last-applied SSH keys +
 	// timestamp. Lets ReconcileSSHKeysForUser skip the agent IPC when
 	// the desired state hasn't changed since the last dispatch. Self-
@@ -142,6 +146,15 @@ func (r *Reconciler) WithUserEgressDropSamples(repo repository.UserEgressDropSam
 // renders the directives inside the server block.
 func (r *Reconciler) WithDomainIPACLs(repo repository.DomainIPACLRepository) *Reconciler {
 	r.domainIPACLs = repo
+	return r
+}
+
+// WithDomainDirectoryPrivacy injects the M50 per-directory password
+// protection repo. When set, createDomainOnAgent fetches each domain's
+// rules + credentials so the agent writes htpasswd files and the vhost
+// gets auth_basic location blocks.
+func (r *Reconciler) WithDomainDirectoryPrivacy(repo repository.DomainDirectoryPrivacyRepository) *Reconciler {
+	r.domainDirPrivacy = repo
 	return r
 }
 
@@ -1102,6 +1115,45 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			}
 			params["ip_acls"] = rules
 		}
+	}
+
+	// M50 per-directory password protection. Fetch rules + their
+	// credentials so the agent can write the htpasswd file and emit
+	// one `location ^~ <path>/ { auth_basic ...; }` block per rule.
+	// Always send the full rule-ID set (even when empty) so the agent
+	// can prune orphaned htpasswd files from previously-deleted rules.
+	if r.domainDirPrivacy != nil {
+		dpCtx, dpCancel := context.WithTimeout(ctx, 3*time.Second)
+		rules, err := r.domainDirPrivacy.ListRulesByDomain(dpCtx, domain.ID)
+		if err == nil {
+			ruleIDs := make([]string, 0, len(rules))
+			payload := make([]map[string]any, 0, len(rules))
+			for _, rule := range rules {
+				ruleIDs = append(ruleIDs, rule.ID)
+				creds, cErr := r.domainDirPrivacy.ListCredentialsByRule(dpCtx, rule.ID)
+				if cErr != nil {
+					creds = nil
+				}
+				credPayload := make([]map[string]string, 0, len(creds))
+				for _, c := range creds {
+					credPayload = append(credPayload, map[string]string{
+						"username":      c.Username,
+						"password_hash": c.PasswordHash,
+					})
+				}
+				payload = append(payload, map[string]any{
+					"rule_id":     rule.ID,
+					"path":        rule.Path,
+					"realm":       rule.Realm,
+					"credentials": credPayload,
+				})
+			}
+			params["directory_privacy_rule_ids"] = ruleIDs
+			if len(payload) > 0 {
+				params["directory_privacy_rules"] = payload
+			}
+		}
+		dpCancel()
 	}
 
 	// Add PHP INI overrides (only if not NULL).

--- a/panel-api/internal/repository/domain_directory_privacy_repository.go
+++ b/panel-api/internal/repository/domain_directory_privacy_repository.go
@@ -1,0 +1,139 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// DomainDirectoryPrivacyRepository persists per-domain HTTP Basic Auth
+// rules + credentials (M50). Reconciler reads ListRulesWithCreds when
+// converging a domain so the agent can write htpasswd files + render
+// the vhost auth_basic location blocks.
+type DomainDirectoryPrivacyRepository interface {
+	CreateRule(ctx context.Context, row *models.DomainDirectoryPrivacyRule) error
+	UpdateRule(ctx context.Context, id string, realm string) error
+	FindRuleByID(ctx context.Context, id string) (*models.DomainDirectoryPrivacyRule, error)
+	ListRulesByDomain(ctx context.Context, domainID string) ([]models.DomainDirectoryPrivacyRule, error)
+	DeleteRule(ctx context.Context, id string) error
+
+	CreateCredential(ctx context.Context, row *models.DomainDirectoryPrivacyCredential) error
+	FindCredentialByID(ctx context.Context, id string) (*models.DomainDirectoryPrivacyCredential, error)
+	ListCredentialsByRule(ctx context.Context, ruleID string) ([]models.DomainDirectoryPrivacyCredential, error)
+	DeleteCredential(ctx context.Context, id string) error
+}
+
+type domainDirectoryPrivacyRepo struct{ db *gorm.DB }
+
+func NewDomainDirectoryPrivacyRepository(db *gorm.DB) DomainDirectoryPrivacyRepository {
+	return &domainDirectoryPrivacyRepo{db: db}
+}
+
+func (r *domainDirectoryPrivacyRepo) CreateRule(ctx context.Context, row *models.DomainDirectoryPrivacyRule) error {
+	now := time.Now().UTC()
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = now
+	}
+	if row.UpdatedAt.IsZero() {
+		row.UpdatedAt = now
+	}
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *domainDirectoryPrivacyRepo) UpdateRule(ctx context.Context, id string, realm string) error {
+	res := r.db.WithContext(ctx).
+		Model(&models.DomainDirectoryPrivacyRule{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"realm":      realm,
+			"updated_at": time.Now().UTC(),
+		})
+	if err := res.Error; err != nil {
+		return err
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *domainDirectoryPrivacyRepo) FindRuleByID(ctx context.Context, id string) (*models.DomainDirectoryPrivacyRule, error) {
+	var row models.DomainDirectoryPrivacyRule
+	err := r.db.WithContext(ctx).First(&row, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *domainDirectoryPrivacyRepo) ListRulesByDomain(ctx context.Context, domainID string) ([]models.DomainDirectoryPrivacyRule, error) {
+	var rows []models.DomainDirectoryPrivacyRule
+	err := r.db.WithContext(ctx).
+		Where("domain_id = ?", domainID).
+		Order("path ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *domainDirectoryPrivacyRepo) DeleteRule(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Delete(&models.DomainDirectoryPrivacyRule{}, "id = ?", id)
+	if err := res.Error; err != nil {
+		return err
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *domainDirectoryPrivacyRepo) CreateCredential(ctx context.Context, row *models.DomainDirectoryPrivacyCredential) error {
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = time.Now().UTC()
+	}
+	return r.db.WithContext(ctx).Create(row).Error
+}
+
+func (r *domainDirectoryPrivacyRepo) FindCredentialByID(ctx context.Context, id string) (*models.DomainDirectoryPrivacyCredential, error) {
+	var row models.DomainDirectoryPrivacyCredential
+	err := r.db.WithContext(ctx).First(&row, "id = ?", id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *domainDirectoryPrivacyRepo) ListCredentialsByRule(ctx context.Context, ruleID string) ([]models.DomainDirectoryPrivacyCredential, error) {
+	var rows []models.DomainDirectoryPrivacyCredential
+	err := r.db.WithContext(ctx).
+		Where("rule_id = ?", ruleID).
+		Order("username ASC").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *domainDirectoryPrivacyRepo) DeleteCredential(ctx context.Context, id string) error {
+	res := r.db.WithContext(ctx).Delete(&models.DomainDirectoryPrivacyCredential{}, "id = ?", id)
+	if err := res.Error; err != nil {
+		return err
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/panel-ui/src/hooks/useDomainDirectoryPrivacy.ts
+++ b/panel-ui/src/hooks/useDomainDirectoryPrivacy.ts
@@ -1,0 +1,189 @@
+// Hooks for M50 per-directory password protection. Mirrors
+// useDomainIPACL: rule list/create/update/delete + nested credential
+// list/create/delete. Cache invalidation on per-domain (rules) and
+// per-rule (credentials) keys.
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+
+import { apiClient } from "../apiClient";
+
+export type DirectoryPrivacyRule = {
+  id: string;
+  domain_id: string;
+  path: string;
+  realm: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type DirectoryPrivacyCredential = {
+  id: string;
+  rule_id: string;
+  username: string;
+  created_at: string;
+};
+
+export type CreateRuleInput = {
+  path: string;
+  realm?: string;
+};
+
+export type UpdateRuleInput = {
+  realm: string;
+};
+
+export type CreateCredentialInput = {
+  username: string;
+  password: string;
+};
+
+const rulesKey = (domainId: string) => [
+  "list",
+  "domain-directory-privacy",
+  domainId,
+];
+
+const credsKey = (domainId: string, ruleId: string) => [
+  "list",
+  "domain-directory-privacy-credentials",
+  domainId,
+  ruleId,
+];
+
+// --- rules ---
+
+export function useDirectoryPrivacyRules(
+  domainId: string | undefined,
+): UseQueryResult<{ data: DirectoryPrivacyRule[]; total: number }> {
+  return useQuery({
+    queryKey: rulesKey(domainId ?? ""),
+    queryFn: async () => {
+      const { data } = await apiClient.get<{
+        data: DirectoryPrivacyRule[];
+        total: number;
+      }>(`/domains/${domainId}/directory-privacy`);
+      return data;
+    },
+    enabled: !!domainId,
+  });
+}
+
+export function useCreateDirectoryPrivacyRule(
+  domainId: string,
+): UseMutationResult<DirectoryPrivacyRule, unknown, CreateRuleInput> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input) => {
+      const { data } = await apiClient.post<DirectoryPrivacyRule>(
+        `/domains/${domainId}/directory-privacy`,
+        input,
+      );
+      return data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: rulesKey(domainId) });
+    },
+  });
+}
+
+export function useUpdateDirectoryPrivacyRule(
+  domainId: string,
+): UseMutationResult<
+  DirectoryPrivacyRule,
+  unknown,
+  { ruleId: string; input: UpdateRuleInput }
+> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ ruleId, input }) => {
+      const { data } = await apiClient.put<DirectoryPrivacyRule>(
+        `/domains/${domainId}/directory-privacy/${ruleId}`,
+        input,
+      );
+      return data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: rulesKey(domainId) });
+    },
+  });
+}
+
+export function useDeleteDirectoryPrivacyRule(
+  domainId: string,
+): UseMutationResult<void, unknown, { ruleId: string }> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ ruleId }) => {
+      await apiClient.delete(
+        `/domains/${domainId}/directory-privacy/${ruleId}`,
+      );
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: rulesKey(domainId) });
+    },
+  });
+}
+
+// --- credentials ---
+
+export function useDirectoryPrivacyCredentials(
+  domainId: string | undefined,
+  ruleId: string | undefined,
+): UseQueryResult<{ data: DirectoryPrivacyCredential[]; total: number }> {
+  return useQuery({
+    queryKey: credsKey(domainId ?? "", ruleId ?? ""),
+    queryFn: async () => {
+      const { data } = await apiClient.get<{
+        data: DirectoryPrivacyCredential[];
+        total: number;
+      }>(`/domains/${domainId}/directory-privacy/${ruleId}/credentials`);
+      return data;
+    },
+    enabled: !!domainId && !!ruleId,
+  });
+}
+
+export function useCreateDirectoryPrivacyCredential(
+  domainId: string,
+  ruleId: string,
+): UseMutationResult<
+  DirectoryPrivacyCredential,
+  unknown,
+  CreateCredentialInput
+> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input) => {
+      const { data } = await apiClient.post<DirectoryPrivacyCredential>(
+        `/domains/${domainId}/directory-privacy/${ruleId}/credentials`,
+        input,
+      );
+      return data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: credsKey(domainId, ruleId) });
+    },
+  });
+}
+
+export function useDeleteDirectoryPrivacyCredential(
+  domainId: string,
+  ruleId: string,
+): UseMutationResult<void, unknown, { credId: string }> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ credId }) => {
+      await apiClient.delete(
+        `/domains/${domainId}/directory-privacy/${ruleId}/credentials/${credId}`,
+      );
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: credsKey(domainId, ruleId) });
+    },
+  });
+}

--- a/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
@@ -1,0 +1,321 @@
+// DomainDirectoryPrivacySection — M50 cPanel-style "Directory Privacy".
+// Each rule locks a docroot subdirectory behind HTTP Basic Auth with a
+// custom realm; the expanded row holds the per-rule credentials (bcrypt
+// hashed at the API, never read back).
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Form,
+  Input,
+  Popconfirm,
+  Skeleton,
+  Space,
+  Table,
+  Typography,
+  message,
+} from "antd";
+import { DeleteOutlined, PlusOutlined } from "@icons";
+
+import {
+  useCreateDirectoryPrivacyCredential,
+  useCreateDirectoryPrivacyRule,
+  useDeleteDirectoryPrivacyCredential,
+  useDeleteDirectoryPrivacyRule,
+  useDirectoryPrivacyCredentials,
+  useDirectoryPrivacyRules,
+  type CreateCredentialInput,
+  type CreateRuleInput,
+  type DirectoryPrivacyCredential,
+  type DirectoryPrivacyRule,
+} from "../../../hooks/useDomainDirectoryPrivacy";
+
+type Props = { domainId: string };
+
+export const DomainDirectoryPrivacySection = ({ domainId }: Props) => {
+  const { data, isLoading } = useDirectoryPrivacyRules(domainId);
+  const createRule = useCreateDirectoryPrivacyRule(domainId);
+  const deleteRule = useDeleteDirectoryPrivacyRule(domainId);
+  const [form] = Form.useForm<CreateRuleInput>();
+  const [adding, setAdding] = useState(false);
+
+  if (isLoading && !data) {
+    return <Skeleton active paragraph={{ rows: 3 }} />;
+  }
+
+  const rows = data?.data ?? [];
+
+  const onAddRule = async (values: CreateRuleInput) => {
+    try {
+      await createRule.mutateAsync({
+        path: values.path.trim(),
+        realm: values.realm?.trim() || undefined,
+      });
+      message.success("Rule added");
+      form.resetFields();
+      setAdding(false);
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { error?: string } } })
+        ?.response?.data;
+      message.error(resp?.error ?? "Failed to add rule");
+    }
+  };
+
+  const onDeleteRule = async (ruleId: string) => {
+    try {
+      await deleteRule.mutateAsync({ ruleId });
+      message.success("Rule deleted");
+    } catch {
+      message.error("Failed to delete rule");
+    }
+  };
+
+  return (
+    <Space direction="vertical" style={{ width: "100%" }} size="middle">
+      <Alert
+        type="info"
+        showIcon
+        message="Per-directory password protection"
+        description={
+          <Typography.Paragraph style={{ marginBottom: 0 }}>
+            Lock a subdirectory of this domain behind HTTP Basic Auth.
+            Click a row to manage usernames + passwords for that rule. A
+            rule with zero credentials denies all access (safer than
+            silently allowing).
+          </Typography.Paragraph>
+        }
+      />
+
+      <Table<DirectoryPrivacyRule>
+        dataSource={rows}
+        rowKey="id"
+        pagination={false}
+        size="small"
+        scroll={{ x: "max-content" }}
+        locale={{ emptyText: "No protected directories." }}
+        expandable={{
+          expandedRowRender: (rule) => (
+            <DirectoryPrivacyCredentialsTable
+              domainId={domainId}
+              ruleId={rule.id}
+            />
+          ),
+        }}
+      >
+        <Table.Column<DirectoryPrivacyRule>
+          title="Path"
+          dataIndex="path"
+          render={(p: string) => <Typography.Text code>{p}</Typography.Text>}
+        />
+        <Table.Column<DirectoryPrivacyRule>
+          title="Realm"
+          dataIndex="realm"
+        />
+        <Table.Column<DirectoryPrivacyRule>
+          title=""
+          width={80}
+          render={(_, r) => (
+            <Popconfirm
+              title="Delete this rule and all its credentials?"
+              onConfirm={() => onDeleteRule(r.id)}
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+            >
+              <Button
+                size="small"
+                type="primary"
+                danger
+                icon={<DeleteOutlined />}
+              />
+            </Popconfirm>
+          )}
+        />
+      </Table>
+
+      {adding ? (
+        <Form<CreateRuleInput>
+          form={form}
+          layout="inline"
+          onFinish={onAddRule}
+          initialValues={{ realm: "Restricted" }}
+        >
+          <Form.Item
+            label="Path"
+            name="path"
+            rules={[
+              { required: true, message: "Required" },
+              {
+                pattern: /^\/[A-Za-z0-9_./-]+$/,
+                message: "Start with /, no spaces or special chars",
+              },
+            ]}
+          >
+            <Input placeholder="/secret" style={{ width: 220 }} />
+          </Form.Item>
+          <Form.Item label="Realm" name="realm">
+            <Input placeholder="Restricted" style={{ width: 180 }} />
+          </Form.Item>
+          <Form.Item>
+            <Space>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={createRule.isPending}
+              >
+                Add
+              </Button>
+              <Button
+                onClick={() => {
+                  form.resetFields();
+                  setAdding(false);
+                }}
+              >
+                Cancel
+              </Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      ) : (
+        <Button icon={<PlusOutlined />} onClick={() => setAdding(true)}>
+          Add protected directory
+        </Button>
+      )}
+    </Space>
+  );
+};
+
+const DirectoryPrivacyCredentialsTable = ({
+  domainId,
+  ruleId,
+}: {
+  domainId: string;
+  ruleId: string;
+}) => {
+  const { data, isLoading } = useDirectoryPrivacyCredentials(domainId, ruleId);
+  const create = useCreateDirectoryPrivacyCredential(domainId, ruleId);
+  const remove = useDeleteDirectoryPrivacyCredential(domainId, ruleId);
+  const [form] = Form.useForm<CreateCredentialInput>();
+  const [adding, setAdding] = useState(false);
+
+  const rows = data?.data ?? [];
+
+  const onAdd = async (values: CreateCredentialInput) => {
+    try {
+      await create.mutateAsync(values);
+      message.success("Credential added");
+      form.resetFields();
+      setAdding(false);
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { error?: string } } })
+        ?.response?.data;
+      message.error(resp?.error ?? "Failed to add credential");
+    }
+  };
+
+  const onDelete = async (credId: string) => {
+    try {
+      await remove.mutateAsync({ credId });
+      message.success("Credential deleted");
+    } catch {
+      message.error("Failed to delete credential");
+    }
+  };
+
+  return (
+    <Space direction="vertical" style={{ width: "100%" }} size="small">
+      <Table<DirectoryPrivacyCredential>
+        dataSource={rows}
+        rowKey="id"
+        loading={isLoading}
+        pagination={false}
+        size="small"
+        locale={{
+          emptyText: "No credentials — directory is locked (deny by default).",
+        }}
+      >
+        <Table.Column<DirectoryPrivacyCredential>
+          title="Username"
+          dataIndex="username"
+        />
+        <Table.Column<DirectoryPrivacyCredential>
+          title=""
+          width={80}
+          render={(_, c) => (
+            <Popconfirm
+              title="Delete this credential?"
+              onConfirm={() => onDelete(c.id)}
+              okText="Delete"
+              okButtonProps={{ danger: true }}
+            >
+              <Button
+                size="small"
+                danger
+                icon={<DeleteOutlined />}
+              />
+            </Popconfirm>
+          )}
+        />
+      </Table>
+
+      {adding ? (
+        <Form<CreateCredentialInput>
+          form={form}
+          layout="inline"
+          onFinish={onAdd}
+        >
+          <Form.Item
+            label="User"
+            name="username"
+            rules={[
+              { required: true, message: "Required" },
+              {
+                pattern: /^[A-Za-z0-9._-]{1,64}$/,
+                message: "1-64 chars; letters, digits, . _ -",
+              },
+            ]}
+          >
+            <Input style={{ width: 160 }} />
+          </Form.Item>
+          <Form.Item
+            label="Password"
+            name="password"
+            rules={[
+              { required: true, message: "Required" },
+              { min: 8, message: "Min 8 characters" },
+              { max: 128, message: "Max 128 characters" },
+            ]}
+          >
+            <Input.Password style={{ width: 200 }} />
+          </Form.Item>
+          <Form.Item>
+            <Space>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={create.isPending}
+              >
+                Add
+              </Button>
+              <Button
+                onClick={() => {
+                  form.resetFields();
+                  setAdding(false);
+                }}
+              >
+                Cancel
+              </Button>
+            </Space>
+          </Form.Item>
+        </Form>
+      ) : (
+        <Button
+          size="small"
+          icon={<PlusOutlined />}
+          onClick={() => setAdding(true)}
+        >
+          Add user
+        </Button>
+      )}
+    </Space>
+  );
+};

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -23,6 +23,7 @@ import { DomainBandwidthCard } from "../../../components/DomainBandwidthCard";
 import type { Domain } from "./DomainList";
 import { DomainEmailSection } from "./DomainEmailSection";
 import { DomainIPACLSection } from "./DomainIPACLSection";
+import { DomainDirectoryPrivacySection } from "./DomainDirectoryPrivacySection";
 import { DomainListenIPSection } from "./DomainListenIPSection";
 import { DomainMailboxesSection } from "./DomainMailboxesSection";
 import { DomainSSLSection } from "./DomainSSLSection";
@@ -168,6 +169,9 @@ export const DomainEdit = () => {
 
           <Divider>IP Allow / Deny</Divider>
           <DomainIPACLSection domainId={domain.id} />
+
+          <Divider>Directory Privacy</Divider>
+          <DomainDirectoryPrivacySection domainId={domain.id} />
 
           <Divider>Email</Divider>
           <DomainEmailSection domainId={domain.id} />


### PR DESCRIPTION
## Summary

cPanel-style **Directory Privacy** — tenants lock any subdirectory of their docroot behind HTTP Basic Auth, manageable from the panel UI.

- Migration 000148: `domain_directory_privacy` + `_credentials` (FK cascade on domain + rule delete)
- panel-api: GORM model + repo (bcrypt-hashed at write; plaintext never reaches DB or logs); 7 REST routes mirroring M36 IP ACL with ownership check, path-traversal validators, reconciler dispatch on every mutation
- Reconciler: fetches rules + creds, pushes into `domain.create` payload, includes full rule-ID set so the agent can prune orphaned htpasswd files
- panel-agent: writes per-rule htpasswd at `/etc/jabali-panel/dir-privacy/<rule_ulid>.htpasswd` (0640 root:www-data, atomic via tmp+rename); new `{{.DirectoryPrivacyDirectives}}` vhost placeholder emits one `location ^~ <path>/ { auth_basic <realm>; auth_basic_user_file <file>; }` block per rule; zero-cred → deny-by-default placeholder so the location still 401s
- panel-ui: `useDomainDirectoryPrivacy` hooks + `DomainDirectoryPrivacySection` (AntD Table with expandable per-rule credentials sub-table; password masked, never read back); mounted in admin `DomainEdit` between IP ACL and Email
- Tests: validator + agent unit tests; `go test ./...` green on both modules; `npm run build` green

## Test plan

- [ ] Migration up/down clean on fresh DB
- [ ] Tenant creates rule `path=/secret realm=Staging`, adds cred `alice:Wonderland42`
- [ ] htpasswd file exists at `/etc/jabali-panel/dir-privacy/<rule_id>.htpasswd`, 0640 `root:www-data`
- [ ] `curl -I https://priv.test/secret/` → `401 WWW-Authenticate: Basic realm="Staging"`
- [ ] `curl -I -u alice:Wonderland42 https://priv.test/secret/` → 200/403/404 (not 401)
- [ ] `curl -I -u alice:wrongpw https://priv.test/secret/` → 401
- [ ] Delete rule → htpasswd removed → location open again
- [ ] `nginx -t` clean after every mutation
- [ ] Reconciler tick idempotent (no churn on no-op convergence)