### PR TITLE
fix(api): user delete must destroy the Stalwart account for each mailbox (orphan on re-migration)

### DIFF
--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -34,6 +34,7 @@ type UserHandlerConfig struct {
 	Domains         repository.DomainRepository
 	Databases       repository.DatabaseRepository
 	DatabaseUsers   repository.DatabaseUserRepository
+	Mailboxes       repository.MailboxRepository
 	Packages        repository.PackageRepository
 	Reconciler      *reconciler.Reconciler
 	Log             *slog.Logger
@@ -497,6 +498,36 @@ func (h *userHandler) delete(c *gin.Context) {
 			for i := range owned {
 				d := &owned[i]
 				name := d.Name
+				// Purge each mailbox's Stalwart Account BEFORE the domain
+				// delete FK-cascades the mailbox rows away. jabali user
+				// delete otherwise removed the panel row + home + DB but
+				// left the Stalwart registry account behind — re-migrating
+				// or recreating the same address then collided with
+				// {"type":"primaryKeyViolation","properties":["email"]}.
+				// Best-effort: a failure here doesn't block the delete (the
+				// reconciler/agent has no retry for this, but an orphan
+				// account is recoverable; a blocked user-delete is worse).
+				if h.cfg.Mailboxes != nil && h.cfg.Agent != nil {
+					mbs, _, mbErr := h.cfg.Mailboxes.ListByDomainID(c.Request.Context(), d.ID, repository.ListOptions{Limit: 10000})
+					if mbErr != nil {
+						slog.Warn("cascade delete: list domain mailboxes failed",
+							"user_id", id, "domain_id", d.ID, "domain", name, "err", mbErr)
+					} else {
+						for j := range mbs {
+							mb := &mbs[j]
+							mctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+							_, delErr := h.cfg.Agent.Call(mctx, "mailbox.delete", map[string]any{
+								"id":    mb.ID,
+								"email": mb.EmailCached,
+							})
+							cancel()
+							if delErr != nil {
+								slog.Warn("cascade delete: stalwart mailbox.delete failed",
+									"user_id", id, "domain", name, "email", mb.EmailCached, "err", delErr)
+							}
+						}
+					}
+				}
 				if err := h.cfg.Domains.Delete(c.Request.Context(), d.ID); err != nil {
 					slog.Warn("cascade delete: domain DB delete failed",
 						"user_id", id, "domain_id", d.ID, "domain", name, "err", err)

--- a/panel-api/internal/api/users_delete_mailbox_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mailbox_cascade_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,8 +60,12 @@ func (m *udMailboxRepo) ListByDomainID(_ context.Context, domainID string, _ rep
 	return mbs, int64(len(mbs)), nil
 }
 
-// udAgent records every Call.
+// udAgent records every Call. Thread-safe: the user-delete handler fires
+// some agent calls from background goroutines (fire-and-forget teardown)
+// that can outlive the HTTP response, so reads/writes of calls must be
+// guarded.
 type udAgent struct {
+	mu    sync.Mutex
 	calls []struct {
 		cmd    string
 		params any
@@ -68,11 +73,30 @@ type udAgent struct {
 }
 
 func (a *udAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.mu.Lock()
 	a.calls = append(a.calls, struct {
 		cmd    string
 		params any
 	}{cmd, params})
+	a.mu.Unlock()
 	return json.RawMessage(`{"ok":true}`), nil
+}
+
+// emails returns the set of emails passed to mailbox.delete calls.
+func (a *udAgent) mailboxDeleteEmails() map[string]bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := map[string]bool{}
+	for _, c := range a.calls {
+		if c.cmd == "mailbox.delete" {
+			if m, ok := c.params.(map[string]any); ok {
+				if e, ok := m["email"].(string); ok {
+					out[e] = true
+				}
+			}
+		}
+	}
+	return out
 }
 
 // TestUserDelete_DestroysStalwartAccounts is the regression guard for the
@@ -118,16 +142,9 @@ func TestUserDelete_DestroysStalwartAccounts(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
 	// Both mailboxes' Stalwart accounts must have been destroyed by email.
-	gotEmails := map[string]bool{}
-	for _, c := range ag.calls {
-		if c.cmd == "mailbox.delete" {
-			if m, ok := c.params.(map[string]any); ok {
-				if e, ok := m["email"].(string); ok {
-					gotEmails[e] = true
-				}
-			}
-		}
-	}
-	assert.True(t, gotEmails["info@victim.example.com"], "info mailbox Stalwart account must be destroyed; calls=%v", ag.calls)
-	assert.True(t, gotEmails["sales@victim.example.com"], "sales mailbox Stalwart account must be destroyed; calls=%v", ag.calls)
+	// mailbox.delete fires synchronously in the cascade (before the
+	// response), so it's recorded by the time doJSON returns.
+	gotEmails := ag.mailboxDeleteEmails()
+	assert.True(t, gotEmails["info@victim.example.com"], "info mailbox Stalwart account must be destroyed; got=%v", gotEmails)
+	assert.True(t, gotEmails["sales@victim.example.com"], "sales mailbox Stalwart account must be destroyed; got=%v", gotEmails)
 }

--- a/panel-api/internal/api/users_delete_mailbox_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mailbox_cascade_test.go
@@ -1,0 +1,133 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gin-gonic/gin"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/api"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/models"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// udDomainRepo: interface-embedding mock; only the two methods the
+// user-delete cascade calls are real (ListByUserID + Delete).
+type udDomainRepo struct {
+	repository.DomainRepository
+	domains []models.Domain
+	deleted []string
+}
+
+func (m *udDomainRepo) ListByUserID(_ context.Context, _ string, _ repository.ListOptions) ([]models.Domain, int64, error) {
+	var live []models.Domain
+	for _, d := range m.domains {
+		gone := false
+		for _, id := range m.deleted {
+			if id == d.ID {
+				gone = true
+				break
+			}
+		}
+		if !gone {
+			live = append(live, d)
+		}
+	}
+	return live, int64(len(live)), nil
+}
+
+func (m *udDomainRepo) Delete(_ context.Context, id string) error {
+	m.deleted = append(m.deleted, id)
+	return nil
+}
+
+// udMailboxRepo: only ListByDomainID is real.
+type udMailboxRepo struct {
+	repository.MailboxRepository
+	byDomain map[string][]models.Mailbox
+}
+
+func (m *udMailboxRepo) ListByDomainID(_ context.Context, domainID string, _ repository.ListOptions) ([]models.Mailbox, int64, error) {
+	mbs := m.byDomain[domainID]
+	return mbs, int64(len(mbs)), nil
+}
+
+// udAgent records every Call.
+type udAgent struct {
+	calls []struct {
+		cmd    string
+		params any
+	}
+}
+
+func (a *udAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.calls = append(a.calls, struct {
+		cmd    string
+		params any
+	}{cmd, params})
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+// TestUserDelete_DestroysStalwartAccounts is the regression guard for the
+// orphaned-Stalwart-account bug: jabali user delete must dispatch
+// mailbox.delete (which Account/set-destroys the Stalwart registry
+// account) for every mailbox under the user's domains BEFORE the domain
+// delete FK-cascades the rows away. Without it, re-creating/re-migrating
+// the same address collides with primaryKeyViolation on email.
+func TestUserDelete_DestroysStalwartAccounts(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	repo.seed(admin)
+	victim := makeUser(t, "victim@example.com", false, "victimpassword")
+	uname := "victim"
+	victim.Username = &uname
+	repo.seed(victim)
+
+	domID := "01DOMAIN0000000000000000AA"
+	dom := &udDomainRepo{domains: []models.Domain{{ID: domID, UserID: victim.ID, Name: "victim.example.com"}}}
+	mbx := &udMailboxRepo{byDomain: map[string][]models.Mailbox{
+		domID: {
+			{ID: "01MBX00000000000000000001", DomainID: domID, LocalPart: "info", EmailCached: "info@victim.example.com"},
+			{ID: "01MBX00000000000000000002", DomainID: domID, LocalPart: "sales", EmailCached: "sales@victim.example.com"},
+		},
+	}}
+	ag := &udAgent{}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	claims := &auth.AccessClaims{UserID: admin.ID, IsAdmin: true}
+	g := r.Group("/api/v1", func(c *gin.Context) {
+		ginctx.SetClaims(c, claims)
+		c.Next()
+	})
+	api.RegisterUserRoutes(g, api.UserHandlerConfig{
+		Repo:      repo,
+		Agent:     ag,
+		Domains:   dom,
+		Mailboxes: mbx,
+	})
+
+	rec := doJSON(t, r, http.MethodDelete, "/api/v1/users/"+victim.ID, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Both mailboxes' Stalwart accounts must have been destroyed by email.
+	gotEmails := map[string]bool{}
+	for _, c := range ag.calls {
+		if c.cmd == "mailbox.delete" {
+			if m, ok := c.params.(map[string]any); ok {
+				if e, ok := m["email"].(string); ok {
+					gotEmails[e] = true
+				}
+			}
+		}
+	}
+	assert.True(t, gotEmails["info@victim.example.com"], "info mailbox Stalwart account must be destroyed; calls=%v", ag.calls)
+	assert.True(t, gotEmails["sales@victim.example.com"], "sales mailbox Stalwart account must be destroyed; calls=%v", ag.calls)
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -432,6 +432,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Domains:         deps.Domains,
 				Databases:       deps.Databases,
 				DatabaseUsers:   deps.DatabaseUsers,
+				Mailboxes:       deps.Mailboxes,
 				Packages:        deps.Packages,
 				Reconciler:      deps.Reconciler,
 				Log:             deps.Log,


### PR DESCRIPTION
jabali user delete removed the panel mailbox row + home + DB but never destroyed the mailbox's Stalwart registry account → orphan, so re-creating/re-migrating the same address collided with primaryKeyViolation on email. Add a mailbox step to the user-delete cascade: dispatch agent mailbox.delete (Account/set destroy) for each owned-domain mailbox before the domain delete FK-cascades the rows. Wired Mailboxes repo into UserHandlerConfig. Best-effort + tested.