### PR TITLE
feat(domains): tenant-editable document root, confined to the domain tree (GH #526)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -150,6 +151,26 @@ func validateDocumentRoot(docRoot, username, domainName string) error {
 		return fmt.Errorf("document root contains invalid path traversal sequences")
 	}
 
+	return nil
+}
+
+// validateTenantDocumentRoot is the stricter confinement for a NON-admin owner
+// changing their own domain's docroot (GH #526): the path must stay inside the
+// domain's OWN tree /home/<user>/domains/<domain>/ (so an app can point at a sub-
+// or parent dir like .../public), never another domain or elsewhere in the home.
+// Admins keep the looser validateDocumentRoot (anywhere under the owner's home).
+func validateTenantDocumentRoot(docRoot, username, domainName string) error {
+	if docRoot == "" {
+		return nil // resets to the canonical default
+	}
+	if strings.Contains(docRoot, "..") {
+		return fmt.Errorf("document root contains invalid path traversal sequences")
+	}
+	clean := filepath.Clean(docRoot)
+	base := "/home/" + username + "/domains/" + domainName
+	if clean != base && !strings.HasPrefix(clean, base+"/") {
+		return fmt.Errorf("document root must be inside /home/%s/domains/%s/", username, domainName)
+	}
 	return nil
 }
 
@@ -849,6 +870,36 @@ func (h *domainHandler) update(c *gin.Context) {
 				return
 			}
 			domain.NginxRules = *req.NginxRules
+		}
+	}
+
+	// GH #526: a non-admin owner may repoint their own domain's docroot within
+	// the domain's own tree (e.g. a framework's public/ subdir) when the admin
+	// has opted in (tenant_domain_options_enabled). Confined by
+	// validateTenantDocumentRoot; admins use the looser whole-home path above.
+	// Silently dropped when the opt-in is off so other fields still PATCH.
+	if !claims.IsAdmin && req.DocRoot != nil {
+		allowed := false
+		if h.cfg.ServerSettings != nil {
+			if st, sErr := h.cfg.ServerSettings.Get(ctx); sErr == nil && st != nil && st.TenantDomainOptionsEnabled {
+				allowed = true
+			}
+		}
+		if allowed {
+			owner, oerr := h.cfg.Users.FindByID(ctx, domain.UserID)
+			if oerr != nil || owner == nil || owner.Username == nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "owner_lookup_failed"})
+				return
+			}
+			newRoot := strings.TrimSpace(*req.DocRoot)
+			if newRoot == "" {
+				newRoot = "/home/" + *owner.Username + "/domains/" + domain.Name + "/public_html"
+			}
+			if err := validateTenantDocumentRoot(newRoot, *owner.Username, domain.Name); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_doc_root", "detail": err.Error()})
+				return
+			}
+			domain.DocRoot = newRoot
 		}
 	}
 

--- a/panel-api/internal/api/domains_test.go
+++ b/panel-api/internal/api/domains_test.go
@@ -400,3 +400,35 @@ func TestExtractDirective(t *testing.T) {
 		})
 	}
 }
+
+// GH #526: a tenant may edit their own domain's docroot but is confined to the
+// domain's OWN tree — a stricter check than the admin whole-home one.
+func TestValidateTenantDocumentRoot(t *testing.T) {
+	const u, d = "alice", "example.com"
+	base := "/home/alice/domains/example.com"
+	ok := []string{
+		"",                     // reset to default
+		base,                   // the domain root
+		base + "/public_html",  // the default
+		base + "/myapp/public", // a framework public/ subdir (the #526 use case)
+		base + "/public_html/sub",
+	}
+	for _, dr := range ok {
+		if err := validateTenantDocumentRoot(dr, u, d); err != nil {
+			t.Errorf("expected %q valid, got %v", dr, err)
+		}
+	}
+	bad := []string{
+		"/home/alice/domains/other.com/public_html", // another domain (theirs, but out of tree)
+		"/home/alice/secret",                        // elsewhere in the home
+		"/home/bob/domains/example.com/public_html", // another user
+		"/etc/passwd",                             // outside home
+		base + "/../other.com/public_html",        // traversal
+		"/home/alice/domains/example.com/../evil", // traversal
+	}
+	for _, dr := range bad {
+		if err := validateTenantDocumentRoot(dr, u, d); err == nil {
+			t.Errorf("expected %q rejected, got nil", dr)
+		}
+	}
+}

--- a/panel-ui/src/shells/user/domains/DomainDocRootModal.tsx
+++ b/panel-ui/src/shells/user/domains/DomainDocRootModal.tsx
@@ -1,0 +1,74 @@
+// DomainDocRootModal — GH #526. Lets a tenant repoint their own domain's
+// document root, confined server-side to the domain's own tree
+// (/home/<user>/domains/<domain>/...). Useful for framework apps whose real
+// entrypoint is a subdir (e.g. Laravel's public/). Surfaced only when the admin
+// has enabled tenant domain options; the backend re-validates regardless.
+import { useState } from "react";
+import { Modal, Form, Input, Typography, message } from "antd";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiClient } from "../../../apiClient";
+
+interface DomainDocRootModalProps {
+  domainId: string;
+  domainName: string;
+  currentDocRoot: string;
+  onClose: () => void;
+}
+
+// domainTreeBase derives /home/<user>/domains/<domain> from the current docroot
+// so the hint shows the exact folder the value must stay inside.
+function domainTreeBase(docRoot: string, domainName: string): string {
+  const marker = `/domains/${domainName}`;
+  const i = docRoot.indexOf(marker);
+  return i >= 0 ? docRoot.slice(0, i + marker.length) : `…/domains/${domainName}`;
+}
+
+export function DomainDocRootModal({ domainId, domainName, currentDocRoot, onClose }: DomainDocRootModalProps) {
+  const qc = useQueryClient();
+  const [form] = Form.useForm<{ doc_root: string }>();
+  const [value, setValue] = useState(currentDocRoot);
+  const base = domainTreeBase(currentDocRoot, domainName);
+
+  const mut = useMutation({
+    mutationFn: async (docRoot: string) => {
+      await apiClient.patch(`/domains/${domainId}`, { doc_root: docRoot });
+    },
+    onSuccess: () => {
+      message.success("Document root updated");
+      void qc.invalidateQueries({ queryKey: ["list", "domains"] });
+      onClose();
+    },
+    onError: (err: unknown) => {
+      const detail = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
+      message.error(detail?.detail ?? detail?.error ?? "Failed to update document root");
+    },
+  });
+
+  return (
+    <Modal
+      title={`Document root — ${domainName}`}
+      open
+      onCancel={onClose}
+      onOk={() => form.submit()}
+      okText="Save"
+      confirmLoading={mut.isPending}
+    >
+      <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+        Point this domain at a folder inside <Typography.Text code>{base}</Typography.Text>. Handy for apps whose
+        entrypoint is a subdirectory (e.g. a framework's <Typography.Text code>public/</Typography.Text>). Leave it
+        empty to reset to the default <Typography.Text code>public_html</Typography.Text>.
+      </Typography.Paragraph>
+      <Form form={form} layout="vertical" onFinish={(v) => void mut.mutateAsync((v.doc_root ?? "").trim())}>
+        <Form.Item name="doc_root" label="Document root" initialValue={currentDocRoot}>
+          <Input
+            placeholder={`${base}/public_html`}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            style={{ fontFamily: "monospace" }}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -15,6 +15,7 @@ import {
   LockOutlined,
   ThunderboltOutlined,
   ToolOutlined,
+  FolderOutlined,
 } from "@icons";
 import { Button, Card, Dropdown, Modal, Space, Table, Tag, Tooltip, Typography, notification } from "antd";
 import { useState } from "react";
@@ -22,6 +23,7 @@ import { useNavigate } from "react-router";
 import type { SorterResult } from "antd/es/table/interface";
 import { useQueryClient } from "@tanstack/react-query";
 
+import { DomainDocRootModal } from "./DomainDocRootModal";
 import { apiClient } from "../../../apiClient";
 import { columnSearchProps } from "../../../components/columnSearch";
 import { RowActionButton } from "../../../components/RowActionButton";
@@ -172,7 +174,7 @@ export type Domain = {
   updated_at: string;
 };
 
-type ActiveModal = { domainId: string; type: "redirects" | "index" | "directory-privacy" | "caching" | "nginx-options" | "rewrite-rules" } | null;
+type ActiveModal = { domainId: string; type: "redirects" | "index" | "directory-privacy" | "caching" | "nginx-options" | "rewrite-rules" | "document-root" } | null;
 
 export const UserDomainList = () => {
   const { t } = useTranslation();
@@ -344,6 +346,12 @@ export const UserDomainList = () => {
                               icon: <ToolOutlined />,
                               onClick: () => setActiveModal({ domainId: r.id, type: "rewrite-rules" }),
                             },
+                            {
+                              key: "document-root",
+                              label: "Document root",
+                              icon: <FolderOutlined />,
+                              onClick: () => setActiveModal({ domainId: r.id, type: "document-root" }),
+                            },
                           ]
                         : []),
                       {
@@ -435,6 +443,14 @@ export const UserDomainList = () => {
                   <TenantNginxRulesButton
                     domain={r}
                     open={true}
+                    onClose={() => setActiveModal(null)}
+                  />
+                )}
+                {activeModal?.domainId === r.id && activeModal.type === "document-root" && (
+                  <DomainDocRootModal
+                    domainId={r.id}
+                    domainName={r.name}
+                    currentDocRoot={r.doc_root}
                     onClose={() => setActiveModal(null)}
                   />
                 )}


### PR DESCRIPTION
The docroot Edit was admin-only (#265, security foot-gun). @johnnyq's clarified ask: let tenants point a domain at a subdirectory **within its own tree** — e.g. a framework's `public/` — which is safe as long as it can't escape the domain. This adds exactly that.

## Backend
A non-admin **owner** may `PATCH doc_root` on their own domain **when the admin has opted in** (`tenant_domain_options_enabled` — the same gate as the tenant nginx Rule Builder, #307). New `validateTenantDocumentRoot` confines the path to `/home/<user>/domains/<domain>/` (the domain's own tree — stricter than the admin whole-home `validateDocumentRoot`) and blocks `..`. Admins keep the looser path. Silently dropped when the opt-in is off, so other fields still PATCH.

## UI
A **Document root** item in the tenant domain `…` menu (shown only when tenant domain options are enabled) opens a small modal — prefilled with the current docroot, a hint scoped to the domain folder, empty resets to `public_html`.

## Tests
`validateTenantDocumentRoot` accepts in-tree paths (`public_html`, a `public/` subdir) and rejects other domains, elsewhere-in-home, other users, outside `/home`, and traversal. Go api suite + `tsc -b` + vitest 132/132 green.