### PR TITLE
fix(csrf): match full origin tuple (scheme+host+port), not hostname (JAB-115)

### DIFF
--- a/panel-api/internal/api/csrf.go
+++ b/panel-api/internal/api/csrf.go
@@ -24,9 +24,10 @@ import (
 //     preflight it can't satisfy, so token/automation callers are not
 //     browser-CSRF-able. Only cookie auth is, and only that path is checked.
 //   - For a cookie-authenticated mutating request, the Origin header (or
-//     Referer when Origin is absent) host must equal the request Host. A
-//     cross-site attacker cannot forge a matching Origin from the victim's
-//     browser, so a mismatch — or a request with neither header — is rejected.
+//     Referer when Origin is absent) must be the same origin as the request —
+//     scheme + host + port all match (RFC 6454). A cross-site attacker cannot
+//     forge a matching Origin from the victim's browser, so a mismatch — or a
+//     request with neither header — is rejected.
 //
 // Mounted on the /api/v1 group, so it covers every authenticated route
 // including the admin subgroups; the separately-mounted HMAC automation group
@@ -51,21 +52,45 @@ func EnforceSameOriginForCookieMutations() gin.HandlerFunc {
 }
 
 // requestIsSameOrigin reports whether the request's Origin (or, when absent,
-// Referer) names the same host as the request itself. Host comparison ignores
-// the port (hostnameOf) — the security property is that an attacker on another
-// domain cannot present the panel's hostname — but is exact hostname equality,
-// never substring matching. Both headers absent → false (a genuine browser
-// always sends at least one on a cross-/same-origin mutation).
+// Referer) is the same origin as the request itself per the RFC 6454 tuple:
+// scheme + host + port must all match (JAB-115). The authority comparison
+// (host[:port], exact) mirrors middleware.isSameOrigin — the CORS gate — and
+// the scheme is pinned on top so a same-hostname-different-port or
+// http-vs-https origin is rejected, not accepted. Both headers absent → false
+// (a genuine browser always sends at least one on a cross-/same-origin
+// mutation).
 func requestIsSameOrigin(c *gin.Context) bool {
+	reqScheme := requestScheme(c)
+	reqHost := c.Request.Host
 	for _, raw := range []string{c.GetHeader("Origin"), c.GetHeader("Referer")} {
 		if raw == "" {
 			continue
 		}
 		u, err := url.Parse(raw)
-		if err != nil || u.Host == "" {
+		if err != nil || u.Host == "" || u.Scheme == "" {
 			return false
 		}
-		return hostnameOf(u.Host) == hostnameOf(c.Request.Host)
+		// u.Host is host[:port]; compare the full authority exactly and pin
+		// the scheme. Browsers omit the default port in Origin, so a request
+		// served on 443 (Host "panel") matches Origin "https://panel".
+		return strings.EqualFold(u.Scheme, reqScheme) && u.Host == reqHost
 	}
 	return false
+}
+
+// requestScheme resolves the scheme the client used to reach the panel. Behind
+// the panel's own nginx, X-Forwarded-Proto is authoritative (nginx overwrites
+// any client-supplied value with $scheme, so a CSRF browser can't forge it);
+// fall back to the TLS state for direct connections.
+func requestScheme(c *gin.Context) string {
+	if xfp := c.GetHeader("X-Forwarded-Proto"); xfp != "" {
+		if i := strings.IndexByte(xfp, ','); i >= 0 {
+			xfp = xfp[:i] // first hop wins on a proxy chain
+		}
+		return strings.ToLower(strings.TrimSpace(xfp))
+	}
+	if c.Request.TLS != nil {
+		return "https"
+	}
+	return "http"
 }

--- a/panel-api/internal/api/csrf_test.go
+++ b/panel-api/internal/api/csrf_test.go
@@ -21,18 +21,26 @@ func TestEnforceSameOriginForCookieMutations(t *testing.T) {
 		origin     string
 		referer    string
 		authHeader string
+		xfProto    string // X-Forwarded-Proto (nginx sets $scheme); default https
 		wantStatus int
 	}{
-		{"safe GET cross-origin allowed", http.MethodGet, "https://evil.example/", "", "", http.StatusOK},
-		{"same-origin POST allowed", http.MethodPost, "https://panel.example.com:8443", "", "", http.StatusOK},
-		{"same-origin POST diff port allowed", http.MethodPost, "https://panel.example.com", "", "", http.StatusOK},
-		{"cross-origin POST rejected", http.MethodPost, "https://evil.example", "", "", http.StatusForbidden},
-		{"cross-origin PUT rejected", http.MethodPut, "https://evil.example", "", "", http.StatusForbidden},
-		{"cross-origin DELETE rejected", http.MethodDelete, "https://evil.example", "", "", http.StatusForbidden},
-		{"bearer token exempt even cross-origin", http.MethodPost, "https://evil.example", "", "Bearer abc123", http.StatusOK},
-		{"no origin no referer rejected", http.MethodPost, "", "", "", http.StatusForbidden},
-		{"origin absent referer same-origin allowed", http.MethodPost, "", "https://panel.example.com:8443/some/page", "", http.StatusOK},
-		{"origin absent referer cross-origin rejected", http.MethodPost, "", "https://evil.example/x", "", http.StatusForbidden},
+		{"safe GET cross-origin allowed", http.MethodGet, "https://evil.example/", "", "", "https", http.StatusOK},
+		{"same-origin POST allowed", http.MethodPost, "https://panel.example.com:8443", "", "", "https", http.StatusOK},
+		// JAB-115: same host but different port is a DIFFERENT origin — reject.
+		{"same-host diff port rejected", http.MethodPost, "https://panel.example.com", "", "", "https", http.StatusForbidden},
+		{"same-host explicit diff port rejected", http.MethodPost, "https://panel.example.com:9999", "", "", "https", http.StatusForbidden},
+		// JAB-115: http origin against an https request is cross-origin — reject.
+		{"same-authority diff scheme rejected", http.MethodPost, "http://panel.example.com:8443", "", "", "https", http.StatusForbidden},
+		{"cross-origin POST rejected", http.MethodPost, "https://evil.example", "", "", "https", http.StatusForbidden},
+		{"cross-origin PUT rejected", http.MethodPut, "https://evil.example", "", "", "https", http.StatusForbidden},
+		{"cross-origin DELETE rejected", http.MethodDelete, "https://evil.example", "", "", "https", http.StatusForbidden},
+		{"bearer token exempt even cross-origin", http.MethodPost, "https://evil.example", "", "Bearer abc123", "https", http.StatusOK},
+		{"no origin no referer rejected", http.MethodPost, "", "", "", "https", http.StatusForbidden},
+		{"origin absent referer same-origin allowed", http.MethodPost, "", "https://panel.example.com:8443/some/page", "", "https", http.StatusOK},
+		{"origin absent referer diff port rejected", http.MethodPost, "", "https://panel.example.com/some/page", "", "https", http.StatusForbidden},
+		{"origin absent referer cross-origin rejected", http.MethodPost, "", "https://evil.example/x", "", "https", http.StatusForbidden},
+		// Plain-http deployment (no proxy): request scheme comes from XFP=http.
+		{"http deployment same-origin allowed", http.MethodPost, "http://panel.example.com:8443", "", "", "http", http.StatusOK},
 	}
 
 	for _, c := range cases {
@@ -46,6 +54,9 @@ func TestEnforceSameOriginForCookieMutations(t *testing.T) {
 
 			req := httptest.NewRequest(c.method, "/api/v1/x", nil)
 			req.Host = host
+			if c.xfProto != "" {
+				req.Header.Set("X-Forwarded-Proto", c.xfProto)
+			}
 			if c.origin != "" {
 				req.Header.Set("Origin", c.origin)
 			}


### PR DESCRIPTION
## What

The same-origin CSRF gate (`requestIsSameOrigin`) compared only the **hostname** of `Origin`/`Referer` against the request `Host`, ignoring scheme and port — so `http://panel-host:9999` was accepted as same-origin for a request to `https://panel-host`. That's looser than the CORS gate, which already does an exact `host:port` authority match. RFC 6454 same-origin = **scheme + host + port**.

## Fix

`requestIsSameOrigin` now:
- compares `u.Host` (host[:port]) **exactly** to the request authority (mirrors `middleware.isSameOrigin`);
- pins the **scheme** via a new `requestScheme()` — reads `X-Forwarded-Proto` (the panel nginx sets it to `https` and overwrites any client value; existing code already trusts it), falling back to `Request.TLS`.

Browsers omit default ports in `Origin`, so a panel served on 443 (`Host: panel`) still matches `Origin: https://panel`. Verified nginx templates set XFP for the panel vhost, so this is production-safe; plain-http `:8484` direct access still works via the TLS/`http` fallback.

## Test plan

- [x] `go build ./...` + `go vet` + full `internal/api` tests pass
- [x] New cases: same-host implicit/explicit diff-port → **403**; `http` origin vs `https` request → **403**; same-origin (incl. `Referer`-only and plain-http deployment via `XFP=http`) → **200**; bearer-exempt + safe-method unchanged
- [ ] CI green

Acceptance: `requestIsSameOrigin` matches scheme+host+port; cross-port and http-vs-https origins rejected for cookie mutations.