### PR TITLE
fix(domains): make Edit the primary row action, move DNS to overflow (#351)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -1,6 +1,6 @@
-// DomainList — admin domains grid. Post-M21 the row action strip
-// stays the same (DNS/Redirects/Index/Settings/Toggle/Edit/Delete);
-// only the hook and the two Refine action buttons change.
+// DomainList — admin domains grid. GH #351: Edit is the primary
+// always-visible row action (used far more than DNS); DNS moved into the
+// "..." overflow with Info/Redirects/Index/Settings/Caching/Toggle/Delete.
 import { useState } from "react";
 import { Button, Card, Dropdown, Modal, Space, Table, Tag, Tooltip, Typography, notification } from "antd";
 import {
@@ -360,19 +360,19 @@ export const DomainList = () => {
             render={(_, r) => (
               <Space>
                 <RowActionButton
-                  icon={<GlobalOutlined />}
-                  onClick={() => navigate(`/jabali-admin/domains/${r.id}/dns`)}
+                  icon={<EditOutlined />}
+                  onClick={() => navigate(`/jabali-admin/domains/edit/${r.id}`)}
                 >
-                  DNS
+                  Edit
                 </RowActionButton>
                 <Dropdown
                   menu={{
                     items: [
                       {
-                        key: "edit",
-                        icon: <EditOutlined />,
-                        label: "Edit",
-                        onClick: () => navigate(`/jabali-admin/domains/edit/${r.id}`),
+                        key: "dns",
+                        icon: <GlobalOutlined />,
+                        label: "DNS",
+                        onClick: () => navigate(`/jabali-admin/domains/${r.id}/dns`),
                       },
                       {
                         key: "info",


### PR DESCRIPTION
## Summary
Closes #351 (core ask). In the admin Domains list, **Edit** is now the primary always-visible row action and **DNS** moves into the "..." overflow menu.

Editing a domain (PHP version, doc root, SSL) is used far more often than jumping to DNS records, so the always-visible slot should be Edit. DNS becomes the first item in the overflow, ahead of Info/Redirects/Index/Settings/Caching/Toggle/Delete.

## Scope
- **Admin list only.** The user Domains list has no Edit button (tenants edit per-domain config via the row drawer), so nothing to swap there.
- The five follow-up ideas in the issue (list SSL renew, lock System domains, copyable doc-root path, Status/SSL filters, `BW (30d)` = `0 B`) are **out of scope** here — tracked separately per the issue thread.

## Test plan
- [x] `npx tsc -b` clean (both icons still referenced)
- [ ] Admin → Domains: Edit button visible in each row, opens the edit page
- [ ] "..." menu now lists DNS as first item, routes to `/dns`
