### PR TITLE
feat(domains): dedicated tenant_docroot_editable setting, default off (GH #526)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -875,13 +875,13 @@ func (h *domainHandler) update(c *gin.Context) {
 
 	// GH #526: a non-admin owner may repoint their own domain's docroot within
 	// the domain's own tree (e.g. a framework's public/ subdir) when the admin
-	// has opted in (tenant_domain_options_enabled). Confined by
+	// has opted in (tenant_docroot_editable). Confined by
 	// validateTenantDocumentRoot; admins use the looser whole-home path above.
 	// Silently dropped when the opt-in is off so other fields still PATCH.
 	if !claims.IsAdmin && req.DocRoot != nil {
 		allowed := false
 		if h.cfg.ServerSettings != nil {
-			if st, sErr := h.cfg.ServerSettings.Get(ctx); sErr == nil && st != nil && st.TenantDomainOptionsEnabled {
+			if st, sErr := h.cfg.ServerSettings.Get(ctx); sErr == nil && st != nil && st.TenantDocrootEditable {
 				allowed = true
 			}
 		}

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -55,7 +55,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": ""})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": ""})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -86,6 +86,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		"docker_apps_user_enabled":      dockerUser,
 		"python_apps_enabled":           settings.PythonAppsEnabled,
 		"tenant_domain_options_enabled": settings.TenantDomainOptionsEnabled,
+		"tenant_docroot_editable":       settings.TenantDocrootEditable,
 		// M353 Phase 1 (GH #353): per-module flags the SPA gates nav + routes on.
 		"dns_enabled":      settings.DNSEnabled,
 		"mail_enabled":     settings.MailEnabled,

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -129,6 +129,7 @@ type updateServerSettingsRequest struct {
 	QuotaEnabled                 *bool   `json:"quota_enabled,omitempty"`
 	APIEnabled                   *bool   `json:"api_enabled,omitempty"`
 	TenantDomainOptionsEnabled   *bool   `json:"tenant_domain_options_enabled,omitempty"`
+	TenantDocrootEditable        *bool   `json:"tenant_docroot_editable,omitempty"`
 	RootTerminalEnabled          *bool   `json:"root_terminal_enabled,omitempty"`
 	BandwidthQuotaEnforceEnabled *bool   `json:"bandwidth_quota_enforce_enabled,omitempty"`
 	UploadMaxSizeMB              *uint32 `json:"upload_max_size_mb,omitempty"`
@@ -481,6 +482,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.TenantDomainOptionsEnabled != nil {
 		current.TenantDomainOptionsEnabled = *req.TenantDomainOptionsEnabled
+	}
+	if req.TenantDocrootEditable != nil {
+		current.TenantDocrootEditable = *req.TenantDocrootEditable
 	}
 	if req.RootTerminalEnabled != nil {
 		current.RootTerminalEnabled = *req.RootTerminalEnabled

--- a/panel-api/internal/db/migrations/000200_tenant_docroot_editable.down.sql
+++ b/panel-api/internal/db/migrations/000200_tenant_docroot_editable.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN tenant_docroot_editable;

--- a/panel-api/internal/db/migrations/000200_tenant_docroot_editable.up.sql
+++ b/panel-api/internal/db/migrations/000200_tenant_docroot_editable.up.sql
@@ -1,0 +1,6 @@
+-- GH #526: docroot editing gets its own switch, decoupled from the tenant nginx
+-- Rule Builder so an admin can enable domain-confined docroot editing without
+-- unlocking the riskier raw options. Default OFF (admin opt-in) — repointing a
+-- docroot is still a foot-gun a tenant can use to expose their own files.
+ALTER TABLE server_settings
+  ADD COLUMN tenant_docroot_editable TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -113,6 +113,12 @@ type ServerSettings struct {
 	// nginx domain options (GH #307). Default off.
 	TenantDomainOptionsEnabled bool `gorm:"column:tenant_domain_options_enabled;type:tinyint(1);not null;default:0" json:"tenant_domain_options_enabled"`
 
+	// TenantDocrootEditable lets a non-admin owner repoint their own domain's
+	// document root within the domain's own tree (GH #526). Default OFF (admin
+	// opt-in); decoupled from TenantDomainOptionsEnabled so docroot editing can be
+	// enabled without unlocking the riskier raw nginx options.
+	TenantDocrootEditable bool `gorm:"column:tenant_docroot_editable;type:tinyint(1);not null;default:0" json:"tenant_docroot_editable"`
+
 	// DNSUserRecordPolicy — per-type create/edit/delete matrix for non-admin
 	// tenants (GH #466, ADR-0150). JSON object keyed by UPPERCASE record type.
 	DNSUserRecordPolicy DNSUserRecordPolicy `gorm:"column:dns_user_record_policy;type:longtext" json:"dns_user_record_policy"`

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -13,6 +13,7 @@ export interface ServerCapabilities {
   docker_apps_user_enabled: boolean;
   python_apps_enabled: boolean;
   tenant_domain_options_enabled: boolean;
+  tenant_docroot_editable: boolean;
   dns_enabled: boolean;
   mail_enabled: boolean;
   security_enabled: boolean;
@@ -37,6 +38,7 @@ export function useServerCapabilities() {
         docker_apps_user_enabled: !!data.docker_apps_user_enabled,
         python_apps_enabled: !!data.python_apps_enabled,
         tenant_domain_options_enabled: !!data.tenant_domain_options_enabled,
+        tenant_docroot_editable: !!data.tenant_docroot_editable,
         dns_enabled: data.dns_enabled !== false,
         mail_enabled: data.mail_enabled !== false,
         security_enabled: data.security_enabled !== false,

--- a/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
@@ -10,15 +10,20 @@ import { apiClient } from "../../../apiClient";
 export const TenantDomainOptionsCard = () => {
   const { t } = useTranslation();
   const [enabled, setEnabled] = useState(false);
+  const [docroot, setDocroot] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [savingDocroot, setSavingDocroot] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const resp = await apiClient.get<{ tenant_domain_options_enabled?: boolean }>("/admin/settings");
-        if (!cancelled) setEnabled(resp.data.tenant_domain_options_enabled === true);
+        const resp = await apiClient.get<{ tenant_domain_options_enabled?: boolean; tenant_docroot_editable?: boolean }>("/admin/settings");
+        if (!cancelled) {
+          setEnabled(resp.data.tenant_domain_options_enabled === true);
+          setDocroot(resp.data.tenant_docroot_editable === true);
+        }
       } catch {
         if (!cancelled) notification.error({ message: "Failed to load tenant domain options setting" });
       } finally {
@@ -43,6 +48,19 @@ export const TenantDomainOptionsCard = () => {
     }
   };
 
+  const onToggleDocroot = async (next: boolean) => {
+    setSavingDocroot(true);
+    try {
+      await apiClient.patch("/admin/settings", { tenant_docroot_editable: next });
+      setDocroot(next);
+      notification.success({ message: next ? "Tenant document-root editing enabled" : "Tenant document-root editing disabled" });
+    } catch {
+      notification.error({ message: "Failed to update setting" });
+    } finally {
+      setSavingDocroot(false);
+    }
+  };
+
   return (
     <Card title={t("tenantdomainoptionscard.tenant_domain_options")} style={{ marginBottom: 16 }} loading={loading}>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
@@ -52,6 +70,12 @@ export const TenantDomainOptionsCard = () => {
         admin-only either way.
       </Typography.Paragraph>
       <Switch checked={enabled} loading={saving} onChange={onToggle} checkedChildren="On" unCheckedChildren="Off" />
+      <Typography.Paragraph type="secondary" style={{ marginTop: 20, marginBottom: 8 }}>
+        Let non-admin users repoint their own domain&apos;s <strong>document root</strong> to a folder inside that
+        domain (e.g. a framework&apos;s <code>public/</code> subdir). Confined server-side to the domain&apos;s own
+        tree — it can&apos;t escape into another domain or elsewhere. Off by default.
+      </Typography.Paragraph>
+      <Switch checked={docroot} loading={savingDocroot} onChange={onToggleDocroot} checkedChildren="On" unCheckedChildren="Off" />
     </Card>
   );
 };

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -346,6 +346,10 @@ export const UserDomainList = () => {
                               icon: <ToolOutlined />,
                               onClick: () => setActiveModal({ domainId: r.id, type: "rewrite-rules" }),
                             },
+                          ]
+                        : []),
+                      ...(caps?.tenant_docroot_editable
+                        ? [
                             {
                               key: "document-root",
                               label: "Document root",


### PR DESCRIPTION
Follow-up to #612. That gated tenant docroot editing behind `tenant_domain_options_enabled`, which conflated it with the riskier tenant nginx Rule Builder (proxy_pass/rewrite). This gives docroot editing its **own** switch so an admin can enable the domain-confined docroot capability **without** unlocking raw nginx options — kept **default OFF** (admin opt-in), since repointing a docroot is still a foot-gun a tenant can use to expose their own files.

- **Migration 000200 + model** — `server_settings.tenant_docroot_editable`, `DEFAULT 0`.
- **caps** (`me.go` + `useServerCapabilities`) — expose `tenant_docroot_editable`.
- **`domains.go`** — the owner docroot PATCH now gates on `TenantDocrootEditable` (was `TenantDomainOptionsEnabled`); `validateTenantDocumentRoot` confinement unchanged.
- **Admin Server Settings card** — a second toggle for it (off by default).
- **Tenant domain `…` menu** — the *Document root* item now shows on its own cap.

`go vet` + api/models suites + `tsc -b` + vitest 132/132 green.