### PR TITLE
feat(packages): tenant-backup limit fields on hosting packages (GH #454 step 1)

### DIFF
--- a/panel-api/internal/api/packages.go
+++ b/panel-api/internal/api/packages.go
@@ -71,54 +71,62 @@ type createPackageRequest struct {
 	Name        string `json:"name"               binding:"required"`
 	DiskQuotaMB uint32 `json:"disk_quota_mb"`
 	// M18 resource limits. Zero = unlimited on every field.
-	CPUQuotaPercent    uint32 `json:"cpu_quota_percent"`
-	MemoryLimitMB      uint32 `json:"memory_limit_mb"`
-	IOReadMbps         uint32 `json:"io_read_mbps"`
-	IOWriteMbps        uint32 `json:"io_write_mbps"`
-	MaxTasks           uint32 `json:"max_tasks"`
-	BandwidthQuotaMB   uint32 `json:"bandwidth_quota_mb"`
-	MaxDomains         uint32 `json:"max_domains"`
-	MaxEmailAccounts   uint32 `json:"max_email_accounts"`
-	MaxDatabases       uint32 `json:"max_databases"`
-	MaxDockerApps      uint32 `json:"max_docker_apps"`
-	MaxPythonApps      uint32 `json:"max_python_apps"`
-	SSHEnabled         bool   `json:"ssh_enabled"`
-	CGIEnabled         bool   `json:"cgi_enabled"`
-	PHPExecEnabled     bool   `json:"php_exec_enabled"`
-	FpmMaxChildrenCap  uint32 `json:"fpm_max_children_cap"`
-	FpmWorkerMemMb     uint32 `json:"fpm_worker_mem_mb"`
-	FpmUserCanEdit     bool   `json:"fpm_user_can_edit"`
-	FpmAdvancedMode    bool   `json:"fpm_advanced_mode"`
-	FpmVersionDefaults string `json:"fpm_version_defaults"`
-	DockerAppSlugs     string `json:"docker_app_slugs"`
+	CPUQuotaPercent  uint32 `json:"cpu_quota_percent"`
+	MemoryLimitMB    uint32 `json:"memory_limit_mb"`
+	IOReadMbps       uint32 `json:"io_read_mbps"`
+	IOWriteMbps      uint32 `json:"io_write_mbps"`
+	MaxTasks         uint32 `json:"max_tasks"`
+	BandwidthQuotaMB uint32 `json:"bandwidth_quota_mb"`
+	MaxDomains       uint32 `json:"max_domains"`
+	MaxEmailAccounts uint32 `json:"max_email_accounts"`
+	MaxDatabases     uint32 `json:"max_databases"`
+	MaxDockerApps    uint32 `json:"max_docker_apps"`
+	MaxPythonApps    uint32 `json:"max_python_apps"`
+	// Tenant backup limits (GH #454). 0 = backups not included on this plan.
+	MaxBackups                    uint32 `json:"max_backups"`
+	ScheduledBackupsEnabled       bool   `json:"scheduled_backups_enabled"`
+	AllowedBackupDestinationKinds string `json:"allowed_backup_destination_kinds"`
+	SSHEnabled                    bool   `json:"ssh_enabled"`
+	CGIEnabled                    bool   `json:"cgi_enabled"`
+	PHPExecEnabled                bool   `json:"php_exec_enabled"`
+	FpmMaxChildrenCap             uint32 `json:"fpm_max_children_cap"`
+	FpmWorkerMemMb                uint32 `json:"fpm_worker_mem_mb"`
+	FpmUserCanEdit                bool   `json:"fpm_user_can_edit"`
+	FpmAdvancedMode               bool   `json:"fpm_advanced_mode"`
+	FpmVersionDefaults            string `json:"fpm_version_defaults"`
+	DockerAppSlugs                string `json:"docker_app_slugs"`
 	// M13: nspawn image pin (empty = use server default).
 	NspawnImageVersion string `json:"nspawn_image_version"`
 }
 
 type updatePackageRequest struct {
-	Name               *string `json:"name"`
-	DiskQuotaMB        *uint32 `json:"disk_quota_mb"`
-	CPUQuotaPercent    *uint32 `json:"cpu_quota_percent"`
-	MemoryLimitMB      *uint32 `json:"memory_limit_mb"`
-	IOReadMbps         *uint32 `json:"io_read_mbps"`
-	IOWriteMbps        *uint32 `json:"io_write_mbps"`
-	MaxTasks           *uint32 `json:"max_tasks"`
-	BandwidthQuotaMB   *uint32 `json:"bandwidth_quota_mb"`
-	MaxDomains         *uint32 `json:"max_domains"`
-	MaxEmailAccounts   *uint32 `json:"max_email_accounts"`
-	MaxDatabases       *uint32 `json:"max_databases"`
-	MaxDockerApps      *uint32 `json:"max_docker_apps"`
-	MaxPythonApps      *uint32 `json:"max_python_apps"`
-	SSHEnabled         *bool   `json:"ssh_enabled"`
-	CGIEnabled         *bool   `json:"cgi_enabled"`
-	PHPExecEnabled     *bool   `json:"php_exec_enabled"`
-	FpmMaxChildrenCap  *uint32 `json:"fpm_max_children_cap"`
-	FpmWorkerMemMb     *uint32 `json:"fpm_worker_mem_mb"`
-	FpmUserCanEdit     *bool   `json:"fpm_user_can_edit"`
-	FpmAdvancedMode    *bool   `json:"fpm_advanced_mode"`
-	FpmVersionDefaults *string `json:"fpm_version_defaults"`
-	DockerAppSlugs     *string `json:"docker_app_slugs"`
-	NspawnImageVersion *string `json:"nspawn_image_version"`
+	Name             *string `json:"name"`
+	DiskQuotaMB      *uint32 `json:"disk_quota_mb"`
+	CPUQuotaPercent  *uint32 `json:"cpu_quota_percent"`
+	MemoryLimitMB    *uint32 `json:"memory_limit_mb"`
+	IOReadMbps       *uint32 `json:"io_read_mbps"`
+	IOWriteMbps      *uint32 `json:"io_write_mbps"`
+	MaxTasks         *uint32 `json:"max_tasks"`
+	BandwidthQuotaMB *uint32 `json:"bandwidth_quota_mb"`
+	MaxDomains       *uint32 `json:"max_domains"`
+	MaxEmailAccounts *uint32 `json:"max_email_accounts"`
+	MaxDatabases     *uint32 `json:"max_databases"`
+	MaxDockerApps    *uint32 `json:"max_docker_apps"`
+	MaxPythonApps    *uint32 `json:"max_python_apps"`
+	// Tenant backup limits (GH #454).
+	MaxBackups                    *uint32 `json:"max_backups"`
+	ScheduledBackupsEnabled       *bool   `json:"scheduled_backups_enabled"`
+	AllowedBackupDestinationKinds *string `json:"allowed_backup_destination_kinds"`
+	SSHEnabled                    *bool   `json:"ssh_enabled"`
+	CGIEnabled                    *bool   `json:"cgi_enabled"`
+	PHPExecEnabled                *bool   `json:"php_exec_enabled"`
+	FpmMaxChildrenCap             *uint32 `json:"fpm_max_children_cap"`
+	FpmWorkerMemMb                *uint32 `json:"fpm_worker_mem_mb"`
+	FpmUserCanEdit                *bool   `json:"fpm_user_can_edit"`
+	FpmAdvancedMode               *bool   `json:"fpm_advanced_mode"`
+	FpmVersionDefaults            *string `json:"fpm_version_defaults"`
+	DockerAppSlugs                *string `json:"docker_app_slugs"`
+	NspawnImageVersion            *string `json:"nspawn_image_version"`
 }
 
 // ---- handlers ----
@@ -164,21 +172,33 @@ func (h *packageHandler) create(c *gin.Context) {
 	if req.FpmAdvancedMode {
 		req.FpmUserCanEdit = true // advanced implies can-edit
 	}
+	// GH #454: validate + canonicalise the allowed backup destination kinds.
+	normKinds, nkErr := models.NormalizeBackupKindsCSV(req.AllowedBackupDestinationKinds)
+	if nkErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_backup_kinds", "detail": nkErr.Error()})
+		return
+	}
+	req.AllowedBackupDestinationKinds = normKinds
 	pkg := &models.HostingPackage{
-		ID:                 ids.NewULID(),
-		Name:               req.Name,
-		DiskQuotaMB:        req.DiskQuotaMB,
-		CPUQuotaPercent:    req.CPUQuotaPercent,
-		MemoryLimitMB:      req.MemoryLimitMB,
-		IOReadMbps:         req.IOReadMbps,
-		IOWriteMbps:        req.IOWriteMbps,
-		MaxTasks:           req.MaxTasks,
-		BandwidthQuotaMB:   req.BandwidthQuotaMB,
-		MaxDomains:         req.MaxDomains,
-		MaxEmailAccounts:   req.MaxEmailAccounts,
-		MaxDatabases:       req.MaxDatabases,
-		MaxDockerApps:      req.MaxDockerApps,
-		MaxPythonApps:      req.MaxPythonApps,
+		ID:               ids.NewULID(),
+		Name:             req.Name,
+		DiskQuotaMB:      req.DiskQuotaMB,
+		CPUQuotaPercent:  req.CPUQuotaPercent,
+		MemoryLimitMB:    req.MemoryLimitMB,
+		IOReadMbps:       req.IOReadMbps,
+		IOWriteMbps:      req.IOWriteMbps,
+		MaxTasks:         req.MaxTasks,
+		BandwidthQuotaMB: req.BandwidthQuotaMB,
+		MaxDomains:       req.MaxDomains,
+		MaxEmailAccounts: req.MaxEmailAccounts,
+		MaxDatabases:     req.MaxDatabases,
+		MaxDockerApps:    req.MaxDockerApps,
+		MaxPythonApps:    req.MaxPythonApps,
+
+		MaxBackups:                    req.MaxBackups,
+		ScheduledBackupsEnabled:       req.ScheduledBackupsEnabled,
+		AllowedBackupDestinationKinds: req.AllowedBackupDestinationKinds,
+
 		SSHEnabled:         req.SSHEnabled,
 		CGIEnabled:         req.CGIEnabled,
 		PHPExecEnabled:     req.PHPExecEnabled,
@@ -308,6 +328,20 @@ func (h *packageHandler) update(c *gin.Context) {
 	}
 	if req.MaxPythonApps != nil {
 		pkg.MaxPythonApps = *req.MaxPythonApps
+	}
+	if req.MaxBackups != nil {
+		pkg.MaxBackups = *req.MaxBackups
+	}
+	if req.ScheduledBackupsEnabled != nil {
+		pkg.ScheduledBackupsEnabled = *req.ScheduledBackupsEnabled
+	}
+	if req.AllowedBackupDestinationKinds != nil {
+		normKinds, nkErr := models.NormalizeBackupKindsCSV(*req.AllowedBackupDestinationKinds)
+		if nkErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_backup_kinds", "detail": nkErr.Error()})
+			return
+		}
+		pkg.AllowedBackupDestinationKinds = normKinds
 	}
 	if req.SSHEnabled != nil {
 		pkg.SSHEnabled = *req.SSHEnabled

--- a/panel-api/internal/db/migrations/000231_package_backup_limits.down.sql
+++ b/panel-api/internal/db/migrations/000231_package_backup_limits.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE hosting_packages
+  DROP COLUMN allowed_backup_destination_kinds,
+  DROP COLUMN scheduled_backups_enabled,
+  DROP COLUMN max_backups;

--- a/panel-api/internal/db/migrations/000231_package_backup_limits.up.sql
+++ b/panel-api/internal/db/migrations/000231_package_backup_limits.up.sql
@@ -1,0 +1,15 @@
+-- GH #454 Step 1: per-package tenant-backup entitlement + limits.
+--
+-- max_backups: tenant retention cap (max snapshots kept); 0 = tenant backups
+--   NOT included on this plan (safe default, opt-in per plan — mirrors
+--   max_docker_apps / max_python_apps). The whole tenant backup UI is gated on
+--   max_backups > 0.
+-- scheduled_backups_enabled: whether tenants on this plan may enable a
+--   scheduled backup. The admin owns the schedule TIME (resource planning); the
+--   tenant owns the content (what/destination) within these limits.
+-- allowed_backup_destination_kinds: CSV of BackupDestinationKind* a tenant may
+--   back up to (e.g. "local,s3"); empty = none allowed (must opt-in).
+ALTER TABLE hosting_packages
+  ADD COLUMN max_backups INT UNSIGNED NOT NULL DEFAULT 0,
+  ADD COLUMN scheduled_backups_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN allowed_backup_destination_kinds VARCHAR(255) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/backup_destination.go
+++ b/panel-api/internal/models/backup_destination.go
@@ -7,6 +7,8 @@ package models
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -30,6 +32,41 @@ var AllBackupDestinationKinds = []string{
 	BackupDestinationKindAzure,
 	BackupDestinationKindGCS,
 	BackupDestinationKindREST,
+}
+
+// IsValidBackupDestinationKind reports whether kind is a known destination kind.
+func IsValidBackupDestinationKind(kind string) bool {
+	for _, k := range AllBackupDestinationKinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeBackupKindsCSV validates + canonicalises a comma-separated list of
+// backup destination kinds (GH #454, hosting_packages.allowed_backup_destination
+// _kinds): lower-cased, trimmed, deduped, order-preserving. Returns an error on
+// any unknown kind so the API rejects bad input rather than silently storing it.
+// The empty string is valid (no kinds allowed).
+func NormalizeBackupKindsCSV(csv string) (string, error) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, part := range strings.Split(csv, ",") {
+		k := strings.ToLower(strings.TrimSpace(part))
+		if k == "" {
+			continue
+		}
+		if !IsValidBackupDestinationKind(k) {
+			return "", fmt.Errorf("unknown backup destination kind %q (valid: %s)", k, strings.Join(AllBackupDestinationKinds, ", "))
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return strings.Join(out, ","), nil
 }
 
 // SFTPAuthKey + SFTPAuthPassword are the values BackupDestinationExtraOptions.SFTP.Auth
@@ -62,21 +99,21 @@ type SFTPOptions struct {
 }
 
 type BackupDestination struct {
-	ID             string          `gorm:"type:char(26);primaryKey" json:"id"`
-	Name           string          `gorm:"type:varchar(64);not null;uniqueIndex:uniq_backup_dest_name" json:"name"`
-	Kind           string          `gorm:"type:enum('local','sftp','s3','b2','azure','gcs','rest');not null" json:"kind"`
-	URL            string          `gorm:"type:varchar(512);not null" json:"url"`
-	CredentialsRef *string         `gorm:"type:varchar(255)" json:"credentials_ref,omitempty"`
+	ID             string  `gorm:"type:char(26);primaryKey" json:"id"`
+	Name           string  `gorm:"type:varchar(64);not null;uniqueIndex:uniq_backup_dest_name" json:"name"`
+	Kind           string  `gorm:"type:enum('local','sftp','s3','b2','azure','gcs','rest');not null" json:"kind"`
+	URL            string  `gorm:"type:varchar(512);not null" json:"url"`
+	CredentialsRef *string `gorm:"type:varchar(255)" json:"credentials_ref,omitempty"`
 	// PasswordEnc is the AES-256-GCM-sealed restic repository password
 	// (M30.2 — per-destination encryption rotation, ADR-pending). NULL
 	// rows fall back to the legacy shared password file. Field is
 	// stripped from JSON; the password is never read by the SPA.
-	PasswordEnc       []byte     `gorm:"type:varbinary(512)" json:"-"`
-	PasswordRotatedAt *time.Time `gorm:"type:datetime(6)" json:"password_rotated_at,omitempty"`
+	PasswordEnc       []byte          `gorm:"type:varbinary(512)" json:"-"`
+	PasswordRotatedAt *time.Time      `gorm:"type:datetime(6)" json:"password_rotated_at,omitempty"`
 	ExtraOptions      json.RawMessage `gorm:"type:json" json:"extra_options,omitempty"`
-	Enabled        bool            `gorm:"not null;default:1" json:"enabled"`
-	CreatedAt      time.Time       `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt      time.Time       `gorm:"type:datetime(6);not null" json:"updated_at"`
+	Enabled           bool            `gorm:"not null;default:1" json:"enabled"`
+	CreatedAt         time.Time       `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt         time.Time       `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (BackupDestination) TableName() string { return "backup_destinations" }

--- a/panel-api/internal/models/hosting_package.go
+++ b/panel-api/internal/models/hosting_package.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 )
 
@@ -42,6 +43,18 @@ type HostingPackage struct {
 	// tenant_installable.
 	DockerAppSlugs string `gorm:"column:docker_app_slugs;type:varchar(2000);not null;default:''" json:"docker_app_slugs"`
 
+	// Backup entitlement (GH #454). MaxBackups is the tenant retention cap
+	// (max snapshots kept); 0 = tenant backups NOT included on this plan (safe
+	// default, opt-in per plan, mirrors MaxDockerApps). The whole tenant backup
+	// UI is gated on MaxBackups > 0. ScheduledBackupsEnabled gates the tenant
+	// scheduled-backup toggle — the admin owns the schedule TIME, the tenant
+	// owns the content within these limits. AllowedBackupDestinationKinds is a
+	// CSV of BackupDestinationKind* a tenant on this package may target; empty
+	// = none allowed.
+	MaxBackups                    uint32 `gorm:"column:max_backups;type:int unsigned;not null;default:0" json:"max_backups"`
+	ScheduledBackupsEnabled       bool   `gorm:"column:scheduled_backups_enabled;type:tinyint(1);not null;default:0" json:"scheduled_backups_enabled"`
+	AllowedBackupDestinationKinds string `gorm:"column:allowed_backup_destination_kinds;type:varchar(255);not null;default:''" json:"allowed_backup_destination_kinds"`
+
 	// Feature toggles.
 	SSHEnabled bool `gorm:"type:tinyint(1);not null;default:0" json:"ssh_enabled"`
 	CGIEnabled bool `gorm:"type:tinyint(1);not null;default:0" json:"cgi_enabled"`
@@ -77,3 +90,44 @@ type HostingPackage struct {
 }
 
 func (HostingPackage) TableName() string { return "hosting_packages" }
+
+// BackupsEnabled reports whether tenants on this package may use backups at all
+// (MaxBackups > 0). The tenant backup UI + API are gated on this (GH #454).
+func (p HostingPackage) BackupsEnabled() bool { return p.MaxBackups > 0 }
+
+// AllowedBackupKinds parses AllowedBackupDestinationKinds (CSV) into a deduped,
+// lower-cased, order-preserving slice. Empty when none are allowed.
+func (p HostingPackage) AllowedBackupKinds() []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, part := range strings.Split(p.AllowedBackupDestinationKinds, ",") {
+		k := strings.ToLower(strings.TrimSpace(part))
+		if k == "" {
+			continue
+		}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
+}
+
+// AllowsBackupKind reports whether a tenant on this package may target the given
+// backup destination kind. Always false when backups are disabled.
+func (p HostingPackage) AllowsBackupKind(kind string) bool {
+	if !p.BackupsEnabled() {
+		return false
+	}
+	k := strings.ToLower(strings.TrimSpace(kind))
+	if k == "" {
+		return false
+	}
+	for _, a := range p.AllowedBackupKinds() {
+		if a == k {
+			return true
+		}
+	}
+	return false
+}

--- a/panel-api/internal/models/hosting_package_backup_test.go
+++ b/panel-api/internal/models/hosting_package_backup_test.go
@@ -1,0 +1,52 @@
+package models
+
+import "testing"
+
+func TestNormalizeBackupKindsCSV(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"local", "local", false},
+		{" LOCAL , s3 ", "local,s3", false},
+		{"local,local,s3", "local,s3", false}, // dedup
+		{"local,bogus", "", true},             // unknown kind
+		{"ftp", "", true},
+	}
+	for _, c := range cases {
+		got, err := NormalizeBackupKindsCSV(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("NormalizeBackupKindsCSV(%q) err=%v, wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if !c.wantErr && got != c.want {
+			t.Errorf("NormalizeBackupKindsCSV(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestHostingPackageBackupHelpers(t *testing.T) {
+	off := HostingPackage{MaxBackups: 0, AllowedBackupDestinationKinds: "local,s3"}
+	if off.BackupsEnabled() {
+		t.Error("MaxBackups=0 must report BackupsEnabled=false")
+	}
+	if off.AllowsBackupKind("local") {
+		t.Error("backups disabled must reject every kind, even allowed ones")
+	}
+
+	on := HostingPackage{MaxBackups: 5, AllowedBackupDestinationKinds: "local, S3"}
+	if !on.BackupsEnabled() {
+		t.Error("MaxBackups>0 must report BackupsEnabled=true")
+	}
+	if got := on.AllowedBackupKinds(); len(got) != 2 || got[0] != "local" || got[1] != "s3" {
+		t.Errorf("AllowedBackupKinds = %v, want [local s3]", got)
+	}
+	if !on.AllowsBackupKind("s3") || !on.AllowsBackupKind("LOCAL") {
+		t.Error("AllowsBackupKind must match allowed kinds case-insensitively")
+	}
+	if on.AllowsBackupKind("b2") {
+		t.Error("AllowsBackupKind must reject a kind not in the allow-list")
+	}
+}

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -26,6 +26,9 @@ import { useDiskQuotaEnabled } from "../../../hooks/useDiskQuotaEnabled";
 
 type NspawnImage = { name: string };
 
+// Mirrors models.AllBackupDestinationKinds (GH #454).
+const BACKUP_DESTINATION_KINDS = ["local", "sftp", "s3", "b2", "azure", "gcs", "rest"] as const;
+
 type PackageCreateInput = {
   name: string;
   disk_quota_mb: number;
@@ -40,6 +43,10 @@ type PackageCreateInput = {
   max_databases: number;
   max_docker_apps: number;
   max_python_apps: number;
+  // Tenant backup limits (GH #454).
+  max_backups: number;
+  scheduled_backups_enabled: boolean;
+  allowed_backup_destination_kinds: string | string[];
   ssh_enabled: boolean;
   cgi_enabled: boolean;
   php_exec_enabled: boolean;
@@ -100,6 +107,9 @@ export const PackageCreate = () => {
       const payload = {
         ...values,
         docker_app_slugs: Array.isArray(values.docker_app_slugs) ? values.docker_app_slugs.join(",") : "",
+        allowed_backup_destination_kinds: Array.isArray(values.allowed_backup_destination_kinds)
+          ? values.allowed_backup_destination_kinds.join(",")
+          : (values.allowed_backup_destination_kinds ?? ""),
       } as unknown as PackageCreateInput;
       await createMutation.mutateAsync(payload);
       message.success("Package created");
@@ -139,6 +149,9 @@ export const PackageCreate = () => {
           max_databases: 0,
           max_docker_apps: 0,
           max_python_apps: 0,
+          max_backups: 0,
+          scheduled_backups_enabled: false,
+          allowed_backup_destination_kinds: [],
         }}
         onFinish={handleFinish}
       >
@@ -284,6 +297,49 @@ export const PackageCreate = () => {
               tooltip="0 = Python apps not included in this package"
             >
               <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Divider titlePlacement="left">Backups</Divider>
+        <Typography.Paragraph type="secondary" style={{ marginTop: -8 }}>
+          Tenant self-service backups (GH #454). The admin owns the schedule time;
+          tenants choose what to back up and which allowed destination, within these
+          limits. Max backups = 0 disables tenant backups entirely.
+        </Typography.Paragraph>
+        <Row gutter={16}>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Max Backups"
+              name="max_backups"
+              tooltip="Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included."
+            >
+              <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Scheduled Backups"
+              name="scheduled_backups_enabled"
+              valuePropName="checked"
+              tooltip="Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled."
+            >
+              <Switch />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Allowed Backup Destinations"
+              name="allowed_backup_destination_kinds"
+              tooltip="Destination kinds a tenant may back up to. Empty = none allowed."
+            >
+              <Select
+                mode="multiple"
+                allowClear
+                placeholder="e.g. local, s3"
+                options={BACKUP_DESTINATION_KINDS.map((k) => ({ value: k, label: k }))}
+                style={{ width: "100%" }}
+              />
             </Form.Item>
           </Col>
         </Row>

--- a/panel-ui/src/shells/admin/packages/PackageEdit.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageEdit.tsx
@@ -27,6 +27,10 @@ import { useDiskQuotaEnabled } from "../../../hooks/useDiskQuotaEnabled";
 
 type NspawnImage = { name: string };
 
+// Mirrors models.AllBackupDestinationKinds (GH #454). Keep in sync with the
+// backend enum in backup_destination.go.
+const BACKUP_DESTINATION_KINDS = ["local", "sftp", "s3", "b2", "azure", "gcs", "rest"] as const;
+
 type PackageEditInput = {
   name: string;
   disk_quota_mb: number;
@@ -42,6 +46,12 @@ type PackageEditInput = {
   max_databases: number;
   max_docker_apps: number;
   max_python_apps: number;
+  // Tenant backup limits (GH #454). allowed_backup_destination_kinds is a CSV
+  // string on the wire; the multi-Select binds an array (converted on load/save,
+  // like docker_app_slugs).
+  max_backups: number;
+  scheduled_backups_enabled: boolean;
+  allowed_backup_destination_kinds: string | string[];
   ssh_enabled: boolean;
   cgi_enabled: boolean;
   php_exec_enabled: boolean;
@@ -109,7 +119,13 @@ export const PackageEdit = () => {
       void _id;
       // docker_app_slugs is a CSV string on the wire; the Select needs an array.
       const csv = typeof rest.docker_app_slugs === "string" ? rest.docker_app_slugs : "";
-      form.setFieldsValue({ ...rest, docker_app_slugs: csv ? csv.split(",").filter(Boolean) : [] });
+      // allowed_backup_destination_kinds (GH #454) is CSV too.
+      const bkCsv = typeof rest.allowed_backup_destination_kinds === "string" ? rest.allowed_backup_destination_kinds : "";
+      form.setFieldsValue({
+        ...rest,
+        docker_app_slugs: csv ? csv.split(",").filter(Boolean) : [],
+        allowed_backup_destination_kinds: bkCsv ? bkCsv.split(",").filter(Boolean) : [],
+      });
     }
   }, [data, form]);
 
@@ -119,6 +135,9 @@ export const PackageEdit = () => {
       const input = {
         ...values,
         docker_app_slugs: Array.isArray(values.docker_app_slugs) ? values.docker_app_slugs.join(",") : (values.docker_app_slugs ?? ""),
+        allowed_backup_destination_kinds: Array.isArray(values.allowed_backup_destination_kinds)
+          ? values.allowed_backup_destination_kinds.join(",")
+          : (values.allowed_backup_destination_kinds ?? ""),
       } as unknown as PackageEditInput;
       await updateMutation.mutateAsync({ id, input });
       message.success("Package updated");
@@ -297,6 +316,49 @@ export const PackageEdit = () => {
               tooltip="0 = Python apps not included in this package"
             >
               <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+        </Row>
+
+        <Divider titlePlacement="left">Backups</Divider>
+        <Typography.Paragraph type="secondary" style={{ marginTop: -8 }}>
+          Tenant self-service backups (GH #454). The admin owns the schedule time;
+          tenants choose what to back up and which allowed destination, within these
+          limits. Max backups = 0 disables tenant backups entirely.
+        </Typography.Paragraph>
+        <Row gutter={16}>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Max Backups"
+              name="max_backups"
+              tooltip="Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included."
+            >
+              <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Scheduled Backups"
+              name="scheduled_backups_enabled"
+              valuePropName="checked"
+              tooltip="Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled."
+            >
+              <Switch />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Allowed Backup Destinations"
+              name="allowed_backup_destination_kinds"
+              tooltip="Destination kinds a tenant may back up to. Empty = none allowed."
+            >
+              <Select
+                mode="multiple"
+                allowClear
+                placeholder="e.g. local, s3"
+                options={BACKUP_DESTINATION_KINDS.map((k) => ({ value: k, label: k }))}
+                style={{ width: "100%" }}
+              />
             </Form.Item>
           </Col>
         </Row>


### PR DESCRIPTION
Step 1 of tenant-mode backup management (blueprint: `plans/gh454-tenant-backup.md`). The admin-controlled **limits** the whole feature keys off. **No tenant surface yet, defaulted OFF** — existing packages are unchanged until an admin opts a package in.

Design consensus from the thread: admin owns the schedule **time** + package **limits**; tenant owns **what** / **destination** / on-demand / history, within those limits.

## What lands
- **Migration 000231**: `hosting_packages` += `max_backups` (retention cap; **0 = backups not included**, gates the whole feature), `scheduled_backups_enabled`, `allowed_backup_destination_kinds` (CSV of destination kinds). Additive, defaulted off.
- **`models.HostingPackage`**: the three fields (explicit column tags — the initialism scar) + `BackupsEnabled` / `AllowedBackupKinds` / `AllowsBackupKind` helpers (disabled plan rejects every kind).
- **`models`**: `IsValidBackupDestinationKind` + `NormalizeBackupKindsCSV` (validate, lower-case, dedup, reject unknown kinds).
- **Packages API**: create/update accept + validate the fields (`400 invalid_backup_kinds` on an unknown destination kind).
- **Admin package editor** (create + edit): a "Backups" section — max backups, scheduled-backups switch, allowed-destinations multi-select (CSV↔array like `docker_app_slugs`).

## Tests
- [x] `NormalizeBackupKindsCSV` (empty/valid/dedup/case/unknown) + package backup helpers
- [x] `go build ./...`, `go vet`, `gofmt`; `panel-ui` `tsc -b`
- [ ] migration applies on deploy (standard additive ALTER, mirrors 000201/000187)

## Next
Steps 2-6: tenant READ surface (history/logs/restore points) -> on-demand backup -> schedule content -> restore + incremental -> retention/docs. Security note carried in the blueprint: every tenant endpoint owner-scoped from the session, cross-tenant negative tests each phase.