### PR TITLE
feat(migrate/cpanel): auto-rewrite self-targeting curl/wget crons → php on import

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -582,13 +582,6 @@ func cpanelRestoreCallback(
 		warnings = append(warnings, fmt.Sprintf("ssh: created=%d", sshRes.Created))
 		warnings = append(warnings, sshRes.Skipped...)
 
-		cronRes, err := cpanel.ImportCron(ctx, cronRepo, p.parsed, p.targetUserID)
-		if err != nil {
-			return bytes, warnings, fmt.Errorf("cron: %w", err)
-		}
-		warnings = append(warnings, fmt.Sprintf("cron: created=%d", cronRes.Created))
-		warnings = append(warnings, cronRes.Skipped...)
-
 		dbsRes, err := cpanel.ImportDatabases(ctx, dbsRepo, dbUsersRepo, dbGrantsRepo, sharedAgent, p.parsed, p.targetUserID, p.targetUsername)
 		if err != nil {
 			return bytes, warnings, fmt.Errorf("databases: %w", err)
@@ -769,6 +762,17 @@ func cpanelRestoreCallback(
 		}
 		warnings = append(warnings, fmt.Sprintf("domains: created=%d email_enabled=%d", domainsRes.Created, domainsRes.EmailEnabled))
 		warnings = append(warnings, domainsRes.Skipped...)
+
+		// Cron import runs HERE — after ImportHomeSplit rsynced the
+		// docroots + ImportDomains created the domains — so the curl→php
+		// self-target rewrite can resolve URL paths to real .php files
+		// that exist on the dest disk (rewrite rule 5 "must exist").
+		cronRes, err := cpanel.ImportCron(ctx, cronRepo, p.parsed, p.targetUserID, p.targetUsername)
+		if err != nil {
+			return bytes, warnings, fmt.Errorf("cron: %w", err)
+		}
+		warnings = append(warnings, fmt.Sprintf("cron: created=%d", cronRes.Created))
+		warnings = append(warnings, cronRes.Skipped...)
 
 		mailRes, err := cpanel.ImportMailboxes(ctx, p.parsed, sharedAgent, job.ID, mbRepo, domainsRepo)
 		if err != nil {

--- a/panel-api/internal/migrate/cpanel/restore_cron.go
+++ b/panel-api/internal/migrate/cpanel/restore_cron.go
@@ -3,12 +3,15 @@ package cpanel
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/google/shlex"
 
 	"git.linux-hosting.co.il/shukivaknin/jabali2/internal/cronvalidate"
 	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/ids"
@@ -46,7 +49,7 @@ type CronImportResult struct {
 // final. Trade-off: import skips most cPanel crons up front,
 // avoids the false-positive of inserting a cron that points at a
 // path that doesn't exist yet.
-func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *ParsedTarball, targetUserID string) (*CronImportResult, error) {
+func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *ParsedTarball, targetUserID, targetUsername string) (*CronImportResult, error) {
 	if repo == nil {
 		return nil, fmt.Errorf("ImportCron: repo nil")
 	}
@@ -57,6 +60,17 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 		return nil, fmt.Errorf("ImportCron: targetUserID empty")
 	}
 	res := &CronImportResult{}
+
+	// The account's own domains + their DEST docroots. Used by the
+	// curl/wget self-target rewrite for (a) the same-origin host gate
+	// and (b) resolving the URL path to a php file under the docroot.
+	// ImportCron runs AFTER ImportHomeSplit + ImportDomains (the caller
+	// reorders it there) so these dest paths exist on disk.
+	docroots := accountDocroots(parsed, targetUsername)
+	ownedDocroots := make([]string, 0, len(docroots))
+	for _, dr := range docroots {
+		ownedDocroots = append(ownedDocroots, dr)
+	}
 
 	for _, cronPath := range parsed.CronFiles {
 		f, err := os.Open(cronPath)
@@ -97,44 +111,78 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 				res.Skipped = append(res.Skipped, fmt.Sprintf("%s:%d schedule: %s", cronPath, lineNum, vErr.Error()))
 				continue
 			}
-			if _, vErr := cronvalidate.ValidateCommand(command, nil); vErr != nil {
-				// curl/wget hitting a wp-cron.php URL is the single most
-				// common cPanel cron (the WordPress scheduler). The raw
-				// allowlist rejection ("binary_not_allowed: first token
-				// must be 'wp' or 'php'") is correct but useless to the
-				// operator. Emit an actionable remediation instead so
-				// they know the WP scheduler was skipped + how to restore
-				// it. (A true auto-rewrite to `php <docroot>/wp-cron.php`
-				// can't run in v1 — migration passes empty ownedDocroots
-				// to the validator, which rejects any --path, so the
-				// rewritten command wouldn't validate either; tracked for
-				// a follow-up that resolves the dest docroot first.)
-				var ve *cronvalidate.ValidationError
-				if errors.As(vErr, &ve) && ve.Code == cronvalidate.ErrCodeBinaryNotAllowed && isWPCronTrigger(command) {
+
+			// Strip a trailing output-discard redirect (>/dev/null,
+			// >/dev/null 2>&1, &>/dev/null, …). Real-world crons almost
+			// always carry one, and cronvalidate's metachar guard rejects
+			// any '>' before it ever reaches the binary check — so without
+			// this even a clean `php …/wp-cron.php >/dev/null 2>&1` fails.
+			// systemd-user routes stdout/stderr to journald regardless, so
+			// dropping the discard is behaviour-preserving. Only /dev/null
+			// + fd-dup targets are stripped; a redirect to a real file is
+			// left intact (it'll fail validation → disabled-import, which
+			// is correct — we don't support file-output crons).
+			origCommand := command
+			command = stripOutputRedirect(command)
+
+			// curl/wget self-targeting the account's own site is the most
+			// common cPanel cron (WordPress scheduler etc.). Rewrite it to
+			// a local `php <docroot>/<file>.php` exec when it provably
+			// targets one of THIS account's domains + a real .php under the
+			// docroot. Converting to a local exec also eliminates the SSRF
+			// surface (no network call survives). Anything that doesn't
+			// qualify is imported DISABLED with the original command + a
+			// note — never silently dropped.
+			if firstToken := firstCronToken(command); firstToken == "curl" || firstToken == "wget" {
+				rewritten, ok, reason := rewriteSelfCurlCron(command, docroots)
+				if !ok {
 					res.Skipped = append(res.Skipped, fmt.Sprintf(
-						"%s:%d wp_scheduler_skipped: %q — WordPress cron. Re-add via the Cron page as 'php <docroot>/wp-cron.php', or leave WP's built-in pseudo-cron to run on page hits.",
-						cronPath, lineNum, command))
+						"%s:%d cron_disabled_import (curl_not_rewritable: %s): %s",
+						cronPath, lineNum, reason, origCommand))
+					if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+						_ = f.Close()
+						return res, cErr
+					}
 					continue
 				}
-				res.Skipped = append(res.Skipped, fmt.Sprintf("%s:%d command: %s", cronPath, lineNum, vErr.Error()))
+				// Defense-in-depth: never trust the rewrite — re-run it
+				// through the same validator the REST handler uses, now
+				// with the account's real docroots so the php path passes.
+				if _, vErr := cronvalidate.ValidateCommand(rewritten, ownedDocroots); vErr != nil {
+					res.Skipped = append(res.Skipped, fmt.Sprintf(
+						"%s:%d cron_disabled_import (rewrite_revalidate_failed: %s): %s",
+						cronPath, lineNum, vErr.Error(), origCommand))
+					if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+						_ = f.Close()
+						return res, cErr
+					}
+					continue
+				}
+				res.Skipped = append(res.Skipped, fmt.Sprintf(
+					"%s:%d cron rewritten curl→php: %s → %s", cronPath, lineNum, origCommand, rewritten))
+				if cErr := createCronRow(ctx, repo, targetUserID, schedule, rewritten, res); cErr != nil {
+					_ = f.Close()
+					return res, cErr
+				}
 				continue
 			}
 
-			row := &models.CronJob{
-				ID:        ids.NewULID(),
-				UserID:    targetUserID,
-				Name:      fmt.Sprintf("imported-%d", res.Created+1),
-				Command:   command,
-				Schedule:  schedule,
-				Enabled:   false, // operator reviews + flips
-				CreatedAt: time.Now().UTC(),
-				UpdatedAt: time.Now().UTC(),
+			// Non-curl/wget: validate against the account's docroots.
+			// Pass → row. Fail → disabled-import (preserve original + note).
+			if _, vErr := cronvalidate.ValidateCommand(command, ownedDocroots); vErr != nil {
+				res.Skipped = append(res.Skipped, fmt.Sprintf(
+					"%s:%d cron_disabled_import (command: %s): %s",
+					cronPath, lineNum, vErr.Error(), origCommand))
+				if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+					_ = f.Close()
+					return res, cErr
+				}
+				continue
 			}
-			if err := repo.Create(ctx, row); err != nil {
+			if cErr := createCronRow(ctx, repo, targetUserID, schedule, command, res); cErr != nil {
 				_ = f.Close()
-				return res, fmt.Errorf("create cron_jobs row (line %d of %s): %w", lineNum, cronPath, err)
+				return res, cErr
 			}
-			res.Created++
 		}
 		if err := scanner.Err(); err != nil {
 			res.Skipped = append(res.Skipped, fmt.Sprintf("scan %s: %v", cronPath, err))
@@ -181,14 +229,169 @@ func isCronEnvLine(line string) bool {
 	return cronEnvLineRe.MatchString(line)
 }
 
-// wpCronTriggerRe matches a curl/wget command whose URL ends in
-// wp-cron.php (optionally with a ?query). Used only to turn the
-// allowlist rejection into an actionable "WordPress scheduler skipped"
-// note — it does not rewrite or schedule anything.
-var wpCronTriggerRe = regexp.MustCompile(`(?i)(?:curl|wget).*/wp-cron[.]php`)
+// createCronRow inserts one imported cron_jobs row (always Enabled=false
+// — the operator reviews + flips after migration) and bumps res.Created.
+func createCronRow(ctx context.Context, repo repository.CronJobRepository, userID, schedule, command string, res *CronImportResult) error {
+	row := &models.CronJob{
+		ID:        ids.NewULID(),
+		UserID:    userID,
+		Name:      fmt.Sprintf("imported-%d", res.Created+1),
+		Command:   command,
+		Schedule:  schedule,
+		Enabled:   false,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := repo.Create(ctx, row); err != nil {
+		return fmt.Errorf("create cron_jobs row: %w", err)
+	}
+	res.Created++
+	return nil
+}
 
-// isWPCronTrigger reports whether command is a curl/wget WordPress-cron
-// trigger.
-func isWPCronTrigger(command string) bool {
-	return wpCronTriggerRe.MatchString(command)
+// accountDocroots maps each of the account's own domains (lowercased) to
+// its DEST docroot. Mirrors ImportDomains' docRootFor: a DocRoots
+// override wins, else the jabali convention
+// /home/<user>/domains/<domain>/public_html. Domains come from the BIND
+// zone basenames when present, else DomainNames.
+func accountDocroots(parsed *ParsedTarball, targetUsername string) map[string]string {
+	out := map[string]string{}
+	add := func(name string) {
+		name = strings.TrimSpace(strings.ToLower(name))
+		if name == "" {
+			return
+		}
+		dr := filepath.Join("/home", targetUsername, "domains", name, "public_html")
+		if parsed.DocRoots != nil {
+			if o, ok := parsed.DocRoots[name]; ok && o != "" {
+				dr = o
+			}
+		}
+		out[name] = dr
+	}
+	if len(parsed.ZoneFiles) > 0 {
+		for _, z := range parsed.ZoneFiles {
+			add(strings.TrimSuffix(filepath.Base(z), ".db"))
+		}
+	}
+	for _, n := range parsed.DomainNames {
+		add(n)
+	}
+	return out
+}
+
+// firstCronToken returns the basename of the first shell token of a
+// command (so "/usr/bin/curl" → "curl"). Empty on parse failure.
+func firstCronToken(command string) string {
+	argv, err := shlex.Split(command)
+	if err != nil || len(argv) == 0 {
+		return ""
+	}
+	return filepath.Base(argv[0])
+}
+
+// outputRedirectRe matches a trailing run of output-DISCARD redirects:
+// >/dev/null, >>/dev/null, 2>/dev/null, 2>&1, 1>&2, &>/dev/null, … in any
+// order at the end of the command. Redirects to a real file are NOT
+// matched (left intact so they fail validation → disabled-import).
+var outputRedirectRe = regexp.MustCompile(`(?:\s*(?:[12]?>>?\s*/dev/null|[12]?>>?\s*&[12]|&>>?\s*/dev/null))+\s*$`)
+
+// stripOutputRedirect removes a trailing output-discard redirect.
+func stripOutputRedirect(command string) string {
+	return strings.TrimSpace(outputRedirectRe.ReplaceAllString(command, ""))
+}
+
+// benignCurlFlags is the tiny allow-list of curl/wget flags the rewrite
+// tolerates — silence + fail-fast only. Anything else (writes a file,
+// uploads, sets a proxy, follows redirects, sends data) disqualifies the
+// rewrite so we never convert a data-moving cron into a blind php exec.
+var benignCurlFlags = map[string]bool{
+	"-s": true, "--silent": true,
+	"-f": true, "--fail": true,
+	"-q": true,
+}
+
+// rewriteSelfCurlCron converts a curl/wget command that self-targets one
+// of the account's own domains into a local `php <docroot>/<file>.php`
+// exec. Returns (rewritten, true, "") on success, or ("", false, reason)
+// when any rule fails (caller imports the original DISABLED). All rules
+// in the spec must hold:
+//   1. shlex-parse; first token curl/wget (already checked by caller).
+//   2. exactly one http(s):// URL; scheme http/https only.
+//   3. URL host is one of the account's own domains (same-origin / SSRF gate).
+//   4. no query string (php-CLI ignores $_GET — silent behaviour change).
+//   5. path resolves under the docroot, ends .php, no traversal, exists.
+//   6. only benign flags; -o/-O permitted only with /dev/null.
+func rewriteSelfCurlCron(command string, docroots map[string]string) (string, bool, string) {
+	argv, err := shlex.Split(command)
+	if err != nil || len(argv) == 0 {
+		return "", false, "shlex_parse_failed"
+	}
+	bin := filepath.Base(argv[0])
+	if bin != "curl" && bin != "wget" {
+		return "", false, "not_curl_wget"
+	}
+
+	var rawURL string
+	for i := 1; i < len(argv); i++ {
+		a := argv[i]
+		switch {
+		case strings.HasPrefix(a, "http://") || strings.HasPrefix(a, "https://"):
+			if rawURL != "" {
+				return "", false, "multiple_urls"
+			}
+			rawURL = a
+		case a == "-o" || a == "-O":
+			// output flag — only the /dev/null discard form is allowed.
+			if i+1 >= len(argv) || argv[i+1] != "/dev/null" {
+				return "", false, "danger_flag:" + a
+			}
+			i++ // consume the /dev/null value
+		case strings.HasPrefix(a, "-"):
+			if !benignCurlFlags[a] {
+				return "", false, "danger_flag:" + a
+			}
+		default:
+			return "", false, "unexpected_arg:" + a
+		}
+	}
+	if rawURL == "" {
+		return "", false, "no_url"
+	}
+
+	u, perr := url.Parse(rawURL)
+	if perr != nil {
+		return "", false, "url_parse_failed"
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", false, "bad_scheme:" + u.Scheme
+	}
+	if u.RawQuery != "" {
+		return "", false, "has_query_string"
+	}
+	host := strings.ToLower(u.Hostname())
+	docroot, ok := docroots[host]
+	if !ok {
+		return "", false, "host_not_owned:" + host
+	}
+
+	upath := u.Path
+	if upath == "" || upath == "/" {
+		return "", false, "empty_path"
+	}
+	if strings.Contains(upath, "..") {
+		return "", false, "path_traversal"
+	}
+	full := filepath.Join(docroot, filepath.Clean("/"+upath))
+	// Containment: the cleaned path must stay under the docroot.
+	if full != docroot && !strings.HasPrefix(full, docroot+string(filepath.Separator)) {
+		return "", false, "escapes_docroot"
+	}
+	if !strings.HasSuffix(full, ".php") {
+		return "", false, "not_php"
+	}
+	if st, serr := os.Stat(full); serr != nil || st.IsDir() {
+		return "", false, "file_not_found"
+	}
+	return "php " + full, true, ""
 }

--- a/panel-api/internal/migrate/cpanel/restore_cron_helpers_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_cron_helpers_test.go
@@ -1,6 +1,10 @@
 package cpanel
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestIsCronEnvLine(t *testing.T) {
 	env := []string{
@@ -29,26 +33,67 @@ func TestIsCronEnvLine(t *testing.T) {
 	}
 }
 
-func TestIsWPCronTrigger(t *testing.T) {
-	yes := []string{
-		`curl https://example.com/wp-cron.php`,
-		`curl -s "https://example.com/wp-cron.php?doing_wp_cron"`,
-		`wget -q -O - https://example.com/wp-cron.php`,
-		`/usr/bin/curl https://www.site.org/wp-cron.php >/dev/null 2>&1`,
+func TestStripOutputRedirect(t *testing.T) {
+	cases := map[string]string{
+		`php /home/u/public_html/wp-cron.php >/dev/null 2>&1`: `php /home/u/public_html/wp-cron.php`,
+		`php x.php >/dev/null`:                                `php x.php`,
+		`php x.php > /dev/null 2>&1`:                          `php x.php`,
+		`php x.php 2>&1 >/dev/null`:                           `php x.php`,
+		`php x.php &>/dev/null`:                               `php x.php`,
+		`php x.php`:                                           `php x.php`,
+		// redirect to a REAL file is left intact (will fail validation).
+		`php x.php >/var/log/cron.log`: `php x.php >/var/log/cron.log`,
 	}
-	for _, c := range yes {
-		if !isWPCronTrigger(c) {
-			t.Errorf("isWPCronTrigger(%q) = false, want true", c)
+	for in, want := range cases {
+		if got := stripOutputRedirect(in); got != want {
+			t.Errorf("stripOutputRedirect(%q) = %q, want %q", in, got, want)
 		}
 	}
-	no := []string{
-		`php /home/u/public_html/wp-cron.php`,        // already php — not a curl trigger
-		`curl https://example.com/healthz.php`,        // not wp-cron
-		`wp cron event run --path=/home/u/public_html`,
+}
+
+// cronRewriteFixture builds a docroots map for "own.example.com" pointing
+// at a temp dir, and drops the named .php files in it.
+func cronRewriteFixture(t *testing.T, files ...string) map[string]string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("<?php\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	for _, c := range no {
-		if isWPCronTrigger(c) {
-			t.Errorf("isWPCronTrigger(%q) = true, want false", c)
+	return map[string]string{"own.example.com": dir}
+}
+
+func TestRewriteSelfCurlCron(t *testing.T) {
+	dr := cronRewriteFixture(t, "cron-pong.php", "wp-cron.php")
+	docroot := dr["own.example.com"]
+
+	type tc struct {
+		name    string
+		cmd     string
+		wantOK  bool
+		wantCmd string // when wantOK
+	}
+	cases := []tc{
+		{"own-domain-php", "curl https://own.example.com/cron-pong.php", true, "php " + filepath.Join(docroot, "cron-pong.php")},
+		{"wget-O-devnull", "wget -q -O /dev/null https://own.example.com/wp-cron.php", true, "php " + filepath.Join(docroot, "wp-cron.php")},
+		{"query-string", "curl https://own.example.com/cron-pong.php?tok=1", false, ""},
+		{"foreign-host", "curl https://evil.com/x.php", false, ""},
+		{"ssrf-metadata", "curl http://169.254.169.254/latest/meta-data", false, ""},
+		{"danger-flag-T", "curl -T /home/u/secret https://own.example.com/cron-pong.php", false, ""},
+		{"danger-o-realfile", "curl -o /tmp/out https://own.example.com/cron-pong.php", false, ""},
+		{"missing-file", "curl https://own.example.com/does-not-exist.php", false, ""},
+		{"not-php", "curl https://own.example.com/cron-pong.txt", false, ""},
+		{"benign-silent-fail", "curl -s -f https://own.example.com/cron-pong.php", true, "php " + filepath.Join(docroot, "cron-pong.php")},
+	}
+	for _, c := range cases {
+		got, ok, reason := rewriteSelfCurlCron(c.cmd, dr)
+		if ok != c.wantOK {
+			t.Errorf("%s: rewriteSelfCurlCron(%q) ok=%v, want %v (reason=%q)", c.name, c.cmd, ok, c.wantOK, reason)
+			continue
+		}
+		if c.wantOK && got != c.wantCmd {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.wantCmd)
 		}
 	}
 }

--- a/panel-api/internal/migrate/cpanel/restore_cron_integration_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_cron_integration_test.go
@@ -1,0 +1,119 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeCronRepo records created rows + satisfies CronJobRepository.
+type fakeCronRepo struct{ rows []*models.CronJob }
+
+func (r *fakeCronRepo) Create(_ context.Context, j *models.CronJob) error {
+	r.rows = append(r.rows, j)
+	return nil
+}
+func (r *fakeCronRepo) FindByID(context.Context, string) (*models.CronJob, error) { return nil, nil }
+func (r *fakeCronRepo) ListByUserID(context.Context, string) ([]*models.CronJob, error) {
+	return nil, nil
+}
+func (r *fakeCronRepo) ListAll(context.Context) ([]*models.CronJob, error) { return nil, nil }
+func (r *fakeCronRepo) Update(context.Context, *models.CronJob) error      { return nil }
+func (r *fakeCronRepo) UpdateStatus(context.Context, string, time.Time, int, string) error {
+	return nil
+}
+func (r *fakeCronRepo) Delete(context.Context, string) error { return nil }
+
+// TestImportCron_CurlRewriteEndToEnd drives the full ImportCron loop with
+// a crontab containing the spec's representative lines and asserts the
+// resulting rows + their enabled/command state.
+func TestImportCron_CurlRewriteEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	// DEST docroot the rewrite resolves to: /home/<user>/domains/<d>/public_html.
+	// We point DocRoots at a real temp dir holding the .php files so rule 5
+	// ("must exist") passes without faking /home.
+	docroot := filepath.Join(home, "docroot")
+	if err := os.MkdirAll(docroot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"cron-pong.php", "wp-cron.php"} {
+		if err := os.WriteFile(filepath.Join(docroot, f), []byte("<?php\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cronFile := filepath.Join(home, "crontab")
+	crontab := strings.Join([]string{
+		`MAILTO=""`,                                                              // env → ignored
+		`*/5 * * * * curl https://own.example.com/cron-pong.php >/dev/null 2>&1`, // rewrite
+		`0 * * * * wget -q -O /dev/null https://own.example.com/wp-cron.php`,     // rewrite
+		`0 0 * * * curl https://own.example.com/cron-pong.php?tok=1`,             // disabled (query)
+		`0 0 * * * curl https://evil.com/x.php`,                                  // disabled (foreign)
+		`0 0 * * * php ` + filepath.Join(docroot, "wp-cron.php") + ` >/dev/null 2>&1`, // valid php, redirect stripped
+	}, "\n") + "\n"
+	if err := os.WriteFile(cronFile, []byte(crontab), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parsed := &ParsedTarball{
+		CronFiles:   []string{cronFile},
+		DomainNames: []string{"own.example.com"},
+		DocRoots:    map[string]string{"own.example.com": docroot},
+	}
+	repo := &fakeCronRepo{}
+	res, err := ImportCron(context.Background(), repo, parsed, "user-ulid", "alice")
+	if err != nil {
+		t.Fatalf("ImportCron: %v", err)
+	}
+
+	// 5 rows: 2 rewritten + 2 disabled-import + 1 valid php. (MAILTO is env-skipped.)
+	if len(repo.rows) != 5 {
+		t.Fatalf("created %d rows, want 5: %+v", len(repo.rows), repo.rows)
+	}
+	for _, row := range repo.rows {
+		if row.Enabled {
+			t.Errorf("imported cron must be disabled, got enabled: %q", row.Command)
+		}
+	}
+
+	cmds := map[string]bool{}
+	for _, row := range repo.rows {
+		cmds[row.Command] = true
+	}
+	// Rewritten commands present.
+	if !cmds["php "+filepath.Join(docroot, "cron-pong.php")] {
+		t.Errorf("missing rewritten cron-pong row; got %v", cmds)
+	}
+	if !cmds["php "+filepath.Join(docroot, "wp-cron.php")] {
+		t.Errorf("missing rewritten/valid wp-cron row; got %v", cmds)
+	}
+	// Disabled-import preserves the ORIGINAL command verbatim.
+	if !cmds["curl https://own.example.com/cron-pong.php?tok=1"] {
+		t.Errorf("query-string cron should be disabled-imported with original; got %v", cmds)
+	}
+	if !cmds["curl https://evil.com/x.php"] {
+		t.Errorf("foreign-host cron should be disabled-imported with original; got %v", cmds)
+	}
+
+	// Manifest notes: at least one rewrite + one disabled_import line.
+	var rewrote, disabled bool
+	for _, sk := range res.Skipped {
+		if strings.Contains(sk, "cron rewritten curl→php") {
+			rewrote = true
+		}
+		if strings.Contains(sk, "cron_disabled_import") {
+			disabled = true
+		}
+	}
+	if !rewrote {
+		t.Errorf("expected a 'cron rewritten' manifest note; got %v", res.Skipped)
+	}
+	if !disabled {
+		t.Errorf("expected a 'cron_disabled_import' manifest note; got %v", res.Skipped)
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -718,17 +718,18 @@ function parseRestoreManifest(raw: string): RestoreParsed {
       line.includes("not found") ||
       line.includes("pending_manual") ||
       line.includes("already imported") ||
-      line.includes("wp_scheduler_skipped") ||
+      line.includes("cron_disabled_import") ||
       line.includes("env_ignored") ||
       line.includes("_skipped:") ||
       line.startsWith("warning:") ||
       line.startsWith("skip:")
     ) {
       // Surface actionable migration skips in the warnings card rather
-      // than burying them in the raw-manifest collapse. wp_scheduler_
-      // skipped (curl wp-cron the allowlist rejected) + env_ignored
-      // (MAILTO/SHELL/PATH crontab lines) are the operator's cue to
-      // re-add the WP scheduler / re-apply env via the panel.
+      // than burying them in the raw-manifest collapse. cron_disabled_
+      // import (a cron we couldn't safely auto-rewrite — imported
+      // disabled with the original command) + env_ignored (MAILTO/SHELL/
+      // PATH crontab lines) are the operator's cue to review/enable the
+      // cron or re-apply env via the panel.
       out.warnings.push(line);
     }
   }


### PR DESCRIPTION
## Summary

Replaces the `wp_scheduler_skipped` advisory (#263) with a real rewrite. A cPanel cron like `curl https://<own-domain>/wp-cron.php` is converted to a local `php <docroot>/<file>.php` exec when it self-targets one of the account's own domains + a real `.php` under the docroot. Local exec also kills the SSRF surface.

Rewrite gate (all must hold, else **disabled-import** preserving the original + note — never silently dropped):
1. shlex first token curl/wget
2. exactly one URL, scheme http/https only
3. host ∈ account's own domains (same-origin / SSRF gate)
4. no query string
5. path under docroot, ends `.php`, no `..`, **exists**
6. benign flags only (`-s -f -q`, `-o/-O` strictly `/dev/null`)

Rewritten command re-validated through `ValidateCommand` with real docroots (defense-in-depth). `cronvalidate` untouched.

**Gap fix:** strip trailing output-discard redirect (`>/dev/null 2>&1`, …) before validation — the metachar guard rejected any `>`, so real-world crons failed before the binary check. Real-file redirects left intact.

**Ordering:** `ImportCron` moved after `ImportHomeSplit`+`ImportDomains` so rule 5's file-existence check sees the rsynced dest docroots; now receives `targetUsername`.

## Test plan
- [x] unit: stripOutputRedirect, rewriteSelfCurlCron (all 7 spec cases + SSRF 169.254.169.254 + missing-file + non-php)
- [x] integration: full ImportCron over a representative crontab (2 rewritten + 2 disabled-import + 1 redirect-stripped php)
- [ ] live: cPanel import on testserver → curl wp-cron rewritten to php, disabled rows visible in manifest warnings