### PR TITLE
fix(install): resolve Go fallback from the published release list, not go.dev/VERSION (GH #670)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4319,16 +4319,24 @@ install_go() {
     # (a version bump that landed before the Go release, or a CDN propagation
     # gap) — that returns 404 and must NOT brick the whole install. Fall back to
     # the current published stable instead of dying on the pin.
-    _warn "Go $GO_VERSION not downloadable from go.dev (unpublished pin or propagation gap) — falling back to current stable"
+    _warn "Go $GO_VERSION not downloadable from go.dev (unpublished pin or propagation gap) — falling back to the latest PUBLISHED stable"
     local go_stable
-    go_stable="$("${go_curl[@]}" "https://go.dev/VERSION?m=text" 2>/dev/null | head -n1 | sed 's/^go//')"
+    # Resolve the fallback from the release LIST (go.dev/dl/?mode=json), NOT
+    # go.dev/VERSION. VERSION reports a version the instant it is tagged — before
+    # its CDN tarballs exist — so it would hand back the SAME unpublished version
+    # and 404 again (exactly the GH #670 regression). The dl list only contains
+    # releases whose files are actually published, so its newest entry is always
+    # downloadable.
+    go_stable="$("${go_curl[@]}" "https://go.dev/dl/?mode=json" 2>/dev/null \
+      | grep -oE '"version"[[:space:]]*:[[:space:]]*"go[0-9.]+"' | head -n1 \
+      | grep -oE 'go[0-9.]+' | sed 's/^go//')"
     if [[ -n "$go_stable" && "$go_stable" != "$GO_VERSION" ]]; then
-      _log "current stable is go${go_stable} — retrying with it"
+      _log "latest published stable is go${go_stable} — retrying with it"
       GO_VERSION="$go_stable"
       tarball="/tmp/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
     fi
     if ! "${go_curl[@]}" -o "$tarball" "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"; then
-      _die "failed to download Go (pinned + stable fallback both failed) from go.dev — check egress to go.dev from this host"
+      _die "failed to download Go (pinned + latest-published fallback both failed) from go.dev — check egress to go.dev from this host"
     fi
   fi
   tar -C /usr/local -xzf "$tarball"


### PR DESCRIPTION
Follow-up to #689 — the fallback it added was itself broken.

**Bug:** the fallback used `go.dev/VERSION?m=text`, which reports a Go version the instant it's **tagged** — *before* the CDN tarballs exist. So when the pinned version was briefly unpublished, the fallback handed back the **same** version and 404'd twice (`pinned + stable fallback both failed`). @mrlp57 hit exactly this after #689 bumped the pin to `1.26.5` during *its own* propagation gap — thought it was their server; it wasn't.

**Fix:** resolve the fallback from `go.dev/dl/?mode=json` — the release **list**, whose entries only appear once their files are actually published, so its newest entry is always downloadable. jq-free (grep), no new dependency. `bash -n` clean.

Refs #670.