### PR TITLE
feat(ui): tenant My Notifications page (JAB-171 phase 5a)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -88,6 +88,7 @@ const UserBackupsPage = lazy(() => import("./shells/user/backups/UserBackupsPage
 const UserLogsPage = lazy(() => import("./shells/user/logs/UserLogsPage").then((m) => ({ default: m.UserLogsPage })));
 const UserSSHKeysPage = lazy(() => import("./shells/user/ssh-keys/UserSSHKeysPage").then((m) => ({ default: m.UserSSHKeysPage })));
 const UserAPITokensPage = lazy(() => import("./shells/user/api-tokens/UserAPITokensPage").then((m) => ({ default: m.UserAPITokensPage })));
+const MyNotificationsPage = lazy(() => import("./shells/user/notifications/MyNotificationsPage").then((m) => ({ default: m.MyNotificationsPage })));
 const APIDocsPage = lazy(() => import("./shells/shared/APIDocsPage").then((m) => ({ default: m.APIDocsPage })));
 const UserCronList = lazy(() => import("./shells/user/cron/UserCronList").then((m) => ({ default: m.UserCronList })));
 const AdminCronList = lazy(() => import("./shells/admin/cron/AdminCronList").then((m) => ({ default: m.AdminCronList })));
@@ -392,6 +393,7 @@ const ThemedApp = () => {
               }
             />
             <Route path="api-docs" element={<APIDocsPage />} />
+            <Route path="notifications" element={<MyNotificationsPage />} />
             <Route path="cron" element={<UserCronList />} />
             <Route path="backups" element={<UserBackupsPage />} />
             <Route path="mail" element={<Navigate to="/jabali-panel/mail/mailboxes" replace />} />

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -65,6 +65,7 @@
       "logs": "Logs & Statistics",
       "ssh-keys": "SSH Keys",
       "api-tokens": "Personal API Tokens",
+      "notifications": "Notifications",
       "dns": "DNS",
       "ssl": "SSL Manager",
       "php-settings": "PHP Settings",

--- a/panel-ui/src/nav.ts
+++ b/panel-ui/src/nav.ts
@@ -339,6 +339,12 @@ export const userNav: NavItem[] = [
     path: "/jabali-panel/api-tokens",
   },
   {
+    key: "notifications",
+    label: "nav.user.notifications",
+    icon: navIcon(BellOutlined),
+    path: "/jabali-panel/notifications",
+  },
+  {
     key: "dns",
     label: "nav.user.dns",
     icon: navIcon(CloudServerOutlined),

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
@@ -1,0 +1,200 @@
+// MyChannelDrawer — tenant create/edit drawer for a user's OWN notification
+// channels (JAB-171 phase 5). Mirrors AdminChannelDrawer but points at the
+// ownership-scoped /me/notifications/channels surface and offers only the
+// tenant-creatable kinds. Secrets are write-only: an edit leaves a secret
+// field blank to keep the stored (sealed) value — the placeholder says so.
+import { useEffect, useMemo } from "react";
+import {
+  Alert,
+  Button,
+  Drawer,
+  Form,
+  Grid,
+  Input,
+  InputNumber,
+  Select,
+  Switch,
+  message,
+} from "antd";
+
+import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
+import { apiClient } from "../../../apiClient";
+import { useCreateMutation, useUpdateMutation } from "../../../hooks/useQueries";
+import {
+  kindFields,
+  kindLabels,
+  type ChannelFormConfig,
+  type ChannelKind,
+} from "../../admin/notifications/channelKindConfig";
+
+// TENANT_KINDS — the kinds a tenant may create in the UI. The safe default
+// server allowlist; if an admin has widened it, the server still accepts other
+// kinds via API, but the common surface is these four.
+export const TENANT_KINDS: ChannelKind[] = ["ntfy", "telegram", "discord", "webpush"];
+
+export type MyChannel = {
+  id: string;
+  name: string;
+  kind: ChannelKind;
+  config: ChannelFormConfig;
+  enabled: boolean;
+  user_id?: string;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type FormValues = {
+  name: string;
+  kind: ChannelKind;
+  enabled: boolean;
+  config: ChannelFormConfig;
+};
+
+export interface MyChannelDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  existing?: MyChannel;
+}
+
+const RESOURCE = "me/notifications/channels";
+
+export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProps) {
+  const [form] = Form.useForm<FormValues>();
+  const screens = Grid.useBreakpoint();
+  const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
+  const create = useCreateMutation<MyChannel, Partial<FormValues>>({ resource: RESOURCE });
+  const update = useUpdateMutation<MyChannel, Partial<FormValues>>({ resource: RESOURCE });
+  const isEdit = Boolean(existing);
+
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    form.setFieldsValue({
+      name: existing?.name ?? "",
+      kind: existing?.kind ?? "ntfy",
+      enabled: existing?.enabled ?? true,
+      config: existing?.config ?? {},
+    });
+  }, [open, existing, form]);
+
+  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? existing?.kind ?? "ntfy";
+  const watchedConfig = Form.useWatch<ChannelFormConfig | undefined>("config", form);
+  const fields = useMemo(() => {
+    const all = kindFields[watchedKind] ?? [];
+    return all.filter((f) => {
+      if (!f.dependsOn) return true;
+      return watchedConfig?.[f.dependsOn.name] === f.dependsOn.value;
+    });
+  }, [watchedKind, watchedConfig]);
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      if (isEdit && existing) {
+        await update.mutateAsync({ id: existing.id, input: values });
+        message.success(`Channel "${values.name}" updated`);
+      } else {
+        await create.mutateAsync(values);
+        message.success(`Channel "${values.name}" created`);
+      }
+      onClose();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Save failed");
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!existing) return;
+    try {
+      await apiClient.post(`/${RESOURCE}/${existing.id}/test`);
+      message.success(`Test sent to "${existing.name}"`);
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Test failed");
+    }
+  };
+
+  return (
+    <Drawer
+      title={isEdit ? `Edit ${existing?.name ?? "channel"}` : "Add channel"}
+      open={open}
+      onClose={onClose}
+      width={isDesktop ? 520 : undefined}
+      placement="right"
+      destroyOnClose
+      footer={
+        <StandardDrawerFooter
+          formId="my-channel-form"
+          primaryText={isEdit ? "Save" : "Create"}
+          primaryLoading={create.isPending || update.isPending}
+          onCancel={onClose}
+          extra={isEdit ? <Button onClick={handleSendTest}>Send test</Button> : null}
+        />
+      }
+    >
+      <Form<FormValues>
+        id="my-channel-form"
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        initialValues={{ kind: "ntfy", enabled: true, config: {} }}
+      >
+        <Form.Item
+          name="name"
+          label="Name"
+          rules={[
+            { required: true, message: "Name required" },
+            { max: 120, message: "Max 120 chars" },
+          ]}
+        >
+          <Input placeholder="My phone" />
+        </Form.Item>
+
+        <Form.Item name="kind" label="Kind" rules={[{ required: true }]}>
+          <Select
+            disabled={isEdit}
+            options={TENANT_KINDS.map((k) => ({ value: k, label: kindLabels[k] }))}
+          />
+        </Form.Item>
+
+        <Form.Item name="enabled" label="Enabled" valuePropName="checked">
+          <Switch />
+        </Form.Item>
+
+        {watchedKind === "webpush" ? (
+          <Alert
+            type="info"
+            showIcon
+            message="Web Push has no fields to configure"
+            description="It delivers to this browser's push subscription, created from the notification bell."
+          />
+        ) : null}
+
+        {fields.map((f) => {
+          const rules: { required?: boolean; message: string }[] = [];
+          if (f.required) rules.push({ required: true, message: `${f.label} required` });
+          const input = (() => {
+            if (f.type === "number") {
+              return <InputNumber min={1} max={5} style={{ width: "100%" }} />;
+            }
+            if (f.type === "password") {
+              return (
+                <Input.Password placeholder={isEdit ? "•••••• (leave blank to keep)" : f.placeholder} />
+              );
+            }
+            if (f.type === "tags") {
+              return <Select mode="tags" tokenSeparators={[",", " "]} placeholder="tag1,tag2" />;
+            }
+            if (f.type === "select") {
+              return <Select options={f.options ?? []} placeholder={f.placeholder} />;
+            }
+            return <Input placeholder={f.placeholder} />;
+          })();
+          return (
+            <Form.Item key={String(f.name)} name={["config", f.name]} label={f.label} rules={rules} extra={f.help}>
+              {input}
+            </Form.Item>
+          );
+        })}
+      </Form>
+    </Drawer>
+  );
+}

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -1,0 +1,294 @@
+// My Notifications — tenant self-service for per-user notification channels +
+// event routing (JAB-171 phase 5). Ownership-scoped to the signed-in user via
+// /api/v1/me/notifications/*. The whole surface is gated server-side behind an
+// admin switch; when it's off every call returns 403 and we render a calm
+// "not enabled" state rather than an error.
+//
+// Wire paths:
+//   GET/POST/PATCH/DELETE  /me/notifications/channels[/:id]
+//   POST                   /me/notifications/channels/:id/test
+//   GET/POST/DELETE        /me/notifications/routes[/:id]
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Form,
+  Input,
+  Popconfirm,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import type { AxiosError } from "axios";
+
+import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
+import { apiClient } from "../../../apiClient";
+import { useDeleteMutation, useUpdateMutation } from "../../../hooks/useQueries";
+import { kindColors, kindLabels } from "../../admin/notifications/channelKindConfig";
+import { MyChannelDrawer, type MyChannel } from "./MyChannelDrawer";
+
+const CH_RESOURCE = "me/notifications/channels";
+const RT_RESOURCE = "me/notifications/routes";
+
+type Route = {
+  id: string;
+  user_id: string;
+  event_kind: string;
+  channel_id: string;
+};
+
+function statusOf(err: unknown): number | undefined {
+  return (err as AxiosError | undefined)?.response?.status;
+}
+
+export function MyNotificationsPage(): JSX.Element {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<MyChannel | undefined>();
+
+  const channelsQ = useQuery<MyChannel[]>({
+    queryKey: ["list", CH_RESOURCE],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ items: MyChannel[] }>(`/${CH_RESOURCE}`);
+      return data.items ?? [];
+    },
+    retry: false,
+  });
+
+  const routesQ = useQuery<Route[]>({
+    queryKey: ["list", RT_RESOURCE],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ items: Route[] }>(`/${RT_RESOURCE}`);
+      return data.items ?? [];
+    },
+    retry: false,
+    // The channels query already surfaces the disabled state; keep this quiet.
+    enabled: statusOf(channelsQ.error) !== 403,
+  });
+
+  const disabled = statusOf(channelsQ.error) === 403;
+
+  const updateMutation = useUpdateMutation<MyChannel, { enabled: boolean }>({ resource: CH_RESOURCE });
+  const deleteMutation = useDeleteMutation({ resource: CH_RESOURCE });
+
+  const channels = channelsQ.data ?? [];
+  const channelName = (id: string) => channels.find((c) => c.id === id)?.name ?? id;
+
+  const toggleEnabled = async (row: MyChannel, next: boolean) => {
+    try {
+      await updateMutation.mutateAsync({ id: row.id, input: { enabled: next } });
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Toggle failed");
+    }
+  };
+
+  const removeChannel = async (row: MyChannel) => {
+    try {
+      await deleteMutation.mutateAsync({ id: row.id });
+      message.success(`Deleted ${row.name}`);
+      qc.invalidateQueries({ queryKey: ["list", RT_RESOURCE] });
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Delete failed");
+    }
+  };
+
+  const testChannel = async (row: MyChannel) => {
+    try {
+      await apiClient.post(`/${CH_RESOURCE}/${row.id}/test`);
+      message.success(`Test sent to ${row.name}`);
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Test failed");
+    }
+  };
+
+  if (disabled) {
+    return (
+      <Card>
+        <Alert
+          type="info"
+          showIcon
+          message="Notifications are not enabled"
+          description="Per-user notification channels are turned off on this server. Ask your administrator to enable them."
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: "100%" }}>
+      <Card
+        title="My notification channels"
+        extra={
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditing(undefined);
+              setDrawerOpen(true);
+            }}
+          >
+            Add channel
+          </Button>
+        }
+      >
+        <Table<MyChannel>
+          rowKey="id"
+          loading={channelsQ.isLoading}
+          dataSource={channels}
+          pagination={false}
+          locale={{ emptyText: <Empty description="No channels yet — add one to get notified." /> }}
+          scroll={{ x: "max-content" }}
+        >
+          <Table.Column
+            dataIndex="name"
+            title="Name"
+            render={(name: string, row: MyChannel) => (
+              <a
+                onClick={() => {
+                  setEditing(row);
+                  setDrawerOpen(true);
+                }}
+              >
+                {name}
+              </a>
+            )}
+          />
+          <Table.Column
+            dataIndex="kind"
+            title="Kind"
+            render={(k: string) => (
+              <Tag color={kindColors[k as keyof typeof kindColors]}>
+                {kindLabels[k as keyof typeof kindLabels] ?? k}
+              </Tag>
+            )}
+          />
+          <Table.Column
+            dataIndex="enabled"
+            title="Enabled"
+            render={(enabled: boolean, row: MyChannel) => (
+              <Switch checked={enabled} onChange={(next) => toggleEnabled(row, next)} />
+            )}
+          />
+          <Table.Column
+            title="Actions"
+            key="actions"
+            render={(_: unknown, row: MyChannel) => (
+              <Space>
+                <Button size="small" icon={<SendOutlined />} onClick={() => testChannel(row)}>
+                  Test
+                </Button>
+                <Button
+                  size="small"
+                  icon={<EditOutlined />}
+                  onClick={() => {
+                    setEditing(row);
+                    setDrawerOpen(true);
+                  }}
+                />
+                <Popconfirm title={`Delete ${row.name}?`} onConfirm={() => removeChannel(row)}>
+                  <Button size="small" danger icon={<DeleteOutlined />} />
+                </Popconfirm>
+              </Space>
+            )}
+          />
+        </Table>
+      </Card>
+
+      <Card title="Event routing">
+        <Typography.Paragraph type="secondary">
+          Route a server event to one of your channels. When that event fires for you, the channel is notified.
+        </Typography.Paragraph>
+        <RouteAdder channels={channels} onAdded={() => routesQ.refetch()} />
+        <Table<Route>
+          rowKey="id"
+          style={{ marginTop: 16 }}
+          loading={routesQ.isLoading}
+          dataSource={routesQ.data ?? []}
+          pagination={false}
+          locale={{ emptyText: <Empty description="No routes yet." /> }}
+          scroll={{ x: "max-content" }}
+        >
+          <Table.Column dataIndex="event_kind" title="Event" render={(e: string) => <Tag>{e}</Tag>} />
+          <Table.Column dataIndex="channel_id" title="Channel" render={(id: string) => channelName(id)} />
+          <Table.Column
+            title="Actions"
+            key="actions"
+            render={(_: unknown, row: Route) => (
+              <Popconfirm
+                title="Remove this route?"
+                onConfirm={async () => {
+                  try {
+                    await apiClient.delete(`/${RT_RESOURCE}/${row.id}`);
+                    routesQ.refetch();
+                  } catch (err) {
+                    message.error(err instanceof Error ? err.message : "Remove failed");
+                  }
+                }}
+              >
+                <Button size="small" danger icon={<DeleteOutlined />} />
+              </Popconfirm>
+            )}
+          />
+        </Table>
+      </Card>
+
+      <MyChannelDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} existing={editing} />
+      {/* t() kept referenced for future i18n of this page */}
+      <span style={{ display: "none" }}>{t("nav.user.notifications", "Notifications")}</span>
+    </Space>
+  );
+}
+
+function RouteAdder({ channels, onAdded }: { channels: MyChannel[]; onAdded: () => void }): JSX.Element {
+  const [form] = Form.useForm<{ event_kind: string; channel_id: string }>();
+  const [saving, setSaving] = useState(false);
+
+  const submit = async (v: { event_kind: string; channel_id: string }) => {
+    setSaving(true);
+    try {
+      await apiClient.post(`/${RT_RESOURCE}`, {
+        event_kind: v.event_kind.trim(),
+        channel_id: v.channel_id,
+      });
+      message.success("Route added");
+      form.resetFields();
+      onAdded();
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Add route failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Form form={form} layout="inline" onFinish={submit}>
+      <Form.Item
+        name="event_kind"
+        rules={[{ required: true, message: "Event kind required" }]}
+        style={{ minWidth: 220 }}
+      >
+        <Input placeholder="event kind, e.g. backup.completed" />
+      </Form.Item>
+      <Form.Item name="channel_id" rules={[{ required: true, message: "Pick a channel" }]} style={{ minWidth: 200 }}>
+        <Select
+          placeholder="Channel"
+          options={channels.map((c) => ({ value: c.id, label: c.name }))}
+        />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit" loading={saving} icon={<PlusOutlined />}>
+          Add route
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+}


### PR DESCRIPTION
## JAB-171 phase 5a — tenant "My Notifications" UI

First UI slice. Self-service page for per-user notification channels + event routing, backed by the ownership-scoped `/me/notifications/*` API (all merged, backend security complete through phase 4).

### What lands
- **`MyNotificationsPage`** (`/jabali-panel/notifications`):
  - own channels table — name / kind / enabled toggle / **test** / edit / delete
  - **event routing** card — route an event kind to one of your channels, list + remove routes
  - renders a calm **"not enabled"** state on the server's `403` when the surface is gated off (rather than an error)
- **`MyChannelDrawer`** — create/edit drawer; mirrors the admin one but points at `/me/notifications/channels` and offers the tenant kinds (`ntfy/telegram/discord/webpush`). **Secret fields are write-only** — an edit leaves them blank to keep the stored (sealed) value; the placeholder says so. Reuses the admin `channelKindConfig` so per-kind form fields stay defined in one place.
- Route + user nav entry (BellOutlined) + `en` i18n key.

Uses react-query with the `["list", resource]` key the create/update/delete mutations invalidate, so the list refreshes after a drawer save.

### Verification
- `npx tsc -b` clean · `vitest` 146 passed · production `npm run build` succeeds
- ⚠️ **Visual QA pending** — the Chrome extension is unavailable in the build env, so I could not click through the page. Please review it in a browser: enable the surface first (`tenant_notifications_enabled` in admin settings), then visit **/jabali-panel/notifications** as a tenant.

### Notes / follow-ups
- The drawer offers the safe default kinds; if an admin widens the allowlist, other kinds are still creatable via API but not surfaced here (a future enhancement could fetch the effective allowlist).
- Admin-side settings UI (the toggle + allowlist editor) is **phase 5b** (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
