### PR TITLE
perf(nginx): gzip + immutable-cache panel static assets (JAB-142, JAB-143)

### DIFF
--- a/install/nginx/jabali-panel-vhost.conf.tmpl
+++ b/install/nginx/jabali-panel-vhost.conf.tmpl
@@ -55,6 +55,16 @@ server {
   # setting "just works" without re-rendering this vhost.
   client_max_body_size 10240m;
 
+  # JAB-142: the SPA (JS/CSS) is served by panel-api (go:embed) via the
+  # proxied `location /` below, so nginx must compress PROXIED responses —
+  # gzip_proxied defaults to `off` and would skip them entirely, shipping the
+  # ~3.1 MB main bundle raw. Compress the text asset types (~3.5x smaller).
+  gzip on;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types application/javascript text/javascript text/css application/json image/svg+xml application/manifest+json;
+
   access_log /var/log/nginx/jabali-panel.access.log;
   error_log  /var/log/nginx/jabali-panel.error.log;
 
@@ -121,6 +131,30 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     proxy_hide_header Content-Security-Policy;
     proxy_hide_header X-Frame-Options;
+  }
+
+  # JAB-143: content-hashed build assets (index-<hash>.js / .css) are
+  # immutable — every build emits a new filename — so cache them for a year
+  # instead of re-fetching the ~3 MB bundle each session. Proxies to the same
+  # panel-api upstream (the SPA is embedded there). A per-location add_header
+  # suppresses the server-scope add_headers, so the security headers relevant
+  # to a static asset response are re-declared here.
+  location ^~ /assets/ {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_http_version 1.1;
+    # Exactly one Cache-Control: drop any the upstream might set, then add ours.
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
   }
 
   # /.ory/* is handled by panel-api itself (in-process reverse proxy


### PR DESCRIPTION
Two panel asset-delivery wins (config-only, panel vhost). The SPA is served by panel-api (`go:embed`) through the proxied `location /`.

## JAB-142 — no compression

`gzip_proxied` defaults to `off`, so nginx never compressed the proxied JS/CSS — the ~3.1 MB main bundle shipped **raw** (~894 KB gzipped, ~3.5×). Added server-scope: `gzip on; gzip_proxied any; gzip_vary on; gzip_min_length 1024; gzip_types <js/css/json/svg/manifest>`.

## JAB-143 — no cache headers

Content-hashed assets (`index-<hash>.js/.css`) are immutable (new build → new filename) but had **no Cache-Control**, so browsers re-fetched the bundle every session. Added `location ^~ /assets/` → `Cache-Control: public, max-age=31536000, immutable`. A per-location `add_header` suppresses inherited server add_headers, so the asset-relevant security headers (HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`) are re-declared; `proxy_hide_header Cache-Control` keeps exactly one. `index.html` keeps the server default (not force-cached).

## Test plan

- [x] rendered template brace-balanced; no stray `${}` vars in the new blocks
- [ ] CI green (no Go/UI change)
- [ ] **On deploy to .86**: `nginx -t` OK; `curl -H 'Accept-Encoding: gzip' .../assets/index-*.js` → `content-encoding: gzip` + size < ~950 KB (JAB-142); `curl -D- .../assets/index-*.js` → `Cache-Control: public, max-age=31536000, immutable` (JAB-143)

Acceptance: entry JS/CSS return `content-encoding: gzip` and `Cache-Control: …immutable`; repeat navigation makes 0 asset requests.

_Note: JAB-144 (serve /assets from disk instead of proxying) is a separate, larger change — not included here._