### PR TITLE
feat(python-apps): framework marketplace — API endpoint + one-click install UI (JAB-164)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -516,6 +516,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		deps.DockerApps = dockerAppRepo
 		deps.PythonApps = pythonAppRepo
 		deps.DockerCatalog = dockerCatalog
+		deps.PyFrameworks = pyCatalog
 		deps.LimitOverrides = limitOverridesRepo
 
 		// M18: resolve the /home mount once at startup. Passed to every

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1407,6 +1407,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: "[{ version, path }]" } }
 
+  /python-apps/frameworks:
+    get:
+      tags: [Python Apps]
+      summary: Framework marketplace catalog (one-click installs)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: "{ frameworks: [{ slug, name, version, description, tags, app_type, server, python_min, needs_db }] }" } }
+
   /python-apps/{id}:
     get:
       tags: [Python Apps]

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -14,6 +14,7 @@ import (
 	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -27,6 +28,9 @@ type PythonAppHandlerConfig struct {
 	Settings   repository.ServerSettingsRepository
 	Agent      agent.AgentInterface
 	Reconciler interface{ Schedule(id string) }
+	// Catalog is the JAB-164 framework marketplace (optional). Drives
+	// GET /frameworks and the framework-driven create path.
+	Catalog *pyframeworks.Catalog
 }
 
 type pythonAppHandler struct{ cfg PythonAppHandlerConfig }
@@ -39,6 +43,7 @@ func RegisterPythonAppRoutes(g *gin.RouterGroup, cfg PythonAppHandlerConfig) {
 	grp.Use(h.requireEnabled)
 	grp.GET("", h.list)
 	grp.GET("/versions", h.versions)
+	grp.GET("/frameworks", h.frameworks)
 	grp.POST("", h.create)
 	grp.GET("/:id", h.get)
 	grp.DELETE("/:id", h.delete)
@@ -126,9 +131,12 @@ type createPythonAppRequest struct {
 	PythonVersion string            `json:"python_version" binding:"required"`
 	AppRoot       string            `json:"app_root" binding:"required"`
 	AppType       string            `json:"app_type"`
-	Entrypoint    string            `json:"entrypoint" binding:"required"`
+	Entrypoint    string            `json:"entrypoint"` // required unless Framework is set
 	BaseURI       string            `json:"base_uri"`
 	Env           map[string]string `json:"env,omitempty"`
+	// Framework, when set, is a marketplace slug (JAB-164). It derives
+	// app_type + entrypoint from the catalog and drives the one-shot scaffold.
+	Framework string `json:"framework,omitempty"`
 }
 
 func (h *pythonAppHandler) create(c *gin.Context) {
@@ -141,6 +149,28 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
 		return
+	}
+	// JAB-164: a framework install derives app_type + entrypoint from the
+	// catalog entry and carries the static split for the nginx alias.
+	var fwStaticURL, fwStaticRoot string
+	if req.Framework != "" {
+		if h.cfg.Catalog == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "framework_catalog_unavailable"})
+			return
+		}
+		fe, ok := h.cfg.Catalog.Get(req.Framework)
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown_framework", "detail": req.Framework})
+			return
+		}
+		spec, serr := fe.ResolveCreate()
+		if serr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "resolve_framework", "detail": serr.Error()})
+			return
+		}
+		req.AppType = spec.AppType
+		req.Entrypoint = spec.Entrypoint
+		fwStaticURL, fwStaticRoot = spec.StaticURL, spec.StaticRoot
 	}
 	if req.AppType == "" {
 		req.AppType = "wsgi"
@@ -237,6 +267,7 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		Entrypoint:    req.Entrypoint,
 		BaseURI:       req.BaseURI,
 		LoopbackPort:  &port,
+		Framework:     req.Framework,
 		Status:        models.PythonAppStatusPending,
 	}
 	if err := h.cfg.Apps.Create(ctx, app); err != nil {
@@ -251,8 +282,8 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		_ = h.cfg.Apps.ReplaceEnv(ctx, app.ID, envMapToRows(req.Env))
 	}
 
-	// Attach the nginx proxy to the domain (reuses the proxy_pass rule path).
-	h.attachProxyRule(ctx, domain, app)
+	// Attach the nginx proxy (+ framework static_alias) to the domain.
+	h.attachProxyRule(ctx, domain, app, fwStaticURL, fwStaticRoot)
 	if h.cfg.Reconciler != nil {
 		h.cfg.Reconciler.Schedule(domain.ID)
 	}
@@ -339,25 +370,60 @@ func (h *pythonAppHandler) putEnv(c *gin.Context) {
 
 // attachProxyRule appends a proxy_pass nginx rule (base_uri -> loopback port)
 // to the domain so the existing reconciler renders the vhost.
-func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp) {
-	target := proxyTargetFor(app)
-	ws := true
-	rule := models.NginxRule{Type: "proxy_pass", Path: app.BaseURI, Target: target, Websocket: &ws}
+func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp, staticURL, staticRoot string) {
 	rules := append(models.NginxRules{}, domain.NginxRules...)
-	// Replace any existing rule for the same path, else append.
-	replaced := false
-	for i := range rules {
-		if rules[i].Type == "proxy_pass" && rules[i].Path == app.BaseURI {
-			rules[i] = rule
-			replaced = true
-			break
+	upsert := func(rule models.NginxRule) {
+		for i := range rules {
+			if rules[i].Type == rule.Type && rules[i].Path == rule.Path {
+				rules[i] = rule
+				return
+			}
 		}
-	}
-	if !replaced {
 		rules = append(rules, rule)
+	}
+	ws := true
+	upsert(models.NginxRule{Type: "proxy_pass", Path: app.BaseURI, Target: proxyTargetFor(app), Websocket: &ws})
+	// Framework static split (Django STATIC_ROOT): serve <base><static_url> from
+	// <app_root>/<static_root>. Django prefixes STATIC_URL with SCRIPT_NAME
+	// (=base_uri), so the location is base_uri + static_url.
+	if staticURL != "" && staticRoot != "" {
+		loc := strings.TrimSuffix(app.BaseURI, "/") + staticURL
+		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(staticRoot, "/") + "/"
+		upsert(models.NginxRule{Type: "static_alias", Path: loc, Target: alias})
 	}
 	domain.NginxRules = rules
 	_ = h.cfg.Domains.Update(ctx, domain)
+}
+
+// frameworkDTO is the catalog projection the UI needs — no template bytes, and
+// snake_case keys consistent with the rest of the API.
+type frameworkDTO struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	Version     string   `json:"version"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Docs        string   `json:"docs,omitempty"`
+	AppType     string   `json:"app_type"`
+	Server      string   `json:"server"`
+	PythonMin   string   `json:"python_min,omitempty"`
+	NeedsDB     string   `json:"needs_db,omitempty"`
+}
+
+// frameworks lists the JAB-164 marketplace entries for the Catalog tab.
+func (h *pythonAppHandler) frameworks(c *gin.Context) {
+	out := []frameworkDTO{}
+	if h.cfg.Catalog != nil {
+		for _, e := range h.cfg.Catalog.All() {
+			out = append(out, frameworkDTO{
+				Slug: e.Slug, Name: e.Name, Version: e.Version, Description: e.Description,
+				Tags: e.Tags, Icon: e.Icon, Docs: e.Docs, AppType: e.AppType,
+				Server: e.Server, PythonMin: e.PythonMin, NeedsDB: e.NeedsDB,
+			})
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"frameworks": out})
 }
 
 func (h *pythonAppHandler) detachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp) {

--- a/panel-api/internal/api/python_apps_framework_test.go
+++ b/panel-api/internal/api/python_apps_framework_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
+)
+
+func loadTestCatalog(t *testing.T) *pyframeworks.Catalog {
+	t.Helper()
+	cat, errs := pyframeworks.LoadDir("../../../install/py-frameworks")
+	if len(errs) != 0 {
+		t.Fatalf("catalog load errors: %v", errs)
+	}
+	return cat
+}
+
+// TestFrameworksEndpoint returns the catalog as a clean snake_case DTO with no
+// template bytes.
+func TestFrameworksEndpoint(t *testing.T) {
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Catalog: loadTestCatalog(t)}}
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/python-apps/frameworks", nil)
+	h.frameworks(c)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "template_files") || strings.Contains(w.Body.String(), "TemplateFiles") {
+		t.Error("frameworks response must not ship template bytes")
+	}
+	var body struct {
+		Frameworks []struct {
+			Slug    string `json:"slug"`
+			AppType string `json:"app_type"`
+			Server  string `json:"server"`
+		} `json:"frameworks"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	seen := map[string]string{}
+	for _, f := range body.Frameworks {
+		seen[f.Slug] = f.AppType
+	}
+	if seen["django"] != "wsgi" || seen["fastapi"] != "asgi" {
+		t.Errorf("catalog DTO wrong: %v", seen)
+	}
+}
+
+// TestCreate_UnknownFramework 400s before any provisioning.
+func TestCreate_UnknownFramework(t *testing.T) {
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Catalog: loadTestCatalog(t)}}
+	c, w := createCtx(t, map[string]any{
+		"domain_id": "dom1", "name": "app", "python_version": "3.12",
+		"app_root": "domains/x/app", "base_uri": "/", "framework": "nope",
+	})
+	h.create(c)
+	if w.Code != 400 {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Error != "unknown_framework" {
+		t.Errorf("error = %q, want unknown_framework", body.Error)
+	}
+}
+
+// TestCreate_FrameworkDerivesEntrypoint proves a framework install needs no
+// entrypoint in the body: flask derives app:app, so the request gets PAST the
+// entrypoint validation (and here reaches the nil domain repo, recovered).
+func TestCreate_FrameworkDerivesEntrypoint(t *testing.T) {
+	ag := agent.NewMockClient()
+	ag.On("app.python.versions", map[string]any{"versions": []string{"3.12"}, "default": "3.12"})
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Agent: ag, Catalog: loadTestCatalog(t)}}
+	c, w := createCtx(t, map[string]any{
+		"domain_id": "dom1", "name": "app", "python_version": "3.12",
+		"app_root": "domains/x/app", "base_uri": "/", "framework": "flask",
+		// no entrypoint / app_type — must be derived from the catalog
+	})
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+	defer func() { _ = recover() }() // nil Domains repo panics after the framework resolve
+	h.create(c)
+	if w.Code == 400 {
+		var body struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(w.Body.Bytes(), &body)
+		if body.Error == "invalid_entrypoint" || body.Error == "invalid_app_type" {
+			t.Errorf("framework install must derive entrypoint/app_type, got %q", body.Error)
+		}
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -22,6 +22,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sso"
@@ -104,6 +105,7 @@ type Deps struct {
 	DockerApps     repository.DockerAppRepository
 	PythonApps     repository.PythonAppRepository
 	DockerCatalog  *dockerapp.Catalog
+	PyFrameworks   *pyframeworks.Catalog
 	SSHKeys        repository.SSHKeyRepository
 	LimitOverrides repository.UserLimitOverrideRepository
 	// M6.5 email feature repositories. Autoresponders/Forwarders/MailboxShares
@@ -1193,6 +1195,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Settings:   deps.ServerSettings,
 				Agent:      deps.Agent,
 				Reconciler: deps.Reconciler,
+				Catalog:    deps.PyFrameworks,
 			})
 		}
 

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -4,12 +4,14 @@
 import {
   App,
   Button,
+  Card,
   Form,
   Input,
   Modal,
   Select,
   Space,
   Table,
+  Tabs,
   Tag,
   Tooltip,
   Typography,
@@ -21,12 +23,13 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
-import type { CreatePythonAppInput, PythonApp } from "./usePythonApps";
+import type { CreatePythonAppInput, Framework, PythonApp } from "./usePythonApps";
 import {
   fetchPythonAppLogs,
   useControlPythonApp,
   useCreatePythonApp,
   useDeletePythonApp,
+  useFrameworks,
   usePythonApps,
   usePythonVersions,
 } from "./usePythonApps";
@@ -71,8 +74,17 @@ export function PythonAppsPage() {
     return m;
   }, [domains.data]);
 
+  const frameworks = useFrameworks();
   const [createOpen, setCreateOpen] = useState(false);
+  // When set, the create modal is a framework install: app_type + entrypoint
+  // are derived from the catalog entry, so those fields are hidden (JAB-164).
+  const [installFw, setInstallFw] = useState<Framework | null>(null);
   const [form] = Form.useForm<CreatePythonAppInput>();
+  const openCreate = (fw?: Framework) => {
+    form.resetFields();
+    setInstallFw(fw ?? null);
+    setCreateOpen(true);
+  };
   // When the create dialog opens, default the Python version to the newest
   // interpreter actually installed on this host.
   useEffect(() => {
@@ -90,8 +102,16 @@ export function PythonAppsPage() {
   const submit = async () => {
     const values = await form.validateFields();
     try {
-      await create.mutateAsync({ ...values, base_uri: values.base_uri || "/" });
-      message.success("App created — building…");
+      await create.mutateAsync({
+        ...values,
+        base_uri: values.base_uri || "/",
+        // Framework install: send the slug; the server derives app_type +
+        // entrypoint and scaffolds the starter.
+        ...(installFw ? { framework: installFw.slug } : {}),
+      });
+      message.success(
+        installFw ? `Installing ${installFw.name}…` : "App created — building…",
+      );
       setCreateOpen(false);
       form.resetFields();
     } catch (e) {
@@ -126,12 +146,19 @@ export function PythonAppsPage() {
         <Typography.Title level={3} style={{ margin: 0 }}>
           Python Apps
         </Typography.Title>
-        <Button type="primary" onClick={() => setCreateOpen(true)}>
+        <Button type="primary" onClick={() => openCreate()}>
           Create app
         </Button>
       </Space>
 
-      <Table<PythonApp>
+      <Tabs
+        defaultActiveKey="installed"
+        items={[
+          {
+            key: "installed",
+            label: "Installed",
+            children: (
+              <Table<PythonApp>
         rowKey="id"
         dataSource={apps.data ?? []}
         loading={apps.isLoading}
@@ -193,10 +220,62 @@ export function PythonAppsPage() {
             />
           )}
         />
-      </Table>
+              </Table>
+            ),
+          },
+          {
+            key: "catalog",
+            label: "Catalog",
+            children: (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
+                  gap: 16,
+                }}
+              >
+                {(frameworks.data ?? []).map((fw) => (
+                  <Card
+                    key={fw.slug}
+                    size="small"
+                    title={fw.name}
+                    extra={<Tag color="blue">{fw.app_type.toUpperCase()}</Tag>}
+                    actions={[
+                      <Button
+                        key="install"
+                        type="link"
+                        onClick={() => openCreate(fw)}
+                      >
+                        Install
+                      </Button>,
+                    ]}
+                  >
+                    <Typography.Paragraph
+                      type="secondary"
+                      style={{ minHeight: 44, marginBottom: 8 }}
+                    >
+                      {fw.description}
+                    </Typography.Paragraph>
+                    <Space size={4} wrap>
+                      {(fw.tags ?? []).map((t) => (
+                        <Tag key={t}>{t}</Tag>
+                      ))}
+                    </Space>
+                  </Card>
+                ))}
+                {frameworks.data && frameworks.data.length === 0 ? (
+                  <Typography.Text type="secondary">
+                    No frameworks available.
+                  </Typography.Text>
+                ) : null}
+              </div>
+            ),
+          },
+        ]}
+      />
 
       <Modal
-        title="Create Python app"
+        title={installFw ? `Install ${installFw.name}` : "Create Python app"}
         open={createOpen}
         onCancel={() => setCreateOpen(false)}
         onOk={() => void submit()}
@@ -226,24 +305,38 @@ export function PythonAppsPage() {
                 notFoundContent="No Python runtime installed on this server"
               />
             </Form.Item>
-            <Form.Item name="app_type" label="Type" rules={[{ required: true }]}>
-              <Select
-                style={{ width: 160 }}
-                options={[
-                  { value: "wsgi", label: "WSGI (gunicorn)" },
-                  { value: "asgi", label: "ASGI (uvicorn)" },
-                ]}
-              />
-            </Form.Item>
+            {!installFw && (
+              <Form.Item name="app_type" label="Type" rules={[{ required: true }]}>
+                <Select
+                  style={{ width: 160 }}
+                  options={[
+                    { value: "wsgi", label: "WSGI (gunicorn)" },
+                    { value: "asgi", label: "ASGI (uvicorn)" },
+                  ]}
+                />
+              </Form.Item>
+            )}
           </Space>
-          <Form.Item
-            name="entrypoint"
-            label="Entrypoint"
-            tooltip="module:callable, e.g. myapp.wsgi:application or main:app"
-            rules={[{ required: true }, { pattern: /^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$/, message: "Expected module:callable" }]}
-          >
-            <Input placeholder="main:app" />
-          </Form.Item>
+          {installFw ? (
+            <Typography.Paragraph type="secondary">
+              {installFw.name} ({installFw.app_type.toUpperCase()} via{" "}
+              {installFw.server}) will be scaffolded into the app directory —
+              starter project, pinned dependencies
+              {installFw.needs_db && installFw.needs_db !== "none"
+                ? `, and a ${installFw.needs_db} database`
+                : ""}
+              .
+            </Typography.Paragraph>
+          ) : (
+            <Form.Item
+              name="entrypoint"
+              label="Entrypoint"
+              tooltip="module:callable, e.g. myapp.wsgi:application or main:app"
+              rules={[{ required: true }, { pattern: /^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$/, message: "Expected module:callable" }]}
+            >
+              <Input placeholder="main:app" />
+            </Form.Item>
+          )}
           <Form.Item name="app_root" label="App directory" tooltip="Path under your home, e.g. domains/example.com/app" rules={[{ required: true }]}>
             <Input placeholder="domains/example.com/app" />
           </Form.Item>

--- a/panel-ui/src/shells/user/python-apps/usePythonApps.ts
+++ b/panel-ui/src/shells/user/python-apps/usePythonApps.ts
@@ -24,11 +24,41 @@ export type CreatePythonAppInput = {
   name: string;
   python_version: string;
   app_root: string;
-  app_type: "wsgi" | "asgi";
-  entrypoint: string;
+  // app_type + entrypoint are derived from the catalog when `framework` is set,
+  // so they are optional on a framework install (JAB-164).
+  app_type?: "wsgi" | "asgi";
+  entrypoint?: string;
   base_uri: string;
   env?: Record<string, string>;
+  framework?: string;
 };
+
+// Framework is a marketplace catalog entry (JAB-164), from GET
+// /python-apps/frameworks.
+export type Framework = {
+  slug: string;
+  name: string;
+  version: string;
+  description: string;
+  tags?: string[];
+  app_type: "wsgi" | "asgi";
+  server: string;
+  python_min?: string;
+  needs_db?: string;
+  docs?: string;
+};
+
+export function useFrameworks() {
+  return useQuery({
+    queryKey: ["python-app-frameworks"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ frameworks: Framework[] }>(
+        "/python-apps/frameworks",
+      );
+      return data.frameworks ?? [];
+    },
+  });
+}
 
 const KEY = ["python-apps"];
 


### PR DESCRIPTION
Completes the JAB-164 UI slice: the Catalog tab + its backing API, so a Python app can be installed from a framework in a couple of clicks.

## Backend
- `GET /python-apps/frameworks` returns the catalog as a clean snake_case DTO (no template bytes). Catalog wired through Deps -> handler.
- `POST /python-apps` accepts `framework`: derives app_type + entrypoint from the entry (entrypoint no longer required when a framework is given), stamps it on the row (reconciler runs the one-shot scaffold), and attaches the static_alias nginx rule alongside proxy_pass — parity with the CLI. Keeps the GH#357 installed-version gate.
- openapi.yaml documents the endpoint (coverage ratchet stays 100%).

## UI
- Python Apps page is now two tabs: **Installed** (existing table) and **Catalog** (card grid of marketplace entries).
- Each card's **Install** opens the create dialog pre-bound to that framework: app_type + entrypoint hidden (derived), a note explains what gets scaffolded; operator fills name / domain / mount path / python / app directory.
- Manual **Create app** still shows the full form.

## Tests / build
- API: frameworks endpoint returns the DTO without template bytes; unknown framework 400s; a flask install with no entrypoint derives app:app.
- panel-ui: `tsc -b` + `vite build` clean.

Depends on the catalog + create-flow already on main (#509/#510). Complements the 5 new entries in #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)