### PR TITLE
fix(m6.6): only mail.<d> mandatory for mail TLS; aux SANs opportunistic (GH #132)

### DIFF
--- a/panel-agent/internal/commands/ssl_mail_issue.go
+++ b/panel-agent/internal/commands/ssl_mail_issue.go
@@ -78,14 +78,19 @@ type dnsScan struct {
 	Error     string   `json:"error,omitempty"`
 }
 
-// scanMailSANDNS resolves each SAN hostname and returns whether
-// every one of them resolves to publicIP. The "every" semantics is
-// the right call here: a half-resolved SAN set fails HTTP-01 the
-// SAME way as an entirely-missing one.
-func scanMailSANDNS(ctx context.Context, sans []string, publicIP string) (map[string]dnsScan, bool) {
+// scanMailSANDNS resolves each SAN hostname and records whether it
+// points at publicIP. The mandatory-vs-opportunistic decision lives
+// in the caller: only mail.<d> MUST resolve to us (it is the live
+// SMTP/IMAP/JMAP endpoint). autoconfig/autodiscover/mta-sts often
+// legitimately point at a separate webmail or MTA-STS policy host,
+// so they are folded into the cert only when they happen to resolve
+// to us — bundling a name that resolves elsewhere fails HTTP-01 for
+// the ENTIRE certbot order, which previously parked the whole cert
+// in dns_missing and left Stalwart on its self-signed default
+// (GH #132). Returns the per-hostname result map.
+func scanMailSANDNS(ctx context.Context, sans []string, publicIP string) map[string]dnsScan {
 	resolver := &net.Resolver{PreferGo: true}
 	out := make(map[string]dnsScan, len(sans))
-	allOK := publicIP != ""
 	for _, h := range sans {
 		row := dnsScan{Hostname: h}
 		// 5s budget per lookup; reconciler tick has more, this just
@@ -95,23 +100,41 @@ func scanMailSANDNS(ctx context.Context, sans []string, publicIP string) (map[st
 		cancel()
 		if err != nil {
 			row.Error = err.Error()
-			allOK = false
 			out[h] = row
 			continue
 		}
 		row.Addresses = addrs
-		for _, a := range addrs {
-			if a == publicIP {
-				row.Matches = true
-				break
+		if publicIP != "" {
+			for _, a := range addrs {
+				if a == publicIP {
+					row.Matches = true
+					break
+				}
 			}
-		}
-		if !row.Matches {
-			allOK = false
 		}
 		out[h] = row
 	}
-	return out, allOK
+	return out
+}
+
+// selectEffectiveSANs returns the cert SAN list given the full
+// mailSANHostnames slice and the DNS scan. allSANs[0] (mail.<d>) is
+// always included — the caller has already verified it resolves to
+// us. Each aux name is appended only when its scan row reports a
+// match, so names pointing at a separate webmail / MTA-STS host are
+// dropped rather than failing the whole certbot order (GH #132).
+// Order is preserved so the lineage primary stays mail.<d>.
+func selectEffectiveSANs(allSANs []string, dns map[string]dnsScan) []string {
+	if len(allSANs) == 0 {
+		return allSANs
+	}
+	out := []string{allSANs[0]}
+	for _, h := range allSANs[1:] {
+		if dns[h].Matches {
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -136,7 +159,11 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
-	sans := mailSANHostnames(p.Domain)
+	allSANs := mailSANHostnames(p.Domain)
+	// effectiveSANs is what we actually hand to certbot. mail.<d> is
+	// always first (primary lineage name); aux names are appended
+	// only when DNS proves they point at us.
+	effectiveSANs := allSANs
 
 	if !p.SkipDNS {
 		if p.PublicIP == "" {
@@ -145,16 +172,24 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 				Message: "public_ip is required for DNS pre-check (or set skip_dns)",
 			}
 		}
-		dns, ok := scanMailSANDNS(ctx, sans, p.PublicIP)
-		if !ok {
+		dns := scanMailSANDNS(ctx, allSANs, p.PublicIP)
+		// Only mail.<d> (allSANs[0]) is mandatory — it is the live
+		// mail endpoint the cert protects. If it doesn't resolve to
+		// us there is nothing to issue for, so park in dns_missing.
+		if !dns[allSANs[0]].Matches {
 			return sslMailIssueResponse{
 				Outcome: "dns_missing",
 				Domain:  p.Domain,
-				SANs:    sans,
+				SANs:    allSANs,
 				DNS:     dns,
-				Detail:  fmt.Sprintf("one or more mail SAN hostnames do not resolve to %s", p.PublicIP),
+				Detail:  fmt.Sprintf("%s must resolve to %s before a mail certificate can be issued", allSANs[0], p.PublicIP),
 			}, nil
 		}
+		// Fold in autoconfig/autodiscover/mta-sts only when each
+		// resolves to us. A name pointing at a separate webmail /
+		// MTA-STS host is silently dropped from the order instead of
+		// failing the whole issuance (GH #132).
+		effectiveSANs = selectEffectiveSANs(allSANs, dns)
 	}
 
 	if p.Webroot == "" {
@@ -172,18 +207,19 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
-	// certbot certonly --webroot --domains mail.<d>,autoconfig.<d>,
-	// autodiscover.<d>,mta-sts.<d>. Primary SAN = mail.<d> so the
+	// certbot certonly --webroot --domains mail.<d>[,autoconfig.<d>]
+	// [,autodiscover.<d>][,mta-sts.<d>]. Primary SAN = mail.<d> so the
 	// lineage lands at /etc/letsencrypt/live/mail.<d>/ -- the
 	// deploy-hook (step 4) uses the lineage basename to route the
-	// new cert into Stalwart's per-domain x:Certificate entry.
+	// new cert into Stalwart's per-domain x:Certificate entry. The
+	// aux SANs are only present when DNS proved they point at us.
 	runner := certbot.NewRunner()
-	res, err := runner.Issue(sans[0], p.Webroot, p.Email, p.Staging, sans[1:])
+	res, err := runner.Issue(effectiveSANs[0], p.Webroot, p.Email, p.Staging, effectiveSANs[1:])
 	if err != nil {
 		return sslMailIssueResponse{
 			Outcome: "failed",
 			Domain:  p.Domain,
-			SANs:    sans,
+			SANs:    effectiveSANs,
 			Detail:  firstMailErrLine(err.Error()),
 		}, nil
 	}
@@ -200,7 +236,7 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 		return sslMailIssueResponse{
 			Outcome:     "issued",
 			Domain:      p.Domain,
-			SANs:        sans,
+			SANs:        effectiveSANs,
 			LineagePath: lineageDirFromCertPath(res.CertPath),
 			IssuedAt:    res.IssuedAt.UTC().Format(time.RFC3339),
 			ExpiresAt:   res.ExpiresAt.UTC().Format(time.RFC3339),
@@ -211,7 +247,7 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 	return sslMailIssueResponse{
 		Outcome:     "issued",
 		Domain:      p.Domain,
-		SANs:        sans,
+		SANs:        effectiveSANs,
 		LineagePath: lineageDirFromCertPath(res.CertPath),
 		IssuedAt:    res.IssuedAt.UTC().Format(time.RFC3339),
 		ExpiresAt:   res.ExpiresAt.UTC().Format(time.RFC3339),

--- a/panel-agent/internal/commands/ssl_mail_issue_test.go
+++ b/panel-agent/internal/commands/ssl_mail_issue_test.go
@@ -56,16 +56,56 @@ func TestSSLMailIssue_SkipDNS_StillRequiresEmail(t *testing.T) {
 	assert.Equal(t, agentwire.CodeInvalidArgument, aerr.Code)
 }
 
-func TestScanMailSANDNS_AllNonResolvableReturnsFalse(t *testing.T) {
+func TestScanMailSANDNS_AllNonResolvableNoneMatch(t *testing.T) {
 	// A bunch of guaranteed-NX hostnames. Even if a flaky network
 	// returns some glue address, none of these can ever equal the
-	// canary publicIP below, so the func must return false.
+	// canary publicIP below, so no row may report Matches=true.
 	sans := []string{
 		"mail.this-domain-cannot-exist-jabali-test.invalid",
 		"autoconfig.this-domain-cannot-exist-jabali-test.invalid",
 		"autodiscover.this-domain-cannot-exist-jabali-test.invalid",
 		"mta-sts.this-domain-cannot-exist-jabali-test.invalid",
 	}
-	_, ok := scanMailSANDNS(context.Background(), sans, "203.0.113.42")
-	assert.False(t, ok, "no SAN should match the canary IP")
+	dns := scanMailSANDNS(context.Background(), sans, "203.0.113.42")
+	require.Len(t, dns, len(sans))
+	for _, h := range sans {
+		assert.False(t, dns[h].Matches, "%s must not match the canary IP", h)
+	}
+}
+
+func TestSelectEffectiveSANs_MailOnlyWhenAuxPointElsewhere(t *testing.T) {
+	// GH #132 shape: mail.<d> points at us, the three autoconfig
+	// helpers point at a separate webmail host. The cert must drop
+	// the non-matching aux names instead of bundling them.
+	all := mailSANHostnames("example.com")
+	dns := map[string]dnsScan{
+		all[0]: {Hostname: all[0], Matches: true},
+		all[1]: {Hostname: all[1], Matches: false},
+		all[2]: {Hostname: all[2], Matches: false},
+		all[3]: {Hostname: all[3], Matches: false},
+	}
+	got := selectEffectiveSANs(all, dns)
+	assert.Equal(t, []string{"mail.example.com"}, got)
+}
+
+func TestSelectEffectiveSANs_AllMatchKeepsEverything(t *testing.T) {
+	all := mailSANHostnames("example.com")
+	dns := map[string]dnsScan{}
+	for _, h := range all {
+		dns[h] = dnsScan{Hostname: h, Matches: true}
+	}
+	got := selectEffectiveSANs(all, dns)
+	assert.Equal(t, all, got, "all-resolving SANs must all be requested")
+}
+
+func TestSelectEffectiveSANs_PartialMatchKeepsOrder(t *testing.T) {
+	all := mailSANHostnames("example.com")
+	dns := map[string]dnsScan{
+		all[0]: {Hostname: all[0], Matches: true},
+		all[1]: {Hostname: all[1], Matches: false},
+		all[2]: {Hostname: all[2], Matches: true},
+		all[3]: {Hostname: all[3], Matches: false},
+	}
+	got := selectEffectiveSANs(all, dns)
+	assert.Equal(t, []string{"mail.example.com", "autodiscover.example.com"}, got)
 }

--- a/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
@@ -142,10 +142,13 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
       </Space>
 
       <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
-        Issues a Let's Encrypt certificate covering the four mail-related hostnames
-        below so mail clients can connect to <code>mail.&lt;your-domain&gt;</code> with a
-        trusted certificate. Without this, clients have to connect via the panel
-        hostname instead.
+        Issues a Let's Encrypt certificate so mail clients can connect to{" "}
+        <code>mail.&lt;your-domain&gt;</code> with a trusted certificate. Only{" "}
+        <code>mail.&lt;your-domain&gt;</code> must point at the panel public IP — the
+        autoconfig / autodiscover / mta-sts hostnames are added to the certificate
+        only when they also resolve here, so it's fine to point them at a separate
+        webmail host. Without this, clients have to connect via the panel hostname
+        instead.
       </Typography.Paragraph>
 
       {cert.last_error && cert.status !== "issued" && (
@@ -161,18 +164,21 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
         size="small"
         rowKey="hostname"
         pagination={false}
-        dataSource={cert.sans.map((h) => ({ hostname: h }))}
+        dataSource={cert.sans.map((h, idx) => ({ hostname: h, required: idx === 0 }))}
         columns={[
           {
-            title: "DNS A record required",
+            title: "Mail hostname",
             dataIndex: "hostname",
             render: (h: string) => <code>{h}</code>,
           },
           {
-            title: "Target",
-            render: () => (
-              <Typography.Text type="secondary">point at panel public IP</Typography.Text>
-            ),
+            title: "DNS A record",
+            render: (_: unknown, row: { required: boolean }) =>
+              row.required ? (
+                <Typography.Text type="danger">required — point at panel public IP</Typography.Text>
+              ) : (
+                <Typography.Text type="secondary">optional — included if it resolves here</Typography.Text>
+              ),
           },
         ]}
         style={{ marginBottom: 12 }}


### PR DESCRIPTION
Closes #132 (second root cause; first was the missing-row backfill in #256)

## Root cause

`ssl.mail.issue` bundled all four mail SAN hostnames into one certbot order and required **every** one to resolve to the panel public IP. But only `mail.<d>` is the live endpoint the cert protects — `autoconfig`/`autodiscover` are mail-client autoconfig hostnames and `mta-sts` is the MTA-STS policy host, all of which legitimately point at a separate webmail/policy provider.

Observed on test box `jabali.site`:

```
mail.jabali.site         -> 182.54.236.60     (panel, correct)
autoconfig.jabali.site   -> webmail.reeva.me.  (different host)
autodiscover.jabali.site -> webmail.reeva.me.
mta-sts.jabali.site      -> webmail.reeva.me.
```

All-or-nothing scan → `dns_missing` forever → Stalwart serves self-signed on `:465` → Thunderbird refuses. Even with #256's row backfill, the row never leaves `dns_missing`.

## Fix

- `mail.<d>` is the only mandatory SAN. If it doesn't resolve → `dns_missing` with a precise detail.
- `selectEffectiveSANs` folds in aux names **only when they resolve to us**; names pointing elsewhere are dropped from the order instead of failing it.
- certbot issues for `mail.<d>` + whichever aux names resolve. Lineage primary stays `mail.<d>` (deploy-hook + Stalwart push-cert routing unchanged).
- UI: DNS table marks `mail.<d>` required, aux rows optional; help text explains aux can point at a separate webmail host.

## Tests

- `selectEffectiveSANs` unit tests: mail-only (GH #132 shape), all-resolve, partial-keep-order.
- `scanMailSANDNS` test updated for map return.
- panel-agent + panel-api suites green.

## Test plan

- [ ] Live: `jabali.site` (mail.<d> only resolves here) → next tick → LE cert on `mail.jabali.site:465`, not self-signed.