### PR TITLE
fix(update): include the shared /internal tree in panel-api + panel-agent rebuild hashes

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -895,8 +895,16 @@ test -x node_modules/.bin/tsc || {
 			// nginx serves the cached HTML pointing at a stale /assets/
 			// index-XXX.js that the embedded FS still has, and the browser
 			// keeps rendering the old UI even after `jabali update`.
-			apiInputs := compositeSHA("panel-api", "agentwire", "go.mod", "go.sum", "panel-ui/dist/index.html")
-			agentInputs := compositeSHA("panel-agent", "agentwire", "go.mod", "go.sum")
+			// "internal" = the repo-root /internal/ tree of SHARED Go
+			// packages (appseccfg, cronvalidate, kratosclient, backup,
+			// limits, …) that BOTH binaries import. It is NOT under the
+			// "panel-api"/"panel-agent" subtrees, so without listing it
+			// explicitly a change to any shared package (e.g. moving
+			// appseccfg.WebmailHostsPath) doesn't bump these composites
+			// and the binary is skipped — shipping a stale binary against
+			// a new unit/config. Same failure mode #255 fixed for dist.
+			apiInputs := compositeSHA("panel-api", "agentwire", "internal", "go.mod", "go.sum", "panel-ui/dist/index.html")
+			agentInputs := compositeSHA("panel-agent", "agentwire", "internal", "go.mod", "go.sum")
 			apiSkip := artifactUnchanged("panel-api-bin", apiInputs, defaultPanelBinPath)
 			agentSkip := artifactUnchanged("panel-agent-bin", agentInputs, defaultAgentBinPath)
 			if apiSkip {


### PR DESCRIPTION
apiInputs/agentInputs composites didn't hash the repo-root /internal/ tree of SHARED packages both binaries import (appseccfg, cronvalidate, kratosclient, …). So a change there didn't bump the hash → jabali update skipped the rebuild → stale binary against a fresh unit/config. Just hit live: #271 moved appseccfg.WebmailHostsPath but the binary wasn't rebuilt. Add `internal` to both composites. Same class as #255 (dist).