### PR TITLE
fix(cron): ship cron-precheck ExecStartPre helper + persist last-run on Run-now

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1782,6 +1782,10 @@ install_jabali_slices() {
   install -d -m 0755 /usr/local/libexec/jabali
   install -m 0755 "$REPO_DIR/install/systemd/fpm-pre-start" /usr/local/libexec/jabali/fpm-pre-start
   install -m 0755 "$REPO_DIR/install/systemd/fpm-exec" /usr/local/libexec/jabali/fpm-exec
+  # cron-precheck is the ExecStartPre guard generated cron .service units
+  # reference (panel-agent buildCronServiceContent). Without it the unit
+  # dies 203/EXEC and scheduled crons never run.
+  install -m 0755 "$REPO_DIR/install/systemd/cron-precheck" /usr/local/libexec/jabali/cron-precheck
 
   install -m 0644 "$REPO_DIR/install/systemd/jabali.slice" /etc/systemd/system/jabali.slice
   install -m 0644 "$REPO_DIR/install/systemd/jabali-user.slice" /etc/systemd/system/jabali-user.slice

--- a/install/systemd/cron-precheck
+++ b/install/systemd/cron-precheck
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# jabali cron pre-check: runs as ExecStartPre before a tenant cron's
+# ExecStart. Validates that the docroot the cron targets still exists
+# and is a directory, so a stale cron (e.g. its domain was deleted but
+# the cron_jobs row lingered) fails cleanly instead of spamming PHP
+# "No such file" errors on every fire.
+#
+# Exits 0 → let the cron run. Non-zero → systemd marks the unit failed
+# and ExecStart is skipped (the intended "don't run" outcome).
+set -u
+
+docroot="${1:-}"
+if [[ -z "$docroot" ]]; then
+  echo "cron-precheck: no docroot argument" >&2
+  exit 1
+fi
+if [[ ! -d "$docroot" ]]; then
+  echo "cron-precheck: docroot '$docroot' does not exist — skipping cron" >&2
+  exit 1
+fi
+exit 0

--- a/panel-agent/internal/commands/cron_precheck_install_test.go
+++ b/panel-agent/internal/commands/cron_precheck_install_test.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/internal/cronvalidate"
+)
+
+// libexecRefRe finds every /usr/local/libexec/jabali/<name> path a
+// generated unit references in an ExecStart* line.
+var libexecRefRe = regexp.MustCompile(`/usr/local/libexec/jabali/([A-Za-z0-9._-]+)`)
+
+// TestGeneratedUnitLibexecHelpersAreShipped guards the cron-precheck
+// 203/EXEC regression: a unit builder must never reference a libexec
+// helper that install.sh doesn't ship. For every /usr/local/libexec/
+// jabali/<name> in a rendered cron service unit, assert install/systemd/
+// <name> exists in the repo AND install.sh installs it.
+func TestGeneratedUnitLibexecHelpersAreShipped(t *testing.T) {
+	cmd, err := cronvalidate.ValidateCommand("php /home/u/public_html/wp-cron.php", []string{"/home/u/public_html"})
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	svc := buildCronServiceContent("job1", "test", cmd, "u", []string{"/home/u/public_html"})
+
+	refs := libexecRefRe.FindAllStringSubmatch(svc, -1)
+	if len(refs) == 0 {
+		t.Skip("no libexec helper referenced in the generated unit")
+	}
+
+	// repo root = panel-agent/internal/commands -> ../../..
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	installSh, err := os.ReadFile(filepath.Join(root, "install.sh"))
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+
+	for _, m := range refs {
+		name := m[1]
+		src := filepath.Join(root, "install", "systemd", name)
+		if _, err := os.Stat(src); err != nil {
+			t.Errorf("unit references /usr/local/libexec/jabali/%s but install/systemd/%s does not exist (203/EXEC at runtime)", name, name)
+		}
+		if !strings.Contains(string(installSh), "install/systemd/"+name) {
+			t.Errorf("install.sh never installs install/systemd/%s — generated unit would hit 203/EXEC on the host", name)
+		}
+	}
+}

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -372,6 +372,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 install -d -m 0755 /usr/local/libexec/jabali
 install -m 0755 ` + repoDir + `/install/systemd/fpm-pre-start /usr/local/libexec/jabali/fpm-pre-start
 install -m 0755 ` + repoDir + `/install/systemd/fpm-exec /usr/local/libexec/jabali/fpm-exec
+install -m 0755 ` + repoDir + `/install/systemd/cron-precheck /usr/local/libexec/jabali/cron-precheck
 install -m 0644 ` + repoDir + `/install/systemd/jabali.slice /etc/systemd/system/jabali.slice
 install -m 0644 ` + repoDir + `/install/systemd/jabali-user.slice /etc/systemd/system/jabali-user.slice
 install -m 0644 ` + repoDir + `/install/systemd/jabali-fpm@.service /etc/systemd/system/jabali-fpm@.service

--- a/panel-api/internal/api/cron.go
+++ b/panel-api/internal/api/cron.go
@@ -451,6 +451,18 @@ func (h *cronHandler) runNow(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_response_invalid"})
 		return
 	}
+	// Persist the run outcome so the UI's "Last Run" / "Last Exit" columns
+	// reflect a manual Run-now (previously nothing ever called UpdateStatus,
+	// so Last Run stayed "Never" even after a successful run). Best-effort.
+	if h.cfg.CronJobs != nil {
+		lastErr := ""
+		if resp.ExitCode != 0 {
+			lastErr = resp.Stderr
+		}
+		if uErr := h.cfg.CronJobs.UpdateStatus(ctx, job.ID, time.Now().UTC(), resp.ExitCode, lastErr); uErr != nil {
+			h.cfg.Log.Warn("cron run_now: persist last-run failed", "job_id", job.ID, "err", uErr)
+		}
+	}
 	c.JSON(http.StatusOK, resp)
 }
 


### PR DESCRIPTION
Scheduled crons died 203/EXEC: buildCronServiceContent references /usr/local/libexec/jabali/cron-precheck but it was never created/installed. Add the helper + install in install.sh + update.go; regression test asserts every libexec path a unit references is shipped. Also persist last_run_at/exit on Run-now (was never written → 'Last Run: Never'). Scheduled-fire last_run polling tracked as follow-up.