### PR TITLE
ci: gate the panel-ui production build in the fast unit-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
         run: cd panel-ui && npm run lint
       - name: vitest
         run: cd panel-ui && npm test
+      # Production build gate. vitest uses its own transform and never runs the
+      # rollup/vite production build, so a build-only break — e.g. a bumped
+      # dep that breaks `monaco-editor/…editor.worker?worker` resolution — passes
+      # vitest yet fails the real build (caught only at deploy). The Playwright
+      # job does build the SPA, but that job is slower and can be skipped under
+      # runner contention; gate the build here too so it fails fast and always.
+      - name: build (production)
+        run: cd panel-ui && NODE_OPTIONS=--max-old-space-size=4096 npm run build
 
   e2e:
     name: Playwright E2E


### PR DESCRIPTION
Follow-up to the July npm bumps (#636).

While bumping npm deps, a plain `npm update` broke the **production build** — `Rollup failed to resolve "monaco-editor/…editor.worker?worker"` (the Monaco lazy loader in `FileManagerPage`) — yet **vitest passed** (vitest uses its own transform and never runs the rollup/vite build).

The Playwright job *does* `npm run build`, so the build isn't entirely un-gated — but it's the slowest job and can be skipped under runner contention, so a build-only break could slip to deploy.

**Fix:** add `npm run build` to the fast `ui-unit` job so the production build fails **fast** and is **always** gated, independent of Playwright. `NODE_OPTIONS` caps heap for the self-hosted runner.

(Correction to my earlier note: the build was already run in the Playwright job — this makes it a fast, guaranteed gate rather than adding a previously-missing one.)