### PR TITLE
fix(apparmor): panel-api can exec tar + read backup downloads dir (GH #462)

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -112,9 +112,14 @@ profile jabali-panel flags=(attach_disconnected) {
   # panel-api's full DIRECT exec surface (exec.CommandContext): most heavy
   # flows are delegated to the agent (its own profile); the daemon itself
   # only shells out to these. zstd = hestia migration decompress;
-  # goaccess = web-stats (M13, websocket_logs.go).
+  # goaccess = web-stats (M13, websocket_logs.go); tar = backup-artifact
+  # download streams the materialized backup as a tar[.zst] (GH #462, backups.go
+  # streamBackupArtifact) — without an exec rule the download fails
+  # "fork/exec /usr/bin/tar: permission denied" under enforce.
   /usr/bin/zstd               rix,
   /usr/bin/goaccess           rix,
+  /usr/bin/tar                rix,
+  /bin/tar                    rix,
   /var/log/nginx/             r,
   /var/log/nginx/**           r,
   /usr/share/goaccess/**      r,
@@ -214,6 +219,13 @@ profile jabali-panel flags=(attach_disconnected) {
   # /etc/jabali-panel/** r above.)
   /var/lib/jabali-migrations/     rw,
   /var/lib/jabali-migrations/**   rwk,
+
+  # GH #462: the backup-artifact download tars the agent-materialized snapshot
+  # under /var/lib/jabali-backups/downloads/<job>/ (backups.go streamBackupArtifact).
+  # Read-only + downloads/ only — the agent writes + cleans it, and the restic
+  # repo (/var/lib/jabali-backups/repo, 0600 root:root) must stay off-limits.
+  /var/lib/jabali-backups/downloads/     r,
+  /var/lib/jabali-backups/downloads/**   r,
   /var/log/jabali-panel/       rw,
   /var/log/jabali-panel/**     rwk,
 

--- a/panel-api/internal/api/upload_staging_apparmor_test.go
+++ b/panel-api/internal/api/upload_staging_apparmor_test.go
@@ -51,3 +51,32 @@ func TestUploadStagingDirHasAppArmorRule(t *testing.T) {
 		}
 	}
 }
+
+// TestBackupDownloadHasAppArmorRules guards GH #462: the backup-artifact
+// download tars the agent-materialized snapshot, so the panel-api profile must
+// (a) allow exec of tar and (b) grant read on the downloads staging dir — or the
+// daemon fails "fork/exec /usr/bin/tar: permission denied", then EACCESes the
+// files, once the profile is in enforce mode.
+func TestBackupDownloadHasAppArmorRules(t *testing.T) {
+	const profilePath = "../../../install/apparmor/usr.local.bin.jabali-panel-api"
+	raw, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatalf("read AppArmor profile: %v", err)
+	}
+	profile := string(raw)
+
+	// tar must be exec'able (ix/rix) — it's the download's transport.
+	if !regexp.MustCompile(`(?m)^\s*/usr/bin/tar\s+r?ix\s*,`).MatchString(profile) {
+		t.Error("AppArmor profile missing an exec rule for /usr/bin/tar (GH #462) — backup download fails 'fork/exec /usr/bin/tar: permission denied' under enforce")
+	}
+
+	// The agent-materialized snapshot dir must be readable so tar can read it.
+	for _, g := range []string{
+		regexp.QuoteMeta("/var/lib/jabali-backups/downloads/"),
+		regexp.QuoteMeta("/var/lib/jabali-backups/downloads/") + `\*\*`,
+	} {
+		if !regexp.MustCompile(`(?m)^\s*` + g + `\s+[a-z]*r[a-z]*\s*,`).MatchString(profile) {
+			t.Errorf("AppArmor profile missing a read rule for %q (GH #462) — tar EACCESes the backup files under enforce", g)
+		}
+	}
+}


### PR DESCRIPTION
## GH #462 follow-up — `fork/exec /usr/bin/tar: permission denied`

A user reported that after updating, backup download (admin **and** tenant) fails with:
```json
{"detail":"fork/exec /usr/bin/tar: permission denied","error":"tar_start","status":"error"}
```

**Root cause:** `streamBackupArtifact` tars the agent-materialized snapshot, but the panel-api **AppArmor** profile — which lists an exec allowlist (`zstd`, `goaccess`, `bash`, `cp`, `git`, …) — never included **`tar`**, and granted no read on the snapshot staging dir. Under enforce, the `execve` of `/usr/bin/tar` is denied; even past that, tar (running `ix` under the profile) would then EACCES the files.

### Audit (per request — checked the whole flow, not just tar)
Panel-api **daemon** exec surface (`internal/` only; the CLI runs unconfined as root): `apt, cscli, goaccess, journalctl, nginx, sudo, systemctl, tail, tar, zstd`. **tar was the only one missing** from the profile. (`psql`/`postgres` in the code are engine-name string comparisons, not exec; `restic`/`rsync`/`curl`/`ufw`/… are CLI-only.)

### Fix
- `/usr/bin/tar` + `/bin/tar` `rix`.
- Read-only `/var/lib/jabali-backups/downloads/` + `/**` — the agent writes/cleans it; the restic repo (`/var/lib/jabali-backups/repo`, 0600 root:root) stays off-limits (least privilege).
- Regression test pins both grants.

`update.go` already restages `install/apparmor/` + reloads on update, so this reaches existing installs.

### Test plan
- [x] `TestBackupDownloadHasAppArmorRules` — profile has tar exec + downloads read.
- [x] `go test ./internal/api/ -run AppArmor`, `go vet` clean.
- [ ] Box: `jabali update` on an enforce-mode host, then download a backup → 200 (not `tar_start`).