### PR TITLE
feat(cli): jabali user suspend/unsuspend (JAB-127)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4839,6 +4839,26 @@ jabali user password <email|username|user-id> [flags]
 - `--password` — explicit new password (omit to auto-generate)
 - `--password-stdin` — read new password from stdin (no prompt, no echo)
 
+#### `jabali user suspend`
+
+Suspend a user (same cascade as the admin GUI/API)
+
+```
+jabali user suspend <id> [flags]
+```
+
+**Flags:**
+
+- `--reason` — operator-facing suspend reason (shown in the admin user list)
+
+#### `jabali user unsuspend`
+
+Unsuspend a user (reverse the cascade)
+
+```
+jabali user unsuspend <id>
+```
+
 ### `jabali user-token`
 
 Manage a user's API tokens (mint / list / revoke)

--- a/panel-api/cmd/server/user.go
+++ b/panel-api/cmd/server/user.go
@@ -31,6 +31,8 @@ func newUserCmd() *cobra.Command {
 		newUserDeleteCmd(),
 		newUserPasswordCmd(),
 		newUser2FAResetCmd(),
+		newUserSuspendCmd(),
+		newUserUnsuspendCmd(),
 	)
 	return cmd
 }

--- a/panel-api/cmd/server/user_suspend_cmd.go
+++ b/panel-api/cmd/server/user_suspend_cmd.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+// user_suspend_cmd.go — `jabali user suspend/unsuspend <id>` (JAB-127). Shares
+// the exact cascade the admin GUI/API uses via userops.Suspend/Unsuspend, so a
+// headless/scriptable suspend has the same side effects (DB flag, Kratos
+// inactive, domains disabled, Docker stopped, OS user locked).
+
+// cliSuspendDeps wires userops.Deps from the shared CLI singletons.
+func cliSuspendDeps() userops.Deps {
+	var kc *kratosclient.Client
+	if sharedCfg != nil {
+		kc = kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL)
+	}
+	d := userops.Deps{
+		Users:        userRepo(),
+		Domains:      domainRepoFromDB(),
+		DockerApps:   dockerAppRepoFromDB(),
+		KratosClient: kc,
+		Log:          slog.Default(),
+	}
+	// Guard the typed-nil trap: only set Agent when the shared client exists.
+	if sharedAgent != nil {
+		d.Agent = sharedAgent
+	}
+	return d
+}
+
+func cliPrintWarnings(warns ...string) {
+	for _, w := range warns {
+		if w != "" {
+			fmt.Fprintf(os.Stderr, "  warning: %s\n", w)
+		}
+	}
+}
+
+func newUserSuspendCmd() *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "suspend <id>",
+		Short: "Suspend a user (same cascade as the admin GUI/API)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
+			defer cancel()
+
+			id := args[0]
+			u, err := userRepo().FindByID(ctx, id)
+			if err != nil || u == nil {
+				return fmt.Errorf("user %q not found", id)
+			}
+			if u.IsAdmin {
+				return fmt.Errorf("refusing to suspend admin user %q — demote first via the admin panel", id)
+			}
+
+			res, err := userops.Suspend(ctx, cliSuspendDeps(), u, reason)
+			if err != nil {
+				return err
+			}
+			if res.AlreadySuspended {
+				fmt.Printf("user %s is already suspended\n", id)
+				return nil
+			}
+			fmt.Printf("suspended user %s (domains disabled: %d)\n", id, res.DomainsDisabled)
+			cliPrintWarnings(res.KratosWarning, res.DomainWarning, res.OSWarning)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "operator-facing suspend reason (shown in the admin user list)")
+	return cmd
+}
+
+func newUserUnsuspendCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unsuspend <id>",
+		Short: "Unsuspend a user (reverse the cascade)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
+			defer cancel()
+
+			id := args[0]
+			u, err := userRepo().FindByID(ctx, id)
+			if err != nil || u == nil {
+				return fmt.Errorf("user %q not found", id)
+			}
+
+			res, err := userops.Unsuspend(ctx, cliSuspendDeps(), u)
+			if err != nil {
+				return err
+			}
+			if res.AlreadyActive {
+				fmt.Printf("user %s is already active\n", id)
+				return nil
+			}
+			fmt.Printf("unsuspended user %s (domains enabled: %d)\n", id, res.DomainsEnabled)
+			cliPrintWarnings(res.KratosWarning, res.DomainWarning, res.OSWarning)
+			return nil
+		},
+	}
+}

--- a/panel-api/internal/api/users_suspend.go
+++ b/panel-api/internal/api/users_suspend.go
@@ -1,49 +1,41 @@
 package api
 
 import (
-	"context"
-	"errors"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
 
-// suspendRequest is the optional JSON body for POST /admin/users/:id/suspend.
-// reason is operator-facing audit text surfaced in the admin user list.
+// users_suspend.go — admin suspend/unsuspend. The multi-step cascade (DB flag,
+// Kratos identity state + whoami invalidation, domain disable, Docker stop, OS
+// user lock) lives in userops.Suspend/Unsuspend so the `jabali user
+// suspend`/`unsuspend` CLI shares exactly the same behaviour (JAB-127).
+
 type suspendRequest struct {
+	// Reason is operator-facing audit text surfaced in the admin user list.
 	Reason string `json:"reason"`
+}
+
+// suspendDeps wires userops.Deps from the handler config.
+func (h *userHandler) suspendDeps() userops.Deps {
+	return userops.Deps{
+		Users:        h.cfg.Repo,
+		Domains:      h.cfg.Domains,
+		DockerApps:   h.cfg.DockerApps,
+		Agent:        h.cfg.Agent,
+		KratosClient: h.cfg.KratosClient,
+		Log:          slog.Default(),
+	}
 }
 
 // suspend handles POST /admin/users/:id/suspend.
 //
-// Three-step cascade — best-effort with rollback on the first hard
-// failure so a partial suspend doesn't leave the panel in a half-
-// off state:
-//  1. flip users.suspended = 1 + stamp suspended_at + suspend_reason
-//  2. PATCH Kratos identity state = inactive (blocks panel + webmail
-//     + every Kratos-fronted UI on next request)
-//  3. bulk-flip every owned domains.is_enabled = 0 (reconciler picks
-//     up next tick + removes the nginx sites-enabled symlinks)
-//
 // Suspending an admin user is refused — admins are the only path to
-// un-suspend, refusing here prevents an accidental org-wide lockout.
-// Suspending the LAST non-admin doesn't need a special guard.
-//
-// Returns:
-//   - 200 {"ok": true, "domains_disabled": N} on success
-//   - 400 if id is empty
-//   - 404 if the user doesn't exist
-//   - 409 if the user is already suspended (idempotent re-call returns
-//     200 with domains_disabled=0; the 409 only fires for clarity in a
-//     concurrent-suspend race)
-//   - 422 if the target is an admin user
-//   - 503 if Kratos client is nil (dev binaries)
+// re-enable anyone, so we never lock the whole panel out. Kratos client nil
+// (dev binaries) is surfaced as a warning, not a hard failure.
 func (h *userHandler) suspend(c *gin.Context) {
 	userID := c.Param("id")
 	if userID == "" {
@@ -67,103 +59,31 @@ func (h *userHandler) suspend(c *gin.Context) {
 		})
 		return
 	}
-	if user.Suspended {
+
+	res, err := userops.Suspend(ctx, h.suspendDeps(), user, req.Reason)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "suspend_db_write_failed", "detail": err.Error()})
+		return
+	}
+	if res.AlreadySuspended {
 		c.JSON(http.StatusOK, gin.H{"ok": true, "already_suspended": true, "domains_disabled": int64(0)})
 		return
 	}
 
-	// Step 1 — flip suspended flag.
-	if err := h.cfg.Repo.SetSuspended(ctx, userID, true, req.Reason); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "suspend_db_write_failed", "detail": err.Error()})
-		return
+	resp := gin.H{"ok": true, "domains_disabled": res.DomainsDisabled}
+	if res.KratosWarning != "" {
+		resp["kratos_warning"] = res.KratosWarning
 	}
-
-	// Step 2 — push Kratos identity inactive. Best-effort: a Kratos
-	// outage shouldn't block the DB + domain cascade; surface as a
-	// warning in the response so the operator can re-run later.
-	var kratosWarn string
-	if user.KratosIdentityID != nil && *user.KratosIdentityID != "" {
-		if h.cfg.KratosClient == nil {
-			kratosWarn = "kratos_client_unavailable"
-		} else if err := h.cfg.KratosClient.SetIdentityState(ctx, *user.KratosIdentityID, "inactive"); err != nil {
-			if errors.Is(err, kratosclient.ErrIdentityNotFound) {
-				kratosWarn = "kratos_identity_not_found"
-			} else {
-				kratosWarn = "kratos_state_patch_failed: " + err.Error()
-			}
-		}
-		// JAB-3: requests are already denied immediately via the panel DB
-		// suspended flag; drop any cached positive whoami for this identity too
-		// so the Kratos-cache layer can't accept the session during the TTL
-		// window (defense in depth). Runs even if the state patch warned.
-		if h.cfg.KratosClient != nil {
-			h.cfg.KratosClient.InvalidateIdentity(*user.KratosIdentityID)
-		}
+	if res.DomainWarning != "" {
+		resp["domain_warning"] = res.DomainWarning
 	}
-
-	// Step 3 — disable every owned domain.
-	disabled, dErr := h.cfg.Domains.BulkSetEnabledByUserID(ctx, userID, false)
-	var domainWarn string
-	if dErr != nil {
-		domainWarn = "domain_bulk_disable_failed: " + dErr.Error()
-	}
-
-	// Step 3b — stop the tenant's Docker apps (Gitea #520): a suspended user's
-	// containers must not keep running/serving. Best-effort; logged on failure.
-	if h.cfg.DockerApps != nil && h.cfg.Agent != nil {
-		if apps, aerr := h.cfg.DockerApps.ListByUserID(ctx, userID); aerr == nil {
-			for _, app := range apps {
-				actx, acancel := context.WithTimeout(ctx, 2*time.Minute)
-				if _, serr := h.cfg.Agent.Call(actx, "docker_app.stop", map[string]any{"slug": app.EffectiveSlug()}); serr != nil {
-					slog.Warn("suspend: docker_app.stop failed", "user_id", userID, "slug", app.EffectiveSlug(), "err", serr)
-				} else {
-					_ = h.cfg.DockerApps.UpdateStatus(ctx, app.ID, models.DockerAppStatusStopped, nil)
-				}
-				acancel()
-			}
-		} else {
-			slog.Warn("suspend: list user docker apps failed", "user_id", userID, "err", aerr)
-		}
-	}
-
-	// Step 4 — agent-side OS cascade: remove from jabali-sftp group +
-	// lock Linux password so SFTP + SSH-password auth are refused.
-	// Best-effort; surfaces as a warning instead of failing the suspend.
-	var osWarn string
-	if user.Username != nil && *user.Username != "" && h.cfg.Agent != nil {
-		if _, err := h.cfg.Agent.Call(ctx, "user.suspend", map[string]any{
-			"username": *user.Username,
-		}); err != nil {
-			osWarn = "user_os_suspend_failed: " + err.Error()
-		}
-	}
-
-	resp := gin.H{
-		"ok":               true,
-		"domains_disabled": disabled,
-	}
-	if kratosWarn != "" {
-		resp["kratos_warning"] = kratosWarn
-	}
-	if domainWarn != "" {
-		resp["domain_warning"] = domainWarn
-	}
-	if osWarn != "" {
-		resp["os_warning"] = osWarn
+	if res.OSWarning != "" {
+		resp["os_warning"] = res.OSWarning
 	}
 	c.JSON(http.StatusOK, resp)
 }
 
-// unsuspend handles POST /admin/users/:id/unsuspend. Reverses the
-// three-step suspend cascade:
-//  1. flip users.suspended = 0 + clear suspended_at + reason
-//  2. PATCH Kratos identity state = active
-//  3. bulk-flip every owned domains.is_enabled = 1 (reconciler
-//     re-creates the nginx symlinks on next tick)
-//
-// Returns 200 with domains_enabled count + optional Kratos / domain
-// warnings same as suspend. 404 on missing user, 200 idempotent on
-// already-active users.
+// unsuspend handles POST /admin/users/:id/unsuspend. Reverses the cascade.
 func (h *userHandler) unsuspend(c *gin.Context) {
 	userID := c.Param("id")
 	if userID == "" {
@@ -177,61 +97,26 @@ func (h *userHandler) unsuspend(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
 	}
-	if !user.Suspended {
+
+	res, err := userops.Unsuspend(ctx, h.suspendDeps(), user)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unsuspend_db_write_failed", "detail": err.Error()})
+		return
+	}
+	if res.AlreadyActive {
 		c.JSON(http.StatusOK, gin.H{"ok": true, "already_active": true, "domains_enabled": int64(0)})
 		return
 	}
 
-	if err := h.cfg.Repo.SetSuspended(ctx, userID, false, ""); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "unsuspend_db_write_failed", "detail": err.Error()})
-		return
+	resp := gin.H{"ok": true, "domains_enabled": res.DomainsEnabled}
+	if res.KratosWarning != "" {
+		resp["kratos_warning"] = res.KratosWarning
 	}
-
-	var kratosWarn string
-	if user.KratosIdentityID != nil && *user.KratosIdentityID != "" {
-		if h.cfg.KratosClient == nil {
-			kratosWarn = "kratos_client_unavailable"
-		} else if err := h.cfg.KratosClient.SetIdentityState(ctx, *user.KratosIdentityID, "active"); err != nil {
-			if errors.Is(err, kratosclient.ErrIdentityNotFound) {
-				kratosWarn = "kratos_identity_not_found"
-			} else {
-				kratosWarn = "kratos_state_patch_failed: " + err.Error()
-			}
-		}
+	if res.DomainWarning != "" {
+		resp["domain_warning"] = res.DomainWarning
 	}
-
-	enabled, dErr := h.cfg.Domains.BulkSetEnabledByUserID(ctx, userID, true)
-	var domainWarn string
-	if dErr != nil {
-		domainWarn = "domain_bulk_enable_failed: " + dErr.Error()
-	}
-
-	// Agent-side OS reverse cascade: re-add jabali-sftp group + unlock.
-	var osWarn string
-	if user.Username != nil && *user.Username != "" && h.cfg.Agent != nil {
-		if _, err := h.cfg.Agent.Call(ctx, "user.unsuspend", map[string]any{
-			"username": *user.Username,
-		}); err != nil {
-			osWarn = "user_os_unsuspend_failed: " + err.Error()
-		}
-	}
-
-	resp := gin.H{
-		"ok":              true,
-		"domains_enabled": enabled,
-	}
-	if kratosWarn != "" {
-		resp["kratos_warning"] = kratosWarn
-	}
-	if domainWarn != "" {
-		resp["domain_warning"] = domainWarn
-	}
-	if osWarn != "" {
-		resp["os_warning"] = osWarn
+	if res.OSWarning != "" {
+		resp["os_warning"] = res.OSWarning
 	}
 	c.JSON(http.StatusOK, resp)
 }
-
-// silence unused-imports if a future refactor inlines the kratosclient
-// constant set; keep the explicit reference here.
-var _ = repository.ErrNotFound

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -39,6 +39,8 @@ type AgentCaller interface {
 type Deps struct {
 	Users        repository.UserRepository
 	Packages     repository.PackageRepository
+	Domains      repository.DomainRepository
+	DockerApps   repository.DockerAppRepository
 	Agent        AgentCaller
 	KratosClient *kratosclient.Client
 	BcryptCost   int

--- a/panel-api/internal/userops/userops_suspend.go
+++ b/panel-api/internal/userops/userops_suspend.go
@@ -1,0 +1,153 @@
+package userops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// SuspendResult / UnsuspendResult carry the domain count + best-effort,
+// step-named warnings so the REST handler maps them 1:1 to its response keys
+// (kratos_warning / domain_warning / os_warning) and the CLI can print them.
+type SuspendResult struct {
+	AlreadySuspended bool
+	DomainsDisabled  int64
+	KratosWarning    string
+	DomainWarning    string
+	OSWarning        string
+}
+
+type UnsuspendResult struct {
+	AlreadyActive  bool
+	DomainsEnabled int64
+	KratosWarning  string
+	DomainWarning  string
+	OSWarning      string
+}
+
+// kratosStateWarning applies a Kratos identity state change (+ invalidate on
+// suspend) and returns a warning string, "" on success. Shared by both paths.
+func kratosStateWarning(ctx context.Context, d Deps, identityID, state string, invalidate bool) string {
+	if d.KratosClient == nil {
+		return "kratos_client_unavailable"
+	}
+	warn := ""
+	if err := d.KratosClient.SetIdentityState(ctx, identityID, state); err != nil {
+		if errors.Is(err, kratosclient.ErrIdentityNotFound) {
+			warn = "kratos_identity_not_found"
+		} else {
+			warn = "kratos_state_patch_failed: " + err.Error()
+		}
+	}
+	if invalidate {
+		d.KratosClient.InvalidateIdentity(identityID)
+	}
+	return warn
+}
+
+// Suspend applies the full suspend cascade shared by the admin REST handler
+// (POST /admin/users/:id/suspend) and the `jabali user suspend` CLI (JAB-127):
+//
+//  1. users.suspended = 1 (+ reason) — the load-bearing login gate.
+//  2. Kratos identity -> inactive + invalidate cached whoami (best-effort).
+//  3. disable every owned domain.
+//  4. stop the tenant's Docker apps (best-effort).
+//  5. agent user.suspend — OS: drop from jabali-sftp group + lock password.
+//
+// Refusing to suspend an admin is the CALLER's responsibility. Steps 2-5 are
+// best-effort: a failure becomes a warning, never a hard error, because step 1
+// already denies access.
+func Suspend(ctx context.Context, d Deps, user *models.User, reason string) (SuspendResult, error) {
+	res := SuspendResult{}
+	if d.Users == nil || user == nil {
+		return res, errors.New("userops.Suspend: users repo + user required")
+	}
+	if user.Suspended {
+		res.AlreadySuspended = true
+		return res, nil
+	}
+
+	if err := d.Users.SetSuspended(ctx, user.ID, true, reason); err != nil {
+		return res, fmt.Errorf("suspend db write: %w", err)
+	}
+
+	if user.KratosIdentityID != nil && *user.KratosIdentityID != "" {
+		res.KratosWarning = kratosStateWarning(ctx, d, *user.KratosIdentityID, "inactive", true)
+	}
+
+	if d.Domains != nil {
+		if n, err := d.Domains.BulkSetEnabledByUserID(ctx, user.ID, false); err != nil {
+			res.DomainWarning = "domain_bulk_disable_failed: " + err.Error()
+		} else {
+			res.DomainsDisabled = n
+		}
+	}
+
+	if d.DockerApps != nil && d.Agent != nil {
+		if apps, aerr := d.DockerApps.ListByUserID(ctx, user.ID); aerr == nil {
+			for _, app := range apps {
+				actx, acancel := context.WithTimeout(ctx, 2*time.Minute)
+				if _, serr := d.Agent.Call(actx, "docker_app.stop", map[string]any{"slug": app.EffectiveSlug()}); serr != nil {
+					if d.Log != nil {
+						d.Log.Warn("suspend: docker_app.stop failed", "user_id", user.ID, "slug", app.EffectiveSlug(), "err", serr)
+					}
+				} else {
+					_ = d.DockerApps.UpdateStatus(actx, app.ID, models.DockerAppStatusStopped, nil)
+				}
+				acancel()
+			}
+		} else if d.Log != nil {
+			d.Log.Warn("suspend: list user docker apps failed", "user_id", user.ID, "err", aerr)
+		}
+	}
+
+	if user.Username != nil && *user.Username != "" && d.Agent != nil {
+		if _, err := d.Agent.Call(ctx, "user.suspend", map[string]any{"username": *user.Username}); err != nil {
+			res.OSWarning = "user_os_suspend_failed: " + err.Error()
+		}
+	}
+
+	return res, nil
+}
+
+// Unsuspend reverses the cascade: flag off, Kratos active, domains re-enabled,
+// OS user unlocked. It does NOT restart Docker apps (matches the REST handler —
+// the operator restarts them deliberately). Best-effort on steps 2-4.
+func Unsuspend(ctx context.Context, d Deps, user *models.User) (UnsuspendResult, error) {
+	res := UnsuspendResult{}
+	if d.Users == nil || user == nil {
+		return res, errors.New("userops.Unsuspend: users repo + user required")
+	}
+	if !user.Suspended {
+		res.AlreadyActive = true
+		return res, nil
+	}
+
+	if err := d.Users.SetSuspended(ctx, user.ID, false, ""); err != nil {
+		return res, fmt.Errorf("unsuspend db write: %w", err)
+	}
+
+	if user.KratosIdentityID != nil && *user.KratosIdentityID != "" {
+		res.KratosWarning = kratosStateWarning(ctx, d, *user.KratosIdentityID, "active", false)
+	}
+
+	if d.Domains != nil {
+		if n, err := d.Domains.BulkSetEnabledByUserID(ctx, user.ID, true); err != nil {
+			res.DomainWarning = "domain_bulk_enable_failed: " + err.Error()
+		} else {
+			res.DomainsEnabled = n
+		}
+	}
+
+	if user.Username != nil && *user.Username != "" && d.Agent != nil {
+		if _, err := d.Agent.Call(ctx, "user.unsuspend", map[string]any{"username": *user.Username}); err != nil {
+			res.OSWarning = "user_os_unsuspend_failed: " + err.Error()
+		}
+	}
+
+	return res, nil
+}

--- a/panel-api/internal/userops/userops_suspend_test.go
+++ b/panel-api/internal/userops/userops_suspend_test.go
@@ -1,0 +1,114 @@
+package userops
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeSuspendUsers records SetSuspended calls; other UserRepository methods are
+// unused (embedded interface panics if called — a guard against scope creep).
+type fakeSuspendUsers struct {
+	repository.UserRepository
+	lastSetID       string
+	lastSetVal      bool
+	lastSetReason   string
+	setSuspendCalls int
+}
+
+func (f *fakeSuspendUsers) SetSuspended(_ context.Context, id string, v bool, reason string) error {
+	f.setSuspendCalls++
+	f.lastSetID, f.lastSetVal, f.lastSetReason = id, v, reason
+	return nil
+}
+
+type fakeSuspendDomains struct {
+	repository.DomainRepository
+	affected int64
+	lastEn   bool
+}
+
+func (f *fakeSuspendDomains) BulkSetEnabledByUserID(_ context.Context, _ string, enabled bool) (int64, error) {
+	f.lastEn = enabled
+	return f.affected, nil
+}
+
+func strptr(s string) *string { return &s }
+
+func TestSuspend_FullCascade(t *testing.T) {
+	users := &fakeSuspendUsers{}
+	doms := &fakeSuspendDomains{affected: 3}
+	ag := &recordingAgent{}
+	d := Deps{Users: users, Domains: doms, Agent: ag}
+	u := &models.User{ID: "u1", Username: strptr("alice")}
+
+	res, err := Suspend(context.Background(), d, u, "spam")
+	if err != nil {
+		t.Fatalf("Suspend: %v", err)
+	}
+	if res.AlreadySuspended {
+		t.Fatal("res.AlreadySuspended = true, want false")
+	}
+	if users.setSuspendCalls != 1 || !users.lastSetVal || users.lastSetReason != "spam" {
+		t.Errorf("SetSuspended not called with (true,'spam'): calls=%d val=%v reason=%q", users.setSuspendCalls, users.lastSetVal, users.lastSetReason)
+	}
+	if res.DomainsDisabled != 3 || doms.lastEn {
+		t.Errorf("domains: disabled=%d lastEnabled=%v, want 3 + false", res.DomainsDisabled, doms.lastEn)
+	}
+	// OS cascade fired for the linux user.
+	if len(ag.calls) != 1 || ag.calls[0].method != "user.suspend" {
+		t.Errorf("agent calls = %+v, want one user.suspend", ag.calls)
+	}
+}
+
+func TestSuspend_AlreadySuspended_NoWrites(t *testing.T) {
+	users := &fakeSuspendUsers{}
+	res, err := Suspend(context.Background(), Deps{Users: users}, &models.User{ID: "u1", Suspended: true}, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.AlreadySuspended {
+		t.Error("res.AlreadySuspended = false, want true")
+	}
+	if users.setSuspendCalls != 0 {
+		t.Errorf("SetSuspended called %d times on an already-suspended user, want 0", users.setSuspendCalls)
+	}
+}
+
+func TestSuspend_NilKratosWarns(t *testing.T) {
+	// User has a Kratos identity but no client is wired → a warning, not a fail.
+	res, err := Suspend(context.Background(), Deps{Users: &fakeSuspendUsers{}}, &models.User{ID: "u1", KratosIdentityID: strptr("kid")}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.KratosWarning != "kratos_client_unavailable" {
+		t.Errorf("KratosWarning = %q, want kratos_client_unavailable", res.KratosWarning)
+	}
+}
+
+func TestUnsuspend_ReversesCascade(t *testing.T) {
+	users := &fakeSuspendUsers{}
+	doms := &fakeSuspendDomains{affected: 2}
+	ag := &recordingAgent{}
+	d := Deps{Users: users, Domains: doms, Agent: ag}
+	u := &models.User{ID: "u1", Username: strptr("alice"), Suspended: true}
+
+	res, err := Unsuspend(context.Background(), d, u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AlreadyActive {
+		t.Fatal("res.AlreadyActive = true, want false")
+	}
+	if users.setSuspendCalls != 1 || users.lastSetVal {
+		t.Errorf("SetSuspended not called with false: calls=%d val=%v", users.setSuspendCalls, users.lastSetVal)
+	}
+	if res.DomainsEnabled != 2 || !doms.lastEn {
+		t.Errorf("domains: enabled=%d lastEnabled=%v, want 2 + true", res.DomainsEnabled, doms.lastEn)
+	}
+	if len(ag.calls) != 1 || ag.calls[0].method != "user.unsuspend" {
+		t.Errorf("agent calls = %+v, want one user.unsuspend", ag.calls)
+	}
+}


### PR DESCRIPTION
Closes JAB-127 (Plane).

Admins could suspend/unsuspend a user via GUI + API but had **no headless CLI** for this common incident-response action.

## Approach — share, don't duplicate
Two suspend paths already existed (admin handler = full cascade; automation = flag-only). Rather than add a third, the cascade is extracted into **`userops.Suspend/Unsuspend`** and both the admin REST handler and the new CLI call it:
1. `users.suspended` flag (the load-bearing login gate)
2. Kratos identity → inactive + invalidate cached whoami
3. disable owned domains
4. stop the tenant's Docker apps
5. agent `user.suspend` (OS: drop from `jabali-sftp` group + lock password)

Steps 2–5 are best-effort (warnings, never hard errors). Refusing to suspend an admin stays with the caller.

- **`internal/userops/userops_suspend.go`** — `Suspend`/`Unsuspend` with step-named warnings so the REST response keys (`kratos_warning`/`domain_warning`/`os_warning`) are **unchanged**.
- **`internal/api/users_suspend.go`** — handler now delegates to userops (~90 lines of inline cascade removed; same contract).
- **`cmd/server`** — `jabali user suspend <id> [--reason]` / `unsuspend <id>`, admin-refused, prints domains-affected + warnings.

## Acceptance criteria
- [x] CLI suspends + unsuspends a user; state matches the GUI badge (same `users.suspended` flag + full cascade)

## Test plan
- [x] `go build ./...`, `go vet`, `go test ./internal/userops ./internal/api ./cmd/server` green
- [x] New userops tests: full cascade, already-suspended no-op, nil-Kratos warning, unsuspend reverse; CLI-reference golden regenerated