### PR TITLE
fix(api): remove duplicate keys in openapi.yaml so /_meta/openapi.json loads (GH #580)

### DIFF
--- a/panel-api/internal/api/api_docs_test.go
+++ b/panel-api/internal/api/api_docs_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestOpenAPISpecParsesStrictly guards the GET /_meta/openapi.json endpoint,
+// which does a FULL yaml.v3 decode of the embedded spec (`var doc any`) and so
+// rejects a duplicate mapping key ANYWHERE — returning 500 spec_parse_failed to
+// the user (GH #580: "mapping key \"summary\" already defined").
+//
+// TestOpenAPICoverage decodes only shallowly (paths -> verb -> yaml.Node), so a
+// duplicate key INSIDE an operation slips past it — which is exactly how #580
+// shipped. This test parses the spec the same way the endpoint does, so any
+// duplicate key (or other parse error) fails CI instead of a user's browser.
+func TestOpenAPISpecParsesStrictly(t *testing.T) {
+	var doc any
+	if err := yaml.Unmarshal(openAPIYAML, &doc); err != nil {
+		t.Fatalf("embedded openapi.yaml does not parse — GET /_meta/openapi.json would return 500: %v", err)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4960,9 +4960,6 @@ paths:
       summary: Get user
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
-      summary: Get user
-      security: [ { KratosSession: [] } ]
-      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses:
         "200": { description: The user, content: { application/json: { schema: { $ref: "#/components/schemas/User" } } } }
         "404": { description: Not found }


### PR DESCRIPTION
Fixes #580 — `Could not load /_meta/openapi.json … yaml: unmarshal errors: line 4963: mapping key "summary" already defined at line 4960`.

## Cause
The `/users/{id}` **GET** operation had `summary` / `security` / `parameters` **duplicated** (a copy-paste slip at lines 4963-4965). `GET /_meta/openapi.json` does a full `yaml.v3` decode (`var doc any`), which rejects duplicate mapping keys → **500 spec_parse_failed**, surfaced in the UI (Personal API Tokens → Automation) as "Could not load…".

## Why CI missed it
`TestOpenAPICoverage` decodes only **shallowly** (`paths -> verb -> yaml.Node`), so a duplicate key **inside** an operation never gets validated.

## Fix
- Remove the duplicated 3 lines (verified 0 duplicate keys remain, whole-file scan).
- Add **`TestOpenAPISpecParsesStrictly`** — parses the embedded spec exactly as the endpoint does (full decode into `any`). It **fails on the buggy spec with the reporter's exact error** and passes on the fixed one, so any future duplicate key fails CI instead of a user's browser.

## Verified
- Regression test: FAIL on pre-fix spec (`mapping key "summary" already defined at line 4960`), PASS on fixed.
- Box (testserver): `/_meta/openapi.json` **500 → 200** + valid JSON (openapi 3.0.3, 420 paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)