### PR TITLE
feat(migrate): IMAP fetch → staging Maildir (GH #390/#374 phase A step 2)

### DIFF
--- a/panel-api/internal/migrate/imap/fetch.go
+++ b/panel-api/internal/migrate/imap/fetch.go
@@ -86,6 +86,13 @@ func fetchWithClient(ctx context.Context, c *imapclient.Client, username, passwo
 		if sub != "" {
 			targetDir = filepath.Join(stagingDir, "."+sub)
 		}
+		// Authoritative containment guard: after the join, the target must
+		// still resolve inside stagingDir. Defends against any path-escape
+		// that slipped past maildirSub's sanitisation.
+		if rel, rerr := filepath.Rel(stagingDir, targetDir); rerr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: unsafe folder name", f.Name))
+			continue
+		}
 		n, b, err := selectAndWrite(ctx, c, f.Name, targetDir)
 		if err != nil {
 			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: %v", f.Name, err))
@@ -127,8 +134,17 @@ func maildirSub(f Folder) (sub string, skip bool) {
 	if f.Delim != 0 {
 		raw = strings.ReplaceAll(raw, string(f.Delim), ".")
 	}
+	// f.Name is the remote server's LIST output — untrusted. Neutralise
+	// every OS path separator + NUL so the name can't escape the staging
+	// dir when it becomes a Maildir++ ".<sub>" segment (a malicious or
+	// buggy source server on a non-"/" delimiter could otherwise return
+	// e.g. "../../etc/x"). Then reject residual traversal / empties.
+	// fetchWithClient also verifies containment after the join.
+	raw = strings.ReplaceAll(raw, "/", ".")
+	raw = strings.ReplaceAll(raw, "\\", ".")
+	raw = strings.ReplaceAll(raw, "\x00", "")
 	raw = strings.Trim(raw, ".")
-	if raw == "" {
+	if raw == "" || strings.Contains(raw, "..") {
 		return "", true
 	}
 	return raw, false

--- a/panel-api/internal/migrate/imap/fetch.go
+++ b/panel-api/internal/migrate/imap/fetch.go
@@ -1,0 +1,249 @@
+package imap
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+const (
+	// maxMessageBytes caps a single fetched message. Mirrors the agent's
+	// migrationMailboxMessageCap so we don't stage a message the importer
+	// will reject as oversized.
+	maxMessageBytes = 512 * 1024 * 1024 // 512 MiB
+	fetchTimeout    = 6 * time.Hour
+)
+
+// FolderFetch is the per-folder outcome of a fetch.
+type FolderFetch struct {
+	Remote   string `json:"remote"`  // remote IMAP folder name
+	Maildir  string `json:"maildir"` // staging subdir written ("" = INBOX root)
+	Messages int64  `json:"messages"`
+	Bytes    int64  `json:"bytes"`
+}
+
+// FetchResult aggregates a fetch into a staging Maildir.
+type FetchResult struct {
+	Folders       []FolderFetch `json:"folders"`
+	TotalMessages int64         `json:"total_messages"`
+	TotalBytes    int64         `json:"total_bytes"`
+	// Skipped records folders intentionally not fetched (e.g. Gmail's
+	// "All Mail", which is a superset of every other folder and would
+	// duplicate the whole account) or that errored mid-fetch.
+	Skipped []string `json:"skipped,omitempty"`
+}
+
+// Fetch connects (SSRF-guarded, TLS), logs in, and streams every
+// selectable folder into a staging Maildir under stagingDir, laid out
+// for the shared migration.import_mailboxes agent step: INBOX at the
+// Maildir root ({cur,new,tmp}); other folders as Maildir++ ".Sub" dirs;
+// \Seen messages in cur/, unseen in new/. If folders is nil it lists
+// them itself. It is the network entrypoint; fetchWithClient holds the
+// testable core.
+func Fetch(ctx context.Context, cfg ProbeConfig, folders []Folder, stagingDir string) (*FetchResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	client, err := connect(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+	return fetchWithClient(ctx, client, cfg.Username, cfg.Password, folders, stagingDir)
+}
+
+func fetchWithClient(ctx context.Context, c *imapclient.Client, username, password string, folders []Folder, stagingDir string) (*FetchResult, error) {
+	if err := c.Login(username, password).Wait(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAuth, err)
+	}
+	defer func() { _ = c.Logout().Wait() }()
+
+	if folders == nil {
+		var err error
+		if folders, err = listFolders(c); err != nil {
+			return nil, err
+		}
+	}
+
+	res := &FetchResult{}
+	for _, f := range folders {
+		if !f.Selectable {
+			continue
+		}
+		sub, skip := maildirSub(f)
+		if skip {
+			res.Skipped = append(res.Skipped, f.Name)
+			continue
+		}
+		targetDir := stagingDir
+		if sub != "" {
+			targetDir = filepath.Join(stagingDir, "."+sub)
+		}
+		n, b, err := selectAndWrite(ctx, c, f.Name, targetDir)
+		if err != nil {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: %v", f.Name, err))
+			continue
+		}
+		res.Folders = append(res.Folders, FolderFetch{Remote: f.Name, Maildir: sub, Messages: n, Bytes: b})
+		res.TotalMessages += n
+		res.TotalBytes += b
+	}
+	return res, nil
+}
+
+// maildirSub maps a remote folder to its Maildir++ subfolder name. The
+// INBOX lands at the Maildir root (""); SPECIAL-USE roles map to the
+// canonical names the importer + Stalwart expect; ordinary folders keep
+// their name with the server's hierarchy delimiter translated to the
+// Maildir++ dot. Returns skip=true for folders we deliberately don't
+// migrate (Gmail "All Mail" superset, or a name that normalises empty).
+func maildirSub(f Folder) (sub string, skip bool) {
+	switch f.Role {
+	case "inbox":
+		return "", false
+	case "sent":
+		return "Sent", false
+	case "drafts":
+		return "Drafts", false
+	case "junk":
+		return "Junk", false
+	case "trash":
+		return "Trash", false
+	case "archive":
+		return "Archive", false
+	case "all":
+		// Gmail's All Mail contains a copy of every message in every
+		// other folder — migrating it duplicates the whole account.
+		return "", true
+	}
+	raw := f.Name
+	if f.Delim != 0 {
+		raw = strings.ReplaceAll(raw, string(f.Delim), ".")
+	}
+	raw = strings.Trim(raw, ".")
+	if raw == "" {
+		return "", true
+	}
+	return raw, false
+}
+
+// selectAndWrite SELECTs one remote folder (read-only) and streams every
+// message into the Maildir at targetDir.
+func selectAndWrite(ctx context.Context, c *imapclient.Client, remoteName, targetDir string) (int64, int64, error) {
+	for _, d := range []string{"tmp", "new", "cur"} {
+		if err := os.MkdirAll(filepath.Join(targetDir, d), 0o700); err != nil {
+			return 0, 0, fmt.Errorf("mkdir maildir: %w", err)
+		}
+	}
+
+	sel, err := c.Select(remoteName, &imap.SelectOptions{ReadOnly: true}).Wait()
+	if err != nil {
+		return 0, 0, fmt.Errorf("select: %w", err)
+	}
+	if sel.NumMessages == 0 {
+		return 0, 0, nil
+	}
+
+	seqSet := imap.SeqSet{}
+	seqSet.AddRange(1, sel.NumMessages)
+	fetchCmd := c.Fetch(seqSet, &imap.FetchOptions{
+		UID:          true,
+		Flags:        true,
+		InternalDate: true,
+		// Peek so fetching the body does NOT set \Seen on the source —
+		// a migration must never mutate the remote account's flags.
+		BodySection: []*imap.FetchItemBodySection{{Peek: true}},
+	})
+	defer fetchCmd.Close()
+
+	var count, bytes int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return count, bytes, err
+		}
+		msg := fetchCmd.Next()
+		if msg == nil {
+			break
+		}
+
+		var uid imap.UID
+		var seen bool
+		var idate time.Time
+		var body []byte
+		var oversized bool
+
+		for {
+			item := msg.Next()
+			if item == nil {
+				break
+			}
+			switch it := item.(type) {
+			case imapclient.FetchItemDataUID:
+				uid = it.UID
+			case imapclient.FetchItemDataFlags:
+				for _, fl := range it.Flags {
+					if fl == imap.FlagSeen {
+						seen = true
+					}
+				}
+			case imapclient.FetchItemDataInternalDate:
+				idate = it.Time
+			case imapclient.FetchItemDataBodySection:
+				// The literal MUST be consumed before advancing the
+				// stream. LimitReader + 1 lets us detect oversize.
+				if it.Literal != nil {
+					b, rerr := io.ReadAll(io.LimitReader(it.Literal, maxMessageBytes+1))
+					if rerr != nil {
+						return count, bytes, fmt.Errorf("read message body: %w", rerr)
+					}
+					if int64(len(b)) > maxMessageBytes {
+						oversized = true
+					} else {
+						body = b
+					}
+				}
+			}
+		}
+
+		if oversized || len(body) == 0 {
+			continue
+		}
+		if werr := writeMaildirMessage(targetDir, seen, idate, uid, body); werr != nil {
+			return count, bytes, werr
+		}
+		count++
+		bytes += int64(len(body))
+	}
+	if err := fetchCmd.Close(); err != nil {
+		return count, bytes, fmt.Errorf("fetch: %w", err)
+	}
+	return count, bytes, nil
+}
+
+// writeMaildirMessage writes one message into <targetDir>/cur (\Seen) or
+// <targetDir>/new (unseen). The UID makes the filename unique within the
+// folder; the :2,S info suffix marks Seen (Maildir convention), though
+// the importer keys Seen on the cur/ vs new/ slot.
+func writeMaildirMessage(targetDir string, seen bool, idate time.Time, uid imap.UID, body []byte) error {
+	slot := "new"
+	name := fmt.Sprintf("%d.U%d.jabali", idate.Unix(), uint32(uid))
+	if seen {
+		slot = "cur"
+		name += ":2,S"
+	}
+	path := filepath.Join(targetDir, slot, name)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if !idate.IsZero() {
+		_ = os.Chtimes(path, idate, idate)
+	}
+	return nil
+}

--- a/panel-api/internal/migrate/imap/fetch_test.go
+++ b/panel-api/internal/migrate/imap/fetch_test.go
@@ -1,0 +1,148 @@
+package imap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// appendMsg APPENDs one RFC822 message to a mailbox on the test server.
+func appendMsg(t *testing.T, addr, user, pass, mailbox, body string, seen bool) {
+	t.Helper()
+	c, err := imapclient.DialInsecure(addr, nil)
+	if err != nil {
+		t.Fatalf("dial for append: %v", err)
+	}
+	defer c.Close()
+	if err := c.Login(user, pass).Wait(); err != nil {
+		t.Fatalf("login for append: %v", err)
+	}
+	defer func() { _ = c.Logout().Wait() }()
+
+	var opts *imap.AppendOptions
+	if seen {
+		opts = &imap.AppendOptions{Flags: []imap.Flag{imap.FlagSeen}}
+	}
+	cmd := c.Append(mailbox, int64(len(body)), opts)
+	if _, err := cmd.Write([]byte(body)); err != nil {
+		t.Fatalf("append write: %v", err)
+	}
+	if err := cmd.Close(); err != nil {
+		t.Fatalf("append close: %v", err)
+	}
+	if _, err := cmd.Wait(); err != nil {
+		t.Fatalf("append %q: %v", mailbox, err)
+	}
+}
+
+func msg(id, subject, bodyText string) string {
+	return strings.Join([]string{
+		"Message-ID: <" + id + "@example.com>",
+		"Subject: " + subject,
+		"From: sender@example.com",
+		"To: user@example.com",
+		"",
+		bodyText,
+		"",
+	}, "\r\n")
+}
+
+func countFiles(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
+	n := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			n++
+		}
+	}
+	return n
+}
+
+func TestFetchWithClient(t *testing.T) {
+	const user, pass = "user@example.com", "app-password"
+	addr := startMemServer(t, user, pass, []string{"INBOX", "Sent", "Projects"})
+
+	// INBOX: one read (Seen → cur/), one unread (→ new/). Sent: one read.
+	appendMsg(t, addr, user, pass, "INBOX", msg("1", "read", "already read"), true)
+	appendMsg(t, addr, user, pass, "INBOX", msg("2", "unread", "still unread"), false)
+	appendMsg(t, addr, user, pass, "Sent", msg("3", "sent", "i sent this"), true)
+
+	staging := t.TempDir()
+	c, err := imapclient.DialInsecure(addr, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	res, err := fetchWithClient(context.Background(), c, user, pass, nil, staging)
+	if err != nil {
+		t.Fatalf("fetchWithClient: %v", err)
+	}
+
+	if res.TotalMessages != 3 {
+		t.Errorf("TotalMessages = %d, want 3", res.TotalMessages)
+	}
+
+	// INBOX → Maildir root: 1 in cur/, 1 in new/.
+	if got := countFiles(t, filepath.Join(staging, "cur")); got != 1 {
+		t.Errorf("INBOX cur/ has %d files, want 1 (the \\Seen message)", got)
+	}
+	if got := countFiles(t, filepath.Join(staging, "new")); got != 1 {
+		t.Errorf("INBOX new/ has %d files, want 1 (the unseen message)", got)
+	}
+
+	// Sent → Maildir++ .Sent subfolder: 1 in cur/ (it was \Seen).
+	if got := countFiles(t, filepath.Join(staging, ".Sent", "cur")); got != 1 {
+		t.Errorf(".Sent/cur has %d files, want 1", got)
+	}
+
+	// The \Seen message's filename carries the :2,S info suffix.
+	curEntries, _ := os.ReadDir(filepath.Join(staging, "cur"))
+	if len(curEntries) == 1 && !strings.HasSuffix(curEntries[0].Name(), ":2,S") {
+		t.Errorf("cur/ file %q missing :2,S Seen suffix", curEntries[0].Name())
+	}
+
+	// Projects is empty — it should have been selected (dirs created) but
+	// contributed no messages.
+	if got := countFiles(t, filepath.Join(staging, ".Projects", "new")); got != 0 {
+		t.Errorf(".Projects/new has %d files, want 0", got)
+	}
+}
+
+func TestMaildirSub(t *testing.T) {
+	cases := []struct {
+		name     string
+		folder   Folder
+		wantSub  string
+		wantSkip bool
+	}{
+		{"inbox root", Folder{Name: "INBOX", Role: "inbox"}, "", false},
+		{"sent role", Folder{Name: "[Gmail]/Sent Mail", Role: "sent"}, "Sent", false},
+		{"drafts role", Folder{Name: "Drafts", Role: "drafts"}, "Drafts", false},
+		{"all-mail skipped", Folder{Name: "[Gmail]/All Mail", Role: "all"}, "", true},
+		{"ordinary flat", Folder{Name: "Receipts", Role: ""}, "Receipts", false},
+		{"ordinary nested slash", Folder{Name: "Work/2026", Role: "", Delim: '/'}, "Work.2026", false},
+		{"ordinary nested dot", Folder{Name: "Work.2026", Role: "", Delim: '.'}, "Work.2026", false},
+		{"empty normalises to skip", Folder{Name: "/", Role: "", Delim: '/'}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sub, skip := maildirSub(tc.folder)
+			if sub != tc.wantSub || skip != tc.wantSkip {
+				t.Errorf("maildirSub(%+v) = (%q, %v), want (%q, %v)", tc.folder, sub, skip, tc.wantSub, tc.wantSkip)
+			}
+		})
+	}
+}

--- a/panel-api/internal/migrate/imap/fetch_test.go
+++ b/panel-api/internal/migrate/imap/fetch_test.go
@@ -136,6 +136,13 @@ func TestMaildirSub(t *testing.T) {
 		{"ordinary nested slash", Folder{Name: "Work/2026", Role: "", Delim: '/'}, "Work.2026", false},
 		{"ordinary nested dot", Folder{Name: "Work.2026", Role: "", Delim: '.'}, "Work.2026", false},
 		{"empty normalises to skip", Folder{Name: "/", Role: "", Delim: '/'}, "", true},
+		// Untrusted remote names must not escape the staging dir. Separators
+		// are neutralised to dots; residual ".." → skip.
+		{"traversal slash delim", Folder{Name: "../../etc/passwd", Role: "", Delim: '/'}, "etc.passwd", false},
+		{"traversal dot delim", Folder{Name: "../../secret", Role: "", Delim: '.'}, "secret", false},
+		{"traversal backslash", Folder{Name: "..\\..\\x", Role: "", Delim: 0}, "x", false},
+		{"nul stripped", Folder{Name: "a\x00b", Role: "", Delim: 0}, "ab", false},
+		{"double-dot only skips", Folder{Name: "..", Role: "", Delim: 0}, "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/panel-api/internal/migrate/imap/probe.go
+++ b/panel-api/internal/migrate/imap/probe.go
@@ -55,6 +55,11 @@ type Folder struct {
 	// Selectable is false for \Noselect / \NonExistent container nodes
 	// that hold no messages (skip them when migrating).
 	Selectable bool `json:"selectable"`
+	// Delim is the server's hierarchy delimiter for this mailbox (e.g.
+	// '/' on Gmail, '.' on Dovecot), used to translate the remote name
+	// into the staging Maildir++ layout. 0 when the server reports a
+	// flat namespace (NIL delimiter).
+	Delim rune `json:"-"`
 }
 
 // ProbeResult is the enumerated remote account.
@@ -69,11 +74,10 @@ type ProbeResult struct {
 // message (don't leak remote banners).
 var ErrAuth = errors.New("imap: authentication failed")
 
-// Probe dials the remote account over the SSRF-guarded transport, logs
-// in, lists folders, and returns the enumeration. It is the network
-// entrypoint; the login + list + mapping logic lives in probeWithClient
-// so it can be unit-tested against an in-memory server.
-func Probe(ctx context.Context, cfg ProbeConfig) (*ProbeResult, error) {
+// connect dials the remote host over the SSRF-guarded transport and
+// returns a ready (but NOT logged-in) IMAP client. Shared by Probe and
+// Fetch. Caller must Close the client.
+func connect(ctx context.Context, cfg ProbeConfig) (*imapclient.Client, error) {
 	host := strings.TrimSpace(cfg.Host)
 	if host == "" {
 		return nil, errors.New("imap: host required")
@@ -98,22 +102,33 @@ func Probe(ctx context.Context, cfg ProbeConfig) (*ProbeResult, error) {
 		return nil, fmt.Errorf("imap: connect %s:%d: %w", host, port, err)
 	}
 
-	var client *imapclient.Client
 	if cfg.STARTTLS {
-		client, err = imapclient.NewStartTLS(conn, &imapclient.Options{
+		client, serr := imapclient.NewStartTLS(conn, &imapclient.Options{
 			TLSConfig: &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12},
 		})
-		if err != nil {
+		if serr != nil {
 			conn.Close()
-			return nil, fmt.Errorf("imap: starttls %s: %w", host, err)
+			return nil, fmt.Errorf("imap: starttls %s: %w", host, serr)
 		}
-	} else {
-		tlsConn := tls.Client(conn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
-		if herr := tlsConn.HandshakeContext(ctx); herr != nil {
-			conn.Close()
-			return nil, fmt.Errorf("imap: tls handshake %s: %w", host, herr)
-		}
-		client = imapclient.New(tlsConn, nil)
+		return client, nil
+	}
+
+	tlsConn := tls.Client(conn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	if herr := tlsConn.HandshakeContext(ctx); herr != nil {
+		conn.Close()
+		return nil, fmt.Errorf("imap: tls handshake %s: %w", host, herr)
+	}
+	return imapclient.New(tlsConn, nil), nil
+}
+
+// Probe dials the remote account over the SSRF-guarded transport, logs
+// in, lists folders, and returns the enumeration. It is the network
+// entrypoint; the login + list + mapping logic lives in probeWithClient
+// so it can be unit-tested against an in-memory server.
+func Probe(ctx context.Context, cfg ProbeConfig) (*ProbeResult, error) {
+	client, err := connect(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
 	defer client.Close()
 
@@ -131,15 +146,23 @@ func probeWithClient(c *imapclient.Client, username, password string) (*ProbeRes
 	// c.Logout() receiver immediately, sending LOGOUT before the LIST below.
 	defer func() { _ = c.Logout().Wait() }()
 
-	// RETURN (SPECIAL-USE) so the server tags Sent/Drafts/Junk/Trash/
-	// Archive/All folders (RFC 6154) — both Gmail and M365 advertise
-	// SPECIAL-USE, and it's how roleOf classifies folders. A non-nil
-	// options value is also required by RFC 5258 LIST-EXTENDED.
+	folders, err := listFolders(c)
+	if err != nil {
+		return nil, err
+	}
+	return &ProbeResult{Folders: folders}, nil
+}
+
+// listFolders runs LIST (RETURN SPECIAL-USE) and maps the result. The
+// SPECIAL-USE return tags Sent/Drafts/Junk/Trash/Archive/All (RFC 6154)
+// — both Gmail and M365 advertise it, and it's how roleOf classifies
+// folders. A non-nil options value is also required by RFC 5258
+// LIST-EXTENDED. Caller must already be logged in.
+func listFolders(c *imapclient.Client) ([]Folder, error) {
 	entries, err := c.List("", "*", &imap.ListOptions{ReturnSpecialUse: true}).Collect()
 	if err != nil {
 		return nil, fmt.Errorf("imap: list folders: %w", err)
 	}
-
 	folders := make([]Folder, 0, len(entries))
 	for _, e := range entries {
 		if e == nil {
@@ -149,9 +172,10 @@ func probeWithClient(c *imapclient.Client, username, password string) (*ProbeRes
 			Name:       e.Mailbox,
 			Role:       roleOf(e.Mailbox, e.Attrs),
 			Selectable: selectable(e.Attrs),
+			Delim:      e.Delim,
 		})
 	}
-	return &ProbeResult{Folders: folders}, nil
+	return folders, nil
 }
 
 // roleOf normalises a mailbox to a SPECIAL-USE role. INBOX has no


### PR DESCRIPTION
## Phase A step 2 — IMAP fetch → staging Maildir (GH #390/#374)

Builds on #422. Fetches a remote account's folders into a staging Maildir
laid out **exactly** for the existing `migration.import_mailboxes` agent
step, so step 3 hands it straight to the JMAP `Email/import` path — no new
Stalwart-ingest code.

### Changes

- `migrate/imap/fetch.go`: `Fetch()` (SSRF-guarded connect + login) + the
  testable `fetchWithClient()` core. Per selectable folder: read-only
  `SELECT`, streaming `FETCH` (UID + FLAGS + INTERNALDATE + `BODY.PEEK[]`),
  write each message to the Maildir — INBOX at the root `{cur,new,tmp}`,
  other folders as Maildir++ `.Sub` dirs, `\Seen` → `cur/` + `:2,S`, unseen
  → `new/`. `maildirSub()` maps SPECIAL-USE roles to canonical names and
  translates ordinary folders' hierarchy delimiter to the Maildir++ dot.
- `probe.go`: extract `connect()` + `listFolders()` for reuse; add
  `Folder.Delim`.

### Correctness

- **`BODY.PEEK[]`** — fetching the body must not set `\Seen` on the source;
  a migration never mutates the remote account's flags. (Caught by a test:
  plain `BODY[]` marked the unread message read.)
- **Gmail "All Mail" skipped** (`\All`) — superset of every folder, would
  duplicate the account; recorded in `FetchResult.Skipped`.
- Read-only `SELECT`; per-message oversize cap matching the agent; `ctx`
  honoured between messages.

### Test plan

- [x] `go build ./...`, `go vet`, `go test -race ./internal/migrate/imap/`
      green.
- [x] Append messages to an in-memory IMAP server, fetch, assert Maildir
      tree + cur/new placement + `:2,S` suffix + All-Mail skip + the
      `maildirSub` mapping table.
- [ ] Box end-to-end lands in step 3 (throwaway account → .86 → Bulwark).

Next: step 3 wires the runner/registry + calls `migration.import_mailboxes`
on the staged Maildir; step 4 = UI wizard + `jabali migrate imap` CLI.
UID-resume deferred (Stalwart `Email/import` already dedups on Message-ID).
