### PR TITLE
fix(install): Kratos URLs port-less behind a proxy + read the real config path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12251,15 +12251,37 @@ install_kratos() {
     _die "Kratos template not found at ${REPO_DIR}/install/kratos.yml.tmpl"
   fi
 
-  # Resolve the panel hostname. Fresh install: prompt_server_settings set
-  # $JABALI_SRV_HOSTNAME. Re-run after config.toml is seeded: pull from
-  # the existing config. Last resort: hostname -f.
+  # Resolve the panel config for hostname + public port. The authoritative
+  # config the panel reads is /etc/jabali/config.toml (main.go defaultConfigPath);
+  # keep the legacy /etc/jabali-panel/config.toml path as a fallback.
+  local panel_cfg=""
+  if [[ -f /etc/jabali/config.toml ]]; then
+    panel_cfg="/etc/jabali/config.toml"
+  elif [[ -f /etc/jabali-panel/config.toml ]]; then
+    panel_cfg="/etc/jabali-panel/config.toml"
+  fi
+
   local panel_hostname="${JABALI_SRV_HOSTNAME:-}"
-  if [[ -z "$panel_hostname" && -f /etc/jabali-panel/config.toml ]]; then
-    panel_hostname="$(awk -F'[= "]+' '/^[[:space:]]*hostname[[:space:]]*=/{print $2; exit}' /etc/jabali-panel/config.toml)"
+  if [[ -z "$panel_hostname" && -n "$panel_cfg" ]]; then
+    panel_hostname="$(awk -F'[= "]+' '/^[[:space:]]*hostname[[:space:]]*=/{print $2; exit}' "$panel_cfg")"
   fi
   if [[ -z "$panel_hostname" ]]; then
     panel_hostname="$(hostname -f 2>/dev/null || hostname 2>/dev/null || echo 'localhost')"
+  fi
+
+  # GH #429: public port. When the panel is fronted by a reverse proxy on 443
+  # (e.g. a Cloudflare tunnel), Kratos must emit PORT-LESS URLs so the browser's
+  # flow/return/redirect URLs resolve on :443, not the origin :8443. Controlled
+  # by [server] public_port in config.toml; absent keeps the default :8443.
+  local panel_port_suffix=":8443"
+  if [[ -n "$panel_cfg" ]]; then
+    local pub_port
+    pub_port="$(awk -F'[= "]+' '/^[[:space:]]*public_port[[:space:]]*=/{print $2; exit}' "$panel_cfg")"
+    if [[ "$pub_port" == "443" ]]; then
+      panel_port_suffix=""
+    elif [[ "$pub_port" =~ ^[0-9]+$ ]]; then
+      panel_port_suffix=":$pub_port"
+    fi
   fi
 
   # None of these values contain `|`, so we use it as the sed delimiter
@@ -12271,6 +12293,7 @@ install_kratos() {
     -e "s|{{\.KratosDatabasePassword}}|${kratos_db_pass}|g" \
     -e "s|{{\.KratosDatabaseName}}|${kratos_db_name}|g" \
     -e "s|{{\.PanelHostname}}|${panel_hostname}|g" \
+    -e "s|{{\.PanelPortSuffix}}|${panel_port_suffix}|g" \
     -e "s|{{\.KratosSecretDefault}}|${kratos_secret_default}|g" \
     -e "s|{{\.KratosCookieSecret}}|${kratos_secret_cookie}|g" \
     "${REPO_DIR}/install/kratos.yml.tmpl" > "$kratos_config"

--- a/install/kratos.yml.tmpl
+++ b/install/kratos.yml.tmpl
@@ -8,7 +8,7 @@ dsn: "mysql://{{.KratosDatabaseUser}}:{{.KratosDatabasePassword}}@unix(/var/run/
 
 serve:
   public:
-    base_url: "https://{{.PanelHostname}}:8443/.ory/"
+    base_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/.ory/"
     # M25 Step 3: public API listens on a Unix-domain socket. panel-api
     # reverse-proxies /.ory/* through this socket via the in-process
     # kratosclient.NewReverseProxyTransport (panel-api/internal/app/
@@ -29,7 +29,7 @@ serve:
     cors:
       enabled: true
       allowed_origins:
-        - "https://{{.PanelHostname}}:8443"
+        - "https://{{.PanelHostname}}{{.PanelPortSuffix}}"
       allowed_methods:
         - GET
         - POST
@@ -68,21 +68,21 @@ serve:
       group: "jabali-sockets"
 
 selfservice:
-  default_browser_return_url: "https://{{.PanelHostname}}:8443/dashboard"
+  default_browser_return_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/dashboard"
   allowed_return_urls:
-    - "https://{{.PanelHostname}}:8443"
-    - "https://{{.PanelHostname}}:8443/dashboard"
-    - "https://{{.PanelHostname}}:8443/login"
-    - "https://{{.PanelHostname}}:8443/admin"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/dashboard"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/login"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/admin"
     # Shell roots — trailing slash makes Kratos treat these as prefix
     # matches, so /jabali-admin/profile, /jabali-panel/profile?flow=…
     # etc. all qualify. Without these, Kratos drops the return_to and
     # falls back to default_browser_return_url (/dashboard) — which
     # broke the M20.1 settings-refresh flow (login w/ refresh=true
     # returned the user to the dashboard instead of /profile).
-    - "https://{{.PanelHostname}}:8443/jabali-admin/"
-    - "https://{{.PanelHostname}}:8443/jabali-panel/"
-    - "https://{{.PanelHostname}}:8443/settings"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/jabali-admin/"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/jabali-panel/"
+    - "https://{{.PanelHostname}}{{.PanelPortSuffix}}/settings"
 
   methods:
     password:
@@ -125,12 +125,12 @@ selfservice:
 
   flows:
     login:
-      ui_url: "https://{{.PanelHostname}}:8443/login"
+      ui_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/login"
       lifespan: 1h
 
     registration:
       enabled: false
-      ui_url: "https://{{.PanelHostname}}:8443/register"
+      ui_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/register"
       lifespan: 1h
       after:
         password:
@@ -138,23 +138,23 @@ selfservice:
             - hook: session
 
     settings:
-      ui_url: "https://{{.PanelHostname}}:8443/settings"
+      ui_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/settings"
       privileged_session_max_age: 15m
       lifespan: 1h
 
     recovery:
       enabled: true
-      ui_url: "https://{{.PanelHostname}}:8443/recovery"
+      ui_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/recovery"
       lifespan: 1h
 
     verification:
       enabled: true
-      ui_url: "https://{{.PanelHostname}}:8443/verify"
+      ui_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/verify"
       lifespan: 24h
 
     logout:
       after:
-        default_browser_return_url: "https://{{.PanelHostname}}:8443/login"
+        default_browser_return_url: "https://{{.PanelHostname}}{{.PanelPortSuffix}}/login"
 
 identity:
   default_schema_id: default


### PR DESCRIPTION
Surfaced while standing up the Cloudflare-tunnel-fronted demo (`demo.jabali-panel.com`). Two coupled `install_kratos` bugs:

## 1. Kratos hardcodes `hostname:8443` → login 404s behind a proxy on 443

`kratos.yml.tmpl` baked `https://{{.PanelHostname}}:8443` into every self-service URL (`base_url`, `ui_url`, `default_browser_return_url`, `allowed_return_urls`, CORS). When the panel is fronted by a reverse proxy on **443** (CF tunnel → origin :8443), Kratos hands the browser `:8443` action/redirect URLs the proxy doesn't expose → the credential POST 404s (`Request failed with status code 404`).

**Fix:** the template's `:8443` becomes `{{.PanelPortSuffix}}`; `install_kratos` derives it from **`[server] public_port`** in config.toml:
- `443` → **port-less** (`https://host/.ory/…`)
- another port → `:port`
- absent → `:8443` (**unchanged default — fully backward compatible**)

## 2. install_kratos read the wrong config path → wrong hostname on update

It read the hostname from `/etc/jabali-panel/config.toml`, but the panel's authoritative config is `/etc/jabali/config.toml` (`main.go` `defaultConfigPath`). The `-panel` path doesn't exist on current layouts, so on any `jabali update` **without** `JABALI_SRV_HOSTNAME` in the env, it fell back to `hostname -f` and rendered kratos.yml against the wrong host. Now prefers `/etc/jabali/config.toml` with the legacy path as fallback; `public_port` is read from the same file.

## Test plan
- [x] Template renders **identically** with the default (`:8443`) and **port-less** with `public_port=443`
- [x] No `{{.…}}` mustaches leak in either case; port-suffix logic covers `443`/other/absent
- [x] `bash -n install.sh` clean
- [ ] CI (self-hosted: install.sh phantom-function lint etc.)
- [ ] Box-verify: set `public_port=443`, re-run `install_kratos`, confirm port-less kratos.yml + working login through the tunnel

Enables a durable proxy-fronted deploy (the demo, or any panel behind nginx/CF on 443). Part of the #429 cluster.