### PR TITLE
fix(backups): download failed for remote-destination backups (GH #462)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -271,6 +271,22 @@ func (h *backupHandler) resolveDest(c *gin.Context, destID string) (*models.Back
 	return d, nil
 }
 
+// materializeDestParams resolves the restic repo params for a backup job's
+// download from the job's recorded destination. Returns nil when the job has
+// no destination (a truly-local backup) so the agent keeps its local default.
+// Without this the download always opened the local repo and 404'd remote
+// backups with "no snapshots for job" (GH #462).
+func materializeDestParams(ctx context.Context, dests repository.BackupDestinationRepository, job *models.BackupJob) map[string]any {
+	if dests == nil || job.DestinationID == nil || *job.DestinationID == "" {
+		return nil
+	}
+	d, err := dests.Get(ctx, *job.DestinationID)
+	if err != nil || d == nil {
+		return nil
+	}
+	return destWireParams(d)
+}
+
 // destWireParams projects a destination into the JSON keys the agent
 // backup commands accept. Mirror of backupscheduler.destWireParams;
 // kept duplicated to avoid the api → backupscheduler import cycle.
@@ -623,7 +639,7 @@ func (h *backupHandler) download(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "no_completed_snapshot"})
 		return
 	}
-	streamBackupArtifact(c, h.cfg.Agent, job, h.cfg.logErr)
+	streamBackupArtifact(c, h.cfg.Agent, job, materializeDestParams(c.Request.Context(), h.cfg.Destinations, job), h.cfg.logErr)
 }
 
 // streamBackupArtifact materializes a SUCCEEDED backup job's restic snapshot
@@ -637,7 +653,7 @@ func (h *backupHandler) download(c *gin.Context) {
 // 0600/0700 root:root), so the restic restore is dispatched to the agent, which
 // materializes the snapshot under /var/lib/jabali-backups/downloads/<job_id>/ as
 // root:jabali 0750 for the tar to read without elevated privileges.
-func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.BackupJob, logErr func(string, error, ...any)) {
+func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.BackupJob, destParams map[string]any, logErr func(string, error, ...any)) {
 	if job.Status != models.BackupJobStatusSucceeded {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "no_completed_snapshot"})
 		return
@@ -652,10 +668,19 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 	}
 	matCtx, matCancel := context.WithTimeout(c.Request.Context(), 30*time.Minute)
 	defer matCancel()
-	raw, err := ag.Call(matCtx, "backup.materialize", map[string]string{
+	// The snapshot lives in the job's DESTINATION repo. Forward repo_url +
+	// credentials so the agent opens that repo, not the local default at
+	// /var/lib/jabali-backups/repo (which has no snapshots and 404s with
+	// "no snapshots for job" — GH #462). destParams is nil for a truly-local
+	// backup, in which case the agent keeps its local default.
+	params := map[string]any{
 		"job_id":      job.ID,
 		"snapshot_id": job.SnapshotID,
-	})
+	}
+	for k, v := range destParams {
+		params[k] = v
+	}
+	raw, err := ag.Call(matCtx, "backup.materialize", params)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"status": "error", "error": "restic_restore_failed", "detail": err.Error(),
@@ -938,6 +963,7 @@ func (h *backupHandler) allUserMailboxes(ctx context.Context, userID string) []s
 type MeBackupsHandlerConfig struct {
 	Agent          agent.AgentInterface
 	Jobs           repository.BackupJobRepository
+	Destinations   repository.BackupDestinationRepository
 	Users          repository.UserRepository
 	Databases      repository.DatabaseRepository
 	DatabaseUsers  repository.DatabaseUserRepository
@@ -1462,5 +1488,5 @@ func (h *meBackupHandler) download(c *gin.Context) {
 	// returned job metadata as JSON, so the browser's <a href> download
 	// got a JSON blob, never a file). Same agent-materialize path as the
 	// admin handler, scoped to the caller's own job by the check above.
-	streamBackupArtifact(c, h.cfg.Agent, job, h.cfg.logErr)
+	streamBackupArtifact(c, h.cfg.Agent, job, materializeDestParams(c.Request.Context(), h.cfg.Destinations, job), h.cfg.logErr)
 }

--- a/panel-api/internal/api/backups_materialize_dest_test.go
+++ b/panel-api/internal/api/backups_materialize_dest_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeDestRepo implements just Get; the rest of the interface panics if used.
+type fakeDestRepo struct {
+	repository.BackupDestinationRepository
+	dest *models.BackupDestination
+	err  error
+}
+
+func (f fakeDestRepo) Get(_ context.Context, _ string) (*models.BackupDestination, error) {
+	return f.dest, f.err
+}
+
+// TestMaterializeDestParams — the download must forward the job's DESTINATION
+// repo so the agent opens the right restic repo, not the local default (which
+// 404s "no snapshots for job" — GH #462).
+func TestMaterializeDestParams(t *testing.T) {
+	dest := &models.BackupDestination{ID: "01D", Kind: "sftp", URL: "sftp:user@host:/backups", CredentialsRef: strptr("cred01")}
+
+	t.Run("job with destination resolves repo_url", func(t *testing.T) {
+		repo := fakeDestRepo{dest: dest}
+		job := &models.BackupJob{ID: "01J", DestinationID: strptr("01D")}
+		p := materializeDestParams(context.Background(), repo, job)
+		if p == nil {
+			t.Fatal("expected params, got nil")
+		}
+		if p["repo_url"] != "sftp:user@host:/backups" {
+			t.Errorf("repo_url = %v, want the destination URL", p["repo_url"])
+		}
+		if p["credentials_ref"] != "cred01" {
+			t.Errorf("credentials_ref = %v, want cred01", p["credentials_ref"])
+		}
+	})
+
+	t.Run("job without destination = nil (local default)", func(t *testing.T) {
+		repo := fakeDestRepo{dest: dest}
+		job := &models.BackupJob{ID: "01J"} // DestinationID nil
+		if p := materializeDestParams(context.Background(), repo, job); p != nil {
+			t.Errorf("expected nil for local backup, got %v", p)
+		}
+	})
+
+	t.Run("nil repo = nil", func(t *testing.T) {
+		job := &models.BackupJob{ID: "01J", DestinationID: strptr("01D")}
+		if p := materializeDestParams(context.Background(), nil, job); p != nil {
+			t.Errorf("expected nil when repo unavailable, got %v", p)
+		}
+	})
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -982,6 +982,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			api.RegisterMeBackupRoutes(v1, api.MeBackupsHandlerConfig{
 				Agent:          deps.Agent,
 				Jobs:           deps.BackupJobs,
+				Destinations:   deps.BackupDestinations,
 				Users:          deps.Users,
 				Databases:      deps.Databases,
 				DatabaseUsers:  deps.DatabaseUsers,


### PR DESCRIPTION
lxsdevcode reported a successful backup that couldn't be downloaded from Admin or Tenant: `{"error":"restic_restore_failed","detail":"agent: internal: no snapshots for job <id>"}`.

## Root cause
The backup succeeded and its snapshot is in the **destination repo**, but the download never told the agent which repo to open. `streamBackupArtifact` called `backup.materialize` with only `job_id` + `snapshot_id`, so the agent fell back to the **local default repo** (`/var/lib/jabali-backups/repo`) — which has no snapshots for a backup that went to SFTP/S3/etc → 0 snapshots → the error. The **restore** path already resolved the destination; **download** didn't.

## Fix
- Resolve the job's destination (`destination_id`) and forward `repo_url` + credentials + `extra_options` to `backup.materialize`, same as restore. `materializeDestParams` returns nil for a truly-local backup (no destination) so the agent keeps its local default.
- Added the `Destinations` repo to the **tenant** (`/me`) backup handler config (it was missing), so tenant downloads resolve the repo too.

## Test plan
- [ ] Backup to an SFTP/S3 destination, then Download from Admin and Tenant → streams the tar.zst.
- [ ] Local backup (no destination) still downloads.

Unit test covers `materializeDestParams` (resolves repo_url; nil without a destination).