### PR TITLE
fix(backups): show tenant scheduled-backup time in UTC to match admin (GH #454)

### DIFF
--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -81,6 +81,7 @@ export const BackupSettingsTab = () => {
           label={t("backupsettingstab.tenant_scheduled_backup_time_cron")}
           tooltip={t("backupsettingstab.tenants_choose_what_to_back_up_and_where_you")}
           rules={[{ required: true, message: "A cron expression is required" }]}
+          extra="Runs in UTC (server time) — e.g. 0 3 * * * fires at 03:00 UTC. The tenant view shows the same UTC time."
         >
           <Input placeholder="0 3 * * *" style={{ fontFamily: "monospace" }} />
         </Form.Item>

--- a/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
@@ -12,7 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../apiClient";
 import { extractApiError } from "../../apiErrors";
-import { shortDateTime } from "../../utils/datetime";
+import { shortDateTimeUTC } from "../../utils/datetime";
 
 type ScheduleView = {
   exists: boolean;
@@ -99,7 +99,7 @@ export const MyProfileScheduleCard = () => {
           <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
             {nextRun ? (
               <>
-                Your host runs your scheduled backup next at <strong>{shortDateTime(nextRun)}</strong>.
+                Your host runs your scheduled backup next at <strong>{shortDateTimeUTC(nextRun)}</strong>.
               </>
             ) : (
               <>Your host sets when scheduled backups run.</>

--- a/panel-ui/src/utils/datetime.test.ts
+++ b/panel-ui/src/utils/datetime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { shortDateTime, shortDateTimeUTC } from "./datetime";
+
+describe("shortDateTimeUTC", () => {
+  // GH #454: a backup schedule runs on a UTC cron; the tenant's next-run must
+  // render in UTC (03:00) to match the admin's `0 3 * * *`, regardless of the
+  // viewer's browser timezone.
+  it("renders a UTC instant in UTC with a UTC suffix", () => {
+    expect(shortDateTimeUTC("2026-07-24T03:00:00Z")).toBe("24 Jul 2026, 03:00 UTC");
+  });
+
+  it("renders an offset instant back in UTC (not local)", () => {
+    // 04:00+01:00 == 03:00 UTC
+    expect(shortDateTimeUTC("2026-07-24T04:00:00+01:00")).toBe("24 Jul 2026, 03:00 UTC");
+  });
+
+  it("returns an em dash for empty/invalid input", () => {
+    expect(shortDateTimeUTC(null)).toBe("—");
+    expect(shortDateTimeUTC(undefined)).toBe("—");
+    expect(shortDateTimeUTC("not-a-date")).toBe("—");
+  });
+
+  it("shortDateTime still exists and formats (local, no suffix)", () => {
+    expect(shortDateTime(null)).toBe("—");
+    // A UTC-midnight value formats without a 'UTC' suffix (local formatter).
+    expect(shortDateTimeUTC("2026-07-24T03:00:00Z")).toContain("UTC");
+    expect(shortDateTime("2026-07-24T03:00:00Z")).not.toContain("UTC");
+  });
+});

--- a/panel-ui/src/utils/datetime.ts
+++ b/panel-ui/src/utils/datetime.ts
@@ -2,6 +2,9 @@
 // Keeps timestamps compact ("25 Jun 2026, 04:04") instead of raw ISO
 // ("2026-06-25T04:04:32.589695Z"). Invalid/empty input renders an em dash.
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
 
 const DASH = "—";
 
@@ -10,6 +13,16 @@ export function shortDateTime(ts: string | null | undefined): string {
   if (!ts) return DASH;
   const d = dayjs(ts);
   return d.isValid() ? d.format("DD MMM YYYY, HH:mm") : DASH;
+}
+
+// shortDateTimeUTC: like shortDateTime but rendered in UTC with a "UTC" suffix.
+// GH #454: backup schedules run on a UTC cron (the admin edits `0 3 * * *`), so
+// the tenant's next-run must show 03:00 UTC to match the admin — not the
+// viewer's browser-local tz (which made admin=03:00 read as tenant=04:00).
+export function shortDateTimeUTC(ts: string | null | undefined): string {
+  if (!ts) return DASH;
+  const d = dayjs.utc(ts);
+  return d.isValid() ? d.format("DD MMM YYYY, HH:mm") + " UTC" : DASH;
 }
 
 // shortDate: date only. e.g. "25 Jun 2026".


### PR DESCRIPTION
@lxsdevcode reported the scheduled backup time showing **03:00 (Admin)** vs **04:00 (Tenant)**.

## Cause
Same instant, different timezone frame:
- The scheduler evaluates the cron in **UTC** (`PreviewFires(cron, time.Now().UTC())`), and the admin edits a UTC cron (`0 3 * * *` → 03:00 UTC).
- The tenant rendered `next_firings[0]` (an RFC3339 UTC timestamp) via `shortDateTime` = `dayjs(ts)` → **browser-local** → 04:00 for a UTC+1 viewer.

## Fix
- New `shortDateTimeUTC` (dayjs `utc` plugin) — the tenant's next-run now renders **03:00 UTC**, matching the admin cron regardless of the viewer's timezone.
- The admin cron field gets a note: *"Runs in UTC (server time) … the tenant view shows the same UTC time."*

## Verified
`tsc -b` + production build + vitest (137 existing + 4 new datetime tests) green. New tests assert a `03:00Z` and an `04:00+01:00` instant both render as `03:00 UTC`.

Next: the **Backup Type column** item (tenant column + admin Type accuracy for DB-only/files-only backups) — separate follow-up.