### PR TITLE
feat(migrate): wizard checkbox to carry over source passwords (GH #633 + #634)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -123,10 +123,16 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
   const [areas, setAreas] = useState<Record<string, boolean>>({
     websites: true, databases: true, mailboxes: true, dns: true, ssl: true, cron: true,
   });
+  // GH #633/#634: opt-in to carrying source passwords (mailboxes + MySQL users).
+  // Off by default (secure); the import reads plan.preserve.credentials.
+  const [preservePasswords, setPreservePasswords] = useState(false);
   const savePlan = async () => {
     if (!draftId) return;
     try {
-      await apiClient.put(`/admin/migrations/${draftId}/plan`, { areas });
+      await apiClient.put(`/admin/migrations/${draftId}/plan`, {
+        areas,
+        preserve: { credentials: preservePasswords },
+      });
     } catch {
       /* best-effort — import defaults to all areas if the plan didn't save */
     }
@@ -752,6 +758,22 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
               <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                 Website files + databases are always imported (the site needs them). Uncheck any of the rest to skip it.
               </Typography.Text>
+            </Card>
+          )}
+          {sourceKind !== "wordpress_ssh" && sourceKind !== "wordpress_plugin" && (
+            // GH #633 (MySQL user passwords) + #634 (mailbox passwords): make the
+            // credential carry-over reachable from the wizard. Off by default.
+            <Card size="small" title="Passwords" style={{ marginTop: 12 }}>
+              <Checkbox checked={preservePasswords} onChange={(e) => setPreservePasswords(e.target.checked)}>
+                Carry over source passwords (mailboxes + database users)
+              </Checkbox>
+              <Alert
+                type="warning"
+                showIcon
+                style={{ marginTop: 8 }}
+                message="Off by default"
+                description="Leave off unless this is a trusted, same-owner migration. When on, each mailbox and MySQL user keeps its ORIGINAL password (carried as a hash), so mail clients and apps that rely on the DB config keep working without a reset. When off, they get fresh passwords the owner must reset."
+              />
             </Card>
           )}
           <Collapse


### PR DESCRIPTION
Addresses two related reports:
- **#633** — MySQL user passwords don't carry over (apps relying on the DB config fail until the owner resets the password + edits config.php).
- **#634** — the migration UI has no option to preserve mailbox passwords.

## Cause
The credential carry-over already exists — `--preserve-source-state` (CLI) or `plan.preserve.credentials` (import reads it in `restore_dbs` + `restore_mail` to keep the original password hashes). But it was **only reachable from the CLI**, so wizard-created migrations always got fresh passwords.

## Fix
A **"Carry over source passwords (mailboxes + database users)"** checkbox in the wizard's import step:
- **Off by default** (secure — matches the CLI's opt-in posture), with a warning that it's for **trusted, same-owner migrations** only.
- When checked, `savePlan` writes `plan.preserve.credentials=true`.

The import already honors `preserve.credentials`, and `updatePlan` stores the raw plan JSON — so **no API change**. One checkbox unlocks both the DB-user (#633) and mailbox (#634) carry-over.

## Verified
`tsc -b` + production build + vitest green. (hestiacp is multi-account → uses this wizard; the plan-less quick-create drawer stays at the secure no-preserve default.)