### PR TITLE
feat(ssl): auto-attach a covering shared cert on domain create (JAB-170 phase 5)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -27,12 +27,13 @@ import (
 )
 
 type DomainHandlerConfig struct {
-	Domains    repository.DomainRepository
-	Users      repository.UserRepository
-	SSLCerts   repository.SSLCertificateRepository
-	Packages   repository.PackageRepository
-	Agent      agent.AgentInterface
-	Reconciler *reconciler.Reconciler
+	Domains     repository.DomainRepository
+	Users       repository.UserRepository
+	SSLCerts    repository.SSLCertificateRepository
+	SharedCerts repository.SharedCertificateRepository
+	Packages    repository.PackageRepository
+	Agent       agent.AgentInterface
+	Reconciler  *reconciler.Reconciler
 	// DNSZones + DNSRecords feed the auto-enable-email path on create.
 	// Both optional — when unset, create proceeds without flipping email
 	// on (matches the pre-auto-enable behaviour). The explicit
@@ -541,6 +542,24 @@ func (h *domainHandler) get(c *gin.Context) {
 	c.JSON(http.StatusOK, h.enrichDomainResponse(c.Request.Context(), *domain))
 }
 
+// findCoveringSharedCert returns a shared cert (server-wide or owned by
+// ownerID) whose SANs cover host, or nil (JAB-170 phase 5 auto-attach).
+func (h *domainHandler) findCoveringSharedCert(ctx context.Context, host, ownerID string) *models.SharedCertificate {
+	if h.cfg.SharedCerts == nil {
+		return nil
+	}
+	certs, err := h.cfg.SharedCerts.ListServerWideAndOwned(ctx, ownerID)
+	if err != nil {
+		return nil
+	}
+	for i := range certs {
+		if sharedCertCoversHost(certs[i].SANs, host) {
+			return &certs[i]
+		}
+	}
+	return nil
+}
+
 func (h *domainHandler) create(c *gin.Context) {
 	claims := ginctx.Claims(c)
 	if claims == nil {
@@ -678,6 +697,10 @@ func (h *domainHandler) create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "ssl_mode_custom_requires_upload", "detail": "create the domain with le/self/none, then upload a custom cert via the SSL settings"})
 		return
 	}
+	if sslMode == models.SSLModeShared {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ssl_mode_shared_requires_attach", "detail": "create the domain with le/self/none, then attach a shared cert via POST /domains/:id/ssl/shared"})
+		return
+	}
 
 	mailEnabled, mailSkipSAN := models.DeriveMailFlags(mailProvider)
 	// Email-enabled + no TLS is contradictory (MTA-STS / autoconfig need HTTPS).
@@ -721,9 +744,26 @@ func (h *domainHandler) create(c *gin.Context) {
 		return
 	}
 
+	// JAB-170 phase 5: if a shared cert (server-wide or the owner's) covers the
+	// new hostname, auto-attach so a matching subdomain gets HTTPS instantly —
+	// no ACME, no upload — and skip the ACME inline below.
+	attachedShared := false
+	if h.cfg.SharedCerts != nil {
+		if cert := h.findCoveringSharedCert(ctx, domain.Name, domain.UserID); cert != nil {
+			if err := h.cfg.Domains.SetSharedCertificate(ctx, domain.ID, &cert.ID, models.SSLModeShared); err == nil {
+				domain.SSLMode = models.SSLModeShared
+				domain.SharedCertificateID = &cert.ID
+				attachedShared = true
+				if h.cfg.Reconciler != nil {
+					h.cfg.Reconciler.Schedule(domain.ID)
+				}
+			}
+		}
+	}
+
 	// Attempt SSL inline (30s timeout): try ACME first with fallback to self-signed.
 	// Never errors out — just logs; cert state is already in DB.
-	if h.cfg.Reconciler != nil {
+	if !attachedShared && h.cfg.Reconciler != nil {
 		inlineCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		h.cfg.Reconciler.ReconcileSSLInline(inlineCtx, domain)
 		cancel()

--- a/panel-api/internal/api/ssl_shared_test.go
+++ b/panel-api/internal/api/ssl_shared_test.go
@@ -88,6 +88,13 @@ func (r *fakeSharedRepo) ListAll(_ context.Context) ([]models.SharedCertificate,
 func (r *fakeSharedRepo) ListByUserID(_ context.Context, _ string) ([]models.SharedCertificate, error) {
 	return nil, nil
 }
+func (r *fakeSharedRepo) ListServerWideAndOwned(_ context.Context, _ string) ([]models.SharedCertificate, error) {
+	out := make([]models.SharedCertificate, 0, len(r.created))
+	for _, c := range r.created {
+		out = append(out, *c)
+	}
+	return out, nil
+}
 func (r *fakeSharedRepo) UpdateInstalled(_ context.Context, _, _, _, _ string, _ time.Time) error {
 	return nil
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -565,12 +565,13 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainRoutes(v1, api.DomainHandlerConfig{
-				Domains:    deps.Domains,
-				Users:      deps.Users,
-				Packages:   deps.Packages,
-				Agent:      deps.Agent,
-				Reconciler: deps.Reconciler,
-				SSLCerts:   deps.SSLCerts,
+				Domains:     deps.Domains,
+				Users:       deps.Users,
+				Packages:    deps.Packages,
+				Agent:       deps.Agent,
+				Reconciler:  deps.Reconciler,
+				SSLCerts:    deps.SSLCerts,
+				SharedCerts: deps.SharedCerts,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.

--- a/panel-api/internal/repository/shared_certificate_repository.go
+++ b/panel-api/internal/repository/shared_certificate_repository.go
@@ -19,6 +19,9 @@ type SharedCertificateRepository interface {
 	ListAll(ctx context.Context) ([]models.SharedCertificate, error)
 	// ListByUserID returns a tenant's own shared certs, newest first.
 	ListByUserID(ctx context.Context, userID string) ([]models.SharedCertificate, error)
+	// ListServerWideAndOwned returns candidates a domain owned by ownerID may
+	// auto-attach: server-wide certs (user_id NULL) plus the owner's own.
+	ListServerWideAndOwned(ctx context.Context, ownerID string) ([]models.SharedCertificate, error)
 	// UpdateInstalled records the on-disk paths + parsed SANs + expiry after a
 	// (re)upload landed the pair on disk.
 	UpdateInstalled(ctx context.Context, id, certPath, keyPath, sansJSON string, expiresAt time.Time) error
@@ -58,6 +61,12 @@ func (r *sharedCertificateRepo) ListAll(ctx context.Context) ([]models.SharedCer
 func (r *sharedCertificateRepo) ListByUserID(ctx context.Context, userID string) ([]models.SharedCertificate, error) {
 	var cs []models.SharedCertificate
 	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&cs).Error
+	return cs, err
+}
+
+func (r *sharedCertificateRepo) ListServerWideAndOwned(ctx context.Context, ownerID string) ([]models.SharedCertificate, error) {
+	var cs []models.SharedCertificate
+	err := r.db.WithContext(ctx).Where("user_id IS NULL OR user_id = ?", ownerID).Find(&cs).Error
 	return cs, err
 }
 


### PR DESCRIPTION
**Phase 5 of JAB-170** — auto-attach. On domain create, if a shared cert (server-wide or the domain owner's) covers the new hostname, auto-attach it so a matching subdomain gets HTTPS instantly (no ACME, no upload). Inline ACME is skipped when it attaches.

- `ListServerWideAndOwned(ownerID)` + `findCoveringSharedCert` (reuses the wildcard-aware SAN matcher).
- Reject `ssl_mode='shared'` at create (like `custom`) — attach after create, or the auto-match does it.
- Wired `SharedCerts` into the domain handler.

Build + `go vet ./...` + api/repository suites green. Remaining JAB-170: 6 UI+CLI, 7 expiry.

Refs JAB-170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)