### PR TITLE
feat(cache): per-domain cache-query-allowlist data model + API (step 1/5)

### DIFF
--- a/panel-api/cmd/server/domain_email_cmd_test.go
+++ b/panel-api/cmd/server/domain_email_cmd_test.go
@@ -93,7 +93,9 @@ func (*fakeDomainRepo) List(context.Context, repository.ListOptions) ([]models.D
 func (*fakeDomainRepo) ListByUserID(context.Context, string, repository.ListOptions) ([]models.Domain, int64, error) {
 	return nil, 0, nil
 }
-func (*fakeDomainRepo) BulkSetEnabledByUserID(context.Context, string, bool) (int64, error) { return 0, nil }
+func (*fakeDomainRepo) BulkSetEnabledByUserID(context.Context, string, bool) (int64, error) {
+	return 0, nil
+}
 func (*fakeDomainRepo) Update(context.Context, *models.Domain) error { return nil }
 func (*fakeDomainRepo) Delete(context.Context, string) error         { return nil }
 func (*fakeDomainRepo) ListForRegistrarRefresh(context.Context, time.Time, int) ([]models.Domain, error) {
@@ -131,8 +133,9 @@ func (*fakeDomainRepo) UpdateDisclaimer(context.Context, string, bool, *string) 
 func (*fakeDomainRepo) UpdateCacheEnabled(context.Context, string, bool) error {
 	return nil
 }
-func (*fakeDomainRepo) UpdateCachePath(context.Context, string, string) error { return nil }
-func (*fakeDomainRepo) UpdateCacheTTL(context.Context, string, int) error { return nil }
+func (*fakeDomainRepo) UpdateCachePath(context.Context, string, string) error           { return nil }
+func (*fakeDomainRepo) UpdateCacheTTL(context.Context, string, int) error               { return nil }
+func (*fakeDomainRepo) UpdateCacheQueryAllowlist(context.Context, string, string) error { return nil }
 
 func (*fakeDomainRepo) UpdateSkipAutoSAN(context.Context, string, bool) error {
 	return nil

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -187,6 +187,9 @@ func (m *mockDomainRepo) UpdateCacheEnabled(ctx context.Context, id string, enab
 
 func (m *mockDomainRepo) UpdateCachePath(_ context.Context, _, _ string) error { return nil }
 func (m *mockDomainRepo) UpdateCacheTTL(_ context.Context, _ string, _ int) error { return nil }
+func (m *mockDomainRepo) UpdateCacheQueryAllowlist(_ context.Context, _, _ string) error {
+	return nil
+}
 
 func (m *mockDomainRepo) UpdateSkipAutoSAN(ctx context.Context, id string, enabled bool) error {
 	return nil

--- a/panel-api/internal/api/domain_cache.go
+++ b/panel-api/internal/api/domain_cache.go
@@ -2,7 +2,11 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -42,12 +46,18 @@ type cacheResponse struct {
 	DomainName string `json:"domain_name"`
 	Enabled    bool   `json:"enabled"`
 	TTLSeconds int    `json:"ttl_seconds"`
+	// QueryAllowlist (migration 000230): param names that get their own cache
+	// entry. Empty/omitted = off. Always a JSON array (never null) for the SPA.
+	QueryAllowlist []string `json:"cache_query_allowlist"`
 }
 
 type cacheUpdateRequest struct {
 	Enabled bool `json:"enabled"`
 	// TTLSeconds (Gitea #596) optional; nil = leave the per-domain TTL unchanged.
 	TTLSeconds *int `json:"ttl_seconds,omitempty"`
+	// QueryAllowlist (migration 000230) optional; nil = leave unchanged, empty
+	// slice = clear (feature off). Names normalized + validated server-side.
+	QueryAllowlist *[]string `json:"cache_query_allowlist,omitempty"`
 }
 
 // loadAndAuth returns the domain after owner-or-admin authz; writes the
@@ -82,6 +92,7 @@ func (h *domainCacheHandler) get(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, cacheResponse{
 		DomainID: dom.ID, DomainName: dom.Name, Enabled: dom.CacheEnabled, TTLSeconds: dom.CacheTTLSeconds,
+		QueryAllowlist: dom.CacheQueryAllowlistNames(),
 	})
 }
 
@@ -130,12 +141,73 @@ func (h *domainCacheHandler) update(c *gin.Context) {
 		_, _ = h.cfg.Agent.Call(pctx, "nginx.cache.purge", map[string]any{"domain": dom.Name})
 		cancel()
 	}
+	// Query-param allowlist (migration 000230). nil = unchanged; a supplied
+	// list (incl. empty = clear) is normalized + validated, then persisted.
+	allowNames := dom.CacheQueryAllowlistNames()
+	if req.QueryAllowlist != nil {
+		csv, err := normalizeCacheQueryAllowlist(*req.QueryAllowlist)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_query_allowlist", "details": err.Error()})
+			return
+		}
+		if err := h.cfg.Domains.UpdateCacheQueryAllowlist(ctx, dom.ID, csv); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "update_failed", "details": err.Error()})
+			return
+		}
+		allowNames = splitAllowlistCSV(csv)
+	}
 	if h.cfg.Reconciler != nil {
 		h.cfg.Reconciler.Schedule(dom.ID)
 	}
 	c.JSON(http.StatusOK, cacheResponse{
 		DomainID: dom.ID, DomainName: dom.Name, Enabled: req.Enabled, TTLSeconds: ttl,
+		QueryAllowlist: allowNames,
 	})
+}
+
+// cacheQueryParamRe bounds an allowlist entry to a safe query-param name:
+// lower-case alnum + underscore, 1-32 chars. This is ALSO the guard that keeps
+// the name safe to interpolate into the nginx regex + $arg_<name> in Step 2
+// (no regex metacharacters can appear), so do not loosen it without revisiting
+// the render.
+var cacheQueryParamRe = regexp.MustCompile(`^[a-z0-9_]{1,32}$`)
+
+const cacheQueryAllowlistMax = 8
+
+// normalizeCacheQueryAllowlist lower-cases, validates, de-dups, sorts, and caps
+// the supplied param names, returning the comma-joined storage form ("" = off).
+// Faceted/combinatorial params multiply cache entries, so the set is
+// deliberately bounded.
+func normalizeCacheQueryAllowlist(in []string) (string, error) {
+	seen := make(map[string]struct{}, len(in))
+	var names []string
+	for _, raw := range in {
+		n := strings.ToLower(strings.TrimSpace(raw))
+		if n == "" {
+			continue
+		}
+		if !cacheQueryParamRe.MatchString(n) {
+			return "", fmt.Errorf("invalid param name %q (allowed: lower-case letters, digits, underscore, 1-32 chars)", raw)
+		}
+		if _, dup := seen[n]; dup {
+			continue
+		}
+		seen[n] = struct{}{}
+		names = append(names, n)
+	}
+	if len(names) > cacheQueryAllowlistMax {
+		return "", fmt.Errorf("too many query params: %d (max %d)", len(names), cacheQueryAllowlistMax)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ","), nil
+}
+
+// splitAllowlistCSV mirrors Domain.CacheQueryAllowlistNames for a raw csv.
+func splitAllowlistCSV(csv string) []string {
+	if csv = strings.TrimSpace(csv); csv == "" {
+		return nil
+	}
+	return strings.Split(csv, ",")
 }
 
 // purge clears this domain's cached pages. v1: host-key grep-unlink in

--- a/panel-api/internal/api/domain_cache_query_allowlist_test.go
+++ b/panel-api/internal/api/domain_cache_query_allowlist_test.go
@@ -1,0 +1,40 @@
+package api
+
+import "testing"
+
+func TestNormalizeCacheQueryAllowlist(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		want    string
+		wantErr bool
+	}{
+		{"empty clears", []string{}, "", false},
+		{"blanks dropped", []string{"", "  "}, "", false},
+		{"single", []string{"paged"}, "paged", false},
+		{"lowercased + sorted", []string{"S", "paged"}, "paged,s", false},
+		{"deduped", []string{"paged", "PAGED", "paged"}, "paged", false},
+		{"underscore + digits ok", []string{"jet_page2"}, "jet_page2", false},
+		{"reject metachar", []string{"pa.ged"}, "", true},
+		{"reject slash", []string{"../x"}, "", true},
+		{"reject space", []string{"a b"}, "", true},
+		{"reject too long", []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, "", true}, // 33 chars
+		{"reject too many", []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeCacheQueryAllowlist(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got %q", tc.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -251,6 +251,9 @@ func (m *MockDomainRepository) UpdateCacheEnabled(ctx context.Context, id string
 
 func (m *MockDomainRepository) UpdateCachePath(_ context.Context, _, _ string) error { return nil }
 func (m *MockDomainRepository) UpdateCacheTTL(_ context.Context, _ string, _ int) error { return nil }
+func (m *MockDomainRepository) UpdateCacheQueryAllowlist(_ context.Context, _, _ string) error {
+	return nil
+}
 
 func (m *MockDomainRepository) UpdateSkipAutoSAN(ctx context.Context, id string, enabled bool) error {
 	return nil

--- a/panel-api/internal/db/migrations/000230_domain_cache_query_allowlist.down.sql
+++ b/panel-api/internal/db/migrations/000230_domain_cache_query_allowlist.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE domains DROP COLUMN cache_query_allowlist;

--- a/panel-api/internal/db/migrations/000230_domain_cache_query_allowlist.up.sql
+++ b/panel-api/internal/db/migrations/000230_domain_cache_query_allowlist.up.sql
@@ -1,0 +1,7 @@
+-- Per-domain cacheable query-param allowlist (cache-query-allowlist blueprint,
+-- rec #1). Comma-joined, lower-cased, sorted param names (e.g. "paged"). Empty
+-- string = feature off (the default) so existing domains are untouched: the
+-- vhost render is byte-identical when this is empty. Only GET pages whose query
+-- is entirely allowlisted (+ tracking/empty) params cache as distinct entries.
+ALTER TABLE domains
+  ADD COLUMN cache_query_allowlist VARCHAR(255) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -280,16 +281,16 @@ type Domain struct {
 	// GORM-zero-value scar as the cron default:1 fix). The DB column keeps
 	// its `DEFAULT 1` from migration 000123 for any non-API insert; the
 	// API always sets this field explicitly via DeriveMailFlags.
-	EmailEnabled    bool       `gorm:"type:tinyint(1);not null" json:"email_enabled"`
+	EmailEnabled bool `gorm:"type:tinyint(1);not null" json:"email_enabled"`
 	// WebmailEnabled (GH #316) gates the per-domain Bulwark webmail vhost,
 	// AND-ed with server_settings.webmail_enabled. Default ON.
-	WebmailEnabled  bool       `gorm:"column:webmail_enabled;type:tinyint(1);not null;default:1" json:"webmail_enabled"`
+	WebmailEnabled bool `gorm:"column:webmail_enabled;type:tinyint(1);not null;default:1" json:"webmail_enabled"`
 	// SkipAutoSAN opts the domain out of ADR-0070 auto-added mail/
 	// autoconfig SAN entries on the LE cert. Set when the tenant runs
 	// mail elsewhere (or has no mail subdomain DNS) — without this the
 	// LE challenge fails for the missing subdomain and the WHOLE cert
 	// stays pending.
-	SkipAutoSAN     bool       `gorm:"column:skip_auto_san;type:tinyint(1);not null;default:0" json:"skip_auto_san"`
+	SkipAutoSAN bool `gorm:"column:skip_auto_san;type:tinyint(1);not null;default:0" json:"skip_auto_san"`
 	// MailProvider (GH#181 / ADR-0120, migration 000166) is the single
 	// source of truth for where this domain's mail lives. EmailEnabled +
 	// SkipAutoSAN are DERIVED from it on create/edit (see
@@ -300,8 +301,8 @@ type Domain struct {
 	// M365Onmicrosoft / GoogleDKIM are optional per-provider DKIM tokens
 	// the operator pastes from the provider's admin console. Empty ->
 	// the provider's DKIM records are simply not published.
-	M365Onmicrosoft *string `gorm:"column:m365_onmicrosoft;type:varchar(255)" json:"m365_onmicrosoft,omitempty"`
-	GoogleDKIM      *string `gorm:"column:google_dkim;type:text" json:"google_dkim,omitempty"`
+	M365Onmicrosoft *string    `gorm:"column:m365_onmicrosoft;type:varchar(255)" json:"m365_onmicrosoft,omitempty"`
+	GoogleDKIM      *string    `gorm:"column:google_dkim;type:text" json:"google_dkim,omitempty"`
 	DkimSelector    *string    `gorm:"type:varchar(64)" json:"dkim_selector,omitempty"`
 	DkimPublicKey   *string    `gorm:"type:text" json:"dkim_public_key,omitempty"`
 	EmailEnabledAt  *time.Time `gorm:"type:datetime(6)" json:"email_enabled_at,omitempty"`
@@ -355,6 +356,11 @@ type Domain struct {
 	// CacheTTLSeconds (migration 000204, Gitea #596) is the per-domain page-cache
 	// validity in seconds. Default 600; the agent clamps to [10, 86400].
 	CacheTTLSeconds int `gorm:"column:cache_ttl_seconds;type:int;not null;default:600" json:"cache_ttl_seconds"`
+	// CacheQueryAllowlist (migration 000230) is the comma-joined, lower-cased,
+	// sorted set of query-param names that get their own page-cache entry
+	// (e.g. "paged" for pagination). Empty = feature off (default): every real
+	// query param bypasses, exactly as before. See CacheQueryAllowlistNames.
+	CacheQueryAllowlist string `gorm:"column:cache_query_allowlist;type:varchar(255);not null;default:''" json:"cache_query_allowlist"`
 
 	// MTA-STS per-domain opt-in (migration 000141, ADR-0109). When
 	// flipped on, the reconciler ensures:
@@ -422,3 +428,21 @@ const (
 )
 
 func (Domain) TableName() string { return "domains" }
+
+// CacheQueryAllowlistNames splits the stored comma-joined allowlist into
+// individual param names, dropping blanks. The stored value is already
+// normalized (lower-cased, de-duped, sorted) by the API on write, so this is a
+// plain split; nil/empty when the feature is off.
+func (d Domain) CacheQueryAllowlistNames() []string {
+	raw := strings.TrimSpace(d.CacheQueryAllowlist)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -116,6 +116,10 @@ func (f *fakeDomainRepo) UpdateCacheTTL(_ context.Context, _ string, _ int) erro
 	return nil
 }
 
+func (f *fakeDomainRepo) UpdateCacheQueryAllowlist(_ context.Context, _, _ string) error {
+	return nil
+}
+
 func (f *fakeDomainRepo) BulkSetEnabledByUserID(_ context.Context, _ string, _ bool) (int64, error) {
 	return 0, nil
 }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -115,6 +115,9 @@ type DomainRepository interface {
 	// UpdateCachePath writes domains.cache_path (Gitea #420).
 	UpdateCachePath(ctx context.Context, id, path string) error
 	UpdateCacheTTL(ctx context.Context, id string, seconds int) error
+	// UpdateCacheQueryAllowlist writes domains.cache_query_allowlist (migration
+	// 000230). csv is the normalized comma-joined param names ("" = off).
+	UpdateCacheQueryAllowlist(ctx context.Context, id, csv string) error
 	// UpdateSkipAutoSAN writes domains.skip_auto_san (M50 SAN opt-out).
 	// Dedicated method per [[feedback_domain_update_allowlist_silent_drop]].
 	UpdateSkipAutoSAN(ctx context.Context, id string, enabled bool) error
@@ -680,6 +683,21 @@ func (r *domainRepo) UpdateCacheTTL(ctx context.Context, id string, seconds int)
 	res := r.db.WithContext(ctx).Model(&models.Domain{}).
 		Where("id = ?", id).
 		Update("cache_ttl_seconds", seconds)
+	if res.Error != nil {
+		return translate(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateCacheQueryAllowlist writes domains.cache_query_allowlist (migration
+// 000230). Dedicated method (no Select allowlist) per the same lesson.
+func (r *domainRepo) UpdateCacheQueryAllowlist(ctx context.Context, id, csv string) error {
+	res := r.db.WithContext(ctx).Model(&models.Domain{}).
+		Where("id = ?", id).
+		Update("cache_query_allowlist", csv)
 	if res.Error != nil {
 		return translate(res.Error)
 	}


### PR DESCRIPTION
**Step 1 of 5** — cache-query-allowlist blueprint (`plans/cache-query-allowlist.md`). Lets paginated/archive GET pages (`?paged=2`) cache as distinct entries instead of bypassing. This PR is **storage + API only** — no nginx render change, **zero functional diff** (parity-safe).

## Changes
- **migration 000230**: `domains.cache_query_allowlist VARCHAR(255) NOT NULL DEFAULT ''` — comma-joined normalized param names; `''` = feature off (default), so every existing domain is untouched.
- `models.Domain.CacheQueryAllowlist` + `CacheQueryAllowlistNames()`.
- `domainRepo.UpdateCacheQueryAllowlist` — dedicated method (no Select allowlist, per the domain.Update-allowlist scar).
- `domain_cache.go` GET/PATCH expose + accept `cache_query_allowlist`; `normalizeCacheQueryAllowlist` lower-cases, validates `^[a-z0-9_]{1,32}$`, de-dups, sorts, caps at 8. `nil` = unchanged, `[]` = clear. That regex is also the guard that keeps names safe to interpolate into the Step 2 nginx regex / `$arg_<name>`.

## Tests
`TestNormalizeCacheQueryAllowlist` (valid/sorted/deduped/reject-metachar/too-many/too-long) + DomainRepository mock stubs. build + vet + api/models/repository/reconciler/cmd-server suites green.

Live `migrate up/down` runs in CI + the Step 5 box-verify (dev DB MCP unavailable locally).

Next: Step 2 (nginx render — the core), depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)