### PR TITLE
fix(ui): make login page logo larger + responsive (JAB-139)

### DIFF
--- a/panel-ui/src/pages/Login.tsx
+++ b/panel-ui/src/pages/Login.tsx
@@ -206,7 +206,15 @@ export const LoginPage = () => {
             <img
               src={logoSrc}
               alt="Jabali"
-              style={{ height: 64, width: "auto" }}
+              // Prominent brand mark: scales with the viewport but is
+              // capped so it never crowds the card or pushes fields below
+              // the fold on small laptop/mobile screens. SVG keeps it crisp
+              // on high-DPI displays at any size.
+              style={{
+                height: "clamp(96px, 16vw, 132px)",
+                width: "auto",
+                maxWidth: "100%",
+              }}
             />
             <Typography.Title level={2} style={{ margin: 0 }}>
               Jabali Panel


### PR DESCRIPTION
## What

The `/login` brand mark was a fixed `height: 64` — under-emphasized next to the login card and title. Switch to `height: clamp(96px, 16vw, 132px)`:

- **Desktop**: up to 132px — a strong first visual signal above the title.
- **Mobile / small laptop**: scales down to a 96px floor (16vw only overtakes 96px above ~600px width), so it never crowds the card or pushes fields below the fold.
- SVG source → crisp at any size on high-DPI. `maxWidth: 100%` guards narrow cards.

## Verification (preview screenshots)

- Desktop 1440×900 — logo prominent, card centered, no overflow.
- Mobile 390×844 — logo scaled to floor, card centered, no vertical overflow.

(Kratos init error in shots is expected — offline preview; only the brand block is under test.)

## Test plan

- [x] `npm run build` clean
- [x] `Login.test.tsx` (4 tests) pass
- [x] Manual visual check desktop + mobile
- [ ] CI green

Acceptance: logo noticeably larger + prominent; form stays centered/balanced; no mobile overflow; branding crisp.