### PR TITLE
fix(disk): bound journald, npm cache, nspawn images, Stalwart + maldet logs (JAB-153/154/156/157/158)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4574,6 +4574,14 @@ build_frontend() {
     NODE_OPTIONS="--max-old-space-size=2048" \
     bash -c "cd '$REPO_DIR/panel-ui' && nice -n 19 ionice -c 3 npm run build"
   _ok "panel-ui built → $REPO_DIR/panel-ui/dist/"
+
+  # JAB-156: cap the npm cache. `npm ci` leaves every downloaded tarball in
+  # $HOME/.npm/_cacache (HOME=$REPO_DIR here → /opt/jabali-panel/.npm), which
+  # grows unbounded across updates as deps churn (630 MB on a 16-day host).
+  # The build is already done, so purge it — the next update's npm ci
+  # re-populates only what that build needs. Best-effort; never fail the build.
+  sudo -u "$SERVICE_USER" -H env HOME="$REPO_DIR" PATH="/usr/bin:/bin" \
+    bash -c "npm cache clean --force" >/dev/null 2>&1 || true
 }
 
 build_backend() {
@@ -7100,6 +7108,58 @@ install_sso_reaper_timer() {
   systemctl enable --now jabali-sso-reaper.timer
 
   _ok "sso reaper timer enabled (every 30s)"
+}
+
+# ---------- JAB-158: journald size cap ------------------------------------
+#
+# install_journald_cap drops a bounded SystemMaxUse/retention config so the
+# persistent journal can never balloon to ~10% of the root filesystem (the
+# systemd default) and fill a small VM's disk. Idempotent file copy; a
+# restart of systemd-journald applies it live.
+install_journald_cap() {
+  _log "installing journald size cap"
+  local src="${REPO_DIR}/install/systemd/journald-jabali.conf"
+  local dst="/etc/systemd/journald.conf.d/jabali.conf"
+  if [[ ! -f "$src" ]]; then
+    _warn "journald cap template missing at $src — skipping"
+    return 0
+  fi
+  install -d -m 0755 /etc/systemd/journald.conf.d
+  install -m 0644 -o root -g root "$src" "$dst"
+  # Apply live; a failed restart must not abort the install (journald is
+  # socket-activated and comes back on next log write regardless).
+  systemctl restart systemd-journald 2>/dev/null || true
+  _ok "journald capped (SystemMaxUse=400M, 1 month retention)"
+}
+
+# ---------- JAB-153 + JAB-157: daily disk maintenance ---------------------
+#
+# install_disk_maintenance_timer wires a daily oneshot that prunes Stalwart's
+# dated tracer logs and stale nspawn sandbox images (see install/systemd/
+# disk-maintenance for the sweep). Same install shape as install_sso_reaper_timer.
+install_disk_maintenance_timer() {
+  local script_src="${REPO_DIR}/install/systemd/disk-maintenance"
+  local svc_src="${REPO_DIR}/install/systemd/jabali-disk-maintenance.service"
+  local timer_src="${REPO_DIR}/install/systemd/jabali-disk-maintenance.timer"
+  local svc_dst="/etc/systemd/system/jabali-disk-maintenance.service"
+  local timer_dst="/etc/systemd/system/jabali-disk-maintenance.timer"
+
+  if [[ ! -f "$script_src" || ! -f "$svc_src" || ! -f "$timer_src" ]]; then
+    _err "disk-maintenance units missing at $script_src / $svc_src / $timer_src"
+    exit 1
+  fi
+
+  install -d -m 0755 /usr/local/libexec/jabali
+  install -m 0755 -o root -g root "$script_src" /usr/local/libexec/jabali/disk-maintenance
+  install -m 0644 -o root -g root "$svc_src" "$svc_dst"
+  install -m 0644 -o root -g root "$timer_src" "$timer_dst"
+
+  _log "disk maintenance: systemctl daemon-reload"
+  systemctl daemon-reload
+  _log "disk maintenance: enable --now jabali-disk-maintenance.timer"
+  systemctl enable --now jabali-disk-maintenance.timer
+
+  _ok "disk maintenance timer enabled (daily)"
 }
 
 # ---------- M35 migration-secrets reaper (ADR-0094) ----------------------
@@ -13268,6 +13328,8 @@ main() {
   install_sso_reaper_timer
   install_cache_doctor_timer
   install_migration_secrets_reaper
+  install_journald_cap
+  install_disk_maintenance_timer
   install_ssh_sandbox_prereqs
   install_backup_foundation
   # Order matters: install_phpmyadmin extracts the tarball to

--- a/install/logrotate/jabali
+++ b/install/logrotate/jabali
@@ -80,7 +80,12 @@
     endscript
 }
 
-/var/log/maldet/*.log {
+# inotify_log has no .log suffix so the *.log glob misses it (JAB-154); the
+# maldet real-time monitor (M33) appends to it while running, so name it
+# explicitly here — copytruncate keeps the monitor's open fd writing across
+# the rotation.
+/var/log/maldet/*.log
+/var/log/maldet/inotify_log {
     daily
     rotate 30
     compress

--- a/install/systemd/disk-maintenance
+++ b/install/systemd/disk-maintenance
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Jabali disk maintenance — daily sweep that keeps unbounded-by-design dirs
+# in check. Runs from jabali-disk-maintenance.service (oneshot, daily timer).
+#
+# Deliberately NOT `set -e`: each prune is independent, and one failing
+# (e.g. nspawn never provisioned) must not skip the rest. Everything here is
+# idempotent and a no-op when its target dir is absent, so it is safe to run
+# on every host regardless of which modules are installed.
+set -uo pipefail
+
+# ---- JAB-153: Stalwart dated tracer logs -------------------------------
+# Stalwart writes a fresh /var/log/stalwart/stalwart.log.<DATE> (and
+# delivery.<DATE>) every day and never prunes them. logrotate can't glob a
+# name that is already date-suffixed, so age-prune with find. 14 days keeps
+# a fortnight for incident response, matching the logrotate `rotate 14`
+# convention used elsewhere. (delivery.<DATE> is JAB-99's file set — pruning
+# it here bounds it too.)
+if [ -d /var/log/stalwart ]; then
+  find /var/log/stalwart -maxdepth 1 -type f \
+    \( -name 'stalwart.log.*' -o -name 'delivery.*' \) \
+    -mtime +14 -delete 2>/dev/null || true
+fi
+
+# ---- JAB-157: sealed nspawn SSH-sandbox images -------------------------
+# `jabali nspawn prune --yes` removes only sealed images that no user is
+# pinned to and that are not the current default — safe to run unattended.
+# No-op when nspawn mode was never provisioned (images dir absent).
+if command -v jabali >/dev/null 2>&1 && [ -d /var/lib/jabali-nspawn/images ]; then
+  jabali nspawn prune --yes >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/install/systemd/jabali-disk-maintenance.service
+++ b/install/systemd/jabali-disk-maintenance.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Jabali disk maintenance (prune dated Stalwart logs + stale nspawn images)
+Documentation=https://github.com/shukiv/jabali-panel/blob/main/install/systemd/disk-maintenance
+# No hard Requires=: the sweep is best-effort and each step no-ops when its
+# target is absent, so it must never fail the boot or wedge on a missing unit.
+After=jabali-agent.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/jabali/disk-maintenance
+StandardOutput=journal
+StandardError=journal
+# The script tolerates its own sub-failures (set -uo pipefail, no -e); a
+# non-zero exit here would only mean the script itself could not start.
+Restart=no

--- a/install/systemd/jabali-disk-maintenance.timer
+++ b/install/systemd/jabali-disk-maintenance.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Run jabali-disk-maintenance.service daily
+Documentation=https://github.com/shukiv/jabali-panel/blob/main/install/systemd/disk-maintenance
+
+[Timer]
+# Daily, a few minutes after midnight, with jitter so a fleet doesn't all
+# sweep at once. Persistent=true fires a missed run after the host wakes.
+OnCalendar=*-*-* 00:07:00
+RandomizedDelaySec=15m
+Persistent=true
+Unit=jabali-disk-maintenance.service
+
+[Install]
+WantedBy=timers.target

--- a/install/systemd/journald-jabali.conf
+++ b/install/systemd/journald-jabali.conf
@@ -1,0 +1,14 @@
+# Jabali — journald size cap (JAB-158).
+#
+# Installed to /etc/systemd/journald.conf.d/jabali.conf. Without this,
+# SystemMaxUse is unset and journald self-limits at ~10% of the filesystem
+# — ~2.4GB on a 24GB VM, which is a lot of pressure on a small box already
+# tight on disk. Cap the persistent journal at a bounded size and age so it
+# can never be the thing that fills the root filesystem.
+#
+# Re-installed unchanged on every update; journald picks it up on the next
+# `systemctl restart systemd-journald` (install.sh reloads it).
+[Journal]
+SystemMaxUse=400M
+SystemKeepFree=1G
+MaxRetentionSec=1month

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -592,6 +592,14 @@ install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.service /etc/s
 install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.timer /etc/systemd/system/jabali-sso-reaper.timer
 install -m 0644 ` + repoDir + `/install/systemd/jabali-notify@.service /etc/systemd/system/jabali-notify@.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-stalwart.service /etc/systemd/system/jabali-stalwart.service
+# JAB-158 journald cap + JAB-153/157 disk-maintenance timer. install.sh drops
+# these on first install (install_journald_cap + install_disk_maintenance_timer);
+# the update path MUST re-copy them or existing hosts never get the caps.
+install -d -m 0755 /etc/systemd/journald.conf.d
+install -m 0644 ` + repoDir + `/install/systemd/journald-jabali.conf /etc/systemd/journald.conf.d/jabali.conf
+install -m 0755 ` + repoDir + `/install/systemd/disk-maintenance /usr/local/libexec/jabali/disk-maintenance
+install -m 0644 ` + repoDir + `/install/systemd/jabali-disk-maintenance.service /etc/systemd/system/jabali-disk-maintenance.service
+install -m 0644 ` + repoDir + `/install/systemd/jabali-disk-maintenance.timer /etc/systemd/system/jabali-disk-maintenance.timer
 # certbot panel-cert deploy-hook. install.sh drops this on first
 # install; the update path MUST re-copy it or hook changes never
 # reach existing hosts. This gap shipped a stale pre-ADR-0105 hook
@@ -618,6 +626,8 @@ sha_before_k=$(sha256sum /etc/systemd/system/jabali-kratos.service 2>/dev/null |
 install -m 0644 ` + repoDir + `/install/systemd/jabali-kratos.service /etc/systemd/system/jabali-kratos.service
 systemctl daemon-reload
 systemctl enable --now jabali-sso-reaper.timer
+systemctl enable --now jabali-disk-maintenance.timer
+systemctl restart systemd-journald 2>/dev/null || true
 sha_after_k=$(sha256sum /etc/systemd/system/jabali-kratos.service 2>/dev/null | awk '{print $1}' || echo "")
 if [ "$sha_before_k" != "$sha_after_k" ]; then
   echo "  (jabali-kratos.service changed — restarting)"
@@ -1090,6 +1100,21 @@ test -x node_modules/.bin/tsc || {
 				return nil
 			}
 			return buildErr
+		}},
+		{"prune npm cache", func() error {
+			// JAB-156: npm ci leaves every downloaded tarball in the
+			// service user's ~/.npm/_cacache (/opt/jabali-panel/.npm),
+			// which grows unbounded across updates as deps churn. The
+			// build is already done, so purge it — the next update's
+			// npm ci re-populates only what it needs. Best-effort: a
+			// clean failure must never fail the update.
+			if installedFromRelease {
+				return nil
+			}
+			if err := asUser(repoDir+"/panel-ui", "bash", "-c", "npm cache clean --force >/dev/null 2>&1 || true"); err != nil {
+				fmt.Printf("  (npm cache clean skipped: %v)\n", err)
+			}
+			return nil
 		}},
 		{"build panel-api + panel-agent (parallel)", func() error {
 			if installedFromRelease {


### PR DESCRIPTION
Five unbounded disk-growth leaks flagged on a test host that hit **95% full (1.2 GB free of 24 GB)**.

| Issue | Leak | Fix |
|---|---|---|
| JAB-158 | journald uncapped (~10% of disk default, 795 MB live) | ship `/etc/systemd/journald.conf.d/jabali.conf` — `SystemMaxUse=400M`, `SystemKeepFree=1G`, 1-month retention |
| JAB-156 | `.npm/_cacache` grows every update (630 MB) | `npm cache clean --force` after the panel-ui build, in install.sh **and** the update build path |
| JAB-154 | maldet `inotify_log` never rotated (`*.log` glob misses it) | name it explicitly in the logrotate drop-in (verified `logrotate -d`) |
| JAB-153 | Stalwart `stalwart.log.<DATE>` / `delivery.<DATE>` never pruned | age-prune >14d via `find` (logrotate can't glob date-suffixed names) |
| JAB-157 | sealed nspawn images never pruned (434 MB) | `jabali nspawn prune --yes` (only unpinned, non-default) on a schedule |

JAB-153 + JAB-157 run from a new daily `jabali-disk-maintenance.timer` → oneshot (`install/systemd/disk-maintenance`). All units + the journald cap install via `install.sh` (`install_journald_cap`, `install_disk_maintenance_timer`) **and** re-install on the `jabali update` path, so existing hosts pick them up. Everything is idempotent and no-ops when its target dir is absent.

Not included: **JAB-155** (urgent orphaned migration staging) — that's Go migrate-package work, separate PR.

Verified: `bash -n`, `go build`/`go vet`, `logrotate -d` (inotify_log now a rotation target, no duplicate-entry warnings), `systemd-analyze verify` on the units, `systemd-analyze calendar` on the timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)