### PR TITLE
fix(m6.6): backfill mail_certificate rows for every email-enabled domain on each reconciler tick (GH #132)

### DIFF
--- a/panel-api/internal/reconciler/mail_certificate_reconciler.go
+++ b/panel-api/internal/reconciler/mail_certificate_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/models"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // reconcileMailCertificates is the M6.6 reconciler hook. For every
@@ -25,6 +26,30 @@ import (
 func (r *Reconciler) reconcileMailCertificates(ctx context.Context) {
 	if r.mailCerts == nil || r.serverSettings == nil {
 		return
+	}
+	// Backfill: every email-enabled domain must have a mail_certificate
+	// row so the state machine below has something to drive. Without
+	// this pass, pre-M6.6 domains stay self-signed forever — they were
+	// never given a row at create time (M6.6 shipped after they were
+	// created) and the on-demand REST handler (GET .../mail-tls) only
+	// fires when an admin opens the Mail TLS section in the UI. Caught
+	// by GH #132: fresh mail.<d>:465 served the Stalwart self-signed
+	// default cert because no row was ever lazy-created.
+	if r.domains != nil {
+		domains, _, err := r.domains.List(ctx, repository.ListOptions{Limit: 10000})
+		if err != nil {
+			r.log.Warn("mail-cert backfill failed to list domains", "error", err)
+		} else {
+			for i := range domains {
+				d := &domains[i]
+				if !d.EmailEnabled {
+					continue
+				}
+				if _, err := r.mailCerts.EnsureForDomain(ctx, d.ID); err != nil {
+					r.log.Warn("mail-cert backfill EnsureForDomain failed", "domain_id", d.ID, "error", err)
+				}
+			}
+		}
 	}
 	rows, err := r.mailCerts.List(ctx)
 	if err != nil {


### PR DESCRIPTION
Closes #132

## Root cause

M6.6 reconciler only iterates rows that already exist in `mail_certificate`. `EnsureForDomain` was wired into exactly one path: the REST handler that backs the admin Mail TLS section. Domains that existed before M6.6 shipped (or whose owner never opened the Mail TLS tab) sit outside the state machine forever, so `jabali-stalwart-push-cert` is never invoked and Stalwart keeps serving its self-signed default cert on `mail.<domain>:465`.

GH #132 hit exactly this — fresh domain, never opened the tab, Thunderbird refuses the self-signed.

## Fix

Walk every email-enabled domain at the top of `reconcileMailCertificates` and call `EnsureForDomain` (idempotent — pre-existing rows untouched, new rows land in `pending` for the same tick's state-machine pass).

- New domains converge on the next tick (~10s window).
- Existing self-signed-stuck domains self-heal on the next tick.
- Reconciler bounded by `Limit=10000` (matches `bandwidth_quota_enforce`).
- Non-email domains skipped at `EmailEnabled` gate so the LE rate-limit soft cap (40/week) isn't burned on domains that don't run mail.

## Test plan

- [x] Reconciler tests pass.
- [ ] Live smoke: pre-existing self-signed domain → wait one tick → `openssl s_client -connect mail.<d>:465 -servername mail.<d>` returns LE cert.
- [ ] Live smoke: create new domain → wait one tick → same.