### PR TITLE
feat(notifications): encrypt channel secrets at rest, never echo them (JAB-171 phase 3a)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3473,6 +3473,14 @@ List configured notification channels
 jabali notification channels list
 ```
 
+##### `jabali notification channels seal-secrets`
+
+Encrypt any plaintext channel secrets at rest (JAB-171 one-time backfill)
+
+```
+jabali notification channels seal-secrets
+```
+
 ##### `jabali notification channels test`
 
 Send a synthetic test notification to one channel

--- a/panel-api/cmd/server/notification_cmd.go
+++ b/panel-api/cmd/server/notification_cmd.go
@@ -40,6 +40,26 @@ func newNotificationChannelsCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "channels", Short: "Notification channels"}
 	cmd.AddCommand(newNotificationChannelCreateCmd(), newNotificationChannelDeleteCmd(), newNotificationChannelTestCmd())
 	cmd.AddCommand(&cobra.Command{
+		Use:     "seal-secrets",
+		Short:   "Encrypt any plaintext channel secrets at rest (JAB-171 one-time backfill)",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := ssoKeyForCLI()
+			if key == nil {
+				return fmt.Errorf("SSO signing key not configured; cannot seal secrets")
+			}
+			repo := repository.NewNotificationChannelRepository(sharedDB, repository.WithSealKey(*key))
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+			n, err := repo.SealAllPlaintext(ctx)
+			if err != nil {
+				return fmt.Errorf("seal secrets: %w", err)
+			}
+			fmt.Printf("Sealed %d channel(s) that had plaintext secrets.\n", n)
+			return nil
+		},
+	})
+	cmd.AddCommand(&cobra.Command{
 		Use:     "list",
 		Short:   "List configured notification channels",
 		Args:    cobra.NoArgs,

--- a/panel-api/cmd/server/notification_send_cmd.go
+++ b/panel-api/cmd/server/notification_send_cmd.go
@@ -25,6 +25,11 @@ import (
 )
 
 func notificationChannelRepoFromDB() repository.NotificationChannelRepository {
+	// Seal channel secrets at rest when a key is available (JAB-171), so a
+	// CLI-created channel stores its token/password encrypted just like the API.
+	if key := ssoKeyForCLI(); key != nil {
+		return repository.NewNotificationChannelRepository(sharedDB, repository.WithSealKey(*key))
+	}
 	return repository.NewNotificationChannelRepository(sharedDB)
 }
 

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -282,7 +282,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// from deps. Dispatcher only starts when cfg.Redis.URL resolved
 		// and at least one ChannelSender is registered (Step 3 adds the
 		// concrete senders — slack, ntfy, webhook, webpush, email).
-		deps.NotificationChannels = repository.NewNotificationChannelRepository(sharedDB)
+		// Seal channel secrets at rest (JAB-171): tokens/passwords in
+		// config_json are encrypted with the SSO key before persist. Without
+		// a key configured, the repo stores configs verbatim (unchanged).
+		var channelRepoOpts []repository.ChannelRepoOption
+		if ssoKeyPtr != nil {
+			channelRepoOpts = append(channelRepoOpts, repository.WithSealKey(*ssoKeyPtr))
+		}
+		deps.NotificationChannels = repository.NewNotificationChannelRepository(sharedDB, channelRepoOpts...)
 		deps.NotificationHistory = repository.NewNotificationHistoryRepository(sharedDB)
 		deps.UserNotificationRoutes = repository.NewUserNotificationRouteRepository(sharedDB)
 		deps.WebhookEndpoints = repository.NewWebhookEndpointRepository(sharedDB)
@@ -1195,6 +1202,9 @@ func startNotificationDispatcher(parent context.Context, deps app.Deps, log *slo
 	}
 	if err == nil && deps.UserNotificationRoutes != nil {
 		d.WithUserRoutes(deps.UserNotificationRoutes)
+	}
+	if err == nil && deps.SSOKey != nil {
+		d.WithSecretKey(deps.SSOKey)
 	}
 	if err != nil {
 		log.Error("notifications dispatcher: construction failed", "err", err)

--- a/panel-api/internal/api/notifications_channels.go
+++ b/panel-api/internal/api/notifications_channels.go
@@ -14,7 +14,9 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 // NotificationsChannelsHandlerConfig wires the admin-facing
@@ -31,6 +33,18 @@ type NotificationsChannelsHandlerConfig struct {
 	Registry        *notifications.Registry
 	Log             *slog.Logger
 	StrictRateLimit gin.HandlerFunc
+	// SSOKey opens sealed channel secrets for the synchronous "Send test"
+	// path (JAB-171). Nil = secrets used as stored (legacy plaintext).
+	SSOKey *ssokey.Key
+}
+
+// redactChannelSecrets blanks every secret field on each channel's config so a
+// GET never echoes a token/password (JAB-171). Operates on the passed rows,
+// which are response-local copies loaded from the DB.
+func redactChannelSecrets(rows []models.NotificationChannel) {
+	for i := range rows {
+		notifsecret.Redact(&rows[i].Config)
+	}
 }
 
 // RegisterNotificationsChannelsRoutes mounts:
@@ -98,6 +112,7 @@ func (h *notificationsChannelsHandler) list(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "list failed"})
 		return
 	}
+	redactChannelSecrets(rows)
 	c.JSON(http.StatusOK, channelListResponse{Data: rows, Total: int(total), Page: page, PageSize: pageSize})
 }
 
@@ -138,6 +153,7 @@ func (h *notificationsChannelsHandler) create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "create failed"})
 		return
 	}
+	notifsecret.Redact(&row.Config)
 	c.JSON(http.StatusCreated, row)
 }
 
@@ -172,11 +188,18 @@ func (h *notificationsChannelsHandler) update(c *gin.Context) {
 		existing.Name = *req.Name
 	}
 	if req.Config != nil {
-		if err := validateChannelKindAndConfig(existing.Kind, *req.Config); err != nil {
+		// Write-only secrets: a secret left empty in the request keeps its
+		// stored (sealed) value, so editing a channel after a redacted GET
+		// doesn't wipe the token/password (JAB-171). Validate the MERGED
+		// config so a secret-presence rule (e.g. webhook hmac_secret) still
+		// passes on a preserved secret.
+		merged := *req.Config
+		notifsecret.PreserveEmptySecrets(&merged, existing.Config)
+		if err := validateChannelKindAndConfig(existing.Kind, merged); err != nil {
 			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 			return
 		}
-		existing.Config = *req.Config
+		existing.Config = merged
 	}
 	if req.Enabled != nil {
 		existing.Enabled = *req.Enabled
@@ -186,6 +209,7 @@ func (h *notificationsChannelsHandler) update(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "update failed"})
 		return
 	}
+	notifsecret.Redact(&existing.Config)
 	c.JSON(http.StatusOK, existing)
 }
 
@@ -236,6 +260,12 @@ func (h *notificationsChannelsHandler) test(c *gin.Context) {
 	// Synchronous send (GH #322): deliver now and report the real result so a
 	// misconfigured channel (e.g. SMTP auth failure) surfaces immediately
 	// instead of failing silently in the async dispatcher.
+	if h.cfg.SSOKey != nil {
+		if oerr := notifsecret.Open(&ch.Config, *h.cfg.SSOKey); oerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "open channel secrets"})
+			return
+		}
+	}
 	if h.cfg.Registry != nil {
 		sender, lerr := h.cfg.Registry.Lookup(ch.Kind)
 		if lerr != nil {

--- a/panel-api/internal/api/notifications_channels_test.go
+++ b/panel-api/internal/api/notifications_channels_test.go
@@ -88,6 +88,8 @@ func (f *fakeChannelsRepo) FindEnabledServerWide(context.Context) ([]models.Noti
 	return nil, nil
 }
 
+func (f *fakeChannelsRepo) SealAllPlaintext(context.Context) (int, error) { return 0, nil }
+
 // --- test plumbing ---
 
 func newAdminCtx() gin.HandlerFunc {
@@ -304,4 +306,32 @@ func TestChannels_Broadcast_BadSeverityIs422(t *testing.T) {
 		"severity": "hmm",
 	})
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+// JAB-171 phase 3: a channel's secret is never echoed by create or list.
+func TestChannels_Create_SecretNotEchoed(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	r := newChannelsRouter(t, repo, nil, newAdminCtx())
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/admin/notifications/channels", map[string]any{
+		"name":   "tg",
+		"kind":   "telegram",
+		"config": map[string]any{"bot_token": "123:SUPER-SECRET", "chat_id": "42"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "SUPER-SECRET", "create must not echo the bot token")
+	require.NotContains(t, rec.Body.String(), "bot_token")
+}
+
+func TestChannels_List_SecretNotEchoed(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"a": {ID: "a", Name: "tg", Kind: "telegram", Enabled: true,
+			Config: models.NotificationChannelConfig{BotToken: "enc:1:sealedvalue", ChatID: "42"}},
+	}}
+	r := newChannelsRouter(t, repo, nil, newAdminCtx())
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/admin/notifications/channels", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "sealedvalue", "list must not echo the sealed secret")
+	require.Contains(t, rec.Body.String(), "\"chat_id\":\"42\"", "public config fields should still appear")
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -913,6 +913,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Registry:        deps.NotificationRegistry,
 				Log:             deps.Log,
 				StrictRateLimit: rl.Strict(),
+				SSOKey:          deps.SSOKey,
 			})
 		}
 		// M31.1 follow-up — DLQ inspector (list / replay / drop / clear).

--- a/panel-api/internal/notifications/dispatcher.go
+++ b/panel-api/internal/notifications/dispatcher.go
@@ -14,7 +14,9 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 // Config tunes the dispatcher's loop behaviours. Zero values pick
@@ -86,8 +88,12 @@ type Dispatcher struct {
 	// pre-JAB-171 behaviour). When set, a user-scoped envelope also reaches
 	// the recipient's OWN channels that they routed this event kind to.
 	userRoutes repository.UserNotificationRouteRepository
-	log        *slog.Logger
-	consumer   string
+	// secretKey opens sealed channel secrets (tokens/passwords) just before a
+	// sender is invoked (JAB-171). Optional — when nil, configs are used as
+	// stored (fine for pre-seal rows / tests).
+	secretKey *ssokey.Key
+	log       *slog.Logger
+	consumer  string
 
 	wg      sync.WaitGroup
 	stopped chan struct{}
@@ -115,6 +121,14 @@ func (d *Dispatcher) WithUsers(r repository.UserRepository) *Dispatcher {
 // is unchanged (server-wide channels only).
 func (d *Dispatcher) WithUserRoutes(r repository.UserNotificationRouteRepository) *Dispatcher {
 	d.userRoutes = r
+	return d
+}
+
+// WithSecretKey injects the SSO key so sealed channel secrets are opened just
+// before delivery (JAB-171 phase 3). Without it, configs are passed to senders
+// as stored — fine for legacy plaintext rows and tests.
+func (d *Dispatcher) WithSecretKey(key *ssokey.Key) *Dispatcher {
+	d.secretKey = key
 	return d
 }
 
@@ -448,6 +462,13 @@ func (d *Dispatcher) recipientRoutedChannels(ctx context.Context, userID, eventK
 // updates the webhook_endpoints retry state, and trips the circuit
 // breaker when consecutive failures reach the limit.
 func (d *Dispatcher) sendOne(ctx context.Context, ch models.NotificationChannel, env Envelope) error {
+	// Open sealed secrets on this local copy just before the sender reads them.
+	// ch is passed by value, so the plaintext never escapes this call.
+	if d.secretKey != nil {
+		if err := notifsecret.Open(&ch.Config, *d.secretKey); err != nil {
+			return fmt.Errorf("open channel secrets: %w", err)
+		}
+	}
 	hist := &models.NotificationHistory{
 		ID:        ulid.Make().String(),
 		ChannelID: strPtr(ch.ID),

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 // --- helpers ---
@@ -98,6 +100,8 @@ func (f *fakeChannels) FindEnabledAll(ctx context.Context) ([]models.Notificatio
 // FindEnabledServerWide returns only the global (user_id IS NULL) enabled
 // channels — mirrors the SQL filter so dispatcher tests can assert tenant-owned
 // channels are excluded from broadcast/server fan-out (JAB-171).
+func (f *fakeChannels) SealAllPlaintext(ctx context.Context) (int, error) { return 0, nil }
+
 func (f *fakeChannels) FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -529,5 +533,37 @@ func TestResolveTargets_PerUserRouting(t *testing.T) {
 	m = ids(got)
 	if !m["G1"] || m["A1"] || m["B1"] {
 		t.Errorf("userA unrouted event: want {G1}, got %v", m)
+	}
+}
+
+// JAB-171 phase 3: the dispatcher opens a sealed secret just before the sender
+// reads it — the sender must see plaintext, never the enc:1: envelope.
+func TestSendOne_OpensSealedSecret(t *testing.T) {
+	var key ssokey.Key
+	for i := range key {
+		key[i] = byte(i + 7)
+	}
+	var gotToken string
+	fs := &fakeSender{kind: "telegram", hookErr: func(ch models.NotificationChannel, env Envelope) error {
+		gotToken = ch.Config.BotToken
+		return nil
+	}}
+	d, _, _, _, _ := newFixture(t, fs)
+	d.WithSecretKey(&key)
+
+	cfg := models.NotificationChannelConfig{BotToken: "123:PLAINTEXT-TOKEN"}
+	if err := notifsecret.Seal(&cfg, key); err != nil {
+		t.Fatal(err)
+	}
+	if gotToken := cfg.BotToken; gotToken == "123:PLAINTEXT-TOKEN" {
+		t.Fatal("precondition: config should be sealed")
+	}
+	ch := models.NotificationChannel{ID: "c1", Kind: "telegram", Enabled: true, Config: cfg}
+
+	if err := d.sendOne(context.Background(), ch, Envelope{EventKind: "x", StreamID: "s1"}); err != nil {
+		t.Fatalf("sendOne: %v", err)
+	}
+	if gotToken != "123:PLAINTEXT-TOKEN" {
+		t.Errorf("sender saw %q, want the opened plaintext token", gotToken)
 	}
 }

--- a/panel-api/internal/notifsecret/notifsecret.go
+++ b/panel-api/internal/notifsecret/notifsecret.go
@@ -1,0 +1,125 @@
+// Package notifsecret seals/opens the secret fields of a notification channel
+// config at rest (JAB-171 phase 3). Bot tokens, bearer tokens, HMAC secrets and
+// SMTP passwords must never sit in the DB as plaintext nor be echoed by any GET.
+//
+// A sealed value is stored in-place in the same string field as
+// `enc:1:<base64url(ssokey envelope)>`. This lets a single JSON blob hold a mix
+// of plaintext public fields (url, topic, chat id) and sealed secret fields,
+// and lets a pre-JAB-171 plaintext row be detected (no prefix) and backfilled.
+//
+// This package is a leaf: it imports only models + ssokey, so both the
+// repository (seal on write) and the notifications dispatcher (open on send)
+// can use it without an import cycle.
+package notifsecret
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+const sealPrefix = "enc:1:"
+
+// secretPtrs returns pointers to every secret string field on the config so
+// Seal/Open/Redact can treat them uniformly. Add new secret fields here.
+func secretPtrs(cfg *models.NotificationChannelConfig) []*string {
+	return []*string{
+		&cfg.Bearer,
+		&cfg.HMACSecret,
+		&cfg.SMTPPassword,
+		&cfg.BotToken,
+	}
+}
+
+func isSealed(s string) bool { return strings.HasPrefix(s, sealPrefix) }
+
+// Seal encrypts every non-empty, not-already-sealed secret field in place.
+// Idempotent: an already-sealed field is left untouched, so re-sealing a row
+// (or sealing a row with a mix of new plaintext + existing sealed fields) is
+// safe.
+func Seal(cfg *models.NotificationChannelConfig, key ssokey.Key) error {
+	for _, p := range secretPtrs(cfg) {
+		if *p == "" || isSealed(*p) {
+			continue
+		}
+		env, err := key.Seal([]byte(*p))
+		if err != nil {
+			return err
+		}
+		*p = sealPrefix + base64.RawURLEncoding.EncodeToString(env)
+	}
+	return nil
+}
+
+// Open decrypts every sealed secret field in place. A field without the seal
+// prefix is treated as legacy plaintext and left as-is (defensive during the
+// backfill window). Call this only on an in-memory copy about to be handed to a
+// sender — never persist an opened config.
+func Open(cfg *models.NotificationChannelConfig, key ssokey.Key) error {
+	for _, p := range secretPtrs(cfg) {
+		if !isSealed(*p) {
+			continue
+		}
+		env, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(*p, sealPrefix))
+		if err != nil {
+			return err
+		}
+		pt, err := key.Open(env)
+		if err != nil {
+			return err
+		}
+		*p = string(pt)
+	}
+	return nil
+}
+
+// Redact blanks every secret field and reports whether any was set. Use before
+// returning a channel from any API GET so a secret is never echoed. Operates on
+// the passed config, so pass a copy.
+func Redact(cfg *models.NotificationChannelConfig) (hasSecret bool) {
+	for _, p := range secretPtrs(cfg) {
+		if *p != "" {
+			hasSecret = true
+			*p = ""
+		}
+	}
+	return hasSecret
+}
+
+// PreserveEmptySecrets implements write-only secret semantics: for each secret
+// field the incoming config leaves empty, restore the previous value. This lets
+// an edit that doesn't re-enter a token (because a GET redacted it) keep the
+// stored secret instead of wiping it. Call before Seal on the update path.
+func PreserveEmptySecrets(next *models.NotificationChannelConfig, prev models.NotificationChannelConfig) {
+	np := secretPtrs(next)
+	pp := secretPtrs(&prev)
+	for i := range np {
+		if *np[i] == "" {
+			*np[i] = *pp[i]
+		}
+	}
+}
+
+// HasSealed reports whether any secret field is currently sealed (used by the
+// backfill to skip already-migrated rows without a key).
+func HasSealed(cfg *models.NotificationChannelConfig) bool {
+	for _, p := range secretPtrs(cfg) {
+		if isSealed(*p) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasPlaintextSecret reports whether any secret field holds an unsealed
+// non-empty value — i.e. a row that still needs backfilling.
+func HasPlaintextSecret(cfg *models.NotificationChannelConfig) bool {
+	for _, p := range secretPtrs(cfg) {
+		if *p != "" && !isSealed(*p) {
+			return true
+		}
+	}
+	return false
+}

--- a/panel-api/internal/notifsecret/notifsecret_test.go
+++ b/panel-api/internal/notifsecret/notifsecret_test.go
@@ -1,0 +1,100 @@
+package notifsecret
+
+import (
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+func testKey() ssokey.Key {
+	var k ssokey.Key
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+func TestSealOpen_RoundTrip(t *testing.T) {
+	key := testKey()
+	cfg := models.NotificationChannelConfig{
+		URL:          "https://ntfy.example/topic", // public — must survive untouched
+		BotToken:     "123:SECRET-BOT",
+		SMTPPassword: "hunter2",
+		Bearer:       "bearer-abc",
+		HMACSecret:   "hmac-0123456789abcdef",
+	}
+	if err := Seal(&cfg, key); err != nil {
+		t.Fatal(err)
+	}
+	// Secrets are now sealed (prefixed, not the original), public field intact.
+	if cfg.URL != "https://ntfy.example/topic" {
+		t.Error("public URL field must not be sealed")
+	}
+	for _, s := range []string{cfg.BotToken, cfg.SMTPPassword, cfg.Bearer, cfg.HMACSecret} {
+		if !strings.HasPrefix(s, sealPrefix) {
+			t.Errorf("secret not sealed: %q", s)
+		}
+	}
+	if strings.Contains(cfg.BotToken, "SECRET-BOT") {
+		t.Error("plaintext token still present after seal")
+	}
+	// Idempotent: sealing again is a no-op.
+	before := cfg.BotToken
+	if err := Seal(&cfg, key); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BotToken != before {
+		t.Error("Seal is not idempotent")
+	}
+	// Open recovers the plaintext.
+	if err := Open(&cfg, key); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BotToken != "123:SECRET-BOT" || cfg.SMTPPassword != "hunter2" {
+		t.Errorf("Open did not recover secrets: %+v", cfg)
+	}
+}
+
+func TestRedact_BlanksAndReports(t *testing.T) {
+	cfg := models.NotificationChannelConfig{URL: "https://x", BotToken: "enc:1:whatever"}
+	if got := Redact(&cfg); !got {
+		t.Error("Redact should report hasSecret=true")
+	}
+	if cfg.BotToken != "" {
+		t.Errorf("BotToken not blanked: %q", cfg.BotToken)
+	}
+	if cfg.URL != "https://x" {
+		t.Error("public field must survive redaction")
+	}
+	empty := models.NotificationChannelConfig{URL: "https://x"}
+	if Redact(&empty) {
+		t.Error("Redact should report hasSecret=false when no secret set")
+	}
+}
+
+func TestPreserveEmptySecrets_WriteOnly(t *testing.T) {
+	prev := models.NotificationChannelConfig{BotToken: "enc:1:OLD", SMTPPassword: "enc:1:OLDPW"}
+	// Incoming edit: new token, but SMTP password left empty (keep existing).
+	next := models.NotificationChannelConfig{BotToken: "new-plaintext", SMTPPassword: ""}
+	PreserveEmptySecrets(&next, prev)
+	if next.BotToken != "new-plaintext" {
+		t.Errorf("a provided secret must be kept, got %q", next.BotToken)
+	}
+	if next.SMTPPassword != "enc:1:OLDPW" {
+		t.Errorf("an empty secret must preserve the previous value, got %q", next.SMTPPassword)
+	}
+}
+
+func TestHasPlaintextSecret(t *testing.T) {
+	if !HasPlaintextSecret(&models.NotificationChannelConfig{BotToken: "raw"}) {
+		t.Error("raw token should be flagged plaintext")
+	}
+	if HasPlaintextSecret(&models.NotificationChannelConfig{BotToken: "enc:1:x"}) {
+		t.Error("sealed token must not be flagged plaintext")
+	}
+	if HasPlaintextSecret(&models.NotificationChannelConfig{URL: "https://x"}) {
+		t.Error("no secret should not be flagged")
+	}
+}

--- a/panel-api/internal/repository/notification_channel_repository.go
+++ b/panel-api/internal/repository/notification_channel_repository.go
@@ -7,6 +7,8 @@ import (
 	"gorm.io/gorm"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 // NotificationChannelRepository covers the notification_channels table
@@ -34,20 +36,79 @@ type NotificationChannelRepository interface {
 	// dispatcher uses this as the base fan-out set so a tenant-owned channel
 	// never receives a broadcast/server event (JAB-171).
 	FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error)
+
+	// SealAllPlaintext encrypts any unsealed secret fields across every row
+	// (the one-time JAB-171 backfill for pre-existing admin channels). Returns
+	// how many rows were re-sealed. No-op when the repo has no seal key.
+	SealAllPlaintext(ctx context.Context) (int, error)
 }
 
-type notificationChannelRepo struct{ db *gorm.DB }
+type notificationChannelRepo struct {
+	db      *gorm.DB
+	sealKey *ssokey.Key
+}
 
-func NewNotificationChannelRepository(db *gorm.DB) NotificationChannelRepository {
-	return &notificationChannelRepo{db: db}
+// ChannelRepoOption configures the channel repo (JAB-171). Variadic so existing
+// NewNotificationChannelRepository(db) call sites keep compiling.
+type ChannelRepoOption func(*notificationChannelRepo)
+
+// WithSealKey enables secret-at-rest encryption: Create/Update seal the config's
+// secret fields before persisting. Without it (tests, CLI without a key) the
+// repo stores configs verbatim.
+func WithSealKey(key ssokey.Key) ChannelRepoOption {
+	return func(r *notificationChannelRepo) { k := key; r.sealKey = &k }
+}
+
+func NewNotificationChannelRepository(db *gorm.DB, opts ...ChannelRepoOption) NotificationChannelRepository {
+	r := &notificationChannelRepo{db: db}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
 }
 
 func (r *notificationChannelRepo) Create(ctx context.Context, ch *models.NotificationChannel) error {
+	if r.sealKey != nil {
+		if err := notifsecret.Seal(&ch.Config, *r.sealKey); err != nil {
+			return err
+		}
+	}
 	return r.db.WithContext(ctx).Create(ch).Error
 }
 
 func (r *notificationChannelRepo) Update(ctx context.Context, ch *models.NotificationChannel) error {
+	if r.sealKey != nil {
+		if err := notifsecret.Seal(&ch.Config, *r.sealKey); err != nil {
+			return err
+		}
+	}
 	return r.db.WithContext(ctx).Save(ch).Error
+}
+
+func (r *notificationChannelRepo) SealAllPlaintext(ctx context.Context) (int, error) {
+	if r.sealKey == nil {
+		return 0, errors.New("seal key not configured")
+	}
+	var rows []models.NotificationChannel
+	if err := r.db.WithContext(ctx).Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	sealed := 0
+	for i := range rows {
+		if !notifsecret.HasPlaintextSecret(&rows[i].Config) {
+			continue
+		}
+		if err := notifsecret.Seal(&rows[i].Config, *r.sealKey); err != nil {
+			return sealed, err
+		}
+		if err := r.db.WithContext(ctx).Model(&models.NotificationChannel{}).
+			Where("id = ?", rows[i].ID).
+			Update("config_json", rows[i].Config).Error; err != nil {
+			return sealed, err
+		}
+		sealed++
+	}
+	return sealed, nil
 }
 
 func (r *notificationChannelRepo) Delete(ctx context.Context, id string) error {


### PR DESCRIPTION
## What

**Unify-encrypt** (the operator-chosen scope). Channel secrets — bot tokens, bearer/HMAC secrets, SMTP passwords — are sealed at rest for **all** channels (admin + tenant) and **never returned by any GET**. This closes a latent gap the blueprint review found: admin channels stored these as **plaintext** in `config_json` and echoed them on list. It's also the foundation for phase 3b, where tenants supply their own secrets.

## How
- **`notifsecret`** (new leaf pkg, imports only models+ssokey → no import cycle): `Seal`/`Open` (ssokey AES-GCM envelope, in-place `enc:1:<base64>` marker so one JSON blob mixes plaintext public fields + sealed secrets), `Redact` (blank for responses), `PreserveEmptySecrets` (write-only edits), + plaintext/sealed detection for the backfill.
- **repo**: `WithSealKey` option (variadic — existing `NewNotificationChannelRepository(db)` call sites unchanged) seals on Create/Update; `SealAllPlaintext` backfill.
- **dispatcher**: `WithSecretKey`; `sendOne` opens the sealed secret on a **by-value copy** just before the sender reads it — senders unchanged, plaintext never touches the DB or escapes the call.
- **admin API**: list/create/update responses redacted; the synchronous **Send test** opens secrets first; update is **write-only** (an empty secret keeps the stored one; validated on the merged config, so editing after a redacted GET can't wipe a token).
- **CLI**: `jabali notification channels seal-secrets` one-time backfill; CLI channel-create now seals too.

Legacy plaintext rows keep working (`Open` skips unsealed fields) until the backfill runs — no flag day.

## Test plan
- [x] `notifsecret`: Seal↔Open round-trip, Redact blanks+reports, write-only preserve, plaintext detection.
- [x] dispatcher: a sealed bot token is **opened before the sender sees it** (sender receives plaintext, never the `enc:1:` envelope).
- [x] admin API: create + list **never echo** the secret (and public fields survive).
- [x] `go vet ./...`, `go test -race` (notifsecret/notifications/api/repository/app), CLI golden regenerated.
- No new routes (no openapi change), no migration.

## Deploy note
Existing admin channels stay plaintext-but-working until `jabali notification channels seal-secrets` runs. Auto-running it in the `jabali update` prelude is a reasonable follow-up.

## Next
Phase 3b — tenant API `/me/notifications/*` (CRUD own channels + routing + test), ownership-scoped, kind-allowlist stub. Then phase 4 (SSRF + full allowlist + rate limits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)