### PR TITLE
fix(migrate): carry over HestiaCP mailbox + DB passwords (GH #633, #634)

### DIFF
--- a/panel-agent/internal/commands/db_user_create.go
+++ b/panel-agent/internal/commands/db_user_create.go
@@ -84,8 +84,19 @@ func dbUserCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		// Migration-compat path. Hash format already validated above;
 		// no escaping needed (hex + '*' is shell+SQL-safe and the
 		// MariaDB grammar requires literal single-quotes around it).
+		//
+		// CREATE ... IF NOT EXISTS keeps resume idempotent, but on its own it
+		// LEAVES an existing user's password untouched — and jabali's own dump
+		// loop may have already created a panel-managed user of the SAME name
+		// (whenever the target jabali username matches the source account
+		// prefix, e.g. johnnyq_wp -> johnnyq_wp). Without the ALTER the source
+		// hash then never lands and the migrated app authenticates with a fresh
+		// random password instead of its original one (GH #633). ALTER forces
+		// the hash on whether the user was just created or pre-existed; it is a
+		// harmless re-set in the freshly-created case.
 		sql = fmt.Sprintf(
-			"CREATE USER IF NOT EXISTS %s@'localhost' IDENTIFIED BY PASSWORD '%s'",
+			"CREATE USER IF NOT EXISTS %[1]s@'localhost' IDENTIFIED BY PASSWORD '%[2]s'; "+
+				"ALTER USER %[1]s@'localhost' IDENTIFIED BY PASSWORD '%[2]s'",
 			escapedUsername,
 			p.PasswordHash,
 		)

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -577,6 +577,21 @@ failed stage. Already-done stages are skipped.`,
 								"/home", *user.Username, "domains", name, "public_html")
 						}
 					}
+					// GH #633: HestiaCP keeps each DB user's mysql_native_password
+					// hash in db/<db>/hestia/db.conf (MD5= field). Recreate the
+					// ORIGINAL DB users with those hashes (preserve-gated in
+					// restore_dbs) so migrated apps keep their hardcoded db creds.
+					if creds := hestiacp.ParseDBCredentials(extractDir); len(creds) > 0 {
+						parsed.CompatUsers = make([]cpanel.CompatUser, 0, len(creds))
+						for _, c := range creds {
+							parsed.CompatUsers = append(parsed.CompatUsers, cpanel.CompatUser{
+								Name:  c.User,
+								Host:  "localhost",
+								Hash:  c.Hash,
+								Grant: []cpanel.CompatGrant{{SourceDB: c.DBName, Privs: []string{"ALL"}}},
+							})
+						}
+					}
 				} else if _, statErr := os.Stat(hTarPath); statErr == nil {
 					// GH #327: the tar is PRESENT but unparseable — do NOT
 					// silently fall through to an empty import + mark the job

--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -313,12 +313,22 @@ func ImportDatabases(
 	// Only recreate the original-hash compatibility users when the operator opts
 	// in (preserve.Credentials / --preserve-source-state) — for apps with
 	// hardcoded original creds. Default: quarantine (record, don't create).
+	// Source compat users come from the cpmove `mysql.sql` grants
+	// (cPanel/WHM/CloudPanel/Plesk) OR, when a source adapter pre-populated
+	// them, parsed.CompatUsers — HestiaCP keeps the native password hash in the
+	// backup's per-DB db.conf MD5= field, not a mysql.sql (GH #633).
 	grantsPath := filepath.Join(parsed.ExtractDir, "cpmove-"+parsed.SourceUser, "mysql.sql")
-	if compatUsers, gerr := ParseMySQLGrants(grantsPath); gerr == nil && len(compatUsers) > 0 && !preserveCredentials {
+	compatUsers := parsed.CompatUsers
+	if len(compatUsers) == 0 {
+		if cu, gerr := ParseMySQLGrants(grantsPath); gerr == nil {
+			compatUsers = cu
+		}
+	}
+	if len(compatUsers) > 0 && !preserveCredentials {
 		res.Skipped = append(res.Skipped, fmt.Sprintf(
 			"compat_users: %d source MySQL user(s) with original password hashes NOT recreated (opt in with --preserve-source-state; apps using the panel-managed user are unaffected)",
 			len(compatUsers)))
-	} else if compatUsers, gerr := ParseMySQLGrants(grantsPath); gerr == nil && len(compatUsers) > 0 {
+	} else if len(compatUsers) > 0 {
 		compatCreated := 0
 		for _, u := range compatUsers {
 			if !IsNativePasswordHash(u.Hash) {

--- a/panel-api/internal/migrate/cpanel/restore_dbs_compatusers_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs_compatusers_test.go
@@ -1,0 +1,51 @@
+package cpanel
+
+import (
+	"context"
+	"testing"
+)
+
+// GH #633: sources without a cpmove `mysql.sql` (HestiaCP) pre-populate
+// parsed.CompatUsers from their own backup metadata. ImportDatabases must
+// honour that slice exactly like the cpmove-parsed grants — recreated only
+// when the operator opts into credential preservation.
+func TestImportDatabases_UsesParsedCompatUsers(t *testing.T) {
+	compat := []CompatUser{{
+		Name: "alice_wp",
+		Host: "localhost",
+		Hash: "*0123456789ABCDEF0123456789ABCDEF01234567",
+		Grant: []CompatGrant{{
+			SourceDB: "alice_wp",
+			Privs:    []string{"ALL"},
+		}},
+	}}
+
+	for _, tc := range []struct {
+		name       string
+		preserve   bool
+		wantCreate bool
+	}{
+		{"default: parsed compat user not recreated", false, false},
+		{"opt-in: parsed compat user recreated", true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := &recordingAgent{}
+			// No cpmove mysql.sql on disk — the ONLY source of compat users is
+			// parsed.CompatUsers (the Hestia adapter path).
+			parsed := &ParsedTarball{ExtractDir: t.TempDir(), SourceUser: "alice", CompatUsers: compat}
+			if _, err := ImportDatabases(context.Background(), &nopDBRepo{}, nil, nil, ag,
+				parsed, "01USERULID0000000000000000", "alice", tc.preserve); err != nil {
+				t.Fatalf("ImportDatabases: %v", err)
+			}
+			created := false
+			for _, n := range ag.dbUserCreates {
+				if n == "alice_wp" {
+					created = true
+				}
+			}
+			if created != tc.wantCreate {
+				t.Fatalf("compat user alice_wp created=%v, want %v (calls=%v)", created, tc.wantCreate, ag.dbUserCreates)
+			}
+		})
+	}
+}

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -324,17 +324,39 @@ func insertOneMailboxRow(
 	if exErr != nil {
 		return []string{fmt.Sprintf("mailbox_rows: exists check %s@%s: %v", localPart, domainName, exErr)}
 	}
-	if exists {
-		return []string{fmt.Sprintf("mailbox_rows: %s@%s already exists", localPart, domainName)}
-	}
 	// JAB-88: preserve the source mailbox password when the operator opted in
 	// (--preserve-source-state) AND the source carries a Stalwart-verifiable
 	// bcrypt hash (Hestia stores {BLF-CRYPT}$2y$… — Stalwart's SQL directory
 	// authenticates $2a/$2b/$2y bcrypt, live-verified). Otherwise set a fresh
 	// random password and warn LOUDLY: the tenant is locked out until reset, and
 	// silent lockout was the reported bug.
-	passwordHash := srcHash
 	preserved := preserveCreds && srcHash != ""
+	if exists {
+		// GH #634: an earlier migration — or a run before the operator ticked
+		// "carry over source passwords" — already created this mailbox with a
+		// FRESH random password. Skipping here meant re-running the migration with
+		// --preserve-source-state was a no-op: the tenant stayed locked out of
+		// their ORIGINAL password (johnnyq's report). When preserve is now on and
+		// the source carries a verifiable hash, retrofit it onto the existing row
+		// instead of skipping.
+		if !preserved {
+			return []string{fmt.Sprintf("mailbox_rows: %s@%s already exists", localPart, domainName)}
+		}
+		cur, fErr := mbRepo.FindByEmail(ctx, localPart+"@"+domainName)
+		if fErr != nil || cur == nil {
+			return []string{fmt.Sprintf("mailbox_rows: %s@%s exists but password retrofit lookup failed: %v", localPart, domainName, fErr)}
+		}
+		if cur.PasswordHash == srcHash {
+			return []string{fmt.Sprintf("mailbox_rows: %s@%s already exists with the SOURCE password", localPart, domainName)}
+		}
+		if uErr := mbRepo.UpdatePasswordHash(ctx, cur.ID, srcHash); uErr != nil {
+			return []string{fmt.Sprintf("mailbox_rows: %s@%s exists; SOURCE-password retrofit failed: %v", localPart, domainName, uErr)}
+		}
+		return []string{fmt.Sprintf(
+			"mailbox_rows: %s@%s already existed — SOURCE password RE-APPLIED (--preserve-source-state); the tenant's original mail password now works",
+			localPart, domainName)}
+	}
+	passwordHash := srcHash
 	if !preserved {
 		tempPwd := ids.NewULID()
 		hash, hErr := bcrypt.GenerateFromPassword([]byte(tempPwd), bcrypt.DefaultCost)

--- a/panel-api/internal/migrate/cpanel/restore_mail_preserve_retrofit_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_preserve_retrofit_test.go
@@ -1,0 +1,119 @@
+package cpanel
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeExistingMailboxRepo simulates a mailbox row a PRIOR migration already
+// created with a FRESH (non-source) password. GH #634: re-running the
+// migration with "carry over source passwords" checked must UPDATE that row to
+// the source hash — the old exists-guard skipped it, so the source password was
+// never applied and the tenant stayed locked out of their original password.
+type fakeExistingMailboxRepo struct {
+	repository.MailboxRepository
+	mb          *models.Mailbox
+	updatedTo   string
+	updateCalls int
+	createCalls int
+}
+
+func (f *fakeExistingMailboxRepo) ExistsByDomainAndLocalPart(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+func (f *fakeExistingMailboxRepo) FindByEmail(_ context.Context, _ string) (*models.Mailbox, error) {
+	return f.mb, nil
+}
+func (f *fakeExistingMailboxRepo) UpdatePasswordHash(_ context.Context, id, hash string) error {
+	f.updateCalls++
+	f.updatedTo = hash
+	if f.mb != nil && f.mb.ID == id {
+		f.mb.PasswordHash = hash
+	}
+	return nil
+}
+func (f *fakeExistingMailboxRepo) Create(_ context.Context, _ *models.Mailbox) error {
+	f.createCalls++
+	return nil
+}
+
+const freshFirstMigrationHash = "$2a$10$freshtemppasswordfromfirstmigrationaaaaaaaaaaaaaaaaaa"
+
+// GH #634 reproduction (johnnyq): first migration created the row with a fresh
+// password; the second run with --preserve-source-state must retrofit the
+// source hash onto the existing row instead of skipping it.
+func TestImportMailboxes_RetrofitsExistingRowOnPreserve(t *testing.T) {
+	parsed := buildHestiaMailTree(t, "itflow.app", "info", "info:{BLF-CRYPT}"+testSrcBcrypt)
+	mb := &fakeExistingMailboxRepo{mb: &models.Mailbox{
+		ID:           "01MAILBOXID000000000000000",
+		LocalPart:    "info",
+		PasswordHash: freshFirstMigrationHash,
+	}}
+	dom := &fakeDomainRepoMB{id: "01DOMAINID0000000000000000"}
+
+	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, true /*preserveCreds*/, "")
+	if err != nil {
+		t.Fatalf("ImportMailboxes: %v", err)
+	}
+	if mb.createCalls != 0 {
+		t.Errorf("existing row must not be re-created; Create called %d time(s)", mb.createCalls)
+	}
+	if mb.updateCalls != 1 {
+		t.Fatalf("want exactly 1 UpdatePasswordHash call, got %d", mb.updateCalls)
+	}
+	if mb.updatedTo != testSrcBcrypt {
+		t.Errorf("retrofit hash = %q, want tag-stripped source %q", mb.updatedTo, testSrcBcrypt)
+	}
+	if !containsSubstr(res.Skipped, "SOURCE password RE-APPLIED") {
+		t.Errorf("expected a 'SOURCE password RE-APPLIED' notice, got %v", res.Skipped)
+	}
+}
+
+// Idempotency: a second preserve run over a row that ALREADY has the source
+// hash must not churn the password (no redundant update).
+func TestImportMailboxes_ExistingRowAlreadySourceNoChurn(t *testing.T) {
+	parsed := buildHestiaMailTree(t, "itflow.app", "info", "info:{BLF-CRYPT}"+testSrcBcrypt)
+	mb := &fakeExistingMailboxRepo{mb: &models.Mailbox{
+		ID:           "01MAILBOXID000000000000000",
+		LocalPart:    "info",
+		PasswordHash: testSrcBcrypt, // already retrofitted on a prior run
+	}}
+	dom := &fakeDomainRepoMB{id: "01DOMAINID0000000000000000"}
+
+	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, true /*preserveCreds*/, "")
+	if err != nil {
+		t.Fatalf("ImportMailboxes: %v", err)
+	}
+	if mb.updateCalls != 0 {
+		t.Errorf("row already carries the source hash; want 0 updates, got %d", mb.updateCalls)
+	}
+	if !containsSubstr(res.Skipped, "already exists with the SOURCE password") {
+		t.Errorf("expected the 'already exists with the SOURCE password' notice, got %v", res.Skipped)
+	}
+}
+
+// Without preserve, an existing row is left untouched — no password churn on a
+// plain re-run.
+func TestImportMailboxes_ExistingRowUntouchedWithoutPreserve(t *testing.T) {
+	parsed := buildHestiaMailTree(t, "itflow.app", "info", "info:{BLF-CRYPT}"+testSrcBcrypt)
+	mb := &fakeExistingMailboxRepo{mb: &models.Mailbox{
+		ID:           "01MAILBOXID000000000000000",
+		LocalPart:    "info",
+		PasswordHash: freshFirstMigrationHash,
+	}}
+	dom := &fakeDomainRepoMB{id: "01DOMAINID0000000000000000"}
+
+	res, err := ImportMailboxes(context.Background(), parsed, stubMailAgent{}, "job1", mb, dom, false /*preserveCreds*/, "")
+	if err != nil {
+		t.Fatalf("ImportMailboxes: %v", err)
+	}
+	if mb.updateCalls != 0 {
+		t.Errorf("no-preserve must not touch an existing password; got %d update(s)", mb.updateCalls)
+	}
+	if !containsSubstr(res.Skipped, "already exists") {
+		t.Errorf("expected an 'already exists' skip, got %v", res.Skipped)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/tarball.go
+++ b/panel-api/internal/migrate/cpanel/tarball.go
@@ -68,6 +68,13 @@ type ParsedTarball struct {
 	// not in scope here, etc.). Used to populate the manifest's
 	// Warnings slice.
 	Skipped []string
+	// CompatUsers, when set by a source adapter, are the ORIGINAL source
+	// MySQL users to recreate with their native password hash (preserve-gated
+	// in ImportDatabases). cPanel/WHM/CloudPanel/Plesk read these from the
+	// cpmove `mysql.sql` grants inline; HestiaCP has no mysql.sql, so its
+	// adapter pre-populates this from the backup's per-DB db.conf MD5= hashes
+	// (GH #633).
+	CompatUsers []CompatUser
 }
 
 // Limits parser behaviour. Tarballs from a malicious source could

--- a/panel-api/internal/migrate/hestiacp/db_credentials.go
+++ b/panel-api/internal/migrate/hestiacp/db_credentials.go
@@ -1,0 +1,111 @@
+package hestiacp
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// DBCredential is one source MySQL user recovered from a HestiaCP backup's
+// per-database db.conf. HestiaCP stores the account's mysql_native_password
+// hash in the (VestaCP-legacy-named) MD5= field — captured at DB-create time
+// via `SHOW CREATE USER` / `SHOW GRANTS` (func/db.sh), NOT an md5 of the
+// plaintext. Recreating the user on the destination with this hash lets a
+// migrated app keep working with its hardcoded db creds (config.php /
+// wp-config.php) — the GH #633 fix (offline Hestia DB-password carry-over).
+type DBCredential struct {
+	DBName string // Hestia DB name, e.g. "olduser_wp" — also the grant target + dump base name
+	User   string // Hestia DB user, e.g. "olduser_wp"
+	Hash   string // normalised '*'+40-hex mysql_native_password hash
+}
+
+// key='value' extractor for a db.conf line
+// (DB='olduser_wp' DBUSER='olduser_wp' MD5='*ABC…' HOST='localhost' TYPE='mysql' …).
+var hestiaDBConfKVRe = regexp.MustCompile(`([A-Z0-9_]+)='([^']*)'`)
+
+// old-style mysql_native_password hash: '*' + 40 hex.
+var hestiaNativeHashRe = regexp.MustCompile(`^\*[0-9A-Fa-f]{40}$`)
+
+// ParseDBCredentials walks the extracted Hestia backup for every
+// db/<db>/hestia/db.conf (plus an aggregated hestia/db.conf when present) and
+// returns the source MySQL users that carry a USABLE native password hash.
+// Non-mysql engines (pgsql), missing/empty hashes, and hash formats jabali
+// can't recreate (ed25519, auth sockets, …) are dropped — the caller falls
+// back to a fresh password for those. Best-effort: a malformed file is
+// skipped, never fatal.
+func ParseDBCredentials(extractDir string) []DBCredential {
+	matches, _ := filepath.Glob(filepath.Join(extractDir, "db", "*", "hestia", "db.conf"))
+	// Some layouts also drop the whole-user db.conf at the top-level hestia/
+	// dir — parse it too (deduped by DB|user below).
+	if agg := filepath.Join(extractDir, "hestia", "db.conf"); fileExists(agg) {
+		matches = append(matches, agg)
+	}
+
+	seen := map[string]bool{}
+	var out []DBCredential
+	for _, path := range matches {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			kv := map[string]string{}
+			for _, m := range hestiaDBConfKVRe.FindAllStringSubmatch(line, -1) {
+				kv[m[1]] = m[2]
+			}
+			if !strings.EqualFold(kv["TYPE"], "mysql") {
+				continue // jabali's native-hash recreate path is mysql only
+			}
+			db, user := kv["DB"], kv["DBUSER"]
+			hash := normalizeHestiaDBHash(kv["MD5"])
+			if db == "" || user == "" || hash == "" {
+				continue
+			}
+			key := db + "|" + user
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, DBCredential{DBName: db, User: user, Hash: hash})
+		}
+	}
+	return out
+}
+
+// normalizeHestiaDBHash converts HestiaCP's MD5= field to the canonical
+// '*'+40-hex mysql_native_password form jabali's db_user.create accepts, or ""
+// when the value isn't a recreatable native hash.
+//
+// Two on-disk forms (func/db.sh):
+//   - "*ABCD…" (41 chars)  — MySQL / MariaDB `SHOW GRANTS` form; used verbatim.
+//   - "0x2A41…"            — MariaDB `print_identified_with_as_hex=ON` form: the
+//     hex encoding of the *XXXX string (0x2A = '*'), so hex-decoding yields the
+//     same "*ABCD…" value.
+func normalizeHestiaDBHash(raw string) string {
+	h := strings.TrimSpace(raw)
+	if h == "" {
+		return ""
+	}
+	if strings.HasPrefix(h, "0x") || strings.HasPrefix(h, "0X") {
+		decoded, err := hex.DecodeString(h[2:])
+		if err != nil {
+			return ""
+		}
+		h = string(decoded)
+	}
+	if hestiaNativeHashRe.MatchString(h) {
+		return h
+	}
+	return ""
+}
+
+func fileExists(p string) bool {
+	st, err := os.Stat(p)
+	return err == nil && !st.IsDir()
+}

--- a/panel-api/internal/migrate/hestiacp/db_credentials_test.go
+++ b/panel-api/internal/migrate/hestiacp/db_credentials_test.go
@@ -1,0 +1,94 @@
+package hestiacp
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeHestiaDBConf(t *testing.T, extract, db, line string) {
+	t.Helper()
+	dir := filepath.Join(extract, "db", db, "hestia")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "db.conf"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// GH #633: the DB user's native password hash lives in db/<db>/hestia/db.conf's
+// MD5= field. Both on-disk forms (`*XXXX` and MariaDB's `0x2A…` hex) must be
+// recovered; pgsql + empty/unusable hashes must be dropped.
+func TestParseDBCredentials(t *testing.T) {
+	extract := t.TempDir()
+
+	const starHash = "*0123456789ABCDEF0123456789ABCDEF01234567"
+	// MariaDB print_identified_with_as_hex=ON form: hex of the *XXXX string.
+	const hexSource = "*ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+	hexForm := "0x" + hex.EncodeToString([]byte(hexSource))
+
+	writeHestiaDBConf(t, extract, "alice_wp",
+		"DB='alice_wp' DBUSER='alice_wp' MD5='"+starHash+"' HOST='localhost' TYPE='mysql' CHARSET='utf8'")
+	writeHestiaDBConf(t, extract, "alice_shop",
+		"DB='alice_shop' DBUSER='alice_shop' MD5='"+hexForm+"' HOST='localhost' TYPE='mysql'")
+	writeHestiaDBConf(t, extract, "alice_pg",
+		"DB='alice_pg' DBUSER='alice_pg' MD5='"+starHash+"' HOST='localhost' TYPE='pgsql'")
+	writeHestiaDBConf(t, extract, "alice_nopw",
+		"DB='alice_nopw' DBUSER='alice_nopw' MD5='' HOST='localhost' TYPE='mysql'")
+	writeHestiaDBConf(t, extract, "alice_bad",
+		"DB='alice_bad' DBUSER='alice_bad' MD5='not-a-hash' HOST='localhost' TYPE='mysql'")
+
+	creds := ParseDBCredentials(extract)
+	byDB := map[string]DBCredential{}
+	for _, c := range creds {
+		byDB[c.DBName] = c
+	}
+
+	if len(creds) != 2 {
+		t.Fatalf("want 2 usable creds, got %d: %+v", len(creds), creds)
+	}
+	if got := byDB["alice_wp"].Hash; got != starHash {
+		t.Errorf("star-form hash = %q, want %q", got, starHash)
+	}
+	if byDB["alice_wp"].User != "alice_wp" {
+		t.Errorf("user = %q", byDB["alice_wp"].User)
+	}
+	if got := byDB["alice_shop"].Hash; got != hexSource {
+		t.Errorf("0x-hex hash decode = %q, want %q", got, hexSource)
+	}
+	if _, ok := byDB["alice_pg"]; ok {
+		t.Error("pgsql database must be skipped (mysql-only native-hash path)")
+	}
+	if _, ok := byDB["alice_nopw"]; ok {
+		t.Error("empty MD5 must be skipped")
+	}
+	if _, ok := byDB["alice_bad"]; ok {
+		t.Error("unparseable hash must be skipped")
+	}
+}
+
+// Missing db/ tree → empty, never a panic.
+func TestParseDBCredentials_NoDBDir(t *testing.T) {
+	if got := ParseDBCredentials(t.TempDir()); len(got) != 0 {
+		t.Errorf("want empty, got %+v", got)
+	}
+}
+
+func TestNormalizeHestiaDBHash(t *testing.T) {
+	star := "*0123456789ABCDEF0123456789ABCDEF01234567"
+	cases := map[string]string{
+		star:                                    star,
+		"0x" + hex.EncodeToString([]byte(star)): star,
+		"":                                      "",
+		"plaintextpw":                           "",
+		"0xZZ":                                  "", // invalid hex
+		"*short":                                "",
+	}
+	for in, want := range cases {
+		if got := normalizeHestiaDBHash(in); got != want {
+			t.Errorf("normalizeHestiaDBHash(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

@johnnyq reported that HestiaCP migrations don't carry over passwords — mailboxes (#634) and MySQL users (#633) come out with fresh passwords, breaking mail clients and any app with hardcoded DB creds (config.php / wp-config).

## Root causes (both reproduced on testserver)

**#634 — mail:** the mechanism works on a *fresh* import with preserve, but `insertOneMailboxRow` **skipped existing rows**, so re-running with `--preserve-source-state` never retrofitted the source password onto a mailbox an earlier run had created with a fresh one.

**#633 — DB:** I was initially wrong that the hash isn't in the backup. It **is** — each `db/<db>/hestia/db.conf` carries `MD5='<hash>'`, a VestaCP-legacy-named field that actually holds the `mysql_native_password` hash (captured via `SHOW CREATE USER` / `SHOW GRANTS`). The offline Hestia path just never read it. Two sub-bugs:
1. no reader for it (cPanel reads the cpmove `mysql.sql`; Hestia has none);
2. even once created, `db_user.create` used `CREATE USER IF NOT EXISTS … IDENTIFIED BY PASSWORD`, which **leaves an existing user untouched** — so when the target jabali username equals the source account prefix (`johnnyq_wp` → `johnnyq_wp`), the dump loop's panel-managed user shadowed the compat user and the source hash never landed.

## Fix

- `hestiacp.ParseDBCredentials` — read `DBUSER`+`MD5` from `db.conf`, decode MariaDB's `0x…` hex form, validate the `*`+40-hex native hash.
- `ParsedTarball.CompatUsers` — adapters can pre-populate the compat-user list; `restore_dbs` uses it when there's no cpmove `mysql.sql`. Same `preserve.Credentials` gate + `db_user.create` writer as cPanel.
- agent `db_user.create` — follow the `CREATE … IF NOT EXISTS` with `ALTER USER … IDENTIFIED BY PASSWORD` so the hash lands whether the user was just created or pre-existed (also fixes cPanel keep-username migrations).
- `insertOneMailboxRow` — retrofit the source bcrypt onto an existing mailbox row when preserve is on, instead of skipping.

## Verification

Box-verified on testserver with synthesized Hestia backups:
- **DB, preserve ON:** migrated user keeps the exact source hash, and `mysql -u <user> -p'<original>'` → `LOGIN_OK`.
- **DB, preserve OFF (control):** source hash correctly **not** applied.
- **Mail:** fresh+preserve carries the source bcrypt byte-for-byte; retrofit unit-tested.

New unit tests: Hestia `db.conf` parser (both hash forms, pgsql/empty/invalid skip), `parsed.CompatUsers` consumer (preserve gate), mailbox retrofit (retrofit / no-churn / untouched-without-preserve).

Refs #633, #634 — do NOT auto-close (maintainer closes issues manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
