### PR TITLE
fix(ui): catalog cards to full-width masonry, not fixed small cards (JAB-167)

### DIFF
--- a/panel-ui/src/components/catalog/CatalogCard.tsx
+++ b/panel-ui/src/components/catalog/CatalogCard.tsx
@@ -1,19 +1,20 @@
-// Shared marketplace catalog card (JAB-167). One card design for all three app
-// marketplaces (Docker Apps, Python Apps, PHP Applications): icon + name + a
-// right-slot meta badge (version / WSGI-ASGI / Database — whatever the type
-// uses, same slot + style), a 3-line description, and one consistent filled
-// Install button. Type-specific bits (icon source, meta content, install
-// handler) come in as props.
-import { Button, Card, Space, Typography } from "antd";
+// Shared marketplace catalog card (JAB-167). One card design for all app
+// marketplaces (Docker Apps, Python Apps, PHP Applications), modelled on the
+// admin Docker-Apps catalog: a full-width masonry card (fills its column), an
+// avatar + name + inline meta badge (version / WSGI-ASGI / Database), the full
+// description (not truncated), and a single blue "Install" link. Type-specific
+// bits (icon, meta content, install handler) come in as props. Pair with
+// <CatalogGrid> for the 3-up masonry layout.
+import { Button, Card, Space } from "antd";
 import type { ReactNode } from "react";
 
 export interface CatalogCardProps {
   name: string;
-  /** Icon as an image URL (Docker/Python) … */
+  /** Icon as an image URL (Docker) — wrapped in the default avatar tile … */
   iconUrl?: string;
-  /** … or an arbitrary node (PHP CmsIcon). iconNode wins when both are set. */
+  /** … or a pre-styled node (Python's brand tile, PHP's CmsIcon). iconNode wins. */
   iconNode?: ReactNode;
-  /** Right-slot meta under the name: version string, WSGI/ASGI badge, etc. */
+  /** Inline badge next to the name: a version Tag, WSGI/ASGI Tag, Database Tag. */
   meta?: ReactNode;
   description?: string;
   installLabel?: string;
@@ -33,43 +34,57 @@ export function CatalogCard({
   installing,
   disabled,
 }: CatalogCardProps) {
+  const avatar =
+    iconNode ??
+    (iconUrl ? (
+      <div
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: 10,
+          background: "rgba(0, 0, 0, 0.03)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <img src={iconUrl} alt="" width={28} height={28} />
+      </div>
+    ) : null);
+
   return (
-    <Card
-      size="small"
-      style={{ width: 240 }}
-      styles={{ body: { display: "flex", flexDirection: "column", gap: 8 } }}
-    >
-      <Space align="start">
-        {iconNode ?? (iconUrl ? <img src={iconUrl} alt="" width={32} height={32} /> : null)}
-        <div>
-          <Typography.Text strong>{name}</Typography.Text>
-          {meta ? (
-            <>
-              <br />
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                {meta}
-              </Typography.Text>
-            </>
-          ) : null}
-        </div>
-      </Space>
-      <Typography.Paragraph
-        type="secondary"
-        ellipsis={{ rows: 3 }}
-        style={{ fontSize: 12, margin: 0, minHeight: 48 }}
+    <div style={{ breakInside: "avoid", marginBottom: 16, display: "inline-block", width: "100%" }}>
+      <Card
+        hoverable={!disabled}
+        onClick={disabled ? undefined : onInstall}
+        styles={{ body: { padding: 16 } }}
+        actions={[
+          <Button
+            type="link"
+            key="install"
+            loading={installing}
+            disabled={disabled}
+            onClick={(e) => {
+              e.stopPropagation();
+              onInstall();
+            }}
+          >
+            {installLabel}
+          </Button>,
+        ]}
       >
-        {description}
-      </Typography.Paragraph>
-      <Button
-        type="primary"
-        size="small"
-        block
-        loading={installing}
-        disabled={disabled}
-        onClick={onInstall}
-      >
-        {installLabel}
-      </Button>
-    </Card>
+        <Card.Meta
+          avatar={avatar}
+          title={
+            <Space size={6} wrap>
+              <span>{name}</span>
+              {meta}
+            </Space>
+          }
+          description={<div style={{ whiteSpace: "pre-line" }}>{description}</div>}
+        />
+      </Card>
+    </div>
   );
 }

--- a/panel-ui/src/components/catalog/CatalogGrid.tsx
+++ b/panel-ui/src/components/catalog/CatalogGrid.tsx
@@ -1,0 +1,9 @@
+// Shared catalog masonry grid (JAB-167). As many >=320px columns as the
+// viewport fits (1 mobile, 2 tablet, 3+ desktop) with no media queries — the
+// admin Docker-Apps layout, now the one design for every marketplace. Each
+// CatalogCard wraps itself in a break-inside-avoid item.
+import type { ReactNode } from "react";
+
+export function CatalogGrid({ children }: { children: ReactNode }) {
+  return <div style={{ columns: "320px", columnGap: 16 }}>{children}</div>;
+}

--- a/panel-ui/src/components/catalog/index.ts
+++ b/panel-ui/src/components/catalog/index.ts
@@ -2,5 +2,6 @@
 // Docker Apps, Python Apps, and PHP Applications catalogs.
 export { CatalogCard } from "./CatalogCard";
 export type { CatalogCardProps } from "./CatalogCard";
+export { CatalogGrid } from "./CatalogGrid";
 export { CategoryFilter } from "./CategoryFilter";
 export type { CategoryFilterProps } from "./CategoryFilter";

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -29,7 +29,7 @@ import { useOneQuery } from "../../../hooks/useQueries";
 import { useSetBreadcrumbs } from "../../../components/admin/BreadcrumbContext";
 import { ownerResourceCrumbs, ownerLabel } from "../../../components/admin/entityLinks";
 import { InstallDrawer } from "./InstallDrawer";
-import { CatalogCard, CategoryFilter } from "../../../components/catalog";
+import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
 import { LogsDrawer } from "./LogsDrawer";
 import { ExecDrawer } from "./ExecDrawer";
 import { BackupsDrawer } from "./BackupsDrawer";
@@ -408,18 +408,18 @@ export const AdminDockerAppsPage = () => {
                 selected={catalogTags}
                 onChange={setCatalogTags}
               />
-              <Space wrap size={[16, 16]}>
+              <CatalogGrid>
                 {visibleCatalog.map((e) => (
                   <CatalogCard
                     key={e.slug}
                     name={e.name}
                     iconUrl={`/api/v1/admin/docker-apps/catalog/${e.slug}/icon?theme=${mode}`}
-                    meta={`v${e.version}`}
+                    meta={<Tag style={{ marginInlineEnd: 0 }}>v{e.version}</Tag>}
                     description={e.description}
                     onInstall={() => setInstallEntry(e)}
                   />
                 ))}
-              </Space>
+              </CatalogGrid>
               </>
             ),
           },

--- a/panel-ui/src/shells/user/applications/CatalogTab.tsx
+++ b/panel-ui/src/shells/user/applications/CatalogTab.tsx
@@ -2,11 +2,11 @@
 // modelled on the admin Docker-Apps catalog: a masonry of cards, one per
 // registered app descriptor (GET /applications/registry). Clicking a card
 // opens the Install drawer pre-targeted to that app_type.
-import { Alert, Empty, Space, Spin, Tag } from "antd";
+import { Alert, Empty, Spin, Tag } from "antd";
 import { useMemo, useState } from "react";
 import { DatabaseOutlined } from "@icons";
 
-import { CatalogCard, CategoryFilter } from "../../../components/catalog";
+import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
 import { useAppRegistry } from "./appRegistry";
 import { CmsIcon } from "./CmsIcon";
 
@@ -68,12 +68,27 @@ export const CatalogTab = ({ onInstall }: Props) => {
           description="No applications match the selected tags"
         />
       ) : (
-        <Space wrap size={[16, 16]}>
+        <CatalogGrid>
           {visibleApps.map((app) => (
             <CatalogCard
               key={app.name}
               name={app.display_name}
-              iconNode={<CmsIcon appType={app.name} size={32} />}
+              iconNode={
+                <div
+                  style={{
+                    width: 44,
+                    height: 44,
+                    borderRadius: 10,
+                    background: "rgba(0, 0, 0, 0.03)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  <CmsIcon appType={app.name} size={28} />
+                </div>
+              }
               meta={
                 app.requires_db ? (
                   <Tag icon={<DatabaseOutlined />} style={{ marginInlineEnd: 0 }}>
@@ -85,7 +100,7 @@ export const CatalogTab = ({ onInstall }: Props) => {
               onInstall={() => onInstall(app.name)}
             />
           ))}
-        </Space>
+        </CatalogGrid>
       )}
     </>
   );

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -5,7 +5,7 @@
 // backend 403s docker_tenant_not_enabled).
 import { useMemo, useState } from "react";
 import { RowActions } from "../../../components/RowActions";
-import { CatalogCard, CategoryFilter } from "../../../components/catalog";
+import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
 import {
   Alert,
   Avatar,
@@ -375,13 +375,13 @@ export const UserDockerAppsPage = () => {
                   selected={catalogTags}
                   onChange={setCatalogTags}
                 />
-                <Space wrap size={[16, 16]}>
+                <CatalogGrid>
                   {visibleCatalog.map((e) => (
                     <CatalogCard
                       key={e.slug}
                       name={e.name}
                       iconUrl={catalogIconUrl(e.slug)}
-                      meta={`v${e.version}`}
+                      meta={<Tag style={{ marginInlineEnd: 0 }}>v{e.version}</Tag>}
                       description={e.description}
                       onInstall={() => setInstallFor(e)}
                     />
@@ -389,7 +389,7 @@ export const UserDockerAppsPage = () => {
                   {catalog.data?.length === 0 && (
                     <Typography.Text type="secondary">No apps available to install.</Typography.Text>
                   )}
-                </Space>
+                </CatalogGrid>
               </>
             ),
           },

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -22,7 +22,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
-import { CatalogCard, CategoryFilter } from "../../../components/catalog";
+import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
 import type { CreatePythonAppInput, Framework, PythonApp } from "./usePythonApps";
 import {
   fetchPythonAppLogs,
@@ -246,34 +246,35 @@ export function PythonAppsPage() {
                   selected={catTags}
                   onChange={setCatTags}
                 />
-                <Space wrap size={[16, 16]}>
+                <CatalogGrid>
                   {visibleFrameworks.map((fw) => (
                     <CatalogCard
                       key={fw.slug}
                       name={fw.name}
                       iconNode={
-                        fw.icon ? (
-                          <span
-                            style={{
-                              display: "inline-flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              width: 32,
-                              height: 32,
-                              borderRadius: 6,
-                              background: "#1f1f1f",
-                              padding: 4,
-                            }}
-                          >
+                        <div
+                          style={{
+                            width: 44,
+                            height: 44,
+                            borderRadius: 10,
+                            background: "#1f1f1f",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            flexShrink: 0,
+                            padding: 8,
+                          }}
+                        >
+                          {fw.icon ? (
                             <img
                               src={fw.icon}
                               alt=""
                               style={{ maxWidth: "100%", maxHeight: "100%" }}
                             />
-                          </span>
-                        ) : undefined
+                          ) : null}
+                        </div>
                       }
-                      meta={fw.app_type.toUpperCase()}
+                      meta={<Tag color="blue">{fw.app_type.toUpperCase()}</Tag>}
                       description={fw.description}
                       onInstall={() => openCreate(fw)}
                     />
@@ -283,7 +284,7 @@ export function PythonAppsPage() {
                       No frameworks available.
                     </Typography.Text>
                   ) : null}
-                </Space>
+                </CatalogGrid>
               </>
             ),
           },


### PR DESCRIPTION
Corrects the JAB-167 catalog design. #519 modelled the small fixed-width (240px) user-Docker card + filled Install button, and regressed the **admin** Docker-Apps catalog — which was already the intended target — into that small-card look.

Target (admin Docker-Apps catalog): full-width **3-up masonry**, full description, an inline version/badge next to the name, and a single blue **Install link**.

- New `CatalogGrid` (`columns: 320px` masonry — 1/2/3+ columns, no media queries).
- `CatalogCard` reworked to `Card.Meta` (avatar tile + name + inline meta badge), untruncated description, `type="link"` Install; each card is a full-width break-inside-avoid masonry item.
- All four catalogs (user Python, user PHP, user Docker, admin Docker) switched from the fixed-width `Space`-wrap grid to `<CatalogGrid>`. Meta is an inline Tag (version / WSGI-ASGI / Database).

tsc + vite build clean; the 4 shared-component tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)