### PR TITLE
feat(demo): nginx-overlay public-demo recipe, panel-api stays stock (JAB-159)

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,73 @@
+# Jabali public demo — nginx-overlay recipe (JAB-159)
+
+A public demo where **panel-api runs 100% stock `main`** (so `jabali update` keeps
+it current) and ALL demo behaviour lives in one reviewable nginx vhost. No demo
+code in the program.
+
+> **Read this first.** A public demo hands anonymous visitors an admin session on
+> a real panel. The nginx write-block is roughly **30%** of the safety. The rest is
+> the host being **disposable** with the hardening below. Do **not** point this at a
+> panel that holds anything real.
+
+## Files
+- `jabali-demo-vhost.conf.tmpl` — drop-in REPLACEMENT for the panel vhost on the
+  demo host. Substitutes `${SSL_CERT_PATH}` `${SSL_KEY_PATH}` `${PANEL_DIST_DIR}`
+  `${NGX_H2_PARAM}` `${NGX_H2_DIR}` `${DEMO_BANNER_HTML}`.
+
+## What the vhost enforces
+1. `/api/v1/` — writes (POST/PUT/PATCH/DELETE) → 403. Covers every mutation,
+   including the POST SSO-mint routes (`/api/v1/sso/{phpmyadmin,adminer,webmail}`).
+2. `/phpmyadmin/` + `/jabali-adminer/` → 403 (DB consoles off; not `include`d).
+3. Kratos `/self-service/{settings,recovery}` submit (non-GET) → 403 (no account
+   takeover); login stays open.
+4. DEMO banner injected into the SPA HTML via `sub_filter`.
+5. Anon per-IP rate-limit.
+
+## Host hardening — the other 70% (do ALL of these)
+- [ ] **Disposable box.** Dedicated VM, no real tenants, no real data, NO secrets
+      shared with production. Treat it as hostile-facing; rebuild freely. This is
+      the primary control.
+- [ ] **Read-only MySQL user for panel-api.** THE key backstop: point
+      `DATABASE_URL` at a user with `SELECT`-only grants on `jabali_panel`. Any
+      write that slips the nginx block (a side-effect GET, a path we missed) hits
+      `Access denied` instead of succeeding. Grant example:
+      `GRANT SELECT ON jabali_panel.* TO 'jabali_demo_ro'@'localhost';`
+      (Seed the DB first with a normal user, then switch panel-api to the RO user.)
+- [ ] **Neuter the agent.** The demo box's jabali-agent must do no real OS/service
+      work — stop/mask it or firewall its socket, so a slipped mutation can't pivot
+      to the host. Reads that need the agent will error; that's fine for a demo.
+- [ ] **Seed two Kratos identities** — a demo admin + a demo user with throwaway
+      passwords. Put those creds in `${DEMO_BANNER_HTML}` so visitors can log in.
+- [ ] **Network isolation** — the demo host must reach nothing internal.
+
+## Apply (on the demo host)
+1. Install the panel normally (stock `main`). Confirm `/run/jabali-panel/api.sock`.
+2. Render the template (substitute the vars) to
+   `/etc/nginx/sites-available/jabali-panel-vhost.conf` (replacing the stock one),
+   e.g. with the same `envsubst`/sed the installer uses, setting `DEMO_BANNER_HTML`
+   to a fixed-position banner, for example:
+   ```
+   <div style="position:fixed;bottom:0;left:0;right:0;z-index:99999;background:#b45309;color:#fff;text-align:center;padding:8px;font:14px sans-serif">
+     DEMO — read-only. Log in: admin@demo / demo1234 · user@demo / demo1234
+   </div>
+   ```
+3. `nginx -t && systemctl reload nginx`.
+4. Do the hardening checklist above (RO DB user + neutered agent especially).
+
+## Verify (must all pass)
+- `curl -sk -X POST https://<demo>:8443/api/v1/domains` → **403**
+- `curl -sk https://<demo>:8443/phpmyadmin/` → **403**
+- `curl -sk -X POST 'https://<demo>:8443/.ory/self-service/settings?flow=x'` → **403**
+- login as the demo account works; changing its password is refused
+- a slipped write (if any) fails at the DB with `Access denied` (RO user)
+- the DEMO banner shows on every page
+
+## Residual risk (accepted)
+GET endpoints with side effects can't be enumerated at nginx — mitigated by the
+RO DB user + neutered agent + disposable box. Admin reads expose config/log shape;
+acceptable with no real data on the box.
+
+## Update
+`jabali update` on the demo host tracks `main` and rebuilds stock panel-api. This
+vhost is independent — it only changes if you edit it here. That's the whole point:
+**the demo updates like any install; the demo behaviour never touches the program.**

--- a/deploy/demo/jabali-demo-vhost.conf.tmpl
+++ b/deploy/demo/jabali-demo-vhost.conf.tmpl
@@ -1,0 +1,144 @@
+# Jabali PUBLIC-DEMO vhost (JAB-159).
+#
+# Drop-in REPLACEMENT for jabali-panel-vhost.conf on a DISPOSABLE demo host.
+# panel-api runs 100% STOCK main (no demo code in the program) — the demo
+# behaviour is entirely in this nginx layer, so the demo host stays current
+# with `main` via a normal `jabali update`.
+#
+# THREAT MODEL: a public demo hands anonymous visitors an admin session on a
+# real panel. This vhost is ~30% of the safety; the rest is host hardening
+# (see deploy/demo/README.md): DISPOSABLE box, READ-ONLY MySQL user, neutered
+# agent, no real data. Do NOT run this in front of a panel that holds anything.
+#
+# Substitutes (same as the panel vhost, plus demo fields):
+#   ${SSL_CERT_PATH} ${SSL_KEY_PATH} ${PANEL_DIST_DIR}
+#   ${DEMO_BANNER_HTML} — pre-escaped HTML injected before </body>
+#
+# Differences from jabali-panel-vhost.conf, all defence-oriented:
+#   1. /api/v1/ write-block (covers every mutation incl. the POST SSO-mint routes)
+#   2. /phpmyadmin/ + /jabali-adminer/ return 403 (no DB console, ever)
+#   3. Kratos /self-service/{settings,recovery} POST blocked (no account takeover;
+#      login stays open)
+#   4. DEMO banner injected into the SPA HTML via sub_filter
+#   5. anon rate-limit
+
+upstream jabali_panel_api {
+  server unix:/run/jabali-panel/api.sock;
+}
+
+# Anon browsing rate-limit (per-IP). Zone declared here; if nginx complains
+# about a duplicate zone, move this limit_req_zone line to http{} (nginx.conf).
+limit_req_zone $binary_remote_addr zone=jabali_demo:10m rate=20r/s;
+
+server {
+  listen 8443 ssl${NGX_H2_PARAM};
+  listen [::]:8443 ssl${NGX_H2_PARAM};
+  ${NGX_H2_DIR}
+  server_name _;
+
+  error_page 497 =301 https://$host:8443$request_uri;
+
+  ssl_certificate     ${SSL_CERT_PATH};
+  ssl_certificate_key ${SSL_KEY_PATH};
+  ssl_protocols       TLSv1.2 TLSv1.3;
+  ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers on;
+
+  client_max_body_size 32m;   # demo has no real uploads; keep it small
+
+  gzip on;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types application/javascript text/javascript text/css application/json image/svg+xml application/manifest+json;
+
+  access_log /var/log/nginx/jabali-demo.access.log;
+  error_log  /var/log/nginx/jabali-demo.error.log;
+
+  add_header Strict-Transport-Security "max-age=31536000" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+  limit_req zone=jabali_demo burst=40 nodelay;
+
+  # (1b) DB consoles are OFF on a demo — return 403 before anything else can
+  # route here. Deliberately do NOT include the phpmyadmin/adminer snippets.
+  location ^~ /phpmyadmin/    { return 403; }
+  location ^~ /jabali-adminer/ { return 403; }
+
+  # (2) Kratos account-mutation flows: block the submit (POST) for settings +
+  # recovery so a visitor can't change the shared demo account's password or
+  # recovery email. Login + the flow-init GETs stay open. These paths arrive
+  # under /.ory/ (panel-api proxies Kratos in-process); match by substring.
+  location ~ /self-service/(settings|recovery) {
+    limit_except GET HEAD OPTIONS { deny all; }
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+
+  # (3) /api/v1 write-block. Every mutation (POST/PUT/PATCH/DELETE), including
+  # the POST SSO-mint routes (/api/v1/sso/*), is refused. GET reads proxy
+  # through so visitors browse the whole read surface. Less specific than the
+  # logs/stream location below, which keeps working for the WS GET.
+  location ^~ /api/v1/ {
+    limit_except GET HEAD OPTIONS { deny all; }
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+
+  # Log-stream WS (GET) — unchanged from the panel vhost.
+  location ^~ /api/v1/logs/stream/ {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 3600s;
+  }
+
+  # Content-hashed assets from disk (same as panel vhost).
+  location ^~ /assets/ {
+    root ${PANEL_DIST_DIR};
+    try_files $uri @panel_assets_embed;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+  location @panel_assets_embed {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_http_version 1.1;
+    proxy_hide_header Cache-Control;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+
+  # (4) SPA + everything else → panel-api. Disable upstream compression so
+  # sub_filter can inject the DEMO banner into index.html; nginx re-gzips.
+  location / {
+    proxy_pass http://jabali_panel_api/;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header Accept-Encoding "";
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 3600s;
+
+    sub_filter_once off;
+    sub_filter '</body>' '${DEMO_BANNER_HTML}</body>';
+  }
+}


### PR DESCRIPTION
## JAB-159 — public demo via nginx overlay (panel-api stays stock)

Delivers the public demo as a **reviewable nginx drop-in on a disposable host** — **no demo code in the program**. panel-api runs 100% stock `main`, so the demo tracks main via a normal `jabali update`. This is the approach you steered toward; it **supersedes the build-tag PR (#684 — please close)**.

### Why this shape
The never-merge policy existed because `/info` exposed seeded creds; keeping demo out of the binary entirely removes that concern. And a public demo is inherently risky (anon admin session on a real panel) — the nginx block is ~30% of safety, the disposable host + read-only DB is the rest.

### `deploy/demo/jabali-demo-vhost.conf.tmpl` (nginx -t validated)
Drop-in replacement for the panel vhost on the demo host:
1. `/api/v1/` writes → **403** (covers every mutation incl. the **POST** SSO-mint routes `/api/v1/sso/*`)
2. `/phpmyadmin/` + `/jabali-adminer/` → **403** (no DB console; snippets not `include`d)
3. Kratos `/self-service/{settings,recovery}` submit → **403** (no account takeover; login open)
4. DEMO banner + creds injected into the SPA via `sub_filter`
5. anon per-IP rate-limit

### `deploy/demo/README.md` — the other ~70% (host hardening)
Disposable box · **read-only MySQL user** (hard backstop for any slipped write) · neutered agent · seeded Kratos identities · network isolation. Plus apply + a verify checklist (curl the blocks).

### Verification
- `nginx -t` on testserver: **syntax OK** (self-contained wrapper, running config untouched)
- No panel-api / SPA changes → nothing in the binary changes; CI is trivially green
- Full box-apply (deploy to `demo.jabali-panel.com` + the RO-DB/agent hardening) is the operator step, guided by the README

### Not a code change
This is a deploy recipe (config + docs). Merging it ships nothing to real installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
