### PR TITLE
fix(backups): prune per-job backup log files by age (JAB-98)

### DIFF
--- a/internal/backup/joblog.go
+++ b/internal/backup/joblog.go
@@ -70,3 +70,42 @@ func (l *JobLogger) Close() {
 func JobLogPath(jobID string) string {
 	return filepath.Join(JobLogDir, jobID+".log")
 }
+
+// DefaultJobLogRetention is how long a per-job backup log file is kept after
+// its last write. A running job's log has a fresh mtime, so an mtime-based
+// prune at this age never removes an active job's log. 90 days matches the
+// fixed-window policy in JAB-98.
+const DefaultJobLogRetention = 90 * 24 * time.Hour
+
+// PruneJobLogs removes per-job log files under JobLogDir whose last
+// modification is older than maxAge, returning the count removed. A missing
+// dir is not an error (no backups have run yet). Age-based, so an in-flight
+// job — still appending to its log — is never pruned. (JAB-98)
+func PruneJobLogs(maxAge time.Duration) (int, error) {
+	return pruneJobLogsIn(JobLogDir, maxAge)
+}
+
+func pruneJobLogsIn(dir string, maxAge time.Duration) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	removed := 0
+	cutoff := time.Now().Add(-maxAge)
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".log" {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		if os.Remove(filepath.Join(dir, e.Name())) == nil {
+			removed++
+		}
+	}
+	return removed, nil
+}

--- a/internal/backup/joblog_prune_test.go
+++ b/internal/backup/joblog_prune_test.go
@@ -1,0 +1,56 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// JAB-98: old job logs are pruned; a fresh (active-job) log and non-.log files
+// are left alone.
+func TestPruneJobLogsIn(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-120 * 24 * time.Hour)
+	fresh := time.Now()
+
+	mk := func(name string, mtime time.Time) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o640); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	oldLog := mk("01OLDJOB.log", old)     // aged out -> removed
+	activeLog := mk("01ACTIVE.log", fresh) // in-flight -> kept
+	notLog := mk("keep.txt", old)          // not a .log -> kept
+
+	n, err := pruneJobLogsIn(dir, DefaultJobLogRetention)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 pruned, got %d", n)
+	}
+	if _, err := os.Stat(oldLog); !os.IsNotExist(err) {
+		t.Errorf("old log should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(activeLog); err != nil {
+		t.Errorf("active job log must be kept: %v", err)
+	}
+	if _, err := os.Stat(notLog); err != nil {
+		t.Errorf("non-.log file must be kept: %v", err)
+	}
+}
+
+// A missing logs dir is a no-op, not an error (no backups have run yet).
+func TestPruneJobLogsIn_MissingDir(t *testing.T) {
+	n, err := pruneJobLogsIn(filepath.Join(t.TempDir(), "nope"), time.Hour)
+	if err != nil || n != 0 {
+		t.Fatalf("missing dir should be (0, nil), got (%d, %v)", n, err)
+	}
+}

--- a/panel-agent/internal/commands/backup_logs.go
+++ b/panel-agent/internal/commands/backup_logs.go
@@ -85,6 +85,13 @@ func backupLogsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		logText = string(out)
 	}
 
+	if strings.TrimSpace(logText) == "" {
+		// JAB-98: the per-job log file was pruned by backup retention (or
+		// the orchestrator died before writing it) and the journal fallback
+		// is empty. Return a clear message instead of a blank modal.
+		logText = "(no log available \u2014 it may have expired by retention or the job predates per-job logging)"
+	}
+
 	resp := backupLogsResponse{
 		Unit:      unit,
 		Status:    status,

--- a/panel-api/cmd/server/backup_retention_cmd.go
+++ b/panel-api/cmd/server/backup_retention_cmd.go
@@ -85,6 +85,19 @@ by install_backup_foundation in install.sh.`,
 				return err
 			}
 
+			// JAB-98: prune per-job backup log files under
+			// /var/lib/jabali-backups/logs older than the retention window.
+			// Age-based (mtime) so an in-flight job's log is never removed,
+			// and independent of restic policy — manual/one-off jobs write
+			// logs too. Runs on every retention pass; skipped under --dry-run.
+			if dryRun {
+				fmt.Fprintln(cmd.OutOrStdout(), "[dry-run] would prune backup job logs older than 90d")
+			} else if n, perr := internalbackup.PruneJobLogs(internalbackup.DefaultJobLogRetention); perr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "prune job logs failed: %v\n", perr)
+			} else if n > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "pruned %d expired backup job log(s)\n", n)
+			}
+
 			schedRepo := repository.NewBackupScheduleRepository(sharedDB)
 			destRepo := repository.NewBackupDestinationRepository(sharedDB)
 			scheds, err := schedRepo.List(ctx)


### PR DESCRIPTION
Backup/restore jobs append to `/var/lib/jabali-backups/logs/<job_id>.log`, but nothing rotated or removed them — the logrotate drop-in only covers `/var/log`, and `jabali-backup-retention` only runs restic forget/prune. On a busy host these grow unbounded.

- **internal/backup**: `PruneJobLogs(maxAge)` removes `*.log` older than maxAge. **Age-based (mtime)**, so an in-flight job — still appending — is never removed. Default 90 days.
- **backup retention apply**: prunes job logs on every pass, independent of restic policy (manual/one-off jobs write logs too); honors `--dry-run`.
- **backup.logs handler**: when the file is pruned/absent and the journal fallback is empty, returns a clear "no log available — may have expired by retention" message instead of a blank modal.

Tests: old log pruned; active-job log + non-`.log` kept; missing dir is a no-op. `go build`/`vet` clean across internal/backup, panel-agent, panel-api.

Box-test post-merge: `jabali backup retention apply --dry-run` on a host with backups prints the job-log line; a real pass reclaims aged logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)