### PR TITLE
fix(ci): monthly-deps works on the gh-less self-hosted runner

### DIFF
--- a/.github/workflows/monthly-deps.yml
+++ b/.github/workflows/monthly-deps.yml
@@ -2,6 +2,9 @@
 # "bump X" issues, this opens ONE consolidated review issue on the 1st of each
 # month covering all three pinning surfaces (install.sh pins + go.mod + npm).
 # It only REPORTS — a human still bumps + E2Es + merges. See scripts/deps-check.sh.
+#
+# The self-hosted runner has curl + python3 + a GITHUB_TOKEN but no gh CLI, so
+# this follows release.yml's REST-over-curl pattern rather than using gh.
 name: Monthly dependency review
 
 on:
@@ -13,38 +16,59 @@ permissions:
   contents: read
   issues: write
 
+env:
+  GO_VERSION: "1.25"
+  NODE_VERSION: "20"
+
 jobs:
   review:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Generate dependency report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # lets deps-check.sh's curl fallback authenticate
         run: bash scripts/deps-check.sh --markdown > "$RUNNER_TEMP/deps-report.md"
 
       - name: Open or update the monthly review issue
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          API="https://api.github.com"
+          REPO="$GITHUB_REPOSITORY"
+          hdr=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           MONTH="$(date -u +'%Y-%m')"
-          TITLE="Monthly dependency review — $MONTH"
-          BODY="$RUNNER_TEMP/deps-body.md"
+          TITLE="Monthly dependency review — ${MONTH}"
+
           {
             echo "_Auto-generated on $(date -u +'%Y-%m-%d') by \`.github/workflows/monthly-deps.yml\`. Bump each upgrade, E2E on a box (framework bumps especially), then merge. Roll open \`deps\`-labelled bump requests into this._"
             echo
             cat "$RUNNER_TEMP/deps-report.md"
-          } > "$BODY"
+          } > "$RUNNER_TEMP/body.md"
 
-          # Idempotent label so a fresh repo doesn't fail the create.
-          gh label create deps --repo "$GITHUB_REPOSITORY" --color 0e8a16 --description "Dependency upgrades" 2>/dev/null || true
+          # Ensure the 'deps' label exists (422 already-exists is fine).
+          curl -sS "${hdr[@]}" -X POST "${API}/repos/${REPO}/labels" \
+            -d '{"name":"deps","color":"0e8a16","description":"Dependency upgrades"}' >/dev/null || true
 
-          # Update the same month's issue if a re-run finds one, else create.
-          NUM="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$TITLE in:title" \
-                   --json number,title --jq "[.[] | select(.title==\"$TITLE\") | .number] | first // empty")"
+          # Find this month's open issue by exact title (list is immediate; search lags indexing).
+          NUM="$(curl -sS "${hdr[@]}" "${API}/repos/${REPO}/issues?state=open&labels=deps&per_page=100" \
+                 | python3 -c 'import json,sys; items=json.load(sys.stdin); t=sys.argv[1]; print(next((i["number"] for i in items if i.get("title")==t and "pull_request" not in i), ""))' "$TITLE")"
+
+          # JSON-encode the payload (python3 handles body escaping; no jq on the runner).
+          PAYLOAD="$(python3 -c 'import json,sys; print(json.dumps({"title":sys.argv[1],"body":open(sys.argv[2]).read(),"labels":["deps"]}))' "$TITLE" "$RUNNER_TEMP/body.md")"
+
           if [[ -n "$NUM" ]]; then
-            gh issue edit "$NUM" --repo "$GITHUB_REPOSITORY" --body-file "$BODY"
-            echo "Updated existing review issue #$NUM"
+            curl -sS "${hdr[@]}" -X PATCH "${API}/repos/${REPO}/issues/${NUM}" -d "$PAYLOAD" >/dev/null
+            echo "Updated existing review issue #${NUM}"
           else
-            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$BODY" --label deps
+            curl -sS "${hdr[@]}" -X POST "${API}/repos/${REPO}/issues" -d "$PAYLOAD" \
+              | python3 -c 'import json,sys; print("Created issue #%s" % json.load(sys.stdin)["number"])'
           fi

--- a/scripts/deps-check.sh
+++ b/scripts/deps-check.sh
@@ -66,9 +66,22 @@ current_pin() {
 }
 
 # latest_release repo tag_prefix -> bare latest version, or "" on failure.
+# Prefers gh (authenticated locally); falls back to curl + the REST API so it
+# also works on the self-hosted CI runner, which has curl + a token but no gh.
 latest_release() {
-  local repo="$1" prefix="$2" tag
-  tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null)" || return 0
+  local repo="$1" prefix="$2" tag=""
+  if command -v gh >/dev/null 2>&1; then
+    tag="$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null)"
+  fi
+  if [[ -z "$tag" ]]; then
+    local -a auth=()
+    local tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    [[ -n "$tok" ]] && auth=(-H "Authorization: Bearer ${tok}")
+    tag="$(curl -fsSL "${auth[@]}" -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null \
+      | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' | head -1 \
+      | sed -E 's/.*"([^"]+)"$/\1/')"
+  fi
   [[ -z "$tag" ]] && return 0
   # phpMyAdmin tags are RELEASE_5_2_3 -> 5.2.3; underscores to dots after strip.
   tag="${tag#"$prefix"}"


### PR DESCRIPTION
Follow-up to #623. The first `workflow_dispatch` failed with `gh: command not found` — the self-hosted runner has **curl + python3 + a token but no `gh` CLI** (release.yml already uses REST-over-curl for this reason).

- **`scripts/deps-check.sh`** — `latest_release` prefers `gh` when present (local dev) and falls back to **curl + the REST API** (auth via `GH_TOKEN`/`GITHUB_TOKEN`) otherwise. Verified the curl path parses `tag_name` identically (`v1.0.11`).
- **`monthly-deps.yml`** — add `setup-go` + `setup-node` (ci.yml's 1.25/20) so the Go/npm sections have toolchains; pass `GH_TOKEN` to the report step; replace `gh issue create/edit` with **curl + python3** (label ensure → list-by-title for idempotency → `json.dumps` for body escaping).

Verified locally: curl fallback returns the same versions as gh; `python3` JSON-encoding escapes quotes/backslash/em-dash/newlines cleanly.