### PR TITLE
fix(ui): flag object-cache-only state in the app Cache drawer

### DIFF
--- a/panel-ui/src/shells/user/applications/CacheSettingsDrawer.tsx
+++ b/panel-ui/src/shells/user/applications/CacheSettingsDrawer.tsx
@@ -269,6 +269,15 @@ export function CacheSettingsDrawer({
         <Form.Item label="Page cache (nginx)" help="Full-page micro-cache for anonymous visitors. Independent of the object cache.">
           <Switch checked={pageOn} onChange={setPageOn} />
         </Form.Item>
+        {enabled && !pageOn && (
+          <Alert
+            type="warning"
+            showIcon
+            style={{ marginBottom: 12 }}
+            message="Object cache only — page cache is off"
+            description="Caching is on, but only the Redis object cache is active. The nginx page cache is off, so the Domains → Caching panel and the site's cache status will report page caching as off. Turn this on and Save to enable it."
+          />
+        )}
         <Form.Item label="Auto-warm" help="Crawl the site to pre-populate the cache after enabling or purging.">
           <Switch checked={autoWarm} onChange={setAutoWarm} />
           {lastWarm?.at ? (


### PR DESCRIPTION
## Reported (via screenshots)
For one WordPress site, the app **Cache settings** drawer showed "Page cache (nginx)" **ON**, while the **Domains → Caching** panel and the WP Jabali-Cache plugin both showed page cache **OFF** ("no server cache detected").

## Investigation (reproduced on testserver)
The two panels read different things by design:
- app drawer → the app's stored `page_cache_enabled` **preference**
- domain panel / WP plugin → the **effective** nginx page cache (`domain.cache_enabled`)

`setCacheCore` couples them: `pageOn = master && page_sub`, then writes `domain.cache_enabled` + re-renders the vhost. **Verified correct in both directions on testserver:**

| stored `page_cache_enabled` | master | → `domain.cache_enabled` |
|---|---|---|
| `false` | enabled | 0 (page off) |
| `true` / `NULL` | enabled | 1 (page on) |

So the reported state is a **valid object-cache-only** config (master on, page sub off), not a coupling bug. The "ON" in the screenshot was an unsaved toggle (drawer had pending Cancel/Save). No backend change needed.

## Fix
Purely visibility: the app Cache drawer now shows an inline warning when the master toggle is on but page cache is off — explaining it's object-cache-only and that the Domains panel / cache status will report page caching as off until page cache is turned on and saved.

- `tsc -b` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)