### PR TITLE
feat(cache): render per-domain query-allowlist gate + canonical key (step 2/5)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -11,6 +11,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -55,9 +56,14 @@ type domainCreateParams struct {
 	CacheBypassPaths []string `json:"cache_bypass_paths,omitempty"`
 	// CacheTTLSeconds (Gitea #596) — per-domain page-cache validity. 0 = use
 	// the default. Drives fastcgi_cache_valid; background_update keeps it fresh.
-	CacheTTLSeconds int    `json:"cache_ttl_seconds,omitempty"`
-	SSLCertPath     string `json:"ssl_cert_path"`
-	SSLKeyPath      string `json:"ssl_key_path"`
+	CacheTTLSeconds int `json:"cache_ttl_seconds,omitempty"`
+	// CacheQueryAllowlist (migration 000230): query-param names that get their
+	// own page-cache entry (e.g. "paged"). Empty ⇒ vhost byte-identical (feature
+	// off). The agent RE-sanitizes before rendering (config-injection boundary,
+	// like CacheBypassPaths).
+	CacheQueryAllowlist []string `json:"cache_query_allowlist,omitempty"`
+	SSLCertPath         string   `json:"ssl_cert_path"`
+	SSLKeyPath          string   `json:"ssl_key_path"`
 	// PHP INI overrides: omitted if not set on the domain.
 	PHPMemoryLimit       string `json:"php_memory_limit,omitempty"`
 	PHPUploadMaxFilesize string `json:"php_upload_max_filesize,omitempty"`
@@ -282,7 +288,15 @@ server {
         # strings are cacheable; $jabali_qs_kind is set by the strict map in
         # jabali-fastcgi-cache.conf. The path-only cache_key below collapses all
         # tracking variants onto the clean-URL entry.
-        if ($jabali_qs_kind = other) { set $jabali_skip 1; }
+{{if .CacheQAllowRegex}}        # cache-query-allowlist (migration 000230): only queries made ENTIRELY of
+        # allowlisted params (non-empty values) cache; any other query param
+        # bypasses. Replaces the shared qs_kind=other line for this domain. Only
+        # ever SETS skip=1 — an allowlisted page relies on the earlier no-cookie
+        # rule for skip=0, so logged-in users stay bypassed.
+        set $jabali_qs_dirty 1;
+        if ($query_string ~ "{{.CacheQAllowRegex}}") { set $jabali_qs_dirty 0; }
+        if ($query_string = "") { set $jabali_qs_dirty 0; }
+        if ($jabali_qs_dirty) { set $jabali_skip 1; }{{else}}        if ($jabali_qs_kind = other) { set $jabali_skip 1; }{{end}}
         if ($request_uri ~* "/wp-admin/|/wp-login|/xmlrpc\.php|/wp-cron\.php|/wp-json/|/cart|/checkout|/my-account|/wc-api/|/edd-api/{{.CacheExtraBypass}}") { set $jabali_skip 1; }
 {{ if ne .CacheGate "" }}        # Gitea #420/#601: cache only within the cache-enabled install path(s) on
         # this domain (union of every cached install's prefix); other (non-WP,
@@ -297,7 +311,12 @@ server {
         # Gitea #610: path-only key (no query) so tracking-param variants
         # collapse onto one entry. Safe because only empty/tracking-only queries
         # reach caching (others bypass via $jabali_qs_kind above).
-        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";
+{{if .CacheQAllowNames}}        # cache-query-allowlist: fold allowlisted args into the key in a fixed
+        # (panel-sorted) order so ?a=1&b=2 and ?b=2&a=1 collapse; non-allowlisted
+        # args never enter the key.
+        set $jabali_qkey "";
+{{range .CacheQAllowNames}}        if ($arg_{{.}}) { set $jabali_qkey "${jabali_qkey}{{.}}=$arg_{{.}}&"; }
+{{end}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
         fastcgi_cache_valid 200 301 {{.CacheTTL}};
         fastcgi_cache_bypass $jabali_skip $http_authorization;
         # GH #637: also skip STORING when the backend opted out via Cache-Control
@@ -349,7 +368,15 @@ server {
         # strings are cacheable; $jabali_qs_kind is set by the strict map in
         # jabali-fastcgi-cache.conf. The path-only cache_key below collapses all
         # tracking variants onto the clean-URL entry.
-        if ($jabali_qs_kind = other) { set $jabali_skip 1; }
+{{if .CacheQAllowRegex}}        # cache-query-allowlist (migration 000230): only queries made ENTIRELY of
+        # allowlisted params (non-empty values) cache; any other query param
+        # bypasses. Replaces the shared qs_kind=other line for this domain. Only
+        # ever SETS skip=1 — an allowlisted page relies on the earlier no-cookie
+        # rule for skip=0, so logged-in users stay bypassed.
+        set $jabali_qs_dirty 1;
+        if ($query_string ~ "{{.CacheQAllowRegex}}") { set $jabali_qs_dirty 0; }
+        if ($query_string = "") { set $jabali_qs_dirty 0; }
+        if ($jabali_qs_dirty) { set $jabali_skip 1; }{{else}}        if ($jabali_qs_kind = other) { set $jabali_skip 1; }{{end}}
         if ($request_uri ~* "/wp-admin/|/wp-login|/xmlrpc\.php|/wp-cron\.php|/wp-json/|/cart|/checkout|/my-account|/wc-api/|/edd-api/{{.CacheExtraBypass}}") { set $jabali_skip 1; }
 {{ if ne .CacheGate "" }}        # Gitea #420/#601: cache only within the cache-enabled install path(s) on
         # this domain (union of every cached install's prefix); other (non-WP,
@@ -364,7 +391,12 @@ server {
         # Gitea #610: path-only key (no query) so tracking-param variants
         # collapse onto one entry. Safe because only empty/tracking-only queries
         # reach caching (others bypass via $jabali_qs_kind above).
-        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";
+{{if .CacheQAllowNames}}        # cache-query-allowlist: fold allowlisted args into the key in a fixed
+        # (panel-sorted) order so ?a=1&b=2 and ?b=2&a=1 collapse; non-allowlisted
+        # args never enter the key.
+        set $jabali_qkey "";
+{{range .CacheQAllowNames}}        if ($arg_{{.}}) { set $jabali_qkey "${jabali_qkey}{{.}}=$arg_{{.}}&"; }
+{{end}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
         fastcgi_cache_valid 200 301 {{.CacheTTL}};
         fastcgi_cache_bypass $jabali_skip $http_authorization;
         # GH #637: also skip STORING when the backend opted out via Cache-Control
@@ -466,10 +498,15 @@ type vhostData struct {
 	// ADR-0108 FastCGI micro-cache. All three are panel/agent-controlled
 	// (never user data). When CacheEnabled is false the template emits
 	// none of the cache/static directives → byte-identical to pre-0108.
-	CacheEnabled      bool
-	CachePath         string // Gitea #420: page-cache path prefix ("/" = whole domain)
-	CacheGate         string // Gitea #601: regex body for the multi-path gate ("" = whole domain, no gate)
-	CacheExtraBypass  string // Gitea #616: "|/path|..." suffix appended to the built-in bypass regex ("" = none)
+	CacheEnabled     bool
+	CachePath        string // Gitea #420: page-cache path prefix ("/" = whole domain)
+	CacheGate        string // Gitea #601: regex body for the multi-path gate ("" = whole domain, no gate)
+	CacheExtraBypass string // Gitea #616: "|/path|..." suffix appended to the built-in bypass regex ("" = none)
+	// CacheQAllowRegex ("" = feature off ⇒ byte-identical): anchored $query_string
+	// match for allowlist-only queries. CacheQAllowNames: sorted allowlisted
+	// param names driving the canonical $arg_<name> key builder (migration 000230).
+	CacheQAllowRegex  string
+	CacheQAllowNames  []string
 	CacheKeyZone      string
 	CacheTTL          string
 	CacheTTLSeconds   int // numeric form of CacheTTL for Cache-Control max-age
@@ -626,6 +663,48 @@ func sanitizeBypassPaths(paths []string) string {
 	return "|" + strings.Join(parts, "|")
 }
 
+// cacheQueryParamRE bounds an allowlist entry at the agent trust boundary:
+// lower-case alnum + underscore, 1-32 chars — the same guard the panel applies,
+// re-checked here so a name can never carry regex metacharacters into the
+// rendered config. Mirrors the sanitizeBypassPaths fail-safe.
+var cacheQueryParamRE = regexp.MustCompile(`^[a-z0-9_]{1,32}$`)
+
+// sanitizeCacheQueryAllowlist re-validates, lower-cases, de-dups, and sorts the
+// panel-supplied allowlist. Invalid entries are dropped fail-safe. Returns the
+// surviving sorted names (nil = feature off).
+func sanitizeCacheQueryAllowlist(names []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.ToLower(strings.TrimSpace(n))
+		if !cacheQueryParamRE.MatchString(n) || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cacheQueryAllowRegex builds the anchored nginx regex that matches a query
+// string composed ONLY of allowlisted params with NON-EMPTY values, e.g.
+// `^(?:(?:paged|s)=[^&]+)(?:&(?:paged|s)=[^&]+)*$`. The value class is `[^&]+`
+// (non-empty) so it agrees with `if ($arg_<name>)` in the key builder — an
+// empty value (`?paged=`) is treated as dirty and bypasses, never colliding
+// with the base path. "" when no names (feature off). names must already be
+// sanitized (no regex metachars).
+func cacheQueryAllowRegex(names []string) string {
+	if len(names) == 0 {
+		return ""
+	}
+	alt := strings.Join(names, "|")
+	return `^(?:(?:` + alt + `)=[^&]+)(?:&(?:` + alt + `)=[^&]+)*$`
+}
+
 // buildCacheGate returns the regex BODY for the page-cache path gate
 // `^<body>(/|$)`, or "" meaning "no gate → cache the whole domain".
 //
@@ -667,9 +746,11 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, fpmSocket string) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
+	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
+	cacheQAllowRegex := cacheQueryAllowRegex(cacheQAllowNames)
 	cachePath = sanitizeCachePath(cachePath)
 	cacheTTLSeconds = clampCacheTTL(cacheTTLSeconds)
 	// GH #329: default to the legacy per-user socket when the caller didn't
@@ -733,6 +814,8 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		CachePath:                  cachePath,
 		CacheGate:                  cacheGate,
 		CacheExtraBypass:           cacheExtraBypass,
+		CacheQAllowRegex:           cacheQAllowRegex,
+		CacheQAllowNames:           cacheQAllowNames,
 		CacheKeyZone:               "jabali_fcgi",
 		CacheTTL:                   fmt.Sprintf("%ds", cacheTTLSeconds),
 		CacheTTLSeconds:            cacheTTLSeconds,
@@ -955,7 +1038,7 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 	dirPrivacyDirectives := buildDirectoryPrivacyDirectives(p.DirectoryPrivacyRules)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.FPMSocket)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_qallow_test.go
+++ b/panel-agent/internal/commands/domain_create_qallow_test.go
@@ -1,0 +1,116 @@
+package commands
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+var updateGolden = flag.Bool("update-qallow-golden", false, "rewrite the query-allowlist golden fixture")
+
+// canonicalCacheVhostData is a fixed, representative cache-enabled vhostData
+// used for the byte-identical baseline. Keep it stable — the golden captures
+// the render of THIS exact input.
+func canonicalCacheVhostData() vhostData {
+	return vhostData{
+		Domain: "example.com", DocRoot: "/home/u/public_html/example.com",
+		HasPHP: true, PHPVersion: "8.3", Username: "u", IsEnabled: true,
+		FPMSocket:    "/run/php/jabali-u/fpm.sock",
+		CacheEnabled: true, CacheKeyZone: "jabali_fcgi", CacheTTL: "600s",
+		CacheGate: "/blog", CachePath: "/",
+	}
+}
+
+func renderQAllowVhost(t *testing.T, vd vhostData) string {
+	t.Helper()
+	tmpl := template.Must(template.New("vhost").Parse(vhostTemplate))
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, vd); err != nil {
+		t.Fatal(err)
+	}
+	return b.String()
+}
+
+// TestVhostRender_NoAllowlist_ByteIdentical is the #1 backward-compat gate: with
+// an empty CacheQueryAllowlist the rendered vhost must be byte-identical to the
+// pre-feature output. Capture the baseline with:
+//
+//	go test ./internal/commands/ -run NoAllowlist_ByteIdentical -update-qallow-golden
+//
+// (run BEFORE the template gains the allowlist directives; the fixture is the
+// frozen pre-feature render). Then this test fails if any allowlist-empty render
+// drifts.
+func TestVhostRender_NoAllowlist_ByteIdentical(t *testing.T) {
+	got := renderQAllowVhost(t, canonicalCacheVhostData()) // CacheQAllow* zero-valued = feature off
+	golden := filepath.Join("testdata", "vhost_qallow_baseline.golden")
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(golden, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote golden %s (%d bytes)", golden, len(got))
+		return
+	}
+	want, err := os.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("read golden (run with -update-qallow-golden first): %v", err)
+	}
+	if got != string(want) {
+		t.Errorf("empty-allowlist render drifted from the pre-feature baseline.\n--- got ---\n%s", got)
+	}
+}
+
+// TestVhostRender_Allowlist_Paged: allowlist ["paged"] renders the dirty-query
+// gate + the canonical $arg_paged key line in the vhost, and drops the shared
+// qs_kind=other bypass line.
+func TestVhostRender_Allowlist_Paged(t *testing.T) {
+	vd := canonicalCacheVhostData()
+	vd.CacheQAllowNames = sanitizeCacheQueryAllowlist([]string{"paged"})
+	vd.CacheQAllowRegex = cacheQueryAllowRegex(vd.CacheQAllowNames)
+	out := renderQAllowVhost(t, vd)
+
+	if !strings.Contains(out, `if ($query_string ~ "^(?:(?:paged)=[^&]+)(?:&(?:paged)=[^&]+)*$")`) {
+		t.Error("missing dirty-query gate for allowlist paged")
+	}
+	if !strings.Contains(out, `if ($arg_paged) { set $jabali_qkey "${jabali_qkey}paged=$arg_paged&"; }`) {
+		t.Error("missing canonical $arg_paged key line")
+	}
+	if !strings.Contains(out, `fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey"`) {
+		t.Error("cache key must append the allowlisted-query suffix")
+	}
+	if strings.Contains(out, "if ($jabali_qs_kind = other) { set $jabali_skip 1; }") {
+		t.Error("allowlist mode must REPLACE the shared qs_kind=other bypass line")
+	}
+	// Both cache blocks (root + subdir) must carry the gate — expect the dirty
+	// test to appear at least twice (or the subdir block absent for this input;
+	// this input renders only the root block, so >=1).
+	if n := strings.Count(out, "set $jabali_qs_dirty 1;"); n < 1 {
+		t.Errorf("dirty gate rendered %d times, want >=1", n)
+	}
+}
+
+// TestVhostRender_Allowlist_SortedCanonical: names render in sorted order so the
+// key is deterministic regardless of client param order.
+func TestVhostRender_Allowlist_SortedCanonical(t *testing.T) {
+	vd := canonicalCacheVhostData()
+	vd.CacheQAllowNames = sanitizeCacheQueryAllowlist([]string{"s", "paged"})
+	vd.CacheQAllowRegex = cacheQueryAllowRegex(vd.CacheQAllowNames)
+	out := renderQAllowVhost(t, vd)
+	ip := strings.Index(out, "paged=$arg_paged")
+	is := strings.Index(out, "s=$arg_s")
+	if ip < 0 || is < 0 {
+		t.Fatalf("both key lines must render (paged=%d s=%d)", ip, is)
+	}
+	if ip > is {
+		t.Error("key lines must be in sorted order: paged before s")
+	}
+	if !strings.Contains(out, "(?:paged|s)=[^&]+") {
+		t.Error("gate regex alternation must be sorted: paged|s")
+	}
+}

--- a/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
+++ b/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
@@ -1,0 +1,235 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name example.com www.example.com;
+
+    # ACME HTTP-01 webroot. Must be a location block — a server-level
+    # redirect fires in nginx SERVER_REWRITE phase BEFORE FIND_CONFIG,
+    # so a server-scoped redirect short-circuits every request
+    # including /.well-known/acme-challenge/, and Let's Encrypt's
+    # challenge fetch bounces to https where LE refuses to follow.
+    # Scoping the redirect to a location block instead pushes it into
+    # the per-location REWRITE phase, after FIND_CONFIG has had a
+    # chance to pick the ^~ ACME match. Webroot mirrors
+    # panel-api/internal/reconciler.IssueDomainCert (-w domain.DocRoot).
+    # Incident 2026-04-26: jabali.site stuck in pending_acme_retry on
+    # first VPS install — first under the no-ACME-location vhost, then
+    # again after we added the location but kept the server-scoped
+    # redirect that won the rewrite race.
+    location ^~ /.well-known/acme-challenge/ {
+        default_type "text/plain";
+        root /home/u/public_html/example.com;
+        try_files $uri =404;
+        # M50: if Directory Privacy with path "/" applied auth_basic at
+        # server scope, override here so the ACME validator can reach
+        # the challenge token without a 401.
+        auth_basic off;
+    }
+
+
+
+    root /home/u/public_html/example.com;
+    
+
+    
+    
+
+
+    location / {
+
+        try_files $uri $uri/ /index.php?$query_string;
+
+    }
+
+    # Branded error pages (M28 page templates). error_page fires ONLY on
+    # NATIVE nginx errors: a missing static file (try_files =404), a denied
+    # directory (403), or an upstream 50x. fastcgi_intercept_errors is
+    # deliberately OFF, so a real app (WordPress, etc.) keeps its own 404
+    # — its index.php runs and owns the response. A no-app PHP domain hits
+    # the index.php existence guard below, which yields a
+    # native 404 that lands here. Files are converged from the editable
+    # page_template rows into /var/www/jabali-errors by the reconciler.
+    error_page 404 /jabali-err-404.html;
+    error_page 403 /jabali-err-403.html;
+    error_page 500 502 503 504 /jabali-err-500.html;
+    location = /jabali-err-404.html { internal; root /var/www/jabali-errors; }
+    location = /jabali-err-403.html { internal; root /var/www/jabali-errors; }
+    location = /jabali-err-500.html { internal; root /var/www/jabali-errors; }
+
+
+    # Long-cache static assets (immutable content; 30 days).
+    location ~* \.(?:css|js|jpe?g|png|gif|ico|svg|webp|woff2?|ttf|eot)$ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+    # Short-cache static HTML (300s / 5 min). Long enough to satisfy
+    # third-party freshness audits, short enough that edits surface
+    # within minutes; ETag + Last-Modified still give instant 304
+    # revalidation on unchanged content. PHP responses use the
+    # separate FastCGI micro-cache (60s) below, not this block.
+    # Without this, a domain with cache_enabled=true but a static
+    # site (no PHP) responds with no Cache-Control header at all —
+    # third-party caching audits (e.g. requestmetrics.com) flag
+    # "no Cache-Control" + "heuristic freshness" warnings even
+    # though caching IS enabled on the domain. PHP responses still
+    # get the server-side FastCGI cache via the location ~ \.php$
+    # block below (with X-Jabali-Cache header). Plain HTML hits
+    # only this; it does not enable server-side caching.
+    location ~* \.html?$ {
+        expires 5m;
+        add_header Cache-Control "public, max-age=300" always;
+    }
+
+
+    # Front-controller with an existence guard: when index.php is absent
+    # (domain has no app installed) try_files yields a native 404 instead
+    # of PHP-FPM's bare "File not found", so the branded error_page shows.
+    # When it exists the app runs and owns its own error pages.
+    location = /index.php {
+        try_files $uri =404;
+        fastcgi_pass unix:/run/php/jabali-u/fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+
+
+        # Fail-CLOSED page-cache gate (Gitea #416/#419): cache ONLY genuinely
+        # anonymous GETs. Default to skip; allow only when there is NO cookie or
+        # the cookie is exclusively known-benign analytics/consent. Auth, session,
+        # language, currency, membership, A/B, and any unknown cookie therefore
+        # bypass — so a member/paywall page or the wrong i18n/device variant is
+        # never stored and served cross-visitor (the old denylist was fail-open).
+        set $jabali_skip 1;
+        if ($http_cookie = "") { set $jabali_skip 0; }
+        if ($http_cookie ~* "^(?:\s*(?:_ga[\w-]*|_gid|_gat[\w-]*|_gcl[\w-]*|__utm[\w-]*|__gads|__gpi|_fbp|_fbc|_pk_[\w-]*|_hj[\w-]*|_clck|_clsk|_dc_gtm[\w-]*|cookie_consent[\w-]*|cookie_?notice[\w-]*|cookielawinfo[\w-]*|euconsent[\w-]*|wordpress_test_cookie)=[^;]*;?\s*)+$") { set $jabali_skip 0; }
+        if ($request_method = POST) { set $jabali_skip 1; }
+        # Gitea #610: bypass only when the query has a non-tracking (content-
+        # affecting) param. Tracking-only (utm_*/gclid/fbclid/…) and empty query
+        # strings are cacheable; $jabali_qs_kind is set by the strict map in
+        # jabali-fastcgi-cache.conf. The path-only cache_key below collapses all
+        # tracking variants onto the clean-URL entry.
+        if ($jabali_qs_kind = other) { set $jabali_skip 1; }
+        if ($request_uri ~* "/wp-admin/|/wp-login|/xmlrpc\.php|/wp-cron\.php|/wp-json/|/cart|/checkout|/my-account|/wc-api/|/edd-api/") { set $jabali_skip 1; }
+        # Gitea #420/#601: cache only within the cache-enabled install path(s) on
+        # this domain (union of every cached install's prefix); other (non-WP,
+        # differently-authed) apps on the same domain are never cached.
+        # Gate on $jabali_cache_path — the ORIGINAL request path with the query
+        # stripped (Codeberg #5). $uri would be /index.php after the try_files
+        # rewrite (collapsing every permalink); $request_uri keeps the query which
+        # broke the subdir homepage anchor (GH #629). $jabali_cache_path fixes both
+        # and mirrors the cache_key below.
+        if ($jabali_cache_path !~ "^/blog(/|$)") { set $jabali_skip 1; }
+        fastcgi_cache jabali_fcgi;
+        # Gitea #610: path-only key (no query) so tracking-param variants
+        # collapse onto one entry. Safe because only empty/tracking-only queries
+        # reach caching (others bypass via $jabali_qs_kind above).
+        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";
+        fastcgi_cache_valid 200 301 600s;
+        fastcgi_cache_bypass $jabali_skip $http_authorization;
+        # GH #637: also skip STORING when the backend opted out via Cache-Control
+        # (no-cache/no-store/private). $jabali_upstream_nocache is set by the map
+        # in jabali-fastcgi-cache.conf from $upstream_http_cache_control.
+        fastcgi_no_cache $jabali_skip $jabali_upstream_nocache $http_authorization $jabali_vary_nocache;
+        fastcgi_cache_use_stale error timeout updating http_500 http_503;
+        fastcgi_cache_lock on;
+        # Gitea #596: serve the stale copy instantly (~100ms) on expiry and
+        # refresh in the background, instead of blocking the visitor on the
+        # full synchronous PHP regen. Pairs with use_stale ... updating above.
+        fastcgi_cache_background_update on;
+        fastcgi_cache_revalidate on;
+        access_log /var/log/nginx/jcache-example.com.log jcache buffer=8k flush=5s;
+        add_header X-Jabali-Cache $upstream_cache_status always;
+        # JAB-70: re-declare security headers (a location's add_header suppresses
+        # server-scope ones).
+        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        # Do NOT advertise public/CDN caching for dynamic PHP responses (Gitea
+        # #417): the origin micro-cache is purgeable but browser/CDN copies are
+        # not, and a skip-miss must never be amplified to Cloudflare scale. The
+        # speedup is the server-side micro-cache only; clients always revalidate.
+        fastcgi_hide_header Cache-Control;
+        add_header Cache-Control "private, no-cache, max-age=0" always;
+
+    }
+    location ~ \.php$ {
+        fastcgi_pass unix:/run/php/jabali-u/fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+
+
+        # Fail-CLOSED page-cache gate (Gitea #416/#419): cache ONLY genuinely
+        # anonymous GETs. Default to skip; allow only when there is NO cookie or
+        # the cookie is exclusively known-benign analytics/consent. Auth, session,
+        # language, currency, membership, A/B, and any unknown cookie therefore
+        # bypass — so a member/paywall page or the wrong i18n/device variant is
+        # never stored and served cross-visitor (the old denylist was fail-open).
+        set $jabali_skip 1;
+        if ($http_cookie = "") { set $jabali_skip 0; }
+        if ($http_cookie ~* "^(?:\s*(?:_ga[\w-]*|_gid|_gat[\w-]*|_gcl[\w-]*|__utm[\w-]*|__gads|__gpi|_fbp|_fbc|_pk_[\w-]*|_hj[\w-]*|_clck|_clsk|_dc_gtm[\w-]*|cookie_consent[\w-]*|cookie_?notice[\w-]*|cookielawinfo[\w-]*|euconsent[\w-]*|wordpress_test_cookie)=[^;]*;?\s*)+$") { set $jabali_skip 0; }
+        if ($request_method = POST) { set $jabali_skip 1; }
+        # Gitea #610: bypass only when the query has a non-tracking (content-
+        # affecting) param. Tracking-only (utm_*/gclid/fbclid/…) and empty query
+        # strings are cacheable; $jabali_qs_kind is set by the strict map in
+        # jabali-fastcgi-cache.conf. The path-only cache_key below collapses all
+        # tracking variants onto the clean-URL entry.
+        if ($jabali_qs_kind = other) { set $jabali_skip 1; }
+        if ($request_uri ~* "/wp-admin/|/wp-login|/xmlrpc\.php|/wp-cron\.php|/wp-json/|/cart|/checkout|/my-account|/wc-api/|/edd-api/") { set $jabali_skip 1; }
+        # Gitea #420/#601: cache only within the cache-enabled install path(s) on
+        # this domain (union of every cached install's prefix); other (non-WP,
+        # differently-authed) apps on the same domain are never cached.
+        # Gate on $jabali_cache_path — the ORIGINAL request path with the query
+        # stripped (Codeberg #5). $uri would be /index.php after the try_files
+        # rewrite (collapsing every permalink); $request_uri keeps the query which
+        # broke the subdir homepage anchor (GH #629). $jabali_cache_path fixes both
+        # and mirrors the cache_key below.
+        if ($jabali_cache_path !~ "^/blog(/|$)") { set $jabali_skip 1; }
+        fastcgi_cache jabali_fcgi;
+        # Gitea #610: path-only key (no query) so tracking-param variants
+        # collapse onto one entry. Safe because only empty/tracking-only queries
+        # reach caching (others bypass via $jabali_qs_kind above).
+        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";
+        fastcgi_cache_valid 200 301 600s;
+        fastcgi_cache_bypass $jabali_skip $http_authorization;
+        # GH #637: also skip STORING when the backend opted out via Cache-Control
+        # (no-cache/no-store/private). $jabali_upstream_nocache is set by the map
+        # in jabali-fastcgi-cache.conf from $upstream_http_cache_control.
+        fastcgi_no_cache $jabali_skip $jabali_upstream_nocache $http_authorization $jabali_vary_nocache;
+        fastcgi_cache_use_stale error timeout updating http_500 http_503;
+        fastcgi_cache_lock on;
+        # Gitea #596: serve the stale copy instantly (~100ms) on expiry and
+        # refresh in the background, instead of blocking the visitor on the
+        # full synchronous PHP regen. Pairs with use_stale ... updating above.
+        fastcgi_cache_background_update on;
+        fastcgi_cache_revalidate on;
+        access_log /var/log/nginx/jcache-example.com.log jcache buffer=8k flush=5s;
+        add_header X-Jabali-Cache $upstream_cache_status always;
+        # JAB-70: re-declare security headers (a location's add_header suppresses
+        # server-scope ones).
+        add_header Strict-Transport-Security "max-age=31536000" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        # Do NOT advertise public/CDN caching for dynamic PHP responses (Gitea
+        # #417): the origin micro-cache is purgeable but browser/CDN copies are
+        # not, and a skip-miss must never be amplified to Cloudflare scale. The
+        # speedup is the server-side micro-cache only; clients always revalidate.
+        fastcgi_hide_header Cache-Control;
+        add_header Cache-Control "private, no-cache, max-age=0" always;
+
+    }
+
+
+    access_log /var/log/nginx/example.com-access.log;
+    error_log /var/log/nginx/example.com-error.log;
+
+    # Per-install rewrites (e.g. Drupal/Joomla subdir pretty-URL routing).
+    # Written by the per-CMS install handler; reloaded on install/delete.
+    # nginx tolerates a missing directory here — no file = no include.
+    include /etc/nginx/jabali/example.com/*.conf;
+
+    
+    
+    
+    
+
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1451,6 +1451,13 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 		"cache_ttl_seconds": domain.CacheTTLSeconds,
 	}
 
+	// cache-query-allowlist: param names that get their own cache entry
+	// (e.g. "paged"). Omitted when empty so opt-out domains send a
+	// byte-identical payload and the agent renders the unchanged vhost.
+	if names := domain.CacheQueryAllowlistNames(); len(names) > 0 {
+		params["cache_query_allowlist"] = names
+	}
+
 	// GH #601: a domain can host several cache-enabled installs (e.g. / and
 	// /blog); the page-cache gate must allow EVERY one's path prefix, not just
 	// the single denormalized cache_path. Gather them and pass cache_paths;


### PR DESCRIPTION
**Step 2 of 5** — the nginx render (the core). **Stacked on #543 (step 1)** — base is the step-1 branch, so this PR shows only the step-2 diff; retarget to `main` after #543 merges.

## Agent (`domain_create.go`)
- Wire field `CacheQueryAllowlist` (json `cache_query_allowlist`).
- `sanitizeCacheQueryAllowlist` — re-validates `^[a-z0-9_]{1,32}$`, dedups, sorts at the config-injection trust boundary (mirrors `sanitizeBypassPaths`); `cacheQueryAllowRegex` — anchored `^(?:(?:paged|…)=[^&]+)(?:&…)*$` (`[^&]+` non-empty to agree with `if ($arg_x)`).
- `vhostData.CacheQAllowRegex`/`CacheQAllowNames`, threaded through `writeVhost`.
- **Both** cache location blocks (root + subdir), inline-guarded so an **empty allowlist renders byte-identical to today**: replaces the shared `if ($jabali_qs_kind = other)` bypass with a per-domain `$jabali_qs_dirty` gate (only ever sets `skip=1`; relies on the earlier no-cookie rule for `skip=0` → logged-in stays bypassed), and appends a canonical `$jabali_qkey` suffix built from `$arg_<name>` in sorted order.

## Panel (`reconciler.go`)
Sends `cache_query_allowlist` in the `domain.create` payload **only when non-empty** — opt-out domains send a byte-identical payload.

## Tests
- `TestVhostRender_NoAllowlist_ByteIdentical` — golden fixture, the #1 backward-compat gate (captured from the pre-feature template).
- `_Allowlist_Paged`, `_Allowlist_SortedCanonical`. Full commands + reconciler suites green.
- `nginx -t` validation lands in step 5 (box-verify on testserver).

Not user-reachable until step 4 (UI) + step 5. Opt-in, default off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)