### PR TITLE
fix(ssh): never trap root in the tenant sandbox shell (GH #658)

### DIFF
--- a/panel-agent/cmd/jabali-ssh-shell/main.go
+++ b/panel-agent/cmd/jabali-ssh-shell/main.go
@@ -57,6 +57,14 @@ func main() {
 }
 
 func run() error {
+	// GH #658: uid 0 (root) must never be trapped in the tenant sandbox. If
+	// this wrapper is ever root's login shell — e.g. a mis-created "root"
+	// panel user (GH #429) chsh'd root here — hand root a real login shell
+	// instead of the sandbox/nologin path, so a chsh mistake can't lock the
+	// operator out of SSH. The sandbox is only ever for hosting tenants.
+	if os.Getuid() == 0 {
+		return execRootLoginShell()
+	}
 	mode, err := readMode()
 	if err != nil {
 		return execNologin(fmt.Sprintf("read mode: %v", err))
@@ -443,6 +451,26 @@ func currentUser() (name string, uid, gid int, home string, err error) {
 func currentUsername() (string, error) {
 	name, _, _, _, err := currentUser()
 	return name, err
+}
+
+// rootShellArgv builds the argv for root's real login shell, preserving
+// sshd's invocation: a remote command (`shell -c "cmd"`, len(osArgs) > 1) keeps
+// its args under a plain argv0; an interactive login gets a leading-dash argv0.
+func rootShellArgv(base string, osArgs []string) []string {
+	if len(osArgs) > 1 {
+		return append([]string{base}, osArgs[1:]...)
+	}
+	return []string{"-" + base}
+}
+
+// execRootLoginShell replaces the process with a real root login shell
+// (GH #658). Prefers /bin/bash, falls back to /bin/sh.
+func execRootLoginShell() error {
+	shell, base := "/bin/bash", "bash"
+	if _, err := os.Stat(shell); err != nil {
+		shell, base = "/bin/sh", "sh"
+	}
+	return syscall.Exec(shell, rootShellArgv(base, os.Args), os.Environ())
 }
 
 // execNologin replaces the current process with /usr/sbin/nologin.

--- a/panel-agent/cmd/jabali-ssh-shell/main_test.go
+++ b/panel-agent/cmd/jabali-ssh-shell/main_test.go
@@ -98,3 +98,16 @@ func TestBuildBwrapArgv_ForwardsCommandAndIsolates(t *testing.T) {
 		t.Errorf("command mode should forward `-c`, got %v", tail)
 	}
 }
+
+// TestRootShellArgv guards GH #658: root's real login shell must preserve
+// sshd's invocation — a leading-dash argv0 for an interactive login, and the
+// passed args (e.g. `-c "cmd"`) for a remote command.
+func TestRootShellArgv(t *testing.T) {
+	if got := rootShellArgv("bash", []string{"-jabali-ssh-shell"}); len(got) != 1 || got[0] != "-bash" {
+		t.Fatalf("interactive: got %v, want [-bash]", got)
+	}
+	got := rootShellArgv("bash", []string{"jabali-ssh-shell", "-c", "id"})
+	if len(got) != 3 || got[0] != "bash" || got[1] != "-c" || got[2] != "id" {
+		t.Fatalf("command: got %v, want [bash -c id]", got)
+	}
+}

--- a/panel-agent/internal/commands/ssh_user_set_shell.go
+++ b/panel-agent/internal/commands/ssh_user_set_shell.go
@@ -57,6 +57,18 @@ func sshUserSetShellHandler(ctx context.Context, params json.RawMessage) (any, e
 		}
 	}
 
+	// GH #658: never chsh a protected system account (root, the service
+	// user) into the tenant sandbox shell. A mis-created "root" panel user
+	// (GH #429) drove exactly this — jabali-ssh-shell then refused root's
+	// non-/home home and fell back to nologin, locking the operator out of
+	// SSH. Shells of system accounts are the OS's business, not the panel's.
+	if protectedUsers[p.Username] {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("refusing to change the login shell of protected system user %q", p.Username),
+		}
+	}
+
 	// Look up current shell from /etc/passwd. os/user.Lookup doesn't
 	// expose the shell field; fall back to getent.
 	cur, err := getentShell(ctx, p.Username)

--- a/panel-agent/internal/commands/ssh_user_set_shell_test.go
+++ b/panel-agent/internal/commands/ssh_user_set_shell_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// TestSSHUserSetShellHandler_RefusesProtectedUsers guards GH #658: a protected
+// system account (root, the service user) must never be chsh'd into the tenant
+// sandbox shell — that's what locked the operator out of SSH after a
+// mis-created "root" panel user (GH #429).
+func TestSSHUserSetShellHandler_RefusesProtectedUsers(t *testing.T) {
+	for _, u := range []string{"root", "jabali"} {
+		params, _ := json.Marshal(map[string]string{
+			"username": u,
+			"shell":    "/usr/local/bin/jabali-ssh-shell",
+		})
+		_, err := sshUserSetShellHandler(context.Background(), params)
+		if err == nil {
+			t.Fatalf("user %q: expected refusal, got nil", u)
+		}
+		ae, ok := err.(*agentwire.AgentError)
+		if !ok || ae.Code != agentwire.CodePermissionDenied {
+			t.Fatalf("user %q: want PermissionDenied AgentError, got %v", u, err)
+		}
+	}
+}


### PR DESCRIPTION
## Bug (#658)

After the #429 bug created a `root` **panel** user, provisioning `chsh`'d the **system** `root` account into `/usr/local/bin/jabali-ssh-shell`. That wrapper refuses any home that isn't `/home/<user>` (root's is `/root`) and falls back to `nologin`:

```
jabali-ssh-shell: refusing sandbox: user "root" home "/root" is not /home/root — falling back to nologin
This account is currently not available.
```

→ `ssh root@host` is dead, operator locked out.

## Fix — two guards

**1. `ssh.user.set_shell` refuses protected system accounts** (`root`, the service user). The panel has no business changing a system account's login shell, and the sandbox shell is only ever meant for hosting tenants. This stops the root cause.

**2. `jabali-ssh-shell` gives uid 0 a real shell instead of nologin.** If the wrapper is *ever* root's login shell (by bug or accident), running as uid 0 now execs a real root login shell (`/bin/bash`, `/bin/sh` fallback) — preserving sshd's invocation (interactive login argv0 with a leading dash vs `-c "cmd"`). Root can no longer be locked out. Non-root users still get the existing sandbox/nologin behavior.

## Test plan
- [x] `set_shell` refuses `root` + the service user (`PermissionDenied`)
- [x] `rootShellArgv` builds `[-bash]` for interactive login and `[bash -c cmd]` for a remote command
- [x] build+vet clean; jabali-ssh-shell + commands packages green
- [ ] CI (self-hosted)
- [ ] Box-verify: `chsh -s $(which jabali-ssh-shell) root` then `ssh root@host` → real shell (not nologin); a hosting user still sandboxes

## Recovery for an already-affected host
The fixed binary can't be installed until root can log in, so a locked-out host needs a one-time (via sudo or console):
```
sudo chsh -s /bin/bash root
```
The guards prevent recurrence + any future lockout.

Fixes #658. Related to the #429 root-user cluster.