### PR TITLE
fix(m6.6): mail vhost :80 serves shared ACME webroot for per-domain mail cert (GH #132)

### DIFF
--- a/install/nginx/jabali-mail-vhost.conf.tmpl
+++ b/install/nginx/jabali-mail-vhost.conf.tmpl
@@ -128,7 +128,19 @@ server {
   ${LISTEN_80}
   server_name mail.${DOMAIN};
 
+  # Serves two webroots in priority order so BOTH the regular
+  # per-domain cert (-w docroot) and the M6.6 per-domain mail cert
+  # (-w /var/www/jabali-acme) can validate mail.<domain> over :80.
+  # GH #132: the mail cert 404'd here because only the docroot was
+  # served, parking the cert in dns_missing/failed and leaving
+  # Stalwart on its self-signed default on :465.
   location ^~ /.well-known/acme-challenge/ {
+    default_type "text/plain";
+    root /var/www/jabali-acme;
+    try_files $uri @acme_docroot;
+  }
+
+  location @acme_docroot {
     default_type "text/plain";
     root ${ACME_WEBROOT};
     try_files $uri =404;

--- a/panel-agent/internal/commands/webmail_vhost.go
+++ b/panel-agent/internal/commands/webmail_vhost.go
@@ -149,7 +149,28 @@ server {
   # owns mail.<panel-hostname> cert renewal via its own pipeline.
   # Skip the ACME location entirely when DocRoot is empty so the
   # template doesn't emit a bare root directive that trips nginx -t.
+  #
+  # When DocRoot IS set (tenant domain) the location serves TWO
+  # webroots in priority order:
+  #   1. /var/www/jabali-acme — the shared panel ACME webroot used by
+  #      the M6.6 per-domain mail cert (ssl.mail.issue passes -w
+  #      /var/www/jabali-acme) and the M32 panel cert.
+  #   2. {{.DocRoot}} — the apex domain docroot used by the regular
+  #      per-domain cert (reconciler IssueDomainCert passes -w
+  #      DocRoot). Reached via the @acme_docroot fallback.
+  # Both certs cover mail.<domain> as a SAN and both validate over
+  # mail.<domain>:80, but they drop their challenge token into
+  # DIFFERENT directories — without serving both, whichever path
+  # didn't write here 404s. Incident GH #132: the M6.6 mail cert
+  # 404'd because this location only served the docroot, leaving
+  # Stalwart on its self-signed default on :465.
 {{ if .DocRoot }}  location ^~ /.well-known/acme-challenge/ {
+    default_type "text/plain";
+    root /var/www/jabali-acme;
+    try_files $uri @acme_docroot;
+  }
+
+  location @acme_docroot {
     default_type "text/plain";
     root {{.DocRoot}};
     try_files $uri =404;

--- a/panel-agent/internal/commands/webmail_vhost_test.go
+++ b/panel-agent/internal/commands/webmail_vhost_test.go
@@ -366,3 +366,45 @@ func TestWebmailVhostApply_EmptyDocRootSkipsACMELocation(t *testing.T) {
 		t.Errorf("vhost missing :80 → :443 redirect:\n%s", s)
 	}
 }
+
+// TestWebmailVhostApply_DocRootServesBothACMEWebroots is the GH #132
+// regression guard. When a tenant domain has a docroot, the :80 ACME
+// location must serve BOTH the shared panel webroot (/var/www/jabali-
+// acme, where the M6.6 mail cert drops its token) AND the docroot
+// (where the regular per-domain cert drops its token), via a
+// @acme_docroot fallback. Before the fix the location only served the
+// docroot, so the M6.6 mail cert HTTP-01 challenge 404'd and the cert
+// never issued — Stalwart stayed on its self-signed default on :465.
+func TestWebmailVhostApply_DocRootServesBothACMEWebroots(t *testing.T) {
+	avail, _ := wireMailVhostPaths(t)
+	wireNginxReload(t)
+
+	params, _ := json.Marshal(webmailVhostApplyParams{
+		DomainName:  "example.com",
+		SSLCertPath: "/etc/letsencrypt/live/example.com/fullchain.pem",
+		SSLKeyPath:  "/etc/letsencrypt/live/example.com/privkey.pem",
+		DocRoot:     "/home/alice/domains/example.com/public_html",
+	})
+	if _, err := webmailVhostApplyHandler(context.Background(), params); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(avail, "example.com-mail.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	// Primary ACME root is the shared panel webroot (M6.6 + M32).
+	if !strings.Contains(s, "root /var/www/jabali-acme;") {
+		t.Errorf("vhost ACME location must root at the shared panel webroot:\n%s", s)
+	}
+	// Fallback to the tenant docroot via a named location.
+	if !strings.Contains(s, "try_files $uri @acme_docroot;") {
+		t.Errorf("vhost ACME location must fall back to @acme_docroot:\n%s", s)
+	}
+	if !strings.Contains(s, "location @acme_docroot {") {
+		t.Errorf("vhost must define the @acme_docroot fallback location:\n%s", s)
+	}
+	if !strings.Contains(s, "root /home/alice/domains/example.com/public_html;") {
+		t.Errorf("@acme_docroot must root at the tenant docroot:\n%s", s)
+	}
+}


### PR DESCRIPTION
Closes #132 (third + final root cause)

## Root cause

The mail vhost's `:80` ACME-challenge location served only the apex docroot. But two cert paths both cover `mail.<domain>` and validate it over HTTP-01 on `mail.<domain>:80` with **different** webroots:

1. Regular per-domain cert → certbot `-w <docroot>`
2. M6.6 mail cert (pushed to Stalwart for :465) → certbot `-w /var/www/jabali-acme`

The vhost served only #1's webroot, so #2's token 404'd. Verified on test box after #257 cleared the DNS gate:

```
Invalid response from http://mail.jabali.site/.well-known/acme-challenge/<token>: 404
```

→ cert `failed` → Stalwart stays self-signed on :465 → Thunderbird refuses (the GH #132 symptom).

## Fix

Tenant `:80` ACME location now serves **both** webroots in priority order — `/var/www/jabali-acme` first, falling back to the docroot via a named `@acme_docroot` location. Unique random tokens → no collision. Panel-primary (empty-docroot) branch unchanged.

Both the load-bearing Go template + the committed `.tmpl` reference updated. New regression test `TestWebmailVhostApply_DocRootServesBothACMEWebroots`.

## The three GH #132 fixes

- #256 — backfill `mail_certificate` rows (were only lazily created on UI visit)
- #257 — only `mail.<d>` mandatory SAN; aux opportunistic
- **this** — serve the shared ACME webroot so HTTP-01 passes

## Test plan

- [x] panel-agent vhost tests green (incl. new regression).
- [ ] Live: deploy → reconciler tick → `openssl s_client -connect mail.jabali.site:465` returns LE cert.