### PR TITLE
fix(migrate): ensure php<v>-mysql for migrated domains' PHP version (GH #531)

### DIFF
--- a/panel-agent/internal/commands/php_version_install.go
+++ b/panel-agent/internal/commands/php_version_install.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -54,6 +55,58 @@ var isFPMAlreadyInstalledFunc = func(version string) bool {
 func isFPMAlreadyInstalled(version string) bool {
 	return isFPMAlreadyInstalledFunc(version)
 }
+
+// phpRequiredExts are the extension packages every supported one-click app
+// (WordPress, Drupal, Joomla, MediaWiki) and most migrated sites need. mysql
+// provides mysqli + pdo_mysql; a version installed without it 500s on every
+// mysqli_connect() (GH #531).
+var phpRequiredExts = []string{"mysql", "mbstring", "zip", "gd", "curl", "xml"}
+
+// isPkgInstalled reports whether a dpkg package is installed and fully
+// configured. Used to backfill only the missing required extensions instead of
+// shelling out to apt when a version is already complete.
+func isPkgInstalled(pkg string) bool {
+	out, err := exec.Command("dpkg-query", "-W", "-f=${Status}", pkg).Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "install ok installed")
+}
+
+// ensureRequiredPHPExts installs any mandatory extension package (php<v>-mysql
+// etc.) that is missing for an ALREADY-installed version. isFPMAlreadyInstalled
+// only checks for php<v> on PATH, so a version pulled in as a dependency,
+// apt-installed by hand without -mysql, or left partial by an interrupted
+// install can satisfy that check yet still lack mysqli — and a migrated domain
+// binding to its pool then 500s (GH #531). dpkg-checks each package first so a
+// complete version is a no-op (no apt invocation).
+func ensureRequiredPHPExts(ctx context.Context, version string) error {
+	var missing []string
+	for _, ext := range phpRequiredExts {
+		pkg := fmt.Sprintf("php%s-%s", version, ext)
+		if isPkgInstalled(pkg) {
+			continue
+		}
+		if !probePackage(pkg) {
+			continue // not in apt sources for this version — mirror base-install skip
+		}
+		missing = append(missing, pkg)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() { done <- installPackages(missing) }()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("timeout installing %v", missing)
+	case err := <-done:
+		return err
+	}
+}
+
+// ensureRequiredPHPExtsFunc is a seam for tests.
+var ensureRequiredPHPExtsFunc = ensureRequiredPHPExts
 
 // probePackage checks if an apt package exists via apt-cache show.
 func probePackage(pkg string) bool {
@@ -209,8 +262,17 @@ func phpVersionInstallHandler(ctx context.Context, params json.RawMessage) (any,
 		}
 	}
 
-	// If already installed, return current status
+	// If already installed, return current status — but first backfill any
+	// missing required extension. isFPMAlreadyInstalled only proves php<v> is
+	// on PATH; the runtime can still be incomplete (no php<v>-mysql), which is
+	// exactly how a migrated domain ends up 500ing on mysqli (GH #531).
 	if isFPMAlreadyInstalled(p.Version) {
+		if err := ensureRequiredPHPExtsFunc(ctx, p.Version); err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("ensure required extensions for php%s: %v", p.Version, err),
+			}
+		}
 		return phpVersionInstallResponse{
 			Version:    p.Version,
 			Installed:  isInstalledPHPVersion(p.Version),
@@ -239,7 +301,7 @@ func phpVersionInstallHandler(ctx context.Context, params json.RawMessage) (any,
 		fmt.Sprintf("php%s-fpm", p.Version),
 		fmt.Sprintf("php%s-cli", p.Version),
 	}
-	requiredExts := []string{"mysql", "mbstring", "zip", "gd", "curl", "xml"}
+	requiredExts := phpRequiredExts
 	var missingRequired []string
 	for _, ext := range requiredExts {
 		pkg := fmt.Sprintf("php%s-%s", p.Version, ext)

--- a/panel-agent/internal/commands/php_version_install_test.go
+++ b/panel-agent/internal/commands/php_version_install_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,57 @@ func TestPHPVersionInstall_NoParams(t *testing.T) {
 	_, err := phpVersionInstallHandler(ctx, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "version parameter required")
+}
+
+// GH #531: an already-installed version must STILL have its required
+// extensions ensured. isFPMAlreadyInstalled only proves php<v> is on PATH; a
+// version installed without php<v>-mysql passes that check yet 500s every
+// migrated domain's mysqli_connect(). The already-installed branch must call
+// the ext-backfill seam, not short-circuit straight to a status response.
+func TestPHPVersionInstall_AlreadyInstalled_BackfillsExts(t *testing.T) {
+	origFPM := isFPMAlreadyInstalledFunc
+	origEnsure := ensureRequiredPHPExtsFunc
+	t.Cleanup(func() {
+		isFPMAlreadyInstalledFunc = origFPM
+		ensureRequiredPHPExtsFunc = origEnsure
+	})
+
+	isFPMAlreadyInstalledFunc = func(string) bool { return true }
+	var called bool
+	var gotVersion string
+	ensureRequiredPHPExtsFunc = func(_ context.Context, version string) error {
+		called = true
+		gotVersion = version
+		return nil
+	}
+
+	params, _ := json.Marshal(phpVersionInstallParams{Version: "8.2"})
+	_, err := phpVersionInstallHandler(context.Background(), params)
+	require.NoError(t, err)
+	assert.True(t, called, "already-installed path must ensure required extensions (GH #531)")
+	assert.Equal(t, "8.2", gotVersion)
+}
+
+// A backfill failure must surface as an error, not be swallowed — otherwise the
+// caller (a migration restore, or the admin API) believes the runtime is
+// complete when mysqli is still missing.
+func TestPHPVersionInstall_AlreadyInstalled_ExtEnsureError(t *testing.T) {
+	origFPM := isFPMAlreadyInstalledFunc
+	origEnsure := ensureRequiredPHPExtsFunc
+	t.Cleanup(func() {
+		isFPMAlreadyInstalledFunc = origFPM
+		ensureRequiredPHPExtsFunc = origEnsure
+	})
+
+	isFPMAlreadyInstalledFunc = func(string) bool { return true }
+	ensureRequiredPHPExtsFunc = func(context.Context, string) error {
+		return fmt.Errorf("apt boom")
+	}
+
+	params, _ := json.Marshal(phpVersionInstallParams{Version: "8.3"})
+	_, err := phpVersionInstallHandler(context.Background(), params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ensure required extensions")
 }
 
 func TestVersionSupportValidation(t *testing.T) {

--- a/panel-api/internal/migrate/cpanel/restore_extras.go
+++ b/panel-api/internal/migrate/cpanel/restore_extras.go
@@ -235,6 +235,21 @@ func ImportExtras(
 					continue
 				}
 			}
+			// Ensure the source PHP version — and its required extensions,
+			// notably php<v>-mysql — is actually installed before applying the
+			// pool. php.pool.apply only writes FPM config and hard-fails if the
+			// version dir is absent; and even a present version can lack mysqli,
+			// which 500s every migrated site's mysqli_connect() (GH #531).
+			// php.version.install is idempotent and backfills missing exts, so a
+			// migrated Hestia/cPanel domain on e.g. 8.2 gets a complete runtime
+			// even when the box shipped only the default version. Non-fatal:
+			// pool.apply below still reports a clear error if the version is
+			// genuinely uninstallable.
+			if _, err := agentCli.Call(ctx, "php.version.install", map[string]any{
+				"version": version,
+			}); err != nil {
+				res.Skipped = append(res.Skipped, fmt.Sprintf("php_version_install_skip:%s:%v", version, err))
+			}
 			// Ensure FPM pool exists at OS level.
 			if _, err := agentCli.Call(ctx, "php.pool.apply", map[string]any{
 				"username":        targetUsername,


### PR DESCRIPTION
## Symptom (GH #531)

> migrated a few hestia sites … error 500 … php mysqli was missing which is weird because mysqli is part of the php package

## Root cause

A migrated Hestia/cPanel domain keeps its **source** PHP version (`ea-php82` → `8.2`). Two gaps let that version end up without `mysqli`:

1. **`php.version.install` trusts PATH.** `isFPMAlreadyInstalled` only checks that `php<v>` is on PATH, then returns early. A version pulled in as a dependency, `apt install php8.2-fpm`'d by hand without `-mysql`, or left partial by an interrupted install passes that check yet has **no `php<v>-mysql`** — so every `mysqli_connect()` 500s.
2. **Restore never ensures the version.** `ImportExtras` called `php.pool.apply` directly. That only writes FPM config (and hard-fails if the version dir is absent); it never installs the version or its extensions. So a box that shipped only the default `8.4` couldn't give a migrated `8.2` domain a complete runtime.

## Fix

- **`php.version.install` already-installed branch now backfills required exts** (`mysql, mbstring, zip, gd, curl, xml`): dpkg-check each, `apt-get install` only the missing ones. Complete version → no-op (no apt); incomplete version → repaired (adds `php<v>-mysql`).
- **Restore calls `php.version.install` before `php.pool.apply`** (idempotent, includes `php<v>-mysql`). Non-fatal — `pool.apply` still reports a clear error if the version is genuinely uninstallable.

## Tests

`php_version_install_test.go`: already-installed path asserts the ext-backfill seam is invoked with the right version, and that a backfill error surfaces (not swallowed). `go build` + `go vet` + `panel-agent/internal/commands` + `panel-api/internal/migrate/...` suites green.

## Note

Diagnosed from the report + code paths; requested the reporter confirm the domain's PHP version so I can box-verify the exact scenario. `provision_php_extensions` also self-heals `php<v>-mysql` for all `/etc/php/*/fpm` versions on the next `jabali update`, so an affected box can also recover with an update — this fix makes the migration self-sufficient so no update is needed.