### PR TITLE
feat(notifications): per-user channel scoping + routing schema (JAB-171 phase 1)

### DIFF
--- a/panel-api/internal/db/migrations/000237_per_user_notifications.down.sql
+++ b/panel-api/internal/db/migrations/000237_per_user_notifications.down.sql
@@ -1,0 +1,6 @@
+-- Reverse JAB-171 phase 1.
+DROP TABLE user_notification_routes;
+
+ALTER TABLE notification_channels DROP FOREIGN KEY fk_notif_channels_user;
+ALTER TABLE notification_channels DROP KEY ix_notif_channels_user;
+ALTER TABLE notification_channels DROP COLUMN user_id;

--- a/panel-api/internal/db/migrations/000237_per_user_notifications.up.sql
+++ b/panel-api/internal/db/migrations/000237_per_user_notifications.up.sql
@@ -1,0 +1,36 @@
+-- JAB-171 phase 1: per-user notification channels + routing (schema only).
+-- Nothing reads these columns yet — the dispatcher stays global until phase 2.
+--
+-- notification_channels.user_id: NULL = server-wide (admin-owned, existing
+-- behaviour); set = owned by that tenant. Global dispatch will filter
+-- `user_id IS NULL` in phase 2.
+ALTER TABLE notification_channels
+    ADD COLUMN user_id CHAR(26) COLLATE utf8mb4_unicode_ci NULL AFTER id,
+    ADD KEY ix_notif_channels_user (user_id),
+    ADD CONSTRAINT fk_notif_channels_user FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE;
+
+-- user_notification_routes maps a tenant's chosen event kinds to their own
+-- channels: (user_id, event_kind) -> channel_id. Absence of a route means the
+-- user has not opted that event into that channel. Explicit COLLATE on every
+-- FK column so MariaDB's exact-collation FK requirement is met regardless of
+-- each referenced table's own collation.
+CREATE TABLE user_notification_routes (
+    id          CHAR(26)    COLLATE utf8mb4_unicode_ci NOT NULL,
+    user_id     CHAR(26)    COLLATE utf8mb4_unicode_ci NOT NULL,
+    event_kind  VARCHAR(64) NOT NULL,
+    channel_id  CHAR(26)    COLLATE utf8mb4_unicode_ci NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    updated_at  DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_event_channel (user_id, event_kind, channel_id),
+    KEY ix_user_notif_routes_user (user_id),
+    KEY ix_user_notif_routes_channel (channel_id),
+    CONSTRAINT fk_user_notif_routes_user FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_notif_routes_channel FOREIGN KEY (channel_id)
+        REFERENCES notification_channels (id) ON DELETE CASCADE
+)
+ENGINE = InnoDB
+DEFAULT CHARSET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;

--- a/panel-api/internal/models/notification_channel.go
+++ b/panel-api/internal/models/notification_channel.go
@@ -27,7 +27,11 @@ const (
 // layer validates per-kind before persistence; the DB only enforces
 // well-formed JSON.
 type NotificationChannel struct {
-	ID        string                    `gorm:"type:char(26);primaryKey" json:"id"`
+	ID string `gorm:"type:char(26);primaryKey" json:"id"`
+	// UserID scopes ownership (JAB-171): NULL = server-wide (admin-owned,
+	// existing behaviour); set = owned by that tenant. The dispatcher filters
+	// on this from phase 2 onward.
+	UserID    *string                   `gorm:"column:user_id;type:char(26)" json:"user_id,omitempty"`
 	Name      string                    `gorm:"type:varchar(120);not null" json:"name"`
 	Kind      string                    `gorm:"type:varchar(16);not null;index:idx_notification_channels_kind_enabled,priority:1" json:"kind"`
 	Config    NotificationChannelConfig `gorm:"column:config_json;type:json;not null" json:"config"`

--- a/panel-api/internal/models/user_notification_route.go
+++ b/panel-api/internal/models/user_notification_route.go
@@ -1,0 +1,19 @@
+package models
+
+import "time"
+
+// UserNotificationRoute maps a tenant's chosen event kind to one of their own
+// notification channels (JAB-171). A route's presence means "deliver this
+// event kind to this channel for this user"; its absence means the user has
+// not opted that event into that channel. Server/admin events are unaffected —
+// they fan out to server-wide channels (notification_channels.user_id IS NULL).
+type UserNotificationRoute struct {
+	ID        string    `gorm:"type:char(26);primaryKey" json:"id"`
+	UserID    string    `gorm:"column:user_id;type:char(26);not null" json:"user_id"`
+	EventKind string    `gorm:"column:event_kind;type:varchar(64);not null" json:"event_kind"`
+	ChannelID string    `gorm:"column:channel_id;type:char(26);not null" json:"channel_id"`
+	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+}
+
+func (UserNotificationRoute) TableName() string { return "user_notification_routes" }

--- a/panel-api/internal/repository/user_notification_route_repository.go
+++ b/panel-api/internal/repository/user_notification_route_repository.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// UserNotificationRouteRepository is the data access for JAB-171 per-user event
+// routing: which of a tenant's own channels a given event kind is delivered to.
+// Nothing consumes it until phase 2 (recipient-aware dispatcher) — it is added
+// here as phase-1 scaffolding so the model + table have a typed surface.
+type UserNotificationRouteRepository interface {
+	Create(ctx context.Context, r *models.UserNotificationRoute) error
+	// ListByUser returns every route a user has configured.
+	ListByUser(ctx context.Context, userID string) ([]models.UserNotificationRoute, error)
+	// ListByUserEvent returns a user's routes for one event kind (the channels
+	// that event fans out to for that user).
+	ListByUserEvent(ctx context.Context, userID, eventKind string) ([]models.UserNotificationRoute, error)
+	Delete(ctx context.Context, id string) error
+	// DeleteByChannel removes every route pointing at a channel (used when a
+	// channel is deleted — belt-and-suspenders alongside the ON DELETE CASCADE).
+	DeleteByChannel(ctx context.Context, channelID string) error
+}
+
+type userNotificationRouteRepo struct{ db *gorm.DB }
+
+func NewUserNotificationRouteRepository(db *gorm.DB) UserNotificationRouteRepository {
+	return &userNotificationRouteRepo{db: db}
+}
+
+func (r *userNotificationRouteRepo) Create(ctx context.Context, route *models.UserNotificationRoute) error {
+	return r.db.WithContext(ctx).Create(route).Error
+}
+
+func (r *userNotificationRouteRepo) ListByUser(ctx context.Context, userID string) ([]models.UserNotificationRoute, error) {
+	var out []models.UserNotificationRoute
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("event_kind ASC").Find(&out).Error
+	return out, err
+}
+
+func (r *userNotificationRouteRepo) ListByUserEvent(ctx context.Context, userID, eventKind string) ([]models.UserNotificationRoute, error) {
+	var out []models.UserNotificationRoute
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND event_kind = ?", userID, eventKind).
+		Find(&out).Error
+	return out, err
+}
+
+func (r *userNotificationRouteRepo) Delete(ctx context.Context, id string) error {
+	return r.db.WithContext(ctx).Where("id = ?", id).Delete(&models.UserNotificationRoute{}).Error
+}
+
+func (r *userNotificationRouteRepo) DeleteByChannel(ctx context.Context, channelID string) error {
+	return r.db.WithContext(ctx).Where("channel_id = ?", channelID).Delete(&models.UserNotificationRoute{}).Error
+}


### PR DESCRIPTION
## What

Phase 1 of JAB-171 (per-user notification channels). **Schema-only + additive** — nothing reads the new columns yet, so the dispatcher stays global. This just lays the foundation.

- **Migration 000237:**
  - `notification_channels` gains nullable `user_id` (NULL = server-wide/admin = existing behaviour; set = tenant-owned) + FK → `users` `ON DELETE CASCADE` + index.
  - New `user_notification_routes` table: `(user_id, event_kind, channel_id)` with a unique key + FKs to `users` and `notification_channels`, both `ON DELETE CASCADE`. Explicit `COLLATE utf8mb4_unicode_ci` on every FK column (MariaDB exact-collation FK rule).
- `NotificationChannel.UserID *string` (`json:",omitempty"`).
- New `UserNotificationRoute` model + `UserNotificationRouteRepository` — phase-1 scaffolding, consumed by the phase-2 recipient-aware dispatcher.

No existing interface changed → no mock breakage.

## Blueprint
Full plan (6 phases, security-gated): `plans/jab171-per-user-notifications.md`. **The tenant surface ships only after phases 3 (ownership + secret encryption) AND 4 (SSRF guard + kind allowlist + rate limits) both land.** Nothing tenant-facing here.

## Test plan
- [x] `go build ./...`, `go vet`
- [x] `go test ./panel-api/internal/{models,repository,notifications}` — green
- [x] **Box-verified** migration up+down on testserver MariaDB: up adds column+table+both FKs (collation OK); down removes them cleanly

## Next
Phase 2 — recipient-aware dispatcher (resolve the recipient's own channels for user-scoped events; server events keep `user_id IS NULL`). Then phase 3 (tenant API + secret encryption, security review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)