### PR TITLE
feat(ui): consistent breadcrumbs on every page (GH #455)

### DIFF
--- a/panel-ui/src/components/admin/BreadcrumbContext.tsx
+++ b/panel-ui/src/components/admin/BreadcrumbContext.tsx
@@ -1,0 +1,40 @@
+// BreadcrumbContext — one breadcrumb per page (GH #455).
+//
+// The shell layout renders a single <RouteBreadcrumb>. By default it derives a
+// trail from the current route + the nav table, so EVERY page gets a
+// breadcrumb. A page with richer, entity-aware crumbs (e.g. Users > alice >
+// Domains) calls useSetBreadcrumbs(...) to override the auto trail; the
+// override clears on unmount so the next page falls back to the default.
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+import type { Crumb } from "./entityLinks";
+
+type BreadcrumbCtx = {
+  override: Crumb[] | null;
+  setOverride: (c: Crumb[] | null) => void;
+};
+
+const Ctx = createContext<BreadcrumbCtx | null>(null);
+
+export function BreadcrumbProvider({ children }: { children: ReactNode }) {
+  const [override, setOverride] = useState<Crumb[] | null>(null);
+  return <Ctx.Provider value={{ override, setOverride }}>{children}</Ctx.Provider>;
+}
+
+// useSetBreadcrumbs replaces the auto-derived trail with the given crumbs while
+// the calling page is mounted. Pass null to keep the route-derived default
+// (e.g. a list page that is entity-scoped only some of the time).
+export function useSetBreadcrumbs(crumbs: Crumb[] | null) {
+  const ctx = useContext(Ctx);
+  const key = crumbs ? JSON.stringify(crumbs) : null;
+  useEffect(() => {
+    ctx?.setOverride(crumbs);
+    return () => ctx?.setOverride(null);
+    // Re-run only when the serialized crumbs change, not on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+}
+
+export function useBreadcrumbOverride(): Crumb[] | null {
+  return useContext(Ctx)?.override ?? null;
+}

--- a/panel-ui/src/components/admin/RouteBreadcrumb.test.tsx
+++ b/panel-ui/src/components/admin/RouteBreadcrumb.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { NavItem } from "../../nav";
+import { deriveCrumbs } from "./RouteBreadcrumb";
+
+const nav: NavItem[] = [
+  { key: "dashboard", label: "Dashboard", path: "/jabali-admin/dashboard" },
+  { key: "users", label: "Users", path: "/jabali-admin/users" },
+  { key: "domains", label: "Domains", path: "/jabali-admin/domains" },
+] as NavItem[];
+
+const HOME = "/jabali-admin/dashboard";
+
+function titles(path: string) {
+  return deriveCrumbs(path, nav, HOME, "Dashboard").map((c) => c.title);
+}
+
+describe("deriveCrumbs", () => {
+  it("dashboard = single unlinked Home crumb", () => {
+    const crumbs = deriveCrumbs(HOME, nav, HOME, "Dashboard");
+    expect(crumbs).toHaveLength(1);
+    expect(crumbs[0]).toEqual({ title: "Dashboard" });
+  });
+
+  it("section list page = Home > Section (section unlinked as current)", () => {
+    const crumbs = deriveCrumbs("/jabali-admin/users", nav, HOME, "Dashboard");
+    expect(crumbs.map((c) => c.title)).toEqual(["Dashboard", "Users"]);
+    expect(crumbs[0].href).toBe(HOME); // home linked
+    expect(crumbs[1].href).toBeUndefined(); // current page, not linked
+  });
+
+  it("maps known trailing segments and skips opaque ids", () => {
+    // /users/<ULID>/edit  → Dashboard > Users > Edit  (id dropped)
+    expect(titles("/jabali-admin/users/01ARZ3NDEKTSV4RRFFQ69G5FAV/edit")).toEqual([
+      "Dashboard",
+      "Users",
+      "Edit",
+    ]);
+  });
+
+  it("title-cases unknown segments", () => {
+    expect(titles("/jabali-admin/domains/dns-records")).toEqual(["Dashboard", "Domains", "Dns records"]);
+  });
+
+  it("falls back to Home when no section matches", () => {
+    expect(titles("/jabali-admin/unmapped")).toEqual(["Dashboard"]);
+  });
+});

--- a/panel-ui/src/components/admin/RouteBreadcrumb.tsx
+++ b/panel-ui/src/components/admin/RouteBreadcrumb.tsx
@@ -1,0 +1,79 @@
+// RouteBreadcrumb — the single breadcrumb the shell layout renders (GH #455).
+//
+// Uses the page's override crumbs when set (see BreadcrumbContext), otherwise
+// derives a trail from the current pathname + the shell's nav table:
+//   Home > <Section> > <segment> > … (last segment = current page, unlinked).
+// Opaque id segments (ULIDs / long hex) are skipped in the default trail — an
+// entity page that wants "Users > alice > Edit" supplies that via
+// useSetBreadcrumbs instead.
+import { useLocation } from "react-router";
+
+import type { NavItem } from "../../nav";
+import { AdminBreadcrumb } from "./AdminBreadcrumb";
+import { useBreadcrumbOverride } from "./BreadcrumbContext";
+import type { Crumb } from "./entityLinks";
+
+const SEGMENT_LABELS: Record<string, string> = {
+  create: "Create",
+  new: "New",
+  edit: "Edit",
+  settings: "Settings",
+  detail: "Details",
+  details: "Details",
+};
+
+function titleCase(seg: string): string {
+  const spaced = seg.replace(/-/g, " ");
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+// Opaque = a URL segment that is an identifier, not a page name: a ULID
+// (26 Crockford base32 chars) or a long hex/uuid. These are skipped in the
+// auto trail because they aren't human-readable.
+function isOpaqueId(seg: string): boolean {
+  return /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/.test(seg) || /^[0-9a-fA-F-]{16,}$/.test(seg);
+}
+
+export function deriveCrumbs(
+  pathname: string,
+  nav: NavItem[],
+  homePath: string,
+  homeLabel: string,
+): Crumb[] {
+  const crumbs: Crumb[] = [{ title: homeLabel, href: homePath }];
+
+  // Longest matching nav path prefix = the section this page lives under.
+  const section = [...nav]
+    .sort((a, b) => b.path.length - a.path.length)
+    .find((n) => pathname === n.path || pathname.startsWith(n.path + "/"));
+
+  if (section && section.path !== homePath) {
+    crumbs.push({ title: section.label, href: section.path });
+    const rest = pathname.slice(section.path.length).split("/").filter(Boolean);
+    for (const seg of rest) {
+      if (isOpaqueId(seg)) continue;
+      crumbs.push({ title: SEGMENT_LABELS[seg] ?? titleCase(seg) });
+    }
+  }
+
+  // The last crumb is the current page — never a link.
+  const last = crumbs.length - 1;
+  crumbs[last] = { title: crumbs[last].title };
+  return crumbs;
+}
+
+export function RouteBreadcrumb({
+  nav,
+  homePath,
+  homeLabel,
+}: {
+  nav: NavItem[];
+  homePath: string;
+  homeLabel: string;
+}) {
+  const override = useBreadcrumbOverride();
+  const { pathname } = useLocation();
+  const items = override && override.length > 0 ? override : deriveCrumbs(pathname, nav, homePath, homeLabel);
+  if (items.length === 0) return null;
+  return <AdminBreadcrumb items={items} />;
+}

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -13,6 +13,8 @@ import { JabaliFooter } from "../components/JabaliFooter";
 import { JabaliHeader } from "../components/JabaliHeader";
 import { JabaliTitle } from "../components/JabaliTitle";
 import { adminNav, selectedNavKey } from "../nav";
+import { BreadcrumbProvider } from "../components/admin/BreadcrumbContext";
+import { RouteBreadcrumb } from "../components/admin/RouteBreadcrumb";
 import { useThemeMode } from "../theme/ThemeModeContext";
 import { QuickStartModal } from "./admin/QuickStartModal";
 
@@ -176,7 +178,10 @@ export function AdminLayout() {
               overflowX: "hidden",
             }}
           >
-            <Outlet />
+            <BreadcrumbProvider>
+              <RouteBreadcrumb nav={adminNav} homePath="/jabali-admin/dashboard" homeLabel="Dashboard" />
+              <Outlet />
+            </BreadcrumbProvider>
             <QuickStartModal />
           </Content>
           <JabaliFooter />

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -13,6 +13,8 @@ import { ImpersonationBanner } from "../components/ImpersonationBanner";
 import { JabaliHeader } from "../components/JabaliHeader";
 import { JabaliTitle } from "../components/JabaliTitle";
 import { selectedNavKey, userNav } from "../nav";
+import { BreadcrumbProvider } from "../components/admin/BreadcrumbContext";
+import { RouteBreadcrumb } from "../components/admin/RouteBreadcrumb";
 import { useThemeMode } from "../theme/ThemeModeContext";
 import { useServerCapabilities } from "../hooks/useServerCapabilities";
 import { QuickStartModal } from "./user/QuickStartModal";
@@ -180,7 +182,10 @@ export function UserLayout() {
               overflowX: "hidden",
             }}
           >
-            <Outlet />
+            <BreadcrumbProvider>
+              <RouteBreadcrumb nav={userNav} homePath="/jabali-panel/dashboard" homeLabel="Dashboard" />
+              <Outlet />
+            </BreadcrumbProvider>
             <QuickStartModal />
           </Content>
           <JabaliFooter />

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -26,7 +26,7 @@ import { deleteApp, lifecycleAction, listCatalog, listInstalled, updateApp } fro
 import type { CatalogEntry, InstalledApp } from "./types";
 import { useSearchParams } from "react-router";
 import { useOneQuery } from "../../../hooks/useQueries";
-import { AdminBreadcrumb } from "../../../components/admin/AdminBreadcrumb";
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
 import { InstallDrawer } from "./InstallDrawer";
 import { LogsDrawer } from "./LogsDrawer";
@@ -128,13 +128,12 @@ export const AdminDockerAppsPage = () => {
     ? { id: ownerId, username: ownerQ.data?.username }
     : undefined;
 
+  useSetBreadcrumbs(
+    ownerRef ? ownerResourceCrumbs(ownerRef, { key: "docker-apps", label: "Docker Apps" }) : null,
+  );
+
   return (
     <div>
-      {ownerRef && (
-        <AdminBreadcrumb
-          items={ownerResourceCrumbs(ownerRef, { key: "docker-apps", label: "Docker Apps" })}
-        />
-      )}
       <Space wrap align="center" style={{ marginBottom: 16 }}>
         <Typography.Title level={3} style={{ margin: 0 }}>
           <ContainerOutlined /> Docker Apps

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -21,7 +21,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router";
 
 import { useOneQuery, useUpdateMutation } from "../../../hooks/useQueries";
-import { AdminBreadcrumb } from "../../../components/admin/AdminBreadcrumb";
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, adminLinks, ownerLabel } from "../../../components/admin/entityLinks";
 import type { Domain } from "./DomainList";
 import { DomainEmailSection } from "./DomainEmailSection";
@@ -72,6 +72,18 @@ export const DomainEdit = () => {
       });
     }
   }, [domain, form]);
+
+  useSetBreadcrumbs(
+    domain
+      ? [
+          ...ownerResourceCrumbs(
+            { id: domain.user_id, username: ownerQ.data?.username ?? domain.username },
+            { key: "domains", label: "Domains" },
+          ),
+          { title: domain.name },
+        ]
+      : null,
+  );
 
   const handleFinish = async (values: DomainEditInput) => {
     if (!id) return;
@@ -266,12 +278,6 @@ export const DomainEdit = () => {
 
   return (
     <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-      <AdminBreadcrumb
-        items={[
-          ...ownerResourceCrumbs(ownerRef, { key: "domains", label: "Domains" }),
-          { title: domain.name },
-        ]}
-      />
       <Card>
         <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 4 }}>
           Edit domain — {domain.name}

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -28,7 +28,7 @@ import { humanBytes } from "../../../utils/bytes";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import { useDeleteMutation, useOneQuery } from "../../../hooks/useQueries";
-import { AdminBreadcrumb } from "../../../components/admin/AdminBreadcrumb";
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, adminLinks, ownerLabel } from "../../../components/admin/entityLinks";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { DomainSettingsButton } from "../../DomainSettingsButton";
@@ -238,17 +238,18 @@ export const DomainList = () => {
     });
   };
 
+  useSetBreadcrumbs(
+    ownerId
+      ? ownerResourceCrumbs({ id: ownerId, username: ownerQ.data?.username }, { key: "domains", label: "Domains" })
+      : null,
+  );
+
   const ownerRef = ownerId
     ? { id: ownerId, username: ownerQ.data?.username }
     : undefined;
 
   return (
     <div>
-      {ownerRef && (
-        <AdminBreadcrumb
-          items={ownerResourceCrumbs(ownerRef, { key: "domains", label: "Domains" })}
-        />
-      )}
       <Space
         wrap
         align="center"

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -30,7 +30,7 @@ import {
 } from "../../../hooks/useMailboxes";
 import { useListQuery, useOneQuery } from "../../../hooks/useQueries";
 import { useSearchParams, Link } from "react-router";
-import { AdminBreadcrumb } from "../../../components/admin/AdminBreadcrumb";
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel, adminLinks } from "../../../components/admin/entityLinks";
 import type { Domain } from "../../user/domains/UserDomainList";
 import { EditMailboxModal } from "../../../components/mail/EditMailboxModal";
@@ -152,19 +152,18 @@ export function AdminMailPage() {
     }
   };
 
+  useSetBreadcrumbs(
+    ownerId
+      ? ownerResourceCrumbs({ id: ownerId, username: ownerQ.data?.username }, { key: "mailboxes", label: "Mailboxes" })
+      : null,
+  );
+
   if (isLoading && !rows) return <Skeleton active paragraph={{ rows: 6 }} />;
 
-  const ownerRef = ownerId
-    ? { id: ownerId, username: ownerQ.data?.username }
-    : undefined;
+  const ownerRef = ownerId ? { id: ownerId, username: ownerQ.data?.username } : undefined;
 
   return (
     <>
-      {ownerRef && (
-        <AdminBreadcrumb
-          items={ownerResourceCrumbs(ownerRef, { key: "mailboxes", label: "Mailboxes" })}
-        />
-      )}
       <Space
         wrap
         align="center"

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -37,7 +37,7 @@ import { useState } from "react";
 import { Link, useParams } from "react-router";
 
 import { apiClient } from "../../../apiClient";
-import { AdminBreadcrumb } from "../../../components/admin/AdminBreadcrumb";
+import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { adminLinks, ownerCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
 import { startImpersonation } from "../../../impersonation";
 
@@ -134,6 +134,8 @@ export function AdminUserOverview() {
     }
   };
 
+  useSetBreadcrumbs(userQ.data ? ownerCrumbs(userQ.data) : null);
+
   if (userQ.isLoading) {
     return <Skeleton active paragraph={{ rows: 4 }} />;
   }
@@ -155,8 +157,6 @@ export function AdminUserOverview() {
 
   return (
     <div>
-      <AdminBreadcrumb items={ownerCrumbs(user)} />
-
       <Space align="start" style={{ width: "100%", justifyContent: "space-between", flexWrap: "wrap" }}>
         <div>
           <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 4 }}>


### PR DESCRIPTION
Extends breadcrumbs from the ~5 pages that had them to the whole panel.

## Approach
A breadcrumb **context** owned by the shell layout renders exactly one trail:
- **Default**: `RouteBreadcrumb` derives `Home > Section > segment…` from the current route + the nav table (title-cases unknown segments, skips opaque id segments). Rendered in both admin + user shells above `<Outlet>` — so every page has a breadcrumb.
- **Entity pages** supply richer crumbs (e.g. `Users > alice > Domains`) via `useSetBreadcrumbs`, cleared on unmount.
- Migrated the 5 inline-`AdminBreadcrumb` pages to the hook (no duplicate trail). File-path breadcrumbs in the file manager are a separate concern, untouched.

## Test plan
- [ ] Every page shows a breadcrumb (Dashboard shows just 'Dashboard').
- [ ] Users → a user → Domains shows the entity trail.
- [ ] Nested pages (e.g. Domain Edit) show a sensible trail; ids aren't shown raw.

Unit tests cover `deriveCrumbs`.