### PR TITLE
fix(files): append-mode create also lands group www-data (GH #533 follow-up)

### DIFF
--- a/panel-agent/internal/commands/files_write.go
+++ b/panel-agent/internal/commands/files_write.go
@@ -209,7 +209,16 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}, nil
 	}
 
-	// Append mode: open existing file or create new one, escape-proof.
+	// Append mode: open existing file or create new one, escape-proof. Record
+	// whether the file already existed BEFORE opening: if O_CREATE makes a new
+	// one, the agent (root) would leave it root-owned, so it must be chowned to
+	// <user>:www-data afterwards — the same invariant the overwrite path applies
+	// (GH #533 follow-up). An existing file's ownership is left untouched.
+	preExisting, existErr := scope.ExistsInScope(cleanPath)
+	if existErr != nil {
+		return nil, classifyFSWriteErr("stat_append", existErr)
+	}
+
 	file, err := scope.OpenInScope(cleanPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, sensitiveFileMode(cleanPath, 0640))
 	if err != nil {
 		return nil, classifyFSWriteErr("open_append", err)
@@ -220,6 +229,29 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	n, err := file.WriteString(p.Content)
 	if err != nil {
 		return nil, classifyFSWriteErr("write_append", err)
+	}
+
+	// Newly created via O_CREATE: normalize ownership to <user>:www-data through
+	// the open fd (no path re-resolve). Chown after the write so an over-quota
+	// target surfaces EDQUOT here, classified like the overwrite path.
+	if preExisting == nil {
+		u, uerr := user.Lookup(p.Username)
+		if uerr != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInvalidArgument,
+				Message: fmt.Sprintf("failed to lookup user %q: %v", p.Username, uerr),
+			}
+		}
+		uid, _ := strconv.Atoi(u.Uid)
+		gid, _ := strconv.Atoi(u.Gid)
+		if g, gerr := user.LookupGroup("www-data"); gerr == nil {
+			if wgid, werr := strconv.Atoi(g.Gid); werr == nil {
+				gid = wgid
+			}
+		}
+		if err := file.Chown(uid, gid); err != nil {
+			return nil, classifyFSWriteErr("chown_append", err)
+		}
 	}
 
 	return &filesWriteResponse{

--- a/panel-agent/internal/commands/files_write_test.go
+++ b/panel-agent/internal/commands/files_write_test.go
@@ -176,4 +176,30 @@ func TestFilesWriteHandler_NewFileGroupWwwData(t *testing.T) {
 	if int(st.Gid) != wantGid {
 		t.Errorf("new file group = %d, want www-data (%d) — GH #533 regression", st.Gid, wantGid)
 	}
+
+	// Append mode that CREATES a brand-new file must also land group www-data
+	// (GH #533 follow-up: previously left root-owned, no chown).
+	absAppend := filepath.Join("/home", username, fmt.Sprintf("gh533-fmtest-append-%d.txt", os.Getpid()))
+	defer os.Remove(absAppend)
+	appendParams, _ := json.Marshal(filesWriteParams{
+		UserID:   "fmtest",
+		Username: username,
+		Path:     absAppend,
+		Content:  "gh533-append",
+		Mode:     "append",
+	})
+	if _, err := filesWriteHandler(context.Background(), appendParams); err != nil {
+		t.Fatalf("files.write (append create) failed: %v", err)
+	}
+	afi, err := os.Stat(absAppend)
+	if err != nil {
+		t.Fatalf("stat %s: %v", absAppend, err)
+	}
+	ast, ok := afi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat_t unavailable (append)")
+	}
+	if int(ast.Gid) != wantGid {
+		t.Errorf("append-created file group = %d, want www-data (%d) — GH #533 regression", ast.Gid, wantGid)
+	}
 }


### PR DESCRIPTION
Follow-up to #557. That PR fixed the overwrite create-path; this closes the sibling gap in the **append** path.

## Gap
`files.write` append mode opens with `O_WRONLY|O_APPEND|O_CREATE` but never chowned. Appending to a **brand-new** path therefore left the file **root-owned** (the agent runs as root). Rare — the File Manager "new file" action uses overwrite (fixed in #557) — but a real inconsistency.

## Fix
Stat the path before opening; if it did not pre-exist, chown the newly created file to `<user>:www-data` through the open fd after the write (so an over-quota target surfaces EDQUOT there, matching the overwrite path). Existing files are left untouched.

## Test
Extends the box-gated `TestFilesWriteHandler_NewFileGroupWwwData` to also create a file via append mode and assert its group is www-data. Verified on a box as root against a real hosting user: `--- PASS`.

## Test plan
- [x] `go vet ./internal/commands/`
- [x] existing error-case unit tests pass
- [x] overwrite + append-create both assert group www-data on a box (root)