### PR TITLE
fix(ui): stop blank-screen on stale assets + order docker catalog by popularity

### DIFF
--- a/install/docker-apps/_schema/app.schema.json
+++ b/install/docker-apps/_schema/app.schema.json
@@ -30,6 +30,11 @@
       "minLength": 1,
       "maxLength": 32
     },
+    "popularity": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Catalog ordering weight; higher floats to the top of the listing. Optional, default 0."
+    },
     "description": {
       "type": "string",
       "minLength": 1,

--- a/install/docker-apps/dokuwiki/app.yaml
+++ b/install/docker-apps/dokuwiki/app.yaml
@@ -1,4 +1,5 @@
 slug: dokuwiki
+popularity: 32
 tenant_installable: true
 name: DokuWiki
 tags: ["Wiki"]

--- a/install/docker-apps/forgejo/app.yaml
+++ b/install/docker-apps/forgejo/app.yaml
@@ -1,4 +1,5 @@
 slug: forgejo
+popularity: 70
 name: Forgejo
 tags: ["Developer tools"]
 version: "15.0.3"

--- a/install/docker-apps/freshrss/app.yaml
+++ b/install/docker-apps/freshrss/app.yaml
@@ -1,4 +1,5 @@
 slug: freshrss
+popularity: 55
 tenant_installable: true
 name: FreshRSS
 tags: ["Productivity"]

--- a/install/docker-apps/ghost/app.yaml
+++ b/install/docker-apps/ghost/app.yaml
@@ -1,4 +1,5 @@
 slug: ghost
+popularity: 80
 name: Ghost
 tags: ["Blog", "CMS"]
 version: "6.44.1"

--- a/install/docker-apps/gitea/app.yaml
+++ b/install/docker-apps/gitea/app.yaml
@@ -1,4 +1,5 @@
 slug: gitea
+popularity: 82
 name: Gitea
 tags: ["Developer tools"]
 version: "1.26.2"

--- a/install/docker-apps/grafana/app.yaml
+++ b/install/docker-apps/grafana/app.yaml
@@ -1,4 +1,5 @@
 slug: grafana
+popularity: 78
 name: Grafana
 tags: ["Monitoring", "Analytics"]
 version: "13.0.2"

--- a/install/docker-apps/immich/app.yaml
+++ b/install/docker-apps/immich/app.yaml
@@ -1,4 +1,5 @@
 slug: immich
+popularity: 95
 name: Immich
 tags: ["File sharing"]
 version: "2.7.5"

--- a/install/docker-apps/jabali-sounder/app.yaml
+++ b/install/docker-apps/jabali-sounder/app.yaml
@@ -1,4 +1,5 @@
 slug: jabali-sounder
+popularity: 38
 name: Jabali Sounder
 tags: ["Monitoring"]
 version: "0.5.17"

--- a/install/docker-apps/joplin/app.yaml
+++ b/install/docker-apps/joplin/app.yaml
@@ -1,4 +1,5 @@
 slug: joplin
+popularity: 40
 name: Joplin Server
 tags: ["Productivity"]
 version: "3.7.1"

--- a/install/docker-apps/linkwarden/app.yaml
+++ b/install/docker-apps/linkwarden/app.yaml
@@ -1,4 +1,5 @@
 slug: linkwarden
+popularity: 48
 tenant_installable: true
 name: Linkwarden
 tags: ["Productivity"]

--- a/install/docker-apps/matomo/app.yaml
+++ b/install/docker-apps/matomo/app.yaml
@@ -1,4 +1,5 @@
 slug: matomo
+popularity: 62
 name: Matomo
 tags: ["Analytics"]
 version: "5.10.1"

--- a/install/docker-apps/mealie/app.yaml
+++ b/install/docker-apps/mealie/app.yaml
@@ -1,4 +1,5 @@
 slug: mealie
+popularity: 60
 tenant_installable: true
 name: Mealie
 tags: ["Productivity"]

--- a/install/docker-apps/memos/app.yaml
+++ b/install/docker-apps/memos/app.yaml
@@ -1,4 +1,5 @@
 slug: memos
+popularity: 34
 tenant_installable: true
 name: Memos
 tags: ["Productivity"]

--- a/install/docker-apps/n8n/app.yaml
+++ b/install/docker-apps/n8n/app.yaml
@@ -1,4 +1,5 @@
 slug: n8n
+popularity: 88
 name: n8n
 tags: ["Automation", "Developer tools"]
 version: "2.25.5"

--- a/install/docker-apps/nextcloud/app.yaml
+++ b/install/docker-apps/nextcloud/app.yaml
@@ -1,4 +1,5 @@
 slug: nextcloud
+popularity: 100
 name: Nextcloud
 tags: ["File sharing"]
 version: "33.0.5"

--- a/install/docker-apps/odoo/app.yaml
+++ b/install/docker-apps/odoo/app.yaml
@@ -1,4 +1,5 @@
 slug: odoo
+popularity: 42
 name: Odoo
 tags: ["ERP", "CRM"]
 version: "18.0"

--- a/install/docker-apps/onlyoffice/app.yaml
+++ b/install/docker-apps/onlyoffice/app.yaml
@@ -1,4 +1,5 @@
 slug: onlyoffice
+popularity: 44
 name: ONLYOFFICE Docs
 tags: ["Productivity", "File sharing"]
 version: "9.4.0"

--- a/install/docker-apps/open-webui/app.yaml
+++ b/install/docker-apps/open-webui/app.yaml
@@ -1,4 +1,5 @@
 slug: open-webui
+popularity: 46
 name: Open WebUI
 tags: ["AI", "Developer tools"]
 version: "0.9.6"

--- a/install/docker-apps/owncloud/app.yaml
+++ b/install/docker-apps/owncloud/app.yaml
@@ -1,4 +1,5 @@
 slug: owncloud
+popularity: 52
 name: ownCloud
 tags: ["File sharing"]
 version: "10.16.3"

--- a/install/docker-apps/paperless-ngx/app.yaml
+++ b/install/docker-apps/paperless-ngx/app.yaml
@@ -1,4 +1,5 @@
 slug: paperless-ngx
+popularity: 75
 tenant_installable: true
 name: Paperless-ngx
 tags: ["Document management", "File sharing"]

--- a/install/docker-apps/peertube/app.yaml
+++ b/install/docker-apps/peertube/app.yaml
@@ -1,4 +1,5 @@
 slug: peertube
+popularity: 30
 name: PeerTube
 tags: ["Media", "Video", "Streaming"]
 version: "8.2.1"

--- a/install/docker-apps/plausible/app.yaml
+++ b/install/docker-apps/plausible/app.yaml
@@ -1,4 +1,5 @@
 slug: plausible
+popularity: 65
 name: Plausible Analytics
 tags: ["Analytics"]
 version: "3.2.1"

--- a/install/docker-apps/privatebin/app.yaml
+++ b/install/docker-apps/privatebin/app.yaml
@@ -1,4 +1,5 @@
 slug: privatebin
+popularity: 36
 tenant_installable: true
 name: PrivateBin
 tags: ["Developer tools"]

--- a/install/docker-apps/rocketchat/app.yaml
+++ b/install/docker-apps/rocketchat/app.yaml
@@ -1,4 +1,5 @@
 slug: rocketchat
+popularity: 68
 name: Rocket.Chat
 tags: ["Communication"]
 version: "6.13.1"

--- a/install/docker-apps/searxng/app.yaml
+++ b/install/docker-apps/searxng/app.yaml
@@ -1,4 +1,5 @@
 slug: searxng
+popularity: 50
 tenant_installable: true
 name: SearXNG
 tags: ["Developer tools"]

--- a/install/docker-apps/uptime-kuma/app.yaml
+++ b/install/docker-apps/uptime-kuma/app.yaml
@@ -1,4 +1,5 @@
 slug: uptime-kuma
+popularity: 85
 tenant_installable: true
 name: Uptime Kuma
 tags: ["Monitoring"]

--- a/install/docker-apps/vaultwarden/app.yaml
+++ b/install/docker-apps/vaultwarden/app.yaml
@@ -1,4 +1,5 @@
 slug: vaultwarden
+popularity: 90
 tenant_installable: true
 name: Vaultwarden
 tags: ["Security"]

--- a/panel-api/internal/dockerapp/catalog.go
+++ b/panel-api/internal/dockerapp/catalog.go
@@ -31,6 +31,10 @@ type Entry struct {
 	Version       string     `yaml:"version"`
 	Description   string     `yaml:"description"`
 	Tags          []string   `yaml:"tags,omitempty" json:"tags,omitempty"`
+	// Popularity orders the catalog: higher floats to the top of the listing,
+	// ties break alphabetically by slug. Optional (default 0). Operator-tunable
+	// per app.yaml so the most-installed apps surface first.
+	Popularity    int        `yaml:"popularity,omitempty" json:"popularity,omitempty"`
 	Icon          string     `yaml:"icon,omitempty"`
 	Upstream      string     `yaml:"upstream,omitempty"`
 	Documentation string     `yaml:"documentation,omitempty"`
@@ -191,7 +195,15 @@ func LoadDir(root string) (*Catalog, []EntryError) {
 		c.order = append(c.order, e.Slug)
 	}
 
-	sort.Strings(c.order)
+	// Order the catalog by popularity (desc) so the most-installed apps surface
+	// first, ties alphabetical by slug for a stable listing.
+	sort.SliceStable(c.order, func(i, j int) bool {
+		a, b := c.bySlug[c.order[i]], c.bySlug[c.order[j]]
+		if a.Popularity != b.Popularity {
+			return a.Popularity > b.Popularity
+		}
+		return a.Slug < b.Slug
+	})
 	return c, errs
 }
 

--- a/panel-api/internal/webui/webui.go
+++ b/panel-api/internal/webui/webui.go
@@ -54,6 +54,15 @@ func RegisterStatic(g *gin.Engine, panelFS fs.FS) {
 		// take over.
 		isFallback := p == "/" || !fileExists(panelFS, strings.TrimPrefix(p, "/"))
 		if isFallback {
+			// A missing hashed asset (a stale chunk requested by a tab that was
+			// open across a deploy) must 404 — NOT fall through to index.html.
+			// Serving the HTML shell for a .js/.css request makes the browser
+			// block it with a "disallowed MIME type (text/html)" error and blank
+			// the SPA until a manual refresh. Only genuine SPA routes fall back.
+			if isStaticAssetPath(p) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+				return
+			}
 			c.Request.URL.Path = "/"
 			// SPA shell must revalidate on every load. Vite hashes asset
 			// filenames so JS/CSS can be cached forever, but index.html
@@ -109,6 +118,23 @@ func looksLikeAPI(p string) bool {
 	case strings.HasPrefix(p, "/health"):
 		return true
 	case strings.HasPrefix(p, "/ws/"):
+		return true
+	}
+	return false
+}
+
+// isStaticAssetPath reports whether p is a request for a build asset (a Vite
+// hashed chunk under /assets/, or any file with a code/font/image extension).
+// When such a path misses the embed it must 404 rather than fall back to the
+// SPA shell — a text/html body for a .js/.css request trips the browser's MIME
+// check and blanks the page (stale-chunk-after-deploy).
+func isStaticAssetPath(p string) bool {
+	if strings.HasPrefix(p, "/assets/") {
+		return true
+	}
+	switch strings.ToLower(path.Ext(p)) {
+	case ".js", ".mjs", ".css", ".map", ".woff", ".woff2", ".ttf",
+		".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg", ".ico":
 		return true
 	}
 	return false

--- a/panel-api/internal/webui/webui_test.go
+++ b/panel-api/internal/webui/webui_test.go
@@ -85,3 +85,49 @@ func TestAPIPathIs404JSON(t *testing.T) {
 		t.Errorf("Content-Type = %q, want application/json...", ct)
 	}
 }
+
+// TestMissingAssetReturns404 — a stale hashed chunk (tab open across a deploy)
+// must 404, not fall through to index.html; serving text/html for a .js request
+// trips the browser MIME check and blanks the SPA. GH: docker-apps blank screen.
+func TestMissingAssetReturns404(t *testing.T) {
+	r := newTestEngine(t)
+	for _, p := range []string{
+		"/assets/RowActions-STALE.js",
+		"/assets/AdminDockerAppsPage-GONE.js",
+		"/assets/index-XXXX.css",
+		"/favicon.ico",
+	} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("path %q: status = %d, want 404 (must not fall back to SPA shell)", p, w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); ct != "" && ct[:9] == "text/html" {
+			t.Errorf("path %q: Content-Type = %q, want non-HTML for a missing asset", p, ct)
+		}
+	}
+}
+
+// TestExistingAssetStillServed — a real hashed asset is served (not 404'd).
+func TestExistingAssetStillServed(t *testing.T) {
+	r := newTestEngine(t)
+	req := httptest.NewRequest(http.MethodGet, "/assets/index-abc.js", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("existing asset status = %d, want 200", w.Code)
+	}
+}
+
+// TestSPARouteStillFallsBack — a genuine deep link (no extension) still serves
+// the SPA shell so client routing works.
+func TestSPARouteStillFallsBack(t *testing.T) {
+	r := newTestEngine(t)
+	req := httptest.NewRequest(http.MethodGet, "/jabali-admin/docker-apps", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("SPA deep-link status = %d, want 200 (index.html fallback)", w.Code)
+	}
+}

--- a/panel-ui/src/main.tsx
+++ b/panel-ui/src/main.tsx
@@ -10,6 +10,22 @@ import "./global.css";
 import App from "./App";
 import { registerServiceWorker } from "./lib/registerServiceWorker";
 
+// A dynamic import (lazy route chunk) failing almost always means the tab was
+// open across a panel deploy: the shell in memory references old asset hashes
+// that no longer exist on the server (now a 404). Reload once to pull the fresh
+// index.html + hashes instead of leaving the user on a blank screen. Guarded so
+// a genuinely broken chunk can't loop-reload; the flag is cleared on any
+// successful load below.
+window.addEventListener("vite:preloadError", () => {
+  // Reload at most once per 10s: a stale chunk recovers on the first reload,
+  // while a genuinely-missing asset (persistent 404) can't spin a reload loop.
+  const last = Number(sessionStorage.getItem("jabali-chunk-reload-at") || 0);
+  if (Date.now() - last > 10_000) {
+    sessionStorage.setItem("jabali-chunk-reload-at", String(Date.now()));
+    window.location.reload();
+  }
+});
+
 const rootEl = document.getElementById("root");
 if (!rootEl) {
   // This would mean index.html was modified incorrectly. Fail loud so


### PR DESCRIPTION
Two fixes for the Docker Apps page, both reported from testserver.

## 1. Blank screen after a deploy (MIME error)

A tab left open across a `jabali update` references the old hashed chunk names. After the rebuild those files are gone, and the SPA fallback served `index.html` for the missing `/assets/*.js` — so the browser got `text/html` for a JS request, blocked it (`disallowed MIME type`), and blanked the page. Refresh worked around it.

- `webui.go`: missing build-asset paths (`/assets/*` or a code/font/image extension) now **404** instead of falling back to the SPA shell. Genuine deep links still fall back to `index.html`.
- `main.tsx`: on `vite:preloadError` (a lazy chunk failing to load) the app reloads once per 10s, so the user auto-recovers with the fresh shell instead of a blank screen.

Tests added: missing asset → 404, existing asset → 200, deep link → 200 fallback.

## 2. Catalog ordering

The catalog was alphabetical by slug ("Apache Answer" first). Added an optional `popularity` weight to `app.yaml` and sort by it (desc, ties alphabetical), so the most-installed apps lead: Nextcloud, Immich, Vaultwarden, n8n, Uptime Kuma, Gitea, Ghost, Grafana… Curated starting weights; everything else stays 0 (alphabetical tail), operator-tunable.

## Test plan

- [ ] Open Docker Apps, `jabali update`, return to tab → page recovers (auto-reload), not blank.
- [ ] `curl -I https://host:8443/assets/does-not-exist.js` → 404, not text/html.
- [ ] Catalog tab lists Nextcloud/Immich/Vaultwarden at the top.
