### PR TITLE
fix(update): point corrupt-worktree hint at 'repair --all --yes', not --auto (GH #606)

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -425,8 +425,12 @@ chmod 0750 "$WR"`)
 				missingOut2, _ := exec.Command("sudo", "-u", serviceUser,
 					"git", "-C", repoDir, "ls-files", "--deleted").Output()
 				if still := strings.TrimSpace(string(missingOut2)); still != "" {
+					// A corrupt .git worktree POINTER can't be fixed by a forced
+					// checkout (git operates through the broken pointer). The repair
+					// that heals it re-clones the tree, which is DESTRUCTIVE, so
+					// `--auto` skips it — the operator needs `--all --yes` (GH #606).
 					return fmt.Errorf("working tree at %s is still missing tracked files after a forced checkout "+
-						"(corrupt git worktree pointer) — run `jabali repair --auto` to rebuild the checkout, then re-run `jabali update`; missing:\n%s",
+						"(corrupt git worktree pointer) — run `jabali repair --all --yes` to re-clone the checkout (--auto skips this destructive fix), then re-run `jabali update`; missing:\n%s",
 						repoDir, still)
 				}
 			}


### PR DESCRIPTION
Follow-up to #616, surfaced by the #606 reporter.

#616's self-heal, when a forced checkout still can't restore the tree (a corrupt `.git` **worktree pointer**), told the operator to run `jabali repair --auto`. But the repair that heals a corrupt pointer **re-clones** `/opt/jabali-panel` — a **destructive** fix, and `--auto` deliberately **skips destructive fixes** (`repair.go`). So the operator ran `--auto` (and `git checkout --force`), neither of which can rebuild a broken pointer, and stayed stuck (`HEAD is now at f55ff851…` on a loop).

**Fix:** point the hint at **`jabali repair --all --yes`** — the command that actually applies the destructive re-clone — so the update failure names the right recovery step.

`go build` green. (No logic change — just the operator-facing hint.)