### PR TITLE
fix(migrate): carry HestiaCP panel-user email from user.conf CONTACT (GH #516)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -159,6 +159,21 @@ failed stage. Already-done stages are skipped.`,
 				targetEmail = meta.Email
 				fmt.Printf("  → target-email detected from cpmove: %s\n", targetEmail)
 			}
+			if targetEmail == "" && job.SourceKind == models.MigrationSourceHestia {
+				// GH #516: HestiaCP stores the account's contact email as
+				// CONTACT='addr' in hestia/user.conf. The offline path hasn't
+				// extracted yet, so read it from the staged tarball (mirrors the
+				// contact-NAME peek below) — carry the real email instead of a
+				// synthetic <user>@<host>.
+				staging := filepath.Join("/var/lib/jabali-migrations", jobID)
+				if e := hestiacp.PeekUserEmailFromStaging(staging, job.SourceUser); e != "" {
+					targetEmail = e
+					fmt.Printf("  → target-email from Hestia user.conf CONTACT: %s\n", targetEmail)
+				} else if e := hestiacp.PeekUserEmail(extractDir); e != "" {
+					targetEmail = e
+					fmt.Printf("  → target-email from Hestia user.conf CONTACT: %s\n", targetEmail)
+				}
+			}
 			if targetEmail == "" {
 				// No contactemail file in the tarball (older pkgacct
 				// versions or pre-extracted blob) — synthesize

--- a/panel-api/internal/migrate/hestiacp/peek_username.go
+++ b/panel-api/internal/migrate/hestiacp/peek_username.go
@@ -24,10 +24,21 @@ import (
 //     extracted dir at create time saw nothing. PeekUserNameFromStaging reads
 //     the name straight out of the staged tarball, before extraction.
 var (
-	hestiaNameRe  = regexp.MustCompile(`(?m)^\s*NAME=['"]?([^'"\n]*)['"]?`)
-	hestiaFNameRe = regexp.MustCompile(`(?m)^\s*FNAME=['"]?([^'"\n]*)['"]?`)
-	hestiaLNameRe = regexp.MustCompile(`(?m)^\s*LNAME=['"]?([^'"\n]*)['"]?`)
+	hestiaNameRe    = regexp.MustCompile(`(?m)^\s*NAME=['"]?([^'"\n]*)['"]?`)
+	hestiaFNameRe   = regexp.MustCompile(`(?m)^\s*FNAME=['"]?([^'"\n]*)['"]?`)
+	hestiaLNameRe   = regexp.MustCompile(`(?m)^\s*LNAME=['"]?([^'"\n]*)['"]?`)
+	hestiaContactRe = regexp.MustCompile(`(?m)^\s*CONTACT=['"]?([^'"\n]*)['"]?`)
 )
+
+// parseHestiaContactEmail pulls the account contact email (CONTACT='addr') out
+// of a user.conf body (GH #516: the panel-user email must carry over instead of
+// being synthesized as <user>@<host>).
+func parseHestiaContactEmail(b []byte) string {
+	if m := hestiaContactRe.FindSubmatch(b); m != nil {
+		return strings.TrimSpace(string(m[1]))
+	}
+	return ""
+}
 
 // parseHestiaContactName pulls the contact name out of a user.conf body.
 // Prefers explicit FNAME/LNAME; else splits the single NAME field on the
@@ -91,6 +102,47 @@ func PeekUserNameFromStaging(stagingDir, sourceUser string) (first, last string)
 		}
 	}
 	return "", ""
+}
+
+// PeekUserEmail reads CONTACT from an already-extracted user.conf tree.
+func PeekUserEmail(extractDir string) string {
+	if extractDir == "" {
+		return ""
+	}
+	for _, p := range []string{
+		filepath.Join(extractDir, "hestia", "user.conf"),
+		filepath.Join(extractDir, "user.conf"),
+	} {
+		if b, err := os.ReadFile(p); err == nil {
+			if e := parseHestiaContactEmail(b); e != "" {
+				return e
+			}
+		}
+	}
+	return ""
+}
+
+// PeekUserEmailFromStaging reads CONTACT straight out of the staged tarball,
+// used at auto-create time before the offline import extracts it (GH #516).
+func PeekUserEmailFromStaging(stagingDir, sourceUser string) string {
+	if stagingDir == "" {
+		return ""
+	}
+	var cands []string
+	cands = append(cands, filepath.Join(stagingDir, "user."+sourceUser+".tar.gz"))
+	for _, pat := range []string{"*.tar.gz", "*.tar"} {
+		if m, _ := filepath.Glob(filepath.Join(stagingDir, pat)); len(m) > 0 {
+			cands = append(cands, m...)
+		}
+	}
+	for _, tarPath := range cands {
+		if b, ok := readTarMember(tarPath, "hestia/user.conf"); ok {
+			if e := parseHestiaContactEmail(b); e != "" {
+				return e
+			}
+		}
+	}
+	return ""
 }
 
 // readTarMember returns the bytes of one member (matched by suffix, with or

--- a/panel-api/internal/migrate/hestiacp/peek_username_test.go
+++ b/panel-api/internal/migrate/hestiacp/peek_username_test.go
@@ -87,3 +87,19 @@ func TestPeekUserNameFromStaging(t *testing.T) {
 		t.Errorf("empty staging should yield empty, got (%q,%q)", f, l)
 	}
 }
+
+// GH #516: the account's contact email (CONTACT=) must carry over from
+// user.conf instead of being synthesized as <user>@<host>.
+func TestParseHestiaContactEmail(t *testing.T) {
+	cases := map[string]string{
+		"NAME='ITFlow Support'\nCONTACT='support@itflow.org'\nPACKAGE='default'\n": "support@itflow.org",
+		"CONTACT=\"user@example.com\"\n":                                          "user@example.com",
+		"CONTACT=bare@nodots.co\n":                                                "bare@nodots.co",
+		"NAME='x'\nPACKAGE='default'\n":                                           "", // no CONTACT
+	}
+	for body, want := range cases {
+		if got := parseHestiaContactEmail([]byte(body)); got != want {
+			t.Errorf("parseHestiaContactEmail(%q) = %q, want %q", body, got, want)
+		}
+	}
+}


### PR DESCRIPTION
A HestiaCP migration synthesized a fake `<user>@<source-host>` email for the created panel user instead of carrying the real one.

HestiaCP stores the account contact email as `CONTACT='addr'` in `hestia/user.conf`, but the migration only parsed the contact **NAME** from that file — the email path checked cpmove metadata (absent for Hestia) and fell straight through to synthesis.

Added `parseHestiaContactEmail` + `PeekUserEmail`/`PeekUserEmailFromStaging`, and for hestiacp sources it reads `CONTACT` from the staged tarball before synthesizing (mirrors the contact-NAME peek; the offline path hasn't extracted yet at auto-create time).

## Box-verified on .86
Sample backup's `user.conf` has `CONTACT='support@itflow.org'` → the created user's email is now `support@itflow.org` (was `itflowapp@<host>`). Unit test for the parser added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)