### PR TITLE
fix(uploads): self-heal jabali-uploads ownership via systemd StateDirectory (GH #355)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5199,6 +5199,13 @@ LockPersonality=true
 # Defense-in-depth still covered by NoNewPrivileges + ProtectSystem +
 # RestrictAddressFamilies + ProtectKernel* above. ADR-0079.
 ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /var/lib/jabali-panel /etc/jabali-panel/migration-secrets /run/mysqld
+# GH #355: systemd creates + chowns /var/lib/jabali-uploads to the panel
+# service user on EVERY start, so a drifted owner (e.g. root, from an old
+# install) self-heals on a plain restart — not only on \`jabali update\`.
+# Uploads failed with "open …/jabali-upload-…: permission denied" when the
+# dir was owned by someone the service user couldn't write as.
+StateDirectory=jabali-uploads
+StateDirectoryMode=0750
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
webquest-nz hit `open /var/lib/jabali-uploads/jabali-upload-…: permission denied` uploading a **33.7 MB** file as a sub-user (screenshot in #355).

## Root cause
Not a size cap — the file is well under every limit. The upload **staging dir** (`/var/lib/jabali-uploads`, where panel-api writes the temp file before handing to the agent) had **drifted to a non-service owner** (e.g. root from an older install), `0750`, so panel-api — running as the unprivileged service user — got `EACCES` creating the file. On a healthy box it's `jabali:jabali 0750` and works.

## Fix
`write_systemd_unit` already reasserts `install -d -o <svc>` on every `jabali update`, but a box that hasn't updated (or drifts between updates) stays broken. Add to the panel-api unit:
```
StateDirectory=jabali-uploads
StateDirectoryMode=0750
```
systemd now **creates AND chowns** the dir to the service user on **every start** — a plain `systemctl restart jabali-panel` heals a drifted owner, no update needed.

## Verified (live box)
`chown root:root /var/lib/jabali-uploads` → restart with the directive → systemd restored it to the service user, panel stayed healthy.

## Refs
GH #355. Does not close (waiting on the reporter to confirm their dir ownership).