### PR TITLE
security(kratos): stop self-service profile edits from drifting panel identity (JAB-5)

### DIFF
--- a/docs/runbooks/kratos-identity-attributes.md
+++ b/docs/runbooks/kratos-identity-attributes.md
@@ -1,0 +1,54 @@
+# Runbook — Kratos identity attributes: panel-controlled vs user-editable (JAB-5)
+
+**Rule:** the **Jabali panel DB is authoritative** for identity and RBAC. Kratos
+stores a mirror of the identity traits, but those traits are **never** the
+source of truth for authorization and **must not** be user-mutable.
+
+## Attribute ownership
+
+| Trait / attribute | Source of truth | User-editable? | How it changes |
+|---|---|---|---|
+| `traits.username` | panel DB (`users.username`) | **No** | Jabali admin/user API → `kratosclient.UpdateUsernameTrait` (`PATCH /admin/identities/{id}`) |
+| `traits.email` | panel DB (`users.email`) | **No** | Jabali admin/user API → Kratos admin API |
+| `traits.is_admin` | panel DB (`users.is_admin`) | **No** | Jabali admin API only; **never** read for authz (middleware uses the DB) |
+| password | Kratos (credential) | **Yes** | `/settings` flow, `password` method (self-service) |
+| TOTP (2FA) | Kratos (credential) | **Yes** | `/settings` flow, `totp` method (self-service) |
+| lookup secrets (recovery codes) | Kratos (credential) | **Yes** | `/settings` flow, `lookup_secret` method (self-service) |
+
+## How the boundary is enforced
+
+1. **Kratos self-service `profile` method is DISABLED**
+   (`install/kratos.yml.tmpl` → `selfservice.methods.profile.enabled: false`).
+   The profile method is the only settings-flow method that mutates identity
+   **traits**. With it off, a signed-in user cannot change username/email/
+   is_admin — not through the UI and not through a crafted direct `/.ory`
+   settings/profile submission (Kratos rejects a disabled method).
+   Guarded by `TestKratosProfileMethodDisabled`.
+
+2. **Password / TOTP / lookup-secret stay self-service** (separate methods),
+   so users still manage their own credentials via `/settings`.
+
+3. **Admin/user changes sync over the Kratos ADMIN API**, never self-service —
+   `UpdateUsernameTrait`, `SetPassword`, `SetIdentityState`, `RemoveSecondFactor`
+   all `PATCH /admin/identities/{id}`. Disabling the profile method does not
+   affect these.
+
+4. **Display never trusts the trait.** The Active Sessions view
+   (`GET /admin/sessions`) resolves `is_admin` from the panel DB by the
+   session's email, falling back to the trait only when no panel row matches
+   (deleted user / dev-without-Kratos). Guarded by
+   `TestListSessions_ResolvesAdminFromPanelDB`. Authorization middleware
+   (`RequireKratosSession`) already uses the DB, not the trait.
+
+## Propagation to existing installs
+
+`install.sh` re-renders `kratos.yml` from the template on **every**
+`jabali update` (not only fresh installs), so existing hosts pick up
+`profile.enabled: false` on their next update — no manual step.
+
+## If you must add a genuinely user-editable trait later
+
+Do **not** re-enable the `profile` method wholesale. Instead split the identity
+schema so only the new self-service field lives in a settings-editable trait,
+keep username/email/is_admin panel-controlled, and update
+`TestKratosProfileMethodDisabled` deliberately with the rationale.

--- a/install/kratos.yml.tmpl
+++ b/install/kratos.yml.tmpl
@@ -88,7 +88,19 @@ selfservice:
     password:
       enabled: true
     profile:
-      enabled: true
+      # JAB-5: DISABLED. The panel DB is authoritative for identity/RBAC
+      # (user id, username, email, is_admin). The self-service profile
+      # method is the only settings-flow method that mutates identity
+      # *traits* — leaving it on lets any signed-in user PATCH their own
+      # traits.username / traits.email / traits.is_admin via a crafted
+      # /.ory settings flow, desyncing Kratos from the panel DB (broken
+      # recovery, misleading sessions/audit, and drift for anything that
+      # later consumes traits). All authoritative changes go through the
+      # Jabali admin/user APIs, which sync to Kratos over the ADMIN API
+      # (kratosclient UpdateUsernameTrait / SetPassword / SetIdentityState
+      # → PATCH /admin/identities/{id}) — unaffected by this. Password,
+      # TOTP, and lookup-secret settings stay enabled (separate methods).
+      enabled: false
     link:
       enabled: false
     code:

--- a/panel-api/internal/api/users_sessions.go
+++ b/panel-api/internal/api/users_sessions.go
@@ -47,7 +47,17 @@ func (h *userHandler) listSessions(c *gin.Context) {
 		if s.Identity != nil {
 			r.Email = s.Identity.GetTraitEmail()
 			r.Username = s.Identity.GetTraitUsername()
+			// JAB-5: the panel DB is authoritative for role — never trust
+			// the Kratos is_admin trait for display or anything else.
+			// Resolve from the DB by the session's email; fall back to the
+			// trait only when no panel row matches (deleted user, or a
+			// dev environment running without Kratos↔DB in lock-step).
 			r.IsAdmin = s.Identity.GetTraitIsAdmin()
+			if h.cfg.Repo != nil && r.Email != "" {
+				if u, uErr := h.cfg.Repo.FindByEmail(c.Request.Context(), r.Email); uErr == nil && u != nil {
+					r.IsAdmin = u.IsAdmin
+				}
+			}
 		}
 		if len(s.Devices) > 0 {
 			r.IP = s.Devices[0].IPAddress

--- a/panel-api/internal/api/users_sessions_admin_from_db_test.go
+++ b/panel-api/internal/api/users_sessions_admin_from_db_test.go
@@ -1,0 +1,93 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-5: the Active Sessions list must resolve the admin flag from the panel
+// DB, never from the Kratos is_admin trait (which must not be trusted). Here a
+// session's identity trait claims is_admin=true, but the matching panel user is
+// a NON-admin — the response row must report is_admin=false (DB wins). This is
+// defence-in-depth alongside disabling the self-service profile method that
+// could let the trait drift in the first place.
+func TestListSessions_ResolvesAdminFromPanelDB(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Kratos admin: GET /admin/sessions → one session whose trait lies.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{
+			"id":"sess-1","active":true,
+			"authenticator_assurance_level":"aal1",
+			"identity":{"id":"idA","traits":{"email":"user@x.test","username":"alice","is_admin":true}},
+			"devices":[{"ip_address":"203.0.113.7","user_agent":"curl"}]
+		}]`))
+	}))
+	defer srv.Close()
+
+	repo := newMemUserRepo()
+	repo.seed(&models.User{ID: "u1", Email: "user@x.test", IsAdmin: false})
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1", func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "admin-1", IsAdmin: true})
+		c.Next()
+	})
+	api.RegisterUserRoutes(g, api.UserHandlerConfig{
+		Repo:         repo,
+		KratosClient: kratosclient.NewClient(srv.URL, srv.URL),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/sessions", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var body struct {
+		Sessions []struct {
+			Email   string `json:"email"`
+			IsAdmin bool   `json:"is_admin"`
+		} `json:"sessions"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Sessions, 1)
+	require.Equal(t, "user@x.test", body.Sessions[0].Email)
+	require.False(t, body.Sessions[0].IsAdmin, "DB non-admin must win over the is_admin=true Kratos trait")
+}
+
+// JAB-5 regression guard: the Kratos self-service *profile* method must stay
+// DISABLED. It is the only settings-flow method that mutates identity traits;
+// re-enabling it lets any signed-in user PATCH their own username/email/is_admin
+// via a crafted /.ory settings flow and desync Kratos from the authoritative
+// panel DB. A live crafted-submission test needs a running Kratos; this cheap
+// guard fails the build if someone flips the template back on.
+func TestKratosProfileMethodDisabled(t *testing.T) {
+	// panel-api/internal/api → repo root is ../../../
+	raw, err := os.ReadFile("../../../install/kratos.yml.tmpl")
+	require.NoError(t, err)
+	tmpl := string(raw)
+
+	// Capture the profile: block up to the next 4-space-indented method key
+	// (`\n    link:` etc.). A plain "\n    " delimiter would wrongly stop at
+	// the 6-space-indented comment lines inside the block.
+	m := regexp.MustCompile(`(?s)\n    profile:\n(.*?)\n    [a-z]`).FindStringSubmatch(tmpl)
+	require.Len(t, m, 2, "profile method block not found in kratos.yml.tmpl")
+	block := m[1]
+	require.NotContains(t, block, "enabled: true",
+		"JAB-5: Kratos self-service profile method must be disabled (found enabled: true in the profile block)")
+	require.Contains(t, block, "enabled: false",
+		"JAB-5: Kratos profile block must explicitly set enabled: false")
+}


### PR DESCRIPTION
Closes JAB-5 (Plane) — high/critical security.

The panel DB is authoritative for identity/RBAC, but Kratos had the self-service **profile** method enabled — the only settings-flow method that mutates identity *traits*. A signed-in user could PATCH their own `traits.username` / `traits.email` / `traits.is_admin` via a crafted `/.ory` settings/profile submission (the UI never surfaced it, but Kratos accepted it), desyncing Kratos from the DB.

## Fix
- **`install/kratos.yml.tmpl`: `profile.enabled: false`** — removes self-service trait mutation. Password / TOTP / lookup-secret stay enabled (separate methods). Admin/user changes are unaffected: they sync over the Kratos **admin API** (`UpdateUsernameTrait` / `SetPassword` / `SetIdentityState` → `PATCH /admin/identities/{id}`), not self-service. `install.sh` re-renders `kratos.yml` on every `jabali update`, so existing hosts get it automatically.
- **`users_sessions.go`** — Active Sessions resolves `is_admin` from the **panel DB** (by session email), not the Kratos trait; falls back to the trait only when no panel row matches.
- **Runbook** `docs/runbooks/kratos-identity-attributes.md` — panel-controlled vs user-editable attributes + how the boundary is enforced.

## Acceptance criteria
- [x] Non-admin can't change username/email/is_admin via a Kratos settings/profile flow → profile method disabled server-side
- [x] Admin/user Jabali API changes still sync to Kratos → admin API, unaffected
- [x] Tests assert the profile method stays disabled (`TestKratosProfileMethodDisabled`) and that Active Sessions ignores the trait (`TestListSessions_ResolvesAdminFromPanelDB` — DB non-admin wins over `is_admin=true` trait)
- [x] Active Sessions UI no longer treats the `is_admin` trait as authoritative
- [x] Runbook documents the attribute ownership

## Out of scope (unchanged)
Password change, TOTP, lookup-secret self-service; panel DB as authz source of truth.

## Test plan
- [x] `go build`, `go vet`, panel-api tests green (incl. the two new guards)
- [ ] Post-merge live check on a host: a crafted `/.ory` settings/profile submission for `traits.is_admin` is rejected (method disabled)
