### PR TITLE
docs(demo): ADR-0160 + README for build-tag demo mode; supersede never-merge (JAB-159 phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,32 +48,34 @@
 - Website: https://jabali-panel.com/
 - Demo: https://demo.jabali-panel.com
 
-### Demo mode (the `feat/demo-mode` branch)
+### Demo mode (build-tag gated, on `main`)
 
-The public demo at `https://demo.jabali-panel.com` runs **demo mode**, which
-lives on the long-lived **`feat/demo-mode`** branch (open PR, e.g. #103) and is
-**intentionally never merged to `main`**.
+The public demo at `https://demo.jabali-panel.com` runs **demo mode**. As of
+JAB-159 it lives on `main`, gated **out of production artifacts at compile time**
+(see [ADR-0160](docs/adr/0160-build-tag-demo-mode.md)). It is not a runtime toggle
+and there is no `feat/demo-mode` branch to rebase.
 
-What demo mode adds:
+What demo mode adds (present only in a demo build):
 
 - write-blocking middleware — every non-idempotent `/api/v1/*` request
   (POST/PUT/PATCH/DELETE) returns `403 {"error":"demo_mode"}`, so visitors can
   browse every read endpoint without ever reaching the agent or a DB write;
 - a `/info` endpoint that **exposes the seeded demo credentials**;
-- a fixed **DEMO banner** + "Enter as admin / Enter as user" buttons that
-  replace the real login form.
+- a fixed **DEMO banner** + "Enter as admin / Enter as user" buttons.
 
-It is config-gated off by default (`[demo] enabled = false`), so it is inert in
-a normal install. It is still kept off `main` on purpose: merging would ship the
-demo middleware, the DEMO banner/login override, and especially the
-credential-exposing `/info` endpoint into **every production binary + SPA** —
-one mis-set toggle away from leaking seeded creds on a real host. Keeping it on
-its own branch means production installs never carry that code at all.
+**Why this is safe on `main`.** The demo Go code carries `//go:build demo` and the
+demo UI is gated behind `import.meta.env.VITE_DEMO === "1"`, so a **production build
+contains none of it** — the write-block, the credential-exposing `/info`, and the
+banner/login override are physically absent from a non-demo binary and SPA bundle.
+CI proves it on every PR (`make demo-guard` + the `demo-guard` / `ui-unit` jobs
+assert a production build has no `demo_mode` / `jabali-demo-banner` markers while a
+demo build does). This is strictly stronger than the old "keep it off a branch and
+hope no one flips a flag" model.
 
-**Operating the demo:** deploy the `feat/demo-mode` branch to the demo host,
-rebase it on `main` when you want newer features, and leave the PR open as the
-deploy/tracking branch — do **not** merge it. Production fixes go to `main` and
-are picked up on the next rebase.
+**Operating the demo:** mark the host with `echo demo > /etc/jabali/deploy-profile`.
+`install.sh` and every `jabali update` then build the panel with `-tags demo` and the
+SPA with `VITE_DEMO=1` automatically — the demo tracks `main` with no rebasing.
+Production hosts leave the file absent (the default) and never carry demo code.
 
 ## Installation
 

--- a/docs/adr/0160-build-tag-demo-mode.md
+++ b/docs/adr/0160-build-tag-demo-mode.md
@@ -1,0 +1,60 @@
+# ADR-0160 — Build-tag-gated demo mode on main (JAB-159)
+
+**Status:** Accepted — JAB-159. **Supersedes** the "never merge `feat/demo-mode`"
+decision that lived in the README "Demo and Website" section. Demo mode now lives on
+`main`, gated out of production artifacts at compile time. Blueprint at
+`plans/jab159-demo-build-tag.md`. Shipped in serial, individually-reviewed slices:
+phase 1 Go build-tag split + CI anti-leak guard (#684), phase 2 SPA `VITE_DEMO` gate
+(#705), phase 3 demo deploy profile wired into `install.sh` + `jabali update` (#707).
+
+## Context
+
+The public demo at `https://demo.jabali-panel.com` runs a read-only "demo mode": a
+write-block that turns every non-idempotent `/api/v1/*` request into
+`403 {"error":"demo_mode"}`, an `/info` endpoint that exposes the *seeded* demo
+credentials, and a fixed banner + "Enter as admin / user" buttons.
+
+That code used to live on a long-lived `feat/demo-mode` branch, **intentionally never
+merged** — the reasoning was that merging would ship the credential-exposing `/info`
+endpoint and the write-block into every production binary + SPA, "one mis-set
+`[demo] enabled` toggle away from leaking seeded creds on a real host." The cost: the
+branch drifted ~1,800 commits behind `main`, so refreshing the demo meant a heavy,
+conflict-prone rebase across heavily-refactored files (`App.tsx`, `Login.tsx`,
+`config.go`, `app.go`). The demo was chronically stale.
+
+## Decision
+
+Keep demo mode on `main`, but gate it so it is **physically absent from production
+artifacts** — a strictly stronger guarantee than a runtime flag.
+
+- **Go:** demo-only files carry `//go:build demo` (`middleware/demo.go` write-block,
+  `api/index_demo_on.go` `/info` handler, `app/demo_on.go` mount). `//go:build !demo`
+  stub files (`*_demo_off.go`) provide no-op equivalents so `app.go`/`index.go` compile
+  both ways. A production (untagged) build contains none of the demo code.
+- **SPA:** the demo UI (`DemoBanner`, `useServiceInfo`) is a dynamic `import()` behind
+  `import.meta.env.VITE_DEMO === "1"`. Vite statically replaces `VITE_DEMO`, so a
+  non-demo build dead-code-eliminates the import and tree-shakes the demo UI out of the
+  bundle.
+- **Deploy profile:** `/etc/jabali/deploy-profile` containing `demo` makes both build
+  paths (`install.sh` and `jabali update`) build the panel with `-tags demo` and the SPA
+  with `VITE_DEMO=1`. Absent / anything else = production. The profile is folded into the
+  per-artifact rebuild hashes so flipping it forces a rebuild of the affected artifacts.
+- **CI anti-leak guard** (`make demo-guard` + the `demo-guard` job, plus a step in the
+  `ui-unit` job): every PR builds both variants and asserts a production binary contains
+  no `demo_mode` marker and a production SPA bundle contains no `jabali-demo-banner`
+  marker, while the demo build contains both. This is what makes demo-on-main safe — the
+  boundary is enforced, not merely intended.
+
+## Consequences
+
+- Demo mode tracks `main` automatically: a demo host refreshes with a plain
+  `jabali update` on the demo profile — no rebasing, ever. The `feat/demo-mode` branch is
+  retired.
+- The security property is now machine-checked. The old "hope the toggle is off" model is
+  replaced by "the code is not in the binary/bundle at all," verified in CI on every PR.
+- The runtime `[demo] enabled` flag still exists **inside** the demo build as a second
+  gate (belt + suspenders), but the build tag is the guarantee.
+- Threat model shift: the risk is no longer "a production host mis-sets a flag" (that code
+  path does not exist in production) but "a build is mistakenly produced with `-tags demo`
+  / `VITE_DEMO=1`." The deploy profile marker + CI guard bound that to an explicit,
+  auditable host-level choice.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -160,6 +160,9 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | [0155](0155-php-fpm-performance-tiers.md) | PHP-FPM performance tiers (package-gated) | Accepted |
 | [0156](0156-send-as-delegation.md) | Send-as delegation (mustMatchSender expression) | Accepted |
 | [0157](0157-automation-write-endpoints.md) | Write-automation endpoints + write scopes (JAB-140) | Accepted |
+| [0158](0158-cacheable-query-param-allowlist.md) | Per-domain cacheable query-param allowlist | Accepted |
+| [0159](0159-per-user-notification-channels.md) | Per-user notification channels + routing (JAB-171) | Accepted |
+| [0160](0160-build-tag-demo-mode.md) | Build-tag-gated demo mode on main (JAB-159) | Accepted |
 <!-- 0133-0140: numbers reserved during planning, no ADR file was ever written (JAB-161). -->
 <!-- /AUTO-GENERATED -->
 


### PR DESCRIPTION
JAB-159 phase 5 (docs half). Records what phases 1–3 (#684/#705/#707) implemented and retires the "never merge `feat/demo-mode`" stance.

- **`docs/adr/0160-build-tag-demo-mode.md`** — new ADR: build-tag/`VITE_DEMO` gating + the `/etc/jabali/deploy-profile` marker + the CI anti-leak guard as the threat model that **supersedes** keeping demo on an unmerged branch. Demo code is physically absent from production artifacts, machine-checked on every PR.
- **`README.md` "Demo and Website"** — rewritten to describe build-tag demo mode on `main` + the marker; dropped the stale `#103` reference and the never-merge branch operating instructions.
- **`docs/adr/README.md`** — indexed 0158/0159/0160 (0158/0159 were missing).

Branch retirement (`feat/demo-mode`) is a separate step — no open PR depends on it.

## Test plan
- [x] markdown only; grep confirms no stale `#103` / never-merge language remains
- [ ] CI