### PR TITLE
fix(migrate): Mailbox/set needs jmap:mail capability (mail-import folders)

### DIFF
--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -534,7 +534,11 @@ func createMailboxUnder(ctx context.Context, accountID, name, role, parentID str
 		"create":    map[string]any{createID: body},
 	}
 	var result jmapSetResult
-	if err := jmapCall(ctx, "Mailbox/set", args, &result); err != nil {
+	// Mailbox/set (like Mailbox/get/query + Email/*) is a mail-capability method:
+	// Stalwart rejects it with "requires capability urn:ietf:params:jmap:mail"
+	// unless it's in the request's `using` set. Surfaced in the CyberPanel mail
+	// E2E creating the Junk/Deleted auto-folders (JAB-29 family).
+	if err := jmapCallWith(ctx, "urn:ietf:params:jmap:mail", "Mailbox/set", args, &result); err != nil {
 		return "", fmt.Errorf("Mailbox/set create: %w", err)
 	}
 	if reason, ok := result.NotCreated[createID]; ok {


### PR DESCRIPTION
`Mailbox/set` was called via plain `jmapCall` (base capability set only), so Stalwart rejected it: *"Method Mailbox/set requires capability urn:ietf:params:jmap:mail which is not present in the using property"*. So the mail import couldn't create the standard folders (Junk / Deleted / etc.) during a migration.

Every other mail method in this file already uses `jmapCallWith(ctx, "urn:ietf:params:jmap:mail", ...)` — `Mailbox/set` was the one that didn't. Affects **all** sources' mail import, not just CyberPanel.

Surfaced in the live CyberPanel mail E2E: the INBOX message imported fine (`messages_pushed=1`) but auto-folder creation warned every run. One-line capability fix.

`go build` / `go vet` / `panel-agent` suite green.