### PR TITLE
feat(ssl): admin GUI for shared certificates (JAB-170 phase 8)

### DIFF
--- a/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
+++ b/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
@@ -1,0 +1,337 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Input,
+  Modal,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  Upload,
+  message,
+} from "antd";
+import type { UploadFile } from "antd";
+import { DeleteOutlined, PlusOutlined, UploadOutlined } from "@icons";
+
+import { apiClient } from "../../apiClient";
+
+// SharedCertificatesCard — admin surface for JAB-170 shared wildcard/multi-SAN
+// certificates: upload one cert, serve it from many domains. Sibling of the
+// per-domain SSLManagerTable; lives on the SSL Manager page beneath the
+// per-domain certificate list. The private key is write-only — it is sent on
+// upload and never returned by the list endpoint.
+
+interface SharedCert {
+  id: string;
+  name: string;
+  sans: string[];
+  expires_at?: string;
+  attached_domains: number;
+}
+
+const daysUntil = (iso?: string): number | null => {
+  if (!iso) return null;
+  const diff = new Date(iso).getTime() - Date.now();
+  return Math.round(diff / 86_400_000);
+};
+
+const formatExpiry = (iso?: string): JSX.Element => {
+  if (!iso) return <span>—</span>;
+  const date = new Date(iso);
+  const dateStr = date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  const days = daysUntil(iso);
+  if (days === null) return <span>{dateStr}</span>;
+  const label = days < 0 ? "expired" : days === 0 ? "today" : `in ${days} days`;
+  return (
+    <Typography.Text type={days < 14 ? "danger" : undefined}>
+      {dateStr} ({label})
+    </Typography.Text>
+  );
+};
+
+// readFileText resolves a picked file's text so the operator can select a .pem
+// off disk instead of pasting. Returning false from beforeUpload keeps antd
+// from actually POSTing the file anywhere.
+const readFileText = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+
+export const SharedCertificatesCard = () => {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [certPem, setCertPem] = useState("");
+  const [keyPem, setKeyPem] = useState("");
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["shared-certificates"],
+    queryFn: async () => {
+      const res = await apiClient.get("/admin/certificates/shared");
+      return (res.data?.data ?? []) as SharedCert[];
+    },
+  });
+
+  const resetForm = () => {
+    setName("");
+    setCertPem("");
+    setKeyPem("");
+  };
+
+  const uploadMutation = useMutation({
+    mutationFn: async () => {
+      await apiClient.post("/admin/certificates/shared", {
+        name: name.trim(),
+        cert_pem: certPem,
+        key_pem: keyPem,
+      });
+    },
+    onSuccess: () => {
+      message.success("Shared certificate uploaded");
+      setUploadOpen(false);
+      resetForm();
+      queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
+    },
+    onError: (err: unknown) => {
+      const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
+      message.error(resp?.detail ?? resp?.error ?? "Failed to upload certificate");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) => {
+      await apiClient.delete(`/admin/certificates/shared/${id}`);
+    },
+    onSuccess: () => {
+      message.success("Shared certificate deleted");
+      queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
+    },
+    onError: (err: unknown) => {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        message.info("Detach every domain from this certificate first");
+      } else {
+        message.error("Failed to delete certificate");
+      }
+    },
+  });
+
+  const submitUpload = () => {
+    if (!name.trim()) {
+      message.error("Give the certificate a name");
+      return;
+    }
+    if (!certPem.trim() || !keyPem.trim()) {
+      message.error("Paste both the certificate and the private key");
+      return;
+    }
+    uploadMutation.mutate();
+  };
+
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name",
+      sorter: (a: SharedCert, b: SharedCert) => a.name.localeCompare(b.name),
+      defaultSortOrder: "ascend" as const,
+      render: (name: string) => <span style={{ fontWeight: 500 }}>{name}</span>,
+    },
+    {
+      title: "SANs",
+      dataIndex: "sans",
+      key: "sans",
+      render: (sans: string[]) => {
+        const list = sans ?? [];
+        if (list.length === 0) return <span>—</span>;
+        return (
+          <Space size={4} wrap>
+            {list.slice(0, 3).map((s) => (
+              <Tag key={s} style={{ fontFamily: "monospace" }}>
+                {s}
+              </Tag>
+            ))}
+            {list.length > 3 && (
+              <Tooltip title={list.join(", ")}>
+                <Tag>+{list.length - 3} more</Tag>
+              </Tooltip>
+            )}
+          </Space>
+        );
+      },
+    },
+    {
+      title: "Expires",
+      dataIndex: "expires_at",
+      key: "expires_at",
+      sorter: (a: SharedCert, b: SharedCert) =>
+        (a.expires_at ? +new Date(a.expires_at) : 0) - (b.expires_at ? +new Date(b.expires_at) : 0),
+      render: (iso?: string) => formatExpiry(iso),
+    },
+    {
+      title: "Attached domains",
+      dataIndex: "attached_domains",
+      key: "attached_domains",
+      sorter: (a: SharedCert, b: SharedCert) => a.attached_domains - b.attached_domains,
+      render: (n: number) =>
+        n > 0 ? <Tag color="blue">{n}</Tag> : <Typography.Text type="secondary">0</Typography.Text>,
+    },
+    {
+      title: "Actions",
+      key: "actions",
+      render: (_: unknown, record: SharedCert) => (
+        <Popconfirm
+          title="Delete shared certificate?"
+          description={
+            record.attached_domains > 0
+              ? `${record.attached_domains} domain(s) still use it — detach them first.`
+              : "This removes the certificate from disk."
+          }
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          onConfirm={() => deleteMutation.mutate(record.id)}
+        >
+          <Button danger size="small" icon={<DeleteOutlined />} loading={deleteMutation.isPending}>
+            Delete
+          </Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  return (
+    <Card
+      title={t("sharedcertificates.title")}
+      extra={
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+          Upload shared certificate
+        </Button>
+      }
+    >
+      <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+        Upload a wildcard or multi-SAN certificate once, then attach it to any
+        covering domain from that domain&apos;s SSL tab. The reconciler renders
+        the shared pair into each attached domain&apos;s vhost.
+      </Typography.Paragraph>
+
+      {error ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="Failed to load shared certificates" />
+      ) : !data || data.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No shared certificates yet"
+        />
+      ) : (
+        <Table
+          dataSource={data}
+          columns={columns}
+          rowKey="id"
+          loading={isLoading}
+          pagination={{ pageSize: 10, showSizeChanger: true }}
+          scroll={{ x: "max-content" }}
+        />
+      )}
+
+      <Modal
+        open={uploadOpen}
+        title="Upload shared certificate"
+        okText="Upload"
+        confirmLoading={uploadMutation.isPending}
+        onOk={submitUpload}
+        onCancel={() => {
+          setUploadOpen(false);
+          resetForm();
+        }}
+        width={680}
+        destroyOnClose
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <Alert
+            type="info"
+            showIcon
+            message="Paste the full-chain certificate (leaf + intermediates) and its private key, or pick the .pem files. The key is stored 0600, root-owned, and never shown again."
+          />
+          <div>
+            <div style={{ marginBottom: 4 }}>Name</div>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. *.example.com wildcard"
+              maxLength={128}
+            />
+          </div>
+          <div>
+            <Space style={{ marginBottom: 4 }} align="center">
+              <span>Certificate (PEM)</span>
+              <Upload
+                accept=".pem,.crt,.cer,.txt"
+                maxCount={1}
+                showUploadList={false}
+                beforeUpload={(file: UploadFile & File) => {
+                  readFileText(file)
+                    .then((text) => setCertPem(text))
+                    .catch(() => message.error("Could not read the certificate file"));
+                  return false;
+                }}
+              >
+                <Button size="small" icon={<UploadOutlined />}>
+                  Pick file
+                </Button>
+              </Upload>
+            </Space>
+            <Input.TextArea
+              rows={6}
+              value={certPem}
+              onChange={(e) => setCertPem(e.target.value)}
+              placeholder="-----BEGIN CERTIFICATE-----"
+              style={{ fontFamily: "monospace" }}
+            />
+          </div>
+          <div>
+            <Space style={{ marginBottom: 4 }} align="center">
+              <span>Private key (PEM)</span>
+              <Upload
+                accept=".pem,.key,.txt"
+                maxCount={1}
+                showUploadList={false}
+                beforeUpload={(file: UploadFile & File) => {
+                  readFileText(file)
+                    .then((text) => setKeyPem(text))
+                    .catch(() => message.error("Could not read the key file"));
+                  return false;
+                }}
+              >
+                <Button size="small" icon={<UploadOutlined />}>
+                  Pick file
+                </Button>
+              </Upload>
+            </Space>
+            <Input.TextArea
+              rows={6}
+              value={keyPem}
+              onChange={(e) => setKeyPem(e.target.value)}
+              placeholder="-----BEGIN PRIVATE KEY-----"
+              style={{ fontFamily: "monospace" }}
+            />
+          </div>
+        </Space>
+      </Modal>
+    </Card>
+  );
+};

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -508,6 +508,9 @@
   },
   "domainsslsection": {
     "acme_issuance_failed": "ACME issuance failed",
+    "attach": "Attach",
+    "attach_shared_certificate": "Attach shared certificate",
+    "only_shared_certificates_that_cover_this_dom": "Only shared certificates that cover this domain are listed. The reconciler re-renders the vhost within a tick of attaching.",
     "install": "Install",
     "paste_the_full_chain_certificate_leaf_interm": "Paste the full-chain certificate (leaf + intermediates) and the matching private key in PEM format. The key is stored on the server and never shown again.",
     "set_an_admin_email_to_use_ssl": "Set an admin email to use SSL",
@@ -517,6 +520,9 @@
   },
   "domainskipautosantoggle": {
     "skip_auto_added_san_names": "Skip auto-added SAN names"
+  },
+  "sharedcertificates": {
+    "title": "Shared Certificates"
   },
   "adminiplist": {
     "actions": "Actions",

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -164,6 +164,7 @@ export const DomainEdit = () => {
       <Space direction="vertical" style={{ width: "100%" }} size="large">
         <DomainSSLSection
           domainId={domain.id}
+          domainName={domain.name}
           sslEnabled={!!domain.ssl_enabled}
           onToggled={() =>
             qc.invalidateQueries({ queryKey: ["one", "domains", id] })

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -53,11 +53,40 @@ function daysUntil(iso?: string): number | null {
 
 type Props = {
   domainId: string;
+  domainName: string;
   sslEnabled: boolean;
   onToggled: () => void;
 };
 
-export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => {
+// Shared wildcard/multi-SAN certificate (JAB-170) — a server-wide or
+// tenant-owned cert an admin uploaded once via the SSL Manager page.
+type SharedCert = {
+  id: string;
+  name: string;
+  sans: string[];
+  expires_at?: string;
+};
+
+// hostMatchesSAN mirrors the API's wildcard-aware matcher (x509.VerifyHostname
+// semantics): exact, or a single-label wildcard. The server re-checks on
+// attach; this just filters the picker to covering certs.
+function hostMatchesSAN(san: string, host: string): boolean {
+  const s = san.trim().toLowerCase();
+  const h = host.trim().toLowerCase();
+  if (!s || !h) return false;
+  if (s === h) return true;
+  if (s.startsWith("*.")) {
+    const base = s.slice(2);
+    const dot = h.indexOf(".");
+    if (dot > 0 && h.slice(dot + 1) === base) return true;
+  }
+  return false;
+}
+
+const certCoversHost = (cert: SharedCert, host: string): boolean =>
+  (cert.sans ?? []).some((s) => hostMatchesSAN(s, host));
+
+export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }: Props) => {
   const { t } = useTranslation();
   const [cert, setCert] = useState<SSLCertificate | null>(null);
   const [certMissing, setCertMissing] = useState(false);
@@ -70,6 +99,11 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
   const [certPem, setCertPem] = useState("");
   const [keyPem, setKeyPem] = useState("");
   const [uploading, setUploading] = useState(false);
+  const [sharedCertId, setSharedCertId] = useState<string | undefined>(undefined);
+  const [sharedPickerOpen, setSharedPickerOpen] = useState(false);
+  const [covering, setCovering] = useState<SharedCert[]>([]);
+  const [selectedShared, setSelectedShared] = useState<string | undefined>(undefined);
+  const [sharedBusy, setSharedBusy] = useState(false);
 
   const fetchCert = useCallback(async () => {
     setLoading(true);
@@ -97,15 +131,75 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
       .then((res) => setAdminEmail(res.data?.settings?.admin_email))
       .catch(() => undefined);
     apiClient
-      .get<{ ssl_mode?: string }>(`/domains/${domainId}`)
-      .then((res) => setSslMode(res.data?.ssl_mode ?? "le"))
+      .get<{ ssl_mode?: string; shared_certificate_id?: string }>(`/domains/${domainId}`)
+      .then((res) => {
+        setSslMode(res.data?.ssl_mode ?? "le");
+        setSharedCertId(res.data?.shared_certificate_id);
+      })
       .catch(() => undefined);
   }, [fetchCert, domainId]);
 
 
+  const openSharedPicker = async () => {
+    setSelectedShared(undefined);
+    setSharedPickerOpen(true);
+    try {
+      const res = await apiClient.get("/admin/certificates/shared");
+      const all = (res.data?.data ?? []) as SharedCert[];
+      setCovering(all.filter((c) => certCoversHost(c, domainName)));
+    } catch {
+      setCovering([]);
+      message.error("Failed to load shared certificates");
+    }
+  };
+
+  const attachShared = async () => {
+    if (!selectedShared) {
+      message.error("Choose a shared certificate");
+      return;
+    }
+    setSharedBusy(true);
+    try {
+      await apiClient.post(`/domains/${domainId}/ssl/shared`, {
+        shared_certificate_id: selectedShared,
+      });
+      setSslMode("shared");
+      setSharedCertId(selectedShared);
+      setSharedPickerOpen(false);
+      message.success("Shared certificate attached");
+      onToggled();
+      await fetchCert();
+    } catch (err: unknown) {
+      const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
+      message.error(resp?.detail ?? "Failed to attach shared certificate");
+    } finally {
+      setSharedBusy(false);
+    }
+  };
+
+  const detachShared = async () => {
+    setSharedBusy(true);
+    try {
+      await apiClient.delete(`/domains/${domainId}/ssl/shared`);
+      setSslMode("le");
+      setSharedCertId(undefined);
+      message.success("Shared certificate detached (reverted to Let's Encrypt)");
+      onToggled();
+      await fetchCert();
+    } catch {
+      message.error("Failed to detach shared certificate");
+    } finally {
+      setSharedBusy(false);
+    }
+  };
+
   const applyMode = async (mode: string) => {
     if (mode === "custom") {
       setCustomOpen(true);
+      return;
+    }
+    if (mode === "shared") {
+      await openSharedPicker();
       return;
     }
     setModeChanging(true);
@@ -236,10 +330,26 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
             { value: "le", label: "Let's Encrypt", disabled: !adminEmail && sslMode !== "le" },
             { value: "self", label: "Self-signed" },
             { value: "custom", label: "Custom (upload)" },
+            { value: "shared", label: "Shared certificate" },
             { value: "none", label: "None (HTTP only)" },
           ]}
         />
         <span>TLS certificate</span>
+
+        {sslMode === "shared" && (
+          <>
+            <Tooltip title={sharedCertId ? `Certificate ${sharedCertId}` : undefined}>
+              <Tag color="geekblue">shared</Tag>
+            </Tooltip>
+            <Button
+              size="small"
+              loading={sharedBusy}
+              onClick={detachShared}
+            >
+              Detach
+            </Button>
+          </>
+        )}
 
         {certMissing && sslEnabled && (
           <Tag color="default">pending issuance</Tag>
@@ -305,6 +415,50 @@ export const DomainSSLSection = ({ domainId, sslEnabled, onToggled }: Props) => 
               style={{ fontFamily: "monospace" }}
             />
           </div>
+        </Space>
+      </Modal>
+
+      <Modal
+        open={sharedPickerOpen}
+        title={t("domainsslsection.attach_shared_certificate")}
+        okText={t("domainsslsection.attach")}
+        okButtonProps={{ disabled: !selectedShared }}
+        confirmLoading={sharedBusy}
+        onOk={attachShared}
+        onCancel={() => setSharedPickerOpen(false)}
+        width={560}
+        destroyOnClose
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <Alert
+            type="info"
+            showIcon
+            message={t("domainsslsection.only_shared_certificates_that_cover_this_dom")}
+          />
+          {covering.length === 0 ? (
+            <Alert
+              type="warning"
+              showIcon
+              message={
+                <>
+                  No shared certificate covers <strong>{domainName}</strong>. Upload
+                  one from{" "}
+                  <Link to="/jabali-admin/ssl">SSL Manager</Link>.
+                </>
+              }
+            />
+          ) : (
+            <Select
+              value={selectedShared}
+              style={{ width: "100%" }}
+              placeholder="Choose a covering certificate"
+              onChange={(v) => setSelectedShared(v)}
+              options={covering.map((c) => ({
+                value: c.id,
+                label: `${c.name} — ${(c.sans ?? []).join(", ")}`,
+              }))}
+            />
+          )}
         </Space>
       </Modal>
     </Space>

--- a/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
+++ b/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
@@ -3,6 +3,7 @@ import { Card, Typography } from "antd";
 import { ShieldCheckOutlined } from "@icons";
 
 import { SSLManagerTable } from "../../../components/ssl/SSLManagerTable";
+import { SharedCertificatesCard } from "../../../components/ssl/SharedCertificatesCard";
 import { PanelSSLCard } from "../settings/PanelSSLCard";
 
 export const SSLManagerPage = () => {
@@ -21,12 +22,17 @@ export const SSLManagerPage = () => {
         <PanelSSLCard />
       </div>
 
-      <Card title={t("sslmanagerpage.domain_certificates")}>
+      <Card title={t("sslmanagerpage.domain_certificates")} style={{ marginBottom: 16 }}>
         <SSLManagerTable
           endpoint="/admin/ssl-certificates"
           showOwner={true}
         />
       </Card>
+
+      {/* Shared wildcard/multi-SAN certificates (JAB-170): upload once,
+          attach to many covering domains from each domain's SSL tab.
+          Owns its own data loading + upload/delete state. */}
+      <SharedCertificatesCard />
     </div>
   );
 };


### PR DESCRIPTION
## What

Completes JAB-170 by wiring the shared wildcard/multi-SAN certificate feature (backend shipped in #654–#663) into the panel UI.

### Admin — SSL Manager page
New **Shared Certificates** card beneath the per-domain cert list:
- Lists shared certs: name, SANs (first 3 + `+N more`), expiry (<14d shows in danger red), attached-domain count.
- **Upload**: name + full-chain PEM + private-key PEM. Paste, or pick a `.pem` off disk (read client-side; nothing is POSTed to antd). → `POST /admin/certificates/shared`.
- **Delete**: `DELETE /admin/certificates/shared/:id`; a 409 (domains still attached) surfaces "detach them first" instead of a generic error.
- Private key is write-only — the list endpoint never returns it.

### Per-domain — domain SSL tab
`DomainSSLSection` gains a **Shared certificate** mode in the existing cert-mode `Select`:
- Picking it opens a modal listing **only** shared certs whose SANs cover this domain (wildcard-aware client-side filter mirroring `x509.VerifyHostname`; the server re-checks on attach). → `POST /domains/:id/ssl/shared`.
- A domain on shared mode shows a `shared` tag + **Detach** (→ `DELETE .../ssl/shared`, reverts to Let's Encrypt).
- No covering cert → a warning links to the SSL Manager to upload one.

## Test plan
- [x] `npx tsc -b` — clean
- [x] `eslint` (all changed files) — clean
- [x] `npm run build` — built
- [x] `vitest run` — 32 files / 146 tests passing
- [ ] Visual QA in a browser against a live panel (shared-cert card render, upload modal, per-domain picker) — **pending, needs your browser**

## Notes
- Follows the sibling `DomainSSLSection` custom-cert Modal for the upload UX (paste two PEM blobs) rather than a Drawer, so the two cert-upload flows read as siblings.
- Depends only on already-merged backend routes; no API changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)