### PR TITLE
feat(cache): warmup pacing + circuit breaker (JAB-95 Phase 4)

### DIFF
--- a/panel-agent/internal/commands/nginx_cache_warmup.go
+++ b/panel-agent/internal/commands/nginx_cache_warmup.go
@@ -30,6 +30,10 @@ const (
 	cacheWarmupDefaultMax = 20
 	cacheWarmupHardMax    = 50
 	cacheWarmupPerURL     = 12 * time.Second
+	// JAB-95 Phase 4: pace requests so warmup can't spike PHP-FPM, and stop
+	// after too many consecutive failures so a struggling site isn't hammered.
+	cacheWarmupPaceDelay     = 150 * time.Millisecond
+	cacheWarmupMaxConsecFail = 5
 )
 
 // locRe pulls URLs out of a sitemap (both urlset <loc> and sitemapindex <loc>).
@@ -266,15 +270,17 @@ func nginxCacheWarmupHandler(ctx context.Context, params json.RawMessage) (any, 
 	clampedTo := max
 
 	start := time.Now()
-	var attempted, warmed, failed int
+	var attempted, warmed, failed, consecFail int
 	var firstError string
 	note := func(path string, code int) {
 		attempted++
 		if code >= 200 && code < 400 {
 			warmed++
+			consecFail = 0
 			return
 		}
 		failed++
+		consecFail++
 		if firstError == "" {
 			firstError = fmt.Sprintf("%s -> %d", path, code)
 		}
@@ -284,6 +290,7 @@ func nginxCacheWarmupHandler(ctx context.Context, params json.RawMessage) (any, 
 	// pages most likely to be hit, not just the first sitemap entries.
 	note("/", warmupFetch(ctx, host, "/"))
 	warmed2 := 0
+	circuitBroken := false
 	for _, path := range prioritizeWarmPaths(sitemapEntries(ctx, host)) {
 		if ctx.Err() != nil || warmed2 >= max-1 {
 			break
@@ -291,20 +298,33 @@ func nginxCacheWarmupHandler(ctx context.Context, params json.RawMessage) (any, 
 		if path == "/" {
 			continue // homepage already warmed above
 		}
+		// JAB-95 Phase 4: stop early if the site keeps failing, so warmup
+		// doesn't pound a struggling backend through the whole list.
+		if consecFail >= cacheWarmupMaxConsecFail {
+			circuitBroken = true
+			firstError = fmt.Sprintf("circuit-broken after %d consecutive failures (first: %s)", consecFail, firstError)
+			break
+		}
+		// Pace so warmup never spikes PHP-FPM.
+		select {
+		case <-time.After(cacheWarmupPaceDelay):
+		case <-ctx.Done():
+		}
 		note(path, warmupFetch(ctx, host, path))
 		warmed2++
 	}
 	return map[string]any{
-		"ok":          true,
-		"host":        host,
-		"requested":   requested,
-		"clamped_to":  clampedTo,
-		"attempted":   attempted,
-		"warmed":      warmed,
-		"skipped":     0, // freshness detection lands in a later phase.
-		"failed":      failed,
-		"first_error": firstError,
-		"duration_ms": time.Since(start).Milliseconds(),
+		"ok":             true,
+		"host":           host,
+		"requested":      requested,
+		"clamped_to":     clampedTo,
+		"attempted":      attempted,
+		"warmed":         warmed,
+		"skipped":        0, // freshness detection lands in a later phase.
+		"failed":         failed,
+		"first_error":    firstError,
+		"circuit_broken": circuitBroken,
+		"duration_ms":    time.Since(start).Milliseconds(),
 	}, nil
 }
 

--- a/panel-agent/internal/commands/nginx_cache_warmup_circuit_test.go
+++ b/panel-agent/internal/commands/nginx_cache_warmup_circuit_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// JAB-95 Phase 4: a site that keeps failing trips the circuit breaker instead
+// of hammering the whole URL list.
+func TestWarmupCircuitBreak(t *testing.T) {
+	origFetch, origBody := warmupFetch, warmupFetchBody
+	t.Cleanup(func() { warmupFetch = origFetch; warmupFetchBody = origBody })
+
+	var sb strings.Builder
+	sb.WriteString("<urlset>")
+	for i := 0; i < 30; i++ {
+		sb.WriteString(fmt.Sprintf("<url><loc>https://ex.com/p%d</loc></url>", i))
+	}
+	sb.WriteString("</urlset>")
+	sitemap := sb.String()
+
+	warmupFetchBody = func(_ context.Context, _ string, entry string) string {
+		if strings.HasSuffix(entry, ".xml") {
+			return sitemap
+		}
+		return ""
+	}
+	warmupFetch = func(_ context.Context, _ string, _ string) int { return 500 } // always fail
+
+	params, _ := json.Marshal(map[string]any{"host": "ex.com", "max_urls": 50})
+	res, err := nginxCacheWarmupHandler(context.Background(), params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := res.(map[string]any)
+	if m["circuit_broken"] != true {
+		t.Fatalf("circuit_broken=%v, want true", m["circuit_broken"])
+	}
+	if att := m["attempted"].(int); att > cacheWarmupMaxConsecFail+2 {
+		t.Fatalf("attempted=%d, breaker should stop near %d, not the whole list", att, cacheWarmupMaxConsecFail)
+	}
+	if !strings.Contains(m["first_error"].(string), "circuit-broken") {
+		t.Errorf("first_error should note the break: %q", m["first_error"])
+	}
+}
+
+// A healthy site warms without tripping the breaker.
+func TestWarmupNoBreakOnSuccess(t *testing.T) {
+	origFetch, origBody := warmupFetch, warmupFetchBody
+	t.Cleanup(func() { warmupFetch = origFetch; warmupFetchBody = origBody })
+	warmupFetchBody = func(_ context.Context, _ string, entry string) string {
+		if strings.HasSuffix(entry, ".xml") {
+			return "<urlset><url><loc>https://ex.com/a</loc></url><url><loc>https://ex.com/b</loc></url></urlset>"
+		}
+		return ""
+	}
+	warmupFetch = func(_ context.Context, _ string, _ string) int { return 200 }
+	params, _ := json.Marshal(map[string]any{"host": "ex.com", "max_urls": 50})
+	res, _ := nginxCacheWarmupHandler(context.Background(), params)
+	m := res.(map[string]any)
+	if m["circuit_broken"] != false {
+		t.Fatalf("circuit_broken=%v, want false on all-success", m["circuit_broken"])
+	}
+	if m["warmed"].(int) != 3 { // homepage + /a + /b
+		t.Errorf("warmed=%d, want 3", m["warmed"])
+	}
+}


### PR DESCRIPTION
Warmup fetched URLs back-to-back and would grind through the **entire list even when the site was failing every request**, piling load on a struggling PHP-FPM.

- **Pace:** a 150ms ctx-aware delay between fetches so warmup can't spike FPM.
- **Circuit breaker:** after 5 consecutive failures, stop early and report `circuit_broken=true` with a `first_error` explaining it, instead of hammering the whole list. A success resets the counter.

Tests: an all-500 site trips the breaker near the threshold (not the full list); an all-200 site warms fully without tripping. `build`/`vet` clean.

Phase 4 of `plans/jab95-adaptive-warmup.md`. Only Phase 5 (UI) + Phase 3c (resume/agent-batching) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)