### PR TITLE
feat(cli): per-user egress approve/deny + set-policy (JAB-131)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3871,6 +3871,22 @@ Per-user PHP-FPM egress firewall (M34) operator commands
 jabali per-user-egress
 ```
 
+#### `jabali per-user-egress approve`
+
+Approve a pending egress request
+
+```
+jabali per-user-egress approve <request-id>
+```
+
+#### `jabali per-user-egress deny`
+
+Deny a pending egress request
+
+```
+jabali per-user-egress deny <request-id>
+```
+
 #### `jabali per-user-egress flip-mature`
 
 Flip mature LEARNING policies to ENFORCED
@@ -3883,6 +3899,43 @@ jabali per-user-egress flip-mature [flags]
 
 - `--dry-run` — show what would change without writing to DB
 - `--soak-days` — minimum LEARNING age before auto-flip to ENFORCED (default `7`)
+
+#### `jabali per-user-egress get`
+
+Show a user's egress policy
+
+```
+jabali per-user-egress get <email-or-id>
+```
+
+#### `jabali per-user-egress requests`
+
+List pending egress requests (the admin queue)
+
+```
+jabali per-user-egress requests
+```
+
+#### `jabali per-user-egress set-policy`
+
+Set a user's egress state + allowed destinations (replaces the list)
+
+```
+jabali per-user-egress set-policy <email-or-id> [flags]
+```
+
+**Flags:**
+
+- `--allow` — allowed destination CIDR[,PORT[,PROTO]] (repeatable; replaces the list) (default `[]`)
+- `--state` — egress state: off|learning|enforced (required)
+
+#### `jabali per-user-egress summary`
+
+Show egress policy state counts + pending queue depth
+
+```
+jabali per-user-egress summary
+```
 
 ### `jabali php`
 

--- a/panel-api/cmd/server/per_user_egress_cmd.go
+++ b/panel-api/cmd/server/per_user_egress_cmd.go
@@ -31,7 +31,15 @@ func newPerUserEgressCmd() *cobra.Command {
 		Use:   "per-user-egress",
 		Short: "Per-user PHP-FPM egress firewall (M34) operator commands",
 	}
-	cmd.AddCommand(newPerUserEgressFlipMatureCmd())
+	cmd.AddCommand(
+		newPerUserEgressFlipMatureCmd(),
+		newPerUserEgressRequestsCmd(),
+		newPerUserEgressDecideCmd(true),  // approve
+		newPerUserEgressDecideCmd(false), // deny
+		newPerUserEgressGetCmd(),
+		newPerUserEgressSummaryCmd(),
+		newPerUserEgressSetPolicyCmd(),
+	)
 	return cmd
 }
 

--- a/panel-api/cmd/server/per_user_egress_ops_cmd.go
+++ b/panel-api/cmd/server/per_user_egress_ops_cmd.go
@@ -1,0 +1,303 @@
+// per_user_egress_ops_cmd.go — JAB-131: CLI parity for the per-user PHP-FPM
+// egress firewall (M34) request queue + policy. The GUI/API can list, approve,
+// and deny egress requests and set a user's policy; the CLI previously only had
+// `flip-mature`. These commands go direct-DB (approve/deny reuse the shared
+// egressops.DecideRequest so the fold-into-policy cascade stays byte-identical
+// to the web path); the running reconciler re-renders nftables within a tick.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/egressops"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// maxCLIEgressExtras mirrors maxAllowedExtras in internal/api/user_egress.go.
+const maxCLIEgressExtras = 50
+
+func egressReqRepo() repository.UserEgressRequestRepository {
+	return repository.NewUserEgressRequestRepository(sharedDB)
+}
+
+func egressPolicyRepo() repository.UserEgressPolicyRepository {
+	return repository.NewUserEgressPolicyRepository(sharedDB)
+}
+
+func newPerUserEgressRequestsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "requests",
+		Short:   "List pending egress requests (the admin queue)",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+			rows, err := egressReqRepo().ListPending(ctx)
+			if err != nil {
+				return fmt.Errorf("list pending: %w", err)
+			}
+			if jsonOutput {
+				return printJSON(map[string]any{"data": rows, "total": len(rows)})
+			}
+			if len(rows) == 0 {
+				fmt.Println("no pending egress requests")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "REQUEST ID\tUSER ID\tCIDR\tPORT\tPROTO\tREASON\tCREATED")
+			for _, r := range rows {
+				port := "-"
+				if r.Port != nil {
+					port = strconv.FormatUint(uint64(*r.Port), 10)
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+					r.ID, r.UserID, r.CIDR, port, r.Protocol, truncateReason(r.Reason), r.CreatedAt.Format(time.RFC3339))
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func truncateReason(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > 40 {
+		return s[:37] + "..."
+	}
+	return s
+}
+
+func newPerUserEgressDecideCmd(approve bool) *cobra.Command {
+	use, verb, status := "deny <request-id>", "Deny", models.UserEgressRequestStatusDenied
+	if approve {
+		use, verb, status = "approve <request-id>", "Approve", models.UserEgressRequestStatusApproved
+	}
+	return &cobra.Command{
+		Use:     use,
+		Short:   verb + " a pending egress request",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			requestID := args[0]
+			// reviewedBy is empty: the CLI has no interactive session. The
+			// audit row below records the operator provenance.
+			req, err := egressops.DecideRequest(ctx,
+				egressops.Deps{Requests: egressReqRepo(), Policies: egressPolicyRepo()},
+				requestID, status, "")
+			if err != nil {
+				switch {
+				case errors.Is(err, repository.ErrNotFound):
+					return fmt.Errorf("request %q not found", requestID)
+				case errors.Is(err, egressops.ErrAlreadyDecided):
+					return fmt.Errorf("request %q is already %s (not pending)", requestID, req.Status)
+				default:
+					return fmt.Errorf("decide: %w", err)
+				}
+			}
+			cliAuditOK(ctx, "egress.request."+status, "user", req.UserID, &req.UserID)
+			if approve {
+				fmt.Printf("approved request %s (folded %s into %s's policy; reconciler will re-render nftables)\n",
+					requestID, req.CIDR, req.UserID)
+			} else {
+				fmt.Printf("denied request %s\n", requestID)
+			}
+			return nil
+		},
+	}
+}
+
+func newPerUserEgressGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "get <email-or-id>",
+		Short:   "Show a user's egress policy",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+			u, err := resolveUser(ctx, args[0])
+			if err != nil || u == nil {
+				return fmt.Errorf("user %q not found", args[0])
+			}
+			row, err := egressPolicyRepo().Get(ctx, u.ID)
+			if err != nil {
+				if errors.Is(err, repository.ErrNotFound) {
+					fmt.Printf("%s has no egress policy row (default applies)\n", args[0])
+					return nil
+				}
+				return fmt.Errorf("get policy: %w", err)
+			}
+			extras, _ := row.DecodeAllowedExtra()
+			if jsonOutput {
+				return printJSON(map[string]any{"user_id": row.UserID, "state": row.State, "allowed_extra": extras})
+			}
+			fmt.Printf("user:  %s (%s)\nstate: %s\nallowed_extra (%d):\n", args[0], row.UserID, row.State, len(extras))
+			for _, e := range extras {
+				fmt.Printf("  %s\n", formatDestination(e))
+			}
+			return nil
+		},
+	}
+}
+
+func newPerUserEgressSummaryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "summary",
+		Short:   "Show egress policy state counts + pending queue depth",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
+			defer cancel()
+			counts, err := egressPolicyRepo().StateCounts(ctx)
+			if err != nil {
+				return fmt.Errorf("state counts: %w", err)
+			}
+			pending, err := egressReqRepo().ListPending(ctx)
+			if err != nil {
+				return fmt.Errorf("list pending: %w", err)
+			}
+			out := map[string]any{
+				"states":           counts,
+				"pending_requests": len(pending),
+			}
+			if jsonOutput {
+				return printJSON(out)
+			}
+			fmt.Printf("egress policy states:\n")
+			for _, s := range []string{models.UserEgressStateOff, models.UserEgressStateLearning, models.UserEgressStateEnforced} {
+				fmt.Printf("  %-9s %d\n", s, counts[s])
+			}
+			fmt.Printf("pending requests: %d\n", len(pending))
+			return nil
+		},
+	}
+}
+
+func newPerUserEgressSetPolicyCmd() *cobra.Command {
+	var (
+		state  string
+		allows []string
+	)
+	cmd := &cobra.Command{
+		Use:   "set-policy <email-or-id>",
+		Short: "Set a user's egress state + allowed destinations (replaces the list)",
+		Long: "Set the per-user egress policy. --state is one of off|learning|enforced.\n" +
+			"Each --allow is CIDR[,PORT[,PROTO]] (repeatable), e.g.\n" +
+			"  --allow 10.0.0.0/8 --allow 1.2.3.4/32,443 --allow 1.2.3.4/32,53,udp\n" +
+			"The allow list REPLACES the user's allowed_extra (matches PUT /users/:id/egress).",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+
+			if !validCLIEgressState(state) {
+				return fmt.Errorf("--state must be one of off|learning|enforced (got %q)", state)
+			}
+			if len(allows) > maxCLIEgressExtras {
+				return fmt.Errorf("too many --allow entries (%d, max %d)", len(allows), maxCLIEgressExtras)
+			}
+			extras := make([]models.EgressDestination, 0, len(allows))
+			for i, a := range allows {
+				dest, err := parseCLIAllow(a)
+				if err != nil {
+					return fmt.Errorf("--allow %q (index %d): %w", a, i, err)
+				}
+				extras = append(extras, dest)
+			}
+
+			u, err := resolveUser(ctx, args[0])
+			if err != nil || u == nil {
+				return fmt.Errorf("user %q not found", args[0])
+			}
+
+			jsonExtras, _ := json.Marshal(extras)
+			policy := &models.UserEgressPolicy{
+				UserID:       u.ID,
+				State:        state,
+				AllowedExtra: jsonExtras,
+			}
+			if err := egressPolicyRepo().Upsert(ctx, policy); err != nil {
+				return fmt.Errorf("upsert policy: %w", err)
+			}
+			cliAuditOK(ctx, "egress.policy.set", "user", u.ID, &u.ID)
+			fmt.Printf("set %s egress policy: state=%s, %d allowed destination(s) (reconciler will re-render nftables)\n",
+				args[0], state, len(extras))
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&state, "state", "", "egress state: off|learning|enforced (required)")
+	f.StringArrayVar(&allows, "allow", nil, "allowed destination CIDR[,PORT[,PROTO]] (repeatable; replaces the list)")
+	_ = cmd.MarkFlagRequired("state")
+	return cmd
+}
+
+func validCLIEgressState(s string) bool {
+	return s == models.UserEgressStateOff ||
+		s == models.UserEgressStateLearning ||
+		s == models.UserEgressStateEnforced
+}
+
+// parseCLIAllow parses a CIDR[,PORT[,PROTO]] token into a validated
+// EgressDestination. Mirrors validateExtra in internal/api/user_egress.go.
+func parseCLIAllow(s string) (models.EgressDestination, error) {
+	var dest models.EgressDestination
+	parts := strings.Split(s, ",")
+	cidr := strings.TrimSpace(parts[0])
+	if _, _, err := net.ParseCIDR(cidr); err != nil {
+		return dest, fmt.Errorf("cidr: %v", err)
+	}
+	dest.CIDR = cidr
+	if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
+		p, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil || p < 1 || p > 65535 {
+			return dest, fmt.Errorf("port must be 1..65535")
+		}
+		dest.Port = &p
+	}
+	proto := models.UserEgressProtocolTCP
+	if len(parts) >= 3 && strings.TrimSpace(parts[2]) != "" {
+		proto = strings.ToLower(strings.TrimSpace(parts[2]))
+	}
+	if proto != models.UserEgressProtocolTCP && proto != models.UserEgressProtocolUDP {
+		return dest, fmt.Errorf("protocol must be tcp or udp")
+	}
+	dest.Protocol = proto
+	if len(parts) > 3 {
+		return dest, fmt.Errorf("too many fields (want CIDR[,PORT[,PROTO]])")
+	}
+	return dest, nil
+}
+
+func formatDestination(e models.EgressDestination) string {
+	proto := e.Protocol
+	if proto == "" {
+		proto = models.UserEgressProtocolTCP
+	}
+	port := "any"
+	if e.Port != nil {
+		port = strconv.Itoa(*e.Port)
+	}
+	out := fmt.Sprintf("%s port=%s proto=%s", e.CIDR, port, proto)
+	if e.Comment != "" {
+		out += "  # " + e.Comment
+	}
+	return out
+}

--- a/panel-api/cmd/server/per_user_egress_ops_cmd_test.go
+++ b/panel-api/cmd/server/per_user_egress_ops_cmd_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func TestParseCLIAllow(t *testing.T) {
+	ok := []struct {
+		in       string
+		cidr     string
+		port     int // -1 = nil
+		protocol string
+	}{
+		{"10.0.0.0/8", "10.0.0.0/8", -1, "tcp"},
+		{"1.2.3.4/32,443", "1.2.3.4/32", 443, "tcp"},
+		{"1.2.3.4/32,53,udp", "1.2.3.4/32", 53, "udp"},
+		{"1.2.3.4/32,,udp", "1.2.3.4/32", -1, "udp"},
+		{" 10.0.0.0/8 , 80 , TCP ", "10.0.0.0/8", 80, "tcp"},
+	}
+	for _, c := range ok {
+		d, err := parseCLIAllow(c.in)
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", c.in, err)
+			continue
+		}
+		if d.CIDR != c.cidr || d.Protocol != c.protocol {
+			t.Errorf("%q: got cidr=%q proto=%q", c.in, d.CIDR, d.Protocol)
+		}
+		if c.port == -1 && d.Port != nil {
+			t.Errorf("%q: expected nil port, got %d", c.in, *d.Port)
+		}
+		if c.port != -1 && (d.Port == nil || *d.Port != c.port) {
+			t.Errorf("%q: expected port %d", c.in, c.port)
+		}
+	}
+
+	bad := []string{
+		"",                     // empty
+		"not-a-cidr",           // bare token
+		"1.2.3.4",              // IP without mask (ParseCIDR requires /n)
+		"1.2.3.4/32,99999",     // port out of range
+		"1.2.3.4/32,0",         // port 0
+		"1.2.3.4/32,443,sctp",  // bad protocol
+		"1.2.3.4/32,443,tcp,x", // too many fields
+	}
+	for _, b := range bad {
+		if _, err := parseCLIAllow(b); err == nil {
+			t.Errorf("%q: expected error, got nil", b)
+		}
+	}
+}
+
+func TestValidCLIEgressState(t *testing.T) {
+	for _, s := range []string{"off", "learning", "enforced"} {
+		if !validCLIEgressState(s) {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	for _, s := range []string{"", "ENFORCED", "on", "block"} {
+		if validCLIEgressState(s) {
+			t.Errorf("%q should be invalid", s)
+		}
+	}
+}

--- a/panel-api/internal/api/user_egress.go
+++ b/panel-api/internal/api/user_egress.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/egressops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -195,89 +196,27 @@ func (h *userEgressHandler) denyRequest(c *gin.Context) {
 
 func (h *userEgressHandler) decideRequest(c *gin.Context, status string) {
 	requestID := c.Param("id")
-	req, err := h.cfg.Requests.Get(c.Request.Context(), requestID)
-	if err != nil {
-		if errors.Is(err, repository.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "request_not_found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "fetch_request"})
-		return
-	}
-	if req.Status != models.UserEgressRequestStatusPending {
-		c.JSON(http.StatusConflict, gin.H{"error": "already_decided", "status": req.Status})
-		return
-	}
-
 	claims := ginctx.Claims(c)
 	reviewedBy := ""
 	if claims != nil {
 		reviewedBy = claims.UserID
 	}
 
-	if err := h.cfg.Requests.Decide(c.Request.Context(), requestID, status, reviewedBy); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "decide", "detail": err.Error()})
+	req, err := egressops.DecideRequest(c.Request.Context(),
+		egressops.Deps{Requests: h.cfg.Requests, Policies: h.cfg.Policies},
+		requestID, status, reviewedBy)
+	if err != nil {
+		switch {
+		case errors.Is(err, repository.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "request_not_found"})
+		case errors.Is(err, egressops.ErrAlreadyDecided):
+			c.JSON(http.StatusConflict, gin.H{"error": "already_decided", "status": req.Status})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "decide", "detail": err.Error()})
+		}
 		return
 	}
-
-	if status == models.UserEgressRequestStatusApproved {
-		if err := h.foldRequestIntoPolicy(c, req); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "fold_request", "detail": err.Error()})
-			return
-		}
-	}
 	c.JSON(http.StatusOK, gin.H{"id": requestID, "status": status})
-}
-
-// foldRequestIntoPolicy appends the approved destination to the user's
-// allowed_extra list. Dedupes on (cidr, port, protocol).
-func (h *userEgressHandler) foldRequestIntoPolicy(c *gin.Context, req *models.UserEgressRequest) error {
-	policy, err := h.cfg.Policies.Get(c.Request.Context(), req.UserID)
-	if err != nil {
-		if !errors.Is(err, repository.ErrNotFound) {
-			return err
-		}
-		// User has no row yet; create one in enforced state with the
-		// approved destination as the only entry.
-		policy = &models.UserEgressPolicy{
-			UserID: req.UserID,
-			State:  models.UserEgressStateEnforced,
-		}
-	}
-	existing, _ := policy.DecodeAllowedExtra()
-	proto := req.Protocol
-	if proto == "" {
-		proto = models.UserEgressProtocolTCP
-	}
-	for _, e := range existing {
-		samePort := (e.Port == nil && req.Port == nil) ||
-			(e.Port != nil && req.Port != nil && uint(*e.Port) == *req.Port)
-		if e.CIDR == req.CIDR && samePort && e.Protocol == proto {
-			return nil // already there
-		}
-	}
-	var portPtr *int
-	if req.Port != nil {
-		v := int(*req.Port)
-		portPtr = &v
-	}
-	existing = append(existing, models.EgressDestination{
-		CIDR:     req.CIDR,
-		Port:     portPtr,
-		Protocol: proto,
-		Comment:  "approved request " + req.ID,
-	})
-	jsonExtras, _ := json.Marshal(existing)
-	policy.AllowedExtra = jsonExtras
-	if policy.State == "" {
-		policy.State = models.UserEgressStateEnforced
-	}
-	claims := ginctx.Claims(c)
-	if claims != nil && claims.UserID != "" {
-		uid := claims.UserID
-		policy.UpdatedBy = &uid
-	}
-	return h.cfg.Policies.Upsert(c.Request.Context(), policy)
 }
 
 // summary returns a quick aggregate for the admin dashboard widget.

--- a/panel-api/internal/egressops/egressops.go
+++ b/panel-api/internal/egressops/egressops.go
@@ -1,0 +1,100 @@
+// Package egressops holds the per-user PHP-FPM egress-firewall (M34)
+// application logic shared by the HTTP handler (internal/api/user_egress.go)
+// and the CLI (cmd/server/per_user_egress_cmd.go). Extracting the
+// approve/deny + fold-into-policy cascade here keeps the web and headless
+// paths byte-identical so the two can never drift (verify_wire_contract scar).
+package egressops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ErrAlreadyDecided is returned by DecideRequest when the target request is no
+// longer pending. Callers map it to a 409 (web) or a friendly message (CLI).
+var ErrAlreadyDecided = errors.New("egress request already decided")
+
+// Deps are the repositories DecideRequest operates on.
+type Deps struct {
+	Requests repository.UserEgressRequestRepository
+	Policies repository.UserEgressPolicyRepository
+}
+
+// DecideRequest approves or denies a pending egress request. On approval it
+// folds the request's destination into the user's policy (dedup on
+// cidr+port+protocol, creating an enforced policy when none exists). reviewedBy
+// is the deciding actor's user id ("" if unknown, e.g. the CLI). It returns the
+// request row even when already decided, so callers can report its status.
+//
+// Errors: repository.ErrNotFound (no such request), ErrAlreadyDecided (not
+// pending), or any repository failure from Decide/Upsert.
+func DecideRequest(ctx context.Context, deps Deps, requestID, status, reviewedBy string) (*models.UserEgressRequest, error) {
+	req, err := deps.Requests.Get(ctx, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if req.Status != models.UserEgressRequestStatusPending {
+		return req, ErrAlreadyDecided
+	}
+	if err := deps.Requests.Decide(ctx, requestID, status, reviewedBy); err != nil {
+		return req, err
+	}
+	if status == models.UserEgressRequestStatusApproved {
+		if err := foldRequestIntoPolicy(ctx, deps, req, reviewedBy); err != nil {
+			return req, err
+		}
+	}
+	return req, nil
+}
+
+// foldRequestIntoPolicy appends the approved destination to the user's
+// allowed_extra list. Dedupes on (cidr, port, protocol). Creates an enforced
+// policy when the user has none yet.
+func foldRequestIntoPolicy(ctx context.Context, deps Deps, req *models.UserEgressRequest, reviewedBy string) error {
+	policy, err := deps.Policies.Get(ctx, req.UserID)
+	if err != nil {
+		if !errors.Is(err, repository.ErrNotFound) {
+			return err
+		}
+		policy = &models.UserEgressPolicy{
+			UserID: req.UserID,
+			State:  models.UserEgressStateEnforced,
+		}
+	}
+	existing, _ := policy.DecodeAllowedExtra()
+	proto := req.Protocol
+	if proto == "" {
+		proto = models.UserEgressProtocolTCP
+	}
+	for _, e := range existing {
+		samePort := (e.Port == nil && req.Port == nil) ||
+			(e.Port != nil && req.Port != nil && uint(*e.Port) == *req.Port)
+		if e.CIDR == req.CIDR && samePort && e.Protocol == proto {
+			return nil // already present
+		}
+	}
+	var portPtr *int
+	if req.Port != nil {
+		v := int(*req.Port)
+		portPtr = &v
+	}
+	existing = append(existing, models.EgressDestination{
+		CIDR:     req.CIDR,
+		Port:     portPtr,
+		Protocol: proto,
+		Comment:  "approved request " + req.ID,
+	})
+	jsonExtras, _ := json.Marshal(existing)
+	policy.AllowedExtra = jsonExtras
+	if policy.State == "" {
+		policy.State = models.UserEgressStateEnforced
+	}
+	if reviewedBy != "" {
+		policy.UpdatedBy = &reviewedBy
+	}
+	return deps.Policies.Upsert(ctx, policy)
+}

--- a/panel-api/internal/egressops/egressops_test.go
+++ b/panel-api/internal/egressops/egressops_test.go
@@ -1,0 +1,169 @@
+package egressops
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes -----------------------------------------------------------------
+
+type fakeReqRepo struct {
+	req         *models.UserEgressRequest
+	getErr      error
+	decideErr   error
+	decidedWith [3]string // id, status, reviewedBy
+	decideCalls int
+}
+
+func (f *fakeReqRepo) Get(_ context.Context, _ string) (*models.UserEgressRequest, error) {
+	return f.req, f.getErr
+}
+func (f *fakeReqRepo) Decide(_ context.Context, id, status, reviewedBy string) error {
+	f.decideCalls++
+	f.decidedWith = [3]string{id, status, reviewedBy}
+	if f.req != nil && f.decideErr == nil {
+		f.req.Status = status
+	}
+	return f.decideErr
+}
+func (f *fakeReqRepo) Create(context.Context, *models.UserEgressRequest) error { return nil }
+func (f *fakeReqRepo) ListPending(context.Context) ([]models.UserEgressRequest, error) {
+	return nil, nil
+}
+func (f *fakeReqRepo) ListByUser(context.Context, string) ([]models.UserEgressRequest, error) {
+	return nil, nil
+}
+func (f *fakeReqRepo) CancelPending(context.Context, string, string) error { return nil }
+
+type fakePolicyRepo struct {
+	policy      *models.UserEgressPolicy
+	getErr      error
+	upserted    *models.UserEgressPolicy
+	upsertCalls int
+}
+
+func (f *fakePolicyRepo) Get(context.Context, string) (*models.UserEgressPolicy, error) {
+	return f.policy, f.getErr
+}
+func (f *fakePolicyRepo) Upsert(_ context.Context, p *models.UserEgressPolicy) error {
+	f.upsertCalls++
+	f.upserted = p
+	return nil
+}
+func (f *fakePolicyRepo) EnsureDefault(context.Context, string, string) error { return nil }
+func (f *fakePolicyRepo) List(context.Context) ([]models.UserEgressPolicy, error) {
+	return nil, nil
+}
+func (f *fakePolicyRepo) ListAllForReconcile(context.Context) ([]repository.PolicyForReconcile, error) {
+	return nil, nil
+}
+func (f *fakePolicyRepo) SetDropCount(context.Context, string, uint64, time.Time) error { return nil }
+func (f *fakePolicyRepo) StateCounts(context.Context) (map[string]uint, error)          { return nil, nil }
+func (f *fakePolicyRepo) ListMatureLearning(context.Context, time.Duration) ([]models.UserEgressPolicy, error) {
+	return nil, nil
+}
+
+// --- tests -----------------------------------------------------------------
+
+func port(p uint) *uint { return &p }
+
+func TestDecideRequest_ApproveFoldsIntoNewPolicy(t *testing.T) {
+	reqs := &fakeReqRepo{req: &models.UserEgressRequest{
+		ID: "REQ1", UserID: "U1", CIDR: "1.2.3.4/32", Port: port(443), Protocol: "tcp",
+		Status: models.UserEgressRequestStatusPending,
+	}}
+	pols := &fakePolicyRepo{getErr: repository.ErrNotFound} // no policy yet
+
+	got, err := DecideRequest(context.Background(), Deps{reqs, pols},
+		"REQ1", models.UserEgressRequestStatusApproved, "admin1")
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if got.Status != models.UserEgressRequestStatusApproved {
+		t.Errorf("request status = %q", got.Status)
+	}
+	if reqs.decideCalls != 1 || reqs.decidedWith[1] != models.UserEgressRequestStatusApproved {
+		t.Errorf("Decide not called with approved: %+v", reqs.decidedWith)
+	}
+	if pols.upsertCalls != 1 {
+		t.Fatalf("expected policy upsert, got %d calls", pols.upsertCalls)
+	}
+	if pols.upserted.State != models.UserEgressStateEnforced {
+		t.Errorf("new policy should be enforced, got %q", pols.upserted.State)
+	}
+	var extras []models.EgressDestination
+	_ = json.Unmarshal(pols.upserted.AllowedExtra, &extras)
+	if len(extras) != 1 || extras[0].CIDR != "1.2.3.4/32" || extras[0].Port == nil || *extras[0].Port != 443 {
+		t.Errorf("folded destination wrong: %+v", extras)
+	}
+}
+
+func TestDecideRequest_ApproveDedupesExisting(t *testing.T) {
+	existing, _ := json.Marshal([]models.EgressDestination{
+		{CIDR: "1.2.3.4/32", Port: func() *int { v := 443; return &v }(), Protocol: "tcp"},
+	})
+	reqs := &fakeReqRepo{req: &models.UserEgressRequest{
+		ID: "REQ2", UserID: "U1", CIDR: "1.2.3.4/32", Port: port(443), Protocol: "tcp",
+		Status: models.UserEgressRequestStatusPending,
+	}}
+	pols := &fakePolicyRepo{policy: &models.UserEgressPolicy{
+		UserID: "U1", State: models.UserEgressStateEnforced, AllowedExtra: existing,
+	}}
+
+	if _, err := DecideRequest(context.Background(), Deps{reqs, pols},
+		"REQ2", models.UserEgressRequestStatusApproved, ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	// Destination already present → no upsert.
+	if pols.upsertCalls != 0 {
+		t.Errorf("expected no upsert for duplicate destination, got %d", pols.upsertCalls)
+	}
+}
+
+func TestDecideRequest_DenyDoesNotFold(t *testing.T) {
+	reqs := &fakeReqRepo{req: &models.UserEgressRequest{
+		ID: "REQ3", UserID: "U1", CIDR: "1.2.3.4/32", Status: models.UserEgressRequestStatusPending,
+	}}
+	pols := &fakePolicyRepo{getErr: repository.ErrNotFound}
+
+	if _, err := DecideRequest(context.Background(), Deps{reqs, pols},
+		"REQ3", models.UserEgressRequestStatusDenied, ""); err != nil {
+		t.Fatalf("deny: %v", err)
+	}
+	if reqs.decidedWith[1] != models.UserEgressRequestStatusDenied {
+		t.Errorf("Decide status = %q", reqs.decidedWith[1])
+	}
+	if pols.upsertCalls != 0 {
+		t.Errorf("deny must not touch policy, got %d upserts", pols.upsertCalls)
+	}
+}
+
+func TestDecideRequest_AlreadyDecided(t *testing.T) {
+	reqs := &fakeReqRepo{req: &models.UserEgressRequest{
+		ID: "REQ4", UserID: "U1", Status: models.UserEgressRequestStatusApproved,
+	}}
+	pols := &fakePolicyRepo{}
+
+	_, err := DecideRequest(context.Background(), Deps{reqs, pols},
+		"REQ4", models.UserEgressRequestStatusApproved, "")
+	if err != ErrAlreadyDecided {
+		t.Fatalf("expected ErrAlreadyDecided, got %v", err)
+	}
+	if reqs.decideCalls != 0 {
+		t.Errorf("Decide should not run on a non-pending request")
+	}
+}
+
+func TestDecideRequest_NotFound(t *testing.T) {
+	reqs := &fakeReqRepo{getErr: repository.ErrNotFound}
+	_, err := DecideRequest(context.Background(), Deps{reqs, &fakePolicyRepo{}},
+		"NOPE", models.UserEgressRequestStatusApproved, "")
+	if err != repository.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

The per-user PHP-FPM egress firewall (M34) request queue + policy were GUI/API-only; the CLI had only `flip-mature`. Adds:

```
jabali per-user-egress requests            # pending queue
jabali per-user-egress approve <req-id>    # approve + fold into policy
jabali per-user-egress deny <req-id>
jabali per-user-egress get <user>
jabali per-user-egress summary
jabali per-user-egress set-policy <user> --state <off|learning|enforced> \
      --allow CIDR[,PORT[,PROTO]] ...
```

## Design — no web/CLI drift

The approve→fold-into-policy cascade is extracted into a new **`internal/egressops`** package (`DecideRequest` + `foldRequestIntoPolicy`). Both the HTTP handler (`internal/api/user_egress.go`) and the CLI call it, so the two paths can never drift (verify_wire_contract scar). The handler keeps its exact **404 / 409 / 200** contract via typed sentinels (`repository.ErrNotFound`, `egressops.ErrAlreadyDecided`).

CLI is direct-DB; the running reconciler re-renders nftables within a tick. Every approve/deny/set-policy is audited via `cliAuditOK`.

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] `internal/egressops` unit tests (fakes): approve-fold-new-policy, dedup no-op, deny-no-fold, already-decided→409 sentinel, not-found propagation
- [x] CLI parse tests (`parseCLIAllow`, `validCLIEgressState`)
- [x] existing `internal/api` tests still pass (handler contract preserved)
- [x] CLI reference golden regenerated
- [ ] CI green
- [ ] Live-verify on .86: approve a request → destination folds into policy → reconciler renders nftables; GUI reflects state

Acceptance: CLI approves/denies a request and sets policy; GUI reflects state.