### PR TITLE
fix(migration): preserve non-bcrypt source mail password hashes (JAB-149)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -386,7 +386,7 @@ func loadSourceMailPasswords(domainDir string) map[string]string {
 		if len(parts) < 2 || parts[0] == "" {
 			continue
 		}
-		if h := normalizeBcryptHash(parts[1]); h != "" {
+		if h := normalizeSourceMailHash(parts[1]); h != "" {
 			out[parts[0]] = h
 		}
 	}
@@ -426,19 +426,41 @@ func listSourceMailAccounts(domainDir string) []string {
 	return out
 }
 
-// normalizeBcryptHash strips a leading {SCHEME} tag and returns the hash only if
-// it is a bcrypt variant Stalwart verifies ($2a/$2b/$2y). Empty otherwise — a
-// non-bcrypt source hash must not be stored (it would never authenticate, re-
-// creating the silent-lockout bug with a different value).
-func normalizeBcryptHash(field string) string {
+// stalwartHashPrefixes are the crypt-string prefixes Stalwart verifies for a
+// stored account password (per stalw.art/docs/auth/authentication/password):
+// bcrypt, SHA-512/256/MD5-crypt, Argon2, PBKDF2, scrypt, SHA-1-crypt. Source
+// panels (cPanel/HestiaCP dovecot) export these as {SCHEME}$crypt strings; once
+// the dovecot {SCHEME} tag is stripped, the bare $-prefixed crypt is exactly
+// what Stalwart recognises by prefix.
+var stalwartHashPrefixes = []string{
+	"$2a$", "$2b$", "$2y$", // bcrypt
+	"$6$",      // SHA-512 crypt
+	"$5$",      // SHA-256 crypt
+	"$1$",      // MD5 crypt
+	"$argon2",  // $argon2id / $argon2i / $argon2d
+	"$pbkdf2",  // PBKDF2 variants
+	"$scrypt",  // scrypt
+	"$sha1",    // SHA-1 crypt
+}
+
+// normalizeSourceMailHash strips a leading dovecot {SCHEME} tag and returns the
+// bare crypt string if Stalwart can verify it (JAB-149). Previously this kept
+// bcrypt only and dropped SHA-512/Argon2/etc., forcing a password reset on every
+// non-bcrypt mailbox even though Stalwart verifies those schemes natively —
+// which needlessly locked migrated users out of their existing password. A hash
+// with no Stalwart-recognised prefix (e.g. {PLAIN} plaintext, unknown scheme) is
+// still dropped: storing it would never authenticate.
+func normalizeSourceMailHash(field string) string {
 	h := field
 	if strings.HasPrefix(h, "{") {
 		if i := strings.IndexByte(h, '}'); i >= 0 {
 			h = h[i+1:]
 		}
 	}
-	if strings.HasPrefix(h, "$2a$") || strings.HasPrefix(h, "$2b$") || strings.HasPrefix(h, "$2y$") {
-		return h
+	for _, pfx := range stalwartHashPrefixes {
+		if strings.HasPrefix(h, pfx) {
+			return h
+		}
 	}
 	return ""
 }

--- a/panel-api/internal/migrate/cpanel/restore_mail_password_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_password_test.go
@@ -6,28 +6,33 @@ import (
 	"testing"
 )
 
-// normalizeBcryptHash strips a {SCHEME} tag and accepts only bcrypt variants
-// Stalwart verifies — a non-bcrypt hash must be dropped (storing it would re-
-// create the silent-lockout bug with a new value).
-func TestNormalizeBcryptHash(t *testing.T) {
+// normalizeSourceMailHash strips a {SCHEME} tag and keeps any crypt string
+// Stalwart verifies (bcrypt, SHA-512/256/MD5-crypt, Argon2, PBKDF2, scrypt).
+// Only unknown/plaintext hashes are dropped (JAB-149).
+func TestNormalizeSourceMailHash(t *testing.T) {
 	cases := map[string]string{
 		"{BLF-CRYPT}$2y$05$abcdefghijklmnopqrstuv": "$2y$05$abcdefghijklmnopqrstuv",
 		"$2a$10$abcdefghijklmnopqrstuv":            "$2a$10$abcdefghijklmnopqrstuv",
 		"$2b$12$abcdefghijklmnopqrstuv":            "$2b$12$abcdefghijklmnopqrstuv",
-		"{SHA512-CRYPT}$6$rounds=5000$salt$hash":   "", // not bcrypt → drop
-		"{PLAIN}hunter2":                           "",
-		"plaintextnope":                            "",
-		"":                                         "",
+		// JAB-149: Stalwart verifies these natively — preserve, don't drop.
+		"{SHA512-CRYPT}$6$rounds=5000$salt$hash": "$6$rounds=5000$salt$hash",
+		"{SHA256-CRYPT}$5$rounds=5000$salt$hash": "$5$rounds=5000$salt$hash",
+		"$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$aGFzaA": "$argon2id$v=19$m=65536,t=3,p=4$c2FsdA$aGFzaA",
+		"{MD5-CRYPT}$1$salt$hash":                "$1$salt$hash",
+		// No Stalwart-recognised prefix → still dropped.
+		"{PLAIN}hunter2": "",
+		"plaintextnope":  "",
+		"":               "",
 	}
 	for in, want := range cases {
-		if got := normalizeBcryptHash(in); got != want {
-			t.Errorf("normalizeBcryptHash(%q) = %q, want %q", in, got, want)
+		if got := normalizeSourceMailHash(in); got != want {
+			t.Errorf("normalizeSourceMailHash(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
 
 // loadSourceMailPasswords parses a Hestia dovecot passwd-file into local→hash,
-// keeping only Stalwart-verifiable bcrypt; missing file → empty.
+// keeping every Stalwart-verifiable scheme (JAB-149); missing file → empty.
 func TestLoadSourceMailPasswords(t *testing.T) {
 	dir := t.TempDir()
 	confDir := filepath.Join(dir, "conf")
@@ -51,11 +56,11 @@ func TestLoadSourceMailPasswords(t *testing.T) {
 	if got["admin"] != "$2b$10$anotheranotheranotherx" {
 		t.Errorf("admin hash = %q", got["admin"])
 	}
-	if _, ok := got["legacy"]; ok {
-		t.Error("legacy (SHA-CRYPT) must be dropped, not stored")
+	if got["legacy"] != "$6$rounds=5000$s$h" {
+		t.Errorf("legacy (SHA512-CRYPT) must be preserved (JAB-149), got %q", got["legacy"])
 	}
-	if len(got) != 2 {
-		t.Errorf("want 2 usable hashes, got %d: %v", len(got), got)
+	if len(got) != 3 {
+		t.Errorf("want 3 usable hashes (JAB-149 keeps SHA512), got %d: %v", len(got), got)
 	}
 
 	// Missing file → empty map, no error.


### PR DESCRIPTION
## JAB-149 — migrated mailboxes keep non-bcrypt passwords

Migration preserved only **bcrypt** (`$2a`/`$2b`/`$2y`) source mailbox hashes and **dropped** SHA-512-crypt, Argon2, etc., forcing a password reset on every non-bcrypt mailbox. The stated reason ("Stalwart verifies bcrypt only") is incorrect.

**Verified against Stalwart docs** (`stalw.art/docs/auth/authentication/password`, via Context7): Stalwart recognises a stored password by prefix and natively verifies **bcrypt, SHA-512/256/MD5-crypt (`$6$`/`$5$`/`$1$`), Argon2 (`$argon2`), PBKDF2, scrypt, SHA-1-crypt** — its migration guide even creates an account with a `$6$` hash directly.

### Change
- `normalizeBcryptHash` → `normalizeSourceMailHash`: after stripping the dovecot `{SCHEME}` tag, keep any crypt string whose prefix Stalwart verifies (`stalwartHashPrefixes`). Unknown/plaintext hashes are still dropped (storing one would never authenticate).
- Shared cpanel restore path → covers HestiaCP too (it reuses these writers).

### Impact
HestiaCP/cPanel mailboxes whose source password is SHA-512-crypt or Argon2 now migrate with the **existing password intact** instead of being silently locked out and reset.

### Test plan
- [x] `TestNormalizeSourceMailHash` — SHA-512/256, Argon2id, MD5-crypt preserved; `{PLAIN}`/unknown dropped.
- [x] `TestLoadSourceMailPasswords` — the SHA512-CRYPT row is now preserved (was asserted-dropped).
- [x] `go test ./internal/migrate/cpanel/` green; `go vet` clean.