### PR TITLE
fix(migrate): create mailbox rows before the JMAP push so mail imports (GH #530)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -166,6 +166,20 @@ func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.
 		res.Skipped = append(res.Skipped, "mailbox_skip:no_job_id_for_agent_dispatch")
 		return res, nil
 	}
+
+	// GH #530: create the panel mailbox rows BEFORE the JMAP push. Stalwart
+	// resolves accounts live from the mailboxes table, so the per-message
+	// Email/import must target accounts that ALREADY exist — otherwise every
+	// message lands on a not-yet-created account and silently drops
+	// (messages_found>0 but messages_pushed=0). Rows first, then import into
+	// them. (Re-running the migration used to "fix" it precisely because the
+	// prior run had by then created the rows.)
+	if mbRepo != nil && domainsRepo != nil {
+		res.Skipped = append(res.Skipped, insertMailboxPanelRows(ctx, mailRoot, parsed.OwnerEmail, preserveCreds, mbRepo, domainsRepo, res)...)
+	}
+
+	// Agent path: hand the mail subtree to migration.import_mailboxes
+	// which handles per-message Blob/upload + Email/import via JMAP.
 	raw, err := agentCli.Call(ctx, "migration.import_mailboxes", map[string]any{
 		"job_id":       jobID,
 		"src_mail_dir": mailRoot,
@@ -188,13 +202,6 @@ func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.
 	res.BytesPushed = ag.BytesImported
 	if len(ag.Skipped) > 0 {
 		res.Skipped = append(res.Skipped, ag.Skipped...)
-	}
-
-	// Insert panel mailboxes rows for every Maildir the agent imported.
-	// Without these rows the UI and API are blind to the mailboxes even
-	// though Stalwart holds the actual data.
-	if mbRepo != nil && domainsRepo != nil {
-		res.Skipped = append(res.Skipped, insertMailboxPanelRows(ctx, mailRoot, parsed.OwnerEmail, preserveCreds, mbRepo, domainsRepo, res)...)
 	}
 
 	return res, nil


### PR DESCRIPTION
## Bug
HestiaCP (and any offline) migration found the maildir messages but pushed **0** of them. `ImportMailboxes` ran the agent JMAP `Email/import` **first** and created the panel mailbox rows **afterwards**. Stalwart resolves accounts live from the `mailboxes` table, so every message targeted a not-yet-created account and silently dropped — `messages_found=1, messages_pushed=0`. Re-running the migration appeared to 'fix' it only because the prior run had by then created the rows.

## Root-cause (reproduced on .86 with johnnyq's hestia-sample.tar)
- 1st run: `messages_found=1 messages_pushed=0 bytes_pushed=0` → DEGRADED.
- Re-run (account now exists): `messages_pushed=1 bytes_pushed=2805`. Confirmed pure ordering.

## Fix
Move `insertMailboxPanelRows` to run **before** `migration.import_mailboxes`, so the accounts exist when the messages import.

## Verified
Clean single run after the fix: `messages_found=1 messages_pushed=1 bytes_pushed=2805`, no degraded. Existing cpanel migrate tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)