### PR TITLE
fix(ci): disable setup-go cache in monthly-deps (was hanging the runner)

### DIFF
--- a/.github/workflows/monthly-deps.yml
+++ b/.github/workflows/monthly-deps.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          # cache: false — matches ci.yml. The self-hosted runner's persistent
+          # $GOMODCACHE already caches; setup-go's tar layer conflicts with it and
+          # HANGS the "Post Run setup-go" cache-save step, which held the single
+          # runner and left the whole monthly run (and queued CI) stuck.
+          cache: false
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
The manual `monthly-deps` run got stuck 20+ min on **Post Run actions/setup-go@v5** (the cache-save post-step). That held the single self-hosted runner, so the next PR's CI (#626) sat **Queued** behind it — the "stuck" you saw.

ci.yml already avoids this with `cache: false` (comment: *the runner's persistent `$GOMODCACHE` caches and setup-go's tar layer conflicts with a pre-existing cache*). This matches it on the monthly workflow.

The job's actual work completed fine (the report generated and #625 was created/updated) — this only removes the hanging post-step. No cache is needed for a monthly report run.