### PR TITLE
feat(python): framework marketplace catalog schema + loader (JAB-164 Step 1)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4283,8 +4283,9 @@ jabali python-app create [flags]
 - `--base-uri` — mount path on the domain (default `/`)
 - `--domain` — domain name to mount on (resolved to its id)
 - `--domain-id` — domain id to mount on (or use --domain)
-- `--entrypoint` — module:callable, e.g. myapp.wsgi:application (required)
+- `--entrypoint` — module:callable, e.g. myapp.wsgi:application (required unless --framework)
 - `--env` — KEY=VALUE (repeatable) (default `[]`)
+- `--framework` — marketplace slug (e.g. django, flask, fastapi); derives app-type/entrypoint and scaffolds the starter
 - `--name` — app name (required)
 - `--python-version` — Python version, e.g. 3.12 (required)
 
@@ -4323,6 +4324,14 @@ jabali python-app env set <app-id> <KEY=VALUE> [<KEY=VALUE>...] [flags]
 **Flags:**
 
 - `--replace` — replace the entire env set instead of merging
+
+#### `jabali python-app frameworks`
+
+List the Python frameworks installable via --framework
+
+```
+jabali python-app frameworks
+```
 
 #### `jabali python-app list`
 

--- a/install.sh
+++ b/install.sh
@@ -4653,6 +4653,18 @@ build_backend() {
     _ok "synced docker-app catalog -> /usr/local/share/jabali/docker-apps/"
   fi
 
+  # JAB-164: sync the Python framework marketplace catalog (framework.yaml +
+  # template/ starters) into the production path panel-api + the CLI read at
+  # startup. Same rationale as the docker-app catalog above.
+  if [[ -d "$REPO_DIR/install/py-frameworks" ]]; then
+    install -d -m 0755 /usr/local/share/jabali/py-frameworks
+    rsync -a --delete \
+      --exclude=".git" \
+      "$REPO_DIR/install/py-frameworks/" \
+      /usr/local/share/jabali/py-frameworks/
+    _ok "synced py-framework catalog -> /usr/local/share/jabali/py-frameworks/"
+  fi
+
   # #406: bundle the jabali-cache WordPress plugin read-only into the
   # production path the agent installs FROM (wordpress.cache_set). Tenants
   # never supply plugin code; re-synced on every `jabali update`.

--- a/install/py-frameworks/django/framework.yaml
+++ b/install/py-frameworks/django/framework.yaml
@@ -1,0 +1,32 @@
+slug: django
+name: Django
+version: "5.1"
+description: The batteries-included WSGI web framework — full project scaffold with admin, ORM, and static handling.
+tags: [wsgi, full-stack, orm, cms]
+popularity: 95
+upstream: https://www.djangoproject.com/
+docs: https://docs.djangoproject.com/
+app_type: wsgi
+server: gunicorn
+python_min: "3.10"
+pip_requirements:
+  - django==5.1.4
+  - gunicorn==23.0.0
+scaffold:
+  kind: cmd
+  command: "django-admin startproject {{.Project}} ."
+  project: site
+entrypoint_template: "{{.Project}}.wsgi:application"
+needs_db: sqlite
+static_url: /static/
+static_root: staticfiles
+post_install:
+  - migrate
+  - collectstatic
+default_env:
+  - key: DJANGO_SECRET_KEY
+    generate: secret_key
+    required: true
+    description: Generated at install; stored in app env, never in source.
+  - key: DJANGO_ALLOWED_HOSTS
+    description: Set from the mounted domain at install.

--- a/install/py-frameworks/django/framework.yaml
+++ b/install/py-frameworks/django/framework.yaml
@@ -15,7 +15,7 @@ pip_requirements:
 scaffold:
   kind: cmd
   command: "django-admin startproject {{.Project}} ."
-  project: site
+  project: config
 entrypoint_template: "{{.Project}}.wsgi:application"
 needs_db: sqlite
 static_url: /static/

--- a/install/py-frameworks/fastapi/framework.yaml
+++ b/install/py-frameworks/fastapi/framework.yaml
@@ -1,0 +1,18 @@
+slug: fastapi
+name: FastAPI
+version: "0.115"
+description: A modern high-performance ASGI framework with automatic OpenAPI docs, served by uvicorn.
+tags: [asgi, api, async]
+popularity: 88
+upstream: https://fastapi.tiangolo.com/
+docs: https://fastapi.tiangolo.com/
+app_type: asgi
+server: uvicorn
+python_min: "3.9"
+pip_requirements:
+  - fastapi==0.115.6
+  - "uvicorn[standard]==0.34.0"
+scaffold:
+  kind: template
+entrypoint_template: main:app
+needs_db: none

--- a/install/py-frameworks/fastapi/template/main.py
+++ b/install/py-frameworks/fastapi/template/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def index():
+    return {"message": "Hello from FastAPI on Jabali."}

--- a/install/py-frameworks/flask/framework.yaml
+++ b/install/py-frameworks/flask/framework.yaml
@@ -1,0 +1,18 @@
+slug: flask
+name: Flask
+version: "3.1"
+description: A lightweight WSGI micro-framework — a single-file starter served by gunicorn.
+tags: [wsgi, micro, api]
+popularity: 90
+upstream: https://flask.palletsprojects.com/
+docs: https://flask.palletsprojects.com/
+app_type: wsgi
+server: gunicorn
+python_min: "3.9"
+pip_requirements:
+  - flask==3.1.0
+  - gunicorn==23.0.0
+scaffold:
+  kind: template
+entrypoint_template: app:app
+needs_db: none

--- a/install/py-frameworks/flask/template/app.py
+++ b/install/py-frameworks/flask/template/app.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index():
+    return "Hello from Flask on Jabali."

--- a/panel-agent/internal/commands/python_app_scaffold.go
+++ b/panel-agent/internal/commands/python_app_scaffold.go
@@ -15,14 +15,15 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"os/user"
+	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -223,21 +224,30 @@ if "STATIC_ROOT" not in s:
 open(path,"w").write(s)
 `
 
-// writeAsUser writes a file inside the tenant's app tree and chowns it to the
-// tenant. The agent runs as root so it can write anywhere; chowning keeps the
-// app tree owned by the user (the venv + code must be user-owned for the
-// loopback service unit that runs as that user).
+// writeAsUser writes a file inside the tenant's app tree AS THE TENANT.
+//
+// The agent runs as root, so a plain root os.WriteFile into the tenant-owned
+// app tree is a privilege-escalation primitive: the tenant can pre-plant a
+// symlink at `path` pointing anywhere on the host, and the root write follows
+// it (symlink-following TOCTOU). Streaming the content through `sudo -u <user>
+// tee` performs the open+write under the tenant uid, so the kernel enforces DAC
+// on the (possibly symlinked) target — a tenant can only ever redirect the
+// write to a path the tenant could already write, which is not an escalation.
+// It also lands the file owned by the tenant with no separate chown (the venv +
+// code must be user-owned for the loopback unit that runs as that user).
+//
+// `--` guards a path beginning with '-'; app_root is always absolute so this is
+// belt-and-suspenders. No shell is involved.
 func writeAsUser(ctx context.Context, username, path, content string) error {
-	u, err := user.Lookup(username)
-	if err != nil {
-		return err
+	cmd := exec.CommandContext(ctx, "sudo", "-u", username, "-H", "tee", "--", path)
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout = io.Discard // tee echoes stdin to stdout; we don't need it
+	var errb bytes.Buffer
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("write as %s: %w: %s", username, err, strings.TrimSpace(errb.String()))
 	}
-	uid, _ := strconv.Atoi(u.Uid)
-	gid, _ := strconv.Atoi(u.Gid)
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return err
-	}
-	return os.Chown(path, uid, gid)
+	return nil
 }
 
 func init() { Default.Register("app.python.scaffold", pythonAppScaffoldHandler) }

--- a/panel-agent/internal/commands/python_app_scaffold.go
+++ b/panel-agent/internal/commands/python_app_scaffold.go
@@ -1,0 +1,243 @@
+// app.python.scaffold (JAB-164) — scaffold a framework starter project into a
+// Python app's app_root, on top of the ADR-0131 runtime. Runs BEFORE the normal
+// app.python.apply: it creates the venv, installs the pinned framework deps, lays
+// down the starter (django-admin startproject / template files), hardens Django
+// settings (SECRET_KEY from env, STATIC_ROOT, ALLOWED_HOSTS), and runs the
+// framework post-install (migrate, collectstatic). Idempotent via a
+// .jabali-scaffolded marker so a re-apply never re-scaffolds over the tenant's code.
+//
+// Everything that touches the app tree runs AS THE OWNING USER (sudo -u), same
+// drop-priv boundary as app.python.apply. Generated secrets (Django SECRET_KEY)
+// are returned to panel-api to persist in the app's env — never written to source.
+//
+// Every scaffold + serve command here was smoke-verified on Ubuntu 24.04/py3.12
+// and Debian 13/py3.13 (Flask/Django/FastAPI → HTTP 200) before it was encoded.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type pythonScaffoldParams struct {
+	AppID         string   `json:"app_id"`
+	Username      string   `json:"username"`
+	AppRoot       string   `json:"app_root"`
+	PythonVersion string   `json:"python_version"`
+	Server        string   `json:"server"` // gunicorn|uvicorn|hypercorn|daphne
+	Requirements  []string `json:"requirements"`
+	ScaffoldKind  string   `json:"scaffold_kind"` // cmd|template
+	// ScaffoldArgv is the scaffold command for kind=cmd, e.g.
+	// ["django-admin","startproject","config","."]; argv[0] is resolved inside
+	// the venv (django-admin ships with django once requirements install).
+	ScaffoldArgv []string `json:"scaffold_argv,omitempty"`
+	// TemplateFiles is relpath→content for kind=template starters (flask app.py …).
+	TemplateFiles map[string]string `json:"template_files,omitempty"`
+	// Project is the startproject dir (kind=cmd) — where settings.py lives.
+	Project string `json:"project,omitempty"`
+	// HardenDjango patches <project>/settings.py to read SECRET_KEY + ALLOWED_HOSTS
+	// from env and set STATIC_ROOT, then generates a SECRET_KEY into GeneratedEnv.
+	HardenDjango bool     `json:"harden_django,omitempty"`
+	StaticRoot   string   `json:"static_root,omitempty"`
+	AllowedHosts string   `json:"allowed_hosts,omitempty"`
+	PostInstall  []string `json:"post_install,omitempty"` // migrate, collectstatic
+}
+
+type pythonScaffoldResult struct {
+	Scaffolded   bool              `json:"scaffolded"`
+	Skipped      bool              `json:"skipped"`
+	GeneratedEnv map[string]string `json:"generated_env,omitempty"`
+}
+
+var scaffoldServers = map[string]bool{"gunicorn": true, "uvicorn": true, "hypercorn": true, "daphne": true}
+
+func scaffoldErr(format string, a ...any) error {
+	return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf(format, a...)}
+}
+
+func pythonAppScaffoldHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p pythonScaffoldParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, csInvalidArg("parse params: " + err.Error())
+	}
+	// The agent is the security boundary — re-validate the caller's values even
+	// though panel-api sends ULIDs + validated names.
+	if !appIDRe.MatchString(p.AppID) {
+		return nil, csInvalidArg("bad app_id")
+	}
+	if !usernameRe.MatchString(p.Username) {
+		return nil, csInvalidArg("bad username")
+	}
+	if !pythonVersionRe.MatchString(p.PythonVersion) {
+		return nil, csInvalidArg("bad python_version")
+	}
+	if !scaffoldServers[p.Server] {
+		return nil, csInvalidArg("bad server")
+	}
+	if !filepath.IsAbs(p.AppRoot) || strings.Contains(p.AppRoot, "..") || hasCtrl(p.AppRoot) {
+		return nil, csInvalidArg("bad app_root")
+	}
+	if p.ScaffoldKind != "cmd" && p.ScaffoldKind != "template" {
+		return nil, csInvalidArg("bad scaffold_kind")
+	}
+	if len(p.Requirements) == 0 {
+		return nil, csInvalidArg("requirements required")
+	}
+
+	marker := filepath.Join(p.AppRoot, ".jabali-scaffolded")
+	if _, err := os.Stat(marker); err == nil {
+		return pythonScaffoldResult{Skipped: true}, nil
+	}
+
+	venv := filepath.Join(p.AppRoot, "venv")
+	pyBin := "/usr/bin/python" + p.PythonVersion
+
+	// 1) venv (GH#357: python<ver>-venv package prerequisite).
+	if _, err := os.Stat(filepath.Join(venv, "bin", "python")); err != nil {
+		if verr := ensurePythonVenvPackage(ctx, p.PythonVersion); verr != nil {
+			return nil, scaffoldErr("venv prerequisite: %v", verr)
+		}
+		if out, err := runAsUser(ctx, p.Username, pyBin, "-m", "venv", venv); err != nil {
+			return nil, scaffoldErr("create venv: %v: %s", err, out)
+		}
+	}
+	pip := filepath.Join(venv, "bin", "pip")
+
+	// 2) requirements.txt (framework + server), written by the tenant.
+	reqBody := strings.Join(append(append([]string(nil), p.Requirements...), p.Server), "\n") + "\n"
+	if werr := writeAsUser(ctx, p.Username, filepath.Join(p.AppRoot, "requirements.txt"), reqBody); werr != nil {
+		return nil, scaffoldErr("write requirements.txt: %v", werr)
+	}
+	if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", "-r", filepath.Join(p.AppRoot, "requirements.txt")); err != nil {
+		return nil, scaffoldErr("pip install: %v: %s", err, lastLines(out, 12))
+	}
+
+	// 3) scaffold the starter.
+	switch p.ScaffoldKind {
+	case "cmd":
+		if len(p.ScaffoldArgv) == 0 {
+			return nil, csInvalidArg("scaffold_argv required for cmd")
+		}
+		// Resolve argv[0] inside the venv (django-admin ships with django).
+		bin := filepath.Join(venv, "bin", filepath.Base(p.ScaffoldArgv[0]))
+		args := append([]string{bin}, p.ScaffoldArgv[1:]...)
+		if out, err := runAsUser(ctx, p.Username, args...); err != nil {
+			return nil, scaffoldErr("scaffold: %v: %s", err, lastLines(out, 8))
+		}
+	case "template":
+		for rel, content := range p.TemplateFiles {
+			if strings.Contains(rel, "..") || filepath.IsAbs(rel) || hasCtrl(rel) {
+				return nil, csInvalidArg("bad template path " + rel)
+			}
+			dst := filepath.Join(p.AppRoot, rel)
+			if dir := filepath.Dir(dst); dir != p.AppRoot {
+				if _, err := runAsUser(ctx, p.Username, "mkdir", "-p", dir); err != nil {
+					return nil, scaffoldErr("mkdir %s: %v", dir, err)
+				}
+			}
+			if err := writeAsUser(ctx, p.Username, dst, content); err != nil {
+				return nil, scaffoldErr("write %s: %v", rel, err)
+			}
+		}
+	}
+
+	result := pythonScaffoldResult{Scaffolded: true, GeneratedEnv: map[string]string{}}
+
+	// 4) Django hardening: patch settings, generate SECRET_KEY.
+	if p.HardenDjango {
+		if !projectDirRe.MatchString(p.Project) {
+			return nil, csInvalidArg("bad django project")
+		}
+		settings := filepath.Join(p.AppRoot, p.Project, "settings.py")
+		vpy := filepath.Join(venv, "bin", "python")
+		if out, err := runAsUser(ctx, p.Username, vpy, "-c", djangoSettingsPatch, settings, p.StaticRoot); err != nil {
+			return nil, scaffoldErr("harden settings: %v: %s", err, out)
+		}
+		key, err := runAsUser(ctx, p.Username, vpy, "-c", "from django.core.management.utils import get_random_secret_key as g;print(g())")
+		if err != nil {
+			return nil, scaffoldErr("generate secret key: %v: %s", err, key)
+		}
+		result.GeneratedEnv["DJANGO_SECRET_KEY"] = strings.TrimSpace(key)
+	}
+
+	// 5) post-install (with the generated env in scope for migrate/collectstatic).
+	if len(p.PostInstall) > 0 {
+		envArgs := []string{"env"}
+		for k, v := range result.GeneratedEnv {
+			envArgs = append(envArgs, k+"="+v)
+		}
+		if p.AllowedHosts != "" {
+			envArgs = append(envArgs, "DJANGO_ALLOWED_HOSTS="+p.AllowedHosts)
+		}
+		vpy := filepath.Join(venv, "bin", "python")
+		manage := filepath.Join(p.AppRoot, "manage.py")
+		for _, step := range p.PostInstall {
+			var sub string
+			switch step {
+			case "migrate":
+				sub = "migrate"
+			case "collectstatic":
+				sub = "collectstatic"
+			default:
+				continue // ignore unknown tokens; the catalog validates the set
+			}
+			args := append(append([]string(nil), envArgs...), vpy, manage, sub, "--noinput")
+			if out, err := runAsUser(ctx, p.Username, args...); err != nil {
+				return nil, scaffoldErr("%s: %v: %s", step, err, lastLines(out, 8))
+			}
+		}
+	}
+
+	// 6) marker (idempotency) — written last so a mid-scaffold failure re-runs clean.
+	if err := writeAsUser(ctx, p.Username, marker, "scaffolded\n"); err != nil {
+		return nil, scaffoldErr("write marker: %v", err)
+	}
+	return result, nil
+}
+
+// projectDirRe guards the Django project dir name (django-admin startproject
+// <name>) — it becomes a Python package + a filesystem path segment.
+var projectDirRe = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$`)
+
+// djangoSettingsPatch reads argv [settings_path, static_root] and rewrites a
+// fresh startproject settings.py to read SECRET_KEY + ALLOWED_HOSTS from env and
+// set STATIC_ROOT (matching the smoke-verified hardening).
+const djangoSettingsPatch = `import re,sys
+path,static_root=sys.argv[1],sys.argv[2]
+s=open(path).read()
+if "\nimport os" not in s and not s.startswith("import os"):
+    s="import os\n"+s
+s=re.sub(r"^SECRET_KEY = .*$","SECRET_KEY = os.environ['DJANGO_SECRET_KEY']",s,flags=re.M)
+s=re.sub(r"^ALLOWED_HOSTS = .*$","ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS','').split(',')",s,flags=re.M)
+if "STATIC_ROOT" not in s:
+    s=s.rstrip()+"\nSTATIC_ROOT = BASE_DIR / %r\n" % static_root
+open(path,"w").write(s)
+`
+
+// writeAsUser writes a file inside the tenant's app tree and chowns it to the
+// tenant. The agent runs as root so it can write anywhere; chowning keeps the
+// app tree owned by the user (the venv + code must be user-owned for the
+// loopback service unit that runs as that user).
+func writeAsUser(ctx context.Context, username, path, content string) error {
+	u, err := user.Lookup(username)
+	if err != nil {
+		return err
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return err
+	}
+	return os.Chown(path, uid, gid)
+}
+
+func init() { Default.Register("app.python.scaffold", pythonAppScaffoldHandler) }

--- a/panel-agent/internal/commands/python_app_scaffold_test.go
+++ b/panel-agent/internal/commands/python_app_scaffold_test.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// The scaffold handler is the security boundary: it must reject a malformed
+// caller BEFORE any exec. These cases return at validation (no venv/pip run).
+func TestPythonScaffold_RejectsBadParams(t *testing.T) {
+	bad := []pythonScaffoldParams{
+		{AppID: "ok", Username: "u", PythonVersion: "3.12", Server: "gunicorn", Requirements: []string{"x"}, ScaffoldKind: "template", AppRoot: "relative/path"},      // non-abs app_root
+		{AppID: "ok", Username: "u", PythonVersion: "3.12", Server: "gunicorn", Requirements: []string{"x"}, ScaffoldKind: "template", AppRoot: "/home/u/../etc"},     // traversal
+		{AppID: "ok", Username: "u", PythonVersion: "3.12", Server: "nope", Requirements: []string{"x"}, ScaffoldKind: "template", AppRoot: "/home/u/app"},            // bad server
+		{AppID: "ok", Username: "u", PythonVersion: "9.9", Server: "gunicorn", Requirements: []string{"x"}, ScaffoldKind: "template", AppRoot: "/home/u/app"},         // bad python
+		{AppID: "ok", Username: "BAD USER", PythonVersion: "3.12", Server: "gunicorn", Requirements: []string{"x"}, ScaffoldKind: "template", AppRoot: "/home/u/app"}, // bad username
+		{AppID: "ok", Username: "u", PythonVersion: "3.12", Server: "gunicorn", Requirements: []string{"x"}, ScaffoldKind: "weird", AppRoot: "/home/u/app"},           // bad kind
+		{AppID: "ok", Username: "u", PythonVersion: "3.12", Server: "gunicorn", Requirements: nil, ScaffoldKind: "template", AppRoot: "/home/u/app"},                  // no requirements
+	}
+	for i, p := range bad {
+		raw, _ := json.Marshal(p)
+		if _, err := pythonAppScaffoldHandler(context.Background(), raw); err == nil {
+			t.Errorf("case %d (%+v) should have been rejected", i, p)
+		}
+	}
+}

--- a/panel-api/cmd/server/python_app_cmd.go
+++ b/panel-api/cmd/server/python_app_cmd.go
@@ -31,8 +31,31 @@ func newPythonAppCmd() *cobra.Command {
 		newPythonAppDeleteCmd(),
 		newPythonAppCreateCmd(),
 		newPythonAppEnvCmd(),
+		newPythonAppFrameworksCmd(),
 	)
 	return cmd
+}
+
+// newPythonAppFrameworksCmd lists the JAB-164 framework marketplace entries
+// usable with `python-app create --framework <slug>`.
+func newPythonAppFrameworksCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "frameworks",
+		Short: "List the Python frameworks installable via --framework",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cat := loadPyFrameworkCatalogCLI()
+			if jsonOutput {
+				return printJSON(cat.All())
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "%-12s %-8s %-9s %s\n", "SLUG", "TYPE", "SERVER", "DESCRIPTION")
+			for _, e := range cat.All() {
+				fmt.Fprintf(out, "%-12s %-8s %-9s %s\n", e.Slug, e.AppType, e.Server, e.Description)
+			}
+			return nil
+		},
+	}
 }
 
 func pythonAppRepoFromDB() repository.PythonAppRepository {

--- a/panel-api/cmd/server/python_app_create_cmd.go
+++ b/panel-api/cmd/server/python_app_create_cmd.go
@@ -19,7 +19,20 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 )
+
+// loadPyFrameworkCatalogCLI loads the JAB-164 framework catalog with the same
+// deployed-path + dev-fallback used by the server.
+func loadPyFrameworkCatalogCLI() *pyframeworks.Catalog {
+	cat, _ := pyframeworks.LoadDir("/usr/local/share/jabali/py-frameworks")
+	if cat.Len() == 0 {
+		if c2, _ := pyframeworks.LoadDir("install/py-frameworks"); c2.Len() > 0 {
+			return c2
+		}
+	}
+	return cat
+}
 
 // Validation regexes mirror api/python_apps.go.
 var (
@@ -39,6 +52,7 @@ func newPythonAppCreateCmd() *cobra.Command {
 		appRoot   string
 		baseURI   string
 		envPairs  []string
+		framework string
 	)
 	cmd := &cobra.Command{
 		Use:     "create",
@@ -48,6 +62,24 @@ func newPythonAppCreateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if name == "" {
 				return fmt.Errorf("--name is required")
+			}
+			// JAB-164: a framework install derives app_type/entrypoint (and a
+			// default python version) from the catalog entry; the reconciler then
+			// scaffolds the starter + deps + generated secrets before first apply.
+			if framework != "" {
+				fe, ok := loadPyFrameworkCatalogCLI().Get(framework)
+				if !ok {
+					return fmt.Errorf("unknown --framework %q (run `python-app frameworks` to list)", framework)
+				}
+				spec, serr := fe.ResolveCreate()
+				if serr != nil {
+					return fmt.Errorf("resolve framework %q: %w", framework, serr)
+				}
+				appType = spec.AppType
+				entry = spec.Entrypoint
+				if pyVersion == "" && fe.PythonMin != "" {
+					pyVersion = fe.PythonMin
+				}
 			}
 			if appType == "" {
 				appType = "wsgi"
@@ -105,6 +137,7 @@ func newPythonAppCreateCmd() *cobra.Command {
 				Entrypoint:    entry,
 				BaseURI:       baseURI,
 				LoopbackPort:  &port,
+				Framework:     framework,
 				Status:        models.PythonAppStatusPending,
 			}
 			if err := repo.Create(ctx, app); err != nil {
@@ -134,7 +167,8 @@ func newPythonAppCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&domain, "domain", "", "domain name to mount on (resolved to its id)")
 	cmd.Flags().StringVar(&pyVersion, "python-version", "", "Python version, e.g. 3.12 (required)")
 	cmd.Flags().StringVar(&appType, "app-type", "wsgi", "wsgi|asgi")
-	cmd.Flags().StringVar(&entry, "entrypoint", "", "module:callable, e.g. myapp.wsgi:application (required)")
+	cmd.Flags().StringVar(&entry, "entrypoint", "", "module:callable, e.g. myapp.wsgi:application (required unless --framework)")
+	cmd.Flags().StringVar(&framework, "framework", "", "marketplace slug (e.g. django, flask, fastapi); derives app-type/entrypoint and scaffolds the starter")
 	cmd.Flags().StringVar(&appRoot, "app-root", "", "app root under the owner's home (required)")
 	cmd.Flags().StringVar(&baseURI, "base-uri", "/", "mount path on the domain")
 	cmd.Flags().StringArrayVar(&envPairs, "env", nil, "KEY=VALUE (repeatable)")

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -33,6 +33,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications/senders"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler/phases"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -224,6 +225,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 		for _, e := range dockerCatalogErrs {
 			slog.Default().Warn("docker-app catalog entry failed to load", "err", e.Error())
 		}
+		// JAB-164: load the Python framework marketplace catalog (same
+		// deployed-path + dev-fallback pattern as docker-apps). Non-fatal.
+		pyCatalog, pyCatalogErrs := pyframeworks.LoadDir("/usr/local/share/jabali/py-frameworks")
+		if pyCatalog.Len() == 0 {
+			if pc2, _ := pyframeworks.LoadDir("install/py-frameworks"); pc2.Len() > 0 {
+				pyCatalog = pc2
+			}
+		}
+		for _, e := range pyCatalogErrs {
+			slog.Default().Warn("py-framework catalog entry failed to load", "err", e.Error())
+		}
 		limitOverridesRepo := repository.NewUserLimitOverrideRepository(sharedDB)
 
 		serverSettingsRepo := repository.NewServerSettingsRepository(sharedDB)
@@ -320,6 +332,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		rec.WithCronJobs(cronJobsRepo)
 		rec.WithDockerApps(dockerAppRepo)
 		rec.WithPythonApps(pythonAppRepo)
+		rec.WithPyFrameworks(pyCatalog)
 		rec.WithDockerCatalog(dockerCatalog)
 		// M18 wiring — packages + overrides + /home mount path so
 		// ReconcileUserLimits and ReconcileNginxRateLimits have every

--- a/panel-api/internal/db/migrations/000229_python_app_framework.down.sql
+++ b/panel-api/internal/db/migrations/000229_python_app_framework.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE python_apps
+    DROP COLUMN framework,
+    DROP COLUMN scaffolded_at;

--- a/panel-api/internal/db/migrations/000229_python_app_framework.up.sql
+++ b/panel-api/internal/db/migrations/000229_python_app_framework.up.sql
@@ -1,0 +1,6 @@
+-- JAB-164: mark a Python app as provisioned from a framework marketplace entry.
+-- framework = catalog slug (empty/NULL for hand-configured apps); scaffolded_at
+-- gates the one-shot app.python.scaffold the reconciler runs before first apply.
+ALTER TABLE python_apps
+    ADD COLUMN framework VARCHAR(32) NULL,
+    ADD COLUMN scaffolded_at TIMESTAMP NULL;

--- a/panel-api/internal/models/python_app.go
+++ b/panel-api/internal/models/python_app.go
@@ -30,6 +30,16 @@ type PythonApp struct {
 	// StartCommand overrides the derived gunicorn/uvicorn command when set.
 	StartCommand *string `gorm:"column:start_command;type:varchar(1024);null" json:"start_command,omitempty"`
 
+	// Framework is the marketplace slug this app was provisioned from (JAB-164),
+	// empty for hand-configured apps. When set and ScaffoldedAt is nil, the
+	// reconciler runs app.python.scaffold (starter project + pinned deps) before
+	// the first app.python.apply.
+	Framework string `gorm:"column:framework;type:varchar(32);null" json:"framework,omitempty"`
+	// ScaffoldedAt records when the framework starter was laid down. nil means the
+	// one-shot scaffold still needs to run; once set the reconciler never
+	// re-scaffolds over the tenant's code.
+	ScaffoldedAt *time.Time `gorm:"column:scaffolded_at;type:timestamp;null" json:"scaffolded_at,omitempty"`
+
 	Status      string  `gorm:"type:varchar(32);not null;default:'pending'" json:"status"`
 	CPULimit    *string `gorm:"column:cpu_limit;type:varchar(16);null" json:"cpu_limit,omitempty"`
 	MemoryLimit *string `gorm:"column:memory_limit;type:varchar(16);null" json:"memory_limit,omitempty"`

--- a/panel-api/internal/pyframeworks/catalog.go
+++ b/panel-api/internal/pyframeworks/catalog.go
@@ -1,0 +1,240 @@
+// Package pyframeworks loads + validates the Python WSGI/ASGI framework
+// marketplace catalog (JAB-164): install/py-frameworks/<slug>/framework.yaml.
+//
+// It's the Step-1 foundation for a one-click framework marketplace on top of the
+// existing per-user Python-app runtime (ADR-0131). The catalog only adds a
+// catalog + scaffold description; provisioning reuses the shipped venv +
+// loopback-port + nginx-proxy flow. Mirrors internal/dockerapp/catalog.go: the
+// catalog is read once at startup, immutable after load, and bad entries are
+// logged + skipped rather than crashing boot.
+package pyframeworks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// App server types the runtime already knows how to launch.
+const (
+	AppTypeWSGI = "wsgi"
+	AppTypeASGI = "asgi"
+)
+
+// EnvVar is one templated environment variable an entry declares. Secret vars
+// (e.g. Django SECRET_KEY) are GENERATED at install time, never stored in the
+// catalog — `generate` marks them so the scaffolder mints a value into the
+// app's env instead of using Default.
+type EnvVar struct {
+	Key         string `yaml:"key"`
+	Default     string `yaml:"default,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	Generate    string `yaml:"generate,omitempty"` // "" | "secret_key" | "hex32"
+	Required    bool   `yaml:"required,omitempty"`
+}
+
+// Entry is the parsed shape of <slug>/framework.yaml.
+type Entry struct {
+	Slug        string   `yaml:"slug"`
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags,omitempty"`
+	// Popularity orders the catalog (higher first, ties by slug). Optional.
+	Popularity int    `yaml:"popularity,omitempty"`
+	Icon       string `yaml:"icon,omitempty"`
+	Upstream   string `yaml:"upstream,omitempty"`
+	Docs       string `yaml:"docs,omitempty"`
+
+	// AppType wires to the runtime's launch model: wsgi → gunicorn, asgi →
+	// uvicorn/hypercorn/daphne.
+	AppType string `yaml:"app_type"`
+	// Server is the ASGI/WSGI server binary installed into the venv.
+	Server string `yaml:"server"`
+	// PythonMin is the minimum Python runtime (e.g. "3.10"); the picker gates on
+	// host-available runtimes (GH#357 scar: never offer an uninstalled runtime).
+	PythonMin string `yaml:"python_min,omitempty"`
+	// PipRequirements are the pinned top-level deps written to requirements.txt.
+	PipRequirements []string `yaml:"pip_requirements"`
+
+	// Scaffold describes how a starter project is created into app_root. Kind
+	// "cmd" runs Command (e.g. django-admin startproject); "template" copies the
+	// entry's template/ dir. Both run AS THE TENANT.
+	Scaffold Scaffold `yaml:"scaffold"`
+	// EntrypointTemplate is the module:callable the server launches, with
+	// {{.Project}} substituted for the scaffolded project name (e.g.
+	// "{{.Project}}.wsgi:application", "app:app", "main:app").
+	EntrypointTemplate string `yaml:"entrypoint_template"`
+
+	DefaultEnv []EnvVar `yaml:"default_env,omitempty"`
+
+	// NeedsDB: none|sqlite|mariadb|postgres. mariadb/postgres optionally link a
+	// Jabali DB instead of SQLite (Step 4).
+	NeedsDB string `yaml:"needs_db,omitempty"`
+	// StaticURL/StaticRoot: for Django-family entries, nginx serves StaticURL
+	// from StaticRoot (a location alongside the proxy). Empty = no static split.
+	StaticURL  string `yaml:"static_url,omitempty"`
+	StaticRoot string `yaml:"static_root,omitempty"`
+	// PostInstall are ordered steps run after pip install (e.g. migrate,
+	// collectstatic). Free-form tokens the scaffolder maps to framework actions.
+	PostInstall []string `yaml:"post_install,omitempty"`
+}
+
+// Scaffold is how a starter project is generated.
+type Scaffold struct {
+	Kind    string `yaml:"kind"`              // "cmd" | "template"
+	Command string `yaml:"command,omitempty"` // for kind=cmd, {{.Project}} templated
+	Project string `yaml:"project,omitempty"` // default project name for cmd scaffolds
+}
+
+var (
+	slugRe  = regexp.MustCompile(`^[a-z][a-z0-9-]{1,31}$`)
+	pyVerRe = regexp.MustCompile(`^3\.[0-9]{1,2}$`)
+	// wsgiServers/asgiServers gate server-vs-type consistency.
+	wsgiServers = map[string]bool{"gunicorn": true}
+	asgiServers = map[string]bool{"uvicorn": true, "hypercorn": true, "daphne": true}
+	needsDBSet  = map[string]bool{"": true, "none": true, "sqlite": true, "mariadb": true, "postgres": true}
+)
+
+func (e Entry) validate() error {
+	if !slugRe.MatchString(e.Slug) {
+		return fmt.Errorf("slug %q: must match ^[a-z][a-z0-9-]{1,31}$", e.Slug)
+	}
+	if e.Name == "" {
+		return errors.New("name is required")
+	}
+	if e.Version == "" {
+		return errors.New("version is required")
+	}
+	if e.Description == "" {
+		return errors.New("description is required")
+	}
+	switch e.AppType {
+	case AppTypeWSGI, AppTypeASGI:
+	default:
+		return fmt.Errorf("app_type %q: must be wsgi or asgi", e.AppType)
+	}
+	// Server must match the app type — a WSGI server can't run an ASGI app.
+	if e.AppType == AppTypeWSGI && !wsgiServers[e.Server] {
+		return fmt.Errorf("server %q: WSGI entries require gunicorn", e.Server)
+	}
+	if e.AppType == AppTypeASGI && !asgiServers[e.Server] {
+		return fmt.Errorf("server %q: ASGI entries require uvicorn, hypercorn, or daphne", e.Server)
+	}
+	if e.PythonMin != "" && !pyVerRe.MatchString(e.PythonMin) {
+		return fmt.Errorf("python_min %q: must be like 3.10", e.PythonMin)
+	}
+	if len(e.PipRequirements) == 0 {
+		return errors.New("pip_requirements must list at least the framework + server")
+	}
+	switch e.Scaffold.Kind {
+	case "cmd":
+		if e.Scaffold.Command == "" {
+			return errors.New("scaffold.command is required for kind=cmd")
+		}
+	case "template":
+	default:
+		return fmt.Errorf("scaffold.kind %q: must be cmd or template", e.Scaffold.Kind)
+	}
+	if e.EntrypointTemplate == "" {
+		return errors.New("entrypoint_template is required")
+	}
+	if !needsDBSet[e.NeedsDB] {
+		return fmt.Errorf("needs_db %q: must be none, sqlite, mariadb, or postgres", e.NeedsDB)
+	}
+	// Static split is all-or-nothing.
+	if (e.StaticURL == "") != (e.StaticRoot == "") {
+		return errors.New("static_url and static_root must be set together")
+	}
+	// Generated env vars must name a supported generator.
+	for _, v := range e.DefaultEnv {
+		if v.Key == "" {
+			return errors.New("default_env: key is required")
+		}
+		switch v.Generate {
+		case "", "secret_key", "hex32":
+		default:
+			return fmt.Errorf("default_env[%s].generate %q: unsupported", v.Key, v.Generate)
+		}
+	}
+	return nil
+}
+
+// Catalog is the loaded, immutable set of framework entries.
+type Catalog struct {
+	bySlug map[string]Entry
+	sorted []Entry
+}
+
+// Get returns an entry by slug.
+func (c *Catalog) Get(slug string) (Entry, bool) { e, ok := c.bySlug[slug]; return e, ok }
+
+// All returns the entries in listing order (popularity desc, then slug).
+func (c *Catalog) All() []Entry { return c.sorted }
+
+// Len is the number of loaded entries.
+func (c *Catalog) Len() int { return len(c.sorted) }
+
+// EntryError pairs a slug (or path) with why it failed to load, so boot can log
+// + skip without crashing.
+type EntryError struct {
+	Slug string
+	Err  error
+}
+
+func (e EntryError) Error() string { return fmt.Sprintf("%s: %v", e.Slug, e.Err) }
+
+// LoadDir reads every <root>/<slug>/framework.yaml, validates it, and returns
+// the catalog plus a slice of per-entry errors for the ones that were skipped.
+func LoadDir(root string) (*Catalog, []EntryError) {
+	c := &Catalog{bySlug: map[string]Entry{}}
+	var errs []EntryError
+
+	dirs, err := os.ReadDir(root)
+	if err != nil {
+		return c, []EntryError{{Slug: root, Err: err}}
+	}
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		slug := d.Name()
+		path := filepath.Join(root, slug, "framework.yaml")
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			errs = append(errs, EntryError{Slug: slug, Err: rerr})
+			continue
+		}
+		var e Entry
+		if uerr := yaml.Unmarshal(raw, &e); uerr != nil {
+			errs = append(errs, EntryError{Slug: slug, Err: uerr})
+			continue
+		}
+		if e.Slug != slug {
+			errs = append(errs, EntryError{Slug: slug, Err: fmt.Errorf("slug %q does not match dir %q", e.Slug, slug)})
+			continue
+		}
+		if verr := e.validate(); verr != nil {
+			errs = append(errs, EntryError{Slug: slug, Err: verr})
+			continue
+		}
+		if _, dup := c.bySlug[slug]; dup {
+			errs = append(errs, EntryError{Slug: slug, Err: errors.New("duplicate slug")})
+			continue
+		}
+		c.bySlug[slug] = e
+		c.sorted = append(c.sorted, e)
+	}
+	sort.SliceStable(c.sorted, func(i, j int) bool {
+		if c.sorted[i].Popularity != c.sorted[j].Popularity {
+			return c.sorted[i].Popularity > c.sorted[j].Popularity
+		}
+		return c.sorted[i].Slug < c.sorted[j].Slug
+	})
+	return c, errs
+}

--- a/panel-api/internal/pyframeworks/catalog.go
+++ b/panel-api/internal/pyframeworks/catalog.go
@@ -12,6 +12,7 @@ package pyframeworks
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -83,6 +84,12 @@ type Entry struct {
 	// PostInstall are ordered steps run after pip install (e.g. migrate,
 	// collectstatic). Free-form tokens the scaffolder maps to framework actions.
 	PostInstall []string `yaml:"post_install,omitempty"`
+
+	// TemplateFiles is relpath->content for a kind=template scaffold, loaded from
+	// <slug>/template/** by LoadDir (NOT the YAML). Kept in-memory on the entry so
+	// the reconciler can ship the starter over agentwire without touching disk,
+	// mirroring the docker-app catalog's inline templates.
+	TemplateFiles map[string]string `yaml:"-"`
 }
 
 // Scaffold is how a starter project is generated.
@@ -138,6 +145,9 @@ func (e Entry) validate() error {
 			return errors.New("scaffold.command is required for kind=cmd")
 		}
 	case "template":
+		if len(e.TemplateFiles) == 0 {
+			return errors.New("scaffold.kind=template requires a non-empty template/ dir")
+		}
 	default:
 		return fmt.Errorf("scaffold.kind %q: must be cmd or template", e.Scaffold.Kind)
 	}
@@ -163,6 +173,41 @@ func (e Entry) validate() error {
 		}
 	}
 	return nil
+}
+
+// readTemplateDir reads every regular file under dir into a relpath->content
+// map (forward-slash keys). The agent re-validates each relpath before writing
+// (no traversal, not absolute), so this only needs to reject the unreadable.
+func readTemplateDir(dir string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return fmt.Errorf("template/%s is not a regular file", d.Name())
+		}
+		rel, rerr := filepath.Rel(dir, p)
+		if rerr != nil {
+			return rerr
+		}
+		body, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return rerr
+		}
+		out[filepath.ToSlash(rel)] = string(body)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read template dir: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("template/ dir is empty")
+	}
+	return out, nil
 }
 
 // Catalog is the loaded, immutable set of framework entries.
@@ -218,6 +263,15 @@ func LoadDir(root string) (*Catalog, []EntryError) {
 		if e.Slug != slug {
 			errs = append(errs, EntryError{Slug: slug, Err: fmt.Errorf("slug %q does not match dir %q", e.Slug, slug)})
 			continue
+		}
+		// Load the starter files for a template scaffold (validated below).
+		if e.Scaffold.Kind == "template" {
+			tf, terr := readTemplateDir(filepath.Join(root, slug, "template"))
+			if terr != nil {
+				errs = append(errs, EntryError{Slug: slug, Err: terr})
+				continue
+			}
+			e.TemplateFiles = tf
 		}
 		if verr := e.validate(); verr != nil {
 			errs = append(errs, EntryError{Slug: slug, Err: verr})

--- a/panel-api/internal/pyframeworks/catalog_test.go
+++ b/panel-api/internal/pyframeworks/catalog_test.go
@@ -1,0 +1,86 @@
+package pyframeworks
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// catalogRoot is the in-repo framework catalog, relative to this package.
+const catalogRoot = "../../../install/py-frameworks"
+
+// TestCatalogLoad_ValidatesAllEntries walks the real catalog and asserts every
+// framework.yaml parses + passes validation (no skipped entries). This is the
+// JAB-164 counterpart of the docker-app TestCatalogLoad — a malformed entry
+// fails CI instead of being silently dropped at boot.
+func TestCatalogLoad_ValidatesAllEntries(t *testing.T) {
+	c, errs := LoadDir(catalogRoot)
+	for _, e := range errs {
+		t.Errorf("catalog entry %s failed to load: %v", e.Slug, e.Err)
+	}
+	if c.Len() == 0 {
+		t.Fatal("catalog loaded zero entries — expected the seeded frameworks")
+	}
+	// The three seed entries must be present and typed correctly.
+	for slug, wantType := range map[string]string{"flask": AppTypeWSGI, "fastapi": AppTypeASGI, "django": AppTypeWSGI} {
+		e, ok := c.Get(slug)
+		if !ok {
+			t.Errorf("expected %q in the catalog", slug)
+			continue
+		}
+		if e.AppType != wantType {
+			t.Errorf("%s app_type = %q, want %q", slug, e.AppType, wantType)
+		}
+		if len(e.PipRequirements) == 0 {
+			t.Errorf("%s: pip_requirements empty", slug)
+		}
+	}
+	// Listing order is popularity-desc: Django (95) before Flask (90) before FastAPI (88).
+	all := c.All()
+	if all[0].Slug != "django" {
+		t.Errorf("most-popular entry = %q, want django", all[0].Slug)
+	}
+}
+
+func TestValidate_RejectsServerTypeMismatch(t *testing.T) {
+	base := func() Entry {
+		return Entry{
+			Slug: "testfw", Name: "X", Version: "1", Description: "d",
+			AppType: AppTypeWSGI, Server: "gunicorn",
+			PipRequirements:    []string{"x==1"},
+			Scaffold:           Scaffold{Kind: "template"},
+			EntrypointTemplate: "app:app",
+		}
+	}
+	if err := base().validate(); err != nil {
+		t.Fatalf("valid WSGI entry rejected: %v", err)
+	}
+	// ASGI app declaring a WSGI server must fail.
+	bad := base()
+	bad.AppType = AppTypeASGI
+	bad.Server = "gunicorn"
+	if err := bad.validate(); err == nil {
+		t.Error("ASGI entry with gunicorn must be rejected")
+	}
+	// Unknown needs_db must fail.
+	db := base()
+	db.NeedsDB = "oracle"
+	if err := db.validate(); err == nil {
+		t.Error("needs_db=oracle must be rejected")
+	}
+	// Half a static split must fail.
+	st := base()
+	st.StaticURL = "/static/"
+	if err := st.validate(); err == nil {
+		t.Error("static_url without static_root must be rejected")
+	}
+}
+
+func TestLoadDir_MissingRoot(t *testing.T) {
+	c, errs := LoadDir(filepath.Join(t.TempDir(), "nope"))
+	if len(errs) == 0 {
+		t.Error("missing root should report an error")
+	}
+	if c.Len() != 0 {
+		t.Error("missing root should yield an empty catalog")
+	}
+}

--- a/panel-api/internal/pyframeworks/catalog_test.go
+++ b/panel-api/internal/pyframeworks/catalog_test.go
@@ -48,6 +48,7 @@ func TestValidate_RejectsServerTypeMismatch(t *testing.T) {
 			AppType: AppTypeWSGI, Server: "gunicorn",
 			PipRequirements:    []string{"x==1"},
 			Scaffold:           Scaffold{Kind: "template"},
+			TemplateFiles:      map[string]string{"app.py": "app = object()\n"},
 			EntrypointTemplate: "app:app",
 		}
 	}

--- a/panel-api/internal/pyframeworks/resolve.go
+++ b/panel-api/internal/pyframeworks/resolve.go
@@ -1,0 +1,90 @@
+package pyframeworks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// CreateSpec is the resolved runtime config for provisioning a Python app from a
+// framework entry: the fields the create flow stamps on the app row + the plan
+// the agent executes (scaffold, requirements, post-install). Pure derivation
+// from an Entry — no I/O — so it's fully unit-testable ahead of the agent wiring.
+type CreateSpec struct {
+	AppType      string   // wsgi | asgi
+	Server       string   // gunicorn | uvicorn | hypercorn | daphne
+	Entrypoint   string   // rendered module:callable (e.g. site.wsgi:application)
+	Requirements []string // pinned pip deps written to requirements.txt
+	Project      string   // scaffold project name (cmd scaffolds)
+
+	ScaffoldKind    string   // cmd | template
+	ScaffoldCommand []string // argv for a cmd scaffold (rendered); nil for template
+
+	NeedsDB     string
+	StaticURL   string
+	StaticRoot  string
+	PostInstall []string
+	// GenerateEnv are the env vars the scaffolder must mint a value for (secret
+	// generators) — kept separate so the caller writes them to the app's env,
+	// never to source.
+	GenerateEnv []EnvVar
+}
+
+var (
+	// projectRe guards a cmd-scaffold project name — it becomes a Python package
+	// (django-admin startproject <name>), so it must be an importable identifier.
+	projectRe = regexp.MustCompile(`^[a-z][a-z0-9_]{0,31}$`)
+	// entrypointRe mirrors the runtime's module:callable contract after rendering.
+	entrypointRe = regexp.MustCompile(`^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$`)
+)
+
+// renderProject substitutes {{.Project}} in a template with the project name.
+// Only that one variable is supported, so a literal replace is enough (and
+// avoids pulling text/template + its error surface into the hot path).
+func renderProject(tmpl, project string) string {
+	return strings.ReplaceAll(tmpl, "{{.Project}}", project)
+}
+
+// ResolveCreate turns a validated Entry into the runtime CreateSpec. It renders
+// the entrypoint + scaffold command against the project name and re-checks the
+// derived entrypoint against the runtime's module:callable contract, so a bad
+// template can't produce an unlaunchable app.
+func (e Entry) ResolveCreate() (CreateSpec, error) {
+	project := e.Scaffold.Project
+	if project == "" {
+		project = "app"
+	}
+	if e.Scaffold.Kind == "cmd" && !projectRe.MatchString(project) {
+		return CreateSpec{}, fmt.Errorf("scaffold.project %q: must be an importable identifier ^[a-z][a-z0-9_]{0,31}$", project)
+	}
+
+	entrypoint := renderProject(e.EntrypointTemplate, project)
+	if !entrypointRe.MatchString(entrypoint) {
+		return CreateSpec{}, fmt.Errorf("rendered entrypoint %q is not module:callable", entrypoint)
+	}
+
+	spec := CreateSpec{
+		AppType:      e.AppType,
+		Server:       e.Server,
+		Entrypoint:   entrypoint,
+		Requirements: append([]string(nil), e.PipRequirements...),
+		Project:      project,
+		ScaffoldKind: e.Scaffold.Kind,
+		NeedsDB:      e.NeedsDB,
+		StaticURL:    e.StaticURL,
+		StaticRoot:   e.StaticRoot,
+		PostInstall:  append([]string(nil), e.PostInstall...),
+	}
+	if e.Scaffold.Kind == "cmd" {
+		spec.ScaffoldCommand = strings.Fields(renderProject(e.Scaffold.Command, project))
+		if len(spec.ScaffoldCommand) == 0 {
+			return CreateSpec{}, fmt.Errorf("scaffold.command rendered empty")
+		}
+	}
+	for _, v := range e.DefaultEnv {
+		if v.Generate != "" {
+			spec.GenerateEnv = append(spec.GenerateEnv, v)
+		}
+	}
+	return spec, nil
+}

--- a/panel-api/internal/pyframeworks/resolve.go
+++ b/panel-api/internal/pyframeworks/resolve.go
@@ -17,8 +17,13 @@ type CreateSpec struct {
 	Requirements []string // pinned pip deps written to requirements.txt
 	Project      string   // scaffold project name (cmd scaffolds)
 
-	ScaffoldKind    string   // cmd | template
-	ScaffoldCommand []string // argv for a cmd scaffold (rendered); nil for template
+	ScaffoldKind    string            // cmd | template
+	ScaffoldCommand []string          // argv for a cmd scaffold (rendered); nil for template
+	TemplateFiles   map[string]string // relpath->content for a template scaffold; nil for cmd
+
+	// HardenSettings requests the Django-style settings.py rewrite (SECRET_KEY +
+	// ALLOWED_HOSTS from env, STATIC_ROOT). Derived from a secret_key generator.
+	HardenSettings bool
 
 	NeedsDB     string
 	StaticURL   string
@@ -28,6 +33,10 @@ type CreateSpec struct {
 	// generators) — kept separate so the caller writes them to the app's env,
 	// never to source.
 	GenerateEnv []EnvVar
+	// Env is the full declared default env (generated + static). The create flow
+	// merges these into the app's env after scaffolding, filling generated keys
+	// from the scaffolder's output.
+	Env []EnvVar
 }
 
 var (
@@ -80,10 +89,16 @@ func (e Entry) ResolveCreate() (CreateSpec, error) {
 		if len(spec.ScaffoldCommand) == 0 {
 			return CreateSpec{}, fmt.Errorf("scaffold.command rendered empty")
 		}
+	} else {
+		spec.TemplateFiles = e.TemplateFiles
 	}
+	spec.Env = append([]EnvVar(nil), e.DefaultEnv...)
 	for _, v := range e.DefaultEnv {
 		if v.Generate != "" {
 			spec.GenerateEnv = append(spec.GenerateEnv, v)
+		}
+		if v.Generate == "secret_key" {
+			spec.HardenSettings = true
 		}
 	}
 	return spec, nil

--- a/panel-api/internal/pyframeworks/resolve_test.go
+++ b/panel-api/internal/pyframeworks/resolve_test.go
@@ -1,0 +1,72 @@
+package pyframeworks
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveCreate_DjangoCmdScaffold(t *testing.T) {
+	c, errs := LoadDir(catalogRoot)
+	if len(errs) != 0 {
+		t.Fatalf("catalog load errors: %v", errs)
+	}
+	dj, _ := c.Get("django")
+	spec, err := dj.ResolveCreate()
+	if err != nil {
+		t.Fatalf("resolve django: %v", err)
+	}
+	if spec.Entrypoint != "site.wsgi:application" {
+		t.Errorf("entrypoint = %q, want site.wsgi:application", spec.Entrypoint)
+	}
+	if want := []string{"django-admin", "startproject", "site", "."}; !reflect.DeepEqual(spec.ScaffoldCommand, want) {
+		t.Errorf("scaffold cmd = %v, want %v", spec.ScaffoldCommand, want)
+	}
+	if spec.NeedsDB != "sqlite" || spec.StaticURL != "/static/" {
+		t.Errorf("django db/static wrong: %+v", spec)
+	}
+	if len(spec.GenerateEnv) != 1 || spec.GenerateEnv[0].Key != "DJANGO_SECRET_KEY" {
+		t.Errorf("django must generate DJANGO_SECRET_KEY, got %+v", spec.GenerateEnv)
+	}
+	if len(spec.PostInstall) != 2 {
+		t.Errorf("django post_install = %v, want migrate+collectstatic", spec.PostInstall)
+	}
+}
+
+func TestResolveCreate_FlaskTemplateScaffold(t *testing.T) {
+	c, _ := LoadDir(catalogRoot)
+	fl, _ := c.Get("flask")
+	spec, err := fl.ResolveCreate()
+	if err != nil {
+		t.Fatalf("resolve flask: %v", err)
+	}
+	if spec.Entrypoint != "app:app" {
+		t.Errorf("entrypoint = %q, want app:app", spec.Entrypoint)
+	}
+	if spec.ScaffoldKind != "template" || spec.ScaffoldCommand != nil {
+		t.Errorf("template scaffold must have no command, got %v", spec.ScaffoldCommand)
+	}
+	if spec.Server != "gunicorn" || spec.AppType != AppTypeWSGI {
+		t.Errorf("flask server/type wrong: %+v", spec)
+	}
+}
+
+func TestResolveCreate_RejectsBadProjectAndEntrypoint(t *testing.T) {
+	// Non-identifier project name for a cmd scaffold.
+	bad := Entry{
+		Slug: "bad", AppType: AppTypeWSGI, Server: "gunicorn",
+		Scaffold:           Scaffold{Kind: "cmd", Command: "django-admin startproject {{.Project}} .", Project: "1nvalid"},
+		EntrypointTemplate: "{{.Project}}.wsgi:application",
+	}
+	if _, err := bad.ResolveCreate(); err == nil {
+		t.Error("bad project name must be rejected")
+	}
+	// Entrypoint template that renders to a non module:callable.
+	badEp := Entry{
+		Slug: "badep", AppType: AppTypeWSGI, Server: "gunicorn",
+		Scaffold:           Scaffold{Kind: "template"},
+		EntrypointTemplate: "not-an-entrypoint",
+	}
+	if _, err := badEp.ResolveCreate(); err == nil {
+		t.Error("non module:callable entrypoint must be rejected")
+	}
+}

--- a/panel-api/internal/pyframeworks/resolve_test.go
+++ b/panel-api/internal/pyframeworks/resolve_test.go
@@ -15,10 +15,10 @@ func TestResolveCreate_DjangoCmdScaffold(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve django: %v", err)
 	}
-	if spec.Entrypoint != "site.wsgi:application" {
-		t.Errorf("entrypoint = %q, want site.wsgi:application", spec.Entrypoint)
+	if spec.Entrypoint != "config.wsgi:application" {
+		t.Errorf("entrypoint = %q, want config.wsgi:application", spec.Entrypoint)
 	}
-	if want := []string{"django-admin", "startproject", "site", "."}; !reflect.DeepEqual(spec.ScaffoldCommand, want) {
+	if want := []string{"django-admin", "startproject", "config", "."}; !reflect.DeepEqual(spec.ScaffoldCommand, want) {
 		t.Errorf("scaffold cmd = %v, want %v", spec.ScaffoldCommand, want)
 	}
 	if spec.NeedsDB != "sqlite" || spec.StaticURL != "/static/" {

--- a/panel-api/internal/reconciler/reconcile_python_apps.go
+++ b/panel-api/internal/reconciler/reconcile_python_apps.go
@@ -4,13 +4,23 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/oklog/ulid/v2"
+
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // WithPythonApps wires the python-app repository into the reconciler (ADR-0131).
 func (r *Reconciler) WithPythonApps(repo repository.PythonAppRepository) *Reconciler {
 	r.pythonApps = repo
+	return r
+}
+
+// WithPyFrameworks wires the JAB-164 framework marketplace catalog so the
+// reconciler can run one-shot framework scaffolds. Optional.
+func (r *Reconciler) WithPyFrameworks(cat *pyframeworks.Catalog) *Reconciler {
+	r.pyFrameworks = cat
 	return r
 }
 
@@ -46,6 +56,15 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 	if err != nil || user == nil || user.Username == nil || *user.Username == "" || user.IsAdmin {
 		r.failPythonApp(ctx, app.ID, "owner has no linux username")
 		return
+	}
+
+	// JAB-164: one-shot framework scaffold (starter project + pinned deps +
+	// generated secrets) before the first apply. Gated on scaffolded_at so it
+	// never re-runs over the tenant's code.
+	if app.Framework != "" && app.ScaffoldedAt == nil {
+		if !r.scaffoldPythonApp(ctx, app, *user.Username) {
+			return // scaffold failed; status already set to failed
+		}
 	}
 
 	envRows, _ := r.pythonApps.ListEnv(ctx, app.ID)
@@ -115,5 +134,106 @@ func (r *Reconciler) failPythonApp(ctx context.Context, id, msg string) {
 	r.log.Warn("pyapp: apply failed", "id", id, "reason", msg)
 	if err := r.pythonApps.UpdateStatus(ctx, id, models.PythonAppStatusFailed, &msg); err != nil {
 		r.log.Warn("pyapp: fail status update failed", "id", id, "err", err)
+	}
+}
+
+// scaffoldPythonApp lays down the framework starter (venv + pinned deps +
+// starter project + optional Django hardening) via app.python.scaffold, persists
+// generated secrets + framework default env, and stamps scaffolded_at. Returns
+// false and marks the app failed on any error. Runs once per app.
+func (r *Reconciler) scaffoldPythonApp(ctx context.Context, app *models.PythonApp, username string) bool {
+	if r.pyFrameworks == nil {
+		r.failPythonApp(ctx, app.ID, "framework catalog unavailable")
+		return false
+	}
+	entry, ok := r.pyFrameworks.Get(app.Framework)
+	if !ok {
+		r.failPythonApp(ctx, app.ID, "unknown framework "+app.Framework)
+		return false
+	}
+	spec, err := entry.ResolveCreate()
+	if err != nil {
+		r.failPythonApp(ctx, app.ID, "resolve framework: "+err.Error())
+		return false
+	}
+
+	var domainName string
+	if r.domains != nil {
+		if d, derr := r.domains.FindByID(ctx, app.DomainID); derr == nil && d != nil {
+			domainName = d.Name
+		}
+	}
+
+	params := map[string]any{
+		"app_id":         app.ID,
+		"username":       username,
+		"app_root":       app.AppRoot,
+		"python_version": app.PythonVersion,
+		"server":         spec.Server,
+		"requirements":   spec.Requirements,
+		"scaffold_kind":  spec.ScaffoldKind,
+	}
+	if spec.ScaffoldKind == "cmd" {
+		params["scaffold_argv"] = spec.ScaffoldCommand
+		params["project"] = spec.Project
+	} else {
+		params["template_files"] = spec.TemplateFiles
+	}
+	if spec.HardenSettings {
+		params["harden_django"] = true
+		params["static_root"] = spec.StaticRoot
+		params["allowed_hosts"] = domainName
+	}
+	if len(spec.PostInstall) > 0 {
+		params["post_install"] = spec.PostInstall
+	}
+
+	raw, err := r.agent.Call(ctx, "app.python.scaffold", params)
+	if err != nil {
+		r.failPythonApp(ctx, app.ID, "scaffold: "+err.Error())
+		return false
+	}
+	var res struct {
+		GeneratedEnv map[string]string `json:"generated_env"`
+		Skipped      bool              `json:"skipped"`
+	}
+	_ = json.Unmarshal(raw, &res)
+
+	r.persistFrameworkEnv(ctx, app, spec, res.GeneratedEnv, domainName)
+	if err := r.pythonApps.MarkScaffolded(ctx, app.ID); err != nil {
+		r.log.Warn("pyapp: mark scaffolded failed", "id", app.ID, "err", err)
+	}
+	return true
+}
+
+// persistFrameworkEnv merges the framework's default + generated env into the
+// app's env set WITHOUT clobbering values the operator already set. Generated
+// secrets (e.g. Django SECRET_KEY) come from the agent's scaffold result;
+// DJANGO_ALLOWED_HOSTS defaults to the mounted domain when the catalog leaves it
+// blank. Secrets live only in the app env (never in source), per ADR-0131.
+func (r *Reconciler) persistFrameworkEnv(ctx context.Context, app *models.PythonApp, spec pyframeworks.CreateSpec, generated map[string]string, domainName string) {
+	existing, _ := r.pythonApps.ListEnv(ctx, app.ID)
+	have := make(map[string]bool, len(existing))
+	merged := make([]models.PythonAppEnv, 0, len(existing)+len(spec.Env))
+	for _, e := range existing {
+		have[e.Key] = true
+		merged = append(merged, models.PythonAppEnv{ID: e.ID, AppID: app.ID, Key: e.Key, Value: e.Value})
+	}
+	for _, v := range spec.Env {
+		if v.Key == "" || have[v.Key] {
+			continue // never overwrite an operator-set value
+		}
+		val := v.Default
+		if v.Generate != "" {
+			val = generated[v.Key]
+		}
+		if v.Key == "DJANGO_ALLOWED_HOSTS" && val == "" {
+			val = domainName
+		}
+		have[v.Key] = true
+		merged = append(merged, models.PythonAppEnv{ID: ulid.Make().String(), AppID: app.ID, Key: v.Key, Value: val})
+	}
+	if err := r.pythonApps.ReplaceEnv(ctx, app.ID, merged); err != nil {
+		r.log.Warn("pyapp: persist framework env failed", "id", app.ID, "err", err)
 	}
 }

--- a/panel-api/internal/reconciler/reconcile_python_scaffold_test.go
+++ b/panel-api/internal/reconciler/reconcile_python_scaffold_test.go
@@ -1,0 +1,146 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// scaffoldStubAgent captures the app.python.scaffold call and returns a fixed
+// generated secret, mimicking the agent's Django SECRET_KEY minting.
+type scaffoldStubAgent struct {
+	method string
+	params map[string]any
+}
+
+func (a *scaffoldStubAgent) Call(_ context.Context, method string, params interface{}) (json.RawMessage, error) {
+	a.method = method
+	a.params, _ = params.(map[string]any)
+	return json.Marshal(map[string]any{
+		"scaffolded":    true,
+		"generated_env": map[string]string{"DJANGO_SECRET_KEY": "generated-secret-xyz"},
+	})
+}
+
+// stubPyRepo implements just the repository methods scaffoldPythonApp touches;
+// the embedded nil interface satisfies the rest (never called here).
+type stubPyRepo struct {
+	repository.PythonAppRepository
+	env      []*models.PythonAppEnv
+	replaced []models.PythonAppEnv
+	marked   string
+}
+
+func (s *stubPyRepo) ListEnv(context.Context, string) ([]*models.PythonAppEnv, error) {
+	return s.env, nil
+}
+func (s *stubPyRepo) ReplaceEnv(_ context.Context, _ string, env []models.PythonAppEnv) error {
+	s.replaced = env
+	return nil
+}
+func (s *stubPyRepo) MarkScaffolded(_ context.Context, id string) error { s.marked = id; return nil }
+
+// stubDomainRepo returns a fixed domain name for FindByID.
+type stubDomainRepo struct {
+	repository.DomainRepository
+	name string
+}
+
+func (s *stubDomainRepo) FindByID(context.Context, string) (*models.Domain, error) {
+	return &models.Domain{Name: s.name}, nil
+}
+
+// TestScaffoldPythonApp_Django checks the reconciler's one-shot scaffold: the
+// cmd-scaffold argv + Django hardening reach the agent, the generated secret and
+// domain-defaulted ALLOWED_HOSTS are persisted, and the app is marked scaffolded.
+func TestScaffoldPythonApp_Django(t *testing.T) {
+	cat, errs := pyframeworks.LoadDir("../../../install/py-frameworks")
+	if len(errs) != 0 {
+		t.Fatalf("catalog load errors: %v", errs)
+	}
+	ag := &scaffoldStubAgent{}
+	repo := &stubPyRepo{}
+	r := &Reconciler{
+		agent:        ag,
+		pythonApps:   repo,
+		pyFrameworks: cat,
+		domains:      &stubDomainRepo{name: "app.example.com"},
+		log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	app := &models.PythonApp{
+		ID: "01APPDJANGO", UserID: "01USER", DomainID: "01DOM",
+		Framework: "django", AppRoot: "/home/tenant/app", PythonVersion: "3.12",
+	}
+
+	if ok := r.scaffoldPythonApp(context.Background(), app, "tenant"); !ok {
+		t.Fatal("scaffoldPythonApp returned false")
+	}
+
+	// Agent got the scaffold call with the Django cmd argv + hardening.
+	if ag.method != "app.python.scaffold" {
+		t.Fatalf("agent method = %q, want app.python.scaffold", ag.method)
+	}
+	if ag.params["scaffold_kind"] != "cmd" {
+		t.Errorf("scaffold_kind = %v, want cmd", ag.params["scaffold_kind"])
+	}
+	if ag.params["harden_django"] != true {
+		t.Errorf("harden_django = %v, want true", ag.params["harden_django"])
+	}
+	if ag.params["server"] != "gunicorn" {
+		t.Errorf("server = %v, want gunicorn", ag.params["server"])
+	}
+	if _, ok := ag.params["scaffold_argv"].([]string); !ok {
+		t.Errorf("scaffold_argv missing/typed wrong: %T", ag.params["scaffold_argv"])
+	}
+	if ag.params["allowed_hosts"] != "app.example.com" {
+		t.Errorf("allowed_hosts = %v, want the mounted domain", ag.params["allowed_hosts"])
+	}
+
+	// Generated secret + domain-defaulted ALLOWED_HOSTS persisted to the app env.
+	got := map[string]string{}
+	for _, e := range repo.replaced {
+		got[e.Key] = e.Value
+	}
+	if got["DJANGO_SECRET_KEY"] != "generated-secret-xyz" {
+		t.Errorf("DJANGO_SECRET_KEY not persisted from the agent: %q", got["DJANGO_SECRET_KEY"])
+	}
+	if got["DJANGO_ALLOWED_HOSTS"] != "app.example.com" {
+		t.Errorf("DJANGO_ALLOWED_HOSTS = %q, want the mounted domain", got["DJANGO_ALLOWED_HOSTS"])
+	}
+	if repo.marked != app.ID {
+		t.Errorf("app not marked scaffolded (marked=%q)", repo.marked)
+	}
+}
+
+// TestScaffoldPythonApp_DoesNotClobberOperatorEnv verifies an operator-set value
+// survives the framework env merge.
+func TestScaffoldPythonApp_DoesNotClobberOperatorEnv(t *testing.T) {
+	cat, _ := pyframeworks.LoadDir("../../../install/py-frameworks")
+	repo := &stubPyRepo{env: []*models.PythonAppEnv{
+		{ID: "e1", Key: "DJANGO_ALLOWED_HOSTS", Value: "operator-set.example"},
+	}}
+	r := &Reconciler{
+		agent:        &scaffoldStubAgent{},
+		pythonApps:   repo,
+		pyFrameworks: cat,
+		domains:      &stubDomainRepo{name: "app.example.com"},
+		log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	app := &models.PythonApp{ID: "01APP", Framework: "django", AppRoot: "/home/t/app", PythonVersion: "3.12"}
+	if ok := r.scaffoldPythonApp(context.Background(), app, "tenant"); !ok {
+		t.Fatal("scaffold returned false")
+	}
+	got := map[string]string{}
+	for _, e := range repo.replaced {
+		got[e.Key] = e.Value
+	}
+	if got["DJANGO_ALLOWED_HOSTS"] != "operator-set.example" {
+		t.Errorf("operator ALLOWED_HOSTS clobbered: %q", got["DJANGO_ALLOWED_HOSTS"])
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/nginxrules"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler/phases"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/redirects"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -66,6 +67,11 @@ type Reconciler struct {
 	cronJobs repository.CronJobRepository
 	// pythonApps holds the python_apps repository (ADR-0131).
 	pythonApps repository.PythonAppRepository
+	// pyFrameworks is the loaded JAB-164 framework marketplace catalog. When a
+	// python_apps row carries a framework slug and hasn't been scaffolded, the
+	// reconciler resolves the entry here and dispatches app.python.scaffold
+	// before app.python.apply. Optional (nil = framework installs unavailable).
+	pyFrameworks *pyframeworks.Catalog
 
 	// dockerApps holds reference to the docker_apps repository (M48 Phase 1).
 	// Nil-safe: when unwired the docker-app tick is a no-op.

--- a/panel-api/internal/repository/python_app_repository.go
+++ b/panel-api/internal/repository/python_app_repository.go
@@ -23,6 +23,9 @@ type PythonAppRepository interface {
 	ListByDomain(ctx context.Context, domainID string) ([]*models.PythonApp, error)
 	Update(ctx context.Context, app *models.PythonApp) error
 	UpdateStatus(ctx context.Context, id, status string, lastError *string) error
+	// MarkScaffolded stamps scaffolded_at=now so the reconciler's one-shot
+	// framework scaffold never re-runs over the tenant's code.
+	MarkScaffolded(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
 
 	// env
@@ -85,6 +88,12 @@ func (r *pythonAppRepo) UpdateStatus(ctx context.Context, id, status string, las
 	return translate(r.db.WithContext(ctx).Model(&models.PythonApp{}).
 		Where("id = ?", id).
 		Updates(map[string]any{"status": status, "last_error": lastError}).Error)
+}
+
+func (r *pythonAppRepo) MarkScaffolded(ctx context.Context, id string) error {
+	return translate(r.db.WithContext(ctx).Model(&models.PythonApp{}).
+		Where("id = ?", id).
+		Update("scaffolded_at", gorm.Expr("CURRENT_TIMESTAMP")).Error)
 }
 
 func (r *pythonAppRepo) Delete(ctx context.Context, id string) error {


### PR DESCRIPTION
## JAB-164 Step 1 — Python framework marketplace foundation

First phase of the one-click WSGI/ASGI framework marketplace on the existing per-user Python-app runtime (ADR-0131). Additive; mirrors the proven docker-app catalog (`internal/dockerapp/catalog.go`) — no new isolation model.

### This PR (Step 1: catalog schema + loader)
- **`internal/pyframeworks`** — `Entry` schema (slug, name, version, tags, popularity, icon, upstream, docs, `app_type` wsgi|asgi, `server`, `python_min`, pinned `pip_requirements`, `scaffold` cmd|template + `entrypoint_template`, `default_env` with secret **generators**, `needs_db`, `static_url`/`static_root`, `post_install`), plus `LoadDir`/`Catalog` (immutable, bad-entry-skip-not-crash) and `validate`:
  - slug regex, `app_type` enum,
  - **server-vs-type consistency** (WSGI→gunicorn, ASGI→uvicorn/hypercorn/daphne),
  - `needs_db` enum, all-or-nothing static split, env-generator allowlist.
- **Seed entries** `install/py-frameworks/{flask,fastapi,django}/framework.yaml` (+ Flask/FastAPI starter templates). Django uses `django-admin startproject` with `SECRET_KEY` **generated into env** (never source), `migrate`/`collectstatic` post-install, and the static split.
- **`TestCatalogLoad_ValidatesAllEntries`** walks the real catalog (a malformed entry fails CI, not a silent boot skip) + validate reject/accept unit tests.

### Follow-ups (the issue's plan)
- **Step 2** install the entry's server into the app venv.
- **Step 3** scaffold-on-create, run **as the tenant** (`systemd-run --uid`, same drop-priv as `ensurePythonVenvPackage`); `jabali python-app create --framework <slug>`.
- **Step 4** Django-family post-install (SECRET_KEY/ALLOWED_HOSTS/CSRF, migrate, collectstatic, nginx static location, optional DB link).
- **Step 5** UI (docker-apps-style two tabs: Installed + Catalog) + CLI parity.
- **Step 6** author the remaining 7 entries — pins/entrypoints **Context7-verified** at build time.
- **Step 7** security (M18 slice + loopback-only + M34 egress; requirements pinned).
- **Step 8** e2e (create → provision → HTTP 200 through nginx → delete) + ADR + BLUEPRINT row + docs.

### Test plan
- [x] `go test ./internal/pyframeworks/` — catalog loads + validates; server/type + needs_db + static rejects.
- [x] `go vet`, `go build ./...` clean.
- [ ] Seed-entry pins get Context7 re-verification at Step 6.