### PR TITLE
fix: reap orphaned FPM pools on user delete (GH #686)

### DIFF
--- a/panel-agent/internal/commands/php_fpm_reap.go
+++ b/panel-agent/internal/commands/php_fpm_reap.go
@@ -1,0 +1,203 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// systemReservedFPMSlugs are non-tenant FPM pools that live under
+// userPhpverDir but must NEVER be reaped as orphans — e.g. phpMyAdmin's "pma"
+// pool, seeded by install.sh. They have no panel-user row, so the orphan
+// reaper would otherwise mistake them for a deleted user's leftovers.
+var systemReservedFPMSlugs = map[string]bool{
+	"pma": true,
+}
+
+// versionedSlugRe matches a versioned pool slug ("alice-php8.2") and captures
+// the owning username. Usernames themselves cannot contain "-" or "." (see
+// phpPoolUsernameRegex), so the split is unambiguous.
+var versionedSlugRe = regexp.MustCompile(`^(.+)-php[0-9]+\.[0-9]+$`)
+
+// usernameForSlug returns the owning username for a pool slug. A versioned slug
+// ("alice-php8.2") maps to its base username ("alice"); a default slug is the
+// username itself.
+func usernameForSlug(slug string) string {
+	if m := versionedSlugRe.FindStringSubmatch(slug); m != nil {
+		return m[1]
+	}
+	return slug
+}
+
+// reapFPMPoolArtifacts stops+disables the slug's FPM master and removes its
+// on-disk artifacts (pool.d confs, per-user fpm conf, version-pin file, and —
+// for a versioned slug — its systemd drop-in dir). Best-effort: every step
+// tolerates already-missing files and never returns an error, so it is safe to
+// call from user.delete teardown and the orphan reaper. Mirrors the teardown in
+// php.pool.remove.
+func reapFPMPoolArtifacts(ctx context.Context, slug string) {
+	if !phpPoolSlugRegex.MatchString(slug) || strings.Contains(slug, "..") {
+		return
+	}
+	isVersioned := versionedSlugRe.MatchString(slug)
+
+	// Stop + disable the FPM master.
+	if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
+		svc := fmt.Sprintf("jabali-fpm@%s.service", slug)
+		_ = exec.CommandContext(ctx, "systemctl", "stop", svc).Run()
+		_ = exec.CommandContext(ctx, "systemctl", "disable", "--quiet", svc).Run()
+	}
+
+	// pool.d confs across all installed PHP versions.
+	if matches, err := filepath.Glob(fmt.Sprintf("/etc/php/*/fpm/pool.d/jabali-%s.conf", slug)); err == nil {
+		for _, path := range matches {
+			_ = os.Remove(path)
+		}
+	}
+
+	// Per-user fpm conf.
+	fpmConfRoot := os.Getenv("JABALI_FPM_CONFIG_ROOT")
+	if fpmConfRoot == "" {
+		fpmConfRoot = "/etc/jabali-panel/fpm"
+	}
+	_ = os.Remove(filepath.Join(fpmConfRoot, slug+".conf"))
+
+	// Version-pin file — the one fpmWorkerStatus counts (GH #686).
+	_ = os.Remove(filepath.Join(userPhpverDir, slug))
+
+	// A versioned slug owns its own drop-in dir; the default pool's is owned by
+	// user.slice.ensure and must be left intact.
+	if isVersioned {
+		_ = os.RemoveAll(filepath.Join(systemdRoot(), fmt.Sprintf("jabali-fpm@%s.service.d", slug)))
+		if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
+			_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+		}
+	}
+}
+
+// reapUserFPMPools tears down every FPM pool owned by username — the default
+// pool (slug == username) plus any versioned masters ("<username>-phpX.Y").
+// Called from user.delete so a deleted user leaves no orphaned pool behind
+// (GH #686: the stale version-pin file otherwise inflated the PHP Manager
+// "FPM workers" count).
+func reapUserFPMPools(ctx context.Context, username string) {
+	if !phpPoolUsernameRegex.MatchString(username) {
+		return
+	}
+	// Default pool.
+	reapFPMPoolArtifacts(ctx, username)
+
+	// Versioned pools: discover them by their per-user fpm confs.
+	fpmConfRoot := os.Getenv("JABALI_FPM_CONFIG_ROOT")
+	if fpmConfRoot == "" {
+		fpmConfRoot = "/etc/jabali-panel/fpm"
+	}
+	if matches, err := filepath.Glob(filepath.Join(fpmConfRoot, username+"-php*.conf")); err == nil {
+		for _, path := range matches {
+			slug := strings.TrimSuffix(filepath.Base(path), ".conf")
+			if usernameForSlug(slug) == username {
+				reapFPMPoolArtifacts(ctx, slug)
+			}
+		}
+	}
+}
+
+// --- Orphan reaper (php.pool.reap-orphans) ---------------------------------
+
+// phpPoolReapOrphansParams is the input shape for php.pool.reap-orphans.
+type phpPoolReapOrphansParams struct {
+	// KeepUsernames is the authoritative set of usernames that still own a
+	// panel account. A pool whose owner is NOT in this set is a candidate
+	// orphan. REQUIRED: a nil pointer (field absent) is refused so a broken
+	// caller can never trigger a mass reap.
+	KeepUsernames *[]string `json:"keep_usernames"`
+}
+
+// phpPoolReapOrphansResponse is the output shape for php.pool.reap-orphans.
+type phpPoolReapOrphansResponse struct {
+	Reaped []string `json:"reaped"`
+}
+
+// osUserExists reports whether an OS account named username exists. A package
+// var so tests can stub it. Used as a hard safety belt: even with a wrong
+// keep-list, a pool whose OS user still exists is never reaped.
+var osUserExists = func(username string) bool {
+	_, err := user.Lookup(username)
+	return err == nil
+}
+
+// maxReapPerCall bounds agent work per reap pass, mirroring the reconciler's
+// 50-item policy elsewhere.
+const maxReapPerCall = 50
+
+// phpPoolReapOrphansHandler garbage-collects FPM pools left behind by a deleted
+// user (GH #686). It enumerates userPhpverDir and reaps any pool whose owning
+// username is (a) not in KeepUsernames, AND (b) has no surviving OS account,
+// AND (c) is not a system-reserved slug (e.g. "pma"). The triple guard means a
+// live tenant's pool survives even if the caller's keep-list is stale/empty.
+func phpPoolReapOrphansHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p phpPoolReapOrphansParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+	if p.KeepUsernames == nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "keep_usernames is required (a nil list would risk a mass reap)",
+		}
+	}
+	keep := make(map[string]bool, len(*p.KeepUsernames))
+	for _, u := range *p.KeepUsernames {
+		keep[u] = true
+	}
+
+	entries, err := os.ReadDir(userPhpverDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return phpPoolReapOrphansResponse{Reaped: []string{}}, nil
+		}
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("failed to read %s: %v", userPhpverDir, err),
+		}
+	}
+
+	reaped := make([]string, 0)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		slug := e.Name()
+		if systemReservedFPMSlugs[slug] {
+			continue
+		}
+		owner := usernameForSlug(slug)
+		if keep[owner] {
+			continue
+		}
+		if osUserExists(owner) { // safety belt vs a stale/empty keep-list
+			continue
+		}
+		reapFPMPoolArtifacts(ctx, slug)
+		reaped = append(reaped, slug)
+		if len(reaped) >= maxReapPerCall {
+			break
+		}
+	}
+	return phpPoolReapOrphansResponse{Reaped: reaped}, nil
+}
+
+func init() {
+	Default.Register("php.pool.reap-orphans", phpPoolReapOrphansHandler)
+}

--- a/panel-agent/internal/commands/php_fpm_reap_test.go
+++ b/panel-agent/internal/commands/php_fpm_reap_test.go
@@ -1,0 +1,114 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestUsernameForSlug(t *testing.T) {
+	cases := map[string]string{
+		"alice":         "alice",
+		"alice-php8.2":  "alice",
+		"bob_1-php8.15": "bob_1",
+		"pma":           "pma",
+	}
+	for slug, want := range cases {
+		if got := usernameForSlug(slug); got != want {
+			t.Errorf("usernameForSlug(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}
+
+func TestPhpPoolReapOrphans_ReapsOnlyOrphans(t *testing.T) {
+	dir := t.TempDir()
+	fpmDir := t.TempDir()
+	sysDir := t.TempDir()
+	t.Setenv("JABALI_PHP_POOL_SKIP_RELOAD", "1")
+	t.Setenv("JABALI_FPM_CONFIG_ROOT", fpmDir)
+	t.Setenv("JABALI_SYSTEMD_ROOT", sysDir)
+
+	oldDir := userPhpverDir
+	userPhpverDir = dir
+	defer func() { userPhpverDir = oldDir }()
+
+	// Only "dave" has a surviving OS account (tests the OS-user safety belt).
+	oldLookup := osUserExists
+	osUserExists = func(u string) bool { return u == "dave" }
+	defer func() { osUserExists = oldLookup }()
+
+	for _, slug := range []string{"alice", "bob", "carol-php8.2", "dave", "pma"} {
+		if err := os.WriteFile(filepath.Join(dir, slug), []byte("8.4"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(fpmDir, slug+".conf"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	params, _ := json.Marshal(map[string]any{"keep_usernames": []string{"alice"}})
+	out, err := phpPoolReapOrphansHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	resp := out.(phpPoolReapOrphansResponse)
+	got := append([]string(nil), resp.Reaped...)
+	sort.Strings(got)
+	want := []string{"bob", "carol-php8.2"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("reaped = %v, want %v", got, want)
+	}
+
+	// alice (keep-list), dave (OS guard), pma (system-reserved) must survive.
+	for _, keep := range []string{"alice", "dave", "pma"} {
+		if _, err := os.Stat(filepath.Join(dir, keep)); err != nil {
+			t.Errorf("expected pin file %q to survive: %v", keep, err)
+		}
+	}
+	// Reaped slugs' pin files + confs are gone.
+	for _, gone := range []string{"bob", "carol-php8.2"} {
+		if _, err := os.Stat(filepath.Join(dir, gone)); !os.IsNotExist(err) {
+			t.Errorf("expected pin %q removed, err=%v", gone, err)
+		}
+		if _, err := os.Stat(filepath.Join(fpmDir, gone+".conf")); !os.IsNotExist(err) {
+			t.Errorf("expected conf %q removed, err=%v", gone, err)
+		}
+	}
+}
+
+func TestPhpPoolReapOrphans_NilKeepRefused(t *testing.T) {
+	if out, err := phpPoolReapOrphansHandler(context.Background(), []byte(`{}`)); err == nil {
+		t.Fatalf("expected error for missing keep_usernames, got %v", out)
+	}
+}
+
+func TestReapUserFPMPools_RemovesDefaultAndVersionedOnly(t *testing.T) {
+	dir := t.TempDir()
+	fpmDir := t.TempDir()
+	sysDir := t.TempDir()
+	t.Setenv("JABALI_PHP_POOL_SKIP_RELOAD", "1")
+	t.Setenv("JABALI_FPM_CONFIG_ROOT", fpmDir)
+	t.Setenv("JABALI_SYSTEMD_ROOT", sysDir)
+	oldDir := userPhpverDir
+	userPhpverDir = dir
+	defer func() { userPhpverDir = oldDir }()
+
+	for _, slug := range []string{"alice", "alice-php8.2", "bob"} {
+		os.WriteFile(filepath.Join(dir, slug), []byte("8.4"), 0o644)
+		os.WriteFile(filepath.Join(fpmDir, slug+".conf"), []byte("x"), 0o644)
+	}
+
+	reapUserFPMPools(context.Background(), "alice")
+
+	for _, gone := range []string{"alice", "alice-php8.2"} {
+		if _, err := os.Stat(filepath.Join(dir, gone)); !os.IsNotExist(err) {
+			t.Errorf("expected %q pin removed, err=%v", gone, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "bob")); err != nil {
+		t.Errorf("expected bob pin (other user) to survive: %v", err)
+	}
+}

--- a/panel-agent/internal/commands/user_delete.go
+++ b/panel-agent/internal/commands/user_delete.go
@@ -66,6 +66,12 @@ func userDeleteHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}
 	}
 
+	// GH #686: tear down the user's FPM pool(s) before removing the account so
+	// no orphaned version-pin file / jabali-fpm@<user> master is left behind (a
+	// stale pin file inflates the PHP Manager "FPM workers" count). Best-effort;
+	// the reconciler's orphan reaper (php.pool.reap-orphans) is the backstop.
+	reapUserFPMPools(ctx, p.Username)
+
 	// Remove the per-user slice BEFORE userdel so systemd can still resolve the UID
 	// while stopping user@<uid>.service.
 	sliceParams, _ := json.Marshal(map[string]string{"username": p.Username}) // GH #694: Marshal, not string-concat

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -594,6 +594,11 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// orphans). No-op when no user has a non-default pool.
 	r.reconcileVersionedPHPPools(ctx)
 
+	// GH #686: garbage-collect FPM pools orphaned by a deleted user. user.delete
+	// tears them down inline; this backstop self-heals pools orphaned before that
+	// fix (or by a failed teardown). Bounded + guarded agent-side.
+	r.reconcileOrphanFPMPools(ctx)
+
 	// M24: managed IPs BEFORE the domain loop. If a domain is bound to a
 	// secondary IP that fell off the kernel (host reboot, netplan drop),
 	// re-bind it first so the vhost render later in the loop can find
@@ -1190,6 +1195,45 @@ func (r *Reconciler) reapVersionedPool(ctx context.Context, user *models.User, p
 		return
 	}
 	r.log.Info("reaped orphan versioned PHP pool", "pool_id", pool.ID, "slug", slug)
+}
+
+// reconcileOrphanFPMPools garbage-collects FPM pools whose owning user was
+// deleted (GH #686). user.delete tears down a deleted user's pool inline, but
+// this backstop also self-heals pools orphaned before that fix shipped (or by a
+// failed teardown). It hands the agent the authoritative set of live usernames;
+// the agent reaps only pools whose owner is absent from that set AND has no
+// surviving OS account (see php.pool.reap-orphans).
+func (r *Reconciler) reconcileOrphanFPMPools(ctx context.Context) {
+	if r.agent == nil || r.users == nil {
+		return
+	}
+	users, _, err := r.users.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		r.log.Error("orphan FPM reap: failed to list users", "err", err)
+		return
+	}
+	keep := make([]string, 0, len(users))
+	for i := range users {
+		if users[i].Username != nil && *users[i].Username != "" {
+			keep = append(keep, *users[i].Username)
+		}
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	raw, err := r.agent.Call(callCtx, "php.pool.reap-orphans", map[string]any{
+		"keep_usernames": keep,
+	})
+	if err != nil {
+		r.log.Warn("orphan FPM reap: agent call failed; will retry next tick", "err", err)
+		return
+	}
+	var resp struct {
+		Reaped []string `json:"reaped"`
+	}
+	if json.Unmarshal(raw, &resp) == nil && len(resp.Reaped) > 0 {
+		r.log.Info("reaped orphan FPM pools", "count", len(resp.Reaped), "slugs", resp.Reaped)
+	}
 }
 
 // reconcileMysqlAdminShadow ensures all active users have mysqladmin shadow accounts.


### PR DESCRIPTION
## Bug (#686)

PHP Manager shows `FPM workers X/Y running` per version: `8.5 = 0/1`, `8.4 = 1/2`. johnnyq deleted a user and suspected leftover pools. **Correct instinct.**

`fpmWorkerStatus(version)` (panel-agent `php_version_status.go`) counts one file per user under `/etc/jabali-panel/user-phpver/` (`total` = files pinned to that version; `running` = those whose `jabali-fpm@<name>` is active).

**Root cause:** user deletion never tears down the **default** FPM pool. `userops/purge.go`, `api/users.go` delete, and CLI `cmd/server/user.go` delete have **zero** pool/FPM cleanup, and the reconciler's reap only handles **versioned** pools that still have a DB row — which cascades away on delete. So a deleted user's pin-file lingers → counted in `total`, but `jabali-fpm@<user>` is inactive → a **non-running phantom** (the extra `1` in `1/2`).

## Fix (two layers)

**1. Teardown on delete** — the agent `user.delete` handler now calls `reapUserFPMPools`, which stops+disables `jabali-fpm@<slug>` and removes the pin-file, per-user fpm conf, `pool.d` confs, and versioned drop-in dir for the user's default pool **plus** any `<user>-phpX.Y` versioned pools. One place covers both REST and CLI delete paths.

**2. Reconciler backstop (self-heals existing orphans)** — new agent command `php.pool.reap-orphans` enumerates `user-phpver` and reaps any pool whose owner is **(a)** absent from the panel's live-username set **AND (b)** has no surviving OS account **AND (c)** is not system-reserved (`pma`). The triple guard means a live tenant's pool is never reaped even if the keep-list is stale/empty; a `nil` keep-list is refused outright. The reconciler calls it each tick with all active usernames — so johnnyq's already-orphaned pool self-heals on the next tick, no manual step.

Note: phpMyAdmin's `pma` pool is a legitimately-running pseudo-user in the count (verified live) — not a phantom; it's explicitly kept.

## Test plan

- [x] `go build ./...` + `go vet` clean (panel-agent + panel-api)
- [x] New unit tests pass: `usernameForSlug` split; reap-orphans keeps kept/OS-guarded/system slugs and reaps only true orphans; `nil` keep-list refused; `reapUserFPMPools` removes default+versioned but not another user's pool
- [x] Full `internal/commands` + `internal/reconciler` packages green
- [ ] CI (self-hosted): Go tests+vet, install.sh lint, panel-ui, Playwright
- [ ] Box-verify: delete a user, confirm PHP Manager count drops + `jabali-fpm@<user>` gone + pin-file removed

Fixes #686.