### PR TITLE
fix(migration): surface SSH connect errors + catch Ubuntu password-off (GH #327)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -1224,7 +1224,7 @@ func (h *adminMigrationsHandler) discoverAccounts(c *gin.Context) {
 
 	sess, err := disc.Connect(ctx, job.SourceHost, job.SourceUser, migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 	if err != nil {
-		respondAgentErr(c, "connect_failed", err)
+		respondMigrateConnectErr(c, err)
 		return
 	}
 	defer func() { _ = disc.Close(ctx, sess) }()
@@ -1387,7 +1387,7 @@ func (h *adminMigrationsHandler) accountSizeProbe(c *gin.Context) {
 
 	sess, err := disc.Connect(ctx, job.SourceHost, job.SourceUser, migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 	if err != nil {
-		respondAgentErr(c, "connect_failed", err)
+		respondMigrateConnectErr(c, err)
 		return
 	}
 	defer func() { _ = disc.Close(ctx, sess) }()

--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -90,7 +90,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 	case models.MigrationSourceWordPressSSH:
 		sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUserOrRoot(job.SourceUser), secret, allowPrivate)
 		if err != nil {
-			respondAgentErr(c, "connect_failed", err)
+			respondMigrateConnectErr(c, err)
 			return
 		}
 		defer sess.Close()
@@ -117,7 +117,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 	}
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
-		respondAgentErr(c, "connect_failed", err)
+		respondMigrateConnectErr(c, err)
 		return
 	}
 	defer func() { _ = d.Close(ctx, sess) }()
@@ -185,7 +185,7 @@ func (h *adminMigrationsHandler) describeAccount(c *gin.Context) {
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
-		respondAgentErr(c, "connect_failed", err)
+		respondMigrateConnectErr(c, err)
 		return
 	}
 	defer func() { _ = d.Close(ctx, sess) }()

--- a/panel-api/internal/api/error_response.go
+++ b/panel-api/internal/api/error_response.go
@@ -23,6 +23,17 @@ func respondAgentErr(c *gin.Context, code string, err error) {
 // respondAgentErrorStatus is respondAgentError for the handlers whose error
 // envelope also carries a top-level "status":"error" field (e.g. the backups
 // endpoints). Same logging + leak-suppression, preserved wire shape.
+// respondMigrateConnectErr surfaces a migration SSH-connect failure WITH its
+// detail. Unlike respondAgentErr, the error here is the panel's OWN migrate
+// connector talking to the SOURCE host over SSH (not the local root agent), so
+// the message is an actionable SSH error (auth rejected, host key, dial) the
+// admin needs to fix their credentials, not root daemon stderr. Mirrors the
+// tenant pull-source path which already returns the detail. (GH #327)
+func respondMigrateConnectErr(c *gin.Context, err error) {
+	logAgentError(c, "connect_failed", err)
+	c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": err.Error()})
+}
+
 func respondAgentErrStatus(c *gin.Context, code string, err error) {
 	logAgentError(c, code, err)
 	c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": code})

--- a/panel-api/internal/api/tenant_migrations.go
+++ b/panel-api/internal/api/tenant_migrations.go
@@ -310,7 +310,7 @@ func (h *tenantMigrationsHandler) scanWP(c *gin.Context) {
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
 	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, secret, allowPrivate)
 	if err != nil {
-		respondAgentErr(c, "connect_failed", err)
+		respondMigrateConnectErr(c, err)
 		return
 	}
 	defer sess.Close()

--- a/panel-api/internal/migrate/cpanel/discover.go
+++ b/panel-api/internal/migrate/cpanel/discover.go
@@ -113,7 +113,7 @@ func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migr
 	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
 	if err != nil {
 		conn.Close()
-		if strings.Contains(err.Error(), "attempted methods [none]") {
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
 			return nil, fmt.Errorf("cpanel.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
 		}
 		return nil, fmt.Errorf("cpanel.Connect: ssh handshake: %w", err)

--- a/panel-api/internal/migrate/directadmin/discover.go
+++ b/panel-api/internal/migrate/directadmin/discover.go
@@ -115,7 +115,7 @@ func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migr
 		// means we offered something (e.g. password) but the
 		// server didn't accept that method — usually source has
 		// PasswordAuthentication=no. Surface a concrete hint.
-		if strings.Contains(err.Error(), "attempted methods [none]") {
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
 			return nil, fmt.Errorf("directadmin.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
 		}
 		return nil, fmt.Errorf("directadmin.Connect: ssh handshake: %w", err)

--- a/panel-api/internal/migrate/hestiacp/discover.go
+++ b/panel-api/internal/migrate/hestiacp/discover.go
@@ -97,7 +97,7 @@ func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migr
 	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
 	if err != nil {
 		conn.Close()
-		if strings.Contains(err.Error(), "attempted methods [none]") {
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
 			return nil, fmt.Errorf("hestiacp.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
 		}
 		return nil, fmt.Errorf("hestiacp.Connect: ssh handshake: %w", err)

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -109,7 +109,7 @@ func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migr
 	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
 	if err != nil {
 		conn.Close()
-		if strings.Contains(err.Error(), "attempted methods [none]") {
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
 			return nil, fmt.Errorf("plesk.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
 		}
 		return nil, fmt.Errorf("plesk.Connect: ssh handshake: %w", err)


### PR DESCRIPTION
HestiaCP migration on an **Ubuntu 24.04** source failed with a bare `Account discovery failed / connect_failed` and no reason, while a **Debian 12** source worked. Two bugs, both a swallowed error:

1. **The wizard showed only the code.** The real SSH error was logged server-side but never sent to the client. `respondAgentErr` suppresses detail by design (JAB-114 — agent errors carry root-daemon stderr), but a **migrate** connect error is the panel's *own* SSH client talking to the **source** host, not the local agent — an actionable SSH error (auth rejected, host key, dial), safe to show an admin. New `respondMigrateConnectErr` returns the detail; the admin test-connection + discovery + tenant pull-source paths use it (mirrors the tenant path that already did).

2. **The auth-failure hint missed Ubuntu.** hestiacp/plesk/cpanel/directadmin only matched `attempted methods [none]`. Ubuntu 24.04 ships `PasswordAuthentication no` by default, so a password attempt yields `[none password]` → no match → no hint. Broadened to the robust form `wordpressssh` already uses (`unable to authenticate` / `no supported methods remain`), so it now tells the operator to use an SSH key.

`build`/`vet` clean; migrate + api tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)