### PR TITLE
fix(install): timeouts + retries on release-asset downloads (GH #545)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4313,8 +4313,10 @@ install_go() {
 
   _log "installing Go $GO_VERSION ($GO_ARCH)"
   local tarball="/tmp/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
-  curl -fsSL -o "$tarball" \
-    "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+  if ! curl -fsSL --connect-timeout 20 --retry 3 --retry-delay 5 --retry-connrefused --speed-limit 1024 --speed-time 30 -o "$tarball" \
+    "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"; then
+    _die "failed to download Go $GO_VERSION from go.dev — check egress to go.dev from this host"
+  fi
   tar -C /usr/local -xzf "$tarball"
   rm -f "$tarball"
 
@@ -11361,7 +11363,7 @@ _install_stalwart_binary() {
   local sha_file="${REPO_DIR}/install/stalwart.sha256"
 
   _log "downloading Stalwart $version from GitHub"
-  if ! curl -fsSL "$url" -o "$tarball_path"; then
+  if ! curl -fsSL --connect-timeout 20 --retry 3 --retry-delay 5 --retry-connrefused --speed-limit 1024 --speed-time 30 "$url" -o "$tarball_path"; then
     _die "failed to download Stalwart from $url"
   fi
 
@@ -11470,7 +11472,7 @@ _install_stalwart_cli() {
   fi
 
   _log "downloading stalwart-cli $cli_version"
-  if ! curl -fsSL "$url" -o "$tarball_path"; then
+  if ! curl -fsSL --connect-timeout 20 --retry 3 --retry-delay 5 --retry-connrefused --speed-limit 1024 --speed-time 30 "$url" -o "$tarball_path"; then
     _die "failed to download stalwart-cli from $url"
   fi
 
@@ -11656,7 +11658,7 @@ install_bulwark() {
 
   local tarball_path="/tmp/${tarball}"
   _log "downloading $tarball"
-  if ! curl -fsSL "$url" -o "$tarball_path"; then
+  if ! curl -fsSL --connect-timeout 20 --retry 3 --retry-delay 5 --retry-connrefused --speed-limit 1024 --speed-time 30 "$url" -o "$tarball_path"; then
     _die "failed to download Bulwark from $url"
   fi
 


### PR DESCRIPTION
altomarketing (#545) hit a fresh install that **hangs forever** at:
```
[i] downloading bulwark-standalone-1.7.7-linux-amd64.tar.gz
```
(prompt returned from a second SSH session; no error, no progress.)

## Cause
The release-asset downloads ran plain `curl -fsSL "$url" -o file` with **no connect/transfer timeout**, so a stalled connection to the GitHub release CDN blocks the installer indefinitely. Four of them: Bulwark, Stalwart server, Stalwart CLI, and the Go toolchain.

## Fix
Add `--connect-timeout 20 --retry 3 --retry-delay 5 --retry-connrefused --speed-limit 1024 --speed-time 30` to all four. A connection transferring < 1KB/s for 30s (a stall) is aborted + retried; a genuinely unreachable CDN now fails cleanly through the existing `_die` ("check egress ...") instead of hanging. The Go download also gains the error guard it lacked (it was a bare `curl`).

## Verified
- Real Bulwark 1.7.7 tarball downloads fine with the flags (happy path intact, 37 MB).
- A stalled / unroutable endpoint aborts in seconds (retries then fails) instead of hanging.
- `bash -n install.sh` clean.

## Note for the reporter
If their VPS simply cannot reach the GitHub release CDN (`objects.githubusercontent.com`), the download will now **fail with a clear message** rather than hang — but they still need working egress. Asking them to confirm `curl -I` to the asset URL in the thread.