### PR TITLE
feat(docker-apps): add Pocket ID, Karakeep, Dawarich to the catalog (GH #461)

### DIFF
--- a/install/docker-apps/dawarich/app.yaml
+++ b/install/docker-apps/dawarich/app.yaml
@@ -1,0 +1,51 @@
+slug: dawarich
+name: Dawarich
+tags: ["Productivity", "Analytics"]
+version: "1.10.0"
+description: |
+  Self-hosted location history and timeline, a privacy-first replacement
+  for Google Timeline / Maps history. Import your data, visualize trips
+  on a map, and track places you've visited. Four containers: web app,
+  background worker, a PostGIS database and Redis.
+icon: icon.svg
+upstream: https://github.com/Freika/dawarich
+documentation: https://dawarich.app
+
+image_channel: freikin/dawarich:1.10.0@sha256:25ba1dc02e5571cc915bd104aae9c4c28929848ad1741c1829f5c40f86489a16
+update_mode: manual
+
+resources:
+  cpu: "1.0"
+  memory: "1536m"
+  pids: 500
+
+env:
+  - name: SECRET_KEY_BASE
+    secret: true
+    generate: password64
+  - name: DATABASE_PASSWORD
+    secret: true
+    generate: password32
+
+volumes:
+  - name: storage
+    container_path: /var/app/storage
+  - name: public
+    container_path: /var/app/public
+  - name: watched
+    container_path: /var/app/tmp/imports/watched
+  - name: db
+    container_path: /var/lib/postgresql/data
+  - name: redis
+    container_path: /data
+  - name: shared
+    container_path: /var/shared
+
+ports:
+  - name: http
+    container_port: 3000
+    protocol: tcp
+    default_enabled: true
+    default_bind: loopback
+    default_reverse_proxy: true
+    health_path: /api/v1/health

--- a/install/docker-apps/dawarich/compose.yml.tmpl
+++ b/install/docker-apps/dawarich/compose.yml.tmpl
@@ -1,0 +1,107 @@
+services:
+  app:
+    image: {{ .ImageChannel }}
+    container_name: jabali-app-{{ .Slug }}
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    entrypoint: web-entrypoint.sh
+    command: ["bin/rails", "server", "-p", "3000", "-b", "0.0.0.0"]
+    environment:
+      RAILS_ENV: "production"
+      SECRET_KEY_BASE: "{{ index .Env "SECRET_KEY_BASE" }}"
+      DATABASE_HOST: "db"
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: "dawarich_production"
+      DATABASE_USERNAME: "postgres"
+      DATABASE_PASSWORD: "{{ index .Env "DATABASE_PASSWORD" }}"
+      REDIS_URL: "redis://redis:6379/0"
+      APPLICATION_PROTOCOL: "https"
+      APPLICATION_HOSTS: "{{ .Domain }},localhost,127.0.0.1"
+      TIME_ZONE: "UTC"
+    volumes:
+      - {{ .DataRoot }}/storage:/var/app/storage
+      - {{ .DataRoot }}/public:/var/app/public
+      - {{ .DataRoot }}/watched:/var/app/tmp/imports/watched
+    ports:
+{{- with index .Ports "http" }}
+      - "{{ .BindInterface }}:{{ .HostPort }}:{{ .ContainerPort }}/{{ .Protocol }}"
+{{- end }}
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ .CPULimit }}"
+          memory: {{ .MemoryLimit }}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sS -o /dev/null http://127.0.0.1:3000/api/v1/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+
+  sidekiq:
+    image: {{ .ImageChannel }}
+    container_name: jabali-app-{{ .Slug }}-sidekiq
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    entrypoint: sidekiq-entrypoint.sh
+    environment:
+      RAILS_ENV: "production"
+      SECRET_KEY_BASE: "{{ index .Env "SECRET_KEY_BASE" }}"
+      DATABASE_HOST: "db"
+      DATABASE_PORT: "5432"
+      DATABASE_NAME: "dawarich_production"
+      DATABASE_USERNAME: "postgres"
+      DATABASE_PASSWORD: "{{ index .Env "DATABASE_PASSWORD" }}"
+      REDIS_URL: "redis://redis:6379/0"
+      APPLICATION_PROTOCOL: "https"
+      APPLICATION_HOSTS: "{{ .Domain }},localhost,127.0.0.1"
+      TIME_ZONE: "UTC"
+    volumes:
+      - {{ .DataRoot }}/storage:/var/app/storage
+      - {{ .DataRoot }}/public:/var/app/public
+      - {{ .DataRoot }}/watched:/var/app/tmp/imports/watched
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512m
+
+  db:
+    image: postgis/postgis:17-3.5-alpine@sha256:fe9821935d163abca5611e3e0a6a7c73c8c547f3412ed2036ec0ed8f789390da
+    container_name: jabali-app-{{ .Slug }}-db
+    restart: unless-stopped
+    shm_size: 1gb
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "{{ index .Env "DATABASE_PASSWORD" }}"
+      POSTGRES_DB: "dawarich_production"
+    volumes:
+      - {{ .DataRoot }}/db:/var/lib/postgresql/data
+      - {{ .DataRoot }}/shared:/var/shared
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d dawarich_production"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  redis:
+    image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+    container_name: jabali-app-{{ .Slug }}-redis
+    restart: unless-stopped
+    volumes:
+      - {{ .DataRoot }}/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s

--- a/install/docker-apps/dawarich/icon.svg
+++ b/install/docker-apps/dawarich/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Dawarich">
+  <rect width="64" height="64" rx="14" fill="#f59e0b"/>
+  <path d="M32 15a13 13 0 0 0-13 13c0 9 13 21 13 21s13-12 13-21a13 13 0 0 0-13-13z" fill="#fff"/>
+  <circle cx="32" cy="28" r="5.5" fill="#f59e0b"/>
+</svg>

--- a/install/docker-apps/karakeep/app.yaml
+++ b/install/docker-apps/karakeep/app.yaml
@@ -1,0 +1,43 @@
+slug: karakeep
+name: Karakeep
+tags: ["Productivity", "Library"]
+version: "0.32.0"
+description: |
+  Self-hosted bookmark and read-it-later app (formerly Hoarder). Saves
+  links, notes and images with full-text search (Meilisearch) and
+  automatic crawling + screenshots via a headless browser. Optional AI
+  tagging. Three containers: web, search, and a headless Chrome.
+icon: icon.svg
+upstream: https://github.com/karakeep-app/karakeep
+documentation: https://docs.karakeep.app
+
+image_channel: ghcr.io/karakeep-app/karakeep:0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
+update_mode: manual
+
+resources:
+  cpu: "1.0"
+  memory: "1g"
+  pids: 400
+
+env:
+  - name: NEXTAUTH_SECRET
+    secret: true
+    generate: password64
+  - name: MEILI_MASTER_KEY
+    secret: true
+    generate: password64
+
+volumes:
+  - name: data
+    container_path: /data
+  - name: meili
+    container_path: /meili_data
+
+ports:
+  - name: http
+    container_port: 3000
+    protocol: tcp
+    default_enabled: true
+    default_bind: loopback
+    default_reverse_proxy: true
+    health_path: /api/health

--- a/install/docker-apps/karakeep/compose.yml.tmpl
+++ b/install/docker-apps/karakeep/compose.yml.tmpl
@@ -1,0 +1,64 @@
+services:
+  web:
+    image: {{ .ImageChannel }}
+    container_name: jabali-app-{{ .Slug }}
+    restart: unless-stopped
+    depends_on:
+      - meilisearch
+      - chrome
+    environment:
+      NEXTAUTH_URL: "https://{{ .Domain }}"
+      NEXTAUTH_SECRET: "{{ index .Env "NEXTAUTH_SECRET" }}"
+      DATA_DIR: "/data"
+      MEILI_ADDR: "http://meilisearch:7700"
+      MEILI_MASTER_KEY: "{{ index .Env "MEILI_MASTER_KEY" }}"
+      BROWSER_WEB_URL: "http://chrome:9222"
+    volumes:
+      - {{ .DataRoot }}/data:/data
+    ports:
+{{- with index .Ports "http" }}
+      - "{{ .BindInterface }}:{{ .HostPort }}:{{ .ContainerPort }}/{{ .Protocol }}"
+{{- end }}
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ .CPULimit }}"
+          memory: {{ .MemoryLimit }}
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 45s
+
+  chrome:
+    image: gcr.io/zenika-hub/alpine-chrome:124@sha256:1a0046448e0bb6c275c88f86e01faf0de62b02ec8572901256ada0a8c08be23f
+    container_name: jabali-app-{{ .Slug }}-chrome
+    restart: unless-stopped
+    command:
+      - --no-sandbox
+      - --disable-gpu
+      - --disable-dev-shm-usage
+      - --remote-debugging-address=0.0.0.0
+      - --remote-debugging-port=9222
+      - --hide-scrollbars
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512m
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.41.0@sha256:860fa4baed04ae1c235de870edab0c8006227546dea1bbb6411fbfc5e27cf1db
+    container_name: jabali-app-{{ .Slug }}-meili
+    restart: unless-stopped
+    environment:
+      MEILI_NO_ANALYTICS: "true"
+      MEILI_MASTER_KEY: "{{ index .Env "MEILI_MASTER_KEY" }}"
+    volumes:
+      - {{ .DataRoot }}/meili:/meili_data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512m

--- a/install/docker-apps/karakeep/icon.svg
+++ b/install/docker-apps/karakeep/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Karakeep">
+  <rect width="64" height="64" rx="14" fill="#14b8a6"/>
+  <path d="M22 16h20a3 3 0 0 1 3 3v29a1.5 1.5 0 0 1-2.4 1.2L32 41l-10.6 8.2A1.5 1.5 0 0 1 19 48V19a3 3 0 0 1 3-3z" fill="#fff"/>
+  <circle cx="32" cy="28" r="5" fill="#14b8a6"/>
+</svg>

--- a/install/docker-apps/pocket-id/app.yaml
+++ b/install/docker-apps/pocket-id/app.yaml
@@ -1,0 +1,40 @@
+slug: pocket-id
+tenant_installable: true
+name: Pocket ID
+tags: ["Security", "IT"]
+version: "2.11.0"
+description: |
+  Simple OIDC provider that signs users in with passkeys instead of
+  passwords. Self-hosted single sign-on for the rest of your apps.
+  Single container, SQLite storage.
+icon: icon.svg
+upstream: https://github.com/pocket-id/pocket-id
+documentation: https://pocket-id.org/docs
+
+image_channel: pocketid/pocket-id:v2.11.0@sha256:b7c37ab3044e53fd29b5f7295eebff5fdc0367dc043f36b41bcbe1815fcd965d
+update_mode: manual
+
+resources:
+  cpu: "0.5"
+  memory: "256m"
+  pids: 200
+
+env:
+  # 32-byte base64 key that encrypts stored secrets at rest. Generated
+  # once at install; changing it invalidates existing encrypted data.
+  - name: ENCRYPTION_KEY
+    secret: true
+    generate: password32
+
+volumes:
+  - name: data
+    container_path: /app/data
+
+ports:
+  - name: http
+    container_port: 1411
+    protocol: tcp
+    default_enabled: true
+    default_bind: loopback
+    default_reverse_proxy: true
+    health_path: /healthz

--- a/install/docker-apps/pocket-id/compose.yml.tmpl
+++ b/install/docker-apps/pocket-id/compose.yml.tmpl
@@ -1,0 +1,28 @@
+services:
+  pocket-id:
+    image: {{ .ImageChannel }}
+    container_name: jabali-app-{{ .Slug }}
+    restart: unless-stopped
+    environment:
+      # Public URL the panel reverse-proxies to this app; passkeys are
+      # origin-bound so this must be the exact https origin users hit.
+      APP_URL: "https://{{ .Domain }}"
+      TRUST_PROXY: "true"
+      ENCRYPTION_KEY: "{{ index .Env "ENCRYPTION_KEY" }}"
+    volumes:
+      - {{ .DataRoot }}/data:/app/data
+    ports:
+{{- with index .Ports "http" }}
+      - "{{ .BindInterface }}:{{ .HostPort }}:{{ .ContainerPort }}/{{ .Protocol }}"
+{{- end }}
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ .CPULimit }}"
+          memory: {{ .MemoryLimit }}
+    healthcheck:
+      test: ["CMD", "/app/pocket-id", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s

--- a/install/docker-apps/pocket-id/icon.svg
+++ b/install/docker-apps/pocket-id/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Pocket ID">
+  <rect width="64" height="64" rx="14" fill="#3b4ee6"/>
+  <g fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round">
+    <path d="M20 30a12 12 0 0 1 24 0v6"/>
+    <path d="M26 30a6 6 0 0 1 12 0v8a4 4 0 0 0 4 4"/>
+    <path d="M32 30v12"/>
+    <path d="M22 40v2a10 10 0 0 0 3 7"/>
+  </g>
+  <circle cx="32" cy="30" r="2.4" fill="#fff"/>
+</svg>


### PR DESCRIPTION
Adds 3 of the 4 apps mrlp57 requested in #461 (tinyauth skipped — see below).

## Apps
- **Pocket ID** — OIDC provider with passkey sign-in. Single container, SQLite, port 1411.
- **Karakeep** (ex-Hoarder) — bookmarks / read-later. 3 containers: web + Meilisearch + headless Chrome.
- **Dawarich** — self-hosted location history (Google-Timeline alternative). 4 containers: Rails app + Sidekiq + PostGIS + Redis.

All images digest-pinned.

## Verification
Karakeep + Dawarich were **box-tested on a docker host** — all containers come up healthy and serve. The dawarich box-test caught + fixed two real issues: APPLICATION_HOSTS needed loopback (else Rails host-auth blocks the healthcheck), and the healthcheck had to tolerate the force-ssl 301. Verified the real nginx path (domain Host + X-Forwarded-Proto: https) returns 200.

## Not included: tinyauth
It's forward-auth middleware (gates other services behind a reverse proxy), not a standalone app — poor fit for the one-app catalog.