### PR TITLE
fix(ui): move Sessions from sidebar into a Users page tab (JAB-126)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -45,7 +45,6 @@ import { PANEL_COLORS } from "./lib/panelColors";
 import { AdminSecurityPage } from "./shells/admin/security/AdminSecurityPage";
 import { ServerStatusPage } from "./shells/admin/server-status/ServerStatusPage";
 import { CacheOverviewPage } from "./shells/admin/cache/CacheOverviewPage";
-import { AdminSessionsPage } from "./shells/admin/sessions/AdminSessionsPage";
 import { MailDeliverabilityPage } from "./shells/admin/mail/MailDeliverabilityPage";
 import { MailThrottlesPage } from "./shells/admin/mail/MailThrottlesPage";
 import { SystemUpdatesPage } from "./shells/admin/updates/SystemUpdatesPage";
@@ -189,7 +188,14 @@ const ThemedApp = () => {
             <Route index element={<Navigate to="dashboard" replace />} />
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="cache" element={<CacheOverviewPage />} />
-            <Route path="sessions" element={<AdminSessionsPage />} />
+            {/* JAB-126: Sessions moved into the Users page as a tab.
+                Preserve old bookmarks/deep-links. */}
+            <Route
+              path="sessions"
+              element={
+                <Navigate to="/jabali-admin/users?tab=sessions" replace />
+              }
+            />
             <Route path="users">
               <Route index element={<UserList />} />
               {/* legacy /create + /edit/:id redirect to list — Drawer

--- a/panel-ui/src/nav.test.ts
+++ b/panel-ui/src/nav.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { adminNav } from "./nav";
+import { adminNav, selectedNavKey } from "./nav";
 
 describe("adminNav", () => {
   it("puts Support last", () => {
@@ -9,5 +9,17 @@ describe("adminNav", () => {
   it("gives every sidebar item a hover description", () => {
     const missing = adminNav.filter((n) => !n.description || n.description.trim() === "");
     expect(missing.map((n) => n.key)).toEqual([]);
+  });
+
+  // JAB-126: Sessions moved into the Users page as a tab.
+  it("has no standalone Sessions sidebar entry", () => {
+    expect(adminNav.some((n) => n.key === "sessions")).toBe(false);
+    expect(adminNav.some((n) => n.key === "users")).toBe(true);
+  });
+
+  it("keeps Users highlighted while viewing the Sessions tab", () => {
+    // ?tab=sessions lives on the /jabali-admin/users path, so the sidebar
+    // resolves to the Users row (selectedNavKey ignores the query string).
+    expect(selectedNavKey(adminNav, "/jabali-admin/users")).toBe("users");
   });
 });

--- a/panel-ui/src/nav.ts
+++ b/panel-ui/src/nav.ts
@@ -89,16 +89,12 @@ export const adminNav: NavItem[] = [
   {
     key: "users",
     label: "Users",
-    description: "Manage panel users and impersonation",
+    // JAB-126: Sessions moved into the Users page as a tab
+    // (/jabali-admin/users?tab=sessions), so this row stays active while
+    // viewing sessions and the sidebar loses the standalone Sessions entry.
+    description: "Manage panel users, sessions, and impersonation",
     icon: navIcon(TeamOutlined),
     path: "/jabali-admin/users",
-  },
-  {
-    key: "sessions",
-    label: "Sessions",
-    description: "Active login sessions",
-    icon: navIcon(KeyOutlined),
-    path: "/jabali-admin/sessions",
   },
   {
     key: "domains",

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -30,6 +30,7 @@ import { UserDiskUsage } from "./UserDiskUsage";
 import { UserReset2FAAction } from "./UserReset2FAAction";
 import { UserResetPasswordAction } from "./UserResetPasswordAction";
 import { UserSuspendAction } from "./UserSuspendAction";
+import { AdminSessionsPage } from "../sessions/AdminSessionsPage";
 
 type User = {
   id: string;
@@ -365,7 +366,9 @@ function UsersShellTable({
 }
 
 export const UserList = () => {
-  const [activeTab, setActiveTab] = useTabParam<"users" | "admins">("users");
+  const [activeTab, setActiveTab] = useTabParam<"users" | "admins" | "sessions">(
+    "users",
+  );
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | undefined>(undefined);
 
@@ -407,9 +410,11 @@ export const UserList = () => {
         <Typography.Title level={3} style={{ margin: 0 }}>
           <TeamOutlined /> Users
         </Typography.Title>
-        <Button type="primary" onClick={openCreate}>
-          Create
-        </Button>
+        {activeTab !== "sessions" && (
+          <Button type="primary" onClick={openCreate}>
+            Create
+          </Button>
+        )}
       </Space>
 
       {/* Card.tabList renders the tab strip visually attached to the
@@ -436,11 +441,21 @@ export const UserList = () => {
               </Space>
             ),
           },
+          {
+            // JAB-126: Sessions is now a tab here rather than a standalone
+            // sidebar entry. The view itself (AdminSessionsPage) is unchanged.
+            key: "sessions",
+            tab: <span>Sessions</span>,
+          },
         ]}
         activeTabKey={activeTab}
-        onTabChange={(k) => setActiveTab(k as "users" | "admins")}
+        onTabChange={(k) =>
+          setActiveTab(k as "users" | "admins" | "sessions")
+        }
       >
-        {activeTab === "users" ? (
+        {activeTab === "sessions" ? (
+          <AdminSessionsPage />
+        ) : activeTab === "users" ? (
           <UsersShellTable
             isAdmin={false}
             searchPlaceholder="Search by email, username, or name"


### PR DESCRIPTION
## What

Sessions belong to user-account management; a standalone sidebar entry split the workflow across two nav rows. Fold it into the Users page as a third tab alongside **Users** + **Administrators**.

- Remove the Sessions item from `adminNav` (sidebar).
- Add a **Sessions** tab to `UserList` — URL-driven via `useTabParam` → `/jabali-admin/users?tab=sessions`; renders the **unchanged** `AdminSessionsPage`.
- Redirect the old `/jabali-admin/sessions` route to the new tab (preserves bookmarks / deep-links).
- Sidebar keeps **Users** highlighted while on the Sessions tab (same path; `selectedNavKey` ignores the query string).
- Hide the Create-user button on the Sessions tab (contextually wrong there).

## Test plan

- [x] `npm run build` + `tsc` clean
- [x] `nav.test.ts`: no standalone `sessions` key; `users` present; `selectedNavKey` resolves `users` on the users path
- [x] existing `AdminBreadcrumb` tests still pass
- [ ] CI green
- [ ] Live-verify post-deploy on .86 (admin pages are auth-gated so offline preview can't render them): Users page shows Users/Administrators/Sessions; old `/jabali-admin/sessions` bookmark redirects; sidebar highlights Users

Acceptance: Sessions not a top-level sidebar item; Users page has 3 tabs; sessions functionality unchanged; old URL routes cleanly; sidebar highlights Users while viewing sessions.