### PR TITLE
fix(files): du must dereference the pinned-fd symlink — folder sizes were 0 (GH #657)

### DIFF
--- a/panel-agent/internal/commands/files_du.go
+++ b/panel-agent/internal/commands/files_du.go
@@ -66,9 +66,6 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("path validation failed: %v", err)}
 	}
 
-	// One `du` call gives every immediate subdir's recursive size (+ the dir
-	// itself). -b = apparent size in bytes; --max-depth=1 = this level only.
-	dirSizes := map[string]int64{}
 	// GH #653: run du against an ESCAPE-PROOF dir fd instead of the resolvable
 	// string path. The fd is passed to the child via ExtraFiles (fd 3) so du
 	// traverses the pinned inode (/proc/self/fd/3) — a parent-directory swap
@@ -77,29 +74,8 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	if derr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("open dir: %v", derr)}
 	}
-	duCmd := exec.CommandContext(ctx, "du", "-b", "--max-depth=1", "/proc/self/fd/3")
-	duCmd.ExtraFiles = []*os.File{df}
-	out, _ := duCmd.Output()
+	dirSizes := duSubdirSizes(ctx, df, resolved)
 	df.Close()
-	const procPfx = "/proc/self/fd/3"
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		tab := strings.IndexByte(line, '\t')
-		if tab <= 0 {
-			continue
-		}
-		sz, perr := strconv.ParseInt(strings.TrimSpace(line[:tab]), 10, 64)
-		if perr != nil {
-			continue
-		}
-		path := strings.TrimSpace(line[tab+1:])
-		// remap the fd path back to the canonical path for the size lookups.
-		if path == procPfx {
-			path = resolved
-		} else if strings.HasPrefix(path, procPfx+"/") {
-			path = resolved + path[len(procPfx):]
-		}
-		dirSizes[path] = sz
-	}
 
 	entries, err := scope.ReadDirInScope(resolved)
 	if err != nil {
@@ -125,6 +101,42 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	sort.SliceStable(result, func(i, j int) bool { return result[i].Size > result[j].Size })
 
 	return &filesDuResponse{Path: resolved, Total: dirSizes[resolved], Entries: result}, nil
+}
+
+// duSubdirSizes runs one `du -b -D --max-depth=1` against the pinned directory
+// fd (passed as child fd 3 via ExtraFiles) and returns a map of canonical path
+// → recursive apparent size for the directory itself and each immediate child.
+//
+// -b = apparent size in bytes; --max-depth=1 = this level only; -D = follow the
+// /proc/self/fd/3 magic symlink to the pinned inode (WITHOUT it, du measures the
+// symlink node and reports no children, so every folder came back 0 — GH #657).
+// -D dereferences only the command-line arg; in-tree symlinks are still not
+// followed, preserving the GH #653 escape-proofing. The child's fd-relative
+// output paths are remapped back onto `canonical` for the caller's lookups.
+func duSubdirSizes(ctx context.Context, dirFd *os.File, canonical string) map[string]int64 {
+	dirSizes := map[string]int64{}
+	duCmd := exec.CommandContext(ctx, "du", "-b", "-D", "--max-depth=1", "/proc/self/fd/3")
+	duCmd.ExtraFiles = []*os.File{dirFd}
+	out, _ := duCmd.Output()
+	const procPfx = "/proc/self/fd/3"
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		tab := strings.IndexByte(line, '\t')
+		if tab <= 0 {
+			continue
+		}
+		sz, perr := strconv.ParseInt(strings.TrimSpace(line[:tab]), 10, 64)
+		if perr != nil {
+			continue
+		}
+		path := strings.TrimSpace(line[tab+1:])
+		if path == procPfx {
+			path = canonical
+		} else if strings.HasPrefix(path, procPfx+"/") {
+			path = canonical + path[len(procPfx):]
+		}
+		dirSizes[path] = sz
+	}
+	return dirSizes
 }
 
 func init() {

--- a/panel-agent/internal/commands/files_du_test.go
+++ b/panel-agent/internal/commands/files_du_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDuSubdirSizes_Recursive guards GH #657: du must follow the
+// /proc/self/fd/3 magic symlink and report each child's RECURSIVE size.
+// The regression it catches — running du without -D — returned the symlink
+// node's own size (~tens of bytes) and no children, so every folder read 0.
+func TestDuSubdirSizes_Recursive(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "alpha"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "beta", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(p string, n int) {
+		if err := os.WriteFile(p, make([]byte, n), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(root, "alpha", "a.bin"), 2_000_000)
+	write(filepath.Join(root, "beta", "b.bin"), 5_000_000)
+	write(filepath.Join(root, "beta", "nested", "c.bin"), 1_000_000) // recursion check
+
+	f, err := os.Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	sizes := duSubdirSizes(context.Background(), f, root)
+
+	// >= (not ==) tolerates the directory nodes' own apparent size, which
+	// varies by filesystem. The point is that they are NOT ~0 (the bug).
+	if got := sizes[filepath.Join(root, "alpha")]; got < 2_000_000 {
+		t.Errorf("alpha size = %d, want >= 2000000 (0-ish means the du-fd deref bug is back)", got)
+	}
+	if got := sizes[filepath.Join(root, "beta")]; got < 6_000_000 {
+		t.Errorf("beta size = %d, want >= 6000000 (5MB + 1MB nested — recursion broken?)", got)
+	}
+	if got := sizes[root]; got < 8_000_000 {
+		t.Errorf("root total = %d, want >= 8000000", got)
+	}
+}


### PR DESCRIPTION
## The bug (found smoke-testing #657)

The File Manager "Folder sizes" action (#667, GH #657) and the disk-usage folder breakdown both compute sizes via the `files.du` agent verb. Smoke-testing on a real box against known folders, **every folder came back size 0** (total 64 bytes).

Root cause: `files.du` runs `du` against the escape-proof directory fd exposed as `/proc/self/fd/3` (GH #653 anti-swap hardening), but the command lacked `-D`. GNU `du` does not dereference a symlink argument by default, so it measured the magic-symlink **node itself** (a few bytes) and reported **no children** → all folders 0.

Box-confirmed:
```
du -b --max-depth=1 /proc/self/fd/3      -> 64  /proc/self/fd/3          (no children)
du -b -D --max-depth=1 /proc/self/fd/3   -> alpha=2000000 beta=6000000 total=8000009
```

## Fix

Add `-D` (`--dereference-args`). It dereferences **only the command-line arg**, so:
- `du` follows `/proc/self/fd/3` to the pinned directory inode and traverses it (correct recursive sizes).
- In-tree symlinks are still **not** followed → the GH #653 escape-proofing is intact (opening `/proc/self/fd/3` reopens the fd's own inode, not a re-resolved path).

Extracted the du run+parse into `duSubdirSizes()` and added the **regression test that never existed** — it builds a real directory tree (with a nested file) and asserts recursive sizes are non-zero and correct. That missing test is why this shipped.

## Scope
Fixes folder sizes everywhere `files.du` is used: the File Manager (#657) and the tenant disk-usage page's folder tree.

## Test plan
- [x] `go test ./panel-agent/internal/commands -run TestDuSubdirSizes` — passes; asserts the recursive sizes that were 0 before
- [x] `go vet`
- [x] Box: `du` probe with/without `-D` (above)

**Deploy note (resolved):** an earlier manual *hot-swap* of a current-`main` agent onto testserver crash-looped, but that was a transient from an interrupted swap (the first deploy command timed out mid-restart). The same binary was then verified to start cleanly as `jabali-agent.service` (active, Result=success, NRestarts=0) and runs fine standalone / under systemd-run / with the real socket+gids. Not seccomp/AppArmor/LockPersonality/corruption. A clean `jabali update` is unaffected. Box left healthy on its repo-HEAD agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)