### PR TITLE
fix(migrate): custom source SSH port was dropped by the wizard + probes (GH #429)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -814,6 +814,10 @@ type patchDraftRequest struct {
 	SourceUser      *string `json:"source_user,omitempty"`
 	TargetUserID    *string `json:"target_user_id,omitempty"`
 	ExpectedHostKey *string `json:"expected_host_key,omitempty"`
+	// SourcePort (GH #429) — the wizard collects the SSH port in the
+	// Connection step, which PATCHes the draft. Without this the port was
+	// silently dropped and the pull dialed 22.
+	SourcePort *int `json:"source_port,omitempty"`
 }
 
 // patchDraft updates a draft-state job. Allows the wizard to keep the
@@ -830,7 +834,13 @@ func (h *adminMigrationsHandler) patchDraft(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_fingerprint", "detail": "expected_host_key must be a SHA256 fingerprint (optionally SHA256:-prefixed)"})
 		return
 	}
-	if err := h.cfg.Jobs.PatchDraft(c.Request.Context(), id, req.SourceHost, req.SourceUser, req.TargetUserID, req.ExpectedHostKey); err != nil {
+	// Clamp the port to a valid range when supplied (GH #429).
+	var portPtr *int
+	if req.SourcePort != nil {
+		p := normalizeSourcePort(*req.SourcePort)
+		portPtr = &p
+	}
+	if err := h.cfg.Jobs.PatchDraft(c.Request.Context(), id, req.SourceHost, req.SourceUser, req.TargetUserID, req.ExpectedHostKey, portPtr); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			c.JSON(http.StatusConflict, gin.H{"error": "not_draft", "detail": "job missing or not in draft state"})
 			return
@@ -1185,6 +1195,9 @@ func (h *adminMigrationsHandler) discoverAccounts(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no_discoverer", "detail": err.Error()})
 		return
 	}
+	// Honor the job's custom source SSH port (GH #429) so test-connection
+	// and size-probe dial the same port the pull will use, not always 22.
+	migrate.ApplyPort(disc, job.SourcePort)
 	// Apply the SSRF private-host override from server_settings so the
 	// admin UI toggle takes effect on the next discover call without a
 	// process restart. Best-effort: settings repo unset or row missing
@@ -1347,6 +1360,9 @@ func (h *adminMigrationsHandler) accountSizeProbe(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no_discoverer", "detail": err.Error()})
 		return
 	}
+	// Honor the job's custom source SSH port (GH #429) so test-connection
+	// and size-probe dial the same port the pull will use, not always 22.
+	migrate.ApplyPort(disc, job.SourcePort)
 	if h.cfg.Settings != nil {
 		if s, sErr := h.cfg.Settings.Get(c.Request.Context()); sErr == nil && s != nil {
 			migrate.ApplyAllowPrivate(disc, s.MigrationAllowPrivateHosts)

--- a/panel-api/internal/migrate/applyport_test.go
+++ b/panel-api/internal/migrate/applyport_test.go
@@ -1,0 +1,32 @@
+package migrate_test
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
+)
+
+// TestApplyPort_SetsPortOnConcreteDiscoverer — the registry hands back a
+// migrate.Discoverer (interface); ApplyPort must reach the concrete Port via
+// the PortSetter capability. GH #429: without this the admin test-connection /
+// size-probe always dialed 22 even for a job with a custom source_port.
+func TestApplyPort_SetsPortOnConcreteDiscoverer(t *testing.T) {
+	d := plesk.New() // default Port 22
+	if d.Port != 22 {
+		t.Fatalf("default port = %d, want 22", d.Port)
+	}
+
+	var disc migrate.Discoverer = d
+	migrate.ApplyPort(disc, 2222)
+	if d.Port != 2222 {
+		t.Errorf("after ApplyPort(2222), port = %d, want 2222", d.Port)
+	}
+
+	// Out-of-range ports are ignored (keeps the last valid value).
+	migrate.ApplyPort(disc, 0)
+	migrate.ApplyPort(disc, 70000)
+	if d.Port != 2222 {
+		t.Errorf("out-of-range ApplyPort changed port to %d, want 2222", d.Port)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/discover.go
+++ b/panel-api/internal/migrate/cpanel/discover.go
@@ -52,6 +52,14 @@ var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
 // time + apply via migrate.ApplyAllowPrivate.
 func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
 
+// SetPort sets the source SSH port (GH #429); ApplyPort calls it via the
+// PortSetter interface. Ports outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
 type session struct {
 	client *ssh.Client
 	// principal records whether the connected user is the cpanel

--- a/panel-api/internal/migrate/directadmin/discover.go
+++ b/panel-api/internal/migrate/directadmin/discover.go
@@ -63,6 +63,14 @@ var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
 // SetAllowPrivate — see cpanel/discover.go for rationale.
 func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
 
+// SetPort sets the source SSH port (GH #429); ApplyPort calls it via the
+// PortSetter interface. Ports outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
 type session struct {
 	client *ssh.Client
 	// connectedUser is the SSH-side principal — must be `admin` (or

--- a/panel-api/internal/migrate/discover.go
+++ b/panel-api/internal/migrate/discover.go
@@ -57,6 +57,26 @@ func ApplyAllowPrivate(d Discoverer, allow bool) {
 	}
 }
 
+// PortSetter is the optional capability for Discoverers that connect over a
+// configurable SSH port (GH #429). Mirrors AllowPrivateSetter so the
+// registry-backed admin call sites can apply job.source_port without a
+// per-kind switch.
+type PortSetter interface {
+	SetPort(int)
+}
+
+// ApplyPort sets the source SSH port on a Discoverer obtained from the
+// registry when it implements PortSetter. No-op otherwise. Ports outside
+// 1..65535 (including 0) are ignored so the Discoverer keeps its default 22.
+func ApplyPort(d Discoverer, port int) {
+	if port < 1 || port > 65535 {
+		return
+	}
+	if s, ok := d.(PortSetter); ok {
+		s.SetPort(port)
+	}
+}
+
 // Session is an opaque per-importer connection handle. Concrete
 // implementations live under internal/migrate/<kind>/.
 type Session interface {

--- a/panel-api/internal/migrate/hestiacp/discover.go
+++ b/panel-api/internal/migrate/hestiacp/discover.go
@@ -55,6 +55,14 @@ var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
 // SetAllowPrivate — see cpanel/discover.go for rationale.
 func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
 
+// SetPort sets the source SSH port (GH #429); ApplyPort calls it via the
+// PortSetter interface. Ports outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
 type session struct {
 	client        *ssh.Client
 	connectedUser string

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -64,6 +64,14 @@ var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
 // SetAllowPrivate honours the server_settings private-host toggle.
 func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
 
+// SetPort sets the source SSH port (GH #429); ApplyPort calls it via the
+// PortSetter interface. Ports outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
 type session struct {
 	client        *ssh.Client
 	connectedUser string

--- a/panel-api/internal/repository/migration_job_repository.go
+++ b/panel-api/internal/repository/migration_job_repository.go
@@ -41,7 +41,7 @@ type MigrationJobRepository interface {
 	// still in state='draft'. ADR-0095 decision 5. Returns ErrNotFound
 	// if the row is missing OR in any non-draft state — callers map
 	// that to 409. Pass nil for any field to skip it.
-	PatchDraft(ctx context.Context, id string, sourceHost, sourceUser, targetUserID, expectedHostKey *string) error
+	PatchDraft(ctx context.Context, id string, sourceHost, sourceUser, targetUserID, expectedHostKey *string, sourcePort *int) error
 	// ListByBatch returns every job sharing a batch_id (ADR-0095
 	// decision 3 — bulk-WHM). Empty result on unknown batch.
 	ListByBatch(ctx context.Context, batchID string) ([]models.MigrationJob, error)
@@ -313,7 +313,7 @@ func (r *migrationJobRepo) UpdateTargetUser(ctx context.Context, id, targetUserI
 }
 
 // PatchDraft updates draft-only mutable fields. Caller passes nil to skip.
-func (r *migrationJobRepo) PatchDraft(ctx context.Context, id string, sourceHost, sourceUser, targetUserID, expectedHostKey *string) error {
+func (r *migrationJobRepo) PatchDraft(ctx context.Context, id string, sourceHost, sourceUser, targetUserID, expectedHostKey *string, sourcePort *int) error {
 	updates := map[string]any{"updated_at": time.Now().UTC()}
 	if sourceHost != nil {
 		updates["source_host"] = *sourceHost
@@ -326,6 +326,9 @@ func (r *migrationJobRepo) PatchDraft(ctx context.Context, id string, sourceHost
 	}
 	if expectedHostKey != nil {
 		updates["expected_host_key"] = *expectedHostKey
+	}
+	if sourcePort != nil {
+		updates["source_port"] = *sourcePort
 	}
 	res := r.db.WithContext(ctx).
 		Model(&models.MigrationJob{}).


### PR DESCRIPTION
lxsdevcode reported the Plesk migrator still dialing `:22` after setting a custom SSH port: `plesk.Connect: tcp dial <ip>:22: i/o timeout`. Two gaps, both fixed:

## 1. The wizard's port never got persisted
The wizard collects the SSH port in the **Connection step**, which PATCHes the draft job. But `patchDraftRequest` and the `PatchDraft` repo method had **no `source_port`** field, so the port was silently dropped — the job kept the draft-create default (22), and `pull-source` read `job.source_port = 22`. Threaded `source_port` through both (clamped via `normalizeSourcePort`).

## 2. Test-connection + size-probe ignored the port
Those build the Discoverer from the registry (the `Discoverer` **interface**, not the concrete type), so they couldn't set `d.Port` and always dialed 22. Added a `PortSetter` capability + `migrate.ApplyPort` (mirrors the existing `AllowPrivateSetter`/`ApplyAllowPrivate`), `SetPort` on all four SSH Discoverers, and `ApplyPort(disc, job.SourcePort)` at both admin connect sites.

Fix #1 alone makes the pull work (pull-source already set `d.Port` on the concrete type); #2 makes the live test-connection + size probe honor the port too.

## Test plan
- [ ] Wizard: set a custom SSH port in the Connection step → job row has that `source_port`; test-connection + pull dial it.
- [ ] Default (no port entered) still uses 22.

Unit test added for `ApplyPort` (interface → concrete port, out-of-range ignored).