### PR TITLE
security(crowdsec): surface Kratos-flow rate-limit hits in Security → CrowdSec (JAB-106)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -565,6 +565,7 @@ install_module_security() {
   install_login_allowlist_default_conf
   install_crowdsec_jabali_scenarios
   install_crowdsec_jabali_stalwart_scenarios
+  install_crowdsec_jabali_kratos_scenarios
   install_crowdsec_blocklists
   install_malware_stack
   install_ufw
@@ -8358,6 +8359,58 @@ install_crowdsec_jabali_stalwart_scenarios() {
   fi
 }
 
+install_crowdsec_jabali_kratos_scenarios() {
+  # JAB-106: surface the panel's Kratos-flow rate-limit marker
+  # (marker=kratos_flow_rate_limited, from JAB-4 / PR #139) in the
+  # Security -> CrowdSec dashboard. Drops the panel acquis + parser +
+  # leaky scenario into the CrowdSec config tree, with the same
+  # write-on-diff (parser/acquis) + seed-only (scenario) discipline as
+  # install_crowdsec_jabali_stalwart_scenarios.
+  local src="${REPO_DIR}/install/crowdsec/panel"
+  if [[ ! -d "$src" ]]; then
+    _warn "install/crowdsec/panel not present in repo — skipping panel/Kratos CrowdSec wiring"
+    return 0
+  fi
+
+  install -d -m 0755 /etc/crowdsec/parsers/s01-parse
+  install -d -m 0755 /etc/crowdsec/scenarios
+  install -d -m 0755 /etc/crowdsec/acquis.d
+
+  local changed=0 f base dst
+  # parser + acquis: write-on-diff (jabali-owned, never touched at runtime).
+  for f in "$src"/parsers/s01-parse/jabali-panel-*.yaml \
+           "$src"/acquis.d/jabali-panel*.yaml; do
+    [[ -e "$f" ]] || continue
+    base="$(basename "$f")"
+    case "$f" in
+      */parsers/*) dst="/etc/crowdsec/parsers/s01-parse/$base" ;;
+      */acquis.d/*) dst="/etc/crowdsec/acquis.d/$base" ;;
+    esac
+    if [[ ! -f "$dst" ]] || ! cmp -s "$f" "$dst"; then
+      install -m 0644 -o root -g root "$f" "$dst"
+      changed=1
+      _log "wrote $dst"
+    fi
+  done
+  # scenarios: SEED-ONLY. The panel-agent's security.crowdsec.sensitivity.apply
+  # verb rewrites these at runtime to apply relaxed/strict thresholds; write-on-
+  # diff here would clobber the operator's preset on every `jabali update`.
+  for f in "$src"/scenarios/jabali-kratos-*.yaml; do
+    [[ -e "$f" ]] || continue
+    base="$(basename "$f")"
+    dst="/etc/crowdsec/scenarios/$base"
+    if [[ ! -f "$dst" ]]; then
+      install -m 0644 -o root -g root "$f" "$dst"
+      changed=1
+      _log "wrote $dst"
+    fi
+  done
+
+  if (( changed )); then
+    systemctl reload crowdsec 2>/dev/null || systemctl restart crowdsec 2>/dev/null || true
+  fi
+}
+
 install_crowdsec_jabali_scenarios() {
   # Seed jabali-owned CrowdSec scenarios that target the panel itself.
   # Three rules:
@@ -13060,6 +13113,7 @@ main() {
   run_if_module security install_login_allowlist_default_conf
   run_if_module security install_crowdsec_jabali_scenarios
   run_if_module security install_crowdsec_jabali_stalwart_scenarios
+  run_if_module security install_crowdsec_jabali_kratos_scenarios
   run_if_module security install_crowdsec_blocklists
   cleanup_modsecurity
   run_if_module security install_malware_stack

--- a/install/crowdsec/panel/acquis.d/jabali-panel.yaml
+++ b/install/crowdsec/panel/acquis.d/jabali-panel.yaml
@@ -1,0 +1,15 @@
+# Managed by jabali install.sh (JAB-106).
+# Source jabali-panel structured logs from systemd-journald. panel-api logs
+# to stdout; in production the slog handler emits JSON (config auto-upgrades
+# env=production to JSON unless LOG_FORMAT=text). systemd captures those lines
+# under jabali-panel.service; CrowdSec tails them here. Same journalctl ingest
+# shape as the Stalwart acquis (install/crowdsec/stalwart/acquis.d/).
+#
+# Today this feeds the JAB-4 rate-limit marker (marker=kratos_flow_rate_limited)
+# into the jabali/kratos-flow-bf scenario; any future panel security markers
+# can reuse this acquisition + a sibling parser node.
+source: journalctl
+journalctl_filter:
+  - "_SYSTEMD_UNIT=jabali-panel.service"
+labels:
+  type: jabali-panel

--- a/install/crowdsec/panel/parsers/s01-parse/jabali-panel-kratos.yaml
+++ b/install/crowdsec/panel/parsers/s01-parse/jabali-panel-kratos.yaml
@@ -1,0 +1,37 @@
+# Managed by jabali install.sh (JAB-106).
+# Parse the panel's Kratos-flow rate-limit marker (JAB-4 / PR #139). The
+# limiter on /.ory self-service login+recovery emits, per throttled request:
+#
+#   JSON  (production): {"time":...,"level":"WARN","msg":"kratos flow rate limited",
+#                        "marker":"kratos_flow_rate_limited","flow":"login",
+#                        "client_ip":"1.2.3.4","path":"/.ory/self-service/login/..."}
+#   text  (LOG_FORMAT=text): time=... level=WARN msg="kratos flow rate limited"
+#                        marker=kratos_flow_rate_limited flow=login
+#                        client_ip=1.2.3.4 path=/.ory/self-service/login/...
+#
+# The filter keys on the marker SUBSTRING (present in both shapes, order-
+# independent), and the grok extracts client_ip with a format-agnostic
+# `client_ip[=:] "?<ip>"?` so it matches JSON and text alike — no reliance on
+# slog attribute order. This mirrors the risk-aversion of the Stalwart parser:
+# validate against a live CrowdSec instance (cscli explain) before trusting it.
+name: jabali/panel-kratos
+description: "Parse jabali-panel Kratos-flow rate-limit markers from journalctl"
+
+filter: "evt.Line.Labels.type == 'jabali-panel' && evt.Line.Raw contains 'kratos_flow_rate_limited'"
+onsuccess: next_stage
+nodes:
+  - grok:
+      # Extract the client IP regardless of JSON ("client_ip":"1.2.3.4") or
+      # logfmt (client_ip=1.2.3.4) rendering. The optional `"?` after the key
+      # eats the JSON key's closing quote (`"client_ip":`) so both the JSON
+      # `":"` and the logfmt `=` separators match.
+      pattern: 'client_ip"?\s*[=:]\s*"?%{IP:client_ip}"?'
+      apply_on: Line.Raw
+
+statics:
+  - meta: service
+    value: jabali-panel
+  - meta: source_ip
+    expression: evt.Parsed.client_ip
+  - meta: log_type
+    value: kratos_flow_rate_limited

--- a/install/crowdsec/panel/scenarios/jabali-kratos-flow-bf.yaml
+++ b/install/crowdsec/panel/scenarios/jabali-kratos-flow-bf.yaml
@@ -1,0 +1,32 @@
+# Managed by jabali install.sh (JAB-106). Mirrors the shape of
+# install/crowdsec/stalwart/scenarios/jabali-stalwart-auth-bf.yaml.
+# Capacity / leakspeed / blackhole may be overwritten at runtime by the
+# panel-agent's security.crowdsec.sensitivity.apply verb (relaxed/strict).
+#
+# Kratos self-service brute-force: each parsed event is already a request the
+# panel THROTTLED (JAB-4), i.e. an IP hammering /.ory login/recovery past the
+# per-IP limit. A handful from one IP = a persistent attacker → ban, so the
+# Security → CrowdSec dashboard shows what the limiter alone couldn't.
+type: leaky
+name: jabali/kratos-flow-bf
+description: "Detect brute force on Kratos self-service login/recovery flows (panel-throttled)"
+
+filter: evt.Meta.log_type == 'kratos_flow_rate_limited'
+
+# Group by source IP to track per-attacker.
+groupby: evt.Meta.source_ip
+
+# 5 throttle-hits within the window → ban. These lines only appear once an IP is
+# ALREADY over the panel's rate limit, so the threshold is deliberately low.
+leakspeed: "30s"
+capacity: 5
+
+# Silence after triggering to reduce alert spam.
+blackhole: "1m"
+
+labels:
+  service: jabali-panel
+  type: bruteforce
+  remediation: true
+  confidence: 3
+  spoofable: 0


### PR DESCRIPTION
Closes JAB-106 (Plane) — the visibility half of JAB-4.

JAB-4 (PR #139) throttles /.ory login/recovery and emits a WARN marker (`marker=kratos_flow_rate_limited client_ip=...`) — but nothing turned it into a CrowdSec ban or dashboard signal. This adds the pipeline, **mirroring the proven Stalwart CrowdSec bundle** to minimize parser risk.

## Changes
- **`install/crowdsec/panel/acquis.d/jabali-panel.yaml`** — journalctl source filtered to `_SYSTEMD_UNIT=jabali-panel.service` (`labels.type: jabali-panel`).
- **`install/crowdsec/panel/parsers/s01-parse/jabali-panel-kratos.yaml`** — filters on the marker substring, extracts `client_ip` → `evt.Meta.source_ip`. **Format-agnostic grok** `client_ip"?\s*[=:]\s*"?<ip>"?`: production logs are JSON (`"client_ip":"1.2.3.4"`), `LOG_FORMAT=text` (`client_ip=1.2.3.4`) also matches.
- **`install/crowdsec/panel/scenarios/jabali-kratos-flow-bf.yaml`** — leaky bucket by `source_ip` (capacity 5 / leakspeed 30s → ban), mirroring `jabali-stalwart-auth-bf`. Low threshold: each event is already a throttled request.
- **`install.sh`** — `install_crowdsec_jabali_kratos_scenarios` (write-on-diff parser+acquis, seed-only scenario) wired into `install_module_security` + the `run_if_module security` path.

## Validation
- [x] `bash -n install.sh`; fn defined + called (phantom-lint safe)
- [x] client_ip grok unit-checked in Python vs JSON / logfmt / IPv6 (an earlier draft silently missed JSON — the exact "parser never matches" scar the issue flagged; fixed by handling the JSON key's closing quote)
- [ ] **Live `cscli explain` on a CrowdSec host** — the issue explicitly requires this before trusting grok/scenario correctness; that's the remaining step to fully close JAB-106.

Provenance/discipline mirrors `install/crowdsec/stalwart/` (write-on-diff configs, seed-only scenarios so `security.crowdsec.sensitivity.apply` isn't clobbered on update).
