### PR TITLE
docs: fix stale install URL (raw/branch/main -> raw/main)

### DIFF
--- a/docs/operations/migrate-to-new-server.md
+++ b/docs/operations/migrate-to-new-server.md
@@ -49,7 +49,7 @@ one command:
 
 ```bash
 # On the NEW server (root)
-bash <(curl -fsSL https://github.com/shukiv/jabali-panel/raw/branch/main/install.sh) \
+bash <(curl -fsSL https://github.com/shukiv/jabali-panel/raw/main/install.sh) \
     --restore-from=sftp:user@backup-host:/path/to/repo \
     --restore-credentials=/root/dest.env \
     --restore-password=/root/restic-repo.password \

--- a/docs/site/operations.md
+++ b/docs/site/operations.md
@@ -75,7 +75,7 @@ curl -fsSL https://get.jabali-panel.com | head -5   # expect the bash shebang + 
 ```
 
 If it fails, the canonical fallback always works:
-`curl -fsSL https://github.com/shukiv/jabali-panel/raw/branch/main/install.sh | sudo bash`.
+`curl -fsSL https://github.com/shukiv/jabali-panel/raw/main/install.sh | sudo bash`.
 Setup + redirect config live in `deploy/get-installer/`.
 
 ### Add a new PHP version


### PR DESCRIPTION
`github.com/shukiv/jabali-panel/raw/branch/main/install.sh` 404s — GitHub's raw path has no `/branch/` segment (that form is codeberg/forgejo). Fixed both operations docs to `/raw/main/` (verified 200).

Found while diagnosing a user's `curl 22 403` install report. The primary `https://get.jabali-panel.com | sudo bash` was fine; these were secondary/mirror commands in the migrate + operations docs.

Note: the marketing site (jabali-panel.com repo) also has a stale `https://jabali-panel.com/install.sh` (404) in two blog posts — separate repo, separate fix.