### PR TITLE
fix(backups): persist chosen content on account backup jobs (GH #454)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -377,6 +377,18 @@ type createBackupRequest struct {
 // bad value can't reach the agent (restic has only off/auto/max — never gzip/xz).
 func validBackupContent(c string) bool { return models.ValidBackupContent(c) }
 
+// normalizeBackupContent maps the empty request default to "full" so the
+// job row records what the run actually captured (GH #454): the content
+// column drives the Type shown in the backup list. Previously the create
+// left Content unset -> GORM applied the column default 'full' -> every
+// account backup showed as "Account Backup" regardless of files/db choice.
+func normalizeBackupContent(c string) string {
+	if c == "" {
+		return models.BackupContentFull
+	}
+	return c
+}
+
 func validBackupCompression(c string) bool {
 	switch c {
 	case "", "off", "auto", "max":
@@ -418,6 +430,7 @@ func (h *backupHandler) createForUser(c *gin.Context) {
 		UserID:        user.ID,
 		DestinationID: &destID,
 		Kind:          models.BackupJobKindAccountBackup,
+		Content:       normalizeBackupContent(req.Content),
 		SystemdUnit:   "",
 		CreatedAt:     time.Now().UTC(),
 		Status:        models.BackupJobStatusQueued,
@@ -1401,6 +1414,7 @@ func (h *meBackupHandler) create(c *gin.Context) {
 		ID:        ids.NewULID(),
 		UserID:    user.ID,
 		Kind:      models.BackupJobKindAccountBackup,
+		Content:   normalizeBackupContent(req.Content),
 		CreatedAt: time.Now().UTC(),
 		Status:    models.BackupJobStatusQueued,
 	}

--- a/panel-api/internal/api/backups_content_test.go
+++ b/panel-api/internal/api/backups_content_test.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #454: the account-backup create must persist the chosen content on the job
+// row so the backup list shows the real Type. An empty request means "full";
+// everything else passes through. Before the fix the create left Content unset,
+// so GORM applied the column default 'full' and every backup showed as
+// "Account Backup" regardless of the files/database choice.
+func TestNormalizeBackupContent(t *testing.T) {
+	if got := normalizeBackupContent(""); got != models.BackupContentFull {
+		t.Errorf("empty should normalize to %q, got %q", models.BackupContentFull, got)
+	}
+	for _, c := range []string{"full", "files", "database", "folders"} {
+		if got := normalizeBackupContent(c); got != c {
+			t.Errorf("%q should pass through unchanged, got %q", c, got)
+		}
+	}
+}


### PR DESCRIPTION
**Root cause of "Type always shows Account Backup"** (lxsdevcode, still reproducing after #700).

The account-backup create passed `req.Content` to the agent and used it to select databases/mailboxes, but **never set `Content` on the `BackupJob` row**. The `content` column is `default:'full'`, so GORM omitted the zero value and the DB stored `full` for *every* account backup — a database-only or files-only run was recorded as full. #700 fixed the *display* (Type reads the run's content), but with the stored content always `full`, it can only ever show "Account Backup".

Both account-create sites now persist `normalizeBackupContent(req.Content)` (`"" → full`; `files`/`database`/`folders` pass through). With #700 + this, a database-only run shows **Database Backup**, files-only **Files Backup**, full/mixed **Account Backup**.

Note: the reporter is on the **stable** channel, which currently lags main and has **neither** #700 nor this fix — both need to reach their channel (next stable promotion) before they'll see it.

## Test plan
- [x] `normalizeBackupContent` unit test; build + openapi coverage green
- [ ] CI
- [ ] box: create a database-only backup → `backup_jobs.content = 'database'` → list shows "Database Backup"