### PR TITLE
feat(installer): self-host release resolution on Cloudflare R2 (kill GitHub API rate limit)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,28 @@ jobs:
           upload_asset "$TARBALL"
           upload_asset "$CHECKSUM"
 
+      - name: Publish to R2 CDN (installer resolver)
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_PUBLIC_BASE: ${{ vars.R2_PUBLIC_BASE }}
+          SHORT_SHA: ${{ steps.build.outputs.short_sha }}
+          FULL_SHA: ${{ steps.build.outputs.full_sha }}
+        run: |
+          set -euo pipefail
+          # The R2 CDN is what lets `curl get.jabali-panel.com | bash` resolve a
+          # release without the GitHub API 60/hr rate limit. Skip cleanly if the
+          # R2 secrets are not configured yet — the GitHub release stays
+          # authoritative and the bootstrap falls back to it.
+          if [[ -z "${R2_ACCOUNT_ID:-}" || -z "${R2_ACCESS_KEY_ID:-}" ]]; then
+            echo "R2 secrets not configured — skipping CDN publish (GitHub release still authoritative)"
+            exit 0
+          fi
+          chmod +x tools/publish-release-r2.sh
+          tools/publish-release-r2.sh
+
       # Authoritative gate: the release is GOOD iff both assets are fetchable
       # for this commit's tag. Runs even if publish reported a transient blip.
       - name: Confirm assets published

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,14 +8,26 @@
 # The installer collects a deploy profile + modules + config, then runs
 # install.sh (JABALI_MODULES=…) with a live progress pane.
 #
+# Release resolution is served from jabali's OWN CDN (Cloudflare R2) via a tiny
+# latest.json manifest — NOT the GitHub API. The unauthenticated GitHub API is
+# capped at 60 requests/hour/IP, and cloud VMs behind shared-egress IPs hit that
+# ceiling constantly ("403 API rate limit exceeded"). The manifest has no such
+# limit. GitHub's releases API is kept only as a fallback for the window right
+# after a release, before the manifest is published.
+#
 # Non-interactive parity: pipe with no TTY, pass --unattended, or preset
 # JABALI_MODULES and the installer skips the TUI and runs install.sh directly.
 # Any args after `bash -s --` are forwarded to the installer (e.g. --dry-run).
 #
-# Overrides: JABALI_RELEASE_API_BASE (default GitHub), JABALI_REF (unused here;
-# the tarball is always the latest published release).
+# Overrides:
+#   JABALI_MANIFEST_URL      default https://dl.jabali-panel.com/latest.json
+#   JABALI_RELEASE_API_BASE  GitHub fallback repo API (used only if the manifest
+#                            is unreachable)
+#   JABALI_GITHUB_TOKEN / GITHUB_TOKEN  auth for the GitHub fallback (raises the
+#                            60/hr unauthenticated limit to 5000/hr)
 set -euo pipefail
 
+MANIFEST_URL="${JABALI_MANIFEST_URL:-https://dl.jabali-panel.com/latest.json}"
 API_BASE="${JABALI_RELEASE_API_BASE:-https://api.github.com/repos/shukiv/jabali-panel}"
 
 die() { printf '\033[1;31m[bootstrap] %s\033[0m\n' "$*" >&2; exit 1; }
@@ -26,40 +38,73 @@ for bin in curl tar sha256sum; do
   command -v "$bin" >/dev/null 2>&1 || die "missing required tool: $bin"
 done
 
-log "resolving latest release with a verified tarball from ${API_BASE}"
-# Scan the releases list (newest first) rather than /releases/latest: the very
-# newest tag may be published seconds before its build finishes, so it can be
-# asset-less. grep/sed only — no jq dependency on a fresh box. The tarball URLs
-# are already newest-first; the matching .sha256 sidecar is ALWAYS derived from
-# the same tarball URL (same release, same path) so we never pair a tarball with
-# a different release's checksum. Walk candidates until one downloads + verifies.
-rel="$(curl -fsSL "${API_BASE}/releases?per_page=30")" || die "could not reach the release API"
-tar_urls="$(printf '%s' "$rel" \
-  | grep -oE '"browser_download_url": *"[^"]+"' \
-  | sed 's/.*"\(https[^"]*\)"/\1/' \
-  | grep -E 'jabali-release-[0-9a-f]+\.tar\.gz$' || true)"
-[[ -n "$tar_urls" ]] || die "no published release tarball found (the release build may not have attached assets yet)"
-
 tmp="$(mktemp -d /tmp/jabali-bootstrap.XXXXXX)"
 trap 'rm -rf "$tmp"' EXIT
 
-verified=""
-while IFS= read -r tar_url; do
-  [[ -n "$tar_url" ]] || continue
-  sum_url="${tar_url}.sha256"                       # same release, same path
-  log "trying $(basename "$tar_url")"
-  curl -fsSL "$sum_url" -o "$tmp/release.sha256" 2>/dev/null || { log "  no checksum sidecar, skipping"; continue; }
-  curl -fsSL "$tar_url" -o "$tmp/release.tar.gz"  || { log "  tarball download failed, skipping"; continue; }
-  expected="$(awk '{print $1}' "$tmp/release.sha256")"
-  actual="$(sha256sum "$tmp/release.tar.gz" | awk '{print $1}')"
-  if [[ -n "$expected" && "$expected" == "$actual" ]]; then
-    verified=1
-    log "checksum verified"
-    break
+# Extract one string field from flat JSON with grep/sed — no jq on a fresh box.
+json_str() { grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | sed -E "s/.*:[[:space:]]*\"([^\"]*)\"/\1/" | head -1; }
+
+tar_url=""      # resolved release tarball URL
+sum_url=""      # optional .sha256 sidecar URL (GitHub fallback path)
+expected=""     # expected sha256 (from the manifest, or the sidecar)
+
+# ---- primary: jabali CDN manifest (Cloudflare R2, no rate limit) ----------
+log "resolving latest release from ${MANIFEST_URL}"
+if manifest="$(curl -fsSL --connect-timeout 15 --retry 2 --retry-delay 2 "$MANIFEST_URL" 2>/dev/null)"; then
+  tar_url="$(printf '%s' "$manifest" | json_str tarball)"
+  expected="$(printf '%s' "$manifest" | json_str sha256)"
+  if [[ -z "$tar_url" || -z "$expected" ]]; then
+    log "manifest is missing tarball/sha256 — falling back to GitHub releases"
+    tar_url="" expected=""
   fi
-  log "  checksum mismatch, skipping"
-done <<< "$tar_urls"
-[[ -n "$verified" ]] || die "no release had a matching .tar.gz + .sha256 pair (the release build may be mid-flight — retry shortly)"
+else
+  log "jabali CDN unreachable — falling back to GitHub releases"
+fi
+
+# ---- fallback: GitHub releases API (rate-limited; optional token) ----------
+# Scan the releases list (newest first) rather than /releases/latest: the very
+# newest tag may be published seconds before its build finishes, so it can be
+# asset-less. Walk candidates until one has both a tarball and a .sha256 sidecar.
+if [[ -z "$tar_url" ]]; then
+  auth=()
+  tok="${JABALI_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
+  [[ -n "$tok" ]] && auth=(-H "Authorization: Bearer $tok")
+  log "resolving latest release from ${API_BASE}"
+  if ! rel="$(curl -fsSL "${auth[@]}" "${API_BASE}/releases?per_page=30" 2>/dev/null)"; then
+    code="$(curl -s -o /dev/null -w '%{http_code}' "${auth[@]}" "${API_BASE}/releases?per_page=30" 2>/dev/null || true)"
+    if [[ "$code" == "403" ]]; then
+      die "GitHub API rate limit hit (60/hr per IP, unauthenticated). Retry within the hour, set JABALI_GITHUB_TOKEN=<token> for 5000/hr, or point JABALI_MANIFEST_URL at the jabali CDN."
+    fi
+    die "could not reach the release API (HTTP ${code:-?})"
+  fi
+  tar_urls="$(printf '%s' "$rel" \
+    | grep -oE '"browser_download_url": *"[^"]+"' \
+    | sed 's/.*"\(https[^"]*\)"/\1/' \
+    | grep -E 'jabali-release-[0-9a-f]+\.tar\.gz$' || true)"
+  [[ -n "$tar_urls" ]] || die "no published release tarball found (the release build may not have attached assets yet)"
+  while IFS= read -r u; do
+    [[ -n "$u" ]] || continue
+    if curl -fsIL "${u}.sha256" >/dev/null 2>&1; then
+      tar_url="$u"
+      sum_url="${u}.sha256"
+      break
+    fi
+  done <<< "$tar_urls"
+  [[ -n "$tar_url" ]] || die "no release had a matching .tar.gz + .sha256 pair (the release build may be mid-flight — retry shortly)"
+fi
+
+# ---- download + verify ----------------------------------------------------
+log "downloading $(basename "$tar_url")"
+curl -fsSL --connect-timeout 20 --retry 3 --retry-delay 3 "$tar_url" -o "$tmp/release.tar.gz" \
+  || die "tarball download failed: $tar_url"
+if [[ -z "$expected" && -n "$sum_url" ]]; then
+  curl -fsSL "$sum_url" -o "$tmp/release.sha256" || die "checksum download failed: $sum_url"
+  expected="$(awk '{print $1}' "$tmp/release.sha256")"
+fi
+[[ -n "$expected" ]] || die "no expected sha256 for the release (manifest and sidecar both absent)"
+actual="$(sha256sum "$tmp/release.tar.gz" | awk '{print $1}')"
+[[ "$expected" == "$actual" ]] || die "checksum mismatch (expected $expected, got $actual)"
+log "checksum verified"
 
 # Extract only what the bootstrap needs.
 tar -C "$tmp" -xzf "$tmp/release.tar.gz" bin/jabali-installer install.sh \

--- a/tools/publish-release-r2.sh
+++ b/tools/publish-release-r2.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Publish a built jabali release to Cloudflare R2 so the installer bootstrap can
+# resolve it WITHOUT the GitHub API (which caps unauthenticated requests at
+# 60/hr/IP — cloud VMs on shared-egress IPs hit that constantly, GH bootstrap
+# "403 API rate limit exceeded"). R2 is S3-compatible; we sign with curl's
+# native --aws-sigv4 so there is no aws-cli / rclone dependency.
+#
+# Uploads three objects to the bucket root:
+#   jabali-release-<sha>.tar.gz          (immutable, long cache)
+#   jabali-release-<sha>.tar.gz.sha256   (immutable, long cache)
+#   latest.json                          (short cache — the pointer the
+#                                         bootstrap reads first)
+#
+# Required env:
+#   R2_ACCOUNT_ID           Cloudflare account id (the R2 S3 endpoint host)
+#   R2_BUCKET               bucket name
+#   R2_ACCESS_KEY_ID        R2 S3 access key id
+#   R2_SECRET_ACCESS_KEY    R2 S3 secret
+# Optional env:
+#   R2_PUBLIC_BASE          public URL the objects are served at
+#                           (default https://dl.jabali-panel.com)
+#   DIST_DIR                where the tarball lives (default ./dist)
+#   SHORT_SHA / FULL_SHA    release identity (default: git rev-parse)
+#   PUBLISHED_AT            ISO-8601 timestamp (default: date -u)
+set -euo pipefail
+
+die() { printf '\033[1;31m[r2-publish] %s\033[0m\n' "$*" >&2; exit 1; }
+log() { printf '\033[1;34m[r2-publish]\033[0m %s\n' "$*"; }
+
+for v in R2_ACCOUNT_ID R2_BUCKET R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+  [[ -n "${!v:-}" ]] || die "missing required env: $v"
+done
+command -v curl >/dev/null 2>&1 || die "curl not found"
+command -v sha256sum >/dev/null 2>&1 || die "sha256sum not found"
+# curl's S3 signer landed in 7.75.0; fail early with a clear message otherwise.
+curl --help all 2>/dev/null | grep -q -- '--aws-sigv4' || die "curl is too old for --aws-sigv4 (need >= 7.75.0)"
+
+PUBLIC_BASE="${R2_PUBLIC_BASE:-https://dl.jabali-panel.com}"
+PUBLIC_BASE="${PUBLIC_BASE%/}"
+DIST_DIR="${DIST_DIR:-dist}"
+SHORT_SHA="${SHORT_SHA:-$(git rev-parse --short HEAD)}"
+FULL_SHA="${FULL_SHA:-$(git rev-parse HEAD)}"
+PUBLISHED_AT="${PUBLISHED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+TARBALL="${DIST_DIR}/jabali-release-${SHORT_SHA}.tar.gz"
+CHECKSUM="${TARBALL}.sha256"
+[[ -f "$TARBALL" ]]  || die "tarball not found: $TARBALL (run tools/build-release.sh first)"
+[[ -f "$CHECKSUM" ]] || die "checksum sidecar not found: $CHECKSUM"
+
+# Verify the sidecar matches the tarball before we publish a pointer to it — a
+# corrupt upload that still gets referenced by latest.json would brick installs.
+expected="$(awk '{print $1}' "$CHECKSUM")"
+actual="$(sha256sum "$TARBALL" | awk '{print $1}')"
+[[ -n "$expected" && "$expected" == "$actual" ]] \
+  || die "local checksum mismatch (sidecar $expected vs file $actual) — rebuild the release"
+
+ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+# put_object <local-file> <key> <content-type> <cache-control>
+put_object() {
+  local file="$1" key="$2" ctype="$3" cache="$4"
+  log "PUT ${key} (${ctype})"
+  curl -fsS --retry 3 --retry-delay 3 \
+    --aws-sigv4 "aws:amz:auto:s3" \
+    --user "${R2_ACCESS_KEY_ID}:${R2_SECRET_ACCESS_KEY}" \
+    -H "Content-Type: ${ctype}" \
+    -H "Cache-Control: ${cache}" \
+    -X PUT --data-binary @"$file" \
+    "${ENDPOINT}/${R2_BUCKET}/${key}" \
+    || die "upload failed: ${key}"
+}
+
+IMMUTABLE="public, max-age=31536000, immutable"
+POINTER="public, max-age=60, must-revalidate"
+
+put_object "$TARBALL"  "jabali-release-${SHORT_SHA}.tar.gz"        "application/gzip" "$IMMUTABLE"
+put_object "$CHECKSUM" "jabali-release-${SHORT_SHA}.tar.gz.sha256" "text/plain"       "$IMMUTABLE"
+
+# The pointer the bootstrap reads FIRST. Written LAST so it never references an
+# object that isn't fully uploaded yet.
+manifest="$(printf '{\n  "version": "%s",\n  "full_sha": "%s",\n  "tarball": "%s/jabali-release-%s.tar.gz",\n  "sha256": "%s",\n  "published_at": "%s"\n}\n' \
+  "$SHORT_SHA" "$FULL_SHA" "$PUBLIC_BASE" "$SHORT_SHA" "$expected" "$PUBLISHED_AT")"
+tmp_manifest="$(mktemp)"; trap 'rm -f "$tmp_manifest"' EXIT
+printf '%s' "$manifest" > "$tmp_manifest"
+put_object "$tmp_manifest" "latest.json" "application/json" "$POINTER"
+
+log "published release ${SHORT_SHA} to ${PUBLIC_BASE}/latest.json"
+printf '%s\n' "$manifest"


### PR DESCRIPTION
## Problem
`curl -fsSL https://get.jabali-panel.com | sudo bash` fails:
```
[bootstrap] resolving latest release with a verified tarball from https://api.github.com/repos/shukiv/jabali-panel
curl: (22) The requested URL returned error: 403
[bootstrap] could not reach the release API
```
`bootstrap.sh` resolved the latest release via `api.github.com`, whose **unauthenticated limit is 60 req/hr/IP**. Cloud VMs on shared-egress IPs (and anyone re-running installs) exhaust it → `403 API rate limit exceeded`. Only the *metadata* call was limited; the tarball/checksum downloads were never affected.

## Fix — resolve from our own CDN (Cloudflare R2)
- **`bootstrap.sh`** reads a tiny `latest.json` from the R2-backed CDN (default `https://dl.jabali-panel.com/latest.json`) — no API, no rate limit — then downloads + `sha256`-verifies the tarball it names. The GitHub releases API stays as a **fallback** (with optional `JABALI_GITHUB_TOKEN`/`GITHUB_TOKEN` auth → 5000/hr, and an explicit rate-limit message) for the brief window after a release before the manifest is published.
- **`tools/publish-release-r2.sh`** uploads tarball + `.sha256` + `latest.json` to R2 via curl's native `--aws-sigv4` (no aws-cli/rclone dep). Verifies the sidecar locally first, writes `latest.json` **last** so it never points at a half-uploaded object.
- **`release.yml`** gains an R2 publish step after the GitHub upload; it **skips cleanly** when R2 secrets aren't set, so the GitHub release stays authoritative during rollout.

## Verified
- `bash -n` on both scripts; `release.yml` parses as YAML.
- Contract test: the exact `latest.json` the publish script emits is parsed correctly by the bootstrap's `json_str` extractor (tarball + sha256 + version).

## Out-of-band provisioning (tracked separately)
1. Enable R2 + create a bucket (e.g. `jabali-installer`).
2. Bind custom domain `dl.jabali-panel.com` → bucket (CF R2 custom domain).
3. Mint R2 S3 creds; add CI secrets `R2_ACCOUNT_ID` / `R2_BUCKET` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` (+ optional var `R2_PUBLIC_BASE`).
4. First publish (run `tools/publish-release-r2.sh` once) so `latest.json` exists.

Until then the bootstrap's GitHub fallback keeps installs working (retry after the hourly reset, or set `JABALI_GITHUB_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)