### PR TITLE
feat(ui): surface CLI-only recovery runbooks in admin Support (JAB-14)

### DIFF
--- a/panel-ui/src/config/cli-only-runbooks.test.ts
+++ b/panel-ui/src/config/cli-only-runbooks.test.ts
@@ -1,0 +1,53 @@
+// Drift guard for JAB-14: the admin Support page renders the CLI-only runbook
+// list from cli-only-runbooks.ts, but the recorded intent lives in
+// docs/operations/cli-only-commands.md. If a command is added/renamed/removed
+// in the doc without updating the structured source (or vice versa), the GUI
+// would quietly show a stale set. This test fails on that drift.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { ALL_CLI_ONLY_RUNBOOKS } from "./cli-only-runbooks";
+
+// Vitest runs with cwd = panel-ui/ (the vite.config.ts dir); the doc lives at
+// the repo root under docs/operations/.
+const DOC_PATH = resolve(
+  process.cwd(),
+  "../docs/operations/cli-only-commands.md",
+);
+
+const doc = readFileSync(DOC_PATH, "utf8");
+
+describe("cli-only runbooks source matches the doc", () => {
+  it("every structured runbook command appears in cli-only-commands.md", () => {
+    const missing = ALL_CLI_ONLY_RUNBOOKS.filter(
+      (rb) => !doc.includes(rb.command),
+    ).map((rb) => rb.command);
+    expect(
+      missing,
+      `commands in cli-only-runbooks.ts but not in the doc: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("every command backticked in the doc is present in the structured source", () => {
+    // Pull `jabali`-ish subcommands out of the doc's markdown tables. The doc
+    // wraps each in backticks and some cells list two (e.g. `audit verify` /
+    // `audit prune`), so match every backtick span in the two command columns.
+    const known = new Set(ALL_CLI_ONLY_RUNBOOKS.map((rb) => rb.command));
+    const docCommands = new Set<string>();
+    for (const line of doc.split("\n")) {
+      // Only the command tables have a leading "| `cmd`" cell.
+      const m = /^\|\s*`([^`]+)`(?:\s*\/\s*`([^`]+)`)?\s*\|/.exec(line);
+      if (!m) continue;
+      docCommands.add(m[1]);
+      if (m[2]) docCommands.add(m[2]);
+    }
+    // Sanity: the doc parse found the tables at all.
+    expect(docCommands.size).toBeGreaterThan(10);
+    const unlisted = [...docCommands].filter((c) => !known.has(c));
+    expect(
+      unlisted,
+      `commands in the doc tables but not in cli-only-runbooks.ts: ${unlisted.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/panel-ui/src/config/cli-only-runbooks.ts
+++ b/panel-ui/src/config/cli-only-runbooks.ts
@@ -1,0 +1,250 @@
+// CLI-only operator runbooks — the single source of truth the admin Support
+// page renders. Mirrors docs/operations/cli-only-commands.md; a drift test
+// (cli-only-runbooks.test.ts) asserts every `command` below still appears in
+// that doc so the GUI list can't silently diverge from the recorded intent.
+//
+// These are deliberately read-only reference entries, NOT action buttons. The
+// doc's own GUI note is explicit: the admin UI should surface where the
+// recovery levers live, not grow one-click buttons for destructive ops.
+
+export type RunbookCategory = "escape-hatch" | "gui-candidate";
+
+export type RunbookRisk =
+  | "destructive"
+  | "recovery"
+  | "one-time"
+  | "key-material"
+  | "maintenance"
+  | "low";
+
+export interface CliRunbook {
+  // The `jabali …` subcommand, verbatim as it appears in the doc (the drift
+  // test matches on this substring).
+  command: string;
+  // Source file that implements it, for operators reading the code.
+  file: string;
+  category: RunbookCategory;
+  risk: RunbookRisk;
+  // Whether the command supports a `--dry-run` preview before it mutates.
+  dryRun: boolean;
+  // One-line purpose / why it stays CLI-only. Condensed from the doc; no new
+  // claims beyond what the doc records.
+  summary: string;
+  // Associated ADR, when the doc cites one.
+  adr?: string;
+}
+
+// Intentionally CLI-only: escape hatches, recovery, one-time migrations, and
+// key-material ops that don't belong behind a click.
+export const CLI_ONLY_ESCAPE_HATCHES: readonly CliRunbook[] = [
+  {
+    command: "admin backfill-usernames",
+    file: "backfill_usernames_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "One-time data backfill; idempotent but bulk-mutating.",
+  },
+  {
+    command: "admin purge-orphan-identities",
+    file: "purge_orphan_identities_cmd.go",
+    category: "escape-hatch",
+    risk: "destructive",
+    dryRun: false,
+    summary: "Destructive Kratos identity GC; run after a manual cleanup.",
+  },
+  {
+    command: "admin rebuild-kratos",
+    file: "kratos_rebuild_cmd.go",
+    category: "escape-hatch",
+    risk: "recovery",
+    dryRun: false,
+    summary: "Disaster recovery — reprovisions the identity store.",
+  },
+  {
+    command: "admin relabel-identifiers",
+    file: "relabel_identifiers_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "One-time identifier migration.",
+  },
+  {
+    command: "admin slice-cutover",
+    file: "admin_slice_cutover.go",
+    category: "escape-hatch",
+    risk: "destructive",
+    dryRun: true,
+    summary:
+      "FPM master to per-user-slice cutover; masks distro units. Run --dry-run first.",
+  },
+  {
+    command: "sso rotate-key",
+    file: "sso_rotate_key.go",
+    category: "escape-hatch",
+    risk: "key-material",
+    dryRun: false,
+    summary: "Rotates SSO signing key material + reloads; needs careful rollback.",
+  },
+  {
+    command: "sso prune-tokens",
+    file: "sso_rotate_key.go",
+    category: "escape-hatch",
+    risk: "maintenance",
+    dryRun: false,
+    summary: "Maintenance GC; also timer-backed (jabali-sso-reap).",
+  },
+  {
+    command: "migrate pull-source",
+    file: "migrate_pull_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "Migration-wizard internal sub-step.",
+  },
+  {
+    command: "migrate reap-secrets",
+    file: "migrate_reap_cmd.go",
+    category: "escape-hatch",
+    risk: "maintenance",
+    dryRun: false,
+    summary: "Migration secret GC.",
+  },
+  {
+    command: "domain prune-orphans",
+    file: "domain_orphan_prune_cmd.go",
+    category: "escape-hatch",
+    risk: "destructive",
+    dryRun: false,
+    summary: "Destructive orphan-vhost cleanup.",
+  },
+  {
+    command: "pdns backfill",
+    file: "pdns_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "One-time PowerDNS backfill.",
+    adr: "ADR-0047",
+  },
+  {
+    command: "appsec render-config",
+    file: "appsec_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "Install-time config render; not an operator action.",
+  },
+  {
+    command: "ufw migrate-ip-bans",
+    file: "ufw_cmd.go",
+    category: "escape-hatch",
+    risk: "one-time",
+    dryRun: false,
+    summary: "One-time M43 ban migration.",
+    adr: "ADR-0089",
+  },
+  {
+    command: "audit verify",
+    file: "audit CLI",
+    category: "escape-hatch",
+    risk: "recovery",
+    dryRun: false,
+    summary:
+      "Hash-chain integrity verification — a forensic operator action; a GUI 'chain valid' button is a weak assurance a compromised panel could forge.",
+  },
+  {
+    command: "audit prune",
+    file: "audit CLI",
+    category: "escape-hatch",
+    risk: "destructive",
+    dryRun: false,
+    summary: "Destructive audit-event retention pruning.",
+  },
+  {
+    command: "nspawn build",
+    file: "nspawn CLI",
+    category: "escape-hatch",
+    risk: "maintenance",
+    dryRun: false,
+    summary: "Sealed nspawn image build (minutes-long, disk-heavy).",
+  },
+  {
+    command: "nspawn prune",
+    file: "nspawn CLI",
+    category: "escape-hatch",
+    risk: "destructive",
+    dryRun: false,
+    summary: "Destructive nspawn image prune.",
+  },
+];
+
+// GUI candidates: backend verb already ships, only a button is missing. Listed
+// here so operators can find the CLI today; a future GUI action may replace the
+// entry (starting with domain email-dkim-rotate per the doc's recommendation).
+export const CLI_ONLY_GUI_CANDIDATES: readonly CliRunbook[] = [
+  {
+    command: "domain email-dkim-rotate",
+    file: "domain.email_dkim_rotate",
+    category: "gui-candidate",
+    risk: "low",
+    dryRun: false,
+    summary:
+      "Best candidate — DKIM rotation is a normal per-domain mail op; verb + reconciler already converge the new key.",
+  },
+  {
+    command: "apparmor flip-mature",
+    file: "security.apparmor.set_mode",
+    category: "gui-candidate",
+    risk: "low",
+    dryRun: true,
+    summary:
+      "Graduate complain to enforce. Risk: premature enforce can break a profile.",
+  },
+  {
+    command: "per-user-egress flip-mature",
+    file: "user.egress.apply",
+    category: "gui-candidate",
+    risk: "low",
+    dryRun: true,
+    summary: "Graduate the egress firewall from log to enforce.",
+  },
+  {
+    command: "malware-purge",
+    file: "security.malware.quarantine.delete",
+    category: "gui-candidate",
+    risk: "low",
+    dryRun: false,
+    summary:
+      "Per-item quarantine delete already exists in the UI; only a bulk 'purge all' is missing.",
+  },
+];
+
+export const ALL_CLI_ONLY_RUNBOOKS: readonly CliRunbook[] = [
+  ...CLI_ONLY_ESCAPE_HATCHES,
+  ...CLI_ONLY_GUI_CANDIDATES,
+];
+
+// Where the full doc lives, for a "read the source" deep link. Served from the
+// docs site; the repo path is docs/operations/cli-only-commands.md.
+export const CLI_ONLY_DOC_URL =
+  "https://jabali-panel.com/docs/operations/cli-only-commands/";
+
+export const RISK_LABELS: Record<RunbookRisk, string> = {
+  destructive: "Destructive",
+  recovery: "Recovery",
+  "one-time": "One-time",
+  "key-material": "Key material",
+  maintenance: "Maintenance",
+  low: "Low risk",
+};
+
+// AntD Tag colors per risk tier.
+export const RISK_COLORS: Record<RunbookRisk, string> = {
+  destructive: "red",
+  recovery: "volcano",
+  "one-time": "gold",
+  "key-material": "magenta",
+  maintenance: "blue",
+  low: "green",
+};

--- a/panel-ui/src/shells/admin/support/CliOnlyRunbooks.tsx
+++ b/panel-ui/src/shells/admin/support/CliOnlyRunbooks.tsx
@@ -1,0 +1,127 @@
+// CliOnlyRunbooks — JAB-14. A read-only reference of the `jabali …` subcommands
+// that have no GUI affordance (escape hatches, recovery, one-time migrations,
+// key-material ops). Per docs/operations/cli-only-commands.md, the admin UI
+// should surface WHERE the recovery levers live, not grow one-click buttons for
+// destructive ops — so this is a table of copyable commands + risk, never an
+// action control. The list is sourced from config/cli-only-runbooks.ts and a
+// drift test keeps it in sync with the doc.
+import { Card, Space, Table, Tag, Tooltip, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
+
+import { CodeOutlined, ExportOutlined, WarningOutlined } from "@icons";
+
+import {
+  ALL_CLI_ONLY_RUNBOOKS,
+  CLI_ONLY_DOC_URL,
+  RISK_COLORS,
+  RISK_LABELS,
+  type CliRunbook,
+} from "../../../config/cli-only-runbooks";
+
+const CATEGORY_LABELS: Record<CliRunbook["category"], string> = {
+  "escape-hatch": "Escape hatch",
+  "gui-candidate": "GUI candidate",
+};
+
+const columns: ColumnsType<CliRunbook> = [
+  {
+    title: "Command",
+    dataIndex: "command",
+    key: "command",
+    render: (command: string) => (
+      <Typography.Text
+        code
+        copyable={{ text: `jabali ${command}` }}
+        style={{ whiteSpace: "nowrap" }}
+      >
+        jabali {command}
+      </Typography.Text>
+    ),
+  },
+  {
+    title: "Risk",
+    dataIndex: "risk",
+    key: "risk",
+    filters: Object.entries(RISK_LABELS).map(([value, text]) => ({ text, value })),
+    onFilter: (value, rb) => rb.risk === value,
+    render: (risk: CliRunbook["risk"]) => (
+      <Tag color={RISK_COLORS[risk]}>{RISK_LABELS[risk]}</Tag>
+    ),
+  },
+  {
+    title: "Dry-run",
+    dataIndex: "dryRun",
+    key: "dryRun",
+    render: (dryRun: boolean) =>
+      dryRun ? (
+        <Tag color="green">--dry-run</Tag>
+      ) : (
+        <Typography.Text type="secondary">—</Typography.Text>
+      ),
+  },
+  {
+    title: "Category",
+    dataIndex: "category",
+    key: "category",
+    filters: Object.entries(CATEGORY_LABELS).map(([value, text]) => ({ text, value })),
+    onFilter: (value, rb) => rb.category === value,
+    render: (category: CliRunbook["category"]) => (
+      <Tag color={category === "gui-candidate" ? "cyan" : "default"}>
+        {CATEGORY_LABELS[category]}
+      </Tag>
+    ),
+  },
+  {
+    title: "Purpose",
+    dataIndex: "summary",
+    key: "summary",
+    render: (summary: string, rb: CliRunbook) => (
+      <Space direction="vertical" size={2}>
+        <Typography.Text>{summary}</Typography.Text>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          <CodeOutlined /> {rb.file}
+          {rb.adr ? ` · ${rb.adr}` : ""}
+        </Typography.Text>
+      </Space>
+    ),
+  },
+];
+
+export const CliOnlyRunbooks = () => (
+  <Card
+    style={{ marginTop: 24 }}
+    title={
+      <Space>
+        <WarningOutlined style={{ color: "#faad14" }} />
+        <span>CLI-only recovery runbooks</span>
+      </Space>
+    }
+    extra={
+      <Typography.Link
+        href={CLI_ONLY_DOC_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Full doc <ExportOutlined />
+      </Typography.Link>
+    }
+  >
+    <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+      These operations run only from a root shell on the host. Most are
+      deliberate escape hatches — destructive, one-time migrations, or
+      key-material ops that don't belong behind a click. Run any{" "}
+      <Tooltip title="Preview the effect before it mutates anything">
+        <Tag color="green">--dry-run</Tag>
+      </Tooltip>{" "}
+      command first, and read the full doc for prerequisites and rollback notes.
+    </Typography.Paragraph>
+    <Table<CliRunbook>
+      rowKey="command"
+      size="small"
+      columns={columns}
+      dataSource={[...ALL_CLI_ONLY_RUNBOOKS]}
+      pagination={false}
+      scroll={{ x: "max-content" }}
+    />
+  </Card>
+);

--- a/panel-ui/src/shells/admin/support/SupportPage.tsx
+++ b/panel-ui/src/shells/admin/support/SupportPage.tsx
@@ -15,6 +15,7 @@ import {
 
 import { SUPPORT_LINKS } from "../../../config/support-links";
 import { DiagnosticReportModal } from "./DiagnosticReportModal";
+import { CliOnlyRunbooks } from "./CliOnlyRunbooks";
 
 interface CardSpec {
   key: string;
@@ -99,6 +100,8 @@ export const SupportPage = () => {
           </Col>
         ))}
       </Row>
+
+      <CliOnlyRunbooks />
 
       <DiagnosticReportModal
         open={modalOpen}


### PR DESCRIPTION
## JAB-14 — surface CLI-only recovery/maintenance runbooks from the GUI

The GUI/CLI gap audit recorded a set of `jabali …` subcommands that are **intentionally CLI-only** (escape hatches, recovery, one-time migrations, key-material ops) in `docs/operations/cli-only-commands.md`. That doc's own GUI note says the admin UI should surface **where** the recovery levers live — **not** grow one-click buttons for destructive ops. Until now the GUI had no such entry point, so an operator hitting a condition like a missing Kratos identity or an nspawn image build had no in-panel pointer to the supported command.

### What this adds
A read-only **"CLI-only recovery runbooks"** section on the admin **Support** page:
- Copyable command (`jabali <cmd>`), risk tier, `--dry-run` availability, source file, ADR.
- Risk + category column filters.
- Link to the full doc for prerequisites and rollback notes.
- **No action controls** — the doc is explicit these must not become GUI buttons.

### Files
- `config/cli-only-runbooks.ts` — structured single source of truth (17 escape hatches + 4 GUI candidates) + risk labels/colors.
- `support/CliOnlyRunbooks.tsx` — read-only AntD table.
- `support/SupportPage.tsx` — renders the section under the support cards.
- `config/cli-only-runbooks.test.ts` — **drift guard**: every structured command must appear in the doc, and every backticked command in the doc's tables must be in the structured source. Satisfies the acceptance criterion "GUI list generated from the same source or covered by a test to prevent drift."

### Acceptance criteria
- [x] Admin Support page has a CLI-only runbooks section.
- [x] Each command lists purpose, risk level, dry-run availability, source, ADR, and links to the doc.
- [x] Destructive commands are **not** exposed as one-click actions.
- [x] Doc and GUI list kept in sync by a drift test.
- [ ] Live visual check on a running admin session (Playwright E2E exercises the Support route in CI).

### Test plan
- [x] `npx vitest run` new drift test — 2 passed.
- [x] `npx tsc -b` clean.
- [x] `npx eslint` on touched files clean.
- [x] `npm run build` (vite) succeeds.