### PR TITLE
fix(python-apps): log apply failures server-side, not just the DB row (GH #357)

### DIFF
--- a/panel-api/internal/reconciler/reconcile_python_apps.go
+++ b/panel-api/internal/reconciler/reconcile_python_apps.go
@@ -85,7 +85,8 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 		return
 	}
 	var res struct {
-		Active bool `json:"active"`
+		Active bool   `json:"active"`
+		Unit   string `json:"unit"`
 	}
 	_ = json.Unmarshal(raw, &res)
 	status := models.PythonAppStatusFailed
@@ -93,8 +94,11 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 	if res.Active {
 		status = models.PythonAppStatusRunning
 	} else {
-		m := "app started but is not active — check the app logs"
+		m := "app started but is not active — check the app logs (journalctl -u " + res.Unit + ")"
 		lastErr = &m
+		// GH #357: surface the failure server-side, not just in the DB row —
+		// otherwise an app that goes pending→failed leaves "nothing in logs".
+		r.log.Warn("pyapp: app applied but not active", "id", app.ID, "unit", res.Unit)
 	}
 	if app.Status != status {
 		if err := r.pythonApps.UpdateStatus(ctx, app.ID, status, lastErr); err != nil {
@@ -104,6 +108,11 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 }
 
 func (r *Reconciler) failPythonApp(ctx context.Context, id, msg string) {
+	// GH #357: log the reason so a failed apply is diagnosable from the server
+	// log, not only the app's last_error column. The agent returns detailed
+	// errors (pip install / systemd restart output) that were previously
+	// swallowed into the DB row alone.
+	r.log.Warn("pyapp: apply failed", "id", id, "reason", msg)
 	if err := r.pythonApps.UpdateStatus(ctx, id, models.PythonAppStatusFailed, &msg); err != nil {
 		r.log.Warn("pyapp: fail status update failed", "id", id, "err", err)
 	}


### PR DESCRIPTION
Re: GH #357 (reference only — must NOT auto-close per repo policy).

## Reported

A Python app went **pending** for a while, then flipped to **failed**, with *"nothing in logs."*

## Root cause

The reconciler dispatches `app.python.apply` to the agent and writes back status. On failure it wrote the reason to `python_apps.last_error` (DB) but emitted **no server log line** — `failPythonApp` and the "not active" branch only logged when the DB *write itself* failed. The agent returns rich errors (pip-install / systemd-restart output, e.g. `pip install …: <stderr>`, `restart jabali-app-X.service: …`), all swallowed into the DB column alone. An operator tailing `journalctl -u jabali-panel` saw nothing.

## Fix

- `failPythonApp` logs `pyapp: apply failed` with the app id + reason — this covers the agent-error path, which carries the real pip/systemd detail.
- The "not active" branch logs the app id + unit, and its `last_error` now names the exact unit to check: `journalctl -u jabali-app-<id>.service`.

The tenant UI already surfaces `last_error` on hover (`PythonAppsPage`); this closes the **server-log** half of the same "nothing in logs" gap.

## Diagnosis / test

- Diagnosed on box `.86`: the `python_apps` feature flag was **off** there (so no live failing app to reproduce), but the reconciler code path confirms the missing log — the failure reason never reached any log sink.
- Logging-only change — no status/behavior change; `go build ./...` + `vet` + the `reconciler` suite pass.
- Post-deploy: a failing Python app now shows its reason in `journalctl -u jabali-panel` (`pyapp: apply failed … reason=…`) in addition to the UI hover.
