### PR TITLE
feat(migrate): IMAP migration admin UI drawer (GH #390/#374 phase A step 4c)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -37,6 +37,7 @@ import { BulkWhmDrawer } from "./BulkWhmDrawer";
 import { RefreshMigrationModal } from "./RefreshMigrationModal";
 import { CreateMigrationDrawer } from "./CreateMigrationDrawer";
 import { CreateMigrationWizard } from "./CreateMigrationWizard";
+import { MigrateImapDrawer } from "./MigrateImapDrawer";
 
 type MigrationJob = {
   id: string;
@@ -85,6 +86,7 @@ export const AdminMigrationsPage = () => {
   const [bulkOpen, setBulkOpen] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [refreshOpen, setRefreshOpen] = useState(false);
+  const [imapOpen, setImapOpen] = useState(false);
   const screens = Grid.useBreakpoint();
 
   // M35.4 — auto-open wizard on landing if URL carries ?wizard=<id>.
@@ -235,6 +237,7 @@ export const AdminMigrationsPage = () => {
             </Tooltip>
             <Button onClick={() => setBulkOpen(true)}>Bulk WHM (paste)</Button>
             <Button onClick={() => setWizardOpen(true)}>Wizard</Button>
+            <Button onClick={() => setImapOpen(true)}>Migrate IMAP mailbox</Button>
             <Button danger onClick={() => setRefreshOpen(true)}>Refresh (re-pull)</Button>
             <Button
               type="primary"
@@ -456,6 +459,7 @@ export const AdminMigrationsPage = () => {
         onClose={() => setDrawerOpen(false)}
       />
       <RefreshMigrationModal open={refreshOpen} onClose={() => setRefreshOpen(false)} />
+      <MigrateImapDrawer open={imapOpen} onClose={() => setImapOpen(false)} />
       <BulkWhmDrawer
         open={bulkOpen}
         onClose={() => setBulkOpen(false)}

--- a/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.test.tsx
+++ b/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.test.tsx
@@ -1,0 +1,106 @@
+// MigrateImapDrawer.test.tsx — GH #390/#374. Locks the wire contract
+// against admin_migrations_imap.go (probe → POST /admin/migrations/imap/
+// probe; start → POST /admin/migrations/imap) and runs the real AntD
+// Drawer/Form/Table so a runtime React/AntD break surfaces here (tsc /
+// npm build don't catch those). Only apiClient is mocked.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MigrateImapDrawer } from "./MigrateImapDrawer";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as { post: ReturnType<typeof vi.fn> };
+
+function renderDrawer() {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <MigrateImapDrawer open onClose={() => {}} />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+async function fillConnection() {
+  fireEvent.change(await screen.findByPlaceholderText("imap.gmail.com"), {
+    target: { value: "imap.gmail.com" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("old-account@company.com"), {
+    target: { value: "old@company.com" },
+  });
+  fireEvent.change(screen.getByPlaceholderText("app-password"), {
+    target: { value: "abcd efgh ijkl mnop" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MigrateImapDrawer", () => {
+  it("probes the remote account and renders the folder map", async () => {
+    mocked.post.mockResolvedValue({
+      data: {
+        total: 2,
+        folders: [
+          { name: "INBOX", role: "inbox", selectable: true },
+          { name: "[Gmail]/All Mail", role: "all", selectable: true },
+        ],
+      },
+    });
+    renderDrawer();
+    await fillConnection();
+    fireEvent.click(screen.getByRole("button", { name: "Preview folders" }));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/admin/migrations/imap/probe", {
+        host: "imap.gmail.com",
+        port: 0,
+        starttls: false,
+        user: "old@company.com",
+        password: "abcd efgh ijkl mnop",
+        allow_private: false,
+      }),
+    );
+    // Folder table rendered; All-Mail is flagged as skipped (duplicate).
+    await screen.findByText("INBOX");
+    await screen.findByText("skipped (duplicate of other folders)");
+  });
+
+  it("starts the migration with the destination mailbox", async () => {
+    mocked.post.mockResolvedValue({ data: { job_id: "JOB123", state: "restoring" } });
+    renderDrawer();
+    await fillConnection();
+    fireEvent.change(screen.getByPlaceholderText("new-account@example.com"), {
+      target: { value: "new@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start migration" }));
+
+    await waitFor(() =>
+      expect(mocked.post).toHaveBeenCalledWith("/admin/migrations/imap", {
+        host: "imap.gmail.com",
+        port: 0,
+        starttls: false,
+        user: "old@company.com",
+        password: "abcd efgh ijkl mnop",
+        allow_private: false,
+        to: "new@example.com",
+      }),
+    );
+  });
+
+  it("requires host, user, password and destination before starting", async () => {
+    renderDrawer();
+    fireEvent.click(await screen.findByRole("button", { name: "Start migration" }));
+    // Validation blocks the request.
+    await waitFor(() => expect(mocked.post).not.toHaveBeenCalled());
+  });
+});

--- a/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
@@ -1,0 +1,282 @@
+// MigrateImapDrawer — GH #390 (Google Workspace) / #374 (M365) phase A.
+//
+// Per-mailbox IMAP migration: connect to a remote IMAP account with an
+// app-password, preview its folder layout (POST /admin/migrations/imap/
+// probe), then start the fetch+import (POST /admin/migrations/imap → 202
+// + job id). The backend runs the pull in a detached goroutine; progress
+// shows on the migration detail page (state pending → restoring → done).
+//
+// Distinct from CreateMigrationDrawer (cpmove/SSH panel-account sources):
+// IMAP carries its own remote login per mailbox and never uploads a
+// tarball. The app-password is sent per-request and never persisted.
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Collapse,
+  Drawer,
+  Form,
+  Input,
+  InputNumber,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+
+import { apiClient } from "../../../apiClient";
+import { ImportOutlined } from "../../../icons";
+
+type Props = { open: boolean; onClose: () => void };
+
+type Folder = {
+  name: string;
+  role: string;
+  selectable: boolean;
+};
+
+type ConnForm = {
+  host: string;
+  port?: number;
+  starttls?: boolean;
+  user: string;
+  password: string;
+  to: string;
+  allow_private?: boolean;
+};
+
+// roleColor maps a SPECIAL-USE role to an antd Tag color for the preview.
+const roleColor: Record<string, string> = {
+  inbox: "blue",
+  sent: "green",
+  drafts: "gold",
+  junk: "volcano",
+  trash: "red",
+  archive: "purple",
+  all: "default",
+};
+
+function connBody(v: ConnForm) {
+  return {
+    host: v.host.trim(),
+    port: v.port ?? 0,
+    starttls: !!v.starttls,
+    user: v.user.trim(),
+    password: v.password,
+    allow_private: !!v.allow_private,
+  };
+}
+
+export function MigrateImapDrawer({ open, onClose }: Props) {
+  const [form] = Form.useForm<ConnForm>();
+  const qc = useQueryClient();
+  const [folders, setFolders] = useState<Folder[] | null>(null);
+
+  const probeMut = useMutation({
+    mutationFn: async (v: ConnForm) => {
+      const { data } = await apiClient.post<{ folders: Folder[]; total: number }>(
+        "/admin/migrations/imap/probe",
+        connBody(v),
+      );
+      return data.folders ?? [];
+    },
+    onSuccess: (f) => {
+      setFolders(f);
+      message.success(`Found ${f.length} folder(s) on the remote account`);
+    },
+    onError: (err: AxiosError<{ error?: string }>) => {
+      if (err.response?.status === 401) {
+        message.error("The remote server rejected the credentials — check the app-password.");
+      } else {
+        message.error("Could not connect to the remote IMAP account.");
+      }
+    },
+  });
+
+  const startMut = useMutation({
+    mutationFn: async (v: ConnForm) => {
+      const { data } = await apiClient.post<{ job_id: string; state: string }>(
+        "/admin/migrations/imap",
+        { ...connBody(v), to: v.to.trim() },
+      );
+      return data;
+    },
+    onSuccess: async (d) => {
+      message.success(`Migration started (job ${d.job_id}). Track progress in the list below.`);
+      await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
+      handleClose();
+    },
+    onError: (err: AxiosError<{ error?: string; existing_job_id?: string }>) => {
+      const body = err.response?.data;
+      if (err.response?.status === 409) {
+        message.error(`A migration is already running for this account (job ${body?.existing_job_id ?? "?"}).`);
+      } else if (err.response?.status === 401) {
+        message.error("The remote server rejected the credentials — check the app-password.");
+      } else {
+        message.error("Could not start the migration.");
+      }
+    },
+  });
+
+  function handleClose() {
+    setFolders(null);
+    form.resetFields();
+    onClose();
+  }
+
+  async function onProbe() {
+    // Probe only needs the connection fields, not the destination.
+    // validateFields rejects on invalid input — swallow it (AntD paints
+    // the field errors) so it doesn't surface as an unhandled rejection.
+    try {
+      const v = await form.validateFields(["host", "port", "starttls", "user", "password", "allow_private"]);
+      probeMut.mutate(v as ConnForm);
+    } catch {
+      /* field-level errors are shown inline by the form */
+    }
+  }
+
+  async function onStart() {
+    try {
+      const v = await form.validateFields();
+      startMut.mutate(v);
+    } catch {
+      /* field-level errors are shown inline by the form */
+    }
+  }
+
+  const columns = [
+    { title: "Remote folder", dataIndex: "name", key: "name" },
+    {
+      title: "Role",
+      dataIndex: "role",
+      key: "role",
+      render: (r: string) =>
+        r ? <Tag color={roleColor[r] ?? "default"}>{r}</Tag> : <Typography.Text type="secondary">—</Typography.Text>,
+    },
+    {
+      title: "Migrated",
+      key: "migrated",
+      render: (_: unknown, f: Folder) => {
+        if (!f.selectable) return <Tag>container (skipped)</Tag>;
+        if (f.role === "all") return <Tag color="default">skipped (duplicate of other folders)</Tag>;
+        return <Tag color="green">yes</Tag>;
+      },
+    },
+  ];
+
+  return (
+    <Drawer
+      title={
+        <Space>
+          <ImportOutlined /> Migrate IMAP mailbox
+        </Space>
+      }
+      width={620}
+      open={open}
+      onClose={handleClose}
+      destroyOnClose
+      extra={
+        <Space>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button
+            type="primary"
+            loading={startMut.isPending}
+            onClick={onStart}
+          >
+            Start migration
+          </Button>
+        </Space>
+      }
+    >
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 16 }}
+        message="App-password required"
+        description="Use a Google Workspace / Microsoft 365 app-password (not the account password). The remote mailbox is read-only during the pull; messages de-duplicate on Message-ID, so re-running resumes safely. The destination mailbox must already exist."
+      />
+
+      <Form form={form} layout="vertical" requiredMark="optional">
+        <Form.Item
+          name="host"
+          label="Remote IMAP host"
+          rules={[{ required: true, message: "e.g. imap.gmail.com or outlook.office365.com" }]}
+        >
+          <Input placeholder="imap.gmail.com" autoComplete="off" />
+        </Form.Item>
+
+        <Form.Item
+          name="user"
+          label="Remote login"
+          rules={[{ required: true, message: "the remote email address" }]}
+        >
+          <Input placeholder="old-account@company.com" autoComplete="off" />
+        </Form.Item>
+
+        <Form.Item
+          name="password"
+          label="App-password"
+          rules={[{ required: true, message: "app-password" }]}
+        >
+          <Input.Password placeholder="app-password" autoComplete="new-password" />
+        </Form.Item>
+
+        <Form.Item
+          name="to"
+          label="Destination mailbox"
+          rules={[{ required: true, message: "the local jabali mailbox to import into" }]}
+          extra="Must already exist on this server."
+        >
+          <Input placeholder="new-account@example.com" autoComplete="off" />
+        </Form.Item>
+
+        <Collapse
+          ghost
+          items={[
+            {
+              key: "adv",
+              label: "Advanced",
+              children: (
+                <>
+                  <Form.Item name="port" label="Port" extra="Leave blank for 993 (implicit TLS) / 143 (STARTTLS).">
+                    <InputNumber min={1} max={65535} style={{ width: "100%" }} placeholder="993" />
+                  </Form.Item>
+                  <Form.Item name="starttls" label="Use STARTTLS (port 143)" valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                  <Form.Item
+                    name="allow_private"
+                    label="Allow private/LAN host"
+                    valuePropName="checked"
+                    extra="Only enable when migrating from a server on a private network."
+                  >
+                    <Switch />
+                  </Form.Item>
+                </>
+              ),
+            },
+          ]}
+        />
+
+        <Button onClick={onProbe} loading={probeMut.isPending} style={{ marginBottom: 16 }}>
+          Preview folders
+        </Button>
+      </Form>
+
+      {folders && (
+        <Table<Folder>
+          size="small"
+          rowKey="name"
+          columns={columns}
+          dataSource={folders}
+          pagination={false}
+        />
+      )}
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## What

Admin **UI** for the IMAP mail migration (GH #390 Google Workspace / #374 M365, **phase A step 4c**), driving the 4b endpoints (#426).

- **`MigrateImapDrawer`** — connection form (remote host, login, app-password, destination mailbox; *Advanced*: port, STARTTLS, allow-private).
  - **Preview folders** → `POST /admin/migrations/imap/probe` → renders the remote folder map: name, SPECIAL-USE role tag, and a migrated/skipped column (`\All` and non-selectable containers flagged skipped, matching the fetcher).
  - **Start migration** → `POST /admin/migrations/imap` (202) → toasts the job id, invalidates the list; progress shows on the existing migration detail page (`state: restoring → done`).
- **`AdminMigrationsPage`** — a *Migrate IMAP mailbox* button mounts the drawer.

## Security

App-password is an `Input.Password` sent per-request — never stored in the job row (mirrors the backend, which holds it only transiently). Distinct from `CreateMigrationDrawer` (cpmove/SSH panel-account sources).

## Dependency

Runtime needs the 4b endpoints (**#426**) live — merge #426 first. This PR compiles/tests standalone (apiClient mocked).

## Test plan

- [x] Wire-contract vitest (real AntD Drawer/Form/Table, only apiClient mocked): probe payload + folder-map render (`\All` skipped), start payload with destination, validation blocks empty submit
- [x] `eslint` clean, `tsc -b` clean
- [ ] CI green
- [ ] Post-merge: operator drives a real Gmail/M365 app-password through the drawer on .86 → verify in Bulwark
