### PR TITLE
fix(install): refresh jabali-stalwart-push-cert on every update, not just stalwart-cli upgrade (GH #132)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9521,6 +9521,26 @@ _install_stalwart_cli() {
   local url="https://github.com/stalwartlabs/cli/releases/download/v${cli_version}/${tarball}"
   local sha_file="${REPO_DIR}/install/stalwart-cli.sha256"
 
+  # Companion script that uses stalwart-cli to push LE certs into
+  # Stalwart's Certificate object — the panel-mail cert (kind=mail) AND
+  # every per-domain mail cert (kind=mail-domain, M6.6, via env
+  # overrides JABALI_STALWART_CERT_*). Installed BEFORE the cli
+  # version-skip gate below: when stalwart-cli is already current the
+  # function early-returns, so an end-of-function copy would never
+  # refresh this script on `jabali update`. That stranded the stale
+  # env-less push-cert on hosts installed before M6.6, so per-domain
+  # mail certs (GH #132) pushed under the panel cert name + path
+  # instead of their own — Stalwart kept serving the panel cert for
+  # every SNI. Hoisted here so the refresh always runs.
+  local push_src="${REPO_DIR}/install/stalwart/jabali-stalwart-push-cert.sh"
+  local push_dst="/usr/local/bin/jabali-stalwart-push-cert"
+  if [[ -f "$push_src" ]]; then
+    install -m 0755 -o root -g root "$push_src" "$push_dst"
+    _ok "jabali-stalwart-push-cert installed at $push_dst"
+  else
+    _warn "$push_src missing — Stalwart will keep serving its rcgen self-signed cert"
+  fi
+
   if [[ -x "$cli_binary" ]]; then
     local installed_version
     installed_version="$("$cli_binary" --version 2>&1 | grep -oP 'v?\K[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || echo unknown)"
@@ -9571,18 +9591,6 @@ _install_stalwart_cli() {
   rm -rf "$new_dir"
   _ok "stalwart-cli $cli_version installed at $cli_binary"
 
-  # Companion script that uses stalwart-cli to push the panel-mail LE
-  # cert into Stalwart's Certificate object. Called by install.sh after
-  # apply-plan AND by install/letsencrypt/jabali-panel-cert.sh on every
-  # renewal of the mail.<panel-hostname> lineage.
-  local push_src="${REPO_DIR}/install/stalwart/jabali-stalwart-push-cert.sh"
-  local push_dst="/usr/local/bin/jabali-stalwart-push-cert"
-  if [[ -f "$push_src" ]]; then
-    install -m 0755 -o root -g root "$push_src" "$push_dst"
-    _ok "jabali-stalwart-push-cert installed at $push_dst"
-  else
-    _warn "$push_src missing — Stalwart will keep serving its rcgen self-signed cert"
-  fi
 }
 
 # _install_spam_rules vendors the Stalwart spam-filter rules bundle into


### PR DESCRIPTION
Closes #132 (fourth + final piece)

## Root cause

The push-cert script install sat at the END of `_install_stalwart_cli`, after the early-return that fires when stalwart-cli is already current:

```bash
if [[ "$installed_version" == "$cli_version" ]]; then
  return 0   # push-cert copy below never runs
fi
...
install ... jabali-stalwart-push-cert.sh   # unreachable on steady state
```

So `jabali update` never refreshed `/usr/local/bin/jabali-stalwart-push-cert`. Hosts predating the M6.6 env-override version kept the stale hardcoded-path copy.

The deploy-hook correctly exported `JABALI_STALWART_CERT_NAME=domain-<id>` + lineage paths, but the stale push-cert ignored them and re-pushed the **panel** cert under the fixed name. The tenant cert was issued to disk but never registered in Stalwart → SNI found no per-domain Certificate → served panel cert for `mail.<tenant>:465`.

## Fix

Hoist the push-cert install above the version-skip gate so it always refreshes. ("install.sh is truth" — companion artifact refresh must not be gated behind an unrelated binary's version.)

## The four GH #132 fixes

- #256 — backfill `mail_certificate` rows
- #257 — only `mail.<d>` mandatory SAN
- #258 — mail vhost :80 serves shared ACME webroot
- **this** — register the issued cert in Stalwart under its own name so SNI serves it

## Test plan

- [ ] Live: deploy → re-push jabali.site cert → `openssl s_client -connect mail.jabali.site:465 -servername mail.jabali.site` returns `CN=mail.jabali.site`.