### PR TITLE
fix(migration): roll back restore side effects on failed row insert (JAB-57)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -183,14 +183,23 @@ func ImportDatabases(
 			UpdatedAt: time.Now().UTC(),
 		}
 		if err := dbsRepo.Create(ctx, row); err != nil {
-			// Schema is materialised, dump is loaded, but the
-			// panel's row failed to land. Operator can SQL the
-			// row in by hand from logs, or re-run import (the
-			// idempotent check above will skip the existing
-			// DB, but databases row insert here is what fails).
-			// Surface the error rather than silent — restore
-			// stage caller decides whether to retry.
-			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: databases row insert failed: %v", finalName, err))
+			// JAB-57: schema is materialised + the dump is loaded, but the
+			// panel's row failed to land. Without compensation this leaves
+			// an INVISIBLE restored database (customer data the UI, quota,
+			// backups, and user-deletion cleanup never see) and a resume
+			// gets worse — the collision check keys on DB rows, not system
+			// state. Roll the side effect back: drop the restored DB so the
+			// system matches the (absent) panel row and a retry re-imports
+			// cleanly from the tarball dump. Safe on migration targets
+			// (freshly provisioned; M35 restores INTO new accounts).
+			dropCtx, dcancel := context.WithTimeout(ctx, 30*time.Second)
+			_, dropErr := agentClient.Call(dropCtx, "db.drop", map[string]any{"db_name": finalName})
+			dcancel()
+			if dropErr != nil {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("%s: databases row insert failed AND rollback db.drop failed (orphan DB may remain): row=%v drop=%v", finalName, err, dropErr))
+			} else {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("%s: databases row insert failed; restored DB rolled back: %v", finalName, err))
+			}
 			continue
 		}
 		res.Created++
@@ -223,7 +232,14 @@ func ImportDatabases(
 						UpdatedAt:    time.Now().UTC(),
 					}
 					if duErr := dbUsersRepo.Create(ctx, duRow); duErr != nil {
-						res.Skipped = append(res.Skipped, fmt.Sprintf("%s: database_users row: %v", finalName, duErr))
+						// JAB-57: the MariaDB user exists but its panel row
+						// failed — an orphaned credential the panel doesn't
+						// manage. Drop the user so no unmanaged login survives;
+						// retry recreates it.
+						duDropCtx, duDropCancel := context.WithTimeout(ctx, 30*time.Second)
+						_, _ = agentClient.Call(duDropCtx, "db_user.drop", map[string]any{"db_user_name": finalName})
+						duDropCancel()
+						res.Skipped = append(res.Skipped, fmt.Sprintf("%s: database_users row failed; MariaDB user rolled back: %v", finalName, duErr))
 					} else {
 						grantCtx, grantCancel := context.WithTimeout(ctx, 30*time.Second)
 						_, grantErr := agentClient.Call(grantCtx, "db_user.grant", map[string]any{

--- a/panel-api/internal/migrate/cpanel/restore_domains.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains.go
@@ -140,7 +140,21 @@ func ImportDomains(
 		applyMigratedHtaccess(filepath.Join(docRoot, ".htaccess"), domainName, d, res)
 
 		if err := domainsRepo.Create(ctx, d); err != nil {
-			res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed:%s:%v", domainName, err))
+			// JAB-57: domain.create already built the nginx vhost (+ enabled
+			// symlink) but the panel row failed to land — an unmanaged vhost
+			// that serves traffic and collides with a retry (whose collision
+			// check keys on the domains row, now absent). Roll it back:
+			// domain.delete removes the vhost + reloads nginx. The docroot
+			// under /home is left (harmless; overwritten by the home-split
+			// rsync on retry) — only the serving/system state is reverted.
+			delCtx, dcancel := context.WithTimeout(ctx, 60*time.Second)
+			_, delErr := agentCli.Call(delCtx, "domain.delete", map[string]string{"domain": domainName})
+			dcancel()
+			if delErr != nil {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_AND_vhost_rollback_failed:%s:row=%v:delete=%v", domainName, err, delErr))
+			} else {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:db_create_failed_vhost_rolled_back:%s:%v", domainName, err))
+			}
 			continue
 		}
 		res.Created++

--- a/panel-api/internal/migrate/cpanel/restore_orphan_rollback_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_orphan_rollback_test.go
@@ -1,0 +1,118 @@
+package cpanel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-57: privileged restore side effects must not outlive a failed panel row
+// insert. These tests force the repository Create to fail *after* the mocked
+// agent call succeeds and assert the compensating cleanup (db.drop /
+// domain.delete) fires, so no invisible restored DB or unmanaged vhost is left.
+
+// rollbackAgent records every command it receives (with the db_name / domain
+// arg) and always succeeds, so the failure under test is the row insert.
+type rollbackAgent struct{ calls []string }
+
+func (a *rollbackAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	arg := ""
+	switch m := params.(type) {
+	case map[string]any:
+		if v, ok := m["db_name"].(string); ok {
+			arg = v
+		}
+	case map[string]string:
+		if v, ok := m["domain"]; ok {
+			arg = v
+		}
+	}
+	a.calls = append(a.calls, command+":"+arg)
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *rollbackAgent) called(want string) bool {
+	for _, c := range a.calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// failingDBRepo: the DB does not already exist, but every Create fails.
+type failingDBRepo struct{ repository.DatabaseRepository }
+
+func (failingDBRepo) ExistsByUserAndName(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+func (failingDBRepo) Create(context.Context, *models.Database) error {
+	return errors.New("simulated databases row insert failure")
+}
+
+func TestImportDatabases_RollsBackRestoredDBOnRowFailure(t *testing.T) {
+	dir := t.TempDir()
+	dump := filepath.Join(dir, "alice_shop.sql")
+	if err := os.WriteFile(dump, []byte("-- dump\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ag := &rollbackAgent{}
+	parsed := &ParsedTarball{MySQLDumps: []string{dump}, ExtractDir: dir, SourceUser: "alice"}
+
+	res, err := ImportDatabases(context.Background(), failingDBRepo{}, nil, nil, ag,
+		parsed, "01USERULID0000000000000000", "alice", false)
+	if err != nil {
+		t.Fatalf("ImportDatabases returned hard error, want per-entry skip: %v", err)
+	}
+	if res.Created != 0 {
+		t.Fatalf("res.Created = %d, want 0 (row insert failed)", res.Created)
+	}
+	// db.create + db.restore ran, then the row failed → db.drop must roll it back.
+	if !ag.called("db.drop:alice_shop") {
+		t.Fatalf("expected compensating db.drop:alice_shop after row-insert failure; calls=%v", ag.calls)
+	}
+	// The skip note must explain the rollback (deterministic, not silent).
+	joined := strings.Join(res.Skipped, "|")
+	if !strings.Contains(joined, "rolled back") {
+		t.Errorf("skip note should record the rollback; got %q", joined)
+	}
+}
+
+// failingDomainRepo: the domain does not already exist, but every Create fails.
+type failingDomainRepo struct{ repository.DomainRepository }
+
+func (failingDomainRepo) FindByName(context.Context, string) (*models.Domain, error) {
+	return nil, errors.New("not found")
+}
+func (failingDomainRepo) Create(context.Context, *models.Domain) error {
+	return errors.New("simulated domains row insert failure")
+}
+
+func TestImportDomains_RollsBackVhostOnRowFailure(t *testing.T) {
+	ag := &rollbackAgent{}
+	parsed := &ParsedTarball{DomainNames: []string{"example.com"}}
+
+	res, err := ImportDomains(context.Background(), failingDomainRepo{}, ag,
+		parsed, "01USERULID0000000000000000", "alice")
+	if err != nil {
+		t.Fatalf("ImportDomains returned hard error, want per-entry skip: %v", err)
+	}
+	if res.Created != 0 {
+		t.Fatalf("res.Created = %d, want 0 (row insert failed)", res.Created)
+	}
+	// domain.create ran, then the row failed → domain.delete must roll it back.
+	if !ag.called("domain.delete:example.com") {
+		t.Fatalf("expected compensating domain.delete:example.com after row-insert failure; calls=%v", ag.calls)
+	}
+	joined := strings.Join(res.Skipped, "|")
+	if !strings.Contains(joined, "vhost_rolled_back") {
+		t.Errorf("skip note should record the vhost rollback; got %q", joined)
+	}
+}


### PR DESCRIPTION
Closes JAB-57 (Plane) — high.

Migration writers applied privileged system-side changes **before** the panel DB row was persisted. If the agent call succeeded but the row insert failed, Jabali left orphaned state outside its source of truth:
- an **invisible restored MariaDB database** (customer data the UI, quota, backups, and user-deletion cleanup never see), or
- an **unmanaged nginx vhost** that serves traffic and collides with a retry (whose collision check keys on the now-absent DB row).

## Fix — compensating cleanup on post-agent row-insert failure
- **`ImportDatabases`** — `dbsRepo.Create` fails after `db.create`+`db.restore` → **`db.drop`** the restored DB. Safe on migration targets (freshly provisioned, restore-into-new-account per M35); retry re-imports from the tarball dump.
- **`ImportDatabases`** — `dbUsersRepo.Create` fails after `db_user.create` → **`db_user.drop`** the orphaned MariaDB user.
- **`ImportDomains`** — `domainsRepo.Create` fails after `domain.create` → **`domain.delete`** the nginx vhost (+ reload). The docroot under `/home` is left (harmless; overwritten by the home-split rsync on retry) — only serving state reverts.

Each skip note records the rollback deterministically, and flags if the rollback *itself* failed (so an operator sees a possible orphan instead of silence). After rollback the DB/domain no longer exist, so the collision checks (`ExistsByUserAndName` / `FindByName`) pass and a retry re-creates cleanly — no manual SQL/shell.

## Acceptance criteria
- [x] A databases-row failure after `db.restore` doesn't leave an invisible restored DB (rolled back)
- [x] A domains-row failure after `domain.create` doesn't leave an unmanaged vhost (rolled back)
- [x] Retries converge without manual cleanup

## Test plan
- [x] New tests force `Create` to fail after successful mocked agent calls; assert `db.drop` / `domain.delete` fire, `res.Created == 0`, and the skip note records the rollback
- [x] `go build`, `go vet`, full `internal/migrate/cpanel` suite green

## Note
Scope is the two writers named in the issue (+ the adjacent db_user in the same loop). The `domain.email_enable` → `UpdateEmailState` path leaves a *visible, managed* domain row (email flag only), not an invisible orphan, so it's out of scope here.
