### PR TITLE
fix(install): flock-guard install_bulwark against concurrent re-entry (GH #545 class)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11596,6 +11596,27 @@ install_bulwark() {
   local url="https://github.com/bulwarkmail/webmail/releases/download/${bulwark_version}/${tarball}"
   _log "installing Bulwark webmail (standalone tarball ${bulwark_version})"
 
+  # Serialize the whole function behind an flock (GH #545/#555 concurrent
+  # re-entry class): two install.sh invocations overlap on a fresh install --
+  # install.sh's own inline call, and the panel agent re-entering via
+  # `source install.sh && install_bulwark` to provision the mail module once
+  # the panel is up. Both race on the shared /tmp/${tarball} download, the
+  # /opt/jabali-webmail.stage extract, and the atomic swap; the losing racer
+  # dies with `tar` exit 2 when the winner's cleanup removes the tarball / stage
+  # out from under its extract (observed on 10.0.3.14: install-<A>.log died
+  # right after "downloading" while install-<B>.log completed the module 3s
+  # later). The version/dir idempotency below then turns the second caller into
+  # a fast no-op. Best-effort: if flock is unavailable proceed unlocked rather
+  # than block the install. Mirrors the install_stalwart guard.
+  local _bw_lockfd=""
+  if command -v flock >/dev/null 2>&1; then
+    exec {_bw_lockfd}>/run/lock/jabali-bulwark-install.lock 2>/dev/null || _bw_lockfd=""
+    if [[ -n "$_bw_lockfd" ]]; then
+      flock -w 600 "$_bw_lockfd" \
+        || _warn "waited 600s for the Bulwark install lock -- proceeding without exclusion"
+    fi
+  fi
+
   if ! getent passwd jabali-webmail >/dev/null 2>&1; then
     _log "creating jabali-webmail service user"
     useradd --system --no-create-home --shell /usr/sbin/nologin \
@@ -11638,6 +11659,8 @@ install_bulwark() {
     _install_bulwark_env
     _install_bulwark_libravatar_plugin
     _install_bulwark_impersonate_secrets
+    # Release the concurrency lock on the idempotent fast-path return too.
+    [[ -n "$_bw_lockfd" ]] && exec {_bw_lockfd}>&- || true
     return
   fi
 
@@ -11719,6 +11742,11 @@ install_bulwark() {
   _ok "Bulwark $bulwark_version installed at /opt/jabali-webmail"
 
   _install_bulwark_systemd
+
+  # Release the concurrency lock (see the flock at the top of the function).
+  # _die paths exit the process, so the kernel drops the fd there; this only
+  # covers the normal fall-through so a later legitimate caller can proceed.
+  [[ -n "$_bw_lockfd" ]] && exec {_bw_lockfd}>&- || true
 }
 
 # _install_bulwark_systemd installs the unit file. Env file is rendered


### PR DESCRIPTION
## Symptom
Fresh install on 10.0.3.14 fails: **`Install failed / exit status 2`**, TUI's last log line `downloading bulwark-standalone-1.7.7-linux-amd64.tar.gz`.

## Root cause — concurrent re-entry race (same class as #545 / #555)
Two `install.sh` invocations overlap on a fresh install:
1. `install.sh`'s own inline `install_bulwark`, and
2. the panel **agent** re-entering via `source install.sh && install_bulwark` to provision the mail module once the panel is up.

The two install logs on the box prove it — both reached `install_bulwark` at `19:44:41`, one died right after `downloading` while the other completed the module 3s later. They race on `install_bulwark`'s **fixed** shared paths: `/tmp/<tarball>`, the `/opt/jabali-webmail.stage` extract dir, and the atomic swap. The losing racer's `tar -xzf` reads a tarball/stage the winner's cleanup already removed → `tar` exits 2 → under `set -e` the ERR trap propagates exit 2.

`install_stalwart` was already guarded against this exact race by an flock in #555; `install_bulwark` never got the same guard.

## Fix
Serialize `install_bulwark` behind an flock on `/run/lock/jabali-bulwark-install.lock` (mirrors the `install_stalwart` guard). The second caller waits, then the version/dir idempotency check turns it into a fast no-op instead of a second concurrent download+extract. Best-effort: proceed unlocked if `flock` is unavailable. Lock released on both the idempotent fast-path return and the normal fall-through.

## Verification (on 10.0.3.14, real box)
Reproduced the exact race — two concurrent `install_bulwark`, forced re-download:
- **Pre-fix:** a loser fails every run (3/3 runs: `rcA=0 rcB=1` / `rcA=1 rcB=0`; the original TUI hit the `tar` exit-2 variant).
- **With the flock:** both exit 0 every run (`rcA=0 rcB=0`), `VERSION=1.7.7` intact, no `tar` error.

## Follow-up
Other re-entrant download steps (kratos/phpMyAdmin/adminer/wp-cli) share the same fixed-`/tmp` pattern; they did not race in this run only because they ran before the agent started. A broader sweep to guard or uniquify every re-entrant download is worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)