### PR TITLE
feat(notifications): recipient-aware dispatcher (JAB-171 phase 2)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -284,6 +284,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// concrete senders — slack, ntfy, webhook, webpush, email).
 		deps.NotificationChannels = repository.NewNotificationChannelRepository(sharedDB)
 		deps.NotificationHistory = repository.NewNotificationHistoryRepository(sharedDB)
+		deps.UserNotificationRoutes = repository.NewUserNotificationRouteRepository(sharedDB)
 		deps.WebhookEndpoints = repository.NewWebhookEndpointRepository(sharedDB)
 		deps.WebPushSubs = repository.NewWebPushSubscriptionRepository(sharedDB)
 		if redisClient != nil {
@@ -1191,6 +1192,9 @@ func startNotificationDispatcher(parent context.Context, deps app.Deps, log *slo
 	}
 	if err == nil && deps.Users != nil {
 		d.WithUsers(deps.Users)
+	}
+	if err == nil && deps.UserNotificationRoutes != nil {
+		d.WithUserRoutes(deps.UserNotificationRoutes)
 	}
 	if err != nil {
 		log.Error("notifications dispatcher: construction failed", "err", err)

--- a/panel-api/internal/api/notifications_channels_test.go
+++ b/panel-api/internal/api/notifications_channels_test.go
@@ -84,6 +84,10 @@ func (f *fakeChannelsRepo) FindEnabledAll(context.Context) ([]models.Notificatio
 	return nil, nil
 }
 
+func (f *fakeChannelsRepo) FindEnabledServerWide(context.Context) ([]models.NotificationChannel, error) {
+	return nil, nil
+}
+
 // --- test plumbing ---
 
 func newAdminCtx() gin.HandlerFunc {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -184,7 +184,10 @@ type Deps struct {
 	// the dispatcher goroutine that drains the Redis stream.
 	NotificationChannels repository.NotificationChannelRepository
 	NotificationHistory  repository.NotificationHistoryRepository
-	WebhookEndpoints     repository.WebhookEndpointRepository
+	// UserNotificationRoutes powers per-user event routing (JAB-171): a
+	// user-scoped envelope also reaches the recipient's own routed channels.
+	UserNotificationRoutes repository.UserNotificationRouteRepository
+	WebhookEndpoints       repository.WebhookEndpointRepository
 	WebPushSubs          repository.WebPushSubscriptionRepository
 	// NotificationQueue is the dispatcher's publish end — the internal
 	// enqueue endpoint (RequireLocalhost) and in-process event sources

--- a/panel-api/internal/notifications/dispatcher.go
+++ b/panel-api/internal/notifications/dispatcher.go
@@ -80,9 +80,14 @@ type Dispatcher struct {
 	// users powers the broadcast → admin-bell fan-out. Optional —
 	// when nil, broadcast envelopes (env.UserID == "") get no bell rows.
 	// Non-broadcast envelopes always get a bell row regardless.
-	users    repository.UserRepository
-	log      *slog.Logger
-	consumer string
+	users repository.UserRepository
+	// userRoutes powers per-user event routing (JAB-171). Optional — when
+	// nil, user-scoped envelopes fan to server-wide channels only (the
+	// pre-JAB-171 behaviour). When set, a user-scoped envelope also reaches
+	// the recipient's OWN channels that they routed this event kind to.
+	userRoutes repository.UserNotificationRouteRepository
+	log        *slog.Logger
+	consumer   string
 
 	wg      sync.WaitGroup
 	stopped chan struct{}
@@ -101,6 +106,15 @@ func (d *Dispatcher) WithEventSettings(r repository.NotificationEventSettingRepo
 // surface in any admin's bell.
 func (d *Dispatcher) WithUsers(r repository.UserRepository) *Dispatcher {
 	d.users = r
+	return d
+}
+
+// WithUserRoutes injects the per-user routing repo (JAB-171). With it, a
+// user-scoped envelope (env.UserID set) additionally fans out to the
+// recipient's own channels routed for that event kind. Without it, behaviour
+// is unchanged (server-wide channels only).
+func (d *Dispatcher) WithUserRoutes(r repository.UserNotificationRouteRepository) *Dispatcher {
+	d.userRoutes = r
 	return d
 }
 
@@ -360,7 +374,25 @@ func (d *Dispatcher) process(ctx context.Context, msg redis.XMessage) {
 // Explicit ChannelIDs → load each by id. Empty → every enabled channel.
 func (d *Dispatcher) resolveTargets(ctx context.Context, env Envelope) ([]models.NotificationChannel, error) {
 	if len(env.ChannelIDs) == 0 {
-		return d.channels.FindEnabledAll(ctx)
+		// Base set = server-wide admin channels (user_id IS NULL). Using
+		// FindEnabledServerWide (not FindEnabledAll) keeps tenant-owned
+		// channels out of broadcast/server fan-out — JAB-171.
+		targets, err := d.channels.FindEnabledServerWide(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// Additively, a user-scoped envelope also reaches the recipient's
+		// OWN channels routed for this event kind. Ownership is re-checked
+		// here (channel.UserID == recipient) so a stray route can never
+		// deliver another user's — or a global admin — channel.
+		if env.UserID != "" && d.userRoutes != nil {
+			userChans, err := d.recipientRoutedChannels(ctx, env.UserID, env.EventKind)
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, userChans...)
+		}
+		return targets, nil
 	}
 	out := make([]models.NotificationChannel, 0, len(env.ChannelIDs))
 	for _, id := range env.ChannelIDs {
@@ -374,6 +406,37 @@ func (d *Dispatcher) resolveTargets(ctx context.Context, env Envelope) ([]models
 			return nil, err
 		}
 		if !ch.Enabled {
+			continue
+		}
+		out = append(out, *ch)
+	}
+	return out, nil
+}
+
+// recipientRoutedChannels returns the recipient's OWN enabled channels that
+// they routed the given event kind to. Every candidate is ownership-checked
+// (channel.UserID == userID) so a route can only ever deliver a channel the
+// same user owns — never a global admin channel, never another tenant's.
+func (d *Dispatcher) recipientRoutedChannels(ctx context.Context, userID, eventKind string) ([]models.NotificationChannel, error) {
+	routes, err := d.userRoutes.ListByUserEvent(ctx, userID, eventKind)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]models.NotificationChannel, 0, len(routes))
+	for _, rt := range routes {
+		ch, err := d.channels.FindByID(ctx, rt.ChannelID)
+		if err != nil {
+			if errors.Is(err, repository.ErrNotFound) {
+				continue // channel deleted since the route was written
+			}
+			return nil, err
+		}
+		if !ch.Enabled {
+			continue
+		}
+		if ch.UserID == nil || *ch.UserID != userID {
+			// Ownership guard: never deliver a global or other-user channel
+			// via a user route, even if a stale/forged route points at one.
 			continue
 		}
 		out = append(out, *ch)

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -95,6 +95,21 @@ func (f *fakeChannels) FindEnabledAll(ctx context.Context) ([]models.Notificatio
 	return out, nil
 }
 
+// FindEnabledServerWide returns only the global (user_id IS NULL) enabled
+// channels — mirrors the SQL filter so dispatcher tests can assert tenant-owned
+// channels are excluded from broadcast/server fan-out (JAB-171).
+func (f *fakeChannels) FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]models.NotificationChannel, 0, len(f.enabled))
+	for _, ch := range f.enabled {
+		if ch.UserID == nil {
+			out = append(out, ch)
+		}
+	}
+	return out, nil
+}
+
 var errNotFound = errors.New("not found")
 
 // Upstream repo interface uses repository.ListOptions — we bridge via
@@ -436,4 +451,83 @@ func TestEnvelope_StreamRoundTrip(t *testing.T) {
 	out, err := envelopeFromStream(sm)
 	require.NoError(t, err)
 	require.Equal(t, in, out)
+}
+
+// --- JAB-171 phase 2: recipient-aware routing ---
+
+type fakeUserRoutes struct {
+	// keyed by userID -> eventKind -> channelIDs
+	routes map[string]map[string][]string
+}
+
+func (f *fakeUserRoutes) Create(ctx context.Context, r *models.UserNotificationRoute) error { return nil }
+func (f *fakeUserRoutes) ListByUser(ctx context.Context, userID string) ([]models.UserNotificationRoute, error) {
+	return nil, nil
+}
+func (f *fakeUserRoutes) ListByUserEvent(ctx context.Context, userID, eventKind string) ([]models.UserNotificationRoute, error) {
+	var out []models.UserNotificationRoute
+	for _, chID := range f.routes[userID][eventKind] {
+		out = append(out, models.UserNotificationRoute{UserID: userID, EventKind: eventKind, ChannelID: chID})
+	}
+	return out, nil
+}
+func (f *fakeUserRoutes) Delete(ctx context.Context, id string) error            { return nil }
+func (f *fakeUserRoutes) DeleteByChannel(ctx context.Context, channelID string) error { return nil }
+
+func ptr(s string) *string { return &s }
+
+func ids(chs []models.NotificationChannel) map[string]bool {
+	m := map[string]bool{}
+	for _, c := range chs {
+		m[c.ID] = true
+	}
+	return m
+}
+
+func TestResolveTargets_PerUserRouting(t *testing.T) {
+	g1 := models.NotificationChannel{ID: "G1", Enabled: true, UserID: nil}                 // server-wide
+	a1 := models.NotificationChannel{ID: "A1", Enabled: true, UserID: ptr("userA")}        // tenant A owns
+	b1 := models.NotificationChannel{ID: "B1", Enabled: true, UserID: ptr("userB")}        // tenant B owns
+	fc := &fakeChannels{
+		byID:    map[string]*models.NotificationChannel{"G1": &g1, "A1": &a1, "B1": &b1},
+		enabled: []models.NotificationChannel{g1, a1, b1},
+	}
+	fr := &fakeUserRoutes{routes: map[string]map[string][]string{
+		"userA": {"backup.done": {"A1", "B1"}}, // A1 owned; B1 is a forged/stale route to another user's channel
+	}}
+	d := &Dispatcher{channels: fc, userRoutes: fr}
+	ctx := context.Background()
+
+	// Server event (no UserID): server-wide channels only; tenant channels excluded.
+	got, err := d.resolveTargets(ctx, Envelope{EventKind: "backup.done"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := ids(got)
+	if !m["G1"] || m["A1"] || m["B1"] {
+		t.Errorf("server event: want {G1}, got %v", m)
+	}
+
+	// User A event: server-wide G1 + A1 (owned+routed); B1 excluded by ownership guard.
+	got, err = d.resolveTargets(ctx, Envelope{EventKind: "backup.done", UserID: "userA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = ids(got)
+	if !m["G1"] || !m["A1"] {
+		t.Errorf("userA event: want G1+A1, got %v", m)
+	}
+	if m["B1"] {
+		t.Error("userA event MUST NOT include B1 (another tenant's channel) — ownership guard failed")
+	}
+
+	// User A, event with no route: server-wide only.
+	got, err = d.resolveTargets(ctx, Envelope{EventKind: "cert.renewed", UserID: "userA"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = ids(got)
+	if !m["G1"] || m["A1"] || m["B1"] {
+		t.Errorf("userA unrouted event: want {G1}, got %v", m)
+	}
 }

--- a/panel-api/internal/repository/notification_channel_repository.go
+++ b/panel-api/internal/repository/notification_channel_repository.go
@@ -28,6 +28,12 @@ type NotificationChannelRepository interface {
 	// FindEnabledAll returns every enabled channel across kinds. Used
 	// by broadcast-on-every-channel event handlers.
 	FindEnabledAll(ctx context.Context) ([]models.NotificationChannel, error)
+
+	// FindEnabledServerWide returns every enabled channel that is NOT owned
+	// by a tenant (user_id IS NULL) — the admin-configured channels. The
+	// dispatcher uses this as the base fan-out set so a tenant-owned channel
+	// never receives a broadcast/server event (JAB-171).
+	FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error)
 }
 
 type notificationChannelRepo struct{ db *gorm.DB }
@@ -103,6 +109,15 @@ func (r *notificationChannelRepo) FindEnabledAll(ctx context.Context) ([]models.
 	var rows []models.NotificationChannel
 	err := r.db.WithContext(ctx).
 		Where("enabled = ?", true).
+		Order("kind asc, id asc").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *notificationChannelRepo) FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error) {
+	var rows []models.NotificationChannel
+	err := r.db.WithContext(ctx).
+		Where("enabled = ? AND user_id IS NULL", true).
 		Order("kind asc, id asc").
 		Find(&rows).Error
 	return rows, err


### PR DESCRIPTION
## What

Phase 2 of JAB-171. Teaches the dispatcher to route by scope. Two changes to channel resolution:

1. **Base set = server-wide only.** `resolveTargets` now uses `FindEnabledServerWide` (enabled AND `user_id IS NULL`) instead of `FindEnabledAll`. **Behaviourally identical today** (no tenant channels exist yet), but it prevents a future leak: once phase 3 lets tenants create channels, `FindEnabledAll` would have delivered every broadcast/server event to tenant-owned channels too. Server events now provably hit admin channels only.
2. **Additive per-user routing.** A user-scoped envelope (`env.UserID` set) also reaches the recipient's OWN channels routed for that event kind (`user_notification_routes`). Every candidate is **ownership-checked** (`channel.UserID == recipient`) so a stale/forged route can never deliver a global admin channel or another tenant's channel.

Additive by design: admin global-channel visibility of user events is preserved; the recipient's own channels are an extra delivery, gated on `WithUserRoutes` being wired.

## Changes
- `repo`: `FindEnabledServerWide` on `NotificationChannelRepository` (+ 2 test fakes updated).
- `dispatcher`: `userRoutes` field + `WithUserRoutes`; `resolveTargets` rewrite + `recipientRoutedChannels` (ownership guard).
- `wiring`: `deps.UserNotificationRoutes` constructed + `WithUserRoutes` in serve.go.

## Test plan
- [x] `TestResolveTargets_PerUserRouting` — server event → global only; user event → global + own routed channel; **another tenant's routed channel excluded** (ownership guard); unrouted event → global only.
- [x] `go vet ./...`, `go build ./...`, `go test -race` (notifications/api/repository/app) — green.

## Gate
Still **no tenant surface**. Phase 3 (tenant API `/me/notifications/*` + secret encryption) is next — that's a SECURITY-REVIEW PR, and includes the admin-secret-plaintext decision flagged in the blueprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)