### PR TITLE
fix(install): honour JABALI_PUBLIC_IPV4 when IPv4 auto-detect fails (before dying)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1007,7 +1007,17 @@ prompt_server_settings() {
   _log "detecting primary interface IPv4…"
   detected_ipv4="$(_detect_public_ipv4 || true)"
   if [[ -z "$detected_ipv4" ]]; then
-    _die "could not auto-detect an IPv4 address. Set JABALI_PUBLIC_IPV4 and re-run."
+    # Auto-detect can come up empty on hosts with no default route or only
+    # non-global addresses (bridged containers, some VPS setups). The error
+    # told the operator to set JABALI_PUBLIC_IPV4 — so honour it here instead
+    # of dying before it is ever read (the value is otherwise consumed below at
+    # inp_ipv4="${JABALI_PUBLIC_IPV4:-$detected_ipv4}").
+    if [[ -n "${JABALI_PUBLIC_IPV4:-}" ]]; then
+      _warn "could not auto-detect an IPv4 address — using JABALI_PUBLIC_IPV4=${JABALI_PUBLIC_IPV4}"
+      detected_ipv4="$JABALI_PUBLIC_IPV4"
+    else
+      _die "could not auto-detect an IPv4 address. Set JABALI_PUBLIC_IPV4 and re-run."
+    fi
   fi
   _ok "primary IPv4: $detected_ipv4"
 


### PR DESCRIPTION
Auto-detection returns empty on hosts with no default route or only non-global addresses (bridged containers, some VPS layouts). The die there told the operator to 'Set JABALI_PUBLIC_IPV4 and re-run' — but the code died before ever reading that env var (only consumed later at inp_ipv4). Now the env is honoured at the failure point; die only fires when auto-detect fails AND JABALI_PUBLIC_IPV4 is unset. Same robustness class as the Go-pin fix (#689 / GH #670). Found standing up a demo host (bridged container, no default route). bash -n clean.