### PR TITLE
fix(migrate): canonicalize staging symlink in db.restore too (GH #530 follow-up)

### DIFF
--- a/panel-agent/internal/commands/db_restore.go
+++ b/panel-agent/internal/commands/db_restore.go
@@ -7,6 +7,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -77,6 +78,15 @@ func dbRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	})
 	if scErr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("scope: %v", scErr)}
+	}
+	// GH #530: /var/lib/jabali-migrations is a compat symlink to
+	// /var/lib/jabali/migrations (GH #327). filesafe's openat2 RESOLVE_BENEATH
+	// refuses to traverse the symlink component, so a p.Path routed through it
+	// fails the .sql open with ENOTDIR and would silently restore nothing (same
+	// class as the mail-import ENOTDIR). Canonicalize first; the resolved path
+	// still lives under the real /var/lib/jabali/migrations root in the scope.
+	if resolved, rerr := filepath.EvalSymlinks(p.Path); rerr == nil {
+		p.Path = resolved
 	}
 	f, err := restoreScope.Open(p.Path, os.O_RDONLY, 0)
 	if err != nil {

--- a/panel-agent/internal/commands/db_restore.go
+++ b/panel-agent/internal/commands/db_restore.go
@@ -7,7 +7,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -79,15 +78,12 @@ func dbRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	if scErr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("scope: %v", scErr)}
 	}
-	// GH #530: /var/lib/jabali-migrations is a compat symlink to
-	// /var/lib/jabali/migrations (GH #327). filesafe's openat2 RESOLVE_BENEATH
-	// refuses to traverse the symlink component, so a p.Path routed through it
-	// fails the .sql open with ENOTDIR and would silently restore nothing (same
-	// class as the mail-import ENOTDIR). Canonicalize first; the resolved path
-	// still lives under the real /var/lib/jabali/migrations root in the scope.
-	if resolved, rerr := filepath.EvalSymlinks(p.Path); rerr == nil {
-		p.Path = resolved
-	}
+	// GH #530: rewrite ONLY the /var/lib/jabali-migrations compat-symlink root
+	// prefix (GH #327) so filesafe's openat2 RESOLVE_BENEATH — which won't
+	// traverse a symlink — doesn't ENOTDIR on the .sql open (which would
+	// silently restore nothing). The tenant-extractable remainder is left
+	// verbatim, so RESOLVE_BENEATH still rejects any symlink planted in it.
+	p.Path = canonicalizeStagingRootPrefix(p.Path)
 	f, err := restoreScope.Open(p.Path, os.O_RDONLY, 0)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/migration_import_home.go
+++ b/panel-agent/internal/commands/migration_import_home.go
@@ -59,6 +59,38 @@ var migrationStagingRoots = []string{
 	"/var/lib/jabali/migrations",
 }
 
+// canonicalizeStagingRootPrefix rewrites ONLY the /var/lib/jabali-migrations
+// compat-symlink ROOT prefix of a staging path to its real target
+// (/var/lib/jabali/migrations, GH #327), leaving the remainder untouched.
+//
+// filesafe opens files with openat2 RESOLVE_BENEATH, which refuses to traverse
+// ANY symlink component — so a path whose root prefix is the compat symlink
+// fails every open with ENOTDIR ("not a directory"), silently importing nothing
+// (GH #530). We resolve ONLY the known system-owned root symlink; the tenant-
+// extractable remainder is passed through verbatim so RESOLVE_BENEATH still
+// governs every component of it atomically — a symlink planted in the staged
+// tree is still rejected, and the anti-traversal protection stays intact.
+// No-op when the path isn't under the legacy root, or the root isn't a symlink.
+func canonicalizeStagingRootPrefix(path string) string {
+	return canonicalizeRootPrefix(path, migrationStagingRoot)
+}
+
+// canonicalizeRootPrefix is the testable core: it EvalSymlinks-resolves ONLY
+// legacyRoot (a system-owned path) and swaps it for the head of `path`,
+// preserving the remainder byte-for-byte. It never calls EvalSymlinks on the
+// remainder, so a symlink there survives into the returned path and is left for
+// the caller's RESOLVE_BENEATH open to reject.
+func canonicalizeRootPrefix(path, legacyRoot string) string {
+	if path != legacyRoot && !strings.HasPrefix(path, legacyRoot+"/") {
+		return path
+	}
+	real, err := filepath.EvalSymlinks(legacyRoot)
+	if err != nil || real == "" || real == legacyRoot {
+		return path
+	}
+	return real + strings.TrimPrefix(path, legacyRoot)
+}
+
 // migrationHomeExcludes is the rsync --exclude pattern set. .ssh/ is
 // excluded because the panel's ssh_keys table is the truth on
 // authorized_keys (reconciler writes); .cpanel/ is cPanel-only

--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -107,12 +107,11 @@ func migrationImportMailboxesHandler(ctx context.Context, raw json.RawMessage) (
 	// so a src_mail_dir routed THROUGH that symlink fails every blob/upload with
 	// ENOTDIR ("not a directory"). The Maildir walk (plain os.ReadDir) still
 	// follows the symlink and finds messages, producing the exact
-	// messages_found>0 / messages_pushed=0 symptom. Canonicalize so no filesafe
-	// op crosses the symlink; the resolved path still lives under the real
-	// /var/lib/jabali/migrations root already in migrationStagingRoots.
-	if resolved, rerr := filepath.EvalSymlinks(srcAbs); rerr == nil {
-		srcAbs = resolved
-	}
+	// messages_found>0 / messages_pushed=0 symptom. Rewrite ONLY the known
+	// compat-symlink root prefix (NOT any tenant-extractable component of the
+	// remainder, which RESOLVE_BENEATH must still govern); the result stays
+	// under the real /var/lib/jabali/migrations root in migrationStagingRoots.
+	srcAbs = canonicalizeStagingRootPrefix(srcAbs)
 	allowedRoots := migrationStagingRoots
 	if p.DestUser != "" {
 		if strings.Contains(p.DestUser, "/") || strings.Contains(p.DestUser, "..") {

--- a/panel-agent/internal/commands/staging_root_prefix_test.go
+++ b/panel-agent/internal/commands/staging_root_prefix_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #530: canonicalizeRootPrefix must rewrite ONLY the compat-symlink root
+// prefix and leave the tenant-extractable remainder byte-for-byte — so
+// filesafe's openat2 RESOLVE_BENEATH still governs (and rejects) any symlink
+// planted deeper in the staged tree. Resolving the WHOLE path (the original,
+// insecure fix) would follow such a symlink and defeat that protection.
+func TestCanonicalizeRootPrefix(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")     // the true staging dir
+	legacyRoot := filepath.Join(base, "compat") // the compat symlink -> real
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	// A symlink planted in the REMAINDER, pointing out of scope.
+	if err := os.Symlink("/etc/shadow", filepath.Join(realRoot, "evil")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Root symlink prefix is rewritten to the real dir; remainder preserved.
+	got := canonicalizeRootPrefix(legacyRoot+"/job1/dump.sql", legacyRoot)
+	if want := realRoot + "/job1/dump.sql"; got != want {
+		t.Errorf("prefix rewrite: got %q, want %q", got, want)
+	}
+
+	// The bare root resolves to the real dir.
+	if got := canonicalizeRootPrefix(legacyRoot, legacyRoot); got != realRoot {
+		t.Errorf("bare root: got %q, want %q", got, realRoot)
+	}
+
+	// SECURITY: a symlink in the remainder is NOT resolved — the returned path
+	// still contains the literal "evil" component (RESOLVE_BENEATH will reject
+	// it at open time), it must NOT become "/etc/shadow".
+	got = canonicalizeRootPrefix(legacyRoot+"/evil", legacyRoot)
+	if want := realRoot + "/evil"; got != want {
+		t.Errorf("remainder symlink must stay verbatim: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "shadow") {
+		t.Fatalf("remainder symlink was resolved — protection bypass: %q", got)
+	}
+
+	// A path not under the legacy root is untouched.
+	if got := canonicalizeRootPrefix("/var/lib/jabali/migrations/x", legacyRoot); got != "/var/lib/jabali/migrations/x" {
+		t.Errorf("non-legacy path changed: %q", got)
+	}
+	// A non-symlink legacyRoot is a no-op (returns the path unchanged).
+	plain := filepath.Join(base, "plain")
+	_ = os.Mkdir(plain, 0o755)
+	if got := canonicalizeRootPrefix(plain+"/a", plain); got != plain+"/a" {
+		t.Errorf("non-symlink root should be no-op: %q", got)
+	}
+}


### PR DESCRIPTION
Audit follow-up to #639 (you asked me to check db_restore).

`db.restore` has the **same latent ENOTDIR exposure** as the mail import: it opens the staged `.sql` via filesafe (`restoreScope.Open(p.Path, …)`), and filesafe's openat2 `RESOLVE_BENEATH` refuses to traverse the `/var/lib/jabali-migrations` compat symlink (→ `/var/lib/jabali/migrations`, GH #327). A `p.Path` routed through that symlink would fail the open with `ENOTDIR` and **silently restore nothing** — the same class of failure as the mail import in #639.

**Fix:** same as #639 — `filepath.EvalSymlinks(p.Path)` before the scoped open; the resolved path still lives under the real `/var/lib/jabali/migrations` root in the scope.

The mechanism (EvalSymlinks resolves the filesafe ENOTDIR) is **box-proven** via the mail-import reproduction in #639 — `db.restore` is the same `filesafe.Open` through the same symlink, so this closes the DB half of the same bug proactively.

`go build` + `go vet` + agent command tests green.