### PR TITLE
feat(migrate): CyberPanel restore step 1 — cpmove synthesize + pull dispatch (GH #522)

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -40,6 +40,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cloudpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cyberpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
@@ -199,6 +200,8 @@ live source SSH. Use scp directly for that kind.`,
 				localTar, err = pullHestia(ctx, sshUser, job, secret, localDir, allowPrivate)
 			case models.MigrationSourceCloudPanel:
 				localTar, err = pullCloudPanel(ctx, sshUser, job, secret, localDir, allowPrivate)
+			case models.MigrationSourceCyberPanel:
+				localTar, err = pullCyberPanel(ctx, sshUser, job, secret, localDir, allowPrivate)
 			case models.MigrationSourcePlesk:
 				localTar, err = pullPlesk(ctx, sshUser, job, secret, localDir, allowPrivate)
 			default:
@@ -312,6 +315,38 @@ func pullCloudPanel(ctx context.Context, sshUser string, job *models.MigrationJo
 	remoteTar, err := d.BackupUser(ctx, s, job.SourceUser)
 	if err != nil {
 		return "", fmt.Errorf("cloudpanel BackupUser: %w", err)
+	}
+	fmt.Printf("  → tarball ready on source: %s — downloading...\n", remoteTar)
+	localTar := filepath.Join(localDir, fmt.Sprintf("cpmove-%s.tar.gz", job.SourceUser))
+	if _, err := d.PullFile(ctx, s, remoteTar, localTar); err != nil {
+		return "", fmt.Errorf("PullFile: %w", err)
+	}
+	// JAB-50: don't leave the full account backup on the source server.
+	if rmErr := d.RemoveRemote(ctx, s, remoteTar); rmErr != nil {
+		fmt.Printf("  (warning: source-side rm %s failed: %v)\n", remoteTar, rmErr)
+	}
+	return localTar, nil
+}
+
+// pullCyberPanel (GH #522 follow-on) connects to a CyberPanel source over SSH
+// and runs BackupUser, which synthesises a cpmove-shaped tarball from
+// CyberPanel's MySQL inventory (cp/<domain>, mysql/<db>.sql, cron/<domain>,
+// domains-paths.txt, homedir/.ssh) — the same DA-style approach so the shared
+// cpanel restore writers consume it unchanged. The CyberPanel account IS the
+// primary domain; the tarball lands at cpmove-<domain>.tar.gz.
+func pullCyberPanel(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {
+	d := cyberpanel.New()
+	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
+	s, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
+	if err != nil {
+		return "", fmt.Errorf("cyberpanel.Connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, s) }()
+	fmt.Printf("  → synthesizing cpmove for %s on the CyberPanel source (dumping databases)...\n", job.SourceUser)
+	remoteTar, err := d.BackupUser(ctx, s, job.SourceUser)
+	if err != nil {
+		return "", fmt.Errorf("cyberpanel BackupUser: %w", err)
 	}
 	fmt.Printf("  → tarball ready on source: %s — downloading...\n", remoteTar)
 	localTar := filepath.Join(localDir, fmt.Sprintf("cpmove-%s.tar.gz", job.SourceUser))

--- a/panel-api/internal/migrate/cyberpanel/backup.go
+++ b/panel-api/internal/migrate/cyberpanel/backup.go
@@ -1,0 +1,177 @@
+package cyberpanel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// BackupUserTimeout caps the source-side synthesize. Dominated by the
+// mysqldump(s); 60 min matches the other sources for very large databases.
+const BackupUserTimeout = 60 * time.Minute
+
+// BackupUser synthesizes a cpanel-cpmove-shaped tarball on the CyberPanel
+// source so the shared cpanel restore writers consume it unchanged — the same
+// approach cloudpanel/directadmin take. This first step covers the web + data
+// subset (DNS zones + mailboxes land in a follow-up step):
+//
+//	/tmp/cpmove-<domain>.tar.gz
+//	└── cpmove-<domain>/
+//	    ├── cp/<domain>           (USER + CONTACTEMAIL + primary-domain DNS line)
+//	    ├── mysql/<db>.sql         (one per site database)
+//	    ├── cron/<domain>          (the externalApp user's crontab)
+//	    ├── domains-paths.txt      (<domain>\t<docroot> for the restore rsync)
+//	    └── homedir/.ssh/authorized_keys
+//
+// cp/ is archived FIRST so cpanel.ParseTarball detects the cpmove-<domain>/
+// wrapper before any area entry (its wrapper detection is lazy on the first
+// cp/ segment; an area seen earlier would be misclassified + silently dropped).
+//
+// The CyberPanel account IS the primary domain (the Linux user that owns
+// /home/<domain>/ is externalApp). Inventory is read from the CyberPanel MySQL
+// database (read-only SELECTs); the only write-shaped command is mysqldump to a
+// scratch file. Requires a root SSH user (MySQL access + read of
+// /home/<domain>/ + the externalApp crontab).
+func (d *Discoverer) BackupUser(ctx context.Context, raw interface{}, account string) (string, error) {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return "", errors.New("BackupUser: bad session")
+	}
+	if !domainRe.MatchString(account) {
+		return "", fmt.Errorf("BackupUser: invalid account %q", account)
+	}
+
+	subctx, cancel := context.WithTimeout(ctx, BackupUserTimeout)
+	defer cancel()
+
+	acct := shellSingleQuote(account)
+	dbn := shellSingleQuote(s.dbName)
+	// One inline script (single ssh exec). `set -e` aborts on hard failure so
+	// partial tarballs don't leak; every conditional uses explicit if/fi (never
+	// a bare `[ ] && cmd`, which aborts the whole script when the test is false
+	// under set -e). externalApp is re-validated in-shell against the same
+	// allow-list before it reaches `crontab -u`.
+	script := fmt.Sprintf(`set -e
+ACCT=%s
+DBN=%s
+TMP=/tmp/jabali-migrate-cyber-$ACCT
+OUT=/tmp/cpmove-$ACCT.tar.gz
+MYQ(){ mysql -N -B "$DBN" -e "$1"; }
+
+rm -rf "$TMP" "$OUT"
+BASE="$TMP/cpmove-$ACCT"
+mkdir -p "$BASE/cp" "$BASE/mysql" "$BASE/cron" "$BASE/homedir/.ssh"
+
+# Resolve the website's id (for db/domain queries) + externalApp (Linux user
+# that owns /home/<domain> + holds the crontab).
+WID=$(MYQ "SELECT id FROM websiteFunctions_websites WHERE domain='$ACCT'")
+EXTAPP=$(MYQ "SELECT externalApp FROM websiteFunctions_websites WHERE domain='$ACCT'")
+ADMINEMAIL=$(MYQ "SELECT adminEmail FROM websiteFunctions_websites WHERE domain='$ACCT'" 2>/dev/null || true)
+if [ -z "$WID" ]; then echo "ERROR: no website row for $ACCT" >&2; exit 3; fi
+
+# 1. cp/<domain> — USER + CONTACTEMAIL + primary-domain DNS line.
+echo "USER=$ACCT" > "$BASE/cp/$ACCT"
+echo "DNS=$ACCT" >> "$BASE/cp/$ACCT"
+if [ -n "$ADMINEMAIL" ]; then echo "CONTACTEMAIL=$ADMINEMAIL" >> "$BASE/cp/$ACCT"; fi
+
+# 2. mysql/<db>.sql — dump every database owned by this website. CyberPanel's
+#    root MySQL auth is ambient for the SSH root user (same as discover's mysql
+#    queries), so no credential args are passed.
+MYSQL_OK=""
+if mysql -N -e "SELECT 1" >/dev/null 2>&1; then MYSQL_OK=1; fi
+if [ -z "$MYSQL_OK" ]; then echo "WARN: no MySQL access — skipping DB dumps" >&2; fi
+MYQ "SELECT dbName FROM databases_databases WHERE website_id=$WID" | while read -r db; do
+  if [ -z "$db" ]; then continue; fi
+  if [ -n "$MYSQL_OK" ]; then
+    if ! mysqldump --skip-lock-tables --single-transaction "$db" > "$BASE/mysql/$db.sql" 2>/dev/null; then
+      echo "WARN: mysqldump $db failed" >&2
+      rm -f "$BASE/mysql/$db.sql"
+    fi
+  fi
+done
+
+# 3. domains-paths.txt — <domain>\t<docroot> for the restore-stage rsync.
+#    Primary + child + alias domains; CyberPanel docroot = /home/<domain>/public_html.
+printf '%%s\t/home/%%s/public_html\n' "$ACCT" "$ACCT" >> "$BASE/domains-paths.txt"
+MYQ "SELECT domain FROM websiteFunctions_childdomains WHERE master_id=$WID" | while read -r cd; do
+  if [ -z "$cd" ]; then continue; fi
+  printf '%%s\t/home/%%s/public_html\n' "$cd" "$ACCT" >> "$BASE/domains-paths.txt"
+done
+MYQ "SELECT aliasDomain FROM websiteFunctions_aliasdomains WHERE master_id=$WID" | while read -r ad; do
+  if [ -z "$ad" ]; then continue; fi
+  printf '%%s\t/home/%%s/public_html\n' "$ad" "$ACCT" >> "$BASE/domains-paths.txt"
+done
+
+# 4. cron/<domain> — the externalApp user's crontab. Guard externalApp against
+#    the same allow-list the Go side enforces before it reaches crontab -u.
+if printf '%%s' "$EXTAPP" | grep -Eq '^[a-z_][a-z0-9._-]{0,63}$'; then
+  crontab -u "$EXTAPP" -l > "$BASE/cron/$ACCT" 2>/dev/null || true
+  if [ ! -s "$BASE/cron/$ACCT" ]; then rm -f "$BASE/cron/$ACCT"; fi
+fi
+
+# 5. homedir/.ssh/authorized_keys — CyberPanel keeps the site home at
+#    /home/<domain>/; copy the account's authorized_keys if present.
+if [ -r "/home/$ACCT/.ssh/authorized_keys" ]; then
+  cp "/home/$ACCT/.ssh/authorized_keys" "$BASE/homedir/.ssh/authorized_keys"
+fi
+if [ ! -s "$BASE/homedir/.ssh/authorized_keys" ]; then rm -f "$BASE/homedir/.ssh/authorized_keys"; fi
+
+# 6. tar it up. cp/ FIRST (ParseTarball wrapper detection — see above), then
+#    the areas that exist. Last stdout line = the path the caller reads.
+TARARGS="cpmove-$ACCT/cp"
+for d in mysql cron homedir domains-paths.txt; do
+  if [ -e "$BASE/$d" ]; then TARARGS="$TARARGS cpmove-$ACCT/$d"; fi
+done
+tar -czf "$OUT" -C "$TMP" $TARARGS
+rm -rf "$TMP"
+echo "$OUT"
+`, acct, dbn)
+
+	out, err := s.run(subctx, BackupUserTimeout, script)
+	if err != nil {
+		return "", fmt.Errorf("cyberpanel synthesize cpmove: %w (stdout=%q)", err, truncForLog(string(out), 1024))
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	path := strings.TrimSpace(lines[len(lines)-1])
+	if path == "" {
+		return "", errors.New("cyberpanel synthesize cpmove: empty tarball path")
+	}
+	return path, nil
+}
+
+// PullFile streams a source-side file to a local path over the session's SSH
+// client (shared migrate helper).
+func (d *Discoverer) PullFile(ctx context.Context, raw interface{}, remotePath, localPath string) (int64, error) {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return 0, errors.New("PullFile: bad session")
+	}
+	return migrate.PullFileViaSSH(ctx, s.client, remotePath, localPath)
+}
+
+// RemoveRemote deletes the synthesized source-side tarball after it's pulled
+// (JAB-50). Allowlist: only /tmp/cpmove-* with no .. traversal — a full account
+// archive must not linger on a possibly-shared source host.
+func (d *Discoverer) RemoveRemote(ctx context.Context, raw interface{}, path string) error {
+	s, ok := raw.(*session)
+	if !ok || s == nil {
+		return errors.New("RemoveRemote: bad session")
+	}
+	if !strings.HasPrefix(path, "/tmp/cpmove-") || strings.Contains(path, "..") {
+		return fmt.Errorf("RemoveRemote: refuses non-cpmove path %q", path)
+	}
+	_, err := s.run(ctx, 30*time.Second, fmt.Sprintf("rm -f %s", shellSingleQuote(path)))
+	return err
+}
+
+// truncForLog bounds stderr/stdout surfaced in error messages.
+func truncForLog(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...[truncated]"
+}

--- a/panel-api/internal/migrate/cyberpanel/backup_test.go
+++ b/panel-api/internal/migrate/cyberpanel/backup_test.go
@@ -1,0 +1,101 @@
+package cyberpanel
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureSession returns a *session whose run() records the last command and
+// replies with canned stdout, exercising the synthesize script without a live
+// CyberPanel host.
+func captureSession(stdout string, runErr error) (*session, *string) {
+	var last string
+	s := &session{dbName: "cyberpanel", commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		last = cmd
+		return []byte(stdout), runErr
+	}
+	return s, &last
+}
+
+func TestBackupUser_SynthesizeScriptAndPath(t *testing.T) {
+	d := New()
+	s, last := captureSession("log\n/tmp/cpmove-smoke.jabalitest.com.tar.gz\n", nil)
+	path, err := d.BackupUser(context.Background(), s, "smoke.jabalitest.com")
+	if err != nil {
+		t.Fatalf("BackupUser: %v", err)
+	}
+	if path != "/tmp/cpmove-smoke.jabalitest.com.tar.gz" {
+		t.Errorf("path = %q, want the trailing tarball path", path)
+	}
+	for _, want := range []string{
+		`set -e`,
+		`BASE="$TMP/cpmove-$ACCT"`,
+		`ACCT='smoke.jabalitest.com'`, // account interpolated + quoted
+		`SELECT id FROM websiteFunctions_websites WHERE domain=`, // website id
+		`externalApp`, // Linux user for cron
+		`echo "USER=$ACCT"`,
+		`FROM databases_databases WHERE website_id=$WID`, // per-db dump
+		`mysqldump`,
+		`domains-paths.txt`,
+		`websiteFunctions_childdomains`, // child domains
+		`websiteFunctions_aliasdomains`, // alias domains
+		`crontab -u "$EXTAPP" -l`,       // cron
+		`TARARGS="cpmove-$ACCT/cp"`,     // cp/ archived FIRST (ParseTarball wrapper detection)
+		`tar -czf "$OUT"`,
+	} {
+		if !strings.Contains(*last, want) {
+			t.Errorf("synthesize script missing %q", want)
+		}
+	}
+	// externalApp must be re-validated in-shell before crontab -u.
+	if !strings.Contains(*last, `grep -Eq '^[a-z_][a-z0-9._-]{0,63}$'`) {
+		t.Error("externalApp must be allow-listed in-shell before reaching crontab -u")
+	}
+}
+
+func TestBackupUser_RejectsBadAccount(t *testing.T) {
+	d := New()
+	s, _ := captureSession("/tmp/cpmove-x.tar.gz\n", nil)
+	for _, bad := range []string{"a'; DROP TABLE websiteFunctions_websites;--", "a b", "../etc", "UPPER.com", ""} {
+		if _, err := d.BackupUser(context.Background(), s, bad); err == nil {
+			t.Errorf("account %q must be rejected by domainRe before any remote exec", bad)
+		}
+	}
+}
+
+func TestBackupUser_EmptyPathIsError(t *testing.T) {
+	d := New()
+	s, _ := captureSession("  \n", nil)
+	if _, err := d.BackupUser(context.Background(), s, "smoke.jabalitest.com"); err == nil {
+		t.Error("empty tarball path must be an error")
+	}
+}
+
+func TestBackupUser_RunErrorSurfaced(t *testing.T) {
+	d := New()
+	s, _ := captureSession("partial", errors.New("boom"))
+	if _, err := d.BackupUser(context.Background(), s, "smoke.jabalitest.com"); err == nil ||
+		!strings.Contains(err.Error(), "synthesize cpmove") {
+		t.Errorf("run error must be wrapped, got %v", err)
+	}
+}
+
+func TestRemoveRemote_AllowlistsCpmove(t *testing.T) {
+	d := New()
+	s, last := captureSession("", nil)
+	for _, bad := range []string{"/etc/passwd", "/tmp/cpmove-../etc", "/root/.my.cnf"} {
+		if err := d.RemoveRemote(context.Background(), s, bad); err == nil {
+			t.Errorf("RemoveRemote must refuse %q", bad)
+		}
+	}
+	if err := d.RemoveRemote(context.Background(), s, "/tmp/cpmove-smoke.jabalitest.com.tar.gz"); err != nil {
+		t.Fatalf("RemoveRemote(valid): %v", err)
+	}
+	if !strings.Contains(*last, "rm -f") {
+		t.Errorf("RemoveRemote should issue rm -f, got %q", *last)
+	}
+}


### PR DESCRIPTION
Starts the CyberPanel **restore** path (discover shipped in #585/#586/#587). Uses the shared cpmove-synthesis approach — the same as CloudPanel/DirectAdmin — so the existing cpanel restore writers do the import unchanged.

## What lands (step 1 = web + data subset)
- **`BackupUser`** — one inline script on the source builds `cpmove-<domain>.tar.gz` from CyberPanel's MySQL inventory:
  ```
  cpmove-<domain>/
    cp/<domain>           USER + CONTACTEMAIL (adminEmail) + DNS primary
    mysql/<db>.sql         mysqldump per site database
    cron/<domain>          the externalApp user's crontab
    domains-paths.txt      primary + child + alias → /home/<domain>/public_html
    homedir/.ssh/authorized_keys
  ```
  The CyberPanel **account is the primary domain** (externalApp is the Linux user owning `/home/<domain>`).
- **`PullFile`** / **`RemoveRemote`** (`/tmp/cpmove-*` allow-list) + **`pullCyberPanel`** dispatch case.

**DNS zones + mailboxes are step 2** — CyberPanel's PowerDNS `records` and `/home/vmail/<domain>/<local>/` Maildirs are the source-specific complex areas and get their own step. Import-side wiring (the 3 `migrate_run_cmd.go` switches) also lands in step 2, so the import still returns "not yet supported" for cyberpanel here — no half-wired mail-less restore.

## Safety
- Read-only MySQL SELECTs; only write-shaped command is `mysqldump` to a scratch file.
- `set -e` safe (explicit `if/fi`); `cp/` archived first (ParseTarball wrapper detection).
- Account passes `domainRe`; `externalApp` re-validated in-shell before `crontab -u`.

## Testing
- **Box-verified** on the live CyberPanel VM (192.168.100.86): `rc=0`, cp-first tar order, correct `cp/domains-paths/cron` layout, `mysqldump` ran.
- Unit tests: synthesize script shape, domain allow-list, path parsing, RemoveRemote allow-list.
- `go build` / `go vet` / package tests `-race` green.