### PR TITLE
fix(python-apps): scaffold resolves interpreter via PATH, not hardcoded /usr/bin (GH #357)

### DIFF
--- a/panel-agent/internal/commands/python_app_scaffold.go
+++ b/panel-agent/internal/commands/python_app_scaffold.go
@@ -113,7 +113,15 @@ func pythonAppScaffoldHandler(ctx context.Context, params json.RawMessage) (any,
 	}
 
 	venv := filepath.Join(p.AppRoot, "venv")
-	pyBin := "/usr/bin/python" + p.PythonVersion
+	// GH #357: resolve the interpreter via the user's PATH (matching
+	// python_app_apply.go) rather than hardcoding /usr/bin. app.python.versions
+	// offers any python3.X found on PATH, so a version installed outside
+	// /usr/bin — e.g. a source `make altinstall` under /usr/local/bin, the
+	// only way to get an EOL interpreter like 3.8 on Debian 13 — would be
+	// offered + accepted, then die here with "no such file" and leave the app
+	// stuck pending. PATH resolution (as the user) fixes that + is consistent
+	// with the apply path.
+	pyBin := "python" + p.PythonVersion
 
 	// 1) venv (GH#357: python<ver>-venv package prerequisite).
 	if _, err := os.Stat(filepath.Join(venv, "bin", "python")); err != nil {


### PR DESCRIPTION
**Root cause of webquest-nz's "agent error / stuck pending" with a `make altinstall` Python 3.8.**

The three python-app paths disagreed on how to find the interpreter:
- `app.python.versions` (`python_app_versions.go`) discovers via **PATH** (`exec.LookPath("python3.8")`) — so a `/usr/local/bin/python3.8` (source `make altinstall`, the only way to get EOL 3.8 on Debian 13) **is offered**.
- `python_app_apply.go` creates its venv with a **PATH-resolved** `python<ver>` — works.
- **`python_app_scaffold.go` hardcoded `/usr/bin/python<ver>`** — so the offered/accepted 3.8 dies at `python3.8 -m venv` ("no such file"), leaving the app stuck pending with a cryptic agent error.

Fix: scaffold now uses `python<ver>` (PATH-resolved as the user), consistent with apply + discovery.

## Test plan
- [x] build + vet + `go test -run Python|Scaffold` green; gofmt clean
- [ ] CI
- [ ] box: `make altinstall` python3.X under /usr/local/bin → create a python app on that version → venv scaffolds + app comes up (was: stuck pending)

Note: the reporter is on a stale build (`fd5f854b`); this + the earlier reconcile/venv-package fixes reach them via `jabali update` (now on stable).