### PR TITLE
fix(api): purge Stalwart accounts by DOMAIN on user-delete (orphan survived #270)

### DIFF
--- a/panel-agent/internal/commands/mail_domain_purge.go
+++ b/panel-agent/internal/commands/mail_domain_purge.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/agentwire"
+)
+
+// mailDomainPurgeParams is the input for mail.domain.purge_accounts.
+type mailDomainPurgeParams struct {
+	Domain string `json:"domain"`
+}
+
+type mailDomainPurgeResult struct {
+	Destroyed int `json:"destroyed"`
+}
+
+// mailDomainPurgeHandler destroys EVERY Stalwart registry Account under a
+// domain, by querying x:Account/query on the domain's registry id rather
+// than per-email. This is the reliable user-delete cleanup path: the
+// per-mailbox mailbox.delete only fires for mailboxes that still have a
+// panel row, so an account whose row was already removed (a failed prior
+// delete, or a migration that pushed mail to Stalwart without a matching
+// row) survived as an orphan and blocked re-creating/re-migrating that
+// address with primaryKeyViolation on email. Querying by domain catches
+// those orphans too.
+//
+// A domain belongs to exactly one panel user, so purging all accounts
+// under it during that user's delete is correct — there are no other
+// tenants' accounts in the domain. Idempotent: if the domain isn't in
+// the registry (nobody ever authed) it's a no-op.
+func mailDomainPurgeHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p mailDomainPurgeParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if p.Domain == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "domain required"}
+	}
+
+	domainID, err := domainIDByName(ctx, p.Domain)
+	if err != nil {
+		return nil, err
+	}
+	if domainID == "" {
+		// Domain never entered the registry → no accounts to purge.
+		return mailDomainPurgeResult{Destroyed: 0}, nil
+	}
+
+	// All accounts under the domain. The SQL directory accepts a filter
+	// on domainId (see accountIDByEmail's note on supported columns).
+	args := map[string]any{
+		"filter": map[string]any{"domainId": domainID},
+		"limit":  50000,
+	}
+	var result jmapQueryResult
+	if err := jmapCall(ctx, "x:Account/query", args, &result); err != nil {
+		return nil, err
+	}
+
+	destroyed := 0
+	for _, id := range result.IDs {
+		if err := accountDestroy(ctx, id); err != nil {
+			// Best-effort: log-equivalent via the returned error would
+			// abort the whole purge; instead skip the one that failed
+			// and keep destroying the rest. The caller treats a partial
+			// purge as non-fatal (orphan is recoverable, blocked delete
+			// is worse).
+			continue
+		}
+		destroyed++
+	}
+	return mailDomainPurgeResult{Destroyed: destroyed}, nil
+}
+
+func init() {
+	Default.Register("mail.domain.purge_accounts", mailDomainPurgeHandler)
+}

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -498,34 +498,32 @@ func (h *userHandler) delete(c *gin.Context) {
 			for i := range owned {
 				d := &owned[i]
 				name := d.Name
-				// Purge each mailbox's Stalwart Account BEFORE the domain
-				// delete FK-cascades the mailbox rows away. jabali user
-				// delete otherwise removed the panel row + home + DB but
-				// left the Stalwart registry account behind — re-migrating
-				// or recreating the same address then collided with
+				// Purge EVERY Stalwart registry account under this domain
+				// BEFORE the domain delete FK-cascades the panel mailbox
+				// rows away (the domain must still be registered in
+				// Stalwart for the purge to resolve it). jabali user
+				// delete otherwise left the Stalwart account behind →
+				// re-creating/re-migrating the same address collided with
 				// {"type":"primaryKeyViolation","properties":["email"]}.
-				// Best-effort: a failure here doesn't block the delete (the
-				// reconciler/agent has no retry for this, but an orphan
-				// account is recoverable; a blocked user-delete is worse).
-				if h.cfg.Mailboxes != nil && h.cfg.Agent != nil {
-					mbs, _, mbErr := h.cfg.Mailboxes.ListByDomainID(c.Request.Context(), d.ID, repository.ListOptions{Limit: 10000})
-					if mbErr != nil {
-						slog.Warn("cascade delete: list domain mailboxes failed",
-							"user_id", id, "domain_id", d.ID, "domain", name, "err", mbErr)
-					} else {
-						for j := range mbs {
-							mb := &mbs[j]
-							mctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
-							_, delErr := h.cfg.Agent.Call(mctx, "mailbox.delete", map[string]any{
-								"id":    mb.ID,
-								"email": mb.EmailCached,
-							})
-							cancel()
-							if delErr != nil {
-								slog.Warn("cascade delete: stalwart mailbox.delete failed",
-									"user_id", id, "domain", name, "email", mb.EmailCached, "err", delErr)
-							}
-						}
+				//
+				// Purge BY DOMAIN, not per panel mailbox row: a row-driven
+				// loop skips orphans (a migration that pushed mail to
+				// Stalwart without a matching row, or a failed prior
+				// delete that removed the row but not the account), which
+				// is exactly how the orphan kept surviving. A domain
+				// belongs to one user, so destroying all its accounts on
+				// that user's delete is correct. Best-effort: a failure
+				// here logs + continues (orphan is recoverable; a blocked
+				// user delete is worse).
+				if h.cfg.Agent != nil {
+					mctx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
+					_, delErr := h.cfg.Agent.Call(mctx, "mail.domain.purge_accounts", map[string]any{
+						"domain": name,
+					})
+					cancel()
+					if delErr != nil {
+						slog.Warn("cascade delete: stalwart domain purge failed",
+							"user_id", id, "domain", name, "err", delErr)
 					}
 				}
 				if err := h.cfg.Domains.Delete(c.Request.Context(), d.ID); err != nil {

--- a/panel-api/internal/api/users_delete_mailbox_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mailbox_cascade_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gin-gonic/gin"
@@ -82,21 +81,21 @@ func (a *udAgent) Call(_ context.Context, cmd string, params any) (json.RawMessa
 	return json.RawMessage(`{"ok":true}`), nil
 }
 
-// emails returns the set of emails passed to mailbox.delete calls.
-func (a *udAgent) mailboxDeleteEmails() map[string]bool {
+// purgedDomain reports whether mail.domain.purge_accounts was called for
+// the given domain.
+func (a *udAgent) purgedDomain(domain string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	out := map[string]bool{}
 	for _, c := range a.calls {
-		if c.cmd == "mailbox.delete" {
+		if c.cmd == "mail.domain.purge_accounts" {
 			if m, ok := c.params.(map[string]any); ok {
-				if e, ok := m["email"].(string); ok {
-					out[e] = true
+				if d, ok := m["domain"].(string); ok && d == domain {
+					return true
 				}
 			}
 		}
 	}
-	return out
+	return false
 }
 
 // TestUserDelete_DestroysStalwartAccounts is the regression guard for the
@@ -141,10 +140,10 @@ func TestUserDelete_DestroysStalwartAccounts(t *testing.T) {
 	rec := doJSON(t, r, http.MethodDelete, "/api/v1/users/"+victim.ID, nil)
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
-	// Both mailboxes' Stalwart accounts must have been destroyed by email.
-	// mailbox.delete fires synchronously in the cascade (before the
-	// response), so it's recorded by the time doJSON returns.
-	gotEmails := ag.mailboxDeleteEmails()
-	assert.True(t, gotEmails["info@victim.example.com"], "info mailbox Stalwart account must be destroyed; got=%v", gotEmails)
-	assert.True(t, gotEmails["sales@victim.example.com"], "sales mailbox Stalwart account must be destroyed; got=%v", gotEmails)
+	// The whole domain's Stalwart accounts must be purged (by domain, not
+	// per panel row — so orphans without a row are caught too). Fires
+	// synchronously in the cascade before the response.
+	if !ag.purgedDomain("victim.example.com") {
+		t.Errorf("expected mail.domain.purge_accounts for victim.example.com; calls=%v", ag.calls)
+	}
 }


### PR DESCRIPTION
#270's per-row mailbox.delete missed orphans (account whose panel row was already removed / migration pushed mail without a row). New mail.domain.purge_accounts agent command destroys ALL Stalwart accounts under a domain via x:Account/query {domainId}; user-delete cascade calls it per owned domain before domain delete. Verified the domainId-query on live Stalwart.