### PR TITLE
feat(backups): accurate backup Type by content, + tenant Type column (GH #454)

### DIFF
--- a/panel-ui/src/shells/admin/backups/BackupLogsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupLogsTab.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
+import { backupTypeColor, backupTypeLabel } from "../../../utils/backupType";
 import {
   Alert,
   DatePicker,
@@ -22,6 +23,7 @@ import { apiClient } from "../../../apiClient";
 interface BackupLogEntry {
   id: string;
   kind: string;
+  content?: string;
   status: string;
   user_id: string;
   destination_id?: string;
@@ -127,15 +129,6 @@ export const BackupLogsTab = () => {
     }
   };
 
-  const renderKindTag = (kind: string) => {
-    const colorMap: Record<string, string> = {
-      account_backup: "blue",
-      account_restore: "green",
-      system_backup: "purple",
-      system_restore: "orange",
-    };
-    return <Tag color={colorMap[kind] || "default"}>{kind.replace("_", " ")}</Tag>;
-  };
 
   const renderStatusTag = (status: string) => {
     const colorMap: Record<string, string> = {
@@ -235,10 +228,15 @@ export const BackupLogsTab = () => {
             ),
           },
           {
-            title: "Kind",
+            // GH #454: show what the backup CAPTURED (kind + content), so a
+            // database-only account backup reads "Database Backup", not the bare
+            // "account backup" kind.
+            title: "Type",
             dataIndex: "kind",
-            width: 140,
-            render: renderKindTag,
+            width: 160,
+            render: (_: unknown, row: BackupLogEntry) => (
+              <Tag color={backupTypeColor(row.kind, row.content)}>{backupTypeLabel(row.kind, row.content)}</Tag>
+            ),
           },
           {
             title: "Status",

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -7,6 +7,7 @@ import { downloadUrl } from "../../utils/download";
 import { Button, Card, Grid, Select, Space, Table, Tag, Typography, message } from "antd";
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
+import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
 import { RowActions } from "../../components/RowActions";
 import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined } from "@icons";
 import { useState } from "react";
@@ -21,6 +22,7 @@ import { RestoreDrawer } from "./RestoreDrawer";
 type MyBackup = {
   id: string;
   status: string;
+  content?: string;
   bytes_total: number;
   bytes_added: number;
   created_at: string;
@@ -164,6 +166,18 @@ export const MyProfileBackupCard = () => {
             title: "Created",
             dataIndex: "created_at",
             render: (t: string) => shortDateTime(t),
+          },
+          {
+            // GH #454: show what each backup captured (full / database / files).
+            // Tenant backups are always account_backup, so the label is
+            // content-driven.
+            title: "Type",
+            dataIndex: "content",
+            render: (_: unknown, row: MyBackup) => (
+              <Tag color={backupTypeColor("account_backup", row.content)}>
+                {backupTypeLabel("account_backup", row.content)}
+              </Tag>
+            ),
           },
           {
             title: "Status",

--- a/panel-ui/src/utils/backupType.test.ts
+++ b/panel-ui/src/utils/backupType.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { backupTypeLabel } from "./backupType";
+
+describe("backupTypeLabel (GH #454)", () => {
+  it("labels a database-only account backup as Database Backup, not Account", () => {
+    expect(backupTypeLabel("account_backup", "database")).toBe("Database Backup");
+  });
+
+  it("labels files/folders content as Files Backup", () => {
+    expect(backupTypeLabel("account_backup", "files")).toBe("Files Backup");
+    expect(backupTypeLabel("account_backup", "folders")).toBe("Files Backup");
+  });
+
+  it("labels full/empty account content as Account Backup", () => {
+    expect(backupTypeLabel("account_backup", "full")).toBe("Account Backup");
+    expect(backupTypeLabel("account_backup", "")).toBe("Account Backup");
+    expect(backupTypeLabel("account_backup", undefined)).toBe("Account Backup");
+    expect(backupTypeLabel("account_backup", null)).toBe("Account Backup");
+  });
+
+  it("labels system backups/restores by kind regardless of content", () => {
+    expect(backupTypeLabel("system_backup", "full")).toBe("Full Server Backup");
+    expect(backupTypeLabel("system_restore", "full")).toBe("Server Restore");
+    expect(backupTypeLabel("account_restore", "database")).toBe("Account Restore");
+  });
+});

--- a/panel-ui/src/utils/backupType.ts
+++ b/panel-ui/src/utils/backupType.ts
@@ -1,0 +1,47 @@
+// backupType — GH #454: describe a backup job by WHAT it captured, not just the
+// operation kind. A backup carries both `kind` (account_backup / system_backup /
+// *_restore) and `content` (full / files / database / folders). The admin list
+// used to show only the kind, so a database-only account backup read as
+// "Account Backup". Combine both into one accurate label.
+
+// backupTypeLabel maps (kind, content) to a human "Type".
+//   system_backup           -> Full Server Backup
+//   account_backup + database -> Database Backup
+//   account_backup + files/folders -> Files Backup
+//   account_backup + full/""  -> Account Backup
+//   *_restore               -> "… Restore"
+export function backupTypeLabel(kind: string, content?: string | null): string {
+  switch (kind) {
+    case "system_backup":
+      return "Full Server Backup";
+    case "system_restore":
+      return "Server Restore";
+    case "account_restore":
+      return "Account Restore";
+  }
+  // account_backup (and any unknown backup kind) — describe by content.
+  switch (content) {
+    case "database":
+      return "Database Backup";
+    case "files":
+    case "folders":
+      return "Files Backup";
+    default: // "full", "", null/undefined
+      return "Account Backup";
+  }
+}
+
+// backupTypeColor picks an AntD Tag color for the label.
+export function backupTypeColor(kind: string, content?: string | null): string {
+  if (kind === "system_backup") return "purple";
+  if (kind === "system_restore" || kind === "account_restore") return "orange";
+  switch (content) {
+    case "database":
+      return "geekblue";
+    case "files":
+    case "folders":
+      return "cyan";
+    default:
+      return "blue";
+  }
+}


### PR DESCRIPTION
@lxsdevcode's two backup-list asks.

## Problem
A backup job carries both `kind` (account/system + backup/restore) **and** `content` (full/files/database/folders). The admin list rendered only `kind`, so a **database-only account backup read "account backup"**. The tenant list had **no type column** at all.

## Fix
- **`backupTypeLabel(kind, content)`** helper → the reporter's labels:
  - `system_backup` → **Full Server Backup**
  - `account_backup` + `database` → **Database Backup**
  - `account_backup` + `files`/`folders` → **Files Backup**
  - `account_backup` + `full`/`""` → **Account Backup**
  - `*_restore` → **… Restore**
  - `backupTypeColor` picks a Tag color per type.
- **Admin `BackupLogsTab`**: the "Type" column now uses the helper (was the bare `kind`) — a DB-only backup shows **Database Backup**.
- **Tenant `MyProfileBackupCard`**: new **Type** column.

Both list endpoints already return `content` (the `BackupJob` model's `json:"content"` tag).

## Verified
`tsc -b` + production build + vitest (137 existing + 4 new `backupType` tests, incl. "database-only account backup ≠ Account"). Happy to browser-check the columns on a box after merge.