### PR TITLE
feat(limits): admin GUI for per-user limit overrides + effective limits (JAB-12)

### DIFF
--- a/panel-api/internal/api/user_limits.go
+++ b/panel-api/internal/api/user_limits.go
@@ -88,10 +88,29 @@ type userLimitsHandler struct{ cfg UserLimitsHandlerConfig }
 // usageResponse is the shape returned by GET /users/:id/usage. `effective`
 // is the resolved limits (never null). `current` may be nil if the agent
 // is unavailable or the slice has no live processes yet.
+// limitFieldsView is the flat six-field limit shape in snake_case, used for
+// the resolved package limits so the admin Limits card can show "inherited
+// from package" values distinctly from the per-user override and the final
+// effective bundle. Zero means unlimited (same convention as EffectiveLimits).
+type limitFieldsView struct {
+	DiskQuotaMB     uint32 `json:"disk_quota_mb"`
+	CPUQuotaPercent uint32 `json:"cpu_quota_percent"`
+	MemoryLimitMB   uint32 `json:"memory_limit_mb"`
+	IOReadMbps      uint32 `json:"io_read_mbps"`
+	IOWriteMbps     uint32 `json:"io_write_mbps"`
+	MaxTasks        uint32 `json:"max_tasks"`
+}
+
 type usageResponse struct {
 	UserID    string                 `json:"user_id"`
 	Effective limits.EffectiveLimits `json:"effective"`
-	Current   json.RawMessage        `json:"current,omitempty"`
+	// Package is the resolved package-level limits (nil when the user has no
+	// package). Override is the raw per-user override row (nil when none) —
+	// its per-field omitempty distinguishes NULL=inherit from &0=explicit
+	// unlimited, which the GUI needs to label each field's source.
+	Package  *limitFieldsView         `json:"package,omitempty"`
+	Override *models.UserLimitOverride `json:"override,omitempty"`
+	Current  json.RawMessage          `json:"current,omitempty"`
 }
 
 func (h *userLimitsHandler) usage(c *gin.Context) {
@@ -110,11 +129,13 @@ func (h *userLimitsHandler) usage(c *gin.Context) {
 		return
 	}
 
-	effective, _ := h.resolveEffective(c.Request.Context(), user)
+	effective, pkgView, override := h.resolveEffective(c.Request.Context(), user)
 
 	resp := usageResponse{
 		UserID:    userID,
 		Effective: effective,
+		Package:   pkgView,
+		Override:  override,
 	}
 
 	// Call the agent for live usage. Failure is non-fatal — we want
@@ -150,8 +171,9 @@ func (h *userLimitsHandler) usage(c *gin.Context) {
 // passes both through the pure resolver. Returns the zero-value
 // EffectiveLimits on lookup errors — the caller falls back to
 // "unlimited everywhere" which is the safe default.
-func (h *userLimitsHandler) resolveEffective(ctx context.Context, user *models.User) (limits.EffectiveLimits, error) {
+func (h *userLimitsHandler) resolveEffective(ctx context.Context, user *models.User) (limits.EffectiveLimits, *limitFieldsView, *models.UserLimitOverride) {
 	var pkgL *limits.PackageLimits
+	var pkgView *limitFieldsView
 	if user.PackageID != nil && *user.PackageID != "" {
 		pkg, err := h.cfg.Packages.FindByID(ctx, *user.PackageID)
 		if err == nil {
@@ -163,11 +185,21 @@ func (h *userLimitsHandler) resolveEffective(ctx context.Context, user *models.U
 				IOWriteMbps:     pkg.IOWriteMbps,
 				MaxTasks:        pkg.MaxTasks,
 			}
+			pkgView = &limitFieldsView{
+				DiskQuotaMB:     pkg.DiskQuotaMB,
+				CPUQuotaPercent: pkg.CPUQuotaPercent,
+				MemoryLimitMB:   pkg.MemoryLimitMB,
+				IOReadMbps:      pkg.IOReadMbps,
+				IOWriteMbps:     pkg.IOWriteMbps,
+				MaxTasks:        pkg.MaxTasks,
+			}
 		}
 	}
 
 	var ovL *limits.OverrideLimits
-	if ov, err := h.cfg.LimitOverrides.FindByUserID(ctx, user.ID); err == nil {
+	var ovRow *models.UserLimitOverride
+	if ov, err := h.cfg.LimitOverrides.FindByUserID(ctx, user.ID); err == nil && ov != nil {
+		ovRow = ov
 		ovL = &limits.OverrideLimits{
 			DiskQuotaMB:     ov.DiskQuotaMB,
 			CPUQuotaPercent: ov.CPUQuotaPercent,
@@ -177,7 +209,7 @@ func (h *userLimitsHandler) resolveEffective(ctx context.Context, user *models.U
 			MaxTasks:        ov.MaxTasks,
 		}
 	}
-	return limits.Resolve(pkgL, ovL), nil
+	return limits.Resolve(pkgL, ovL), pkgView, ovRow
 }
 
 type overrideRequest struct {

--- a/panel-api/internal/api/user_limits_view_test.go
+++ b/panel-api/internal/api/user_limits_view_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-12: the admin Limits card needs the usage endpoint to expose the package
+// limits and the raw override row alongside the resolved effective bundle so it
+// can label each field's source (inherited vs explicit override, incl. an
+// explicit-unlimited &0). These fakes drive that response shape.
+
+type ulUserRepo struct {
+	repository.UserRepository
+	u *models.User
+}
+
+func (r *ulUserRepo) FindByID(context.Context, string) (*models.User, error) { return r.u, nil }
+
+type ulPackageRepo struct {
+	repository.PackageRepository
+	p *models.HostingPackage
+}
+
+func (r *ulPackageRepo) FindByID(context.Context, string) (*models.HostingPackage, error) {
+	return r.p, nil
+}
+
+type ulOverrideRepo struct {
+	repository.UserLimitOverrideRepository
+	o *models.UserLimitOverride
+}
+
+func (r *ulOverrideRepo) FindByUserID(context.Context, string) (*models.UserLimitOverride, error) {
+	if r.o == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.o, nil
+}
+
+func u32(v uint32) *uint32 { return &v }
+
+func serveUsage(t *testing.T, cfg UserLimitsHandlerConfig) usageResponse {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: true})
+		c.Next()
+	})
+	RegisterUserLimitsRoutes(v1, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/u1/usage", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d %s", rec.Code, rec.Body.String())
+	}
+	var resp usageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestUsage_ExposesPackageAndOverride(t *testing.T) {
+	uname := "alice"
+	pkgID := "pkg1"
+	cfg := UserLimitsHandlerConfig{
+		Users:    &ulUserRepo{u: &models.User{ID: "u1", Username: &uname, PackageID: &pkgID}},
+		Packages: &ulPackageRepo{p: &models.HostingPackage{ID: pkgID, MemoryLimitMB: 512, MaxTasks: 100}},
+		// Override raises memory to 1024 and pins CPU to 0 (explicit unlimited).
+		LimitOverrides: &ulOverrideRepo{o: &models.UserLimitOverride{
+			UserID:          "u1",
+			MemoryLimitMB:   u32(1024),
+			CPUQuotaPercent: u32(0),
+		}},
+	}
+	resp := serveUsage(t, cfg)
+
+	if resp.Package == nil {
+		t.Fatal("package limits must be present when the user has a package")
+	}
+	if resp.Package.MemoryLimitMB != 512 || resp.Package.MaxTasks != 100 {
+		t.Errorf("package view wrong: %+v", resp.Package)
+	}
+	if resp.Override == nil || resp.Override.MemoryLimitMB == nil || *resp.Override.MemoryLimitMB != 1024 {
+		t.Fatalf("override memory must be the explicit 1024, got %+v", resp.Override)
+	}
+	// Override beats package: effective memory is the override 1024, not 512.
+	if resp.Effective.MemoryLimitMB != 1024 {
+		t.Errorf("effective memory: want 1024 (override wins), got %d", resp.Effective.MemoryLimitMB)
+	}
+	// MaxTasks has no override → inherits the package value.
+	if resp.Effective.MaxTasks != 100 {
+		t.Errorf("effective max_tasks: want 100 (inherited), got %d", resp.Effective.MaxTasks)
+	}
+	// CPU override is an explicit &0 (unlimited): the row must carry a non-nil
+	// pointer to 0, so the GUI shows "explicit unlimited", not "inherited".
+	if resp.Override.CPUQuotaPercent == nil || *resp.Override.CPUQuotaPercent != 0 {
+		t.Errorf("cpu override must be explicit &0, got %+v", resp.Override.CPUQuotaPercent)
+	}
+}
+
+func TestUsage_NoPackageNoOverride(t *testing.T) {
+	uname := "bob"
+	cfg := UserLimitsHandlerConfig{
+		Users:          &ulUserRepo{u: &models.User{ID: "u1", Username: &uname}},
+		Packages:       &ulPackageRepo{},
+		LimitOverrides: &ulOverrideRepo{},
+	}
+	resp := serveUsage(t, cfg)
+	if resp.Package != nil {
+		t.Errorf("no package → package must be nil, got %+v", resp.Package)
+	}
+	if resp.Override != nil {
+		t.Errorf("no override → override must be nil, got %+v", resp.Override)
+	}
+}

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -40,6 +40,7 @@ import { apiClient } from "../../../apiClient";
 import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { adminLinks, ownerCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
 import { startImpersonation } from "../../../impersonation";
+import { UserLimitsCard } from "./UserLimitsCard";
 
 type AdminUser = {
   id: string;
@@ -221,6 +222,12 @@ export function AdminUserOverview() {
           </Col>
         )}
       </Row>
+
+      {!user.is_admin && (
+        <div style={{ marginTop: 24 }}>
+          <UserLimitsCard userId={id} />
+        </div>
+      )}
 
       {!user.is_admin && (
         <>

--- a/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
+++ b/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
@@ -1,0 +1,316 @@
+// UserLimitsCard — JAB-12. Admin view + editor for a single user's resource
+// limits on the AdminUserOverview detail page. Surfaces the shipped CLI/API
+// (`jabali limits …`, PUT/DELETE /users/:id/limit-overrides) in the GUI:
+//
+//   - package limits (inherited), the per-user override, and the resolved
+//     effective bundle side by side, so an operator can see where each value
+//     comes from (inherited vs explicit override, including explicit-unlimited);
+//   - live disk usage from the agent's user.limits.report;
+//   - set / clear overrides for all six resources.
+//
+// Writes go to the override row only. The reconciler converges the live
+// cgroup/quota state on its next tick (DB is the source of truth), so there is
+// no separate "apply" button here — a saved override takes effect shortly after.
+import { useState } from "react";
+import {
+  Button,
+  Card,
+  Drawer,
+  Form,
+  InputNumber,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { HddOutlined, EditOutlined } from "@icons";
+
+import { apiClient } from "../../../apiClient";
+
+// The six limit fields, with the effective (PascalCase, legacy contract) and
+// override/package (snake_case) JSON keys, plus display metadata.
+type FieldKey =
+  | "disk_quota_mb"
+  | "cpu_quota_percent"
+  | "memory_limit_mb"
+  | "io_read_mbps"
+  | "io_write_mbps"
+  | "max_tasks";
+
+interface FieldSpec {
+  key: FieldKey;
+  effectiveKey:
+    | "DiskQuotaMB"
+    | "CPUQuotaPercent"
+    | "MemoryLimitMB"
+    | "IOReadMbps"
+    | "IOWriteMbps"
+    | "MaxTasks";
+  label: string;
+  unit: string;
+  max: number;
+}
+
+const FIELDS: FieldSpec[] = [
+  { key: "disk_quota_mb", effectiveKey: "DiskQuotaMB", label: "Disk quota", unit: "MB", max: 4_194_304 },
+  { key: "cpu_quota_percent", effectiveKey: "CPUQuotaPercent", label: "CPU quota", unit: "%", max: 6400 },
+  { key: "memory_limit_mb", effectiveKey: "MemoryLimitMB", label: "Memory", unit: "MB", max: 4_194_304 },
+  { key: "io_read_mbps", effectiveKey: "IOReadMbps", label: "IO read", unit: "MB/s", max: 100_000 },
+  { key: "io_write_mbps", effectiveKey: "IOWriteMbps", label: "IO write", unit: "MB/s", max: 100_000 },
+  { key: "max_tasks", effectiveKey: "MaxTasks", label: "Max tasks", unit: "", max: 1_000_000 },
+];
+
+type LimitFields = Partial<Record<FieldKey, number>>;
+
+type UsageResponse = {
+  effective: Record<FieldSpec["effectiveKey"], number>;
+  package?: LimitFields | null;
+  override?: LimitFields | null;
+  current?: { disk?: { used_kb?: number; limit_kb?: number } };
+};
+
+function fmtValue(v: number | undefined, unit: string): string {
+  if (v === undefined) return "—";
+  if (v === 0) return "Unlimited";
+  return unit ? `${v.toLocaleString()} ${unit}` : v.toLocaleString();
+}
+
+type Row = {
+  key: FieldKey;
+  label: string;
+  unit: string;
+  pkg?: number;
+  override?: number;
+  effective: number;
+  source: "override" | "package" | "default";
+};
+
+export function UserLimitsCard({ userId }: { userId: string }) {
+  const qc = useQueryClient();
+  const [editOpen, setEditOpen] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["user-usage", userId],
+    queryFn: async () => {
+      const resp = await apiClient.get<UsageResponse>(`/users/${userId}/usage`);
+      return resp.data;
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: async () => {
+      await apiClient.delete(`/users/${userId}/limit-overrides`);
+    },
+    onSuccess: async () => {
+      message.success("Overrides cleared — reconciler will apply shortly");
+      await qc.invalidateQueries({ queryKey: ["user-usage", userId] });
+    },
+    onError: () => message.error("Failed to clear overrides"),
+  });
+
+  const rows: Row[] = FIELDS.map((f) => {
+    const pkg = data?.package?.[f.key];
+    const override = data?.override?.[f.key];
+    const effective = data?.effective?.[f.effectiveKey] ?? 0;
+    const source: Row["source"] =
+      override !== undefined ? "override" : pkg !== undefined && pkg !== 0 ? "package" : "default";
+    return { key: f.key, label: f.label, unit: f.unit, pkg, override, effective, source };
+  });
+
+  const columns: ColumnsType<Row> = [
+    { title: "Resource", dataIndex: "label", key: "label" },
+    {
+      title: "Package",
+      key: "pkg",
+      render: (_, r) => (
+        <Typography.Text type="secondary">{fmtValue(r.pkg, r.unit)}</Typography.Text>
+      ),
+    },
+    {
+      title: "Override",
+      key: "override",
+      render: (_, r) =>
+        r.override !== undefined ? (
+          <Typography.Text strong>{fmtValue(r.override, r.unit)}</Typography.Text>
+        ) : (
+          <Typography.Text type="secondary">—</Typography.Text>
+        ),
+    },
+    {
+      title: "Effective",
+      key: "effective",
+      render: (_, r) => <Typography.Text>{fmtValue(r.effective, r.unit)}</Typography.Text>,
+    },
+    {
+      title: "Source",
+      key: "source",
+      render: (_, r) =>
+        r.source === "override" ? (
+          <Tag color="gold">Override</Tag>
+        ) : r.source === "package" ? (
+          <Tag color="blue">Package</Tag>
+        ) : (
+          <Tooltip title="No package value and no override — unlimited">
+            <Tag>Default</Tag>
+          </Tooltip>
+        ),
+    },
+  ];
+
+  const diskUsed = data?.current?.disk?.used_kb;
+  const hasOverride = data?.override != null && Object.keys(data.override).length > 0;
+
+  return (
+    <Card
+      title={
+        <Space>
+          <HddOutlined />
+          <span>Resource limits</span>
+        </Space>
+      }
+      extra={
+        <Space>
+          <Button icon={<EditOutlined />} onClick={() => setEditOpen(true)}>
+            Edit overrides
+          </Button>
+          <Popconfirm
+            title="Clear all overrides?"
+            description="The user falls back to package limits."
+            okText="Clear"
+            okButtonProps={{ danger: true }}
+            disabled={!hasOverride}
+            onConfirm={() => clearMutation.mutate()}
+          >
+            <Button danger disabled={!hasOverride} loading={clearMutation.isPending}>
+              Clear overrides
+            </Button>
+          </Popconfirm>
+        </Space>
+      }
+    >
+      <Table<Row>
+        rowKey="key"
+        size="small"
+        loading={isLoading}
+        columns={columns}
+        dataSource={rows}
+        pagination={false}
+      />
+      {diskUsed !== undefined && diskUsed > 0 ? (
+        <Typography.Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>
+          Live disk usage: {(diskUsed / 1024).toFixed(0)} MB
+        </Typography.Paragraph>
+      ) : null}
+
+      <EditOverridesDrawer
+        open={editOpen}
+        userId={userId}
+        initial={data?.override ?? {}}
+        onClose={() => setEditOpen(false)}
+        onSaved={() => qc.invalidateQueries({ queryKey: ["user-usage", userId] })}
+      />
+    </Card>
+  );
+}
+
+function EditOverridesDrawer({
+  open,
+  userId,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  userId: string;
+  initial: LimitFields;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form] = Form.useForm<LimitFields>();
+
+  const saveMutation = useMutation({
+    mutationFn: async (values: LimitFields) => {
+      // PUT replaces the whole override row. An empty field means "inherit"
+      // (send null); a number (including 0 = explicit unlimited) is an override.
+      const payload: Record<FieldKey, number | null> = {
+        disk_quota_mb: null,
+        cpu_quota_percent: null,
+        memory_limit_mb: null,
+        io_read_mbps: null,
+        io_write_mbps: null,
+        max_tasks: null,
+      };
+      for (const f of FIELDS) {
+        const v = values[f.key];
+        payload[f.key] = v === undefined || v === null ? null : v;
+      }
+      await apiClient.put(`/users/${userId}/limit-overrides`, payload);
+    },
+    onSuccess: () => {
+      message.success("Overrides saved — reconciler will apply shortly");
+      onSaved();
+      onClose();
+    },
+    onError: (err: unknown) => {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      message.error(detail ? `Validation failed: ${detail}` : "Failed to save overrides");
+    },
+  });
+
+  return (
+    <Drawer
+      title="Edit resource-limit overrides"
+      open={open}
+      onClose={onClose}
+      width={420}
+      destroyOnClose
+      extra={
+        <Space>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button
+            type="primary"
+            loading={saveMutation.isPending}
+            onClick={() => form.submit()}
+          >
+            Save
+          </Button>
+        </Space>
+      }
+    >
+      <Typography.Paragraph type="secondary">
+        Leave a field empty to inherit the package value. Enter <b>0</b> for
+        explicit unlimited. Saved values take effect on the next reconcile tick.
+      </Typography.Paragraph>
+      <Form
+        form={form}
+        layout="vertical"
+        initialValues={initial}
+        onFinish={(v) => saveMutation.mutate(v)}
+      >
+        {FIELDS.map((f) => (
+          <Form.Item
+            key={f.key}
+            name={f.key}
+            label={`${f.label}${f.unit ? ` (${f.unit})` : ""}`}
+          >
+            <InputNumber
+              min={0}
+              max={f.max}
+              step={1}
+              style={{ width: "100%" }}
+              placeholder="inherit from package"
+            />
+          </Form.Item>
+        ))}
+      </Form>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## JAB-12 — expose per-user limit overrides and effective limits in the admin GUI

The CLI/API already support per-user resource-limit overrides (`PUT`/`DELETE /users/:id/limit-overrides`) and the reconciler applies them, but the admin GUI had no editor — only a disk-usage cell. Admins couldn't handle common support cases from the panel: temporarily raise one user's memory, clear an override, or even see **where** an effective limit comes from (package vs override).

### Backend (additive, backward-compatible)
- `GET /users/:id/usage` now also returns:
  - `package` — the resolved package-level limits (nil when the user has no package);
  - `override` — the raw per-user override row (nil when none). Its per-field `omitempty` distinguishes **NULL = inherit** from **`&0` = explicit unlimited**, which the GUI needs to label each field's source.
  - (`effective` and `current` unchanged; the existing `UserDiskUsage` consumer reads only those and is unaffected.)
- `resolveEffective` surfaces the package view + override row it already loaded — only the one override lookup, no extra queries.

### Frontend
- **`UserLimitsCard`** on the `AdminUserOverview` detail page: a **package / override / effective / source** table for all six resources (disk, CPU, memory, IO read/write, max tasks), live disk usage, an edit **drawer** (empty = inherit, `0` = explicit unlimited), and clear-overrides.
- Writes hit the override row only; the reconciler converges live cgroup/quota state (DB is the source of truth), so there's no separate "apply" button — a saved override takes effect on the next reconcile tick.

### Acceptance criteria
- [x] User detail page has a Limits card: package limits, override values, effective limits, current usage.
- [x] Admins can set/clear per-user overrides for disk MB, CPU %, memory MB, IO read/write MB/s, max tasks.
- [x] Clearly distinguishes inherited package values from explicit overrides, including explicit-unlimited (`0`).
- [ ] "Apply limits now" per user — deferred (reconciler already converges; explicit action is a follow-up).
- [ ] Package "re-apply to package users" + dry-run preview — **follow-up PR**.
- [ ] `limits check` host-prereq view — **follow-up PR**.

### Test plan
- [x] `go test ./internal/api/` — new `TestUsage_ExposesPackageAndOverride` / `_NoPackageNoOverride` assert the response shape + inherit/override/explicit-unlimited resolution.
- [x] `go vet ./internal/api/` clean.
- [x] `npx tsc -b`, `npx eslint`, `npm run build` (vite) clean.
- [ ] Live admin visual check (Playwright E2E covers the AdminUserOverview route in CI).