### PR TITLE
feat(backups): schedule content + tenant-cron schema foundation (GH #454)

### DIFF
--- a/panel-api/internal/db/migrations/000232_schedule_content_tenant_cron.down.sql
+++ b/panel-api/internal/db/migrations/000232_schedule_content_tenant_cron.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings DROP COLUMN tenant_backup_cron;
+ALTER TABLE backup_schedules DROP COLUMN content;

--- a/panel-api/internal/db/migrations/000232_schedule_content_tenant_cron.up.sql
+++ b/panel-api/internal/db/migrations/000232_schedule_content_tenant_cron.up.sql
@@ -1,0 +1,11 @@
+-- GH #454: schedule content + tenant scheduled-backup time (foundation).
+-- backup_schedules.content: what a scheduled backup includes
+--   (full/files/database/folders); default 'full' = the pre-existing behaviour,
+--   so existing schedules are unchanged.
+-- server_settings.tenant_backup_cron: the ADMIN-owned cron time tenant scheduled
+--   backups run at. Tenants choose the content + destination; the admin owns the
+--   timing (resource planning), per the GH #454 design consensus.
+ALTER TABLE backup_schedules
+  ADD COLUMN content VARCHAR(16) NOT NULL DEFAULT 'full';
+ALTER TABLE server_settings
+  ADD COLUMN tenant_backup_cron VARCHAR(64) NOT NULL DEFAULT '0 3 * * *';

--- a/panel-api/internal/models/backup_schedule.go
+++ b/panel-api/internal/models/backup_schedule.go
@@ -12,15 +12,20 @@ const (
 )
 
 type BackupSchedule struct {
-	ID          string     `gorm:"type:char(26);primaryKey" json:"id"`
-	Kind        string     `gorm:"type:enum('account_backup','system_backup');not null" json:"kind"`
-	UserID      *string    `gorm:"type:char(26)" json:"user_id,omitempty"`
+	ID     string  `gorm:"type:char(26);primaryKey" json:"id"`
+	Kind   string  `gorm:"type:enum('account_backup','system_backup');not null" json:"kind"`
+	UserID *string `gorm:"type:char(26)" json:"user_id,omitempty"`
 	// IncludeSystemBackup, when true on a kind=account_backup schedule,
 	// fires a system.backup job alongside the per-user account fan-out
 	// every time the schedule ticks. Ignored on kind=system_backup
 	// (those always back up the system by definition).
-	IncludeSystemBackup bool `gorm:"not null;default:0" json:"include_system_backup"`
-	CronExpr    string     `gorm:"type:varchar(64);not null" json:"cron_expr"`
+	IncludeSystemBackup bool   `gorm:"not null;default:0" json:"include_system_backup"`
+	CronExpr            string `gorm:"type:varchar(64);not null" json:"cron_expr"`
+	// Content is what a firing of this schedule backs up: full / files /
+	// database / folders (GH #454). Default 'full' preserves the pre-feature
+	// behaviour. Used by the scheduler fan-out (wired in a follow-up) and set by
+	// tenants on their own schedule.
+	Content     string     `gorm:"column:content;type:varchar(16);not null;default:'full'" json:"content"`
 	Enabled     bool       `gorm:"not null;default:1" json:"enabled"`
 	KeepDaily   *int       `gorm:"type:int" json:"keep_daily,omitempty"`
 	KeepWeekly  *int       `gorm:"type:int" json:"keep_weekly,omitempty"`

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -220,6 +220,11 @@ type ServerSettings struct {
 	BackupKeepMonthly          uint32 `gorm:"column:backup_keep_monthly;type:int unsigned;not null;default:6"   json:"backup_keep_monthly"`
 	BackupRemoteURL            string `gorm:"column:backup_remote_url;type:varchar(512);not null;default:''"    json:"backup_remote_url"`
 	BackupRemoteCredentialsRef string `gorm:"column:backup_remote_credentials_ref;type:varchar(128);not null;default:''" json:"backup_remote_credentials_ref"`
+	// TenantBackupCron (GH #454) is the admin-owned cron time that TENANT
+	// scheduled backups run at. Tenants choose the content + destination of
+	// their own scheduled backup; the admin owns the timing (resource
+	// planning). Default 03:00 daily.
+	TenantBackupCron string `gorm:"column:tenant_backup_cron;type:varchar(64);not null;default:'0 3 * * *'" json:"tenant_backup_cron"`
 
 	// BackupMaxConcurrentJobs caps how many backup_jobs the in-process
 	// dispatcher will keep in status=running at once. Scheduler ticks
@@ -352,7 +357,6 @@ func EffectiveDNSTTL(s *ServerSettings) int {
 	}
 	return 300
 }
-
 
 // Log-retention category keys (Server Settings -> Logs). Each groups one or more
 // log/report tables the retention sweep prunes.


### PR DESCRIPTION
First **safe, additive** step of tenant scheduled backups. **Schema + model only** — the load-bearing scheduler is untouched and defaults preserve current behaviour, so nothing changes until the follow-up wires it.

- **Migration 000232**: `backup_schedules.content` (full/files/database/folders, **default `full`** = pre-feature behaviour) + `server_settings.tenant_backup_cron` (admin-owned time tenant scheduled backups run at, default `0 3 * * *`).
- **Models**: `BackupSchedule.Content` + `ServerSettings.TenantBackupCron`.

Design (GH #454 consensus): tenants own the **content + destination** of their scheduled backup; the admin owns the **timing** (resource planning).

## Verified
- `go build ./...`, `go vet`, `gofmt`; models tests pass.
- Additive columns, defaulted to preserve behaviour; migration mirrors the proven ALTER format.

## Follow-up (the sensitive parts, next pass)
Wire the scheduler fan-out to pass `Content` to `backup.create`; add `PUT /me/backup-schedule` (cron **forced** from `tenant_backup_cron`, gated by `scheduled_backups_enabled` + `max_backups`); admin cron-time control; tenant schedule UI. Each with its own box-verify.