### PR TITLE
feat(migrate): IMAP migration admin HTTP endpoints (GH #390/#374 phase A step 4b)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -6,14 +6,15 @@
 // import); the REST adds a UI-friendly observation surface.
 //
 // Routes mounted under /admin/migrations:
-//   GET    /admin/migrations                  list (paginated envelope)
-//   POST   /admin/migrations                  create (state=pending; runner
-//                                             stays operator-driven via CLI)
-//   GET    /admin/migrations/:id              one job + recent stages
-//   GET    /admin/migrations/:id/stages       full stage timeline
-//   DELETE /admin/migrations/:id              soft-revoke (state→cancelled)
-//   POST   /admin/migrations/:id/destroy      hard-delete row + secret + extracted dir
-//                                             (requires terminal state)
+//
+//	GET    /admin/migrations                  list (paginated envelope)
+//	POST   /admin/migrations                  create (state=pending; runner
+//	                                          stays operator-driven via CLI)
+//	GET    /admin/migrations/:id              one job + recent stages
+//	GET    /admin/migrations/:id/stages       full stage timeline
+//	DELETE /admin/migrations/:id              soft-revoke (state→cancelled)
+//	POST   /admin/migrations/:id/destroy      hard-delete row + secret + extracted dir
+//	                                          (requires terminal state)
 //
 // Admin-gated. RequireAdmin already mounted by the parent group.
 package api
@@ -25,9 +26,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -69,12 +70,16 @@ func RegisterAdminMigrationRoutes(g *gin.RouterGroup, cfg AdminMigrationsHandler
 	rg.DELETE("/:id", h.cancel)
 	rg.POST("/:id/destroy", h.destroy)
 	rg.POST("/refresh", h.refresh) // GH #646
+	// GH #390/#374 phase A — per-mailbox IMAP source. probe enumerates
+	// remote folders; the run endpoint launches fetch+import async.
+	rg.POST("/imap/probe", h.probeIMAP)
+	rg.POST("/imap", h.runIMAP)
 	// SPA-driven migration endpoints. Each writes/launches via the
 	// agent (transient systemd unit pattern, M29 §updates) so the
 	// long-running pull + import survive panel-api restarts.
 	rg.POST("/:id/secrets", h.uploadSecrets)
-	rg.POST("/:id/test-connection", h.testConnection) // GH #665
-	rg.PUT("/:id/plan", h.updatePlan)                 // GH #665
+	rg.POST("/:id/test-connection", h.testConnection)   // GH #665
+	rg.PUT("/:id/plan", h.updatePlan)                   // GH #665
 	rg.POST("/:id/describe-account", h.describeAccount) // GH #665
 	rg.POST("/:id/pull-source", h.runPullSource)
 	rg.POST("/:id/import", h.runImport)
@@ -126,8 +131,8 @@ func (h *adminMigrationsHandler) list(c *gin.Context) {
 // recent stage rows so the UI can render the timeline without
 // a follow-up call.
 type migrationJobDetailResponse struct {
-	Job    *models.MigrationJob     `json:"job"`
-	Stages []models.MigrationStage  `json:"stages"`
+	Job    *models.MigrationJob    `json:"job"`
+	Stages []models.MigrationStage `json:"stages"`
 }
 
 func (h *adminMigrationsHandler) get(c *gin.Context) {
@@ -234,11 +239,11 @@ func (h *adminMigrationsHandler) create(c *gin.Context) {
 		state = models.MigrationStateDraft
 	}
 	row := &models.MigrationJob{
-		ID:         genULID(),
-		SourceKind: req.SourceKind,
-		SourceHost: req.SourceHost,
-		SourceUser: req.SourceUser,
-		State:      state,
+		ID:              genULID(),
+		SourceKind:      req.SourceKind,
+		SourceHost:      req.SourceHost,
+		SourceUser:      req.SourceUser,
+		State:           state,
 		ExpectedHostKey: strings.TrimSpace(req.ExpectedHostKey),
 	}
 	if sp := strings.TrimSpace(req.SourcePath); sp != "" { // GH #647 wordpress_ssh
@@ -250,7 +255,6 @@ func (h *adminMigrationsHandler) create(c *gin.Context) {
 	}
 	c.JSON(http.StatusCreated, row)
 }
-
 
 // validMigrationFingerprint accepts an empty value (TOFU) or a SHA256 host-key
 // fingerprint: an optional "SHA256:" prefix over 43 base64 chars (Gitea #461).
@@ -271,8 +275,9 @@ func isKnownSourceKind(s string) bool {
 		models.MigrationSourceWHMpkgacct,
 		models.MigrationSourceDirectAdmin,
 		models.MigrationSourceHestia,
-		models.MigrationSourceWordPressSSH, // GH #647
-		models.MigrationSourceWordPressPlugin: // GH #648
+		models.MigrationSourceWordPressSSH,    // GH #647
+		models.MigrationSourceWordPressPlugin, // GH #648
+		models.MigrationSourceIMAP:            // GH #390/#374
 		return true
 	}
 	return false
@@ -631,7 +636,6 @@ func atoiNonNeg(s string) (int, error) {
 	return n, nil
 }
 
-
 // migrationStagingDir returns the per-job staging dir used by both
 // SSH-pull (jabali migrate pull-source) and the offline tarball-
 // upload paths. Mirrored from migrate_pull_cmd.go so the SPA hits
@@ -761,8 +765,8 @@ func (h *adminMigrationsHandler) uploadTarball(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"path":        target,
-		"size_bytes":  wrote,
+		"path":       target,
+		"size_bytes": wrote,
 	})
 }
 
@@ -1292,12 +1296,13 @@ func (h *adminMigrationsHandler) submitDraft(c *gin.Context) {
 // the cache, returns the size.
 //
 // 5xx ladder:
-//   501 Not Implemented — Discoverer for this source_kind doesn't
-//       implement SizeProber. Falls back to "discovery returned 0".
-//   502 Bad Gateway     — SSH connect / du failed upstream.
-//   412 Precondition    — secret missing (POST /:id/secrets first).
-//   404 Not Found       — draft job missing.
-//   409 Conflict        — job not in draft/pending state.
+//
+//	501 Not Implemented — Discoverer for this source_kind doesn't
+//	    implement SizeProber. Falls back to "discovery returned 0".
+//	502 Bad Gateway     — SSH connect / du failed upstream.
+//	412 Precondition    — secret missing (POST /:id/secrets first).
+//	404 Not Found       — draft job missing.
+//	409 Conflict        — job not in draft/pending state.
 func (h *adminMigrationsHandler) accountSizeProbe(c *gin.Context) {
 	id := c.Param("id")
 	login := c.Param("user")

--- a/panel-api/internal/api/admin_migrations_imap.go
+++ b/panel-api/internal/api/admin_migrations_imap.go
@@ -1,0 +1,174 @@
+// IMAP mail-migration admin endpoints (GH #390 Google Workspace / #374
+// M365, phase A step 4b). Unlike the cpmove-tarball sources handled in
+// admin_migrations.go, IMAP is per-mailbox: each account carries its
+// own remote login + app-password, and the message FETCH runs inside
+// panel-api (internal/migrate/imap) rather than in the agent — there
+// is no agent verb for pulling a remote IMAP account. So the run
+// endpoint launches the fetch+import in a detached goroutine and
+// returns 202; the operator polls GET /admin/migrations/:id for state.
+//
+// Routes (mounted by RegisterAdminMigrationRoutes, admin-gated):
+//
+//	POST /admin/migrations/imap/probe   enumerate remote folders (sync)
+//	POST /admin/migrations/imap         start a migration (202 + goroutine)
+//
+// The app-password is used transiently and never persisted (no secret
+// file): a panel-api restart mid-run drops the in-memory password, and
+// the operator re-POSTs to resume — safe because the import de-dupes on
+// Message-ID.
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/imap"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// imapRunTimeout bounds a single account's fetch+import. Matches the
+// fetch package's own ceiling; a real Workspace/M365 mailbox pull can
+// run for hours.
+const imapRunTimeout = 6 * time.Hour
+
+// imapProbeFn / imapImportFn are seams so handler tests drive the
+// endpoints without a live TLS IMAP transport. Production wiring uses
+// the real package functions.
+var (
+	imapProbeFn  = imap.Probe
+	imapImportFn = imap.Import
+)
+
+// imapConnRequest is the shared connection shape for probe + run.
+type imapConnRequest struct {
+	Host         string `json:"host" binding:"required"`
+	Port         int    `json:"port"`
+	STARTTLS     bool   `json:"starttls"`
+	User         string `json:"user" binding:"required"`
+	Password     string `json:"password" binding:"required"`
+	AllowPrivate bool   `json:"allow_private"`
+}
+
+func (r imapConnRequest) probeConfig() imap.ProbeConfig {
+	return imap.ProbeConfig{
+		Host: r.Host, Port: r.Port, STARTTLS: r.STARTTLS,
+		Username: r.User, Password: r.Password, AllowPrivate: r.AllowPrivate,
+	}
+}
+
+// probeIMAP — POST /admin/migrations/imap/probe. Enumerates the remote
+// account's folders + roles so the wizard can preview the mapping.
+// Synchronous (LIST is fast). Auth failures are distinguished from
+// connect failures, and the remote banner is never echoed to the
+// client.
+func (h *adminMigrationsHandler) probeIMAP(c *gin.Context) {
+	var req imapConnRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	res, err := imapProbeFn(ctx, req.probeConfig())
+	if err != nil {
+		if errors.Is(err, imap.ErrAuth) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "auth_failed", "detail": "the remote server rejected the credentials"})
+			return
+		}
+		c.JSON(http.StatusBadGateway, gin.H{"error": "probe_failed", "detail": "could not enumerate the remote account"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"folders": res.Folders, "total": len(res.Folders)})
+}
+
+// imapRunRequest adds the destination mailbox to the connection shape.
+type imapRunRequest struct {
+	imapConnRequest
+	To string `json:"to" binding:"required"` // local jabali mailbox (must exist)
+}
+
+// runIMAP — POST /admin/migrations/imap. Creates/reuses the
+// migration_jobs row and launches the fetch+import in a detached
+// goroutine, returning 202 with the job id. The operator polls
+// GET /admin/migrations/:id for progress.
+func (h *adminMigrationsHandler) runIMAP(c *gin.Context) {
+	var req imapRunRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unconfigured"})
+		return
+	}
+	if h.cfg.Settings == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "settings_unconfigured"})
+		return
+	}
+	ctx := c.Request.Context()
+
+	// Reuse the natural-key row; refuse if a run is already in flight.
+	var jobID string
+	if ex, _ := h.cfg.Jobs.FindBySource(ctx, models.MigrationSourceIMAP, req.Host, req.User); ex != nil {
+		if ex.State == models.MigrationStateRestoring {
+			c.JSON(http.StatusConflict, gin.H{"error": "already_running", "existing_job_id": ex.ID})
+			return
+		}
+		jobID = ex.ID
+	} else {
+		row := &models.MigrationJob{
+			ID:         genULID(),
+			SourceKind: models.MigrationSourceIMAP,
+			SourceHost: req.Host,
+			SourceUser: req.User,
+			State:      models.MigrationStatePending,
+		}
+		if err := h.cfg.Jobs.Create(ctx, row); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal", "detail": err.Error()})
+			return
+		}
+		jobID = row.ID
+	}
+
+	stagingBase := migrate.MigrationsRoot(ctx, h.cfg.Settings)
+	if err := h.cfg.Jobs.UpdateState(ctx, jobID, models.MigrationStateRestoring, nil); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal", "detail": err.Error()})
+		return
+	}
+
+	// Detach: the request context dies when this handler returns, so
+	// the long fetch+import runs under a fresh bounded context. The
+	// app-password lives only in this closure.
+	go runIMAPImport(h.cfg.Jobs, h.cfg.Agent, imap.ImportConfig{
+		Account:     req.probeConfig(),
+		TargetEmail: req.To,
+		JobID:       jobID,
+		StagingBase: stagingBase,
+	})
+
+	c.JSON(http.StatusAccepted, gin.H{"job_id": jobID, "state": models.MigrationStateRestoring})
+}
+
+// runIMAPImport runs one account's fetch+import to completion and
+// records the terminal state. Runs in its own goroutine, detached from
+// any request. Package-level (not a closure) so the seam imapImportFn
+// is exercised and the goroutine body stays testable.
+func runIMAPImport(jobs repository.MigrationJobRepository, agentCli agent.AgentInterface, cfg imap.ImportConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), imapRunTimeout)
+	defer cancel()
+
+	if _, err := imapImportFn(ctx, cfg, agentCli); err != nil {
+		msg := err.Error()
+		_ = jobs.UpdateState(context.Background(), cfg.JobID, models.MigrationStateFailed, &msg)
+		return
+	}
+	_ = jobs.UpdateState(context.Background(), cfg.JobID, models.MigrationStateDone, nil)
+}

--- a/panel-api/internal/api/admin_migrations_imap_test.go
+++ b/panel-api/internal/api/admin_migrations_imap_test.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/imap"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes ---
+
+type fakeIMAPJobs struct {
+	repository.MigrationJobRepository
+	mu       sync.Mutex
+	byKey    map[string]*models.MigrationJob // "kind|host|user"
+	byID     map[string]*models.MigrationJob
+	created  int
+	stateLog []string
+}
+
+func newFakeIMAPJobs() *fakeIMAPJobs {
+	return &fakeIMAPJobs{byKey: map[string]*models.MigrationJob{}, byID: map[string]*models.MigrationJob{}}
+}
+
+func imapKey(kind, host, user string) string { return kind + "|" + host + "|" + user }
+
+func (f *fakeIMAPJobs) FindBySource(_ context.Context, kind, host, user string) (*models.MigrationJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if j, ok := f.byKey[imapKey(kind, host, user)]; ok {
+		return j, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (f *fakeIMAPJobs) Create(_ context.Context, j *models.MigrationJob) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.created++
+	f.byKey[imapKey(j.SourceKind, j.SourceHost, j.SourceUser)] = j
+	f.byID[j.ID] = j
+	return nil
+}
+
+func (f *fakeIMAPJobs) UpdateState(_ context.Context, id, state string, _ *string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stateLog = append(f.stateLog, state)
+	if j, ok := f.byID[id]; ok {
+		j.State = state
+	}
+	return nil
+}
+
+func (f *fakeIMAPJobs) states() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.stateLog))
+	copy(out, f.stateLog)
+	return out
+}
+
+type fakeIMAPSettings struct {
+	repository.ServerSettingsRepository
+}
+
+func (fakeIMAPSettings) Get(_ context.Context) (*models.ServerSettings, error) {
+	return nil, errors.New("none") // → DefaultWorkingFolder
+}
+
+type fakeIMAPAgent struct{}
+
+func (fakeIMAPAgent) Call(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+	return json.RawMessage("{}"), nil
+}
+
+func newIMAPHandler(agentCli agent.AgentInterface) (*adminMigrationsHandler, *fakeIMAPJobs) {
+	jobs := newFakeIMAPJobs()
+	h := &adminMigrationsHandler{cfg: AdminMigrationsHandlerConfig{
+		Jobs:     jobs,
+		Settings: fakeIMAPSettings{},
+		Agent:    agentCli,
+	}}
+	return h, jobs
+}
+
+func postJSON(h func(*gin.Context), body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h(c)
+	return w
+}
+
+// TestRegisterAdminMigrationRoutesNoPanic guards against a gin routing
+// conflict from the new static /imap segment coexisting with the /:id
+// param routes (a boot-time panic that would otherwise only surface in
+// the Playwright job).
+func TestRegisterAdminMigrationRoutesNoPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	RegisterAdminMigrationRoutes(e.Group("/api/v1"), AdminMigrationsHandlerConfig{
+		Jobs: newFakeIMAPJobs(), Settings: fakeIMAPSettings{}, Agent: fakeIMAPAgent{},
+	})
+}
+
+// --- probe ---
+
+func TestProbeIMAP(t *testing.T) {
+	orig := imapProbeFn
+	defer func() { imapProbeFn = orig }()
+	imapProbeFn = func(_ context.Context, _ imap.ProbeConfig) (*imap.ProbeResult, error) {
+		return &imap.ProbeResult{Folders: []imap.Folder{
+			{Name: "INBOX", Role: "inbox", Selectable: true},
+			{Name: "[Gmail]/Sent Mail", Role: "sent", Selectable: true},
+		}}, nil
+	}
+	h, _ := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.probeIMAP, `{"host":"imap.gmail.com","user":"a@b.com","password":"pw"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Total   int `json:"total"`
+		Folders []imap.Folder
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Total != 2 {
+		t.Errorf("total = %d, want 2", resp.Total)
+	}
+}
+
+func TestProbeIMAPAuthFailed(t *testing.T) {
+	orig := imapProbeFn
+	defer func() { imapProbeFn = orig }()
+	imapProbeFn = func(_ context.Context, _ imap.ProbeConfig) (*imap.ProbeResult, error) {
+		return nil, imap.ErrAuth
+	}
+	h, _ := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.probeIMAP, `{"host":"h","user":"u","password":"bad"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("code = %d, want 401", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "ErrAuth") || strings.Contains(w.Body.String(), "imap:") {
+		t.Errorf("response leaks internal error text: %s", w.Body.String())
+	}
+}
+
+func TestProbeIMAPValidation(t *testing.T) {
+	h, _ := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.probeIMAP, `{"host":"h"}`) // missing user + password
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", w.Code)
+	}
+}
+
+// --- run ---
+
+func TestRunIMAPHappyPath(t *testing.T) {
+	origImp := imapImportFn
+	defer func() { imapImportFn = origImp }()
+	done := make(chan imap.ImportConfig, 1)
+	imapImportFn = func(_ context.Context, cfg imap.ImportConfig, _ agent.AgentInterface) (*imap.ImportResult, error) {
+		done <- cfg
+		return &imap.ImportResult{MessagesImported: 5, BytesImported: 500}, nil
+	}
+
+	h, jobs := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.runIMAP, `{"host":"imap.gmail.com","user":"a@b.com","password":"pw","to":"dest@local"}`)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		JobID string `json:"job_id"`
+		State string `json:"state"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.JobID == "" || resp.State != models.MigrationStateRestoring {
+		t.Fatalf("resp = %+v, want a job_id + restoring", resp)
+	}
+
+	select {
+	case cfg := <-done:
+		if cfg.TargetEmail != "dest@local" || cfg.JobID != resp.JobID {
+			t.Errorf("import cfg = %+v", cfg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("import goroutine never ran")
+	}
+
+	// Terminal state lands as done (poll — goroutine writes after import).
+	deadline := time.After(3 * time.Second)
+	for {
+		st := jobs.states()
+		if len(st) > 0 && st[len(st)-1] == models.MigrationStateDone {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("state never reached done; log=%v", jobs.states())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if jobs.created != 1 {
+		t.Errorf("created = %d, want 1", jobs.created)
+	}
+}
+
+func TestRunIMAPAlreadyRunning(t *testing.T) {
+	h, jobs := newIMAPHandler(fakeIMAPAgent{})
+	jobs.byKey[imapKey(models.MigrationSourceIMAP, "h", "u")] = &models.MigrationJob{
+		ID: "EXISTING", State: models.MigrationStateRestoring,
+	}
+	w := postJSON(h.runIMAP, `{"host":"h","user":"u","password":"pw","to":"d@l"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("code = %d, want 409", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "EXISTING") {
+		t.Errorf("409 body should carry existing job id: %s", w.Body.String())
+	}
+}
+
+func TestRunIMAPAgentUnconfigured(t *testing.T) {
+	h, _ := newIMAPHandler(nil) // Agent nil
+	w := postJSON(h.runIMAP, `{"host":"h","user":"u","password":"pw","to":"d@l"}`)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("code = %d, want 503", w.Code)
+	}
+}
+
+func TestRunIMAPValidation(t *testing.T) {
+	h, _ := newIMAPHandler(fakeIMAPAgent{})
+	w := postJSON(h.runIMAP, `{"host":"h","user":"u","password":"pw"}`) // missing to
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", w.Code)
+	}
+}


### PR DESCRIPTION
## What

IMAP mail-migration **admin HTTP endpoints** (GH #390 Google Workspace / #374 M365, **phase A step 4b**) — exposes the merged `migrate/imap` pipeline (probe #422, fetch #423, import #424, CLI #425) over the admin API so the UI wizard (4c) can drive it.

```
POST /admin/migrations/imap/probe   → enumerate remote folders + roles (sync)
POST /admin/migrations/imap         → start a migration (202 + job_id)
```

## Execution model

IMAP is **per-mailbox** and the message FETCH runs **inside panel-api** (`internal/migrate/imap`) — there is no agent verb for pulling a remote IMAP account (the agent only owns the Maildir→Stalwart `import_mailboxes` step). So the run endpoint launches `imap.Import` in a **detached, bounded goroutine** and returns `202 {job_id, state:"restoring"}`; the operator polls the existing `GET /admin/migrations/:id` for `pending → restoring → done/failed`. The `migration_jobs` row is created/reused on the natural key `(host,user,imap)`, so re-POST resumes (import de-dupes on Message-ID).

## Security

- App-password used **transiently, never persisted** (no secret file). A restart mid-run drops it; operator re-POSTs to resume.
- Probe distinguishes **auth failure (401)** from **connect failure (502)** and never echoes the remote banner.
- Admin-gated (`RequireAdmin`, inherited). `agent`/`settings` nil → 503.

## Scope

Additive; no existing route changed. `imap` added to `isKnownSourceKind` for list/get observability. New file (`admin_migrations.go` is already 1400+ lines). UI wizard (4c) is the next PR; operator-credentialed box e2e runs after.

## Test plan

- [x] `go build ./internal/api` + `go vet` + gofmt
- [x] Handler unit tests (seams `imapProbeFn`/`imapImportFn`, no live transport): probe 200/401/400, run 202 happy-path (goroutine invoked + terminal state=done), 409 already-running, 503 agent-nil, 400 validation — all `-race`
- [x] Route-registration guard (gin static `/imap` vs param `/:id` boot-panic)
- [ ] CI green
- [ ] Post-merge: operator box e2e on .86
