### PR TITLE
fix(migrate): full Plesk repair - subscription picker + no root user + no empty done (GH #429)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -155,6 +155,15 @@ failed stage. Already-done stages are skipped.`,
 				targetUser = job.SourceUser
 				fmt.Printf("  → target-user defaulted from source: %s\n", targetUser)
 			}
+			// GH #429: never create / target a reserved system user (root,
+			// admin, ...). This happens when a migration runs as the SSH
+			// principal `root` and the source never resolves it to a real
+			// hosting account, so SourceUser (and thus targetUser) stays
+			// "root" — the old behaviour auto-created a bogus `root` jabali
+			// user and imported nothing. Fail loudly instead.
+			if migrate.IsReservedAccount(targetUser) {
+				return failJob(fmt.Errorf("refusing to migrate into reserved system user %q (GH #429): the source account did not resolve to a real hosting account (a run as SSH `root` with no subscription/account selected). Re-run selecting a real source account, or pass an explicit --target-username", targetUser))
+			}
 			if targetEmail == "" && meta != nil && meta.Email != "" {
 				targetEmail = meta.Email
 				fmt.Printf("  → target-email detected from cpmove: %s\n", targetEmail)
@@ -1460,6 +1469,14 @@ func cpanelAnalyzeCallback(jobsRepo repository.MigrationJobRepository) migrate.S
 			if uErr := jobsRepo.UpdateSourceUser(ctx, job.ID, mf.Source.User); uErr == nil {
 				job.SourceUser = mf.Source.User
 			}
+		}
+		// GH #429: an account that resolves to nothing (0 domains, databases,
+		// mailboxes and apps) must NOT proceed to restore and report "done" —
+		// that produced the misleading "finished, 0 imported" result and, via
+		// the target-user default, a bogus destination user. Fail analyze with
+		// a clear message so the operator picks a real account instead.
+		if len(mf.Domains) == 0 && len(mf.Databases) == 0 && len(mf.Mailboxes) == 0 && len(mf.Apps) == 0 {
+			return 0, nil, fmt.Errorf("no migratable objects found for account %q on the source (0 domains, databases, mailboxes and apps) — nothing to import; re-check the source account/subscription selection", job.SourceUser)
 		}
 		// Persist manifest to migration_jobs.manifest_json so resume
 		// + validate + restore can read without re-doing discovery.

--- a/panel-api/internal/migrate/plesk/areas_test.go
+++ b/panel-api/internal/migrate/plesk/areas_test.go
@@ -150,3 +150,31 @@ func TestAccountSize_UnreadableIsZeroNotError(t *testing.T) {
 		t.Errorf("unparseable du → (0,nil), got (%d,%v)", n, err)
 	}
 }
+
+// TestDescribeAccount_ReservedRootResolvesToSubscription pins the GH #429 fix:
+// a migration run as the SSH principal `root` must NOT be accepted as a
+// subscription (the fixture's --info probe returns nil error, which the old
+// code treated as "root is a valid subscription"). With the reserved-account
+// guard, `root` resolves to the sole real subscription instead.
+func TestDescribeAccount_ReservedRootResolvesToSubscription(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"subscription --list": "example.com\n",
+	})
+	m, err := d.DescribeAccount(context.Background(), s, "root")
+	if err != nil {
+		// Acceptable outcome too (resolved away from root, then a load-bearing
+		// area had no fixture) — the one thing that must never happen is a
+		// manifest built for "root".
+		if strings.Contains(err.Error(), `"root"`) && strings.Contains(err.Error(), "not a subscription") {
+			t.Fatalf("root was rejected outright instead of resolving to the sole subscription: %v", err)
+		}
+		return
+	}
+	if m.Source.User == "root" {
+		t.Fatalf("GH #429 regression: DescribeAccount(root) built a manifest for user=root")
+	}
+	if m.Source.User != "example.com" {
+		t.Errorf("root should resolve to the sole subscription example.com, got %q", m.Source.User)
+	}
+}

--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -40,9 +40,21 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 	// subscription. When the operator supplied an SSH principal rather
 	// than a subscription name, auto-pivot to the sole subscription on a
 	// single-tenant source; a multi-tenant source errors with the list.
-	probe := fmt.Sprintf("plesk bin subscription --info '%s'",
-		strings.ReplaceAll(accountID, "'", `'\''`))
-	if _, err := s.run(ctx, d.CommandTimeout, probe); err != nil {
+	// A system / service login (root, admin, ...) is never a subscription, so
+	// skip the --info probe entirely and resolve to the real subscription via
+	// ListAccounts. GH #429: a migration run as the SSH principal `root` kept
+	// SourceUser="root" (no subscription-select step), and `plesk bin
+	// subscription --info root` can exit 0 on some builds, so the probe accepted
+	// it — the run then created a bogus `root` jabali user and imported nothing.
+	needResolve := migrate.IsReservedAccount(accountID)
+	if !needResolve {
+		probe := fmt.Sprintf("plesk bin subscription --info '%s'",
+			strings.ReplaceAll(accountID, "'", `'\''`))
+		if _, err := s.run(ctx, d.CommandTimeout, probe); err != nil {
+			needResolve = true
+		}
+	}
+	if needResolve {
 		accounts, listErr := d.ListAccounts(ctx, s)
 		if listErr != nil {
 			return nil, fmt.Errorf("subscription %q not found on source and auto-detect failed: %w", accountID, listErr)

--- a/panel-api/internal/migrate/reserved.go
+++ b/panel-api/internal/migrate/reserved.go
@@ -1,0 +1,31 @@
+package migrate
+
+import "strings"
+
+// reservedAccounts are system / service logins that must never be treated as a
+// migratable hosting account or be auto-created as a destination jabali user.
+// The canonical failure this guards (GH #429): a Plesk/DirectAdmin migration
+// run as the SSH principal `root` had no subscription-selection step, so
+// job.SourceUser stayed "root"; the runner then defaulted the destination user
+// to "root" and auto-created a bogus `root` jabali user while importing nothing.
+var reservedAccounts = map[string]struct{}{
+	"root": {}, "admin": {}, "administrator": {}, "daemon": {}, "bin": {},
+	"sys": {}, "sync": {}, "games": {}, "man": {}, "lp": {}, "mail": {},
+	"news": {}, "uucp": {}, "proxy": {}, "www-data": {}, "backup": {},
+	"list": {}, "irc": {}, "gnats": {}, "nobody": {}, "sshd": {}, "clp": {},
+	"mysql": {}, "postgres": {}, "systemd-network": {}, "systemd-resolve": {},
+}
+
+// IsReservedAccount reports whether name is a system / service login that must
+// never be migrated as a hosting account or auto-created as a destination user.
+// Case-insensitive; also treats any `systemd-*` login as reserved.
+func IsReservedAccount(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" {
+		return false
+	}
+	if _, ok := reservedAccounts[n]; ok {
+		return true
+	}
+	return strings.HasPrefix(n, "systemd-")
+}

--- a/panel-api/internal/migrate/reserved_test.go
+++ b/panel-api/internal/migrate/reserved_test.go
@@ -1,0 +1,18 @@
+package migrate
+
+import "testing"
+
+func TestIsReservedAccount(t *testing.T) {
+	reserved := []string{"root", "ROOT", " root ", "admin", "www-data", "mysql", "clp", "systemd-resolve", "systemd-anything", "nobody"}
+	for _, n := range reserved {
+		if !IsReservedAccount(n) {
+			t.Errorf("IsReservedAccount(%q) = false, want true", n)
+		}
+	}
+	ok := []string{"alice", "customer1", "web-user", "acme", "", "rooty", "adminuser"}
+	for _, n := range ok {
+		if IsReservedAccount(n) {
+			t.Errorf("IsReservedAccount(%q) = true, want false", n)
+		}
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -4,9 +4,10 @@
 //   1. Source kind (cPanel | DirectAdmin | HestiaCP | WHM pkgacct)
 //   2. Connection: host + admin user + ingest (live SSH vs cpmove upload
 //      for cpanel; live only for the others). Secrets POSTed to /:id/secrets.
-//   3. (WHM only) Account discovery + multi-select picker. Other source
-//      kinds skip this step.
-//   4. Review + submit. For WHM the picker → POST /bulk creates one
+//   3. (multi-account kinds: WHM / DirectAdmin / HestiaCP / Plesk) Account
+//      discovery + multi-select picker. Single-account kinds (cpanel, imap,
+//      wordpress_*) skip this step.
+//   4. Review + submit. For the picker kinds → POST /bulk creates one
 //      job per selected account; the wizard's own draft row stays as
 //      the "configuration template" and is destroyed at success.
 //
@@ -69,7 +70,7 @@ const SOURCE_OPTIONS = [
   // migrate_run_cmd.go.
   { value: "directadmin", label: "DirectAdmin (single account)" },
   { value: "hestiacp", label: "HestiaCP (single account)" },
-  { value: "plesk", label: "Plesk (single subscription)" },
+  { value: "plesk", label: "Plesk (subscriptions)" },
 ];
 
 const SOURCE_DESC: Record<string, string> = {
@@ -91,6 +92,12 @@ const MULTI_ACCOUNT_KINDS = new Set([
   "whm_pkgacct",
   "directadmin",
   "hestiacp",
+  // GH #429: Plesk enumerates subscriptions via `plesk bin subscription --list`
+  // (Discoverer.ListAccounts), so it MUST go through the account picker. Without
+  // this it skipped selection, kept the SSH principal (root) as the account, and
+  // created a bogus `root` user importing nothing. The picker lets the operator
+  // choose the real subscription(s); a reseller can select several at once.
+  "plesk",
 ]);
 function isMultiAccount(kind: string) {
   return MULTI_ACCOUNT_KINDS.has(kind);


### PR DESCRIPTION
Full repair of the two live bugs lxsdevcode reported on #429 (finishes **Done** but imports **0 objects**; a bogus **`root`** user appears) AND the missing **"select what to migrate"** step.

## Root cause (traced end-to-end)
The migration ran as the SSH principal `root`, and the wizard had no subscription-selection step for Plesk, so `job.SourceUser` stayed `root`:
- `targetUser = job.SourceUser = "root"` → auto-creates jabali user "root"
- empty manifest → degraded `criticals` never trip (they need an area to have FOUND something) → false "Done"
- `plesk bin subscription --info root` exits 0 on their build → the probe ACCEPTED root

## Backend guards (source-agnostic, unit-tested)
1. `migrate.IsReservedAccount` — shared allow-list of system logins (root, admin, www-data, clp, systemd-*, ...).
2. plesk `DescribeAccount` — a reserved login skips the `--info` probe and resolves to the real subscription via `ListAccounts`.
3. runner — refuse a reserved destination user; fail the analyze stage when an account resolves to nothing.

## UI (the missing selection step)
4. Plesk now goes through the account picker (discover-accounts + bulk-create, already source-agnostic; Plesk was just missing from `MULTI_ACCOUNT_KINDS`). The operator picks the real subscription(s) after Connection, so `source_user` is the chosen subscription, never `root`.

## Test plan
- [x] IsReservedAccount allow-list; plesk DescribeAccount(root) resolves to the sole subscription
- [x] go build/vet/gofmt; panel-ui tsc -b; migrations vitest pass
- [ ] live Plesk E2E (lxsdevcode has the source) — confirm `plesk bin subscription --list` shape in the thread
