### PR TITLE
feat(docker-apps): converge log-volume logrotate for existing apps (JAB-121 phase 2)

### DIFF
--- a/panel-agent/internal/commands/docker_app_logrotate.go
+++ b/panel-agent/internal/commands/docker_app_logrotate.go
@@ -85,7 +85,10 @@ func writeDockerAppLogrotate(slug, dataDir string, specs []dockerAppLogRotate) e
 		}
 	}
 	if valid == 0 {
-		removeDockerAppLogrotate(slug)
+		// No usable specs → leave any existing snippet ALONE. Removal is the
+		// delete handler's job (removeDockerAppLogrotate); a minimal-payload
+		// install or a logrotate_ensure with empty specs (recovery) must never
+		// nuke a snippet a prior real install wrote (JAB-121 phase 2).
 		return nil
 	}
 	// logrotate parses every file in /etc/logrotate.d; write directly (0644

--- a/panel-agent/internal/commands/docker_app_logrotate_ensure.go
+++ b/panel-agent/internal/commands/docker_app_logrotate_ensure.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// docker_app.logrotate_ensure (JAB-121 phase 2) (re)writes the host logrotate
+// snippet for one already-installed docker app from catalog-supplied specs.
+// The reconciler dispatches it once per app per panel-api lifetime so apps
+// installed BEFORE the retention feature — and any whose snippet drifted — get
+// bounded logs without a reinstall. Empty specs are a no-op (never removes; the
+// delete handler owns removal).
+func dockerAppLogrotateEnsureHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		Slug      string               `json:"slug"`
+		LogRotate []dockerAppLogRotate `json:"log_rotate"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse: %v", err)}
+	}
+	if err := validateSlug(p.Slug); err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(dockerAppDataRoot, p.Slug)
+	if err := writeDockerAppLogrotate(p.Slug, dir, p.LogRotate); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	}
+	return map[string]any{"ok": true}, nil
+}
+
+func init() {
+	Default.Register("docker_app.logrotate_ensure", dockerAppLogrotateEnsureHandler)
+}

--- a/panel-agent/internal/commands/docker_app_logrotate_ensure_test.go
+++ b/panel-agent/internal/commands/docker_app_logrotate_ensure_test.go
@@ -1,0 +1,34 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// JAB-121 phase 2: the ensure handler validates its slug and no-ops on empty
+// specs (never writes to /etc for a bogus/empty request).
+func TestDockerAppLogrotateEnsureHandler_Validation(t *testing.T) {
+	// bad slug → InvalidArgument, no filesystem touch.
+	_, err := dockerAppLogrotateEnsureHandler(context.Background(),
+		json.RawMessage(`{"slug":"../etc","log_rotate":[{"volume":"logs"}]}`))
+	if err == nil {
+		t.Fatal("expected error for bad slug")
+	}
+	if ae, ok := err.(*agentwire.AgentError); !ok || ae.Code != agentwire.CodeInvalidArgument {
+		t.Errorf("want InvalidArgument, got %v", err)
+	}
+
+	// valid slug + empty specs → no-op success (writeDockerAppLogrotate returns
+	// nil for empty and never creates a file).
+	out, err := dockerAppLogrotateEnsureHandler(context.Background(),
+		json.RawMessage(`{"slug":"someapp","log_rotate":[]}`))
+	if err != nil {
+		t.Fatalf("empty specs should succeed as no-op, got %v", err)
+	}
+	if m, ok := out.(map[string]any); !ok || m["ok"] != true {
+		t.Errorf("unexpected result %v", out)
+	}
+}

--- a/panel-api/internal/reconciler/docker_apps.go
+++ b/panel-api/internal/reconciler/docker_apps.go
@@ -3,35 +3,35 @@
 //
 // State machine (see ADR-0116 + plans/m48-docker-app-marketplace.md):
 //
-//   pending      -> dispatch docker_app.install; on success move to
-//                   `running` (or `unhealthy` if healthchecks failed
-//                   within the install verb's wait_healthy budget)
-//   installing   -> in-flight install; status-poll to find out
-//                   whether it landed in `running` / `failed`
-//   running      -> status-poll; if the agent says not-running,
-//                   move to `failed` (a crashed-after-install case)
-//   stopped      -> no-op; operator owns the next move
-//   failed       -> no-op; operator clicks "Retry" to flip back to
-//                   pending
-//   updating, rolling_back, deleted -> not handled in Phase 3
-//                   (Phase 7 ships update/rollback; deletion is
-//                   synchronous in the REST handler).
+//	pending      -> dispatch docker_app.install; on success move to
+//	                `running` (or `unhealthy` if healthchecks failed
+//	                within the install verb's wait_healthy budget)
+//	installing   -> in-flight install; status-poll to find out
+//	                whether it landed in `running` / `failed`
+//	running      -> status-poll; if the agent says not-running,
+//	                move to `failed` (a crashed-after-install case)
+//	stopped      -> no-op; operator owns the next move
+//	failed       -> no-op; operator clicks "Retry" to flip back to
+//	                pending
+//	updating, rolling_back, deleted -> not handled in Phase 3
+//	                (Phase 7 ships update/rollback; deletion is
+//	                synchronous in the REST handler).
 //
 // The reconciler only DISPATCHES work; it never blocks waiting for
 // the docker daemon. The agent verbs have their own deadlines.
 package reconciler
 
 import (
-	"strings"
-	"sort"
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -315,6 +315,10 @@ func (r *Reconciler) reconcileOneDockerApp(ctx context.Context, app *models.Dock
 		// outside the panel -- otherwise the UI shows stale "stopped"
 		// indefinitely.
 		r.statusPoll(ctx, app)
+		// JAB-121 phase 2: (re)assert this app's host logrotate snippet once per
+		// panel-api lifetime, so apps installed before the retention feature
+		// converge to bounded logs without a reinstall.
+		r.ensureLogrotate(ctx, app)
 		// M48 Phase 7 follow-up: image-digest poll. Cheap (~1 HTTP
 		// HEAD via `docker manifest inspect`) but gated by
 		// last_check_at so each app gets checked at most once per
@@ -353,10 +357,10 @@ func (r *Reconciler) dispatchInstall(ctx context.Context, app *models.DockerApp)
 	// compose.yml from disk and brings it up. The full install
 	// payload is set by the REST handler on first dispatch.
 	raw, err := r.agent.Call(callCtx, "docker_app.install", map[string]any{
-		"slug":          app.EffectiveSlug(),
-		"compose_yml":   "RECOVERY",                       // sentinel: agent recovery path reads compose.yml from disk
-		"volumes":       []string{},
-		"wait_healthy":  false,
+		"slug":                        app.EffectiveSlug(),
+		"compose_yml":                 "RECOVERY", // sentinel: agent recovery path reads compose.yml from disk
+		"volumes":                     []string{},
+		"wait_healthy":                false,
 		"healthcheck_timeout_seconds": 0,
 	})
 	if err != nil {
@@ -471,6 +475,49 @@ func (r *Reconciler) WithDockerCatalog(cat *dockerapp.Catalog) *Reconciler {
 // stringification in future Phase 7 work.
 var _ = fmt.Sprintf
 
+// ensureLogrotate (JAB-121 phase 2) asks the agent to (re)write this app's
+// host logrotate snippet from its catalog rotate policy. Runs at most once per
+// app per panel-api lifetime (the in-memory set clears on restart, so a jabali
+// update re-converges every installed app). Apps with no log volumes are
+// marked done without an agent round-trip.
+func (r *Reconciler) ensureLogrotate(ctx context.Context, app *models.DockerApp) {
+	if app == nil || r.dockerCatalog == nil || r.agent == nil {
+		return
+	}
+	if _, done := r.logrotateEnsured.Load(app.ID); done {
+		return
+	}
+	entry, ok := r.dockerCatalog.Get(app.Slug)
+	if !ok {
+		return
+	}
+	specs := make([]map[string]any, 0)
+	for _, v := range entry.Volumes {
+		if v.Rotate != nil {
+			specs = append(specs, map[string]any{
+				"volume":         v.Name,
+				"retention_days": v.Rotate.RetentionDays,
+				"max_size":       v.Rotate.MaxSize,
+				"mode":           v.Rotate.Mode,
+			})
+		}
+	}
+	// Nothing to rotate → mark done (no per-tick re-check) and skip the agent.
+	if len(specs) == 0 {
+		r.logrotateEnsured.Store(app.ID, true)
+		return
+	}
+	callCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	if _, err := r.agent.Call(callCtx, "docker_app.logrotate_ensure", map[string]any{
+		"slug":       app.EffectiveSlug(),
+		"log_rotate": specs,
+	}); err != nil {
+		r.log.Warn("dockerapp: logrotate ensure failed", "id", app.ID, "slug", app.Slug, "err", err)
+		return // leave unmarked so the next tick retries
+	}
+	r.logrotateEnsured.Store(app.ID, true)
+}
 
 // dockerAppCheckInterval is the per-app poll cadence for upstream
 // image digests. 6h is conservative; busy registries (docker hub
@@ -576,7 +623,6 @@ func (r *Reconciler) pollImageUpdate(ctx context.Context, app *models.DockerApp)
 		}
 	}
 }
-
 
 // shortDigest trims a `sha256:abcdef...` to a 12-char view for
 // notifications and log lines.

--- a/panel-api/internal/reconciler/docker_logrotate_ensure_test.go
+++ b/panel-api/internal/reconciler/docker_logrotate_ensure_test.go
@@ -1,0 +1,79 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+type fakeLogrotateAgent struct{ ensureCalls []map[string]any }
+
+func (f *fakeLogrotateAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	if cmd == "docker_app.logrotate_ensure" {
+		if m, ok := params.(map[string]any); ok {
+			f.ensureCalls = append(f.ensureCalls, m)
+		}
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func loadReconcileTestCatalog(t *testing.T) *dockerapp.Catalog {
+	t.Helper()
+	_, file, _, _ := runtime.Caller(0)
+	root := filepath.Join(filepath.Dir(file), "..", "..", "..", "install", "docker-apps")
+	cat, errs := dockerapp.LoadDir(root)
+	if len(errs) > 0 {
+		t.Fatalf("catalog load: %v", errs)
+	}
+	return cat
+}
+
+// JAB-121 phase 2: an app whose catalog entry declares a log rotate volume gets
+// a logrotate_ensure dispatch — exactly once per panel-api lifetime.
+func TestEnsureLogrotate_DispatchesOncePerBoot(t *testing.T) {
+	ag := &fakeLogrotateAgent{}
+	r := &Reconciler{agent: ag, dockerCatalog: loadReconcileTestCatalog(t), log: slog.Default()}
+	app := &models.DockerApp{ID: "app1", Slug: "flarum"}
+
+	r.ensureLogrotate(context.Background(), app)
+	if len(ag.ensureCalls) != 1 {
+		t.Fatalf("want 1 ensure call, got %d", len(ag.ensureCalls))
+	}
+	specs, _ := ag.ensureCalls[0]["log_rotate"].([]map[string]any)
+	if len(specs) == 0 || specs[0]["volume"] != "storagelogs" {
+		t.Errorf("expected flarum storagelogs spec, got %v", ag.ensureCalls[0]["log_rotate"])
+	}
+
+	// second call → no re-dispatch (once per boot).
+	r.ensureLogrotate(context.Background(), app)
+	if len(ag.ensureCalls) != 1 {
+		t.Errorf("second call re-dispatched; want 1 total, got %d", len(ag.ensureCalls))
+	}
+}
+
+// An app whose catalog entry has NO rotate volume is a no-op (no agent call).
+func TestEnsureLogrotate_NoLogVolumeSkipsAgent(t *testing.T) {
+	ag := &fakeLogrotateAgent{}
+	r := &Reconciler{agent: ag, dockerCatalog: loadReconcileTestCatalog(t), log: slog.Default()}
+	app := &models.DockerApp{ID: "app2", Slug: "gitea"} // gitea has volumes but no rotate
+	r.ensureLogrotate(context.Background(), app)
+	if len(ag.ensureCalls) != 0 {
+		t.Errorf("no-log app should not dispatch, got %d", len(ag.ensureCalls))
+	}
+}
+
+// Unknown slug (not in catalog) is a safe no-op.
+func TestEnsureLogrotate_UnknownSlugNoop(t *testing.T) {
+	ag := &fakeLogrotateAgent{}
+	r := &Reconciler{agent: ag, dockerCatalog: loadReconcileTestCatalog(t), log: slog.Default()}
+	r.ensureLogrotate(context.Background(), &models.DockerApp{ID: "app3", Slug: "does-not-exist"})
+	if len(ag.ensureCalls) != 0 {
+		t.Errorf("unknown slug should not dispatch, got %d", len(ag.ensureCalls))
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -80,6 +80,11 @@ type Reconciler struct {
 	// image-update poller to resolve a docker_apps row to its
 	// catalog entry's image_channel. Optional.
 	dockerCatalog *dockerapp.Catalog
+	// logrotateEnsured tracks docker apps whose host logrotate snippet the
+	// reconciler has (re)asserted this panel-api lifetime (JAB-121 phase 2).
+	// Cleared on process restart, so a `jabali update` re-converges every
+	// installed app's snippet exactly once.
+	logrotateEnsured sync.Map
 	// M18 — hosting packages + per-user overrides + /home mount path.
 	packages       repository.PackageRepository
 	limitOverrides repository.UserLimitOverrideRepository


### PR DESCRIPTION
**Phase 2 of JAB-121.** Phase 1 (#651) only wrote the logrotate snippet on a fresh REST install. This makes it converge for apps installed **before** the feature, and hardens the write path.

## Changes
- **Harden** `writeDockerAppLogrotate`: empty specs no longer **remove** the snippet — they leave any existing one alone. Removal is the delete handler's job. This closes a footgun: the reconciler's recovery `dispatchInstall` sends no `log_rotate`, so without this a recovered log-app would lose its rotation.
- **New agent verb** `docker_app.logrotate_ensure` (slug + specs) → (re)writes the snippet, no docker interaction.
- **`Reconciler.ensureLogrotate`**: for each installed app, **once per panel-api lifetime**, resolve its catalog `rotate:` policy and dispatch the ensure. The in-memory set clears on process restart, so a `jabali update` re-converges every installed app's snippet exactly once. Apps with no log volumes are marked done with no agent round-trip.

## Result
Apps installed before the retention feature — or whose snippet drifted — get bounded logs on the next panel-api restart. Satisfies JAB-121's "existing Docker apps with persistent log mounts have bounded retention."

## Verification
- Unit: ensure dispatches once + carries the right specs (flarum `storagelogs`), skips no-log (`gitea`) + unknown slugs; agent handler validates the slug + no-ops on empty specs; hardened empty-branch. Build + vet + full reconciler/commands/dockerapp suites green.
- The write path itself (valid `logrotate` config) was box-proven in #651.

## Remaining JAB-121 phases
Unmanaged-log scanner (report large/undeclared app log dirs) + per-app log disk-usage in the Docker Apps UI.

Refs JAB-121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)