### PR TITLE
fix(apparmor): gate flip-mature on a clean soak — zero denials (JAB-17)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -293,7 +293,7 @@ jabali apparmor
 
 #### `jabali apparmor flip-mature`
 
-Flip mature complain-mode profiles to enforce
+Flip soak-clean complain-mode profiles to enforce
 
 ```
 jabali apparmor flip-mature [flags]
@@ -302,7 +302,9 @@ jabali apparmor flip-mature [flags]
 **Flags:**
 
 - `--dry-run` — show what would change without invoking aa-enforce
+- `--force` — flip even if recent denials exist (DANGEROUS — this is how #705 crash-looped mx)
 - `--profile` — Flip a single profile only
+- `--soak-days` — denial-scan window in days; a profile with any AppArmor DENIED in this window is not flipped (default `7`)
 
 #### `jabali apparmor status`
 

--- a/panel-api/cmd/server/apparmor_cmd.go
+++ b/panel-api/cmd/server/apparmor_cmd.go
@@ -1,7 +1,12 @@
 // `jabali apparmor flip-mature` — operator-driven flip of jabali
-// AppArmor profiles from complain to enforce. Lists profiles in
-// complain mode older than --soak-days (default 7) and flips them
-// via aa-enforce. Honors per-profile filter via --profile.
+// AppArmor profiles from complain to enforce. For each complain-mode
+// jabali profile it scans the kernel log for AppArmor DENIED events in
+// the last --soak-days (default 7) and flips ONLY profiles with zero
+// denials (a clean soak). A profile that is still denying is skipped
+// with the pending denials surfaced — flipping it would EACCES the
+// daemon's real syscalls and crash-loop it (JAB-17 / GH #705, which is
+// exactly how mx went down). --force overrides the gate; --profile
+// targets one.
 //
 // See ADR-0086 + plans/m40-apparmor-jabali-daemons.md Step 5.
 
@@ -83,12 +88,19 @@ func newAppArmorFlipMatureCmd() *cobra.Command {
 	var (
 		profileFilter string
 		dryRun        bool
+		soakDays      int
+		force         bool
 	)
 	cmd := &cobra.Command{
 		Use:     "flip-mature",
-		Short:   "Flip mature complain-mode profiles to enforce",
+		Short:   "Flip soak-clean complain-mode profiles to enforce",
 		PreRunE: requireAgent,
-		Long: `Find AppArmor profiles in complain mode and flip them to enforce.
+		Long: `Find AppArmor profiles in complain mode and flip them to enforce,
+but only when they are soak-clean: zero kernel AppArmor DENIED events in
+the last --soak-days (default 7). A still-denying profile is skipped and
+its pending denials are shown — flipping it would EACCES the daemon and
+crash-loop it (JAB-17 / GH #705). Add the missing allow rules, keep
+soaking, and re-run. --force flips despite denials (DANGEROUS).
 Limits the flip to the jabali-shipped allowlist; never touches
 arbitrary system profiles. Use --profile <name> to target one.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -120,8 +132,30 @@ arbitrary system profiles. Use --profile <name> to target one.`,
 				return nil
 			}
 
-			fmt.Printf("apparmor flip-mature: %d candidates\n", len(toFlip))
+			fmt.Printf("apparmor flip-mature: %d complain-mode candidate(s); soak window %dd\n", len(toFlip), soakDays)
+			flipped, skipped := 0, 0
 			for _, name := range toFlip {
+				// JAB-17 / GH #705 gate: never flip a profile that is still
+				// denying. A DENIED in complain is a missing allow rule that
+				// becomes a hard EACCES (and a daemon crash-loop) under enforce.
+				denials, sample, derr := apparmorRecentDenials(name, soakDays)
+				if derr != nil && !force {
+					fmt.Fprintf(os.Stderr, "  %s: SKIP — could not verify soak-cleanliness (%v); --force to override\n", name, derr)
+					skipped++
+					continue
+				}
+				if denials > 0 && !force {
+					fmt.Printf("  %s: SKIP — %d AppArmor denial(s) in the last %dd (not soak-clean)\n", name, denials, soakDays)
+					if sample != "" {
+						fmt.Printf("      e.g. %s\n", sample)
+					}
+					fmt.Printf("      Add the missing allow rule(s) to the profile and keep soaking; flipping now risks the #705 crash-loop.\n")
+					skipped++
+					continue
+				}
+				if denials > 0 && force {
+					fmt.Printf("  %s: %d denial(s) in the last %dd — flipping anyway (--force)\n", name, denials, soakDays)
+				}
 				fmt.Printf("  %s  complain → enforce\n", name)
 				if dryRun {
 					continue
@@ -136,17 +170,20 @@ arbitrary system profiles. Use --profile <name> to target one.`,
 					fmt.Fprintf(os.Stderr, "  flip %s failed: %v\n", name, err)
 					continue
 				}
+				flipped++
 			}
 			if dryRun {
-				fmt.Println("apparmor flip-mature: dry-run, no profiles flipped")
+				fmt.Printf("apparmor flip-mature: dry-run, no profiles flipped (%d would flip, %d skipped as not soak-clean)\n", len(toFlip)-skipped, skipped)
 			} else {
-				fmt.Printf("apparmor flip-mature: flipped %d profile(s) to enforce\n", len(toFlip))
+				fmt.Printf("apparmor flip-mature: flipped %d profile(s) to enforce, %d skipped\n", flipped, skipped)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&profileFilter, "profile", "", "Flip a single profile only")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show what would change without invoking aa-enforce")
+	cmd.Flags().IntVar(&soakDays, "soak-days", 7, "denial-scan window in days; a profile with any AppArmor DENIED in this window is not flipped")
+	cmd.Flags().BoolVar(&force, "force", false, "flip even if recent denials exist (DANGEROUS — this is how #705 crash-looped mx)")
 	return cmd
 }
 
@@ -171,4 +208,48 @@ func listJabaliApparmorProfiles() (map[string]string, error) {
 		out2[name] = mode
 	}
 	return out2, nil
+}
+
+// apparmorRecentDenials counts kernel AppArmor "DENIED" events for the given
+// profile within the last `days` days (JAB-17). A non-zero count means the
+// profile is NOT soak-clean: flipping it to enforce would turn those logged-
+// but-permitted denials into hard EACCES and crash-loop the daemon (GH #705).
+// Returns the count + one sample line. Fails closed (returns the error) rather
+// than reporting a false "clean" when journalctl can't be read.
+func apparmorRecentDenials(profile string, days int) (int, string, error) {
+	args := []string{"-k", "--no-pager"}
+	if days > 0 {
+		args = append(args, "--since", fmt.Sprintf("%d days ago", days))
+	} else {
+		// A non-positive window would scan ~nothing via --since; fall back to
+		// the whole current boot so the gate can't be trivially bypassed.
+		args = append(args, "-b")
+	}
+	out, err := exec.Command("journalctl", args...).Output()
+	if err != nil {
+		return 0, "", fmt.Errorf("journalctl -k: %w", err)
+	}
+	count, sample := countApparmorDenials(string(out), profile)
+	return count, sample, nil
+}
+
+// countApparmorDenials scans kernel-log text for AppArmor DENIED lines naming
+// the given profile and returns the count + the first matching line. Split out
+// from apparmorRecentDenials so the match logic is unit-testable without a
+// live journal. A denial line looks like:
+//
+//	... apparmor="DENIED" operation="open" profile="jabali-panel" name="/x" ...
+func countApparmorDenials(logText, profile string) (int, string) {
+	needle := `profile="` + profile + `"`
+	count := 0
+	var sample string
+	for _, line := range strings.Split(logText, "\n") {
+		if strings.Contains(line, `apparmor="DENIED"`) && strings.Contains(line, needle) {
+			count++
+			if sample == "" {
+				sample = strings.TrimSpace(line)
+			}
+		}
+	}
+	return count, sample
 }

--- a/panel-api/cmd/server/apparmor_cmd_test.go
+++ b/panel-api/cmd/server/apparmor_cmd_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+// JAB-17: the flip-mature soak gate must recognise a still-denying profile
+// (so it refuses to flip it into the #705 crash-loop) and must not
+// cross-match a different profile's denials.
+func TestCountApparmorDenials(t *testing.T) {
+	log := `Jul 12 00:01:02 mx kernel: audit: type=1400 audit(1.2:3): apparmor="DENIED" operation="open" profile="jabali-panel" name="/etc/secret" pid=42 comm="jabali-panel" requested_mask="r" denied_mask="r"
+Jul 12 00:01:03 mx kernel: audit: type=1400 audit(1.2:4): apparmor="ALLOWED" operation="open" profile="jabali-panel" name="/ok"
+Jul 12 00:02:00 mx kernel: audit: type=1400 audit(1.2:5): apparmor="DENIED" operation="connect" profile="jabali-panel" name="/run/x.sock"
+Jul 12 00:03:00 mx kernel: audit: type=1400 audit(1.2:6): apparmor="DENIED" operation="exec" profile="stalwart-mail" name="/usr/bin/foo"`
+
+	// jabali-panel: 2 denials (the ALLOWED line and the stalwart line excluded).
+	n, sample := countApparmorDenials(log, "jabali-panel")
+	if n != 2 {
+		t.Fatalf("jabali-panel denials = %d, want 2", n)
+	}
+	if sample == "" {
+		t.Error("expected a sample denial line")
+	}
+
+	// A different profile's denials must not count toward jabali-panel.
+	if n, _ := countApparmorDenials(log, "jabali-bulwark"); n != 0 {
+		t.Errorf("jabali-bulwark denials = %d, want 0 (no cross-match)", n)
+	}
+
+	// stalwart-mail has exactly one.
+	if n, _ := countApparmorDenials(log, "stalwart-mail"); n != 1 {
+		t.Errorf("stalwart-mail denials = %d, want 1", n)
+	}
+
+	// A clean log → zero → soak-clean → flip allowed.
+	clean := `Jul 12 00:01:02 mx kernel: audit: apparmor="ALLOWED" profile="jabali-panel" name="/ok"`
+	if n, _ := countApparmorDenials(clean, "jabali-panel"); n != 0 {
+		t.Errorf("clean log denials = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
Addresses the safety core of JAB-17 (the operational soak stays operator-driven; this makes the *flip* refuse to fire unless it's safe).

**Problem:** `jabali apparmor flip-mature` flipped every complain-mode jabali profile to enforce with **no check** — the documented `--soak-days` gate wasn't even implemented. Flipping a profile that's still logging `apparmor="DENIED"` turns those permitted-in-complain accesses into hard EACCES and **crash-loops the daemon** — exactly how mx went down in #705, and precisely what JAB-17 says not to do ("do NOT flip before a clean soak").

**Fix:** flip-mature now scans `journalctl -k` for `apparmor="DENIED"` events naming each candidate profile within the last `--soak-days` (default 7) and flips **only soak-clean profiles** (zero denials). A still-denying profile is skipped with its denial count + a sample line + the hint to add the missing allow rule and keep soaking. Fails **closed** (a journalctl error skips, never flips blind).

- new `--soak-days` (default 7) + `--force` (override, loud) flags
- `countApparmorDenials` extracted as a pure, unit-tested matcher — counts a profile's DENIED lines with no cross-match to other profiles
- CLI reference golden regenerated

## Test plan
- [x] `go build`, `go vet`, `go test ./cmd/server` green (new `TestCountApparmorDenials` + golden)
- [ ] Live on a host: `jabali apparmor flip-mature --dry-run` reports soak-clean profiles as flip-eligible; a profile with a planted denial is skipped

Note: .86 soak is currently clean (profiles loaded, complain, zero denials). The production (mx) soak + final flip remain the operator's call — this just ensures the flip can't repeat #705.