### PR TITLE
feat(users): show admin disk-usage as a progress bar

### DIFF
--- a/panel-ui/src/shells/admin/users/UserDiskUsage.tsx
+++ b/panel-ui/src/shells/admin/users/UserDiskUsage.tsx
@@ -9,7 +9,7 @@
 //
 // No 5s polling. If an operator wants a fresh number, they hit Cmd+R.
 import { useQuery } from "@tanstack/react-query";
-import { Typography } from "antd";
+import { Progress, Typography } from "antd";
 
 import { apiClient } from "../../../apiClient";
 
@@ -58,7 +58,19 @@ export function UserDiskUsage({ userId }: { userId: string }) {
         : 0;
 
   if (limitKB > 0) {
-    return <span>{`${formatBytes(usedKB * 1024)} / ${formatBytes(limitKB * 1024)}`}</span>;
+    const pct = Math.min(100, Math.round((usedKB / limitKB) * 100));
+    return (
+      <div style={{ minWidth: 130, maxWidth: 180 }}>
+        <Progress
+          percent={pct}
+          size="small"
+          status={pct >= 95 ? "exception" : "normal"}
+        />
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {`${formatBytes(usedKB * 1024)} / ${formatBytes(limitKB * 1024)}`}
+        </Typography.Text>
+      </div>
+    );
   }
   if (usedKB > 0) {
     return <span>{formatBytes(usedKB * 1024)}</span>;


### PR DESCRIPTION
The admin Users list showed disk usage as plain `used / limit` text. Render it as a compact antd `Progress` bar with percent + the used/limit caption (matching the My Profile usage card), turning red at >=95%.

## Test plan
- [ ] Users list: disk-usage column shows a progress bar + percent + `X GB / Y GB`.
- [ ] User near quota (>=95%) shows red.