### PR TITLE
fix(migrate): Plesk test-connection + keyboard-interactive SSH + test-path port (GH #429)

### DIFF
--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -13,6 +13,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressplugin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressssh"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -32,6 +33,10 @@ func panelDiscoverer(kind string, allowPrivate bool) migrate.Discoverer {
 		return d
 	case models.MigrationSourceHestia:
 		d := hestiacp.New()
+		d.AllowPrivate = allowPrivate
+		return d
+	case models.MigrationSourcePlesk:
+		d := plesk.New()
 		d.AllowPrivate = allowPrivate
 		return d
 	}
@@ -115,6 +120,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported_kind"})
 		return
 	}
+	migrate.ApplyPort(d, job.SourcePort) // GH #429: test/describe previously ignored the custom SSH port (only the run path applied it)
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
 		respondMigrateConnectErr(c, err)
@@ -154,6 +160,8 @@ func panelLabel(kind string) string {
 		return "DirectAdmin"
 	case models.MigrationSourceHestia:
 		return "HestiaCP"
+	case models.MigrationSourcePlesk:
+		return "Plesk"
 	}
 	return kind
 }
@@ -183,6 +191,7 @@ func (h *adminMigrationsHandler) describeAccount(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 120*time.Second)
 	defer cancel()
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
+	migrate.ApplyPort(d, job.SourcePort) // GH #429: test/describe previously ignored the custom SSH port (only the run path applied it)
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {
 		respondMigrateConnectErr(c, err)

--- a/panel-api/internal/api/admin_migrations_testconn_plesk_test.go
+++ b/panel-api/internal/api/admin_migrations_testconn_plesk_test.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestPanelDiscoverer_SupportsPlesk guards GH #429: plesk was missing from the
+// panelDiscoverer switch, so the wizard's Test Connection (and the per-account
+// describe) returned "unsupported_kind" for a Plesk source.
+func TestPanelDiscoverer_SupportsPlesk(t *testing.T) {
+	if d := panelDiscoverer(models.MigrationSourcePlesk, false); d == nil {
+		t.Fatal("panelDiscoverer(plesk) = nil — Test Connection would return unsupported_kind")
+	}
+	if got := panelLabel(models.MigrationSourcePlesk); got != "Plesk" {
+		t.Fatalf("panelLabel(plesk) = %q, want %q", got, "Plesk")
+	}
+}

--- a/panel-api/internal/migrate/cloudpanel/discover.go
+++ b/panel-api/internal/migrate/cloudpanel/discover.go
@@ -516,7 +516,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/cpanel/discover.go
+++ b/panel-api/internal/migrate/cpanel/discover.go
@@ -161,7 +161,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/cyberpanel/discover.go
+++ b/panel-api/internal/migrate/cyberpanel/discover.go
@@ -619,7 +619,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/directadmin/discover.go
+++ b/panel-api/internal/migrate/directadmin/discover.go
@@ -164,7 +164,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/hestiacp/discover.go
+++ b/panel-api/internal/migrate/hestiacp/discover.go
@@ -132,7 +132,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -151,7 +151,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {

--- a/panel-api/internal/migrate/sshauth.go
+++ b/panel-api/internal/migrate/sshauth.go
@@ -1,0 +1,29 @@
+package migrate
+
+import "golang.org/x/crypto/ssh"
+
+// SSHPasswordAuthMethods returns the SSH auth methods to try for a plaintext
+// password. It offers BOTH the "password" method and "keyboard-interactive".
+//
+// GH #429: many servers do password login through PAM and advertise ONLY the
+// keyboard-interactive method, not "password". With ssh.Password alone the
+// handshake fails with `no supported methods remain [none password]` even
+// though `ssh host` logs in fine with the same password (lxsdevcode's Plesk
+// source hit exactly this). The keyboard-interactive callback answers every
+// challenge prompt with the password, which covers the common single-prompt
+// ("Password:") PAM flow while leaving genuine multi-factor prompts to fail.
+func SSHPasswordAuthMethods(password string) []ssh.AuthMethod {
+	return []ssh.AuthMethod{ssh.Password(password), ssh.KeyboardInteractive(passwordChallenge(password))}
+}
+
+// passwordChallenge answers every keyboard-interactive prompt with the given
+// password. Extracted for testability.
+func passwordChallenge(password string) ssh.KeyboardInteractiveChallenge {
+	return func(_, _ string, questions []string, _ []bool) ([]string, error) {
+		answers := make([]string, len(questions))
+		for i := range questions {
+			answers[i] = password
+		}
+		return answers, nil
+	}
+}

--- a/panel-api/internal/migrate/sshauth_test.go
+++ b/panel-api/internal/migrate/sshauth_test.go
@@ -1,0 +1,39 @@
+package migrate
+
+import "testing"
+
+// TestSSHPasswordAuthMethods_OffersBoth guards GH #429: a plaintext password
+// must be tried via BOTH "password" and "keyboard-interactive", so a PAM
+// source that only advertises keyboard-interactive still authenticates.
+func TestSSHPasswordAuthMethods_OffersBoth(t *testing.T) {
+	methods := SSHPasswordAuthMethods("hunter2")
+	if len(methods) != 2 {
+		t.Fatalf("want 2 auth methods (password + keyboard-interactive), got %d", len(methods))
+	}
+}
+
+// TestPasswordChallenge_AnswersEveryPromptWithPassword covers the single- and
+// multi-prompt PAM flows.
+func TestPasswordChallenge_AnswersEveryPromptWithPassword(t *testing.T) {
+	ch := passwordChallenge("s3cret")
+	ans, err := ch("", "", []string{"Password: "}, []bool{false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ans) != 1 || ans[0] != "s3cret" {
+		t.Fatalf("single prompt: got %v, want [s3cret]", ans)
+	}
+	ans, err = ch("", "", []string{"Password: ", "Verification code: "}, []bool{false, true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ans) != 2 || ans[0] != "s3cret" || ans[1] != "s3cret" {
+		t.Fatalf("multi prompt: got %v", ans)
+	}
+
+	// Zero prompts (server sends an empty round) must yield an empty,
+	// non-nil slice — never a panic.
+	if ans, err := ch("", "", nil, nil); err != nil || len(ans) != 0 {
+		t.Fatalf("zero prompts: got %v, err %v", ans, err)
+	}
+}

--- a/panel-api/internal/migrate/wordpressssh/discover.go
+++ b/panel-api/internal/migrate/wordpressssh/discover.go
@@ -248,7 +248,7 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		}
 		switch k {
 		case "SSH_PASSWORD":
-			auths = append(auths, ssh.Password(v))
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
 			signer, perr := ssh.ParsePrivateKey([]byte(v))
 			if perr != nil {


### PR DESCRIPTION
@lxsdevcode's Plesk source hit three connection bugs (latest comments on #429).

## 1. Test Connection → `unsupported_kind`

`panelDiscoverer` (used by both Test Connection and the per-account describe) switched over cPanel/WHM, DirectAdmin, and HestiaCP — **but not `plesk`** — so it returned nil → `unsupported_kind` before dialing. Added the `plesk` case to `panelDiscoverer` + `panelLabel`.

## 2. SSH password auth fails despite `ssh host` working

Error: `no supported methods remain [none password]`. Every migrator's `loadSecret` offered only `ssh.Password`, but many servers do password login through **PAM and advertise only `keyboard-interactive`**, not the `password` method — so `ssh host` works while the migrator's handshake fails. New shared `migrate.SSHPasswordAuthMethods(pw)` offers **both** (password + a keyboard-interactive challenge that answers each prompt with the password), swapped into all seven SSH migrators (plesk, directadmin, hestiacp, cpanel, cloudpanel, cyberpanel, wordpressssh).

## 3. Test/describe ignored the custom SSH port

Only the *run* path called `migrate.ApplyPort`; `testConnection` and `describeAccount` dialed **22** regardless. Added `ApplyPort(d, job.SourcePort)` before `Connect` in both — otherwise, once plesk was wired in, the probe would time out on 22 (the `dial …:22` symptom from earlier comments).

## Test plan
- [x] `SSHPasswordAuthMethods` offers both methods; challenge answers single/multi/zero prompts
- [x] `panelDiscoverer` + `panelLabel` resolve plesk (no more `unsupported_kind`)
- [x] build+vet clean; full `internal/migrate/...` package tests green
- [ ] CI (self-hosted)
- [ ] Box-verify against a real Plesk source on a custom SSH port with password auth

## Not in this PR (separate follow-ups from the same report)
- Dest user still created when analyze fails
- `user@remote_ip` display name
- Wizard lets you save past a failed Test Connection

Addresses the connection blockers on #429.