### PR TITLE
docs: fix dead links + broken internal references (doc audit)

### DIFF
--- a/docs/adr/0036-m16-hydra-identity.md
+++ b/docs/adr/0036-m16-hydra-identity.md
@@ -48,7 +48,7 @@ Deploy **Ory Hydra v2.4.x** as a separate systemd unit under `jabali.slice`, bou
 
 The apps framework mints a per-install OIDC client when a WordPress install is created: `client_id` + AES-GCM-sealed `client_secret` persist on `application_installs` (migration 000050). The installer auto-provisions the OpenID Connect Generic WP plugin (SHA-256 pinned) with the rendered callback URI. Trusted first-party clients (`metadata.trusted=true`, set server-side only by the apps framework) auto-accept consent; untrusted clients render the AntD consent screen at `/oauth2-consent`.
 
-Full 16-decision matrix: [plans/m16-hydra-oauth.md](../../plans/m16-hydra-oauth.md).
+Full 16-decision matrix: plans/m16-hydra-oauth.md (archived on M16 rollback).
 
 ## Alternatives Considered
 

--- a/docs/adr/0039-m22-magic-link.md
+++ b/docs/adr/0039-m22-magic-link.md
@@ -7,10 +7,10 @@
 **Deciders**: shuki
 
 **Related**:
-- [ADR-0036: OIDC for WordPress Admin Access (M16)](./0036-oidc-for-wordpress-admin.md) — superseded by this ADR
-- [ADR-0038: Rollback of M16 OIDC (M16R)](./0038-rollback-of-m16-oidc.md) — immediate predecessor
+- [ADR-0036: OIDC for WordPress Admin Access (M16)](./0036-m16-hydra-identity.md) — superseded by this ADR
+- [ADR-0038: Rollback of M16 OIDC (M16R)](./0038-m16-rollback.md) — immediate predecessor
 - [ADR-0040: Self-Deleting SSO File (M22 Rework)](./0040-m22-sso-file.md) — supersedes this ADR
-- [M16 Hydra Deployment](../runbooks/m16-hydra.md) — decommissioned by M16R
+- M16 Hydra Deployment (runbook decommissioned) — decommissioned by M16R
 - [M22 Magic-Link Plan](../../plans/m16-rollback-and-m22-magic-link.md)
 - [M22 Rework Plan](../../plans/m22-rework-sso-file.md)
 

--- a/docs/adr/0088-snuffleupagus-php-hardening.md
+++ b/docs/adr/0088-snuffleupagus-php-hardening.md
@@ -143,6 +143,6 @@ audit-detect alerts on any unwrapped php-cli invocation.
 - Snuffleupagus upstream: https://github.com/jvoisin/snuffleupagus
 - Documentation: https://snuffleupagus.readthedocs.io/
 - Imunify360 Proactive Defense (the comparison product):
-  https://docs.imunify360.com/proactive_defense/
+  https://docs.imunify360.com/
 - ADR-0031 (M9.6 PHP extension build pipeline)
 - ADR-0086 (M40 AppArmor — parked, this ADR's predecessor in scope)

--- a/docs/runbooks/nginx-layer.md
+++ b/docs/runbooks/nginx-layer.md
@@ -1,0 +1,503 @@
+# Nginx Layer — Architecture & Operations
+
+> **Status:** Living document. Updated when the nginx layer changes.
+> **Audience:** Operators, developers, and QA working on Jabali Panel.
+> **Scope:** How nginx is configured, how vhosts are generated, how the
+> cache / rate limits / tunables work, and how changes flow from the
+> database to disk.
+
+---
+
+## 1. Topology
+
+```
+Internet
+   │
+   ▼ :8443 (TLS)
+┌──────────────────────────────────────────────────────┐
+│  nginx (www-data)                                     │
+│                                                       │
+│  /etc/nginx/nginx.conf              — stock Debian +  │
+│                                         jabali patches│
+│  /etc/nginx/conf.d/                  — http{} scope   │
+│    00-jabali-ratelimits.conf         — zone declarations│
+│    05-jabali-tunables.conf           — server-wide knobs│
+│    jabali-fastcgi-cache.conf         — cache keyzone   │
+│    jabali-websocket-map.conf         — upgrade map     │
+│    crowdsec_nginx.conf               — AppSec WAF      │
+│                                                       │
+│  /etc/nginx/sites-enabled/           — per-domain     │
+│    <domain>.conf                     — tenant vhost    │
+│    <domain>-mail.conf                — webmail vhost   │
+│    jabali-panel.conf                 — panel vhost     │
+│                                                       │
+│  /etc/nginx/jabali/<domain>/         — per-install    │
+│    <app>-<subdir>.conf               — rewrite snippet │
+│    wordpress-xmlrpc.conf             — xmlrpc deny     │
+└──────────────────────────────────────────────────────┘
+   │                           │
+   ▼ unix:/run/jabali-panel/   ▼ unix:/run/php/jabali-<user>/
+   api.sock                     fpm.sock
+┌──────────────────┐     ┌──────────────────┐
+│  panel-api (Go)  │     │  PHP-FPM (per    │
+│  jabali user     │     │  user, cgroup v2)│
+└──────────────────┘     └──────────────────┘
+```
+
+### Two listener scopes
+
+| Scope | Port | Vhost file | Purpose |
+|-------|------|------------|---------|
+| Panel | 8443 | `jabali-panel.conf` | API + SPA + phpMyAdmin + Adminer |
+| Tenant domains | 80 → 443 | `<domain>.conf` | User websites |
+| Webmail | 80 → 443 | `<domain>-mail.conf` | Bulwark + Stalwart JMAP |
+
+The panel vhost is the **only** listener on :8443. Tenant domains
+listen on :80 (HTTP→HTTPS redirect) and :443. Webmail vhosts listen
+on :80 and :443 with `server_name mail.<domain> autoconfig.<domain> …`.
+
+---
+
+## 2. Vhost generation pipeline
+
+```
+Database (domains row)
+       │
+       ▼  reconciler tick (60s) or API mutation
+panel-api internal/reconciler
+       │
+       ▼  agent.Call("domain.create", {vhostData…})
+panel-agent internal/commands/domain_create.go
+       │
+       ▼  text/template.Execute(vhostTemplate, vhostData)
+       │  → write to /etc/nginx/sites-available/<domain>.conf
+       │  → symlink sites-enabled/<domain>.conf → sites-available/
+       │  → nginx -t
+       │  → systemctl reload nginx
+       ▼
+Live nginx
+```
+
+### Content-hash gate
+
+The reconciler calls `writeVhost` on **every** 60s tick for every
+domain. Without the content-hash gate this would rewrite + reload
+nginx ~180 times/hour. The gate reads the existing file, compares
+bytes, and skips the write + reload when identical.
+
+### What goes into a vhost
+
+The `vhostData` struct (`domain_create.go:397-460`) carries every
+field the template needs:
+
+| Field | Source | Validation |
+|-------|--------|------------|
+| `Domain` | DB `domains.name` | `domainRegex` (RFC 1035) |
+| `DocRoot` | DB `domains.doc_root` | `filesafe.Scope` (openat2) |
+| `FPMSocket` | `/run/php/jabali-<user>/fpm.sock` or per-domain | agent-computed |
+| `CustomDirectives` | DB `domains.nginx_custom_directives` | admin-only; allowlist |
+| `RuleDirectives` | `nginxrules.Compile(domain.NginxRules)` | typed rules; validated |
+| `RedirectDirectives` | `redirects.Compile(domain)` | structured redirects |
+| `IPACLDirectives` | `domain_ip_acls` table | `net.ParseCIDR` |
+| `DirectoryPrivacyDirectives` | `domain_directory_privacy` table | bcrypt-hashed credentials |
+| `RateLimitDirectives` | `BuildRateLimitDirectives(domainID, rps, conn)` | ULID-gated zone names |
+| `CacheEnabled` / `CacheGate` / `CacheTTL` | DB `domains.cache_*` | panel-controlled |
+| `SSLCertPath` / `SSLKeyPath` | `/etc/letsencrypt/live/<domain>/` or self-signed | agent-computed |
+| `ListenIPv4` / `ListenIPv6` | M24 IP manager | `net.ParseIP` |
+
+### HTTP/2 version awareness
+
+The agent probes `nginx -v` on every render and picks the correct
+HTTP/2 syntax (`listen … http2` on <1.25.1, `http2 on;` on ≥1.25.1).
+See `nginx_http2.go`.
+
+---
+
+## 3. Per-domain vhost template
+
+The template lives at `panel-agent/internal/commands/domain_create.go:132-395`.
+
+### Structure
+
+```
+server {                          # :80 — HTTP
+    listen 80;
+    server_name <domain> www.<domain>;
+
+    # ACME challenge location (^~ — wins over the redirect)
+    location ^~ /.well-known/acme-challenge/ { … }
+
+    # HTTP → HTTPS redirect (scoped to location /)
+    location / { return 301 https://$host$request_uri; }
+}
+
+server {                          # :443 — HTTPS (when SSL is configured)
+    listen 443 ssl;
+    server_name <domain> www.<domain>;
+    ssl_certificate …;
+    ssl_certificate_key …;
+
+    root <docroot>;
+    index …;
+
+    # IP ACLs (M36)
+    # Directory Privacy (M50)
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;   # PHP
+        # or
+        try_files $uri $uri/ =404;                        # static
+    }
+
+    # Error pages (M28)
+    # Static asset caching (if cache_enabled)
+    # PHP handler: location = /index.php { … }
+    # PHP handler: location ~ \.php$ { … }
+    # FastCGI micro-cache gate (if cache_enabled)
+
+    # Per-install rewrites (include /etc/nginx/jabali/<domain>/*.conf)
+    # Redirect directives
+    # Rule directives (proxy_pass, rewrite, custom_header, ip_access, …)
+    # Custom directives (admin-only allowlist)
+    # Rate limit directives
+}
+```
+
+### Disabled domain
+
+When `IsEnabled = false`, the template serves a branded "site
+disabled" page from `/var/www/jabali-disabled/` instead of the
+tenant's docroot.
+
+---
+
+## 4. FastCGI micro-cache (ADR-0108)
+
+### What it caches
+
+PHP responses from `index.php` and `*.php` for **anonymous** GET
+requests. The cache is opt-in per domain (`domains.cache_enabled`).
+
+### Fail-closed gate
+
+The cache gate (`$jabali_skip`) defaults to **skip** (1). It only
+allows caching (sets to 0) when:
+
+1. **No cookie** OR the cookie is exclusively known-benign
+   analytics/consent tokens (exhaustive allowlist:
+   `_ga*`, `_gid`, `_gat*`, `_gcl*`, `__utm*`, `_fbp`, `_fbc`,
+   `_pk_*`, `_hj*`, `cookie_consent*`, `wordpress_test_cookie`, …)
+2. **Request method is GET** (POST always skips)
+3. **Query string is empty or tracking-only** (`utm_*`, `gclid`,
+   `fbclid`, … — strict map in `jabali-fastcgi-cache.conf`)
+4. **Request URI is not in the bypass list** (`/wp-admin/`,
+   `/wp-login`, `/xmlrpc.php`, `/cart`, `/checkout`, …)
+5. **Cache gate path matches** (per-install prefix when multiple
+   installs share a domain)
+
+Any cookie not in the allowlist → bypass. This is the Gitea #416/#419
+fix: the old denylist was fail-open (unknown cookies were cached);
+the new allowlist is fail-closed.
+
+### Cache key
+
+```
+$scheme$request_method$host$jabali_cache_path
+```
+
+Where `$jabali_cache_path` is the **original** request path (before
+`try_files` rewrites `$uri` to `/index.php`). This prevents every
+WordPress permalink from collapsing onto one cache entry (Codeberg #5).
+
+### Upstream opt-out
+
+`fastcgi_no_cache` also checks `$upstream_http_cache_control` and
+`$upstream_http_vary` — if the PHP backend sends
+`Cache-Control: no-cache|no-store|private` or a non-Accept-Encoding
+`Vary`, the response is not stored (GH #637, #642).
+
+### Purge
+
+| Mode | How | Cost |
+|------|-----|------|
+| Targeted (paths) | MD5 of cache key → direct file unlink | O(1) per path |
+| Full domain | `filepath.WalkDir` over shared cache, match `KEY:` line host field | O(total cache files) |
+
+> **Known issue:** full purge walks ALL tenants' cache files. See
+> Plane issue `2ab86c0a`.
+
+### Warmup
+
+After cache enable or purge, the agent fetches the homepage + up to
+20 sitemap URLs through the local nginx (`curl --resolve` pins the
+host to `127.0.0.1`) to pre-populate the cache.
+
+### Capacity
+
+`nginx.cache.capacity_apply` rewrites `keys_zone`, `max_size`, and
+`inactive` in `jabali-fastcgi-cache.conf` with regex replacement +
+`nginx -t` gate + rollback.
+
+---
+
+## 5. Rate limits (M18 / M43)
+
+### Zone declarations
+
+A single fragment at `/etc/nginx/conf.d/00-jabali-ratelimits.conf`
+declares every `limit_req_zone` and `limit_conn_zone` referenced by
+any domain vhost. The `00-` prefix ensures alphabetical load order
+(zone must exist before vhost references it).
+
+### Per-vhost directives
+
+`BuildRateLimitDirectives(domainID, rps, conn)` emits:
+
+```nginx
+    limit_req zone=rl_<ULID> burst=<rps*2> nodelay;
+    limit_conn cn_<ULID> <conn>;
+```
+
+Zone names use the domain's ULID (26-char Crockford alphabet) —
+validated by `ulidRegex`. No user-controllable data reaches the zone
+name.
+
+### Atomic apply
+
+1. Write candidate to `.new`
+2. Back up live → `.bak`
+3. Rename `.new` → live
+4. `nginx -t`
+5. On fail: restore `.bak` → live
+6. On pass: remove `.bak`
+
+### Security framing (M43 / ADR-0089)
+
+Rate limits are an **anti-noise pre-filter** (scraping resistance,
+burst smoothing), **NOT** a security layer. CrowdSec scenarios +
+AppSec own behavioural rate / attack detection.
+
+---
+
+## 6. Tunables (M55)
+
+### Two destinations
+
+| Directive type | Where | How |
+|----------------|-------|-----|
+| `server_tokens`, `gzip`, `keepalive_timeout`, `worker_processes`, `worker_connections` | `/etc/nginx/nginx.conf` | Replace-in-place (first match only) |
+| `client_max_body_size`, timeouts, `proxy_*_timeout`, custom HTTP block | `/etc/nginx/conf.d/05-jabali-tunables.conf` | Additive fragment |
+
+### Validation
+
+| Input | Regex |
+|-------|-------|
+| Size values (`client_max_body_size`) | `^[0-9]+[kKmMgG]?$` |
+| Time values (timeouts) | `^[0-9]+(ms\|s\|m\|h)?$` |
+| `worker_processes` | `^(auto\|[1-9][0-9]?)$` |
+| `worker_connections` | ≤ 1,048,576 |
+| `custom_http` | ≤ 4000 chars, no NUL bytes |
+
+The custom HTTP block is **not** directive-validated — it's gated
+only by `nginx -t` (the "advanced, can destabilize" contract).
+
+### Atomicity
+
+Both files are staged with backups, swapped in, then a single
+`nginx -t` validates. On failure, **both** roll back in reverse
+order.
+
+---
+
+## 7. Custom directives & rule builder
+
+### Custom directives (admin-only)
+
+Admins can add raw nginx directives via
+`domains.nginx_custom_directives`. The validation at
+`validateNginxDirectives` (`domains.go:1244-1308`):
+
+- Rejects NUL bytes
+- Splits by newline, strips comments (respecting quoted strings)
+- Counts braces (max nesting depth 3, must be balanced)
+- Checks the first token of each line against `allowedNginxDirectives`
+  (a ~80-entry allowlist)
+
+Non-admins (tenants) **cannot** set custom directives — the PATCH
+handler checks `claims.IsAdmin` before accepting the field.
+
+### Rule builder (structured, tenant-safe subset)
+
+The `NginxRules` JSON column holds typed rules:
+
+| Type | Fields | Tenant-safe? |
+|------|--------|--------------|
+| `custom_header` | name, value, always | Yes |
+| `rewrite` | pattern, replacement, flag | Yes (replacement must be local path) |
+| `proxy_pass` | path, target, read_timeout, websocket | No (admin-only) |
+| `ip_access` | path, mode, IPs | No (admin-only) |
+| `php_setting` | name, value | No (admin-only) |
+| `max_upload_size` | size | No (admin-only) |
+
+Tenant-safe rules are validated by `validateTenantNginxRules` which:
+1. Rejects any type not in `tenantSafeNginxRuleTypes` (rewrite + custom_header only)
+2. For rewrites: rejects replacements containing `://` or starting with `//`
+3. Falls through to the full `validateNginxRules` for structural checks
+
+### NginxSafeOptions (GH #307)
+
+A curated, structured set of options a tenant may set when the admin
+opts in via `server_settings.tenant_domain_options_enabled`:
+
+- `max_body_mb` → `client_max_body_size`
+- `hsts` → `Strict-Transport-Security`
+- `security_headers` → `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`
+- `gzip` → `gzip on` + `gzip_types`
+
+Every option renders to a **fixed, vetted directive** with no
+caller-supplied target, path, or routing.
+
+---
+
+## 8. Panel vhost (`jabali-panel.conf`)
+
+Installed by `install.sh` from `install/nginx/jabali-panel-vhost.conf.tmpl`.
+
+### Key features
+
+- **Upstream:** `unix:/run/jabali-panel/api.sock` (jabali-sockets group)
+- **TLS:** `ssl_protocols TLSv1.2 TLSv1.3`, `ssl_ciphers HIGH:!aNULL:!MD5`
+- **Security headers:** HSTS, X-Frame-Options DENY, X-Content-Type-Options, CSP, Referrer-Policy
+- **CSP:** `default-src 'self'; script-src 'self' 'unsafe-inline'; …` — `unsafe-inline` needed for AntD emotion CSS-in-JS
+- **Body size:** 10 GiB ceiling (panel API enforces the precise per-user limit)
+- **WebSocket:** `/api/v1/logs/stream/*` — upgrade map + relaxed CSP for GoAccess iframe
+- **phpMyAdmin + Adminer:** `include` snippets with `location ^~`
+- **Kratos:** `/.ory/*` is proxied by panel-api itself (in-process)
+
+### GoAccess CSP exception
+
+The `/api/v1/logs/stream/*` location overrides CSP to allow
+`'unsafe-eval'` (GoAccess uses `new Function(...)` for its template
+compiler). Parent block headers are re-declared because nginx
+`add_header` semantics don't inherit when a location defines any
+`add_header`.
+
+---
+
+## 9. Webmail vhost
+
+Installed per-domain by `webmail_vhost.go` from
+`install/nginx/jabali-mail-vhost.conf.tmpl`.
+
+- **Upstream:** `jabali_bulwark` (Unix socket) for the SPA
+- **Stalwart JMAP:** proxied to `127.0.0.1:8446` at `/jmap` and `/.well-known/jmap`
+- **SSO landing:** `/sso/webmail` proxied to `jabali_panel_api`
+- **sub_filter:** rewrites `${PANEL_HOSTNAME}` → `$host` so the SPA stays same-origin
+- **No X-Forwarded-Proto:** intentionally omitted (Bulwark's Next.js middleware breaks on it)
+
+---
+
+## 10. nginx -t and reload
+
+Every nginx-mutating agent handler follows the same pattern:
+
+1. Write the new config (vhost file, fragment, snippet)
+2. Run `nginx -t`
+3. On failure: remove/rollback the file, return error
+4. On success: `systemctl reload nginx`
+5. On reload failure: return error (config is valid but reload failed)
+
+### Known issue: no serialization
+
+There is no shared mutex across the 6+ handlers that do
+write-test-reload. Concurrent operations can interleave. See Plane
+issue `0df956af`.
+
+---
+
+## 11. File layout reference
+
+| Path | Owner | Mode | Purpose |
+|------|-------|------|---------|
+| `/etc/nginx/nginx.conf` | root:root | 0644 | Stock Debian + jabali patches |
+| `/etc/nginx/conf.d/00-jabali-ratelimits.conf` | root:root | 0644 | Zone declarations |
+| `/etc/nginx/conf.d/05-jabali-tunables.conf` | root:root | 0644 | Server-wide tunables |
+| `/etc/nginx/conf.d/jabali-fastcgi-cache.conf` | root:root | 0644 | Cache keyzone + maps |
+| `/etc/nginx/conf.d/jabali-websocket-map.conf` | root:root | 0644 | WebSocket upgrade map |
+| `/etc/nginx/sites-available/<domain>.conf` | root:root | 0644 | Per-domain vhost |
+| `/etc/nginx/sites-enabled/<domain>.conf` | root:root | 0777 (symlink) | → sites-available |
+| `/etc/nginx/jabali/<domain>/*.conf` | root:root | 0644 | Per-install rewrite snippets |
+| `/var/cache/nginx/jabali/` | www-data:www-data | 0700 | FastCGI cache store |
+| `/var/log/nginx/<domain>-access.log` | www-data:adm | 0640 | Per-domain access log |
+| `/var/log/nginx/jcache-<domain>.log` | www-data:adm | 0640 | Cache status log |
+
+---
+
+## 12. Related ADRs
+
+| ADR | Topic |
+|-----|-------|
+| 0009 | Nginx file-per-vhost |
+| 0014 | Panel port 8443, user sites on 443 |
+| 0046 | Responsive tables (`scroll={{ x: "max-content" }}`) |
+| 0050 | Localhost backend via Unix sockets |
+| 0077 | HTTP/2 directive version awareness |
+| 0089 | Rate limits as anti-noise, not security |
+| 0108 | Per-domain FastCGI micro-cache |
+
+---
+
+## 13. Troubleshooting
+
+### `nginx -t` fails after a domain change
+
+```bash
+nginx -t 2>&1
+# Read the error — it names the file and the directive
+```
+
+Common causes:
+- Duplicate `location /` — custom directives declare it when the
+  template also emits one (check `RootOverridden` logic)
+- Missing zone — rate limit zone not declared in
+  `00-jabali-ratelimits.conf` before the vhost references it
+- Bad SSL path — cert not yet issued; check `ssl_certificates` table
+
+### Domain serves the disabled page despite being enabled
+
+The vhost file was not regenerated after the `is_enabled` flip.
+Force a reconcile:
+
+```bash
+jabali-panel admin reconciler run --token JWT
+```
+
+Or wait 60s for the next tick.
+
+### Cache not working (always MISS)
+
+Check the `X-Jabali-Cache` response header:
+
+| Value | Meaning |
+|-------|---------|
+| MISS | First request — expected |
+| HIT | Cache working |
+| BYPASS | Gate skipped — check cookies, query string, auth |
+| EXPIRED | TTL elapsed — expected, background update refreshes |
+
+Verify the cache gate log:
+
+```bash
+tail /var/log/nginx/jcache-<domain>.log
+```
+
+### Reload fails but `nginx -t` passes
+
+Rare — means nginx's master process is stuck. Check:
+
+```bash
+systemctl status nginx
+journalctl -u nginx -n 20
+# If master is unresponsive:
+systemctl restart nginx  # hard restart (drops connections)
+```

--- a/docs/security/audit-2026-07-08.md
+++ b/docs/security/audit-2026-07-08.md
@@ -1,0 +1,287 @@
+# Jabali Panel — Security Audit Report
+
+> **Date:** 2026-07-08
+> **Auditor:** AI-assisted security review (opencode / glm-5.2)
+> **Scope:** Full codebase at `~/projects/jabali2/` — Go backend, Go
+> agent, React SPA, install.sh, nginx configuration
+> **Method:** Manual code review + targeted tooling (gosec) +
+> architecture analysis + nginx deep dive
+> **Classification:** Internal — for project maintainers
+
+---
+
+## 1. Executive Summary
+
+Two audit passes were conducted:
+
+| Pass | Scope | Issues filed | Fixed | Disproved |
+|------|-------|--------------|-------|-----------|
+| Pass 1 | General codebase security | 9 (Gitea #693–#701) | 6 | 3 |
+| Pass 2 | Nginx layer deep dive | 8 (Plane work items) | Pending | — |
+
+**Overall assessment:** The codebase is well-hardened. No remotely
+exploitable critical vulnerabilities were found in the Go backend or
+agent. The filesafe package (`openat2` + `RESOLVE_BENEATH`) provides
+kernel-enforced path containment that is superior to user-mode string
+checks. Auth layering (Kratos + API tokens + HMAC automation) is
+correctly implemented with replay defense and scope checking.
+
+The nginx layer has the highest concentration of findings, primarily
+defense-in-depth gaps that require admin access to exploit but should
+be narrowed.
+
+---
+
+## 2. Pass 1 — General Codebase Security
+
+### 2.1 Methodology
+
+1. **Static analysis:** `gosec` on `panel-api` and `panel-agent` (0
+   findings — gosec did not resolve internal packages correctly)
+2. **Secret scan:** regex search for hardcoded API keys, passwords,
+   tokens in `.go`, `.ts`, `.sh` files (0 found)
+3. **Manual review** of security-critical code paths:
+   - Auth middleware: `auth_kratos.go`, `auth_user_api_token.go`,
+     `automation_hmac.go`, `impersonation.go`, `cors.go`, `rbac.go`
+   - Agent commands: `terminal_pty.go`, `files_*.go`,
+     `user_create.go`, `user_password.go`, `user_delete.go`,
+     `db_user_create.go`, `db_root_password.go`, `system_kill.go`,
+     `ssh_authorized_keys_write.go`, `php_cli_wrapper.go`,
+     `migration_imapsync.go`, `cron_apply.go`
+   - File safety: `filesafe.go`, `openat2.go`
+   - API handlers: `domains.go`, `backups.go`, `applications.go`,
+     `ddns.go`, `webmail_sso.go`, `sso_phpmyadmin.go`
+   - Install: `install.sh` (13K lines — sampled critical sections)
+   - Crypto: token hashing, SSO token lifecycle, HMAC verification
+
+### 2.2 Findings
+
+#### Fixed (6)
+
+| # | Severity | Finding | Fix SHA |
+|---|----------|---------|---------|
+| 696 | High | Rate limiter keyed on `gin c.ClientIP()` (XFF-spoofable) | `3fbc1aea` |
+| 697 | High | Root cron `ExecStart` uses Go `%q` instead of systemd-safe `singleQuote()` | `b7fbad18` |
+| 699 | High | `/admin/cron` route group lacks `RequireAdmin()` middleware | `b7fbad18` |
+| 694 | Low | Raw JSON construction from username in `user_create`/`user_delete` | `8fac63c3` |
+| 700 | Medium | Docker compose error messages include raw subprocess output | `8fac63c3` |
+| 701 | Low | install.sh secret file creation race window | `8fac63c3` |
+
+#### Disproved (3)
+
+| # | Claim | Disproof |
+|---|-------|----------|
+| 695 | No CSRF protection | `EnforceSameOriginForCookieMutations()` is applied to the whole `/api/v1` group + cookie is `SameSite=Lax` |
+| 698 | Agent should independently verify admin for `RunAsRoot` | The agent has no user session — the panel IS the auth boundary over the trusted Unix socket |
+| 693 | Admin bootstrap password world-readable | `panel.env` is created `0640 root:jabali` via `install -m`; `umask 077` wraps the writes |
+
+### 2.3 Positive findings (things done right)
+
+- **filesafe/openat2:** Kernel-enforced `RESOLVE_BENEATH` on every
+  file operation. Symlink-TOCTOU is impossible at the kernel level.
+- **Archive extraction:** Zip-slip defense + decompression bomb limits
+  (100K entries, 10 GiB total, 5 GiB per file) + symlink/device skip.
+- **Cron validation:** `cronvalidate` package rejects unquoted shell
+  metacharacters, uses `shlex.Split` for parsing, allowlists binaries
+  (wp/php/phpX.Y only), validates paths against owned docroots, rejects
+  inline-code PHP flags (`-r`, `-R`, `-B`, `-E`).
+- **SQL escaping:** `EscapeMariaDBLiteral` and `EscapeMariaDBIdentifier`
+  with NUL rejection and backslash escaping. GORM parameterized queries
+  everywhere — no string-concat SQL found.
+- **API token hashing:** SHA-256 of full token (prefix included),
+  stored as hex. Indistinguishable error responses for invalid vs
+  revoked tokens.
+- **HMAC automation:** Constant-time comparison, 5-min skew window,
+  Redis SETNX replay defense (fail-closed on Redis-down), per-token
+  scope checking.
+- **Impersonation:** Admin-only, grant must be active + owned by the
+  real admin, target must be non-admin, impersonation-management
+  endpoints exempt from override.
+- **SO_PEERCRED:** Root terminal PTY broker verifies caller's primary
+  GID via `SO_PEERCRED` — only panel-api (or root) can connect.
+- **Suspended account enforcement:** Both Kratos cookie path and API
+  token path check `panelUser.Suspended` — a suspend takes effect
+  regardless of Kratos propagation.
+
+---
+
+## 3. Pass 2 — Nginx Layer Deep Dive
+
+### 3.1 Methodology
+
+1. **File mapping:** All 21 nginx-related `.go` files + 7 nginx config
+   templates in `install/nginx/` + nginx sections of `install.sh`
+2. **Template review:** Full read of `vhostTemplate` (264 lines),
+   `vhostData` struct, `writeVhost` function, content-hash gate
+3. **Directive validation review:** `allowedNginxDirectives` allowlist
+   (80 entries), `validateNginxDirectives` (brace counting, comment
+   stripping, NUL rejection), `validateNginxRules` (per-type field
+   validation), `validateTenantNginxRules` (tenant-safe subset)
+4. **Cache review:** `nginx_cache_purge.go` (targeted + full purge),
+   `nginx_cache_warmup.go` (sitemap fetch), `nginx_cache_capacity.go`
+   (conf rewrite), `jabali-fastcgi-cache.conf` (maps + keyzone)
+5. **Rate limit review:** `nginx_ratelimits.go` (zone declarations,
+   per-vhost directives, atomic apply + rollback)
+6. **Tunables review:** `nginx_tunables.go` (nginx.conf patching,
+   fragment generation, validation regexes)
+7. **Reload flow review:** All 6 handlers that do write-test-reload
+8. **Install.sh review:** nginx.conf setup, TLS configuration, SSL
+   cipher suites, security headers, tunables seeding
+9. **External reference:** Mozilla SSL Configuration Generator for
+   cipher suite comparison
+
+### 3.2 Findings (Plane work items)
+
+| ID | Priority | Finding |
+|----|----------|---------|
+| `0df956af` | **Urgent** | Concurrent vhost writes race on `nginx -t` and reload — 6 handlers, no shared mutex |
+| `762a6431` | **High** | `proxy_pass` rule target has no SSRF restriction — admin can proxy to `127.0.0.1:3306`, `unix:/run/...` |
+| `2417099e` | **High** | Custom directives allowlist permits `auth_basic_user_file`, `sub_filter`, `proxy_pass` — file oracle + response injection |
+| `8966d307` | **High** | SSL cipher suite `HIGH:!aNULL:!MD5` permits 3DES (Sweet32), CBC (Lucky13) — SSL Labs grade B |
+| `502848f8` | **High** | Per-domain vhost template has no security headers (HSTS, X-Frame-Options, X-Content-Type-Options) |
+| `2ab86c0a` | **Medium** | Full-domain cache purge walks ALL tenants' cache files — O(N) cross-tenant I/O DoS |
+| `13543a04` | **Medium** | `nginx -t` failure output leaked in error messages to API callers — internal path disclosure (5 handlers) |
+| `63af88a2` | **Medium** | Rewrite rule pattern is unvalidated regex — nginx PCRE ReDoS, tenant-accessible |
+
+### 3.3 Positive findings (nginx things done right)
+
+- **Cache gate is fail-closed:** `$jabali_skip` defaults to 1 (skip).
+  Only genuinely anonymous GETs with no cookie or known-benign
+  analytics cookies are cached. Gitea #416/#419 fix.
+- **Cache key uses original path:** `$jabali_cache_path` (from
+  `$request_uri`) prevents permalink collapse. Codeberg #5 fix.
+- **Upstream cache opt-out honored:** `fastcgi_no_cache` checks
+  `$upstream_http_cache_control` and `$upstream_http_vary`. GH #637,
+  #642.
+- **Cross-tenant cache eviction prevented:** `keyLineHost()` does
+  exact host comparison, not substring. Gitea #418 fix.
+- **Rate limit zone names are ULID-gated:** No user-controllable data
+  reaches `limit_req_zone` / `limit_conn_zone` names.
+- **Tenant-safe rule types:** `proxy_pass`, `ip_access`,
+  `php_setting`, `max_upload_size` are excluded from tenant access.
+  Tenant rewrites must be local paths (no scheme/host).
+- **nginx -t is the final gate:** Every handler tests before reload.
+  Rollback on failure is implemented in 5 of 6 handlers.
+- **HTTP/2 version awareness:** Probes `nginx -v` on every render.
+  Correct syntax for both sides of the 1.25.1 boundary.
+- **Content-hash idempotency:** Prevents ~180 reloads/hour from
+  reconciler ticks.
+
+---
+
+## 4. Recommendations
+
+### Immediate (urgent)
+
+1. **Add a shared mutex** to all nginx-mutating agent handlers.
+   The write-test-reload sequence must be serialized.
+
+### Short-term (high priority)
+
+2. **Restrict `proxy_pass` targets** — reject loopback, RFC1916, link-
+   local, and Unix socket paths in `validateNginxRules`.
+3. **Narrow the custom directives allowlist** — remove
+   `auth_basic_user_file`, `sub_filter*`, and `proxy_pass` from the
+   raw allowlist. Use structured features (Directory Privacy, rule
+   builder) instead.
+4. **Upgrade SSL cipher suite** — replace `HIGH:!aNULL:!MD5` with
+   Mozilla intermediate cipher list. Add `ssl_session_cache` and
+   `ssl_session_timeout`.
+5. **Add baseline security headers** to the per-domain vhost template
+   — `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`,
+   and HSTS when SSL is enabled.
+
+### Medium-term
+
+6. **Per-domain cache partitioning** — eliminate the full-walk purge
+   by partitioning the cache directory per domain.
+7. **Sanitize error messages** — stop embedding raw `nginx -t` output
+   in `AgentError.Message`. Use `AgentError.Details` for admin
+   debugging; return generic messages to tenants.
+8. **Validate rewrite regex patterns** — cap length, detect ReDoS
+   patterns, validate PCRE syntax.
+
+### Ongoing
+
+9. **Run `gosec` with correct configuration** — the current run
+   produced 0 findings because it didn't resolve internal packages.
+   Configure `gosec` to track the full module path.
+10. **Add `semgrep` to CI** — complement `golangci-lint` with
+    semgrep's security rules for Go.
+
+---
+
+## 5. Appendix — Files reviewed
+
+### Pass 1 (general)
+
+| File | Lines | Focus |
+|------|-------|-------|
+| `panel-agent/internal/commands/terminal_pty.go` | 360 | Root shell broker, SO_PEERCRED |
+| `panel-agent/internal/commands/files_read.go` | 140 | File read, filesafe scope |
+| `panel-agent/internal/commands/files_write.go` | 222 | File write, temp-rename, chown |
+| `panel-agent/internal/commands/files_extract.go` | 374 | Archive extraction, zip-slip |
+| `panel-agent/internal/commands/files_ingest.go` | 181 | Upload staging, atomic move |
+| `panel-agent/internal/commands/user_create.go` | 169 | User creation, useradd, chpasswd |
+| `panel-agent/internal/commands/user_password.go` | 103 | Password change, chpasswd |
+| `panel-agent/internal/commands/user_delete.go` | 143 | User deletion, userdel, rollback |
+| `panel-agent/internal/commands/db_user_create.go` | 120 | DB user, SQL escaping |
+| `panel-agent/internal/commands/db_root_password.go` | 173 | Root password, socket auth guard |
+| `panel-agent/internal/commands/system_kill.go` | 109 | Process kill, denylist |
+| `panel-agent/internal/commands/ssh_authorized_keys_write.go` | 127 | SSH keys, filesafe scope |
+| `panel-agent/internal/commands/php_cli_wrapper.go` | 317 | PHP wrapper, symlink TOCTOU |
+| `panel-agent/internal/commands/migration_imapsync.go` | 230 | IMAP migration, passfile |
+| `panel-agent/internal/commands/cron_apply.go` | 552 | Cron apply, validation, root cron |
+| `panel-agent/internal/commands/runbounded.go` | 113 | Bounded output ring buffer |
+| `panel-agent/internal/commands/shell_quote.go` | 11 | Shell quoting |
+| `panel-agent/internal/commands/mysql_escape.go` | 41 | MariaDB escaping |
+| `panel-agent/internal/commands/sensitive_files.go` | 53 | Sensitive file mode hardening |
+| `panel-agent/internal/commands/docker_app.go` | 730 | Docker app install/lifecycle |
+| `panel-agent/internal/commands/migration_rsync_remote_home.go` | 267 | rsync migration, filesafe |
+| `panel-agent/internal/commands/migration_admin_run.go` | 327 | Migration secrets, systemd-run |
+| `internal/filesafe/filesafe.go` | 345 | Scope, Clean, Resolve, verifyInScope |
+| `internal/filesafe/openat2.go` | 908 | openat2, RESOLVE_BENEATH, ExtractDir |
+| `panel-api/internal/middleware/auth_kratos.go` | 117 | Kratos session validation |
+| `panel-api/internal/middleware/auth_user_api_token.go` | 207 | API token bearer auth |
+| `panel-api/internal/middleware/automation_hmac.go` | 252 | HMAC verification, replay defense |
+| `panel-api/internal/middleware/impersonation.go` | 104 | Admin act-as override |
+| `panel-api/internal/middleware/cors.go` | 111 | CORS, same-origin check |
+| `panel-api/internal/middleware/rbac.go` | 55 | RequireAdmin, RequireOwner |
+| `panel-api/internal/middleware/ratelimit.go` | 130 | Per-IP token bucket |
+| `panel-api/internal/middleware/localhost.go` | 50 | RequireLocalhost |
+| `panel-api/internal/api/domains.go` | 1681 | Domain CRUD, ownership checks |
+| `panel-api/internal/api/ddns.go` | 266 | DynDNS shim, token validation |
+| `panel-api/internal/api/webmail_sso.go` | 204 | Webmail SSO, JWT mint |
+| `panel-api/internal/api/sso_phpmyadmin.go` | 260 | phpMyAdmin SSO, same-origin check |
+| `panel-api/internal/api/me_api_tokens.go` | 211 | API token creation, entropy |
+| `panel-api/internal/webui/webui.go` | 127 | SPA serving, embed.FS |
+| `panel-api/internal/sso/sso.go` | 186 | Shadow account, FOR UPDATE |
+| `agentwire/wire.go` | 81 | NDJSON wire protocol |
+| `panel-api/internal/webui/webui.go` | 127 | Embedded SPA serving |
+| `install.sh` | 13,480 | Full installer (sampled) |
+
+### Pass 2 (nginx)
+
+| File | Lines | Focus |
+|------|-------|-------|
+| `panel-agent/internal/commands/domain_create.go` | 1117 | Vhost template, writeVhost, content-hash gate |
+| `panel-agent/internal/commands/nginx.go` | 58 | nginx.test, nginx.reload |
+| `panel-agent/internal/commands/nginx_cache_purge.go` | 200 | Targeted + full cache purge |
+| `panel-agent/internal/commands/nginx_cache_warmup.go` | 175 | Sitemap fetch, cache pre-warm |
+| `panel-agent/internal/commands/nginx_cache_capacity.go` | 75 | Cache zone size rewrite |
+| `panel-agent/internal/commands/nginx_ratelimits.go` | 190 | Zone declarations, per-vhost directives |
+| `panel-agent/internal/commands/nginx_tunables.go` | 230 | nginx.conf patching, fragment generation |
+| `panel-agent/internal/commands/nginx_http2.go` | 72 | HTTP/2 version detection |
+| `panel-agent/internal/commands/nginx_app_rewrites.go` | 190 | Per-install rewrite snippets |
+| `panel-agent/internal/commands/nginx_status.go` | — | nginx status |
+| `panel-api/internal/nginxrules/compile.go` | 132 | Rule compilation to directives |
+| `panel-api/internal/models/nginx_safe_options.go` | 115 | Tenant-safe options, Render() |
+| `panel-api/internal/api/domain_htaccess.go` | 121 | .htaccess import preview |
+| `panel-api/internal/eventsources/nginx_config.go` | — | nginx config event source |
+| `install/nginx/jabali-panel-vhost.conf.tmpl` | 125 | Panel vhost template |
+| `install/nginx/jabali-fastcgi-cache.conf` | 55 | Cache keyzone + maps |
+| `install/nginx/jabali-mail-vhost.conf.tmpl` | 105 | Webmail vhost template |
+| `install/nginx/jabali-bulwark-upstream.conf` | 15 | Bulwark upstream |
+| `install/nginx/.ory-location.conf` | 30 | Kratos proxy location |
+| `install/nginx/jabali-websocket-map.conf` | 10 | WebSocket upgrade map |
+| `install.sh` (nginx sections) | ~500 | nginx.conf, TLS, tunables seeding |

--- a/docs/site/INTEGRATION.md
+++ b/docs/site/INTEGRATION.md
@@ -520,9 +520,9 @@ Keys follow camelCase with the leading prefix `admin` / `user`:
 
 Do **not** port these existing legacy `.astro` pages into the new build:
 
-- `admin/geo-block-rules.astro`, `admin/geo-block-rules-create.astro`, `admin/geo-block-rules-edit.astro` — the model is replaced by [CrowdSec scenarios + allowlists](../admin/crowdsec-decisions.md) plus [AppSec](../admin/appsec.md).
-- `admin/waf.astro` — superseded by [AppSec](../admin/appsec.md).
-- `admin/webhook-endpoints*.astro` — admin webhooks are not currently shipped; use [Notifications](../admin/notifications-channels.md) sender channels instead.
+- `admin/geo-block-rules.astro`, `admin/geo-block-rules-create.astro`, `admin/geo-block-rules-edit.astro` — the model is replaced by [CrowdSec scenarios + allowlists](./admin/crowdsec-decisions.md) plus [AppSec](./admin/appsec.md).
+- `admin/waf.astro` — superseded by [AppSec](./admin/appsec.md).
+- `admin/webhook-endpoints*.astro` — admin webhooks are not currently shipped; use [Notifications](./admin/notifications-channels.md) sender channels instead.
 - `user/cdn-integration.astro` — not shipped.
 - `user/git-deployment.astro` — not shipped.
 - `user/image-optimization.astro` — not shipped.
@@ -586,7 +586,7 @@ done
 
 ### Sidebar grouping for the subpages
 
-In `src/layouts/DocsLayout.astro`, the sidebar should mirror the page-level IA from [admin.md](../admin.md) and [user.md](../user.md). Suggested structure:
+In `src/layouts/DocsLayout.astro`, the sidebar should mirror the page-level IA from [admin.md](./admin.md) and [user.md](./user.md). Suggested structure:
 
 **Admin sidebar group**
 

--- a/docs/site/admin/hosting-packages-edit.md
+++ b/docs/site/admin/hosting-packages-edit.md
@@ -22,7 +22,7 @@ Convergence completes within 60 seconds (the reconciler tick interval).
 
 ## Field-level audit
 
-Every save writes one audit row per changed field, with a structured diff (old value → new value). See [Audit Log](./audit.md).
+Every save writes one audit row per changed field, with a structured diff (old value → new value). See [Audit Log](./audit-log.md).
 
 ## CLI
 

--- a/docs/site/admin/terminal.md
+++ b/docs/site/admin/terminal.md
@@ -27,7 +27,7 @@ If keystroke-level recording is required for compliance, run a real SSH session 
 
 - Single-tab. Open two browser tabs for two sessions.
 - No tmux / screen multiplexing inside the panel terminal (the terminal element does not interpret all terminal-multiplexer escape sequences correctly). Use `tmux` from a real SSH session.
-- No file upload. Use [Files](./files.md) (or SFTP) to move files.
+- No file upload. Use [Files](../user/files.md) (or SFTP) to move files.
 - Performance is bounded by the WebSocket latency; for high-throughput operations (large `find`, `tail -f` of a chatty log) use SSH instead.
 
 ## Disabling

--- a/docs/site/admin/users-edit.md
+++ b/docs/site/admin/users-edit.md
@@ -30,4 +30,4 @@ A single transactional `UPDATE` against `users`, plus a Kratos call if identity 
 
 ## Audit
 
-Every field-level change writes an audit row with a structured diff (old value → new value). See [Audit Log](./audit.md).
+Every field-level change writes an audit row with a structured diff (old value → new value). See [Audit Log](./audit-log.md).

--- a/docs/site/admin/users.md
+++ b/docs/site/admin/users.md
@@ -54,4 +54,4 @@ jabali admin purge-orphan-identities --username <name> --apply
 
 ## Audit
 
-Every action above writes an audit row: actor user, subject user, action, result. See [Audit Log](./audit.md).
+Every action above writes an audit row: actor user, subject user, action, result. See [Audit Log](./audit-log.md).

--- a/docs/site/platform/stack.md
+++ b/docs/site/platform/stack.md
@@ -69,4 +69,4 @@ Wire-contract drift is caught by golden tests (mirror `security_crowdsec_geobloc
 - **Single agent over UDS** keeps privilege boundary one process; no setuid binaries, no sudoers.d expansion.
 - **Sockets only for everything that can be a socket** (Kratos public/admin, MariaDB, Stalwart admin) removes TCP attack surface.
 
-ADRs covering the major decisions live under [docs/adr/](https://github.com/shuki-vaknin/jabali2/tree/main/docs/adr).
+ADRs covering the major decisions live under [docs/adr/](https://github.com/shukiv/jabali-panel/tree/main/docs/adr).


### PR DESCRIPTION
Audited every external URL and relative link in `docs/`. All external URLs return 200 except a few placeholders; fixed the real breakage.

## Fixed
- **Wrong github org** `shuki-vaknin/jabali2` → `shukiv/jabali-panel` (stack.md).
- **INTEGRATION.md** used `../admin/…` from `docs/site/` (one level too high) → `./admin/…` — 6 links, targets exist.
- `./audit.md` → `./audit-log.md` (users, users-edit, hosting-packages-edit).
- terminal.md Files link → `../user/files.md` (page lives under `user/`).
- **ADR-0039** cross-refs to pre-rename ADR filenames → current names (`0036-m16-hydra-identity`, `0038-m16-rollback`); dropped the decommissioned m16-hydra runbook link.
- **imunify360** dead `/proactive_defense/` → docs root (200).
- **ADR-0036** link to the deleted `m16-hydra-oauth` plan → unlinked (archived on rollback).

Broken-internal-link scan: **0 remaining (was 14)**.

## Not changed (needs your decision)
- README's **live demo** at `https://jabali-panel.com/demo/` 404s (×3). Either the demo isn't deployed or the URL moved — a product decision, not a doc-text fix.