### PR TITLE
feat(demo): block Kratos self-service writes on demo hosts (JAB-159 phase 6)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6019,6 +6019,34 @@ install_nginx_panel_vhost() {
     _die "unsubstituted \${VAR} placeholders left in $panel_vhost_file — template drift?"
   fi
 
+  # JAB-159 phase 6: on a demo host, block Kratos self-service credential +
+  # recovery WRITES. The Go demo middleware only guards /api/v1; /.ory is
+  # reverse-proxied to Kratos, so without this a shared-cred demo visitor could
+  # change the password (bricking login) or trigger recovery. Reads (viewing the
+  # settings page) still work. A regex location wins over the prefix `location /`.
+  if [[ "$(_deploy_profile)" == "demo" ]]; then
+    local guard_file; guard_file="$(mktemp)"
+    cat > "$guard_file" <<'GUARD'
+  location ~ ^/\.ory/self-service/(settings|recovery) {
+    limit_except GET HEAD OPTIONS { deny all; }
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_http_version 1.1;
+  }
+GUARD
+    sed -i -e "/# __JAB159_DEMO_SELFSERVICE_GUARD__/{r ${guard_file}
+d}" "$panel_vhost_file"
+    rm -f "$guard_file"
+    _log "demo profile: nginx blocks Kratos self-service settings/recovery writes"
+  else
+    sed -i '/# __JAB159_DEMO_SELFSERVICE_GUARD__/d' "$panel_vhost_file"
+  fi
+
   ln -sf "$panel_vhost_file" "${nginx_enabled_dir}/jabali-panel.conf"
 
   # The vhost template hard-`include`s the phpMyAdmin + Adminer snippets.

--- a/install/nginx/jabali-panel-vhost.conf.tmpl
+++ b/install/nginx/jabali-panel-vhost.conf.tmpl
@@ -173,6 +173,7 @@ server {
   # /.ory/* is handled by panel-api itself (in-process reverse proxy
   # to the Kratos public socket). nginx just forwards to the panel
   # upstream — no special-case for /.ory/.
+  # __JAB159_DEMO_SELFSERVICE_GUARD__ (rendered by install_nginx_panel_vhost when deploy-profile=demo)
   location / {
     proxy_pass http://jabali_panel_api/;
     # Use $http_host to preserve port number (mx.jabali-panel.local:8443)


### PR DESCRIPTION
Closes the last gap in the JAB-159 build-tag demo: the Go demo middleware only guards `/api/v1`, but `/.ory/self-service` is reverse-proxied to Kratos, so on a shared-credential public demo a visitor could **change the password (brick login)** or trigger recovery.

Kratos config can't disable settings-password without also breaking login (verified via Ory docs — `methods.password.enabled` governs both login and settings), so this gates it at nginx.

## Change
`install_nginx_panel_vhost`, when `/etc/jabali/deploy-profile == "demo"`, renders a regex location for `/.ory/self-service/(settings|recovery)` that `limit_except GET HEAD OPTIONS { deny all; }` (reads still render the settings page; all writes 403). Lives in the **vhost render path**, so it survives `jabali update` re-rendering the vhost — which is exactly what silently dropped the old hand-applied overlay. Production renders the vhost with the marker stripped (no demo code in the prod vhost).

## Verified
- Local render simulation: guard present under demo profile, absent (marker stripped) under production
- `install.sh` syntax + phantom-function lint clean

## Deploy
After merge, `jabali update` on the demo host re-renders the vhost with the guard; I'll then confirm `POST /.ory/self-service/settings` → 403.

## Test plan
- [x] local render sim (demo + prod) + install.sh lint
- [ ] CI
- [ ] box: nginx -t + POST /.ory/self-service/settings → 403 after deploy