### PR TITLE
fix(install): add /etc/jabali-panel to panel ReadWritePaths (webmail-hosts.list write fails read-only)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4250,7 +4250,7 @@ LockPersonality=true
 # JIT-compiles YARA rules to WASM and requires PROT_EXEC mmap pages.
 # Defense-in-depth still covered by NoNewPrivileges + ProtectSystem +
 # RestrictAddressFamilies + ProtectKernel* above. ADR-0079.
-ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /etc/jabali-panel/migration-secrets /run/mysqld
+ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /etc/jabali-panel /run/mysqld
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
jabali-panel.service ProtectSystem=strict + ReadWritePaths only listed the migration-secrets subdir, so the webmail reconciler's write to /etc/jabali-panel/webmail-hosts.list failed read-only every tick. Widen to the parent dir. update.go re-renders the unit on `jabali update`.