### PR TITLE
feat(python-apps): 5 more framework marketplace entries — Starlette/Litestar/Quart/Dash/Bottle (JAB-164)

### DIFF
--- a/install/py-frameworks/bottle/framework.yaml
+++ b/install/py-frameworks/bottle/framework.yaml
@@ -1,0 +1,18 @@
+slug: bottle
+name: Bottle
+version: "0.13"
+description: A fast, dependency-free single-file WSGI micro-framework, served by gunicorn.
+tags: [wsgi, micro]
+popularity: 40
+upstream: https://bottlepy.org/
+docs: https://bottlepy.org/docs/dev/
+app_type: wsgi
+server: gunicorn
+python_min: "3.9"
+pip_requirements:
+  - bottle==0.13.4
+  - gunicorn==23.0.0
+scaffold:
+  kind: template
+entrypoint_template: app:app
+needs_db: none

--- a/install/py-frameworks/bottle/template/app.py
+++ b/install/py-frameworks/bottle/template/app.py
@@ -1,0 +1,10 @@
+import bottle
+
+
+@bottle.route("/")
+def index():
+    return "Hello from Bottle on Jabali."
+
+
+# gunicorn serves the module-level WSGI application (app:app).
+app = bottle.default_app()

--- a/install/py-frameworks/dash/framework.yaml
+++ b/install/py-frameworks/dash/framework.yaml
@@ -1,0 +1,18 @@
+slug: dash
+name: Dash
+version: "4.4"
+description: A Python framework for building analytical web apps and dashboards on Flask (WSGI), served by gunicorn.
+tags: [wsgi, dashboard, data]
+popularity: 65
+upstream: https://dash.plotly.com/
+docs: https://dash.plotly.com/
+app_type: wsgi
+server: gunicorn
+python_min: "3.9"
+pip_requirements:
+  - dash==4.4.0
+  - gunicorn==23.0.0
+scaffold:
+  kind: template
+entrypoint_template: app:server
+needs_db: none

--- a/install/py-frameworks/dash/template/app.py
+++ b/install/py-frameworks/dash/template/app.py
@@ -1,0 +1,7 @@
+from dash import Dash, html
+
+app = Dash(__name__)
+app.layout = html.Div("Hello from Dash on Jabali.")
+
+# gunicorn serves the underlying Flask WSGI app (app:server).
+server = app.server

--- a/install/py-frameworks/litestar/framework.yaml
+++ b/install/py-frameworks/litestar/framework.yaml
@@ -1,0 +1,18 @@
+slug: litestar
+name: Litestar
+version: "2.24"
+description: A batteries-included ASGI framework with fast routing, dependency injection, and OpenAPI, served by uvicorn.
+tags: [asgi, async, api]
+popularity: 55
+upstream: https://litestar.dev/
+docs: https://docs.litestar.dev/
+app_type: asgi
+server: uvicorn
+python_min: "3.9"
+pip_requirements:
+  - litestar==2.24.0
+  - "uvicorn[standard]==0.51.0"
+scaffold:
+  kind: template
+entrypoint_template: app:app
+needs_db: none

--- a/install/py-frameworks/litestar/template/app.py
+++ b/install/py-frameworks/litestar/template/app.py
@@ -1,0 +1,9 @@
+from litestar import Litestar, get
+
+
+@get("/")
+async def index() -> str:
+    return "Hello from Litestar on Jabali."
+
+
+app = Litestar([index])

--- a/install/py-frameworks/quart/framework.yaml
+++ b/install/py-frameworks/quart/framework.yaml
@@ -1,0 +1,18 @@
+slug: quart
+name: Quart
+version: "0.20"
+description: An async, Flask-compatible ASGI framework — the same API as Flask with async/await — served by uvicorn.
+tags: [asgi, async, flask-compatible]
+popularity: 45
+upstream: https://quart.palletsprojects.com/
+docs: https://quart.palletsprojects.com/
+app_type: asgi
+server: uvicorn
+python_min: "3.9"
+pip_requirements:
+  - quart==0.20.0
+  - "uvicorn[standard]==0.51.0"
+scaffold:
+  kind: template
+entrypoint_template: main:app
+needs_db: none

--- a/install/py-frameworks/quart/template/main.py
+++ b/install/py-frameworks/quart/template/main.py
@@ -1,0 +1,8 @@
+from quart import Quart
+
+app = Quart(__name__)
+
+
+@app.route("/")
+async def index():
+    return "Hello from Quart on Jabali."

--- a/install/py-frameworks/starlette/framework.yaml
+++ b/install/py-frameworks/starlette/framework.yaml
@@ -1,0 +1,18 @@
+slug: starlette
+name: Starlette
+version: "1.3"
+description: A lightweight ASGI framework and toolkit — the async foundation under FastAPI — with a single-file starter served by uvicorn.
+tags: [asgi, async, micro]
+popularity: 60
+upstream: https://www.starlette.io/
+docs: https://www.starlette.io/
+app_type: asgi
+server: uvicorn
+python_min: "3.9"
+pip_requirements:
+  - starlette==1.3.1
+  - "uvicorn[standard]==0.51.0"
+scaffold:
+  kind: template
+entrypoint_template: main:app
+needs_db: none

--- a/install/py-frameworks/starlette/template/main.py
+++ b/install/py-frameworks/starlette/template/main.py
@@ -1,0 +1,10 @@
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+
+async def index(request):
+    return PlainTextResponse("Hello from Starlette on Jabali.")
+
+
+app = Starlette(routes=[Route("/", index)])


### PR DESCRIPTION
Extends the JAB-164 Python framework marketplace with 5 single-file starters, same template pattern as flask/fastapi.

| slug | type | server | pin |
|------|------|--------|-----|
| starlette | asgi | uvicorn | starlette==1.3.1 |
| litestar | asgi | uvicorn | litestar==2.24.0 |
| quart | asgi | uvicorn | quart==0.20.0 |
| dash | wsgi | gunicorn | dash==4.4.0 |
| bottle | wsgi | gunicorn | bottle==0.13.4 |

Pins are the versions that actually resolve + serve on the host Python (probed on testserver py3.12), not doc guesses. Each starter served HTTP 200 under its server; the full `create --framework` -> reconciler-scaffold -> serve pipeline was run for dash (200 through nginx) and litestar (200 on loopback). `python-app frameworks` lists all 8, popularity-ordered.

**Known caveat**: an ASGI framework mounted at a sub-path base_uri (e.g. /lite) can 404 because `uvicorn --root-path` is advisory and the framework may not strip it before routing; root ("/") mounts serve fine. Threading root_path per framework is a separate base_uri concern that also affects the existing entries.

**Deferred**: Wagtail + Channels — Django-family with settings layouts that differ from the plain `config/settings.py` the scaffold hardener patches, so they need the hardening path generalized first (own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)