### PR TITLE
feat(migrate): CloudPanel + CyberPanel in the admin migration picker (GH #522)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -63,6 +63,8 @@ const SOURCE_DESC: Record<string, string> = {
   whm_pkgacct: "Uploaded WHM Full Backup / pkgacct tarball",
   directadmin: "Live SSH or backup_user tarball — domains, users, DBs, mail, DNS, SSL",
   hestiacp: "Live SSH or v-backup-user tarball — web, mail, DNS, databases, cron",
+  cloudpanel: "Live SSH — web sites, PHP, databases, cron, SSH keys (no mail)",
+  cyberpanel: "Live SSH — web sites, databases, cron, SSH keys, DNS, mail",
   plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
   wordpress_ssh: "Cloudways / VPS / generic SSH — single WP site (files + DB + wp-config rewrite)",
   wordpress_plugin: "No SSH — jabali-migrator plugin on the source pushes over a token-authed API",
@@ -97,6 +99,8 @@ const SOURCE_OPTIONS = [
   { value: "whm_pkgacct", label: "WHM pkgacct (uploaded tarball)" },
   { value: "directadmin", label: "DirectAdmin (live SSH source)" },
   { value: "hestiacp", label: "HestiaCP (live SSH source)" },
+  { value: "cloudpanel", label: "CloudPanel (live SSH source)" },
+  { value: "cyberpanel", label: "CyberPanel (live SSH source)" },
   { value: "plesk", label: "Plesk (live SSH source)" },
 ];
 

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -71,6 +71,8 @@ const SOURCE_OPTIONS = [
   // migrate_run_cmd.go.
   { value: "directadmin", label: "DirectAdmin (single account)" },
   { value: "hestiacp", label: "HestiaCP (single account)" },
+  { value: "cloudpanel", label: "CloudPanel (site users)" },
+  { value: "cyberpanel", label: "CyberPanel (websites)" },
   { value: "plesk", label: "Plesk (subscriptions)" },
 ];
 
@@ -79,6 +81,8 @@ const SOURCE_DESC: Record<string, string> = {
   cpanel: "Live SSH or pkgacct backup — one full cPanel account",
   directadmin: "Live SSH or backup_user tarball — DA account(s)",
   hestiacp: "Live SSH or v-backup-user tarball — Hestia account(s)",
+  cloudpanel: "Live SSH — web sites, PHP, databases, cron, SSH keys (no mail)",
+  cyberpanel: "Live SSH — web sites, databases, cron, SSH keys, DNS, mail",
   plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
   wordpress_ssh: "Cloudways / VPS / generic SSH — a single WordPress site",
 };
@@ -93,6 +97,8 @@ const MULTI_ACCOUNT_KINDS = new Set([
   "whm_pkgacct",
   "directadmin",
   "hestiacp",
+  "cloudpanel",
+  "cyberpanel",
   // GH #429: Plesk enumerates subscriptions via `plesk bin subscription --list`
   // (Discoverer.ListAccounts), so it MUST go through the account picker. Without
   // this it skipped selection, kept the SSH principal (root) as the account, and


### PR DESCRIPTION
CloudPanel + CyberPanel are fully implemented and E2E-verified, but weren't **operator-reachable** — neither the migration drawer nor the wizard offered them. Adds both:

- **`SOURCE_OPTIONS`** (drawer + wizard) — CloudPanel + CyberPanel as live SSH sources.
- **`SOURCE_DESC`** — CloudPanel = web / PHP / DBs / cron / SSH (no mail); CyberPanel = web / DBs / cron / SSH / DNS / mail.
- **`MULTI_ACCOUNT_KINDS`** (wizard) — both expose `ListAccounts` (CloudPanel site users, CyberPanel websites), so they route through the Step-3 account picker like DirectAdmin/Hestia. Without it the wizard would keep the SSH principal (root) as the account and import nothing — the exact Plesk bug the comment there warns about.

No other per-kind gating excludes them; they follow the DirectAdmin live-SSH secrets → pull → import path unchanged.

tsc + vitest 132/132 green.