### PR TITLE
fix(updates): actionable diagnostics for system package check failures (JAB-10)

### DIFF
--- a/panel-agent/internal/commands/system_apt_check.go
+++ b/panel-agent/internal/commands/system_apt_check.go
@@ -4,20 +4,43 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os/exec"
 	"regexp"
 	"strings"
-
-	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
 
 // systemAptCheckResponse is the wire shape for system.apt_check.
+//
+// JAB-10: on a healthy host Error is nil and Packages/Total are populated.
+// When apt fails (dpkg lock held by a running upgrade, repo unreachable,
+// bad perms, unparseable output, …) the handler does NOT return a bare
+// agent error — it returns this response with a *structured* Error the
+// admin UI can render (reason + failed command + exit code + stderr
+// summary + a recovery hint). A hard agent error is reserved for the
+// agent being unreachable, which is a different failure than "apt said no".
 type systemAptCheckResponse struct {
 	Packages       []aptUpgradablePackage `json:"packages"`
 	Total          int                    `json:"total"`
 	SecurityTotal  int                    `json:"security_total"`
 	InstalledTotal int                    `json:"installed_total"`
+	Error          *aptCheckError         `json:"error,omitempty"`
+}
+
+// aptCheckError is the admin-facing, structured diagnostic for a failed
+// system-package check (JAB-10).
+type aptCheckError struct {
+	// Reason is a stable machine key the UI switches on:
+	//   apt_locked | repo_unreachable | permission | command_failed
+	Reason string `json:"reason"`
+	// Command is the failed command, e.g. "apt-get update".
+	Command string `json:"command"`
+	// ExitCode is the process exit code, or -1 when it never ran / was killed.
+	ExitCode int `json:"exit_code"`
+	// Stderr is a trimmed, size-capped stderr/stdout summary.
+	Stderr string `json:"stderr"`
+	// Hint is the next recovery step, in plain admin language.
+	Hint string `json:"hint"`
 }
 
 type aptUpgradablePackage struct {
@@ -32,20 +55,24 @@ type aptUpgradablePackage struct {
 
 // systemAptCheckHandler runs `apt-get update` then `apt list --upgradable`
 // and parses the column-stable output. Every apt invocation includes
-// `-o DPkg::Lock::Timeout=60` because unattended-upgrades.timer runs
-// nightly and holds the dpkg lock; without the timeout, ops see a
-// cryptic crash. LC_ALL=C pins the column header locale.
+// `-o DPkg::Lock::Timeout=60` because unattended-upgrades.timer (and the
+// panel's own jabali-apt-oneshot.service) can hold the dpkg lock; without
+// the timeout, ops see a cryptic crash. LC_ALL=C pins the column locale.
 //
 // This command takes NO user-controlled parameters — apt is invoked with
 // fixed args only. Any future params should be type-tagged enums, not
 // passed through as strings.
 func systemAptCheckHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	if err := runApt(ctx, "update", "-qq"); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("apt-get update: %v", err)}
+	if _, stderr, code, err := runAptCapture(ctx, "update", "-qq"); err != nil {
+		return systemAptCheckResponse{
+			Error: classifyAptError("apt-get update", stderr, code, err),
+		}, nil
 	}
-	out, err := aptList(ctx)
+	out, stderr, code, err := aptListCapture(ctx)
 	if err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("apt list: %v", err)}
+		return systemAptCheckResponse{
+			Error: classifyAptError("apt list --upgradable", stderr, code, err),
+		}, nil
 	}
 	pkgs := parseAptUpgradable(string(out))
 	sec := 0
@@ -60,6 +87,99 @@ func systemAptCheckHandler(ctx context.Context, _ json.RawMessage) (any, error) 
 		SecurityTotal:  sec,
 		InstalledTotal: countInstalledPackages(ctx),
 	}, nil
+}
+
+// aptLockPatterns / aptRepoPatterns / aptPermPatterns are matched
+// case-insensitively against the failed command's output to pick a Reason.
+// Order matters: lock is checked before the generic fallback so a lock held
+// by a running upgrade reads as "in progress", not "command failed".
+var (
+	aptLockPatterns = []string{
+		"could not get lock", "unable to acquire the dpkg", "dpkg frontend lock",
+		"dpkg::lock::timeout", "lock::timeout", "dpkg was interrupted",
+		"is another process using it", "resource temporarily unavailable",
+	}
+	aptRepoPatterns = []string{
+		"failed to fetch", "could not resolve", "temporary failure resolving",
+		"could not connect", "unable to connect", "connection failed",
+		"connection timed out", "network is unreachable", "cannot initiate the connection",
+	}
+	aptPermPatterns = []string{
+		"permission denied", "are you root", "requires superuser",
+		"must be run as root", "eacces", "operation not permitted",
+	}
+)
+
+// classifyAptError maps a failed apt invocation to a structured, admin-facing
+// diagnostic. It never returns nil.
+func classifyAptError(command, stderr string, exitCode int, err error) *aptCheckError {
+	low := strings.ToLower(stderr)
+	summary := summarizeStderr(stderr)
+	if summary == "" && err != nil {
+		summary = err.Error()
+	}
+	switch {
+	case containsAny(low, aptLockPatterns):
+		return &aptCheckError{
+			Reason: "apt_locked", Command: command, ExitCode: exitCode, Stderr: summary,
+			Hint: "A package operation is in progress (unattended-upgrades or a Jabali system update holds the dpkg lock). Wait for it to finish, then retry.",
+		}
+	case containsAny(low, aptRepoPatterns):
+		return &aptCheckError{
+			Reason: "repo_unreachable", Command: command, ExitCode: exitCode, Stderr: summary,
+			Hint: "apt could not reach a repository. Check the server's network/DNS and its apt sources, then retry.",
+		}
+	case containsAny(low, aptPermPatterns):
+		return &aptCheckError{
+			Reason: "permission", Command: command, ExitCode: exitCode, Stderr: summary,
+			Hint: "The package check must run with root privileges. Verify the panel-agent is running as root.",
+		}
+	default:
+		return &aptCheckError{
+			Reason: "command_failed", Command: command, ExitCode: exitCode, Stderr: summary,
+			Hint: "The package manager returned an error. Run `sudo apt-get update` on the host to reproduce and inspect the full output.",
+		}
+	}
+}
+
+func containsAny(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// summarizeStderr trims apt's output to a compact, admin-safe summary: the
+// last few non-empty lines (apt puts the actionable error last), capped in
+// length so it stays displayable and never leaks a wall of text.
+func summarizeStderr(s string) string {
+	const maxLines, maxLen = 4, 600
+	var lines []string
+	for _, l := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(l); t != "" {
+			lines = append(lines, t)
+		}
+	}
+	if len(lines) > maxLines {
+		lines = lines[len(lines)-maxLines:]
+	}
+	out := strings.Join(lines, "\n")
+	if len(out) > maxLen {
+		out = out[:maxLen] + "…"
+	}
+	return out
+}
+
+// exitCodeOf extracts the process exit code from an exec error, or -1 when
+// the command could not run (binary missing, context cancelled, killed).
+func exitCodeOf(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
 }
 
 // countInstalledPackages returns the number of installed dpkg packages, for
@@ -78,25 +198,33 @@ func countInstalledPackages(ctx context.Context) int {
 	return n
 }
 
-func runApt(ctx context.Context, args ...string) error {
+// runAptCapture runs apt-get with the shared lock-timeout + locale env and
+// returns stdout, a combined output summary source, the exit code, and err.
+func runAptCapture(ctx context.Context, args ...string) (stdout []byte, stderr string, exitCode int, err error) {
 	full := append([]string{"-o", "DPkg::Lock::Timeout=60"}, args...)
 	cmd := exec.CommandContext(ctx, "apt-get", full...)
 	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "DEBIAN_FRONTEND=noninteractive")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	// apt-get writes most diagnostics to stderr but some to stdout; combine
+	// so classification sees everything regardless of stream.
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		return nil, string(out), exitCodeOf(runErr), runErr
 	}
-	return nil
+	return out, "", 0, nil
 }
 
-func aptList(ctx context.Context) ([]byte, error) {
+// aptListCapture runs `apt list --upgradable`, capturing stderr separately so
+// a failure (rare — lock/perm) is classifiable.
+func aptListCapture(ctx context.Context) (stdout []byte, stderr string, exitCode int, err error) {
 	cmd := exec.CommandContext(ctx, "apt", "list", "--upgradable")
 	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
+	var errBuf strings.Builder
+	cmd.Stderr = &errBuf
+	out, runErr := cmd.Output()
+	if runErr != nil {
+		return nil, errBuf.String(), exitCodeOf(runErr), runErr
 	}
-	return out, nil
+	return out, "", 0, nil
 }
 
 // parseAptUpgradable reads `apt list --upgradable` output, format example:

--- a/panel-agent/internal/commands/system_apt_check_test.go
+++ b/panel-agent/internal/commands/system_apt_check_test.go
@@ -1,6 +1,9 @@
 package commands
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const aptListUpgradableSample = `Listing...
 curl/stable 8.5.0-2 amd64 [upgradable from: 8.4.0-2]
@@ -68,4 +71,113 @@ func TestParseAptUpgradable_IgnoresWarnings(t *testing.T) {
 	if len(pkgs) != 0 {
 		t.Fatalf("want 0 packages, got %d (warning lines must be skipped)", len(pkgs))
 	}
+}
+
+// JAB-10: parseAptUpgradable must not crash or invent packages on malformed
+// package-manager output (garbage lines, truncated columns).
+func TestParseAptUpgradable_Malformed(t *testing.T) {
+	garbage := "Listing...\n" +
+		"this is not a valid apt line\n" +
+		"curl/stable 8.5.0-2\n" + // truncated: no [upgradable from: …]
+		"\x00\x01 binary junk \xff\n"
+	pkgs := parseAptUpgradable(garbage)
+	if len(pkgs) != 0 {
+		t.Fatalf("malformed output must parse to 0 packages, got %d: %+v", len(pkgs), pkgs)
+	}
+}
+
+// JAB-10: classifyAptError maps apt failures to stable, admin-facing reasons.
+func TestClassifyAptError(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "dpkg lock",
+			stderr: "E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4211 (unattended-upgr)",
+			want:   "apt_locked",
+		},
+		{
+			name:   "lock timeout exceeded",
+			stderr: "E: dpkg::Lock::Timeout of 60 seconds was exceeded",
+			want:   "apt_locked",
+		},
+		{
+			name:   "repo dns failure",
+			stderr: "Err:1 http://deb.debian.org/debian bookworm InRelease\n  Temporary failure resolving 'deb.debian.org'",
+			want:   "repo_unreachable",
+		},
+		{
+			name:   "repo fetch failure",
+			stderr: "E: Failed to fetch http://deb.debian.org/… Connection timed out",
+			want:   "repo_unreachable",
+		},
+		{
+			name:   "not root",
+			stderr: "E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)\nAre you root?",
+			want:   "permission",
+		},
+		{
+			name:   "generic failure",
+			stderr: "E: Some packages could not be installed. Unmet dependencies.",
+			want:   "command_failed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := classifyAptError("apt-get update", tc.stderr, 100, nil)
+			if e == nil {
+				t.Fatal("classifyAptError returned nil")
+			}
+			if e.Reason != tc.want {
+				t.Errorf("reason = %q, want %q (stderr=%q)", e.Reason, tc.want, tc.stderr)
+			}
+			if e.Command != "apt-get update" {
+				t.Errorf("command = %q, want apt-get update", e.Command)
+			}
+			if e.ExitCode != 100 {
+				t.Errorf("exit_code = %d, want 100", e.ExitCode)
+			}
+			if e.Hint == "" {
+				t.Error("hint must not be empty (admins need a recovery step)")
+			}
+			if e.Stderr == "" {
+				t.Error("stderr summary must not be empty when stderr was provided")
+			}
+		})
+	}
+}
+
+// summarizeStderr keeps only the last few lines and caps length so a wall of
+// apt output can't blow up the admin card.
+func TestSummarizeStderr(t *testing.T) {
+	if got := summarizeStderr("  \n\n  "); got != "" {
+		t.Errorf("all-blank input = %q, want empty", got)
+	}
+	many := ""
+	for i := 0; i < 20; i++ {
+		many += "line\n"
+	}
+	got := summarizeStderr(many)
+	if lines := len(splitNonEmpty(got)); lines > 4 {
+		t.Errorf("summary kept %d lines, want <= 4", lines)
+	}
+	long := ""
+	for i := 0; i < 1000; i++ {
+		long += "x"
+	}
+	if got := summarizeStderr(long); len([]rune(got)) > 601 {
+		t.Errorf("summary length = %d runes, want <= 601 (600 + ellipsis)", len([]rune(got)))
+	}
+}
+
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
 }

--- a/panel-api/internal/api/admin_updates.go
+++ b/panel-api/internal/api/admin_updates.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -205,10 +206,17 @@ func (h *adminUpdatesHandler) repairDomainOrphansPrune(c *gin.Context) {
 
 // --- apt -------------------------------------------------------------------
 
-// aptCheckResult mirrors the agent's system.apt_check wire shape.
+// aptCheckResult mirrors the agent's system.apt_check wire shape. Error is the
+// structured diagnostic (JAB-10) present when the check itself failed (apt lock,
+// repo unreachable, …); when set, Total/SecurityTotal are meaningless.
 type aptCheckResult struct {
 	Total         int `json:"total"`
 	SecurityTotal int `json:"security_total"`
+	Error         *struct {
+		Reason   string `json:"reason"`
+		Command  string `json:"command"`
+		ExitCode int    `json:"exit_code"`
+	} `json:"error"`
 }
 
 func (h *adminUpdatesHandler) aptCheck(c *gin.Context) {
@@ -216,11 +224,17 @@ func (h *adminUpdatesHandler) aptCheck(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if h.cfg.State != nil {
-		var r aptCheckResult
-		if json.Unmarshal(raw, &r) == nil {
-			_ = h.cfg.State.UpsertApt(c.Request.Context(), r.Total, r.SecurityTotal, time.Now())
-		}
+	// Persist the counts only on a clean check. On a structured failure
+	// (JAB-10) we do NOT UpsertApt — clobbering the last-known-good total
+	// with a failed-check 0 would misreport "0 updates" as if healthy.
+	var r aptCheckResult
+	decoded := json.Unmarshal(raw, &r) == nil
+	if h.cfg.State != nil && decoded && r.Error == nil {
+		_ = h.cfg.State.UpsertApt(c.Request.Context(), r.Total, r.SecurityTotal, time.Now())
+	}
+	if decoded && r.Error != nil {
+		log.Printf("[updates] system.apt_check failed: reason=%s command=%q exit=%d",
+			r.Error.Reason, r.Error.Command, r.Error.ExitCode)
 	}
 	writeAgentJSON(c, raw)
 }

--- a/panel-api/internal/api/admin_updates_test.go
+++ b/panel-api/internal/api/admin_updates_test.go
@@ -111,3 +111,28 @@ func TestAdminUpdates_Stop_CallsUnitStop(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"ok":true`)
 }
+
+// JAB-10: when the agent's system.apt_check reports a structured failure
+// (apt lock etc.), the panel forwards it as a 200 body carrying the reason +
+// hint (not a bare "agent_error"), so the admin card can render diagnostics.
+func TestAdminUpdates_AptCheck_ForwardsStructuredError(t *testing.T) {
+	mock := agent.NewMockClient().On("system.apt_check", map[string]any{
+		"packages": []map[string]any{},
+		"total":    0,
+		"error": map[string]any{
+			"reason":    "apt_locked",
+			"command":   "apt-get update",
+			"exit_code": 100,
+			"stderr":    "E: Could not get lock /var/lib/dpkg/lock-frontend",
+			"hint":      "A package operation is in progress. Wait, then retry.",
+		},
+	})
+	r := newAdminUpdatesRouter(mock, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/updates/apt/check", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"reason":"apt_locked"`)
+	assert.Contains(t, rec.Body.String(), `"hint":`)
+}

--- a/panel-ui/src/hooks/useSystemUpdates.ts
+++ b/panel-ui/src/hooks/useSystemUpdates.ts
@@ -32,11 +32,23 @@ export interface AptPackage {
   security?: boolean;
 }
 
+// AptCheckError (JAB-10) — structured diagnostic when the package check itself
+// failed. reason is a stable key: apt_locked | repo_unreachable | permission |
+// command_failed. When present, total/packages are meaningless.
+export interface AptCheckError {
+  reason: string;
+  command: string;
+  exit_code: number;
+  stderr: string;
+  hint: string;
+}
+
 export interface AptCheckResult {
   packages: AptPackage[];
   total: number;
   security_total?: number;
   installed_total?: number;
+  error?: AptCheckError | null;
 }
 
 export interface RunResult {

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -131,6 +131,7 @@ import {
   useUpdateAutoupdate,
   useUpdateHistory,
   useUpdateState,
+  type AptCheckError,
   type AptCheckResult,
   type AptPackage,
   type AutoupdateConfig,
@@ -568,6 +569,94 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
   );
 }
 
+// aptErrorMeta maps a structured apt-check failure reason (JAB-10) to a title
+// and Alert severity. apt_locked is a transient "in progress" state (warning),
+// the rest are real errors.
+function aptErrorMeta(reason: string): { title: string; type: "warning" | "error" } {
+  switch (reason) {
+    case "apt_locked":
+      return { title: "A package operation is in progress", type: "warning" };
+    case "repo_unreachable":
+      return { title: "Couldn't reach the package repositories", type: "error" };
+    case "permission":
+      return { title: "Insufficient privileges to check packages", type: "error" };
+    default:
+      return { title: "Couldn't check system packages", type: "error" };
+  }
+}
+
+// SystemPackagesError renders the structured apt-check diagnostic (JAB-10):
+// a plain-language reason + recovery hint, the failed command / exit code /
+// stderr under a collapse, and a Retry. When a lock is held by a running apt
+// upgrade the retry is disabled so we don't stack duplicate checks.
+function SystemPackagesError({
+  err,
+  running,
+  retrying,
+  onRetry,
+}: {
+  err: AptCheckError;
+  running: boolean;
+  retrying: boolean;
+  onRetry: () => void;
+}) {
+  const meta = aptErrorMeta(err.reason);
+  const lockedDuringRun = err.reason === "apt_locked" && running;
+  return (
+    <Alert
+      type={meta.type}
+      showIcon
+      style={{ marginTop: 8 }}
+      message={meta.title}
+      description={
+        <Space direction="vertical" size={8} style={{ width: "100%" }}>
+          <Text>{err.hint}</Text>
+          <Collapse
+            ghost
+            size="small"
+            items={[
+              {
+                key: "details",
+                label: "Diagnostics",
+                children: (
+                  <Space direction="vertical" size={2} style={{ width: "100%" }}>
+                    <Text type="secondary">
+                      Command: <Text code>{err.command}</Text>
+                      {err.exit_code >= 0 ? <> · exit {err.exit_code}</> : null}
+                    </Text>
+                    {err.stderr ? (
+                      <pre
+                        style={{
+                          margin: 0,
+                          whiteSpace: "pre-wrap",
+                          fontSize: 12,
+                          maxHeight: 160,
+                          overflow: "auto",
+                        }}
+                      >
+                        {err.stderr}
+                      </pre>
+                    ) : null}
+                  </Space>
+                ),
+              },
+            ]}
+          />
+          <Button
+            size="small"
+            icon={<ReloadOutlined />}
+            loading={retrying}
+            disabled={lockedDuringRun}
+            onClick={onRetry}
+          >
+            {lockedDuringRun ? "Waiting for the update to finish…" : "Retry"}
+          </Button>
+        </Space>
+      }
+    />
+  );
+}
+
 // --- System Packages card --------------------------------------------------
 
 function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }) {
@@ -634,6 +723,17 @@ function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }
         <div style={{ textAlign: "center", padding: 24 }}>
           <Spin />
         </div>
+      ) : result?.error ? (
+        // JAB-10: the check ran but apt failed — surface the real reason
+        // (lock / repo / perms / command) instead of a bare "up to date" or
+        // a generic error. When a lock is held by a running apt upgrade we
+        // disable the retry so we don't pile on duplicate checks.
+        <SystemPackagesError
+          err={result.error}
+          running={running}
+          retrying={check.isPending}
+          onRetry={() => check.mutate()}
+        />
       ) : result && result.total === 0 ? (
         <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="System is up to date" />
       ) : result ? (


### PR DESCRIPTION
Closes JAB-10 (Plane) — high.

The System Packages card showed a bare **"Couldn't check system packages"** on any apt failure (usually the dpkg lock held by a running upgrade). No reason, command, exit code, or stderr — and the failed check clobbered the stored total to 0, so the card could even read "System is up to date" while broken.

## Changes
- **Agent `system.apt_check`** — on failure, return a structured `error` (in a normal response, not a bare agent error): `{reason, command, exit_code, stderr, hint}`. `classifyAptError` maps stderr → a stable reason: `apt_locked` / `repo_unreachable` / `permission` / `command_failed`, each with a recovery hint. stderr is trimmed + length-capped.
- **Panel `admin_updates.go`** — forwards the structured error to the UI; **skips `UpsertApt` on a failed check** so a transient failure never overwrites the last-known-good count with 0; logs the failure server-side.
- **UI (System Packages card)** — branches on `result.error` **first** (a failed check no longer falls through to "up to date"). New `SystemPackagesError` shows the reason + hint, with command / exit code / stderr under a "Diagnostics" collapse, and a Retry. `apt_locked` renders as a warning; when a lock is held by an active apt run the Retry is **disabled** ("Waiting for the update to finish…") so duplicate checks don't stack.

## Acceptance criteria
- [x] Failure produces a stored/logged structured error with exit code + stderr summary
- [x] Card shows a concise admin-facing reason, not just "Couldn't check system packages"
- [x] apt/dpkg lock during an active update → lock/in-progress message + retry disabled
- [x] Independent check succeeds while a panel update runs, or explains the real failure
- [x] Retry performs a fresh check without a page reload
- [x] Tests cover success, apt lock, command failure, network/repository failure, malformed output

## Test plan
- [x] `go build`, `go vet`, panel-agent + panel-api unit tests green (new `classifyAptError`, malformed-parse, `summarizeStderr`, and handler error-forwarding tests)
- [x] `npx tsc -b` clean
- [ ] Live: trigger apt lock (hold `/var/lib/dpkg/lock-frontend`) → card shows the lock reason + disabled retry
