### PR TITLE
feat(docker-apps): unmanaged/oversized log-dir scanner (JAB-121 phase 3)

### DIFF
--- a/panel-agent/internal/commands/docker_app_log_scan.go
+++ b/panel-agent/internal/commands/docker_app_log_scan.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// dockerAppLogScanEntry is one immediate DataRoot subdirectory of a docker app:
+// its size and whether it holds *.log files (JAB-121 phase 3).
+type dockerAppLogScanEntry struct {
+	Name    string `json:"name"`
+	Bytes   int64  `json:"bytes"`
+	HasLogs bool   `json:"has_logs"`
+}
+
+type dockerAppLogScanResult struct {
+	Entries []dockerAppLogScanEntry `json:"entries"`
+}
+
+// docker_app.log_scan (JAB-121 phase 3) reports the size of each immediate
+// DataRoot subdirectory of one app and whether it holds *.log files. Purely
+// READ-ONLY — the reconciler's fallback scanner uses it to WARN about log dirs
+// that grow unmanaged (hold logs but have no rotate policy) or oversized
+// (rotated yet huge). It never deletes anything.
+func dockerAppLogScanHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "parse: " + err.Error()}
+	}
+	if err := validateSlug(p.Slug); err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(dockerAppDataRoot, p.Slug)
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return dockerAppLogScanResult{}, nil // no data dir yet — nothing to scan
+		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "readdir: " + err.Error()}
+	}
+	res := dockerAppLogScanResult{}
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		sub := filepath.Join(dir, e.Name())
+		bytes, _ := dirSizeBytes(ctx, sub) // best-effort; 0 on du failure
+		logs, _ := filepath.Glob(filepath.Join(sub, "*.log"))
+		res.Entries = append(res.Entries, dockerAppLogScanEntry{
+			Name:    e.Name(),
+			Bytes:   bytes,
+			HasLogs: len(logs) > 0,
+		})
+	}
+	return res, nil
+}
+
+func init() {
+	Default.Register("docker_app.log_scan", dockerAppLogScanHandler)
+}

--- a/panel-api/internal/reconciler/docker_apps.go
+++ b/panel-api/internal/reconciler/docker_apps.go
@@ -319,6 +319,9 @@ func (r *Reconciler) reconcileOneDockerApp(ctx context.Context, app *models.Dock
 		// panel-api lifetime, so apps installed before the retention feature
 		// converge to bounded logs without a reinstall.
 		r.ensureLogrotate(ctx, app)
+		// JAB-121 phase 3: report (never delete) log dirs that grow unmanaged
+		// or oversized, once per panel-api lifetime.
+		r.scanLogs(ctx, app)
 		// M48 Phase 7 follow-up: image-digest poll. Cheap (~1 HTTP
 		// HEAD via `docker manifest inspect`) but gated by
 		// last_check_at so each app gets checked at most once per
@@ -517,6 +520,68 @@ func (r *Reconciler) ensureLogrotate(ctx context.Context, app *models.DockerApp)
 		return // leave unmarked so the next tick retries
 	}
 	r.logrotateEnsured.Store(app.ID, true)
+}
+
+// dockerAppLogWarnBytes is the size at which a ROTATED log dir is flagged —
+// this large despite a rotate policy means logrotate isn't running or can't
+// keep up. 1 GiB is deliberately generous (rotation keeps a handful of
+// compressed generations).
+const dockerAppLogWarnBytes int64 = 1 << 30
+
+// scanLogs (JAB-121 phase 3) is the read-only fallback scanner: it asks the
+// agent for the size of each DataRoot subdir + whether it holds *.log files,
+// then WARNS (never deletes) about log dirs that are unmanaged (hold logs but
+// have no catalog rotate policy) or oversized (rotated yet huge). Runs once
+// per app per panel-api lifetime; the operator sees the slug + dir + bytes in
+// the panel-api log.
+func (r *Reconciler) scanLogs(ctx context.Context, app *models.DockerApp) {
+	if app == nil || r.dockerCatalog == nil || r.agent == nil {
+		return
+	}
+	if _, done := r.logScanned.Load(app.ID); done {
+		return
+	}
+	entry, ok := r.dockerCatalog.Get(app.Slug)
+	if !ok {
+		return
+	}
+	declared := map[string]bool{}
+	for _, v := range entry.Volumes {
+		if v.Rotate != nil {
+			declared[v.Name] = true
+		}
+	}
+	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	raw, err := r.agent.Call(callCtx, "docker_app.log_scan", map[string]any{"slug": app.EffectiveSlug()})
+	if err != nil {
+		return // unmarked → retry next tick
+	}
+	var res struct {
+		Entries []struct {
+			Name    string `json:"name"`
+			Bytes   int64  `json:"bytes"`
+			HasLogs bool   `json:"has_logs"`
+		} `json:"entries"`
+	}
+	if json.Unmarshal(raw, &res) != nil {
+		r.logScanned.Store(app.ID, true)
+		return
+	}
+	for _, e := range res.Entries {
+		if !e.HasLogs {
+			continue
+		}
+		switch {
+		case !declared[e.Name]:
+			r.log.Warn("dockerapp: UNMANAGED log dir (no rotate policy) — declare rotate in the catalog or investigate",
+				"slug", app.Slug, "instance", app.EffectiveSlug(), "dir", e.Name, "bytes", e.Bytes)
+		case e.Bytes >= dockerAppLogWarnBytes:
+			r.log.Warn("dockerapp: rotated log dir is oversized — logrotate may not be running or keeping up",
+				"slug", app.Slug, "instance", app.EffectiveSlug(), "dir", e.Name, "bytes", e.Bytes)
+		}
+	}
+	r.logScanned.Store(app.ID, true)
 }
 
 // dockerAppCheckInterval is the per-app poll cadence for upstream

--- a/panel-api/internal/reconciler/docker_log_scan_test.go
+++ b/panel-api/internal/reconciler/docker_log_scan_test.go
@@ -1,0 +1,121 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// scanFakeAgent returns a canned docker_app.log_scan result.
+type scanFakeAgent struct{ result string }
+
+func (a *scanFakeAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	if cmd == "docker_app.log_scan" {
+		return json.RawMessage(a.result), nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// captureHandler records slog records so a test can assert what the scanner
+// warned about.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) warnDirs() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var dirs []string
+	for _, rec := range h.records {
+		if rec.Level != slog.LevelWarn {
+			continue
+		}
+		rec.Attrs(func(a slog.Attr) bool {
+			if a.Key == "dir" {
+				dirs = append(dirs, a.Value.String())
+			}
+			return true
+		})
+	}
+	return dirs
+}
+
+func (h *captureHandler) warnMsgContains(sub string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, rec := range h.records {
+		if rec.Level == slog.LevelWarn && strings.Contains(rec.Message, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func has(ss []string, v string) bool {
+	for _, s := range ss {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// JAB-121 phase 3: a log-holding dir with no catalog rotate policy is warned as
+// unmanaged; a declared dir (flarum storagelogs) below the size threshold and a
+// non-log dir are not; the scan runs once per boot.
+func TestScanLogs_WarnsUnmanaged(t *testing.T) {
+	cap := &captureHandler{}
+	ag := &scanFakeAgent{result: `{"entries":[
+		{"name":"storagelogs","bytes":100,"has_logs":true},
+		{"name":"mystery-logs","bytes":500,"has_logs":true},
+		{"name":"db","bytes":99999,"has_logs":false}
+	]}`}
+	r := &Reconciler{agent: ag, dockerCatalog: loadReconcileTestCatalog(t), log: slog.New(cap)}
+	app := &models.DockerApp{ID: "a1", Slug: "flarum"}
+
+	r.scanLogs(context.Background(), app)
+	dirs := cap.warnDirs()
+	if !has(dirs, "mystery-logs") {
+		t.Errorf("expected unmanaged warn for mystery-logs, warned dirs=%v", dirs)
+	}
+	if has(dirs, "storagelogs") {
+		t.Errorf("declared+small storagelogs should not warn, warned dirs=%v", dirs)
+	}
+	if has(dirs, "db") {
+		t.Errorf("non-log dir should not warn, warned dirs=%v", dirs)
+	}
+
+	before := len(cap.records)
+	r.scanLogs(context.Background(), app)
+	if len(cap.records) != before {
+		t.Errorf("second scan should be a no-op (once per boot)")
+	}
+}
+
+// A DECLARED log dir that is huge (rotation not keeping up) is warned as oversized.
+func TestScanLogs_WarnsOversizedDeclared(t *testing.T) {
+	cap := &captureHandler{}
+	ag := &scanFakeAgent{result: fmt.Sprintf(`{"entries":[{"name":"storagelogs","bytes":%d,"has_logs":true}]}`, int64(2)<<30)}
+	r := &Reconciler{agent: ag, dockerCatalog: loadReconcileTestCatalog(t), log: slog.New(cap)}
+	r.scanLogs(context.Background(), &models.DockerApp{ID: "a2", Slug: "flarum"})
+	if !cap.warnMsgContains("oversized") {
+		t.Errorf("expected oversized warn for a 2 GiB declared log dir")
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -85,6 +85,9 @@ type Reconciler struct {
 	// Cleared on process restart, so a `jabali update` re-converges every
 	// installed app's snippet exactly once.
 	logrotateEnsured sync.Map
+	// logScanned tracks docker apps whose log dirs the reconciler has scanned
+	// for unmanaged/oversized growth this panel-api lifetime (JAB-121 phase 3).
+	logScanned sync.Map
 	// M18 — hosting packages + per-user overrides + /home mount path.
 	packages       repository.PackageRepository
 	limitOverrides repository.UserLimitOverrideRepository


### PR DESCRIPTION
**Phase 3 of JAB-121** — the read-only fallback scanner (step 5). Report, never delete.

## Changes
- **New agent verb** `docker_app.log_scan(slug)`: reports each immediate `DataRoot` subdir's size (`du -sb`) + whether it holds `*.log` files. Purely read-only.
- **`Reconciler.scanLogs`**: once per app per panel-api lifetime, compares the scan against the app's catalog `rotate:` policy and **WARNs** (slug + dir + bytes):
  - a log-holding dir with **no** rotate policy → *"UNMANAGED log dir"* (an app writing logs somewhere the catalog didn't declare)
  - a **declared** log dir over **1 GiB** → *"oversized — logrotate not running/keeping up"*

Nothing is deleted — the operator gets a loud, structured panel-api log line (slug + dir + bytes), exactly as the issue asks ("reports … instead of deleting blindly").

## Verification
Unit: unmanaged dir warns; declared+small and non-log dirs don't; oversized declared dir warns; once-per-boot. Build + vet + full reconciler/commands suites green. (`du` path reuses the existing, tested `dirSizeBytes`.)

## Remaining JAB-121 phase
Step 6 — surface per-app log disk-usage in the Docker Apps UI (frontend; needs visual QA, deferred until the browser ext is available here).

Refs JAB-121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)