### PR TITLE
feat(cli): add `jabali dns` zone/record management (JAB-119)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1349,6 +1349,98 @@ Show a tenant's last stored disk-usage snapshot
 jabali disk-usage show <user-email|username|id>
 ```
 
+### `jabali dns`
+
+DNS zones and records (dns_zones / dns_records): list / add / update / delete
+
+```
+jabali dns
+```
+
+#### `jabali dns record`
+
+DNS records: list / add / update / delete
+
+```
+jabali dns record
+```
+
+##### `jabali dns record add`
+
+Add a record to a zone (same validation + conflict rules as the UI)
+
+```
+jabali dns record add <domain> --name <name> --type <TYPE> --content <content> [flags]
+```
+
+**Flags:**
+
+- `--content` — record content (e.g. an IP, hostname, or TXT value)
+- `--disabled` — create the record disabled (kept in DB, not served)
+- `--name` — record name ('@' for apex)
+- `--priority` — priority (MX/SRV) (default `0`)
+- `--ttl` — TTL seconds (60-604800; 0 uses default 300) (default `0`)
+- `--type` — record type: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA
+
+##### `jabali dns record delete`
+
+Delete a record from a zone
+
+```
+jabali dns record delete <domain> <record-id> [flags]
+```
+
+**Flags:**
+
+- `--force` — confirm deletion
+
+##### `jabali dns record list`
+
+List records in a zone
+
+```
+jabali dns record list <domain>
+```
+
+##### `jabali dns record update`
+
+Update a record's content / ttl / priority / enabled flag
+
+```
+jabali dns record update <domain> <record-id> [flags]
+```
+
+**Flags:**
+
+- `--content` — new content
+- `--enabled` — set enabled flag (default `true`)
+- `--priority` — new priority (MX/SRV) (default `0`)
+- `--ttl` — new TTL seconds (60-604800) (default `0`)
+
+#### `jabali dns zone`
+
+DNS zones: list / show
+
+```
+jabali dns zone
+```
+
+##### `jabali dns zone list`
+
+List all DNS zones
+
+```
+jabali dns zone list
+```
+
+##### `jabali dns zone show`
+
+Show a zone and its records
+
+```
+jabali dns zone show <domain>
+```
+
 ### `jabali docker`
 
 Manage the docker engine + app-marketplace host (M48/M49)

--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -1,0 +1,398 @@
+// Operator DNS CLI (JAB-119). Zone/record management was GUI + REST only
+// (panel-api/internal/api/dns.go); a headless operator on a fresh host or in a
+// script had no way to list a zone or add/fix a record without the browser.
+// This mirrors those handlers over the same repositories and the same
+// validation/conflict rules (api.ValidateDNSRecord / api.CheckDNSRecordConflict),
+// so a record added here is byte-for-byte what the UI would have written.
+//
+// The DB is the source of truth. This command does NOT push into PowerDNS
+// itself — it writes the row and the running reconciler converges the zone on
+// its next tick (same as the UI when its in-process Schedule() nudge is
+// missed; see cli_ops.go setDomainEnabledDirect). Mutations are CLI-audited.
+//
+// The mutation logic lives in repo-injected helpers (dnsRecordAdd/Update/Delete)
+// so it is unit-testable with fakes; the cobra RunE wrappers only wire sharedDB
+// repos, flags, and output.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func dnsZoneRepoFromDB() repository.DNSZoneRepository {
+	return repository.NewDNSZoneRepository(sharedDB)
+}
+
+func dnsRecordRepoFromDB() repository.DNSRecordRepository {
+	return repository.NewDNSRecordRepository(sharedDB)
+}
+
+// dnsResolveZone finds the zone whose apex equals the given domain name.
+// Zone.Name is denormalised from domains.name at provisioning time, so a
+// zone only exists once the reconciler has provisioned the domain.
+func dnsResolveZone(ctx context.Context, zones repository.DNSZoneRepository, domain string) (*models.DNSZone, error) {
+	z, err := zones.FindByName(ctx, domain)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, fmt.Errorf("no DNS zone for %q — the domain may not be provisioned yet (the reconciler creates the zone on its next sync)", domain)
+		}
+		return nil, err
+	}
+	return z, nil
+}
+
+// dnsRecordSpec is the mutable field set a record add/update accepts.
+type dnsRecordSpec struct {
+	Name     string
+	Type     string
+	Content  string
+	TTL      int
+	Priority int
+	Enabled  bool
+}
+
+// dnsRecordAdd validates + conflict-checks + persists a new record in the zone
+// for domain. Returns the created record. Pure of cobra/flags for testability.
+func dnsRecordAdd(ctx context.Context, zones repository.DNSZoneRepository, recs repository.DNSRecordRepository, domain string, spec dnsRecordSpec) (*models.DNSRecord, error) {
+	zone, err := dnsResolveZone(ctx, zones, domain)
+	if err != nil {
+		return nil, err
+	}
+	rec := &models.DNSRecord{
+		ID:        ids.NewULID(),
+		ZoneID:    zone.ID,
+		Name:      spec.Name,
+		Type:      spec.Type,
+		Content:   spec.Content,
+		TTL:       spec.TTL,
+		Priority:  spec.Priority,
+		Managed:   false,
+		IsEnabled: spec.Enabled,
+	}
+	// ValidateDNSRecord trims/upper-cases and defaults TTL 0 -> 300.
+	if err := api.ValidateDNSRecord(rec); err != nil {
+		return nil, err
+	}
+	if err := api.CheckDNSRecordConflict(ctx, recs, zone.ID, rec, ""); err != nil {
+		return nil, err
+	}
+	if err := recs.Create(ctx, rec); err != nil {
+		return nil, fmt.Errorf("create record: %w", err)
+	}
+	return rec, nil
+}
+
+// dnsLoadRecordInZone fetches a record and asserts it belongs to domain's zone
+// and is not panel-managed (managed rows are owned by a feature, not hand-edits).
+func dnsLoadRecordInZone(ctx context.Context, zones repository.DNSZoneRepository, recs repository.DNSRecordRepository, domain, recordID string) (*models.DNSRecord, error) {
+	zone, err := dnsResolveZone(ctx, zones, domain)
+	if err != nil {
+		return nil, err
+	}
+	rec, err := recs.FindByID(ctx, recordID)
+	if err != nil {
+		return nil, fmt.Errorf("record not found: %w", err)
+	}
+	if rec.ZoneID != zone.ID {
+		return nil, fmt.Errorf("record %s does not belong to zone %s", recordID, zone.Name)
+	}
+	if rec.Managed {
+		return nil, fmt.Errorf("record %s is managed by the panel (%s); edit the owning feature instead of the raw record",
+			rec.ID, managedByLabel(rec.ManagedBy))
+	}
+	return rec, nil
+}
+
+// dnsRecordUpdate mutates only the fields flagged in `set` (content/ttl/priority/
+// enabled), re-validates, conflict-checks (excluding self), and persists.
+func dnsRecordUpdate(ctx context.Context, zones repository.DNSZoneRepository, recs repository.DNSRecordRepository, domain, recordID string, spec dnsRecordSpec, set map[string]bool) (*models.DNSRecord, error) {
+	rec, err := dnsLoadRecordInZone(ctx, zones, recs, domain, recordID)
+	if err != nil {
+		return nil, err
+	}
+	if set["content"] {
+		rec.Content = spec.Content
+	}
+	if set["ttl"] {
+		rec.TTL = spec.TTL
+	}
+	if set["priority"] {
+		rec.Priority = spec.Priority
+	}
+	if set["enabled"] {
+		rec.IsEnabled = spec.Enabled
+	}
+	if err := api.ValidateDNSRecord(rec); err != nil {
+		return nil, err
+	}
+	if err := api.CheckDNSRecordConflict(ctx, recs, rec.ZoneID, rec, rec.ID); err != nil {
+		return nil, err
+	}
+	if err := recs.Update(ctx, rec); err != nil {
+		return nil, fmt.Errorf("update record: %w", err)
+	}
+	return rec, nil
+}
+
+// dnsRecordDelete removes a non-managed record from domain's zone.
+func dnsRecordDelete(ctx context.Context, zones repository.DNSZoneRepository, recs repository.DNSRecordRepository, domain, recordID string) (*models.DNSRecord, error) {
+	rec, err := dnsLoadRecordInZone(ctx, zones, recs, domain, recordID)
+	if err != nil {
+		return nil, err
+	}
+	if err := recs.Delete(ctx, rec.ID); err != nil {
+		return nil, fmt.Errorf("delete record: %w", err)
+	}
+	return rec, nil
+}
+
+func managedByLabel(m *string) string {
+	if m == nil {
+		return "unknown"
+	}
+	return *m
+}
+
+// ---------- cobra wiring ----------
+
+func newDNSCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dns",
+		Short: "DNS zones and records (dns_zones / dns_records): list / add / update / delete",
+		Long: "Operator-facing DNS management, mirroring the admin GUI + REST API over the same\n" +
+			"validation and conflict rules. Records are written to the DB; the reconciler pushes\n" +
+			"them into PowerDNS on its next tick.",
+	}
+	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd())
+	return cmd
+}
+
+func newDNSZoneCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "zone", Short: "DNS zones: list / show"}
+	cmd.AddCommand(newDNSZoneListCmd(), newDNSZoneShowCmd())
+	return cmd
+}
+
+func newDNSZoneListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List all DNS zones",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			zones, err := dnsZoneRepoFromDB().ListAll(ctx)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return printJSON(zones)
+			}
+			tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(tw, "NAME\tSERIAL\tENABLED\tID")
+			for _, z := range zones {
+				fmt.Fprintf(tw, "%s\t%d\t%v\t%s\n", z.Name, z.Serial, z.IsEnabled, z.ID)
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func newDNSZoneShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "show <domain>",
+		Short:   "Show a zone and its records",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			zone, err := dnsResolveZone(ctx, dnsZoneRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			recs, err := dnsRecordRepoFromDB().ListByZoneID(ctx, zone.ID)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return printJSON(map[string]any{"zone": zone, "records": recs})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Zone %s  serial=%d  enabled=%v  id=%s\n",
+				zone.Name, zone.Serial, zone.IsEnabled, zone.ID)
+			printDNSRecords(recs)
+			return nil
+		},
+	}
+}
+
+func newDNSRecordCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "record", Short: "DNS records: list / add / update / delete"}
+	cmd.AddCommand(newDNSRecordListCmd(), newDNSRecordAddCmd(), newDNSRecordUpdateCmd(), newDNSRecordDeleteCmd())
+	return cmd
+}
+
+func printDNSRecords(recs []models.DNSRecord) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tCONTENT\tTTL\tPRIO\tENABLED\tMANAGED")
+	for _, r := range recs {
+		managed := ""
+		if r.Managed {
+			managed = "managed"
+			if r.ManagedBy != nil {
+				managed += "(" + *r.ManagedBy + ")"
+			}
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%d\t%v\t%s\n",
+			r.ID, r.Name, r.Type, r.Content, r.TTL, r.Priority, r.IsEnabled, managed)
+	}
+	_ = tw.Flush()
+}
+
+func newDNSRecordListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list <domain>",
+		Short:   "List records in a zone",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			zone, err := dnsResolveZone(ctx, dnsZoneRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			recs, err := dnsRecordRepoFromDB().ListByZoneID(ctx, zone.ID)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return printJSON(recs)
+			}
+			printDNSRecords(recs)
+			return nil
+		},
+	}
+}
+
+func newDNSRecordAddCmd() *cobra.Command {
+	var (
+		name, rtype, content string
+		ttl, priority        int
+		disabled             bool
+	)
+	cmd := &cobra.Command{
+		Use:     "add <domain> --name <name> --type <TYPE> --content <content>",
+		Short:   "Add a record to a zone (same validation + conflict rules as the UI)",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			rec, err := dnsRecordAdd(ctx, dnsZoneRepoFromDB(), dnsRecordRepoFromDB(), args[0], dnsRecordSpec{
+				Name: name, Type: rtype, Content: content, TTL: ttl, Priority: priority, Enabled: !disabled,
+			})
+			if err != nil {
+				return err
+			}
+			cliAuditOK(ctx, "dns.record.add", "dns_record", rec.ID, nil)
+			if jsonOutput {
+				return printJSON(rec)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"Added %s %s -> %s (ttl=%d) id=%s. The reconciler pushes it into PowerDNS on its next tick.\n",
+				rec.Type, rec.Name, rec.Content, rec.TTL, rec.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "record name ('@' for apex)")
+	cmd.Flags().StringVar(&rtype, "type", "", "record type: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA")
+	cmd.Flags().StringVar(&content, "content", "", "record content (e.g. an IP, hostname, or TXT value)")
+	cmd.Flags().IntVar(&ttl, "ttl", 0, "TTL seconds (60-604800; 0 uses default 300)")
+	cmd.Flags().IntVar(&priority, "priority", 0, "priority (MX/SRV)")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "create the record disabled (kept in DB, not served)")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("content")
+	return cmd
+}
+
+func newDNSRecordUpdateCmd() *cobra.Command {
+	var (
+		content       string
+		ttl, priority int
+		enable        bool
+	)
+	cmd := &cobra.Command{
+		Use:     "update <domain> <record-id>",
+		Short:   "Update a record's content / ttl / priority / enabled flag",
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			set := map[string]bool{
+				"content":  cmd.Flags().Changed("content"),
+				"ttl":      cmd.Flags().Changed("ttl"),
+				"priority": cmd.Flags().Changed("priority"),
+				"enabled":  cmd.Flags().Changed("enabled"),
+			}
+			rec, err := dnsRecordUpdate(ctx, dnsZoneRepoFromDB(), dnsRecordRepoFromDB(), args[0], args[1],
+				dnsRecordSpec{Content: content, TTL: ttl, Priority: priority, Enabled: enable}, set)
+			if err != nil {
+				return err
+			}
+			cliAuditOK(ctx, "dns.record.update", "dns_record", rec.ID, nil)
+			if jsonOutput {
+				return printJSON(rec)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Updated record %s. The reconciler re-pushes the zone on its next tick.\n", rec.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&content, "content", "", "new content")
+	cmd.Flags().IntVar(&ttl, "ttl", 0, "new TTL seconds (60-604800)")
+	cmd.Flags().IntVar(&priority, "priority", 0, "new priority (MX/SRV)")
+	cmd.Flags().BoolVar(&enable, "enabled", true, "set enabled flag")
+	return cmd
+}
+
+func newDNSRecordDeleteCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:     "delete <domain> <record-id>",
+		Short:   "Delete a record from a zone",
+		Args:    cobra.ExactArgs(2),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !force {
+				return fmt.Errorf("re-run with --force to delete record %s", args[1])
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			rec, err := dnsRecordDelete(ctx, dnsZoneRepoFromDB(), dnsRecordRepoFromDB(), args[0], args[1])
+			if err != nil {
+				return err
+			}
+			cliAuditOK(ctx, "dns.record.delete", "dns_record", rec.ID, nil)
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s %s (%s). The reconciler re-pushes the zone on its next tick.\n",
+				rec.Type, rec.Name, rec.ID)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "confirm deletion")
+	return cmd
+}

--- a/panel-api/cmd/server/dns_cmd_test.go
+++ b/panel-api/cmd/server/dns_cmd_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ---------- fakes ----------
+
+type memDNSZoneRepo struct{ byName map[string]*models.DNSZone }
+
+func newMemDNSZoneRepo(zs ...*models.DNSZone) *memDNSZoneRepo {
+	f := &memDNSZoneRepo{byName: map[string]*models.DNSZone{}}
+	for _, z := range zs {
+		f.byName[z.Name] = z
+	}
+	return f
+}
+
+func (f *memDNSZoneRepo) FindByName(_ context.Context, name string) (*models.DNSZone, error) {
+	if z, ok := f.byName[name]; ok {
+		return z, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (f *memDNSZoneRepo) Create(context.Context, *models.DNSZone) error          { return nil }
+func (f *memDNSZoneRepo) Update(context.Context, *models.DNSZone) error          { return nil }
+func (f *memDNSZoneRepo) Delete(context.Context, string) error                   { return nil }
+func (f *memDNSZoneRepo) FindByID(context.Context, string) (*models.DNSZone, error) {
+	return nil, repository.ErrNotFound
+}
+func (f *memDNSZoneRepo) FindByDomainID(context.Context, string) (*models.DNSZone, error) {
+	return nil, repository.ErrNotFound
+}
+func (f *memDNSZoneRepo) ListAll(context.Context) ([]models.DNSZone, error) { return nil, nil }
+
+type memDNSRecordRepo struct{ byID map[string]*models.DNSRecord }
+
+func newMemDNSRecordRepo(rs ...*models.DNSRecord) *memDNSRecordRepo {
+	f := &memDNSRecordRepo{byID: map[string]*models.DNSRecord{}}
+	for _, r := range rs {
+		f.byID[r.ID] = r
+	}
+	return f
+}
+
+func (f *memDNSRecordRepo) Create(_ context.Context, r *models.DNSRecord) error {
+	cp := *r
+	f.byID[r.ID] = &cp
+	return nil
+}
+func (f *memDNSRecordRepo) Update(_ context.Context, r *models.DNSRecord) error {
+	cp := *r
+	f.byID[r.ID] = &cp
+	return nil
+}
+func (f *memDNSRecordRepo) Delete(_ context.Context, id string) error {
+	delete(f.byID, id)
+	return nil
+}
+func (f *memDNSRecordRepo) FindByID(_ context.Context, id string) (*models.DNSRecord, error) {
+	if r, ok := f.byID[id]; ok {
+		cp := *r
+		return &cp, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (f *memDNSRecordRepo) ListByZoneID(_ context.Context, zoneID string) ([]models.DNSRecord, error) {
+	var out []models.DNSRecord
+	for _, r := range f.byID {
+		if r.ZoneID == zoneID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+func (f *memDNSRecordRepo) DeleteByZoneID(context.Context, string) error            { return nil }
+func (f *memDNSRecordRepo) DeleteByZoneIDAndManagedBy(context.Context, string, string) error {
+	return nil
+}
+
+// ensure the fakes satisfy the interfaces
+var (
+	_ repository.DNSZoneRepository   = (*memDNSZoneRepo)(nil)
+	_ repository.DNSRecordRepository = (*memDNSRecordRepo)(nil)
+)
+
+func testDNSZone() *models.DNSZone {
+	return &models.DNSZone{ID: "01ZONEEXAMPLECOM0000000000", DomainID: "01DOMEXAMPLE00000000000000", Name: "example.com", IsEnabled: true}
+}
+
+// ---------- tests ----------
+
+func TestDNSRecordAdd_ValidDefaultsTTL(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+	rec, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{
+		Name: "www", Type: "a", Content: "203.0.113.10", Enabled: true, // ttl 0 -> validator defaults 300
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if rec.Type != "A" {
+		t.Errorf("type not upper-cased: %q", rec.Type)
+	}
+	if rec.TTL != 300 {
+		t.Errorf("ttl default = %d, want 300", rec.TTL)
+	}
+	if rec.ZoneID != testDNSZone().ID {
+		t.Errorf("record not bound to the zone: %q", rec.ZoneID)
+	}
+	if _, ok := recs.byID[rec.ID]; !ok {
+		t.Errorf("record not persisted")
+	}
+}
+
+func TestDNSRecordAdd_RejectsUnknownZone(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo() // empty
+	recs := newMemDNSRecordRepo()
+	_, err := dnsRecordAdd(ctx, zones, recs, "nope.example", dnsRecordSpec{Name: "@", Type: "A", Content: "203.0.113.1", Enabled: true})
+	if err == nil || !strings.Contains(err.Error(), "no DNS zone") {
+		t.Fatalf("want no-zone error, got %v", err)
+	}
+}
+
+func TestDNSRecordAdd_RejectsInvalidType(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+	if _, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{Name: "@", Type: "WKS", Content: "x", Enabled: true}); err == nil {
+		t.Fatal("expected invalid-type rejection")
+	}
+	if len(recs.byID) != 0 {
+		t.Errorf("invalid record was persisted")
+	}
+}
+
+func TestDNSRecordAdd_RejectsInvalidContent(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+	// A record with a non-IPv4 content must be rejected by ValidateDNSRecord.
+	if _, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{Name: "@", Type: "A", Content: "not-an-ip", Enabled: true}); err == nil {
+		t.Fatal("expected invalid A content rejection")
+	}
+}
+
+func TestDNSRecordAdd_CNAMEConflict(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	zones := newMemDNSZoneRepo(z)
+	// existing A at "www"
+	recs := newMemDNSRecordRepo(&models.DNSRecord{ID: "01EXISTINGARECORD000000000", ZoneID: z.ID, Name: "www", Type: "A", Content: "203.0.113.9", TTL: 300, IsEnabled: true})
+	// adding a CNAME at the same name must be rejected (RFC 1034 §3.6.2)
+	if _, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{Name: "www", Type: "CNAME", Content: "target.example.com", Enabled: true}); err == nil {
+		t.Fatal("expected CNAME-exclusivity conflict")
+	}
+}
+
+func TestDNSRecordDelete_ForceRemovesNonManaged(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	zones := newMemDNSZoneRepo(z)
+	rec := &models.DNSRecord{ID: "01RECTODELETE0000000000000", ZoneID: z.ID, Name: "old", Type: "A", Content: "203.0.113.5", TTL: 300, IsEnabled: true}
+	recs := newMemDNSRecordRepo(rec)
+	if _, err := dnsRecordDelete(ctx, zones, recs, "example.com", rec.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, ok := recs.byID[rec.ID]; ok {
+		t.Errorf("record not deleted")
+	}
+}
+
+func TestDNSRecordDelete_RefusesManaged(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	zones := newMemDNSZoneRepo(z)
+	mb := "m6"
+	rec := &models.DNSRecord{ID: "01MANAGEDREC00000000000000", ZoneID: z.ID, Name: "_autodiscover._tcp", Type: "SRV", Content: "0 0 443 mail.example.com", TTL: 300, Managed: true, ManagedBy: &mb, IsEnabled: true}
+	recs := newMemDNSRecordRepo(rec)
+	_, err := dnsRecordDelete(ctx, zones, recs, "example.com", rec.ID)
+	if err == nil || !strings.Contains(err.Error(), "managed") {
+		t.Fatalf("want managed-record refusal, got %v", err)
+	}
+	if _, ok := recs.byID[rec.ID]; !ok {
+		t.Errorf("managed record was deleted despite refusal")
+	}
+}
+
+func TestDNSRecordUpdate_RejectsCrossZone(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	zones := newMemDNSZoneRepo(z)
+	// record belongs to a different zone id
+	rec := &models.DNSRecord{ID: "01OTHERZONEREC000000000000", ZoneID: "01OTHERZONE0000000000000000", Name: "x", Type: "A", Content: "203.0.113.7", TTL: 300, IsEnabled: true}
+	recs := newMemDNSRecordRepo(rec)
+	_, err := dnsRecordUpdate(ctx, zones, recs, "example.com", rec.ID, dnsRecordSpec{Content: "203.0.113.8"}, map[string]bool{"content": true})
+	if err == nil || !strings.Contains(err.Error(), "does not belong") {
+		t.Fatalf("want cross-zone refusal, got %v", err)
+	}
+}
+
+func TestDNSRecordUpdate_ContentOnly(t *testing.T) {
+	ctx := context.Background()
+	z := testDNSZone()
+	zones := newMemDNSZoneRepo(z)
+	rec := &models.DNSRecord{ID: "01UPDREC000000000000000000", ZoneID: z.ID, Name: "@", Type: "A", Content: "203.0.113.1", TTL: 300, IsEnabled: true}
+	recs := newMemDNSRecordRepo(rec)
+	out, err := dnsRecordUpdate(ctx, zones, recs, "example.com", rec.ID, dnsRecordSpec{Content: "203.0.113.2"}, map[string]bool{"content": true})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if out.Content != "203.0.113.2" {
+		t.Errorf("content not updated: %q", out.Content)
+	}
+	if recs.byID[rec.ID].Content != "203.0.113.2" {
+		t.Errorf("update not persisted")
+	}
+}
+
+// The dns command tree is well-formed: zone{list,show} + record{list,add,update,delete},
+// and `record add` marks name/type/content required.
+func TestDNSCmd_Tree(t *testing.T) {
+	root := newDNSCmd()
+	sub := map[string]*cobra.Command{}
+	for _, c := range root.Commands() {
+		sub[strings.Fields(c.Use)[0]] = c
+	}
+	for _, want := range []string{"zone", "record"} {
+		if sub[want] == nil {
+			t.Fatalf("dns missing subcommand %q", want)
+		}
+	}
+	recNames := map[string]bool{}
+	for _, c := range sub["record"].Commands() {
+		recNames[strings.Fields(c.Use)[0]] = true
+	}
+	for _, want := range []string{"list", "add", "update", "delete"} {
+		if !recNames[want] {
+			t.Errorf("dns record missing %q", want)
+		}
+	}
+}

--- a/panel-api/cmd/server/root.go
+++ b/panel-api/cmd/server/root.go
@@ -113,6 +113,7 @@ func newRootCmd() *cobra.Command {
 		newMailboxCmd(),
 		newSharedResourceCmd(),
 		newPdnsCmd(),
+		newDNSCmd(),
 		newPanelPrimaryCmd(),
 		newNspawnCmd(),
 		adminCmd,

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -379,7 +379,7 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 	}
 
 	// Validate record
-	if err := validateDNSRecord(record); err != nil {
+	if err := ValidateDNSRecord(record); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":  "invalid_record",
 			"detail": err.Error(),
@@ -388,7 +388,7 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 	}
 
 	// Conflict check: CNAME exclusivity + exact-duplicate rejection.
-	if err := checkDNSRecordConflict(c.Request.Context(), h.cfg.Records, zone.ID, record, ""); err != nil {
+	if err := CheckDNSRecordConflict(c.Request.Context(), h.cfg.Records, zone.ID, record, ""); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "record_conflict", "detail": err.Error()})
 		return
 	}
@@ -523,7 +523,7 @@ func (h *dnsHandler) updateRecord(c *gin.Context) {
 	}
 
 	// Validate updated record
-	if err := validateDNSRecord(record); err != nil {
+	if err := ValidateDNSRecord(record); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":  "invalid_record",
 			"detail": err.Error(),
@@ -532,7 +532,7 @@ func (h *dnsHandler) updateRecord(c *gin.Context) {
 	}
 
 	// Conflict check (skip self via excludeID).
-	if err := checkDNSRecordConflict(c.Request.Context(), h.cfg.Records, record.ZoneID, record, record.ID); err != nil {
+	if err := CheckDNSRecordConflict(c.Request.Context(), h.cfg.Records, record.ZoneID, record, record.ID); err != nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "record_conflict", "detail": err.Error()})
 		return
 	}
@@ -643,7 +643,7 @@ func (h *dnsHandler) deleteRecord(c *gin.Context) {
 
 // Validation helpers
 
-func isValidDNSType(t string) bool {
+func IsValidDNSType(t string) bool {
 	switch strings.ToUpper(t) {
 	case "A", "AAAA", "CNAME", "MX", "TXT", "NS", "SRV", "CAA":
 		return true
@@ -651,12 +651,12 @@ func isValidDNSType(t string) bool {
 	return false
 }
 
-func validateDNSRecord(r *models.DNSRecord) error {
+func ValidateDNSRecord(r *models.DNSRecord) error {
 	r.Type = strings.ToUpper(strings.TrimSpace(r.Type))
 	r.Name = strings.TrimSpace(r.Name)
 	r.Content = strings.TrimSpace(r.Content)
 
-	if !isValidDNSType(r.Type) {
+	if !IsValidDNSType(r.Type) {
 		return fmt.Errorf("unsupported record type %q (allowed: A, AAAA, CNAME, MX, TXT, NS, SRV, CAA)", r.Type)
 	}
 	if r.Name == "" {
@@ -731,7 +731,7 @@ func validateDNSRecord(r *models.DNSRecord) error {
 }
 
 
-// checkDNSRecordConflict enforces RFC 1034 §3.6.2 (CNAME exclusivity)
+// CheckDNSRecordConflict enforces RFC 1034 §3.6.2 (CNAME exclusivity)
 // and prevents exact-duplicate rows.
 //
 // Rules:
@@ -745,7 +745,7 @@ func validateDNSRecord(r *models.DNSRecord) error {
 //
 // excludeID is the record being updated (skip self-conflict on edit);
 // pass "" on create.
-func checkDNSRecordConflict(ctx context.Context, records repository.DNSRecordRepository, zoneID string, candidate *models.DNSRecord, excludeID string) error {
+func CheckDNSRecordConflict(ctx context.Context, records repository.DNSRecordRepository, zoneID string, candidate *models.DNSRecord, excludeID string) error {
 	existing, err := records.ListByZoneID(ctx, zoneID)
 	if err != nil {
 		return fmt.Errorf("list records for conflict check: %w", err)

--- a/panel-api/internal/api/dns_conflict_test.go
+++ b/panel-api/internal/api/dns_conflict_test.go
@@ -16,7 +16,7 @@ func TestCheckDNSRecordConflict_RejectsDuplicateExact(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "A", "1.2.3.4")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "A", Content: "1.2.3.4"}
-	if err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err == nil {
+	if err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err == nil {
 		t.Error("exact duplicate should be rejected")
 	}
 }
@@ -26,7 +26,7 @@ func TestCheckDNSRecordConflict_AllowsDifferentContent(t *testing.T) {
 	seedRecord(r, "rec1", "zone1", "www", "A", "1.2.3.4")
 	// Two A records at same name with different content = round-robin, OK.
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "A", Content: "5.6.7.8"}
-	if err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err != nil {
+	if err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err != nil {
 		t.Errorf("round-robin A should be allowed, got: %v", err)
 	}
 }
@@ -35,7 +35,7 @@ func TestCheckDNSRecordConflict_RejectsCNAMEWhenAExists(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "A", "1.2.3.4")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "CNAME", Content: "host.example.com"}
-	err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, "")
+	err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, "")
 	if err == nil || !strings.Contains(err.Error(), "RFC 1034") {
 		t.Errorf("CNAME-after-A should be rejected with RFC 1034 explanation, got: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestCheckDNSRecordConflict_RejectsAWhenCNAMEExists(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "CNAME", "host.example.com")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "A", Content: "1.2.3.4"}
-	err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, "")
+	err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, "")
 	if err == nil || !strings.Contains(err.Error(), "CNAME already exists") {
 		t.Errorf("A-after-CNAME should be rejected with CNAME-precedence explanation, got: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestCheckDNSRecordConflict_RejectsTwoCNAMEsAtSameName(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "CNAME", "host1.example.com")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "CNAME", Content: "host2.example.com"}
-	err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, "")
+	err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, "")
 	if err == nil {
 		t.Error("second CNAME at same name should be rejected (only one allowed per RFC 1034)")
 	}
@@ -65,7 +65,7 @@ func TestCheckDNSRecordConflict_AllowsCNAMEAndAOnDifferentNames(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "A", "1.2.3.4")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "mail", Type: "CNAME", Content: "host.example.com"}
-	if err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err != nil {
+	if err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, ""); err != nil {
 		t.Errorf("CNAME on different name from A should be allowed, got: %v", err)
 	}
 }
@@ -75,7 +75,7 @@ func TestCheckDNSRecordConflict_SelfExcludedOnUpdate(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "www", "CNAME", "old.example.com")
 	cand := &models.DNSRecord{ID: "rec1", ZoneID: "zone1", Name: "www", Type: "CNAME", Content: "new.example.com"}
-	if err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, "rec1"); err != nil {
+	if err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, "rec1"); err != nil {
 		t.Errorf("self-edit should be exempt from conflict check, got: %v", err)
 	}
 }
@@ -85,7 +85,7 @@ func TestCheckDNSRecordConflict_CaseInsensitiveName(t *testing.T) {
 	r := newMockDNSRecordRepo()
 	seedRecord(r, "rec1", "zone1", "WWW", "A", "1.2.3.4")
 	cand := &models.DNSRecord{ZoneID: "zone1", Name: "www", Type: "CNAME", Content: "host.example.com"}
-	err := checkDNSRecordConflict(context.Background(), r, "zone1", cand, "")
+	err := CheckDNSRecordConflict(context.Background(), r, "zone1", cand, "")
 	if err == nil {
 		t.Error("CNAME at lowercase name should conflict with existing A at uppercase name (DNS names are case-insensitive)")
 	}


### PR DESCRIPTION
## JAB-119 — `jabali dns` CLI (DNS was GUI + REST only)

DNS zone/record management had no `jabali` CLI equivalent — the single core resource without CLI parity, so DNS couldn't be managed headlessly / scripted / break-glass'd without the browser.

### What this adds
- `jabali dns zone {list,show}`
- `jabali dns record {list,add,update,delete}`

Mirrors the admin handlers (`internal/api/dns.go`) over the **same repositories** and the **same validation + conflict rules** — `ValidateDNSRecord` / `IsValidDNSType` / `CheckDNSRecordConflict` are exported from the api package and reused, so a record written via the CLI is byte-identical to one the UI would write (satisfies the parity-smoke criterion).

### Behaviour
- **DB is source of truth**: the CLI writes the row; the running reconciler converges it into PowerDNS on its next tick (same pattern as `cli_ops.go` domain mutations — no in-process `Schedule()` from a one-shot CLI).
- **Managed records** (DKIM / autoconfig / etc., `Managed=true`) are refused for hand edit/delete — disable the owning feature instead.
- Admin/operator-scoped (runs against the DB like `jabali ip` / `jabali limits`); owner-scoping isn't a CLI concept.
- All mutations are CLI-audited.

### Design for testability
Mutation logic is factored into repo-injected helpers (`dnsRecordAdd`/`Update`/`Delete`, `dnsResolveZone`, `dnsLoadRecordInZone`); the cobra `RunE` wrappers only wire `sharedDB` repos, flags, and output.

### Test plan
- [x] 10 unit tests (`dns_cmd_test.go`): TTL defaulting, invalid type, invalid content, CNAME exclusivity conflict, unknown-zone error, cross-zone refusal, managed-record refusal (edit + delete), content-only update, command-tree shape.
- [x] `go build ./...`, `go vet ./cmd/server/... ./internal/api/` clean.
- [x] `cmd/server` + `internal/api` package tests green.
- [x] CLI reference golden regenerated (`docs/site/platform/cli-reference.md`).
- [ ] Live parity smoke on a host: `jabali dns record add` → appears in GUI (pending merge/deploy).

### Deferred (minor)
`jabali dns zone update` (SOA timers / enable toggle — the `PATCH /zone` surface). Record CRUD is the actual headless gap; zone-patch can be a follow-up.
