### PR TITLE
fix(files): new files land group www-data, not the user's own group (GH #533)

### DIFF
--- a/panel-agent/internal/commands/files_write.go
+++ b/panel-agent/internal/commands/files_write.go
@@ -131,6 +131,17 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}
 		uid, _ := strconv.Atoi(u.Uid)
 		gid, _ := strconv.Atoi(u.Gid)
+		// New files under the docroot must be group www-data so nginx (running
+		// as www-data) can serve them via the 0640 group-read bit set below; the
+		// user's own primary group would leave them unreadable AND surface to the
+		// operator as "User:User" instead of "User:www-data" (GH #533). Mirror
+		// files.mkdir / files.extract (hostingIDs): keep the user's gid only if
+		// www-data is somehow absent.
+		if g, gerr := user.LookupGroup("www-data"); gerr == nil {
+			if wgid, werr := strconv.Atoi(g.Gid); werr == nil {
+				gid = wgid
+			}
+		}
 
 		// Generate temp filename with random suffix
 		randBytes := make([]byte, 8)

--- a/panel-agent/internal/commands/files_write_test.go
+++ b/panel-agent/internal/commands/files_write_test.go
@@ -3,7 +3,13 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -119,5 +125,55 @@ func TestFilesWriteHandler(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestFilesWriteHandler_NewFileGroupWwwData is an integration gate for GH #533:
+// a file created via files.write must land group www-data (so nginx, running as
+// www-data, can serve it through the 0640 group-read bit) — NOT the user's own
+// primary group, which shows up to operators as "User:User". Chowning to
+// www-data needs privilege and a real /home/<user>, so this is gated on
+// root + JABALI_FMTEST_USER=<an existing hosting user>; it skips in the
+// unprivileged CI job (the error-case unit tests above still run there).
+func TestFilesWriteHandler_NewFileGroupWwwData(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to chown a new file to www-data; set JABALI_FMTEST_USER and run as root")
+	}
+	username := os.Getenv("JABALI_FMTEST_USER")
+	if username == "" {
+		t.Skip("set JABALI_FMTEST_USER=<existing hosting user> to run this integration gate")
+	}
+	if _, err := user.Lookup(username); err != nil {
+		t.Skipf("JABALI_FMTEST_USER %q not found: %v", username, err)
+	}
+	wg, err := user.LookupGroup("www-data")
+	if err != nil {
+		t.Skip("www-data group not present; skipping")
+	}
+	wantGid, _ := strconv.Atoi(wg.Gid)
+
+	abs := filepath.Join("/home", username, fmt.Sprintf("gh533-fmtest-%d.txt", os.Getpid()))
+	defer os.Remove(abs)
+
+	params, _ := json.Marshal(filesWriteParams{
+		UserID:   "fmtest",
+		Username: username,
+		Path:     abs,
+		Content:  "gh533",
+	})
+	if _, err := filesWriteHandler(context.Background(), params); err != nil {
+		t.Fatalf("files.write failed: %v", err)
+	}
+
+	fi, err := os.Stat(abs)
+	if err != nil {
+		t.Fatalf("stat %s: %v", abs, err)
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat_t unavailable")
+	}
+	if int(st.Gid) != wantGid {
+		t.Errorf("new file group = %d, want www-data (%d) — GH #533 regression", st.Gid, wantGid)
 	}
 }


### PR DESCRIPTION
Fixes GH #533 — File Manager creates files as `User:User` instead of `User:www-data`.

## Root cause
`files.write` (panel-agent) chowned a newly created file to `<uid>:<u.Gid>` — the user's **own** primary group:
```go
uid, _ := strconv.Atoi(u.Uid)
gid, _ := strconv.Atoi(u.Gid)   // <-- user's own group
...
tmpFile.Chown(uid, gid)         // comment says "user:www-data", code says user:user
```
The 0640 mode grants group-read specifically so nginx (running as www-data) can serve the file — but with the group set to the user's own group, nginx can't read it, and operators see `User:User`.

`files.mkdir`, `files.extract`, and `files.ingest` (via `hostingIDs`) already do this correctly; `files.write` was the only create-path that skipped the www-data override.

## Fix
Override the group to www-data before the chown (fall back to the user's gid only if www-data is absent), mirroring the sibling handlers.

## Test
Adds `TestFilesWriteHandler_NewFileGroupWwwData` — a root + `JABALI_FMTEST_USER`-gated integration gate asserting the new file's group is www-data. Skips in the unprivileged CI job (the existing error-case unit tests still run there).

Verified on a box as root against a real hosting user: `--- PASS`.

## Test plan
- [x] `go vet ./internal/commands/`
- [x] existing `TestFilesWriteHandler` (error cases) pass
- [x] new gate PASSes on a box (root, real user, www-data group 33)