### PR TITLE
feat(docker-apps): post-install first-run note; Pocket ID -> /setup (GH #521)

### DIFF
--- a/install/docker-apps/_schema/app.schema.json
+++ b/install/docker-apps/_schema/app.schema.json
@@ -53,6 +53,10 @@
       "type": "string",
       "format": "uri"
     },
+    "post_install_note": {
+      "type": "string",
+      "description": "Optional first-run guidance shown to the operator in the panel AFTER a successful install (e.g. Pocket ID: create the first admin at https://<domain>/setup). Plain text; the {{domain}} placeholder is substituted with the app's assigned domain at display time."
+    },
     "image_channel": {
       "type": "string",
       "description": "Docker image reference. Use a stable tag (e.g. 'vaultwarden/server:latest') not a digest; the panel pins the digest at install time and tracks updates separately.",

--- a/install/docker-apps/pocket-id/app.yaml
+++ b/install/docker-apps/pocket-id/app.yaml
@@ -10,6 +10,11 @@ description: |
 icon: icon.svg
 upstream: https://github.com/pocket-id/pocket-id
 documentation: https://pocket-id.org/docs
+post_install_note: |
+  Create the first admin at https://{{domain}}/setup and register a passkey
+  (Pocket ID is passwordless — no password or email needed for the initial
+  admin). Open it over HTTPS at that domain: passkeys will not work over
+  plain HTTP or via an IP address.
 
 image_channel: pocketid/pocket-id:v2.11.0@sha256:b7c37ab3044e53fd29b5f7295eebff5fdc0367dc043f36b41bcbe1815fcd965d
 update_mode: manual

--- a/panel-api/internal/api/docker_apps.go
+++ b/panel-api/internal/api/docker_apps.go
@@ -124,6 +124,7 @@ type catalogEntryResponse struct {
 	Icon              string                  `json:"icon"`
 	Upstream          string                  `json:"upstream,omitempty"`
 	Documentation     string                  `json:"documentation,omitempty"`
+	PostInstallNote   string                  `json:"post_install_note,omitempty"`
 	UpdateMode        string                  `json:"update_mode"`
 	Resources         dockerapp.Resources     `json:"resources"`
 	Volumes           []dockerapp.Volume      `json:"volumes"`
@@ -235,6 +236,7 @@ func catalogEntryToResponse(e dockerapp.Entry) catalogEntryResponse {
 		Icon:              e.Icon,
 		Upstream:          e.Upstream,
 		Documentation:     e.Documentation,
+		PostInstallNote:   e.PostInstallNote,
 		UpdateMode:        e.UpdateMode,
 		Resources:         e.Resources,
 		Volumes:           e.Volumes,
@@ -250,6 +252,30 @@ type installedResponse struct {
 	models.DockerApp
 	Ports  []*models.DockerAppPublishedPort `json:"ports"`
 	Domain string                           `json:"domain,omitempty"`
+	// PostInstallNote is the catalog entry's first-run guidance (GH #521) with
+	// its "{{domain}}" token substituted for the app's assigned domain. Empty
+	// when the catalog entry has no note. The UI shows it as a dismissible
+	// hint on the installed-app card so operators know the first-run step
+	// (e.g. Pocket ID: create the first admin at https://<domain>/setup).
+	PostInstallNote string `json:"post_install_note,omitempty"`
+}
+
+// postInstallNoteFor returns the catalog entry's post-install note with the
+// "{{domain}}" token replaced by the app's assigned domain. Returns "" when the
+// catalog is unavailable, the entry is unknown, or it declares no note.
+func (h *dockerAppHandler) postInstallNoteFor(slug, domain string) string {
+	if h.cfg.Catalog == nil {
+		return ""
+	}
+	entry, ok := h.cfg.Catalog.Get(slug)
+	if !ok || entry.PostInstallNote == "" {
+		return ""
+	}
+	d := domain
+	if d == "" {
+		d = "<your app's domain>"
+	}
+	return strings.ReplaceAll(entry.PostInstallNote, "{{domain}}", d)
 }
 
 func (h *dockerAppHandler) list(c *gin.Context) {
@@ -285,6 +311,7 @@ func (h *dockerAppHandler) list(c *gin.Context) {
 				break
 			}
 		}
+		resp.PostInstallNote = h.postInstallNoteFor(a.Slug, resp.Domain)
 		out = append(out, resp)
 	}
 	c.JSON(http.StatusOK, gin.H{"items": out})
@@ -935,7 +962,19 @@ func (h *dockerAppHandler) get(c *gin.Context) {
 		return
 	}
 	ports, _ := h.cfg.Repo.ListPortsForApp(ctx, id)
-	c.JSON(http.StatusOK, installedResponse{DockerApp: *app, Ports: ports})
+	resp := installedResponse{DockerApp: *app, Ports: ports}
+	if h.cfg.Domains != nil {
+		if domList, _, derr := h.cfg.Domains.List(ctx, repository.ListOptions{}); derr == nil {
+			for _, d := range domList {
+				if d.DockerAppID != nil && *d.DockerAppID == app.ID {
+					resp.Domain = d.Name
+					break
+				}
+			}
+		}
+	}
+	resp.PostInstallNote = h.postInstallNoteFor(app.Slug, resp.Domain)
+	c.JSON(http.StatusOK, resp)
 }
 
 type updateRequest struct {

--- a/panel-api/internal/dockerapp/catalog.go
+++ b/panel-api/internal/dockerapp/catalog.go
@@ -13,11 +13,11 @@ package dockerapp
 
 import (
 	"errors"
-	"regexp"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -26,24 +26,29 @@ import (
 
 // Entry is the parsed shape of <slug>/app.yaml.
 type Entry struct {
-	Slug          string     `yaml:"slug"`
-	Name          string     `yaml:"name"`
-	Version       string     `yaml:"version"`
-	Description   string     `yaml:"description"`
-	Tags          []string   `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Slug        string   `yaml:"slug"`
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags,omitempty" json:"tags,omitempty"`
 	// Popularity orders the catalog: higher floats to the top of the listing,
 	// ties break alphabetically by slug. Optional (default 0). Operator-tunable
 	// per app.yaml so the most-installed apps surface first.
-	Popularity    int        `yaml:"popularity,omitempty" json:"popularity,omitempty"`
-	Icon          string     `yaml:"icon,omitempty"`
-	Upstream      string     `yaml:"upstream,omitempty"`
-	Documentation string     `yaml:"documentation,omitempty"`
-	ImageChannel  string     `yaml:"image_channel"`
-	UpdateMode    string     `yaml:"update_mode,omitempty"`
-	Resources     Resources  `yaml:"resources,omitempty"`
-	Volumes       []Volume   `yaml:"volumes"`
-	Ports         []PortSpec `yaml:"ports"`
-	Env           []EnvVar   `yaml:"env,omitempty"`
+	Popularity    int    `yaml:"popularity,omitempty" json:"popularity,omitempty"`
+	Icon          string `yaml:"icon,omitempty"`
+	Upstream      string `yaml:"upstream,omitempty"`
+	Documentation string `yaml:"documentation,omitempty"`
+	// PostInstallNote is optional first-run guidance shown in the panel AFTER a
+	// successful install (GH #521, e.g. Pocket ID: create the first admin at
+	// https://<domain>/setup). Plain text; a literal "{{domain}}" token is
+	// substituted with the app's assigned domain when the note is served.
+	PostInstallNote string     `yaml:"post_install_note,omitempty" json:"post_install_note,omitempty"`
+	ImageChannel    string     `yaml:"image_channel"`
+	UpdateMode      string     `yaml:"update_mode,omitempty"`
+	Resources       Resources  `yaml:"resources,omitempty"`
+	Volumes         []Volume   `yaml:"volumes"`
+	Ports           []PortSpec `yaml:"ports"`
+	Env             []EnvVar   `yaml:"env,omitempty"`
 	// SMTP (GH #322), when true, auto-injects the standard SMTP_* env vars
 	// (host/port/user/password/from/from_name/tls) as optional, operator-
 	// supplied install fields. The app's compose.yml.tmpl maps them to its own

--- a/panel-api/internal/dockerapp/catalog_postinstallnote_test.go
+++ b/panel-api/internal/dockerapp/catalog_postinstallnote_test.go
@@ -1,0 +1,32 @@
+package dockerapp
+
+import "testing"
+
+// TestPocketIDHasPostInstallNote pins the GH #521 fix: the Pocket ID catalog
+// entry must carry a post-install note pointing operators at /setup (Pocket ID
+// v2 creates the first admin there, not at /), with the {{domain}} token the
+// API substitutes for the assigned domain.
+func TestPocketIDHasPostInstallNote(t *testing.T) {
+	cat, _ := LoadDir(repoCatalogDir(t))
+	e, ok := cat.Get("pocket-id")
+	if !ok {
+		t.Fatal("pocket-id entry not found in catalog")
+	}
+	if e.PostInstallNote == "" {
+		t.Fatal("pocket-id has no post_install_note (GH #521 regression)")
+	}
+	for _, want := range []string{"/setup", "{{domain}}"} {
+		if !contains(e.PostInstallNote, want) {
+			t.Errorf("post_install_note missing %q; got: %q", want, e.PostInstallNote)
+		}
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -1,6 +1,6 @@
 // AdminDockerAppsPage — landing page for the M48 marketplace.
 // Two tabs: Catalog (browse + install) and Installed (lifecycle).
-import { App, Avatar, Button, Col, Drawer, Empty, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { Alert, App, Avatar, Button, Col, Drawer, Empty, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { humanBytes } from "../../../utils/bytes";
@@ -267,6 +267,18 @@ export const AdminDockerAppsPage = () => {
                             >
                               {r.domain}
                             </Typography.Link>
+                          )}
+                          {r.post_install_note && (
+                            <Alert
+                              type="info"
+                              showIcon
+                              style={{ marginTop: 6, padding: "4px 8px", maxWidth: 320 }}
+                              message={
+                                <Typography.Text style={{ fontSize: 11, whiteSpace: "normal" }}>
+                                  {r.post_install_note}
+                                </Typography.Text>
+                              }
+                            />
                           )}
                         </Space>
                       </Space>

--- a/panel-ui/src/shells/admin/docker-apps/types.ts
+++ b/panel-ui/src/shells/admin/docker-apps/types.ts
@@ -87,6 +87,11 @@ export interface InstalledApp {
   created_at: string;
   updated_at: string;
   domain?: string;
+  // First-run guidance from the catalog entry (GH #521), with {{domain}}
+  // already substituted server-side. Shown as a "Setup" hint on the card so
+  // operators know the first-run step (e.g. Pocket ID: create the admin at
+  // https://<domain>/setup). Absent when the catalog entry has no note.
+  post_install_note?: string;
   ports: InstalledPort[];
 }
 

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -255,6 +255,18 @@ export const UserDockerAppsPage = () => {
                                 {r.domain}
                               </Typography.Link>
                             )}
+                            {r.post_install_note && (
+                              <Alert
+                                type="info"
+                                showIcon
+                                style={{ marginTop: 6, padding: "4px 8px", maxWidth: 320 }}
+                                message={
+                                  <Typography.Text style={{ fontSize: 11, whiteSpace: "normal" }}>
+                                    {r.post_install_note}
+                                  </Typography.Text>
+                                }
+                              />
+                            )}
                           </Space>
                         </Space>
                       ),


### PR DESCRIPTION
Fixes GH #521 — Pocket ID "first screen doesn't allow authentication".

## Diagnosis (not a config bug)
Pocket ID **v2** creates the first admin at **`/setup`**, not `/`. A fresh install lands on the passkey login screen with no account and no hint, so it looks broken. The reporter guessed at `POCKET_ID_ALLOW_REGISTRATION` / `POCKET_ID_ADMIN_EMAIL` — those are **v1** var names, gone in v2. `APP_URL` + `TRUST_PROXY` are already set correctly in `pocket-id/compose.yml.tmpl`, so origin/proxy were never the problem. The gap is **first-run guidance**.

## Change — general post-install note
- `app.schema.json`: new optional `post_install_note` field.
- `dockerapp.Entry`: parse `post_install_note`.
- API: carry it on the catalog DTO, and on the installed-app **list/get** responses with its `{{domain}}` token substituted for the app's assigned domain (`postInstallNoteFor`).
- `pocket-id/app.yaml`: note → `https://{{domain}}/setup` + passkey + the HTTPS/secure-context requirement.
- `panel-ui`: render the note as an info `Alert` on the installed-app card (user + admin docker-app lists).

Reusable for any app with a first-run step, not just Pocket ID.

## Tests
- [x] `TestPocketIDHasPostInstallNote` (note present + `/setup` + `{{domain}}` token)
- [x] `go build ./...`, `gofmt` clean, `go vet`
- [x] existing `dockerapp` + `api` suites pass
- [x] `panel-ui` `tsc -b` clean

Note: the info-Alert render is type-checked but not yet visually verified on a box (needs Pocket ID installed against the new panel build) — easy to eyeball after deploy.