### PR TITLE
feat(automation): expose orderable build_time + commit in /status (JAB-141)

### DIFF
--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -321,6 +321,12 @@ func (m *automationMetrics) handle(c *gin.Context) {
 		"healthy": len(errs) == 0,
 		"time":    time.Now().UTC(),
 		"version": Version,
+		// JAB-141: Sounder needs an ORDERABLE release identifier, not just the
+		// short SHA (which can't be compared/sorted). build_time is the RFC3339
+		// link time — lexically sortable, so the monitor can tell which managed
+		// panel is running a newer build. commit is the full SHA for provenance.
+		"commit":     Commit,
+		"build_time": BuildTime,
 	}
 	if info != nil {
 		out["system"] = info

--- a/panel-api/internal/api/automation_status_shape_test.go
+++ b/panel-api/internal/api/automation_status_shape_test.go
@@ -47,6 +47,14 @@ func TestAutomationStatus_NormalizedServiceHealthAndNet(t *testing.T) {
 		}
 	}
 
+	// JAB-141: orderable release identity — version (SHA), commit (full SHA),
+	// and build_time (RFC3339, sortable) must all be present for Sounder.
+	for _, k := range []string{"version", "commit", "build_time"} {
+		if _, ok := body[k]; !ok {
+			t.Errorf("expected release field %q in payload", k)
+		}
+	}
+
 	var health []automationServiceHealth
 	if err := json.Unmarshal(body["service_health"], &health); err != nil {
 		t.Fatalf("decode service_health: %v", err)


### PR DESCRIPTION
## JAB-141 — orderable release identity for Sounder

`GET /api/v1/automation/status` returned only `version` (the **short git SHA**), which the Sounder monitor can't compare or sort — so it can't tell which managed panel is on a newer build.

Add two additive fields, both already baked in via `-ldflags` (`api.BuildTime` / `api.Commit`):
- **`build_time`** — RFC3339 link timestamp, **lexically orderable** → the monitor can rank builds.
- **`commit`** — full git SHA, for provenance.

Back-compat: existing fields unchanged; the additions are tolerated by Sounder.

### Test plan
- [x] `TestAutomationStatus_*` asserts `version`/`commit`/`build_time` present.
- [x] `go test ./internal/api/`, `go vet` clean.