### PR TITLE
docs(notifications): CLI owner flag + ADR-0159 + tenant docs (JAB-171 phase 6)

### DIFF
--- a/docs/adr/0159-per-user-notification-channels.md
+++ b/docs/adr/0159-per-user-notification-channels.md
@@ -1,0 +1,74 @@
+# ADR-0159 — Per-user notification channels + routing (JAB-171)
+
+**Status:** Accepted — JAB-171. Extends the M14 notification dispatcher (ADR-0056) so
+non-admin tenants can own their own channels and route their own events to them, behind a
+default-off, security-gated surface. Blueprint at `plans/jab171-per-user-notifications.md`.
+Shipped in six serial, individually-reviewed slices (phases 1–6).
+
+## Context
+
+The M14 dispatcher (ADR-0056) delivered notifications to **server-wide, admin-only** channels:
+`notification_channels` had no owner, and every enabled channel received every event it was
+configured for. Tenants had no way to be notified on their own channels (their phone's ntfy,
+their Telegram) for their own events (their backup finished, their cert renewed). Adding a
+tenant-facing surface is mostly **scoping + routing + a safe tenant boundary** — the senders
+already exist; the risk is entirely in exposing channel creation to untrusted users.
+
+## Decision
+
+**Ownership.** `notification_channels` gains a nullable `user_id` (NULL = server-wide/admin;
+set = tenant-owned). A new `user_notification_routes(user_id, event_kind, channel_id)` maps a
+user's events to their own channels. The dispatcher's base fan-out uses
+`FindEnabledServerWide` (`user_id IS NULL`) so a tenant channel never receives a broadcast;
+a user-scoped envelope *additively* reaches the recipient's own routed channels, each
+re-checked for ownership (`channel.UserID == recipient`) so a stray/forged route can never
+deliver another user's — or an admin — channel.
+
+**Tenant API** `/api/v1/me/notifications/*` (channels CRUD + `:id/test`, routes CRUD),
+Kratos-session only. Every read/mutate is scoped to `claims.UserID` and returns **404, never
+403**, for another user's id so channel existence never leaks. Create forces
+`user_id = claims.UserID` (never from the body).
+
+**The security crux — nothing tenant-facing ships until all of these land (phases 3–5):**
+
+1. **Secrets at rest.** Channel secrets (bearer/HMAC/SMTP password/bot token) are sealed with
+   the SSO key (`internal/notifsecret`, `enc:1:<b64url>` marker) on write, opened only just
+   before a sender runs, redacted on every GET, and edited write-only (an empty secret keeps
+   the stored one). Legacy plaintext rows keep working until a one-time backfill re-seals them.
+2. **SSRF.** A tenant channel's outbound HTTP (ntfy/discord/webhook/slack/sms) uses a guarded
+   client (`internal/ssrfguard`) that resolves, range-checks and **pins the dial to a validated
+   public IP**, refusing loopback / link-local (cloud metadata) / private space at connect time
+   (defeats DNS rebinding). Selected per channel (`UserID != nil`), so admin channels — which
+   may legitimately target an internal host — are unaffected.
+3. **Admin-controlled kind allowlist**, default-off for risky kinds. `TenantNotificationKinds`
+   on server settings; empty = the safe default set (ntfy/telegram/discord/webpush). Admins opt
+   into webhook/slack/sms/email. Enforced on create AND at delivery (removing a kind stops
+   existing tenant channels of that kind).
+4. **Abuse limits.** Per-user channel quota (10) and a per-user test-send rate limit (5/min);
+   the test endpoint is the only tenant-triggerable send.
+5. **Email is own-address only.** A tenant email channel is forced (create + every edit) to
+   `to_email = from_email = the caller's account email`, `smtp_mode = local` — no arbitrary
+   destination (open relay) and no tenant-supplied SMTP host (SSRF).
+6. **Master gate + kill switch.** `ServerSettings.TenantNotificationsEnabled` (default OFF) is
+   the master switch, exposed to admins only after 1–5 landed. The dispatcher honours it as a
+   **live delivery kill switch, fail-closed**: off (or a settings read error) → tenant channels
+   receive nothing; admin channels are unaffected.
+
+**Admin override.** The admin channel API is not ownership-scoped, so an admin lists (with an
+owner column), disables, or deletes any tenant channel.
+
+**CLI/UI.** Tenants manage their channels + routes at `/jabali-panel/notifications`; admins get
+the toggle + allowlist in Server Settings → General and an owner column on the channels tab.
+`jabali notification channels create --user <id>` provisions a tenant-owned channel from the box.
+
+## Consequences / security (the load-bearing part)
+
+- **Fail-closed everywhere it matters.** The master gate and the dispatcher policy both fail
+  closed; the SSRF guard is selected by channel ownership (not a call-site flag) so it can't be
+  forgotten; the allowlist governs delivery, not just creation.
+- **Do-not-ship discipline.** The feature merged in slices, but each abuse control had to be in
+  before the toggle became flippable — so at no point could an operator enable an unsafe surface.
+- **Defense in depth over convenience.** Tenant email is deliberately own-address-only;
+  arbitrary verified destinations are a future additive enhancement, not a launch requirement.
+- **Migrations** `000237` (owner + routes table), `000238` (master flag), `000239` (kind
+  allowlist) are schema-only and box-verified up/down.

--- a/docs/site/notifications.md
+++ b/docs/site/notifications.md
@@ -57,3 +57,37 @@ Stub sources defined but not yet wired: `domain-registrar`, `backup-future-warni
 Users can opt **in** for `cron_failed`, `backup_succeeded`, `backup_failed`, `mail_quarantined` notifications to their own email — `/jabali-panel/profile` → Notifications.
 
 Per-event subscription scope is bounded by ownership: a user cannot subscribe to `crowdsec_spike` for the whole server, only to events affecting their own account.
+
+## Per-user (tenant) channels — JAB-171
+
+Tenants can own their own channels and route their own events to them at
+**`/jabali-panel/notifications`**. This is separate from (and additive to) the
+server-wide admin channels above. See ADR-0159 for the full design + security model.
+
+**Off by default.** The whole surface is gated behind a master switch an admin flips at
+**Server Settings → General → Tenant notifications**. Until then every `/me/notifications/*`
+call returns 403 and the tenant page shows a "not enabled" state. Turning it off again is a
+**live kill switch** — tenant channels immediately stop receiving anything.
+
+**What a tenant can do (when enabled):**
+
+- Create/edit/delete their own channels (name, kind, config, enabled), and send a test.
+- Route an event kind to one of their own channels; the event then also fans out to that
+  channel when it fires *for that tenant*.
+
+**Guardrails (all enforced server-side):**
+
+| Control | Behaviour |
+|---|---|
+| **Ownership** | A tenant only ever sees/manages their own channels + routes; another user's id returns 404, never 403. |
+| **Kind allowlist** | Admin-controlled (Server Settings → General). Empty = safe default set (ntfy/telegram/discord/webpush). webhook/slack/sms/email are admin opt-in. Governs creation **and** live delivery. |
+| **SSRF** | Tenant channel URLs (ntfy/discord/webhook/slack/sms) resolve-and-pin their dial and refuse loopback / cloud-metadata / private ranges. |
+| **Secrets** | Encrypted at rest, never returned on GET, write-only on edit. |
+| **Email** | Forced to the tenant's **own account address** over local delivery — no arbitrary destination, no custom SMTP host. |
+| **Limits** | 10 channels/user; 5 test-sends/min/user. |
+
+**Admin view.** The admin channels tab (`/jabali-admin/notifications/channels`) shows an
+**Owner** column (Tenant vs Server-wide) and can disable or delete any tenant channel.
+
+**CLI.** `jabali notification channels create --user <id> …` provisions a tenant-owned channel
+from the box (omit `--user` for a server-wide channel).

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3452,6 +3452,7 @@ jabali notification channels create --name <n> --kind <email|slack|discord|ntfy|
 - `--disabled` — create in the disabled state
 - `--kind` — email|slack|discord|ntfy|webhook|webpush|sms (required)
 - `--name` — channel name (required)
+- `--user` — owner user id (tenant-owned channel; omit for server-wide)
 
 ##### `jabali notification channels delete`
 

--- a/panel-api/cmd/server/notification_send_cmd.go
+++ b/panel-api/cmd/server/notification_send_cmd.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func notificationChannelRepoFromDB() repository.NotificationChannelRepository {
 }
 
 func newNotificationChannelCreateCmd() *cobra.Command {
-	var name, kind, configJSON string
+	var name, kind, configJSON, userID string
 	var disabled bool
 	cmd := &cobra.Command{
 		Use:     "create --name <n> --kind <email|slack|discord|ntfy|webhook|webpush|sms> --config <json>",
@@ -66,15 +67,25 @@ func newNotificationChannelCreateCmd() *cobra.Command {
 				Config:  cfg,
 				Enabled: !disabled,
 			}
+			// --user makes the channel tenant-owned (JAB-171); omit for a
+			// server-wide admin channel. The users FK rejects an unknown id.
+			if uid := strings.TrimSpace(userID); uid != "" {
+				row.UserID = &uid
+			}
 			if err := notificationChannelRepoFromDB().Create(ctx, row); err != nil {
 				cliAuditErr(ctx, "notification_channel.create", "notification_channel", row.ID, nil)
 				return fmt.Errorf("create channel: %w", err)
 			}
 			cliAuditOK(ctx, "notification_channel.create", "notification_channel", row.ID, nil)
-			fmt.Printf("created %s channel %q (%s)\n", kind, name, row.ID)
+			owner := "server-wide"
+			if row.UserID != nil {
+				owner = "user " + *row.UserID
+			}
+			fmt.Printf("created %s channel %q (%s, %s)\n", kind, name, row.ID, owner)
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&userID, "user", "", "owner user id (tenant-owned channel; omit for server-wide)")
 	cmd.Flags().StringVar(&name, "name", "", "channel name (required)")
 	cmd.Flags().StringVar(&kind, "kind", "", "email|slack|discord|ntfy|webhook|webpush|sms (required)")
 	cmd.Flags().StringVar(&configJSON, "config", "", "per-kind config JSON (e.g. '{\"url\":\"https://…\"}')")


### PR DESCRIPTION
## JAB-171 phase 6 — CLI owner flag + ADR-0159 + tenant docs

**Final slice.** CLI parity + documentation. Backend (1–4) and UI (5) are merged/open; this closes the feature. Based on `main`; disjoint from the UI PRs.

### What lands
- **CLI**: `jabali notification channels create --user <id>` provisions a **tenant-owned** channel from the box (omit `--user` → server-wide). The `users` FK rejects an unknown id; secrets are sealed on write like the REST path. `cli-reference` golden regenerated (`TestCLIReferenceGolden`).
- **ADR-0159** — records the per-user channels + routing design and the **security model**: ownership (404-not-403), the do-not-ship gate, secrets-at-rest, the SSRF guard, the admin kind allowlist (create + live delivery), abuse limits, own-address email, and the master **fail-closed delivery kill switch**.
- **docs/site/notifications.md** — a "Per-user (tenant) channels" section: what a tenant can do, a guardrails table, the admin view, and the CLI.

`openapi.yaml` already documents `/me/notifications/*` (added phase 3b); phases 4–5 added no routes, so it's current — nothing to add.

### Verification
- `go build` / `go vet ./panel-api/...` clean; `cmd/server` tests + `TestCLIReferenceGolden` green

### JAB-171 is feature-complete after this
1 model+migration · 2 dispatcher · 3 tenant API + secrets · 4 abuse controls (SSRF/allowlist/quota+rate-limit/email/gate) · 5 UI · 6 CLI+docs. Flip JAB-171 → Done once the UI PRs (#680✓, #681) and this land — pending your browser QA of the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
