### PR TITLE
fix(pyapps): surface the real startup error when a python app isn't active (GH #357)

### DIFF
--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -71,6 +71,11 @@ type pythonAppApplyParams struct {
 type pythonAppApplyResult struct {
 	Active bool   `json:"active"`
 	Unit   string `json:"unit"`
+	// Detail carries the unit's recent journal when the app started but isn't
+	// active, so the panel surfaces the real startup error (e.g. gunicorn
+	// failing to import the entrypoint) instead of a generic "not active" — the
+	// exact "nothing in logs" wall from GH #357.
+	Detail string `json:"detail,omitempty"`
 }
 
 func pythonAppUnitName(appID string) string { return "jabali-app-" + appID + ".service" }
@@ -199,7 +204,16 @@ func pythonAppApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	}
 
 	active := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
-	return pythonAppApplyResult{Active: active, Unit: unit}, nil
+	res := pythonAppApplyResult{Active: active, Unit: unit}
+	if !active {
+		// Capture WHY it isn't active so the panel shows the real startup error
+		// instead of only "not active — check journalctl" (GH #357).
+		// --output=cat drops syslog metadata; last 15 lines keep it bounded.
+		if out, jerr := exec.CommandContext(ctx, "journalctl", "-u", unit, "-n", "20", "--no-pager", "--output=cat").CombinedOutput(); jerr == nil {
+			res.Detail = lastLines(strings.TrimSpace(string(out)), 15)
+		}
+	}
+	return res, nil
 }
 
 // derivePythonStart builds the gunicorn (WSGI) / uvicorn (ASGI) command bound

--- a/panel-api/internal/reconciler/reconcile_python_apps.go
+++ b/panel-api/internal/reconciler/reconcile_python_apps.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/oklog/ulid/v2"
 
@@ -106,6 +107,7 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 	var res struct {
 		Active bool   `json:"active"`
 		Unit   string `json:"unit"`
+		Detail string `json:"detail"`
 	}
 	_ = json.Unmarshal(raw, &res)
 	status := models.PythonAppStatusFailed
@@ -113,11 +115,16 @@ func (r *Reconciler) reconcileOnePythonApp(ctx context.Context, app *models.Pyth
 	if res.Active {
 		status = models.PythonAppStatusRunning
 	} else {
+		// GH #357: surface the ACTUAL startup error (the unit's journal tail the
+		// agent captured), not just "not active" — that opaque message was the
+		// reporter's "nothing in logs" wall. Fall back to the pointer when the
+		// agent couldn't read the journal.
 		m := "app started but is not active — check the app logs (journalctl -u " + res.Unit + ")"
+		if d := strings.TrimSpace(res.Detail); d != "" {
+			m = "app started but is not active. Recent logs (journalctl -u " + res.Unit + "):\n" + d
+		}
 		lastErr = &m
-		// GH #357: surface the failure server-side, not just in the DB row —
-		// otherwise an app that goes pending→failed leaves "nothing in logs".
-		r.log.Warn("pyapp: app applied but not active", "id", app.ID, "unit", res.Unit)
+		r.log.Warn("pyapp: app applied but not active", "id", app.ID, "unit", res.Unit, "detail", res.Detail)
 	}
 	if app.Status != status {
 		if err := r.pythonApps.UpdateStatus(ctx, app.ID, status, lastErr); err != nil {

--- a/panel-api/internal/reconciler/reconcile_python_notactive_test.go
+++ b/panel-api/internal/reconciler/reconcile_python_notactive_test.go
@@ -1,0 +1,83 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// notActiveAgent mimics app.python.apply returning "started but not active" with
+// the unit journal tail in detail (GH #357).
+type notActiveAgent struct{}
+
+func (notActiveAgent) Call(_ context.Context, _ string, _ interface{}) (json.RawMessage, error) {
+	return json.Marshal(map[string]any{
+		"active": false,
+		"unit":   "jabali-app-01APP.service",
+		"detail": "ModuleNotFoundError: No module named 'wsgi'\ngunicorn worker failed to boot",
+	})
+}
+
+type notActiveUsers struct {
+	repository.UserRepository
+	u *models.User
+}
+
+func (s notActiveUsers) FindByID(context.Context, string) (*models.User, error) { return s.u, nil }
+
+type statusCaptureRepo struct {
+	repository.PythonAppRepository
+	status  string
+	lastErr string
+}
+
+func (s *statusCaptureRepo) ListEnv(context.Context, string) ([]*models.PythonAppEnv, error) {
+	return nil, nil
+}
+
+func (s *statusCaptureRepo) UpdateStatus(_ context.Context, _, status string, lastErr *string) error {
+	s.status = status
+	if lastErr != nil {
+		s.lastErr = *lastErr
+	}
+	return nil
+}
+
+// GH #357: when a python app starts but isn't active, the reconciler must put
+// the agent-captured journal tail into last_error. The reporter's "nothing in
+// logs" wall was a generic "not active" with no reason — this asserts the real
+// startup error now reaches the app record (and thus the panel).
+func TestReconcileOnePythonApp_NotActive_SurfacesJournal(t *testing.T) {
+	uname := "tenant"
+	pyRepo := &statusCaptureRepo{}
+	port := 8123
+	r := &Reconciler{
+		agent:      notActiveAgent{},
+		pythonApps: pyRepo,
+		users:      notActiveUsers{u: &models.User{ID: "01USER", Username: &uname}},
+		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	app := &models.PythonApp{
+		ID: "01APP", UserID: "01USER", AppRoot: "/home/tenant/app",
+		PythonVersion: "3.12", AppType: "wsgi", Entrypoint: "wsgi:app",
+		Status: models.PythonAppStatusPending, LoopbackPort: &port,
+	}
+
+	r.reconcileOnePythonApp(context.Background(), app)
+
+	if pyRepo.status != models.PythonAppStatusFailed {
+		t.Fatalf("status = %q, want failed", pyRepo.status)
+	}
+	if !strings.Contains(pyRepo.lastErr, "ModuleNotFoundError") {
+		t.Errorf("last_error must carry the agent journal detail; got %q", pyRepo.lastErr)
+	}
+	if !strings.Contains(pyRepo.lastErr, "jabali-app-01APP.service") {
+		t.Errorf("last_error should reference the unit; got %q", pyRepo.lastErr)
+	}
+}


### PR DESCRIPTION
Addresses the remaining #357 wall: a python app that goes pending → failed with an opaque "agent error" and **"nothing in logs"**, even on current main.

## Gap
The earlier #357 fixes surface pip/scaffold failures into `last_error` (+ the panel log + the failed-status hover tooltip). But when the app's systemd unit **starts and then immediately crashes** (e.g. gunicorn can't import the entrypoint), the apply returned `Active=false` and the reconciler set `last_error` to a generic *"not active — check journalctl for the unit"*. The tenant saw only that; the real traceback lived in the app's unit journal they didn't know to check — the reporter kept pasting the `jabali-agent` journal, which only shows the pip `sudo` sessions.

## Fix
- **Agent** (`python_app_apply.go`): when `is-active` is false, capture the unit's recent journal (last ~20 lines, `--output=cat`, trimmed to 15) into the apply result's new `detail` field.
- **Reconciler** (`reconcile_python_apps.go`): fold that `detail` into `last_error`. The panel already renders `last_error` on the failed status, so the actual startup error now reaches the user. Falls back to the old pointer when the journal can't be read.

## Verified
- Unit test: the reconciler surfaces the agent-provided journal detail into `last_error` on the not-active path (asserts the traceback + unit name land in `last_error`).
- `go vet ./...`, build, existing reconciler/agent tests green.

## Note for the reporter (out of band)
Their `pip install` looping every ~60s is the reconciler re-applying; with this build, the failed app's status now carries the real reason (hover it, or `journalctl -u jabali-panel | grep pyapp`). If it's still opaque, confirm `jabali version` is a build from this PR or later — a stale origin (frozen mirror) is the other way "nothing in logs" happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)