### PR TITLE
feat(mail): tabbed side-car Edit Mailbox drawer + group field in Add (GH #529)

### DIFF
--- a/panel-ui/src/components/mail/EditMailboxModal.tsx
+++ b/panel-ui/src/components/mail/EditMailboxModal.tsx
@@ -1,7 +1,13 @@
 // EditMailboxModal — edit a mailbox's display name (GH #197), quota, and
 // enabled state. Shared by the user Mail tab and the admin server-wide
 // Mail tab. Only changed fields are sent (partial PATCH /mailboxes/:id).
-import { App, Form, InputNumber, Input, Modal, Switch, Typography } from "antd";
+//
+// GH #529: rendered as a right-hand side-car Drawer (matching Add mailbox)
+// with the previously-crowded flat layout split into tabs — Account /
+// Forwarding / Groups / Send As. The Account tab is the only form-backed tab
+// (Save applies to it); the other tabs are self-contained sections that
+// persist their own changes independently.
+import { App, Button, Drawer, Form, Grid, Input, InputNumber, Space, Switch, Tabs, Typography } from "antd";
 import { useEffect } from "react";
 
 import { useUpdateMailbox, type Mailbox } from "../../hooks/useMailboxes";
@@ -29,6 +35,8 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
   const { message } = App.useApp();
   const [form] = Form.useForm<FormValues>();
   const update = useUpdateMailbox();
+  const screens = Grid.useBreakpoint();
+  const isDesktop = !!screens.md;
 
   useEffect(() => {
     if (open && mailbox) {
@@ -88,59 +96,84 @@ export function EditMailboxModal({ open, mailbox, onClose }: EditMailboxModalPro
     }
   };
 
-  return (
-    <Modal
-      open={open}
-      title={mailbox ? `Edit ${mailbox.email}` : "Edit mailbox"}
-      okText="Save"
-      confirmLoading={update.isPending}
-      onOk={submit}
-      onCancel={onClose}
-      destroyOnClose
-    >
-      <Form form={form} layout="vertical" requiredMark={false}>
-        <Form.Item
-          label="Display name"
-          name="display_name"
-          tooltip="Shown as the sender name in webmail and outgoing mail. Optional."
-        >
-          <Input placeholder="Alice Smith" maxLength={255} autoComplete="off" />
-        </Form.Item>
-        <Form.Item
-          label="Quota (MiB)"
-          name="quota_mib"
-          rules={[{ required: true, message: "Quota is required" }]}
-        >
-          <InputNumber min={QUOTA_MIN_MIB} max={1024 * 1024} step={256} style={{ width: 200 }} />
-        </Form.Item>
-        <Form.Item label="Enabled" name="enabled" valuePropName="checked">
-          <Switch />
-        </Form.Item>
-        <Form.Item
-          label="Send-only (SMTP submission, no inbox)"
-          name="send_only"
-          valuePropName="checked"
-          tooltip="A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials. Toggling this on discards inbound delivery; existing stored mail is not deleted."
-        >
-          <Switch />
-        </Form.Item>
-        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-          A display-name change applies to webmail on the mailbox&apos;s next login;
-          an existing webmail identity may keep the old name until then.
-        </Typography.Text>
-        {mailbox ? (
+  const accountTab = (
+    <Form form={form} layout="vertical" requiredMark={false}>
+      <Form.Item
+        label="Display name"
+        name="display_name"
+        tooltip="Shown as the sender name in webmail and outgoing mail. Optional."
+      >
+        <Input placeholder="Alice Smith" maxLength={255} autoComplete="off" />
+      </Form.Item>
+      <Form.Item
+        label="Quota (MiB)"
+        name="quota_mib"
+        rules={[{ required: true, message: "Quota is required" }]}
+      >
+        <InputNumber min={QUOTA_MIN_MIB} max={1024 * 1024} step={256} style={{ width: 200 }} />
+      </Form.Item>
+      <Form.Item label="Enabled" name="enabled" valuePropName="checked">
+        <Switch />
+      </Form.Item>
+      <Form.Item
+        label="Send-only (SMTP submission, no inbox)"
+        name="send_only"
+        valuePropName="checked"
+        tooltip="A send-only mailbox can authenticate for SMTP submission (sending) but never receives or stores mail — inbound is rejected. Ideal for per-service or per-appliance notification credentials. Toggling this on discards inbound delivery; existing stored mail is not deleted."
+      >
+        <Switch />
+      </Form.Item>
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        A display-name change applies to webmail on the mailbox&apos;s next login;
+        an existing webmail identity may keep the old name until then.
+      </Typography.Text>
+    </Form>
+  );
+
+  const tabItems = [{ key: "account", label: "Account", children: accountTab }];
+  if (mailbox) {
+    tabItems.push(
+      {
+        key: "forwarding",
+        label: "Forwarding",
+        children: (
           <MailboxForwardingSection
             mailboxId={mailbox.id}
             domainName={mailbox.email.split("@")[1] ?? ""}
           />
-        ) : null}
-        {mailbox ? (
-          <MailboxGroupsSection mailboxId={mailbox.id} domainId={mailbox.domain_id} />
-        ) : null}
-        {mailbox ? (
-          <MailboxSendAsSection mailboxId={mailbox.id} domainId={mailbox.domain_id} />
-        ) : null}
-      </Form>
-    </Modal>
+        ),
+      },
+      {
+        key: "groups",
+        label: "Groups",
+        children: <MailboxGroupsSection mailboxId={mailbox.id} domainId={mailbox.domain_id} />,
+      },
+      {
+        key: "sendas",
+        label: "Send As",
+        children: <MailboxSendAsSection mailboxId={mailbox.id} domainId={mailbox.domain_id} />,
+      },
+    );
+  }
+
+  return (
+    <Drawer
+      open={open}
+      title={mailbox ? `Edit ${mailbox.email}` : "Edit mailbox"}
+      onClose={onClose}
+      width={isDesktop ? 520 : undefined}
+      placement="right"
+      destroyOnClose
+      extra={
+        <Space>
+          <Button onClick={onClose}>Cancel</Button>
+          <Button type="primary" loading={update.isPending} onClick={submit}>
+            Save
+          </Button>
+        </Space>
+      }
+    >
+      <Tabs defaultActiveKey="account" items={tabItems} />
+    </Drawer>
   );
 }

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
@@ -258,21 +258,20 @@ export const CreateMailboxWizardModal = ({
               <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
             </Form.Item>
 
-            {domainGroups && domainGroups.length > 0 && (
-              <Form.Item
-                label={t("createmailboxwizardmodal.add_to_groups")}
-                name="group_ids"
-                tooltip={t("createmailboxwizardmodal.the_mailbox_joins_these_groups_and_gains_the")}
-              >
-                <Select
-                  mode="multiple"
-                  allowClear
-                  placeholder={t("createmailboxwizardmodal.select_groups_optional")}
-                  optionFilterProp="label"
-                  options={domainGroups.map((g) => ({ value: g.id, label: g.display_name || g.email }))}
-                />
-              </Form.Item>
-            )}
+            <Form.Item
+              label={t("createmailboxwizardmodal.add_to_groups")}
+              name="group_ids"
+              tooltip={t("createmailboxwizardmodal.the_mailbox_joins_these_groups_and_gains_the")}
+            >
+              <Select
+                mode="multiple"
+                allowClear
+                disabled={!domainGroups || domainGroups.length === 0}
+                placeholder={t("createmailboxwizardmodal.select_groups_optional")}
+                optionFilterProp="label"
+                options={(domainGroups ?? []).map((g) => ({ value: g.id, label: g.display_name || g.email }))}
+              />
+            </Form.Item>
 
             <Form.Item
               label={t("createmailboxwizardmodal.aliases_optional")}


### PR DESCRIPTION
Closes the UI-consistency part of #529 (johnnyq).

## What
- **Edit Mailbox: Modal → side-car Drawer with Tabs.** `EditMailboxModal` now renders as a right-hand Drawer (width 520 desktop, `Cancel` + primary `Save` in the header extra) — matching Add Mailbox. The previously-crowded flat form is split into tabs:
  - **Account** — display name, quota, enabled, send-only (the form-backed fields; `Save` applies here)
  - **Forwarding** · **Groups** · **Send As** — the existing self-contained sections, each persisting its own changes
- **Add Mailbox: group field always visible.** The *Add to groups* field was hidden entirely when the domain had no groups (why johnnyq saw it "missing"); it's now always rendered, disabled with the existing placeholder when the domain has no groups.

## Deferred (from #529, needs product decisions)
- **Send As in Add** — Send As needs an existing mailbox id (it lists *other* mailboxes as grantors), so it only works post-create. Would require a create-then-configure flow.
- **"Logins" tab** — no per-mailbox logins/app-password feature exists yet.
- **"Aliases"** — Add already has an Aliases field; there's no separate per-mailbox alias concept beyond forwarders/forwarding.

A clarifying comment on these is going to the reporter.

## Test plan
- [x] `npx tsc -b` clean
- [x] `eslint` clean on both files
- [x] vitest: CreateMailboxWizardModal + useMailboxes + DomainMailboxesSection suites green (20 tests)
- [x] `npm run build` succeeds
- [ ] CI (self-hosted)
- [ ] Visual: Edit opens as a right drawer with the 4 tabs; sections still save independently