### PR TITLE
perf(cache): targeted Redis page-cache purge on post edit (JAB-91)

### DIFF
--- a/wp-plugins/jabali-cache/includes/class-page-cache.php
+++ b/wp-plugins/jabali-cache/includes/class-page-cache.php
@@ -127,6 +127,68 @@ class Jabali_Cache_Page_Cache {
 		return $this->client->delete_by_pattern( $this->cfg['prefix'] . 'page:*' );
 	}
 
+	/**
+	 * Build the exact page-cache keys for a set of URL paths (JAB-91). Mirrors
+	 * request_hash(): one key per path per variant (desktop 'd' + mobile 'm'),
+	 * with any query string stripped so /p and /p?utm_x map to the same entry.
+	 * Pure + prefix-scoped so it is unit-testable without Redis.
+	 *
+	 * @param array<int,string> $paths
+	 * @param string            $scheme 'http' | 'https'
+	 * @param string            $host   host[:port], as it appears in HTTP_HOST
+	 * @return array<int,string> deduped page-cache keys
+	 */
+	public function keys_for_paths( array $paths, $scheme, $host ) {
+		$keys = array();
+		foreach ( $paths as $path ) {
+			$path = (string) $path;
+			$qpos = strpos( $path, '?' );
+			if ( false !== $qpos ) {
+				$path = substr( $path, 0, $qpos );
+			}
+			if ( '' === $path ) {
+				continue;
+			}
+			foreach ( array( 'd', 'm' ) as $variant ) {
+				$key            = $this->cfg['prefix'] . 'page:' . md5( $scheme . '|' . $host . '|' . $path . '|' . $variant );
+				$keys[ $key ] = true;
+			}
+		}
+		return array_keys( $keys );
+	}
+
+	/**
+	 * Targeted purge (JAB-91): delete only the page-cache entries for $paths, in
+	 * both desktop and mobile variants, instead of nuking the whole site's warm
+	 * cache on a single post edit. Falls back to purge_all() when the canonical
+	 * scheme/host can't be derived (correctness over precision).
+	 *
+	 * @param array<int,string> $paths
+	 * @return int keys deleted (or the purge_all() count on fallback)
+	 */
+	public function purge_paths( array $paths ) {
+		if ( ! $this->client->connect() ) {
+			return 0;
+		}
+		// The stored key used the visitor's HTTP_HOST + REQUEST_URI (see
+		// request_hash()). home_url() gives the site's own scheme+host; on the
+		// common single-host install they match. If we can't resolve a host,
+		// fall back to a whole-site purge rather than silently missing.
+		$home = function_exists( 'home_url' ) ? home_url( '/' ) : '';
+		$u    = $home ? wp_parse_url( $home ) : false;
+		if ( ! is_array( $u ) || empty( $u['host'] ) ) {
+			return $this->purge_all();
+		}
+		$scheme = ( isset( $u['scheme'] ) && 'https' === $u['scheme'] ) ? 'https' : 'http';
+		$host   = $u['host'] . ( isset( $u['port'] ) ? ':' . $u['port'] : '' );
+
+		$keys = $this->keys_for_paths( $paths, $scheme, $host );
+		if ( empty( $keys ) ) {
+			return 0;
+		}
+		return (int) $this->client->del( $keys );
+	}
+
 	// ------------------------------------------------------------------
 	// Decisions.
 	// ------------------------------------------------------------------

--- a/wp-plugins/jabali-cache/jabali-cache.php
+++ b/wp-plugins/jabali-cache/jabali-cache.php
@@ -213,7 +213,11 @@ function jabali_cache_purge_pages() {
  * @param int $post_id
  */
 function jabali_cache_purge_post( $post_id ) {
-	jabali_cache_purge_redis();
+	// JAB-91: build the affected paths first (home + the post permalink), then
+	// purge ONLY those from the Redis page cache — a single post edit must not
+	// discard the whole site's warm cache. Whole-site Redis purge stays for
+	// site-wide changes (jabali_cache_purge_pages via theme/customize/option
+	// hooks). The nginx purge was already path-targeted.
 	$paths = array( '/' );
 	$link  = get_permalink( (int) $post_id );
 	if ( $link ) {
@@ -222,7 +226,23 @@ function jabali_cache_purge_post( $post_id ) {
 			$paths[] = $p;
 		}
 	}
+	jabali_cache_purge_redis_paths( $paths );
 	jabali_cache_purge_nginx( $paths );
+}
+
+/**
+ * Targeted Redis page-cache purge for specific URL paths (JAB-91). No-op when
+ * the optional Redis page cache is off.
+ *
+ * @param array<int,string> $paths
+ */
+function jabali_cache_purge_redis_paths( array $paths ) {
+	$cfg = Jabali_Cache_Config::load();
+	if ( empty( $cfg['page_cache'] ) || ! class_exists( 'Jabali_Cache_Page_Cache' ) ) {
+		return;
+	}
+	$pc = new Jabali_Cache_Page_Cache();
+	$pc->purge_paths( $paths );
 }
 
 /**

--- a/wp-plugins/jabali-cache/tests/test-lib.php
+++ b/wp-plugins/jabali-cache/tests/test-lib.php
@@ -180,5 +180,36 @@ if ( is_array( $cb_glob ) ) {
 @rmdir( $cb_root . '/cache' );
 @rmdir( $cb_root );
 
+// ---------------------------------------------------------------------------
+// Targeted page-cache purge key derivation (JAB-91).
+// ---------------------------------------------------------------------------
+echo "Page-cache targeted purge (JAB-91):\n";
+require __DIR__ . '/../includes/class-page-cache.php';
+$pc  = new Jabali_Cache_Page_Cache();
+$pfx = $cfg['prefix'];
+
+// One path → desktop + mobile keys, matching request_hash()'s md5 format.
+$k_home = $pc->keys_for_paths( array( '/' ), 'https', 'example.com' );
+jc_assert( 2 === count( $k_home ), 'purge_paths: one path yields desktop + mobile keys' );
+$expect_d = $pfx . 'page:' . md5( 'https|example.com|/|d' );
+$expect_m = $pfx . 'page:' . md5( 'https|example.com|/|m' );
+jc_assert(
+	in_array( $expect_d, $k_home, true ) && in_array( $expect_m, $k_home, true ),
+	'purge_paths: keys match the request_hash format for both variants'
+);
+
+// Query string is stripped: /p and /p?utm=1 map to the same keys.
+$k_q   = $pc->keys_for_paths( array( '/p?utm=1' ), 'https', 'example.com' );
+$k_noq = $pc->keys_for_paths( array( '/p' ), 'https', 'example.com' );
+jc_assert( $k_q === $k_noq, 'purge_paths: query string is stripped' );
+
+// Two distinct paths → 4 keys; duplicates deduped.
+$k2 = $pc->keys_for_paths( array( '/', '/hello/', '/hello/' ), 'https', 'example.com' );
+jc_assert( 4 === count( $k2 ), 'purge_paths: two distinct paths -> 4 keys, dupes deduped' );
+
+// Empty / query-only paths yield nothing (guards the whole-site fallback path).
+$k_empty = $pc->keys_for_paths( array( '', '?only-query' ), 'http', 'example.com' );
+jc_assert( 0 === count( $k_empty ), 'purge_paths: empty / query-only paths produce no keys' );
+
 echo "\n{$tests} checks, {$failed} failed\n";
 exit( $failed > 0 ? 1 : 0 );


### PR DESCRIPTION
Closes JAB-91 (Plane).

A single post edit purged the **entire** Redis full-page cache (`purge_all` → `{prefix}page:*`), discarding the whole site's warm cache and forcing PHP regeneration across unrelated URLs — even though the nginx purge in the same hook was already path-targeted.

## Changes
- **`Jabali_Cache_Page_Cache::purge_paths( array $paths )`** — delete only the entries for the given paths, in **both desktop + mobile** variants (the key includes that dimension). Falls back to `purge_all()` when the canonical scheme/host can't be derived.
- **`keys_for_paths()`** — the pure key-derivation half, mirroring `request_hash()` (`md5(scheme|host|path|variant)`, query stripped) — unit-testable without Redis.
- **`jabali_cache_purge_post()`** now purges only `/` + the post permalink from Redis (via new `jabali_cache_purge_redis_paths()`), matching the paths it already hands the nginx purge. **Whole-site Redis purge stays for site-wide changes** (theme/customize/permalink/home/siteurl/page_on_front option hooks — unchanged).

## Acceptance criteria
- [x] Updating one post no longer deletes unrelated Redis page-cache entries
- [x] Home + edited post URL purged in both mobile and desktop variants
- [x] Site-wide content/layout changes still purge the full Redis page cache
- [x] Tests cover single-post purge, query stripping, mobile/desktop variants, dedupe (+ whole-site fallback via the empty-keys guard)

## Test plan
- [x] `php -l` clean; `php tests/test-lib.php` → **29 checks, 0 failed** (5 new page-cache purge tests). Plugin PHP tests aren't wired into CI (verified locally).