### PR TITLE
fix(migrate): apply custom source SSH port in analyze + DA list stages (GH #429)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1434,6 +1434,11 @@ func cpanelAnalyzeCallback(jobsRepo repository.MigrationJobRepository) migrate.S
 		if s, sErr := settingsRepo.Get(ctx); sErr == nil && s != nil {
 			migrate.ApplyAllowPrivate(disc, s.MigrationAllowPrivateHosts)
 		}
+		// GH #429: honor the custom source SSH port in the analyze stage.
+		// The API test-connection + size probe already apply it, but this
+		// stage dialed the default 22 regardless (lxsdevcode: "stage
+		// analyze: connect: plesk.Connect: tcp dial remote_ip:22").
+		migrate.ApplyPort(disc, job.SourcePort)
 		s, err := disc.Connect(ctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath})
 		if err != nil {
 			return 0, nil, fmt.Errorf("connect: %w", err)
@@ -1538,6 +1543,8 @@ func preflightDAPivot(ctx context.Context, job *models.MigrationJob) (string, er
 	if s, sErr := settingsRepo.Get(ctx); sErr == nil && s != nil {
 		migrate.ApplyAllowPrivate(disc, s.MigrationAllowPrivateHosts)
 	}
+	// GH #429: DA single-account auto-pick also honors the custom SSH port.
+	migrate.ApplyPort(disc, job.SourcePort)
 	subctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	s, err := disc.Connect(subctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath})


### PR DESCRIPTION
The earlier port fix wired `job.SourcePort` into the API test-connection and size-probe paths, but the migration **runner's analyze stage** (the generic cpanel/plesk/hestia/whm callback via `migrate.Get`) and the DirectAdmin single-account auto-pick still called `disc.Connect` **without applying the port** — so both dialed the default 22 regardless of the configured port.

For a Plesk source with a custom SSH port that surfaced as (lxsdevcode, #429):

```
stage analyze: connect: plesk.Connect: tcp dial remote_ip:22: i/o timeout
```

## Fix
Add `migrate.ApplyPort(disc, job.SourcePort)` before both `Connect` calls, mirroring the already-tested pull path (which uses `srcSSHPort`). Audited every `disc.Connect` site in the run/pull paths — all now apply the port (pull sites already did via `d.Port = srcSSHPort(job)`; the plesk docroot helper already did too).

## Verification
- `go vet` + `go build` + port/migrate tests green (`ApplyPort`, `srcSSHPort`, `normalizeSourcePort` already covered).
- No Plesk test host available; fix is a direct mirror of the verified pull path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)