### PR TITLE
feat(demo): build-tag-gated demo mode foundation on main (JAB-159 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: scripts/check-pinned-downloads.sh install.sh
 
+  demo-guard:
+    name: demo anti-leak guard
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+      # JAB-159: the security guarantee for merging demo code to main is that a
+      # production (untagged) build physically excludes it. Assert the prod
+      # binary carries no demo_mode marker while the -tags demo build does, and
+      # run the demo write-block test under the demo tag.
+      - name: prod build excludes demo, demo build includes it
+        run: make demo-guard
+
   ui-unit:
     name: panel-ui unit tests (vitest)
     runs-on: self-hosted

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help build run test test-short test-coverage coverage-check lint fmt vet tidy clean \
-	test-ui test-e2e test-all ui-install ui-build
+	test-ui test-e2e test-all ui-install ui-build demo-guard
 
 GO         := go
 API_PKG    := ./panel-api/...
@@ -19,6 +19,15 @@ build: ## Compile both binaries (panel + agent)
 	$(GO) build -o $(BIN) ./panel-api/cmd/server
 	$(GO) build -o $(AGENT_BIN) ./panel-agent/cmd/jabali-agent
 	$(GO) build -o bin/jabali-installer ./installer/cmd/jabali-installer
+
+demo-guard: ## JAB-159: prod build must EXCLUDE demo code; demo build must INCLUDE it
+	mkdir -p bin
+	$(GO) build -tags demo -o bin/jabali-demo ./panel-api/cmd/server
+	$(GO) build -o bin/jabali-prod ./panel-api/cmd/server
+	@grep -aq 'demo_mode' bin/jabali-demo || { echo 'FAIL: demo build missing demo_mode marker'; exit 1; }
+	@if grep -aq 'demo_mode' bin/jabali-prod; then echo 'FAIL: prod build leaked demo_mode symbol'; exit 1; fi
+	@echo 'demo-guard OK: prod excludes demo_mode, demo build includes it'
+	$(GO) test -tags demo -count=1 ./panel-api/internal/middleware/
 
 run: ## Run the panel server (dev)
 	$(GO) run ./panel-api/cmd/server

--- a/panel-api/internal/api/index.go
+++ b/panel-api/internal/api/index.go
@@ -15,7 +15,7 @@ func RegisterServiceInfoRoute(r *gin.Engine) {
 }
 
 func infoHandler(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"service": "jabali-panel",
 		"version": Version,
 		"status":  "ok",
@@ -25,7 +25,11 @@ func infoHandler(c *gin.Context) {
 			"ui":     "/ (SPA)",
 		},
 		"docs": "https://github.com/shukiv/jabali-panel",
-	})
+	}
+	// injectDemo is a no-op in production builds and adds the seeded-credential
+	// "demo" block only in a `-tags demo` build (JAB-159). See index_demo_*.go.
+	injectDemo(resp)
+	c.JSON(http.StatusOK, resp)
 }
 
 // RegisterMethodNotAllowedHandler installs a JSON response for NoMethod.

--- a/panel-api/internal/api/index_demo_off.go
+++ b/panel-api/internal/api/index_demo_off.go
@@ -1,0 +1,11 @@
+//go:build !demo
+
+package api
+
+import "github.com/gin-gonic/gin"
+
+// injectDemo is a no-op in production builds: the demo credential block does not
+// exist in the binary. The demo variant (index_demo_on.go, //go:build demo)
+// carries the DemoInfo type + the /info exposer. This is the security boundary
+// for JAB-159 — a prod binary can never surface seeded demo credentials.
+func injectDemo(_ gin.H) {}

--- a/panel-api/internal/api/index_demo_off_test.go
+++ b/panel-api/internal/api/index_demo_off_test.go
@@ -1,0 +1,32 @@
+//go:build !demo
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// In a production build (no `demo` tag) the /info endpoint must NEVER carry a
+// "demo" block — the credential-exposing route + injectDemo variant are compiled
+// out. This is the JAB-159 security boundary, asserted at the HTTP layer.
+func TestInfo_ProdBuild_NoDemoBlock(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterServiceInfoRoute(r)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/info", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	_, hasDemo := body["demo"]
+	require.False(t, hasDemo, "prod /info must not expose a demo block")
+	require.NotContains(t, rec.Body.String(), "admin_password")
+}

--- a/panel-api/internal/api/index_demo_on.go
+++ b/panel-api/internal/api/index_demo_on.go
@@ -1,0 +1,34 @@
+//go:build demo
+
+package api
+
+import "github.com/gin-gonic/gin"
+
+// DemoInfo is the public projection of config.DemoConfig surfaced via /info so
+// the SPA can render the DEMO banner + "Enter as admin/user" buttons. Passwords
+// are deliberately included — a demo instance is a public service and visitors
+// need the seeded credentials. This type exists ONLY in a `-tags demo` build.
+type DemoInfo struct {
+	Enabled       bool   `json:"enabled"`
+	AdminEmail    string `json:"admin_email,omitempty"`
+	AdminPassword string `json:"admin_password,omitempty"`
+	UserEmail     string `json:"user_email,omitempty"`
+	UserPassword  string `json:"user_password,omitempty"`
+	Banner        string `json:"banner,omitempty"`
+}
+
+// demoInfo is set by RegisterServiceInfoRouteWithDemo when demo mode is enabled.
+var demoInfo DemoInfo
+
+// RegisterServiceInfoRouteWithDemo is the demo-mode variant of the /info route:
+// the payload additionally carries the DemoInfo block. Exists only in a demo build.
+func RegisterServiceInfoRouteWithDemo(r *gin.Engine, di DemoInfo) {
+	demoInfo = di
+	r.GET("/info", infoHandler)
+}
+
+func injectDemo(resp gin.H) {
+	if demoInfo.Enabled {
+		resp["demo"] = demoInfo
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -304,7 +304,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 	r.Use(middleware.NoCacheAPI())
 	r.Use(middleware.RequireContentType())
 
-	api.RegisterServiceInfoRoute(r)
+	// /info registration + the demo write-gate live behind a build tag (JAB-159):
+	// in a production build this just registers the base /info; in a `-tags demo`
+	// build it mounts the write-block middleware and the credential-carrying /info
+	// when cfg.Demo.Enabled. See app/demo_off.go and app/demo_on.go.
+	setupDemoAndInfo(r, cfg)
 	api.RegisterHealthRoutes(r)
 	if deps.Agent != nil {
 		api.RegisterAgentHealthRoute(r, deps.Agent)

--- a/panel-api/internal/app/demo_off.go
+++ b/panel-api/internal/app/demo_off.go
@@ -1,0 +1,17 @@
+//go:build !demo
+
+package app
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/config"
+)
+
+// setupDemoAndInfo (production build) registers only the base /info route. The
+// demo write-gate + credential-exposing /info do not exist in this binary — the
+// demo variant lives in demo_on.go (//go:build demo). JAB-159 security boundary.
+func setupDemoAndInfo(r *gin.Engine, _ *config.Config) {
+	api.RegisterServiceInfoRoute(r)
+}

--- a/panel-api/internal/app/demo_on.go
+++ b/panel-api/internal/app/demo_on.go
@@ -1,0 +1,31 @@
+//go:build demo
+
+package app
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/config"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+)
+
+// setupDemoAndInfo (demo build, `-tags demo`). When cfg.Demo.Enabled, mount the
+// write-block middleware and register the credential-carrying /info so the SPA
+// can render demo affordances. Still runtime-gated: a demo binary with
+// Demo.Enabled=false behaves like production.
+func setupDemoAndInfo(r *gin.Engine, cfg *config.Config) {
+	if cfg.Demo.Enabled {
+		r.Use(middleware.DemoMode(nil, cfg.Demo.Banner))
+		api.RegisterServiceInfoRouteWithDemo(r, api.DemoInfo{
+			Enabled:       true,
+			AdminEmail:    cfg.Demo.AdminEmail,
+			AdminPassword: cfg.Demo.AdminPassword,
+			UserEmail:     cfg.Demo.UserEmail,
+			UserPassword:  cfg.Demo.UserPassword,
+			Banner:        cfg.Demo.Banner,
+		})
+		return
+	}
+	api.RegisterServiceInfoRoute(r)
+}

--- a/panel-api/internal/config/config.go
+++ b/panel-api/internal/config/config.go
@@ -43,6 +43,28 @@ type Config struct {
 	SSO       SSOConfig       `toml:"sso"`
 	WordPress WordPressConfig `toml:"wordpress"`
 	Redis     RedisConfig     `toml:"redis"`
+	Demo      DemoConfig      `toml:"demo"`
+}
+
+// DemoConfig enables read-only public-demo mode (JAB-159). When Enabled, the
+// demo build's middleware short-circuits every non-idempotent /api/v1/* request
+// with 403 {"error":"demo_mode"} and the /info payload carries the seeded demo
+// identities so the SPA can render a DEMO banner + "Enter as admin/user" login
+// buttons. The credential-exposing surface only exists in a `-tags demo` build,
+// so a production binary carries none of it regardless of this config.
+//
+// Operator responsibility on a demo host: create the demo identities (admin +
+// regular user in Kratos) and point a read-only DB user at panel-api as
+// defense-in-depth beyond the write-block.
+type DemoConfig struct {
+	Enabled       bool   `toml:"enabled"`
+	AdminEmail    string `toml:"admin_email"`
+	AdminPassword string `toml:"admin_password"`
+	UserEmail     string `toml:"user_email"`
+	UserPassword  string `toml:"user_password"`
+	// Banner is the operator-overridable copy shown in the SPA banner.
+	// Empty falls back to the SPA default.
+	Banner string `toml:"banner"`
 }
 
 // ServerConfig controls HTTP listener and runtime mode.

--- a/panel-api/internal/middleware/demo.go
+++ b/panel-api/internal/middleware/demo.go
@@ -1,0 +1,64 @@
+//go:build demo
+
+// Package middleware — DemoMode.
+//
+// DemoMode short-circuits every non-idempotent HTTP method
+// (POST/PUT/PATCH/DELETE) under /api/v1/* with HTTP 403 +
+// {"error":"demo_mode","detail":"<banner copy>"} so a public demo
+// instance lets visitors browse every read endpoint without ever
+// reaching the agent or the database write path.
+//
+// The middleware is intentionally narrow:
+//
+//   - GET / HEAD / OPTIONS always pass through (reads + CORS preflight)
+//   - Any path NOT under /api/v1/ passes through (Kratos browser-flow
+//     login lives under /.ory/*, /sso/* is the SSO bridge, /info /
+//     /health are read-only metadata)
+//   - Caller-supplied allowedPrefixes always pass through (defensive
+//     hook for future panel-side login endpoints, currently unused —
+//     the Kratos browser flow lives outside /api/v1/)
+//
+// Mounted only when cfg.Demo.Enabled = true. Off by default; production
+// installs leave it off and panel-api behaves exactly as before.
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DemoMode returns the gin middleware. allowedPrefixes is the list of
+// path prefixes that bypass the write-block (always empty in current
+// deployments; reserved for future panel-side auth endpoints). banner
+// is the operator-visible explanation surfaced in the JSON error
+// payload — empty falls back to a sane default so the SPA can render a
+// useful toast even if config.toml omits the field.
+func DemoMode(allowedPrefixes []string, banner string) gin.HandlerFunc {
+	if banner == "" {
+		banner = "Demo mode — changes are disabled"
+	}
+	return func(c *gin.Context) {
+		switch c.Request.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			c.Next()
+			return
+		}
+		path := c.Request.URL.Path
+		if !strings.HasPrefix(path, "/api/v1/") {
+			c.Next()
+			return
+		}
+		for _, prefix := range allowedPrefixes {
+			if prefix != "" && strings.HasPrefix(path, prefix) {
+				c.Next()
+				return
+			}
+		}
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error":  "demo_mode",
+			"detail": banner,
+		})
+	}
+}

--- a/panel-api/internal/middleware/demo_test.go
+++ b/panel-api/internal/middleware/demo_test.go
@@ -1,0 +1,85 @@
+//go:build demo
+
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func newDemoRouter(t *testing.T, allowed []string, banner string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(DemoMode(allowed, banner))
+	for _, m := range []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"} {
+		r.Handle(m, "/api/v1/domains", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	}
+	r.Handle("POST", "/api/v1/auth/login", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	r.GET("/info", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	r.POST("/sso/webmail", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func do(r *gin.Engine, method, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(""))
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestDemoMode_AllowsReadsAndPreflights(t *testing.T) {
+	r := newDemoRouter(t, nil, "")
+	for _, m := range []string{"GET", "HEAD", "OPTIONS"} {
+		w := do(r, m, "/api/v1/domains")
+		if w.Code != http.StatusOK {
+			t.Errorf("%s should pass, got %d", m, w.Code)
+		}
+	}
+}
+
+func TestDemoMode_BlocksWrites(t *testing.T) {
+	r := newDemoRouter(t, nil, "")
+	for _, m := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		w := do(r, m, "/api/v1/domains")
+		if w.Code != http.StatusForbidden {
+			t.Errorf("%s should 403, got %d", m, w.Code)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Errorf("%s: body not JSON: %v", m, err)
+		}
+		if body["error"] != "demo_mode" {
+			t.Errorf("%s: expected error=demo_mode, got %v", m, body["error"])
+		}
+	}
+}
+
+func TestDemoMode_BannerInPayload(t *testing.T) {
+	r := newDemoRouter(t, nil, "Custom banner copy 123")
+	w := do(r, "POST", "/api/v1/domains")
+	if !strings.Contains(w.Body.String(), "Custom banner copy 123") {
+		t.Errorf("banner not in payload: %s", w.Body.String())
+	}
+}
+
+func TestDemoMode_AllowedPrefixesPassThrough(t *testing.T) {
+	r := newDemoRouter(t, []string{"/api/v1/auth"}, "")
+	w := do(r, "POST", "/api/v1/auth/login")
+	if w.Code != http.StatusOK {
+		t.Errorf("POST allowed-prefix should pass, got %d", w.Code)
+	}
+}
+
+func TestDemoMode_NonAPIWritesPassThrough(t *testing.T) {
+	r := newDemoRouter(t, nil, "")
+	w := do(r, "POST", "/sso/webmail")
+	if w.Code != http.StatusOK {
+		t.Errorf("non-/api/v1 POST should pass, got %d", w.Code)
+	}
+}

--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -39,6 +39,7 @@ import { useApplyBrandingToTitle, useBranding } from "./hooks/useBranding";
 import { PANEL_COLORS } from "./lib/panelColors";
 import { CapabilityRoute } from "./components/CapabilityRoute";
 import { LoginPage } from "./pages/Login";
+import { DemoBanner } from "./components/DemoBanner";
 
 // JAB-145: route-level code splitting — each page is its own lazy chunk
 // so the initial bundle no longer eagerly pulls all ~55 pages. Layouts,
@@ -188,6 +189,9 @@ const ThemedApp = () => {
         renderEmpty={() => <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />}
       >
         <AntdApp>
+        {/* JAB-159: renders nothing unless /info reports demo mode (prod /info
+            never does, since the cred-exposing route is compiled out). */}
+        <DemoBanner />
         <BrandingTitleApplier />
         <Suspense
           fallback={

--- a/panel-ui/src/components/DemoBanner.tsx
+++ b/panel-ui/src/components/DemoBanner.tsx
@@ -1,0 +1,79 @@
+// DemoBanner — fixed strip above every route when /info reports
+// demo.enabled. Stays out of the DOM completely in production (the
+// useServiceInfo hook returns `undefined` for `demo` when the backend
+// omits the key, so the banner short-circuits before AntD renders).
+//
+// Render strategy: AntD Alert with a `closable={false}` ribbon at the
+// top of the viewport. The CSS var `--jabali-demo-banner-h` is set on
+// the document element so shell layouts can pad themselves down by
+// reading it (e.g. `padding-top: var(--jabali-demo-banner-h, 0px)`).
+
+import { Alert } from "antd";
+import { useEffect } from "react";
+
+import { useServiceInfo } from "../useServiceInfo";
+
+const BANNER_HEIGHT_PX = 72;
+
+export function DemoBanner() {
+  const { data } = useServiceInfo();
+  const demo = data?.demo;
+  const enabled = !!demo?.enabled;
+
+  useEffect(() => {
+    const h = enabled ? `${BANNER_HEIGHT_PX}px` : "0px";
+    document.documentElement.style.setProperty("--jabali-demo-banner-h", h);
+    // AntD shells use position:fixed headers + 100vh siders. Injecting
+    // a stylesheet that offsets every header/sider by the banner height
+    // is the lightest fix — no shell components need to be aware of
+    // demo mode. Cleanup on toggle removes the rule.
+    const STYLE_ID = "jabali-demo-banner-shift";
+    if (enabled) {
+      let el = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+      if (!el) {
+        el = document.createElement("style");
+        el.id = STYLE_ID;
+        document.head.appendChild(el);
+      }
+      // Shift the entire viewport down by BANNER_HEIGHT so the AntD
+      // shell (which uses 100vh + position:sticky/fixed) lays out
+      // BELOW the banner. html padding works where body padding
+      // doesn't because AntD's Layout reads viewport height directly.
+      el.textContent = `
+        html { padding-top: ${BANNER_HEIGHT_PX}px; box-sizing: border-box; }
+        body, #root { min-height: calc(100vh - ${BANNER_HEIGHT_PX}px); }
+        .ant-layout { min-height: calc(100vh - ${BANNER_HEIGHT_PX}px) !important; }
+      `;
+    } else {
+      document.getElementById(STYLE_ID)?.remove();
+    }
+    return () => {
+      document.getElementById(STYLE_ID)?.remove();
+    };
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  const message =
+    demo?.banner ||
+    "Demo mode — every change is disabled. Browse freely; nothing you do here persists.";
+
+  return (
+    <Alert
+      type="warning"
+      banner
+      showIcon
+      message={message}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 2000,
+        height: BANNER_HEIGHT_PX,
+        display: "flex",
+        alignItems: "center",
+      }}
+    />
+  );
+}

--- a/panel-ui/src/useServiceInfo.ts
+++ b/panel-ui/src/useServiceInfo.ts
@@ -1,0 +1,53 @@
+// useServiceInfo — TanStack Query hook for GET /info.
+//
+// Backend exposes demo-mode metadata under the `demo` key when
+// cfg.Demo.Enabled is true; the SPA reads it once at boot to render
+// (a) the "Enter as admin / user" buttons on the Login page and
+// (b) the persistent DEMO banner above every shell.
+//
+// In production /info still returns version + endpoints + docs (no
+// `demo` key), so `info.demo?.enabled` is the canonical "are we in
+// demo mode" predicate.
+
+import { useQuery } from "@tanstack/react-query";
+
+export type ServiceInfoDemo = {
+  enabled: boolean;
+  admin_email?: string;
+  admin_password?: string;
+  user_email?: string;
+  user_password?: string;
+  banner?: string;
+};
+
+export type ServiceInfo = {
+  service: string;
+  version: string;
+  status: string;
+  endpoints?: Record<string, string>;
+  docs?: string;
+  demo?: ServiceInfoDemo;
+};
+
+async function fetchServiceInfo(): Promise<ServiceInfo> {
+  const r = await fetch("/info", {
+    headers: { Accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (!r.ok) {
+    throw new Error(`/info HTTP ${r.status}`);
+  }
+  return (await r.json()) as ServiceInfo;
+}
+
+export function useServiceInfo() {
+  return useQuery({
+    queryKey: ["service-info"],
+    queryFn: fetchServiceInfo,
+    // /info changes only on panel restart — long stale time is fine
+    // and avoids one extra request per route change.
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 1,
+  });
+}


### PR DESCRIPTION
## JAB-159 phase 1 — build-tag-gated demo mode foundation on main

Brings demo mode onto `main` behind a `demo` build tag, so the demo host can track `main` via `jabali update` (an **updatable demo**) instead of the long-lived `feat/demo-mode` rebase branch — **without** shipping the credential-exposing code into production binaries.

Approach chosen over merging the runtime-flag branch as-is: the never-merge policy (README/#318) exists because `/info` exposes seeded demo creds; build tags compile that OUT of prod, resolving the exact concern.

### Security boundary (Go — the whole point)
The write-block middleware + the `/info` variant that exposes seeded creds live ONLY in `//go:build demo` files. A production build compiles **none** of it:
- `middleware/demo.go` (+test) — `//go:build demo`
- `api/index_demo_on.go` — `DemoInfo` + `RegisterServiceInfoRouteWithDemo` + `injectDemo`
- `api/index_demo_off.go` (`//go:build !demo`) — `injectDemo` is a no-op
- `app/demo_on.go` / `demo_off.go` — demo write-gate wiring vs plain `/info`
- `app.go` + `index.go` call the tagged seams

**Verified:** `demo_mode` string + `RegisterServiceInfoRouteWithDemo` symbol are **absent** from a default `go build` binary, **present** under `-tags demo`. `config.DemoConfig` stays on main (data only; the exposer that surfaces it is tagged out).

### SPA
`DemoBanner` + `useServiceInfo` added; the banner is runtime-gated on `/info.demo.enabled`, which a prod `/info` never reports (exposer tagged out) → inert on prod, no separate SPA build needed.

### Verification
- `go build` AND `go build -tags demo` both compile + vet
- prod-boundary test (`/info` has no demo block, untagged) + demo middleware test (`//go:build demo`)
- `-race` green (api/app/config); tsc + vitest (146) + SPA build green
- CI builds prod (untagged) — clean

### Deferred (see `plans/jab159-demo-build-tag.md`)
- **phase 2**: Login "Enter as admin/user" quick-enter buttons (touches the login flow — own QA) + the **demo deploy profile** so `jabali update` builds `-tags demo` on the demo host (+ fold the tag into the rebuild-hash inputs) + a CI `go build -tags demo` guard against bitrot.
- **phase 3**: retire `feat/demo-mode`, rewrite README §Demo, flip JAB-159 Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
