### PR TITLE
fix(migration): reap orphaned staging dirs with no job row (JAB-155)

### DIFF
--- a/panel-api/cmd/server/migrate_reap_cmd.go
+++ b/panel-api/cmd/server/migrate_reap_cmd.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -60,6 +61,10 @@ daily cadence; operator can also invoke directly.`,
 			page := 1
 			deleted := 0
 			scanned := 0
+			// JAB-155: track every job ID that still has a row so the orphan
+			// sweep below can tell a stranded (row-deleted) staging dir from
+			// a live one.
+			live := map[string]struct{}{}
 			for {
 				rows, total, err := repo.List(ctx, page, pageSize)
 				if err != nil {
@@ -67,6 +72,7 @@ daily cadence; operator can also invoke directly.`,
 				}
 				for _, row := range rows {
 					scanned++
+					live[row.ID] = struct{}{}
 					if !isTerminal(row.State) {
 						continue
 					}
@@ -112,6 +118,15 @@ daily cadence; operator can also invoke directly.`,
 				}
 				page++
 			}
+
+			// JAB-155: orphan sweep. The row-driven pass above only reaps
+			// staging for jobs that still have a migration_jobs row. When a
+			// row is hard-deleted (admin removed the job, or a wizard draft
+			// was cleaned), its /var/lib/jabali-migrations/<id>/ tree is left
+			// stranded and invisible to that pass — on a test host this
+			// stranded ~6GB across 5 dirs and pushed / to 95% full.
+			deleted += reapOrphanStaging(migrationStagingDir, live, stagingMaxAge, dryRun, cmd.OutOrStdout(), cmd.ErrOrStderr())
+
 			fmt.Fprintf(cmd.OutOrStdout(), "scanned=%d deleted=%d (dry-run=%v)\n", scanned, deleted, dryRun)
 			// ADR-0095 decision 5 — also reap draft migration_jobs
 			// older than 24h. Drafts are created by the wizard at Step
@@ -136,6 +151,51 @@ daily cadence; operator can also invoke directly.`,
 	cmd.Flags().DurationVar(&stagingMaxAge, "staging-max-age", migrationStagingMaxAge,
 		"Reap /var/lib/jabali-migrations/<id>/ only when the job has been terminal at least this long (default 168h = 7d; pass 0 to wipe immediately)")
 	return cmd
+}
+
+// reapOrphanStaging removes per-job staging dirs under stagingDir whose ID has
+// no entry in live (the set of job IDs that still have a migration_jobs row)
+// and whose mtime is older than maxAge. The mtime guard protects an in-flight
+// extraction whose job row is not committed yet. Returns the number of dirs
+// removed (or, under dryRun, that would be removed). Missing stagingDir is not
+// an error. Split out from the command for direct testing. (JAB-155)
+func reapOrphanStaging(stagingDir string, live map[string]struct{}, maxAge time.Duration, dryRun bool, out, errw io.Writer) int {
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(errw, "readdir %s: %v\n", stagingDir, err)
+		}
+		return 0
+	}
+	deleted := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := live[e.Name()]; ok {
+			continue // job row still exists — handled by the row-driven pass
+		}
+		p := filepath.Join(stagingDir, e.Name())
+		info, iErr := e.Info()
+		if iErr != nil {
+			continue
+		}
+		age := time.Since(info.ModTime())
+		if age < maxAge {
+			continue
+		}
+		if dryRun {
+			fmt.Fprintf(out, "[dry-run] would rm -rf %s (orphan: no job row, age=%s)\n", p, age.Truncate(time.Hour))
+			deleted++
+			continue
+		}
+		if rmErr := os.RemoveAll(p); rmErr != nil {
+			fmt.Fprintf(errw, "rm -rf %s: %v\n", p, rmErr)
+			continue
+		}
+		deleted++
+	}
+	return deleted
 }
 
 func isTerminal(state string) bool {

--- a/panel-api/cmd/server/migrate_reap_orphan_test.go
+++ b/panel-api/cmd/server/migrate_reap_orphan_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// JAB-155: orphan staging sweep. A staging dir whose migration_jobs row was
+// hard-deleted must be reclaimed, but a live job's dir and a too-young dir
+// must be left alone.
+func TestReapOrphanStaging(t *testing.T) {
+	root := t.TempDir()
+	old := time.Now().Add(-30 * 24 * time.Hour) // well past maxAge
+	fresh := time.Now()                          // just created
+
+	// mk makes a staging dir with a file inside and sets its mtime.
+	mk := func(name string, mtime time.Time) string {
+		p := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Join(p, "extracted"), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, "user.tar.gz"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	orphanOld := mk("01ORPHANOLD0000000000000000", old)   // row-less + old  -> reap
+	orphanYoung := mk("01ORPHANYOUNG00000000000000", fresh) // row-less + young -> keep (in-flight guard)
+	liveOld := mk("01LIVEJOB000000000000000000", old)      // has a row + old  -> keep (row pass owns it)
+
+	live := map[string]struct{}{"01LIVEJOB000000000000000000": {}}
+
+	// Also drop a stray file (not a dir) to prove it is ignored.
+	if err := os.WriteFile(filepath.Join(root, "stray.txt"), []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	n := reapOrphanStaging(root, live, 7*24*time.Hour, false, io.Discard, io.Discard)
+	if n != 1 {
+		t.Fatalf("expected 1 dir reaped, got %d", n)
+	}
+	if _, err := os.Stat(orphanOld); !os.IsNotExist(err) {
+		t.Errorf("old orphan should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(orphanYoung); err != nil {
+		t.Errorf("young orphan must be kept: %v", err)
+	}
+	if _, err := os.Stat(liveOld); err != nil {
+		t.Errorf("live job dir must be kept: %v", err)
+	}
+}
+
+// Dry-run counts but never removes.
+func TestReapOrphanStaging_DryRun(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "01ORPHAN00000000000000000000")
+	if err := os.MkdirAll(p, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(p, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	n := reapOrphanStaging(root, nil, 7*24*time.Hour, true, io.Discard, io.Discard)
+	if n != 1 {
+		t.Fatalf("dry-run should report 1, got %d", n)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Errorf("dry-run must not remove the dir: %v", err)
+	}
+}
+
+// A missing staging root is a no-op, not an error.
+func TestReapOrphanStaging_MissingRoot(t *testing.T) {
+	if n := reapOrphanStaging(filepath.Join(t.TempDir(), "does-not-exist"), nil, time.Hour, false, io.Discard, io.Discard); n != 0 {
+		t.Fatalf("missing root should reap 0, got %d", n)
+	}
+}


### PR DESCRIPTION
**Urgent** — unbounded disk growth. On a test host, orphaned migration staging stranded ~6 GB across 5 dirs and pushed `/` to **95% full (1.2 GB free of 24 GB)**.

## Root cause
The reaper (`jabali migrate reap-secrets`) is **row-driven**: it walks `migration_jobs` and removes each terminal job's `/var/lib/jabali-migrations/<id>/` tree. When a job row is hard-deleted (admin removed the job, or a wizard draft was cleaned), the staging tree is left stranded and **invisible** to that pass — distinct from JAB-49 (reaper skipped degraded jobs); here the row is gone entirely.

## Fix
Add an **orphan sweep** to the same command: collect every job ID that still has a row, then remove any `<id>` dir under the staging root not in that set whose mtime is older than `--staging-max-age` (default 7d). The mtime guard protects an in-flight extraction whose row isn't committed yet. Runs on the existing daily `jabali-migration-secrets-reap.timer`; honors `--dry-run`. Split into `reapOrphanStaging()` for direct testing.

## Not changed
Immediate delete-at-import-end. The 7-day staging window for row-having terminal jobs is a **deliberate forensics affordance** (re-attempt / cpmove download, documented in the reaper). The orphan sweep + that existing reap together bound the staging root across create+delete cycles — the acceptance criterion.

## Tests
`TestReapOrphanStaging` (old orphan reaped; young orphan + live-job dir kept; stray file ignored), `_DryRun` (counts, never removes), `_MissingRoot` (no-op). `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)