### PR TITLE
fix(files): allow editing empty (0-byte) files (GH #532)

### DIFF
--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -85,6 +85,7 @@ import {
   filesTree,
   filesWrite,
 } from "./filesApi";
+import { isTextEditable } from "./editability";
 import { UploadDrawer } from "./UploadDrawer";
 import type { UploadDrawerHandle } from "./UploadDrawer";
 // Monaco is ~500KB gzipped of the bundle; lazy-load it so the initial
@@ -184,21 +185,6 @@ function isImagePath(name: string): boolean {
   const i = name.lastIndexOf(".");
   if (i < 0) return false;
   return imageExtensions.has(name.slice(i).toLowerCase());
-}
-
-// EDIT_MAX_BYTES matches the server preview cap (files.read default 1 MiB).
-// Gating Edit at this size means the editor always loads the FULL file, so a
-// save can never truncate a larger file on disk.
-const EDIT_MAX_BYTES = 1024 * 1024;
-
-// isTextEditable decides whether to OFFER the per-row "Edit" item. It allows
-// ANY file small enough to load fully — dotfiles (.bashrc, .htaccess) and
-// extensionless configs included, not just whitelisted extensions. openEditor
-// still refuses real binaries (mime sniff + NUL bytes), so an accidental Edit
-// on a binary fails gracefully rather than corrupting it.
-function isTextEditable(entry: FileEntry): boolean {
-  if (entry.is_dir || entry.is_symlink) return false;
-  return entry.size > 0 && entry.size < EDIT_MAX_BYTES;
 }
 
 // Monaco language key by extension. Only common ones are mapped; other

--- a/panel-ui/src/shells/user/files/editability.test.ts
+++ b/panel-ui/src/shells/user/files/editability.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { EDIT_MAX_BYTES, isTextEditable } from "./editability";
+import type { FileEntry } from "./filesApi";
+
+function entry(over: Partial<FileEntry>): FileEntry {
+  return {
+    name: "test.txt",
+    is_dir: false,
+    size: 10,
+    is_symlink: false,
+    ...over,
+  } as FileEntry;
+}
+
+describe("isTextEditable", () => {
+  // GH #532: a freshly-created 0-byte file must be editable — the whole point
+  // of "create then edit" — even though it renders "—" and has size 0.
+  it("allows empty (0-byte) files", () => {
+    expect(isTextEditable(entry({ size: 0 }))).toBe(true);
+  });
+
+  it("allows a normal small text file", () => {
+    expect(isTextEditable(entry({ size: 1234 }))).toBe(true);
+  });
+
+  it("allows a file just under the cap", () => {
+    expect(isTextEditable(entry({ size: EDIT_MAX_BYTES - 1 }))).toBe(true);
+  });
+
+  it("rejects a file at/over the cap (editor loads the full file)", () => {
+    expect(isTextEditable(entry({ size: EDIT_MAX_BYTES }))).toBe(false);
+    expect(isTextEditable(entry({ size: EDIT_MAX_BYTES + 1 }))).toBe(false);
+  });
+
+  it("rejects directories and symlinks", () => {
+    expect(isTextEditable(entry({ is_dir: true, size: 0 }))).toBe(false);
+    expect(isTextEditable(entry({ is_symlink: true, size: 5 }))).toBe(false);
+  });
+});

--- a/panel-ui/src/shells/user/files/editability.ts
+++ b/panel-ui/src/shells/user/files/editability.ts
@@ -1,0 +1,21 @@
+import type { FileEntry } from "./filesApi";
+
+// EDIT_MAX_BYTES matches the server preview cap (files.read default 1 MiB).
+// Gating Edit at this size means the editor always loads the FULL file, so a
+// save can never truncate a larger file on disk.
+export const EDIT_MAX_BYTES = 1024 * 1024;
+
+// isTextEditable decides whether to OFFER the per-row "Edit" item. It allows
+// ANY file small enough to load fully — dotfiles (.bashrc, .htaccess) and
+// extensionless configs included, not just whitelisted extensions. openEditor
+// still refuses real binaries (mime sniff + NUL bytes), so an accidental Edit
+// on a binary fails gracefully rather than corrupting it.
+//
+// Empty (0-byte) files ARE editable: creating a file then editing it is the
+// whole point (GH #532 — a freshly-created test.txt showed no Edit item
+// because the old gate required size > 0). A 0-byte file loads as "" and
+// saves fine. Only the upper bound matters.
+export function isTextEditable(entry: FileEntry): boolean {
+  if (entry.is_dir || entry.is_symlink) return false;
+  return entry.size >= 0 && entry.size < EDIT_MAX_BYTES;
+}


### PR DESCRIPTION
## Symptom (GH #532)

> try create a file called file.txt, then try to edit it — it won't let you edit, actually no sub-menu option

The File Manager already has a full Monaco editor + an **Edit** row-menu item. But a **freshly-created empty file** showed no Edit option (repro in the issue: `test.txt`, Size renders `—`).

## Root cause

`isTextEditable` — the gate that decides whether to offer the Edit item — required `entry.size > 0`:

```ts
return entry.size > 0 && entry.size < EDIT_MAX_BYTES;
```

A 0-byte file (`formatBytes(0)` → `—`) fails `size > 0`, so no Edit item. `openEditor` already handles empty files correctly (mime `""` → treated as text, no NUL, loads as `""`, saves fine) — the gate was the only blocker.

## Fix

- Extracted the gate + cap into `editability.ts` (pure, unit-testable without pulling in Monaco).
- Lower bound `> 0` → `>= 0` so empty files are editable. Only the upper bound (`EDIT_MAX_BYTES`, 1 MiB — the editor loads the full file) matters, to keep a save from truncating a larger on-disk file.

## Tests

`editability.test.ts`: empty (0-byte) editable, normal small editable, just-under-cap editable, at/over cap rejected, dir/symlink rejected. `tsc -b` + full vitest (137) green.

## Note

This fixes the concrete tested complaint. The issue also floats "make edit the default when you click a file, else preview" — that's a separate UX call (click currently opens preview); happy to do it as a follow-up if you want click-to-edit for text/code files.