### PR TITLE
docs(cli): regenerate CLI reference golden for jabali ssl shared (fixes #663 CI red)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4739,6 +4739,73 @@ jabali ssl set-custom [flags]
 - `--domain` — domain name or id (required)
 - `--key` — path to the private key PEM file (required)
 
+#### `jabali ssl shared`
+
+Manage shared wildcard/multi-SAN certificates (upload once, serve many domains)
+
+```
+jabali ssl shared
+```
+
+##### `jabali ssl shared attach`
+
+Attach a domain to a shared certificate (must cover the domain)
+
+```
+jabali ssl shared attach --domain <name> --cert-id <id> [flags]
+```
+
+**Flags:**
+
+- `--cert-id` — shared certificate id
+- `--domain` — domain name
+
+##### `jabali ssl shared delete`
+
+Delete a shared certificate (fails if domains are still attached)
+
+```
+jabali ssl shared delete --id <id> [flags]
+```
+
+**Flags:**
+
+- `--id` — shared certificate id
+
+##### `jabali ssl shared detach`
+
+Detach a domain from its shared certificate (reverts to LE)
+
+```
+jabali ssl shared detach --domain <name> [flags]
+```
+
+**Flags:**
+
+- `--domain` — domain name
+
+##### `jabali ssl shared list`
+
+List shared certificates + their attached-domain counts
+
+```
+jabali ssl shared list
+```
+
+##### `jabali ssl shared upload`
+
+Upload a server-wide shared certificate (agent validates + writes it)
+
+```
+jabali ssl shared upload --name <name> --cert <fullchain.pem> --key <privkey.pem> [flags]
+```
+
+**Flags:**
+
+- `--cert` — path to fullchain PEM
+- `--key` — path to private key PEM
+- `--name` — human-readable name
+
 ### `jabali sso`
 
 SSO (Single Sign-On) management commands


### PR DESCRIPTION
## Why

#663 (`jabali ssl shared` CLI) added a new Cobra command subtree but did not regenerate the committed CLI reference golden file. `TestCLIReferenceGolden` (`panel-api/cmd/server`) compares the live command tree against `docs/site/platform/cli-reference.md` and failed — turning the "Go tests + vet" job red on main (run 30098095797). This is now on main + stable + testserver.

## Fix

Regenerated the golden via the sanctioned path:
```
go test ./panel-api/cmd/server -run TestCLIReferenceGolden -update
```
Diff is purely additive: the `jabali ssl shared` {list,upload,attach,detach,delete} subtree (+67 lines). No command behavior changes.

## Test plan
- [x] `go test -race ./panel-api/cmd/server` → ok
- [x] Golden diff reviewed: only the new shared-cert subtree added

🤖 Generated with [Claude Code](https://claude.com/claude-code)