### PR TITLE
fix(update): upgrade the Stalwart server binary on jabali update (GH #525)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10630,8 +10630,44 @@ install_notify_template() {
 #   /etc/jabali-panel/bulwark.env       — Bulwark runtime env (jabali-webmail:jabali-webmail, 0640)
 #   /etc/jabali-panel/bulwark-session.key — Bulwark SESSION_SECRET (jabali-webmail:jabali-webmail, 0640)
 
+# STALWART_VERSION is the single pin for the Stalwart Mail server binary,
+# consumed by both install_stalwart (fresh install) and upgrade_stalwart_binary
+# (the jabali update path). Bump here + install/stalwart.sha256 together.
+STALWART_VERSION="0.16.14"
+
+# upgrade_stalwart_binary is the jabali-update entry point for the Stalwart
+# server binary (GH #525). install.sh's full install_stalwart runs on fresh
+# installs only; the update path re-copies the unit + push-cert but never
+# re-downloads the SERVER binary, so a version bump never reached existing
+# hosts (they stayed on the originally-installed version). This narrow function
+# does JUST the binary: compare the installed version to the pinned target and,
+# on mismatch, download + checksum-verify + atomically swap it (via the shared
+# _install_stalwart_binary), then restart jabali-stalwart so the new binary goes
+# live. Idempotent — a no-op when already at STALWART_VERSION. Mirrors how
+# install_kratos / _install_bulwark self-upgrade on update.
+upgrade_stalwart_binary() {
+  local stalwart_binary="/usr/local/bin/stalwart"
+  if [[ -x "$stalwart_binary" ]]; then
+    local installed
+    installed=$("$stalwart_binary" --version 2>&1 | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || echo "unknown")
+    if [[ "$installed" == "$STALWART_VERSION" ]]; then
+      _ok "Stalwart already at $STALWART_VERSION"
+      return 0
+    fi
+    _log "upgrading Stalwart $installed -> $STALWART_VERSION"
+  else
+    _log "installing Stalwart $STALWART_VERSION (binary absent)"
+  fi
+  _install_stalwart_binary "$STALWART_VERSION"
+  if systemctl is-active --quiet jabali-stalwart 2>/dev/null; then
+    systemctl restart jabali-stalwart \
+      || _warn "jabali-stalwart restart failed after binary upgrade — check 'journalctl -u jabali-stalwart'"
+    _ok "jabali-stalwart restarted on Stalwart $STALWART_VERSION"
+  fi
+}
+
 install_stalwart() {
-  local stalwart_version="0.16.14"
+  local stalwart_version="$STALWART_VERSION"
   _log "installing Stalwart Mail Server (v${stalwart_version})"
 
   # M353 / GH #545 concurrency guard. install_stalwart runs from TWO paths

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1407,6 +1407,26 @@ test -x node_modules/.bin/tsc || {
 			}
 			return nil
 		}},
+		{"sync stalwart binary", func() error {
+			// install.sh installs the Stalwart SERVER binary only on a fresh
+			// install; the update path re-copies the unit + push-cert (above)
+			// but never re-downloaded the binary, so a version bump (GH #525)
+			// never reached existing hosts — they stayed on the originally-
+			// installed version. upgrade_stalwart_binary is idempotent: a no-op
+			// when already at the pinned STALWART_VERSION, else it downloads +
+			// checksum-verifies + atomically swaps the binary and restarts
+			// jabali-stalwart. Non-fatal — a host that can't upgrade keeps
+			// running the old binary rather than failing the whole update.
+			installSh := repoDir + "/install.sh"
+			if _, err := os.Stat(installSh); err != nil {
+				return nil
+			}
+			if err := run("", "bash", "-c",
+				"source "+installSh+" && upgrade_stalwart_binary"); err != nil {
+				fmt.Printf("  (stalwart binary upgrade failed: %v — continuing)\n", err)
+			}
+			return nil
+		}},
 		{"sync stalwart spam-filter rules", func() error {
 			// Vendor the pinned spam-filter rules bundle + (re-)install
 			// the weekly auto-refresh timer + script. Existing hosts


### PR DESCRIPTION
Follow-up to #560 — makes the Stalwart bump actually reach deployed hosts.

## The gap
#560 bumped `install.sh`'s Stalwart version to 0.16.14, but `jabali update` re-copies the systemd unit + push-cert and **never re-downloaded the server binary** (`update.go` even notes the CLI upgrade path is skipped). So the bump only applied to **fresh installs**; existing mail hosts stayed on their originally-installed version. On testserver, `jabali update` completed green yet `stalwart --version` was still `0.16.12`.

## Fix (mirrors kratos / bulwark self-upgrade on update)
- `install.sh`: hoist the version to a single `STALWART_VERSION` pin; add `upgrade_stalwart_binary` — idempotent (no-op at the pinned version, else download + checksum-verify + atomic swap via the shared `_install_stalwart_binary`, then restart `jabali-stalwart`).
- `update.go`: new **"sync stalwart binary"** step runs `source install.sh && upgrade_stalwart_binary`. Non-fatal — a host that can't upgrade keeps running the old binary rather than failing the whole update.

## Verified on a real mail host (testserver)
```
[i] upgrading Stalwart 0.16.12 -> 0.16.14
[i] downloading Stalwart 0.16.14 from GitHub
[✓] Stalwart 0.16.14 installed at /opt/stalwart (symlinked to /usr/local/bin/stalwart)
[✓] jabali-stalwart restarted on Stalwart 0.16.14
```
`stalwart --version` -> `0.16.14`, `jabali-stalwart` active.

## Test plan
- [x] `bash -n install.sh`
- [x] `go build`/`go vet ./cmd/server/`
- [x] on-box: 0.16.12 -> 0.16.14 upgrade + restart, service active
- [x] idempotent: re-run is a no-op ("already at 0.16.14")