### PR TITLE
fix(ui): Server Settings fills content width like other admin pages

### DIFF
--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -955,7 +955,7 @@ export const ServerSettingsPage = () => {
   const [activeTab, setActiveTab] = useTabParam<SettingsTabKey>("general");
 
   return (
-    <div style={{ maxWidth: 960 }}>
+    <div>
       <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
         <SettingOutlined /> Server Settings
       </Typography.Title>


### PR DESCRIPTION
**Reported:** the Server Settings page/cards are a bit narrower than every other admin page.

**Cause:** `ServerSettingsPage` wraps its whole body in `<div style={{ maxWidth: 960 }}>`. No other admin page has a page-level width cap — they render straight into the shell's padded `<Content>` (`AdminLayout.tsx`, `padding: 32px 24px 24px`). So Server Settings alone stopped short on the right.

**Fix:** drop the `maxWidth: 960` cap so the page fills the content area like the rest.

## Test plan
- [x] `tsc -b` + `eslint` clean
- [ ] CI
- [ ] Visual: Server Settings cards now span the same width as Users/Domains/etc.