### PR TITLE
feat(migrate): Plesk customers + service-plan discovery and pure mapping (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/customers.go
+++ b/panel-api/internal/migrate/plesk/customers.go
@@ -1,0 +1,220 @@
+package plesk
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// customers.go — Plesk customer + service-plan discovery and the PURE
+// mapping to jabali packages/users (GH #429 step 5). This file does NOT
+// mutate the destination: it reads the source (`plesk bin customer` /
+// `plesk bin service_plan`) and produces the drafts that the restore
+// step will turn into HostingPackage rows + users. Password handling +
+// the actual create/upsert (the security-sensitive half) live in the
+// restore step, which mints an invite/forced-reset rather than importing
+// any source hash.
+//
+// jabali has no reseller tier (only user.IsAdmin) — a reseller-owned
+// customer is flagged IsReseller so the restore step can flatten it to
+// an admin-owned user (Step 6). Coded against the Plesk Obsidian CLI
+// docs; not yet live-validated.
+
+// PleskPlan is a source service plan (hosting package).
+type PleskPlan struct {
+	Name         string
+	DiskMB       uint32
+	BandwidthMB  uint32
+	MaxDomains   uint32
+	MaxMailboxes uint32
+	MaxDatabases uint32
+	Owner        string // reseller login that owns the plan, "" = admin
+}
+
+// PleskCustomer is a source customer account.
+type PleskCustomer struct {
+	Login       string
+	ContactName string
+	Email       string
+	Company     string
+	Suspended   bool
+	Reseller    string // owning reseller login, "" = owned by admin
+}
+
+// TenantSet is the server-level discovery result: every plan + customer
+// visible to the admin principal.
+type TenantSet struct {
+	Plans     []PleskPlan
+	Customers []PleskCustomer
+}
+
+// UserDraft is the jabali user a customer maps to. NOTE: no password
+// field — Plesk hashes aren't portable, so the restore step mints an
+// invite / forced reset. IsReseller drives the Step-6 flatten.
+type UserDraft struct {
+	Username    string
+	Email       string
+	DisplayName string
+	Suspended   bool
+	IsReseller  bool
+}
+
+// DiscoverTenants enumerates the source's service plans + customers.
+// Read-only; server-level (not per-subscription), so it is a Plesk
+// extension rather than part of migrate.Discoverer. Best-effort: a
+// per-item info failure is skipped, not fatal.
+func (d *Discoverer) DiscoverTenants(ctx context.Context, raw migrate.Session) (*TenantSet, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, fmt.Errorf("DiscoverTenants: wrong session type")
+	}
+	ts := &TenantSet{Plans: []PleskPlan{}, Customers: []PleskCustomer{}}
+
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin service_plan --list"); err == nil {
+		for _, name := range splitLines(string(out)) {
+			info, ierr := s.run(ctx, d.CommandTimeout, "plesk bin service_plan --info "+shellQuote(name))
+			if ierr != nil {
+				continue
+			}
+			ts.Plans = append(ts.Plans, parsePleskPlan(name, string(info)))
+		}
+	}
+
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin customer --list"); err == nil {
+		for _, login := range splitLines(string(out)) {
+			info, ierr := s.run(ctx, d.CommandTimeout, "plesk bin customer --info "+shellQuote(login))
+			if ierr != nil {
+				continue
+			}
+			ts.Customers = append(ts.Customers, parsePleskCustomer(login, string(info)))
+		}
+	}
+	return ts, nil
+}
+
+func parsePleskPlan(name, info string) PleskPlan {
+	m := parsePleskInfo(info)
+	return PleskPlan{
+		Name:         name,
+		DiskMB:       parsePleskSizeMB(firstNonEmpty(m["disk space"], m["disk_space"], m["disk quota"])),
+		BandwidthMB:  parsePleskSizeMB(firstNonEmpty(m["max traffic"], m["traffic"], m["max_traffic"])),
+		MaxDomains:   parsePleskCount(firstNonEmpty(m["domains"], m["max domains"], m["maximum number of domains"])),
+		MaxMailboxes: parsePleskCount(firstNonEmpty(m["mailboxes"], m["mailboxes number"], m["maximum number of mailboxes"])),
+		MaxDatabases: parsePleskCount(firstNonEmpty(m["databases"], m["max databases"], m["maximum number of databases"])),
+		Owner:        firstNonEmpty(m["owner"], m["reseller"]),
+	}
+}
+
+func parsePleskCustomer(login, info string) PleskCustomer {
+	m := parsePleskInfo(info)
+	suspended := truthy(m["suspended"])
+	if !suspended && strings.EqualFold(strings.TrimSpace(m["status"]), "suspended") {
+		suspended = true
+	}
+	return PleskCustomer{
+		Login:       login,
+		ContactName: firstNonEmpty(m["contact name"], m["personal name"], m["contact"]),
+		Email:       firstNonEmpty(m["email"], m["e-mail"]),
+		Company:     firstNonEmpty(m["company"], m["company name"]),
+		Suspended:   suspended,
+		Reseller:    firstNonEmpty(m["reseller"], m["owner"]),
+	}
+}
+
+// PlanToHostingPackage is the PURE mapping from a Plesk plan to a jabali
+// HostingPackage. Zero = unlimited in HostingPackage, which is also how
+// an unmapped/unlimited Plesk limit lands (safe default). Docker/Python
+// app allowances default to 0 (opt-in per plan on jabali; Plesk has no
+// equivalent). ID + timestamps are assigned at create time, not here.
+func PlanToHostingPackage(p PleskPlan) models.HostingPackage {
+	return models.HostingPackage{
+		Name:             p.Name,
+		DiskQuotaMB:      p.DiskMB,
+		BandwidthQuotaMB: p.BandwidthMB,
+		MaxDomains:       p.MaxDomains,
+		MaxEmailAccounts: p.MaxMailboxes,
+		MaxDatabases:     p.MaxDatabases,
+		// No Plesk equivalent → jabali-safe defaults (0 = not included).
+		MaxDockerApps: 0,
+		MaxPythonApps: 0,
+	}
+}
+
+// CustomerToUser is the PURE mapping from a Plesk customer to a jabali
+// user draft. No password is carried — the restore step mints an invite.
+func CustomerToUser(c PleskCustomer) UserDraft {
+	return UserDraft{
+		Username:    sanitizeUsername(c.Login),
+		Email:       strings.TrimSpace(c.Email),
+		DisplayName: firstNonEmpty(c.ContactName, c.Company, c.Login),
+		Suspended:   c.Suspended,
+		IsReseller:  false, // set by the caller from reseller enumeration (Step 6)
+	}
+}
+
+var usernameStrip = regexp.MustCompile(`[^a-z0-9_-]`)
+
+// sanitizeUsername lowercases a Plesk login and strips it to jabali's
+// username charset. An email-shaped login keeps only the local part.
+func sanitizeUsername(login string) string {
+	login = strings.ToLower(strings.TrimSpace(login))
+	if at := strings.IndexByte(login, '@'); at > 0 {
+		login = login[:at]
+	}
+	return usernameStrip.ReplaceAllString(login, "")
+}
+
+// parsePleskSizeMB parses a Plesk size ("500M", "1 GB", "1073741824"
+// bytes, "unlimited", "-1") into megabytes. Unlimited / unparseable → 0
+// (unlimited in HostingPackage).
+func parsePleskSizeMB(s string) uint32 {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" || s == "unlimited" || s == "-1" || s == "0" {
+		return 0
+	}
+	// leading number (may be float), optional unit suffix.
+	num := s
+	i := 0
+	for i < len(num) && (num[i] >= '0' && num[i] <= '9' || num[i] == '.') {
+		i++
+	}
+	val, err := strconv.ParseFloat(strings.TrimSpace(num[:i]), 64)
+	if err != nil || val <= 0 {
+		return 0
+	}
+	unit := strings.TrimSpace(num[i:])
+	switch {
+	case strings.HasPrefix(unit, "t"): // TB
+		val *= 1024 * 1024
+	case strings.HasPrefix(unit, "g"): // GB
+		val *= 1024
+	case strings.HasPrefix(unit, "m"): // MB
+		// already MB
+	case strings.HasPrefix(unit, "k"): // KB
+		val /= 1024
+	case unit == "": // bare number → bytes
+		val /= 1024 * 1024
+	}
+	if val < 0 {
+		return 0
+	}
+	return uint32(val)
+}
+
+// parsePleskCount parses a Plesk count limit; "unlimited"/-1/"" → 0.
+func parsePleskCount(s string) uint32 {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" || s == "unlimited" || s == "-1" {
+		return 0
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(n)
+}

--- a/panel-api/internal/migrate/plesk/customers_test.go
+++ b/panel-api/internal/migrate/plesk/customers_test.go
@@ -1,0 +1,130 @@
+package plesk
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParsePleskSizeMB(t *testing.T) {
+	cases := map[string]uint32{
+		"unlimited":  0,
+		"-1":         0,
+		"":           0,
+		"0":          0,
+		"500M":       500,
+		"500 MB":     500,
+		"1G":         1024,
+		"1 GB":       1024,
+		"2T":         2 * 1024 * 1024,
+		"1048576":    1,    // bytes → MB
+		"1073741824": 1024, // 1 GiB in bytes → MB
+		"2048K":      2,    // KB → MB
+	}
+	for in, want := range cases {
+		if got := parsePleskSizeMB(in); got != want {
+			t.Errorf("parsePleskSizeMB(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestParsePleskCount(t *testing.T) {
+	cases := map[string]uint32{"unlimited": 0, "-1": 0, "": 0, "10": 10, "x": 0}
+	for in, want := range cases {
+		if got := parsePleskCount(in); got != want {
+			t.Errorf("parsePleskCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestPlanToHostingPackage_FieldMap(t *testing.T) {
+	p := PleskPlan{
+		Name: "Business", DiskMB: 10240, BandwidthMB: 102400,
+		MaxDomains: 25, MaxMailboxes: 100, MaxDatabases: 50,
+	}
+	pkg := PlanToHostingPackage(p)
+	if pkg.Name != "Business" {
+		t.Errorf("name = %q", pkg.Name)
+	}
+	if pkg.DiskQuotaMB != 10240 || pkg.BandwidthQuotaMB != 102400 {
+		t.Errorf("size fields wrong: %+v", pkg)
+	}
+	if pkg.MaxDomains != 25 || pkg.MaxEmailAccounts != 100 || pkg.MaxDatabases != 50 {
+		t.Errorf("count fields wrong: %+v", pkg)
+	}
+	// jabali-safe defaults: app allowances off, ID unset (assigned at create).
+	if pkg.MaxDockerApps != 0 || pkg.MaxPythonApps != 0 {
+		t.Errorf("app allowances must default to 0: %+v", pkg)
+	}
+	if pkg.ID != "" {
+		t.Errorf("ID must be assigned at create time, not by the mapper: %q", pkg.ID)
+	}
+}
+
+func TestCustomerToUser_NoPasswordSanitizedUsername(t *testing.T) {
+	u := CustomerToUser(PleskCustomer{
+		Login: "John.Doe@Example.com", ContactName: "John Doe",
+		Email: "jd@example.com", Suspended: true,
+	})
+	if u.Username != "johndoe" {
+		// '@Example.com' stripped; '.' is not in jabali's username charset
+		// so it is stripped too → "johndoe".
+		t.Errorf("username = %q, want johndoe", u.Username)
+	}
+	if u.Email != "jd@example.com" || u.DisplayName != "John Doe" || !u.Suspended {
+		t.Errorf("draft = %+v", u)
+	}
+	// Security: the draft type has no password field at all — nothing to
+	// leak. (Compile-time guarantee; this test documents the intent.)
+}
+
+func TestSanitizeUsername(t *testing.T) {
+	cases := map[string]string{
+		"john.doe@example.com": "johndoe",   // '.' not in charset → stripped
+		"Weird User!":          "weirduser", // space + '!' stripped, lowered
+		"ok_name-1":            "ok_name-1",
+	}
+	for in, want := range cases {
+		if got := sanitizeUsername(in); got != want {
+			t.Errorf("sanitizeUsername(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDiscoverTenants_ParsesPlansAndCustomers(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"service_plan --list":             "Unlimited\nBusiness\n",
+		"service_plan --info 'Unlimited'": "disk space: unlimited\nmax traffic: unlimited\ndomains: unlimited\n",
+		"service_plan --info 'Business'":  "disk space: 10240M\nmax traffic: 100G\ndomains: 25\nmailboxes: 100\ndatabases: 50\n",
+		"customer --list":                 "jdoe\nacme\n",
+		"customer --info 'jdoe'":          "contact name: John Doe\nemail: jd@example.com\nstatus: active\n",
+		"customer --info 'acme'":          "company: ACME Ltd\nemail: ops@acme.com\nsuspended: true\nreseller: bigres\n",
+	})
+	ts, err := d.DiscoverTenants(context.Background(), s)
+	if err != nil {
+		t.Fatalf("DiscoverTenants: %v", err)
+	}
+	if len(ts.Plans) != 2 || len(ts.Customers) != 2 {
+		t.Fatalf("got %d plans / %d customers, want 2/2", len(ts.Plans), len(ts.Customers))
+	}
+	// Business plan field mapping.
+	var biz PleskPlan
+	for _, p := range ts.Plans {
+		if p.Name == "Business" {
+			biz = p
+		}
+	}
+	if biz.DiskMB != 10240 || biz.BandwidthMB != 100*1024 || biz.MaxDomains != 25 || biz.MaxMailboxes != 100 || biz.MaxDatabases != 50 {
+		t.Errorf("Business plan mapped wrong: %+v", biz)
+	}
+	// acme customer: suspended + reseller-owned.
+	var acme PleskCustomer
+	for _, c := range ts.Customers {
+		if c.Login == "acme" {
+			acme = c
+		}
+	}
+	if !acme.Suspended || acme.Reseller != "bigres" || acme.Company != "ACME Ltd" {
+		t.Errorf("acme customer parsed wrong: %+v", acme)
+	}
+}


### PR DESCRIPTION
**Step 5 of the Plesk migration blueprint** (`plans/gh429-plesk-migration.md`) — read-only tenant **discovery** + the **pure mapping** to jabali packages/users. **No destination writes.**

## What
- **`DiscoverTenants`** — server-level enumeration of service plans (`plesk bin service_plan --list/--info`) and customers (`plesk bin customer --list/--info`) → `TenantSet`. Best-effort; per-item failure skipped.
- **`PlanToHostingPackage`** (pure) — Plesk plan → `models.HostingPackage`: disk/traffic → `DiskQuotaMB`/`BandwidthQuotaMB`; domains/mailboxes/databases → `MaxDomains`/`MaxEmailAccounts`/`MaxDatabases`. Docker/Python allowances default `0` (no Plesk equivalent). `ID`+timestamps assigned at create, not by the mapper. `0` = unlimited (also how an unmapped Plesk limit lands — safe default).
- **`CustomerToUser`** (pure) — → `UserDraft`. **No password field exists on the draft** — Plesk hashes aren't portable, so restore mints an invite/forced-reset. Username sanitised to jabali's charset (email logins keep the local part).
- `parsePleskSizeMB` / `parsePleskCount` — unit-aware (`500M`, `1 GB`, bare bytes, `unlimited`/`-1` → 0).

## ⚠️ Plan mutation — Step 5 split (discover / create)
This PR is **discovery + pure mapping** only. The **destination create** (HostingPackage upsert + user creation + invite + ownership wiring + reseller flatten — the security-sensitive, *mutating* half) folds into the restore step (**3b**), where the **security review** lands. Nothing here writes to the destination or handles credentials.

## Tests
Size/count unit conversions, plan→package field map, customer→user draft (no password, sanitised username), `DiscoverTenants` parsing. Build + vet green.

## Refs
GH #429. Does not close the issue. Coded against Plesk CLI docs; not yet live-validated.