### PR TITLE
feat(migrate): CyberPanel restore step 4a — mail-paths.txt manifest (GH #522)

### DIFF
--- a/panel-api/internal/migrate/cyberpanel/backup.go
+++ b/panel-api/internal/migrate/cyberpanel/backup.go
@@ -123,6 +123,16 @@ if [ -f "$BASE/domains-paths.txt" ]; then
   done
 fi
 
+# 3c. mail-paths.txt — <address>\t<abs Maildir> for the restore-time Maildir
+#     sync into the staging mail tree (parity with Plesk's mail-paths.txt).
+#     CyberPanel stores mail at /home/vmail/<domain>/<local>/Maildir;
+#     e_users.email is the full address, e_domains maps the mail domain to the
+#     website (domainOwner_id = WID). The Maildir rsync + ImportMailboxes push
+#     into Stalwart land in a follow-up step; this manifests the inventory.
+#     Two columns (mysql -N -B tab-separates) so the tab is real, not escaped.
+MYQ "SELECT u.email, CONCAT('/home/vmail/', SUBSTRING_INDEX(u.email, '@', -1), '/', SUBSTRING_INDEX(u.email, '@', 1), '/Maildir') FROM e_users u JOIN e_domains d ON u.emailOwner_id = d.domain WHERE d.domainOwner_id = $WID" > "$BASE/mail-paths.txt" 2>/dev/null || true
+if [ ! -s "$BASE/mail-paths.txt" ]; then rm -f "$BASE/mail-paths.txt"; fi
+
 # 4. cron/<domain> — the externalApp user's crontab. Guard externalApp against
 #    the same allow-list the Go side enforces before it reaches crontab -u.
 if printf '%%s' "$EXTAPP" | grep -Eq '^[a-z_][a-z0-9._-]{0,63}$'; then
@@ -140,7 +150,7 @@ if [ ! -s "$BASE/homedir/.ssh/authorized_keys" ]; then rm -f "$BASE/homedir/.ssh
 # 6. tar it up. cp/ FIRST (ParseTarball wrapper detection — see above), then
 #    the areas that exist. Last stdout line = the path the caller reads.
 TARARGS="cpmove-$ACCT/cp"
-for d in mysql dnszones cron homedir domains-paths.txt; do
+for d in mysql dnszones cron homedir domains-paths.txt mail-paths.txt; do
   if [ -e "$BASE/$d" ]; then TARARGS="$TARARGS cpmove-$ACCT/$d"; fi
 done
 tar -czf "$OUT" -C "$TMP" $TARARGS

--- a/panel-api/internal/migrate/cyberpanel/backup_test.go
+++ b/panel-api/internal/migrate/cyberpanel/backup_test.go
@@ -44,9 +44,11 @@ func TestBackupUser_SynthesizeScriptAndPath(t *testing.T) {
 		`websiteFunctions_childdomains`, // child domains
 		`websiteFunctions_aliasdomains`, // alias domains
 		`FROM records WHERE domain_id`,  // DNS BIND-zone synth
-		`dnszones`,                      // per-domain zone dir
-		`crontab -u "$EXTAPP" -l`,       // cron
-		`TARARGS="cpmove-$ACCT/cp"`,     // cp/ archived FIRST (ParseTarball wrapper detection)
+		`FROM e_users u JOIN e_domains`, // mail-paths.txt manifest
+		`mail-paths.txt`,
+		`dnszones`,                  // per-domain zone dir
+		`crontab -u "$EXTAPP" -l`,   // cron
+		`TARARGS="cpmove-$ACCT/cp"`, // cp/ archived FIRST (ParseTarball wrapper detection)
 		`tar -czf "$OUT"`,
 	} {
 		if !strings.Contains(*last, want) {


### PR DESCRIPTION
Emits `mail-paths.txt` in the synthesized cpmove — `<address>\t<abs Maildir>` per mailbox — so the restore stage can locate each source Maildir. Parity with Plesk's `mail-paths.txt`: CyberPanel keeps mail at `/home/vmail/<domain>/<local>/Maildir` (**outside** the account home, so it's not bundled). Built from `e_users JOIN e_domains` (`domainOwner_id = WID`); two SELECT columns so `mysql -N -B` tab-separates them (real tab). Archived after `cp/`.

**This is the manifest half.** Step 4b wires the Maildir rsync (reusing `migration.rsync_remote_home` with `src_account=vmail`, dest `/home/<target>/mail/<domain>/<local>`) + points `ParsedTarball.MailRoot` there so the generic `cpanel.ImportMailboxes` walks it + pushes into Stalwart — gated on a **live mail E2E**: the source layout `<local>/Maildir/{cur,new,tmp}` differs from the cpanel `<local>/{cur,new,tmp}` `ImportMailboxes` expects, so the rsync path mapping must be E2E-verified before it ships.

Note found while investigating: **no source currently rsyncs Maildirs at restore** — even Plesk's `mail-paths.txt` is manifest-only. Step 4b closes that for CyberPanel.

## Testing
- **Box-verified** on the live CyberPanel VM (192.168.100.86): `info@smoke.jabalitest.com` → `/home/vmail/smoke.jabalitest.com/info/Maildir`; full synth still cp-first with `dnszones` + `domains-paths` + `mail-paths`.
- Synth-script test asserts the `e_users`/`e_domains` query + `mail-paths` dir. build + vet + package suite green.