### PR TITLE
feat(migrate): CloudPanel source_kind + Discoverer scaffold (GH #522 step 1)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -47,6 +47,7 @@ import (
 	// importer's init() so the source-kind → Discoverer factory
 	// is available before the first admin REST call. Adding a
 	// new source kind = adding one line here.
+	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cloudpanel"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"

--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -281,7 +281,8 @@ func isKnownSourceKind(s string) bool {
 		models.MigrationSourceWordPressSSH,    // GH #647
 		models.MigrationSourceWordPressPlugin, // GH #648
 		models.MigrationSourceIMAP,            // GH #390/#374
-		models.MigrationSourcePlesk:           // GH #429
+		models.MigrationSourcePlesk,           // GH #429
+		models.MigrationSourceCloudPanel:      // GH #522
 		return true
 	}
 	return false

--- a/panel-api/internal/migrate/cloudpanel/discover.go
+++ b/panel-api/internal/migrate/cloudpanel/discover.go
@@ -1,0 +1,383 @@
+// Package cloudpanel implements the GH #522 Discoverer + Restorer for
+// CloudPanel source panels. SSH-based connect (parity with the cpanel /
+// directadmin packages); discovery reads CloudPanel's SQLite config
+// database directly.
+//
+// CloudPanel stores its entire inventory in a single SQLite database at
+// /home/clp/htdocs/app/data/db.sq3 (tables: site, php_settings, database,
+// user). Enumeration is therefore plain read-only SELECTs via the `sqlite3`
+// CLI over SSH — cleaner than the CLI-output scraping the cpanel/DA sources
+// do. `clpctl` is used only for DB credentials + dumps (Step 2+), and
+// `mysqldump` for the dumps themselves. We NEVER run a mutating command
+// (`clpctl *:add/*:delete`, `site:*`) against the source.
+//
+// CloudPanel is web-only — it has no mail server — so the manifest's
+// Mailboxes area is always empty (no mail phase, unlike cpanel/Plesk).
+//
+// Step 1 (this file) ships the Discoverer scaffold + Connect + ListAccounts
+// and returns a valid (SchemaVersion + Source) empty manifest that the Step 2
+// per-area builders fill — the same incremental shape the directadmin package
+// took (see directadmin/discover.go).
+package cloudpanel
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// DefaultDBPath is where CloudPanel keeps its SQLite config database.
+const DefaultDBPath = "/home/clp/htdocs/app/data/db.sq3"
+
+// siteUserRe is the strict allow-list a CloudPanel site user / account id must
+// match before it is ever interpolated into a SQL or shell string. CloudPanel
+// site users are Linux usernames; anything outside this set is rejected rather
+// than escaped, so no SQL/shell metacharacter can reach the source (defence in
+// depth — DescribeAccount also validates via the Go-side account list).
+var siteUserRe = regexp.MustCompile(`^[a-z_][a-z0-9._-]{0,63}$`)
+
+// Discoverer is the CloudPanel-side implementation of migrate.Discoverer.
+type Discoverer struct {
+	// AllowPrivate — when true the SSRF guard permits RFC1918 / ULA targets.
+	// Default false; the admin toggle (migration_allow_private_hosts) sets it
+	// via migrate.ApplyAllowPrivate.
+	AllowPrivate bool
+	// Port is the source SSH port (GH #429 PortSetter). Default 22.
+	Port int
+	// CommandTimeout bounds each remote command. Default 30s.
+	CommandTimeout time.Duration
+	// DBPath is the CloudPanel SQLite database path on the source. Overridable
+	// only for tests; production always uses DefaultDBPath.
+	DBPath string
+}
+
+// New returns a Discoverer with sensible defaults.
+func New() *Discoverer {
+	return &Discoverer{
+		Port:           22,
+		CommandTimeout: 30 * time.Second,
+		DBPath:         DefaultDBPath,
+	}
+}
+
+// Compile-time interface assertions.
+var _ migrate.Discoverer = (*Discoverer)(nil)
+var _ migrate.AllowPrivateSetter = (*Discoverer)(nil)
+var _ migrate.PortSetter = (*Discoverer)(nil)
+
+// SetAllowPrivate — see cpanel/discover.go for rationale.
+func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
+
+// SetPort sets the source SSH port; ApplyPort calls it via PortSetter. Ports
+// outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
+// runnerFunc executes one command on the source and returns stdout. Real
+// sessions run over SSH (session.sshRun); tests inject a fake so the
+// SQLite-parsing logic in ListAccounts / DescribeAccount is exercised without
+// a live CloudPanel host.
+type runnerFunc func(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error)
+
+type session struct {
+	client         *ssh.Client
+	connectedUser  string
+	dbPath         string
+	commandTimeout time.Duration
+	// run is the command executor. Connect wires it to sshRun; tests set it
+	// directly on a hand-built session.
+	run runnerFunc
+}
+
+func (s *session) Kind() string { return models.MigrationSourceCloudPanel }
+
+// Connect dials the source over SSH, verifies the host key, and validates the
+// credentials with a single read: counting rows in CloudPanel's `site` table.
+// A successful count proves (a) the SSH creds work, (b) `sqlite3` is present,
+// and (c) the db.sq3 schema is really CloudPanel's — all before returning.
+func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migrate.SecretRef) (migrate.Session, error) {
+	port := d.Port
+	if port == 0 {
+		port = 22
+	}
+	auth, err := loadSecret(secret.Path)
+	if err != nil {
+		return nil, fmt.Errorf("cloudpanel.Connect: load secret: %w", err)
+	}
+	cfg := &ssh.ClientConfig{
+		User:            user,
+		Auth:            auth,
+		HostKeyCallback: migrate.PinningHostKeyCallback(secret.ExpectedHostKey),
+		Timeout:         15 * time.Second,
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	conn, err := migrate.DialTCP(ctx, host, port, d.AllowPrivate, 15*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("cloudpanel.Connect: tcp dial %s: %w", addr, err)
+	}
+	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
+	if err != nil {
+		conn.Close()
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
+			return nil, fmt.Errorf("cloudpanel.Connect: source SSH server rejected the supplied auth method (likely PasswordAuthentication=no — upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", err)
+		}
+		return nil, fmt.Errorf("cloudpanel.Connect: ssh handshake: %w", err)
+	}
+	client := ssh.NewClient(c, ch, reqs)
+	dbPath := d.DBPath
+	if dbPath == "" {
+		dbPath = DefaultDBPath
+	}
+	s := &session{
+		client:         client,
+		connectedUser:  user,
+		dbPath:         dbPath,
+		commandTimeout: d.CommandTimeout,
+	}
+	s.run = s.sshRun
+
+	subctx, cancel := context.WithTimeout(ctx, d.CommandTimeout)
+	defer cancel()
+	if _, err := s.run(subctx, d.CommandTimeout, sqliteQuery(dbPath, "SELECT count(*) FROM site")); err != nil {
+		client.Close()
+		return nil, fmt.Errorf("cloudpanel.Connect: read probe failed — is this a CloudPanel host with %s readable by the SSH user (need root), and is sqlite3 installed? %w", dbPath, err)
+	}
+	return s, nil
+}
+
+// ListAccounts returns one row per CloudPanel SITE USER (a Linux user that may
+// own several sites). Cheap mode — no per-account size lookup here; that lands
+// on DescribeAccount / SizeProber (Step 2). The query is static (no user input)
+// so it needs no sanitisation.
+func (d *Discoverer) ListAccounts(ctx context.Context, raw migrate.Session) ([]migrate.AccountSummary, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("cloudpanel.ListAccounts: wrong session type")
+	}
+	// user | comma-joined domains — one row per site user, so the admin picker
+	// can show which domains ride along. group_concat keeps it a single round
+	// trip. `clp` is CloudPanel's own service account, never a hosting user.
+	q := "SELECT user, group_concat(domain_name, ',') FROM site " +
+		"WHERE user IS NOT NULL AND user != '' GROUP BY user ORDER BY user"
+	out, err := s.run(ctx, s.commandTimeout, sqliteQuerySep(s.dbPath, "|", q))
+	if err != nil {
+		return nil, fmt.Errorf("cloudpanel.ListAccounts: read site users: %w", err)
+	}
+	rows := []migrate.AccountSummary{}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		user, domains, _ := strings.Cut(line, "|")
+		user = strings.TrimSpace(user)
+		if user == "" || user == "clp" {
+			continue
+		}
+		primary := ""
+		if d := strings.SplitN(domains, ",", 2); len(d) > 0 {
+			primary = strings.TrimSpace(d[0])
+		}
+		rows = append(rows, migrate.AccountSummary{
+			ID:     user,
+			Login:  user,
+			Domain: primary,
+		})
+	}
+	return rows, nil
+}
+
+// DescribeAccount returns a manifest scaffold for one CloudPanel site user.
+// Per-area builders (Domains / Databases / Cron / SSH) ship in Step 2. The
+// account is validated against the Go-side account list (no user input reaches
+// SQL) — plus a strict format check so later interpolating builders are safe.
+func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, accountID string) (*migrate.AccountManifest, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("cloudpanel.DescribeAccount: wrong session type")
+	}
+	if accountID == "" {
+		return nil, errors.New("cloudpanel.DescribeAccount: accountID empty")
+	}
+	if !siteUserRe.MatchString(accountID) {
+		return nil, fmt.Errorf("cloudpanel.DescribeAccount: invalid account id %q (must be a CloudPanel site user)", accountID)
+	}
+
+	accounts, err := d.ListAccounts(ctx, s)
+	if err != nil {
+		return nil, fmt.Errorf("cloudpanel.DescribeAccount: enumerate accounts: %w", err)
+	}
+	found := false
+	for _, a := range accounts {
+		if a.ID == accountID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		switch len(accounts) {
+		case 0:
+			return nil, fmt.Errorf("no CloudPanel site users found on source (queried %s); %q is not a hosting user", s.dbPath, accountID)
+		case 1:
+			// Single-tenant source — pivot to the only account, matching the
+			// directadmin auto-detect convenience.
+			accountID = accounts[0].ID
+		default:
+			names := make([]string, 0, len(accounts))
+			for _, a := range accounts {
+				names = append(names, a.ID)
+			}
+			return nil, fmt.Errorf("user %q is not a CloudPanel site user; pick one of: %s", accountID, strings.Join(names, ", "))
+		}
+	}
+
+	host := ""
+	if s.client != nil {
+		host = s.client.RemoteAddr().String()
+	}
+	return &migrate.AccountManifest{
+		SchemaVersion: migrate.ManifestSchemaVersion,
+		Source: migrate.SourceRef{
+			Kind: models.MigrationSourceCloudPanel,
+			Host: host,
+			User: accountID,
+		},
+		// CloudPanel has no mail server — Mailboxes stays empty by design.
+		Mailboxes: []migrate.MailboxSpec{},
+		Warnings:  []migrate.Warning{},
+	}, nil
+}
+
+// Close releases the SSH client. Best-effort.
+func (d *Discoverer) Close(ctx context.Context, raw migrate.Session) error {
+	s, ok := raw.(*session)
+	if !ok || s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+// sshRun executes one command via SSH and returns stdout. Hard timeout via
+// context; SIGKILL on expiry so a stuck command doesn't pin the session.
+// Mirrors directadmin/discover.go's run().
+func (s *session) sshRun(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	subctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("ssh new session: %w", err)
+	}
+	defer sess.Close()
+
+	var stdout, stderr bytes.Buffer
+	sess.Stdout = &stdout
+	sess.Stderr = &stderr
+
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(cmd) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return nil, fmt.Errorf("ssh exec %q: %w (stderr=%q)", cmd, err, stderr.String())
+		}
+		return stdout.Bytes(), nil
+	case <-subctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return nil, fmt.Errorf("ssh exec %q: timed out after %s", cmd, timeout)
+	}
+}
+
+// sqliteQuery builds a read-only `sqlite3 <db> "<query>"` command. The db path
+// is single-quoted for the shell; the query is a package-controlled literal
+// (never operator input) so no escaping of it is required. `-readonly` opens
+// the database without a write lock, guaranteeing we cannot mutate the source.
+func sqliteQuery(dbPath, query string) string {
+	return fmt.Sprintf("sqlite3 -readonly %s %s", shellSingleQuote(dbPath), shellSingleQuote(query))
+}
+
+// sqliteQuerySep is sqliteQuery with an explicit column separator.
+func sqliteQuerySep(dbPath, sep, query string) string {
+	return fmt.Sprintf("sqlite3 -readonly -separator %s %s %s",
+		shellSingleQuote(sep), shellSingleQuote(dbPath), shellSingleQuote(query))
+}
+
+// shellSingleQuote wraps s in single quotes, escaping embedded single quotes,
+// so it is safe as one shell argument.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// loadSecret matches the cpanel / directadmin loadSecret semantics: two
+// recognised env-file lines, SSH_PASSWORD=<plaintext> and
+// SSH_PRIVATE_KEY[_B64]=<PEM|base64-PEM>. Raw is zeroed before returning so the
+// plaintext doesn't sit in the process heap.
+func loadSecret(path string) ([]ssh.AuthMethod, error) {
+	if path == "" {
+		return nil, errors.New("secret path empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer zero(raw)
+
+	var auths []ssh.AuthMethod
+	for _, line := range strings.Split(string(raw), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "SSH_PASSWORD":
+			auths = append(auths, ssh.Password(v))
+		case "SSH_PRIVATE_KEY":
+			signer, perr := ssh.ParsePrivateKey([]byte(v))
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		case "SSH_PRIVATE_KEY_B64":
+			pem, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(v))
+			if derr != nil {
+				return nil, fmt.Errorf("base64-decode SSH_PRIVATE_KEY_B64: %w", derr)
+			}
+			signer, perr := ssh.ParsePrivateKey(pem)
+			zero(pem)
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY_B64: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		}
+	}
+	if len(auths) == 0 {
+		return nil, errors.New("no SSH_PASSWORD / SSH_PRIVATE_KEY / SSH_PRIVATE_KEY_B64 in secret file")
+	}
+	return auths, nil
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/panel-api/internal/migrate/cloudpanel/discover_test.go
+++ b/panel-api/internal/migrate/cloudpanel/discover_test.go
@@ -1,0 +1,138 @@
+package cloudpanel
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeSession builds a *session whose run() returns canned sqlite output,
+// so the SQLite-parsing logic is exercised without a live CloudPanel host.
+func fakeSession(out string) *session {
+	s := &session{dbPath: "/test/db.sq3", commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, _ string) ([]byte, error) {
+		return []byte(out), nil
+	}
+	return s
+}
+
+func TestListAccounts_ParsesSiteUsersAndFiltersClp(t *testing.T) {
+	// user|comma-joined-domains, one row per site user; clp is CloudPanel's own
+	// service account and must be filtered.
+	d := New()
+	s := fakeSession("alice|a.example.com,b.example.com\nbob|c.example.com\nclp|panel.example.com\n")
+	accts, err := d.ListAccounts(context.Background(), s)
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(accts) != 2 {
+		t.Fatalf("want 2 accounts (clp filtered), got %d: %+v", len(accts), accts)
+	}
+	if accts[0].ID != "alice" || accts[0].Login != "alice" || accts[0].Domain != "a.example.com" {
+		t.Errorf("account[0] = %+v, want alice / a.example.com primary", accts[0])
+	}
+	if accts[1].ID != "bob" || accts[1].Domain != "c.example.com" {
+		t.Errorf("account[1] = %+v, want bob / c.example.com", accts[1])
+	}
+}
+
+func TestDescribeAccount_EmptyManifestForKnownUser(t *testing.T) {
+	d := New()
+	s := fakeSession("alice|a.example.com\nbob|c.example.com\n")
+	m, err := d.DescribeAccount(context.Background(), s, "alice")
+	if err != nil {
+		t.Fatalf("DescribeAccount: %v", err)
+	}
+	if m.SchemaVersion != migrate.ManifestSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", m.SchemaVersion, migrate.ManifestSchemaVersion)
+	}
+	if m.Source.Kind != models.MigrationSourceCloudPanel || m.Source.User != "alice" {
+		t.Errorf("Source = %+v, want kind=cloudpanel user=alice", m.Source)
+	}
+	if len(m.Mailboxes) != 0 {
+		t.Errorf("CloudPanel has no mail — Mailboxes must be empty, got %d", len(m.Mailboxes))
+	}
+}
+
+func TestDescribeAccount_SingleTenantAutodetect(t *testing.T) {
+	// Operator typed the SSH principal (root) but there is exactly one site
+	// user — pivot to it, mirroring the DirectAdmin convenience.
+	d := New()
+	s := fakeSession("alice|a.example.com\n")
+	m, err := d.DescribeAccount(context.Background(), s, "root")
+	if err != nil {
+		t.Fatalf("DescribeAccount autodetect: %v", err)
+	}
+	if m.Source.User != "alice" {
+		t.Errorf("autodetect user = %q, want alice", m.Source.User)
+	}
+}
+
+func TestDescribeAccount_MultiTenantUnknownErrors(t *testing.T) {
+	d := New()
+	s := fakeSession("alice|a\nbob|b\n")
+	_, err := d.DescribeAccount(context.Background(), s, "carol")
+	if err == nil || !strings.Contains(err.Error(), "pick one of") {
+		t.Fatalf("want multi-tenant 'pick one of' error, got %v", err)
+	}
+}
+
+func TestDescribeAccount_RejectsInjectionyID(t *testing.T) {
+	d := New()
+	s := fakeSession("alice|a\n")
+	for _, bad := range []string{"a'; DROP TABLE site;--", "a b", "a$(whoami)", "../etc", "A_UPPER"} {
+		if _, err := d.DescribeAccount(context.Background(), s, bad); err == nil {
+			t.Errorf("accountID %q should be rejected by siteUserRe", bad)
+		}
+	}
+}
+
+func TestShellSingleQuote_EscapesQuotes(t *testing.T) {
+	got := shellSingleQuote("a'b")
+	want := `'a'\''b'`
+	if got != want {
+		t.Errorf("shellSingleQuote(a'b) = %q, want %q", got, want)
+	}
+}
+
+func TestSqliteQuery_IsReadonlyAndQuoted(t *testing.T) {
+	cmd := sqliteQuery("/home/clp/htdocs/app/data/db.sq3", "SELECT count(*) FROM site")
+	if !strings.Contains(cmd, "-readonly") {
+		t.Errorf("query must use -readonly to guarantee no source mutation: %q", cmd)
+	}
+	if !strings.Contains(cmd, `'/home/clp/htdocs/app/data/db.sq3'`) {
+		t.Errorf("db path must be single-quoted: %q", cmd)
+	}
+}
+
+func TestSiteUserRe(t *testing.T) {
+	ok := []string{"alice", "web-user", "a_b.c", "_svc", "u123"}
+	bad := []string{"", "Alice", "a b", "a'b", "a;b", "1abc", strings.Repeat("x", 65)}
+	for _, s := range ok {
+		if !siteUserRe.MatchString(s) {
+			t.Errorf("siteUserRe should accept %q", s)
+		}
+	}
+	for _, s := range bad {
+		if siteUserRe.MatchString(s) {
+			t.Errorf("siteUserRe should reject %q", s)
+		}
+	}
+}
+
+func TestRegistered(t *testing.T) {
+	d, err := migrate.Get(models.MigrationSourceCloudPanel)
+	if err != nil {
+		t.Fatalf("migrate.Get(cloudpanel): %v — init() registration missing?", err)
+	}
+	if _, ok := d.(migrate.AllowPrivateSetter); !ok {
+		t.Error("cloudpanel Discoverer must implement AllowPrivateSetter")
+	}
+	if _, ok := d.(migrate.PortSetter); !ok {
+		t.Error("cloudpanel Discoverer must implement PortSetter")
+	}
+}

--- a/panel-api/internal/migrate/cloudpanel/init.go
+++ b/panel-api/internal/migrate/cloudpanel/init.go
@@ -1,0 +1,12 @@
+package cloudpanel
+
+import (
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func init() {
+	migrate.Register(models.MigrationSourceCloudPanel, func() migrate.Discoverer {
+		return New()
+	})
+}

--- a/panel-api/internal/models/migration_job.go
+++ b/panel-api/internal/models/migration_job.go
@@ -33,6 +33,15 @@ const (
 	// synthesising a cpmove-shaped tarball and reusing the cpanel restore
 	// writers. See plans/gh429-plesk-migration.md.
 	MigrationSourcePlesk = "plesk"
+	// MigrationSourceCloudPanel (GH #522) — full web-hosting migration from a
+	// CloudPanel source over SSH. CloudPanel stores its whole inventory in a
+	// SQLite database (/home/clp/htdocs/app/data/db.sq3), so discovery reads
+	// sites / databases / PHP versions with plain read-only SELECTs; `clpctl`
+	// + `mysqldump` handle DB creds + dumps. CloudPanel has NO mail server, so
+	// the manifest's Mailboxes area is always empty. Restore reuses the cpanel
+	// writers via cpmove synthesis (DirectAdmin strategy). See
+	// plans/gh522-cloudpanel-migration.md.
+	MigrationSourceCloudPanel = "cloudpanel"
 )
 
 // MigrationState is the per-job lifecycle. Stage transitions are


### PR DESCRIPTION
Step 1 of the CloudPanel migration source (blueprint: `plans/gh522-cloudpanel-migration.md`; feasibility: `plans/gh522-cloudpanel-migration-feasibility.md`). Additive + isolated — registered read-only Discoverer, **no restore, not in the UI picker yet** (per the "no half-features on main" rule).

## What lands
- `models.MigrationSourceCloudPanel = "cloudpanel"`.
- `internal/migrate/cloudpanel/`: Discoverer over SSH. CloudPanel keeps its whole inventory in **SQLite** (`/home/clp/htdocs/app/data/db.sq3`), so:
  - `Connect` validates by counting the `site` table — proves creds work, `sqlite3` is present, and it really is CloudPanel, before returning.
  - `ListAccounts` enumerates **site users** (a user may own several sites) with a read-only `SELECT`, filtering CloudPanel's own `clp` account.
  - `DescribeAccount` returns a valid empty manifest scaffold (per-area builders = step 2). CloudPanel has no mail → `Mailboxes` always empty.
- Registration via `serve.go` blank-import; `isKnownSourceKind` accepts the kind.

## Security
- All source reads use `sqlite3 -readonly` (cannot mutate the source).
- Account ids are allow-list validated (`siteUserRe`, Linux-username shape) and validated against the Go-side account list — **no operator input is interpolated into SQL/shell unescaped** (`shellSingleQuote` + regex gate, both tested).

## Tests (fixture-injected runner — no live host needed)
- [x] ListAccounts parsing + `clp` filtering
- [x] empty-manifest describe (Mailboxes empty, Source kind/user correct)
- [x] single-tenant autodetect; multi-tenant "pick one of" error
- [x] SQL/shell-injection ids rejected; `-readonly` + quoting asserted
- [x] registry wiring (`migrate.Get("cloudpanel")` + optional-interface conformance)
- [x] `go build ./...`, `go vet`, `gofmt` clean

Next: step 2 — per-account describe (domains / PHP version / databases / cron / ssh + SizeProber).