### PR TITLE
fix(backups): admin list shows real Type (Files/Database), not always Account Backup (GH #454)

### DIFF
--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -64,6 +64,7 @@ type BackupRunSummary struct {
 	RunID         string    `json:"run_id"`
 	ScheduleID    *string   `json:"schedule_id,omitempty"`
 	Kind          string    `json:"kind"`
+	Content       string    `json:"content"`
 	Total         int       `json:"total"`
 	Succeeded     int       `json:"succeeded"`
 	Failed        int       `json:"failed"`
@@ -180,6 +181,7 @@ func (r *backupJobRepo) ListRuns(ctx context.Context, limit, offset int) ([]Back
 		RunID         string
 		ScheduleID    *string
 		Kind          string
+		Content       string
 		Total         int
 		Succeeded     int
 		Failed        int
@@ -197,6 +199,8 @@ func (r *backupJobRepo) ListRuns(ctx context.Context, limit, offset int) ([]Back
 SELECT run_id                                                             AS run_id,
        MAX(schedule_id)                                                   AS schedule_id,
        MAX(kind)                                                          AS kind,
+       CASE WHEN COUNT(DISTINCT content) = 1 THEN MAX(content)
+            ELSE 'full' END                                              AS content,
        COUNT(*)                                                           AS total,
        SUM(status = 'succeeded')                                          AS succeeded,
        SUM(status = 'failed')                                             AS failed,
@@ -224,6 +228,7 @@ SELECT run_id                                                             AS run
 			RunID:         x.RunID,
 			ScheduleID:    x.ScheduleID,
 			Kind:          x.Kind,
+			Content:       x.Content,
 			Total:         x.Total,
 			Succeeded:     x.Succeeded,
 			Failed:        x.Failed,

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -3,6 +3,7 @@
 // expandable to per-user children). Manual creates render flat.
 import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { downloadUrl } from "../../../utils/download";
+import { backupTypeColor, backupTypeLabel } from "../../../utils/backupType";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { RowActions } from "../../../components/RowActions";
@@ -41,6 +42,7 @@ interface BackupJob {
   user_id: string;
   destination_id?: string;
   kind: string;
+  content?: string;
   status: string;
   systemd_unit: string;
   snapshot_id: string;
@@ -56,6 +58,7 @@ interface BackupRun {
   run_id: string;
   schedule_id?: string;
   kind: string;
+  content?: string;
   total: number;
   succeeded: number;
   failed: number;
@@ -107,21 +110,6 @@ const formatBytes = (n: number): string => {
     i += 1;
   }
   return `${v.toFixed(1)} ${units[i]}`;
-};
-
-const renderTypeTag = (k: string) => {
-  const label =
-    k === "system_backup"
-      ? "System Backup"
-      : k === "account_backup"
-        ? "Account Backup"
-        : k === "system_restore"
-          ? "System Restore"
-          : k === "account_restore"
-            ? "Account Restore"
-            : k;
-  const color = k.startsWith("system") ? "purple" : "blue";
-  return <Tag color={color}>{label}</Tag>;
 };
 
 // Run summary collapses 6 status counters into a single Tag stack so
@@ -538,8 +526,13 @@ export const AdminBackupsPage = () => {
               {
                 title: "Type",
                 sorter: (a, b) => (a.isRun ? a.run.kind : a.job.kind).localeCompare(b.isRun ? b.run.kind : b.job.kind),
-                render: (_: unknown, row: TableRow) =>
-                  renderTypeTag(row.isRun ? row.run.kind : row.job.kind),
+                render: (_: unknown, row: TableRow) => {
+                  const kind = row.isRun ? row.run.kind : row.job.kind;
+                  const content = row.isRun ? row.run.content : row.job.content;
+                  return (
+                    <Tag color={backupTypeColor(kind, content)}>{backupTypeLabel(kind, content)}</Tag>
+                  );
+                },
               },
               {
                 title: "Status",


### PR DESCRIPTION
@lxsdevcode: the admin **Backups** list **Type** column always read **Account Backup**, even for a files-only or database-only backup.

## Cause
The parent run rows come from `BackupRunSummary`, which aggregated only `MAX(kind)` (always `account_backup`) and carried **no content** — and `AdminBackupsPage`'s local `renderTypeTag` rendered the *kind* alone, ignoring the per-run content. (The tenant card already used `backupTypeLabel(kind, content)`, so it was correct — this was admin-only.)

## Fix
- `BackupRunSummary` + `ListRuns` now carry `content`, derived per run as
  `CASE WHEN COUNT(DISTINCT content)=1 THEN MAX(content) ELSE 'full' END` — a single-content run reports that content; a mixed (multi-tenant scheduled) run reports `full`.
- `AdminBackupsPage` drops the kind-only `renderTypeTag` and uses the shared `backupTypeLabel`/`backupTypeColor(kind, content)` for both run rows and manual (on-demand job) rows. Files/database/folders now render as **Files** / **Database** backups; full + system unchanged.

## Test plan
- [x] `backupType.test` pins the `(kind, content) → label` mapping (Database/Files/Account)
- [x] `tsc -b` + backup-area vitest green; repository build + tests green
- [ ] CI (self-hosted)
- [ ] Box-verify: create a database-only + a files-only backup as a tenant → admin list shows **Database Backup** / **Files Backup** (not Account Backup)

Closes the last open item on #454 (tenant backup mgmt is otherwise shipped: retention #578, save-fix #620).