### PR TITLE
fix(files): RFC 6266-escape Content-Disposition filenames (JAB-108)

### DIFF
--- a/panel-api/internal/api/content_disposition.go
+++ b/panel-api/internal/api/content_disposition.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// contentDisposition builds an RFC 6266-safe Content-Disposition header value
+// for a user-controlled filename (JAB-108). Linux filenames legally contain
+// `"` `;` and control characters; concatenating one straight into
+// `filename="..."` lets it break out of the quoted value and spoof the saved
+// name. We defend on two fronts:
+//
+//   - an ASCII-only `filename=` legacy fallback with `"` `\` control chars and
+//     non-ASCII bytes replaced by `_`, so it can never break out of the quotes;
+//   - an RFC 5987 extended `filename*` parameter (UTF-8, percent-encoded)
+//     carrying the true name, which modern browsers prefer and round-trips.
+//
+// dispType is "attachment" or "inline".
+func contentDisposition(dispType, filename string) string {
+	// Defense in depth: never let a path (separators / traversal) through.
+	filename = filepath.Base(filename)
+	if filename == "." || filename == string(filepath.Separator) || filename == "" {
+		filename = "download"
+	}
+
+	// ASCII fallback: keep printable ASCII; replace the quoting-relevant and
+	// non-representable runes with '_' so the quoted value is unambiguous.
+	var ascii strings.Builder
+	for _, r := range filename {
+		switch {
+		case r < 0x20 || r == 0x7f: // C0 controls + DEL
+			ascii.WriteByte('_')
+		case r == '"' || r == '\\':
+			ascii.WriteByte('_')
+		case r > 0x7f: // non-ASCII: not representable in the legacy param
+			ascii.WriteByte('_')
+		default:
+			ascii.WriteRune(r)
+		}
+	}
+	fallback := ascii.String()
+	if fallback == "" {
+		fallback = "download"
+	}
+
+	return fmt.Sprintf(
+		`%s; filename="%s"; filename*=UTF-8''%s`,
+		dispType, fallback, rfc5987Encode(filename),
+	)
+}
+
+// rfc5987Encode percent-encodes a string per RFC 5987 (ext-value), encoding
+// every byte that is not an attr-char. It operates on raw UTF-8 bytes so
+// multibyte runes are encoded byte-by-byte, as the RFC requires.
+func rfc5987Encode(s string) string {
+	const attrChars = "!#$&+-.^_`|~" // plus ALPHA / DIGIT, handled below
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || strings.IndexByte(attrChars, c) >= 0 {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}

--- a/panel-api/internal/api/content_disposition_test.go
+++ b/panel-api/internal/api/content_disposition_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"mime"
+	"strings"
+	"testing"
+)
+
+// rawFallback extracts the legacy `filename="..."` token straight from the
+// header string (before mime.ParseMediaType folds filename* over it), so we can
+// assert the fallback itself can't break out of its quotes.
+func rawFallback(t *testing.T, header string) string {
+	t.Helper()
+	const marker = `filename="`
+	i := strings.Index(header, marker)
+	if i < 0 {
+		t.Fatalf("no legacy filename= param in %q", header)
+	}
+	rest := header[i+len(marker):]
+	j := strings.IndexByte(rest, '"') // our fallback strips all inner quotes, so the next quote closes it
+	if j < 0 {
+		t.Fatalf("unterminated filename= param in %q", header)
+	}
+	return rest[:j]
+}
+
+func TestContentDisposition_ParsesToTrueName(t *testing.T) {
+	cases := []struct {
+		name     string
+		filename string
+		wantName string // the true name the browser should save
+	}{
+		{"plain", "report.pdf", "report.pdf"},
+		{"breakout attempt", `evil";filename="safe.txt`, `evil";filename="safe.txt`},
+		{"semicolon", "a;b;c.txt", "a;b;c.txt"},
+		{"backslash", `a\b.txt`, `a\b.txt`},
+		{"utf8", "naïve—файл.txt", "naïve—файл.txt"},
+		{"leading path stripped", "../../etc/passwd", "passwd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := contentDisposition("attachment", tc.filename)
+
+			// A breakout would either fail to parse or yield a filename other
+			// than the true name (a stray injected param wins/duplicates).
+			dtype, params, err := mime.ParseMediaType(h)
+			if err != nil {
+				t.Fatalf("header %q does not parse: %v", h, err)
+			}
+			if dtype != "attachment" {
+				t.Errorf("disposition type = %q, want attachment", dtype)
+			}
+			// mime folds the decoded filename* into params["filename"].
+			if got := params["filename"]; got != tc.wantName {
+				t.Errorf("decoded filename = %q, want %q", got, tc.wantName)
+			}
+
+			// The raw legacy fallback must be free of breakout vectors.
+			fb := rawFallback(t, h)
+			if strings.ContainsAny(fb, "\"\\") {
+				t.Errorf("legacy fallback %q contains a quote/backslash", fb)
+			}
+			for _, r := range fb {
+				if r < 0x20 || r == 0x7f {
+					t.Errorf("legacy fallback %q contains a control char", fb)
+				}
+			}
+		})
+	}
+}
+
+func TestContentDisposition_ControlCharsStripped(t *testing.T) {
+	h := contentDisposition("attachment", "a\r\n\tb\x00.txt")
+	_, params, err := mime.ParseMediaType(h)
+	if err != nil {
+		t.Fatalf("header does not parse: %v", err)
+	}
+	// filename* preserves the true bytes (percent-encoded on the wire).
+	if params["filename"] != "a\r\n\tb\x00.txt" {
+		t.Errorf("decoded filename = %q, lost the true bytes", params["filename"])
+	}
+	// The ASCII fallback replaced every control char with '_'.
+	if strings.ContainsAny(rawFallback(t, h), "\r\n\t\x00") {
+		t.Errorf("fallback still has control chars: %q", rawFallback(t, h))
+	}
+}
+
+func TestContentDisposition_InlineType(t *testing.T) {
+	h := contentDisposition("inline", "pic.png")
+	if !strings.HasPrefix(h, "inline; ") {
+		t.Errorf("want inline disposition, got %q", h)
+	}
+}
+
+func TestContentDisposition_EmptyFallsBackToDownload(t *testing.T) {
+	h := contentDisposition("attachment", "/")
+	if _, _, err := mime.ParseMediaType(h); err != nil {
+		t.Fatalf("header does not parse: %v", err)
+	}
+	if !strings.Contains(h, `filename="download"`) {
+		t.Errorf("want download fallback, got %q", h)
+	}
+}
+
+func TestRFC5987Encode(t *testing.T) {
+	cases := map[string]string{
+		"abc":     "abc",
+		"a b":     "a%20b",
+		`a"b`:     "a%22b",
+		"a;b":     "a%3Bb",
+		"café":    "caf%C3%A9", // UTF-8 bytes, per-byte percent-encoding
+		"a-b_c.d": "a-b_c.d",   // attr-chars pass through
+	}
+	for in, want := range cases {
+		if got := rfc5987Encode(in); got != want {
+			t.Errorf("rfc5987Encode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -494,8 +494,11 @@ func (h *databaseHandler) backup(c *gin.Context) {
 	}
 	defer f.Close()
 
-	// Set response headers for download
-	c.Header("Content-Disposition", "attachment; filename=\""+d.Name+"-"+time.Now().Format("20060102-150405")+".sql\"")
+	// Set response headers for download. JAB-108: d.Name is a user-chosen
+	// database name — route it through the RFC 6266 escaper so it can't
+	// break out of the quoted filename value.
+	dumpName := d.Name + "-" + time.Now().Format("20060102-150405") + ".sql"
+	c.Header("Content-Disposition", contentDisposition("attachment", dumpName))
 	c.Header("Content-Type", "application/sql")
 	c.Header("Content-Length", fmt.Sprintf("%d", resp.SizeBytes))
 

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -586,10 +586,15 @@ func (h *filesHandler) download(c *gin.Context) {
 	// downloads as an attachment.
 	inline := (strings.HasPrefix(ct, "image/") && !strings.Contains(ct, "svg")) ||
 		ct == "application/pdf"
-	disposition := `attachment; filename="` + filename + `"`
+	// JAB-108: filename is user-controlled (tenants can create files named
+	// with `"` / `;` / control chars over SFTP). Emit an RFC 6266-escaped
+	// header so the name can't break out of the quoted value and spoof the
+	// browser's save-as name.
+	dispType := "attachment"
 	if inline {
-		disposition = `inline; filename="` + filename + `"`
+		dispType = "inline"
 	}
+	disposition := contentDisposition(dispType, filename)
 
 	c.Header("Content-Type", ct)
 	c.Header("Content-Disposition", disposition)


### PR DESCRIPTION
## What

The File Manager download handler (`files.go`) and the DB export handler (`databases.go`) built `Content-Disposition` by concatenating a **user-controlled** filename straight inside `filename="..."`. Linux filenames legally contain `"` `;` and control chars, so a tenant who creates such a file over SFTP could break out of the quoted value and **spoof the browser's save-as name** (filename-spoofing, CWE-214 class).

## Fix

New `contentDisposition(dispType, filename)` helper emits an RFC 6266-safe header:

- ASCII-sanitized `filename=` fallback — `"` `\` control chars + non-ASCII → `_`, so it can never break out of the quotes;
- RFC 5987 `filename*=UTF-8''<pct-encoded>` carrying the **true** name, which modern browsers prefer and which round-trips exactly;
- `filepath.Base` guards path injection.

Applied to `files.go` download (attachment + inline) and `databases.go` SQL export — the two user-controlled sites. (`backups.go`/archive use ULIDs/constants — no user input.)

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] Unit tests: quote/semicolon/backslash/UTF-8/control-char/path names — each parses via `mime.ParseMediaType` to a **single** param whose decoded true name matches (a breakout would inject a second param or mis-decode); raw fallback asserted free of quotes/backslashes/controls; `rfc5987Encode` byte-level checks
- [x] Existing `files_test.go` disposition assertion still passes
- [ ] CI green

Acceptance: `evil";filename="safe.txt` yields one correctly-escaped disposition, browser saves the true name; control chars stripped from the fallback; unit test covers quote/semicolon/UTF-8.