### PR TITLE
perf(cache): fail-fast circuit breaker for Redis outages (JAB-89)

### DIFF
--- a/wp-plugins/jabali-cache/includes/class-cli.php
+++ b/wp-plugins/jabali-cache/includes/class-cli.php
@@ -64,6 +64,12 @@ class Jabali_Cache_CLI {
 		);
 		if ( ! $ok ) {
 			$rows[] = array( 'field' => 'error', 'value' => $c->last_error() );
+			// JAB-89: surface the circuit breaker so an operator sees Redis is
+			// held down (fail-fast) rather than being re-probed every request.
+			$open = $c->circuit_open_until();
+			if ( $open > 0 ) {
+				$rows[] = array( 'field' => 'circuit_open_until', 'value' => gmdate( 'c', $open ) . ' (' . max( 0, $open - time() ) . 's)' );
+			}
 		}
 		$c->close();
 		\WP_CLI\Utils\format_items( 'table', $rows, array( 'field', 'value' ) );
@@ -164,7 +170,9 @@ class Jabali_Cache_CLI {
 	 */
 	public function verify() {
 		$cfg = Jabali_Cache_Config::load();
-		$c   = new Jabali_Cache_Client( $cfg );
+		// JAB-89: force a live probe so an open circuit breaker never masks a
+		// real diagnostic run.
+		$c = ( new Jabali_Cache_Client( $cfg ) )->force_probe();
 		if ( ! $c->connect() ) {
 			\WP_CLI::error( 'Redis connect failed: ' . $c->last_error() );
 		}
@@ -194,7 +202,8 @@ class Jabali_Cache_CLI {
 		\WP_CLI::log( 'igbinary extension: ' . ( function_exists( 'igbinary_serialize' ) ? 'present' : 'absent' ) );
 		\WP_CLI::log( 'scheme/target: ' . $cfg['scheme'] . ' ' . ( 'unix' === $cfg['scheme'] ? $cfg['socket'] : $cfg['host'] . ':' . $cfg['port'] ) );
 
-		$c = new Jabali_Cache_Client( $cfg );
+		// JAB-89: diagnose forces a live probe too (bypass the breaker).
+		$c = ( new Jabali_Cache_Client( $cfg ) )->force_probe();
 		if ( $c->connect() ) {
 			\WP_CLI::success( 'Connected via ' . $c->driver() . '. Keys for this site: ' . $c->count_keys( $cfg['prefix'] ) );
 			$c->close();

--- a/wp-plugins/jabali-cache/includes/lib.php
+++ b/wp-plugins/jabali-cache/includes/lib.php
@@ -255,6 +255,24 @@ class Jabali_Cache_Client {
 	private $driver = '';
 
 	/**
+	 * @var bool When true, ignore the cross-request circuit breaker and always
+	 * attempt a live Redis connection. Set by diagnostics (wp jabali-cache
+	 * verify, panel health probes) so an open breaker can't mask a real test.
+	 * JAB-89.
+	 */
+	private $force_probe = false;
+
+	/**
+	 * Circuit breaker (JAB-89). After a connection/auth/socket failure Redis is
+	 * marked "known down" for CIRCUIT_TTL_BASE + up-to-JITTER seconds (jitter
+	 * spreads the recovery probe across a fleet). While open, connect() returns
+	 * runtime-only immediately instead of paying the per-request connect
+	 * timeout on every uncached page.
+	 */
+	const CIRCUIT_TTL_BASE   = 15;
+	const CIRCUIT_TTL_JITTER = 10;
+
+	/**
 	 * @param array<string,mixed>|null $cfg
 	 */
 	public function __construct( $cfg = null ) {
@@ -267,6 +285,30 @@ class Jabali_Cache_Client {
 
 	public function last_error() {
 		return $this->last_error;
+	}
+
+	/**
+	 * Force live Redis probes, bypassing the circuit breaker. Chainable.
+	 * Used by `wp jabali-cache verify` + panel health checks. JAB-89.
+	 *
+	 * @param bool $on
+	 * @return $this
+	 */
+	public function force_probe( $on = true ) {
+		$this->force_probe = (bool) $on;
+		return $this;
+	}
+
+	/**
+	 * Unix timestamp the circuit breaker stays open until, or 0 if closed.
+	 * Surfaced in status/diagnostics so the panel can show "Redis down until X".
+	 * JAB-89.
+	 *
+	 * @return int
+	 */
+	public function circuit_open_until() {
+		$st = $this->breaker_read();
+		return ( is_array( $st ) && isset( $st['until'] ) && (int) $st['until'] > time() ) ? (int) $st['until'] : 0;
 	}
 
 	public function is_connected() {
@@ -288,15 +330,138 @@ class Jabali_Cache_Client {
 			return false;
 		}
 
+		// JAB-89: cross-request circuit breaker. If a recent request already
+		// found Redis down, skip the connect attempt (and its timeout) and go
+		// straight to runtime-only caching until the breaker expires. Bypassed
+		// by force_probe() for diagnostics so `verify` always tests live.
+		if ( ! $this->force_probe && $this->breaker_is_open() ) {
+			$this->fail( 'redis unavailable (circuit breaker open): ' . $this->breaker_last_error() );
+			return false;
+		}
+
+		$ok = false;
 		if ( class_exists( 'Redis' ) ) {
-			if ( $this->connect_phpredis() ) {
-				return true;
-			}
 			// Fall through to pure-PHP only if phpredis is present but failed
 			// for a non-protocol reason — usually it just means unavailable,
 			// in which case pure-PHP will fail too. Try anyway; it is cheap.
+			$ok = $this->connect_phpredis();
 		}
-		return $this->connect_pure();
+		if ( ! $ok ) {
+			$ok = $this->connect_pure();
+		}
+
+		if ( $ok ) {
+			// Recovery self-heals immediately on the first successful connect,
+			// not only after the breaker TTL.
+			$this->breaker_clear();
+			return true;
+		}
+		// Both drivers failed → trip the breaker so the next requests fail fast.
+		$this->breaker_open( $this->last_error );
+		return false;
+	}
+
+	/** Storage key for this client's breaker, unique per socket/host + DB. */
+	private function breaker_key() {
+		return 'jabali_cache_cb:' . md5(
+			$this->cfg['scheme'] . '|' . $this->cfg['socket'] . '|' .
+			$this->cfg['host'] . '|' . (int) $this->cfg['port'] . '|' . (int) $this->cfg['database']
+		);
+	}
+
+	/** @return bool true while Redis is marked down. */
+	private function breaker_is_open() {
+		$st = $this->breaker_read();
+		return is_array( $st ) && isset( $st['until'] ) && (int) $st['until'] > time();
+	}
+
+	/** @return string last error recorded when the breaker tripped. */
+	private function breaker_last_error() {
+		$st = $this->breaker_read();
+		return ( is_array( $st ) && isset( $st['err'] ) ) ? (string) $st['err'] : '';
+	}
+
+	/**
+	 * Trip the breaker for CIRCUIT_TTL_BASE + jitter seconds.
+	 *
+	 * @param string $err
+	 */
+	private function breaker_open( $err ) {
+		$ttl = self::CIRCUIT_TTL_BASE + mt_rand( 0, self::CIRCUIT_TTL_JITTER );
+		$this->breaker_write(
+			array( 'until' => time() + $ttl, 'err' => (string) $err ),
+			$ttl
+		);
+	}
+
+	/** Clear the breaker (Redis is healthy again). */
+	private function breaker_clear() {
+		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() ) {
+			@apcu_delete( $this->breaker_key() ); // phpcs:ignore
+			return;
+		}
+		$f = $this->breaker_file();
+		if ( '' !== $f && is_file( $f ) ) {
+			@unlink( $f ); // phpcs:ignore
+		}
+	}
+
+	/**
+	 * Read the breaker state. APCu when available (shared across the pool's
+	 * FPM workers and cheap in the early object-cache drop-in); otherwise a
+	 * small JSON file under wp-content/cache/jabali-cache.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	private function breaker_read() {
+		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() ) {
+			$ok = false;
+			$v  = apcu_fetch( $this->breaker_key(), $ok );
+			return ( $ok && is_array( $v ) ) ? $v : null;
+		}
+		$f = $this->breaker_file();
+		if ( '' !== $f && is_file( $f ) ) {
+			$raw = @file_get_contents( $f ); // phpcs:ignore
+			$v   = $raw ? json_decode( $raw, true ) : null;
+			return is_array( $v ) ? $v : null;
+		}
+		return null;
+	}
+
+	/**
+	 * @param array<string,mixed> $st
+	 * @param int                 $ttl
+	 */
+	private function breaker_write( array $st, $ttl ) {
+		if ( function_exists( 'apcu_enabled' ) && apcu_enabled() ) {
+			@apcu_store( $this->breaker_key(), $st, (int) $ttl + 5 ); // phpcs:ignore
+			return;
+		}
+		$f = $this->breaker_file();
+		if ( '' !== $f ) {
+			@file_put_contents( $f, json_encode( $st ), LOCK_EX ); // phpcs:ignore
+		}
+	}
+
+	/**
+	 * Path to the file-fallback breaker marker, or '' when no writable cache
+	 * dir is available (then the breaker is best-effort per-request only —
+	 * still correct, just without cross-request memory).
+	 *
+	 * @return string
+	 */
+	private function breaker_file() {
+		if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+			return '';
+		}
+		$dir = WP_CONTENT_DIR . '/cache/jabali-cache';
+		if ( ! is_dir( $dir ) ) {
+			@mkdir( $dir, 0755, true ); // phpcs:ignore
+		}
+		if ( ! is_dir( $dir ) || ! is_writable( $dir ) ) {
+			return '';
+		}
+		return $dir . '/circuit-' . md5( $this->breaker_key() ) . '.json';
 	}
 
 	/**

--- a/wp-plugins/jabali-cache/tests/test-lib.php
+++ b/wp-plugins/jabali-cache/tests/test-lib.php
@@ -26,6 +26,12 @@ function jc_assert( $cond, $msg ) {
 	}
 }
 
+// lib.php guards direct access with `defined( 'ABSPATH' ) || exit;`. Define a
+// dummy so the standalone harness can require it without WordPress loaded.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
 require __DIR__ . '/../includes/lib.php';
 
 // ---------------------------------------------------------------------------
@@ -118,6 +124,51 @@ if ( $live ) {
 } else {
 	echo "Client (live): SKIP (set JABALI_TEST_REDIS=/run/redis/redis.sock to enable)\n";
 }
+
+// ---------------------------------------------------------------------------
+// Circuit breaker (JAB-89): a Redis outage must fail fast across requests.
+// Define a temp WP_CONTENT_DIR so the file-fallback store persists across
+// client instances (APCu is usually disabled in CLI).
+// ---------------------------------------------------------------------------
+echo "Circuit breaker (JAB-89):\n";
+$cb_root = sys_get_temp_dir() . '/jc-cb-test-' . getmypid();
+@mkdir( $cb_root, 0755, true );
+if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+	define( 'WP_CONTENT_DIR', $cb_root );
+}
+$cb_cfg = array_merge(
+	$cfg,
+	array( 'scheme' => 'unix', 'socket' => '/nonexistent/jc-cb.sock', 'timeout' => 0.2 )
+);
+
+// First client: connect to a dead socket fails → breaker trips.
+$cb1 = new Jabali_Cache_Client( $cb_cfg );
+jc_assert( false === $cb1->connect(), 'breaker: first connect to a dead socket fails' );
+jc_assert( $cb1->circuit_open_until() > time(), 'breaker: circuit is open after the failure' );
+jc_assert(
+	$cb1->circuit_open_until() <= time() + Jabali_Cache_Client::CIRCUIT_TTL_BASE + Jabali_Cache_Client::CIRCUIT_TTL_JITTER,
+	'breaker: open window is within the TTL bounds'
+);
+
+// Second client (same target): breaker open → fail fast with the breaker error.
+$cb2 = new Jabali_Cache_Client( $cb_cfg );
+jc_assert( false === $cb2->connect(), 'breaker: second connect fails while open' );
+jc_assert( false !== strpos( $cb2->last_error(), 'circuit breaker open' ), 'breaker: fail-fast error names the breaker' );
+
+// force_probe() bypasses the breaker → real connect attempt (still fails on a
+// dead socket, but the error is the real one, not the breaker short-circuit).
+$cb3 = ( new Jabali_Cache_Client( $cb_cfg ) )->force_probe();
+jc_assert( false === $cb3->connect(), 'breaker: force_probe still fails on a dead socket' );
+jc_assert( false === strpos( $cb3->last_error(), 'circuit breaker open' ), 'breaker: force_probe bypasses the breaker' );
+
+// Cleanup temp breaker artifacts.
+$cb_glob = glob( $cb_root . '/cache/jabali-cache/*' );
+if ( is_array( $cb_glob ) ) {
+	array_map( 'unlink', $cb_glob );
+}
+@rmdir( $cb_root . '/cache/jabali-cache' );
+@rmdir( $cb_root . '/cache' );
+@rmdir( $cb_root );
 
 echo "\n{$tests} checks, {$failed} failed\n";
 exit( $failed > 0 ? 1 : 0 );


### PR DESCRIPTION
Closes JAB-89 (Plane).

The jabali-cache client only remembered a Redis failure for the current request, so during a Redis/socket/group outage **every uncached page paid the full connect timeout** (default 1s) before falling back to runtime-only caching.

## Change — cross-request circuit breaker in `Jabali_Cache_Client`
- On a failed connect (phpredis **or** pure-PHP), trip the breaker for `CIRCUIT_TTL_BASE + jitter` (15–25s). Stored in **APCu** when available (shared across the pool's FPM workers, cheap in the early object-cache drop-in), else a small JSON file under `wp-content/cache/jabali-cache`.
- `connect()` checks the breaker first → returns runtime-only immediately while open (no per-request timeout).
- **Self-heals**: a successful connect clears the breaker, and it expires on its TTL so the next request after the window re-probes.
- `force_probe()` bypasses the breaker — wired into `wp jabali-cache verify` + `diagnose` (and thus panel health checks) so diagnostics always test live.
- `status()` gains a `circuit_open_until` row.

## Acceptance criteria
- [x] During an outage, first request pays the connection cost, subsequent requests fail fast until the breaker expires
- [x] Normal recovery self-heals after the breaker TTL (and immediately on first success)
- [x] `wp jabali-cache verify` can still force a real Redis test
- [x] Tests cover phpredis + pure-PHP failure, breaker open, and force_probe bypass (expiry is TTL-based; asserted within bounds)

## Test plan
- [x] `php -l` clean on all three files
- [x] `php tests/test-lib.php` → **21 checks, 0 failed** (incl. 7 new breaker tests). Also fixes the standalone harness, which silently exited because `lib.php` guards on `ABSPATH` — now defined before the require.

Note: this plugin's PHP tests aren't wired into CI; verified locally with the standalone harness.