### PR TITLE
feat(demo): gate demo UI behind VITE_DEMO — prod SPA excludes it (JAB-159 phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
       # runner contention; gate the build here too so it fails fast and always.
       - name: build (production)
         run: cd panel-ui && NODE_OPTIONS=--max-old-space-size=4096 npm run build
+      # JAB-159 phase 2: the prod SPA (just built above) must not contain the
+      # demo UI; a VITE_DEMO=1 build must. `jabali-demo-banner` is a DemoBanner
+      # string literal (CSS var + style id) that survives minification.
+      - name: demo UI stripped from prod bundle, present in demo build (JAB-159)
+        run: |
+          cd panel-ui
+          if grep -rq 'jabali-demo-banner' dist/; then echo 'FAIL: demo UI leaked into prod bundle'; exit 1; fi
+          VITE_DEMO=1 NODE_OPTIONS=--max-old-space-size=4096 npm run build
+          if ! grep -rq 'jabali-demo-banner' dist/; then echo 'FAIL: demo build missing demo UI'; exit 1; fi
+          echo 'SPA demo-gate OK: prod excludes demo UI, demo build includes it'
 
   e2e:
     name: Playwright E2E

--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -39,11 +39,19 @@ import { useApplyBrandingToTitle, useBranding } from "./hooks/useBranding";
 import { PANEL_COLORS } from "./lib/panelColors";
 import { CapabilityRoute } from "./components/CapabilityRoute";
 import { LoginPage } from "./pages/Login";
-import { DemoBanner } from "./components/DemoBanner";
 
 // JAB-145: route-level code splitting — each page is its own lazy chunk
 // so the initial bundle no longer eagerly pulls all ~55 pages. Layouts,
 // guards, and the public LoginPage stay eager (needed on first paint).
+// JAB-159 phase 2: demo-only UI, gated behind VITE_DEMO. The ternary
+// condition is a build-time constant (Vite define), so a non-demo build
+// dead-code-eliminates the import() and tree-shakes DemoBanner +
+// useServiceInfo out of the production bundle.
+const DemoBanner =
+  import.meta.env.VITE_DEMO === "1"
+    ? lazy(() => import("./components/DemoBanner").then((m) => ({ default: m.DemoBanner })))
+    : null;
+
 const Dashboard = lazy(() => import("./shells/admin/Dashboard").then((m) => ({ default: m.Dashboard })));
 const UserList = lazy(() => import("./shells/admin/users/UserList").then((m) => ({ default: m.UserList })));
 const AdminUserOverview = lazy(() => import("./shells/admin/users/AdminUserOverview").then((m) => ({ default: m.AdminUserOverview })));
@@ -189,9 +197,15 @@ const ThemedApp = () => {
         renderEmpty={() => <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />}
       >
         <AntdApp>
-        {/* JAB-159: renders nothing unless /info reports demo mode (prod /info
-            never does, since the cred-exposing route is compiled out). */}
-        <DemoBanner />
+        {/* JAB-159 phase 2: demo UI is compiled out of production bundles.
+            VITE_DEMO is statically replaced by Vite; when it is not "1" the
+            dynamic import above is tree-shaken, dropping DemoBanner +
+            useServiceInfo from the prod SPA entirely. */}
+        {DemoBanner ? (
+          <Suspense fallback={null}>
+            <DemoBanner />
+          </Suspense>
+        ) : null}
         <BrandingTitleApplier />
         <Suspense
           fallback={

--- a/panel-ui/src/vite-env.d.ts
+++ b/panel-ui/src/vite-env.d.ts
@@ -2,3 +2,8 @@
 
 // Allow side-effectful CSS imports (Refine + AntD reset.css).
 declare module "*.css";
+
+// JAB-159: VITE_DEMO="1" selects the demo build; unset/other = production.
+interface ImportMetaEnv {
+  readonly VITE_DEMO?: string;
+}


### PR DESCRIPTION
JAB-159 phase 2. Phase 1 (#684) build-tag-gated the **Go** demo surface out of production binaries; the **SPA** still bundled `DemoBanner` + `useServiceInfo` unconditionally (they only no-op'd at runtime). This gates them at build time too, so production bundles physically exclude the demo UI.

## What
- **`App.tsx`** — `DemoBanner` is now a dynamic import behind `import.meta.env.VITE_DEMO === "1"`. Vite statically replaces `VITE_DEMO`, so a non-demo build dead-code-eliminates the `import()` and tree-shakes `DemoBanner` + its sole dependent `useServiceInfo` out of the prod bundle. (`DemoBanner` ← only `App.tsx`; `useServiceInfo` ← only `DemoBanner`, so both drop cleanly.)
- **`vite-env.d.ts`** — type `VITE_DEMO` on `ImportMetaEnv`.
- **`ci.yml` (ui-unit)** — extend the anti-leak guard to the SPA: the prod bundle must not contain the `jabali-demo-banner` marker (a `DemoBanner` string literal that survives minification) while a `VITE_DEMO=1` build must.

## Verified locally
- prod `npm run build`: no `jabali-demo-banner`, no "Demo mode" text in `dist/`
- `VITE_DEMO=1 npm run build`: both present
- `tsc -b`, `eslint`, Login vitest all green

## Remaining (JAB-159)
- Phase 3 — demo deploy profile (`-tags demo` + `VITE_DEMO=1`) wired into installer/`jabali update`.
- Phase 5 — ADR superseding "never merge demo" + README rewrite + retire `feat/demo-mode`.
- Phase 6 — deploy demo host + parity check.

## Test plan
- [x] local prod/demo bundle grep + tsc + eslint + vitest
- [ ] CI (self-hosted) incl. the SPA demo-gate step