### PR TITLE
feat(migrate): Plesk restore tree-population builders (GH #429 step 3b-iii core)

### DIFF
--- a/panel-api/internal/migrate/plesk/restore.go
+++ b/panel-api/internal/migrate/plesk/restore.go
@@ -1,0 +1,68 @@
+package plesk
+
+import (
+	"fmt"
+	"strings"
+)
+
+// restore.go — the source-side building blocks that turn the Plesk
+// metadata cpmove tarball (databases.txt / domains-paths.txt /
+// mail-paths.txt manifests) into a full cpmove tree the existing cpanel
+// import writers consume. These are PURE builders/parsers — no execution,
+// no destination mutation. The import step (3b-iii, dest-mutating) wires
+// them into the pull/restore flow: it streams each DB dump and rsyncs each
+// docroot/Maildir using these commands, then dispatches migration.import_run.
+//
+// Why stream instead of bundle: a real Plesk box carried a 6.9 GB
+// WordPress DB — bundling a mysqldump into the /tmp tarball would batter
+// the source. The DB is dumped straight to the destination-side staging
+// dir via `ssh source '<dbDumpCommand>' > mysql/<db>.sql`.
+
+// ManifestEntry is one row of a TSV manifest (domains-paths.txt /
+// mail-paths.txt): a logical name + an absolute source path.
+type ManifestEntry struct {
+	Name string // domain (domains-paths) or address (mail-paths)
+	Path string // absolute source path (docroot / Maildir)
+}
+
+// parseTSVManifest parses `name\tpath` lines (domains-paths.txt,
+// mail-paths.txt). Blank/comment lines and rows missing a tab are skipped.
+func parseTSVManifest(content string) []ManifestEntry {
+	out := []ManifestEntry{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		name, path, ok := strings.Cut(line, "\t")
+		name, path = strings.TrimSpace(name), strings.TrimSpace(path)
+		if !ok || name == "" || path == "" {
+			continue
+		}
+		out = append(out, ManifestEntry{Name: name, Path: path})
+	}
+	return out
+}
+
+// parseLinesManifest parses a one-value-per-line manifest (databases.txt).
+func parseLinesManifest(content string) []string {
+	return splitLines(content)
+}
+
+// dbDumpCommand builds the READ-ONLY mysqldump command to run on the Plesk
+// source (over SSH) to stream one database to stdout. Plesk stashes the
+// admin DB password at /etc/psa/.psa.shadow; --single-transaction takes a
+// consistent snapshot without locking (InnoDB). The db name (from the
+// source manifest) is shell-escaped. Caller redirects stdout into the
+// destination-side mysql/<db>.sql — the dump is never staged on the source.
+func dbDumpCommand(db string) string {
+	return fmt.Sprintf(
+		`MYSQL_PWD="$(cat /etc/psa/.psa.shadow)" mysqldump -uadmin --skip-lock-tables --single-transaction %s`,
+		shellQuote(db))
+}
+
+// docrootRemotePath returns the absolute source docroot for a
+// domains-paths.txt entry (identity — the manifest already holds the
+// absolute path). Exposed as a named helper so the rsync wiring reads
+// intently and a future path-rewrite has one home.
+func docrootRemotePath(e ManifestEntry) string { return e.Path }

--- a/panel-api/internal/migrate/plesk/restore_test.go
+++ b/panel-api/internal/migrate/plesk/restore_test.go
@@ -1,0 +1,61 @@
+package plesk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTSVManifest(t *testing.T) {
+	content := "lychee-fruits.co.il\t/var/www/vhosts/lychee-fruits.co.il/httpdocs\n" +
+		"\n# comment\n" +
+		"addon.example.net\t/var/www/vhosts/addon.example.net/httpdocs\r\n" +
+		"broken-no-tab\n"
+	got := parseTSVManifest(content)
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2 (blank/comment/no-tab skipped): %+v", len(got), got)
+	}
+	if got[0].Name != "lychee-fruits.co.il" || got[0].Path != "/var/www/vhosts/lychee-fruits.co.il/httpdocs" {
+		t.Errorf("entry0 = %+v", got[0])
+	}
+	if got[1].Name != "addon.example.net" { // trailing \r stripped
+		t.Errorf("entry1 name = %q", got[1].Name)
+	}
+}
+
+func TestParseLinesManifest(t *testing.T) {
+	got := parseLinesManifest("lycheefr_wp2\n\n# x\nother_db\n")
+	if len(got) != 2 || got[0] != "lycheefr_wp2" || got[1] != "other_db" {
+		t.Errorf("dbs = %v", got)
+	}
+}
+
+func TestDBDumpCommand_ReadOnlyAndEscaped(t *testing.T) {
+	cmd := dbDumpCommand("lycheefr_wp2")
+	// read-only snapshot, admin creds from the Plesk shadow file.
+	for _, want := range []string{
+		"mysqldump", "--single-transaction", "-uadmin",
+		"/etc/psa/.psa.shadow", "'lycheefr_wp2'",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("dbDumpCommand missing %q in %q", want, cmd)
+		}
+	}
+	// must NOT be a mutating verb.
+	for _, bad := range []string{"mysql -e", "DROP", "DELETE", "--where"} {
+		if strings.Contains(cmd, bad) {
+			t.Errorf("dbDumpCommand must be read-only, found %q", bad)
+		}
+	}
+	// a hostile db name is single-quote-escaped, not injected.
+	evil := dbDumpCommand("a'; DROP DATABASE x; --")
+	if !strings.Contains(evil, `'a'\''; DROP DATABASE x; --'`) {
+		t.Errorf("db name not escaped: %q", evil)
+	}
+}
+
+func TestDocrootRemotePath(t *testing.T) {
+	e := ManifestEntry{Name: "d", Path: "/var/www/vhosts/d/httpdocs"}
+	if docrootRemotePath(e) != "/var/www/vhosts/d/httpdocs" {
+		t.Errorf("got %q", docrootRemotePath(e))
+	}
+}


### PR DESCRIPTION
**Step 3b-iii (core) of the Plesk migration blueprint** — pure, **non-mutating** source-side builders that turn the Plesk metadata cpmove tarball into a full cpmove tree the existing cpanel import writers consume. No execution, no destination writes.

## What
- **`parseTSVManifest` / `parseLinesManifest`** — read the `databases.txt`, `domains-paths.txt`, `mail-paths.txt` manifests the backup step (#437) emits.
- **`dbDumpCommand`** — builds the **read-only** `mysqldump` the import streams over SSH (source → destination-side `mysql/<db>.sql`). Admin creds from `/etc/psa/.psa.shadow`; `--single-transaction` snapshots without locking; the db name (from the source manifest) is **single-quote escaped**. The 6.9 GB DB is streamed, never staged on the source.

## Deferred to 3b-iii-exec (the dest-mutating half)
Wire these into the import to stream DBs + rsync docroots/Maildirs into the extracted tree, add `plesk` to the import switch + `isKnownSourceKind` + UI picker, **create the target user/HostingPackage** from the Step-5 mapping + invite (**security review**), import mailboxes, and run the live **prod→.86 e2e**.

## Tests
Manifest parsing (blank/comment/no-tab/`\r`), `dbDumpCommand` read-only assertions + SQL-injection escaping. Build + vet green.

## Refs
GH #429. Does not close.