### PR TITLE
fix(ui): spurious 'Network Failed' toast on backup download (GH #462)

### DIFF
--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -2,6 +2,7 @@
 // Scheduler-fired jobs roll up under their run_id (one parent row,
 // expandable to per-user children). Manual creates render flat.
 import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { downloadUrl } from "../../../utils/download";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { RowActions } from "../../../components/RowActions";
@@ -262,8 +263,9 @@ export const AdminBackupsPage = () => {
       message.warning("Backup must complete before download");
       return;
     }
-    const url = `/api/v1/admin/backups/${row.id}/download`;
-    window.location.href = url;
+    // GH #462: anchor-download, not window.location.href — navigating aborts the
+    // in-flight backups poll and shows a spurious "Network Failed" toast.
+    downloadUrl(`/api/v1/admin/backups/${row.id}/download`);
   };
 
   const handleCancel = async (row: BackupJob) => {

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -3,6 +3,7 @@
 // when a row is succeeded. Mirrors AdminBackupsPage data shape but
 // scoped via /me/backups (auth-gated to caller's user_id).
 import { useTranslation } from "react-i18next";
+import { downloadUrl } from "../../utils/download";
 import { Button, Card, Grid, Select, Space, Table, Tag, Typography, message } from "antd";
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
@@ -182,7 +183,7 @@ export const MyProfileBackupCard = () => {
                 actions={[
                   ...(row.status === "succeeded"
                     ? [
-                        { key: "download", label: "Download", icon: <DownloadOutlined />, onClick: () => { const a = getActAs(); window.location.href = `/api/v1/me/backups/${row.id}/download${a ? `?act_as=${encodeURIComponent(a.id)}` : ""}`; } },
+                        { key: "download", label: "Download", icon: <DownloadOutlined />, onClick: () => { const act = getActAs(); downloadUrl(`/api/v1/me/backups/${row.id}/download${act ? `?act_as=${encodeURIComponent(act.id)}` : ""}`); } },
                         { key: "restore", label: "Restore", icon: <ReloadOutlined />, onClick: () => setRestoreId(row.id) },
                       ]
                     : []),

--- a/panel-ui/src/utils/download.ts
+++ b/panel-ui/src/utils/download.ts
@@ -1,0 +1,17 @@
+// Trigger a browser file download without navigating the page.
+//
+// Setting `window.location.href` to a download URL makes the browser begin a
+// navigation, which ABORTS any in-flight XHR (e.g. the backups-list poll). The
+// aborted request then surfaces a spurious "Network Failed" toast a moment
+// before the download actually starts (GH #462). An `<a download>` click
+// triggers the download in the background and leaves the SPA (and its pending
+// requests) untouched. Same-origin + cookie auth still apply, and the filename
+// comes from the response's Content-Disposition header.
+export function downloadUrl(url: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}


### PR DESCRIPTION
Follow-up to #462. After #584 got large backups downloading to completion, the reporter noted a false **"Network Failed"** toast that flashes just before the download starts — the download itself succeeds.

**Cause:** the download used `window.location.href = <url>`. Setting `location.href` begins a navigation, which **aborts the in-flight backups-list poll**; the aborted XHR surfaces as a network error → toast. Then the browser sees `Content-Disposition: attachment` and stays on the page, so the download proceeds — but the toast already fired.

**Fix:** a shared `downloadUrl()` helper that clicks a hidden `<a download>`. It downloads in the background without navigating, so nothing gets aborted and no toast fires. Applied to both the admin (`AdminBackupsPage`) and user (`MyProfileBackupCard`) download actions. Matches the `<a download>` pattern already used for files, SSH keys, AIDE reports, and encryption keys.

tsc + vitest 132/132 green.