### PR TITLE
fix(install): guard converge_pdns_masking DB query so fresh installs survive (GH #545, #544)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3301,8 +3301,15 @@ converge_pdns_masking() {
   # install where the settings row doesn't exist yet.
   local dns_on=1 db_val=""
   if command -v mariadb >/dev/null 2>&1; then
+    # `|| true` is load-bearing: on a FRESH install the server_settings table
+    # doesn't exist yet (panel migrations run much later), so this query exits
+    # non-zero. Under `set -e` + the __on_err trap a bare command-substitution
+    # assignment would kill the installer silently right after the Redis step
+    # (GH #545/#544: "Install failed, exit status 1", log ending at Redis). The
+    # `|| true` makes the substitution succeed with empty output → the
+    # fresh-install fallback (is_module_enabled) below takes over.
     db_val="$(mariadb jabali_panel -N -B -e \
-      "SELECT dns_enabled FROM server_settings WHERE id=1;" 2>/dev/null)"
+      "SELECT dns_enabled FROM server_settings WHERE id=1;" 2>/dev/null || true)"
   fi
   if [[ -n "$db_val" ]]; then
     [[ "$db_val" == "0" ]] && dns_on=0


### PR DESCRIPTION
## Critical: every fresh install was aborting silently
Reporters (#545, #544) hit "Install failed, exit status 1" with the log ending at "Redis ACLs configured" and no error. Root-caused on a fresh Debian 13 box:

`converge_pdns_masking` reads the DNS module state from `server_settings`. On a **fresh** install that table doesn't exist yet (panel migrations run much later), so the query exits non-zero. It's a **bare command-substitution assignment**, so under `set -e` + the `__on_err` ERR trap it kills the installer — right after Redis, **before PowerDNS is ever configured**. The pdns "no backends configured" journal lines reporters saw were downstream noise (install died before `install_powerdns`).

## Fix
Add `|| true` inside the substitution — matching the already-correct sibling `reconstruct_server_env_from_db` (line 411). A missing table now yields empty output and the `is_module_enabled` fresh-install fallback takes over. This was the **lone** unguarded query of the pattern; the other four DB reads already had the guard.

## Verified on a fresh box
- Without the fix: `set -e` kills a bare `var="$(mariadb ... server_settings ...)"` (repro'd directly).
- With the fix: the run clears the DNS step — **pdns + pdns-recursor come up, self-zone created**, install continues to CrowdSec, far past where it died for every reporter.
- `bash` syntax validated.

Note: the DNS auto-heal (#550) is still valid for genuinely locked-down VPS, but THIS is the blocker that was making people ditch the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
