### PR TITLE
fix(backups): correct admin Source + System/Full-Server Type labels (GH #502)

### DIFF
--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -65,6 +65,7 @@ type BackupRunSummary struct {
 	ScheduleID    *string   `json:"schedule_id,omitempty"`
 	Kind          string    `json:"kind"`
 	Content       string    `json:"content"`
+	HasAccounts   bool      `json:"has_accounts"`
 	Total         int       `json:"total"`
 	Succeeded     int       `json:"succeeded"`
 	Failed        int       `json:"failed"`
@@ -182,6 +183,7 @@ func (r *backupJobRepo) ListRuns(ctx context.Context, limit, offset int) ([]Back
 		ScheduleID    *string
 		Kind          string
 		Content       string
+		HasAccounts   bool
 		Total         int
 		Succeeded     int
 		Failed        int
@@ -201,6 +203,7 @@ SELECT run_id                                                             AS run
        MAX(kind)                                                          AS kind,
        CASE WHEN COUNT(DISTINCT content) = 1 THEN MAX(content)
             ELSE 'full' END                                              AS content,
+       SUM(kind = 'account_backup') > 0                                  AS has_accounts,
        COUNT(*)                                                           AS total,
        SUM(status = 'succeeded')                                          AS succeeded,
        SUM(status = 'failed')                                             AS failed,
@@ -229,6 +232,7 @@ SELECT run_id                                                             AS run
 			ScheduleID:    x.ScheduleID,
 			Kind:          x.Kind,
 			Content:       x.Content,
+			HasAccounts:   x.HasAccounts,
 			Total:         x.Total,
 			Succeeded:     x.Succeeded,
 			Failed:        x.Failed,
@@ -337,7 +341,6 @@ func (r *backupJobRepo) MarkFinished(
 	}
 	return nil
 }
-
 
 // ListByStatusSince implements BackupJobRepository.
 func (r *backupJobRepo) ListByStatusSince(ctx context.Context, status string, since time.Time, limit int) ([]models.BackupJob, error) {

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -57,6 +57,7 @@ interface BackupJob {
 interface BackupRun {
   run_id: string;
   schedule_id?: string;
+  has_accounts?: boolean;
   kind: string;
   content?: string;
   total: number;
@@ -518,9 +519,14 @@ export const AdminBackupsPage = () => {
               },
               {
                 title: "Source",
-                sorter: (a, b) => Number(a.isRun) - Number(b.isRun),
+                // GH #502: manual vs scheduled is the run's schedule_id (set only
+                // by the scheduler) — NOT whether jobs are grouped into a run. A
+                // manual Full Server backup is a grouped run with no schedule_id,
+                // and was wrongly labelled "scheduled run" before.
+                sorter: (a, b) =>
+                  Number(a.isRun && !!a.run.schedule_id) - Number(b.isRun && !!b.run.schedule_id),
                 render: (_: unknown, row: TableRow) =>
-                  row.isRun ? (
+                  row.isRun && row.run.schedule_id ? (
                     <Tag color="geekblue">scheduled run</Tag>
                   ) : (
                     <Tag>manual</Tag>
@@ -532,8 +538,9 @@ export const AdminBackupsPage = () => {
                 render: (_: unknown, row: TableRow) => {
                   const kind = row.isRun ? row.run.kind : row.job.kind;
                   const content = row.isRun ? row.run.content : row.job.content;
+                  const hasAccounts = row.isRun ? row.run.has_accounts : false;
                   return (
-                    <Tag color={backupTypeColor(kind, content)}>{backupTypeLabel(kind, content)}</Tag>
+                    <Tag color={backupTypeColor(kind, content)}>{backupTypeLabel(kind, content, hasAccounts)}</Tag>
                   );
                 },
               },

--- a/panel-ui/src/utils/backupType.test.ts
+++ b/panel-ui/src/utils/backupType.test.ts
@@ -3,6 +3,15 @@ import { describe, expect, it } from "vitest";
 import { backupTypeLabel } from "./backupType";
 
 describe("backupTypeLabel (GH #454)", () => {
+  it("labels a system_backup with fanned-out accounts as Full Server (GH #502)", () => {
+    expect(backupTypeLabel("system_backup", "full", true)).toBe("Full Server Backup");
+  });
+
+  it("labels a system-only backup (no accounts) as System Backup (GH #502)", () => {
+    expect(backupTypeLabel("system_backup", "full", false)).toBe("System Backup");
+    expect(backupTypeLabel("system_backup")).toBe("System Backup");
+  });
+
   it("labels a database-only account backup as Database Backup, not Account", () => {
     expect(backupTypeLabel("account_backup", "database")).toBe("Database Backup");
   });
@@ -20,7 +29,8 @@ describe("backupTypeLabel (GH #454)", () => {
   });
 
   it("labels system backups/restores by kind regardless of content", () => {
-    expect(backupTypeLabel("system_backup", "full")).toBe("Full Server Backup");
+    // GH #502: a bare system_backup (no fanned-out accounts) is System-only.
+    expect(backupTypeLabel("system_backup", "full")).toBe("System Backup");
     expect(backupTypeLabel("system_restore", "full")).toBe("Server Restore");
     expect(backupTypeLabel("account_restore", "database")).toBe("Account Restore");
   });

--- a/panel-ui/src/utils/backupType.ts
+++ b/panel-ui/src/utils/backupType.ts
@@ -5,15 +5,17 @@
 // "Account Backup". Combine both into one accurate label.
 
 // backupTypeLabel maps (kind, content) to a human "Type".
-//   system_backup           -> Full Server Backup
+//   system_backup (+accounts) -> Full Server Backup; alone -> System Backup
 //   account_backup + database -> Database Backup
 //   account_backup + files/folders -> Files Backup
 //   account_backup + full/""  -> Account Backup
 //   *_restore               -> "… Restore"
-export function backupTypeLabel(kind: string, content?: string | null): string {
+export function backupTypeLabel(kind: string, content?: string | null, hasAccounts?: boolean): string {
   switch (kind) {
     case "system_backup":
-      return "Full Server Backup";
+      // GH #502: a system_backup run that fanned out account backups is a Full
+      // Server backup; one on its own (include_accounts off) is System-only.
+      return hasAccounts ? "Full Server Backup" : "System Backup";
     case "system_restore":
       return "Server Restore";
     case "account_restore":


### PR DESCRIPTION
Two admin-list inconsistencies lxsdevcode reported after #702/#703:

**1. Source: manual Full Server showed "scheduled run".** The Source column keyed off run-vs-job *grouping* (`isRun ? "scheduled run" : "manual"`), but a manual Full Server backup is a grouped run (system + per-account jobs) → mislabelled scheduled. Manual vs scheduled is the run's `schedule_id` (set only by the scheduler). Now: run with `schedule_id` → scheduled; run without → manual.

**2. Type: System-only showed "Full Server Backup".** `backupTypeLabel` mapped every `system_backup` to "Full Server Backup". A system_backup run is Full Server only when it fanned out account backups. Added `has_accounts` to the run summary (`SUM(kind='account_backup')>0`); `backupTypeLabel` now: system + accounts → **Full Server Backup**; system alone → **System Backup**.

The reporter's other Type complaint — a *user* backup always reading "Account Backup" regardless of content — was the persist bug fixed in #713.

Not addressed here (needs your call): item 3 — repackaging Full Server as a *single* archive instead of the current per-account fan-out. That reverses #703's restic-dedup / per-account-restore design; flagged for a separate decision.

## Test plan
- [x] backupType vitest (incl. new System vs Full Server cases); go vet + backup/api tests + openapi coverage; tsc/eslint; SPA build
- [ ] CI