### PR TITLE
fix(ui): Applications page uses plain Tabs like the other marketplaces (JAB-167)

### DIFF
--- a/panel-ui/src/components/catalog/CatalogCard.tsx
+++ b/panel-ui/src/components/catalog/CatalogCard.tsx
@@ -42,7 +42,7 @@ export function CatalogCard({
           width: 44,
           height: 44,
           borderRadius: 10,
-          background: "rgba(0, 0, 0, 0.03)",
+          background: "rgba(127, 127, 127, 0.12)",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",

--- a/panel-ui/src/shells/user/applications/CatalogTab.tsx
+++ b/panel-ui/src/shells/user/applications/CatalogTab.tsx
@@ -79,7 +79,7 @@ export const CatalogTab = ({ onInstall }: Props) => {
                     width: 44,
                     height: 44,
                     borderRadius: 10,
-                    background: "rgba(0, 0, 0, 0.03)",
+                    background: "rgba(127, 127, 127, 0.12)",
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -8,7 +8,7 @@ import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
 import {
   Button,
-  Card,
+  Tabs,
   Col,
   Empty,
   Row,
@@ -447,17 +447,17 @@ export const UserApplicationList = () => {
         onClose={() => setCacheSettingsFor(null)}
       />
 
-      {/* Card.tabList = tabs inside the card, matching the admin Users
-          reference layout (Gitea #524). */}
-      <Card
-        tabList={[
-          { key: "installed", tab: "Installed" },
-          { key: "catalog", tab: "Catalog" },
-        ]}
-        activeTabKey={activeTab}
-        onTabChange={setActiveTab}
-      >
-        {activeTab === "installed" && (
+      {/* JAB-167: plain <Tabs>, matching the Docker Apps + Python Apps
+          marketplaces (was a Card.tabList, which rendered a heavier card-header
+          tab bar unlike the rest and a flat card container in dark). */}
+      <Tabs
+        activeKey={activeTab}
+        onChange={setActiveTab}
+        items={[
+          {
+            key: "installed",
+            label: "Installed",
+            children: (
               <div>
                 {(() => {
                   const rows = tableQuery.items;
@@ -680,16 +680,22 @@ export const UserApplicationList = () => {
           />
         </SearchableTableStringQ>
               </div>
-        )}
-        {activeTab === "catalog" && (
+            ),
+          },
+          {
+            key: "catalog",
+            label: "Catalog",
+            children: (
               <CatalogTab
                 onInstall={(appType) => {
                   setPresetAppType(appType);
                   setInstallOpen(true);
                 }}
               />
-        )}
-      </Card>
+            ),
+          },
+        ]}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Follow-up to the marketplace unification. The Applications page still used a `Card.tabList` (card-header tabs) for Installed/Catalog, unlike the Docker Apps + Python Apps pages that use a plain `<Tabs>`. That made the tab bar inconsistent and wrapped the page in a Card whose surface reads flat/borderless in dark theme.

Switched to `<Tabs items={...}>` matching the others — consistent tab bar, and the catalog masonry cards now sit on the page background with their own card chrome (no flat outer Card).

tsc + vite build clean; applications + catalog tests pass.