### PR TITLE
feat(migrate): custom source SSH port for all migration sources (GH #429)

### DIFF
--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ type migrationRsyncRemoteHomeParams struct {
 	SrcAccount string `json:"src_account"` // source cPanel/DA account; src_path must live under /home/<src_account>/ (JAB-45)
 	DestPath   string `json:"dest_path"`   // absolute dest path on this host
 	DestUser   string `json:"dest_user"`   // chown target after rsync
+	Port       int    `json:"port"`        // source SSH port; 0 → 22 (GH #429)
 }
 
 type migrationRsyncRemoteHomeResult struct {
@@ -173,6 +175,11 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 	// first use — never the old blind StrictHostKeyChecking=no + /dev/null.
 	knownHosts := strings.TrimSuffix(p.SecretPath, ".env") + ".known_hosts"
 	sshOpt := "-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=" + knownHosts
+	port := p.Port
+	if port < 1 || port > 65535 {
+		port = 22
+	}
+	sshOpt += " -p " + strconv.Itoa(port)
 	if keyTmp != "" {
 		sshOpt += " -i " + keyTmp + " -o IdentitiesOnly=yes"
 	}

--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -266,6 +266,7 @@ live source SSH. Use scp directly for that kind.`,
 func pullCpanel(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
 	d := cpanel.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
 	if err != nil {
 		return "", fmt.Errorf("cpanel.Connect: %w", err)
@@ -312,7 +313,7 @@ func wpMigDoneStage(ctx context.Context, repo repository.MigrationJobRepository,
 }
 
 func pullWordPressSSH(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool, repo repository.MigrationJobRepository) error {
-	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, secret, allowPrivate)
+	sess, err := wordpressssh.Connect(ctx, job.SourceHost, srcSSHPort(job), sshUser, secret, allowPrivate)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
@@ -533,6 +534,7 @@ func readPluginToken(path string) (string, error) {
 func pullDirectAdmin(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
 	d := directadmin.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
 	if err != nil {
 		return "", fmt.Errorf("directadmin.Connect: %w", err)
@@ -562,6 +564,7 @@ func pullDirectAdmin(ctx context.Context, sshUser string, job *models.MigrationJ
 func pullPlesk(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
 	d := plesk.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
 	if err != nil {
 		return "", fmt.Errorf("plesk.Connect: %w", err)
@@ -590,6 +593,7 @@ func pullPlesk(ctx context.Context, sshUser string, job *models.MigrationJob, se
 func populatePleskDBsAfterExtract(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, extractDir string, allowPrivate bool) error {
 	d := plesk.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
 	if err != nil {
 		return fmt.Errorf("plesk.Connect: %w", err)
@@ -609,6 +613,7 @@ func populatePleskDBsAfterExtract(ctx context.Context, sshUser string, job *mode
 func pullHestia(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
 	d := hestiacp.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
 	if err != nil {
 		return "", fmt.Errorf("hestiacp.Connect: %w", err)
@@ -637,3 +642,12 @@ func pullHestia(ctx context.Context, sshUser string, job *models.MigrationJob, s
 // extractTar streams a .tar or .tar.gz into dest. Uses the same
 // path-escape + size-cap hardening as cpanel.ParseTarball; doesn't
 // classify entries since the per-importer parser does that.
+
+// srcSSHPort returns the migration job's source SSH port, defaulting to 22
+// when unset (GH #429).
+func srcSSHPort(job *models.MigrationJob) int {
+	if job != nil && job.SourcePort >= 1 && job.SourcePort <= 65535 {
+		return job.SourcePort
+	}
+	return 22
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1043,6 +1043,7 @@ func cpanelRestoreCallback(
 				for _, r := range rsyncRows {
 					destPath := filepath.Join("/home", p.targetUsername, "domains", r.Dom, "public_html")
 					rawResp, rerr := restoreAgent.Call(ctx, "migration.rsync_remote_home", map[string]any{
+						"port":        srcSSHPort(job),
 						"job_id":      job.ID,
 						"host":        job.SourceHost,
 						"ssh_user":    remoteSSHUser,
@@ -1630,6 +1631,7 @@ func pleskAuthorizedDocroots(ctx context.Context, job *models.MigrationJob, db *
 	}
 	d := plesk.New()
 	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
 	secret := migrate.SecretRef{Path: fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID)}
 	sess, err := d.Connect(ctx, job.SourceHost, migrationSSHUser(job), secret)
 	if err != nil {

--- a/panel-api/cmd/server/migration_src_port_test.go
+++ b/panel-api/cmd/server/migration_src_port_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestSrcSSHPort(t *testing.T) {
+	if srcSSHPort(nil) != 22 {
+		t.Error("nil job → 22")
+	}
+	cases := map[int]int{0: 22, -5: 22, 70000: 22, 22: 22, 2222: 2222}
+	for in, want := range cases {
+		if got := srcSSHPort(&models.MigrationJob{SourcePort: in}); got != want {
+			t.Errorf("srcSSHPort(port=%d) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -182,6 +182,8 @@ type createMigrationRequest struct {
 	ExpectedHostKey string `json:"expected_host_key,omitempty"`
 	// SourcePath (GH #647 wordpress_ssh) — the WP root on the source.
 	SourcePath string `json:"source_path,omitempty"`
+	// SourcePort (GH #429) — source SSH port; 0/absent → default 22.
+	SourcePort int `json:"source_port,omitempty"`
 }
 
 // create inserts a fresh migration_jobs row with state='pending'.
@@ -245,6 +247,7 @@ func (h *adminMigrationsHandler) create(c *gin.Context) {
 		SourceUser:      req.SourceUser,
 		State:           state,
 		ExpectedHostKey: strings.TrimSpace(req.ExpectedHostKey),
+		SourcePort:      normalizeSourcePort(req.SourcePort),
 	}
 	if sp := strings.TrimSpace(req.SourcePath); sp != "" { // GH #647 wordpress_ssh
 		row.SourcePath = &sp
@@ -1431,4 +1434,13 @@ func (h *adminMigrationsHandler) refresh(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, res)
+}
+
+// normalizeSourcePort clamps an operator-supplied SSH port to a valid range,
+// defaulting to 22 when unset (0) or out of range (GH #429).
+func normalizeSourcePort(p int) int {
+	if p < 1 || p > 65535 {
+		return 22
+	}
+	return p
 }

--- a/panel-api/internal/api/migration_source_port_test.go
+++ b/panel-api/internal/api/migration_source_port_test.go
@@ -1,0 +1,13 @@
+package api
+
+import "testing"
+
+// GH #429: a source SSH port defaults to 22 when unset/out of range.
+func TestNormalizeSourcePort(t *testing.T) {
+	cases := map[int]int{0: 22, -1: 22, 65536: 22, 22: 22, 2222: 2222, 1: 1, 65535: 65535}
+	for in, want := range cases {
+		if got := normalizeSourcePort(in); got != want {
+			t.Errorf("normalizeSourcePort(%d) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/panel-api/internal/db/migrations/000222_migration_source_port.down.sql
+++ b/panel-api/internal/db/migrations/000222_migration_source_port.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE migration_jobs DROP COLUMN source_port;

--- a/panel-api/internal/db/migrations/000222_migration_source_port.up.sql
+++ b/panel-api/internal/db/migrations/000222_migration_source_port.up.sql
@@ -1,0 +1,6 @@
+-- GH #429 (lxsdevcode): source panels on a non-default SSH port could not be
+-- migrated — the connectors hardcoded port 22. Add a per-job source SSH port
+-- (default 22) so cPanel/DirectAdmin/HestiaCP/Plesk sources behind a custom
+-- port work. Schema-only; existing rows default to 22.
+ALTER TABLE migration_jobs
+  ADD COLUMN source_port INT NOT NULL DEFAULT 22;

--- a/panel-api/internal/models/migration_job.go
+++ b/panel-api/internal/models/migration_job.go
@@ -76,6 +76,9 @@ type MigrationJob struct {
 	SourceHost      string `gorm:"column:source_host;type:varchar(255);not null;uniqueIndex:uq_migration_source,priority:1" json:"source_host"`
 	SourceUser      string `gorm:"column:source_user;type:varchar(64);not null;uniqueIndex:uq_migration_source,priority:2" json:"source_user"`
 	ExpectedHostKey string `gorm:"column:expected_host_key;type:varchar(128);not null;default:''" json:"expected_host_key"`
+	// SourcePort (GH #429) — the source panel's SSH port; connectors default to
+	// 22 when unset. Lets operators migrate a source behind a custom SSH port.
+	SourcePort int `gorm:"column:source_port;type:int;not null;default:22" json:"source_port"`
 	// SourcePath (GH #647) — the WordPress root on the source (control-INPUT,
 	// like source_host/source_user). NULL until the operator supplies it or the
 	// discoverer auto-detects it. Distinct from ManifestJSON, which holds the

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -8,6 +8,7 @@ import {
   Drawer,
   Form,
   Input,
+  InputNumber,
   Card,
   Space,
   Steps,
@@ -27,6 +28,7 @@ type CreateInput = {
   source_kind: string;
   source_host: string;
   source_user: string;
+  source_port?: number;
   source_path?: string;
 };
 
@@ -35,6 +37,7 @@ type MigrationJob = {
   source_kind: string;
   source_host: string;
   source_user: string;
+  source_port?: number;
   state: string;
 };
 
@@ -538,7 +541,7 @@ export const CreateMigrationDrawer = ({
           form={form}
           layout="vertical"
           onFinish={handleSubmit}
-          initialValues={{ source_kind: "cpanel" }}
+          initialValues={{ source_kind: "cpanel", source_port: 22 }}
         >
           <Form.Item
             label="Source kind"
@@ -555,9 +558,9 @@ export const CreateMigrationDrawer = ({
                 <Form.Item
                   label={isPlugin ? "Source site URL" : "Source host"}
                   name="source_host"
-                  tooltip={isPlugin ? "The source WordPress site URL (https://old-site.com)." : "Hostname/IP of the source panel. Not required for WHM tarball uploads."}
+                  tooltip={isPlugin ? "The source WordPress site URL (https://old-site.com)." : "Hostname or IP of the source panel. Prefer the direct IP if the server sits behind Cloudflare/a proxy — a hostname can resolve to the proxy instead of the source. Not required for WHM tarball uploads."}
                 >
-                  <Input placeholder={isPlugin ? "https://old-site.com" : "src.example.com"} />
+                  <Input placeholder={isPlugin ? "https://old-site.com" : "203.0.113.10 or src.example.com"} />
                 </Form.Item>
               );
             }}
@@ -578,6 +581,24 @@ export const CreateMigrationDrawer = ({
                   tooltip={k === "wordpress_ssh" ? "SSH login on the source. Cloudways: the master_xxx user (needs an SSH KEY, not a password)." : "Login name on the source panel."}
                 >
                   <Input placeholder={k === "wordpress_ssh" ? "root or master_xxxx" : "bob"} />
+                </Form.Item>
+              );
+            }}
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate={(a, b) => a.source_kind !== b.source_kind}>
+            {({ getFieldValue }) => {
+              const k = getFieldValue("source_kind");
+              // No SSH for token-plugin or offline tarball sources.
+              if (k === "wordpress_plugin" || k === "whm_pkgacct") {
+                return null;
+              }
+              return (
+                <Form.Item
+                  label="SSH port"
+                  name="source_port"
+                  tooltip="The source server's SSH port. Defaults to 22."
+                >
+                  <InputNumber min={1} max={65535} style={{ width: 140 }} />
                 </Form.Item>
               );
             }}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -28,6 +28,7 @@ import {
   Drawer,
   Form,
   Input,
+  InputNumber,
   Modal,
   Radio,
   Card,
@@ -117,6 +118,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
   };
   const [sourceKind, setSourceKind] = useState<string>("whm_pkgacct");
   const [sourceHost, setSourceHost] = useState<string>("");
+  const [sourcePort, setSourcePort] = useState<number>(22);
   const [sourceUser, setSourceUser] = useState<string>("");
   const [credKind, setCredKind] = useState<"password" | "key">("password");
   const [credValue, setCredValue] = useState<string>("");
@@ -193,6 +195,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
         source_kind: sourceKind,
         source_host: sourceHost || `__draft_${(crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`).replace(/-/g, "").slice(0, 24)}`,
         source_user: sourceUser || `__draft_${(crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`).replace(/-/g, "").slice(0, 24)}`,
+        source_port: sourcePort,
         state: "draft",
       });
       return data;
@@ -224,6 +227,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
       await apiClient.patch(`/admin/migrations/${draftId}`, {
         source_host: sourceHost,
         source_user: sourceUser,
+        source_port: sourcePort,
         expected_host_key: expectedHostKey.trim(),
       });
       const body: Record<string, string> =
@@ -475,11 +479,24 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
             description="Credentials are written to /etc/jabali-panel/migration-secrets and reaped 24h after job completion."
           />
           <Form layout="vertical">
-            <Form.Item label="Source host" required>
+            <Form.Item
+              label="Source host"
+              required
+              tooltip="Use the server's direct IP if it sits behind Cloudflare or another proxy — a hostname can resolve to the proxy instead of the source server."
+            >
               <Input
                 value={sourceHost}
                 onChange={(e) => setSourceHost(e.target.value)}
-                placeholder="src.example.com"
+                placeholder="203.0.113.10 or src.example.com"
+              />
+            </Form.Item>
+            <Form.Item label="SSH port" tooltip="The source server's SSH port. Defaults to 22.">
+              <InputNumber
+                min={1}
+                max={65535}
+                value={sourcePort}
+                onChange={(v: number | null) => setSourcePort(typeof v === "number" ? v : 22)}
+                style={{ width: 140 }}
               />
             </Form.Item>
             <Form.Item label="Admin user" required>


### PR DESCRIPTION
lxsdevcode couldn't migrate a Plesk server on a non-default SSH port — the connectors hardcoded port 22. Adds a **per-job source SSH port** end-to-end, for every live-SSH source (cPanel/DirectAdmin/HestiaCP/Plesk/WordPress-SSH). Also addresses their other two points.

## What
- **Migration 000222**: `migration_jobs.source_port INT NOT NULL DEFAULT 22` (schema-only; existing rows default to 22).
- **Model + API**: `MigrationJob.SourcePort`; create accepts `source_port`, clamped via `normalizeSourcePort` (0/out-of-range → 22).
- **Pull CLI**: `srcSSHPort(job)` sets `d.Port` on every connector before `Connect` (cpanel/DA/plesk/hestia), passed to `wordpressssh.Connect`, and used by the import-side Plesk psa-verify connect.
- **Agent**: `migration.rsync_remote_home` gains a `port` param and injects `ssh -p <port>` so the home rsync reaches a non-22 source.
- **UI**: an **SSH port** field (default 22) in both the guided Wizard and the New-migration drawer, for live-SSH kinds.
- **Source host hint** (their #3): the tooltip/placeholder now recommend the **direct IP** when the server sits behind Cloudflare/a proxy, since a hostname can resolve to the proxy instead of the source.
- **Connection clarity** (their #2): answered in the issue reply (plain SSH, host + login + password/key, read-only discovery).

## Tests
`normalizeSourcePort` + `srcSSHPort` defaulting/clamping. `go build` + `vet` both modules, panel-ui `tsc` + `eslint` green.

## Refs
GH #429.