### PR TITLE
fix(ui): cap update-commit list + group RTL languages last (JAB-172, JAB-173)

### DIFF
--- a/panel-ui/src/components/JabaliHeader.tsx
+++ b/panel-ui/src/components/JabaliHeader.tsx
@@ -38,7 +38,7 @@ import { useTranslation } from "react-i18next";
 
 import { apiClient } from "../apiClient";
 import { useAuth } from "../auth/AuthContext";
-import { LANGUAGE_LABELS, SUPPORTED, setLanguage } from "../i18n";
+import { DISPLAY_ORDER, LANGUAGE_LABELS, setLanguage } from "../i18n";
 import { adminNav, userNav } from "../nav";
 import { JabaliTitle } from "./JabaliTitle";
 import { InstallAppButton } from "./InstallAppButton";
@@ -290,7 +290,7 @@ export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHead
       // someone who cannot read the language the panel is currently in. The
       // checkmark marks the active one; the others get an equal-width spacer
       // so the labels stay on a single left edge.
-      children: SUPPORTED.map((lng) => ({
+      children: DISPLAY_ORDER.map((lng) => ({
         key: `lang:${lng}`,
         label: LANGUAGE_LABELS[lng],
         icon:

--- a/panel-ui/src/i18n.ts
+++ b/panel-ui/src/i18n.ts
@@ -100,6 +100,20 @@ export const LANGUAGE_LABELS: Record<SupportedLng, string> = {
 /** Right-to-left scripts. Drives AntD's `direction` + the <html dir> attribute. */
 const RTL = new Set<string>(["he", "ar", "fa", "ur"]);
 
+// DISPLAY_ORDER (JAB-173) is the language-switcher render order: English
+// first (the source language), then the LTR locales in SUPPORTED order, then
+// the RTL locales (he/ar/…) grouped at the end. Derived from SUPPORTED + RTL
+// so adding a locale needs no second edit and a future RTL locale lands in the
+// trailing group automatically. SUPPORTED itself must NOT be reordered for a
+// menu concern — it backs normalise()/ANTD_LOCALES/DAYJS_LOCALES/supportedLngs.
+export const DISPLAY_ORDER: SupportedLng[] = [...SUPPORTED].sort((a, b) => {
+  if (a === DEFAULT_LNG) return -1;
+  if (b === DEFAULT_LNG) return 1;
+  const ar = RTL.has(a) ? 1 : 0;
+  const br = RTL.has(b) ? 1 : 0;
+  return ar - br; // LTR (0) before RTL (1); stable sort keeps SUPPORTED order within a group
+});
+
 const ANTD_LOCALES: Record<SupportedLng, AntdLocale> = {
   en: enUS,
   he: heIL,

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -501,24 +501,7 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
                     key: "included",
                     label: `Included in this update (${behind})`,
                     children: (
-                      <>
-                        <ul style={{ margin: 0, paddingLeft: 18 }}>
-                          {pending.map((c) => (
-                            <li key={c.sha} style={{ marginBottom: 4 }}>
-                              <Text>{c.subject}</Text>{" "}
-                              <Text type="secondary" code style={{ fontSize: 11 }}>{c.sha}</Text>{" "}
-                              <Text type="secondary" style={{ fontSize: 11 }}>
-                                {c.date ? dayjs(c.date).format("MMM D") : ""}
-                              </Text>
-                            </li>
-                          ))}
-                        </ul>
-                        {behind > pending.length ? (
-                          <Text type="secondary" style={{ fontSize: 11 }}>
-                            + {behind - pending.length} more…
-                          </Text>
-                        ) : null}
-                      </>
+                      <CommitList commits={pending} truncatedMore={behind - pending.length} />
                     ),
                   },
                 ]
@@ -528,19 +511,7 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
                   {
                     key: "recent",
                     label: "Recent changes",
-                    children: (
-                      <ul style={{ margin: 0, paddingLeft: 18 }}>
-                        {commits.map((c) => (
-                          <li key={c.sha} style={{ marginBottom: 4 }}>
-                            <Text>{c.subject}</Text>{" "}
-                            <Text type="secondary" code style={{ fontSize: 11 }}>{c.sha}</Text>{" "}
-                            <Text type="secondary" style={{ fontSize: 11 }}>
-                              {c.date ? dayjs(c.date).format("MMM D") : ""}
-                            </Text>
-                          </li>
-                        ))}
-                      </ul>
-                    ),
+                    children: <CommitList commits={commits} />,
                   },
                 ]
               : []),
@@ -548,6 +519,57 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
         />
       ) : null}
     </Card>
+  );
+}
+
+// CommitList (JAB-172) renders a pending/recent commit list capped at `cap`
+// with an in-place Show more/less toggle, so a host that has drifted weeks
+// behind does not bury the rest of the Updates page under a wall of commits.
+// `truncatedMore` is the SEPARATE server-side truncation count (commits beyond
+// pendingCommits() git log -50 cap); it renders only once the full available
+// list is shown, so the two never double-count.
+function CommitList({
+  commits,
+  cap = 5,
+  truncatedMore = 0,
+}: {
+  commits: { sha: string; subject: string; date?: string | null }[];
+  cap?: number;
+  truncatedMore?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? commits : commits.slice(0, cap);
+  return (
+    <>
+      <ul style={{ margin: 0, paddingLeft: 18 }}>
+        {shown.map((c) => (
+          <li key={c.sha} style={{ marginBottom: 4 }}>
+            <Text>{c.subject}</Text>{" "}
+            <Text type="secondary" code style={{ fontSize: 11 }}>
+              {c.sha}
+            </Text>{" "}
+            <Text type="secondary" style={{ fontSize: 11 }}>
+              {c.date ? dayjs(c.date).format("MMM D") : ""}
+            </Text>
+          </li>
+        ))}
+      </ul>
+      {commits.length > cap ? (
+        <Button
+          type="link"
+          size="small"
+          style={{ padding: 0, height: "auto", fontSize: 11 }}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? "Show less" : `Show more (${commits.length - cap})…`}
+        </Button>
+      ) : null}
+      {truncatedMore > 0 && (expanded || commits.length <= cap) ? (
+        <Text type="secondary" style={{ fontSize: 11, display: "block" }}>
+          + {truncatedMore} more…
+        </Text>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
Two small, self-contained UI fixes from the QA board.

## JAB-172 — cap "Included in this update" at 5 with show-more
On a host drifted weeks behind, the update panel rendered every pending commit (up to the server's `git log -50`), pushing Repair Center / Automatic Updates / history far below the fold.

- New `CommitList` shows the first **5**, with an in-place **Show more (N)… / Show less** toggle (no reload/refetch).
- ≤5 commits → no toggle.
- Section label still shows the true total (`Included in this update (22)`).
- The separate `+N more…` note (commits the *server* truncated past its 50 cap) now renders only once the full list is expanded, so it never double-counts with the UI cap.
- Same treatment applied to the sibling **Recent changes** list.

## JAB-173 — group RTL languages at the end of the switcher
The language menu rendered `SUPPORTED` verbatim (insertion order), so Hebrew sat second under English while Arabic sat last.

- Added a derived `DISPLAY_ORDER` in `i18n.ts`: English first, then LTR locales in `SUPPORTED` order, then RTL locales grouped last — keyed on the existing `RTL` set. Result: `en, de, es, fr, it, ja, uk, zh_Hans, pt_BR, ru, tr, he, ar`.
- `SUPPORTED` is **not** reordered — it backs `normalise()` / `ANTD_LOCALES` / `DAYJS_LOCALES` / `supportedLngs`. A future RTL locale lands in the trailing group with no second edit.
- The switcher (`JabaliHeader.tsx`) now maps `DISPLAY_ORDER`; the active-language checkmark follows wherever the locale lands.

## Verification
`npx tsc -b`, `eslint`, and `npm run build` all clean. DISPLAY_ORDER order verified against the real `SUPPORTED` array (English first; he+ar last and adjacent).

Refs JAB-172, JAB-173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)