### PR TITLE
fix(mail): scope forwarder/share lists to the tenant in SQL (JAB-107)

### DIFF
--- a/panel-api/internal/api/mailbox_forwarder.go
+++ b/panel-api/internal/api/mailbox_forwarder.go
@@ -91,7 +91,23 @@ func (h *forwarderHandler) loadMailbox(ctx context.Context, id string, claims *a
 func (h *forwarderHandler) listAll(c *gin.Context) {
 	ctx := c.Request.Context()
 	claims := ginctx.Claims(c)
-	fwds, _, err := h.cfg.Forwarders.ListAll(ctx, repository.ListOptions{Limit: 500})
+	page, pageSize := paginationParams(c)
+	opts := repository.ListOptions{Offset: (page - 1) * pageSize, Limit: pageSize}
+
+	// JAB-107: scope to the tenant in SQL so every one of their forwarders is
+	// returned regardless of the global row count (the old global newest-500
+	// window hid a tenant's rows past 500 total). Admins keep the cross-tenant
+	// view via ListAll.
+	var (
+		fwds  []models.EmailForwarder
+		total int64
+		err   error
+	)
+	if claims.IsAdmin {
+		fwds, total, err = h.cfg.Forwarders.ListAll(ctx, opts)
+	} else {
+		fwds, total, err = h.cfg.Forwarders.ListByUserID(ctx, claims.UserID, opts)
+	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
@@ -101,7 +117,8 @@ func (h *forwarderHandler) listAll(c *gin.Context) {
 		if f.MailboxID == nil {
 			// Domain-scoped DA-imported forwarder; M65 mailbox-keyed UI
 			// can't render it. Skip — future domain-scoped endpoint will
-			// surface these.
+			// surface these. (ListByUserID already excludes these; only the
+			// admin ListAll path reaches here.)
 			continue
 		}
 		mb, err := h.cfg.Mailboxes.FindByID(ctx, *f.MailboxID)
@@ -113,11 +130,11 @@ func (h *forwarderHandler) listAll(c *gin.Context) {
 			continue
 		}
 		if !claims.IsAdmin && dom.UserID != claims.UserID {
-			continue
+			continue // defense-in-depth; ListByUserID already enforces this
 		}
 		items = append(items, h.resolve(ctx, f, mb, dom))
 	}
-	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items)), "page": 1, "page_size": len(items)})
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": total, "page": page, "page_size": pageSize})
 }
 
 // applyForwarders re-lists a mailbox's forwarders and pushes the full

--- a/panel-api/internal/api/mailbox_share.go
+++ b/panel-api/internal/api/mailbox_share.go
@@ -100,10 +100,23 @@ func (h *shareHandler) list(c *gin.Context) {
 func (h *shareHandler) listAllForUser(c *gin.Context) {
 	ctx := c.Request.Context()
 	claims := ginctx.Claims(c)
-	// Load user's mailboxes — filter shares to owners the user controls.
-	// Simplified: fetch all shares, filter by ownership in-memory. For scale,
-	// add ListByUser at repo layer later.
-	shares, _, err := h.cfg.MailboxShares.ListAll(ctx, repository.ListOptions{Limit: 500})
+	page, pageSize := paginationParams(c)
+	opts := repository.ListOptions{Offset: (page - 1) * pageSize, Limit: pageSize}
+
+	// JAB-107: scope to the tenant in SQL (owner mailbox -> domain -> user) so
+	// every one of their shares is returned regardless of the global row count.
+	// The old global newest-500 window filtered in memory hid a tenant's shares
+	// past 500 total. Admins keep the cross-tenant view via ListAll.
+	var (
+		shares []models.MailboxShare
+		total  int64
+		err    error
+	)
+	if claims.IsAdmin {
+		shares, total, err = h.cfg.MailboxShares.ListAll(ctx, opts)
+	} else {
+		shares, total, err = h.cfg.MailboxShares.ListByUserID(ctx, claims.UserID, opts)
+	}
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
@@ -119,11 +132,11 @@ func (h *shareHandler) listAllForUser(c *gin.Context) {
 			continue
 		}
 		if !claims.IsAdmin && dom.UserID != claims.UserID {
-			continue
+			continue // defense-in-depth; ListByUserID already enforces this
 		}
 		items = append(items, h.resolve(ctx, s))
 	}
-	c.JSON(http.StatusOK, gin.H{"data": items, "total": int64(len(items)), "page": 1, "page_size": len(items)})
+	c.JSON(http.StatusOK, gin.H{"data": items, "total": total, "page": page, "page_size": pageSize})
 }
 
 func (h *shareHandler) create(c *gin.Context) {

--- a/panel-api/internal/repository/email_forwarder_repository.go
+++ b/panel-api/internal/repository/email_forwarder_repository.go
@@ -17,6 +17,7 @@ type EmailForwarderRepository interface {
 	FindByID(ctx context.Context, id string) (*models.EmailForwarder, error)
 	ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
 	ListByMailboxID(ctx context.Context, mailboxID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
+	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.EmailForwarder, int64, error)
 	ListAll(ctx context.Context, opts ListOptions) ([]models.EmailForwarder, int64, error)
 	Create(ctx context.Context, fwd *models.EmailForwarder) error
 	Update(ctx context.Context, fwd *models.EmailForwarder) error
@@ -68,6 +69,34 @@ func (r *emailForwarderRepo) ListByDomainID(ctx context.Context, domainID string
 
 func (r *emailForwarderRepo) ListByMailboxID(ctx context.Context, mailboxID string, opts ListOptions) ([]models.EmailForwarder, int64, error) {
 	return r.listByField(ctx, "mailbox_id", mailboxID, opts)
+}
+
+// ListByUserID returns the forwarders owned by one user — those whose domain
+// belongs to the user — scoped entirely in SQL (JOIN domains) so a tenant
+// always sees all of their own entries regardless of the global row count
+// (JAB-107). Only mailbox-keyed forwarders are returned: domain-scoped
+// DA-imported rows have no mailbox and the M65 mailbox-keyed UI cannot render
+// them, so `total` matches exactly what the caller displays.
+func (r *emailForwarderRepo) ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.EmailForwarder, int64, error) {
+	var rows []models.EmailForwarder
+	var total int64
+	q := r.db.WithContext(ctx).Model(&models.EmailForwarder{}).
+		Joins("JOIN domains ON domains.id = email_forwarders.domain_id").
+		Where("domains.user_id = ? AND email_forwarders.mailbox_id IS NOT NULL", userID)
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	tx := q.Select("email_forwarders.*").Order("email_forwarders.created_at DESC")
+	if opts.Limit > 0 {
+		tx = tx.Limit(opts.Limit)
+	}
+	if opts.Offset > 0 {
+		tx = tx.Offset(opts.Offset)
+	}
+	if err := tx.Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
 }
 
 func (r *emailForwarderRepo) ListAll(ctx context.Context, opts ListOptions) ([]models.EmailForwarder, int64, error) {

--- a/panel-api/internal/repository/email_forwarder_repository_test.go
+++ b/panel-api/internal/repository/email_forwarder_repository_test.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMockForwarderDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	mock.ExpectQuery(`SELECT VERSION\(\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	return gdb, mock, raw
+}
+
+// JAB-107: ListByUserID must scope to the owner in SQL (JOIN domains on
+// user_id) rather than pull a global window and filter in memory — otherwise a
+// tenant's rows past the global newest-N vanish. The mock asserts both the
+// count and the select carry the join + user filter, and that mailbox_id
+// IS NOT NULL is applied so `total` matches the rendered set.
+func TestEmailForwarder_ListByUserID_ScopesInSQL(t *testing.T) {
+	db, mock, raw := newMockForwarderDB(t)
+	defer raw.Close()
+	repo := NewEmailForwarderRepository(db)
+
+	// Count: joined + user-scoped + mailbox-keyed.
+	mock.ExpectQuery(`SELECT count\(\*\) FROM .email_forwarders. JOIN domains ON domains\.id = email_forwarders\.domain_id WHERE domains\.user_id = \? AND email_forwarders\.mailbox_id IS NOT NULL`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(742))
+
+	// Select: same scope, paginated, ordered.
+	mbID := "mbx-1"
+	mock.ExpectQuery(`SELECT email_forwarders\.\* FROM .email_forwarders. JOIN domains ON domains\.id = email_forwarders\.domain_id WHERE domains\.user_id = \? AND email_forwarders\.mailbox_id IS NOT NULL ORDER BY email_forwarders\.created_at DESC LIMIT`).
+		WithArgs("user-1", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "mailbox_id", "domain_id", "created_at"}).
+			AddRow("fwd-1", mbID, "dom-1", time.Now()))
+
+	rows, total, err := repo.ListByUserID(context.Background(), "user-1",
+		ListOptions{Offset: 500, Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, int64(742), total, "total must be the user's full count, not a capped window")
+	require.Len(t, rows, 1)
+	require.Equal(t, "fwd-1", rows[0].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/repository/mailbox_share_repository.go
+++ b/panel-api/internal/repository/mailbox_share_repository.go
@@ -17,6 +17,7 @@ type MailboxShareRepository interface {
 	FindByID(ctx context.Context, id string) (*models.MailboxShare, error)
 	FindByOwnerID(ctx context.Context, ownerMailboxID string, opts ListOptions) ([]models.MailboxShare, int64, error)
 	FindBySharedWithID(ctx context.Context, sharedWithMailboxID string, opts ListOptions) ([]models.MailboxShare, int64, error)
+	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.MailboxShare, int64, error)
 	ListAll(ctx context.Context, opts ListOptions) ([]models.MailboxShare, int64, error)
 	Create(ctx context.Context, share *models.MailboxShare) error
 	Update(ctx context.Context, share *models.MailboxShare) error
@@ -68,6 +69,33 @@ func (r *mailboxShareRepo) FindByOwnerID(ctx context.Context, ownerMailboxID str
 
 func (r *mailboxShareRepo) FindBySharedWithID(ctx context.Context, sharedWithMailboxID string, opts ListOptions) ([]models.MailboxShare, int64, error) {
 	return r.listByField(ctx, "shared_with_mailbox_id", sharedWithMailboxID, opts)
+}
+
+// ListByUserID returns the shares owned by one user — those whose owner mailbox
+// lives in a domain the user owns — scoped in SQL (mailbox_shares -> mailboxes
+// -> domains) so a tenant always sees all of their own shares regardless of the
+// global row count (JAB-107).
+func (r *mailboxShareRepo) ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.MailboxShare, int64, error) {
+	var shares []models.MailboxShare
+	var total int64
+	q := r.db.WithContext(ctx).Model(&models.MailboxShare{}).
+		Joins("JOIN mailboxes ON mailboxes.id = mailbox_shares.owner_mailbox_id").
+		Joins("JOIN domains ON domains.id = mailboxes.domain_id").
+		Where("domains.user_id = ?", userID)
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	tx := q.Select("mailbox_shares.*").Order("mailbox_shares.created_at DESC")
+	if opts.Limit > 0 {
+		tx = tx.Limit(opts.Limit)
+	}
+	if opts.Offset > 0 {
+		tx = tx.Offset(opts.Offset)
+	}
+	if err := tx.Find(&shares).Error; err != nil {
+		return nil, 0, err
+	}
+	return shares, total, nil
 }
 
 func (r *mailboxShareRepo) ListAll(ctx context.Context, opts ListOptions) ([]models.MailboxShare, int64, error) {

--- a/panel-api/internal/repository/mailbox_share_repository_test.go
+++ b/panel-api/internal/repository/mailbox_share_repository_test.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMockShareDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	mock.ExpectQuery(`SELECT VERSION\(\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	return gdb, mock, raw
+}
+
+// JAB-107: ListByUserID scopes shares to the owner in SQL via a two-hop join
+// (mailbox_shares -> mailboxes -> domains on user_id) instead of a global
+// window filtered in memory.
+func TestMailboxShare_ListByUserID_ScopesInSQL(t *testing.T) {
+	db, mock, raw := newMockShareDB(t)
+	defer raw.Close()
+	repo := NewMailboxShareRepository(db)
+
+	mock.ExpectQuery(`SELECT count\(\*\) FROM .mailbox_shares. JOIN mailboxes ON mailboxes\.id = mailbox_shares\.owner_mailbox_id JOIN domains ON domains\.id = mailboxes\.domain_id WHERE domains\.user_id = \?`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(631))
+
+	mock.ExpectQuery(`SELECT mailbox_shares\.\* FROM .mailbox_shares. JOIN mailboxes ON mailboxes\.id = mailbox_shares\.owner_mailbox_id JOIN domains ON domains\.id = mailboxes\.domain_id WHERE domains\.user_id = \? ORDER BY mailbox_shares\.created_at DESC LIMIT`).
+		WithArgs("user-1", sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "owner_mailbox_id", "shared_with_mailbox_id", "created_at"}).
+			AddRow("share-1", "own-1", "with-1", time.Now()))
+
+	rows, total, err := repo.ListByUserID(context.Background(), "user-1",
+		ListOptions{Offset: 500, Limit: 50})
+	require.NoError(t, err)
+	require.Equal(t, int64(631), total)
+	require.Len(t, rows, 1)
+	require.Equal(t, "share-1", rows[0].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
## What

`GET /mail/forwarders` and `/mail/shares` fetched the **newest 500 rows across all tenants**, then filtered to the caller in memory. On a server with >500 total forwarders/shares, a tenant whose rows weren't in the global newest-500 saw an **empty list** — silent data-visibility loss (users think config was lost, recreate entries, hit the `uq_external_forward` unique key → 500s / tickets). The envelope `total`/`page_size` were the post-filter slice length, so pagination was also wrong.

## Fix

Add `ListByUserID` to both repos, scoping the owner in **SQL**:

- **forwarders**: `JOIN domains ON domains.user_id`, `mailbox_id IS NOT NULL` (matches the M65 mailbox-keyed UI, so `total` is exact)
- **shares**: two-hop `JOIN mailboxes → domains ON domains.user_id`

Handlers use it for tenants (admins keep the cross-tenant `ListAll`) with real `?page`/`?page_size` pagination and an accurate `total`. The per-row ownership check stays as defense-in-depth.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] sqlmock repo tests assert the **count + select carry the join + user filter** (scoped in SQL, not a capped in-memory window) with pagination + correct total — i.e. a tenant's rows past the global newest-500 are no longer hidden
- [x] full `internal/repository` + `internal/api` suites pass
- [ ] CI green

Acceptance: a tenant with forwarders/shares created before the global newest-500 sees all their own entries; list scopes by owner in SQL; correct total/pagination.

_Note: repo tests use the project's sqlmock harness (no real DB), so the >500-row scenario is asserted structurally — the query is user-scoped, making the global row count irrelevant._