### PR TITLE
feat(demo): port "Enter as admin/user" quick-enter buttons to Login (JAB-159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,9 @@ jobs:
       - name: demo UI stripped from prod bundle, present in demo build (JAB-159)
         run: |
           cd panel-ui
-          if grep -rq 'jabali-demo-banner' dist/; then echo 'FAIL: demo UI leaked into prod bundle'; exit 1; fi
+          if grep -rq 'jabali-demo-' dist/; then echo 'FAIL: demo UI leaked into prod bundle'; exit 1; fi
           VITE_DEMO=1 NODE_OPTIONS=--max-old-space-size=4096 npm run build
-          if ! grep -rq 'jabali-demo-banner' dist/; then echo 'FAIL: demo build missing demo UI'; exit 1; fi
+          if ! grep -rq 'jabali-demo-' dist/; then echo 'FAIL: demo build missing demo UI'; exit 1; fi
           echo 'SPA demo-gate OK: prod excludes demo UI, demo build includes it'
 
   e2e:

--- a/panel-ui/src/components/DemoQuickEnter.tsx
+++ b/panel-ui/src/components/DemoQuickEnter.tsx
@@ -1,0 +1,58 @@
+// DemoQuickEnter — JAB-159. Two buttons on the Login page that auto-submit the
+// Kratos password flow with the seeded demo identities surfaced by /info, so a
+// visitor doesn't have to copy the creds out of the banner. Renders nothing
+// unless /info reports demo mode.
+//
+// This component is demo-only: Login.tsx imports it via a dynamic import gated
+// on import.meta.env.VITE_DEMO, so a production SPA build tree-shakes it out
+// entirely (the `jabali-demo-quick-enter` marker below is asserted absent from
+// the prod bundle by the ui-unit anti-leak CI step).
+import { Alert, Button, Space } from "antd";
+
+import { useServiceInfo } from "../useServiceInfo";
+
+interface DemoQuickEnterProps {
+  // Fills the Kratos password flow with (identifier, password) and submits it —
+  // wired to Login's onFinish("password", …).
+  onEnter: (identifier: string, password: string) => void;
+}
+
+export function DemoQuickEnter({ onEnter }: DemoQuickEnterProps) {
+  const { data } = useServiceInfo();
+  const demo = data?.demo;
+  if (!demo?.enabled) return null;
+
+  const adminReady = !!(demo.admin_email && demo.admin_password);
+  const userReady = !!(demo.user_email && demo.user_password);
+  if (!adminReady && !userReady) return null;
+
+  return (
+    <Alert
+      type="info"
+      showIcon
+      data-marker="jabali-demo-quick-enter"
+      style={{ marginBottom: 16 }}
+      message="Demo mode"
+      description={
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <span>Jump straight in with a seeded account — no typing needed:</span>
+          <Space wrap>
+            {adminReady && (
+              <Button
+                type="primary"
+                onClick={() => onEnter(demo.admin_email ?? "", demo.admin_password ?? "")}
+              >
+                Enter as admin
+              </Button>
+            )}
+            {userReady && (
+              <Button onClick={() => onEnter(demo.user_email ?? "", demo.user_password ?? "")}>
+                Enter as user
+              </Button>
+            )}
+          </Space>
+        </Space>
+      }
+    />
+  );
+}

--- a/panel-ui/src/pages/Login.tsx
+++ b/panel-ui/src/pages/Login.tsx
@@ -12,7 +12,7 @@
 // new group (usually "totp"). The renderer reads node.group and groups
 // the form visually — each non-default group becomes its own submit
 // button, matching the M5c behaviour the legacy panel had.
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import {
   Alert,
@@ -51,6 +51,14 @@ import {
   type KratosFlow,
   type RenderableField,
 } from "../kratos";
+
+// JAB-159: demo-only quick-enter buttons. VITE_DEMO is a build-time
+// constant, so a non-demo build dead-code-eliminates the import() and
+// tree-shakes DemoQuickEnter out of the production bundle.
+const DemoQuickEnter =
+  import.meta.env.VITE_DEMO === "1"
+    ? lazy(() => import("../components/DemoQuickEnter").then((m) => ({ default: m.DemoQuickEnter })))
+    : null;
 
 export const LoginPage = () => {
   const { t } = useTranslation();
@@ -241,6 +249,15 @@ export const LoginPage = () => {
             </div>
           )}
 
+          {DemoQuickEnter && flow ? (
+            <Suspense fallback={null}>
+              <DemoQuickEnter
+                onEnter={(identifier, password) =>
+                  void onFinish("password", { identifier, password })
+                }
+              />
+            </Suspense>
+          ) : null}
           {flow && <FlowForm flow={flow} onFinish={onFinish} />}
         </Space>
       </Card>


### PR DESCRIPTION
The JAB-159 follow-up: the build-tag demo shows seeded creds in the banner but had no one-click entry — the "Enter as admin/user" buttons lived only on the retired `feat/demo-mode` branch. Ported (recovered the design from the branch SHA).

## What
- **`DemoQuickEnter.tsx`** — reads `/info.demo` and renders "Enter as admin" / "Enter as user" buttons that auto-submit the Kratos password flow (`onFinish("password", {identifier, password})`) with the seeded identities. Renders nothing unless `/info` reports demo mode.
- **`Login.tsx`** — imports it via a dynamic `import()` gated on `import.meta.env.VITE_DEMO`, so a non-demo build tree-shakes it out; renders above the manual login form (which stays available).
- **`ci.yml`** — broadened the ui-unit anti-leak grep from `jabali-demo-banner` to `jabali-demo-` so it also covers the new `jabali-demo-quick-enter` marker.

## Verified
- prod `npm run build`: no `jabali-demo-` / "Enter as admin" in `dist/`
- `VITE_DEMO=1` build: both `jabali-demo-quick-enter` and `jabali-demo-banner` present
- `tsc -b`, `eslint` (0 errors), Login vitest (4) green

## Deploy
After merge, `jabali update --from-source` on the demo picks it up (dev channel). I'll confirm the buttons render + log in.

## Test plan
- [x] tree-shake both ways + tsc + eslint + Login vitest
- [ ] CI
- [ ] demo: buttons render + "Enter as admin" logs in