### PR TITLE
fix(status): stop reporting pdns as failed on no-DNS installs (GH #447)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3276,6 +3276,39 @@ PG_DROPIN
 
 # ---------- step 2.6: PowerDNS authoritative nameserver ----------------------
 
+# converge_pdns_masking — GH #447. The base package batch apt-installs the
+# pdns + pdns-recursor units on EVERY host, but their post-install config only
+# runs when the DNS module is enabled (run_if_module dns install_powerdns). On a
+# no-DNS host the units are therefore left unconfigured and sit in "failed",
+# surfacing as a bogus "pdns.service is failed" warning on the dashboard and the
+# Server Status page. Mask them when DNS is off so systemd reports "masked"
+# (the capability-aware health paths omit masked/not-found units) instead of
+# "failed"; unmask when DNS is on so install_powerdns can start them.
+# Idempotent + convergent: safe on fresh install and on every `jabali update`.
+converge_pdns_masking() {
+  command -v systemctl >/dev/null 2>&1 || return 0
+  # Desired DNS state: on an installed host the DB (server_settings.dns_enabled)
+  # is truth — `jabali update` runs with JABALI_MODULES unset, so is_module_enabled
+  # would wrongly report "on". Only fall back to the module selection on a fresh
+  # install where the settings row doesn't exist yet.
+  local dns_on=1 db_val=""
+  if command -v mariadb >/dev/null 2>&1; then
+    db_val="$(mariadb jabali_panel -N -B -e \
+      "SELECT dns_enabled FROM server_settings WHERE id=1;" 2>/dev/null)"
+  fi
+  if [[ -n "$db_val" ]]; then
+    [[ "$db_val" == "0" ]] && dns_on=0
+  elif ! is_module_enabled dns; then
+    dns_on=0
+  fi
+  if [[ "$dns_on" -eq 1 ]]; then
+    systemctl unmask pdns.service pdns-recursor.service >/dev/null 2>&1 || true
+  else
+    systemctl mask pdns.service pdns-recursor.service >/dev/null 2>&1 || true
+    _log "DNS module off — masked pdns/pdns-recursor so they don't report failed (GH #447)"
+  fi
+}
+
 install_powerdns() {
   _log "configuring PowerDNS (packages installed in base batch; this runs post-install config)"
 
@@ -12566,6 +12599,11 @@ provision_new_software() {
   ensure_jabali_panel_dir_traversable
   ensure_snuffleupagus_loadable
 
+  # GH #447: converge pdns/pdns-recursor masking to the DB's dns_enabled on
+  # every update, so a host that has the DNS module off stops reporting the
+  # unconfigured pdns unit as "failed" on the dashboard + Server Status.
+  converge_pdns_masking
+
   # GH #253: refresh the per-user PHP-FPM pool template so updated installs pick
   # up new shared-hosting defaults (memory_limit, upload sizes, etc.). Idempotent
   # copy; the reconciler re-renders each pool from the installed template on its
@@ -13121,6 +13159,9 @@ main() {
   # fresh install. Operator flips server_settings.postgres_enabled in
   # the Databases tab; panel-api dispatches db.postgres.install which
   # sources install.sh and runs install_postgres on demand.
+  # Mask/unmask pdns units to match the DNS module state BEFORE the config
+  # step runs (unmask must precede install_powerdns starting pdns). GH #447.
+  converge_pdns_masking
   run_if_module dns install_powerdns
   run_if_module dns bootstrap_pdns_self_zone
   # M6.3: recursor owns loopback :53 and forwards panel-authoritative zones

--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -428,6 +428,13 @@ func (h *adminServerStatusHandler) filterModuleServices(ctx context.Context, raw
 	kept := payload.Services[:0]
 	for _, svc := range payload.Services {
 		unit, _ := svc["unit"].(string)
+		// Capability-aware: a unit that isn't installed on this host, or was
+		// masked because its module is off (e.g. pdns on a no-DNS install —
+		// GH #447), shouldn't be reported as a failed/down service. Matches
+		// the dashboard health path (normalizeServiceHealth in automation.go).
+		if ls, _ := svc["load_state"].(string); ls == "masked" || ls == "not-found" {
+			continue
+		}
 		if gate, ok := moduleGatedUnits[unit]; ok && !gate(settings) {
 			continue // owning module is off — hide it
 		}

--- a/plans/gh447-modular-installer-triage.md
+++ b/plans/gh447-modular-installer-triage.md
@@ -1,0 +1,64 @@
+# GH #447 triage — pdns false-failure + modular installer feedback
+
+Source: issue #447 (netsol-dev) + comment by mrlp57 (2026-07-16). Two layers:
+a concrete pdns bug (fixed) and a batch of modular/TUI installer feedback that
+belongs to the WIP M353 workstream (`plans/m353-*`).
+
+## 1. pdns.service reported "failed" on a no-DNS install — FIXED
+
+**Symptom:** operator chose no PowerDNS (all sites on Cloudflare); dashboard +
+Server Status show `pdns.service is failed`.
+
+**Root cause:** the base apt batch installs the pdns + pdns-recursor units on
+*every* host, but their post-install config only runs when the DNS module is
+enabled (`run_if_module dns install_powerdns`). On a no-DNS host the units are
+left unconfigured → systemd `failed`. The Server Status module-gate only hides
+pdns when `server_settings.dns_enabled=0`, and that flag is seeded to 0 only for
+modular installs (`JABALI_MODULES` set) — it defaults to 1 — so a host that kept
+`dns_enabled=1` still shows the failed unit. The dashboard/monitor health path
+(`normalizeServiceHealth`) never gated on the flag at all; it only omits
+`masked`/`not-found` units, so a *present-but-failed* pdns always showed.
+
+**Fix (this change):**
+- `install.sh` `converge_pdns_masking`: mask pdns + pdns-recursor when DNS is off
+  (DB `dns_enabled` is truth on installed hosts; `JABALI_MODULES` fallback on
+  fresh installs), unmask when on. Called in `main()` before the DNS config step
+  AND in the `provision_new_software` update prelude, so existing hosts converge
+  on `jabali update`. A masked unit reports `masked`, not `failed`, and the
+  capability-aware health paths omit it.
+- `server_status.go` `filterModuleServices`: also omit `masked`/`not-found`
+  units, matching the dashboard's `normalizeServiceHealth`. So a masked pdns
+  disappears from Server Status too, independent of the flag.
+
+**Operator remediation for an already-broken host:** toggle DNS off in
+Server Settings → Modules (sets `dns_enabled=0`), then `jabali update` masks pdns
+and the warning clears. (Before the update reaches them, `systemctl mask
+pdns.service pdns-recursor.service` does it immediately.)
+
+**Validation:** `converge_pdns_masking` branch logic verified 4 ways (DB on/off ×
+module on/off, DB wins); DB-read path confirmed on a live host; server_status
+change unit-tested. NOT yet end-to-end on a live no-DNS host (none available
+safely) — worth a box run when one exists.
+
+## 2. Modular / TUI installer feedback — M353 workstream (NOT fixed here)
+
+mrlp57 tested the new module installer. Actionable items for `plans/m353-*`:
+
+- **Selections not honored.** "Whatever I didn't select to install is still
+  listed in menu" + "installs unselected modules." Strong signal the TUI
+  selection isn't threaded into `JABALI_MODULES` / `is_module_enabled`, so
+  `run_if_module` runs everything and `seed_module_flags` no-ops (or seeds
+  wrong). This is *why* `dns_enabled` stayed 1 above. **Highest priority** — the
+  module gating is the whole point of M353.
+- **Let's Encrypt didn't work** in the module install. Likely `setup_certbot`
+  ordering/skip under the modular path, or the DNS-off ordering (certbot HTTP-01
+  needs the panel hostname to resolve). Repro + fix under M353.
+- **Graph/TUI installer hard to read** over SSH. Readability pass on the
+  bubbletea TUI (`plans/m353-tui-installer-bubbletea.md`) — contrast, plain
+  fallback for dumb terminals.
+- **Positive (keep):** installing modules from the panel (Server Settings →
+  Modules, runtime `install_module <key>`) "worked very well." The runtime path
+  is solid; the install-time selection path is the gap.
+
+See `plans/m353-modular-panel-proposal.md`, `plans/m353-phase1-modular-install.md`,
+`plans/m353-tui-installer-bubbletea.md`.


### PR DESCRIPTION
## What

Fixes the bogus `pdns.service is failed` warning on the dashboard + Server Status for hosts that chose no PowerDNS (GH #447).

## Root cause

The base apt batch installs the pdns + pdns-recursor units on every host, but their config only runs when the DNS module is enabled (`run_if_module dns install_powerdns`). On a no-DNS host the units are left unconfigured → systemd `failed`. The Server Status module-gate only hid pdns when `dns_enabled=0` (seeded that way only for modular installs), and the dashboard health path never gated on the flag at all.

## Fix

- `install.sh` `converge_pdns_masking`: mask pdns/pdns-recursor when DNS is off (DB `dns_enabled` is truth on installed hosts, `JABALI_MODULES` fallback on fresh installs), unmask when on. Called in `main()` before the DNS config step and in the `provision_new_software` update prelude, so existing hosts converge on `jabali update`.
- `server_status.go` `filterModuleServices`: also omit `masked`/`not-found` units, matching the dashboard's `normalizeServiceHealth`.

## Triage

`plans/gh447-modular-installer-triage.md` captures the modular-installer feedback from the thread (selections not honored — the reason `dns_enabled` stayed 1 — plus LE failure and TUI readability) for the M353 workstream. Not fixed here.

## Validation

- `converge_pdns_masking` branch logic verified 4 ways (DB on/off × module on/off; DB wins).
- DB-read + unmask path confirmed on a live host.
- `server_status` change unit-tested; go build/vet + install.sh syntax green.
- NOT yet run end-to-end on a live no-DNS host (none available safely).

## Test plan

- [ ] Fresh no-DNS install: pdns units masked, no failed warning on dashboard/Server Status.
- [ ] Existing no-DNS host: `jabali update` masks pdns; warning clears.
- [ ] DNS-on host: pdns stays unmasked + active; nothing regresses.
