### PR TITLE
feat(backups): admin-selectable tenant retention policy + cap notifications (GH #454)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -27,6 +27,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
@@ -1058,6 +1059,10 @@ type MeBackupsHandlerConfig struct {
 	// CLOSED (denies) rather than skipping when the entitlement can't be resolved.
 	Packages repository.PackageRepository
 
+	// Notify publishes the backup.limit.reached event to the tenant + admins when
+	// the retention cap is hit (GH #454). Optional — nil just skips the notice.
+	Notify *notifications.Queue
+
 	// Schedules + Settings power the tenant scheduled-backup card (GH #454
 	// Step 4): the tenant owns content/destination/on-off within their package
 	// limits, the admin owns the cron TIME (server_settings.tenant_backup_cron).
@@ -1292,8 +1297,17 @@ func (h *meBackupHandler) create(c *gin.Context) {
 			return
 		}
 		if total >= int64(pkg.MaxBackups) {
-			c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "backup_limit_reached", "detail": fmt.Sprintf("your plan allows %d backups; delete an old one before creating another", pkg.MaxBackups)})
-			return
+			// Retention policy (GH #454): the admin picks reject (default, safe) or
+			// prune. Prune auto-forgets the tenant's OLDEST OWNED backup(s) to make
+			// room; if it can't free enough (e.g. only running jobs remain) it falls
+			// back to reject. Either way, the tenant + admins are notified.
+			if pkg.BackupRetentionPrunes() && h.pruneOldestOwned(c.Request.Context(), user, int(pkg.MaxBackups)) {
+				h.notifyBackupLimit(c.Request.Context(), user, "prune", pkg.MaxBackups)
+			} else {
+				h.notifyBackupLimit(c.Request.Context(), user, "reject", pkg.MaxBackups)
+				c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "backup_limit_reached", "detail": fmt.Sprintf("your plan allows %d backups; delete an old one before creating another", pkg.MaxBackups)})
+				return
+			}
 		}
 	}
 	var req createBackupRequest // content/folders/compression + optional destination_id
@@ -1623,6 +1637,72 @@ func (h *meBackupHandler) putSchedule(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// pruneOldestOwned auto-forgets the caller's OLDEST owned account_backup(s)
+// until they are under maxBackups, for the "prune" retention policy (GH #454).
+// Owner-scoped: OldestAccountBackupForUser filters by user_id, so a tenant can
+// only ever prune their OWN backups. Returns true once under the cap; false if
+// it can't free enough (e.g. only running/restore jobs remain) -> caller falls
+// back to reject. The forget is best-effort (an orphaned snapshot is reclaimed
+// by the retention sweep); the row delete is what guarantees loop progress.
+func (h *meBackupHandler) pruneOldestOwned(ctx context.Context, user *models.User, maxBackups int) bool {
+	for i := 0; i < 1000; i++ { // bounded so an odd repo state can't spin forever
+		_, total, err := h.cfg.Jobs.ListForUser(ctx, user.ID, 1, 0)
+		if err != nil {
+			return false
+		}
+		if total < int64(maxBackups) {
+			return true
+		}
+		oldest, oerr := h.cfg.Jobs.OldestAccountBackupForUser(ctx, user.ID)
+		if oerr != nil || oldest == nil {
+			return false
+		}
+		if h.cfg.Agent != nil {
+			fctx, cancel := context.WithTimeout(ctx, backupCallTimeout)
+			_, _ = h.cfg.Agent.Call(fctx, "backup.forget", map[string]any{
+				"job_id": oldest.ID, "user_id": oldest.UserID, "kind": oldest.Kind,
+			})
+			cancel()
+		}
+		if derr := h.cfg.Jobs.Delete(ctx, oldest.ID); derr != nil {
+			return false
+		}
+	}
+	return false
+}
+
+// notifyBackupLimit fires the backup.limit.reached event to the tenant's own
+// inbox (UserID set) AND broadcasts it to every admin bell (UserID empty), with
+// bodies tailored to the outcome ("reject" blocked / "prune" auto-removed).
+// Best-effort — a notify failure never blocks the backup path (GH #454).
+func (h *meBackupHandler) notifyBackupLimit(ctx context.Context, user *models.User, outcome string, limit uint32) {
+	if h.cfg.Notify == nil {
+		return
+	}
+	who := user.ID
+	if user.Username != nil && *user.Username != "" {
+		who = *user.Username
+	}
+	var tenantBody, adminBody string
+	if outcome == "prune" {
+		tenantBody = fmt.Sprintf("You reached your plan's backup limit (%d). Your oldest backup was automatically removed to make room for the new one.", limit)
+		adminBody = fmt.Sprintf("Tenant %s reached their backup limit (%d); the oldest backup was auto-pruned per the package retention policy.", who, limit)
+	} else {
+		tenantBody = fmt.Sprintf("You reached your plan's backup limit (%d). Delete an old backup before creating another, or ask your host to raise the limit.", limit)
+		adminBody = fmt.Sprintf("Tenant %s reached their backup limit (%d); the new backup was blocked (reject policy).", who, limit)
+	}
+	nctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, _ = h.cfg.Notify.Publish(nctx, notifications.Envelope{
+		EventKind: "backup.limit.reached", Severity: "warning",
+		Title: "Backup limit reached", Body: tenantBody, UserID: user.ID,
+	})
+	_, _ = h.cfg.Notify.Publish(nctx, notifications.Envelope{
+		EventKind: "backup.limit.reached", Severity: "warning",
+		Title: "Tenant backup limit reached", Body: adminBody,
+	})
 }
 
 func (h *meBackupHandler) list(c *gin.Context) {

--- a/panel-api/internal/api/packages.go
+++ b/panel-api/internal/api/packages.go
@@ -86,6 +86,7 @@ type createPackageRequest struct {
 	MaxBackups                    uint32 `json:"max_backups"`
 	ScheduledBackupsEnabled       bool   `json:"scheduled_backups_enabled"`
 	AllowedBackupDestinationKinds string `json:"allowed_backup_destination_kinds"`
+	BackupRetentionPolicy         string `json:"backup_retention_policy"`
 	SSHEnabled                    bool   `json:"ssh_enabled"`
 	CGIEnabled                    bool   `json:"cgi_enabled"`
 	PHPExecEnabled                bool   `json:"php_exec_enabled"`
@@ -117,6 +118,7 @@ type updatePackageRequest struct {
 	MaxBackups                    *uint32 `json:"max_backups"`
 	ScheduledBackupsEnabled       *bool   `json:"scheduled_backups_enabled"`
 	AllowedBackupDestinationKinds *string `json:"allowed_backup_destination_kinds"`
+	BackupRetentionPolicy         *string `json:"backup_retention_policy"`
 	SSHEnabled                    *bool   `json:"ssh_enabled"`
 	CGIEnabled                    *bool   `json:"cgi_enabled"`
 	PHPExecEnabled                *bool   `json:"php_exec_enabled"`
@@ -179,6 +181,13 @@ func (h *packageHandler) create(c *gin.Context) {
 		return
 	}
 	req.AllowedBackupDestinationKinds = normKinds
+	if !models.IsValidBackupRetentionPolicy(req.BackupRetentionPolicy) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_backup_retention_policy", "detail": "must be reject or prune"})
+		return
+	}
+	if req.BackupRetentionPolicy == "" {
+		req.BackupRetentionPolicy = models.BackupRetentionReject
+	}
 	pkg := &models.HostingPackage{
 		ID:               ids.NewULID(),
 		Name:             req.Name,
@@ -198,6 +207,7 @@ func (h *packageHandler) create(c *gin.Context) {
 		MaxBackups:                    req.MaxBackups,
 		ScheduledBackupsEnabled:       req.ScheduledBackupsEnabled,
 		AllowedBackupDestinationKinds: req.AllowedBackupDestinationKinds,
+		BackupRetentionPolicy:         req.BackupRetentionPolicy,
 
 		SSHEnabled:         req.SSHEnabled,
 		CGIEnabled:         req.CGIEnabled,
@@ -342,6 +352,17 @@ func (h *packageHandler) update(c *gin.Context) {
 			return
 		}
 		pkg.AllowedBackupDestinationKinds = normKinds
+	}
+	if req.BackupRetentionPolicy != nil {
+		if !models.IsValidBackupRetentionPolicy(*req.BackupRetentionPolicy) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_backup_retention_policy", "detail": "must be reject or prune"})
+			return
+		}
+		v := *req.BackupRetentionPolicy
+		if v == "" {
+			v = models.BackupRetentionReject
+		}
+		pkg.BackupRetentionPolicy = v
 	}
 	if req.SSHEnabled != nil {
 		pkg.SSHEnabled = *req.SSHEnabled

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1007,6 +1007,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// routes; absent, the card's endpoints simply aren't mounted.
 				Schedules: deps.BackupSchedules,
 				Settings:  deps.ServerSettings,
+				Notify:    deps.NotificationQueue,
 				Log:       deps.Log,
 			})
 		}

--- a/panel-api/internal/db/migrations/000234_package_backup_retention_policy.down.sql
+++ b/panel-api/internal/db/migrations/000234_package_backup_retention_policy.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE hosting_packages DROP COLUMN backup_retention_policy;

--- a/panel-api/internal/db/migrations/000234_package_backup_retention_policy.up.sql
+++ b/panel-api/internal/db/migrations/000234_package_backup_retention_policy.up.sql
@@ -1,0 +1,8 @@
+-- GH #454: admin-selectable tenant backup retention policy. When a tenant
+-- reaches their package's max_backups, backup_retention_policy chooses the
+-- behaviour: 'reject' (default, safe — block the new backup and notify the
+-- tenant + admins) or 'prune' (auto-forget the tenant's OLDEST owned backup to
+-- make room, then create, and notify). Default 'reject' preserves the existing
+-- reject-at-cap behaviour so no plan changes silently until an admin opts in.
+ALTER TABLE hosting_packages
+  ADD COLUMN backup_retention_policy VARCHAR(16) NOT NULL DEFAULT 'reject';

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -24,6 +24,10 @@ func (f *fakeBackupJobs) Delete(context.Context, string) error            { retu
 func (f *fakeBackupJobs) Get(context.Context, string) (*models.BackupJob, error) {
 	return nil, nil
 }
+func (f *fakeBackupJobs) OldestAccountBackupForUser(context.Context, string) (*models.BackupJob, error) {
+	return nil, nil
+}
+
 func (f *fakeBackupJobs) ListForUser(context.Context, string, int, int) ([]models.BackupJob, int64, error) {
 	return nil, 0, nil
 }

--- a/panel-api/internal/models/hosting_package.go
+++ b/panel-api/internal/models/hosting_package.go
@@ -54,6 +54,11 @@ type HostingPackage struct {
 	MaxBackups                    uint32 `gorm:"column:max_backups;type:int unsigned;not null;default:0" json:"max_backups"`
 	ScheduledBackupsEnabled       bool   `gorm:"column:scheduled_backups_enabled;type:tinyint(1);not null;default:0" json:"scheduled_backups_enabled"`
 	AllowedBackupDestinationKinds string `gorm:"column:allowed_backup_destination_kinds;type:varchar(255);not null;default:''" json:"allowed_backup_destination_kinds"`
+	// BackupRetentionPolicy (GH #454) chooses the behaviour when a tenant hits
+	// MaxBackups: "reject" (default, safe) blocks the new backup and notifies;
+	// "prune" auto-forgets the oldest OWNED backup to make room, then creates,
+	// and notifies. Admin-owned, per package.
+	BackupRetentionPolicy string `gorm:"column:backup_retention_policy;type:varchar(16);not null;default:'reject'" json:"backup_retention_policy"`
 
 	// Feature toggles.
 	SSHEnabled bool `gorm:"type:tinyint(1);not null;default:0" json:"ssh_enabled"`
@@ -130,4 +135,29 @@ func (p HostingPackage) AllowsBackupKind(kind string) bool {
 		}
 	}
 	return false
+}
+
+// Backup retention policies (GH #454).
+const (
+	BackupRetentionReject = "reject"
+	BackupRetentionPrune  = "prune"
+)
+
+// IsValidBackupRetentionPolicy validates the admin-supplied policy so a bad
+// value can't reach the DB / the create gate. The empty string is accepted and
+// treated as the safe "reject" default.
+func IsValidBackupRetentionPolicy(s string) bool {
+	switch s {
+	case "", BackupRetentionReject, BackupRetentionPrune:
+		return true
+	}
+	return false
+}
+
+// BackupRetentionPrunes reports whether this package auto-prunes the oldest
+// backup at the cap. Anything other than an explicit "prune" (including the
+// empty string / an unknown value) means reject — fail safe, never auto-delete
+// tenant data on a misconfiguration.
+func (p HostingPackage) BackupRetentionPrunes() bool {
+	return p.BackupRetentionPolicy == BackupRetentionPrune
 }

--- a/panel-api/internal/models/hosting_package_retention_test.go
+++ b/panel-api/internal/models/hosting_package_retention_test.go
@@ -1,0 +1,32 @@
+package models
+
+import "testing"
+
+func TestIsValidBackupRetentionPolicy(t *testing.T) {
+	for _, ok := range []string{"", "reject", "prune"} {
+		if !IsValidBackupRetentionPolicy(ok) {
+			t.Errorf("IsValidBackupRetentionPolicy(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"REJECT", "delete", "keep", "x", "purge"} {
+		if IsValidBackupRetentionPolicy(bad) {
+			t.Errorf("IsValidBackupRetentionPolicy(%q) = true, want false", bad)
+		}
+	}
+}
+
+// BackupRetentionPrunes must FAIL SAFE: only an explicit "prune" auto-deletes
+// tenant data. Empty / unknown / mis-cased values must mean reject, so a
+// misconfiguration never silently destroys backups (GH #454).
+func TestBackupRetentionPrunes_FailsSafe(t *testing.T) {
+	prune := HostingPackage{BackupRetentionPolicy: "prune"}
+	if !prune.BackupRetentionPrunes() {
+		t.Error("policy=prune should prune")
+	}
+	for _, safe := range []string{"", "reject", "REJECT", "Prune", "delete", "x"} {
+		p := HostingPackage{BackupRetentionPolicy: safe}
+		if p.BackupRetentionPrunes() {
+			t.Errorf("policy=%q must NOT prune (fail-safe to reject)", safe)
+		}
+	}
+}

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -122,6 +122,13 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		DefaultOn:   true,
 	},
 	{
+		Kind:        "backup.limit.reached",
+		Label:       "Tenant backup limit reached",
+		Description: "A tenant hit their package's max_backups cap. Depending on the package retention policy the backup was blocked (reject) or the oldest was auto-pruned (prune). Notifies the tenant and admins (GH #454).",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
 		Kind:        "admin.login",
 		Label:       "Admin signed in",
 		Description: "First request of a new Kratos admin session.",

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -25,6 +25,11 @@ type BackupJobRepository interface {
 	Delete(ctx context.Context, id string) error
 	Get(ctx context.Context, id string) (*models.BackupJob, error)
 	ListForUser(ctx context.Context, userID string, limit, offset int) ([]models.BackupJob, int64, error)
+	// OldestAccountBackupForUser returns the caller's OLDEST account_backup job
+	// (created_at ASC) for auto-prune retention (GH #454), or ErrNotFound when
+	// they have none. Owner-scoped by user_id; the prune caller never passes a
+	// body id.
+	OldestAccountBackupForUser(ctx context.Context, userID string) (*models.BackupJob, error)
 	ListAll(ctx context.Context, limit, offset int) ([]models.BackupJob, int64, error)
 	MarkStarted(ctx context.Context, id string) error
 	MarkFinished(ctx context.Context, id, status string, snapshotID, parentSnapshot string, bytesAdded, bytesTotal uint64, manifest, warnings json.RawMessage, errText string) error
@@ -108,6 +113,18 @@ func (r *backupJobRepo) Delete(ctx context.Context, id string) error {
 
 func (r *backupJobRepo) ListForUser(ctx context.Context, userID string, limit, offset int) ([]models.BackupJob, int64, error) {
 	return r.list(ctx, "user_id = ?", []any{userID}, limit, offset)
+}
+
+func (r *backupJobRepo) OldestAccountBackupForUser(ctx context.Context, userID string) (*models.BackupJob, error) {
+	var out models.BackupJob
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND kind = ?", userID, models.BackupJobKindAccountBackup).
+		Order("created_at ASC").
+		First(&out).Error
+	if err != nil {
+		return nil, translate(err)
+	}
+	return &out, nil
 }
 
 func (r *backupJobRepo) ListAll(ctx context.Context, limit, offset int) ([]models.BackupJob, int64, error) {

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -47,6 +47,7 @@ type PackageCreateInput = {
   max_backups: number;
   scheduled_backups_enabled: boolean;
   allowed_backup_destination_kinds: string | string[];
+  backup_retention_policy: string;
   ssh_enabled: boolean;
   cgi_enabled: boolean;
   php_exec_enabled: boolean;
@@ -152,6 +153,7 @@ export const PackageCreate = () => {
           max_backups: 0,
           scheduled_backups_enabled: false,
           allowed_backup_destination_kinds: [],
+          backup_retention_policy: "reject",
         }}
         onFinish={handleFinish}
       >
@@ -338,6 +340,21 @@ export const PackageCreate = () => {
                 allowClear
                 placeholder="e.g. local, s3"
                 options={BACKUP_DESTINATION_KINDS.map((k) => ({ value: k, label: k }))}
+                style={{ width: "100%" }}
+              />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Backup Retention Policy"
+              name="backup_retention_policy"
+              tooltip="What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+            >
+              <Select
+                options={[
+                  { value: "reject", label: "Reject at cap (safe)" },
+                  { value: "prune", label: "Auto-prune oldest" },
+                ]}
                 style={{ width: "100%" }}
               />
             </Form.Item>

--- a/panel-ui/src/shells/admin/packages/PackageEdit.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageEdit.tsx
@@ -52,6 +52,7 @@ type PackageEditInput = {
   max_backups: number;
   scheduled_backups_enabled: boolean;
   allowed_backup_destination_kinds: string | string[];
+  backup_retention_policy: string;
   ssh_enabled: boolean;
   cgi_enabled: boolean;
   php_exec_enabled: boolean;
@@ -357,6 +358,21 @@ export const PackageEdit = () => {
                 allowClear
                 placeholder="e.g. local, s3"
                 options={BACKUP_DESTINATION_KINDS.map((k) => ({ value: k, label: k }))}
+                style={{ width: "100%" }}
+              />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label="Backup Retention Policy"
+              name="backup_retention_policy"
+              tooltip="What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+            >
+              <Select
+                options={[
+                  { value: "reject", label: "Reject at cap (safe)" },
+                  { value: "prune", label: "Auto-prune oldest" },
+                ]}
                 style={{ width: "100%" }}
               />
             </Form.Item>


### PR DESCRIPTION
Operator ask: make the max_backups behaviour an admin choice, default to the safe one, and notify admin + tenant on the cap event.

## What
- **Per-package `backup_retention_policy`** (migration 000234, VARCHAR default `reject`): `reject` (safe, current — block the new backup) or `prune` (auto-forget the tenant's OLDEST OWNED backup to make room, then create). `models.BackupRetentionPrunes()` **fails safe** — only an explicit `"prune"` auto-deletes; empty/unknown/mis-cased ⇒ reject.
- **`meBackupHandler.create`** at cap: `reject` → 403 (unchanged); `prune` → `pruneOldestOwned()` loops `OldestAccountBackupForUser` (**owner-scoped by user_id** — a tenant can only prune their OWN) + agent `backup.forget` + row delete until under cap, falling back to reject if it can't free room. Either outcome fires **`backup.limit.reached`** to the tenant's inbox (`Envelope.UserID`) AND broadcasts to admins (UserID empty).
- New `backup.limit.reached` notification event kind (warning, default-on).
- **Admin package editor** (Create + Edit): Backup Retention Policy dropdown, validated server-side on create + update.

Default `reject` = no behaviour change until an admin opts a plan into prune.

## Box-verified on testserver (real Kratos sessions) — 10/10
- reject (default): at cap → 403 `backup_limit_reached`; tenant's backups intact; tenant notified + admin broadcast (≥2 rows).
- prune: tenant's OLDEST backup forgotten; tenant notified.
- **owner-scoping**: a second tenant's backups untouched when the first prunes.
- migration 000234 applied; `backup.limit.reached` kind seeded default-on.

## Scope
This is the on-demand path + admin UI (a complete, working feature). **Follow-up unit:** the scheduler fan-out currently doesn't check `max_backups` at all — scheduled backups bypass the cap; applying the same policy there is next.

Incremental is a non-feature (restic is inherently incremental) — documented, no fake toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)