### PR TITLE
ci(install): fail if a pinned download is ahead of upstream (GH #670 class)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,19 @@ jobs:
       - name: Run lint
         run: tools/lint-install-sh.sh
 
+  pinned-downloads:
+    name: install.sh pinned downloads published
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify pinned versions resolve to published artifacts
+        # Fails if any pinned third-party version in install.sh is AHEAD of
+        # upstream (tagged/not-yet-published) — catches the GH #670 class in the
+        # PR that bumps the pin, instead of bricking real installs.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/check-pinned-downloads.sh install.sh
+
   ui-unit:
     name: panel-ui unit tests (vitest)
     runs-on: self-hosted

--- a/scripts/check-pinned-downloads.sh
+++ b/scripts/check-pinned-downloads.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Verify every pinned third-party download in install.sh points at a PUBLISHED
+# artifact (GH #670). A version bumped AHEAD of upstream — tagged before its
+# release files exist, or a CDN propagation gap — 404s here, so the PR that
+# introduces it fails CI instead of bricking real installs 10 minutes in.
+#
+# Versions are read FROM install.sh (single source of truth — no drift). Adding
+# a new pinned download to install.sh should add a line here too; that coupling
+# is deliberate, so coverage can't silently lapse.
+#
+# Usage: scripts/check-pinned-downloads.sh [path/to/install.sh]
+set -uo pipefail
+INSTALL="${1:-install.sh}"
+[[ -f "$INSTALL" ]] || { echo "no such file: $INSTALL" >&2; exit 2; }
+fail=0
+
+# pin <regex> — pull the first dotted version number matched by <regex> from install.sh
+pin() { grep -oE "$1" "$INSTALL" | head -1 | grep -oE '[0-9]+(\.[0-9]+)+' | head -1; }
+
+# curl HEAD; treat any 2xx/3xx as published (GitHub asset URLs 302 to the CDN)
+_head() { curl -gsSL -I --retry 3 --retry-delay 3 --connect-timeout 20 -o /dev/null -w '%{http_code}' "$1" 2>/dev/null; }
+
+# GitHub release tag exists? (API — rate-limit-safe with GITHUB_TOKEN in CI)
+_gh_release() {
+  local repo="$1" tag="$2" code auth=()
+  [[ -n "${GITHUB_TOKEN:-}" ]] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  code="$(curl -gsSL -o /dev/null -w '%{http_code}' "${auth[@]}" \
+    -H 'Accept: application/vnd.github+json' \
+    --retry 3 --retry-delay 3 --connect-timeout 20 \
+    "https://api.github.com/repos/${repo}/releases/tags/${tag}" 2>/dev/null)"
+  [[ "$code" == "200" ]]
+}
+
+ok=0
+report() { # label  ok|fail  detail
+  if [[ "$2" == ok ]]; then printf '  \033[32mok\033[0m   %-22s %s\n' "$1" "$3"; ((ok++))
+  else printf '  \033[31mFAIL\033[0m %-22s %s\n' "$1" "$3"; fail=1; fi
+}
+
+check_url() { # label url
+  local code; code="$(_head "$2")"
+  if [[ "$code" =~ ^(2|3) ]]; then report "$1" ok "$2 [$code]"; else report "$1" fail "$2 [$code] — NOT PUBLISHED"; fi
+}
+check_gh() { # label owner/repo tag
+  if _gh_release "$2" "$3"; then report "$1" ok "$2 @ $3"; else report "$1" fail "$2 @ $3 — release tag missing"; fi
+}
+
+echo "verifying pinned downloads in $INSTALL"
+
+GO_V="$(pin 'JABALI_GO_VERSION:-[0-9.]+')"
+check_url "go $GO_V"          "https://go.dev/dl/go${GO_V}.linux-amd64.tar.gz"
+
+WP_V="$(pin 'wp_version="[0-9.]+"')"
+check_url "wp-cli $WP_V"      "https://github.com/wp-cli/wp-cli/releases/download/v${WP_V}/wp-cli-${WP_V}.phar"
+
+LMD_V="$(pin 'LMD_VERSION="[0-9.]+"')"
+check_url "linux-malware $LMD_V" "https://github.com/rfxn/linux-malware-detect/archive/refs/tags/v${LMD_V}.tar.gz"
+
+YX_V="$(pin 'YARAX_VERSION="[0-9.]+"')"
+check_url "yara-x $YX_V"      "https://github.com/VirusTotal/yara-x/releases/download/v${YX_V}/yara-x-v${YX_V}-x86_64-unknown-linux-gnu.tar.gz"
+
+SW_V="$(pin 'STALWART_VERSION="[0-9.]+"')"
+check_gh  "stalwart $SW_V"    "stalwartlabs/stalwart"    "v${SW_V}"
+
+CLI_V="$(pin 'cli_version="[0-9.]+"')"
+check_gh  "stalwart-cli $CLI_V" "stalwartlabs/cli"       "v${CLI_V}"
+
+BW_V="$(pin 'bulwark_version="[0-9.]+"')"
+check_gh  "bulwark-webmail $BW_V" "bulwarkmail/webmail"  "${BW_V}"   # no v-prefix
+
+KR_V="$(pin 'kratos_version="[0-9.]+"')"
+check_url "kratos $KR_V"      "https://github.com/ory/kratos/releases/download/v${KR_V}/kratos_${KR_V}-linux_64bit.tar.gz"
+
+check_url "adminer 4.8.1"     "https://github.com/vrana/adminer/releases/download/v4.8.1/adminer-4.8.1.php"
+
+echo ""
+if [[ $fail -eq 0 ]]; then
+  echo "all $ok pinned downloads are published ✓"
+else
+  echo "one or more pins are AHEAD of upstream (unpublished) — see FAIL above."
+  echo "wait for the upstream release, or lower the pin, before merging."
+  exit 1
+fi


### PR DESCRIPTION
The Go pin bricked installs twice (#670 → #689 → #692) because a version can be bumped **ahead of upstream** — tagged before its release files publish, or a CDN propagation gap — so the download 404s at install time. Nothing caught it in the PR that introduced the pin; real users hit it (@mrlp57).

**This adds the guard that would've caught both bad Go pins in their PRs:**
- `scripts/check-pinned-downloads.sh` reads each pinned version **from install.sh** (single source of truth — no drift) and HEAD-checks the actual download URL (go, wp-cli, linux-malware-detect, yara-x, kratos, adminer) or the GitHub release tag (stalwart, stalwart-cli, bulwark — arch-dynamic asset names). Any 404/missing → non-zero exit.
- new `ci.yml` job **"install.sh pinned downloads published"** runs it on every PR (`GITHUB_TOKEN` for the API calls). A PR that bumps a version ahead of upstream now goes **red** instead of shipping a broken installer.

All **9** current pins verified published. Adding a new pinned download to install.sh should add a line to the script — the coupling is deliberate so coverage can't silently lapse.

Part 2 (clearer app-dep die messages) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)