### PR TITLE
fix(cache): purge-safe query-allowlist key + purge coverage (step 3/5)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -316,7 +316,14 @@ server {
         # args never enter the key.
         set $jabali_qkey "";
 {{range .CacheQAllowNames}}        if ($arg_{{.}}) { set $jabali_qkey "${jabali_qkey}{{.}}=$arg_{{.}}&"; }
-{{end}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
+{{end}}        # Only add the "?" separator when an allowlisted arg is actually present,
+        # so a query-less page keys as plain $jabali_cache_path (byte-identical to
+        # the non-allowlist key AND targeted-purge-safe — post-edit purge computes
+        # md5(scheme+method+host+path) with no trailing "?"). Query variants are
+        # cleared by whole-domain purge (host-match) or TTL, not targeted purge.
+        set $jabali_qsep "";
+        if ($jabali_qkey != "") { set $jabali_qsep "?"; }
+        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path$jabali_qsep$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
         fastcgi_cache_valid 200 301 {{.CacheTTL}};
         fastcgi_cache_bypass $jabali_skip $http_authorization;
         # GH #637: also skip STORING when the backend opted out via Cache-Control
@@ -396,7 +403,14 @@ server {
         # args never enter the key.
         set $jabali_qkey "";
 {{range .CacheQAllowNames}}        if ($arg_{{.}}) { set $jabali_qkey "${jabali_qkey}{{.}}=$arg_{{.}}&"; }
-{{end}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
+{{end}}        # Only add the "?" separator when an allowlisted arg is actually present,
+        # so a query-less page keys as plain $jabali_cache_path (byte-identical to
+        # the non-allowlist key AND targeted-purge-safe — post-edit purge computes
+        # md5(scheme+method+host+path) with no trailing "?"). Query variants are
+        # cleared by whole-domain purge (host-match) or TTL, not targeted purge.
+        set $jabali_qsep "";
+        if ($jabali_qkey != "") { set $jabali_qsep "?"; }
+        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path$jabali_qsep$jabali_qkey";{{else}}        fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path";{{end}}
         fastcgi_cache_valid 200 301 {{.CacheTTL}};
         fastcgi_cache_bypass $jabali_skip $http_authorization;
         # GH #637: also skip STORING when the backend opted out via Cache-Control

--- a/panel-agent/internal/commands/domain_create_qallow_test.go
+++ b/panel-agent/internal/commands/domain_create_qallow_test.go
@@ -81,8 +81,13 @@ func TestVhostRender_Allowlist_Paged(t *testing.T) {
 	if !strings.Contains(out, `if ($arg_paged) { set $jabali_qkey "${jabali_qkey}paged=$arg_paged&"; }`) {
 		t.Error("missing canonical $arg_paged key line")
 	}
-	if !strings.Contains(out, `fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path?$jabali_qkey"`) {
-		t.Error("cache key must append the allowlisted-query suffix")
+	if !strings.Contains(out, `fastcgi_cache_key "$scheme$request_method$host$jabali_cache_path$jabali_qsep$jabali_qkey"`) {
+		t.Error("cache key must append the allowlisted-query suffix via $jabali_qsep")
+	}
+	// The "?" separator is conditional so a query-less page keys as plain
+	// $jabali_cache_path — targeted-purge-safe + byte-identical base key.
+	if !strings.Contains(out, `if ($jabali_qkey != "") { set $jabali_qsep "?"; }`) {
+		t.Error("missing conditional query separator (base page must stay purge-safe)")
 	}
 	if strings.Contains(out, "if ($jabali_qs_kind = other) { set $jabali_skip 1; }") {
 		t.Error("allowlist mode must REPLACE the shared qs_kind=other bypass line")

--- a/panel-agent/internal/commands/nginx_cache_purge_host_test.go
+++ b/panel-agent/internal/commands/nginx_cache_purge_host_test.go
@@ -7,10 +7,14 @@ func TestKeyLineHost(t *testing.T) {
 	cases := []struct{ line, want string }{
 		{"KEY: httpsGETa.com/path", "a.com"},
 		{"KEY: httpGETa.com/", "a.com"},
-		{"KEY: httpsHEADsub.a.com/x", "sub.a.com"},   // must NOT be "a.com"
-		{"KEY: httpsGETmya.com/", "mya.com"},          // must NOT be "a.com"
+		{"KEY: httpsHEADsub.a.com/x", "sub.a.com"},         // must NOT be "a.com"
+		{"KEY: httpsGETmya.com/", "mya.com"},               // must NOT be "a.com"
 		{"KEY: httpsGETvictim.com/go/a.com", "victim.com"}, // path contains a.com
 		{"KEY: httpsPOSTa.com/cart", "a.com"},
+		// cache-query-allowlist: query-variant entries carry a "?paged=2&" suffix
+		// after the path — whole-domain purge must still extract the host so those
+		// variants are evicted alongside the base page.
+		{"KEY: httpsGETa.com/blog?paged=2&", "a.com"},
 	}
 	for _, c := range cases {
 		if got := keyLineHost([]byte(c.line)); got != c.want {


### PR DESCRIPTION
**Step 3 of 5** — reconcile + purge correctness. Base `main` (steps 1+2 already merged).

## The fix
Step 2 appended `?$jabali_qkey` **unconditionally**, so an allowlist domain's *query-less* page keyed as `path?` (trailing `?`). Targeted post-edit purge computes `md5(scheme+method+host+path)` with **no** `?`, so it would have **missed the base page**.

Now a conditional `$jabali_qsep` adds the `?` **only when an allowlisted arg is present**, so a query-less page keys as plain `$jabali_cache_path` — byte-identical to the non-allowlist key **and** targeted-purge-safe. Query variants (`path?paged=2&`) are cleared by whole-domain purge (host-match) or TTL, not targeted purge — a documented v1 limitation.

## Coverage
- `TestKeyLineHost` gains a query-variant KEY (`…a.com/blog?paged=2&`) proving whole-domain purge still extracts the host and evicts the variant.
- Render test asserts the conditional separator + new key shape.
- Reconcile-on-change already covered: `domain_cache.go` update schedules a reconcile after persisting the allowlist → re-renders the vhost.

Empty-allowlist golden stays byte-identical (qsep only in the allowlist branch). Full commands + api suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)