### PR TITLE
perf(api): collapse dashboard counts into one query (JAB-148)

### DIFF
--- a/panel-api/internal/api/admin_counts.go
+++ b/panel-api/internal/api/admin_counts.go
@@ -4,7 +4,8 @@
 // / mailboxes). Routing each through its own list endpoint with limit=1
 // works for users + domains but mailboxes only ships per-domain lists,
 // so the SPA would have to N+1 across domains. /admin/counts collapses
-// that into one round-trip with three COUNT(*) queries.
+// that into a single round-trip: one SELECT with three scalar COUNT(*)
+// subqueries (JAB-148), instead of three sequential COUNT statements.
 
 package api
 
@@ -48,18 +49,17 @@ type adminCountsHandler struct {
 
 func (h *adminCountsHandler) get(c *gin.Context) {
 	ctx := c.Request.Context()
-	db := h.cfg.DB.WithContext(ctx)
 
+	// JAB-148: one round-trip via scalar subqueries instead of three
+	// sequential COUNT(*) statements. The column aliases match the response
+	// field names, so GORM scans them straight into the struct.
 	var resp adminCountsResponse
-	if err := db.Table("users").Count(&resp.Users).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-	if err := db.Table("domains").Count(&resp.Domains).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-	if err := db.Table("mailboxes").Count(&resp.Mailboxes).Error; err != nil {
+	if err := h.cfg.DB.WithContext(ctx).Raw(
+		"SELECT " +
+			"(SELECT COUNT(*) FROM users) AS users, " +
+			"(SELECT COUNT(*) FROM domains) AS domains, " +
+			"(SELECT COUNT(*) FROM mailboxes) AS mailboxes",
+	).Scan(&resp).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}

--- a/panel-api/internal/api/admin_counts_test.go
+++ b/panel-api/internal/api/admin_counts_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newCountsMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	mock.ExpectQuery(`SELECT VERSION\(\)`).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	return gdb, mock, raw
+}
+
+// JAB-148: /admin/counts must issue ONE round-trip (a single SELECT with three
+// scalar COUNT subqueries) and scan the aliased columns straight into the
+// response — not silently return zeros.
+func TestAdminCounts_SingleQueryScans(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, mock, raw := newCountsMockDB(t)
+	defer raw.Close()
+
+	mock.ExpectQuery(`SELECT .*\(SELECT COUNT\(\*\) FROM users\) AS users.*\(SELECT COUNT\(\*\) FROM domains\) AS domains.*\(SELECT COUNT\(\*\) FROM mailboxes\) AS mailboxes`).
+		WillReturnRows(sqlmock.NewRows([]string{"users", "domains", "mailboxes"}).
+			AddRow(int64(7), int64(4), int64(19)))
+
+	h := &adminCountsHandler{cfg: AdminCountsHandlerConfig{DB: db}}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/counts", nil)
+
+	h.get(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp adminCountsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, int64(7), resp.Users)
+	require.Equal(t, int64(4), resp.Domains)
+	require.Equal(t, int64(19), resp.Mailboxes)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
`GET /admin/counts` ran **three sequential `COUNT(*)`** statements (users, domains, mailboxes) — three round-trips + three full-table scans on every dashboard load.

Replace with a single `SELECT` carrying three scalar `COUNT(*)` subqueries whose aliases scan straight into the response struct. Identical wire shape; **one** round-trip.

## Test plan

- [x] `go build ./...` + `vet` clean
- [x] sqlmock test asserts the single query maps aliased columns → `Users`/`Domains`/`Mailboxes` (guards a silent-zero mapping mismatch)
- [ ] CI green

Acceptance: dashboard counts issue one batched query, not three sequential COUNTs.