### PR TITLE
fix(terminal): PTY broker gid + hide disabled Terminal nav (GH #515, JAB-169)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5126,6 +5126,16 @@ write_agent_systemd_unit() {
   jabali_gid="$(getent group "$SERVICE_USER" | cut -d: -f3)"
   [[ -n "$jabali_gid" ]] || _die "can't resolve gid of $SERVICE_USER"
 
+  # GH #515 / JAB-169: the PTY broker's SO_PEERCRED gate must match panel-api's
+  # PRIMARY gid, which is jabali-sockets (panel-api unit sets Group=jabali-sockets
+  # so nginx can reach its listen socket). -gid above is the jabali gid for the
+  # MAIN agent socket; -pty-gid is jabali-sockets for the terminal broker. One
+  # -gid for both refused panel-api and left the web terminal with no keyboard
+  # input on every install.
+  local jabali_sockets_gid
+  jabali_sockets_gid="$(getent group jabali-sockets | cut -d: -f3)"
+  [[ -n "$jabali_sockets_gid" ]] || _die "can't resolve gid of jabali-sockets"
+
   cat >"/etc/systemd/system/${AGENT_SERVICE_NAME}.service" <<EOF
 [Unit]
 Description=Jabali Agent (privileged host operations)
@@ -5145,7 +5155,7 @@ Group=$SERVICE_USER
 RuntimeDirectory=jabali
 RuntimeDirectoryMode=0750
 RuntimeDirectoryPreserve=no
-ExecStart=$AGENT_BIN_PATH -socket $AGENT_SOCKET -gid $jabali_gid
+ExecStart=$AGENT_BIN_PATH -socket $AGENT_SOCKET -gid $jabali_gid -pty-gid $jabali_sockets_gid
 Restart=on-failure
 RestartSec=3
 TimeoutStopSec=10

--- a/panel-agent/cmd/jabali-agent/main.go
+++ b/panel-agent/cmd/jabali-agent/main.go
@@ -49,6 +49,13 @@ func main() {
 	var (
 		socketPath = flag.String("socket", envOr("JABALI_AGENT_SOCKET", defaultSocketPath), "path to the unix socket to listen on")
 		socketGID  = flag.Int("gid", envInt("JABALI_AGENT_GID", -1), "chown socket to root:<gid> after bind; -1 to skip")
+		// GH #515 / JAB-169: the PTY broker's SO_PEERCRED gate must match
+		// panel-api's PRIMARY gid, which is jabali-sockets (systemd
+		// Group=jabali-sockets), NOT the jabali gid used for the main
+		// agent socket. Passing one -gid for both refused panel-api on
+		// every install. -pty-gid overrides it for the broker; falls back
+		// to -gid when unset so old units keep their prior behaviour.
+		ptyGID = flag.Int("pty-gid", envInt("JABALI_AGENT_PTY_GID", -1), "PTY broker socket gid + SO_PEERCRED gate (panel-api primary gid = jabali-sockets); -1 falls back to -gid")
 		timeout    = flag.Duration("timeout", defaultTimeout, "per-request wall-clock timeout (when caller sets no deadline)")
 		logFormat  = flag.String("log-format", envOr("JABALI_AGENT_LOG_FORMAT", "json"), "json|text")
 		logLevel   = flag.String("log-level", envOr("JABALI_AGENT_LOG_LEVEL", "info"), "debug|info|warn|error")
@@ -119,7 +126,11 @@ func main() {
 	// default panel-api-side; unreachable except by the jabali-group
 	// panel-api process.
 	ptySock := filepath.Join(filepath.Dir(*socketPath), "agent-pty.sock")
-	commands.StartTerminalPTYBroker(ctx, ptySock, *socketGID, "/var/log/jabali/terminal", log)
+	brokerGID := *ptyGID
+	if brokerGID < 0 {
+		brokerGID = *socketGID
+	}
+	commands.StartTerminalPTYBroker(ctx, ptySock, brokerGID, "/var/log/jabali/terminal", log)
 
 	// GH #184: backfill per-user CLI php wrappers for existing pinned users
 	// (reconciler only applies pending/error pools, so a restart converges

--- a/panel-agent/internal/commands/terminal_pty.go
+++ b/panel-agent/internal/commands/terminal_pty.go
@@ -159,7 +159,7 @@ func handleTerminalConn(raw net.Conn, recordDir string, gid int, log *slog.Logge
 			log.Warn("terminal: refusing connection: cannot read peer credentials")
 			return
 		}
-		if uid != 0 && pgid != gid {
+		if !terminalPeerAllowed(uid, pgid, gid) {
 			log.Warn("terminal: refusing connection: peer is not panel-api", "peer_uid", uid, "peer_gid", pgid, "want_gid", gid)
 			return
 		}
@@ -339,6 +339,21 @@ func sanitizeSessionID(s string) string {
 // terminalPeerCred reads the connecting peer's uid + primary gid via
 // SO_PEERCRED (Gitea #469). ok=false when the conn is not a unix socket or the
 // credentials cannot be read, so callers fail closed.
+// terminalPeerAllowed decides whether a broker peer may spawn a root shell
+// (Gitea #469 / GH #515). root (uid 0) is always allowed. Everyone else must
+// present the expected PRIMARY gid: panel-api runs with systemd
+// Group=jabali-sockets, so its SO_PEERCRED primary gid is the jabali-sockets
+// gid — which is what the broker is handed via -pty-gid. Matching the
+// jabali-sockets gid (NOT the jabali gid of the main agent socket) is what
+// #515 got wrong: one -gid conflated two groups and refused panel-api on every
+// install. Fails closed for any other primary gid.
+func terminalPeerAllowed(uid, pgid, wantGID int) bool {
+	if uid == 0 {
+		return true
+	}
+	return pgid == wantGID
+}
+
 func terminalPeerCred(c net.Conn) (uid, gid int, ok bool) {
 	uc, isUnix := c.(*net.UnixConn)
 	if !isUnix {

--- a/panel-agent/internal/commands/terminal_pty_peercred_test.go
+++ b/panel-agent/internal/commands/terminal_pty_peercred_test.go
@@ -60,3 +60,31 @@ func TestTerminalPeerCred(t *testing.T) {
 		t.Error("non-unix conn must fail closed (ok=false)")
 	}
 }
+
+// TestTerminalPeerAllowed pins the SO_PEERCRED gate (GH #515 / JAB-169): the
+// broker must accept panel-api's real PRIMARY gid (jabali-sockets, what
+// -pty-gid carries), accept root, and refuse anything else — in particular the
+// jabali gid used for the main agent socket, which is what the pre-fix single
+// -gid wrongly compared against.
+func TestTerminalPeerAllowed(t *testing.T) {
+	const (
+		jabaliGID        = 996 // main agent-socket gid (WRONG for the broker)
+		jabaliSocketsGID = 995 // panel-api primary gid == -pty-gid (correct)
+	)
+	cases := []struct {
+		name            string
+		uid, pgid, want int
+		allowed         bool
+	}{
+		{"panel-api primary jabali-sockets", 1000, jabaliSocketsGID, jabaliSocketsGID, true},
+		{"root always allowed", 0, 0, jabaliSocketsGID, true},
+		{"root with any gid", 0, 12345, jabaliSocketsGID, true},
+		{"jabali gid refused (the #515 bug)", 1000, jabaliGID, jabaliSocketsGID, false},
+		{"unrelated gid refused", 1000, 1000, jabaliSocketsGID, false},
+	}
+	for _, tc := range cases {
+		if got := terminalPeerAllowed(tc.uid, tc.pgid, tc.want); got != tc.allowed {
+			t.Errorf("%s: terminalPeerAllowed(%d,%d,%d) = %v, want %v", tc.name, tc.uid, tc.pgid, tc.want, got, tc.allowed)
+		}
+	}
+}

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -55,7 +55,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "public_ipv4": "", "public_ipv6": ""})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": ""})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -92,6 +92,9 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		"security_enabled": settings.SecurityEnabled,
 		"quota_enabled":    settings.QuotaEnabled,
 		"api_enabled":      settings.APIEnabled,
+		// GH #515 / JAB-169: the admin Terminal nav entry stayed visible with
+		// the module off. Surface the flag so the sidebar hides it.
+		"root_terminal_enabled": settings.RootTerminalEnabled,
 		// GH #361: surface the server's public IPv4/IPv6 so the user + admin
 		// dashboards can show them (already tracked for the panel cert + DNS;
 		// not per-user sensitive). Empty string when unset.

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -18,6 +18,8 @@ export interface ServerCapabilities {
   security_enabled: boolean;
   quota_enabled: boolean;
   api_enabled: boolean;
+  /** GH #515: admin web terminal (root_terminal_enabled). Gates the Terminal nav entry. */
+  root_terminal_enabled: boolean;
   /** GH #361: the server's public IPv4, for the dashboard. "" when unset. */
   public_ipv4: string;
   /** GH #361: the server's public IPv6, for the dashboard. "" when unset. */
@@ -40,6 +42,7 @@ export function useServerCapabilities() {
         security_enabled: data.security_enabled !== false,
         quota_enabled: data.quota_enabled !== false,
         api_enabled: data.api_enabled !== false,
+        root_terminal_enabled: !!data.root_terminal_enabled,
         public_ipv4: data.public_ipv4 ?? "",
         public_ipv6: data.public_ipv6 ?? "",
       };

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -42,6 +42,8 @@ export function AdminLayout() {
   // and the brief pre-caps render never flash-hide a real feature.
   const visibleNav = adminNav.filter((n) => {
     if (n.key === "docker-apps") return !!caps?.docker_marketplace_enabled;
+    // GH #515: default-off module — hide until explicitly enabled (like docker-apps).
+    if (n.key === "terminal") return !!caps?.root_terminal_enabled;
     if (n.key === "mail") return caps?.mail_enabled !== false;
     if (n.key === "dns") return caps?.dns_enabled !== false;
     if (n.key === "security") return caps?.security_enabled !== false;


### PR DESCRIPTION
Two Terminal bugs from GH #515 (JAB-169), both root-caused live.

## Part 1 — web terminal accepts no keyboard input
The #469 `SO_PEERCRED` hardening on the root PTY broker refused panel-api because of a **gid mismatch**. The agent is started with `-gid` = the **jabali** gid (correct for chowning the main agent socket), and that same gid was reused for the broker's peercred gate. But panel-api's unit sets `Group=jabali-sockets`, so its process **primary** gid — what `SO_PEERCRED` reports — is the **jabali-sockets** gid. `pgid != gid` -> the root shell was never spawned, so the terminal opened but ate every keystroke.

**Confirmed live (testserver):** `jabali`=989, `jabali-sockets`=988, agent `-gid`=989, panel-api primary Gid=**988** -> refused.

**Fix:** a separate `-pty-gid` flag (`JABALI_AGENT_PTY_GID`) carries the jabali-sockets gid to the broker for both the socket chown and the peercred gate; `-gid` stays the jabali gid for the main socket. `install.sh` resolves the jabali-sockets gid and passes it. The gate is extracted into `terminalPeerAllowed()` with a regression test asserting it accepts panel-api's real primary gid (jabali-sockets) and root, and refuses the jabali gid.

## Part 2 — disabled Terminal still in sidebar
The admin nav already filters most modules via `/me/server-capabilities`, but the Terminal entry was never gated. Surface `root_terminal_enabled` in the capabilities payload and hide the Terminal nav item when off (default-off -> hidden until enabled).

## Verification
- `go build ./...` + `go test` (peercred gate, caps) green; `tsc -b` green.
- Root cause reproduced live on testserver (gids above).
- Full end-to-end (deploy + type in web terminal) pending box authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)