### PR TITLE
fix(apparmor): grant panel-api rw to upload staging dir (GH #355)

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -193,6 +193,16 @@ profile jabali-panel flags=(attach_disconnected) {
 
   /var/lib/jabali-panel/       rw,
   /var/lib/jabali-panel/**     rwk,
+  # GH #355: file-manager upload staging. panel-api writes the incoming
+  # upload to /var/lib/jabali-uploads/jabali-upload-* before the agent's
+  # files.ingest moves it into the tenant home (both units share this
+  # path — see files.go). The dir is in the unit's ReadWritePaths and is
+  # owned by the jabali user 0750, but under enforce mode AppArmor also
+  # needs an explicit rule or the open() EACCESes ("permission denied"
+  # on every upload once the profile matures out of complain). The agent
+  # runs as root/unconfined and reads it without a rule here.
+  /var/lib/jabali-uploads/     rw,
+  /var/lib/jabali-uploads/**   rwk,
   /var/log/jabali-panel/       rw,
   /var/log/jabali-panel/**     rwk,
 

--- a/panel-api/internal/api/upload_staging_apparmor_test.go
+++ b/panel-api/internal/api/upload_staging_apparmor_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestUploadStagingDirHasAppArmorRule guards GH #355: the panel-api
+// AppArmor profile (jabali-panel) must grant read-write to the upload
+// staging dir, or the daemon EACCESes the open() of every file-manager
+// upload once the profile matures from complain to enforce mode.
+//
+// The staging dir is listed in the systemd unit's ReadWritePaths, but
+// systemd path allow-listing and AppArmor file mediation are independent
+// layers — an ReadWritePaths entry without a matching profile rule fails
+// silently in complain and hard-fails in enforce. This test pins the two
+// together so a future edit to uploadStagingDir (or the profile) can't
+// reopen the regression.
+func TestUploadStagingDirHasAppArmorRule(t *testing.T) {
+	const profilePath = "../../../install/apparmor/usr.local.bin.jabali-panel-api"
+
+	raw, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatalf("read AppArmor profile %s: %v", profilePath, err)
+	}
+	profile := string(raw)
+
+	// uploadStagingDir is "/var/lib/jabali-uploads" (files.go). The
+	// profile must grant rw to both the dir itself and its contents.
+	dir := strings.TrimRight(uploadStagingDir, "/") + "/"
+
+	// Match e.g. `/var/lib/jabali-uploads/**  rwk,` — the path, some
+	// whitespace, then a permission set containing at least r and w.
+	for _, pathGlob := range []string{regexp.QuoteMeta(dir), regexp.QuoteMeta(dir) + `\*\*`} {
+		re := regexp.MustCompile(`(?m)^\s*` + pathGlob + `\s+[a-z]*r[a-z]*w[a-z]*\s*,`)
+		if !re.MatchString(profile) {
+			t.Errorf("AppArmor profile is missing an rw rule for %q — file-manager uploads will EACCES under enforce mode (GH #355). Add `%s rw,`", pathGlob, dir)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (GH #355)

File-manager uploads fail with

```
open /var/lib/jabali-uploads/jabali-upload-…: permission denied
```

The reporter hit it as a sub-user with a 33.7 MB archive, but the staging
path is user-id-hashed, so it affects **every** user, not just sub-users.

## Root cause

`/var/lib/jabali-uploads` is created `0750` owned by the `jabali` service
user and is listed in the `jabali-panel.service` `ReadWritePaths`, so
systemd permits the write. But the AppArmor profile (`jabali-panel`) had
**no rule** for it. systemd path allow-listing and AppArmor file mediation
are independent layers: an `ReadWritePaths` entry with no matching profile
rule is silently allowed in **complain** mode and hard-`EACCES`es once the
profile matures to **enforce** (`jabali apparmor flip-mature` after the
7-day soak). The reporter's box was in enforce.

## Fix

Add an rw rule (dir + contents) to the profile, mirroring the existing
`/var/lib/jabali-panel` block, plus a Go regression test that reads the
shipped profile and asserts it grants rw to `uploadStagingDir` — so a
future edit to either the constant or the profile can't reopen the gap.

## Verification (box .86, profile in enforce)

- Before: a write to `/var/lib/jabali-uploads` under
  `aa-exec -p jabali-panel` was **denied**; the same write unconfined
  succeeded.
- After (patched profile reloaded live): the confined write **succeeds**,
  while an unlisted control path (`/var/lib/aa-should-be-denied-xyz`)
  stays denied — confirming it's the new rule, not a blanket allow.
- `go test ./internal/api/` green; regression test fails when the rule is
  removed.

## Follow-up (not in this PR)

The profile is also missing rw for other `ReadWritePaths` entries the
daemon writes (`/var/lib/jabali-migrations`; the `migration-secrets`
subdir is read-only) — same bug class, but those flows involve symlink
resolution and a runtime-configurable working folder, so they need their
own verification. Tracking separately.
