### PR TITLE
fix(api): route backup download Content-Disposition through the RFC 6266 helper (JAB-108)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -750,7 +750,7 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 		return
 	}
 	c.Header("Content-Type", contentType)
-	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	c.Header("Content-Disposition", contentDisposition("attachment", filename))
 	if _, werr := c.Writer.Write(head[:n]); werr != nil {
 		logErr("tar download write head", werr, "job_id", job.ID)
 	}


### PR DESCRIPTION
## JAB-108 — no raw Content-Disposition in download handlers

The RFC 6266-safe `contentDisposition()` helper already backed the **files** and **database-dump** downloads, but the **backup-archive** download (`backups.go`) still built the header by raw string interpolation:

```go
c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
```

The name is a ULID job id today (no special chars), so there's no live break-out — but leaving one raw site means a future filename source silently reintroduces the quote/semicolon spoof. This routes it through the same helper (ASCII-sanitized `filename=` + RFC 5987 `filename*`), so **no** download handler concatenates a filename into the header.

### Test plan
- [x] `go build` / `go vet ./internal/api/` clean.
- [x] `go test ./internal/api/` (existing `TestContentDisposition_*` cover the helper's escaping; the change just routes through it).