### PR TITLE
fix(backup,apparmor): backup download under enforce — symlink path + shell-free tar|zstd (GH #462)

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -116,7 +116,12 @@ profile jabali-panel flags=(attach_disconnected) {
   # download streams the materialized backup as a tar[.zst] (GH #462, backups.go
   # streamBackupArtifact) — without an exec rule the download fails
   # "fork/exec /usr/bin/tar: permission denied" under enforce.
+  # zstd (both merged-usr paths). Backup download no longer runs `tar -I zstd`
+  # (that shells out via /bin/sh to run the filter, which this profile does NOT
+  # grant — GH #462 round 3); the panel now pipes `tar` -> `zstd` itself, so both
+  # are direct execs matched here.
   /usr/bin/zstd               rix,
+  /bin/zstd                   rix,
   /usr/bin/goaccess           rix,
   /usr/bin/tar                rix,
   /bin/tar                    rix,
@@ -224,8 +229,14 @@ profile jabali-panel flags=(attach_disconnected) {
   # under /var/lib/jabali-backups/downloads/<job>/ (backups.go streamBackupArtifact).
   # Read-only + downloads/ only — the agent writes + cleans it, and the restic
   # repo (/var/lib/jabali-backups/repo, 0600 root:root) must stay off-limits.
+  # /var/lib/jabali-backups is a SYMLINK to /var/lib/jabali/backups; AppArmor
+  # matches the RESOLVED path, so the rule MUST use the real target (round 3 of
+  # GH #462: the symlink-path rules never matched → every read denied in
+  # enforce). Both spellings kept so it works whether or not the box symlinks.
   /var/lib/jabali-backups/downloads/     r,
   /var/lib/jabali-backups/downloads/**   r,
+  /var/lib/jabali/backups/downloads/     r,
+  /var/lib/jabali/backups/downloads/**   r,
   /var/log/jabali-panel/       rw,
   /var/log/jabali-panel/**     rwk,
 

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -707,32 +707,56 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 
 	// GH #462: choose the compressor by what's actually installed. A box that
 	// lacks the zstd binary (installed before zstd became a dependency, then
-	// only ever `jabali update`d) fails `tar -I zstd` and hands the browser a
-	// 0-byte file. Fall back to an uncompressed tar so the download always works.
+	// only ever `jabali update`d) falls back to an uncompressed tar so the
+	// download always works.
 	useZstd := false
 	if _, lerr := exec.LookPath("zstd"); lerr == nil {
 		useZstd = true
 	}
-	tarArgs := []string{"-cf", "-"}
 	filename := job.ID + ".tar"
 	contentType := "application/x-tar"
+
+	// GH #462 round 3: build the archive as a Go pipeline (tar -> zstd), NOT
+	// `tar -I zstd` / `tar --zstd`. Those run the compressor through /bin/sh,
+	// which the panel's AppArmor profile deliberately does not grant (no shell),
+	// so under enforce the download died with "zstd: Cannot exec". Two direct
+	// execs stay on the profile's tar + zstd allowlist and never touch a shell.
+	tarCmd := exec.CommandContext(c.Request.Context(), "tar", "-cf", "-",
+		"-C", filepath.Dir(mat.Path), filepath.Base(mat.Path))
+	var tarErr, zstdErr bytes.Buffer
+	tarCmd.Stderr = &tarErr
+
+	streamCmd := tarCmd // the process whose stdout is streamed to the client
 	if useZstd {
-		tarArgs = []string{"-I", "zstd", "-cf", "-"}
 		filename = job.ID + ".tar.zst"
 		contentType = "application/zstd"
+		zstdCmd := exec.CommandContext(c.Request.Context(), "zstd", "-c", "-")
+		zstdCmd.Stderr = &zstdErr
+		tarOut, perr := tarCmd.StdoutPipe()
+		if perr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "tar_pipe", "detail": perr.Error()})
+			return
+		}
+		zstdCmd.Stdin = tarOut
+		streamCmd = zstdCmd
 	}
-	tarArgs = append(tarArgs, "-C", filepath.Dir(mat.Path), filepath.Base(mat.Path))
-	tarCmd := exec.CommandContext(c.Request.Context(), "tar", tarArgs...)
-	var tarErr bytes.Buffer
-	tarCmd.Stderr = &tarErr
-	stdout, perr := tarCmd.StdoutPipe()
+	stdout, perr := streamCmd.StdoutPipe()
 	if perr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "tar_pipe", "detail": perr.Error()})
 		return
 	}
+	// Start tar first so its stdout is flowing before zstd reads it.
 	if serr := tarCmd.Start(); serr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "tar_start", "detail": serr.Error()})
 		return
+	}
+	if useZstd {
+		if serr := streamCmd.Start(); serr != nil {
+			_ = tarCmd.Process.Kill()
+			_ = tarCmd.Wait()
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "zstd_start", "detail": serr.Error()})
+			return
+		}
 	}
 	// GH #462: read the first chunk BEFORE sending the download headers. If tar
 	// produces no output (missing binary, unreadable materialized path,
@@ -741,11 +765,15 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 	head := make([]byte, 64*1024)
 	n, rerr := io.ReadFull(stdout, head)
 	if n == 0 {
-		_ = tarCmd.Wait()
-		logErr("tar download produced no output", rerr, "job_id", job.ID, "stderr", strings.TrimSpace(tarErr.String()))
+		_ = streamCmd.Wait()
+		if useZstd {
+			_ = tarCmd.Wait()
+		}
+		detail := strings.TrimSpace(tarErr.String() + " " + zstdErr.String())
+		logErr("tar download produced no output", rerr, "job_id", job.ID, "stderr", detail)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"status": "error", "error": "archive_empty",
-			"detail": "could not build the download archive: " + strings.TrimSpace(tarErr.String()),
+			"detail": "could not build the download archive: " + detail,
 		})
 		return
 	}
@@ -757,8 +785,13 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 	if rerr == nil { // more than the first chunk remains
 		_, _ = io.Copy(c.Writer, stdout)
 	}
-	if werr := tarCmd.Wait(); werr != nil {
-		logErr("tar download", werr, "job_id", job.ID, "stderr", strings.TrimSpace(tarErr.String()))
+	if werr := streamCmd.Wait(); werr != nil {
+		logErr("archive download", werr, "job_id", job.ID, "stderr", strings.TrimSpace(tarErr.String()+" "+zstdErr.String()))
+	}
+	if useZstd {
+		if werr := tarCmd.Wait(); werr != nil {
+			logErr("archive download (tar)", werr, "job_id", job.ID, "stderr", strings.TrimSpace(tarErr.String()))
+		}
 	}
 }
 


### PR DESCRIPTION
Round 3 of #462. Reproduced both denials under **enforce** on a test box (earlier reproductions failed because the box ran a stale looser-loaded profile).

## Two real AppArmor denials
1. **Symlink path**: `/var/lib/jabali-backups` is a symlink to `/var/lib/jabali/backups`. AppArmor matches the **resolved** path, so `/var/lib/jabali-backups/downloads/**` never matched the real `/var/lib/jabali/backups/downloads/**` — every read (tar, even `cat`/`ls`) denied. Added the resolved-path rules (kept both spellings).
2. **Shell in the exec chain**: `tar -I zstd` / `tar --zstd` run the compressor via `/bin/sh`, which the profile deliberately does not grant. `aa-status` showed `jabali-panel//null-/usr/bin/dash//null-/usr/bin/zstd`. `streamBackupArtifact` now builds the archive as a Go pipeline `tar -cf -` -> `zstd -c` — two **direct** execs on the profile's tar+zstd allowlist, no shell. Uncompressed fallback unchanged.

## Verified under enforce (testserver)
`tar` reads the downloads dir (rc=0), `zstd` execs (rc=0); the reporter's `Cannot open downloads` + `zstd: Cannot exec` are gone. build + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)