### PR TITLE
feat(ssl): shared-certificate data model + migration (JAB-170 phase 1)

### DIFF
--- a/panel-api/internal/db/migrations/000236_shared_certificates.down.sql
+++ b/panel-api/internal/db/migrations/000236_shared_certificates.down.sql
@@ -1,0 +1,7 @@
+-- Reverse JAB-170 shared certificates.
+ALTER TABLE domains DROP FOREIGN KEY fk_domains_shared_cert;
+ALTER TABLE domains DROP KEY ix_domains_shared_cert;
+ALTER TABLE domains DROP COLUMN shared_certificate_id;
+ALTER TABLE domains
+    MODIFY COLUMN ssl_mode ENUM('le','self','custom','none') NOT NULL DEFAULT 'le';
+DROP TABLE shared_certificates;

--- a/panel-api/internal/db/migrations/000236_shared_certificates.up.sql
+++ b/panel-api/internal/db/migrations/000236_shared_certificates.up.sql
@@ -1,0 +1,41 @@
+-- JAB-170: shared wildcard / multi-SAN certificate — uploaded once, served from
+-- many domains. `shared_certificates` holds one cert/key pair + parsed SANs;
+-- `domains.shared_certificate_id` attaches a domain to one; `ssl_mode` gains
+-- 'shared'. Reconciler treats 'shared' like 'custom' (never ACME/revoke) but
+-- re-renders every attached vhost when the shared cert is replaced.
+CREATE TABLE shared_certificates (
+    id          CHAR(26)     NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    -- user_id NULL = server-wide (admin-owned, attachable to any domain);
+    -- otherwise the owning tenant (attachable only to domains they own).
+    user_id     CHAR(26)     NULL,
+    cert_path   VARCHAR(512) NULL,
+    key_path    VARCHAR(512) NULL,
+    -- sans is a JSON array of the certificate's Subject Alternative Names,
+    -- parsed at upload for wildcard-aware attach matching.
+    sans        TEXT         NULL,
+    expires_at  DATETIME(6)  NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    KEY ix_shared_cert_user (user_id),
+    KEY ix_shared_cert_expires (expires_at),
+    CONSTRAINT fk_shared_cert_user FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;
+
+-- Add 'shared' to the ssl_mode enum (was 'le','self','custom','none').
+ALTER TABLE domains
+    MODIFY COLUMN ssl_mode ENUM('le','self','custom','none','shared') NOT NULL DEFAULT 'le';
+
+-- Attach column + FK. Explicit COLLATE so the FK column matches
+-- shared_certificates.id regardless of the domains table's own collation
+-- (MariaDB FK requires an exact collation match).
+ALTER TABLE domains
+    ADD COLUMN shared_certificate_id CHAR(26) COLLATE utf8mb4_unicode_ci NULL,
+    ADD KEY ix_domains_shared_cert (shared_certificate_id),
+    ADD CONSTRAINT fk_domains_shared_cert FOREIGN KEY (shared_certificate_id)
+        REFERENCES shared_certificates (id) ON DELETE SET NULL;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -139,12 +139,15 @@ const (
 	SSLModeSelf   = "self"
 	SSLModeCustom = "custom"
 	SSLModeNone   = "none"
+	// SSLModeShared: a shared wildcard/multi-SAN cert (JAB-170) attached via
+	// domains.shared_certificate_id. Operator-managed like custom (no ACME).
+	SSLModeShared = "shared"
 )
 
 // ValidSSLMode reports whether s is a recognised TLS cert mode.
 func ValidSSLMode(s string) bool {
 	switch s {
-	case SSLModeLE, SSLModeSelf, SSLModeCustom, SSLModeNone:
+	case SSLModeLE, SSLModeSelf, SSLModeCustom, SSLModeNone, SSLModeShared:
 		return true
 	}
 	return false
@@ -225,7 +228,12 @@ type Domain struct {
 	// SSLEnabled is a derived shadow (mode != 'none') kept in sync on every
 	// write; the reconciler switches on SSLMode. Pinned column tag to match
 	// the other toggles.
-	SSLMode string `gorm:"column:ssl_mode;type:enum('le','self','custom','none');not null;default:'le'" json:"ssl_mode"`
+	SSLMode string `gorm:"column:ssl_mode;type:enum('le','self','custom','none','shared');not null;default:'le'" json:"ssl_mode"`
+
+	// SharedCertificateID attaches this domain to a shared wildcard/multi-SAN
+	// cert (JAB-170) when ssl_mode='shared'; NULL otherwise. FK →
+	// shared_certificates(id) ON DELETE SET NULL.
+	SharedCertificateID *string `gorm:"column:shared_certificate_id;type:char(26)" json:"shared_certificate_id,omitempty"`
 
 	// SSLState is a computed field (not persisted) that represents the actual SSL
 	// certificate state. Values: "active_le" (valid LE cert), "self_signed", "pending",

--- a/panel-api/internal/models/shared_certificate.go
+++ b/panel-api/internal/models/shared_certificate.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// SharedCertificate is a wildcard / multi-SAN TLS certificate uploaded once and
+// served from MANY domains (JAB-170), instead of re-uploading the same cert per
+// subdomain. A domain attaches via domains.shared_certificate_id + ssl_mode
+// 'shared'. Replacing the cert re-renders every attached vhost in one action —
+// the payoff over per-domain custom certs.
+//
+// The cert/key live as ONE pair on disk (not copied per domain); the private
+// key is never readable via the API. UserID NULL = server-wide (admin-owned,
+// attachable to any domain); otherwise the owning tenant (attachable only to
+// domains they own).
+type SharedCertificate struct {
+	ID       string  `gorm:"type:char(26);primaryKey"                       json:"id"`
+	Name     string  `gorm:"type:varchar(255);not null"                     json:"name"`
+	UserID   *string `gorm:"column:user_id;type:char(26);index:ix_shared_cert_user" json:"user_id,omitempty"`
+	CertPath *string `gorm:"type:varchar(512)"                              json:"cert_path,omitempty"`
+	KeyPath  *string `gorm:"type:varchar(512)"                              json:"key_path,omitempty"`
+	// SANs is a JSON array of the certificate's Subject Alternative Names,
+	// parsed at upload and used for wildcard-aware attach matching.
+	SANs      *string    `gorm:"column:sans;type:text"                          json:"sans,omitempty"`
+	ExpiresAt *time.Time `gorm:"type:datetime(6);index:ix_shared_cert_expires"  json:"expires_at,omitempty"`
+	CreatedAt time.Time  `gorm:"type:datetime(6);not null"                      json:"created_at"`
+	UpdatedAt time.Time  `gorm:"type:datetime(6);not null"                      json:"updated_at"`
+}
+
+func (SharedCertificate) TableName() string { return "shared_certificates" }


### PR DESCRIPTION
**Phase 1 of JAB-170** — the data-model foundation for uploading a wildcard / multi-SAN cert **once** and serving it from **many** domains (today a wildcard works only by re-uploading it per subdomain, with N manual renewals).

## Changes
- **Migration 000236:**
  - `shared_certificates` — `id, name, user_id (NULL = server-wide / admin-owned), cert_path, key_path, sans (JSON of parsed SANs), expires_at, timestamps`. FK `user_id → users ON DELETE CASCADE`.
  - `domains.shared_certificate_id CHAR(26)` — FK `→ shared_certificates ON DELETE SET NULL` (detaching a deleted cert reverts the domain to needing its own). Explicit `COLLATE utf8mb4_unicode_ci` on the FK column (MariaDB exact-match requirement).
  - `domains.ssl_mode` enum gains `'shared'`.
- **Models:** `SharedCertificate` + `Domain.SharedCertificateID`; `SSLModeShared` const; `ValidSSLMode` accepts it.

## Inert by design
`'shared'` isn't selectable in the UI and no domain can attach yet — this is scaffolding. Behaviour (agent verb, vhost cert-path resolution, attach/ownership, reconciler re-render, auto-match, UI + CLI) lands in later phases.

## Verification
Build + `TestEmbeddedMigrationsComplete` (numbering) green. **Box-verified** on testserver's live MariaDB: `up` applies cleanly (table + FK + enum-modify + `char(26)` column all succeed), `down` rolls back to a pristine schema.

## Remaining JAB-170 phases
agent install verb + shared storage → per-vhost cert-path resolution → attach/detach API + ownership + reconciler re-render → auto-match on create → UI + CLI → renewal/expiry warnings + ADR.

Refs JAB-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)