### PR TITLE
fix(applications): stop flagging non-WordPress apps as drifted (GH #378)

### DIFF
--- a/panel-api/internal/db/migrations/000221_repair_nonwp_drift_failed.down.sql
+++ b/panel-api/internal/db/migrations/000221_repair_nonwp_drift_failed.down.sql
@@ -1,0 +1,3 @@
+-- Irreversible data repair (GH #378): the pre-repair 'failed' state was itself
+-- the bug, and the original per-row timestamps are not recoverable. No-op.
+SELECT 1;

--- a/panel-api/internal/db/migrations/000221_repair_nonwp_drift_failed.up.sql
+++ b/panel-api/internal/db/migrations/000221_repair_nonwp_drift_failed.up.sql
@@ -1,0 +1,11 @@
+-- GH #378: the WordPress drift probe ran a wp-includes/version.php existence
+-- check against every ready install regardless of app_type, so non-WordPress
+-- apps (itflow, dokuwiki, …) — which have no such file — were flipped to
+-- 'failed' with the drift message. The reconciler no longer probes non-WordPress
+-- apps; repair the rows it already mislabeled, matched by that exact message so
+-- genuinely-failed installs are left untouched.
+UPDATE application_installs
+SET status = 'ready', last_error = ''
+WHERE app_type <> 'wordpress'
+  AND status = 'failed'
+  AND last_error = 'wp-includes/version.php missing — install drifted';

--- a/panel-api/internal/reconciler/wordpress_reconcile.go
+++ b/panel-api/internal/reconciler/wordpress_reconcile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -115,6 +116,11 @@ func (r *Reconciler) probeReadyWordPressInstalls(ctx context.Context, _ []models
 // retries next tick.
 func (r *Reconciler) probeOneWordPressInstall(ctx context.Context, install models.ApplicationInstall) {
 	if r.agent == nil || r.domains == nil {
+		return
+	}
+	// GH #378: the version.php probe is WordPress-specific. Never run it against
+	// another app type — belt-and-braces behind the app_type-scoped query.
+	if !strings.EqualFold(install.AppType, "wordpress") {
 		return
 	}
 	dom, err := r.domains.FindByID(ctx, install.DomainID)

--- a/panel-api/internal/repository/application_install_repository.go
+++ b/panel-api/internal/repository/application_install_repository.go
@@ -60,10 +60,13 @@ type ApplicationInstallRepository interface {
 	// (GH #409).
 	CountCacheEnabledByDomainID(ctx context.Context, domainID, excludeID string) (int64, error)
 	Delete(ctx context.Context, id string) error
-	// ListReadyByUpdatedAtAsc returns ready installs ordered oldest-
-	// updated-first, capped to limit. Reconciler probe loop uses this
-	// for round-robin fairness — without it the probe always picks
-	// the same head-of-list installs first.
+	// ListReadyByUpdatedAtAsc returns ready WORDPRESS installs ordered
+	// oldest-updated-first, capped to limit. The reconciler probe loop
+	// uses this for round-robin fairness. It is scoped to app_type =
+	// 'wordpress' because the only probe is a WordPress-specific
+	// wp-includes/version.php check — non-WordPress apps (itflow,
+	// dokuwiki, …) have no such file and would be falsely flagged as
+	// drifted (GH #378).
 	ListReadyByUpdatedAtAsc(ctx context.Context, limit int) ([]models.ApplicationInstall, error)
 }
 
@@ -291,7 +294,7 @@ func (r *applicationInstallRepo) ListReadyByUpdatedAtAsc(ctx context.Context, li
 	}
 	var rows []models.ApplicationInstall
 	err := r.db.WithContext(ctx).
-		Where("status = ?", "ready").
+		Where("status = ? AND app_type = ?", "ready", "wordpress").
 		Order("updated_at ASC").
 		Limit(limit).
 		Find(&rows).Error

--- a/panel-api/internal/repository/application_install_repository_test.go
+++ b/panel-api/internal/repository/application_install_repository_test.go
@@ -352,3 +352,27 @@ func TestWordPressInstallDelete_NotFound(t *testing.T) {
 	require.Equal(t, ErrNotFound, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// GH #378: the reconciler's WordPress drift probe must only see WordPress
+// installs — the query has to scope status='ready' AND app_type='wordpress',
+// otherwise non-WordPress apps (itflow, dokuwiki, …) get falsely flagged as
+// drifted. This asserts both predicates are in the SQL.
+func TestListReadyByUpdatedAtAsc_ScopesToWordPress(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewWordPressInstallRepository(db)
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .* FROM `application_installs` WHERE status = \\? AND app_type = \\?.*ORDER BY updated_at ASC.*LIMIT").
+		WithArgs("ready", "wordpress", 100).
+		WillReturnRows(sqlmock.NewRows(
+			[]string{"id", "status", "app_type", "updated_at"},
+		).AddRow("inst_wp", "ready", "wordpress", now))
+
+	rows, err := repo.ListReadyByUpdatedAtAsc(context.Background(), 100)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "inst_wp", rows[0].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Re: GH #378 (reference only — must NOT auto-close per repo policy).

## Root cause

The reconciler's drift probe stats `<docroot>/wp-includes/version.php` and flips an install to `failed` ("wp-includes/version.php missing — install drifted") when it's gone. But `ListReadyByUpdatedAtAsc` returned **every** ready install regardless of `app_type`, so **non-WordPress** apps (itflow, dokuwiki, MediaWiki, …) — which have no `wp-includes/version.php` — were always flagged as drifted and marked failed, even though they run fine. (The reporter saw it on itflow.)

## Fix

- **Scope the probe query** to `app_type = 'wordpress'` — non-WP apps never enter the probe batch (bonus: they no longer dilute the `ProbeBatch` and starve real WP probes).
- **Defensive guard** in `probeOneWordPressInstall` (`app_type != wordpress → return`), belt-and-braces behind the query.
- **Migration 000221** repairs rows already mislabeled by the bug: non-WordPress installs stuck in `failed` with the exact drift message are reset to `ready`. Matching the exact message leaves genuinely-failed installs untouched.

## Test plan

- [x] sqlmock test asserts the query carries `status='ready' AND app_type='wordpress'`
- [x] `reconciler` + `repository` suites pass; `go build ./...` + `vet` clean
- [x] migration 000221 numbering unique/highest; drift-message em-dash matches the Go string byte-for-byte (U+2014)
- [ ] CI green
- [ ] Post-deploy: reporter's itflow app returns to `ready`

Acceptance: non-WordPress apps are no longer marked drifted/failed; existing false-failures are repaired.
