### PR TITLE
fix(python-apps): scaffold cwd + explicit python version + Django static serving (JAB-164)

### DIFF
--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -259,8 +259,18 @@ func renderPythonUnit(p pythonAppApplyParams, appRoot, envPath, start string) st
 
 // runAsUser runs a command as the hosting user via sudo, capturing output.
 func runAsUser(ctx context.Context, username string, args ...string) (string, error) {
+	return runAsUserInDir(ctx, username, "", args...)
+}
+
+// runAsUserInDir is runAsUser with an explicit working directory. Needed by
+// scaffolds whose commands resolve relative paths (e.g. `django-admin
+// startproject config .` writes manage.py into the cwd) — without it the child
+// inherits the agent's cwd and writes to the wrong place. dir="" keeps the
+// inherited cwd. dir must be a tenant-owned path the user can chdir into.
+func runAsUserInDir(ctx context.Context, username, dir string, args ...string) (string, error) {
 	full := append([]string{"-u", username, "-H"}, args...)
 	cmd := exec.CommandContext(ctx, "sudo", full...)
+	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "PIP_DISABLE_PIP_VERSION_CHECK=1")
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/panel-agent/internal/commands/python_app_scaffold.go
+++ b/panel-agent/internal/commands/python_app_scaffold.go
@@ -131,7 +131,9 @@ func pythonAppScaffoldHandler(ctx context.Context, params json.RawMessage) (any,
 		// Resolve argv[0] inside the venv (django-admin ships with django).
 		bin := filepath.Join(venv, "bin", filepath.Base(p.ScaffoldArgv[0]))
 		args := append([]string{bin}, p.ScaffoldArgv[1:]...)
-		if out, err := runAsUser(ctx, p.Username, args...); err != nil {
+		// Run IN app_root: scaffolders use relative targets (e.g. `startproject
+		// config .`), so cwd must be the app tree or files land in the agent's cwd.
+		if out, err := runAsUserInDir(ctx, p.Username, p.AppRoot, args...); err != nil {
 			return nil, scaffoldErr("scaffold: %v: %s", err, lastLines(out, 8))
 		}
 	case "template":
@@ -192,7 +194,7 @@ func pythonAppScaffoldHandler(ctx context.Context, params json.RawMessage) (any,
 				continue // ignore unknown tokens; the catalog validates the set
 			}
 			args := append(append([]string(nil), envArgs...), vpy, manage, sub, "--noinput")
-			if out, err := runAsUser(ctx, p.Username, args...); err != nil {
+			if out, err := runAsUserInDir(ctx, p.Username, p.AppRoot, args...); err != nil {
 				return nil, scaffoldErr("%s: %v: %s", step, err, lastLines(out, 8))
 			}
 		}

--- a/panel-api/cmd/server/python_app_cmd.go
+++ b/panel-api/cmd/server/python_app_cmd.go
@@ -152,6 +152,7 @@ func newPythonAppDeleteCmd() *cobra.Command {
 			if _, err := sharedAgent.Call(callCtx, "app.python.remove", map[string]any{"app_id": app.ID}); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: agent remove failed: %v\n", err)
 			}
+			detachPythonRulesCLI(ctx, app)
 			if err := repo.Delete(ctx, app.ID); err != nil {
 				return err
 			}

--- a/panel-api/cmd/server/python_app_create_cmd.go
+++ b/panel-api/cmd/server/python_app_create_cmd.go
@@ -54,6 +54,9 @@ func newPythonAppCreateCmd() *cobra.Command {
 		envPairs  []string
 		framework string
 	)
+	// Framework-derived static split (Django STATIC_ROOT), attached as an nginx
+	// static_alias rule alongside the proxy_pass so /static/ is served from disk.
+	var fwStaticURL, fwStaticRoot string
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a Python app (same validation + port/proxy allocation as the UI)",
@@ -77,6 +80,7 @@ func newPythonAppCreateCmd() *cobra.Command {
 				}
 				appType = spec.AppType
 				entry = spec.Entrypoint
+				fwStaticURL, fwStaticRoot = spec.StaticURL, spec.StaticRoot
 				// Do NOT default to fe.PythonMin: that is the framework's *minimum*,
 				// not a version guaranteed installed on this host (GH#357 scar —
 				// never provision against an uninstalled runtime). The CLI has no
@@ -153,7 +157,7 @@ func newPythonAppCreateCmd() *cobra.Command {
 				}
 				_ = repo.ReplaceEnv(ctx, app.ID, rows)
 			}
-			attachPythonProxyRuleCLI(ctx, dom, app)
+			attachPythonProxyRuleCLI(ctx, dom, app, fwStaticURL, fwStaticRoot)
 
 			cliAuditOK(ctx, "python_app.create", "python_app", app.ID, &dom.UserID)
 			if jsonOutput {
@@ -192,26 +196,67 @@ func parsePythonEnvPairs(pairs []string) ([]models.PythonAppEnv, error) {
 // attachPythonProxyRuleCLI mirrors api.attachProxyRule: proxy_pass base_uri ->
 // loopback port, replacing any same-path rule, then persists the domain so the
 // reconciler renders the vhost.
-func attachPythonProxyRuleCLI(ctx context.Context, dom *models.Domain, app *models.PythonApp) {
+func attachPythonProxyRuleCLI(ctx context.Context, dom *models.Domain, app *models.PythonApp, staticURL, staticRoot string) {
 	port := 0
 	if app.LoopbackPort != nil {
 		port = *app.LoopbackPort
 	}
 	ws := true
-	rule := models.NginxRule{Type: "proxy_pass", Path: app.BaseURI, Target: "http://127.0.0.1:" + strconv.Itoa(port), Websocket: &ws}
 	rules := append(models.NginxRules{}, dom.NginxRules...)
-	replaced := false
-	for i := range rules {
-		if rules[i].Type == "proxy_pass" && rules[i].Path == app.BaseURI {
-			rules[i] = rule
-			replaced = true
-			break
+
+	upsert := func(rule models.NginxRule) {
+		for i := range rules {
+			if rules[i].Type == rule.Type && rules[i].Path == rule.Path {
+				rules[i] = rule
+				return
+			}
 		}
-	}
-	if !replaced {
 		rules = append(rules, rule)
 	}
+
+	upsert(models.NginxRule{Type: "proxy_pass", Path: app.BaseURI, Target: "http://127.0.0.1:" + strconv.Itoa(port), Websocket: &ws})
+
+	// Framework static split (Django STATIC_ROOT): serve <base><static_url> from
+	// <app_root>/<static_root> so admin/site static loads without hitting gunicorn.
+	// Django prefixes STATIC_URL with SCRIPT_NAME (=base_uri), so the location is
+	// base_uri + static_url; matches what the app requests.
+	if staticURL != "" && staticRoot != "" {
+		loc := strings.TrimSuffix(app.BaseURI, "/") + staticURL
+		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(staticRoot, "/") + "/"
+		upsert(models.NginxRule{Type: "static_alias", Path: loc, Target: alias})
+	}
+
 	dom.NginxRules = rules
+	_ = domainRepoFromDB().Update(ctx, dom)
+}
+
+// detachPythonRulesCLI removes the app's proxy_pass + framework static_alias
+// rules from its domain on delete (mirrors the API handler's detach; the CLI
+// delete previously left them orphaned on the domain vhost).
+func detachPythonRulesCLI(ctx context.Context, app *models.PythonApp) {
+	if app.DomainID == "" {
+		return
+	}
+	dom, err := domainRepoFromDB().FindByID(ctx, app.DomainID)
+	if err != nil || dom == nil {
+		return
+	}
+	target := "http://127.0.0.1:"
+	if app.LoopbackPort != nil {
+		target += strconv.Itoa(*app.LoopbackPort)
+	}
+	aliasPrefix := strings.TrimSuffix(app.AppRoot, "/") + "/"
+	var kept models.NginxRules
+	for _, r := range dom.NginxRules {
+		if r.Type == "proxy_pass" && r.Path == app.BaseURI && r.Target == target {
+			continue
+		}
+		if r.Type == "static_alias" && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	dom.NginxRules = kept
 	_ = domainRepoFromDB().Update(ctx, dom)
 }
 

--- a/panel-api/cmd/server/python_app_create_cmd.go
+++ b/panel-api/cmd/server/python_app_create_cmd.go
@@ -77,9 +77,11 @@ func newPythonAppCreateCmd() *cobra.Command {
 				}
 				appType = spec.AppType
 				entry = spec.Entrypoint
-				if pyVersion == "" && fe.PythonMin != "" {
-					pyVersion = fe.PythonMin
-				}
+				// Do NOT default to fe.PythonMin: that is the framework's *minimum*,
+				// not a version guaranteed installed on this host (GH#357 scar —
+				// never provision against an uninstalled runtime). The CLI has no
+				// agent handle to probe installed versions, so require an explicit
+				// --python-version and let the validation below enforce it.
 			}
 			if appType == "" {
 				appType = "wsgi"

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -1213,21 +1213,21 @@ var allowedNginxDirectives = map[string]struct{}{
 	"autoindex_localtime":  {},
 	// sub_filter{,_once,_types} removed (JAB-66): arbitrary content injection /
 	// response splitting into proxied responses.
-	"charset":              {},
-	"default_type":         {},
-	"types":                {},
-	"log_not_found":        {},
+	"charset":       {},
+	"default_type":  {},
+	"types":         {},
+	"log_not_found": {},
 	// Access
-	"allow":                {},
-	"deny":                 {},
-	"satisfy":              {},
+	"allow":   {},
+	"deny":    {},
+	"satisfy": {},
 	// auth_basic{,_user_file} removed (JAB-66): auth_basic_user_file is an
 	// arbitrary-file read / existence oracle (point it at /etc/shadow). Use the
 	// structured Directory Privacy feature, which manages the htpasswd file.
-	"limit_except":         {},
-	"limit_req":            {},
-	"limit_req_zone":       {},
-	"limit_conn":           {},
+	"limit_except":   {},
+	"limit_req":      {},
+	"limit_req_zone": {},
+	"limit_conn":     {},
 	// Gzip
 	"gzip":            {},
 	"gzip_types":      {},
@@ -1424,7 +1424,7 @@ func validatePageRedirects(prs models.PageRedirects) error {
 
 func isValidNginxRuleType(s string) bool {
 	switch s {
-	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size":
+	case "custom_header", "rewrite", "proxy_pass", "ip_access", "php_setting", "max_upload_size", "static_alias":
 		return true
 	}
 	return false
@@ -1508,6 +1508,21 @@ func validateNginxRules(rules models.NginxRules) error {
 		case "max_upload_size":
 			if r.Size == "" {
 				return fmt.Errorf("rule %d: size required", i)
+			}
+		case "static_alias":
+			// Serves a filesystem dir (Path=location, Target=alias dir). Used by
+			// framework apps (Django STATIC_ROOT). Admin-only (not in the tenant
+			// safe set). Constrain the alias to under /home/ so it can never be
+			// pointed at /etc or another system path (file disclosure), even by
+			// an admin PATCH; static aliases are always a tenant app dir.
+			if r.Path == "" || r.Target == "" {
+				return fmt.Errorf("rule %d: path and target required", i)
+			}
+			if !strings.HasPrefix(r.Target, "/home/") || strings.Contains(r.Target, "..") {
+				return fmt.Errorf("rule %d: static_alias target must be an absolute path under /home/ with no ..", i)
+			}
+			if strings.ContainsAny(r.Target, " \t\n\r;{}") {
+				return fmt.Errorf("rule %d: invalid chars in static_alias target", i)
 			}
 		}
 		// Forbid control characters everywhere to prevent newline injection into vhost

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -362,9 +362,14 @@ func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.D
 
 func (h *pythonAppHandler) detachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp) {
 	target := proxyTargetFor(app)
+	aliasPrefix := strings.TrimSuffix(app.AppRoot, "/") + "/"
 	var kept models.NginxRules
 	for _, r := range domain.NginxRules {
 		if r.Type == "proxy_pass" && r.Target == target {
+			continue
+		}
+		// Drop the framework static_alias that points into this app's tree.
+		if r.Type == "static_alias" && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
 			continue
 		}
 		kept = append(kept, r)

--- a/panel-api/internal/nginxrules/compile.go
+++ b/panel-api/internal/nginxrules/compile.go
@@ -111,6 +111,20 @@ func Compile(d *models.Domain) string {
 				"    fastcgi_param PHP_VALUE %s;\n",
 				quoteNginxString(r.Name+"="+r.Value))
 
+		case "static_alias":
+			// Serve a filesystem dir (framework STATIC_ROOT) directly from nginx.
+			// ^~ so it beats the template's regex asset-cache block; the alias +
+			// target are constrained to /home/ by the validator (no traversal /
+			// system paths). Long-cache immutable static assets.
+			fmt.Fprintf(&b,
+				"    location ^~ %s {\n"+
+					"        alias %s;\n"+
+					"        access_log off;\n"+
+					"        expires 30d;\n"+
+					"        add_header Cache-Control \"public\";\n"+
+					"    }\n",
+				quoteNginxLocation(r.Path), r.Target)
+
 		case "max_upload_size":
 			fmt.Fprintf(&b, "    client_max_body_size %s;\n", r.Size)
 		}

--- a/panel-api/internal/nginxrules/compile_test.go
+++ b/panel-api/internal/nginxrules/compile_test.go
@@ -396,3 +396,19 @@ func TestCompileProxyPassWebsocket(t *testing.T) {
 		t.Errorf("websocket proxy should not emit empty Connection header:\n%s", got)
 	}
 }
+
+func TestCompile_StaticAlias(t *testing.T) {
+	d := &models.Domain{NginxRules: models.NginxRules{
+		{Type: "static_alias", Path: "/dj/static/", Target: "/home/u/djtest/staticfiles/"},
+	}}
+	got := Compile(d)
+	for _, want := range []string{
+		"location ^~ /dj/static/ {",
+		"alias /home/u/djtest/staticfiles/;",
+		"expires 30d;",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("compiled output missing %q:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Three items the first real create --framework django serve run on testserver surfaced, all fixed + verified end to end.

1. **Scaffold cwd** (bug): cmd-scaffold + post-install ran with the agent's cwd, so `django-admin startproject config .` wrote manage.py to `/`. Added runAsUserInDir; scaffold + migrate/collectstatic now run in app_root.
2. **PythonMin default** (bug): `create --framework` defaulted --python-version to the entry minimum (3.10), failing on a 3.12-only host (GH#357 scar). Now requires an explicit --python-version.
3. **Django static serving** (feature): frameworks with static_url+static_root get a static_alias nginx rule alongside proxy_pass, so <base_uri>/static/ serves from <app_root>/<static_root>. New admin-only rule type, validator constrains the alias to under /home/ (no traversal/system paths), not tenant-settable. Delete detaches proxy_pass + static_alias (CLI delete previously orphaned the proxy rule).

Verified on testserver: create --framework django -> /dj/admin/ 200 (styled) + /dj/static/admin/css/base.css 200 -> delete removes both rules.