### PR TITLE
feat(backups): tenant destination picker + /me/backup-destinations (GH #454)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1149,6 +1149,66 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	g.DELETE("/:id", h.delete)
 	g.GET("/:id/manifest", h.manifest)
 	g.POST("/:id/restore", h.restoreSelective)
+	g.GET("/destinations", h.destinations)
+}
+
+// meDestView is the SAFE tenant-facing projection of a backup destination
+// (GH #454): id/name/kind only. It deliberately omits URL, credentials_ref,
+// and extra_options (bucket names, SFTP hosts) so a tenant picker never leaks
+// the admin's infrastructure details.
+type meDestView struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+// destinations lists the backup destinations the caller may target — those
+// whose kind is in the caller's hosting-package allow-list (GH #454). Admins
+// see every enabled destination. allow_local flags whether the plain local
+// default (no destination row) is permitted, so the UI can offer it. Fails
+// closed: a non-admin whose package can't be resolved sees nothing.
+func (h *meBackupHandler) destinations(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "error": "unauthenticated"})
+		return
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "user_not_found"})
+		return
+	}
+	var pkg *models.HostingPackage
+	if !user.IsAdmin {
+		if h.cfg.Packages == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "backup_gating_unavailable"})
+			return
+		}
+		if user.PackageID != nil {
+			pkg, _ = h.cfg.Packages.FindByID(c.Request.Context(), *user.PackageID)
+		}
+	}
+	allowKind := func(kind string) bool {
+		if user.IsAdmin {
+			return true
+		}
+		return pkg != nil && pkg.AllowsBackupKind(kind)
+	}
+	out := make([]meDestView, 0)
+	if h.cfg.Destinations != nil {
+		all, lerr := h.cfg.Destinations.ListEnabled(c.Request.Context())
+		if lerr == nil {
+			for _, d := range all {
+				if allowKind(d.Kind) {
+					out = append(out, meDestView{ID: d.ID, Name: d.Name, Kind: d.Kind})
+				}
+			}
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"data":        out,
+		"allow_local": allowKind(models.BackupDestinationKindLocal),
+	})
 }
 
 type meBackupHandler struct{ cfg MeBackupsHandlerConfig }

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -8,6 +8,7 @@ import { shortDateTime } from "../../utils/datetime";
 import { RowActions } from "../../components/RowActions";
 import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined } from "@icons";
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../apiClient";
 import { useListQuery } from "../../hooks/useQueries";
@@ -44,12 +45,32 @@ export const MyProfileBackupCard = () => {
   const [restoreId, setRestoreId] = useState<string | null>(null);
   const [content, setContent] = useState<string>("full");
   const [compression, setCompression] = useState<string>("");
+  const [destinationId, setDestinationId] = useState<string>("");
   const query = useListQuery<MyBackup>({ resource: "me/backups" });
+
+  // Destinations this tenant may target (GH #454). The backend returns only
+  // the kinds allowed by the hosting package (id/name/kind — no secrets), plus
+  // allow_local for the plain local default.
+  const destQuery = useQuery({
+    queryKey: ["me-backup-destinations"],
+    queryFn: async () =>
+      (
+        await apiClient.get<{ data: { id: string; name: string; kind: string }[]; allow_local: boolean }>(
+          "/me/backups/destinations",
+        )
+      ).data,
+  });
+  const dests = destQuery.data?.data ?? [];
+  const allowLocal = destQuery.data?.allow_local ?? false;
+  const destOptions = [
+    ...(allowLocal ? [{ value: "", label: "Local (default)" }] : []),
+    ...dests.map((d) => ({ value: d.id, label: `${d.name} (${d.kind})` })),
+  ];
 
   const handleCreate = async () => {
     setSubmitting(true);
     try {
-      await apiClient.post("/me/backups", { content, compression });
+      await apiClient.post("/me/backups", { content, compression, destination_id: destinationId });
       message.success("Backup queued");
       query.refetch();
     } catch (err) {
@@ -91,7 +112,21 @@ export const MyProfileBackupCard = () => {
               { value: "off", label: "No compression" },
             ]}
           />
-          <Button type="primary" loading={submitting} onClick={handleCreate}>
+          {destOptions.length > 0 && (
+            <Select
+              value={destinationId}
+              onChange={setDestinationId}
+              style={{ minWidth: 180 }}
+              placeholder="Destination"
+              options={destOptions}
+            />
+          )}
+          <Button
+            type="primary"
+            loading={submitting}
+            disabled={destOptions.length === 0}
+            onClick={handleCreate}
+          >
             Generate backup
           </Button>
         </Space>


### PR DESCRIPTION
Pairs with #568 (backend gating of `destination_id`). Gives tenants the UI to see + pick which allowed destination to back up to.

- **New `GET /me/backups/destinations`**: enabled destinations whose kind is in the caller's hosting-package allow-list (admins see all), plus `allow_local` for the plain local default. **Safe projection — `id`/`name`/`kind` only**, never URL / `credentials_ref` / sftp host, so a tenant picker cannot leak the admin's infra. Fails closed (non-admin without a resolvable package sees nothing).
- **`MyProfileBackupCard`**: a Destination select populated from that endpoint, passes `destination_id` on create; "Generate backup" disabled when the plan exposes no allowed destination.

## Verified
- `go build ./...`, `go vet`, api tests; `panel-ui` `tsc -b` + user-shell vitest (15) pass.
- [ ] box-verify post-deploy: tenant sees only package-allowed destinations; picking one routes the backup there.

## Remaining on #454
Tenant schedule content (admin owns the time), retention auto-prune, incremental toggle.