### PR TITLE
fix(php): stop the PHP-version install/uninstall flap on every update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1595,6 +1595,14 @@ EARLYDNS
     if echo "$php_versions" | grep -qw "$_pv"; then
       continue
     fi
+    # In-use guard: a version with a configured FPM tree is panel-managed and a
+    # tenant pool uses it — provision_php_extensions reinstalls its ext packages
+    # on the same signal, so purging here causes an install/uninstall flap on
+    # every update. Only purge pure transitive php-cli pulls (no FPM tree).
+    if [[ -d "/etc/php/${_pv}/fpm" ]]; then
+      _log "keeping php${_pv} (configured FPM version in use)"
+      continue
+    fi
     if dpkg -l "php${_pv}-cli" 2>/dev/null | grep -q "^ii"; then
       # Preserve versions an admin installed on purpose via the panel PHP
       # version manager (GH #302): those packages are apt-"manual". Only purge
@@ -12749,6 +12757,16 @@ provision_new_software() {
   # Purge any stale PHP versions not in JABALI_PHP_VERSIONS
   for _pv in 8.4 8.3 8.2 8.1 8.0 7.4; do
     if echo "$_upd_php_versions" | grep -qw "$_pv"; then continue; fi
+    # In-use guard: a version with a configured FPM tree is one the panel PHP
+    # Manager installed and a tenant pool/domain uses. provision_php_extensions
+    # keys on this same /etc/php/<v>/fpm signal and reinstalls the ext packages,
+    # so purging here just gets it reinstalled on the SAME update run — an
+    # install/uninstall flap on every `jabali update`. Only pure transitive
+    # php-cli pulls (no FPM tree) should be purged.
+    if [[ -d "/etc/php/${_pv}/fpm" ]]; then
+      _log "provision: keeping php${_pv} (configured FPM version in use)"
+      continue
+    fi
     if dpkg -l "php${_pv}-cli" 2>/dev/null | grep -q "^ii"; then
       # Preserve admin-installed versions (apt-manual, via the panel PHP
       # version manager) — only purge transitive/auto pulls (GH #302).


### PR DESCRIPTION
## Problem

On a host with a PHP version that isn't in `JABALI_PHP_VERSIONS` but is in active use (a tenant pool pinned to e.g. 8.3 via the PHP Manager), **every `jabali update` installed and then uninstalled php8.2/8.3**, churning apt and reloading FPM each run.

## Root cause

Two steps with disagreeing sources of truth, both in the update path:

1. **provision purge** (and its fresh-install twin in `install_base_packages`) purges any version not in `JABALI_PHP_VERSIONS` (just `8.4`) that isn't `apt-mark manual`: `apt-get purge php8.3*`.
2. **`provision_php_extensions`** reinstalls php8.3-* because it enumerates `/etc/php/*/fpm` — and the config tree survives the purge (`dpkg: directory not empty so not removed`), so it re-adds the packages as auto.

Next update repeats → perpetual flap. Confirmed from a live update log (`provision: purging stale php8.3` followed by `installing missing PHP extensions: php8.3-mysql …` in the same run).

## Fix

Both purge loops now skip a version that has a configured `/etc/php/<v>/fpm` tree — the exact in-use signal `provision_php_extensions` keys on. Pure transitive `php-cli` pulls (no FPM tree) are still purged, preserving the original GH #302 intent.

## Test plan

- [ ] Host with a tenant pool on 8.3: `jabali update` twice — no purge/reinstall of php8.3; `apt` quiet.
- [ ] Host with a transitive php-cli pull (no FPM tree): still purged.
- [ ] Fresh install: only JABALI_PHP_VERSIONS present; no stray versions.
