### PR TITLE
feat(ssl): resolve shared cert path in the domain vhost render (JAB-170 phase 3)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1633,7 +1634,12 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 	// only state we deliberately skip is 'revoked' — those rows have their
 	// cert_path cleared by sslRevokeForDomain so the check is belt-and-
 	// braces.
-	if r.sslCerts != nil {
+	// JAB-170: a shared-cert domain serves the ONE shared pair by path,
+	// independent of any per-domain ssl_certificates row. The agent stats the
+	// path and falls back to HTTP if the shared cert is not on disk yet.
+	if domain.SSLMode == models.SSLModeShared && domain.SharedCertificateID != nil && *domain.SharedCertificateID != "" {
+		params["ssl_cert_path"], params["ssl_key_path"] = sharedCertPaths(*domain.SharedCertificateID)
+	} else if r.sslCerts != nil {
 		sslCtx, sslCancel := context.WithTimeout(ctx, 10*time.Second)
 		cert, err := r.sslCerts.FindByDomainID(sslCtx, domain.ID)
 		sslCancel()
@@ -1654,6 +1660,19 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			"domain", domain.Name,
 			"err", err)
 	}
+}
+
+// sharedCertDir mirrors the agent's sslSharedRoot: /etc/jabali/ssl/shared/<id>
+// holds the ONE cert/key pair a shared certificate serves from every attached
+// domain (JAB-170).
+const sharedCertDir = "/etc/jabali/ssl/shared"
+
+// sharedCertPaths returns the on-disk fullchain + privkey paths for a shared
+// certificate id. The agent stat-guards them, so an id whose cert has not been
+// installed yet renders as HTTP-only rather than a broken :443 block.
+func sharedCertPaths(id string) (certPath, keyPath string) {
+	dir := filepath.Join(sharedCertDir, id)
+	return filepath.Join(dir, "fullchain.pem"), filepath.Join(dir, "privkey.pem")
 }
 
 // reconcileDockerAppDomain renders the proxy-only nginx vhost for a
@@ -1704,7 +1723,9 @@ func (r *Reconciler) reconcileDockerAppDomain(ctx context.Context, domain *model
 	// self-signed fallback on every ACME failure, so this populates
 	// within a tick of the domain appearing.
 	var certPath, keyPath string
-	if r.sslCerts != nil {
+	if domain.SSLMode == models.SSLModeShared && domain.SharedCertificateID != nil && *domain.SharedCertificateID != "" {
+		certPath, keyPath = sharedCertPaths(*domain.SharedCertificateID)
+	} else if r.sslCerts != nil {
 		sslCtx, sslCancel := context.WithTimeout(ctx, 10*time.Second)
 		cert, err := r.sslCerts.FindByDomainID(sslCtx, domain.ID)
 		sslCancel()

--- a/panel-api/internal/reconciler/shared_cert_path_test.go
+++ b/panel-api/internal/reconciler/shared_cert_path_test.go
@@ -1,0 +1,17 @@
+package reconciler
+
+import "testing"
+
+// JAB-170 phase 3: a shared-cert domain's vhost points at the ONE shared pair
+// under /etc/jabali/ssl/shared/<id>/, matching the agent's sslSharedRoot.
+func TestSharedCertPaths(t *testing.T) {
+	cert, key := sharedCertPaths("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	wantCert := "/etc/jabali/ssl/shared/01ARZ3NDEKTSV4RRFFQ69G5FAV/fullchain.pem"
+	wantKey := "/etc/jabali/ssl/shared/01ARZ3NDEKTSV4RRFFQ69G5FAV/privkey.pem"
+	if cert != wantCert {
+		t.Errorf("cert = %q, want %q", cert, wantCert)
+	}
+	if key != wantKey {
+		t.Errorf("key = %q, want %q", key, wantKey)
+	}
+}


### PR DESCRIPTION
**Phase 3 of JAB-170** — the issue's flagged *riskiest* step: per-vhost cert-path resolution. Done conservatively so it can't touch the existing render.

## Change
The per-domain nginx vhost render (reconciler → `domain.create`) resolves the cert path by `ssl_mode`:
- **`ssl_mode='shared'`** with a `shared_certificate_id` → serves the ONE shared pair at `/etc/jabali/ssl/shared/<id>/{fullchain,privkey}.pem`.
- everything else → unchanged (`/etc/letsencrypt/live/<domain>/…` from the per-domain `ssl_certificates` row).

Applied to **both** vhost paths — the regular hosted-domain render and the docker-app proxy render — via a shared `sharedCertPaths(id)` helper (mirrors the agent's `sslSharedRoot`).

## Why it's low-risk
- The `le`/`self`/`custom` resolution is **untouched** — the shared branch is purely additive, taken only when `ssl_mode='shared'`.
- The nginx template itself is unchanged (same `ssl_certificate {{.SSLCertPath}}` directive, only a different path value).
- The agent already **stat-guards** `ssl_cert_path` (blanks it if the file is missing → HTTP-only), so a shared domain whose cert isn't on disk yet renders cleanly instead of a broken `:443` block that would fail `nginx -t` and abort `domain.create`.

## Inert until Phase 4
No domain can be set to `'shared'` or attached yet — that's the Phase 4 attach API. So this plumbing changes nothing for existing domains.

## Verification
`sharedCertPaths` unit-tested; full reconciler suite green (existing domain-render tests unaffected). End-to-end nginx box-verify (a shared cert serving multiple domains + `nginx -t`) lands with Phase 4, when a domain can actually be attached.

Refs JAB-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)