### PR TITLE
feat(migrate): Plesk source foundation — Discoverer scaffold + registry (GH #429)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -49,6 +49,7 @@ import (
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 )
 
 const (

--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -1,0 +1,72 @@
+package plesk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// DescribeAccount returns a manifest scaffold for one Plesk
+// subscription. Step 1 validates the subscription exists on the source
+// and returns an empty-but-valid manifest (SchemaVersion + Source). The
+// per-area builders (Domains via `plesk bin domain --info`, Databases
+// via `plesk bin database --info`, DNS via `plesk bin dns --info`,
+// Cron, then WordPress + mail + customers/packages) ship in follow-up
+// steps — the same incremental shape the directadmin package took, so
+// the registry + admin REST plumbing can wire Plesk now.
+func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, accountID string) (*migrate.AccountManifest, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("DescribeAccount: wrong session type")
+	}
+	if accountID == "" {
+		return nil, errors.New("DescribeAccount: accountID empty")
+	}
+	host := ""
+	if s.client != nil {
+		host = s.client.RemoteAddr().String()
+	}
+
+	// Validate the subscription exists on the source. `plesk bin
+	// subscription --info <name>` exits non-zero for an unknown
+	// subscription. When the operator supplied an SSH principal rather
+	// than a subscription name, auto-pivot to the sole subscription on a
+	// single-tenant source; a multi-tenant source errors with the list.
+	probe := fmt.Sprintf("plesk bin subscription --info '%s'",
+		strings.ReplaceAll(accountID, "'", `'\''`))
+	if _, err := s.run(ctx, d.CommandTimeout, probe); err != nil {
+		accounts, listErr := d.ListAccounts(ctx, s)
+		if listErr != nil {
+			return nil, fmt.Errorf("subscription %q not found on source and auto-detect failed: %w", accountID, listErr)
+		}
+		switch len(accounts) {
+		case 0:
+			return nil, fmt.Errorf("no Plesk subscriptions found on source; supplied %q is not a subscription", accountID)
+		case 1:
+			accountID = accounts[0].ID
+		default:
+			names := make([]string, 0, len(accounts))
+			for _, a := range accounts {
+				names = append(names, a.ID)
+			}
+			return nil, fmt.Errorf("subscription %q not found; pick one of: %s", accountID, strings.Join(names, ", "))
+		}
+	}
+
+	return &migrate.AccountManifest{
+		SchemaVersion: migrate.ManifestSchemaVersion,
+		Source: migrate.SourceRef{
+			Kind: models.MigrationSourcePlesk,
+			Host: host,
+			User: accountID,
+		},
+		Warnings: []migrate.Warning{{
+			Code:   "plesk_areas_pending",
+			Detail: "Plesk per-area builders (domains/databases/dns/cron), WordPress, mail, and customers/packages ship in follow-up steps (plans/gh429-plesk-migration.md).",
+		}},
+	}, nil
+}

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -1,0 +1,235 @@
+// Package plesk implements the GH #429 Discoverer for Plesk source
+// panels. SSH-based connect (parity with the cpanel + directadmin
+// packages); discovery via the `plesk bin` / `plesk ext wp-toolkit`
+// admin CLI.
+//
+// Read-only contract: every command this package shells out to is a
+// list / info / json-export variant (`--list`, `--info`,
+// `-format json`). We never run a create / delete / modify call
+// against the source panel. Restore-side mutations (mariadb-import,
+// JMAP push, pdns/BIND zone upsert) run on the destination host, via
+// the cpmove-tarball synthesis path the directadmin package uses.
+//
+// Step 1 (this commit) ships the Discoverer scaffold + Connect +
+// ListAccounts + an empty-but-valid AccountManifest. Per-area builders
+// (Domains / Databases / DNS / Cron), WordPress, mail, and the
+// customers/packages layer land in follow-up steps — the same
+// incremental shape the directadmin package took (see its Wave A
+// scaffold). See plans/gh429-plesk-migration.md.
+package plesk
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Discoverer is the Plesk-side implementation of migrate.Discoverer.
+type Discoverer struct {
+	// AllowPrivate — when true the SSRF guard permits RFC1918 / ULA
+	// targets (server_settings.migration_allow_private_hosts). Default false.
+	AllowPrivate   bool
+	Port           int
+	CommandTimeout time.Duration
+}
+
+// New returns a Discoverer with sensible defaults. Plesk is managed
+// over plain SSH (port 22); the credential model matches cpanel/DA's
+// SecretRef env-file (SSH_PASSWORD or SSH_PRIVATE_KEY_B64). The
+// principal must be root (or a sudo-capable admin) so `plesk bin`
+// can enumerate every subscription.
+func New() *Discoverer {
+	return &Discoverer{
+		Port:           22,
+		CommandTimeout: 30 * time.Second,
+	}
+}
+
+// Compile-time interface assertions.
+var _ migrate.Discoverer = (*Discoverer)(nil)
+var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
+
+// SetAllowPrivate honours the server_settings private-host toggle.
+func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
+
+type session struct {
+	client        *ssh.Client
+	connectedUser string
+}
+
+func (s *session) Kind() string { return models.MigrationSourcePlesk }
+
+// Connect dials the source over SSH, pins the host key, and validates
+// the principal can run the Plesk CLI via a cheap `plesk version`
+// probe. A principal without `plesk` in PATH / without privileges
+// fails here so the operator sees the auth problem early.
+func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migrate.SecretRef) (migrate.Session, error) {
+	port := d.Port
+	if port == 0 {
+		port = 22
+	}
+	auth, err := loadSecret(secret.Path)
+	if err != nil {
+		return nil, fmt.Errorf("plesk.Connect: load secret: %w", err)
+	}
+	cfg := &ssh.ClientConfig{
+		User:            user,
+		Auth:            auth,
+		HostKeyCallback: migrate.PinningHostKeyCallback(secret.ExpectedHostKey),
+		Timeout:         15 * time.Second,
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	conn, err := migrate.DialTCP(ctx, host, port, d.AllowPrivate, 15*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("plesk.Connect: tcp dial %s: %w", addr, err)
+	}
+	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
+	if err != nil {
+		conn.Close()
+		if strings.Contains(err.Error(), "attempted methods [none]") {
+			return nil, fmt.Errorf("plesk.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
+		}
+		return nil, fmt.Errorf("plesk.Connect: ssh handshake: %w", err)
+	}
+	client := ssh.NewClient(c, ch, reqs)
+	s := &session{client: client, connectedUser: user}
+
+	// Admin probe: `plesk version` prints the Plesk build on success and
+	// exits non-zero when the CLI is absent or the principal lacks
+	// privileges. Either way a non-nil error is the gate.
+	subctx, cancel := context.WithTimeout(ctx, d.CommandTimeout)
+	defer cancel()
+	if _, err := s.run(subctx, d.CommandTimeout, "plesk version"); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("plesk.Connect: `plesk version` probe failed (need root or an admin SSH user on a Plesk host): %w", err)
+	}
+	return s, nil
+}
+
+// loadSecret mirrors the cpanel/directadmin loadSecret: two recognised
+// env-file auth lines, SSH_PASSWORD=<plaintext> and
+// SSH_PRIVATE_KEY_B64=<base64-PEM> (plus raw SSH_PRIVATE_KEY). The
+// in-memory file bytes are zeroed before returning.
+func loadSecret(path string) ([]ssh.AuthMethod, error) {
+	if path == "" {
+		return nil, errors.New("secret path empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer zero(raw)
+
+	var auths []ssh.AuthMethod
+	for _, line := range strings.Split(string(raw), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "SSH_PASSWORD":
+			auths = append(auths, ssh.Password(v))
+		case "SSH_PRIVATE_KEY":
+			signer, perr := ssh.ParsePrivateKey([]byte(v))
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		case "SSH_PRIVATE_KEY_B64":
+			pem, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(v))
+			if derr != nil {
+				return nil, fmt.Errorf("base64-decode SSH_PRIVATE_KEY_B64: %w", derr)
+			}
+			signer, perr := ssh.ParsePrivateKey(pem)
+			zero(pem)
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY_B64: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		}
+	}
+	if len(auths) == 0 {
+		return nil, errors.New("no SSH_PASSWORD / SSH_PRIVATE_KEY / SSH_PRIVATE_KEY_B64 in secret file")
+	}
+	return auths, nil
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// run executes one command via SSH and returns stdout. Hard timeout via
+// context; SIGKILL on expiry so a stuck command doesn't pin the session.
+func (s *session) run(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	subctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("ssh new session: %w", err)
+	}
+	defer sess.Close()
+
+	var stdout, stderr bytes.Buffer
+	sess.Stdout = &stdout
+	sess.Stderr = &stderr
+
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(cmd) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return nil, fmt.Errorf("ssh exec %q: %w (stderr=%q)", cmd, err, stderr.String())
+		}
+		return stdout.Bytes(), nil
+	case <-subctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return nil, fmt.Errorf("ssh exec %q: timed out after %s", cmd, timeout)
+	}
+}
+
+// ListAccounts returns one row per Plesk subscription visible to the
+// admin principal, via `plesk bin subscription --list` (one
+// subscription name — the primary domain — per line). Per-account
+// sizes land on DescribeAccount, not here (cheap mode).
+func (d *Discoverer) ListAccounts(ctx context.Context, raw migrate.Session) ([]migrate.AccountSummary, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("ListAccounts: wrong session type")
+	}
+	out, err := s.run(ctx, d.CommandTimeout, "plesk bin subscription --list")
+	if err != nil {
+		return nil, fmt.Errorf("list Plesk subscriptions: %w", err)
+	}
+	return parsePleskList(string(out)), nil
+}
+
+// Close releases the SSH client. Best-effort.
+func (d *Discoverer) Close(ctx context.Context, raw migrate.Session) error {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil
+	}
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}

--- a/panel-api/internal/migrate/plesk/discover_test.go
+++ b/panel-api/internal/migrate/plesk/discover_test.go
@@ -1,0 +1,59 @@
+package plesk
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestParsePleskList(t *testing.T) {
+	// `plesk bin subscription --list` prints one subscription name per
+	// line; blanks and banner/comment lines are ignored.
+	out := "example.com\n\nshop.example.net\n# banner line\n  spaced.org  \n"
+	got := parsePleskList(out)
+	want := []string{"example.com", "shop.example.net", "spaced.org"}
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d rows, want %d: %+v", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i].ID != name || got[i].Login != name || got[i].Domain != name {
+			t.Errorf("row %d = %+v, want ID/Login/Domain = %q", i, got[i], name)
+		}
+	}
+}
+
+func TestParsePleskList_Empty(t *testing.T) {
+	if got := parsePleskList("\n  \n# only comments\n"); len(got) != 0 {
+		t.Errorf("expected no rows, got %+v", got)
+	}
+}
+
+func TestNew_Defaults(t *testing.T) {
+	d := New()
+	if d.Port != 22 {
+		t.Errorf("default port = %d, want 22", d.Port)
+	}
+	if d.CommandTimeout == 0 {
+		t.Error("command timeout must be non-zero")
+	}
+	d.SetAllowPrivate(true)
+	if !d.AllowPrivate {
+		t.Error("SetAllowPrivate(true) did not stick")
+	}
+}
+
+// TestRegistered proves init() wired the plesk kind into the shared
+// registry so the admin source-picker + import dispatch can find it.
+func TestRegistered(t *testing.T) {
+	d, err := migrate.Get(models.MigrationSourcePlesk)
+	if err != nil {
+		t.Fatalf("migrate.Get(%q) failed: %v", models.MigrationSourcePlesk, err)
+	}
+	if d == nil {
+		t.Fatal("registered plesk discoverer is nil")
+	}
+	if _, ok := d.(migrate.AllowPrivateSetter); !ok {
+		t.Error("plesk discoverer must implement AllowPrivateSetter")
+	}
+}

--- a/panel-api/internal/migrate/plesk/init.go
+++ b/panel-api/internal/migrate/plesk/init.go
@@ -1,0 +1,12 @@
+package plesk
+
+import (
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func init() {
+	migrate.Register(models.MigrationSourcePlesk, func() migrate.Discoverer {
+		return New()
+	})
+}

--- a/panel-api/internal/migrate/plesk/parse.go
+++ b/panel-api/internal/migrate/plesk/parse.go
@@ -1,0 +1,27 @@
+package plesk
+
+import (
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// parsePleskList turns `plesk bin subscription --list` output — one
+// subscription name (the primary domain) per line — into account
+// summaries. Blank lines and comment/banner lines are skipped. The
+// subscription name is both the source-side ID and the primary domain.
+func parsePleskList(out string) []migrate.AccountSummary {
+	rows := []migrate.AccountSummary{}
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if name == "" || strings.HasPrefix(name, "#") {
+			continue
+		}
+		rows = append(rows, migrate.AccountSummary{
+			ID:     name,
+			Login:  name,
+			Domain: name,
+		})
+	}
+	return rows
+}

--- a/panel-api/internal/models/migration_job.go
+++ b/panel-api/internal/models/migration_job.go
@@ -26,6 +26,13 @@ const (
 	// to the shared migration.import_mailboxes agent step. See
 	// plans/gh374-imap-mail-migration.md.
 	MigrationSourceIMAP = "imap"
+	// MigrationSourcePlesk (GH #429) — full control-panel migration from a Plesk
+	// source over SSH. Discovers subscriptions, WordPress installs, mailboxes,
+	// databases, DNS, and (reseller) customers + service plans via `plesk bin` /
+	// `plesk ext wp-toolkit` read-only CLI, then restores destination-side by
+	// synthesising a cpmove-shaped tarball and reusing the cpanel restore
+	// writers. See plans/gh429-plesk-migration.md.
+	MigrationSourcePlesk = "plesk"
 )
 
 // MigrationState is the per-job lifecycle. Stage transitions are
@@ -61,14 +68,14 @@ type MigrationJob struct {
 	ID string `gorm:"column:id;type:char(26);primaryKey" json:"id"`
 	// BatchID — ADR-0095 decision 3. NULL for single-account jobs.
 	// Non-NULL ULID groups every job created from one bulk-WHM submit.
-	BatchID         *string `gorm:"column:batch_id;type:varchar(26);index" json:"batch_id,omitempty"`
-	SourceKind      string  `gorm:"column:source_kind;type:varchar(32);not null;uniqueIndex:uq_migration_source,priority:3" json:"source_kind"`
+	BatchID    *string `gorm:"column:batch_id;type:varchar(26);index" json:"batch_id,omitempty"`
+	SourceKind string  `gorm:"column:source_kind;type:varchar(32);not null;uniqueIndex:uq_migration_source,priority:3" json:"source_kind"`
 	// Mode (GH #646): "import" (first migration / resume) or "refresh"
 	// (force re-pull into an already-migrated account, backup-first).
-	Mode            string  `gorm:"column:mode;type:varchar(16);not null;default:'import'" json:"mode"`
-	SourceHost      string  `gorm:"column:source_host;type:varchar(255);not null;uniqueIndex:uq_migration_source,priority:1" json:"source_host"`
-	SourceUser      string  `gorm:"column:source_user;type:varchar(64);not null;uniqueIndex:uq_migration_source,priority:2" json:"source_user"`
-	ExpectedHostKey string  `gorm:"column:expected_host_key;type:varchar(128);not null;default:''" json:"expected_host_key"`
+	Mode            string `gorm:"column:mode;type:varchar(16);not null;default:'import'" json:"mode"`
+	SourceHost      string `gorm:"column:source_host;type:varchar(255);not null;uniqueIndex:uq_migration_source,priority:1" json:"source_host"`
+	SourceUser      string `gorm:"column:source_user;type:varchar(64);not null;uniqueIndex:uq_migration_source,priority:2" json:"source_user"`
+	ExpectedHostKey string `gorm:"column:expected_host_key;type:varchar(128);not null;default:''" json:"expected_host_key"`
 	// SourcePath (GH #647) — the WordPress root on the source (control-INPUT,
 	// like source_host/source_user). NULL until the operator supplies it or the
 	// discoverer auto-detects it. Distinct from ManifestJSON, which holds the


### PR DESCRIPTION
**Step 1 of the Plesk migration blueprint** (`plans/gh429-plesk-migration.md`). Backend-only scaffold, mirroring the DirectAdmin Wave-A scaffold commit.

## What
- `models.MigrationSourcePlesk = "plesk"` — new source_kind, no schema change.
- `internal/migrate/plesk/` — read-only `Discoverer` over SSH:
  - `Connect` — SSRF-guarded dial (`migrate.DialTCP`) + host-key pin (`SecretRef.ExpectedHostKey` TOFU) + `plesk version` admin probe. Secret loader mirrors cpanel/DA (`SSH_PASSWORD` / `SSH_PRIVATE_KEY_B64`, zeroed after use).
  - `ListAccounts` — `plesk bin subscription --list` → `parsePleskList`.
  - `DescribeAccount` — validates the subscription exists, returns an empty-but-valid `AccountManifest` (SchemaVersion + Source + a "pending areas" warning). Per-area builders land in Step 2.
  - `Close`, `SetAllowPrivate`.
- `init.go` registers the kind; `serve.go` blank-imports the package.

## Read-only contract
Every source command is `--list` / `--info`. No create/delete/modify against the source. Restore (cpmove synthesis → cpanel writers), WordPress, mail, and customers/packages ship in follow-up steps.

## Not in the UI yet
`CreateMigrationDrawer` hardcodes its source options (not fed by `migrate.Kinds()`), so `plesk` stays **backend-only and invisible to operators** until end-to-end restore exists (Step 6). Deliberate — avoids exposing a half-feature on main.

## Tests
`parsePleskList` (blank/comment skip), `New` defaults + `SetAllowPrivate`, and registry wiring (`migrate.Get("plesk")` returns a Discoverer implementing `AllowPrivateSetter`). Build + vet green.

## Refs
GH #429. Does not close the issue (5 more steps: describe → WordPress → email → customers/packages → reseller+UI).