### PR TITLE
feat(mail): per-domain DMARCbis np + testing tags (GH #648)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -190,6 +190,10 @@ type updateDomainRequest struct {
 	NginxSafeOptions      *models.NginxSafeOptions `json:"nginx_safe_options,omitempty"`
 	IndexPriority         *string                  `json:"index_priority,omitempty"`
 	WebmailEnabled        *bool                    `json:"webmail_enabled,omitempty"`
+	// GH #648 (DMARCbis): per-domain settable np (non-existent subdomain
+	// policy) + t=y testing tag, folded into the canonical _dmarc record.
+	DmarcNP      *string `json:"dmarc_np,omitempty"`
+	DmarcTesting *bool   `json:"dmarc_testing,omitempty"`
 	// GH#181: mail provider + optional DKIM tokens. Pointers so an absent
 	// field in the PATCH leaves the columns untouched. When MailProvider is
 	// present, EmailEnabled + SkipAutoSAN are re-derived from it.
@@ -954,6 +958,19 @@ func (h *domainHandler) update(c *gin.Context) {
 			}
 			domain.RedirectAllTo = &trimmed
 		}
+	}
+
+	// GH #648: DMARCbis np + testing tags (any authorised domain manager).
+	if req.DmarcNP != nil {
+		np := strings.TrimSpace(*req.DmarcNP)
+		if !dnscompile.ValidDMARCNP(np) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "dmarc_np must be empty, none, quarantine, or reject"})
+			return
+		}
+		domain.DmarcNP = np
+	}
+	if req.DmarcTesting != nil {
+		domain.DmarcTesting = *req.DmarcTesting
 	}
 
 	if req.RedirectAllType != nil {

--- a/panel-api/internal/db/migrations/000240_dmarc_np_testing.down.sql
+++ b/panel-api/internal/db/migrations/000240_dmarc_np_testing.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains
+  DROP COLUMN dmarc_np,
+  DROP COLUMN dmarc_testing;

--- a/panel-api/internal/db/migrations/000240_dmarc_np_testing.up.sql
+++ b/panel-api/internal/db/migrations/000240_dmarc_np_testing.up.sql
@@ -1,0 +1,6 @@
+-- GH #648 (DMARCbis): per-domain settable np (non-existent subdomain policy)
+-- and t=y (testing) tags, folded into the canonical _dmarc record by the
+-- reconciler. Empty np = omit (receiver falls back to sp). Schema-only.
+ALTER TABLE domains
+  ADD COLUMN dmarc_np VARCHAR(12) NOT NULL DEFAULT '',
+  ADD COLUMN dmarc_testing TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/dnscompile/dmarc.go
+++ b/panel-api/internal/dnscompile/dmarc.go
@@ -1,0 +1,62 @@
+package dnscompile
+
+// GH #648 (DMARCbis): jabali generates a canonical per-domain _dmarc record.
+// The base policy is fixed (p=quarantine; sp=quarantine; adkim=r; aspf=r); the
+// operator-settable DMARCbis tags are `np` (policy for non-existent subdomains
+// — RFC 9091/DMARCbis) and `t=y` (testing mode, which replaces the retired
+// `pct`). Keeping generation in one place lets the reconciler recognise a
+// jabali-authored record (any canonical variant) and re-render it when the
+// domain's setting changes, WITHOUT clobbering a fully operator-customised
+// _dmarc (mail_provider_reconcile preserves anything not in this set).
+
+// DMARCNPValues is the allowlist for the np tag. Empty = omit np (receivers
+// fall back to sp, then p — the pre-DMARCbis behaviour).
+var DMARCNPValues = []string{"none", "quarantine", "reject"}
+
+// ValidDMARCNP reports whether np is empty (omit) or one of the allowed values.
+func ValidDMARCNP(np string) bool {
+	if np == "" {
+		return true
+	}
+	for _, v := range DMARCNPValues {
+		if np == v {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildDMARCString renders jabali's canonical _dmarc TXT content (quoted).
+// BuildDMARCString("", false) is byte-identical to the legacy hardcoded record,
+// so pre-#648 records are recognised as canonical (see CanonicalDMARCStrings).
+func BuildDMARCString(np string, testing bool) string {
+	s := `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r`
+	if np == "none" || np == "quarantine" || np == "reject" {
+		s += "; np=" + np
+	}
+	if testing {
+		s += "; t=y"
+	}
+	return s + `"`
+}
+
+// CanonicalDMARCStrings returns every record BuildDMARCString can emit. The
+// reconciler treats a _dmarc whose content is in this set as jabali-authored
+// (safe to re-render); anything else is an operator edit and left untouched.
+func CanonicalDMARCStrings() []string {
+	out := make([]string, 0, (len(DMARCNPValues)+1)*2)
+	for _, np := range append([]string{""}, DMARCNPValues...) {
+		out = append(out, BuildDMARCString(np, false), BuildDMARCString(np, true))
+	}
+	return out
+}
+
+// IsCanonicalDMARC reports whether content is one jabali could have generated.
+func IsCanonicalDMARC(content string) bool {
+	for _, s := range CanonicalDMARCStrings() {
+		if s == content {
+			return true
+		}
+	}
+	return false
+}

--- a/panel-api/internal/dnscompile/dmarc_test.go
+++ b/panel-api/internal/dnscompile/dmarc_test.go
@@ -1,0 +1,51 @@
+package dnscompile
+
+import "testing"
+
+func TestBuildDMARCString(t *testing.T) {
+	const base = `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"`
+	cases := map[string]struct {
+		np      string
+		testing bool
+		want    string
+	}{
+		"default (legacy)": {"", false, base},
+		"np=reject":        {"reject", false, `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r; np=reject"`},
+		"testing":          {"", true, `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r; t=y"`},
+		"np+testing":       {"quarantine", true, `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r; np=quarantine; t=y"`},
+		"bogus np omitted": {"bogus", false, base},
+	}
+	for name, c := range cases {
+		if got := BuildDMARCString(c.np, c.testing); got != c.want {
+			t.Errorf("%s: got %s want %s", name, got, c.want)
+		}
+	}
+}
+
+func TestIsCanonicalDMARC(t *testing.T) {
+	// The pre-#648 hardcoded record must be recognised as canonical so the
+	// reconciler will re-render it (not treat it as an operator edit).
+	if !IsCanonicalDMARC(`"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"`) {
+		t.Error("legacy default must be canonical")
+	}
+	if !IsCanonicalDMARC(BuildDMARCString("reject", true)) {
+		t.Error("np+testing variant must be canonical")
+	}
+	// A hand-tuned record must NOT be canonical → the reconciler leaves it alone.
+	if IsCanonicalDMARC(`"v=DMARC1; p=reject; rua=mailto:dmarc@example.com"`) {
+		t.Error("operator-customised _dmarc must not be treated as canonical")
+	}
+}
+
+func TestValidDMARCNP(t *testing.T) {
+	for _, v := range []string{"", "none", "quarantine", "reject"} {
+		if !ValidDMARCNP(v) {
+			t.Errorf("%q should be valid", v)
+		}
+	}
+	for _, v := range []string{"bogus", "y", "p=reject", "REJECT"} {
+		if ValidDMARCNP(v) {
+			t.Errorf("%q should be invalid", v)
+		}
+	}
+}

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -315,6 +315,13 @@ type Domain struct {
 	DkimPublicKey   *string    `gorm:"type:text" json:"dkim_public_key,omitempty"`
 	EmailEnabledAt  *time.Time `gorm:"type:datetime(6)" json:"email_enabled_at,omitempty"`
 
+	// GH #648 (DMARCbis): operator-settable DMARC tags the reconciler folds
+	// into the canonical _dmarc record (jabali-mail domains only). DmarcNP is
+	// the non-existent-subdomain policy ("", none, quarantine, reject; empty =
+	// omit np -> receiver falls back to sp). DmarcTesting adds t=y.
+	DmarcNP      string `gorm:"column:dmarc_np;type:varchar(12);not null;default:''" json:"dmarc_np"`
+	DmarcTesting bool   `gorm:"column:dmarc_testing;type:tinyint(1);not null;default:0" json:"dmarc_testing"`
+
 	// IsPanelPrimary marks the single domain row auto-registered for the
 	// panel hostname (ADR-0048). Delete-protected at the repo and API
 	// layer; surfaced in Settings → Email. At-most-one is enforced in

--- a/panel-api/internal/reconciler/mail_provider_reconcile.go
+++ b/panel-api/internal/reconciler/mail_provider_reconcile.go
@@ -49,7 +49,7 @@ func (r *Reconciler) reconcileMailProviderRecords(ctx context.Context, zone *mod
 		r.deleteMailScope(ctx, existing, dnscompile.ApexMailManagedBy)
 		r.deleteMailScope(ctx, existing, dnscompile.ProviderMailManagedBy(models.MailProviderM365))
 		r.deleteMailScope(ctx, existing, dnscompile.ProviderMailManagedBy(models.MailProviderGoogle))
-		r.restoreBootstrapApex(ctx, zone, srv, existing, now)
+		r.restoreBootstrapApex(ctx, zone, domain, srv, existing, now)
 		return
 	}
 
@@ -188,9 +188,11 @@ func (r *Reconciler) pruneJabaliMailRecords(ctx context.Context, zone *models.DN
 // _dmarc when they are absent (e.g. after switching back from an external
 // provider that pruned them). Only inserts what's missing — never
 // duplicates an existing apex record.
-func (r *Reconciler) restoreBootstrapApex(ctx context.Context, zone *models.DNSZone, srv *models.ServerSettings, existing []models.DNSRecord, now time.Time) {
+func (r *Reconciler) restoreBootstrapApex(ctx context.Context, zone *models.DNSZone, domain *models.Domain, srv *models.ServerSettings, existing []models.DNSRecord, now time.Time) {
 	hasMX, hasSPF, hasDMARC := false, false, false
-	for _, e := range existing {
+	var dmarcRec *models.DNSRecord
+	for i := range existing {
+		e := existing[i]
 		switch {
 		case e.Name == "@" && e.Type == "MX":
 			hasMX = true
@@ -198,6 +200,7 @@ func (r *Reconciler) restoreBootstrapApex(ctx context.Context, zone *models.DNSZ
 			hasSPF = true
 		case e.Name == "_dmarc" && e.Type == "TXT":
 			hasDMARC = true
+			dmarcRec = &existing[i]
 		}
 	}
 	mk := func(name, typ, content string, prio int) *models.DNSRecord {
@@ -216,9 +219,21 @@ func (r *Reconciler) restoreBootstrapApex(ctx context.Context, zone *models.DNSZ
 			r.log.Warn("mail-provider reconcile: restore SPF", "err", err)
 		}
 	}
+	// GH #648: the canonical _dmarc reflects the domain's DMARCbis settings
+	// (np / testing). Create it when absent; re-render it when a
+	// jabali-authored record has drifted from the current settings. A
+	// fully operator-customised _dmarc (not a canonical variant) is left
+	// untouched.
+	expectedDMARC := dnscompile.BuildDMARCString(domain.DmarcNP, domain.DmarcTesting)
 	if !hasDMARC {
-		if err := r.dnsRecords.Create(ctx, mk("_dmarc", "TXT", `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"`, 0)); err != nil {
+		if err := r.dnsRecords.Create(ctx, mk("_dmarc", "TXT", expectedDMARC, 0)); err != nil {
 			r.log.Warn("mail-provider reconcile: restore DMARC", "err", err)
+		}
+	} else if dmarcRec != nil && dnscompile.IsCanonicalDMARC(dmarcRec.Content) && dmarcRec.Content != expectedDMARC {
+		dmarcRec.Content = expectedDMARC
+		dmarcRec.UpdatedAt = now
+		if err := r.dnsRecords.Update(ctx, dmarcRec); err != nil {
+			r.log.Warn("mail-provider reconcile: re-render DMARC", "err", err)
 		}
 	}
 }

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -333,7 +333,8 @@ func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {
 		"name", "doc_root", "is_enabled", "nginx_custom_directives",
 		"nginx_rules", "nginx_safe_options",
 		"redirect_all_to", "redirect_all_type", "page_redirects",
-		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled", "updated_at",
+		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled",
+		"dmarc_np", "dmarc_testing", "updated_at",
 	).Updates(d).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Popconfirm,
   Card,
+  Select,
   Skeleton,
   Space,
   Switch,
@@ -54,7 +55,11 @@ export const DomainEmailSection = ({ domainId }: Props) => {
   const disableMutation = useDisableDomainEmail();
   const [flipping, setFlipping] = useState(false);
   const qc = useQueryClient();
-  const { data: domain } = useOneQuery<{ webmail_enabled: boolean }>({
+  const { data: domain } = useOneQuery<{
+    webmail_enabled: boolean;
+    dmarc_np?: string;
+    dmarc_testing?: boolean;
+  }>({
     resource: "domains",
     id: domainId,
   });
@@ -86,6 +91,21 @@ export const DomainEmailSection = ({ domainId }: Props) => {
       message.error("Failed to toggle webmail");
     } finally {
       setWmFlipping(false);
+    }
+  };
+
+  const [dmarcSaving, setDmarcSaving] = useState(false);
+  const saveDmarc = async (patch: { dmarc_np?: string; dmarc_testing?: boolean }) => {
+    setDmarcSaving(true);
+    try {
+      await apiClient.patch(`/domains/${domainId}`, patch);
+      qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
+      message.success("DMARC settings saved");
+    } catch (err) {
+      const resp = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
+      message.error(resp?.detail ?? resp?.error ?? "Failed to save DMARC settings");
+    } finally {
+      setDmarcSaving(false);
     }
   };
 
@@ -141,6 +161,48 @@ export const DomainEmailSection = ({ domainId }: Props) => {
             vhost; mail delivery is unaffected.
           </span>
         </Space>
+      )}
+
+      {enabled && (
+        <Card size="small" title="DMARC (DMARCbis)">
+          <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+            <Space align="center" wrap>
+              <span>Non-existent subdomain policy (np):</span>
+              <Select
+                style={{ minWidth: 240 }}
+                loading={dmarcSaving}
+                value={domain?.dmarc_np ?? ""}
+                onChange={(v) => void saveDmarc({ dmarc_np: v })}
+                options={[
+                  { value: "", label: "Inherit subdomain policy (sp)" },
+                  { value: "none", label: "none — monitor only" },
+                  { value: "quarantine", label: "quarantine" },
+                  { value: "reject", label: "reject — strictest" },
+                ]}
+              />
+            </Space>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              DMARCbis <Typography.Text code>np</Typography.Text> sets the policy for mail from{" "}
+              <em>non-existent</em> subdomains (phantom-subdomain protection). Empty = receivers fall
+              back to the subdomain policy (sp).
+            </Typography.Text>
+            <Space align="center" wrap>
+              <Switch
+                checked={domain?.dmarc_testing ?? false}
+                loading={dmarcSaving}
+                onChange={(v) => void saveDmarc({ dmarc_testing: v })}
+              />
+              <span>
+                Testing mode (<Typography.Text code>t=y</Typography.Text>) — receivers evaluate the
+                policy but treat it as monitoring.
+              </span>
+            </Space>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Applies to the panel-managed <Typography.Text code>_dmarc</Typography.Text> record; a
+              hand-edited DMARC record is left untouched.
+            </Typography.Text>
+          </Space>
+        </Card>
       )}
 
       {enabled && !dkim && (


### PR DESCRIPTION
First slice of #648 (DMARCbis). Stalwart 0.16.14 (jabali's pin) already does DKIM2 + DMARCbis evaluation at the MTA; this exposes the two new **settable** DMARCbis tags per domain in the panel.

## What
- **`dnscompile.BuildDMARCString(np, testing)`** renders the canonical `_dmarc`: base `v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r`, plus `; np=<none|quarantine|reject>` (non-existent-subdomain policy) and `; t=y` (testing). `np=""` omits the tag (receivers fall back to `sp`). `BuildDMARCString("", false)` is byte-identical to the old hardcoded record.
- **`CanonicalDMARCStrings` / `IsCanonicalDMARC`** enumerate every record the builder can emit, so the reconciler can tell a jabali-authored `_dmarc` from a hand-edited one.
- **Domain** gains `dmarc_np` + `dmarc_testing` (migration `000240`), added to the Update `Select()` allowlist so they persist.
- **`restoreBootstrapApex`** re-renders `_dmarc` from the domain's settings when the current record is **canonical-but-stale**; creates it from the settings when absent; **leaves an operator-customised `_dmarc` untouched** (preserves the existing invariant — chosen design).
- **domains update handler** accepts `dmarc_np` (validated) + `dmarc_testing`.
- **`DomainEmailSection`**: an np `Select` + a testing `Switch` wired to `PATCH /domains/:id`.

DKIM2 is still an IETF draft (`-04`) and is entirely Stalwart's job — no panel work here; tracked in #648.

## Verified
- Go: `dnscompile`, `reconciler`, `api` (incl. `TestOpenAPICoverage`), domain tests green; `go vet` + `gofmt` clean
- UI: `tsc -b`, `eslint`, domain vitest (7), SPA build clean
- No new route → no `openapi.yaml` change

## Test plan
- [x] unit: BuildDMARCString / IsCanonicalDMARC / ValidDMARCNP; existing reconciler + domain suites
- [ ] CI (self-hosted)
- [ ] box: migration 000240 up/down on a test box; set np=reject on a jabali-mail domain → reconciler re-renders `_dmarc` with `np=reject`; hand-edit `_dmarc` → left untouched