### PR TITLE
fix(python-apps): resolve app_root under home, create it, reload catalog after sync

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4665,6 +4665,17 @@ build_backend() {
     _ok "synced py-framework catalog -> /usr/local/share/jabali/py-frameworks/"
   fi
 
+  # panel-api loads BOTH app catalogs (docker-apps + py-frameworks) into memory
+  # at startup. The syncs above run AFTER the buildSteps panel-api restart, so
+  # without a reload the panel keeps serving the pre-sync catalog — the Python
+  # marketplace showed only the 3 original frameworks + blank icons until a
+  # manual restart. Reload now that the catalog dirs are current (idempotent,
+  # ~2s; try-restart is a no-op if the unit isn't running yet).
+  if [[ -d /usr/local/share/jabali/py-frameworks || -d /usr/local/share/jabali/docker-apps ]]; then
+    systemctl try-restart jabali-panel 2>/dev/null || true
+    _ok "reloaded panel-api so the app catalogs pick up the sync"
+  fi
+
   # #406: bundle the jabali-cache WordPress plugin read-only into the
   # production path the agent installs FROM (wordpress.cache_set). Tenants
   # never supply plugin code; re-synced on every `jabali update`.

--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -128,8 +128,15 @@ func pythonAppApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("app_root validation failed: %v", err)}
 	}
-	if fi, err := os.Stat(appRoot); err != nil || !fi.IsDir() {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "app_root is not a directory"}
+	if fi, err := os.Stat(appRoot); err != nil {
+		// Fresh plain app: the dir doesn't exist yet and there is no framework
+		// scaffold to create it. Make it AS THE TENANT so the venv + code land
+		// tenant-owned, inside the scope-validated path under the owner's home.
+		if out, mkerr := runAsUser(ctx, p.Username, "mkdir", "-p", appRoot); mkerr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("create app_root: %v: %s", mkerr, out)}
+		}
+	} else if !fi.IsDir() {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "app_root exists but is not a directory"}
 	}
 
 	venv := filepath.Join(appRoot, "venv")

--- a/panel-api/cmd/server/python_app_create_cmd.go
+++ b/panel-api/cmd/server/python_app_create_cmd.go
@@ -10,6 +10,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // loadPyFrameworkCatalogCLI loads the JAB-164 framework catalog with the same
@@ -124,6 +126,24 @@ func newPythonAppCreateCmd() *cobra.Command {
 			}
 			if derr != nil || dom == nil {
 				return fmt.Errorf("domain not found (check --domain/--domain-id)")
+			}
+
+			// Resolve --app-root under the owner's home so a bare "test" (or a
+			// rooted "/test") lands at /home/<user>/test, not at the filesystem
+			// root where the tenant venv build fails "Permission denied".
+			owner, uerr := repository.NewUserRepository(sharedDB).FindByID(ctx, dom.UserID)
+			if uerr != nil || owner == nil || owner.Username == nil || *owner.Username == "" {
+				return fmt.Errorf("domain owner has no linux username")
+			}
+			home := "/home/" + *owner.Username
+			in := strings.TrimSpace(appRoot)
+			if in == home || strings.HasPrefix(in, home+"/") {
+				appRoot = filepath.Clean(in) // already an absolute path under home
+			} else {
+				appRoot = filepath.Join(home, strings.TrimPrefix(in, "/"))
+			}
+			if appRoot != home && !strings.HasPrefix(appRoot, home+"/") {
+				return fmt.Errorf("--app-root must be under the owner's home (%s)", home)
 			}
 
 			repo := pythonAppRepoFromDB()

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -216,6 +217,32 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 	if !claims.IsAdmin && domain.UserID != claims.UserID {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
+	}
+
+	// Resolve app_root under the OWNER's home. The "App directory" field is
+	// documented as a path under your home, so a bare "test" (or a rooted
+	// "/test") must land at /home/<user>/test — NOT at the filesystem root,
+	// where the tenant venv build failed with "Permission denied: '/test'". A
+	// leading slash is treated as home-relative; anything escaping the home is
+	// rejected up front instead of dying pending->failed at the venv step.
+	if h.cfg.Users != nil {
+		owner, oerr := h.cfg.Users.FindByID(ctx, domain.UserID)
+		if oerr != nil || owner == nil || owner.Username == nil || *owner.Username == "" {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "owner_no_username"})
+			return
+		}
+		home := "/home/" + *owner.Username
+		in := strings.TrimSpace(req.AppRoot)
+		if in == home || strings.HasPrefix(in, home+"/") {
+			req.AppRoot = filepath.Clean(in) // already an absolute path under home
+		} else {
+			// bare "test" or rooted "/test" -> treat as home-relative
+			req.AppRoot = filepath.Join(home, strings.TrimPrefix(in, "/"))
+		}
+		if req.AppRoot != home && !strings.HasPrefix(req.AppRoot, home+"/") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "app_root_outside_home", "detail": "app directory must be under your home"})
+			return
+		}
 	}
 
 	// Package entitlement + per-user quota (Gitea #491). Mirrors the tenant


### PR DESCRIPTION
Three reliability bugs from real use of the Python Apps marketplace:

1. **app_root escaped the home.** The App-directory field is documented as a path under your home, but a bare `test` (or rooted `/test`) was stored raw, so the tenant venv build tried `/test` at the filesystem root → `Permission denied: '/test'` → pending/failed with no logs. The create flow (API + CLI) now resolves app_root under the owner's home: an already-under-home absolute path is kept, everything else is treated as home-relative, and anything escaping the home is rejected up front.

2. **Fresh plain apps had no app_root dir.** A framework install's scaffold makes the dir via the venv, but a plain create went straight to `app.python.apply`, which required app_root to exist (`app_root is not a directory`). apply now creates it **as the tenant** (scope-validated) when missing.

3. **Marketplace showed only 3 frameworks + blank icons until a manual restart.** The catalog syncs run AFTER the buildSteps panel-api restart, so the panel kept serving the pre-sync in-memory catalog. install.sh now reloads panel-api after the docker-app + py-framework catalog syncs.

## Box-verified on .86
`create --app-root test` → `/home/<user>/test`; apply creates the dir + builds the venv; status=running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)