### PR TITLE
fix(migrate): HestiaCP contact-name + mailbox-count (GH #327)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -208,10 +208,13 @@ failed stage. Already-done stages are skipped.`,
 				if targetPackageID != "" {
 					cu.PackageID = &targetPackageID
 				}
-				// GH #327 (johnnyq): carry the HestiaCP Contact Name
-				// (user.conf FNAME/LNAME) onto the created user's name.
+				// GH #327 (johnnyq): carry the HestiaCP Contact Name onto the
+				// created user's name. Read it from the STAGED tarball, not the
+				// extractDir — the offline restore path hasn't extracted yet at
+				// this point (extraction happens later in the parse step).
 				if job.SourceKind == models.MigrationSourceHestia {
-					if fn, ln := hestiacp.PeekUserName(extractDir); fn != "" || ln != "" {
+					stagingDir := filepath.Join("/var/lib/jabali-migrations", jobID)
+					if fn, ln := hestiacp.PeekUserNameFromStaging(stagingDir, job.SourceUser); fn != "" || ln != "" {
 						cu.NameFirst, cu.NameLast = fn, ln
 						fmt.Printf("  → carried Hestia contact name: %s %s\n", fn, ln)
 					}
@@ -1156,8 +1159,8 @@ func cpanelRestoreCallback(
 				return bytes, warnings, fmt.Errorf("mailboxes: %w", err)
 			}
 			warnings = append(warnings, fmt.Sprintf(
-				"mailboxes: maildirs=%d messages_found=%d messages_pushed=%d bytes_pushed=%d",
-				mailRes.MaildirsFound, mailRes.MessagesFound, mailRes.MessagesPushed, mailRes.BytesPushed))
+				"mailboxes: count=%d messages_found=%d messages_pushed=%d bytes_pushed=%d",
+				mailRes.MailboxesCreated, mailRes.MessagesFound, mailRes.MessagesPushed, mailRes.BytesPushed))
 			warnings = append(warnings, mailRes.Skipped...)
 			// JAB-31: messages found but none pushed means the mailbox import hit
 			// an error (e.g. a JMAP failure) — core failure, not a warning.

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -30,12 +30,13 @@ import (
 //     on the agent. Counts/bytes reflect what Stalwart actually
 //     ingested via Email/import.
 type MailImportResult struct {
-	MaildirsFound  int
-	MessagesFound  int
-	MessagesPushed int64
-	BytesFound     int64
-	BytesPushed    int64
-	Skipped        []string
+	MaildirsFound    int // maildir-shaped dirs the pre-scan found (message import + dispatch gate)
+	MailboxesCreated int // GH #327: DISTINCT panel mailbox rows created — the operator-facing count
+	MessagesFound    int
+	MessagesPushed   int64
+	BytesFound       int64
+	BytesPushed      int64
+	Skipped          []string
 }
 
 // agentImportMailboxesResult mirrors panel-agent's
@@ -343,7 +344,10 @@ func insertOneMailboxRow(
 	if cErr := mbRepo.Create(ctx, mb); cErr != nil {
 		return []string{fmt.Sprintf("mailbox_rows: create %s@%s: %v", localPart, domainName, cErr)}
 	}
-	res.MaildirsFound++
+	// GH #327: the pre-scan already counted maildir-shaped dirs into
+	// MaildirsFound; counting again here double-reported real mailboxes
+	// (johnnyq saw "7" for 3). Count DISTINCT rows created separately.
+	res.MailboxesCreated++
 	if preserved {
 		return []string{fmt.Sprintf(
 			"mailbox_rows: created %s@%s — SOURCE password preserved (--preserve-source-state); the tenant's original mail password works",

--- a/panel-api/internal/migrate/hestiacp/peek_username.go
+++ b/panel-api/internal/migrate/hestiacp/peek_username.go
@@ -1,36 +1,136 @@
 package hestiacp
 
 import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
-// GH #327 (johnnyq): HestiaCP's user.conf carries the account's Contact Name
-// (FNAME / LNAME). Carry it into the created jabali user's name so the migrated
-// account keeps its display name instead of a blank one.
-
+// GH #327 (johnnyq): HestiaCP's user.conf carries the account's Contact Name.
+// Carry it onto the created jabali user so the migrated account keeps its
+// display name instead of a blank one.
+//
+// Three things the first passes got wrong (root-caused against johnnyq's real
+// v-backup-user tarball on the test box):
+//  1. The file lives at hestia/user.conf inside the archive, NOT the root.
+//  2. HestiaCP writes the contact name as NAME='Full Name' — FNAME/LNAME are
+//     only in the v-list-users JSON and are usually empty on disk.
+//  3. The offline `migrate restore` path only STAGES the tarball; extraction
+//     happens later in the import, AFTER the auto-create step — so reading the
+//     extracted dir at create time saw nothing. PeekUserNameFromStaging reads
+//     the name straight out of the staged tarball, before extraction.
 var (
+	hestiaNameRe  = regexp.MustCompile(`(?m)^\s*NAME=['"]?([^'"\n]*)['"]?`)
 	hestiaFNameRe = regexp.MustCompile(`(?m)^\s*FNAME=['"]?([^'"\n]*)['"]?`)
 	hestiaLNameRe = regexp.MustCompile(`(?m)^\s*LNAME=['"]?([^'"\n]*)['"]?`)
 )
 
-// PeekUserName reads <extractDir>/user.conf (the top-level Hestia account file)
-// and returns the FNAME / LNAME contact name. Best-effort: returns "","" when
-// the file is absent or the fields are empty.
-func PeekUserName(extractDir string) (first, last string) {
-	if extractDir == "" {
-		return "", ""
-	}
-	b, err := os.ReadFile(filepath.Join(extractDir, "user.conf"))
-	if err != nil {
-		return "", ""
-	}
+// parseHestiaContactName pulls the contact name out of a user.conf body.
+// Prefers explicit FNAME/LNAME; else splits the single NAME field on the
+// first space.
+func parseHestiaContactName(b []byte) (first, last string) {
 	if m := hestiaFNameRe.FindSubmatch(b); m != nil {
 		first = string(m[1])
 	}
 	if m := hestiaLNameRe.FindSubmatch(b); m != nil {
 		last = string(m[1])
 	}
+	if first == "" && last == "" {
+		if m := hestiaNameRe.FindSubmatch(b); m != nil {
+			full := strings.TrimSpace(string(m[1]))
+			if i := strings.IndexByte(full, ' '); i > 0 {
+				first, last = full[:i], strings.TrimSpace(full[i+1:])
+			} else {
+				first = full
+			}
+		}
+	}
 	return first, last
+}
+
+// PeekUserName reads the Hestia account's user.conf from an already-EXTRACTED
+// tree (hestia/user.conf, root user.conf fallback). Best-effort → "","".
+func PeekUserName(extractDir string) (first, last string) {
+	if extractDir == "" {
+		return "", ""
+	}
+	for _, p := range []string{
+		filepath.Join(extractDir, "hestia", "user.conf"),
+		filepath.Join(extractDir, "user.conf"),
+	} {
+		if b, err := os.ReadFile(p); err == nil {
+			return parseHestiaContactName(b)
+		}
+	}
+	return "", ""
+}
+
+// PeekUserNameFromStaging finds the staged v-backup-user tarball in stagingDir
+// and reads hestia/user.conf straight out of it — used at auto-create time,
+// before the import extracts the tarball. Best-effort → "","".
+func PeekUserNameFromStaging(stagingDir, sourceUser string) (first, last string) {
+	if stagingDir == "" {
+		return "", ""
+	}
+	// Same discovery the Hestia parse case uses: user.<user>.tar.gz, then any
+	// *.tar.gz / *.tar in the staging dir.
+	var cands []string
+	cands = append(cands, filepath.Join(stagingDir, "user."+sourceUser+".tar.gz"))
+	for _, pat := range []string{"*.tar.gz", "*.tar"} {
+		if m, _ := filepath.Glob(filepath.Join(stagingDir, pat)); len(m) > 0 {
+			cands = append(cands, m...)
+		}
+	}
+	for _, tarPath := range cands {
+		if b, ok := readTarMember(tarPath, "hestia/user.conf"); ok {
+			return parseHestiaContactName(b)
+		}
+	}
+	return "", ""
+}
+
+// readTarMember returns the bytes of one member (matched by suffix, with or
+// without a leading "./") from a .tar or .tar.gz archive.
+func readTarMember(tarPath, member string) ([]byte, bool) {
+	f, err := os.Open(tarPath)
+	if err != nil {
+		return nil, false
+	}
+	defer f.Close()
+	// Sniff the gzip magic (0x1f 0x8b) rather than trusting the extension:
+	// the offline restore stages a plain .tar under a user.<u>.tar.gz name,
+	// so the suffix lies.
+	var magic [2]byte
+	n, _ := io.ReadFull(f, magic[:])
+	if _, serr := f.Seek(0, io.SeekStart); serr != nil {
+		return nil, false
+	}
+	var r io.Reader = f
+	if n == 2 && magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return nil, false
+		}
+		defer gz.Close()
+		r = gz
+	}
+	tr := tar.NewReader(r)
+	for {
+		h, nerr := tr.Next()
+		if nerr != nil {
+			return nil, false
+		}
+		name := strings.TrimPrefix(h.Name, "./")
+		if name == member || strings.HasSuffix(name, "/"+member) {
+			b, rerr := io.ReadAll(io.LimitReader(tr, 1<<20))
+			if rerr != nil {
+				return nil, false
+			}
+			return b, true
+		}
+	}
 }

--- a/panel-api/internal/migrate/hestiacp/peek_username_test.go
+++ b/panel-api/internal/migrate/hestiacp/peek_username_test.go
@@ -1,21 +1,89 @@
 package hestiacp
 
 import (
+	"archive/tar"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestPeekUserName(t *testing.T) {
+// GH #327: the contact name lives at hestia/user.conf as NAME='Full Name'.
+func TestPeekUserName_HestiaNameFieldAndPath(t *testing.T) {
 	dir := t.TempDir()
-	os.WriteFile(filepath.Join(dir, "user.conf"),
-		[]byte("SUSPENDED='no'\nFNAME='John'\nLNAME='Doe'\nCONTACT='john@x.com'\n"), 0o644)
-	fn, ln := PeekUserName(dir)
-	if fn != "John" || ln != "Doe" {
-		t.Errorf("got (%q,%q), want (John,Doe)", fn, ln)
+	if err := os.MkdirAll(filepath.Join(dir, "hestia"), 0o750); err != nil {
+		t.Fatal(err)
 	}
-	// absent file → empty, no panic
-	if f, l := PeekUserName(t.TempDir()); f != "" || l != "" {
-		t.Errorf("absent user.conf should be empty, got (%q,%q)", f, l)
+	conf := "NAME='ITFlow Support'\nCONTACT='support@itflow.org'\nPACKAGE='default'\n"
+	if err := os.WriteFile(filepath.Join(dir, "hestia", "user.conf"), []byte(conf), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	first, last := PeekUserName(dir)
+	if first != "ITFlow" || last != "Support" {
+		t.Errorf("got (%q,%q), want (ITFlow, Support)", first, last)
+	}
+}
+
+// A single-token NAME goes entirely into first.
+func TestPeekUserName_SingleToken(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "hestia"), 0o750)
+	_ = os.WriteFile(filepath.Join(dir, "hestia", "user.conf"), []byte("NAME='ITFlow'\n"), 0o640)
+	if first, last := PeekUserName(dir); first != "ITFlow" || last != "" {
+		t.Errorf("got (%q,%q), want (ITFlow, \"\")", first, last)
+	}
+}
+
+// Explicit FNAME/LNAME win over NAME when present.
+func TestPeekUserName_FNameLNamePreferred(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(dir, "hestia"), 0o750)
+	_ = os.WriteFile(filepath.Join(dir, "hestia", "user.conf"),
+		[]byte("NAME='Ignored Name'\nFNAME='John'\nLNAME='Doe'\n"), 0o640)
+	if first, last := PeekUserName(dir); first != "John" || last != "Doe" {
+		t.Errorf("got (%q,%q), want (John, Doe)", first, last)
+	}
+}
+
+// Root-level user.conf still works (fallback layout).
+func TestPeekUserName_RootFallback(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "user.conf"), []byte("NAME='Root Layout'\n"), 0o640)
+	if first, _ := PeekUserName(dir); first != "Root" {
+		t.Errorf("root fallback: got first=%q, want Root", first)
+	}
+}
+
+func TestPeekUserName_Absent(t *testing.T) {
+	if first, last := PeekUserName(t.TempDir()); first != "" || last != "" {
+		t.Errorf("absent conf should yield empty, got (%q,%q)", first, last)
+	}
+}
+
+func TestPeekUserNameFromStaging(t *testing.T) {
+	staging := t.TempDir()
+	// build a minimal v-backup-user-shaped tar with hestia/user.conf.
+	tarPath := filepath.Join(staging, "user.itflowapp.tar")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(f)
+	body := []byte("NAME='ITFlow Support'\nCONTACT='x@y.z'\n")
+	if err := tw.WriteHeader(&tar.Header{Name: "./hestia/user.conf", Mode: 0o640, Size: int64(len(body))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	_ = tw.Close()
+	_ = f.Close()
+
+	first, last := PeekUserNameFromStaging(staging, "itflowapp")
+	if first != "ITFlow" || last != "Support" {
+		t.Errorf("from staging tar: got (%q,%q), want (ITFlow, Support)", first, last)
+	}
+	// absent staging → empty, no panic.
+	if f, l := PeekUserNameFromStaging(t.TempDir(), "nobody"); f != "" || l != "" {
+		t.Errorf("empty staging should yield empty, got (%q,%q)", f, l)
 	}
 }


### PR DESCRIPTION
Two of johnnyq's three remaining #327 items — **root-caused and validated end-to-end against his real `itflowapp` v-backup-user tarball** on the test box (no guessing this time).

## 1. Contact name never carried
Three compounding causes:
- the config lives at `hestia/user.conf` inside the archive, **not** the root;
- HestiaCP writes the name as `NAME='Full Name'` — `FNAME`/`LNAME` are only in the `v-list-users` JSON and are empty on disk;
- the offline `migrate restore` path only **stages** the tarball; extraction happens later in the import, **after** the auto-create step — so reading the extracted dir at create time saw nothing.

Fix: `PeekUserNameFromStaging` reads `hestia/user.conf` straight out of the staged tarball (sniffing the gzip **magic bytes**, since the offline stage writes a plain `.tar` under a `user.<u>.tar.gz` name), and parses `NAME` (explicit `FNAME`/`LNAME` still win).

**Verified live:** created user now has `name_first="ITFlow"`, `name_last="APP Subdomains"` (was blank).

## 2. Mailbox count over-reported ("showed 7, had 3")
`MaildirsFound` was incremented both by the message-import pre-scan **and** per created panel row — double-counting every real mailbox. Added a distinct `MailboxesCreated` counter, reported as `mailboxes: count=`.

**Verified live:** a one-mailbox account now reports `count=1` (was `maildirs=2`).

## 3. LE certs — NOT in this PR (by design)
Source certs are quarantined and the reconciler auto-LE reissues (johnnyq agreed reissue is the path, #47, since Hestia has no autoconfig/autodiscover hosts). Not a clean code bug; flagging separately.

## Tests
`parseHestiaContactName` via extracted dir + staged tarball (plain tar named `.gz`), NAME/FNAME/LNAME precedence, root fallback, single token, absent.

## Refs
GH #327. Does not close.