### PR TITLE
feat(cache): cache_warmup_runs schema + repository (JAB-95 Phase 3a)

### DIFF
--- a/panel-api/internal/db/migrations/000225_cache_warmup_runs.down.sql
+++ b/panel-api/internal/db/migrations/000225_cache_warmup_runs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS cache_warmup_runs;

--- a/panel-api/internal/db/migrations/000225_cache_warmup_runs.up.sql
+++ b/panel-api/internal/db/migrations/000225_cache_warmup_runs.up.sql
@@ -1,0 +1,27 @@
+-- JAB-95 Phase 3: persistent, queryable cache-warmup runs. Turns warmup from a
+-- fire-and-forget goroutine into a durable record so the panel can show what a
+-- warmup did (state, warmed/attempted/failed, first error, duration) and later
+-- resume an interrupted one from cursor_pos. (`cursor` is a MySQL reserved word,
+-- hence cursor_pos.)
+CREATE TABLE cache_warmup_runs (
+  id           CHAR(26) NOT NULL,
+  install_id   CHAR(26) NOT NULL,
+  host         VARCHAR(255) NOT NULL,
+  state        VARCHAR(16) NOT NULL DEFAULT 'queued', -- queued|running|done|failed
+  requested    INT NOT NULL DEFAULT 0,
+  clamped_to   INT NOT NULL DEFAULT 0,
+  total        INT NOT NULL DEFAULT 0,
+  cursor_pos   INT NOT NULL DEFAULT 0,
+  attempted    INT NOT NULL DEFAULT 0,
+  warmed       INT NOT NULL DEFAULT 0,
+  skipped      INT NOT NULL DEFAULT 0,
+  failed       INT NOT NULL DEFAULT 0,
+  first_error  VARCHAR(1024) NOT NULL DEFAULT '',
+  started_at   TIMESTAMP NULL,
+  finished_at  TIMESTAMP NULL,
+  created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_cwr_install_created (install_id, created_at),
+  KEY idx_cwr_state (state)
+);

--- a/panel-api/internal/models/cache_warmup_run.go
+++ b/panel-api/internal/models/cache_warmup_run.go
@@ -1,0 +1,36 @@
+package models
+
+import "time"
+
+// CacheWarmupRun records one cache-warmup pass so the panel can show status
+// (state, warmed/attempted/failed, first error) and, in a later phase, resume
+// an interrupted run from CursorPos. (JAB-95 Phase 3)
+type CacheWarmupRun struct {
+	ID         string     `gorm:"type:char(26);primaryKey" json:"id"`
+	InstallID  string     `gorm:"type:char(26);not null;index:idx_cwr_install_created,priority:1" json:"install_id"`
+	Host       string     `gorm:"type:varchar(255);not null" json:"host"`
+	State      string     `gorm:"type:varchar(16);not null;default:queued" json:"state"`
+	Requested  int        `gorm:"not null;default:0" json:"requested"`
+	ClampedTo  int        `gorm:"column:clamped_to;not null;default:0" json:"clamped_to"`
+	Total      int        `gorm:"not null;default:0" json:"total"`
+	CursorPos  int        `gorm:"column:cursor_pos;not null;default:0" json:"cursor_pos"`
+	Attempted  int        `gorm:"not null;default:0" json:"attempted"`
+	Warmed     int        `gorm:"not null;default:0" json:"warmed"`
+	Skipped    int        `gorm:"not null;default:0" json:"skipped"`
+	Failed     int        `gorm:"not null;default:0" json:"failed"`
+	FirstError string     `gorm:"column:first_error;type:varchar(1024);not null;default:''" json:"first_error"`
+	StartedAt  *time.Time `json:"started_at,omitempty"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}
+
+// Warmup run states.
+const (
+	CacheWarmupStateQueued  = "queued"
+	CacheWarmupStateRunning = "running"
+	CacheWarmupStateDone    = "done"
+	CacheWarmupStateFailed  = "failed"
+)
+
+func (CacheWarmupRun) TableName() string { return "cache_warmup_runs" }

--- a/panel-api/internal/repository/cache_warmup_run_repository.go
+++ b/panel-api/internal/repository/cache_warmup_run_repository.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// CacheWarmupRunRepository persists cache-warmup run records (JAB-95 Phase 3).
+type CacheWarmupRunRepository interface {
+	Create(ctx context.Context, run *models.CacheWarmupRun) error
+	Update(ctx context.Context, run *models.CacheWarmupRun) error
+	LatestForInstall(ctx context.Context, installID string) (*models.CacheWarmupRun, error)
+}
+
+type cacheWarmupRunRepo struct{ db *gorm.DB }
+
+func NewCacheWarmupRunRepository(db *gorm.DB) CacheWarmupRunRepository {
+	return &cacheWarmupRunRepo{db: db}
+}
+
+func (r *cacheWarmupRunRepo) Create(ctx context.Context, run *models.CacheWarmupRun) error {
+	return r.db.WithContext(ctx).Create(run).Error
+}
+
+func (r *cacheWarmupRunRepo) Update(ctx context.Context, run *models.CacheWarmupRun) error {
+	return r.db.WithContext(ctx).Save(run).Error
+}
+
+// LatestForInstall returns the most recent run for an install, or ErrNotFound.
+func (r *cacheWarmupRunRepo) LatestForInstall(ctx context.Context, installID string) (*models.CacheWarmupRun, error) {
+	var run models.CacheWarmupRun
+	err := r.db.WithContext(ctx).
+		Where("install_id = ?", installID).
+		Order("created_at DESC").
+		First(&run).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &run, nil
+}

--- a/panel-api/internal/repository/cache_warmup_run_repository_test.go
+++ b/panel-api/internal/repository/cache_warmup_run_repository_test.go
@@ -1,0 +1,63 @@
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func TestCacheWarmupRun_LatestForInstall_NotFound(t *testing.T) {
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewCacheWarmupRunRepository(gdb)
+
+	mock.ExpectQuery("cache_warmup_runs.+WHERE install_id = ").
+		WithArgs("01INSTALL0000000000000000", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id"})) // no rows
+
+	_, err := repo.LatestForInstall(context.Background(), "01INSTALL0000000000000000")
+	require.True(t, errors.Is(err, repository.ErrNotFound), "no rows -> ErrNotFound, got %v", err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCacheWarmupRun_LatestForInstall_ReturnsNewest(t *testing.T) {
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewCacheWarmupRunRepository(gdb)
+
+	mock.ExpectQuery("cache_warmup_runs.+ORDER BY created_at DESC").
+		WithArgs("01INSTALL0000000000000000", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "install_id", "host", "state", "warmed"}).
+			AddRow("01RUN00000000000000000000", "01INSTALL0000000000000000", "ex.com", models.CacheWarmupStateDone, 12))
+
+	got, err := repo.LatestForInstall(context.Background(), "01INSTALL0000000000000000")
+	require.NoError(t, err)
+	require.Equal(t, "ex.com", got.Host)
+	require.Equal(t, models.CacheWarmupStateDone, got.State)
+	require.Equal(t, 12, got.Warmed)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCacheWarmupRun_Create(t *testing.T) {
+	gdb, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := repository.NewCacheWarmupRunRepository(gdb)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `cache_warmup_runs`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.Create(context.Background(), &models.CacheWarmupRun{
+		ID: "01RUN00000000000000000000", InstallID: "01INSTALL0000000000000000",
+		Host: "ex.com", State: models.CacheWarmupStateRunning,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Data layer for durable, resumable warmup (blueprint Phase 3). **Schema-first**, same way `python_apps` (000168) landed its table ahead of the wiring.

- **migration 000225** `cache_warmup_runs`: state, requested/clamped_to, total, `cursor_pos`, attempted/warmed/skipped/failed, first_error, started/finished timestamps. `cursor_pos` (not `cursor` — a MySQL reserved word); indexed by `(install_id, created_at)` + `state`.
- **models.CacheWarmupRun** + state constants.
- **CacheWarmupRunRepository**: Create / Update / LatestForInstall (newest per install, ErrNotFound on miss).

**Verified:** migration applies on **real MySQL** (all 17 columns correct); build/vet clean; repo sqlmock tests pass (create, latest-newest, not-found).

Phase 3b wires the warmup goroutine to create+finalize a run + adds `GET .../cache/warmup`; resume-from-cursor + agent batching follow. Migration number 000225 is next after 000224 (account_skeleton) — no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)