### PR TITLE
feat(migrate): CyberPanel restore step 3 — DNS zone synthesis (GH #522)

### DIFF
--- a/panel-api/internal/migrate/cpanel/bind_parse_cyberpanel_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_cyberpanel_test.go
@@ -1,0 +1,43 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #522: CyberPanel synthesises BIND zones from its PowerDNS records as
+// "<name>. <ttl> IN <type> [<prio> ]<content>" (SOA skipped, TXT quoted).
+// Assert ParseBINDZone reads that exact shape back into records.
+func TestParseBINDZone_CyberPanelGeneratedFormat(t *testing.T) {
+	zone := strings.Join([]string{
+		"smoke.jabalitest.com. 3600 IN A 192.0.2.50",
+		"www.smoke.jabalitest.com. 3600 IN A 192.0.2.50",
+		"smoke.jabalitest.com. 3600 IN MX 10 mail.smoke.jabalitest.com",
+		"smoke.jabalitest.com. 3600 IN TXT \"v=spf1 a mx ~all\"",
+	}, "\n") + "\n"
+
+	z, _, ok := ParseBINDZone(strings.NewReader(zone), "smoke.jabalitest.com")
+	if !ok {
+		t.Fatal("ParseBINDZone rejected the CyberPanel-generated zone")
+	}
+	byType := map[string]int{}
+	var mx, txt string
+	for _, r := range z.Records {
+		byType[r.Type]++
+		if r.Type == "MX" {
+			mx = r.Content
+		}
+		if r.Type == "TXT" {
+			txt = r.Content
+		}
+	}
+	if byType["A"] != 2 || byType["MX"] != 1 || byType["TXT"] != 1 {
+		t.Errorf("record types = %v, want 2 A + 1 MX + 1 TXT", byType)
+	}
+	if !strings.Contains(mx, "mail.smoke.jabalitest.com") {
+		t.Errorf("MX content lost the target: %q", mx)
+	}
+	if !strings.Contains(txt, "v=spf1") {
+		t.Errorf("TXT content lost the SPF record: %q", txt)
+	}
+}

--- a/panel-api/internal/migrate/cyberpanel/backup.go
+++ b/panel-api/internal/migrate/cyberpanel/backup.go
@@ -106,6 +106,23 @@ MYQ "SELECT aliasDomain FROM websiteFunctions_aliasdomains WHERE master_id=$WID"
   printf '%%s\t/home/%%s/public_html\n' "$ad" "$ACCT" >> "$BASE/domains-paths.txt"
 done
 
+# 3b. dnszones/<domain>.db — BIND zone per domain from CyberPanel's PowerDNS
+#     records (gmysql backend). Emit one record line per row:
+#       "<name>. <ttl> IN <type> [<prio> ]<content>"  (TXT content quoted).
+#     cpanel.ParseTarball classifies dnszones/ into ZoneFiles; cpanel.ImportDNS
+#     parses each + overlays the records onto the bootstrapped jabali zone
+#     (apex SOA/NS are filtered there — pdns owns them — so SOA is skipped
+#     here). No $ORIGIN/$TTL needed: ImportDNS derives the origin from the .db
+#     filename and each record carries its own FQDN name + TTL.
+mkdir -p "$BASE/dnszones"
+if [ -f "$BASE/domains-paths.txt" ]; then
+  cut -f1 "$BASE/domains-paths.txt" | while read -r DOM; do
+    if [ -z "$DOM" ]; then continue; fi
+    MYQ "SELECT CONCAT(name, '. ', ttl, ' IN ', type, ' ', IF(type IN ('MX','SRV'), CONCAT(prio, ' '), ''), IF(type = 'TXT', CONCAT(CHAR(34), content, CHAR(34)), content)) FROM records WHERE domain_id = (SELECT id FROM domains WHERE name = '$DOM') AND type <> 'SOA' AND (disabled = 0 OR disabled IS NULL) ORDER BY type" > "$BASE/dnszones/$DOM.db" 2>/dev/null || true
+    if [ ! -s "$BASE/dnszones/$DOM.db" ]; then rm -f "$BASE/dnszones/$DOM.db"; fi
+  done
+fi
+
 # 4. cron/<domain> — the externalApp user's crontab. Guard externalApp against
 #    the same allow-list the Go side enforces before it reaches crontab -u.
 if printf '%%s' "$EXTAPP" | grep -Eq '^[a-z_][a-z0-9._-]{0,63}$'; then
@@ -123,7 +140,7 @@ if [ ! -s "$BASE/homedir/.ssh/authorized_keys" ]; then rm -f "$BASE/homedir/.ssh
 # 6. tar it up. cp/ FIRST (ParseTarball wrapper detection — see above), then
 #    the areas that exist. Last stdout line = the path the caller reads.
 TARARGS="cpmove-$ACCT/cp"
-for d in mysql cron homedir domains-paths.txt; do
+for d in mysql dnszones cron homedir domains-paths.txt; do
   if [ -e "$BASE/$d" ]; then TARARGS="$TARARGS cpmove-$ACCT/$d"; fi
 done
 tar -czf "$OUT" -C "$TMP" $TARARGS

--- a/panel-api/internal/migrate/cyberpanel/backup_test.go
+++ b/panel-api/internal/migrate/cyberpanel/backup_test.go
@@ -43,6 +43,8 @@ func TestBackupUser_SynthesizeScriptAndPath(t *testing.T) {
 		`domains-paths.txt`,
 		`websiteFunctions_childdomains`, // child domains
 		`websiteFunctions_aliasdomains`, // alias domains
+		`FROM records WHERE domain_id`,  // DNS BIND-zone synth
+		`dnszones`,                      // per-domain zone dir
 		`crontab -u "$EXTAPP" -l`,       // cron
 		`TARARGS="cpmove-$ACCT/cp"`,     // cp/ archived FIRST (ParseTarball wrapper detection)
 		`tar -czf "$OUT"`,


### PR DESCRIPTION
Synthesizes BIND zone files from CyberPanel's PowerDNS `records` so source DNS migrates. `BackupUser` emits `dnszones/<domain>.db` per domain — one record line each, in the exact shape `cpanel.ParseTarball` + `ImportDNS` already consume:

```
<name>. <ttl> IN <type> [<prio> ]<content>
```

built directly in SQL (`records` JOIN `domains` by name). Apex `SOA` skipped (ImportDNS filters apex SOA/NS — pdns owns them); TXT quoted via `CHAR(34)`; disabled records excluded. No `$ORIGIN`/`$TTL` needed — ImportDNS derives origin from the `.db` filename, each record carries its own FQDN + TTL. `dnszones/` is archived after `cp/`, so wrapper-detection order holds.

**No import wiring needed**: `ParseTarball` classifies `dnszones/` into `ZoneFiles` and `ImportDNS` runs generically (gated by `plan.DNS`, not source kind, wired in #599), so records overlay the bootstrapped jabali zone with the source IP repointed.

Mailboxes (`/home/vmail` Maildir migration) remain **step 4**.

## Testing
- **Box-verified** on the live CyberPanel VM (192.168.100.86): seeded a PowerDNS zone (A / www / MX / TXT + SOA); the synth produced exactly the 4 BIND lines (SOA skipped, MX prio prepended, TXT quoted); cp-first tar order intact; `dnszones/smoke.jabalitest.com.db` in the tarball.
- `ParseBINDZone` round-trips the generated format (2 A + MX-with-target + TXT-with-SPF).
- Synth-script test asserts the records query + `dnszones` dir. build + vet + package suites green.