### PR TITLE
feat(notifications): per-user quota + test-send rate limit (JAB-171 phase 4c)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -32,6 +32,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -67,7 +68,10 @@ func RegisterMeNotificationsRoutes(g *gin.RouterGroup, cfg MeNotificationsConfig
 	if cfg.Log == nil {
 		cfg.Log = slog.Default()
 	}
-	h := &meNotificationsHandler{cfg: cfg}
+	h := &meNotificationsHandler{
+		cfg:       cfg,
+		testLimit: newBroadcastLimit(time.Minute, tenantTestSendPerMinute),
+	}
 	grp := g.Group("/me/notifications")
 	grp.GET("/channels", h.listChannels)
 	grp.POST("/channels", h.createChannel)
@@ -79,8 +83,21 @@ func RegisterMeNotificationsRoutes(g *gin.RouterGroup, cfg MeNotificationsConfig
 	grp.DELETE("/routes/:id", h.deleteRoute)
 }
 
+// Per-user anti-abuse limits (JAB-171 phase 4c). Consts, not admin-configurable
+// — a conservative ceiling that a tenant can't tune. The quota bounds stored
+// state; the test-send limit bounds tenant-triggerable outbound traffic (real
+// events fire from system actions, not on tenant demand, so the test endpoint is
+// the only tenant-controllable send).
+const (
+	maxTenantChannelsPerUser = 10
+	tenantTestSendPerMinute  = 5
+)
+
 type meNotificationsHandler struct {
 	cfg MeNotificationsConfig
+	// testLimit is a per-user token bucket for the synchronous test-send,
+	// reusing the admin broadcast limiter (keyed by claims.UserID).
+	testLimit *perAdminBroadcastLimit
 }
 
 // loadSettings loads server settings and enforces the master gate. Fails
@@ -170,6 +187,21 @@ func (h *meNotificationsHandler) createChannel(c *gin.Context) {
 	}
 	if err := validateChannelKindAndConfig(req.Kind, req.Config); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+		return
+	}
+	// Per-user channel quota — bound how many channels one tenant can create.
+	existing, err := h.cfg.Channels.ListByUser(c.Request.Context(), claims.UserID)
+	if err != nil {
+		h.cfg.Log.Error("count own channels failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "create_failed"})
+		return
+	}
+	if len(existing) >= maxTenantChannelsPerUser {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":   "too_many_channels",
+			"message": fmt.Sprintf("channel limit reached (%d per user)", maxTenantChannelsPerUser),
+			"max":     maxTenantChannelsPerUser,
+		})
 		return
 	}
 	enabled := true
@@ -281,6 +313,15 @@ func (h *meNotificationsHandler) testChannel(c *gin.Context) {
 	}
 	claims, ok := requireBrowserAuth(c)
 	if !ok {
+		return
+	}
+	// Per-user test-send rate limit — the test endpoint is the only
+	// tenant-triggerable outbound send, so cap it to blunt third-party spam.
+	if h.testLimit != nil && !h.testLimit.allow(claims.UserID) {
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+			"error":   "rate_limited",
+			"message": fmt.Sprintf("test-send rate limit exceeded (%d/min)", tenantTestSendPerMinute),
+		})
 		return
 	}
 	if h.cfg.Registry == nil {

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -296,6 +296,38 @@ func TestMeNotif_KindAllowlist_DefaultBlocksWebhook_AdminOptInAllows(t *testing.
 	}
 }
 
+func TestMeNotif_ChannelQuota_Is409WhenFull(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	// Seed the per-user cap worth of channels for u1.
+	for i := 0; i < 10; i++ {
+		_ = repo.Create(context.Background(), ownedChannel("u1", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/a"}))
+	}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+		"name":   "one too many",
+		"kind":   "ntfy",
+		"config": map[string]any{"url": "https://ntfy.sh/b"},
+	})
+	require.Equal(t, http.StatusConflict, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "too_many_channels")
+	require.Len(t, repo.rows, 10, "the 11th channel must not be persisted")
+}
+
+func TestMeNotif_TestSendRateLimited_After5PerMin(t *testing.T) {
+	t.Parallel()
+	// One router → one handler → one limiter shared across the requests.
+	r := newMeNotifRouter(t, meNotifSettings(true), &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	// Registry is nil, so an allowed call falls through to 503; the 6th call is
+	// refused by the rate limiter (5/min) BEFORE reaching that path.
+	var last int
+	for i := 0; i < 6; i++ {
+		rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels/anyid/test", nil)
+		last = rec.Code
+	}
+	require.Equal(t, http.StatusTooManyRequests, last, "6th test-send within a minute must be 429")
+}
+
 func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {
 	t.Parallel()
 	repo := &fakeChannelsRepo{}


### PR DESCRIPTION
## JAB-171 phase 4c — per-user quota + test-send rate limit

Third slice of phase 4. Anti-abuse limits for the tenant notification surface. Based on `main` (has 4a #675 + 4b #676).

### What lands
- **Channel quota** — cap a tenant at `maxTenantChannelsPerUser` (10). The create handler counts the caller's own channels and returns **409 `too_many_channels`** past the cap → no unbounded rows.
- **Test-send rate limit** — `/me/notifications/channels/:id/test` is the only tenant-triggerable outbound send (real events fire from system actions, not on tenant demand), so cap it at `tenantTestSendPerMinute` (**5/min per user**) via a token bucket (reuses the admin broadcast limiter, keyed by `claims.UserID`) → **429** when exhausted.

Both are consts — a conservative ceiling a tenant can't tune. No migration, no new routes, no interface change.

### Tests
- 11th channel → 409 (not persisted)
- 6th test-send within a minute → 429
- `go build` / `go vet ./panel-api/...` clean; `-race` green across api + app

### Remaining phase-4 slices
4d email-to-own-verified · **4e admin override + gate toggle** (gated on 4a–4d; flips the master `TenantNotificationsEnabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
