### PR TITLE
fix(update): compositeSHA falls back to file content for gitignored paths (was always missing)

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -169,13 +169,37 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		}
 		return strings.TrimSpace(string(out)), nil
 	}
+	// fileContentSHA falls back to a sha256 of raw file bytes —
+	// used when a path lives outside HEAD (gitignored generated
+	// artifacts like panel-ui/dist/index.html). Returns "<missing>"
+	// only when the file truly isn't on disk.
+	fileContentSHA := func(path string) string {
+		full := filepath.Join(repoDir, path)
+		b, err := os.ReadFile(full)
+		if err != nil {
+			return "<missing>"
+		}
+		sum := sha256.Sum256(b)
+		return hex.EncodeToString(sum[:])
+	}
 	compositeSHA := func(paths ...string) string {
 		lines := make([]string, 0, len(paths))
 		for _, p := range paths {
+			// Prefer git's blob SHA when the path is tracked (free, no
+			// extra I/O). Fall back to a content hash for gitignored
+			// build outputs (panel-ui/dist/index.html) — without it,
+			// those paths always resolve to "<missing>" and the
+			// composite never changes from rebuilds of generated files.
+			// PR #248 added panel-ui/dist/index.html to apiInputs to
+			// trigger a panel-api rebuild on every UI change, but the
+			// gitPathSHA-only impl meant the SHA was always "<missing>"
+			// — UI rebuilds never bumped apiInputs and the binary never
+			// re-embedded the new dist (observed on testserver 2026-
+			// 06-07: binary stuck at #250 through three PRs of UI-only
+			// changes).
 			sha, err := gitPathSHA(p)
 			if err != nil {
-				lines = append(lines, p+":<missing>")
-				continue
+				sha = fileContentSHA(p)
 			}
 			lines = append(lines, p+":"+sha)
 		}


### PR DESCRIPTION
## Summary

PR #248 was supposed to make panel-api rebuild whenever `panel-ui/dist/index.html` changes, so the embedded SPA picks up new asset hashes. The fix added the file to `apiInputs` but `compositeSHA` only knows how to hash via `git rev-parse HEAD:<path>` — and `panel-ui/dist/*` is gitignored. The rev-parse always errors and the catch-all branch appends the **literal string** `"panel-ui/dist/index.html:<missing>"`. apiInputs collapses to a function of the four committed Go paths only; the binary is skipped on every UI-only PR.

Reproduced on testserver 2026-06-07: binary stuck at `jabali version 31cc909e` across three subsequent UI-only PRs (#251 / #254 / etc.). `jabali update --force` was the only way to ship new SPA. After force-run: `jabali version 966601f6`, served asset hash flipped `index-BEIqqHIL.js` → `index-DSVoR4qC.js`.

## Fix

- Add `fileContentSHA(path)` — sha256 over raw file bytes inside `repoDir`.
- `compositeSHA` falls back to it when `gitPathSHA` errors.
- Tracked paths still resolve via git (free, no extra I/O); generated artifacts get a real content hash.
- Returns `<missing>` only when neither HEAD nor disk has the file.

## Test plan

- [ ] CI green (Go vet + build)
- [ ] On testserver: UI-only change → `jabali update` (no --force) → binary version bumps + asset hash flips.