### PR TITLE
fix(migrate): add Plesk to the guided migration wizard source picker (GH #429)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -68,6 +68,7 @@ const SOURCE_OPTIONS = [
   // migrate_run_cmd.go.
   { value: "directadmin", label: "DirectAdmin (single account)" },
   { value: "hestiacp", label: "HestiaCP (single account)" },
+  { value: "plesk", label: "Plesk (single subscription)" },
 ];
 
 const SOURCE_DESC: Record<string, string> = {
@@ -75,6 +76,7 @@ const SOURCE_DESC: Record<string, string> = {
   cpanel: "Live SSH or pkgacct backup — one full cPanel account",
   directadmin: "Live SSH or backup_user tarball — DA account(s)",
   hestiacp: "Live SSH or v-backup-user tarball — Hestia account(s)",
+  plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
   wordpress_ssh: "Cloudways / VPS / generic SSH — a single WordPress site",
 };
 


### PR DESCRIPTION
#441 enabled `plesk` in the **New migration job** drawer's source list but missed the separate **guided-wizard** (`CreateMigrationWizard`) source picker, which hardcodes its own `SOURCE_OPTIONS`. So Plesk appeared in one entry point but not the other (spotted in the UI). Adds `plesk` to the wizard's options + description; single-subscription, so not added to `MULTI_ACCOUNT_KINDS`. tsc + eslint + vitest green. Refs GH #429.