### PR TITLE
fix(migrate): canonicalize staging symlink so mail import can push (GH #530)

### DIFF
--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -100,6 +100,19 @@ func migrationImportMailboxesHandler(ctx context.Context, raw json.RawMessage) (
 			Code: agentwire.CodeInvalidArgument, Message: "src_mail_dir not absolute: " + err.Error(),
 		}
 	}
+	// GH #530: /var/lib/jabali-migrations is a compat SYMLINK to
+	// /var/lib/jabali/migrations on hosts moved to the config-driven
+	// working-folder scheme (GH #327). filesafe opens message files with
+	// openat2 RESOLVE_BENEATH, which refuses to traverse a symlink component —
+	// so a src_mail_dir routed THROUGH that symlink fails every blob/upload with
+	// ENOTDIR ("not a directory"). The Maildir walk (plain os.ReadDir) still
+	// follows the symlink and finds messages, producing the exact
+	// messages_found>0 / messages_pushed=0 symptom. Canonicalize so no filesafe
+	// op crosses the symlink; the resolved path still lives under the real
+	// /var/lib/jabali/migrations root already in migrationStagingRoots.
+	if resolved, rerr := filepath.EvalSymlinks(srcAbs); rerr == nil {
+		srcAbs = resolved
+	}
 	allowedRoots := migrationStagingRoots
 	if p.DestUser != "" {
 		if strings.Contains(p.DestUser, "/") || strings.Contains(p.DestUser, "..") {


### PR DESCRIPTION
## Reproduced the reporter's `messages_found>0, messages_pushed=0`

Built a minimal cpmove with the reporter's exact Maildir shape (empty INBOX + a `.Sent` subfolder message + a message in `cur`) and ran `jabali migrate restore` on a box. It failed identically:

```
mailboxes: messages_found=1 messages_pushed=0 bytes_pushed=0
- .../alice/.Sent/cur/…:2,S: blob/upload: not a directory
- .../bob/cur/…:2,:        blob/upload: not a directory
```

## Root cause
On hosts moved to the config-driven working-folder scheme (GH #327), **`/var/lib/jabali-migrations` is a compat symlink → `/var/lib/jabali/migrations`**. The Maildir walk (plain `os.ReadDir`) follows the symlink and finds messages, but each message is pushed via filesafe's **openat2 `RESOLVE_BENEATH`** (the GH #421-428 traversal hardening), which **refuses to traverse a symlink component** → every `blob/upload` fails with `ENOTDIR` ("not a directory").

Folder creation goes over JMAP (no filesystem), so the folders appeared while **no mail imported** — exactly the reporter's symptom.

## Fix
`EvalSymlinks(src_mail_dir)` at the top of the import handler, so no filesafe op crosses the symlink. The resolved path still lives under the real `/var/lib/jabali/migrations` root already in `migrationStagingRoots`.

## Verified (box)
Same restore after the fix: **`messages_pushed` 0 → 2** (`bytes_pushed=341`), no `ENOTDIR`, restore no longer DEGRADED. `go vet` clean.