### PR TITLE
fix(dns): apply default TTL to NS/SOA + all managed mail records (GH #527)

### DIFF
--- a/panel-api/cmd/server/domain_email_cmd.go
+++ b/panel-api/cmd/server/domain_email_cmd.go
@@ -219,7 +219,11 @@ func syncEmailDNSOnEnableDirect(ctx context.Context, deps domainEmailDeps, domai
 		slog.Error("cli m6 dns: list records", "zone_id", zone.ID, "err", err)
 		return []string{"DNS autoconfig couldn't read existing records."}
 	}
-	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, pubKey, ids.NewULID, time.Now().UTC())
+	var srv *models.ServerSettings
+	if sharedDB != nil {
+		srv, _ = repository.NewServerSettingsRepository(sharedDB).Get(ctx)
+	}
+	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, pubKey, srv, ids.NewULID, time.Now().UTC())
 
 	var warnings []string
 	for _, rec := range intended {

--- a/panel-api/internal/api/domain_email.go
+++ b/panel-api/internal/api/domain_email.go
@@ -31,12 +31,13 @@ import (
 // they're nil, the helper skips the flip (call sites that don't wire
 // SSL, like some unit tests, still work).
 type enableDomainEmailDeps struct {
-	Agent         agent.AgentInterface
-	Domains       repository.DomainRepository
-	DNSZones      repository.DNSZoneRepository
-	DNSRecords    repository.DNSRecordRepository
-	SSLCerts      repository.SSLCertificateRepository
-	SSLReconciler SSLScheduler
+	Agent          agent.AgentInterface
+	Domains        repository.DomainRepository
+	DNSZones       repository.DNSZoneRepository
+	DNSRecords     repository.DNSRecordRepository
+	ServerSettings repository.ServerSettingsRepository
+	SSLCerts       repository.SSLCertificateRepository
+	SSLReconciler  SSLScheduler
 }
 
 // Sentinel errors so callers can distinguish HTTP status classes when
@@ -104,7 +105,7 @@ func EnableDomainEmailInline(
 	// DNS sync is best-effort. Warnings flow back to caller; a DNS-side
 	// failure does NOT roll back the email_enabled flip (the mailbox
 	// system still works without the convenience records).
-	warnings = syncEmailDNSOnEnableInline(ctx, deps.DNSZones, deps.DNSRecords, dom.ID, selector, pubKey)
+	warnings = syncEmailDNSOnEnableInline(ctx, deps.DNSZones, deps.DNSRecords, deps.ServerSettings, dom.ID, selector, pubKey)
 
 	// Mutate caller's Domain struct so the response reflects new state.
 	dom.EmailEnabled = true
@@ -170,12 +171,13 @@ func triggerSSLSANExpansion(ctx context.Context, deps enableDomainEmailDeps, dom
 // SSLCerts + SSLReconciler are optional — when both are wired, enabling
 // email on a domain triggers SSL SAN expansion via the reconciler.
 type DomainEmailHandlerConfig struct {
-	Domains       repository.DomainRepository
-	Agent         agent.AgentInterface
-	DNSZones      repository.DNSZoneRepository
-	DNSRecords    repository.DNSRecordRepository
-	SSLCerts      repository.SSLCertificateRepository
-	SSLReconciler SSLScheduler
+	Domains        repository.DomainRepository
+	Agent          agent.AgentInterface
+	DNSZones       repository.DNSZoneRepository
+	DNSRecords     repository.DNSRecordRepository
+	ServerSettings repository.ServerSettingsRepository
+	SSLCerts       repository.SSLCertificateRepository
+	SSLReconciler  SSLScheduler
 }
 
 const (
@@ -377,12 +379,13 @@ func (h *domainEmailHandler) enable(c *gin.Context) {
 	}
 
 	selector, pubKey, warnings, err := EnableDomainEmailInline(ctx, enableDomainEmailDeps{
-		Agent:         h.cfg.Agent,
-		Domains:       h.cfg.Domains,
-		DNSZones:      h.cfg.DNSZones,
-		DNSRecords:    h.cfg.DNSRecords,
-		SSLCerts:      h.cfg.SSLCerts,
-		SSLReconciler: h.cfg.SSLReconciler,
+		Agent:          h.cfg.Agent,
+		Domains:        h.cfg.Domains,
+		DNSZones:       h.cfg.DNSZones,
+		DNSRecords:     h.cfg.DNSRecords,
+		ServerSettings: h.cfg.ServerSettings,
+		SSLCerts:       h.cfg.SSLCerts,
+		SSLReconciler:  h.cfg.SSLReconciler,
 	}, dom)
 	if err != nil {
 		// Translate helper error categories back to HTTP responses.
@@ -483,6 +486,7 @@ func syncEmailDNSOnEnableInline(
 	ctx context.Context,
 	dnsZones repository.DNSZoneRepository,
 	dnsRecords repository.DNSRecordRepository,
+	serverSettings repository.ServerSettingsRepository,
 	domainID, selector, dkimPub string,
 ) []string {
 	if dnsZones == nil || dnsRecords == nil {
@@ -505,7 +509,11 @@ func syncEmailDNSOnEnableInline(
 		slog.Error("m6 dns: list records", "zone_id", zone.ID, "err", err)
 		return []string{"DNS autoconfig couldn't read existing records."}
 	}
-	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, dkimPub, ids.NewULID, time.Now().UTC())
+	var srv *models.ServerSettings
+	if serverSettings != nil {
+		srv, _ = serverSettings.Get(ctx)
+	}
+	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, dkimPub, srv, ids.NewULID, time.Now().UTC())
 
 	var warnings []string
 	for _, rec := range intended {
@@ -532,7 +540,7 @@ func syncEmailDNSOnEnableInline(
 // syncEmailDNSOnEnable is the method-form thin wrapper kept for callers
 // still using the handler receiver (disable path's sibling + tests).
 func (h *domainEmailHandler) syncEmailDNSOnEnable(ctx context.Context, domainID, selector, dkimPub string) []string {
-	return syncEmailDNSOnEnableInline(ctx, h.cfg.DNSZones, h.cfg.DNSRecords, domainID, selector, dkimPub)
+	return syncEmailDNSOnEnableInline(ctx, h.cfg.DNSZones, h.cfg.DNSRecords, h.cfg.ServerSettings, domainID, selector, dkimPub)
 }
 
 // deleteEmailDNSOnDisable removes M6-managed records (by managed_by

--- a/panel-api/internal/api/domain_mta_sts.go
+++ b/panel-api/internal/api/domain_mta_sts.go
@@ -15,8 +15,9 @@
 //     covers the SAN.
 //
 // GET /domains/:id/mta-sts → current state + projected policy + cert-
-//   readiness hint so the UI can tell the operator whether the policy
-//   is live yet.
+//
+//	readiness hint so the UI can tell the operator whether the policy
+//	is live yet.
 //
 // The handler does NOT call the agent synchronously on toggle: the
 // vhost can't be written until the SSL cert SAN actually covers
@@ -165,7 +166,7 @@ func (h *domainMTAStsHandler) publishDNSRecords(ctx context.Context, dom *models
 	}
 	intended := dnscompile.BuildMTAStsRecords(
 		zone.ID, zone.Name, srv.PublicIPv4, dom.MTASTSId,
-		ids.NewULID, time.Now().UTC(),
+		srv, ids.NewULID, time.Now().UTC(),
 	)
 	if len(intended) == 0 {
 		return
@@ -217,11 +218,11 @@ func hasExistingMTAStsRecord(rows []models.DNSRecord, name, typ string) bool {
 // buildResponse summarises state for the UI. status_hint values:
 //   - "off"                   — toggle is off
 //   - "policy_published"      — toggle on, DNS records out; cert
-//                               renewal still pending (next ACME tick
-//                               adds the SAN, then Wave 7c reconciler
-//                               step writes the vhost). The UI surfaces
-//                               this as "Policy live in DNS — vhost
-//                               waiting for SSL renewal."
+//     renewal still pending (next ACME tick
+//     adds the SAN, then Wave 7c reconciler
+//     step writes the vhost). The UI surfaces
+//     this as "Policy live in DNS — vhost
+//     waiting for SSL renewal."
 func (h *domainMTAStsHandler) buildResponse(ctx context.Context, dom *models.Domain) mtaStsResponse {
 	_ = ctx
 	resp := mtaStsResponse{

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -718,12 +718,13 @@ func (h *domainHandler) create(c *gin.Context) {
 	// computes live DNS status anyway. Hard errors go to slog.
 	if mailProvider == models.MailProviderJabali && h.cfg.Agent != nil && h.cfg.DNSZones != nil && h.cfg.DNSRecords != nil {
 		if _, _, warnings, err := EnableDomainEmailInline(ctx, enableDomainEmailDeps{
-			Agent:         h.cfg.Agent,
-			Domains:       h.cfg.Domains,
-			DNSZones:      h.cfg.DNSZones,
-			DNSRecords:    h.cfg.DNSRecords,
-			SSLCerts:      h.cfg.SSLCerts,
-			SSLReconciler: h.cfg.Reconciler,
+			Agent:          h.cfg.Agent,
+			Domains:        h.cfg.Domains,
+			DNSZones:       h.cfg.DNSZones,
+			DNSRecords:     h.cfg.DNSRecords,
+			ServerSettings: h.cfg.ServerSettings,
+			SSLCerts:       h.cfg.SSLCerts,
+			SSLReconciler:  h.cfg.Reconciler,
 		}, domain); err != nil {
 			slog.Warn("auto-enable email failed during domain.create (operator can retry from UI)",
 				"domain_id", domain.ID, "domain", domain.Name, "err", err)

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -676,12 +676,13 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainEmailRoutes(mailGroup, api.DomainEmailHandlerConfig{
-				Domains:       deps.Domains,
-				Agent:         deps.Agent,
-				DNSZones:      deps.DNSZones,
-				DNSRecords:    deps.DNSRecords,
-				SSLCerts:      deps.SSLCerts,
-				SSLReconciler: deps.Reconciler,
+				Domains:        deps.Domains,
+				Agent:          deps.Agent,
+				DNSZones:       deps.DNSZones,
+				DNSRecords:     deps.DNSRecords,
+				ServerSettings: deps.ServerSettings,
+				SSLCerts:       deps.SSLCerts,
+				SSLReconciler:  deps.Reconciler,
 			})
 		}
 		// M6.5 Email features: forwarders, autoresponders, catch-all, disclaimer,

--- a/panel-api/internal/dnscompile/compile.go
+++ b/panel-api/internal/dnscompile/compile.go
@@ -34,6 +34,9 @@ func SystemRecords(zone *models.DNSZone, srv *models.ServerSettings) []Record {
 		return nil
 	}
 	zoneName := strings.TrimSuffix(zone.Name, ".")
+	// GH #527: apex SOA + NS TTLs follow the operator default like every other
+	// record (the SOA content refresh/retry/expire/minimum timers are unchanged).
+	sysTTL := models.EffectiveDNSTTL(srv)
 
 	// SOA is generated from server_settings + zone scalars, never from
 	// the dns_records table directly. That keeps SOA consistent even
@@ -56,18 +59,18 @@ func SystemRecords(zone *models.DNSZone, srv *models.ServerSettings) []Record {
 		Content: fmt.Sprintf("%s %s %d %d %d %d %d",
 			primaryNS, hostmaster, serial,
 			zone.RefreshSeconds, zone.RetrySeconds, zone.ExpireSeconds, zone.MinimumTTL),
-		TTL: zone.MinimumTTL,
+		TTL: sysTTL,
 	}}
 
 	// NS records — one per configured nameserver. Without server_settings
 	// we still emit the zone apex as its own NS so PowerDNS accepts the
 	// zone as valid.
 	if srv == nil || srv.NS1Name == "" {
-		out = append(out, Record{Name: zoneName, Type: "NS", Content: zoneName, TTL: zone.MinimumTTL})
+		out = append(out, Record{Name: zoneName, Type: "NS", Content: zoneName, TTL: sysTTL})
 	} else {
-		out = append(out, Record{Name: zoneName, Type: "NS", Content: srv.NS1Name, TTL: zone.MinimumTTL})
+		out = append(out, Record{Name: zoneName, Type: "NS", Content: srv.NS1Name, TTL: sysTTL})
 		if srv.NS2Name != "" {
-			out = append(out, Record{Name: zoneName, Type: "NS", Content: srv.NS2Name, TTL: zone.MinimumTTL})
+			out = append(out, Record{Name: zoneName, Type: "NS", Content: srv.NS2Name, TTL: sysTTL})
 		}
 	}
 	return out

--- a/panel-api/internal/dnscompile/email_records.go
+++ b/panel-api/internal/dnscompile/email_records.go
@@ -64,6 +64,7 @@ const EmailRecordsSelector = "jabali"
 //     a textual diff between the two won't flap on reconciliation.
 func BuildEmailRecords(
 	zoneID, zoneName, selector, dkimPublicKey string,
+	srv *models.ServerSettings,
 	idNew func() string,
 	now time.Time,
 ) []models.DNSRecord {
@@ -75,7 +76,7 @@ func BuildEmailRecords(
 			Name:      name,
 			Type:      typ,
 			Content:   content,
-			TTL:       300,
+			TTL:       models.EffectiveDNSTTL(srv),
 			Priority:  priority,
 			Managed:   true,
 			ManagedBy: &m6,

--- a/panel-api/internal/dnscompile/email_records_test.go
+++ b/panel-api/internal/dnscompile/email_records_test.go
@@ -26,6 +26,7 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 		"example.com",
 		"jabali",
 		"v=DKIM1; k=ed25519; p=AAAA",
+		nil,
 		idCounter(),
 		now,
 	)
@@ -108,7 +109,7 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 // rotation lands, the handler will pass the rotated selector through.
 func TestBuildEmailRecords_HonorsSelector(t *testing.T) {
 	recs := BuildEmailRecords(
-		"z", "example.com", "rotated-20260101", "dummy-pub", idCounter(), time.Now(),
+		"z", "example.com", "rotated-20260101", "dummy-pub", nil, idCounter(), time.Now(),
 	)
 	require.Equal(t, "rotated-20260101._domainkey", recs[0].Name)
 }
@@ -117,7 +118,7 @@ func TestBuildEmailRecords_HonorsSelector(t *testing.T) {
 // refactor that accidentally reuses ids across records (which would
 // violate the PK and blow up Create).
 func TestBuildEmailRecords_IDGeneratorCalledOncePerRecord(t *testing.T) {
-	recs := BuildEmailRecords("z", "example.com", "s", "p", idCounter(), time.Now())
+	recs := BuildEmailRecords("z", "example.com", "s", "p", nil, idCounter(), time.Now())
 	seen := map[string]bool{}
 	for _, r := range recs {
 		require.False(t, seen[r.ID], "duplicate id %q", r.ID)

--- a/panel-api/internal/dnscompile/external_mail_records.go
+++ b/panel-api/internal/dnscompile/external_mail_records.go
@@ -50,7 +50,7 @@ func BuildApexMailRecords(provider, zoneName string, srv *models.ServerSettings,
 	mk := func(name, typ, content string, prio int) models.DNSRecord {
 		return models.DNSRecord{
 			ID: idNew(), ZoneID: "", Name: name, Type: typ, Content: content,
-			TTL: 300, Priority: prio, Managed: true, ManagedBy: &marker,
+			TTL: models.EffectiveDNSTTL(srv), Priority: prio, Managed: true, ManagedBy: &marker,
 			IsEnabled: true, CreatedAt: now, UpdatedAt: now,
 		}
 	}
@@ -82,7 +82,7 @@ func BuildApexMailRecords(provider, zoneName string, srv *models.ServerSettings,
 // (autodiscover CNAME + optional DKIM). jabali/none return nil — jabali's
 // non-apex set is BuildEmailRecords; none has nothing. ZoneID is left empty
 // for the caller to stamp. Tokens must already be validated.
-func BuildProviderMailRecords(provider, zoneName, m365Onmicrosoft, googleDKIM string, idNew func() string, now time.Time) []models.DNSRecord {
+func BuildProviderMailRecords(provider, zoneName, m365Onmicrosoft, googleDKIM string, srv *models.ServerSettings, idNew func() string, now time.Time) []models.DNSRecord {
 	marker := ProviderMailManagedBy(provider)
 	if marker == "" {
 		return nil
@@ -90,7 +90,7 @@ func BuildProviderMailRecords(provider, zoneName, m365Onmicrosoft, googleDKIM st
 	mk := func(name, typ, content string, prio int) models.DNSRecord {
 		return models.DNSRecord{
 			ID: idNew(), ZoneID: "", Name: name, Type: typ, Content: content,
-			TTL: 300, Priority: prio, Managed: true, ManagedBy: &marker,
+			TTL: models.EffectiveDNSTTL(srv), Priority: prio, Managed: true, ManagedBy: &marker,
 			IsEnabled: true, CreatedAt: now, UpdatedAt: now,
 		}
 	}

--- a/panel-api/internal/dnscompile/external_mail_records_test.go
+++ b/panel-api/internal/dnscompile/external_mail_records_test.go
@@ -68,22 +68,22 @@ func TestBuildApexMailRecords_PerProvider(t *testing.T) {
 func TestBuildProviderMailRecords_NonApex(t *testing.T) {
 	now := time.Unix(0, 0)
 	// m365 without token -> just autodiscover; with token -> + selectors
-	m := recStr(BuildProviderMailRecords(models.MailProviderM365, "example.com", "", "", ids(), now))
+	m := recStr(BuildProviderMailRecords(models.MailProviderM365, "example.com", "", "", nil, ids(), now))
 	if !strings.Contains(m, "autodiscover CNAME autodiscover.outlook.com [mail-provider-m365]") {
 		t.Errorf("m365 autodiscover missing:\n%s", m)
 	}
 	if strings.Contains(m, "selector1") {
 		t.Errorf("m365 selectors should be absent without token:\n%s", m)
 	}
-	mt := recStr(BuildProviderMailRecords(models.MailProviderM365, "example.com", "contoso.onmicrosoft.com", "", ids(), now))
+	mt := recStr(BuildProviderMailRecords(models.MailProviderM365, "example.com", "contoso.onmicrosoft.com", "", nil, ids(), now))
 	if !strings.Contains(mt, "selector1._domainkey CNAME selector1-example-com._domainkey.contoso.onmicrosoft.com [mail-provider-m365]") {
 		t.Errorf("m365 selector1 wrong:\n%s", mt)
 	}
 	// google DKIM only when token present
-	if r := BuildProviderMailRecords(models.MailProviderGoogle, "example.com", "", "", ids(), now); len(r) != 0 {
+	if r := BuildProviderMailRecords(models.MailProviderGoogle, "example.com", "", "", nil, ids(), now); len(r) != 0 {
 		t.Errorf("google without DKIM token should be empty, got %d", len(r))
 	}
-	gt := recStr(BuildProviderMailRecords(models.MailProviderGoogle, "example.com", "", "v=DKIM1; k=rsa; p=ABC", ids(), now))
+	gt := recStr(BuildProviderMailRecords(models.MailProviderGoogle, "example.com", "", "v=DKIM1; k=rsa; p=ABC", nil, ids(), now))
 	if !strings.Contains(gt, `google._domainkey TXT "v=DKIM1; k=rsa; p=ABC" [mail-provider-google]`) {
 		t.Errorf("google DKIM wrong:\n%s", gt)
 	}

--- a/panel-api/internal/dnscompile/mta_sts_records.go
+++ b/panel-api/internal/dnscompile/mta_sts_records.go
@@ -34,6 +34,7 @@ const MTAStsRecordsManagedBy = "mta-sts"
 func BuildMTAStsRecords(
 	zoneID, zoneName, panelIPv4 string,
 	mtaStsID uint64,
+	srv *models.ServerSettings,
 	idNew func() string,
 	now time.Time,
 ) []models.DNSRecord {
@@ -48,7 +49,7 @@ func BuildMTAStsRecords(
 			Name:      name,
 			Type:      typ,
 			Content:   content,
-			TTL:       300,
+			TTL:       models.EffectiveDNSTTL(srv),
 			Priority:  0,
 			Managed:   true,
 			ManagedBy: &marker,

--- a/panel-api/internal/dnscompile/mta_sts_records_test.go
+++ b/panel-api/internal/dnscompile/mta_sts_records_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBuildMTAStsRecords_HappyPath(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
-	recs := BuildMTAStsRecords("zone1", "example.com", "203.0.113.7", 1716206400, idCounter(), now)
+	recs := BuildMTAStsRecords("zone1", "example.com", "203.0.113.7", 1716206400, nil, idCounter(), now)
 	if len(recs) != 2 {
 		t.Fatalf("want 2 records, got %d", len(recs))
 	}
@@ -46,14 +46,14 @@ func TestBuildMTAStsRecords_HappyPath(t *testing.T) {
 
 func TestBuildMTAStsRecords_NilWhenEmptyIP(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
-	if got := BuildMTAStsRecords("z", "x.com", "", 1, idCounter(), now); got != nil {
+	if got := BuildMTAStsRecords("z", "x.com", "", 1, nil, idCounter(), now); got != nil {
 		t.Errorf("empty ip should return nil, got %+v", got)
 	}
 }
 
 func TestBuildMTAStsRecords_NilWhenZeroID(t *testing.T) {
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
-	if got := BuildMTAStsRecords("z", "x.com", "203.0.113.7", 0, idCounter(), now); got != nil {
+	if got := BuildMTAStsRecords("z", "x.com", "203.0.113.7", 0, nil, idCounter(), now); got != nil {
 		t.Errorf("zero id should return nil (no policy ever published), got %+v", got)
 	}
 }

--- a/panel-api/internal/reconciler/mail_provider_reconcile.go
+++ b/panel-api/internal/reconciler/mail_provider_reconcile.go
@@ -71,7 +71,7 @@ func (r *Reconciler) reconcileMailProviderRecords(ctx context.Context, zone *mod
 	if domain.GoogleDKIM != nil {
 		gdkim = *domain.GoogleDKIM
 	}
-	desiredProv := dnscompile.BuildProviderMailRecords(provider, zone.Name, m365, gdkim, ids.NewULID, now)
+	desiredProv := dnscompile.BuildProviderMailRecords(provider, zone.Name, m365, gdkim, srv, ids.NewULID, now)
 	stampZone(desiredProv, zone.ID)
 	marker := dnscompile.ProviderMailManagedBy(provider)
 	if marker != "" {
@@ -203,7 +203,7 @@ func (r *Reconciler) restoreBootstrapApex(ctx context.Context, zone *models.DNSZ
 	mk := func(name, typ, content string, prio int) *models.DNSRecord {
 		return &models.DNSRecord{
 			ID: ids.NewULID(), ZoneID: zone.ID, Name: name, Type: typ, Content: content,
-			TTL: 3600, Priority: prio, Managed: true, IsEnabled: true, CreatedAt: now, UpdatedAt: now,
+			TTL: models.EffectiveDNSTTL(srv), Priority: prio, Managed: true, IsEnabled: true, CreatedAt: now, UpdatedAt: now,
 		}
 	}
 	if !hasMX && zone.Name != "" {

--- a/panel-api/internal/reconciler/panel_primary_dkim.go
+++ b/panel-api/internal/reconciler/panel_primary_dkim.go
@@ -243,7 +243,11 @@ func (r *Reconciler) syncPanelPrimaryEmailDNS(ctx context.Context, domainID, sel
 			"zone_id", zone.ID, "err", err)
 		return
 	}
-	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, pubKey, ids.NewULID, time.Now().UTC())
+	var srv *models.ServerSettings
+	if r.serverSettings != nil {
+		srv, _ = r.serverSettings.Get(ctx)
+	}
+	intended := dnscompile.BuildEmailRecords(zone.ID, zone.Name, selector, pubKey, srv, ids.NewULID, time.Now().UTC())
 	for i := range intended {
 		rec := intended[i]
 		if hasExistingM6DNSRecord(existing, rec.Name, rec.Type) {
@@ -281,7 +285,6 @@ func hasExistingM6DNSRecord(existing []models.DNSRecord, name, recType string) b
 	}
 	return false
 }
-
 
 // domainIsMailRoutable returns false for RFC 6761 reserved TLDs
 // (.local, .test, .localhost, .invalid, .example) that Stalwart refuses


### PR DESCRIPTION
Follow-up to #541. @johnnyq reported that after #541 most records use the panel default TTL, but **NS, the apex itself, MX, SPF, DMARC, and DKIM** still don't. Several auto-generated records were still hardcoding their TTL:

- **`SystemRecords`** — apex **SOA + NS** were pinned to `zone.MinimumTTL` → now `EffectiveDNSTTL(srv)`. (The SOA content refresh/retry/expire/minimum values are *protocol timers* and stay untouched.)
- **`external_mail_records`** — apex **MX/SPF/DMARC** + provider **DKIM** were `TTL 300`.
- **`email_records`** — local **DKIM/DMARC/SPF** were `TTL 300`.
- **`mta_sts_records`** — MTA-STS TXT/CNAME were `TTL 300`.
- **`mail_provider_reconcile`** — the missing-MX/SPF/DMARC fallback was `TTL 3600`.

All now use `EffectiveDNSTTL(srv)`; `srv` is threaded through the three builders that lacked it plus their callers (reconciler, API handlers, CLI). These are all reconciler-**managed** records, so **existing zones normalize to the operator default on the next reconcile** — a migrated zone becomes TTL-consistent instead of a grab-bag. Non-managed user records keep their own TTL (unchanged).

build + vet + dnscompile / reconciler / api / cmd-server suites green.