### PR TITLE
feat(i18n): extract attribute strings across the user shell

### DIFF
--- a/panel-ui/src/components/DomainCacheSection.tsx
+++ b/panel-ui/src/components/DomainCacheSection.tsx
@@ -2,6 +2,7 @@
 // (ADR-0108, Gitea #596). Self-contained like DomainEmailSection: loads its own
 // state, flips the switch, edits the cache TTL (DB-as-truth → reconciler
 // re-renders the vhost), and exposes a manual purge button.
+import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
 import {
   Alert,
@@ -39,6 +40,7 @@ const sameSet = (a: string[], b: string[]) =>
   a.length === b.length && [...a].sort().join(",") === [...b].sort().join(",");
 
 export const DomainCacheSection = ({ domainId }: Props) => {
+  const { t } = useTranslation();
   const [state, setState] = useState<CacheState | null>(null);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
@@ -169,8 +171,8 @@ export const DomainCacheSection = ({ domainId }: Props) => {
         />
         <span>nginx page cache</span>
         <Popconfirm
-          title="Purge cached pages for this domain?"
-          okText="Purge"
+          title={t("domaincachesection.purge_cached_pages_for_this_domain")}
+          okText={t("domaincachesection.purge")}
           onConfirm={onPurge}
           disabled={!enabled}
         >
@@ -234,15 +236,15 @@ export const DomainCacheSection = ({ domainId }: Props) => {
       <Alert
         type="info"
         showIcon
-        title="Cacheable query parameters"
-        description="Query-string params that get their own cache entry (e.g. paged for pagination). Everything else with a query string still bypasses. This does NOT cache JetEngine AJAX filters — those are admin-ajax POST requests and always bypass. Keep the list tight: faceted params multiply cache entries. Names are lower-case letters, digits, and underscores."
+        title={t("domaincachesection.cacheable_query_parameters")}
+        description={t("domaincachesection.query_string_params_that_get_their_own_cache")}
       />
 
       <Alert
         type="info"
         showIcon
-        title="Page cache with background refresh"
-        description="Caches PHP/HTML responses for the TTL above (default 600s). On expiry the stale page is served instantly while nginx refreshes it in the background — no visitor waits for the rebuild. Automatically bypassed for POST requests, logged-in WordPress users, carts/checkout, wp-admin and session cookies, so dynamic and authenticated pages stay correct."
+        title={t("domaincachesection.page_cache_with_background_refresh")}
+        description={t("domaincachesection.caches_php_html_responses_for_the_ttl_above")}
       />
     </Space>
   );

--- a/panel-ui/src/components/DomainNginxOptionsModal.tsx
+++ b/panel-ui/src/components/DomainNginxOptionsModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Checkbox, Form, InputNumber, Modal, Typography, message } from "antd";
 
@@ -19,6 +20,7 @@ export interface DomainNginxOptionsModalProps {
 // Only mounted when the admin has enabled tenant_domain_options_enabled. The
 // panel renders these to fixed, vetted directives; no raw config.
 export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOptionsModalProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<SafeOptions>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -62,7 +64,7 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
   };
 
   return (
-    <Modal open title="Domain options" onCancel={onClose} onOk={onOk} confirmLoading={saving} okText="Save">
+    <Modal open title={t("domainnginxoptionsmodal.domain_options")} onCancel={onClose} onOk={onOk} confirmLoading={saving} okText={t("domainnginxoptionsmodal.save")}>
       <Typography.Paragraph type="secondary">
         Safe nginx options for this domain. The panel renders fixed directives —
         no raw config.
@@ -70,7 +72,7 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
       <Form<SafeOptions> form={form} layout="vertical" disabled={loading}>
         <Form.Item
           name="max_body_mb"
-          label="Max upload size (MB)"
+          label={t("domainnginxoptionsmodal.max_upload_size_mb")}
           tooltip="client_max_body_size. 0 = use the default."
         >
           <InputNumber min={0} max={10240} style={{ width: "100%" }} placeholder="0" />

--- a/panel-ui/src/components/InstallAppButton.tsx
+++ b/panel-ui/src/components/InstallAppButton.tsx
@@ -2,6 +2,7 @@
 // only after the browser fires `beforeinstallprompt` (i.e. the manifest + SW
 // install criteria are met and the app isn't already installed); hidden
 // otherwise, so it's a no-op on unsupported browsers / installed instances.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
 import { Button, Tooltip } from "antd";
@@ -15,6 +16,7 @@ type BeforeInstallPromptEvent = Event & {
 };
 
 export function InstallAppButton() {
+  const { t } = useTranslation();
   const [promptEvent, setPromptEvent] =
     useState<BeforeInstallPromptEvent | null>(null);
 
@@ -35,10 +37,10 @@ export function InstallAppButton() {
   if (!promptEvent) return null;
 
   return (
-    <Tooltip title="Install Jabali as an app">
+    <Tooltip title={t("installappbutton.install_jabali_as_an_app")}>
       <Button
         type="text"
-        aria-label="Install app"
+        aria-label={t("installappbutton.install_app")}
         icon={<DownloadOutlined />}
         onClick={async () => {
           try {

--- a/panel-ui/src/components/JabaliFooter.tsx
+++ b/panel-ui/src/components/JabaliFooter.tsx
@@ -5,6 +5,7 @@
 //
 // The version string is imported from panel-ui/package.json at build
 // time so bumping the SPA version there propagates automatically.
+import { useTranslation } from "react-i18next";
 import { GithubOutlined } from "@icons";
 import { Grid, Layout, Space, theme, Typography } from "antd";
 
@@ -17,6 +18,7 @@ const SOURCE_URL = "https://github.com/shukiv/jabali-panel";
 const WEBSITE_URL = "https://jabali-panel.com/";
 
 export function JabaliFooter() {
+  const { t } = useTranslation();
   const { mode } = useThemeMode();
   const { token } = theme.useToken();
   const screens = Grid.useBreakpoint();
@@ -82,7 +84,7 @@ export function JabaliFooter() {
           href={SOURCE_URL}
           target="_blank"
           rel="noreferrer"
-          aria-label="Source code"
+          aria-label={t("jabalifooter.source_code")}
           style={{ color: "inherit", display: "inline-flex", alignItems: "center" }}
         >
           <GithubOutlined style={{ fontSize: 18 }} />

--- a/panel-ui/src/components/NotificationBell.tsx
+++ b/panel-ui/src/components/NotificationBell.tsx
@@ -9,6 +9,7 @@
 // a footer Space for the push toggle. Container uses theme tokens
 // (colorBgElevated / borderRadiusLG / boxShadowSecondary) so the
 // popup is visually identical to every other AntD dropdown.
+import { useTranslation } from "react-i18next";
 import { Badge, Button, Divider, Dropdown, Empty, Grid, Popconfirm, Space, Tag, Tooltip, Typography, message, theme } from "antd";
 import type { MenuProps } from "antd";
 import type { CSSProperties, ReactElement } from "react";
@@ -70,6 +71,7 @@ function relativeTime(iso: string): string {
 }
 
 export function NotificationBell() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { user } = useAuth();
   const [open, setOpen] = useState(false);
@@ -286,7 +288,7 @@ export function NotificationBell() {
             </Space>
             <Space size={token.marginXS}>
               {isNarrow ? (
-                <Tooltip title="Mark all read">
+                <Tooltip title={t("notificationbell.mark_all_read")}>
                   <Button
                     type="text"
                     size="small"
@@ -306,10 +308,10 @@ export function NotificationBell() {
                 </Button>
               )}
               <Popconfirm
-                title="Clear all notifications?"
-                description="This deletes every notification in your inbox."
+                title={t("notificationbell.clear_all_notifications")}
+                description={t("notificationbell.this_deletes_every_notification_in_your_inbo")}
                 onConfirm={clearAll}
-                okText="Clear"
+                okText={t("notificationbell.clear")}
                 okButtonProps={{ danger: true }}
               >
                 <Button
@@ -353,7 +355,7 @@ export function NotificationBell() {
         </div>
       )}
     >
-      <Button type="text" aria-label="Notifications" style={{ width: 40, height: 40, padding: 0, display: "inline-flex", alignItems: "center", justifyContent: "center" }}>
+      <Button type="text" aria-label={t("notificationbell.notifications")} style={{ width: 40, height: 40, padding: 0, display: "inline-flex", alignItems: "center", justifyContent: "center" }}>
         <Badge count={unread} size="small" overflowCount={99}>
           <BellOutlined />
         </Badge>

--- a/panel-ui/src/components/ServerHealthIndicator.tsx
+++ b/panel-ui/src/components/ServerHealthIndicator.tsx
@@ -7,6 +7,7 @@
 // Endpoint is admin-gated; on the user shell this component MUST NOT
 // mount (caller in JabaliHeader checks isAdminShell).
 
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { Badge, Button, Tooltip } from "antd";
 import { ExclamationCircleOutlined, WarningOutlined } from "@icons";
@@ -28,6 +29,7 @@ interface ServerStatusPayload {
 const POLL_MS = 30_000;
 
 export function ServerHealthIndicator(): JSX.Element | null {
+  const { t } = useTranslation();
   const [worst, setWorst] = useState<"ok" | "warning" | "critical">("ok");
   const [count, setCount] = useState(0);
   const [tooltip, setTooltip] = useState("");
@@ -70,7 +72,7 @@ export function ServerHealthIndicator(): JSX.Element | null {
     <Tooltip title={tooltip} placement="bottomRight">
       <Button
         type="text"
-        aria-label="Server health alerts"
+        aria-label={t("serverhealthindicator.server_health_alerts")}
         onClick={() => navigate("/jabali-admin/server-status")}
         style={{ width: 40, height: 40, padding: 0, display: "inline-flex", alignItems: "center", justifyContent: "center" }}
       >

--- a/panel-ui/src/components/TasksIndicator.tsx
+++ b/panel-ui/src/components/TasksIndicator.tsx
@@ -2,6 +2,7 @@
 // (panel/system-package updates, backups, malware scans). Polls
 // /admin/active-tasks every 8s; spins + badges the count when tasks are
 // active, and lists them in a dropdown. Admin shell only.
+import { useTranslation } from "react-i18next";
 import { Badge, Button, Dropdown, Empty, Space, Tag, Tooltip, Typography } from "antd";
 import type { MenuProps } from "antd";
 import { useNavigate } from "react-router";
@@ -31,6 +32,7 @@ const deeplinkFor = (kind: ActiveTask["kind"]) =>
       : "/jabali-admin/security";
 
 export function TasksIndicator() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const q = useQuery({
     queryKey: ["admin-active-tasks"],
@@ -61,7 +63,7 @@ export function TasksIndicator() {
             label: (
               <Empty
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description="No tasks running"
+                description={t("tasksindicator.no_tasks_running")}
                 style={{ padding: 8, margin: 0 }}
               />
             ),
@@ -82,7 +84,7 @@ export function TasksIndicator() {
     <Dropdown menu={{ items }} placement="bottomRight" trigger={["click"]}>
       <Tooltip title={count > 0 ? `${count} task${count > 1 ? "s" : ""} running` : "Background tasks"}>
         <Badge count={count} size="small" offset={[-2, 4]}>
-          <Button type="text" icon={<SyncOutlined spin={count > 0} />} aria-label="Background tasks" />
+          <Button type="text" icon={<SyncOutlined spin={count > 0} />} aria-label={t("tasksindicator.background_tasks")} />
         </Badge>
       </Tooltip>
     </Dropdown>

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -126,6 +127,7 @@ export const SSLManagerTable = ({
   endpoint,
   showOwner,
 }: SSLManagerTableProps) => {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   // Client-side search over the fetched rows — SSL list is small
@@ -224,7 +226,7 @@ export const SSLManagerTable = ({
     return (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="Failed to load SSL certificates"
+        description={t("sslmanagertable.failed_to_load_ssl_certificates")}
       />
     );
   }
@@ -251,7 +253,7 @@ export const SSLManagerTable = ({
             <Space size={4}>
               <span style={{ fontFamily: "monospace" }}>{text}</span>
               {isPanelCert && (
-                <Tooltip title="Panel cert — managed via Server Settings → Panel SSL">
+                <Tooltip title={t("sslmanagertable.panel_cert_managed_via_server_settings_panel")}>
                   <Tag color="purple">panel</Tag>
                 </Tooltip>
               )}
@@ -326,7 +328,7 @@ export const SSLManagerTable = ({
               </Tag>
             </Tooltip>
             {hasError && (
-              <Tooltip title="Show last error">
+              <Tooltip title={t("sslmanagertable.show_last_error")}>
                 <Button
                   size="small"
                   type="text"
@@ -407,7 +409,7 @@ export const SSLManagerTable = ({
         // exist for it). GH#132.
         if (record.id.startsWith("mail-cert:")) {
           return (
-            <Tooltip title="Clears backoff and reissues the Let's Encrypt mail certificate">
+            <Tooltip title={t("sslmanagertable.clears_backoff_and_reissues_the_let_s_encryp")}>
               <Button
                 icon={<RedoOutlined />}
                 loading={reissueMailMutation.isPending}
@@ -423,7 +425,7 @@ export const SSLManagerTable = ({
         return (
           <Space>
             {isRetryable && (
-              <Tooltip title="Force ACME retry now">
+              <Tooltip title={t("sslmanagertable.force_acme_retry_now")}>
                 <Button
                   icon={<RedoOutlined />}
                   loading={retryMutation.isPending}
@@ -432,7 +434,7 @@ export const SSLManagerTable = ({
               </Tooltip>
             )}
             {record.status === "issued" && (
-              <Tooltip title="Renew certificate">
+              <Tooltip title={t("sslmanagertable.renew_certificate")}>
                 <Button
                   type="primary"
                   icon={<ReloadOutlined />}
@@ -443,10 +445,10 @@ export const SSLManagerTable = ({
             )}
             {record.status === "issued" && (
               <Popconfirm
-                title="Revoke Certificate"
-                description="Are you sure you want to revoke this certificate?"
+                title={t("sslmanagertable.revoke_certificate")}
+                description={t("sslmanagertable.are_you_sure_you_want_to_revoke_this_certifi")}
                 onConfirm={() => revokeMutation.mutate(record.domain_id)}
-                okText="Yes"
+                okText={t("sslmanagertable.yes")}
                 cancelText="No"
               >
                 <Button
@@ -467,7 +469,7 @@ export const SSLManagerTable = ({
       {!data || data.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No SSL certificates yet"
+          description={t("sslmanagertable.no_ssl_certificates_yet")}
         />
       ) : (
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
@@ -503,19 +505,19 @@ export const SSLManagerTable = ({
         {errorRow && (
           <Space direction="vertical" size="middle" style={{ width: "100%" }}>
             <Descriptions column={1} size="small" bordered>
-              <Descriptions.Item label="Status">
+              <Descriptions.Item label={t("sslmanagertable.status")}>
                 {errorRow.status.charAt(0).toUpperCase() +
                   errorRow.status.slice(1).replace(/_/g, " ")}
               </Descriptions.Item>
-              <Descriptions.Item label="Last attempt">
+              <Descriptions.Item label={t("sslmanagertable.last_attempt")}>
                 {errorRow.last_attempt_at
                   ? new Date(errorRow.last_attempt_at).toLocaleString()
                   : "—"}
               </Descriptions.Item>
-              <Descriptions.Item label="Retry count">
+              <Descriptions.Item label={t("sslmanagertable.retry_count")}>
                 {errorRow.retry_count}
               </Descriptions.Item>
-              <Descriptions.Item label="Next retry">
+              <Descriptions.Item label={t("sslmanagertable.next_retry")}>
                 {errorRow.next_retry_at
                   ? new Date(errorRow.next_retry_at).toLocaleString()
                   : "—"}

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1212,5 +1212,420 @@
     "new_password_shown_once": "New password — shown once",
     "reset": "Reset",
     "reset_password": "Reset password?"
+  },
+  "myprofile": {
+    "account": "Account",
+    "email": "Email",
+    "full_name": "Full name",
+    "hosting_package": "Hosting package",
+    "member_since": "Member since",
+    "password_and_two_factor_2fa_totp_settings_al": "Password and two-factor (2FA/TOTP) settings always apply to your own admin account — there is no separate login session for the user you are acting as, so changing them here would change YOUR credentials, not theirs. Exit impersonation to manage your own security. To reset a user's 2FA, go to Users → the user → Reset 2FA.",
+    "role": "Role",
+    "security": "Security",
+    "security_settings_unavailable_while_acting_a": "Security settings unavailable while acting as another user",
+    "user_id": "User ID",
+    "username": "Username"
+  },
+  "myprofilebackupcard": {
+    "destination": "Destination"
+  },
+  "myprofileschedulecard": {
+    "destination": "Destination",
+    "scheduled_backups_are_not_included_in_your_h": "Scheduled backups are not included in your hosting plan."
+  },
+  "restoredrawer": {
+    "restore_from_backup": "Restore from backup",
+    "restore_result": "Restore result",
+    "the_selected_items_will_be_overwritten_with": "The selected items will be overwritten with the backed-up copy.",
+    "this_is_destructive": "This is destructive"
+  },
+  "userdashboard": {
+    "applications": "Applications",
+    "databases": "Databases",
+    "domains": "Domains",
+    "mailboxes": "Mailboxes",
+    "recent_applications": "Recent Applications",
+    "recent_databases": "Recent Databases",
+    "recent_domains": "Recent Domains",
+    "recent_mailboxes": "Recent Mailboxes"
+  },
+  "accountactivity": {
+    "result": "Result",
+    "target": "Target",
+    "what": "What"
+  },
+  "ddnssetupguide": {
+    "dynamic_dns_ddns_setup": "Dynamic DNS (DDNS) setup",
+    "point_your_router_or_ddclient_at_the_update": "Point your router or ddclient at the update URL below and use a ddns-scoped API token (mint one above) as the Basic-auth PASSWORD. The username is ignored — put anything. Scope the token to a single record for least privilege.",
+    "your_api_token_is_the_ddns_password": "Your API token is the DDNS password"
+  },
+  "userapitokenspage": {
+    "any_script_using_it_will_start_getting_401": "Any script using it will start getting 401.",
+    "copy_this_secret_now": "Copy this secret now.",
+    "create": "Create",
+    "create_api_token": "Create API token",
+    "expires_in_seconds_optional": "Expires in (seconds, optional)",
+    "full_access_can_do_anything_you_can_a_custom": "Full access can do anything you can. A custom token is restricted to exactly the areas you tick and is rejected everywhere else.",
+    "i_ve_copied_it": "I've copied it",
+    "limit_to_one_dns_record_id_optional": "Limit to one DNS record ID (optional)",
+    "my_token": "My token",
+    "name": "Name",
+    "permissions": "Permissions",
+    "personal_api_tokens": "Personal API Tokens",
+    "revoke": "Revoke",
+    "revoke_this_token": "Revoke this token?",
+    "the_plaintext_token_is_shown_only_once_after": "The plaintext token is shown only once. After you close this dialog the panel only stores its hash — there's no way to retrieve it again. Lost? Revoke + create a new one."
+  },
+  "catalogtab": {
+    "failed_to_load_the_application_catalog": "Failed to load the application catalog",
+    "no_applications_available": "No applications available",
+    "no_applications_match_the_selected_tags": "No applications match the selected tags",
+    "try_reloading_the_page": "Try reloading the page."
+  },
+  "cloneapplicationmodal": {
+    "clone_application": "Clone application",
+    "destination_domain": "Destination domain",
+    "select_a_domain": "Select a domain"
+  },
+  "installapplicationmodal": {
+    "application": "Application",
+    "copy": "Copy",
+    "directory_optional": "Directory (optional)",
+    "domain": "Domain",
+    "install_application": "Install application",
+    "install_queued": "Install queued",
+    "no_domains_yet": "No domains yet",
+    "select_a_domain": "Select a domain",
+    "select_an_application": "Select an application",
+    "the_install_runs_in_the_background_copy_the": "The install runs in the background. Copy the password now — it is shown only once. We store only a bcrypt hash.",
+    "what_happens_next": "What happens next",
+    "you_have_no_domains_create_one_first": "You have no domains. Create one first."
+  },
+  "userapplicationlist": {
+    "actions": "Actions",
+    "admin_email": "Admin email",
+    "app_version": "App / Version",
+    "cache": "Cache",
+    "cache_settings": "Cache settings",
+    "created": "Created",
+    "detect_wordpress_joomla_drupal_and_magento_i": "Detect WordPress, Joomla, Drupal, and Magento installs on disk that aren't yet tracked by the panel.",
+    "domain": "Domain",
+    "failed": "Failed",
+    "in_progress": "In Progress",
+    "installed_apps": "Installed Apps",
+    "no_installed_apps_yet": "No installed apps yet",
+    "ready": "Ready",
+    "redis_object_cache_nginx_page_cache": "Redis object cache + nginx page cache"
+  },
+  "createcronmodal": {
+    "command": "Command",
+    "cron_expression": "Cron Expression",
+    "name": "Name",
+    "schedule": "Schedule"
+  },
+  "cronlogdrawer": {
+    "cron_job_log": "Cron Job Log"
+  },
+  "runnowresultmodal": {
+    "cron_job_execution_result": "Cron Job Execution Result",
+    "standard_error": "Standard Error",
+    "standard_output": "Standard Output"
+  },
+  "usercronlist": {
+    "search_by_name_command_or_schedule": "Search by name, command, or schedule"
+  },
+  "quicksetupmodal": {
+    "copy": "Copy",
+    "copy_the_password_now_it_is_shown_only_once": "Copy the password now — it is shown only once. We store only a bcrypt hash.",
+    "database_and_user_created": "Database and user created",
+    "database_user_name": "Database & User Name",
+    "engine": "Engine",
+    "mariadb_is_the_default_postgresql_must_be_en": "MariaDB is the default. PostgreSQL must be enabled in Server Settings.",
+    "quick_database_setup": "Quick Database Setup"
+  },
+  "userdatabasedrawer": {
+    "create_database": "Create database",
+    "engine": "Engine",
+    "mariadb_is_the_default_postgresql_must_be_en": "MariaDB is the default. PostgreSQL must be enabled by an admin in Server Settings.",
+    "name": "Name",
+    "the_final_database_name_is_your_username_plu": "The final database name is your username plus an underscore plus this suffix (e.g. `alice_wp`)."
+  },
+  "userdatabaselist": {
+    "actions": "Actions",
+    "charset": "Charset",
+    "created": "Created",
+    "database": "Database",
+    "engine": "Engine",
+    "size": "Size"
+  },
+  "diskusagepage": {
+    "could_not_load_disk_usage": "Could not load disk usage",
+    "home_directory_is_empty": "Home directory is empty",
+    "no_disk_usage_snapshot_yet_click_refresh_to": "No disk-usage snapshot yet — click Refresh to calculate."
+  },
+  "userdnszonesoverviewpage": {
+    "actions": "Actions",
+    "dns_zones_are_provisioned_automatically_when": "DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings.",
+    "dnssec": "DNSSEC",
+    "domain_name": "Domain Name",
+    "domain_registration_expiry_from_whois": "Domain registration expiry (from WHOIS)",
+    "expiration": "Expiration",
+    "no_domains_found": "No domains found",
+    "records": "Records",
+    "ttl": "TTL",
+    "zone_status": "Zone Status"
+  },
+  "userdockerappspage": {
+    "ask_your_administrator_to_enable_tenant_dock": "Ask your administrator to enable tenant Docker apps for your hosting package.",
+    "docker_apps_are_not_enabled_on_this_server": "Docker apps are not enabled on this server",
+    "docker_apps_are_over_your_disk_quota": "Docker apps are over your disk quota",
+    "installed_apps": "Installed Apps",
+    "no_installed_apps_yet": "No installed apps yet",
+    "running": "Running",
+    "search_by_name": "Search by name",
+    "stopped": "Stopped",
+    "updates_available": "Updates Available",
+    "your_installed_apps_exceed_your_package_disk": "Your installed apps exceed your package disk allowance. Delete an app or ask your administrator to raise the quota."
+  },
+  "userdomaindrawer": {
+    "add_domain": "Add domain",
+    "adds_a_www_cname_pointing_at_the_domain_apex": "Adds a www CNAME pointing at the domain apex. Off by default — leave unchecked for subdomains or domains that don't serve a www host.",
+    "domain_name": "Domain Name",
+    "google_dkim_value": "Google DKIM value",
+    "let_s_encrypt_issues_a_free_trusted_certific": "Let's Encrypt issues a free trusted certificate automatically (recommended). Self-signed works without DNS/ACME but browsers warn. None serves over HTTP only.",
+    "mail": "Mail",
+    "microsoft_365_tenant": "Microsoft 365 tenant",
+    "optional_paste_the_google_domainkey_txt_valu": "Optional. Paste the google._domainkey TXT value from Google Admin. MX/SPF are added automatically.",
+    "optional_your_tenant_onmicrosoft_com_adds_th": "Optional. Your <tenant>.onmicrosoft.com — adds the selector1/2 DKIM CNAMEs. MX/SPF/autodiscover are added automatically.",
+    "tls_certificate": "TLS certificate",
+    "where_this_domain_s_email_is_hosted_none_and": "Where this domain's email is hosted. 'None' and the external providers skip Jabali's mail DNS records and mail certificate SANs."
+  },
+  "userdomainlist": {
+    "actions": "Actions",
+    "bw_30d": "BW (30d)",
+    "domain": "Domain",
+    "more_actions": "More actions",
+    "redirect": "Redirect",
+    "ssl": "SSL",
+    "status": "Status"
+  },
+  "filemanagerpage": {
+    "apply": "Apply",
+    "create": "Create",
+    "empty_directory": "Empty directory",
+    "folders": "Folders",
+    "move": "Move",
+    "new_file": "New File",
+    "new_folder": "New Folder",
+    "rename": "Rename",
+    "save": "Save"
+  },
+  "autoreplymodal": {
+    "active_dates_optional": "Active dates (optional)",
+    "html_body_optional": "HTML body (optional)",
+    "i_m_away_until": "I'm away until...",
+    "out_of_office": "Out of office",
+    "plain_text_body": "Plain text body",
+    "save": "Save",
+    "send_automatic_replies": "Send automatic replies",
+    "subject": "Subject",
+    "turn_off": "Turn off"
+  },
+  "createmailboxwizardmodal": {
+    "a_send_only_mailbox_can_authenticate_for_smt": "A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials, so each system has its own account to revoke or rotate.",
+    "add_to_groups": "Add to groups",
+    "aliases_optional": "Aliases (optional)",
+    "alice_smith": "Alice Smith",
+    "create_mailbox": "Create mailbox",
+    "display_name": "Display name",
+    "domain": "Domain",
+    "email_address": "Email address",
+    "enable_email_on_at_least_one_domain_before_c": "Enable email on at least one domain before creating a mailbox.",
+    "extra_addresses_that_deliver_to_this_mailbox": "Extra addresses that deliver to this mailbox. One local-part per line or comma-separated — e.g. sales, info.",
+    "forward_to_optional": "Forward to (optional)",
+    "leave_blank_to_auto_generate_generated_passw": "Leave blank to auto-generate. Generated passwords are shown exactly once.",
+    "no_email_enabled_domains": "No email-enabled domains",
+    "only_domains_with_email_enabled_appear_here": "Only domains with email enabled appear here.",
+    "password": "Password",
+    "quota_mib": "Quota (MiB)",
+    "redirect_a_copy_of_incoming_mail_to_an_exter": "Redirect a copy of incoming mail to an external address.",
+    "select_a_domain": "Select a domain",
+    "select_groups_optional": "Select groups (optional)",
+    "shown_as_the_sender_name_in_webmail_and_outg": "Shown as the sender name in webmail and outgoing mail (e.g. Alice Smith). Optional.",
+    "the_mailbox_joins_these_groups_and_gains_the": "The mailbox joins these groups and gains their shared mailbox, calendar, address book and files."
+  },
+  "catchalltab": {
+    "domain": "Domain",
+    "no_email_enabled_domains_yet": "No email-enabled domains yet",
+    "save": "Save",
+    "select_email_enabled_domain": "Select email-enabled domain",
+    "target_mailbox": "Target mailbox"
+  },
+  "disclaimertab": {
+    "disclaimer_text": "Disclaimer Text",
+    "edit": "Edit",
+    "enable_disclaimer": "Enable Disclaimer",
+    "if_you_received_this_email_by_mistake_please": "If you received this email by mistake, please notify the sender and delete it.",
+    "no_email_enabled_domains": "No email-enabled domains",
+    "save": "Save"
+  },
+  "forwarderstab": {
+    "add_forwarder": "Add forwarder",
+    "alias_local_part": "Alias local-part",
+    "create": "Create",
+    "create_mailboxes_first": "Create mailboxes first",
+    "external_target": "External target",
+    "remove": "Remove",
+    "remove_forwarder": "Remove forwarder?",
+    "select_mailbox": "Select mailbox",
+    "type": "Type"
+  },
+  "groupstab": {
+    "enable_email_on_a_domain_first_to_create_gro": "Enable email on a domain first to create groups",
+    "no_groups": "No groups"
+  },
+  "logstab": {
+    "from": "From",
+    "mail_logs_unavailable": "Mail logs unavailable",
+    "recipient_contains": "Recipient contains",
+    "sender_contains": "Sender contains",
+    "the_mail_server_s_trace_log_isn_t_responding": "The mail server's trace log isn't responding. Try again in a moment."
+  },
+  "maillogdetaildrawer": {
+    "delivery_trail": "Delivery trail",
+    "no_delivery_trail_found": "No delivery trail found"
+  },
+  "mailboxestab": {
+    "automatic_replies_active": "Automatic replies active",
+    "leave_blank_to_auto_generate_auto_generated": "Leave blank to auto-generate. Auto-generated passwords are shown exactly once.",
+    "new_password": "New password",
+    "no_mailboxes": "No mailboxes",
+    "no_mailboxes_yet": "No mailboxes yet",
+    "set_password": "Set password"
+  },
+  "sharedfolderstab": {
+    "create_mailboxes_first": "Create mailboxes first",
+    "remove": "Remove",
+    "remove_share": "Remove share?",
+    "rights": "Rights",
+    "select_owner_mailbox": "Select owner mailbox",
+    "select_target_mailbox": "Select target mailbox",
+    "share": "Share",
+    "share_folder": "Share folder",
+    "source_mailbox_owner": "Source mailbox (owner)",
+    "target_mailbox_grantee": "Target mailbox (grantee)"
+  },
+  "sharedresourcestab": {
+    "no_email_enabled_domains_yet": "No email-enabled domains yet"
+  },
+  "userphpperformancecard": {
+    "ask_your_provider_to_enable_it_on_your_hosti": "Ask your provider to enable it on your hosting package.",
+    "max_requests_per_worker_0_never": "Max requests per worker (0 = never)",
+    "max_spare_dynamic": "Max spare (dynamic)",
+    "min_spare_dynamic": "Min spare (dynamic)",
+    "php_performance": "PHP Performance",
+    "php_performance_tuning_isn_t_enabled_on_your": "PHP performance tuning isn't enabled on your plan.",
+    "process_manager": "Process manager",
+    "start_servers_dynamic": "Start servers (dynamic)"
+  },
+  "userphpsettingspage": {
+    "caution": "Caution",
+    "changing_php_settings_can_affect_your_websit": "Changing PHP settings can affect your website performance and functionality. Incorrect values may cause errors or prevent your site from functioning properly. Changes apply after the next request to PHP.",
+    "cli_terminal_default_php_version": "CLI / Terminal default PHP version",
+    "domain": "Domain",
+    "max_execution_time": "Max Execution Time",
+    "max_input_time": "Max Input Time",
+    "max_input_variables": "Max Input Variables",
+    "memory_limit": "Memory Limit",
+    "php_version": "PHP Version",
+    "post_max_size": "POST Max Size",
+    "select_a_domain": "Select a domain",
+    "upload_max_file_size": "Upload Max File Size",
+    "use_pool_default": "Use pool default"
+  },
+  "pythonappspage": {
+    "app_directory": "App directory",
+    "create": "Create",
+    "domain": "Domain",
+    "entrypoint": "Entrypoint",
+    "mount_path": "Mount path",
+    "my_api": "My API",
+    "name": "Name",
+    "path_under_your_home_e_g_domains_example_com": "Path under your home, e.g. domains/example.com/app",
+    "python": "Python",
+    "runtime": "Runtime",
+    "select_a_domain": "Select a domain",
+    "status": "Status",
+    "type": "Type"
+  },
+  "usersshkeyspage": {
+    "add_ssh_key": "Add SSH Key",
+    "are_you_sure_this_revokes_sftp_access": "Are you sure? This revokes SFTP access.",
+    "comment_optional": "Comment (optional)",
+    "connect_to_your_server_securely_using_ssh_fo": "Connect to your server securely using SSH for terminal access or SFTP for file transfers. Generate a new key pair or add your existing public SSH keys below.",
+    "copy_or_download_it_now_if_you_close_this_di": "Copy or download it now. If you close this dialog without saving, you'll need to generate a new key and delete this one.",
+    "delete_ssh_key": "Delete SSH Key",
+    "generate_ssh_key": "Generate SSH Key",
+    "name": "Name",
+    "public_key": "Public Key",
+    "save_your_private_key_now": "Save your private key now",
+    "search_by_name_or_fingerprint": "Search by name or fingerprint",
+    "this_is_the_only_time_the_private_key_will_b": "This is the only time the private key will be shown.",
+    "yes": "Yes"
+  },
+  "dnsrecordspage": {
+    "no_dns_records_yet": "No DNS records yet",
+    "system_records": "System Records",
+    "your_administrator_has_restricted_changes_to": "Your administrator has restricted changes to this record type."
+  },
+  "domaincachesection": {
+    "cacheable_query_parameters": "Cacheable query parameters",
+    "caches_php_html_responses_for_the_ttl_above": "Caches PHP/HTML responses for the TTL above (default 600s). On expiry the stale page is served instantly while nginx refreshes it in the background — no visitor waits for the rebuild. Automatically bypassed for POST requests, logged-in WordPress users, carts/checkout, wp-admin and session cookies, so dynamic and authenticated pages stay correct.",
+    "page_cache_with_background_refresh": "Page cache with background refresh",
+    "purge": "Purge",
+    "purge_cached_pages_for_this_domain": "Purge cached pages for this domain?",
+    "query_string_params_that_get_their_own_cache": "Query-string params that get their own cache entry (e.g. paged for pagination). Everything else with a query string still bypasses. This does NOT cache JetEngine AJAX filters — those are admin-ajax POST requests and always bypass. Keep the list tight: faceted params multiply cache entries. Names are lower-case letters, digits, and underscores."
+  },
+  "domainnginxoptionsmodal": {
+    "domain_options": "Domain options",
+    "max_upload_size_mb": "Max upload size (MB)",
+    "save": "Save"
+  },
+  "installappbutton": {
+    "install_app": "Install app",
+    "install_jabali_as_an_app": "Install Jabali as an app"
+  },
+  "jabalifooter": {
+    "source_code": "Source code"
+  },
+  "notificationbell": {
+    "clear": "Clear",
+    "clear_all_notifications": "Clear all notifications?",
+    "mark_all_read": "Mark all read",
+    "notifications": "Notifications",
+    "this_deletes_every_notification_in_your_inbo": "This deletes every notification in your inbox."
+  },
+  "serverhealthindicator": {
+    "server_health_alerts": "Server health alerts"
+  },
+  "tasksindicator": {
+    "background_tasks": "Background tasks",
+    "no_tasks_running": "No tasks running"
+  },
+  "sslmanagertable": {
+    "are_you_sure_you_want_to_revoke_this_certifi": "Are you sure you want to revoke this certificate?",
+    "clears_backoff_and_reissues_the_let_s_encryp": "Clears backoff and reissues the Let's Encrypt mail certificate",
+    "failed_to_load_ssl_certificates": "Failed to load SSL certificates",
+    "force_acme_retry_now": "Force ACME retry now",
+    "last_attempt": "Last attempt",
+    "next_retry": "Next retry",
+    "no_ssl_certificates_yet": "No SSL certificates yet",
+    "panel_cert_managed_via_server_settings_panel": "Panel cert — managed via Server Settings → Panel SSL",
+    "renew_certificate": "Renew certificate",
+    "retry_count": "Retry count",
+    "revoke_certificate": "Revoke Certificate",
+    "show_last_error": "Show last error",
+    "status": "Status",
+    "yes": "Yes"
   }
 }

--- a/panel-ui/src/shells/dns/DNSRecordsPage.tsx
+++ b/panel-ui/src/shells/dns/DNSRecordsPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useState, useEffect } from "react";
 import {
   ArrowLeftOutlined,
@@ -176,6 +177,7 @@ const getPlaceholders = (
 };
 
 export const DNSRecordsPage = () => {
+  const { t } = useTranslation();
   const { id: domainId } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
@@ -586,7 +588,7 @@ export const DNSRecordsPage = () => {
       {/* Records Table */}
       {displayRecords.length === 0 ? (
         <Card style={{ marginBottom: 24 }}>
-          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No DNS records yet" />
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("dnsrecordspage.no_dns_records_yet")} />
         </Card>
       ) : (
         <Card style={{ marginBottom: 24 }}>
@@ -681,7 +683,7 @@ export const DNSRecordsPage = () => {
                   const canDelete = allowsRecord(record.type as string, "delete");
                   if (!canEdit && !canDelete) {
                     return (
-                      <Tooltip title="Your administrator has restricted changes to this record type.">
+                      <Tooltip title={t("dnsrecordspage.your_administrator_has_restricted_changes_to")}>
                         <Space>
                           <LockOutlined />
                           {!isCompact && <Typography.Text type="secondary">Restricted</Typography.Text>}
@@ -722,7 +724,7 @@ export const DNSRecordsPage = () => {
           settings on the Server Settings page. */}
       {systemRecords.length > 0 && (
         <Card
-          title="System Records"
+          title={t("dnsrecordspage.system_records")}
           style={{ marginBottom: 24 }}
           extra={
             <Typography.Text type="secondary" style={{ fontSize: 12 }}>

--- a/panel-ui/src/shells/user/MyProfile.tsx
+++ b/panel-ui/src/shells/user/MyProfile.tsx
@@ -7,6 +7,7 @@
 // the SPA bounces to `/jabali-panel/profile?flow=<id>`. When this page
 // sees `?flow=<id>` it fetches the flow and renders the Kratos node
 // tree inline inside the Security card — no extra page, no extra tab.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -41,6 +42,7 @@ import {
 import { MyProfileUsageCard } from "./MyProfileUsageCard";
 
 export function MyProfile() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const [me, setMe] = useState<Identity | null>(null);
@@ -174,33 +176,33 @@ export function MyProfile() {
         }}
       >
         <div style={{ breakInside: "avoid", marginBottom: 16, display: "inline-block", width: "100%" }}>
-        <Card title="Account" loading={!me}>
+        <Card title={t("myprofile.account")} loading={!me}>
           {me && (
             <Descriptions column={1}>
-              <Descriptions.Item label="Email">{me.email}</Descriptions.Item>
+              <Descriptions.Item label={t("myprofile.email")}>{me.email}</Descriptions.Item>
               {me.fullName && (
-                <Descriptions.Item label="Full name">{me.fullName}</Descriptions.Item>
+                <Descriptions.Item label={t("myprofile.full_name")}>{me.fullName}</Descriptions.Item>
               )}
               {me.username && (
-                <Descriptions.Item label="Username">
+                <Descriptions.Item label={t("myprofile.username")}>
                   <Typography.Text code>{me.username}</Typography.Text>
                 </Descriptions.Item>
               )}
-              <Descriptions.Item label="User ID">
+              <Descriptions.Item label={t("myprofile.user_id")}>
                 <Typography.Text code>{me.id}</Typography.Text>
               </Descriptions.Item>
-              <Descriptions.Item label="Hosting package">
+              <Descriptions.Item label={t("myprofile.hosting_package")}>
                 {me.packageName ? (
                   me.packageName
                 ) : (
                   <Typography.Text type="secondary">No package</Typography.Text>
                 )}
               </Descriptions.Item>
-              <Descriptions.Item label="Role">
+              <Descriptions.Item label={t("myprofile.role")}>
                 {me.isAdmin ? "Administrator" : "Tenant"}
               </Descriptions.Item>
               {me.createdAt && (
-                <Descriptions.Item label="Member since">
+                <Descriptions.Item label={t("myprofile.member_since")}>
                   {new Date(me.createdAt).toLocaleDateString()}
                 </Descriptions.Item>
               )}
@@ -210,13 +212,13 @@ export function MyProfile() {
         </div>
 
         <div style={{ breakInside: "avoid", marginBottom: 16, display: "inline-block", width: "100%" }}>
-        <Card title="Security">
+        <Card title={t("myprofile.security")}>
           {impersonating ? (
             <Alert
               type="info"
               showIcon
-              message="Security settings unavailable while acting as another user"
-              description="Password and two-factor (2FA/TOTP) settings always apply to your own admin account — there is no separate login session for the user you are acting as, so changing them here would change YOUR credentials, not theirs. Exit impersonation to manage your own security. To reset a user's 2FA, go to Users → the user → Reset 2FA."
+              message={t("myprofile.security_settings_unavailable_while_acting_a")}
+              description={t("myprofile.password_and_two_factor_2fa_totp_settings_al")}
             />
           ) : (
           <>

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -2,6 +2,7 @@
 // backup of the caller's account; list recent self-backups; download
 // when a row is succeeded. Mirrors AdminBackupsPage data shape but
 // scoped via /me/backups (auth-gated to caller's user_id).
+import { useTranslation } from "react-i18next";
 import { Button, Card, Grid, Select, Space, Table, Tag, Typography, message } from "antd";
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
@@ -40,6 +41,7 @@ const statusColor = (status: string): string => {
 };
 
 export const MyProfileBackupCard = () => {
+  const { t } = useTranslation();
   const screens = Grid.useBreakpoint();
   const [submitting, setSubmitting] = useState(false);
   const [restoreId, setRestoreId] = useState<string | null>(null);
@@ -117,7 +119,7 @@ export const MyProfileBackupCard = () => {
               value={destinationId}
               onChange={setDestinationId}
               style={{ minWidth: 180 }}
-              placeholder="Destination"
+              placeholder={t("myprofilebackupcard.destination")}
               options={destOptions}
             />
           )}

--- a/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
@@ -4,6 +4,7 @@
 // Gated on the hosting package's scheduled_backups_enabled. Unlike the on-demand
 // card, a schedule needs a real destination row — the implicit "local default"
 // is skipped by the scheduler fan-out — so only concrete destinations are offered.
+import { useTranslation } from "react-i18next";
 import { Alert, Button, Card, InputNumber, Select, Space, Switch, Typography, message } from "antd";
 import { ClockCircleOutlined } from "@icons";
 import { useEffect, useState } from "react";
@@ -26,6 +27,7 @@ type ScheduleView = {
 };
 
 export const MyProfileScheduleCard = () => {
+  const { t } = useTranslation();
   const schedQuery = useQuery({
     queryKey: ["me-backup-schedule"],
     queryFn: async () => (await apiClient.get<{ data: ScheduleView }>("/me/backup-schedule")).data.data,
@@ -91,7 +93,7 @@ export const MyProfileScheduleCard = () => {
       loading={schedQuery.isLoading}
     >
       {view && !view.scheduled_backups_enabled ? (
-        <Alert type="info" showIcon message="Scheduled backups are not included in your hosting plan." />
+        <Alert type="info" showIcon message={t("myprofileschedulecard.scheduled_backups_are_not_included_in_your_h")} />
       ) : (
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
           <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
@@ -120,7 +122,7 @@ export const MyProfileScheduleCard = () => {
               value={destinationId}
               onChange={setDestinationId}
               style={{ minWidth: 200 }}
-              placeholder="Destination"
+              placeholder={t("myprofileschedulecard.destination")}
               options={destOptions}
               notFoundContent="No allowed destinations"
             />

--- a/panel-ui/src/shells/user/RestoreDrawer.tsx
+++ b/panel-ui/src/shells/user/RestoreDrawer.tsx
@@ -6,6 +6,7 @@
 // added since). Mail / DNS are not offered — see
 // plans/m267-tenant-selective-restore.md (mail is RocksDB-unsafe via file apply;
 // custom DNS records aren't captured).
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
 import {
@@ -45,6 +46,7 @@ interface RestoreDrawerProps {
 }
 
 export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) => {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [databases, setDatabases] = useState<string[]>([]);
   const [selected, setSelected] = useState<string[]>([]);
@@ -112,7 +114,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
 
   return (
     <Drawer
-      title="Restore from backup"
+      title={t("restoredrawer.restore_from_backup")}
       width={460}
       open={open}
       onClose={onClose}
@@ -196,8 +198,8 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             <Alert
               type="warning"
               showIcon
-              message="This is destructive"
-              description="The selected items will be overwritten with the backed-up copy."
+              message={t("restoredrawer.this_is_destructive")}
+              description={t("restoredrawer.the_selected_items_will_be_overwritten_with")}
             />
           )}
 
@@ -225,7 +227,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             <Alert
               type={(result.applied?.length ?? 0) > 0 ? "success" : "info"}
               showIcon
-              message="Restore result"
+              message={t("restoredrawer.restore_result")}
               description={
                 <Space direction="vertical" size={2}>
                   {(result.applied ?? []).map((a) => (

--- a/panel-ui/src/shells/user/UserDashboard.tsx
+++ b/panel-ui/src/shells/user/UserDashboard.tsx
@@ -4,6 +4,7 @@
 // recent-rows tables (domains, mailboxes, applications, databases)
 // on the other. Cards pack height-balanced like the admin shell so a
 // long table doesn't leave whitespace next to a short one.
+import { useTranslation } from "react-i18next";
 import {
   Button,
   Card,
@@ -59,6 +60,7 @@ type DatabaseRow = {
 type MailboxRow = Mailbox & { domain_name: string };
 
 export function UserDashboard() {
+  const { t } = useTranslation();
   const [me, setMe] = useState<Identity | null>(null);
 
   useEffect(() => {
@@ -125,7 +127,7 @@ export function UserDashboard() {
       data: null,
       children: (
         <Card
-          title="Recent Domains"
+          title={t("userdashboard.recent_domains")}
           size="small"
           extra={
             <Link to="/jabali-panel/domains">
@@ -152,7 +154,7 @@ export function UserDashboard() {
       data: null,
       children: (
         <Card
-          title="Recent Mailboxes"
+          title={t("userdashboard.recent_mailboxes")}
           size="small"
           extra={
             <Link to="/jabali-panel/mail/mailboxes">
@@ -185,7 +187,7 @@ export function UserDashboard() {
       data: null,
       children: (
         <Card
-          title="Recent Applications"
+          title={t("userdashboard.recent_applications")}
           size="small"
           extra={
             <Link to="/jabali-panel/applications">
@@ -225,7 +227,7 @@ export function UserDashboard() {
       data: null,
       children: (
         <Card
-          title="Recent Databases"
+          title={t("userdashboard.recent_databases")}
           size="small"
           extra={
             <Link to="/jabali-panel/databases">
@@ -271,7 +273,7 @@ export function UserDashboard() {
       <Row gutter={[16, 16]}>
         <Col xs={24} sm={12} md={6}>
           <StatCard
-            label="Domains"
+            label={t("userdashboard.domains")}
             value={formatCount(recentDomains.total)}
             icon={<GlobalOutlined />}
             iconBg="rgba(146, 84, 222, 0.14)"
@@ -281,7 +283,7 @@ export function UserDashboard() {
         </Col>
         <Col xs={24} sm={12} md={6}>
           <StatCard
-            label="Mailboxes"
+            label={t("userdashboard.mailboxes")}
             value={formatCount(mailboxTotal)}
             icon={<MailOutlined />}
             iconBg="rgba(250, 140, 22, 0.14)"
@@ -291,7 +293,7 @@ export function UserDashboard() {
         </Col>
         <Col xs={24} sm={12} md={6}>
           <StatCard
-            label="Applications"
+            label={t("userdashboard.applications")}
             value={formatCount(recentApps.total)}
             icon={<AppstoreOutlined />}
             iconBg="rgba(22, 119, 255, 0.12)"
@@ -301,7 +303,7 @@ export function UserDashboard() {
         </Col>
         <Col xs={24} sm={12} md={6}>
           <StatCard
-            label="Databases"
+            label={t("userdashboard.databases")}
             value={formatCount(recentDatabases.total)}
             icon={<DatabaseOutlined />}
             iconBg="rgba(82, 196, 26, 0.14)"

--- a/panel-ui/src/shells/user/activity/AccountActivity.tsx
+++ b/panel-ui/src/shells/user/activity/AccountActivity.tsx
@@ -10,6 +10,7 @@
 // Timestamps render in the viewer's browser timezone: the server tz
 // lives behind an admin-only endpoint, and the column header names the
 // tz so the rendered time is never ambiguous.
+import { useTranslation } from "react-i18next";
 import { Card, Space, Table, Tag, Typography } from "antd";
 import { FileTextOutlined } from "@icons";
 
@@ -26,6 +27,7 @@ import {
 import { useTableURL } from "../../../hooks/useTableURL";
 
 export const AccountActivity = () => {
+  const { t } = useTranslation();
   const tz = browserTz();
   const query = useTableURL<AuditRow>({
     resource: "me/activity",
@@ -80,7 +82,7 @@ export const AccountActivity = () => {
             render={(ts: string) => <code>{fmtTSInTz(ts, tz)}</code>}
           />
           <Table.Column
-            title="What"
+            title={t("accountactivity.what")}
             key="action"
             render={(_: unknown, r: AuditRow) => (
               <AuditActionLabel
@@ -94,7 +96,7 @@ export const AccountActivity = () => {
             )}
           />
           <Table.Column
-            title="Target"
+            title={t("accountactivity.target")}
             key="target"
             render={(_: unknown, r: AuditRow) =>
               r.target_type || r.target_id ? (
@@ -108,7 +110,7 @@ export const AccountActivity = () => {
           />
           <Table.Column
             dataIndex="result"
-            title="Result"
+            title={t("accountactivity.result")}
             key="result"
             render={resultTag}
           />

--- a/panel-ui/src/shells/user/api-tokens/DDNSSetupGuide.tsx
+++ b/panel-ui/src/shells/user/api-tokens/DDNSSetupGuide.tsx
@@ -4,6 +4,7 @@
 // ddclient config for a chosen hostname, documents the DynDNS response strings,
 // and runs an optional live test update. No new backend — it drives the
 // existing GET /nic/update shim (api/ddns.go).
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Alert,
@@ -47,6 +48,7 @@ const CodeBlock = ({ text }: { text: string }) => (
 );
 
 export function DDNSSetupGuide(): JSX.Element {
+  const { t } = useTranslation();
   const [hostname, setHostname] = useState("");
   const [token, setToken] = useState("");
   const [testing, setTesting] = useState(false);
@@ -101,14 +103,14 @@ export function DDNSSetupGuide(): JSX.Element {
     : undefined;
 
   return (
-    <Card title="Dynamic DNS (DDNS) setup" size="small" style={{ marginTop: 24 }}>
+    <Card title={t("ddnssetupguide.dynamic_dns_ddns_setup")} size="small" style={{ marginTop: 24 }}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Alert
           type="info"
           showIcon
           icon={<KeyOutlined />}
-          message="Your API token is the DDNS password"
-          description="Point your router or ddclient at the update URL below and use a ddns-scoped API token (mint one above) as the Basic-auth PASSWORD. The username is ignored — put anything. Scope the token to a single record for least privilege."
+          message={t("ddnssetupguide.your_api_token_is_the_ddns_password")}
+          description={t("ddnssetupguide.point_your_router_or_ddclient_at_the_update")}
         />
 
         <div>

--- a/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
+++ b/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
@@ -10,6 +10,7 @@
 // the user can't dismiss without copying. Anything else risks a
 // "wait, what was that secret?" support ticket.
 
+import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
@@ -107,6 +108,7 @@ function statusTag(t: UserAPIToken): JSX.Element {
 }
 
 export function UserAPITokensPage(): JSX.Element {
+  const { t } = useTranslation();
   const [rows, setRows] = useState<UserAPIToken[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
@@ -289,9 +291,9 @@ export function UserAPITokensPage(): JSX.Element {
             </Typography.Text>
           ) : (
             <Popconfirm
-              title="Revoke this token?"
-              description="Any script using it will start getting 401."
-              okText="Revoke"
+              title={t("userapitokenspage.revoke_this_token")}
+              description={t("userapitokenspage.any_script_using_it_will_start_getting_401")}
+              okText={t("userapitokenspage.revoke")}
               okType="danger"
               onConfirm={() => onRevoke(row)}
             >
@@ -307,7 +309,7 @@ export function UserAPITokensPage(): JSX.Element {
 
   const tokensCard = (
     <Card
-      title="Personal API Tokens"
+      title={t("userapitokenspage.personal_api_tokens")}
       extra={
         <Button
           type="primary"
@@ -352,18 +354,18 @@ export function UserAPITokensPage(): JSX.Element {
       />
 
       <Modal
-        title="Create API token"
+        title={t("userapitokenspage.create_api_token")}
         open={createOpen}
         onCancel={() => {
           setCreateOpen(false);
           createForm.resetFields();
         }}
         onOk={onCreate}
-        okText="Create"
+        okText={t("userapitokenspage.create")}
       >
         <Form form={createForm} layout="vertical">
           <Form.Item
-            label="Name"
+            label={t("userapitokenspage.name")}
             name="name"
             rules={[
               { required: true, message: "Required" },
@@ -371,10 +373,10 @@ export function UserAPITokensPage(): JSX.Element {
             ]}
             extra="A label for you — e.g. 'office router DDNS', 'CI deploy bot'."
           >
-            <Input placeholder="My token" autoFocus maxLength={100} />
+            <Input placeholder={t("userapitokenspage.my_token")} autoFocus maxLength={100} />
           </Form.Item>
           <Form.Item
-            label="Expires in (seconds, optional)"
+            label={t("userapitokenspage.expires_in_seconds_optional")}
             name="expires_in_seconds"
             extra="Leave blank for a token that never expires. Max 1 year (31536000)."
             rules={[
@@ -395,8 +397,8 @@ export function UserAPITokensPage(): JSX.Element {
             />
           </Form.Item>
           <Form.Item
-            label="Permissions"
-            tooltip="Full access can do anything you can. A custom token is restricted to exactly the areas you tick and is rejected everywhere else."
+            label={t("userapitokenspage.permissions")}
+            tooltip={t("userapitokenspage.full_access_can_do_anything_you_can_a_custom")}
           >
             <Radio.Group
               value={accessMode}
@@ -424,7 +426,7 @@ export function UserAPITokensPage(): JSX.Element {
                     <div style={{ marginTop: 6, marginLeft: 24 }}>
                       <Input
                         size="small"
-                        placeholder="Limit to one DNS record ID (optional)"
+                        placeholder={t("userapitokenspage.limit_to_one_dns_record_id_optional")}
                         value={ddnsRecordId}
                         onChange={(e) => setDdnsRecordId(e.target.value)}
                         allowClear
@@ -469,7 +471,7 @@ export function UserAPITokensPage(): JSX.Element {
         open={!!secret}
         onCancel={() => setSecret(null)}
         onOk={() => setSecret(null)}
-        okText="I've copied it"
+        okText={t("userapitokenspage.i_ve_copied_it")}
         cancelButtonProps={{ style: { display: "none" } }}
         closable={false}
         maskClosable={false}
@@ -477,8 +479,8 @@ export function UserAPITokensPage(): JSX.Element {
         <Alert
           type="warning"
           showIcon
-          message="Copy this secret now."
-          description="The plaintext token is shown only once. After you close this dialog the panel only stores its hash — there's no way to retrieve it again. Lost? Revoke + create a new one."
+          message={t("userapitokenspage.copy_this_secret_now")}
+          description={t("userapitokenspage.the_plaintext_token_is_shown_only_once_after")}
           style={{ marginBottom: 16 }}
         />
         <Input.Group compact>

--- a/panel-ui/src/shells/user/applications/CatalogTab.tsx
+++ b/panel-ui/src/shells/user/applications/CatalogTab.tsx
@@ -2,6 +2,7 @@
 // modelled on the admin Docker-Apps catalog: a masonry of cards, one per
 // registered app descriptor (GET /applications/registry). Clicking a card
 // opens the Install drawer pre-targeted to that app_type.
+import { useTranslation } from "react-i18next";
 import { Alert, Empty, Spin, Tag } from "antd";
 import { useMemo, useState } from "react";
 import { DatabaseOutlined } from "@icons";
@@ -15,6 +16,7 @@ type Props = {
 };
 
 export const CatalogTab = ({ onInstall }: Props) => {
+  const { t } = useTranslation();
   const { data: apps = [], isLoading, isError } = useAppRegistry();
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
@@ -44,8 +46,8 @@ export const CatalogTab = ({ onInstall }: Props) => {
       <Alert
         type="error"
         showIcon
-        message="Failed to load the application catalog"
-        description="Try reloading the page."
+        message={t("catalogtab.failed_to_load_the_application_catalog")}
+        description={t("catalogtab.try_reloading_the_page")}
       />
     );
   }
@@ -54,7 +56,7 @@ export const CatalogTab = ({ onInstall }: Props) => {
     return (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="No applications available"
+        description={t("catalogtab.no_applications_available")}
       />
     );
   }
@@ -65,7 +67,7 @@ export const CatalogTab = ({ onInstall }: Props) => {
       {visibleApps.length === 0 ? (
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description="No applications match the selected tags"
+          description={t("catalogtab.no_applications_match_the_selected_tags")}
         />
       ) : (
         <CatalogGrid>

--- a/panel-ui/src/shells/user/applications/CloneApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/CloneApplicationModal.tsx
@@ -4,6 +4,7 @@
 // the WordPress descriptor only); future clonable apps reuse the same
 // modal and POST /applications/:id/clone path.
 
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Modal,
@@ -53,6 +54,7 @@ export const CloneApplicationModal = ({
   onSuccess,
   installId,
 }: Props) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<{ dest_domain_id: string }>();
   const [submitting, setSubmitting] = useState(false);
   const [domains, setDomains] = useState<Domain[]>([]);
@@ -128,7 +130,7 @@ export const CloneApplicationModal = ({
 
   return (
     <Modal
-      title="Clone application"
+      title={t("cloneapplicationmodal.clone_application")}
       open={open}
       onCancel={handleClose}
       maskClosable={!submitting}
@@ -159,12 +161,12 @@ export const CloneApplicationModal = ({
         disabled={submitting}
       >
         <Form.Item
-          label="Destination domain"
+          label={t("cloneapplicationmodal.destination_domain")}
           name="dest_domain_id"
           rules={[{ required: true, message: "Pick a destination domain" }]}
         >
           <Select
-            placeholder="Select a domain"
+            placeholder={t("cloneapplicationmodal.select_a_domain")}
             loading={loadingDomains}
             options={availableDomains.map((d) => ({
               value: d.id,

--- a/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
@@ -12,6 +12,7 @@
 // app type (e.g. DokuWiki with a "license" enum) requires zero UI
 // code — the descriptor on the API side is the only source of truth.
 
+import { useTranslation } from "react-i18next";
 import { useState, useEffect, useMemo } from "react";
 import {
   Drawer,
@@ -314,6 +315,7 @@ export const InstallApplicationModal = ({
   defaultAdminEmail,
   presetAppType,
 }: Props) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<Record<string, unknown>>();
   const [submitting, setSubmitting] = useState(false);
   const [domains, setDomains] = useState<Domain[]>([]);
@@ -546,7 +548,7 @@ export const InstallApplicationModal = ({
 
   return (
     <Drawer
-      title="Install application"
+      title={t("installapplicationmodal.install_application")}
       open={open}
       onClose={handleClose}
       maskClosable={!submitting && !result}
@@ -581,7 +583,7 @@ export const InstallApplicationModal = ({
             type="info"
             showIcon
             style={{ marginBottom: 16 }}
-            title="What happens next"
+            title={t("installapplicationmodal.what_happens_next")}
             description={
               <>
                 We&rsquo;ll provision the application&rsquo;s database (if
@@ -598,8 +600,8 @@ export const InstallApplicationModal = ({
               type="info"
               showIcon
               style={{ marginBottom: 16 }}
-              title="No domains yet"
-              description="You have no domains. Create one first."
+              title={t("installapplicationmodal.no_domains_yet")}
+              description={t("installapplicationmodal.you_have_no_domains_create_one_first")}
             />
           )}
           <Form
@@ -636,12 +638,12 @@ export const InstallApplicationModal = ({
               </>
             ) : (
               <Form.Item
-                label="Application"
+                label={t("installapplicationmodal.application")}
                 name="app_type"
                 rules={[{ required: true, message: "Pick an application" }]}
               >
                 <Select
-                  placeholder="Select an application"
+                  placeholder={t("installapplicationmodal.select_an_application")}
                   loading={loadingApps}
                   suffixIcon={<AppstoreOutlined />}
                   options={apps.map((a) => ({
@@ -672,12 +674,12 @@ export const InstallApplicationModal = ({
             )}
 
             <Form.Item
-              label="Domain"
+              label={t("installapplicationmodal.domain")}
               name="domain_id"
               rules={[{ required: true, message: "Pick a domain" }]}
             >
               <Select
-                placeholder="Select a domain"
+                placeholder={t("installapplicationmodal.select_a_domain")}
                 loading={loadingDomains}
                 options={availableDomains.map((d) => ({
                   value: d.id,
@@ -705,7 +707,7 @@ export const InstallApplicationModal = ({
                 </div>
 
                 <Form.Item
-                  label="Directory (optional)"
+                  label={t("installapplicationmodal.directory_optional")}
                   name="subdirectory"
                   rules={[{ validator: validateSubdirectory }]}
                 >
@@ -736,8 +738,8 @@ export const InstallApplicationModal = ({
             type="success"
             showIcon
             icon={<CheckCircleTwoTone twoToneColor="#52c41a" />}
-            title="Install queued"
-            description="The install runs in the background. Copy the password now — it is shown only once. We store only a bcrypt hash."
+            title={t("installapplicationmodal.install_queued")}
+            description={t("installapplicationmodal.the_install_runs_in_the_background_copy_the")}
           />
           <div>
             <Typography.Text strong>Domain</Typography.Text>
@@ -750,7 +752,7 @@ export const InstallApplicationModal = ({
                 readOnly
                 value={result.adminUsername}
                 addonAfter={
-                  <Tooltip title="Copy">
+                  <Tooltip title={t("installapplicationmodal.copy")}>
                     <Button
                       type="text"
                       icon={<CopyOutlined />}
@@ -772,7 +774,7 @@ export const InstallApplicationModal = ({
               value={result.adminPassword}
               visibilityToggle
               addonAfter={
-                <Tooltip title="Copy">
+                <Tooltip title={t("installapplicationmodal.copy")}>
                   <Button
                     type="text"
                     icon={<CopyOutlined />}

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -3,6 +3,7 @@
 // useTableURL with a custom useQuery `refetchInterval` so
 // transitional statuses (pending/installing/cloning/deleting) poll
 // until ready.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
@@ -222,6 +223,7 @@ const ActionsCell = ({
 };
 
 export const UserApplicationList = () => {
+  const { t } = useTranslation();
   const { user } = useAuth();
   const qc = useQueryClient();
 
@@ -381,7 +383,7 @@ export const UserApplicationList = () => {
           <AppstoreOutlined /> Applications
         </Typography.Title>
         <Space wrap size={[8, 8]}>
-          <Tooltip title="Detect WordPress, Joomla, Drupal, and Magento installs on disk that aren't yet tracked by the panel.">
+          <Tooltip title={t("userapplicationlist.detect_wordpress_joomla_drupal_and_magento_i")}>
             <Button
               icon={<SearchOutlined />}
               loading={scanning}
@@ -473,21 +475,21 @@ export const UserApplicationList = () => {
                       <Col xs={12} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
-                          label="Installed Apps" value={installedCount}
+                          label={t("userapplicationlist.installed_apps")} value={installedCount}
                           subtitle={<Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>}
                         />
                       </Col>
                       <Col xs={12} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={CheckCircleOutlined}
-                          label="Ready" value={readyCount}
+                          label={t("userapplicationlist.ready")} value={readyCount}
                           subtitle={<Typography.Text type="secondary">{pct(readyCount)}% of installed</Typography.Text>}
                         />
                       </Col>
                       <Col xs={12} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(22, 119, 255, 0.12)" iconColor="#1677ff" Icon={SyncOutlined}
-                          label="In Progress" value={inProgressCount}
+                          label={t("userapplicationlist.in_progress")} value={inProgressCount}
                           subtitle={inProgressCount > 0
                             ? <Typography.Text type="warning">Working…</Typography.Text>
                             : <Typography.Text type="secondary">Idle</Typography.Text>}
@@ -496,7 +498,7 @@ export const UserApplicationList = () => {
                       <Col xs={12} sm={12} lg={6}>
                         <StatCard
                           iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={ExclamationCircleOutlined}
-                          label="Failed" value={failedCount}
+                          label={t("userapplicationlist.failed")} value={failedCount}
                           subtitle={failedCount > 0
                             ? <Typography.Text type="danger">Needs attention</Typography.Text>
                             : <Typography.Text type="secondary">All healthy</Typography.Text>}
@@ -513,7 +515,7 @@ export const UserApplicationList = () => {
           searchPlaceholder="Search by domain"
           locale={{
             emptyText: (
-              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No installed apps yet">
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userapplicationlist.no_installed_apps_yet")}>
                 <Button type="primary" onClick={() => setActiveTab("catalog")}>
                   Browse Catalog
                 </Button>
@@ -530,7 +532,7 @@ export const UserApplicationList = () => {
         >
           <Table.Column<ApplicationInstall>
             dataIndex="domain_name"
-            title="Domain"
+            title={t("userapplicationlist.domain")}
             key="domain_name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -589,7 +591,7 @@ export const UserApplicationList = () => {
           />
           <Table.Column<ApplicationInstall>
             dataIndex="version"
-            title="App / Version"
+            title={t("userapplicationlist.app_version")}
             responsive={["lg"]}
             render={(version: string | null, record) => (
               <Space size={6}>
@@ -600,19 +602,19 @@ export const UserApplicationList = () => {
           />
           <Table.Column<ApplicationInstall>
             dataIndex="admin_email"
-            title="Admin email"
+            title={t("userapplicationlist.admin_email")}
             responsive={["md"]}
           />
           <Table.Column<ApplicationInstall>
             dataIndex="created_at"
-            title="Created"
+            title={t("userapplicationlist.created")}
             responsive={["lg"]}
             key="created_at"
             sorter={{ multiple: 2 }}
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<ApplicationInstall>
-            title="Cache"
+            title={t("userapplicationlist.cache")}
             dataIndex="cache_enabled"
             responsive={["md"]}
             render={(_, r) => {
@@ -631,15 +633,15 @@ export const UserApplicationList = () => {
               if (!supported) return sw;
               return (
                 <Space size={4}>
-                  <Tooltip title="Redis object cache + nginx page cache">
+                  <Tooltip title={t("userapplicationlist.redis_object_cache_nginx_page_cache")}>
                     {sw}
                   </Tooltip>
-                  <Tooltip title="Cache settings">
+                  <Tooltip title={t("userapplicationlist.cache_settings")}>
                     <Button
                       type="text"
                       size="small"
                       icon={<SettingOutlined />}
-                      aria-label="Cache settings"
+                      aria-label={t("userapplicationlist.cache_settings")}
                       onClick={() => setCacheSettingsFor(r)}
                     />
                   </Tooltip>
@@ -648,7 +650,7 @@ export const UserApplicationList = () => {
             }}
           />
           <Table.Column<ApplicationInstall>
-            title="Actions"
+            title={t("userapplicationlist.actions")}
             dataIndex="actions"
             render={(_, r) => {
               const isDeleting =

--- a/panel-ui/src/shells/user/cron/CreateCronModal.tsx
+++ b/panel-ui/src/shells/user/cron/CreateCronModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Drawer,
@@ -39,6 +40,7 @@ export const CreateCronModal = ({
   onSuccess,
   initial,
 }: CreateCronModalProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
   const [scheduleMode, setScheduleMode] = useState<string>(
@@ -159,7 +161,7 @@ export const CreateCronModal = ({
         }}
       >
         <Form.Item
-          label="Name"
+          label={t("createcronmodal.name")}
           name="name"
           rules={[
             { required: true, message: "Please enter a job name" },
@@ -170,7 +172,7 @@ export const CreateCronModal = ({
         </Form.Item>
 
         <Form.Item
-          label="Command"
+          label={t("createcronmodal.command")}
           name="command"
           rules={[
             { required: true, message: "Please enter a command" },
@@ -193,7 +195,7 @@ export const CreateCronModal = ({
 
         <Divider style={{ margin: "16px 0" }} />
 
-        <Form.Item label="Schedule">
+        <Form.Item label={t("createcronmodal.schedule")}>
           <Radio.Group
             value={scheduleMode}
             onChange={(e) => setScheduleMode(e.target.value)}
@@ -208,7 +210,7 @@ export const CreateCronModal = ({
 
         {scheduleMode === "advanced" && (
           <Form.Item
-            label="Cron Expression"
+            label={t("createcronmodal.cron_expression")}
             rules={[
               { required: true, message: "Please enter a cron expression" },
             ]}

--- a/panel-ui/src/shells/user/cron/CronLogDrawer.tsx
+++ b/panel-ui/src/shells/user/cron/CronLogDrawer.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Drawer,
@@ -26,6 +27,7 @@ export const CronLogDrawer = ({
   onClose,
   jobId,
 }: CronLogDrawerProps) => {
+  const { t } = useTranslation();
   const [lines, setLines] = useState<number>(200);
 
   const {
@@ -50,7 +52,7 @@ export const CronLogDrawer = ({
 
   return (
     <Drawer
-      title="Cron Job Log"
+      title={t("cronlogdrawer.cron_job_log")}
       placement="right"
       onClose={onClose}
       open={open}

--- a/panel-ui/src/shells/user/cron/RunNowResultModal.tsx
+++ b/panel-ui/src/shells/user/cron/RunNowResultModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { Modal, Alert, Card, Space } from "antd";
 
 interface RunNowResultModalProps {
@@ -15,6 +16,7 @@ export const RunNowResultModal = ({
   onClose,
   result,
 }: RunNowResultModalProps) => {
+  const { t } = useTranslation();
   if (!result) {
     return null;
   }
@@ -23,7 +25,7 @@ export const RunNowResultModal = ({
 
   return (
     <Modal
-      title="Cron Job Execution Result"
+      title={t("runnowresultmodal.cron_job_execution_result")}
       open={open}
       onCancel={onClose}
       footer={null}
@@ -38,7 +40,7 @@ export const RunNowResultModal = ({
         />
 
         {result.stdout && (
-          <Card title="Standard Output">
+          <Card title={t("runnowresultmodal.standard_output")}>
             <pre
               style={{
                 fontFamily: "monospace",
@@ -59,7 +61,7 @@ export const RunNowResultModal = ({
 
         {result.stderr && (
           <Card
-            title="Standard Error"
+            title={t("runnowresultmodal.standard_error")}
             style={{ borderColor: "var(--ant-color-error)" }}
           >
             <pre

--- a/panel-ui/src/shells/user/cron/UserCronList.tsx
+++ b/panel-ui/src/shells/user/cron/UserCronList.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   App,
@@ -51,6 +52,7 @@ const humanizeSchedule = (schedule: string): string => {
 };
 
 export const UserCronList = () => {
+  const { t } = useTranslation();
   const { message: antMessage } = App.useApp();
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [editingJob, setEditingJob] = useState<CronJob | null>(null);
@@ -195,7 +197,7 @@ export const UserCronList = () => {
       <Card>
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Input.Search
-          placeholder="Search by name, command, or schedule"
+          placeholder={t("usercronlist.search_by_name_command_or_schedule")}
           allowClear
           value={search}
           onChange={(e) => setSearch(e.target.value)}

--- a/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
+++ b/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
@@ -11,6 +11,7 @@
 // Atomic rollback would need a new backend endpoint — out of scope for
 // the shortcut.
 
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import {
   Modal,
@@ -56,6 +57,7 @@ function extractError(err: unknown, fallback: string): string {
 }
 
 export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<{ name: string; engine: "mariadb" | "postgres" }>();
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<CreatedResult | null>(null);
@@ -160,7 +162,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
 
   return (
     <Modal
-      title="Quick Database Setup"
+      title={t("quicksetupmodal.quick_database_setup")}
       open={open}
       onCancel={handleClose}
       maskClosable={!submitting && !result}
@@ -200,9 +202,9 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
           >
             {postgresEnabled && (
               <Form.Item
-                label="Engine"
+                label={t("quicksetupmodal.engine")}
                 name="engine"
-                tooltip="MariaDB is the default. PostgreSQL must be enabled in Server Settings."
+                tooltip={t("quicksetupmodal.mariadb_is_the_default_postgresql_must_be_en")}
               >
                 <Segmented
                   options={[
@@ -213,7 +215,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
               </Form.Item>
             )}
             <Form.Item
-              label="Database & User Name"
+              label={t("quicksetupmodal.database_user_name")}
               name="name"
               rules={[
                 { required: true, message: "Name is required" },
@@ -237,8 +239,8 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
             type="success"
             showIcon
             icon={<CheckCircleTwoTone twoToneColor="#52c41a" />}
-            title="Database and user created"
-            description="Copy the password now — it is shown only once. We store only a bcrypt hash."
+            title={t("quicksetupmodal.database_and_user_created")}
+            description={t("quicksetupmodal.copy_the_password_now_it_is_shown_only_once")}
           />
           <div>
             <Typography.Text strong>Database</Typography.Text>
@@ -246,7 +248,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
               readOnly
               value={result.databaseName}
               addonAfter={
-                <Tooltip title="Copy">
+                <Tooltip title={t("quicksetupmodal.copy")}>
                   <Button
                     type="text"
                     icon={<CopyOutlined />}
@@ -262,7 +264,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
               readOnly
               value={result.username}
               addonAfter={
-                <Tooltip title="Copy">
+                <Tooltip title={t("quicksetupmodal.copy")}>
                   <Button
                     type="text"
                     icon={<CopyOutlined />}
@@ -279,7 +281,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
               value={result.password}
               visibilityToggle
               addonAfter={
-                <Tooltip title="Copy">
+                <Tooltip title={t("quicksetupmodal.copy")}>
                   <Button
                     type="text"
                     icon={<CopyOutlined />}

--- a/panel-ui/src/shells/user/databases/UserDatabaseDrawer.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseDrawer.tsx
@@ -1,6 +1,7 @@
 // UserDatabaseDrawer — tenant Create-database Drawer (replaces the
 // /jabali-panel/databases/create page route). Backend prepends the
 // caller's username to the final database name.
+import { useTranslation } from "react-i18next";
 import { Button, Drawer, Form, Grid, Input, Segmented, Space, message } from "antd";
 import { useEffect, useState } from "react";
 
@@ -16,6 +17,7 @@ export interface UserDatabaseDrawerProps {
 }
 
 export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<UserDatabaseCreateInput>();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -50,7 +52,7 @@ export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) =
 
   return (
     <Drawer
-      title="Create database"
+      title={t("userdatabasedrawer.create_database")}
       open={open}
       onClose={onClose}
       width={isDesktop ? 480 : undefined}
@@ -65,9 +67,9 @@ export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) =
       >
         {postgresEnabled && (
           <Form.Item
-            label="Engine"
+            label={t("userdatabasedrawer.engine")}
             name="engine"
-            tooltip="MariaDB is the default. PostgreSQL must be enabled by an admin in Server Settings."
+            tooltip={t("userdatabasedrawer.mariadb_is_the_default_postgresql_must_be_en")}
           >
             <Segmented
               options={[
@@ -79,7 +81,7 @@ export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) =
         )}
 
         <Form.Item
-          label="Name"
+          label={t("userdatabasedrawer.name")}
           name="name"
           rules={[
             { required: true, message: "Database name is required" },
@@ -89,7 +91,7 @@ export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) =
                 "Lowercase letters, digits and underscores only; must start with a letter; max 30 chars",
             },
           ]}
-          tooltip="The final database name is your username plus an underscore plus this suffix (e.g. `alice_wp`)."
+          tooltip={t("userdatabasedrawer.the_final_database_name_is_your_username_plu")}
           extra="Your username will be prepended automatically."
         >
           <Input placeholder="e.g. wp_prod" autoComplete="off" />

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -2,6 +2,7 @@
 // + Open-in-phpMyAdmin + Delete. phpMyAdmin SSO is wired through the
 // apiClient helper; a blank tab is opened synchronously to dodge
 // popup blockers while the SSO call runs.
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
@@ -56,6 +57,7 @@ const formatBytes = (bytes: number | undefined): string => {
 };
 
 export const UserDatabaseList = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const query = useTableURL<Database>({
     resource: "databases",
@@ -214,7 +216,7 @@ export const UserDatabaseList = () => {
         >
           <Table.Column<Database>
             dataIndex="name"
-            title="Database"
+            title={t("userdatabaselist.database")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -226,31 +228,31 @@ export const UserDatabaseList = () => {
           />
           <Table.Column<Database>
             dataIndex="engine"
-            title="Engine"
+            title={t("userdatabaselist.engine")}
             width={140}
             render={(engine: string) => <EngineTag engine={engine} />}
           />
           <Table.Column<Database>
             dataIndex="size_bytes"
-            title="Size"
+            title={t("userdatabaselist.size")}
             key="size_bytes"
             sorter={{ multiple: 3 }}
             render={(size_bytes?: number) => formatBytes(size_bytes)}
           />
           <Table.Column<Database>
             dataIndex="charset"
-            title="Charset"
+            title={t("userdatabaselist.charset")}
             render={(charset?: string) => charset || "-"}
           />
           <Table.Column<Database>
             dataIndex="created_at"
-            title="Created"
+            title={t("userdatabaselist.created")}
             key="created_at"
             sorter={{ multiple: 2 }}
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<Database>
-            title="Actions"
+            title={t("userdatabaselist.actions")}
             dataIndex="actions"
             render={(_, r) => {
               const isPostgres = r.engine === "postgres";

--- a/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
+++ b/panel-ui/src/shells/user/disk-usage/DiskUsagePage.tsx
@@ -2,6 +2,7 @@
 // stat cards (Total / Files / Email / Databases / Quota). Bottom row: three
 // breakdown cards (Files & Folders, Email Mailboxes, Databases) each with a
 // table + a "View all" link. Backed by GET /api/v1/me/disk-usage.
+import { useTranslation } from "react-i18next";
 import { Alert, Button, Card, Col, Empty, Row, Spin, Table, Tag, Tree, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import type { DataNode } from "antd/es/tree";
@@ -104,6 +105,7 @@ function updateTreeData(list: DataNode[], key: string, children: DataNode[]): Da
 // carries its recursive size; expanding a folder fetches the next level on
 // demand (GET /me/disk-usage/files?path=).
 function FilesTree() {
+  const { t } = useTranslation();
   const [treeData, setTreeData] = useState<DataNode[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -144,7 +146,7 @@ function FilesTree() {
   if (treeData.length === 0) {
     return (
       <div style={{ padding: 24 }}>
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Home directory is empty" />
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("diskusagepage.home_directory_is_empty")} />
       </div>
     );
   }
@@ -163,6 +165,7 @@ const COLORS = {
 } as const;
 
 export function DiskUsagePage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
   const { data, isLoading, error } = useQuery<DiskUsage>({
@@ -195,7 +198,7 @@ export function DiskUsagePage() {
       <Alert
         type="error"
         showIcon
-        message="Could not load disk usage"
+        message={t("diskusagepage.could_not_load_disk_usage")}
         description={error instanceof Error ? error.message : "Please try again."}
       />
     );
@@ -344,7 +347,7 @@ export function DiskUsagePage() {
       <div>
         {header}
         <Empty
-          description="No disk-usage snapshot yet — click Refresh to calculate."
+          description={t("diskusagepage.no_disk_usage_snapshot_yet_click_refresh_to")}
           style={{ padding: 64 }}
         />
       </div>

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -2,6 +2,7 @@
 // pattern matches admin DNS + UserList — controlled activeTabKey,
 // count Tag in each tab label, panel-attached strip. Both tabs view
 // the same `domains` list.
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { Alert, Button, Card, Empty, Spin, Table, Tag, Tooltip, Typography } from "antd";
@@ -31,6 +32,7 @@ interface ZoneStatus {
 }
 
 const ZonesTab = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [zoneStatuses, setZoneStatuses] = useState<Map<string, ZoneStatus>>(
     new Map(),
@@ -84,7 +86,7 @@ const ZonesTab = () => {
   return (
     <>
       <Alert
-        title="DNS zones are provisioned automatically when a domain is created. Nameservers are configured in Server Settings."
+        title={t("userdnszonesoverviewpage.dns_zones_are_provisioned_automatically_when")}
         type="info"
         showIcon
         style={{ marginBottom: 16 }}
@@ -92,7 +94,7 @@ const ZonesTab = () => {
       {query.isLoading ? (
         <Spin />
       ) : query.items.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No domains found" />
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdnszonesoverviewpage.no_domains_found")} />
       ) : (
         <SearchableTableStringQ<Domain>
           rowKey="id"
@@ -110,7 +112,7 @@ const ZonesTab = () => {
         >
           <Table.Column<Domain>
             dataIndex="name"
-            title="Domain Name"
+            title={t("userdnszonesoverviewpage.domain_name")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -121,11 +123,11 @@ const ZonesTab = () => {
             })}
           />
           <Table.Column<Domain>
-            title="Zone Status"
+            title={t("userdnszonesoverviewpage.zone_status")}
             render={(_, record) => getZoneStatusTag(record.id)}
           />
           <Table.Column<Domain>
-            title="Records"
+            title={t("userdnszonesoverviewpage.records")}
             render={(_, record) => {
               const s = zoneStatuses.get(record.id);
               if (s === undefined) return <Spin size="small" />;
@@ -133,7 +135,7 @@ const ZonesTab = () => {
             }}
           />
           <Table.Column<Domain>
-            title="TTL"
+            title={t("userdnszonesoverviewpage.ttl")}
             render={(_, record) => {
               const s = zoneStatuses.get(record.id);
               if (s === undefined) return <Spin size="small" />;
@@ -141,18 +143,18 @@ const ZonesTab = () => {
             }}
           />
           <Table.Column<Domain>
-            title="DNSSEC"
+            title={t("userdnszonesoverviewpage.dnssec")}
             dataIndex="dnssec_enabled"
             render={(enabled: boolean | undefined) =>
               enabled ? <Tag color="green">Signed</Tag> : <Tag>Unsigned</Tag>
             }
           />
           <Table.Column<Domain>
-            title="Expiration"
+            title={t("userdnszonesoverviewpage.expiration")}
             dataIndex="registrar_expires_at"
             render={(d: string | null | undefined) =>
               d ? (
-                <Tooltip title="Domain registration expiry (from WHOIS)">
+                <Tooltip title={t("userdnszonesoverviewpage.domain_registration_expiry_from_whois")}>
                   {new Date(d).toLocaleDateString()}
                 </Tooltip>
               ) : (
@@ -161,7 +163,7 @@ const ZonesTab = () => {
             }
           />
           <Table.Column<Domain>
-            title="Actions"
+            title={t("userdnszonesoverviewpage.actions")}
             render={(_, record) => (
               <Button
                 type="primary"

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -3,6 +3,7 @@
 // table of your installs with start/stop/restart/delete. Degrades to a clear
 // "not enabled on this server" notice when the host has no userns-remap (the
 // backend 403s docker_tenant_not_enabled).
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
@@ -68,6 +69,7 @@ const statusColor = (s: InstalledApp["status"]) =>
         : "default";
 
 export const UserDockerAppsPage = () => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [installFor, setInstallFor] = useState<CatalogEntry | null>(null);
   const [logsFor, setLogsFor] = useState<InstalledApp | null>(null);
@@ -136,8 +138,8 @@ export const UserDockerAppsPage = () => {
         <Alert
           type="info"
           showIcon
-          message="Docker apps are not enabled on this server"
-          description="Ask your administrator to enable tenant Docker apps for your hosting package."
+          message={t("userdockerappspage.docker_apps_are_not_enabled_on_this_server")}
+          description={t("userdockerappspage.ask_your_administrator_to_enable_tenant_dock")}
         />
       </div>
     );
@@ -154,8 +156,8 @@ export const UserDockerAppsPage = () => {
           type="warning"
           showIcon
           style={{ marginBottom: 16 }}
-          message="Docker apps are over your disk quota"
-          description="Your installed apps exceed your package disk allowance. Delete an app or ask your administrator to raise the quota."
+          message={t("userdockerappspage.docker_apps_are_over_your_disk_quota")}
+          description={t("userdockerappspage.your_installed_apps_exceed_your_package_disk")}
         />
       )}
       <Tabs
@@ -171,14 +173,14 @@ export const UserDockerAppsPage = () => {
                   <Col xs={24} sm={12} lg={6}>
                     <StatCard
                       iconBg="rgba(207, 19, 34, 0.12)" iconColor="#cf1322" Icon={AppstoreOutlined}
-                      label="Installed Apps" value={installedCount}
+                      label={t("userdockerappspage.installed_apps")} value={installedCount}
                       subtitle={<Typography.Text type="secondary">{catalogCount} in catalog</Typography.Text>}
                     />
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <StatCard
                       iconBg="rgba(114, 46, 209, 0.12)" iconColor="#722ed1" Icon={SyncOutlined}
-                      label="Updates Available" value={updateCount}
+                      label={t("userdockerappspage.updates_available")} value={updateCount}
                       subtitle={updateCount > 0
                         ? <Typography.Text type="warning">Needs attention</Typography.Text>
                         : <Typography.Text type="secondary">Up to date</Typography.Text>}
@@ -187,21 +189,21 @@ export const UserDockerAppsPage = () => {
                   <Col xs={24} sm={12} lg={6}>
                     <StatCard
                       iconBg="rgba(63, 134, 0, 0.12)" iconColor="#3f8600" Icon={PlayCircleOutlined}
-                      label="Running" value={runningCount}
+                      label={t("userdockerappspage.running")} value={runningCount}
                       subtitle={<Typography.Text type="secondary">{pct(runningCount)}% of installed</Typography.Text>}
                     />
                   </Col>
                   <Col xs={24} sm={12} lg={6}>
                     <StatCard
                       iconBg="rgba(212, 107, 8, 0.12)" iconColor="#d46b08" Icon={PauseCircleOutlined}
-                      label="Stopped" value={stoppedCount}
+                      label={t("userdockerappspage.stopped")} value={stoppedCount}
                       subtitle={<Typography.Text type="secondary">{pct(stoppedCount)}% of installed</Typography.Text>}
                     />
                   </Col>
                 </Row>
                 <Input.Search
                   allowClear
-                  placeholder="Search by name"
+                  placeholder={t("userdockerappspage.search_by_name")}
                   value={installedSearch}
                   onChange={(e) => setInstalledSearch(e.target.value)}
                   style={{ marginBottom: 16, maxWidth: 360 }}
@@ -226,7 +228,7 @@ export const UserDockerAppsPage = () => {
                   }}
                   locale={{
                     emptyText: (
-                      <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No installed apps yet">
+                      <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdockerappspage.no_installed_apps_yet")}>
                         <Button type="primary" onClick={() => setTab("catalog")}>
                           Browse Catalog
                         </Button>

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,5 +1,6 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
+import { useTranslation } from "react-i18next";
 import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space, message } from "antd";
 import { useEffect } from "react";
 
@@ -21,6 +22,7 @@ export interface UserDomainDrawerProps {
 }
 
 export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<UserDomainCreateInput>();
   const mailProvider = Form.useWatch("mail_provider", form) ?? "jabali";
   const screens = Grid.useBreakpoint();
@@ -46,7 +48,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
 
   return (
     <Drawer
-      title="Add domain"
+      title={t("userdomaindrawer.add_domain")}
       open={open}
       onClose={onClose}
       width={isDesktop ? 480 : undefined}
@@ -55,7 +57,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
     >
       <Form<UserDomainCreateInput> form={form} layout="vertical" onFinish={handleFinish}>
         <Form.Item
-          label="Domain Name"
+          label={t("userdomaindrawer.domain_name")}
           name="name"
           rules={[
             { required: true, message: "Domain name is required" },
@@ -70,10 +72,10 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         </Form.Item>
 
         <Form.Item
-          label="Mail"
+          label={t("userdomaindrawer.mail")}
           name="mail_provider"
           initialValue="jabali"
-          tooltip="Where this domain's email is hosted. 'None' and the external providers skip Jabali's mail DNS records and mail certificate SANs."
+          tooltip={t("userdomaindrawer.where_this_domain_s_email_is_hosted_none_and")}
         >
           <Select
             options={[
@@ -87,9 +89,9 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
 
         {mailProvider === "m365" && (
           <Form.Item
-            label="Microsoft 365 tenant"
+            label={t("userdomaindrawer.microsoft_365_tenant")}
             name="m365_onmicrosoft"
-            tooltip="Optional. Your <tenant>.onmicrosoft.com — adds the selector1/2 DKIM CNAMEs. MX/SPF/autodiscover are added automatically."
+            tooltip={t("userdomaindrawer.optional_your_tenant_onmicrosoft_com_adds_th")}
           >
             <Input placeholder="contoso.onmicrosoft.com (optional)" />
           </Form.Item>
@@ -97,19 +99,19 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
 
         {mailProvider === "google" && (
           <Form.Item
-            label="Google DKIM value"
+            label={t("userdomaindrawer.google_dkim_value")}
             name="google_dkim"
-            tooltip="Optional. Paste the google._domainkey TXT value from Google Admin. MX/SPF are added automatically."
+            tooltip={t("userdomaindrawer.optional_paste_the_google_domainkey_txt_valu")}
           >
             <Input.TextArea rows={2} placeholder="v=DKIM1; k=rsa; p=... (optional)" />
           </Form.Item>
         )}
 
         <Form.Item
-          label="TLS certificate"
+          label={t("userdomaindrawer.tls_certificate")}
           name="ssl_mode"
           initialValue="le"
-          tooltip="Let's Encrypt issues a free trusted certificate automatically (recommended). Self-signed works without DNS/ACME but browsers warn. None serves over HTTP only."
+          tooltip={t("userdomaindrawer.let_s_encrypt_issues_a_free_trusted_certific")}
         >
           <Select
             options={[
@@ -124,7 +126,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
           name="create_www"
           valuePropName="checked"
           initialValue={false}
-          tooltip="Adds a www CNAME pointing at the domain apex. Off by default — leave unchecked for subdomains or domains that don't serve a www host."
+          tooltip={t("userdomaindrawer.adds_a_www_cname_pointing_at_the_domain_apex")}
         >
           <Checkbox>Create www record</Checkbox>
         </Form.Item>

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -2,6 +2,7 @@
 // strip as the admin list (DNS/Redirects/Index/Settings/Toggle/Delete)
 // minus the Edit button (users edit per-domain config via the row
 // buttons rather than a full edit page).
+import { useTranslation } from "react-i18next";
 import {
   PlusSquareOutlined,
   GlobalOutlined,
@@ -174,6 +175,7 @@ export type Domain = {
 type ActiveModal = { domainId: string; type: "redirects" | "index" | "directory-privacy" | "caching" | "nginx-options" | "rewrite-rules" } | null;
 
 export const UserDomainList = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
   const [activeModal, setActiveModal] = useState<ActiveModal>(null);
@@ -248,7 +250,7 @@ export const UserDomainList = () => {
         >
           <Table.Column<Domain>
             dataIndex="name"
-            title="Domain"
+            title={t("userdomainlist.domain")}
             key="name"
             sorter={{ multiple: 1 }}
             defaultSortOrder="ascend"
@@ -263,7 +265,7 @@ export const UserDomainList = () => {
           />
           <Table.Column<Domain>
             dataIndex="is_enabled"
-            title="Status"
+            title={t("userdomainlist.status")}
             render={(enabled: boolean) =>
               enabled ? (
                 <Tag color="green">active</Tag>
@@ -274,22 +276,22 @@ export const UserDomainList = () => {
           />
           <Table.Column<Domain>
             dataIndex="ssl_state"
-            title="SSL"
+            title={t("userdomainlist.ssl")}
             render={(state?: string) => (
               <Tag color={getSSLTagColor(state)}>{getSSLTagLabel(state)}</Tag>
             )}
           />
           <Table.Column<Domain>
-            title="Redirect"
+            title={t("userdomainlist.redirect")}
             render={(_, record) => renderRedirect(record)}
           />
           <Table.Column<Domain>
             dataIndex="bytes_30d"
-            title="BW (30d)"
+            title={t("userdomainlist.bw_30d")}
             render={(v: number | undefined) => humanBytes(v ?? 0)}
           />
           <Table.Column<Domain>
-            title="Actions"
+            title={t("userdomainlist.actions")}
             dataIndex="actions"
             render={(_, r) => (
               <>
@@ -390,7 +392,7 @@ export const UserDomainList = () => {
                     ],
                   }}
                 >
-                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label="More actions" />
+                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label={t("userdomainlist.more_actions")} />
                 </Dropdown>
                 </Space>
                 {activeModal?.domainId === r.id && activeModal.type === "redirects" && (

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -15,6 +15,7 @@
 //
 // Scope: still no multi-select, no chmod, no image preview, no editor —
 // those remain Phase 2.
+import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
@@ -308,6 +309,7 @@ function makeTreeNode(path: string, name: string): TreeNode {
 }
 
 export const FileManagerPage = () => {
+  const { t } = useTranslation();
   // Pull live theme tokens so the bulk-action bar (and any other
   // tinted surface here) tracks the global light/dark palette — we had
   // hard-coded #f0f5ff / #adc6ff / dim text before and those only
@@ -1339,7 +1341,7 @@ export const FileManagerPage = () => {
         onClose={() => setTreeDrawerOpen(false)}
         placement="left"
         width={280}
-        title="Folders"
+        title={t("filemanagerpage.folders")}
         styles={{ body: { padding: 8, background: token.colorBgContainer } }}
       >
         <Tree
@@ -1479,7 +1481,7 @@ export const FileManagerPage = () => {
               columns={columns as never}
               pagination={false}
               scroll={{ x: "max-content" }}
-              locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Empty directory" /> }}
+              locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("filemanagerpage.empty_directory")} /> }}
               // Row drag-to-move: any row is draggable; folders are drop
               // targets. `dragPathMime` carries the list of paths being
               // dragged (array, JSON-encoded). If the dragged row is part
@@ -1565,11 +1567,11 @@ export const FileManagerPage = () => {
       )}
 
       <Modal
-        title="New Folder"
+        title={t("filemanagerpage.new_folder")}
         open={mkdirOpen}
         onOk={() => void submitMkdir()}
         onCancel={() => setMkdirOpen(false)}
-        okText="Create"
+        okText={t("filemanagerpage.create")}
       >
         <Input
           value={mkdirName}
@@ -1581,11 +1583,11 @@ export const FileManagerPage = () => {
       </Modal>
 
       <Modal
-        title="New File"
+        title={t("filemanagerpage.new_file")}
         open={newFileOpen}
         onOk={() => void submitNewFile()}
         onCancel={() => setNewFileOpen(false)}
-        okText="Create"
+        okText={t("filemanagerpage.create")}
       >
         <Input
           value={newFileName}
@@ -1601,7 +1603,7 @@ export const FileManagerPage = () => {
         open={renameOpen}
         onOk={() => void submitRename()}
         onCancel={() => setRenameOpen(false)}
-        okText="Rename"
+        okText={t("filemanagerpage.rename")}
       >
         <Input
           value={renameNewName}
@@ -1654,7 +1656,7 @@ export const FileManagerPage = () => {
           setBulkMoveOpen(false);
           setBulkMoveDest("");
         }}
-        okText="Move"
+        okText={t("filemanagerpage.move")}
         okButtonProps={{ disabled: !bulkMoveDest }}
       >
         <p style={{ marginBottom: 8 }}>Pick a destination folder:</p>
@@ -1710,7 +1712,7 @@ export const FileManagerPage = () => {
         open={bulkChmodOpen}
         onOk={() => void handleBulkChmod()}
         onCancel={() => setBulkChmodOpen(false)}
-        okText="Apply"
+        okText={t("filemanagerpage.apply")}
       >
         <ChmodEditor value={bulkChmodMode} onChange={setBulkChmodMode} />
       </Modal>
@@ -1720,7 +1722,7 @@ export const FileManagerPage = () => {
         open={!!chmodTarget}
         onOk={() => void submitSingleChmod()}
         onCancel={() => setChmodTarget(null)}
-        okText="Apply"
+        okText={t("filemanagerpage.apply")}
       >
         <ChmodEditor value={chmodTargetMode} onChange={setChmodTargetMode} />
       </Modal>
@@ -1730,7 +1732,7 @@ export const FileManagerPage = () => {
         open={!!editTarget}
         onOk={() => void submitEdit()}
         onCancel={() => setEditTarget(null)}
-        okText="Save"
+        okText={t("filemanagerpage.save")}
         okButtonProps={{ loading: editSaving, disabled: editContent === editOriginal }}
         width="min(1100px, 95vw)"
       >

--- a/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
+++ b/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
@@ -2,6 +2,7 @@
 // editor. GH #240: autoresponders moved out of their own tab and into the
 // Mailboxes list, edited inline per mailbox. Renamed "Automatic Replies"
 // to match the Microsoft 365 wording.
+import { useTranslation } from "react-i18next";
 import { useEffect } from "react";
 import {
   Button,
@@ -45,6 +46,7 @@ export const AutoReplyModal = ({
   current,
   onClose,
 }: AutoReplyModalProps) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<FormValues>();
   const updateMut = useUpdateAutoresponder();
   const deleteMut = useDeleteAutoresponder();
@@ -109,7 +111,7 @@ export const AutoReplyModal = ({
       title={`Automatic replies: ${email}`}
       onCancel={onClose}
       onOk={submit}
-      okText="Save"
+      okText={t("autoreplymodal.save")}
       confirmLoading={updateMut.isPending}
       destroyOnClose
       width={640}
@@ -119,7 +121,7 @@ export const AutoReplyModal = ({
             key="off"
             title={`Turn off automatic replies for ${email}?`}
             onConfirm={turnOff}
-            okText="Turn off"
+            okText={t("autoreplymodal.turn_off")}
             okButtonProps={{ danger: true }}
           >
             <Button danger loading={deleteMut.isPending} style={{ float: "left" }}>
@@ -141,19 +143,19 @@ export const AutoReplyModal = ({
       ]}
     >
       <Form form={form} layout="vertical" preserve={false}>
-        <Form.Item name="enabled" label="Send automatic replies" valuePropName="checked">
+        <Form.Item name="enabled" label={t("autoreplymodal.send_automatic_replies")} valuePropName="checked">
           <Switch />
         </Form.Item>
-        <Form.Item name="date_range" label="Active dates (optional)">
+        <Form.Item name="date_range" label={t("autoreplymodal.active_dates_optional")}>
           <DatePicker.RangePicker showTime style={{ width: "100%" }} />
         </Form.Item>
-        <Form.Item name="subject" label="Subject">
-          <Input placeholder="Out of office" maxLength={200} />
+        <Form.Item name="subject" label={t("autoreplymodal.subject")}>
+          <Input placeholder={t("autoreplymodal.out_of_office")} maxLength={200} />
         </Form.Item>
-        <Form.Item name="text_body" label="Plain text body">
-          <Input.TextArea rows={4} placeholder="I'm away until..." />
+        <Form.Item name="text_body" label={t("autoreplymodal.plain_text_body")}>
+          <Input.TextArea rows={4} placeholder={t("autoreplymodal.i_m_away_until")} />
         </Form.Item>
-        <Form.Item name="html_body" label="HTML body (optional)">
+        <Form.Item name="html_body" label={t("autoreplymodal.html_body_optional")}>
           <Input.TextArea rows={4} placeholder="<p>I'm away until...</p>" />
         </Form.Item>
       </Form>

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
@@ -10,6 +10,7 @@
 // The modal calls POST /domains/:id/mailboxes on submit and surfaces
 // the reveal-once password via the onCreated callback — the parent
 // page pops the DatabaseUserPasswordModal with it.
+import { useTranslation } from "react-i18next";
 import { Alert, Button, Checkbox, Drawer, Form, Grid, Input, InputNumber, Select, Space } from "antd";
 
 import { PasswordInput } from "../../../components/PasswordInput";
@@ -60,6 +61,7 @@ export const CreateMailboxWizardModal = ({
   onCancel,
   onCreated,
 }: Props) => {
+  const { t } = useTranslation();
   const [form] = Form.useForm<FormValues>();
   const createMutation = useCreateMailbox();
   const screens = Grid.useBreakpoint();
@@ -157,7 +159,7 @@ export const CreateMailboxWizardModal = ({
 
   return (
     <Drawer
-      title="Create mailbox"
+      title={t("createmailboxwizardmodal.create_mailbox")}
       open={open}
       onClose={onCancelInternal}
       width={isDesktop ? 520 : undefined}
@@ -178,15 +180,15 @@ export const CreateMailboxWizardModal = ({
         initialValues={{ quota_mib: QUOTA_DEFAULT_BYTES / 1024 / 1024 }}
       >
         <Form.Item
-          label="Domain"
+          label={t("createmailboxwizardmodal.domain")}
           name="domain_id"
           rules={[{ required: true, message: "Pick a domain" }]}
-          tooltip="Only domains with email enabled appear here."
+          tooltip={t("createmailboxwizardmodal.only_domains_with_email_enabled_appear_here")}
         >
           <Select
             showSearch
             optionFilterProp="label"
-            placeholder="Select a domain"
+            placeholder={t("createmailboxwizardmodal.select_a_domain")}
             options={domains.map((d) => ({ value: d.id, label: d.name }))}
           />
         </Form.Item>
@@ -194,7 +196,7 @@ export const CreateMailboxWizardModal = ({
         {chosenDomain && (
           <>
             <Form.Item
-              label="Email address"
+              label={t("createmailboxwizardmodal.email_address")}
               name="local_part"
               rules={[
                 { required: true, message: "Required" },
@@ -214,17 +216,17 @@ export const CreateMailboxWizardModal = ({
             </Form.Item>
 
             <Form.Item
-              label="Display name"
+              label={t("createmailboxwizardmodal.display_name")}
               name="display_name"
-              tooltip="Shown as the sender name in webmail and outgoing mail (e.g. Alice Smith). Optional."
+              tooltip={t("createmailboxwizardmodal.shown_as_the_sender_name_in_webmail_and_outg")}
             >
-              <Input placeholder="Alice Smith" autoComplete="off" maxLength={255} />
+              <Input placeholder={t("createmailboxwizardmodal.alice_smith")} autoComplete="off" maxLength={255} />
             </Form.Item>
 
             <Form.Item
-              label="Password"
+              label={t("createmailboxwizardmodal.password")}
               name="password"
-              tooltip="Leave blank to auto-generate. Generated passwords are shown exactly once."
+              tooltip={t("createmailboxwizardmodal.leave_blank_to_auto_generate_generated_passw")}
               rules={[{ min: 8, message: "8 characters minimum" }]}
             >
               <PasswordInput
@@ -234,7 +236,7 @@ export const CreateMailboxWizardModal = ({
             </Form.Item>
 
             <Form.Item
-              label="Quota (MiB)"
+              label={t("createmailboxwizardmodal.quota_mib")}
               name="quota_mib"
               tooltip={`Default ${QUOTA_DEFAULT_BYTES / 1024 / 1024} MiB. Minimum ${
                 QUOTA_MIN_BYTES / 1024 / 1024
@@ -251,21 +253,21 @@ export const CreateMailboxWizardModal = ({
             <Form.Item
               name="send_only"
               valuePropName="checked"
-              tooltip="A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials, so each system has its own account to revoke or rotate."
+              tooltip={t("createmailboxwizardmodal.a_send_only_mailbox_can_authenticate_for_smt")}
             >
               <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
             </Form.Item>
 
             {domainGroups && domainGroups.length > 0 && (
               <Form.Item
-                label="Add to groups"
+                label={t("createmailboxwizardmodal.add_to_groups")}
                 name="group_ids"
-                tooltip="The mailbox joins these groups and gains their shared mailbox, calendar, address book and files."
+                tooltip={t("createmailboxwizardmodal.the_mailbox_joins_these_groups_and_gains_the")}
               >
                 <Select
                   mode="multiple"
                   allowClear
-                  placeholder="Select groups (optional)"
+                  placeholder={t("createmailboxwizardmodal.select_groups_optional")}
                   optionFilterProp="label"
                   options={domainGroups.map((g) => ({ value: g.id, label: g.display_name || g.email }))}
                 />
@@ -273,9 +275,9 @@ export const CreateMailboxWizardModal = ({
             )}
 
             <Form.Item
-              label="Aliases (optional)"
+              label={t("createmailboxwizardmodal.aliases_optional")}
               name="aliases"
-              tooltip="Extra addresses that deliver to this mailbox. One local-part per line or comma-separated — e.g. sales, info."
+              tooltip={t("createmailboxwizardmodal.extra_addresses_that_deliver_to_this_mailbox")}
             >
               <Input.TextArea
                 rows={2}
@@ -284,9 +286,9 @@ export const CreateMailboxWizardModal = ({
               />
             </Form.Item>
             <Form.Item
-              label="Forward to (optional)"
+              label={t("createmailboxwizardmodal.forward_to_optional")}
               name="forward_target"
-              tooltip="Redirect a copy of incoming mail to an external address."
+              tooltip={t("createmailboxwizardmodal.redirect_a_copy_of_incoming_mail_to_an_exter")}
               rules={[{ type: "email", message: "Must be a valid email" }]}
             >
               <Input placeholder="external@example.com" autoComplete="off" />
@@ -301,8 +303,8 @@ export const CreateMailboxWizardModal = ({
           <Alert
             type="warning"
             showIcon
-            message="No email-enabled domains"
-            description="Enable email on at least one domain before creating a mailbox."
+            message={t("createmailboxwizardmodal.no_email_enabled_domains")}
+            description={t("createmailboxwizardmodal.enable_email_on_at_least_one_domain_before_c")}
           />
         )}
       </Form>

--- a/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
@@ -3,6 +3,7 @@
 // Lists all email-enabled domains + their catch-all target (if any).
 // Create/edit dialog: pick domain, enter target mailbox email.
 
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -40,6 +41,7 @@ interface CatchAllRow {
 }
 
 export const CatchAllTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -122,7 +124,7 @@ export const CatchAllTab = () => {
   }
 
   if (emailEnabledDomains.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No email-enabled domains yet" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("catchalltab.no_email_enabled_domains_yet")} />;
   }
 
   // Build the mailbox options; preserve a current target that isn't in
@@ -222,18 +224,18 @@ export const CatchAllTab = () => {
         title={editing ? `Catch-all: ${editing.domain_name}` : "Set catch-all"}
         onCancel={() => setEditOpen(false)}
         onOk={submit}
-        okText="Save"
+        okText={t("catchalltab.save")}
         confirmLoading={updateMut.isPending}
         destroyOnClose
       >
         <Form form={form} layout="vertical" preserve={false}>
           <Form.Item
             name="domain_id"
-            label="Domain"
+            label={t("catchalltab.domain")}
             rules={[{ required: true, message: "Select a domain" }]}
           >
             <Select
-              placeholder="Select email-enabled domain"
+              placeholder={t("catchalltab.select_email_enabled_domain")}
               disabled={!!editing}
               onChange={() => form.setFieldValue("target", undefined)}
               options={emailEnabledDomains.map((d) => ({ label: d.name, value: d.id }))}
@@ -241,7 +243,7 @@ export const CatchAllTab = () => {
           </Form.Item>
           <Form.Item
             name="target"
-            label="Target mailbox"
+            label={t("catchalltab.target_mailbox")}
             rules={[{ required: true, message: "Select a target mailbox" }]}
             extra="Mail sent to unknown addresses at this domain is delivered to this mailbox."
           >

--- a/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
@@ -1,6 +1,7 @@
 // DisclaimerTab — M6.5 Step 6. Per-domain outbound disclaimer.
 // Mockup: row click → modal with Enable toggle + Disclaimer Text TextArea + Save/Cancel.
 
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -32,6 +33,7 @@ interface FormValues {
 }
 
 export const DisclaimerTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -82,7 +84,7 @@ export const DisclaimerTab = () => {
 
   if (loadingDomains && domains.length === 0) return <Skeleton active paragraph={{ rows: 4 }} />;
   if (emailEnabled.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No email-enabled domains" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("disclaimertab.no_email_enabled_domains")} />;
   }
 
   return (
@@ -128,7 +130,7 @@ export const DisclaimerTab = () => {
               title: "Actions",
               width: 100,
               render: (_, row) => (
-                <Tooltip title="Edit">
+                <Tooltip title={t("disclaimertab.edit")}>
                   <Button type="text" icon={<EditOutlined />} onClick={() => openEdit(row)} />
                 </Tooltip>
               ),
@@ -148,18 +150,18 @@ export const DisclaimerTab = () => {
         }
         onCancel={() => setOpen(false)}
         onOk={submit}
-        okText="Save"
+        okText={t("disclaimertab.save")}
         confirmLoading={updateMut.isPending}
         destroyOnClose
         width={640}
       >
         <Form form={form} layout="vertical" preserve={false}>
-          <Form.Item name="enabled" label="Enable Disclaimer" valuePropName="checked" extra="Append a disclaimer to all outbound emails from this domain">
+          <Form.Item name="enabled" label={t("disclaimertab.enable_disclaimer")} valuePropName="checked" extra="Append a disclaimer to all outbound emails from this domain">
             <Switch />
           </Form.Item>
           <Form.Item
             name="text"
-            label="Disclaimer Text"
+            label={t("disclaimertab.disclaimer_text")}
             rules={[
               ({ getFieldValue }) => ({
                 validator(_, value) {
@@ -172,7 +174,7 @@ export const DisclaimerTab = () => {
             ]}
             extra="This text will be appended to every outgoing email"
           >
-            <Input.TextArea rows={5} placeholder="If you received this email by mistake, please notify the sender and delete it." />
+            <Input.TextArea rows={5} placeholder={t("disclaimertab.if_you_received_this_email_by_mistake_please")} />
           </Form.Item>
         </Form>
       </Modal>

--- a/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
@@ -1,5 +1,6 @@
 // ForwardersTab — M6.5 Step 5. Two-flavor forwarders (alias + external).
 
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -48,6 +49,7 @@ interface FormValues {
 }
 
 export const ForwardersTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -122,7 +124,7 @@ export const ForwardersTab = () => {
     return <Skeleton active paragraph={{ rows: 4 }} />;
   }
   if (mailboxes.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Create mailboxes first" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("forwarderstab.create_mailboxes_first")} />;
   }
 
   return (
@@ -178,7 +180,7 @@ export const ForwardersTab = () => {
               width: 80,
               render: (_, row) => (
                 <Popconfirm
-                  title="Remove forwarder?"
+                  title={t("forwarderstab.remove_forwarder")}
                   onConfirm={async () => {
                     try {
                       await deleteMut.mutateAsync(row.id);
@@ -189,10 +191,10 @@ export const ForwardersTab = () => {
                       message.error(msg);
                     }
                   }}
-                  okText="Remove"
+                  okText={t("forwarderstab.remove")}
                   okButtonProps={{ danger: true }}
                 >
-                  <Tooltip title="Remove">
+                  <Tooltip title={t("forwarderstab.remove")}>
                     <RowActionButton danger icon={<DeleteOutlined />}>Remove</RowActionButton>
                   </Tooltip>
                 </Popconfirm>
@@ -206,10 +208,10 @@ export const ForwardersTab = () => {
 
       <Modal
         open={open}
-        title="Add forwarder"
+        title={t("forwarderstab.add_forwarder")}
         onCancel={() => setOpen(false)}
         onOk={submit}
-        okText="Create"
+        okText={t("forwarderstab.create")}
         confirmLoading={createMut.isPending}
         destroyOnClose
         width={560}
@@ -220,7 +222,7 @@ export const ForwardersTab = () => {
           preserve={false}
           initialValues={{ type: "alias" }}
         >
-          <Form.Item name="type" label="Type" rules={[{ required: true }]}>
+          <Form.Item name="type" label={t("forwarderstab.type")} rules={[{ required: true }]}>
             <Radio.Group>
               <Radio value="alias">Alias (local-part → mailbox)</Radio>
               <Radio value="external">External (mailbox → outside email)</Radio>
@@ -233,7 +235,7 @@ export const ForwardersTab = () => {
             rules={[{ required: true }]}
           >
             <Select
-              placeholder="Select mailbox"
+              placeholder={t("forwarderstab.select_mailbox")}
               showSearch
               optionFilterProp="label"
               options={mailboxes.map((m) => ({ label: m.email, value: m.id }))}
@@ -243,7 +245,7 @@ export const ForwardersTab = () => {
           {type === "alias" && (
             <Form.Item
               name="local_part"
-              label="Alias local-part"
+              label={t("forwarderstab.alias_local_part")}
               rules={[{ required: true, pattern: /^[a-z0-9._-]+$/, message: "a-z 0-9 . _ -" }]}
               extra="Alias @ source-mailbox's domain. Mail to alias@domain delivers to the mailbox."
             >
@@ -254,7 +256,7 @@ export const ForwardersTab = () => {
           {type === "external" && (
             <Form.Item
               name="target"
-              label="External target"
+              label={t("forwarderstab.external_target")}
               rules={[{ required: true, type: "email", message: "Enter a valid email" }]}
               extra="Mail to the source mailbox is forwarded (copy kept) to this address."
             >

--- a/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/GroupsTab.tsx
@@ -1,6 +1,7 @@
 // GroupsTab — M51 mail groups (issue #201). Pick a mail-enabled domain,
 // create/edit groups (shared mailbox + calendar + address book + files),
 // manage membership, delete. Mirrors MailboxesTab styling.
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { RowActions } from "../../../../components/RowActions";
 import {
@@ -43,6 +44,7 @@ import {
 
 
 export function GroupsTab() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
 
   const { items: domains } = useListQuery<Domain>({
@@ -67,7 +69,7 @@ export function GroupsTab() {
     return (
       <Empty
         image={Empty.PRESENTED_IMAGE_SIMPLE}
-        description="Enable email on a domain first to create groups"
+        description={t("groupstab.enable_email_on_a_domain_first_to_create_gro")}
       />
     );
   }
@@ -108,7 +110,7 @@ export function GroupsTab() {
           onSearchChange={setSearch}
           pagination={{ pageSize: 25 }}
           locale={{
-            emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No groups" />,
+            emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("groupstab.no_groups")} />,
           }}
           columns={[
             {

--- a/panel-ui/src/shells/user/mail/tabs/LogsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/LogsTab.tsx
@@ -1,5 +1,6 @@
 // LogsTab — M6.5 Step 7. Read-only mail log viewer.
 
+import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import {
   Alert,
@@ -25,6 +26,7 @@ interface Filters {
 }
 
 export const LogsTab = () => {
+  const { t } = useTranslation();
   const [filters, setFilters] = useState<Filters>({});
   const [page, setPage] = useState(1);
   const [detailQid, setDetailQid] = useState<string | null>(null);
@@ -59,7 +61,7 @@ export const LogsTab = () => {
       <Space wrap style={{ marginBottom: 12 }}>
         <DatePicker
           showTime
-          placeholder="From"
+          placeholder={t("logstab.from")}
           value={filters.from}
           onChange={(v) => setFilters((f) => ({ ...f, from: v }))}
         />
@@ -70,14 +72,14 @@ export const LogsTab = () => {
           onChange={(v) => setFilters((f) => ({ ...f, to: v }))}
         />
         <Input
-          placeholder="Sender contains"
+          placeholder={t("logstab.sender_contains")}
           allowClear
           value={filters.sender ?? ""}
           onChange={(e) => setFilters((f) => ({ ...f, sender: e.target.value }))}
           style={{ width: 200 }}
         />
         <Input
-          placeholder="Recipient contains"
+          placeholder={t("logstab.recipient_contains")}
           allowClear
           value={filters.recipient ?? ""}
           onChange={(e) => setFilters((f) => ({ ...f, recipient: e.target.value }))}
@@ -88,8 +90,8 @@ export const LogsTab = () => {
       {error && (
         <Alert
           type="warning"
-          message="Mail logs unavailable"
-          description="The mail server's trace log isn't responding. Try again in a moment."
+          message={t("logstab.mail_logs_unavailable")}
+          description={t("logstab.the_mail_server_s_trace_log_isn_t_responding")}
           style={{ marginBottom: 12 }}
           showIcon
         />

--- a/panel-ui/src/shells/user/mail/tabs/MailLogDetailDrawer.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailLogDetailDrawer.tsx
@@ -5,6 +5,7 @@
 // STARTTLS → delivered / DSN with the remote server's response — which answers
 // "why didn't my mail arrive". Fetches GET /mail/logs/detail (scoped server-side
 // to the caller's domains).
+import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
 import { Drawer, Empty, Spin, Timeline, Typography, message } from "antd";
@@ -39,6 +40,7 @@ const dotColor = (ev: string): string => {
 };
 
 export const MailLogDetailDrawer = ({ queueId, open, onClose }: Props) => {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<DetailResponse | null>(null);
 
@@ -56,13 +58,13 @@ export const MailLogDetailDrawer = ({ queueId, open, onClose }: Props) => {
   }, [open, queueId]);
 
   return (
-    <Drawer title="Delivery trail" width={480} open={open} onClose={onClose} destroyOnClose>
+    <Drawer title={t("maillogdetaildrawer.delivery_trail")} width={480} open={open} onClose={onClose} destroyOnClose>
       {loading ? (
         <div style={{ textAlign: "center", padding: 48 }}>
           <Spin />
         </div>
       ) : !data || data.events.length === 0 ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No delivery trail found" />
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("maillogdetaildrawer.no_delivery_trail_found")} />
       ) : (
         <>
           <Typography.Paragraph style={{ marginBottom: 4 }}>

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -3,6 +3,7 @@
 // Lists mailboxes from all user domains in a single table. Extracted from
 // the original UserMailboxesPage. Merges results from per-domain list queries
 // client-side and provides password rotation, SSO mint, and delete actions.
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -61,6 +62,7 @@ function formatBytes(n: number): string {
 }
 
 export const MailboxesTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -267,7 +269,7 @@ export const MailboxesTab = () => {
   }
 
   if (rows.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No mailboxes yet" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("mailboxestab.no_mailboxes_yet")} />;
   }
 
   return (
@@ -281,7 +283,7 @@ export const MailboxesTab = () => {
         initialSearch={search}
         onSearchChange={setSearch}
         pagination={{ pageSize: 20 }}
-        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No mailboxes" /> }}
+        locale={{ emptyText: <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("mailboxestab.no_mailboxes")} /> }}
         columns={[
           {
             title: "Mailbox",
@@ -380,7 +382,7 @@ export const MailboxesTab = () => {
                   <Button
                     type="text"
                     icon={<ClockCircleOutlined style={{ color: "#52c41a" }} />}
-                    aria-label="Automatic replies active"
+                    aria-label={t("mailboxestab.automatic_replies_active")}
                     onClick={() => setArTarget(record)}
                   />
                 </Tooltip>
@@ -503,7 +505,7 @@ export const MailboxesTab = () => {
       <Modal
         open={resetTarget !== null}
         title={resetTarget ? `Reset password — ${resetTarget.email}` : "Reset password"}
-        okText="Set password"
+        okText={t("mailboxestab.set_password")}
         confirmLoading={resetTarget ? rotatingId === resetTarget.id : false}
         onOk={submitReset}
         onCancel={() => setResetTarget(null)}
@@ -511,9 +513,9 @@ export const MailboxesTab = () => {
       >
         <Form form={resetForm} layout="vertical" requiredMark={false}>
           <Form.Item
-            label="New password"
+            label={t("mailboxestab.new_password")}
             name="password"
-            tooltip="Leave blank to auto-generate. Auto-generated passwords are shown exactly once."
+            tooltip={t("mailboxestab.leave_blank_to_auto_generate_auto_generated")}
           >
             <PasswordInput
               autoComplete="new-password"

--- a/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
@@ -1,5 +1,6 @@
 // SharedFoldersTab — M6.5 Step 4. Cross-mailbox ACL sharing via Mailbox.shareWith.
 
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -56,6 +57,7 @@ interface FormValues {
 }
 
 export const SharedFoldersTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -125,7 +127,7 @@ export const SharedFoldersTab = () => {
   }
 
   if (mailboxes.length === 0) {
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Create mailboxes first" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("sharedfolderstab.create_mailboxes_first")} />;
   }
 
   return (
@@ -189,7 +191,7 @@ export const SharedFoldersTab = () => {
               width: 80,
               render: (_, row) => (
                 <Popconfirm
-                  title="Remove share?"
+                  title={t("sharedfolderstab.remove_share")}
                   onConfirm={async () => {
                     try {
                       await deleteMut.mutateAsync({
@@ -203,10 +205,10 @@ export const SharedFoldersTab = () => {
                       message.error(msg);
                     }
                   }}
-                  okText="Remove"
+                  okText={t("sharedfolderstab.remove")}
                   okButtonProps={{ danger: true }}
                 >
-                  <Tooltip title="Remove">
+                  <Tooltip title={t("sharedfolderstab.remove")}>
                     <RowActionButton danger icon={<DeleteOutlined />}>Remove</RowActionButton>
                   </Tooltip>
                 </Popconfirm>
@@ -218,10 +220,10 @@ export const SharedFoldersTab = () => {
 
       <Modal
         open={open}
-        title="Share folder"
+        title={t("sharedfolderstab.share_folder")}
         onCancel={() => setOpen(false)}
         onOk={submit}
-        okText="Share"
+        okText={t("sharedfolderstab.share")}
         confirmLoading={createMut.isPending}
         destroyOnClose
         width={560}
@@ -229,11 +231,11 @@ export const SharedFoldersTab = () => {
         <Form form={form} layout="vertical" preserve={false}>
           <Form.Item
             name="owner_mailbox_id"
-            label="Source mailbox (owner)"
+            label={t("sharedfolderstab.source_mailbox_owner")}
             rules={[{ required: true }]}
           >
             <Select
-              placeholder="Select owner mailbox"
+              placeholder={t("sharedfolderstab.select_owner_mailbox")}
               showSearch
               optionFilterProp="label"
               options={mailboxes.map((m) => ({ label: m.email, value: m.id }))}
@@ -241,11 +243,11 @@ export const SharedFoldersTab = () => {
           </Form.Item>
           <Form.Item
             name="shared_with_mailbox_id"
-            label="Target mailbox (grantee)"
+            label={t("sharedfolderstab.target_mailbox_grantee")}
             rules={[{ required: true }]}
           >
             <Select
-              placeholder="Select target mailbox"
+              placeholder={t("sharedfolderstab.select_target_mailbox")}
               showSearch
               optionFilterProp="label"
               options={mailboxes.map((m) => ({ label: m.email, value: m.id }))}
@@ -253,7 +255,7 @@ export const SharedFoldersTab = () => {
           </Form.Item>
           <Form.Item
             name="rights"
-            label="Rights"
+            label={t("sharedfolderstab.rights")}
             initialValue={["mayRead"]}
             rules={[{ required: true, message: "Select at least one right" }]}
           >

--- a/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
@@ -2,6 +2,7 @@
 // address books, and file folders across the user's mail-enabled domains, and
 // assign them to mailboxes / groups via grants. The shared-mailbox kind (#241)
 // is intentionally not offered here yet — its send-as path is pending.
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import {
   Button,
@@ -55,6 +56,7 @@ const KIND_COLOR: Record<string, string> = {
 const OFFERED_KINDS: SharedResourceKind[] = ["calendar", "addressbook", "files"];
 
 export const SharedResourcesTab = () => {
+  const { t } = useTranslation();
   const { items: domains, isLoading: loadingDomains } = useListQuery<Domain>({
     resource: "domains",
     params: { page: 1, pageSize: 200, sort: "name", order: "asc" },
@@ -92,7 +94,7 @@ export const SharedResourcesTab = () => {
 
   if (loadingDomains && domains.length === 0) return <Skeleton active paragraph={{ rows: 4 }} />;
   if (mailDomains.length === 0)
-    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No email-enabled domains yet" />;
+    return <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("sharedresourcestab.no_email_enabled_domains_yet")} />;
 
   return (
     <>

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
@@ -4,6 +4,7 @@
 // if the package doesn't allow editing, the whole card renders a hint instead.
 // This replaces the old raw UserPHPPoolCard (removed in PR #34) with the
 // package-gated, preset-based model.
+import { useTranslation } from "react-i18next";
 import {
   Alert,
   Button,
@@ -35,6 +36,7 @@ export const UserPHPPerformanceCard = ({
 }: {
   versions: string[];
 }) => {
+  const { t } = useTranslation();
   const qc = useQueryClient();
   const [version, setVersion] = useState<string>(versions[0] ?? "");
   const [mode, setMode] = useState<string>("balanced");
@@ -52,8 +54,8 @@ export const UserPHPPerformanceCard = ({
       <Alert
         type="info"
         showIcon
-        message="PHP performance tuning isn't enabled on your plan."
-        description="Ask your provider to enable it on your hosting package."
+        message={t("userphpperformancecard.php_performance_tuning_isn_t_enabled_on_your")}
+        description={t("userphpperformancecard.ask_your_provider_to_enable_it_on_your_hosti")}
       />
     );
   }
@@ -90,7 +92,7 @@ export const UserPHPPerformanceCard = ({
   const cap = policy.max_children_cap;
 
   return (
-    <Card title="PHP Performance">
+    <Card title={t("userphpperformancecard.php_performance")}>
       <Space direction="vertical" size="large" style={{ width: "100%", maxWidth: 560 }}>
         <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
           Pick how your PHP workers scale. Values are capped for your plan (max{" "}
@@ -130,7 +132,7 @@ export const UserPHPPerformanceCard = ({
                 label: "Advanced (raw pm.* — clamped to your plan)",
                 children: (
                   <Form form={advForm} layout="vertical" initialValues={{ pm_mode: "dynamic", pm_max_children: Math.min(10, cap) }}>
-                    <Form.Item name="pm_mode" label="Process manager">
+                    <Form.Item name="pm_mode" label={t("userphpperformancecard.process_manager")}>
                       <Select
                         options={[
                           { value: "dynamic", label: "dynamic" },
@@ -142,16 +144,16 @@ export const UserPHPPerformanceCard = ({
                     <Form.Item name="pm_max_children" label={`Max children (≤ ${cap})`}>
                       <InputNumber min={1} max={cap} style={{ width: 160 }} />
                     </Form.Item>
-                    <Form.Item name="pm_start_servers" label="Start servers (dynamic)">
+                    <Form.Item name="pm_start_servers" label={t("userphpperformancecard.start_servers_dynamic")}>
                       <InputNumber min={1} max={cap} style={{ width: 160 }} />
                     </Form.Item>
-                    <Form.Item name="pm_min_spare_servers" label="Min spare (dynamic)">
+                    <Form.Item name="pm_min_spare_servers" label={t("userphpperformancecard.min_spare_dynamic")}>
                       <InputNumber min={1} max={cap} style={{ width: 160 }} />
                     </Form.Item>
-                    <Form.Item name="pm_max_spare_servers" label="Max spare (dynamic)">
+                    <Form.Item name="pm_max_spare_servers" label={t("userphpperformancecard.max_spare_dynamic")}>
                       <InputNumber min={1} max={cap} style={{ width: 160 }} />
                     </Form.Item>
-                    <Form.Item name="pm_max_requests" label="Max requests per worker (0 = never)">
+                    <Form.Item name="pm_max_requests" label={t("userphpperformancecard.max_requests_per_worker_0_never")}>
                       <InputNumber min={0} max={100000} style={{ width: 160 }} />
                     </Form.Item>
                     <Button loading={saving} onClick={applyAdvanced}>

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import {
   Tabs,
   Alert,
@@ -106,6 +107,7 @@ const MAX_INPUT_TIME_OPTIONS = [
 ];
 
 export function UserPHPSettingsPage() {
+  const { t } = useTranslation();
   const [, setMe] = useState<Identity | null>(null);
   const [domains, setDomains] = useState<Domain[]>([]);
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
@@ -288,8 +290,8 @@ export function UserPHPSettingsPage() {
         </Typography.Title>
 
         <Alert
-          title="Caution"
-          description="Changing PHP settings can affect your website performance and functionality. Incorrect values may cause errors or prevent your site from functioning properly. Changes apply after the next request to PHP."
+          title={t("userphpsettingspage.caution")}
+          description={t("userphpsettingspage.changing_php_settings_can_affect_your_websit")}
           type="warning"
           showIcon
         />
@@ -302,7 +304,7 @@ export function UserPHPSettingsPage() {
               label: "Version & Domains",
               children: (
                 <Space direction="vertical" size="large" style={{ width: "100%" }}>
-        <Card title="CLI / Terminal default PHP version" size="small">
+        <Card title={t("userphpsettingspage.cli_terminal_default_php_version")} size="small">
           <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
             Sets which PHP version a bare <code>php</code> (and composer / wp-cli)
             uses in your SSH/terminal sessions. This is separate from each
@@ -328,12 +330,12 @@ export function UserPHPSettingsPage() {
             onFinish={onSave}
           >
             <Form.Item
-              label="Domain"
+              label={t("userphpsettingspage.domain")}
               name="domain_id"
               rules={[{ required: true, message: "Please select a domain" }]}
             >
               <Select
-                placeholder="Select a domain"
+                placeholder={t("userphpsettingspage.select_a_domain")}
                 onChange={setSelectedDomain}
                 options={domains.map((d) => ({
                   label: d.name,
@@ -346,7 +348,7 @@ export function UserPHPSettingsPage() {
               {selectedDomain && phpSettings && (
                 <>
                   <Form.Item
-                    label="PHP Version"
+                    label={t("userphpsettingspage.php_version")}
                     extra="Applies to this domain only — each domain can run its own PHP version. EOL versions have no security patches; avoid them on public sites."
                   >
                     <Select
@@ -378,11 +380,11 @@ export function UserPHPSettingsPage() {
                   <Row gutter={[16, 16]}>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="Memory Limit"
+                        label={t("userphpsettingspage.memory_limit")}
                         name="php_memory_limit"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={MEMORY_LIMIT_OPTIONS}
                         />
@@ -390,11 +392,11 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="Upload Max File Size"
+                        label={t("userphpsettingspage.upload_max_file_size")}
                         name="php_upload_max_filesize"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={UPLOAD_MAX_OPTIONS}
                         />
@@ -402,11 +404,11 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="POST Max Size"
+                        label={t("userphpsettingspage.post_max_size")}
                         name="php_post_max_size"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={POST_MAX_OPTIONS}
                         />
@@ -414,11 +416,11 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="Max Input Variables"
+                        label={t("userphpsettingspage.max_input_variables")}
                         name="php_max_input_vars"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={MAX_INPUT_VARS_OPTIONS}
                         />
@@ -430,11 +432,11 @@ export function UserPHPSettingsPage() {
                   <Row gutter={[16, 16]}>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="Max Execution Time"
+                        label={t("userphpsettingspage.max_execution_time")}
                         name="php_max_execution_time"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={MAX_EXECUTION_TIME_OPTIONS}
                         />
@@ -442,11 +444,11 @@ export function UserPHPSettingsPage() {
                     </Col>
                     <Col xs={24} sm={12}>
                       <Form.Item
-                        label="Max Input Time"
+                        label={t("userphpsettingspage.max_input_time")}
                         name="php_max_input_time"
                       >
                         <Select
-                          placeholder="Use pool default"
+                          placeholder={t("userphpsettingspage.use_pool_default")}
                           allowClear
                           options={MAX_INPUT_TIME_OPTIONS}
                         />

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -1,6 +1,7 @@
 // Python Application Manager (ADR-0131 / GH #203) — user-shell page to
 // register and control native Python web apps. Hidden behind the
 // python_apps_enabled server setting; the API 403s when off.
+import { useTranslation } from "react-i18next";
 import {
   App,
   Button,
@@ -45,6 +46,7 @@ const STATUS_COLOR: Record<string, string> = {
 };
 
 export function PythonAppsPage() {
+  const { t } = useTranslation();
   const { message } = App.useApp();
   const apps = usePythonApps();
   const create = useCreatePythonApp();
@@ -177,9 +179,9 @@ export function PythonAppsPage() {
         loading={apps.isLoading}
         pagination={false}
       >
-        <Table.Column<PythonApp> title="Name" dataIndex="name" />
+        <Table.Column<PythonApp> title={t("pythonappspage.name")} dataIndex="name" />
         <Table.Column<PythonApp>
-          title="Domain"
+          title={t("pythonappspage.domain")}
           render={(_, r) => (
             <Typography.Text>
               {domainName.get(r.domain_id) ?? "—"}
@@ -190,7 +192,7 @@ export function PythonAppsPage() {
           )}
         />
         <Table.Column<PythonApp>
-          title="Runtime"
+          title={t("pythonappspage.runtime")}
           render={(_, r) => (
             <span>
               Python {r.python_version}{" "}
@@ -199,7 +201,7 @@ export function PythonAppsPage() {
           )}
         />
         <Table.Column<PythonApp>
-          title="Status"
+          title={t("pythonappspage.status")}
           render={(_, r) => {
             const tag = <Tag color={STATUS_COLOR[r.status] ?? "default"}>{r.status}</Tag>;
             // GH #357: a failed app used to show just "failed" with no reason
@@ -296,25 +298,25 @@ export function PythonAppsPage() {
         open={createOpen}
         onCancel={() => setCreateOpen(false)}
         onOk={() => void submit()}
-        okText="Create"
+        okText={t("pythonappspage.create")}
         confirmLoading={create.isPending}
       >
         <Form form={form} layout="vertical" initialValues={{ app_type: "wsgi", base_uri: "/" }}>
-          <Form.Item name="name" label="Name" rules={[{ required: true }]}>
-            <Input placeholder="My API" />
+          <Form.Item name="name" label={t("pythonappspage.name")} rules={[{ required: true }]}>
+            <Input placeholder={t("pythonappspage.my_api")} />
           </Form.Item>
-          <Form.Item name="domain_id" label="Domain" rules={[{ required: true }]}>
+          <Form.Item name="domain_id" label={t("pythonappspage.domain")} rules={[{ required: true }]}>
             <Select
               loading={domains.isLoading}
               options={(domains.data ?? []).map((d) => ({ value: d.id, label: d.name }))}
-              placeholder="Select a domain"
+              placeholder={t("pythonappspage.select_a_domain")}
             />
           </Form.Item>
-          <Form.Item name="base_uri" label="Mount path" tooltip="'/' for the whole domain, or '/app' for a sub-path">
+          <Form.Item name="base_uri" label={t("pythonappspage.mount_path")} tooltip="'/' for the whole domain, or '/app' for a sub-path">
             <Input placeholder="/" />
           </Form.Item>
           <Space style={{ width: "100%" }} size="middle">
-            <Form.Item name="python_version" label="Python" rules={[{ required: true }]}>
+            <Form.Item name="python_version" label={t("pythonappspage.python")} rules={[{ required: true }]}>
               <Select
                 style={{ width: 120 }}
                 loading={pyVersions.isLoading}
@@ -323,7 +325,7 @@ export function PythonAppsPage() {
               />
             </Form.Item>
             {!installFw && (
-              <Form.Item name="app_type" label="Type" rules={[{ required: true }]}>
+              <Form.Item name="app_type" label={t("pythonappspage.type")} rules={[{ required: true }]}>
                 <Select
                   style={{ width: 160 }}
                   options={[
@@ -347,14 +349,14 @@ export function PythonAppsPage() {
           ) : (
             <Form.Item
               name="entrypoint"
-              label="Entrypoint"
+              label={t("pythonappspage.entrypoint")}
               tooltip="module:callable, e.g. myapp.wsgi:application or main:app"
               rules={[{ required: true }, { pattern: /^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$/, message: "Expected module:callable" }]}
             >
               <Input placeholder="main:app" />
             </Form.Item>
           )}
-          <Form.Item name="app_root" label="App directory" tooltip="Path under your home, e.g. domains/example.com/app" rules={[{ required: true }]}>
+          <Form.Item name="app_root" label={t("pythonappspage.app_directory")} tooltip={t("pythonappspage.path_under_your_home_e_g_domains_example_com")} rules={[{ required: true }]}>
             <Input placeholder="domains/example.com/app" />
           </Form.Item>
         </Form>

--- a/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
+++ b/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
@@ -52,6 +53,7 @@ function generateEd25519Keypair(comment: string) {
 }
 
 export const UserSSHKeysPage = () => {
+  const { t } = useTranslation();
   const [form] = Form.useForm();
   const [genForm] = Form.useForm();
   const [modalOpen, setModalOpen] = useState(false);
@@ -242,7 +244,7 @@ export const UserSSHKeysPage = () => {
         showIcon
         style={{ marginBottom: 16 }}
         title={<strong>SSH & SFTP Access</strong>}
-        description="Connect to your server securely using SSH for terminal access or SFTP for file transfers. Generate a new key pair or add your existing public SSH keys below."
+        description={t("usersshkeyspage.connect_to_your_server_securely_using_ssh_fo")}
       />
 
       {conn && (
@@ -283,7 +285,7 @@ export const UserSSHKeysPage = () => {
 
       <Card>
         <Input.Search
-          placeholder="Search by name or fingerprint"
+          placeholder={t("usersshkeyspage.search_by_name_or_fingerprint")}
           allowClear
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -327,10 +329,10 @@ export const UserSSHKeysPage = () => {
               dataIndex: "actions",
               render: (_, record) => (
                 <Popconfirm
-                  title="Delete SSH Key"
-                  description="Are you sure? This revokes SFTP access."
+                  title={t("usersshkeyspage.delete_ssh_key")}
+                  description={t("usersshkeyspage.are_you_sure_this_revokes_sftp_access")}
                   onConfirm={() => handleDelete(record)}
-                  okText="Yes"
+                  okText={t("usersshkeyspage.yes")}
                   cancelText="No"
                 >
                   <RowActionButton
@@ -349,7 +351,7 @@ export const UserSSHKeysPage = () => {
       </Card>
 
       <Drawer
-        title="Add SSH Key"
+        title={t("usersshkeyspage.add_ssh_key")}
         open={modalOpen}
         onClose={() => {
           setModalOpen(false);
@@ -377,7 +379,7 @@ export const UserSSHKeysPage = () => {
           onFinish={handleAddKey}
         >
           <Form.Item
-            label="Name"
+            label={t("usersshkeyspage.name")}
             name="name"
             rules={[
               { required: true, message: "Please enter a name" },
@@ -388,7 +390,7 @@ export const UserSSHKeysPage = () => {
           </Form.Item>
 
           <Form.Item
-            label="Public Key"
+            label={t("usersshkeyspage.public_key")}
             name="public_key"
             rules={[
               { required: true, message: "Please paste your public key" },
@@ -414,7 +416,7 @@ export const UserSSHKeysPage = () => {
           and POSTs only the public half. The private key is shown once
           in the result modal below. */}
       <Drawer
-        title="Generate SSH Key"
+        title={t("usersshkeyspage.generate_ssh_key")}
         open={genOpen}
         onClose={() => {
           setGenOpen(false);
@@ -442,7 +444,7 @@ export const UserSSHKeysPage = () => {
         </Typography.Paragraph>
         <Form id="ssh-gen-form" form={genForm} layout="vertical" onFinish={handleGenerate}>
           <Form.Item
-            label="Name"
+            label={t("usersshkeyspage.name")}
             name="name"
             rules={[
               { required: true, message: "Please enter a name" },
@@ -452,7 +454,7 @@ export const UserSSHKeysPage = () => {
             <Input placeholder="e.g., My Laptop" />
           </Form.Item>
           <Form.Item
-            label="Comment (optional)"
+            label={t("usersshkeyspage.comment_optional")}
             name="comment"
             extra="Embedded in the public key as a label; defaults to 'jabali'."
           >
@@ -465,7 +467,7 @@ export const UserSSHKeysPage = () => {
           Shows the private key once with copy + download. Dismissing
           clears it from React state so it's not retained in memory. */}
       <Modal
-        title="Save your private key now"
+        title={t("usersshkeyspage.save_your_private_key_now")}
         open={generatedPrivate !== null}
         onCancel={() => {
           setGeneratedPrivate(null);
@@ -485,8 +487,8 @@ export const UserSSHKeysPage = () => {
           type="warning"
           showIcon
           style={{ marginBottom: 12 }}
-          title="This is the only time the private key will be shown."
-          description="Copy or download it now. If you close this dialog without saving, you'll need to generate a new key and delete this one."
+          title={t("usersshkeyspage.this_is_the_only_time_the_private_key_will_b")}
+          description={t("usersshkeyspage.copy_or_download_it_now_if_you_close_this_di")}
         />
         <Space style={{ marginBottom: 8 }}>
           <Button icon={<CopyOutlined />} onClick={copyPrivateKey}>


### PR DESCRIPTION

Applies the same codemod to the tenant-facing side: 40 files under shells/user,
the DNS records page and 8 shared components, for 317 visible attribute strings
in total. English source only, with every other language coming from Weblate.

This is the half of the panel most likely to be read by someone who does not
work in English. An administrator choosing a hosting panel usually can; the
tenant handed an account on it often cannot, and reaches the file manager, mail
and database screens with no say in the matter.

Shared components are included because their strings surface on every page that
mounts them, which makes them the highest-leverage entries in the catalog: one
translation each, visible almost everywhere.

Long multi-line prose is untouched for the same reason as the admin sweep, and
falls back to English until it is split by hand.

Verified: `npx tsc -b --force` clean (0 errors), `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)