### PR TITLE
feat(backups): scheduler honours the retention policy + cap notifications (GH #454)

### DIFF
--- a/panel-api/cmd/server/backup_scheduler_tick_cmd.go
+++ b/panel-api/cmd/server/backup_scheduler_tick_cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduler"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -49,6 +50,13 @@ inFlight map dedupe duplicate dispatches.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 			defer cancel()
+			// Best-effort: wire the notification queue so a manual tick notifies
+			// tenants + admins on a retention-cap event too (GH #454). If Redis is
+			// unavailable the tick still runs; Notify just stays nil.
+			var notify *notifications.Queue
+			if requireRedis(cmd, args) == nil && sharedRedis != nil {
+				notify = notifications.NewQueue(sharedRedis)
+			}
 			s := backupscheduler.New(backupscheduler.Deps{
 				Schedules:      repository.NewBackupScheduleRepository(sharedDB),
 				Jobs:           repository.NewBackupJobRepository(sharedDB),
@@ -61,6 +69,8 @@ inFlight map dedupe duplicate dispatches.`,
 				Mailboxes:      repository.NewMailboxRepository(sharedDB),
 				AppInstalls:    repository.NewWordPressInstallRepository(sharedDB),
 				Settings:       repository.NewServerSettingsRepository(sharedDB),
+				Packages:       repository.NewPackageRepository(sharedDB),
+				Notify:         notify,
 				SSLCerts:       repository.NewSSLCertificateRepository(sharedDB),
 				PHPPools:       repository.NewPHPPoolRepository(sharedDB),
 				PHPPoolIni:     repository.NewPHPPoolIniOverrideRepository(sharedDB),
@@ -77,8 +87,8 @@ inFlight map dedupe duplicate dispatches.`,
 				// TickOnce dispatches too, and dispatch unseals per-destination restic
 				// passwords — wire the same SSO key the production scheduler uses, else
 				// sealed-password destinations fail before the agent call (Gitea #538).
-				SSOKey:         ssoKeyForCLI(),
-				Log:            sharedLog,
+				SSOKey: ssoKeyForCLI(),
+				Log:    sharedLog,
 			})
 			if s == nil {
 				return fmt.Errorf("scheduler.New returned nil — required deps missing (check serve.go's Deps assembly)")

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -904,6 +904,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Mailboxes:      deps.Mailboxes,
 		AppInstalls:    deps.WordPressInstalls,
 		Settings:       deps.ServerSettings,
+		Packages:       deps.Packages,
+		Notify:         deps.NotificationQueue,
 		SSLCerts:       deps.SSLCerts,
 		PHPPools:       deps.PHPPools,
 		PHPPoolIni:     deps.PHPPoolIniOverrides,

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -28,6 +28,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
@@ -66,6 +67,12 @@ type Deps struct {
 	Mailboxes      repository.MailboxRepository
 	AppInstalls    repository.ApplicationInstallRepository
 	Settings       repository.ServerSettingsRepository
+	// Packages + Notify (GH #454) enforce the per-package retention cap on
+	// SCHEDULED backups too — the on-demand path already does. Both OPTIONAL:
+	// nil Packages skips the cap check entirely (pre-#454 behaviour); nil Notify
+	// just omits the tenant/admin notice.
+	Packages repository.PackageRepository
+	Notify   *notifications.Queue
 
 	// Schema-v2 metadata producer fan-out — every nullable repo here is
 	// queried by buildScheduleMetadata so scheduled backups carry the
@@ -328,6 +335,21 @@ func (s *Scheduler) enqueueBackup(ctx context.Context, sched models.BackupSchedu
 // is a first-class field on backup_jobs.
 func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.BackupSchedule, user *models.User, dest *models.BackupDestination, runID string) bool {
 	logger := s.deps.Log.With("schedule_id", sched.ID, "user_id", user.ID, "destination_id", dest.ID, "run_id", runID)
+	// Retention cap (GH #454): honour the tenant's package policy on scheduled
+	// backups, matching the on-demand path. Only enforced when the package repo
+	// is wired AND the plan actually caps backups; otherwise the scheduled
+	// backup proceeds unchanged (no regression for uncapped/unresolvable plans).
+	if s.deps.Packages != nil {
+		if pkg := s.userPackage(ctx, user); pkg != nil && pkg.BackupsEnabled() && s.atOrOverCap(ctx, user.ID, int(pkg.MaxBackups)) {
+			if pkg.BackupRetentionPrunes() && s.pruneOldestForUser(ctx, user, int(pkg.MaxBackups)) {
+				s.notifyBackupLimit(ctx, user, "prune", pkg.MaxBackups)
+			} else {
+				s.notifyBackupLimit(ctx, user, "reject", pkg.MaxBackups)
+				logger.Warn("scheduled backup skipped: retention cap reached", "policy", pkg.BackupRetentionPolicy, "max_backups", pkg.MaxBackups)
+				return false
+			}
+		}
+	}
 	schedID := sched.ID
 	rid := runID
 	dID := dest.ID
@@ -354,6 +376,87 @@ func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.Backu
 
 // enqueueSystemBackup creates one backup_jobs row in status=queued
 // for a system backup against the given destination.
+// userPackage resolves the tenant's hosting package for the retention cap
+// check, or nil (no package / lookup error -> the caller treats it as uncapped,
+// so a transient error never blocks a scheduled run) (GH #454).
+func (s *Scheduler) userPackage(ctx context.Context, user *models.User) *models.HostingPackage {
+	if user.PackageID == nil || s.deps.Packages == nil {
+		return nil
+	}
+	pkg, err := s.deps.Packages.FindByID(ctx, *user.PackageID)
+	if err != nil {
+		return nil
+	}
+	return pkg
+}
+
+// atOrOverCap reports whether the user already holds >= maxBackups jobs.
+func (s *Scheduler) atOrOverCap(ctx context.Context, userID string, maxBackups int) bool {
+	_, total, err := s.deps.Jobs.ListForUser(ctx, userID, 1, 0)
+	if err != nil {
+		return false
+	}
+	return total >= int64(maxBackups)
+}
+
+// pruneOldestForUser forgets the user's OLDEST OWNED account_backup(s) until
+// under maxBackups. Owner-scoped: OldestAccountBackupForUser filters by
+// user_id, so a scheduled prune only ever touches the target tenant's own
+// backups. Returns true once under the cap (GH #454).
+func (s *Scheduler) pruneOldestForUser(ctx context.Context, user *models.User, maxBackups int) bool {
+	for i := 0; i < 1000; i++ {
+		if !s.atOrOverCap(ctx, user.ID, maxBackups) {
+			return true
+		}
+		oldest, err := s.deps.Jobs.OldestAccountBackupForUser(ctx, user.ID)
+		if err != nil || oldest == nil {
+			return false
+		}
+		if s.deps.Agent != nil {
+			fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			_, _ = s.deps.Agent.Call(fctx, "backup.forget", map[string]any{
+				"job_id": oldest.ID, "user_id": oldest.UserID, "kind": oldest.Kind,
+			})
+			cancel()
+		}
+		if derr := s.deps.Jobs.Delete(ctx, oldest.ID); derr != nil {
+			return false
+		}
+	}
+	return false
+}
+
+// notifyBackupLimit fires backup.limit.reached to the tenant's inbox
+// (Envelope.UserID) and broadcasts to admins (UserID empty), tailored to the
+// outcome. Best-effort (GH #454).
+func (s *Scheduler) notifyBackupLimit(ctx context.Context, user *models.User, outcome string, limit uint32) {
+	if s.deps.Notify == nil {
+		return
+	}
+	who := user.ID
+	if user.Username != nil && *user.Username != "" {
+		who = *user.Username
+	}
+	var tenantBody, adminBody string
+	if outcome == "prune" {
+		tenantBody = fmt.Sprintf("Your scheduled backup reached your plan's limit (%d); the oldest backup was automatically removed to make room.", limit)
+		adminBody = fmt.Sprintf("Scheduled backup for tenant %s hit the backup limit (%d); the oldest was auto-pruned per the package retention policy.", who, limit)
+	} else {
+		tenantBody = fmt.Sprintf("Your scheduled backup was skipped: you reached your plan's backup limit (%d). Delete an old backup or ask your host to raise the limit.", limit)
+		adminBody = fmt.Sprintf("Scheduled backup for tenant %s was skipped — backup limit (%d) reached (reject policy).", who, limit)
+	}
+	nctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, _ = s.deps.Notify.Publish(nctx, notifications.Envelope{
+		EventKind: "backup.limit.reached", Severity: "warning",
+		Title: "Scheduled backup limit reached", Body: tenantBody, UserID: user.ID,
+	})
+	_, _ = s.deps.Notify.Publish(nctx, notifications.Envelope{
+		EventKind: "backup.limit.reached", Severity: "warning",
+		Title: "Tenant scheduled backup limit reached", Body: adminBody,
+	})
+}
+
 func (s *Scheduler) enqueueSystemBackup(ctx context.Context, sched models.BackupSchedule, dest *models.BackupDestination, runID string) bool {
 	logger := s.deps.Log.With("schedule_id", sched.ID, "kind", "system_backup", "destination_id", dest.ID, "run_id", runID)
 	schedID := sched.ID


### PR DESCRIPTION
Unit 2 (follow-up to #578) — closes the last #454 gap: **scheduled backups bypassed the per-package cap entirely**. The on-demand path enforced it (#578); the scheduler fan-out never checked `max_backups`.

## Change
`enqueueAccountBackup` now applies the same policy per (user, destination):
- Resolve the tenant's package. Enforced **only** when `Packages` is wired AND the plan caps backups (`BackupsEnabled`) — otherwise the scheduled backup proceeds unchanged (no regression for uncapped/unresolvable plans; a transient package-load error never blocks a run).
- At cap: `prune` → `pruneOldestForUser` (**owner-scoped** via `OldestAccountBackupForUser` + agent `backup.forget` + row delete) then enqueue; else `reject` → skip the enqueue. Either fires `backup.limit.reached` to the tenant + admins.
- `backupscheduler.Deps` gains optional `Packages` + `Notify`, wired from `deps.Packages` / `deps.NotificationQueue` in `serve.go`, and (best-effort Redis) in the `backup scheduler tick` CLI so manual ticks notify too.

## Box-verified on testserver (via `backup scheduler tick`) — 8/8
- reject: no scheduled job enqueued; nothing pruned; tenant notified.
- prune: oldest forgotten; scheduled job enqueued; tenant notified.
- **owner-scoping**: a second tenant's backups untouched when the first prunes.

## #454 now complete
Steps 1-6 shipped. Incremental confirmed a non-feature (restic is inherently incremental). With this, the retention policy is enforced on **both** on-demand and scheduled paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)