### PR TITLE
feat(ssl): ssl.install_shared / ssl.delete_shared agent verbs (JAB-170 phase 2)

### DIFF
--- a/panel-agent/internal/commands/ssl_install_shared.go
+++ b/panel-agent/internal/commands/ssl_install_shared.go
@@ -1,0 +1,124 @@
+// ssl.install_shared / ssl.delete_shared — one cert/key pair per SHARED
+// certificate (JAB-170), stored once under /etc/jabali/ssl/shared/<id>/ and
+// served from MANY domains' vhosts by path (Phase 3 wires the vhost template).
+// Unlike ssl.install_custom (per-domain, under /etc/letsencrypt/live/<domain>),
+// the shared pair is NOT copied per domain — replacing it renews every attached
+// domain in one action. The private key stays root-owned 0600 and never leaves
+// the box.
+
+package commands
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// sslSharedRoot is a var (not const) so tests can point it at a temp dir.
+var sslSharedRoot = "/etc/jabali/ssl/shared"
+
+// A shared-cert id is a ULID (26 Crockford base32 chars). Anchored so it can
+// never escape sslSharedRoot as a path component.
+var sslSharedIDRegex = regexp.MustCompile(`^[0-9A-HJKMNP-TV-Z]{26}$`)
+
+type sslInstallSharedParams struct {
+	ID      string `json:"id"`
+	CertPEM string `json:"cert_pem"`
+	KeyPEM  string `json:"key_pem"`
+}
+
+type sslInstallSharedResponse struct {
+	CertPath  string   `json:"cert_path"`
+	KeyPath   string   `json:"key_path"`
+	SANs      []string `json:"sans"`
+	ExpiresAt string   `json:"expires_at"` // RFC3339
+}
+
+func sslInstallSharedHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p sslInstallSharedParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "parse params: " + err.Error()}
+	}
+	if !sslSharedIDRegex.MatchString(p.ID) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid shared-cert id"}
+	}
+	if strings.TrimSpace(p.CertPEM) == "" || strings.TrimSpace(p.KeyPEM) == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "cert_pem + key_pem required"}
+	}
+	leaf, err := parseLeafCert(p.CertPEM)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "cert_pem: " + err.Error()}
+	}
+	if err := validateKeyMatchesCert(p.KeyPEM, leaf); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
+
+	dir := filepath.Join(sslSharedRoot, p.ID)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "mkdir shared: " + err.Error()}
+	}
+	certPath := filepath.Join(dir, "fullchain.pem")
+	keyPath := filepath.Join(dir, "privkey.pem")
+	if err := writeAtomic(certPath, []byte(strings.TrimSpace(p.CertPEM)+"\n"), 0o644); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "write cert: " + err.Error()}
+	}
+	if err := writeAtomic(keyPath, []byte(strings.TrimSpace(p.KeyPEM)+"\n"), 0o600); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "write key: " + err.Error()}
+	}
+
+	return sslInstallSharedResponse{
+		CertPath:  certPath,
+		KeyPath:   keyPath,
+		SANs:      certSANs(leaf),
+		ExpiresAt: leaf.NotAfter.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// certSANs returns the certificate's DNS SANs, lowercased + deduped. Falls back
+// to the CN when a (legacy) cert carries no DNS SANs. This is the set the panel
+// stores + matches domains against for wildcard-aware attach.
+func certSANs(leaf *x509.Certificate) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(leaf.DNSNames))
+	for _, n := range leaf.DNSNames {
+		n = strings.ToLower(strings.TrimSpace(n))
+		if n != "" && !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	if len(out) == 0 && strings.TrimSpace(leaf.Subject.CommonName) != "" {
+		out = append(out, strings.ToLower(strings.TrimSpace(leaf.Subject.CommonName)))
+	}
+	return out
+}
+
+// ssl.delete_shared removes a shared cert's on-disk pair. Idempotent: a missing
+// dir is success.
+func sslDeleteSharedHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "parse: " + err.Error()}
+	}
+	if !sslSharedIDRegex.MatchString(p.ID) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid shared-cert id"}
+	}
+	if err := os.RemoveAll(filepath.Join(sslSharedRoot, p.ID)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "rm shared: " + err.Error()}
+	}
+	return map[string]any{"ok": true}, nil
+}
+
+func init() {
+	Default.Register("ssl.install_shared", sslInstallSharedHandler)
+	Default.Register("ssl.delete_shared", sslDeleteSharedHandler)
+}

--- a/panel-agent/internal/commands/ssl_install_shared_test.go
+++ b/panel-agent/internal/commands/ssl_install_shared_test.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func genTestCertKey(t *testing.T, dnsNames []string, cn string) (certPEM, keyPEM string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(90 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+	return
+}
+
+const testSharedULID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+// JAB-170 phase 2: install writes the pair under sslSharedRoot/<id> with a
+// root-only key, reports deduped+lowercased SANs and an expiry; delete removes
+// it.
+func TestSSLInstallShared_WritesAndReports(t *testing.T) {
+	tmp := t.TempDir()
+	old := sslSharedRoot
+	sslSharedRoot = tmp
+	defer func() { sslSharedRoot = old }()
+
+	certPEM, keyPEM := genTestCertKey(t, []string{"*.example.com", "Example.com"}, "example.com")
+	raw, _ := json.Marshal(map[string]any{"id": testSharedULID, "cert_pem": certPEM, "key_pem": keyPEM})
+	out, err := sslInstallSharedHandler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	resp, ok := out.(sslInstallSharedResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", out)
+	}
+
+	if _, e := os.Stat(filepath.Join(tmp, testSharedULID, "fullchain.pem")); e != nil {
+		t.Error("cert file not written")
+	}
+	ki, e := os.Stat(filepath.Join(tmp, testSharedULID, "privkey.pem"))
+	if e != nil {
+		t.Fatalf("key file not written: %v", e)
+	}
+	if ki.Mode().Perm() != 0o600 {
+		t.Errorf("key perm = %o, want 0600", ki.Mode().Perm())
+	}
+	if !reflect.DeepEqual(resp.SANs, []string{"*.example.com", "example.com"}) {
+		t.Errorf("SANs = %v, want [*.example.com example.com]", resp.SANs)
+	}
+	if resp.ExpiresAt == "" {
+		t.Error("empty ExpiresAt")
+	}
+
+	// delete → dir gone; idempotent on a second delete.
+	draw, _ := json.Marshal(map[string]any{"id": testSharedULID})
+	if _, e := sslDeleteSharedHandler(context.Background(), draw); e != nil {
+		t.Fatalf("delete: %v", e)
+	}
+	if _, e := os.Stat(filepath.Join(tmp, testSharedULID)); !os.IsNotExist(e) {
+		t.Error("dir not removed")
+	}
+	if _, e := sslDeleteSharedHandler(context.Background(), draw); e != nil {
+		t.Errorf("second delete should be idempotent, got %v", e)
+	}
+}
+
+// Bad id, empty cert, and a key that doesn't pair with the cert are all rejected
+// before any write.
+func TestSSLInstallShared_Rejections(t *testing.T) {
+	tmp := t.TempDir()
+	old := sslSharedRoot
+	sslSharedRoot = tmp
+	defer func() { sslSharedRoot = old }()
+
+	certPEM, keyPEM := genTestCertKey(t, []string{"a.com"}, "a.com")
+	_, otherKey := genTestCertKey(t, []string{"b.com"}, "b.com")
+	for _, c := range []struct{ name, id, cert, key string }{
+		{"bad id (path escape)", "../../etc/passwd", certPEM, keyPEM},
+		{"non-ulid id", "not-a-ulid", certPEM, keyPEM},
+		{"empty cert", testSharedULID, "", keyPEM},
+		{"mismatched key", testSharedULID, certPEM, otherKey},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			raw, _ := json.Marshal(map[string]any{"id": c.id, "cert_pem": c.cert, "key_pem": c.key})
+			if _, err := sslInstallSharedHandler(context.Background(), raw); err == nil {
+				t.Errorf("expected rejection")
+			}
+		})
+	}
+	// nothing should have been written.
+	if ents, _ := os.ReadDir(tmp); len(ents) != 0 {
+		t.Errorf("rejections wrote files: %v", ents)
+	}
+}


### PR DESCRIPTION
**Phase 2 of JAB-170** — the agent verb + shared on-disk storage. One cert/key pair per shared certificate, stored once and served from many domains by path (not copied per domain — the whole point).

## Verbs
- **`ssl.install_shared(id, cert_pem, key_pem)`** — validates the pair (reuses `parseLeafCert` + `validateKeyMatchesCert` from the box-proven `ssl.install_custom`), atomic-writes to `/etc/jabali/ssl/shared/<id>/{fullchain.pem,privkey.pem}` (cert `0644`, **key `0600`**, root-owned), and returns the **deduped + lowercased DNS SANs** + `NotAfter` so the panel can store them for wildcard-aware attach.
- **`ssl.delete_shared(id)`** — idempotent removal of the on-disk pair.

## Safety
- `id` is validated as a ULID, so it can never escape the shared root as a path component (a `../../etc/passwd` id is rejected).
- The private key is written `0600` root-owned and never leaves the box.

## Inert until Phase 3
Nothing serves these files yet — Phase 3 gives the per-domain nginx vhost template a shared cert-path branch.

## Verification
Unit (self-signed cert generated in-test): install writes the pair with a `0600` key + correct SANs (`*.example.com`, `example.com` — deduped/lowercased) + expiry; delete removes it and is idempotent; **every** rejection (path-escaping id, non-ULID id, empty cert, key that doesn't pair the cert) is blocked **before any write**. Build + vet + full commands suite green. (The write path reuses the same `writeAtomic` helper already deployed for custom certs.)

Refs JAB-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)