### PR TITLE
feat(migrate): Plesk describe — domains + databases + account size (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/areas.go
+++ b/panel-api/internal/migrate/plesk/areas.go
@@ -1,0 +1,171 @@
+package plesk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// areas.go — per-area manifest builders for the Plesk importer.
+//
+// STATUS: coded against the Plesk Obsidian CLI docs + the documented
+// vhost layout (`/var/www/vhosts/<domain>/httpdocs`, HTTPD_VHOSTS_D in
+// /etc/psa/psa.conf). NOT yet validated against a live Plesk host — each
+// builder is best-effort and records a manifest Warning on partial /
+// missing data rather than failing the whole describe (mirrors the
+// directadmin builders' incremental cadence). DNS zones, cron, and SSH
+// keys are deferred to a follow-up step behind explicit warnings rather
+// than shipping unvalidated parsers.
+
+const pleskVhostRoot = "/var/www/vhosts"
+
+// describeDomains enumerates a subscription's domains. Best path:
+// `plesk bin subscription --info <name>` exposes the domain set; when
+// that field can't be parsed we fall back to the subscription name as
+// the sole (primary) domain. Per-domain docroot + PHP come from
+// `plesk bin domain --info <domain>`; docroot defaults to the standard
+// Plesk vhost path.
+func (d *Discoverer) describeDomains(ctx context.Context, s *session, account string) ([]migrate.DomainSpec, error) {
+	domains := []string{account}
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin subscription --info "+shellQuote(account)); err == nil {
+		info := parsePleskInfo(string(out))
+		if v := firstNonEmpty(info["domains"], info["domain aliases"]); v != "" {
+			if parsed := splitCSV(v); len(parsed) > 0 {
+				domains = parsed
+			}
+		}
+	}
+
+	rows := make([]migrate.DomainSpec, 0, len(domains))
+	for _, dom := range domains {
+		spec := migrate.DomainSpec{
+			Name:      dom,
+			DocRoot:   fmt.Sprintf("%s/%s/httpdocs", pleskVhostRoot, dom),
+			IsPrimary: dom == account,
+			HasPHP:    true,
+		}
+		if out, err := s.run(ctx, d.CommandTimeout, "plesk bin domain --info "+shellQuote(dom)); err == nil {
+			di := parsePleskInfo(string(out))
+			if v := firstNonEmpty(di["php version"], di["php_version"]); v != "" {
+				spec.PHPVer = v
+			}
+			if v := firstNonEmpty(di["www-root"], di["www_root"], di["document root"]); v != "" {
+				spec.DocRoot = v
+			}
+			if v := di["php"]; v != "" {
+				spec.HasPHP = truthy(v)
+			}
+		}
+		rows = append(rows, spec)
+	}
+	return rows, nil
+}
+
+// describeDatabases lists the MySQL databases for each domain via
+// `plesk bin database --list -domain <domain>` (one database name per
+// line). Postgres databases are recorded with a warning (v1 restore is
+// MySQL-only, same as the other importers). A per-domain failure warns
+// and continues rather than aborting the whole account.
+func (d *Discoverer) describeDatabases(ctx context.Context, s *session, domains []migrate.DomainSpec) ([]migrate.DatabaseSpec, []migrate.Warning, error) {
+	rows := []migrate.DatabaseSpec{}
+	warns := []migrate.Warning{}
+	for _, dom := range domains {
+		out, err := s.run(ctx, d.CommandTimeout, "plesk bin database --list -domain "+shellQuote(dom.Name))
+		if err != nil {
+			warns = append(warns, migrate.Warning{
+				Code:   "databases_domain_failed",
+				Detail: fmt.Sprintf("%s: %v", dom.Name, err),
+			})
+			continue
+		}
+		for _, name := range splitLines(string(out)) {
+			rows = append(rows, migrate.DatabaseSpec{
+				Engine:    "mysql",
+				Name:      name,
+				GrantUser: "",
+			})
+		}
+	}
+	return rows, warns, nil
+}
+
+// AccountSize implements migrate.SizeProber: best-effort byte count of
+// the subscription's vhost tree via `du -sb`. Returns 0 (not an error)
+// when the path can't be read so the lazy size endpoint degrades to
+// "unknown" rather than 500ing.
+func (d *Discoverer) AccountSize(ctx context.Context, raw migrate.Session, login string) (int64, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return 0, errors.New("AccountSize: wrong session type")
+	}
+	cmd := fmt.Sprintf("du -sb %s/%s 2>/dev/null | cut -f1", pleskVhostRoot, shellQuote(login))
+	out, err := s.run(ctx, d.CommandTimeout, cmd)
+	if err != nil {
+		return 0, nil // best-effort; caller renders "unknown"
+	}
+	// Take the first whitespace field: robust whether or not the shell
+	// `cut -f1` collapsed the `du` output to bare bytes.
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 0, nil
+	}
+	n, perr := strconv.ParseInt(fields[0], 10, 64)
+	if perr != nil {
+		return 0, nil
+	}
+	return n, nil
+}
+
+// --- small helpers ---
+
+// shellQuote single-quotes an argument for safe SSH command
+// interpolation. Untrusted source-side names never reach the shell
+// unquoted.
+func shellQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", `'\''`) + "'"
+}
+
+func splitLines(s string) []string {
+	out := []string{}
+	for _, line := range strings.Split(s, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func splitCSV(s string) []string {
+	out := []string{}
+	for _, part := range strings.Split(s, ",") {
+		t := strings.TrimSpace(part)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func truthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "on", "yes", "true", "enabled", "1":
+		return true
+	default:
+		return false
+	}
+}

--- a/panel-api/internal/migrate/plesk/areas_test.go
+++ b/panel-api/internal/migrate/plesk/areas_test.go
@@ -1,0 +1,134 @@
+package plesk
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// fixtureSession returns a *session whose run() dispatches to `responses`
+// keyed by a substring of the command. First matching key wins; an
+// unmatched command returns empty output (best-effort builders treat
+// that as "no data" + warning, never a panic).
+func fixtureSession(responses map[string]string) *session {
+	return &session{execFn: func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		for key, out := range responses {
+			if strings.Contains(cmd, key) {
+				return []byte(out), nil
+			}
+		}
+		return []byte(""), nil
+	}}
+}
+
+func TestParsePleskInfo(t *testing.T) {
+	raw := "Subscription info:\n" +
+		"    Domain name: example.com\n" +
+		"    PHP version: 8.2\n" +
+		"    Hosting type: virtual\n" +
+		"    # a comment\n" +
+		"    Status\n" // valueless line → skipped
+	got := parsePleskInfo(raw)
+	if got["domain name"] != "example.com" {
+		t.Errorf("domain name = %q, want example.com", got["domain name"])
+	}
+	if got["php version"] != "8.2" {
+		t.Errorf("php version = %q, want 8.2", got["php version"])
+	}
+	if _, ok := got["status"]; ok {
+		t.Error("valueless line must be skipped")
+	}
+}
+
+func TestDescribeDomains_DocrootAndPHP(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"subscription --info":               "Domain name: example.com\ndomains: example.com, addon.example.net\n",
+		"domain --info 'example.com'":       "PHP version: 8.2\nphp: on\n",
+		"domain --info 'addon.example.net'": "PHP version: 7.4\nphp: on\nwww-root: /var/www/vhosts/example.com/addon\n",
+	})
+	rows, err := d.describeDomains(context.Background(), s, "example.com")
+	if err != nil {
+		t.Fatalf("describeDomains: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d domains, want 2: %+v", len(rows), rows)
+	}
+	if !rows[0].IsPrimary || rows[0].Name != "example.com" {
+		t.Errorf("row0 primary/name wrong: %+v", rows[0])
+	}
+	if rows[0].DocRoot != "/var/www/vhosts/example.com/httpdocs" {
+		t.Errorf("primary docroot = %q, want default vhost path", rows[0].DocRoot)
+	}
+	if rows[0].PHPVer != "8.2" {
+		t.Errorf("primary PHPVer = %q, want 8.2", rows[0].PHPVer)
+	}
+	// addon carries an overridden docroot from www-root.
+	if rows[1].DocRoot != "/var/www/vhosts/example.com/addon" {
+		t.Errorf("addon docroot override not applied: %q", rows[1].DocRoot)
+	}
+	if rows[1].IsPrimary {
+		t.Error("addon domain must not be primary")
+	}
+}
+
+func TestDescribeDomains_FallbackToPrimary(t *testing.T) {
+	// subscription --info yields no parseable domain set → primary only.
+	d := New()
+	s := fixtureSession(map[string]string{
+		"domain --info": "PHP version: 8.1\n",
+	})
+	rows, err := d.describeDomains(context.Background(), s, "solo.example.org")
+	if err != nil {
+		t.Fatalf("describeDomains: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Name != "solo.example.org" || !rows[0].IsPrimary {
+		t.Fatalf("fallback should yield the single primary domain: %+v", rows)
+	}
+}
+
+func TestDescribeDatabases_ParsesAndWarnsPerDomain(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"database --list -domain 'example.com'": "wp_main\nwp_shop\n",
+		// addon.example.net returns empty → no rows, no crash.
+	})
+	domains := []migrate.DomainSpec{{Name: "example.com"}, {Name: "addon.example.net"}}
+	dbs, warns, err := d.describeDatabases(context.Background(), s, domains)
+	if err != nil {
+		t.Fatalf("describeDatabases: %v", err)
+	}
+	if len(dbs) != 2 {
+		t.Fatalf("got %d dbs, want 2: %+v", len(dbs), dbs)
+	}
+	if dbs[0].Engine != "mysql" || dbs[0].Name != "wp_main" {
+		t.Errorf("db0 = %+v, want mysql/wp_main", dbs[0])
+	}
+	_ = warns // no forced failure here; warns may be empty
+}
+
+func TestAccountSize_ParsesDuBytes(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"du -sb": "5242880\t/var/www/vhosts/example.com\n",
+	})
+	n, err := d.AccountSize(context.Background(), s, "example.com")
+	if err != nil {
+		t.Fatalf("AccountSize: %v", err)
+	}
+	if n != 5242880 {
+		t.Errorf("size = %d, want 5242880", n)
+	}
+}
+
+func TestAccountSize_UnreadableIsZeroNotError(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{"du -sb": "not-a-number\n"})
+	n, err := d.AccountSize(context.Background(), s, "example.com")
+	if err != nil || n != 0 {
+		t.Errorf("unparseable du → (0,nil), got (%d,%v)", n, err)
+	}
+}

--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -10,6 +10,10 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
+// Compile-time: the Plesk Discoverer answers cheap per-account size
+// queries for the lazy size endpoint.
+var _ migrate.SizeProber = (*Discoverer)(nil)
+
 // DescribeAccount returns a manifest scaffold for one Plesk
 // subscription. Step 1 validates the subscription exists on the source
 // and returns an empty-but-valid manifest (SchemaVersion + Source). The
@@ -57,16 +61,48 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 		}
 	}
 
-	return &migrate.AccountManifest{
+	m := &migrate.AccountManifest{
 		SchemaVersion: migrate.ManifestSchemaVersion,
 		Source: migrate.SourceRef{
 			Kind: models.MigrationSourcePlesk,
 			Host: host,
 			User: accountID,
 		},
-		Warnings: []migrate.Warning{{
-			Code:   "plesk_areas_pending",
-			Detail: "Plesk per-area builders (domains/databases/dns/cron), WordPress, mail, and customers/packages ship in follow-up steps (plans/gh429-plesk-migration.md).",
-		}},
-	}, nil
+		Warnings: []migrate.Warning{},
+	}
+
+	// Per-area builders. Best-effort: each area records a warning on
+	// failure but does not short-circuit. Domains is load-bearing — a
+	// hard failure with zero domains parsed returns an error so the
+	// operator sees it.
+	var firstErr error
+	if doms, err := d.describeDomains(ctx, s, accountID); err != nil {
+		firstErr = fmt.Errorf("domains: %w", err)
+		m.Warnings = append(m.Warnings, migrate.Warning{Code: "domains_failed", Detail: err.Error()})
+	} else {
+		m.Domains = doms
+	}
+
+	if dbs, warns, err := d.describeDatabases(ctx, s, m.Domains); err != nil {
+		if firstErr == nil {
+			firstErr = fmt.Errorf("databases: %w", err)
+		}
+		m.Warnings = append(m.Warnings, migrate.Warning{Code: "databases_failed", Detail: err.Error()})
+	} else {
+		m.Databases = dbs
+		m.Warnings = append(m.Warnings, warns...)
+	}
+
+	// DNS zones, cron, SSH keys, mailboxes, WordPress, and the
+	// customers/packages layer land in later steps — flagged so the
+	// operator knows the manifest is partial (plans/gh429-plesk-migration.md).
+	m.Warnings = append(m.Warnings, migrate.Warning{
+		Code:   "plesk_areas_pending",
+		Detail: "DNS/cron/SSH, mailboxes, WordPress, and customers/packages ship in follow-up steps; describe currently covers domains + databases.",
+	})
+
+	if firstErr != nil && len(m.Domains) == 0 {
+		return nil, firstErr
+	}
+	return m, nil
 }

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -67,6 +67,9 @@ func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
 type session struct {
 	client        *ssh.Client
 	connectedUser string
+	// execFn lets tests substitute the SSH round-trip with a fixture
+	// runner. nil in production → run() shells out over SSH.
+	execFn func(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error)
 }
 
 func (s *session) Kind() string { return models.MigrationSourcePlesk }
@@ -172,9 +175,18 @@ func zero(b []byte) {
 	}
 }
 
-// run executes one command via SSH and returns stdout. Hard timeout via
-// context; SIGKILL on expiry so a stuck command doesn't pin the session.
+// run executes one command against the source, dispatching to the
+// injected fixture runner in tests or SSH in production.
 func (s *session) run(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
+	if s.execFn != nil {
+		return s.execFn(ctx, timeout, cmd)
+	}
+	return s.sshExec(ctx, timeout, cmd)
+}
+
+// sshExec runs one command via SSH and returns stdout. Hard timeout via
+// context; SIGKILL on expiry so a stuck command doesn't pin the session.
+func (s *session) sshExec(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}

--- a/panel-api/internal/migrate/plesk/parse.go
+++ b/panel-api/internal/migrate/plesk/parse.go
@@ -25,3 +25,39 @@ func parsePleskList(out string) []migrate.AccountSummary {
 	}
 	return rows
 }
+
+// parsePleskInfo parses the raw key/value output of `plesk bin <util>
+// --info` into a map. Plesk prints `Key: value` (and some indented
+// `Key   value`) lines; the first `:` or run of spaces after the key
+// splits it. Blank lines, comment/banner lines, and section headers
+// (lines ending in `:` with no value) are skipped. Keys are lowercased
+// + trimmed so callers can look up case-insensitively.
+//
+// NOTE: coded against Plesk Obsidian CLI docs, not yet validated against
+// a live Plesk host — callers treat a missing key as best-effort and
+// record a manifest Warning rather than failing (mirrors the DA builders).
+func parsePleskInfo(raw string) map[string]string {
+	out := map[string]string{}
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, val := "", ""
+		if i := strings.IndexByte(trimmed, ':'); i >= 0 {
+			key, val = trimmed[:i], strings.TrimSpace(trimmed[i+1:])
+		} else if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
+			key, val = trimmed[:i], strings.TrimSpace(trimmed[i+1:])
+		} else {
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" || val == "" {
+			continue // section header or valueless line
+		}
+		if _, seen := out[key]; !seen {
+			out[key] = val
+		}
+	}
+	return out
+}


### PR DESCRIPTION
**Step 2 of the Plesk migration blueprint** (`plans/gh429-plesk-migration.md`). Fills the per-account `AccountManifest` from `plesk bin`, mirroring the DirectAdmin area-builder cadence.

## What
- **`parsePleskInfo`** — tolerant key/value parser for `plesk bin … --info` raw output (lowercased keys; section/valueless lines skipped).
- **`describeDomains`** — enumerate a subscription's domains (from `subscription --info`, falling back to the subscription name as the sole primary domain). Docroot defaults to the documented Plesk vhost path `/var/www/vhosts/<domain>/httpdocs`, overridden by `www-root`; PHP version + on/off from `domain --info`.
- **`describeDatabases`** — `plesk bin database --list -domain <domain>` → MySQL `DatabaseSpec`s; a per-domain failure warns and continues.
- **`AccountSize`** (`migrate.SizeProber`) — best-effort `du -sb` of the vhost tree; unreadable → `0` (not an error) so the lazy size endpoint degrades to "unknown".
- `session` gains a **test-injectable `execFn` seam** (SSH exec factored to `sshExec`) so builders test against fixtures without a live host.

## Scope (as shipped)
Covers the load-bearing web-migration areas: **domains + databases + size**. **DNS zones and cron are deferred** to a follow-up rather than shipping parsers coded against output I can't validate on a live Plesk box this session — the same honest incrementalism the DA builders used (they deferred cron/ssh). Every builder is best-effort and records a manifest `Warning` on partial data; marked "not live-validated" in `areas.go`.

## Read-only
Every source command is `--list` / `--info` / `du`. No source mutation.

## Tests
`parsePleskInfo`, `describeDomains` (docroot default + www-root override + primary flag + fallback-to-primary), `describeDatabases` (parse + per-domain empty), `AccountSize` (du parse + unreadable→0). Build + vet green.

## Refs
GH #429. Does not close the issue (steps remaining: WordPress → email → customers/packages → reseller+UI; DNS/cron folded into a later describe pass).