### PR TITLE
feat(migrate): IMAP source probe — connect + folder enumeration (GH #390/#374)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
+	github.com/emersion/go-imap/v2 v2.0.0-beta.8
 	github.com/emersion/go-message v0.18.2
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/gin-gonic/gin v1.11.0
@@ -51,6 +52,7 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,12 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/emersion/go-imap/v2 v2.0.0-beta.8 h1:5IXZK1E33DyeP526320J3RS7eFlCYGFgtbrfapqDPug=
+github.com/emersion/go-imap/v2 v2.0.0-beta.8/go.mod h1:dhoFe2Q0PwLrMD7oZw8ODuaD0vLYPe5uj2wcOMnvh48=
 github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
+github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/panel-api/internal/migrate/imap/probe.go
+++ b/panel-api/internal/migrate/imap/probe.go
@@ -1,0 +1,191 @@
+// Package imap is the source-side of the IMAP mail migration (GH #390
+// Google Workspace / #374 M365). Phase A step 1: connect to a remote
+// IMAP account and enumerate its folders + SPECIAL-USE roles, so the UI
+// can preview what will be migrated and map remote folders to Stalwart
+// mailboxes. Later steps FETCH the messages into a staging Maildir and
+// hand them to the shared migration.import_mailboxes agent step.
+//
+// See plans/gh374-imap-mail-migration.md.
+package imap
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// DefaultIMAPSPort is implicit-TLS IMAP (RFC 8314). DefaultIMAPPort is
+// the cleartext/STARTTLS port.
+const (
+	DefaultIMAPSPort = 993
+	DefaultIMAPPort  = 143
+	dialTimeout      = 20 * time.Second
+)
+
+// ProbeConfig is one remote IMAP account's connection parameters.
+type ProbeConfig struct {
+	Host     string
+	Port     int    // 0 → 993 (implicit TLS) or 143 (STARTTLS)
+	Username string // full remote address, e.g. user@gmail.com
+	Password string // app-password (GH #390/#374 phase A auth)
+	STARTTLS bool   // false → implicit TLS on 993; true → STARTTLS on 143
+
+	// AllowPrivate lets the SSRF guard reach RFC1918 / loopback targets.
+	// Production callers leave this false; only tests / an operator
+	// migrating from a LAN server set it.
+	AllowPrivate bool
+}
+
+// Folder is one remote mailbox and its resolved role.
+type Folder struct {
+	// Name is the raw IMAP mailbox name (server hierarchy, e.g.
+	// "[Gmail]/Sent Mail" or "INBOX/Archive").
+	Name string `json:"name"`
+	// Role is the normalised SPECIAL-USE role: inbox / sent / drafts /
+	// junk / trash / archive / all, or "" for an ordinary folder.
+	Role string `json:"role"`
+	// Selectable is false for \Noselect / \NonExistent container nodes
+	// that hold no messages (skip them when migrating).
+	Selectable bool `json:"selectable"`
+}
+
+// ProbeResult is the enumerated remote account.
+type ProbeResult struct {
+	Folders []Folder `json:"folders"`
+}
+
+// ErrAuth is returned when the remote server rejects the credentials —
+// distinguished from connect errors so the UI can tell the operator to
+// check the app-password vs the host/port. The underlying server text is
+// wrapped for logs but callers surfacing to clients should show a fixed
+// message (don't leak remote banners).
+var ErrAuth = errors.New("imap: authentication failed")
+
+// Probe dials the remote account over the SSRF-guarded transport, logs
+// in, lists folders, and returns the enumeration. It is the network
+// entrypoint; the login + list + mapping logic lives in probeWithClient
+// so it can be unit-tested against an in-memory server.
+func Probe(ctx context.Context, cfg ProbeConfig) (*ProbeResult, error) {
+	host := strings.TrimSpace(cfg.Host)
+	if host == "" {
+		return nil, errors.New("imap: host required")
+	}
+	if cfg.Username == "" || cfg.Password == "" {
+		return nil, errors.New("imap: username and password required")
+	}
+
+	port := cfg.Port
+	if port == 0 {
+		if cfg.STARTTLS {
+			port = DefaultIMAPPort
+		} else {
+			port = DefaultIMAPSPort
+		}
+	}
+
+	// SSRF-guarded TCP dial (resolve + range check + rebind guard) —
+	// every migrate/* outbound goes through this.
+	conn, err := migrate.DialTCP(ctx, host, port, cfg.AllowPrivate, dialTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("imap: connect %s:%d: %w", host, port, err)
+	}
+
+	var client *imapclient.Client
+	if cfg.STARTTLS {
+		client, err = imapclient.NewStartTLS(conn, &imapclient.Options{
+			TLSConfig: &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12},
+		})
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("imap: starttls %s: %w", host, err)
+		}
+	} else {
+		tlsConn := tls.Client(conn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+		if herr := tlsConn.HandshakeContext(ctx); herr != nil {
+			conn.Close()
+			return nil, fmt.Errorf("imap: tls handshake %s: %w", host, herr)
+		}
+		client = imapclient.New(tlsConn, nil)
+	}
+	defer client.Close()
+
+	return probeWithClient(client, cfg.Username, cfg.Password)
+}
+
+// probeWithClient runs LOGIN + LIST against an already-connected client
+// and maps the result. Split out so tests drive it with an in-memory
+// server (no TLS / no real network).
+func probeWithClient(c *imapclient.Client, username, password string) (*ProbeResult, error) {
+	if err := c.Login(username, password).Wait(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAuth, err)
+	}
+	// Closure, not `defer c.Logout().Wait()` — the latter evaluates the
+	// c.Logout() receiver immediately, sending LOGOUT before the LIST below.
+	defer func() { _ = c.Logout().Wait() }()
+
+	// RETURN (SPECIAL-USE) so the server tags Sent/Drafts/Junk/Trash/
+	// Archive/All folders (RFC 6154) — both Gmail and M365 advertise
+	// SPECIAL-USE, and it's how roleOf classifies folders. A non-nil
+	// options value is also required by RFC 5258 LIST-EXTENDED.
+	entries, err := c.List("", "*", &imap.ListOptions{ReturnSpecialUse: true}).Collect()
+	if err != nil {
+		return nil, fmt.Errorf("imap: list folders: %w", err)
+	}
+
+	folders := make([]Folder, 0, len(entries))
+	for _, e := range entries {
+		if e == nil {
+			continue
+		}
+		folders = append(folders, Folder{
+			Name:       e.Mailbox,
+			Role:       roleOf(e.Mailbox, e.Attrs),
+			Selectable: selectable(e.Attrs),
+		})
+	}
+	return &ProbeResult{Folders: folders}, nil
+}
+
+// roleOf normalises a mailbox to a SPECIAL-USE role. INBOX has no
+// SPECIAL-USE attribute (RFC 6154) so it is matched by name.
+func roleOf(name string, attrs []imap.MailboxAttr) string {
+	if strings.EqualFold(name, "INBOX") {
+		return "inbox"
+	}
+	for _, a := range attrs {
+		switch a {
+		case imap.MailboxAttrSent:
+			return "sent"
+		case imap.MailboxAttrDrafts:
+			return "drafts"
+		case imap.MailboxAttrJunk:
+			return "junk"
+		case imap.MailboxAttrTrash:
+			return "trash"
+		case imap.MailboxAttrArchive:
+			return "archive"
+		case imap.MailboxAttrAll:
+			return "all"
+		}
+	}
+	return ""
+}
+
+// selectable reports whether the folder holds messages — \Noselect and
+// \NonExistent nodes are hierarchy containers only.
+func selectable(attrs []imap.MailboxAttr) bool {
+	for _, a := range attrs {
+		if a == imap.MailboxAttrNoSelect || a == imap.MailboxAttrNonExistent {
+			return false
+		}
+	}
+	return true
+}

--- a/panel-api/internal/migrate/imap/probe_test.go
+++ b/panel-api/internal/migrate/imap/probe_test.go
@@ -1,0 +1,160 @@
+package imap
+
+import (
+	"errors"
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+func TestRoleOf(t *testing.T) {
+	cases := []struct {
+		name  string
+		mbox  string
+		attrs []imap.MailboxAttr
+		want  string
+	}{
+		{"inbox by name", "INBOX", nil, "inbox"},
+		{"inbox case-insensitive", "inbox", nil, "inbox"},
+		{"sent special-use", "[Gmail]/Sent Mail", []imap.MailboxAttr{imap.MailboxAttrSent}, "sent"},
+		{"drafts", "Drafts", []imap.MailboxAttr{imap.MailboxAttrDrafts}, "drafts"},
+		{"junk", "Spam", []imap.MailboxAttr{imap.MailboxAttrJunk}, "junk"},
+		{"trash", "Bin", []imap.MailboxAttr{imap.MailboxAttrTrash}, "trash"},
+		{"archive", "All Mail", []imap.MailboxAttr{imap.MailboxAttrArchive}, "archive"},
+		{"all", "[Gmail]/All Mail", []imap.MailboxAttr{imap.MailboxAttrAll}, "all"},
+		{"ordinary folder", "Projects/2026", nil, ""},
+		{"unrelated attr", "Projects", []imap.MailboxAttr{imap.MailboxAttrHasChildren}, ""},
+		// INBOX wins over a stray special-use attr on the same node.
+		{"inbox precedence", "INBOX", []imap.MailboxAttr{imap.MailboxAttrSent}, "inbox"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := roleOf(tc.mbox, tc.attrs); got != tc.want {
+				t.Errorf("roleOf(%q, %v) = %q, want %q", tc.mbox, tc.attrs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectable(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs []imap.MailboxAttr
+		want  bool
+	}{
+		{"plain folder", nil, true},
+		{"has children only", []imap.MailboxAttr{imap.MailboxAttrHasChildren}, true},
+		{"noselect container", []imap.MailboxAttr{imap.MailboxAttrNoSelect}, false},
+		{"nonexistent", []imap.MailboxAttr{imap.MailboxAttrNonExistent}, false},
+		{"noselect among others", []imap.MailboxAttr{imap.MailboxAttrHasChildren, imap.MailboxAttrNoSelect}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectable(tc.attrs); got != tc.want {
+				t.Errorf("selectable(%v) = %v, want %v", tc.attrs, got, tc.want)
+			}
+		})
+	}
+}
+
+// startMemServer spins up an in-memory IMAP server on a loopback
+// listener with one user + the given mailboxes, and returns its address
+// plus a cleanup func.
+func startMemServer(t *testing.T, username, password string, mailboxes []string) string {
+	t.Helper()
+
+	mem := imapmemserver.New()
+	user := imapmemserver.NewUser(username, password)
+	for _, mb := range mailboxes {
+		if err := user.Create(mb, nil); err != nil {
+			t.Fatalf("create mailbox %q: %v", mb, err)
+		}
+	}
+	mem.AddUser(user)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		// Advertise IMAP4rev2 so LIST-EXTENDED (RETURN SPECIAL-USE) is
+		// handled — the probe issues an extended LIST, which an
+		// IMAP4rev1-only server can't parse. Gmail/M365 advertise
+		// SPECIAL-USE + LIST-EXTENDED in production.
+		Caps: imap.CapSet{imap.CapIMAP4rev2: {}},
+		// The test transport is plaintext loopback; allow LOGIN without TLS.
+		InsecureAuth: true,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		_ = ln.Close()
+	})
+	return ln.Addr().String()
+}
+
+func TestProbeWithClient(t *testing.T) {
+	const user, pass = "user@example.com", "app-password"
+	addr := startMemServer(t, user, pass, []string{"INBOX", "Sent", "Drafts", "Projects"})
+
+	c, err := imapclient.DialInsecure(addr, nil)
+	if err != nil {
+		t.Fatalf("dial memserver: %v", err)
+	}
+	defer c.Close()
+
+	res, err := probeWithClient(c, user, pass)
+	if err != nil {
+		t.Fatalf("probeWithClient: %v", err)
+	}
+
+	got := make([]string, 0, len(res.Folders))
+	var inboxRole string
+	for _, f := range res.Folders {
+		got = append(got, f.Name)
+		if f.Name == "INBOX" {
+			inboxRole = f.Role
+		}
+		if !f.Selectable {
+			t.Errorf("folder %q unexpectedly not selectable", f.Name)
+		}
+	}
+	sort.Strings(got)
+	want := []string{"Drafts", "INBOX", "Projects", "Sent"}
+	if len(got) != len(want) {
+		t.Fatalf("folders = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("folders = %v, want %v", got, want)
+		}
+	}
+	if inboxRole != "inbox" {
+		t.Errorf("INBOX role = %q, want inbox", inboxRole)
+	}
+}
+
+func TestProbeWithClientBadPassword(t *testing.T) {
+	const user, pass = "user@example.com", "app-password"
+	addr := startMemServer(t, user, pass, []string{"INBOX"})
+
+	c, err := imapclient.DialInsecure(addr, nil)
+	if err != nil {
+		t.Fatalf("dial memserver: %v", err)
+	}
+	defer c.Close()
+
+	_, err = probeWithClient(c, user, "wrong-password")
+	if !errors.Is(err, ErrAuth) {
+		t.Fatalf("probeWithClient with bad password: got %v, want ErrAuth", err)
+	}
+}

--- a/panel-api/internal/models/migration_job.go
+++ b/panel-api/internal/models/migration_job.go
@@ -19,6 +19,13 @@ const (
 	// jabali-migrator plugin's token-authed REST API (no source SSH). Jabali
 	// fetches manifest+DB+files, stages, then runs the shared import-wp.
 	MigrationSourceWordPressPlugin = "wordpress_plugin"
+	// MigrationSourceIMAP (GH #390 Google Workspace / #374 M365) — per-mailbox
+	// IMAP account migration. Unlike the panel-account sources above this is
+	// per-mailbox: each migrated account carries its own remote IMAP login.
+	// The importer FETCHes remote messages into a staging Maildir and hands it
+	// to the shared migration.import_mailboxes agent step. See
+	// plans/gh374-imap-mail-migration.md.
+	MigrationSourceIMAP = "imap"
 )
 
 // MigrationState is the per-job lifecycle. Stage transitions are

--- a/plans/gh374-imap-mail-migration.md
+++ b/plans/gh374-imap-mail-migration.md
@@ -1,0 +1,136 @@
+# Blueprint — Google Workspace / M365 migration program (GH #390 / #374)
+
+**Status:** scoped, not started. **Full scope confirmed** by operator: email +
+aliases + contacts + calendars (incl. shared) + shared-mailbox permissions.
+Auth: **app-password first**, OAuth2/XOAUTH2 a later phase. This is a multi-
+protocol **program** delivered in sequential, independently-shippable phases —
+IMAP email is the foundation everything else layers on. Both GWS and M365 expose
+standard IMAP + CardDAV/CalDAV (M365 also EWS/Graph), so one importer family
+serves both providers.
+
+## Program phases (each = its own set of PRs)
+
+| Phase | Scope | Protocol | Depends on |
+|-------|-------|----------|-----------|
+| **A. Email** (this blueprint's detail below) | messages, folders, flags | IMAP | — |
+| **B. Aliases** | send-as / proxy addresses → jabali forwarders/aliases | Gmail settings API / M365 proxyAddresses (or manual CSV) | A (account exists) |
+| **C. Contacts** | personal contacts → Stalwart CardDAV | CardDAV (Google People / M365) | A |
+| **D. Calendars** | events + shared calendars → Stalwart CalDAV | CalDAV / EWS | A |
+| **E. Shared mailboxes + perms** | shared mailbox + delegate ACLs → jabali `mailbox_shares` | provider directory + IMAP ACL | A, and jabali mailbox-share model |
+
+Phases B–E each get their own blueprint when reached; the sections below detail
+**Phase A (IMAP email)**, which is what gets built first. The source model +
+job framework below are designed so B–E slot in as additional stages/fetchers on
+the same job, not a rewrite.
+
+## Design in one line
+
+Add an **IMAP source** that FETCHes a remote account's messages into a staging
+Maildir, then hand that Maildir to the **existing** agent verb
+`migration.import_mailboxes` (JMAP `Blob/upload` + `Email/import` into
+Stalwart). Reuse maximised: no new Stalwart-ingest path, no new dedup/resume
+logic — those already exist and are battle-tested by the cPanel restore.
+
+## Why this shape
+
+- `panel-agent .../migration_import_mailboxes.go` already imports a **Maildir on
+  disk** → Stalwart via JMAP, dedups explicitly (Stalwart `Email/import` does
+  NOT dedup on Message-ID — [[feedback_stalwart_jmap_import_gotchas]]), and is
+  idempotent on resume.
+- The migrate framework is source-plugin based: `registry.go` maps a source
+  `kind` → Discoverer; `runner.go` walks ordered stages with idempotent resume;
+  `ssrf.go` already guards outbound connect (reuse for the IMAP dial).
+- `github.com/emersion/go-message` is already a dep (MIME). Its sibling
+  `github.com/emersion/go-imap/v2` is the natural IMAP client (verify API via
+  Context7 in phase 1 — [[feedback_verify_capability_via_context7]]).
+- The daemon can now write `/var/lib/jabali-migrations/<job>/` staging (the
+  AppArmor fix just shipped, PR #419), so the fetch stage can stage there.
+
+## What's fundamentally different from cPanel/DA/Hestia
+
+Those are **per-panel-account** SSH/tarball pulls. IMAP is **per-mailbox**: each
+migrated account carries its own remote IMAP login (host, port, TLS, username,
+password). So the job model is a **list of mailbox migrations**, not one account
+tarball. A single job may carry many accounts (bulk CSV) or one.
+
+## Source model
+
+New source kind `models.MigrationSourceIMAP = "imap"`. Per-mailbox spec:
+
+| field | notes |
+|-------|-------|
+| remote_host, remote_port | e.g. imap.gmail.com:993 / outlook.office365.com:993 |
+| tls | implicit TLS (993) default; STARTTLS optional |
+| remote_username | full remote address |
+| remote_secret_ref | password (or OAuth token — see decision) stored in the encrypted migration-secrets store, agent-written |
+| target_mailbox | jabali mailbox the mail lands in (must exist, or create — decision) |
+| folder_map | remote folder → Stalwart mailbox; auto via SPECIAL-USE (INBOX/Sent/Drafts/Trash/Junk/Archive), custom folders created as-is |
+
+## Stages (plug into the existing runner)
+
+1. **connect / validate** — dial remote IMAP through `migrate/ssrf.go` guard,
+   LOGIN, LIST folders, capability probe. Fail fast on auth error with a clear,
+   non-leaking message. (Gmail/M365 require an **app password** or OAuth — see
+   decision; a normal password with 2FA on will fail.)
+2. **fetch → staging Maildir** — per folder, FETCH `RFC822`/`BODY[]` + flags +
+   INTERNALDATE, write each message as a Maildir file under
+   `/var/lib/jabali-migrations/<job>/<account>/Maildir/<folder>/{cur,new}` with
+   the flag suffix. Resumable: track last-seen UID per folder (UIDVALIDITY
+   guarded) so a re-run continues, not restarts.
+3. **import → Stalwart** — call the **existing** `migration.import_mailboxes`
+   agent verb pointed at the staging Maildir + target account. Dedup + idempotent
+   resume come for free.
+4. **verify / cleanup** — counts (fetched vs imported), record per-folder
+   warnings, then reap the staging Maildir (the #425 reaper already ages
+   `/var/lib/jabali-migrations`).
+
+## Phased PRs
+
+1. **Model + registry + IMAP connect/validate stage** (no fetch yet):
+   `MigrationSourceIMAP`, per-mailbox job payload, `go-imap/v2` dial through the
+   SSRF guard, LOGIN + folder LIST + SPECIAL-USE detection, returned as a
+   discovery/preview. Unit tests with a fake IMAP server (go-imap ships a test
+   server) — no network. **Box-verify** connect against a throwaway account.
+2. **Fetch → staging Maildir stage**: streaming FETCH, Maildir writer (reuse
+   Maildir conventions the cpanel importer already reads), UID-resume state.
+   Tests: fetch from the fake server, assert Maildir tree + flags.
+3. **Wire import stage** to `migration.import_mailboxes` + **verify/cleanup**.
+   Box end-to-end: throwaway IMAP account → jabali mailbox on .86, assert message
+   count + folders in Bulwark webmail.
+4. **UI wizard**: source=IMAP form (single + bulk CSV), folder-map preview,
+   progress via `migration_stages`; **CLI**: `jabali migrate imap --host … --user
+   … --to <mailbox> [--password-stdin]` / `--csv accounts.csv`.
+
+## Decisions
+
+- **Auth**: DECIDED — app-password first (operator generates one per account);
+  OAuth2/XOAUTH2 is a later phase.
+- **Scope**: DECIDED — full suite (email + aliases + contacts + calendars +
+  shared perms), delivered as phases A–E above; Phase A (email) first.
+- **Target mailbox** (still open, gates Phase A step 3): require the jabali
+  mailbox to pre-exist, or create-on-migrate (needs a password for the new local
+  mailbox — same reveal-once flow as mailbox-create)? Default proposal: **require
+  pre-exist** for phase-A step 1–3; add create-on-migrate in the phase-A UI (step
+  4) where the reveal-once modal already lives.
+- **Bulk** (open, gates Phase A step 4 UI): single-account first, CSV bulk in a
+  follow-up.
+
+## Scars to respect
+
+- [[feedback_stalwart_jmap_import_gotchas]] — Email/import doesn't dedup; the
+  agent verb already handles it. Don't re-import without the UID-resume guard.
+- [[feedback_verify_capability_via_context7]] — pin the go-imap/v2 + JMAP API via
+  Context7 before writing calls.
+- [[feedback_migration_data_seed_ordering]] — schema-only migration for the new
+  source kind / per-mailbox rows; data moves in app code.
+- [[feedback_security_highest_priority]] — remote IMAP creds are secrets: store
+  in the encrypted migration-secrets store (agent-written, root:jabali 0750),
+  never in the job row or logs; SSRF-guard the dial; audit each migration.
+- Reuse the existing Maildir reader contract so the importer sees a tree
+  identical to what cpanel produces.
+
+## Not in this slice (separate features)
+
+Calendars + shared calendars (CalDAV/EWS → Stalwart CalDAV), contacts (CardDAV),
+aliases, shared-mailbox membership + permissions. Each is its own blueprint;
+#390/#374 as written ask for all of them.


### PR DESCRIPTION
## Foundation for Google Workspace (#390) / M365 (#374) mail migration

First PR of a phased program — full blueprint in
`plans/gh374-imap-mail-migration.md`. Scope confirmed with operator: email +
aliases + contacts + calendars + shared-mailbox perms, delivered as phases
A–E; **auth = app-password first**. This is **Phase A, step 1**.

### Design

An IMAP source that FETCHes a remote account into a staging Maildir, then
hands it to the **existing** `migration.import_mailboxes` agent step (JMAP
`Blob/upload` + `Email/import` into Stalwart — dedup + idempotent resume
already solved by the cPanel restore). This PR is the connect + folder
enumeration piece that everything else builds on.

### Changes

- `models`: add `MigrationSourceIMAP = "imap"` — a **per-mailbox** source
  (each account carries its own remote IMAP login), unlike the per-panel
  SSH/tarball sources.
- `migrate/imap`: `Probe()` dials over the SSRF-guarded transport
  (`migrate.DialTCP` → TLS/STARTTLS → `imapclient`), logs in with an
  app-password, `LIST`s with `RETURN (SPECIAL-USE)`, and classifies each
  folder (inbox/sent/drafts/junk/trash/archive). `probeWithClient()` holds
  the login+list+map logic (unit-tested against an in-memory IMAP server);
  `Probe()` is the thin transport wrapper (box-verified later).
- Add `go-imap/v2` (+ `go-sasl` indirect).

Not yet wired into the job runner/registry — step 2 (fetch → staging
Maildir), step 3 (import), step 4 (UI/CLI) follow.

### Test plan

- [x] `go build ./...`, `go vet`, `go test -race ./internal/migrate/imap/
      ./internal/models/` green.
- [x] Unit tests: folder enumeration + INBOX role + `roleOf`/`selectable`
      table cases + bad-password → `ErrAuth`, all against an in-memory
      `imapmemserver`.
- [ ] Box-verify `Probe()` against a throwaway Gmail/M365 account with an
      app-password (once wired to an endpoint in step 2).

### Notes

- Every remote dial goes through the `migrate.DialTCP` SSRF guard (remote
  host is operator-supplied).
- Found + fixed a Go defer gotcha during dev: `defer c.Logout().Wait()`
  evaluates the `c.Logout()` receiver immediately (sends LOGOUT before the
  LIST); wrapped in a closure. Caught via the server wire trace.
