### PR TITLE
fix(migrations/ui): responsive mobile layouts for admin migration views (JAB-34/35/36)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -176,7 +176,7 @@ export const AdminMigrationDetailPage = () => {
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
       <Card>
-        <Space style={{ marginBottom: 16 }}>
+        <Space wrap style={{ marginBottom: 16, rowGap: 4 }}>
           <Typography.Title level={4} style={{ margin: 0 }}>
             Migration {job.source_user}@{job.source_host}
           </Typography.Title>
@@ -188,7 +188,7 @@ export const AdminMigrationDetailPage = () => {
           </Typography.Link>
         </Space>
 
-        <Descriptions size="small" column={2} bordered>
+        <Descriptions size="small" column={{ xs: 1, sm: 2 }} bordered>
           <Descriptions.Item label="Job ID">
             <Typography.Text code>{job.id}</Typography.Text>
           </Descriptions.Item>
@@ -234,7 +234,7 @@ export const AdminMigrationDetailPage = () => {
         })()}
         <Steps
           direction="horizontal"
-          responsive={false}
+          responsive
           current={STAGE_ORDER.findIndex(
             (n) => stagesByName.get(n)?.state === "running",
           )}
@@ -285,7 +285,7 @@ export const AdminMigrationDetailPage = () => {
                       {s.state.toUpperCase()}
                     </Tag>
                   </Space>
-                  <Descriptions size="small" column={2}>
+                  <Descriptions size="small" column={{ xs: 1, sm: 2 }}>
                     <Descriptions.Item label="Started">
                       {s.started_at
                         ? new Date(s.started_at).toLocaleString()

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   Card,
   Empty,
+  List,
   Popconfirm,
   Space,
   Switch,
@@ -249,6 +250,90 @@ export const AdminMigrationsPage = () => {
           </Space>
   );
 
+  const renderRowActions = (r: MigrationJob) => {
+  const terminal =
+    r.state === "done" ||
+    r.state === "failed" ||
+    r.state === "cancelled";
+  return (
+    <RowActions
+      actions={[
+        { key: "view", label: "View", icon: <SwapOutlined />, onClick: () => navigate(`/jabali-admin/migrations/${r.id}`) },
+        {
+          key: "rekick",
+          label: "Re-kick",
+          icon: <RedoOutlined />,
+          hidden: r.state !== "pending",
+          onClick: () => reKick.mutate({ id: r.id }),
+          confirm: { title: `Re-kick pull-source for ${r.source_user}?`, description: "Re-dispatches the agent's pull-source runner. Use for rows that landed pending before auto-kick existed, or after a transient SSH/network blip.", okText: "Re-kick" },
+        },
+        {
+          key: "cancel",
+          label: "Cancel",
+          icon: <DeleteOutlined />,
+          danger: true,
+          hidden: terminal,
+          onClick: () => cancel.mutate({ id: r.id }),
+          confirm: { title: `Cancel migration ${r.source_user}?`, description: "Stamps the DB row as cancelled. Does NOT kill an in-flight CLI process — Ctrl-C the cobra cmd separately.", okText: "Cancel job" },
+        },
+        {
+          key: "destroy",
+          label: "Destroy",
+          icon: <DeleteOutlined />,
+          danger: true,
+          hidden: !terminal,
+          onClick: () => destroy.mutate({ id: r.id }),
+          confirm: { title: `Destroy migration ${r.source_user}?`, description: "Removes the DB row, secrets file, and /var/lib/jabali-migrations/<id>/ extracted dir. Operator-irreversible.", okText: "Destroy" },
+        },
+      ]}
+    />
+  );
+  };
+
+  // JAB-34: below the md breakpoint the 8-column Table needs horizontal
+  // scroll, which hides State/Started/Ended/actions on a phone. Render each
+  // job as a stacked card instead so every field + the row actions are
+  // reachable in one tap. Desktop keeps the Table unchanged.
+  const renderMobileJobCard = (r: MigrationJob) => {
+    const badge = SOURCE_BADGE[r.source_kind] ?? { color: "default", label: r.source_kind };
+    const st = STATE_TAG[r.state] ?? { color: "default", label: r.state };
+    return (
+      <List.Item key={r.id} style={{ paddingInline: 0 }}>
+        <Card size="small" style={{ width: "100%" }}>
+          <Space direction="vertical" size={6} style={{ width: "100%" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+              <Space size={6} wrap>
+                <Tag color={badge.color}>{badge.label}</Tag>
+                <Tag color={st.color}>{st.label}</Tag>
+              </Space>
+              {renderRowActions(r)}
+            </div>
+            <Typography.Text code style={{ fontSize: 12, wordBreak: "break-all" }}>
+              {r.source_user}@{r.source_host}
+            </Typography.Text>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: 12 }}>
+              <Typography.Text type="secondary">Started {shortDateTime(r.started_at)}</Typography.Text>
+              <Typography.Text type="secondary">Ended {r.ended_at ? shortDateTime(r.ended_at) : "\u2014"}</Typography.Text>
+            </div>
+            {r.batch_id ? (
+              <Popconfirm
+                title={`Cancel entire batch ${r.batch_id.slice(-6)}?`}
+                description="Cancels every non-terminal job sharing this batch_id."
+                okText="Cancel batch"
+                okButtonProps={{ danger: true }}
+                onConfirm={() => cancelBatch.mutate({ batchId: r.batch_id! })}
+              >
+                <Tag color="purple" style={{ fontFamily: "monospace", fontSize: 11, cursor: "pointer", width: "fit-content" }}>
+                  batch {r.batch_id.slice(-6)}
+                </Tag>
+              </Popconfirm>
+            ) : null}
+          </Space>
+        </Card>
+      </List.Item>
+    );
+  };
+
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
       <Alert
@@ -291,6 +376,7 @@ export const AdminMigrationsPage = () => {
         {!screens.md ? (
           <div style={{ width: "100%", marginBottom: 12 }}>{migrationsToolbar}</div>
         ) : null}
+        {screens.md ? (
         <Table<MigrationJob>
           dataSource={rows}
           rowKey="id"
@@ -388,47 +474,17 @@ export const AdminMigrationsPage = () => {
           <Table.Column<MigrationJob>
             title=""
             width={200}
-            render={(_, r) => {
-              const terminal =
-                r.state === "done" ||
-                r.state === "failed" ||
-                r.state === "cancelled";
-              return (
-                <RowActions
-                  actions={[
-                    { key: "view", label: "View", icon: <SwapOutlined />, onClick: () => navigate(`/jabali-admin/migrations/${r.id}`) },
-                    {
-                      key: "rekick",
-                      label: "Re-kick",
-                      icon: <RedoOutlined />,
-                      hidden: r.state !== "pending",
-                      onClick: () => reKick.mutate({ id: r.id }),
-                      confirm: { title: `Re-kick pull-source for ${r.source_user}?`, description: "Re-dispatches the agent's pull-source runner. Use for rows that landed pending before auto-kick existed, or after a transient SSH/network blip.", okText: "Re-kick" },
-                    },
-                    {
-                      key: "cancel",
-                      label: "Cancel",
-                      icon: <DeleteOutlined />,
-                      danger: true,
-                      hidden: terminal,
-                      onClick: () => cancel.mutate({ id: r.id }),
-                      confirm: { title: `Cancel migration ${r.source_user}?`, description: "Stamps the DB row as cancelled. Does NOT kill an in-flight CLI process — Ctrl-C the cobra cmd separately.", okText: "Cancel job" },
-                    },
-                    {
-                      key: "destroy",
-                      label: "Destroy",
-                      icon: <DeleteOutlined />,
-                      danger: true,
-                      hidden: !terminal,
-                      onClick: () => destroy.mutate({ id: r.id }),
-                      confirm: { title: `Destroy migration ${r.source_user}?`, description: "Removes the DB row, secrets file, and /var/lib/jabali-migrations/<id>/ extracted dir. Operator-irreversible.", okText: "Destroy" },
-                    },
-                  ]}
-                />
-              );
-            }}
+            render={(_, r) => renderRowActions(r)}
           />
         </Table>
+        ) : (
+          <List
+            dataSource={rows}
+            loading={list.isLoading}
+            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No migrations yet" /> }}
+            renderItem={renderMobileJobCard}
+          />
+        )}
       </Card>
 
       <Card size="small" title="Per-source-kind support">

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -420,7 +420,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
             message="Pick the source panel type"
             description="WHM enables bulk migration of every cPanel account. Single-account migrations are still available via the 'New migration' button."
           />
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12 }}>
             {SOURCE_OPTIONS.map((o) => {
               const disabled = "disabled" in o ? Boolean(o.disabled) : false;
               const active = sourceKind === o.value;
@@ -431,6 +431,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
                   size="small"
                   onClick={() => !disabled && setSourceKind(o.value)}
                   style={{
+                    minHeight: 72,
                     opacity: disabled ? 0.5 : 1,
                     cursor: disabled ? "not-allowed" : "pointer",
                     borderColor: active ? "#1677ff" : undefined,


### PR DESCRIPTION
Three admin → Migrations views were desktop-shaped and unusable at phone widths (390px).

| Issue | View | Fix |
|---|---|---|
| JAB-34 | Jobs list | 8-column Table needs horizontal scroll (hides State/Started/Ended/actions). Below `md`, render each job as a **stacked card** — source+state tags, `user@host`, started/ended, batch, row actions — reachable in one tap. Desktop Table unchanged; row actions extracted into a shared `renderRowActions()`. |
| JAB-35 | Create wizard | Two-column source-card grid too narrow on phones → CSS `auto-fill minmax(240px)` (one column under ~480px) + stable min tap-target height. All wizard form steps are already responsive. |
| JAB-36 | Detail page | Job + stage `Descriptions` → `column={{ xs: 1, sm: 2 }}` (stack on phones); pipeline `Steps` had `responsive={false}` forcing the cramped horizontal row → enabled `responsive` (vertical timeline under 480px); header `Space` wraps so a long title stops truncating the tag + back-link. |

Native antd responsive props / CSS only — no new deps.

**Verification:** `tsc -b`, `eslint`, and the full `vite build` pass. I could not do pixel-level 390px QA myself — the admin views are auth-gated and I can't enter the admin password — so a logged-in eyeball at 390px is worth a glance before merge. The changes are all standard antd responsive patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)