### PR TITLE
feat(cli): jabali domain php-settings get/set (JAB-129)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1981,6 +1981,39 @@ jabali domain mta-sts <domain-name|domain-id> [flags]
 - `--disable` — disable MTA-STS
 - `--enable` — enable MTA-STS
 
+#### `jabali domain php-settings`
+
+Get/set a domain's php.ini directives (JAB-129)
+
+```
+jabali domain php-settings
+```
+
+##### `jabali domain php-settings get`
+
+Show a domain's php.ini directives
+
+```
+jabali domain php-settings get <domain-name-or-id>
+```
+
+##### `jabali domain php-settings set`
+
+Set php.ini directives (only the flags you pass change; reconciler converges)
+
+```
+jabali domain php-settings set <domain-name-or-id> [flags]
+```
+
+**Flags:**
+
+- `--max-execution-time` — max_execution_time seconds (1..86400) (default `0`)
+- `--max-input-time` — max_input_time seconds (1..86400) (default `0`)
+- `--max-input-vars` — max_input_vars (1..86400) (default `0`)
+- `--memory-limit` — memory_limit (e.g. 256M)
+- `--post-max-size` — post_max_size (e.g. 64M)
+- `--upload-max-filesize` — upload_max_filesize (e.g. 64M)
+
 #### `jabali domain php-version`
 
 Manage a domain's PHP version (per-domain FPM pool, GH #329)

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -40,6 +40,7 @@ func newDomainCmd() *cobra.Command {
 	cmd.AddCommand(domainExtraSubcommands()...)
 	// GH #329 per-domain PHP version (domain_php_version_cmd.go).
 	cmd.AddCommand(domainPHPVersionSubcommands()...)
+	cmd.AddCommand(domainPHPSettingsSubcommands()...)
 	return cmd
 }
 

--- a/panel-api/cmd/server/domain_php_settings_cmd.go
+++ b/panel-api/cmd/server/domain_php_settings_cmd.go
@@ -1,0 +1,178 @@
+// domain_php_settings_cmd.go — JAB-129: CLI parity for per-domain php.ini
+// directives (memory_limit, upload_max_filesize, post_max_size, max_input_vars,
+// max_execution_time, max_input_time). Mirrors GET/PATCH /domains/:id/php-settings
+// (domain_php_settings.go) but goes direct-DB; the running reconciler re-renders
+// the FPM pool config within a tick, same as the web path. PHP *version* has its
+// own command (`domain php-version`).
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+var cliPHPSizeRe = regexp.MustCompile(`^\d{1,8}[KMGkmg]?$`)
+
+func cliValidatePHPSize(name, v string) error {
+	if len(v) > 8 || !cliPHPSizeRe.MatchString(v) {
+		return fmt.Errorf("--%s %q invalid (digits + optional K/M/G, max 8 chars)", name, v)
+	}
+	return nil
+}
+
+func cliValidatePHPInt(name string, v int) error {
+	if v < 1 || v > 86400 {
+		return fmt.Errorf("--%s %d out of range (1..86400)", name, v)
+	}
+	return nil
+}
+
+// domainPHPSettingsSubcommands returns the `domain php-settings` group.
+func domainPHPSettingsSubcommands() []*cobra.Command {
+	return []*cobra.Command{newDomainPHPSettingsCmd()}
+}
+
+func newDomainPHPSettingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "php-settings",
+		Short: "Get/set a domain's php.ini directives (JAB-129)",
+	}
+	cmd.AddCommand(newDomainPHPSettingsGetCmd(), newDomainPHPSettingsSetCmd())
+	return cmd
+}
+
+func newDomainPHPSettingsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "get <domain-name-or-id>",
+		Short:   "Show a domain's php.ini directives",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			dom, err := resolveDomainSpec(ctx, domainRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			out := map[string]any{
+				"domain":              dom.Name,
+				"memory_limit":        derefStr(dom.PHPMemoryLimit),
+				"upload_max_filesize": derefStr(dom.PHPUploadMaxFilesize),
+				"post_max_size":       derefStr(dom.PHPPostMaxSize),
+				"max_input_vars":      derefInt(dom.PHPMaxInputVars),
+				"max_execution_time":  derefInt(dom.PHPMaxExecutionTime),
+				"max_input_time":      derefInt(dom.PHPMaxInputTime),
+			}
+			if jsonOutput {
+				return printJSON(out)
+			}
+			fmt.Printf("%s php.ini directives:\n", dom.Name)
+			for _, k := range []string{"memory_limit", "upload_max_filesize", "post_max_size", "max_input_vars", "max_execution_time", "max_input_time"} {
+				fmt.Printf("  %-20s %v\n", k, out[k])
+			}
+			return nil
+		},
+	}
+}
+
+func newDomainPHPSettingsSetCmd() *cobra.Command {
+	var (
+		memoryLimit  string
+		uploadMax    string
+		postMax      string
+		maxInputVars int
+		maxExecTime  int
+		maxInputTime int
+	)
+	cmd := &cobra.Command{
+		Use:     "set <domain-name-or-id> [flags]",
+		Short:   "Set php.ini directives (only the flags you pass change; reconciler converges)",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+
+			var s repository.DomainPHPSettings
+			any := false
+			f := cmd.Flags()
+			if f.Changed("memory-limit") {
+				if err := cliValidatePHPSize("memory-limit", memoryLimit); err != nil {
+					return err
+				}
+				s.MemoryLimit = &memoryLimit
+				any = true
+			}
+			if f.Changed("upload-max-filesize") {
+				if err := cliValidatePHPSize("upload-max-filesize", uploadMax); err != nil {
+					return err
+				}
+				s.UploadMaxFilesize = &uploadMax
+				any = true
+			}
+			if f.Changed("post-max-size") {
+				if err := cliValidatePHPSize("post-max-size", postMax); err != nil {
+					return err
+				}
+				s.PostMaxSize = &postMax
+				any = true
+			}
+			if f.Changed("max-input-vars") {
+				if err := cliValidatePHPInt("max-input-vars", maxInputVars); err != nil {
+					return err
+				}
+				s.MaxInputVars = &maxInputVars
+				any = true
+			}
+			if f.Changed("max-execution-time") {
+				if err := cliValidatePHPInt("max-execution-time", maxExecTime); err != nil {
+					return err
+				}
+				s.MaxExecutionTime = &maxExecTime
+				any = true
+			}
+			if f.Changed("max-input-time") {
+				if err := cliValidatePHPInt("max-input-time", maxInputTime); err != nil {
+					return err
+				}
+				s.MaxInputTime = &maxInputTime
+				any = true
+			}
+			if !any {
+				return fmt.Errorf("pass at least one directive flag (see --help)")
+			}
+
+			dom, err := resolveDomainSpec(ctx, domainRepoFromDB(), args[0])
+			if err != nil {
+				return err
+			}
+			if err := domainRepoFromDB().UpdatePHPSettings(ctx, dom.ID, s); err != nil {
+				return fmt.Errorf("update php-settings: %w", err)
+			}
+			fmt.Printf("updated php.ini directives for %s (reconciler will re-render the FPM pool)\n", dom.Name)
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&memoryLimit, "memory-limit", "", "memory_limit (e.g. 256M)")
+	f.StringVar(&uploadMax, "upload-max-filesize", "", "upload_max_filesize (e.g. 64M)")
+	f.StringVar(&postMax, "post-max-size", "", "post_max_size (e.g. 64M)")
+	f.IntVar(&maxInputVars, "max-input-vars", 0, "max_input_vars (1..86400)")
+	f.IntVar(&maxExecTime, "max-execution-time", 0, "max_execution_time seconds (1..86400)")
+	f.IntVar(&maxInputTime, "max-input-time", 0, "max_input_time seconds (1..86400)")
+	return cmd
+}
+
+func derefInt(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/panel-api/cmd/server/domain_php_settings_cmd_test.go
+++ b/panel-api/cmd/server/domain_php_settings_cmd_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+func TestCLIValidatePHPSize(t *testing.T) {
+	ok := []string{"256M", "64m", "128K", "1G", "512", "99999999"}
+	bad := []string{"", "256MB", "-1", "M", "256 M", "999999999", "12.5M"}
+	for _, v := range ok {
+		if err := cliValidatePHPSize("memory-limit", v); err != nil {
+			t.Errorf("size %q should be valid: %v", v, err)
+		}
+	}
+	for _, v := range bad {
+		if err := cliValidatePHPSize("memory-limit", v); err == nil {
+			t.Errorf("size %q should be invalid", v)
+		}
+	}
+}
+
+func TestCLIValidatePHPInt(t *testing.T) {
+	for _, v := range []int{1, 1000, 86400} {
+		if err := cliValidatePHPInt("max-input-vars", v); err != nil {
+			t.Errorf("int %d should be valid: %v", v, err)
+		}
+	}
+	for _, v := range []int{0, -5, 86401, 1000000} {
+		if err := cliValidatePHPInt("max-input-vars", v); err == nil {
+			t.Errorf("int %d should be invalid", v)
+		}
+	}
+}


### PR DESCRIPTION
Closes JAB-129 (Plane).

Per-domain php.ini directives were editable in the GUI/API (`GET/PATCH /domains/:id/php-settings`) but had **no CLI** — per-site PHP tuning couldn't be scripted.

## `jabali domain php-settings`
- **`get <domain>`** — memory_limit, upload_max_filesize, post_max_size, max_input_vars, max_execution_time, max_input_time (`-j` for JSON).
- **`set <domain> [flags]`** — `--memory-limit --upload-max-filesize --post-max-size --max-input-vars --max-execution-time --max-input-time`. Only the flags you pass change (PATCH semantics), with the **same validation as the API** (size: digits + optional K/M/G, ≤8 chars; ints 1..86400).

Direct-DB via `Domains.UpdatePHPSettings`; the running reconciler re-renders the FPM pool config within a tick, same as the web path. PHP *version* keeps its own command (`domain php-version`).

## Acceptance criteria
- [x] CLI reads + patches per-domain php-settings; GUI reflects the change (same DB rows + reconciler)

## Test plan
- [x] `go build ./...`, `go vet` clean; new `cliValidatePHPSize/Int` tests; CLI-reference golden regenerated