### PR TITLE
feat(settings): operator-configurable log retention — Server Settings → Logs (P1)

### DIFF
--- a/panel-api/cmd/server/audit_cmd.go
+++ b/panel-api/cmd/server/audit_cmd.go
@@ -81,11 +81,13 @@ func newAuditVerifyCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 			defer cancel()
-			rows, err := auditRepoFromDB().AllForVerify(ctx)
+			repo := auditRepoFromDB()
+			rows, err := repo.AllForVerify(ctx)
 			if err != nil {
 				return err
 			}
-			brokenID, checked, ok := audit.VerifyChain(rows)
+			anchor, _ := repo.ChainAnchor(ctx)
+			brokenID, checked, ok := audit.VerifyChain(rows, anchor)
 			if ok {
 				fmt.Printf("chain OK — %d sealed rows verified (%d total rows)\n", checked, len(rows))
 				return nil
@@ -110,7 +112,7 @@ func newAuditPruneCmd() *cobra.Command {
 			}
 			repo := auditRepoFromDB()
 			cutoff := time.Now().UTC().AddDate(0, 0, -days)
-			n, err := repo.PruneOlderThan(ctx, cutoff)
+			n, err := repo.PruneOlderThanWithAnchor(ctx, cutoff)
 			if err != nil {
 				return err
 			}

--- a/panel-api/cmd/server/retention_sweep_cmd.go
+++ b/panel-api/cmd/server/retention_sweep_cmd.go
@@ -160,6 +160,23 @@ blind delete), bw_daily (billing rollup decision), migration_jobs/stages
 				}
 				grand += n
 			}
+			// JAB-105: audit_events is hash-chained and excluded from the generic
+			// targets. Prune it only when the operator opts in (audit window > 0),
+			// via the chain-safe prune that re-anchors so `audit verify` still
+			// passes. Default is keep-forever (0) → skipped.
+			if auditDays := settings.RetentionDays(models.RetentionCatAudit); auditDays > 0 {
+				cutoff := time.Now().Add(-time.Duration(auditDays) * retentionDay)
+				if dryRun {
+					fmt.Fprintf(cmd.OutOrStdout(), "audit_events: would prune rows older than %s (%dd) with chain re-anchor\n", cutoff.Format(time.RFC3339), auditDays)
+				} else if n, err := auditRepoFromDB().PruneOlderThanWithAnchor(ctx, cutoff); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "audit_events: prune failed: %v\n", err)
+				} else {
+					grand += n
+					if n > 0 {
+						fmt.Fprintf(cmd.OutOrStdout(), "audit_events: pruned %d rows older than %s (chain re-anchored)\n", n, cutoff.Format(time.RFC3339))
+					}
+				}
+			}
 			fmt.Fprintf(cmd.OutOrStdout(), "retention-sweep: %d rows (dry-run=%v)\n", grand, dryRun)
 			return nil
 		},

--- a/panel-api/cmd/server/retention_sweep_cmd.go
+++ b/panel-api/cmd/server/retention_sweep_cmd.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
 const retentionDay = 24 * time.Hour
@@ -32,6 +34,11 @@ const retentionDay = 24 * time.Hour
 type retentionTarget struct {
 	table    string
 	tsColumn string
+	// category ties this target to a Server Settings -> Logs retention window
+	// (models.RetentionCat*). Empty = a FIXED cleanup not operator-configurable
+	// (e.g. expiry-based stream keys). window is the fallback used when category
+	// is empty; for a categorized target the window comes from server_settings.
+	category string
 	window   time.Duration
 	why      string
 }
@@ -41,16 +48,19 @@ type retentionTarget struct {
 // tables (malware, WAF incidents, db-admin audit) get a generous 1-year window
 // so forensics survive while disk stays bounded.
 var retentionTargets = []retentionTarget{
-	{"log_access_streams", "expires_at", 1 * retentionDay, "expired log-view stream keys (JAB-103)"},
-	{"terminal_sessions", "created_at", 90 * retentionDay, "root-terminal session rows; .cast files rotate via logrotate (JAB-103)"},
-	{"notification_history", "created_at", 90 * retentionDay, "delivered-notification log (JAB-100)"},
-	{"update_history", "started_at", 180 * retentionDay, "update-center run history + stored log excerpts (JAB-101)"},
-	{"dmarc_aggregate", "created_at", 180 * retentionDay, "DMARC aggregate reports (JAB-125)"},
-	{"tlsrpt_aggregate", "created_at", 180 * retentionDay, "TLS-RPT aggregate reports (JAB-125)"},
-	{"arf_report", "received_at", 180 * retentionDay, "ARF failure reports (JAB-125)"},
-	{"malware_events", "created_at", 365 * retentionDay, "malware raw event log — security, 1y window (JAB-123)"},
-	{"snuffleupagus_incidents", "ts", 365 * retentionDay, "Snuffleupagus WAF incidents — security, 1y window (JAB-122)"},
-	{"db_admin_audit", "ts", 365 * retentionDay, "legacy DB-admin audit — 1y window (JAB-105; hash-chained audit_events excluded)"},
+	// Fixed (not operator-configurable): expiry-based cleanup of temporary
+	// stream credentials — keeping these 90d would defeat their purpose.
+	{"log_access_streams", "expires_at", "", 1 * retentionDay, "expired log-view stream keys (JAB-103)"},
+	// Operator-configurable via Server Settings -> Logs (default 90d, security 365d).
+	{"terminal_sessions", "created_at", models.RetentionCatSessions, 90 * retentionDay, "root-terminal session rows; .cast files rotate via logrotate (JAB-103)"},
+	{"notification_history", "created_at", models.RetentionCatNotifications, 90 * retentionDay, "delivered-notification log (JAB-100)"},
+	{"update_history", "started_at", models.RetentionCatUpdates, 90 * retentionDay, "update-center run history + stored log excerpts (JAB-101)"},
+	{"dmarc_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "DMARC aggregate reports (JAB-125)"},
+	{"tlsrpt_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "TLS-RPT aggregate reports (JAB-125)"},
+	{"arf_report", "received_at", models.RetentionCatMailReports, 90 * retentionDay, "ARF failure reports (JAB-125)"},
+	{"malware_events", "created_at", models.RetentionCatSecurityEvents, 365 * retentionDay, "malware raw event log — security (JAB-123)"},
+	{"snuffleupagus_incidents", "ts", models.RetentionCatSecurityEvents, 365 * retentionDay, "Snuffleupagus WAF incidents — security (JAB-122)"},
+	{"db_admin_audit", "ts", models.RetentionCatDBAdminAudit, 365 * retentionDay, "legacy DB-admin audit — security (JAB-105)"},
 }
 
 // retentionBatchSize bounds each DELETE so a large backlog can't hold a long
@@ -109,9 +119,24 @@ blind delete), bw_daily (billing rollup decision), migration_jobs/stages
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Minute)
 			defer cancel()
+			// Load the single settings row once so every categorized target
+			// resolves its window from the operator's config (default on error).
+			var settings models.ServerSettings
+			if err := sharedDB.WithContext(ctx).First(&settings, "id = ?", 1).Error; err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "retention-sweep: server_settings unreadable (%v) — using code defaults\n", err)
+			}
 			var grand int64
 			for _, t := range retentionTargets {
-				n, err := pruneRetentionTarget(ctx, sharedDB, t, dryRun, cmd.OutOrStdout())
+				eff := t
+				if t.category != "" {
+					days := settings.RetentionDays(t.category)
+					if days <= 0 {
+						fmt.Fprintf(cmd.OutOrStdout(), "%s: retention disabled (keep forever) — skipped\n", t.table)
+						continue
+					}
+					eff.window = time.Duration(days) * retentionDay
+				}
+				n, err := pruneRetentionTarget(ctx, sharedDB, eff, dryRun, cmd.OutOrStdout())
 				if err != nil {
 					// One table failing (e.g. absent on an older schema) must
 					// not skip the rest — log and continue.

--- a/panel-api/cmd/server/retention_sweep_cmd.go
+++ b/panel-api/cmd/server/retention_sweep_cmd.go
@@ -40,7 +40,10 @@ type retentionTarget struct {
 	// is empty; for a categorized target the window comes from server_settings.
 	category string
 	window   time.Duration
-	why      string
+	// extraWhere is an optional additional predicate ANDed into the prune (e.g.
+	// only terminal migration jobs). Empty = age cutoff only.
+	extraWhere string
+	why        string
 }
 
 // retentionTargets — every entry is a leaf log/report table with no hash chain
@@ -50,17 +53,23 @@ type retentionTarget struct {
 var retentionTargets = []retentionTarget{
 	// Fixed (not operator-configurable): expiry-based cleanup of temporary
 	// stream credentials — keeping these 90d would defeat their purpose.
-	{"log_access_streams", "expires_at", "", 1 * retentionDay, "expired log-view stream keys (JAB-103)"},
+	{"log_access_streams", "expires_at", "", 1 * retentionDay, "", "expired log-view stream keys (JAB-103)"},
 	// Operator-configurable via Server Settings -> Logs (default 90d, security 365d).
-	{"terminal_sessions", "created_at", models.RetentionCatSessions, 90 * retentionDay, "root-terminal session rows; .cast files rotate via logrotate (JAB-103)"},
-	{"notification_history", "created_at", models.RetentionCatNotifications, 90 * retentionDay, "delivered-notification log (JAB-100)"},
-	{"update_history", "started_at", models.RetentionCatUpdates, 90 * retentionDay, "update-center run history + stored log excerpts (JAB-101)"},
-	{"dmarc_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "DMARC aggregate reports (JAB-125)"},
-	{"tlsrpt_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "TLS-RPT aggregate reports (JAB-125)"},
-	{"arf_report", "received_at", models.RetentionCatMailReports, 90 * retentionDay, "ARF failure reports (JAB-125)"},
-	{"malware_events", "created_at", models.RetentionCatSecurityEvents, 365 * retentionDay, "malware raw event log — security (JAB-123)"},
-	{"snuffleupagus_incidents", "ts", models.RetentionCatSecurityEvents, 365 * retentionDay, "Snuffleupagus WAF incidents — security (JAB-122)"},
-	{"db_admin_audit", "ts", models.RetentionCatDBAdminAudit, 365 * retentionDay, "legacy DB-admin audit — security (JAB-105)"},
+	{"terminal_sessions", "created_at", models.RetentionCatSessions, 90 * retentionDay, "", "root-terminal session rows; .cast files rotate via logrotate (JAB-103)"},
+	{"notification_history", "created_at", models.RetentionCatNotifications, 90 * retentionDay, "", "delivered-notification log (JAB-100)"},
+	{"update_history", "started_at", models.RetentionCatUpdates, 90 * retentionDay, "", "update-center run history + stored log excerpts (JAB-101)"},
+	{"dmarc_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "", "DMARC aggregate reports (JAB-125)"},
+	{"tlsrpt_aggregate", "created_at", models.RetentionCatMailReports, 90 * retentionDay, "", "TLS-RPT aggregate reports (JAB-125)"},
+	{"arf_report", "received_at", models.RetentionCatMailReports, 90 * retentionDay, "", "ARF failure reports (JAB-125)"},
+	{"malware_events", "created_at", models.RetentionCatSecurityEvents, 365 * retentionDay, "", "malware raw event log — security (JAB-123)"},
+	{"snuffleupagus_incidents", "ts", models.RetentionCatSecurityEvents, 365 * retentionDay, "", "Snuffleupagus WAF incidents — security (JAB-122)"},
+	{"db_admin_audit", "ts", models.RetentionCatDBAdminAudit, 365 * retentionDay, "", "legacy DB-admin audit — security (JAB-105)"},
+	// JAB-124: per-domain daily bandwidth ledger. Plain age-prune on the date.
+	{"bw_daily", "day", models.RetentionCatBandwidth, 90 * retentionDay, "", "per-domain daily bandwidth ledger (JAB-124)"},
+	// JAB-102: terminal migration jobs (stages cascade via ON DELETE CASCADE).
+	// Only terminal states + rows with ended_at set — never touches an in-flight
+	// job. reap-secrets already wiped their secrets/staging.
+	{"migration_jobs", "ended_at", models.RetentionCatMigrations, 90 * retentionDay, "state IN ('done','failed','degraded','cancelled')", "terminal migration job + stage rows (JAB-102)"},
 }
 
 // retentionBatchSize bounds each DELETE so a large backlog can't hold a long
@@ -71,9 +80,15 @@ const retentionBatchSize = 5000
 // now-window. Returns the number removed / would-remove.
 func pruneRetentionTarget(ctx context.Context, db *gorm.DB, t retentionTarget, dryRun bool, out io.Writer) (int64, error) {
 	cutoff := time.Now().Add(-t.window)
+	// Optional extra predicate (e.g. only terminal migration jobs), ANDed in.
+	andWhere := ""
+	if t.extraWhere != "" {
+		andWhere = " AND " + t.extraWhere
+	}
 	if dryRun {
 		var n int64
-		if err := db.WithContext(ctx).Table(t.table).Where(t.tsColumn+" < ?", cutoff).Count(&n).Error; err != nil {
+		q := db.WithContext(ctx).Table(t.table).Where(t.tsColumn+" < ?"+andWhere, cutoff)
+		if err := q.Count(&n).Error; err != nil {
 			return 0, err
 		}
 		if n > 0 {
@@ -84,7 +99,7 @@ func pruneRetentionTarget(ctx context.Context, db *gorm.DB, t retentionTarget, d
 	var total int64
 	for {
 		res := db.WithContext(ctx).Exec(
-			"DELETE FROM "+t.table+" WHERE "+t.tsColumn+" < ? LIMIT ?", cutoff, retentionBatchSize)
+			"DELETE FROM "+t.table+" WHERE "+t.tsColumn+" < ?"+andWhere+" LIMIT ?", cutoff, retentionBatchSize)
 		if res.Error != nil {
 			return total, res.Error
 		}

--- a/panel-api/cmd/server/retention_sweep_test.go
+++ b/panel-api/cmd/server/retention_sweep_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -65,5 +66,38 @@ func TestRetentionTargets_SecurityTablesKeptLong(t *testing.T) {
 		if security[tgt.table] && tgt.window < minSecurity {
 			t.Errorf("%s is security-sensitive; window %s is under the 1y forensics floor", tgt.table, tgt.window)
 		}
+	}
+}
+
+// JAB-102: the migration_jobs prune must be gated to TERMINAL states — never
+// delete an in-flight job. JAB-124: bw_daily is a configurable target.
+func TestRetentionTargets_P2MigrationAndBandwidth(t *testing.T) {
+	byTable := map[string]retentionTarget{}
+	for _, tgt := range retentionTargets {
+		byTable[tgt.table] = tgt
+	}
+
+	mj, ok := byTable["migration_jobs"]
+	if !ok {
+		t.Fatal("migration_jobs must be a retention target (JAB-102)")
+	}
+	if !strings.Contains(mj.extraWhere, "state IN") {
+		t.Errorf("migration_jobs prune must filter on terminal state, got extraWhere=%q", mj.extraWhere)
+	}
+	for _, s := range []string{"pending", "analyzing", "restoring"} {
+		if strings.Contains(mj.extraWhere, s) {
+			t.Errorf("migration_jobs prune must NOT include the in-flight state %q", s)
+		}
+	}
+	if mj.tsColumn != "ended_at" {
+		t.Errorf("migration_jobs must prune on ended_at (NULL for in-flight), got %q", mj.tsColumn)
+	}
+
+	bw, ok := byTable["bw_daily"]
+	if !ok {
+		t.Fatal("bw_daily must be a retention target (JAB-124)")
+	}
+	if bw.category != "bandwidth" {
+		t.Errorf("bw_daily category = %q, want bandwidth", bw.category)
 	}
 }

--- a/panel-api/internal/api/audit.go
+++ b/panel-api/internal/api/audit.go
@@ -77,7 +77,8 @@ func (h *auditHandler) verify(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	brokenID, checked, ok := audit.VerifyChain(rows)
+	anchor, _ := h.cfg.Repo.ChainAnchor(c.Request.Context())
+	brokenID, checked, ok := audit.VerifyChain(rows, anchor)
 	c.JSON(http.StatusOK, gin.H{
 		"ok":        ok,
 		"checked":   checked,
@@ -99,7 +100,7 @@ func (h *auditHandler) prune(c *gin.Context) {
 	}
 	ctx := c.Request.Context()
 	cutoff := time.Now().UTC().AddDate(0, 0, -req.Days)
-	n, err := h.cfg.Repo.PruneOlderThan(ctx, cutoff)
+	n, err := h.cfg.Repo.PruneOlderThanWithAnchor(ctx, cutoff)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -91,6 +91,7 @@ type updateServerSettingsRequest struct {
 	NS2Name                  *string `json:"ns2_name,omitempty"`
 	NS2IPv4                  *string `json:"ns2_ipv4,omitempty"`
 	AdminEmail               *string `json:"admin_email,omitempty"`
+	LogRetention             *json.RawMessage `json:"log_retention,omitempty"`
 	Timezone                 *string `json:"timezone,omitempty"`
 	SSHPort                  *uint16 `json:"ssh_port,omitempty"`
 	SSHPasswordAuth          *bool   `json:"ssh_password_auth,omitempty"`
@@ -288,6 +289,14 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.Timezone != nil {
 		current.Timezone = strings.TrimSpace(*req.Timezone)
+	}
+	if req.LogRetention != nil {
+		if err := validateLogRetention(*req.LogRetention); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
+			return
+		}
+		lr := *req.LogRetention
+		current.LogRetention = &lr
 	}
 	if req.SSHPort != nil {
 		current.SSHPort = *req.SSHPort
@@ -1315,4 +1324,27 @@ func (h *serverSettingsHandler) moduleInstall(c *gin.Context) {
 	}
 	h.dispatchModuleInstall(req.Key)
 	c.JSON(http.StatusAccepted, gin.H{"status": "installing", "key": req.Key})
+}
+
+
+// validateLogRetention checks a Server Settings -> Logs retention map: every key
+// must be a known category and every value an int in [0, 3650] days (0 = keep
+// forever). Rejects unknown keys so a typo can't silently no-op.
+func validateLogRetention(raw json.RawMessage) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var m map[string]int
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("log_retention must be a { category: days } object: %w", err)
+	}
+	for k, v := range m {
+		if _, ok := models.DefaultLogRetentionDays[k]; !ok {
+			return fmt.Errorf("unknown log-retention category %q", k)
+		}
+		if v < 0 || v > 3650 {
+			return fmt.Errorf("log-retention days for %q must be 0..3650, got %d", k, v)
+		}
+	}
+	return nil
 }

--- a/panel-api/internal/api/server_settings_retention_test.go
+++ b/panel-api/internal/api/server_settings_retention_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateLogRetention(t *testing.T) {
+	ok := []string{
+		``,
+		`null`,
+		`{"notifications": 90}`,
+		`{"audit": 0, "bandwidth": 3650}`,
+	}
+	for _, in := range ok {
+		if err := validateLogRetention(json.RawMessage(in)); err != nil {
+			t.Errorf("validateLogRetention(%q) = %v, want nil", in, err)
+		}
+	}
+	bad := []string{
+		`{"not_a_category": 90}`, // unknown key
+		`{"updates": -1}`,        // negative
+		`{"updates": 100000}`,    // over the cap
+		`[1,2,3]`,                // wrong shape
+	}
+	for _, in := range bad {
+		if err := validateLogRetention(json.RawMessage(in)); err == nil {
+			t.Errorf("validateLogRetention(%q) = nil, want error", in)
+		}
+	}
+}

--- a/panel-api/internal/audit/verify.go
+++ b/panel-api/internal/audit/verify.go
@@ -19,8 +19,12 @@ import "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 // guarantee is only as good as that function staying stable; a
 // deliberate change to canonical()/computeRowHash is itself a chain
 // break by design (old rows will fail verify) and must be versioned.
-func VerifyChain(rows []models.AuditEvent) (brokenID string, checked int, ok bool) {
-	prev := ""
+// startPrev is the chain root the recomputation begins from: "" for a full
+// (never-pruned) log, or server_settings.audit_chain_anchor after a retention
+// prune (JAB-105), so the surviving chain verifies against the pruned tail's
+// last sealed hash.
+func VerifyChain(rows []models.AuditEvent, startPrev string) (brokenID string, checked int, ok bool) {
+	prev := startPrev
 	for i := range rows {
 		r := &rows[i]
 		if r.RowHash == nil {

--- a/panel-api/internal/audit/verify_test.go
+++ b/panel-api/internal/audit/verify_test.go
@@ -29,7 +29,7 @@ func TestVerifyChain_ValidChainPasses(t *testing.T) {
 	r1 := sealed("01", 1, "")
 	r2 := sealed("02", 2, *r1.RowHash)
 	r3 := sealed("03", 3, *r2.RowHash)
-	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, r2, r3})
+	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, r2, r3}, "")
 	require.True(t, ok)
 	require.Equal(t, "", broken)
 	require.Equal(t, 3, checked)
@@ -41,7 +41,7 @@ func TestVerifyChain_TamperDetectedAtFirstBadRow(t *testing.T) {
 	r3 := sealed("03", 3, *r2.RowHash)
 	bad := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	r2.RowHash = &bad // tamper
-	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, r2, r3})
+	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, r2, r3}, "")
 	require.False(t, ok)
 	require.Equal(t, "02", broken, "first mismatching row id")
 	require.Equal(t, 1, checked, "r1 verified before the break")
@@ -51,8 +51,32 @@ func TestVerifyChain_PreChainRowsSkipped(t *testing.T) {
 	r1 := sealed("01", 1, "")
 	pre := models.AuditEvent{ID: "fold", TS: time.Unix(0, 2).UTC(), ActorKind: "admin", Action: "db.admin.x", Result: "ok"} // RowHash nil (M46 fold-in / fallback-pending)
 	r2 := sealed("02", 3, *r1.RowHash)                                                                                      // chained off r1, NOT off the nil row
-	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, pre, r2})
+	broken, checked, ok := VerifyChain([]models.AuditEvent{r1, pre, r2}, "")
 	require.True(t, ok, "nil-RowHash rows are skipped, not chain breaks")
 	require.Equal(t, "", broken)
 	require.Equal(t, 2, checked, "only the 2 sealed rows counted")
+}
+
+// JAB-105: after pruning the chain tail, the surviving rows verify only when
+// VerifyChain starts from the anchor (the last-pruned sealed row's hash) — not
+// from genesis. This is the invariant the retention re-anchor relies on.
+func TestVerifyChain_PrunedTailVerifiesFromAnchor(t *testing.T) {
+	r1 := sealed("01", 1, "")
+	r2 := sealed("02", 2, *r1.RowHash)
+	r3 := sealed("03", 3, *r2.RowHash)
+
+	// Prune r1 + r2. The anchor persisted by the prune = the newest deleted
+	// sealed row's hash = r2.RowHash (which is r3.PrevHash).
+	anchor := *r2.RowHash
+	survivors := []models.AuditEvent{r3}
+
+	// From genesis the pruned chain looks broken (r3's prev is not "").
+	_, _, okGenesis := VerifyChain(survivors, "")
+	require.False(t, okGenesis, "survivors must NOT verify from genesis after a tail prune")
+
+	// From the anchor they verify cleanly.
+	broken, checked, ok := VerifyChain(survivors, anchor)
+	require.True(t, ok, "survivors verify from the anchor")
+	require.Equal(t, "", broken)
+	require.Equal(t, 1, checked)
 }

--- a/panel-api/internal/db/migrations/000227_log_retention_config.down.sql
+++ b/panel-api/internal/db/migrations/000227_log_retention_config.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN log_retention;

--- a/panel-api/internal/db/migrations/000227_log_retention_config.up.sql
+++ b/panel-api/internal/db/migrations/000227_log_retention_config.up.sql
@@ -1,0 +1,7 @@
+-- Operator-configurable log/report retention (Server Settings -> Logs). One JSON
+-- column on the single-row server_settings holds a { category: days } map; an
+-- absent category falls back to the code default (90d baseline, 365d security,
+-- 0 = keep-forever for the hash-chained audit log). Closes the "make retention
+-- configurable" ask + backs JAB-102/105/124.
+ALTER TABLE server_settings
+  ADD COLUMN log_retention JSON NULL;

--- a/panel-api/internal/db/migrations/000228_audit_chain_anchor.down.sql
+++ b/panel-api/internal/db/migrations/000228_audit_chain_anchor.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN audit_chain_anchor;

--- a/panel-api/internal/db/migrations/000228_audit_chain_anchor.up.sql
+++ b/panel-api/internal/db/migrations/000228_audit_chain_anchor.up.sql
@@ -1,0 +1,8 @@
+-- JAB-105: pruning the hash-chained audit_events tail would leave the new-oldest
+-- surviving row's prev_hash pointing at a deleted row, so `audit verify` (which
+-- recomputes from genesis "") would report the chain broken. Persist an anchor =
+-- the row_hash of the newest sealed row that was pruned; verify then starts from
+-- the anchor instead of "", keeping the surviving chain verifiable. NULL = never
+-- pruned (chain roots at genesis).
+ALTER TABLE server_settings
+  ADD COLUMN audit_chain_anchor CHAR(64) NULL;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -331,6 +331,12 @@ type ServerSettings struct {
 	// RetentionDays(); never index into the raw map directly.
 	LogRetention *json.RawMessage `gorm:"column:log_retention;type:json" json:"log_retention,omitempty"`
 
+	// AuditChainAnchor is the row_hash of the newest sealed audit_events row that
+	// retention pruning removed (JAB-105). audit verify starts the chain
+	// recomputation from this anchor instead of genesis so the surviving chain
+	// stays verifiable after a prune. NULL/empty = never pruned (root at "").
+	AuditChainAnchor *string `gorm:"column:audit_chain_anchor;type:char(64)" json:"audit_chain_anchor,omitempty"`
+
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null"             json:"updated_at"`
 }
 

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -325,7 +325,65 @@ type ServerSettings struct {
 	NginxCacheKeyzoneMB   int `gorm:"column:nginx_cache_keyzone_mb;type:int;not null;default:64"    json:"nginx_cache_keyzone_mb"`
 	NginxCacheInactiveMin int `gorm:"column:nginx_cache_inactive_min;type:int;not null;default:60"  json:"nginx_cache_inactive_min"`
 
+	// LogRetention holds operator-configured retention windows for the log/report
+	// tables, as a { category: days } JSON map (Server Settings -> Logs). An
+	// absent/invalid category falls back to DefaultLogRetentionDays. Read via
+	// RetentionDays(); never index into the raw map directly.
+	LogRetention *json.RawMessage `gorm:"column:log_retention;type:json" json:"log_retention,omitempty"`
+
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null"             json:"updated_at"`
 }
 
 func (ServerSettings) TableName() string { return "server_settings" }
+
+
+// Log-retention category keys (Server Settings -> Logs). Each groups one or more
+// log/report tables the retention sweep prunes.
+const (
+	RetentionCatNotifications  = "notifications"
+	RetentionCatUpdates        = "updates"
+	RetentionCatMailReports    = "mail_reports"
+	RetentionCatSecurityEvents = "security_events"
+	RetentionCatDBAdminAudit   = "db_admin_audit"
+	RetentionCatSessions       = "sessions"
+	RetentionCatMigrations     = "migrations"
+	RetentionCatBandwidth      = "bandwidth"
+	RetentionCatAudit          = "audit"
+)
+
+// DefaultLogRetentionDays is the fallback window per category when the operator
+// hasn't set one. 90d baseline; 365d for forensic security tables; 0 (keep
+// forever) for the hash-chained audit log (a security audit must not silently
+// self-delete — it prunes with a chain re-anchor only when explicitly set).
+var DefaultLogRetentionDays = map[string]int{
+	RetentionCatNotifications:  90,
+	RetentionCatUpdates:        90,
+	RetentionCatMailReports:    90,
+	RetentionCatSecurityEvents: 365,
+	RetentionCatDBAdminAudit:   365,
+	RetentionCatSessions:       90,
+	RetentionCatMigrations:     90,
+	RetentionCatBandwidth:      90,
+	RetentionCatAudit:          0,
+}
+
+// RetentionDays returns the configured retention window (in days) for a log
+// category: the operator override when present + valid, else the code default
+// (90 for an unknown category). 0 means keep forever (pruning disabled).
+func (s ServerSettings) RetentionDays(category string) int {
+	def, ok := DefaultLogRetentionDays[category]
+	if !ok {
+		def = 90
+	}
+	if s.LogRetention == nil || len(*s.LogRetention) == 0 {
+		return def
+	}
+	var m map[string]int
+	if err := json.Unmarshal(*s.LogRetention, &m); err != nil {
+		return def
+	}
+	if v, present := m[category]; present && v >= 0 && v <= 3650 {
+		return v
+	}
+	return def
+}

--- a/panel-api/internal/models/server_settings_retention_test.go
+++ b/panel-api/internal/models/server_settings_retention_test.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func rawJSON(v any) *json.RawMessage {
+	b, _ := json.Marshal(v)
+	r := json.RawMessage(b)
+	return &r
+}
+
+func TestRetentionDays_DefaultsAndOverride(t *testing.T) {
+	// No config → code defaults (90 baseline, 365 security, 0 audit).
+	var none ServerSettings
+	if d := none.RetentionDays(RetentionCatNotifications); d != 90 {
+		t.Errorf("notifications default = %d, want 90", d)
+	}
+	if d := none.RetentionDays(RetentionCatSecurityEvents); d != 365 {
+		t.Errorf("security default = %d, want 365", d)
+	}
+	if d := none.RetentionDays(RetentionCatAudit); d != 0 {
+		t.Errorf("audit default = %d, want 0 (keep forever)", d)
+	}
+	if d := none.RetentionDays("unknown-cat"); d != 90 {
+		t.Errorf("unknown category = %d, want 90 fallback", d)
+	}
+
+	// Operator override wins for the configured category; others still default.
+	s := ServerSettings{LogRetention: rawJSON(map[string]int{
+		RetentionCatNotifications: 30,
+		RetentionCatAudit:         180, // opt into pruning the audit log
+	})}
+	if d := s.RetentionDays(RetentionCatNotifications); d != 30 {
+		t.Errorf("notifications override = %d, want 30", d)
+	}
+	if d := s.RetentionDays(RetentionCatAudit); d != 180 {
+		t.Errorf("audit override = %d, want 180", d)
+	}
+	if d := s.RetentionDays(RetentionCatSecurityEvents); d != 365 {
+		t.Errorf("unconfigured security = %d, want 365 default", d)
+	}
+
+	// 0 means keep forever, and an out-of-range value falls back to default.
+	zero := ServerSettings{LogRetention: rawJSON(map[string]int{RetentionCatBandwidth: 0})}
+	if d := zero.RetentionDays(RetentionCatBandwidth); d != 0 {
+		t.Errorf("explicit 0 = %d, want 0", d)
+	}
+	bad := ServerSettings{LogRetention: rawJSON(map[string]int{RetentionCatUpdates: 999999})}
+	if d := bad.RetentionDays(RetentionCatUpdates); d != 90 {
+		t.Errorf("out-of-range = %d, want 90 default", d)
+	}
+}

--- a/panel-api/internal/repository/audit_event_repository.go
+++ b/panel-api/internal/repository/audit_event_repository.go
@@ -80,6 +80,17 @@ type AuditEventRepository interface {
 	// is the honest v1. The prune itself is recorded as an audit
 	// event by the caller (never a silent selective delete).
 	PruneOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+
+	// PruneOlderThanWithAnchor is the JAB-105 chain-safe prune: it captures the
+	// row_hash of the newest SEALED row being deleted, deletes rows with
+	// ts < cutoff, and persists that hash as server_settings.audit_chain_anchor
+	// (all in one transaction) so `audit verify` can resume the chain from the
+	// anchor instead of genesis. Returns the deleted count.
+	PruneOlderThanWithAnchor(ctx context.Context, cutoff time.Time) (int64, error)
+
+	// ChainAnchor returns server_settings.audit_chain_anchor ("" when never
+	// pruned) — the prev_hash VerifyChain should start from.
+	ChainAnchor(ctx context.Context) (string, error)
 }
 
 // Column allowlists for the audit_events list views. Empty-key-proof
@@ -260,3 +271,49 @@ func (r *auditEventRepo) PruneOlderThan(ctx context.Context, cutoff time.Time) (
 	}
 	return res.RowsAffected, nil
 }
+
+func (r *auditEventRepo) PruneOlderThanWithAnchor(ctx context.Context, cutoff time.Time) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Anchor = row_hash of the newest sealed row in the to-be-deleted tail.
+		// That hash is exactly the prev_hash of the first sealed survivor, so
+		// verify can resume from it. If the deleted range has no sealed row,
+		// leave the anchor unchanged.
+		var newest models.AuditEvent
+		e := tx.Where("ts < ? AND row_hash IS NOT NULL", cutoff).
+			Order("ts DESC, id DESC").Limit(1).First(&newest).Error
+		anchor := ""
+		if e == nil && newest.RowHash != nil {
+			anchor = *newest.RowHash
+		} else if e != nil && !errors.Is(e, gorm.ErrRecordNotFound) {
+			return e
+		}
+		res := tx.Where("ts < ?", cutoff).Delete(&models.AuditEvent{})
+		if res.Error != nil {
+			return res.Error
+		}
+		n = res.RowsAffected
+		if anchor != "" {
+			if e := tx.Table("server_settings").Where("id = ?", 1).
+				Update("audit_chain_anchor", anchor).Error; e != nil {
+				return e
+			}
+		}
+		return nil
+	})
+	return n, err
+}
+
+func (r *auditEventRepo) ChainAnchor(ctx context.Context) (string, error) {
+	var row struct{ AuditChainAnchor *string }
+	err := r.db.WithContext(ctx).Table("server_settings").
+		Select("audit_chain_anchor").Where("id = ?", 1).Scan(&row).Error
+	if err != nil {
+		return "", err
+	}
+	if row.AuditChainAnchor == nil {
+		return "", nil
+	}
+	return *row.AuditChainAnchor, nil
+}
+

--- a/panel-ui/src/shells/admin/settings/LogRetentionCard.tsx
+++ b/panel-ui/src/shells/admin/settings/LogRetentionCard.tsx
@@ -1,0 +1,143 @@
+// LogRetentionCard — Server Settings → Logs. Operator-configurable retention
+// (in days) for each log/report table the retention sweep prunes. 90d baseline,
+// 365d for forensic security tables, 0 = keep forever. Saving PATCHes
+// /admin/settings with a { category: days } log_retention map; the daily
+// jabali-retention-sweep reads it (an absent category uses the code default).
+import {
+  Alert,
+  App,
+  Button,
+  Card,
+  Form,
+  InputNumber,
+  Space,
+  Spin,
+  Tooltip,
+  Typography,
+} from "antd";
+import { useEffect, useState } from "react";
+
+import { apiClient } from "../../../apiClient";
+
+type RetentionMap = Record<string, number>;
+
+interface SettingsResponse {
+  log_retention?: RetentionMap | null;
+}
+
+// Mirrors models.DefaultLogRetentionDays. An unset category shows its default.
+const CATEGORIES: {
+  key: string;
+  label: string;
+  def: number;
+  help: string;
+  warn?: boolean;
+}[] = [
+  { key: "notifications", label: "Notifications", def: 90, help: "Delivered-notification log (bell / inbox rows)." },
+  { key: "updates", label: "Update history", def: 90, help: "Update-center run history + stored log excerpts." },
+  { key: "mail_reports", label: "Mail reports", def: 90, help: "DMARC, TLS-RPT, and ARF aggregate/failure reports." },
+  { key: "security_events", label: "Security events", def: 365, help: "Malware events + Snuffleupagus WAF incidents. Forensic — longer default." },
+  { key: "db_admin_audit", label: "DB-admin audit", def: 365, help: "Legacy database-admin audit log. Forensic — longer default." },
+  { key: "sessions", label: "Sessions & log streams", def: 90, help: "Root-terminal session rows + expired log-view stream keys." },
+  { key: "migrations", label: "Migration jobs", def: 90, help: "Terminal migration job + stage rows (secrets/staging are reaped separately)." },
+  { key: "bandwidth", label: "Bandwidth ledger", def: 90, help: "Per-domain daily bandwidth/request totals (bw_daily)." },
+  {
+    key: "audit",
+    label: "Audit log (tamper-evident)",
+    def: 0,
+    warn: true,
+    help: "Hash-chained security audit. Default: keep forever. Setting a window prunes with a chain re-anchor — shorter forensic history.",
+  },
+];
+
+export function LogRetentionCard() {
+  const { message } = App.useApp();
+  const [form] = Form.useForm<RetentionMap>();
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const r = await apiClient.get<SettingsResponse>("/admin/settings");
+        const saved = r.data.log_retention ?? {};
+        const values: RetentionMap = {};
+        for (const c of CATEGORIES) {
+          values[c.key] = saved[c.key] ?? c.def;
+        }
+        form.setFieldsValue(values);
+        setLoaded(true);
+      } catch {
+        message.error("Failed to load log-retention settings");
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const save = async () => {
+    const vals = await form.validateFields();
+    const payload: RetentionMap = {};
+    for (const c of CATEGORIES) {
+      payload[c.key] = typeof vals[c.key] === "number" ? vals[c.key] : c.def;
+    }
+    setSaving(true);
+    try {
+      await apiClient.patch("/admin/settings", { log_retention: payload });
+      message.success("Log-retention settings saved. Applied on the next daily sweep.");
+    } catch {
+      message.error("Failed to save log-retention settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card title="Logs — retention" style={{ marginBottom: 16 }}>
+      <Typography.Paragraph type="secondary">
+        How long each log/report table is kept before the daily retention sweep
+        prunes it. <b>0 = keep forever.</b> Changes take effect on the next sweep.
+      </Typography.Paragraph>
+      {!loaded ? (
+        <Spin />
+      ) : (
+        <Form form={form} layout="vertical">
+          <Space direction="vertical" size={0} style={{ width: "100%" }}>
+            {CATEGORIES.map((c) => (
+              <Form.Item
+                key={c.key}
+                name={c.key}
+                label={
+                  <Tooltip title={c.help}>
+                    <span>
+                      {c.label}
+                      {c.warn ? " ⚠" : ""}
+                    </span>
+                  </Tooltip>
+                }
+                style={{ marginBottom: 12, maxWidth: 420 }}
+              >
+                <InputNumber
+                  min={0}
+                  max={3650}
+                  step={1}
+                  style={{ width: 180 }}
+                  addonAfter="days (0 = forever)"
+                />
+              </Form.Item>
+            ))}
+          </Space>
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginTop: 8, marginBottom: 16, maxWidth: 640 }}
+            message="The audit log defaults to keep-forever"
+            description="It's hash-chained and tamper-evident. Set a window only if you accept a shorter forensic record; pruning re-anchors the chain so it stays verifiable forward."
+          />
+          <Button type="primary" loading={saving} onClick={() => void save()}>
+            Save retention
+          </Button>
+        </Form>
+      )}
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   CodeOutlined,
   CloseOutlined,
   DatabaseOutlined,
+  FileTextOutlined,
   GlobalOutlined,
   HddOutlined,
   MailOutlined,
@@ -72,6 +73,7 @@ import { NspawnImagesCard } from "./NspawnImagesCard";
 import { SSOMaintenanceCard } from "./SSOMaintenanceCard";
 import { TenantDomainOptionsCard } from "./TenantDomainOptionsCard";
 import { NginxSettingsCard } from "./NginxSettingsCard";
+import { LogRetentionCard } from "./LogRetentionCard";
 
 type ServerSettings = {
   id: number;
@@ -688,7 +690,8 @@ type SettingsTabKey =
   | "databases"
   | "apps"
   | "nginx"
-  | "branding";
+  | "branding"
+  | "logs";
 
 const BrandingSettingsTab = () => (
   <>
@@ -1037,6 +1040,15 @@ export const ServerSettingsPage = () => {
               </span>
             ),
           },
+          {
+            key: "logs",
+            tab: (
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
+                <FileTextOutlined />
+                Logs
+              </span>
+            ),
+          },
         ]}
         activeTabKey={activeTab}
         onTabChange={(k) => setActiveTab(k as SettingsTabKey)}
@@ -1072,6 +1084,7 @@ export const ServerSettingsPage = () => {
           </>
         )}
         {activeTab === "branding" && <BrandingSettingsTab />}
+        {activeTab === "logs" && <LogRetentionCard />}
       </Card>
     </div>
   );

--- a/plans/jab-log-retention-config.md
+++ b/plans/jab-log-retention-config.md
@@ -1,0 +1,80 @@
+# Blueprint: operator-configurable log retention (Server Settings → Logs)
+
+Closes JAB-102 (migration rows), JAB-105 (audit_events), JAB-124 (bw_daily), and
+makes the *existing* retention-sweep windows configurable instead of hardcoded.
+Default **90 days** everywhere. Configured in **Server Settings → Logs**.
+
+## Storage
+
+`server_settings` is a single-row typed-column table (already has JSON fields).
+Add one column:
+
+- `log_retention JSON` — map of **category → days**. Empty/absent category → use
+  the 90-day default. `0` = keep forever (disable pruning). Migration `000227`.
+
+A single JSON column (not one column per table) keeps it extensible — new log
+tables just add a category key, no schema churn.
+
+## Categories (group the ~13 tables into operator-meaningful units)
+
+| Category key | Tables | Default |
+|---|---|---|
+| `notifications` | notification_history | 90 |
+| `updates` | update_history | 90 |
+| `mail_reports` | dmarc_aggregate, tlsrpt_aggregate, arf_report | 90 |
+| `security_events` | malware_events, snuffleupagus_incidents | 90 |
+| `db_admin_audit` | db_admin_audit | 90 |
+| `sessions` | log_access_streams, terminal_sessions | 90 |
+| `migrations` | migration_jobs, migration_stages (**JAB-102**) | 90 |
+| `bandwidth` | bw_daily (**JAB-124**) | 90 |
+| `audit` | audit_events (**JAB-105**) | **0 (keep forever)** |
+
+**Audit exception:** `audit_events` is hash-chained/tamper-evident. Its default
+is **keep-forever (0)**, not 90d — a security log shouldn't silently self-delete.
+An operator *can* set a window; when they do, pruning re-anchors the chain (see
+below) rather than a blind DELETE. This is the one deviation from "90d default";
+flagged for sign-off.
+
+## Backend
+
+1. **models/server_settings.go** — add `LogRetention json.RawMessage`; a typed
+   accessor `RetentionDays(category) int` returning the configured value or 90
+   (or 0 for `audit`).
+2. **retention_sweep_cmd.go** — each `retentionTarget` gains a `category`; the
+   window is read from server_settings via the accessor, not a constant. `0` →
+   skip. Existing batched-DELETE loop unchanged.
+3. **JAB-102** — new target: terminal `migration_jobs` (+ cascade
+   `migration_stages`) older than the `migrations` window. Fold into the sweep
+   (delete stages first for the FK). reap-secrets still owns secrets/staging.
+4. **JAB-124** — new target: `bw_daily` WHERE `day < now - window`.
+5. **JAB-105** — `audit_events` prune (only when window > 0): before deleting the
+   aged tail, compute + persist an **anchor** (the row_hash of the newest deleted
+   row) so the surviving chain stays forward-verifiable; then delete. Store the
+   anchor in `server_settings.audit_chain_anchor` (or an `audit_anchors` row).
+   `jabali audit verify` already exists — teach it to accept the anchor as the
+   chain root.
+6. **API** — `server_settings` GET/PUT already exist; extend the payload with
+   `log_retention` (validated: ints 0..3650).
+
+## Frontend
+
+7. **settings/LogRetentionCard.tsx** — one numeric field (days) per category,
+   default 90, `0` = "keep forever", with a tooltip per category and an explicit
+   warning on `audit` (tamper-evidence). Wired into `ServerSettingsPage`.
+
+## Tests
+
+- retention_sweep: window resolved from settings (default + override + 0-skip).
+- migration-rows + bw_daily prune windows.
+- audit prune re-anchors + `audit verify` accepts the anchor.
+- server_settings PUT validates the retention map.
+
+## Phasing (PRs)
+
+- **P1** storage + settings API + retention-sweep reads config (existing tables
+  become configurable; default 90d) + UI card. No behaviour change at default
+  except db_admin_audit 1y→90d (call out).
+- **P2** JAB-102 migration rows + JAB-124 bw_daily prunes.
+- **P3** JAB-105 audit_events anchor-prune + verify.
+
+Ship P1 first (the "configurable in Server Settings" ask), then 102/124/105.

--- a/plans/jab-log-retention-config.md
+++ b/plans/jab-log-retention-config.md
@@ -78,3 +78,5 @@ flagged for sign-off.
 - **P3** JAB-105 audit_events anchor-prune + verify.
 
 Ship P1 first (the "configurable in Server Settings" ask), then 102/124/105.
+
+**STATUS 2026-07-19: all phases implemented in PR #503** (P1 config+UI, P2 102/124, P3 105 audit anchor). Flip JAB-102/105/124 to Done when #503 merges.


### PR DESCRIPTION
## Configurable log retention (P1 of 3)

Retention windows were **hardcoded** per table in the daily `retention-sweep`. This makes them configurable from **Server Settings → Logs**, default **90 days** (365 for forensic security tables; keep-forever for the tamper-evident audit log). Blueprint: `plans/jab-log-retention-config.md`.

### Backend
- **Migration 000227**: `server_settings.log_retention` JSON column — a `{ category: days }` map.
- **models**: `LogRetention` field + `RetentionDays(category)` accessor; category constants + `DefaultLogRetentionDays` (90 baseline / 365 security / **0 = keep-forever** for `audit`).
- **retention_sweep**: each target now carries a category; the window resolves from `server_settings` (0 → skip), falling back to code defaults if the row is unreadable. Mail-report/update windows move to the 90d default; security (malware / WAF / db-admin-audit) stays 365d.
- **API**: `PUT /admin/settings` accepts + validates a `log_retention` map (known categories only, 0..3650 days); `GET` returns it.

### UI
- **`LogRetentionCard`** on a new **Server Settings → Logs** tab: one field per category, 90d default, `0 = keep forever`, with the audit-log tamper-evidence caveat spelled out.

### Defaults (my call, per "set the defaults")
90d baseline; **365d** for db-admin-audit + security events (forensic); **keep-forever** for the hash-chained `audit_events` (a security audit shouldn't silently self-delete — an operator can set a window, and pruning then re-anchors the chain, added in P3).

### Test plan
- [x] `RetentionDays` defaults / override / 0 / out-of-range.
- [x] `validateLogRetention` accept + reject (unknown key, negative, over-cap, wrong shape).
- [x] `go test ./internal/... ./cmd/server/`, `go vet`, CLI golden — green.
- [x] `tsc -b`, `eslint`, `npm run build` — clean.
- [ ] Live: Server Settings → Logs renders + saves (Playwright covers the settings route in CI).

### Follow-ups (this blueprint)
- **P2** — add the `migration_jobs`/`stages` (JAB-102) + `bw_daily` (JAB-124) prune targets to the sweep.
- **P3** — `audit_events` anchor-prune + `audit verify` accepts the anchor (JAB-105).