### PR TITLE
feat(migrate): CloudPanel restore step 2 — import wiring + cp-first tar fix (GH #522)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -326,6 +326,7 @@ failed stage. Already-done stages are skipped.`,
 				models.MigrationSourceWHMpkgacct,
 				models.MigrationSourceDirectAdmin,
 				models.MigrationSourceHestia,
+				models.MigrationSourceCloudPanel,
 				models.MigrationSourcePlesk:
 				// supported — fall through
 			default:
@@ -416,6 +417,52 @@ failed stage. Already-done stages are skipped.`,
 					fmt.Fprintf(cmd.ErrOrStderr(),
 						"warning: cpanel.ParseTarball failed on DA tarball %s (%v); using pre-extracted cp/<user>/ assumption\n",
 						daTarPath, perr)
+				}
+			case models.MigrationSourceCloudPanel:
+				// CloudPanel pull synthesises a cpmove-shaped tarball
+				// (cloudpanel/backup.go BackupUser) at cpmove-<user>.tar.gz,
+				// so the cpanel restore writers consume it unchanged.
+				// CloudPanel is web-only and doesn't bundle homedir/domains
+				// or dnszones, so the AUTHORITATIVE domain list is
+				// domains-paths.txt (written by BackupUser). Populate
+				// DomainNames + DocRoots from it so ImportDomains creates one
+				// panel domain + nginx vhost per site; the dest docroot is
+				// jabali-native /home/<target>/domains/<dom>/public_html —
+				// the per-domain rsync at the home stage lands the source
+				// htdocs content there (rsyncRows below reads the same file).
+				clpTar := filepath.Join("/var/lib/jabali-migrations", job.ID,
+					fmt.Sprintf("cpmove-%s.tar.gz", job.SourceUser))
+				if cp, perr := cpanel.ParseTarball(clpTar, extractDir); perr == nil {
+					parsed = cp
+					manifestPath := filepath.Join(extractDir, "cpmove-"+parsed.SourceUser, "domains-paths.txt")
+					if raw, rerr := os.ReadFile(manifestPath); rerr == nil {
+						if parsed.DocRoots == nil {
+							parsed.DocRoots = map[string]string{}
+						}
+						for _, line := range strings.Split(string(raw), "\n") {
+							line = strings.TrimSpace(line)
+							if line == "" {
+								continue
+							}
+							dom := strings.SplitN(line, "\t", 2)[0]
+							if dom == "" {
+								continue
+							}
+							parsed.DomainNames = append(parsed.DomainNames, dom)
+							parsed.DocRoots[dom] = filepath.Join("/home", *user.Username, "domains", dom, "public_html")
+						}
+					}
+				} else {
+					// Pre-extracted fallback (operator dropped the cpmove
+					// tree out of band).
+					parsed = &cpanel.ParsedTarball{
+						ExtractDir: extractDir,
+						HomeDir:    filepath.Join(extractDir, "cpmove-"+job.SourceUser, "homedir"),
+						SourceUser: job.SourceUser,
+					}
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"warning: cpanel.ParseTarball failed on CloudPanel tarball %s (%v); using pre-extracted assumption\n",
+						clpTar, perr)
 				}
 			case models.MigrationSourcePlesk:
 				// Plesk pull synthesises a METADATA cpmove (cpmove-<slug>/
@@ -924,7 +971,7 @@ func cpanelRestoreCallback(
 			type rsyncPair struct{ Dom, SrcPath string }
 			var rsyncRows []rsyncPair
 			switch job.SourceKind {
-			case models.MigrationSourceDirectAdmin, models.MigrationSourcePlesk:
+			case models.MigrationSourceDirectAdmin, models.MigrationSourcePlesk, models.MigrationSourceCloudPanel:
 				manifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+p.parsed.SourceUser, "domains-paths.txt")
 				if raw, rerr := os.ReadFile(manifest); rerr == nil {
 					for _, line := range strings.Split(string(raw), "\n") {

--- a/panel-api/internal/migrate/cloudpanel/backup.go
+++ b/panel-api/internal/migrate/cloudpanel/backup.go
@@ -107,8 +107,17 @@ if [ ! -s "$BASE/cron/$ACCT" ]; then rm -f "$BASE/cron/$ACCT"; fi
 Q "SELECT su.ssh_keys FROM ssh_user su JOIN site s ON su.site_id=s.id WHERE s.user='$ACCT' AND su.ssh_keys IS NOT NULL AND su.ssh_keys != ''" > "$BASE/homedir/.ssh/authorized_keys" 2>/dev/null || true
 if [ ! -s "$BASE/homedir/.ssh/authorized_keys" ]; then rm -f "$BASE/homedir/.ssh/authorized_keys"; fi
 
-# 6. tar it up (last stdout line = the path the caller reads).
-tar -czf "$OUT" -C "$TMP" "cpmove-$ACCT"
+# 6. tar it up (last stdout line = the path the caller reads). cp/ MUST be the
+#    first area in the stream: cpanel.ParseTarball detects the cpmove-<user>/
+#    wrapper lazily on the first 'cp/' segment and only strips it from later
+#    entries, so an area (mysql/cron/homedir) seen before cp/ would be
+#    misclassified and silently dropped. List cp first, then the areas that
+#    exist, so classification is deterministic regardless of readdir order.
+TARARGS="cpmove-$ACCT/cp"
+for d in mysql cron homedir domains-paths.txt; do
+  if [ -e "$BASE/$d" ]; then TARARGS="$TARARGS cpmove-$ACCT/$d"; fi
+done
+tar -czf "$OUT" -C "$TMP" $TARARGS
 rm -rf "$TMP"
 echo "$OUT"
 `, acct, dbp)

--- a/panel-api/internal/migrate/cloudpanel/backup_test.go
+++ b/panel-api/internal/migrate/cloudpanel/backup_test.go
@@ -45,6 +45,7 @@ func TestBackupUser_SynthesizeScriptAndPath(t *testing.T) {
 		`domains-paths.txt`,            // rsync manifest
 		`FROM cron_job cj JOIN site`,   // cron reconstruction
 		`FROM ssh_user su JOIN site`,   // authorized_keys
+		`TARARGS="cpmove-$ACCT/cp"`,    // cp/ archived FIRST (ParseTarball wrapper detection)
 		`tar -czf "$OUT"`,              // final archive
 	} {
 		if !strings.Contains(*last, want) {

--- a/panel-api/internal/migrate/cpanel/tarball_cloudpanel_test.go
+++ b/panel-api/internal/migrate/cpanel/tarball_cloudpanel_test.go
@@ -1,0 +1,92 @@
+package cpanel
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tarEntry is one regular-file entry; an ordered slice is used (not a map) so
+// the stream order is deterministic — ParseTarball's wrapper detection is lazy
+// on the first cp/ segment, and cloudpanel/backup.go guarantees cp/ is archived
+// first. The test reproduces that ordering.
+type tarEntry struct{ name, content string }
+
+func writeGzTar(t *testing.T, path string, entries []tarEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create tar: %v", err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: e.name, Mode: 0o644, Size: int64(len(e.content)), Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header %s: %v", e.name, err)
+		}
+		if _, err := tw.Write([]byte(e.content)); err != nil {
+			t.Fatalf("tar write %s: %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The CloudPanel source (GH #522) synthesises a cpmove-shaped tarball whose
+// areas sit one level below a cpmove-<user>/ wrapper — exactly what the
+// DirectAdmin source produces. This asserts ParseTarball strips the wrapper,
+// detects SourceUser from cp/<user>, and classifies the web-only subset
+// (mysql/ + cron/ + homedir/.ssh) plus extracts domains-paths.txt for the
+// import stage to read. A regression here would silently drop a CloudPanel
+// account's databases, cron jobs, or SSH keys on restore.
+func TestParseTarball_CloudPanelSynthesizedLayout(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "cpmove-smokeuser.tar.gz")
+	// cp/ first, then the areas — the exact order cloudpanel/backup.go emits.
+	writeGzTar(t, tarPath, []tarEntry{
+		{"cpmove-smokeuser/cp/smokeuser", "USER=smokeuser\nDNS=smoke.jabalitest.com\n"},
+		{"cpmove-smokeuser/mysql/smokedb.sql", "CREATE TABLE `widgets` (id INT);\nINSERT INTO `widgets` VALUES (1);\n"},
+		{"cpmove-smokeuser/cron/smokeuser", "30 3 * * * /usr/bin/php /home/smokeuser/htdocs/smoke.jabalitest.com/cron.php\n"},
+		{"cpmove-smokeuser/domains-paths.txt", "smoke.jabalitest.com\t/home/smokeuser/htdocs/smoke.jabalitest.com\n"},
+		{"cpmove-smokeuser/homedir/.ssh/authorized_keys", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAISmoke smoke@test\n"},
+	})
+
+	extractDir := filepath.Join(dir, "extracted")
+	p, err := ParseTarball(tarPath, extractDir)
+	if err != nil {
+		t.Fatalf("ParseTarball: %v", err)
+	}
+	if p.SourceUser != "smokeuser" {
+		t.Errorf("SourceUser = %q, want smokeuser (from cp/<user> under the cpmove- wrapper)", p.SourceUser)
+	}
+	if len(p.MySQLDumps) != 1 {
+		t.Errorf("MySQLDumps = %v, want the single smokedb.sql", p.MySQLDumps)
+	}
+	if len(p.CronFiles) != 1 {
+		t.Errorf("CronFiles = %v, want cron/smokeuser", p.CronFiles)
+	}
+	if len(p.SSHAuthorized) != 1 {
+		t.Errorf("SSHAuthorized = %v, want homedir/.ssh/authorized_keys", p.SSHAuthorized)
+	}
+	// CloudPanel is web-only: no BIND zones, so ImportDomains must fall back to
+	// the domains-paths.txt list (populated in migrate_run_cmd, not here).
+	if len(p.ZoneFiles) != 0 {
+		t.Errorf("ZoneFiles = %v, want none (CloudPanel has no dnszones/)", p.ZoneFiles)
+	}
+	// The import stage reads domains-paths.txt from the extracted tree, so it
+	// must have been written to disk under the wrapper dir.
+	if _, err := os.Stat(filepath.Join(extractDir, "cpmove-smokeuser", "domains-paths.txt")); err != nil {
+		t.Errorf("domains-paths.txt not extracted for the import stage: %v", err)
+	}
+}


### PR DESCRIPTION
Wires CloudPanel into the import pipeline so a pulled `cpmove-<user>.tar.gz` (from #591) restores through the shared cpanel writers — the same path DirectAdmin uses. Three edits in `migrate_run_cmd.go`:

- **Supported-kind switch** — add cloudpanel (import no longer returns "not yet supported").
- **Parse case** — `cpanel.ParseTarball(cpmove-<user>.tar.gz)` + populate `DomainNames`/`DocRoots` from `domains-paths.txt`. CloudPanel is web-only (no BIND zones, no bundled `homedir/domains`), so that file is the authoritative domain list. Dest docroot = jabali-native `/home/<target>/domains/<dom>/public_html`.
- **rsync-rows switch** — join the DA/Plesk case: each source docroot (`/home/<user>/htdocs/<root>`) rsyncs to the dest docroot. The existing `/home/<user>/` allow-list already covers CloudPanel paths.

Databases, cron, SSH need **no** per-kind wiring — `ImportDatabases`/`ImportCron`/`ImportSSHKeys` run generically on the parsed tarball; the synthesized `mysql/`, `cron/<user>`, `homedir/.ssh/authorized_keys` classify via the shared parser.

## Real fix bundled: cp-first tar ordering
`cpanel.ParseTarball` detects the `cpmove-<user>/` wrapper **lazily** on the first `cp/` segment and only strips it from later entries — so any area (`mysql`/`cron`/`homedir`) archived *before* `cp/` is misclassified and **silently dropped**. `tar` over an ext4 dir emits children in readdir (hash) order, not alphabetical, so cp-first wasn't guaranteed. The synthesize now archives `cp/` explicitly first, then the areas that exist. (DirectAdmin shares this latent hazard.) **Box-verified** on the live CloudPanel VM: the real tar now streams `cp/` before every area.

## Testing
- New `TestParseTarball_CloudPanelSynthesizedLayout` — the shared parser consumes the CloudPanel layout: `SourceUser` + `MySQLDumps` + `CronFiles` + `SSHAuthorized` populated, no `ZoneFiles`, `domains-paths.txt` extracted for the import stage.
- Backup unit test locks the cp-first tar order.
- `go build` / `go vet` / full `migrate/...` + `cmd/server` suites green.

**Remaining gate:** a full pull→import E2E migrating a real CloudPanel account into a jabali destination (needs a target box reachable to the CloudPanel VM). The parse/classification integration is unit- + box-verified; the end-to-end file placement is the next verification.