### PR TITLE
ux(api): rename API nav pages for clarity (JAB-16)

### DIFF
--- a/panel-ui/src/nav.ts
+++ b/panel-ui/src/nav.ts
@@ -215,14 +215,14 @@ export const adminNav: NavItem[] = [
   },
   {
     key: "automation",
-    label: "Automation API",
-    description: "Automation API tokens and scopes",
+    label: "Server API Access",
+    description: "Server/global API tokens and scopes for automations",
     icon: navIcon(KeyOutlined),
     path: "/jabali-admin/automation",
   },
   {
     key: "api-tokens",
-    label: "API Tokens",
+    label: "Personal API Tokens",
     description: "REST API keys",
     icon: navIcon(ApiOutlined),
     path: "/jabali-admin/api-tokens",
@@ -337,7 +337,7 @@ export const userNav: NavItem[] = [
   },
   {
     key: "api-tokens",
-    label: "API Tokens",
+    label: "Personal API Tokens",
     icon: navIcon(ApiOutlined),
     path: "/jabali-panel/api-tokens",
   },

--- a/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
+++ b/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
@@ -159,7 +159,7 @@ export const AdminAutomationTokensPage = () => {
     <div>
       <Typography.Title level={2}>
         <Space>
-          <KeyOutlined /> Automation API Tokens
+          <KeyOutlined /> Server API Access
         </Space>
       </Typography.Title>
       <Typography.Paragraph type="secondary">
@@ -262,7 +262,7 @@ export const AdminAutomationTokensPage = () => {
       </Card>
 
       <Drawer
-        title="Mint Automation API Token"
+        title="Mint Server API Token"
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         width={500}

--- a/panel-ui/src/shells/admin/settings/ModulesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/ModulesCard.tsx
@@ -29,7 +29,7 @@ const MODULES: { key: ModuleKey; label: string; desc: string }[] = [
   { key: "mail_enabled", label: "Mail server (Stalwart + Bulwark)", desc: "Mailboxes, forwarders, webmail, and the Mail pages." },
   { key: "security_enabled", label: "Security (CrowdSec, malware/ClamAV, AppArmor)", desc: "Intrusion detection, malware scanning, and the Security page." },
   { key: "quota_enabled", label: "Filesystem quota", desc: "Per-user disk quota enforcement + the quota fields." },
-  { key: "api_enabled", label: "REST API (API keys)", desc: "Remote-management API keys + the API Tokens page." },
+  { key: "api_enabled", label: "REST API (API keys)", desc: "Remote-management API keys + the Personal API Tokens page." },
 ];
 
 type ModuleStatus = { installed: boolean; active: boolean };

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -92,7 +92,7 @@ const USER_PANEL_CARDS: { key: string; label: string; icon: React.ReactNode; pat
   { key: "disk-usage", label: "Disk Usage", icon: <HddOutlined />, path: "/jabali-panel/disk-usage" },
   { key: "logs", label: "Logs", icon: <FileTextOutlined />, path: "/jabali-panel/logs" },
   { key: "ssh-keys", label: "SSH Keys", icon: <KeyOutlined />, path: "/jabali-panel/ssh-keys" },
-  { key: "api-tokens", label: "API Tokens", icon: <ApiOutlined />, path: "/jabali-panel/api-tokens" },
+  { key: "api-tokens", label: "Personal API Tokens", icon: <ApiOutlined />, path: "/jabali-panel/api-tokens" },
   { key: "cron", label: "Cron Jobs", icon: <ClockCircleOutlined />, path: "/jabali-panel/cron" },
 ];
 

--- a/panel-ui/src/shells/shared/APIDocsPage.tsx
+++ b/panel-ui/src/shells/shared/APIDocsPage.tsx
@@ -324,7 +324,7 @@ function ExampleCurl(props: {
   return (
     <div>
       <Typography.Text strong>Example</Typography.Text>{" "}
-      <Tooltip title="Replace jat_REPLACE_ME with your token from the API Tokens page. Replace panel.example.com with your panel hostname.">
+      <Tooltip title="Replace jat_REPLACE_ME with your token from the Personal API Tokens page. Replace panel.example.com with your panel hostname.">
         <LinkOutlined style={{ color: "#999" }} />
       </Tooltip>
       <pre

--- a/panel-ui/src/shells/user/QuickStartModal.tsx
+++ b/panel-ui/src/shells/user/QuickStartModal.tsx
@@ -73,7 +73,7 @@ const STEPS: Step[] = [
   },
   {
     number: 6,
-    title: "API Tokens",
+    title: "Personal API Tokens",
     desc: "Mint a token for scripting / DDNS — same key works in routers, ddclient, CI.",
     href: "/jabali-panel/api-tokens",
     icon: ApiOutlined,

--- a/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
+++ b/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
@@ -307,7 +307,7 @@ export function UserAPITokensPage(): JSX.Element {
 
   const tokensCard = (
     <Card
-      title="API Tokens"
+      title="Personal API Tokens"
       extra={
         <Button
           type="primary"


### PR DESCRIPTION
Closes JAB-16 (Plane).

Sidebar showed **Automation API** (admin/global) and **API Tokens** (personal) — too similar. Renamed both consistently everywhere they surface:

- `Automation API` → **Server API Access** (admin/global automation tokens)
- `API Tokens` → **Personal API Tokens** (the signed-in user's own tokens)

Touched: sidebar nav (`nav.ts`, admin + user), page headers (`AdminAutomationTokensPage`, `UserAPITokensPage`), mint-dialog title, admin user-overview tab, Modules-card description, quick-start step, API-docs tooltip.

**No behavior change** — no route/permission/scope/token-contract edits; paths untouched so existing URLs keep working (acceptance criterion). The `Automation API` product name in the docs tab is intentionally kept (both token kinds hit that same API).

## Test plan
- [x] `npx tsc -b` clean; `nav.test.ts` passes; no test asserted the old labels
- [ ] Visual: sidebar shows the two new names; page headers match