### PR TITLE
perf(api): batch mailbox+domain lookups in mail list handlers (JAB-147)

### DIFF
--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -37,6 +37,16 @@ func newFakeDomainRepo(doms ...*models.Domain) *fakeDomainRepo {
 	return f
 }
 
+func (f *fakeDomainRepo) FindByIDs(_ context.Context, ids []string) ([]models.Domain, error) {
+	var out []models.Domain
+	for _, id := range ids {
+		if d, ok := f.byID[id]; ok {
+			out = append(out, *d)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeDomainRepo) FindByID(_ context.Context, id string) (*models.Domain, error) {
 	if d, ok := f.byID[id]; ok {
 		cp := *d

--- a/panel-api/cmd/server/mailbox_cmd_test.go
+++ b/panel-api/cmd/server/mailbox_cmd_test.go
@@ -34,6 +34,16 @@ func newFakeMailboxRepo() *fakeMailboxRepo {
 	return &fakeMailboxRepo{rows: map[string]*models.Mailbox{}}
 }
 
+func (f *fakeMailboxRepo) FindByIDs(_ context.Context, ids []string) ([]models.Mailbox, error) {
+	var out []models.Mailbox
+	for _, id := range ids {
+		if mb, ok := f.rows[id]; ok {
+			out = append(out, *mb)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeMailboxRepo) FindByID(_ context.Context, id string) (*models.Mailbox, error) {
 	if f.findErr != nil {
 		return nil, f.findErr

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -54,6 +54,16 @@ func (m *mockDomainRepo) FindByID(ctx context.Context, id string) (*models.Domai
 	return nil, repository.ErrNotFound
 }
 
+func (m *mockDomainRepo) FindByIDs(_ context.Context, ids []string) ([]models.Domain, error) {
+	var out []models.Domain
+	for _, id := range ids {
+		if d, ok := m.domains[id]; ok {
+			out = append(out, *d)
+		}
+	}
+	return out, nil
+}
+
 func (m *mockDomainRepo) FindByName(ctx context.Context, name string) (*models.Domain, error) {
 	for _, d := range m.domains {
 		if d.Name == name {

--- a/panel-api/internal/api/mail_batch.go
+++ b/panel-api/internal/api/mail_batch.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-147: mail list handlers (forwarders / shares / groups) resolved each row
+// with per-row FindByID for the owning mailbox + domain — an N+1 that issues
+// hundreds of queries for a full page. These helpers batch-load by id in one
+// query each and return an id→row map for O(1) resolution.
+
+func dedupeIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// mailboxMapByID batch-loads the given mailbox ids into an id→*Mailbox map.
+// A load error yields an empty map (callers skip rows they can't resolve, the
+// same failure mode as the per-row FindByID it replaced).
+func mailboxMapByID(ctx context.Context, repo repository.MailboxRepository, ids []string) map[string]*models.Mailbox {
+	m := map[string]*models.Mailbox{}
+	rows, err := repo.FindByIDs(ctx, dedupeIDs(ids))
+	if err != nil {
+		return m
+	}
+	for i := range rows {
+		m[rows[i].ID] = &rows[i]
+	}
+	return m
+}
+
+// domainMapByID batch-loads the given domain ids into an id→*Domain map.
+func domainMapByID(ctx context.Context, repo repository.DomainRepository, ids []string) map[string]*models.Domain {
+	m := map[string]*models.Domain{}
+	rows, err := repo.FindByIDs(ctx, dedupeIDs(ids))
+	if err != nil {
+		return m
+	}
+	for i := range rows {
+		m[rows[i].ID] = &rows[i]
+	}
+	return m
+}

--- a/panel-api/internal/api/mailbox_forwarder.go
+++ b/panel-api/internal/api/mailbox_forwarder.go
@@ -112,6 +112,19 @@ func (h *forwarderHandler) listAll(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+	// JAB-147: batch-load the mailboxes + domains once instead of a per-row
+	// FindByID pair (N+1). Build id→row maps, then resolve from memory.
+	mbIDs := make([]string, 0, len(fwds))
+	domIDs := make([]string, 0, len(fwds))
+	for _, f := range fwds {
+		if f.MailboxID != nil {
+			mbIDs = append(mbIDs, *f.MailboxID)
+		}
+		domIDs = append(domIDs, f.DomainID)
+	}
+	mbByID := mailboxMapByID(ctx, h.cfg.Mailboxes, mbIDs)
+	domByID := domainMapByID(ctx, h.cfg.Domains, domIDs)
+
 	items := make([]forwarderResponse, 0, len(fwds))
 	for _, f := range fwds {
 		if f.MailboxID == nil {
@@ -121,12 +134,9 @@ func (h *forwarderHandler) listAll(c *gin.Context) {
 			// admin ListAll path reaches here.)
 			continue
 		}
-		mb, err := h.cfg.Mailboxes.FindByID(ctx, *f.MailboxID)
-		if err != nil {
-			continue
-		}
-		dom, err := h.cfg.Domains.FindByID(ctx, f.DomainID)
-		if err != nil {
+		mb := mbByID[*f.MailboxID]
+		dom := domByID[f.DomainID]
+		if mb == nil || dom == nil {
 			continue
 		}
 		if !claims.IsAdmin && dom.UserID != claims.UserID {
@@ -274,8 +284,13 @@ func (h *forwarderHandler) resolve(_ context.Context, f models.EmailForwarder, m
 		lp = *f.LocalPart
 	}
 	return forwarderResponse{
-		ID:           f.ID,
-		MailboxID:    func() string { if f.MailboxID != nil { return *f.MailboxID }; return "" }(),
+		ID: f.ID,
+		MailboxID: func() string {
+			if f.MailboxID != nil {
+				return *f.MailboxID
+			}
+			return ""
+		}(),
 		MailboxEmail: mb.LocalPart + "@" + dom.Name,
 		DomainID:     f.DomainID,
 		DomainName:   dom.Name,
@@ -304,15 +319,15 @@ func (h *forwarderHandler) writeErr(c *gin.Context, err error) {
 // mailbox list. No mailbox_email — the entry redirects without a
 // source account.
 type domainScopedForwarderResponse struct {
-	ID          string `json:"id"`
-	DomainID    string `json:"domain_id"`
-	DomainName  string `json:"domain_name"`
-	Type        string `json:"type"`
-	LocalPart   string `json:"local_part"`
-	Target      string `json:"target"`
-	Enabled     bool   `json:"enabled"`
-	ManagedBy   string `json:"managed_by"`
-	CreatedAt   string `json:"created_at"`
+	ID         string `json:"id"`
+	DomainID   string `json:"domain_id"`
+	DomainName string `json:"domain_name"`
+	Type       string `json:"type"`
+	LocalPart  string `json:"local_part"`
+	Target     string `json:"target"`
+	Enabled    bool   `json:"enabled"`
+	ManagedBy  string `json:"managed_by"`
+	CreatedAt  string `json:"created_at"`
 }
 
 func (h *forwarderHandler) listDomainScoped(c *gin.Context) {

--- a/panel-api/internal/api/mailbox_share.go
+++ b/panel-api/internal/api/mailbox_share.go
@@ -33,13 +33,13 @@ type MailboxShareHandlerConfig struct {
 }
 
 type shareResponse struct {
-	ID                     string         `json:"id"`
-	OwnerMailboxID         string         `json:"owner_mailbox_id"`
-	OwnerMailboxEmail      string         `json:"owner_mailbox_email,omitempty"`
-	SharedWithMailboxID    string         `json:"shared_with_mailbox_id"`
-	SharedWithMailboxEmail string         `json:"shared_with_mailbox_email,omitempty"`
-	Rights                 models.Rights  `json:"rights"`
-	CreatedAt              string         `json:"created_at"`
+	ID                     string        `json:"id"`
+	OwnerMailboxID         string        `json:"owner_mailbox_id"`
+	OwnerMailboxEmail      string        `json:"owner_mailbox_email,omitempty"`
+	SharedWithMailboxID    string        `json:"shared_with_mailbox_id"`
+	SharedWithMailboxEmail string        `json:"shared_with_mailbox_email,omitempty"`
+	Rights                 models.Rights `json:"rights"`
+	CreatedAt              string        `json:"created_at"`
 }
 
 type shareCreateRequest struct {
@@ -90,9 +90,10 @@ func (h *shareHandler) list(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+	mbByID, domByID := h.shareRowMaps(ctx, shares)
 	items := make([]shareResponse, 0, len(shares))
 	for _, s := range shares {
-		items = append(items, h.resolve(ctx, s))
+		items = append(items, resolveShareFromMaps(s, mbByID, domByID))
 	}
 	c.JSON(http.StatusOK, gin.H{"data": items, "total": total, "page": 1, "page_size": 200})
 }
@@ -121,20 +122,22 @@ func (h *shareHandler) listAllForUser(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+	// JAB-147: batch-load owner/target mailboxes + their domains once.
+	mbByID, domByID := h.shareRowMaps(ctx, shares)
 	items := make([]shareResponse, 0, len(shares))
 	for _, s := range shares {
-		owner, err := h.cfg.Mailboxes.FindByID(ctx, s.OwnerMailboxID)
-		if err != nil {
+		owner := mbByID[s.OwnerMailboxID]
+		if owner == nil {
 			continue
 		}
-		dom, err := h.cfg.Domains.FindByID(ctx, owner.DomainID)
-		if err != nil {
+		dom := domByID[owner.DomainID]
+		if dom == nil {
 			continue
 		}
 		if !claims.IsAdmin && dom.UserID != claims.UserID {
 			continue // defense-in-depth; ListByUserID already enforces this
 		}
-		items = append(items, h.resolve(ctx, s))
+		items = append(items, resolveShareFromMaps(s, mbByID, domByID))
 	}
 	c.JSON(http.StatusOK, gin.H{"data": items, "total": total, "page": page, "page_size": pageSize})
 }
@@ -189,6 +192,44 @@ func (h *shareHandler) del(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusNoContent, nil)
+}
+
+// shareRowMaps batch-loads every owner + shared-with mailbox for the given
+// shares and their domains into id→row maps (JAB-147), replacing the per-row
+// FindByID pairs the list handlers used to run.
+func (h *shareHandler) shareRowMaps(ctx context.Context, shares []models.MailboxShare) (map[string]*models.Mailbox, map[string]*models.Domain) {
+	mbIDs := make([]string, 0, len(shares)*2)
+	for _, s := range shares {
+		mbIDs = append(mbIDs, s.OwnerMailboxID, s.SharedWithMailboxID)
+	}
+	mbByID := mailboxMapByID(ctx, h.cfg.Mailboxes, mbIDs)
+	domIDs := make([]string, 0, len(mbByID))
+	for _, mb := range mbByID {
+		domIDs = append(domIDs, mb.DomainID)
+	}
+	return mbByID, domainMapByID(ctx, h.cfg.Domains, domIDs)
+}
+
+// resolveShareFromMaps builds a shareResponse from pre-batched maps (no query).
+func resolveShareFromMaps(s models.MailboxShare, mbByID map[string]*models.Mailbox, domByID map[string]*models.Domain) shareResponse {
+	resp := shareResponse{
+		ID:                  s.ID,
+		OwnerMailboxID:      s.OwnerMailboxID,
+		SharedWithMailboxID: s.SharedWithMailboxID,
+		Rights:              s.Rights,
+		CreatedAt:           s.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if owner := mbByID[s.OwnerMailboxID]; owner != nil {
+		if dom := domByID[owner.DomainID]; dom != nil {
+			resp.OwnerMailboxEmail = owner.LocalPart + "@" + dom.Name
+		}
+	}
+	if target := mbByID[s.SharedWithMailboxID]; target != nil {
+		if dom := domByID[target.DomainID]; dom != nil {
+			resp.SharedWithMailboxEmail = target.LocalPart + "@" + dom.Name
+		}
+	}
+	return resp
 }
 
 func (h *shareHandler) resolve(ctx context.Context, s models.MailboxShare) shareResponse {

--- a/panel-api/internal/api/mailgroups.go
+++ b/panel-api/internal/api/mailgroups.go
@@ -328,10 +328,13 @@ func (h *mailGroupHandler) get(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+	// JAB-147: batch-load the member mailboxes once (was per-member FindByID).
+	// Iterate memberIDs to preserve order; the map gives O(1) lookup.
+	mbByID := mailboxMapByID(ctx, h.cfg.Mailboxes, memberIDs)
 	members := make([]mailGroupMemberDTO, 0, len(memberIDs))
 	for _, mid := range memberIDs {
-		mb, err := h.cfg.Mailboxes.FindByID(ctx, mid)
-		if err != nil {
+		mb := mbByID[mid]
+		if mb == nil {
 			continue // mailbox vanished mid-read; cascade will clean the edge
 		}
 		members = append(members, mailGroupMemberDTO{MailboxID: mb.ID, Email: mb.EmailCached})

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -141,6 +141,10 @@ func (m *MockDomainRepository) FindByID(ctx context.Context, id string) (*models
 }
 
 func (m *MockDomainRepository) UpdateSSLMode(context.Context, string, string) error { return nil }
+func (m *MockDomainRepository) FindByIDs(context.Context, []string) ([]models.Domain, error) {
+	return nil, nil
+}
+
 
 func (m *MockDomainRepository) BulkSetEnabledByUserID(_ context.Context, _ string, _ bool) (int64, error) {
 	return 0, nil

--- a/panel-api/internal/api/webmail_sso_test.go
+++ b/panel-api/internal/api/webmail_sso_test.go
@@ -86,6 +86,16 @@ func (r *ssoFakeMailboxRepo) FindByID(ctx context.Context, id string) (*models.M
 	}
 	return nil, repository.ErrNotFound
 }
+
+func (r *ssoFakeMailboxRepo) FindByIDs(_ context.Context, ids []string) ([]models.Mailbox, error) {
+	var out []models.Mailbox
+	for _, id := range ids {
+		if mb, ok := r.mbs[id]; ok {
+			out = append(out, *mb)
+		}
+	}
+	return out, nil
+}
 func (r *ssoFakeMailboxRepo) Create(ctx context.Context, mb *models.Mailbox) error { return nil }
 func (r *ssoFakeMailboxRepo) FindByEmail(ctx context.Context, email string) (*models.Mailbox, error) {
 	return nil, repository.ErrNotFound

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -62,6 +62,16 @@ func (f *fakeDomainRepo) Create(ctx context.Context, d *models.Domain) error {
 	return nil
 }
 
+func (f *fakeDomainRepo) FindByIDs(_ context.Context, ids []string) ([]models.Domain, error) {
+	var out []models.Domain
+	for _, id := range ids {
+		if d, ok := f.domains[id]; ok {
+			out = append(out, *d)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeDomainRepo) FindByID(ctx context.Context, id string) (*models.Domain, error) {
 	d, ok := f.domains[id]
 	if !ok {

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -15,6 +15,9 @@ import (
 type DomainRepository interface {
 	Create(ctx context.Context, d *models.Domain) error
 	FindByID(ctx context.Context, id string) (*models.Domain, error)
+	// FindByIDs batch-loads domains by id (deduped, one query) — the
+	// N+1-free path for list handlers resolving many rows (JAB-147).
+	FindByIDs(ctx context.Context, ids []string) ([]models.Domain, error)
 	FindByName(ctx context.Context, name string) (*models.Domain, error)
 	List(ctx context.Context, opts ListOptions) ([]models.Domain, int64, error)
 	ListByUserID(ctx context.Context, userID string, opts ListOptions) ([]models.Domain, int64, error)
@@ -200,6 +203,19 @@ func (r *domainRepo) FindByID(ctx context.Context, id string) (*models.Domain, e
 		return nil, err
 	}
 	return &d, nil
+}
+
+// FindByIDs batch-loads domains by id (deduped, one query) — the N+1-free
+// path for list handlers resolving many rows (JAB-147).
+func (r *domainRepo) FindByIDs(ctx context.Context, ids []string) ([]models.Domain, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var rows []models.Domain
+	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *domainRepo) FindByName(ctx context.Context, name string) (*models.Domain, error) {
@@ -406,7 +422,6 @@ func (r *domainRepo) CountByUserID(ctx context.Context, userID string) (int64, e
 	}
 	return count, nil
 }
-
 
 func (r *domainRepo) SetPHPPoolID(ctx context.Context, id string, poolID *string) error {
 	res := r.db.WithContext(ctx).Model(&models.Domain{}).

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -18,6 +18,9 @@ import (
 // migration 000054 — we never set it here directly.
 type MailboxRepository interface {
 	FindByID(ctx context.Context, id string) (*models.Mailbox, error)
+	// FindByIDs batch-loads mailboxes by id (deduped, one query) — the
+	// N+1-free path for list handlers that resolve many rows (JAB-147).
+	FindByIDs(ctx context.Context, ids []string) ([]models.Mailbox, error)
 	FindByEmail(ctx context.Context, email string) (*models.Mailbox, error)
 	ListByDomainID(ctx context.Context, domainID string, opts ListOptions) ([]models.Mailbox, int64, error)
 	ListAllWithDomain(ctx context.Context) ([]MailboxWithDomain, error)
@@ -56,6 +59,17 @@ func (r *mailboxRepo) FindByID(ctx context.Context, id string) (*models.Mailbox,
 		return nil, err
 	}
 	return &mb, nil
+}
+
+func (r *mailboxRepo) FindByIDs(ctx context.Context, ids []string) ([]models.Mailbox, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var rows []models.Mailbox
+	if err := r.db.WithContext(ctx).Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func (r *mailboxRepo) FindByEmail(ctx context.Context, email string) (*models.Mailbox, error) {

--- a/panel-api/internal/repository/mailbox_repository_test.go
+++ b/panel-api/internal/repository/mailbox_repository_test.go
@@ -215,3 +215,33 @@ func TestMailboxRepository_UpdateUsage(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// JAB-147: FindByIDs must batch-load in a single IN query (the N+1-free path
+// for the mail list handlers), not one SELECT per id.
+func TestMailboxFindByIDs_SingleINQuery(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := NewMailboxRepository(db)
+
+	cols := []string{"id", "domain_id", "local_part", "email_cached"}
+	mock.ExpectQuery("SELECT .* FROM `mailboxes` WHERE id IN \\(\\?,\\?\\)").
+		WithArgs("mb1", "mb2").
+		WillReturnRows(sqlmock.NewRows(cols).
+			AddRow("mb1", "dom1", "alice", "alice@example.com").
+			AddRow("mb2", "dom1", "bob", "bob@example.com"))
+
+	rows, err := repo.FindByIDs(context.Background(), []string{"mb1", "mb2"})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMailboxFindByIDs_EmptyNoQuery(t *testing.T) {
+	db, _, raw := newMockDB(t)
+	defer raw.Close()
+	repo := NewMailboxRepository(db)
+	// No ExpectQuery registered — an empty id set must not hit the DB.
+	rows, err := repo.FindByIDs(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}


### PR DESCRIPTION
## What

The mail **forwarders**, **shares**, and **group-member** list handlers resolved each row with per-row `FindByID` for the owning mailbox + domain — an N+1 issuing up to hundreds of queries for a full page. The share `resolve` was worst: **2 mailbox + 2 domain `FindByID` per row**, re-fetching the owner already loaded in the loop.

## Fix

- Add `MailboxRepository.FindByIDs` + `DomainRepository.FindByIDs` — a single deduped `WHERE id IN (?)` query.
- `mail_batch.go`: `mailboxMapByID` / `domainMapByID` helpers → id→row maps.
- `forwarder listAll`, `share list` + `listAllForUser`, and `mailgroup detail members` batch-load once and resolve from memory (iteration order preserved where it matters — group members).

Per-page DB queries drop from **O(2N)–O(4N) → O(1)** (2–3 batch queries). Wire contract unchanged (identical response shape/fields).

## Test plan

- [x] `go build ./...` + `go vet ./...` clean
- [x] sqlmock test: `FindByIDs` issues **one** `IN` query; empty id set skips the DB
- [x] all `internal/...` + `cmd/server` suites pass (updated the repo mocks that implement the two interfaces)
- [ ] CI green

Related: builds on JAB-107 (same list handlers). Acceptance: no per-row lookups in the mail list handlers; response bytes unchanged.