### PR TITLE
fix(dns): DNS Zones overview shows effective default TTL, not SOA minimum (GH #527)

### DIFF
--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -142,7 +142,15 @@ func (h *dnsHandler) getZone(c *gin.Context) {
 			recordCount = len(recs)
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"zone": zone, "record_count": recordCount})
+	// GH #527: the effective default record TTL (server_settings.default_dns_ttl)
+	// — what auto-records + new records use. Surfaced so the DNS Zones overview
+	// shows the configured default (e.g. 300) rather than the SOA minimum_ttl
+	// (a negative-cache timer that stays fixed at 3600 by design).
+	c.JSON(http.StatusOK, gin.H{
+		"zone":          zone,
+		"record_count":  recordCount,
+		"effective_ttl": h.defaultRecordTTL(c.Request.Context()),
+	})
 }
 
 func (h *dnsHandler) updateZone(c *gin.Context) {

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -59,7 +59,9 @@ const ZonesTab = () => {
             domainId: domain.id,
             provisioned: !!res.data?.zone?.id,
             recordCount: res.data?.record_count as number | undefined,
-            ttl: (res.data?.zone?.minimum_ttl ?? null) as number | null,
+            // GH #527: show the effective default record TTL (what records
+            // use), not the SOA minimum_ttl (negative-cache timer, fixed 3600).
+            ttl: (res.data?.effective_ttl ?? null) as number | null,
           };
         } catch {
           return { domainId: domain.id, provisioned: false, recordCount: undefined, ttl: null };

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -56,7 +56,9 @@ const ZonesTab = () => {
             domainId: domain.id,
             provisioned: !!res.data?.zone?.id,
             recordCount: res.data?.record_count as number | undefined,
-            ttl: (res.data?.zone?.minimum_ttl ?? null) as number | null,
+            // GH #527: show the effective default record TTL (what records
+            // use), not the SOA minimum_ttl (negative-cache timer, fixed 3600).
+            ttl: (res.data?.effective_ttl ?? null) as number | null,
           };
         } catch {
           return { domainId: domain.id, provisioned: false, recordCount: undefined, ttl: null };


### PR DESCRIPTION
Follow-up to the #527 TTL work. The reporter confirmed records are now **300** (the configured default), but the **DNS Zones overview** still shows **3600** in the TTL column.

## Root cause
The overview "TTL" column read `zone.minimum_ttl` — the **SOA minimum** (negative-cache timer), which is deliberately kept fixed at 3600. So it showed 3600 while the actual record TTLs are 300.

## Fix (option A)
- **API**: `GET /domains/:id/dns/zone` now returns `effective_ttl` = `defaultRecordTTL(ctx)` (i.e. `server_settings.default_dns_ttl`, default 300) — what auto-records and new records actually use.
- **UI**: both overview pages (admin + user) show `effective_ttl` in the TTL column instead of `minimum_ttl`.

The SOA `minimum_ttl` stays 3600 — it's a separate negative-cache timer, not the record TTL (consistent with the earlier note that SOA protocol timers stay fixed).

## Verified
`go build` + `go vet` + api dns tests + `tsc -b` + production build + vitest (137) all green.