### PR TITLE
feat(demo): demo deploy profile drives the build tags (JAB-159 phase 3)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4684,6 +4684,13 @@ ensure_swap() {
   _ok "build-swap: 2 GB active at $swap_file (persists via /etc/fstab); vm.swappiness=10"
 }
 
+# JAB-159 phase 3: echo the host deploy profile. "demo" selects a demo build
+# (-tags demo + VITE_DEMO=1); absent/unreadable = production (empty output).
+_deploy_profile() {
+  local f=/etc/jabali/deploy-profile
+  [ -r "$f" ] && tr -d "[:space:]" < "$f" 2>/dev/null || true
+}
+
 build_frontend() {
   ensure_swap
   _log "building panel-ui (npm ci + npm run build)"
@@ -4712,10 +4719,13 @@ build_frontend() {
   # service installs (MariaDB postinst, CrowdSec hub-data fetch,
   # PHP-FPM enable) win contention. Adds ~5-10s to total build
   # time on a fully-loaded box; ~0s on an idle one.
+  local vite_demo=""
+  [ "$(_deploy_profile)" = "demo" ] && { vite_demo="VITE_DEMO=1"; _log "demo profile active: building panel-ui with VITE_DEMO=1"; }
   sudo -u "$SERVICE_USER" -H env \
     HOME="$REPO_DIR" \
     PATH="/usr/bin:/bin" \
     NODE_OPTIONS="--max-old-space-size=2048" \
+    $vite_demo \
     bash -c "cd '$REPO_DIR/panel-ui' && nice -n 19 ionice -c 3 npm run build"
   _ok "panel-ui built → $REPO_DIR/panel-ui/dist/"
 
@@ -4781,6 +4791,8 @@ build_backend() {
   # update.go (gitRevParseAsUser + ldflagsAPI) so the version string
   # survives both install.sh AND every `jabali update` cycle.
   local panel_ld="-s -w"
+  local panel_tags=""
+  [ "$(_deploy_profile)" = "demo" ] && { panel_tags="-tags demo"; _log "demo profile active: building panel-api with -tags demo"; }
   panel_ld+=" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.Version=$version"
   panel_ld+=" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.Commit=$full_sha"
   panel_ld+=" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.BuildTime=$btime"
@@ -4792,7 +4804,7 @@ build_backend() {
     GOCACHE="$REPO_DIR/.cache/go-build" \
     GOMODCACHE="$REPO_DIR/.cache/go-mod" \
     bash -c "cd '$REPO_DIR' && \
-      go build -trimpath -ldflags '$panel_ld' -o '$tmp_panel' ./panel-api/cmd/server && \
+      go build -trimpath $panel_tags -ldflags '$panel_ld' -o '$tmp_panel' ./panel-api/cmd/server && \
       go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_agent' ./panel-agent/cmd/jabali-agent && \
       go build -trimpath -ldflags '-s -w' -o '$tmp_sshshell' ./panel-agent/cmd/jabali-ssh-shell && \
       go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_mailhook' ./panel-agent/cmd/jabali-mailhook"

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -585,6 +585,16 @@ source ` + installSh + ` && install_nginx_default_vhost && install_nginx_websock
 
 	// Build/apply steps — run only when HEAD moved OR --force was passed.
 	// Keep in lockstep with the install.sh counterparts they mirror.
+	// JAB-159 phase 3: /etc/jabali/deploy-profile == "demo" selects a demo
+	// build (-tags demo + VITE_DEMO=1). Absent/other = production. Read once
+	// and folded into the per-artifact rebuild hashes below so flipping the
+	// profile forces a rebuild of the affected artifacts.
+	demoProfile := ""
+	if b, err := os.ReadFile("/etc/jabali/deploy-profile"); err == nil {
+		demoProfile = strings.TrimSpace(string(b))
+	}
+	demoBuild := demoProfile == "demo"
+
 	buildSteps := []struct {
 		name string
 		fn   func() error
@@ -1084,6 +1094,7 @@ test -x node_modules/.bin/tsc || {
 				"panel-ui/tsconfig.node.json",
 				"panel-ui/package-lock.json",
 			)
+			want += "|profile:" + demoProfile
 			if artifactUnchanged("vite", want, repoDir+"/panel-ui/dist/index.html") {
 				fmt.Println("  (vite build skipped: src + config + lockfile unchanged + dist intact)")
 				return nil
@@ -1110,7 +1121,11 @@ test -x node_modules/.bin/tsc || {
 			// node within budget; transient garbage pressure rises but
 			// the build actually completes.
 			viteBuild := func() error {
-				bashCmd := "NODE_OPTIONS=\"--max-old-space-size=$(awk '/MemTotal/{print int($2*0.5/1024)}' /proc/meminfo)\" npm run build"
+				viteEnv := ""
+				if demoBuild {
+					viteEnv = "VITE_DEMO=1 "
+				}
+				bashCmd := viteEnv + "NODE_OPTIONS=\"--max-old-space-size=$(awk '/MemTotal/{print int($2*0.5/1024)}' /proc/meminfo)\" npm run build"
 				return asUser(repoDir+"/panel-ui", "bash", "-c", bashCmd)
 			}
 			buildErr := viteBuild()
@@ -1178,6 +1193,7 @@ test -x node_modules/.bin/tsc || {
 			// and the binary is skipped — shipping a stale binary against
 			// a new unit/config. Same failure mode #255 fixed for dist.
 			apiInputs := compositeSHA("panel-api", "agentwire", "internal", "go.mod", "go.sum", "panel-ui/dist/index.html")
+			apiInputs += "|profile:" + demoProfile
 			agentInputs := compositeSHA("panel-agent", "agentwire", "internal", "go.mod", "go.sum")
 			apiSkip := artifactUnchanged("panel-api-bin", apiInputs, defaultPanelBinPath)
 			agentSkip := artifactUnchanged("panel-agent-bin", agentInputs, defaultAgentBinPath)
@@ -1210,8 +1226,12 @@ test -x node_modules/.bin/tsc || {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					apiErr = asUser(repoDir, goBin, "build", "-trimpath", "-ldflags", ldflagsAPI,
-						"-o", repoDir+"/bin/jabali-panel.new", "./panel-api/cmd/server")
+					apiArgs := []string{"build", "-trimpath"}
+					if demoBuild {
+						apiArgs = append(apiArgs, "-tags", "demo")
+					}
+					apiArgs = append(apiArgs, "-ldflags", ldflagsAPI, "-o", repoDir+"/bin/jabali-panel.new", "./panel-api/cmd/server")
+					apiErr = asUser(repoDir, goBin, apiArgs...)
 				}()
 			}
 			if !agentSkip {


### PR DESCRIPTION
JAB-159 phase 3. Phases 1–2 added the Go build-tag gate and the SPA `VITE_DEMO` gate. This makes **both build paths self-select them** from a persistent marker, so a demo host stays a demo build across every `jabali update` — no rebasing, ever.

## Marker
`/etc/jabali/deploy-profile` containing `demo` selects a demo build (`-tags demo` + `VITE_DEMO=1`). Absent / anything else = production.

## Changes
- **`install.sh`** — `_deploy_profile` helper; `build_frontend` runs the SPA build with `VITE_DEMO=1` and `build_backend` adds `-tags demo` to the panel-api `go build` when the profile is `demo`.
- **`update.go`** (`jabali update`) — reads the profile once; the vite step runs with `VITE_DEMO=1` and the panel-api build gets `-tags demo` when demo. The profile is **folded into the vite + panel-api rebuild hashes** (`uiInputs`/`apiInputs`) so flipping the profile forces a rebuild of exactly those artifacts (guards against the per-artifact skip silently keeping the wrong variant).

Only the **panel-api** binary gets the tag (agent/ssh-shell/mailhook have no demo code) and only the **SPA** gets `VITE_DEMO`; agent build + npm ci are untouched.

## Verified
- `make demo-guard` green (prod excludes `demo_mode`, demo build includes it)
- `go vet` + `gofmt` clean; `install.sh` syntax check + phantom-function lint clean

## Deferred (later JAB-159 phases)
- Phase 5 — ADR superseding "never merge demo" + README documenting the marker + retire `feat/demo-mode`.
- Phase 6 — set the marker on the demo host + parity check.
- An installer/TUI profile *picker* is optional polish; the marker file is the mechanism and can be written directly (`echo demo > /etc/jabali/deploy-profile`).

## Test plan
- [x] make demo-guard / go vet / gofmt / install.sh lint local
- [ ] CI (self-hosted)