### PR TITLE
feat(migrate): CyberPanel restore step 2 — import wiring (GH #522)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -327,6 +327,7 @@ failed stage. Already-done stages are skipped.`,
 				models.MigrationSourceDirectAdmin,
 				models.MigrationSourceHestia,
 				models.MigrationSourceCloudPanel,
+				models.MigrationSourceCyberPanel,
 				models.MigrationSourcePlesk:
 				// supported — fall through
 			default:
@@ -418,10 +419,15 @@ failed stage. Already-done stages are skipped.`,
 						"warning: cpanel.ParseTarball failed on DA tarball %s (%v); using pre-extracted cp/<user>/ assumption\n",
 						daTarPath, perr)
 				}
-			case models.MigrationSourceCloudPanel:
-				// CloudPanel pull synthesises a cpmove-shaped tarball
-				// (cloudpanel/backup.go BackupUser) at cpmove-<user>.tar.gz,
-				// so the cpanel restore writers consume it unchanged.
+			case models.MigrationSourceCloudPanel, models.MigrationSourceCyberPanel:
+				// CloudPanel + CyberPanel pull synthesise a cpmove-shaped
+				// tarball (<source>/backup.go BackupUser) at
+				// cpmove-<user>.tar.gz, so the cpanel restore writers consume
+				// it unchanged. Both populate DomainNames/DocRoots from
+				// domains-paths.txt (their authoritative domain list). CyberPanel
+				// additionally ships dnszones/ once DNS lands, which ParseTarball
+				// classifies into ZoneFiles automatically — additive, no change
+				// here. (CyberPanel's account id is its primary domain.)
 				// CloudPanel is web-only and doesn't bundle homedir/domains
 				// or dnszones, so the AUTHORITATIVE domain list is
 				// domains-paths.txt (written by BackupUser). Populate
@@ -971,7 +977,7 @@ func cpanelRestoreCallback(
 			type rsyncPair struct{ Dom, SrcPath string }
 			var rsyncRows []rsyncPair
 			switch job.SourceKind {
-			case models.MigrationSourceDirectAdmin, models.MigrationSourcePlesk, models.MigrationSourceCloudPanel:
+			case models.MigrationSourceDirectAdmin, models.MigrationSourcePlesk, models.MigrationSourceCloudPanel, models.MigrationSourceCyberPanel:
 				manifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+p.parsed.SourceUser, "domains-paths.txt")
 				if raw, rerr := os.ReadFile(manifest); rerr == nil {
 					for _, line := range strings.Split(string(raw), "\n") {

--- a/panel-api/internal/migrate/cpanel/tarball_cloudpanel_test.go
+++ b/panel-api/internal/migrate/cpanel/tarball_cloudpanel_test.go
@@ -90,3 +90,27 @@ func TestParseTarball_CloudPanelSynthesizedLayout(t *testing.T) {
 		t.Errorf("domains-paths.txt not extracted for the import stage: %v", err)
 	}
 }
+
+// CyberPanel's account id is a domain (dotted), so the cpmove wrapper is
+// cpmove-<domain>/ and cp/<domain> carries dots. Assert ParseTarball detects
+// the wrapper + SourceUser correctly with a dotted account (GH #522 CyberPanel).
+func TestParseTarball_CyberPanelDottedDomainAccount(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "cpmove-smoke.jabalitest.com.tar.gz")
+	writeGzTar(t, tarPath, []tarEntry{
+		{"cpmove-smoke.jabalitest.com/cp/smoke.jabalitest.com", "USER=smoke.jabalitest.com\nDNS=smoke.jabalitest.com\nCONTACTEMAIL=admin@smoke.jabalitest.com\n"},
+		{"cpmove-smoke.jabalitest.com/mysql/smokedb.sql", "CREATE TABLE t (id INT);\n"},
+		{"cpmove-smoke.jabalitest.com/cron/smoke.jabalitest.com", "15 2 * * * /usr/bin/php /home/smoke.jabalitest.com/public_html/cron.php\n"},
+		{"cpmove-smoke.jabalitest.com/domains-paths.txt", "smoke.jabalitest.com\t/home/smoke.jabalitest.com/public_html\n"},
+	})
+	p, err := ParseTarball(tarPath, filepath.Join(dir, "extracted"))
+	if err != nil {
+		t.Fatalf("ParseTarball: %v", err)
+	}
+	if p.SourceUser != "smoke.jabalitest.com" {
+		t.Errorf("SourceUser = %q, want the dotted domain", p.SourceUser)
+	}
+	if len(p.MySQLDumps) != 1 || len(p.CronFiles) != 1 {
+		t.Errorf("dumps=%v cron=%v — dotted-account wrapper strip broke classification", p.MySQLDumps, p.CronFiles)
+	}
+}


### PR DESCRIPTION
Wires CyberPanel into the import pipeline so a pulled `cpmove-<domain>.tar.gz` (from #598) restores through the shared cpanel writers — the same 3 switches CloudPanel uses (#597):

- **Supported-kind switch** — add cyberpanel.
- **Parse case** — join the CloudPanel case: populate `DomainNames`/`DocRoots` from `domains-paths.txt`, read `cpmove-<user>.tar.gz`. CyberPanel's account id is its primary domain.
- **rsync-rows switch** — join the DA/Plesk/CloudPanel case: each source docroot `/home/<domain>/public_html` rsyncs to the dest docroot (the `/home/<SourceUser>/` allow-list covers it — SourceUser is the domain).

Databases + cron + SSH import **generically** on the parsed tarball, so **web/db/cron/ssh restore is now functional** for CyberPanel.

**DNS + mail are step 3** — CyberPanel's PowerDNS `records` need BIND-zone synthesis and `/home/vmail/<domain>/<local>/` Maildirs need their own migration. `ImportMailboxes` cleanly skips when no mail subtree is present (warns `mailbox_skip:no_mail_subtree`), so there's no half-wired mail restore.

## Testing
- `TestParseTarball_CyberPanelDottedDomainAccount` — the shared parser handles a **dotted-domain** account (`cpmove-<domain>/` wrapper strip + `SourceUser` + mysql/cron classification).
- `go build` / `go vet` / cpanel + cmd-server suites green.

**Shared gate (with CloudPanel):** full pull→import E2E into a jabali destination reachable to the CyberPanel VM (192.168.100.86).