### PR TITLE
feat(migrate): IMAP account import orchestrator (GH #390/#374 phase A step 3)

### DIFF
--- a/panel-api/internal/migrate/imap/import.go
+++ b/panel-api/internal/migrate/imap/import.go
@@ -1,0 +1,111 @@
+package imap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// ImportConfig drives a single IMAP account migration end to end.
+type ImportConfig struct {
+	// Account is the remote IMAP login (host/port/user/app-password).
+	Account ProbeConfig
+	// TargetEmail is the local jabali mailbox the mail lands in. It must
+	// already exist as a panel mailbox; the agent ensures the matching
+	// Stalwart account. Passed as owner_email so the whole staged Maildir
+	// (INBOX + Maildir++ subfolders) imports under this address.
+	TargetEmail string
+	// JobID scopes the staging dir + the agent's path-prefix validation.
+	JobID string
+	// StagingBase is the migrations working root the staging Maildir is
+	// built under. It MUST be one of the agent's accepted staging roots
+	// (/var/lib/jabali/migrations by default, or the legacy
+	// /var/lib/jabali-migrations) or the agent rejects the import. Callers
+	// pass migrate.MigrationsRoot(...).
+	StagingBase string
+	// Folders optionally restricts/pre-supplies the folder set (e.g. from
+	// an earlier Probe the operator reviewed). nil → fetch lists them.
+	Folders []Folder
+}
+
+// ImportResult is the end-to-end outcome for one account.
+type ImportResult struct {
+	Fetch            *FetchResult `json:"fetch"`
+	MessagesImported int64        `json:"messages_imported"`
+	BytesImported    int64        `json:"bytes_imported"`
+	Skipped          []string     `json:"skipped,omitempty"`
+}
+
+// agentImportMailboxesResult mirrors panel-agent's
+// migrationImportMailboxesResult so we can decode the JSON envelope.
+type agentImportMailboxesResult struct {
+	MailboxesProcessed int      `json:"mailboxes_processed"`
+	MessagesImported   int64    `json:"messages_imported"`
+	MessagesSkipped    int64    `json:"messages_skipped"`
+	BytesImported      int64    `json:"bytes_imported"`
+	Skipped            []string `json:"skipped,omitempty"`
+}
+
+// accountPathSanitize keeps a remote username safe as a single path
+// segment (it names the per-account staging subdir).
+var accountPathSanitize = regexp.MustCompile(`[^a-zA-Z0-9._@-]+`)
+
+// fetchFn is the fetch step, indirected so tests can drive Import's
+// orchestration (staging path + agent dispatch + result merge) without a
+// live TLS IMAP transport. Production wiring uses Fetch.
+var fetchFn = Fetch
+
+// Import fetches one remote IMAP account into a staging Maildir and hands
+// it to the migration.import_mailboxes agent step, which pushes every
+// message into the target Stalwart account via JMAP (dedup on Message-ID
+// → idempotent on resume). The target jabali mailbox must already exist.
+func Import(ctx context.Context, cfg ImportConfig, agentCli agent.AgentInterface) (*ImportResult, error) {
+	if cfg.TargetEmail == "" {
+		return nil, errors.New("imap: target_email required")
+	}
+	if cfg.JobID == "" {
+		return nil, errors.New("imap: job_id required")
+	}
+	if cfg.StagingBase == "" {
+		return nil, errors.New("imap: staging_base required")
+	}
+	if agentCli == nil {
+		return nil, errors.New("imap: agent client required")
+	}
+
+	safeAccount := accountPathSanitize.ReplaceAllString(cfg.Account.Username, "_")
+	maildirRoot := filepath.Join(cfg.StagingBase, cfg.JobID, "imap", safeAccount, "Maildir")
+
+	fetchRes, err := fetchFn(ctx, cfg.Account, cfg.Folders, maildirRoot)
+	if err != nil {
+		return nil, fmt.Errorf("imap: fetch: %w", err)
+	}
+
+	raw, err := agentCli.Call(ctx, "migration.import_mailboxes", map[string]any{
+		"job_id":       cfg.JobID,
+		"src_mail_dir": maildirRoot,
+		"owner_email":  cfg.TargetEmail,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("imap: import_mailboxes: %w", err)
+	}
+
+	var ag agentImportMailboxesResult
+	if err := json.Unmarshal(raw, &ag); err != nil {
+		return nil, fmt.Errorf("imap: decode import result: %w", err)
+	}
+
+	res := &ImportResult{
+		Fetch:            fetchRes,
+		MessagesImported: ag.MessagesImported,
+		BytesImported:    ag.BytesImported,
+	}
+	res.Skipped = append(res.Skipped, fetchRes.Skipped...)
+	res.Skipped = append(res.Skipped, ag.Skipped...)
+	return res, nil
+}

--- a/panel-api/internal/migrate/imap/import_test.go
+++ b/panel-api/internal/migrate/imap/import_test.go
@@ -1,0 +1,129 @@
+package imap
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+func TestImportOrchestration(t *testing.T) {
+	orig := fetchFn
+	defer func() { fetchFn = orig }()
+
+	var gotStaging string
+	fetchFn = func(_ context.Context, _ ProbeConfig, _ []Folder, stagingDir string) (*FetchResult, error) {
+		gotStaging = stagingDir
+		return &FetchResult{TotalMessages: 2, TotalBytes: 100, Skipped: []string{"[Gmail]/All Mail"}}, nil
+	}
+
+	mock := agent.NewMockClient()
+	mock.On("migration.import_mailboxes", agentImportMailboxesResult{
+		MailboxesProcessed: 2,
+		MessagesImported:   2,
+		BytesImported:      100,
+		Skipped:            []string{"oversized:x"},
+	})
+
+	res, err := Import(context.Background(), ImportConfig{
+		Account:     ProbeConfig{Username: "user@example.com", Password: "app-pass", Host: "imap.example.com"},
+		TargetEmail: "dest@local.test",
+		JobID:       "job-123",
+		StagingBase: "/var/lib/jabali/migrations",
+	}, mock)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Staging Maildir path: <base>/<job>/imap/<account>/Maildir.
+	wantStaging := "/var/lib/jabali/migrations/job-123/imap/user@example.com/Maildir"
+	if gotStaging != wantStaging {
+		t.Errorf("staging dir = %q, want %q", gotStaging, wantStaging)
+	}
+
+	calls := mock.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("agent calls = %d, want 1", len(calls))
+	}
+	if calls[0].Command != "migration.import_mailboxes" {
+		t.Errorf("command = %q, want migration.import_mailboxes", calls[0].Command)
+	}
+	var params struct {
+		JobID      string `json:"job_id"`
+		SrcMailDir string `json:"src_mail_dir"`
+		OwnerEmail string `json:"owner_email"`
+	}
+	if err := json.Unmarshal(calls[0].Params, &params); err != nil {
+		t.Fatalf("decode params: %v", err)
+	}
+	if params.JobID != "job-123" {
+		t.Errorf("job_id = %q, want job-123", params.JobID)
+	}
+	if params.SrcMailDir != wantStaging {
+		t.Errorf("src_mail_dir = %q, want %q", params.SrcMailDir, wantStaging)
+	}
+	if params.OwnerEmail != "dest@local.test" {
+		t.Errorf("owner_email = %q, want dest@local.test", params.OwnerEmail)
+	}
+
+	if res.MessagesImported != 2 || res.BytesImported != 100 {
+		t.Errorf("result = %d msgs/%d bytes, want 2/100", res.MessagesImported, res.BytesImported)
+	}
+	// Skipped merges fetch-side + agent-side notes.
+	if len(res.Skipped) != 2 {
+		t.Errorf("skipped = %v, want the fetch + agent notes", res.Skipped)
+	}
+}
+
+func TestImportValidation(t *testing.T) {
+	mock := agent.NewMockClient()
+	base := ImportConfig{
+		Account:     ProbeConfig{Username: "u@x", Password: "p", Host: "h"},
+		TargetEmail: "dest@local",
+		JobID:       "j1",
+		StagingBase: "/var/lib/jabali/migrations",
+	}
+	cases := map[string]func(*ImportConfig){
+		"missing target":  func(c *ImportConfig) { c.TargetEmail = "" },
+		"missing job":     func(c *ImportConfig) { c.JobID = "" },
+		"missing staging": func(c *ImportConfig) { c.StagingBase = "" },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := base
+			mutate(&cfg)
+			if _, err := Import(context.Background(), cfg, mock); err == nil {
+				t.Errorf("Import(%s) = nil error, want validation error", name)
+			}
+		})
+	}
+
+	t.Run("nil agent", func(t *testing.T) {
+		if _, err := Import(context.Background(), base, nil); err == nil {
+			t.Error("Import(nil agent) = nil error, want error")
+		}
+	})
+}
+
+func TestImportAgentError(t *testing.T) {
+	orig := fetchFn
+	defer func() { fetchFn = orig }()
+	fetchFn = func(_ context.Context, _ ProbeConfig, _ []Folder, _ string) (*FetchResult, error) {
+		return &FetchResult{}, nil
+	}
+
+	mock := agent.NewMockClient()
+	mock.OnError("migration.import_mailboxes", errors.New("agent down"))
+
+	_, err := Import(context.Background(), ImportConfig{
+		Account:     ProbeConfig{Username: "u@x", Password: "p", Host: "h"},
+		TargetEmail: "dest@local",
+		JobID:       "j1",
+		StagingBase: "/var/lib/jabali/migrations",
+	}, mock)
+	if err == nil {
+		t.Fatal("Import with failing agent = nil error, want error")
+	}
+}


### PR DESCRIPTION
## Phase A step 3 — IMAP account import orchestrator (GH #390/#374)

Ties steps 1 (#422 probe) + 2 (#423 fetch) together into one end-to-end call.

`Import(ctx, ImportConfig, agent.AgentInterface)`:
1. Fetch the remote account's folders into a staging Maildir under
   `<StagingBase>/<job>/imap/<account>/Maildir` (account segment path-sanitised).
2. Dispatch the **existing** `migration.import_mailboxes` agent step with
   `src_mail_dir` + `owner_email=<target mailbox>`, so the whole staged tree
   (INBOX + Maildir++ subfolders) imports under the target Stalwart account —
   JMAP `Blob/upload` + `Email/import`, dedup on Message-ID → idempotent resume.

`StagingBase` must be one of the agent's accepted staging roots
(`migrate.MigrationsRoot` → `/var/lib/jabali/migrations`, or legacy
`/var/lib/jabali-migrations`). Target jabali mailbox must pre-exist
(create-on-migrate is step 4).

### Testing

The fetch step is indirected (`fetchFn`) so the orchestration is unit-tested
against `agent.MockClient` without a live TLS transport:
- [x] asserts the staging path, agent command + params
      (`job_id`/`src_mail_dir`/`owner_email`), fetch+agent skip merge.
- [x] validation (missing target/job/staging/agent) + agent-error propagation.
- [x] `go build ./...`, `go vet`, `go test -race ./internal/migrate/imap/` green.

### Not in this PR

- Endpoint/CLI/UI — **step 4** (`jabali migrate imap`, single + bulk CSV,
  UI wizard) calls this orchestrator.
- **Box end-to-end** (real Gmail/M365 account + app-password → .86 → Bulwark)
  is operator-credentialed, landing with the step-4 UI. The downstream
  Maildir→Stalwart half is already proven by the cPanel restore path that
  shares `migration.import_mailboxes`.
