### PR TITLE
fix(backups): Download is the primary backup row action (GH #502)

### DIFF
--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -359,8 +359,11 @@ export const AdminBackupsPage = () => {
           render: (_: unknown, row: BackupJob) => (
             <RowActions
               actions={[
-                { key: "log", label: "Log", icon: <FileTextOutlined />, onClick: () => setLogJob(row) },
+                // GH #502: Download is the most common action after a backup completes —
+                // make it the primary (first, visible) action; Log + the rest collapse
+                // into the overflow menu.
                 { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: row.status !== "succeeded", onClick: () => handleDownload(row) },
+                { key: "log", label: "Log", icon: <FileTextOutlined />, onClick: () => setLogJob(row) },
                 {
                   key: "restore",
                   label: "Restore",


### PR DESCRIPTION
@lxsdevcode's UI suggestion on #502: Download is the most common action after a backup completes, but it was hidden in the overflow (+) menu while a less-common action was the visible primary.

`RowActions` renders the first non-hidden action as the primary button and collapses the rest into the overflow menu — so this just reorders the actions to put **Download** first (visible for a succeeded backup); **Log / Restore / Cancel / Delete** move into the menu.

## Test plan
- [x] `tsc -b` clean
- [ ] CI
- [ ] Box-verify: a succeeded backup shows Download as the visible button; others in the menu

(The Full-Server-only-backs-up-System bug + scheduler flexibility on #502 are tracked separately.)