### PR TITLE
fix(migrate/cpanel): sanitize migrated php.ini/.user.ini out-of-jail path directives

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -803,8 +803,8 @@ func cpanelRestoreCallback(
 			warnings = append(warnings, fmt.Sprintf("appconfigs: %v", err))
 		} else {
 			warnings = append(warnings, fmt.Sprintf(
-				"appconfigs: wordpress=%d joomla=%d drupal=%d magento=%d caches_cleared=%d",
-				appRes.WordPress, appRes.Joomla, appRes.Drupal, appRes.Magento, appRes.CachesCleared))
+				"appconfigs: wordpress=%d joomla=%d drupal=%d magento=%d caches_cleared=%d php_ini_fixed=%d",
+				appRes.WordPress, appRes.Joomla, appRes.Drupal, appRes.Magento, appRes.CachesCleared, appRes.PhpIniFixed))
 			warnings = append(warnings, appRes.Skipped...)
 		}
 

--- a/panel-api/internal/migrate/cpanel/restore_appconfigs.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs.go
@@ -40,6 +40,7 @@ type AppConfigsResult struct {
 	Drupal        int      // settings.php files rewritten
 	Magento       int      // app/etc/env.php files rewritten
 	CachesCleared int      // cache directories wiped (WP Rocket / LiteSpeed / W3TC / Joomla / Drupal etc.)
+	PhpIniFixed   int      // php.ini/.user.ini files whose out-of-jail path directives were neutralized
 	Skipped       []string // human-readable reasons (file unreadable, no match, etc.)
 }
 
@@ -103,6 +104,24 @@ func ImportAppConfigs(
 			res.Magento += n
 		} else if sk != "" {
 			res.Skipped = append(res.Skipped, sk)
+		}
+
+		// php.ini / .user.ini sanitization: a verbatim-copied cPanel ini
+		// often points session.save_path / open_basedir / *_tmp_dir /
+		// error_log / extension_dir at a path outside jabali's per-user
+		// open_basedir jail, which breaks every request under the pool.
+		// Neutralize only the out-of-jail path directives; preserve
+		// benign tunables (memory_limit, upload_max_filesize, …).
+		for _, ini := range []string{
+			filepath.Join(docroot, "php.ini"),
+			filepath.Join(docroot, ".user.ini"),
+		} {
+			n, sk := sanitizePhpIniFile(ctx, agentCli, targetUserID, targetUsername, ini, res)
+			if n > 0 {
+				res.PhpIniFixed += n
+			} else if sk != "" {
+				res.Skipped = append(res.Skipped, sk)
+			}
 		}
 
 		// Cache-plugin / framework-cache cleanup. cpanel-side
@@ -224,6 +243,49 @@ func rewriteOne(
 var (
 	wpDefineRe = regexp.MustCompile(`(?m)^\s*define\(\s*['"](DB_NAME|DB_USER|DB_PASSWORD|DB_HOST)['"]\s*,\s*['"]([^'"]*)['"]\s*\)\s*;`)
 )
+
+// sanitizePhpIniFile reads a migrated php.ini/.user.ini via the agent,
+// neutralizes path directives pointing outside the user's open_basedir
+// jail (sanitizePhpIni), and writes it back. Returns (1, "") on a real
+// rewrite, (0, "") when absent/clean, (0, note) on an error. The per-
+// directive changes are appended to res.Skipped as manifest notes.
+func sanitizePhpIniFile(ctx context.Context, agentCli agent.AgentInterface, targetUserID, targetUsername, path string, res *AppConfigsResult) (int, string) {
+	if _, err := os.Stat(path); err != nil {
+		return 0, ""
+	}
+	raw, err := agentCli.Call(ctx, "files.read", map[string]any{
+		"user_id":  targetUserID,
+		"username": targetUsername,
+		"path":     path,
+	})
+	if err != nil {
+		return 0, fmt.Sprintf("php_ini_read_skip:%s:%v", path, err)
+	}
+	var r struct {
+		Content  string `json:"content"`
+		IsBinary bool   `json:"is_binary"`
+	}
+	if jErr := json.Unmarshal(raw, &r); jErr != nil || r.IsBinary {
+		return 0, fmt.Sprintf("php_ini_decode_skip:%s", path)
+	}
+	updated, notes, changed := sanitizePhpIni(r.Content, targetUsername)
+	if !changed {
+		return 0, ""
+	}
+	if _, err := agentCli.Call(ctx, "files.write", map[string]any{
+		"user_id":  targetUserID,
+		"username": targetUsername,
+		"path":     path,
+		"content":  updated,
+		"mode":     "overwrite",
+	}); err != nil {
+		return 0, fmt.Sprintf("php_ini_write_skip:%s:%v", path, err)
+	}
+	for _, n := range notes {
+		res.Skipped = append(res.Skipped, fmt.Sprintf("php_ini_sanitized:%s: %s", path, n))
+	}
+	return 1, ""
+}
 
 func rewriteWordPress(text string, creds map[string]DBCredential) (string, bool) {
 	if !strings.Contains(text, "DB_NAME") {

--- a/panel-api/internal/migrate/cpanel/sanitize_php_ini.go
+++ b/panel-api/internal/migrate/cpanel/sanitize_php_ini.go
@@ -1,0 +1,100 @@
+package cpanel
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// phpIniPathDirectives are the PHP ini settings whose value is a
+// filesystem path. A migrated cPanel ini that points one of these
+// OUTSIDE the per-user FPM pool's open_basedir
+// (/home/<u>:/run/mysqld/mysqld.sock:/tmp:/var/tmp, ADR-0023) breaks
+// the site under jabali's jail — e.g.
+//   session.save_path = "/var/cpanel/php/sessions/ea-php83"
+// triggers an open_basedir PHP warning on every request and $_SESSION
+// silently stops persisting (logins/carts break).
+var phpIniPathDirectives = map[string]bool{
+	"session.save_path":   true,
+	"open_basedir":        true,
+	"error_log":           true,
+	"sys_temp_dir":        true,
+	"upload_tmp_dir":      true,
+	"extension_dir":       true,
+	"soap.wsdl_cache_dir": true,
+}
+
+var iniDirectiveRe = regexp.MustCompile(`^(\s*)([A-Za-z0-9_.]+)\s*=\s*(.*?)\s*$`)
+
+// pathInJail reports whether an absolute path lives inside the per-user
+// open_basedir jail for username.
+func pathInJail(p, username string) bool {
+	p = strings.Trim(p, `"' `)
+	home := "/home/" + username
+	switch {
+	case p == home, strings.HasPrefix(p, home+"/"):
+		return true
+	case p == "/tmp", strings.HasPrefix(p, "/tmp/"):
+		return true
+	case p == "/var/tmp", strings.HasPrefix(p, "/var/tmp/"):
+		return true
+	}
+	return false
+}
+
+// sanitizePhpIni neutralizes path-valued PHP directives in a migrated
+// php.ini / .user.ini that resolve outside the user's open_basedir
+// jail, preserving every benign tunable (memory_limit, upload_max_
+// filesize, …) verbatim. Returns the rewritten content + a per-change
+// note list for the manifest. changed=false ⇒ content untouched.
+//
+//   session.save_path outside jail → rewritten to /tmp (in jail, always
+//       present, session files are 0600 so cross-tenant read is blocked;
+//       matches jabali's own sso.php). Dropping it isn't safe — the
+//       system php.ini default (/var/lib/php/sessions) is also outside
+//       the jail.
+//   open_basedir → always dropped (the pool hard-codes it; a migrated
+//       value only conflicts).
+//   error_log / sys_temp_dir / upload_tmp_dir / extension_dir /
+//       soap.wsdl_cache_dir with an absolute path outside the jail →
+//       dropped (PHP falls back to an in-jail default).
+func sanitizePhpIni(content, username string) (string, []string, bool) {
+	lines := strings.Split(content, "\n")
+	var notes []string
+	for i, line := range lines {
+		m := iniDirectiveRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		indent, key, val := m[1], m[2], m[3]
+		kl := strings.ToLower(key)
+		if !phpIniPathDirectives[kl] {
+			continue
+		}
+		switch kl {
+		case "session.save_path":
+			v := strings.Trim(val, `"' `)
+			pathPart := v
+			if semi := strings.LastIndex(v, ";"); semi >= 0 {
+				pathPart = v[semi+1:] // "N;/path" depth form
+			}
+			if strings.HasPrefix(pathPart, "/") && !pathInJail(pathPart, username) {
+				lines[i] = indent + key + " = /tmp"
+				notes = append(notes, fmt.Sprintf("session.save_path %q → /tmp", v))
+			}
+		case "open_basedir":
+			lines[i] = indent + "; jabali-migration: removed open_basedir (pool-managed) ; was: " + val
+			notes = append(notes, "open_basedir removed (pool sets it)")
+		default:
+			v := strings.Trim(val, `"' `)
+			if strings.HasPrefix(v, "/") && !pathInJail(v, username) {
+				lines[i] = indent + "; jabali-migration: removed " + key + " (path outside open_basedir) ; was: " + val
+				notes = append(notes, fmt.Sprintf("%s removed (path %q outside open_basedir)", kl, v))
+			}
+		}
+	}
+	if len(notes) == 0 {
+		return content, nil, false
+	}
+	return strings.Join(lines, "\n"), notes, true
+}

--- a/panel-api/internal/migrate/cpanel/sanitize_php_ini_test.go
+++ b/panel-api/internal/migrate/cpanel/sanitize_php_ini_test.go
@@ -1,0 +1,63 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizePhpIni(t *testing.T) {
+	in := strings.Join([]string{
+		`session.save_path = "/var/cpanel/php/sessions/ea-php83"`,
+		`open_basedir = "/home/old:/usr/local/cpanel"`,
+		`error_log = /var/cpanel/logs/error_log`,
+		`upload_tmp_dir = /home/migdaleinav/tmp`, // already in jail → keep
+		`memory_limit = 256M`,                    // benign → keep verbatim
+		`max_execution_time = 120`,               // benign → keep
+		`error_log = syslog`,                     // not a path → keep
+		`extension_dir = "/opt/cpanel/ea-php83/root/usr/lib64/php/modules"`,
+	}, "\n")
+
+	out, notes, changed := sanitizePhpIni(in, "migdaleinav")
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	// session.save_path rewritten to /tmp
+	if !strings.Contains(out, "session.save_path = /tmp") {
+		t.Errorf("session.save_path not rewritten:\n%s", out)
+	}
+	// open_basedir dropped
+	if strings.Contains(out, "\nopen_basedir = ") || strings.Contains(out, "^open_basedir = ") {
+		t.Errorf("open_basedir not removed:\n%s", out)
+	}
+	if !strings.Contains(out, "jabali-migration: removed open_basedir") {
+		t.Errorf("open_basedir removal note missing:\n%s", out)
+	}
+	// cPanel error_log dropped, but error_log=syslog kept
+	if !strings.Contains(out, "removed error_log (path") {
+		t.Errorf("cPanel error_log not removed:\n%s", out)
+	}
+	if !strings.Contains(out, "error_log = syslog") {
+		t.Errorf("benign error_log=syslog was clobbered:\n%s", out)
+	}
+	// extension_dir at cPanel path dropped
+	if !strings.Contains(out, "removed extension_dir") {
+		t.Errorf("cPanel extension_dir not removed:\n%s", out)
+	}
+	// benign tunables preserved verbatim
+	for _, keep := range []string{"memory_limit = 256M", "max_execution_time = 120", "upload_tmp_dir = /home/migdaleinav/tmp"} {
+		if !strings.Contains(out, keep) {
+			t.Errorf("benign directive clobbered: %q\n%s", keep, out)
+		}
+	}
+	if len(notes) == 0 {
+		t.Error("expected manifest notes")
+	}
+}
+
+func TestSanitizePhpIni_NoOp(t *testing.T) {
+	in := "memory_limit = 512M\nupload_max_filesize = 64M\nsession.save_path = /home/u/sessions\n"
+	out, notes, changed := sanitizePhpIni(in, "u")
+	if changed || out != in || notes != nil {
+		t.Errorf("clean ini should be untouched; changed=%v notes=%v", changed, notes)
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -720,6 +720,7 @@ function parseRestoreManifest(raw: string): RestoreParsed {
       line.includes("already imported") ||
       line.includes("cron_disabled_import") ||
       line.includes("env_ignored") ||
+      line.includes("php_ini_sanitized") ||
       line.includes("_skipped:") ||
       line.startsWith("warning:") ||
       line.startsWith("skip:")


### PR DESCRIPTION
cPanel php.ini/.user.ini copied verbatim point session.save_path/open_basedir/etc outside jabali's per-user open_basedir → open_basedir PHP warnings, sessions don't persist (logins break). Add sanitizePhpIni over each docroot's php.ini + .user.ini (via agent, post-rsync): session.save_path→/tmp, open_basedir dropped, other out-of-jail path dirs commented; benign tunables preserved verbatim. Manifest-recorded + surfaced in warnings card.