### PR TITLE
feat(notifications): admin-configurable tenant kind allowlist (JAB-171 phase 4b)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -18,11 +18,11 @@
 // existence never leaks. Secrets are sealed at rest (notifsecret) and redacted on
 // every response; edits are write-only (empty secret keeps the stored one).
 //
-// The tenant-creatable kind allowlist is a STUB: only ntfy/telegram/discord/
-// webpush in phase 3b. email (needs verified-address plumbing), webhook, sms and
-// slack are rejected until phase 4 adds SSRF + email-verify + the admin-controlled
-// allowlist. Because ntfy/discord carry a user-supplied URL that is NOT yet
-// SSRF-guarded, the master flag MUST stay off until phase 4 — the two land together.
+// The tenant-creatable kind allowlist is admin-configurable
+// (ServerSettings.TenantNotificationKinds, phase 4b): empty → the safe default
+// set (ntfy/telegram/discord/webpush); webhook/slack/sms are admin opt-in and
+// SSRF-guarded (phase 4a). email stays out until phase 4d ships verified-address
+// plumbing.
 
 package api
 
@@ -57,17 +57,6 @@ type MeNotificationsConfig struct {
 	Log            *slog.Logger
 }
 
-// tenantChannelKinds is the phase-3b allowlist of kinds a tenant may create.
-// Deliberately narrow: email/webhook/sms/slack are withheld until phase 4 adds
-// SSRF guarding, the admin-controlled allowlist and email verified-address
-// plumbing. See the file header.
-var tenantChannelKinds = map[string]struct{}{
-	models.NotificationChannelKindNtfy:     {},
-	models.NotificationChannelKindTelegram: {},
-	models.NotificationChannelKindDiscord:  {},
-	models.NotificationChannelKindWebpush:  {},
-}
-
 // RegisterMeNotificationsRoutes mounts the /me/notifications/* surface. Auth
 // comes from the parent group; handlers resolve the caller from the session and
 // enforce ownership + the master gate themselves.
@@ -94,19 +83,26 @@ type meNotificationsHandler struct {
 	cfg MeNotificationsConfig
 }
 
-// gateOpen reports whether the tenant surface is enabled. Fails CLOSED: a nil
-// repo, a read error, or the flag being off all yield false, and the caller
-// aborts with 403. Security-sensitive — never fail open here.
-func (h *meNotificationsHandler) gateOpen(c *gin.Context) bool {
+// loadSettings loads server settings and enforces the master gate. Fails
+// CLOSED: a nil repo, a read error, or the flag being off all abort with 403.
+// Security-sensitive — never fail open here. The returned settings are reused by
+// createChannel for the kind allowlist so the gate + allowlist share one read.
+func (h *meNotificationsHandler) loadSettings(c *gin.Context) (*models.ServerSettings, bool) {
 	st, err := h.cfg.ServerSettings.Get(c.Request.Context())
 	if err != nil || st == nil || !st.TenantNotificationsEnabled {
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
 			"error":   "tenant_notifications_disabled",
 			"message": "per-user notification channels are not enabled on this server",
 		})
-		return false
+		return nil, false
 	}
-	return true
+	return st, true
+}
+
+// gateOpen is the master-gate check for handlers that don't need the settings.
+func (h *meNotificationsHandler) gateOpen(c *gin.Context) bool {
+	_, ok := h.loadSettings(c)
+	return ok
 }
 
 // loadOwnedChannel fetches a channel and enforces tenant ownership. Any miss —
@@ -147,7 +143,8 @@ type meChannelCreateReq struct {
 }
 
 func (h *meNotificationsHandler) createChannel(c *gin.Context) {
-	if !h.gateOpen(c) {
+	st, ok := h.loadSettings(c)
+	if !ok {
 		return
 	}
 	claims, ok := requireBrowserAuth(c)
@@ -163,8 +160,12 @@ func (h *meNotificationsHandler) createChannel(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
 	}
-	if err := requireTenantKind(req.Kind); err != nil {
-		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+	// Admin-configurable kind allowlist (empty settings → safe default set).
+	if !st.TenantNotificationKinds.OrDefault().Allows(req.Kind) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error":   "kind_not_allowed_for_tenant",
+			"message": "channel kind " + req.Kind + " is not permitted for tenant channels on this server",
+		})
 		return
 	}
 	if err := validateChannelKindAndConfig(req.Kind, req.Config); err != nil {
@@ -422,14 +423,6 @@ func (h *meNotificationsHandler) deleteRoute(c *gin.Context) {
 }
 
 // --- validation helpers ---
-
-// requireTenantKind gates channel creation to the phase-3b tenant allowlist.
-func requireTenantKind(kind string) error {
-	if _, ok := tenantChannelKinds[kind]; !ok {
-		return fmt.Errorf("channel kind %q is not available for tenant channels yet (allowed: ntfy, telegram, discord, webpush)", kind)
-	}
-	return nil
-}
 
 // validateEventKind bounds the routed event kind. A stricter allowlist of
 // routable kinds is a later phase; here we only guard shape.

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -265,6 +265,37 @@ func TestMeNotif_RouteHappyThenDeleteOwnership(t *testing.T) {
 	require.Empty(t, routes.rows)
 }
 
+func TestMeNotif_KindAllowlist_DefaultBlocksWebhook_AdminOptInAllows(t *testing.T) {
+	t.Parallel()
+	body := map[string]any{
+		"name":   "wh",
+		"kind":   "webhook",
+		"config": map[string]any{"url": "https://example.com/hook", "hmac_secret": "0123456789abcdef"},
+	}
+
+	// Default allowlist (empty settings → safe set) blocks webhook.
+	rDefault := newMeNotifRouter(t, meNotifSettings(true), &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	recBlocked := doNotifJSON(t, rDefault, http.MethodPost, "/api/v1/me/notifications/channels", body)
+	require.Equal(t, http.StatusUnprocessableEntity, recBlocked.Code, recBlocked.Body.String())
+	require.Contains(t, recBlocked.Body.String(), "kind_not_allowed_for_tenant")
+
+	// Admin opts webhook into the allowlist → tenant may now create it.
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds{"ntfy", "webhook"},
+	}}
+	repo := &fakeChannelsRepo{}
+	rAllowed := newMeNotifRouter(t, settings, repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	recOK := doNotifJSON(t, rAllowed, http.MethodPost, "/api/v1/me/notifications/channels", body)
+	require.Equal(t, http.StatusCreated, recOK.Code, recOK.Body.String())
+	require.Len(t, repo.rows, 1)
+	for _, row := range repo.rows {
+		require.Equal(t, "webhook", row.Kind)
+		require.NotNil(t, row.UserID)
+		require.Equal(t, "u1", *row.UserID)
+	}
+}
+
 func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {
 	t.Parallel()
 	repo := &fakeChannelsRepo{}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -80,6 +80,12 @@ func (h *serverSettingsHandler) get(c *gin.Context) {
 		}
 	}
 
+	// Surface the EFFECTIVE tenant channel-kind allowlist: an empty column means
+	// "safe defaults", so show them rather than a blank list. Doesn't write back.
+	if len(s.TenantNotificationKinds) == 0 {
+		s.TenantNotificationKinds = models.DefaultTenantNotificationKinds()
+	}
+
 	c.JSON(http.StatusOK, s)
 }
 
@@ -130,6 +136,12 @@ type updateServerSettingsRequest struct {
 	APIEnabled                   *bool   `json:"api_enabled,omitempty"`
 	TenantDomainOptionsEnabled   *bool   `json:"tenant_domain_options_enabled,omitempty"`
 	TenantDocrootEditable        *bool   `json:"tenant_docroot_editable,omitempty"`
+	// TenantNotificationKinds — admin-configurable tenant channel-kind allowlist
+	// (phase 4b). The master TenantNotificationsEnabled toggle is deliberately
+	// NOT exposed here: it stays un-flippable until phase 4e, after rate limits
+	// and email-verify land (do-not-ship gate). Editing the allowlist while the
+	// surface is off is harmless.
+	TenantNotificationKinds *models.TenantNotificationKinds `json:"tenant_notification_kinds,omitempty"`
 	RootTerminalEnabled          *bool   `json:"root_terminal_enabled,omitempty"`
 	BandwidthQuotaEnforceEnabled *bool   `json:"bandwidth_quota_enforce_enabled,omitempty"`
 	UploadMaxSizeMB              *uint32 `json:"upload_max_size_mb,omitempty"`
@@ -485,6 +497,11 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.TenantDocrootEditable != nil {
 		current.TenantDocrootEditable = *req.TenantDocrootEditable
+	}
+	if req.TenantNotificationKinds != nil {
+		// Sanitize drops unknown / not-yet-safe kinds (e.g. email), so a PATCH
+		// can never smuggle an unsupported kind into the tenant allowlist.
+		current.TenantNotificationKinds = req.TenantNotificationKinds.Sanitize()
 	}
 	if req.RootTerminalEnabled != nil {
 		current.RootTerminalEnabled = *req.RootTerminalEnabled

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -211,6 +211,39 @@ func TestServerSettingsPatch_InvalidJSON(t *testing.T) {
 	assert.Equal(t, "validation_failed", respBody["error"])
 }
 
+func TestServerSettingsPatch_TenantNotificationKinds_SanitizesEmail(t *testing.T) {
+	t.Parallel()
+	mockRepo := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1, SSHPort: 22}}
+	r := settingsRouter(true, mockRepo, agent.NewMockClient())
+
+	// Admin tries to add email (never tenant-configurable) alongside webhook.
+	payload := map[string]any{"tenant_notification_kinds": []string{"webhook", "email", "bogus"}}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Persisted set must have dropped email + bogus, kept webhook.
+	require.ElementsMatch(t, []string{"webhook"}, []string(mockRepo.getResult.TenantNotificationKinds))
+}
+
+func TestServerSettingsGet_TenantNotificationKinds_EffectiveDefault(t *testing.T) {
+	t.Parallel()
+	// Empty column → GET surfaces the safe default set, not a blank list.
+	mockRepo := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1}}
+	r := settingsRouter(true, mockRepo, agent.NewMockClient())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp models.ServerSettings
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.ElementsMatch(t, []string{"ntfy", "telegram", "discord", "webpush"},
+		[]string(resp.TenantNotificationKinds))
+}
+
 func TestServerSettingsPatch_PartialUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/panel-api/internal/db/migrations/000239_tenant_notification_kinds.down.sql
+++ b/panel-api/internal/db/migrations/000239_tenant_notification_kinds.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE server_settings DROP COLUMN tenant_notification_kinds;

--- a/panel-api/internal/db/migrations/000239_tenant_notification_kinds.up.sql
+++ b/panel-api/internal/db/migrations/000239_tenant_notification_kinds.up.sql
@@ -1,0 +1,7 @@
+-- JAB-171 phase 4b: admin-configurable allowlist of channel kinds a tenant may
+-- create. JSON array in a longtext column. Empty/NULL is interpreted by the app
+-- as the safe default set (ntfy/telegram/discord/webpush) — webhook/slack/sms
+-- are admin opt-in. No seed: the app substitutes the default when the column is
+-- empty, so a fresh row needs no data migration.
+ALTER TABLE server_settings
+  ADD COLUMN tenant_notification_kinds LONGTEXT NULL;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -130,6 +130,13 @@ type ServerSettings struct {
 	// row keeps the surface off. Security-sensitive tenant cap → default OFF.
 	TenantNotificationsEnabled bool `gorm:"column:tenant_notifications_enabled;type:tinyint(1);not null;default:0" json:"tenant_notifications_enabled"`
 
+	// TenantNotificationKinds is the admin-configurable allowlist of channel
+	// kinds a tenant may create (JAB-171 phase 4b). Empty column = safe default
+	// set (ntfy/telegram/discord/webpush); webhook/slack/sms are admin opt-in.
+	// Enforcement substitutes the default via OrDefault(); "deny all" is the
+	// master TenantNotificationsEnabled switch, not an empty list.
+	TenantNotificationKinds TenantNotificationKinds `gorm:"column:tenant_notification_kinds;type:longtext" json:"tenant_notification_kinds"`
+
 	// DNSUserRecordPolicy — per-type create/edit/delete matrix for non-admin
 	// tenants (GH #466, ADR-0150). JSON object keyed by UPPERCASE record type.
 	DNSUserRecordPolicy DNSUserRecordPolicy `gorm:"column:dns_user_record_policy;type:longtext" json:"dns_user_record_policy"`

--- a/panel-api/internal/models/tenant_notification_kinds.go
+++ b/panel-api/internal/models/tenant_notification_kinds.go
@@ -1,0 +1,135 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Admin-configurable allowlist of the notification channel KINDS a non-admin
+// tenant may create (JAB-171 phase 4b). A server-wide set enforced
+// authoritatively in panel-api; admins are never restricted by it.
+//
+// Security-sensitive tenant cap → risky kinds default OFF. The stored value
+// being empty means "use the safe default set" (OrDefault), NOT "deny all" —
+// the whole surface is disabled via ServerSettings.TenantNotificationsEnabled,
+// not by an empty allowlist.
+
+// TenantConfigurableKinds is the closed set of kinds an admin MAY place in the
+// allowlist. email is deliberately absent until phase 4d ships verified-address
+// / local-only plumbing (an arbitrary to_email is an open-relay risk); it must
+// not become tenant-creatable before then.
+var TenantConfigurableKinds = []string{
+	NotificationChannelKindNtfy,
+	NotificationChannelKindTelegram,
+	NotificationChannelKindDiscord,
+	NotificationChannelKindWebpush,
+	NotificationChannelKindWebhook,
+	NotificationChannelKindSlack,
+	NotificationChannelKindSMS,
+}
+
+// safeDefaultTenantKinds is the allowlist assumed when none is stored: the
+// kinds that carry no tenant-supplied network destination (telegram/webpush) or
+// whose destination is SSRF-guarded (ntfy/discord, phase 4a). webhook/slack/sms
+// require an explicit admin opt-in.
+var safeDefaultTenantKinds = []string{
+	NotificationChannelKindNtfy,
+	NotificationChannelKindTelegram,
+	NotificationChannelKindDiscord,
+	NotificationChannelKindWebpush,
+}
+
+// TenantNotificationKinds is a set of channel kinds, stored as a JSON array.
+type TenantNotificationKinds []string
+
+// DefaultTenantNotificationKinds returns a copy of the safe default set.
+func DefaultTenantNotificationKinds() TenantNotificationKinds {
+	out := make(TenantNotificationKinds, len(safeDefaultTenantKinds))
+	copy(out, safeDefaultTenantKinds)
+	return out
+}
+
+// OrDefault substitutes the safe default set when nothing is stored, so an
+// unset column means "safe defaults", not "deny everything".
+func (k TenantNotificationKinds) OrDefault() TenantNotificationKinds {
+	if len(k) == 0 {
+		return DefaultTenantNotificationKinds()
+	}
+	return k
+}
+
+// Allows reports whether tenants may create a channel of this kind. Fail-closed:
+// an unknown kind is denied.
+func (k TenantNotificationKinds) Allows(kind string) bool {
+	want := strings.ToLower(strings.TrimSpace(kind))
+	for _, v := range k {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Sanitize lowercases, de-duplicates and drops any kind not in
+// TenantConfigurableKinds, so a PATCH cannot smuggle an unsupported or
+// not-yet-safe kind (e.g. email) into the allowlist. Returns a stable-sorted
+// set.
+func (k TenantNotificationKinds) Sanitize() TenantNotificationKinds {
+	allowed := make(map[string]bool, len(TenantConfigurableKinds))
+	for _, c := range TenantConfigurableKinds {
+		allowed[c] = true
+	}
+	seen := make(map[string]bool, len(k))
+	out := make(TenantNotificationKinds, 0, len(k))
+	for _, v := range k {
+		key := strings.ToLower(strings.TrimSpace(v))
+		if allowed[key] && !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Value implements driver.Valuer — stored as a JSON array string; empty → "[]".
+func (k TenantNotificationKinds) Value() (driver.Value, error) {
+	if len(k) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal([]string(k))
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// Scan implements sql.Scanner for a JSON array in a TEXT/JSON column.
+func (k *TenantNotificationKinds) Scan(src any) error {
+	if src == nil {
+		*k = TenantNotificationKinds{}
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("TenantNotificationKinds: unsupported scan type %T", src)
+	}
+	if len(b) == 0 {
+		*k = TenantNotificationKinds{}
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal(b, &out); err != nil {
+		return fmt.Errorf("TenantNotificationKinds: unmarshal: %w", err)
+	}
+	*k = TenantNotificationKinds(out)
+	return nil
+}

--- a/panel-api/internal/models/tenant_notification_kinds_test.go
+++ b/panel-api/internal/models/tenant_notification_kinds_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantNotificationKinds_OrDefault(t *testing.T) {
+	t.Parallel()
+	require.ElementsMatch(t, []string{"ntfy", "telegram", "discord", "webpush"},
+		[]string(TenantNotificationKinds(nil).OrDefault()))
+	// A non-empty set is returned as-is.
+	explicit := TenantNotificationKinds{"ntfy"}
+	require.Equal(t, TenantNotificationKinds{"ntfy"}, explicit.OrDefault())
+}
+
+func TestTenantNotificationKinds_DefaultExcludesRisky(t *testing.T) {
+	t.Parallel()
+	def := DefaultTenantNotificationKinds()
+	require.False(t, def.Allows("webhook"), "webhook must be admin opt-in, not default")
+	require.False(t, def.Allows("sms"))
+	require.False(t, def.Allows("slack"))
+	require.False(t, def.Allows("email"))
+	require.True(t, def.Allows("ntfy"))
+}
+
+func TestTenantNotificationKinds_SanitizeDropsUnsafe(t *testing.T) {
+	t.Parallel()
+	// email is never configurable (phase 4d); "bogus" is unknown; dupes collapse.
+	in := TenantNotificationKinds{"NTFY", "email", "webhook", "bogus", "webhook", " discord "}
+	out := in.Sanitize()
+	require.ElementsMatch(t, []string{"ntfy", "webhook", "discord"}, []string(out))
+	require.NotContains(t, []string(out), "email")
+	require.NotContains(t, []string(out), "bogus")
+}
+
+func TestTenantNotificationKinds_ValueScanRoundTrip(t *testing.T) {
+	t.Parallel()
+	orig := TenantNotificationKinds{"ntfy", "webhook"}
+	v, err := orig.Value()
+	require.NoError(t, err)
+
+	var back TenantNotificationKinds
+	require.NoError(t, back.Scan(v))
+	require.Equal(t, orig, back)
+
+	// nil / empty column scans to an empty set (→ OrDefault at read time).
+	var empty TenantNotificationKinds
+	require.NoError(t, empty.Scan(nil))
+	require.Len(t, empty, 0)
+}


### PR DESCRIPTION
## JAB-171 phase 4b — admin-configurable tenant kind allowlist

Second slice of phase 4. Replaces the phase-3b hardcoded stub with an admin-controlled allowlist on server settings.

Independent of #675 (4a) — disjoint files; based on `main`.

### What lands
- **`models.TenantNotificationKinds`** — JSON-array type (`Value`/`Scan`) with:
  - safe default set `{ntfy, telegram, discord, webpush}`; empty stored value → defaults via `OrDefault()` (**empty means "safe defaults", not "deny all"** — disabling the surface is the master `TenantNotificationsEnabled` switch)
  - `Sanitize()` drops unknown / not-yet-safe kinds so a PATCH can never smuggle one in
- **webhook/slack/sms** become admin opt-in (now SSRF-guarded by #675). **email stays non-configurable** until phase 4d ships verified-address / local-only plumbing (arbitrary `to_email` = open-relay risk).
- **migration 000239**: `tenant_notification_kinds LONGTEXT` (no seed; app defaults on empty). **Box-verified up/down** on testserver MariaDB.
- **`/me/notifications` create** now checks the settings allowlist (gate + allowlist share one settings read).
- **admin settings API**: PATCH accepts `tenant_notification_kinds` (sanitized); GET surfaces the **effective** set (defaults when unset).

### Security
The master `TenantNotificationsEnabled` toggle is **deliberately NOT exposed** in PATCH — it stays un-flippable until phase 4e, after rate limits (4c) + email-verify (4d) land. Editing the allowlist while the surface is off is harmless. `[[feedback_tenant_caps_default_off]]` respected: risky kinds default off.

### Tests
- model: default excludes webhook/sms/slack/email; `Sanitize` drops email + unknown; `Value`/`Scan` round-trip
- handler: default allowlist blocks webhook (422 `kind_not_allowed_for_tenant`); admin opt-in allows it (201, `user_id` server-set)
- settings API: PATCH sanitizes email out; GET shows effective default set
- `go build` / `go vet ./panel-api/...` clean; `-race` green across models/api/app (OpenAPI coverage unchanged — no new routes)

### Remaining phase-4 slices
4c rate-limits/quotas · 4d email-to-own-verified · **4e admin override + gate toggle** (gated on 4a–4d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
