### PR TITLE
fix(ui): use AntD default menu styling for row Action dropdowns

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -290,60 +290,29 @@ export const DomainList = () => {
                     items: [
                       {
                         key: "redirects",
-                        label: (
-                          <Button
-                            variant="filled"
-                            color="primary"
-                            icon={<SwapOutlined />}
-                            block
-                            onClick={() => setActiveModal({ domain: r, type: "redirects" })}
-                          >
-                            Redirects
-                          </Button>
-                        ),
+                        icon: <SwapOutlined />,
+                        label: "Redirects",
+                        onClick: () => setActiveModal({ domain: r, type: "redirects" }),
                       },
                       {
                         key: "index",
-                        label: (
-                          <Button
-                            variant="filled"
-                            color="primary"
-                            icon={<FileTextOutlined />}
-                            block
-                            onClick={() => setActiveModal({ domain: r, type: "index" })}
-                          >
-                            Index Files
-                          </Button>
-                        ),
+                        icon: <FileTextOutlined />,
+                        label: "Index Files",
+                        onClick: () => setActiveModal({ domain: r, type: "index" }),
                       },
                       {
                         key: "settings",
-                        label: (
-                          <Button
-                            variant="filled"
-                            color="primary"
-                            icon={<SettingOutlined />}
-                            block
-                            onClick={() => setActiveModal({ domain: r, type: "settings" })}
-                          >
-                            Nginx Settings
-                          </Button>
-                        ),
+                        icon: <SettingOutlined />,
+                        label: "Nginx Settings",
+                        onClick: () => setActiveModal({ domain: r, type: "settings" }),
                       },
                       {
                         key: "toggle",
-                        label: (
-                          <Button
-                            variant="filled"
-                            color={r.is_enabled ? "danger" : "primary"}
-                            icon={r.is_enabled ? <PauseCircleOutlined /> : <PlayCircleOutlined />}
-                            block
-                            disabled={togglingId === r.id}
-                            onClick={() => handleToggle(r)}
-                          >
-                            {r.is_enabled ? "Disable" : "Enable"}
-                          </Button>
-                        ),
+                        icon: r.is_enabled ? <PauseCircleOutlined /> : <PlayCircleOutlined />,
+                        label: r.is_enabled ? "Disable" : "Enable",
+                        danger: r.is_enabled,
+                        disabled: togglingId === r.id,
+                        onClick: () => handleToggle(r),
                       },
                       ...(r.is_panel_primary
                         ? []
@@ -351,26 +320,18 @@ export const DomainList = () => {
                             { type: "divider" as const },
                             {
                               key: "delete",
-                              label: (
-                                <Button
-                                  variant="filled"
-                                  color="danger"
-                                  icon={<DeleteOutlined />}
-                                  block
-                                  onClick={() =>
-                                    Modal.confirm({
-                                      title: `Delete domain "${r.name}"?`,
-                                      okText: "Delete",
-                                      okButtonProps: { danger: true },
-                                      onOk: async () => {
-                                        await deleteMutation.mutateAsync({ id: r.id });
-                                      },
-                                    })
-                                  }
-                                >
-                                  Delete
-                                </Button>
-                              ),
+                              icon: <DeleteOutlined />,
+                              label: "Delete",
+                              danger: true,
+                              onClick: () =>
+                                Modal.confirm({
+                                  title: `Delete domain "${r.name}"?`,
+                                  okText: "Delete",
+                                  okButtonProps: { danger: true },
+                                  onOk: async () => {
+                                    await deleteMutation.mutateAsync({ id: r.id });
+                                  },
+                                }),
                             },
                           ]),
                     ],

--- a/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
@@ -1,10 +1,10 @@
-// UserDeleteAction — row-level destructive action with a confirmation
-// modal. There is no longer a "preserve files" mode; deleting a user
-// always removes everything they own (domains, databases, mailboxes,
-// cron jobs, OS account, /home, related rows).
+// UserDeleteAction — controlled destructive confirmation modal.
+// There is no longer a "preserve files" mode; deleting a user always
+// removes everything they own (domains, databases, mailboxes, cron
+// jobs, OS account, /home, related rows). Parent (UserList RowActions)
+// drives `open` via its dropdown menu.
 import { useState } from "react";
 import { Button, Modal, message } from "antd";
-import { DeleteOutlined } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -12,23 +12,18 @@ import { apiClient } from "../../../apiClient";
 interface UserDeleteActionProps {
   recordItemId: string;
   userEmail: string;
+  open: boolean;
+  onClose: () => void;
 }
 
 export const UserDeleteAction = ({
   recordItemId,
   userEmail,
+  open,
+  onClose,
 }: UserDeleteActionProps) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const qc = useQueryClient();
-
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
-
-  const handleCancel = () => {
-    setIsModalOpen(false);
-  };
 
   const handleDelete = async () => {
     setIsLoading(true);
@@ -42,7 +37,7 @@ export const UserDeleteAction = ({
       qc.invalidateQueries({ queryKey: ["list", "users"] });
       qc.invalidateQueries({ queryKey: ["one", "users", recordItemId] });
 
-      setIsModalOpen(false);
+      onClose();
     } catch (err: unknown) {
       const errMsg =
         err instanceof Error ? err.message : "Failed to delete user";
@@ -55,51 +50,39 @@ export const UserDeleteAction = ({
   const localPart = userEmail.split("@")[0];
 
   return (
-    <>
-      <Button
-        variant="filled"
-        color="danger"
-        icon={<DeleteOutlined />}
-        aria-label="Delete"
-        onClick={handleOpenModal}
-      >
-        Delete
-      </Button>
-
-      <Modal
-        title={`Delete user "${userEmail}"?`}
-        open={isModalOpen}
-        onCancel={handleCancel}
-        footer={[
-          <Button key="cancel" onClick={handleCancel}>
-            Cancel
-          </Button>,
-          <Button
-            key="delete"
-            danger
-            type="primary"
-            loading={isLoading}
-            onClick={handleDelete}
-          >
-            Delete user
-          </Button>,
-        ]}
-      >
-        <p>
-          This is permanent and cannot be undone. Deleting{" "}
-          <strong>{userEmail}</strong> will remove:
-        </p>
-        <ul>
-          <li>All owned domains, DNS zones, SSL certificates, nginx sites</li>
-          <li>All databases and database users (panel + MariaDB)</li>
-          <li>All mailboxes, forwarders, and Stalwart mail accounts</li>
-          <li>All cron jobs, applications, SSH keys</li>
-          <li>
-            The OS account <code>{localPart}</code> and <code>/home/{localPart}</code>
-          </li>
-          <li>The Kratos identity (login record)</li>
-        </ul>
-      </Modal>
-    </>
+    <Modal
+      title={`Delete user "${userEmail}"?`}
+      open={open}
+      onCancel={onClose}
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Cancel
+        </Button>,
+        <Button
+          key="delete"
+          danger
+          type="primary"
+          loading={isLoading}
+          onClick={handleDelete}
+        >
+          Delete user
+        </Button>,
+      ]}
+    >
+      <p>
+        This is permanent and cannot be undone. Deleting{" "}
+        <strong>{userEmail}</strong> will remove:
+      </p>
+      <ul>
+        <li>All owned domains, DNS zones, SSL certificates, nginx sites</li>
+        <li>All databases and database users (panel + MariaDB)</li>
+        <li>All mailboxes, forwarders, and Stalwart mail accounts</li>
+        <li>All cron jobs, applications, SSH keys</li>
+        <li>
+          The OS account <code>{localPart}</code> and <code>/home/{localPart}</code>
+        </li>
+        <li>The Kratos identity (login record)</li>
+      </ul>
+    </Modal>
   );
 };

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -9,7 +9,7 @@
 // total stays correct per tab.
 import { useState } from "react";
 import { Badge, Button, Card, Dropdown, Input, Segmented, Space, Table, Tag, Tooltip, Typography } from "antd";
-import { EditOutlined, MoreOutlined, SearchOutlined, TeamOutlined } from "@icons";
+import { DeleteOutlined, EditOutlined, MoreOutlined, PauseCircleOutlined, PlayCircleOutlined, SafetyOutlined, SearchOutlined, TeamOutlined } from "@icons";
 
 import { RowActionButton } from "../../../components/RowActionButton";
 import type { SorterResult } from "antd/es/table/interface";
@@ -62,52 +62,72 @@ function RowActions({
   user: User;
   onEdit: (id: string) => void;
 }) {
+  const [reset2faOpen, setReset2faOpen] = useState(false);
+  const [suspendOpen, setSuspendOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  type MenuItem = NonNullable<
+    NonNullable<Parameters<typeof Dropdown>[0]["menu"]>["items"]
+  >[number];
+  const items: MenuItem[] = [
+    {
+      key: "reset2fa",
+      icon: <SafetyOutlined />,
+      label: "Reset 2FA",
+      onClick: () => setReset2faOpen(true),
+    },
+    ...(!user.is_admin
+      ? [
+          {
+            key: "suspend",
+            icon: user.suspended ? <PlayCircleOutlined /> : <PauseCircleOutlined />,
+            label: user.suspended ? "Unsuspend" : "Suspend",
+            danger: !user.suspended,
+            onClick: () => setSuspendOpen(true),
+          } as MenuItem,
+        ]
+      : []),
+    { type: "divider" } as MenuItem,
+    {
+      key: "delete",
+      icon: <DeleteOutlined />,
+      label: "Delete",
+      danger: true,
+      onClick: () => setDeleteOpen(true),
+    },
+  ];
+
   return (
     <Space size="middle">
       <RowActionButton icon={<EditOutlined />} onClick={() => onEdit(user.id)}>
         Edit
       </RowActionButton>
-      <Dropdown
-        trigger={["click"]}
-        placement="bottomRight"
-        menu={{
-          items: [
-            {
-              key: "reset2fa",
-              label: (
-                <UserReset2FAAction userId={user.id} userEmail={user.email} />
-              ),
-            },
-            ...(!user.is_admin
-              ? [
-                  {
-                    key: "suspend",
-                    label: (
-                      <UserSuspendAction
-                        userId={user.id}
-                        userEmail={user.email}
-                        suspended={!!user.suspended}
-                      />
-                    ),
-                  },
-                ]
-              : []),
-            {
-              key: "delete",
-              label: (
-                <UserDeleteAction
-                  recordItemId={user.id}
-                  userEmail={user.email}
-                />
-              ),
-            },
-          ],
-        }}
-      >
+      <Dropdown trigger={["click"]} placement="bottomRight" menu={{ items }}>
         <RowActionButton icon={<MoreOutlined />} color="default">
           Actions
         </RowActionButton>
       </Dropdown>
+      <UserReset2FAAction
+        userId={user.id}
+        userEmail={user.email}
+        open={reset2faOpen}
+        onClose={() => setReset2faOpen(false)}
+      />
+      {!user.is_admin && (
+        <UserSuspendAction
+          userId={user.id}
+          userEmail={user.email}
+          suspended={!!user.suspended}
+          open={suspendOpen}
+          onClose={() => setSuspendOpen(false)}
+        />
+      )}
+      <UserDeleteAction
+        recordItemId={user.id}
+        userEmail={user.email}
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+      />
     </Space>
   );
 }

--- a/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
@@ -1,23 +1,28 @@
-// UserReset2FAAction — admin button to strip TOTP + recovery codes from
-// a user's Kratos identity. Used when a user has lost their authenticator
-// AND burned through their recovery codes. The user keeps their password;
-// on next login they're at aal1 and can re-enrol from /profile.
+// UserReset2FAAction — controlled modal that strips TOTP + recovery
+// codes from a user's Kratos identity. Used when a user has lost their
+// authenticator AND burned through their recovery codes. The user
+// keeps their password; on next login they're at aal1 and can re-enrol
+// from /profile. The parent (UserList RowActions) drives `open` via
+// its dropdown menu so the modal lives alongside the row's other
+// action modals and the dropdown items can use stock AntD styling.
 import { useState } from "react";
-import { Button, Modal, message } from "antd";
-import { SafetyOutlined } from "@icons";
+import { Modal, message } from "antd";
 
 import { apiClient } from "../../../apiClient";
 
 interface UserReset2FAActionProps {
   userId: string;
   userEmail: string;
+  open: boolean;
+  onClose: () => void;
 }
 
 export const UserReset2FAAction = ({
   userId,
   userEmail,
+  open,
+  onClose,
 }: UserReset2FAActionProps) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleReset = async () => {
@@ -25,7 +30,7 @@ export const UserReset2FAAction = ({
     try {
       await apiClient.post(`/admin/users/${encodeURIComponent(userId)}/2fa/reset`);
       message.success(`Two-factor authentication reset for "${userEmail}"`);
-      setIsModalOpen(false);
+      onClose();
     } catch (err: unknown) {
       const errMsg =
         err instanceof Error ? err.message : "Failed to reset two-factor authentication";
@@ -36,31 +41,21 @@ export const UserReset2FAAction = ({
   };
 
   return (
-    <>
-      <Button
-        variant="filled"
-        color="primary"
-        icon={<SafetyOutlined />}
-        onClick={() => setIsModalOpen(true)}
-      >
-        Reset 2FA
-      </Button>
-      <Modal
-        title="Reset two-factor authentication?"
-        open={isModalOpen}
-        onCancel={() => setIsModalOpen(false)}
-        onOk={handleReset}
-        confirmLoading={isLoading}
-        okText="Reset"
-        okButtonProps={{ danger: true }}
-      >
-        <p>
-          Removes the TOTP authenticator and recovery codes from{" "}
-          <strong>{userEmail}</strong>. The user keeps their password and can
-          re-enrol from their profile page after their next sign-in.
-        </p>
-        <p>Use only when the user has confirmed they cannot recover access.</p>
-      </Modal>
-    </>
+    <Modal
+      title="Reset two-factor authentication?"
+      open={open}
+      onCancel={onClose}
+      onOk={handleReset}
+      confirmLoading={isLoading}
+      okText="Reset"
+      okButtonProps={{ danger: true }}
+    >
+      <p>
+        Removes the TOTP authenticator and recovery codes from{" "}
+        <strong>{userEmail}</strong>. The user keeps their password and can
+        re-enrol from their profile page after their next sign-in.
+      </p>
+      <p>Use only when the user has confirmed they cannot recover access.</p>
+    </Modal>
   );
 };

--- a/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
@@ -1,13 +1,13 @@
-// UserSuspendAction — admin button to toggle a user's online state.
-// Suspending flips users.suspended=1, pushes the Kratos identity to
-// state=inactive (blocks panel + webmail + every Kratos-fronted UI
+// UserSuspendAction — controlled modal that toggles a user's online
+// state. Suspending flips users.suspended=1, pushes the Kratos identity
+// to state=inactive (blocks panel + webmail + every Kratos-fronted UI
 // on next request) and bulk-disables every owned domain (reconciler
 // drops the nginx sites-enabled symlinks on next tick so all sites
 // serve 404). Unsuspending reverses all three. Reason is operator-
-// facing audit text visible on the row.
+// facing audit text visible on the row. Parent (UserList RowActions)
+// drives `open` via its dropdown menu.
 import { useState } from "react";
-import { Button, Input, Modal, message } from "antd";
-import { PauseCircleOutlined, PlayCircleOutlined } from "@icons";
+import { Input, Modal, message } from "antd";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -16,17 +16,25 @@ interface UserSuspendActionProps {
   userId: string;
   userEmail: string;
   suspended: boolean;
+  open: boolean;
+  onClose: () => void;
 }
 
 export const UserSuspendAction = ({
   userId,
   userEmail,
   suspended,
+  open,
+  onClose,
 }: UserSuspendActionProps) => {
   const qc = useQueryClient();
-  const [isModalOpen, setIsModalOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [reason, setReason] = useState("");
+
+  const handleClose = () => {
+    setReason("");
+    onClose();
+  };
 
   const handleSubmit = async () => {
     setIsLoading(true);
@@ -57,8 +65,7 @@ export const UserSuspendAction = ({
         message.warning(`Domains: ${data.domain_warning}`);
       }
       qc.invalidateQueries({ queryKey: ["list", "users"] });
-      setIsModalOpen(false);
-      setReason("");
+      handleClose();
     } catch (err: unknown) {
       const errMsg =
         (err as { response?: { data?: { detail?: string; error?: string } } })
@@ -73,49 +80,39 @@ export const UserSuspendAction = ({
   };
 
   return (
-    <>
-      <Button
-        variant="filled"
-        color={suspended ? "primary" : "danger"}
-        icon={suspended ? <PlayCircleOutlined /> : <PauseCircleOutlined />}
-        onClick={() => setIsModalOpen(true)}
-      >
-        {suspended ? "Unsuspend" : "Suspend"}
-      </Button>
-      <Modal
-        title={suspended ? "Unsuspend user?" : "Suspend user?"}
-        open={isModalOpen}
-        onCancel={() => setIsModalOpen(false)}
-        onOk={handleSubmit}
-        confirmLoading={isLoading}
-        okText={suspended ? "Unsuspend" : "Suspend"}
-        okButtonProps={{ danger: !suspended }}
-      >
-        {suspended ? (
+    <Modal
+      title={suspended ? "Unsuspend user?" : "Suspend user?"}
+      open={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      confirmLoading={isLoading}
+      okText={suspended ? "Unsuspend" : "Suspend"}
+      okButtonProps={{ danger: !suspended }}
+    >
+      {suspended ? (
+        <p>
+          Restores access for <strong>{userEmail}</strong>. The Kratos
+          identity is reactivated and every owned domain is re-enabled.
+        </p>
+      ) : (
+        <>
           <p>
-            Restores access for <strong>{userEmail}</strong>. The Kratos
-            identity is reactivated and every owned domain is re-enabled.
+            Takes <strong>{userEmail}</strong> offline:
           </p>
-        ) : (
-          <>
-            <p>
-              Takes <strong>{userEmail}</strong> offline:
-            </p>
-            <ul>
-              <li>Kratos identity → inactive (blocks panel + webmail login)</li>
-              <li>All owned domains disabled (sites serve 404)</li>
-            </ul>
-            <p>Optional reason (visible in the user list):</p>
-            <Input.TextArea
-              rows={2}
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              placeholder="e.g. non-payment, ToS violation"
-              maxLength={255}
-            />
-          </>
-        )}
-      </Modal>
-    </>
+          <ul>
+            <li>Kratos identity → inactive (blocks panel + webmail login)</li>
+            <li>All owned domains disabled (sites serve 404)</li>
+          </ul>
+          <p>Optional reason (visible in the user list):</p>
+          <Input.TextArea
+            rows={2}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="e.g. non-payment, ToS violation"
+            maxLength={255}
+          />
+        </>
+      )}
+    </Modal>
   );
 };

--- a/panel-ui/tests/e2e/users.spec.ts
+++ b/panel-ui/tests/e2e/users.spec.ts
@@ -151,12 +151,13 @@ test.describe("users CRUD (admin)", () => {
 
     const victimRow = page.getByRole("row", { name: /doomed@test\.local/ });
     // Reset 2FA / Suspend / Delete now live behind a per-row "Actions"
-    // dropdown (PR#40). Open it, then click the Delete item — the AntD
-    // menu renders in a portal at the document root, so the Delete
-    // button is no longer scoped to the row. `/^delete$/i` avoids the
-    // footer "Delete user" confirm button.
+    // dropdown (PR#40). Items render as stock AntD menu rows (role=
+    // "menuitem", PR #254) — the inline filled-Button labels are gone.
+    // The portal at the document root means the Delete item is no
+    // longer scoped to the row. `/^delete$/i` avoids the footer
+    // "Delete user" confirm button.
     await victimRow.getByRole("button", { name: /actions/i }).click();
-    await page.getByRole("button", { name: /^delete$/i }).click();
+    await page.getByRole("menuitem", { name: /^delete$/i }).click();
 
     // UserDeleteAction opens an AntD Modal titled `Delete user "<email>"?`
     // with a two-checkbox choice and a "Delete user" confirm button in the


### PR DESCRIPTION
Convert Users + admin Domains row Action dropdowns from coloured filled Button labels to stock AntD menu items (`icon` + plain `label` + `danger` for destructive). Reset 2FA/Suspend/Delete user-action components are now controlled (open/onClose); parent RowActions renders them as siblings of Dropdown. Vitest 83/83, tsc clean, build green.