### PR TITLE
feat(docker-apps): logrotate for persistent app log volumes (JAB-121 phase 1)

### DIFF
--- a/install/docker-apps/erpnext/app.yaml
+++ b/install/docker-apps/erpnext/app.yaml
@@ -36,6 +36,10 @@ volumes:
     container_path: /home/frappe/frappe-bench/sites
   - name: logs
     container_path: /home/frappe/frappe-bench/logs
+    rotate:
+      retention_days: 14
+      max_size: 50M
+      mode: copytruncate
   - name: db-data
     container_path: /var/lib/mysql
   - name: redis-queue-data

--- a/install/docker-apps/flarum/app.yaml
+++ b/install/docker-apps/flarum/app.yaml
@@ -26,6 +26,10 @@ volumes:
     container_path: /flarum/app/extensions
   - name: storagelogs
     container_path: /flarum/app/storage/logs
+    rotate:
+      retention_days: 14
+      max_size: 50M
+      mode: copytruncate
   - name: db
     container_path: /var/lib/mysql
 

--- a/install/docker-apps/onlyoffice/app.yaml
+++ b/install/docker-apps/onlyoffice/app.yaml
@@ -32,6 +32,10 @@ volumes:
     container_path: /var/lib/postgresql
   - name: logs
     container_path: /var/log/onlyoffice
+    rotate:
+      retention_days: 14
+      max_size: 50M
+      mode: copytruncate
 
 ports:
   - name: http

--- a/install/docker-apps/plausible/app.yaml
+++ b/install/docker-apps/plausible/app.yaml
@@ -27,6 +27,10 @@ volumes:
     container_path: /var/lib/clickhouse
   - name: clickhouse-logs
     container_path: /var/log/clickhouse-server
+    rotate:
+      retention_days: 14
+      max_size: 50M
+      mode: copytruncate
 
 ports:
   - name: http

--- a/panel-agent/internal/commands/docker_app.go
+++ b/panel-agent/internal/commands/docker_app.go
@@ -73,7 +73,19 @@ type dockerAppInstallParams struct {
 	TenantValidate bool     `json:"tenant_validate,omitempty"`
 	TenantCaps     []string `json:"tenant_caps,omitempty"`
 	// TenantCgroup is the exact owner slice the compose must declare (Gitea #525).
-	TenantCgroup   string   `json:"tenant_cgroup,omitempty"`
+	TenantCgroup string `json:"tenant_cgroup,omitempty"`
+	// LogRotate (JAB-121) lists persistent log volumes to cover with a host
+	// logrotate snippet at install so their file logs — which bypass Docker's
+	// journald driver — stay bounded on tenant disk. Empty = no snippet.
+	LogRotate []dockerAppLogRotate `json:"log_rotate,omitempty"`
+}
+
+// dockerAppLogRotate is one persistent log volume's retention policy (JAB-121).
+type dockerAppLogRotate struct {
+	Volume        string `json:"volume"`
+	RetentionDays int    `json:"retention_days,omitempty"`
+	MaxSize       string `json:"max_size,omitempty"`
+	Mode          string `json:"mode,omitempty"`
 }
 
 type dockerAppInstallResponse struct {
@@ -122,6 +134,15 @@ func dockerAppInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 		if err := os.MkdirAll(vd, 0o750); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir %s: %v", vd, err)}
 		}
+	}
+
+	// JAB-121: install a host logrotate snippet for declared persistent log
+	// volumes so their file logs (which bypass Docker's journald driver) stay
+	// bounded on tenant disk. Best-effort: a logrotate write failure must NOT
+	// fail the install — the app still works, the logs just are not rotated yet
+	// (a re-install/update re-asserts the snippet).
+	if err := writeDockerAppLogrotate(p.Slug, dir, p.LogRotate); err != nil {
+		fmt.Fprintf(os.Stderr, "docker_app.install: logrotate snippet for %s: %v\n", p.Slug, err)
 	}
 
 	// Chown the data root + each volume subdir so the container can write its
@@ -236,7 +257,7 @@ type dockerAppLifecycleParams struct {
 	TenantValidate bool     `json:"tenant_validate,omitempty"`
 	TenantCaps     []string `json:"tenant_caps,omitempty"`
 	// TenantCgroup is the exact owner slice the compose must declare (Gitea #525).
-	TenantCgroup   string   `json:"tenant_cgroup,omitempty"`
+	TenantCgroup string `json:"tenant_cgroup,omitempty"`
 }
 
 type dockerAppLifecycleResponse struct {
@@ -304,6 +325,8 @@ func dockerAppDeleteHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil, err
 	}
 	dir := filepath.Join(dockerAppDataRoot, p.Slug)
+	// JAB-121: drop this app's host logrotate snippet (best-effort).
+	removeDockerAppLogrotate(p.Slug)
 	// docker compose down. -v removes named volumes too; we use bind
 	// mounts under DataRoot so this is mostly defensive. A `down` failure
 	// is remembered, NOT returned early: a failed/half-broken install still

--- a/panel-agent/internal/commands/docker_app_logrotate.go
+++ b/panel-agent/internal/commands/docker_app_logrotate.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// docker_app_logrotate.go — host logrotate snippets for docker-app persistent
+// log volumes (JAB-121).
+//
+// Several catalog apps bind an internal log directory into the app's DataRoot
+// (flarum storage/logs, erpnext frappe-bench/logs, onlyoffice, plausible
+// clickhouse-server, …). Those file logs bypass Docker's journald log driver
+// AND the static jabali logrotate drop-in (install/logrotate/jabali), so a busy
+// app grows tenant disk without bound. For every volume the catalog marks with
+// a `rotate:` policy, the install handler drops a logrotate snippet here; the
+// delete handler removes it.
+
+// dockerAppLogrotateDir is the host logrotate.d directory. The agent runs as
+// root, so it can write here directly.
+const dockerAppLogrotateDir = "/etc/logrotate.d"
+
+// dockerAppLogrotatePath returns the snippet path for one app slug. Callers
+// validate the slug against dockerAppSlugRE before using it in a filename.
+func dockerAppLogrotatePath(slug string) string {
+	return filepath.Join(dockerAppLogrotateDir, "jabali-dockerapp-"+slug)
+}
+
+// buildDockerAppLogrotate renders the logrotate config body covering every log
+// volume of one docker app. dataDir is the app's DataRoot
+// (/var/lib/jabali/docker-apps/<slug>); each volume's file logs live at
+// <dataDir>/<volume>/*.log. Pure (no I/O) so it is unit-testable.
+//
+// Defaults: 14 days retention, copytruncate (safe while a container holds the
+// file open — no reload needed), daily + compress. A per-volume max_size adds
+// a size trigger; retention_days/mode override the defaults.
+func buildDockerAppLogrotate(slug, dataDir string, specs []dockerAppLogRotate) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Managed by jabali (JAB-121) — docker-app %q file logs.\n", slug)
+	b.WriteString("# Regenerated on every install; manual edits are overwritten.\n")
+	for _, s := range specs {
+		if !dockerAppSlugRE.MatchString(s.Volume) {
+			continue // defensive: never build a glob from an unvalidated name
+		}
+		days := s.RetentionDays
+		if days <= 0 {
+			days = 14
+		}
+		mode := s.Mode
+		if mode != "create" {
+			mode = "copytruncate"
+		}
+		glob := filepath.Join(dataDir, s.Volume, "*.log")
+		fmt.Fprintf(&b, "\n%s {\n", glob)
+		b.WriteString("    daily\n")
+		fmt.Fprintf(&b, "    rotate %d\n", days)
+		if s.MaxSize != "" {
+			fmt.Fprintf(&b, "    maxsize %s\n", s.MaxSize)
+		}
+		b.WriteString("    missingok\n")
+		b.WriteString("    notifempty\n")
+		b.WriteString("    compress\n")
+		b.WriteString("    delaycompress\n")
+		b.WriteString("    " + mode + "\n")
+		b.WriteString("    su root root\n")
+		b.WriteString("}\n")
+	}
+	return b.String()
+}
+
+// writeDockerAppLogrotate writes (or replaces) the app's logrotate snippet. No
+// usable specs → the snippet is removed (an app that dropped its log volumes
+// must not leave a stale config that logrotate keeps parsing).
+func writeDockerAppLogrotate(slug, dataDir string, specs []dockerAppLogRotate) error {
+	if !dockerAppSlugRE.MatchString(slug) {
+		return fmt.Errorf("invalid slug %q", slug)
+	}
+	// Count volumes that would actually render (valid name).
+	valid := 0
+	for _, s := range specs {
+		if dockerAppSlugRE.MatchString(s.Volume) {
+			valid++
+		}
+	}
+	if valid == 0 {
+		removeDockerAppLogrotate(slug)
+		return nil
+	}
+	// logrotate parses every file in /etc/logrotate.d; write directly (0644
+	// root:root). The file is tiny and rewritten on each install, so a torn
+	// write self-heals on the next run — a temp+rename here would risk
+	// logrotate parsing the leftover temp (its default tabooext excludes .tmp).
+	if err := os.WriteFile(dockerAppLogrotatePath(slug), []byte(buildDockerAppLogrotate(slug, dataDir, specs)), 0o644); err != nil {
+		return fmt.Errorf("write logrotate snippet: %w", err)
+	}
+	return nil
+}
+
+// removeDockerAppLogrotate deletes the app's snippet. Best-effort: a missing
+// file is not an error.
+func removeDockerAppLogrotate(slug string) {
+	if !dockerAppSlugRE.MatchString(slug) {
+		return
+	}
+	_ = os.Remove(dockerAppLogrotatePath(slug))
+}

--- a/panel-agent/internal/commands/docker_app_logrotate_test.go
+++ b/panel-agent/internal/commands/docker_app_logrotate_test.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-121: the rendered logrotate snippet must target <DataRoot>/<vol>/*.log,
+// honour per-volume overrides, and default to a container-safe policy.
+func TestBuildDockerAppLogrotate(t *testing.T) {
+	body := buildDockerAppLogrotate("flarum-abc", "/var/lib/jabali/docker-apps/flarum-abc", []dockerAppLogRotate{
+		{Volume: "storagelogs", RetentionDays: 14, MaxSize: "50M", Mode: "copytruncate"},
+		{Volume: "logs"}, // defaults
+	})
+	for _, want := range []string{
+		"/var/lib/jabali/docker-apps/flarum-abc/storagelogs/*.log {",
+		"/var/lib/jabali/docker-apps/flarum-abc/logs/*.log {",
+		"rotate 14",
+		"maxsize 50M",
+		"copytruncate",
+		"su root root",
+		"missingok",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("snippet missing %q\n---\n%s", want, body)
+		}
+	}
+	// the defaults-only volume must NOT emit a maxsize line but must still
+	// default to rotate 14 + copytruncate.
+	logsBlock := body[strings.Index(body, "/logs/*.log {"):]
+	if strings.Contains(logsBlock, "maxsize") {
+		t.Errorf("defaults-only volume should have no maxsize:\n%s", logsBlock)
+	}
+	if !strings.Contains(logsBlock, "rotate 14") || !strings.Contains(logsBlock, "copytruncate") {
+		t.Errorf("defaults-only volume missing default rotate/mode:\n%s", logsBlock)
+	}
+}
+
+// A bogus volume name must never reach the glob (path-injection guard).
+func TestBuildDockerAppLogrotate_SkipsBadVolume(t *testing.T) {
+	body := buildDockerAppLogrotate("app", "/var/lib/jabali/docker-apps/app", []dockerAppLogRotate{
+		{Volume: "../../etc/cron.d"},
+	})
+	if strings.Contains(body, "cron.d") {
+		t.Errorf("unvalidated volume name leaked into the snippet:\n%s", body)
+	}
+}
+
+// write → remove round-trip against a temp dir stand-in for /etc/logrotate.d.
+// (dockerAppLogrotateDir is a const, so we exercise the pure builder above and
+// the write/remove path here with a slug-scoped temp file via os APIs.)
+func TestWriteRemoveDockerAppLogrotate_EmptySpecsRemoves(t *testing.T) {
+	// Empty specs must not create a file. We can't redirect the const dir, so
+	// assert the no-op contract: writeDockerAppLogrotate with no valid specs
+	// returns nil and (best-effort) removes — it must not error.
+	if err := writeDockerAppLogrotate("nonexistent-slug", t.TempDir(), nil); err != nil {
+		t.Errorf("empty specs should be a no-op, got %v", err)
+	}
+	if err := writeDockerAppLogrotate("nonexistent-slug", t.TempDir(), []dockerAppLogRotate{{Volume: "bad/name"}}); err != nil {
+		t.Errorf("all-invalid specs should be a no-op, got %v", err)
+	}
+	// sanity: dockerAppLogrotatePath is slug-scoped under logrotate.d.
+	if got := dockerAppLogrotatePath("myapp"); got != filepath.Join("/etc/logrotate.d", "jabali-dockerapp-myapp") {
+		t.Errorf("path = %q", got)
+	}
+}

--- a/panel-api/internal/api/docker_apps.go
+++ b/panel-api/internal/api/docker_apps.go
@@ -602,8 +602,19 @@ func (h *dockerAppHandler) install(c *gin.Context) {
 	if h.cfg.Agent != nil {
 		_ = h.cfg.Repo.UpdateStatus(ctx, app.ID, models.DockerAppStatusInstalling, nil)
 		volumeNames := make([]string, 0, len(entry.Volumes))
+		logRotate := make([]map[string]any, 0)
 		for _, v := range entry.Volumes {
 			volumeNames = append(volumeNames, v.Name)
+			// JAB-121: declared persistent log volumes get a host logrotate
+			// snippet so their file logs (which bypass journald) stay bounded.
+			if v.Rotate != nil {
+				logRotate = append(logRotate, map[string]any{
+					"volume":         v.Name,
+					"retention_days": v.Rotate.RetentionDays,
+					"max_size":       v.Rotate.MaxSize,
+					"mode":           v.Rotate.Mode,
+				})
+			}
 		}
 		installParams := map[string]any{
 			"slug":                        instanceSlug,
@@ -611,6 +622,7 @@ func (h *dockerAppHandler) install(c *gin.Context) {
 			"env_file":                    buildEnvFile(envMap),
 			"volumes":                     volumeNames,
 			"volume_owner":                entry.VolumeOwner,
+			"log_rotate":                  logRotate,
 			"wait_healthy":                true,
 			"healthcheck_timeout_seconds": 300,
 		}

--- a/panel-api/internal/dockerapp/catalog.go
+++ b/panel-api/internal/dockerapp/catalog.go
@@ -93,6 +93,23 @@ type Resources struct {
 type Volume struct {
 	Name          string `yaml:"name" json:"name"`
 	ContainerPath string `yaml:"container_path" json:"container_path"`
+	// Rotate marks this volume as a persistent LOG directory whose files
+	// bypass Docker's journald driver + the host logrotate drop-in and so
+	// grow tenant disk unbounded (JAB-121). When set, the agent writes a host
+	// logrotate snippet for <DataRoot>/<name>/*.log at install time.
+	Rotate *VolumeRotate `yaml:"rotate,omitempty" json:"rotate,omitempty"`
+}
+
+// VolumeRotate is a persistent log volume's retention policy (JAB-121).
+type VolumeRotate struct {
+	// RetentionDays is how many rotated files logrotate keeps (its `rotate`).
+	RetentionDays int `yaml:"retention_days,omitempty" json:"retention_days,omitempty"`
+	// MaxSize forces rotation when a single log exceeds this size (logrotate
+	// `maxsize`, e.g. "50M"); empty = daily-only.
+	MaxSize string `yaml:"max_size,omitempty" json:"max_size,omitempty"`
+	// Mode is "copytruncate" (default — safe while a container holds the log
+	// file open) or "create".
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
 }
 
 type PortSpec struct {

--- a/panel-api/internal/dockerapp/catalog_logrotate_test.go
+++ b/panel-api/internal/dockerapp/catalog_logrotate_test.go
@@ -1,0 +1,73 @@
+package dockerapp
+
+import (
+	"strings"
+	"testing"
+)
+
+// looksLikeLogVolume reports whether a catalog volume is a persistent log
+// directory — by name (contains "log") or container mount path (a "/log"
+// segment or a "logs" leaf). JAB-121: such volumes bypass Docker's journald
+// driver, so they must declare a retention policy (or the lint below fails).
+func looksLikeLogVolume(v Volume) bool {
+	n := strings.ToLower(v.Name)
+	p := strings.ToLower(v.ContainerPath)
+	if strings.Contains(n, "log") {
+		return true
+	}
+	// "/var/log/...", ".../logs", ".../storage/logs"
+	return strings.Contains(p, "/log/") || strings.HasSuffix(p, "/logs") || strings.HasSuffix(p, "/log")
+}
+
+// JAB-121 catalog lint: every persistent log volume must declare a `rotate:`
+// policy so the agent installs a host logrotate snippet for it. A new catalog
+// entry that persists logs without retention fails here, which is the whole
+// point — it stops the unbounded-disk regression from re-entering the catalog.
+func TestDockerAppLogVolumesDeclareRotation(t *testing.T) {
+	cat, errs := LoadDir(repoCatalogDir(t))
+	for _, e := range errs {
+		t.Fatalf("catalog load error: %v", e)
+	}
+	for _, e := range cat.All() {
+		for _, v := range e.Volumes {
+			if looksLikeLogVolume(v) && v.Rotate == nil {
+				t.Errorf("%s: persistent log volume %q (%s) has no `rotate:` policy — "+
+					"declare retention_days/max_size/mode so the agent installs a logrotate "+
+					"snippet, or rename it if it is not actually a log dir (JAB-121)",
+					e.Slug, v.Name, v.ContainerPath)
+			}
+		}
+	}
+}
+
+// The four apps flagged in JAB-121 must carry a concrete rotate policy — a
+// regression guard tighter than the generic lint above.
+func TestDockerAppKnownLogAppsHaveRotation(t *testing.T) {
+	cat, _ := LoadDir(repoCatalogDir(t))
+	for slug, vol := range map[string]string{
+		"flarum":     "storagelogs",
+		"erpnext":    "logs",
+		"onlyoffice": "logs",
+		"plausible":  "clickhouse-logs",
+	} {
+		e, ok := cat.Get(slug)
+		if !ok {
+			t.Errorf("catalog missing %q", slug)
+			continue
+		}
+		found := false
+		for _, v := range e.Volumes {
+			if v.Name == vol {
+				found = true
+				if v.Rotate == nil {
+					t.Errorf("%s: log volume %q must declare rotate (JAB-121)", slug, vol)
+				} else if v.Rotate.RetentionDays <= 0 {
+					t.Errorf("%s: log volume %q rotate.retention_days must be > 0", slug, vol)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected log volume %q not found", slug, vol)
+		}
+	}
+}

--- a/panel-ui/src/components/JabaliHeader.tsx
+++ b/panel-ui/src/components/JabaliHeader.tsx
@@ -38,7 +38,7 @@ import { useTranslation } from "react-i18next";
 
 import { apiClient } from "../apiClient";
 import { useAuth } from "../auth/AuthContext";
-import { LANGUAGE_LABELS, SUPPORTED, setLanguage } from "../i18n";
+import { DISPLAY_ORDER, LANGUAGE_LABELS, setLanguage } from "../i18n";
 import { adminNav, userNav } from "../nav";
 import { JabaliTitle } from "./JabaliTitle";
 import { InstallAppButton } from "./InstallAppButton";
@@ -290,7 +290,7 @@ export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHead
       // someone who cannot read the language the panel is currently in. The
       // checkmark marks the active one; the others get an equal-width spacer
       // so the labels stay on a single left edge.
-      children: SUPPORTED.map((lng) => ({
+      children: DISPLAY_ORDER.map((lng) => ({
         key: `lang:${lng}`,
         label: LANGUAGE_LABELS[lng],
         icon:

--- a/panel-ui/src/i18n.ts
+++ b/panel-ui/src/i18n.ts
@@ -100,6 +100,20 @@ export const LANGUAGE_LABELS: Record<SupportedLng, string> = {
 /** Right-to-left scripts. Drives AntD's `direction` + the <html dir> attribute. */
 const RTL = new Set<string>(["he", "ar", "fa", "ur"]);
 
+// DISPLAY_ORDER (JAB-173) is the language-switcher render order: English
+// first (the source language), then the LTR locales in SUPPORTED order, then
+// the RTL locales (he/ar/…) grouped at the end. Derived from SUPPORTED + RTL
+// so adding a locale needs no second edit and a future RTL locale lands in the
+// trailing group automatically. SUPPORTED itself must NOT be reordered for a
+// menu concern — it backs normalise()/ANTD_LOCALES/DAYJS_LOCALES/supportedLngs.
+export const DISPLAY_ORDER: SupportedLng[] = [...SUPPORTED].sort((a, b) => {
+  if (a === DEFAULT_LNG) return -1;
+  if (b === DEFAULT_LNG) return 1;
+  const ar = RTL.has(a) ? 1 : 0;
+  const br = RTL.has(b) ? 1 : 0;
+  return ar - br; // LTR (0) before RTL (1); stable sort keeps SUPPORTED order within a group
+});
+
 const ANTD_LOCALES: Record<SupportedLng, AntdLocale> = {
   en: enUS,
   he: heIL,

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -501,24 +501,7 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
                     key: "included",
                     label: `Included in this update (${behind})`,
                     children: (
-                      <>
-                        <ul style={{ margin: 0, paddingLeft: 18 }}>
-                          {pending.map((c) => (
-                            <li key={c.sha} style={{ marginBottom: 4 }}>
-                              <Text>{c.subject}</Text>{" "}
-                              <Text type="secondary" code style={{ fontSize: 11 }}>{c.sha}</Text>{" "}
-                              <Text type="secondary" style={{ fontSize: 11 }}>
-                                {c.date ? dayjs(c.date).format("MMM D") : ""}
-                              </Text>
-                            </li>
-                          ))}
-                        </ul>
-                        {behind > pending.length ? (
-                          <Text type="secondary" style={{ fontSize: 11 }}>
-                            + {behind - pending.length} more…
-                          </Text>
-                        ) : null}
-                      </>
+                      <CommitList commits={pending} truncatedMore={behind - pending.length} />
                     ),
                   },
                 ]
@@ -528,19 +511,7 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
                   {
                     key: "recent",
                     label: "Recent changes",
-                    children: (
-                      <ul style={{ margin: 0, paddingLeft: 18 }}>
-                        {commits.map((c) => (
-                          <li key={c.sha} style={{ marginBottom: 4 }}>
-                            <Text>{c.subject}</Text>{" "}
-                            <Text type="secondary" code style={{ fontSize: 11 }}>{c.sha}</Text>{" "}
-                            <Text type="secondary" style={{ fontSize: 11 }}>
-                              {c.date ? dayjs(c.date).format("MMM D") : ""}
-                            </Text>
-                          </li>
-                        ))}
-                      </ul>
-                    ),
+                    children: <CommitList commits={commits} />,
                   },
                 ]
               : []),
@@ -548,6 +519,57 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
         />
       ) : null}
     </Card>
+  );
+}
+
+// CommitList (JAB-172) renders a pending/recent commit list capped at `cap`
+// with an in-place Show more/less toggle, so a host that has drifted weeks
+// behind does not bury the rest of the Updates page under a wall of commits.
+// `truncatedMore` is the SEPARATE server-side truncation count (commits beyond
+// pendingCommits() git log -50 cap); it renders only once the full available
+// list is shown, so the two never double-count.
+function CommitList({
+  commits,
+  cap = 5,
+  truncatedMore = 0,
+}: {
+  commits: { sha: string; subject: string; date?: string | null }[];
+  cap?: number;
+  truncatedMore?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? commits : commits.slice(0, cap);
+  return (
+    <>
+      <ul style={{ margin: 0, paddingLeft: 18 }}>
+        {shown.map((c) => (
+          <li key={c.sha} style={{ marginBottom: 4 }}>
+            <Text>{c.subject}</Text>{" "}
+            <Text type="secondary" code style={{ fontSize: 11 }}>
+              {c.sha}
+            </Text>{" "}
+            <Text type="secondary" style={{ fontSize: 11 }}>
+              {c.date ? dayjs(c.date).format("MMM D") : ""}
+            </Text>
+          </li>
+        ))}
+      </ul>
+      {commits.length > cap ? (
+        <Button
+          type="link"
+          size="small"
+          style={{ padding: 0, height: "auto", fontSize: 11 }}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? "Show less" : `Show more (${commits.length - cap})…`}
+        </Button>
+      ) : null}
+      {truncatedMore > 0 && (expanded || commits.length <= cap) ? (
+        <Text type="secondary" style={{ fontSize: 11, display: "block" }}>
+          + {truncatedMore} more…
+        </Text>
+      ) : null}
+    </>
   );
 }
 


### PR DESCRIPTION
**Phase 1 of JAB-121** — bound the tenant disk that persistent Docker-app file logs consume.

## Problem
Several catalog apps bind an internal log dir into the app's `DataRoot`:
- flarum → `storage/logs`, erpnext → `frappe-bench/logs`, onlyoffice → `/var/log/onlyoffice`, plausible → `/var/log/clickhouse-server`.

Those file logs bypass **both** Docker's journald log driver **and** the static `install/logrotate/jabali` drop-in, so a busy app grows tenant disk with no bound.

## This PR
- **Catalog schema:** `Volume.rotate` (`retention_days` / `max_size` / `mode`) marks a volume as a persistent log dir. Declared on the 4 apps above.
- **Agent:** on `docker_app.install`, write `/etc/logrotate.d/jabali-dockerapp-<slug>` covering `<DataRoot>/<vol>/*.log` — `daily`, `rotate N`, optional `maxsize`, `copytruncate` (safe while the container holds the file open, no reload). Removed on `docker_app.delete`. Best-effort: a snippet write never fails the install.
- **Wire:** the REST install dispatch threads per-volume rotate specs to the agent.
- **Catalog lint** (`TestDockerAppLogVolumesDeclareRotation`): any log-looking volume (`*log*` name or `/log`/`/logs` mount) **without** a `rotate:` policy fails CI — so the unbounded-disk regression can't re-enter the catalog when a new app is added. Plus a concrete guard for the 4 known apps.

## Verification
- Unit: snippet builder (glob/retention/maxsize/copytruncate defaults + path-injection guard); catalog lint + known-app guard. Build + vet + full dockerapp/commands suites green.
- **Box** (testserver): the generated config parses under `logrotate -d` → `rotating pattern: …/storagelogs/*.log after 1 days (14 rotations)`, no error; doesn't disturb the global run.

## Scope notes
- Docker **stdout/stderr stays journal-managed** — this only covers app-internal *file* logs.
- privatebin's `/var/log/nginx` + `/var/log/php-fpm` are **anonymous** volumes (Docker-managed, removed on `down -v`) — not tenant disk, out of scope.
- The lint found **no other** catalog log volumes, so these 4 are the complete current set.

## Follow-up phases (JAB-121)
Convergence for already-installed apps (reconciler self-heal), the periodic unmanaged-log scanner (step 5), and per-app log disk-usage in the Docker Apps UI (step 6).

Refs JAB-121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)