### PR TITLE
fix(search): header search shows/matches localized labels, not raw i18n keys (GH #455)

### DIFF
--- a/panel-ui/src/components/JabaliHeader.test.tsx
+++ b/panel-ui/src/components/JabaliHeader.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { navSearchOptions } from "./JabaliHeader";
+
+// Mock translator: nav labels are keys ("menu.users") -> localized text ("Users").
+const t = (k: string): string =>
+  (({ "menu.dashboard": "Dashboard", "menu.users": "Users", "menu.domains": "Domains" }) as Record<string, string>)[
+    k
+  ] ?? k;
+
+const nav = [
+  { label: "menu.dashboard", path: "/jabali-admin/dashboard" },
+  { label: "menu.users", path: "/jabali-admin/users" },
+  { label: "menu.domains", path: "/jabali-admin/domains" },
+];
+
+describe("navSearchOptions (GH #455)", () => {
+  it("displays the TRANSLATED label, not the raw key", () => {
+    const opts = navSearchOptions(nav, "", t);
+    expect(opts.map((o) => o.label)).toEqual(["Dashboard", "Users", "Domains"]);
+    expect(opts.map((o) => o.value)).toEqual([
+      "page:/jabali-admin/dashboard",
+      "page:/jabali-admin/users",
+      "page:/jabali-admin/domains",
+    ]);
+  });
+
+  it("filters on the TRANSLATED text", () => {
+    expect(navSearchOptions(nav, "user", t).map((o) => o.label)).toEqual(["Users"]);
+  });
+
+  it("does NOT match against the raw key (the bug)", () => {
+    // "menu." prefixes every key; filtering on the localized text must ignore it.
+    expect(navSearchOptions(nav, "menu", t)).toHaveLength(0);
+  });
+});

--- a/panel-ui/src/components/JabaliHeader.tsx
+++ b/panel-ui/src/components/JabaliHeader.tsx
@@ -76,6 +76,22 @@ type JabaliHeaderProps = {
   onMenuClick?: () => void;
 };
 
+// navSearchOptions builds the "Pages" search results from the shell nav. GH #455:
+// nav labels are TRANSLATION KEYS (e.g. "menu.users"); both the substring filter
+// and the displayed label must run through t() so the search shows and matches the
+// localized text like the rest of the UI — not the raw key.
+export function navSearchOptions(
+  items: readonly { label: string; path: string }[],
+  query: string,
+  t: (key: string) => string,
+): SearchOption[] {
+  const trimmed = query.trim().toLowerCase();
+  const filtered = trimmed
+    ? items.filter((n) => t(n.label).toLowerCase().includes(trimmed))
+    : items;
+  return filtered.map((n) => ({ value: `page:${n.path}`, label: t(n.label) }));
+}
+
 export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHeaderProps = {}) {
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
@@ -128,20 +144,13 @@ export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHead
   // the AntD docs example for AutoComplete) shows every destination
   // in the current shell. When the user types, we substring-match the
   // label so unrelated pages drop out of the dropdown.
-  const pagesGroup = useMemo<OptionGroup>(() => {
-    const items = isAdminShell ? adminNav : userNav;
-    const trimmed = query.trim().toLowerCase();
-    const filtered = trimmed
-      ? items.filter((n) => n.label.toLowerCase().includes(trimmed))
-      : items;
-    return {
+  const pagesGroup = useMemo<OptionGroup>(
+    () => ({
       label: "Pages",
-      options: filtered.map((n) => ({
-        value: `page:${n.path}`,
-        label: n.label,
-      })),
-    };
-  }, [isAdminShell, query]);
+      options: navSearchOptions(isAdminShell ? adminNav : userNav, query, t),
+    }),
+    [isAdminShell, query, t],
+  );
 
   // Debounced remote fetch. 250ms is tight enough to feel live without
   // hammering the API; an empty/whitespace query keeps the Pages


### PR DESCRIPTION
Follow-up on #455 (after the breadcrumb i18n fix). @lxsdevcode: the header **Search** still showed raw translation keys.

## Cause
The header search's "Pages" group is built from the shell nav, whose labels are **translation keys** (`menu.users`, …). It both **displayed** `n.label` raw and **substring-matched** against it — so results read as keys, typing the localized word ("users") often wouldn't match, and typing a key prefix ("menu") matched *everything*.

## Fix
Extract `navSearchOptions(items, query, t)` and run every nav label through `t()` for **both** the displayed label and the filter — so search behaves like the rest of the UI (localized text).

(The group headers "Pages/Users/Domains" are plain English category labels, not raw keys — left as-is to avoid churning 11 locale files for non-reported polish.)

## Test plan
- [x] New `JabaliHeader.test.tsx`: results show **translated** labels (Users, not menu.users); filtering matches the **translated** text; a raw-key substring ("menu") no longer matches
- [x] `tsc -b` clean
- [ ] CI (self-hosted)
- [ ] Box-verify: switch language, open header search — page results appear localized

Closes the last i18n gap on #455.