### PR TITLE
fix(python-apps): only offer installed interpreters + friendlier restart (GH #357)

### DIFF
--- a/panel-agent/internal/commands/python_app_lifecycle.go
+++ b/panel-agent/internal/commands/python_app_lifecycle.go
@@ -34,6 +34,16 @@ func pythonAppControlHandler(ctx context.Context, params json.RawMessage) (any, 
 	unit := pythonAppUnitName(p.AppID)
 	switch p.Action {
 	case "start", "stop", "restart":
+		// GH #357: if the app never finished provisioning (its build failed
+		// at the venv/pip step, before the unit was written) the raw
+		// systemctl error is a cryptic "Unit ... not found". Detect the
+		// missing unit and return an actionable message instead.
+		if _, statErr := os.Stat(filepath.Join(pythonAppUnitDir, unit)); statErr != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeFailedPrecondition,
+				Message: "app is not provisioned — its build has not completed or failed (check the app logs / requirements). It rebuilds automatically once the problem is fixed.",
+			}
+		}
 		if out, err := exec.CommandContext(ctx, "systemctl", p.Action, unit).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemctl %s %s: %v: %s", p.Action, unit, err, strings.TrimSpace(string(out)))}
 		}

--- a/panel-agent/internal/commands/python_app_versions.go
+++ b/panel-agent/internal/commands/python_app_versions.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// pythonCandidateVersions is the range of interpreters the probe looks for.
+// The panel must only ever offer versions that resolve to a real python3.X
+// binary on THIS host — offering an absent one (e.g. 3.11 on a 3.13-only
+// Debian 13 box) is what left apps stuck pending→failed and made Restart
+// return a cryptic "Unit not found" (GH #357: the venv step shells out to
+// `python<ver> -m venv` and dies before the systemd unit is ever written).
+var pythonCandidateVersions = []string{"3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"}
+
+// pythonLookPath is exec.LookPath, indirected so tests can stub which
+// interpreters "exist" without touching the host PATH.
+var pythonLookPath = exec.LookPath
+
+// PythonVersionsResponse reports the interpreters actually installed here.
+type PythonVersionsResponse struct {
+	Versions []string `json:"versions"` // installed, ascending, e.g. ["3.11","3.13"]
+	Default  string   `json:"default"`  // newest installed; "" when none
+}
+
+func pythonVersionsHandler(_ context.Context, _ json.RawMessage) (any, error) {
+	found := make([]string, 0, len(pythonCandidateVersions))
+	for _, v := range pythonCandidateVersions {
+		if _, err := pythonLookPath("python" + v); err == nil {
+			found = append(found, v)
+		}
+	}
+	sort.Slice(found, func(i, j int) bool { return pyVerLess(found[i], found[j]) })
+	resp := PythonVersionsResponse{Versions: found}
+	if len(found) > 0 {
+		resp.Default = found[len(found)-1] // newest installed
+	}
+	return resp, nil
+}
+
+// pyVerLess orders "3.9" before "3.10" numerically rather than lexically.
+func pyVerLess(a, b string) bool {
+	amaj, amin := splitPyVer(a)
+	bmaj, bmin := splitPyVer(b)
+	if amaj != bmaj {
+		return amaj < bmaj
+	}
+	return amin < bmin
+}
+
+func splitPyVer(v string) (int, int) {
+	parts := strings.SplitN(v, ".", 2)
+	maj, _ := strconv.Atoi(parts[0])
+	minor := 0
+	if len(parts) == 2 {
+		minor, _ = strconv.Atoi(parts[1])
+	}
+	return maj, minor
+}
+
+func init() {
+	Default.Register("app.python.versions", pythonVersionsHandler)
+}

--- a/panel-agent/internal/commands/python_app_versions_test.go
+++ b/panel-agent/internal/commands/python_app_versions_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestPythonVersions_ReportsInstalledAndNewestDefault(t *testing.T) {
+	orig := pythonLookPath
+	t.Cleanup(func() { pythonLookPath = orig })
+	// Only 3.11 and 3.13 "installed"; 3.9 present too, to prove numeric order.
+	installed := map[string]bool{"python3.9": true, "python3.11": true, "python3.13": true}
+	pythonLookPath = func(file string) (string, error) {
+		if installed[file] {
+			return "/usr/bin/" + file, nil
+		}
+		return "", exec.ErrNotFound
+	}
+
+	raw, err := pythonVersionsHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	got := raw.(PythonVersionsResponse)
+	want := []string{"3.9", "3.11", "3.13"} // numeric ascending, not lexical
+	if len(got.Versions) != len(want) {
+		t.Fatalf("versions = %v, want %v", got.Versions, want)
+	}
+	for i := range want {
+		if got.Versions[i] != want[i] {
+			t.Errorf("versions[%d] = %q, want %q (%v)", i, got.Versions[i], want[i], got.Versions)
+		}
+	}
+	if got.Default != "3.13" {
+		t.Errorf("default = %q, want 3.13 (newest)", got.Default)
+	}
+}
+
+func TestPythonVersions_NoneInstalled(t *testing.T) {
+	orig := pythonLookPath
+	t.Cleanup(func() { pythonLookPath = orig })
+	pythonLookPath = func(string) (string, error) { return "", errors.New("nope") }
+
+	raw, err := pythonVersionsHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	got := raw.(PythonVersionsResponse)
+	if len(got.Versions) != 0 {
+		t.Errorf("expected no versions, got %v", got.Versions)
+	}
+	if got.Default != "" {
+		t.Errorf("default must be empty when none installed, got %q", got.Default)
+	}
+}

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"regexp"
 	"strings"
@@ -37,6 +38,7 @@ func RegisterPythonAppRoutes(g *gin.RouterGroup, cfg PythonAppHandlerConfig) {
 	grp := g.Group("/python-apps")
 	grp.Use(h.requireEnabled)
 	grp.GET("", h.list)
+	grp.GET("/versions", h.versions)
 	grp.POST("", h.create)
 	grp.GET("/:id", h.get)
 	grp.DELETE("/:id", h.delete)
@@ -148,6 +150,18 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 	}
 	if !pyVersionRe.MatchString(req.PythonVersion) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_python_version"})
+		return
+	}
+	// GH #357: reject a version whose interpreter isn't installed on this
+	// host, echoing the installed list — instead of accepting it and letting
+	// the app die pending→failed at the venv step (which shells out to
+	// python<ver>) with a cryptic "Unit not found" on the next Restart.
+	if avail, derr := h.installedPythonVersions(c.Request.Context()); derr == nil && len(avail) > 0 && !containsStr(avail, req.PythonVersion) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":     "python_version_not_available",
+			"detail":    "Python " + req.PythonVersion + " is not installed on this server",
+			"available": avail,
+		})
 		return
 	}
 	if req.AppType != "wsgi" && req.AppType != "asgi" {
@@ -377,4 +391,48 @@ func envMapToRows(m map[string]string) []models.PythonAppEnv {
 		rows = append(rows, models.PythonAppEnv{ID: ulid.Make().String(), Key: k, Value: v})
 	}
 	return rows
+}
+
+// versions lists the Python interpreters installed on this host so the UI
+// only ever offers a version that will actually build (GH #357).
+func (h *pythonAppHandler) versions(c *gin.Context) {
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusOK, gin.H{"versions": []string{}, "default": ""})
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "app.python.versions", nil)
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	c.Data(http.StatusOK, "application/json", raw)
+}
+
+// installedPythonVersions asks the agent which python3.X interpreters exist.
+// Fail-open: on any agent/probe error the caller skips the create-time gate
+// rather than blocking creation when the probe is unavailable.
+func (h *pythonAppHandler) installedPythonVersions(ctx context.Context) ([]string, error) {
+	if h.cfg.Agent == nil {
+		return nil, nil
+	}
+	raw, err := h.cfg.Agent.Call(ctx, "app.python.versions", nil)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Versions []string `json:"versions"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, err
+	}
+	return res.Versions, nil
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
 }

--- a/panel-api/internal/api/python_apps_version_gate_test.go
+++ b/panel-api/internal/api/python_apps_version_gate_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+// createCtx builds a gin context carrying claims + a JSON create body.
+func createCtx(t *testing.T, body map[string]any) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	b, _ := json.Marshal(body)
+	c.Request = httptest.NewRequest("POST", "/python-apps", bytes.NewReader(b))
+	c.Request.Header.Set("Content-Type", "application/json")
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+	return c, w
+}
+
+// TestCreate_RejectsUninstalledPythonVersion locks the GH #357 gate: the
+// create handler bounces a version whose interpreter isn't on the host —
+// before any domain/package work — echoing the installed set.
+func TestCreate_RejectsUninstalledPythonVersion(t *testing.T) {
+	ag := agent.NewMockClient()
+	ag.On("app.python.versions", map[string]any{"versions": []string{"3.13"}, "default": "3.13"})
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Agent: ag}}
+
+	c, w := createCtx(t, map[string]any{
+		"domain_id":      "dom1",
+		"name":           "app",
+		"python_version": "3.11", // not installed → must be rejected
+		"app_root":       "domains/x/app",
+		"app_type":       "wsgi",
+		"entrypoint":     "app:app",
+		"base_uri":       "/",
+	})
+	h.create(c)
+
+	if w.Code != 400 {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	var body struct {
+		Error     string   `json:"error"`
+		Available []string `json:"available"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Error != "python_version_not_available" {
+		t.Errorf("error = %q, want python_version_not_available", body.Error)
+	}
+	if len(body.Available) != 1 || body.Available[0] != "3.13" {
+		t.Errorf("available = %v, want [3.13]", body.Available)
+	}
+}
+
+// TestCreate_VersionGateFailsOpen ensures an unavailable probe (agent nil /
+// error) does NOT block creation on the version check — the request falls
+// through to the normal path (which 404s here on the missing domain repo).
+func TestCreate_VersionGateFailsOpen(t *testing.T) {
+	// Agent that errors on the probe → gate skipped (fail-open).
+	ag := agent.NewMockClient() // no On() → returns unknown_command error
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Agent: ag}}
+
+	c, w := createCtx(t, map[string]any{
+		"domain_id":      "dom1",
+		"name":           "app",
+		"python_version": "3.11",
+		"app_root":       "domains/x/app",
+		"app_type":       "wsgi",
+		"entrypoint":     "app:app",
+		"base_uri":       "/",
+	})
+	// Domains repo is nil; a fail-open gate lets execution reach the domain
+	// lookup, which panics on nil. Guard so the test asserts intent without
+	// wiring every repo: we only care that it did NOT 400 on the version.
+	defer func() { _ = recover() }()
+	h.create(c)
+	if w.Code == 400 {
+		var body struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &body)
+		if body.Error == "python_version_not_available" {
+			t.Error("gate must fail-open when the probe is unavailable")
+		}
+	}
+}
+
+// TestVersionsEndpoint_NoAgentReturnsEmpty verifies the versions endpoint
+// degrades to an empty list rather than erroring when no agent is wired.
+func TestVersionsEndpoint_NoAgentReturnsEmpty(t *testing.T) {
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{}}
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/python-apps/versions", nil)
+	h.versions(c)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body struct {
+		Versions []string `json:"versions"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if len(body.Versions) != 0 {
+		t.Errorf("versions = %v, want empty", body.Versions)
+	}
+}

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -17,7 +17,7 @@ import {
 import { ReloadOutlined, PauseCircleOutlined, FileTextOutlined, DeleteOutlined, SettingOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
 import { PythonAppEnvDrawer } from "./PythonAppEnvDrawer";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -28,6 +28,7 @@ import {
   useCreatePythonApp,
   useDeletePythonApp,
   usePythonApps,
+  usePythonVersions,
 } from "./usePythonApps";
 
 type DomainRow = { id: string; name: string };
@@ -44,6 +45,16 @@ export function PythonAppsPage() {
   const { message } = App.useApp();
   const apps = usePythonApps();
   const create = useCreatePythonApp();
+  const pyVersions = usePythonVersions();
+  // Only offer installed interpreters; fall back to the common trio only if
+  // the probe is unavailable (the API still gates the final choice, GH #357).
+  const versionOptions = useMemo(
+    () =>
+      pyVersions.data?.versions && pyVersions.data.versions.length > 0
+        ? pyVersions.data.versions
+        : ["3.11", "3.12", "3.13"],
+    [pyVersions.data],
+  );
   const del = useDeletePythonApp();
   const control = useControlPythonApp();
 
@@ -62,6 +73,16 @@ export function PythonAppsPage() {
 
   const [createOpen, setCreateOpen] = useState(false);
   const [form] = Form.useForm<CreatePythonAppInput>();
+  // When the create dialog opens, default the Python version to the newest
+  // interpreter actually installed on this host.
+  useEffect(() => {
+    if (!createOpen) return;
+    const def =
+      pyVersions.data?.default || versionOptions[versionOptions.length - 1];
+    if (def && !form.getFieldValue("python_version")) {
+      form.setFieldValue("python_version", def);
+    }
+  }, [createOpen, pyVersions.data, versionOptions, form]);
   const [logsApp, setLogsApp] = useState<PythonApp | null>(null);
   const [logsText, setLogsText] = useState("");
   const [envApp, setEnvApp] = useState<PythonApp | null>(null);
@@ -182,7 +203,7 @@ export function PythonAppsPage() {
         okText="Create"
         confirmLoading={create.isPending}
       >
-        <Form form={form} layout="vertical" initialValues={{ app_type: "wsgi", python_version: "3.11", base_uri: "/" }}>
+        <Form form={form} layout="vertical" initialValues={{ app_type: "wsgi", base_uri: "/" }}>
           <Form.Item name="name" label="Name" rules={[{ required: true }]}>
             <Input placeholder="My API" />
           </Form.Item>
@@ -200,7 +221,9 @@ export function PythonAppsPage() {
             <Form.Item name="python_version" label="Python" rules={[{ required: true }]}>
               <Select
                 style={{ width: 120 }}
-                options={["3.11", "3.12", "3.13"].map((v) => ({ value: v, label: v }))}
+                loading={pyVersions.isLoading}
+                options={versionOptions.map((v) => ({ value: v, label: v }))}
+                notFoundContent="No Python runtime installed on this server"
               />
             </Form.Item>
             <Form.Item name="app_type" label="Type" rules={[{ required: true }]}>

--- a/panel-ui/src/shells/user/python-apps/usePythonApps.ts
+++ b/panel-ui/src/shells/user/python-apps/usePythonApps.ts
@@ -108,3 +108,20 @@ export function useUpdatePythonAppEnv() {
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
   });
 }
+
+export type PythonVersions = { versions: string[]; default: string };
+
+// GH #357: the create dialog must only offer interpreters that are actually
+// installed on this host, so an app can never be created against a python
+// that isn't there (which failed silently at the venv step).
+export function usePythonVersions() {
+  return useQuery({
+    queryKey: ["python-app-versions"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<PythonVersions>(
+        "/python-apps/versions",
+      );
+      return data;
+    },
+  });
+}


### PR DESCRIPTION
## Root cause (GH #357)

Reported: a Python app went **pending → failed** with "nothing in logs", and clicking **Restart** flashed:
```
agent: internal: systemctl restart jabali-app-<ULID>.service: exit status 5:
Failed to restart ...: Unit jabali-app-<ULID>.service not found.
```

Traced the full chain:
1. The create dialog **hardcoded** the version dropdown to `["3.11","3.12","3.13"]`, default **3.11** (`PythonAppsPage.tsx`).
2. The reporter's host (Debian 13) ships only **python3.13**. Reproduced on .86: `python3.11 … MISSING`, only `python3.13`.
3. Reconciler → `app.python.apply` runs `python3.11 -m venv` → command-not-found → returns **before** the systemd unit is written (unit write is a later step).
4. App → `failed`, `jabali-app-<ULID>.service` never created.
5. **Restart** → `app.python.control` runs `systemctl restart <unit>` blindly → exit 5 **"Unit not found"** = the flashed error.

It's a create-time validation gap: the API only regex-checked the version *format*, never whether the interpreter exists.

## Fix

- **Agent** — new probe `app.python.versions`: returns the `python3.X` interpreters actually installed (numeric order, newest = default). `pythonLookPath` indirected for tests.
- **Agent** — `app.python.control` now stats the unit file before start/stop/restart and returns an actionable `failed_precondition` ("app is not provisioned — its build failed…") instead of the raw systemctl "Unit not found".
- **API** — `GET /python-apps/versions` exposes the probe; `create()` rejects a version whose interpreter isn't installed (`400 python_version_not_available` + `available[]`) rather than accepting it into a silent pending→failed. **Fail-open** if the probe is unavailable (agent down) so creation isn't blocked by a flaky probe.
- **UI** — the create dialog fills the dropdown from the probe and defaults to the newest installed interpreter, so an absent version can't be picked. Falls back to the static trio only if the probe returns nothing (API still gates the final choice).

The `last_error`-on-hover Tooltip for failed apps is already on `main` (earlier #357 work) — the reporter's box just predates it; deploying current main restores the reason on hover.

## Tests
- Agent: numeric ordering (`3.9 < 3.10`), newest default, none-installed empty.
- API: reject uninstalled version (+ echo available), fail-open when probe errors, no-agent versions endpoint returns empty.
- panel-ui `tsc -b` + eslint clean.

## Refs
GH #357. Does not close the issue (operator to verify on their box after deploy).