### PR TITLE
fix(update): self-heal origin remote in the update check (unblock stranded clients)

### DIFF
--- a/panel-agent/internal/commands/system_update_check.go
+++ b/panel-agent/internal/commands/system_update_check.go
@@ -117,6 +117,26 @@ func systemUpdateCheckHandler(ctx context.Context, raw json.RawMessage) (any, er
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
+	// Self-heal the origin remote BEFORE fetching. A client whose origin still
+	// points at the retired Codeberg / self-hosted-gitea mirror (git.jabali-
+	// panel.com / git.linux-hosting.co.il / codeberg.org) would fetch a frozen
+	// ref, report "up to date" forever, and never trigger the update that
+	// migrates it — a deadlock, since the migrating rewrite in update.go only
+	// runs on an actual update the UI won't offer. Mirror that rewrite here so
+	// the *check* itself repoints to GitHub (the source of truth after the
+	// 2026-07 cutover), fetches real commits, and surfaces the backlog. No-op
+	// once origin is already GitHub. Best-effort — a get-url/set-url hiccup
+	// must not fail the check.
+	if urlOut, uerr := runAsServiceUser(ctx, "git", "-C", systemRepoDir, "remote", "get-url", "origin"); uerr == nil {
+		u := strings.TrimSpace(string(urlOut))
+		if strings.Contains(u, "codeberg.org") ||
+			strings.Contains(u, "git.linux-hosting.co.il") ||
+			strings.Contains(u, "git.jabali-panel.com") {
+			_, _ = runAsServiceUser(ctx, "git", "-C", systemRepoDir,
+				"remote", "set-url", "origin", "https://github.com/shukiv/jabali-panel.git")
+		}
+	}
+
 	// Resolve the channel target ref to compare against.
 	// Always fetch main (required). It also keeps RemoteSHA/branch sane.
 	if _, err := runAsServiceUser(ctx, "git", "-C", systemRepoDir, "fetch", "--quiet", "origin", "main"); err != nil {


### PR DESCRIPTION
**Production incident fix (hardening layer).**

The update check is git-based (`git fetch origin main` + count `HEAD..origin/main`). After the Codeberg→GitHub cutover, clients whose `origin` still pointed at the retired mirror (codeberg.org / git.linux-hosting.co.il / git.jabali-panel.com) fetched a **frozen** ref → reported **"up to date" forever** → never triggered the update that migrates `origin` to GitHub. Deadlock: update.go's origin rewrite only runs during an actual update the UI never offered.

**Fix:** mirror update.go's rewrite in `system.update_check` — before fetching, if `origin` is a retired mirror, repoint it to GitHub. The check then fetches real commits and surfaces the backlog, so the UI offers the update. No-op once `origin` is GitHub; best-effort so a get-url/set-url hiccup never fails the check.

**Scope note:** this hardens *future* checks. Clients already frozen at the final cutover commit (`ddf7679b`) predate this code, so they still need the **one-time Codeberg re-sync** (advancing codeberg/main to github's content) to receive any new build — after which this self-heal keeps them healthy.

## Test plan
- [x] `go build`, `go vet` clean
- [ ] Live: a box with `origin` = codeberg → run check → `origin` becomes GitHub, backlog appears