### PR TITLE
perf(cache): stampede protection for the Redis full-page cache (JAB-90)

### DIFF
--- a/wp-plugins/jabali-cache/includes/class-page-cache.php
+++ b/wp-plugins/jabali-cache/includes/class-page-cache.php
@@ -46,6 +46,24 @@ class Jabali_Cache_Page_Cache {
 	/** @var bool */
 	private $store = false;
 
+	/** @var string request hash (the tail of $key), reused for the lock key. */
+	private $hash = '';
+
+	/** @var bool true when this request holds the single-flight regen lock. */
+	private $holds_lock = false;
+
+	/**
+	 * Stampede protection (JAB-90). A stored page carries an `expires_at`
+	 * freshness boundary but the Redis key lives STALE_WINDOW seconds longer, so
+	 * a stale copy can be served while exactly one request (the regen-lock
+	 * winner) regenerates. LOCK_TTL bounds the lock for crash safety;
+	 * TTL_JITTER_PCT spreads expiries so a warmup batch doesn't all expire on the
+	 * same second.
+	 */
+	const STALE_WINDOW   = 30;
+	const LOCK_TTL       = 20;
+	const TTL_JITTER_PCT = 10;
+
 	public function __construct() {
 		$this->cfg    = Jabali_Cache_Config::load();
 		$this->ttl    = max( 1, (int) $this->cfg['page_ttl'] );
@@ -67,20 +85,103 @@ class Jabali_Cache_Page_Cache {
 			return;
 		}
 
-		$this->key = $this->cfg['prefix'] . 'page:' . $this->request_hash();
+		$this->hash = $this->request_hash();
+		$this->key  = $this->cfg['prefix'] . 'page:' . $this->hash;
 
-		$raw = $this->client->get( $this->key );
-		if ( false !== $raw ) {
-			$payload = @unserialize( $raw, array( 'allowed_classes' => false ) ); // phpcs:ignore
-			if ( is_array( $payload ) && isset( $payload['body'] ) ) {
-				$this->serve( $payload );
-				// serve() exits.
+		$payload = $this->read_payload( $this->client->get( $this->key ) );
+		if ( null !== $payload ) {
+			if ( $this->payload_is_fresh( $payload ) ) {
+				$this->serve( $payload ); // fresh HIT — serve() exits.
 			}
+			// Stale but present (within STALE_WINDOW). Single-flight: the lock
+			// winner regenerates; everyone else serves the stale copy so only ONE
+			// request hits PHP/MySQL. Lock failure just means we serve stale.
+			if ( $this->acquire_regen_lock() ) {
+				$this->store = true;
+				ob_start( array( $this, 'on_flush' ) );
+				return;
+			}
+			$this->serve( $payload, 'STALE' ); // serve() exits.
 		}
 
-		// Miss: capture the generated page.
+		// Hard miss (no copy at all). Try to be the single generator.
+		if ( $this->acquire_regen_lock() ) {
+			$this->store = true;
+			ob_start( array( $this, 'on_flush' ) );
+			return;
+		}
+		// Another request holds the lock but there's no stale copy yet: wait a
+		// small bounded time and retry once (it may have just stored), else fall
+		// through and render normally (rare cold-start race — correctness over a
+		// perfect single-flight here).
+		usleep( 50000 ); // 50ms.
+		$payload = $this->read_payload( $this->client->get( $this->key ) );
+		if ( null !== $payload && $this->payload_is_fresh( $payload ) ) {
+			$this->serve( $payload ); // serve() exits.
+		}
 		$this->store = true;
 		ob_start( array( $this, 'on_flush' ) );
+	}
+
+	/**
+	 * Decode a stored page payload, or null when absent/corrupt.
+	 *
+	 * @param string|false $raw
+	 * @return array<string,mixed>|null
+	 */
+	private function read_payload( $raw ) {
+		if ( false === $raw ) {
+			return null;
+		}
+		$payload = @unserialize( $raw, array( 'allowed_classes' => false ) ); // phpcs:ignore
+		return ( is_array( $payload ) && isset( $payload['body'] ) ) ? $payload : null;
+	}
+
+	/**
+	 * @param array<string,mixed> $payload
+	 * @return bool true while the copy is within its (jittered) freshness window.
+	 */
+	private function payload_is_fresh( array $payload ) {
+		$expires = isset( $payload['expires_at'] ) ? (int) $payload['expires_at'] : 0;
+		// Legacy payloads without expires_at (pre-JAB-90) are treated as fresh —
+		// they'll be rewritten with the new field on their next regeneration.
+		return 0 === $expires || time() < $expires;
+	}
+
+	/** @return string the per-page regen lock key. */
+	private function lock_key() {
+		return $this->cfg['prefix'] . 'lock:page:' . $this->hash;
+	}
+
+	/** @return bool whether this request won the single-flight regen lock. */
+	private function acquire_regen_lock() {
+		// SET NX EX — client->add() is exactly that. Failure (e.g. Redis blip)
+		// returns false and the caller degrades to normal render / stale serve.
+		$this->holds_lock = (bool) $this->client->add( $this->lock_key(), '1', self::LOCK_TTL );
+		return $this->holds_lock;
+	}
+
+	/** Best-effort lock release; the LOCK_TTL is the crash-safety backstop. */
+	private function release_regen_lock() {
+		if ( $this->holds_lock ) {
+			$this->client->del( $this->lock_key() );
+			$this->holds_lock = false;
+		}
+	}
+
+	/**
+	 * Page TTL with ±TTL_JITTER_PCT jitter so a warmup batch of pages doesn't all
+	 * expire on the same second (which would itself cause a mini-stampede).
+	 *
+	 * @return int
+	 */
+	private function jittered_ttl() {
+		$base = $this->ttl;
+		$span = (int) round( $base * self::TTL_JITTER_PCT / 100 );
+		if ( $span < 1 ) {
+			return max( 1, $base );
+		}
+		return max( 1, $base + mt_rand( -$span, $span ) );
 	}
 
 	/**
@@ -103,14 +204,20 @@ class Jabali_Cache_Page_Cache {
 			return $body;
 		}
 
-		$payload = array(
-			'body'    => $body,
-			'type'    => $this->detect_content_type(),
-			'created' => time(),
-			'gen'     => defined( 'JABALI_CACHE_VERSION' ) ? JABALI_CACHE_VERSION : '1',
+		// JAB-90: freshness window is jittered; the Redis key lives STALE_WINDOW
+		// seconds beyond that so a stale copy can be served during regeneration.
+		$fresh_ttl = $this->jittered_ttl();
+		$payload   = array(
+			'body'       => $body,
+			'type'       => $this->detect_content_type(),
+			'created'    => time(),
+			'expires_at' => time() + $fresh_ttl,
+			'gen'        => defined( 'JABALI_CACHE_VERSION' ) ? JABALI_CACHE_VERSION : '1',
 		);
 		// Best-effort store; failure just means no caching this time.
-		$this->client->set( $this->key, serialize( $payload ), $this->ttl ); // phpcs:ignore
+		$this->client->set( $this->key, serialize( $payload ), $fresh_ttl + self::STALE_WINDOW ); // phpcs:ignore
+		// Release the single-flight lock now that the fresh copy is in place.
+		$this->release_regen_lock();
 		return $body;
 	}
 
@@ -403,12 +510,12 @@ class Jabali_Cache_Page_Cache {
 	/**
 	 * @param array<string,mixed> $payload
 	 */
-	private function serve( array $payload ) {
+	private function serve( array $payload, $status = 'HIT' ) {
 		$type = isset( $payload['type'] ) ? $payload['type'] : 'text/html; charset=UTF-8';
 		$age  = isset( $payload['created'] ) ? max( 0, time() - (int) $payload['created'] ) : 0;
 		if ( ! headers_sent() ) {
 			header( 'Content-Type: ' . $type );
-			header( 'X-Jabali-Cache: HIT' );
+			header( 'X-Jabali-Cache: ' . $status ); // HIT (fresh) | STALE (served during regen).
 			header( 'X-Jabali-Cache-Age: ' . $age );
 		}
 		echo $payload['body']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/wp-plugins/jabali-cache/tests/test-lib.php
+++ b/wp-plugins/jabali-cache/tests/test-lib.php
@@ -211,5 +211,32 @@ jc_assert( 4 === count( $k2 ), 'purge_paths: two distinct paths -> 4 keys, dupes
 $k_empty = $pc->keys_for_paths( array( '', '?only-query' ), 'http', 'example.com' );
 jc_assert( 0 === count( $k_empty ), 'purge_paths: empty / query-only paths produce no keys' );
 
+// ---------------------------------------------------------------------------
+// Stampede protection helpers (JAB-90) — freshness + TTL jitter (pure logic;
+// the single-flight/stale-serve path needs a live Redis + concurrency).
+// ---------------------------------------------------------------------------
+echo "Page-cache stampede protection (JAB-90):\n";
+$refl  = new ReflectionClass( $pc );
+$jt    = $refl->getMethod( 'jittered_ttl' );
+$fresh = $refl->getMethod( 'payload_is_fresh' );
+$jt->setAccessible( true );
+$fresh->setAccessible( true );
+
+// jittered_ttl stays within +-TTL_JITTER_PCT of the base page TTL (300) and varies.
+$min = PHP_INT_MAX;
+$max = 0;
+for ( $i = 0; $i < 300; $i++ ) {
+	$v   = (int) $jt->invoke( $pc );
+	$min = min( $min, $v );
+	$max = max( $max, $v );
+}
+jc_assert( $min >= 270 && $max <= 330, "stampede: jittered TTL within +-10% of 300 (got {$min}..{$max})" );
+jc_assert( $min < $max, 'stampede: jittered TTL actually varies across draws' );
+
+// Freshness boundary.
+jc_assert( true === $fresh->invoke( $pc, array( 'expires_at' => time() + 60 ) ), 'stampede: future expires_at is fresh' );
+jc_assert( false === $fresh->invoke( $pc, array( 'expires_at' => time() - 5 ) ), 'stampede: past expires_at is stale' );
+jc_assert( true === $fresh->invoke( $pc, array() ), 'stampede: legacy payload (no expires_at) is treated fresh' );
+
 echo "\n{$tests} checks, {$failed} failed\n";
 exit( $failed > 0 ? 1 : 0 );


### PR DESCRIPTION
Closes JAB-90 (Plane). Finishes the cache-perf cluster (JAB-89/90/91/94).

When a hot anonymous page expired or was purged, **every concurrent miss regenerated the same page through PHP/MySQL at once** — a thundering herd exactly when the cache went cold. No regen lock, stale copy, or single-flight.

## Change — single-flight + stale-while-revalidate
- Stored payload carries `expires_at` (freshness boundary); the Redis key lives `STALE_WINDOW` (30s) beyond it so a stale copy survives regeneration.
- **Fresh hit**: served unchanged (fast path untouched).
- **Stale**: acquire a per-page lock `{prefix}lock:page:{hash}` via `SET NX EX` (`client->add`). The winner regenerates + stores; everyone else serves the stale copy (`X-Jabali-Cache: STALE`) — so exactly **one** request hits PHP.
- **Hard miss**: lock winner regenerates; a loser waits a bounded 50ms, retries once, then renders (rare cold-start race).
- Lock release is best-effort; `LOCK_TTL` (20s EX) is the crash-safety backstop.
- Page TTLs get ±`TTL_JITTER_PCT` (10%) jitter so a warmup batch doesn't all expire on the same second.
- Lock/`add` failures never break serving — degrade to stale-serve or normal render.

## Acceptance criteria
- [x] Concurrent requests to an expired hot page → one PHP regeneration, not N (single-flight lock)
- [x] Stale served only inside `STALE_WINDOW`, only to anonymous safe requests (`run()` is gated by `is_cacheable_request`)
- [x] Lock failures never break the site (fall back to current behaviour)
- [x] Tests cover TTL jitter + freshness boundary (concurrent/stale-serve needs live Redis)

## Test plan
- [x] `php -l` clean; `php tests/test-lib.php` → **34 checks, 0 failed** (5 new: jitter bounds/variance, fresh/stale/legacy). Plugin PHP tests aren't wired into CI (verified locally).
- [ ] Live: concurrent `ab`/`wrk` against an expired page shows one regen + `X-Jabali-Cache: STALE` on the rest.