### PR TITLE
fix(update): chown the whole repo tree before reset --hard, not just .git

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -266,33 +266,23 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		fn   func() error
 	}{
 		{"fix repo ownership", func() error {
-			// `git pull` runs as the jabali user, but a previous hand-run
-			// of `git fetch`/`git pull` as root inside the repo silently
-			// chowns FETCH_HEAD/ORIG_HEAD/objects/* to root — and the
-			// next `jabali update` then dies with "cannot open
-			// '.git/FETCH_HEAD': Permission denied". Re-chown the .git
-			// dir before pulling so the update self-heals instead of
-			// requiring the operator to know the magic chown command.
+			// `git reset --hard` runs as the jabali user, but root-owned
+			// paths anywhere in the tree make it fail. This happens when a
+			// previous git op ran as root (e.g. a hand-run `git fetch`/`pull`
+			// chowning .git/FETCH_HEAD|objects to root), when `npx playwright
+			// test` ran as root and dropped root-owned files under
+			// panel-ui/test-results|playwright-report, or when a root
+			// checkout of a branch added a new top-level dir owned by root —
+			// most recently "cannot create directory at
+			// 'wp-plugins/jabali-cache': Permission denied" (exit 128).
 			//
-			// Also chown panel-ui/test-results/ + playwright-report/
-			// since `npx playwright test` run as root drops files
-			// there which then block sudo-as-jabali `git reset --hard`
-			// with "unable to unlink: Permission denied". Both dirs
-			// are .gitignore'd; chown is purely to let `git reset`
-			// remove any leftovers from a previous Playwright run.
+			// Chown the WHOLE repo tree (not just .git) so the update
+			// self-heals any such ownership drift instead of requiring the
+			// operator to know the magic chown command.
 			if err := run("", "chown", "-R",
-				serviceUser+":"+serviceUser, repoDir+"/.git"); err != nil {
+				serviceUser+":"+serviceUser, repoDir); err != nil {
 				return err
 			}
-			// Ignore failures on the panel-ui dirs — they may not
-			// exist yet on a fresh install, and missing dirs are not
-			// a deployment-blocking condition.
-			_ = run("", "bash", "-c",
-				"shopt -s nullglob; "+
-					"chown -R "+serviceUser+":"+serviceUser+" "+
-					repoDir+"/panel-ui/test-results "+
-					repoDir+"/panel-ui/playwright-report 2>/dev/null; "+
-					"true")
 			return nil
 		}},
 		{"ensure mail ACME webroot (/var/www/jabali-acme)", func() error {


### PR DESCRIPTION
## Bug

The in-panel self-update fails with exit code 1 / git exit 128:

```
fatal: cannot create directory at 'wp-plugins/jabali-cache': Permission denied
git reset --hard origin/main: exit status 128
```

## Cause

The update's "fix repo ownership" pre-step chowned only `.git` (plus the
playwright dirs) to the service user before the jabali-run
`git reset --hard origin/main`. Any **other** root-owned path in the tree still
blocked the reset. Here `wp-plugins/` was root-owned (from a prior root git op /
root checkout), so the jabali-run reset couldn't create the new
`wp-plugins/jabali-cache/` directory → "Permission denied", exit 128.

## Fix

Chown the **whole repo tree** (not just `.git`) to the service user before the
reset, so the update self-heals any ownership drift — `.git`, the playwright
dirs, `wp-plugins/`, `node_modules`, etc. — instead of requiring the operator to
run the magic `chown -R jabali:jabali /opt/jabali-panel` by hand.

## Verified

- `go build ./cmd/server` clean.
- One-call change (broaden the existing chown target; the now-redundant
  playwright-dirs chown is folded in since the full-tree chown covers it).
