### PR TITLE
test(db): guard embedded migrations for up/down pairing + contiguity

### DIFF
--- a/panel-api/internal/db/migrations_completeness_test.go
+++ b/panel-api/internal/db/migrations_completeness_test.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"io/fs"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// migrationFilePattern matches an embedded migration filename, e.g.
+// "000205_crowdsec_login_allowlist.up.sql" → version 205, dir "up".
+var migrationFilePattern = regexp.MustCompile(`^(\d+)_.+\.(up|down)\.sql$`)
+
+// TestEmbeddedMigrationsComplete guards the class of failure behind GH #352
+// ("no migration found for version N: read down for version N: file does not
+// exist"). golang-migrate reads BOTH the up and down file for every version
+// it discovers, so a version shipped with only one half — or a gap in the
+// numbering — makes `migrate up` hard-fail on boot, which surfaces to the
+// user as an unreachable panel / identity service.
+//
+// This runs against the go:embed'd FS (the exact bytes baked into the
+// binary), not the on-disk tree, so it verifies what actually deploys.
+func TestEmbeddedMigrationsComplete(t *testing.T) {
+	root, err := migrationsFSRoot()
+	if err != nil {
+		t.Fatalf("migrationsFSRoot: %v", err)
+	}
+
+	entries, err := fs.ReadDir(root, ".")
+	if err != nil {
+		t.Fatalf("read embedded migrations dir: %v", err)
+	}
+
+	type pair struct{ up, down bool }
+	versions := map[int]*pair{}
+	names := map[int]string{}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := migrationFilePattern.FindStringSubmatch(e.Name())
+		if m == nil {
+			t.Errorf("embedded migration file %q does not match the NNNNNN_name.(up|down).sql convention", e.Name())
+			continue
+		}
+		// Version is a zero-padded integer; Atoi via the regexp group.
+		var v int
+		for _, r := range m[1] {
+			v = v*10 + int(r-'0')
+		}
+		p := versions[v]
+		if p == nil {
+			p = &pair{}
+			versions[v] = p
+			names[v] = m[1]
+		}
+		switch m[2] {
+		case "up":
+			p.up = true
+		case "down":
+			p.down = true
+		}
+	}
+
+	if len(versions) == 0 {
+		t.Fatal("no embedded migrations found — check the go:embed directive in db.go")
+	}
+
+	// Every discovered version must have BOTH halves.
+	sorted := make([]int, 0, len(versions))
+	for v, p := range versions {
+		sorted = append(sorted, v)
+		if !p.up {
+			t.Errorf("migration version %s is missing its .up.sql", names[v])
+		}
+		if !p.down {
+			t.Errorf("migration version %s is missing its .down.sql (this is exactly the GH #352 failure)", names[v])
+		}
+	}
+	sort.Ints(sorted)
+
+	// Versions must be contiguous — a gap means golang-migrate can't walk
+	// the chain and `migrate up` fails partway.
+	for i := 1; i < len(sorted); i++ {
+		if sorted[i] != sorted[i-1]+1 {
+			t.Errorf("migration numbering gap: %d follows %d (expected %d) — versions must be contiguous", sorted[i], sorted[i-1], sorted[i-1]+1)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Relates to GH #352, where `jabali update` died with:

```
migrate: migrate up: no migration found for version 205: read down for version 205 .: file does not exist
```

and the panel/identity service then wouldn't come up. golang-migrate reads
**both** the up and down file for every version it discovers, so a
half-shipped version (up without down, or vice-versa) or a gap in the
numbering hard-fails `migrate up` on boot.

The repo's migration set is currently correct (205 has both halves,
221/221 balanced), so #352 was environment-specific — but nothing in the
default `go test ./...` run would have caught a partial/mismatched migration
before it shipped: the only migration test is behind the `integration`
build tag and needs a live DB.

## What

A CI-gated unit test over the `go:embed`'d migration FS (the exact bytes
baked into the binary — not the on-disk tree) that asserts:

- every version has **both** an `.up.sql` and a `.down.sql`;
- version numbers are **contiguous** (no gaps).

No DB required, so it gates every PR.

## Verification

- Passes on the current 221/221 set.
- Fails with a clear message when a down file is removed:
  `migration version 000205 is missing its .down.sql (this is exactly the GH #352 failure)`.
