### PR TITLE
fix(ui): translate breadcrumb nav labels (raw i18n keys after multi-language) (GH #455)

### DIFF
--- a/panel-ui/src/components/admin/RouteBreadcrumb.tsx
+++ b/panel-ui/src/components/admin/RouteBreadcrumb.tsx
@@ -7,6 +7,7 @@
 // entity page that wants "Users > alice > Edit" supplies that via
 // useSetBreadcrumbs instead.
 import { useLocation } from "react-router";
+import { useTranslation } from "react-i18next";
 
 import type { NavItem } from "../../nav";
 import { AdminBreadcrumb } from "./AdminBreadcrumb";
@@ -73,7 +74,15 @@ export function RouteBreadcrumb({
 }) {
   const override = useBreadcrumbOverride();
   const { pathname } = useLocation();
-  const items = override && override.length > 0 ? override : deriveCrumbs(pathname, nav, homePath, homeLabel);
+  const { t } = useTranslation();
+  // GH #455: nav labels are i18n KEYS (e.g. "nav.admin.users"); the sidebar runs
+  // them through t() but the auto breadcrumb used them verbatim, so after the
+  // multi-language update the trail showed the raw keys. Translate the nav
+  // labels (and homeLabel) before deriving. t() on an already-plain string is a
+  // no-op, so entity overrides and the tests are unaffected.
+  const translatedNav = nav.map((n) => ({ ...n, label: t(n.label) }));
+  const items =
+    override && override.length > 0 ? override : deriveCrumbs(pathname, translatedNav, homePath, t(homeLabel));
   if (items.length === 0) return null;
   return <AdminBreadcrumb items={items} />;
 }

--- a/panel-ui/src/components/admin/RouteBreadcrumbI18n.test.tsx
+++ b/panel-ui/src/components/admin/RouteBreadcrumbI18n.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import { RouteBreadcrumb } from "./RouteBreadcrumb";
+import type { NavItem } from "../../nav";
+
+// GH #455: nav labels are i18n keys ("nav.admin.users"). The auto breadcrumb
+// used them verbatim after the multi-language update, showing raw keys. The
+// component must run them through t(). Test setup loads the real i18n instance,
+// so "nav.admin.users" resolves to "Users".
+const nav: NavItem[] = [{ key: "users", label: "nav.admin.users", icon: null, path: "/jabali-admin/users" }];
+
+describe("RouteBreadcrumb i18n (GH #455)", () => {
+  it("translates nav key labels instead of rendering the raw key", () => {
+    const { queryByText } = render(
+      <MemoryRouter initialEntries={["/jabali-admin/users"]}>
+        <RouteBreadcrumb nav={nav} homePath="/jabali-admin/dashboard" homeLabel="Dashboard" />
+      </MemoryRouter>,
+    );
+    expect(queryByText("nav.admin.users")).toBeNull(); // no raw key on screen
+    expect(queryByText("Users")).not.toBeNull(); // translated label shown
+  });
+});


### PR DESCRIPTION
@lxsdevcode: after the multi-language update, the auto breadcrumbs showed **raw translation keys** (e.g. `nav.admin.users`) instead of the localized labels.

## Cause
`adminNav`/`userNav` labels are i18n **keys**. The sidebar runs them through `t()`, but `RouteBreadcrumb` passed the nav straight to `deriveCrumbs`, so the auto trail rendered the keys verbatim.

## Fix
Translate the nav labels (and `homeLabel`) with `t()` in `RouteBreadcrumb` before deriving. `t()` on an already-plain string is a no-op, so page-set entity overrides and the pure `deriveCrumbs` unit tests are unaffected.

## Verified
New component test (the test harness loads the real i18n instance) asserts `nav.admin.users` renders as **"Users"**, not the raw key — and would fail without the fix. `tsc -b` + production build + vitest green.