### PR TITLE
fix(settings): duplicate 'Settings saved' toast on save (#273)

### DIFF
--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -453,7 +453,6 @@ const GeneralSettingsTab = () => {
           type="primary"
           icon={<SaveOutlined />}
           loading={saving}
-          htmlType="submit"
           onClick={() => {
             const currentSSHPort = form.getFieldValue("ssh_port") || 22;
             const currentSSHPasswordAuth =


### PR DESCRIPTION
## Bug (#273)
Saving Server Settings shows **two** stacked `Settings saved` toasts.

## Cause
The main **Save Settings** button had both `htmlType="submit"` **and** an `onClick` that calls `form.submit()`. A single click triggered the form's `onFinish` **twice** (native submit + the onClick's `form.submit()`), so the save ran twice → two toasts. The native submit also fired immediately, **bypassing the SSH-change confirmation modal**.

## Fix
Remove `htmlType="submit"`. The `onClick` is the intended path — it shows the SSH confirm when ports/auth changed, then calls `form.submit()`. One submit, one toast, and the SSH guard is restored. The other two Save buttons on the page are submit-only and were unaffected.

## Verified
- `tsc -b` clean.
- One-line change (removed an optional prop).

Closes #273