### PR TITLE
fix(backups): clear the write deadline so large backup downloads finish (GH #462)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -656,6 +656,15 @@ func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.B
 		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "agent_unavailable"})
 		return
 	}
+	// Backup downloads stream multi-GB archives, and the restic materialize can
+	// take minutes — both far exceed the server's 30s WriteTimeout, which would
+	// sever the connection mid-stream. GH #462: the download stalled at ~1.15 GB,
+	// i.e. exactly 30s of throughput. Clear this request's write deadline so the
+	// stream runs to completion (nginx already allows an hour via
+	// proxy_send/read_timeout 3600s). Best-effort: a writer that doesn't support
+	// deadlines just keeps the default.
+	_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
+
 	matCtx, matCancel := context.WithTimeout(c.Request.Context(), 30*time.Minute)
 	defer matCancel()
 	// The snapshot lives in the job's DESTINATION repo. Forward repo_url +

--- a/panel-api/internal/api/backups_download_timeout_test.go
+++ b/panel-api/internal/api/backups_download_timeout_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// A streaming download whose duration exceeds the server WriteTimeout must run
+// to completion once the handler clears its per-request write deadline via
+// http.ResponseController — the fix for GH #462 (backup download stalled at
+// ~1.15 GB = 30s of throughput against the 30s WriteTimeout). This exercises the
+// exact mechanism streamBackupArtifact uses, through gin's ResponseWriter.
+func TestStreamingDefeatsWriteTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Total stream time (~500ms) comfortably exceeds the 150ms WriteTimeout.
+	const chunks = 5
+	const chunk = "chunkchunkchunk" // 15 bytes
+	stream := func(clearDeadline bool) func(c *gin.Context) {
+		return func(c *gin.Context) {
+			if clearDeadline {
+				_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
+			}
+			c.Status(http.StatusOK)
+			fl, _ := c.Writer.(http.Flusher)
+			for i := 0; i < chunks; i++ {
+				_, _ = c.Writer.Write([]byte(chunk))
+				if fl != nil {
+					fl.Flush()
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}
+	run := func(clearDeadline bool) (int, bool) {
+		r := gin.New()
+		r.GET("/dl", stream(clearDeadline))
+		srv := httptest.NewUnstartedServer(r)
+		srv.Config.WriteTimeout = 150 * time.Millisecond
+		srv.Start()
+		defer srv.Close()
+		resp, err := http.Get(srv.URL + "/dl")
+		if err != nil {
+			return 0, false // connection torn down before/at headers
+		}
+		defer resp.Body.Close()
+		b, rerr := io.ReadAll(resp.Body)
+		return len(b), rerr == nil
+	}
+
+	// With the deadline cleared: the whole body arrives.
+	if n, ok := run(true); !ok || n != chunks*len(chunk) {
+		t.Fatalf("with deadline cleared: got %d bytes ok=%v, want %d bytes complete", n, ok, chunks*len(chunk))
+	}
+
+	// Sanity: without the clear, the 150ms WriteTimeout truncates the stream
+	// (fewer bytes or a read error) — confirming the timeout is the real cutter.
+	if n, ok := run(false); ok && n == chunks*len(chunk) {
+		t.Fatalf("without the deadline clear the stream unexpectedly completed (%d bytes) — the WriteTimeout should have cut it", n)
+	}
+}


### PR DESCRIPTION
Latest round of #462: after the AppArmor fixes (#504/#523), the download now builds but **stalls at ~1.15 GB every time** and never completes (local storage), with a brief "Network Failed" toast first.

## Root cause
`streamBackupArtifact` streams the materialized snapshot (`tar[.zst]`) to the client via `io.Copy`. The panel-api `http.Server` sets **`WriteTimeout = 30s`** — the deadline for writing the *entire* response — so any download longer than 30s is severed mid-stream. **1.15 GB is exactly 30s of throughput** at local `tar`+`zstd` rates. nginx already allows an hour (`proxy_send/read_timeout 3600s`); the panel's own 30s deadline was the cutter. (The migration SSE stream survives the same 30s only because the browser auto-reconnects — a file download can't.)

## Fix
Clear this request's write deadline before the materialize + stream:
```go
_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
```
gin v1.11's `responseWriter` implements `Unwrap()`, so the controller reaches the underlying conn (verified). The download then runs to completion, bounded only by nginx's hour. Best-effort — a writer without deadline support keeps the default. Covers both admin + tenant download (they share `streamBackupArtifact`).

## Verified
- Deterministic test: a gin stream whose duration exceeds a short server `WriteTimeout` **completes** when the handler clears the deadline, and is **truncated** when it doesn't — proving both the mechanism and that the timeout was the real cutter.
- `go vet`, build green.

A real >1.15 GB download is the final end-to-end confirmation post-merge (couldn't stage a multi-GB backup on the test host cheaply); the root cause + mechanism are exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)