### PR TITLE
feat(backups): tenant scheduled-backup content + admin-owned cron time (GH #454)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -329,13 +329,7 @@ type createBackupRequest struct {
 
 // validBackupContent / validBackupCompression whitelist the GH #294 options so a
 // bad value can't reach the agent (restic has only off/auto/max — never gzip/xz).
-func validBackupContent(c string) bool {
-	switch c {
-	case "", "full", "files", "database", "folders":
-		return true
-	}
-	return false
-}
+func validBackupContent(c string) bool { return models.ValidBackupContent(c) }
 
 func validBackupCompression(c string) bool {
 	switch c {
@@ -348,14 +342,7 @@ func validBackupCompression(c string) bool {
 // applyBackupContent zeroes the db/mail selections a content mode excludes:
 // "files"/"folders" -> home only; "database" -> dbs only; else (full) unchanged.
 func applyBackupContent(content string, dbs, mbs, pgDbs []string) ([]string, []string, []string) {
-	switch content {
-	case "files", "folders":
-		return nil, nil, nil
-	case "database":
-		return dbs, nil, pgDbs
-	default:
-		return dbs, mbs, pgDbs
-	}
+	return models.ApplyBackupContent(content, dbs, mbs, pgDbs)
 }
 
 func (h *backupHandler) createForUser(c *gin.Context) {
@@ -1071,6 +1058,14 @@ type MeBackupsHandlerConfig struct {
 	// CLOSED (denies) rather than skipping when the entitlement can't be resolved.
 	Packages repository.PackageRepository
 
+	// Schedules + Settings power the tenant scheduled-backup card (GH #454
+	// Step 4): the tenant owns content/destination/on-off within their package
+	// limits, the admin owns the cron TIME (server_settings.tenant_backup_cron).
+	// Both are OPTIONAL — the /me/backup-schedule routes mount only when both
+	// are non-nil, so a deployment without them simply lacks tenant scheduling.
+	Schedules repository.BackupScheduleRepository
+	Settings  repository.ServerSettingsRepository
+
 	Log *slog.Logger
 }
 
@@ -1150,6 +1145,12 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	g.GET("/:id/manifest", h.manifest)
 	g.POST("/:id/restore", h.restoreSelective)
 	g.GET("/destinations", h.destinations)
+	// Tenant scheduled-backup card (GH #454 Step 4). Mounted only when the
+	// schedule repo + server settings (the admin-owned cron time) are wired.
+	if cfg.Schedules != nil && cfg.Settings != nil {
+		rg.GET("/me/backup-schedule", h.getSchedule)
+		rg.PUT("/me/backup-schedule", h.putSchedule)
+	}
 }
 
 // meDestView is the SAFE tenant-facing projection of a backup destination
@@ -1381,6 +1382,247 @@ func (h *meBackupHandler) create(c *gin.Context) {
 		_ = h.cfg.Jobs.MarkStarted(c.Request.Context(), job.ID)
 	}
 	c.JSON(http.StatusCreated, gin.H{"status": "ok", "job_id": job.ID})
+}
+
+// meScheduleView is the tenant's own scheduled-backup state plus the
+// admin-owned knobs the card needs to render (GH #454 Step 4). CronExpr and the
+// firing times are READ-ONLY to the tenant (the admin owns the timing via
+// server_settings.tenant_backup_cron); ScheduledBackupsEnabled + MaxBackups
+// come from the hosting package and cap what the tenant may set.
+type meScheduleView struct {
+	Exists                  bool     `json:"exists"`
+	Enabled                 bool     `json:"enabled"`
+	Content                 string   `json:"content"`
+	DestinationID           string   `json:"destination_id,omitempty"`
+	KeepDaily               *int     `json:"keep_daily,omitempty"`
+	KeepWeekly              *int     `json:"keep_weekly,omitempty"`
+	KeepMonthly             *int     `json:"keep_monthly,omitempty"`
+	CronExpr                string   `json:"cron_expr"`
+	NextFirings             []string `json:"next_firings,omitempty"`
+	ScheduledBackupsEnabled bool     `json:"scheduled_backups_enabled"`
+	MaxBackups              uint32   `json:"max_backups"`
+}
+
+// meScheduleGate resolves the caller + hosting package for the tenant
+// scheduled-backup endpoints, failing CLOSED exactly like the on-demand create
+// gate: any inability to resolve the package entitlement denies (it writes the
+// error and returns ok=false). Admins pass with a nil package — they manage
+// schedules through the admin surface, so PUT still denies them (nil package
+// fails the scheduled_backups_enabled check), while GET renders a disabled card.
+func (h *meBackupHandler) meScheduleGate(c *gin.Context) (*models.User, *models.HostingPackage, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "error": "unauthenticated"})
+		return nil, nil, false
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "user_not_found"})
+		return nil, nil, false
+	}
+	if user.IsAdmin {
+		return user, nil, true
+	}
+	if h.cfg.Packages == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "backup_gating_unavailable"})
+		return nil, nil, false
+	}
+	if user.PackageID == nil {
+		c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "backups_not_included", "detail": "your hosting plan does not include self-service backups"})
+		return nil, nil, false
+	}
+	pkg, perr := h.cfg.Packages.FindByID(c.Request.Context(), *user.PackageID)
+	if perr != nil || pkg == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "backup_gating_unavailable"})
+		return nil, nil, false
+	}
+	return user, pkg, true
+}
+
+// findMeSchedule returns the caller's OWN account_backup schedule, or nil. A
+// tenant-owned schedule is marked by a non-null user_id == the tenant (admin
+// schedules always leave user_id NULL and target users via the join table), so
+// ListForUser(userID) returns only the tenant's own rows — a tenant can never
+// reach an admin-created fan-out schedule through this path.
+func (h *meBackupHandler) findMeSchedule(ctx context.Context, userID string) *models.BackupSchedule {
+	rows, err := h.cfg.Schedules.ListForUser(ctx, userID)
+	if err != nil {
+		return nil
+	}
+	for i := range rows {
+		if rows[i].Kind == models.BackupScheduleKindAccount {
+			return &rows[i]
+		}
+	}
+	return nil
+}
+
+func (h *meBackupHandler) getSchedule(c *gin.Context) {
+	user, pkg, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	settings, serr := h.cfg.Settings.Get(c.Request.Context())
+	if serr != nil || settings == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "settings_unavailable"})
+		return
+	}
+	view := meScheduleView{
+		Content:  models.BackupContentFull,
+		CronExpr: settings.TenantBackupCron,
+	}
+	if pkg != nil {
+		view.ScheduledBackupsEnabled = pkg.BackupsEnabled() && pkg.ScheduledBackupsEnabled
+		view.MaxBackups = pkg.MaxBackups
+	}
+	if fires, ferr := internalbackup.PreviewFires(settings.TenantBackupCron, time.Now().UTC(), 3); ferr == nil {
+		for _, f := range fires {
+			view.NextFirings = append(view.NextFirings, f.Format(time.RFC3339))
+		}
+	}
+	if sched := h.findMeSchedule(c.Request.Context(), user.ID); sched != nil {
+		view.Exists = true
+		view.Enabled = sched.Enabled
+		view.Content = models.NormalizeBackupContent(sched.Content)
+		view.KeepDaily, view.KeepWeekly, view.KeepMonthly = sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly
+		if dests, derr := h.cfg.Schedules.GetDestinations(c.Request.Context(), sched.ID); derr == nil && len(dests) > 0 {
+			view.DestinationID = dests[0].ID
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}
+
+// meScheduleRequest is the tenant-editable schedule payload. cron_expr is NOT a
+// field — the tenant can never set the timing; it is always forced from the
+// admin-owned server_settings.tenant_backup_cron.
+type meScheduleRequest struct {
+	Enabled       bool   `json:"enabled"`
+	Content       string `json:"content"`
+	DestinationID string `json:"destination_id"`
+	KeepDaily     *int   `json:"keep_daily"`
+	KeepWeekly    *int   `json:"keep_weekly"`
+	KeepMonthly   *int   `json:"keep_monthly"`
+}
+
+func (h *meBackupHandler) putSchedule(c *gin.Context) {
+	user, pkg, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	// Admins and plans without scheduled backups cannot use the tenant card.
+	if pkg == nil || !pkg.BackupsEnabled() || !pkg.ScheduledBackupsEnabled {
+		c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "scheduled_backups_not_enabled", "detail": "your hosting plan does not allow scheduled backups"})
+		return
+	}
+	var req meScheduleRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
+		return
+	}
+	if !validBackupContent(req.Content) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_option", "detail": "content must be full/files/database/folders"})
+		return
+	}
+	content := models.NormalizeBackupContent(req.Content)
+	// A schedule with no destination is inert (the fan-out skips it), so an
+	// enabled schedule MUST carry an allowed, enabled destination. When disabled
+	// the tenant may still save their content/destination choice for later.
+	destID := strings.TrimSpace(req.DestinationID)
+	if destID != "" {
+		if h.cfg.Destinations == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "destination_lookup_unavailable"})
+			return
+		}
+		d, derr := h.cfg.Destinations.Get(c.Request.Context(), destID)
+		if derr != nil || d == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "unknown_destination", "detail": "no such backup destination"})
+			return
+		}
+		if !d.Enabled {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "destination_disabled", "detail": "that backup destination is disabled"})
+			return
+		}
+		if !pkg.AllowsBackupKind(d.Kind) {
+			c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "destination_not_allowed", "detail": fmt.Sprintf("your hosting plan does not allow the %q backup destination", d.Kind)})
+			return
+		}
+	}
+	if req.Enabled && destID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "destination_required", "detail": "pick a backup destination to enable scheduled backups"})
+		return
+	}
+	// Retention: no keep_* may exceed the package's max_backups cap.
+	maxKeep := int(pkg.MaxBackups)
+	clamp := func(v *int) *int {
+		if v == nil {
+			return nil
+		}
+		n := *v
+		if n < 0 {
+			n = 0
+		}
+		if n > maxKeep {
+			n = maxKeep
+		}
+		return &n
+	}
+	keepDaily, keepWeekly, keepMonthly := clamp(req.KeepDaily), clamp(req.KeepWeekly), clamp(req.KeepMonthly)
+	// cron_expr is ALWAYS the admin-owned time — never anything from the body.
+	settings, serr := h.cfg.Settings.Get(c.Request.Context())
+	if serr != nil || settings == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "settings_unavailable"})
+		return
+	}
+	next, ferr := internalbackup.NextFire(settings.TenantBackupCron, time.Now().UTC())
+	if ferr != nil {
+		// A misconfigured admin cron shouldn't 500 the tenant; surface it.
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "schedule_time_invalid", "detail": "the scheduled-backup time set by your host is invalid; contact support"})
+		return
+	}
+	uid := user.ID
+	sched := h.findMeSchedule(c.Request.Context(), user.ID)
+	if sched == nil {
+		sched = &models.BackupSchedule{
+			ID:     ids.NewULID(),
+			Kind:   models.BackupScheduleKindAccount,
+			UserID: &uid,
+		}
+		sched.CronExpr = settings.TenantBackupCron
+		sched.Content = content
+		sched.Enabled = req.Enabled
+		sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
+		sched.NextRunAt = &next
+		if err := h.cfg.Schedules.Create(c.Request.Context(), sched); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
+			return
+		}
+	} else {
+		sched.UserID = &uid
+		sched.CronExpr = settings.TenantBackupCron
+		sched.Content = content
+		sched.Enabled = req.Enabled
+		sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
+		sched.NextRunAt = &next
+		if err := h.cfg.Schedules.Update(c.Request.Context(), sched); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
+			return
+		}
+	}
+	// Scope the fan-out to THIS tenant only (empty user list would fan out to
+	// every non-admin user at tick time — never for a tenant-owned schedule).
+	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), sched.ID, []string{uid}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
+		return
+	}
+	dests := []string{}
+	if destID != "" {
+		dests = append(dests, destID)
+	}
+	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), sched.ID, dests); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
 func (h *meBackupHandler) list(c *gin.Context) {

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -866,6 +866,16 @@ paths:
       summary: List backup destinations your hosting plan allows
       responses: { "200": { description: OK } }
 
+  /me/backup-schedule:
+    get:
+      tags: [Backups]
+      summary: Your scheduled-backup settings (admin owns the time)
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Backups]
+      summary: Set your scheduled-backup content, destination, and on/off
+      responses: { "200": { description: OK } }
+
   /me/backups/{id}/restore:
     post:
       tags: [Backups]

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
@@ -83,37 +84,37 @@ func (h *serverSettingsHandler) get(c *gin.Context) {
 }
 
 type updateServerSettingsRequest struct {
-	Hostname                 *string `json:"hostname,omitempty"`
-	PublicIPv4               *string `json:"public_ipv4,omitempty"`
-	PublicIPv6               *string `json:"public_ipv6,omitempty"`
-	NS1Name                  *string `json:"ns1_name,omitempty"`
-	NS1IPv4                  *string `json:"ns1_ipv4,omitempty"`
-	NS2Name                  *string `json:"ns2_name,omitempty"`
-	NS2IPv4                  *string `json:"ns2_ipv4,omitempty"`
-	AdminEmail               *string `json:"admin_email,omitempty"`
+	Hostname                 *string          `json:"hostname,omitempty"`
+	PublicIPv4               *string          `json:"public_ipv4,omitempty"`
+	PublicIPv6               *string          `json:"public_ipv6,omitempty"`
+	NS1Name                  *string          `json:"ns1_name,omitempty"`
+	NS1IPv4                  *string          `json:"ns1_ipv4,omitempty"`
+	NS2Name                  *string          `json:"ns2_name,omitempty"`
+	NS2IPv4                  *string          `json:"ns2_ipv4,omitempty"`
+	AdminEmail               *string          `json:"admin_email,omitempty"`
 	LogRetention             *json.RawMessage `json:"log_retention,omitempty"`
-	Timezone                 *string `json:"timezone,omitempty"`
-	SSHPort                  *uint16 `json:"ssh_port,omitempty"`
-	SSHPasswordAuth          *bool   `json:"ssh_password_auth,omitempty"`
-	SSHUserPasswordAuth      *bool   `json:"ssh_user_password_auth,omitempty"`
-	PanelBrandText           *string `json:"panel_brand_text,omitempty"`
-	PanelFontSize            *string `json:"panel_font_size,omitempty"`
-	PanelPrimaryColor        *string `json:"panel_primary_color,omitempty"`
-	PanelAccentColor         *string `json:"panel_accent_color,omitempty"`
-	PanelSuccessColor        *string `json:"panel_success_color,omitempty"`
-	PanelWarningColor        *string `json:"panel_warning_color,omitempty"`
-	PanelErrorColor          *string `json:"panel_error_color,omitempty"`
-	PanelInfoColor           *string `json:"panel_info_color,omitempty"`
-	PanelLinkColor           *string `json:"panel_link_color,omitempty"`
-	PanelLightTopbarColor    *string `json:"panel_light_topbar_color,omitempty"`
-	PanelDarkTopbarColor     *string `json:"panel_dark_topbar_color,omitempty"`
-	PanelLightBgColor        *string `json:"panel_light_bg_color,omitempty"`
-	PanelDarkBgColor         *string `json:"panel_dark_bg_color,omitempty"`
-	PanelLightContainerColor *string `json:"panel_light_container_color,omitempty"`
-	PanelDarkContainerColor  *string `json:"panel_dark_container_color,omitempty"`
-	PanelLightTextColor      *string `json:"panel_light_text_color,omitempty"`
-	PanelDarkTextColor       *string `json:"panel_dark_text_color,omitempty"`
-	ReleaseChannel           *string `json:"release_channel,omitempty"`
+	Timezone                 *string          `json:"timezone,omitempty"`
+	SSHPort                  *uint16          `json:"ssh_port,omitempty"`
+	SSHPasswordAuth          *bool            `json:"ssh_password_auth,omitempty"`
+	SSHUserPasswordAuth      *bool            `json:"ssh_user_password_auth,omitempty"`
+	PanelBrandText           *string          `json:"panel_brand_text,omitempty"`
+	PanelFontSize            *string          `json:"panel_font_size,omitempty"`
+	PanelPrimaryColor        *string          `json:"panel_primary_color,omitempty"`
+	PanelAccentColor         *string          `json:"panel_accent_color,omitempty"`
+	PanelSuccessColor        *string          `json:"panel_success_color,omitempty"`
+	PanelWarningColor        *string          `json:"panel_warning_color,omitempty"`
+	PanelErrorColor          *string          `json:"panel_error_color,omitempty"`
+	PanelInfoColor           *string          `json:"panel_info_color,omitempty"`
+	PanelLinkColor           *string          `json:"panel_link_color,omitempty"`
+	PanelLightTopbarColor    *string          `json:"panel_light_topbar_color,omitempty"`
+	PanelDarkTopbarColor     *string          `json:"panel_dark_topbar_color,omitempty"`
+	PanelLightBgColor        *string          `json:"panel_light_bg_color,omitempty"`
+	PanelDarkBgColor         *string          `json:"panel_dark_bg_color,omitempty"`
+	PanelLightContainerColor *string          `json:"panel_light_container_color,omitempty"`
+	PanelDarkContainerColor  *string          `json:"panel_dark_container_color,omitempty"`
+	PanelLightTextColor      *string          `json:"panel_light_text_color,omitempty"`
+	PanelDarkTextColor       *string          `json:"panel_dark_text_color,omitempty"`
+	ReleaseChannel           *string          `json:"release_channel,omitempty"`
 	// DNS record-type permissions (GH #466): supply either a named preset
 	// (permissive | hosting-safe | locked-down) or the full per-type matrix.
 	DNSUserRecordPolicy       *models.DNSUserRecordPolicy `json:"dns_user_record_policy,omitempty"`
@@ -131,6 +132,10 @@ type updateServerSettingsRequest struct {
 	RootTerminalEnabled          *bool   `json:"root_terminal_enabled,omitempty"`
 	BandwidthQuotaEnforceEnabled *bool   `json:"bandwidth_quota_enforce_enabled,omitempty"`
 	UploadMaxSizeMB              *uint32 `json:"upload_max_size_mb,omitempty"`
+	// TenantBackupCron (GH #454): the admin-owned cron time tenant scheduled
+	// backups run at. Tenants choose content + destination; only the admin sets
+	// the timing. Validated server-side via internalbackup.ParseCron.
+	TenantBackupCron *string `json:"tenant_backup_cron,omitempty"`
 
 	// M13 SSH shell sandbox.
 	SSHSandboxMode            *string `json:"ssh_sandbox_mode,omitempty"`
@@ -485,6 +490,14 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.UploadMaxSizeMB != nil {
 		current.UploadMaxSizeMB = *req.UploadMaxSizeMB
+	}
+	if req.TenantBackupCron != nil {
+		cronExpr := strings.TrimSpace(*req.TenantBackupCron)
+		if _, err := internalbackup.ParseCron(cronExpr); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cron", "detail": err.Error()})
+			return
+		}
+		current.TenantBackupCron = cronExpr
 	}
 	if req.SSHSandboxMode != nil {
 		current.SSHSandboxMode = strings.TrimSpace(*req.SSHSandboxMode)
@@ -1325,7 +1338,6 @@ func (h *serverSettingsHandler) moduleInstall(c *gin.Context) {
 	h.dispatchModuleInstall(req.Key)
 	c.JSON(http.StatusAccepted, gin.H{"status": "installing", "key": req.Key})
 }
-
 
 // validateLogRetention checks a Server Settings -> Logs retention map: every key
 // must be a known category and every value an int in [0, 3650] days (0 = keep

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -571,3 +571,56 @@ func TestServerSettingsPatch_DatabaseError(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &respBody))
 	assert.Equal(t, "internal", respBody["error"])
 }
+
+// GH #454: the admin owns the tenant scheduled-backup time via
+// server_settings.tenant_backup_cron. A valid cron is stored; an invalid one is
+// rejected 400 before it can strand the tenant scheduler with an unparseable time.
+func TestServerSettingsPatch_TenantBackupCron_Valid(t *testing.T) {
+	t.Parallel()
+
+	existing := &models.ServerSettings{
+		ID: 1, Hostname: "h.example.com", PublicIPv4: "192.0.2.1",
+		NS1Name: "ns1.example.com", NS1IPv4: "192.0.2.1",
+		NS2Name: "ns2.example.com", NS2IPv4: "192.0.2.2",
+		AdminEmail: "admin@example.com", SSHPort: 22,
+		TenantBackupCron: "0 3 * * *",
+	}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	r := settingsRouter(true, mockRepo, agent.NewMockClient())
+
+	body, _ := json.Marshal(map[string]any{"tenant_backup_cron": "30 2 * * *"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var respBody models.ServerSettings
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &respBody))
+	assert.Equal(t, "30 2 * * *", respBody.TenantBackupCron)
+}
+
+func TestServerSettingsPatch_TenantBackupCron_Invalid(t *testing.T) {
+	t.Parallel()
+
+	existing := &models.ServerSettings{
+		ID: 1, Hostname: "h.example.com", PublicIPv4: "192.0.2.1",
+		NS1Name: "ns1.example.com", NS1IPv4: "192.0.2.1",
+		NS2Name: "ns2.example.com", NS2IPv4: "192.0.2.2",
+		AdminEmail: "admin@example.com", SSHPort: 22,
+		TenantBackupCron: "0 3 * * *",
+	}
+	mockRepo := &mockServerSettingsRepo{getResult: existing}
+	r := settingsRouter(true, mockRepo, agent.NewMockClient())
+
+	body, _ := json.Marshal(map[string]any{"tenant_backup_cron": "not a cron"})
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var respBody map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &respBody))
+	assert.Equal(t, "invalid_cron", respBody["error"])
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1002,7 +1002,12 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				AppInstalls:    deps.WordPressInstalls,
 				DNSZones:       deps.DNSZones,
 				DNSRecords:     deps.DNSRecords,
-				Log:            deps.Log,
+				// GH #454 Step 4: tenant scheduled-backup card. Schedules +
+				// Settings (the admin-owned cron time) gate the /me/backup-schedule
+				// routes; absent, the card's endpoints simply aren't mounted.
+				Schedules: deps.BackupSchedules,
+				Settings:  deps.ServerSettings,
+				Log:       deps.Log,
 			})
 		}
 		// M30.1 (ADR-0078): backup destinations + schedules.

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -90,7 +90,7 @@ type Deps struct {
 	// M30.2.x — sso key for unsealing per-destination restic
 	// passwords. Optional; nil falls back to the legacy shared file.
 	SSOKey *ssokey.Key
-	Log   *slog.Logger
+	Log    *slog.Logger
 }
 
 // Scheduler is the goroutine wrapper. Construct via New, start with
@@ -339,7 +339,11 @@ func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.Backu
 		RunID:         &rid,
 		Kind:          models.BackupJobKindAccountBackup,
 		Status:        models.BackupJobStatusQueued,
-		CreatedAt:     time.Now().UTC(),
+		// Denormalise the schedule's content onto the job so the dispatcher
+		// trims the db/mailbox lists to match without re-loading the schedule
+		// (GH #454). "" normalises to "full" = the pre-feature behaviour.
+		Content:   models.NormalizeBackupContent(sched.Content),
+		CreatedAt: time.Now().UTC(),
 	}
 	if err := s.deps.Jobs.Create(ctx, job); err != nil {
 		logger.Error("create backup_job failed", "err", err)
@@ -408,6 +412,12 @@ func (s *Scheduler) dispatchAccount(ctx context.Context, j models.BackupJob) {
 	dbs := userDatabases(callCtx, s.deps, user.ID, logger)
 	pgDbs := userPostgresDatabases(callCtx, s.deps, user.ID, logger)
 	mbs := userMailboxes(callCtx, s.deps, user.ID, logger)
+	// Honour the schedule's content selection (GH #454): the agent skips the
+	// home stage only for content=database but backs up whatever db/mailbox
+	// lists it is handed, so trim the lists the content excludes here and pass
+	// the selector through. Empty content -> "full" -> everything (unchanged).
+	content := models.NormalizeBackupContent(j.Content)
+	dbs, mbs, pgDbs = models.ApplyBackupContent(content, dbs, mbs, pgDbs)
 	meta := buildScheduleMetadata(callCtx, s.deps, user, logger)
 	scheduleID := ""
 	if j.ScheduleID != nil {
@@ -422,6 +432,7 @@ func (s *Scheduler) dispatchAccount(ctx context.Context, j models.BackupJob) {
 		"databases":          dbs,
 		"databases_postgres": pgDbs,
 		"mailboxes":          mbs,
+		"content":            content,
 		"metadata":           meta,
 		"schedule_id":        scheduleID,
 	}

--- a/panel-api/internal/db/migrations/000233_backup_job_content.down.sql
+++ b/panel-api/internal/db/migrations/000233_backup_job_content.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE backup_jobs DROP COLUMN content;

--- a/panel-api/internal/db/migrations/000233_backup_job_content.up.sql
+++ b/panel-api/internal/db/migrations/000233_backup_job_content.up.sql
@@ -1,0 +1,8 @@
+-- GH #454 Step 4: denormalise the schedule's content onto each backup_job.
+-- backup_jobs.content records what a run captured (full/files/database/folders,
+-- the GH #294 selectors). The scheduler stamps it from the schedule at enqueue
+-- time so the dispatcher trims the db/mailbox lists to match, and the history UI
+-- shows what each restore point contains without re-loading the schedule.
+-- Default 'full' preserves the pre-feature behaviour for existing rows.
+ALTER TABLE backup_jobs
+  ADD COLUMN content VARCHAR(16) NOT NULL DEFAULT 'full';

--- a/panel-api/internal/models/backup_content.go
+++ b/panel-api/internal/models/backup_content.go
@@ -1,0 +1,52 @@
+// Backup "content" is what a single account_backup run captures: the whole
+// account, files only, databases only, or specific home folders (GH #294).
+// It is a first-class domain value shared by the on-demand create path
+// (internal/api) AND the scheduled fan-out (internal/backupscheduler), so it
+// lives in models — the one package both import — to keep a single source of
+// truth for the valid set and the list-trimming rule (GH #454).
+package models
+
+const (
+	BackupContentFull     = "full"
+	BackupContentFiles    = "files"
+	BackupContentDatabase = "database"
+	BackupContentFolders  = "folders"
+)
+
+// ValidBackupContent reports whether c is an accepted content selector. The
+// empty string is accepted and means "full" (the pre-#294 default), so a bad
+// value can't reach the agent.
+func ValidBackupContent(c string) bool {
+	switch c {
+	case "", BackupContentFull, BackupContentFiles, BackupContentDatabase, BackupContentFolders:
+		return true
+	}
+	return false
+}
+
+// NormalizeBackupContent maps the empty string to the explicit "full" default
+// so persisted rows and wire params never carry an ambiguous "".
+func NormalizeBackupContent(c string) string {
+	if c == "" {
+		return BackupContentFull
+	}
+	return c
+}
+
+// ApplyBackupContent trims the per-stage item lists to match the content
+// selection, mirroring what the agent's stage gating expects: the agent skips
+// the home stage only for content=database, but iterates whatever database and
+// mailbox lists it is handed — so the CALLER must empty the lists the selected
+// content excludes. "files"/"folders" -> home only (no db, no mail);
+// "database" -> databases only (no mail; agent drops home); else (full) -> all.
+// Returned slices are the inputs or nil; callers pass fresh slices.
+func ApplyBackupContent(content string, dbs, mbs, pgDbs []string) ([]string, []string, []string) {
+	switch content {
+	case BackupContentFiles, BackupContentFolders:
+		return nil, nil, nil
+	case BackupContentDatabase:
+		return dbs, nil, pgDbs
+	default:
+		return dbs, mbs, pgDbs
+	}
+}

--- a/panel-api/internal/models/backup_content_test.go
+++ b/panel-api/internal/models/backup_content_test.go
@@ -1,0 +1,57 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidBackupContent(t *testing.T) {
+	for _, c := range []string{"", "full", "files", "database", "folders"} {
+		if !ValidBackupContent(c) {
+			t.Errorf("ValidBackupContent(%q) = false, want true", c)
+		}
+	}
+	for _, c := range []string{"all", "db", "FULL", "home", "x"} {
+		if ValidBackupContent(c) {
+			t.Errorf("ValidBackupContent(%q) = true, want false", c)
+		}
+	}
+}
+
+func TestNormalizeBackupContent(t *testing.T) {
+	if got := NormalizeBackupContent(""); got != BackupContentFull {
+		t.Errorf("NormalizeBackupContent(\"\") = %q, want %q", got, BackupContentFull)
+	}
+	if got := NormalizeBackupContent("database"); got != "database" {
+		t.Errorf("NormalizeBackupContent(\"database\") = %q, want database", got)
+	}
+}
+
+// ApplyBackupContent must empty the lists the selected content excludes so the
+// agent — which backs up whatever db/mailbox lists it is handed — doesn't
+// capture data the tenant deselected (GH #454). This is the load-bearing wiring
+// for scheduled content; a regression here silently over-backs-up.
+func TestApplyBackupContent(t *testing.T) {
+	dbs := []string{"d1", "d2"}
+	mbs := []string{"m1"}
+	pg := []string{"p1"}
+
+	tests := []struct {
+		content         string
+		wantDB, wantMB  []string
+		wantPG          []string
+	}{
+		{"full", dbs, mbs, pg},
+		{"", dbs, mbs, pg}, // empty behaves as full at the switch default
+		{"database", dbs, nil, pg},
+		{"files", nil, nil, nil},
+		{"folders", nil, nil, nil},
+	}
+	for _, tt := range tests {
+		gotDB, gotMB, gotPG := ApplyBackupContent(tt.content, dbs, mbs, pg)
+		if !reflect.DeepEqual(gotDB, tt.wantDB) || !reflect.DeepEqual(gotMB, tt.wantMB) || !reflect.DeepEqual(gotPG, tt.wantPG) {
+			t.Errorf("ApplyBackupContent(%q) = (%v,%v,%v), want (%v,%v,%v)",
+				tt.content, gotDB, gotMB, gotPG, tt.wantDB, tt.wantMB, tt.wantPG)
+		}
+	}
+}

--- a/panel-api/internal/models/backup_job.go
+++ b/panel-api/internal/models/backup_job.go
@@ -40,26 +40,31 @@ const (
 // indexes are created in the migration so the schema and the code stay
 // readable side-by-side (other M-series tables follow the same pattern).
 type BackupJob struct {
-	ID              string          `gorm:"type:char(26);primaryKey"                                                  json:"id"`
-	UserID          string          `gorm:"type:char(26);not null"                                                    json:"user_id"`
-	DestinationID   *string         `gorm:"type:char(26)"                                                             json:"destination_id,omitempty"`
-	ScheduleID      *string         `gorm:"type:char(26)"                                                             json:"schedule_id,omitempty"`
-	RunID           *string         `gorm:"type:char(26)"                                                             json:"run_id,omitempty"`
-	Kind            string          `gorm:"type:enum('account_backup','account_restore','system_backup','system_restore');not null" json:"kind"`
-	Status          string          `gorm:"type:enum('queued','running','succeeded','partial','failed','cancelled');not null;default:'queued'" json:"status"`
-	SystemdUnit     string          `gorm:"type:varchar(128);not null"                                                json:"systemd_unit"`
-	SnapshotID      string          `gorm:"type:char(64);not null;default:''"                                         json:"snapshot_id"`
-	ParentSnapshot  string          `gorm:"type:char(64);not null;default:''"                                         json:"parent_snapshot"`
-	BytesAdded      uint64          `gorm:"type:bigint unsigned;not null;default:0"                                   json:"bytes_added"`
-	BytesTotal      uint64          `gorm:"type:bigint unsigned;not null;default:0"                                   json:"bytes_total"`
-	ManifestJSON    json.RawMessage `gorm:"type:json"                                                                 json:"manifest_json,omitempty"`
-	WarningsJSON    json.RawMessage `gorm:"type:json"                                                                 json:"warnings_json,omitempty"`
-	ErrorText       string          `gorm:"type:text"                                                                 json:"error_text,omitempty"`
-	SourceHostname  string          `gorm:"type:varchar(253);not null;default:''"                                     json:"source_hostname"`
-	SourcePanelSHA  string          `gorm:"column:source_panel_sha;type:char(40);not null;default:''"                 json:"source_panel_sha"`
-	CreatedAt       time.Time       `gorm:"type:datetime(6);not null"                                                 json:"created_at"`
-	StartedAt       *time.Time      `gorm:"type:datetime(6)"                                                          json:"started_at,omitempty"`
-	FinishedAt      *time.Time      `gorm:"type:datetime(6)"                                                          json:"finished_at,omitempty"`
+	ID            string  `gorm:"type:char(26);primaryKey"                                                  json:"id"`
+	UserID        string  `gorm:"type:char(26);not null"                                                    json:"user_id"`
+	DestinationID *string `gorm:"type:char(26)"                                                             json:"destination_id,omitempty"`
+	ScheduleID    *string `gorm:"type:char(26)"                                                             json:"schedule_id,omitempty"`
+	RunID         *string `gorm:"type:char(26)"                                                             json:"run_id,omitempty"`
+	Kind          string  `gorm:"type:enum('account_backup','account_restore','system_backup','system_restore');not null" json:"kind"`
+	// Content records what this run captured: full / files / database / folders
+	// (GH #294 selectors, GH #454). Denormalised from the schedule at enqueue
+	// time so the dispatcher and the history UI both read it off the job without
+	// re-loading the schedule (which may have changed or been deleted since).
+	Content        string          `gorm:"column:content;type:varchar(16);not null;default:'full'"                   json:"content"`
+	Status         string          `gorm:"type:enum('queued','running','succeeded','partial','failed','cancelled');not null;default:'queued'" json:"status"`
+	SystemdUnit    string          `gorm:"type:varchar(128);not null"                                                json:"systemd_unit"`
+	SnapshotID     string          `gorm:"type:char(64);not null;default:''"                                         json:"snapshot_id"`
+	ParentSnapshot string          `gorm:"type:char(64);not null;default:''"                                         json:"parent_snapshot"`
+	BytesAdded     uint64          `gorm:"type:bigint unsigned;not null;default:0"                                   json:"bytes_added"`
+	BytesTotal     uint64          `gorm:"type:bigint unsigned;not null;default:0"                                   json:"bytes_total"`
+	ManifestJSON   json.RawMessage `gorm:"type:json"                                                                 json:"manifest_json,omitempty"`
+	WarningsJSON   json.RawMessage `gorm:"type:json"                                                                 json:"warnings_json,omitempty"`
+	ErrorText      string          `gorm:"type:text"                                                                 json:"error_text,omitempty"`
+	SourceHostname string          `gorm:"type:varchar(253);not null;default:''"                                     json:"source_hostname"`
+	SourcePanelSHA string          `gorm:"column:source_panel_sha;type:char(40);not null;default:''"                 json:"source_panel_sha"`
+	CreatedAt      time.Time       `gorm:"type:datetime(6);not null"                                                 json:"created_at"`
+	StartedAt      *time.Time      `gorm:"type:datetime(6)"                                                          json:"started_at,omitempty"`
+	FinishedAt     *time.Time      `gorm:"type:datetime(6)"                                                          json:"finished_at,omitempty"`
 }
 
 // TableName pins to the exact table from migration 000084.

--- a/panel-api/internal/repository/backup_schedule_repository.go
+++ b/panel-api/internal/repository/backup_schedule_repository.go
@@ -128,6 +128,7 @@ func (r *backupScheduleRepo) Update(ctx context.Context, s *models.BackupSchedul
 			"user_id":               s.UserID,
 			"include_system_backup": s.IncludeSystemBackup,
 			"cron_expr":             s.CronExpr,
+			"content":               s.Content,
 			"enabled":               s.Enabled,
 			"keep_daily":            s.KeepDaily,
 			"keep_weekly":           s.KeepWeekly,

--- a/panel-api/internal/repository/backup_schedule_repository_test.go
+++ b/panel-api/internal/repository/backup_schedule_repository_test.go
@@ -74,3 +74,31 @@ func TestBackupSchedule_ReplaceDestinations_AtomicReplace(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// GH #454: the Update column allowlist must include `content` — it was added to
+// the model (#570) after this method was written, and an omitted column is a
+// SILENT drop (the map-based Updates only writes listed columns). Regression
+// guard: a tenant changing their scheduled-backup content must persist.
+func TestBackupSchedule_Update_PersistsContent(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupScheduleRepository(db)
+
+	mock.ExpectBegin()
+	// Fails if `content` is missing from the SET clause (the bug).
+	mock.ExpectExec("UPDATE .backup_schedules. SET .content.=").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	uid := "01J5USER0000000000000000001"
+	s := &models.BackupSchedule{
+		ID:       "01J5SCHED0000000000000000A",
+		Kind:     models.BackupScheduleKindAccount,
+		UserID:   &uid,
+		CronExpr: "0 3 * * *",
+		Content:  models.BackupContentFiles,
+		Enabled:  true,
+	}
+	require.NoError(t, repo.Update(context.Background(), s))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -1,7 +1,7 @@
 // BackupSettingsTab — knobs that govern the in-process backup
 // scheduler/dispatcher. Backed by server_settings (PATCH /admin/settings).
 // Retention is per-schedule (Schedules tab) — not server-wide.
-import { Button, Form, InputNumber, Spin, message } from "antd";
+import { Button, Form, Input, InputNumber, Spin, message } from "antd";
 import { SaveOutlined } from "@icons";
 import { useEffect, useState } from "react";
 
@@ -10,10 +10,14 @@ import { extractApiError } from "../../../apiErrors";
 
 interface BackupSettingsShape {
   backup_max_concurrent_jobs: number;
+  // GH #454: the admin-owned time tenant scheduled backups run at. Tenants pick
+  // content + destination; only the admin sets the cron.
+  tenant_backup_cron: string;
 }
 
 interface ServerSettingsResponse {
   backup_max_concurrent_jobs?: number;
+  tenant_backup_cron?: string;
 }
 
 export const BackupSettingsTab = () => {
@@ -29,6 +33,7 @@ export const BackupSettingsTab = () => {
         if (cancelled) return;
         form.setFieldsValue({
           backup_max_concurrent_jobs: resp.data.backup_max_concurrent_jobs ?? 2,
+          tenant_backup_cron: resp.data.tenant_backup_cron ?? "0 3 * * *",
         });
       } catch (err) {
         message.error(extractApiError(err, "Load failed"));
@@ -68,6 +73,14 @@ export const BackupSettingsTab = () => {
           rules={[{ required: true, type: "number", min: 1, max: 64 }]}
         >
           <InputNumber min={1} max={64} style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item
+          name="tenant_backup_cron"
+          label="Tenant scheduled-backup time (cron)"
+          tooltip="Tenants choose what to back up and where; you own when. 5-field cron (min hour day-of-month month day-of-week), e.g. '0 3 * * *' = daily at 03:00 UTC."
+          rules={[{ required: true, message: "A cron expression is required" }]}
+        >
+          <Input placeholder="0 3 * * *" style={{ fontFamily: "monospace" }} />
         </Form.Item>
         <Form.Item>
           <Button type="primary" htmlType="submit" loading={saving} icon={<SaveOutlined />}>

--- a/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
@@ -1,0 +1,146 @@
+// MyProfileScheduleCard — tenant scheduled-backup control (GH #454 Step 4).
+// The tenant owns WHAT (content) + WHERE (destination) + on/off + retention;
+// the ADMIN owns the TIME (server_settings.tenant_backup_cron), shown read-only.
+// Gated on the hosting package's scheduled_backups_enabled. Unlike the on-demand
+// card, a schedule needs a real destination row — the implicit "local default"
+// is skipped by the scheduler fan-out — so only concrete destinations are offered.
+import { Alert, Button, Card, InputNumber, Select, Space, Switch, Typography, message } from "antd";
+import { ClockCircleOutlined } from "@icons";
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+import { extractApiError } from "../../apiErrors";
+import { shortDateTime } from "../../utils/datetime";
+
+type ScheduleView = {
+  exists: boolean;
+  enabled: boolean;
+  content: string;
+  destination_id?: string;
+  keep_daily?: number | null;
+  cron_expr: string;
+  next_firings?: string[];
+  scheduled_backups_enabled: boolean;
+  max_backups: number;
+};
+
+export const MyProfileScheduleCard = () => {
+  const schedQuery = useQuery({
+    queryKey: ["me-backup-schedule"],
+    queryFn: async () => (await apiClient.get<{ data: ScheduleView }>("/me/backup-schedule")).data.data,
+  });
+  // Shares the on-demand card's query key so the two cards fetch destinations once.
+  const destQuery = useQuery({
+    queryKey: ["me-backup-destinations"],
+    queryFn: async () =>
+      (
+        await apiClient.get<{ data: { id: string; name: string; kind: string }[]; allow_local: boolean }>(
+          "/me/backups/destinations",
+        )
+      ).data,
+  });
+
+  const [enabled, setEnabled] = useState(false);
+  const [content, setContent] = useState("full");
+  const [destinationId, setDestinationId] = useState("");
+  const [keepDaily, setKeepDaily] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const view = schedQuery.data;
+  useEffect(() => {
+    if (!view) return;
+    setEnabled(view.enabled);
+    setContent(view.content || "full");
+    setDestinationId(view.destination_id ?? "");
+    setKeepDaily(view.keep_daily ?? null);
+  }, [view]);
+
+  const dests = destQuery.data?.data ?? [];
+  const destOptions = dests.map((d) => ({ value: d.id, label: `${d.name} (${d.kind})` }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await apiClient.put("/me/backup-schedule", {
+        enabled,
+        content,
+        destination_id: destinationId,
+        keep_daily: keepDaily,
+      });
+      message.success("Schedule saved");
+      schedQuery.refetch();
+    } catch (err) {
+      message.error(extractApiError(err, "Save failed"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const nextRun = view?.next_firings?.[0];
+
+  return (
+    <Card
+      title={
+        <span>
+          <ClockCircleOutlined style={{ marginRight: 8 }} />
+          Scheduled backups
+        </span>
+      }
+      style={{ marginTop: 16 }}
+      loading={schedQuery.isLoading}
+    >
+      {view && !view.scheduled_backups_enabled ? (
+        <Alert type="info" showIcon message="Scheduled backups are not included in your hosting plan." />
+      ) : (
+        <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+            {nextRun ? (
+              <>
+                Your host runs your scheduled backup next at <strong>{shortDateTime(nextRun)}</strong>.
+              </>
+            ) : (
+              <>Your host sets when scheduled backups run.</>
+            )}{" "}
+            You choose what to back up and where — the timing is set by your host.
+          </Typography.Paragraph>
+          <Space wrap align="center">
+            <Switch checked={enabled} onChange={setEnabled} checkedChildren="On" unCheckedChildren="Off" />
+            <Select
+              value={content}
+              onChange={setContent}
+              style={{ minWidth: 150 }}
+              options={[
+                { value: "full", label: "Full account" },
+                { value: "files", label: "Files only" },
+                { value: "database", label: "Databases only" },
+              ]}
+            />
+            <Select
+              value={destinationId}
+              onChange={setDestinationId}
+              style={{ minWidth: 200 }}
+              placeholder="Destination"
+              options={destOptions}
+              notFoundContent="No allowed destinations"
+            />
+            <Space>
+              <span>Keep</span>
+              <InputNumber
+                min={1}
+                max={view?.max_backups || 1}
+                value={keepDaily ?? undefined}
+                onChange={(v) => setKeepDaily(typeof v === "number" ? v : null)}
+                style={{ width: 80 }}
+              />
+              <span>copies</span>
+            </Space>
+            <Button type="primary" loading={saving} onClick={handleSave}>
+              Save schedule
+            </Button>
+          </Space>
+        </Space>
+      )}
+    </Card>
+  );
+};

--- a/panel-ui/src/shells/user/backups/UserBackupsPage.tsx
+++ b/panel-ui/src/shells/user/backups/UserBackupsPage.tsx
@@ -7,6 +7,7 @@ import { Typography } from "antd";
 import { SaveOutlined } from "@icons";
 
 import { MyProfileBackupCard } from "../MyProfileBackupCard";
+import { MyProfileScheduleCard } from "../MyProfileScheduleCard";
 
 export const UserBackupsPage = () => {
   return (
@@ -15,6 +16,7 @@ export const UserBackupsPage = () => {
         <SaveOutlined /> Backup / Restore
       </Typography.Title>
       <MyProfileBackupCard />
+      <MyProfileScheduleCard />
     </div>
   );
 };


### PR DESCRIPTION
GH #454 Step 4 of the tenant-backup blueprint. The tenant owns **what** (content) + **where** (destination) + on/off + retention for their scheduled backup; the admin owns the **time**. Shipped as one unit so content is never stored-but-ignored.

## Scheduler wiring (the half that was missing)
- `backup_jobs.content` (migration 000233 + model field, default `full`): the schedule's content is denormalised onto each job at enqueue time.
- `dispatchAccount` now trims the db/mailbox lists via `models.ApplyBackupContent` and passes the `content` selector. Before this, a files-only / database-only schedule **silently backed up everything** — the agent gates only the home stage on `content=database` and otherwise iterates whatever lists it is handed, so the caller must trim. Content helpers moved to `models` as the single source of truth shared by the on-demand create path and the scheduler.

## Tenant API — `GET`/`PUT /me/backup-schedule` (owner-scoped, fail-closed)
- `cron_expr` is **forced** from the admin-owned `server_settings.tenant_backup_cron` and never read from the body.
- `PUT` requires the package's `scheduled_backups_enabled`, gates the destination to the package's allowed kinds, and clamps `keep_*` to `max_backups`.
- Ownership marker: tenant schedules carry `user_id` (admin schedules leave it NULL), so `ListForUser` returns only the caller's own rows — a tenant can never reach an admin fan-out schedule. The fan-out is scoped to the caller (`ReplaceUsers([self])`).

## Admin
- `tenant_backup_cron` editable via `PATCH /admin/settings` (validated with `internalbackup.ParseCron`) + a cron field on `BackupSettingsTab`.

## UI
- Tenant schedule card (enable, content, allowed destination, retention capped at `max_backups`, next firing shown read-only) on the user Backups page.

## Tests
- `models` content helpers (`ValidBackupContent` / `NormalizeBackupContent` / `ApplyBackupContent`).
- Admin `tenant_backup_cron` valid + invalid-cron PATCH.
- `openapi.yaml` entries for the two new routes (TestOpenAPICoverage).

## Test plan
- [ ] Migration 000233 applies on a box; `backup_jobs.content` defaults `full`.
- [ ] Admin sets `tenant_backup_cron`; invalid cron rejected 400.
- [ ] Tenant `PUT /me/backup-schedule`: 403 when plan lacks scheduled backups; created schedule's cron == admin cron; destination gating + retention clamp.
- [ ] Cross-tenant: tenant A's GET/PUT never touches B's schedule.
- [ ] Content honored on dispatch (tick with a files-only schedule → job trims db/mail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)