### PR TITLE
fix(mail): name a group's shared file folder after the group (GH #350)

### DIFF
--- a/panel-agent/internal/commands/mailgroup_commands.go
+++ b/panel-agent/internal/commands/mailgroup_commands.go
@@ -33,6 +33,7 @@ type mailGroupApplyParams struct {
 	DisplayName  string `json:"display_name"`  // drives the group's sending Identity name
 	Description  string `json:"description"`   // admin note (also stored on the principal)
 	InternalOnly bool   `json:"internal_only"` // GH #348: reject external senders
+	HasFiles     bool   `json:"has_files"`     // GH #350: name the shared file folder too
 }
 
 func mailGroupApplyHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -63,7 +64,7 @@ func mailGroupApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	// GH #350: rename the group's auto-created "Personal (<addr>)" calendar +
 	// address book to the group name so shared resources read as the group,
 	// not each member's "Personal". Best-effort (guards on empty name).
-	renameGroupResources(ctx, email, name)
+	renameGroupResources(ctx, email, name, p.HasFiles)
 	// GH #348: install/remove the internal-only delivery Sieve on the group.
 	applyGroupInternalOnly(ctx, email, p.InternalOnly)
 	return mailGroupApplyResult{Ok: true, GroupID: gid}, nil

--- a/panel-agent/internal/commands/mailgroup_resource_names.go
+++ b/panel-agent/internal/commands/mailgroup_resource_names.go
@@ -14,9 +14,10 @@ import (
 // Best-effort: the group principal already exists when this runs, so a naming
 // hiccup must never fail the apply (same reflex as setAccountDescription). For
 // distribution groups (no calendar/address book) the default-id lookups return
-// "" and this no-ops. FileNode is created on demand (no default node to rename
-// at provision time), so it's left to the share/create path.
-func renameGroupResources(ctx context.Context, groupEmail, displayName string) {
+// "" and this no-ops. When hasFiles is set the group's shared file folder is
+// named too (GH #350) — Stalwart doesn't auto-create a file node, so this
+// creates the root node named after the group (or renames an existing default).
+func renameGroupResources(ctx context.Context, groupEmail, displayName string, hasFiles bool) {
 	name := strings.TrimSpace(displayName)
 	if name == "" {
 		return
@@ -31,6 +32,39 @@ func renameGroupResources(ctx context.Context, groupEmail, displayName string) {
 	if abID, err := defaultAddressBookID(ctx, acctID); err == nil && abID != "" {
 		_ = jmapSetCollectionName(ctx, jmapCapContacts, "AddressBook/set", acctID, abID, name)
 	}
+	if hasFiles {
+		renameGroupFileNode(ctx, acctID, name)
+	}
+}
+
+// renameGroupFileNode names the group's shared file folder after the group.
+// Unlike calendar/address book, Stalwart does not auto-create a file node for a
+// principal, so the group's root folder is otherwise created on demand with the
+// default "Shared" name (GH #350). This renames the existing root node when one
+// is present, or creates one named after the group so shared files read as the
+// group from the moment files are enabled. Best-effort.
+func renameGroupFileNode(ctx context.Context, accountID, name string) {
+	var listRes struct {
+		List []struct {
+			ID       string  `json:"id"`
+			Name     string  `json:"name"`
+			ParentID *string `json:"parentId"`
+		} `json:"list"`
+	}
+	if err := jmapCallWith(ctx, jmapCapFileNode, "FileNode/get",
+		map[string]any{"accountId": accountID, "properties": []string{"parentId", "name"}}, &listRes); err != nil {
+		return
+	}
+	for _, n := range listRes.List {
+		if n.ParentID == nil || *n.ParentID == "" {
+			if n.Name != name {
+				_ = jmapSetCollectionName(ctx, jmapCapFileNode, "FileNode/set", accountID, n.ID, name)
+			}
+			return
+		}
+	}
+	// No root node yet — create one named after the group.
+	_, _ = ensureRootFileNode(ctx, accountID, name)
 }
 
 // jmapSetCollectionName updates the `name` of one collection via a JMAP */set.

--- a/panel-api/cmd/server/mail_group_cmd.go
+++ b/panel-api/cmd/server/mail_group_cmd.go
@@ -233,6 +233,7 @@ func newMailGroupCreateCmd() *cobra.Command {
 				"display_name":  g.DisplayName,
 				"description":   g.Description,
 				"internal_only": g.InternalOnly,
+				"has_files":     g.HasFiles,
 			})
 			cliAuditOK(ctx, "mail_group.create", "mail_group", g.ID, nil)
 			fmt.Printf("created %s mail group %s\n", g.GroupKind, email)

--- a/panel-api/internal/api/mailgroups.go
+++ b/panel-api/internal/api/mailgroups.go
@@ -305,6 +305,7 @@ func (h *mailGroupHandler) create(c *gin.Context) {
 		"display_name":  g.DisplayName,
 		"description":   g.Description,
 		"internal_only": g.InternalOnly,
+		"has_files":     g.HasFiles,
 	})
 
 	g.EmailCached = email
@@ -387,6 +388,9 @@ func (h *mailGroupHandler) update(c *gin.Context) {
 			return
 		}
 		g.HasMailbox, g.HasCalendar, g.HasAddressbook, g.HasFiles = mbx, cal, ab, fl
+		// GH #350: re-run apply so a newly-enabled resource (esp. files, whose
+		// node is created on demand) is named after the group, not a default.
+		metaChanged = true
 	}
 	// GH #348: toggling internal-only re-projects via mailgroup.apply, which
 	// installs/removes the sender-domain sieve on the group account.
@@ -407,6 +411,7 @@ func (h *mailGroupHandler) update(c *gin.Context) {
 			"display_name":  g.DisplayName,
 			"description":   g.Description,
 			"internal_only": g.InternalOnly,
+			"has_files":     g.HasFiles,
 		})
 	}
 	_ = dom


### PR DESCRIPTION
Resource groups' calendar + address book are already named after the group; their shared **file folder** was not (Stalwart doesn't auto-create a file node, so it defaulted to "Shared"). Extends `renameGroupResources` to name the group's root FileNode (rename if present, create named after the group when files are enabled). `has_files` is wired through `mailgroup.apply` from the REST handler (create + update re-applies on resource toggle) and the CLI. Live-verified on Stalwart 0.16.12: a fresh resource group's root FileNode = the group name, matching calendar + address book. Closes #350.