### PR TITLE
feat(migrate): CloudPanel restore step 1 — cpmove synthesize + pull dispatch (GH #522)

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -38,6 +38,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cloudpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
@@ -196,6 +197,8 @@ live source SSH. Use scp directly for that kind.`,
 				localTar, err = pullDirectAdmin(ctx, sshUser, job, secret, localDir, allowPrivate)
 			case models.MigrationSourceHestia:
 				localTar, err = pullHestia(ctx, sshUser, job, secret, localDir, allowPrivate)
+			case models.MigrationSourceCloudPanel:
+				localTar, err = pullCloudPanel(ctx, sshUser, job, secret, localDir, allowPrivate)
 			case models.MigrationSourcePlesk:
 				localTar, err = pullPlesk(ctx, sshUser, job, secret, localDir, allowPrivate)
 			default:
@@ -284,6 +287,38 @@ func pullCpanel(ctx context.Context, sshUser string, job *models.MigrationJob, s
 	}
 	// M35.8: clean up source-side cpmove tarball so a multi-account
 	// migration doesn't accumulate GB on the source. Best-effort.
+	if rmErr := d.RemoveRemote(ctx, s, remoteTar); rmErr != nil {
+		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
+	}
+	return localTar, nil
+}
+
+// pullCloudPanel (GH #522) connects to a CloudPanel source over SSH and runs
+// BackupUser, which synthesizes a cpmove-shaped tarball from CloudPanel's
+// SQLite inventory (cp/<user>, mysql/<db>.sql, cron/<user>, domains-paths.txt,
+// homedir/.ssh) — the same DA-style approach so the shared cpanel restore
+// writers consume it unchanged. The tarball lands at cpmove-<user>.tar.gz to
+// match what the extract + import stages expect.
+func pullCloudPanel(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
+	d := cloudpanel.New()
+	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
+	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
+	if err != nil {
+		return "", fmt.Errorf("cloudpanel.Connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, s) }()
+	fmt.Printf("  → synthesizing cpmove for %s on the CloudPanel source (dumping databases)...\n", job.SourceUser)
+	remoteTar, err := d.BackupUser(ctx, s, job.SourceUser)
+	if err != nil {
+		return "", fmt.Errorf("cloudpanel BackupUser: %w", err)
+	}
+	fmt.Printf("  → tarball ready on source: %s — downloading...\n", remoteTar)
+	localTar := filepath.Join(localDir, fmt.Sprintf("cpmove-%s.tar.gz", job.SourceUser))
+	if _, err := d.PullFile(ctx, s, remoteTar, localTar); err != nil {
+		return "", fmt.Errorf("PullFile: %w", err)
+	}
+	// JAB-50: don't leave the full account backup on the source server.
 	if rmErr := d.RemoveRemote(ctx, s, remoteTar); rmErr != nil {
 		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
 	}

--- a/panel-api/internal/migrate/cloudpanel/backup.go
+++ b/panel-api/internal/migrate/cloudpanel/backup.go
@@ -1,0 +1,162 @@
+package cloudpanel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// BackupUserTimeout caps the source-side synthesize. CloudPanel accounts are
+// web-only (no mail tree to pack), so this is dominated by the mysqldump(s);
+// 60 min matches the other sources for symmetry on very large databases.
+const BackupUserTimeout = 60 * time.Minute
+
+// BackupUser synthesizes a cpanel-cpmove-shaped tarball on the CloudPanel
+// source so the shared cpanel restore writers (ImportDatabases, ImportCron,
+// ImportSSHKeys, ImportDomains) consume it unchanged — the same approach the
+// directadmin source takes (directadmin/backup.go). CloudPanel is web-only, so
+// the produced layout is a strict subset of the cpanel one:
+//
+//	/tmp/cpmove-<user>.tar.gz
+//	└── cpmove-<user>/
+//	    ├── cp/<user>            (USER + primary-domain DNS line)
+//	    ├── mysql/<db>.sql        (one per site database)
+//	    ├── cron/<user>           (reconstructed crontab lines)
+//	    ├── domains-paths.txt     (<domain>\t<docroot> for the restore rsync)
+//	    └── homedir/.ssh/authorized_keys
+//
+// No dnszones/ or mail (CloudPanel has neither). The homedir file tree is NOT
+// bundled — like directadmin, the restore stage rsyncs each docroot listed in
+// domains-paths.txt directly source→dest so a retry resumes instead of
+// re-pulling. Inventory is read from CloudPanel's SQLite config DB (read-only);
+// the only mutating-looking command is mysqldump against a scratch dump file.
+//
+// Requires a root SSH user: read access to db.sq3 + MariaDB root-socket auth
+// for mysqldump (CloudPanel installs MariaDB with unix_socket root, so
+// `mysql -u root` over the local socket needs no password).
+func (d *Discoverer) BackupUser(ctx context.Context, raw interface{}, account string) (string, error) {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return "", errors.New("BackupUser: bad session")
+	}
+	if !siteUserRe.MatchString(account) {
+		return "", fmt.Errorf("BackupUser: invalid account %q", account)
+	}
+
+	subctx, cancel := context.WithTimeout(ctx, BackupUserTimeout)
+	defer cancel()
+
+	acct := shellSingleQuote(account)
+	dbp := shellSingleQuote(s.dbPath)
+	// Single inline script (one ssh exec: one handshake, one tempdir).
+	// `set -e` aborts on any hard failure so partial tarballs don't leak —
+	// every conditional uses explicit if/fi (never a bare `[ ] && cmd`, which
+	// would abort the whole script when the test is false under set -e).
+	script := fmt.Sprintf(`set -e
+ACCT=%s
+DB=%s
+TMP=/tmp/jabali-migrate-clp-$ACCT
+OUT=/tmp/cpmove-$ACCT.tar.gz
+Q(){ sqlite3 -readonly -separator '|' "$DB" "$1"; }
+
+rm -rf "$TMP" "$OUT"
+BASE="$TMP/cpmove-$ACCT"
+mkdir -p "$BASE/cp" "$BASE/mysql" "$BASE/cron" "$BASE/homedir/.ssh"
+
+# 1. cp/<user> — USER + primary-domain DNS line. CloudPanel has no per-site
+#    contact email (site owner is a Linux user, not a panel user), so
+#    CONTACTEMAIL is left to the operator's --target-email.
+echo "USER=$ACCT" > "$BASE/cp/$ACCT"
+PRIMARY=$(Q "SELECT domain_name FROM site WHERE user='$ACCT' ORDER BY id LIMIT 1")
+if [ -n "$PRIMARY" ]; then echo "DNS=$PRIMARY" >> "$BASE/cp/$ACCT"; fi
+
+# 2. mysql/<db>.sql — dump every database owned by the account's sites.
+#    Root-socket auth (CloudPanel MariaDB uses unix_socket root).
+MYSQL_AUTH=""
+if mysql -u root -BN -e "SELECT 1" >/dev/null 2>&1; then MYSQL_AUTH="-u root"; fi
+if [ -z "$MYSQL_AUTH" ]; then echo "WARN: no MariaDB root-socket auth — skipping DB dumps" >&2; fi
+Q "SELECT d.name FROM \"database\" d JOIN site s ON d.site_id=s.id WHERE s.user='$ACCT'" | while read -r db; do
+  if [ -z "$db" ]; then continue; fi
+  if [ -n "$MYSQL_AUTH" ]; then
+    if ! mysqldump $MYSQL_AUTH --skip-lock-tables --single-transaction "$db" > "$BASE/mysql/$db.sql" 2>/dev/null; then
+      echo "WARN: mysqldump $db failed" >&2
+      rm -f "$BASE/mysql/$db.sql"
+    fi
+  fi
+done
+
+# 3. domains-paths.txt — <domain>\t<docroot> so the restore stage rsyncs each
+#    site's files. CloudPanel docroot = /home/<user>/htdocs/<root_directory>.
+Q "SELECT domain_name, root_directory FROM site WHERE user='$ACCT' ORDER BY id" | while IFS='|' read -r dom root; do
+  if [ -z "$dom" ]; then continue; fi
+  printf '%%s\t/home/%%s/htdocs/%%s\n' "$dom" "$ACCT" "$root" >> "$BASE/domains-paths.txt"
+done
+
+# 4. cron/<user> — reconstruct crontab lines from cron_job (5 schedule fields
+#    + command). cpanel.ImportCron reads cp/<user>/cron/<user>... but the
+#    cpmove convention also accepts cron/<user>; keep it flat here.
+Q "SELECT cj.minute||' '||cj.hour||' '||cj.day||' '||cj.month||' '||cj.weekday||' '||cj.command FROM cron_job cj JOIN site s ON cj.site_id=s.id WHERE s.user='$ACCT' ORDER BY cj.id" > "$BASE/cron/$ACCT" 2>/dev/null || true
+if [ ! -s "$BASE/cron/$ACCT" ]; then rm -f "$BASE/cron/$ACCT"; fi
+
+# 5. homedir/.ssh/authorized_keys — from ssh_user.ssh_keys (authorized_keys
+#    blob). cpanel.ImportSSHKeys dedups by fingerprint on restore.
+Q "SELECT su.ssh_keys FROM ssh_user su JOIN site s ON su.site_id=s.id WHERE s.user='$ACCT' AND su.ssh_keys IS NOT NULL AND su.ssh_keys != ''" > "$BASE/homedir/.ssh/authorized_keys" 2>/dev/null || true
+if [ ! -s "$BASE/homedir/.ssh/authorized_keys" ]; then rm -f "$BASE/homedir/.ssh/authorized_keys"; fi
+
+# 6. tar it up (last stdout line = the path the caller reads).
+tar -czf "$OUT" -C "$TMP" "cpmove-$ACCT"
+rm -rf "$TMP"
+echo "$OUT"
+`, acct, dbp)
+
+	out, err := s.run(subctx, BackupUserTimeout, script)
+	if err != nil {
+		return "", fmt.Errorf("cloudpanel synthesize cpmove: %w (stdout=%q)", err, truncForLog(string(out), 1024))
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	path := strings.TrimSpace(lines[len(lines)-1])
+	if path == "" {
+		return "", errors.New("cloudpanel synthesize cpmove: empty tarball path")
+	}
+	return path, nil
+}
+
+// PullFile streams a source-side file to a local path over the session's SSH
+// client (shared migrate helper). Same shape as the other sources' PullFile so
+// the pull orchestrator branches on kind without special-casing args.
+func (d *Discoverer) PullFile(ctx context.Context, raw interface{}, remotePath, localPath string) (int64, error) {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return 0, errors.New("PullFile: bad session")
+	}
+	return migrate.PullFileViaSSH(ctx, s.client, remotePath, localPath)
+}
+
+// RemoveRemote deletes the synthesized source-side tarball after it's pulled
+// (JAB-50). Allowlist: only /tmp/cpmove-* (what BackupUser writes) with no ..
+// traversal — a full account archive (files list, DB dumps) must not linger on
+// a possibly-shared source host.
+func (d *Discoverer) RemoveRemote(ctx context.Context, raw interface{}, path string) error {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return errors.New("RemoveRemote: bad session")
+	}
+	if !strings.HasPrefix(path, "/tmp/cpmove-") || strings.Contains(path, "..") {
+		return fmt.Errorf("RemoveRemote: refuses non-cpmove path %q", path)
+	}
+	_, err := s.run(ctx, 30*time.Second, fmt.Sprintf("rm -f %s", shellSingleQuote(path)))
+	return err
+}
+
+// truncForLog bounds stderr/stdout surfaced in error messages so a stuck
+// mysqldump producing MB of output doesn't blow up the JSON envelope.
+func truncForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...[truncated]"
+}

--- a/panel-api/internal/migrate/cloudpanel/backup_test.go
+++ b/panel-api/internal/migrate/cloudpanel/backup_test.go
@@ -1,0 +1,104 @@
+package cloudpanel
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureSession returns a *session whose run() records the last command it was
+// handed and replies with a canned stdout, so the synthesize script can be
+// asserted without a live CloudPanel host.
+func captureSession(stdout string, runErr error) (*session, *string) {
+	var last string
+	s := &session{dbPath: "/home/clp/htdocs/app/data/db.sq3", commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		last = cmd
+		return []byte(stdout), runErr
+	}
+	return s, &last
+}
+
+func TestBackupUser_SynthesizeScriptAndPath(t *testing.T) {
+	d := New()
+	s, last := captureSession("some log line\n/tmp/cpmove-smokeuser.tar.gz\n", nil)
+	path, err := d.BackupUser(context.Background(), s, "smokeuser")
+	if err != nil {
+		t.Fatalf("BackupUser: %v", err)
+	}
+	// Returned path is the LAST stdout line (script echoes $OUT last).
+	if path != "/tmp/cpmove-smokeuser.tar.gz" {
+		t.Errorf("path = %q, want the trailing tarball path", path)
+	}
+	// The script must build the cpmove subset from CloudPanel's own tables.
+	for _, want := range []string{
+		`set -e`,                       // abort-on-error
+		`BASE="$TMP/cpmove-$ACCT"`,     // cpmove wrapper dir
+		`ACCT='smokeuser'`,             // account interpolated + single-quoted
+		`echo "USER=$ACCT"`,            // cp/<user> USER line
+		`FROM site WHERE user='$ACCT'`, // domains + primary scoping
+		`WHERE s.user='$ACCT'`,         // db/cron/ssh scoping to the account
+		`mysqldump`,                    // per-db dump
+		`d JOIN site s ON d.site_id`,   // db enumeration
+		`domains-paths.txt`,            // rsync manifest
+		`FROM cron_job cj JOIN site`,   // cron reconstruction
+		`FROM ssh_user su JOIN site`,   // authorized_keys
+		`tar -czf "$OUT"`,              // final archive
+	} {
+		if !strings.Contains(*last, want) {
+			t.Errorf("synthesize script missing %q", want)
+		}
+	}
+	// set -e safety: no bare `[ ... ] && cmd` that would abort when the test is
+	// false (must be if/fi or guarded with || true).
+	if strings.Contains(*last, `] && echo`) {
+		t.Error("script uses a bare `[ ] && echo` — aborts under set -e when the test is false; use if/fi")
+	}
+}
+
+func TestBackupUser_RejectsBadAccount(t *testing.T) {
+	d := New()
+	s, _ := captureSession("/tmp/cpmove-x.tar.gz\n", nil)
+	for _, bad := range []string{"a'; rm -rf /;--", "a b", "../etc", "UPPER", ""} {
+		if _, err := d.BackupUser(context.Background(), s, bad); err == nil {
+			t.Errorf("account %q must be rejected by siteUserRe before any remote exec", bad)
+		}
+	}
+}
+
+func TestBackupUser_EmptyPathIsError(t *testing.T) {
+	d := New()
+	s, _ := captureSession("   \n", nil) // no path echoed
+	if _, err := d.BackupUser(context.Background(), s, "smokeuser"); err == nil {
+		t.Error("empty tarball path must be an error")
+	}
+}
+
+func TestBackupUser_RunErrorSurfaced(t *testing.T) {
+	d := New()
+	s, _ := captureSession("partial", errors.New("boom"))
+	if _, err := d.BackupUser(context.Background(), s, "smokeuser"); err == nil ||
+		!strings.Contains(err.Error(), "synthesize cpmove") {
+		t.Errorf("run error must be wrapped, got %v", err)
+	}
+}
+
+func TestRemoveRemote_AllowlistsCpmove(t *testing.T) {
+	d := New()
+	s, last := captureSession("", nil)
+	// Refuses anything outside /tmp/cpmove-*.
+	for _, bad := range []string{"/etc/passwd", "/tmp/cpmove-../etc", "/home/clp/htdocs/app/data/db.sq3"} {
+		if err := d.RemoveRemote(context.Background(), s, bad); err == nil {
+			t.Errorf("RemoveRemote must refuse %q", bad)
+		}
+	}
+	// Accepts the canonical synthesized path.
+	if err := d.RemoveRemote(context.Background(), s, "/tmp/cpmove-smokeuser.tar.gz"); err != nil {
+		t.Fatalf("RemoveRemote(valid): %v", err)
+	}
+	if !strings.Contains(*last, "rm -f") {
+		t.Errorf("RemoveRemote should issue rm -f, got %q", *last)
+	}
+}


### PR DESCRIPTION
Starts the CloudPanel **restore** path (discover was completed in #588/#590). Uses the shared cpmove-synthesis approach the DirectAdmin source pioneered, so the existing cpanel restore writers do the actual import unchanged.

## What lands
- **`BackupUser`** — one inline script on the source builds a cpmove-shaped tarball from CloudPanel's SQLite inventory:
  ```
  cpmove-<user>/
    cp/<user>            USER + primary-domain DNS line
    mysql/<db>.sql        mysqldump per site DB (MariaDB root-socket auth)
    cron/<user>           crontab lines rebuilt from cron_job
    domains-paths.txt     <domain>\t<docroot> for the restore rsync
    homedir/.ssh/authorized_keys   from ssh_user.ssh_keys
  ```
  CloudPanel is web-only → no `dnszones/` or mail (a subset of the cpanel layout). The home tree is not bundled (rsync'd per-docroot at restore, like DA, so retries resume).
- **`PullFile`** / **`RemoveRemote`** (`/tmp/cpmove-*` allow-list, JAB-50).
- **`pullCloudPanel`** case in the migrate pull dispatch (mirrors `pullDirectAdmin`), saving `cpmove-<user>.tar.gz`.

The import-side switch still returns "not yet supported" for cloudpanel — that's **step 2** (parse + rsync-rows + domain/db/cron/ssh creation) plus the end-to-end box migration into a jabali target. Keeping pull and import as separate PRs avoids a half-wired import.

## Safety
- `sqlite3 -readonly`; the only write-shaped command is `mysqldump` to a scratch file.
- `set -e` safe — explicit `if/fi`, no bare `[ ] && cmd` (a false test would abort under `set -e`); asserted in a unit test.
- Account passes `siteUserRe` before any remote exec.

## Testing
- **Box-verified** on the live CloudPanel VM (192.168.100.87): script `rc=0`, correct tarball layout, real `smokedb` dump (`INSERT INTO widgets`), `cp/smokeuser` (USER+DNS), `domains-paths.txt`, `cron/smokeuser`, `authorized_keys` all populated.
- Unit tests: synthesize script shape, account allow-list rejection, path parsing, run-error wrapping, RemoveRemote allow-list.
- `go build ./panel-api/...`, `go vet`, package tests `-race` green.