### PR TITLE
feat(cache): prioritize warmup URLs by value + sitemap hints (JAB-95 Phase 2)

### DIFF
--- a/panel-agent/internal/commands/nginx_cache_warmup.go
+++ b/panel-agent/internal/commands/nginx_cache_warmup.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,19 +72,70 @@ var warmupFetchBody = func(ctx context.Context, host, path string) string {
 	return string(out)
 }
 
-// sitemapPaths fetches the site's sitemap and returns up to max same-host URL
-// paths. Tries the WP core sitemap first, then a generic sitemap.xml. One level
-// of sitemap-index expansion (WP core's wp-sitemap.xml is an index).
-func sitemapPaths(ctx context.Context, host string, max int) []string {
-	seen := map[string]bool{}
-	var paths []string
-	add := func(u string) {
-		p := toSameHostPath(host, u)
-		if p == "" || seen[p] {
-			return
+// sitemapEntry is one URL discovered in a sitemap, with the optional priority
+// and lastmod hints SEO plugins (Yoast/RankMath) emit. WP core sitemaps omit
+// both, so they default to priority 0.5 / empty lastmod and ranking falls back
+// to the URL value tier.
+type sitemapEntry struct {
+	path     string
+	priority float64
+	lastmod  string
+}
+
+var (
+	urlBlockRe  = regexp.MustCompile(`(?is)<url>(.*?)</url>`)
+	priorityRe  = regexp.MustCompile(`(?i)<priority>\s*([0-9.]+)\s*</priority>`)
+	lastmodRe   = regexp.MustCompile(`(?i)<lastmod>\s*([^<\s]+)\s*</lastmod>`)
+	dateArchive = regexp.MustCompile(`^/(19|20)\d\d/`)
+)
+
+// sitemapMaxEntries bounds how many URLs we parse+rank. Parsing is cheap (just
+// the XML), and the caller only warms `max-1` of the ranked result, so a
+// generous ceiling costs little while giving ranking enough to work with.
+const sitemapMaxEntries = 2000
+
+// parseUrlset extracts <url> entries (loc + optional priority/lastmod) from a
+// urlset sitemap body, resolved to same-host paths.
+func parseUrlset(host, body string) []sitemapEntry {
+	var out []sitemapEntry
+	for _, m := range urlBlockRe.FindAllStringSubmatch(body, -1) {
+		block := m[1]
+		loc := locRe.FindStringSubmatch(block)
+		if loc == nil {
+			continue
 		}
-		seen[p] = true
-		paths = append(paths, p)
+		path := toSameHostPath(host, loc[1])
+		if path == "" {
+			continue
+		}
+		e := sitemapEntry{path: path, priority: 0.5}
+		if pr := priorityRe.FindStringSubmatch(block); pr != nil {
+			if f, err := strconv.ParseFloat(pr[1], 64); err == nil {
+				e.priority = f
+			}
+		}
+		if lm := lastmodRe.FindStringSubmatch(block); lm != nil {
+			e.lastmod = lm[1]
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// sitemapEntries fetches the site's sitemap and returns the same-host URL
+// entries. Tries the WP core sitemap first, then generic sitemap.xml. One level
+// of sitemap-index expansion (WP core's wp-sitemap.xml is an index).
+func sitemapEntries(ctx context.Context, host string) []sitemapEntry {
+	seen := map[string]bool{}
+	var entries []sitemapEntry
+	addUrlset := func(body string) {
+		for _, e := range parseUrlset(host, body) {
+			if seen[e.path] {
+				continue
+			}
+			seen[e.path] = true
+			entries = append(entries, e)
+		}
 	}
 	for _, entry := range []string{"/wp-sitemap.xml", "/sitemap.xml", "/sitemap_index.xml"} {
 		body := warmupFetchBody(ctx, host, entry)
@@ -90,30 +143,70 @@ func sitemapPaths(ctx context.Context, host string, max int) []string {
 		if len(locs) == 0 {
 			continue
 		}
-		// If these are sub-sitemaps (contain "sitemap" in the path), expand one
-		// level; otherwise treat them as page URLs.
+		// Sub-<loc> that are .xml sitemaps → index; expand one level. Otherwise
+		// this body is itself a urlset.
+		isIndex := false
 		for _, m := range locs {
-			u := m[1]
-			if strings.Contains(strings.ToLower(u), "sitemap") && strings.HasSuffix(strings.ToLower(u), ".xml") {
-				sub := warmupFetchBody(ctx, host, toSameHostPath(host, u))
-				for _, sm := range locRe.FindAllStringSubmatch(sub, -1) {
-					add(sm[1])
-					if len(paths) >= max {
-						return paths
-					}
+			u := strings.ToLower(m[1])
+			if strings.Contains(u, "sitemap") && strings.HasSuffix(u, ".xml") {
+				isIndex = true
+				addUrlset(warmupFetchBody(ctx, host, toSameHostPath(host, m[1])))
+				if len(entries) >= sitemapMaxEntries {
+					return entries
 				}
-			} else {
-				add(u)
-			}
-			if len(paths) >= max {
-				return paths
 			}
 		}
-		if len(paths) > 0 {
+		if !isIndex {
+			addUrlset(body)
+		}
+		if len(entries) > 0 {
 			break
 		}
 	}
-	return paths
+	return entries
+}
+
+// warmValueTier ranks a path by how much it benefits from a warm cache. Higher
+// warms first. Homepage/shop + WooCommerce product & category pages are hottest;
+// tag/author/date/paged archives are low value and warm last.
+func warmValueTier(path string) int {
+	lp := strings.ToLower(path)
+	switch {
+	case lp == "/":
+		return 4
+	case strings.HasPrefix(lp, "/shop") ||
+		strings.Contains(lp, "/product/") ||
+		strings.Contains(lp, "/product-category/"):
+		return 3
+	case strings.Contains(lp, "/tag/") ||
+		strings.Contains(lp, "/author/") ||
+		strings.Contains(lp, "/page/") ||
+		dateArchive.MatchString(lp):
+		return 1
+	default:
+		return 2 // pages + posts
+	}
+}
+
+// prioritizeWarmPaths orders sitemap entries: value tier first, then the
+// sitemap priority hint, then most-recently-modified. Stable so equal entries
+// keep sitemap order. Returns the ordered paths. (JAB-95 Phase 2)
+func prioritizeWarmPaths(entries []sitemapEntry) []string {
+	sort.SliceStable(entries, func(i, j int) bool {
+		ti, tj := warmValueTier(entries[i].path), warmValueTier(entries[j].path)
+		if ti != tj {
+			return ti > tj
+		}
+		if entries[i].priority != entries[j].priority {
+			return entries[i].priority > entries[j].priority
+		}
+		return entries[i].lastmod > entries[j].lastmod // ISO dates sort lexically; recent first
+	})
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.path)
+	}
+	return out
 }
 
 // toSameHostPath returns the absolute path of u only if u is on host (defends
@@ -186,13 +279,20 @@ func nginxCacheWarmupHandler(ctx context.Context, params json.RawMessage) (any, 
 			firstError = fmt.Sprintf("%s -> %d", path, code)
 		}
 	}
-	// Homepage first, then bounded sitemap URLs.
+	// JAB-95 Phase 2: homepage first, then sitemap URLs in priority order
+	// (high-value pages before low-value archives) so a small budget warms the
+	// pages most likely to be hit, not just the first sitemap entries.
 	note("/", warmupFetch(ctx, host, "/"))
-	for _, path := range sitemapPaths(ctx, host, max-1) {
-		if ctx.Err() != nil {
+	warmed2 := 0
+	for _, path := range prioritizeWarmPaths(sitemapEntries(ctx, host)) {
+		if ctx.Err() != nil || warmed2 >= max-1 {
 			break
 		}
+		if path == "/" {
+			continue // homepage already warmed above
+		}
 		note(path, warmupFetch(ctx, host, path))
+		warmed2++
 	}
 	return map[string]any{
 		"ok":          true,

--- a/panel-agent/internal/commands/nginx_cache_warmup_priority_test.go
+++ b/panel-agent/internal/commands/nginx_cache_warmup_priority_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+)
+
+// JAB-95 Phase 2: high-value pages warm before low-value archives; within a
+// tier the sitemap priority hint then lastmod break ties.
+func TestPrioritizeWarmPaths(t *testing.T) {
+	entries := []sitemapEntry{
+		{path: "/tag/sale", priority: 0.5},
+		{path: "/about", priority: 0.5},
+		{path: "/product/widget", priority: 0.5},
+		{path: "/blog", priority: 0.9, lastmod: "2026-07-01"},
+		{path: "/blog-old", priority: 0.9, lastmod: "2026-01-01"},
+		{path: "/product-category/tools", priority: 0.5},
+	}
+	got := prioritizeWarmPaths(entries)
+	want := []string{
+		"/product/widget",         // tier 3
+		"/product-category/tools", // tier 3
+		"/blog",                   // tier 2, prio 0.9, newer lastmod
+		"/blog-old",               // tier 2, prio 0.9, older lastmod
+		"/about",                  // tier 2, prio 0.5
+		"/tag/sale",               // tier 1
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order=%v\nwant %v", got, want)
+	}
+}
+
+func TestWarmValueTier(t *testing.T) {
+	cases := map[string]int{
+		"/":                    4,
+		"/shop":                3,
+		"/product/x":           3,
+		"/product-category/y":  3,
+		"/about":               2,
+		"/2025/06/hello":       1,
+		"/tag/foo":             1,
+		"/author/jane":         1,
+		"/page/3":              1,
+	}
+	for path, want := range cases {
+		if got := warmValueTier(path); got != want {
+			t.Errorf("warmValueTier(%q)=%d, want %d", path, got, want)
+		}
+	}
+}
+
+// parseUrlset pulls loc + optional priority/lastmod, defaults priority 0.5, and
+// drops off-host URLs.
+func TestParseUrlset(t *testing.T) {
+	body := `<urlset>
+	  <url><loc>https://ex.com/a</loc><priority>0.8</priority><lastmod>2026-07-01</lastmod></url>
+	  <url><loc>https://ex.com/b</loc></url>
+	  <url><loc>https://other.com/x</loc></url>
+	</urlset>`
+	got := parseUrlset("ex.com", body)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 same-host entries, got %d: %+v", len(got), got)
+	}
+	if got[0].path != "/a" || got[0].priority != 0.8 || got[0].lastmod != "2026-07-01" {
+		t.Errorf("entry a wrong: %+v", got[0])
+	}
+	if got[1].path != "/b" || got[1].priority != 0.5 {
+		t.Errorf("entry b should default priority 0.5: %+v", got[1])
+	}
+}


### PR DESCRIPTION
Warmup fetched homepage + sitemap URLs in **raw sitemap order**, so a small budget could warm the first 50 low-value archive pages and leave hot pages cold.

Build the warm list in priority order, then warm the first `max-1`:
- parse sitemap `<url>` blocks for the optional `<priority>`/`<lastmod>` hints SEO plugins emit (WP core omits both → default 0.5 / empty, ranking falls back to the URL value tier);
- `warmValueTier`: homepage/shop + WooCommerce product & product-category pages first, then pages/posts, then tag/author/date/paged archives last;
- `prioritizeWarmPaths`: value tier → sitemap priority → most-recent lastmod; stable so equal entries keep sitemap order.

Homepage is always warmed first. Pure ranking + parse are **unit-tested** (tier order, priority/lastmod tiebreak, off-host drop, priority default). `build`/`vet` clean.

Phase 2 of `plans/jab95-adaptive-warmup.md`. Remaining: Phase 3 resumable progress (`cache_warmup_runs` table), Phase 4 per-host load controls, Phase 5 UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)