### PR TITLE
feat(notifications): gate toggle + live delivery kill switch (JAB-171 phase 4e)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -1206,6 +1206,11 @@ func startNotificationDispatcher(parent context.Context, deps app.Deps, log *slo
 	if err == nil && deps.SSOKey != nil {
 		d.WithSecretKey(deps.SSOKey)
 	}
+	if err == nil && deps.ServerSettings != nil {
+		// JAB-171 phase 4e: master gate + kind allowlist govern live tenant
+		// delivery, so the admin toggle is a real kill switch.
+		d.WithServerSettings(deps.ServerSettings)
+	}
 	if err != nil {
 		log.Error("notifications dispatcher: construction failed", "err", err)
 		return nil, nil

--- a/panel-api/internal/api/notifications_channels_test.go
+++ b/panel-api/internal/api/notifications_channels_test.go
@@ -256,6 +256,23 @@ func TestChannels_Update_Partial(t *testing.T) {
 	require.Equal(t, "Ops", row.Name) // untouched
 }
 
+// JAB-171 phase 4e: an admin can disable ANY channel, including a tenant-owned
+// one (admin override) — the admin surface is not ownership-scoped.
+func TestChannels_AdminCanDisableTenantChannel(t *testing.T) {
+	t.Parallel()
+	uid := "tenant1"
+	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{
+		"t": {ID: "t", Name: "TenantNtfy", Kind: "ntfy", Enabled: true, UserID: &uid, Config: models.NotificationChannelConfig{URL: "https://ntfy.sh/x"}},
+	}}
+	r := newChannelsRouter(t, repo, nil, newAdminCtx())
+	rec := doNotifJSON(t, r, http.MethodPatch, "/api/v1/admin/notifications/channels/t", map[string]any{"enabled": false})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	row, err := repo.FindByID(context.Background(), "t")
+	require.NoError(t, err)
+	require.False(t, row.Enabled, "admin must be able to disable a tenant channel")
+	require.NotNil(t, row.UserID)
+}
+
 func TestChannels_Delete(t *testing.T) {
 	t.Parallel()
 	repo := &fakeChannelsRepo{rows: map[string]*models.NotificationChannel{

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -137,11 +137,13 @@ type updateServerSettingsRequest struct {
 	TenantDomainOptionsEnabled   *bool   `json:"tenant_domain_options_enabled,omitempty"`
 	TenantDocrootEditable        *bool   `json:"tenant_docroot_editable,omitempty"`
 	// TenantNotificationKinds — admin-configurable tenant channel-kind allowlist
-	// (phase 4b). The master TenantNotificationsEnabled toggle is deliberately
-	// NOT exposed here: it stays un-flippable until phase 4e, after rate limits
-	// and email-verify land (do-not-ship gate). Editing the allowlist while the
-	// surface is off is harmless.
+	// (phase 4b).
 	TenantNotificationKinds *models.TenantNotificationKinds `json:"tenant_notification_kinds,omitempty"`
+	// TenantNotificationsEnabled — master switch for the whole /me/notifications
+	// surface (phase 4e). Now exposed: the abuse controls it gated on (SSRF 4a,
+	// allowlist 4b, quota+rate-limit 4c, email-to-own 4d) have all landed, and
+	// the dispatcher honours this flag as a live delivery kill switch.
+	TenantNotificationsEnabled *bool `json:"tenant_notifications_enabled,omitempty"`
 	RootTerminalEnabled          *bool   `json:"root_terminal_enabled,omitempty"`
 	BandwidthQuotaEnforceEnabled *bool   `json:"bandwidth_quota_enforce_enabled,omitempty"`
 	UploadMaxSizeMB              *uint32 `json:"upload_max_size_mb,omitempty"`
@@ -499,9 +501,12 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 		current.TenantDocrootEditable = *req.TenantDocrootEditable
 	}
 	if req.TenantNotificationKinds != nil {
-		// Sanitize drops unknown / not-yet-safe kinds (e.g. email), so a PATCH
-		// can never smuggle an unsupported kind into the tenant allowlist.
+		// Sanitize drops unknown kinds, so a PATCH can never smuggle an
+		// unsupported kind into the tenant allowlist.
 		current.TenantNotificationKinds = req.TenantNotificationKinds.Sanitize()
+	}
+	if req.TenantNotificationsEnabled != nil {
+		current.TenantNotificationsEnabled = *req.TenantNotificationsEnabled
 	}
 	if req.RootTerminalEnabled != nil {
 		current.RootTerminalEnabled = *req.RootTerminalEnabled

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -229,6 +229,21 @@ func TestServerSettingsPatch_TenantNotificationKinds_SanitizesUnknown(t *testing
 	require.ElementsMatch(t, []string{"webhook", "email"}, []string(mockRepo.getResult.TenantNotificationKinds))
 }
 
+func TestServerSettingsPatch_TenantNotificationsToggle(t *testing.T) {
+	t.Parallel()
+	mockRepo := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1, SSHPort: 22}}
+	r := settingsRouter(true, mockRepo, agent.NewMockClient())
+
+	payload := map[string]any{"tenant_notifications_enabled": true}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/admin/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.True(t, mockRepo.getResult.TenantNotificationsEnabled, "toggle must persist")
+}
+
 func TestServerSettingsGet_TenantNotificationKinds_EffectiveDefault(t *testing.T) {
 	t.Parallel()
 	// Empty column → GET surfaces the safe default set, not a blank list.

--- a/panel-api/internal/notifications/dispatcher.go
+++ b/panel-api/internal/notifications/dispatcher.go
@@ -92,7 +92,14 @@ type Dispatcher struct {
 	// sender is invoked (JAB-171). Optional — when nil, configs are used as
 	// stored (fine for pre-seal rows / tests).
 	secretKey *ssokey.Key
-	log       *slog.Logger
+	// serverSettings makes the tenant surface's master gate + kind allowlist a
+	// real DELIVERY kill switch (JAB-171 phase 4e), not just a create-time gate:
+	// when TenantNotificationsEnabled is off, tenant-owned channels receive
+	// nothing; a channel whose kind is no longer in the allowlist stops
+	// delivering even if the row survives. Optional — when nil, no gate is
+	// applied (pre-phase-4e behaviour, used by tests).
+	serverSettings repository.ServerSettingsRepository
+	log            *slog.Logger
 	consumer  string
 
 	wg      sync.WaitGroup
@@ -129,6 +136,15 @@ func (d *Dispatcher) WithUserRoutes(r repository.UserNotificationRouteRepository
 // as stored — fine for legacy plaintext rows and tests.
 func (d *Dispatcher) WithSecretKey(key *ssokey.Key) *Dispatcher {
 	d.secretKey = key
+	return d
+}
+
+// WithServerSettings injects the settings repo so the tenant surface's master
+// gate + kind allowlist govern LIVE delivery, not just channel creation
+// (JAB-171 phase 4e). Without it, tenant channels resolve unconditionally
+// (pre-phase-4e behaviour).
+func (d *Dispatcher) WithServerSettings(r repository.ServerSettingsRepository) *Dispatcher {
+	d.serverSettings = r
 	return d
 }
 
@@ -400,11 +416,21 @@ func (d *Dispatcher) resolveTargets(ctx context.Context, env Envelope) ([]models
 		// here (channel.UserID == recipient) so a stray route can never
 		// deliver another user's — or a global admin — channel.
 		if env.UserID != "" && d.userRoutes != nil {
-			userChans, err := d.recipientRoutedChannels(ctx, env.UserID, env.EventKind)
-			if err != nil {
-				return nil, err
+			allowTenant, allowedKinds := d.tenantDeliveryPolicy(ctx)
+			if allowTenant {
+				userChans, err := d.recipientRoutedChannels(ctx, env.UserID, env.EventKind)
+				if err != nil {
+					return nil, err
+				}
+				for _, ch := range userChans {
+					// Live allowlist: a kind removed from the tenant allowlist
+					// stops delivering even though the channel row survives.
+					if allowedKinds != nil && !allowedKinds.Allows(ch.Kind) {
+						continue
+					}
+					targets = append(targets, ch)
+				}
 			}
-			targets = append(targets, userChans...)
 		}
 		return targets, nil
 	}
@@ -425,6 +451,24 @@ func (d *Dispatcher) resolveTargets(ctx context.Context, env Envelope) ([]models
 		out = append(out, *ch)
 	}
 	return out, nil
+}
+
+// tenantDeliveryPolicy reads the master gate + kind allowlist that govern
+// whether tenant-owned channels receive anything (JAB-171 phase 4e). Returns
+// (allow, allowedKinds):
+//   - serverSettings unset → (true, nil): no gate, deliver as before (tests).
+//   - gate off, nil settings, or a read error → (false, nil): fail CLOSED, the
+//     master switch is a real kill switch and a DB blip can't bypass it.
+//   - gate on → (true, effective allowlist) so callers filter by channel kind.
+func (d *Dispatcher) tenantDeliveryPolicy(ctx context.Context) (bool, models.TenantNotificationKinds) {
+	if d.serverSettings == nil {
+		return true, nil
+	}
+	st, err := d.serverSettings.Get(ctx)
+	if err != nil || st == nil || !st.TenantNotificationsEnabled {
+		return false, nil
+	}
+	return true, st.TenantNotificationKinds.OrDefault()
 }
 
 // recipientRoutedChannels returns the recipient's OWN enabled channels that

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -548,6 +548,66 @@ func TestResolveTargets_PerUserRouting(t *testing.T) {
 	}
 }
 
+// fakeSettings is a minimal ServerSettingsRepository for gate tests.
+type fakeSettings struct {
+	st  *models.ServerSettings
+	err error
+}
+
+func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) { return f.st, f.err }
+func (f *fakeSettings) Upsert(context.Context, *models.ServerSettings) error { return nil }
+func (f *fakeSettings) EnsureVAPID(context.Context, string) (bool, error)    { return false, nil }
+
+// JAB-171 phase 4e: the master gate + kind allowlist are a LIVE delivery kill
+// switch, not just a create-time gate.
+func TestResolveTargets_TenantGate(t *testing.T) {
+	g1 := models.NotificationChannel{ID: "G1", Enabled: true, UserID: nil}
+	a1 := models.NotificationChannel{ID: "A1", Kind: "ntfy", Enabled: true, UserID: ptr("userA")}
+	newFC := func() *fakeChannels {
+		return &fakeChannels{
+			byID:    map[string]*models.NotificationChannel{"G1": &g1, "A1": &a1},
+			enabled: []models.NotificationChannel{g1, a1},
+		}
+	}
+	fr := &fakeUserRoutes{routes: map[string]map[string][]string{"userA": {"backup.done": {"A1"}}}}
+	env := Envelope{EventKind: "backup.done", UserID: "userA"}
+	ctx := context.Background()
+
+	// Gate OFF → tenant channel A1 excluded (only server-wide G1 delivered).
+	dOff := &Dispatcher{channels: newFC(), userRoutes: fr,
+		serverSettings: &fakeSettings{st: &models.ServerSettings{TenantNotificationsEnabled: false}}}
+	got, err := dOff.resolveTargets(ctx, env)
+	require.NoError(t, err)
+	m := ids(got)
+	require.True(t, m["G1"])
+	require.False(t, m["A1"], "gate OFF must exclude tenant channels from delivery")
+
+	// Settings read error → fail CLOSED (tenant excluded).
+	dErr := &Dispatcher{channels: newFC(), userRoutes: fr,
+		serverSettings: &fakeSettings{err: context.DeadlineExceeded}}
+	got, _ = dErr.resolveTargets(ctx, env)
+	require.False(t, ids(got)["A1"], "settings read error must fail closed")
+
+	// Gate ON, allowlist excludes ntfy → A1 excluded (live kind revocation).
+	dRevoked := &Dispatcher{channels: newFC(), userRoutes: fr,
+		serverSettings: &fakeSettings{st: &models.ServerSettings{
+			TenantNotificationsEnabled: true,
+			TenantNotificationKinds:    models.TenantNotificationKinds{"telegram"},
+		}}}
+	got, _ = dRevoked.resolveTargets(ctx, env)
+	require.False(t, ids(got)["A1"], "a kind removed from the allowlist must stop delivering")
+
+	// Gate ON, allowlist includes ntfy → A1 delivered.
+	dOn := &Dispatcher{channels: newFC(), userRoutes: fr,
+		serverSettings: &fakeSettings{st: &models.ServerSettings{
+			TenantNotificationsEnabled: true,
+			TenantNotificationKinds:    models.TenantNotificationKinds{"ntfy"},
+		}}}
+	got, err = dOn.resolveTargets(ctx, env)
+	require.NoError(t, err)
+	require.True(t, ids(got)["A1"], "gate ON + kind allowed must deliver")
+}
+
 // JAB-171 phase 3: the dispatcher opens a sealed secret just before the sender
 // reads it — the sender must see plaintext, never the enc:1: envelope.
 func TestSendOne_OpensSealedSecret(t *testing.T) {


### PR DESCRIPTION
## JAB-171 phase 4e — gate toggle + live delivery kill switch

**Final phase-4 slice.** The abuse controls this gated on are all merged (SSRF #675, allowlist #676, quota+rate-limit #677, email-to-own #678), so expose the master switch and make it a *real* kill switch. Based on `main` (has 4a–4d).

### What lands
- **Gate toggle** — server settings PATCH now accepts `tenant_notifications_enabled`, so an admin can finally enable/disable the `/me/notifications` surface. GET already returns it; the allowlist (`tenant_notification_kinds`) landed in 4b.
- **Dispatcher kill switch** — `WithServerSettings` makes the master gate + kind allowlist govern **live delivery**, not just channel creation:
  - gate **OFF** (or a settings read error) → tenant-owned channels receive **nothing** (fail closed); server-wide/admin channels unaffected.
  - a kind **removed from the allowlist** stops delivering to tenant channels of that kind even though the row survives (**live revocation**).
  - nil settings (tests) → no gate, unchanged behaviour.
- **serve.go** — wire `deps.ServerSettings` into the dispatcher.
- **Admin override** already exists (the admin channel API is not ownership-scoped: list shows `user_id`, admin can disable/delete any tenant channel) — added a test pinning it.

No migration (column exists from 3b), no new routes.

### Tests
- dispatcher: gate off / settings-read-error (fail closed) / kind-revoked / kind-allowed
- settings PATCH `tenant_notifications_enabled` persists
- admin disables a tenant-owned channel
- `go vet ./panel-api/...` clean; `-race` green across notifications/api/app

### Phase 4 COMPLETE
The tenant notification surface is now safe to enable. An operator turns it on via `tenant_notifications_enabled` once they've reviewed the kind allowlist.

**Remaining for JAB-171:** phase 5 (tenant + admin UI) and phase 6 (CLI + docs/ADR). Do **not** flip JAB-171 → Done until those ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
