### PR TITLE
fix(python-apps): surface failure reason on a failed app (GH #357)

### DIFF
--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -11,6 +11,7 @@ import {
   Space,
   Table,
   Tag,
+  Tooltip,
   Typography,
 } from "antd";
 import { ReloadOutlined, PauseCircleOutlined, FileTextOutlined, DeleteOutlined, SettingOutlined } from "@icons";
@@ -138,9 +139,16 @@ export function PythonAppsPage() {
         />
         <Table.Column<PythonApp>
           title="Status"
-          render={(_, r) => (
-            <Tag color={STATUS_COLOR[r.status] ?? "default"}>{r.status}</Tag>
-          )}
+          render={(_, r) => {
+            const tag = <Tag color={STATUS_COLOR[r.status] ?? "default"}>{r.status}</Tag>;
+            // GH #357: a failed app used to show just "failed" with no reason
+            // ("nothing in logs") — surface last_error on hover, like Docker apps.
+            return r.status === "failed" && r.last_error ? (
+              <Tooltip title={r.last_error}>{tag}</Tooltip>
+            ) : (
+              tag
+            );
+          }}
         />
         <Table.Column<PythonApp>
           title=""


### PR DESCRIPTION
A failed Python app showed only a red `failed` tag with no reason ("nothing in logs"), though the reconciler records why in `last_error`. The API already returns it; the Python Apps page just didn't render it. Wrap the status tag in a Tooltip showing `last_error` on failed, matching Docker apps + the unified list. Refs #357 (surfaces the cause; root-cause pinning depends on the now-visible reason).