### PR TITLE
feat(cache): admin fleet cache-doctor / repair / refresh with run history (JAB-11 fleet)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -169,6 +169,18 @@ jabali app cache-doctor [flags]
 - `--migrate-acl` — JAB-62: re-provision every cache-enabled install to a per-install Redis ACL user, then reap orphaned legacy shared users (safe/idempotent)
 - `--repair` — re-provision drifted installs (re-stamp constants, re-provision ACL, re-verify)
 
+#### `jabali app cache-doctor-run`
+
+Run a recorded fleet cache-doctor sweep (persists a run for the admin GUI history)
+
+```
+jabali app cache-doctor-run [flags]
+```
+
+**Flags:**
+
+- `--kind` — sweep kind: doctor | repair | refresh (default `doctor`)
+
 #### `jabali app clone`
 
 Clone a WordPress app install onto another domain (files + DB)

--- a/install/systemd/jabali-cache-doctor.service
+++ b/install/systemd/jabali-cache-doctor.service
@@ -11,7 +11,10 @@ Type=oneshot
 # Sweeps every cache-enabled WordPress install, runs `wp jabali-cache verify`
 # via the agent, and re-provisions (re-stamps constants, re-provisions the ACL,
 # re-verifies) any that have drifted. Idempotent: a healthy site is a no-op.
-ExecStart=/usr/local/bin/jabali app cache-doctor --repair
+# cache-doctor-run records the sweep as a cache_doctor_runs row (JAB-11) so the
+# result shows in the admin Cache page's history — same repair behavior as the
+# older `cache-doctor --repair`, now visible in the GUI.
+ExecStart=/usr/local/bin/jabali app cache-doctor-run --kind repair
 StandardOutput=journal
 StandardError=journal
 Restart=no

--- a/panel-api/cmd/server/app_cache_doctor_run_cmd.go
+++ b/panel-api/cmd/server/app_cache_doctor_run_cmd.go
@@ -1,0 +1,76 @@
+// app_cache_doctor_run_cmd.go — JAB-11 fleet follow-up. `jabali app
+// cache-doctor-run` runs the SAME fleet sweep as the admin GUI's
+// POST /admin/cache/doctor-runs (api.SweepCacheDoctor) and persists a
+// cache_doctor_runs row. The jabali-cache-doctor.timer runs this nightly so
+// standing drift shows up in the admin Cache page's run history without anyone
+// clicking "Run doctor". (The older `cache-doctor` command prints to stdout and
+// does not record a run; this one records.)
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func newAppCacheDoctorRunCmd() *cobra.Command {
+	var kind string
+	cmd := &cobra.Command{
+		Use:   "cache-doctor-run",
+		Short: "Run a recorded fleet cache-doctor sweep (persists a run for the admin GUI history)",
+		Long: `Sweep every cache-enabled WordPress install and record the result as a
+cache_doctor_runs row visible in the admin Cache page. --kind doctor (default)
+detects drift read-only; repair re-provisions drifted installs; refresh updates
+the jabali-cache plugin fleet-wide. Runs the same executor as the GUI trigger.
+Invoked nightly by jabali-cache-doctor.timer.`,
+		Args:    cobra.NoArgs,
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch kind {
+			case models.CacheDoctorKindDoctor, models.CacheDoctorKindRepair, models.CacheDoctorKindRefresh:
+			default:
+				return fmt.Errorf("--kind must be doctor, repair, or refresh")
+			}
+
+			cfg, err := buildAppDeps()
+			if err != nil {
+				return fmt.Errorf("wire app deps: %w", err)
+			}
+			if kind == models.CacheDoctorKindRepair && cfg.Redis == nil {
+				return fmt.Errorf("repair needs Redis wiring (JABALI_REDIS_* not configured)")
+			}
+			cfg.CacheDoctorRuns = repository.NewCacheDoctorRunRepository(sharedDB)
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
+			defer cancel()
+
+			run := &models.CacheDoctorRun{
+				ID:          ids.NewULID(),
+				Kind:        kind,
+				State:       models.CacheDoctorStateQueued,
+				TriggeredBy: "", // timer/CLI — no interactive actor
+			}
+			if err := cfg.CacheDoctorRuns.Create(ctx, run); err != nil {
+				return fmt.Errorf("create run: %w", err)
+			}
+			if err := api.SweepCacheDoctor(ctx, cfg, run, ""); err != nil {
+				return fmt.Errorf("sweep: %w", err)
+			}
+			fmt.Printf("cache-doctor-run %s (%s): checked %d/%d, drifted %d, repaired %d, refreshed %d, failed %d\n",
+				run.ID, run.Kind, run.Checked, run.Total, run.Drifted, run.Repaired, run.Refreshed, run.Failed)
+			if run.FirstError != "" {
+				fmt.Printf("  first error: %s\n", run.FirstError)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", models.CacheDoctorKindDoctor, "sweep kind: doctor | repair | refresh")
+	return cmd
+}

--- a/panel-api/cmd/server/app_cmd.go
+++ b/panel-api/cmd/server/app_cmd.go
@@ -40,6 +40,7 @@ func newAppCmd() *cobra.Command {
 		newAppCacheCmd(),
 		newAppRefreshCachePluginCmd(),
 		newAppCacheDoctorCmd(),
+		newAppCacheDoctorRunCmd(),
 		newAppCloneCmd(),
 		newAppMagicLinkCmd(),
 		newAppDeleteCmd(),

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -592,6 +592,8 @@ install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.service /etc/s
 install -m 0644 ` + repoDir + `/install/systemd/jabali-sso-reaper.timer /etc/systemd/system/jabali-sso-reaper.timer
 install -m 0644 ` + repoDir + `/install/systemd/jabali-retention-sweep.service /etc/systemd/system/jabali-retention-sweep.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-retention-sweep.timer /etc/systemd/system/jabali-retention-sweep.timer
+install -m 0644 ` + repoDir + `/install/systemd/jabali-cache-doctor.service /etc/systemd/system/jabali-cache-doctor.service
+install -m 0644 ` + repoDir + `/install/systemd/jabali-cache-doctor.timer /etc/systemd/system/jabali-cache-doctor.timer
 install -m 0644 ` + repoDir + `/install/systemd/jabali-notify@.service /etc/systemd/system/jabali-notify@.service
 install -m 0644 ` + repoDir + `/install/systemd/jabali-stalwart.service /etc/systemd/system/jabali-stalwart.service
 # JAB-158 journald cap + JAB-153/157 disk-maintenance timer. install.sh drops

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -94,6 +94,10 @@ func RegisterApplicationRoutes(g *gin.RouterGroup, cfg ApplicationHandlerConfig)
 	adminCache := g.Group("/admin/cache")
 	adminCache.Use(middleware.RequireAdmin())
 	adminCache.GET("/overview", wp.cacheOverview)
+	// JAB-11: fleet cache-doctor/repair/refresh runs (async — poll by id).
+	adminCache.POST("/doctor-runs", wp.startCacheDoctorRun)
+	adminCache.GET("/doctor-runs", wp.listCacheDoctorRuns)
+	adminCache.GET("/doctor-runs/:id", wp.getCacheDoctorRun)
 	apps.POST("/:id/cache-advise", wp.cacheAdvise) // GH #620
 }
 

--- a/panel-api/internal/api/applications_cache_doctor.go
+++ b/panel-api/internal/api/applications_cache_doctor.go
@@ -115,10 +115,8 @@ func (h *wordPressHandler) getCacheDoctorRun(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"run": run})
 }
 
-// runCacheDoctorSweep is the background worker. It sweeps every cache-enabled,
-// ready WordPress install, runs the health check, and (per kind) re-provisions
-// drifted installs or refreshes the plugin, updating the run row as it goes so
-// the poller sees live progress.
+// runCacheDoctorSweep is the background worker for the HTTP trigger. It owns the
+// deadline and delegates to SweepCacheDoctor.
 func (h *wordPressHandler) runCacheDoctorSweep(runID, kind, actorUserID string) {
 	ctx, cancel := context.WithTimeout(context.Background(), cacheDoctorSweepTimeout)
 	defer cancel()
@@ -128,15 +126,26 @@ func (h *wordPressHandler) runCacheDoctorSweep(runID, kind, actorUserID string) 
 		slog.ErrorContext(ctx, "cache-doctor: run vanished before sweep", "run", runID, "err", err)
 		return
 	}
+	_ = SweepCacheDoctor(ctx, h.cfg, run, actorUserID)
+}
+
+// SweepCacheDoctor runs a fleet cache-maintenance sweep synchronously against
+// cfg, updating the (already-Created) run row as it progresses. Exported so the
+// nightly CLI timer (`jabali app cache-doctor-run`) runs the exact same executor
+// as the HTTP trigger — no second sweep implementation to drift. The caller owns
+// the context deadline.
+func SweepCacheDoctor(ctx context.Context, cfg ApplicationHandlerConfig, run *models.CacheDoctorRun, actorUserID string) error {
+	h := &wordPressHandler{cfg: cfg}
+	kind := run.Kind
 	now := time.Now().UTC()
 	run.State = models.CacheDoctorStateRunning
 	run.StartedAt = &now
-	_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+	_ = cfg.CacheDoctorRuns.Update(ctx, run)
 
-	installs, _, lErr := h.cfg.ApplicationInstalls.List(ctx, repository.ListOptions{Limit: 100000})
+	installs, _, lErr := cfg.ApplicationInstalls.List(ctx, repository.ListOptions{Limit: 100000})
 	if lErr != nil {
 		h.failCacheDoctorRun(ctx, run, "list installs: "+lErr.Error())
-		return
+		return lErr
 	}
 
 	items := make([]models.CacheDoctorItem, 0)
@@ -171,13 +180,14 @@ func (h *wordPressHandler) runCacheDoctorSweep(runID, kind, actorUserID string) 
 		if raw, mErr := json.Marshal(items); mErr == nil {
 			run.Results = raw
 		}
-		_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+		_ = cfg.CacheDoctorRuns.Update(ctx, run)
 	}
 
 	fin := time.Now().UTC()
 	run.FinishedAt = &fin
 	run.State = models.CacheDoctorStateDone
-	_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+	_ = cfg.CacheDoctorRuns.Update(ctx, run)
+	return nil
 }
 
 // doctorOneInstall health-checks one install and, per kind, repairs drift or

--- a/panel-api/internal/api/applications_cache_doctor.go
+++ b/panel-api/internal/api/applications_cache_doctor.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"path"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// applications_cache_doctor.go — JAB-11 fleet half. A cache-doctor / repair /
+// refresh sweep touches every cache-enabled WordPress install with one agent
+// call each, so a synchronous HTTP sweep would exceed the proxy timeout. The
+// POST creates a run row and kicks off a background goroutine; the admin GUI
+// polls the run (and lists history). Mirrors the JAB-95 warmup async-run shape.
+
+// cacheDoctorInstallCallTimeout bounds each per-install agent call so one hung
+// install can't stall the whole sweep.
+const cacheDoctorInstallCallTimeout = 90 * time.Second
+
+// cacheDoctorSweepTimeout bounds the whole background sweep.
+const cacheDoctorSweepTimeout = 30 * time.Minute
+
+// startCacheDoctorRun (POST /admin/cache/doctor-runs) starts a fleet sweep of
+// the given kind (doctor|repair|refresh) and returns the run id immediately.
+func (h *wordPressHandler) startCacheDoctorRun(c *gin.Context) {
+	if h.cfg.CacheDoctorRuns == nil || h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	var body struct {
+		Kind string `json:"kind"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	kind := body.Kind
+	switch kind {
+	case models.CacheDoctorKindDoctor, models.CacheDoctorKindRepair, models.CacheDoctorKindRefresh:
+	case "":
+		kind = models.CacheDoctorKindDoctor
+	default:
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "bad_kind", "detail": "kind must be doctor, repair, or refresh"})
+		return
+	}
+	// Repair re-provisions via SetApplicationCache, which needs the full cache
+	// wiring (Redis + token secret). Refuse rather than silently no-op.
+	if kind == models.CacheDoctorKindRepair && h.cfg.Redis == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "repair_unavailable", "detail": "cache repair needs Redis wiring"})
+		return
+	}
+
+	// One sweep at a time — a second concurrent fleet pass just doubles agent
+	// load and races on the same installs.
+	if active, err := h.cfg.CacheDoctorRuns.CountActive(c.Request.Context()); err == nil && active > 0 {
+		c.JSON(http.StatusConflict, gin.H{"error": "run_in_progress"})
+		return
+	}
+
+	triggeredBy := ""
+	if claims := ginctx.Claims(c); claims != nil {
+		triggeredBy = claims.UserID
+	}
+	run := &models.CacheDoctorRun{
+		ID:          ids.NewULID(),
+		Kind:        kind,
+		State:       models.CacheDoctorStateQueued,
+		TriggeredBy: triggeredBy,
+	}
+	if err := h.cfg.CacheDoctorRuns.Create(c.Request.Context(), run); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_run"})
+		return
+	}
+
+	go h.runCacheDoctorSweep(run.ID, kind, triggeredBy)
+
+	c.JSON(http.StatusAccepted, gin.H{"id": run.ID, "kind": kind, "state": run.State})
+}
+
+// listCacheDoctorRuns (GET /admin/cache/doctor-runs) returns recent runs (history).
+func (h *wordPressHandler) listCacheDoctorRuns(c *gin.Context) {
+	if h.cfg.CacheDoctorRuns == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	runs, err := h.cfg.CacheDoctorRuns.ListRecent(c.Request.Context(), 50)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "list_runs"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"runs": runs})
+}
+
+// getCacheDoctorRun (GET /admin/cache/doctor-runs/:id) returns one run for polling.
+func (h *wordPressHandler) getCacheDoctorRun(c *gin.Context) {
+	if h.cfg.CacheDoctorRuns == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	run, err := h.cfg.CacheDoctorRuns.Get(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if err == repository.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "get_run"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"run": run})
+}
+
+// runCacheDoctorSweep is the background worker. It sweeps every cache-enabled,
+// ready WordPress install, runs the health check, and (per kind) re-provisions
+// drifted installs or refreshes the plugin, updating the run row as it goes so
+// the poller sees live progress.
+func (h *wordPressHandler) runCacheDoctorSweep(runID, kind, actorUserID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cacheDoctorSweepTimeout)
+	defer cancel()
+
+	run, err := h.cfg.CacheDoctorRuns.Get(ctx, runID)
+	if err != nil {
+		slog.ErrorContext(ctx, "cache-doctor: run vanished before sweep", "run", runID, "err", err)
+		return
+	}
+	now := time.Now().UTC()
+	run.State = models.CacheDoctorStateRunning
+	run.StartedAt = &now
+	_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+
+	installs, _, lErr := h.cfg.ApplicationInstalls.List(ctx, repository.ListOptions{Limit: 100000})
+	if lErr != nil {
+		h.failCacheDoctorRun(ctx, run, "list installs: "+lErr.Error())
+		return
+	}
+
+	items := make([]models.CacheDoctorItem, 0)
+	for i := range installs {
+		in := installs[i]
+		if in.AppType != "wordpress" || !in.CacheEnabled || in.Status != "ready" {
+			continue
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		run.Total++
+		item := h.doctorOneInstall(ctx, &installs[i], kind, actorUserID)
+		items = append(items, item)
+
+		run.Checked++
+		if item.Drifted {
+			run.Drifted++
+		}
+		if item.Repaired {
+			run.Repaired++
+		}
+		if item.Refreshed {
+			run.Refreshed++
+		}
+		if item.Error != "" {
+			run.Failed++
+			if run.FirstError == "" {
+				run.FirstError = truncateDoctorErr(item.InstallID + ": " + item.Error)
+			}
+		}
+		if raw, mErr := json.Marshal(items); mErr == nil {
+			run.Results = raw
+		}
+		_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+	}
+
+	fin := time.Now().UTC()
+	run.FinishedAt = &fin
+	run.State = models.CacheDoctorStateDone
+	_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+}
+
+// doctorOneInstall health-checks one install and, per kind, repairs drift or
+// refreshes the plugin. Never returns an error — every outcome is recorded on
+// the item so one bad install doesn't abort the sweep.
+func (h *wordPressHandler) doctorOneInstall(ctx context.Context, in *models.ApplicationInstall, kind, actorUserID string) models.CacheDoctorItem {
+	item := models.CacheDoctorItem{InstallID: in.ID}
+
+	dom, dErr := h.cfg.Domains.FindByID(ctx, in.DomainID)
+	if dErr != nil || dom == nil || dom.DocRoot == "" {
+		item.Error = "domain/docroot unresolved"
+		return item
+	}
+	item.Host = dom.Name
+	osUser := ""
+	if u, uErr := h.cfg.Users.FindByID(ctx, in.UserID); uErr == nil && u != nil && u.Username != nil {
+		osUser = *u.Username
+	}
+	if osUser == "" {
+		item.Error = "no linux account for owner"
+		return item
+	}
+	installPath := dom.DocRoot
+	if in.Subdirectory != "" {
+		installPath = path.Join(dom.DocRoot, in.Subdirectory)
+	}
+	item.Path = installPath
+
+	// Refresh is independent of health — it updates the plugin regardless.
+	if kind == models.CacheDoctorKindRefresh {
+		callCtx, cancel := context.WithTimeout(ctx, cacheDoctorInstallCallTimeout)
+		_, rErr := h.cfg.Agent.Call(callCtx, "wordpress.cache_plugin_refresh", map[string]any{
+			"os_user": osUser, "install_path": installPath,
+		})
+		cancel()
+		if rErr != nil {
+			item.Error = rErr.Error()
+			return item
+		}
+		item.Refreshed = true
+		return item
+	}
+
+	// doctor + repair both start with a health check.
+	callCtx, cancel := context.WithTimeout(ctx, cacheDoctorInstallCallTimeout)
+	raw, hErr := h.cfg.Agent.Call(callCtx, "wordpress.cache_health", map[string]any{
+		"os_user": osUser, "install_path": installPath, "host": dom.Name,
+	})
+	cancel()
+	if hErr != nil {
+		item.Error = hErr.Error()
+		return item
+	}
+	var health struct {
+		Healthy bool   `json:"healthy"`
+		Detail  string `json:"detail"`
+	}
+	_ = json.Unmarshal(raw, &health)
+	item.Healthy = health.Healthy
+	item.Drifted = in.CacheEnabled && !health.Healthy
+	if !item.Drifted {
+		return item
+	}
+	if health.Detail != "" {
+		item.Error = health.Detail
+	}
+
+	if kind == models.CacheDoctorKindRepair {
+		// Re-run the idempotent enable path — re-stamps constants, re-provisions
+		// the ACL, re-verifies. Same call the CLI cache-doctor --repair makes.
+		if rErr := SetApplicationCache(ctx, h.cfg, in.ID, true, true, actorUserID); rErr != nil {
+			item.Error = "repair failed: " + rErr.Error()
+			return item
+		}
+		item.Repaired = true
+		item.Error = "" // repaired — clear the drift detail
+	}
+	return item
+}
+
+func (h *wordPressHandler) failCacheDoctorRun(ctx context.Context, run *models.CacheDoctorRun, msg string) {
+	fin := time.Now().UTC()
+	run.FinishedAt = &fin
+	run.State = models.CacheDoctorStateFailed
+	run.FirstError = truncateDoctorErr(msg)
+	_ = h.cfg.CacheDoctorRuns.Update(ctx, run)
+}
+
+func truncateDoctorErr(s string) string {
+	const max = 1024
+	if len(s) > max {
+		return s[:max]
+	}
+	return s
+}

--- a/panel-api/internal/api/applications_cache_doctor_test.go
+++ b/panel-api/internal/api/applications_cache_doctor_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-11 fleet: in-memory cache-doctor run repo for the sweep executor tests.
+type memDoctorRunRepo struct {
+	runs map[string]*models.CacheDoctorRun
+}
+
+func newMemDoctorRunRepo() *memDoctorRunRepo {
+	return &memDoctorRunRepo{runs: map[string]*models.CacheDoctorRun{}}
+}
+func (m *memDoctorRunRepo) Create(_ context.Context, run *models.CacheDoctorRun) error {
+	cp := *run
+	m.runs[run.ID] = &cp
+	return nil
+}
+func (m *memDoctorRunRepo) Update(_ context.Context, run *models.CacheDoctorRun) error {
+	cp := *run
+	m.runs[run.ID] = &cp
+	return nil
+}
+func (m *memDoctorRunRepo) Get(_ context.Context, id string) (*models.CacheDoctorRun, error) {
+	if r, ok := m.runs[id]; ok {
+		cp := *r
+		return &cp, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (m *memDoctorRunRepo) ListRecent(_ context.Context, _ int) ([]models.CacheDoctorRun, error) {
+	out := make([]models.CacheDoctorRun, 0, len(m.runs))
+	for _, r := range m.runs {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+func (m *memDoctorRunRepo) CountActive(_ context.Context) (int64, error) {
+	var n int64
+	for _, r := range m.runs {
+		if r.State == models.CacheDoctorStateQueued || r.State == models.CacheDoctorStateRunning {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func doctorTestHandler(t *testing.T, ag *mockAgent) (*wordPressHandler, *memDoctorRunRepo, *mockWordPressInstallRepo) {
+	t.Helper()
+	wpRepo, domainRepo, userRepo := wpUserAndDomain()
+	runs := newMemDoctorRunRepo()
+	h := &wordPressHandler{cfg: ApplicationHandlerConfig{
+		ApplicationInstalls: wpRepo,
+		Domains:             domainRepo,
+		Users:               userRepo,
+		Agent:               ag,
+		CacheDoctorRuns:     runs,
+	}}
+	return h, runs, wpRepo
+}
+
+func seedDoctorCacheInstall(wpRepo *mockWordPressInstallRepo, id string) {
+	wpRepo.installs = map[string]*models.WordPressInstall{
+		id: {ID: id, UserID: "user1", DomainID: "domain1", AppType: "wordpress", CacheEnabled: true, Status: "ready"},
+	}
+}
+
+func TestCacheDoctorSweep_DetectsDrift(t *testing.T) {
+	ag := &mockAgent{}
+	ag.callFn = func(_ context.Context, command string, _ any) (json.RawMessage, error) {
+		if command == "wordpress.cache_health" {
+			return json.RawMessage(`{"healthy": false, "detail": "plugin inactive"}`), nil
+		}
+		return json.RawMessage(`{}`), nil
+	}
+	h, runs, wpRepo := doctorTestHandler(t, ag)
+	seedDoctorCacheInstall(wpRepo, "inst1")
+
+	run := &models.CacheDoctorRun{ID: "run1", Kind: models.CacheDoctorKindDoctor, State: models.CacheDoctorStateQueued}
+	_ = runs.Create(context.Background(), run)
+	h.runCacheDoctorSweep("run1", models.CacheDoctorKindDoctor, "admin1")
+
+	got, _ := runs.Get(context.Background(), "run1")
+	if got.State != models.CacheDoctorStateDone {
+		t.Fatalf("state = %q, want done", got.State)
+	}
+	if got.Total != 1 || got.Checked != 1 || got.Drifted != 1 {
+		t.Errorf("counts total/checked/drifted = %d/%d/%d, want 1/1/1", got.Total, got.Checked, got.Drifted)
+	}
+	if got.Repaired != 0 {
+		t.Errorf("doctor kind must not repair, got repaired=%d", got.Repaired)
+	}
+	var items []models.CacheDoctorItem
+	if err := json.Unmarshal(got.Results, &items); err != nil || len(items) != 1 {
+		t.Fatalf("results: %v (%d items)", err, len(items))
+	}
+	if !items[0].Drifted || items[0].InstallID != "inst1" {
+		t.Errorf("item wrong: %+v", items[0])
+	}
+}
+
+func TestCacheDoctorSweep_HealthySkipsDrift(t *testing.T) {
+	ag := &mockAgent{}
+	ag.callFn = func(_ context.Context, command string, _ any) (json.RawMessage, error) {
+		return json.RawMessage(`{"healthy": true, "detail": "ok"}`), nil
+	}
+	h, runs, wpRepo := doctorTestHandler(t, ag)
+	seedDoctorCacheInstall(wpRepo, "inst1")
+
+	run := &models.CacheDoctorRun{ID: "run2", Kind: models.CacheDoctorKindDoctor, State: models.CacheDoctorStateQueued}
+	_ = runs.Create(context.Background(), run)
+	h.runCacheDoctorSweep("run2", models.CacheDoctorKindDoctor, "admin1")
+
+	got, _ := runs.Get(context.Background(), "run2")
+	if got.Drifted != 0 || got.Failed != 0 {
+		t.Errorf("healthy install: drifted/failed = %d/%d, want 0/0", got.Drifted, got.Failed)
+	}
+}
+
+func TestCacheDoctorSweep_RefreshUpdatesPlugin(t *testing.T) {
+	ag := &mockAgent{}
+	var refreshCalls int
+	ag.callFn = func(_ context.Context, command string, _ any) (json.RawMessage, error) {
+		if command == "wordpress.cache_plugin_refresh" {
+			refreshCalls++
+			return json.RawMessage(`{"updated": true}`), nil
+		}
+		return json.RawMessage(`{}`), nil
+	}
+	h, runs, wpRepo := doctorTestHandler(t, ag)
+	seedDoctorCacheInstall(wpRepo, "inst1")
+
+	run := &models.CacheDoctorRun{ID: "run3", Kind: models.CacheDoctorKindRefresh, State: models.CacheDoctorStateQueued}
+	_ = runs.Create(context.Background(), run)
+	h.runCacheDoctorSweep("run3", models.CacheDoctorKindRefresh, "admin1")
+
+	got, _ := runs.Get(context.Background(), "run3")
+	if got.Refreshed != 1 || refreshCalls != 1 {
+		t.Errorf("refresh: refreshed=%d calls=%d, want 1/1", got.Refreshed, refreshCalls)
+	}
+}

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -49,6 +49,9 @@ type ApplicationHandlerConfig struct {
 	// CacheWarmupRuns persists warmup run records (JAB-95 Phase 3). Optional;
 	// nil disables run recording (warmup still runs).
 	CacheWarmupRuns repository.CacheWarmupRunRepository
+	// CacheDoctorRuns persists fleet cache-doctor/repair/refresh run records
+	// (JAB-11). Optional; nil → the admin fleet endpoints return 503.
+	CacheDoctorRuns repository.CacheDoctorRunRepository
 	// Reconciler re-renders the domain vhost after the nginx page-cache flag
 	// flips (mirrors DomainCacheHandlerConfig.Reconciler). Optional.
 	Reconciler DNSScheduler

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1112,6 +1112,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				CacheTokenSecret:    cacheHMACSecret(),
 				CacheTokenSalts:     repository.NewCacheTokenSaltRepository(deps.DB),
 				CacheWarmupRuns:     repository.NewCacheWarmupRunRepository(deps.DB),
+				CacheDoctorRuns:     repository.NewCacheDoctorRunRepository(deps.DB),
 			}
 			api.RegisterApplicationRoutes(v1, appCfg)
 

--- a/panel-api/internal/db/migrations/000226_cache_doctor_runs.down.sql
+++ b/panel-api/internal/db/migrations/000226_cache_doctor_runs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS cache_doctor_runs;

--- a/panel-api/internal/db/migrations/000226_cache_doctor_runs.up.sql
+++ b/panel-api/internal/db/migrations/000226_cache_doctor_runs.up.sql
@@ -1,0 +1,25 @@
+-- JAB-11: durable, queryable fleet cache-maintenance runs. A cache-doctor /
+-- repair / refresh sweep touches every cache-enabled WordPress install with one
+-- agent call each, so it runs in the background and the panel polls this row
+-- for progress + keeps a history. Mirrors cache_warmup_runs (000225).
+CREATE TABLE cache_doctor_runs (
+  id            CHAR(26) NOT NULL,
+  kind          VARCHAR(16) NOT NULL,                    -- doctor|repair|refresh
+  state         VARCHAR(16) NOT NULL DEFAULT 'queued',   -- queued|running|done|failed
+  triggered_by  VARCHAR(26) NOT NULL DEFAULT '',
+  total         INT NOT NULL DEFAULT 0,
+  checked       INT NOT NULL DEFAULT 0,
+  drifted       INT NOT NULL DEFAULT 0,
+  repaired      INT NOT NULL DEFAULT 0,
+  refreshed     INT NOT NULL DEFAULT 0,
+  failed        INT NOT NULL DEFAULT 0,
+  first_error   VARCHAR(1024) NOT NULL DEFAULT '',
+  results       JSON NULL,
+  started_at    TIMESTAMP NULL,
+  finished_at   TIMESTAMP NULL,
+  created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_cdr_created (created_at),
+  KEY idx_cdr_state (state)
+);

--- a/panel-api/internal/models/cache_doctor_run.go
+++ b/panel-api/internal/models/cache_doctor_run.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// CacheDoctorRun records one fleet cache-maintenance pass across all
+// cache-enabled WordPress installs (JAB-11). A sweep is long (one agent call
+// per install), so it runs in a background goroutine and the panel polls this
+// row for progress + a durable history — the same async-run shape as
+// CacheWarmupRun.
+type CacheDoctorRun struct {
+	ID          string          `gorm:"type:char(26);primaryKey" json:"id"`
+	Kind        string          `gorm:"type:varchar(16);not null" json:"kind"` // doctor|repair|refresh
+	State       string          `gorm:"type:varchar(16);not null;default:queued" json:"state"`
+	TriggeredBy string          `gorm:"column:triggered_by;type:varchar(26);not null;default:''" json:"triggered_by"`
+	Total       int             `gorm:"not null;default:0" json:"total"`     // cache-enabled installs to process
+	Checked     int             `gorm:"not null;default:0" json:"checked"`   // installs health-checked
+	Drifted     int             `gorm:"not null;default:0" json:"drifted"`   // found unhealthy while cache_enabled
+	Repaired    int             `gorm:"not null;default:0" json:"repaired"`  // re-provisioned (repair kind)
+	Refreshed   int             `gorm:"not null;default:0" json:"refreshed"` // plugin updated (refresh kind)
+	Failed      int             `gorm:"not null;default:0" json:"failed"`    // agent/repair errors
+	FirstError  string          `gorm:"column:first_error;type:varchar(1024);not null;default:''" json:"first_error"`
+	Results     json.RawMessage `gorm:"type:json" json:"results,omitempty"` // []CacheDoctorItem
+	StartedAt   *time.Time      `json:"started_at,omitempty"`
+	FinishedAt  *time.Time      `json:"finished_at,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}
+
+// CacheDoctorItem is one install's outcome within a run, serialized into the
+// Results JSON. Every failure carries the install ID + path + detail so an
+// operator can act on the exact site.
+type CacheDoctorItem struct {
+	InstallID string `json:"install_id"`
+	Path      string `json:"path"`
+	Host      string `json:"host,omitempty"`
+	Healthy   bool   `json:"healthy"`
+	Drifted   bool   `json:"drifted"`
+	Repaired  bool   `json:"repaired,omitempty"`
+	Refreshed bool   `json:"refreshed,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// Cache-doctor run kinds.
+const (
+	CacheDoctorKindDoctor  = "doctor"  // detect drift only (read-only)
+	CacheDoctorKindRepair  = "repair"  // detect + re-provision drifted installs
+	CacheDoctorKindRefresh = "refresh" // update the jabali-cache plugin fleet-wide
+)
+
+// Cache-doctor run states (shared vocabulary with warmup runs).
+const (
+	CacheDoctorStateQueued  = "queued"
+	CacheDoctorStateRunning = "running"
+	CacheDoctorStateDone    = "done"
+	CacheDoctorStateFailed  = "failed"
+)
+
+func (CacheDoctorRun) TableName() string { return "cache_doctor_runs" }

--- a/panel-api/internal/repository/cache_doctor_run_repository.go
+++ b/panel-api/internal/repository/cache_doctor_run_repository.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// CacheDoctorRunRepository persists fleet cache-maintenance run records (JAB-11).
+type CacheDoctorRunRepository interface {
+	Create(ctx context.Context, run *models.CacheDoctorRun) error
+	Update(ctx context.Context, run *models.CacheDoctorRun) error
+	Get(ctx context.Context, id string) (*models.CacheDoctorRun, error)
+	ListRecent(ctx context.Context, limit int) ([]models.CacheDoctorRun, error)
+	// CountActive returns how many runs are queued or running — used to reject a
+	// second concurrent sweep.
+	CountActive(ctx context.Context) (int64, error)
+}
+
+type cacheDoctorRunRepo struct{ db *gorm.DB }
+
+func NewCacheDoctorRunRepository(db *gorm.DB) CacheDoctorRunRepository {
+	return &cacheDoctorRunRepo{db: db}
+}
+
+func (r *cacheDoctorRunRepo) Create(ctx context.Context, run *models.CacheDoctorRun) error {
+	return r.db.WithContext(ctx).Create(run).Error
+}
+
+func (r *cacheDoctorRunRepo) Update(ctx context.Context, run *models.CacheDoctorRun) error {
+	return r.db.WithContext(ctx).Save(run).Error
+}
+
+func (r *cacheDoctorRunRepo) Get(ctx context.Context, id string) (*models.CacheDoctorRun, error) {
+	var run models.CacheDoctorRun
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&run).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+func (r *cacheDoctorRunRepo) ListRecent(ctx context.Context, limit int) ([]models.CacheDoctorRun, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	var runs []models.CacheDoctorRun
+	err := r.db.WithContext(ctx).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&runs).Error
+	return runs, err
+}
+
+func (r *cacheDoctorRunRepo) CountActive(ctx context.Context) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).
+		Model(&models.CacheDoctorRun{}).
+		Where("state IN ?", []string{models.CacheDoctorStateQueued, models.CacheDoctorStateRunning}).
+		Count(&n).Error
+	return n, err
+}

--- a/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
@@ -5,6 +5,7 @@ import { App, Card, Table, Tag, Typography } from "antd";
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
+import { FleetCacheDoctor } from "./FleetCacheDoctor";
 import { extractApiError } from "../../../apiErrors";
 
 type Row = {
@@ -32,7 +33,9 @@ export function CacheOverviewPage() {
   }, []);
 
   return (
-    <Card title="Cache overview — page-cache hit ratio by domain">
+    <>
+      <FleetCacheDoctor />
+      <Card title="Cache overview — page-cache hit ratio by domain">
       <Typography.Paragraph type="secondary">
         Cache-enabled WordPress domains, ranked with the lowest hit ratio (most in
         need of attention) first. A low ratio with high traffic suggests a
@@ -68,6 +71,7 @@ export function CacheOverviewPage() {
           { title: "Bypass", dataIndex: "bypass" },
         ]}
       />
-    </Card>
+      </Card>
+    </>
   );
 }

--- a/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
+++ b/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
@@ -1,0 +1,293 @@
+// FleetCacheDoctor — JAB-11 (fleet). Admin controls for the cache-doctor /
+// repair / refresh sweep across all cache-enabled WordPress installs. The sweep
+// is long (one agent call per install), so the POST returns a run id and this
+// polls it — no synchronous fleet call that would 502. Shows live progress,
+// per-install results, and recent run history.
+import { useEffect, useState } from "react";
+import {
+  App,
+  Alert,
+  Button,
+  Card,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  Typography,
+} from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ReloadOutlined, ThunderboltOutlined, ToolOutlined } from "@icons";
+
+import { apiClient } from "../../../apiClient";
+import { extractApiError } from "../../../apiErrors";
+import { shortDateTime } from "../../../utils/datetime";
+
+type Kind = "doctor" | "repair" | "refresh";
+
+type DoctorItem = {
+  install_id: string;
+  path: string;
+  host?: string;
+  healthy: boolean;
+  drifted: boolean;
+  repaired?: boolean;
+  refreshed?: boolean;
+  error?: string;
+};
+
+type DoctorRun = {
+  id: string;
+  kind: Kind;
+  state: "queued" | "running" | "done" | "failed";
+  triggered_by: string;
+  total: number;
+  checked: number;
+  drifted: number;
+  repaired: number;
+  refreshed: number;
+  failed: number;
+  first_error: string;
+  results?: DoctorItem[];
+  started_at?: string | null;
+  finished_at?: string | null;
+  created_at: string;
+};
+
+const KIND_LABEL: Record<Kind, string> = {
+  doctor: "Doctor",
+  repair: "Repair",
+  refresh: "Refresh plugin",
+};
+
+function stateColor(state: DoctorRun["state"]): string {
+  return state === "done"
+    ? "green"
+    : state === "failed"
+      ? "red"
+      : state === "running"
+        ? "blue"
+        : "default";
+}
+
+const itemColumns: ColumnsType<DoctorItem> = [
+  {
+    title: "Site",
+    key: "site",
+    render: (_, r) => (
+      <Space direction="vertical" size={0}>
+        <Typography.Text>{r.host || r.install_id}</Typography.Text>
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {r.path}
+        </Typography.Text>
+      </Space>
+    ),
+  },
+  {
+    title: "Status",
+    key: "status",
+    render: (_, r) => {
+      if (r.refreshed) return <Tag color="green">Refreshed</Tag>;
+      if (r.repaired) return <Tag color="green">Repaired</Tag>;
+      if (r.drifted) return <Tag color="red">Drifted</Tag>;
+      if (r.healthy) return <Tag color="green">Healthy</Tag>;
+      return <Tag color="orange">Unhealthy</Tag>;
+    },
+  },
+  {
+    title: "Detail / next action",
+    dataIndex: "error",
+    key: "error",
+    render: (err: string | undefined, r) =>
+      err ? (
+        <Typography.Text type={r.repaired || r.refreshed ? "secondary" : "danger"} style={{ fontSize: 12 }}>
+          {err}
+          {r.drifted && !r.repaired ? " — run Repair, or toggle the site's cache off/on." : ""}
+        </Typography.Text>
+      ) : (
+        <Typography.Text type="secondary">—</Typography.Text>
+      ),
+  },
+];
+
+export function FleetCacheDoctor() {
+  const { message } = App.useApp();
+  const qc = useQueryClient();
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+
+  const history = useQuery({
+    queryKey: ["cache-doctor-runs"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ runs: DoctorRun[] }>(`/admin/cache/doctor-runs`);
+      return data.runs ?? [];
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  const activeRun = useQuery({
+    queryKey: ["cache-doctor-run", activeRunId],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ run: DoctorRun }>(
+        `/admin/cache/doctor-runs/${activeRunId}`,
+      );
+      return data.run;
+    },
+    enabled: !!activeRunId,
+    // Poll while the run is in flight; stop once terminal.
+    refetchInterval: (query) => {
+      const st = query.state.data?.state;
+      return st === "done" || st === "failed" ? false : 2500;
+    },
+  });
+
+  // When the active run finishes, refresh the history table once.
+  const runState = activeRun.data?.state;
+  useEffect(() => {
+    if (runState === "done" || runState === "failed") {
+      void qc.invalidateQueries({ queryKey: ["cache-doctor-runs"] });
+    }
+  }, [runState, qc]);
+
+  const startMutation = useMutation({
+    mutationFn: async (kind: Kind) => {
+      const { data } = await apiClient.post<{ id: string }>(`/admin/cache/doctor-runs`, { kind });
+      return data.id;
+    },
+    onSuccess: (id, kind) => {
+      setActiveRunId(id);
+      message.success(`${KIND_LABEL[kind]} sweep started`);
+    },
+    onError: (e) => {
+      const detail = extractApiError(e);
+      message.error(
+        detail?.includes("run_in_progress")
+          ? "A sweep is already running — wait for it to finish."
+          : (detail ?? "Failed to start sweep"),
+      );
+    },
+  });
+
+  const run = activeRun.data;
+  const busy = startMutation.isPending || run?.state === "running" || run?.state === "queued";
+
+  return (
+    <Card
+      title={
+        <Space>
+          <ThunderboltOutlined />
+          <span>Fleet cache doctor</span>
+        </Space>
+      }
+      style={{ marginBottom: 16 }}
+    >
+      <Typography.Paragraph type="secondary">
+        Sweep every cache-enabled WordPress install. <b>Doctor</b> detects drift
+        (plugin inactive, missing drop-in/constants, unreachable Redis) read-only.
+        <b> Repair</b> re-provisions drifted installs. <b>Refresh plugin</b> updates
+        the jabali-cache plugin fleet-wide. Sweeps run in the background — progress
+        updates below.
+      </Typography.Paragraph>
+
+      <Space wrap style={{ marginBottom: 12 }}>
+        <Button
+          type="primary"
+          icon={<ThunderboltOutlined />}
+          loading={busy && run?.kind === "doctor"}
+          disabled={busy}
+          onClick={() => startMutation.mutate("doctor")}
+        >
+          Run doctor
+        </Button>
+        <Popconfirm
+          title="Repair all drifted installs?"
+          description="Re-provisions cache (constants, ACL, drop-in) for every drifted site."
+          okText="Repair"
+          okButtonProps={{ danger: true }}
+          disabled={busy}
+          onConfirm={() => startMutation.mutate("repair")}
+        >
+          <Button danger icon={<ToolOutlined />} disabled={busy}>
+            Repair drift
+          </Button>
+        </Popconfirm>
+        <Popconfirm
+          title="Refresh the jabali-cache plugin on every cache-enabled site?"
+          okText="Refresh"
+          disabled={busy}
+          onConfirm={() => startMutation.mutate("refresh")}
+        >
+          <Button icon={<ReloadOutlined />} disabled={busy}>
+            Refresh plugin
+          </Button>
+        </Popconfirm>
+      </Space>
+
+      {run ? (
+        <div style={{ marginBottom: 16 }}>
+          <Space wrap>
+            <Tag color={stateColor(run.state)}>{run.state.toUpperCase()}</Tag>
+            <span>{KIND_LABEL[run.kind]}</span>
+            <Typography.Text type="secondary">
+              checked {run.checked}/{run.total}
+              {run.drifted ? `, drifted ${run.drifted}` : ""}
+              {run.repaired ? `, repaired ${run.repaired}` : ""}
+              {run.refreshed ? `, refreshed ${run.refreshed}` : ""}
+              {run.failed ? `, failed ${run.failed}` : ""}
+            </Typography.Text>
+          </Space>
+          {run.first_error ? (
+            <Alert
+              type="error"
+              showIcon
+              style={{ marginTop: 8 }}
+              message={run.first_error}
+            />
+          ) : null}
+          {run.results && run.results.length > 0 ? (
+            <Table<DoctorItem>
+              rowKey="install_id"
+              size="small"
+              style={{ marginTop: 12 }}
+              columns={itemColumns}
+              dataSource={run.results}
+              pagination={{ pageSize: 10, hideOnSinglePage: true }}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      <Typography.Title level={5}>Recent runs</Typography.Title>
+      <Table<DoctorRun>
+        rowKey="id"
+        size="small"
+        loading={history.isLoading}
+        dataSource={history.data ?? []}
+        pagination={{ pageSize: 10, hideOnSinglePage: true }}
+        onRow={(r) => ({ onClick: () => setActiveRunId(r.id), style: { cursor: "pointer" } })}
+        columns={[
+          { title: "When", dataIndex: "created_at", render: (v: string) => shortDateTime(v) },
+          { title: "Kind", dataIndex: "kind", render: (k: Kind) => KIND_LABEL[k] },
+          {
+            title: "State",
+            dataIndex: "state",
+            render: (s: DoctorRun["state"]) => <Tag color={stateColor(s)}>{s}</Tag>,
+          },
+          {
+            title: "Result",
+            key: "result",
+            render: (_, r) => (
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {r.checked}/{r.total} checked
+                {r.drifted ? `, ${r.drifted} drifted` : ""}
+                {r.repaired ? `, ${r.repaired} repaired` : ""}
+                {r.refreshed ? `, ${r.refreshed} refreshed` : ""}
+                {r.failed ? `, ${r.failed} failed` : ""}
+              </Typography.Text>
+            ),
+          },
+        ]}
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## JAB-11 (fleet half) — admin fleet cache-doctor, repair, refresh + run history

Slice 1 (#494) shipped per-install cache-health. This adds the fleet sweep the issue asks for — across **every** cache-enabled WordPress install — without the synchronous-sweep 502 risk. The sweep runs in a background goroutine and the GUI polls a durable run record (same async-run shape as JAB-95's `cache_warmup_runs`).

### Schema + model + repo
- `000226_cache_doctor_runs`: id / kind / state / counts (total, checked, drifted, repaired, refreshed, failed) / first_error / `results` (JSON, per-install) / timestamps.
- `models.CacheDoctorRun` + `CacheDoctorItem`; kind `{doctor|repair|refresh}`, state `{queued|running|done|failed}`.
- `CacheDoctorRunRepository`: Create / Update / Get / ListRecent / CountActive.

### API (admin, async)
- `POST /admin/cache/doctor-runs {kind}` — creates a run, spawns the background sweep, returns the id immediately (**202**). One sweep at a time (`CountActive` → **409**). `repair` needs Redis wiring (**503** otherwise).
- `GET /admin/cache/doctor-runs` — recent runs (history).
- `GET /admin/cache/doctor-runs/:id` — poll one run.
- Executor sweeps cache-enabled ready WordPress installs: per install runs `wordpress.cache_health`; **repair** re-runs the idempotent `SetApplicationCache` (constants + ACL + drop-in, the same call the CLI `cache-doctor --repair` makes); **refresh** calls `wordpress.cache_plugin_refresh`. Per-install call bounded 90s, whole sweep 30m; every failure records the exact install id + path + detail. Admin-route audit middleware records the trigger.

### UI
- `FleetCacheDoctor` card on the admin Cache overview page: **Run doctor / Repair drift / Refresh plugin** (repair + refresh confirm-gated), live progress polling, per-install results (site / status badge / detail + next action), and a recent run history table (click a row to re-open its results).

### Acceptance criteria (issue JAB-11)
- [x] Admin cache page has a WordPress cache maintenance section.
- [x] Shows all cache-enabled installs with state / drift / per-site results + last doctor result (history).
- [x] Read-only "Run cache doctor" returning structured drift data.
- [x] Confirm-gated "Repair drift" (== `cache-doctor --repair`), per-site results.
- [x] Confirm-gated "Refresh Jabali cache plugin" (== `refresh-cache-plugin`), per-install success/failure.
- [x] Audited (admin-route middleware) + recent run history.
- [x] Failures include the exact install id / path + recommended next action.

### Test plan
- [x] `go test ./internal/api/` — executor sweep: drift detection, healthy no-drift, refresh-updates-plugin (in-memory run repo + mock agent).
- [x] `go test ./internal/... ./cmd/server/` green; `go vet` clean; CLI golden unchanged.
- [x] `npx tsc -b`, `npx eslint`, `npm run build` clean.
- [ ] Live admin visual + a real fleet sweep on a box (Playwright E2E covers the cache route render in CI).

Follow-up (optional): a nightly `doctor` timer that surfaces standing drift without a manual click.