### PR TITLE
feat(cli): jabali session list/revoke/revoke-user (JAB-120)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4266,6 +4266,42 @@ Show service status details
 jabali service status
 ```
 
+### `jabali session`
+
+Audit and revoke active login sessions (Kratos)
+
+```
+jabali session
+```
+
+#### `jabali session list`
+
+List active login sessions (optionally filtered by --user email)
+
+```
+jabali session list [flags]
+```
+
+**Flags:**
+
+- `--user` — only show sessions for this user email
+
+#### `jabali session revoke`
+
+Revoke a single login session
+
+```
+jabali session revoke <session-id>
+```
+
+#### `jabali session revoke-user`
+
+Revoke ALL login sessions for a user (sign out everywhere)
+
+```
+jabali session revoke-user <email-or-id>
+```
+
 ### `jabali settings`
 
 Inspect and patch server settings (headless equivalent of /admin/settings)

--- a/internal/kratosclient/admin.go
+++ b/internal/kratosclient/admin.go
@@ -767,3 +767,28 @@ func (c *Client) RevokeSession(ctx context.Context, sessionID string) error {
 	}
 	return nil
 }
+
+// RevokeIdentitySessions deletes ALL active sessions for one identity (JAB-120):
+// the headless equivalent of "sign this user out everywhere". Kratos admin:
+// DELETE /admin/identities/{id}/sessions. A 404 (identity has no sessions /
+// unknown) is treated as success — the desired end state already holds.
+func (c *Client) RevokeIdentitySessions(ctx context.Context, identityID string) error {
+	if identityID == "" {
+		return fmt.Errorf("revokeidentitysessions: empty identity id")
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete,
+		c.adminURL+"/admin/identities/"+url.PathEscape(identityID)+"/sessions", nil)
+	if err != nil {
+		return fmt.Errorf("revokeidentitysessions: request: %w", err)
+	}
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("revokeidentitysessions: do: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		errBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("revokeidentitysessions: status %d: %s", resp.StatusCode, string(errBody))
+	}
+	return nil
+}

--- a/internal/kratosclient/admin_test.go
+++ b/internal/kratosclient/admin_test.go
@@ -752,3 +752,52 @@ func TestSetIdentityState_EmptyIDFails(t *testing.T) {
 		t.Fatal("expected error on empty identity id")
 	}
 }
+
+func TestRevokeIdentitySessions_Success(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/admin/identities/idA/sessions" {
+			t.Errorf("wrong path: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newAdminClient(srv)
+	if err := c.RevokeIdentitySessions(context.Background(), "idA"); err != nil {
+		t.Fatalf("RevokeIdentitySessions: %v", err)
+	}
+}
+
+func TestRevokeIdentitySessions_404IsIdempotent(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newAdminClient(srv)
+	if err := c.RevokeIdentitySessions(context.Background(), "no-sessions"); err != nil {
+		t.Fatalf("404 (no sessions) must be idempotent: %v", err)
+	}
+}
+
+func TestRevokeIdentitySessions_EmptyIDShortCircuits(t *testing.T) {
+	t.Parallel()
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newAdminClient(srv)
+	if err := c.RevokeIdentitySessions(context.Background(), ""); err == nil {
+		t.Fatal("empty id should error")
+	}
+	if hits != 0 {
+		t.Errorf("empty id triggered %d HTTP calls (want 0)", hits)
+	}
+}

--- a/panel-api/cmd/server/root.go
+++ b/panel-api/cmd/server/root.go
@@ -102,6 +102,7 @@ func newRootCmd() *cobra.Command {
 		newServeCmd(),
 		newVersionCmd(),
 		newUserCmd(),
+		newSessionCmd(),
 		newPackageCmd(),
 		newDomainCmd(),
 		newAppCmd(),

--- a/panel-api/cmd/server/session_cmd.go
+++ b/panel-api/cmd/server/session_cmd.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+)
+
+// session_cmd.go — `jabali session list/revoke/revoke-user` (JAB-120). Headless
+// equivalent of the admin Sessions page: audit + kill interactive Kratos login
+// sessions during an incident or when the GUI is unavailable. Backed by the same
+// kratosclient the API uses (ListActiveSessions / RevokeSession /
+// RevokeIdentitySessions over the Kratos admin socket).
+
+func cliKratos() (*kratosclient.Client, error) {
+	if sharedCfg == nil {
+		return nil, fmt.Errorf("config not loaded")
+	}
+	return kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL), nil
+}
+
+func newSessionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "session",
+		Short: "Audit and revoke active login sessions (Kratos)",
+	}
+	cmd.AddCommand(newSessionListCmd(), newSessionRevokeCmd(), newSessionRevokeUserCmd())
+	return cmd
+}
+
+func newSessionListCmd() *cobra.Command {
+	var userFilter string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List active login sessions (optionally filtered by --user email)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+			kc, err := cliKratos()
+			if err != nil {
+				return err
+			}
+			sessions, err := kc.ListActiveSessions(ctx)
+			if err != nil {
+				return fmt.Errorf("list sessions: %w", err)
+			}
+			filter := strings.ToLower(strings.TrimSpace(userFilter))
+
+			type row struct {
+				ID, Email, Username, IP, AAL, AuthAt string
+			}
+			var rows []row
+			for _, s := range sessions {
+				email, username := "", ""
+				if s.Identity != nil {
+					email = s.Identity.GetTraitEmail()
+					username = s.Identity.GetTraitUsername()
+				}
+				if filter != "" && strings.ToLower(email) != filter {
+					continue
+				}
+				ip := ""
+				if len(s.Devices) > 0 {
+					ip = s.Devices[0].IPAddress
+				}
+				rows = append(rows, row{s.ID, email, username, ip, s.AAL, s.AuthenticatedAt})
+			}
+
+			if jsonOutput {
+				return printJSON(map[string]interface{}{"sessions": rows, "total": len(rows)})
+			}
+			if len(rows) == 0 {
+				fmt.Println("no active sessions")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "SESSION ID\tEMAIL\tUSERNAME\tIP\tAAL\tAUTHENTICATED")
+			for _, r := range rows {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.ID, r.Email, r.Username, r.IP, r.AAL, r.AuthAt)
+			}
+			return w.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&userFilter, "user", "", "only show sessions for this user email")
+	return cmd
+}
+
+func newSessionRevokeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <session-id>",
+		Short: "Revoke a single login session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+			kc, err := cliKratos()
+			if err != nil {
+				return err
+			}
+			if err := kc.RevokeSession(ctx, args[0]); err != nil {
+				return fmt.Errorf("revoke session: %w", err)
+			}
+			fmt.Printf("revoked session %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newSessionRevokeUserCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke-user <email-or-id>",
+		Short: "Revoke ALL login sessions for a user (sign out everywhere)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+
+			ident := args[0]
+			u, err := resolveUser(ctx, ident)
+			if err != nil || u == nil {
+				return fmt.Errorf("user %q not found", ident)
+			}
+			if u.KratosIdentityID == nil || *u.KratosIdentityID == "" {
+				return fmt.Errorf("user %q has no linked Kratos identity", ident)
+			}
+
+			kc, err := cliKratos()
+			if err != nil {
+				return err
+			}
+			if err := kc.RevokeIdentitySessions(ctx, *u.KratosIdentityID); err != nil {
+				return fmt.Errorf("revoke user sessions: %w", err)
+			}
+			fmt.Printf("revoked all sessions for user %s\n", ident)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Closes JAB-120 (Plane).

The admin Sessions page lists + revokes interactive Kratos login sessions, but there was **no CLI** — session audit/kill during an incident (or when the GUI is down) required a browser.

## `jabali session`
- **`list [--user <email>]`** — active sessions (id, email, username, ip, aal, authenticated-at); `-j` for JSON. Backed by `kratosclient.ListActiveSessions`.
- **`revoke <session-id>`** — `kratosclient.RevokeSession`.
- **`revoke-user <email|username|id>`** — sign a user out everywhere; resolves the user (`resolveUser`) → Kratos identity → new `kratosclient.RevokeIdentitySessions` (`DELETE /admin/identities/{id}/sessions`; 404 = idempotent no-op).

Same `kratosclient` the API uses, over the Kratos admin socket.

## Acceptance criteria
- [x] CLI lists active sessions and revokes one/all for a user, admin-scoped, mirroring the Sessions page + API

## Test plan
- [x] `go build ./...`, `go vet` clean; new kratosclient tests (RevokeIdentitySessions success / 404-idempotent / empty-id short-circuit); CLI-reference golden regenerated