### PR TITLE
fix(appsec): write webmail-hosts.list to /var/lib/jabali-panel (service-user owned), not the root config dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4250,7 +4250,7 @@ LockPersonality=true
 # JIT-compiles YARA rules to WASM and requires PROT_EXEC mmap pages.
 # Defense-in-depth still covered by NoNewPrivileges + ProtectSystem +
 # RestrictAddressFamilies + ProtectKernel* above. ADR-0079.
-ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /etc/jabali-panel /run/mysqld
+ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /var/lib/jabali-panel /etc/jabali-panel/migration-secrets /run/mysqld
 
 [Install]
 WantedBy=multi-user.target

--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -36,7 +36,7 @@ type Opts struct {
 	// session after the JWT exchange.
 	//
 	// Caller MUST populate from a managed source (the panel-api
-	// reconciler writes /etc/jabali-panel/webmail-hosts.list from the
+	// reconciler writes /var/lib/jabali-panel/webmail-hosts.list from the
 	// domain repo every pass; render-config + agent both read that
 	// file). MUST NOT be derived from the request — `req.Host
 	// startsWith "mail."` is bypassable via arbitrary Host headers

--- a/internal/appseccfg/state.go
+++ b/internal/appseccfg/state.go
@@ -23,7 +23,14 @@ import (
 // Format: one lower-case FQDN per line. Lines starting with '#' and
 // blank lines are ignored. Anything failing sanitizeWebmailHosts is
 // dropped silently — operators must not edit this file by hand.
-const WebmailHostsPath = "/etc/jabali-panel/webmail-hosts.list"
+// Lives under /var/lib/jabali-panel (owned by the panel's service user)
+// rather than /etc/jabali-panel (root-owned config dir): the reconciler
+// runs as the unprivileged service user and could not create the file
+// (or its tmp) in the root-owned config dir — "permission denied" every
+// pass — and widening that dir would have made the root-owned secrets
+// (kratos.yml, *.env) group-writable. The agent reads via this same
+// const, so both writer + readers follow the move.
+const WebmailHostsPath = "/var/lib/jabali-panel/webmail-hosts.list"
 
 // LoadWebmailHosts reads and sanitizes the state file at the given
 // path. Missing file is NOT an error (returns nil, nil) — fresh


### PR DESCRIPTION
Follow-up to #269. Widening ReadWritePaths to /etc/jabali-panel fixed 'read-only' but exposed 'permission denied' — the panel runs as the unprivileged service user and /etc/jabali-panel is root:root 0755. Move the state file to /var/lib/jabali-panel/webmail-hosts.list (already jabali:jabali, verified writable). Const-driven so both panel-api + agent follow. ReadWritePaths: drop the broad /etc/jabali-panel (secrets dir hardened again), restore migration-secrets subdir, add /var/lib/jabali-panel.