### PR TITLE
fix(apparmor): allow PHP-FPM to load the Microsoft ODBC driver (JAB-166)

### DIFF
--- a/install/apparmor/usr.local.libexec.jabali.fpm-exec
+++ b/install/apparmor/usr.local.libexec.jabali.fpm-exec
@@ -47,6 +47,19 @@ profile jabali-fpm-app /usr/local/libexec/jabali/fpm-exec flags=(attach_disconne
   /etc/jabali/snuffleupagus/ r,
   /etc/jabali/snuffleupagus/** r,
 
+  # Microsoft ODBC Driver for SQL Server (sqlsrv / pdo_sqlsrv). The extension
+  # dlopen()s the driver at connect time, so the profile — not open_basedir —
+  # gates it. Without these the load fails and sqlsrv reports IMSSP -49
+  # "This extension requires the Microsoft ODBC Driver for SQL Server" even
+  # though the driver is installed, which reads as a missing-package problem
+  # and sends operators down a reinstall rabbit hole (newzaps 2026-07-19:
+  # denial was on /opt/microsoft/ while msodbcsql18 had been installed for a
+  # month). Read-only; drivers are root-owned so this grants no tenant write.
+  /opt/microsoft/ r,
+  /opt/microsoft/** mr,
+  /etc/odbcinst.ini r,
+  /etc/odbc.ini r,
+
   # Tenant docroots (POSIX perms enforce per-user isolation; this layer bounds
   # escape to system files, not cross-tenant). Two layouts: native jabali +
   # cPanel/DA use domains/<dom>/public_html; HestiaCP-migrated accounts use


### PR DESCRIPTION
## Problem

The `jabali-fpm-app` AppArmor profile (enforce) grants `/usr/lib/php/** mr,` but has no rule for `/opt/microsoft/**`, where the Microsoft ODBC Driver for SQL Server lives. `sqlsrv` / `pdo_sqlsrv` `dlopen()` the driver at connect time, so the profile — **not `open_basedir`** — gates it.

Result: any tenant using MSSQL from PHP fails with

```
IMSSP -49: This extension requires the Microsoft ODBC Driver for SQL Server
```

The error text blames a missing package, so it reads as a hosting/packaging problem rather than a jabali policy bug.

## Impact (real, twice)

On newzaps (`sample.nfinance.co.il`) this caused two production outages. Both times the driver was installed and registered the whole time — `msodbcsql18 18.6.2.1` since Jun 21, `odbcinst -q -d` returning `[ODBC Driver 18 for SQL Server]`, and **no removal events in apt/dpkg logs, ever**.

Two separate requests were nearly sent to the hosting provider asking them to reinstall a driver that had never been missing, `apt-mark hold` it, and restart `php8.4-fpm` (which is masked on jabali — sites run `jabali-fpm@<user>`).

The second outage happened because the first fix was applied as a hand-edit and config convergence restored the shipped template overnight. That is exactly why this needs to be in the repo.

## Root cause evidence

```
apparmor="DENIED" operation="open" profile="jabali-fpm-app"
name="/opt/microsoft/" comm="php-fpm8.4" requested_mask="r" denied_mask="r"
FSUID="samplenfinanceco"
```

CLI `/usr/bin/php8.4` is unconfined and connects fine; FPM `/usr/sbin/php-fpm8.4` is confined and fails. That is the entire CLI-vs-FPM split.

Ruled out by controlled test, not assumption:
- **`open_basedir`** — CLI with the *identical* `open_basedir` connects fine; `dlopen()` bypasses it at the C level.
- **Snuffleupagus** — every rule is `.simulation()` (log-only), and it loads under CLI too.
- **Per-user egress (M34)** — policy explicitly allows it: `ip daddr 83.229.74.50 tcp dport 1433 accept`.
- Stale master, file permissions, mount namespace, `clear_env`, driver `.so` deps — all verified fine.

## Change

```
/opt/microsoft/ r,
/opt/microsoft/** mr,
/etc/odbcinst.ini r,
/etc/odbc.ini r,
```

Read-only. The driver tree is root-owned, so this grants no tenant write capability and does not weaken cross-tenant isolation.

## Verification

Applied on mx.zaps.co.il: error moved from `IMSSP -49` to `28000 / 18456` — a real SQL Server login rejection for dummy credentials, i.e. extension → driver → TLS → SQL Server all work. The tenant's own connection test returns success.

## Test plan

- [x] `apparmor_parser -r` accepts the profile
- [x] Tenant MSSQL connection succeeds under the enforced profile
- [x] Verified on newzaps end-to-end (customer page green)
- [ ] After merge: `jabali update` on newzaps so the deployed profile matches the repo and the hand-edit is no longer load-bearing

## Notes

Tracked as JAB-166. Worth a follow-up audit of the profile for other `dlopen()`'d vendor library paths under `/opt` — this failure mode recurs for any tenant library outside `/usr/lib/php`, and always presents as a misleading "missing package" error.
