### PR TITLE
perf(ui): slim Monaco to editor core + basic grammars, drop ts.worker (JAB-146)

### DIFF
--- a/panel-ui/src/monaco-slim.d.ts
+++ b/panel-ui/src/monaco-slim.d.ts
@@ -1,0 +1,8 @@
+// JAB-146: monaco-editor's package `exports` map doesn't expose these deep ESM
+// subpaths to TypeScript's bundler resolution, so declare them. `editor.api`
+// re-exports the full monaco namespace; the `_.contribution` barrel is a
+// side-effect import (registers the basic-language grammars).
+declare module "monaco-editor/esm/vs/editor/editor.api" {
+  export * from "monaco-editor";
+}
+declare module "monaco-editor/esm/vs/basic-languages/_.contribution";

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -97,11 +97,14 @@ import type { UploadDrawerHandle } from "./UploadDrawer";
 // the bundled monaco-editor module to loader.config so no network
 // fetch happens; the chunk lives inside our own vite-built bundle.
 const Editor = lazy(async () => {
-  const [{ loader }, monaco, EditorWorker] = await Promise.all([
+  const [{ loader }, monacoMod, EditorWorker] = await Promise.all([
     import("@monaco-editor/react"),
-    import("monaco-editor"),
+    // JAB-146: slim Monaco (editor core + basic-language grammars only) —
+    // drops the multi-MB ts.worker / css / html / json language services.
+    import("./monacoSlim"),
     import("monaco-editor/esm/vs/editor/editor.worker?worker"),
   ]);
+  const monaco = monacoMod.default;
   // Monaco resolves language workers via self.MonacoEnvironment. We
   // only need the base editor worker for plain-text editing of
   // wp-config.php / .htaccess / etc.; JSON / CSS / HTML / TS

--- a/panel-ui/src/shells/user/files/monacoSlim.ts
+++ b/panel-ui/src/shells/user/files/monacoSlim.ts
@@ -1,0 +1,19 @@
+// JAB-146: load Monaco's editor CORE (editor.api) plus only the lightweight
+// Monarch syntax grammars (basic-languages), NOT the heavy language SERVICES
+// (typescript / css / html / json). Importing the full `monaco-editor` barrel
+// pulls in those services and their web workers — ts.worker (~6.7 MB), the
+// css/html/json workers, and a much larger editor.main — none of which the
+// panel uses: MonacoEnvironment (in FileManagerPage) wires ONLY the base
+// editor.worker, so the language-service workers were dead weight.
+//
+// `_.contribution` lazily registers every basic language, so each grammar
+// (php / javascript / sql / shell / python / go / rust / java / kotlin / ruby /
+// xml / yaml / ini / markdown / css / scss / less / html / typescript-basic …
+// see languageByExt) still highlights, loading only on first use. JSON is the
+// one exception — its grammar ships only with the dropped json language
+// service — so .json files render as plaintext, an acceptable trade for
+// dropping several MB from the editor chunk.
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import "monaco-editor/esm/vs/basic-languages/_.contribution";
+
+export default monaco;


### PR DESCRIPTION
The file-manager editor did `import("monaco-editor")` — the **full barrel**, which pulls in the TypeScript/CSS/HTML/JSON language **services** and their web workers: `ts.worker` (~7 MB), css/html/json workers (~2 MB), and a bloated `editor.main`. But `MonacoEnvironment` only ever wired the base `editor.worker`, so those service workers were **dead weight** downloaded on first editor open.

## Fix

Load `monaco-editor/esm/vs/editor/editor.api` (core) + the `_.contribution` basic-languages barrel instead. Every basic language `languageByExt` maps (php / js / sql / shell / python / go / rust / java / kotlin / ruby / xml / yaml / ini / markdown / css / scss / less / html / ts-basic) keeps syntax highlighting, lazy per-language. **JSON degrades to plaintext** (its grammar ships only with the dropped json service) — an acceptable trade.

## Result (measured)

| | before | after |
|---|--------|-------|
| ts.worker | 7.0 MB | **gone** |
| css/html/json workers | ~2.1 MB | **gone** |
| editor chunk | editor.main 3.8 MB | monacoSlim 3.7 MB |
| **Monaco total** | **~13 MB** | **~4.1 MB** |

Lazy-loaded on editor open (not the initial critical path).

## Test plan

- [x] `tsc -b` + `vite build` clean (ambient d.ts declares the deep ESM subpaths for bundler resolution)
- [x] measured chunk sizes: `ts.worker`/css/html/json workers absent from dist
- [ ] CI green
- [ ] **Post-deploy spot-check** (editor is auth-gated, not reachable headlessly): open a `.php` file in the file manager → renders + highlights

Acceptance: Monaco payload trimmed; no `ts.worker`.