### PR TITLE
security(api): stop leaking agent-origin error strings to clients (JAB-114)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -595,7 +595,7 @@ func (h *adminMigrationsHandler) callAgent(c *gin.Context, cmd string, params an
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, cmd, params)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var data any
@@ -1203,14 +1203,14 @@ func (h *adminMigrationsHandler) discoverAccounts(c *gin.Context) {
 
 	sess, err := disc.Connect(ctx, job.SourceHost, job.SourceUser, migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+		respondAgentErr(c, "connect_failed", err)
 		return
 	}
 	defer func() { _ = disc.Close(ctx, sess) }()
 
 	accounts, err := disc.ListAccounts(ctx, sess)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "list_failed", "detail": err.Error()})
+		respondAgentErr(c, "list_failed", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
@@ -1362,14 +1362,14 @@ func (h *adminMigrationsHandler) accountSizeProbe(c *gin.Context) {
 
 	sess, err := disc.Connect(ctx, job.SourceHost, job.SourceUser, migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+		respondAgentErr(c, "connect_failed", err)
 		return
 	}
 	defer func() { _ = disc.Close(ctx, sess) }()
 
 	size, err := prober.AccountSize(ctx, sess, login)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "probe_failed", "detail": err.Error()})
+		respondAgentErr(c, "probe_failed", err)
 		return
 	}
 

--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -73,12 +73,12 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 		cli := wordpressplugin.New(site, token, allowPrivate)
 		ping, err := cli.PingInfo(ctx)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "handshake_failed", "detail": err.Error()})
+			respondAgentErr(c, "handshake_failed", err)
 			return
 		}
 		facts, err := cli.Manifest(ctx)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "manifest_failed", "detail": err.Error()})
+			respondAgentErr(c, "manifest_failed", err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"ok": true, "kind": "wordpress_plugin", "panel": "WordPress",
@@ -90,7 +90,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 	case models.MigrationSourceWordPressSSH:
 		sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUserOrRoot(job.SourceUser), secret, allowPrivate)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+			respondAgentErr(c, "connect_failed", err)
 			return
 		}
 		defer sess.Close()
@@ -100,7 +100,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 		}
 		facts, err := wordpressssh.DiscoverWordPress(ctx, sess, hint)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "discover_failed", "detail": err.Error()})
+			respondAgentErr(c, "discover_failed", err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"ok": true, "kind": "wordpress_ssh", "panel": "WordPress",
@@ -117,13 +117,13 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 	}
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+		respondAgentErr(c, "connect_failed", err)
 		return
 	}
 	defer func() { _ = d.Close(ctx, sess) }()
 	accts, err := d.ListAccounts(ctx, sess)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "list_failed", "detail": err.Error()})
+		respondAgentErr(c, "list_failed", err)
 		return
 	}
 	var domains int
@@ -185,13 +185,13 @@ func (h *adminMigrationsHandler) describeAccount(c *gin.Context) {
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+		respondAgentErr(c, "connect_failed", err)
 		return
 	}
 	defer func() { _ = d.Close(ctx, sess) }()
 	m, err := d.DescribeAccount(ctx, sess, strings.TrimSpace(req.SourceUser))
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "describe_failed", "detail": err.Error()})
+		respondAgentErr(c, "describe_failed", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{

--- a/panel-api/internal/api/admin_processes.go
+++ b/panel-api/internal/api/admin_processes.go
@@ -68,7 +68,7 @@ func (h *adminProcessesHandler) kill(c *gin.Context) {
 	if err != nil {
 		h.cfg.Log.Warn("event=audit kind=process_kill_failed",
 			"actor_id", actorID, "pid", pid, "force", req.Force, "err", err.Error())
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var data any

--- a/panel-api/internal/api/admin_services.go
+++ b/panel-api/internal/api/admin_services.go
@@ -107,7 +107,7 @@ func (h *adminServicesHandler) action(c *gin.Context) {
 	if err != nil {
 		h.cfg.Log.Warn("event=audit kind=service_action_failed",
 			"actor_id", actorID, "service", name, "action", action, "err", err.Error())
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var data any

--- a/panel-api/internal/api/admin_support.go
+++ b/panel-api/internal/api/admin_support.go
@@ -44,7 +44,7 @@ func (h *adminSupportHandler) diagnostic(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "system.diagnostic_report", nil)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var data any

--- a/panel-api/internal/api/admin_updates.go
+++ b/panel-api/internal/api/admin_updates.go
@@ -83,7 +83,7 @@ func (h *adminUpdatesHandler) callAgentRaw(c *gin.Context, cmd string, params an
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, cmd, params)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return nil, false
 	}
 	return raw, true

--- a/panel-api/internal/api/agent_error_leak_test.go
+++ b/panel-api/internal/api/agent_error_leak_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoAgentErrorLeak is the JAB-114 regression gate. Agent-origin errors can
+// carry the root daemon's stderr, filesystem paths, and driver internals; they
+// must be logged server-side (respondAgentErr / respondAgentErrStatus /
+// logAgentError) and NEVER echoed to the HTTP client. This test scans the api
+// package's own source and fails if any handler puts an agent-error code and a
+// raw .Error() on the same response line again.
+//
+// If this fires on new code: replace the c.JSON(...) with respondAgentErr(c,
+// "<code>", err) (or respondAgentErrStatus for the status-wrapped envelope),
+// which logs the detail and returns just the code.
+func TestNoAgentErrorLeak(t *testing.T) {
+	// Agent-origin error codes + a raw error string on the same source line.
+	leak := regexp.MustCompile(`"(agent_error|agent_failed|agent_call_failed|apply_failed)"[^\n]*\.Error\(\)`)
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var offenders []string
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if leak.MatchString(line) {
+				offenders = append(offenders, f+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("agent-error detail leaked to the client in %d place(s); use respondAgentErr instead:\n%s",
+			len(offenders), strings.Join(offenders, "\n"))
+	}
+}

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -1379,7 +1379,7 @@ func (h *applicationsHandler) scan(c *gin.Context) {
 		"username": *user.Username,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var resp struct {
@@ -1392,7 +1392,7 @@ func (h *applicationsHandler) scan(c *gin.Context) {
 		} `json:"hits"`
 	}
 	if jErr := json.Unmarshal(raw, &resp); jErr != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_decode", "detail": jErr.Error()})
+		respondAgentErr(c, "agent_decode", jErr)
 		return
 	}
 

--- a/panel-api/internal/api/applications_cache_settings.go
+++ b/panel-api/internal/api/applications_cache_settings.go
@@ -263,7 +263,7 @@ func (h *wordPressHandler) cacheStats(c *gin.Context) {
 		"os_user": osUser, "install_path": installPath,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var stats map[string]any
@@ -359,7 +359,7 @@ func (h *wordPressHandler) cacheAdvise(c *gin.Context) {
 		"os_user": osUser, "install_path": installPath, "host": dom.Name,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var probe struct {

--- a/panel-api/internal/api/applications_service.go
+++ b/panel-api/internal/api/applications_service.go
@@ -181,7 +181,9 @@ func InstallApplication(ctx context.Context, deps ApplicationHandlerConfig, p In
 		chain, err = provisionDBChain(ctx, deps, p.UserID, osUser, descriptor.Name, domain.Name, p.Subdirectory, dbPassword)
 		if err != nil {
 			slog.ErrorContext(ctx, "applications create: provision db chain", "err", err)
-			return nil, newInstallErr(http.StatusBadGateway, "agent_failed", err.Error())
+			// JAB-114: err here is agent-origin (db.create) — logged above,
+			// never echoed to the client (InstallError.Detail renders to the body).
+			return nil, newInstallErr(http.StatusBadGateway, "agent_failed", "")
 		}
 	}
 

--- a/panel-api/internal/api/applications_test.go
+++ b/panel-api/internal/api/applications_test.go
@@ -936,7 +936,7 @@ func TestApplicationsClone_Characterization(t *testing.T) {
 		}
 	})
 
-	t.Run("agent failure -> 502 + detail", func(t *testing.T) {
+	t.Run("agent failure -> 502, no leaked detail", func(t *testing.T) {
 		wpRepo, domainRepo, userRepo := wpUserAndDomain()
 		domainRepo.domains["domain2"] = &models.Domain{ID: "domain2", UserID: "user1", Name: "dest.com", DocRoot: "/home/alice/domains/dest.com/public_html"}
 		wpRepo.Create(ctx, &models.WordPressInstall{ID: "src", UserID: "user1", DomainID: "domain1", AppType: "wordpress", Subdirectory: "blog", DBID: models.DBIDPtr("srcdb")})
@@ -953,8 +953,13 @@ func TestApplicationsClone_Characterization(t *testing.T) {
 		if body["error"] != "agent_failed" {
 			t.Fatalf("want error=agent_failed, got %v", body["error"])
 		}
-		if d, _ := body["detail"].(string); d == "" {
-			t.Fatalf("want non-empty detail, got %v", body["detail"])
+		// JAB-114: the raw agent error ("boom") must NOT be echoed to the
+		// client — it's logged server-side instead.
+		if _, ok := body["detail"]; ok {
+			t.Fatalf("agent error detail leaked to client: %v", body["detail"])
+		}
+		if strings.Contains(w.Body.String(), "boom") {
+			t.Fatalf("raw agent error leaked in body: %s", w.Body.String())
 		}
 	})
 

--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -471,7 +471,7 @@ func (h *backupDestinationHandler) test(c *gin.Context) {
 	}
 	raw, err := h.agent.Call(ctx, "backup.dest.test", payload)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call", err)
 		return
 	}
 	var resp struct {

--- a/panel-api/internal/api/backup_encryption_key.go
+++ b/panel-api/internal/api/backup_encryption_key.go
@@ -38,7 +38,7 @@ func (h *backupEncryptionKeyHandler) reveal(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "backup.repo.password.read", map[string]any{})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call", err)
 		return
 	}
 	var resp struct {

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -428,7 +428,7 @@ func (h *backupHandler) createForUser(c *gin.Context) {
 			// Mark failed so the UI surfaces the issue right away.
 			_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), job.ID, models.BackupJobStatusFailed,
 				"", "", 0, 0, nil, nil, err.Error())
-			c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call_failed", "detail": err.Error()})
+			respondAgentErrStatus(c, "agent_call_failed", err)
 			return
 		}
 		_ = h.cfg.Jobs.MarkStarted(c.Request.Context(), job.ID)
@@ -564,7 +564,7 @@ func (h *backupHandler) status(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "backup.status", map[string]string{"job_id": jobID})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call_failed", err)
 		return
 	}
 	var resp any
@@ -609,7 +609,7 @@ func (h *backupHandler) logs(c *gin.Context) {
 		"kind":   job.Kind,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call_failed", err)
 		return
 	}
 	var resp any
@@ -779,7 +779,7 @@ func (h *backupHandler) restore(c *gin.Context) {
 	if err != nil {
 		_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), job.ID, models.BackupJobStatusFailed,
 			"", "", 0, 0, nil, nil, err.Error())
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call_failed", err)
 		return
 	}
 	// Parse the agent's restore result so the job row reflects what

--- a/panel-api/internal/api/cron.go
+++ b/panel-api/internal/api/cron.go
@@ -54,7 +54,7 @@ func (h *cronHandler) mapCronopsErr(c *gin.Context, err error) {
 	case errors.Is(err, cronops.ErrJobNotFound):
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 	case errors.Is(err, cronops.ErrAgentFailed):
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_apply_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_apply_failed", err)
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 	}
@@ -453,7 +453,7 @@ func (h *cronHandler) runNow(c *gin.Context) {
 		Command: job.Command, OwnedDocroots: docroots, OwnedDomains: domains,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_run_now_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_run_now_failed", err)
 		return
 	}
 	var resp runNowResponse
@@ -502,7 +502,7 @@ func (h *cronHandler) readLog(c *gin.Context) {
 		UserID: job.UserID, Username: username, JobID: job.ID, Lines: lines,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_tail_log_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_tail_log_failed", err)
 		return
 	}
 	var resp cronLogResponse

--- a/panel-api/internal/api/database_users.go
+++ b/panel-api/internal/api/database_users.go
@@ -501,7 +501,7 @@ func (h *databaseUserHandler) create(c *gin.Context) {
 		})
 	}
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -644,7 +644,7 @@ func (h *databaseUserHandler) addGrant(c *gin.Context) {
 		})
 	}
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -743,7 +743,7 @@ func (h *databaseUserHandler) deleteGrant(c *gin.Context) {
 		})
 	}
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -818,7 +818,7 @@ func (h *databaseUserHandler) delete(c *gin.Context) {
 			})
 		}
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+			respondAgentErr(c, "agent_failed", err)
 			return
 		}
 	}
@@ -829,7 +829,7 @@ func (h *databaseUserHandler) delete(c *gin.Context) {
 
 	_, err = h.cfg.Agent.Call(agentCtx, dbUserCmd(du.Engine, "drop"), dbUserDropParams(du.Engine, du.Username))
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -910,7 +910,7 @@ func (h *databaseUserHandler) rotatePassword(c *gin.Context) {
 		})
 	}
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -1031,7 +1031,7 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 		})
 	}
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -1068,7 +1068,7 @@ func (h *databaseUserHandler) updateGrant(c *gin.Context) {
 				"privileges":   strings.Split(grant.Privileges, ","),
 			})
 		}
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -324,7 +324,7 @@ func dbopsRESTError(c *gin.Context, err error) {
 	case errors.Is(err, dbops.ErrNameTaken):
 		c.JSON(http.StatusConflict, gin.H{"error": "database_name_exists"})
 	case errors.Is(err, dbops.ErrAgentFailed):
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 	case errors.Is(err, dbops.ErrNotFound):
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 	default:
@@ -420,7 +420,7 @@ func (h *databaseHandler) delete(c *gin.Context) {
 	}
 	if _, err := h.cfg.Agent.Call(agentCtx, dropCmd, map[string]any{"db_name": d.Name}); err != nil {
 		slog.ErrorContext(ctx, "databases.delete: agent drop failed", "err", err, "db_name", d.Name, "engine", d.Engine)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -472,7 +472,7 @@ func (h *databaseHandler) backup(c *gin.Context) {
 		"db_name": d.Name,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 
@@ -596,7 +596,7 @@ func (h *databaseHandler) restore(c *gin.Context) {
 	if err != nil {
 		// Agent cleanup the file on failure, but delete it here too just in case
 		_ = deleteFile(restorePath)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 

--- a/panel-api/internal/api/databases_admin_ops.go
+++ b/panel-api/internal/api/databases_admin_ops.go
@@ -384,7 +384,7 @@ func (h *databaseAdminOpsHandler) putConfig(c *gin.Context) {
 				Body:      req.Engine + " did not recover after a config change AND rollback. Manual intervention required (see /var/lib/jabali-agent/db-config-broken.json).",
 				Deeplink:  "/jabali-admin/settings",
 			})
-			c.JSON(http.StatusBadGateway, gin.H{"error": "unrecoverable", "detail": aerr.Error()})
+			respondAgentErr(c, "unrecoverable", aerr)
 			return
 		}
 		h.audit(ctx, claims.UserID, req.Engine, "config.apply", "", "error", "agent rejected")
@@ -396,7 +396,7 @@ func (h *databaseAdminOpsHandler) putConfig(c *gin.Context) {
 			Deeplink:  "/jabali-admin/settings",
 			UserID:    claims.UserID,
 		})
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": aerr.Error()})
+		respondAgentErr(c, "agent_failed", aerr)
 		return
 	}
 

--- a/panel-api/internal/api/docker_app_env.go
+++ b/panel-api/internal/api/docker_app_env.go
@@ -77,7 +77,7 @@ func (h *dockerAppHandler) getEnv(c *gin.Context) {
 	}
 	env, err := h.readInstallEnv(c.Request.Context(), app.EffectiveSlug())
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "read_env_failed", "detail": err.Error()})
+		respondAgentErr(c, "read_env_failed", err)
 		return
 	}
 	out := make([]envVarView, 0, len(env))
@@ -123,7 +123,7 @@ func (h *dockerAppHandler) putEnv(c *gin.Context) {
 	ctx := c.Request.Context()
 	existing, err := h.readInstallEnv(ctx, app.EffectiveSlug())
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "read_env_failed", "detail": err.Error()})
+		respondAgentErr(c, "read_env_failed", err)
 		return
 	}
 	merged := make(map[string]string, len(existing)+len(body.Env))
@@ -135,7 +135,7 @@ func (h *dockerAppHandler) putEnv(c *gin.Context) {
 	}
 
 	if err := h.applyEnv(ctx, app, merged); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "apply_failed", "detail": err.Error()})
+		respondAgentErr(c, "apply_failed", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "applied"})
@@ -171,13 +171,13 @@ func (h *dockerAppHandler) regenerateEnv(c *gin.Context) {
 	ctx := c.Request.Context()
 	existing, err := h.readInstallEnv(ctx, app.EffectiveSlug())
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "read_env_failed", "detail": err.Error()})
+		respondAgentErr(c, "read_env_failed", err)
 		return
 	}
 	delete(existing, body.Key) // absent → MaterialiseEnv generates a fresh value
 
 	if err := h.applyEnv(ctx, app, existing); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "apply_failed", "detail": err.Error()})
+		respondAgentErr(c, "apply_failed", err)
 		return
 	}
 	// Read back so the UI can show the new secret once.

--- a/panel-api/internal/api/docker_apps.go
+++ b/panel-api/internal/api/docker_apps.go
@@ -1229,7 +1229,7 @@ func (h *dockerAppHandler) delete(c *gin.Context) {
 				app.Status == models.DockerAppStatusInstalling ||
 				app.Status == models.DockerAppStatusPending
 			if !force && !broken {
-				c.JSON(http.StatusBadGateway, gin.H{"error": "agent_delete_failed", "detail": err.Error()})
+				respondAgentErr(c, "agent_delete_failed", err)
 				return
 			}
 			// Fall through to DB cleanup.
@@ -1311,7 +1311,7 @@ func (h *dockerAppHandler) lifecycle(action string) gin.HandlerFunc {
 		}
 		raw, err := h.cfg.Agent.Call(callCtx, verb, lifeParams)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+			respondAgentErr(c, "agent_call_failed", err)
 			return
 		}
 		// Reflect the post-lifecycle state in the docker_apps row so
@@ -1478,7 +1478,7 @@ func (h *dockerAppHandler) logs(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(callCtx, "docker_app.logs", params)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1520,7 +1520,7 @@ func (h *dockerAppHandler) execCmd(c *gin.Context) {
 		"command": req.Command,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1551,7 +1551,7 @@ func (h *dockerAppHandler) backup(c *gin.Context) {
 	}
 	raw, err := h.cfg.Agent.Call(callCtx, "docker_app.backup", bkParams)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_backup_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_backup_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1582,7 +1582,7 @@ func (h *dockerAppHandler) listBackups(c *gin.Context) {
 	}
 	raw, err := h.cfg.Agent.Call(callCtx, "docker_app.list_backups", lbParams)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1621,7 +1621,7 @@ func (h *dockerAppHandler) restoreBackup(c *gin.Context) {
 	}
 	raw, err := h.cfg.Agent.Call(callCtx, "docker_app.restore", rsParams)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_restore_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_restore_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1736,7 +1736,7 @@ func (h *dockerAppHandler) maintenanceDiskUsage(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(callCtx, "docker.disk_usage", map[string]any{})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1765,7 +1765,7 @@ func (h *dockerAppHandler) maintenancePrune(c *gin.Context) {
 		"all":     req.All,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
@@ -1787,7 +1787,7 @@ func (h *dockerAppHandler) engineStatus(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(callCtx, "docker.status", map[string]any{})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)

--- a/panel-api/internal/api/docker_apps_user.go
+++ b/panel-api/internal/api/docker_apps_user.go
@@ -277,7 +277,7 @@ func (h *userDockerAppHandler) lifecycle(statusOnSuccess string, composeArgs ...
 				}
 			}
 			if _, err := h.cfg.Agent.Call(ctx, "docker_app."+composeArgs[0], params); err != nil {
-				c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": firstLineString(err.Error())})
+				respondAgentErr(c, "agent_error", err)
 				return
 			}
 		}
@@ -673,7 +673,7 @@ func (h *userDockerAppHandler) logs(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "docker_app.logs", params)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_call_failed", "detail": firstLineString(err.Error())})
+		respondAgentErr(c, "agent_call_failed", err)
 		return
 	}
 	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)

--- a/panel-api/internal/api/domain_cache.go
+++ b/panel-api/internal/api/domain_cache.go
@@ -159,7 +159,7 @@ func (h *domainCacheHandler) purge(c *gin.Context) {
 	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if _, err := h.cfg.Agent.Call(agentCtx, "nginx.cache.purge", map[string]any{"domain": dom.Name, "paths": req.Paths}); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	// GH #632: re-warm the cache after a manual purge so the next visitor

--- a/panel-api/internal/api/domain_catchall.go
+++ b/panel-api/internal/api/domain_catchall.go
@@ -112,7 +112,7 @@ func (h *domainCatchallHandler) update(c *gin.Context) {
 			"target":      req.Target,
 		})
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+			respondAgentErr(c, "agent_error", err)
 			return
 		}
 	}
@@ -169,7 +169,7 @@ func (h *domainCatchallHandler) delete(c *gin.Context) {
 			"domain_name": dom.Name,
 		})
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+			respondAgentErr(c, "agent_error", err)
 			return
 		}
 	}

--- a/panel-api/internal/api/domain_dnssec.go
+++ b/panel-api/internal/api/domain_dnssec.go
@@ -143,7 +143,7 @@ func (h *domainDNSSECHandler) update(c *gin.Context) {
 		}
 		raw, err := h.cfg.Agent.Call(agentCtx, cmd, map[string]any{"domain_name": dom.Name})
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+			respondAgentErr(c, "agent_error", err)
 			return
 		}
 		if req.Enabled {
@@ -214,7 +214,7 @@ func (h *domainDNSSECHandler) dsExport(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(agentCtx, "dns.dnssec_ds_export", map[string]any{"domain_name": dom.Name})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var agentResp struct {

--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -390,9 +390,9 @@ func (h *domainEmailHandler) enable(c *gin.Context) {
 		case errors.Is(err, errAgentUnconfigured):
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "agent_unconfigured"})
 		case errors.Is(err, errAgentBadResponse):
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_bad_response", "detail": err.Error()})
+			respondAgentErr(c, "agent_bad_response", err)
 		case errors.Is(err, errAgentFailed):
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+			respondAgentErr(c, "agent_failed", err)
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		}
@@ -448,7 +448,7 @@ func (h *domainEmailHandler) disable(c *gin.Context) {
 		"domain_id":   dom.ID,
 		"domain_name": dom.Name,
 	}); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 

--- a/panel-api/internal/api/domain_whois.go
+++ b/panel-api/internal/api/domain_whois.go
@@ -94,7 +94,7 @@ func (h *domainWhoisHandler) get(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(agentCtx, "domain.whois", map[string]any{"domain": dom.Name})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "details": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	var data whoisData

--- a/panel-api/internal/api/error_response.go
+++ b/panel-api/internal/api/error_response.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+// respondAgentError logs an agent-origin failure server-side (with request-id
+// correlation) and returns a generic 502 to the client WITHOUT the raw error
+// string (JAB-114, OWASP A05). Agent errors can carry the root daemon's stderr,
+// filesystem paths, and driver internals — those belong in the server log, never
+// the HTTP body, even for an authenticated caller. `code` is the stable
+// machine-readable error code the client already switches on.
+func respondAgentErr(c *gin.Context, code string, err error) {
+	logAgentError(c, code, err)
+	c.JSON(http.StatusBadGateway, gin.H{"error": code})
+}
+
+// respondAgentErrorStatus is respondAgentError for the handlers whose error
+// envelope also carries a top-level "status":"error" field (e.g. the backups
+// endpoints). Same logging + leak-suppression, preserved wire shape.
+func respondAgentErrStatus(c *gin.Context, code string, err error) {
+	logAgentError(c, code, err)
+	c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": code})
+}
+
+func logAgentError(c *gin.Context, code string, err error) {
+	slog.ErrorContext(c.Request.Context(), "agent call failed",
+		"code", code,
+		"err", err,
+		"method", c.Request.Method,
+		"path", c.FullPath(),
+		"request_id", ginctx.RequestID(c),
+	)
+}

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -452,7 +452,12 @@ func agentErrorCode(err error) string {
 }
 
 func respondAgentError(c *gin.Context, err error) {
-	c.JSON(agentErrorStatus(err), gin.H{"error": agentErrorCode(err), "detail": err.Error()})
+	// JAB-114: derive a stable status + client code from the error, but never
+	// echo the raw agent error string (paths / stderr / driver internals) to the
+	// client — log it server-side instead.
+	code := agentErrorCode(err)
+	logAgentError(c, code, err)
+	c.JSON(agentErrorStatus(err), gin.H{"error": code})
 }
 
 // ---- handlers ----

--- a/panel-api/internal/api/ips.go
+++ b/panel-api/internal/api/ips.go
@@ -238,7 +238,7 @@ func (h *ipHandler) create(c *gin.Context) {
 			// Roll back the DB row — caller sees a clean 502 instead of
 			// a half-created entry.
 			_ = h.cfg.Repo.Delete(ctx, row.ID)
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_bind_failed", "detail": bindErr.Error()})
+			respondAgentErr(c, "agent_bind_failed", bindErr)
 			return
 		}
 		resp.Warnings = warnings

--- a/panel-api/internal/api/mail_queue.go
+++ b/panel-api/internal/api/mail_queue.go
@@ -106,7 +106,7 @@ func RegisterAdminMailQueueRoutes(rg *gin.RouterGroup, cli agent.AgentInterface)
 			Total int              `json:"total"`
 		}
 		if jerr := json.Unmarshal(raw, &resp); jerr != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_parse_failed", "detail": jerr.Error()})
+			respondAgentErr(c, "agent_parse_failed", jerr)
 			return
 		}
 		filtered := filterByDomain(resp.Data, c.Query("domain"))

--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -550,7 +550,7 @@ func (h *mailboxHandler) delete(c *gin.Context) {
 		"email": mb.LocalPart + "@" + dom.Name,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+		respondAgentErr(c, "agent_failed", err)
 		return
 	}
 

--- a/panel-api/internal/api/mailgroups.go
+++ b/panel-api/internal/api/mailgroups.go
@@ -599,7 +599,7 @@ func (h *mailGroupHandler) delete(c *gin.Context) {
 			"group_email":   g.EmailCached,
 			"member_emails": memberEmails,
 		}); err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": err.Error()})
+			respondAgentErr(c, "agent_failed", err)
 			return
 		}
 	}

--- a/panel-api/internal/api/me_php_cli.go
+++ b/panel-api/internal/api/me_php_cli.go
@@ -96,7 +96,7 @@ func (h *mePhpCliHandler) put(c *gin.Context) {
 			"username": *user.Username,
 			"version":  req.Version,
 		}); aerr != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": firstLineString(aerr.Error())})
+			respondAgentErr(c, "agent_error", aerr)
 			return
 		}
 	}

--- a/panel-api/internal/api/system_ssh_keys.go
+++ b/panel-api/internal/api/system_ssh_keys.go
@@ -47,7 +47,7 @@ func (h *systemSSHKeysHandler) list(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "system.sshkeys.list", map[string]any{})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call", err)
 		return
 	}
 	var resp struct {
@@ -84,7 +84,7 @@ func (h *systemSSHKeysHandler) generate(c *gin.Context) {
 		"name": req.Name, "type": keyType,
 	})
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "agent_call", "detail": err.Error()})
+		respondAgentErrStatus(c, "agent_call", err)
 		return
 	}
 	var resp struct {

--- a/panel-api/internal/api/tenant_migrations.go
+++ b/panel-api/internal/api/tenant_migrations.go
@@ -310,13 +310,13 @@ func (h *tenantMigrationsHandler) scanWP(c *gin.Context) {
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
 	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, secret, allowPrivate)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+		respondAgentErr(c, "connect_failed", err)
 		return
 	}
 	defer sess.Close()
 	installs, err := wordpressssh.ScanWordPress(ctx, sess)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "scan_failed", "detail": err.Error()})
+		respondAgentErr(c, "scan_failed", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"installs": installs})
@@ -386,7 +386,7 @@ func (h *tenantMigrationsHandler) verify(c *gin.Context) {
 		}
 		facts, err := cli.Manifest(ctx)
 		if err != nil {
-			c.JSON(http.StatusBadGateway, gin.H{"error": "manifest_failed", "detail": err.Error()})
+			respondAgentErr(c, "manifest_failed", err)
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{
@@ -416,7 +416,7 @@ func (h *tenantMigrationsHandler) verify(c *gin.Context) {
 	}
 	facts, err := wordpressssh.DiscoverWordPress(ctx, sess, hint)
 	if err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "discover_failed", "detail": err.Error()})
+		respondAgentErr(c, "discover_failed", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
@@ -452,7 +452,7 @@ func (h *tenantMigrationsHandler) callAgent(c *gin.Context, verb string, params 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 	defer cancel()
 	if _, err := h.cfg.Agent.Call(ctx, verb, params); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_error", "detail": err.Error()})
+		respondAgentErr(c, "agent_error", err)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"ok": true})

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -350,7 +350,7 @@ func (h *wordPressHandler) create(c *gin.Context) {
 		}); acErr != nil {
 			rollbackPanelRows()
 			slog.ErrorContext(ctx, "wordpress create: agent db.create", "err", acErr, "db_name", dbName)
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": acErr.Error()})
+			respondAgentErr(c, "agent_failed", acErr)
 			return
 		}
 
@@ -362,7 +362,7 @@ func (h *wordPressHandler) create(c *gin.Context) {
 			h.cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": dbName})
 			rollbackPanelRows()
 			slog.ErrorContext(ctx, "wordpress create: agent db_user.create", "err", acErr, "db_user", dbUsername)
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": acErr.Error()})
+			respondAgentErr(c, "agent_failed", acErr)
 			return
 		}
 
@@ -376,7 +376,7 @@ func (h *wordPressHandler) create(c *gin.Context) {
 			h.cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": dbName})
 			rollbackPanelRows()
 			slog.ErrorContext(ctx, "wordpress create: agent db_user.grant", "err", acErr)
-			c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": acErr.Error()})
+			respondAgentErr(c, "agent_failed", acErr)
 			return
 		}
 	}
@@ -735,7 +735,7 @@ func (h *wordPressHandler) clone(c *gin.Context) {
 	case errors.Is(err, errCloneUserNotProvisioned):
 		c.JSON(http.StatusConflict, gin.H{"error": "user_not_provisioned"})
 	case errors.As(err, &agentErr):
-		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed", "detail": agentErr.detail})
+		respondAgentErr(c, "agent_failed", agentErr)
 	default:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 	}


### PR DESCRIPTION
## What

Agent errors can carry the root daemon's **stderr, filesystem paths, and driver internals**. ~82 handlers echoed them straight to the authenticated HTTP client via `"detail": err.Error()` on agent-failure responses — OWASP A05, and the issue's explicitly **highest-value leak class** ("agent-error passthrough reflects root-daemon internals").

## Fix

- **`respondAgentErr` / `respondAgentErrStatus`** (+ `logAgentError`): log the full error server-side (`slog`, with request-id + method/path correlation) and return just the stable `{"error": code}` the client already switches on.
- Migrated every `agent_error` / `agent_failed` / `agent_call_failed` / `apply_failed` passthrough (all `502`) across **30+ handlers** to the helpers.
- Fixed `files.go`'s own `respondAgentError(c, err)` helper (fed ~15 file handlers) and the `InstallError.Detail` path to log-not-leak.
- **`TestNoAgentErrorLeak`**: a source-scanning regression gate — fails if an agent-error code and a raw `.Error()` ever land on the same response line again (the lint the issue asked for, runs in `Go tests + vet`).

Client wire contract preserved: same HTTP status + `error` code; only the leaked `detail` is dropped (verified no test asserted on it; updated the one clone test that asserted the old leak to assert its absence).

## Scope note

This targets the **agent-origin** leaks (highest value). Lower-value non-agent `err.Error()` in `detail` (path/driver/validation) across the wider handler surface is left for a follow-up — a full 304-site sweep is a separate, larger change. Sibling **JAB-111** targets `manager-api`/`manager-ui` (not this repo) and is skipped.

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] all 39 `internal/...` packages pass
- [x] `TestNoAgentErrorLeak` green (0 leak sites); clone-failure test now asserts no `detail`/raw-error in body
- [ ] CI green

Acceptance: handlers no longer place agent-origin `err.Error()` in HTTP responses; detailed errors logged server-side with request-id; lint gate enforces it; spot-checks (catch-all update, grant add) return no internal detail.