### PR TITLE
feat(notifications): SSRF-guard tenant channel egress (JAB-171 phase 4a)

### DIFF
--- a/panel-api/internal/notifications/senders/client.go
+++ b/panel-api/internal/notifications/senders/client.go
@@ -14,6 +14,9 @@ package senders
 import (
 	"net/http"
 	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssrfguard"
 )
 
 // DefaultHTTPTimeout bounds outbound senders. Admin-configured URLs
@@ -38,4 +41,29 @@ const DefaultHTTPTimeout = 10 * time.Second
 func newHTTPClient() *http.Client {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	return &http.Client{Timeout: DefaultHTTPTimeout, Transport: t}
+}
+
+// sharedGuardedClient is the SSRF-guarded client used for tenant-owned channels
+// (JAB-171 phase 4). Its transport resolves + pins every dial and rejects
+// loopback / link-local (cloud metadata) / private ranges, defeating a tenant
+// pointing an ntfy/discord/webhook URL at an internal address. Server-wide/admin
+// channels keep the normal client — an operator may legitimately target an
+// internal host. Package-level singleton: the guard holds no per-channel state.
+var sharedGuardedClient = newGuardedHTTPClient()
+
+func newGuardedHTTPClient() *http.Client {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = ssrfguard.GuardedDialContext
+	return &http.Client{Timeout: DefaultHTTPTimeout, Transport: t}
+}
+
+// clientForChannel returns the SSRF-guarded client for a tenant-owned channel
+// (UserID set) and the sender's default client for server-wide/admin channels.
+// Selecting on the channel itself makes the guard fail-closed per channel,
+// independent of which call site invoked Send.
+func clientForChannel(def *http.Client, channel models.NotificationChannel) *http.Client {
+	if channel.UserID != nil {
+		return sharedGuardedClient
+	}
+	return def
 }

--- a/panel-api/internal/notifications/senders/discord.go
+++ b/panel-api/internal/notifications/senders/discord.go
@@ -70,7 +70,7 @@ func (d *Discord) Send(ctx context.Context, channel models.NotificationChannel, 
 		return fmt.Errorf("discord: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := d.client.Do(req)
+	resp, err := clientForChannel(d.client, channel).Do(req)
 	if err != nil {
 		return fmt.Errorf("discord: post: %w", err)
 	}

--- a/panel-api/internal/notifications/senders/ntfy.go
+++ b/panel-api/internal/notifications/senders/ntfy.go
@@ -48,7 +48,7 @@ func (n *Ntfy) Send(ctx context.Context, channel models.NotificationChannel, env
 	if env.Deeplink != "" {
 		req.Header.Set("Click", env.Deeplink)
 	}
-	resp, err := n.client.Do(req)
+	resp, err := clientForChannel(n.client, channel).Do(req)
 	if err != nil {
 		return fmt.Errorf("ntfy: post: %w", err)
 	}

--- a/panel-api/internal/notifications/senders/slack.go
+++ b/panel-api/internal/notifications/senders/slack.go
@@ -43,7 +43,7 @@ func (s *Slack) Send(ctx context.Context, channel models.NotificationChannel, en
 		return fmt.Errorf("slack: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := s.client.Do(req)
+	resp, err := clientForChannel(s.client, channel).Do(req)
 	if err != nil {
 		return fmt.Errorf("slack: post: %w", err)
 	}

--- a/panel-api/internal/notifications/senders/sms.go
+++ b/panel-api/internal/notifications/senders/sms.go
@@ -86,7 +86,7 @@ func (s *SMS) Send(ctx context.Context, channel models.NotificationChannel, env 
 		req.Header.Set("Authorization", "Bearer "+channel.Config.Bearer)
 	}
 
-	resp, err := s.client.Do(req)
+	resp, err := clientForChannel(s.client, channel).Do(req)
 	if err != nil {
 		return fmt.Errorf("sms: post: %w", err)
 	}

--- a/panel-api/internal/notifications/senders/ssrf_test.go
+++ b/panel-api/internal/notifications/senders/ssrf_test.go
@@ -1,0 +1,70 @@
+package senders
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+// The httptest server binds loopback (127.0.0.1). A tenant-owned channel routes
+// through the SSRF-guarded client, which rejects loopback before connecting; a
+// server-wide (admin) channel keeps the default client and reaches it. This is
+// the JAB-171 phase-4 end-to-end guard proof — one server, ownership decides.
+func TestSenders_TenantChannelGuarded_AdminChannelNot(t *testing.T) {
+	t.Parallel()
+	var hits int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	env := notifications.Envelope{Title: "t", Body: "b"}
+	uid := "u1"
+
+	// Server-wide (UserID nil) — reaches the loopback server.
+	adminCh := models.NotificationChannel{Kind: "ntfy", Config: models.NotificationChannelConfig{URL: ts.URL}}
+	require.NoError(t, NewNtfy().Send(context.Background(), adminCh, env))
+	require.Equal(t, 1, hits)
+
+	// Tenant-owned (UserID set) — same URL, but the guarded client refuses the
+	// loopback dial. The server must NOT be hit.
+	tenantCh := models.NotificationChannel{Kind: "ntfy", UserID: &uid, Config: models.NotificationChannelConfig{URL: ts.URL}}
+	err := NewNtfy().Send(context.Background(), tenantCh, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssrf")
+	require.Equal(t, 1, hits, "guarded tenant send must not reach the loopback server")
+}
+
+// The guard also covers the other tenant-reachable / phase-4 URL senders.
+func TestSenders_TenantGuard_AcrossURLKinds(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+	defer ts.Close()
+	uid := "u1"
+	env := notifications.Envelope{Title: "t", Body: "b"}
+
+	cases := []struct {
+		name string
+		send func(models.NotificationChannel) error
+		cfg  models.NotificationChannelConfig
+	}{
+		{"discord", func(ch models.NotificationChannel) error { return NewDiscord().Send(context.Background(), ch, env) }, models.NotificationChannelConfig{URL: ts.URL}},
+		{"webhook", func(ch models.NotificationChannel) error { return NewWebhook().Send(context.Background(), ch, env) }, models.NotificationChannelConfig{URL: ts.URL, HMACSecret: "0123456789abcdef"}},
+		{"slack", func(ch models.NotificationChannel) error { return NewSlack().Send(context.Background(), ch, env) }, models.NotificationChannelConfig{URL: ts.URL}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ch := models.NotificationChannel{Kind: tc.name, UserID: &uid, Config: tc.cfg}
+			err := tc.send(ch)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "ssrf", "%s tenant send must be SSRF-blocked", tc.name)
+		})
+	}
+}

--- a/panel-api/internal/notifications/senders/webhook.go
+++ b/panel-api/internal/notifications/senders/webhook.go
@@ -71,7 +71,7 @@ func (w *Webhook) Send(ctx context.Context, channel models.NotificationChannel, 
 	req.Header.Set("X-Jabali-Signature", sig)
 	req.Header.Set("User-Agent", "jabali-panel-webhook/1")
 
-	resp, err := w.client.Do(req)
+	resp, err := clientForChannel(w.client, channel).Do(req)
 	if err != nil {
 		return fmt.Errorf("webhook: post: %w", err)
 	}

--- a/panel-api/internal/ssrfguard/ssrfguard.go
+++ b/panel-api/internal/ssrfguard/ssrfguard.go
@@ -1,0 +1,141 @@
+// Package ssrfguard is a zero-dependency leaf providing SSRF-safe outbound
+// dialing: resolve a hostname, reject any IP in a blocked range, then pin the
+// TCP connection to a validated IP so a DNS rebind between resolve and dial is
+// refused at connect time.
+//
+// It is used by the notification senders (internal/notifications/senders) to
+// guard tenant-supplied channel URLs (ntfy, discord, webhook) against pointing
+// at loopback / link-local (cloud metadata) / private space. The senders select
+// a guarded client for tenant-owned channels (channel.UserID != nil) and their
+// normal client for server-wide/admin channels, which an operator may
+// legitimately point at an internal host — so the guard is fail-closed per
+// channel, independent of the call site.
+//
+// The IP-classification + rebind-pin logic mirrors the migration SSRF guard
+// (internal/migrate/ssrf.go, ADR-0095 decision 8). It is duplicated here rather
+// than shared so this leaf stays dependency-free and the proven migration path
+// is untouched; the two should be unified into this package in a later cleanup.
+package ssrfguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"time"
+)
+
+// DefaultDialTimeout bounds one guarded dial (DNS + handshake).
+const DefaultDialTimeout = 10 * time.Second
+
+// Validator captures the AllowPrivate toggle and the resolved IPs for one host.
+type Validator struct {
+	Hostname     string
+	AllowPrivate bool
+	resolved     []net.IP
+}
+
+// ValidateHost resolves hostname to A/AAAA and rejects if any resolved IP is in
+// a blocked range. The returned Validator must be used via Dialer()+DialAddr()
+// for the connection so the peer IP is re-checked at connect time.
+func ValidateHost(ctx context.Context, hostname string, allowPrivate bool) (*Validator, error) {
+	if hostname == "" {
+		return nil, errors.New("ssrf: empty hostname")
+	}
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", hostname)
+	if err != nil {
+		return nil, fmt.Errorf("ssrf: resolve %s: %w", hostname, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("ssrf: %s resolved to zero records", hostname)
+	}
+	for _, ip := range ips {
+		if err := checkIP(ip, allowPrivate); err != nil {
+			return nil, fmt.Errorf("ssrf: %s → %s: %w", hostname, ip.String(), err)
+		}
+	}
+	return &Validator{Hostname: hostname, AllowPrivate: allowPrivate, resolved: ips}, nil
+}
+
+// DialAddr returns "ip:port" for a validated resolved IP (IPv4 preferred) so the
+// dial connects to an already-checked address instead of re-resolving.
+func (v *Validator) DialAddr(port string) string {
+	ip := v.resolved[0]
+	for _, cand := range v.resolved {
+		if cand.To4() != nil {
+			ip = cand
+			break
+		}
+	}
+	return net.JoinHostPort(ip.String(), port)
+}
+
+// Dialer returns a net.Dialer whose Control hook re-checks the peer IP the
+// kernel is about to connect to, refusing a DNS-rebound IP outside the resolved
+// set before the TCP handshake.
+func (v *Validator) Dialer() *net.Dialer {
+	allowed := make(map[string]struct{}, len(v.resolved))
+	for _, ip := range v.resolved {
+		allowed[ip.String()] = struct{}{}
+	}
+	allow := v.AllowPrivate
+	return &net.Dialer{
+		Timeout: DefaultDialTimeout,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("ssrf: split %q: %w", address, err)
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("ssrf: unparseable peer IP %q", host)
+			}
+			if _, ok := allowed[ip.String()]; !ok {
+				return fmt.Errorf("ssrf: dial peer %s not in resolved set (DNS rebinding suspected)", ip)
+			}
+			if err := checkIP(ip, allow); err != nil {
+				return fmt.Errorf("ssrf: dial-time check %s: %w", ip, err)
+			}
+			return nil
+		},
+	}
+}
+
+// GuardedDialContext is a net/http Transport.DialContext that validates and
+// pins every outbound connection, always with private ranges blocked. It is the
+// dial hook for the tenant-facing HTTP client; plug it into
+// http.Transport.DialContext.
+func GuardedDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("ssrf: split %q: %w", addr, err)
+	}
+	v, err := ValidateHost(ctx, host, false)
+	if err != nil {
+		return nil, err
+	}
+	return v.Dialer().DialContext(ctx, network, v.DialAddr(port))
+}
+
+func checkIP(ip net.IP, allowPrivate bool) error {
+	if ip == nil {
+		return errors.New("nil IP")
+	}
+	if ip.IsLoopback() {
+		return errors.New("loopback rejected")
+	}
+	if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return errors.New("link-local rejected (cloud metadata blocked)")
+	}
+	if ip.IsUnspecified() {
+		return errors.New("0.0.0.0 / :: rejected")
+	}
+	if ip.IsMulticast() {
+		return errors.New("multicast rejected")
+	}
+	if !allowPrivate && ip.IsPrivate() {
+		return errors.New("private (RFC1918 / ULA) address rejected")
+	}
+	return nil
+}

--- a/panel-api/internal/ssrfguard/ssrfguard_test.go
+++ b/panel-api/internal/ssrfguard/ssrfguard_test.go
@@ -1,0 +1,67 @@
+package ssrfguard
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// IP literals short-circuit the resolver (no network), so these run offline.
+
+func TestValidateHost_BlocksDangerousRanges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	blocked := []string{
+		"127.0.0.1",       // loopback
+		"::1",             // IPv6 loopback
+		"169.254.169.254", // link-local / cloud metadata
+		"0.0.0.0",         // unspecified
+	}
+	for _, ip := range blocked {
+		_, err := ValidateHost(ctx, ip, false)
+		require.Error(t, err, "expected %s to be blocked", ip)
+		require.Contains(t, err.Error(), "ssrf")
+	}
+}
+
+func TestValidateHost_PrivateGatedByAllowFlag(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	for _, ip := range []string{"10.0.0.1", "172.16.0.1", "192.168.1.1"} {
+		_, err := ValidateHost(ctx, ip, false)
+		require.Error(t, err, "%s must be blocked when allowPrivate=false", ip)
+
+		_, err = ValidateHost(ctx, ip, true)
+		require.NoError(t, err, "%s must be allowed when allowPrivate=true", ip)
+	}
+}
+
+func TestValidateHost_AllowsPublic(t *testing.T) {
+	t.Parallel()
+	_, err := ValidateHost(context.Background(), "8.8.8.8", false)
+	require.NoError(t, err)
+}
+
+func TestValidateHost_EmptyHost(t *testing.T) {
+	t.Parallel()
+	_, err := ValidateHost(context.Background(), "", false)
+	require.Error(t, err)
+}
+
+func TestGuardedDialContext_RejectsLoopbackBeforeConnect(t *testing.T) {
+	t.Parallel()
+	// Nothing is listening; a successful guard rejects at classification time,
+	// well before any TCP attempt, so the error is the ssrf rejection.
+	_, err := GuardedDialContext(context.Background(), "tcp", "127.0.0.1:80")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "ssrf"), "want ssrf rejection, got %v", err)
+}
+
+func TestGuardedDialContext_RejectsMetadataIP(t *testing.T) {
+	t.Parallel()
+	_, err := GuardedDialContext(context.Background(), "tcp", "169.254.169.254:80")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssrf")
+}


### PR DESCRIPTION
## JAB-171 phase 4a — SSRF-guard tenant channel egress

First slice of phase 4 (abuse controls). Phases 1–3b are merged (#671/#672/#673/#674); the tenant surface stays gated OFF until the whole of phase 4 lands.

### Problem
A tenant-owned channel with a user-supplied URL (`ntfy`, `discord`, and the phase-4 `webhook/slack/sms`) could point at `127.0.0.1`, `169.254.169.254` (cloud metadata), or RFC1918 space — classic SSRF.

### Fix
- **New leaf `internal/ssrfguard`**: `ValidateHost` (resolve + range-check) + a `Dialer` whose `Control` hook re-checks the peer IP at connect time (**defeats DNS rebinding** between validate and dial) + `GuardedDialContext` for `net/http` transports. Zero jabali deps. IP-classification mirrors the proven migration guard (`internal/migrate/ssrf.go`, ADR-0095) — duplicated on purpose to keep this a dependency-free leaf and leave the migration path untouched (unify later).
- **Senders**: a package-level SSRF-guarded `http.Client`; each URL sender selects it via `clientForChannel()` **when `channel.UserID != nil`**. Selecting on the channel makes the guard **fail-closed per channel, independent of the call site** — the async dispatcher and the tenant test-send inherit it automatically. Server-wide/admin channels (`UserID` nil) keep the default client, so an operator may still target an internal host — **no behaviour change, no test churn**.

Blocked always: loopback, link-local/metadata, unspecified, multicast. Blocked unless server-wide: RFC1918 / IPv6 ULA.

### Tests
- `ssrfguard`: classification + rebind-pin unit tests (IP literals → offline, no network)
- `senders`: end-to-end — a tenant `ntfy/discord/webhook/slack` send to a loopback `httptest` server is refused with an `ssrf` error, while the **same URL as a server-wide channel is delivered**
- `go build` / `go vet ./panel-api/...` clean; `-race` green across `ssrfguard` + `notifications/...`

### Deliberately out of scope
- webpush endpoints (browser-subscription sourced, not free-form config)
- create-time URL validation (advisory) — the dial-time guard is authoritative
- proxied egress (jabali has no outbound proxy)

### Remaining phase-4 slices (each its own PR)
- **4b** admin-configurable kind allowlist (replaces the 3b const stub; risky kinds default OFF)
- **4c** rate limits + per-user quotas (channels-per-user, test-send rate)
- **4d** email-to-own-verified (tenant email, local mode, verified address)
- **4e** admin override/visibility **+ the gate toggle** (admin API to flip `TenantNotificationsEnabled`) — gated on all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
