### PR TITLE
feat(dashboard): show server public IP on admin dashboard + add IPv6 (GH #361)

### DIFF
--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -55,7 +55,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "public_ipv4": ""})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "public_ipv4": "", "public_ipv6": ""})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -92,9 +92,11 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		"security_enabled": settings.SecurityEnabled,
 		"quota_enabled":    settings.QuotaEnabled,
 		"api_enabled":      settings.APIEnabled,
-		// GH #361: surface the server's public IPv4 so the user dashboard can show
-		// it (already tracked for the panel cert + DNS; not per-user sensitive).
+		// GH #361: surface the server's public IPv4/IPv6 so the user + admin
+		// dashboards can show them (already tracked for the panel cert + DNS;
+		// not per-user sensitive). Empty string when unset.
 		"public_ipv4": settings.PublicIPv4,
+		"public_ipv6": settings.PublicIPv6,
 	})
 }
 

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -20,6 +20,8 @@ export interface ServerCapabilities {
   api_enabled: boolean;
   /** GH #361: the server's public IPv4, for the dashboard. "" when unset. */
   public_ipv4: string;
+  /** GH #361: the server's public IPv6, for the dashboard. "" when unset. */
+  public_ipv6: string;
 }
 
 export function useServerCapabilities() {
@@ -39,6 +41,7 @@ export function useServerCapabilities() {
         quota_enabled: data.quota_enabled !== false,
         api_enabled: data.api_enabled !== false,
         public_ipv4: data.public_ipv4 ?? "",
+        public_ipv6: data.public_ipv6 ?? "",
       };
     },
     staleTime: 60_000,

--- a/panel-ui/src/shells/admin/Dashboard.tsx
+++ b/panel-ui/src/shells/admin/Dashboard.tsx
@@ -13,6 +13,7 @@ import { apiClient } from "../../apiClient";
 import { StatCard } from "../../components/StatCard";
 import { useListQuery } from "../../hooks/useQueries";
 import { useServerStatus } from "../../hooks/useServerStatus";
+import { useServerCapabilities } from "../../hooks/useServerCapabilities";
 
 interface UserRow {
   id: string;
@@ -57,6 +58,7 @@ const formatCount = (n: number | undefined) =>
 export const Dashboard = () => {
   const status = useServerStatus();
   const env = status.data;
+  const { data: caps } = useServerCapabilities();
 
   const counts = useQuery({
     queryKey: ["dashboard", "admin-counts"],
@@ -149,6 +151,25 @@ export const Dashboard = () => {
                     </Typography.Title>
                     {healthTag}
                   </Space>
+                  {caps?.public_ipv4 || caps?.public_ipv6 ? (
+                    <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+                      Server IP:{" "}
+                      {caps?.public_ipv4 ? (
+                        <Typography.Text copyable code style={{ fontSize: 13 }}>
+                          {caps.public_ipv4}
+                        </Typography.Text>
+                      ) : null}
+                      {caps?.public_ipv6 ? (
+                        <Typography.Text
+                          copyable
+                          code
+                          style={{ fontSize: 13, marginLeft: caps?.public_ipv4 ? 8 : 0 }}
+                        >
+                          {caps.public_ipv6}
+                        </Typography.Text>
+                      ) : null}
+                    </Typography.Text>
+                  ) : null}
                   <Typography.Text type="secondary">
                     Top-level summary. For live metrics, services, network, and processes,
                     see Server Status.

--- a/panel-ui/src/shells/user/UserDashboard.tsx
+++ b/panel-ui/src/shells/user/UserDashboard.tsx
@@ -253,12 +253,19 @@ export function UserDashboard() {
 
   return (
     <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-      {caps?.public_ipv4 ? (
+      {caps?.public_ipv4 || caps?.public_ipv6 ? (
         <Typography.Text type="secondary" style={{ fontSize: 13 }}>
           Server IP:{" "}
-          <Typography.Text copyable code style={{ fontSize: 13 }}>
-            {caps.public_ipv4}
-          </Typography.Text>
+          {caps?.public_ipv4 ? (
+            <Typography.Text copyable code style={{ fontSize: 13 }}>
+              {caps.public_ipv4}
+            </Typography.Text>
+          ) : null}
+          {caps?.public_ipv6 ? (
+            <Typography.Text copyable code style={{ fontSize: 13, marginLeft: caps?.public_ipv4 ? 8 : 0 }}>
+              {caps.public_ipv6}
+            </Typography.Text>
+          ) : null}
         </Typography.Text>
       ) : null}
       <Row gutter={[16, 16]}>


### PR DESCRIPTION
## GH #361 — show current server IP on the dashboards

Completes the request ("Show current IP address on admin/user dashboard or
under System Health").

State before: the **user** dashboard already showed the server's public
**IPv4** (via `/me/server-capabilities`), but the **admin** dashboard showed
only the hostname, and **IPv6** was never exposed.

## Changes

- **Backend** (`me.go` server-capabilities): add `public_ipv6` (from
  `server_settings.public_ipv6`) to both the seeded-defaults branch and the
  live response. Additive — existing `public_ipv4` unchanged.
- **Hook** (`useServerCapabilities`): add `public_ipv6` to the interface +
  mapping.
- **User dashboard**: render IPv6 alongside IPv4 (each `copyable`, shown only
  when set).
- **Admin dashboard**: add the same "Server IP" line (v4 + v6) under the
  hostname in the health card.

Both fields are already tracked for the panel cert + bootstrap DNS and are
not per-user sensitive; empty string when unset.

## Test plan

- [x] `go build ./...`, `go vet`, `go test ./internal/api/` green.
- [x] `npx tsc -b`, `npm run lint` (0 errors), `npm test` (118/118) green.
- [ ] Visual check on .86 post-deploy: admin + user dashboards render the
      Server IP (box has `public_ipv4` set).
