### PR TITLE
fix(apparmor): grant panel-api rw to migration tarball staging dir

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -203,6 +203,17 @@ profile jabali-panel flags=(attach_disconnected) {
   # runs as root/unconfined and reads it without a rule here.
   /var/lib/jabali-uploads/     rw,
   /var/lib/jabali-uploads/**   rwk,
+  # Offline migration tarball staging. uploadTarball (POST
+  # /admin/migrations/:id/tarball) runs in the daemon and does MkdirAll
+  # + OpenFile under /var/lib/jabali-migrations/<id>/ (admin_migrations.go).
+  # Same layer split as the upload staging above (GH #355): the dir is
+  # jabali-owned 0750 and in ReadWritePaths, but without a profile rule
+  # the offline cPanel/HestiaCP tarball upload EACCESes once the profile
+  # is in enforce. (The migration-secrets dir is root-owned and written
+  # by the root agent, so it stays read-only here — covered by
+  # /etc/jabali-panel/** r above.)
+  /var/lib/jabali-migrations/     rw,
+  /var/lib/jabali-migrations/**   rwk,
   /var/log/jabali-panel/       rw,
   /var/log/jabali-panel/**     rwk,
 

--- a/panel-api/internal/api/upload_staging_apparmor_test.go
+++ b/panel-api/internal/api/upload_staging_apparmor_test.go
@@ -27,16 +27,27 @@ func TestUploadStagingDirHasAppArmorRule(t *testing.T) {
 	}
 	profile := string(raw)
 
-	// uploadStagingDir is "/var/lib/jabali-uploads" (files.go). The
-	// profile must grant rw to both the dir itself and its contents.
-	dir := strings.TrimRight(uploadStagingDir, "/") + "/"
+	// Every jabali-owned ReadWritePaths dir the daemon writes in-process
+	// must also have a matching AppArmor rw rule — systemd path
+	// allow-listing and AppArmor file mediation are independent layers.
+	// - uploadStagingDir (files.go): file-manager uploads (GH #355).
+	// - /var/lib/jabali-migrations (admin_migrations.go migrationStagingDir):
+	//   offline cPanel/HestiaCP tarball upload via uploadTarball.
+	cases := []struct {
+		dir, why string
+	}{
+		{strings.TrimRight(uploadStagingDir, "/") + "/", "file-manager uploads (GH #355)"},
+		{"/var/lib/jabali-migrations/", "offline migration tarball upload"},
+	}
 
-	// Match e.g. `/var/lib/jabali-uploads/**  rwk,` — the path, some
-	// whitespace, then a permission set containing at least r and w.
-	for _, pathGlob := range []string{regexp.QuoteMeta(dir), regexp.QuoteMeta(dir) + `\*\*`} {
-		re := regexp.MustCompile(`(?m)^\s*` + pathGlob + `\s+[a-z]*r[a-z]*w[a-z]*\s*,`)
-		if !re.MatchString(profile) {
-			t.Errorf("AppArmor profile is missing an rw rule for %q — file-manager uploads will EACCES under enforce mode (GH #355). Add `%s rw,`", pathGlob, dir)
+	for _, tc := range cases {
+		// Match e.g. `/var/lib/jabali-uploads/**  rwk,` — the path, some
+		// whitespace, then a permission set containing at least r and w.
+		for _, pathGlob := range []string{regexp.QuoteMeta(tc.dir), regexp.QuoteMeta(tc.dir) + `\*\*`} {
+			re := regexp.MustCompile(`(?m)^\s*` + pathGlob + `\s+[a-z]*r[a-z]*w[a-z]*\s*,`)
+			if !re.MatchString(profile) {
+				t.Errorf("AppArmor profile is missing an rw rule for %q — %s will EACCES under enforce mode. Add `%s rw,`", pathGlob, tc.why, tc.dir)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Fast-follow to #418 (GH #355). The same AppArmor layer-split bug affects
**offline migrations**. `uploadTarball` (POST `/admin/migrations/:id/tarball`)
runs in the daemon and does `MkdirAll` + `OpenFile` under
`/var/lib/jabali-migrations/<id>/` (`admin_migrations.go`), but the
`jabali-panel` AppArmor profile had no rule for that dir.

The dir is `jabali`-owned `0750` and listed in the unit's `ReadWritePaths`,
so systemd permits the write — but under **enforce** mode AppArmor `EACCES`es
it, so the offline **cPanel / HestiaCP** tarball upload fails
(`mkdir_staging` / permission denied) once the profile matures out of
complain. Confirmed on .86; unreported in the tracker.

## Fix

- Add the rw rule (dir + contents) to the profile.
- Extend the profile regression test to assert rw for **both** jabali-owned
  daemon-written `ReadWritePaths` staging dirs (uploads + migrations).

The `migration-secrets` dir is root-owned and written by the root agent, so
it stays read-only here (covered by `/etc/jabali-panel/** r`).

## Verification (box .86, profile in enforce)

- `MkdirAll` + write under `/var/lib/jabali-migrations` via
  `aa-exec -p jabali-panel` **succeeds** after the fix.
- Upload staging still works; an unlisted control path stays **denied**.
- `go test ./internal/api/` green; regression test fails when either rule is
  removed.
