### PR TITLE
feat(automation): per-service health + WAN telemetry on /status (JAB-150)

### DIFF
--- a/panel-agent/internal/commands/system_net_telemetry.go
+++ b/panel-agent/internal/commands/system_net_telemetry.go
@@ -1,0 +1,171 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// netTelemetryParams tunes the sampling window. The collector reads
+// /proc/net/dev twice, WindowSeconds apart, and reports the aggregate WAN
+// throughput + packet loss over that window. Unlike system.network (which
+// keeps per-iface state across calls and needs a warm-up call), this is
+// fully self-contained, so a single stateless request — e.g. the public
+// automation status API — gets real numbers on the first hit.
+type netTelemetryParams struct {
+	WindowSeconds int `json:"window_seconds,omitempty"`
+}
+
+// NetTelemetry is the aggregated WAN telemetry over one sampling window.
+// Rates are BYTES per second, consistent with system.network's rx_bps /
+// tx_bps (also byte-rates). PacketLossPct is derived from interface rx
+// error+drop counters over the window — it reflects NIC/driver loss, NOT
+// ICMP path loss (the collector issues no egress ping).
+type NetTelemetry struct {
+	DownloadBps   uint64  `json:"download_bps"`
+	UploadBps     uint64  `json:"upload_bps"`
+	PacketLossPct float64 `json:"packet_loss_pct"`
+	WindowSeconds int     `json:"window_seconds"`
+	SampledAt     string  `json:"sampled_at"`
+}
+
+const (
+	netTelDefaultWindow = 3
+	netTelMinWindow     = 1
+	netTelMaxWindow     = 10
+	netTelCacheTTL      = 2 * time.Second
+)
+
+var (
+	// Single-flight guard: the mutex is held across the whole sampling
+	// window so two concurrent callers never run overlapping windows. A
+	// short result cache collapses back-to-back polls onto one sample
+	// rather than blocking each caller for a fresh window.
+	netTelMu     sync.Mutex
+	netTelLast   *NetTelemetry
+	netTelLastAt time.Time
+
+	// vars for tests: fixture reader, clock, and a ctx-aware wait.
+	netTelReadDev = func() (string, error) {
+		b, err := os.ReadFile(netDevPath)
+		return string(b), err
+	}
+	netTelNowFn = time.Now
+	netTelWait  = func(ctx context.Context, d time.Duration) error {
+		t := time.NewTimer(d)
+		defer t.Stop()
+		select {
+		case <-t.C:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+)
+
+func systemNetTelemetryHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p netTelemetryParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+		}
+	}
+	window := p.WindowSeconds
+	switch {
+	case window == 0:
+		window = netTelDefaultWindow
+	case window < netTelMinWindow:
+		window = netTelMinWindow
+	case window > netTelMaxWindow:
+		window = netTelMaxWindow
+	}
+
+	netTelMu.Lock()
+	defer netTelMu.Unlock()
+
+	// A very-recent sample is reused rather than re-blocking for another
+	// window — cheap protection against a burst of status polls.
+	if netTelLast != nil && netTelNowFn().Sub(netTelLastAt) < netTelCacheTTL {
+		cached := *netTelLast
+		return cached, nil
+	}
+
+	first, err := netTelReadDev()
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read %s: %v", netDevPath, err)}
+	}
+	start := netTelNowFn()
+	if err := netTelWait(ctx, time.Duration(window)*time.Second); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("sampling interrupted: %v", err)}
+	}
+	second, err := netTelReadDev()
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read %s: %v", netDevPath, err)}
+	}
+	end := netTelNowFn()
+
+	elapsed := end.Sub(start).Seconds()
+	if elapsed <= 0 {
+		elapsed = float64(window)
+	}
+
+	out := aggregateNetTelemetry(parseProcNetDev(first), parseProcNetDev(second), elapsed, window)
+	out.SampledAt = end.UTC().Format(time.RFC3339)
+
+	netTelLast = &out
+	netTelLastAt = end
+	return out, nil
+}
+
+// aggregateNetTelemetry sums the byte/packet/error/drop deltas across every
+// non-loopback interface between two /proc/net/dev samples. Counter resets
+// (NIC reset, rollover) collapse to 0 via the guarded subtraction rather
+// than casting a negative to a giant uint64.
+func aggregateNetTelemetry(before, after []procNetDevRow, elapsed float64, window int) NetTelemetry {
+	prev := make(map[string]procNetDevRow, len(before))
+	for _, r := range before {
+		prev[r.iface] = r
+	}
+	var rxBytes, txBytes, rxPackets, lostPackets uint64
+	for _, cur := range after {
+		if cur.iface == "lo" {
+			continue
+		}
+		p, ok := prev[cur.iface]
+		if !ok {
+			continue // iface appeared mid-window; no trustworthy delta
+		}
+		rxBytes += subCounter(cur.rxBytes, p.rxBytes)
+		txBytes += subCounter(cur.txBytes, p.txBytes)
+		rxPackets += subCounter(cur.rxPackets, p.rxPackets)
+		lostPackets += subCounter(cur.rxErrors, p.rxErrors) + subCounter(cur.rxDrop, p.rxDrop)
+	}
+	out := NetTelemetry{
+		DownloadBps:   uint64(float64(rxBytes) / elapsed),
+		UploadBps:     uint64(float64(txBytes) / elapsed),
+		WindowSeconds: window,
+	}
+	// Loss over the window = lost / (received + lost). Zero traffic → 0.
+	if total := rxPackets + lostPackets; total > 0 {
+		out.PacketLossPct = 100 * float64(lostPackets) / float64(total)
+	}
+	return out
+}
+
+// subCounter is rateDelta's sibling without the divide — guards against
+// counter resets by returning 0 when the counter went backwards.
+func subCounter(curr, prev uint64) uint64 {
+	if curr < prev {
+		return 0
+	}
+	return curr - prev
+}
+
+func init() {
+	Default.Register("system.net_telemetry", systemNetTelemetryHandler)
+}

--- a/panel-agent/internal/commands/system_net_telemetry_test.go
+++ b/panel-agent/internal/commands/system_net_telemetry_test.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// twoSampleDev returns a reader that hands out `first` then `second` on
+// successive calls, so the collector sees a real delta without touching
+// the host's /proc/net/dev.
+func twoSampleDev(first, second string) func() (string, error) {
+	n := 0
+	return func() (string, error) {
+		n++
+		if n == 1 {
+			return first, nil
+		}
+		return second, nil
+	}
+}
+
+// restoreNetTel snapshots the package-level sampling vars and clears the
+// single-flight cache so each test starts clean.
+func restoreNetTel(t *testing.T) {
+	t.Helper()
+	origRead, origNow, origWait := netTelReadDev, netTelNowFn, netTelWait
+	netTelMu.Lock()
+	netTelLast, netTelLastAt = nil, time.Time{}
+	netTelMu.Unlock()
+	t.Cleanup(func() {
+		netTelReadDev, netTelNowFn, netTelWait = origRead, origNow, origWait
+		netTelMu.Lock()
+		netTelLast, netTelLastAt = nil, time.Time{}
+		netTelMu.Unlock()
+	})
+}
+
+// A /proc/net/dev line has: iface: rxBytes rxPackets rxErrs rxDrop fifo
+// frame compressed multicast txBytes txPackets txErrs txDrop ...
+// (16 numeric columns). Only the columns we read need to be realistic.
+func devLine(iface string, rxBytes, rxPkts, rxErr, rxDrop, txBytes, txPkts uint64) string {
+	return iface + ": " +
+		u(rxBytes) + " " + u(rxPkts) + " " + u(rxErr) + " " + u(rxDrop) +
+		" 0 0 0 0 " +
+		u(txBytes) + " " + u(txPkts) + " 0 0 0 0 0 0\n"
+}
+
+func u(v uint64) string { b, _ := json.Marshal(v); return string(b) }
+
+func TestNetTelemetry_ComputesRatesAndLoss(t *testing.T) {
+	restoreNetTel(t)
+
+	header := "Inter-|   Receive ...\n face |bytes ...\n"
+	// lo must be excluded from the aggregate; eth0 carries the traffic.
+	first := header +
+		devLine("lo", 1000, 10, 0, 0, 1000, 10) +
+		devLine("eth0", 1_000_000, 1000, 5, 5, 500_000, 800)
+	second := header +
+		devLine("lo", 2000, 20, 0, 0, 2000, 20) +
+		devLine("eth0", 1_030_000, 1090, 6, 9, 515_000, 830)
+	// eth0 window deltas: rx bytes 30_000, tx 15_000, rx pkts 90,
+	// lost = (6-5)+(9-5) = 5. Over a 3s window.
+	netTelReadDev = twoSampleDev(first, second)
+	// Deterministic 3-second window via a fake clock.
+	base := time.Unix(1_700_000_000, 0)
+	calls := 0
+	netTelNowFn = func() time.Time {
+		// first=start, second=end(+3s); reused for cache checks.
+		calls++
+		if calls == 1 {
+			return base
+		}
+		return base.Add(3 * time.Second)
+	}
+	netTelWait = func(_ context.Context, _ time.Duration) error { return nil }
+
+	raw, err := systemNetTelemetryHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	got := raw.(NetTelemetry)
+	if got.WindowSeconds != netTelDefaultWindow {
+		t.Errorf("window = %d, want %d", got.WindowSeconds, netTelDefaultWindow)
+	}
+	if got.DownloadBps != 10_000 { // 30_000 bytes / 3s
+		t.Errorf("download_bps = %d, want 10000", got.DownloadBps)
+	}
+	if got.UploadBps != 5_000 { // 15_000 bytes / 3s
+		t.Errorf("upload_bps = %d, want 5000", got.UploadBps)
+	}
+	// loss = 5 / (90 + 5) * 100 ≈ 5.263%
+	if got.PacketLossPct < 5.2 || got.PacketLossPct > 5.3 {
+		t.Errorf("packet_loss_pct = %v, want ~5.26", got.PacketLossPct)
+	}
+	if got.SampledAt == "" {
+		t.Error("sampled_at must be set")
+	}
+}
+
+func TestNetTelemetry_CounterResetClampsToZero(t *testing.T) {
+	restoreNetTel(t)
+	header := "h\nh\n"
+	// second < first (NIC reset) → deltas clamp to 0, not a huge uint.
+	first := header + devLine("eth0", 5_000_000, 5000, 0, 0, 5_000_000, 5000)
+	second := header + devLine("eth0", 10, 1, 0, 0, 10, 1)
+	netTelReadDev = twoSampleDev(first, second)
+	base := time.Unix(1_700_000_000, 0)
+	first_call := true
+	netTelNowFn = func() time.Time {
+		if first_call {
+			first_call = false
+			return base
+		}
+		return base.Add(3 * time.Second)
+	}
+	netTelWait = func(_ context.Context, _ time.Duration) error { return nil }
+
+	raw, err := systemNetTelemetryHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	got := raw.(NetTelemetry)
+	if got.DownloadBps != 0 || got.UploadBps != 0 {
+		t.Errorf("reset should clamp rates to 0, got dl=%d ul=%d", got.DownloadBps, got.UploadBps)
+	}
+	if got.PacketLossPct != 0 {
+		t.Errorf("reset should give 0 loss, got %v", got.PacketLossPct)
+	}
+}
+
+func TestNetTelemetry_WindowClamped(t *testing.T) {
+	restoreNetTel(t)
+	netTelReadDev = twoSampleDev("h\nh\n", "h\nh\n")
+	netTelWait = func(_ context.Context, _ time.Duration) error { return nil }
+
+	raw, err := systemNetTelemetryHandler(context.Background(), json.RawMessage(`{"window_seconds":999}`))
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if got := raw.(NetTelemetry).WindowSeconds; got != netTelMaxWindow {
+		t.Errorf("window clamped to %d, want %d", got, netTelMaxWindow)
+	}
+}

--- a/panel-agent/internal/commands/system_network.go
+++ b/panel-agent/internal/commands/system_network.go
@@ -158,9 +158,11 @@ type procNetDevRow struct {
 	rxBytes   uint64
 	rxPackets uint64
 	rxErrors  uint64
+	rxDrop    uint64
 	txBytes   uint64
 	txPackets uint64
 	txErrors  uint64
+	txDrop    uint64
 }
 
 // parseProcNetDev reads /proc/net/dev. Format (after the two header
@@ -187,9 +189,11 @@ func parseProcNetDev(content string) []procNetDevRow {
 		row.rxBytes, _ = strconv.ParseUint(fields[0], 10, 64)
 		row.rxPackets, _ = strconv.ParseUint(fields[1], 10, 64)
 		row.rxErrors, _ = strconv.ParseUint(fields[2], 10, 64)
+		row.rxDrop, _ = strconv.ParseUint(fields[3], 10, 64)
 		row.txBytes, _ = strconv.ParseUint(fields[8], 10, 64)
 		row.txPackets, _ = strconv.ParseUint(fields[9], 10, 64)
 		row.txErrors, _ = strconv.ParseUint(fields[10], 10, 64)
+		row.txDrop, _ = strconv.ParseUint(fields[11], 10, 64)
 		out = append(out, row)
 	}
 	return out

--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -290,6 +290,7 @@ func (m *automationMetrics) handle(c *gin.Context) {
 		info     json.RawMessage
 		services json.RawMessage
 		cpu      json.RawMessage
+		netRaw   json.RawMessage
 		errs     = map[string]string{}
 	)
 	fetch := func(name, cmd string, dst *json.RawMessage) {
@@ -310,6 +311,10 @@ func (m *automationMetrics) handle(c *gin.Context) {
 	fetch("info", "system.info", &info)
 	fetch("services", "system.service_details", &services)
 	fetch("cpu", "system.cpu_usage", &cpu)
+	// JAB-150: WAN throughput + packet loss for the Sounder Monitor. The
+	// collector samples over a short window, so this leg is the slow one;
+	// the 8s per-fetch timeout above bounds it.
+	fetch("net", "system.net_telemetry", &netRaw)
 	_ = g.Wait()
 
 	out := gin.H{
@@ -322,9 +327,17 @@ func (m *automationMetrics) handle(c *gin.Context) {
 	}
 	if services != nil {
 		out["services"] = services
+		// Normalized per-service health for the Sounder Monitor (JAB-150).
+		// Additive: existing consumers keep reading the raw "services".
+		if health := normalizeServiceHealth(services); len(health) > 0 {
+			out["service_health"] = health
+		}
 	}
 	if cpu != nil {
 		out["cpu"] = cpu
+	}
+	if netRaw != nil {
+		out["net"] = netRaw
 	}
 	if len(errs) > 0 {
 		out["errors"] = errs
@@ -334,4 +347,105 @@ func (m *automationMetrics) handle(c *gin.Context) {
 	m.cached, m.cachedAt = out, time.Now()
 	m.mu.Unlock()
 	c.JSON(http.StatusOK, out)
+}
+
+// agentServiceDetail is the subset of the agent's system.service_details
+// ServiceDetail that the normalized health view needs. Declared locally so
+// panel-api doesn't import the agent's command package.
+type agentServiceDetail struct {
+	Unit          string `json:"unit"`
+	Active        string `json:"active"`
+	Sub           string `json:"sub"`
+	LoadState     string `json:"load_state"`
+	UnitFileState string `json:"unit_file_state"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+}
+
+// automationServiceHealth is the normalized, monitor-friendly health row
+// the Sounder Monitor consumes (JAB-150). Status is one of healthy |
+// degraded | failed | stopped; reason carries the systemd sub-state for
+// context (e.g. "running", "dead", "failed").
+type automationServiceHealth struct {
+	Name          string `json:"name"`
+	Unit          string `json:"unit"`
+	Status        string `json:"status"`
+	Reason        string `json:"reason,omitempty"`
+	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
+	LastChecked   string `json:"last_checked"`
+}
+
+// automationLogicalServices maps a stable logical service name (what the
+// monitor keys on, forward-compatible across host layout changes) to the
+// systemd unit that backs it. Only units the agent actually reports get a
+// row — the list is intentionally a superset. Units with no clean single
+// systemd unit on jabali hosts (php-fpm runs as per-user jabali-fpm@<user>
+// slices per ADR-0025; backups run via agent backup.run + per-user timers,
+// not a daemon; crowdsec is not in the agent probe allowlist) are omitted
+// rather than reported as perpetually "stopped".
+var automationLogicalServices = []struct{ Name, Unit string }{
+	{"web", "nginx.service"},
+	{"database", "mariadb.service"},
+	{"cache", "redis-server.service"},
+	{"mail", "jabali-stalwart.service"},
+	{"webmail", "jabali-webmail.service"},
+	{"identity", "jabali-kratos.service"},
+	{"dns", "pdns.service"},
+	{"docker", "docker.service"},
+	{"panel", "jabali-panel.service"},
+	{"agent", "jabali-agent.service"},
+	{"ssh", "ssh.service"},
+}
+
+// normalizeServiceHealth folds the raw system.service_details payload into
+// the normalized health view. Capability-aware: a logical service whose
+// unit is absent, not-found, or masked on this host is omitted so the
+// monitor only ever sees actions/services that exist here. Returns nil on
+// a malformed payload (the raw "services" field is still emitted).
+func normalizeServiceHealth(raw json.RawMessage) []automationServiceHealth {
+	var payload struct {
+		Services []agentServiceDetail `json:"services"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil
+	}
+	byUnit := make(map[string]agentServiceDetail, len(payload.Services))
+	for _, d := range payload.Services {
+		byUnit[d.Unit] = d
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	out := make([]automationServiceHealth, 0, len(automationLogicalServices))
+	for _, ls := range automationLogicalServices {
+		d, ok := byUnit[ls.Unit]
+		if !ok {
+			continue // agent didn't report it → not installed here
+		}
+		if d.LoadState == "not-found" || d.LoadState == "masked" {
+			continue // capability-aware omit
+		}
+		out = append(out, automationServiceHealth{
+			Name:          ls.Name,
+			Unit:          ls.Unit,
+			Status:        serviceHealthStatus(d.Active),
+			Reason:        d.Sub,
+			UptimeSeconds: d.UptimeSeconds,
+			LastChecked:   now,
+		})
+	}
+	return out
+}
+
+// serviceHealthStatus maps a systemd ActiveState to the normalized status
+// vocabulary. activating/deactivating are transient → degraded so a
+// mid-restart blip doesn't page the monitor as a hard failure.
+func serviceHealthStatus(active string) string {
+	switch active {
+	case "active", "reloading":
+		return "healthy"
+	case "failed":
+		return "failed"
+	case "activating", "deactivating":
+		return "degraded"
+	default: // inactive, dead, unknown
+		return "stopped"
+	}
 }

--- a/panel-api/internal/api/automation_status_shape_test.go
+++ b/panel-api/internal/api/automation_status_shape_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// TestAutomationStatus_NormalizedServiceHealthAndNet locks the JAB-150
+// shaping: the raw "services" payload is folded into a normalized
+// "service_health" array (capability-aware) and the net_telemetry leg
+// surfaces as "net", while the pre-existing raw fields stay present.
+func TestAutomationStatus_NormalizedServiceHealthAndNet(t *testing.T) {
+	ag := agent.NewMockClient()
+	ag.On("system.info", map[string]any{"hostname": "mx"})
+	ag.On("system.cpu_usage", map[string]any{"percent": 12.5})
+	ag.On("system.net_telemetry", map[string]any{
+		"download_bps": 10000, "upload_bps": 5000,
+		"packet_loss_pct": 0.5, "window_seconds": 3,
+	})
+	ag.On("system.service_details", map[string]any{
+		"services": []map[string]any{
+			{"unit": "nginx.service", "active": "active", "sub": "running", "load_state": "loaded", "uptime_seconds": 3600},
+			{"unit": "mariadb.service", "active": "failed", "sub": "failed", "load_state": "loaded"},
+			{"unit": "jabali-stalwart.service", "active": "activating", "sub": "start", "load_state": "loaded"},
+			{"unit": "jabali-webmail.service", "active": "inactive", "sub": "dead", "load_state": "loaded"},
+			// docker present in the reply but not installed here → omitted.
+			{"unit": "docker.service", "active": "inactive", "sub": "dead", "load_state": "not-found"},
+		},
+	})
+
+	m := newAutomationMetrics(ag)
+	w := doStatus(m)
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	// Raw back-compat fields still present.
+	for _, k := range []string{"system", "services", "cpu", "net"} {
+		if _, ok := body[k]; !ok {
+			t.Errorf("expected raw field %q in payload", k)
+		}
+	}
+
+	var health []automationServiceHealth
+	if err := json.Unmarshal(body["service_health"], &health); err != nil {
+		t.Fatalf("decode service_health: %v", err)
+	}
+	byName := map[string]automationServiceHealth{}
+	for _, h := range health {
+		byName[h.Name] = h
+	}
+
+	if got := byName["web"].Status; got != "healthy" {
+		t.Errorf("web status = %q, want healthy", got)
+	}
+	if got := byName["web"].UptimeSeconds; got != 3600 {
+		t.Errorf("web uptime = %d, want 3600", got)
+	}
+	if got := byName["database"].Status; got != "failed" {
+		t.Errorf("database status = %q, want failed", got)
+	}
+	if got := byName["mail"].Status; got != "degraded" {
+		t.Errorf("mail (activating) status = %q, want degraded", got)
+	}
+	if got := byName["webmail"].Status; got != "stopped" {
+		t.Errorf("webmail (inactive) status = %q, want stopped", got)
+	}
+	if _, ok := byName["docker"]; ok {
+		t.Error("docker is not-found on this host and must be omitted (capability-aware)")
+	}
+	if byName["web"].LastChecked == "" {
+		t.Error("each health row must carry last_checked")
+	}
+
+	// net telemetry passthrough shape.
+	var net map[string]any
+	if err := json.Unmarshal(body["net"], &net); err != nil {
+		t.Fatalf("decode net: %v", err)
+	}
+	if net["download_bps"] == nil || net["packet_loss_pct"] == nil {
+		t.Errorf("net telemetry missing fields: %v", net)
+	}
+}
+
+// TestAutomationStatus_MalformedServicesStillEmitsRaw ensures a bad
+// service_details payload doesn't drop the raw field or panic — normalized
+// health is simply omitted.
+func TestAutomationStatus_MalformedServicesStillEmitsRaw(t *testing.T) {
+	ag := agent.NewMockClient()
+	ag.On("system.info", map[string]any{"hostname": "mx"})
+	ag.On("system.cpu_usage", map[string]any{"percent": 1})
+	ag.On("system.net_telemetry", map[string]any{"download_bps": 0})
+	ag.On("system.service_details", "not-an-object")
+
+	m := newAutomationMetrics(ag)
+	w := doStatus(m)
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]json.RawMessage
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if _, ok := body["services"]; !ok {
+		t.Error("raw services must still be emitted on malformed payload")
+	}
+	if _, ok := body["service_health"]; ok {
+		t.Error("service_health must be omitted when the payload can't be normalized")
+	}
+}


### PR DESCRIPTION
## What

Extends the read-only public automation status endpoint `GET /api/v1/automation/status` (scope `read:status`) for the **Sounder Monitor** (SND-80/81). All **additive** — the existing raw `system` / `services` / `cpu` fields are byte-unchanged, so existing read tokens keep working.

Two new pieces:

### 1. Agent collector `system.net_telemetry`
Samples `/proc/net/dev` twice, a short window apart, and returns aggregate WAN telemetry:
```json
{"download_bps":..., "upload_bps":..., "packet_loss_pct":..., "window_seconds":3, "sampled_at":"..."}
```
- Self-contained (unlike `system.network`, which is stateful across calls and needs a warm-up hit) so a single stateless status request gets real numbers on the first poll.
- **Single-flight**: the sampling mutex is held across the whole window so two concurrent callers never run overlapping windows; a 2s result cache collapses burst polls onto one sample.
- Rates are **bytes/sec** (consistent with `system.network`'s `rx_bps`/`tx_bps`).
- `packet_loss_pct` is derived from interface rx **error+drop** counters over the window (NIC/driver loss). See _Deviations_ below.
- ctx-aware wait so a cancelled status request doesn't block a full window.

### 2. Panel-api normalized `service_health[]` + `net{}`
`automationMetrics.handle` folds the raw `system.service_details` payload into a monitor-friendly array:
```json
"service_health":[{"name":"web","unit":"nginx.service","status":"healthy","reason":"running","uptime_seconds":3600,"last_checked":"..."}]
```
- Status vocabulary: `active`→`healthy`, `failed`→`failed`, `activating`/`deactivating`→`degraded`, else `stopped`.
- **Capability-aware**: a logical service whose unit is absent / `not-found` / `masked` on the host is omitted, so the monitor only sees services that exist here.
- `net{}` carries the new collector output.

## Deviations from the original recon plan (please sanity-check)
- **Logical service set**: plan named `web, php-fpm, database, mail, dns, crowdsec, docker, backup`. Recon showed 3 of those have no clean single systemd unit on jabali hosts, so they're **omitted** rather than reported as perpetually stopped: `php-fpm` (per-user `jabali-fpm@<user>` slices, ADR-0025; globals are masked), `backup` (runs via agent `backup.run` + per-user timers, no daemon), `crowdsec` (not in the agent probe allowlist — adding it is a security-boundary change I kept out of this PR). The mapping is a superset and adding a service later is one line. Mapped units that DO exist: web/database/cache/mail/webmail/identity/dns/docker/panel/agent/ssh.
- **Packet loss** uses `/proc/net/dev` drop+error counters, **not** an ICMP ping. Ping needs a target host + egress + `CAP_NET_RAW` and false-alarms when egress is filtered; the drop-counter signal is self-contained and deterministic. Can add an opt-in ping target later if the monitor needs path loss.
- New keys are `service_health` and `net` (raw `services` stays under `services` for back-compat — can't have two `services` keys).

## Tests
- Agent: rate/loss math, counter-reset clamp-to-zero, window clamp.
- Panel-api (via `agent.MockClient`): normalized statuses, capability-aware omit of a `not-found` unit, `net` passthrough, malformed-payload keeps raw `services` + omits `service_health`.

## Refs
JAB-150. Does not close the issue.