### PR TITLE
fix(packages): persist tenant-backup limit columns on package update (GH #454)

### DIFF
--- a/panel-api/internal/repository/package_repository.go
+++ b/panel-api/internal/repository/package_repository.go
@@ -113,7 +113,14 @@ func (r *packageRepo) Update(ctx context.Context, p *models.HostingPackage) erro
 		// persisted (the "allowlist silent drop" scar again).
 		"fpm_max_children_cap", "fpm_worker_mem_mb", "fpm_user_can_edit",
 		"fpm_advanced_mode", "fpm_version_defaults",
-		"nspawn_image_version", "updated_at",
+		"nspawn_image_version",
+		// GH #454: tenant backup entitlement columns. Added to the model + API
+		// update handler but missed here, so the admin's backup-limit changes
+		// reported success yet silently never persisted (reverted on reload) —
+		// the allowlist silent-drop scar exactly as warned above.
+		"max_backups", "scheduled_backups_enabled",
+		"allowed_backup_destination_kinds", "backup_retention_policy",
+		"updated_at",
 	).Updates(p).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-api/internal/repository/package_repository_test.go
+++ b/panel-api/internal/repository/package_repository_test.go
@@ -111,3 +111,15 @@ func TestPackage_Update_PersistsDockerAppSlugs(t *testing.T) {
 func TestPackage_Update_PersistsPHPExecEnabled(t *testing.T) {
 	updatePersistsColumn(t, "php_exec_enabled")
 }
+
+// GH #454: the tenant-backup entitlement columns were added to the model + API
+// update handler but missed from the Update Select allowlist, so admins saw a
+// success toast yet the backup limits never persisted (reverted on reload) —
+// tenants never received the backup permissions. Guard every backup column
+// appears in the emitted UPDATE (each would be absent with the old allowlist).
+func TestPackage_Update_PersistsBackupLimits(t *testing.T) {
+	updatePersistsColumn(t, "max_backups")
+	updatePersistsColumn(t, "scheduled_backups_enabled")
+	updatePersistsColumn(t, "allowed_backup_destination_kinds")
+	updatePersistsColumn(t, "backup_retention_policy")
+}


### PR DESCRIPTION
## Symptom (GH #454, reported by @lxsdevcode)

> the backup permissions in the hosting package still cannot be saved. Although the UI shows a success notification after clicking Save, the changes are not actually persisted, so tenants never receive the backup permissions.

This blocked all tenant-backup testing.

## Root cause

`packageRepo.Update` uses a GORM `.Select(...)` allowlist — and it must list **every** column the API update handler can set, or that column is silently dropped. The four tenant-backup entitlement columns were added to the model + the API update handler during the #454 work but **never added to this allowlist**:

- `max_backups`
- `scheduled_backups_enabled`
- `allowed_backup_destination_kinds`
- `backup_retention_policy`

So GORM emitted the UPDATE without them → success (no error) → reverted on reload. This is the exact "allowlist silent-drop" scar the comment above the `Select` already warns about (GH #170 `docker_app_slugs`, #402 `php_exec_enabled`, #339 FPM columns).

## Fix

Add the four backup columns to the `Select` allowlist. Regression test `TestPackage_Update_PersistsBackupLimits` asserts each appears in the emitted UPDATE — **verified it fails** when the columns are stripped from the Select (actual SQL omits `max_backups`).

`go test ./panel-api/internal/repository/` + `go vet` green.

## Note

Unblocks @lxsdevcode's tenant-backup testing. Happy to redeploy testserver and confirm a package backup-limit Save persists through the admin UI once merged.