### PR TITLE
perf(cache): gzip large page-cache payloads + skip oversize bodies (JAB-92)

### DIFF
--- a/wp-plugins/jabali-cache/includes/class-page-cache.php
+++ b/wp-plugins/jabali-cache/includes/class-page-cache.php
@@ -64,6 +64,14 @@ class Jabali_Cache_Page_Cache {
 	const LOCK_TTL       = 20;
 	const TTL_JITTER_PCT = 10;
 
+	/**
+	 * JAB-92: gzip the stored HTML body above COMPRESS_MIN_BYTES to cut shared
+	 * Redis memory. Bodies larger than MAX_BODY_BYTES are not cached at all so a
+	 * single huge response can't evict useful object-cache keys.
+	 */
+	const COMPRESS_MIN_BYTES = 8192;
+	const MAX_BODY_BYTES     = 2097152;
+
 	public function __construct() {
 		$this->cfg    = Jabali_Cache_Config::load();
 		$this->ttl    = max( 1, (int) $this->cfg['page_ttl'] );
@@ -124,6 +132,70 @@ class Jabali_Cache_Page_Cache {
 	}
 
 	/**
+	 * JAB-92: true when a body is small enough to be worth caching. Very large
+	 * responses are skipped so they don't evict useful keys from shared Redis.
+	 *
+	 * @param string $body
+	 * @return bool
+	 */
+	private static function is_storable_size( $body ) {
+		return strlen( (string) $body ) <= self::MAX_BODY_BYTES;
+	}
+
+	/**
+	 * JAB-92: gzip-compress the payload body when zlib is available and the
+	 * body clears COMPRESS_MIN_BYTES and actually shrinks. Marks the payload
+	 * with compressed=gzip + the original length. No-op otherwise.
+	 *
+	 * @param array<string,mixed> $payload
+	 * @return array<string,mixed>
+	 */
+	public static function compress_payload_body( array $payload ) {
+		if ( ! isset( $payload['body'] ) || ! is_string( $payload['body'] ) ) {
+			return $payload;
+		}
+		if ( ! function_exists( 'gzencode' ) ) {
+			return $payload;
+		}
+		$body = $payload['body'];
+		if ( strlen( $body ) <= self::COMPRESS_MIN_BYTES ) {
+			return $payload;
+		}
+		$gz = @gzencode( $body, 6 ); // phpcs:ignore
+		if ( false === $gz || strlen( $gz ) >= strlen( $body ) ) {
+			return $payload; // incompressible — keep the plain body.
+		}
+		$payload['body']       = $gz;
+		$payload['compressed'] = 'gzip';
+		$payload['body_len']   = strlen( $body );
+		return $payload;
+	}
+
+	/**
+	 * JAB-92: reverse compress_payload_body(). Returns the payload with a plain
+	 * body, or FALSE when a gzip payload can't be decoded (corrupt / zlib gone)
+	 * so the caller can treat it as a miss and delete the bad key.
+	 *
+	 * @param array<string,mixed> $payload
+	 * @return array<string,mixed>|false
+	 */
+	public static function decompress_payload_body( array $payload ) {
+		if ( empty( $payload['compressed'] ) ) {
+			return $payload;
+		}
+		if ( 'gzip' !== $payload['compressed'] || ! function_exists( 'gzdecode' ) ) {
+			return false;
+		}
+		$plain = @gzdecode( $payload['body'] ); // phpcs:ignore
+		if ( false === $plain ) {
+			return false;
+		}
+		$payload['body'] = $plain;
+		unset( $payload['compressed'], $payload['body_len'] );
+		return $payload;
+	}
+
+	/**
 	 * Decode a stored page payload, or null when absent/corrupt.
 	 *
 	 * @param string|false $raw
@@ -134,7 +206,19 @@ class Jabali_Cache_Page_Cache {
 			return null;
 		}
 		$payload = @unserialize( $raw, array( 'allowed_classes' => false ) ); // phpcs:ignore
-		return ( is_array( $payload ) && isset( $payload['body'] ) ) ? $payload : null;
+		if ( ! is_array( $payload ) || ! isset( $payload['body'] ) ) {
+			return null;
+		}
+		// JAB-92: transparently inflate a gzip payload. A corrupt one is a miss —
+		// drop the bad key so the next request regenerates it.
+		$decoded = self::decompress_payload_body( $payload );
+		if ( false === $decoded ) {
+			if ( '' !== $this->key ) {
+				$this->client->del( $this->key );
+			}
+			return null;
+		}
+		return $decoded;
 	}
 
 	/**
@@ -203,6 +287,10 @@ class Jabali_Cache_Page_Cache {
 		if ( ! $this->is_cacheable_response( $body ) ) {
 			return $body;
 		}
+		// JAB-92: don't cache an oversized body — it would evict useful keys.
+		if ( ! self::is_storable_size( $body ) ) {
+			return $body;
+		}
 
 		// JAB-90: freshness window is jittered; the Redis key lives STALE_WINDOW
 		// seconds beyond that so a stale copy can be served during regeneration.
@@ -214,6 +302,8 @@ class Jabali_Cache_Page_Cache {
 			'expires_at' => time() + $fresh_ttl,
 			'gen'        => defined( 'JABALI_CACHE_VERSION' ) ? JABALI_CACHE_VERSION : '1',
 		);
+		// JAB-92: gzip large bodies before storing.
+		$payload = self::compress_payload_body( $payload );
 		// Best-effort store; failure just means no caching this time.
 		$this->client->set( $this->key, serialize( $payload ), $fresh_ttl + self::STALE_WINDOW ); // phpcs:ignore
 		// Release the single-flight lock now that the fresh copy is in place.

--- a/wp-plugins/jabali-cache/tests/test-page-cache.php
+++ b/wp-plugins/jabali-cache/tests/test-page-cache.php
@@ -54,5 +54,25 @@ jc_assert( Jabali_Cache_Page_Cache::response_opts_out( array( 'Expires: Thu, 01 
 jc_assert( ! Jabali_Cache_Page_Cache::response_opts_out( array( 'Cache-Control: public, max-age=300' ) ), 'public max-age=300 still cacheable' );
 jc_assert( ! Jabali_Cache_Page_Cache::response_opts_out( array( 'Content-Type: text/html' ) ), 'plain response still cacheable' );
 
+echo "JAB-92 — page-cache payload compression:\n";
+$big = str_repeat( "<p>hello world</p>", 2000 ); // ~36 KiB, well over COMPRESS_MIN_BYTES
+$pc  = Jabali_Cache_Page_Cache::compress_payload_body( array( 'body' => $big, 'type' => 'text/html' ) );
+jc_assert( isset( $pc['compressed'] ) && 'gzip' === $pc['compressed'], 'large body is marked gzip' );
+jc_assert( strlen( $pc['body'] ) < strlen( $big ), 'compressed body is smaller' );
+jc_assert( isset( $pc['body_len'] ) && (int) $pc['body_len'] === strlen( $big ), 'original length is recorded' );
+$round = Jabali_Cache_Page_Cache::decompress_payload_body( $pc );
+jc_assert( is_array( $round ) && $round['body'] === $big, 'decompress round-trips to the original body' );
+jc_assert( ! isset( $round['compressed'] ), 'decompressed payload drops the gzip marker' );
+
+$small = '<p>tiny</p>';
+$sp    = Jabali_Cache_Page_Cache::compress_payload_body( array( 'body' => $small ) );
+jc_assert( ! isset( $sp['compressed'] ), 'small body is left uncompressed' );
+jc_assert( $sp['body'] === $small, 'small body is unchanged' );
+$sr = Jabali_Cache_Page_Cache::decompress_payload_body( $sp );
+jc_assert( is_array( $sr ) && $sr['body'] === $small, 'uncompressed payload passes through decompress' );
+
+$corrupt = array( 'body' => 'not-actually-gzip', 'compressed' => 'gzip' );
+jc_assert( false === Jabali_Cache_Page_Cache::decompress_payload_body( $corrupt ), 'corrupt gzip payload decodes to false (miss)' );
+
 echo "\n{$tests} tests, {$failed} failed\n";
 exit( $failed > 0 ? 1 : 0 );


### PR DESCRIPTION
The Redis full-page cache stored serialized HTML bodies **uncompressed**. On Jabali's single shared Redis, large pages (homepages, archives, landing pages) raise eviction pressure for every tenant's object-cache keys.

- `compress_payload_body()` — gzip the body when zlib is available, it clears `COMPRESS_MIN_BYTES` (8 KiB), and it actually shrinks. Marks `compressed=gzip` + records original length. Small/incompressible bodies stored as-is (no CPU cost).
- `decompress_payload_body()` — inflate on read; an undecodable gzip payload returns `false` so `read_payload` treats it as a **miss and deletes the bad key** (corruption never breaks rendering).
- `on_flush` — skip storing bodies over `MAX_BODY_BYTES` (2 MiB) so one huge response can't evict useful keys.

Both helpers are pure public-static. Tests cover compressed round-trip, small/uncompressed pass-through, gzip-marker handling, original-length record, and corrupt-payload fallback.

**Verified:** `php -l` clean; **26/26 plugin tests pass locally and on testserver (PHP 8.4.23)**.

Next in the cache-perf batch: JAB-96 (pconnect), 97 (atomic counters), 93 (purge coalescing), 95 (warmup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)