### PR TITLE
chore(deps): bump Bulwark webmail 1.7.7 -> 1.7.8 (#625)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11614,7 +11614,7 @@ _install_spam_rules() {
 }
 
 install_bulwark() {
-  local bulwark_version="1.7.7"
+  local bulwark_version="1.7.8"
   local arch="linux-amd64"
   local tarball="bulwark-standalone-${bulwark_version}-${arch}.tar.gz"
   local url="https://github.com/bulwarkmail/webmail/releases/download/${bulwark_version}/${tarball}"

--- a/install/bulwark.sha256
+++ b/install/bulwark.sha256
@@ -1,9 +1,9 @@
-# Bulwark Webmail 1.7.7 standalone tarball SHA-256.
-# Source: https://github.com/bulwarkmail/webmail/releases/tag/1.7.7
-#   asset: bulwark-standalone-1.7.7-linux-amd64.tar.gz
-# Captured 2026-07-11 directly from the GitHub release artifact (GH #349 / bump #372;
-# 1.7.7 "Composer: Preselect the identity of the active mailbox for new messages"
-# fixes shared-mailbox compose defaulting to the wrong From).
+# Bulwark Webmail 1.7.8 standalone tarball SHA-256.
+# Source: https://github.com/bulwarkmail/webmail/releases/tag/1.7.8
+#   asset: bulwark-standalone-1.7.8-linux-amd64.tar.gz
+# Captured 2026-07-23 directly from the GitHub release artifact (monthly review
+# #625). 1.7.8 (2026-07-22): Unified Mailbox, Category Tabs, Collapsible Quoted
+# Replies, Arabic translation, expanded plugin APIs.
 #
 # Bulwark ships a prebuilt "standalone" Next.js tarball (server.js +
 # node_modules + .next), so we no longer git-clone + `npm ci` +
@@ -14,4 +14,4 @@
 #   curl -sSL https://github.com/bulwarkmail/webmail/releases/download/<v>/bulwark-standalone-<v>-linux-amd64.tar.gz | sha256sum
 # Paste the returned 64-char hex below. install.sh `_die`s if the
 # placeholder PLACEHOLDER_CAPTURE_ON_FIRST_DEPLOY survives.
-38d3178bfacd841e1899b6d483ff09b0df32af3e75cd12c11d6c47a67e2af962
+db461aec112b071b2db69a9a0b5b29c2ec53f692cb8a500b221cb95c85fcefb7


### PR DESCRIPTION
Batch 2 of the July monthly dependency review (#625).

- `bulwark_version` 1.7.7 → **1.7.8**; `install/bulwark.sha256` refreshed (captured directly from `bulwark-standalone-1.7.8-linux-amd64.tar.gz`, 200 OK).
- **1.7.8** (2026-07-22): Unified Mailbox, Category Tabs, Collapsible Quoted Replies, Arabic translation, expanded plugin APIs.
- **Deploy path already good**: update.go's *"sync bulwark systemd + env"* step version-compares installed vs pinned and re-runs `install_bulwark` on mismatch (confirmed in the deploy-path audit).

## Box E2E (testserver)
Ran the real upgrade path (`install_bulwark` with the 1.7.8 pin):
```
[i] downloading bulwark-standalone-1.7.8-linux-amd64.tar.gz
[✓] Bulwark 1.7.8 installed at /opt/jabali-webmail
VERSION=1.7.8  service=active
HTTP via bulwark socket: 200   (Next.js app markers in the response)
```
The standalone Next.js tarball downloaded, **sha-verified**, extracted, the service **booted active**, and it **serves HTTP 200** over `/run/jabali-bulwark/bulwark.sock`. `bash -n install.sh` clean.