### PR TITLE
feat(retention): daily sweep for unbounded log/report tables (JAB-100/101/103/122/123/125)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4404,6 +4404,18 @@ jabali repair [flags]
 - `--uploads-dir` — Fix only: /var/lib/jabali-uploads missing or wrong perms
 - `--yes` — Skip interactive confirmation for destructive repairs
 
+### `jabali retention-sweep`
+
+Prune expired rows from unbounded log/report tables
+
+```
+jabali retention-sweep [flags]
+```
+
+**Flags:**
+
+- `--dry-run` — count would-delete rows without removing them
+
 ### `jabali serve`
 
 Start the Jabali Panel HTTP(S) server

--- a/install.sh
+++ b/install.sh
@@ -7162,6 +7162,33 @@ install_disk_maintenance_timer() {
   _ok "disk maintenance timer enabled (daily)"
 }
 
+# ---------- retention sweep (JAB-100/101/103/122/123/125) ------------------
+#
+# install_retention_sweep_timer wires the daily oneshot that prunes expired
+# rows from the log/report tables that had no retention. Same install shape
+# as install_sso_reaper_timer.
+install_retention_sweep_timer() {
+  local svc_src="${REPO_DIR}/install/systemd/jabali-retention-sweep.service"
+  local timer_src="${REPO_DIR}/install/systemd/jabali-retention-sweep.timer"
+  local svc_dst="/etc/systemd/system/jabali-retention-sweep.service"
+  local timer_dst="/etc/systemd/system/jabali-retention-sweep.timer"
+
+  if [[ ! -f "$svc_src" || ! -f "$timer_src" ]]; then
+    _err "retention-sweep units missing at $svc_src / $timer_src"
+    exit 1
+  fi
+
+  install -m 0644 -o root -g root "$svc_src" "$svc_dst"
+  install -m 0644 -o root -g root "$timer_src" "$timer_dst"
+
+  _log "retention sweep: systemctl daemon-reload"
+  systemctl daemon-reload
+  _log "retention sweep: enable --now jabali-retention-sweep.timer"
+  systemctl enable --now jabali-retention-sweep.timer
+
+  _ok "retention sweep timer enabled (daily)"
+}
+
 # ---------- M35 migration-secrets reaper (ADR-0094) ----------------------
 #
 # install_migration_secrets_reaper writes the daily timer + service
@@ -13330,6 +13357,7 @@ main() {
   install_migration_secrets_reaper
   install_journald_cap
   install_disk_maintenance_timer
+  install_retention_sweep_timer
   install_ssh_sandbox_prereqs
   install_backup_foundation
   # Order matters: install_phpmyadmin extracts the tarball to

--- a/install/systemd/jabali-retention-sweep.service
+++ b/install/systemd/jabali-retention-sweep.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Jabali retention sweep (prune expired log/report table rows)
+Documentation=https://github.com/shukiv/jabali-panel/blob/main/panel-api/cmd/server/retention_sweep_cmd.go
+After=jabali-panel.service
+# No Requires=: the sweep talks to the panel DB directly; a transient failure
+# during boot/restart is tolerated (next daily firing retries).
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/jabali retention-sweep
+StandardOutput=journal
+StandardError=journal
+Restart=no

--- a/install/systemd/jabali-retention-sweep.timer
+++ b/install/systemd/jabali-retention-sweep.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run jabali-retention-sweep.service daily
+Documentation=https://github.com/shukiv/jabali-panel/blob/main/panel-api/cmd/server/retention_sweep_cmd.go
+
+[Timer]
+# Daily at 03:40 + jitter, offset from the other jabali timers (sso-reap 30s,
+# migration-secrets-reap 04:30, disk-maintenance 00:07) so they don't all fire
+# at once. Persistent fires a missed run after the host wakes.
+OnCalendar=*-*-* 03:40:00
+RandomizedDelaySec=20m
+Persistent=true
+Unit=jabali-retention-sweep.service
+
+[Install]
+WantedBy=timers.target

--- a/panel-api/cmd/server/retention_sweep_cmd.go
+++ b/panel-api/cmd/server/retention_sweep_cmd.go
@@ -1,0 +1,129 @@
+// `jabali retention-sweep` — one daily pass that prunes expired rows from the
+// unbounded log / report tables that had no retention (JAB-100, 101, 103, 122,
+// 123, 125, and the legacy db_admin_audit half of 105). Run by
+// jabali-retention-sweep.timer; idempotent; honors --dry-run.
+//
+// DELIBERATELY EXCLUDED — these need their own design, not a blind DELETE:
+//   - audit_events: a hash-chained tamper-evident log (prev_hash/row_hash).
+//     Deleting old rows dangles the chain; retention there must archive or
+//     re-anchor the chain, so it is out of scope here (the core of JAB-105).
+//   - bw_daily: bandwidth billing ledger — JAB-124 wants a rollup decision
+//     (aggregate to monthly) rather than a delete, so it is left for that.
+//   - migration_jobs / migration_stages: owned by `migrate reap-secrets`
+//     (JAB-102) which already reaps terminal jobs + their staging.
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gorm.io/gorm"
+)
+
+const retentionDay = 24 * time.Hour
+
+// retentionTarget is one leaf table pruned by the sweep. Rows whose tsColumn is
+// older than now-window are deleted in batches. table + tsColumn are compile-
+// time constants from this file only — never user input — so they are safe to
+// interpolate into the DELETE.
+type retentionTarget struct {
+	table    string
+	tsColumn string
+	window   time.Duration
+	why      string
+}
+
+// retentionTargets — every entry is a leaf log/report table with no hash chain
+// and no active-state rows, so an age-based DELETE is safe. Security-sensitive
+// tables (malware, WAF incidents, db-admin audit) get a generous 1-year window
+// so forensics survive while disk stays bounded.
+var retentionTargets = []retentionTarget{
+	{"log_access_streams", "expires_at", 1 * retentionDay, "expired log-view stream keys (JAB-103)"},
+	{"terminal_sessions", "created_at", 90 * retentionDay, "root-terminal session rows; .cast files rotate via logrotate (JAB-103)"},
+	{"notification_history", "created_at", 90 * retentionDay, "delivered-notification log (JAB-100)"},
+	{"update_history", "started_at", 180 * retentionDay, "update-center run history + stored log excerpts (JAB-101)"},
+	{"dmarc_aggregate", "created_at", 180 * retentionDay, "DMARC aggregate reports (JAB-125)"},
+	{"tlsrpt_aggregate", "created_at", 180 * retentionDay, "TLS-RPT aggregate reports (JAB-125)"},
+	{"arf_report", "received_at", 180 * retentionDay, "ARF failure reports (JAB-125)"},
+	{"malware_events", "created_at", 365 * retentionDay, "malware raw event log — security, 1y window (JAB-123)"},
+	{"snuffleupagus_incidents", "ts", 365 * retentionDay, "Snuffleupagus WAF incidents — security, 1y window (JAB-122)"},
+	{"db_admin_audit", "ts", 365 * retentionDay, "legacy DB-admin audit — 1y window (JAB-105; hash-chained audit_events excluded)"},
+}
+
+// retentionBatchSize bounds each DELETE so a large backlog can't hold a long
+// row lock on the table. The loop repeats until a batch clears fewer rows.
+const retentionBatchSize = 5000
+
+// pruneRetentionTarget deletes (or, under dryRun, counts) rows in t older than
+// now-window. Returns the number removed / would-remove.
+func pruneRetentionTarget(ctx context.Context, db *gorm.DB, t retentionTarget, dryRun bool, out io.Writer) (int64, error) {
+	cutoff := time.Now().Add(-t.window)
+	if dryRun {
+		var n int64
+		if err := db.WithContext(ctx).Table(t.table).Where(t.tsColumn+" < ?", cutoff).Count(&n).Error; err != nil {
+			return 0, err
+		}
+		if n > 0 {
+			fmt.Fprintf(out, "[dry-run] %s: %d rows older than %s — %s\n", t.table, n, cutoff.Format(time.RFC3339), t.why)
+		}
+		return n, nil
+	}
+	var total int64
+	for {
+		res := db.WithContext(ctx).Exec(
+			"DELETE FROM "+t.table+" WHERE "+t.tsColumn+" < ? LIMIT ?", cutoff, retentionBatchSize)
+		if res.Error != nil {
+			return total, res.Error
+		}
+		total += res.RowsAffected
+		if res.RowsAffected < retentionBatchSize {
+			break
+		}
+	}
+	if total > 0 {
+		fmt.Fprintf(out, "%s: pruned %d rows older than %s\n", t.table, total, cutoff.Format(time.RFC3339))
+	}
+	return total, nil
+}
+
+func newRetentionSweepCmd() *cobra.Command {
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "retention-sweep",
+		Short: "Prune expired rows from unbounded log/report tables",
+		Long: `Deletes aged rows from the log/report tables that previously had
+no retention (notification_history, update_history, dmarc/tlsrpt/arf reports,
+malware_events, snuffleupagus_incidents, db_admin_audit, log_access_streams,
+terminal_sessions). Each table has its own window; security tables keep a
+1-year window. Batched DELETEs (5000/loop) so a big backlog can't long-lock a
+table. Idempotent; run by jabali-retention-sweep.timer daily. --dry-run counts
+without deleting.
+
+Not touched here: audit_events (hash-chained — needs archive/re-anchor, not a
+blind delete), bw_daily (billing rollup decision), migration_jobs/stages
+(owned by 'migrate reap-secrets').`,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Minute)
+			defer cancel()
+			var grand int64
+			for _, t := range retentionTargets {
+				n, err := pruneRetentionTarget(ctx, sharedDB, t, dryRun, cmd.OutOrStdout())
+				if err != nil {
+					// One table failing (e.g. absent on an older schema) must
+					// not skip the rest — log and continue.
+					fmt.Fprintf(cmd.ErrOrStderr(), "%s: prune failed: %v\n", t.table, err)
+					continue
+				}
+				grand += n
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "retention-sweep: %d rows (dry-run=%v)\n", grand, dryRun)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "count would-delete rows without removing them")
+	return cmd
+}

--- a/panel-api/cmd/server/retention_sweep_test.go
+++ b/panel-api/cmd/server/retention_sweep_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// The retention sweep interpolates table + tsColumn straight into a DELETE, so
+// every target must be a well-formed, non-empty identifier with a sane window.
+func TestRetentionTargets_WellFormed(t *testing.T) {
+	if len(retentionTargets) == 0 {
+		t.Fatal("no retention targets defined")
+	}
+	identRe := func(s string) bool {
+		if s == "" {
+			return false
+		}
+		for _, r := range s {
+			if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+				return false
+			}
+		}
+		return true
+	}
+	seen := map[string]bool{}
+	for _, tgt := range retentionTargets {
+		if !identRe(tgt.table) {
+			t.Errorf("table %q is not a bare identifier (SQL-injection guard)", tgt.table)
+		}
+		if !identRe(tgt.tsColumn) {
+			t.Errorf("%s: tsColumn %q is not a bare identifier", tgt.table, tgt.tsColumn)
+		}
+		if tgt.window <= 0 {
+			t.Errorf("%s: window must be positive, got %s", tgt.table, tgt.window)
+		}
+		if tgt.window < 24*time.Hour {
+			t.Errorf("%s: window %s is under a day — too aggressive, likely a mistake", tgt.table, tgt.window)
+		}
+		if seen[tgt.table] {
+			t.Errorf("%s: duplicate target", tgt.table)
+		}
+		seen[tgt.table] = true
+	}
+	if retentionBatchSize <= 0 {
+		t.Errorf("retentionBatchSize must be positive, got %d", retentionBatchSize)
+	}
+}
+
+// audit_events is a hash-chained tamper-evident log; a blind DELETE would dangle
+// the chain. It must never be swept here — guard the exclusion so a future edit
+// can't add it back without tripping this test.
+func TestRetentionTargets_ExcludesHashChainedAudit(t *testing.T) {
+	for _, tgt := range retentionTargets {
+		if tgt.table == "audit_events" {
+			t.Fatal("audit_events (hash-chained) must NOT be in the retention sweep — see JAB-105")
+		}
+	}
+}
+
+// Security-forensics tables get a generous window so incidents survive.
+func TestRetentionTargets_SecurityTablesKeptLong(t *testing.T) {
+	minSecurity := 365 * retentionDay
+	security := map[string]bool{"malware_events": true, "snuffleupagus_incidents": true, "db_admin_audit": true}
+	for _, tgt := range retentionTargets {
+		if security[tgt.table] && tgt.window < minSecurity {
+			t.Errorf("%s is security-sensitive; window %s is under the 1y forensics floor", tgt.table, tgt.window)
+		}
+	}
+}

--- a/panel-api/cmd/server/root.go
+++ b/panel-api/cmd/server/root.go
@@ -121,6 +121,7 @@ func newRootCmd() *cobra.Command {
 		newSSOCmd(),
 		newSSOReapCmd(),
 		newMalwarePurgeCmd(),
+		newRetentionSweepCmd(),
 		newBackupCmd(),
 		newRepairCmd(),
 		newDockerCmd(),

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -590,6 +590,8 @@ install -m 0644 ` + repoDir + `/install/systemd/jabali-user.slice /etc/systemd/s
 install -m 0644 ` + repoDir + `/install/systemd/jabali-fpm@.service /etc/systemd/system/jabali-fpm@.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.service /etc/systemd/system/jabali-sso-reaper.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.timer /etc/systemd/system/jabali-sso-reaper.timer
+install -m 0644 ` + repoDir + `/install/systemd/jabali-retention-sweep.service /etc/systemd/system/jabali-retention-sweep.service
+install -m 0644 ` + repoDir + `/install/systemd/jabali-retention-sweep.timer /etc/systemd/system/jabali-retention-sweep.timer
 install -m 0644 ` + repoDir + `/install/systemd/jabali-notify@.service /etc/systemd/system/jabali-notify@.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-stalwart.service /etc/systemd/system/jabali-stalwart.service
 # JAB-158 journald cap + JAB-153/157 disk-maintenance timer. install.sh drops
@@ -627,6 +629,7 @@ install -m 0644 ` + repoDir + `/install/systemd/jabali-kratos.service /etc/syste
 systemctl daemon-reload
 systemctl enable --now jabali-sso-reaper.timer
 systemctl enable --now jabali-disk-maintenance.timer
+systemctl enable --now jabali-retention-sweep.timer
 systemctl restart systemd-journald 2>/dev/null || true
 sha_after_k=$(sha256sum /etc/systemd/system/jabali-kratos.service 2>/dev/null | awk '{print $1}' || echo "")
 if [ "$sha_before_k" != "$sha_after_k" ]; then


### PR DESCRIPTION
Ten log/report tables had **no retention** and grew unbounded. One consolidated `jabali retention-sweep` + daily timer batch-deletes aged rows (5000/loop so a backlog can't long-lock a table).

| Table | Window | Issue |
|---|---|---|
| log_access_streams (expired keys), terminal_sessions | expiry / 90d | JAB-103 |
| notification_history | 90d | JAB-100 |
| update_history (+ log excerpts) | 180d | JAB-101 |
| dmarc_aggregate / tlsrpt_aggregate / arf_report | 180d | JAB-125 |
| malware_events | 365d | JAB-123 |
| snuffleupagus_incidents | 365d | JAB-122 |
| db_admin_audit (legacy) | 365d | JAB-105 (partial) |

Security-forensics tables keep a 1-year window; reports/notifications 90-180d. Installed by `install.sh` (`install_retention_sweep_timer`) **and** re-installed on the `jabali update` path.

## Deliberately excluded — need their own design (not a blind DELETE)
- **audit_events**: hash-chained tamper-evident log (`prev_hash`/`row_hash`). Deleting old rows dangles the chain — this is the core of JAB-105 and needs archive/re-anchor. Guarded by a test so it can't be added back accidentally.
- **bw_daily**: bandwidth billing ledger — JAB-124 wants a monthly rollup, not a delete.
- **migration_jobs/stages**: owned by `migrate reap-secrets` (JAB-102).

## Tests
Every target validated as a bare identifier (injection guard), windows sane, security tables ≥1y, audit_events never included. `go build`/`vet`, `bash -n`, `systemd-analyze` clean. Table + column names verified against the model structs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)