### PR TITLE
fix(migrate): correct Plesk describe against a live Plesk Obsidian 18 box (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/areas.go
+++ b/panel-api/internal/migrate/plesk/areas.go
@@ -29,12 +29,26 @@ const pleskVhostRoot = "/var/www/vhosts"
 // `plesk bin domain --info <domain>`; docroot defaults to the standard
 // Plesk vhost path.
 func (d *Discoverer) describeDomains(ctx context.Context, s *session, account string) ([]migrate.DomainSpec, error) {
+	// All domains of the subscription: the primary (name=account) plus any
+	// domain whose webspace_id points at the primary's id (addon domains).
+	// The `plesk bin subscription/domain --info` output does NOT list the
+	// domain set, so this comes from the psa `domains` table.
 	domains := []string{account}
-	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin subscription --info "+shellQuote(account)); err == nil {
-		info := parsePleskInfo(string(out))
-		if v := firstNonEmpty(info["domains"], info["domain aliases"]); v != "" {
-			if parsed := splitCSV(v); len(parsed) > 0 {
-				domains = parsed
+	sql := fmt.Sprintf(
+		"SELECT name FROM domains WHERE name=%s OR webspace_id=(SELECT id FROM domains WHERE name=%s LIMIT 1)",
+		sqlQuote(account), sqlQuote(account))
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql)); err == nil {
+		if parsed := splitLines(string(out)); len(parsed) > 0 {
+			seen := map[string]bool{}
+			domains = domains[:0]
+			for _, n := range parsed {
+				if !seen[n] {
+					seen[n] = true
+					domains = append(domains, n)
+				}
+			}
+			if !seen[account] {
+				domains = append([]string{account}, domains...)
 			}
 		}
 	}
@@ -49,14 +63,13 @@ func (d *Discoverer) describeDomains(ctx context.Context, s *session, account st
 		}
 		if out, err := s.run(ctx, d.CommandTimeout, "plesk bin domain --info "+shellQuote(dom)); err == nil {
 			di := parsePleskInfo(string(out))
+			// Real Plesk exposes "PHP support: Yes" (not "php"); PHP version
+			// isn't in this block. Docroot stays the standard vhost path.
+			if v := firstNonEmpty(di["php support"], di["php"]); v != "" {
+				spec.HasPHP = truthy(v)
+			}
 			if v := firstNonEmpty(di["php version"], di["php_version"]); v != "" {
 				spec.PHPVer = v
-			}
-			if v := firstNonEmpty(di["www-root"], di["www_root"], di["document root"]); v != "" {
-				spec.DocRoot = v
-			}
-			if v := di["php"]; v != "" {
-				spec.HasPHP = truthy(v)
 			}
 		}
 		rows = append(rows, spec)
@@ -73,7 +86,11 @@ func (d *Discoverer) describeDatabases(ctx context.Context, s *session, domains 
 	rows := []migrate.DatabaseSpec{}
 	warns := []migrate.Warning{}
 	for _, dom := range domains {
-		out, err := s.run(ctx, d.CommandTimeout, "plesk bin database --list -domain "+shellQuote(dom.Name))
+		// `plesk bin database` has no list verb; enumerate via the psa DB.
+		sql := fmt.Sprintf(
+			"SELECT db.name FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name=%s",
+			sqlQuote(dom.Name))
+		out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql))
 		if err != nil {
 			warns = append(warns, migrate.Warning{
 				Code:   "databases_domain_failed",

--- a/panel-api/internal/migrate/plesk/areas_test.go
+++ b/panel-api/internal/migrate/plesk/areas_test.go
@@ -24,31 +24,50 @@ func fixtureSession(responses map[string]string) *session {
 	}}
 }
 
-func TestParsePleskInfo(t *testing.T) {
-	raw := "Subscription info:\n" +
-		"    Domain name: example.com\n" +
-		"    PHP version: 8.2\n" +
-		"    Hosting type: virtual\n" +
-		"    # a comment\n" +
-		"    Status\n" // valueless line → skipped
+func TestParsePleskInfo_ColonFormat(t *testing.T) {
+	raw := "General\n" +
+		"=============================\n" +
+		"Domain name:                            example.com\n" +
+		"PHP support:                            Yes\n" +
+		"Total size of local backup files (if enabled in Server Settings):0 B\n"
 	got := parsePleskInfo(raw)
 	if got["domain name"] != "example.com" {
 		t.Errorf("domain name = %q, want example.com", got["domain name"])
 	}
-	if got["php version"] != "8.2" {
-		t.Errorf("php version = %q, want 8.2", got["php version"])
+	if got["php support"] != "Yes" {
+		t.Errorf("php support = %q, want Yes", got["php support"])
 	}
-	if _, ok := got["status"]; ok {
-		t.Error("valueless line must be skipped")
+	if _, ok := got["general"]; ok {
+		t.Error("section header must be skipped")
+	}
+}
+
+func TestParsePleskInfo_AlignedFormat(t *testing.T) {
+	raw := "Limits\n" +
+		"================================================\n" +
+		"Service plan name                               Unlimited\n" +
+		"Disk space                                      10240M\n" +
+		"Log rotation condition                          by size: 10240 KB\n"
+	got := parsePleskInfo(raw)
+	if got["service plan name"] != "Unlimited" {
+		t.Errorf("service plan name = %q, want Unlimited", got["service plan name"])
+	}
+	if got["disk space"] != "10240M" {
+		t.Errorf("disk space = %q, want 10240M", got["disk space"])
+	}
+	if got["log rotation condition"] != "by size: 10240 KB" {
+		t.Errorf("log rotation condition = %q, want 'by size: 10240 KB'", got["log rotation condition"])
 	}
 }
 
 func TestDescribeDomains_DocrootAndPHP(t *testing.T) {
 	d := New()
 	s := fixtureSession(map[string]string{
-		"subscription --info":               "Domain name: example.com\ndomains: example.com, addon.example.net\n",
-		"domain --info 'example.com'":       "PHP version: 8.2\nphp: on\n",
-		"domain --info 'addon.example.net'": "PHP version: 7.4\nphp: on\nwww-root: /var/www/vhosts/example.com/addon\n",
+		// domains enumerated from the psa DB (primary + addon); key is a
+		// quote-free substring of the shell-escaped `plesk db` command.
+		"SELECT name FROM domains":          "example.com\naddon.example.net\n",
+		"domain --info 'example.com'":       "PHP support:  Yes\n",
+		"domain --info 'addon.example.net'": "PHP support:  Yes\n",
 	})
 	rows, err := d.describeDomains(context.Background(), s, "example.com")
 	if err != nil {
@@ -63,12 +82,8 @@ func TestDescribeDomains_DocrootAndPHP(t *testing.T) {
 	if rows[0].DocRoot != "/var/www/vhosts/example.com/httpdocs" {
 		t.Errorf("primary docroot = %q, want default vhost path", rows[0].DocRoot)
 	}
-	if rows[0].PHPVer != "8.2" {
-		t.Errorf("primary PHPVer = %q, want 8.2", rows[0].PHPVer)
-	}
-	// addon carries an overridden docroot from www-root.
-	if rows[1].DocRoot != "/var/www/vhosts/example.com/addon" {
-		t.Errorf("addon docroot override not applied: %q", rows[1].DocRoot)
+	if !rows[0].HasPHP {
+		t.Error("primary should have PHP (PHP support: Yes)")
 	}
 	if rows[1].IsPrimary {
 		t.Error("addon domain must not be primary")
@@ -93,7 +108,10 @@ func TestDescribeDomains_FallbackToPrimary(t *testing.T) {
 func TestDescribeDatabases_ParsesAndWarnsPerDomain(t *testing.T) {
 	d := New()
 	s := fixtureSession(map[string]string{
-		"database --list -domain 'example.com'": "wp_main\nwp_shop\n",
+		// key on the bare domain (a literal substring of the escaped SQL,
+		// which wraps quotes as '\'') so only example.com resolves;
+		// addon.example.net returns empty → no rows.
+		"example.com": "wp_main\nwp_shop\n",
 		// addon.example.net returns empty → no rows, no crash.
 	})
 	domains := []migrate.DomainSpec{{Name: "example.com"}, {Name: "addon.example.net"}}

--- a/panel-api/internal/migrate/plesk/customers.go
+++ b/panel-api/internal/migrate/plesk/customers.go
@@ -75,7 +75,11 @@ func (d *Discoverer) DiscoverTenants(ctx context.Context, raw migrate.Session) (
 	}
 	ts := &TenantSet{Plans: []PleskPlan{}, Customers: []PleskCustomer{}}
 
-	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin service_plan --list"); err == nil {
+	// `plesk bin service_plan` / `customer` have no list verb; enumerate the
+	// names via the psa DB (`plesk db` reads bypass the customer-management
+	// license gate), then pull each one's detail with `--info`. Hosting
+	// plans are Templates.type='domain' (reseller plans are 'reseller').
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote("SELECT name FROM Templates WHERE type='domain'")); err == nil {
 		for _, name := range splitLines(string(out)) {
 			info, ierr := s.run(ctx, d.CommandTimeout, "plesk bin service_plan --info "+shellQuote(name))
 			if ierr != nil {
@@ -85,7 +89,7 @@ func (d *Discoverer) DiscoverTenants(ctx context.Context, raw migrate.Session) (
 		}
 	}
 
-	if out, err := s.run(ctx, d.CommandTimeout, "plesk bin customer --list"); err == nil {
+	if out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote("SELECT login FROM clients WHERE type='customer'")); err == nil {
 		for _, login := range splitLines(string(out)) {
 			info, ierr := s.run(ctx, d.CommandTimeout, "plesk bin customer --info "+shellQuote(login))
 			if ierr != nil {
@@ -106,7 +110,7 @@ func parsePleskPlan(name, info string) PleskPlan {
 		MaxDomains:   parsePleskCount(firstNonEmpty(m["domains"], m["max domains"], m["maximum number of domains"])),
 		MaxMailboxes: parsePleskCount(firstNonEmpty(m["mailboxes"], m["mailboxes number"], m["maximum number of mailboxes"])),
 		MaxDatabases: parsePleskCount(firstNonEmpty(m["databases"], m["max databases"], m["maximum number of databases"])),
-		Owner:        firstNonEmpty(m["owner"], m["reseller"]),
+		Owner:        firstNonEmpty(m["service plan owner"], m["owner"], m["reseller"]),
 	}
 }
 

--- a/panel-api/internal/migrate/plesk/customers_test.go
+++ b/panel-api/internal/migrate/plesk/customers_test.go
@@ -93,12 +93,13 @@ func TestSanitizeUsername(t *testing.T) {
 func TestDiscoverTenants_ParsesPlansAndCustomers(t *testing.T) {
 	d := New()
 	s := fixtureSession(map[string]string{
-		"service_plan --list":             "Unlimited\nBusiness\n",
-		"service_plan --info 'Unlimited'": "disk space: unlimited\nmax traffic: unlimited\ndomains: unlimited\n",
-		"service_plan --info 'Business'":  "disk space: 10240M\nmax traffic: 100G\ndomains: 25\nmailboxes: 100\ndatabases: 50\n",
-		"customer --list":                 "jdoe\nacme\n",
-		"customer --info 'jdoe'":          "contact name: John Doe\nemail: jd@example.com\nstatus: active\n",
-		"customer --info 'acme'":          "company: ACME Ltd\nemail: ops@acme.com\nsuspended: true\nreseller: bigres\n",
+		"SELECT name FROM Templates": "Unlimited\nBusiness\n",
+		// real service_plan --info: column-aligned (no colon).
+		"service_plan --info 'Unlimited'": "Disk space                Unlimited\nTraffic                   Unlimited\nDomains                   Unlimited\n",
+		"service_plan --info 'Business'":  "Disk space                10240M\nTraffic                   100G\nDomains                   25\nMailboxes                 100\nDatabases                 50\n",
+		"SELECT login FROM clients":       "jdoe\nacme\n",
+		"customer --info 'jdoe'":          "Contact name:  John Doe\nEmail:  jd@example.com\nStatus:  active\n",
+		"customer --info 'acme'":          "Company:  ACME Ltd\nEmail:  ops@acme.com\nSuspended:  true\nReseller:  bigres\n",
 	})
 	ts, err := d.DiscoverTenants(context.Background(), s)
 	if err != nil {

--- a/panel-api/internal/migrate/plesk/parse.go
+++ b/panel-api/internal/migrate/plesk/parse.go
@@ -1,10 +1,15 @@
 package plesk
 
 import (
+	"regexp"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
 )
+
+// multiSpaceGap matches the column gap (2+ spaces) between a key and its
+// value in Plesk's aligned `--info` output.
+var multiSpaceGap = regexp.MustCompile(`\s{2,}`)
 
 // parsePleskList turns `plesk bin subscription --list` output — one
 // subscription name (the primary domain) per line — into account
@@ -43,12 +48,20 @@ func parsePleskInfo(raw string) map[string]string {
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
 		}
+		// Two Plesk --info formats coexist: `Key: value` (colon-separated,
+		// e.g. subscription/domain --info) and `Key<2+ spaces>value`
+		// (column-aligned, multi-word keys, e.g. service_plan --info). Split
+		// on whichever delimiter appears FIRST so an aligned line whose value
+		// itself contains a colon ("... by size: 10240 KB") keys correctly.
 		key, val := "", ""
-		if i := strings.IndexByte(trimmed, ':'); i >= 0 {
-			key, val = trimmed[:i], strings.TrimSpace(trimmed[i+1:])
-		} else if i := strings.IndexAny(trimmed, " \t"); i >= 0 {
-			key, val = trimmed[:i], strings.TrimSpace(trimmed[i+1:])
-		} else {
+		colon := strings.IndexByte(trimmed, ':')
+		gap := multiSpaceGap.FindStringIndex(trimmed)
+		switch {
+		case colon >= 0 && (gap == nil || colon < gap[0]):
+			key, val = trimmed[:colon], strings.TrimSpace(trimmed[colon+1:])
+		case gap != nil:
+			key, val = trimmed[:gap[0]], strings.TrimSpace(trimmed[gap[1]:])
+		default:
 			continue
 		}
 		key = strings.ToLower(strings.TrimSpace(key))
@@ -60,4 +73,11 @@ func parsePleskInfo(raw string) map[string]string {
 		}
 	}
 	return out
+}
+
+// sqlQuote single-quotes a value for safe interpolation into a `plesk db`
+// SQL statement (doubles embedded single quotes). Source-provided names
+// (domains) never reach the psa SQL unescaped.
+func sqlQuote(v string) string {
+	return "'" + strings.ReplaceAll(v, "'", "''") + "'"
 }

--- a/panel-api/internal/migrate/plesk/wordpress.go
+++ b/panel-api/internal/migrate/plesk/wordpress.go
@@ -34,7 +34,7 @@ func (d *Discoverer) describeWordPress(ctx context.Context, s *session, domains 
 	warns := []migrate.Warning{}
 	owned := map[string]migrate.DomainSpec{}
 	for _, dom := range domains {
-		owned[strings.ToLower(dom.Name)] = dom
+		owned[normalizeHost(dom.Name)] = dom
 	}
 
 	out, err := s.run(ctx, d.CommandTimeout, "plesk ext wp-toolkit --list -format json")
@@ -57,14 +57,18 @@ func (d *Discoverer) describeWordPress(ctx context.Context, s *session, domains 
 
 	apps := []migrate.AppSpec{}
 	for _, inst := range instances {
-		host := strings.ToLower(inst.domainHost())
-		dom, ok := owned[host]
+		dom, ok := owned[normalizeHost(inst.domainHost())]
 		if !ok {
 			continue // instance belongs to another account
 		}
+		// Prefer WP Toolkit's absolute fullPath; else derive from docroot.
+		instPath := inst.FullPath
+		if instPath == "" {
+			instPath = joinDocrootPath(dom, inst.Path)
+		}
 		apps = append(apps, migrate.AppSpec{
 			Kind:    "wordpress",
-			Path:    joinDocrootPath(dom, inst.Path),
+			Path:    instPath,
 			Version: inst.Version,
 		})
 	}
@@ -92,6 +96,7 @@ type wpInstance struct {
 	MainDomain string
 	SiteURL    string
 	Path       string
+	FullPath   string // absolute install path (WP Toolkit "fullPath")
 	Version    string
 }
 
@@ -147,6 +152,7 @@ func parseWPToolkitList(raw string) ([]wpInstance, error) {
 			MainDomain: strFromKeys(r, "mainDomain", "main_domain", "domainName", "domain"),
 			SiteURL:    strFromKeys(r, "siteUrl", "site_url", "url"),
 			Path:       strFromKeys(r, "path", "mainDomainPath", "main_domain_path", "mainDomainsPath"),
+			FullPath:   strFromKeys(r, "fullPath", "full_path"),
 			Version:    strFromKeys(r, "version", "wpVersion", "wp_version"),
 		})
 	}
@@ -180,4 +186,11 @@ func joinDocrootPath(dom migrate.DomainSpec, wpPath string) string {
 	// vhost root is the docroot with a trailing "/httpdocs" removed.
 	vhostRoot := strings.TrimSuffix(dom.DocRoot, "/httpdocs")
 	return path.Clean(vhostRoot + "/" + strings.TrimPrefix(wpPath, "/"))
+}
+
+// normalizeHost lowercases a hostname and strips a leading "www." so a
+// WP Toolkit siteUrl of https://www.example.com matches the account's
+// "example.com" domain.
+func normalizeHost(h string) string {
+	return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(h)), "www.")
 }

--- a/panel-api/internal/migrate/plesk/wordpress_test.go
+++ b/panel-api/internal/migrate/plesk/wordpress_test.go
@@ -8,13 +8,18 @@ import (
 )
 
 func TestParseWPToolkitList_ArrayAndWrapper(t *testing.T) {
-	arr := `[{"mainDomain":"example.com","path":"/httpdocs","version":"6.5","siteUrl":"https://example.com"}]`
+	// Real Plesk Obsidian 18 shape: no mainDomain; siteUrl carries www.,
+	// fullPath is absolute.
+	arr := `[{"id":1,"mainDomainId":1,"path":"\/httpdocs","siteUrl":"https:\/\/www.example.com","version":"6.7.5","fullPath":"\/var\/www\/vhosts\/example.com\/httpdocs"}]`
 	rows, err := parseWPToolkitList(arr)
 	if err != nil || len(rows) != 1 {
 		t.Fatalf("array parse: %v rows=%+v", err, rows)
 	}
-	if rows[0].MainDomain != "example.com" || rows[0].Version != "6.5" {
+	if rows[0].SiteURL != "https://www.example.com" || rows[0].Version != "6.7.5" {
 		t.Errorf("row = %+v", rows[0])
+	}
+	if rows[0].FullPath != "/var/www/vhosts/example.com/httpdocs" {
+		t.Errorf("fullPath = %q", rows[0].FullPath)
 	}
 
 	wrapped := `{"instances":[{"domainName":"shop.example.net","mainDomainPath":"/httpdocs/blog","wpVersion":"6.4"}]}`
@@ -56,9 +61,11 @@ func TestDescribeWordPress_FiltersToAccountDomains(t *testing.T) {
 	d := New()
 	// Server has two instances; only example.com belongs to this account.
 	s := fixtureSession(map[string]string{
+		// siteUrl carries www.; matching must normalise. fullPath is used
+		// for Path. Second instance belongs to another account → filtered.
 		"wp-toolkit --list -format json": `[
-			{"mainDomain":"example.com","path":"/httpdocs","version":"6.5"},
-			{"mainDomain":"other.tld","path":"/httpdocs","version":"6.5"}
+			{"siteUrl":"https://www.example.com","version":"6.7.5","fullPath":"/var/www/vhosts/example.com/httpdocs"},
+			{"siteUrl":"https://other.tld","version":"6.5","fullPath":"/var/www/vhosts/other.tld/httpdocs"}
 		]`,
 	})
 	domains := []migrate.DomainSpec{{Name: "example.com", DocRoot: "/var/www/vhosts/example.com/httpdocs"}}
@@ -66,7 +73,7 @@ func TestDescribeWordPress_FiltersToAccountDomains(t *testing.T) {
 	if len(apps) != 1 {
 		t.Fatalf("got %d apps, want 1 (filtered to account domains): %+v", len(apps), apps)
 	}
-	if apps[0].Kind != "wordpress" || apps[0].Path != "/var/www/vhosts/example.com/httpdocs" || apps[0].Version != "6.5" {
+	if apps[0].Kind != "wordpress" || apps[0].Path != "/var/www/vhosts/example.com/httpdocs" || apps[0].Version != "6.7.5" {
 		t.Errorf("app = %+v", apps[0])
 	}
 	if len(warns) != 0 {


### PR DESCRIPTION
Validated the shipped Plesk describe code (Steps 1–5) against a **real Plesk Obsidian 18.0.78** host — read-only — and fixed four places where it was coded against docs but diverged from actual output. Without these, describe would find **zero databases and zero plans** on a real box.

## Bugs found on the live box + fixes
| Area | Real behaviour | Fix |
|---|---|---|
| `parsePleskInfo` | `--info` uses **two** formats: `Key: value` (subscription/domain) **and** column-aligned `Key<2+ spaces>value` with multi-word keys (service_plan) | Split on whichever delimiter (colon or 2+ space run) comes **first** — handles aligned values that contain a colon (`by size: 10240 KB`) |
| `describeDatabases` | `plesk bin database` has **no list verb** → errored on every call | Enumerate via `plesk db` SQL (`data_bases JOIN domains`) |
| `DiscoverTenants` | `service_plan --list` / `customer --list` **don't exist** | Names from psa DB (`Templates.type='domain'`, `clients.type='customer'` — `plesk db` reads bypass the customer-mgmt license gate), then `--info` |
| `describeDomains` | domain set isn't in `--info` | Enumerate from psa `domains` table (primary + addon via `webspace_id`); read real `PHP support:` key |
| WordPress | `wp-toolkit --list -format json` has **no `mainDomain`** — only `mainDomainId` + `siteUrl` (with `www.`) + absolute `fullPath` | Match after stripping `www.`; use `fullPath` for the install path |

## Safety
- All source access read-only: `plesk bin … --info`, `plesk db` **SELECT** only, `ls`. No source mutation.
- Source-provided names (domains) are **SQL-escaped** (`sqlQuote`) before interpolation into `plesk db`.
- Validated against a single-subscription production box (`lychee-fruits.co.il`): DB `lycheefr_wp2`, plans in `Templates`, one WP 6.7.5 install — all now parsed correctly.

## Tests
Updated to the **real captured output shapes** — both `--info` formats, the SQL enumeration commands, real WP Toolkit JSON. Build + vet green.

## Refs
GH #429. Does not close. This validates the read-only surface; restore (3b) still pending.