### PR TITLE
fix(login): hint 'use your username, not your email' on the identifier field (GH #545)

### DIFF
--- a/panel-ui/src/pages/Login.tsx
+++ b/panel-ui/src/pages/Login.tsx
@@ -387,6 +387,10 @@ function renderField(f: RenderableField) {
       rules={[{ required: f.required, message: "Required" }]}
       help={f.errors.length ? f.errors.join("; ") : undefined}
       validateStatus={f.errors.length ? "error" : undefined}
+      // GH #545: operators keep entering their email here and get "invalid
+      // credentials" — login is by username (the email is contact-only in the
+      // identity schema). Nudge them on the identifier field.
+      extra={f.name === "identifier" ? "Use your username, not your email." : undefined}
     >
       {Control}
     </Form.Item>


### PR DESCRIPTION
Fresh-install operators (GH #545) keep entering their admin **email** on the login page and get "The provided credentials are invalid" — because login is by **username** (the identity schema marks email as contact-only, non-login; reproduced on a live box: email → invalid, username → OK).

The install banner already prints the derived `Username:`, but people miss it and blame the install. Add a persistent helper under the identifier field so the login page itself says it:

> Use your username, not your email.

## Verified
- `panel-ui` `tsc -b` clean; `Login.test.tsx` (4) pass.
- Renders as antd `Form.Item` `extra` under the `identifier` field only.