### PR TITLE
feat(notifications): add Telegram as a notification channel (GH #456)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -1123,6 +1123,7 @@ func buildNotificationRegistry(parent context.Context, deps app.Deps, log *slog.
 	registry.Register(senders.NewNtfy())
 	registry.Register(senders.NewWebhook())
 	registry.Register(senders.NewSMS())
+	registry.Register(senders.NewTelegram())
 	notifyEmail := provisionNotifyMailbox(parent, deps, log)
 	registry.Register(senders.NewEmail("127.0.0.1:587").WithLocalCreds(notifyLocalCreds(deps, notifyEmail)))
 	if deps.ServerSettings != nil && deps.WebPushSubs != nil {

--- a/panel-api/internal/api/notifications_channels.go
+++ b/panel-api/internal/api/notifications_channels.go
@@ -314,8 +314,9 @@ var knownChannelKinds = map[string]struct{}{
 	models.NotificationChannelKindDiscord: {},
 	models.NotificationChannelKindNtfy:    {},
 	models.NotificationChannelKindWebhook: {},
-	models.NotificationChannelKindWebpush: {},
-	models.NotificationChannelKindSMS:     {},
+	models.NotificationChannelKindWebpush:  {},
+	models.NotificationChannelKindSMS:      {},
+	models.NotificationChannelKindTelegram: {},
 }
 
 var knownSeverities = map[string]struct{}{
@@ -350,7 +351,7 @@ func validateChannelName(name string) error {
 
 func validateChannelKindAndConfig(kind string, cfg models.NotificationChannelConfig) error {
 	if _, ok := knownChannelKinds[kind]; !ok {
-		return fmt.Errorf("unknown channel kind %q (valid: email/slack/discord/ntfy/webhook/webpush/sms)", kind)
+		return fmt.Errorf("unknown channel kind %q (valid: email/slack/discord/ntfy/webhook/webpush/sms/telegram)", kind)
 	}
 	switch kind {
 	case models.NotificationChannelKindEmail:
@@ -404,6 +405,13 @@ func validateChannelKindAndConfig(kind string, cfg models.NotificationChannelCon
 		// HMAC secret optional but recommended.
 		if cfg.HMACSecret != "" && len(cfg.HMACSecret) < 16 {
 			return errors.New("sms channel: hmac_secret must be >= 16 chars when set")
+		}
+	case models.NotificationChannelKindTelegram:
+		if cfg.BotToken == "" {
+			return errors.New("telegram channel: bot_token required (from @BotFather)")
+		}
+		if cfg.ChatID == "" {
+			return errors.New("telegram channel: chat_id required (the chat/channel to post to)")
 		}
 	}
 	return nil

--- a/panel-api/internal/db/migrations/000223_notifications_telegram_kind.down.sql
+++ b/panel-api/internal/db/migrations/000223_notifications_telegram_kind.down.sql
@@ -1,0 +1,4 @@
+-- Revert the ENUM to the pre-#456 set. Fails if any telegram channels
+-- still exist — delete them first if rolling back.
+ALTER TABLE notification_channels
+  MODIFY COLUMN kind ENUM('email','slack','discord','ntfy','webhook','webpush','sms') NOT NULL;

--- a/panel-api/internal/db/migrations/000223_notifications_telegram_kind.up.sql
+++ b/panel-api/internal/db/migrations/000223_notifications_telegram_kind.up.sql
@@ -1,0 +1,6 @@
+-- GH #456: add 'telegram' to notification_channels.kind ENUM.
+-- The Telegram channel POSTs `{chat_id, text}` JSON to the Bot API
+-- sendMessage endpoint (https://api.telegram.org/bot<token>/sendMessage);
+-- bot_token + chat_id live in the per-channel config_json blob.
+ALTER TABLE notification_channels
+  MODIFY COLUMN kind ENUM('email','slack','discord','ntfy','webhook','webpush','sms','telegram') NOT NULL;

--- a/panel-api/internal/models/notification_channel.go
+++ b/panel-api/internal/models/notification_channel.go
@@ -10,13 +10,14 @@ import (
 // NotificationChannelKind enumerates the channel transports. Mirrors the
 // ENUM in migration 000064.
 const (
-	NotificationChannelKindEmail   = "email"
-	NotificationChannelKindSlack   = "slack"
-	NotificationChannelKindDiscord = "discord"
-	NotificationChannelKindNtfy    = "ntfy"
-	NotificationChannelKindWebhook = "webhook"
-	NotificationChannelKindWebpush = "webpush"
-	NotificationChannelKindSMS     = "sms"
+	NotificationChannelKindEmail    = "email"
+	NotificationChannelKindSlack    = "slack"
+	NotificationChannelKindDiscord  = "discord"
+	NotificationChannelKindNtfy     = "ntfy"
+	NotificationChannelKindWebhook  = "webhook"
+	NotificationChannelKindWebpush  = "webpush"
+	NotificationChannelKindSMS      = "sms"
+	NotificationChannelKindTelegram = "telegram"
 )
 
 // NotificationChannel is a configured delivery target for system events.
@@ -69,6 +70,11 @@ type NotificationChannelConfig struct {
 	// (e.g. "+15551234567"). Sent as the "to" field in the JSON
 	// payload POSTed to the gateway URL.
 	ToNumber string `json:"to_number,omitempty"`
+
+	// Telegram channel: bot token (from @BotFather) + the chat/channel ID
+	// to deliver to. The sender POSTs to the Bot API sendMessage endpoint.
+	BotToken string `json:"bot_token,omitempty"`
+	ChatID   string `json:"chat_id,omitempty"`
 }
 
 func (c *NotificationChannelConfig) Scan(src any) error {

--- a/panel-api/internal/notifications/senders/telegram.go
+++ b/panel-api/internal/notifications/senders/telegram.go
@@ -1,0 +1,87 @@
+package senders
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+// Telegram delivers via the Bot API sendMessage endpoint
+// (https://api.telegram.org/bot<token>/sendMessage). The bot token comes
+// from @BotFather; chat_id is the user/group/channel the bot posts to
+// (the bot must have been started by / added to that chat). Plain-text
+// body — no parse_mode — so message content never needs Markdown/HTML
+// escaping.
+type Telegram struct {
+	client *http.Client
+	// apiBase is overridable in tests; defaults to the public Bot API host.
+	apiBase string
+}
+
+func NewTelegram() *Telegram {
+	return &Telegram{client: newHTTPClient(), apiBase: "https://api.telegram.org"}
+}
+
+func (t *Telegram) Kind() string { return models.NotificationChannelKindTelegram }
+
+type telegramSendMessage struct {
+	ChatID             string `json:"chat_id"`
+	Text               string `json:"text"`
+	DisableWebPagePrev bool   `json:"disable_web_page_preview,omitempty"`
+}
+
+func (t *Telegram) Send(ctx context.Context, channel models.NotificationChannel, env notifications.Envelope) error {
+	if channel.Config.BotToken == "" {
+		return fmt.Errorf("telegram: missing bot_token in channel config: %w", notifications.ErrPermanent)
+	}
+	if channel.Config.ChatID == "" {
+		return fmt.Errorf("telegram: missing chat_id in channel config: %w", notifications.ErrPermanent)
+	}
+	title, body := notifications.RenderForChannel(env, t.Kind())
+	text := body
+	if title != "" {
+		text = title + "\n\n" + body
+	}
+
+	payload, err := json.Marshal(telegramSendMessage{
+		ChatID:             channel.Config.ChatID,
+		Text:               text,
+		DisableWebPagePrev: true,
+	})
+	if err != nil {
+		return fmt.Errorf("telegram: marshal: %w", err)
+	}
+
+	// The bot token is in the path, so it is never logged as a header.
+	endpoint := t.apiBase + "/bot" + url.PathEscape(channel.Config.BotToken) + "/sendMessage"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("telegram: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("telegram: post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	// 401 = bad token, 400 = bad/unknown chat_id, 403 = bot blocked/kicked.
+	// All are misconfiguration — permanent, don't retry.
+	if resp.StatusCode == http.StatusUnauthorized ||
+		resp.StatusCode == http.StatusBadRequest ||
+		resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("telegram: %d %s: %w", resp.StatusCode, string(respBody), notifications.ErrPermanent)
+	}
+	return fmt.Errorf("telegram: %d %s", resp.StatusCode, string(respBody))
+}

--- a/panel-api/internal/notifications/senders/telegram_test.go
+++ b/panel-api/internal/notifications/senders/telegram_test.go
@@ -1,0 +1,84 @@
+package senders
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+func telegramChannel() models.NotificationChannel {
+	return models.NotificationChannel{
+		Kind: "telegram",
+		Config: models.NotificationChannelConfig{
+			BotToken: "123:ABC",
+			ChatID:   "-1001234567890",
+		},
+	}
+}
+
+func TestTelegram_SendsChatIDAndText(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	var payload struct {
+		ChatID string `json:"chat_id"`
+		Text   string `json:"text"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &payload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tg := NewTelegram()
+	tg.apiBase = ts.URL
+	env := notifications.Envelope{Title: "Backup failed", Body: "nightly job died", Deeplink: "https://panel/backups"}
+	require.NoError(t, tg.Send(context.Background(), telegramChannel(), env))
+
+	require.Equal(t, "/bot123:ABC/sendMessage", gotPath)
+	require.Equal(t, "-1001234567890", payload.ChatID)
+	require.True(t, strings.Contains(payload.Text, "Backup failed"), "title in text")
+	require.True(t, strings.Contains(payload.Text, "nightly job died"), "body in text")
+	require.True(t, strings.Contains(payload.Text, "https://panel/backups"), "deeplink in text")
+}
+
+func TestTelegram_MissingConfigIsPermanent(t *testing.T) {
+	t.Parallel()
+	tg := NewTelegram()
+	env := notifications.Envelope{Title: "x", Body: "y"}
+	err := tg.Send(context.Background(), models.NotificationChannel{Kind: "telegram"}, env)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, notifications.ErrPermanent), "missing bot_token → permanent")
+
+	err = tg.Send(context.Background(), models.NotificationChannel{
+		Kind:   "telegram",
+		Config: models.NotificationChannelConfig{BotToken: "t"},
+	}, env)
+	require.True(t, errors.Is(err, notifications.ErrPermanent), "missing chat_id → permanent")
+}
+
+func TestTelegram_BadTokenIsPermanent(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"ok":false,"error_code":401,"description":"Unauthorized"}`))
+	}))
+	defer ts.Close()
+
+	tg := NewTelegram()
+	tg.apiBase = ts.URL
+	err := tg.Send(context.Background(), telegramChannel(), notifications.Envelope{Title: "t", Body: "b"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, notifications.ErrPermanent), "401 → permanent (don't retry a bad token)")
+}

--- a/panel-api/internal/notifications/templates.go
+++ b/panel-api/internal/notifications/templates.go
@@ -32,6 +32,15 @@ func RenderForChannel(env Envelope, kind string) (title, body string) {
 			body = strings.TrimSpace(body + "\n" + env.Deeplink)
 		}
 		return
+	case "telegram":
+		// Telegram Bot API plain-text message (no parse_mode → no escaping).
+		// The sender joins title + body; append the deeplink as a bare URL.
+		title = env.Title
+		body = strings.TrimSpace(env.Body)
+		if env.Deeplink != "" {
+			body = strings.TrimSpace(body + "\n\n" + env.Deeplink)
+		}
+		return
 	case "webpush":
 		// Push payloads are size-limited (~4KB). Truncate aggressively.
 		title = truncate(env.Title, 100)

--- a/panel-ui/src/shells/admin/notifications/channelKindConfig.tsx
+++ b/panel-ui/src/shells/admin/notifications/channelKindConfig.tsx
@@ -10,7 +10,8 @@ export type ChannelKind =
   | "ntfy"
   | "webhook"
   | "webpush"
-  | "sms";
+  | "sms"
+  | "telegram";
 
 // CHANNEL_KINDS — kinds the admin can pick when creating a channel.
 // "webpush" lives in the type union (and the kindLabels/kindFields
@@ -24,6 +25,7 @@ export const CHANNEL_KINDS: ChannelKind[] = [
   "ntfy",
   "webhook",
   "sms",
+  "telegram",
 ];
 
 export const kindColors: Record<ChannelKind, string> = {
@@ -34,6 +36,7 @@ export const kindColors: Record<ChannelKind, string> = {
   webhook: "gold",
   webpush: "green",
   sms: "magenta",
+  telegram: "blue",
 };
 
 export const kindLabels: Record<ChannelKind, string> = {
@@ -44,6 +47,7 @@ export const kindLabels: Record<ChannelKind, string> = {
   webhook: "Generic webhook",
   webpush: "Web Push (browser)",
   sms: "SMS (gateway)",
+  telegram: "Telegram",
 };
 
 // ChannelFormFields — which per-kind config fields to render. The
@@ -78,6 +82,8 @@ export type ChannelFormConfig = {
   smtp_password?: string;
   smtp_tls?: "starttls" | "tls" | "none";
   to_number?: string;
+  bot_token?: string;
+  chat_id?: string;
 };
 
 export const kindFields: Record<ChannelKind, FieldSpec[]> = {
@@ -183,6 +189,22 @@ export const kindFields: Record<ChannelKind, FieldSpec[]> = {
       label: "Bearer token (optional)",
       type: "password",
       help: "Sent as Authorization: Bearer … if your gateway authenticates that way.",
+    },
+  ],
+  telegram: [
+    {
+      name: "bot_token",
+      label: "Bot token",
+      type: "password",
+      required: true,
+      help: "From @BotFather. Create a bot with /newbot, copy the token.",
+    },
+    {
+      name: "chat_id",
+      label: "Chat ID",
+      placeholder: "123456789 or -1001234567890",
+      required: true,
+      help: "The chat/group/channel to post to. Message the bot, then check https://api.telegram.org/bot<token>/getUpdates for your chat id.",
     },
   ],
 };


### PR DESCRIPTION
Brings back Telegram notifications (was in v1). Slots into the existing pluggable `ChannelSender` registry alongside slack/discord/ntfy/webhook/sms/email/webpush.

## Changes
- `senders/telegram.go` — Bot API `sendMessage` (`{chat_id, text}`, token in URL path, plain-text body). 401/400/403 → permanent (no retry).
- Migration 000223 — adds `telegram` to the `notification_channels.kind` ENUM.
- Model `bot_token`/`chat_id` config + kind constant.
- Template branch, sender registration, per-kind API validation.
- UI: Telegram in the channel drawer (bot token + chat id).

## Test plan
- [ ] Notifications → Channels → Add → Telegram: enter bot token (@BotFather) + chat id, Save.
- [ ] Send test → message arrives in the chat.
- [ ] Backup/service-failure events fan out to the Telegram channel.

Unit tests cover payload/path, missing-config→permanent, bad-token→permanent.