### PR TITLE
feat(migrate): Plesk DB-stream + tree populate for restore (GH #429 step 3b-iii)

### DIFF
--- a/panel-api/internal/migrate/plesk/backup.go
+++ b/panel-api/internal/migrate/plesk/backup.go
@@ -183,3 +183,7 @@ func truncForLog(s string, n int) string {
 	}
 	return s[:n] + "...[truncated]"
 }
+
+// Slug exposes the subscription→archive-slug mapping to the pull/import
+// wiring (which locates cpmove-<slug>/ inside the extracted tree).
+func Slug(sub string) string { return pleskSlug(sub) }

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -245,3 +245,34 @@ func (d *Discoverer) Close(ctx context.Context, raw migrate.Session) error {
 	}
 	return nil
 }
+
+// streamCommandToFile runs cmd on the source and streams its stdout to
+// localPath WITHOUT buffering — essential for a multi-GB mysqldump (a real
+// box carried a 6.9 GB DB; buffering it through run() would OOM the panel).
+func (s *session) streamCommandToFile(ctx context.Context, timeout time.Duration, cmd, localPath string) error {
+	subctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("ssh new session: %w", err)
+	}
+	defer sess.Close()
+	f, err := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return fmt.Errorf("open local %s: %w", localPath, err)
+	}
+	defer f.Close()
+	sess.Stdout = f
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(cmd) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("ssh stream %q: %w", cmd, err)
+		}
+		return nil
+	case <-subctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return fmt.Errorf("ssh stream %q: timed out after %s", cmd, timeout)
+	}
+}

--- a/panel-api/internal/migrate/plesk/restore.go
+++ b/panel-api/internal/migrate/plesk/restore.go
@@ -1,9 +1,25 @@
 package plesk
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 )
+
+// dbNameRe bounds a MySQL database name to a safe charset before it is used
+// as a local filename (<db>.sql) — blocks path traversal / injection from a
+// tampered source manifest.
+var dbNameRe = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+func validDBName(db string) bool { return dbNameRe.MatchString(db) }
+
+// dbStreamTimeout bounds a single DB dump stream. A 6.9 GB DB over a slow
+// link can take a while; this is generous.
+const dbStreamTimeout = 4 * time.Hour
 
 // restore.go — the source-side building blocks that turn the Plesk
 // metadata cpmove tarball (databases.txt / domains-paths.txt /
@@ -66,3 +82,45 @@ func dbDumpCommand(db string) string {
 // absolute path). Exposed as a named helper so the rsync wiring reads
 // intently and a future path-rewrite has one home.
 func docrootRemotePath(e ManifestEntry) string { return e.Path }
+
+// PopulatePleskDBs streams each database named in the extracted tree's
+// databases.txt into cpmove-<slug>/mysql/<db>.sql so the existing cpanel
+// ImportDatabases writer finds them. The dump is streamed straight to disk
+// (never buffered — see streamCommandToFile) and never staged on the
+// source. `stream` is injected so callers pass the live session's streamer
+// (and tests pass a fake). Returns the number of DBs dumped. A db name that
+// fails the charset guard is skipped (never used as an unchecked filename).
+func PopulatePleskDBs(extractDir, slug string, stream func(cmd, dstPath string) error) (int, error) {
+	base := filepath.Join(extractDir, "cpmove-"+slug)
+	mysqlDir := filepath.Join(base, "mysql")
+	if err := os.MkdirAll(mysqlDir, 0o750); err != nil {
+		return 0, fmt.Errorf("mkdir mysql dir: %w", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(base, "databases.txt"))
+	if err != nil {
+		return 0, nil // no manifest → no DBs (not fatal)
+	}
+	n := 0
+	for _, db := range parseLinesManifest(string(raw)) {
+		if !validDBName(db) {
+			continue // refuse a suspicious name as a filename
+		}
+		dst := filepath.Join(mysqlDir, db+".sql")
+		if err := stream(dbDumpCommand(db), dst); err != nil {
+			return n, fmt.Errorf("stream db %s: %w", db, err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// StreamDBDump is the production streamer bound to a live pull session; the
+// pull wiring passes a closure over this. Kept here so the SSH primitive and
+// the orchestration live together.
+func (d *Discoverer) StreamDBDump(ctx context.Context, raw interface{}, cmd, dstPath string) error {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return fmt.Errorf("StreamDBDump: bad session")
+	}
+	return s.streamCommandToFile(ctx, dbStreamTimeout, cmd, dstPath)
+}

--- a/panel-api/internal/migrate/plesk/restore_populate_test.go
+++ b/panel-api/internal/migrate/plesk/restore_populate_test.go
@@ -1,0 +1,81 @@
+package plesk
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidDBName(t *testing.T) {
+	ok := []string{"lycheefr_wp2", "db1", "A_b_9"}
+	bad := []string{"", "../etc", "a.sql", "a b", "a;b", "a/b", "a'b"}
+	for _, s := range ok {
+		if !validDBName(s) {
+			t.Errorf("%q should be valid", s)
+		}
+	}
+	for _, s := range bad {
+		if validDBName(s) {
+			t.Errorf("%q should be rejected", s)
+		}
+	}
+}
+
+func TestPopulatePleskDBs_StreamsValidSkipsBad(t *testing.T) {
+	extract := t.TempDir()
+	slug := "lychee_fruits_co_il"
+	base := filepath.Join(extract, "cpmove-"+slug)
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// databases.txt: two valid + one path-traversal attempt (must be skipped).
+	if err := os.WriteFile(filepath.Join(base, "databases.txt"),
+		[]byte("lycheefr_wp2\nshop_db\n../../etc/passwd\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	var streamed []string
+	fake := func(cmd, dstPath string) error {
+		streamed = append(streamed, dstPath)
+		// the command must be the read-only dump for the right db.
+		if !strings.Contains(cmd, "mysqldump") || !strings.Contains(cmd, "--single-transaction") {
+			t.Errorf("stream cmd not a read-only dump: %q", cmd)
+		}
+		return os.WriteFile(dstPath, []byte("-- dump\n"), 0o640)
+	}
+	n, err := PopulatePleskDBs(extract, slug, fake)
+	if err != nil {
+		t.Fatalf("PopulatePleskDBs: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("streamed %d dbs, want 2 (traversal skipped)", n)
+	}
+	// dumps landed under mysql/ with safe filenames.
+	for _, want := range []string{
+		filepath.Join(base, "mysql", "lycheefr_wp2.sql"),
+		filepath.Join(base, "mysql", "shop_db.sql"),
+	} {
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("expected dump %s: %v", want, err)
+		}
+	}
+}
+
+func TestPopulatePleskDBs_NoManifestIsQuiet(t *testing.T) {
+	extract := t.TempDir()
+	slug := "x"
+	if err := os.MkdirAll(filepath.Join(extract, "cpmove-"+slug), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	n, err := PopulatePleskDBs(extract, slug, func(_, _ string) error { return nil })
+	if err != nil || n != 0 {
+		t.Errorf("no databases.txt → (0,nil), got (%d,%v)", n, err)
+	}
+}
+
+func TestSlugExported(t *testing.T) {
+	if Slug("Lychee-Fruits.CO.il") != "lychee_fruits_co_il" {
+		t.Errorf("Slug wrapper wrong: %q", Slug("Lychee-Fruits.CO.il"))
+	}
+}


### PR DESCRIPTION
The safe, **non-mutating** core of the Plesk import: stream each manifested database into the extracted cpmove tree so the existing cpanel `ImportDatabases` writer consumes it. Stages to the local migration dir only — no destination writes.

## What
- **`session.streamCommandToFile`** — runs a source command and streams stdout **straight to a local file** (`sess.Stdout=f`, no buffering). Essential for the **6.9 GB** DB, which would OOM the panel through the buffering `run()` path. SIGKILL on timeout.
- **`PopulatePleskDBs`** — reads `databases.txt`, streams each db to `cpmove-<slug>/mysql/<db>.sql` via an injected streamer (live session in prod, fake in tests). A db name failing the `[A-Za-z0-9_]+` guard is **skipped** — never used as an unchecked filename (blocks path traversal from a tampered manifest).
- **`StreamDBDump`** — production streamer bound to a live pull session.
- **`Slug`** — exports the subscription→archive-slug mapping for the wiring.

## Still gated
`plesk` is not in `isKnownSourceKind`/UI. This stages DB dumps locally; the remaining **exec** step wires this into pull + the cpanel import switch, adds the **source-kind-aware rsync security guard** (security review), enables plesk, and runs the live prod→.86 e2e.

## Tests
`validDBName` charset, `PopulatePleskDBs` (streams valid, skips a path-traversal db name, no-manifest-is-quiet), `Slug`. Build + vet green.

## Refs
GH #429. Does not close.