### PR TITLE
feat(notifications): tenant /me/notifications API, gated off (JAB-171 phase 3b)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -1,0 +1,461 @@
+// Tenant-facing notification channels + routing (JAB-171 phase 3b).
+//
+//	GET    /me/notifications/channels          list the caller's own channels
+//	POST   /me/notifications/channels          create an own channel (kind-gated)
+//	PATCH  /me/notifications/channels/:id       update an own channel (write-only secrets)
+//	DELETE /me/notifications/channels/:id       delete an own channel
+//	POST   /me/notifications/channels/:id/test  synchronous test-send to an own channel
+//	GET    /me/notifications/routes             list the caller's event→channel routes
+//	POST   /me/notifications/routes             route one event kind to an own channel
+//	DELETE /me/notifications/routes/:id         delete an own route
+//
+// SECURITY — this surface is gated behind ServerSettings.TenantNotificationsEnabled,
+// which defaults OFF and has no admin toggle until phase 4. The gate fails CLOSED
+// (unreadable settings → 403) because, unlike a UI module, exposing this early
+// would let a tenant point an ntfy/discord channel at an internal address before
+// the phase-4 SSRF guard exists. Every handler is ownership-scoped to
+// claims.UserID and returns 404 (never 403) for another user's IDs so channel
+// existence never leaks. Secrets are sealed at rest (notifsecret) and redacted on
+// every response; edits are write-only (empty secret keeps the stored one).
+//
+// The tenant-creatable kind allowlist is a STUB: only ntfy/telegram/discord/
+// webpush in phase 3b. email (needs verified-address plumbing), webhook, sms and
+// slack are rejected until phase 4 adds SSRF + email-verify + the admin-controlled
+// allowlist. Because ntfy/discord carry a user-supplied URL that is NOT yet
+// SSRF-guarded, the master flag MUST stay off until phase 4 — the two land together.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifsecret"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// MeNotificationsConfig wires the per-user notification surface. Channels +
+// Routes + ServerSettings are mandatory; without them the routes stay unmounted
+// so a partial DI graph never half-serves the feature. Registry powers the
+// synchronous test-send; nil → /test returns 503. SSOKey opens sealed secrets
+// for the test send; nil → secrets used as stored (legacy plaintext).
+type MeNotificationsConfig struct {
+	Channels       repository.NotificationChannelRepository
+	Routes         repository.UserNotificationRouteRepository
+	ServerSettings repository.ServerSettingsRepository
+	Registry       *notifications.Registry
+	SSOKey         *ssokey.Key
+	Log            *slog.Logger
+}
+
+// tenantChannelKinds is the phase-3b allowlist of kinds a tenant may create.
+// Deliberately narrow: email/webhook/sms/slack are withheld until phase 4 adds
+// SSRF guarding, the admin-controlled allowlist and email verified-address
+// plumbing. See the file header.
+var tenantChannelKinds = map[string]struct{}{
+	models.NotificationChannelKindNtfy:     {},
+	models.NotificationChannelKindTelegram: {},
+	models.NotificationChannelKindDiscord:  {},
+	models.NotificationChannelKindWebpush:  {},
+}
+
+// RegisterMeNotificationsRoutes mounts the /me/notifications/* surface. Auth
+// comes from the parent group; handlers resolve the caller from the session and
+// enforce ownership + the master gate themselves.
+func RegisterMeNotificationsRoutes(g *gin.RouterGroup, cfg MeNotificationsConfig) {
+	if cfg.Channels == nil || cfg.Routes == nil || cfg.ServerSettings == nil {
+		return
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.Default()
+	}
+	h := &meNotificationsHandler{cfg: cfg}
+	grp := g.Group("/me/notifications")
+	grp.GET("/channels", h.listChannels)
+	grp.POST("/channels", h.createChannel)
+	grp.PATCH("/channels/:id", h.updateChannel)
+	grp.DELETE("/channels/:id", h.deleteChannel)
+	grp.POST("/channels/:id/test", h.testChannel)
+	grp.GET("/routes", h.listRoutes)
+	grp.POST("/routes", h.createRoute)
+	grp.DELETE("/routes/:id", h.deleteRoute)
+}
+
+type meNotificationsHandler struct {
+	cfg MeNotificationsConfig
+}
+
+// gateOpen reports whether the tenant surface is enabled. Fails CLOSED: a nil
+// repo, a read error, or the flag being off all yield false, and the caller
+// aborts with 403. Security-sensitive — never fail open here.
+func (h *meNotificationsHandler) gateOpen(c *gin.Context) bool {
+	st, err := h.cfg.ServerSettings.Get(c.Request.Context())
+	if err != nil || st == nil || !st.TenantNotificationsEnabled {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error":   "tenant_notifications_disabled",
+			"message": "per-user notification channels are not enabled on this server",
+		})
+		return false
+	}
+	return true
+}
+
+// loadOwnedChannel fetches a channel and enforces tenant ownership. Any miss —
+// not found, or owned by someone else / server-wide — returns a uniform 404 so
+// a tenant can't probe for another user's channel IDs.
+func (h *meNotificationsHandler) loadOwnedChannel(c *gin.Context, id, userID string) (*models.NotificationChannel, bool) {
+	ch, err := h.cfg.Channels.FindByID(c.Request.Context(), id)
+	if err != nil || ch == nil || ch.UserID == nil || *ch.UserID != userID {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return nil, false
+	}
+	return ch, true
+}
+
+func (h *meNotificationsHandler) listChannels(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	rows, err := h.cfg.Channels.ListByUser(c.Request.Context(), claims.UserID)
+	if err != nil {
+		h.cfg.Log.Error("list own channels failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "list_failed"})
+		return
+	}
+	redactChannelSecrets(rows)
+	c.JSON(http.StatusOK, gin.H{"items": rows})
+}
+
+type meChannelCreateReq struct {
+	Name    string                           `json:"name"`
+	Kind    string                           `json:"kind"`
+	Config  models.NotificationChannelConfig `json:"config"`
+	Enabled *bool                            `json:"enabled"`
+}
+
+func (h *meNotificationsHandler) createChannel(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	var req meChannelCreateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json: " + err.Error()})
+		return
+	}
+	if err := validateChannelName(req.Name); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	if err := requireTenantKind(req.Kind); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	if err := validateChannelKindAndConfig(req.Kind, req.Config); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	uid := claims.UserID
+	row := &models.NotificationChannel{
+		ID:      ids.NewULID(),
+		UserID:  &uid, // ownership is server-assigned, never from the body.
+		Name:    req.Name,
+		Kind:    req.Kind,
+		Config:  req.Config,
+		Enabled: enabled,
+	}
+	if err := h.cfg.Channels.Create(c.Request.Context(), row); err != nil {
+		h.cfg.Log.Error("create own channel failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_failed"})
+		return
+	}
+	notifsecret.Redact(&row.Config)
+	c.JSON(http.StatusCreated, row)
+}
+
+type meChannelUpdateReq struct {
+	Name    *string                           `json:"name"`
+	Config  *models.NotificationChannelConfig `json:"config"`
+	Enabled *bool                             `json:"enabled"`
+}
+
+func (h *meNotificationsHandler) updateChannel(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	existing, ok := h.loadOwnedChannel(c, c.Param("id"), claims.UserID)
+	if !ok {
+		return
+	}
+	var req meChannelUpdateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json: " + err.Error()})
+		return
+	}
+	if req.Name != nil {
+		if err := validateChannelName(*req.Name); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+			return
+		}
+		existing.Name = *req.Name
+	}
+	if req.Config != nil {
+		// Write-only secrets: an empty secret in the request keeps the stored
+		// (sealed) value, so editing after a redacted GET never wipes a token.
+		// Validate the MERGED config so presence rules pass on preserved secrets.
+		merged := *req.Config
+		notifsecret.PreserveEmptySecrets(&merged, existing.Config)
+		if err := validateChannelKindAndConfig(existing.Kind, merged); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+			return
+		}
+		existing.Config = merged
+	}
+	if req.Enabled != nil {
+		existing.Enabled = *req.Enabled
+	}
+	if err := h.cfg.Channels.Update(c.Request.Context(), existing); err != nil {
+		h.cfg.Log.Error("update own channel failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "update_failed"})
+		return
+	}
+	notifsecret.Redact(&existing.Config)
+	c.JSON(http.StatusOK, existing)
+}
+
+func (h *meNotificationsHandler) deleteChannel(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	ch, ok := h.loadOwnedChannel(c, c.Param("id"), claims.UserID)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	// Drop the routes first (belt-and-suspenders alongside ON DELETE CASCADE) so
+	// a dangling route never survives its channel.
+	if err := h.cfg.Routes.DeleteByChannel(ctx, ch.ID); err != nil {
+		h.cfg.Log.Error("delete routes for channel failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed"})
+		return
+	}
+	if err := h.cfg.Channels.Delete(ctx, ch.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *meNotificationsHandler) testChannel(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	if h.cfg.Registry == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dispatcher not initialised"})
+		return
+	}
+	ch, ok := h.loadOwnedChannel(c, c.Param("id"), claims.UserID)
+	if !ok {
+		return
+	}
+	if !ch.Enabled {
+		c.JSON(http.StatusConflict, gin.H{"error": "channel is disabled — enable it before testing"})
+		return
+	}
+	sender, lerr := h.cfg.Registry.Lookup(ch.Kind)
+	if lerr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no sender for channel kind " + ch.Kind})
+		return
+	}
+	// Open sealed secrets on this by-value copy before handing it to the sender;
+	// the stored row stays sealed.
+	if h.cfg.SSOKey != nil {
+		if oerr := notifsecret.Open(&ch.Config, *h.cfg.SSOKey); oerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "open channel secrets"})
+			return
+		}
+	}
+	env := notifications.Envelope{
+		EventKind: "notifications.channel.test",
+		Severity:  models.NotificationSeverityInfo,
+		Title:     fmt.Sprintf("Test notification for %s", ch.Name),
+		Body:      "Synthetic envelope fired by the notifications 'Send test' button. If you see it, the channel is wired up correctly.",
+		Deeplink:  "/me/notifications",
+	}
+	if serr := sender.Send(c.Request.Context(), *ch, env); serr != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "delivery failed: " + serr.Error(), "channel_id": ch.ID})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"delivered": true, "channel_id": ch.ID})
+}
+
+// --- routes (event_kind → channel) ---
+
+func (h *meNotificationsHandler) listRoutes(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	rows, err := h.cfg.Routes.ListByUser(c.Request.Context(), claims.UserID)
+	if err != nil {
+		h.cfg.Log.Error("list own routes failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "list_failed"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"items": rows})
+}
+
+type meRouteCreateReq struct {
+	EventKind string `json:"event_kind"`
+	ChannelID string `json:"channel_id"`
+}
+
+func (h *meNotificationsHandler) createRoute(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	var req meRouteCreateReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json: " + err.Error()})
+		return
+	}
+	req.EventKind = strings.TrimSpace(req.EventKind)
+	if err := validateEventKind(req.EventKind); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	// The target channel must exist AND be owned by the caller — this is what
+	// stops a tenant from routing their events at someone else's channel.
+	if _, ok := h.loadOwnedChannel(c, req.ChannelID, claims.UserID); !ok {
+		return
+	}
+	route := &models.UserNotificationRoute{
+		ID:        ids.NewULID(),
+		UserID:    claims.UserID,
+		EventKind: req.EventKind,
+		ChannelID: req.ChannelID,
+	}
+	if err := h.cfg.Routes.Create(c.Request.Context(), route); err != nil {
+		// UNIQUE(user_id,event_kind,channel_id) → duplicate is a 409, not a 500.
+		if isDuplicateKeyErr(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": "route already exists"})
+			return
+		}
+		h.cfg.Log.Error("create route failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_failed"})
+		return
+	}
+	c.JSON(http.StatusCreated, route)
+}
+
+func (h *meNotificationsHandler) deleteRoute(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	claims, ok := requireBrowserAuth(c)
+	if !ok {
+		return
+	}
+	id := c.Param("id")
+	// Ownership: confirm the route id belongs to the caller before deleting, so
+	// a tenant can't delete another user's route by guessing its id. Uniform 404.
+	routes, err := h.cfg.Routes.ListByUser(c.Request.Context(), claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed"})
+		return
+	}
+	owned := false
+	for i := range routes {
+		if routes[i].ID == id {
+			owned = true
+			break
+		}
+	}
+	if !owned {
+		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	if err := h.cfg.Routes.Delete(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "delete_failed"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// --- validation helpers ---
+
+// requireTenantKind gates channel creation to the phase-3b tenant allowlist.
+func requireTenantKind(kind string) error {
+	if _, ok := tenantChannelKinds[kind]; !ok {
+		return fmt.Errorf("channel kind %q is not available for tenant channels yet (allowed: ntfy, telegram, discord, webpush)", kind)
+	}
+	return nil
+}
+
+// validateEventKind bounds the routed event kind. A stricter allowlist of
+// routable kinds is a later phase; here we only guard shape.
+func validateEventKind(k string) error {
+	if k == "" {
+		return errors.New("event_kind required")
+	}
+	if len(k) > 64 {
+		return errors.New("event_kind must be <= 64 chars")
+	}
+	for _, r := range k {
+		if !(r == '.' || r == '_' || r == '-' ||
+			(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+			return errors.New("event_kind may contain only letters, digits, '.', '_' and '-'")
+		}
+	}
+	return nil
+}
+
+// isDuplicateKeyErr recognises a MySQL/MariaDB unique-constraint violation so a
+// duplicate route maps to 409. Matches on the driver's 1062 code text, which
+// survives GORM wrapping.
+func isDuplicateKeyErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "1062") || strings.Contains(strings.ToLower(s), "duplicate entry")
+}

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -1,0 +1,279 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fake route repo ---
+
+type fakeUserRoutesRepo struct {
+	mu   sync.Mutex
+	rows map[string]*models.UserNotificationRoute
+}
+
+func (f *fakeUserRoutesRepo) Create(_ context.Context, r *models.UserNotificationRoute) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.rows == nil {
+		f.rows = map[string]*models.UserNotificationRoute{}
+	}
+	// Emulate UNIQUE(user_id,event_kind,channel_id) with a driver-shaped error
+	// so the handler's 409 mapping (isDuplicateKeyErr) is exercised realistically.
+	for _, e := range f.rows {
+		if e.UserID == r.UserID && e.EventKind == r.EventKind && e.ChannelID == r.ChannelID {
+			return errors.New("Error 1062: Duplicate entry")
+		}
+	}
+	dup := *r
+	f.rows[r.ID] = &dup
+	return nil
+}
+func (f *fakeUserRoutesRepo) ListByUser(_ context.Context, userID string) ([]models.UserNotificationRoute, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]models.UserNotificationRoute, 0)
+	for _, r := range f.rows {
+		if r.UserID == userID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+func (f *fakeUserRoutesRepo) ListByUserEvent(_ context.Context, userID, eventKind string) ([]models.UserNotificationRoute, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]models.UserNotificationRoute, 0)
+	for _, r := range f.rows {
+		if r.UserID == userID && r.EventKind == eventKind {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+func (f *fakeUserRoutesRepo) Delete(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.rows, id)
+	return nil
+}
+func (f *fakeUserRoutesRepo) DeleteByChannel(_ context.Context, channelID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for id, r := range f.rows {
+		if r.ChannelID == channelID {
+			delete(f.rows, id)
+		}
+	}
+	return nil
+}
+
+// --- plumbing ---
+
+func meNotifSettings(enabled bool) *mockServerSettingsRepo {
+	return &mockServerSettingsRepo{getResult: &models.ServerSettings{TenantNotificationsEnabled: enabled}}
+}
+
+func newUserCtxID(userID string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: false})
+		c.Next()
+	}
+}
+
+func newMeNotifRouter(t *testing.T, settings repository.ServerSettingsRepository, channels repository.NotificationChannelRepository, routes repository.UserNotificationRouteRepository, authFn gin.HandlerFunc) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	g := r.Group("/api/v1")
+	if authFn != nil {
+		g.Use(authFn)
+	}
+	RegisterMeNotificationsRoutes(g, MeNotificationsConfig{
+		Channels:       channels,
+		Routes:         routes,
+		ServerSettings: settings,
+	})
+	return r
+}
+
+func ownedChannel(userID, kind string, cfg models.NotificationChannelConfig) *models.NotificationChannel {
+	uid := userID
+	return &models.NotificationChannel{
+		ID:      ids.NewULID(),
+		UserID:  &uid,
+		Name:    "ch-" + kind,
+		Kind:    kind,
+		Config:  cfg,
+		Enabled: true,
+	}
+}
+
+// --- tests ---
+
+func TestMeNotif_GateOff_Is403(t *testing.T) {
+	t.Parallel()
+	r := newMeNotifRouter(t, meNotifSettings(false), &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtx())
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+func TestMeNotif_GateFailsClosedOnSettingsError(t *testing.T) {
+	t.Parallel()
+	settings := &mockServerSettingsRepo{getErr: context.DeadlineExceeded}
+	r := newMeNotifRouter(t, settings, &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtx())
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
+func TestMeNotif_CreateNtfy_SetsOwnerAndRedacts(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+		"name":   "My phone",
+		"kind":   "ntfy",
+		"config": map[string]any{"url": "https://ntfy.sh/mytopic"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	// Stored row must be owned by the caller — never a body-supplied user_id.
+	require.Len(t, repo.rows, 1)
+	for _, row := range repo.rows {
+		require.NotNil(t, row.UserID)
+		require.Equal(t, "u1", *row.UserID)
+	}
+}
+
+func TestMeNotif_CreateDisallowedKind_Is422(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"webhook", "sms", "slack", "email"} {
+		repo := &fakeChannelsRepo{}
+		r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+		rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+			"name":   "x",
+			"kind":   kind,
+			"config": map[string]any{"url": "https://example.com/h", "hmac_secret": "0123456789abcdef"},
+		})
+		require.Equal(t, http.StatusUnprocessableEntity, rec.Code, "kind %s should be rejected: %s", kind, rec.Body.String())
+		require.Empty(t, repo.rows, "kind %s must not be persisted", kind)
+	}
+}
+
+func TestMeNotif_CreateTelegram_SecretNotEchoed(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+		"name":   "tg",
+		"kind":   "telegram",
+		"config": map[string]any{"bot_token": "123:secretzzz", "chat_id": "42"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "secretzzz", "bot_token must not be echoed")
+	// And a subsequent list also redacts.
+	lrec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusOK, lrec.Code)
+	require.NotContains(t, lrec.Body.String(), "secretzzz")
+}
+
+func TestMeNotif_ListReturnsOnlyOwn(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	mine := ownedChannel("u1", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/a"})
+	theirs := ownedChannel("u2", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/b"})
+	_ = repo.Create(context.Background(), mine)
+	_ = repo.Create(context.Background(), theirs)
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), mine.ID)
+	require.NotContains(t, rec.Body.String(), theirs.ID)
+}
+
+func TestMeNotif_MutateOtherUsersChannel_Is404(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	theirs := ownedChannel("u2", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/b"})
+	_ = repo.Create(context.Background(), theirs)
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+
+	del := doNotifJSON(t, r, http.MethodDelete, "/api/v1/me/notifications/channels/"+theirs.ID, nil)
+	require.Equal(t, http.StatusNotFound, del.Code, del.Body.String())
+
+	patch := doNotifJSON(t, r, http.MethodPatch, "/api/v1/me/notifications/channels/"+theirs.ID, map[string]any{"name": "hijack"})
+	require.Equal(t, http.StatusNotFound, patch.Code, patch.Body.String())
+
+	// The row must be untouched.
+	require.Equal(t, "ch-ntfy", repo.rows[theirs.ID].Name)
+}
+
+func TestMeNotif_RouteToUnownedChannel_Is404(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	theirs := ownedChannel("u2", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/b"})
+	_ = repo.Create(context.Background(), theirs)
+	routes := &fakeUserRoutesRepo{}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
+		"event_kind": "backup.completed",
+		"channel_id": theirs.ID,
+	})
+	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
+	require.Empty(t, routes.rows)
+}
+
+func TestMeNotif_RouteHappyThenDeleteOwnership(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	mine := ownedChannel("u1", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/a"})
+	_ = repo.Create(context.Background(), mine)
+	routes := &fakeUserRoutesRepo{}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u1"))
+
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
+		"event_kind": "backup.completed",
+		"channel_id": mine.ID,
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.Len(t, routes.rows, 1)
+
+	// A different user cannot delete u1's route.
+	var routeID string
+	for id := range routes.rows {
+		routeID = id
+	}
+	rOther := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u2"))
+	del := doNotifJSON(t, rOther, http.MethodDelete, "/api/v1/me/notifications/routes/"+routeID, nil)
+	require.Equal(t, http.StatusNotFound, del.Code, del.Body.String())
+	require.Len(t, routes.rows, 1, "route must survive the foreign delete")
+
+	// The owner can.
+	delOwn := doNotifJSON(t, r, http.MethodDelete, "/api/v1/me/notifications/routes/"+routeID, nil)
+	require.Equal(t, http.StatusNoContent, delOwn.Code, delOwn.Body.String())
+	require.Empty(t, routes.rows)
+}
+
+func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	mine := ownedChannel("u1", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/a"})
+	_ = repo.Create(context.Background(), mine)
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
+		"event_kind": "bad kind!",
+		"channel_id": mine.ID,
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, rec.Body.String())
+}

--- a/panel-api/internal/api/notifications_channels_test.go
+++ b/panel-api/internal/api/notifications_channels_test.go
@@ -88,6 +88,18 @@ func (f *fakeChannelsRepo) FindEnabledServerWide(context.Context) ([]models.Noti
 	return nil, nil
 }
 
+func (f *fakeChannelsRepo) ListByUser(_ context.Context, userID string) ([]models.NotificationChannel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]models.NotificationChannel, 0)
+	for _, r := range f.rows {
+		if r.UserID != nil && *r.UserID == userID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeChannelsRepo) SealAllPlaintext(context.Context) (int, error) { return 0, nil }
 
 // --- test plumbing ---

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3719,6 +3719,87 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  # -------------------------------------------------- tenant notifications (JAB-171 phase 3b) ---
+  # Gated behind ServerSettings.TenantNotificationsEnabled (default OFF, no admin
+  # toggle until phase 4). All routes are ownership-scoped to the caller and
+  # return 404 (never 403) for another user's ids. Browser session only.
+  /me/notifications/channels:
+    get:
+      tags: [Notifications]
+      summary: List your own notification channels
+      security: [ { KratosSession: [] } ]
+      responses:
+        "200": { description: OK }
+        "403": { description: Tenant notifications disabled }
+    post:
+      tags: [Notifications]
+      summary: Create an own notification channel (ntfy/telegram/discord/webpush only)
+      security: [ { KratosSession: [] } ]
+      responses:
+        "201": { description: Created }
+        "403": { description: Tenant notifications disabled }
+        "422": { description: Validation error / kind not allowed for tenants }
+
+  /me/notifications/channels/{id}:
+    patch:
+      tags: [Notifications]
+      summary: Update an own notification channel (write-only secrets)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "200": { description: OK }
+        "403": { description: Tenant notifications disabled }
+        "404": { description: No such channel (or owned by another user) }
+    delete:
+      tags: [Notifications]
+      summary: Delete an own notification channel
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "204": { description: Deleted }
+        "403": { description: Tenant notifications disabled }
+        "404": { description: No such channel (or owned by another user) }
+
+  /me/notifications/channels/{id}/test:
+    post:
+      tags: [Notifications]
+      summary: Synchronous test-send to an own channel
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "200": { description: Delivered }
+        "403": { description: Tenant notifications disabled }
+        "404": { description: No such channel (or owned by another user) }
+
+  /me/notifications/routes:
+    get:
+      tags: [Notifications]
+      summary: List your event→channel routes
+      security: [ { KratosSession: [] } ]
+      responses:
+        "200": { description: OK }
+        "403": { description: Tenant notifications disabled }
+    post:
+      tags: [Notifications]
+      summary: Route an event kind to an own channel
+      security: [ { KratosSession: [] } ]
+      responses:
+        "201": { description: Created }
+        "403": { description: Tenant notifications disabled }
+        "404": { description: Target channel not found (or owned by another user) }
+        "409": { description: Route already exists }
+
+  /me/notifications/routes/{id}:
+    delete:
+      tags: [Notifications]
+      summary: Delete an own route
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses:
+        "204": { description: Deleted }
+        "403": { description: Tenant notifications disabled }
+        "404": { description: No such route (or owned by another user) }
+
   /admin/notifications/dlq:
     delete:
       tags: [Notifications]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -503,6 +503,18 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			QuotaMount: deps.QuotaMount,
 			Snapshots:  repository.NewDiskUsageSnapshotRepository(deps.DB),
 		})
+		// JAB-171 phase 3b — tenant-facing notification channels + routing.
+		// Gated behind ServerSettings.TenantNotificationsEnabled (default OFF,
+		// no admin toggle until phase 4 lands the SSRF guard + email-verify),
+		// so registering the routes here does not expose them to tenants yet.
+		api.RegisterMeNotificationsRoutes(v1, api.MeNotificationsConfig{
+			Channels:       deps.NotificationChannels,
+			Routes:         deps.UserNotificationRoutes,
+			ServerSettings: deps.ServerSettings,
+			Registry:       deps.NotificationRegistry,
+			SSOKey:         deps.SSOKey,
+			Log:            deps.Log,
+		})
 
 		// ADR-0128 — admin act-as grant management (GH #183). Mounted on v1;
 		// ResolveImpersonation skips this path so it always runs as the real

--- a/panel-api/internal/app/openapi_coverage_test.go
+++ b/panel-api/internal/app/openapi_coverage_test.go
@@ -99,6 +99,7 @@ func fullDeps() Deps {
 		UserEgressRequests: repository.NewUserEgressRequestRepository(db),
 		UserEgressDropSamples: repository.NewUserEgressDropSampleRepository(db),
 		NotificationChannels: repository.NewNotificationChannelRepository(db),
+		UserNotificationRoutes: repository.NewUserNotificationRouteRepository(db),
 		NotificationHistory: repository.NewNotificationHistoryRepository(db),
 		WebhookEndpoints: repository.NewWebhookEndpointRepository(db),
 		WebPushSubs: repository.NewWebPushSubscriptionRepository(db),

--- a/panel-api/internal/db/migrations/000238_tenant_notifications_enabled.down.sql
+++ b/panel-api/internal/db/migrations/000238_tenant_notifications_enabled.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN tenant_notifications_enabled;

--- a/panel-api/internal/db/migrations/000238_tenant_notifications_enabled.up.sql
+++ b/panel-api/internal/db/migrations/000238_tenant_notifications_enabled.up.sql
@@ -1,0 +1,9 @@
+-- JAB-171 phase 3b: master switch for the tenant-facing notification surface
+-- (/me/notifications/*). Default OFF and there is deliberately NO admin toggle
+-- in phase 3b — the endpoints exist, are ownership-scoped, redact secrets and
+-- are OpenAPI-documented, but stay physically un-enablable until phase 4 lands
+-- the SSRF guard, per-kind allowlist and email-verify. Only phase 4 adds the
+-- admin control that can flip this on. Follows the TenantDomainOptionsEnabled
+-- default-off tenant-cap precedent (security-sensitive caps default OFF).
+ALTER TABLE server_settings
+  ADD COLUMN tenant_notifications_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -121,6 +121,15 @@ type ServerSettings struct {
 	// stands apart from the riskier raw nginx options.
 	TenantDocrootEditable bool `gorm:"column:tenant_docroot_editable;type:tinyint(1);not null;default:1" json:"tenant_docroot_editable"`
 
+	// TenantNotificationsEnabled is the master switch for the tenant-facing
+	// notification surface (/me/notifications/*, JAB-171). Default OFF and, in
+	// phase 3b, there is NO admin API to flip it — the endpoints are built,
+	// ownership-scoped and secret-redacting but stay un-enablable until phase 4
+	// adds the SSRF guard, per-kind allowlist and email-verify. Handlers fail
+	// CLOSED on this flag (unlike the module guard), so an unreadable settings
+	// row keeps the surface off. Security-sensitive tenant cap → default OFF.
+	TenantNotificationsEnabled bool `gorm:"column:tenant_notifications_enabled;type:tinyint(1);not null;default:0" json:"tenant_notifications_enabled"`
+
 	// DNSUserRecordPolicy — per-type create/edit/delete matrix for non-admin
 	// tenants (GH #466, ADR-0150). JSON object keyed by UPPERCASE record type.
 	DNSUserRecordPolicy DNSUserRecordPolicy `gorm:"column:dns_user_record_policy;type:longtext" json:"dns_user_record_policy"`

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -102,6 +102,18 @@ func (f *fakeChannels) FindEnabledAll(ctx context.Context) ([]models.Notificatio
 // channels are excluded from broadcast/server fan-out (JAB-171).
 func (f *fakeChannels) SealAllPlaintext(ctx context.Context) (int, error) { return 0, nil }
 
+func (f *fakeChannels) ListByUser(_ context.Context, userID string) ([]models.NotificationChannel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]models.NotificationChannel, 0)
+	for _, ch := range f.enabled {
+		if ch.UserID != nil && *ch.UserID == userID {
+			out = append(out, ch)
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeChannels) FindEnabledServerWide(ctx context.Context) ([]models.NotificationChannel, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/panel-api/internal/repository/notification_channel_repository.go
+++ b/panel-api/internal/repository/notification_channel_repository.go
@@ -22,6 +22,12 @@ type NotificationChannelRepository interface {
 	FindByID(ctx context.Context, id string) (*models.NotificationChannel, error)
 	ListAll(ctx context.Context, opts ListOptions) ([]models.NotificationChannel, int64, error)
 
+	// ListByUser returns every channel owned by one tenant (user_id = userID),
+	// newest first. Powers the ownership-scoped /me/notifications/channels list
+	// (JAB-171) — a tenant sees only their own channels, never server-wide or
+	// another user's rows. Secrets are returned sealed; the handler redacts.
+	ListByUser(ctx context.Context, userID string) ([]models.NotificationChannel, error)
+
 	// FindEnabledByKind returns every row with the given kind that has
 	// enabled=true. Used by the dispatcher at fanout time to resolve
 	// which concrete channels a kind (e.g. "slack") targets.
@@ -171,6 +177,15 @@ func (r *notificationChannelRepo) FindEnabledAll(ctx context.Context) ([]models.
 	err := r.db.WithContext(ctx).
 		Where("enabled = ?", true).
 		Order("kind asc, id asc").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *notificationChannelRepo) ListByUser(ctx context.Context, userID string) ([]models.NotificationChannel, error) {
+	var rows []models.NotificationChannel
+	err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC, id DESC").
 		Find(&rows).Error
 	return rows, err
 }


### PR DESCRIPTION
## JAB-171 phase 3b — tenant `/me/notifications/*` API (gated OFF)

Ownership-scoped tenant surface for per-user notification channels + event routing. Fourth slice of JAB-171 (phase 1 #671, phase 2 #672, phase 3a #673 all merged).

### What lands
Routes (browser-session only; secrets sealed at rest via `notifsecret`, redacted on every response, edits write-only):

| Method | Path |
|---|---|
| GET / POST | `/me/notifications/channels` |
| PATCH / DELETE | `/me/notifications/channels/:id` |
| POST | `/me/notifications/channels/:id/test` (synchronous send) |
| GET / POST | `/me/notifications/routes` |
| DELETE | `/me/notifications/routes/:id` |

### Security posture (this is a SECURITY-REVIEW phase)
- **Master gate, default OFF, fail-closed.** Whole surface sits behind `ServerSettings.TenantNotificationsEnabled` (migration `000238`, default `0`). There is **no admin toggle in this phase** — the endpoints are built, tested and OpenAPI-documented but stay physically un-enablable until phase 4 lands the SSRF guard + per-kind allowlist + email-verify (they ship together). The gate **fails closed** (unreadable settings → 403), unlike the fail-open module guard, because exposing this before the phase-4 SSRF guard would let a tenant point an ntfy/discord channel at an internal/metadata address. Follows the `TenantDomainOptionsEnabled` default-off tenant-cap precedent.
- **Ownership everywhere.** Every read/mutate scoped to `claims.UserID`; foreign ids → **404 (never 403)** so channel existence never leaks. Create forces `user_id = claims.UserID` (never from the body). Route create requires the target channel to be owned by the caller.
- **Kind allowlist STUB.** Tenants may create only `ntfy/telegram/discord/webpush`; `email/webhook/sms/slack` → 422 until phase 4.
- **Secrets.** Reuses phase-3a `notifsecret` — `Redact` on responses, `PreserveEmptySecrets` on PATCH (write-only), `Open` before the synchronous test send only.

### Changes
- `models`: `ServerSettings.TenantNotificationsEnabled`
- `repository`: `NotificationChannelRepository.ListByUser(ctx, userID)`
- `api`: new `me_notifications.go` handler
- `app`: `RegisterMeNotificationsRoutes` wired into v1
- `openapi.yaml`: 8 route entries — `TestOpenAPICoverage` stays green (no golden change)

### Tests / verification
- `go build ./panel-api/...`, `go vet ./panel-api/...` clean
- `go test -race` green across api / app / repository / notifications / models
- New `me_notifications_test.go`: gate-off + settings-error → 403 (fail-closed), owner-only → 404, secret-never-echoed, kind-allowlist → 422, route ownership on create + delete
- Migration **box-verified up/down** on testserver MariaDB (throwaway `server_settings` clone): up → `tinyint(1) NOT NULL default 0`, down → column gone, live row untouched

### Not in this PR (phase 4+)
SSRF guard for tenant URLs, admin-controlled kind allowlist + the toggle that flips the master gate on, rate limits/quotas, email verified-address, tenant UI, CLI/docs/ADR. **Do-not-ship gate:** nothing tenant-facing until phases 3+4 both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
