### PR TITLE
fix(backup): honest status + restic exit-3 handling for tenant backups (GH #454)

### DIFF
--- a/internal/backup/restic.go
+++ b/internal/backup/restic.go
@@ -187,6 +187,10 @@ type BackupSummary struct {
 	TotalBytesProcessed uint64  `json:"total_bytes_processed"`
 	TotalDuration       float64 `json:"total_duration"`
 	SnapshotID          string  `json:"snapshot_id"`
+	// Warnings is populated by us (not restic JSON) when restic exits 3
+	// — "at least one source file could not be read". The snapshot is
+	// still created and usable; these name the files that were skipped.
+	Warnings []string `json:"-"`
 }
 
 // BackupOpts controls one `restic backup` invocation.
@@ -228,35 +232,73 @@ func (c *Client) Backup(ctx context.Context, opts BackupOpts) (*BackupSummary, e
 		args = append(args, opts.Paths...)
 	}
 	stdout, _, err := c.run(ctx, args, opts.Stdin)
+	// restic exit code 3 means "at least one source file could not be
+	// read" (permission denied, a file that vanished or changed mid-read,
+	// a socket/pipe, …). Crucially the snapshot IS still created and the
+	// summary IS emitted — the backup is complete for every readable file.
+	// Treat it as success-with-warnings so a single unreadable file in a
+	// tenant's home does not discard the entire (valid) home snapshot and
+	// make a full account backup silently drop its files (GH #454). Any
+	// other non-zero exit is a real failure.
+	partialRead := false
 	if err != nil {
-		return nil, err
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 3 {
+			partialRead = true
+		} else {
+			return nil, err
+		}
 	}
 	// `backup --json` emits one JSON object per line; the last line is
-	// the summary. Walk lines until we find message_type=summary.
+	// the summary. Walk lines until we find message_type=summary and
+	// collect message_type=error items as read warnings.
 	var summary *BackupSummary
+	var readWarnings []string
 	for _, line := range bytes.Split(stdout, []byte("\n")) {
 		if len(bytes.TrimSpace(line)) == 0 {
 			continue
 		}
 		var probe struct {
 			MessageType string `json:"message_type"`
+			Item        string `json:"item"`
 		}
 		if err := json.Unmarshal(line, &probe); err != nil {
 			continue // skip non-JSON debug lines
 		}
-		if probe.MessageType == "summary" {
+		switch probe.MessageType {
+		case "summary":
 			var s BackupSummary
 			if err := json.Unmarshal(line, &s); err != nil {
 				return nil, fmt.Errorf("parse backup summary: %w", err)
 			}
 			summary = &s
+		case "error":
+			if probe.Item != "" && len(readWarnings) < maxReadWarnings {
+				readWarnings = append(readWarnings, "could not read "+probe.Item)
+			}
 		}
 	}
 	if summary == nil {
+		// No summary even on exit 3 means restic did not complete a
+		// snapshot — that is a genuine failure, not a partial read.
+		if partialRead {
+			return nil, errors.New("backup: restic exited 3 with no summary (no snapshot created)")
+		}
 		return nil, errors.New("backup: no summary line in restic --json output")
+	}
+	if partialRead {
+		if len(readWarnings) == 0 {
+			readWarnings = []string{"at least one source file could not be read"}
+		}
+		summary.Warnings = readWarnings
 	}
 	return summary, nil
 }
+
+// maxReadWarnings caps how many unreadable-file paths we attach to a
+// partial-read summary so a home dir with thousands of unreadable files
+// (e.g. a broken mount) can't bloat the manifest.
+const maxReadWarnings = 25
 
 // RestoreOpts controls one `restic restore` invocation.
 type RestoreOpts struct {

--- a/internal/backup/restic_test.go
+++ b/internal/backup/restic_test.go
@@ -5,10 +5,63 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 )
+
+// exit3Err returns a genuine *exec.ExitError with code 3 (what restic
+// returns when at least one source file could not be read).
+func exit3Err(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 3").Run()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) || ee.ExitCode() != 3 {
+		t.Fatalf("could not synthesize an exit-3 error: %v", err)
+	}
+	return err
+}
+
+// GH #454: restic exit 3 (unreadable file) still produces a valid snapshot
+// + summary. Backup must return that summary as success-with-warnings, not
+// discard the whole stage.
+func TestBackup_Exit3IsPartialReadNotFailure(t *testing.T) {
+	stdout := `{"message_type":"error","error":{"Op":"open","Path":"/home/u/secret","Err":13},"item":"/home/u/secret"}` + "\n" +
+		`{"message_type":"summary","data_added":2002159,"total_bytes_processed":2000009,"snapshot_id":"abc123"}` + "\n"
+	r := &fakeRunner{stdout: []byte(stdout), err: exit3Err(t)}
+	c := newClient(t, r)
+
+	s, err := c.Backup(context.Background(), BackupOpts{Paths: []string{"/home/u"}})
+	if err != nil {
+		t.Fatalf("exit 3 should not be a hard error, got %v", err)
+	}
+	if s.TotalBytesProcessed != 2000009 || s.SnapshotID != "abc123" {
+		t.Errorf("summary not parsed from exit-3 output: %+v", s)
+	}
+	if len(s.Warnings) == 0 {
+		t.Error("expected read warnings on a partial-read backup")
+	}
+}
+
+// Exit 3 with no summary means no snapshot was created — a real failure.
+func TestBackup_Exit3NoSummaryFails(t *testing.T) {
+	r := &fakeRunner{stdout: []byte(`{"message_type":"status"}` + "\n"), err: exit3Err(t)}
+	c := newClient(t, r)
+	if _, err := c.Backup(context.Background(), BackupOpts{Paths: []string{"/x"}}); err == nil {
+		t.Error("exit 3 with no summary must fail")
+	}
+}
+
+// Any other non-zero exit (e.g. fatal error) stays a failure.
+func TestBackup_NonExit3StaysFailure(t *testing.T) {
+	summary := `{"message_type":"summary","total_bytes_processed":10,"snapshot_id":"x"}` + "\n"
+	r := &fakeRunner{stdout: []byte(summary), err: errors.New("restic died")}
+	c := newClient(t, r)
+	if _, err := c.Backup(context.Background(), BackupOpts{Paths: []string{"/x"}}); err == nil {
+		t.Error("a non-exit-3 runner error must propagate even if stdout has a summary")
+	}
+}
 
 // fakeRunner records every Run call and returns canned responses.
 type fakeRunner struct {

--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -500,6 +500,12 @@ func backupStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 		// at top level) or when the manifest can't be read.
 		BytesAdded uint64 `json:"bytes_added,omitempty"`
 		BytesTotal uint64 `json:"bytes_total,omitempty"`
+		// FailedStages names the manifest stages whose status=failed so the
+		// finalizer can downgrade the job to "partial" instead of reporting
+		// a full "succeeded" backup that is silently missing its home dir
+		// (GH #454). Warnings carries the per-stage failure reasons.
+		FailedStages []string `json:"failed_stages,omitempty"`
+		Warnings     []string `json:"warnings,omitempty"`
 	}{
 		JobID:     req.JobID,
 		Snapshots: snaps,
@@ -538,10 +544,14 @@ func backupStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 				} `json:"restic"`
 				// stages[] also carries per-stage byte counts; sum them as
 				// a fallback when Restic.BytesAdded is zero (some older
-				// backup paths leave the top-level zero).
+				// backup paths leave the top-level zero). name/status/warnings
+				// let us detect a failed stage (GH #454).
 				Stages []struct {
-					BytesAdded uint64 `json:"bytes_added"`
-					BytesTotal uint64 `json:"bytes_total"`
+					Name       string   `json:"name"`
+					Status     string   `json:"status"`
+					Warnings   []string `json:"warnings"`
+					BytesAdded uint64   `json:"bytes_added"`
+					BytesTotal uint64   `json:"bytes_total"`
 				} `json:"stages"`
 			}
 			if err := json.Unmarshal(stripTar(raw), &m); err == nil {
@@ -551,6 +561,17 @@ func backupStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 					for _, st := range m.Stages {
 						resp.BytesAdded += st.BytesAdded
 						resp.BytesTotal += st.BytesTotal
+					}
+				}
+				// A "skipped" stage is intentional (e.g. mail with no
+				// mailboxes, or home under content=database) — only a
+				// "failed" stage means the backup is incomplete.
+				for _, st := range m.Stages {
+					if st.Status == backup.StageStatusFailed {
+						resp.FailedStages = append(resp.FailedStages, st.Name)
+						for _, w := range st.Warnings {
+							resp.Warnings = append(resp.Warnings, st.Name+": "+w)
+						}
 					}
 				}
 			}

--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -282,6 +282,10 @@ func runHomeStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 	st.SnapshotID = res.SnapshotID
 	st.BytesAdded = res.BytesAdded
 	st.BytesTotal = res.BytesTotal
+	// restic exit 3 (unreadable files) is captured as a usable snapshot
+	// with warnings, not a stage failure (GH #454). Surface which files
+	// were skipped so the tenant knows the backup is complete-but-partial.
+	st.Warnings = res.Warnings
 	return st
 }
 

--- a/panel-agent/internal/commands/backup_home.go
+++ b/panel-agent/internal/commands/backup_home.go
@@ -41,11 +41,12 @@ type backupHomeParams struct {
 }
 
 type backupHomeResult struct {
-	SnapshotID     string `json:"snapshot_id"`
-	ParentSnapshot string `json:"parent_snapshot,omitempty"`
-	BytesAdded     uint64 `json:"bytes_added"`
-	BytesTotal     uint64 `json:"bytes_total"`
-	LogicalBytes   uint64 `json:"logical_bytes"`
+	SnapshotID     string   `json:"snapshot_id"`
+	ParentSnapshot string   `json:"parent_snapshot,omitempty"`
+	BytesAdded     uint64   `json:"bytes_added"`
+	BytesTotal     uint64   `json:"bytes_total"`
+	LogicalBytes   uint64   `json:"logical_bytes"`
+	Warnings       []string `json:"warnings,omitempty"`
 }
 
 func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -127,6 +128,7 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		BytesAdded:   summary.DataAdded,
 		BytesTotal:   summary.TotalBytesProcessed,
 		LogicalBytes: logical,
+		Warnings:     summary.Warnings,
 	}, nil
 }
 

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
@@ -81,6 +82,11 @@ type agentStatus struct {
 	} `json:"snapshots"`
 	BytesAdded uint64 `json:"bytes_added"`
 	BytesTotal uint64 `json:"bytes_total"`
+	// FailedStages names manifest stages whose status=failed. A backup
+	// whose manifest snapshot exists but whose home/db/mail stage failed
+	// is incomplete and must NOT report a plain "succeeded" (GH #454).
+	FailedStages []string `json:"failed_stages"`
+	Warnings     []string `json:"warnings"`
 }
 
 func (f *Finalizer) tickOnce(ctx context.Context) {
@@ -157,11 +163,26 @@ func (f *Finalizer) checkOne(ctx context.Context, j models.BackupJob) {
 			break
 		}
 	}
+	// A failed stage (e.g. the home dir under a repo lock) leaves the
+	// manifest snapshot present but the backup incomplete. Downgrade to
+	// "partial" and record why, so a tenant never trusts + restores a
+	// full backup that is silently missing its files (GH #454).
+	status := models.BackupJobStatusSucceeded
+	var warningsJSON json.RawMessage
+	errText := ""
+	if len(st.FailedStages) > 0 {
+		status = models.BackupJobStatusPartial
+		errText = "incomplete backup — stage(s) failed: " + strings.Join(st.FailedStages, ", ")
+		if b, mErr := json.Marshal(st.Warnings); mErr == nil {
+			warningsJSON = b
+		}
+	}
 	if err := f.deps.Jobs.MarkFinished(ctx, j.ID,
-		models.BackupJobStatusSucceeded,
-		manifestSnapID, "", st.BytesAdded, st.BytesTotal, nil, nil, ""); err != nil {
-		logger.Error("mark succeeded failed", "err", err)
+		status,
+		manifestSnapID, "", st.BytesAdded, st.BytesTotal, nil, warningsJSON, errText); err != nil {
+		logger.Error("mark finished failed", "err", err, "status", status)
 		return
 	}
-	logger.Info("backup finalized", "snapshot_id", manifestSnapID)
+	logger.Info("backup finalized", "snapshot_id", manifestSnapID,
+		"status", status, "failed_stages", st.FailedStages)
 }

--- a/panel-api/internal/backupfinalizer/finalizer_test.go
+++ b/panel-api/internal/backupfinalizer/finalizer_test.go
@@ -1,0 +1,116 @@
+package backupfinalizer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeStatusAgent returns a canned backup.status reply.
+type fakeStatusAgent struct{ reply string }
+
+func (a *fakeStatusAgent) Call(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+	return json.RawMessage(a.reply), nil
+}
+
+// captureJobs records the MarkFinished call. Everything else embeds the
+// interface so an unexpected call panics (checkOne must only MarkFinished).
+type captureJobs struct {
+	repository.BackupJobRepository
+	gotStatus   string
+	gotErrText  string
+	gotWarnings json.RawMessage
+	gotBytes    uint64
+	called      bool
+}
+
+func (j *captureJobs) MarkFinished(_ context.Context, _, status string, _, _ string,
+	_, bytesTotal uint64, _, warnings json.RawMessage, errText string) error {
+	j.called = true
+	j.gotStatus = status
+	j.gotErrText = errText
+	j.gotWarnings = warnings
+	j.gotBytes = bytesTotal
+	return nil
+}
+
+func newTestFinalizer(agentReply string) (*Finalizer, *captureJobs) {
+	jobs := &captureJobs{}
+	f := &Finalizer{deps: Deps{
+		Jobs:  jobs,
+		Agent: &fakeStatusAgent{reply: agentReply},
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+	return f, jobs
+}
+
+func runningJob() models.BackupJob {
+	started := time.Now().Add(-time.Minute)
+	return models.BackupJob{
+		ID:        "01HJOBJOBJOBJOBJOBJOBJOB00",
+		UserID:    "01HUSERUSERUSERUSERUSER000",
+		Kind:      models.BackupJobKindAccountBackup,
+		Status:    models.BackupJobStatusRunning,
+		StartedAt: &started,
+	}
+}
+
+// GH #454: a manifest with a failed stage must downgrade the job to
+// "partial" (not "succeeded") and record the reason — otherwise a full
+// backup silently missing its home dir reports success.
+func TestCheckOne_FailedStage_MarksPartial(t *testing.T) {
+	reply := `{"manifest_found":true,"bytes_added":1500000,"bytes_total":1500000,` +
+		`"failed_stages":["home"],"warnings":["home: repository is already locked"],` +
+		`"snapshots":[{"id":"snapM","tags":["stage=manifest"]}]}`
+	f, jobs := newTestFinalizer(reply)
+
+	f.checkOne(context.Background(), runningJob())
+
+	if !jobs.called {
+		t.Fatal("MarkFinished was not called")
+	}
+	if jobs.gotStatus != models.BackupJobStatusPartial {
+		t.Errorf("status = %q, want partial", jobs.gotStatus)
+	}
+	if jobs.gotErrText == "" {
+		t.Error("expected an error_text explaining the failed stage")
+	}
+	var warns []string
+	if err := json.Unmarshal(jobs.gotWarnings, &warns); err != nil || len(warns) == 0 {
+		t.Errorf("expected warnings JSON, got %q (err %v)", jobs.gotWarnings, err)
+	}
+}
+
+// A clean manifest (no failed stages) still reports "succeeded".
+func TestCheckOne_AllStagesOK_MarksSucceeded(t *testing.T) {
+	reply := `{"manifest_found":true,"bytes_added":3600000000,"bytes_total":3600000000,` +
+		`"snapshots":[{"id":"snapM","tags":["stage=manifest"]}]}`
+	f, jobs := newTestFinalizer(reply)
+
+	f.checkOne(context.Background(), runningJob())
+
+	if !jobs.called {
+		t.Fatal("MarkFinished was not called")
+	}
+	if jobs.gotStatus != models.BackupJobStatusSucceeded {
+		t.Errorf("status = %q, want succeeded", jobs.gotStatus)
+	}
+	if jobs.gotErrText != "" {
+		t.Errorf("clean backup should have no error_text, got %q", jobs.gotErrText)
+	}
+}
+
+// A manifest not yet present means the run is still going — no MarkFinished.
+func TestCheckOne_NoManifest_NoOp(t *testing.T) {
+	f, jobs := newTestFinalizer(`{"manifest_found":false}`)
+	f.checkOne(context.Background(), runningJob())
+	if jobs.called {
+		t.Error("MarkFinished should not be called while the manifest is absent")
+	}
+}

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -4,12 +4,12 @@
 // scoped via /me/backups (auth-gated to caller's user_id).
 import { useTranslation } from "react-i18next";
 import { downloadUrl } from "../../utils/download";
-import { Button, Card, Grid, Select, Space, Table, Tag, Typography, message } from "antd";
+import { Button, Card, Grid, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
 import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
 import { RowActions } from "../../components/RowActions";
-import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined } from "@icons";
+import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined, WarningOutlined } from "@icons";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -26,6 +26,7 @@ type MyBackup = {
   bytes_total: number;
   bytes_added: number;
   created_at: string;
+  error_text?: string;
 };
 
 const statusColor = (status: string): string => {
@@ -180,9 +181,21 @@ export const MyProfileBackupCard = () => {
             ),
           },
           {
+            // A "partial" backup completed but a stage (e.g. the home dir)
+            // failed — surface the reason so a tenant doesn't restore an
+            // incomplete backup thinking it is whole (GH #454).
             title: "Status",
             dataIndex: "status",
-            render: (s: string) => <Tag color={statusColor(s)}>{s}</Tag>,
+            render: (s: string, row: MyBackup) => (
+              <Space size={4}>
+                <Tag color={statusColor(s)}>{s}</Tag>
+                {row.error_text && (
+                  <Tooltip title={row.error_text}>
+                    <WarningOutlined style={{ color: "#faad14" }} />
+                  </Tooltip>
+                )}
+              </Space>
+            ),
           },
           {
             title: "Size",


### PR DESCRIPTION
Fixes the tenant "My backups" report: identical **full** account backups showing wildly different sizes — some **1.5 MB**, some **3.6 GB** — all marked `succeeded`.

## Root cause (confirmed on testserver)

restic returns **exit code 3** when at least one source file could not be read — a permission-denied file, a socket/pipe, or a file that vanished or changed mid-backup. **But the snapshot is still created and the `--json` summary is still emitted** — the backup is complete for every readable file.

The wrapper (`internal/backup.Client.Backup`) treated **any** non-zero exit as a hard error. So a single unreadable file in a tenant's home discarded the entire (valid) home snapshot: the home stage was marked `failed` (0 bytes), db+mail still succeeded, and the finalizer marked the job **`succeeded`** at ~1.5 MB — while the real 3.6 GB of home data that restic *had actually captured* was dropped from the manifest.

Two separate defects stacked up:
1. **restic exit 3 = total stage loss** — an ordinary unreadable file nukes the whole home stage.
2. **finalizer never checked stage status** — marked `succeeded` the moment a manifest snapshot existed, hiding the loss.

Box evidence (testserver): as an unprivileged user, `restic backup` of a dir with one root-owned `0600` file → **exit 3**, snapshot still written, valid summary (`total_bytes_processed` = the readable bytes). Separately verified `total_bytes_processed` stays *full* on an incremental run, ruling out dedup as the cause.

## Fix

**`internal/backup.Backup` — exit 3 is success-with-warnings.** Parses the summary restic still emits, returns it as success, and collects `message_type=error` items as read warnings (capped 25). Exit 3 with *no* summary = no snapshot = still a failure. Any other non-zero exit still propagates. The home stage records those warnings with status `ok`, so the tenant sees which files were skipped without losing the backup.

**Finalizer — honest status.** `backup.status` now returns `failed_stages[]` + `warnings[]` from the manifest; a job with any genuinely-failed stage is marked **`partial`** (enum already exists) instead of `succeeded`, with the reason in `error_text`/`warnings_json`. A `skipped` stage (intentional) is not a failure.

**`MyProfileBackupCard`** — shows a ⚠ + reason tooltip beside a `partial` status.

Net effect: unreadable-file backups keep their home data (counted, `ok` + warnings); only a real stage failure downgrades to `partial`. No more silent 1.5 MB "succeeded" backups missing the home dir.

## Test plan
- [x] `go test ./internal/backup` — exit-3 partial-read / exit-3-no-summary / non-exit-3 paths
- [x] `go test ./panel-api/internal/backupfinalizer` — partial / succeeded / no-manifest
- [x] `go test ./panel-agent/internal/commands` — green
- [x] `go vet` — clean (struct fields only; no interface change)
- [x] `tsc` + `eslint` + `vitest` (146) — green
- [x] Root cause reproduced on testserver (restic exit-3 behaviour)
- [x] **Full agent E2E on testserver** — reproduced a restic exit-3 (churn-induced transient read error) through the real orchestrator.
  - Buggy agent (main): home stage `status=failed`, `bytes_total=0` — home data discarded.
  - Fixed agent (branch): home stage `status=ok`, `bytes_total=55.6 MB` — home data kept + `warnings` surfaced. Original binary restored after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
