### PR TITLE
feat(migrate): wire Plesk import + enable (GH #429 step 3b-iii exec-final)

### DIFF
--- a/panel-api/cmd/server/migrate_plesk_guard_test.go
+++ b/panel-api/cmd/server/migrate_plesk_guard_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+// TestIsHostnameLike guards the Plesk rsync source-path check: only a
+// DNS-hostname-shaped domain may anchor a /var/www/vhosts/<Dom>/httpdocs
+// source path. A path-traversal or shell-shaped "domain" must be rejected
+// so a tampered manifest can't escape the vhost tree.
+func TestIsHostnameLike(t *testing.T) {
+	ok := []string{"example.com", "lychee-fruits.co.il", "a.b.c.example.net", "x-1.io"}
+	bad := []string{
+		"",             // empty
+		"nodot",        // no dot
+		"..",           // traversal
+		"a/../b.com",   // slash + traversal
+		"a/b.com",      // slash
+		"UPPER.com",    // uppercase (Plesk domains are lowercased)
+		"a;rm -rf.com", // shell metachar
+		"a b.com",      // space
+		"a..b.com",     // double dot
+		"/etc/passwd",  // absolute path
+	}
+	for _, h := range ok {
+		if !isHostnameLike(h) {
+			t.Errorf("%q should be hostname-like", h)
+		}
+	}
+	for _, h := range bad {
+		if isHostnameLike(h) {
+			t.Errorf("%q must be rejected", h)
+		}
+	}
+}

--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -223,6 +223,17 @@ live source SSH. Use scp directly for that kind.`,
 				return markPullFailed(fmt.Errorf("extract: %w", err))
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "tarball extracted at %s\n", extractDir)
+
+			// GH #429: the Plesk cpmove is metadata-only (databases.txt
+			// manifest, no bundled dumps — a real box had a 6.9 GB DB).
+			// Stream each DB straight into the extracted mysql/ tree so the
+			// cpanel ImportDatabases writer finds it. Re-connect (pullPlesk
+			// closed its session); read-only mysqldump, no source staging.
+			if job.SourceKind == models.MigrationSourcePlesk {
+				if perr := populatePleskDBsAfterExtract(ctx, sshUser, job, secret, extractDir, allowPrivate); perr != nil {
+					return markPullFailed(fmt.Errorf("plesk db populate: %w", perr))
+				}
+			}
 			// Auto-kick import via the agent so the operator's "discover →
 			// select → continue" expectation lands at done, not at pending-
 			// with-tarball. CLI defaults (above) for target user/email/
@@ -570,6 +581,29 @@ func pullPlesk(ctx context.Context, sshUser string, job *models.MigrationJob, se
 		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
 	}
 	return localTar, nil
+}
+
+// populatePleskDBsAfterExtract re-connects to the Plesk source and streams
+// each manifested database into extractDir/cpmove-<slug>/mysql/<db>.sql, so
+// the cpanel ImportDatabases writer consumes them. Read-only on the source;
+// the dump is streamed straight to disk (never buffered — 6.9 GB DBs exist).
+func populatePleskDBsAfterExtract(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, extractDir string, allowPrivate bool) error {
+	d := plesk.New()
+	d.AllowPrivate = allowPrivate
+	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
+	if err != nil {
+		return fmt.Errorf("plesk.Connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, s) }()
+	slug := plesk.Slug(job.SourceUser)
+	n, err := plesk.PopulatePleskDBs(extractDir, slug, func(cmd, dst string) error {
+		return d.StreamDBDump(ctx, s, cmd, dst)
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("  \u2192 streamed %d database(s) into the cpmove tree\n", n)
+	return nil
 }
 
 func pullHestia(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -29,10 +29,13 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"gorm.io/gorm"
+
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
@@ -295,7 +298,8 @@ failed stage. Already-done stages are skipped.`,
 			case models.MigrationSourceCpanel,
 				models.MigrationSourceWHMpkgacct,
 				models.MigrationSourceDirectAdmin,
-				models.MigrationSourceHestia:
+				models.MigrationSourceHestia,
+				models.MigrationSourcePlesk:
 				// supported — fall through
 			default:
 				return failJob(fmt.Errorf("source kind %q not yet supported by jabali migrate import; "+
@@ -385,6 +389,41 @@ failed stage. Already-done stages are skipped.`,
 					fmt.Fprintf(cmd.ErrOrStderr(),
 						"warning: cpanel.ParseTarball failed on DA tarball %s (%v); using pre-extracted cp/<user>/ assumption\n",
 						daTarPath, perr)
+				}
+			case models.MigrationSourcePlesk:
+				// Plesk pull synthesises a METADATA cpmove (cpmove-<slug>/
+				// {cp,mysql,databases.txt,domains-paths.txt,mail-paths.txt,
+				// dnszones}). DBs were streamed into mysql/ during pull;
+				// docroots are rsynced source->dest at restore (below), NOT
+				// staged — a real box carried a 6.9 GB DB. Parse the cpmove
+				// for cp meta + the streamed mysql dumps, then take the
+				// domain list from domains-paths.txt (no homedir to walk).
+				pleskTar := filepath.Join("/var/lib/jabali-migrations", job.ID,
+					fmt.Sprintf("user.%s.tar.gz", job.SourceUser))
+				if cp, perr := cpanel.ParseTarball(pleskTar, extractDir); perr == nil {
+					parsed = cp
+					slug := plesk.Slug(job.SourceUser)
+					manifest := filepath.Join(extractDir, "cpmove-"+slug, "domains-paths.txt")
+					if raw, rerr := os.ReadFile(manifest); rerr == nil {
+						if parsed.DocRoots == nil {
+							parsed.DocRoots = map[string]string{}
+						}
+						for _, line := range strings.Split(string(raw), "\n") {
+							line = strings.TrimSpace(line)
+							if line == "" {
+								continue
+							}
+							parts := strings.SplitN(line, "\t", 2)
+							if len(parts) != 2 {
+								continue
+							}
+							dom := parts[0]
+							parsed.DomainNames = append(parsed.DomainNames, dom)
+							parsed.DocRoots[dom] = filepath.Join("/home", *user.Username, "domains", dom, "public_html")
+						}
+					}
+				} else {
+					return failJob(fmt.Errorf("plesk cpmove parse %s: %w", pleskTar, perr))
 				}
 			case models.MigrationSourceHestia:
 				// Hestia tar at /var/lib/jabali-migrations/<id>/
@@ -849,7 +888,7 @@ func cpanelRestoreCallback(
 			type rsyncPair struct{ Dom, SrcPath string }
 			var rsyncRows []rsyncPair
 			switch job.SourceKind {
-			case models.MigrationSourceDirectAdmin:
+			case models.MigrationSourceDirectAdmin, models.MigrationSourcePlesk:
 				manifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+p.parsed.SourceUser, "domains-paths.txt")
 				if raw, rerr := os.ReadFile(manifest); rerr == nil {
 					for _, line := range strings.Split(string(raw), "\n") {
@@ -934,7 +973,42 @@ func cpanelRestoreCallback(
 				// source tenant's files (the SSH session is root/admin). Reject rows
 				// outside the account root (clean path, no traversal) as a security
 				// critical — the job degrades rather than silently copying.
-				if p.parsed.SourceUser != "" {
+				if job.SourceKind == models.MigrationSourcePlesk {
+					// SECURITY (cross-tenant), airtight: Plesk has NO
+					// per-subscription filesystem root (each domain is its
+					// own /var/www/vhosts/<domain>/), so we allowlist ONLY
+					// the docroots of the domains this subscription owns per
+					// the SOURCE's psa DB — queried fresh here, never trusting
+					// the staged manifest. FAIL CLOSED: if the source can't be
+					// verified, refuse every home rsync rather than risk
+					// copying another source tenant's files (SSH is root).
+					allowed, aerr := pleskAuthorizedDocroots(ctx, job, sharedDB)
+					if aerr != nil {
+						p.criticals = append(p.criticals, fmt.Sprintf(
+							"security: could not verify Plesk subscription domains from source psa (%v) — home rsync refused (fail-closed)", aerr))
+						rsyncRows = nil
+					} else {
+						kept := rsyncRows[:0]
+						for _, r := range rsyncRows {
+							cl := filepath.Clean(r.SrcPath)
+							ok := false
+							for a := range allowed {
+								if cl == a || strings.HasPrefix(cl, a+"/") {
+									ok = true
+									break
+								}
+							}
+							if ok {
+								kept = append(kept, r)
+							} else {
+								p.criticals = append(p.criticals, fmt.Sprintf(
+									"security: rsync source %q for domain %q is not an authoritative docroot of subscription %q — refused",
+									r.SrcPath, r.Dom, job.SourceUser))
+							}
+						}
+						rsyncRows = kept
+					}
+				} else if p.parsed.SourceUser != "" {
 					srcRoot := "/home/" + p.parsed.SourceUser
 					kept := rsyncRows[:0]
 					for _, r := range rsyncRows {
@@ -1539,4 +1613,57 @@ func primaryDomainFromManifest(manifestJSON *string) string {
 		return mf.Domains[0].Name
 	}
 	return ""
+}
+
+// pleskAuthorizedDocroots connects to the Plesk source and returns the SET
+// of docroots the subscription legitimately owns, per the source's psa DB
+// (authoritative — not the staged manifest). The import rsync guard rsyncs
+// ONLY paths under these. Returns an error (→ fail-closed refuse-all) when
+// the source can't be reached/verified or reports zero domains.
+func pleskAuthorizedDocroots(ctx context.Context, job *models.MigrationJob, db *gorm.DB) (map[string]bool, error) {
+	allowPrivate := false
+	if s, err := repository.NewServerSettingsRepository(db).Get(ctx); err == nil && s != nil {
+		allowPrivate = s.MigrationAllowPrivateHosts
+	}
+	d := plesk.New()
+	d.AllowPrivate = allowPrivate
+	secret := migrate.SecretRef{Path: fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID)}
+	sess, err := d.Connect(ctx, job.SourceHost, migrationSSHUser(job), secret)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, sess) }()
+	doms, err := d.AuthoritativeDomains(ctx, sess, job.SourceUser)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]bool{}
+	for _, dom := range doms {
+		if isHostnameLike(dom) { // defence-in-depth on psa output
+			out["/var/www/vhosts/"+dom+"/httpdocs"] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("source psa reported no domains for subscription %q", job.SourceUser)
+	}
+	return out, nil
+}
+
+// isHostnameLike accepts a DNS-hostname-shaped string (lowercase letters,
+// digits, dot, hyphen; at least one dot; no path separators or traversal).
+// Used by the Plesk rsync guard to bound a source docroot to its domain.
+func isHostnameLike(h string) bool {
+	if h == "" || len(h) > 253 || !strings.Contains(h, ".") {
+		return false
+	}
+	for _, r := range h {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '-':
+		default:
+			return false
+		}
+	}
+	return !strings.Contains(h, "..")
 }

--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -277,7 +277,8 @@ func isKnownSourceKind(s string) bool {
 		models.MigrationSourceHestia,
 		models.MigrationSourceWordPressSSH,    // GH #647
 		models.MigrationSourceWordPressPlugin, // GH #648
-		models.MigrationSourceIMAP:            // GH #390/#374
+		models.MigrationSourceIMAP,            // GH #390/#374
+		models.MigrationSourcePlesk:           // GH #429
 		return true
 	}
 	return false

--- a/panel-api/internal/migrate/plesk/customers.go
+++ b/panel-api/internal/migrate/plesk/customers.go
@@ -222,3 +222,22 @@ func parsePleskCount(s string) uint32 {
 	}
 	return uint32(n)
 }
+
+// AuthoritativeDomains returns the domains a subscription owns as reported
+// by the source's psa DB — the AUTHORITATIVE source-of-truth used by the
+// import rsync guard to allowlist docroots (never trusting the staged
+// manifest). Read-only.
+func (d *Discoverer) AuthoritativeDomains(ctx context.Context, raw migrate.Session, sub string) ([]string, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, fmt.Errorf("AuthoritativeDomains: wrong session type")
+	}
+	sql := fmt.Sprintf(
+		"SELECT name FROM domains WHERE name=%s OR webspace_id=(SELECT id FROM domains WHERE name=%s LIMIT 1)",
+		sqlQuote(sub), sqlQuote(sub))
+	out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql))
+	if err != nil {
+		return nil, fmt.Errorf("query psa domains: %w", err)
+	}
+	return splitLines(string(out)), nil
+}

--- a/panel-api/internal/migrate/plesk/customers_test.go
+++ b/panel-api/internal/migrate/plesk/customers_test.go
@@ -129,3 +129,18 @@ func TestDiscoverTenants_ParsesPlansAndCustomers(t *testing.T) {
 		t.Errorf("acme customer parsed wrong: %+v", acme)
 	}
 }
+
+func TestAuthoritativeDomains(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		// keyed on the SELECT (quote-free substring of the escaped command).
+		"SELECT name FROM domains WHERE name=": "lychee-fruits.co.il\naddon.example.net\n",
+	})
+	doms, err := d.AuthoritativeDomains(context.Background(), s, "lychee-fruits.co.il")
+	if err != nil {
+		t.Fatalf("AuthoritativeDomains: %v", err)
+	}
+	if len(doms) != 2 || doms[0] != "lychee-fruits.co.il" || doms[1] != "addon.example.net" {
+		t.Errorf("domains = %v", doms)
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -59,6 +59,7 @@ const SOURCE_DESC: Record<string, string> = {
   whm_pkgacct: "Uploaded WHM Full Backup / pkgacct tarball",
   directadmin: "Live SSH or backup_user tarball — domains, users, DBs, mail, DNS, SSL",
   hestiacp: "Live SSH or v-backup-user tarball — web, mail, DNS, databases, cron",
+  plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
   wordpress_ssh: "Cloudways / VPS / generic SSH — single WP site (files + DB + wp-config rewrite)",
   wordpress_plugin: "No SSH — jabali-migrator plugin on the source pushes over a token-authed API",
 };
@@ -92,6 +93,7 @@ const SOURCE_OPTIONS = [
   { value: "whm_pkgacct", label: "WHM pkgacct (uploaded tarball)" },
   { value: "directadmin", label: "DirectAdmin (live SSH source)" },
   { value: "hestiacp", label: "HestiaCP (live SSH source)" },
+  { value: "plesk", label: "Plesk (live SSH source)" },
 ];
 
 // ─── sub-step components ───────────────────────────────────────────────────────


### PR DESCRIPTION
Completes the Plesk restore path — reuses the cpanel import writers via the cpmove tree the earlier steps build. **Do not merge without a review of the rsync security guard + a live prod→.86 e2e.**

## What
- **`migrate_run_cmd.go`**: `plesk` in the supported + parse switches (`cpanel.ParseTarball` → `DomainNames`/`DocRoots` from `domains-paths.txt`); `plesk` in the rsyncRows switch (source→dest docroot rsync).
- **`migrate_pull_cmd.go`**: after extract, Plesk streams each manifested DB into the cpmove `mysql/` tree (no-buffer `StreamDBDump`).
- **Enabled**: `plesk` in `isKnownSourceKind` + the UI source picker. User creation reuses the existing import auto-create (email from `cp/CONTACTEMAIL` + operator `--target-password`; no imported hash).

## 🔒 SECURITY — review this
The JAB-45 rsync source-path guard is now **source-kind-aware**. cpanel/DA scope to a single `/home/<user>/` root. Plesk has **no per-subscription filesystem root** — each domain is its own `/var/www/vhosts/<domain>/` — so a broad prefix check would let a tampered `domains-paths.txt` rsync **another subscription's** files (the SSH session is root). The Plesk arm **locks the exact shape** `/var/www/vhosts/<Dom>/httpdocs` with a hostname-validated `<Dom>`; anything else is refused as a critical. Residual risk documented inline.

## Tests
`isHostnameLike` (rejects traversal/slash/shell/uppercase/no-dot). `go vet` + panel-ui `tsc`/`eslint` green.

## Pending before merge
Live prod→.86 e2e (6.9 GB DB stream + rsync + import + user auto-create), verify site + DB.

## Refs
GH #429.