### PR TITLE
test(nginxgate): isolate nginx -t gate from runner filesystem perms

### DIFF
--- a/panel-api/internal/htaccess/nginxgate_test.go
+++ b/panel-api/internal/htaccess/nginxgate_test.go
@@ -40,10 +40,20 @@ Allow from 203.0.113.0/24`
 		t.Fatalf("compiler produced empty output for %d rules", len(r.Rules))
 	}
 
-	conf := "events {}\nhttp {\n  server {\n    listen 8081;\n    server_name _;\n" +
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "nginx.pid")
+
+	// Point error_log at stderr, pid into the test's temp dir, and turn
+	// access_log off. Without these, `nginx -t` falls back to the compiled
+	// defaults (/var/log/nginx/error.log, /run/nginx.pid, /var/log/nginx/
+	// access.log), which an unprivileged CI runner cannot open -- nginx then
+	// prints "syntax is ok" but still exits 1, false-failing this gate. The
+	// config being validated is fine; this only isolates the test from the
+	// runner's filesystem permissions (chronic self-hosted-runner flake).
+	conf := "error_log stderr;\npid " + pidPath + ";\n" +
+		"events {}\nhttp {\n  access_log off;\n  server {\n    listen 8081;\n    server_name _;\n" +
 		directives + "  }\n}\n"
 
-	dir := t.TempDir()
 	confPath := filepath.Join(dir, "nginx.conf")
 	if err := os.WriteFile(confPath, []byte(conf), 0o644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes the chronic CI red on `Go tests + vet -> go test -race`: `TestCompiledOutputPassesNginxT` false-fails on every PR (forcing `--admin` merges).

## Root cause
The test builds a minimal nginx config with **no** `error_log`, `pid`, or `access_log` directive, so `nginx -t` falls back to the compiled defaults (`/var/log/nginx/error.log`, `/run/nginx.pid`, `/var/log/nginx/access.log`). On the unprivileged self-hosted runner those are not writable:
```
nginx: the configuration file ... syntax is ok        <- config is valid
nginx: [alert] could not open error log file: .../var/log/nginx/error.log (13: Permission denied)
[emerg] open() "/run/nginx.pid" failed (13: Permission denied)
```
Syntax OK, but `-t` exits 1 on the pid open -> gate reds.

## Fix
Point `error_log` at stderr, `pid` into the test `t.TempDir()`, and `access_log off`, so `nginx -t` never touches a runner-owned path. The config being validated is unchanged; this only isolates the test from the runner filesystem.

## Verified
On a box as an unprivileged user (`nobody`, `/var/log/nginx` confirmed not writable — the exact runner condition): `--- PASS: TestCompiledOutputPassesNginxT`. Previously failed there with the permission-denied above.

## Test plan
- [x] `go vet ./internal/htaccess/`
- [x] Compiles (`go test -c`)
- [x] PASS as non-root with unwritable /var/log/nginx