### PR TITLE
fix(agent): translate cron schedule to systemd OnCalendar (timer never fired)

### DIFF
--- a/internal/cronvalidate/oncalendar.go
+++ b/internal/cronvalidate/oncalendar.go
@@ -1,0 +1,118 @@
+package cronvalidate
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// dowNames maps cron weekday number (0=Sun … 6=Sat) to the systemd
+// OnCalendar weekday name. cron also allows 7 for Sunday.
+var dowNames = []string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+
+// CronToSystemdCalendar translates a validated 5-field POSIX cron
+// expression ("min hour dom month dow") into a systemd OnCalendar=
+// specification ("[DOW ]Y-Mon-Day H:Min:Sec").
+//
+// Why: systemd timers parse OnCalendar in systemd-calendar format, NOT
+// cron — dumping "*/5 * * * *" into OnCalendar yields
+// "Loaded: bad-setting" and the timer never fires. Callers must run the
+// expression through ValidateSchedule first (this assumes 5 fields).
+//
+// Field translation per cron atom (each comma-separated piece):
+//   *           -> *
+//   N           -> N
+//   */K         -> <fieldmin>/K            (systemd start/step; min 0 for
+//                                            minute/hour, 1 for dom/month)
+//   A-B         -> A..B
+//   A-B/K       -> A..B/K
+// dow numbers become names (7 -> Sun); month/day numbers pass through
+// (systemd accepts numeric month + day). Seconds are pinned to :00.
+func CronToSystemdCalendar(expr string) (string, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return "", fmt.Errorf("CronToSystemdCalendar: expected 5 cron fields, got %d (%q)", len(fields), expr)
+	}
+	minute := cronFieldToSystemd(fields[0], 0)
+	hour := cronFieldToSystemd(fields[1], 0)
+	dom := cronFieldToSystemd(fields[2], 1)
+	month := cronFieldToSystemd(fields[3], 1)
+	dow := cronDOWToSystemd(fields[4])
+
+	cal := fmt.Sprintf("*-%s-%s %s:%s:00", month, dom, hour, minute)
+	if dow != "" {
+		cal = dow + " " + cal
+	}
+	return cal, nil
+}
+
+// cronFieldToSystemd converts a non-DOW cron field (which may be a
+// comma list of atoms) to systemd syntax. fieldMin is the lowest legal
+// value (0 for minute/hour, 1 for day-of-month/month) used to expand
+// a bare */K step.
+func cronFieldToSystemd(field string, fieldMin int) string {
+	atoms := strings.Split(field, ",")
+	for i, a := range atoms {
+		atoms[i] = cronAtomToSystemd(a, fieldMin)
+	}
+	return strings.Join(atoms, ",")
+}
+
+func cronAtomToSystemd(atom string, fieldMin int) string {
+	// */K  -> <min>/K
+	if strings.HasPrefix(atom, "*/") {
+		return fmt.Sprintf("%d/%s", fieldMin, atom[2:])
+	}
+	// A-B/K or A-B  -> A..B[/K]
+	if slash := strings.IndexByte(atom, '/'); slash >= 0 {
+		rng, step := atom[:slash], atom[slash+1:]
+		rng = strings.Replace(rng, "-", "..", 1)
+		return rng + "/" + step
+	}
+	if strings.Contains(atom, "-") {
+		return strings.Replace(atom, "-", "..", 1)
+	}
+	// * or a bare number
+	return atom
+}
+
+// cronDOWToSystemd converts the cron day-of-week field to a systemd
+// weekday spec. Returns "" for "*" (systemd omits the weekday → every
+// day). Numeric tokens become names; non-numeric (already a name) pass
+// through.
+func cronDOWToSystemd(field string) string {
+	if field == "*" {
+		return ""
+	}
+	atoms := strings.Split(field, ",")
+	for i, a := range atoms {
+		if slash := strings.IndexByte(a, '/'); slash >= 0 {
+			rng, step := a[:slash], a[slash+1:]
+			atoms[i] = cronDOWRange(rng) + "/" + step
+			continue
+		}
+		atoms[i] = cronDOWRange(a)
+	}
+	return strings.Join(atoms, ",")
+}
+
+func cronDOWRange(s string) string {
+	if dash := strings.IndexByte(s, '-'); dash >= 0 {
+		return cronDOWName(s[:dash]) + ".." + cronDOWName(s[dash+1:])
+	}
+	return cronDOWName(s)
+}
+
+func cronDOWName(s string) string {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return s // already a name (Mon, Tue, …)
+	}
+	if n == 7 {
+		n = 0
+	}
+	if n >= 0 && n <= 6 {
+		return dowNames[n]
+	}
+	return s
+}

--- a/internal/cronvalidate/oncalendar_test.go
+++ b/internal/cronvalidate/oncalendar_test.go
@@ -1,0 +1,34 @@
+package cronvalidate
+
+import "testing"
+
+func TestCronToSystemdCalendar(t *testing.T) {
+	cases := map[string]string{
+		"*/5 * * * *":   "*-*-* *:0/5:00",
+		"0 0 * * *":     "*-*-* 0:0:00",
+		"30 2 * * 1":    "Mon *-*-* 2:30:00",
+		"0 */6 * * *":   "*-*-* 0/6:0:00",
+		"15 10 1 * *":   "*-*-1 10:15:00",
+		"0 9 * * 1-5":   "Mon..Fri *-*-* 9:0:00",
+		"*/15 * * * *":  "*-*-* *:0/15:00",
+		"0 0 * * 0":     "Sun *-*-* 0:0:00",
+		"0 0 1,15 * *":  "*-*-1,15 0:0:00",
+		"0 0 * * 7":     "Sun *-*-* 0:0:00",
+	}
+	for in, want := range cases {
+		got, err := CronToSystemdCalendar(in)
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("CronToSystemdCalendar(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCronToSystemdCalendar_BadFieldCount(t *testing.T) {
+	if _, err := CronToSystemdCalendar("*/5 * * *"); err == nil {
+		t.Error("expected error for 4-field expr")
+	}
+}

--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -163,7 +163,13 @@ func cronApplyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 
 	// Generate unit file content
 	serviceContent := buildCronServiceContent(p.JobID, p.Name, cmd, p.Username, p.OwnedDocroots)
-	timerContent := buildCronTimerContent(p.JobID, p.Schedule)
+	timerContent, tcErr := buildCronTimerContent(p.JobID, p.Schedule)
+	if tcErr != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("translate schedule %q to OnCalendar: %v", p.Schedule, tcErr),
+		}
+	}
 
 	// Check for no-change (idempotency per spec §3 invariant)
 	serviceMatch := filesMatch(servicePath, []byte(serviceContent))
@@ -264,8 +270,15 @@ WorkingDirectory=%%h
 `, jobID, name, execStartPre, execStart)
 }
 
-// buildCronTimerContent generates the systemd timer unit content.
-func buildCronTimerContent(jobID, schedule string) string {
+// buildCronTimerContent generates the systemd timer unit content. The
+// stored schedule is 5-field POSIX cron; systemd OnCalendar= needs
+// systemd-calendar format (cron syntax yields "Loaded: bad-setting" and
+// the timer never fires), so translate it via cronvalidate.
+func buildCronTimerContent(jobID, schedule string) (string, error) {
+	onCalendar, err := cronvalidate.CronToSystemdCalendar(schedule)
+	if err != nil {
+		return "", err
+	}
 	return fmt.Sprintf(`[Unit]
 Description=Jabali cron timer for %s
 
@@ -276,7 +289,7 @@ Unit=jabali-cron-%s.service
 
 [Install]
 WantedBy=timers.target
-`, jobID, schedule, jobID)
+`, jobID, onCalendar, jobID), nil
 }
 
 // singleQuote wraps a token in single quotes, escaping any embedded single quotes.
@@ -371,7 +384,13 @@ func applyRootCron(ctx context.Context, p cronApplyParams) (any, error) {
 	timerPath := filepath.Join("/etc/systemd/system", fmt.Sprintf("jabali-cron-%s.timer", p.JobID))
 
 	serviceContent := buildRootCronServiceContent(p.JobID, p.Name, p.Command)
-	timerContent := buildCronTimerContent(p.JobID, p.Schedule)
+	timerContent, tcErr := buildCronTimerContent(p.JobID, p.Schedule)
+	if tcErr != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("translate schedule %q to OnCalendar: %v", p.Schedule, tcErr),
+		}
+	}
 
 	if filesMatch(servicePath, []byte(serviceContent)) && filesMatch(timerPath, []byte(timerContent)) {
 		return &cronApplyResponse{ServicePath: servicePath, TimerPath: timerPath, NoChange: true}, nil

--- a/panel-agent/internal/commands/cron_apply_test.go
+++ b/panel-agent/internal/commands/cron_apply_test.go
@@ -267,7 +267,10 @@ func TestBuildCronServiceContent(t *testing.T) {
 }
 
 func TestBuildCronTimerContent(t *testing.T) {
-	content := buildCronTimerContent("job1", "0 * * * *")
+	content, err := buildCronTimerContent("job1", "0 * * * *")
+	if err != nil {
+		t.Fatalf("buildCronTimerContent: %v", err)
+	}
 
 	// Verify structure
 	if !contains(content, "[Unit]") {
@@ -279,8 +282,10 @@ func TestBuildCronTimerContent(t *testing.T) {
 	if !contains(content, "[Install]") {
 		t.Error("missing [Install] section")
 	}
-	if !contains(content, "OnCalendar=0 * * * *") {
-		t.Error("missing OnCalendar setting")
+	// 5-field cron is translated to systemd OnCalendar (NOT raw cron,
+	// which yields "Loaded: bad-setting"). "0 * * * *" → hourly at :00.
+	if !contains(content, "OnCalendar=*-*-* *:0:00") {
+		t.Errorf("OnCalendar not translated to systemd format; got:\n%s", content)
 	}
 	if !contains(content, "Unit=jabali-cron-job1.service") {
 		t.Error("missing Unit setting")


### PR DESCRIPTION
Final cron bug. #273 placed+enabled the timer, but buildCronTimerContent dumped raw 5-field cron into OnCalendar=, which systemd can't parse (`Loaded: bad-setting`, never fires). Add cronvalidate.CronToSystemdCalendar (cron → systemd-calendar) and run the schedule through it in both timer paths. Every mapping verified against `systemd-analyze calendar` on the box (e.g. `*/5 * * * *` → `*-*-* *:0/5:00`).