### PR TITLE
fix(cron): reconciler harvests scheduled-fire last_run_at from the user timer

### DIFF
--- a/panel-agent/internal/commands/cron_status.go
+++ b/panel-agent/internal/commands/cron_status.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.linux-hosting.co.il/shukivaknin/jabali2/agentwire"
+)
+
+// cronStatusParams is the input for cron.status.
+type cronStatusParams struct {
+	UserID   string `json:"user_id"`
+	Username string `json:"username"`
+	JobID    string `json:"job_id"`
+}
+
+// cronStatusResult reports the last completion of a user cron's systemd
+// service. HasRun is false when the unit has never executed, so the
+// panel keeps whatever it had.
+type cronStatusResult struct {
+	HasRun    bool   `json:"has_run"`
+	LastRunAt string `json:"last_run_at"` // RFC3339 UTC, empty when !HasRun
+	ExitCode  int    `json:"exit_code"`
+}
+
+// cronStatusHandler harvests the last-run result of a user cron's
+// systemd service so the panel can show "Last Run" for autonomous timer
+// fires (the timer runs the unit directly — nothing otherwise reports
+// the result back to the DB; only Run-now did).
+//
+// Property choice: a Type=oneshot service (which jabali crons are) with
+// RemainAfterExit=no CLEARS ExecMainExitTimestamp once it goes inactive,
+// but KEEPS ExecMainStartTimestamp (the last fire's start) and
+// ExecMainStatus (the last exit code) — verified on the box. So we read
+// ExecMainStartTimestamp for the run time.
+//
+// Connection: env-through-sudo (XDG_RUNTIME_DIR + DBUS_SESSION_BUS_
+// ADDRESS), the #268 path — NOT `--machine=<user>@.host`, which proxies
+// a LIMITED property set that returns EMPTY runtime timestamps (verified
+// on the box). bare `systemctl --user` also fails (sudo env_reset).
+func cronStatusHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p cronStatusParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if p.Username == "" || p.JobID == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username and job_id required"}
+	}
+
+	u, err := user.Lookup(p.Username)
+	if err != nil {
+		return cronStatusResult{HasRun: false}, nil
+	}
+	runtimeDir := fmt.Sprintf("/run/user/%s", u.Uid)
+	unit := fmt.Sprintf("jabali-cron-%s.service", p.JobID)
+
+	cmd := exec.CommandContext(ctx, "sudo", "-u", p.Username,
+		"env",
+		"XDG_RUNTIME_DIR="+runtimeDir,
+		"DBUS_SESSION_BUS_ADDRESS=unix:path="+runtimeDir+"/bus",
+		"systemctl", "--user", "show", unit,
+		"-p", "ExecMainStartTimestamp",
+		"-p", "ExecMainStatus",
+		"--no-pager")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// Unit not loaded / user manager down → best-effort no-op.
+		return cronStatusResult{HasRun: false}, nil
+	}
+
+	props := map[string]string{}
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if eq := strings.IndexByte(line, '='); eq > 0 {
+			props[line[:eq]] = strings.TrimSpace(line[eq+1:])
+		}
+	}
+
+	ts := props["ExecMainStartTimestamp"]
+	if ts == "" {
+		return cronStatusResult{HasRun: false}, nil
+	}
+	// systemd wall-clock format, e.g. "Sun 2026-06-08 02:35:59 UTC".
+	t, err := time.Parse("Mon 2006-01-02 15:04:05 MST", ts)
+	if err != nil {
+		return cronStatusResult{HasRun: false}, nil
+	}
+
+	exitCode := 0
+	if ec, err := strconv.Atoi(props["ExecMainStatus"]); err == nil {
+		exitCode = ec
+	}
+
+	return cronStatusResult{
+		HasRun:    true,
+		LastRunAt: t.UTC().Format(time.RFC3339),
+		ExitCode:  exitCode,
+	}, nil
+}
+
+func init() {
+	Default.Register("cron.status", cronStatusHandler)
+}

--- a/panel-api/internal/reconciler/cron_reconcile.go
+++ b/panel-api/internal/reconciler/cron_reconcile.go
@@ -72,6 +72,9 @@ func (r *Reconciler) reconcileCronJobs(ctx context.Context) {
 			}
 			applied++
 			delete(onDisk, job.ID)
+			// Harvest the last autonomous (timer) run so the panel's
+			// "Last Run" reflects scheduled fires, not just Run-now.
+			r.cronHarvestLastRun(ctx, userID, username, job)
 		}
 
 		for _, job := range userJobs {
@@ -147,6 +150,48 @@ func (r *Reconciler) cronListOnDisk(ctx context.Context, userID, username string
 		set[id] = struct{}{}
 	}
 	return set, nil
+}
+
+// cronHarvestLastRun polls the user cron's systemd service for its last
+// completion (cron.status) and writes last_run_at/last_exit_code back to
+// the DB — but ONLY when the systemd timestamp is newer than the stored
+// value, so a recent manual Run-now (#275) isn't clobbered by an older
+// scheduled-fire poll (and vice-versa). Best-effort: any failure is
+// logged at Debug and the pass continues (display-only).
+func (r *Reconciler) cronHarvestLastRun(ctx context.Context, userID, username string, job *models.CronJob) {
+	if r.cronJobs == nil {
+		return
+	}
+	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	raw, err := r.agent.Call(agentCtx, "cron.status", map[string]any{
+		"user_id":  userID,
+		"username": username,
+		"job_id":   job.ID,
+	})
+	if err != nil {
+		r.log.Debug("reconcile: cron.status failed", "job_id", job.ID, "err", err)
+		return
+	}
+	var st struct {
+		HasRun    bool   `json:"has_run"`
+		LastRunAt string `json:"last_run_at"`
+		ExitCode  int    `json:"exit_code"`
+	}
+	if jErr := json.Unmarshal(raw, &st); jErr != nil || !st.HasRun {
+		return
+	}
+	t, pErr := time.Parse(time.RFC3339, st.LastRunAt)
+	if pErr != nil {
+		return
+	}
+	// Don't clobber a newer stored value (e.g. a Run-now that just landed).
+	if job.LastRunAt != nil && !t.After(*job.LastRunAt) {
+		return
+	}
+	if uErr := r.cronJobs.UpdateStatus(ctx, job.ID, t.UTC(), st.ExitCode, ""); uErr != nil {
+		r.log.Debug("reconcile: cron.status write-back failed", "job_id", job.ID, "err", uErr)
+	}
 }
 
 func (r *Reconciler) cronApplyOne(ctx context.Context, userID, username string, job *models.CronJob, docroots []string) error {


### PR DESCRIPTION
last_run_at was written only by Run-now (#275); autonomous timer fires never reported back → UI 'Last Run' stale/Never while the cron ran fine. New cron.status agent command reads the service's last completion; cron reconcile writes back last_run_at+last_exit_code (max, won't clobber a newer Run-now). Findings: oneshot keeps ExecMainStartTimestamp not ExecMainExitTimestamp; --machine returns empty timestamps so use the env-sudo path. Display-only.