### PR TITLE
feat(mail): send-only mailboxes (#371)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10849,7 +10849,11 @@ print(sql[0]["id"] if sql else "")' 2>/dev/null || true)"
   if [[ -z "$sql_dir_id" ]]; then
     _warn "could not resolve SQL Directory id — skipping query-field convergence"
   else
-    local query_recipient="SELECT m.email_cached, m.password_hash FROM (SELECT ? AS lookup) input JOIN mailboxes m ON m.is_disabled = 0 AND (m.email_cached = input.lookup OR m.id = (SELECT f.mailbox_id FROM email_forwarders f JOIN domains d ON d.id = f.domain_id WHERE f.enabled = 1 AND f.type = 'alias' AND f.mailbox_id IS NOT NULL AND CONCAT(f.local_part, '@', d.name) = input.lookup LIMIT 1))"
+    # GH #371: `AND m.send_only = 0` excludes send-only mailboxes from the
+    # recipient/delivery lookup while queryLogin (auth) still returns them —
+    # so a send-only account can submit mail but inbound gets a 550 (no valid
+    # recipient) and nothing is ever stored. Same gate shape as is_disabled.
+    local query_recipient="SELECT m.email_cached, m.password_hash FROM (SELECT ? AS lookup) input JOIN mailboxes m ON m.is_disabled = 0 AND m.send_only = 0 AND (m.email_cached = input.lookup OR m.id = (SELECT f.mailbox_id FROM email_forwarders f JOIN domains d ON d.id = f.domain_id WHERE f.enabled = 1 AND f.type = 'alias' AND f.mailbox_id IS NOT NULL AND CONCAT(f.local_part, '@', d.name) = input.lookup LIMIT 1))"
     local query_aliases="SELECT CONCAT(f.local_part, '@', d.name) AS alias FROM email_forwarders f JOIN domains d ON d.id = f.domain_id JOIN mailboxes m ON m.id = f.mailbox_id WHERE f.enabled = 1 AND f.type = 'alias' AND m.email_cached = ?"
     local patch_json
     patch_json="$(python3 -c 'import json,sys; print(json.dumps({"queryRecipient": sys.argv[1], "queryEmailAliases": sys.argv[2]}))' "$query_recipient" "$query_aliases")"

--- a/panel-api/cmd/server/mailbox_cmd_test.go
+++ b/panel-api/cmd/server/mailbox_cmd_test.go
@@ -137,6 +137,7 @@ func (f *fakeMailboxRepo) UpdateQuota(_ context.Context, id string, quotaBytes u
 
 func (f *fakeMailboxRepo) UpdateDisplayName(_ context.Context, _ string, _ string) error { return nil }
 func (f *fakeMailboxRepo) SetDisabled(_ context.Context, _ string, _ bool) error         { return nil }
+func (f *fakeMailboxRepo) SetSendOnly(_ context.Context, _ string, _ bool) error         { return nil }
 func (f *fakeMailboxRepo) ListAllWithDomain(_ context.Context) ([]repository.MailboxWithDomain, error) { return nil, nil }
 func (f *fakeMailboxRepo) ListByOwnerWithDomain(_ context.Context, _ string) ([]repository.MailboxWithDomain, error) {
 	return nil, nil

--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -119,6 +119,11 @@ type createMailboxRequest struct {
 	// DisplayName — optional human-readable name (GH #197). Wired to the
 	// Stalwart principal description → Bulwark webmail identity name.
 	DisplayName string `json:"display_name"`
+
+	// SendOnly (GH #371) — when true the mailbox can authenticate for SMTP
+	// submission but never receives or stores mail. Handy for per-service
+	// notification credentials.
+	SendOnly bool `json:"send_only"`
 }
 
 type createMailboxResponse struct {
@@ -126,6 +131,7 @@ type createMailboxResponse struct {
 	Email       string `json:"email"`
 	QuotaBytes  uint64 `json:"quota_bytes"`
 	DisplayName string `json:"display_name"`
+	SendOnly    bool   `json:"send_only"`
 	// Password is returned exactly once when the caller did NOT send a
 	// password — the agent-computed random one. Empty when the caller
 	// supplied their own.
@@ -148,6 +154,7 @@ type updateMailboxRequest struct {
 	QuotaBytes  *uint64 `json:"quota_bytes"`
 	DisplayName *string `json:"display_name"`
 	IsDisabled  *bool   `json:"is_disabled"`
+	SendOnly    *bool   `json:"send_only"`
 }
 
 type mailboxResponse struct {
@@ -157,6 +164,7 @@ type mailboxResponse struct {
 	DisplayName    string     `json:"display_name"`
 	QuotaBytes     uint64     `json:"quota_bytes"`
 	IsDisabled     bool       `json:"is_disabled"`
+	SendOnly       bool       `json:"send_only"`
 	LastUsageBytes uint64     `json:"last_usage_bytes"`
 	LastUsageAt    *time.Time `json:"last_usage_at,omitempty"`
 	CreatedAt      time.Time  `json:"created_at"`
@@ -320,6 +328,7 @@ func (h *mailboxHandler) create(c *gin.Context) {
 		PasswordHash: string(hash),
 		PasswordEnc:  enc,
 		QuotaBytes:   quota,
+		SendOnly:     req.SendOnly,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}
@@ -347,6 +356,7 @@ func (h *mailboxHandler) create(c *gin.Context) {
 		Email:       canonLocal + "@" + dom.Name,
 		QuotaBytes:  quota,
 		DisplayName: mb.DisplayName,
+		SendOnly:    mb.SendOnly,
 		Password:    generatedPassword,
 	})
 }
@@ -444,6 +454,14 @@ func (h *mailboxHandler) update(c *gin.Context) {
 			return
 		}
 		mb.IsDisabled = *req.IsDisabled
+	}
+
+	if req.SendOnly != nil {
+		if err := h.cfg.Mailboxes.SetSendOnly(ctx, mb.ID, *req.SendOnly); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		mb.SendOnly = *req.SendOnly
 	}
 
 	mb.UpdatedAt = time.Now().UTC()
@@ -723,6 +741,7 @@ func toMailboxResponse(mb models.Mailbox) mailboxResponse {
 		DisplayName:    mb.DisplayName,
 		QuotaBytes:     mb.QuotaBytes,
 		IsDisabled:     mb.IsDisabled,
+		SendOnly:       mb.SendOnly,
 		LastUsageBytes: mb.LastUsageBytes,
 		LastUsageAt:    mb.LastUsageAt,
 		CreatedAt:      mb.CreatedAt,

--- a/panel-api/internal/api/webmail_sso_test.go
+++ b/panel-api/internal/api/webmail_sso_test.go
@@ -113,6 +113,7 @@ func (r *ssoFakeMailboxRepo) UpdateDisplayName(_ context.Context, _ string, _ st
 	return nil
 }
 func (r *ssoFakeMailboxRepo) SetDisabled(_ context.Context, _ string, _ bool) error { return nil }
+func (r *ssoFakeMailboxRepo) SetSendOnly(_ context.Context, _ string, _ bool) error { return nil }
 func (r *ssoFakeMailboxRepo) ListAllWithDomain(_ context.Context) ([]repository.MailboxWithDomain, error) {
 	return nil, nil
 }

--- a/panel-api/internal/db/migrations/000220_mailbox_send_only.down.sql
+++ b/panel-api/internal/db/migrations/000220_mailbox_send_only.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mailboxes
+  DROP COLUMN send_only;

--- a/panel-api/internal/db/migrations/000220_mailbox_send_only.up.sql
+++ b/panel-api/internal/db/migrations/000220_mailbox_send_only.up.sql
@@ -1,0 +1,7 @@
+-- GH #371: send-only mailboxes. A send-only account authenticates for SMTP
+-- submission (Stalwart directory queryLogin) but is excluded from delivery
+-- (queryRecipient gains `AND send_only = 0`), so it can send but never
+-- receives or stores mail. Useful for per-appliance/per-service notification
+-- credentials with isolation (compromise one, rotate one).
+ALTER TABLE mailboxes
+  ADD COLUMN send_only TINYINT(1) NOT NULL DEFAULT 0 AFTER is_disabled;

--- a/panel-api/internal/models/mailbox.go
+++ b/panel-api/internal/models/mailbox.go
@@ -29,6 +29,11 @@ type Mailbox struct {
 	PasswordEnc    []byte    `gorm:"type:varbinary(512)" json:"-"`
 	QuotaBytes     uint64    `gorm:"type:bigint unsigned;not null;default:1073741824" json:"quota_bytes"`
 	IsDisabled     bool      `gorm:"type:tinyint(1);not null;default:0" json:"is_disabled"`
+	// SendOnly (GH #371) — the account authenticates for SMTP submission
+	// but is excluded from delivery (Stalwart directory queryRecipient
+	// filters `send_only = 0`), so it can send mail but never receives or
+	// stores any. Set at create; toggleable via update.
+	SendOnly       bool      `gorm:"column:send_only;type:tinyint(1);not null;default:0" json:"send_only"`
 	LastUsageBytes uint64    `gorm:"type:bigint unsigned;not null;default:0" json:"last_usage_bytes"`
 	LastUsageAt    *time.Time `gorm:"type:datetime(6)" json:"last_usage_at,omitempty"`
 	CreatedAt      time.Time `gorm:"type:datetime(6);not null" json:"created_at"`

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -36,6 +36,7 @@ type MailboxRepository interface {
 	UpdateQuota(ctx context.Context, id string, quotaBytes uint64) error
 	UpdateDisplayName(ctx context.Context, id, displayName string) error
 	SetDisabled(ctx context.Context, id string, disabled bool) error
+	SetSendOnly(ctx context.Context, id string, sendOnly bool) error
 	UpdateUsage(ctx context.Context, id string, usageBytes uint64, at time.Time) error
 	ExistsByDomainAndLocalPart(ctx context.Context, domainID, localPart string) (bool, error)
 }
@@ -209,6 +210,19 @@ func (r *mailboxRepo) SetDisabled(ctx context.Context, id string, disabled bool)
 		Updates(map[string]any{
 			"is_disabled": disabled,
 			"updated_at":  time.Now().UTC(),
+		}).Error
+}
+
+// SetSendOnly flips the send-only flag (GH #371). Stalwart's SqlDirectory
+// re-reads the row on the next recipient lookup (no cache to invalidate,
+// ADR-0045), so a send-only account stops receiving on the next inbound
+// delivery attempt with no agent round-trip.
+func (r *mailboxRepo) SetSendOnly(ctx context.Context, id string, sendOnly bool) error {
+	return r.db.WithContext(ctx).Model(&models.Mailbox{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"send_only":  sendOnly,
+			"updated_at": time.Now().UTC(),
 		}).Error
 }
 

--- a/panel-api/internal/repository/mailbox_repository_test.go
+++ b/panel-api/internal/repository/mailbox_repository_test.go
@@ -121,6 +121,24 @@ func TestMailboxRepository_UpdateQuota(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// GH #371: SetSendOnly flips the send_only column so Stalwart's
+// queryRecipient (which filters `send_only = 0`) stops delivering to it.
+func TestMailboxRepository_SetSendOnly(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `mailboxes` SET .*`send_only`.* WHERE id = \\?").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := repo.SetSendOnly(context.Background(), "mb_new", true)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestMailboxRepository_Delete(t *testing.T) {
 	db, mock, raw := newMockDB(t)
 	defer raw.Close()

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -66,6 +66,9 @@ export interface Mailbox {
   display_name: string;
   quota_bytes: number;
   is_disabled: boolean;
+  // send_only (GH #371): authenticates for SMTP submission but never
+  // receives or stores mail.
+  send_only: boolean;
   last_usage_bytes: number;
   last_usage_at?: string | null;
   created_at: string;
@@ -77,6 +80,7 @@ export interface CreateMailboxInput {
   display_name?: string;
   password?: string;
   quota_bytes?: number;
+  send_only?: boolean;
 }
 
 export interface CreateMailboxResponse {
@@ -84,6 +88,7 @@ export interface CreateMailboxResponse {
   email: string;
   quota_bytes: number;
   display_name?: string;
+  send_only?: boolean;
   // Present only when caller didn't supply a password — reveal-once.
   password?: string;
 }

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -13,6 +13,7 @@ import {
   Card,
   Form,
   Input,
+  Checkbox,
   InputNumber,
   Modal,
   Progress,
@@ -118,6 +119,7 @@ export const DomainMailboxesSection = ({
     local_part: string;
     password?: string;
     quota_mib?: number;
+    send_only?: boolean;
   }>();
 
   // Only render the in-dialog domain picker when the caller actually
@@ -245,6 +247,7 @@ export const DomainMailboxesSection = ({
           local_part: values.local_part,
           password: values.password || undefined,
           quota_bytes: parseQuotaInput(values.quota_mib),
+          send_only: values.send_only || undefined,
         },
       });
       setCreateOpen(false);
@@ -349,8 +352,12 @@ export const DomainMailboxesSection = ({
               title: "Status",
               dataIndex: "is_disabled",
               width: 100,
-              render: (disabled: boolean) =>
-                disabled ? <Tag color="red">disabled</Tag> : <Tag color="green">active</Tag>,
+              render: (disabled: boolean, row: Mailbox) => (
+                <Space size={4} wrap>
+                  {disabled ? <Tag color="red">disabled</Tag> : <Tag color="green">active</Tag>}
+                  {row.send_only && <Tag color="blue">send-only</Tag>}
+                </Space>
+              ),
             },
             {
               title: "Actions",
@@ -455,6 +462,13 @@ export const DomainMailboxesSection = ({
               step={256}
               style={{ width: 200 }}
             />
+          </Form.Item>
+          <Form.Item
+            name="send_only"
+            valuePropName="checked"
+            tooltip="A send-only mailbox authenticates for SMTP submission but never receives or stores mail — inbound is rejected. Useful for per-service notification credentials."
+          >
+            <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
           </Form.Item>
         </Form>
       </Modal>

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
@@ -47,6 +47,7 @@ type FormValues = {
   display_name?: string;
   password?: string;
   quota_mib?: number;
+  send_only?: boolean;
   group_ids?: string[];
   aliases?: string;
   forward_target?: string;
@@ -92,6 +93,7 @@ export const CreateMailboxWizardModal = ({
           display_name: values.display_name?.trim() || undefined,
           password: values.password || undefined,
           quota_bytes: parseQuotaInput(values.quota_mib),
+          send_only: values.send_only || undefined,
         },
       });
       if (values.group_ids?.length) {
@@ -244,6 +246,14 @@ export const CreateMailboxWizardModal = ({
                 step={256}
                 style={{ width: 200 }}
               />
+            </Form.Item>
+
+            <Form.Item
+              name="send_only"
+              valuePropName="checked"
+              tooltip="A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials, so each system has its own account to revoke or rotate."
+            >
+              <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
             </Form.Item>
 
             {domainGroups && domainGroups.length > 0 && (


### PR DESCRIPTION
## Summary
Closes #371. Adds **send-only mailboxes** — accounts that authenticate for SMTP submission but never receive or store mail. Purpose-built for the issue's use case: per-service/per-appliance notification credentials with isolation, instead of a shared `notify@` password reused across every system.

## Mechanism (Stalwart-native, spike-verified)
Stalwart's SQL directory has two independent queries:
- `queryLogin` — auth by login address → **unchanged**, so send-only accounts can submit.
- `queryRecipient` — account by recipient address → gains `AND m.send_only = 0`, so a send-only account returns 0 rows on recipient lookup → inbound gets **550** and nothing is stored.

Same gate shape as the existing `is_disabled = 0`. No agent round-trip — the SqlDirectory re-reads the row on the next lookup (ADR-0045).

## Changes
- **migration 000220** — `send_only TINYINT(1) NOT NULL DEFAULT 0` on `mailboxes`
- **model + repository** — `SendOnly` field, `SetSendOnly` (+ sqlmock test)
- **API** — create/update DTOs, handlers, response carry `send_only`
- **install.sh** — `queryRecipient` convergence gains `AND m.send_only = 0` (the single authoritative definition; converges on every install/update)
- **UI** — send-only checkbox in the user create wizard + admin create modal; `send-only` tag in the admin mailbox list

## Test plan
- [x] `go build ./...`, `go vet`, panel-api unit tests (incl. new `SetSendOnly` sqlmock test)
- [x] `npx tsc -b`, panel-ui vitest (useMailboxes + DomainMailboxesSection)
- [x] **Live on .86** (mutate+revert, additive column): normal mailbox resolves for delivery; `send_only=1` → 0 rows for delivery (550) yet still resolves for login (auth intact); reverted cleanly
- [ ] Post-merge: create a send-only mailbox on a real host, confirm `swaks` submission succeeds and inbound bounces 550
