### PR TITLE
feat(migrate): CyberPanel restore step 4b — Maildir rsync into MailRoot (GH #522)

### DIFF
--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -479,7 +479,7 @@ func applyAccountRestore(
 				warnings = append(warnings, "mail: Stalwart inactive — message import skipped")
 				continue
 			}
-			impRes, impErr := importMaildirTree(ctx, mailTree, "")
+			impRes, impErr := importMaildirTree(ctx, mailTree, "", migrationStagingRoots)
 			if impErr != nil {
 				warnings = append(warnings, fmt.Sprintf("mail: import: %v", impErr))
 				continue

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -291,7 +291,7 @@ func applySelectiveMail(ctx context.Context, stagingRoot string, mailboxes []str
 			warnings = append(warnings, "mail "+mb+": not found in this backup — skipped")
 			continue
 		}
-		n, _, _, ierr := importOneMailbox(ctx, mb, md)
+		n, _, _, ierr := importOneMailbox(ctx, mb, md, migrationStagingRoots)
 		if ierr != nil {
 			warnings = append(warnings, "mail "+mb+": import: "+ierr.Error())
 			continue

--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -63,6 +63,11 @@ type migrationImportMailboxesParams struct {
 	// handler skips owner-mailbox detection — only per-domain
 	// dirs are processed.
 	OwnerEmail string `json:"owner_email,omitempty"`
+	// DestUser, when set, additionally permits src_mail_dir under
+	// /home/<DestUser>/mail — CyberPanel Maildirs are rsynced into the migrated
+	// user's home (out-of-tarball /home/vmail source), not the staging tree.
+	// Reads stay symlink-safe (scoped RESOLVE_BENEATH this root).
+	DestUser string `json:"dest_user,omitempty"`
 }
 
 type migrationImportMailboxesResult struct {
@@ -95,8 +100,17 @@ func migrationImportMailboxesHandler(ctx context.Context, raw json.RawMessage) (
 			Code: agentwire.CodeInvalidArgument, Message: "src_mail_dir not absolute: " + err.Error(),
 		}
 	}
+	allowedRoots := migrationStagingRoots
+	if p.DestUser != "" {
+		if strings.Contains(p.DestUser, "/") || strings.Contains(p.DestUser, "..") {
+			return nil, &agentwire.AgentError{
+				Code: agentwire.CodeInvalidArgument, Message: "dest_user must be a bare username",
+			}
+		}
+		allowedRoots = append(append([]string{}, migrationStagingRoots...), "/home/"+p.DestUser+"/mail")
+	}
 	underRoot := false
-	for _, root := range migrationStagingRoots {
+	for _, root := range allowedRoots {
 		if strings.HasPrefix(srcAbs+"/", root+"/") {
 			underRoot = true
 			break
@@ -105,11 +119,11 @@ func migrationImportMailboxesHandler(ctx context.Context, raw json.RawMessage) (
 	if !underRoot {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("src_mail_dir must live under %s, got %q", strings.Join(migrationStagingRoots, " or "), srcAbs),
+			Message: fmt.Sprintf("src_mail_dir must live under %s, got %q", strings.Join(allowedRoots, " or "), srcAbs),
 		}
 	}
 
-	return importMaildirTree(ctx, srcAbs, p.OwnerEmail)
+	return importMaildirTree(ctx, srcAbs, p.OwnerEmail, allowedRoots)
 }
 
 // importMaildirTree imports every <domain>/<local>/{cur,new,.Sub} Maildir
@@ -119,7 +133,7 @@ func migrationImportMailboxesHandler(ctx context.Context, raw json.RawMessage) (
 // Shared by migration.import_mailboxes (operator-supplied path, prefix-
 // guarded by the caller) and account-restore (internally-derived path,
 // ADR-0123). Applies its own 4h ceiling.
-func importMaildirTree(ctx context.Context, srcAbs, ownerEmail string) (*migrationImportMailboxesResult, error) {
+func importMaildirTree(ctx context.Context, srcAbs, ownerEmail string, allowedRoots []string) (*migrationImportMailboxesResult, error) {
 	subctx, cancel := context.WithTimeout(ctx, migrationMailboxTimeout)
 	defer cancel()
 
@@ -131,7 +145,7 @@ func importMaildirTree(ctx context.Context, srcAbs, ownerEmail string) (*migrati
 	// when supplied so messages aren't silently dropped.
 	if ownerEmail != "" {
 		if _, ok := looksLikeMailMaildir(srcAbs); ok {
-			n, b, skipped, err := importOneMailbox(subctx, ownerEmail, srcAbs)
+			n, b, skipped, err := importOneMailbox(subctx, ownerEmail, srcAbs, allowedRoots)
 			if err != nil {
 				res.Skipped = append(res.Skipped, fmt.Sprintf("owner_mailbox %s: %v", ownerEmail, err))
 			} else {
@@ -172,7 +186,7 @@ func importMaildirTree(ctx context.Context, srcAbs, ownerEmail string) (*migrati
 				continue
 			}
 			email := fmt.Sprintf("%s@%s", u.Name(), dom.Name())
-			n, b, skipped, err := importOneMailbox(subctx, email, maildirPath)
+			n, b, skipped, err := importOneMailbox(subctx, email, maildirPath, allowedRoots)
 			if err != nil {
 				// Don't fail the whole job on one mailbox — record
 				// + skip. Operator inspects manifest_json + can
@@ -235,7 +249,7 @@ func looksLikeMailMaildir(path string) (string, bool) {
 // is per-blob, not per-batch. Pipelining 10-100 imports per JMAP
 // call would be a follow-up optimisation; v1 sequential import is
 // correct + bounded.
-func importOneMailbox(ctx context.Context, destEmail, maildir string) (int64, int64, []string, error) {
+func importOneMailbox(ctx context.Context, destEmail, maildir string, allowedRoots []string) (int64, int64, []string, error) {
 	// Ensure domain + account exist in Stalwart before trying to import.
 	// accountEnsureInRegistry is idempotent: creates domain then account
 	// when absent, no-ops when they already exist.
@@ -258,7 +272,7 @@ func importOneMailbox(ctx context.Context, destEmail, maildir string) (int64, in
 	var skipped []string
 
 	// Push INBOX (mailroot itself: cur/ + new/).
-	in, ib, isk := pushMaildirSlots(ctx, accountID, inboxID, maildir, &skipped)
+	in, ib, isk := pushMaildirSlots(ctx, accountID, inboxID, maildir, &skipped, allowedRoots)
 	imported += in
 	bytes += ib
 	skipped = append(skipped, isk...)
@@ -297,7 +311,7 @@ func importOneMailbox(ctx context.Context, destEmail, maildir string) (int64, in
 			skipped = append(skipped, fmt.Sprintf("ensure mailbox %q: %v", raw, err))
 			continue
 		}
-		sn, sb, ssk := pushMaildirSlots(ctx, accountID, mboxID, subDir, &skipped)
+		sn, sb, ssk := pushMaildirSlots(ctx, accountID, mboxID, subDir, &skipped, allowedRoots)
 		imported += sn
 		bytes += sb
 		skipped = append(skipped, ssk...)
@@ -309,7 +323,7 @@ func importOneMailbox(ctx context.Context, destEmail, maildir string) (int64, in
 // pushMaildirSlots imports every .eml-shaped message under
 // <maildir>/cur + <maildir>/new into the named Stalwart mailbox.
 // Returns (messages_imported, bytes_imported, skipped).
-func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string, _ *[]string) (int64, int64, []string) {
+func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string, _ *[]string, allowedRoots []string) (int64, int64, []string) {
 	var imported, bytes int64
 	var skipped []string
 	// Idempotency: Stalwart's Email/import does NOT dedup on Message-ID
@@ -338,7 +352,7 @@ func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string,
 				skipped = append(skipped, fmt.Sprintf("oversized:%s:%d", path, info.Size()))
 				continue
 			}
-			if mid := messageIDFromFile(path); mid != "" {
+			if mid := messageIDFromFile(path, allowedRoots); mid != "" {
 				if seen[mid] {
 					continue // already in mailbox → idempotent skip
 				}
@@ -357,7 +371,7 @@ func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string,
 					keywords["$seen"] = true
 				}
 			}
-			n, err := importOneMessage(ctx, accountID, mailboxID, path, info.Size(), keywords, info.ModTime())
+			n, err := importOneMessage(ctx, accountID, mailboxID, path, info.Size(), keywords, info.ModTime(), allowedRoots)
 			if err != nil {
 				skipped = append(skipped, fmt.Sprintf("%s: %v", path, err))
 				continue
@@ -564,8 +578,8 @@ func mailboxIDByRole(ctx context.Context, accountID, role string) (string, error
 
 // importOneMessage = blob upload + Email/import in two HTTP round-
 // trips. Returns the bytes uploaded.
-func importOneMessage(ctx context.Context, accountID, mailboxID, path string, size int64, keywords map[string]bool, receivedAt time.Time) (int64, error) {
-	blobID, err := uploadBlob(ctx, accountID, path)
+func importOneMessage(ctx context.Context, accountID, mailboxID, path string, size int64, keywords map[string]bool, receivedAt time.Time, allowedRoots []string) (int64, error) {
+	blobID, err := uploadBlob(ctx, accountID, path, allowedRoots)
 	if err != nil {
 		return 0, fmt.Errorf("blob/upload: %w", err)
 	}
@@ -608,8 +622,8 @@ func importOneMessage(ctx context.Context, accountID, mailboxID, path string, si
 
 // uploadBlob streams the file at `path` to Stalwart's /jmap/upload/<accountId>
 // endpoint. Returns the produced blobId.
-func uploadBlob(ctx context.Context, accountID, path string) (string, error) {
-	f, err := openMaildirFileInStaging(path)
+func uploadBlob(ctx context.Context, accountID, path string, allowedRoots []string) (string, error) {
+	f, err := openMaildirFileInStaging(path, allowedRoots)
 	if err != nil {
 		return "", err
 	}
@@ -777,8 +791,8 @@ func existingMessageIDs(ctx context.Context, accountID, mailboxID string) map[st
 
 // messageIDFromFile reads the Message-ID header from an RFC822 file.
 // Returns "" when absent (such messages can't be deduped — they import).
-func messageIDFromFile(path string) string {
-	f, err := openMaildirFileInStaging(path)
+func messageIDFromFile(path string, allowedRoots []string) string {
+	f, err := openMaildirFileInStaging(path, allowedRoots)
 	if err != nil {
 		return ""
 	}
@@ -812,8 +826,8 @@ func normMsgID(s string) string {
 // the root agent into reading a host file and uploading it into a mailbox
 // (Gitea #477). ReadDir/Stat above may follow a symlink, but this open is the
 // gate: a symlinked component is refused here.
-func openMaildirFileInStaging(path string) (*os.File, error) {
-	scope, err := filesafe.NewScope("migration", "migration", migrationStagingRoots)
+func openMaildirFileInStaging(path string, allowedRoots []string) (*os.File, error) {
+	scope, err := filesafe.NewScope("migration", "migration", allowedRoots)
 	if err != nil {
 		return nil, err
 	}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1257,6 +1257,68 @@ func cpanelRestoreCallback(
 			warnings = append(warnings, "cron: skipped per migration plan")
 		}
 
+		// CyberPanel mail: Maildirs live at /home/vmail/<domain>/<local>/Maildir,
+		// OUTSIDE the account home, so they aren't in the cpmove tarball. rsync
+		// each one (manifested in mail-paths.txt) into the target's home mail
+		// tree via the shared rsync_remote_home: src_account=vmail scopes the
+		// source to /home/vmail, dest is /home/<target>/mail/<domain>/<local>.
+		// The agent copies <Maildir>/ CONTENTS (trailing slash), so cur/new/tmp
+		// land directly under <local>/ — exactly the layout ImportMailboxes
+		// walks. Point MailRoot there so the generic import below picks it up.
+		if plan.Mailboxes && job.SourceKind == models.MigrationSourceCyberPanel && job.SourceHost != "" {
+			mailManifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+p.parsed.SourceUser, "mail-paths.txt")
+			if raw, rerr := os.ReadFile(mailManifest); rerr == nil {
+				secretPath := fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID)
+				remoteSSHUser := migrationSSHUser(job) // root for CyberPanel
+				destMailRoot := filepath.Join("/home", p.targetUsername, "mail")
+				mboxCount := 0
+				for _, line := range strings.Split(string(raw), "\n") {
+					line = strings.TrimSpace(line)
+					if line == "" {
+						continue
+					}
+					parts := strings.SplitN(line, "\t", 2)
+					if len(parts) != 2 {
+						continue
+					}
+					addr, srcMaildir := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+					at := strings.LastIndex(addr, "@")
+					if at < 1 {
+						continue
+					}
+					// SECURITY: only a source Maildir under /home/vmail/ — a
+					// tampered manifest must not rsync an arbitrary source path
+					// (the SSH login is root). The agent re-checks via
+					// src_account=vmail; this is defence in depth.
+					if !strings.HasPrefix(filepath.Clean(srcMaildir), "/home/vmail/") {
+						warnings = append(warnings, fmt.Sprintf("mail_rsync: %s: source %q not under /home/vmail — refused", addr, srcMaildir))
+						continue
+					}
+					local, mdom := addr[:at], addr[at+1:]
+					destPath := filepath.Join(destMailRoot, mdom, local)
+					if _, mrErr := restoreAgent.Call(ctx, "migration.rsync_remote_home", map[string]any{
+						"port":        srcSSHPort(job),
+						"job_id":      job.ID,
+						"src_account": "vmail",
+						"host":        job.SourceHost,
+						"ssh_user":    remoteSSHUser,
+						"secret_path": secretPath,
+						"src_path":    srcMaildir,
+						"dest_path":   destPath,
+						"dest_user":   p.targetUsername,
+					}); mrErr != nil {
+						warnings = append(warnings, fmt.Sprintf("mail_rsync: %s: %v", addr, mrErr))
+						continue
+					}
+					mboxCount++
+				}
+				if mboxCount > 0 {
+					p.parsed.MailRoot = destMailRoot
+					warnings = append(warnings, fmt.Sprintf("mail: rsynced %d maildir(s) -> %s (CyberPanel /home/vmail)", mboxCount, destMailRoot))
+				}
+			}
+		}
+
 		if plan.Mailboxes {
 			mailRes, err := cpanel.ImportMailboxes(ctx, p.parsed, restoreAgent, job.ID, mbRepo, domainsRepo, preserve.Credentials)
 			if err != nil {

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1320,7 +1320,7 @@ func cpanelRestoreCallback(
 		}
 
 		if plan.Mailboxes {
-			mailRes, err := cpanel.ImportMailboxes(ctx, p.parsed, restoreAgent, job.ID, mbRepo, domainsRepo, preserve.Credentials)
+			mailRes, err := cpanel.ImportMailboxes(ctx, p.parsed, restoreAgent, job.ID, mbRepo, domainsRepo, preserve.Credentials, p.targetUsername)
 			if err != nil {
 				return bytes, warnings, fmt.Errorf("mailboxes: %w", err)
 			}

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -65,7 +65,7 @@ type agentImportMailboxesResult struct {
 // agentCli nil → observation-only behaviour (legacy stub —
 // per-mailbox 'pending_manual' warnings recorded; no JMAP push).
 // Useful for tests + dry-run paths where Stalwart isn't reachable.
-func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.AgentInterface, jobID string, mbRepo repository.MailboxRepository, domainsRepo repository.DomainRepository, preserveCreds bool) (*MailImportResult, error) {
+func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.AgentInterface, jobID string, mbRepo repository.MailboxRepository, domainsRepo repository.DomainRepository, preserveCreds bool, destUser string) (*MailImportResult, error) {
 	if parsed == nil {
 		return nil, fmt.Errorf("ImportMailboxes: parsed nil")
 	}
@@ -184,6 +184,10 @@ func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.
 		"job_id":       jobID,
 		"src_mail_dir": mailRoot,
 		"owner_email":  parsed.OwnerEmail, // empty → agent skips owner-mailbox detection
+		// dest_user lets the agent also accept a MailRoot under /home/<destUser>/mail
+		// (CyberPanel rsyncs its /home/vmail Maildirs into the target's home, not
+		// the staging tree). Empty for tarball-bundled sources (staging root only).
+		"dest_user": destUser,
 	})
 	if err != nil {
 		// Don't fail the whole restore stage on a mail import
@@ -441,13 +445,13 @@ func listSourceMailAccounts(domainDir string) []string {
 // what Stalwart recognises by prefix.
 var stalwartHashPrefixes = []string{
 	"$2a$", "$2b$", "$2y$", // bcrypt
-	"$6$",      // SHA-512 crypt
-	"$5$",      // SHA-256 crypt
-	"$1$",      // MD5 crypt
-	"$argon2",  // $argon2id / $argon2i / $argon2d
-	"$pbkdf2",  // PBKDF2 variants
-	"$scrypt",  // scrypt
-	"$sha1",    // SHA-1 crypt
+	"$6$",     // SHA-512 crypt
+	"$5$",     // SHA-256 crypt
+	"$1$",     // MD5 crypt
+	"$argon2", // $argon2id / $argon2i / $argon2d
+	"$pbkdf2", // PBKDF2 variants
+	"$scrypt", // scrypt
+	"$sha1",   // SHA-1 crypt
 }
 
 // normalizeSourceMailHash strips a leading dovecot {SCHEME} tag and returns the

--- a/panel-api/internal/migrate/cpanel/restore_mail_owner_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_owner_test.go
@@ -44,7 +44,7 @@ func TestImportMailboxes_CountsOwnerTopLevelMaildir(t *testing.T) {
 	}
 
 	// agentCli nil → observation-only: counts then returns, no JMAP.
-	res, err := ImportMailboxes(context.Background(), parsed, nil, "", nil, nil, false)
+	res, err := ImportMailboxes(context.Background(), parsed, nil, "", nil, nil, false, "")
 	if err != nil {
 		t.Fatalf("ImportMailboxes: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestImportMailboxes_NoOwnerEmailSkipsTopLevel(t *testing.T) {
 		MailRoot:   mailRoot,
 		// OwnerEmail intentionally empty.
 	}
-	res, err := ImportMailboxes(context.Background(), parsed, nil, "", nil, nil, false)
+	res, err := ImportMailboxes(context.Background(), parsed, nil, "", nil, nil, false, "")
 	if err != nil {
 		t.Fatalf("ImportMailboxes: %v", err)
 	}

--- a/panel-api/internal/migrate/cpanel/restore_mail_preserve_integration_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_preserve_integration_test.go
@@ -80,7 +80,7 @@ func TestImportMailboxes_PreservesSourcePassword(t *testing.T) {
 	mb := &fakeMailboxRepoMB{}
 	dom := &fakeDomainRepoMB{id: "01DOMAINID0000000000000000"}
 
-	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, true /*preserveCreds*/)
+	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, true /*preserveCreds*/, "")
 	if err != nil {
 		t.Fatalf("ImportMailboxes: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestImportMailboxes_DefaultSetsFreshPasswordAndWarns(t *testing.T) {
 	mb := &fakeMailboxRepoMB{}
 	dom := &fakeDomainRepoMB{id: "01DOMAINID0000000000000000"}
 
-	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, false /*preserveCreds*/)
+	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, false /*preserveCreds*/, "")
 	if err != nil {
 		t.Fatalf("ImportMailboxes: %v", err)
 	}


### PR DESCRIPTION
Completes CyberPanel mail restore. Its Maildirs live at `/home/vmail/<domain>/<local>/Maildir` (outside the account home, not bundled), so each one (from `mail-paths.txt`, #603) is rsynced into the target's home mail tree via the shared `migration.rsync_remote_home`:

- `src_account=vmail` scopes the source to `/home/vmail`; dest is `/home/<target>/mail/<domain>/<local>`.
- The agent copies `<Maildir>/` **contents** (trailing slash), so `cur/new/tmp` land directly under `<local>/` — exactly the layout `cpanel.ImportMailboxes` walks (verified from the agent's rsync argv).
- `MailRoot` is then pointed at `/home/<target>/mail`, so the generic `ImportMailboxes` below imports + pushes the messages into Stalwart (JMAP).
- Source path allow-listed to `/home/vmail/` before dispatch (defence in depth vs the agent's `vmail` scope).

Gated by `plan.Mailboxes` + online source. Reuses the analyze-root + `src_account` fixes from #601.

## ⚠ E2E pending
This is the mail-data path — it **must** be verified by a live CyberPanel→jabali migration (real Maildir message → Stalwart) before it's trusted. The verification was blocked: the CyberPanel test VM (192.168.100.86) went unreachable mid-run. The code reuses the `rsync_remote_home` path that #601 already E2E-verified end-to-end (CloudPanel), and the Maildir→MailRoot mapping is derived directly from the agent's trailing-slash contents copy, but the mail→Stalwart push is **not yet live-confirmed**. Recommend holding merge until the mail E2E runs.

## Testing
- build + vet + cmd/server suite green.
- (Mail E2E: pending VM availability.)