### PR TITLE
feat(cache): per-install WordPress cache health check in the GUI (JAB-11 slice 1)

### DIFF
--- a/panel-api/cmd/server/per_user_egress_cmd.go
+++ b/panel-api/cmd/server/per_user_egress_cmd.go
@@ -15,16 +15,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/egressops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
-
-const operatorPinFile = "/etc/jabali/per-user-egress.mode"
 
 func newPerUserEgressCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -54,46 +51,34 @@ func newPerUserEgressFlipMatureCmd() *cobra.Command {
 		Long:    `Find user_egress_policies rows in 'learning' state older than soak-days and flip to 'enforced'. Honors /etc/jabali/per-user-egress.mode = "learning" as an operator pin (no-op when set).`,
 		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if soakDays <= 0 {
-				return fmt.Errorf("soak-days must be > 0")
-			}
-			if mode, err := os.ReadFile(operatorPinFile); err == nil {
-				if strings.TrimSpace(string(mode)) == "learning" {
-					fmt.Printf("per-user-egress flip-mature: operator pin %s = 'learning', skipping\n", operatorPinFile)
-					return nil
-				}
-			}
-
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			repo := repository.NewUserEgressPolicyRepository(sharedDB)
-			soak := time.Duration(soakDays) * 24 * time.Hour
-			rows, err := repo.ListMatureLearning(ctx, soak)
+			// Shared with the admin GUI (POST /egress/flip-mature) so both paths
+			// honor the same pin + soak semantics (verify_wire_contract scar).
+			res, err := egressops.FlipMature(ctx, repo, soakDays, egressops.DefaultPinPath, dryRun)
 			if err != nil {
-				return fmt.Errorf("list mature: %w", err)
+				return fmt.Errorf("flip-mature: %w", err)
 			}
-			if len(rows) == 0 {
+			if res.Pinned {
+				fmt.Printf("per-user-egress flip-mature: operator pin %s = 'learning', skipping\n", egressops.DefaultPinPath)
+				return nil
+			}
+			if len(res.Eligible) == 0 {
 				fmt.Printf("per-user-egress flip-mature: no mature LEARNING rows (soak=%dd)\n", soakDays)
 				return nil
 			}
-
-			fmt.Printf("per-user-egress flip-mature: %d mature rows (soak=%dd)\n", len(rows), soakDays)
-			for _, r := range rows {
+			fmt.Printf("per-user-egress flip-mature: %d mature rows (soak=%dd)\n", len(res.Eligible), soakDays)
+			for _, r := range res.Eligible {
 				fmt.Printf("  %s  learning_started=%s\n", r.UserID, r.LearningStartedAt)
-				if dryRun {
-					continue
-				}
-				next := r
-				next.State = models.UserEgressStateEnforced
-				if err := repo.Upsert(ctx, &next); err != nil {
-					fmt.Fprintf(os.Stderr, "  upsert %s failed: %v\n", r.UserID, err)
-					continue
-				}
 			}
-			if dryRun {
+			for uid, msg := range res.Failed {
+				fmt.Fprintf(os.Stderr, "  upsert %s failed: %s\n", uid, msg)
+			}
+			if res.DryRun {
 				fmt.Println("per-user-egress flip-mature: dry-run, no rows flipped")
 			} else {
-				fmt.Printf("per-user-egress flip-mature: flipped %d rows to ENFORCED\n", len(rows))
+				fmt.Printf("per-user-egress flip-mature: flipped %d rows to ENFORCED\n", len(res.Flipped))
 			}
 			return nil
 		},

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -88,6 +88,7 @@ func RegisterApplicationRoutes(g *gin.RouterGroup, cfg ApplicationHandlerConfig)
 	apps.GET("/:id/cache-warmup", wp.getCacheWarmup)   // JAB-95 Phase 3: last warmup run
 	apps.GET("/cache-profiles", wp.cacheProfiles) // GH #618
 	apps.GET("/:id/cache-stats", wp.cacheStats) // GH #617
+	apps.GET("/:id/cache-health", wp.cacheHealth) // JAB-11: per-install drift check
 	// GH #617: admin cache overview — cache-enabled domains ranked by page-cache
 	// hit ratio so low-hit/noisy sites are visible.
 	adminCache := g.Group("/admin/cache")

--- a/panel-api/internal/api/applications_cache_health_test.go
+++ b/panel-api/internal/api/applications_cache_health_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-11: GET /applications/:id/cache-health runs the agent per-install drift
+// check and derives `drifted` = cache_enabled && !healthy — the field the GUI
+// badges when the DB's cache_enabled flag disagrees with the live stack.
+
+func cacheHealthResp(t *testing.T, r http.Handler, id string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/applications/"+id+"/cache-health", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func TestCacheHealth_DriftedWhenUnhealthy(t *testing.T) {
+	wpRepo, domainRepo, userRepo := wpUserAndDomain()
+	wpRepo.installs = map[string]*models.WordPressInstall{
+		"inst1": {ID: "inst1", UserID: "user1", DomainID: "domain1", AppType: "wordpress", CacheEnabled: true, Status: "ready"},
+	}
+	r, ag, _ := applicationsRouter(t, "user1", true, wpRepo, domainRepo, userRepo, nil)
+	ag.callFn = func(_ context.Context, command string, _ any) (json.RawMessage, error) {
+		if command != "wordpress.cache_health" {
+			return json.RawMessage(`{}`), nil
+		}
+		return json.RawMessage(`{"healthy": false, "detail": "jabali-cache plugin inactive"}`), nil
+	}
+
+	out := cacheHealthResp(t, r, "inst1")
+	if out["healthy"] != false {
+		t.Errorf("healthy = %v, want false", out["healthy"])
+	}
+	if out["drifted"] != true {
+		t.Errorf("drifted = %v, want true (cache_enabled && !healthy)", out["drifted"])
+	}
+	if out["detail"] != "jabali-cache plugin inactive" {
+		t.Errorf("detail = %v", out["detail"])
+	}
+}
+
+func TestCacheHealth_NotDriftedWhenHealthy(t *testing.T) {
+	wpRepo, domainRepo, userRepo := wpUserAndDomain()
+	wpRepo.installs = map[string]*models.WordPressInstall{
+		"inst1": {ID: "inst1", UserID: "user1", DomainID: "domain1", AppType: "wordpress", CacheEnabled: true, Status: "ready"},
+	}
+	r, ag, _ := applicationsRouter(t, "user1", true, wpRepo, domainRepo, userRepo, nil)
+	ag.callFn = func(_ context.Context, command string, _ any) (json.RawMessage, error) {
+		return json.RawMessage(`{"healthy": true, "detail": "ok"}`), nil
+	}
+
+	out := cacheHealthResp(t, r, "inst1")
+	if out["healthy"] != true {
+		t.Errorf("healthy = %v, want true", out["healthy"])
+	}
+	if out["drifted"] != false {
+		t.Errorf("drifted = %v, want false", out["drifted"])
+	}
+}

--- a/panel-api/internal/api/applications_cache_settings.go
+++ b/panel-api/internal/api/applications_cache_settings.go
@@ -404,6 +404,72 @@ func recommendCacheProfile(plugins []string) (profile string, note string) {
 }
 
 // cacheAdvise (GH #620) probes the install and recommends a profile + settings.
+// cacheHealth (JAB-11) runs the agent's per-install drift check
+// (`wp jabali-cache verify` as the tenant, which fails if the plugin is
+// inactive, the drop-in / JABALI_CACHE_* constants are gone, or the Redis ACL /
+// socket is unreachable). Read-only: it detects the drift the DB's
+// cache_enabled=true flag silently lies about; repair stays on the operator
+// cache-doctor path. Bounded to 45s so a single slow install can't hang the
+// request past the proxy timeout (long-agent-call scar).
+func (h *wordPressHandler) cacheHealth(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	inst := h.loadOwnedInstall(c, claims)
+	if inst == nil {
+		return
+	}
+	if inst.AppType != "wordpress" {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "not_wordpress"})
+		return
+	}
+	dom, err := h.cfg.Domains.FindByID(c.Request.Context(), inst.DomainID)
+	if err != nil || dom == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+		return
+	}
+	osUser := ""
+	if u, uErr := h.cfg.Users.FindByID(c.Request.Context(), inst.UserID); uErr == nil && u != nil && u.Username != nil {
+		osUser = *u.Username
+	}
+	if osUser == "" || h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	installPath := dom.DocRoot
+	if inst.Subdirectory != "" {
+		installPath = path.Join(dom.DocRoot, inst.Subdirectory)
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
+	defer cancel()
+	res, err := h.cfg.Agent.Call(ctx, "wordpress.cache_health", map[string]any{
+		"os_user": osUser, "install_path": installPath, "host": dom.Name,
+	})
+	if err != nil {
+		respondAgentErr(c, "agent_error", err)
+		return
+	}
+	var health struct {
+		Healthy bool   `json:"healthy"`
+		Detail  string `json:"detail"`
+	}
+	if uErr := json.Unmarshal(res, &health); uErr != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "unparseable_health"})
+		return
+	}
+	// cache_enabled is the DB's claim; healthy is the live truth. When they
+	// disagree the site is drifted — the field the GUI badges.
+	c.JSON(http.StatusOK, gin.H{
+		"install_id":    inst.ID,
+		"cache_enabled": inst.CacheEnabled,
+		"healthy":       health.Healthy,
+		"drifted":       inst.CacheEnabled && !health.Healthy,
+		"detail":        health.Detail,
+	})
+}
+
 func (h *wordPressHandler) cacheAdvise(c *gin.Context) {
 	claims := ginctx.Claims(c)
 	if claims == nil {

--- a/panel-api/internal/api/user_egress.go
+++ b/panel-api/internal/api/user_egress.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,9 @@ type UserEgressHandlerConfig struct {
 	DropSamples repository.UserEgressDropSampleRepository
 	// Agent (GH #713) backs the drop-events drill-down (reads the nft drop log).
 	Agent agent.AgentInterface
+	// PinPath overrides the operator-pin file for the mature-soak promotion
+	// endpoints (JAB-13). Empty → egressops.DefaultPinPath. Injectable for tests.
+	PinPath string
 }
 
 // RegisterAdminUserEgressRoutes mounts the admin-side egress endpoints.
@@ -51,6 +55,9 @@ func RegisterAdminUserEgressRoutes(g *gin.RouterGroup, cfg UserEgressHandlerConf
 	g.GET("/egress-summary", h.summary)
 	g.GET("/users/:id/egress/drops-24h", h.adminDrops24h)
 	g.GET("/users/:id/egress/drop-events", h.adminDropEvents) // GH #713
+	// JAB-13: mature-soak promotion — preview (dry-run) + confirm-gated flip.
+	g.GET("/egress/mature-preview", h.maturePreview)
+	g.POST("/egress/flip-mature", h.flipMature)
 }
 
 // RegisterMeEgressRoutes mounts the user-facing /me/egress endpoints.
@@ -484,4 +491,109 @@ func (h *userEgressHandler) adminDropEvents(c *gin.Context) {
 		return
 	}
 	c.Data(http.StatusOK, "application/json", raw)
+}
+
+
+// pinPath resolves the operator-pin file, defaulting to the shared constant.
+func (h *userEgressHandler) pinPath() string {
+	if h.cfg.PinPath != "" {
+		return h.cfg.PinPath
+	}
+	return egressops.DefaultPinPath
+}
+
+// flipMatureEligible is one LEARNING policy that is (or would be) promoted,
+// with the soak-decision signals the GUI shows: how long it has been learning
+// and how many drops it saw in the last 24h.
+type flipMatureEligible struct {
+	UserID            string     `json:"user_id"`
+	LearningStartedAt *time.Time `json:"learning_started_at,omitempty"`
+	AgeDays           int        `json:"age_days"`
+	DropCount24h      uint64     `json:"drop_count_24h"`
+}
+
+// flipMatureResponse is the shared shape for the preview + flip endpoints so the
+// GUI renders both from one type. flipped/failed are empty on a dry-run preview.
+type flipMatureResponse struct {
+	SoakDays      int                  `json:"soak_days"`
+	DryRun        bool                 `json:"dry_run"`
+	Pinned        bool                 `json:"pinned"`
+	PinValue      string               `json:"pin_value,omitempty"`
+	EligibleCount int                  `json:"eligible_count"`
+	Eligible      []flipMatureEligible `json:"eligible"`
+	Flipped       []string             `json:"flipped,omitempty"`
+	FlippedCount  int                  `json:"flipped_count"`
+	Failed        map[string]string    `json:"failed,omitempty"`
+}
+
+func newFlipMatureResponse(res *egressops.FlipMatureResult) flipMatureResponse {
+	out := flipMatureResponse{
+		SoakDays:      res.SoakDays,
+		DryRun:        res.DryRun,
+		Pinned:        res.Pinned,
+		PinValue:      res.PinValue,
+		EligibleCount: len(res.Eligible),
+		Eligible:      make([]flipMatureEligible, 0, len(res.Eligible)),
+		Flipped:       res.Flipped,
+		FlippedCount:  len(res.Flipped),
+	}
+	now := time.Now().UTC()
+	for _, r := range res.Eligible {
+		e := flipMatureEligible{
+			UserID:            r.UserID,
+			LearningStartedAt: r.LearningStartedAt,
+			DropCount24h:      r.DropCount24h,
+		}
+		if r.LearningStartedAt != nil {
+			e.AgeDays = int(now.Sub(r.LearningStartedAt.UTC()).Hours() / 24)
+		}
+		out.Eligible = append(out.Eligible, e)
+	}
+	if len(res.Failed) > 0 {
+		out.Failed = res.Failed
+	}
+	return out
+}
+
+// soakDaysFromQuery parses ?soak_days=N, defaulting to 7 and clamping the lower
+// bound so egressops.FlipMature's >0 guard is never the failure path for a GET.
+func soakDaysFromQuery(c *gin.Context) int {
+	v := c.DefaultQuery("soak_days", "7")
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 7
+	}
+	return n
+}
+
+// maturePreview (GET /egress/mature-preview) is the dry-run: which LEARNING
+// policies are mature enough to flip, and whether the operator pin blocks it.
+func (h *userEgressHandler) maturePreview(c *gin.Context) {
+	res, err := egressops.FlipMature(c.Request.Context(), h.cfg.Policies, soakDaysFromQuery(c), h.pinPath(), true)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "mature_preview", "detail": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, newFlipMatureResponse(res))
+}
+
+// flipMature (POST /egress/flip-mature) promotes mature LEARNING policies to
+// ENFORCED. Confirm-gated in the GUI; the admin-route audit middleware records
+// the actor + request. No-op when the operator pin holds.
+func (h *userEgressHandler) flipMature(c *gin.Context) {
+	var body struct {
+		SoakDays int `json:"soak_days"`
+	}
+	// Body is optional; default the soak window when omitted.
+	_ = c.ShouldBindJSON(&body)
+	soakDays := body.SoakDays
+	if soakDays <= 0 {
+		soakDays = 7
+	}
+	res, err := egressops.FlipMature(c.Request.Context(), h.cfg.Policies, soakDays, h.pinPath(), false)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "flip_mature", "detail": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, newFlipMatureResponse(res))
 }

--- a/panel-api/internal/api/user_egress_flipmature_test.go
+++ b/panel-api/internal/api/user_egress_flipmature_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-13: the admin mature-soak endpoints wrap egressops.FlipMature. These
+// tests cover the HTTP shape — age_days derivation, dry-run vs promote, and the
+// pin passthrough — via a minimal embedded-interface fake.
+
+type fmPolicyRepo struct {
+	repository.UserEgressPolicyRepository
+	mature      []models.UserEgressPolicy
+	upsertCalls int
+}
+
+func (r *fmPolicyRepo) ListMatureLearning(context.Context, time.Duration) ([]models.UserEgressPolicy, error) {
+	return r.mature, nil
+}
+
+func (r *fmPolicyRepo) Upsert(context.Context, *models.UserEgressPolicy) error {
+	r.upsertCalls++
+	return nil
+}
+
+func fmServe(t *testing.T, method, path string, body string, repo *fmPolicyRepo) flipMatureResponse {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1/admin")
+	// PinPath points at a nonexistent file → never pinned.
+	RegisterAdminUserEgressRoutes(g, UserEgressHandlerConfig{Policies: repo, PinPath: "/nonexistent/pin"})
+
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d %s", rec.Code, rec.Body.String())
+	}
+	var out flipMatureResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+func TestMaturePreview_DryRunAndAge(t *testing.T) {
+	started := time.Now().UTC().Add(-10 * 24 * time.Hour)
+	repo := &fmPolicyRepo{mature: []models.UserEgressPolicy{
+		{UserID: "u1", State: models.UserEgressStateLearning, LearningStartedAt: &started, DropCount24h: 5},
+	}}
+	out := fmServe(t, http.MethodGet, "/api/v1/admin/egress/mature-preview?soak_days=7", "", repo)
+	if !out.DryRun || out.EligibleCount != 1 {
+		t.Fatalf("preview should be dry-run with 1 eligible, got %+v", out)
+	}
+	if repo.upsertCalls != 0 {
+		t.Errorf("preview must not write, got %d upserts", repo.upsertCalls)
+	}
+	e := out.Eligible[0]
+	if e.UserID != "u1" || e.DropCount24h != 5 {
+		t.Errorf("eligible row wrong: %+v", e)
+	}
+	if e.AgeDays < 9 || e.AgeDays > 11 {
+		t.Errorf("age_days ~10 expected, got %d", e.AgeDays)
+	}
+}
+
+func TestFlipMature_Promotes(t *testing.T) {
+	repo := &fmPolicyRepo{mature: []models.UserEgressPolicy{
+		{UserID: "u1", State: models.UserEgressStateLearning},
+		{UserID: "u2", State: models.UserEgressStateLearning},
+	}}
+	out := fmServe(t, http.MethodPost, "/api/v1/admin/egress/flip-mature", `{"soak_days":7}`, repo)
+	if out.DryRun {
+		t.Fatal("flip must not be a dry-run")
+	}
+	if out.FlippedCount != 2 || repo.upsertCalls != 2 {
+		t.Fatalf("expected 2 flips + 2 upserts, got flipped=%d upserts=%d", out.FlippedCount, repo.upsertCalls)
+	}
+}

--- a/panel-api/internal/egressops/egressops.go
+++ b/panel-api/internal/egressops/egressops.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"strings"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -97,4 +100,76 @@ func foldRequestIntoPolicy(ctx context.Context, deps Deps, req *models.UserEgres
 		policy.UpdatedBy = &reviewedBy
 	}
 	return deps.Policies.Upsert(ctx, policy)
+}
+
+
+// DefaultPinPath is the operator pin file for the per-user egress LEARNING
+// hold. When it contains the literal "learning", FlipMature is a no-op — an
+// operator-controlled hold for hosts where the soak needs to run longer.
+// Shared by the CLI (per-user-egress flip-mature) and the admin API so the two
+// paths honor the same pin (verify_wire_contract scar).
+const DefaultPinPath = "/etc/jabali/per-user-egress.mode"
+
+// ReadEgressPin reports whether the operator pin at path holds the LEARNING
+// hold and returns the trimmed file contents for display. A missing/unreadable
+// file is "not pinned" (the common case).
+func ReadEgressPin(path string) (pinned bool, value string) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false, ""
+	}
+	value = strings.TrimSpace(string(b))
+	return value == models.UserEgressStateLearning, value
+}
+
+// FlipMatureResult is the outcome of a FlipMature run — the same shape whether
+// dry-run (preview) or a real promotion, so the CLI and the admin GUI render
+// from one struct.
+type FlipMatureResult struct {
+	SoakDays int                        // soak window applied (days)
+	DryRun   bool                       // true = preview only, nothing written
+	Pinned   bool                       // operator pin active → no rows flipped
+	PinValue string                     // trimmed pin file contents, for display
+	Eligible []models.UserEgressPolicy  // mature LEARNING rows (would flip / did flip)
+	Flipped  []string                   // user IDs actually flipped (empty on dry-run/pin)
+	Failed   map[string]string          // user ID → upsert error, for the rows that failed
+}
+
+// FlipMature finds user_egress_policies rows in LEARNING older than soakDays and
+// flips them to ENFORCED — the graduate-from-soak decision. Honors the operator
+// pin at pinPath (no-op when "learning"). With dryRun it lists eligible rows
+// without writing. Errors only on bad input or the mature-list query; per-row
+// upsert failures are collected in Failed so one bad row doesn't abort the rest.
+func FlipMature(ctx context.Context, policies repository.UserEgressPolicyRepository, soakDays int, pinPath string, dryRun bool) (*FlipMatureResult, error) {
+	if soakDays <= 0 {
+		return nil, errors.New("soak-days must be > 0")
+	}
+	res := &FlipMatureResult{SoakDays: soakDays, DryRun: dryRun, Failed: map[string]string{}}
+
+	if pinned, val := ReadEgressPin(pinPath); pinned {
+		res.Pinned = true
+		res.PinValue = val
+		return res, nil
+	}
+
+	soak := time.Duration(soakDays) * 24 * time.Hour
+	rows, err := policies.ListMatureLearning(ctx, soak)
+	if err != nil {
+		return nil, err
+	}
+	res.Eligible = rows
+	if dryRun {
+		return res, nil
+	}
+
+	for _, r := range rows {
+		next := r
+		next.State = models.UserEgressStateEnforced
+		if err := policies.Upsert(ctx, &next); err != nil {
+			res.Failed[r.UserID] = err.Error()
+			continue
+		}
+		res.Flipped = append(res.Flipped, r.UserID)
+	}
+	return res, nil
 }

--- a/panel-api/internal/egressops/egressops_test.go
+++ b/panel-api/internal/egressops/egressops_test.go
@@ -45,6 +45,7 @@ type fakePolicyRepo struct {
 	getErr      error
 	upserted    *models.UserEgressPolicy
 	upsertCalls int
+	mature      []models.UserEgressPolicy // JAB-13: rows ListMatureLearning returns
 }
 
 func (f *fakePolicyRepo) Get(context.Context, string) (*models.UserEgressPolicy, error) {
@@ -65,7 +66,7 @@ func (f *fakePolicyRepo) ListAllForReconcile(context.Context) ([]repository.Poli
 func (f *fakePolicyRepo) SetDropCount(context.Context, string, uint64, time.Time) error { return nil }
 func (f *fakePolicyRepo) StateCounts(context.Context) (map[string]uint, error)          { return nil, nil }
 func (f *fakePolicyRepo) ListMatureLearning(context.Context, time.Duration) ([]models.UserEgressPolicy, error) {
-	return nil, nil
+	return f.mature, nil
 }
 
 // --- tests -----------------------------------------------------------------

--- a/panel-api/internal/egressops/flipmature_test.go
+++ b/panel-api/internal/egressops/flipmature_test.go
@@ -1,0 +1,78 @@
+package egressops
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-13: FlipMature graduates mature LEARNING policies to ENFORCED, honoring
+// the operator pin and a dry-run preview mode. Same logic backs the CLI and the
+// admin GUI, so these tests lock the shared semantics.
+
+func learningRows(ids ...string) []models.UserEgressPolicy {
+	out := make([]models.UserEgressPolicy, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, models.UserEgressPolicy{UserID: id, State: models.UserEgressStateLearning})
+	}
+	return out
+}
+
+func TestFlipMature_PromotesEligible(t *testing.T) {
+	pols := &fakePolicyRepo{mature: learningRows("u1", "u2")}
+	res, err := FlipMature(context.Background(), pols, 7, "/nonexistent/pin", false)
+	if err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+	if res.Pinned || res.DryRun {
+		t.Fatalf("expected a real flip, got pinned=%v dryRun=%v", res.Pinned, res.DryRun)
+	}
+	if len(res.Flipped) != 2 || pols.upsertCalls != 2 {
+		t.Fatalf("expected 2 flips + 2 upserts, got flipped=%v upserts=%d", res.Flipped, pols.upsertCalls)
+	}
+	if pols.upserted.State != models.UserEgressStateEnforced {
+		t.Errorf("flipped row must be ENFORCED, got %q", pols.upserted.State)
+	}
+}
+
+func TestFlipMature_DryRunWritesNothing(t *testing.T) {
+	pols := &fakePolicyRepo{mature: learningRows("u1", "u2")}
+	res, err := FlipMature(context.Background(), pols, 7, "/nonexistent/pin", true)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !res.DryRun || len(res.Eligible) != 2 {
+		t.Fatalf("dry-run should list 2 eligible, got dryRun=%v eligible=%d", res.DryRun, len(res.Eligible))
+	}
+	if len(res.Flipped) != 0 || pols.upsertCalls != 0 {
+		t.Errorf("dry-run must not write, got flipped=%v upserts=%d", res.Flipped, pols.upsertCalls)
+	}
+}
+
+func TestFlipMature_OperatorPinBlocks(t *testing.T) {
+	pinFile := filepath.Join(t.TempDir(), "per-user-egress.mode")
+	if err := os.WriteFile(pinFile, []byte("learning\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pols := &fakePolicyRepo{mature: learningRows("u1")}
+	res, err := FlipMature(context.Background(), pols, 7, pinFile, false)
+	if err != nil {
+		t.Fatalf("pinned flip: %v", err)
+	}
+	if !res.Pinned || res.PinValue != "learning" {
+		t.Errorf("expected pinned=true value=learning, got %+v", res)
+	}
+	if pols.upsertCalls != 0 || len(res.Eligible) != 0 {
+		t.Errorf("pin must no-op: upserts=%d eligible=%d", pols.upsertCalls, len(res.Eligible))
+	}
+}
+
+func TestFlipMature_RejectsBadSoak(t *testing.T) {
+	pols := &fakePolicyRepo{}
+	if _, err := FlipMature(context.Background(), pols, 0, "/nonexistent/pin", true); err == nil {
+		t.Fatal("soak_days=0 must error")
+	}
+}

--- a/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
@@ -27,6 +27,7 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
+import { EgressMaturePromotion } from "./EgressMaturePromotion";
 import { Sparkline } from "../../../components/Sparkline";
 import { useListQuery } from "../../../hooks/useQueries";
 import {
@@ -118,6 +119,8 @@ export const AdminSecurityEgress = () => {
           />
         </Space>
       </Card>
+
+      <EgressMaturePromotion />
 
       <Card size="small" title="Per-user policy">
         <Table<UserRow>

--- a/panel-ui/src/shells/admin/security/EgressMaturePromotion.tsx
+++ b/panel-ui/src/shells/admin/security/EgressMaturePromotion.tsx
@@ -1,0 +1,194 @@
+// EgressMaturePromotion — JAB-13. The bulk mature-soak promotion flow for the
+// per-user egress firewall, surfaced from the admin GUI to match the CLI's
+// `jabali per-user-egress flip-mature`.
+//
+// The observe -> review drops -> enforce path used to require flipping each
+// LEARNING user by hand. Here an operator picks a soak window, previews which
+// LEARNING policies are mature enough to graduate (with their soak age + drop
+// count), sees whether the operator pin blocks promotion, and — confirm-gated —
+// promotes them all at once. Backed by GET /admin/egress/mature-preview (dry
+// run) and POST /admin/egress/flip-mature.
+import { useState } from "react";
+import {
+  Alert,
+  App,
+  Button,
+  Card,
+  InputNumber,
+  Popconfirm,
+  Space,
+  Table,
+  Typography,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { ThunderboltOutlined, WarningOutlined } from "@icons";
+
+import { apiClient } from "../../../apiClient";
+
+type Eligible = {
+  user_id: string;
+  learning_started_at?: string;
+  age_days: number;
+  drop_count_24h: number;
+};
+
+type FlipMatureResponse = {
+  soak_days: number;
+  dry_run: boolean;
+  pinned: boolean;
+  pin_value?: string;
+  eligible_count: number;
+  eligible: Eligible[];
+  flipped?: string[];
+  flipped_count: number;
+  failed?: Record<string, string>;
+};
+
+const columns: ColumnsType<Eligible> = [
+  { title: "User", dataIndex: "user_id", key: "user_id" },
+  {
+    title: "Learning age",
+    dataIndex: "age_days",
+    key: "age_days",
+    render: (d: number) => `${d} day${d === 1 ? "" : "s"}`,
+  },
+  {
+    title: "Drops (24h)",
+    dataIndex: "drop_count_24h",
+    key: "drop_count_24h",
+    render: (n: number) => n.toLocaleString(),
+  },
+];
+
+export function EgressMaturePromotion() {
+  const { message } = App.useApp();
+  const qc = useQueryClient();
+  const [soakDays, setSoakDays] = useState(7);
+  const [preview, setPreview] = useState<FlipMatureResponse | null>(null);
+
+  const previewMutation = useMutation({
+    mutationFn: async (days: number) => {
+      const { data } = await apiClient.get<FlipMatureResponse>(
+        `/admin/egress/mature-preview`,
+        { params: { soak_days: days } },
+      );
+      return data;
+    },
+    onSuccess: (data) => setPreview(data),
+    onError: () => message.error("Failed to load mature-soak preview"),
+  });
+
+  const promoteMutation = useMutation({
+    mutationFn: async (days: number) => {
+      const { data } = await apiClient.post<FlipMatureResponse>(
+        `/admin/egress/flip-mature`,
+        { soak_days: days },
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      if (data.pinned) {
+        message.warning("Operator pin holds promotion — nothing flipped");
+      } else {
+        const failed = data.failed ? Object.keys(data.failed).length : 0;
+        message.success(
+          `Promoted ${data.flipped_count} policy(ies) to ENFORCED` +
+            (failed ? `, ${failed} failed` : ""),
+        );
+      }
+      setPreview(data);
+      void qc.invalidateQueries({ queryKey: ["user-egress"] });
+    },
+    onError: () => message.error("Failed to promote mature policies"),
+  });
+
+  const pinned = preview?.pinned ?? false;
+  const eligibleCount = preview?.eligible_count ?? 0;
+
+  return (
+    <Card
+      size="small"
+      title={
+        <Space>
+          <ThunderboltOutlined />
+          <span>Mature-soak promotion</span>
+        </Space>
+      }
+    >
+      <Typography.Paragraph type="secondary">
+        Graduate LEARNING policies that have soaked long enough to ENFORCED.
+        Preview first — promotion is skipped for any user whose policy is too
+        young, and the whole run no-ops when the operator pin
+        (<code>/etc/jabali/per-user-egress.mode = learning</code>) is set.
+      </Typography.Paragraph>
+
+      <Space wrap style={{ marginBottom: 12 }}>
+        <span>Soak window (days):</span>
+        <InputNumber
+          min={1}
+          max={365}
+          value={soakDays}
+          onChange={(v) => setSoakDays(typeof v === "number" ? v : 7)}
+        />
+        <Button
+          onClick={() => previewMutation.mutate(soakDays)}
+          loading={previewMutation.isPending}
+        >
+          Dry-run preview
+        </Button>
+        <Popconfirm
+          title={`Promote ${eligibleCount} mature policy(ies) to ENFORCED?`}
+          description="This enforces the egress firewall for those users on the next reconcile tick."
+          okText="Promote"
+          okButtonProps={{ danger: true }}
+          disabled={pinned || eligibleCount === 0}
+          onConfirm={() => promoteMutation.mutate(soakDays)}
+        >
+          <Button
+            type="primary"
+            danger
+            disabled={pinned || eligibleCount === 0}
+            loading={promoteMutation.isPending}
+          >
+            Promote mature ({eligibleCount})
+          </Button>
+        </Popconfirm>
+      </Space>
+
+      {pinned ? (
+        <Alert
+          type="warning"
+          showIcon
+          icon={<WarningOutlined />}
+          style={{ marginBottom: 12 }}
+          message="Operator pin active"
+          description={
+            <span>
+              <code>per-user-egress.mode</code> ={" "}
+              <b>{preview?.pin_value || "learning"}</b> — promotion is held. Clear
+              the pin file on the host to allow flips.
+            </span>
+          }
+        />
+      ) : null}
+
+      {preview && !pinned ? (
+        eligibleCount > 0 ? (
+          <Table<Eligible>
+            rowKey="user_id"
+            size="small"
+            columns={columns}
+            dataSource={preview.eligible}
+            pagination={false}
+          />
+        ) : (
+          <Typography.Text type="secondary">
+            No LEARNING policies are mature at a {preview.soak_days}-day soak.
+          </Typography.Text>
+        )
+      ) : null}
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/user/applications/CacheSettingsDrawer.tsx
+++ b/panel-ui/src/shells/user/applications/CacheSettingsDrawer.tsx
@@ -77,6 +77,10 @@ export function CacheSettingsDrawer({
   };
   const [warmRun, setWarmRun] = useState<WarmRun | null>(null);
   const [warming, setWarming] = useState(false);
+  // JAB-11: per-install cache drift check.
+  type CacheHealth = { healthy: boolean; drifted: boolean; detail: string };
+  const [health, setHealth] = useState<CacheHealth | null>(null);
+  const [checkingHealth, setCheckingHealth] = useState(false);
 
   useEffect(() => {
     if (!install) return;
@@ -111,6 +115,7 @@ export function CacheSettingsDrawer({
       .get<{ run: WarmRun | null }>(`/applications/${install.id}/cache-warmup`)
       .then((res) => setWarmRun(res.data.run ?? null))
       .catch(() => setWarmRun(null));
+    setHealth(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [install]);
 
@@ -131,6 +136,23 @@ export function CacheSettingsDrawer({
       message.error(extractApiError(e) ?? "Failed to start warmup");
     } finally {
       setWarming(false);
+    }
+  };
+
+  // JAB-11: run the agent's drift check for this one install. Read-only; repair
+  // stays on the operator `jabali app cache-doctor` path.
+  const checkHealth = async () => {
+    if (!install) return;
+    setCheckingHealth(true);
+    try {
+      const res = await apiClient.get<CacheHealth>(
+        `/applications/${install.id}/cache-health`,
+      );
+      setHealth(res.data);
+    } catch (e) {
+      message.error(extractApiError(e) ?? "Failed to check cache health");
+    } finally {
+      setCheckingHealth(false);
     }
   };
 
@@ -281,6 +303,30 @@ export function CacheSettingsDrawer({
               {warmRun.first_error ? (
                 <div style={{ color: "#c0392b", fontSize: 12, marginTop: 4 }}>
                   {warmRun.first_error}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </Form.Item>
+        <Form.Item label="Cache health" help="Verify the cache stack live (plugin active, drop-in + constants present, Redis reachable).">
+          <Button size="small" onClick={() => void checkHealth()} loading={checkingHealth}>
+            Check now
+          </Button>
+          {health ? (
+            <div style={{ marginTop: 8 }}>
+              <Tag color={health.drifted ? "red" : health.healthy ? "green" : "orange"}>
+                {health.drifted ? "DRIFTED" : health.healthy ? "Healthy" : "Unhealthy"}
+              </Tag>
+              {health.detail ? (
+                <span style={{ color: health.drifted ? "#c0392b" : "#888", fontSize: 12 }}>
+                  {health.detail}
+                </span>
+              ) : null}
+              {health.drifted ? (
+                <div style={{ color: "#c0392b", fontSize: 12, marginTop: 4 }}>
+                  Cache is enabled but the live stack failed verification. Toggle
+                  cache off and on to re-provision, or ask an operator to run
+                  <code> jabali app cache-doctor --repair</code>.
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## JAB-11 (slice 1) — per-install WordPress cache drift check in the GUI

`cache_enabled=true` in the DB silently lies when the `jabali-cache` plugin is deactivated, the object-cache drop-in or `JABALI_CACHE_*` constants are gone, or the Redis ACL/socket drifts. The CLI has `jabali app cache-doctor` for a fleet sweep, but the panel gave no per-site drift visibility.

### This slice
- **`GET /applications/:id/cache-health`** — runs the agent's `wordpress.cache_health` verb (`wp jabali-cache verify` as the tenant, the same check `cache-doctor` uses) for one install, returning `{healthy, drifted, detail}` where `drifted = cache_enabled && !healthy`. Owner-or-admin, read-only. Bounded to 45s so a slow install can't hang past the proxy timeout (long-agent-call scar); repair stays on the operator cache-doctor path.
- **`CacheSettingsDrawer`** — a "Cache health / Check now" control with a Healthy / Unhealthy / **DRIFTED** badge and, on drift, the failure detail + recommended next action.

### Why sliced
The issue's fleet view (all cache-enabled installs, bulk repair, refresh-plugin, run history) requires an **async job model** — a synchronous fleet sweep of N installs, each an agent call of seconds, would exceed the proxy timeout and 502. That's a follow-up built on JAB-95's `cache_warmup_runs` run-record pattern. This slice ships the safe, bounded, per-site drift visibility today.

### Deferred to follow-up PRs
- Admin fleet cache-doctor report across all cache-enabled installs.
- Confirm-gated bulk "Repair drift" (`cache-doctor --repair`).
- "Refresh Jabali cache plugin" (`refresh-cache-plugin`).
- Persisted run history + last-doctor-result.

### Test plan
- [x] `go test ./internal/api/` — `TestCacheHealth_DriftedWhenUnhealthy` / `_NotDriftedWhenHealthy`.
- [x] `go vet` clean.
- [x] Existing `CacheSettingsDrawer` vitest still green.
- [x] `npx tsc -b`, `npx eslint`, `npm run build` clean.
- [ ] Live check (Playwright E2E covers the applications route in CI).