### PR TITLE
fix(mail): let Stalwart unpack the WebAdmin bundle under ProtectSystem=strict

### DIFF
--- a/install/systemd/jabali-stalwart.service
+++ b/install/systemd/jabali-stalwart.service
@@ -21,6 +21,17 @@ Slice=jabali.slice
 # signatures) live as JMAP objects in Stalwart's registry, provisioned
 # via `stalwart-cli apply` at bootstrap time.
 EnvironmentFile=-/etc/jabali-panel/stalwart.env
+
+# Redirect Stalwart's temp dir into its writable data volume. Stalwart unpacks
+# downloaded application bundles — the WebAdmin SPA served at /admin (opt-in via
+# Server Settings → Stalwart WebAdmin), plus periodically-refreshed resources —
+# into the system temp dir by default. Under ProtectSystem=strict that default
+# path is read-only to the sandbox, so the unpack failed with "Permission denied
+# (os error 13) — Failed to unpack application bundle" and /admin returned 404
+# (no AppArmor denial: it's the mount-namespace, not AA). Pointing TMPDIR at a
+# pre-created dir inside ReadWritePaths lets the unpack land. Verified on .86.
+Environment=TMPDIR=/var/lib/stalwart/tmp
+ExecStartPre=/usr/bin/mkdir -p /var/lib/stalwart/tmp
 ExecStart=/usr/local/bin/stalwart --config=/etc/stalwart/config.json
 
 Restart=on-failure


### PR DESCRIPTION
Reported live: enabling **Stalwart WebAdmin (advanced)** exposed the `:8449` proxy but `/admin/` returned a Stalwart 404 — the WebAdmin SPA was never installed.

## Root cause (diagnosed on .86)
Stalwart downloads the WebAdmin bundle from GitHub and **unpacks it into the system temp dir**. The `jabali-stalwart` unit runs `ProtectSystem=strict` with `ReadWritePaths=/var/lib/stalwart /etc/stalwart /etc/jabali-panel`, so the default temp path is **read-only to the sandbox** and unpack failed:

```
ERROR Resource error reason = "Permission denied (os error 13)",
  details = "Failed to unpack application bundle",
  url = ".../stalwartlabs/webui/releases/latest/download/webui.zip"
```

Not AppArmor (the `stalwart-mail` profile is enforce but logs zero denials and already allows `/var/lib/stalwart`) — it's the systemd mount namespace. Egress was fine (the zip + ASN/Geo data downloaded).

## Fix
Point Stalwart's `TMPDIR` at a pre-created dir inside the writable data volume:
```
Environment=TMPDIR=/var/lib/stalwart/tmp
ExecStartPre=/usr/bin/mkdir -p /var/lib/stalwart/tmp
```

## Verified live on .86
After the change: `curl http://127.0.0.1:8446/admin/` → **200**, and the log shows `Application resource unpacked ... path = /var/lib/stalwart/tmp/...`. The browser `:8449/admin/` WebAdmin now loads.

## Rollout
install.sh already reinstalls this unit + `daemon-reload`s on every run, and `install_stalwart_apply` restarts Stalwart — so existing installs pick it up on their next `jabali update`.

## Test plan
- [x] Live-verified on .86 (200 + unpack log)
- [ ] Fresh-install smoke: enable WebAdmin, confirm /admin loads without a manual restart