### PR TITLE
fix: bound folder-size du + show 0 B for empty folders (GH #657)

### DIFF
--- a/panel-agent/internal/commands/files_du.go
+++ b/panel-agent/internal/commands/files_du.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
@@ -74,8 +75,21 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	if derr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("open dir: %v", derr)}
 	}
-	dirSizes := duSubdirSizes(ctx, df, resolved)
+	// GH #657: bound the recursive `du` so a huge tree can't hang the request
+	// past the gateway timeout (Cloudflare ~100s) — which surfaced as an opaque
+	// "invalid or incomplete response" 520. A hard 45s budget (under the panel's
+	// call ctx) lets du finish for most trees; if it can't, return a clean,
+	// explicit error instead of silently-partial (wrong) sizes or a 520.
+	duCtx, duCancel := context.WithTimeout(ctx, 45*time.Second)
+	defer duCancel()
+	dirSizes, duTimedOut := duSubdirSizes(duCtx, df, resolved)
 	df.Close()
+	if duTimedOut {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeDeadlineExceeded,
+			Message: "size calculation timed out — this directory is too large to size within 45s; size a smaller subfolder instead",
+		}
+	}
 
 	entries, err := scope.ReadDirInScope(resolved)
 	if err != nil {
@@ -113,7 +127,7 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 // -D dereferences only the command-line arg; in-tree symlinks are still not
 // followed, preserving the GH #653 escape-proofing. The child's fd-relative
 // output paths are remapped back onto `canonical` for the caller's lookups.
-func duSubdirSizes(ctx context.Context, dirFd *os.File, canonical string) map[string]int64 {
+func duSubdirSizes(ctx context.Context, dirFd *os.File, canonical string) (map[string]int64, bool) {
 	dirSizes := map[string]int64{}
 	duCmd := exec.CommandContext(ctx, "du", "-b", "-D", "--max-depth=1", "/proc/self/fd/3")
 	duCmd.ExtraFiles = []*os.File{dirFd}
@@ -136,7 +150,10 @@ func duSubdirSizes(ctx context.Context, dirFd *os.File, canonical string) map[st
 		}
 		dirSizes[path] = sz
 	}
-	return dirSizes
+	// A fired deadline means du was killed mid-walk (directory too large); the
+	// caller turns this into an explicit error rather than shipping the partial
+	// (and therefore wrong) sizes we managed to parse.
+	return dirSizes, ctx.Err() == context.DeadlineExceeded
 }
 
 func init() {

--- a/panel-agent/internal/commands/files_du_test.go
+++ b/panel-agent/internal/commands/files_du_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestDuSubdirSizes_Recursive guards GH #657: du must follow the
@@ -34,7 +35,10 @@ func TestDuSubdirSizes_Recursive(t *testing.T) {
 	}
 	defer f.Close()
 
-	sizes := duSubdirSizes(context.Background(), f, root)
+	sizes, timedOut := duSubdirSizes(context.Background(), f, root)
+	if timedOut {
+		t.Fatal("unexpected timeout on a small tree")
+	}
 
 	// >= (not ==) tolerates the directory nodes' own apparent size, which
 	// varies by filesystem. The point is that they are NOT ~0 (the bug).
@@ -46,5 +50,22 @@ func TestDuSubdirSizes_Recursive(t *testing.T) {
 	}
 	if got := sizes[root]; got < 8_000_000 {
 		t.Errorf("root total = %d, want >= 8000000", got)
+	}
+}
+
+// TestDuSubdirSizes_Timeout guards GH #657: when du is killed by a fired
+// deadline (directory too large), duSubdirSizes must report timedOut=true so
+// the handler returns a clean error rather than silently-partial sizes.
+func TestDuSubdirSizes_Timeout(t *testing.T) {
+	root := t.TempDir()
+	f, err := os.Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	if _, timedOut := duSubdirSizes(ctx, f, root); !timedOut {
+		t.Fatal("expected timedOut=true for an already-expired context")
 	}
 }

--- a/panel-api/internal/api/me_disk_usage.go
+++ b/panel-api/internal/api/me_disk_usage.go
@@ -226,7 +226,7 @@ func (h *meDiskUsageHandler) filesTree(c *gin.Context) {
 	if path == "" {
 		path = "/home/" + username
 	}
-	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, 55*time.Second)
 	defer cancel()
 	raw, derr := h.cfg.Agent.Call(cctx, "files.du", map[string]any{
 		"user_id":  claims.UserID,

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -147,7 +147,9 @@ function parseDragPayload(raw: string): string[] {
 }
 
 function formatBytes(bytes: number): string {
-  if (bytes === 0) return "—";
+  // GH #657: a known 0 renders as "0 B"; "not yet calculated" is handled by the
+  // caller (undefined -> "—"), so 0 must not collapse to the same dash.
+  if (bytes === 0) return "0 B";
   const units = ["B", "KB", "MB", "GB"];
   let size = bytes;
   let i = 0;

--- a/panel-ui/src/shells/user/files/editability.test.ts
+++ b/panel-ui/src/shells/user/files/editability.test.ts
@@ -15,7 +15,7 @@ function entry(over: Partial<FileEntry>): FileEntry {
 
 describe("isTextEditable", () => {
   // GH #532: a freshly-created 0-byte file must be editable — the whole point
-  // of "create then edit" — even though it renders "—" and has size 0.
+  // of "create then edit" — even though it has size 0 (rendered as "0 B" — GH #657).
   it("allows empty (0-byte) files", () => {
     expect(isTextEditable(entry({ size: 0 }))).toBe(true);
   });


### PR DESCRIPTION
Two bugs reported by @lxsdevcode on the on-demand folder-size feature.

## 1. Size calculation fails (Cloudflare 520)

> Size calculation failed: The origin web server returned an invalid or incomplete response to Cloudflare…

Both the toolbar **Folder Sizes** and the per-folder **Calculate size** call `files.du`, which runs a recursive `du --max-depth=1` — `--max-depth` only limits *output* depth, so du still walks the **entire** subtree. On a large tree it can outrun the gateway window (CF ~100s), and the kill was swallowed (`out, _ := duCmd.Output()`), so it also shipped **silently-partial (wrong)** sizes when it did return.

**Fix:** bound `du` with a hard **45s** budget, detect the fired deadline, and return a clean `deadline_exceeded` error — *"this directory is too large to size within 45s; size a smaller subfolder instead"* — instead of a 520 or partial data. The panel-side call ctx is bumped **30s → 55s** (still well under CF ~100s and nginx's 300s `proxy_read_timeout`) so more trees finish before erroring.

## 2. Empty folders show `--` instead of `0 B`

`FileManagerPage`'s local `formatBytes` returned `"—"` for `0`, which collides with the "not yet calculated" dash (the render already maps `undefined → "—"`). So a *calculated* empty folder (size 0) was indistinguishable from an uncalculated one.

**Fix:** a known `0` now renders `"0 B"`, matching the shared `humanBytes` util (`humanBytes(0) === "0 B"`). Uncalculated folders still show `"—"` via the `undefined` branch.

## Test plan

- [x] `duSubdirSizes` now returns `(sizes, timedOut)`; new test asserts `timedOut=true` on a fired deadline; existing recursive-size test updated
- [x] Go build+vet clean (panel-agent + panel-api)
- [x] `tsc -b` clean; files-area + `bytes` vitest green (14 tests)
- [ ] CI (self-hosted)
- [ ] Box-verify: size a large dir → clean "too large" message (no 520); size an empty folder → `0 B`

Fixes the two follow-ups on #657.