### PR TITLE
test(mail): cover the DMARCbis _dmarc re-render invariant (GH #648)

### DIFF
--- a/panel-api/internal/reconciler/dmarc_rerender_test.go
+++ b/panel-api/internal/reconciler/dmarc_rerender_test.go
@@ -1,0 +1,57 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #648: restoreBootstrapApex re-renders a jabali-authored (canonical) _dmarc
+// to the domain's DMARCbis settings, but leaves an operator-customised record
+// alone. MX + apex SPF are pre-seeded so only the _dmarc path is exercised.
+func dmarcApexExisting(dmarcContent string) []models.DNSRecord {
+	return []models.DNSRecord{
+		{ID: "mx", ZoneID: "z1", Name: "@", Type: "MX", Content: "mail.example.com"},
+		{ID: "spf", ZoneID: "z1", Name: "@", Type: "TXT", Content: `"v=spf1 mx ~all"`},
+		{ID: "dmarc", ZoneID: "z1", Name: "_dmarc", Type: "TXT", Content: dmarcContent},
+	}
+}
+
+func TestRestoreBootstrapApex_ReRendersCanonicalDMARC(t *testing.T) {
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	legacy := `"v=DMARC1; p=quarantine; sp=quarantine; adkim=r; aspf=r"` // canonical default
+	dnsRepo := &fakeDNSRecordRepo{records: map[string]*models.DNSRecord{
+		"dmarc": {ID: "dmarc", ZoneID: "z1", Name: "_dmarc", Type: "TXT", Content: legacy},
+	}}
+	r := &Reconciler{dnsRecords: dnsRepo, log: slog.Default()}
+	dom := &models.Domain{ID: "d1", DmarcNP: "reject", DmarcTesting: true}
+
+	r.restoreBootstrapApex(context.Background(), zone, dom, &models.ServerSettings{},
+		dmarcApexExisting(legacy), time.Now().UTC())
+
+	want := dnscompile.BuildDMARCString("reject", true)
+	if got := dnsRepo.records["dmarc"].Content; got != want {
+		t.Errorf("canonical _dmarc should re-render to %s, got %s", want, got)
+	}
+}
+
+func TestRestoreBootstrapApex_LeavesOperatorCustomDMARC(t *testing.T) {
+	zone := &models.DNSZone{ID: "z1", Name: "example.com"}
+	custom := `"v=DMARC1; p=reject; rua=mailto:dmarc@example.com"` // hand-edited, not canonical
+	dnsRepo := &fakeDNSRecordRepo{records: map[string]*models.DNSRecord{
+		"dmarc": {ID: "dmarc", ZoneID: "z1", Name: "_dmarc", Type: "TXT", Content: custom},
+	}}
+	r := &Reconciler{dnsRecords: dnsRepo, log: slog.Default()}
+	dom := &models.Domain{ID: "d1", DmarcNP: "reject", DmarcTesting: true}
+
+	r.restoreBootstrapApex(context.Background(), zone, dom, &models.ServerSettings{},
+		dmarcApexExisting(custom), time.Now().UTC())
+
+	if got := dnsRepo.records["dmarc"].Content; got != custom {
+		t.Errorf("operator-customised _dmarc must be left untouched, got %s", got)
+	}
+}


### PR DESCRIPTION
Follow-up test for #711. The DMARC re-render (`restoreBootstrapApex`) merged without a dedicated test and can't be live-verified on the demo (read-only DB). Adds two reconciler tests: a canonical `_dmarc` re-renders to the domain's `np`/`testing` settings; an operator-customised `_dmarc` is left untouched.

Migration 000240 up/down already verified on testserver (real `domains` table).

## Test plan
- [x] both tests pass locally (`go test -run RestoreBootstrapApex`)
- [ ] CI