### PR TITLE
feat(migrate): Plesk mailbox detection into the manifest (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/areas.go
+++ b/panel-api/internal/migrate/plesk/areas.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
@@ -107,17 +106,9 @@ func (d *Discoverer) AccountSize(ctx context.Context, raw migrate.Session, login
 	if err != nil {
 		return 0, nil // best-effort; caller renders "unknown"
 	}
-	// Take the first whitespace field: robust whether or not the shell
-	// `cut -f1` collapsed the `du` output to bare bytes.
-	fields := strings.Fields(string(out))
-	if len(fields) == 0 {
-		return 0, nil
-	}
-	n, perr := strconv.ParseInt(fields[0], 10, 64)
-	if perr != nil {
-		return 0, nil
-	}
-	return n, nil
+	// First whitespace field: robust whether or not the shell `cut -f1`
+	// already collapsed the `du` output to bare bytes.
+	return parseFirstInt(string(out)), nil
 }
 
 // --- small helpers ---

--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -93,6 +93,12 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 		m.Warnings = append(m.Warnings, warns...)
 	}
 
+	// Mailboxes (GH #429 step 4): enumerate /var/qmail/mailnames per
+	// owned domain. Best-effort — warns, never fatal.
+	boxes, mailWarns := d.describeMailboxes(ctx, s, m.Domains)
+	m.Mailboxes = boxes
+	m.Warnings = append(m.Warnings, mailWarns...)
+
 	// WordPress detection (GH #429 step 3): WP Toolkit JSON with a
 	// docroot wp-config.php fallback. Best-effort — warns, never fatal.
 	apps, wpWarns := d.describeWordPress(ctx, s, m.Domains)
@@ -104,7 +110,7 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 	// manifest is partial (plans/gh429-plesk-migration.md).
 	m.Warnings = append(m.Warnings, migrate.Warning{
 		Code:   "plesk_areas_pending",
-		Detail: "DNS/cron/SSH, mailboxes, and customers/packages ship in follow-up steps; describe currently covers domains + databases + WordPress detection.",
+		Detail: "DNS/cron/SSH and customers/packages ship in follow-up steps; describe currently covers domains + databases + WordPress + mailboxes.",
 	})
 
 	if firstErr != nil && len(m.Domains) == 0 {

--- a/panel-api/internal/migrate/plesk/mail.go
+++ b/panel-api/internal/migrate/plesk/mail.go
@@ -1,0 +1,71 @@
+package plesk
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// mail.go — mailbox detection for the Plesk importer.
+//
+// Plesk stores mailboxes at PLESK_MAILNAMES_D (default /var/qmail/
+// mailnames), one directory per mail name: <base>/<domain>/<local>/
+// Maildir. We enumerate the filesystem per owned domain rather than
+// parsing `plesk bin mail -l -json` — the filesystem is authoritative,
+// yields the exact Maildir path the (later) import step needs, and
+// avoids a version-varying JSON shape. Quota isn't exposed on disk, so
+// QuotaBytes is left 0 (unknown/unlimited).
+
+const pleskMailnamesRoot = "/var/qmail/mailnames"
+
+// describeMailboxes lists the mailboxes under each of the account's
+// domains, with a best-effort du size per box. Per-domain failures warn
+// and continue rather than aborting the describe.
+func (d *Discoverer) describeMailboxes(ctx context.Context, s *session, domains []migrate.DomainSpec) ([]migrate.MailboxSpec, []migrate.Warning) {
+	warns := []migrate.Warning{}
+	boxes := []migrate.MailboxSpec{}
+	for _, dom := range domains {
+		base := fmt.Sprintf("%s/%s", pleskMailnamesRoot, dom.Name)
+		out, err := s.run(ctx, d.CommandTimeout, "ls -1 "+shellQuote(base)+" 2>/dev/null")
+		if err != nil {
+			warns = append(warns, migrate.Warning{
+				Code:   "mailboxes_domain_failed",
+				Detail: fmt.Sprintf("%s: %v", dom.Name, err),
+			})
+			continue
+		}
+		for _, local := range splitLines(string(out)) {
+			if strings.HasPrefix(local, ".") || strings.Contains(local, "@") {
+				continue // skip dotfiles / stray entries
+			}
+			maildir := fmt.Sprintf("%s/%s/Maildir", base, local)
+			spec := migrate.MailboxSpec{
+				Address:     local + "@" + dom.Name,
+				MaildirPath: maildir,
+			}
+			if szOut, e := s.run(ctx, d.CommandTimeout, "du -sb "+shellQuote(maildir)+" 2>/dev/null | cut -f1"); e == nil {
+				spec.BytesUsed = parseFirstInt(string(szOut))
+			}
+			boxes = append(boxes, spec)
+		}
+	}
+	return boxes, warns
+}
+
+// parseFirstInt returns the first whitespace-separated integer field of
+// s, or 0 when there isn't one. Robust whether or not a shell `cut`
+// already reduced the input to a bare number.
+func parseFirstInt(s string) int64 {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return 0
+	}
+	n, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/panel-api/internal/migrate/plesk/mail_test.go
+++ b/panel-api/internal/migrate/plesk/mail_test.go
@@ -1,0 +1,65 @@
+package plesk
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+func TestDescribeMailboxes_EnumeratesAndSizes(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"ls -1 '/var/qmail/mailnames/example.com'": "info\nsales\n.skipme\n",
+		// du per mailbox
+		"du -sb '/var/qmail/mailnames/example.com/info/Maildir'":  "1048576\t/path\n",
+		"du -sb '/var/qmail/mailnames/example.com/sales/Maildir'": "2097152\t/path\n",
+	})
+	domains := []migrate.DomainSpec{{Name: "example.com", DocRoot: "/var/www/vhosts/example.com/httpdocs"}}
+	boxes, warns := d.describeMailboxes(context.Background(), s, domains)
+	if len(boxes) != 2 {
+		t.Fatalf("got %d boxes, want 2 (dotfile skipped): %+v", len(boxes), boxes)
+	}
+	if boxes[0].Address != "info@example.com" {
+		t.Errorf("box0 address = %q, want info@example.com", boxes[0].Address)
+	}
+	if boxes[0].MaildirPath != "/var/qmail/mailnames/example.com/info/Maildir" {
+		t.Errorf("box0 maildir = %q", boxes[0].MaildirPath)
+	}
+	if boxes[0].BytesUsed != 1048576 || boxes[1].BytesUsed != 2097152 {
+		t.Errorf("sizes wrong: %d, %d", boxes[0].BytesUsed, boxes[1].BytesUsed)
+	}
+	if len(warns) != 0 {
+		t.Errorf("clean run should have no warnings: %+v", warns)
+	}
+}
+
+func TestDescribeMailboxes_NoMailForDomainIsQuiet(t *testing.T) {
+	d := New()
+	// ls returns empty (no mailnames dir) → no boxes, no warning (ls
+	// with 2>/dev/null + empty output is the "no mail" case).
+	s := fixtureSession(map[string]string{})
+	domains := []migrate.DomainSpec{{Name: "nomail.example.org"}}
+	boxes, warns := d.describeMailboxes(context.Background(), s, domains)
+	if len(boxes) != 0 {
+		t.Errorf("expected no boxes, got %+v", boxes)
+	}
+	if len(warns) != 0 {
+		t.Errorf("empty listing is not an error: %+v", warns)
+	}
+}
+
+func TestParseFirstInt(t *testing.T) {
+	cases := map[string]int64{
+		"5242880\t/path": 5242880,
+		"42":             42,
+		"":               0,
+		"not-a-number":   0,
+		"  99  x":        99,
+	}
+	for in, want := range cases {
+		if got := parseFirstInt(in); got != want {
+			t.Errorf("parseFirstInt(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
**Step 4 of the Plesk migration blueprint** (`plans/gh429-plesk-migration.md`) — read-only mailbox **detection**.

## What
- **`describeMailboxes`** — enumerate `/var/qmail/mailnames/<domain>/<local>` (`PLESK_MAILNAMES_D` default) per owned domain → `MailboxSpec` carrying the exact **Maildir path** (`<base>/<domain>/<local>/Maildir`) the import step needs, plus a best-effort `du -sb` size. Filesystem enumeration is authoritative and avoids a version-varying `mail -l -json` shape; quota isn't on disk so `QuotaBytes` stays `0` (unknown). Dotfiles/stray entries skipped; per-domain failure warns and continues.
- `parseFirstInt` helper shared with `AccountSize`.
- Wired into `DescribeAccount` (`m.Mailboxes`).

## ⚠️ Plan mutation — Step 4 split (detect / import)
This PR ships **detection** only. The **import** half (stage each Maildir → the shipped `migrate/imap` importer / `migration.import_mailboxes` agent verb) folds into the restore step (**3b**) — it shares the runner/StageCallback wiring and needs a live box to validate. Read-only, no destination mutation.

## Tests
Enumerate + per-box `du` size + dotfile skip, empty-listing-is-quiet, `parseFirstInt`. Build + vet green.

## Refs
GH #429. Does not close the issue. Reuses the Phase-A IMAP/Maildir importer at restore time.