### PR TITLE
fix(update): re-run stalwart-cli installer in provision so a cli bump deploys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13229,6 +13229,18 @@ EOF
     install_malware_stack
   fi
 
+  # stalwart-cli: historically installed only on fresh installs, so a
+  # cli_version bump never reached existing hosts on `jabali update` (the CLI
+  # speaks Stalwart's JMAP management API). Re-run the version-gated installer
+  # here so a bump deploys. It's a no-op when already current (--version skip);
+  # the subshell + `|| _warn` isolates its _die on a transient download/sha
+  # failure so it can't skip the rest of provision (provision is best-effort —
+  # update.go continues on a provision failure).
+  if declare -f _install_stalwart_cli >/dev/null 2>&1; then
+    _log "provision: ensuring stalwart-cli at the pinned version"
+    ( _install_stalwart_cli ) || _warn "provision: stalwart-cli install failed (will retry next update)"
+  fi
+
   # logrotate drop-in — refreshed every update so new log paths added in
   # later releases land on existing hosts. Cheap: cmp -s short-circuits
   # when the file is byte-identical.

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -640,10 +640,10 @@ install -m 0644 ` + repoDir + `/install/systemd/jabali-disk-maintenance.timer /e
 # self-restart fix from ever reaching deployed hosts.
 install -d -m 0755 /etc/letsencrypt/renewal-hooks/deploy
 install -m 0755 ` + repoDir + `/install/letsencrypt/jabali-panel-cert.sh /etc/letsencrypt/renewal-hooks/deploy/jabali-panel-cert.sh
-# jabali-stalwart-push-cert: install.sh only refreshes this inside
-# _install_stalwart_cli, which jabali update never calls (the cli is
-# already at the pinned version, so that function isn't in the update
-# path). Without re-copying here, hosts keep the pre-M6.6 hardcoded-
+# jabali-stalwart-push-cert: install.sh refreshes this inside
+# _install_stalwart_cli, which provision_new_software now re-runs on
+# update (version-gated) — but provision is best-effort, so re-copy it
+# here too as a belt-and-suspenders. Without it, hosts keep the pre-M6.6 hardcoded-
 # path push-cert that ignores the JABALI_STALWART_CERT_* env the
 # mail-domain deploy-hook exports — so per-domain mail certs (GH #132)
 # got pushed under the PANEL cert name and Stalwart served the panel


### PR DESCRIPTION
## Found while box-verifying #626

Deploying #626 to a box: **maldet 2.0.1** ✅ and **yara-x 1.19.0** ✅ installed (their `install_malware_stack` is re-run in `provision_new_software`), but **stalwart-cli stayed at 1.0.8**. `_install_stalwart_cli` was only ever called on a **fresh install**, never on `jabali update` — update.go even baked in the assumption ("*the cli is already at the pinned version, so that function isn't in the update path*"). So the #625 bump — and every future cli bump — never reached existing hosts.

## Fix
- `provision_new_software` now re-runs `_install_stalwart_cli`. It's **version-gated** (a no-op when already current via `--version`), and wrapped in a subshell + `|| _warn` so its `_die` on a transient download/sha failure can't skip the rest of provision (provision is best-effort — update.go continues on a provision failure).
- Updated the now-stale update.go comment; it still re-copies `jabali-stalwart-push-cert` as a belt-and-suspenders since provision can fail.

## Verified on a box
Running the installer against the current pin upgraded **stalwart-cli 1.0.8 → 1.0.11** (download + sha256 verify + install), and it no-ops when already current:
```
[!] upgrading stalwart-cli 1.0.8 -> 1.0.11
[✓] stalwart-cli 1.0.11 installed at /usr/local/bin/stalwart-cli
```
`bash -n install.sh` + `go build ./panel-api/cmd/server/` green.