### PR TITLE
fix(install): flock-guard install_phpmyadmin against concurrent re-entry (GH #545/#574 class)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6627,6 +6627,24 @@ install_phpmyadmin() {
   local pma_link="${pma_root}/current"
   local pma_archive="/tmp/phpMyAdmin-${pma_version}-all-languages.tar.gz"
 
+  # Serialize the whole function behind an flock (GH #545/#574 concurrent
+  # re-entry class): install.sh's own call and the panel agent re-entering via
+  # provision_new_software both reach install_phpmyadmin, and race on the shared
+  # /tmp/phpMyAdmin-*.tar.gz download + the /opt/phpmyadmin extract. The losing
+  # racer's `tar -xzf` reads a tarball the winner's `rm -f "$pma_archive"` has
+  # already removed -> `tar` exit 2 -> `set -e` kills the install (same failure
+  # as install_bulwark #574 / install_stalwart #555). The idempotency check
+  # below then makes the second caller a fast no-op. Best-effort: proceed
+  # unlocked if flock is unavailable.
+  local _pma_lockfd=""
+  if command -v flock >/dev/null 2>&1; then
+    exec {_pma_lockfd}>/run/lock/jabali-phpmyadmin-install.lock 2>/dev/null || _pma_lockfd=""
+    if [[ -n "$_pma_lockfd" ]]; then
+      flock -w 600 "$_pma_lockfd" \
+        || _warn "waited 600s for the phpMyAdmin install lock -- proceeding without exclusion"
+    fi
+  fi
+
   # Idempotency: if already extracted, skip the download + extract.
   if [[ -d "$pma_extract" && -L "$pma_link" ]]; then
     _ok "phpMyAdmin $pma_version already installed at $pma_root"
@@ -6655,6 +6673,7 @@ install_phpmyadmin() {
       _warn "failed to download phpMyAdmin $pma_version after 5 retries — skipping (panel works without it; re-run 'jabali update' once https://www.phpmyadmin.net/downloads/ is reachable)"
       mkdir -p /etc/nginx/sites-available/includes
       [[ -f /etc/nginx/sites-available/includes/phpmyadmin.conf ]] || : > /etc/nginx/sites-available/includes/phpmyadmin.conf
+      [[ -n "$_pma_lockfd" ]] && exec {_pma_lockfd}>&- || true
       return 0
     fi
 
@@ -6956,6 +6975,11 @@ NGINXEOF
   chown www-data:www-data /var/log/nginx/jabali-pma.{access,error}.log
 
   _ok "phpMyAdmin installed and configured"
+
+  # Release the concurrency lock (see the flock at the top of the function).
+  # _die paths exit the process so the kernel drops the fd; this covers the
+  # normal fall-through so a later legitimate caller can proceed.
+  [[ -n "$_pma_lockfd" ]] && exec {_pma_lockfd}>&- || true
 }
 
 install_sftp_group() {


### PR DESCRIPTION
Follow-up to #574 — the concurrent-reentry sweep flagged in that PR.

## The race (same class as #574 bulwark / #555 stalwart)
`install_phpmyadmin` is re-entered by `provision_new_software` (jabali update / agent self-heal, `install.sh:13039`) as well as install.sh's own call, so the two run concurrently on a fresh install. It has the identical race surface:
- fixed `/tmp/phpMyAdmin-<ver>-all-languages.tar.gz` download
- TOCTOU idempotency check (`[[ -d "$pma_extract" && -L "$pma_link" ]]`)
- `tar -C /opt/phpmyadmin -xzf "$pma_archive"` then `rm -f "$pma_archive"`

The losing racer's `tar` reads a tarball the winner's `rm` already deleted → **`tar` exit 2** → `set -e` kills the whole install (or the loser's `sha256sum` fails first, exit 1). Same failure mode that produced the "Install failed / exit status 2" in #574.

## Scope — checked the others too
`provision_new_software` re-enters **only** `install_phpmyadmin` among the download functions. `install_wpcli` is explicitly not re-entered (`install.sh:6578`); `install_kratos` / `install_adminer` aren't called by `provision_new_software` either. So this is the only remaining at-risk function — no guard needed on the rest.

## Fix
Serialize the function behind `flock /run/lock/jabali-phpmyadmin-install.lock` (verbatim mirror of #574/#555): the second caller waits, then the version/dir idempotency check makes it a fast no-op. Best-effort (proceeds unlocked if `flock` absent); lock released on the non-fatal download-fail `return` and the normal fall-through (`_die` paths drop the fd on exit).

## Verified
- `bash -n install.sh`.
- The exact acquire/release block I added: 3 concurrent runs serialize (all exit 0, critical section never overlaps) and release cleanly (a subsequent `flock -n` acquires instantly). The download-race correctness is established by #574's box repro (old fails 3/3, flock 0 fails) on the identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)