### PR TITLE
fix(dns): apply default_dns_ttl to auto-created + migrated records (GH #527)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1156,10 +1156,12 @@ func cpanelRestoreCallback(
 			// #327: pass this server's public IPv4 so ImportDNS can repoint any
 			// record that pointed at the source box (mail A, custom subdomains).
 			var serverIPv4 string
+			var dnsTTL int
 			if s, serr := repository.NewServerSettingsRepository(sharedDB).Get(ctx); serr == nil && s != nil {
 				serverIPv4 = s.PublicIPv4
+				dnsTTL = models.EffectiveDNSTTL(s) // GH #527: normalize migrated TTLs
 			}
-			dnsRes, derr := cpanel.ImportDNS(ctx, dnsZonesRepo, dnsRecordsRepo, domainsRepo, p.parsed, serverIPv4)
+			dnsRes, derr := cpanel.ImportDNS(ctx, dnsZonesRepo, dnsRecordsRepo, domainsRepo, p.parsed, serverIPv4, dnsTTL)
 			if derr != nil {
 				return bytes, warnings, fmt.Errorf("dns: %w", derr)
 			}

--- a/panel-api/internal/dnscompile/bootstrap.go
+++ b/panel-api/internal/dnscompile/bootstrap.go
@@ -34,6 +34,10 @@ import (
 //     the local stalwart over the apex bind.
 func BootstrapRecords(zoneID, zoneName string, srv *models.ServerSettings, idNew func() string, includeMail, includeWWW bool) []models.DNSRecord {
 	now := time.Now().UTC()
+	// GH #527: honor server_settings.default_dns_ttl for bootstrap records
+	// instead of a hardcoded value, so the operator's configured default
+	// actually applies to the apex / mail / NS rows a new zone starts with.
+	defTTL := models.EffectiveDNSTTL(srv)
 	mk := func(name, typ, content string, priority int) models.DNSRecord {
 		return models.DNSRecord{
 			ID:        idNew(),
@@ -41,7 +45,7 @@ func BootstrapRecords(zoneID, zoneName string, srv *models.ServerSettings, idNew
 			Name:      name,
 			Type:      typ,
 			Content:   content,
-			TTL:       300,
+			TTL:       defTTL,
 			Priority:  priority,
 			Managed:   true,
 			IsEnabled: true,

--- a/panel-api/internal/migrate/cpanel/bind_parse.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse.go
@@ -349,6 +349,7 @@ func ImportDNS(
 	domainsRepo repository.DomainRepository,
 	parsed *ParsedTarball,
 	serverIPv4 string,
+	defaultTTL int,
 ) (*ImportDNSResult, error) {
 	if zonesRepo == nil || recordsRepo == nil || domainsRepo == nil {
 		return nil, fmt.Errorf("ImportDNS: dns repos nil")
@@ -503,7 +504,11 @@ func ImportDNS(
 				Name:      pname,
 				Type:      r.Type,
 				Content:   r.Content,
-				TTL:       r.TTL,
+				// GH #527: normalize migrated records to the panel's default
+				// TTL (fallback to the parsed source TTL only when no default
+				// is supplied) so a migrated zone is consistent with what the
+				// panel creates, instead of carrying the source's mixed TTLs.
+				TTL:       ttlOrDefault(r.TTL, defaultTTL),
 				Priority:  r.Prio,
 				IsEnabled: true,
 			}
@@ -517,6 +522,16 @@ func ImportDNS(
 		res.Records += inserted
 	}
 	return res, nil
+}
+
+// ttlOrDefault returns the panel default TTL when one is supplied (>0),
+// otherwise falls back to the source record's TTL. GH #527: migrated records
+// adopt the panel's default_dns_ttl so the zone isn't a mix of source TTLs.
+func ttlOrDefault(sourceTTL, defaultTTL int) int {
+	if defaultTTL > 0 {
+		return defaultTTL
+	}
+	return sourceTTL
 }
 
 // toPanelRecordName converts a parsed FQDN record name into the panel's

--- a/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_apex_test.go
@@ -104,7 +104,7 @@ www     IN  A   192.0.2.10
 `)
 	zones := &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{"example.com": {ID: "z1", Name: "example.com"}}}
 	recs := &fakeDNSRecordRepo{}
-	res, err := ImportDNS(context.Background(), zones, recs, domains("example.com"), parsed, "203.0.113.9")
+	res, err := ImportDNS(context.Background(), zones, recs, domains("example.com"), parsed, "203.0.113.9", 0)
 	if err != nil {
 		t.Fatalf("ImportDNS: %v", err)
 	}
@@ -139,7 +139,7 @@ mail._domainkey IN TXT "v=DKIM1; k=rsa; p=abc"
 `)
 	zones := &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{"example.com": {ID: "z1", Name: "example.com"}}}
 	recs := &fakeDNSRecordRepo{existing: []models.DNSRecord{{Name: "@", Type: "MX", Content: "10 mail.example.com"}}}
-	if _, err := ImportDNS(context.Background(), zones, recs, domains("example.com"), parsed, "203.0.113.9"); err != nil {
+	if _, err := ImportDNS(context.Background(), zones, recs, domains("example.com"), parsed, "203.0.113.9", 0); err != nil {
 		t.Fatalf("ImportDNS: %v", err)
 	}
 	got := createdNames(recs)
@@ -167,7 +167,7 @@ www IN A 192.0.2.1
 	zones := &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{}}
 	recs := &fakeDNSRecordRepo{}
 	// Neither the zone nor the domain exist -> domain_not_found, nothing created.
-	res, _ := ImportDNS(context.Background(), zones, recs, &fakeDomainRepo{byName: map[string]*models.Domain{}}, parsed, "203.0.113.9")
+	res, _ := ImportDNS(context.Background(), zones, recs, &fakeDomainRepo{byName: map[string]*models.Domain{}}, parsed, "203.0.113.9", 0)
 	if len(recs.created) != 0 {
 		t.Errorf("no records should be created when the domain is missing")
 	}
@@ -183,7 +183,7 @@ www IN A 192.0.2.1
 
 	// Zone missing but the domain EXISTS -> the zone is created + records land.
 	recs2 := &fakeDNSRecordRepo{}
-	res2, _ := ImportDNS(context.Background(), &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{}}, recs2, domains("example.com"), writeZone(t, "$ORIGIN example.com.\nwww IN A 192.0.2.1\n"), "203.0.113.9")
+	res2, _ := ImportDNS(context.Background(), &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{}}, recs2, domains("example.com"), writeZone(t, "$ORIGIN example.com.\nwww IN A 192.0.2.1\n"), "203.0.113.9", 0)
 	if !createdNames(recs2)["www/A"] {
 		t.Errorf("zone should be auto-created and www A imported; created=%v skipped=%v", recs2.created, res2.Skipped)
 	}
@@ -252,5 +252,38 @@ func TestParseBINDZone_CAA(t *testing.T) {
 	}
 	if caa.Content != "0 issue \"letsencrypt.org\"" {
 		t.Errorf("CAA content = %q, want verbatim rdata", caa.Content)
+	}
+}
+
+// GH #527: migrated records adopt the panel's default TTL instead of the
+// source zone's, so a migrated zone isn't a mix of source TTLs.
+func TestImportDNS_NormalizesTTLToDefault(t *testing.T) {
+	parsed := writeZone(t, `$ORIGIN example.com.
+$TTL 14400
+@   IN  SOA ns1.example.com. admin.example.com. ( 1 3600 1800 1209600 86400 )
+www     IN  A   192.0.2.10
+shop    IN  A   192.0.2.11
+`)
+	zones := &fakeDNSZoneRepo{byName: map[string]*models.DNSZone{"example.com": {ID: "z1", Name: "example.com"}}}
+	recs := &fakeDNSRecordRepo{}
+	if _, err := ImportDNS(context.Background(), zones, recs, domains("example.com"), parsed, "203.0.113.9", 300); err != nil {
+		t.Fatalf("ImportDNS: %v", err)
+	}
+	if len(recs.created) == 0 {
+		t.Fatal("no records imported")
+	}
+	for _, r := range recs.created {
+		if r.TTL != 300 {
+			t.Errorf("%s/%s TTL = %d, want 300 (normalized from source 14400)", r.Name, r.Type, r.TTL)
+		}
+	}
+}
+
+func TestTTLOrDefault(t *testing.T) {
+	if got := ttlOrDefault(14400, 300); got != 300 {
+		t.Errorf("ttlOrDefault(14400,300) = %d, want 300", got)
+	}
+	if got := ttlOrDefault(14400, 0); got != 14400 {
+		t.Errorf("ttlOrDefault(14400,0) = %d, want 14400 (no default keeps source)", got)
 	}
 }

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -342,6 +342,17 @@ type ServerSettings struct {
 
 func (ServerSettings) TableName() string { return "server_settings" }
 
+// EffectiveDNSTTL returns the operator-configured default DNS record TTL, or
+// 300s when unset/nil. GH #527: apply the default consistently to auto-created
+// zone records (apex/www/NS) and migrated records, not just hand-made ones —
+// mirrors the API create path's fallback (dns.go defaultRecordTTL).
+func EffectiveDNSTTL(s *ServerSettings) int {
+	if s != nil && s.DefaultDNSTTL != 0 {
+		return int(s.DefaultDNSTTL)
+	}
+	return 300
+}
+
 
 // Log-retention category keys (Server Settings -> Logs). Each groups one or more
 // log/report tables the retention sweep prunes.

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2627,8 +2627,15 @@ func (r *Reconciler) convergeApexAddrRecords(ctx context.Context, zone *models.D
 		r.log.Error("converge apex addrs: list records failed", "zone", zone.Name, "err", err)
 		return
 	}
-	r.ensureApexAddrRow(ctx, zone.ID, existing, "A", v4)
-	r.ensureApexAddrRow(ctx, zone.ID, existing, "AAAA", v6)
+	// GH #527: apex A/AAAA rows use the configured default TTL, not a
+	// hardcoded value, so operator changes to default_dns_ttl take effect.
+	var srv *models.ServerSettings
+	if r.serverSettings != nil {
+		srv, _ = r.serverSettings.Get(ctx)
+	}
+	ttl := models.EffectiveDNSTTL(srv)
+	r.ensureApexAddrRow(ctx, zone.ID, existing, "A", v4, ttl)
+	r.ensureApexAddrRow(ctx, zone.ID, existing, "AAAA", v6, ttl)
 }
 
 // ensureApexAddrRow finds the `@` record of the given type in the
@@ -2642,7 +2649,7 @@ func (r *Reconciler) convergeApexAddrRecords(ctx context.Context, zone *models.D
 // v6 configured and no v6 binding). In that case we DON'T create a row
 // and DON'T blank an existing managed row — the operator may intend to
 // add v6 later; clobbering the row would drop a working record.
-func (r *Reconciler) ensureApexAddrRow(ctx context.Context, zoneID string, existing []models.DNSRecord, recType, content string) {
+func (r *Reconciler) ensureApexAddrRow(ctx context.Context, zoneID string, existing []models.DNSRecord, recType, content string, ttl int) {
 	var existingRow *models.DNSRecord
 	for i := range existing {
 		if existing[i].Name == "@" && existing[i].Type == recType {
@@ -2681,7 +2688,7 @@ func (r *Reconciler) ensureApexAddrRow(ctx context.Context, zoneID string, exist
 		Name:      "@",
 		Type:      recType,
 		Content:   content,
-		TTL:       3600,
+		TTL:       ttl,
 		Managed:   true,
 		IsEnabled: true,
 		CreatedAt: time.Now().UTC(),
@@ -2746,7 +2753,7 @@ func (r *Reconciler) migrateBootstrapShape(ctx context.Context, zone *models.DNS
 				Name:      "www",
 				Type:      "CNAME",
 				Content:   zone.Name,
-				TTL:       3600,
+				TTL:       models.EffectiveDNSTTL(srv), // GH #527
 				Managed:   true,
 				IsEnabled: true,
 				CreatedAt: now,
@@ -2864,7 +2871,7 @@ func (r *Reconciler) migrateBootstrapShape(ctx context.Context, zone *models.DNS
 				Name:      label,
 				Type:      "A",
 				Content:   ns.ipv4,
-				TTL:       3600,
+				TTL:       models.EffectiveDNSTTL(srv), // GH #527
 				Managed:   true,
 				IsEnabled: true,
 				CreatedAt: now,


### PR DESCRIPTION
`server_settings.default_dns_ttl` was honored **only** on the API create path (hand-made records). Three other paths ignored it:

| Path | Was | Now |
|---|---|---|
| `dnscompile.BootstrapRecords` (new-zone rows) | hardcoded 300 | `EffectiveDNSTTL(srv)` |
| reconciler apex `@`, `www` CNAME, NS glue A | hardcoded **3600** | `EffectiveDNSTTL(srv)` |
| migration `ImportDNS` (cpanel/hestia) | **source** TTL (e.g. 14400) | normalized to default |

So the operator's configured default never reached the domain apex, the NS records, or migrated records — exactly what #527 reports ("the domain name itself is not using the default TTL along with ns records" + "inconsistencies … on hestiacp migration").

## Change
- `models.EffectiveDNSTTL(srv)` — configured value, or 300 fallback (mirrors the API path).
- Bootstrap + `migrateBootstrapShape` already had `srv`; `convergeApexAddrRecords` now fetches it (nil-guarded).
- `ImportDNS` takes a `defaultTTL`; `ttlOrDefault` keeps the source TTL only when no default is supplied (0).
- **SOA refresh/minimum timers left as protocol defaults** — they are not record TTLs.

## Tests
- `TestImportDNS_NormalizesTTLToDefault` (source 14400 → default 300), `TestTTLOrDefault`, existing apex/bootstrap suites pass 0 to keep their source-TTL assertions.
- `go build` + `vet` + reconciler/dnscompile/models/cpanel/api suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)