### PR TITLE
fix(migrate/hestiacp): resolve v-* helpers via PATH over non-login SSH (GH #327)

### DIFF
--- a/panel-api/internal/migrate/hestiacp/discover.go
+++ b/panel-api/internal/migrate/hestiacp/discover.go
@@ -164,6 +164,22 @@ func zero(b []byte) {
 	}
 }
 
+// hestiaBinDir is Hestia's standard install path; its v-* control-panel
+// helpers live here. A non-interactive `ssh host "cmd"` runs a non-login shell
+// whose PATH omits this dir on some distros (notably Ubuntu, where the error is
+// `v-list-users: command not found` / exit 127 even though root can run it in an
+// interactive login shell) — GH #327. Debian's non-interactive PATH happens to
+// include it, which is why it only broke on Ubuntu.
+const hestiaBinDir = "/usr/local/hestia/bin"
+
+// withHestiaPath prepends the Hestia bin dir to PATH for a remote command so the
+// v-* helpers resolve regardless of the SSH session's default PATH. Uses
+// `export …;` (not a var-assignment prefix) so it also covers piped/compound
+// commands. Harmless for non-Hestia commands (date/rm/find stay resolvable).
+func withHestiaPath(cmd string) string {
+	return `export PATH="` + hestiaBinDir + `:$PATH"; ` + cmd
+}
+
 func (s *session) run(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
 	if timeout == 0 {
 		timeout = 30 * time.Second
@@ -182,7 +198,7 @@ func (s *session) run(ctx context.Context, timeout time.Duration, cmd string) ([
 	sess.Stderr = &stderr
 
 	done := make(chan error, 1)
-	go func() { done <- sess.Run(cmd) }()
+	go func() { done <- sess.Run(withHestiaPath(cmd)) }()
 
 	select {
 	case err := <-done:

--- a/panel-api/internal/migrate/hestiacp/hestia_path_test.go
+++ b/panel-api/internal/migrate/hestiacp/hestia_path_test.go
@@ -1,0 +1,19 @@
+package hestiacp
+
+import "testing"
+
+// GH #327: Hestia v-* helpers live in /usr/local/hestia/bin, which a
+// non-interactive SSH session's PATH omits on Ubuntu → exit 127. Every remote
+// command must be prefixed so they resolve.
+func TestWithHestiaPath(t *testing.T) {
+	got := withHestiaPath("v-list-users json")
+	want := `export PATH="/usr/local/hestia/bin:$PATH"; v-list-users json`
+	if got != want {
+		t.Errorf("withHestiaPath = %q, want %q", got, want)
+	}
+	// export …; form so a piped/compound command is fully covered.
+	comp := withHestiaPath("find /backup -newer /tmp/x | head -1")
+	if comp[:len(`export PATH="/usr/local/hestia/bin:$PATH"; `)] != `export PATH="/usr/local/hestia/bin:$PATH"; ` {
+		t.Errorf("compound command not prefixed: %q", comp)
+	}
+}


### PR DESCRIPTION
## GH #327 follow-up — `v-list-users: command not found` (exit 127) on Ubuntu

After #488 surfaced the real error, the reporter hit the next one: HestiaCP account discovery runs `v-list-users json` over SSH and gets
```
ssh exec "v-list-users json": Process exited with status 127 (stderr="bash: line 1: v-list-users: command not found")
```
even though `root` can run `v-list-users json` interactively (`whereis` → `/usr/local/hestia/bin/v-list-users`).

**Root cause:** Hestia's `v-*` helpers live in `/usr/local/hestia/bin`. A non-interactive `ssh host "cmd"` runs a **non-login** shell whose `PATH` omits that dir on **Ubuntu**. An interactive root login sources profile (which adds it), so it works by hand. Debian's non-interactive PATH happens to include it — which is why the break is Ubuntu-only.

**Fix:** prepend the Hestia bin dir to `PATH` for every remote command in `session.run`:
```
export PATH="/usr/local/hestia/bin:$PATH"; <cmd>
```
The `export …;` form (not a bare `VAR=… cmd` prefix) also covers piped/compound commands, and it's harmless for the non-Hestia `date`/`rm`/`find` calls the same helper runs.

### Test plan
- [x] `TestWithHestiaPath` — the prefix wraps simple + compound commands.
- [x] `go test ./internal/migrate/hestiacp/`, `go vet` clean.
- [ ] Box: run a HestiaCP discovery against an Ubuntu Hestia source → accounts list instead of exit 127.