### PR TITLE
feat(mail): expose Send-only toggle in Edit mailbox (GH #528)

### DIFF
--- a/panel-ui/src/components/mail/EditMailboxModal.tsx
+++ b/panel-ui/src/components/mail/EditMailboxModal.tsx
@@ -22,6 +22,7 @@ type FormValues = {
   display_name: string;
   quota_mib: number;
   enabled: boolean;
+  send_only: boolean;
 };
 
 export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalProps) {
@@ -35,6 +36,7 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
         display_name: mailbox.display_name ?? "",
         quota_mib: Math.round(mailbox.quota_bytes / MIB),
         enabled: !mailbox.is_disabled,
+        send_only: mailbox.send_only ?? false,
       });
     }
   }, [open, mailbox, form]);
@@ -48,6 +50,7 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
       display_name?: string;
       quota_bytes?: number;
       is_disabled?: boolean;
+      send_only?: boolean;
     } = { id: mailbox.id, domainId: mailbox.domain_id };
 
     const nextName = (v.display_name ?? "").trim();
@@ -59,10 +62,14 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
     const nextDisabled = !v.enabled;
     if (nextDisabled !== mailbox.is_disabled) patch.is_disabled = nextDisabled;
 
+    const nextSendOnly = !!v.send_only;
+    if (nextSendOnly !== mailbox.send_only) patch.send_only = nextSendOnly;
+
     if (
       patch.display_name === undefined &&
       patch.quota_bytes === undefined &&
-      patch.is_disabled === undefined
+      patch.is_disabled === undefined &&
+      patch.send_only === undefined
     ) {
       onClose();
       return;
@@ -107,6 +114,14 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
           <InputNumber min={QUOTA_MIN_MIB} max={1024 * 1024} step={256} style={{ width: 200 }} />
         </Form.Item>
         <Form.Item label="Enabled" name="enabled" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+        <Form.Item
+          label="Send-only (SMTP submission, no inbox)"
+          name="send_only"
+          valuePropName="checked"
+          tooltip="A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials. Toggling this on discards inbound delivery; existing stored mail is not deleted."
+        >
           <Switch />
         </Form.Item>
         <Typography.Text type="secondary" style={{ fontSize: 12 }}>

--- a/panel-ui/src/hooks/useMailboxes.ts
+++ b/panel-ui/src/hooks/useMailboxes.ts
@@ -300,15 +300,17 @@ export function useUpdateMailbox(): UseMutationResult<
     display_name?: string;
     quota_bytes?: number;
     is_disabled?: boolean;
+    send_only?: boolean;
   }
 > {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, display_name, quota_bytes, is_disabled }) => {
+    mutationFn: async ({ id, display_name, quota_bytes, is_disabled, send_only }) => {
       const body: Record<string, unknown> = {};
       if (display_name !== undefined) body.display_name = display_name;
       if (quota_bytes !== undefined) body.quota_bytes = quota_bytes;
       if (is_disabled !== undefined) body.is_disabled = is_disabled;
+      if (send_only !== undefined) body.send_only = send_only;
       const { data } = await apiClient.patch<Mailbox>(`/mailboxes/${id}`, body);
       return data;
     },


### PR DESCRIPTION
## Gap
`send_only` was settable only at **create** time (CreateMailboxWizardModal). The **Edit Mailbox** modal couldn't change it, so you couldn't switch an existing mailbox to/from send-only.

## Change (UI + hook only)
- `EditMailboxModal`: add the **Send-only (SMTP submission, no inbox)** toggle, loaded from the mailbox and included in the only-changed-fields PATCH dirty check.
- `useUpdateMailbox`: thread `send_only` through the partial PATCH body.

## Backend already supports it
- `PATCH /mailboxes/:id` accepts `send_only` and applies it via `SetSendOnly`.
- Stalwart's recipient query filters `AND m.send_only = 0` **live from the DB**, so toggling takes effect immediately — no reconcile/agent action.

tsc + eslint + `useMailboxes` tests green. Existing stored mail isn't deleted when toggling on (tooltip says so).

🤖 Generated with [Claude Code](https://claude.com/claude-code)