### PR TITLE
chore(mail): bump Stalwart Mail to 0.16.14 (GH #525)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10631,7 +10631,7 @@ install_notify_template() {
 #   /etc/jabali-panel/bulwark-session.key — Bulwark SESSION_SECRET (jabali-webmail:jabali-webmail, 0640)
 
 install_stalwart() {
-  local stalwart_version="0.16.12"
+  local stalwart_version="0.16.14"
   _log "installing Stalwart Mail Server (v${stalwart_version})"
 
   # M353 / GH #545 concurrency guard. install_stalwart runs from TWO paths
@@ -10707,7 +10707,7 @@ install_stalwart() {
   # across 0.14.x-0.16.x ("Stalwart Mail Server v0.16.0").
   if [[ -x "$stalwart_binary" ]]; then
     local installed_version
-    # `stalwart --version` prints a bare semver ("0.16.12", no `v` prefix), so
+    # `stalwart --version` prints a bare semver ("0.16.14", no `v` prefix), so
     # match the plain version — an anchored `v\K` matched nothing here, leaving
     # installed_version="unknown" and re-downloading the binary on EVERY run
     # (every `jabali update` / `--install-module mail`). (M353 idempotency fix.)

--- a/install/stalwart.sha256
+++ b/install/stalwart.sha256
@@ -1,6 +1,9 @@
-# Stalwart Mail Server v0.16.12 SHA-256 checksum for stalwart-x86_64-unknown-linux-gnu.tar.gz
-# Source: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.12
-# Captured 2026-07-08 directly from the GitHub release artifact (GH #288).
+# Stalwart Mail Server v0.16.14 SHA-256 checksum for stalwart-x86_64-unknown-linux-gnu.tar.gz
+# Source: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.14
+# Captured 2026-07-21 directly from the GitHub release artifact (GH #525;
+# bumped past the requested 0.16.13 to the latest stable 0.16.14). Both
+# releases are drop-in binary replacements from v0.16.x (bugfix-only; no
+# config/JMAP-management changes per upstream notes).
 #
 # Stalwart v0.16.x replaced its REST API with a JMAP management API
 # (see ADR-0041 + plan #1). SQL directory is supported against MariaDB
@@ -10,4 +13,4 @@
 #   curl -sSL https://github.com/stalwartlabs/stalwart/releases/download/v<x.y.z>/stalwart-x86_64-unknown-linux-gnu.tar.gz | sha256sum
 # install.sh `_die`s if the placeholder PLACEHOLDER_CAPTURE_ON_FIRST_DEPLOY
 # survives — matches the DokuWiki/MediaWiki tarball precedent.
-d0eceed73be4e08da034e9f1a824d62c4a666a34fa95074b0c717d16f98fe74e  stalwart-x86_64-unknown-linux-gnu.tar.gz
+05da156fc7a13ffc7ffc940013d12f0d7b7ba935a66bd73af7696dac7db82a98  stalwart-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
Fixes GH #525 (bump Stalwart 0.16.12 -> 0.16.13).

Bumped straight to **0.16.14** (2026-07-20) — the current latest stable, one patch past the requested 0.16.13.

## Safety
Both 0.16.13 and 0.16.14 are drop-in binary replacements from v0.16.x per upstream notes — bugfix-only (IMAP/JMAP/CalDAV/MTA), **no config or JMAP-management API changes**, so jabali's apply-plan / mustMatchSender / SQL-directory integration is unaffected. No migration. 0.16.14 also fixes "stale push subscription can block verification of a new one", relevant to our Web Push path.

## Changes
- `install.sh`: `stalwart_version` 0.16.12 -> 0.16.14 (+ the version-check comment).
- `install/stalwart.sha256`: real v0.16.14 tarball checksum + updated header.

## Verified
- Pinned checksum (`05da156f...`) matches the GitHub release artifact (`curl | sha256sum`).
- Tarball extracts to a `stalwart` binary reporting `0.16.14` — matches install.sh's idempotency version check, so an existing 0.16.12 host upgrades (version mismatch -> re-download -> sha verify -> swap).

## Test plan
- [x] `bash -n install.sh`
- [x] checksum matches release artifact
- [x] binary reports 0.16.14
- [ ] on-box `jabali update` upgrade (will run at deploy)