### PR TITLE
fix(openapi): document GET /me/backups/destinations (fixes TestOpenAPICoverage)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -860,6 +860,12 @@ paths:
       summary: Trigger an on-demand backup
       responses: { "202": { description: Job queued } }
 
+  /me/backups/destinations:
+    get:
+      tags: [Backups]
+      summary: List backup destinations your hosting plan allows
+      responses: { "200": { description: OK } }
+
   /me/backups/{id}/restore:
     post:
       tags: [Backups]


### PR DESCRIPTION
The CI red on recent PRs is a **real** regression, not the nginx-gate flake: #569 added the `GET /me/backups/destinations` route without an `openapi.yaml` entry, so `TestOpenAPICoverage` (internal/app) flags a new undocumented route vs its golden. #569 merged via `--admin` past the red CI, so **main went red and every branch cut from it inherited it** (#570, #571).

Fix: add the minimal openapi entry for the route, mirroring the other `/me/backups` docs.

## Verified
- `go test ./internal/app/ -run TestOpenAPICoverage` → **ok** (was FAIL).

After this merges, the open PR (#571) goes green on rebase.

Note to self: `--admin` bypasses a red CI even when the failure is real, not a flake. This one should have been caught + documented in #569.