### PR TITLE
feat(migrate): wire Plesk into the pull-source command (GH #429 step 3b-ii)

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -41,6 +41,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressplugin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressssh"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -195,6 +196,8 @@ live source SSH. Use scp directly for that kind.`,
 				localTar, err = pullDirectAdmin(ctx, sshUser, job, secret, localDir, allowPrivate)
 			case models.MigrationSourceHestia:
 				localTar, err = pullHestia(ctx, sshUser, job, secret, localDir, allowPrivate)
+			case models.MigrationSourcePlesk:
+				localTar, err = pullPlesk(ctx, sshUser, job, secret, localDir, allowPrivate)
 			default:
 				return markPullFailed(fmt.Errorf("unknown source kind %q", job.SourceKind))
 			}
@@ -533,6 +536,36 @@ func pullDirectAdmin(ctx context.Context, sshUser string, job *models.MigrationJ
 		return "", fmt.Errorf("PullFile: %w", err)
 	}
 	// JAB-50: don't leave the full account backup on the source server.
+	if rmErr := d.RemoveRemote(ctx, s, remoteTar); rmErr != nil {
+		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
+	}
+	return localTar, nil
+}
+
+// pullPlesk stages the Plesk source's cpmove METADATA tarball into localDir,
+// mirroring pullDirectAdmin. The tarball is tiny (~KB) — DB dumps + docroots
+// + Maildirs are manifested inside it (databases.txt / domains-paths.txt /
+// mail-paths.txt) and streamed/rsynced by the import step, NOT bundled here
+// (a real Plesk box carried a 6.9 GB DB). SourceUser is the subscription
+// (primary domain). Read-only on the source; stages locally + stops.
+func pullPlesk(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
+	d := plesk.New()
+	d.AllowPrivate = allowPrivate
+	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
+	if err != nil {
+		return "", fmt.Errorf("plesk.Connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, s) }()
+	remoteTar, err := d.BackupUser(ctx, s, job.SourceUser)
+	if err != nil {
+		return "", fmt.Errorf("plesk cpmove synthesize: %w", err)
+	}
+	localTar := filepath.Join(localDir, fmt.Sprintf("user.%s.tar.gz", job.SourceUser))
+	if _, err := d.PullFile(ctx, s, remoteTar, localTar); err != nil {
+		return "", fmt.Errorf("PullFile: %w", err)
+	}
+	// JAB-50: don't leave the metadata backup (DB dumps manifest, contact
+	// email) on the source server.
 	if rmErr := d.RemoveRemote(ctx, s, remoteTar); rmErr != nil {
 		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
 	}

--- a/panel-api/internal/migrate/plesk/backup_test.go
+++ b/panel-api/internal/migrate/plesk/backup_test.go
@@ -63,3 +63,14 @@ func TestBackupUser_RejectsBadSubscription(t *testing.T) {
 		t.Error("BackupUser must reject a shell-unsafe subscription name")
 	}
 }
+
+// pullCaller is the method set migrate_pull_cmd.go's pullPlesk relies on.
+// This compile-time assertion catches a signature drift in BackupUser /
+// PullFile / RemoveRemote before it breaks the pull command's build.
+type pullCaller interface {
+	BackupUser(ctx context.Context, raw interface{}, account string) (string, error)
+	PullFile(ctx context.Context, raw interface{}, remotePath, localPath string) (int64, error)
+	RemoveRemote(ctx context.Context, raw interface{}, path string) error
+}
+
+var _ pullCaller = (*Discoverer)(nil)


### PR DESCRIPTION
**Step 3b-ii of the Plesk migration blueprint** — wire Plesk into the `jabali migrate pull-source` command.

## What
- **`pullPlesk`** mirrors `pullDirectAdmin`: Connect → `BackupUser` (cpmove metadata tarball) → `PullFile` into the local staging dir → `RemoveRemote` (don't leave the backup on the source).
- `plesk` case added to the pull-source `source_kind` switch.
- Compile-time `pullCaller` guard in the plesk package catches a `BackupUser`/`PullFile`/`RemoveRemote` signature drift before it breaks the pull build.

## Gated — deliberately
`plesk` is **not** added to `isKnownSourceKind` (the admin-create allowlist) or the UI picker yet, so no operator can start a plesk migration until the import side works. Consistent with the read-only-first rollout. This is **code-complete pull wiring**; the pull stages to a local dir and **stops** (operator-gated import next), so it is **non-destination-mutating**.

## Deferred to 3b-iii (import)
DB dumps + docroots + Maildirs are manifested in the tarball (`databases.txt` / `domains-paths.txt` / `mail-paths.txt`), not bundled — the import streams the DB directly (a real box carried a **6.9 GB** DB) and rsyncs docroots/Maildirs, then dispatches `import_run` + creates the target user/package (with the security review + live e2e).

## Tests
`pullCaller` compile guard + existing plesk suite. Build + vet green (`pullPlesk` reuses the live-validated `BackupUser` from #437).

## Refs
GH #429. Does not close.