### PR TITLE
fix(update): re-run wp-cli installer in provision so a wp_version bump deploys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13280,6 +13280,16 @@ EOF
   if declare -f ensure_jabali_in_mysql_group >/dev/null 2>&1; then
     ensure_jabali_in_mysql_group
   fi
+  # wp-cli: ensure the PINNED phar is present so a wp_version bump deploys on
+  # update. ensure_wpcli_symlink (below) only heals a missing/dangling symlink —
+  # with an intact old symlink a bumped version never downloaded, so wp stayed
+  # on the old version on existing hosts (the same fresh-install-only gap as
+  # stalwart-cli). install_wp_cli is version-gated (downloads only when the
+  # pinned phar is absent), subshell-isolated so its _die on a transient
+  # download failure can't skip the rest of provision.
+  if declare -f install_wp_cli >/dev/null 2>&1; then
+    ( install_wp_cli ) || _warn "provision: wp-cli install failed (will retry next update)"
+  fi
   if declare -f ensure_wpcli_symlink >/dev/null 2>&1; then
     ensure_wpcli_symlink
   fi


### PR DESCRIPTION
## Deploy-path audit (follow-up to #628)

Checked every `install.sh` version pin for whether a bump actually reaches existing hosts on `jabali update`:

| pin | update-path installer | deploys on bump? |
|---|---|---|
| stalwart | "sync stalwart binary" step | ✅ |
| stalwart-cli | provision (#628) | ✅ |
| bulwark | "sync bulwark systemd + env" (version-compare → `install_bulwark`) | ✅ |
| kratos | "sync kratos config" → version-gated `install_kratos` | ✅ |
| maldet / yara-x | "sync malware stack" + provision | ✅ |
| phpMyAdmin | provision → version-gated `install_phpmyadmin` | ✅ |
| snuffleupagus | "sync PHP Defense" → version-gated build | ✅ |
| **wp-cli** | `ensure_wpcli_symlink` only | ❌ **gap** |

`ensure_wpcli_symlink` (the only update-path caller of `install_wp_cli`) re-installs **only when `/opt/wp-cli/current` is missing/dangling** — with an intact old symlink, a bumped `wp_version` never downloaded, so wp stayed on the old version on existing hosts. Same fresh-install-only gap as stalwart-cli.

## Fix
`provision_new_software` now runs `install_wp_cli` (version-gated — downloads only when the pinned phar is absent), subshell-isolated so a transient download `_die` can't skip the rest of provision.

## Verified
`bash -n` clean. On a box, `install_wp_cli` no-ops at the current version (*"wp-cli 2.12.0 phar already present"* → recreates symlink, wp still 2.12.0) — same version-gate as the box-proven stalwart-cli upgrade, so a bump will download the new phar.

**Audit conclusion: wp-cli was the only remaining gap; all other pins deploy correctly on update.**