### PR TITLE
feat(notifications): tenant email channels, own-address only (JAB-171 phase 4d)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -55,7 +55,10 @@ type MeNotificationsConfig struct {
 	ServerSettings repository.ServerSettingsRepository
 	Registry       *notifications.Registry
 	SSOKey         *ssokey.Key
-	Log            *slog.Logger
+	// Users resolves the caller's own account email for tenant email channels
+	// (phase 4d). Required only for the email kind; nil → email create/update 503.
+	Users repository.UserRepository
+	Log   *slog.Logger
 }
 
 // RegisterMeNotificationsRoutes mounts the /me/notifications/* surface. Auth
@@ -185,6 +188,15 @@ func (h *meNotificationsHandler) createChannel(c *gin.Context) {
 		})
 		return
 	}
+	// Tenant email channels are forced to deliver only to the caller's own
+	// account address over the local submission path — no arbitrary destination
+	// (open relay) and no custom SMTP host (SSRF). Applied before validation so
+	// the forced fields satisfy the email config rules.
+	if req.Kind == models.NotificationChannelKindEmail {
+		if !h.forceOwnEmailConfig(c, claims.UserID, &req.Config) {
+			return
+		}
+	}
 	if err := validateChannelKindAndConfig(req.Kind, req.Config); err != nil {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
@@ -262,6 +274,13 @@ func (h *meNotificationsHandler) updateChannel(c *gin.Context) {
 		// Validate the MERGED config so presence rules pass on preserved secrets.
 		merged := *req.Config
 		notifsecret.PreserveEmptySecrets(&merged, existing.Config)
+		// Re-force own-address + local mode on every email edit so a tenant can't
+		// PATCH to_email to an arbitrary destination after create (phase 4d).
+		if existing.Kind == models.NotificationChannelKindEmail {
+			if !h.forceOwnEmailConfig(c, claims.UserID, &merged) {
+				return
+			}
+		}
 		if err := validateChannelKindAndConfig(existing.Kind, merged); err != nil {
 			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 			return
@@ -464,6 +483,38 @@ func (h *meNotificationsHandler) deleteRoute(c *gin.Context) {
 }
 
 // --- validation helpers ---
+
+// forceOwnEmailConfig rewrites a tenant email channel's config so it can only
+// deliver to the caller's OWN account address over the local submission path.
+// This is the phase-4d safety property: no arbitrary destination (open relay)
+// and no tenant-supplied SMTP host (SSRF). Returns false (and writes the
+// response) when the user can't be resolved. Any body-supplied to_email /
+// smtp_host / smtp_mode is discarded.
+func (h *meNotificationsHandler) forceOwnEmailConfig(c *gin.Context, userID string, cfg *models.NotificationChannelConfig) bool {
+	if h.cfg.Users == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "email channels unavailable"})
+		return false
+	}
+	u, err := h.cfg.Users.FindByID(c.Request.Context(), userID)
+	if err != nil || u == nil || u.Email == "" {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error":   "no_account_email",
+			"message": "your account has no email address to deliver to",
+		})
+		return false
+	}
+	// Preserve only the non-destination display/formatting fields; hard-set the
+	// destination + transport to the safe own-account/local values.
+	cfg.ToEmail = u.Email
+	cfg.FromEmail = u.Email
+	cfg.SMTPMode = "local"
+	cfg.SMTPHost = ""
+	cfg.SMTPPort = 0
+	cfg.SMTPTLS = ""
+	cfg.SMTPUsername = ""
+	cfg.SMTPPassword = ""
+	return true
+}
 
 // validateEventKind bounds the routed event kind. A stricter allowlist of
 // routable kinds is a later phase; here we only guard shape.

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -94,6 +94,10 @@ func newUserCtxID(userID string) gin.HandlerFunc {
 }
 
 func newMeNotifRouter(t *testing.T, settings repository.ServerSettingsRepository, channels repository.NotificationChannelRepository, routes repository.UserNotificationRouteRepository, authFn gin.HandlerFunc) *gin.Engine {
+	return newMeNotifRouterU(t, settings, channels, routes, nil, authFn)
+}
+
+func newMeNotifRouterU(t *testing.T, settings repository.ServerSettingsRepository, channels repository.NotificationChannelRepository, routes repository.UserNotificationRouteRepository, users repository.UserRepository, authFn gin.HandlerFunc) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -105,6 +109,7 @@ func newMeNotifRouter(t *testing.T, settings repository.ServerSettingsRepository
 		Channels:       channels,
 		Routes:         routes,
 		ServerSettings: settings,
+		Users:          users,
 	})
 	return r
 }
@@ -326,6 +331,61 @@ func TestMeNotif_TestSendRateLimited_After5PerMin(t *testing.T) {
 		last = rec.Code
 	}
 	require.Equal(t, http.StatusTooManyRequests, last, "6th test-send within a minute must be 429")
+}
+
+func TestMeNotif_EmailChannel_ForcesOwnAddressAndLocalMode(t *testing.T) {
+	t.Parallel()
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds{"email"},
+	}}
+	users := &fakeUserRepo{user: &models.User{ID: "u1", Email: "u1@example.com"}}
+	repo := &fakeChannelsRepo{}
+	r := newMeNotifRouterU(t, settings, repo, &fakeUserRoutesRepo{}, users, newUserCtxID("u1"))
+
+	// Attacker-supplied destination + custom SMTP host must be discarded.
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/channels", map[string]any{
+		"name": "mail me",
+		"kind": "email",
+		"config": map[string]any{
+			"to_email":   "victim@evil.com",
+			"from_email": "spoof@evil.com",
+			"smtp_mode":  "smtp",
+			"smtp_host":  "169.254.169.254",
+			"smtp_port":  25,
+		},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.Len(t, repo.rows, 1)
+	for _, row := range repo.rows {
+		require.Equal(t, "u1@example.com", row.Config.ToEmail, "to_email must be forced to the account address")
+		require.Equal(t, "local", row.Config.SMTPMode, "smtp_mode must be forced local")
+		require.Empty(t, row.Config.SMTPHost, "custom smtp host must be discarded")
+		require.NotEqual(t, "victim@evil.com", row.Config.ToEmail)
+	}
+	require.NotContains(t, rec.Body.String(), "evil.com", "no attacker destination echoed")
+}
+
+func TestMeNotif_EmailChannel_UpdateCannotRepointDestination(t *testing.T) {
+	t.Parallel()
+	settings := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds{"email"},
+	}}
+	users := &fakeUserRepo{user: &models.User{ID: "u1", Email: "u1@example.com"}}
+	repo := &fakeChannelsRepo{}
+	// Seed an existing email channel owned by u1.
+	existing := ownedChannel("u1", "email", models.NotificationChannelConfig{ToEmail: "u1@example.com", FromEmail: "u1@example.com", SMTPMode: "local"})
+	_ = repo.Create(context.Background(), existing)
+	r := newMeNotifRouterU(t, settings, repo, &fakeUserRoutesRepo{}, users, newUserCtxID("u1"))
+
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/me/notifications/channels/"+existing.ID, map[string]any{
+		"config": map[string]any{"to_email": "victim@evil.com", "smtp_mode": "smtp", "smtp_host": "10.0.0.1"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "u1@example.com", repo.rows[existing.ID].Config.ToEmail, "edit must not repoint to_email")
+	require.Equal(t, "local", repo.rows[existing.ID].Config.SMTPMode)
+	require.Empty(t, repo.rows[existing.ID].Config.SMTPHost)
 }
 
 func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -211,12 +211,12 @@ func TestServerSettingsPatch_InvalidJSON(t *testing.T) {
 	assert.Equal(t, "validation_failed", respBody["error"])
 }
 
-func TestServerSettingsPatch_TenantNotificationKinds_SanitizesEmail(t *testing.T) {
+func TestServerSettingsPatch_TenantNotificationKinds_SanitizesUnknown(t *testing.T) {
 	t.Parallel()
 	mockRepo := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1, SSHPort: 22}}
 	r := settingsRouter(true, mockRepo, agent.NewMockClient())
 
-	// Admin tries to add email (never tenant-configurable) alongside webhook.
+	// email is admin opt-in (phase 4d); "bogus" is unknown and dropped.
 	payload := map[string]any{"tenant_notification_kinds": []string{"webhook", "email", "bogus"}}
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
@@ -225,8 +225,8 @@ func TestServerSettingsPatch_TenantNotificationKinds_SanitizesEmail(t *testing.T
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 
-	// Persisted set must have dropped email + bogus, kept webhook.
-	require.ElementsMatch(t, []string{"webhook"}, []string(mockRepo.getResult.TenantNotificationKinds))
+	// Persisted set: webhook + email kept, bogus dropped.
+	require.ElementsMatch(t, []string{"webhook", "email"}, []string(mockRepo.getResult.TenantNotificationKinds))
 }
 
 func TestServerSettingsGet_TenantNotificationKinds_EffectiveDefault(t *testing.T) {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -513,6 +513,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			ServerSettings: deps.ServerSettings,
 			Registry:       deps.NotificationRegistry,
 			SSOKey:         deps.SSOKey,
+			Users:          deps.Users,
 			Log:            deps.Log,
 		})
 

--- a/panel-api/internal/models/tenant_notification_kinds.go
+++ b/panel-api/internal/models/tenant_notification_kinds.go
@@ -18,9 +18,9 @@ import (
 // not by an empty allowlist.
 
 // TenantConfigurableKinds is the closed set of kinds an admin MAY place in the
-// allowlist. email is deliberately absent until phase 4d ships verified-address
-// / local-only plumbing (an arbitrary to_email is an open-relay risk); it must
-// not become tenant-creatable before then.
+// allowlist. email is admin opt-in like webhook/slack/sms: a tenant email
+// channel is forced to deliver only to the caller's own account address over the
+// local submission path (phase 4d), so it carries no open-relay / SSRF risk.
 var TenantConfigurableKinds = []string{
 	NotificationChannelKindNtfy,
 	NotificationChannelKindTelegram,
@@ -29,6 +29,7 @@ var TenantConfigurableKinds = []string{
 	NotificationChannelKindWebhook,
 	NotificationChannelKindSlack,
 	NotificationChannelKindSMS,
+	NotificationChannelKindEmail,
 }
 
 // safeDefaultTenantKinds is the allowlist assumed when none is stored: the

--- a/panel-api/internal/models/tenant_notification_kinds_test.go
+++ b/panel-api/internal/models/tenant_notification_kinds_test.go
@@ -25,13 +25,13 @@ func TestTenantNotificationKinds_DefaultExcludesRisky(t *testing.T) {
 	require.True(t, def.Allows("ntfy"))
 }
 
-func TestTenantNotificationKinds_SanitizeDropsUnsafe(t *testing.T) {
+func TestTenantNotificationKinds_SanitizeDropsUnknown(t *testing.T) {
 	t.Parallel()
-	// email is never configurable (phase 4d); "bogus" is unknown; dupes collapse.
+	// "bogus" is unknown and dropped; known kinds (incl. email, phase 4d) are
+	// kept, lowercased/trimmed; dupes collapse.
 	in := TenantNotificationKinds{"NTFY", "email", "webhook", "bogus", "webhook", " discord "}
 	out := in.Sanitize()
-	require.ElementsMatch(t, []string{"ntfy", "webhook", "discord"}, []string(out))
-	require.NotContains(t, []string(out), "email")
+	require.ElementsMatch(t, []string{"ntfy", "email", "webhook", "discord"}, []string(out))
 	require.NotContains(t, []string(out), "bogus")
 }
 


### PR DESCRIPTION
## JAB-171 phase 4d — tenant email channels, own-address only

Fourth slice of phase 4. Makes the `email` kind safe for tenants so an admin can opt it into the allowlist. Based on `main` (has 4a/4b/4c).

### Safety model
A tenant email channel is forced — on create **and on every edit** — to deliver only to the caller's **own account address** over the local submission path:
- `to_email` / `from_email` := the user's account email (resolved server-side via `Users.FindByID`)
- `smtp_mode` := `local` (loopback Stalwart); custom `smtp_host/port/username/password` discarded

Any body-supplied `to_email` or SMTP host is dropped. This closes:
- **open relay** — no arbitrary destination (delivery is always the tenant's own mailbox)
- **SSRF** — no tenant-supplied SMTP host

No verification-token flow needed: the account email is the tenant's own, already-verified address. Arbitrary *other* verified addresses can be a later additive enhancement.

### Changes
- **models**: `email` joins `TenantConfigurableKinds` (admin opt-in, like webhook/slack/sms). It stays **out of the safe default set** — admins must opt in explicitly.
- **me/notifications**: `MeNotificationsConfig` gains `Users`; `forceOwnEmailConfig()` rewrites the config for the email kind on create + update. `Users` nil → 503.
- **app**: wire `deps.Users`.

No migration, no new routes, no interface change.

### Tests
- create discards attacker `to_email` + custom SMTP host → forced own address + local mode (no `evil.com` echoed)
- edit cannot repoint `to_email`
- allowlist `Sanitize` now keeps `email`; default allowlist still excludes it
- `go build` / `go vet ./panel-api/...` clean; `-race` green across api/app/models

### Remaining
**4e** — admin override/visibility (admin can list/disable any tenant channel) **+ the gate toggle** (admin API to flip `TenantNotificationsEnabled`). Gated on 4a–4d; last slice before the surface can be enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
