### PR TITLE
feat(migrate): CloudPanel DescribeAccount per-area builders (step 2, GH #522)

### DIFF
--- a/panel-api/internal/migrate/cloudpanel/discover.go
+++ b/panel-api/internal/migrate/cloudpanel/discover.go
@@ -251,17 +251,106 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 	if s.client != nil {
 		host = s.client.RemoteAddr().String()
 	}
-	return &migrate.AccountManifest{
+	m := &migrate.AccountManifest{
 		SchemaVersion: migrate.ManifestSchemaVersion,
 		Source: migrate.SourceRef{
 			Kind: models.MigrationSourceCloudPanel,
 			Host: host,
 			User: accountID,
 		},
+		Domains:   []migrate.DomainSpec{},
+		Databases: []migrate.DatabaseSpec{},
 		// CloudPanel has no mail server — Mailboxes stays empty by design.
 		Mailboxes: []migrate.MailboxSpec{},
 		Warnings:  []migrate.Warning{},
-	}, nil
+	}
+	m.Domains = s.buildDomains(ctx, accountID, &m.Warnings)
+	m.Databases = s.buildDatabases(ctx, accountID, &m.Warnings)
+	return m, nil
+}
+
+// buildDomains returns one DomainSpec per site the account owns. CloudPanel
+// stores each site's docroot as root_directory under /home/<user>/htdocs; the
+// first site (alphabetical) is marked primary so the restore has a main domain.
+// accountID is already siteUserRe-validated, so embedding it in a SQL string
+// literal is safe and sqliteQuerySep shell-quotes the whole statement.
+func (s *session) buildDomains(ctx context.Context, user string, warns *[]migrate.Warning) []migrate.DomainSpec {
+	q := "SELECT s.domain_name, s.root_directory, s.type, coalesce(ps.php_version, '') " +
+		"FROM site s LEFT JOIN php_settings ps ON ps.site_id = s.id " +
+		"WHERE s.user = '" + user + "' ORDER BY s.domain_name"
+	b, err := s.run(ctx, s.commandTimeout, sqliteQuerySep(s.dbPath, "|", q))
+	if err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "cloudpanel_domains", Detail: err.Error()})
+		return []migrate.DomainSpec{}
+	}
+	out := []migrate.DomainSpec{}
+	first := true
+	for _, line := range splitLines(b) {
+		cols := strings.Split(line, "|")
+		name := strings.TrimSpace(cols[0])
+		if name == "" {
+			continue
+		}
+		root := ""
+		if len(cols) > 1 {
+			root = strings.TrimSpace(cols[1])
+		}
+		docroot := "/home/" + user + "/htdocs/" + name
+		if root != "" {
+			docroot = "/home/" + user + "/htdocs/" + root
+		}
+		hasPHP := len(cols) > 2 && strings.TrimSpace(cols[2]) == "php"
+		php := ""
+		if len(cols) > 3 {
+			php = strings.TrimSpace(cols[3])
+		}
+		out = append(out, migrate.DomainSpec{
+			Name: name, DocRoot: docroot, IsPrimary: first, HasPHP: hasPHP, PHPVer: php,
+		})
+		first = false
+	}
+	return out
+}
+
+// buildDatabases returns the MySQL databases across all of the account's sites,
+// with the CloudPanel database user as the grant user.
+func (s *session) buildDatabases(ctx context.Context, user string, warns *[]migrate.Warning) []migrate.DatabaseSpec {
+	q := "SELECT d.name, coalesce(du.user_name, '') FROM \"database\" d " +
+		"JOIN site s ON d.site_id = s.id " +
+		"LEFT JOIN database_user du ON du.database_id = d.id " +
+		"WHERE s.user = '" + user + "' ORDER BY d.name"
+	b, err := s.run(ctx, s.commandTimeout, sqliteQuerySep(s.dbPath, "|", q))
+	if err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "cloudpanel_databases", Detail: err.Error()})
+		return []migrate.DatabaseSpec{}
+	}
+	out := []migrate.DatabaseSpec{}
+	for _, line := range splitLines(b) {
+		cols := strings.Split(line, "|")
+		name := strings.TrimSpace(cols[0])
+		if name == "" {
+			continue
+		}
+		spec := migrate.DatabaseSpec{Engine: "mysql", Name: name}
+		if len(cols) > 1 {
+			spec.GrantUser = strings.TrimSpace(cols[1])
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+// splitLines splits sqlite output into non-empty, CR-trimmed lines.
+func splitLines(b []byte) []string {
+	var out []string
+	for _, line := range strings.Split(string(b), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
 }
 
 // Close releases the SSH client. Best-effort.

--- a/panel-api/internal/migrate/cloudpanel/discover_test.go
+++ b/panel-api/internal/migrate/cloudpanel/discover_test.go
@@ -12,12 +12,52 @@ import (
 
 // fakeSession builds a *session whose run() returns canned sqlite output,
 // so the SQLite-parsing logic is exercised without a live CloudPanel host.
-func fakeSession(out string) *session {
+// route pairs a distinctive SQL substring with canned sqlite output so the fake
+// answers each of DescribeAccount's queries independently.
+type route struct{ contains, out string }
+
+func fakeRouted(routes ...route) *session {
 	s := &session{dbPath: "/test/db.sq3", commandTimeout: time.Second}
-	s.run = func(_ context.Context, _ time.Duration, _ string) ([]byte, error) {
-		return []byte(out), nil
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		for _, r := range routes {
+			if strings.Contains(cmd, r.contains) {
+				return []byte(r.out), nil
+			}
+		}
+		return nil, nil
 	}
 	return s
+}
+
+// fakeSession answers only the ListAccounts query (group_concat), so the older
+// DescribeAccount tests see empty domains/databases.
+func fakeSession(out string) *session {
+	return fakeRouted(route{"group_concat", out})
+}
+
+func TestDescribeAccount_PopulatesAreas(t *testing.T) {
+	d := New()
+	s := fakeRouted(
+		route{"group_concat", "smokeuser|smoke.jabalitest.com\n"},
+		route{"root_directory", "smoke.jabalitest.com|smoke.jabalitest.com|php|8.1\n"},
+		route{"database_user", "smokedb|smokedbu\n"},
+	)
+	m, err := d.DescribeAccount(context.Background(), s, "smokeuser")
+	if err != nil {
+		t.Fatalf("DescribeAccount: %v", err)
+	}
+	if len(m.Domains) != 1 || !m.Domains[0].IsPrimary || m.Domains[0].Name != "smoke.jabalitest.com" {
+		t.Fatalf("domains = %+v", m.Domains)
+	}
+	if m.Domains[0].DocRoot != "/home/smokeuser/htdocs/smoke.jabalitest.com" || !m.Domains[0].HasPHP || m.Domains[0].PHPVer != "8.1" {
+		t.Errorf("domain docroot/php wrong: %+v", m.Domains[0])
+	}
+	if len(m.Databases) != 1 || m.Databases[0].Name != "smokedb" || m.Databases[0].GrantUser != "smokedbu" || m.Databases[0].Engine != "mysql" {
+		t.Fatalf("databases = %+v", m.Databases)
+	}
+	if len(m.Mailboxes) != 0 {
+		t.Errorf("CloudPanel has no mail — Mailboxes must be empty, got %d", len(m.Mailboxes))
+	}
 }
 
 func TestListAccounts_ParsesSiteUsersAndFiltersClp(t *testing.T) {


### PR DESCRIPTION
Advances **#522** — fills the manifest the step-1 CloudPanel discoverer (#563) returned empty. First run against a **real CloudPanel box** (the operator provisioned one).

## Areas (CloudPanel SQLite `db.sq3`)
- **Domains** — one `DomainSpec` per site (`site` JOIN `php_settings`): Name=`domain_name`, DocRoot=`/home/<user>/htdocs/<root_directory>`, HasPHP=(type=='php'), PHPVer=`php_settings.php_version`; first site marked primary.
- **Databases** — the MySQL DBs across the account's sites (`database` JOIN `site` LEFT JOIN `database_user`): Engine=mysql, Name, GrantUser.
- **Mailboxes** stay empty (CloudPanel is web-only).

`accountID` is `siteUserRe`-validated (no quote/metachar), so embedding it in the SQL literal is safe and `sqliteQuerySep` shell-quotes the whole statement; per-area failures degrade to `Warnings`.

## Verified live
Real CloudPanel box (Ubuntu 22.04): the sample account `smokeuser` / `smoke.jabalitest.com` yields the domain (php 8.1, `/home/smokeuser/htdocs/...`) and its database (`smokedb`/`smokedbu`), **zero warnings**. This is also the **first live verification of the shipped #563 Connect + ListAccounts** against a real CloudPanel host. Unit tests route each query.

## Next
DNS/Cron/SSH → then the restore path (cpmove synthesis reusing the cpanel writers) — shared with the CyberPanel restore work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)