### PR TITLE
feat(notifications): labelled event picker for tenant routing (JAB-171 phase 5c)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -84,6 +84,26 @@ func RegisterMeNotificationsRoutes(g *gin.RouterGroup, cfg MeNotificationsConfig
 	grp.GET("/routes", h.listRoutes)
 	grp.POST("/routes", h.createRoute)
 	grp.DELETE("/routes/:id", h.deleteRoute)
+	grp.GET("/event-catalog", h.eventCatalog)
+}
+
+// tenantRelevantEventKinds is the subset of the notification event catalog that
+// fires per-user and is therefore meaningful for a tenant to route to their own
+// channels. Server-only events (crowdsec, postgres, reconciler, admin.login, …)
+// are excluded so a tenant isn't offered events that would never reach them.
+var tenantRelevantEventKinds = map[string]bool{
+	"cert.renew.fail":                       true,
+	"cert.renew.ok":                         true,
+	"domain.expiry.7d":                      true,
+	"domain.expiry.1d":                      true,
+	"disk.quota.warn":                       true,
+	"backup.fail":                           true,
+	"backup.limit.reached":                  true,
+	"docker_app.update_available":           true,
+	"ssh.login":                             true,
+	"snuffleupagus.incident.detected":       true,
+	"notifications.channel.auto_disabled":   true,
+	"panel.welcome":                         true,
 }
 
 // Per-user anti-abuse limits (JAB-171 phase 4c). Consts, not admin-configurable
@@ -424,6 +444,15 @@ func (h *meNotificationsHandler) createRoute(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
 	}
+	// Only routable (tenant-relevant) event kinds — a server-only kind would
+	// never fire for this user, so reject it rather than store a dead route.
+	if !tenantRelevantEventKinds[req.EventKind] {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error":   "unroutable_event_kind",
+			"message": "that event kind is not available for per-user routing",
+		})
+		return
+	}
 	// The target channel must exist AND be owned by the caller — this is what
 	// stops a tenant from routing their events at someone else's channel.
 	if _, ok := h.loadOwnedChannel(c, req.ChannelID, claims.UserID); !ok {
@@ -480,6 +509,41 @@ func (h *meNotificationsHandler) deleteRoute(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// eventCatalogEntry is the tenant-facing view of a routable event kind: enough
+// to render a friendly picker, without the admin's global enable state.
+type eventCatalogEntry struct {
+	EventKind   string `json:"event_kind"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+}
+
+// eventCatalog lists the event kinds a tenant may route to their own channels
+// (the per-user-relevant subset), so the UI offers labelled events instead of a
+// raw event-kind string.
+func (h *meNotificationsHandler) eventCatalog(c *gin.Context) {
+	if !h.gateOpen(c) {
+		return
+	}
+	if _, ok := requireBrowserAuth(c); !ok {
+		return
+	}
+	out := make([]eventCatalogEntry, 0, len(tenantRelevantEventKinds))
+	for i := range models.AllNotificationEventKinds {
+		m := models.AllNotificationEventKinds[i]
+		if !tenantRelevantEventKinds[m.Kind] {
+			continue
+		}
+		out = append(out, eventCatalogEntry{
+			EventKind:   m.Kind,
+			Label:       m.Label,
+			Description: m.Description,
+			Severity:    m.Severity,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": out})
 }
 
 // --- validation helpers ---

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -232,7 +232,7 @@ func TestMeNotif_RouteToUnownedChannel_Is404(t *testing.T) {
 	routes := &fakeUserRoutesRepo{}
 	r := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u1"))
 	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
-		"event_kind": "backup.completed",
+		"event_kind": "backup.fail",
 		"channel_id": theirs.ID,
 	})
 	require.Equal(t, http.StatusNotFound, rec.Code, rec.Body.String())
@@ -248,7 +248,7 @@ func TestMeNotif_RouteHappyThenDeleteOwnership(t *testing.T) {
 	r := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u1"))
 
 	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
-		"event_kind": "backup.completed",
+		"event_kind": "backup.fail",
 		"channel_id": mine.ID,
 	})
 	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
@@ -386,6 +386,36 @@ func TestMeNotif_EmailChannel_UpdateCannotRepointDestination(t *testing.T) {
 	require.Equal(t, "u1@example.com", repo.rows[existing.ID].Config.ToEmail, "edit must not repoint to_email")
 	require.Equal(t, "local", repo.rows[existing.ID].Config.SMTPMode)
 	require.Empty(t, repo.rows[existing.ID].Config.SMTPHost)
+}
+
+func TestMeNotif_EventCatalog_ReturnsTenantRelevantLabelled(t *testing.T) {
+	t.Parallel()
+	r := newMeNotifRouter(t, meNotifSettings(true), &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/event-catalog", nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	body := rec.Body.String()
+	// A tenant-relevant kind is present with its friendly label...
+	require.Contains(t, body, "backup.fail")
+	require.Contains(t, body, "label")
+	// ...and a server-only kind is not offered.
+	require.NotContains(t, body, "crowdsec.ban.spike")
+	require.NotContains(t, body, "reconciler.error")
+}
+
+func TestMeNotif_RouteRejectsServerOnlyKind(t *testing.T) {
+	t.Parallel()
+	repo := &fakeChannelsRepo{}
+	mine := ownedChannel("u1", "ntfy", models.NotificationChannelConfig{URL: "https://ntfy.sh/a"})
+	_ = repo.Create(context.Background(), mine)
+	routes := &fakeUserRoutesRepo{}
+	r := newMeNotifRouter(t, meNotifSettings(true), repo, routes, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodPost, "/api/v1/me/notifications/routes", map[string]any{
+		"event_kind": "crowdsec.ban.spike", // server-only — never fires per-user
+		"channel_id": mine.ID,
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "unroutable_event_kind")
+	require.Empty(t, routes.rows)
 }
 
 func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3800,6 +3800,15 @@ paths:
         "403": { description: Tenant notifications disabled }
         "404": { description: No such route (or owned by another user) }
 
+  /me/notifications/event-catalog:
+    get:
+      tags: [Notifications]
+      summary: List the event kinds a tenant may route (labelled)
+      security: [ { KratosSession: [] } ]
+      responses:
+        "200": { description: OK }
+        "403": { description: Tenant notifications disabled }
+
   /admin/notifications/dlq:
     delete:
       tags: [Notifications]

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -4,11 +4,10 @@
 // admin switch; when it's off every call returns 403 and we render a calm
 // "not enabled" state rather than an error.
 //
-// Wire paths:
-//   GET/POST/PATCH/DELETE  /me/notifications/channels[/:id]
-//   POST                   /me/notifications/channels/:id/test
-//   GET/POST/DELETE        /me/notifications/routes[/:id]
-import { useState } from "react";
+// Routing is a matrix: the server hands back a labelled catalog of the events
+// that fire for this user (GET .../event-catalog), and for each the tenant picks
+// which of their channels should receive it — no raw event-kind typing.
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -16,8 +15,6 @@ import {
   Button,
   Card,
   Empty,
-  Form,
-  Input,
   Popconfirm,
   Select,
   Space,
@@ -37,12 +34,27 @@ import { MyChannelDrawer, type MyChannel } from "./MyChannelDrawer";
 
 const CH_RESOURCE = "me/notifications/channels";
 const RT_RESOURCE = "me/notifications/routes";
+const CATALOG_RESOURCE = "me/notifications/event-catalog";
 
 type Route = {
   id: string;
   user_id: string;
   event_kind: string;
   channel_id: string;
+};
+
+type CatalogEntry = {
+  event_kind: string;
+  label: string;
+  description: string;
+  severity: "info" | "warning" | "error" | "critical";
+};
+
+const severityColor: Record<CatalogEntry["severity"], string> = {
+  info: "blue",
+  warning: "gold",
+  error: "red",
+  critical: "magenta",
 };
 
 function statusOf(err: unknown): number | undefined {
@@ -64,6 +76,8 @@ export function MyNotificationsPage(): JSX.Element {
     retry: false,
   });
 
+  const disabled = statusOf(channelsQ.error) === 403;
+
   const routesQ = useQuery<Route[]>({
     queryKey: ["list", RT_RESOURCE],
     queryFn: async () => {
@@ -71,17 +85,35 @@ export function MyNotificationsPage(): JSX.Element {
       return data.items ?? [];
     },
     retry: false,
-    // The channels query already surfaces the disabled state; keep this quiet.
-    enabled: statusOf(channelsQ.error) !== 403,
+    enabled: !disabled,
   });
 
-  const disabled = statusOf(channelsQ.error) === 403;
+  const catalogQ = useQuery<CatalogEntry[]>({
+    queryKey: ["list", CATALOG_RESOURCE],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ items: CatalogEntry[] }>(`/${CATALOG_RESOURCE}`);
+      return data.items ?? [];
+    },
+    retry: false,
+    enabled: !disabled,
+  });
 
   const updateMutation = useUpdateMutation<MyChannel, { enabled: boolean }>({ resource: CH_RESOURCE });
   const deleteMutation = useDeleteMutation({ resource: CH_RESOURCE });
 
   const channels = channelsQ.data ?? [];
-  const channelName = (id: string) => channels.find((c) => c.id === id)?.name ?? id;
+
+  // event_kind -> [{channelId, routeId}] so the matrix can show current
+  // selections and delete the right route row when a channel is unpicked.
+  const routesByEvent = useMemo(() => {
+    const m = new Map<string, { channelId: string; routeId: string }[]>();
+    for (const r of routesQ.data ?? []) {
+      const arr = m.get(r.event_kind) ?? [];
+      arr.push({ channelId: r.channel_id, routeId: r.id });
+      m.set(r.event_kind, arr);
+    }
+    return m;
+  }, [routesQ.data]);
 
   const toggleEnabled = async (row: MyChannel, next: boolean) => {
     try {
@@ -110,6 +142,27 @@ export function MyNotificationsPage(): JSX.Element {
     }
   };
 
+  // Reconcile a row's channel multi-select against the stored routes: POST the
+  // added channels, DELETE the removed ones, then refetch.
+  const applyRoute = async (eventKind: string, nextIds: string[]) => {
+    const current = routesByEvent.get(eventKind) ?? [];
+    const currentIds = current.map((r) => r.channelId);
+    const toAdd = nextIds.filter((id) => !currentIds.includes(id));
+    const toRemove = current.filter((r) => !nextIds.includes(r.channelId));
+    try {
+      for (const id of toAdd) {
+        await apiClient.post(`/${RT_RESOURCE}`, { event_kind: eventKind, channel_id: id });
+      }
+      for (const r of toRemove) {
+        await apiClient.delete(`/${RT_RESOURCE}/${r.routeId}`);
+      }
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Routing update failed");
+    } finally {
+      routesQ.refetch();
+    }
+  };
+
   if (disabled) {
     return (
       <Card>
@@ -122,6 +175,8 @@ export function MyNotificationsPage(): JSX.Element {
       </Card>
     );
   }
+
+  const channelOptions = channels.map((c) => ({ value: c.id, label: c.name }));
 
   return (
     <Space direction="vertical" size="large" style={{ width: "100%" }}>
@@ -205,37 +260,53 @@ export function MyNotificationsPage(): JSX.Element {
 
       <Card title="Event routing">
         <Typography.Paragraph type="secondary">
-          Route a server event to one of your channels. When that event fires for you, the channel is notified.
+          Pick which of your channels should be notified for each event. Events fire for your own
+          account (your certs, backups, quota, and so on).
         </Typography.Paragraph>
-        <RouteAdder channels={channels} onAdded={() => routesQ.refetch()} />
-        <Table<Route>
-          rowKey="id"
-          style={{ marginTop: 16 }}
-          loading={routesQ.isLoading}
-          dataSource={routesQ.data ?? []}
+        <Table<CatalogEntry>
+          rowKey="event_kind"
+          loading={catalogQ.isLoading}
+          dataSource={catalogQ.data ?? []}
           pagination={false}
-          locale={{ emptyText: <Empty description="No routes yet." /> }}
+          locale={{ emptyText: <Empty description="No routable events." /> }}
           scroll={{ x: "max-content" }}
         >
-          <Table.Column dataIndex="event_kind" title="Event" render={(e: string) => <Tag>{e}</Tag>} />
-          <Table.Column dataIndex="channel_id" title="Channel" render={(id: string) => channelName(id)} />
-          <Table.Column
-            title="Actions"
-            key="actions"
-            render={(_: unknown, row: Route) => (
-              <Popconfirm
-                title="Remove this route?"
-                onConfirm={async () => {
-                  try {
-                    await apiClient.delete(`/${RT_RESOURCE}/${row.id}`);
-                    routesQ.refetch();
-                  } catch (err) {
-                    message.error(err instanceof Error ? err.message : "Remove failed");
-                  }
-                }}
-              >
-                <Button size="small" danger icon={<DeleteOutlined />} />
-              </Popconfirm>
+          <Table.Column<CatalogEntry>
+            title="Event"
+            dataIndex="label"
+            render={(label: string, row) => (
+              <div>
+                <Typography.Text strong>{label}</Typography.Text>
+                <div>
+                  <Tag color={severityColor[row.severity]} style={{ marginTop: 4 }}>
+                    {row.severity}
+                  </Tag>
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    <code>{row.event_kind}</code>
+                  </Typography.Text>
+                </div>
+                <Typography.Paragraph type="secondary" style={{ fontSize: 12, marginBottom: 0 }}>
+                  {row.description}
+                </Typography.Paragraph>
+              </div>
+            )}
+          />
+          <Table.Column<CatalogEntry>
+            title="Deliver to"
+            key="deliver"
+            width={340}
+            render={(_: unknown, row) => (
+              <Select
+                mode="multiple"
+                allowClear
+                style={{ minWidth: 260, width: "100%" }}
+                placeholder={channels.length ? "No channels — event ignored" : "Add a channel first"}
+                disabled={channels.length === 0}
+                value={(routesByEvent.get(row.event_kind) ?? []).map((r) => r.channelId)}
+                onChange={(ids: string[]) => applyRoute(row.event_kind, ids)}
+                options={channelOptions}
+                loading={routesQ.isFetching}
+              />
             )}
           />
         </Table>
@@ -245,50 +316,5 @@ export function MyNotificationsPage(): JSX.Element {
       {/* t() kept referenced for future i18n of this page */}
       <span style={{ display: "none" }}>{t("nav.user.notifications", "Notifications")}</span>
     </Space>
-  );
-}
-
-function RouteAdder({ channels, onAdded }: { channels: MyChannel[]; onAdded: () => void }): JSX.Element {
-  const [form] = Form.useForm<{ event_kind: string; channel_id: string }>();
-  const [saving, setSaving] = useState(false);
-
-  const submit = async (v: { event_kind: string; channel_id: string }) => {
-    setSaving(true);
-    try {
-      await apiClient.post(`/${RT_RESOURCE}`, {
-        event_kind: v.event_kind.trim(),
-        channel_id: v.channel_id,
-      });
-      message.success("Route added");
-      form.resetFields();
-      onAdded();
-    } catch (err) {
-      message.error(err instanceof Error ? err.message : "Add route failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <Form form={form} layout="inline" onFinish={submit}>
-      <Form.Item
-        name="event_kind"
-        rules={[{ required: true, message: "Event kind required" }]}
-        style={{ minWidth: 220 }}
-      >
-        <Input placeholder="event kind, e.g. backup.completed" />
-      </Form.Item>
-      <Form.Item name="channel_id" rules={[{ required: true, message: "Pick a channel" }]} style={{ minWidth: 200 }}>
-        <Select
-          placeholder="Channel"
-          options={channels.map((c) => ({ value: c.id, label: c.name }))}
-        />
-      </Form.Item>
-      <Form.Item>
-        <Button type="primary" htmlType="submit" loading={saving} icon={<PlusOutlined />}>
-          Add route
-        </Button>
-      </Form.Item>
-    </Form>
   );
 }


### PR DESCRIPTION
## JAB-171 phase 5c — labelled event picker for tenant routing

Fixes the routing UX flagged on the deployed page: the tenant routing section shipped a **raw "event kind" text box**, so a tenant had no way to know what events exist. Now it's a labelled catalog + per-event channel picker, matching the admin **Events** page.

### What changed
- **API** `GET /me/notifications/event-catalog` — returns the **tenant-relevant** subset of the event catalog (`kind` + `label` + `description` + `severity`): events that fire *per-user* (their certs/backups/quota/docker-app updates/ssh-login/…), **not** server-only ones (crowdsec, postgres, reconciler, admin.login, disk-full, …). Gated by the master switch, browser-session only.
- **Route creation tightened** to that subset — routing a server-only kind (which would never fire for the user) is rejected `422 unroutable_event_kind` instead of storing a dead route.
- **UI** — the routing section is now a **matrix**: each routable event shown with its label, code, severity tag and description, plus a "Deliver to" multi-select of the tenant's own channels. Picking/unpicking reconciles the underlying routes (POST added, DELETE removed). No more free-text typing.

### Verification
- `go build`/`vet` clean; `me_notifications` + OpenAPI-coverage tests green (added catalog + unroutable-kind tests)
- `tsc -b` clean · `vitest` 146 passed · production build succeeds
- ⚠️ Visual QA pending (extension down) — please re-check `/jabali-panel/notifications` after this deploys.

### Note on the curated list
The tenant-relevant set is a conservative pick of per-user event kinds. If any event is miscategorised (shown that shouldn't be, or missing one that fires per-user), it's a one-line change to `tenantRelevantEventKinds` — tell me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
