### PR TITLE
fix(agent): cron units to systemd-user search path + run_now via systemd-run (cron never executed)

### DIFF
--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -127,14 +127,35 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 		}
 	}
 
-	// Create cron-units directory
-	unitsDir := fmt.Sprintf("/etc/jabali-panel/cron-units/%s", p.Username)
+	// Units MUST live in a systemd-user search path or `systemctl --user
+	// enable <name>` can't find them ("Unit … does not exist"). The
+	// previous /etc/jabali-panel/cron-units/<user> path is NOT a search
+	// path, so timers were written to disk but never loaded (list-timers
+	// empty, last_run NULL). Write into the user's
+	// ~/.config/systemd/user/ — the standard per-user search path — and
+	// chown the tree so the user manager can read it.
+	uidN, _ := strconv.Atoi(u.Uid)
+	gidN, _ := strconv.Atoi(u.Gid)
+	unitsDir := filepath.Join(u.HomeDir, ".config", "systemd", "user")
 	if err := os.MkdirAll(unitsDir, 0755); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: fmt.Sprintf("failed to create units directory: %v", err),
 		}
 	}
+	// chown the dirs we may have just created (idempotent if already
+	// user-owned) so systemd --user + the user can manage them.
+	for _, d := range []string{
+		filepath.Join(u.HomeDir, ".config"),
+		filepath.Join(u.HomeDir, ".config", "systemd"),
+		unitsDir,
+	} {
+		_ = os.Chown(d, uidN, gidN)
+	}
+	// Best-effort: clean up units stranded in the old non-search-path
+	// location from before this fix so they don't linger on disk.
+	_ = os.RemoveAll(fmt.Sprintf("/etc/jabali-panel/cron-units/%s/jabali-cron-%s.service", p.Username, p.JobID))
+	_ = os.RemoveAll(fmt.Sprintf("/etc/jabali-panel/cron-units/%s/jabali-cron-%s.timer", p.Username, p.JobID))
 
 	// Generate unit file paths
 	servicePath := filepath.Join(unitsDir, fmt.Sprintf("jabali-cron-%s.service", p.JobID))
@@ -169,6 +190,8 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 			Message: fmt.Sprintf("failed to write timer file: %v", err),
 		}
 	}
+	_ = os.Chown(servicePath, uidN, gidN)
+	_ = os.Chown(timerPath, uidN, gidN)
 
 	// Reload systemd as user and enable timer
 	if err := systemctlUserExec(ctx, p.Username, runtimeDir, "daemon-reload"); err != nil {

--- a/panel-agent/internal/commands/cron_run_now.go
+++ b/panel-agent/internal/commands/cron_run_now.go
@@ -5,20 +5,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
 
 	"git.linux-hosting.co.il/shukivaknin/jabali2/agentwire"
+	"git.linux-hosting.co.il/shukivaknin/jabali2/internal/cronvalidate"
 )
 
 // cronRunNowParams is the input for cron.run_now command.
 type cronRunNowParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	JobID    string `json:"job_id"`
+	UserID        string   `json:"user_id"`
+	Username      string   `json:"username"`
+	JobID         string   `json:"job_id"`
+	Command       string   `json:"command"`
+	OwnedDocroots []string `json:"owned_docroots"`
 }
 
 // cronRunNowResponse is the output from cron.run_now.
@@ -28,6 +30,22 @@ type cronRunNowResponse struct {
 	Stderr   string `json:"stderr,omitempty"`
 }
 
+// cronRunNowHandler runs a cron job's command ONCE, immediately, in the
+// owning user's context, and returns its exit code + output.
+//
+// It executes the command directly via
+//
+//	systemd-run --user --machine=<user>@.host --pipe --wait --collect -- <argv>
+//
+// rather than `systemctl --user start <timer's .service>`:
+//   - --machine=<user>@.host connects to the user's systemd manager over
+//     the system bus, so no fragile XDG_RUNTIME_DIR / DBUS env plumbing
+//     through `sudo -u` (whose env_reset stripped it — the old bug).
+//   - --pipe captures stdout/stderr, --wait blocks until the unit
+//     finishes and propagates its exit code, --collect garbage-collects
+//     the transient unit. So the operator gets the REAL command exit code
+//     + output, independent of whether the persistent timer/service unit
+//     happens to be loaded.
 func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p cronRunNowParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -36,22 +54,27 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 			Message: fmt.Sprintf("failed to parse params: %v", err),
 		}
 	}
-
-	// Validate inputs
 	if p.Username == "" {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: "username required",
-		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username required"}
 	}
 	if p.JobID == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "job_id required"}
+	}
+	if p.Command == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "command required"}
+	}
+
+	// Defense-in-depth: re-validate the command against the user's owned
+	// docroots (same gate as cron.apply) before executing it. Never trust
+	// the stored command blindly.
+	validated, vErr := cronvalidate.ValidateCommand(p.Command, p.OwnedDocroots)
+	if vErr != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: "job_id required",
+			Message: fmt.Sprintf("command failed validation: %v", vErr),
 		}
 	}
 
-	// Resolve user's UID
 	u, err := user.Lookup(p.Username)
 	if err != nil {
 		return nil, &agentwire.AgentError{
@@ -59,27 +82,34 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 			Message: fmt.Sprintf("user %s not found: %v", p.Username, err),
 		}
 	}
-
 	uid, _ := strconv.Atoi(u.Uid)
 	runtimeDir := fmt.Sprintf("/run/user/%d", uid)
 
-	// Start the service (systemctl --user start)
-	cmd := exec.CommandContext(ctx, "sudo", "-u", p.Username)
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir),
-	)
-	cmd.Args = append(cmd.Args, "systemctl", "--user", "start", fmt.Sprintf("jabali-cron-%s.service", p.JobID))
+	// Ensure the user manager is up (linger + bus) so --machine can reach it.
+	if err := ensureUserManager(ctx, p.Username, uid, runtimeDir); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("prepare user systemd manager for %s: %v", p.Username, err),
+		}
+	}
+
+	args := []string{
+		"--user",
+		"--machine=" + p.Username + "@.host",
+		"--pipe", "--wait", "--collect",
+		"--",
+	}
+	args = append(args, validated.Argv...)
+	cmd := exec.CommandContext(ctx, "systemd-run", args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	runErr := cmd.Run()
 
-	err = cmd.Run()
-
-	// Extract exit code (0 for success, >0 for failure)
 	exitCode := 0
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
 			exitCode = 1
@@ -88,7 +118,7 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 
 	return &cronRunNowResponse{
 		ExitCode: exitCode,
-		Stdout:   stdout.String(),
+		Stdout:   strings.TrimSpace(stdout.String()),
 		Stderr:   strings.TrimSpace(stderr.String()),
 	}, nil
 }

--- a/panel-agent/internal/commands/cron_run_now_test.go
+++ b/panel-agent/internal/commands/cron_run_now_test.go
@@ -54,7 +54,9 @@ func TestCronRunNowUnknownUser(t *testing.T) {
 	params := json.RawMessage(`{
 		"user_id": "999",
 		"username": "nonexistentuser12345",
-		"job_id": "job1"
+		"job_id": "job1",
+		"command": "php /home/nonexistentuser12345/public_html/wp-cron.php",
+		"owned_docroots": ["/home/nonexistentuser12345/public_html"]
 	}`)
 
 	_, err := cronRunNowHandler(context.Background(), params)

--- a/panel-api/internal/api/cron.go
+++ b/panel-api/internal/api/cron.go
@@ -141,9 +141,11 @@ type cronRemoveAgentParams struct {
 }
 
 type cronRunNowAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	JobID    string `json:"job_id"`
+	UserID        string   `json:"user_id"`
+	Username      string   `json:"username"`
+	JobID         string   `json:"job_id"`
+	Command       string   `json:"command"`
+	OwnedDocroots []string `json:"owned_docroots"`
 }
 
 type cronTailLogAgentParams struct {
@@ -424,8 +426,21 @@ func (h *cronHandler) runNow(c *gin.Context) {
 		return
 	}
 
+	// Resolve the user's owned docroots so the agent can re-validate the
+	// command (defense-in-depth) before executing it.
+	var docroots []string
+	if h.cfg.Domains != nil {
+		if owned, _, dErr := h.cfg.Domains.ListByUserID(ctx, job.UserID, repository.ListOptions{Limit: 1000}); dErr == nil {
+			for _, dm := range owned {
+				if dm.DocRoot != "" {
+					docroots = append(docroots, dm.DocRoot)
+				}
+			}
+		}
+	}
 	result, err := h.cfg.Agent.Call(ctx, "cron.run_now", cronRunNowAgentParams{
 		UserID: job.UserID, Username: username, JobID: job.ID,
+		Command: job.Command, OwnedDocroots: docroots,
 	})
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_run_now_failed", "detail": err.Error()})

--- a/panel-api/internal/api/cron_wire_test.go
+++ b/panel-api/internal/api/cron_wire_test.go
@@ -31,8 +31,8 @@ func TestCronAgentParamsWireShape(t *testing.T) {
 		},
 		{
 			name:    "cron.run_now",
-			payload: cronRunNowAgentParams{UserID: "u", Username: "shuki", JobID: "j"},
-			want:    []string{"job_id", "user_id", "username"},
+			payload: cronRunNowAgentParams{UserID: "u", Username: "shuki", JobID: "j", Command: "php /home/u/public_html/wp-cron.php", OwnedDocroots: []string{"/home/u/public_html"}},
+			want:    []string{"command", "job_id", "owned_docroots", "user_id", "username"},
 		},
 		{
 			name:    "cron.tail_log_with_lines",


### PR DESCRIPTION
Two bugs left every jabali user cron non-functional (post-#268).

**Bug A** — cron.apply wrote units to `/etc/jabali-panel/cron-units/<user>/`, not a systemd-user search path, so `enable --now <name>` couldn't find them (timer never loaded, last_run NULL). Write to `~/.config/systemd/user/` + chown; clean up old location. Verified: timer loads + appears in list-timers.

**Bug B** — cron.run_now still used the stripped-env `sudo -u` form (#268 only fixed cron.apply) AND started an unloaded unit. Rewrite to run the command directly via `systemd-run --user --machine=<user>@.host --pipe --wait --collect -- <argv>` (real exit + output, no env plumbing). Re-validates the command against owned docroots. Verified: ran php wp-cron.php → exit 0, pong written.

Wire: cronRunNowAgentParams gains command + owned_docroots; panel resolves docroots + passes the stored command.

## Test plan
- [x] agent + wire-contract unit tests updated/green
- [x] live: unit in ~/.config/systemd/user enables + loads; systemd-run --machine runs the command
- [ ] post-deploy: real cron job → timer appears in `systemctl --user list-timers`, Run-now returns exit 0