### PR TITLE
perf(nginx): serve /assets/ from disk with a panel-api fallback (JAB-144)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5809,11 +5809,15 @@ install_nginx_panel_vhost() {
   # via sed. envsubst would be cleaner but isn't a dependency we want to
   # add solely for two substitutions.
   _nginx_http2_form
+  # JAB-144: /assets/ is served from the on-disk build output (panel-ui/dist),
+  # the same tree the panel-api binary embedded, with a proxy fallback.
+  local panel_dist_dir="${REPO_DIR}/panel-ui/dist"
   sed \
     -e "s|\${SSL_CERT_PATH}|${tls_cert}|g" \
     -e "s|\${SSL_KEY_PATH}|${tls_key}|g" \
     -e "s|\${NGX_H2_PARAM}|${_NGX_H2_PARAM}|g" \
     -e "s|\${NGX_H2_DIR}|${_NGX_H2_DIR}|g" \
+    -e "s|\${PANEL_DIST_DIR}|${panel_dist_dir}|g" \
     "$tmpl" > "$panel_vhost_file"
 
   if grep -q '\${' "$panel_vhost_file"; then

--- a/install/nginx/jabali-panel-vhost.conf.tmpl
+++ b/install/nginx/jabali-panel-vhost.conf.tmpl
@@ -133,13 +133,27 @@ server {
     proxy_hide_header X-Frame-Options;
   }
 
-  # JAB-143: content-hashed build assets (index-<hash>.js / .css) are
-  # immutable — every build emits a new filename — so cache them for a year
-  # instead of re-fetching the ~3 MB bundle each session. Proxies to the same
-  # panel-api upstream (the SPA is embedded there). A per-location add_header
-  # suppresses the server-scope add_headers, so the security headers relevant
-  # to a static asset response are re-declared here.
+  # JAB-143/144: content-hashed build assets (index-<hash>.js / .css) are
+  # immutable — every build emits a new filename — so cache them for a year.
+  # JAB-144: serve them straight from disk (the on-disk panel-ui/dist that the
+  # panel-api binary was built from) instead of proxying every static file
+  # through the Go process. `root` (not `alias`) keeps try_files sane: a request
+  # /assets/x maps to ${PANEL_DIST_DIR}/assets/x. If a hashed file isn't on disk
+  # yet (e.g. mid-update, before the rebuilt dist lands), fall back to the
+  # panel-api go:embed copy so the asset still resolves — no white-screen.
   location ^~ /assets/ {
+    root ${PANEL_DIST_DIR};
+    try_files $uri @panel_assets_embed;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  }
+
+  # Fallback for /assets/* not present on disk: serve from the panel-api
+  # embedded SPA. Same immutable cache + security headers as the disk path.
+  location @panel_assets_embed {
     proxy_pass http://jabali_panel_api;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -148,7 +162,6 @@ server {
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_http_version 1.1;
-    # Exactly one Cache-Control: drop any the upstream might set, then add ours.
     proxy_hide_header Cache-Control;
     add_header Cache-Control "public, max-age=31536000, immutable" always;
     add_header Strict-Transport-Security "max-age=31536000" always;


### PR DESCRIPTION
## JAB-144 — serve SPA assets from disk instead of proxying through panel-api

The content-hashed SPA assets (`index-<hash>.js/.css`) were proxied through the Go panel-api for every request (it embeds the SPA via `go:embed`). JAB-142/143 already made that path cache well (gzip + immutable `Cache-Control`), but each cache miss still costs a Go proxy hop. Serve them straight from the on-disk build output — the same `panel-ui/dist` tree the binary was built from.

### Change
- **vhost**: `location ^~ /assets/` now uses `root ${PANEL_DIST_DIR}` + `try_files`, so `/assets/x` maps to `<dist>/assets/x` served directly by nginx. `root` (not `alias`) keeps `try_files` correct.
- **Safety fallback**: a file not on disk (e.g. mid-update, before the rebuilt dist lands) falls back to `@panel_assets_embed`, which proxies to the panel-api `go:embed` copy — no white-screen during the update window.
- **install.sh**: renders `${PANEL_DIST_DIR}` = `${REPO_DIR}/panel-ui/dist` via sed; the strict unsubstituted-`${}` check still guards template drift.
- **Propagation**: `update.go` already re-renders this vhost (the sync-nginx-panel-vhost step), so existing installs pick it up on `jabali update`.

### Perms
`REPO_DIR` is created `0755` and npm-built assets are world-readable, so nginx (`www-data`) can traverse+read them without extra chmod. gzip, security headers, and immutable `Cache-Control` are preserved on **both** the disk path and the fallback.

### Verification done
- [x] Rendered the template with sed → 0 leftover `${}`, braces balanced, blocks correct.
- [x] `root`+`try_files` (not `alias`) avoids the known try_files+alias quirk.

### Needs a box smoke before merge (no automated nginx test in CI)
- [ ] On a test host: `nginx -t` on the re-rendered vhost.
- [ ] `curl -I https://panel/assets/<real-hash>.js` → **200**, `Cache-Control: …immutable`, served from disk (not the upstream).
- [ ] `curl -I https://panel/assets/does-not-exist.js` → falls back to panel-api (no 500).