### PR TITLE
fix(logrotate): drop redundant/asymmetric nginx stanza, age out /tmp install logs (JAB-104)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10260,6 +10260,13 @@ install_logrotate() {
   elif ! logrotate -d "$dst" >/dev/null 2>&1; then
     _warn "logrotate parse failed for $dst — review syntax"
   fi
+
+  # JAB-104: the install logger falls back to /tmp/jabali_install-<ts>.log
+  # when /var/log/jabali can't be created (see LOG_FILE bootstrap). Those
+  # fall outside every logrotate policy, so age them out opportunistically on
+  # each install/update tick — the only events that create them — so they
+  # can't accumulate forever on hosts with weak /tmp cleanup.
+  find /tmp -maxdepth 1 -name 'jabali_install-*.log' -type f -mtime +14 -delete 2>/dev/null || true
 }
 
 install_notify_template() {

--- a/install/logrotate/jabali
+++ b/install/logrotate/jabali
@@ -102,19 +102,19 @@
     su root root
 }
 
-/var/log/nginx/jabali-pma.access.log {
-    daily
-    rotate 14
-    compress
-    delaycompress
-    missingok
-    notifempty
-    sharedscripts
-    postrotate
-        # nginx default logrotate sends USR1; ours rides alongside.
-        [ ! -f /var/run/nginx.pid ] || kill -USR1 "$(cat /var/run/nginx.pid)"
-    endscript
-}
+# nginx logs (JAB-104): every log jabali points nginx at lives under
+# /var/log/nginx/*.log —
+#   default.access.log        default.error.log
+#   jabali-hostname.access.log jabali-hostname.error.log
+#   jabali-pma.access.log     jabali-pma.error.log
+# The distro nginx package ships /etc/logrotate.d/nginx with a
+# `/var/log/nginx/*.log` glob (with the USR1 postrotate), which already
+# rotates ALL of the above — both the access AND error side. install.sh
+# never removes that drop-in, so we deliberately do NOT restate any
+# /var/log/nginx/* path here: a jabali stanza would either duplicate the
+# distro glob (logrotate "duplicate log entry" noise) or, worse, cover only
+# one half of an access/error pair and create a false sense of coverage —
+# which is exactly the jabali-pma.access-only stanza this comment replaced.
 
 # M8 per-user cron logs (#432). One subdir per hosting user under
 # /var/log/jabali/cron/<user>/. maxsize caps a chatty cron from filling the


### PR DESCRIPTION
## What

Two log-retention hygiene gaps.

**1. nginx logs — false sense of coverage.** `install/logrotate/jabali` had a `/var/log/nginx/jabali-pma.access.log`-only stanza: it rotated `pma.access` but **not** `pma.error`, and it duplicated the distro nginx drop-in (`/var/log/nginx/*.log` glob) — which `install.sh` never removes and which already rotates every jabali nginx log (`default`/`jabali-hostname`/`jabali-pma`, **both** access and error, with the USR1 postrotate). The one-sided stanza was pure downside: duplicate-entry noise + an access/error asymmetry that looked like a gap. Replaced with a documenting comment so no future stanza reintroduces the duplicate-or-half-covered pattern. Net: every jabali nginx log has documented coverage (distro glob), consistently for access + error.

**2. /tmp install-log fallback.** The install logger falls back to `/tmp/jabali_install-<ts>.log` when `/var/log/jabali` can't be created — outside every rotate policy, can accumulate. `install_logrotate` now age-deletes them (`find … -mtime +14 -delete`) on each install/update tick, the only events that create them.

## Test plan

- [x] `bash -n install.sh` clean
- [x] `logrotate -d install/logrotate/jabali` parses with no syntax/duplicate errors (only non-root euid-switch noise locally)
- [x] no `/var/log/nginx/*` path remains in the jabali drop-in (comment only)
- [ ] CI green (install.sh phantom-function lint)

Acceptance: every jabali-created nginx log has explicit/documented retention; pma access+error treated consistently; /tmp fallback logs can't accumulate forever.

_Note: JAB-111 (sibling in the batch) targets `manager-api`/`manager-ui` — not in this repo — so it's skipped here._