### PR TITLE
feat(ui): admin tenant-notifications settings + owner column (JAB-171 phase 5b)

### DIFF
--- a/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
+++ b/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
@@ -33,6 +33,9 @@ export type NotificationChannel = {
   kind: ChannelKind;
   config: ChannelFormConfig;
   enabled: boolean;
+  // user_id is set for tenant-owned channels (JAB-171); null/undefined = a
+  // server-wide admin channel.
+  user_id?: string | null;
   created_at?: string;
   updated_at?: string;
 };

--- a/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
@@ -119,6 +119,19 @@ export const ChannelsTab = () => {
           )}
         />
         <Table.Column
+          dataIndex="user_id"
+          title="Owner"
+          render={(userID: string | null | undefined) =>
+            userID ? (
+              <Tag color="blue" title={userID}>
+                Tenant
+              </Tag>
+            ) : (
+              <Tag>Server-wide</Tag>
+            )
+          }
+        />
+        <Table.Column
           dataIndex="enabled"
           title={t("channelstab.enabled")}
           render={(enabled: boolean, row: NotificationChannel) => (

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -73,6 +73,7 @@ import { PanelSSLCard } from "./PanelSSLCard";
 import { NspawnImagesCard } from "./NspawnImagesCard";
 import { SSOMaintenanceCard } from "./SSOMaintenanceCard";
 import { TenantDomainOptionsCard } from "./TenantDomainOptionsCard";
+import { TenantNotificationsCard } from "./TenantNotificationsCard";
 import { NginxSettingsCard } from "./NginxSettingsCard";
 import { LogRetentionCard } from "./LogRetentionCard";
 
@@ -1058,7 +1059,12 @@ export const ServerSettingsPage = () => {
         activeTabKey={activeTab}
         onTabChange={(k) => setActiveTab(k as SettingsTabKey)}
       >
-        {activeTab === "general" && <GeneralSettingsTab />}
+        {activeTab === "general" && (
+          <>
+            <GeneralSettingsTab />
+            <TenantNotificationsCard />
+          </>
+        )}
         {activeTab === "ssh" && <SSHSettingsTab />}
         {activeTab === "storage" && <StorageSettingsTab />}
         {activeTab === "dns" && <DNSSettingsTab />}

--- a/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { Alert, Card, Select, Space, Switch, Typography, notification } from "antd";
+
+import { apiClient } from "../../../apiClient";
+import { kindLabels, type ChannelKind } from "../notifications/channelKindConfig";
+
+// TenantNotificationsCard — Server Settings → General: the master switch for the
+// tenant-facing /me/notifications surface (JAB-171) plus the admin-controlled
+// allowlist of channel KINDS a tenant may create. Off by default; the surface
+// only comes to life once an admin flips it. The allowlist gates creation AND
+// live delivery server-side, so narrowing it stops existing tenant channels of a
+// removed kind.
+
+// Kinds an admin may allow tenants to configure. Mirrors the server's
+// TenantConfigurableKinds; safe kinds first, higher-risk ones flagged in help.
+const CONFIGURABLE_KINDS: ChannelKind[] = [
+  "ntfy",
+  "telegram",
+  "discord",
+  "webpush",
+  "webhook",
+  "slack",
+  "sms",
+  "email",
+];
+
+export const TenantNotificationsCard = () => {
+  const [enabled, setEnabled] = useState(false);
+  const [kinds, setKinds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [savingToggle, setSavingToggle] = useState(false);
+  const [savingKinds, setSavingKinds] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiClient.get<{
+          tenant_notifications_enabled?: boolean;
+          tenant_notification_kinds?: string[];
+        }>("/admin/settings");
+        if (!cancelled) {
+          setEnabled(resp.data.tenant_notifications_enabled === true);
+          setKinds(resp.data.tenant_notification_kinds ?? []);
+        }
+      } catch {
+        if (!cancelled) notification.error({ message: "Failed to load notification settings" });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = async (next: boolean) => {
+    setSavingToggle(true);
+    try {
+      await apiClient.patch("/admin/settings", { tenant_notifications_enabled: next });
+      setEnabled(next);
+      notification.success({ message: next ? "Tenant notifications enabled" : "Tenant notifications disabled" });
+    } catch {
+      notification.error({ message: "Failed to update setting" });
+    } finally {
+      setSavingToggle(false);
+    }
+  };
+
+  const onKindsChange = async (next: string[]) => {
+    setSavingKinds(true);
+    try {
+      const resp = await apiClient.patch<{ tenant_notification_kinds?: string[] }>("/admin/settings", {
+        tenant_notification_kinds: next,
+      });
+      // The server sanitizes (drops unknown kinds) and returns the effective set.
+      setKinds(resp.data.tenant_notification_kinds ?? next);
+      notification.success({ message: "Allowed channel kinds updated" });
+    } catch {
+      notification.error({ message: "Failed to update allowed kinds" });
+    } finally {
+      setSavingKinds(false);
+    }
+  };
+
+  return (
+    <Card title="Tenant notifications" style={{ marginBottom: 16 }} loading={loading}>
+      <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+        Let non-admin users configure their own notification channels (ntfy, Telegram,
+        Discord, web push, and more) and route their own events to them. Off by default —
+        the whole surface is inert until you turn it on. Turning it off is a live kill
+        switch: tenant channels stop receiving anything.
+      </Typography.Paragraph>
+      <Switch
+        checked={enabled}
+        loading={savingToggle}
+        onChange={onToggle}
+        checkedChildren="On"
+        unCheckedChildren="Off"
+      />
+
+      <Typography.Paragraph type="secondary" style={{ marginTop: 20, marginBottom: 8 }}>
+        <strong>Allowed channel kinds.</strong> Which kinds a tenant may create. Empty means
+        the safe default set (ntfy, Telegram, Discord, web push). Narrowing the list also
+        stops delivery to existing tenant channels of a removed kind.
+      </Typography.Paragraph>
+      <Space direction="vertical" style={{ width: "100%" }}>
+        <Select
+          mode="multiple"
+          style={{ width: "100%", maxWidth: 520 }}
+          value={kinds}
+          loading={savingKinds}
+          onChange={onKindsChange}
+          placeholder="Safe defaults (ntfy, Telegram, Discord, web push)"
+          options={CONFIGURABLE_KINDS.map((k) => ({ value: k, label: kindLabels[k] }))}
+        />
+        <Alert
+          type="warning"
+          showIcon
+          message="Higher-risk kinds"
+          description="webhook / Slack / SMS send to tenant-supplied URLs (SSRF-guarded, but still tenant-controlled). email is forced to the tenant's own account address over local delivery. Only allow these if you trust your tenants."
+        />
+      </Space>
+    </Card>
+  );
+};


### PR DESCRIPTION
## JAB-171 phase 5b — admin tenant-notifications settings + owner column

Second UI slice. The admin surface for the tenant notification feature. Independent of #680 (5a) — disjoint files; based on `main`.

### What lands
- **`TenantNotificationsCard`** (Server Settings → General):
  - **master enable switch** (`tenant_notifications_enabled`) — off by default; a note explains it's a **live kill switch** (turning it off stops tenant delivery).
  - **kind allowlist** multi-select (`tenant_notification_kinds`) — empty = safe defaults (ntfy/telegram/discord/webpush); a warning flags the higher-risk kinds (webhook/slack/sms, and email which is forced to the tenant's own address).
  - loads + saves via `PATCH /admin/settings`; the server sanitizes the list and returns the effective set.
- **`ChannelsTab` owner column** — an "Owner" tag (`Tenant` w/ user_id tooltip vs `Server-wide`) so an admin can tell tenant-owned channels from server-wide ones at a glance. (The admin surface already lets an admin disable/delete any channel — that landed in the backend.)

### Verification
- `npx tsc -b` clean · `vitest` 146 passed · production build succeeds
- ⚠️ **Visual QA pending** (Chrome extension unavailable here) — please review Server Settings → General and the admin Notifications → Channels tab in a browser.

### JAB-171 after this
Phases 1–4 (backend, merged) + 5a (#680, tenant UI) + 5b (this) cover the full feature. **Remaining: phase 6** — CLI parity for tenant channels + `openapi`/docs/ADR. Flip JAB-171 → Done only once 6 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
