### PR TITLE
feat(cache): persist warmup runs + GET /cache-warmup status (JAB-95 Phase 3b)

### DIFF
--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -85,6 +85,7 @@ func RegisterApplicationRoutes(g *gin.RouterGroup, cfg ApplicationHandlerConfig)
 	apps.GET("/:id/cache-settings", wp.getCacheSettings) // GH #612/#616/#618
 	apps.PUT("/:id/cache-settings", wp.setCacheSettings)
 	apps.POST("/:id/cache-warmup", wp.cacheWarmup) // GH #615
+	apps.GET("/:id/cache-warmup", wp.getCacheWarmup)   // JAB-95 Phase 3: last warmup run
 	apps.GET("/cache-profiles", wp.cacheProfiles) // GH #618
 	apps.GET("/:id/cache-stats", wp.cacheStats) // GH #617
 	// GH #617: admin cache overview — cache-enabled domains ranked by page-cache

--- a/panel-api/internal/api/applications_cache_settings.go
+++ b/panel-api/internal/api/applications_cache_settings.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"math"
 	"net/http"
@@ -24,7 +25,9 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 const (
@@ -189,10 +192,22 @@ func (h *wordPressHandler) cacheWarmup(c *gin.Context) {
 		trimPath = path.Join(dom.DocRoot, inst.Subdirectory)
 	}
 	repo := h.cfg.ApplicationInstalls
+	runsRepo := h.cfg.CacheWarmupRuns
 	go func() {
 		wctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
+		// JAB-95 Phase 3: record a durable run (running -> done/failed).
+		var run *models.CacheWarmupRun
+		if runsRepo != nil {
+			started := time.Now().UTC()
+			run = &models.CacheWarmupRun{ID: ids.NewULID(), InstallID: installID, Host: host, State: models.CacheWarmupStateRunning, Requested: 100, StartedAt: &started}
+			_ = runsRepo.Create(context.Background(), run)
+		}
 		res, err := agent.Call(wctx, "nginx.cache_warmup", map[string]any{"host": host, "max_urls": 100})
+		if run != nil {
+			finalizeCacheWarmupRun(run, res, err)
+			_ = runsRepo.Update(context.Background(), run)
+		}
 		// GH #612: enforce the object-cache budget after warmup (which adds keys).
 		if osUser != "" {
 			// JAB-59: surface trim failures instead of swallowing them — the
@@ -223,6 +238,67 @@ func (h *wordPressHandler) cacheWarmup(c *gin.Context) {
 		}
 	}()
 	c.JSON(http.StatusAccepted, gin.H{"ok": true, "warming": host})
+}
+
+// finalizeCacheWarmupRun stamps a run from the agent's nginx.cache_warmup
+// response (JAB-95 Phase 1 stats). A transport error -> failed; otherwise done
+// with the warmed/attempted/failed counts. (JAB-95 Phase 3)
+func finalizeCacheWarmupRun(run *models.CacheWarmupRun, raw json.RawMessage, callErr error) {
+	now := time.Now().UTC()
+	run.FinishedAt = &now
+	if callErr != nil {
+		run.State = models.CacheWarmupStateFailed
+		run.FirstError = truncateWarmupErr(callErr.Error())
+		return
+	}
+	var r cacheWarmupResult
+	if json.Unmarshal(raw, &r) == nil {
+		run.Requested = r.Requested
+		run.ClampedTo = r.ClampedTo
+		run.Total = r.Attempted
+		run.CursorPos = r.Attempted
+		run.Attempted = r.Attempted
+		run.Warmed = r.Warmed
+		run.Skipped = r.Skipped
+		run.Failed = r.Failed
+		run.FirstError = truncateWarmupErr(r.FirstError)
+	}
+	run.State = models.CacheWarmupStateDone
+}
+
+func truncateWarmupErr(s string) string {
+	if len(s) > 1024 {
+		return s[:1024]
+	}
+	return s
+}
+
+// getCacheWarmup returns the install's most recent warmup run for the UI
+// (JAB-95 Phase 3). Null run when none has ever run.
+func (h *wordPressHandler) getCacheWarmup(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	inst := h.loadOwnedInstall(c, claims)
+	if inst == nil {
+		return
+	}
+	if h.cfg.CacheWarmupRuns == nil {
+		c.JSON(http.StatusOK, gin.H{"run": nil})
+		return
+	}
+	run, err := h.cfg.CacheWarmupRuns.LatestForInstall(c.Request.Context(), inst.ID)
+	if errors.Is(err, repository.ErrNotFound) {
+		c.JSON(http.StatusOK, gin.H{"run": nil})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "warmup_lookup_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"run": run})
 }
 
 // cacheProfiles returns the static cache-profile registry for the UI (GH #618).

--- a/panel-api/internal/api/cache_warmup_run_finalize_test.go
+++ b/panel-api/internal/api/cache_warmup_run_finalize_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-95 Phase 3: a successful warmup response stamps the run done with the
+// agent's stats.
+func TestFinalizeCacheWarmupRun_Success(t *testing.T) {
+	run := &models.CacheWarmupRun{State: models.CacheWarmupStateRunning}
+	raw, _ := json.Marshal(map[string]any{
+		"requested": 100, "clamped_to": 50, "attempted": 47,
+		"warmed": 45, "skipped": 0, "failed": 2, "first_error": "/x -> 500",
+	})
+	finalizeCacheWarmupRun(run, raw, nil)
+
+	if run.State != models.CacheWarmupStateDone {
+		t.Fatalf("state=%q, want done", run.State)
+	}
+	if run.ClampedTo != 50 || run.Attempted != 47 || run.Warmed != 45 || run.Failed != 2 {
+		t.Errorf("stats not mapped: %+v", run)
+	}
+	if run.Total != 47 || run.CursorPos != 47 {
+		t.Errorf("total/cursor should track attempted: total=%d cursor=%d", run.Total, run.CursorPos)
+	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at should be set")
+	}
+}
+
+// A transport error stamps the run failed with the error text.
+func TestFinalizeCacheWarmupRun_Error(t *testing.T) {
+	run := &models.CacheWarmupRun{State: models.CacheWarmupStateRunning}
+	finalizeCacheWarmupRun(run, nil, errors.New("agent unavailable"))
+	if run.State != models.CacheWarmupStateFailed {
+		t.Fatalf("state=%q, want failed", run.State)
+	}
+	if run.FirstError != "agent unavailable" {
+		t.Errorf("first_error=%q", run.FirstError)
+	}
+	if run.FinishedAt == nil {
+		t.Error("finished_at should be set")
+	}
+}

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -46,6 +46,9 @@ type ApplicationHandlerConfig struct {
 	CacheTokenSecret string
 	// CacheTokenSalts persists the per-tenant token salt (Gitea #415).
 	CacheTokenSalts repository.CacheTokenSaltRepository
+	// CacheWarmupRuns persists warmup run records (JAB-95 Phase 3). Optional;
+	// nil disables run recording (warmup still runs).
+	CacheWarmupRuns repository.CacheWarmupRunRepository
 	// Reconciler re-renders the domain vhost after the nginx page-cache flag
 	// flips (mirrors DomainCacheHandlerConfig.Reconciler). Optional.
 	Reconciler DNSScheduler

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1111,6 +1111,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Reconciler:          deps.Reconciler,
 				CacheTokenSecret:    cacheHMACSecret(),
 				CacheTokenSalts:     repository.NewCacheTokenSaltRepository(deps.DB),
+				CacheWarmupRuns:     repository.NewCacheWarmupRunRepository(deps.DB),
 			}
 			api.RegisterApplicationRoutes(v1, appCfg)
 


### PR DESCRIPTION
Wires the `cache_warmup_runs` schema (Phase 3a, #484) to the warmup path so status is **durable and queryable** — feeding the Phase 5 UI.

- `ApplicationHandlerConfig` gains a `CacheWarmupRuns` repo (optional; nil = no recording, warmup still runs); wired in `app.go` from `deps.DB`.
- **POST `/:id/cache-warmup`** ('Warm now'): create a run (`running`) before the agent call, then `finalizeCacheWarmupRun` stamps it `done`/`failed` with the Phase 1 stats (requested/clamped_to/attempted/warmed/skipped/failed/first_error) + cursor.
- **GET `/:id/cache-warmup`**: latest run for the install (null when none has run).

Tests: finalize maps success stats (done + counts, total/cursor track attempted) and error (failed + message). `build`/`vet` clean.

Scope: the auto-warmup-on-enable goroutines still only log — recording those is a small follow-up. Resume-from-cursor + agent batching are Phase 3c; Phase 5 is the UI that reads this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)