### PR TITLE
feat(migrate): Plesk WordPress detection into the manifest (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -93,12 +93,18 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 		m.Warnings = append(m.Warnings, warns...)
 	}
 
-	// DNS zones, cron, SSH keys, mailboxes, WordPress, and the
-	// customers/packages layer land in later steps — flagged so the
-	// operator knows the manifest is partial (plans/gh429-plesk-migration.md).
+	// WordPress detection (GH #429 step 3): WP Toolkit JSON with a
+	// docroot wp-config.php fallback. Best-effort — warns, never fatal.
+	apps, wpWarns := d.describeWordPress(ctx, s, m.Domains)
+	m.Apps = apps
+	m.Warnings = append(m.Warnings, wpWarns...)
+
+	// DNS zones, cron, SSH keys, mailboxes, and the customers/packages
+	// layer land in later steps — flagged so the operator knows the
+	// manifest is partial (plans/gh429-plesk-migration.md).
 	m.Warnings = append(m.Warnings, migrate.Warning{
 		Code:   "plesk_areas_pending",
-		Detail: "DNS/cron/SSH, mailboxes, WordPress, and customers/packages ship in follow-up steps; describe currently covers domains + databases.",
+		Detail: "DNS/cron/SSH, mailboxes, and customers/packages ship in follow-up steps; describe currently covers domains + databases + WordPress detection.",
 	})
 
 	if firstErr != nil && len(m.Domains) == 0 {

--- a/panel-api/internal/migrate/plesk/wordpress.go
+++ b/panel-api/internal/migrate/plesk/wordpress.go
@@ -1,0 +1,183 @@
+package plesk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// wordpress.go — WordPress detection for the Plesk importer.
+//
+// Primary source: `plesk ext wp-toolkit --list -format json`, which
+// enumerates every WordPress instance on the server (columns: ID, Main
+// Domain ID, Main Domain's Path, Owner ID, Alive, Site URL, Name,
+// Version). We filter to the account's own domains and record each as an
+// AppSpec so the operator + the (later) restore step know what to move.
+//
+// Fallback: when WP Toolkit isn't installed the CLI errors — we then scan
+// each domain's docroot for wp-config.php (mirrors migrate/wordpressssh's
+// filesystem detection).
+//
+// STATUS: JSON key spellings vary across Plesk / WP Toolkit versions, so
+// the parser tries several spellings and degrades to the filesystem scan;
+// not yet validated against a live host.
+
+// describeWordPress returns the WordPress installs that belong to the
+// account's domains. Best-effort: a probe failure warns and falls back to
+// the docroot scan rather than failing the describe.
+func (d *Discoverer) describeWordPress(ctx context.Context, s *session, domains []migrate.DomainSpec) ([]migrate.AppSpec, []migrate.Warning) {
+	warns := []migrate.Warning{}
+	owned := map[string]migrate.DomainSpec{}
+	for _, dom := range domains {
+		owned[strings.ToLower(dom.Name)] = dom
+	}
+
+	out, err := s.run(ctx, d.CommandTimeout, "plesk ext wp-toolkit --list -format json")
+	if err != nil {
+		warns = append(warns, migrate.Warning{
+			Code:   "wp_toolkit_unavailable",
+			Detail: fmt.Sprintf("wp-toolkit --list failed (%v); falling back to a docroot wp-config.php scan", err),
+		})
+		return d.scanWordPress(ctx, s, domains), warns
+	}
+
+	instances, perr := parseWPToolkitList(string(out))
+	if perr != nil {
+		warns = append(warns, migrate.Warning{
+			Code:   "wp_toolkit_parse_failed",
+			Detail: fmt.Sprintf("could not parse wp-toolkit JSON (%v); falling back to a docroot scan", perr),
+		})
+		return d.scanWordPress(ctx, s, domains), warns
+	}
+
+	apps := []migrate.AppSpec{}
+	for _, inst := range instances {
+		host := strings.ToLower(inst.domainHost())
+		dom, ok := owned[host]
+		if !ok {
+			continue // instance belongs to another account
+		}
+		apps = append(apps, migrate.AppSpec{
+			Kind:    "wordpress",
+			Path:    joinDocrootPath(dom, inst.Path),
+			Version: inst.Version,
+		})
+	}
+	return apps, warns
+}
+
+// scanWordPress is the fallback: test each domain docroot for
+// wp-config.php. Version is left blank (no cheap way to read it here).
+func (d *Discoverer) scanWordPress(ctx context.Context, s *session, domains []migrate.DomainSpec) []migrate.AppSpec {
+	apps := []migrate.AppSpec{}
+	for _, dom := range domains {
+		cmd := fmt.Sprintf("test -f %s/wp-config.php && echo found", shellQuote(dom.DocRoot))
+		out, err := s.run(ctx, d.CommandTimeout, cmd)
+		if err != nil || !strings.Contains(string(out), "found") {
+			continue
+		}
+		apps = append(apps, migrate.AppSpec{Kind: "wordpress", Path: dom.DocRoot})
+	}
+	return apps
+}
+
+// wpInstance is the subset of a WP Toolkit instance we need, normalised
+// across the key spellings different Plesk versions emit.
+type wpInstance struct {
+	MainDomain string
+	SiteURL    string
+	Path       string
+	Version    string
+}
+
+// domainHost resolves the instance's domain from its main-domain field,
+// falling back to the host parsed out of the site URL.
+func (w wpInstance) domainHost() string {
+	if w.MainDomain != "" {
+		return w.MainDomain
+	}
+	if w.SiteURL != "" {
+		if u, err := url.Parse(w.SiteURL); err == nil && u.Host != "" {
+			return u.Host
+		}
+		// bare host without scheme
+		return strings.SplitN(w.SiteURL, "/", 2)[0]
+	}
+	return ""
+}
+
+// parseWPToolkitList parses `wp-toolkit --list -format json`. The output
+// is either a bare array or an object with an "instances"/"data" array.
+// Keys vary by version, so each field is pulled with a fallback set.
+func parseWPToolkitList(raw string) ([]wpInstance, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &rows); err != nil {
+		// try {"instances":[...]} / {"data":[...]} wrappers
+		var wrap map[string]json.RawMessage
+		if werr := json.Unmarshal([]byte(trimmed), &wrap); werr != nil {
+			return nil, err
+		}
+		var inner json.RawMessage
+		for _, k := range []string{"instances", "data", "list"} {
+			if v, ok := wrap[k]; ok {
+				inner = v
+				break
+			}
+		}
+		if inner == nil {
+			return nil, err
+		}
+		if uerr := json.Unmarshal(inner, &rows); uerr != nil {
+			return nil, uerr
+		}
+	}
+
+	out := make([]wpInstance, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, wpInstance{
+			MainDomain: strFromKeys(r, "mainDomain", "main_domain", "domainName", "domain"),
+			SiteURL:    strFromKeys(r, "siteUrl", "site_url", "url"),
+			Path:       strFromKeys(r, "path", "mainDomainPath", "main_domain_path", "mainDomainsPath"),
+			Version:    strFromKeys(r, "version", "wpVersion", "wp_version"),
+		})
+	}
+	return out, nil
+}
+
+// strFromKeys returns the first key present as a non-empty string.
+func strFromKeys(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}
+
+// joinDocrootPath turns a WP Toolkit "Main Domain's Path" (e.g.
+// "/httpdocs/wordpress", relative to the vhost root) into an absolute
+// filesystem path. When the path already sits under the domain's docroot
+// (or is already absolute) we don't double it.
+func joinDocrootPath(dom migrate.DomainSpec, wpPath string) string {
+	wpPath = strings.TrimSpace(wpPath)
+	if wpPath == "" {
+		return dom.DocRoot
+	}
+	if strings.HasPrefix(wpPath, "/var/") {
+		return wpPath // already absolute
+	}
+	// vhost root is the docroot with a trailing "/httpdocs" removed.
+	vhostRoot := strings.TrimSuffix(dom.DocRoot, "/httpdocs")
+	return path.Clean(vhostRoot + "/" + strings.TrimPrefix(wpPath, "/"))
+}

--- a/panel-api/internal/migrate/plesk/wordpress_test.go
+++ b/panel-api/internal/migrate/plesk/wordpress_test.go
@@ -1,0 +1,93 @@
+package plesk
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+func TestParseWPToolkitList_ArrayAndWrapper(t *testing.T) {
+	arr := `[{"mainDomain":"example.com","path":"/httpdocs","version":"6.5","siteUrl":"https://example.com"}]`
+	rows, err := parseWPToolkitList(arr)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("array parse: %v rows=%+v", err, rows)
+	}
+	if rows[0].MainDomain != "example.com" || rows[0].Version != "6.5" {
+		t.Errorf("row = %+v", rows[0])
+	}
+
+	wrapped := `{"instances":[{"domainName":"shop.example.net","mainDomainPath":"/httpdocs/blog","wpVersion":"6.4"}]}`
+	rows2, err := parseWPToolkitList(wrapped)
+	if err != nil || len(rows2) != 1 {
+		t.Fatalf("wrapper parse: %v rows=%+v", err, rows2)
+	}
+	if rows2[0].MainDomain != "shop.example.net" || rows2[0].Path != "/httpdocs/blog" || rows2[0].Version != "6.4" {
+		t.Errorf("wrapped row = %+v", rows2[0])
+	}
+}
+
+func TestWPInstance_DomainHostFromSiteURL(t *testing.T) {
+	w := wpInstance{SiteURL: "https://blog.example.com/wp"}
+	if got := w.domainHost(); got != "blog.example.com" {
+		t.Errorf("host from URL = %q, want blog.example.com", got)
+	}
+	if got := (wpInstance{MainDomain: "a.com", SiteURL: "https://b.com"}).domainHost(); got != "a.com" {
+		t.Errorf("main domain must win: %q", got)
+	}
+}
+
+func TestJoinDocrootPath(t *testing.T) {
+	dom := migrate.DomainSpec{Name: "example.com", DocRoot: "/var/www/vhosts/example.com/httpdocs"}
+	cases := map[string]string{
+		"/httpdocs":            "/var/www/vhosts/example.com/httpdocs",
+		"/httpdocs/wordpress":  "/var/www/vhosts/example.com/httpdocs/wordpress",
+		"":                     "/var/www/vhosts/example.com/httpdocs",
+		"/var/www/vhosts/x/wp": "/var/www/vhosts/x/wp", // already absolute
+	}
+	for in, want := range cases {
+		if got := joinDocrootPath(dom, in); got != want {
+			t.Errorf("joinDocrootPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDescribeWordPress_FiltersToAccountDomains(t *testing.T) {
+	d := New()
+	// Server has two instances; only example.com belongs to this account.
+	s := fixtureSession(map[string]string{
+		"wp-toolkit --list -format json": `[
+			{"mainDomain":"example.com","path":"/httpdocs","version":"6.5"},
+			{"mainDomain":"other.tld","path":"/httpdocs","version":"6.5"}
+		]`,
+	})
+	domains := []migrate.DomainSpec{{Name: "example.com", DocRoot: "/var/www/vhosts/example.com/httpdocs"}}
+	apps, warns := d.describeWordPress(context.Background(), s, domains)
+	if len(apps) != 1 {
+		t.Fatalf("got %d apps, want 1 (filtered to account domains): %+v", len(apps), apps)
+	}
+	if apps[0].Kind != "wordpress" || apps[0].Path != "/var/www/vhosts/example.com/httpdocs" || apps[0].Version != "6.5" {
+		t.Errorf("app = %+v", apps[0])
+	}
+	if len(warns) != 0 {
+		t.Errorf("clean run should have no warnings: %+v", warns)
+	}
+}
+
+func TestDescribeWordPress_FallbackScanOnToolkitError(t *testing.T) {
+	d := New()
+	// wp-toolkit returns non-JSON (extension absent) → parse fails →
+	// docroot scan runs; the test-and-echo reports wp-config present.
+	fs := fixtureSession(map[string]string{
+		"wp-toolkit --list": "ERROR: extension not installed",
+		"wp-config.php":     "found\n",
+	})
+	domains := []migrate.DomainSpec{{Name: "example.com", DocRoot: "/var/www/vhosts/example.com/httpdocs"}}
+	apps, warns := d.describeWordPress(context.Background(), fs, domains)
+	if len(apps) != 1 || apps[0].Path != "/var/www/vhosts/example.com/httpdocs" {
+		t.Fatalf("fallback scan should find wp-config: %+v", apps)
+	}
+	if len(warns) == 0 {
+		t.Error("fallback must record a warning")
+	}
+}


### PR DESCRIPTION
**Step 3 of the Plesk migration blueprint** (`plans/gh429-plesk-migration.md`) — read-only WordPress **detection**.

## What
- **`describeWordPress`** — `plesk ext wp-toolkit --list -format json` → an `AppSpec` per install, **filtered to the account's own domains** (match on main-domain / site-URL host). Absolute install path derived from the domain docroot + WP Toolkit "Main Domain's Path".
- **`parseWPToolkitList`** — permissive JSON parser: bare array or `{instances|data|list:[…]}` wrapper; each field pulled with a fallback key set (`mainDomain`/`domainName`, `path`/`mainDomainPath`, `version`/`wpVersion`) because key spellings vary across Plesk / WP Toolkit versions.
- **Fallback** — when WP Toolkit is absent (CLI errors / non-JSON), scan each domain docroot for `wp-config.php` (mirrors `wordpressssh`).
- Wired into `DescribeAccount` (`m.Apps`); best-effort with warnings.

## ⚠️ Plan mutation — Step 3 split
The **restore** half (cpmove synthesis → cpanel writers + wp-config rewrite) is deferred to a new **Step 3b**. The restore StageCallback orchestration isn't populated in `migrate/cpanel` (it's wired elsewhere and needs tracing), and restore is unvalidatable without a live Plesk box. This PR ships **read-only detection only** — safe, testable, no destination mutation.

## Tests
Array + wrapper JSON parse, host-from-siteURL, docroot path join, account-domain filtering, fallback-scan-on-toolkit-error. Build + vet green.

## Refs
GH #429. Does not close the issue. Coded against WP Toolkit CLI docs; not yet live-validated (parser degrades to the docroot scan).