### PR TITLE
fix(m48-ui): docker apps mobile + tablet polish

### DIFF
--- a/panel-ui/src/components/JabaliFooter.tsx
+++ b/panel-ui/src/components/JabaliFooter.tsx
@@ -20,7 +20,13 @@ export function JabaliFooter() {
   const { mode } = useThemeMode();
   const { token } = theme.useToken();
   const screens = Grid.useBreakpoint();
-  const isWide = screens.sm !== false;
+  // Inline row layout only on desktop (lg+). Phone + tablet stack
+  // vertically and center so the brand block and version block don't
+  // hug the left edge on narrow shells.
+  const isWide = screens.lg !== false;
+  // Tagline + AGPL link stay visible from sm upward (tablet still has
+  // room); only true phone xs hides them.
+  const showExtras = screens.sm !== false;
   const logoSrc =
     mode === "dark" ? "/images/jabali_logo_dark.svg" : "/images/jabali_logo.svg";
   // Match the Layout body color (gray-50 light / colorBgLayout dark) so
@@ -34,8 +40,9 @@ export function JabaliFooter() {
       style={{
         display: "flex",
         flexDirection: isWide ? "row" : "column",
-        alignItems: isWide ? "center" : "flex-start",
-        justifyContent: "space-between",
+        alignItems: "center",
+        justifyContent: isWide ? "space-between" : "center",
+        textAlign: isWide ? "left" : "center",
         gap: isWide ? 16 : 8,
         // AntD's Footer default padding is 24px 50px — the 24 top/bottom
         // leaves a visible gap above the logo on short list views. Tight
@@ -62,7 +69,7 @@ export function JabaliFooter() {
               Jabali Panel
             </a>
           </Typography.Text>
-          {isWide && (
+          {showExtras && (
             <Typography.Text type="secondary">
               Web Hosting Control Panel
             </Typography.Text>
@@ -80,7 +87,7 @@ export function JabaliFooter() {
         >
           <GithubOutlined style={{ fontSize: 18 }} />
         </a>
-        {isWide && (
+        {showExtras && (
           <>
             <Typography.Text type="secondary">·</Typography.Text>
             <Typography.Text type="secondary">

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -90,14 +90,9 @@ export const AdminDockerAppsPage = () => {
 
   return (
     <div>
-      <Space style={{ marginBottom: 16, width: "100%", justifyContent: "space-between" }}>
-        <Typography.Title level={3} style={{ margin: 0 }}>
-          <ContainerOutlined /> Docker Apps
-        </Typography.Title>
-        <Typography.Text type="secondary">
-          {installed.data?.length ?? 0} installed • {catalog.data?.length ?? 0} in catalog
-        </Typography.Text>
-      </Space>
+      <Typography.Title level={3} style={{ margin: 0, marginBottom: 16 }}>
+        <ContainerOutlined /> Docker Apps
+      </Typography.Title>
 
       <Tabs
         activeKey={activeTab}
@@ -155,14 +150,14 @@ export const AdminDockerAppsPage = () => {
                   );
                   return (
                     <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
-                      <Col xs={12} sm={6}>
+                      <Col xs={24} sm={12} lg={6}>
                         {renderStat(
                           "rgba(207, 19, 34, 0.12)", "#cf1322", AppstoreOutlined,
                           "Installed Apps", installedCount,
                           <Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>,
                         )}
                       </Col>
-                      <Col xs={12} sm={6}>
+                      <Col xs={24} sm={12} lg={6}>
                         {renderStat(
                           "rgba(114, 46, 209, 0.12)", "#722ed1", SyncOutlined,
                           "Updates Available", updateCount,
@@ -171,14 +166,14 @@ export const AdminDockerAppsPage = () => {
                             : <Typography.Text type="secondary">Up to date</Typography.Text>,
                         )}
                       </Col>
-                      <Col xs={12} sm={6}>
+                      <Col xs={24} sm={12} lg={6}>
                         {renderStat(
                           "rgba(63, 134, 0, 0.12)", "#3f8600", PlayCircleOutlined,
                           "Running", runningCount,
                           <Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>,
                         )}
                       </Col>
-                      <Col xs={12} sm={6}>
+                      <Col xs={24} sm={12} lg={6}>
                         {renderStat(
                           "rgba(212, 107, 8, 0.12)", "#d46b08", PauseCircleOutlined,
                           "Stopped", stoppedCount,
@@ -193,6 +188,7 @@ export const AdminDockerAppsPage = () => {
                 size="small"
                 loading={installed.isLoading}
                 dataSource={installed.data ?? []}
+                scroll={{ x: 1100 }}
                 pagination={{
                   pageSize: 25,
                   showTotal: (total, range) => `Showing ${range[0]} to ${range[1]} of ${total} results`,
@@ -213,6 +209,7 @@ export const AdminDockerAppsPage = () => {
                   {
                     title: "Name",
                     dataIndex: "name",
+                    width: 260,
                     render: (n, r) => (
                       <Space size={12} align="start">
                         <Avatar


### PR DESCRIPTION
## Summary

Four mobile/tablet polish fixes for `/jabali-admin/docker-apps`:

1. **Stat cards 1-col on phone / 2-col on tablet / 4-col on desktop.** Was `xs={12} sm={6}` → now `xs={24} sm={12} lg={6}`. Phone screenshot showed 2-col with cards crushed to letter-stack text.
2. **Installed table horizontal scroll.** Added `scroll={{ x: 1100 }}` + explicit `width: 260` on Name column. Without it, AntD compressed Name to fit alongside fixed Status/Ports/Limits/Actions columns on a 336px viewport — name cell rendered each letter on its own line.
3. **Header subtitle "N installed • M in catalog" removed.** Duplicated by the "Installed Apps" stat card directly below.
4. **Footer centred on phone + tablet** (column up to `lg`). Was column only on `xs`, leaving brand block and version block hugging opposite edges of a 600-960px tablet shell. Tagline + AGPL link still appear from `sm` upward.

## Test plan

- [ ] CI green
- [ ] Mobile (336px): stat cards 1-col, table scrolls h, footer stacked centred
- [ ] Tablet (594px): stat cards 2-col, table scrolls h, footer stacked centred
- [ ] Desktop (>=992px): stat cards 4-col, table fits, footer inline space-between