### PR TITLE
feat(dns): publish full Stalwart-recommended mail DNS record set on email-enable (GH #134)

### DIFF
--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -275,13 +275,13 @@ func TestEnableDomainEmail_HappyPath(t *testing.T) {
 	if len(warnings) != 0 {
 		t.Errorf("clean zone should produce 0 warnings, got %v", warnings)
 	}
-	// dnscompile.BuildEmailRecords emits 7 rows: DKIM TXT + autoconfig
-	// CNAME + 5 SRVs (_autodiscover + _caldav/_caldavs + _carddav/_carddavs).
-	// CalDAV/CardDAV SRVs added in 034a57e1.
-	if len(rr.createCalls) != 7 {
-		t.Errorf("expected 7 DNS records inserted, got %d", len(rr.createCalls))
+	// dnscompile.BuildEmailRecords emits 15 rows: DKIM + autoconfig +
+	// autodiscover + 5 cal/carddav SRVs + 4 client SRVs + TLS-RPT + 2 CAA
+	// (GH #134).
+	if len(rr.createCalls) != 15 {
+		t.Errorf("expected 15 DNS records inserted, got %d", len(rr.createCalls))
 	}
-	// All 7 must be tagged managed_by="m6".
+	// All must be tagged managed_by="m6".
 	for _, r := range rr.createCalls {
 		if r.ManagedBy == nil || *r.ManagedBy != dnscompile.EmailRecordsManagedBy {
 			t.Errorf("record %s/%s not tagged managed_by=%q: %+v", r.Type, r.Name, dnscompile.EmailRecordsManagedBy, r.ManagedBy)

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -589,7 +589,7 @@ func (h *dnsHandler) deleteRecord(c *gin.Context) {
 
 func isValidDNSType(t string) bool {
 	switch strings.ToUpper(t) {
-	case "A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV":
+	case "A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA":
 		return true
 	}
 	return false
@@ -601,7 +601,7 @@ func validateDNSRecord(r *models.DNSRecord) error {
 	r.Content = strings.TrimSpace(r.Content)
 
 	if !isValidDNSType(r.Type) {
-		return fmt.Errorf("unsupported record type %q (allowed: A, AAAA, CNAME, MX, TXT, NS, SRV)", r.Type)
+		return fmt.Errorf("unsupported record type %q (allowed: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA)", r.Type)
 	}
 	if r.Name == "" {
 		return fmt.Errorf("name required (use '@' for apex)")
@@ -651,6 +651,24 @@ func validateDNSRecord(r *models.DNSRecord) error {
 		port, err := strconv.Atoi(fields[2])
 		if err != nil || port < 1 || port > 65535 {
 			return fmt.Errorf("SRV port must be 1-65535")
+		}
+	case "CAA":
+		// content format: "<flags> <tag> \"<value>\"" per RFC 8659,
+		// e.g. `0 issue "letsencrypt.org"`. flags 0-255, tag one of
+		// issue/issuewild/iodef (the common set jabali emits + most
+		// operators use). PowerDNS stores the content verbatim.
+		fields := strings.Fields(r.Content)
+		if len(fields) < 3 {
+			return fmt.Errorf("CAA content must be \"<flags> <tag> \\\"<value>\\\"\" e.g. 0 issue \\\"letsencrypt.org\\\"")
+		}
+		flags, err := strconv.Atoi(fields[0])
+		if err != nil || flags < 0 || flags > 255 {
+			return fmt.Errorf("CAA flags must be 0-255")
+		}
+		switch fields[1] {
+		case "issue", "issuewild", "iodef":
+		default:
+			return fmt.Errorf("CAA tag must be issue, issuewild, or iodef")
 		}
 	}
 	return nil

--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -546,7 +546,15 @@ func staticEmailHints(domainName, selector, pubKey string) []domainEmailDNSHint 
 		{Purpose: "SPF — authorises this host to send mail for the domain", Name: domainName + ".", Type: "TXT", Value: `v=spf1 mx ~all`},
 		{Purpose: "DMARC — tells receivers to reject unauthenticated mail", Name: "_dmarc." + domainName + ".", Type: "TXT", Value: "v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"},
 		{Purpose: "autoconfig — Thunderbird / mobile client auto-discovery", Name: "autoconfig." + domainName + ".", Type: "CNAME", Value: "mail." + domainName + "."},
+		{Purpose: "autodiscover — Outlook auto-discovery (CNAME flavour)", Name: "autodiscover." + domainName + ".", Type: "CNAME", Value: "mail." + domainName + "."},
 		{Purpose: "_autodiscover._tcp — alternative auto-discovery flavour (Outlook)", Name: "_autodiscover._tcp." + domainName + ".", Type: "SRV", Value: "0 0 443 mail." + domainName + "."},
+		{Purpose: "_imap._tcp — IMAP client auto-config (RFC 6186)", Name: "_imap._tcp." + domainName + ".", Type: "SRV", Value: "0 1 143 mail." + domainName + "."},
+		{Purpose: "_imaps._tcp — IMAPS client auto-config", Name: "_imaps._tcp." + domainName + ".", Type: "SRV", Value: "0 1 993 mail." + domainName + "."},
+		{Purpose: "_submission._tcp — SMTP submission (STARTTLS) auto-config", Name: "_submission._tcp." + domainName + ".", Type: "SRV", Value: "0 1 587 mail." + domainName + "."},
+		{Purpose: "_submissions._tcp — SMTP submission (implicit TLS) auto-config", Name: "_submissions._tcp." + domainName + ".", Type: "SRV", Value: "0 1 465 mail." + domainName + "."},
+		{Purpose: "TLS-RPT — receives aggregate TLS-failure reports (RFC 8460)", Name: "_smtp._tls." + domainName + ".", Type: "TXT", Value: "v=TLSRPTv1; rua=mailto:postmaster@" + domainName},
+		{Purpose: "CAA — restricts cert issuance to Let's Encrypt", Name: domainName + ".", Type: "CAA", Value: `0 issue "letsencrypt.org"`},
+		{Purpose: "CAA — incident-reporting address for cert issues", Name: domainName + ".", Type: "CAA", Value: `0 iodef "mailto:postmaster@` + domainName + `"`},
 	}
 	if selector != "" && pubKey != "" {
 		hints = append(hints, domainEmailDNSHint{

--- a/panel-api/internal/api/domain_email_test.go
+++ b/panel-api/internal/api/domain_email_test.go
@@ -112,7 +112,7 @@ func TestDomainEmail_Enable_Success(t *testing.T) {
 	// _autodiscover._tcp SRV, DKIM. Expanded from the pre-Step-6 count
 	// of 4 when we added autoconfig + autodiscover as part of the DNS
 	// autoconfig work.
-	require.Len(t, resp.Records, 6)
+	require.Len(t, resp.Records, 14)
 }
 
 // TestDomainEmail_Enable_AgentFails verifies the panel does NOT flip
@@ -224,17 +224,16 @@ func TestDomainEmail_Get_ShowsHints(t *testing.T) {
 	var resp domainEmailResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.False(t, resp.EmailEnabled)
-	// Six records in the hint list: MX, SPF, DMARC, autoconfig CNAME,
-	// _autodiscover._tcp SRV, DKIM. Expanded from the pre-Step-6 count
-	// of 4 when we added autoconfig + autodiscover as part of the DNS
-	// autoconfig work.
-	require.Len(t, resp.Records, 6)
+	// 14 records in the hint list: MX, SPF, DMARC, autoconfig CNAME,
+	// autodiscover CNAME, _autodiscover._tcp SRV, _imap/_imaps/
+	// _submission/_submissions SRV, TLS-RPT TXT, 2 CAA, DKIM (GH #134).
+	require.Len(t, resp.Records, 14)
 	// Last record is the DKIM placeholder before enable — empty Value
-	// is the contract for "generated later". Index 5 (last) is the
-	// DKIM slot; indices 3 + 4 are autoconfig/autodiscover.
-	require.Equal(t, "TXT", resp.Records[5].Type)
-	require.Contains(t, resp.Records[5].Purpose, "DKIM")
-	require.Equal(t, "", resp.Records[5].Value, "DKIM placeholder has empty value pre-enable")
+	// is the contract for "generated later".
+	last := len(resp.Records) - 1
+	require.Equal(t, "TXT", resp.Records[last].Type)
+	require.Contains(t, resp.Records[last].Purpose, "DKIM")
+	require.Equal(t, "", resp.Records[last].Value, "DKIM placeholder has empty value pre-enable")
 }
 
 // TestDomainEmail_Get_NotFound — requesting email for a non-existent
@@ -277,10 +276,11 @@ func TestDomainEmail_Enable_InsertsM6DNSRecords(t *testing.T) {
 		}
 		got[rec.Type+":"+rec.Name] = rec.Content
 	}
-	// 7 M6 records: DKIM TXT + autoconfig CNAME + 5 SRVs
-	// (_autodiscover + _caldav/_caldavs + _carddav/_carddavs).
-	// CalDAV/CardDAV SRVs added in 034a57e1.
-	require.Len(t, got, 7, "expected 7 M6 records, got %v", got)
+	// 14 distinct (type:name) M6 keys. BuildEmailRecords emits 15 rows
+	// — DKIM + autoconfig + autodiscover + 5 cal/carddav + 4 client SRVs
+	// + TLS-RPT + 2 apex CAA (GH #134) — but the two CAA share the
+	// type:name key "CAA:@" so the map collapses them to 13... +1 = 14.
+	require.Len(t, got, 14, "expected 14 M6 record keys, got %v", got)
 	require.Equal(t, `"v=DKIM1;k=ed25519;p=AAAA"`, got["TXT:jabali._domainkey"])
 	require.Equal(t, "mail.example.com", got["CNAME:autoconfig"])
 	require.Equal(t, "0 0 443 mail.example.com", got["SRV:_autodiscover._tcp"])
@@ -371,8 +371,9 @@ func TestDomainEmail_Enable_UserOverride_Warns(t *testing.T) {
 			m6Count++
 		}
 	}
-	// 7 M6 records normally; user-edited autoconfig blocks 1 insert → 6.
-	require.Equal(t, 6, m6Count, "user-edited autoconfig row blocks exactly one insert")
+	// 15 M6 records normally (GH #134 set); user-edited autoconfig blocks
+	// 1 insert → 14.
+	require.Equal(t, 14, m6Count, "user-edited autoconfig row blocks exactly one insert")
 
 	// Warning must mention autoconfig so the operator knows what to
 	// fix; the exact wording isn't locked down to avoid brittleness.
@@ -409,7 +410,7 @@ func TestDomainEmail_Enable_Idempotent(t *testing.T) {
 			m6Count++
 		}
 	}
-	require.Equal(t, 7, m6Count, "re-enable must not duplicate rows")
+	require.Equal(t, 15, m6Count, "re-enable must not duplicate rows")
 }
 
 // TestEnableDomainEmailInline_HappyPath exercises the shared helper

--- a/panel-api/internal/dnscompile/email_records.go
+++ b/panel-api/internal/dnscompile/email_records.go
@@ -36,9 +36,16 @@ const EmailRecordsSelector = "jabali"
 //
 //	jabali._domainkey  TXT    "v=DKIM1; k=ed25519; p=<pubkey>"
 //	autoconfig         CNAME  mail
+//	autodiscover       CNAME  mail
 //	_autodiscover._tcp SRV    0 0 443 mail
+//	_caldav(s)/_carddav(s)._tcp SRV ...
+//	_imap/_imaps/_submission/_submissions._tcp SRV ...  (RFC 6186)
+//	_smtp._tls         TXT    "v=TLSRPTv1; rua=mailto:postmaster@<zone>"
+//	@                  CAA    0 issue "letsencrypt.org"
+//	@                  CAA    0 iodef "mailto:postmaster@<zone>"
 //
-// Three records instead of the blueprint's "7 total" — the other four
+// The DKIM/autoconfig/SRV set plus the GH #134 additions (client-
+// service SRVs, TLS-RPT, CAA, autodiscover) — the apex A/MX/SPF/DMARC
 // exist already and rewriting them would (a) invalidate any operator
 // edit (the entire point of ManagedBy scoping is to preserve
 // overrides) and (b) churn PowerDNS unnecessarily. If an install
@@ -86,5 +93,25 @@ func BuildEmailRecords(
 		mk("_carddavs._tcp", "SRV", "0 1 443 "+mailTarget, 0),
 		mk("_caldav._tcp", "SRV", "0 1 80 "+mailTarget, 0),
 		mk("_carddav._tcp", "SRV", "0 1 80 "+mailTarget, 0),
+		// --- GH #134: full Stalwart-recommended mail record set ---
+		// autodiscover CNAME — the Outlook/Exchange autodiscovery
+		// flavour, alongside the _autodiscover._tcp SRV above.
+		mk("autodiscover", "CNAME", mailTarget, 0),
+		// Client-service SRV records (RFC 6186) — let MUAs auto-discover
+		// the IMAP + submission ports Stalwart listens on. weight 1 so a
+		// resolver picks them deterministically.
+		mk("_imap._tcp", "SRV", "0 1 143 "+mailTarget, 0),
+		mk("_imaps._tcp", "SRV", "0 1 993 "+mailTarget, 0),
+		mk("_submission._tcp", "SRV", "0 1 587 "+mailTarget, 0),
+		mk("_submissions._tcp", "SRV", "0 1 465 "+mailTarget, 0),
+		// TLS-RPT (RFC 8460) — where receivers send aggregate reports of
+		// TLS negotiation failures delivering to this domain.
+		mk("_smtp._tls", "TXT", `"v=TLSRPTv1; rua=mailto:postmaster@`+zoneName+`"`, 0),
+		// CAA — restrict certificate issuance to Let's Encrypt (the CA
+		// jabali uses for both web + mail certs) and publish an incident-
+		// reporting address. Two records form one CAA RRset; PowerDNS
+		// stores them as distinct rows under the apex.
+		mk("@", "CAA", `0 issue "letsencrypt.org"`, 0),
+		mk("@", "CAA", `0 iodef "mailto:postmaster@`+zoneName+`"`, 0),
 	}
 }

--- a/panel-api/internal/dnscompile/email_records_test.go
+++ b/panel-api/internal/dnscompile/email_records_test.go
@@ -30,7 +30,7 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 		now,
 	)
 
-	require.Len(t, recs, 7, "M6 should inject 7 records — DKIM + autoconfig + autodiscover + CalDAV/CardDAV SRV")
+	require.Len(t, recs, 15, "M6 should inject 15 records — DKIM + autoconfig + autodiscover + CalDAV/CardDAV + client SRVs + TLS-RPT + 2 CAA")
 
 	// Record 0 — DKIM TXT. Quoted content to match BootstrapRecords.
 	require.Equal(t, "jabali._domainkey", recs[0].Name)
@@ -65,6 +65,31 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 	require.Equal(t, "SRV", recs[6].Type)
 	require.Equal(t, "0 1 80 mail.example.com", recs[6].Content)
 
+	// GH #134 additions (appended after the existing set).
+	require.Equal(t, "autodiscover", recs[7].Name)
+	require.Equal(t, "CNAME", recs[7].Type)
+	require.Equal(t, "mail.example.com", recs[7].Content)
+
+	require.Equal(t, "_imap._tcp", recs[8].Name)
+	require.Equal(t, "0 1 143 mail.example.com", recs[8].Content)
+	require.Equal(t, "_imaps._tcp", recs[9].Name)
+	require.Equal(t, "0 1 993 mail.example.com", recs[9].Content)
+	require.Equal(t, "_submission._tcp", recs[10].Name)
+	require.Equal(t, "0 1 587 mail.example.com", recs[10].Content)
+	require.Equal(t, "_submissions._tcp", recs[11].Name)
+	require.Equal(t, "0 1 465 mail.example.com", recs[11].Content)
+
+	require.Equal(t, "_smtp._tls", recs[12].Name)
+	require.Equal(t, "TXT", recs[12].Type)
+	require.Equal(t, `"v=TLSRPTv1; rua=mailto:postmaster@example.com"`, recs[12].Content)
+
+	require.Equal(t, "@", recs[13].Name)
+	require.Equal(t, "CAA", recs[13].Type)
+	require.Equal(t, `0 issue "letsencrypt.org"`, recs[13].Content)
+	require.Equal(t, "@", recs[14].Name)
+	require.Equal(t, "CAA", recs[14].Type)
+	require.Equal(t, `0 iodef "mailto:postmaster@example.com"`, recs[14].Content)
+
 	// All three must be flagged Managed + ManagedBy="m6" so the
 	// delete-on-disable WHERE clause can find them without touching
 	// M4 bootstrap records (which have ManagedBy=NULL).
@@ -98,7 +123,7 @@ func TestBuildEmailRecords_IDGeneratorCalledOncePerRecord(t *testing.T) {
 		require.False(t, seen[r.ID], "duplicate id %q", r.ID)
 		seen[r.ID] = true
 	}
-	require.Len(t, seen, 7)
+	require.Len(t, seen, 15)
 }
 
 // Sanity — the exported constants used across the package and the

--- a/panel-ui/src/shells/dns/DNSRecordsPage.tsx
+++ b/panel-ui/src/shells/dns/DNSRecordsPage.tsx
@@ -64,7 +64,7 @@ function useNotification() {
 import { apiClient } from "../../apiClient";
 
 // Type definitions
-type DNSRecordType = "A" | "AAAA" | "CNAME" | "MX" | "TXT" | "NS";
+type DNSRecordType = "A" | "AAAA" | "CNAME" | "MX" | "TXT" | "NS" | "SRV" | "CAA";
 
 // recordTypeColor maps each DNS record type to an AntD Tag colour so
 // the table scans visually — A/AAAA share the blue family (IPv4/IPv6
@@ -77,6 +77,12 @@ const recordTypeColor: Record<DNSRecordType, string> = {
   MX: "orange",
   TXT: "green",
   NS: "magenta",
+  // SRV (service discovery) + CAA (cert-authority authorization) are
+  // auto-created on email-enable (GH #134); give them colours so the
+  // table renders them cleanly even though they're not in the manual
+  // add-record dropdown.
+  SRV: "cyan",
+  CAA: "gold",
 };
 
 interface DNSZone {
@@ -156,6 +162,16 @@ const getPlaceholders = (
       return {
         nameHelper: "e.g. sub (subdomain)",
         contentHelper: "Nameserver, e.g. ns.external.com",
+      };
+    case "SRV":
+      return {
+        nameHelper: "e.g. _imap._tcp, _submission._tcp",
+        contentHelper: "priority weight port target, e.g. 0 1 993 mail.example.com",
+      };
+    case "CAA":
+      return {
+        nameHelper: "Usually @ (root)",
+        contentHelper: 'flags tag "value", e.g. 0 issue "letsencrypt.org"',
       };
   }
 };


### PR DESCRIPTION
Closes #134

## Summary

Email-enable now publishes the fuller Stalwart-recommended mail DNS set. Added (all `ManagedBy=m6`, cleaned on disable, idempotent):

- `autodiscover` CNAME (Outlook)
- `_imap` / `_imaps` / `_submission` / `_submissions` `._tcp` SRV (RFC 6186 client auto-config)
- `_smtp._tls` TXT (TLS-RPT, RFC 8460)
- `@` CAA `issue "letsencrypt.org"` + `iodef "mailto:postmaster@<d>"`

Appended after the existing records so original ordering/indices are unchanged.

**Out of scope** (noted on issue): TLSA/DANE needs the live cert fingerprint + DNSSEC — can't be a static template record. MTA-STS already ships behind the M47 per-domain toggle.

Compile + agent pass types verbatim → PowerDNS serves CAA/SRV natively. Added CAA to the DNS-editor `validateDNSRecord` allow-list (RFC 8659 content check) so operators can manage the auto-created CAA rows; UI gains SRV+CAA type/colour/placeholder.

## Test plan
- [x] email_records + domain_email unit tests updated/green
- [ ] Live: enable email on a domain → `dig CAA <d>`, `dig SRV _imaps._tcp.<d>`, `dig TXT _smtp._tls.<d>` all resolve