### PR TITLE
feat(i18n): extract attribute strings across the admin shell

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -184,5 +184,1033 @@
       "users": "Search by email, username, or name",
       "admins": "Search by email or name"
     }
+  },
+  "adminapplicationlist": {
+    "actions": "Actions",
+    "created": "Created",
+    "domain": "Domain",
+    "owner": "Owner",
+    "search_by_domain_or_user": "Search by domain or user",
+    "status": "Status",
+    "version": "Version"
+  },
+  "adminauditlist": {
+    "action": "Action",
+    "actor": "Actor",
+    "chain_broken_tamper_detected": "Chain BROKEN — tamper detected",
+    "integrity_retention": "Integrity & retention",
+    "prune": "Prune",
+    "result": "Result",
+    "target": "Target",
+    "this_permanently_deletes_old_audit_records_t": "This permanently deletes old audit records. The prune itself is recorded as an audit event (ADR-0106)."
+  },
+  "adminautomationtokenspage": {
+    "actions": "Actions",
+    "copy_it_now_and_store_it_in_your_automation": "Copy it now and store it in your automation's secret manager. The server only keeps an encrypted copy. If you lose it, revoke this token and mint a new one.",
+    "created": "Created",
+    "external_callers_using_this_token_will_start": "External callers using this token will start failing immediately. Revoke is soft (audit-only); the row stays in this list with a 'revoked' tag.",
+    "last_used": "Last Used",
+    "mint_server_api_token": "Mint Server API Token",
+    "name": "Name",
+    "revoke": "Revoke",
+    "scopes": "Scopes",
+    "status": "Status",
+    "this_is_the_only_time_the_secret_will_be_sho": "This is the only time the secret will be shown.",
+    "token_id": "Token ID",
+    "writes_enabled": "Writes enabled"
+  },
+  "backuplogstab": {
+    "backup_logs_unavailable": "Backup logs unavailable",
+    "from": "From",
+    "kind_contains": "Kind contains",
+    "status": "Status",
+    "the_backup_service_isn_t_responding_try_agai": "The backup service isn't responding. Try again in a moment.",
+    "user_id": "User ID"
+  },
+  "backupsettingstab": {
+    "max_concurrent_backup_jobs": "Max concurrent backup jobs",
+    "tenant_scheduled_backup_time_cron": "Tenant scheduled-backup time (cron)",
+    "tenants_choose_what_to_back_up_and_where_you": "Tenants choose what to back up and where; you own when. 5-field cron (min hour day-of-month month day-of-week), e.g. '0 3 * * *' = daily at 03:00 UTC.",
+    "the_dispatcher_runs_at_most_this_many_backup": "The dispatcher runs at most this many backup_jobs at once. Scheduled jobs queue and start as slots free."
+  },
+  "createbackupdrawer": {
+    "backups_run_as_a_goroutine_inside_panel_agen": "Backups run as a goroutine inside panel-agent.",
+    "compression": "Compression",
+    "content": "Content",
+    "create_backup": "Create backup",
+    "databases_comma_separated_optional": "Databases (comma-separated, optional)",
+    "destination": "Destination",
+    "folders_comma_separated": "Folders (comma-separated)",
+    "mailboxes_comma_separated_optional": "Mailboxes (comma-separated, optional)",
+    "pick_a_destination": "Pick a destination",
+    "pick_a_user": "Pick a user",
+    "type": "Type",
+    "user": "User"
+  },
+  "destinationstab": {
+    "actions": "Actions",
+    "backend": "Backend",
+    "credentials": "Credentials",
+    "enabled": "Enabled",
+    "name": "Name",
+    "url": "URL"
+  },
+  "encryptionkeycard": {
+    "losing_this_key_loses_every_snapshot": "Losing this key loses every snapshot."
+  },
+  "recoveryhandofftab": {
+    "bare_metal_full_host_restore_overwrites_the": "Bare-metal / full-host restore overwrites the running host and is run from the root shell, never as a one-click browser action. Use the template below on a clean OS install.",
+    "bare_metal_recovery_sequence": "Bare-metal recovery sequence",
+    "deleted_user_restore_panel_user_row_is_gone": "Deleted-user restore (panel user row is gone)",
+    "every_restore_flow_above_requires_the_restic": "Every restore flow above requires the restic master encryption key for the repository. Reveal and stash it now from the Encryption key tab — without it, no snapshot can be decrypted and recovery is impossible.",
+    "interactive_pick_destination_snapshot_and_us": "Interactive — pick destination, snapshot, and user from real lists",
+    "normal_account_restore_runs_from_the_backups": "Normal account restore runs from the Backups tab. The advanced and disaster-recovery flows below run from the root shell on the host — they are intentionally CLI-only so they work even when the panel itself is down.",
+    "restore_what_the_panel_does_vs_what_the_cli": "Restore: what the panel does vs. what the CLI does",
+    "staging_only_materialize_to_staging_do_not_a": "Staging-only (materialize to staging, do not apply)",
+    "system_restore_is_not_available_in_the_brows": "System restore is not available in the browser",
+    "you_need_the_backup_encryption_key_to_restor": "You need the backup encryption key to restore"
+  },
+  "schedulestab": {
+    "actions": "Actions",
+    "create_at_least_one_destination_before_addin": "Create at least one destination before adding schedules.",
+    "cron": "Cron",
+    "destinations": "Destinations",
+    "enabled": "Enabled",
+    "last_run": "Last run",
+    "next_run": "Next run",
+    "users": "Users"
+  },
+  "cacheoverviewpage": {
+    "cache_overview_page_cache_hit_ratio_by_domai": "Cache overview — page-cache hit ratio by domain"
+  },
+  "fleetcachedoctor": {
+    "re_provisions_cache_constants_acl_drop_in_fo": "Re-provisions cache (constants, ACL, drop-in) for every drifted site.",
+    "refresh": "Refresh",
+    "refresh_the_jabali_cache_plugin_on_every_cac": "Refresh the jabali-cache plugin on every cache-enabled site?",
+    "repair": "Repair",
+    "repair_all_drifted_installs": "Repair all drifted installs?"
+  },
+  "admincreatecronmodal": {
+    "choose_tenant": "Choose tenant",
+    "command": "Command",
+    "custom_cron_expression": "Custom cron expression",
+    "name": "Name",
+    "new_cron_job_as_tenant": "New cron job (as tenant)",
+    "run_as": "Run as",
+    "schedule": "Schedule",
+    "tenant": "Tenant"
+  },
+  "admincronlist": {
+    "no_cron_jobs_yet": "No cron jobs yet",
+    "search_by_name_command_schedule_or_owner": "Search by name, command, schedule, or owner"
+  },
+  "databaseuserdrawer": {
+    "create_database_user": "Create database user",
+    "database_user_created": "Database user created",
+    "engine": "Engine",
+    "mariadb_is_the_default_postgresql_must_be_en": "MariaDB is the default. PostgreSQL must be enabled in Server Settings.",
+    "the_final_mariadb_username_will_be_your_pane": "The final MariaDB username will be your panel username plus an underscore plus this value (e.g. alice_api).",
+    "username": "Username"
+  },
+  "databaseuserslist": {
+    "actions": "Actions",
+    "created": "Created",
+    "database_privileges": "Database Privileges",
+    "engine": "Engine",
+    "user": "User"
+  },
+  "databasecreate": {
+    "admins_create_databases_without_a_username_p": "Admins create databases without a username prefix. When a non-admin user creates one, the server prepends their username automatically (e.g. `alice_wp`).",
+    "name": "Name"
+  },
+  "databaselist": {
+    "actions": "Actions",
+    "charset": "Charset",
+    "created": "Created",
+    "database": "Database",
+    "engine": "Engine",
+    "no_databases_yet": "No databases yet",
+    "user_id": "User ID"
+  },
+  "dnszonesoverviewpage": {
+    "actions": "Actions",
+    "dns_zones_are_provisioned_automatically_when": "DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings.",
+    "dnssec": "DNSSEC",
+    "domain_name": "Domain Name",
+    "domain_registration_expiry_from_whois": "Domain registration expiry (from WHOIS)",
+    "expiration": "Expiration",
+    "no_dns_zones_yet_create_a_domain_to_manage_i": "No DNS zones yet — create a domain to manage its DNS",
+    "owner": "Owner",
+    "records": "Records",
+    "ttl": "TTL",
+    "zone_status": "Zone Status"
+  },
+  "admindockerappspage": {
+    "credentials": "Credentials",
+    "installed_apps": "Installed Apps",
+    "no_installed_apps_yet": "No installed apps yet",
+    "running": "Running",
+    "search_by_name": "Search by name",
+    "stopped": "Stopped",
+    "updates_available": "Updates Available"
+  },
+  "backupsdrawer": {
+    "backups": "Backups",
+    "container_will_be_stopped_files_restored_con": "Container will be stopped, files restored, container brought back up.",
+    "phase_8_1_restic_via_env_vars": "Phase 8.1: restic via env vars",
+    "restore": "Restore",
+    "restore_this_snapshot": "Restore this snapshot?"
+  },
+  "editdrawer": {
+    "cpu": "CPU",
+    "domain": "Domain",
+    "limits_update_mode_can_still_be_saved_ports": "Limits + update mode can still be saved; ports/domain edits will return 409 conflict while the container is running.",
+    "memory": "Memory",
+    "pick_from_the_panel_s_domains_list_leave_emp": "Pick from the panel's domains list. Leave empty to drop the managed-domain row.",
+    "pids": "PIDs",
+    "select_a_domain": "Select a domain",
+    "stop_the_container_before_editing_ports_or_d": "Stop the container before editing ports or domain",
+    "update_mode": "Update mode"
+  },
+  "envsection": {
+    "copy": "Copy",
+    "mints_a_new_secret_and_recreates_the_contain": "Mints a new secret and recreates the container.",
+    "recreate_the_container": "Recreate the container?",
+    "regenerate": "Regenerate",
+    "save_recreate": "Save & recreate",
+    "saving_applies_the_new_values_by_recreating": "Saving applies the new values by recreating the container (brief downtime)."
+  },
+  "execdrawer": {
+    "admin_only": "Admin-only",
+    "exec_command": "Exec command",
+    "runs_sh_c_command_in_the_first_service_of_th": "Runs `sh -c <command>` in the first service of the compose project. No TTY, no shell history. Use one command at a time."
+  },
+  "installdrawer": {
+    "backup_destination": "Backup destination",
+    "cpu": "CPU",
+    "domain": "Domain",
+    "hostname_to_attach_to_the_loopback_bound_por": "Hostname to attach to the loopback-bound port via nginx. Pick from the panel's domains list -- a vhost gets auto-rendered on save.",
+    "inherit_env_var_fallback": "Inherit env-var fallback",
+    "install_name": "Install name",
+    "memory": "Memory",
+    "per_install_identifier_combined_with_the_cat": "Per-install identifier. Combined with the catalog slug to form a unique data root + container name, so the same catalog app can be installed multiple times side-by-side.",
+    "pick_a_destination_from_server_settings_back": "Pick a destination from Server Settings -> Backups. Leave empty to fall back to JABALI_RESTIC_REPO env vars (Phase 8.1).",
+    "pids": "PIDs",
+    "select_a_domain": "Select a domain",
+    "update_mode": "Update mode"
+  },
+  "maintenancetab": {
+    "build_cache": "Build cache",
+    "containers": "Containers",
+    "disk_usage": "Disk usage",
+    "images": "Images",
+    "prune": "Prune",
+    "reclaimable": "Reclaimable",
+    "volumes": "Volumes"
+  },
+  "domaincreate": {
+    "adds_a_www_cname_pointing_at_the_domain_apex": "Adds a www CNAME pointing at the domain apex. Off by default — leave unchecked for subdomains or domains that don't serve a www host.",
+    "doc_root": "Doc Root",
+    "google_dkim_value": "Google DKIM value",
+    "leave_empty_for_auto_generated_path": "Leave empty for auto-generated path",
+    "let_s_encrypt_recommended_self_signed_or_non": "Let's Encrypt (recommended), self-signed, or none (HTTP only). Custom certs are uploaded after create from the domain's SSL settings.",
+    "mail": "Mail",
+    "microsoft_365_tenant": "Microsoft 365 tenant",
+    "name": "Name",
+    "optional_paste_the_google_domainkey_txt_valu": "Optional. Paste the google._domainkey TXT value from Google Admin. MX/SPF are added automatically.",
+    "optional_your_tenant_onmicrosoft_com_adds_th": "Optional. Your <tenant>.onmicrosoft.com — adds the selector1/2 DKIM CNAMEs. MX/SPF/autodiscover are added automatically.",
+    "select_a_user": "Select a user",
+    "tls_certificate": "TLS certificate",
+    "user": "User",
+    "where_this_domain_s_email_is_hosted_none_and": "Where this domain's email is hosted. 'None' and the external providers skip Jabali's mail DNS records and mail certificate SANs."
+  },
+  "domaindeliverabilitysection": {
+    "deliverability_score": "Deliverability score",
+    "deliverability_score_unavailable_for_this_do": "Deliverability score unavailable for this domain"
+  },
+  "domaindirectoryprivacysection": {
+    "authentication_name": "Authentication name",
+    "delete": "Delete",
+    "delete_this_rule_and_all_its_credentials": "Delete this rule and all its credentials?",
+    "delete_this_user": "Delete this user?",
+    "directory_under_the_docroot_to_protect_e_g_s": "Directory under the docroot to protect (e.g. /secret).",
+    "label_shown_in_the_browser_s_basic_auth_popu": "Label shown in the browser's Basic Auth popup.",
+    "password": "Password",
+    "path": "Path",
+    "per_directory_password_protection": "Per-directory password protection",
+    "user": "User",
+    "username": "Username"
+  },
+  "domainedit": {
+    "doc_root": "Doc Root",
+    "name": "Name",
+    "panel_hostname_domain_mail_only": "Panel hostname domain (mail-only)"
+  },
+  "domainemailsection": {
+    "a_fresh_dkim_keypair_is_generated_and_the_dn": "A fresh DKIM keypair is generated and the DNS TXT record changes. Remote receivers may need propagation time before they accept the new signature; the old key is kept as a backup.",
+    "copy_value": "Copy value",
+    "dkim_key_missing": "DKIM key missing",
+    "dns_autoconfig_partially_applied": "DNS autoconfig partially applied",
+    "dns_records": "DNS records",
+    "email_is_enabled_but_no_dkim_public_key_is_s": "Email is enabled but no DKIM public key is stored. Toggle off and back on to regenerate.",
+    "failed_to_load_email_state": "Failed to load email state",
+    "rotate": "Rotate",
+    "rotate_dkim_key": "Rotate DKIM key?"
+  },
+  "domainipaclsection": {
+    "action": "Action",
+    "cidr": "CIDR",
+    "comment": "Comment",
+    "delete": "Delete",
+    "delete_this_rule": "Delete this rule?",
+    "per_domain_ip_allow_deny": "Per-domain IP allow / deny",
+    "priority": "Priority"
+  },
+  "domainlist": {
+    "actions": "Actions",
+    "bw_30d": "BW (30d)",
+    "domain": "Domain",
+    "more_actions": "More actions",
+    "no_domains_yet": "No domains yet",
+    "redirect": "Redirect",
+    "ssl": "SSL",
+    "status": "Status",
+    "user": "User"
+  },
+  "domainmtastssection": {
+    "mta_sts_protects_inbound_mail_from_tls_downg": "MTA-STS protects inbound mail from TLS downgrade",
+    "policy_live_in_dns_vhost_waiting_for_ssl_ren": "Policy live in DNS — vhost waiting for SSL renewal",
+    "when_enabled_jabali_publishes_a_policy_telli": "When enabled, jabali publishes a policy telling every sending mail server to require TLS for messages to this domain. Two DNS records (TXT + A) appear and the agent serves the policy at https://mta-sts.<domain>/.well-known/mta-sts.txt. Cert renewal handles the SAN; no manual steps."
+  },
+  "domainmailprovidersection": {
+    "mail_provider": "Mail provider"
+  },
+  "domainmailtlssection": {
+    "clears_backoff_and_dispatches_ssl_mail_issue": "Clears backoff and dispatches ssl.mail.issue on the next reconciler tick"
+  },
+  "domainmailboxessection": {
+    "a_send_only_mailbox_authenticates_for_smtp_s": "A send-only mailbox authenticates for SMTP submission but never receives or stores mail — inbound is rejected. Useful for per-service notification credentials.",
+    "create": "Create",
+    "create_mailbox": "Create mailbox",
+    "domain": "Domain",
+    "email_isn_t_enabled_on_this_domain": "Email isn't enabled on this domain",
+    "leave_blank_to_auto_generate_generated_passw": "Leave blank to auto-generate. Generated passwords are shown exactly once.",
+    "local_part": "Local part",
+    "mailboxes_can_only_be_created_once_email_is": "Mailboxes can only be created once email is enabled. Usually this happens automatically when the domain is created — click below to retry.",
+    "only_domains_with_email_enabled_appear_here": "Only domains with email enabled appear here.",
+    "password": "Password",
+    "pick_a_domain": "Pick a domain",
+    "quota_mib": "Quota (MiB)"
+  },
+  "domainpathbrowsermodal": {
+    "no_subfolders_here": "No subfolders here.",
+    "pick_a_folder_under_the_docroot": "Pick a folder under the docroot"
+  },
+  "domainsslsection": {
+    "acme_issuance_failed": "ACME issuance failed",
+    "install": "Install",
+    "paste_the_full_chain_certificate_leaf_interm": "Paste the full-chain certificate (leaf + intermediates) and the matching private key in PEM format. The key is stored on the server and never shown again.",
+    "set_an_admin_email_to_use_ssl": "Set an admin email to use SSL",
+    "this_domain_is_using_a_self_signed_certifica": "This domain is using a self-signed certificate while Let's Encrypt issuance retries. Browsers will show a security warning until the real cert is issued.",
+    "upload_custom_certificate": "Upload custom certificate",
+    "using_self_signed_certificate": "Using self-signed certificate"
+  },
+  "domainskipautosantoggle": {
+    "skip_auto_added_san_names": "Skip auto-added SAN names"
+  },
+  "adminiplist": {
+    "actions": "Actions",
+    "address": "Address",
+    "bound": "Bound",
+    "default": "Default",
+    "family": "Family",
+    "ip_is_in_use": "IP is in use",
+    "label": "Label",
+    "no_managed_ips_yet": "No managed IPs yet",
+    "status": "Status",
+    "user_selectable": "User-selectable"
+  },
+  "logstreammodal": {
+    "goaccess_dashboard": "GoAccess Dashboard"
+  },
+  "admingroupstab": {
+    "no_groups": "No groups"
+  },
+  "adminmailpage": {
+    "leave_blank_to_auto_generate_auto_generated": "Leave blank to auto-generate. Auto-generated passwords are shown exactly once.",
+    "mailbox_password": "Mailbox password",
+    "new_password": "New password",
+    "no_mailboxes": "No mailboxes",
+    "search_email_name_domain_owner": "Search email, name, domain, owner",
+    "set_password": "Set password"
+  },
+  "maildeliverabilitypage": {
+    "each_of_the_four_signals_can_subtract_up_to": "Each of the four signals can subtract up to 25 points from a clean 100. The signals come from M47: RBL listings of the public IP, DKIM-failing buckets in inbound DMARC RUA reports, TLS-session failures in TLS-RPT reports, and abuse-feedback (ARF) reports from receiver postmasters. All counted over the last 7 days.",
+    "failed_to_load_deliverability_score": "Failed to load deliverability score",
+    "how_this_score_works": "How this score works",
+    "mail_deliverability_server_wide_score": "Mail deliverability — server-wide score"
+  },
+  "mailthrottlespage": {
+    "each_row_converges_into_a_stalwart_mtaoutbou": "Each row converges into a Stalwart MtaOutboundThrottle object on the next reconciler tick. 0 = unlimited. v1 enforces the hourly cap (Stalwart's rate object takes one window); daily cap is logged but not enforced until a later wave splits it into a paired object.",
+    "enabled": "Enabled",
+    "max_per_day_logged_only_v1": "Max per day (logged only, v1)",
+    "max_per_hour_0_unlimited": "Max per hour (0 = unlimited)",
+    "per_account_per_domain_server_wide_outbound": "Per-account / per-domain / server-wide outbound rate caps",
+    "scope": "Scope",
+    "scope_ref_ulid": "Scope ref (ULID)"
+  },
+  "adminmigrationdetailpage": {
+    "bytes_processed": "Bytes processed",
+    "destination_domain": "Destination domain",
+    "destination_user": "Destination user",
+    "ended": "Ended",
+    "error": "Error",
+    "job_id": "Job ID",
+    "last_error": "Last error",
+    "no_migration_job_selected": "No migration job selected",
+    "no_stage_rows_yet": "No stage rows yet",
+    "pipeline": "Pipeline",
+    "source_kind": "Source kind",
+    "stage_timeline": "Stage timeline",
+    "started": "Started",
+    "target_user_id": "Target user ID"
+  },
+  "adminmigrationspage": {
+    "account_migration_importer_m35": "Account migration importer (M35)",
+    "allow_ssh_to_rfc1918_loopback_link_local_sou": "Allow SSH to RFC1918 / loopback / link-local source hosts. Default off for production safety. Restart panel + agent after flipping to pick up the change.",
+    "batch": "Batch",
+    "cancel_batch": "Cancel batch",
+    "cancels_every_non_terminal_job_sharing_this": "Cancels every non-terminal job sharing this batch_id.",
+    "ended": "Ended",
+    "no_migrations_yet": "No migrations yet",
+    "per_source_kind_support": "Per-source-kind support",
+    "recent_migration_jobs": "Recent migration jobs",
+    "source": "Source",
+    "source_host": "Source host",
+    "source_user": "Source user",
+    "started": "Started",
+    "state": "State"
+  },
+  "bulkwhmdrawer": {
+    "accounts": "Accounts",
+    "bulk_whm": "Bulk WHM",
+    "create_whm_migration_batch": "Create WHM migration batch",
+    "creates_one_migration_job_per_account_all_sh": "Creates one migration_job per account, all sharing a batch_id. Cancel-batch + per-account retry are available from the list page.",
+    "hostname_or_ip_of_the_source_whm_server_priv": "Hostname or IP of the source WHM server. Private-IP targets require server_settings.migration_allow_private_hosts=true.",
+    "one_account_per_line_or_comma_separated_exis": "One account per line, or comma-separated. Existing jobs for any (host, account) are skipped automatically.",
+    "source_host": "Source host"
+  },
+  "createmigrationdrawer": {
+    "absolute_path_to_the_wordpress_root_on_the_s": "Absolute path to the WordPress root on the source (must contain wp-config.php). Leave blank to auto-detect ~/public_html, /home/*/public_html, or Cloudways /home/master/applications/*/public_html.",
+    "import_started": "Import started",
+    "new_migration_job": "New migration job",
+    "source_kind": "Source kind",
+    "ssh_port": "SSH port",
+    "the_migration_is_running_in_the_background_o": "The migration is running in the background. Open the migration job to track stage-by-stage progress.",
+    "the_source_server_s_ssh_port_defaults_to_22": "The source server's SSH port. Defaults to 22.",
+    "wordpress_path_optional": "WordPress path (optional)"
+  },
+  "createmigrationwizard": {
+    "account_discovery_failed": "Account discovery failed",
+    "admin_user": "Admin user",
+    "create_migration": "Create migration",
+    "credential_type": "Credential type",
+    "credentials_are_written_to_etc_jabali_panel": "Credentials are written to /etc/jabali-panel/migration-secrets and reaped 24h after job completion.",
+    "first_connection_is_unverified": "First connection is unverified",
+    "import_options": "Import options",
+    "pick_the_source_panel_type": "Pick the source panel type",
+    "pick_which_accounts_to_migrate_each_becomes": "Pick which accounts to migrate. Each becomes its own migration_job sharing a batch_id.",
+    "review": "Review",
+    "sha256_abc123": "SHA256:abc123…",
+    "source_host": "Source host",
+    "source_host_key_fingerprint_optional": "Source host key fingerprint (optional)",
+    "ssh_port": "SSH port",
+    "the_source_server_s_ssh_port_defaults_to_22": "The source server's SSH port. Defaults to 22.",
+    "use_the_server_s_direct_ip_if_it_sits_behind": "Use the server's direct IP if it sits behind Cloudflare or another proxy — a hostname can resolve to the proxy instead of the source server.",
+    "whm_enables_bulk_migration_of_every_cpanel_a": "WHM enables bulk migration of every cPanel account. Single-account migrations are still available via the 'New migration' button.",
+    "without_a_fingerprint_the_first_connection_t": "Without a fingerprint, the first connection to the source is trusted blindly (trust-on-first-use). For a hostile network, paste the source host key fingerprint above to verify it."
+  },
+  "channelstab": {
+    "actions": "Actions",
+    "enabled": "Enabled",
+    "kind": "Kind",
+    "name": "Name"
+  },
+  "dlqtab": {
+    "clear": "Clear",
+    "dlq_is_empty": "DLQ is empty",
+    "re_publishes_every_envelope_to_the_main_deli": "Re-publishes every envelope to the main delivery queue. Legacy entries without a preserved payload will be dropped silently.",
+    "replay_all": "Replay all",
+    "this_deletes_every_entry_in_the_stream_use_o": "This deletes every entry in the stream. Use only if you've already addressed the underlying failures (e.g. fixed a misconfigured channel)."
+  },
+  "eventstab": {
+    "description": "Description",
+    "enabled": "Enabled",
+    "event": "Event",
+    "severity": "Severity"
+  },
+  "historytab": {
+    "body": "Body",
+    "channel": "Channel",
+    "clear": "Clear",
+    "clear_all_notifications": "Clear all notifications?",
+    "deeplink": "Deeplink",
+    "event": "Event",
+    "outcome": "Outcome",
+    "read": "Read",
+    "retries": "Retries",
+    "severity": "Severity",
+    "show_details": "Show details",
+    "this_envelope_was_moved_to_the_dead_letter_q": "This envelope was moved to the Dead Letter queue after the dispatcher exhausted its retries.",
+    "this_permanently_deletes_every_row_in_your_i": "This permanently deletes every row in your inbox.",
+    "time": "Time",
+    "title": "Title"
+  },
+  "webpushtab": {
+    "browser_blocked_notifications": "Browser blocked notifications",
+    "browser_push_is_not_supported_in_this_browse": "Browser push is not supported in this browser",
+    "couldn_t_enable_browser_push": "Couldn't enable browser push",
+    "notifications_appear_via_your_operating_syst": "Notifications appear via your operating system even when the panel tab isn't focused. Disable any time below.",
+    "open_the_site_permissions_for_this_domain_in": "Open the site permissions for this domain in your browser settings and re-allow notifications, then reload.",
+    "this_browser_is_receiving_jabali_push_notifi": "This browser is receiving Jabali push notifications",
+    "web_push_relies_on_the_service_worker_push_a": "Web Push relies on the Service Worker + Push API. Try a modern Chrome, Firefox, Safari 16+, or Edge build."
+  },
+  "packagecreate": {
+    "allow_cgi_scripts": "Allow CGI scripts",
+    "allow_ssh_access": "Allow SSH access",
+    "allow_tenants_on_this_plan_to_enable_a_sched": "Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled.",
+    "allowed_backup_destinations": "Allowed Backup Destinations",
+    "also_expose_the_individual_pm_knobs_clamped": "Also expose the individual pm.* knobs (clamped to the cap). Implies the toggle above.",
+    "backup_retention_policy": "Backup Retention Policy",
+    "bandwidth_quota_mb": "Bandwidth Quota (MB)",
+    "cpu_quota": "CPU Quota (%)",
+    "destination_kinds_a_tenant_may_back_up_to_em": "Destination kinds a tenant may back up to. Empty = none allowed.",
+    "disk_quota_mb": "Disk Quota (MB)",
+    "docker_apps_per_package_allowlist": "Docker apps (per-package allowlist)",
+    "empty_server_wide_default": "Empty = server-wide default",
+    "est_ram_per_worker_mb_drives_the_memory_budg": "Est. RAM per worker (MB) — drives the memory-budget estimate",
+    "io_read_bandwidth_mb_s": "IO Read Bandwidth (MB/s)",
+    "io_write_bandwidth_mb_s": "IO Write Bandwidth (MB/s)",
+    "let_tenants_pick_a_safe_php_performance_mode": "Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized).",
+    "max_backups": "Max Backups",
+    "max_children_per_user_fpm_cap": "Max children per user (FPM cap)",
+    "max_databases": "Max Databases",
+    "max_docker_apps": "Max Docker Apps",
+    "max_domains": "Max Domains",
+    "max_email_accounts": "Max Email Accounts",
+    "max_python_apps": "Max Python Apps",
+    "max_tasks": "Max Tasks",
+    "memory_limit_mb": "Memory Limit (MB)",
+    "name": "Name",
+    "retention_cap_most_snapshots_a_tenant_on_thi": "Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included.",
+    "scheduled_backups": "Scheduled Backups",
+    "security_re_enables_php_exec_proc_open_shell": "Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs.",
+    "what_happens_when_a_tenant_reaches_max_backu": "What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+  },
+  "packageedit": {
+    "allow_cgi_scripts": "Allow CGI scripts",
+    "allow_ssh_access": "Allow SSH access",
+    "allow_tenants_on_this_plan_to_enable_a_sched": "Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled.",
+    "allowed_backup_destinations": "Allowed Backup Destinations",
+    "also_expose_the_individual_pm_knobs_clamped": "Also expose the individual pm.* knobs (clamped to the cap). Implies the toggle above.",
+    "backup_retention_policy": "Backup Retention Policy",
+    "bandwidth_quota_mb": "Bandwidth Quota (MB)",
+    "cpu_quota": "CPU Quota (%)",
+    "destination_kinds_a_tenant_may_back_up_to_em": "Destination kinds a tenant may back up to. Empty = none allowed.",
+    "disk_quota_mb": "Disk Quota (MB)",
+    "docker_apps_per_package_allowlist": "Docker apps (per-package allowlist)",
+    "empty_server_wide_default": "Empty = server-wide default",
+    "est_ram_per_worker_mb_drives_the_memory_budg": "Est. RAM per worker (MB) — drives the memory-budget estimate",
+    "io_read_bandwidth_mb_s": "IO Read Bandwidth (MB/s)",
+    "io_write_bandwidth_mb_s": "IO Write Bandwidth (MB/s)",
+    "let_tenants_pick_a_safe_php_performance_mode": "Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized).",
+    "max_backups": "Max Backups",
+    "max_children_per_user_fpm_cap": "Max children per user (FPM cap)",
+    "max_databases": "Max Databases",
+    "max_docker_apps": "Max Docker Apps",
+    "max_domains": "Max Domains",
+    "max_email_accounts": "Max Email Accounts",
+    "max_python_apps": "Max Python Apps",
+    "max_tasks": "Max Tasks",
+    "memory_limit_mb": "Memory Limit (MB)",
+    "name": "Name",
+    "retention_cap_most_snapshots_a_tenant_on_thi": "Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included.",
+    "scheduled_backups": "Scheduled Backups",
+    "security_re_enables_php_exec_proc_open_shell": "Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs.",
+    "what_happens_when_a_tenant_reaches_max_backu": "What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+  },
+  "packagelist": {
+    "actions": "Actions",
+    "bandwidth_mb": "Bandwidth (MB)",
+    "created": "Created",
+    "disk_mb": "Disk (MB)",
+    "domains": "Domains",
+    "email": "Email",
+    "name": "Name",
+    "no_hosting_packages_yet": "No hosting packages yet",
+    "php_exec": "PHP exec",
+    "search_by_package_name": "Search by package name",
+    "ssh": "SSH"
+  },
+  "fpmpoolstab": {
+    "could_not_load_php_fpm_pools": "Could not load PHP-FPM pools.",
+    "filter_by_php_version": "Filter by PHP version"
+  },
+  "phpextensionstab": {
+    "action": "Action",
+    "extension": "Extension",
+    "install_a_php_version_first_under_the_php_ve": "Install a PHP version first under the PHP Versions tab. Extension management requires at least one installed version.",
+    "installed": "Installed",
+    "no_php_versions_installed": "No PHP versions installed",
+    "php_version": "PHP version",
+    "search_extensions": "Search extensions",
+    "status": "Status"
+  },
+  "versionstab": {
+    "actions": "Actions",
+    "default": "Default",
+    "end_of_life_no_upstream_security_patches_run": "End of life — no upstream security patches. Running an EOL PHP version on a public site is a security risk.",
+    "fpm_workers": "FPM workers",
+    "modifying_php_versions_can_cause_server_down": "Modifying PHP versions can cause server downtime",
+    "php_version": "PHP Version",
+    "status": "Status",
+    "uninstalling_php_versions_may_break_websites": "Uninstalling PHP versions may break websites that depend on them. Ensure you understand the impact before making changes."
+  },
+  "phppooledit": {
+    "add_ini_override": "Add INI Override",
+    "directive": "Directive",
+    "idle_timeout_in_seconds": "Idle timeout in seconds",
+    "kind": "Kind",
+    "max_children": "Max Children",
+    "max_requests_per_worker_0_never": "Max Requests per Worker (0 = never)",
+    "max_spare_servers_dynamic_max_children": "Max Spare Servers (dynamic, <= max children)",
+    "min_spare_servers_dynamic": "Min Spare Servers (dynamic)",
+    "number_of_child_processes": "Number of child processes",
+    "php_version": "PHP Version",
+    "process_idle_timeout_seconds": "Process Idle Timeout (seconds)",
+    "process_mode": "Process Mode",
+    "request_terminate_timeout_seconds_0_no_limit": "Request Terminate Timeout (seconds, 0 = no limit)",
+    "select_process_manager_mode": "Select process manager mode",
+    "start_servers_dynamic": "Start Servers (dynamic)",
+    "value": "Value"
+  },
+  "adminsecurityaide": {
+    "added": "Added",
+    "aide_file_integrity_monitor": "AIDE — file integrity monitor",
+    "aide_not_active": "AIDE not active",
+    "all_watched_paths_match_the_baseline_checksu": "All watched paths match the baseline checksum.",
+    "category": "Category",
+    "change_type": "Change type",
+    "changed": "Changed",
+    "db_age": "DB age",
+    "last_check": "Last check",
+    "no_tamper_detected": "No tamper detected",
+    "prioritize_these": "Prioritize these",
+    "rebuild": "Rebuild",
+    "rebuild_the_aide_baseline": "Rebuild the AIDE baseline?",
+    "removed": "Removed",
+    "review_the_sample_below_if_the_changes_are_e": "Review the sample below. If the changes are expected (kernel bump, manual config edit), re-baseline via SSH: jabali aide rebuild --full.",
+    "this_replaces_the_integrity_baseline_with_th": "This replaces the integrity baseline with the current filesystem state (aideinit -y -f). Only do this after deliberate changes — any tampering present now becomes the new 'clean' baseline."
+  },
+  "adminsecurityapparmor": {
+    "apparmor": "AppArmor",
+    "apparmor_disabled": "AppArmor disabled",
+    "apparmor_profiles_intentionally_not_loaded_o": "AppArmor profiles intentionally not loaded on this kernel",
+    "complain_mode_profiles_are_logging_would_den": "Complain-mode profiles are logging would-deny (apparmor ALLOWED) violations — not soak-ready to enforce. Resolve or allowlist these before flipping to enforce.",
+    "denied_enforce_blocks": "Denied (enforce blocks)",
+    "enforce_will_start_denying_paths_caps_not_in": "Enforce will start denying paths/caps not in the profile.",
+    "filter_mode": "Filter mode",
+    "flip": "Flip",
+    "if_the_profile_is_missing_a_path_the_daemon": "If the profile is missing a path the daemon needs, the daemon will fail. Review complain-mode AVC denials in journalctl -k before flipping.",
+    "mode": "Mode",
+    "protects": "Protects",
+    "this_profile_is_not_soak_ready_enforcing_now": "This profile is NOT soak-ready. Enforcing now will BLOCK those operations and can break the daemon. Resolve or allowlist them first.",
+    "would_deny_complain": "Would-deny (complain)"
+  },
+  "adminsecuritycrowdsec": {
+    "active_decision_sources": "Active decision sources",
+    "active_decisions": "Active decisions",
+    "active_until": "Active until",
+    "add_crowdsec_decision_manual_ban": "Add CrowdSec decision (manual ban)",
+    "add_to_allowlist": "Add to allowlist",
+    "added": "Added",
+    "aggregates_every_active_decision_by_origin_s": "Aggregates every active decision by (origin/scenario). CAPI = pulled from app.crowdsec.net; cscli-import = manually imported; crowdsec = local detection. Subscribe to community blocklists at app.crowdsec.net → Blocklists.",
+    "alert_not_found": "Alert not found",
+    "alerts_last_24h": "Alerts (last 24h)",
+    "all_time_alerts_since_crowdsec_started": "All-time alerts since CrowdSec started",
+    "allow_list_with_no_countries_blocks_every_re": "Allow-list with no countries blocks every request — add at least one before applying.",
+    "allowlist_never_ban": "Allowlist (never ban)",
+    "allowlisted_ips_bypass_every_scenario_decisi": "Allowlisted IPs bypass every scenario, decision, and the AppSec geoblock. Use for your office, home IP, or CI runner CIDR.",
+    "apply": "Apply",
+    "apply_appsec_geoblock": "Apply AppSec geoblock",
+    "apply_captcha_settings": "Apply captcha settings?",
+    "apply_overrides": "Apply overrides?",
+    "appsec_geoblock_server_wide": "AppSec geoblock (server-wide)",
+    "auto_allowlist_login_ips_server_wide": "Auto-allowlist login IPs (server-wide)",
+    "ban_duration": "Ban duration",
+    "behaviour_based_intrusion_prevention_tails_s": "Behaviour-based intrusion-prevention. Tails server logs (nginx, sshd, panel, mail), matches them against scenarios (brute-force, scanners, web exploits, credential stuffing), and emits IP decisions. Bouncers enforce them at the firewall (UFW), at nginx (AppSec WAF with OWASP CRS rules + optional captcha challenge), and against a crowdsourced blocklist of IPs flagged by the wider community in the last hours.",
+    "bouncer_mode_server_wide": "Bouncer mode (server-wide)",
+    "cancel": "Cancel",
+    "captcha_action_requires_the_captcha_remediat": "Captcha action requires the Captcha remediation card above to be enabled.",
+    "captcha_remediation": "Captcha remediation",
+    "config_validation_failed_crowdsec_t": "Config validation failed (crowdsec -t)",
+    "country_bans_rely_on_the_geoip_enricher_as_b": "Country bans rely on the GeoIP enricher; AS bans on the ASN enricher. Both are installed by default on fresh CrowdSec hosts.",
+    "create_an_hcaptcha_recaptcha_turnstile_site": "Create an hCaptcha / reCAPTCHA / Turnstile site at the provider, paste the keys below. Secret is stored server-side and never returned.",
+    "decisions": "Decisions",
+    "decisions_issued": "Decisions issued",
+    "deny_list_with_no_countries_has_no_effect_ad": "Deny-list with no countries has no effect — add at least one before applying.",
+    "description": "Description",
+    "duration": "Duration",
+    "enabled": "Enabled",
+    "events": "Events",
+    "how_this_is_enforced": "How this is enforced",
+    "ip_or_cidr": "IP or CIDR",
+    "ip_value": "IP / value",
+    "ips_currently_banned_under_captcha": "IPs currently banned / under captcha",
+    "item": "Item",
+    "leave_blank_to_keep_the_stored_secret_unchan": "Leave blank to keep the stored secret unchanged.",
+    "lines_no_parser_matched_gaps_in_coverage": "Lines no parser matched (gaps in coverage)",
+    "machine": "Machine",
+    "no_active_decisions": "No active decisions",
+    "no_alerts_in_the_last_24h": "No alerts in the last 24h",
+    "no_allowlist_entries": "No allowlist entries",
+    "no_bouncers_registered_cscli_bouncers_add": "No bouncers registered (cscli bouncers add)",
+    "no_decisions_issued": "No decisions issued",
+    "no_scenarios_installed": "No scenarios installed",
+    "one_click_install_of_upstream_crowdsec_hub_i": "One-click install of upstream CrowdSec Hub items",
+    "override": "Override",
+    "per_scenario_remediation_override": "Per-scenario remediation override",
+    "provider": "Provider",
+    "reason": "Reason",
+    "recent_changes_audit": "Recent changes (audit)",
+    "recommended_free_blocklists_scenarios": "Recommended free blocklists & scenarios",
+    "remove": "Remove",
+    "remove_from_allowlist": "Remove from allowlist",
+    "rewrites_etc_crowdsec_profiles_yaml_marker_b": "Rewrites /etc/crowdsec/profiles.yaml (marker-bounded) and reloads crowdsec.",
+    "scenario": "Scenario",
+    "scenario_fired": "Scenario fired",
+    "scenario_thresholds_tripped_suspicious_patte": "Scenario thresholds tripped (suspicious patterns matched)",
+    "scope": "Scope",
+    "secret_key_write_only": "Secret key (write-only)",
+    "security_trade_off": "Security trade-off",
+    "sensitivity_preset_server_wide": "Sensitivity preset (server-wide)",
+    "single_ipv4_ipv6_address_or_cidr_block_e_g_1": "Single IPv4/IPv6 address or CIDR block (e.g. 192.0.2.1 or 10.0.0.0/24).",
+    "site_key_public": "Site key (public)",
+    "source": "Source",
+    "started": "Started",
+    "this_ip_was_banned_because_the_scenario_abov": "This IP was banned because the scenario above fired on its traffic. Enforcement is applied by the active bouncers: the firewall bouncer drops it at nftables (all ports), and the nginx bouncer returns 403 on HTTP. To lift it, delete the decision (or add the IP to the Allowlist so it is never re-banned).",
+    "this_is_a_broad_crowdsec_exemption_a_success": "This is a broad CrowdSec exemption. A successful login from a stolen key or compromised account shields that source IP from all CrowdSec decisions for the TTL. Lower the TTL or disable this if that window is unacceptable for your threat model.",
+    "this_rewrites_etc_crowdsec_bouncers_crowdsec": "This rewrites /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf and reloads nginx.",
+    "type": "Type",
+    "type_a_country_name_or_code_or_pick_from_the": "Type a country name or code, or pick from the list",
+    "until": "Until",
+    "value": "Value",
+    "what_is_crowdsec": "What is CrowdSec?",
+    "when_enabled_crowdsec_scenarios_flagged_for": "When enabled, CrowdSec scenarios flagged for captcha serve a challenge page instead of a 403.",
+    "why_reason": "Why (reason)"
+  },
+  "adminsecurityegress": {
+    "actions": "Actions",
+    "cidr": "CIDR",
+    "comment": "Comment",
+    "drops_24h": "Drops 24h",
+    "drops_last_tick": "Drops (last tick)",
+    "egress_state": "Egress state",
+    "enforced_users": "Enforced users",
+    "learning_users": "Learning users",
+    "off_users": "Off users",
+    "per_user_php_fpm_egress_firewall": "Per-user PHP-FPM egress firewall",
+    "per_user_policy": "Per-user policy",
+    "port": "Port",
+    "proto": "Proto",
+    "protocol": "Protocol",
+    "reason": "Reason",
+    "state": "State",
+    "submitted": "Submitted",
+    "total_drops_last_tick": "Total drops (last tick)",
+    "user": "User"
+  },
+  "adminsecuritymalware": {
+    "built_in_rule_packs": "Built-in rule packs",
+    "custom_yara_rules": "Custom YARA rules",
+    "daily_scan_schedule_cron": "Daily scan schedule (cron)",
+    "enable_mail_attachment_scanning": "Enable mail attachment scanning",
+    "event_detail": "Event detail",
+    "exec_audit_auditd_jabali_susp_exec": "Exec audit (auditd jabali_susp_exec)",
+    "explain_why_this_restore_is_safe": "Explain why this restore is safe",
+    "filename": "Filename",
+    "inotify_watches": "Inotify watches",
+    "manual_scan": "Manual scan",
+    "max_attachment_size_mb": "Max attachment size (MB)",
+    "max_scan_size_per_file_mb": "Max scan size per file (MB)",
+    "notification_severity_threshold": "Notification severity threshold",
+    "original": "Original",
+    "per_attachment_scan_timeout_seconds": "Per-attachment scan timeout (seconds)",
+    "per_tick_budget_mailboxes_scanned_each_cycle": "Per-tick budget (mailboxes scanned each cycle)",
+    "pre_flight_parsed_via_yara_w_before_install": "Pre-flight parsed via 'yara -w' before install",
+    "quarantine": "Quarantine",
+    "quarantine_retention_days": "Quarantine retention (days)",
+    "real_time_scanning": "Real-time scanning",
+    "real_time_scanning_is_off": "Real-time scanning is off",
+    "realtime_monitor": "Realtime monitor",
+    "reason_audit": "Reason (audit)",
+    "recent_events": "Recent events",
+    "restore_from_quarantine": "Restore from quarantine",
+    "restoring_re_introduces_the_file_to_disk": "Restoring re-introduces the file to disk",
+    "rule_content": "Rule content",
+    "scan_all_folders_not_just_inbox": "Scan all folders (not just Inbox)",
+    "search_username_name_or_email": "Search username, name, or email",
+    "settings": "Settings",
+    "sha256": "SHA256",
+    "skip_these_recipient_addresses_comma_separat": "Skip these recipient addresses (comma-separated)",
+    "the_inotify_monitor_is_not_running_daily_sch": "The inotify monitor is not running. Daily scheduled scans + on-demand scans still work. Enable real-time scanning in the Settings tab to catch threats within ~120s of file write (~1.7GB RAM peak per scan cycle).",
+    "upload_fails_with_the_parser_error_if_the_ru": "Upload fails with the parser error if the rule is malformed. Filenames must match ^[a-z0-9][a-z0-9._-]{0,63}\\\\.yar$ and are capped at 64 KB.",
+    "upload_yara_rule": "Upload YARA rule",
+    "yara_engine": "YARA engine"
+  },
+  "adminsecuritysnuffleupagus": {
+    "action": "Action",
+    "disable": "Disable",
+    "disable_rule_reason_required": "Disable rule — reason required",
+    "domain_tenant": "Domain / tenant",
+    "php_defense": "PHP Defense",
+    "php_defense_rules": "PHP Defense rules",
+    "php_version": "PHP version",
+    "re_enable_this_rule": "Re-enable this rule?",
+    "request_uri": "Request URI",
+    "rule": "Rule",
+    "rules_log_incidents_below_without_blocking_s": "Rules log incidents below without blocking. Soak for 7 days to identify false positives, then flip to enforce.",
+    "simulation_mode_active": "Simulation mode active",
+    "source_ip": "Source IP",
+    "when": "When"
+  },
+  "adminsecurityufw": {
+    "action": "Action",
+    "add_ufw_rule": "Add UFW rule",
+    "cancel": "Cancel",
+    "continue": "Continue",
+    "delete": "Delete",
+    "delete_rule": "Delete rule",
+    "disable_firewall": "Disable firewall?",
+    "disabling_ufw_drops_host_firewall_protection": "Disabling UFW DROPS host firewall protection. CrowdSec firewall-bouncer also stops applying rules. Use only for emergency triage.",
+    "enable_the_firewall_to_view_and_manage_rules": "Enable the firewall to view and manage rules.",
+    "enabling_ufw_will_activate_default_deny_inco": "Enabling UFW will activate default-deny incoming. Make sure SSH (22) is in the allow-list.",
+    "firewall_disabled": "Firewall DISABLED",
+    "from": "From",
+    "no_rules": "No rules",
+    "port": "Port",
+    "proto": "Proto",
+    "protocol": "Protocol",
+    "rules": "Rules",
+    "rules_hidden_firewall_disabled": "Rules hidden — firewall disabled",
+    "status": "Status",
+    "this_drops_the_host_firewall_crowdsec_firewa": "This drops the host firewall. CrowdSec firewall-bouncer stops applying rules. Confirm again in the next dialog.",
+    "ufw_is_not_active_rules_below_if_any_are_not": "UFW is not active. Rules below (if any) are not enforced. CrowdSec firewall-bouncer also has no effect until UFW is enabled.",
+    "ufw_is_port_policy_only": "UFW is port policy only",
+    "yes": "YES"
+  },
+  "crowdsectestipcard": {
+    "drops_every_active_crowdsec_decision_targeti": "Drops every active CrowdSec decision targeting this IP.",
+    "test_failed": "Test failed",
+    "test_ip_would_this_ip_be_blocked": "Test IP — would this IP be blocked?",
+    "unban": "Unban"
+  },
+  "egressmaturepromotion": {
+    "operator_pin_active": "Operator pin active",
+    "promote": "Promote",
+    "this_enforces_the_egress_firewall_for_those": "This enforces the egress firewall for those users on the next reconcile tick."
+  },
+  "speedtestcard": {
+    "jitter": "Jitter"
+  },
+  "adminsessionspage": {
+    "active_sessions": "Active Sessions",
+    "revoke": "Revoke",
+    "revoke_this_session": "Revoke this session?",
+    "the_user_will_be_signed_out_of_the_panel": "The user will be signed out of the panel."
+  },
+  "accountskeletoncard": {
+    "account_skeleton": "Account skeleton",
+    "add": "Add",
+    "add_skeleton_file": "Add skeleton file",
+    "path": "Path"
+  },
+  "brandingcard": {
+    "brand_text": "Brand text",
+    "browser_cache": "Browser cache",
+    "jabali": "Jabali",
+    "newly_uploaded_logos_may_take_up_to_5_minute": "Newly uploaded logos may take up to 5 minutes to appear across all sessions due to HTTP cache. Force-reload (Ctrl+Shift+R) to see yours immediately.",
+    "panel_branding": "Panel Branding"
+  },
+  "dnspermissionscard": {
+    "admins_always_have_full_control_ns_and_soa_r": "Admins always have full control. NS and SOA records are zone infrastructure and are never user-editable. Use a preset or fine-tune per type, then Save.",
+    "dns_record_permissions": "DNS Record Permissions",
+    "which_dns_record_types_regular_users_may_man": "Which DNS record types regular users may manage"
+  },
+  "dnsresolverscard": {
+    "dns_resolvers": "DNS Resolvers",
+    "ipv4_primary": "IPv4 Primary",
+    "ipv4_secondary_optional": "IPv4 Secondary (optional)",
+    "ipv6_primary_optional": "IPv6 Primary (optional)",
+    "ipv6_secondary_optional": "IPv6 Secondary (optional)",
+    "search_domain_optional": "Search domain (optional)",
+    "the_drop_in_will_still_be_written_but_change": "The drop-in will still be written, but changes won't take effect until the service is running."
+  },
+  "databaseadminsections": {
+    "actions": "Actions",
+    "apply": "Apply",
+    "command": "Command",
+    "host": "Host",
+    "i_saved_it": "I saved it",
+    "kill": "Kill",
+    "query": "Query",
+    "rotate": "Rotate",
+    "state": "State",
+    "the_previous_password_if_any_stops_working_i": "The previous password (if any) stops working immediately.",
+    "time": "Time",
+    "user": "User"
+  },
+  "dockermarketplacecard": {
+    "docker_app_marketplace_m48": "Docker App Marketplace (M48)",
+    "marketplace_live": "Marketplace live",
+    "opt_in_feature": "Opt-in feature"
+  },
+  "emailcard": {
+    "dkim": "DKIM",
+    "enabled_at": "Enabled at",
+    "failed_to_load_email_settings": "Failed to load email settings",
+    "primary_mail_domain": "Primary mail domain",
+    "the_panel_hostname_s_mail_domain_is_being_pr": "The panel hostname's mail domain is being provisioned (DKIM keypair, Stalwart, DNS records, nginx vhost). This typically takes ~30 seconds on a fresh install. This page will refresh automatically.",
+    "webmail_is_initializing": "Webmail is initializing",
+    "webmail_url": "Webmail URL"
+  },
+  "logretentioncard": {
+    "it_s_hash_chained_and_tamper_evident_set_a_w": "It's hash-chained and tamper-evident. Set a window only if you accept a shorter forensic record; pruning re-anchors the chain so it stays verifiable forward.",
+    "logs_retention": "Logs — retention",
+    "the_audit_log_defaults_to_keep_forever": "The audit log defaults to keep-forever"
+  },
+  "lookandfeelcard": {
+    "look_and_feel": "Look and feel",
+    "panel_font_size": "Panel font size"
+  },
+  "modulescard": {
+    "modules": "Modules"
+  },
+  "nginxsettingscard": {
+    "cache_key_metadata_zone_8000_keys_mb": "Cache key metadata zone (~8000 keys/MB)",
+    "custom_http_directives": "Custom http{} directives",
+    "evict_entries_not_accessed_within_this_windo": "Evict entries not accessed within this window",
+    "gzip_compression": "Gzip compression",
+    "keepalive_timeout": "Keepalive timeout",
+    "largest_request_body_nginx_accepts_before_41": "Largest request body nginx accepts before 413. Raise it for big-upload apps (ownCloud, Nextcloud). e.g. 50m, 2g.",
+    "max_upload_size_client_max_body_size": "Max upload size (client_max_body_size)",
+    "nginx": "Nginx",
+    "off_hides_the_nginx_version_in_responses_err": "Off hides the nginx version in responses + error pages (recommended).",
+    "raw_nginx_directives_can_make_the_server_uns": "Raw nginx directives — can make the server unstable",
+    "shared_fastcgi_cache_max_on_disk_size": "Shared FastCGI cache max on-disk size",
+    "show_nginx_version_server_tokens": "Show nginx version (server_tokens)"
+  },
+  "nspawnimagescard": {
+    "codename": "Codename",
+    "delete_all_unused_images": "Delete all unused images?",
+    "prune": "Prune",
+    "prune_result": "Prune result",
+    "removes_every_sealed_image_no_user_and_not_t": "Removes every sealed image no user (and not the server default) is pinned to. Irreversible — you'd rebuild from a snapshot to restore.",
+    "snapshot": "Snapshot",
+    "ssh_sandbox_images_nspawn": "SSH sandbox images (nspawn)",
+    "suite": "Suite",
+    "version": "Version"
+  },
+  "phpperformancemodescard": {
+    "idle_timeout_s": "Idle timeout (s)",
+    "max_children": "Max children",
+    "max_requests_0_never": "Max requests (0 = never)",
+    "max_spare": "Max spare",
+    "min_spare": "Min spare",
+    "php_performance_modes": "PHP Performance Modes",
+    "process_manager": "Process manager",
+    "start_servers": "Start servers"
+  },
+  "pagetemplatescard": {
+    "cancel": "Cancel",
+    "page_templates": "Page Templates",
+    "save": "Save"
+  },
+  "panelsslcard": {
+    "failed_to_load_panel_ssl_state": "Failed to load panel SSL state",
+    "hostname": "Hostname",
+    "let_s_encrypt_is_unavailable_for_the_panel": "Let's Encrypt is unavailable for the panel",
+    "mail": "Mail",
+    "panel_certificate_not_initialised_yet": "Panel certificate not initialised yet.",
+    "panel_ssl": "Panel SSL"
+  },
+  "pythonappscard": {
+    "apps_need_python3_venv_and_a_build_toolchain": "Apps need python3-venv and a build toolchain (gcc, python3-dev, libffi/ssl-dev). These are installed by the host provisioner; if a venv build fails for a C-extension package, run jabali update to ensure the toolchain is present.",
+    "runtime_prerequisites": "Runtime prerequisites"
+  },
+  "ssomaintenancecard": {
+    "deletes_only_already_expired_tokens_active_s": "Deletes only already-expired tokens — active SSO sessions are unaffected.",
+    "operator_procedure_run_on_the_host_not_from": "Operator procedure — run on the host, not from the browser",
+    "purge": "Purge",
+    "purge_expired_sso_tokens_now": "Purge expired SSO tokens now?",
+    "rotation_re_encrypts_every_stored_db_user_pa": "Rotation re-encrypts every stored DB-user password, then swaps the on-disk key file and reloads the panel. It is intentionally CLI-only: a browser-triggered rotation that reloads the panel mid-request is high-risk, and a failure between re-encrypt and key-swap breaks phpMyAdmin SSO for all tenants. Take a backup (step 3) so you can roll back.",
+    "sso_maintenance_phpmyadmin": "SSO maintenance (phpMyAdmin)"
+  },
+  "stalwartwebadmincard": {
+    "done": "Done",
+    "stalwart_webadmin_advanced": "Stalwart WebAdmin (advanced)",
+    "the_full_mail_server_admin_is_reachable_behi": "The full mail-server admin is reachable behind Stalwart’s own login. Restrict by IP and disable when not in use."
+  },
+  "tenantdomainoptionscard": {
+    "tenant_domain_options": "Tenant Domain Options"
+  },
+  "webmailtogglecard": {
+    "webmail": "Webmail"
+  },
+  "sslmanagerpage": {
+    "domain_certificates": "Domain Certificates"
+  },
+  "adminterminal": {
+    "root_shell_every_keystroke_and_all_output_is": "ROOT SHELL — every keystroke and all output is recorded to /var/log/jabali/terminal and an alert is sent on open.",
+    "root_terminal_is_disabled": "Root terminal is disabled"
+  },
+  "domainrepaircard": {
+    "cancel": "Cancel",
+    "delete_all_orphan_sites": "Delete all orphan sites?",
+    "delete_permanently": "Delete permanently",
+    "no_orphan_sites_found": "No orphan sites found.",
+    "select_a_user": "Select a user",
+    "this_is_irreversible_it_tears_down_each_site": "This is irreversible — it tears down each site's nginx vhost, DKIM keys, and Stalwart mail domain row. Scan first and review the list."
+  },
+  "repaircard": {
+    "applies_non_destructive_fixes_only_jabali_re": "Applies non-destructive fixes only (jabali repair --auto). The panel may briefly restart.",
+    "auto_repair_safe_issues": "Auto-repair safe issues?",
+    "cancel": "Cancel",
+    "click_auto_repair_to_fix_the_non_destructive": "Click Auto-Repair to fix the non-destructive ones.",
+    "diagnostics_failed": "Diagnostics failed",
+    "no_issues_detected_all_healthy": "No issues detected — all healthy.",
+    "run": "Run",
+    "run_diagnostics_to_see_what_s_broken": "Run diagnostics to see what's broken."
+  },
+  "systemupdatespage": {
+    "a_bad_self_update_can_take_the_panel_offline": "A bad self-update can take the panel offline. Leave off unless you want hands-off panel upgrades.",
+    "development_channel_less_reviewed_builds": "Development channel: less-reviewed builds",
+    "development_follows_the_latest_main_commit_a": "Development follows the latest main commit and may include unreviewed changes. Use it only on test hosts; switch back to Stable for production.",
+    "no_update_runs_yet": "No update runs yet",
+    "promoting_a_build_to_stable_is_an_operator_c": "Promoting a build to Stable is an operator/CI task",
+    "update_carefully_especially_system_packages": "Update carefully — especially system packages"
+  },
+  "adminuseroverview": {
+    "user_not_found": "User not found"
+  },
+  "userreset2faaction": {
+    "reset": "Reset",
+    "reset_two_factor_authentication": "Reset two-factor authentication?"
+  },
+  "userresetpasswordaction": {
+    "done": "Done",
+    "new_password_shown_once": "New password — shown once",
+    "reset": "Reset",
+    "reset_password": "Reset password?"
   }
 }

--- a/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
+++ b/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
@@ -5,6 +5,7 @@
 //
 // Status badge styling is inlined from UserApplicationList to keep
 // coupling low and avoid tight dependency on that component.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
@@ -144,6 +145,7 @@ const AdminActionsCell = ({
 };
 
 export const AdminApplicationList = () => {
+  const { t } = useTranslation();
   const query = useTableURL<ApplicationInstall>({
     resource: "applications",
     defaultSort: "created_at",
@@ -215,7 +217,7 @@ export const AdminApplicationList = () => {
         >
           <Table.Column<ApplicationInstall>
             dataIndex="domain_name"
-            title="Domain"
+            title={t("adminapplicationlist.domain")}
             key="domain_name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -227,7 +229,7 @@ export const AdminApplicationList = () => {
             filterDropdown={({ confirm, close }) => (
               <div style={{ padding: 8, minWidth: 240 }}>
                 <Input.Search
-                  placeholder="Search by domain or user"
+                  placeholder={t("adminapplicationlist.search_by_domain_or_user")}
                   allowClear
                   defaultValue={query.params.q}
                   onSearch={(value) => {
@@ -268,7 +270,7 @@ export const AdminApplicationList = () => {
           />
           <Table.Column<ApplicationInstall>
             dataIndex="owner_email"
-            title="Owner"
+            title={t("adminapplicationlist.owner")}
             filterIcon={() => (
               <SearchOutlined
                 style={{ color: query.params.q ? "#ef4444" : undefined }}
@@ -277,7 +279,7 @@ export const AdminApplicationList = () => {
             filterDropdown={({ confirm, close }) => (
               <div style={{ padding: 8, minWidth: 240 }}>
                 <Input.Search
-                  placeholder="Search by domain or user"
+                  placeholder={t("adminapplicationlist.search_by_domain_or_user")}
                   allowClear
                   defaultValue={query.params.q}
                   onSearch={(value) => {
@@ -294,11 +296,11 @@ export const AdminApplicationList = () => {
           />
           <Table.Column<ApplicationInstall>
             dataIndex="version"
-            title="Version"
+            title={t("adminapplicationlist.version")}
           />
           <Table.Column<ApplicationInstall>
             dataIndex="status"
-            title="Status"
+            title={t("adminapplicationlist.status")}
             render={(status: ApplicationInstall["status"], record) => {
               const meta = STATUS_META[status] ?? STATUS_META.pending;
               const tag = (
@@ -314,14 +316,14 @@ export const AdminApplicationList = () => {
           />
           <Table.Column<ApplicationInstall>
             dataIndex="created_at"
-            title="Created"
+            title={t("adminapplicationlist.created")}
             key="created_at"
             sorter={{ multiple: 2 }}
             defaultSortOrder="descend"
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<ApplicationInstall>
-            title="Actions"
+            title={t("adminapplicationlist.actions")}
             dataIndex="actions"
             render={(_, r) => {
               const appType = r.app_type ?? "wordpress";

--- a/panel-ui/src/shells/admin/audit/AdminAuditList.tsx
+++ b/panel-ui/src/shells/admin/audit/AdminAuditList.tsx
@@ -8,6 +8,7 @@
 // Timestamps render in the server timezone (Server Settings →
 // Timezone). Actor shows the resolved username (API batch-resolves the
 // ULID). The Action cell opens a modal with the full recorded detail.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   App,
@@ -46,6 +47,7 @@ interface VerifyResult {
   broken_id: string;
 }
 const AuditMaintenanceCard = () => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [days, setDays] = useState<number>(365);
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
@@ -67,7 +69,7 @@ const AuditMaintenanceCard = () => {
   });
 
   return (
-    <Card title="Integrity & retention" size="small" style={{ marginBottom: 16 }}>
+    <Card title={t("adminauditlist.integrity_retention")} size="small" style={{ marginBottom: 16 }}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <div>
           <Space wrap>
@@ -90,7 +92,7 @@ const AuditMaintenanceCard = () => {
                 <Alert
                   type="error"
                   showIcon
-                  message="Chain BROKEN — tamper detected"
+                  message={t("adminauditlist.chain_broken_tamper_detected")}
                   description={
                     <span>
                       First broken row after {verifyResult.checked} verified:{" "}
@@ -115,8 +117,8 @@ const AuditMaintenanceCard = () => {
             <Typography.Text>days</Typography.Text>
             <Popconfirm
               title={`Prune audit rows older than ${days} days?`}
-              description="This permanently deletes old audit records. The prune itself is recorded as an audit event (ADR-0106)."
-              okText="Prune"
+              description={t("adminauditlist.this_permanently_deletes_old_audit_records_t")}
+              okText={t("adminauditlist.prune")}
               okButtonProps={{ danger: true }}
               onConfirm={() => prune.mutate()}
             >
@@ -132,6 +134,7 @@ const AuditMaintenanceCard = () => {
 };
 
 export const AdminAuditList = () => {
+  const { t } = useTranslation();
   const tz = useServerTz();
   const query = useTableURL<AuditRow>({
     resource: "admin/audit",
@@ -175,7 +178,7 @@ export const AdminAuditList = () => {
             render={(ts: string) => <code>{fmtTSInTz(ts, tz)}</code>}
           />
           <Table.Column
-            title="Actor"
+            title={t("adminauditlist.actor")}
             key="actor"
             render={(_: unknown, r: AuditRow) => (
               <span>
@@ -189,13 +192,13 @@ export const AdminAuditList = () => {
             )}
           />
           <Table.Column
-            title="Action"
+            title={t("adminauditlist.action")}
             key="action"
             sorter={{ multiple: 1 }}
             render={(_: unknown, r: AuditRow) => <AuditActionLabel row={r} />}
           />
           <Table.Column
-            title="Target"
+            title={t("adminauditlist.target")}
             key="target"
             render={(_: unknown, r: AuditRow) =>
               r.target_type || r.target_id ? (
@@ -209,7 +212,7 @@ export const AdminAuditList = () => {
           />
           <Table.Column
             dataIndex="result"
-            title="Result"
+            title={t("adminauditlist.result")}
             key="result"
             sorter={{ multiple: 1 }}
             render={resultTag}

--- a/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
+++ b/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
@@ -8,6 +8,7 @@
 //
 // Revocation is soft (sets revoked_at). Operators can audit which
 // admin minted what + when it was last used.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
@@ -74,6 +75,7 @@ function fmt(iso?: string | null): string {
 }
 
 export const AdminAutomationTokensPage = () => {
+  const { t } = useTranslation();
   const { token } = theme.useToken();
   const qc = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -191,9 +193,9 @@ export const AdminAutomationTokensPage = () => {
           pagination={false}
           scroll={{ x: "max-content" }}
         >
-          <Table.Column<Token> title="Name" dataIndex="name" />
+          <Table.Column<Token> title={t("adminautomationtokenspage.name")} dataIndex="name" />
           <Table.Column<Token>
-            title="Token ID"
+            title={t("adminautomationtokenspage.token_id")}
             dataIndex="id"
             render={(v: string) => (
               <Typography.Text copyable code style={{ fontSize: 12 }}>
@@ -202,7 +204,7 @@ export const AdminAutomationTokensPage = () => {
             )}
           />
           <Table.Column<Token>
-            title="Scopes"
+            title={t("adminautomationtokenspage.scopes")}
             width={260}
             render={(_, r) => (
               <Space wrap size={4} style={{ maxWidth: 260 }}>
@@ -215,12 +217,12 @@ export const AdminAutomationTokensPage = () => {
             )}
           />
           <Table.Column<Token>
-            title="Created"
+            title={t("adminautomationtokenspage.created")}
             dataIndex="created_at"
             render={(v: string) => fmt(v)}
           />
           <Table.Column<Token>
-            title="Last Used"
+            title={t("adminautomationtokenspage.last_used")}
             render={(_, r) => (
               <Space direction="vertical" size={0}>
                 <span>{fmt(r.last_used_at)}</span>
@@ -233,7 +235,7 @@ export const AdminAutomationTokensPage = () => {
             )}
           />
           <Table.Column<Token>
-            title="Status"
+            title={t("adminautomationtokenspage.status")}
             render={(_, r) =>
               r.revoked_at ? (
                 <Tag color="red">revoked {fmt(r.revoked_at)}</Tag>
@@ -243,15 +245,15 @@ export const AdminAutomationTokensPage = () => {
             }
           />
           <Table.Column<Token>
-            title="Actions"
+            title={t("adminautomationtokenspage.actions")}
             render={(_, r) =>
               r.revoked_at ? (
                 <Typography.Text type="secondary">—</Typography.Text>
               ) : (
                 <Popconfirm
                   title={`Revoke token "${r.name}"?`}
-                  description="External callers using this token will start failing immediately. Revoke is soft (audit-only); the row stays in this list with a 'revoked' tag."
-                  okText="Revoke"
+                  description={t("adminautomationtokenspage.external_callers_using_this_token_will_start")}
+                  okText={t("adminautomationtokenspage.revoke")}
                   okButtonProps={{ danger: true }}
                   onConfirm={() => revoke.mutateAsync({ id: r.id })}
                 >
@@ -266,7 +268,7 @@ export const AdminAutomationTokensPage = () => {
       </Card>
 
       <Drawer
-        title="Mint Server API Token"
+        title={t("adminautomationtokenspage.mint_server_api_token")}
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
         width={500}
@@ -289,7 +291,7 @@ export const AdminAutomationTokensPage = () => {
         >
           <Form.Item
             name="name"
-            label="Name"
+            label={t("adminautomationtokenspage.name")}
             rules={[
               { required: true, message: "Required" },
               { max: 100 },
@@ -301,7 +303,7 @@ export const AdminAutomationTokensPage = () => {
 
           <Form.Item
             name="scopes"
-            label="Scopes"
+            label={t("adminautomationtokenspage.scopes")}
             rules={[{ required: true, message: "At least one scope" }]}
             getValueFromEvent={normalizeScopes}
             extra="Wildcard 'read:*' grants every read; otherwise tick only the resources the automation needs (mutually exclusive)."
@@ -312,7 +314,7 @@ export const AdminAutomationTokensPage = () => {
           {hasWriteScope ? (
             <Form.Item
               name="writes_enabled"
-              label="Writes enabled"
+              label={t("adminautomationtokenspage.writes_enabled")}
               valuePropName="checked"
               initialValue={true}
               extra="Master switch. Turn off to mint a write-scoped token with writes paused — it can be enabled later without re-issuing the secret. A write token acts on any tenant; grant sparingly."
@@ -355,8 +357,8 @@ export const AdminAutomationTokensPage = () => {
         <Alert
           type="warning"
           showIcon
-          message="This is the only time the secret will be shown."
-          description="Copy it now and store it in your automation's secret manager. The server only keeps an encrypted copy. If you lose it, revoke this token and mint a new one."
+          message={t("adminautomationtokenspage.this_is_the_only_time_the_secret_will_be_sho")}
+          description={t("adminautomationtokenspage.copy_it_now_and_store_it_in_your_automation")}
           style={{ marginBottom: 16 }}
         />
         <Typography.Text type="secondary">Secret</Typography.Text>

--- a/panel-ui/src/shells/admin/backups/BackupLogsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupLogsTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import {
@@ -46,6 +47,7 @@ interface Filters {
 }
 
 export const BackupLogsTab = () => {
+  const { t } = useTranslation();
   const { token } = theme.useToken();
   const [filters, setFilters] = useState<Filters>({});
   const [page, setPage] = useState(1);
@@ -166,7 +168,7 @@ export const BackupLogsTab = () => {
       <Space wrap style={{ marginBottom: 12 }}>
         <DatePicker
           showTime
-          placeholder="From"
+          placeholder={t("backuplogstab.from")}
           value={filters.from}
           onChange={(v) => setFilters((f) => ({ ...f, from: v }))}
         />
@@ -177,21 +179,21 @@ export const BackupLogsTab = () => {
           onChange={(v) => setFilters((f) => ({ ...f, to: v }))}
         />
         <Input
-          placeholder="Kind contains"
+          placeholder={t("backuplogstab.kind_contains")}
           allowClear
           value={filters.kind ?? ""}
           onChange={(e) => setFilters((f) => ({ ...f, kind: e.target.value }))}
           style={{ width: 150 }}
         />
         <Input
-          placeholder="Status"
+          placeholder={t("backuplogstab.status")}
           allowClear
           value={filters.status ?? ""}
           onChange={(e) => setFilters((f) => ({ ...f, status: e.target.value }))}
           style={{ width: 120 }}
         />
         <Input
-          placeholder="User ID"
+          placeholder={t("backuplogstab.user_id")}
           allowClear
           value={filters.user_id ?? ""}
           onChange={(e) => setFilters((f) => ({ ...f, user_id: e.target.value }))}
@@ -202,8 +204,8 @@ export const BackupLogsTab = () => {
       {error && (
         <Alert
           type="warning"
-          message="Backup logs unavailable"
-          description="The backup service isn't responding. Try again in a moment."
+          message={t("backuplogstab.backup_logs_unavailable")}
+          description={t("backuplogstab.the_backup_service_isn_t_responding_try_agai")}
           style={{ marginBottom: 12 }}
           showIcon
         />

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -1,6 +1,7 @@
 // BackupSettingsTab — knobs that govern the in-process backup
 // scheduler/dispatcher. Backed by server_settings (PATCH /admin/settings).
 // Retention is per-schedule (Schedules tab) — not server-wide.
+import { useTranslation } from "react-i18next";
 import { Button, Form, Input, InputNumber, Spin, message } from "antd";
 import { SaveOutlined } from "@icons";
 import { useEffect, useState } from "react";
@@ -21,6 +22,7 @@ interface ServerSettingsResponse {
 }
 
 export const BackupSettingsTab = () => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<BackupSettingsShape>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -68,16 +70,16 @@ export const BackupSettingsTab = () => {
       >
         <Form.Item
           name="backup_max_concurrent_jobs"
-          label="Max concurrent backup jobs"
-          tooltip="The dispatcher runs at most this many backup_jobs at once. Scheduled jobs queue and start as slots free."
+          label={t("backupsettingstab.max_concurrent_backup_jobs")}
+          tooltip={t("backupsettingstab.the_dispatcher_runs_at_most_this_many_backup")}
           rules={[{ required: true, type: "number", min: 1, max: 64 }]}
         >
           <InputNumber min={1} max={64} style={{ width: "100%" }} />
         </Form.Item>
         <Form.Item
           name="tenant_backup_cron"
-          label="Tenant scheduled-backup time (cron)"
-          tooltip="Tenants choose what to back up and where; you own when. 5-field cron (min hour day-of-month month day-of-week), e.g. '0 3 * * *' = daily at 03:00 UTC."
+          label={t("backupsettingstab.tenant_scheduled_backup_time_cron")}
+          tooltip={t("backupsettingstab.tenants_choose_what_to_back_up_and_where_you")}
           rules={[{ required: true, message: "A cron expression is required" }]}
         >
           <Input placeholder="0 3 * * *" style={{ fontFamily: "monospace" }} />

--- a/panel-ui/src/shells/admin/backups/CreateBackupDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/CreateBackupDrawer.tsx
@@ -2,6 +2,7 @@
 // backup (kind=account_backup) or a system_backup. The agent
 // orchestrator runs the actual stages; the panel just creates the
 // workflow row + dispatches.
+import { useTranslation } from "react-i18next";
 import { Alert, Button, Drawer, Form, Grid, Input, Radio, Select, Space, message } from "antd";
 import { useEffect, useState } from "react";
 
@@ -38,6 +39,7 @@ interface FormValues {
 type Destination = { id: string; name: string; kind: string; enabled: boolean };
 
 export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDrawerProps) => {
+  const { t } = useTranslation();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
   const [form] = Form.useForm<FormValues>();
@@ -114,7 +116,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
 
   return (
     <Drawer
-      title="Create backup"
+      title={t("createbackupdrawer.create_backup")}
       open={open}
       onClose={onClose}
       width={isDesktop ? 520 : undefined}
@@ -132,7 +134,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
       <Alert
         type="info"
         showIcon
-        message="Backups run as a goroutine inside panel-agent."
+        message={t("createbackupdrawer.backups_run_as_a_goroutine_inside_panel_agen")}
         description={
           kind === "full_server"
             ? "Full Server: the complete system/panel backup PLUS every account (each account's home, databases, and mailboxes) in one run. Best for disaster recovery."
@@ -148,7 +150,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
         onFinish={handleSubmit}
         initialValues={{ kind: "account_backup" }}
       >
-        <Form.Item label="Type" name="kind" rules={[{ required: true }]}>
+        <Form.Item label={t("createbackupdrawer.type")} name="kind" rules={[{ required: true }]}>
           <Radio.Group>
             <Radio.Button value="account_backup">Account</Radio.Button>
             <Radio.Button value="system_backup">System</Radio.Button>
@@ -157,13 +159,13 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
         </Form.Item>
 
         <Form.Item
-          label="Destination"
+          label={t("createbackupdrawer.destination")}
           name="destination_id"
           rules={[{ required: true, message: "Pick a destination" }]}
           extra="The backup writes directly to this destination — no local source repo."
         >
           <Select
-            placeholder="Pick a destination"
+            placeholder={t("createbackupdrawer.pick_a_destination")}
             loading={destQuery.isLoading}
             options={(destQuery.items ?? [])
               .filter((d) => d.enabled)
@@ -174,12 +176,12 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
         {kind === "account_backup" && (
           <>
             <Form.Item
-              label="User"
+              label={t("createbackupdrawer.user")}
               name="user_id"
               rules={[{ required: true, message: "Pick a user" }]}
             >
               <Select
-                placeholder="Pick a user"
+                placeholder={t("createbackupdrawer.pick_a_user")}
                 showSearch
                 optionFilterProp="label"
                 loading={usersQuery.isLoading}
@@ -192,21 +194,21 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
               />
             </Form.Item>
             <Form.Item
-              label="Databases (comma-separated, optional)"
+              label={t("createbackupdrawer.databases_comma_separated_optional")}
               name="databases"
               extra="Names of databases owned by the user. Leave empty to skip the DB stage."
             >
               <Input placeholder="alice_wp, alice_blog" />
             </Form.Item>
             <Form.Item
-              label="Mailboxes (comma-separated, optional)"
+              label={t("createbackupdrawer.mailboxes_comma_separated_optional")}
               name="mailboxes"
               extra="user@domain pairs. Skips with warning when Stalwart is down."
             >
               <Input placeholder="alice@example.com, hello@example.com" />
             </Form.Item>
             <Form.Item
-              label="Content"
+              label={t("createbackupdrawer.content")}
               name="content"
               extra="Full = home + databases + mailboxes. Files = home only. Databases = DBs only. Folders = a subset of the home directory."
             >
@@ -221,7 +223,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
             </Form.Item>
             {content === "folders" && (
               <Form.Item
-                label="Folders (comma-separated)"
+                label={t("createbackupdrawer.folders_comma_separated")}
                 name="folders"
                 rules={[{ required: true, message: "List at least one folder" }]}
                 extra="Paths relative to the account home, e.g. public_html, public_html/wp-content/uploads"
@@ -230,7 +232,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
               </Form.Item>
             )}
             <Form.Item
-              label="Compression"
+              label={t("createbackupdrawer.compression")}
               name="compression"
               extra="restic compression level (zstd). Auto is recommended; Max is smaller but slower; Off is fastest."
             >

--- a/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
@@ -7,6 +7,7 @@
 // /root/.ssh/ via the system-ssh-keys endpoint and offers a
 // "Generate new key" inline action that calls the same endpoint with
 // POST.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -579,6 +580,7 @@ function parseEnvBlock(block: string): Record<string, string> {
 }
 
 export function DestinationsTab() {
+  const { t } = useTranslation();
   const [rows, setRows] = useState<BackupDestination[]>([]);
   const [loading, setLoading] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -721,27 +723,27 @@ export function DestinationsTab() {
         pagination={false}
         scroll={{ x: "max-content" }}
       >
-        <Table.Column dataIndex="name" title="Name" />
+        <Table.Column dataIndex="name" title={t("destinationstab.name")} />
         <Table.Column
           dataIndex="kind"
-          title="Backend"
+          title={t("destinationstab.backend")}
           render={(k: string) => <Tag>{k.toUpperCase()}</Tag>}
         />
-        <Table.Column dataIndex="url" title="URL" />
+        <Table.Column dataIndex="url" title={t("destinationstab.url")} />
         <Table.Column
           dataIndex="enabled"
-          title="Enabled"
+          title={t("destinationstab.enabled")}
           render={(v: boolean) => (v ? <Tag color="green">yes</Tag> : <Tag>no</Tag>)}
         />
         <Table.Column
           dataIndex="has_credentials"
-          title="Credentials"
+          title={t("destinationstab.credentials")}
           render={(v: boolean) =>
             v ? <CheckCircleOutlined style={{ color: "#52c41a" }} /> : "—"
           }
         />
         <Table.Column<BackupDestination>
-          title="Actions"
+          title={t("destinationstab.actions")}
           render={(_, row) => (
             <RowActions
               actions={[

--- a/panel-ui/src/shells/admin/backups/EncryptionKeyCard.tsx
+++ b/panel-ui/src/shells/admin/backups/EncryptionKeyCard.tsx
@@ -6,6 +6,7 @@
 // Reveal is gated behind a click-to-show button; the page never auto-
 // loads the secret. Copy + Download buttons let the operator stash
 // it in a password manager / printed sheet / off-host vault.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -35,6 +36,7 @@ interface RevealResponse {
 }
 
 export function EncryptionKeyCard() {
+  const { t } = useTranslation();
   const [revealed, setRevealed] = useState(false);
   const [busy, setBusy] = useState(false);
   const [secret, setSecret] = useState<RevealResponse | null>(null);
@@ -91,7 +93,7 @@ export function EncryptionKeyCard() {
         type="warning"
         showIcon
         style={{ marginBottom: 16 }}
-        message="Losing this key loses every snapshot."
+        message={t("encryptionkeycard.losing_this_key_loses_every_snapshot")}
         description={
           <>
             Restic encrypts every backup with AES-256-GCM using the password at{" "}

--- a/panel-ui/src/shells/admin/backups/RecoveryHandoffTab.tsx
+++ b/panel-ui/src/shells/admin/backups/RecoveryHandoffTab.tsx
@@ -4,6 +4,7 @@
 // system restore. This tab makes those discoverable BEFORE an incident, with
 // copy-able command templates and the encryption-key prerequisite, instead of
 // leaving operators to find them mid-disaster.
+import { useTranslation } from "react-i18next";
 import { Alert, Space, Table, Typography } from "antd";
 import { LifeBuoyOutlined, KeyOutlined } from "@icons";
 
@@ -66,14 +67,15 @@ const CommandBlock = ({ label, cmd }: { label: string; cmd: string }) => (
 );
 
 export const RecoveryHandoffTab = () => {
+  const { t } = useTranslation();
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
       <Alert
         type="info"
         showIcon
         icon={<LifeBuoyOutlined />}
-        message="Restore: what the panel does vs. what the CLI does"
-        description="Normal account restore runs from the Backups tab. The advanced and disaster-recovery flows below run from the root shell on the host — they are intentionally CLI-only so they work even when the panel itself is down."
+        message={t("recoveryhandofftab.restore_what_the_panel_does_vs_what_the_cli")}
+        description={t("recoveryhandofftab.normal_account_restore_runs_from_the_backups")}
       />
 
       <Table<FlowRow>
@@ -99,9 +101,9 @@ export const RecoveryHandoffTab = () => {
 
       <div>
         <Title level={5}>Advanced account restore (CLI)</Title>
-        <CommandBlock label="Interactive — pick destination, snapshot, and user from real lists" cmd={CMD_INTERACTIVE} />
-        <CommandBlock label="Staging-only (materialize to staging, do not apply)" cmd={CMD_STAGE} />
-        <CommandBlock label="Deleted-user restore (panel user row is gone)" cmd={CMD_DELETED} />
+        <CommandBlock label={t("recoveryhandofftab.interactive_pick_destination_snapshot_and_us")} cmd={CMD_INTERACTIVE} />
+        <CommandBlock label={t("recoveryhandofftab.staging_only_materialize_to_staging_do_not_a")} cmd={CMD_STAGE} />
+        <CommandBlock label={t("recoveryhandofftab.deleted_user_restore_panel_user_row_is_gone")} cmd={CMD_DELETED} />
       </div>
 
       <div>
@@ -110,18 +112,18 @@ export const RecoveryHandoffTab = () => {
           type="warning"
           showIcon
           style={{ marginBottom: 12 }}
-          message="System restore is not available in the browser"
-          description="Bare-metal / full-host restore overwrites the running host and is run from the root shell, never as a one-click browser action. Use the template below on a clean OS install."
+          message={t("recoveryhandofftab.system_restore_is_not_available_in_the_brows")}
+          description={t("recoveryhandofftab.bare_metal_full_host_restore_overwrites_the")}
         />
-        <CommandBlock label="Bare-metal recovery sequence" cmd={CMD_SYSTEM} />
+        <CommandBlock label={t("recoveryhandofftab.bare_metal_recovery_sequence")} cmd={CMD_SYSTEM} />
       </div>
 
       <Alert
         type="warning"
         showIcon
         icon={<KeyOutlined />}
-        message="You need the backup encryption key to restore"
-        description="Every restore flow above requires the restic master encryption key for the repository. Reveal and stash it now from the Encryption key tab — without it, no snapshot can be decrypted and recovery is impossible."
+        message={t("recoveryhandofftab.you_need_the_backup_encryption_key_to_restor")}
+        description={t("recoveryhandofftab.every_restore_flow_above_requires_the_restic")}
       />
     </Space>
   );

--- a/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
+++ b/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
@@ -1,5 +1,6 @@
 // M30.1 Schedules admin tab. Lists every backup_schedules row, drawer
 // for create/edit, multi-select destinations, "Run now" button.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -406,6 +407,7 @@ function ScheduleDrawer({
 }
 
 export function SchedulesTab() {
+  const { t } = useTranslation();
   const [rows, setRows] = useState<BackupSchedule[]>([]);
   const [destinations, setDestinations] = useState<BackupDestinationOption[]>([]);
   const [users, setUsers] = useState<User[]>([]);
@@ -484,7 +486,7 @@ export function SchedulesTab() {
           showIcon
           type="warning"
           style={{ marginBottom: 12 }}
-          message="Create at least one destination before adding schedules."
+          message={t("schedulestab.create_at_least_one_destination_before_addin")}
         />
       )}
       <Table<BackupSchedule>
@@ -495,7 +497,7 @@ export function SchedulesTab() {
         scroll={{ x: "max-content" }}
       >
         <Table.Column<BackupSchedule>
-          title="Users"
+          title={t("schedulestab.users")}
           render={(_, row) => {
             if (row.kind === "system_backup") return "—";
             const ids = row.user_ids ?? [];
@@ -512,7 +514,7 @@ export function SchedulesTab() {
         />
         <Table.Column
           dataIndex="cron_expr"
-          title="Cron"
+          title={t("schedulestab.cron")}
           render={(c: string, row: BackupSchedule) => (
             <Tooltip
               title={
@@ -527,11 +529,11 @@ export function SchedulesTab() {
         />
         <Table.Column
           dataIndex="enabled"
-          title="Enabled"
+          title={t("schedulestab.enabled")}
           render={(v: boolean) => (v ? <Tag color="green">yes</Tag> : <Tag>no</Tag>)}
         />
         <Table.Column<BackupSchedule>
-          title="Destinations"
+          title={t("schedulestab.destinations")}
           render={(_, row) => (
             <Space wrap>
               {(row.destinations ?? []).map((d) => (
@@ -547,16 +549,16 @@ export function SchedulesTab() {
         />
         <Table.Column
           dataIndex="next_run_at"
-          title="Next run"
+          title={t("schedulestab.next_run")}
           render={(v: string | null) => v ?? "—"}
         />
         <Table.Column
           dataIndex="last_run_at"
-          title="Last run"
+          title={t("schedulestab.last_run")}
           render={(v: string | null) => shortDateTime(v)}
         />
         <Table.Column<BackupSchedule>
-          title="Actions"
+          title={t("schedulestab.actions")}
           render={(_, row) => (
             <RowActions
               actions={[

--- a/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/cache/CacheOverviewPage.tsx
@@ -1,6 +1,7 @@
 // CacheOverviewPage — GH #617 admin cache visibility. Ranks cache-enabled
 // domains by nginx page-cache hit ratio so low-hit / high-bypass / noisy sites
 // are visible at a glance. Reads GET /api/v1/admin/cache/overview.
+import { useTranslation } from "react-i18next";
 import { App, Card, Table, Tag, Typography } from "antd";
 import { useEffect, useState } from "react";
 
@@ -17,6 +18,7 @@ type Row = {
 };
 
 export function CacheOverviewPage() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(false);
@@ -35,7 +37,7 @@ export function CacheOverviewPage() {
   return (
     <>
       <FleetCacheDoctor />
-      <Card title="Cache overview — page-cache hit ratio by domain">
+      <Card title={t("cacheoverviewpage.cache_overview_page_cache_hit_ratio_by_domai")}>
       <Typography.Paragraph type="secondary">
         Cache-enabled WordPress domains, ranked with the lowest hit ratio (most in
         need of attention) first. A low ratio with high traffic suggests a

--- a/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
+++ b/panel-ui/src/shells/admin/cache/FleetCacheDoctor.tsx
@@ -3,6 +3,7 @@
 // is long (one agent call per install), so the POST returns a run id and this
 // polls it — no synchronous fleet call that would 502. Shows live progress,
 // per-install results, and recent run history.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   App,
@@ -112,6 +113,7 @@ const itemColumns: ColumnsType<DoctorItem> = [
 ];
 
 export function FleetCacheDoctor() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
@@ -200,9 +202,9 @@ export function FleetCacheDoctor() {
           Run doctor
         </Button>
         <Popconfirm
-          title="Repair all drifted installs?"
-          description="Re-provisions cache (constants, ACL, drop-in) for every drifted site."
-          okText="Repair"
+          title={t("fleetcachedoctor.repair_all_drifted_installs")}
+          description={t("fleetcachedoctor.re_provisions_cache_constants_acl_drop_in_fo")}
+          okText={t("fleetcachedoctor.repair")}
           okButtonProps={{ danger: true }}
           disabled={busy}
           onConfirm={() => startMutation.mutate("repair")}
@@ -212,8 +214,8 @@ export function FleetCacheDoctor() {
           </Button>
         </Popconfirm>
         <Popconfirm
-          title="Refresh the jabali-cache plugin on every cache-enabled site?"
-          okText="Refresh"
+          title={t("fleetcachedoctor.refresh_the_jabali_cache_plugin_on_every_cac")}
+          okText={t("fleetcachedoctor.refresh")}
           disabled={busy}
           onConfirm={() => startMutation.mutate("refresh")}
         >

--- a/panel-ui/src/shells/admin/cron/AdminCreateCronModal.tsx
+++ b/panel-ui/src/shells/admin/cron/AdminCreateCronModal.tsx
@@ -3,6 +3,7 @@
 // user-side CreateCronModal but adds a target-user picker as the
 // first field. UserID flows into the request body; the server
 // uses it only when caller.IsAdmin (security gate in panel-api).
+import { useTranslation } from "react-i18next";
 import { App, Button, Divider, Drawer, Form, Grid, Input, Radio, Select, Space, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -31,6 +32,7 @@ interface Props {
 }
 
 export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const screens = Grid.useBreakpoint();
   const [form] = Form.useForm<{
@@ -109,7 +111,7 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
     <Drawer
       open={open}
       onClose={onClose}
-      title="New cron job (as tenant)"
+      title={t("admincreatecronmodal.new_cron_job_as_tenant")}
       width={screens.xs ? "100%" : 560}
       destroyOnClose
       extra={
@@ -134,7 +136,7 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
           if (c.run_as !== undefined) setRunAs(c.run_as);
         }}
       >
-        <Form.Item label="Run as" name="run_as" initialValue="tenant">
+        <Form.Item label={t("admincreatecronmodal.run_as")} name="run_as" initialValue="tenant">
           <Radio.Group>
             <Radio value="tenant">Tenant (per-user systemd)</Radio>
             <Radio value="root">Root (system-scoped systemd)</Radio>
@@ -142,12 +144,12 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
         </Form.Item>
         {runAs === "tenant" && (
           <Form.Item
-            label="Tenant"
+            label={t("admincreatecronmodal.tenant")}
             name="user_id"
             rules={[{ required: true, message: "Pick a tenant" }]}
           >
             <Select
-              placeholder="Choose tenant"
+              placeholder={t("admincreatecronmodal.choose_tenant")}
               options={userOptions}
               loading={usersQ.isLoading}
               showSearch
@@ -158,7 +160,7 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
           </Form.Item>
         )}
         <Form.Item
-          label="Name"
+          label={t("admincreatecronmodal.name")}
           name="name"
           rules={[
             { required: true, message: "Name is required" },
@@ -168,14 +170,14 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
           <Input placeholder="e.g. nightly-backup" />
         </Form.Item>
         <Form.Item
-          label="Command"
+          label={t("admincreatecronmodal.command")}
           name="command"
           rules={[{ required: true, message: "Command is required" }]}
         >
           <Input.TextArea placeholder="cd /home/tenant && ./run.sh" rows={3} />
         </Form.Item>
         <Divider />
-        <Form.Item label="Schedule" name="preset">
+        <Form.Item label={t("admincreatecronmodal.schedule")} name="preset">
           <Radio.Group>
             <Space direction="vertical" size="small" style={{ width: "100%" }}>
               {SCHEDULE_PRESETS.map((p) => (
@@ -193,7 +195,7 @@ export const AdminCreateCronModal = ({ open, onClose, onSuccess }: Props) => {
         </Form.Item>
         {preset === "advanced" && (
           <Form.Item
-            label="Custom cron expression"
+            label={t("admincreatecronmodal.custom_cron_expression")}
             name="schedule"
             rules={[{ required: true, message: "Cron expression required" }]}
           >

--- a/panel-ui/src/shells/admin/cron/AdminCronList.tsx
+++ b/panel-ui/src/shells/admin/cron/AdminCronList.tsx
@@ -5,6 +5,7 @@
 // is out of scope for the initial cut. PATCH / DELETE / run-now / log
 // all go through the existing /cron/:id endpoints, which authorise
 // admins via fetchAndAuthorize's claims.IsAdmin bypass.
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { App, Button, Card, Input, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
 import {
@@ -44,6 +45,7 @@ const SCHEDULE_PRESETS: Record<string, string> = {
 const humanizeSchedule = (s: string): string => SCHEDULE_PRESETS[s] || s;
 
 export const AdminCronList = () => {
+  const { t } = useTranslation();
   const { message: antMessage } = App.useApp();
   const [logDrawerOpen, setLogDrawerOpen] = useState(false);
   const [logJobId, setLogJobId] = useState<string | null>(null);
@@ -146,7 +148,7 @@ export const AdminCronList = () => {
       <Card>
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
           <Input.Search
-            placeholder="Search by name, command, schedule, or owner"
+            placeholder={t("admincronlist.search_by_name_command_schedule_or_owner")}
             allowClear
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -162,7 +164,7 @@ export const AdminCronList = () => {
             locale={{
               emptyText: (
                 <EmptyWithCTA
-                  description="No cron jobs yet"
+                  description={t("admincronlist.no_cron_jobs_yet")}
                   ctaLabel="Create cron job"
                   onCta={() => setCreateOpen(true)}
                 />

--- a/panel-ui/src/shells/admin/database-users/DatabaseUserDrawer.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUserDrawer.tsx
@@ -2,6 +2,7 @@
 // /database-users/create page route). On success the reveal-once
 // password modal is shown — the form drawer closes first so the
 // modal isn't trapped inside it.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Button, Drawer, Form, Grid, Input, Segmented, Space, message } from "antd";
 
@@ -22,6 +23,7 @@ export const DatabaseUserDrawer = ({
   onClose,
   onCreated,
 }: DatabaseUserDrawerProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<CreateInput>();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -59,7 +61,7 @@ export const DatabaseUserDrawer = ({
   return (
     <>
       <Drawer
-        title="Create database user"
+        title={t("databaseuserdrawer.create_database_user")}
         open={open}
         onClose={onClose}
         width={isDesktop ? 480 : undefined}
@@ -68,12 +70,12 @@ export const DatabaseUserDrawer = ({
       >
         <Form<CreateInput> form={form} layout="vertical" onFinish={onFinish} initialValues={{ engine: "mariadb" }}>
           {postgresEnabled && (
-            <Form.Item label="Engine" name="engine" tooltip="MariaDB is the default. PostgreSQL must be enabled in Server Settings.">
+            <Form.Item label={t("databaseuserdrawer.engine")} name="engine" tooltip={t("databaseuserdrawer.mariadb_is_the_default_postgresql_must_be_en")}>
               <Segmented options={[{ label: "MariaDB", value: "mariadb" }, { label: "PostgreSQL", value: "postgres" }]} />
             </Form.Item>
           )}
           <Form.Item
-            label="Username"
+            label={t("databaseuserdrawer.username")}
             name="username"
             rules={[
               { required: true, message: "Username is required" },
@@ -83,7 +85,7 @@ export const DatabaseUserDrawer = ({
                   "Lowercase letters, digits and underscores only; must start with a letter; max 30 chars",
               },
             ]}
-            tooltip="The final MariaDB username will be your panel username plus an underscore plus this value (e.g. alice_api)."
+            tooltip={t("databaseuserdrawer.the_final_mariadb_username_will_be_your_pane")}
             extra="Your username will be prepended automatically."
           >
             <Input placeholder="e.g. api" autoComplete="off" />
@@ -104,7 +106,7 @@ export const DatabaseUserDrawer = ({
         open={revealed !== null}
         username={revealed?.username ?? ""}
         password={revealed?.password ?? ""}
-        title="Database user created"
+        title={t("databaseuserdrawer.database_user_created")}
         onClose={() => setRevealed(null)}
       />
     </>

--- a/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
@@ -5,6 +5,7 @@
 // × that revokes just that grant. Row-level actions are Add Access
 // (open AddGrantModal), Password (rotate + reveal modal), and Delete
 // (drops the whole user, cascading all grants).
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { Button, Card, Space, Table, Tag, Typography, message } from "antd";
@@ -71,6 +72,7 @@ function grantLabel(grant: Grant): string {
 }
 
 export const DatabaseUsersList = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const query = useTableURL<DatabaseUser>({
     resource: "database-users",
@@ -176,7 +178,7 @@ export const DatabaseUsersList = () => {
         >
           <Table.Column<DatabaseUser>
             dataIndex="username"
-            title="User"
+            title={t("databaseuserslist.user")}
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
             {...columnSearchProps<DatabaseUser>({
@@ -194,7 +196,7 @@ export const DatabaseUsersList = () => {
           />
           <Table.Column<DatabaseUser>
             dataIndex="engine"
-            title="Engine"
+            title={t("databaseuserslist.engine")}
             key="engine"
             sorter={{ multiple: 1 }}
             width={140}
@@ -203,7 +205,7 @@ export const DatabaseUsersList = () => {
             )}
           />
           <Table.Column<DatabaseUser>
-            title="Database Privileges"
+            title={t("databaseuserslist.database_privileges")}
             dataIndex="grants"
             render={(grants: Grant[] | undefined) => {
               if (!grants || grants.length === 0) {
@@ -242,13 +244,13 @@ export const DatabaseUsersList = () => {
           />
           <Table.Column<DatabaseUser>
             dataIndex="created_at"
-            title="Created"
+            title={t("databaseuserslist.created")}
             sorter={{ multiple: 2 }}
             render={(date: string) => shortDateTime(date)}
             width={120}
           />
           <Table.Column<DatabaseUser>
-            title="Actions"
+            title={t("databaseuserslist.actions")}
             dataIndex="actions"
             width={180}
             render={(_, row) => (

--- a/panel-ui/src/shells/admin/databases/DatabaseCreate.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseCreate.tsx
@@ -2,6 +2,7 @@
 // name segment — non-admin users get their username auto-prefixed
 // on the server (see panel-api/internal/api/databases.go). Admins
 // create without a prefix. The helper text reflects that distinction.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Form, Input, Typography, message } from "antd";
 import { useNavigate } from "react-router";
 
@@ -14,6 +15,7 @@ type DatabaseCreateInput = {
 type DatabaseCreated = { id: string };
 
 export const DatabaseCreate = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [form] = Form.useForm<DatabaseCreateInput>();
   const createMutation = useCreateMutation<DatabaseCreated, DatabaseCreateInput>({
@@ -43,7 +45,7 @@ export const DatabaseCreate = () => {
         onFinish={handleFinish}
       >
         <Form.Item
-          label="Name"
+          label={t("databasecreate.name")}
           name="name"
           rules={[
             { required: true, message: "Database name is required" },
@@ -53,7 +55,7 @@ export const DatabaseCreate = () => {
                 "Lowercase letters, digits and underscores only; must start with a letter; max 30 chars",
             },
           ]}
-          tooltip="Admins create databases without a username prefix. When a non-admin user creates one, the server prepends their username automatically (e.g. `alice_wp`)."
+          tooltip={t("databasecreate.admins_create_databases_without_a_username_p")}
         >
           <Input placeholder="e.g. wp_prod" autoComplete="off" />
         </Form.Item>

--- a/panel-ui/src/shells/admin/databases/DatabaseList.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseList.tsx
@@ -1,6 +1,7 @@
 // DatabaseList — admin view. Currently unrouted (no /jabali-admin/
 // databases mount in App.tsx) but kept Refine-free so a future route
 // wire-up doesn't have to touch this file again.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Space, Table, Tag, Typography } from "antd";
 import { shortDateTime } from "../../../utils/datetime";
 import { useNavigate } from "react-router";
@@ -30,6 +31,7 @@ const engineColorMap: Record<string, string> = {
 };
 
 export const DatabaseList = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const query = useTableURL<Database>({
     resource: "databases",
@@ -96,7 +98,7 @@ export const DatabaseList = () => {
           locale={{
             emptyText: (
               <EmptyWithCTA
-                description="No databases yet"
+                description={t("databaselist.no_databases_yet")}
                 ctaLabel="Create database"
                 onCta={() => navigate("/jabali-admin/databases/create")}
               />
@@ -105,7 +107,7 @@ export const DatabaseList = () => {
         >
           <Table.Column<Database>
             dataIndex="name"
-            title="Database"
+            title={t("databaselist.database")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -117,29 +119,29 @@ export const DatabaseList = () => {
           />
           <Table.Column<Database>
             dataIndex="user_id"
-            title="User ID"
+            title={t("databaselist.user_id")}
             render={(value: string) => value.substring(0, 8)}
           />
           <Table.Column<Database>
             dataIndex="engine"
-            title="Engine"
+            title={t("databaselist.engine")}
             render={(engine: string) => (
               <Tag color={engineColorMap[engine] || "default"}>{engine}</Tag>
             )}
           />
           <Table.Column<Database>
             dataIndex="charset"
-            title="Charset"
+            title={t("databaselist.charset")}
           />
           <Table.Column<Database>
             dataIndex="created_at"
-            title="Created"
+            title={t("databaselist.created")}
             key="created_at"
             sorter={{ multiple: 2 }}
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<Database>
-            title="Actions"
+            title={t("databaselist.actions")}
             dataIndex="actions"
             render={(_, r) => (
               <Space>

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -3,6 +3,7 @@
 // + DS export). Mirrors the UserList tab style — a count Tag in each
 // label, controlled activeTabKey, panel-attached strip. Both tabs
 // view the same `domains` list so the badge total matches on both.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Alert, Button, Card, Spin, Table, Tag, Tooltip, Typography } from "antd";
@@ -34,6 +35,7 @@ interface ZoneStatus {
 }
 
 const ZonesTab = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [zoneStatuses, setZoneStatuses] = useState<Map<string, ZoneStatus>>(
     new Map(),
@@ -87,7 +89,7 @@ const ZonesTab = () => {
   return (
     <>
       <Alert
-        title="DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings."
+        title={t("dnszonesoverviewpage.dns_zones_are_provisioned_automatically_when")}
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
@@ -95,7 +97,7 @@ const ZonesTab = () => {
       {query.isLoading ? (
         <Spin />
       ) : query.items.length === 0 ? (
-        <EmptyWithCTA description="No DNS zones yet — create a domain to manage its DNS" ctaLabel="Create domain" onCta={() => navigate("/jabali-admin/domains/create")} />
+        <EmptyWithCTA description={t("dnszonesoverviewpage.no_dns_zones_yet_create_a_domain_to_manage_i")} ctaLabel="Create domain" onCta={() => navigate("/jabali-admin/domains/create")} />
       ) : (
         <SearchableTableStringQ<Domain>
           rowKey="id"
@@ -113,7 +115,7 @@ const ZonesTab = () => {
         >
           <Table.Column<Domain>
             dataIndex="name"
-            title="Domain Name"
+            title={t("dnszonesoverviewpage.domain_name")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -125,7 +127,7 @@ const ZonesTab = () => {
           />
           <Table.Column<Domain>
             dataIndex="username"
-            title="Owner"
+            title={t("dnszonesoverviewpage.owner")}
             key="username"
             sorter={{ multiple: 1 }}
             render={(username: string | null | undefined, record: Domain) =>
@@ -133,11 +135,11 @@ const ZonesTab = () => {
             }
           />
           <Table.Column<Domain>
-            title="Zone Status"
+            title={t("dnszonesoverviewpage.zone_status")}
             render={(_, record) => getZoneStatusTag(record.id)}
           />
           <Table.Column<Domain>
-            title="Records"
+            title={t("dnszonesoverviewpage.records")}
             render={(_, record) => {
               const s = zoneStatuses.get(record.id);
               if (s === undefined) return <Spin size="small" />;
@@ -145,7 +147,7 @@ const ZonesTab = () => {
             }}
           />
           <Table.Column<Domain>
-            title="TTL"
+            title={t("dnszonesoverviewpage.ttl")}
             render={(_, record) => {
               const s = zoneStatuses.get(record.id);
               if (s === undefined) return <Spin size="small" />;
@@ -153,18 +155,18 @@ const ZonesTab = () => {
             }}
           />
           <Table.Column<Domain>
-            title="DNSSEC"
+            title={t("dnszonesoverviewpage.dnssec")}
             dataIndex="dnssec_enabled"
             render={(enabled: boolean | undefined) =>
               enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
             }
           />
           <Table.Column<Domain>
-            title="Expiration"
+            title={t("dnszonesoverviewpage.expiration")}
             dataIndex="registrar_expires_at"
             render={(d: string | null | undefined) =>
               d ? (
-                <Tooltip title="Domain registration expiry (from WHOIS)">
+                <Tooltip title={t("dnszonesoverviewpage.domain_registration_expiry_from_whois")}>
                   {new Date(d).toLocaleDateString()}
                 </Tooltip>
               ) : (
@@ -173,7 +175,7 @@ const ZonesTab = () => {
             }
           />
           <Table.Column<Domain>
-            title="Actions"
+            title={t("dnszonesoverviewpage.actions")}
             render={(_, record) => (
               <Button
                 type="primary"

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -1,5 +1,6 @@
 // AdminDockerAppsPage — landing page for the M48 marketplace.
 // Two tabs: Catalog (browse + install) and Installed (lifecycle).
+import { useTranslation } from "react-i18next";
 import { Alert, App, Avatar, Button, Col, Drawer, Empty, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -51,6 +52,7 @@ const STATUS_COLOR: Record<string, string> = {
 };
 
 export const AdminDockerAppsPage = () => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const { mode } = useThemeMode();
   const qc = useQueryClient();
@@ -168,14 +170,14 @@ export const AdminDockerAppsPage = () => {
                       <Col xs={24} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
-                          label="Installed Apps" value={installedCount}
+                          label={t("admindockerappspage.installed_apps")} value={installedCount}
                           subtitle={<Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>}
                         />
                       </Col>
                       <Col xs={24} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(114, 46, 209, 0.12)" iconColor="#722ed1" Icon={SyncOutlined}
-                          label="Updates Available" value={updateCount}
+                          label={t("admindockerappspage.updates_available")} value={updateCount}
                           subtitle={updateCount > 0
                             ? <Typography.Text type="warning">Needs attention</Typography.Text>
                             : <Typography.Text type="secondary">Up to date</Typography.Text>}
@@ -184,14 +186,14 @@ export const AdminDockerAppsPage = () => {
                       <Col xs={24} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={PlayCircleOutlined}
-                          label="Running" value={runningCount}
+                          label={t("admindockerappspage.running")} value={runningCount}
                           subtitle={<Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>}
                         />
                       </Col>
                       <Col xs={24} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={PauseCircleOutlined}
-                          label="Stopped" value={stoppedCount}
+                          label={t("admindockerappspage.stopped")} value={stoppedCount}
                           subtitle={<Typography.Text type="secondary">{pct(stoppedCount)}% of installed</Typography.Text>}
                         />
                       </Col>
@@ -200,7 +202,7 @@ export const AdminDockerAppsPage = () => {
                 })()}
               <Input.Search
                 allowClear
-                placeholder="Search by name"
+                placeholder={t("admindockerappspage.search_by_name")}
                 value={installedSearch}
                 onChange={(e) => setInstalledSearch(e.target.value)}
                 style={{ marginBottom: 16, maxWidth: 360 }}
@@ -228,7 +230,7 @@ export const AdminDockerAppsPage = () => {
                   emptyText: (
                     <Empty
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      description="No installed apps yet"
+                      description={t("admindockerappspage.no_installed_apps_yet")}
                     >
                       <Button type="primary" onClick={() => setActiveTab("catalog")}>
                         Browse Catalog
@@ -473,7 +475,7 @@ export const AdminDockerAppsPage = () => {
         onClose={() => setBackupsAppId(null)}
       />
       <Drawer
-        title="Credentials"
+        title={t("admindockerappspage.credentials")}
         open={credsAppId !== null}
         onClose={() => setCredsAppId(null)}
         width={760}

--- a/panel-ui/src/shells/admin/docker-apps/BackupsDrawer.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/BackupsDrawer.tsx
@@ -3,6 +3,7 @@
 // (JABALI_RESTIC_REPO + JABALI_RESTIC_PASSWORD on the agent
 // service unit); a 503 from the backend means the operator hasn't
 // configured them yet.
+import { useTranslation } from "react-i18next";
 import { Alert, App, Button, Drawer, Popconfirm, Space, Table, Tag, Typography } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export const BackupsDrawer = ({ open, appId, onClose }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
 
@@ -55,7 +57,7 @@ export const BackupsDrawer = ({ open, appId, onClose }: Props) => {
     <Drawer
       open={open}
       onClose={onClose}
-      title="Backups"
+      title={t("backupsdrawer.backups")}
       width="min(100%, 760px)"
       destroyOnClose
       extra={
@@ -68,7 +70,7 @@ export const BackupsDrawer = ({ open, appId, onClose }: Props) => {
         <Alert
           type="info"
           showIcon
-          message="Phase 8.1: restic via env vars"
+          message={t("backupsdrawer.phase_8_1_restic_via_env_vars")}
           description={
             <>
               Operator must set <code>JABALI_RESTIC_REPO</code> and{" "}
@@ -117,9 +119,9 @@ export const BackupsDrawer = ({ open, appId, onClose }: Props) => {
               width: 130,
               render: (_, row) => (
                 <Popconfirm
-                  title="Restore this snapshot?"
-                  description="Container will be stopped, files restored, container brought back up."
-                  okText="Restore"
+                  title={t("backupsdrawer.restore_this_snapshot")}
+                  description={t("backupsdrawer.container_will_be_stopped_files_restored_con")}
+                  okText={t("backupsdrawer.restore")}
                   okButtonProps={{ danger: true, loading: restore.isPending }}
                   onConfirm={() => restore.mutate(row.id)}
                 >

--- a/panel-ui/src/shells/admin/docker-apps/EditDrawer.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/EditDrawer.tsx
@@ -3,6 +3,7 @@
 // the wire-level knobs (domain + per-port enabled/bind/host_port/
 // reverse_proxy). Backend gates port + domain edits on `status =
 // stopped` and re-renders the compose + re-dispatches the agent.
+import { useTranslation } from "react-i18next";
 import { Alert, App, Divider, Drawer, Form, Input, InputNumber, Select, Space, Switch, Table, Typography } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
@@ -34,6 +35,7 @@ interface FormValues {
 }
 
 export const EditDrawer = ({ open, app, onClose }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const [form] = Form.useForm<FormValues>();
@@ -239,12 +241,12 @@ export const EditDrawer = ({ open, app, onClose }: Props) => {
           type="warning"
           showIcon
           style={{ marginBottom: 16 }}
-          message="Stop the container before editing ports or domain"
-          description="Limits + update mode can still be saved; ports/domain edits will return 409 conflict while the container is running."
+          message={t("editdrawer.stop_the_container_before_editing_ports_or_d")}
+          description={t("editdrawer.limits_update_mode_can_still_be_saved_ports")}
         />
       )}
       <Form layout="vertical" form={form} onFinish={(v) => patch.mutate(v)}>
-        <Form.Item label="Update mode" name="update_mode">
+        <Form.Item label={t("editdrawer.update_mode")} name="update_mode">
           <Select
             options={[
               { value: "manual", label: "Manual" },
@@ -253,12 +255,12 @@ export const EditDrawer = ({ open, app, onClose }: Props) => {
           />
         </Form.Item>
 
-        <Form.Item label="Domain" name="domain" tooltip="Pick from the panel's domains list. Leave empty to drop the managed-domain row.">
+        <Form.Item label={t("editdrawer.domain")} name="domain" tooltip={t("editdrawer.pick_from_the_panel_s_domains_list_leave_emp")}>
           <Select
             showSearch
             allowClear
             disabled={running}
-            placeholder="Select a domain"
+            placeholder={t("editdrawer.select_a_domain")}
             optionFilterProp="label"
             options={(domainsQ.data ?? []).map((d) => ({ value: d.name, label: d.name }))}
             loading={domainsQ.isLoading}
@@ -266,13 +268,13 @@ export const EditDrawer = ({ open, app, onClose }: Props) => {
         </Form.Item>
 
         <Space size="middle" style={{ width: "100%" }}>
-          <Form.Item label="CPU" name="cpu_limit" style={{ flex: 1 }} extra={cpuCapNote}>
+          <Form.Item label={t("editdrawer.cpu")} name="cpu_limit" style={{ flex: 1 }} extra={cpuCapNote}>
             <Input placeholder="0.5" />
           </Form.Item>
-          <Form.Item label="Memory" name="memory_limit" style={{ flex: 1 }}>
+          <Form.Item label={t("editdrawer.memory")} name="memory_limit" style={{ flex: 1 }}>
             <Input placeholder="256m" />
           </Form.Item>
-          <Form.Item label="PIDs" name="pids_limit" style={{ flex: 1 }}>
+          <Form.Item label={t("editdrawer.pids")} name="pids_limit" style={{ flex: 1 }}>
             <InputNumber min={1} max={65535} style={{ width: "100%" }} />
           </Form.Item>
         </Space>

--- a/panel-ui/src/shells/admin/docker-apps/EnvSection.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/EnvSection.tsx
@@ -3,6 +3,7 @@
 // secrets, lets you edit a value, and regenerate a generated secret. Apply
 // re-renders the compose and recreates the container, so it has its own
 // action independent of the ports/limits Save above it.
+import { useTranslation } from "react-i18next";
 import { App, Button, Input, Popconfirm, Space, Table, Tooltip, Typography } from "antd";
 import { CopyOutlined, EyeInvisibleOutlined, EyeOutlined, ReloadOutlined } from "@ant-design/icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -17,6 +18,7 @@ interface Props {
 }
 
 export const EnvSection = ({ appId, active }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const [edits, setEdits] = useState<Record<string, string>>({});
@@ -74,9 +76,9 @@ export const EnvSection = ({ appId, active }: Props) => {
           Environment
         </Typography.Title>
         <Popconfirm
-          title="Recreate the container?"
-          description="Saving applies the new values by recreating the container (brief downtime)."
-          okText="Save & recreate"
+          title={t("envsection.recreate_the_container")}
+          description={t("envsection.saving_applies_the_new_values_by_recreating")}
+          okText={t("envsection.save_recreate")}
           disabled={!dirty}
           onConfirm={() => save.mutate()}
         >
@@ -128,7 +130,7 @@ export const EnvSection = ({ appId, active }: Props) => {
                       />
                     </Tooltip>
                   )}
-                  <Tooltip title="Copy">
+                  <Tooltip title={t("envsection.copy")}>
                     <Button icon={<CopyOutlined />} onClick={() => copy(editing ? edits[r.name] : v)} />
                   </Tooltip>
                 </Space.Compact>
@@ -143,8 +145,8 @@ export const EnvSection = ({ appId, active }: Props) => {
               r.generated ? (
                 <Popconfirm
                   title={`Regenerate ${r.name}?`}
-                  description="Mints a new secret and recreates the container."
-                  okText="Regenerate"
+                  description={t("envsection.mints_a_new_secret_and_recreates_the_contain")}
+                  okText={t("envsection.regenerate")}
                   onConfirm={() => regen.mutate(r.name)}
                 >
                   <Button size="small" icon={<ReloadOutlined />} loading={regen.isPending && regen.variables === r.name}>

--- a/panel-ui/src/shells/admin/docker-apps/ExecDrawer.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/ExecDrawer.tsx
@@ -1,6 +1,7 @@
 // ExecDrawer — admin-only one-shot exec into the app's container.
 // Not a TTY/shell; pipe one command at a time. Bidi shell over
 // websocket is queued as a follow-up.
+import { useTranslation } from "react-i18next";
 import { Alert, App, Button, Drawer, Input, Space, Typography } from "antd";
 import { useState } from "react";
 
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export const ExecDrawer = ({ open, appId, onClose }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [command, setCommand] = useState("");
   const [busy, setBusy] = useState(false);
@@ -35,7 +37,7 @@ export const ExecDrawer = ({ open, appId, onClose }: Props) => {
     <Drawer
       open={open}
       onClose={onClose}
-      title="Exec command"
+      title={t("execdrawer.exec_command")}
       width="min(100%, 720px)"
       destroyOnClose
     >
@@ -43,8 +45,8 @@ export const ExecDrawer = ({ open, appId, onClose }: Props) => {
         <Alert
           type="warning"
           showIcon
-          message="Admin-only"
-          description="Runs `sh -c <command>` in the first service of the compose project. No TTY, no shell history. Use one command at a time."
+          message={t("execdrawer.admin_only")}
+          description={t("execdrawer.runs_sh_c_command_in_the_first_service_of_th")}
         />
         <Input.TextArea
           rows={3}

--- a/panel-ui/src/shells/admin/docker-apps/InstallDrawer.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/InstallDrawer.tsx
@@ -2,6 +2,7 @@
 // request. Renders one editable row per catalog-declared port so the
 // admin can flip Enabled / Bind / Host port / Reverse-proxy before
 // committing. See ADR-0116 Decision 5.
+import { useTranslation } from "react-i18next";
 import { Alert, App, Button, Drawer, Form, Input, InputNumber, Select, Space, Switch, Table, Tag, Typography } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
@@ -26,6 +27,7 @@ interface PortRow extends InstallPortOverride {
 }
 
 export const InstallDrawer = ({ open, entry, onClose, onInstalled }: Props) => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const destsQ = useQuery({
@@ -242,7 +244,7 @@ export const InstallDrawer = ({ open, entry, onClose, onInstalled }: Props) => {
             showIcon
           />
           <Form.Item
-            label="Install name"
+            label={t("installdrawer.install_name")}
             name="name"
             rules={[
               { required: true, message: "Name is required" },
@@ -258,25 +260,25 @@ export const InstallDrawer = ({ open, entry, onClose, onInstalled }: Props) => {
                 },
               },
             ]}
-            tooltip="Per-install identifier. Combined with the catalog slug to form a unique data root + container name, so the same catalog app can be installed multiple times side-by-side."
+            tooltip={t("installdrawer.per_install_identifier_combined_with_the_cat")}
           >
             <Input placeholder="e.g. vault-prod" />
           </Form.Item>
           <Form.Item
-            label="Domain"
+            label={t("installdrawer.domain")}
             name="domain"
-            tooltip="Hostname to attach to the loopback-bound port via nginx. Pick from the panel's domains list -- a vhost gets auto-rendered on save."
+            tooltip={t("installdrawer.hostname_to_attach_to_the_loopback_bound_por")}
           >
             <Select
               showSearch
               allowClear
-              placeholder="Select a domain"
+              placeholder={t("installdrawer.select_a_domain")}
               optionFilterProp="label"
               options={(domainsQ.data ?? []).map((d) => ({ value: d.name, label: d.name }))}
               loading={domainsQ.isLoading}
             />
           </Form.Item>
-          <Form.Item label="Update mode" name="update_mode">
+          <Form.Item label={t("installdrawer.update_mode")} name="update_mode">
             <Select
               options={[
                 { value: "manual", label: "Manual" },
@@ -285,25 +287,25 @@ export const InstallDrawer = ({ open, entry, onClose, onInstalled }: Props) => {
             />
           </Form.Item>
           <Space size="middle" style={{ width: "100%" }}>
-            <Form.Item label="CPU" name="cpu_limit" style={{ flex: 1 }} extra={cpuCapNote}>
+            <Form.Item label={t("installdrawer.cpu")} name="cpu_limit" style={{ flex: 1 }} extra={cpuCapNote}>
               <Input placeholder="0.5" />
             </Form.Item>
-            <Form.Item label="Memory" name="memory_limit" style={{ flex: 1 }}>
+            <Form.Item label={t("installdrawer.memory")} name="memory_limit" style={{ flex: 1 }}>
               <Input placeholder="256m" />
             </Form.Item>
-            <Form.Item label="PIDs" name="pids_limit" style={{ flex: 1 }}>
+            <Form.Item label={t("installdrawer.pids")} name="pids_limit" style={{ flex: 1 }}>
               <InputNumber min={1} max={65535} style={{ width: "100%" }} />
             </Form.Item>
           </Space>
 
           <Form.Item
-            label="Backup destination"
+            label={t("installdrawer.backup_destination")}
             name="backup_destination_id"
-            tooltip="Pick a destination from Server Settings -> Backups. Leave empty to fall back to JABALI_RESTIC_REPO env vars (Phase 8.1)."
+            tooltip={t("installdrawer.pick_a_destination_from_server_settings_back")}
           >
             <Select
               allowClear
-              placeholder="Inherit env-var fallback"
+              placeholder={t("installdrawer.inherit_env_var_fallback")}
               options={(destsQ.data ?? []).map((d) => ({
                 value: d.id,
                 label: `${d.name} (${d.kind})`,

--- a/panel-ui/src/shells/admin/docker-apps/MaintenanceTab.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/MaintenanceTab.tsx
@@ -1,6 +1,7 @@
 // Maintenance tab — reclaim disk + sweep stale containers / images /
 // volumes / build cache. Backed by docker.disk_usage + docker.prune
 // agent verbs (see panel-agent/internal/commands/docker_lifecycle.go).
+import { useTranslation } from "react-i18next";
 import { App, Button, Card, Col, Modal, Row, Space, Statistic, Switch, Typography } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -34,6 +35,7 @@ function fmtBytes(n: number): string {
 }
 
 export const MaintenanceTab = () => {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const [pruneAll, setPruneAll] = useState(false);
@@ -93,23 +95,23 @@ export const MaintenanceTab = () => {
   return (
     <div>
       <DockerEngineCard />
-      <Card title="Disk usage" loading={usage.isLoading} style={{ marginBottom: 16 }}>
+      <Card title={t("maintenancetab.disk_usage")} loading={usage.isLoading} style={{ marginBottom: 16 }}>
         <Row gutter={[16, 16]}>
           <Col xs={12} sm={6}>
-            <Statistic title="Images" value={fmtBytes(usage.data?.images_bytes ?? 0)} />
+            <Statistic title={t("maintenancetab.images")} value={fmtBytes(usage.data?.images_bytes ?? 0)} />
           </Col>
           <Col xs={12} sm={6}>
-            <Statistic title="Containers" value={fmtBytes(usage.data?.containers_bytes ?? 0)} />
+            <Statistic title={t("maintenancetab.containers")} value={fmtBytes(usage.data?.containers_bytes ?? 0)} />
           </Col>
           <Col xs={12} sm={6}>
-            <Statistic title="Volumes" value={fmtBytes(usage.data?.volumes_bytes ?? 0)} />
+            <Statistic title={t("maintenancetab.volumes")} value={fmtBytes(usage.data?.volumes_bytes ?? 0)} />
           </Col>
           <Col xs={12} sm={6}>
-            <Statistic title="Build cache" value={fmtBytes(usage.data?.build_cache_bytes ?? 0)} />
+            <Statistic title={t("maintenancetab.build_cache")} value={fmtBytes(usage.data?.build_cache_bytes ?? 0)} />
           </Col>
           <Col span={24}>
             <Statistic
-              title="Reclaimable"
+              title={t("maintenancetab.reclaimable")}
               valueStyle={{ color: (usage.data?.reclaimable_bytes ?? 0) > 0 ? "#cf1322" : undefined }}
               value={fmtBytes(usage.data?.reclaimable_bytes ?? 0)}
             />
@@ -117,7 +119,7 @@ export const MaintenanceTab = () => {
         </Row>
       </Card>
 
-      <Card title="Prune">
+      <Card title={t("maintenancetab.prune")}>
         <Typography.Paragraph type="secondary">
           Frees disk by removing what docker considers unused. Toggle to control how aggressive.
         </Typography.Paragraph>

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -3,6 +3,7 @@
 // Intentionally thin: name + user id + optional doc root. The server
 // auto-generates doc_root when blank. Post-M21: Form.useForm +
 // useCreateMutation, no Refine wrappers.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Checkbox, Form, Input, Select, Typography, message } from "antd";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
@@ -24,6 +25,7 @@ export type DomainCreateInput = {
 type DomainCreated = { id: string };
 
 export const DomainCreate = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [form] = Form.useForm<DomainCreateInput>();
   const mailProvider = Form.useWatch("mail_provider", form) ?? "jabali";
@@ -63,7 +65,7 @@ export const DomainCreate = () => {
         onFinish={handleFinish}
       >
         <Form.Item
-          label="Name"
+          label={t("domaincreate.name")}
           name="name"
           rules={[
             { required: true, message: "Domain name is required" },
@@ -78,13 +80,13 @@ export const DomainCreate = () => {
         </Form.Item>
 
         <Form.Item
-          label="User"
+          label={t("domaincreate.user")}
           name="user_id"
           rules={[{ required: true, message: "User is required" }]}
         >
           <Select
             showSearch
-            placeholder="Select a user"
+            placeholder={t("domaincreate.select_a_user")}
             optionFilterProp="label"
             loading={usersQ.isLoading}
             options={(usersQ.data ?? []).map((u) => ({
@@ -95,18 +97,18 @@ export const DomainCreate = () => {
         </Form.Item>
 
         <Form.Item
-          label="Doc Root"
+          label={t("domaincreate.doc_root")}
           name="doc_root"
-          tooltip="Leave empty for auto-generated path"
+          tooltip={t("domaincreate.leave_empty_for_auto_generated_path")}
         >
           <Input placeholder="auto-generated if empty" />
         </Form.Item>
 
         <Form.Item
-          label="Mail"
+          label={t("domaincreate.mail")}
           name="mail_provider"
           initialValue="jabali"
-          tooltip="Where this domain's email is hosted. 'None' and the external providers skip Jabali's mail DNS records and mail certificate SANs."
+          tooltip={t("domaincreate.where_this_domain_s_email_is_hosted_none_and")}
         >
           <Select
             options={[
@@ -120,9 +122,9 @@ export const DomainCreate = () => {
 
         {mailProvider === "m365" && (
           <Form.Item
-            label="Microsoft 365 tenant"
+            label={t("domaincreate.microsoft_365_tenant")}
             name="m365_onmicrosoft"
-            tooltip="Optional. Your <tenant>.onmicrosoft.com — adds the selector1/2 DKIM CNAMEs. MX/SPF/autodiscover are added automatically."
+            tooltip={t("domaincreate.optional_your_tenant_onmicrosoft_com_adds_th")}
           >
             <Input placeholder="contoso.onmicrosoft.com (optional)" />
           </Form.Item>
@@ -130,19 +132,19 @@ export const DomainCreate = () => {
 
         {mailProvider === "google" && (
           <Form.Item
-            label="Google DKIM value"
+            label={t("domaincreate.google_dkim_value")}
             name="google_dkim"
-            tooltip="Optional. Paste the google._domainkey TXT value from Google Admin. MX/SPF are added automatically."
+            tooltip={t("domaincreate.optional_paste_the_google_domainkey_txt_valu")}
           >
             <Input.TextArea rows={2} placeholder="v=DKIM1; k=rsa; p=... (optional)" />
           </Form.Item>
         )}
 
         <Form.Item
-          label="TLS certificate"
+          label={t("domaincreate.tls_certificate")}
           name="ssl_mode"
           initialValue="le"
-          tooltip="Let's Encrypt (recommended), self-signed, or none (HTTP only). Custom certs are uploaded after create from the domain's SSL settings."
+          tooltip={t("domaincreate.let_s_encrypt_recommended_self_signed_or_non")}
         >
           <Select
             options={[
@@ -157,7 +159,7 @@ export const DomainCreate = () => {
           name="create_www"
           valuePropName="checked"
           initialValue={false}
-          tooltip="Adds a www CNAME pointing at the domain apex. Off by default — leave unchecked for subdomains or domains that don't serve a www host."
+          tooltip={t("domaincreate.adds_a_www_cname_pointing_at_the_domain_apex")}
         >
           <Checkbox>Create www record</Checkbox>
         </Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainDeliverabilitySection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainDeliverabilitySection.tsx
@@ -4,6 +4,7 @@
 // RBL stays server-wide (the IP is shared across all hosted domains)
 // so it's omitted from the per-domain view; the operator sees it on
 // the server-wide /jabali-admin/mail/deliverability page.
+import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { Alert, Card, Descriptions, Progress, Skeleton, Tag, Typography } from "antd";
 
@@ -33,6 +34,7 @@ const severityColour: Record<ScoreResponse["severity"], string> = {
 type Props = { domainName: string };
 
 export const DomainDeliverabilitySection = ({ domainName }: Props) => {
+  const { t } = useTranslation();
   const { data, isLoading, error } = useQuery({
     queryKey: ["admin", "mail", "deliverability", domainName],
     queryFn: async () =>
@@ -43,7 +45,7 @@ export const DomainDeliverabilitySection = ({ domainName }: Props) => {
 
   if (isLoading) return <Skeleton active />;
   if (error || !data) {
-    return <Alert type="warning" message="Deliverability score unavailable for this domain" />;
+    return <Alert type="warning" message={t("domaindeliverabilitysection.deliverability_score_unavailable_for_this_do")} />;
   }
   // Filter out the rbl component server-side returns even with ?domain= set
   // (RBL is server-wide; the handler already skips it when domain is set,
@@ -51,7 +53,7 @@ export const DomainDeliverabilitySection = ({ domainName }: Props) => {
   const components = data.components.filter((c) => c.name !== "rbl");
 
   return (
-    <Card title="Deliverability score" size="small">
+    <Card title={t("domaindeliverabilitysection.deliverability_score")} size="small">
       <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 16 }}>
         <Progress
           type="circle"

--- a/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
@@ -3,6 +3,7 @@
 // custom realm; the expanded row holds the per-rule credentials (bcrypt
 // hashed at the API, never read back). Rule-creation form collects the
 // first credential too so newly-added rules ship with a working login.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -46,6 +47,7 @@ export const DomainDirectoryPrivacySection = ({
   domainId,
   domainName,
 }: Props) => {
+  const { t } = useTranslation();
   const { data, isLoading } = useDirectoryPrivacyRules(domainId);
   const createRule = useCreateDirectoryPrivacyRule(domainId);
   const deleteRule = useDeleteDirectoryPrivacyRule(domainId);
@@ -110,7 +112,7 @@ export const DomainDirectoryPrivacySection = ({
       <Alert
         type="info"
         showIcon
-        message="Per-directory password protection"
+        message={t("domaindirectoryprivacysection.per_directory_password_protection")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             Lock a subdirectory of this domain behind HTTP Basic Auth.{" "}
@@ -138,12 +140,12 @@ export const DomainDirectoryPrivacySection = ({
         }}
       >
         <Table.Column<DirectoryPrivacyRule>
-          title="Path"
+          title={t("domaindirectoryprivacysection.path")}
           dataIndex="path"
           render={(p: string) => <Typography.Text code>{p}</Typography.Text>}
         />
         <Table.Column<DirectoryPrivacyRule>
-          title="Authentication name"
+          title={t("domaindirectoryprivacysection.authentication_name")}
           dataIndex="realm"
         />
         <Table.Column<DirectoryPrivacyRule>
@@ -151,9 +153,9 @@ export const DomainDirectoryPrivacySection = ({
           width={80}
           render={(_, r) => (
             <Popconfirm
-              title="Delete this rule and all its credentials?"
+              title={t("domaindirectoryprivacysection.delete_this_rule_and_all_its_credentials")}
               onConfirm={() => onDeleteRule(r.id)}
-              okText="Delete"
+              okText={t("domaindirectoryprivacysection.delete")}
               okButtonProps={{ danger: true }}
             >
               <Button
@@ -175,9 +177,9 @@ export const DomainDirectoryPrivacySection = ({
           style={{ maxWidth: 520 }}
         >
           <Form.Item
-            label="Path"
+            label={t("domaindirectoryprivacysection.path")}
             name="path"
-            tooltip="Directory under the docroot to protect (e.g. /secret)."
+            tooltip={t("domaindirectoryprivacysection.directory_under_the_docroot_to_protect_e_g_s")}
             rules={[
               { required: true, message: "Required" },
               {
@@ -196,14 +198,14 @@ export const DomainDirectoryPrivacySection = ({
             />
           </Form.Item>
           <Form.Item
-            label="Authentication name"
+            label={t("domaindirectoryprivacysection.authentication_name")}
             name="realm"
-            tooltip="Label shown in the browser's Basic Auth popup."
+            tooltip={t("domaindirectoryprivacysection.label_shown_in_the_browser_s_basic_auth_popu")}
           >
             <Input placeholder={realmPlaceholder} />
           </Form.Item>
           <Form.Item
-            label="Username"
+            label={t("domaindirectoryprivacysection.username")}
             name="username"
             rules={[
               { required: true, message: "Required" },
@@ -216,7 +218,7 @@ export const DomainDirectoryPrivacySection = ({
             <Input placeholder="user" />
           </Form.Item>
           <Form.Item
-            label="Password"
+            label={t("domaindirectoryprivacysection.password")}
             name="password"
             rules={[
               { required: true, message: "Required" },
@@ -272,6 +274,7 @@ const DirectoryPrivacyCredentialsTable = ({
   domainId: string;
   ruleId: string;
 }) => {
+  const { t } = useTranslation();
   const { data, isLoading } = useDirectoryPrivacyCredentials(domainId, ruleId);
   const create = useCreateDirectoryPrivacyCredential(domainId, ruleId);
   const remove = useDeleteDirectoryPrivacyCredential(domainId, ruleId);
@@ -315,7 +318,7 @@ const DirectoryPrivacyCredentialsTable = ({
         }}
       >
         <Table.Column<DirectoryPrivacyCredential>
-          title="Username"
+          title={t("domaindirectoryprivacysection.username")}
           dataIndex="username"
         />
         <Table.Column<DirectoryPrivacyCredential>
@@ -323,9 +326,9 @@ const DirectoryPrivacyCredentialsTable = ({
           width={80}
           render={(_, c) => (
             <Popconfirm
-              title="Delete this user?"
+              title={t("domaindirectoryprivacysection.delete_this_user")}
               onConfirm={() => onDelete(c.id)}
-              okText="Delete"
+              okText={t("domaindirectoryprivacysection.delete")}
               okButtonProps={{ danger: true }}
             >
               <Button
@@ -345,7 +348,7 @@ const DirectoryPrivacyCredentialsTable = ({
           onFinish={onAdd}
         >
           <Form.Item
-            label="User"
+            label={t("domaindirectoryprivacysection.user")}
             name="username"
             rules={[
               { required: true, message: "Required" },
@@ -358,7 +361,7 @@ const DirectoryPrivacyCredentialsTable = ({
             <Input style={{ width: 160 }} />
           </Form.Item>
           <Form.Item
-            label="Password"
+            label={t("domaindirectoryprivacysection.password")}
             name="password"
             rules={[
               { required: true, message: "Required" },

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -2,6 +2,7 @@
 // Network / Security / Email so the page stops being a 1500px scroll. Each
 // tab owns one section component; General hosts the basic Form
 // (name/doc_root/enabled/custom directives + Save).
+import { useTranslation } from "react-i18next";
 import { useEffect } from "react";
 import {
   Alert,
@@ -44,6 +45,7 @@ export type DomainEditInput = {
 };
 
 export const DomainEdit = () => {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const qc = useQueryClient();
@@ -119,12 +121,12 @@ export const DomainEdit = () => {
 
   const generalTab = (
     <Form<DomainEditInput> form={form} layout="vertical" onFinish={handleFinish}>
-      <Form.Item label="Name">
+      <Form.Item label={t("domainedit.name")}>
         <Typography.Text>{domain.name}</Typography.Text>
       </Form.Item>
 
       <Form.Item
-        label="Doc Root"
+        label={t("domainedit.doc_root")}
         name="doc_root"
         extra="Must be under the owner's home directory. Changing it re-points the vhost on the next sync and creates the new directory — existing files are NOT moved. Leave blank to reset to the default public_html."
       >
@@ -290,7 +292,7 @@ export const DomainEdit = () => {
             type="info"
             showIcon
             style={{ marginBottom: 16 }}
-            message="Panel hostname domain (mail-only)"
+            message={t("domainedit.panel_hostname_domain_mail_only")}
             description={
               <>
                 This row backs the panel hostname's mail service (DKIM,

--- a/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
@@ -7,6 +7,7 @@
 // from the API's `records` hint list. Live record-presence status
 // is blueprint Step 5 scope (DNS autoconfig) — until then, hints
 // render as static instructions (empty `status` column).
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -47,6 +48,7 @@ async function copyText(text: string) {
 }
 
 export const DomainEmailSection = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const { data, isLoading } = useDomainEmail(domainId);
   const enableMutation = useEnableDomainEmail();
   const disableMutation = useDisableDomainEmail();
@@ -110,7 +112,7 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     return <Skeleton active paragraph={{ rows: 3 }} />;
   }
   if (!data) {
-    return <Alert type="error" showIcon title="Failed to load email state" />;
+    return <Alert type="error" showIcon title={t("domainemailsection.failed_to_load_email_state")} />;
   }
 
   const enabled = data.email_enabled;
@@ -148,16 +150,16 @@ export const DomainEmailSection = ({ domainId }: Props) => {
         <Alert
           type="error"
           showIcon
-          title="DKIM key missing"
-          description="Email is enabled but no DKIM public key is stored. Toggle off and back on to regenerate."
+          title={t("domainemailsection.dkim_key_missing")}
+          description={t("domainemailsection.email_is_enabled_but_no_dkim_public_key_is_s")}
         />
       )}
 
       {enabled && dkim && (
         <Popconfirm
-          title="Rotate DKIM key?"
-          description="A fresh DKIM keypair is generated and the DNS TXT record changes. Remote receivers may need propagation time before they accept the new signature; the old key is kept as a backup."
-          okText="Rotate"
+          title={t("domainemailsection.rotate_dkim_key")}
+          description={t("domainemailsection.a_fresh_dkim_keypair_is_generated_and_the_dn")}
+          okText={t("domainemailsection.rotate")}
           okButtonProps={{ danger: true }}
           onConfirm={onRotateDKIM}
         >
@@ -173,7 +175,7 @@ export const DomainEmailSection = ({ domainId }: Props) => {
         <Alert
           type="warning"
           showIcon
-          message="DNS autoconfig partially applied"
+          message={t("domainemailsection.dns_autoconfig_partially_applied")}
           description={
             <ul style={{ margin: 0, paddingInlineStart: 20 }}>
               {data.warnings.map((w) => (
@@ -185,7 +187,7 @@ export const DomainEmailSection = ({ domainId }: Props) => {
       )}
 
       {enabled && (
-        <Card size="small" title="DNS records">
+        <Card size="small" title={t("domainemailsection.dns_records")}>
           <Table<DomainEmailDNSHint>
             size="small"
             pagination={false}
@@ -229,7 +231,7 @@ export const DomainEmailSection = ({ domainId }: Props) => {
                         size="small"
                         icon={<CopyOutlined />}
                         onClick={() => copyText(value)}
-                        aria-label="Copy value"
+                        aria-label={t("domainemailsection.copy_value")}
                       />
                     </Space>
                   ) : (

--- a/panel-ui/src/shells/admin/domains/DomainIPACLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainIPACLSection.tsx
@@ -2,6 +2,7 @@
 // a table of existing rules (priority asc) with delete + an inline
 // add form. nginx interprets `allow` and `deny` directives top-down
 // inside the server block; lower priority = higher precedence.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -42,6 +43,7 @@ const ACTION_TAG: Record<ACLAction, { color: string; label: string }> = {
 };
 
 export const DomainIPACLSection = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const { data, isLoading } = useDomainIPACLs(domainId);
   const create = useCreateDomainIPACL(domainId);
   const remove = useDeleteDomainIPACL(domainId);
@@ -86,7 +88,7 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
       <Alert
         type="info"
         showIcon
-        message="Per-domain IP allow / deny"
+        message={t("domainipaclsection.per_domain_ip_allow_deny")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             Rules are evaluated by nginx top-down (lower priority = higher
@@ -106,12 +108,12 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
         locale={{ emptyText: "No rules — domain accepts all traffic." }}
       >
         <Table.Column<DomainIPACL>
-          title="Priority"
+          title={t("domainipaclsection.priority")}
           dataIndex="priority"
           width={80}
         />
         <Table.Column<DomainIPACL>
-          title="Action"
+          title={t("domainipaclsection.action")}
           dataIndex="action"
           width={100}
           render={(a: ACLAction) => {
@@ -120,12 +122,12 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
           }}
         />
         <Table.Column<DomainIPACL>
-          title="CIDR"
+          title={t("domainipaclsection.cidr")}
           dataIndex="cidr"
           render={(c: string) => <Typography.Text code>{c}</Typography.Text>}
         />
         <Table.Column<DomainIPACL>
-          title="Comment"
+          title={t("domainipaclsection.comment")}
           dataIndex="comment"
           render={(c: string) =>
             c ? (
@@ -140,9 +142,9 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
           width={80}
           render={(_, r) => (
             <Popconfirm
-              title="Delete this rule?"
+              title={t("domainipaclsection.delete_this_rule")}
               onConfirm={() => onDelete(r.id)}
-              okText="Delete"
+              okText={t("domainipaclsection.delete")}
               okButtonProps={{ danger: true }}
             >
               <Button
@@ -164,23 +166,23 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
           initialValues={{ action: "allow", priority: 100 }}
         >
           <Form.Item
-            label="CIDR"
+            label={t("domainipaclsection.cidr")}
             name="cidr"
             rules={[{ required: true, message: "Required" }]}
           >
             <Input placeholder="203.0.113.0/24" style={{ width: 180 }} />
           </Form.Item>
           <Form.Item
-            label="Action"
+            label={t("domainipaclsection.action")}
             name="action"
             rules={[{ required: true }]}
           >
             <Select options={ACTION_OPTIONS} style={{ width: 100 }} />
           </Form.Item>
-          <Form.Item label="Priority" name="priority">
+          <Form.Item label={t("domainipaclsection.priority")} name="priority">
             <InputNumber min={0} max={9999} style={{ width: 90 }} />
           </Form.Item>
-          <Form.Item label="Comment" name="comment">
+          <Form.Item label={t("domainipaclsection.comment")} name="comment">
             <Input style={{ width: 200 }} />
           </Form.Item>
           <Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -1,6 +1,7 @@
 // DomainList — admin domains grid. GH #351: Edit is the primary
 // always-visible row action (used far more than DNS); DNS moved into the
 // "..." overflow with Info/Redirects/Index/Settings/Caching/Toggle/Delete.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { Button, Card, Dropdown, Modal, Space, Table, Tag, Tooltip, Typography, notification } from "antd";
 import {
@@ -176,6 +177,7 @@ export type Domain = {
 };
 
 export const DomainList = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
   const [activeModal, setActiveModal] = useState<ActiveModal>(null);
@@ -295,7 +297,7 @@ export const DomainList = () => {
           locale={{
             emptyText: (
               <EmptyWithCTA
-                description="No domains yet"
+                description={t("domainlist.no_domains_yet")}
                 ctaLabel="Create domain"
                 onCta={() => navigate("create")}
               />
@@ -304,7 +306,7 @@ export const DomainList = () => {
         >
           <Table.Column<Domain>
             dataIndex="name"
-            title="Domain"
+            title={t("domainlist.domain")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -319,7 +321,7 @@ export const DomainList = () => {
           />
           <Table.Column<Domain>
             dataIndex="username"
-            title="User"
+            title={t("domainlist.user")}
             key="username"
             sorter={{ multiple: 1 }}
             render={(username: string | null | undefined, record: Domain) => (
@@ -330,7 +332,7 @@ export const DomainList = () => {
           />
           <Table.Column<Domain>
             dataIndex="is_enabled"
-            title="Status"
+            title={t("domainlist.status")}
             key="is_enabled"
             sorter={{ multiple: 1 }}
             render={(enabled: boolean) =>
@@ -343,20 +345,20 @@ export const DomainList = () => {
           />
           <Table.Column<Domain>
             dataIndex="ssl"
-            title="SSL"
+            title={t("domainlist.ssl")}
             render={(ssl: SSLBadge | null | undefined) => renderSSL(ssl)}
           />
           <Table.Column<Domain>
-            title="Redirect"
+            title={t("domainlist.redirect")}
             render={(_, record) => renderRedirect(record)}
           />
           <Table.Column<Domain>
             dataIndex="bytes_30d"
-            title="BW (30d)"
+            title={t("domainlist.bw_30d")}
             render={(v: number | undefined) => humanBytes(v ?? 0)}
           />
           <Table.Column<Domain>
-            title="Actions"
+            title={t("domainlist.actions")}
             dataIndex="actions"
             render={(_, r) => (
               <Space>
@@ -436,7 +438,7 @@ export const DomainList = () => {
                     ],
                   }}
                 >
-                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label="More actions" />
+                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label={t("domainlist.more_actions")} />
                 </Dropdown>
                 {activeModal?.domain.id === r.id && activeModal.type === "redirects" && (
                   <DomainRedirectsButton

--- a/panel-ui/src/shells/admin/domains/DomainMTASTSSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMTASTSSection.tsx
@@ -10,6 +10,7 @@
 // the reconciler step that fires the agent call. Until then, the UI
 // shows "Policy live in DNS — vhost waiting for SSL renewal" so the
 // operator knows the toggle worked and the wait is intentional.
+import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Skeleton, Space, Switch, Typography, message } from "antd";
 import { CheckOutlined, CloseOutlined, SafetyOutlined } from "@icons";
@@ -28,6 +29,7 @@ type MTAStsState = {
 type Props = { domainId: string };
 
 export const DomainMTASTSSection = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const [state, setState] = useState<MTAStsState | null>(null);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
@@ -97,7 +99,7 @@ export const DomainMTASTSSection = ({ domainId }: Props) => {
         <Alert
           type="warning"
           showIcon
-          message="Policy live in DNS — vhost waiting for SSL renewal"
+          message={t("domainmtastssection.policy_live_in_dns_vhost_waiting_for_ssl_ren")}
           description={
             <>
               The TXT and A records are published. The agent will start
@@ -114,8 +116,8 @@ export const DomainMTASTSSection = ({ domainId }: Props) => {
         <Alert
           type="info"
           showIcon
-          message="MTA-STS protects inbound mail from TLS downgrade"
-          description="When enabled, jabali publishes a policy telling every sending mail server to require TLS for messages to this domain. Two DNS records (TXT + A) appear and the agent serves the policy at https://mta-sts.<domain>/.well-known/mta-sts.txt. Cert renewal handles the SAN; no manual steps."
+          message={t("domainmtastssection.mta_sts_protects_inbound_mail_from_tls_downg")}
+          description={t("domainmtastssection.when_enabled_jabali_publishes_a_policy_telli")}
         />
       )}
     </Space>

--- a/panel-ui/src/shells/admin/domains/DomainMailProviderSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailProviderSection.tsx
@@ -2,6 +2,7 @@
 // hosted. The choice derives email_enabled + skip_auto_san server-side and
 // publishes (or prunes) the provider's DNS records. Switching re-publishes
 // DNS and reissues the cert on the next reconcile.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Alert, Button, Input, Select, Space, Typography, message } from "antd";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -28,6 +29,7 @@ export const DomainMailProviderSection = ({
   m365Onmicrosoft,
   googleDkim,
 }: Props) => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [provider, setProvider] = useState<string>(mailProvider ?? "jabali");
   const [m365, setM365] = useState<string>(m365Onmicrosoft ?? "");
@@ -60,7 +62,7 @@ export const DomainMailProviderSection = ({
       <Alert
         type="info"
         showIcon
-        message="Mail provider"
+        message={t("domainmailprovidersection.mail_provider")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             Where this domain's email is hosted. <b>No mail</b> and the

--- a/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
@@ -10,6 +10,7 @@
 //   POST   /api/v1/domains/:id/mail-certificate/enable
 //   POST   /api/v1/domains/:id/mail-certificate/disable
 //   POST   /api/v1/domains/:id/mail-certificate/reissue
+import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Skeleton, Space, Switch, Table, Tag, Tooltip, Typography, message } from "antd";
 import { ReloadOutlined } from "@icons";
@@ -61,6 +62,7 @@ interface Props {
 }
 
 export const DomainMailTLSSection = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const [cert, setCert] = useState<MailCertResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
@@ -185,7 +187,7 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
       />
 
       {(cert.status === "failed" || cert.status === "dns_missing" || cert.status === "issued") && (
-        <Tooltip title="Clears backoff and dispatches ssl.mail.issue on the next reconciler tick">
+        <Tooltip title={t("domainmailtlssection.clears_backoff_and_dispatches_ssl_mail_issue")}>
           <Button icon={<ReloadOutlined />} loading={busy} onClick={handleReissue}>
             Re-issue
           </Button>

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -5,6 +5,7 @@
 // 409 email_not_enabled on create otherwise), so the empty-state
 // explains that. Reveal-once passwords reuse DatabaseUserPasswordModal
 // — the UX is identical (operator saves, we never display again).
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import {
@@ -86,6 +87,7 @@ export const DomainMailboxesSection = ({
   domainOptions,
   onDomainCreated,
 }: Props) => {
+  const { t } = useTranslation();
   const email = useDomainEmail(domainId);
   const enabled = email.data?.email_enabled ?? false;
 
@@ -157,8 +159,8 @@ export const DomainMailboxesSection = ({
       <Alert
         type="info"
         showIcon
-        message="Email isn't enabled on this domain"
-        description="Mailboxes can only be created once email is enabled. Usually this happens automatically when the domain is created — click below to retry."
+        message={t("domainmailboxessection.email_isn_t_enabled_on_this_domain")}
+        description={t("domainmailboxessection.mailboxes_can_only_be_created_once_email_is")}
         action={
           <Button
             type="primary"
@@ -392,21 +394,21 @@ export const DomainMailboxesSection = ({
       </Card>
 
       <Modal
-        title="Create mailbox"
+        title={t("domainmailboxessection.create_mailbox")}
         open={createOpen}
         onCancel={() => setCreateOpen(false)}
         onOk={onCreate}
         confirmLoading={createMutation.isPending}
-        okText="Create"
+        okText={t("domainmailboxessection.create")}
         destroyOnClose
       >
         <Form form={form} layout="vertical">
           {showDomainPicker && (
             <Form.Item
-              label="Domain"
+              label={t("domainmailboxessection.domain")}
               name="domain_id"
               rules={[{ required: true, message: "Pick a domain" }]}
-              tooltip="Only domains with email enabled appear here."
+              tooltip={t("domainmailboxessection.only_domains_with_email_enabled_appear_here")}
             >
               <Select
                 showSearch
@@ -415,12 +417,12 @@ export const DomainMailboxesSection = ({
                   value: d.id,
                   label: d.name,
                 }))}
-                placeholder="Pick a domain"
+                placeholder={t("domainmailboxessection.pick_a_domain")}
               />
             </Form.Item>
           )}
           <Form.Item
-            label="Local part"
+            label={t("domainmailboxessection.local_part")}
             name="local_part"
             rules={[
               { required: true, message: "Required" },
@@ -440,9 +442,9 @@ export const DomainMailboxesSection = ({
           </Form.Item>
 
           <Form.Item
-            label="Password"
+            label={t("domainmailboxessection.password")}
             name="password"
-            tooltip="Leave blank to auto-generate. Generated passwords are shown exactly once."
+            tooltip={t("domainmailboxessection.leave_blank_to_auto_generate_generated_passw")}
             rules={[
               { min: 8, message: "8 characters minimum" },
             ]}
@@ -451,7 +453,7 @@ export const DomainMailboxesSection = ({
           </Form.Item>
 
           <Form.Item
-            label="Quota (MiB)"
+            label={t("domainmailboxessection.quota_mib")}
             name="quota_mib"
             tooltip={`Default 1024 MiB. Minimum ${QUOTA_MIN_BYTES / 1024 / 1024} MiB.`}
             initialValue={QUOTA_DEFAULT_BYTES / 1024 / 1024}
@@ -466,7 +468,7 @@ export const DomainMailboxesSection = ({
           <Form.Item
             name="send_only"
             valuePropName="checked"
-            tooltip="A send-only mailbox authenticates for SMTP submission but never receives or stores mail — inbound is rejected. Useful for per-service notification credentials."
+            tooltip={t("domainmailboxessection.a_send_only_mailbox_authenticates_for_smtp_s")}
           >
             <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
           </Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainPathBrowserModal.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainPathBrowserModal.tsx
@@ -2,6 +2,7 @@
 // "Path" field. Calls /api/v1/domains/:id/browse to list directories
 // under the domain's docroot; user clicks a folder to drill in,
 // breadcrumb to navigate up, "Select this folder" returns the path.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -40,6 +41,7 @@ export const DomainPathBrowserModal = ({
   onCancel,
   onSelect,
 }: Props) => {
+  const { t } = useTranslation();
   const [path, setPath] = useState<string>(initialPath || "/");
 
   const { data, isLoading, error } = useQuery({
@@ -72,7 +74,7 @@ export const DomainPathBrowserModal = ({
   return (
     <Modal
       open={open}
-      title="Pick a folder under the docroot"
+      title={t("domainpathbrowsermodal.pick_a_folder_under_the_docroot")}
       onCancel={onCancel}
       width={620}
       destroyOnClose
@@ -127,7 +129,7 @@ export const DomainPathBrowserModal = ({
         {!isLoading && data && data.entries.length === 0 && (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description="No subfolders here."
+            description={t("domainpathbrowsermodal.no_subfolders_here")}
           />
         )}
         {!isLoading && data && data.entries.length > 0 && (

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
 import { Alert, Button, Input, Modal, Select, Skeleton, Space, Tag, Tooltip, message } from "antd";
 import { ReloadOutlined } from "@icons";
@@ -57,6 +58,7 @@ type Props = {
 };
 
 export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => {
+  const { t } = useTranslation();
   const [cert, setCert] = useState<SSLCertificate | null>(null);
   const [certMissing, setCertMissing] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -184,7 +186,7 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
         <Alert
           type="warning"
           showIcon
-          title="Set an admin email to use SSL"
+          title={t("domainsslsection.set_an_admin_email_to_use_ssl")}
           description={
             <>
               Let&apos;s Encrypt requires an email on the account. Configure it in{" "}
@@ -198,8 +200,8 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
         <Alert
           type="warning"
           showIcon
-          title="Using self-signed certificate"
-          description="This domain is using a self-signed certificate while Let's Encrypt issuance retries. Browsers will show a security warning until the real cert is issued."
+          title={t("domainsslsection.using_self_signed_certificate")}
+          description={t("domainsslsection.this_domain_is_using_a_self_signed_certifica")}
         />
       ) : null}
 
@@ -207,7 +209,7 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
         <Alert
           type="error"
           showIcon
-          title="ACME issuance failed"
+          title={t("domainsslsection.acme_issuance_failed")}
           description={
             <>
               {cert?.last_error && <div>Error: {cert.last_error}</div>}
@@ -269,8 +271,8 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
 
       <Modal
         open={customOpen}
-        title="Upload custom certificate"
-        okText="Install"
+        title={t("domainsslsection.upload_custom_certificate")}
+        okText={t("domainsslsection.install")}
         confirmLoading={uploading}
         onOk={uploadCustom}
         onCancel={() => setCustomOpen(false)}
@@ -281,7 +283,7 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
           <Alert
             type="info"
             showIcon
-            message="Paste the full-chain certificate (leaf + intermediates) and the matching private key in PEM format. The key is stored on the server and never shown again."
+            message={t("domainsslsection.paste_the_full_chain_certificate_leaf_interm")}
           />
           <div>
             <div style={{ marginBottom: 4 }}>Certificate (PEM)</div>

--- a/panel-ui/src/shells/admin/domains/DomainSkipAutoSANToggle.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSkipAutoSANToggle.tsx
@@ -3,6 +3,7 @@
 // cert SAN list per ADR-0070. On: panel issues a cert for ONLY
 // <domain> + www.<domain>. Use when the tenant's mail runs elsewhere
 // or the helper subdomains aren't DNS-resolvable.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Alert, Skeleton, Space, Switch, Typography, message } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -14,6 +15,7 @@ type Resp = { domain_id: string; domain_name: string; enabled: boolean };
 type Props = { domainId: string };
 
 export const DomainSkipAutoSANToggle = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const { data, isLoading } = useQuery({
     queryKey: ["domain-skip-auto-san", domainId],
@@ -60,7 +62,7 @@ export const DomainSkipAutoSANToggle = ({ domainId }: Props) => {
       <Alert
         type="info"
         showIcon
-        message="Skip auto-added SAN names"
+        message={t("domainskipautosantoggle.skip_auto_added_san_names")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             By default the panel adds <code>mail.&lt;domain&gt;</code> and{" "}

--- a/panel-ui/src/shells/admin/ips/AdminIPList.tsx
+++ b/panel-ui/src/shells/admin/ips/AdminIPList.tsx
@@ -3,6 +3,7 @@
 // Same shape as PackageList.tsx: useTableURL + SearchableTable +
 // RowDeleteButton. Delete handles the 409 ip_in_use case by surfacing
 // the affected-domains list returned by the API.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Modal, Space, Table, Tag, Typography, message } from "antd";
 import { DeleteOutlined, EditOutlined, EthernetPortOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
@@ -53,6 +54,7 @@ type AffectedDomainsBody = {
 };
 
 export const AdminIPList = () => {
+  const { t } = useTranslation();
   const [conflictModal, setConflictModal] = useState<AffectedDomainsBody | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | undefined>(undefined);
@@ -129,7 +131,7 @@ export const AdminIPList = () => {
           locale={{
             emptyText: (
               <EmptyWithCTA
-                description="No managed IPs yet"
+                description={t("adminiplist.no_managed_ips_yet")}
                 ctaLabel="Add IP"
                 onCta={openCreate}
               />
@@ -138,14 +140,14 @@ export const AdminIPList = () => {
         >
           <Table.Column
             dataIndex="address"
-            title="Address"
+            title={t("adminiplist.address")}
             key="address"
             sorter={(a: ManagedIP, b: ManagedIP) => a.address.localeCompare(b.address)}
             render={(addr: string) => <code>{addr}</code>}
           />
           <Table.Column
             dataIndex="family"
-            title="Family"
+            title={t("adminiplist.family")}
             sorter={(a: ManagedIP, b: ManagedIP) => a.family.localeCompare(b.family)}
             render={(family: ManagedIP["family"]) => (
               <Tag color={family === "ipv4" ? "blue" : "purple"}>{family}</Tag>
@@ -153,24 +155,24 @@ export const AdminIPList = () => {
           />
           <Table.Column
             dataIndex="label"
-            title="Label"
+            title={t("adminiplist.label")}
             sorter={(a: ManagedIP, b: ManagedIP) => (a.label ?? "").localeCompare(b.label ?? "")}
           />
           <Table.Column
             dataIndex="is_default"
-            title="Default"
+            title={t("adminiplist.default")}
             sorter={(a: ManagedIP, b: ManagedIP) => Number(a.is_default) - Number(b.is_default)}
             render={(v: boolean) => (v ? <Tag color="gold">default</Tag> : null)}
           />
           <Table.Column
-            title="Bound"
+            title={t("adminiplist.bound")}
             key="is_bound"
             sorter={(a: ManagedIP, b: ManagedIP) => Number(a.is_bound) - Number(b.is_bound)}
             render={(_: unknown, row: ManagedIP) => renderBoundTag(row)}
           />
           <Table.Column
             dataIndex="is_user_selectable"
-            title="User-selectable"
+            title={t("adminiplist.user_selectable")}
             sorter={(a: ManagedIP, b: ManagedIP) => Number(a.is_user_selectable) - Number(b.is_user_selectable)}
             render={(v: boolean) =>
               v ? <Tag color="cyan">yes</Tag> : <Tag>no</Tag>
@@ -178,14 +180,14 @@ export const AdminIPList = () => {
           />
           <Table.Column
             dataIndex="degraded"
-            title="Status"
+            title={t("adminiplist.status")}
             sorter={(a: ManagedIP, b: ManagedIP) => Number(a.degraded) - Number(b.degraded)}
             render={(v: boolean) =>
               v ? <Tag color="red">degraded</Tag> : <Tag color="green">ok</Tag>
             }
           />
           <Table.Column
-            title="Actions"
+            title={t("adminiplist.actions")}
             dataIndex="actions"
             render={(_: unknown, r: ManagedIP) => (
               <RowActions
@@ -202,7 +204,7 @@ export const AdminIPList = () => {
       <AdminIPDrawer open={drawerOpen} onClose={closeDrawer} editingId={editingId} />
 
       <Modal
-        title="IP is in use"
+        title={t("adminiplist.ip_is_in_use")}
         open={conflictModal !== null}
         onCancel={() => setConflictModal(null)}
         onOk={() => setConflictModal(null)}

--- a/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
+++ b/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useState, useEffect, useRef } from "react";
 import { Modal, Typography, Button, Space, message, Spin, theme } from "antd";
 import { PauseOutlined, PlayCircleOutlined, ClearOutlined } from "@ant-design/icons";
@@ -46,6 +47,7 @@ const buildGoAccessHttpUrl = (streamUrl: string): string | null => {
 };
 
 export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: LogStreamModalProps) => {
+  const { t } = useTranslation();
   const { token } = theme.useToken();
   const [logs, setLogs] = useState<string[]>([]);
   const [connected, setConnected] = useState(false);
@@ -232,7 +234,7 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
               border: "none",
               display: "block",
             }}
-            title="GoAccess Dashboard"
+            title={t("logstreammodal.goaccess_dashboard")}
             sandbox="allow-scripts allow-same-origin"
             onLoad={() => {
               const iframe = goAccessFrameRef.current;

--- a/panel-ui/src/shells/admin/mail/AdminGroupsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminGroupsTab.tsx
@@ -2,6 +2,7 @@
 // Lists every group across all domains; reuses the user GroupDrawer +
 // MembersModal for edit/members. Create uses a "Create in:" domain picker
 // since groups are domain-scoped.
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import {
@@ -35,6 +36,7 @@ const RESOURCE_TAGS: { key: keyof MailGroup; label: string; color: string }[] = 
 ];
 
 export function AdminGroupsTab() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const { data: rows, isLoading } = useAdminMailGroups();
   const { items: domains } = useListQuery<Domain>({
@@ -81,7 +83,7 @@ export function AdminGroupsTab() {
         rowKey="id"
         dataSource={rows ?? []}
         pagination={{ pageSize: 25, showSizeChanger: true }}
-        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No groups" /> }}
+        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("admingroupstab.no_groups")} /> }}
         columns={[
           {
             title: "Group",

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -1,6 +1,7 @@
 // AdminMailPage — server-wide mailbox management (admin). Lists every mailbox
 // across all domains with add / edit / reset-password / delete. Reuses the
 // per-domain create wizard + the shared EditMailboxModal (GH #197 companion).
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import {
@@ -48,6 +49,7 @@ function formatBytes(n: number): string {
 }
 
 export function AdminMailPage() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const { data: rows, isLoading } = useAdminMailboxes();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -205,7 +207,7 @@ export function AdminMailPage() {
       <>
         <Space style={{ width: "100%", justifyContent: "flex-start", marginBottom: 16 }} wrap>
           <Input.Search
-            placeholder="Search email, name, domain, owner"
+            placeholder={t("adminmailpage.search_email_name_domain_owner")}
             allowClear
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -219,7 +221,7 @@ export function AdminMailPage() {
           dataSource={filtered}
           loading={isLoading}
           pagination={{ pageSize: 25, showSizeChanger: true }}
-          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No mailboxes" /> }}
+          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminmailpage.no_mailboxes")} /> }}
           columns={[
             {
               title: "Email",
@@ -339,7 +341,7 @@ export function AdminMailPage() {
       <Modal
         open={resetTarget !== null}
         title={resetTarget ? `Reset password — ${resetTarget.email}` : "Reset password"}
-        okText="Set password"
+        okText={t("adminmailpage.set_password")}
         confirmLoading={rotate.isPending}
         onOk={submitReset}
         onCancel={() => setResetTarget(null)}
@@ -347,9 +349,9 @@ export function AdminMailPage() {
       >
         <Form form={resetForm} layout="vertical" requiredMark={false}>
           <Form.Item
-            label="New password"
+            label={t("adminmailpage.new_password")}
             name="password"
-            tooltip="Leave blank to auto-generate. Auto-generated passwords are shown exactly once."
+            tooltip={t("adminmailpage.leave_blank_to_auto_generate_auto_generated")}
           >
             <PasswordInput autoComplete="new-password" placeholder="(leave blank to auto-generate)" />
           </Form.Item>
@@ -361,7 +363,7 @@ export function AdminMailPage() {
           open
           username={revealed.email}
           password={revealed.password}
-          title="Mailbox password"
+          title={t("adminmailpage.mailbox_password")}
           onClose={() => setRevealed(null)}
         />
       )}

--- a/panel-ui/src/shells/admin/mail/MailDeliverabilityPage.tsx
+++ b/panel-ui/src/shells/admin/mail/MailDeliverabilityPage.tsx
@@ -3,6 +3,7 @@
 // Single GET /api/v1/admin/mail/deliverability; renders the 0-100 score
 // with a colour badge and each contributing signal as its own line so
 // the operator sees exactly which axis cost what.
+import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { Alert, Card, Descriptions, Progress, Skeleton, Tag, Typography } from "antd";
 
@@ -29,6 +30,7 @@ const severityColour: Record<ScoreResponse["severity"], string> = {
 };
 
 export const MailDeliverabilityPage = () => {
+  const { t } = useTranslation();
   const { data, isLoading, error } = useQuery({
     queryKey: ["admin", "mail", "deliverability"],
     queryFn: async () => (await apiClient.get<ScoreResponse>("/admin/mail/deliverability")).data,
@@ -37,11 +39,11 @@ export const MailDeliverabilityPage = () => {
 
   if (isLoading) return <Skeleton active />;
   if (error || !data) {
-    return <Alert type="error" message="Failed to load deliverability score" />;
+    return <Alert type="error" message={t("maildeliverabilitypage.failed_to_load_deliverability_score")} />;
   }
 
   return (
-    <Card title="Mail deliverability — server-wide score" variant="outlined">
+    <Card title={t("maildeliverabilitypage.mail_deliverability_server_wide_score")} variant="outlined">
       <div style={{ marginBottom: 24 }}>
         <Progress
           type="circle"
@@ -81,8 +83,8 @@ export const MailDeliverabilityPage = () => {
         type="info"
         showIcon
         style={{ marginTop: 16 }}
-        message="How this score works"
-        description="Each of the four signals can subtract up to 25 points from a clean 100. The signals come from M47: RBL listings of the public IP, DKIM-failing buckets in inbound DMARC RUA reports, TLS-session failures in TLS-RPT reports, and abuse-feedback (ARF) reports from receiver postmasters. All counted over the last 7 days."
+        message={t("maildeliverabilitypage.how_this_score_works")}
+        description={t("maildeliverabilitypage.each_of_the_four_signals_can_subtract_up_to")}
       />
     </Card>
   );

--- a/panel-ui/src/shells/admin/mail/MailThrottlesPage.tsx
+++ b/panel-ui/src/shells/admin/mail/MailThrottlesPage.tsx
@@ -4,6 +4,7 @@
 // reconciler converges each row into Stalwart's MtaOutboundThrottle
 // on the next tick (5s typical). last_applied_at + last_error on each
 // row tell the operator whether the Stalwart side caught up.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -28,6 +29,7 @@ type Policy = {
 };
 
 export const MailThrottlesPage = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [drawer, setDrawer] = useState<{ open: boolean; row?: Policy }>({ open: false });
   const [form] = Form.useForm();
@@ -128,8 +130,8 @@ export const MailThrottlesPage = () => {
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
-        message="Per-account / per-domain / server-wide outbound rate caps"
-        description="Each row converges into a Stalwart MtaOutboundThrottle object on the next reconciler tick. 0 = unlimited. v1 enforces the hourly cap (Stalwart's rate object takes one window); daily cap is logged but not enforced until a later wave splits it into a paired object."
+        message={t("mailthrottlespage.per_account_per_domain_server_wide_outbound")}
+        description={t("mailthrottlespage.each_row_converges_into_a_stalwart_mtaoutbou")}
       />
       <Table rowKey="id" loading={isLoading} dataSource={data ?? []} columns={columns} pagination={false} />
       <Drawer
@@ -147,7 +149,7 @@ export const MailThrottlesPage = () => {
         }
       >
         <Form form={form} layout="vertical" initialValues={{ scope: "global", enabled: true }}>
-          <Form.Item name="scope" label="Scope" rules={[{ required: true }]}>
+          <Form.Item name="scope" label={t("mailthrottlespage.scope")} rules={[{ required: true }]}>
             <Select disabled={!!drawer.row}>
               <Select.Option value="global">global (server-wide)</Select.Option>
               <Select.Option value="user">user</Select.Option>
@@ -157,19 +159,19 @@ export const MailThrottlesPage = () => {
           <Form.Item shouldUpdate={(p, n) => p.scope !== n.scope} noStyle>
             {({ getFieldValue }) =>
               getFieldValue("scope") !== "global" ? (
-                <Form.Item name="scope_ref" label="Scope ref (ULID)" rules={[{ required: true }]}>
+                <Form.Item name="scope_ref" label={t("mailthrottlespage.scope_ref_ulid")} rules={[{ required: true }]}>
                   <Input placeholder={getFieldValue("scope") === "user" ? "users.id" : "domains.id"} disabled={!!drawer.row} />
                 </Form.Item>
               ) : null
             }
           </Form.Item>
-          <Form.Item name="max_per_hour" label="Max per hour (0 = unlimited)">
+          <Form.Item name="max_per_hour" label={t("mailthrottlespage.max_per_hour_0_unlimited")}>
             <InputNumber min={0} max={1000000} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item name="max_per_day" label="Max per day (logged only, v1)">
+          <Form.Item name="max_per_day" label={t("mailthrottlespage.max_per_day_logged_only_v1")}>
             <InputNumber min={0} max={10000000} style={{ width: "100%" }} />
           </Form.Item>
-          <Form.Item name="enabled" label="Enabled" valuePropName="checked">
+          <Form.Item name="enabled" label={t("mailthrottlespage.enabled")} valuePropName="checked">
             <Switch />
           </Form.Item>
         </Form>

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -5,6 +5,7 @@
 //
 // Polls every 10s when the job is in a non-terminal state so the
 // operator sees stages advance live while the cobra CLI runs.
+import { useTranslation } from "react-i18next";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import {
   Alert,
@@ -105,6 +106,7 @@ function isTerminal(state: string): boolean {
 }
 
 export const AdminMigrationDetailPage = () => {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
@@ -162,7 +164,7 @@ export const AdminMigrationDetailPage = () => {
   }, [id]);
 
   if (!id) {
-    return <Empty description="No migration job selected" />;
+    return <Empty description={t("adminmigrationdetailpage.no_migration_job_selected")} />;
   }
   if (detail.isLoading || !detail.data) {
     return (
@@ -189,38 +191,38 @@ export const AdminMigrationDetailPage = () => {
         </Space>
 
         <Descriptions size="small" column={{ xs: 1, sm: 2 }} bordered>
-          <Descriptions.Item label="Job ID">
+          <Descriptions.Item label={t("adminmigrationdetailpage.job_id")}>
             <Typography.Text code>{job.id}</Typography.Text>
           </Descriptions.Item>
-          <Descriptions.Item label="Source kind">
+          <Descriptions.Item label={t("adminmigrationdetailpage.source_kind")}>
             {job.source_kind}
           </Descriptions.Item>
-          <Descriptions.Item label="Started">
+          <Descriptions.Item label={t("adminmigrationdetailpage.started")}>
             {new Date(job.started_at).toLocaleString()}
           </Descriptions.Item>
-          <Descriptions.Item label="Ended">
+          <Descriptions.Item label={t("adminmigrationdetailpage.ended")}>
             {job.ended_at ? new Date(job.ended_at).toLocaleString() : "—"}
           </Descriptions.Item>
-          <Descriptions.Item label="Target user ID">
+          <Descriptions.Item label={t("adminmigrationdetailpage.target_user_id")}>
             {job.target_user_id ? (
               <Typography.Text code>{job.target_user_id}</Typography.Text>
             ) : (
               "—"
             )}
           </Descriptions.Item>
-          <Descriptions.Item label="Destination user">
+          <Descriptions.Item label={t("adminmigrationdetailpage.destination_user")}>
             {job.dest_user ? job.dest_user : <Typography.Text type="secondary">—</Typography.Text>}
           </Descriptions.Item>
-          <Descriptions.Item label="Destination domain">
+          <Descriptions.Item label={t("adminmigrationdetailpage.destination_domain")}>
             {job.dest_domain ? job.dest_domain : <Typography.Text type="secondary">—</Typography.Text>}
           </Descriptions.Item>
-          <Descriptions.Item label="Last error">
+          <Descriptions.Item label={t("adminmigrationdetailpage.last_error")}>
             {job.last_error ?? "—"}
           </Descriptions.Item>
         </Descriptions>
       </Card>
 
-      <Card size="small" title="Pipeline">
+      <Card size="small" title={t("adminmigrationdetailpage.pipeline")}>
         {(() => {
           const done = STAGE_ORDER.filter((n) => stagesByName.get(n)?.state === "done").length;
           const pct = job.state === "done" ? 100 : Math.round((done / STAGE_ORDER.length) * 100);
@@ -259,9 +261,9 @@ export const AdminMigrationDetailPage = () => {
 
       <DriveCard jobId={job.id} jobState={job.state} jobSourceKind={job.source_kind} />
 
-      <Card size="small" title="Stage timeline">
+      <Card size="small" title={t("adminmigrationdetailpage.stage_timeline")}>
         {stages.length === 0 ? (
-          <Empty description="No stage rows yet" />
+          <Empty description={t("adminmigrationdetailpage.no_stage_rows_yet")} />
         ) : (
           <Space direction="vertical" style={{ width: "100%" }}>
             {stages.map((s) => (
@@ -286,18 +288,18 @@ export const AdminMigrationDetailPage = () => {
                     </Tag>
                   </Space>
                   <Descriptions size="small" column={{ xs: 1, sm: 2 }}>
-                    <Descriptions.Item label="Started">
+                    <Descriptions.Item label={t("adminmigrationdetailpage.started")}>
                       {s.started_at
                         ? new Date(s.started_at).toLocaleString()
                         : "—"}
                     </Descriptions.Item>
-                    <Descriptions.Item label="Ended">
+                    <Descriptions.Item label={t("adminmigrationdetailpage.ended")}>
                       {s.ended_at ? new Date(s.ended_at).toLocaleString() : "—"}
                     </Descriptions.Item>
-                    <Descriptions.Item label="Bytes processed">
+                    <Descriptions.Item label={t("adminmigrationdetailpage.bytes_processed")}>
                       {s.bytes_processed.toLocaleString()}
                     </Descriptions.Item>
-                    <Descriptions.Item label="Error">
+                    <Descriptions.Item label={t("adminmigrationdetailpage.error")}>
                       {s.last_error ?? "—"}
                     </Descriptions.Item>
                   </Descriptions>

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -10,6 +10,7 @@
 //
 // Backed by panel-api/internal/api/admin_migrations.go (commit
 // 5981541a).
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import {
@@ -81,6 +82,7 @@ const SOURCE_BADGE: Record<string, { color: string; label: string }> = {
 };
 
 export const AdminMigrationsPage = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -220,7 +222,7 @@ export const AdminMigrationsPage = () => {
   const migrationsToolbar = (
           <Space wrap>
             <Tooltip
-              title="Allow SSH to RFC1918 / loopback / link-local source hosts. Default off for production safety. Restart panel + agent after flipping to pick up the change."
+              title={t("adminmigrationspage.allow_ssh_to_rfc1918_loopback_link_local_sou")}
             >
               <Space size={6}>
                 <Typography.Text type="secondary" style={{ fontSize: 12 }}>
@@ -318,8 +320,8 @@ export const AdminMigrationsPage = () => {
             {r.batch_id ? (
               <Popconfirm
                 title={`Cancel entire batch ${r.batch_id.slice(-6)}?`}
-                description="Cancels every non-terminal job sharing this batch_id."
-                okText="Cancel batch"
+                description={t("adminmigrationspage.cancels_every_non_terminal_job_sharing_this")}
+                okText={t("adminmigrationspage.cancel_batch")}
                 okButtonProps={{ danger: true }}
                 onConfirm={() => cancelBatch.mutate({ batchId: r.batch_id! })}
               >
@@ -339,7 +341,7 @@ export const AdminMigrationsPage = () => {
       <Alert
         type="info"
         showIcon
-        message="Account migration importer (M35)"
+        message={t("adminmigrationspage.account_migration_importer_m35")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             Read-only view of the migration_jobs table. Start new migrations
@@ -370,7 +372,7 @@ export const AdminMigrationsPage = () => {
 
       <Card
         size="small"
-        title="Recent migration jobs"
+        title={t("adminmigrationspage.recent_migration_jobs")}
         extra={screens.md ? migrationsToolbar : undefined}
       >
         {!screens.md ? (
@@ -387,13 +389,13 @@ export const AdminMigrationsPage = () => {
             emptyText: (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description="No migrations yet"
+                description={t("adminmigrationspage.no_migrations_yet")}
               />
             ),
           }}
         >
           <Table.Column<MigrationJob>
-            title="Source"
+            title={t("adminmigrationspage.source")}
             dataIndex="source_kind"
             sorter={(a, b) => (a.source_kind ?? "").localeCompare(b.source_kind ?? "")}
             render={(k: string) => {
@@ -402,7 +404,7 @@ export const AdminMigrationsPage = () => {
             }}
           />
           <Table.Column<MigrationJob>
-            title="Source host"
+            title={t("adminmigrationspage.source_host")}
             dataIndex="source_host"
             sorter={(a, b) => (a.source_host ?? "").localeCompare(b.source_host ?? "")}
             render={(s: string) => (
@@ -412,15 +414,15 @@ export const AdminMigrationsPage = () => {
             )}
           />
           <Table.Column<MigrationJob>
-            title="Batch"
+            title={t("adminmigrationspage.batch")}
             dataIndex="batch_id"
             sorter={(a, b) => (a.batch_id ?? "").localeCompare(b.batch_id ?? "")}
             render={(b: string | null) =>
               b ? (
                 <Popconfirm
                   title={`Cancel entire batch ${b.slice(-6)}?`}
-                  description="Cancels every non-terminal job sharing this batch_id."
-                  okText="Cancel batch"
+                  description={t("adminmigrationspage.cancels_every_non_terminal_job_sharing_this")}
+                  okText={t("adminmigrationspage.cancel_batch")}
                   okButtonProps={{ danger: true }}
                   onConfirm={() => cancelBatch.mutate({ batchId: b })}
                 >
@@ -439,7 +441,7 @@ export const AdminMigrationsPage = () => {
             }
           />
           <Table.Column<MigrationJob>
-            title="Source user"
+            title={t("adminmigrationspage.source_user")}
             dataIndex="source_user"
             sorter={(a, b) => (a.source_user ?? "").localeCompare(b.source_user ?? "")}
             render={(s: string) => (
@@ -449,7 +451,7 @@ export const AdminMigrationsPage = () => {
             )}
           />
           <Table.Column<MigrationJob>
-            title="State"
+            title={t("adminmigrationspage.state")}
             dataIndex="state"
             sorter={(a, b) => (a.state ?? "").localeCompare(b.state ?? "")}
             render={(s: string) => {
@@ -458,13 +460,13 @@ export const AdminMigrationsPage = () => {
             }}
           />
           <Table.Column<MigrationJob>
-            title="Started"
+            title={t("adminmigrationspage.started")}
             dataIndex="started_at"
             sorter={(a, b) => (a.started_at ? +new Date(a.started_at) : 0) - (b.started_at ? +new Date(b.started_at) : 0)}
             render={(s: string) => shortDateTime(s)}
           />
           <Table.Column<MigrationJob>
-            title="Ended"
+            title={t("adminmigrationspage.ended")}
             dataIndex="ended_at"
             sorter={(a, b) => (a.ended_at ? +new Date(a.ended_at) : 0) - (b.ended_at ? +new Date(b.ended_at) : 0)}
             render={(s: string | null) =>
@@ -481,13 +483,13 @@ export const AdminMigrationsPage = () => {
           <List
             dataSource={rows}
             loading={list.isLoading}
-            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No migrations yet" /> }}
+            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminmigrationspage.no_migrations_yet")} /> }}
             renderItem={renderMobileJobCard}
           />
         )}
       </Card>
 
-      <Card size="small" title="Per-source-kind support">
+      <Card size="small" title={t("adminmigrationspage.per_source_kind_support")}>
         <Space direction="vertical" style={{ width: "100%" }}>
           <Typography.Text>
             <Tag color="green">cPanel</Tag> SSH discovery + pkgacct + full

--- a/panel-ui/src/shells/admin/migrations/BulkWhmDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/BulkWhmDrawer.tsx
@@ -6,6 +6,7 @@
 // v1 surface: paste accounts as newline / comma-separated list. The
 // M35.2 follow-up replaces the textarea with a discover-accounts call
 // that returns the cPanel account list from a live WHM API session.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -33,6 +34,7 @@ interface Props {
 }
 
 export const BulkWhmDrawer = ({ open, onClose, onCreated }: Props) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<{ source_host: string; accounts: string }>();
   const [result, setResult] = useState<BulkResp | null>(null);
 
@@ -76,7 +78,7 @@ export const BulkWhmDrawer = ({ open, onClose, onCreated }: Props) => {
       open={open}
       onClose={handleDone}
       width={520}
-      title="Create WHM migration batch"
+      title={t("bulkwhmdrawer.create_whm_migration_batch")}
       destroyOnClose
     >
       {!result ? (
@@ -88,22 +90,22 @@ export const BulkWhmDrawer = ({ open, onClose, onCreated }: Props) => {
           <Alert
             type="info"
             showIcon
-            message="Bulk WHM"
-            description="Creates one migration_job per account, all sharing a batch_id. Cancel-batch + per-account retry are available from the list page."
+            message={t("bulkwhmdrawer.bulk_whm")}
+            description={t("bulkwhmdrawer.creates_one_migration_job_per_account_all_sh")}
           />
           <Form.Item
-            label="Source host"
+            label={t("bulkwhmdrawer.source_host")}
             name="source_host"
             rules={[{ required: true, message: "Source WHM host required" }]}
-            tooltip="Hostname or IP of the source WHM server. Private-IP targets require server_settings.migration_allow_private_hosts=true."
+            tooltip={t("bulkwhmdrawer.hostname_or_ip_of_the_source_whm_server_priv")}
           >
             <Input placeholder="src.example.com" />
           </Form.Item>
           <Form.Item
-            label="Accounts"
+            label={t("bulkwhmdrawer.accounts")}
             name="accounts"
             rules={[{ required: true, message: "At least one account required" }]}
-            tooltip="One account per line, or comma-separated. Existing jobs for any (host, account) are skipped automatically."
+            tooltip={t("bulkwhmdrawer.one_account_per_line_or_comma_separated_exis")}
           >
             <Input.TextArea
               rows={8}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -1,6 +1,7 @@
 // CreateMigrationDrawer — operator-driven 'New Migration' wizard.
 // Step 1: pick source kind / host / user and create the job.
 // Step 2+: source-specific drive steps (upload / pull / import) — no CLI needed.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -482,6 +483,7 @@ export const CreateMigrationDrawer = ({
   open,
   onClose,
 }: CreateMigrationDrawerProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<CreateInput>();
   const qc = useQueryClient();
   const [created, setCreated] = useState<MigrationJob | null>(null);
@@ -529,7 +531,7 @@ export const CreateMigrationDrawer = ({
 
   return (
     <Drawer
-      title="New migration job"
+      title={t("createmigrationdrawer.new_migration_job")}
       open={open}
       onClose={handleDone}
       width={640}
@@ -544,7 +546,7 @@ export const CreateMigrationDrawer = ({
           initialValues={{ source_kind: "cpanel", source_port: 22 }}
         >
           <Form.Item
-            label="Source kind"
+            label={t("createmigrationdrawer.source_kind")}
             name="source_kind"
             rules={[{ required: true, message: "Pick a source panel kind" }]}
           >
@@ -594,9 +596,9 @@ export const CreateMigrationDrawer = ({
               }
               return (
                 <Form.Item
-                  label="SSH port"
+                  label={t("createmigrationdrawer.ssh_port")}
                   name="source_port"
-                  tooltip="The source server's SSH port. Defaults to 22."
+                  tooltip={t("createmigrationdrawer.the_source_server_s_ssh_port_defaults_to_22")}
                 >
                   <InputNumber min={1} max={65535} style={{ width: 140 }} />
                 </Form.Item>
@@ -607,9 +609,9 @@ export const CreateMigrationDrawer = ({
             {({ getFieldValue }) =>
               getFieldValue("source_kind") === "wordpress_ssh" ? (
                 <Form.Item
-                  label="WordPress path (optional)"
+                  label={t("createmigrationdrawer.wordpress_path_optional")}
                   name="source_path"
-                  tooltip="Absolute path to the WordPress root on the source (must contain wp-config.php). Leave blank to auto-detect ~/public_html, /home/*/public_html, or Cloudways /home/master/applications/*/public_html."
+                  tooltip={t("createmigrationdrawer.absolute_path_to_the_wordpress_root_on_the_s")}
                 >
                   <Input placeholder="/home/master/applications/xxxx/public_html" />
                 </Form.Item>
@@ -671,8 +673,8 @@ export const CreateMigrationDrawer = ({
               <Alert
                 type="success"
                 showIcon
-                message="Import started"
-                description="The migration is running in the background. Open the migration job to track stage-by-stage progress."
+                message={t("createmigrationdrawer.import_started")}
+                description={t("createmigrationdrawer.the_migration_is_running_in_the_background_o")}
               />
               <Button type="primary" onClick={handleDone}>
                 Done

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -18,6 +18,7 @@
 //
 // Single-account flow stays in CreateMigrationDrawer for now —
 // migrating it into the wizard is M35.2 work.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -110,6 +111,7 @@ interface Props {
 }
 
 export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
+  const { t } = useTranslation();
   const [step, setStep] = useState(0);
   const [draftId, setDraftId] = useState<string | null>(null);
   const [areas, setAreas] = useState<Record<string, boolean>>({
@@ -404,7 +406,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
       open={open}
       onClose={handleClose}
       width={680}
-      title="Create migration"
+      title={t("createmigrationwizard.create_migration")}
       destroyOnClose
     >
       <Steps
@@ -424,8 +426,8 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
           <Alert
             type="info"
             showIcon
-            message="Pick the source panel type"
-            description="WHM enables bulk migration of every cPanel account. Single-account migrations are still available via the 'New migration' button."
+            message={t("createmigrationwizard.pick_the_source_panel_type")}
+            description={t("createmigrationwizard.whm_enables_bulk_migration_of_every_cpanel_a")}
           />
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12 }}>
             {SOURCE_OPTIONS.map((o) => {
@@ -484,13 +486,13 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
             type="info"
             showIcon
             message={`Draft ${draftId.slice(-6)} created`}
-            description="Credentials are written to /etc/jabali-panel/migration-secrets and reaped 24h after job completion."
+            description={t("createmigrationwizard.credentials_are_written_to_etc_jabali_panel")}
           />
           <Form layout="vertical">
             <Form.Item
-              label="Source host"
+              label={t("createmigrationwizard.source_host")}
               required
-              tooltip="Use the server's direct IP if it sits behind Cloudflare or another proxy — a hostname can resolve to the proxy instead of the source server."
+              tooltip={t("createmigrationwizard.use_the_server_s_direct_ip_if_it_sits_behind")}
             >
               <Input
                 value={sourceHost}
@@ -498,7 +500,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
                 placeholder="203.0.113.10 or src.example.com"
               />
             </Form.Item>
-            <Form.Item label="SSH port" tooltip="The source server's SSH port. Defaults to 22.">
+            <Form.Item label={t("createmigrationwizard.ssh_port")} tooltip={t("createmigrationwizard.the_source_server_s_ssh_port_defaults_to_22")}>
               <InputNumber
                 min={1}
                 max={65535}
@@ -507,14 +509,14 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
                 style={{ width: 140 }}
               />
             </Form.Item>
-            <Form.Item label="Admin user" required>
+            <Form.Item label={t("createmigrationwizard.admin_user")} required>
               <Input
                 value={sourceUser}
                 onChange={(e) => setSourceUser(e.target.value)}
                 placeholder="root"
               />
             </Form.Item>
-            <Form.Item label="Credential type">
+            <Form.Item label={t("createmigrationwizard.credential_type")}>
               <Radio.Group value={credKind} onChange={(e) => setCredKind(e.target.value)}>
                 <Radio value="password">Password</Radio>
                 <Radio value="key">SSH key</Radio>
@@ -538,13 +540,13 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
               )}
             </Form.Item>
             <Form.Item
-              label="Source host key fingerprint (optional)"
+              label={t("createmigrationwizard.source_host_key_fingerprint_optional")}
               help="SHA256 fingerprint of the source server's SSH host key, e.g. from `ssh-keyscan -t ed25519 HOST | ssh-keygen -lf -`. When set, the connection is rejected unless the host key matches — protecting against a man-in-the-middle on the source even on first connect."
             >
               <Input
                 value={expectedHostKey}
                 onChange={(e) => setExpectedHostKey(e.target.value)}
-                placeholder="SHA256:abc123…"
+                placeholder={t("createmigrationwizard.sha256_abc123")}
               />
             </Form.Item>
             {!expectedHostKey.trim() && (
@@ -552,8 +554,8 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
                 type="warning"
                 showIcon
                 style={{ marginBottom: 8 }}
-                message="First connection is unverified"
-                description="Without a fingerprint, the first connection to the source is trusted blindly (trust-on-first-use). For a hostile network, paste the source host key fingerprint above to verify it."
+                message={t("createmigrationwizard.first_connection_is_unverified")}
+                description={t("createmigrationwizard.without_a_fingerprint_the_first_connection_t")}
               />
             )}
           </Form>
@@ -582,7 +584,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
             <Alert
               type="error"
               showIcon
-              message="Account discovery failed"
+              message={t("createmigrationwizard.account_discovery_failed")}
               description={(accounts.error as Error).message}
             />
           )}
@@ -592,7 +594,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
                 type="success"
                 showIcon
                 message={`Found ${accounts.data.accounts.length} accounts`}
-                description="Pick which accounts to migrate. Each becomes its own migration_job sharing a batch_id."
+                description={t("createmigrationwizard.pick_which_accounts_to_migrate_each_becomes")}
               />
               <Checkbox
                 checked={selected.size === accounts.data.accounts.length}
@@ -705,7 +707,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
           <Alert
             type="info"
             showIcon
-            message="Review"
+            message={t("createmigrationwizard.review")}
             description={
               <>
                 <div>
@@ -724,7 +726,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
             }
           />
           {sourceKind !== "wordpress_ssh" && sourceKind !== "wordpress_plugin" && (
-            <Card size="small" title="Import options">
+            <Card size="small" title={t("createmigrationwizard.import_options")}>
               <Checkbox.Group
                 value={Object.keys(areas).filter((k) => areas[k])}
                 onChange={(vals) => {

--- a/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
@@ -3,6 +3,7 @@
 // Rendered inside NotificationsTabsPage Card.tabList. Strips its own
 // page-level header; the "Add channel" button stays here because it's
 // tab-specific (the History tab has a different action).
+import { useTranslation } from "react-i18next";
 import { Button, Space, Switch, Table, Tag, message } from "antd";
 import { useState } from "react";
 
@@ -22,6 +23,7 @@ import { kindColors, kindLabels } from "./channelKindConfig";
 const RESOURCE = "admin/notifications/channels";
 
 export const ChannelsTab = () => {
+  const { t } = useTranslation();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState<NotificationChannel | undefined>();
 
@@ -102,14 +104,14 @@ export const ChannelsTab = () => {
       >
         <Table.Column
           dataIndex="name"
-          title="Name"
+          title={t("channelstab.name")}
           render={(name: string, row: NotificationChannel) => (
             <a onClick={() => openEdit(row)}>{name}</a>
           )}
         />
         <Table.Column
           dataIndex="kind"
-          title="Kind"
+          title={t("channelstab.kind")}
           render={(k: string) => (
             <Tag color={kindColors[k as keyof typeof kindColors]}>
               {kindLabels[k as keyof typeof kindLabels] ?? k}
@@ -118,13 +120,13 @@ export const ChannelsTab = () => {
         />
         <Table.Column
           dataIndex="enabled"
-          title="Enabled"
+          title={t("channelstab.enabled")}
           render={(enabled: boolean, row: NotificationChannel) => (
             <Switch checked={enabled} onChange={(next) => handleToggleEnabled(row, next)} />
           )}
         />
         <Table.Column
-          title="Actions"
+          title={t("channelstab.actions")}
           key="actions"
           render={(_: unknown, row: NotificationChannel) => (
             <RowActions

--- a/panel-ui/src/shells/admin/notifications/DLQTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/DLQTab.tsx
@@ -4,6 +4,7 @@
 // every retry. Each row exposes Replay (re-publish to the main queue +
 // drop from DLQ) and Drop (XDEL just that entry). Clear-all empties
 // the stream via XTRIM MAXLEN 0.
+import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Button,
@@ -49,6 +50,7 @@ function formatTs(iso: string): string {
 }
 
 export const DLQTab = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [busyID, setBusyID] = useState<string | null>(null);
 
@@ -144,8 +146,8 @@ export const DLQTab = () => {
             <>
               <Popconfirm
                 title={`Replay all ${total} dead-letter entries?`}
-                description="Re-publishes every envelope to the main delivery queue. Legacy entries without a preserved payload will be dropped silently."
-                okText="Replay all"
+                description={t("dlqtab.re_publishes_every_envelope_to_the_main_deli")}
+                okText={t("dlqtab.replay_all")}
                 onConfirm={replayAll}
               >
                 <Button icon={<RedoOutlined />} loading={replayingAll}>
@@ -154,8 +156,8 @@ export const DLQTab = () => {
               </Popconfirm>
               <Popconfirm
                 title={`Clear all ${total} dead-letter entries?`}
-                description="This deletes every entry in the stream. Use only if you've already addressed the underlying failures (e.g. fixed a misconfigured channel)."
-                okText="Clear"
+                description={t("dlqtab.this_deletes_every_entry_in_the_stream_use_o")}
+                okText={t("dlqtab.clear")}
                 okButtonProps={{ danger: true }}
                 onConfirm={clearAll}
               >
@@ -175,7 +177,7 @@ export const DLQTab = () => {
         pagination={false}
         size="small"
         scroll={{ x: "max-content" }}
-        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="DLQ is empty" /> }}
+        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("dlqtab.dlq_is_empty")} /> }}
         columns={[
           {
             title: "When",

--- a/panel-ui/src/shells/admin/notifications/EventsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.tsx
@@ -1,6 +1,7 @@
 // EventsTab — admin Notifications > Events. Per-event-kind enable
 // toggle. Defaults seeded by panel-api first-boot per
 // models.AllNotificationEventKinds (important = on).
+import { useTranslation } from "react-i18next";
 import { Switch, Table, Tag, Tooltip, Typography, message } from "antd";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -25,6 +26,7 @@ const severityColor: Record<EventKindRow["severity"], string> = {
 };
 
 export const EventsTab = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
 
   const list = useQuery<{ data: EventKindRow[] }>({
@@ -61,7 +63,7 @@ export const EventsTab = () => {
       scroll={{ x: 800 }}
     >
       <Table.Column<EventKindRow>
-        title="Event"
+        title={t("eventstab.event")}
         dataIndex="label"
         width={280}
         render={(label: string, row) => (
@@ -76,7 +78,7 @@ export const EventsTab = () => {
         )}
       />
       <Table.Column<EventKindRow>
-        title="Severity"
+        title={t("eventstab.severity")}
         dataIndex="severity"
         width={120}
         render={(s: EventKindRow["severity"]) => (
@@ -84,7 +86,7 @@ export const EventsTab = () => {
         )}
       />
       <Table.Column<EventKindRow>
-        title="Description"
+        title={t("eventstab.description")}
         dataIndex="description"
         // Wrap on word boundaries instead of truncating — long
         // sentences span multiple lines inside the cell so the
@@ -104,7 +106,7 @@ export const EventsTab = () => {
         )}
       />
       <Table.Column<EventKindRow>
-        title="Enabled"
+        title={t("eventstab.enabled")}
         dataIndex="enabled"
         width={120}
         render={(enabled: boolean, row) => (

--- a/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
@@ -4,6 +4,7 @@
 // own per-user deliveries AND system-wide broadcast rows (user_id IS
 // NULL) via ListForAdminInbox on the backend. Click a row to mark it
 // read and (if a deeplink exists) navigate there.
+import { useTranslation } from "react-i18next";
 import { Button, Descriptions, Modal, Popconfirm, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -60,6 +61,7 @@ function formatTs(iso: string): string {
 }
 
 export const HistoryTab = () => {
+  const { t } = useTranslation();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
   const [info, setInfo] = useState<NotificationHistoryRow | null>(null);
@@ -145,10 +147,10 @@ export const HistoryTab = () => {
             Mark all as read
           </Button>
           <Popconfirm
-            title="Clear all notifications?"
-            description="This permanently deletes every row in your inbox."
+            title={t("historytab.clear_all_notifications")}
+            description={t("historytab.this_permanently_deletes_every_row_in_your_i")}
             onConfirm={clearAll}
-            okText="Clear"
+            okText={t("historytab.clear")}
             okButtonProps={{ danger: true }}
           >
             <Button
@@ -188,13 +190,13 @@ export const HistoryTab = () => {
         })}
       >
         <Table.Column<NotificationHistoryRow>
-          title="Time"
+          title={t("historytab.time")}
           dataIndex="created_at"
           width={180}
           render={(v: string) => formatTs(v)}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Severity"
+          title={t("historytab.severity")}
           dataIndex="severity"
           width={110}
           render={(s: NotificationHistoryRow["severity"]) => (
@@ -202,18 +204,18 @@ export const HistoryTab = () => {
           )}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Event"
+          title={t("historytab.event")}
           dataIndex="event_kind"
           width={200}
           render={(k: string) => <code style={{ fontSize: 12 }}>{k}</code>}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Title"
+          title={t("historytab.title")}
           dataIndex="title"
           render={(v: string) => <Typography.Text strong>{v}</Typography.Text>}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Body"
+          title={t("historytab.body")}
           dataIndex="body"
           width={420}
           render={(v: string) => (
@@ -226,7 +228,7 @@ export const HistoryTab = () => {
           )}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Outcome"
+          title={t("historytab.outcome")}
           dataIndex="outcome"
           width={160}
           render={(o: NotificationHistoryRow["outcome"], row) => {
@@ -241,7 +243,7 @@ export const HistoryTab = () => {
               return (
                 <Space size={4} wrap>
                   {wrapped}
-                  <Tooltip title="This envelope was moved to the Dead Letter queue after the dispatcher exhausted its retries.">
+                  <Tooltip title={t("historytab.this_envelope_was_moved_to_the_dead_letter_q")}>
                     <Tag color="volcano">dead letter</Tag>
                   </Tooltip>
                 </Space>
@@ -251,7 +253,7 @@ export const HistoryTab = () => {
           }}
         />
         <Table.Column<NotificationHistoryRow>
-          title="Read"
+          title={t("historytab.read")}
           dataIndex="read_at"
           width={80}
           render={(v: string | null | undefined) =>
@@ -270,7 +272,7 @@ export const HistoryTab = () => {
                 setInfo(row);
                 void markRead(row);
               }}
-              aria-label="Show details"
+              aria-label={t("historytab.show_details")}
             >
               View
             </RowActionButton>
@@ -305,17 +307,17 @@ export const HistoryTab = () => {
       >
         {info && (
           <Descriptions column={1} size="small" bordered>
-            <Descriptions.Item label="Time">{formatTs(info.created_at)}</Descriptions.Item>
-            <Descriptions.Item label="Severity">
+            <Descriptions.Item label={t("historytab.time")}>{formatTs(info.created_at)}</Descriptions.Item>
+            <Descriptions.Item label={t("historytab.severity")}>
               <Tag color={severityColor[info.severity] ?? "default"}>{info.severity}</Tag>
             </Descriptions.Item>
-            <Descriptions.Item label="Event">
+            <Descriptions.Item label={t("historytab.event")}>
               <code style={{ fontSize: 12 }}>{info.event_kind}</code>
             </Descriptions.Item>
-            <Descriptions.Item label="Title">
+            <Descriptions.Item label={t("historytab.title")}>
               <Typography.Text strong>{info.title}</Typography.Text>
             </Descriptions.Item>
-            <Descriptions.Item label="Body">
+            <Descriptions.Item label={t("historytab.body")}>
               <Typography.Paragraph
                 style={{ margin: 0, fontSize: 13, whiteSpace: "pre-wrap" }}
                 copyable={{ text: info.body }}
@@ -323,7 +325,7 @@ export const HistoryTab = () => {
                 {info.body}
               </Typography.Paragraph>
             </Descriptions.Item>
-            <Descriptions.Item label="Outcome">
+            <Descriptions.Item label={t("historytab.outcome")}>
               <Space size={4} wrap>
                 <Tag color={outcomeColor[info.outcome] ?? "default"}>{info.outcome}</Tag>
                 {info.is_dead_letter && <Tag color="volcano">dead letter</Tag>}
@@ -338,15 +340,15 @@ export const HistoryTab = () => {
               )}
             </Descriptions.Item>
             {info.channel_id && (
-              <Descriptions.Item label="Channel">
+              <Descriptions.Item label={t("historytab.channel")}>
                 <code style={{ fontSize: 12 }}>{info.channel_id}</code>
               </Descriptions.Item>
             )}
             {info.retry_count > 0 && (
-              <Descriptions.Item label="Retries">{info.retry_count}</Descriptions.Item>
+              <Descriptions.Item label={t("historytab.retries")}>{info.retry_count}</Descriptions.Item>
             )}
             {info.deeplink && (
-              <Descriptions.Item label="Deeplink">
+              <Descriptions.Item label={t("historytab.deeplink")}>
                 <code style={{ fontSize: 12 }}>{info.deeplink}</code>
               </Descriptions.Item>
             )}

--- a/panel-ui/src/shells/admin/notifications/WebPushTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/WebPushTab.tsx
@@ -6,12 +6,14 @@
 // notification "channel" was misleading — every browser already needs
 // its own enable click anyway. This tab exposes the same toggle the
 // bell dropdown footer offers, with a bit more context around it.
+import { useTranslation } from "react-i18next";
 import { Alert, Button, Card, Space, Typography, message } from "antd";
 import { BellOutlined } from "@icons";
 
 import { useWebPushSubscription } from "../../../hooks/useWebPushSubscription";
 
 export const WebPushTab = () => {
+  const { t } = useTranslation();
   const webpush = useWebPushSubscription();
 
   const handleEnable = async () => {
@@ -38,8 +40,8 @@ export const WebPushTab = () => {
         <Alert
           type="warning"
           showIcon
-          message="Browser push is not supported in this browser"
-          description="Web Push relies on the Service Worker + Push API. Try a modern Chrome, Firefox, Safari 16+, or Edge build."
+          message={t("webpushtab.browser_push_is_not_supported_in_this_browse")}
+          description={t("webpushtab.web_push_relies_on_the_service_worker_push_a")}
         />
       );
     }
@@ -48,8 +50,8 @@ export const WebPushTab = () => {
         <Alert
           type="warning"
           showIcon
-          message="Browser blocked notifications"
-          description="Open the site permissions for this domain in your browser settings and re-allow notifications, then reload."
+          message={t("webpushtab.browser_blocked_notifications")}
+          description={t("webpushtab.open_the_site_permissions_for_this_domain_in")}
         />
       );
     }
@@ -59,8 +61,8 @@ export const WebPushTab = () => {
           <Alert
             type="success"
             showIcon
-            message="This browser is receiving Jabali push notifications"
-            description="Notifications appear via your operating system even when the panel tab isn't focused. Disable any time below."
+            message={t("webpushtab.this_browser_is_receiving_jabali_push_notifi")}
+            description={t("webpushtab.notifications_appear_via_your_operating_syst")}
           />
           <Button danger onClick={handleDisable} loading={webpush.loading}>
             Disable on this browser
@@ -79,7 +81,7 @@ export const WebPushTab = () => {
           <Alert
             type="error"
             showIcon
-            message="Couldn't enable browser push"
+            message={t("webpushtab.couldn_t_enable_browser_push")}
             description={webpush.error}
           />
         )}

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -2,6 +2,7 @@
 //
 // Form.useForm + useCreateMutation; layout matches the old Refine
 // version (grid of resource limits + feature quotas + two switches).
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Card,
@@ -62,6 +63,7 @@ type PackageCreateInput = {
 type PackageCreated = { id: string };
 
 export const PackageCreate = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [form] = Form.useForm<PackageCreateInput>();
   const { enabled: diskQuotaEnabled } = useDiskQuotaEnabled();
@@ -158,7 +160,7 @@ export const PackageCreate = () => {
         onFinish={handleFinish}
       >
         <Form.Item
-          label="Name"
+          label={t("packagecreate.name")}
           name="name"
           rules={[{ required: true, message: "Package name is required" }]}
         >
@@ -174,7 +176,7 @@ export const PackageCreate = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Disk Quota (MB)"
+              label={t("packagecreate.disk_quota_mb")}
               name="disk_quota_mb"
               rules={[{ required: true, message: "Disk quota is required" }]}
               tooltip={
@@ -193,7 +195,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="CPU Quota (%)"
+              label={t("packagecreate.cpu_quota")}
               name="cpu_quota_percent"
               tooltip="systemd CPUQuota — 100% = 1 core, 200% = 2 cores. 0 = unlimited."
             >
@@ -202,7 +204,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Memory Limit (MB)"
+              label={t("packagecreate.memory_limit_mb")}
               name="memory_limit_mb"
               tooltip="systemd MemoryMax; MemoryHigh is fixed at 90% of this. 0 = unlimited."
             >
@@ -211,7 +213,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="IO Read Bandwidth (MB/s)"
+              label={t("packagecreate.io_read_bandwidth_mb_s")}
               name="io_read_mbps"
               tooltip="systemd IOReadBandwidthMax on /. 0 = unlimited."
             >
@@ -220,7 +222,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="IO Write Bandwidth (MB/s)"
+              label={t("packagecreate.io_write_bandwidth_mb_s")}
               name="io_write_mbps"
               tooltip="systemd IOWriteBandwidthMax on /. 0 = unlimited."
             >
@@ -229,7 +231,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Tasks"
+              label={t("packagecreate.max_tasks")}
               name="max_tasks"
               tooltip="systemd TasksMax — upper bound on concurrent processes. 0 = unlimited."
             >
@@ -243,7 +245,7 @@ export const PackageCreate = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Bandwidth Quota (MB)"
+              label={t("packagecreate.bandwidth_quota_mb")}
               name="bandwidth_quota_mb"
               rules={[{ required: true, message: "Bandwidth quota is required" }]}
               tooltip="0 = unlimited"
@@ -253,7 +255,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Domains"
+              label={t("packagecreate.max_domains")}
               name="max_domains"
               rules={[{ required: true, message: "Max domains is required" }]}
               tooltip="0 = unlimited"
@@ -263,7 +265,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Email Accounts"
+              label={t("packagecreate.max_email_accounts")}
               name="max_email_accounts"
               rules={[
                 { required: true, message: "Max email accounts is required" },
@@ -275,7 +277,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Databases"
+              label={t("packagecreate.max_databases")}
               name="max_databases"
               rules={[{ required: true, message: "Max databases is required" }]}
               tooltip="0 = unlimited"
@@ -285,7 +287,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Docker Apps"
+              label={t("packagecreate.max_docker_apps")}
               name="max_docker_apps"
               tooltip="0 = Docker apps not included in this package"
             >
@@ -294,7 +296,7 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Python Apps"
+              label={t("packagecreate.max_python_apps")}
               name="max_python_apps"
               tooltip="0 = Python apps not included in this package"
             >
@@ -312,28 +314,28 @@ export const PackageCreate = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Backups"
+              label={t("packagecreate.max_backups")}
               name="max_backups"
-              tooltip="Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included."
+              tooltip={t("packagecreate.retention_cap_most_snapshots_a_tenant_on_thi")}
             >
               <InputNumber min={0} style={{ width: "100%" }} />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Scheduled Backups"
+              label={t("packagecreate.scheduled_backups")}
               name="scheduled_backups_enabled"
               valuePropName="checked"
-              tooltip="Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled."
+              tooltip={t("packagecreate.allow_tenants_on_this_plan_to_enable_a_sched")}
             >
               <Switch />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Allowed Backup Destinations"
+              label={t("packagecreate.allowed_backup_destinations")}
               name="allowed_backup_destination_kinds"
-              tooltip="Destination kinds a tenant may back up to. Empty = none allowed."
+              tooltip={t("packagecreate.destination_kinds_a_tenant_may_back_up_to_em")}
             >
               <Select
                 mode="multiple"
@@ -346,9 +348,9 @@ export const PackageCreate = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Backup Retention Policy"
+              label={t("packagecreate.backup_retention_policy")}
               name="backup_retention_policy"
-              tooltip="What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+              tooltip={t("packagecreate.what_happens_when_a_tenant_reaches_max_backu")}
             >
               <Select
                 options={[
@@ -367,7 +369,7 @@ export const PackageCreate = () => {
           <Form.Item
             name="ssh_enabled"
             valuePropName="checked"
-            tooltip="Allow SSH access"
+            tooltip={t("packagecreate.allow_ssh_access")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -379,7 +381,7 @@ export const PackageCreate = () => {
           <Form.Item
             name="cgi_enabled"
             valuePropName="checked"
-            tooltip="Allow CGI scripts"
+            tooltip={t("packagecreate.allow_cgi_scripts")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -391,7 +393,7 @@ export const PackageCreate = () => {
           <Form.Item
             name="php_exec_enabled"
             valuePropName="checked"
-            tooltip="Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs."
+            tooltip={t("packagecreate.security_re_enables_php_exec_proc_open_shell")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -406,7 +408,7 @@ export const PackageCreate = () => {
           <Form.Item
             name="fpm_user_can_edit"
             valuePropName="checked"
-            tooltip="Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized)."
+            tooltip={t("packagecreate.let_tenants_pick_a_safe_php_performance_mode")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -417,30 +419,30 @@ export const PackageCreate = () => {
           <Form.Item
             name="fpm_advanced_mode"
             valuePropName="checked"
-            tooltip="Also expose the individual pm.* knobs (clamped to the cap). Implies the toggle above."
+            tooltip={t("packagecreate.also_expose_the_individual_pm_knobs_clamped")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
           </Form.Item>
           <Typography.Text>Users can use Advanced mode (raw pm.*, clamped to the cap)</Typography.Text>
         </div>
-        <Form.Item name="fpm_max_children_cap" label="Max children per user (FPM cap)">
+        <Form.Item name="fpm_max_children_cap" label={t("packagecreate.max_children_per_user_fpm_cap")}>
           <InputNumber min={1} max={2000} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item name="fpm_worker_mem_mb" label="Est. RAM per worker (MB) — drives the memory-budget estimate">
+        <Form.Item name="fpm_worker_mem_mb" label={t("packagecreate.est_ram_per_worker_mb_drives_the_memory_budg")}>
           <InputNumber min={8} max={2048} style={{ width: 160 }} />
         </Form.Item>
 
 
         <Form.Item
-          label="Docker apps (per-package allowlist)"
+          label={t("packagecreate.docker_apps_per_package_allowlist")}
           name="docker_app_slugs"
           extra="Tenants on this package may install only these apps. Empty = use the server-wide Docker Apps curation. Requires Max Docker Apps > 0."
         >
           <Select
             mode="multiple"
             allowClear
-            placeholder="Empty = server-wide default"
+            placeholder={t("packagecreate.empty_server_wide_default")}
             options={dockerApps.map((a) => ({ value: a.slug, label: a.name }))}
           />
         </Form.Item>

--- a/panel-ui/src/shells/admin/packages/PackageEdit.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageEdit.tsx
@@ -2,6 +2,7 @@
 //
 // Same field set as PackageCreate; initial values load via useOneQuery
 // and seed the Form once they arrive.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Button,
@@ -67,6 +68,7 @@ type PackageEditInput = {
 type PackageRecord = PackageEditInput & { id: string };
 
 export const PackageEdit = () => {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [form] = Form.useForm<PackageEditInput>();
@@ -176,7 +178,7 @@ export const PackageEdit = () => {
         onFinish={handleFinish}
       >
         <Form.Item
-          label="Name"
+          label={t("packageedit.name")}
           name="name"
           rules={[{ required: true, message: "Package name is required" }]}
         >
@@ -192,7 +194,7 @@ export const PackageEdit = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Disk Quota (MB)"
+              label={t("packageedit.disk_quota_mb")}
               name="disk_quota_mb"
               rules={[{ required: true, message: "Disk quota is required" }]}
               tooltip={
@@ -211,7 +213,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="CPU Quota (%)"
+              label={t("packageedit.cpu_quota")}
               name="cpu_quota_percent"
               tooltip="systemd CPUQuota — 100% = 1 core, 200% = 2 cores. 0 = unlimited."
             >
@@ -220,7 +222,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Memory Limit (MB)"
+              label={t("packageedit.memory_limit_mb")}
               name="memory_limit_mb"
               tooltip="systemd MemoryMax; MemoryHigh is fixed at 90% of this. 0 = unlimited."
             >
@@ -229,7 +231,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="IO Read Bandwidth (MB/s)"
+              label={t("packageedit.io_read_bandwidth_mb_s")}
               name="io_read_mbps"
               tooltip="systemd IOReadBandwidthMax on /. 0 = unlimited."
             >
@@ -238,7 +240,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="IO Write Bandwidth (MB/s)"
+              label={t("packageedit.io_write_bandwidth_mb_s")}
               name="io_write_mbps"
               tooltip="systemd IOWriteBandwidthMax on /. 0 = unlimited."
             >
@@ -247,7 +249,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Tasks"
+              label={t("packageedit.max_tasks")}
               name="max_tasks"
               tooltip="systemd TasksMax — upper bound on concurrent processes. 0 = unlimited."
             >
@@ -261,7 +263,7 @@ export const PackageEdit = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Bandwidth Quota (MB)"
+              label={t("packageedit.bandwidth_quota_mb")}
               name="bandwidth_quota_mb"
               rules={[{ required: true, message: "Bandwidth quota is required" }]}
               tooltip="0 = unlimited"
@@ -271,7 +273,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Domains"
+              label={t("packageedit.max_domains")}
               name="max_domains"
               rules={[{ required: true, message: "Max domains is required" }]}
               tooltip="0 = unlimited"
@@ -281,7 +283,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Email Accounts"
+              label={t("packageedit.max_email_accounts")}
               name="max_email_accounts"
               rules={[
                 { required: true, message: "Max email accounts is required" },
@@ -293,7 +295,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Databases"
+              label={t("packageedit.max_databases")}
               name="max_databases"
               rules={[{ required: true, message: "Max databases is required" }]}
               tooltip="0 = unlimited"
@@ -303,7 +305,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Docker Apps"
+              label={t("packageedit.max_docker_apps")}
               name="max_docker_apps"
               tooltip="0 = Docker apps not included in this package"
             >
@@ -312,7 +314,7 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Python Apps"
+              label={t("packageedit.max_python_apps")}
               name="max_python_apps"
               tooltip="0 = Python apps not included in this package"
             >
@@ -330,28 +332,28 @@ export const PackageEdit = () => {
         <Row gutter={16}>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Max Backups"
+              label={t("packageedit.max_backups")}
               name="max_backups"
-              tooltip="Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included."
+              tooltip={t("packageedit.retention_cap_most_snapshots_a_tenant_on_thi")}
             >
               <InputNumber min={0} style={{ width: "100%" }} />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Scheduled Backups"
+              label={t("packageedit.scheduled_backups")}
               name="scheduled_backups_enabled"
               valuePropName="checked"
-              tooltip="Allow tenants on this plan to enable a scheduled backup. The schedule time is admin-controlled."
+              tooltip={t("packageedit.allow_tenants_on_this_plan_to_enable_a_sched")}
             >
               <Switch />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Allowed Backup Destinations"
+              label={t("packageedit.allowed_backup_destinations")}
               name="allowed_backup_destination_kinds"
-              tooltip="Destination kinds a tenant may back up to. Empty = none allowed."
+              tooltip={t("packageedit.destination_kinds_a_tenant_may_back_up_to_em")}
             >
               <Select
                 mode="multiple"
@@ -364,9 +366,9 @@ export const PackageEdit = () => {
           </Col>
           <Col xs={24} sm={12} md={8}>
             <Form.Item
-              label="Backup Retention Policy"
+              label={t("packageedit.backup_retention_policy")}
               name="backup_retention_policy"
-              tooltip="What happens when a tenant reaches Max Backups: Reject (safe — block the new backup) or Auto-prune (delete the tenant's oldest backup to make room). Both notify the tenant and admins."
+              tooltip={t("packageedit.what_happens_when_a_tenant_reaches_max_backu")}
             >
               <Select
                 options={[
@@ -385,7 +387,7 @@ export const PackageEdit = () => {
           <Form.Item
             name="ssh_enabled"
             valuePropName="checked"
-            tooltip="Allow SSH access"
+            tooltip={t("packageedit.allow_ssh_access")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -397,7 +399,7 @@ export const PackageEdit = () => {
           <Form.Item
             name="cgi_enabled"
             valuePropName="checked"
-            tooltip="Allow CGI scripts"
+            tooltip={t("packageedit.allow_cgi_scripts")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -409,7 +411,7 @@ export const PackageEdit = () => {
           <Form.Item
             name="php_exec_enabled"
             valuePropName="checked"
-            tooltip="Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs."
+            tooltip={t("packageedit.security_re_enables_php_exec_proc_open_shell")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -424,7 +426,7 @@ export const PackageEdit = () => {
           <Form.Item
             name="fpm_user_can_edit"
             valuePropName="checked"
-            tooltip="Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized)."
+            tooltip={t("packageedit.let_tenants_pick_a_safe_php_performance_mode")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
@@ -435,30 +437,30 @@ export const PackageEdit = () => {
           <Form.Item
             name="fpm_advanced_mode"
             valuePropName="checked"
-            tooltip="Also expose the individual pm.* knobs (clamped to the cap). Implies the toggle above."
+            tooltip={t("packageedit.also_expose_the_individual_pm_knobs_clamped")}
             noStyle
           >
             <Switch checkedChildren={<CheckOutlined />} unCheckedChildren={<CloseOutlined />} />
           </Form.Item>
           <Typography.Text>Users can use Advanced mode (raw pm.*, clamped to the cap)</Typography.Text>
         </div>
-        <Form.Item name="fpm_max_children_cap" label="Max children per user (FPM cap)">
+        <Form.Item name="fpm_max_children_cap" label={t("packageedit.max_children_per_user_fpm_cap")}>
           <InputNumber min={1} max={2000} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item name="fpm_worker_mem_mb" label="Est. RAM per worker (MB) — drives the memory-budget estimate">
+        <Form.Item name="fpm_worker_mem_mb" label={t("packageedit.est_ram_per_worker_mb_drives_the_memory_budg")}>
           <InputNumber min={8} max={2048} style={{ width: 160 }} />
         </Form.Item>
 
 
         <Form.Item
-          label="Docker apps (per-package allowlist)"
+          label={t("packageedit.docker_apps_per_package_allowlist")}
           name="docker_app_slugs"
           extra="Tenants on this package may install only these apps. Empty = use the server-wide Docker Apps curation. Requires Max Docker Apps > 0."
         >
           <Select
             mode="multiple"
             allowClear
-            placeholder="Empty = server-wide default"
+            placeholder={t("packageedit.empty_server_wide_default")}
             options={dockerApps.map((a) => ({ value: a.slug, label: a.name }))}
           />
         </Form.Item>

--- a/panel-ui/src/shells/admin/packages/PackageList.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageList.tsx
@@ -2,6 +2,7 @@
 // Post-M21: useTable → useTableURL, <CreateButton>/<EditButton>/
 // <DeleteButton> replaced with plain react-router <Button>s + a
 // RowDeleteButton wired to useDeleteMutation.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Input, Space, Table, Tag, Typography } from "antd";
 import { EditOutlined, PackageOpenOutlined, SearchOutlined, DeleteOutlined } from "@icons";
 
@@ -34,6 +35,7 @@ type Package = {
 const formatQuota = (value: number) => (value === 0 ? "∞" : value);
 
 export const PackageList = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const query = useTableURL<Package>({
     resource: "packages",
@@ -102,7 +104,7 @@ export const PackageList = () => {
           locale={{
             emptyText: (
               <EmptyWithCTA
-                description="No hosting packages yet"
+                description={t("packagelist.no_hosting_packages_yet")}
                 ctaLabel="Create package"
                 onCta={() => navigate("/jabali-admin/packages/create")}
               />
@@ -111,7 +113,7 @@ export const PackageList = () => {
         >
           <Table.Column
             dataIndex="name"
-            title="Name"
+            title={t("packagelist.name")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -123,7 +125,7 @@ export const PackageList = () => {
             filterDropdown={({ confirm, close }) => (
               <div style={{ padding: 8, minWidth: 240 }}>
                 <Input.Search
-                  placeholder="Search by package name"
+                  placeholder={t("packagelist.search_by_package_name")}
                   allowClear
                   defaultValue={query.params.q}
                   onSearch={(value) => {
@@ -137,28 +139,28 @@ export const PackageList = () => {
           />
           <Table.Column
             dataIndex="disk_quota_mb"
-            title="Disk (MB)"
+            title={t("packagelist.disk_mb")}
             key="disk_quota_mb"
             sorter={{ multiple: 1 }}
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="bandwidth_quota_mb"
-            title="Bandwidth (MB)"
+            title={t("packagelist.bandwidth_mb")}
             key="bandwidth_quota_mb"
             sorter={{ multiple: 1 }}
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="max_domains"
-            title="Domains"
+            title={t("packagelist.domains")}
             key="max_domains"
             sorter={{ multiple: 1 }}
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="max_email_accounts"
-            title="Email"
+            title={t("packagelist.email")}
             key="max_email_accounts"
             sorter={{ multiple: 1 }}
             render={(value: number) => formatQuota(value)}
@@ -172,7 +174,7 @@ export const PackageList = () => {
           />
           <Table.Column
             dataIndex="ssh_enabled"
-            title="SSH"
+            title={t("packagelist.ssh")}
             key="ssh_enabled"
             sorter={{ multiple: 1 }}
             render={(enabled: boolean) =>
@@ -181,7 +183,7 @@ export const PackageList = () => {
           />
           <Table.Column
             dataIndex="php_exec_enabled"
-            title="PHP exec"
+            title={t("packagelist.php_exec")}
             key="php_exec_enabled"
             sorter={{ multiple: 1 }}
             render={(enabled: boolean) =>
@@ -190,13 +192,13 @@ export const PackageList = () => {
           />
           <Table.Column
             dataIndex="created_at"
-            title="Created"
+            title={t("packagelist.created")}
             key="created_at"
             sorter={{ multiple: 1 }}
             render={(ts: string) => shortDateTime(ts)}
           />
           <Table.Column
-            title="Actions"
+            title={t("packagelist.actions")}
             dataIndex="actions"
             render={(_: unknown, r: Package) => (
               <RowActions

--- a/panel-ui/src/shells/admin/php-pools/PHPPoolEdit.tsx
+++ b/panel-ui/src/shells/admin/php-pools/PHPPoolEdit.tsx
@@ -3,6 +3,7 @@
 // Main form tweaks pm_mode / pm_max_children / idle timeout. A nested
 // INI overrides table lives below the save button, driven by its own
 // useListQuery + direct apiClient POST/DELETE calls.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Button,
@@ -59,6 +60,7 @@ type IniOverrideInput = {
 };
 
 export const PHPPoolEdit = () => {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [form] = Form.useForm<PHPPoolInput>();
@@ -165,11 +167,11 @@ export const PHPPoolEdit = () => {
         onFinish={handleFinish}
       >
         <Form.Item
-          label="Process Mode"
+          label={t("phppooledit.process_mode")}
           name="pm_mode"
           rules={[{ required: true, message: "Process mode is required" }]}
         >
-          <Select placeholder="Select process manager mode">
+          <Select placeholder={t("phppooledit.select_process_manager_mode")}>
             <Select.Option value="static">static</Select.Option>
             <Select.Option value="dynamic">dynamic</Select.Option>
             <Select.Option value="ondemand">ondemand</Select.Option>
@@ -177,44 +179,44 @@ export const PHPPoolEdit = () => {
         </Form.Item>
 
         <Form.Item
-          label="Max Children"
+          label={t("phppooledit.max_children")}
           name="pm_max_children"
           rules={[{ required: true, message: "Max children is required" }]}
         >
-          <InputNumber min={1} placeholder="Number of child processes" />
+          <InputNumber min={1} placeholder={t("phppooledit.number_of_child_processes")} />
         </Form.Item>
 
         <Form.Item
-          label="Process Idle Timeout (seconds)"
+          label={t("phppooledit.process_idle_timeout_seconds")}
           name="process_idle_timeout_seconds"
           rules={[{ required: false }]}
         >
-          <InputNumber min={0} placeholder="Idle timeout in seconds" />
+          <InputNumber min={0} placeholder={t("phppooledit.idle_timeout_in_seconds")} />
         </Form.Item>
 
         {pmMode === "dynamic" && (
           <>
-            <Form.Item label="Start Servers (dynamic)" name="pm_start_servers">
+            <Form.Item label={t("phppooledit.start_servers_dynamic")} name="pm_start_servers">
               <InputNumber min={1} placeholder="pm.start_servers" />
             </Form.Item>
-            <Form.Item label="Min Spare Servers (dynamic)" name="pm_min_spare_servers">
+            <Form.Item label={t("phppooledit.min_spare_servers_dynamic")} name="pm_min_spare_servers">
               <InputNumber min={1} placeholder="pm.min_spare_servers" />
             </Form.Item>
-            <Form.Item label="Max Spare Servers (dynamic, <= max children)" name="pm_max_spare_servers">
+            <Form.Item label={t("phppooledit.max_spare_servers_dynamic_max_children")} name="pm_max_spare_servers">
               <InputNumber min={1} placeholder="pm.max_spare_servers" />
             </Form.Item>
           </>
         )}
 
-        <Form.Item label="Max Requests per Worker (0 = never)" name="pm_max_requests">
+        <Form.Item label={t("phppooledit.max_requests_per_worker_0_never")} name="pm_max_requests">
           <InputNumber min={0} placeholder="pm.max_requests" />
         </Form.Item>
 
-        <Form.Item label="Request Terminate Timeout (seconds, 0 = no limit)" name="request_terminate_timeout_seconds">
+        <Form.Item label={t("phppooledit.request_terminate_timeout_seconds_0_no_limit")} name="request_terminate_timeout_seconds">
           <InputNumber min={0} placeholder="request_terminate_timeout" />
         </Form.Item>
 
-        <Form.Item label="PHP Version" name="php_version">
+        <Form.Item label={t("phppooledit.php_version")} name="php_version">
           <Input disabled />
         </Form.Item>
 
@@ -297,7 +299,7 @@ export const PHPPoolEdit = () => {
         />
 
         <Modal
-          title="Add INI Override"
+          title={t("phppooledit.add_ini_override")}
           open={isOverrideModalOpen}
           onOk={handleAddOverride}
           onCancel={() => {
@@ -306,7 +308,7 @@ export const PHPPoolEdit = () => {
           }}
         >
           <Form layout="vertical">
-            <Form.Item label="Directive">
+            <Form.Item label={t("phppooledit.directive")}>
               <Input
                 placeholder="e.g., memory_limit"
                 value={overrideForm.directive}
@@ -318,7 +320,7 @@ export const PHPPoolEdit = () => {
                 }
               />
             </Form.Item>
-            <Form.Item label="Value">
+            <Form.Item label={t("phppooledit.value")}>
               <Input
                 placeholder="e.g., 256M"
                 value={overrideForm.value}
@@ -327,7 +329,7 @@ export const PHPPoolEdit = () => {
                 }
               />
             </Form.Item>
-            <Form.Item label="Kind">
+            <Form.Item label={t("phppooledit.kind")}>
               <Select
                 value={overrideForm.kind}
                 onChange={(value) =>

--- a/panel-ui/src/shells/admin/php/FPMPoolsTab.tsx
+++ b/panel-ui/src/shells/admin/php/FPMPoolsTab.tsx
@@ -1,6 +1,7 @@
 // FPMPoolsTab — GH #339 phase 2, Step 3. Admin PHP Manager tab: pick a PHP
 // version, see every user's pool on it, edit the raw pm.* via the existing
 // PHPPoolEdit route. L3 (admin, uncapped). /php-pools is admin-only (PR #34).
+import { useTranslation } from "react-i18next";
 import { Alert, Select, Space, Spin, Table, Tag, Typography } from "antd";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -18,6 +19,7 @@ type Pool = {
 };
 
 export const FPMPoolsTab = () => {
+  const { t } = useTranslation();
   const [version, setVersion] = useState<string>("");
   const { data, isLoading, isError } = useQuery<Pool[]>({
     queryKey: ["admin-php-pools"],
@@ -25,7 +27,7 @@ export const FPMPoolsTab = () => {
   });
 
   if (isLoading) return <Spin />;
-  if (isError) return <Alert type="error" message="Could not load PHP-FPM pools." />;
+  if (isError) return <Alert type="error" message={t("fpmpoolstab.could_not_load_php_fpm_pools")} />;
 
   const pools = data ?? [];
   const versions = Array.from(new Set(pools.map((p) => p.php_version))).sort();
@@ -39,7 +41,7 @@ export const FPMPoolsTab = () => {
       </Typography.Paragraph>
       <Select
         style={{ width: 220 }}
-        placeholder="Filter by PHP version"
+        placeholder={t("fpmpoolstab.filter_by_php_version")}
         allowClear
         value={version || undefined}
         onChange={(v) => setVersion(v ?? "")}

--- a/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
@@ -41,6 +42,7 @@ interface VersionStatusResponse {
 type ApplyAction = "install" | "remove" | "enable" | "disable";
 
 export const PHPExtensionsTab = () => {
+  const { t } = useTranslation();
   const [versions, setVersions] = useState<string[]>([]);
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null);
   const [extensions, setExtensions] = useState<ExtensionState[]>([]);
@@ -153,8 +155,8 @@ export const PHPExtensionsTab = () => {
       <Alert
         type="info"
         showIcon
-        title="No PHP versions installed"
-        description="Install a PHP version first under the PHP Versions tab. Extension management requires at least one installed version."
+        title={t("phpextensionstab.no_php_versions_installed")}
+        description={t("phpextensionstab.install_a_php_version_first_under_the_php_ve")}
       />
     );
   }
@@ -168,7 +170,7 @@ export const PHPExtensionsTab = () => {
           value={selectedVersion ?? undefined}
           onChange={(v) => setSelectedVersion(v)}
           options={versions.map((v) => ({ value: v, label: `PHP ${v}` }))}
-          aria-label="PHP version"
+          aria-label={t("phpextensionstab.php_version")}
         />
       </Space>
 
@@ -185,7 +187,7 @@ export const PHPExtensionsTab = () => {
         >
           <Table.Column<ExtensionState>
             dataIndex="name"
-            title="Extension"
+            title={t("phpextensionstab.extension")}
             sorter={(a, b) => a.name.localeCompare(b.name)}
             filterIcon={() => <SearchOutlined />}
             // Column-level search wired to the same `search` state that
@@ -196,7 +198,7 @@ export const PHPExtensionsTab = () => {
             filterDropdown={({ confirm, close }) => (
               <div style={{ padding: 8, minWidth: 220 }}>
                 <Input.Search
-                  placeholder="Search extensions"
+                  placeholder={t("phpextensionstab.search_extensions")}
                   allowClear
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
@@ -217,7 +219,7 @@ export const PHPExtensionsTab = () => {
           />
           <Table.Column<ExtensionState>
             dataIndex="enabled"
-            title="Status"
+            title={t("phpextensionstab.status")}
             width={120}
             sorter={(a, b) => Number(b.enabled) - Number(a.enabled)}
             render={(enabled: boolean) =>
@@ -226,7 +228,7 @@ export const PHPExtensionsTab = () => {
           />
           <Table.Column<ExtensionState>
             dataIndex="installed"
-            title="Installed"
+            title={t("phpextensionstab.installed")}
             width={120}
             sorter={(a, b) => Number(b.installed) - Number(a.installed)}
             render={(installed: boolean) =>
@@ -234,7 +236,7 @@ export const PHPExtensionsTab = () => {
             }
           />
           <Table.Column<ExtensionState>
-            title="Action"
+            title={t("phpextensionstab.action")}
             width={260}
             render={(_: unknown, record) => (
               <ExtensionActions

--- a/panel-ui/src/shells/admin/php/VersionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/VersionsTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Alert, notification, Spin, Table, Tag, Tooltip } from "antd";
 import {
@@ -26,6 +27,7 @@ interface PHPVersionStatusResponse {
 }
 
 export const VersionsTab = () => {
+  const { t } = useTranslation();
   const [statusData, setStatusData] = useState<PHPVersionStatusResponse | null>(
     null
   );
@@ -203,8 +205,8 @@ export const VersionsTab = () => {
         <Alert
           type="warning"
           showIcon
-          title="Modifying PHP versions can cause server downtime"
-          description="Uninstalling PHP versions may break websites that depend on them. Ensure you understand the impact before making changes."
+          title={t("versionstab.modifying_php_versions_can_cause_server_down")}
+          description={t("versionstab.uninstalling_php_versions_may_break_websites")}
           closable
           onClose={() => setDismissedWarning(true)}
           style={{ marginBottom: 16 }}
@@ -220,12 +222,12 @@ export const VersionsTab = () => {
       >
         <Table.Column<PHPVersionStatus>
           dataIndex="version"
-          title="PHP Version"
+          title={t("versionstab.php_version")}
           render={(version: string) => (
             <span>
               PHP {version}
               {isPHPEOL(version) && (
-                <Tooltip title="End of life — no upstream security patches. Running an EOL PHP version on a public site is a security risk.">
+                <Tooltip title={t("versionstab.end_of_life_no_upstream_security_patches_run")}>
                   <Tag color="red" style={{ marginLeft: 8 }}>
                     EOL
                   </Tag>
@@ -236,7 +238,7 @@ export const VersionsTab = () => {
         />
         <Table.Column<PHPVersionStatus>
           dataIndex="installed"
-          title="Status"
+          title={t("versionstab.status")}
           width={150}
           render={(installed: boolean) =>
             installed ? (
@@ -247,7 +249,7 @@ export const VersionsTab = () => {
           }
         />
         <Table.Column<PHPVersionStatus>
-          title="Default"
+          title={t("versionstab.default")}
           width={140}
           render={(_: any, record: PHPVersionStatus) => {
             if (record.version === statusData?.default_version && record.installed) {
@@ -272,7 +274,7 @@ export const VersionsTab = () => {
         />
         <Table.Column<PHPVersionStatus>
           dataIndex="fpm_running"
-          title="FPM workers"
+          title={t("versionstab.fpm_workers")}
           width={170}
           render={(_fpmRunning: boolean, record: PHPVersionStatus) => {
             if (!record.installed) return "—";
@@ -289,7 +291,7 @@ export const VersionsTab = () => {
           }}
         />
         <Table.Column<PHPVersionStatus>
-          title="Actions"
+          title={t("versionstab.actions")}
           width={220}
           render={(_: any, record: PHPVersionStatus) => {
             const isInstalling = installingVersion === record.version;

--- a/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
@@ -1,5 +1,6 @@
 // AdminSecurityAide — admin Security tab "AIDE" sub-tab (M42, ADR-0087).
 // Read-only FIM status + manual recheck trigger.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { apiClient } from "../../../apiClient";
 import { Alert, Badge, Button, Card, Popconfirm, Select, Space, Statistic, Table, Tag, Tooltip, Typography, message } from "antd";
@@ -37,6 +38,7 @@ function humanizeAge(seconds: number): string {
 }
 
 export const AdminSecurityAide = () => {
+  const { t } = useTranslation();
   const { data, isLoading, refetch } = useAideStatus();
   const [aideCatFilter, setAideCatFilter] = useState<string | undefined>(undefined);
   const [aideTypeFilter, setAideTypeFilter] = useState<string | undefined>(undefined);
@@ -45,7 +47,7 @@ export const AdminSecurityAide = () => {
 
   if (isLoading) {
     return (
-      <Card title="AIDE — file integrity monitor" size="small">
+      <Card title={t("adminsecurityaide.aide_file_integrity_monitor")} size="small">
         <Typography.Text type="secondary">Loading…</Typography.Text>
       </Card>
     );
@@ -53,11 +55,11 @@ export const AdminSecurityAide = () => {
 
   if (!data?.enabled) {
     return (
-      <Card title="AIDE — file integrity monitor" size="small">
+      <Card title={t("adminsecurityaide.aide_file_integrity_monitor")} size="small">
         <Alert
           type="warning"
           showIcon
-          message="AIDE not active"
+          message={t("adminsecurityaide.aide_not_active")}
           description={data?.reason || "AIDE not installed or DB missing. install_aide() runs on jabali update."}
         />
       </Card>
@@ -68,7 +70,7 @@ export const AdminSecurityAide = () => {
 
   return (
     <Card
-      title="AIDE — file integrity monitor"
+      title={t("adminsecurityaide.aide_file_integrity_monitor")}
       size="small"
       extra={
         <Space>
@@ -127,9 +129,9 @@ export const AdminSecurityAide = () => {
             Rebuild (dry run)
           </Button>
           <Popconfirm
-            title="Rebuild the AIDE baseline?"
-            description="This replaces the integrity baseline with the current filesystem state (aideinit -y -f). Only do this after deliberate changes — any tampering present now becomes the new 'clean' baseline."
-            okText="Rebuild"
+            title={t("adminsecurityaide.rebuild_the_aide_baseline")}
+            description={t("adminsecurityaide.this_replaces_the_integrity_baseline_with_th")}
+            okText={t("adminsecurityaide.rebuild")}
             okButtonProps={{ danger: true }}
             onConfirm={() =>
               runRebuild.mutate(false, {
@@ -155,11 +157,11 @@ export const AdminSecurityAide = () => {
       </Typography.Paragraph>
 
       <Space size="large" style={{ marginBottom: 16 }}>
-        <Statistic title="DB age" value={humanizeAge(data.db_age_seconds)} />
-        <Statistic title="Last check" value={data.last_check_ts || "—"} />
-        <Statistic title="Added" value={data.summary.added} />
-        <Statistic title="Changed" value={data.summary.changed} />
-        <Statistic title="Removed" value={data.summary.removed} />
+        <Statistic title={t("adminsecurityaide.db_age")} value={humanizeAge(data.db_age_seconds)} />
+        <Statistic title={t("adminsecurityaide.last_check")} value={data.last_check_ts || "—"} />
+        <Statistic title={t("adminsecurityaide.added")} value={data.summary.added} />
+        <Statistic title={t("adminsecurityaide.changed")} value={data.summary.changed} />
+        <Statistic title={t("adminsecurityaide.removed")} value={data.summary.removed} />
       </Space>
 
       {total > 0 ? (
@@ -167,15 +169,15 @@ export const AdminSecurityAide = () => {
           type="warning"
           showIcon
           message={`${total} file(s) changed since the last baseline`}
-          description="Review the sample below. If the changes are expected (kernel bump, manual config edit), re-baseline via SSH: jabali aide rebuild --full."
+          description={t("adminsecurityaide.review_the_sample_below_if_the_changes_are_e")}
           style={{ marginBottom: 12 }}
         />
       ) : (
         <Alert
           type="success"
           showIcon
-          message="No tamper detected"
-          description="All watched paths match the baseline checksum."
+          message={t("adminsecurityaide.no_tamper_detected")}
+          description={t("adminsecurityaide.all_watched_paths_match_the_baseline_checksu")}
           style={{ marginBottom: 12 }}
         />
       )}
@@ -197,7 +199,7 @@ export const AdminSecurityAide = () => {
               type="warning"
               showIcon
               style={{ marginTop: 12 }}
-              message="Prioritize these"
+              message={t("adminsecurityaide.prioritize_these")}
               description="`security-control` and `unknown/unowned` changes deserve scrutiny before re-baselining — the rest is usually package/kernel churn."
             />
           ) : null}
@@ -206,7 +208,7 @@ export const AdminSecurityAide = () => {
       <Space wrap style={{ marginBottom: 12 }}>
         <Select
           allowClear
-          placeholder="Category"
+          placeholder={t("adminsecurityaide.category")}
           style={{ width: 180 }}
           value={aideCatFilter}
           onChange={setAideCatFilter}
@@ -214,7 +216,7 @@ export const AdminSecurityAide = () => {
         />
         <Select
           allowClear
-          placeholder="Change type"
+          placeholder={t("adminsecurityaide.change_type")}
           style={{ width: 150 }}
           value={aideTypeFilter}
           onChange={setAideTypeFilter}

--- a/panel-ui/src/shells/admin/security/AdminSecurityAppArmor.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityAppArmor.tsx
@@ -3,6 +3,7 @@
 // flip behind a confirm modal. Recent denials feed (last 24h, capped
 // 50 rows) below the profile table — answers "what did AppArmor
 // actually drop?" without dropping to journalctl.
+import { useTranslation } from "react-i18next";
 import { Alert, Badge, Button, Card, Checkbox, Descriptions, Drawer, Empty, Modal, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { useState } from "react";
 
@@ -28,6 +29,7 @@ const MODE_TINT: Record<AppArmorProfile["mode"], "success" | "warning" | "error"
 };
 
 export const AdminSecurityAppArmor = () => {
+  const { t } = useTranslation();
   const { data, isLoading, refetch } = useAppArmorStatus();
   const setMode = useSetAppArmorMode();
   const [pendingFlip, setPendingFlip] = useState<{ profile: string; nextMode: "enforce" | "complain" } | null>(null);
@@ -37,7 +39,7 @@ export const AdminSecurityAppArmor = () => {
 
   if (isLoading) {
     return (
-      <Card title="AppArmor" size="small">
+      <Card title={t("adminsecurityapparmor.apparmor")} size="small">
         <Typography.Text type="secondary">Loading…</Typography.Text>
       </Card>
     );
@@ -45,11 +47,11 @@ export const AdminSecurityAppArmor = () => {
 
   if (!data?.enabled) {
     return (
-      <Card title="AppArmor" size="small">
+      <Card title={t("adminsecurityapparmor.apparmor")} size="small">
         <Alert
           type="warning"
           showIcon
-          message="AppArmor disabled"
+          message={t("adminsecurityapparmor.apparmor_disabled")}
           description={data?.reason || "AppArmor is not active on this host. Reboot may be required if /etc/jabali/.apparmor-grub-pending exists."}
         />
       </Card>
@@ -58,7 +60,7 @@ export const AdminSecurityAppArmor = () => {
 
   return (
     <Card
-      title="AppArmor"
+      title={t("adminsecurityapparmor.apparmor")}
       size="small"
       extra={
         <Button size="small" onClick={() => refetch()}>
@@ -79,7 +81,7 @@ export const AdminSecurityAppArmor = () => {
           showIcon
           style={{ marginBottom: 16 }}
           message={`${data?.violations?.length} complain-mode would-deny event(s) in the recent window`}
-          description="Complain-mode profiles are logging would-deny (apparmor ALLOWED) violations — not soak-ready to enforce. Resolve or allowlist these before flipping to enforce."
+          description={t("adminsecurityapparmor.complain_mode_profiles_are_logging_would_den")}
         />
       ) : null}
       {(data?.profiles ?? []).some((p) => p.mode === "kernel-gated") && (
@@ -87,7 +89,7 @@ export const AdminSecurityAppArmor = () => {
           type="info"
           showIcon
           style={{ marginBottom: 16 }}
-          message="AppArmor profiles intentionally not loaded on this kernel"
+          message={t("adminsecurityapparmor.apparmor_profiles_intentionally_not_loaded_o")}
           description={
             data?.reason ||
             "This kernel lacks AppArmor unix-socket mediation (Debian 13 / Ubuntu 24.04). Jabali profiles are deliberately not loaded here — attaching them would break DNS/DB over unix sockets. This is expected, not a failure or a security regression."
@@ -98,7 +100,7 @@ export const AdminSecurityAppArmor = () => {
         <Select
           allowClear
           size="small"
-          placeholder="Filter mode"
+          placeholder={t("adminsecurityapparmor.filter_mode")}
           style={{ width: 160 }}
           value={modeFilter}
           onChange={setModeFilter}
@@ -261,7 +263,7 @@ export const AdminSecurityAppArmor = () => {
             ? `Flip ${pendingFlip.profile} → ${pendingFlip.nextMode}`
             : ""
         }
-        okText="Flip"
+        okText={t("adminsecurityapparmor.flip")}
         okButtonProps={(() => {
           // GH #715: block flip-to-enforce on a profile with unresolved
           // would-deny events unless the operator explicitly acknowledges —
@@ -290,8 +292,8 @@ export const AdminSecurityAppArmor = () => {
           <Alert
             type="warning"
             showIcon
-            message="Enforce will start denying paths/caps not in the profile."
-            description="If the profile is missing a path the daemon needs, the daemon will fail. Review complain-mode AVC denials in journalctl -k before flipping."
+            message={t("adminsecurityapparmor.enforce_will_start_denying_paths_caps_not_in")}
+            description={t("adminsecurityapparmor.if_the_profile_is_missing_a_path_the_daemon")}
             style={{ marginBottom: 12 }}
           />
         ) : null}
@@ -302,7 +304,7 @@ export const AdminSecurityAppArmor = () => {
               type="error"
               showIcon
               message={`${(data?.violations ?? []).filter((v) => v.profile === pendingFlip.profile).length} unresolved would-deny event(s) on this profile`}
-              description="This profile is NOT soak-ready. Enforcing now will BLOCK those operations and can break the daemon. Resolve or allowlist them first."
+              description={t("adminsecurityapparmor.this_profile_is_not_soak_ready_enforcing_now")}
               style={{ marginBottom: 12 }}
             />
             <Checkbox checked={ackRisk} onChange={(e) => setAckRisk(e.target.checked)}>
@@ -335,10 +337,10 @@ export const AdminSecurityAppArmor = () => {
               return (
                 <>
                   <Descriptions column={1} size="small" bordered>
-                    <Descriptions.Item label="Protects">{PROFILE_DESC[detail] ?? "—"}</Descriptions.Item>
-                    <Descriptions.Item label="Mode">{prof?.mode ?? "?"}</Descriptions.Item>
-                    <Descriptions.Item label="Would-deny (complain)">{viols.length}</Descriptions.Item>
-                    <Descriptions.Item label="Denied (enforce blocks)">{dens.length}</Descriptions.Item>
+                    <Descriptions.Item label={t("adminsecurityapparmor.protects")}>{PROFILE_DESC[detail] ?? "—"}</Descriptions.Item>
+                    <Descriptions.Item label={t("adminsecurityapparmor.mode")}>{prof?.mode ?? "?"}</Descriptions.Item>
+                    <Descriptions.Item label={t("adminsecurityapparmor.would_deny_complain")}>{viols.length}</Descriptions.Item>
+                    <Descriptions.Item label={t("adminsecurityapparmor.denied_enforce_blocks")}>{dens.length}</Descriptions.Item>
                   </Descriptions>
                   {prof?.mode === "complain" ? (
                     <Alert

--- a/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
@@ -8,6 +8,7 @@
 // inline marginLeft. Hooks stay direct useQuery (not useTableURL) —
 // these endpoints are not the standard {data,total,page,page_size}
 // list shape; they're agent passthroughs.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -123,6 +124,7 @@ const fmtTime = (s?: string): string => (s ? new Date(s).toLocaleString() : "—
 
 
 export const AdminSecurityCrowdsec = () => {
+  const { t } = useTranslation();
   const [scope, setScope] = useState<CrowdsecScope | "all">("all");
   const decisions = useCrowdsecDecisions(scope === "all" ? undefined : scope);
   const hub = useCrowdsecHub();
@@ -207,8 +209,8 @@ export const AdminSecurityCrowdsec = () => {
       <Alert
         type="info"
         showIcon
-        message="What is CrowdSec?"
-        description="Behaviour-based intrusion-prevention. Tails server logs (nginx, sshd, panel, mail), matches them against scenarios (brute-force, scanners, web exploits, credential stuffing), and emits IP decisions. Bouncers enforce them at the firewall (UFW), at nginx (AppSec WAF with OWASP CRS rules + optional captcha challenge), and against a crowdsourced blocklist of IPs flagged by the wider community in the last hours."
+        message={t("adminsecuritycrowdsec.what_is_crowdsec")}
+        description={t("adminsecuritycrowdsec.behaviour_based_intrusion_prevention_tails_s")}
       />
       <TopSourcesCard />
       <AlertsOverTimeCard />
@@ -219,7 +221,7 @@ export const AdminSecurityCrowdsec = () => {
   const decisionsPanel = (
     <Card
       size="small"
-      title="Active decisions"
+      title={t("adminsecuritycrowdsec.active_decisions")}
       extra={
         <Space wrap>
           <Select
@@ -240,7 +242,7 @@ export const AdminSecurityCrowdsec = () => {
         dataSource={decisions.data ?? []}
         loading={decisions.isLoading}
         pagination={{ pageSize: 20, showSizeChanger: false }}
-        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No active decisions" /> }}
+        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.no_active_decisions")} /> }}
         scroll={{ x: "max-content" }}
       >
         <Table.Column<CrowdsecDecision>
@@ -253,11 +255,11 @@ export const AdminSecurityCrowdsec = () => {
             </Button>
           )}
         />
-        <Table.Column<CrowdsecDecision> dataIndex="scenario" title="Scenario" key="scenario" />
-        <Table.Column<CrowdsecDecision> dataIndex="reason" title="Reason" key="reason" />
+        <Table.Column<CrowdsecDecision> dataIndex="scenario" title={t("adminsecuritycrowdsec.scenario")} key="scenario" />
+        <Table.Column<CrowdsecDecision> dataIndex="reason" title={t("adminsecuritycrowdsec.reason")} key="reason" />
         <Table.Column<CrowdsecDecision>
           dataIndex="until"
-          title="Until"
+          title={t("adminsecuritycrowdsec.until")}
           key="until"
           render={(s: string) => fmtTime(s)}
         />
@@ -284,18 +286,18 @@ export const AdminSecurityCrowdsec = () => {
         {detailDecision ? (
           <>
             <Descriptions column={1} size="small" bordered>
-              <Descriptions.Item label="IP / value">{detailDecision.ip}</Descriptions.Item>
-              <Descriptions.Item label="Why (reason)">{detailDecision.reason || "—"}</Descriptions.Item>
-              <Descriptions.Item label="Scenario fired">{detailDecision.scenario || "—"}</Descriptions.Item>
-              <Descriptions.Item label="Ban duration">{detailDecision.duration || "—"}</Descriptions.Item>
-              <Descriptions.Item label="Active until">{detailDecision.until || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritycrowdsec.ip_value")}>{detailDecision.ip}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritycrowdsec.why_reason")}>{detailDecision.reason || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritycrowdsec.scenario_fired")}>{detailDecision.scenario || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritycrowdsec.ban_duration")}>{detailDecision.duration || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritycrowdsec.active_until")}>{detailDecision.until || "—"}</Descriptions.Item>
             </Descriptions>
             <Alert
               style={{ marginTop: 12 }}
               type="info"
               showIcon
-              message="How this is enforced"
-              description="This IP was banned because the scenario above fired on its traffic. Enforcement is applied by the active bouncers: the firewall bouncer drops it at nftables (all ports), and the nginx bouncer returns 403 on HTTP. To lift it, delete the decision (or add the IP to the Allowlist so it is never re-banned)."
+              message={t("adminsecuritycrowdsec.how_this_is_enforced")}
+              description={t("adminsecuritycrowdsec.this_ip_was_banned_because_the_scenario_abov")}
             />
             {(() => {
               // GH #716: alert -> decision linkage. Show the alerts whose source
@@ -356,7 +358,7 @@ export const AdminSecurityCrowdsec = () => {
       />
 
       <Drawer
-        title="Add CrowdSec decision (manual ban)"
+        title={t("adminsecuritycrowdsec.add_crowdsec_decision_manual_ban")}
         open={addOpen}
         onClose={() => setAddOpen(false)}
         width={isDesktop ? 520 : undefined}
@@ -384,9 +386,9 @@ export const AdminSecurityCrowdsec = () => {
         >
           <Form.Item
             name="scope"
-            label="Scope"
+            label={t("adminsecuritycrowdsec.scope")}
             rules={[{ required: true, message: "Scope required" }]}
-            tooltip="Country bans rely on the GeoIP enricher; AS bans on the ASN enricher. Both are installed by default on fresh CrowdSec hosts."
+            tooltip={t("adminsecuritycrowdsec.country_bans_rely_on_the_geoip_enricher_as_b")}
           >
             <Select options={ADD_SCOPE_OPTIONS} />
           </Form.Item>
@@ -447,7 +449,7 @@ export const AdminSecurityCrowdsec = () => {
           </Form.Item>
           <Form.Item
             name="duration"
-            label="Duration"
+            label={t("adminsecuritycrowdsec.duration")}
             initialValue="4h"
             rules={[
               { required: true, message: "Duration required" },
@@ -458,7 +460,7 @@ export const AdminSecurityCrowdsec = () => {
           </Form.Item>
           <Form.Item
             name="reason"
-            label="Reason"
+            label={t("adminsecuritycrowdsec.reason")}
             rules={[
               { required: true, message: "Reason required" },
               { min: 3, max: 200, message: "3..200 characters" },
@@ -480,6 +482,7 @@ export const AdminSecurityCrowdsec = () => {
 // Country") reason. Operator must wire nginx to CrowdSec's AppSec
 // endpoint for enforcement — see plans/m26-security-tab-runbook.md.
 const AppSecGeoblockCard = () => {
+  const { t } = useTranslation();
   const geoblock = useAppSecGeoblock();
   const updateGeoblock = useUpdateAppSecGeoblock();
 
@@ -522,7 +525,7 @@ const AppSecGeoblockCard = () => {
   };
 
   return (
-    <Card size="small" title="AppSec geoblock (server-wide)" loading={geoblock.isLoading}>
+    <Card size="small" title={t("adminsecuritycrowdsec.appsec_geoblock_server_wide")} loading={geoblock.isLoading}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           HTTP-layer country filter applied by CrowdSec AppSec. Blocks with
@@ -547,7 +550,7 @@ const AppSecGeoblockCard = () => {
             <Select<string[]>
               mode="multiple"
               style={{ width: "100%", maxWidth: 720 }}
-              placeholder="Type a country name or code, or pick from the list"
+              placeholder={t("adminsecuritycrowdsec.type_a_country_name_or_code_or_pick_from_the")}
               value={countries}
               onChange={(next) =>
                 setCountries(
@@ -571,19 +574,19 @@ const AppSecGeoblockCard = () => {
           <Alert
             type="warning"
             showIcon
-            message="Allow-list with no countries blocks every request — add at least one before applying."
+            message={t("adminsecuritycrowdsec.allow_list_with_no_countries_blocks_every_re")}
           />
         )}
         {mode === "deny" && countries.length === 0 && (
           <Alert
             type="warning"
             showIcon
-            message="Deny-list with no countries has no effect — add at least one before applying."
+            message={t("adminsecuritycrowdsec.deny_list_with_no_countries_has_no_effect_ad")}
           />
         )}
         <Space>
           <Popconfirm
-            title="Apply AppSec geoblock"
+            title={t("adminsecuritycrowdsec.apply_appsec_geoblock")}
             description={
               mode === "off"
                 ? "Disables the server-wide country filter. Requests from any country pass AppSec."
@@ -591,7 +594,7 @@ const AppSecGeoblockCard = () => {
                     countries.length === 1 ? "country" : "countries"
                   }. CrowdSec is reloaded (SIGHUP) — no traffic drops.`
             }
-            okText="Apply"
+            okText={t("adminsecuritycrowdsec.apply")}
             onConfirm={apply}
             disabled={!dirty || updateGeoblock.isPending}
           >
@@ -635,6 +638,7 @@ const ALLOWLIST_IP_OR_CIDR = /^[0-9a-fA-F:.]+(\/\d{1,3})?$/;
 // BlocklistsCard — community blocklists currently contributing active
 // decisions to this engine. Subscriptions live at app.crowdsec.net.
 const BlocklistsCard = () => {
+  const { t } = useTranslation();
   const q = useCrowdsecBlocklists();
   const refresh = useRefreshCrowdsecBlocklists();
   const data = q.data?.blocklists ?? [];
@@ -642,7 +646,7 @@ const BlocklistsCard = () => {
 
   return (
     <Card
-      title="Active decision sources"
+      title={t("adminsecuritycrowdsec.active_decision_sources")}
       extra={
         <Space size={12}>
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
@@ -662,7 +666,7 @@ const BlocklistsCard = () => {
       <Alert
         type="info"
         showIcon
-        message="Aggregates every active decision by (origin/scenario). CAPI = pulled from app.crowdsec.net; cscli-import = manually imported; crowdsec = local detection. Subscribe to community blocklists at app.crowdsec.net → Blocklists."
+        message={t("adminsecuritycrowdsec.aggregates_every_active_decision_by_origin_s")}
         style={{ marginBottom: 12 }}
       />
       <Table<{ name: string; count: number; latest_end: string }>
@@ -700,6 +704,7 @@ const BlocklistsCard = () => {
 };
 
 const AllowlistsCard = () => {
+  const { t } = useTranslation();
   const allowlists = useCrowdsecAllowlists();
   const [allowlistQuery, setAllowlistQuery] = useState("");
   const addEntry = useAddCrowdsecAllowlist();
@@ -733,7 +738,7 @@ const AllowlistsCard = () => {
     <>
       <Card
         size="small"
-        title="Allowlist (never ban)"
+        title={t("adminsecuritycrowdsec.allowlist_never_ban")}
         extra={
           <Button type="primary" size="small" onClick={() => setAddOpen(true)}>
             Add to allowlist
@@ -744,7 +749,7 @@ const AllowlistsCard = () => {
           type="info"
           showIcon
           style={{ marginBottom: 12 }}
-          message="Allowlisted IPs bypass every scenario, decision, and the AppSec geoblock. Use for your office, home IP, or CI runner CIDR."
+          message={t("adminsecuritycrowdsec.allowlisted_ips_bypass_every_scenario_decisi")}
         />
         <SearchableTableStringQ<CrowdsecAllowlistEntry>
           onSearchChange={setAllowlistQuery}
@@ -758,22 +763,22 @@ const AllowlistsCard = () => {
           )}
           loading={allowlists.isLoading}
           pagination={{ pageSize: 10, showSizeChanger: false }}
-          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No allowlist entries" /> }}
+          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.no_allowlist_entries")} /> }}
         >
           <Table.Column<CrowdsecAllowlistEntry>
             dataIndex="value"
-            title="IP or CIDR"
+            title={t("adminsecuritycrowdsec.ip_or_cidr")}
             key="value"
             render={(v: string) => <Typography.Text code>{v}</Typography.Text>}
           />
           <Table.Column<CrowdsecAllowlistEntry>
             dataIndex="reason"
-            title="Reason"
+            title={t("adminsecuritycrowdsec.reason")}
             key="reason"
           />
           <Table.Column<CrowdsecAllowlistEntry>
             dataIndex="created_at"
-            title="Added"
+            title={t("adminsecuritycrowdsec.added")}
             key="created_at"
             render={(s: string) => fmtTime(s)}
           />
@@ -783,11 +788,11 @@ const AllowlistsCard = () => {
             width={90}
             render={(_, row) => (
               <Popconfirm
-                title="Remove from allowlist"
+                title={t("adminsecuritycrowdsec.remove_from_allowlist")}
                 description={`${row.value} will be subject to scenarios and decisions again.`}
-                okText="Remove"
+                okText={t("adminsecuritycrowdsec.remove")}
                 okButtonProps={{ danger: true }}
-                cancelText="Cancel"
+                cancelText={t("adminsecuritycrowdsec.cancel")}
                 onConfirm={() => onRemove(row)}
               >
                 <Button danger type="text" size="small">
@@ -800,7 +805,7 @@ const AllowlistsCard = () => {
       </Card>
 
       <Drawer
-        title="Add to allowlist"
+        title={t("adminsecuritycrowdsec.add_to_allowlist")}
         open={addOpen}
         onClose={() => setAddOpen(false)}
         width={isDesktop ? 520 : undefined}
@@ -818,18 +823,18 @@ const AllowlistsCard = () => {
         <Form<AllowlistFormValues> form={form} layout="vertical" onFinish={onSubmit}>
           <Form.Item
             name="value"
-            label="IP or CIDR"
+            label={t("adminsecuritycrowdsec.ip_or_cidr")}
             rules={[
               { required: true, message: "Value required" },
               { pattern: ALLOWLIST_IP_OR_CIDR, message: "Must be a valid IP or CIDR" },
             ]}
-            tooltip="Single IPv4/IPv6 address or CIDR block (e.g. 192.0.2.1 or 10.0.0.0/24)."
+            tooltip={t("adminsecuritycrowdsec.single_ipv4_ipv6_address_or_cidr_block_e_g_1")}
           >
             <Input placeholder="192.0.2.1 or 10.0.0.0/24" />
           </Form.Item>
           <Form.Item
             name="reason"
-            label="Reason"
+            label={t("adminsecuritycrowdsec.reason")}
             rules={[
               { required: true, message: "Reason required" },
               { min: 3, max: 200, message: "Reason must be 3..200 chars" },
@@ -859,6 +864,7 @@ type AlertDetail = {
 };
 
 const AlertsCard = () => {
+  const { t } = useTranslation();
   const alerts = useCrowdsecAlerts();
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const detail = useCrowdsecAlert(selectedId);
@@ -866,22 +872,22 @@ const AlertsCard = () => {
 
   return (
     <>
-      <Card size="small" title="Alerts (last 24h)">
+      <Card size="small" title={t("adminsecuritycrowdsec.alerts_last_24h")}>
         <Table<CrowdsecAlert>
           rowKey="id"
           dataSource={alerts.data ?? []}
           loading={alerts.isLoading}
           pagination={{ pageSize: 20, showSizeChanger: false }}
-          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No alerts in the last 24h" /> }}
+          locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.no_alerts_in_the_last_24h")} /> }}
           scroll={{ x: "max-content" }}
           onRow={(row) => ({
             onClick: () => setSelectedId(row.id),
             style: { cursor: "pointer" },
           })}
         >
-          <Table.Column<CrowdsecAlert> dataIndex="scenario" title="Scenario" key="scenario" />
+          <Table.Column<CrowdsecAlert> dataIndex="scenario" title={t("adminsecuritycrowdsec.scenario")} key="scenario" />
           <Table.Column<CrowdsecAlert>
-            title="Source"
+            title={t("adminsecuritycrowdsec.source")}
             key="source"
             render={(_, row) => (
               <Space size="small">
@@ -892,25 +898,25 @@ const AlertsCard = () => {
           />
           <Table.Column<CrowdsecAlert>
             dataIndex="events_count"
-            title="Events"
+            title={t("adminsecuritycrowdsec.events")}
             key="events_count"
             width={100}
           />
           <Table.Column<CrowdsecAlert>
             dataIndex="decisions_count"
-            title="Decisions"
+            title={t("adminsecuritycrowdsec.decisions")}
             key="decisions_count"
             width={110}
           />
           <Table.Column<CrowdsecAlert>
             dataIndex="started_at"
-            title="Started"
+            title={t("adminsecuritycrowdsec.started")}
             key="started_at"
             render={(s: string) => fmtTime(s)}
           />
           <Table.Column<CrowdsecAlert>
             dataIndex="machine_id"
-            title="Machine"
+            title={t("adminsecuritycrowdsec.machine")}
             key="machine_id"
             render={(s: string) => <Typography.Text type="secondary">{s || "—"}</Typography.Text>}
           />
@@ -952,9 +958,9 @@ const AlertsCard = () => {
               ]}
             />
 
-            <Card size="small" title="Decisions issued">
+            <Card size="small" title={t("adminsecuritycrowdsec.decisions_issued")}>
               {(alert.decisions ?? []).length === 0 ? (
-                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No decisions issued" />
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.no_decisions_issued")} />
               ) : (
                 <Table
                   rowKey={(_, idx) => `d-${idx}`}
@@ -963,15 +969,15 @@ const AlertsCard = () => {
                   size="small"
                   scroll={{ x: "max-content" }}
                 >
-                  <Table.Column dataIndex="type" title="Type" key="type" />
-                  <Table.Column dataIndex="value" title="Value" key="value" />
-                  <Table.Column dataIndex="duration" title="Duration" key="duration" />
+                  <Table.Column dataIndex="type" title={t("adminsecuritycrowdsec.type")} key="type" />
+                  <Table.Column dataIndex="value" title={t("adminsecuritycrowdsec.value")} key="value" />
+                  <Table.Column dataIndex="duration" title={t("adminsecuritycrowdsec.duration")} key="duration" />
                 </Table>
               )}
             </Card>
           </Space>
         ) : (
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Alert not found" />
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.alert_not_found")} />
         )}
       </Drawer>
     </>
@@ -996,6 +1002,7 @@ const PROVIDER_OPTIONS = [
 ];
 
 const CaptchaRemediationCard = () => {
+  const { t } = useTranslation();
   const captcha = useCrowdsecCaptcha();
   const update = useUpdateCrowdsecCaptcha();
   const [form] = Form.useForm<CaptchaFormValues>();
@@ -1029,7 +1036,7 @@ const CaptchaRemediationCard = () => {
   return (
     <Card
       size="small"
-      title="Captcha remediation"
+      title={t("adminsecuritycrowdsec.captcha_remediation")}
       loading={captcha.isLoading}
       extra={
         <Typography.Text type="secondary" style={{ fontSize: 12 }}>
@@ -1041,8 +1048,8 @@ const CaptchaRemediationCard = () => {
         type="info"
         showIcon
         style={{ marginBottom: 12 }}
-        message="When enabled, CrowdSec scenarios flagged for captcha serve a challenge page instead of a 403."
-        description="Create an hCaptcha / reCAPTCHA / Turnstile site at the provider, paste the keys below. Secret is stored server-side and never returned."
+        message={t("adminsecuritycrowdsec.when_enabled_crowdsec_scenarios_flagged_for")}
+        description={t("adminsecuritycrowdsec.create_an_hcaptcha_recaptcha_turnstile_site")}
       />
       <Form<CaptchaFormValues>
         form={form}
@@ -1052,7 +1059,7 @@ const CaptchaRemediationCard = () => {
       >
         <Form.Item
           name="enabled"
-          label="Enabled"
+          label={t("adminsecuritycrowdsec.enabled")}
           getValueProps={(v) => ({ value: v ? "on" : "off" })}
           normalize={(v) => v === "on"}
         >
@@ -1073,14 +1080,14 @@ const CaptchaRemediationCard = () => {
               <>
                 <Form.Item
                   name="provider"
-                  label="Provider"
+                  label={t("adminsecuritycrowdsec.provider")}
                   rules={enabled ? [{ required: true, message: "Provider required" }] : []}
                 >
                   <Select disabled={!enabled} options={PROVIDER_OPTIONS} />
                 </Form.Item>
                 <Form.Item
                   name="site_key"
-                  label="Site key (public)"
+                  label={t("adminsecuritycrowdsec.site_key_public")}
                   rules={
                     enabled
                       ? [{ required: true, message: "Site key required" }, { max: 512 }]
@@ -1091,8 +1098,8 @@ const CaptchaRemediationCard = () => {
                 </Form.Item>
                 <Form.Item
                   name="secret_key"
-                  label="Secret key (write-only)"
-                  tooltip="Leave blank to keep the stored secret unchanged."
+                  label={t("adminsecuritycrowdsec.secret_key_write_only")}
+                  tooltip={t("adminsecuritycrowdsec.leave_blank_to_keep_the_stored_secret_unchan")}
                   rules={[{ max: 512 }]}
                 >
                   <Input.Password
@@ -1108,10 +1115,10 @@ const CaptchaRemediationCard = () => {
         </Form.Item>
         <Space>
           <Popconfirm
-            title="Apply captcha settings?"
-            description="This rewrites /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf and reloads nginx."
-            okText="Apply"
-            cancelText="Cancel"
+            title={t("adminsecuritycrowdsec.apply_captcha_settings")}
+            description={t("adminsecuritycrowdsec.this_rewrites_etc_crowdsec_bouncers_crowdsec")}
+            okText={t("adminsecuritycrowdsec.apply")}
+            cancelText={t("adminsecuritycrowdsec.cancel")}
             onConfirm={() => form.submit()}
           >
             <Button type="primary" loading={update.isPending}>
@@ -1132,6 +1139,7 @@ type ProfileRow = CrowdsecScenarioItem & {
 };
 
 const ProfilesCard = () => {
+  const { t } = useTranslation();
   const profiles = useCrowdsecProfiles();
   const update = useUpdateCrowdsecProfiles();
   const [draft, setDraft] = useState<Record<string, "default" | "captcha" | "off">>({});
@@ -1167,17 +1175,17 @@ const ProfilesCard = () => {
   return (
     <Card
       size="small"
-      title="Per-scenario remediation override"
+      title={t("adminsecuritycrowdsec.per_scenario_remediation_override")}
       loading={profiles.isLoading}
       extra={
         dirty && (
           <Space>
             <Button onClick={() => setDraft({})}>Reset</Button>
             <Popconfirm
-              title="Apply overrides?"
-              description="Rewrites /etc/crowdsec/profiles.yaml (marker-bounded) and reloads crowdsec."
-              okText="Apply"
-              cancelText="Cancel"
+              title={t("adminsecuritycrowdsec.apply_overrides")}
+              description={t("adminsecuritycrowdsec.rewrites_etc_crowdsec_profiles_yaml_marker_b")}
+              okText={t("adminsecuritycrowdsec.apply")}
+              cancelText={t("adminsecuritycrowdsec.cancel")}
               onConfirm={onApply}
             >
               <Button type="primary" loading={update.isPending}>
@@ -1193,26 +1201,26 @@ const ProfilesCard = () => {
           type="warning"
           showIcon
           style={{ marginBottom: 12 }}
-          message="Captcha action requires the Captcha remediation card above to be enabled."
+          message={t("adminsecuritycrowdsec.captcha_action_requires_the_captcha_remediat")}
         />
       )}
       <Table<ProfileRow>
         rowKey="name"
         dataSource={rows}
         pagination={{ pageSize: 20, showSizeChanger: false }}
-        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No scenarios installed" /> }}
+        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecuritycrowdsec.no_scenarios_installed")} /> }}
         tableLayout="fixed"
       >
         <Table.Column<ProfileRow>
           dataIndex="name"
-          title="Scenario"
+          title={t("adminsecuritycrowdsec.scenario")}
           key="name"
           width={320}
           render={(v: string) => <Typography.Text code>{v}</Typography.Text>}
         />
         <Table.Column<ProfileRow>
           dataIndex="description"
-          title="Description"
+          title={t("adminsecuritycrowdsec.description")}
           key="description"
           ellipsis={{ showTitle: false }}
           render={(v: string) => (
@@ -1222,7 +1230,7 @@ const ProfilesCard = () => {
           )}
         />
         <Table.Column<ProfileRow>
-          title="Override"
+          title={t("adminsecuritycrowdsec.override")}
           key="override"
           width={200}
           render={(_, row) => (
@@ -1336,6 +1344,7 @@ const RecommendedHubCard = ({
 }: {
   hub: ReturnType<typeof useCrowdsecHub>;
 }) => {
+  const { t } = useTranslation();
   const install = useInstallCrowdsecHubItem();
   const remove = useRemoveCrowdsecHubItem();
   const [pending, setPending] = useState<string | null>(null);
@@ -1376,7 +1385,7 @@ const RecommendedHubCard = ({
   return (
     <Card
       size="small"
-      title="Recommended free blocklists & scenarios"
+      title={t("adminsecuritycrowdsec.recommended_free_blocklists_scenarios")}
       extra={
         <Typography.Link
           href="https://hub.crowdsec.net/"
@@ -1391,7 +1400,7 @@ const RecommendedHubCard = ({
         type="info"
         showIcon
         style={{ marginBottom: 12 }}
-        message="One-click install of upstream CrowdSec Hub items"
+        message={t("adminsecuritycrowdsec.one_click_install_of_upstream_crowdsec_hub_i")}
         description={
           <>
             Curated free items from the public Hub. Install runs{" "}
@@ -1409,7 +1418,7 @@ const RecommendedHubCard = ({
         tableLayout="fixed"
       >
         <Table.Column<RecommendedItem>
-          title="Item"
+          title={t("adminsecuritycrowdsec.item")}
           key="title"
           width={260}
           render={(_, row) => (
@@ -1428,7 +1437,7 @@ const RecommendedHubCard = ({
           )}
         />
         <Table.Column<RecommendedItem>
-          title="Description"
+          title={t("adminsecuritycrowdsec.description")}
           dataIndex="description"
           key="description"
           ellipsis={{ showTitle: false }}
@@ -1450,7 +1459,7 @@ const RecommendedHubCard = ({
             return isInstalled ? (
               <Popconfirm
                 title={`Remove ${row.name}?`}
-                okText="Remove"
+                okText={t("adminsecuritycrowdsec.remove")}
                 okButtonProps={{ danger: true }}
                 onConfirm={() => onRemove(row)}
               >
@@ -1524,6 +1533,7 @@ const lastPullStatus = (lastPull: string | undefined, kind: string) => {
 };
 
 const RemediationComponentsCard = () => {
+  const { t } = useTranslation();
   const bouncers = useCrowdsecBouncers();
   const rows = bouncers.data ?? [];
   return (
@@ -1545,7 +1555,7 @@ const RemediationComponentsCard = () => {
       {rows.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No bouncers registered (cscli bouncers add)"
+          description={t("adminsecuritycrowdsec.no_bouncers_registered_cscli_bouncers_add")}
         />
       ) : (
         <Row gutter={[12, 12]}>
@@ -1627,6 +1637,7 @@ type SecAuditEvent = {
   result: string;
 };
 const RecentChangesCard = () => {
+  const { t } = useTranslation();
   const q = useQuery({
     queryKey: ["security", "crowdsec", "recent-changes"],
     queryFn: async () =>
@@ -1637,7 +1648,7 @@ const RecentChangesCard = () => {
       ).data.data,
   });
   return (
-    <Card size="small" title="Recent changes (audit)">
+    <Card size="small" title={t("adminsecuritycrowdsec.recent_changes_audit")}>
       <Table<SecAuditEvent>
         size="small"
         pagination={false}
@@ -1660,6 +1671,7 @@ const RecentChangesCard = () => {
 
 // GH #716: at-a-glance health cards — pass/fail per enforcement layer.
 const EngineIdentityCard = () => {
+  const { t } = useTranslation();
   const status = useCrowdsecStatus();
   const metrics = useCrowdsecMetrics();
   const settings = useQuery({
@@ -1713,7 +1725,7 @@ const EngineIdentityCard = () => {
           <Alert
             type="error"
             showIcon
-            message="Config validation failed (crowdsec -t)"
+            message={t("adminsecuritycrowdsec.config_validation_failed_crowdsec_t")}
             description={
               <pre style={{ whiteSpace: "pre-wrap", margin: 0 }}>
                 {status.data.config_valid_detail}
@@ -1751,7 +1763,7 @@ const EngineIdentityCard = () => {
             </div>
           </Col>
           <Col xs={12} md={8} lg={4}>
-            <Tooltip title="Lines no parser matched (gaps in coverage)">
+            <Tooltip title={t("adminsecuritycrowdsec.lines_no_parser_matched_gaps_in_coverage")}>
               <Typography.Text type="secondary" style={{ fontSize: 11 }}>
                 Unparsed
               </Typography.Text>
@@ -1767,7 +1779,7 @@ const EngineIdentityCard = () => {
             </div>
           </Col>
           <Col xs={12} md={8} lg={4}>
-            <Tooltip title="Scenario thresholds tripped (suspicious patterns matched)">
+            <Tooltip title={t("adminsecuritycrowdsec.scenario_thresholds_tripped_suspicious_patte")}>
               <Typography.Text type="secondary" style={{ fontSize: 11 }}>
                 Buckets fired
               </Typography.Text>
@@ -1777,7 +1789,7 @@ const EngineIdentityCard = () => {
             </div>
           </Col>
           <Col xs={12} md={8} lg={4}>
-            <Tooltip title="IPs currently banned / under captcha">
+            <Tooltip title={t("adminsecuritycrowdsec.ips_currently_banned_under_captcha")}>
               <Typography.Text type="secondary" style={{ fontSize: 11 }}>
                 Active decisions
               </Typography.Text>
@@ -1793,7 +1805,7 @@ const EngineIdentityCard = () => {
             </div>
           </Col>
           <Col xs={12} md={8} lg={4}>
-            <Tooltip title="All-time alerts since CrowdSec started">
+            <Tooltip title={t("adminsecuritycrowdsec.all_time_alerts_since_crowdsec_started")}>
               <Typography.Text type="secondary" style={{ fontSize: 11 }}>
                 Total alerts
               </Typography.Text>
@@ -2030,6 +2042,7 @@ const CaptchaPanel = () => (
 // saves. Three presets collapse all three knobs (ssh-bf threshold,
 // AppSec anomaly score, ban duration) into one choice.
 const SensitivityCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const settings = useQuery({
     queryKey: ["admin-settings"],
@@ -2057,7 +2070,7 @@ const SensitivityCard = () => {
   });
 
   return (
-    <Card size="small" title="Sensitivity preset (server-wide)" loading={settings.isLoading}>
+    <Card size="small" title={t("adminsecuritycrowdsec.sensitivity_preset_server_wide")} loading={settings.isLoading}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           Single dial that tunes three CrowdSec knobs at once: SSH brute-
@@ -2112,6 +2125,7 @@ const SensitivityCard = () => {
 //          firewall bouncer is also 60s so net L3 exposure is the
 //          same.
 const BouncerModeCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const settings = useQuery({
     queryKey: ["admin-settings"],
@@ -2139,7 +2153,7 @@ const BouncerModeCard = () => {
   });
 
   return (
-    <Card size="small" title="Bouncer mode (server-wide)" loading={settings.isLoading}>
+    <Card size="small" title={t("adminsecuritycrowdsec.bouncer_mode_server_wide")} loading={settings.isLoading}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           How the nginx bouncer evaluates each request. Stream mode caches
@@ -2187,6 +2201,7 @@ const BouncerModeCard = () => {
 // on /admin/settings; the panel middleware reads it directly and the agent SSH
 // watcher gets it pushed via security.crowdsec.login_allowlist.apply.
 const LoginAllowlistCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const settings = useQuery({
     queryKey: ["admin-settings"],
@@ -2230,7 +2245,7 @@ const LoginAllowlistCard = () => {
     ttlHours !== settings.data?.crowdsec_login_allowlist_ttl_hours;
 
   return (
-    <Card size="small" title="Auto-allowlist login IPs (server-wide)" loading={settings.isLoading}>
+    <Card size="small" title={t("adminsecuritycrowdsec.auto_allowlist_login_ips_server_wide")} loading={settings.isLoading}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           After a successful panel or SSH login, add the source IP to the CrowdSec
@@ -2241,8 +2256,8 @@ const LoginAllowlistCard = () => {
         <Alert
           type="warning"
           showIcon
-          message="Security trade-off"
-          description="This is a broad CrowdSec exemption. A successful login from a stolen key or compromised account shields that source IP from all CrowdSec decisions for the TTL. Lower the TTL or disable this if that window is unacceptable for your threat model."
+          message={t("adminsecuritycrowdsec.security_trade_off")}
+          description={t("adminsecuritycrowdsec.this_is_a_broad_crowdsec_exemption_a_success")}
         />
         <Space align="center">
           <Switch checked={enabled} onChange={setEnabled} />

--- a/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
@@ -3,6 +3,7 @@
 // panel below the table; approve/deny inline.
 //
 // Backed by panel-api/internal/api/user_egress.go.
+import { useTranslation } from "react-i18next";
 import {
   App,
   Alert,
@@ -71,6 +72,7 @@ const renderStateTag = (state: EgressState) => {
 };
 
 export const AdminSecurityEgress = () => {
+  const { t } = useTranslation();
   const summary = useEgressSummary();
   const pending = usePendingEgressRequests();
   const usersQuery = useListQuery<UserRow>({
@@ -87,7 +89,7 @@ export const AdminSecurityEgress = () => {
       <Alert
         type="info"
         showIcon
-        message="Per-user PHP-FPM egress firewall"
+        message={t("adminsecurityegress.per_user_php_fpm_egress_firewall")}
         description={
           <Typography.Paragraph style={{ marginBottom: 0 }}>
             Kernel-level packet filter via nftables + cgroup v2 socket match. ENFORCED
@@ -102,19 +104,19 @@ export const AdminSecurityEgress = () => {
       <Card size="small">
         <Space size="large" wrap>
           <Statistic
-            title="Enforced users"
+            title={t("adminsecurityegress.enforced_users")}
             value={summary.data?.state_counts.enforced ?? 0}
           />
           <Statistic
-            title="Learning users"
+            title={t("adminsecurityegress.learning_users")}
             value={summary.data?.state_counts.learning ?? 0}
           />
           <Statistic
-            title="Off users"
+            title={t("adminsecurityegress.off_users")}
             value={summary.data?.state_counts.off ?? 0}
           />
           <Statistic
-            title="Total drops (last tick)"
+            title={t("adminsecurityegress.total_drops_last_tick")}
             value={summary.data?.total_drops ?? 0}
           />
         </Space>
@@ -122,7 +124,7 @@ export const AdminSecurityEgress = () => {
 
       <EgressMaturePromotion />
 
-      <Card size="small" title="Per-user policy">
+      <Card size="small" title={t("adminsecurityegress.per_user_policy")}>
         <Table<UserRow>
           dataSource={nonAdminUsers}
           rowKey="id"
@@ -131,24 +133,24 @@ export const AdminSecurityEgress = () => {
           scroll={{ x: "max-content" }}
         >
           <Table.Column<UserRow>
-            title="User"
+            title={t("adminsecurityegress.user")}
             dataIndex="username"
             render={(_, r) => r.username ?? r.email}
           />
           <Table.Column<UserRow>
-            title="Egress state"
+            title={t("adminsecurityegress.egress_state")}
             render={(_, r) => <UserStateCell userID={r.id} />}
           />
           <Table.Column<UserRow>
-            title="Drops (last tick)"
+            title={t("adminsecurityegress.drops_last_tick")}
             render={(_, r) => <UserDropsCell userID={r.id} />}
           />
           <Table.Column<UserRow>
-            title="Drops 24h"
+            title={t("adminsecurityegress.drops_24h")}
             render={(_, r) => <UserDrops24hSparkline userID={r.id} />}
           />
           <Table.Column<UserRow>
-            title="Actions"
+            title={t("adminsecurityegress.actions")}
             render={(_, r) => (
               <Button size="small" onClick={() => setEditingUserID(r.id)}>
                 Edit policy
@@ -341,6 +343,7 @@ type FormValues = {
 };
 
 const UserEgressDrawer = ({ open, userID, onClose }: UserEgressDrawerProps) => {
+  const { t } = useTranslation();
   const policy = useUserEgressPolicy(userID);
   const update = useUpdateUserEgress(userID ?? "");
   const [form] = Form.useForm<FormValues>();
@@ -383,7 +386,7 @@ const UserEgressDrawer = ({ open, userID, onClose }: UserEgressDrawerProps) => {
         <Typography.Text>Loading...</Typography.Text>
       ) : (
         <Form<FormValues> form={form} layout="vertical" onFinish={onFinish}>
-          <Form.Item label="State" name="state" rules={[{ required: true }]}>
+          <Form.Item label={t("adminsecurityegress.state")} name="state" rules={[{ required: true }]}>
             <Select options={STATE_OPTIONS} />
           </Form.Item>
 
@@ -399,23 +402,23 @@ const UserEgressDrawer = ({ open, userID, onClose }: UserEgressDrawerProps) => {
                 {fields.map((field) => (
                   <Space key={field.key} align="baseline" wrap>
                     <Form.Item
-                      label="CIDR"
+                      label={t("adminsecurityegress.cidr")}
                       name={[field.name, "cidr"]}
                       rules={[{ required: true, message: "Required" }]}
                     >
                       <Input placeholder="203.0.113.0/24" style={{ width: 200 }} />
                     </Form.Item>
-                    <Form.Item label="Port" name={[field.name, "port"]}>
+                    <Form.Item label={t("adminsecurityegress.port")} name={[field.name, "port"]}>
                       <InputNumber min={1} max={65535} style={{ width: 100 }} />
                     </Form.Item>
-                    <Form.Item label="Protocol" name={[field.name, "protocol"]}>
+                    <Form.Item label={t("adminsecurityegress.protocol")} name={[field.name, "protocol"]}>
                       <Select
                         options={PROTOCOL_OPTIONS}
                         defaultValue="tcp"
                         style={{ width: 100 }}
                       />
                     </Form.Item>
-                    <Form.Item label="Comment" name={[field.name, "comment"]}>
+                    <Form.Item label={t("adminsecurityegress.comment")} name={[field.name, "comment"]}>
                       <Input style={{ width: 200 }} />
                     </Form.Item>
                     <Button danger size="small" onClick={() => remove(field.name)}>
@@ -443,21 +446,22 @@ const UserEgressDrawer = ({ open, userID, onClose }: UserEgressDrawerProps) => {
 };
 
 const PendingRequestsTable = ({ rows }: { rows: EgressRequest[] }) => {
+  const { t } = useTranslation();
   const decide = useDecideEgressRequest();
   if (rows.length === 0) {
     return <Typography.Text type="secondary">No pending requests.</Typography.Text>;
   }
   return (
     <Table<EgressRequest> dataSource={rows} rowKey="id" pagination={false} size="small">
-      <Table.Column<EgressRequest> title="User" dataIndex="user_id" />
-      <Table.Column<EgressRequest> title="CIDR" dataIndex="cidr" />
+      <Table.Column<EgressRequest> title={t("adminsecurityegress.user")} dataIndex="user_id" />
+      <Table.Column<EgressRequest> title={t("adminsecurityegress.cidr")} dataIndex="cidr" />
       <Table.Column<EgressRequest>
-        title="Port"
+        title={t("adminsecurityegress.port")}
         render={(_, r) => r.port ?? "—"}
       />
-      <Table.Column<EgressRequest> title="Proto" dataIndex="protocol" />
+      <Table.Column<EgressRequest> title={t("adminsecurityegress.proto")} dataIndex="protocol" />
       <Table.Column<EgressRequest>
-        title="Reason"
+        title={t("adminsecurityegress.reason")}
         dataIndex="reason"
         render={(s: string) => (
           <Typography.Text style={{ maxWidth: 280 }} ellipsis={{ tooltip: s }}>
@@ -466,12 +470,12 @@ const PendingRequestsTable = ({ rows }: { rows: EgressRequest[] }) => {
         )}
       />
       <Table.Column<EgressRequest>
-        title="Submitted"
+        title={t("adminsecurityegress.submitted")}
         dataIndex="created_at"
         render={(s: string) => shortDateTime(s)}
       />
       <Table.Column<EgressRequest>
-        title="Actions"
+        title={t("adminsecurityegress.actions")}
         render={(_, r) => (
           <RowActions
             actions={[

--- a/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
@@ -3,6 +3,7 @@
 // LMD + YARA-X + signature-base stack.
 //
 // Sub-tabs: Overview / Quarantine / Events / ManualScan / YARA / Settings.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -130,6 +131,7 @@ const formatTime = (s?: string): string => {
 // on one fact at a time; tints follow the same scheme as the CrowdSec
 // metrics overview (blue/green = healthy, amber/red = attention).
 function OverviewCard() {
+  const { t } = useTranslation();
   const { data, isLoading } = useMalwareStatus();
   const { data: settings } = useMalwareSettings();
   const updateSigs = useUpdateMalwareSignatures();
@@ -169,8 +171,8 @@ function OverviewCard() {
         <Alert
           type="info"
           showIcon
-          message="Real-time scanning is off"
-          description="The inotify monitor is not running. Daily scheduled scans + on-demand scans still work. Enable real-time scanning in the Settings tab to catch threats within ~120s of file write (~1.7GB RAM peak per scan cycle)."
+          message={t("adminsecuritymalware.real_time_scanning_is_off")}
+          description={t("adminsecuritymalware.the_inotify_monitor_is_not_running_daily_sch")}
         />
       )}
 
@@ -186,7 +188,7 @@ function OverviewCard() {
                 ? warnTint
                 : offTint
           }
-          label="Realtime monitor"
+          label={t("adminsecuritymalware.realtime_monitor")}
           value={
             data.monitor_active
               ? "active"
@@ -224,7 +226,7 @@ function OverviewCard() {
           lg={8}
           icon={<BugOutlined />}
           tint={data.yara_engine_version ? activeTint : warnTint}
-          label="YARA engine"
+          label={t("adminsecuritymalware.yara_engine")}
           value={data.yara_engine_version || "missing"}
           hint="Scan engine for .yar rules (yara-x preferred, legacy yara fallback)"
         />
@@ -232,7 +234,7 @@ function OverviewCard() {
           lg={8}
           icon={<ThunderboltOutlined />}
           tint={infoTint}
-          label="Inotify watches"
+          label={t("adminsecuritymalware.inotify_watches")}
           value={`${data.watch_count_configured ?? 0} / ${data.watch_ceiling ?? 0}`}
           hint="Active inotify watches vs kernel ceiling"
         />
@@ -316,6 +318,7 @@ function StatusTile({
 
 // ---- Quarantine card ----
 function QuarantineCard() {
+  const { t } = useTranslation();
   const [page, setPage] = useState(1);
   const { data, isLoading } = useMalwareQuarantine(page, 50);
   const restore = useRestoreQuarantine();
@@ -443,7 +446,7 @@ function QuarantineCard() {
 
   return (
     <>
-      <Card title="Quarantine" size="small">
+      <Card title={t("adminsecuritymalware.quarantine")} size="small">
         <Table
           rowKey="id"
           loading={isLoading}
@@ -464,7 +467,7 @@ function QuarantineCard() {
 
       <Drawer
         open={restoreOpen !== null}
-        title="Restore from quarantine"
+        title={t("adminsecuritymalware.restore_from_quarantine")}
         onClose={() => setRestoreOpen(null)}
         footer={
           <Space>
@@ -499,22 +502,22 @@ function QuarantineCard() {
             <Alert
               type="warning"
               showIcon
-              message="Restoring re-introduces the file to disk"
+              message={t("adminsecuritymalware.restoring_re_introduces_the_file_to_disk")}
               description={`Signature: ${restoreOpen.signature}. Confirm only if this is a known false positive.`}
             />
             <Descriptions size="small" column={1} bordered>
-              <Descriptions.Item label="Original">{restoreOpen.original_path}</Descriptions.Item>
-              <Descriptions.Item label="Quarantine">{restoreOpen.quarantine_path}</Descriptions.Item>
-              <Descriptions.Item label="SHA256">
+              <Descriptions.Item label={t("adminsecuritymalware.original")}>{restoreOpen.original_path}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritymalware.quarantine")}>{restoreOpen.quarantine_path}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritymalware.sha256")}>
                 <code style={{ fontSize: 11 }}>{restoreOpen.sha256}</code>
               </Descriptions.Item>
             </Descriptions>
-            <Form.Item label="Reason (audit)" required>
+            <Form.Item label={t("adminsecuritymalware.reason_audit")} required>
               <Input.TextArea
                 rows={3}
                 value={restoreReason}
                 onChange={(e) => setRestoreReason(e.target.value)}
-                placeholder="Explain why this restore is safe"
+                placeholder={t("adminsecuritymalware.explain_why_this_restore_is_safe")}
               />
             </Form.Item>
           </Space>
@@ -534,6 +537,7 @@ function QuarantineCard() {
 //     reuses the existing /api/v1/users list endpoint with
 //     is_admin=false so the picker matches the Users page.
 function ManualScanCard() {
+  const { t } = useTranslation();
   const [mode, setMode] = useState<"path" | "users">("users");
   const [pathValue, setPathValue] = useState("");
   const [selectedUsernames, setSelectedUsernames] = useState<string[]>([]);
@@ -676,7 +680,7 @@ function ManualScanCard() {
   ];
 
   return (
-    <Card title="Manual scan" size="small">
+    <Card title={t("adminsecuritymalware.manual_scan")} size="small">
       <Space direction="vertical" size={12} style={{ width: "100%" }}>
         <Radio.Group
           value={mode}
@@ -704,7 +708,7 @@ function ManualScanCard() {
           <Space direction="vertical" size={8} style={{ width: "100%" }}>
             <Space wrap style={{ justifyContent: "space-between", width: "100%", rowGap: 8 }}>
               <Input.Search
-                placeholder="Search username, name, or email"
+                placeholder={t("adminsecuritymalware.search_username_name_or_email")}
                 allowClear
                 value={userSearch}
                 onChange={(e) => setUserSearch(e.target.value)}
@@ -809,6 +813,7 @@ function ScanProgress({
 
 // ---- Events card ----
 function EventsCard() {
+  const { t } = useTranslation();
   const [src, setSrc] = useState<MalwareScanner | undefined>();
   const [sev, setSev] = useState<MalwareSeverity | undefined>();
   const { data, isLoading } = useMalwareEvents({ source: src, severity: sev });
@@ -817,7 +822,7 @@ function EventsCard() {
   return (
     <>
       <Card
-        title="Recent events"
+        title={t("adminsecuritymalware.recent_events")}
         size="small"
         extra={
           <Space size={4}>
@@ -911,7 +916,7 @@ function EventsCard() {
       <Drawer
         open={drawerRow !== null}
         onClose={() => setDrawerRow(null)}
-        title="Event detail"
+        title={t("adminsecuritymalware.event_detail")}
         width={640}
       >
         <pre style={{ fontSize: 12 }}>{JSON.stringify(drawerRow, null, 2)}</pre>
@@ -922,20 +927,21 @@ function EventsCard() {
 
 // ---- Settings card ----
 function SettingsCard() {
+  const { t } = useTranslation();
   const { data, isLoading } = useMalwareSettings();
   const update = useUpdateMalwareSettings();
   const [form] = Form.useForm();
 
   if (isLoading || !data) {
     return (
-      <Card title="Settings" size="small">
+      <Card title={t("adminsecuritymalware.settings")} size="small">
         <Typography.Text type="secondary">Loading…</Typography.Text>
       </Card>
     );
   }
 
   return (
-    <Card title="Settings" size="small">
+    <Card title={t("adminsecuritymalware.settings")} size="small">
       <Form
         form={form}
         layout="vertical"
@@ -948,19 +954,19 @@ function SettingsCard() {
         }}
       >
         <Form.Item
-          label="Daily scan schedule (cron)"
+          label={t("adminsecuritymalware.daily_scan_schedule_cron")}
           name="schedule_cron"
           rules={[{ required: true, message: "cron expression required" }]}
         >
           <Input placeholder="0 3 * * *" />
         </Form.Item>
-        <Form.Item label="Quarantine retention (days)" name="quarantine_retain_days">
+        <Form.Item label={t("adminsecuritymalware.quarantine_retention_days")} name="quarantine_retain_days">
           <InputNumber min={1} max={365} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item label="Max scan size per file (MB)" name="max_scan_mb">
+        <Form.Item label={t("adminsecuritymalware.max_scan_size_per_file_mb")} name="max_scan_mb">
           <InputNumber min={1} max={10240} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item label="Notification severity threshold" name="notify_threshold">
+        <Form.Item label={t("adminsecuritymalware.notification_severity_threshold")} name="notify_threshold">
           <Select
             style={{ width: 200 }}
             options={[
@@ -971,7 +977,7 @@ function SettingsCard() {
           />
         </Form.Item>
         <Form.Item
-          label="Real-time scanning"
+          label={t("adminsecuritymalware.real_time_scanning")}
           name="realtime_enabled"
           valuePropName="checked"
           extra="Watches user docroots via inotify and scans changed files in batches with maldet's native HEX/MD5/SHA-256 + YARA scanner. Lightweight (~50MB RAM during scans). Off by default — enable on production hosts where you want immediate webshell-upload detection."
@@ -989,7 +995,7 @@ function SettingsCard() {
         </Typography.Paragraph>
 
         <Form.Item
-          label="Enable mail attachment scanning"
+          label={t("adminsecuritymalware.enable_mail_attachment_scanning")}
           name="mail_scan_enabled"
           valuePropName="checked"
           extra="Off by default. Reads /etc/jabali-panel/stalwart-admin.token for JMAP."
@@ -997,7 +1003,7 @@ function SettingsCard() {
           <Switch />
         </Form.Item>
         <Form.Item
-          label="Scan all folders (not just Inbox)"
+          label={t("adminsecuritymalware.scan_all_folders_not_just_inbox")}
           name="mail_scan_all_folders"
           valuePropName="checked"
           extra="Skips Sent / Trash / Drafts / Junk / Spam regardless."
@@ -1005,19 +1011,19 @@ function SettingsCard() {
           <Switch />
         </Form.Item>
         <Form.Item
-          label="Skip these recipient addresses (comma-separated)"
+          label={t("adminsecuritymalware.skip_these_recipient_addresses_comma_separat")}
           name="mail_scan_skip_addresses"
           extra="Per-mailbox skip list — e.g. samples@panel-host for sysadmin sample analysis."
         >
           <Input placeholder="samples@example.com, lab@example.com" />
         </Form.Item>
-        <Form.Item label="Max attachment size (MB)" name="mail_scan_max_attachment_mb">
+        <Form.Item label={t("adminsecuritymalware.max_attachment_size_mb")} name="mail_scan_max_attachment_mb">
           <InputNumber min={1} max={500} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item label="Per-attachment scan timeout (seconds)" name="mail_scan_timeout_sec">
+        <Form.Item label={t("adminsecuritymalware.per_attachment_scan_timeout_seconds")} name="mail_scan_timeout_sec">
           <InputNumber min={1} max={120} style={{ width: 160 }} />
         </Form.Item>
-        <Form.Item label="Per-tick budget (mailboxes scanned each cycle)" name="mail_scan_per_tick_budget">
+        <Form.Item label={t("adminsecuritymalware.per_tick_budget_mailboxes_scanned_each_cycle")} name="mail_scan_per_tick_budget">
           <InputNumber min={10} max={2000} style={{ width: 160 }} />
         </Form.Item>
 
@@ -1031,6 +1037,7 @@ function SettingsCard() {
 
 // ---- Built-in YARA rule packs (read-only) ----
 function BuiltinYARACard() {
+  const { t } = useTranslation();
   const { data: status, isLoading } = useMalwareStatus();
   const updateSigs = useUpdateMalwareSignatures();
 
@@ -1058,7 +1065,7 @@ function BuiltinYARACard() {
 
   return (
     <Card
-      title="Built-in rule packs"
+      title={t("adminsecuritymalware.built_in_rule_packs")}
       size="small"
       style={{ marginBottom: 16 }}
       extra={
@@ -1133,6 +1140,7 @@ function BuiltinYARACard() {
 
 // ---- YARA rules card (M33 Step 8) ----
 function YARACard() {
+  const { t } = useTranslation();
   const { data, isLoading } = useYARARules();
   const [ruleQuery, setRuleQuery] = useState("");
   const upload = useUploadYARARule();
@@ -1152,7 +1160,7 @@ function YARACard() {
     <>
       <BuiltinYARACard />
       <Card
-        title="Custom YARA rules"
+        title={t("adminsecuritymalware.custom_yara_rules")}
         size="small"
         extra={
           <Button size="small" type="primary" onClick={() => setUploadOpen(true)}>
@@ -1219,7 +1227,7 @@ function YARACard() {
 
       <Drawer
         open={uploadOpen}
-        title="Upload YARA rule"
+        title={t("adminsecuritymalware.upload_yara_rule")}
         onClose={reset}
         width={640}
         footer={
@@ -1255,17 +1263,17 @@ function YARACard() {
           <Alert
             type="info"
             showIcon
-            message="Pre-flight parsed via 'yara -w' before install"
-            description="Upload fails with the parser error if the rule is malformed. Filenames must match ^[a-z0-9][a-z0-9._-]{0,63}\\.yar$ and are capped at 64 KB."
+            message={t("adminsecuritymalware.pre_flight_parsed_via_yara_w_before_install")}
+            description={t("adminsecuritymalware.upload_fails_with_the_parser_error_if_the_ru")}
           />
-          <Form.Item label="Filename" required>
+          <Form.Item label={t("adminsecuritymalware.filename")} required>
             <Input
               placeholder="my-custom-rule.yar"
               value={filename}
               onChange={(e) => setFilename(e.target.value)}
             />
           </Form.Item>
-          <Form.Item label="Rule content" required>
+          <Form.Item label={t("adminsecuritymalware.rule_content")} required>
             <Input.TextArea
               rows={14}
               value={content}
@@ -1281,11 +1289,12 @@ function YARACard() {
 }
 // ---- Exec audit card (M39 ADR-0085) ----
 function ExecAuditCard() {
+  const { t } = useTranslation();
   const { data, isLoading, refetch } = useAuditRecent(100);
 
   return (
     <Card
-      title="Exec audit (auditd jabali_susp_exec)"
+      title={t("adminsecuritymalware.exec_audit_auditd_jabali_susp_exec")}
       size="small"
       extra={
         <Button size="small" onClick={() => refetch()}>

--- a/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
@@ -1,6 +1,7 @@
 // AdminSecuritySnuffleupagus — Security tab card for M41 Snuffleupagus.
 // Wave D — full surface: mode toggle, php-version load matrix, recent
 // incidents table, per-rule kill switch.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -48,6 +49,7 @@ const ACTION_COLOR: Record<string, string> = {
 };
 
 export function AdminSecuritySnuffleupagus() {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const status = useSnuffleupagusStatus();
   const incidents = useSnuffleupagusIncidents({ limit: 50 });
@@ -61,7 +63,7 @@ export function AdminSecuritySnuffleupagus() {
 
   if (status.isLoading) {
     return (
-      <Card title="PHP Defense" size="small">
+      <Card title={t("adminsecuritysnuffleupagus.php_defense")} size="small">
         <Text type="secondary">Loading…</Text>
       </Card>
     );
@@ -73,7 +75,7 @@ export function AdminSecuritySnuffleupagus() {
 
   return (
     <Card
-      title="PHP Defense"
+      title={t("adminsecuritysnuffleupagus.php_defense")}
       size="small"
       extra={
         <Space>
@@ -156,8 +158,8 @@ export function AdminSecuritySnuffleupagus() {
           <Alert
             type="info"
             showIcon
-            message="Simulation mode active"
-            description="Rules log incidents below without blocking. Soak for 7 days to identify false positives, then flip to enforce."
+            message={t("adminsecuritysnuffleupagus.simulation_mode_active")}
+            description={t("adminsecuritysnuffleupagus.rules_log_incidents_below_without_blocking_s")}
           />
         )}
 
@@ -213,7 +215,7 @@ export function AdminSecuritySnuffleupagus() {
       </Space>
 
       <Modal
-        title="PHP Defense rules"
+        title={t("adminsecuritysnuffleupagus.php_defense_rules")}
         open={rulesOpen}
         onCancel={() => setRulesOpen(false)}
         footer={<Button onClick={() => setRulesOpen(false)}>Close</Button>}
@@ -260,7 +262,7 @@ export function AdminSecuritySnuffleupagus() {
                   />
                 ) : (
                   <Popconfirm
-                    title="Re-enable this rule?"
+                    title={t("adminsecuritysnuffleupagus.re_enable_this_rule")}
                     onConfirm={() =>
                       toggleRule
                         .mutateAsync({ name: row.name, enabled: true })
@@ -288,13 +290,13 @@ export function AdminSecuritySnuffleupagus() {
         {detailIncident ? (
           <>
             <Descriptions column={1} size="small" bordered>
-              <Descriptions.Item label="When">{new Date(detailIncident.ts).toLocaleString()}</Descriptions.Item>
-              <Descriptions.Item label="Action">{detailIncident.action}</Descriptions.Item>
-              <Descriptions.Item label="Rule">{detailIncident.rule_name}</Descriptions.Item>
-              <Descriptions.Item label="Domain / tenant">{detailIncident.domain || "—"}</Descriptions.Item>
-              <Descriptions.Item label="Request URI">{detailIncident.request_uri || "—"}</Descriptions.Item>
-              <Descriptions.Item label="Source IP">{detailIncident.source_ip || "—"}</Descriptions.Item>
-              <Descriptions.Item label="PHP version">{detailIncident.php_version || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.when")}>{new Date(detailIncident.ts).toLocaleString()}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.action")}>{detailIncident.action}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.rule")}>{detailIncident.rule_name}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.domain_tenant")}>{detailIncident.domain || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.request_uri")}>{detailIncident.request_uri || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.source_ip")}>{detailIncident.source_ip || "—"}</Descriptions.Item>
+              <Descriptions.Item label={t("adminsecuritysnuffleupagus.php_version")}>{detailIncident.php_version || "—"}</Descriptions.Item>
             </Descriptions>
             {(() => {
               // GH #717: per-rule incident history from the loaded window — how
@@ -343,9 +345,9 @@ export function AdminSecuritySnuffleupagus() {
         ) : null}
       </Drawer>
       <Modal
-        title="Disable rule — reason required"
+        title={t("adminsecuritysnuffleupagus.disable_rule_reason_required")}
         open={disabling !== null}
-        okText="Disable"
+        okText={t("adminsecuritysnuffleupagus.disable")}
         okButtonProps={{ danger: true, disabled: !disabling?.reason.trim() }}
         onCancel={() => setDisabling(null)}
         onOk={() => {

--- a/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
@@ -6,6 +6,7 @@
 // Tables consume <Table.Column> children. Modal.confirm stays for the
 // enable/disable typed-YES gate — that's a destructive confirmation,
 // not a create form, so it's the right antd primitive.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -70,6 +71,7 @@ const renderActionTag = (a: string) => {
 };
 
 export const AdminSecurityUfw = () => {
+  const { t } = useTranslation();
   const status = useUfwStatus();
   const addRule = useAddUfwRule();
   const deleteRule = useDeleteUfwRule();
@@ -116,20 +118,20 @@ export const AdminSecurityUfw = () => {
             <Alert
               type="warning"
               showIcon
-              message="Enabling UFW will activate default-deny incoming. Make sure SSH (22) is in the allow-list."
+              message={t("adminsecurityufw.enabling_ufw_will_activate_default_deny_inco")}
             />
           ) : (
             <Alert
               type="error"
               showIcon
-              message="Disabling UFW DROPS host firewall protection. CrowdSec firewall-bouncer also stops applying rules. Use only for emergency triage."
+              message={t("adminsecurityufw.disabling_ufw_drops_host_firewall_protection")}
             />
           )}
           <Typography.Text>
             Type <Typography.Text code>YES</Typography.Text> to confirm:
           </Typography.Text>
           <Input
-            placeholder="YES"
+            placeholder={t("adminsecurityufw.yes")}
             autoComplete="off"
             onChange={(e) => {
               typed = e.target.value;
@@ -163,8 +165,8 @@ export const AdminSecurityUfw = () => {
         <Alert
           type="error"
           showIcon
-          message="Firewall DISABLED"
-          description="UFW is not active. Rules below (if any) are not enforced. CrowdSec firewall-bouncer also has no effect until UFW is enabled."
+          message={t("adminsecurityufw.firewall_disabled")}
+          description={t("adminsecurityufw.ufw_is_not_active_rules_below_if_any_are_not")}
           action={
             <Button type="primary" onClick={() => openToggleModal(true)}>
               Enable firewall
@@ -173,7 +175,7 @@ export const AdminSecurityUfw = () => {
         />
       )}
 
-      <Card size="small" title="Status">
+      <Card size="small" title={t("adminsecurityufw.status")}>
         <Space wrap>
           {active ? <Tag color="green">active</Tag> : <Tag color="red">inactive</Tag>}
           {status.data?.default_in && (
@@ -188,9 +190,9 @@ export const AdminSecurityUfw = () => {
           )}
           {active ? (
             <Popconfirm
-              title="Disable firewall?"
-              description="This drops the host firewall. CrowdSec firewall-bouncer stops applying rules. Confirm again in the next dialog."
-              okText="Continue"
+              title={t("adminsecurityufw.disable_firewall")}
+              description={t("adminsecurityufw.this_drops_the_host_firewall_crowdsec_firewa")}
+              okText={t("adminsecurityufw.continue")}
               okButtonProps={{ danger: true }}
               onConfirm={() => openToggleModal(false)}
             >
@@ -209,7 +211,7 @@ export const AdminSecurityUfw = () => {
       {active ? (
         <Card
           size="small"
-          title="Rules"
+          title={t("adminsecurityufw.rules")}
           extra={
             <Button type="primary" size="small" onClick={() => setAddOpen(true)}>
               Add rule
@@ -222,31 +224,31 @@ export const AdminSecurityUfw = () => {
             loading={status.isLoading}
             pagination={false}
             size="small"
-            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No rules" /> }}
+            locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("adminsecurityufw.no_rules")} /> }}
             scroll={{ x: "max-content" }}
           >
             <Table.Column<UfwRule> dataIndex="num" title="#" key="num" width={60} />
             <Table.Column<UfwRule>
               dataIndex="action"
-              title="Action"
+              title={t("adminsecurityufw.action")}
               key="action"
               width={120}
               render={renderActionTag}
             />
             <Table.Column<UfwRule> dataIndex="to" title="To" key="to" />
-            <Table.Column<UfwRule> dataIndex="from" title="From" key="from" />
-            <Table.Column<UfwRule> dataIndex="proto" title="Proto" key="proto" width={80} />
+            <Table.Column<UfwRule> dataIndex="from" title={t("adminsecurityufw.from")} key="from" />
+            <Table.Column<UfwRule> dataIndex="proto" title={t("adminsecurityufw.proto")} key="proto" width={80} />
             <Table.Column<UfwRule>
               title=""
               key="delete"
               width={90}
               render={(_, row) => (
                 <Popconfirm
-                  title="Delete rule"
+                  title={t("adminsecurityufw.delete_rule")}
                   description={`Delete rule #${row.num} (${row.action} ${row.to})? Existing connections continue; new ones are subject to the next-matching rule.`}
-                  okText="Delete"
+                  okText={t("adminsecurityufw.delete")}
                   okButtonProps={{ danger: true }}
-                  cancelText="Cancel"
+                  cancelText={t("adminsecurityufw.cancel")}
                   onConfirm={() => onDelete(row)}
                 >
                   <RowActionButton danger size="small" icon={<DeleteOutlined />}>
@@ -261,13 +263,13 @@ export const AdminSecurityUfw = () => {
         <Alert
           type="info"
           showIcon
-          message="Rules hidden — firewall disabled"
-          description="Enable the firewall to view and manage rules."
+          message={t("adminsecurityufw.rules_hidden_firewall_disabled")}
+          description={t("adminsecurityufw.enable_the_firewall_to_view_and_manage_rules")}
         />
       )}
 
       <Drawer
-        title="Add UFW rule"
+        title={t("adminsecurityufw.add_ufw_rule")}
         open={addOpen}
         onClose={() => setAddOpen(false)}
         width={isDesktop ? 520 : undefined}
@@ -288,12 +290,12 @@ export const AdminSecurityUfw = () => {
           onFinish={submitAdd}
           initialValues={{ action: "allow", proto: "tcp" }}
         >
-          <Form.Item name="action" label="Action" rules={[{ required: true }]}>
+          <Form.Item name="action" label={t("adminsecurityufw.action")} rules={[{ required: true }]}>
             <Select options={ACTION_OPTIONS} />
           </Form.Item>
           <Form.Item
             name="port"
-            label="Port"
+            label={t("adminsecurityufw.port")}
             rules={[
               { required: true, message: "Required" },
               { pattern: PORT_OR_RANGE, message: 'Number or "lo:hi" range' },
@@ -301,7 +303,7 @@ export const AdminSecurityUfw = () => {
           >
             <Input placeholder="9999 or 1000:2000" autoComplete="off" />
           </Form.Item>
-          <Form.Item name="proto" label="Protocol" rules={[{ required: true }]}>
+          <Form.Item name="proto" label={t("adminsecurityufw.protocol")} rules={[{ required: true }]}>
             <Select options={PROTO_OPTIONS} />
           </Form.Item>
           {/*
@@ -314,7 +316,7 @@ export const AdminSecurityUfw = () => {
             type="info"
             showIcon
             style={{ marginTop: 8 }}
-            message="UFW is port policy only"
+            message={t("adminsecurityufw.ufw_is_port_policy_only")}
             description={
               <span>
                 IP-level decisions live in CrowdSec — open the

--- a/panel-ui/src/shells/admin/security/CrowdsecTestIPCard.tsx
+++ b/panel-ui/src/shells/admin/security/CrowdsecTestIPCard.tsx
@@ -8,11 +8,13 @@
 // the table renders an inline Unban button that DELETEs every
 // active decision for that IP/CIDR. Lets the operator self-recover
 // without dropping to a shell.
+import { useTranslation } from "react-i18next";
 import { Alert, App, Button, Card, Form, Input, Popconfirm, Space, Table, Tag, Typography } from "antd";
 
 import { useTrustTest, useUnbanIP, type TrustTestResponse, type TrustVerdict } from "../../../hooks/useSecurityTrust";
 
 export const CrowdsecTestIPCard = () => {
+  const { t } = useTranslation();
   const trustTest = useTrustTest();
   const unbanIP = useUnbanIP();
   const { message } = App.useApp();
@@ -32,7 +34,7 @@ export const CrowdsecTestIPCard = () => {
   };
 
   return (
-    <Card size="small" title="Test IP — would this IP be blocked?">
+    <Card size="small" title={t("crowdsectestipcard.test_ip_would_this_ip_be_blocked")}>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
         Asks every brain at once. Returns each layer's verdict so you can
         spot disagreement (the failure mode M43 fixes — see ADR-0089).
@@ -50,7 +52,7 @@ export const CrowdsecTestIPCard = () => {
       {trustTest.isError && (
         <Alert
           type="error"
-          message="Test failed"
+          message={t("crowdsectestipcard.test_failed")}
           description={trustTest.error instanceof Error ? trustTest.error.message : "unknown error"}
         />
       )}
@@ -81,8 +83,8 @@ export const CrowdsecTestIPCard = () => {
                 row.layer === "crowdsec" && row.outcome === "deny" ? (
                   <Popconfirm
                     title={`Unban ${lastResult.ip}?`}
-                    description="Drops every active CrowdSec decision targeting this IP."
-                    okText="Unban"
+                    description={t("crowdsectestipcard.drops_every_active_crowdsec_decision_targeti")}
+                    okText={t("crowdsectestipcard.unban")}
                     okButtonProps={{ danger: true }}
                     onConfirm={() => handleUnban(lastResult.ip)}
                   >

--- a/panel-ui/src/shells/admin/security/EgressMaturePromotion.tsx
+++ b/panel-ui/src/shells/admin/security/EgressMaturePromotion.tsx
@@ -8,6 +8,7 @@
 // count), sees whether the operator pin blocks promotion, and — confirm-gated —
 // promotes them all at once. Backed by GET /admin/egress/mature-preview (dry
 // run) and POST /admin/egress/flip-mature.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -63,6 +64,7 @@ const columns: ColumnsType<Eligible> = [
 ];
 
 export function EgressMaturePromotion() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
   const [soakDays, setSoakDays] = useState(7);
@@ -140,8 +142,8 @@ export function EgressMaturePromotion() {
         </Button>
         <Popconfirm
           title={`Promote ${eligibleCount} mature policy(ies) to ENFORCED?`}
-          description="This enforces the egress firewall for those users on the next reconcile tick."
-          okText="Promote"
+          description={t("egressmaturepromotion.this_enforces_the_egress_firewall_for_those")}
+          okText={t("egressmaturepromotion.promote")}
           okButtonProps={{ danger: true }}
           disabled={pinned || eligibleCount === 0}
           onConfirm={() => promoteMutation.mutate(soakDays)}
@@ -163,7 +165,7 @@ export function EgressMaturePromotion() {
           showIcon
           icon={<WarningOutlined />}
           style={{ marginBottom: 12 }}
-          message="Operator pin active"
+          message={t("egressmaturepromotion.operator_pin_active")}
           description={
             <span>
               <code>per-user-egress.mode</code> ={" "}

--- a/panel-ui/src/shells/admin/server-status/SpeedTestCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/SpeedTestCard.tsx
@@ -6,6 +6,7 @@
 // The measurement runs on the main thread with fetch + a streaming reader
 // (no Web Worker / vendored asset) — parallel streams over a fixed time
 // window approximate LibreSpeed's accuracy without the worker plumbing.
+import { useTranslation } from "react-i18next";
 import { useRef, useState } from "react";
 import { Button, Card, Space, Statistic, Typography } from "antd";
 import {
@@ -130,6 +131,7 @@ const fmtMbps = (v: number | undefined) =>
 const fmtMs = (v: number | undefined) => (v === undefined ? "—" : v.toFixed(1));
 
 export const SpeedTestCard = () => {
+  const { t } = useTranslation();
   const [phase, setPhase] = useState<Phase>("idle");
   const [results, setResults] = useState<Partial<Results>>({});
   const [live, setLive] = useState<number | undefined>(undefined);
@@ -199,7 +201,7 @@ export const SpeedTestCard = () => {
           value={fmtMs(results.ping)}
           suffix="ms"
         />
-        <Statistic title="Jitter" value={fmtMs(results.jitter)} suffix="ms" />
+        <Statistic title={t("speedtestcard.jitter")} value={fmtMs(results.jitter)} suffix="ms" />
         <Statistic
           title={
             <>

--- a/panel-ui/src/shells/admin/sessions/AdminSessionsPage.tsx
+++ b/panel-ui/src/shells/admin/sessions/AdminSessionsPage.tsx
@@ -1,5 +1,6 @@
 // AdminSessionsPage — GH #338. Live panel (Kratos) login sessions: user, source
 // IP, channel, auth level, when authenticated / expires, with a revoke action.
+import { useTranslation } from "react-i18next";
 import { App, Button, Card, Popconfirm, Space, Table, Tag, Tooltip, Typography } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -26,6 +27,7 @@ const fmt = (s: string): string => {
 };
 
 export function AdminSessionsPage() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const qc = useQueryClient();
 
@@ -46,7 +48,7 @@ export function AdminSessionsPage() {
 
   return (
     <Card
-      title="Active Sessions"
+      title={t("adminsessionspage.active_sessions")}
       extra={<Typography.Text type="secondary">Live panel logins (auto-refreshes)</Typography.Text>}
     >
       <Table<SessionRow>
@@ -113,9 +115,9 @@ export function AdminSessionsPage() {
             width: 110,
             render: (_, r) => (
               <Popconfirm
-                title="Revoke this session?"
-                description="The user will be signed out of the panel."
-                okText="Revoke"
+                title={t("adminsessionspage.revoke_this_session")}
+                description={t("adminsessionspage.the_user_will_be_signed_out_of_the_panel")}
+                okText={t("adminsessionspage.revoke")}
                 okButtonProps={{ danger: true }}
                 onConfirm={() => revoke.mutate(r.id)}
               >

--- a/panel-ui/src/shells/admin/settings/AccountSkeletonCard.tsx
+++ b/panel-ui/src/shells/admin/settings/AccountSkeletonCard.tsx
@@ -2,6 +2,7 @@
 // skeleton: the tree of starter files copied into every new domain's web
 // root on creation. List + delete on the left; "Add file" uploads a file
 // (stored base64) at an operator-chosen relative path.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Button,
@@ -53,6 +54,7 @@ function fileToBase64(file: File): Promise<string> {
 }
 
 export const AccountSkeletonCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [adding, setAdding] = useState(false);
   const [relPath, setRelPath] = useState("");
@@ -101,7 +103,7 @@ export const AccountSkeletonCard = () => {
 
   return (
     <Card
-      title="Account skeleton"
+      title={t("accountskeletoncard.account_skeleton")}
       style={{ marginBottom: 16 }}
       extra={
         <Button icon={<PlusOutlined />} onClick={() => setAdding(true)}>
@@ -151,11 +153,11 @@ export const AccountSkeletonCard = () => {
       />
 
       <Modal
-        title="Add skeleton file"
+        title={t("accountskeletoncard.add_skeleton_file")}
         open={adding}
         onCancel={() => setAdding(false)}
         onOk={() => put.mutate()}
-        okText="Add"
+        okText={t("accountskeletoncard.add")}
         confirmLoading={put.isPending}
         okButtonProps={{ disabled: !pending }}
       >
@@ -170,7 +172,7 @@ export const AccountSkeletonCard = () => {
             <Button icon={<UploadOutlined />}>Choose file</Button>
           </Upload>
           <Input
-            addonBefore="Path"
+            addonBefore={t("accountskeletoncard.path")}
             placeholder={pending?.name ? pending.name : "index.html or css/style.css"}
             value={relPath}
             onChange={(e) => setRelPath(e.target.value)}

--- a/panel-ui/src/shells/admin/settings/BrandingCard.tsx
+++ b/panel-ui/src/shells/admin/settings/BrandingCard.tsx
@@ -9,6 +9,7 @@
 // invalidate the public /branding key so the topbar re-reads
 // immediately. DELETE clears the custom logo; the topbar falls back
 // to the built-in SVG.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -39,6 +40,7 @@ const LOGO_ACCEPT = "image/png,image/svg+xml,image/webp,image/jpeg,image/gif";
 const MAX_LOGO_BYTES = 512 * 1024;
 
 export const BrandingCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [form] = Form.useForm<ServerSettingsShape>();
   const [loading, setLoading] = useState(true);
@@ -147,7 +149,7 @@ export const BrandingCard = () => {
 
   return (
     <>
-      <Card title="Panel Branding" style={{ marginBottom: 16 }}>
+      <Card title={t("brandingcard.panel_branding")} style={{ marginBottom: 16 }}>
         <Form
           form={form}
           layout="vertical"
@@ -155,12 +157,12 @@ export const BrandingCard = () => {
           disabled={loading}
         >
           <Form.Item
-            label="Brand text"
+            label={t("brandingcard.brand_text")}
             name="panel_brand_text"
             rules={[{ max: 60, message: "<= 60 chars" }]}
             extra="Shown next to the logo and in the browser tab title. Empty falls back to 'Jabali'."
           >
-            <Input placeholder="Jabali" maxLength={60} showCount />
+            <Input placeholder={t("brandingcard.jabali")} maxLength={60} showCount />
           </Form.Item>
 
           <Space>
@@ -216,8 +218,8 @@ export const BrandingCard = () => {
           type="info"
           showIcon
           style={{ marginTop: 16 }}
-          message="Browser cache"
-          description="Newly uploaded logos may take up to 5 minutes to appear across all sessions due to HTTP cache. Force-reload (Ctrl+Shift+R) to see yours immediately."
+          message={t("brandingcard.browser_cache")}
+          description={t("brandingcard.newly_uploaded_logos_may_take_up_to_5_minute")}
         />
       </Card>
     </>

--- a/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -53,6 +54,7 @@ function applyPreset(name: "permissive" | "hosting-safe" | "locked-down"): Polic
 }
 
 export function DNSPermissionsCard() {
+  const { t } = useTranslation();
   const [policy, setPolicy] = useState<Policy>(() => normalize(undefined));
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -110,12 +112,12 @@ export function DNSPermissionsCard() {
   ];
 
   return (
-    <Card title="DNS Record Permissions" style={{ marginBottom: 16 }} loading={loading}>
+    <Card title={t("dnspermissionscard.dns_record_permissions")} style={{ marginBottom: 16 }} loading={loading}>
       <Alert
         type="info"
         style={{ marginBottom: 16 }}
-        message="Which DNS record types regular users may manage"
-        description="Admins always have full control. NS and SOA records are zone infrastructure and are never user-editable. Use a preset or fine-tune per type, then Save."
+        message={t("dnspermissionscard.which_dns_record_types_regular_users_may_man")}
+        description={t("dnspermissionscard.admins_always_have_full_control_ns_and_soa_r")}
       />
       <Space wrap style={{ marginBottom: 16 }}>
         <Button onClick={() => setPolicy(applyPreset("permissive"))}>Permissive</Button>

--- a/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -148,6 +149,7 @@ function notifyError(notify: NotifyFn, title: string, err: unknown) {
 }
 
 export const DNSResolversCard = () => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<FormShape>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -209,7 +211,7 @@ export const DNSResolversCard = () => {
   };
 
   return (
-    <Card title="DNS Resolvers" style={{ marginBottom: 16 }}>
+    <Card title={t("dnsresolverscard.dns_resolvers")} style={{ marginBottom: 16 }}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Set the upstream DNS servers this server uses to resolve hostnames.
         Writes a drop-in at <code>/etc/systemd/resolved.conf.d/jabali.conf</code>
@@ -233,7 +235,7 @@ export const DNSResolversCard = () => {
           showIcon
           style={{ marginBottom: 12 }}
           title="systemd-resolved is not active"
-          description="The drop-in will still be written, but changes won't take effect until the service is running."
+          description={t("dnsresolverscard.the_drop_in_will_still_be_written_but_change")}
         />
       )}
 
@@ -261,7 +263,7 @@ export const DNSResolversCard = () => {
         <Row gutter={16}>
           <Col span={12}>
             <Form.Item
-              label="IPv4 Primary"
+              label={t("dnsresolverscard.ipv4_primary")}
               name="ipv4_primary"
               rules={[
                 {
@@ -275,7 +277,7 @@ export const DNSResolversCard = () => {
           </Col>
           <Col span={12}>
             <Form.Item
-              label="IPv4 Secondary (optional)"
+              label={t("dnsresolverscard.ipv4_secondary_optional")}
               name="ipv4_secondary"
               rules={[
                 {
@@ -292,7 +294,7 @@ export const DNSResolversCard = () => {
         <Row gutter={16}>
           <Col span={12}>
             <Form.Item
-              label="IPv6 Primary (optional)"
+              label={t("dnsresolverscard.ipv6_primary_optional")}
               name="ipv6_primary"
               rules={[
                 {
@@ -306,7 +308,7 @@ export const DNSResolversCard = () => {
           </Col>
           <Col span={12}>
             <Form.Item
-              label="IPv6 Secondary (optional)"
+              label={t("dnsresolverscard.ipv6_secondary_optional")}
               name="ipv6_secondary"
               rules={[
                 {
@@ -321,7 +323,7 @@ export const DNSResolversCard = () => {
         </Row>
 
         <Form.Item
-          label="Search domain (optional)"
+          label={t("dnsresolverscard.search_domain_optional")}
           name="search_domain"
           extra="Appended to unqualified hostnames (systemd-resolved Domains=)."
           rules={[

--- a/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
+++ b/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
@@ -5,6 +5,7 @@
 //
 // Icons go through the @icons shim (CONVENTIONS) — never
 // @ant-design/icons.
+import { useTranslation } from "react-i18next";
 import {
   DatabaseOutlined,
   KeyOutlined,
@@ -44,6 +45,7 @@ const ENGINE_LABEL: Record<Engine, string> = {
 };
 
 function RootPasswordSection() {
+  const { t } = useTranslation();
   const [busy, setBusy] = useState<Engine | null>(null);
   const [revealed, setRevealed] = useState<{ engine: Engine; password: string } | null>(
     null,
@@ -89,8 +91,8 @@ function RootPasswordSection() {
           <Popconfirm
             key={engine}
             title={`Rotate the ${ENGINE_LABEL[engine]} password?`}
-            description="The previous password (if any) stops working immediately."
-            okText="Rotate"
+            description={t("databaseadminsections.the_previous_password_if_any_stops_working_i")}
+            okText={t("databaseadminsections.rotate")}
             okButtonProps={{ danger: true }}
             onConfirm={() => rotate(engine)}
           >
@@ -117,7 +119,7 @@ function RootPasswordSection() {
         }
         onCancel={() => setRevealed(null)}
         onOk={() => setRevealed(null)}
-        okText="I saved it"
+        okText={t("databaseadminsections.i_saved_it")}
         cancelButtonProps={{ style: { display: "none" } }}
         maskClosable={false}
       >
@@ -150,6 +152,7 @@ interface ConfigParam {
 }
 
 function ConfigTunerSection() {
+  const { t } = useTranslation();
   const [engine, setEngine] = useState<Engine>("mariadb");
   const [params, setParams] = useState<ConfigParam[] | null>(null);
   const [loading, setLoading] = useState(false);
@@ -294,7 +297,7 @@ function ConfigTunerSection() {
                 ? "Some changed keys require a service restart — DB connections will drop briefly."
                 : "Configuration will be reloaded."
             }
-            okText="Apply"
+            okText={t("databaseadminsections.apply")}
             onConfirm={apply}
           >
             <Button type="primary" loading={saving}>
@@ -489,6 +492,7 @@ interface DbProc {
 }
 
 function ProcessesSection() {
+  const { t } = useTranslation();
   const [engine, setEngine] = useState<Engine>("mariadb");
   const [rows, setRows] = useState<DbProc[]>([]);
   const [loading, setLoading] = useState(false);
@@ -560,19 +564,19 @@ function ProcessesSection() {
         scroll={{ x: "max-content", y: 320 }}
       >
         <Table.Column dataIndex="id" title="ID" />
-        <Table.Column dataIndex="user" title="User" />
-        <Table.Column dataIndex="host" title="Host" />
+        <Table.Column dataIndex="user" title={t("databaseadminsections.user")} />
+        <Table.Column dataIndex="host" title={t("databaseadminsections.host")} />
         <Table.Column dataIndex="db" title="DB" />
         {engine === "mariadb" && (
-          <Table.Column dataIndex="command" title="Command" />
+          <Table.Column dataIndex="command" title={t("databaseadminsections.command")} />
         )}
         {engine === "mariadb" && (
-          <Table.Column dataIndex="time" title="Time" />
+          <Table.Column dataIndex="time" title={t("databaseadminsections.time")} />
         )}
-        <Table.Column dataIndex="state" title="State" />
+        <Table.Column dataIndex="state" title={t("databaseadminsections.state")} />
         <Table.Column
           dataIndex="info"
-          title="Query"
+          title={t("databaseadminsections.query")}
           width={380}
           render={(v: string) => (
             // Bounded + ellipsis so a long query can't blow out the
@@ -595,11 +599,11 @@ function ProcessesSection() {
           )}
         />
         <Table.Column
-          title="Actions"
+          title={t("databaseadminsections.actions")}
           render={(_, row: DbProc) => (
             <Popconfirm
               title={`Kill ${row.id}?`}
-              okText="Kill"
+              okText={t("databaseadminsections.kill")}
               okButtonProps={{ danger: true }}
               onConfirm={() => kill(row.id)}
             >

--- a/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
@@ -5,6 +5,7 @@
 //   (sources install.sh, runs install_docker_engine, starts docker).
 // Flip false: panel-api dispatches `docker.disable` (stops + disables
 //   docker units). Data under /var/lib/jabali/docker-apps/ stays.
+import { useTranslation } from "react-i18next";
 import { App, Alert, Button, Card, Checkbox, Modal, Space, Spin, Switch, Tag, Typography } from "antd";
 import { useEffect, useState } from "react";
 
@@ -23,6 +24,7 @@ interface CatalogEntry {
 }
 
 export function DockerMarketplaceCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
@@ -179,7 +181,7 @@ export function DockerMarketplaceCard() {
 
   if (enabled === null) {
     return (
-      <Card title="Docker App Marketplace (M48)">
+      <Card title={t("dockermarketplacecard.docker_app_marketplace_m48")}>
         <Spin />
       </Card>
     );
@@ -206,7 +208,7 @@ export function DockerMarketplaceCard() {
           <Alert
             type="info"
             showIcon
-            message="Opt-in feature"
+            message={t("dockermarketplacecard.opt_in_feature")}
             description={
               <>
                 Click <b>Enable</b> below to install Docker and unlock the marketplace at{" "}
@@ -221,7 +223,7 @@ export function DockerMarketplaceCard() {
           <Alert
             type="success"
             showIcon
-            message="Marketplace live"
+            message={t("dockermarketplacecard.marketplace_live")}
             description={
               <>
                 Open <a href="/jabali-admin/docker-apps">/jabali-admin/docker-apps</a> to

--- a/panel-ui/src/shells/admin/settings/EmailCard.tsx
+++ b/panel-ui/src/shells/admin/settings/EmailCard.tsx
@@ -6,12 +6,14 @@
 // No edit affordance; the hostname comes from JABALI_SRV_HOSTNAME at
 // install time and isn't editable from the panel UI.
 
+import { useTranslation } from "react-i18next";
 import { MailOutlined, ReloadOutlined } from "@icons";
 import { Alert, Badge, Button, Card, Descriptions, Skeleton, Space, Typography } from "antd";
 
 import { useSettingsEmail } from "../../../hooks/useSettingsEmail";
 
 export const EmailCard = () => {
+  const { t } = useTranslation();
   const q = useSettingsEmail();
 
   if (q.isPending) {
@@ -27,7 +29,7 @@ export const EmailCard = () => {
       <Card title={<CardTitle />}>
         <Alert
           type="error"
-          message="Failed to load email settings"
+          message={t("emailcard.failed_to_load_email_settings")}
           description={q.error.message}
           action={
             <Button icon={<ReloadOutlined />} onClick={() => q.refetch()}>
@@ -53,8 +55,8 @@ export const EmailCard = () => {
         <Alert
           type="info"
           showIcon
-          message="Webmail is initializing"
-          description="The panel hostname's mail domain is being provisioned (DKIM keypair, Stalwart, DNS records, nginx vhost). This typically takes ~30 seconds on a fresh install. This page will refresh automatically."
+          message={t("emailcard.webmail_is_initializing")}
+          description={t("emailcard.the_panel_hostname_s_mail_domain_is_being_pr")}
         />
       </Card>
     );
@@ -68,22 +70,22 @@ export const EmailCard = () => {
   return (
     <Card title={<CardTitle />}>
       <Descriptions column={1} size="middle" layout="vertical">
-        <Descriptions.Item label="Primary mail domain">
+        <Descriptions.Item label={t("emailcard.primary_mail_domain")}>
           <Typography.Text code>{data.primaryDomainName}</Typography.Text>
         </Descriptions.Item>
-        <Descriptions.Item label="Webmail URL">
+        <Descriptions.Item label={t("emailcard.webmail_url")}>
           <Typography.Link href={data.webmailURL} target="_blank" rel="noreferrer">
             {data.webmailURL}
           </Typography.Link>
         </Descriptions.Item>
-        <Descriptions.Item label="DKIM">
+        <Descriptions.Item label={t("emailcard.dkim")}>
           {data.dkimPublished ? (
             <Badge status="success" text="Published" />
           ) : (
             <Badge status="processing" text="Initializing" />
           )}
         </Descriptions.Item>
-        <Descriptions.Item label="Enabled at">{enabledAtLabel}</Descriptions.Item>
+        <Descriptions.Item label={t("emailcard.enabled_at")}>{enabledAtLabel}</Descriptions.Item>
       </Descriptions>
       <Typography.Paragraph type="secondary" style={{ marginTop: 16, marginBottom: 0 }}>
         Auto-registered at install time. The hostname comes from{" "}

--- a/panel-ui/src/shells/admin/settings/LogRetentionCard.tsx
+++ b/panel-ui/src/shells/admin/settings/LogRetentionCard.tsx
@@ -3,6 +3,7 @@
 // 365d for forensic security tables, 0 = keep forever. Saving PATCHes
 // /admin/settings with a { category: days } log_retention map; the daily
 // jabali-retention-sweep reads it (an absent category uses the code default).
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   App,
@@ -51,6 +52,7 @@ const CATEGORIES: {
 ];
 
 export function LogRetentionCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [form] = Form.useForm<RetentionMap>();
   const [loaded, setLoaded] = useState(false);
@@ -92,7 +94,7 @@ export function LogRetentionCard() {
   };
 
   return (
-    <Card title="Logs — retention" style={{ marginBottom: 16 }}>
+    <Card title={t("logretentioncard.logs_retention")} style={{ marginBottom: 16 }}>
       <Typography.Paragraph type="secondary">
         How long each log/report table is kept before the daily retention sweep
         prunes it. <b>0 = keep forever.</b> Changes take effect on the next sweep.
@@ -130,8 +132,8 @@ export function LogRetentionCard() {
             type="info"
             showIcon
             style={{ marginTop: 8, marginBottom: 16, maxWidth: 640 }}
-            message="The audit log defaults to keep-forever"
-            description="It's hash-chained and tamper-evident. Set a window only if you accept a shorter forensic record; pruning re-anchors the chain so it stays verifiable forward."
+            message={t("logretentioncard.the_audit_log_defaults_to_keep_forever")}
+            description={t("logretentioncard.it_s_hash_chained_and_tamper_evident_set_a_w")}
           />
           <Button type="primary" loading={saving} onClick={() => void save()}>
             Save retention

--- a/panel-ui/src/shells/admin/settings/LookAndFeelCard.tsx
+++ b/panel-ui/src/shells/admin/settings/LookAndFeelCard.tsx
@@ -1,6 +1,7 @@
 // LookAndFeelCard — panel-wide appearance: font size + operator colors. Stored
 // as a server_settings singleton and applied for ALL users via the app's
 // ConfigProvider (useBranding -> useMuiTheme). Empty color = built-in default.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
 import {
@@ -56,6 +57,7 @@ const toHex = (c: unknown): string => {
 };
 
 export const LookAndFeelCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [form] = Form.useForm<FormShape>();
   const [loading, setLoading] = useState(true);
@@ -111,10 +113,10 @@ export const LookAndFeelCard = () => {
   };
 
   return (
-    <Card title="Look and feel" style={{ marginBottom: 16 }}>
+    <Card title={t("lookandfeelcard.look_and_feel")} style={{ marginBottom: 16 }}>
       <Form form={form} layout="vertical" onFinish={persist} disabled={loading}>
         <Form.Item
-          label="Panel font size"
+          label={t("lookandfeelcard.panel_font_size")}
           name="panel_font_size"
           extra="Applies to the whole panel for all users. Medium is the default."
         >

--- a/panel-ui/src/shells/admin/settings/ModulesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/ModulesCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
 import { Button, Card, Space, Spin, Switch, Tag, Typography, notification } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
@@ -38,6 +39,7 @@ const POLL_INTERVAL_MS = 5000;
 const POLL_MAX_ATTEMPTS = 60; // ~5 minutes; apt + downloads can be slow
 
 export const ModulesCard = () => {
+  const { t } = useTranslation();
   const [state, setState] = useState<Record<ModuleKey, boolean>>({
     dns_enabled: true,
     mail_enabled: true,
@@ -170,7 +172,7 @@ export const ModulesCard = () => {
   };
 
   return (
-    <Card title="Modules" style={{ marginBottom: 16 }} loading={loading}>
+    <Card title={t("modulescard.modules")} style={{ marginBottom: 16 }} loading={loading}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Turn optional modules on or off. Enabling a module installs its software in
         the background (the panel hides a module's pages when it's off; existing

--- a/panel-ui/src/shells/admin/settings/NginxSettingsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/NginxSettingsCard.tsx
@@ -7,6 +7,7 @@
 // The Advanced free-form box drops raw directives into the http{} fragment.
 // It is gated only by nginx -t, so a syntactically-valid-but-wrong directive
 // can still degrade the server — hence the red warning.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   App,
@@ -55,6 +56,7 @@ const sizeRule = { pattern: SIZE_RE, message: "e.g. 50m, 1g, or a number" };
 const timeRule = { pattern: TIME_RE, message: "e.g. 60s, 300, 5m" };
 
 export function NginxSettingsCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [form] = Form.useForm<NginxSettings>();
   const [loaded, setLoaded] = useState(false);
@@ -94,14 +96,14 @@ export function NginxSettingsCard() {
 
   if (!loaded) {
     return (
-      <Card title="Nginx">
+      <Card title={t("nginxsettingscard.nginx")}>
         <Spin />
       </Card>
     );
   }
 
   return (
-    <Card title="Nginx">
+    <Card title={t("nginxsettingscard.nginx")}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Server-wide nginx tunables applied at <code>http&#123;&#125;</code> scope (individual
         sites may override per-directive). Changes are validated with{" "}
@@ -111,23 +113,23 @@ export function NginxSettingsCard() {
       <Form form={form} layout="vertical" requiredMark={false}>
         <Form.Item
           name="nginx_client_max_body_size"
-          label="Max upload size (client_max_body_size)"
-          tooltip="Largest request body nginx accepts before 413. Raise it for big-upload apps (ownCloud, Nextcloud). e.g. 50m, 2g."
+          label={t("nginxsettingscard.max_upload_size_client_max_body_size")}
+          tooltip={t("nginxsettingscard.largest_request_body_nginx_accepts_before_41")}
           rules={[sizeRule]}
         >
           <Input style={{ maxWidth: 200 }} placeholder="50m" />
         </Form.Item>
 
         <Space size="large" wrap>
-          <Form.Item name="nginx_server_tokens" label="Show nginx version (server_tokens)" valuePropName="checked" tooltip="Off hides the nginx version in responses + error pages (recommended).">
+          <Form.Item name="nginx_server_tokens" label={t("nginxsettingscard.show_nginx_version_server_tokens")} valuePropName="checked" tooltip={t("nginxsettingscard.off_hides_the_nginx_version_in_responses_err")}>
             <Switch checkedChildren="on" unCheckedChildren="off" />
           </Form.Item>
-          <Form.Item name="nginx_gzip" label="Gzip compression" valuePropName="checked">
+          <Form.Item name="nginx_gzip" label={t("nginxsettingscard.gzip_compression")} valuePropName="checked">
             <Switch checkedChildren="on" unCheckedChildren="off" />
           </Form.Item>
         </Space>
 
-        <Form.Item name="nginx_keepalive_timeout" label="Keepalive timeout" rules={[timeRule]}>
+        <Form.Item name="nginx_keepalive_timeout" label={t("nginxsettingscard.keepalive_timeout")} rules={[timeRule]}>
           <Input style={{ maxWidth: 160 }} placeholder="65s" />
         </Form.Item>
 
@@ -180,13 +182,13 @@ export function NginxSettingsCard() {
 
         <Divider plain>FastCGI cache capacity (GH #634)</Divider>
         <Space wrap>
-          <Form.Item name="nginx_cache_max_size_gb" label="max_size (GB)" tooltip="Shared FastCGI cache max on-disk size">
+          <Form.Item name="nginx_cache_max_size_gb" label="max_size (GB)" tooltip={t("nginxsettingscard.shared_fastcgi_cache_max_on_disk_size")}>
             <InputNumber min={1} max={1024} style={{ width: 140 }} />
           </Form.Item>
-          <Form.Item name="nginx_cache_keyzone_mb" label="keys_zone (MB)" tooltip="Cache key metadata zone (~8000 keys/MB)">
+          <Form.Item name="nginx_cache_keyzone_mb" label="keys_zone (MB)" tooltip={t("nginxsettingscard.cache_key_metadata_zone_8000_keys_mb")}>
             <InputNumber min={8} max={1024} style={{ width: 140 }} />
           </Form.Item>
-          <Form.Item name="nginx_cache_inactive_min" label="inactive (min)" tooltip="Evict entries not accessed within this window">
+          <Form.Item name="nginx_cache_inactive_min" label="inactive (min)" tooltip={t("nginxsettingscard.evict_entries_not_accessed_within_this_windo")}>
             <InputNumber min={1} max={1440} style={{ width: 140 }} />
           </Form.Item>
         </Space>
@@ -198,7 +200,7 @@ export function NginxSettingsCard() {
           type="error"
           showIcon
           style={{ marginBottom: 12 }}
-          message="Raw nginx directives — can make the server unstable"
+          message={t("nginxsettingscard.raw_nginx_directives_can_make_the_server_uns")}
           description={
             <>
               Directives below are inserted verbatim into the http&#123;&#125; block. They are
@@ -210,7 +212,7 @@ export function NginxSettingsCard() {
         />
         <Form.Item
           name="nginx_custom_http"
-          label="Custom http{} directives"
+          label={t("nginxsettingscard.custom_http_directives")}
           rules={[{ max: 4000, message: "Max 4000 characters" }]}
         >
           <Input.TextArea

--- a/panel-ui/src/shells/admin/settings/NspawnImagesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/NspawnImagesCard.tsx
@@ -3,6 +3,7 @@
 // as a transient unit, polled for progress), and prune images no user is
 // pinned to. Proxies the operator `jabali nspawn build/prune` CLIs via the
 // agent; nothing is re-implemented client-side.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Alert,
@@ -37,6 +38,7 @@ interface PruneResult {
 }
 
 export function NspawnImagesCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [form] = Form.useForm();
   const [since, setSince] = useState<string | null>(null);
@@ -95,7 +97,7 @@ export function NspawnImagesCard() {
   });
 
   return (
-    <Card title="SSH sandbox images (nspawn)" style={{ marginBottom: 16 }}>
+    <Card title={t("nspawnimagescard.ssh_sandbox_images_nspawn")} style={{ marginBottom: 16 }}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Typography.Text type="secondary">
           Sealed, immutable base images for the nspawn SSH sandbox. Building runs
@@ -126,15 +128,15 @@ export function NspawnImagesCard() {
           initialValues={{ codename: "debian-13", suite: "trixie" }}
           onFinish={(v) => build.mutate(v)}
         >
-          <Form.Item name="codename" label="Codename" rules={[{ required: true }]}>
+          <Form.Item name="codename" label={t("nspawnimagescard.codename")} rules={[{ required: true }]}>
             <Input placeholder="debian-13" style={{ width: 130 }} />
           </Form.Item>
-          <Form.Item name="version" label="Version" rules={[{ required: true }]}>
+          <Form.Item name="version" label={t("nspawnimagescard.version")} rules={[{ required: true }]}>
             <Input placeholder="v1" style={{ width: 90 }} />
           </Form.Item>
           <Form.Item
             name="snapshot"
-            label="Snapshot"
+            label={t("nspawnimagescard.snapshot")}
             rules={[
               { required: true },
               {
@@ -145,7 +147,7 @@ export function NspawnImagesCard() {
           >
             <Input placeholder="20260426T000000Z" style={{ width: 175 }} />
           </Form.Item>
-          <Form.Item name="suite" label="Suite">
+          <Form.Item name="suite" label={t("nspawnimagescard.suite")}>
             <Input placeholder="trixie" style={{ width: 100 }} />
           </Form.Item>
           <Form.Item>
@@ -169,9 +171,9 @@ export function NspawnImagesCard() {
             Scan for unused images
           </Button>
           <Popconfirm
-            title="Delete all unused images?"
-            description="Removes every sealed image no user (and not the server default) is pinned to. Irreversible — you'd rebuild from a snapshot to restore."
-            okText="Prune"
+            title={t("nspawnimagescard.delete_all_unused_images")}
+            description={t("nspawnimagescard.removes_every_sealed_image_no_user_and_not_t")}
+            okText={t("nspawnimagescard.prune")}
             okButtonProps={{ danger: true }}
             onConfirm={() => prune.mutate(true)}
           >
@@ -183,7 +185,7 @@ export function NspawnImagesCard() {
         {pruneOut && (
           <Alert
             type="info"
-            message="Prune result"
+            message={t("nspawnimagescard.prune_result")}
             description={<pre style={{ whiteSpace: "pre-wrap", margin: 0, fontSize: 12 }}>{pruneOut}</pre>}
           />
         )}

--- a/panel-ui/src/shells/admin/settings/PHPPerformanceModesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PHPPerformanceModesCard.tsx
@@ -1,6 +1,7 @@
 // PHPPerformanceModesCard — GH #339 phase 2, Step 2 UI. Admin editor for the 4
 // PHP Performance Mode presets that L1 users select from. Edits are the ceiling
 // templates; per-package clamping happens at apply.
+import { useTranslation } from "react-i18next";
 import { Button, Card, Collapse, Form, InputNumber, Select, Typography, message } from "antd";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -20,6 +21,7 @@ type Mode = {
 };
 
 const ModeForm = ({ mode }: { mode: Mode }) => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [form] = Form.useForm();
   const [saving, setSaving] = useState(false);
@@ -39,27 +41,28 @@ const ModeForm = ({ mode }: { mode: Mode }) => {
   };
   return (
     <Form form={form} layout="vertical" initialValues={mode} style={{ maxWidth: 420 }}>
-      <Form.Item name="pm_mode" label="Process manager">
+      <Form.Item name="pm_mode" label={t("phpperformancemodescard.process_manager")}>
         <Select options={["dynamic", "ondemand", "static"].map((v) => ({ value: v, label: v }))} />
       </Form.Item>
-      <Form.Item name="pm_max_children" label="Max children"><InputNumber min={1} max={2000} /></Form.Item>
-      <Form.Item name="pm_start_servers" label="Start servers"><InputNumber min={1} max={2000} /></Form.Item>
-      <Form.Item name="pm_min_spare_servers" label="Min spare"><InputNumber min={1} max={2000} /></Form.Item>
-      <Form.Item name="pm_max_spare_servers" label="Max spare"><InputNumber min={1} max={2000} /></Form.Item>
-      <Form.Item name="pm_max_requests" label="Max requests (0 = never)"><InputNumber min={0} max={100000} /></Form.Item>
-      <Form.Item name="process_idle_timeout_seconds" label="Idle timeout (s)"><InputNumber min={1} max={86400} /></Form.Item>
+      <Form.Item name="pm_max_children" label={t("phpperformancemodescard.max_children")}><InputNumber min={1} max={2000} /></Form.Item>
+      <Form.Item name="pm_start_servers" label={t("phpperformancemodescard.start_servers")}><InputNumber min={1} max={2000} /></Form.Item>
+      <Form.Item name="pm_min_spare_servers" label={t("phpperformancemodescard.min_spare")}><InputNumber min={1} max={2000} /></Form.Item>
+      <Form.Item name="pm_max_spare_servers" label={t("phpperformancemodescard.max_spare")}><InputNumber min={1} max={2000} /></Form.Item>
+      <Form.Item name="pm_max_requests" label={t("phpperformancemodescard.max_requests_0_never")}><InputNumber min={0} max={100000} /></Form.Item>
+      <Form.Item name="process_idle_timeout_seconds" label={t("phpperformancemodescard.idle_timeout_s")}><InputNumber min={1} max={86400} /></Form.Item>
       <Button type="primary" loading={saving} onClick={save}>Save {mode.mode}</Button>
     </Form>
   );
 };
 
 export const PHPPerformanceModesCard = () => {
+  const { t } = useTranslation();
   const { data } = useQuery<Mode[]>({
     queryKey: ["php-performance-modes"],
     queryFn: async () => (await apiClient.get<{ data: Mode[] }>("/php-performance-modes")).data.data ?? [],
   });
   return (
-    <Card title="PHP Performance Modes" style={{ marginBottom: 16 }}>
+    <Card title={t("phpperformancemodescard.php_performance_modes")} style={{ marginBottom: 16 }}>
       <Typography.Paragraph type="secondary">
         The presets users pick from (when enabled per hosting package). Values are
         re-clamped to each package&apos;s cap at apply time.

--- a/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
@@ -1,6 +1,7 @@
 // PageTemplatesCard — M28 admin list of operator-editable page
 // templates (default domain index, 404/403/500). List on the left,
 // edit in a Modal with a textarea.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Button,
@@ -33,6 +34,7 @@ const LIST_KEY = ["admin", "page-templates"] as const;
 const MAX_BYTES = 128 * 1024;
 
 export const PageTemplatesCard = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [editing, setEditing] = useState<PageTemplate | null>(null);
   const [draft, setDraft] = useState("");
@@ -91,7 +93,7 @@ export const PageTemplatesCard = () => {
 
   return (
     <>
-      <Card title="Page Templates" style={{ marginBottom: 16 }}>
+      <Card title={t("pagetemplatescard.page_templates")} style={{ marginBottom: 16 }}>
         <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
           Edit the HTML written to disk on new domains and rendered for common
           error pages. The domain default index supports{" "}
@@ -148,8 +150,8 @@ export const PageTemplatesCard = () => {
         width={900}
         confirmLoading={saving}
         onOk={save}
-        okText="Save"
-        cancelText="Cancel"
+        okText={t("pagetemplatescard.save")}
+        cancelText={t("pagetemplatescard.cancel")}
         destroyOnClose
       >
         {editing && (

--- a/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
@@ -4,6 +4,7 @@
 // and the panel mail (mail.<hostname>) cert. Each gets its own status
 // row + Retry; mail can never block the hostname cert. The single
 // Use-LE / staging toggle (the hostname row's flags) governs both.
+import { useTranslation } from "react-i18next";
 import {
   CheckCircleOutlined,
   CloseOutlined,
@@ -122,19 +123,20 @@ function CertRow({
 }
 
 export function PanelSSLCard() {
+  const { t } = useTranslation();
   const q = usePanelCertificate();
   const toggle = usePanelCertificateToggle();
   const issue = usePanelCertificateIssue();
 
   if (q.isPending) {
-    return <Card title="Panel SSL" loading style={{ marginBottom: 16 }} />;
+    return <Card title={t("panelsslcard.panel_ssl")} loading style={{ marginBottom: 16 }} />;
   }
   if (q.isError || !q.data) {
     return (
-      <Card title="Panel SSL" style={{ marginBottom: 16 }}>
+      <Card title={t("panelsslcard.panel_ssl")} style={{ marginBottom: 16 }}>
         <Alert
           type="error"
-          message="Failed to load panel SSL state"
+          message={t("panelsslcard.failed_to_load_panel_ssl_state")}
           description={String((q.error as Error)?.message ?? "")}
           showIcon
         />
@@ -147,8 +149,8 @@ export function PanelSSLCard() {
   const mail = certs.find((c) => c.kind === "mail");
   if (!host) {
     return (
-      <Card title="Panel SSL" style={{ marginBottom: 16 }}>
-        <Alert type="info" message="Panel certificate not initialised yet." showIcon />
+      <Card title={t("panelsslcard.panel_ssl")} style={{ marginBottom: 16 }}>
+        <Alert type="info" message={t("panelsslcard.panel_certificate_not_initialised_yet")} showIcon />
       </Card>
     );
   }
@@ -195,7 +197,7 @@ export function PanelSSLCard() {
           <Alert
             type="warning"
             showIcon
-            message="Let's Encrypt is unavailable for the panel"
+            message={t("panelsslcard.let_s_encrypt_is_unavailable_for_the_panel")}
             description={
               host.routable_reason
                 ? `${host.routable_reason}. Point the panel hostname's DNS A record at this server's public IP, then click Refresh.`
@@ -244,14 +246,14 @@ export function PanelSSLCard() {
         </Space>
 
         <CertRow
-          label="Hostname"
+          label={t("panelsslcard.hostname")}
           cert={host}
           retrying={issue.isPending}
           onRetry={() => doIssue("hostname")}
         />
         {mail && (
           <CertRow
-            label="Mail"
+            label={t("panelsslcard.mail")}
             cert={mail}
             retrying={issue.isPending}
             onRetry={() => doIssue("mail")}

--- a/panel-ui/src/shells/admin/settings/PythonAppsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PythonAppsCard.tsx
@@ -3,6 +3,7 @@
 // persists python_apps_enabled; the host installs the Python runtime
 // prerequisites (python3-venv + build toolchain) via install.sh on the
 // next `jabali update` (or already, on a fresh install with the flag set).
+import { useTranslation } from "react-i18next";
 import { App, Alert, Card, Space, Spin, Switch, Tag, Typography } from "antd";
 import { useEffect, useState } from "react";
 
@@ -13,6 +14,7 @@ interface ServerSettingsPyApps {
 }
 
 export function PythonAppsCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
@@ -112,8 +114,8 @@ export function PythonAppsCard() {
           <Alert
             type="info"
             showIcon
-            message="Runtime prerequisites"
-            description="Apps need python3-venv and a build toolchain (gcc, python3-dev, libffi/ssl-dev). These are installed by the host provisioner; if a venv build fails for a C-extension package, run jabali update to ensure the toolchain is present."
+            message={t("pythonappscard.runtime_prerequisites")}
+            description={t("pythonappscard.apps_need_python3_venv_and_a_build_toolchain")}
           />
         )}
       </Space>

--- a/panel-ui/src/shells/admin/settings/SSOMaintenanceCard.tsx
+++ b/panel-ui/src/shells/admin/settings/SSOMaintenanceCard.tsx
@@ -7,6 +7,7 @@
 //   rotation that reloads the serving process is a foot-gun that, done wrong,
 //   breaks phpMyAdmin SSO for every tenant. We surface the exact guarded
 //   procedure + rollback instead (the CLI-supported branch of #575).
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   App,
@@ -43,6 +44,7 @@ mv /etc/jabali/sso_key.txt.bak /etc/jabali/sso_key.txt
 systemctl kill -s SIGHUP jabali-panel`;
 
 export function SSOMaintenanceCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
 
   const prune = useMutation({
@@ -54,7 +56,7 @@ export function SSOMaintenanceCard() {
   });
 
   return (
-    <Card title="SSO maintenance (phpMyAdmin)" style={{ marginBottom: 16 }}>
+    <Card title={t("ssomaintenancecard.sso_maintenance_phpmyadmin")} style={{ marginBottom: 16 }}>
       <Space direction="vertical" size="large" style={{ width: "100%" }}>
         {/* prune — safe, one-click */}
         <div>
@@ -64,9 +66,9 @@ export function SSOMaintenanceCard() {
             sweep. This forces an immediate purge.
           </Paragraph>
           <Popconfirm
-            title="Purge expired SSO tokens now?"
-            description="Deletes only already-expired tokens — active SSO sessions are unaffected."
-            okText="Purge"
+            title={t("ssomaintenancecard.purge_expired_sso_tokens_now")}
+            description={t("ssomaintenancecard.deletes_only_already_expired_tokens_active_s")}
+            okText={t("ssomaintenancecard.purge")}
             onConfirm={() => prune.mutate()}
           >
             <Button loading={prune.isPending}>Prune expired tokens</Button>
@@ -80,8 +82,8 @@ export function SSOMaintenanceCard() {
             style={{ margin: "8px 0" }}
             type="warning"
             showIcon
-            message="Operator procedure — run on the host, not from the browser"
-            description="Rotation re-encrypts every stored DB-user password, then swaps the on-disk key file and reloads the panel. It is intentionally CLI-only: a browser-triggered rotation that reloads the panel mid-request is high-risk, and a failure between re-encrypt and key-swap breaks phpMyAdmin SSO for all tenants. Take a backup (step 3) so you can roll back."
+            message={t("ssomaintenancecard.operator_procedure_run_on_the_host_not_from")}
+            description={t("ssomaintenancecard.rotation_re_encrypts_every_stored_db_user_pa")}
           />
           <Paragraph type="secondary" style={{ marginBottom: 4 }}>
             Rotate the AES-256-GCM key (as root on the panel host):

--- a/panel-ui/src/shells/admin/settings/StalwartWebadminCard.tsx
+++ b/panel-ui/src/shells/admin/settings/StalwartWebadminCard.tsx
@@ -2,6 +2,7 @@
 // Stalwart's WebAdmin UI through an nginx reverse-proxy (TLS + optional IP
 // allowlist + Stalwart's own admin login). Stalwart itself stays loopback-bound;
 // this is the only door. Default off. Lives on the Server Settings → Email tab.
+import { useTranslation } from "react-i18next";
 import { App, Alert, Button, Card, Input, Modal, Space, Switch, Typography } from "antd";
 import { useEffect, useState } from "react";
 
@@ -21,6 +22,7 @@ interface AdminCredential {
 }
 
 export function StalwartWebadminCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [enabled, setEnabled] = useState(false);
   const [cidrs, setCidrs] = useState("");
@@ -129,7 +131,7 @@ export function StalwartWebadminCard() {
     });
 
   return (
-    <Card title="Stalwart WebAdmin (advanced)" size="small" style={{ marginTop: 16 }}>
+    <Card title={t("stalwartwebadmincard.stalwart_webadmin_advanced")} size="small" style={{ marginTop: 16 }}>
       <Space direction="vertical" style={{ width: "100%" }} size="middle">
         <Typography.Paragraph type="secondary" style={{ margin: 0 }}>
           Exposes Stalwart&apos;s native admin UI (queues, tracing, fine-grained
@@ -167,7 +169,7 @@ export function StalwartWebadminCard() {
               type="warning"
               showIcon
               message={`Live at https://${hostname}:8449/`}
-              description="The full mail-server admin is reachable behind Stalwart’s own login. Restrict by IP and disable when not in use."
+              description={t("stalwartwebadmincard.the_full_mail_server_admin_is_reachable_behi")}
             />
             <div>
               <Typography.Text strong>Stalwart admin login</Typography.Text>
@@ -193,7 +195,7 @@ export function StalwartWebadminCard() {
           title={adminCred?.rotated ? "New Stalwart admin password" : "Stalwart admin login"}
           onOk={() => setAdminCred(null)}
           onCancel={() => setAdminCred(null)}
-          okText="Done"
+          okText={t("stalwartwebadmincard.done")}
           cancelButtonProps={{ style: { display: "none" } }}
         >
           <Typography.Paragraph>

--- a/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Card, Switch, Typography, notification } from "antd";
 
@@ -7,6 +8,7 @@ import { apiClient } from "../../../apiClient";
 // owners into the curated safe nginx options (GH #307). Off by default; raw
 // nginx directives stay admin-only regardless.
 export const TenantDomainOptionsCard = () => {
+  const { t } = useTranslation();
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -42,7 +44,7 @@ export const TenantDomainOptionsCard = () => {
   };
 
   return (
-    <Card title="Tenant Domain Options" style={{ marginBottom: 16 }} loading={loading}>
+    <Card title={t("tenantdomainoptionscard.tenant_domain_options")} style={{ marginBottom: 16 }} loading={loading}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Let non-admin users set a curated, safe set of nginx options on their own
         domains — max upload size, HSTS, security headers, and gzip. The panel

--- a/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Card, Switch, Typography, notification } from "antd";
 
@@ -7,6 +8,7 @@ import { apiClient } from "../../../apiClient";
 // Bulwark webmail client server-wide (GH #316). When off, the reconciler tears
 // down the webmail vhosts and stops the jabali-webmail service.
 export const WebmailToggleCard = () => {
+  const { t } = useTranslation();
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -47,7 +49,7 @@ export const WebmailToggleCard = () => {
   };
 
   return (
-    <Card title="Webmail" style={{ marginBottom: 16 }} loading={loading}>
+    <Card title={t("webmailtogglecard.webmail")} style={{ marginBottom: 16 }} loading={loading}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Serve the bundled webmail client (Bulwark) at <Typography.Text code>mail.&lt;domain&gt;</Typography.Text>{" "}
         for every email-enabled domain. Turn it off to stop offering webmail

--- a/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
+++ b/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Card, Typography } from "antd";
 import { ShieldCheckOutlined } from "@icons";
 
@@ -5,6 +6,7 @@ import { SSLManagerTable } from "../../../components/ssl/SSLManagerTable";
 import { PanelSSLCard } from "../settings/PanelSSLCard";
 
 export const SSLManagerPage = () => {
+  const { t } = useTranslation();
   return (
     <div>
       <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
@@ -19,7 +21,7 @@ export const SSLManagerPage = () => {
         <PanelSSLCard />
       </div>
 
-      <Card title="Domain Certificates">
+      <Card title={t("sslmanagerpage.domain_certificates")}>
         <SSLManagerTable
           endpoint="/admin/ssl-certificates"
           showOwner={true}

--- a/panel-ui/src/shells/admin/terminal/AdminTerminal.tsx
+++ b/panel-ui/src/shells/admin/terminal/AdminTerminal.tsx
@@ -2,6 +2,7 @@
 // root PTY broker. Off by default; this page shows enable-instructions
 // when the gate is closed. Every byte of an open session is recorded
 // server-side to /var/log/jabali/terminal/<id>.cast.
+import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
 import { Alert, Card, Result, Spin, Typography } from "antd";
 import { Terminal } from "@xterm/xterm";
@@ -27,6 +28,7 @@ function frame(op: number, payload: Uint8Array): Uint8Array {
 }
 
 export function AdminTerminal() {
+  const { t } = useTranslation();
   const gate = useRootTerminalEnabled();
   const hostRef = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<"idle" | "connecting" | "open" | "closed" | "error">("idle");
@@ -146,7 +148,7 @@ export function AdminTerminal() {
     return (
       <Result
         status="warning"
-        title="Root terminal is disabled"
+        title={t("adminterminal.root_terminal_is_disabled")}
         subTitle="This is a true unrestricted root shell and is off by default. Enable it in Server Settings → root_terminal_enabled. Every session is fully recorded."
       />
     );
@@ -165,7 +167,7 @@ export function AdminTerminal() {
         type="error"
         showIcon
         banner
-        message="ROOT SHELL — every keystroke and all output is recorded to /var/log/jabali/terminal and an alert is sent on open."
+        message={t("adminterminal.root_shell_every_keystroke_and_all_output_is")}
       />
       {status === "error" && (
         <Alert type="error" showIcon style={{ margin: 12 }} message={errMsg} />

--- a/panel-ui/src/shells/admin/updates/DomainRepairCard.tsx
+++ b/panel-ui/src/shells/admin/updates/DomainRepairCard.tsx
@@ -3,6 +3,7 @@
 // group/setgid retrofit) and `jabali domain prune-orphans` (list orphan nginx
 // sites; delete is guarded + dry-run-first). Both proxy the CLI via the agent
 // (POST /admin/updates/repair/domain/*); nothing is re-implemented client-side.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -40,6 +41,7 @@ interface OrphansResult {
 }
 
 export function DomainRepairCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const [username, setUsername] = useState<string | undefined>();
   const [fixResult, setFixResult] = useState<FixPermsResult | null>(null);
@@ -130,7 +132,7 @@ export function DomainRepairCard() {
           <Space style={{ marginTop: 8 }} wrap>
             <Select
               style={{ minWidth: 220 }}
-              placeholder="Select a user"
+              placeholder={t("domainrepaircard.select_a_user")}
               loading={users.isLoading}
               showSearch
               optionFilterProp="label"
@@ -186,11 +188,11 @@ export function DomainRepairCard() {
               Scan for orphans
             </Button>
             <Popconfirm
-              title="Delete all orphan sites?"
-              description="This is irreversible — it tears down each site's nginx vhost, DKIM keys, and Stalwart mail domain row. Scan first and review the list."
-              okText="Delete permanently"
+              title={t("domainrepaircard.delete_all_orphan_sites")}
+              description={t("domainrepaircard.this_is_irreversible_it_tears_down_each_site")}
+              okText={t("domainrepaircard.delete_permanently")}
               okButtonProps={{ danger: true }}
-              cancelText="Cancel"
+              cancelText={t("domainrepaircard.cancel")}
               onConfirm={() => prune.mutate()}
               disabled={orphanList.length === 0}
             >
@@ -206,7 +208,7 @@ export function DomainRepairCard() {
               style={{ marginTop: 8 }}
               type="success"
               showIcon
-              message="No orphan sites found."
+              message={t("domainrepaircard.no_orphan_sites_found")}
             />
           )}
           {orphanList.length > 0 && (

--- a/panel-ui/src/shells/admin/updates/RepairCard.tsx
+++ b/panel-ui/src/shells/admin/updates/RepairCard.tsx
@@ -3,6 +3,7 @@
 // broken; "Auto-Repair safe issues" fires `jabali repair --auto` as a
 // transient unit and tails its output until done. Destructive fixes are
 // intentionally NOT exposed here — they stay on the CLI (`--all --yes`).
+import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
@@ -59,6 +60,7 @@ function parseDiagnose(text: string): RepairItem[] {
 }
 
 export function RepairCard() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const screens = Grid.useBreakpoint();
   const diagnose = useRepairDiagnose();
@@ -103,10 +105,10 @@ export function RepairCard() {
         Run Diagnostics
       </Button>
       <Popconfirm
-        title="Auto-repair safe issues?"
-        description="Applies non-destructive fixes only (jabali repair --auto). The panel may briefly restart."
-        okText="Run"
-        cancelText="Cancel"
+        title={t("repaircard.auto_repair_safe_issues")}
+        description={t("repaircard.applies_non_destructive_fixes_only_jabali_re")}
+        okText={t("repaircard.run")}
+        cancelText={t("repaircard.cancel")}
         onConfirm={onAutoRepair}
         disabled={running}
       >
@@ -146,7 +148,7 @@ export function RepairCard() {
           <Alert
             type="info"
             showIcon
-            message="Run diagnostics to see what's broken."
+            message={t("repaircard.run_diagnostics_to_see_what_s_broken")}
           />
         )}
 
@@ -154,7 +156,7 @@ export function RepairCard() {
           <Alert
             type="error"
             showIcon
-            message="Diagnostics failed"
+            message={t("repaircard.diagnostics_failed")}
             description={
               diagnose.error instanceof Error ? diagnose.error.message : "Unknown error"
             }
@@ -164,13 +166,13 @@ export function RepairCard() {
         {parsedOk && (
           <>
             {brokenCount === 0 ? (
-              <Alert type="success" showIcon message="No issues detected — all healthy." />
+              <Alert type="success" showIcon message={t("repaircard.no_issues_detected_all_healthy")} />
             ) : (
               <Alert
                 type="warning"
                 showIcon
                 message={`${brokenCount} issue${brokenCount === 1 ? "" : "s"} detected`}
-                description="Click Auto-Repair to fix the non-destructive ones."
+                description={t("repaircard.click_auto_repair_to_fix_the_non_destructive")}
               />
             )}
             <List

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -4,6 +4,7 @@
 // of Jabali Panel + System Packages, then Automatic Updates + Recent History,
 // then the Changelog. Data auto-loads on mount (jabali + apt checks fire once)
 // so the page shows real numbers immediately instead of empty placeholders.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState, type CSSProperties } from "react";
 import {
   Alert,
@@ -47,6 +48,7 @@ import { apiClient } from "../../../apiClient";
 // tracks the latest main commit. Persisted in server_settings; the updater +
 // behind-count honor it.
 const ReleaseChannelCard = () => {
+  const { t } = useTranslation();
   const [channel, setChannel] = useState<string>("stable");
   const [saving, setSaving] = useState(false);
   useEffect(() => {
@@ -94,15 +96,15 @@ const ReleaseChannelCard = () => {
           type="warning"
           showIcon
           style={{ marginTop: 12 }}
-          message="Development channel: less-reviewed builds"
-          description="Development follows the latest main commit and may include unreviewed changes. Use it only on test hosts; switch back to Stable for production."
+          message={t("systemupdatespage.development_channel_less_reviewed_builds")}
+          description={t("systemupdatespage.development_follows_the_latest_main_commit_a")}
         />
       )}
       <Alert
         type="info"
         showIcon
         style={{ marginTop: 12 }}
-        message="Promoting a build to Stable is an operator/CI task"
+        message={t("systemupdatespage.promoting_a_build_to_stable_is_an_operator_c")}
         description={
           <span>
             This switch only chooses which tag this host tracks. Moving the{" "}
@@ -644,13 +646,14 @@ function SystemPackagesError({
 // commands behind a "Show recovery steps" toggle (collapsed by default each
 // load, so the page stays compact). No safety content is removed.
 export function UpdateWarningAlert() {
+  const { t } = useTranslation();
   const [showRecovery, setShowRecovery] = useState(false);
   return (
     <Alert
       type="warning"
       showIcon
       style={{ marginBottom: 16 }}
-      message="Update carefully — especially system packages"
+      message={t("systemupdatespage.update_carefully_especially_system_packages")}
       description={
         <div>
           <ul style={{ margin: "4px 0 8px", paddingLeft: 18 }}>
@@ -858,6 +861,7 @@ function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }
 // --- Automatic Updates -----------------------------------------------------
 
 function AutomaticUpdatesCard() {
+  const { t } = useTranslation();
   const { data, isLoading } = useAutoupdateConfig();
   const save = useUpdateAutoupdate();
   const [draft, setDraft] = useState<AutoupdateConfig | null>(null);
@@ -921,7 +925,7 @@ function AutomaticUpdatesCard() {
             <Col flex="auto">
               <Text strong>
                 Jabali panel self-update{" "}
-                <Tooltip title="A bad self-update can take the panel offline. Leave off unless you want hands-off panel upgrades.">
+                <Tooltip title={t("systemupdatespage.a_bad_self_update_can_take_the_panel_offline")}>
                   <Tag color="orange">advanced</Tag>
                 </Tooltip>
               </Text>
@@ -964,6 +968,7 @@ const historyStatusTag = (status: string) => {
 };
 
 function RecentHistoryCard() {
+  const { t } = useTranslation();
   const { data, isLoading } = useUpdateHistory(8);
   const rows = data?.items ?? [];
   return (
@@ -979,7 +984,7 @@ function RecentHistoryCard() {
       {isLoading ? (
         <div style={{ textAlign: "center", padding: 24 }}><Spin /></div>
       ) : rows.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No update runs yet" />
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("systemupdatespage.no_update_runs_yet")} />
       ) : (
         <Timeline
           items={rows.map((r: UpdateHistoryRow) => ({

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -11,6 +11,7 @@
 //      the card starts impersonation (#545) and opens the matching
 //      /jabali-panel/... page AS that user (same flow as the Users-table
 //      "Log in as user" action, ADR-0128).
+import { useTranslation } from "react-i18next";
 import {
   ApiOutlined,
   AppstoreOutlined,
@@ -98,6 +99,7 @@ const USER_PANEL_CARDS: { key: string; label: string; icon: React.ReactNode; pat
 ];
 
 export function AdminUserOverview() {
+  const { t } = useTranslation();
   const { id = "" } = useParams();
   const [impersonating, setImpersonating] = useState(false);
 
@@ -141,7 +143,7 @@ export function AdminUserOverview() {
     return <Skeleton active paragraph={{ rows: 4 }} />;
   }
   if (userQ.isError || !userQ.data) {
-    return <Alert type="error" showIcon message="User not found" />;
+    return <Alert type="error" showIcon message={t("adminuseroverview.user_not_found")} />;
   }
 
   const user = userQ.data;

--- a/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
@@ -5,6 +5,7 @@
 // from /profile. The parent (UserList RowActions) drives `open` via
 // its dropdown menu so the modal lives alongside the row's other
 // action modals and the dropdown items can use stock AntD styling.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { Modal, message } from "antd";
 
@@ -23,6 +24,7 @@ export const UserReset2FAAction = ({
   open,
   onClose,
 }: UserReset2FAActionProps) => {
+  const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleReset = async () => {
@@ -42,12 +44,12 @@ export const UserReset2FAAction = ({
 
   return (
     <Modal
-      title="Reset two-factor authentication?"
+      title={t("userreset2faaction.reset_two_factor_authentication")}
       open={open}
       onCancel={onClose}
       onOk={handleReset}
       confirmLoading={isLoading}
-      okText="Reset"
+      okText={t("userreset2faaction.reset")}
       okButtonProps={{ danger: true }}
     >
       <p>

--- a/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
@@ -3,6 +3,7 @@
 // so Kratos has no self-service recovery; this admin-set flow is the only
 // password reset. Mirrors UserReset2FAAction's controlled-modal shape; the
 // parent (UserList RowActions) drives `open`.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { Modal, Typography, message } from "antd";
 
@@ -16,6 +17,7 @@ interface Props {
 }
 
 export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Props) => {
+  const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [tempPassword, setTempPassword] = useState<string | null>(null);
 
@@ -42,12 +44,12 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
   if (tempPassword !== null) {
     return (
       <Modal
-        title="New password — shown once"
+        title={t("userresetpasswordaction.new_password_shown_once")}
         open={open}
         onCancel={close}
         onOk={close}
         cancelButtonProps={{ style: { display: "none" } }}
-        okText="Done"
+        okText={t("userresetpasswordaction.done")}
       >
         <p>
           Hand this temporary password to <strong>{userEmail}</strong>. It is shown
@@ -62,12 +64,12 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
 
   return (
     <Modal
-      title="Reset password?"
+      title={t("userresetpasswordaction.reset_password")}
       open={open}
       onCancel={close}
       onOk={handleReset}
       confirmLoading={isLoading}
-      okText="Reset"
+      okText={t("userresetpasswordaction.reset")}
       okButtonProps={{ danger: true }}
     >
       <p>

--- a/panel-ui/src/test/setup.ts
+++ b/panel-ui/src/test/setup.ts
@@ -4,7 +4,13 @@
 //   - jest-dom matchers (toBeInTheDocument, etc.)
 //   - window.matchMedia polyfill (AntD uses it for responsive bits;
 //     happy-dom doesn't ship it)
+//   - i18n, so components render English text rather than raw catalog keys
 import "@testing-library/jest-dom/vitest";
+// Components call useTranslation(); without an initialised instance i18next
+// echoes the key back, so queries like getByLabelText(/^Domain$/) miss. main.tsx
+// does this for the app — the same import keeps tests on the real i18n path
+// instead of a mock that could drift from it.
+import "../i18n";
 
 if (typeof window !== "undefined" && !window.matchMedia) {
   Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION

Sweeps 102 admin files and moves 824 visible attribute strings into the
catalog: card and modal titles, form labels, placeholders, alert headings,
confirm button text and table empty states. English source only, so every
other language comes from Weblate and translators own it from the start.

Done as a codemod rather than by hand, with two constraints that matter for
correctness. It only rewrites strings that sit inside a component body, since
the replacement calls a hook and a module-level constant has none in scope.
And it adds the useTranslation import before the first import rather than
after the last line beginning with "import", because the latter lands inside
multi-line import blocks and corrupted eleven files on the first attempt.

Keys are namespaced per source file, so two pages using the same English word
keep separate entries. That costs some duplication in the catalog and buys
translators the freedom to render the same word differently depending on where
it appears, which several of these languages need.

Long multi-line prose is untouched. Those blocks carry embedded markup and
need splitting by hand so a translator receives whole sentences; they continue
to render in English through the existing fallback.

Verified: `npx tsc -b --force` clean (0 errors), `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)