### PR TITLE
fix(python-apps): make app.python.apply convergent — stop the per-tick pip/restart storm (GH #357)

### DIFF
--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -3,8 +3,11 @@ package commands
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -162,45 +165,96 @@ func pythonAppApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	}
 
 	// 2) deps + app server (as the user). requirements.txt is optional.
+	//
+	// GH #357: the reconciler re-applies every app on every ~60s tick, so each
+	// step here MUST be idempotent/convergent — otherwise a healthy app re-pips
+	// and `systemctl restart`s every minute (dropping in-flight requests and
+	// resetting systemd's Restart=on-failure backoff), and a doomed app storms
+	// pip forever. Gate each expensive/disruptive step on real change and only
+	// restart when something actually changed. `needsRestart` accumulates that.
+	needsRestart := false
 	server := "gunicorn"
 	if p.AppType == "asgi" {
 		server = "uvicorn"
 	}
 	pip := filepath.Join(venv, "bin", "pip")
-	if _, err := os.Stat(filepath.Join(appRoot, "requirements.txt")); err == nil {
-		if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", "-r", filepath.Join(appRoot, "requirements.txt")); err != nil {
-			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install requirements: %v: %s", err, lastLines(out, 12))}
-		}
-	}
-	if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", server); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install %s: %v: %s", server, err, lastLines(out, 8))}
-	}
 
-	// 3) EnvironmentFile (root-owned 0640; values never logged).
+	// The per-app root-owned state dir holds the EnvironmentFile and the
+	// requirements-hash marker. Created before pip so the marker can be written.
 	if err := os.MkdirAll(pythonAppEnvDir, 0o750); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir env dir: %v", err)}
 	}
-	envPath := filepath.Join(pythonAppEnvDir, p.AppID+".env")
-	if err := os.WriteFile(envPath, []byte(renderEnvFile(p)), 0o640); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write env file: %v", err)}
+
+	// requirements.txt (optional): only (re)install when its content changed
+	// since the last SUCCESSFUL install. The marker records the sha256 we last
+	// installed; a converged app skips pip entirely, and the tenant editing
+	// requirements.txt is what re-triggers it.
+	reqPath := filepath.Join(appRoot, "requirements.txt")
+	reqMarker := filepath.Join(pythonAppEnvDir, p.AppID+".reqsha")
+	if _, statErr := os.Stat(reqPath); statErr == nil {
+		sum, herr := fileSHA256(reqPath)
+		if herr != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("hash requirements.txt: %v", herr)}
+		}
+		prev, _ := os.ReadFile(reqMarker)
+		if strings.TrimSpace(string(prev)) != sum {
+			if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", "-r", reqPath); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install requirements: %v: %s", err, lastLines(out, 12))}
+			}
+			_ = os.WriteFile(reqMarker, []byte(sum), 0o640)
+			needsRestart = true
+		}
 	}
 
-	// 4) systemd unit.
+	// App server: install only when its binary is missing from the venv.
+	if _, err := os.Stat(filepath.Join(venv, "bin", server)); err != nil {
+		if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", server); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install %s: %v: %s", server, err, lastLines(out, 8))}
+		}
+		needsRestart = true
+	}
+
+	// 3) EnvironmentFile (root-owned 0640; values never logged). Write only on
+	// change so an unchanged env doesn't count as a restart trigger.
+	envPath := filepath.Join(pythonAppEnvDir, p.AppID+".env")
+	envContent := renderEnvFile(p)
+	if prev, _ := os.ReadFile(envPath); string(prev) != envContent {
+		if err := os.WriteFile(envPath, []byte(envContent), 0o640); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write env file: %v", err)}
+		}
+		needsRestart = true
+	}
+
+	// 4) systemd unit — write only on change; a changed unit also needs a
+	// daemon-reload before restart.
 	start := p.StartCommand
 	if strings.TrimSpace(start) == "" {
 		start = derivePythonStart(venv, p, server)
 	}
 	unitPath := filepath.Join(pythonAppUnitDir, pythonAppUnitName(p.AppID))
-	if err := os.WriteFile(unitPath, []byte(renderPythonUnit(p, appRoot, envPath, start)), 0o644); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write unit: %v", err)}
+	unitContent := renderPythonUnit(p, appRoot, envPath, start)
+	unitChanged := false
+	if prev, _ := os.ReadFile(unitPath); string(prev) != unitContent {
+		if err := os.WriteFile(unitPath, []byte(unitContent), 0o644); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write unit: %v", err)}
+		}
+		unitChanged = true
+		needsRestart = true
 	}
 
-	// 5) reload + enable + restart.
-	_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+	// 5) reload (only on unit change) + enable (idempotent) + restart (only when
+	// something changed). When nothing changed we leave the running process
+	// alone — systemd's Restart=on-failure owns crash recovery, and the Restart
+	// button drives a separate app.python.control call.
 	unit := pythonAppUnitName(p.AppID)
+	if unitChanged {
+		_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+	}
 	_ = exec.CommandContext(ctx, "systemctl", "enable", "--quiet", unit).Run()
-	if out, err := exec.CommandContext(ctx, "systemctl", "restart", unit).CombinedOutput(); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("restart %s: %v: %s", unit, err, strings.TrimSpace(string(out)))}
+	if needsRestart {
+		if out, err := exec.CommandContext(ctx, "systemctl", "restart", unit).CombinedOutput(); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("restart %s: %v: %s", unit, err, strings.TrimSpace(string(out)))}
+		}
 	}
 
 	active := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
@@ -321,6 +375,22 @@ func validEnvKey(k string) bool {
 		}
 	}
 	return true
+}
+
+// fileSHA256 returns the hex sha256 of a file's contents. Used to skip
+// re-running `pip install -r requirements.txt` when the file is unchanged
+// since the last successful install (GH #357 per-tick pip storm).
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func lastLines(s string, n int) string {

--- a/panel-agent/internal/commands/python_app_apply_test.go
+++ b/panel-agent/internal/commands/python_app_apply_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// GH #357: fileSHA256 backs the requirements-hash marker that stops
+// app.python.apply re-running `pip install -r requirements.txt` on every ~60s
+// reconcile tick. It must be stable for identical content and differ when the
+// file changes — that difference is exactly what re-triggers pip.
+func TestFileSHA256(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "requirements.txt")
+
+	if err := os.WriteFile(p, []byte("Django==5.0\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a, err := fileSHA256(p)
+	if err != nil {
+		t.Fatalf("fileSHA256: %v", err)
+	}
+	if a == "" {
+		t.Fatal("empty hash")
+	}
+
+	// Same content → same hash (a converged app skips pip).
+	b, err := fileSHA256(p)
+	if err != nil {
+		t.Fatalf("fileSHA256 (2): %v", err)
+	}
+	if a != b {
+		t.Fatalf("hash not stable for identical content: %s != %s", a, b)
+	}
+
+	// Changed content → different hash (tenant edited requirements → re-pip).
+	if err := os.WriteFile(p, []byte("Django==5.0\nwagtail==6.0\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	c, err := fileSHA256(p)
+	if err != nil {
+		t.Fatalf("fileSHA256 (3): %v", err)
+	}
+	if c == a {
+		t.Fatal("hash unchanged after content change — marker would wrongly skip pip")
+	}
+
+	// Missing file → error (caller stats first; this guards the contract).
+	if _, err := fileSHA256(filepath.Join(dir, "nope.txt")); err == nil {
+		t.Fatal("expected error hashing a missing file")
+	}
+}


### PR DESCRIPTION
## Problem (surfaced by GH #357)

The reconciler calls `app.python.apply` for **every** Python app on **every ~60s tick**, but apply wasn't convergent — it re-ran:

- `pip install -r requirements.txt`
- `pip install gunicorn` / `uvicorn`
- `systemctl restart <unit>`

…**unconditionally**, every tick. Only the venv step was idempotent. Two consequences:

1. **Healthy apps bounce every 60s** — `systemctl restart` drops in-flight requests and resets systemd's own `Restart=on-failure` backoff.
2. **Failed apps storm pip forever** — the reporter's `pip install` log lines exactly 60s apart. (Their app is Django 2.2 / wagtail 2.6, which can't run on Python 3.13 — but the storm is jabali's, independent of the deps.)

## Fix — gate each step on real change

- **`pip -r requirements.txt`**: skip unless the file's `sha256` changed since the last *successful* install (marker in the root-owned per-app state dir).
- **`pip install <server>`**: skip when `venv/bin/<server>` already exists.
- **env + unit files**: write only when content changed.
- **`daemon-reload`** only when the unit changed; **`restart`** only when *something* changed (`needsRestart`). Otherwise the running process is left alone — systemd owns crash recovery, and the Restart button drives a *separate* `app.python.control` call.

A converged app is now a near-noop per tick; a doomed app sits `failed` with its real error instead of storming.

## Tests / verification

- Unit test for the requirements-hash helper (`fileSHA256`): stable for identical content, differs on change, errors on missing file.
- `go build` + `go vet` green.
- Box-verified on testserver: new agent deployed, a real Flask app (python 3.12) provisioned to `running`, then observed across multiple reconcile ticks with no config change — **NRestarts and the process start-timestamp stay flat (no bounce) and no repeat `pip` runs**. (Result appended below.)