### PR TITLE
fix(ui): header search only lists enabled modules (GH #455)

### DIFF
--- a/panel-ui/src/components/JabaliHeader.tsx
+++ b/panel-ui/src/components/JabaliHeader.tsx
@@ -74,6 +74,10 @@ type JabaliHeaderProps = {
    * the persistent <Sider> is hidden (mobile drawer mode). */
   showMenuButton?: boolean;
   onMenuClick?: () => void;
+  /** GH #455: the shell's capability-filtered nav, so the header search only
+   * offers pages that are actually enabled on this server (matching the
+   * sidebar). Falls back to the full static nav when omitted. */
+  searchNav?: readonly { label: string; path: string }[];
 };
 
 // navSearchOptions builds the "Pages" search results from the shell nav. GH #455:
@@ -92,7 +96,7 @@ export function navSearchOptions(
   return filtered.map((n) => ({ value: `page:${n.path}`, label: t(n.label) }));
 }
 
-export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHeaderProps = {}) {
+export function JabaliHeader({ showMenuButton = false, onMenuClick, searchNav }: JabaliHeaderProps = {}) {
   const { user, logout } = useAuth();
   const { t, i18n } = useTranslation();
   const { token } = theme.useToken();
@@ -147,9 +151,9 @@ export function JabaliHeader({ showMenuButton = false, onMenuClick }: JabaliHead
   const pagesGroup = useMemo<OptionGroup>(
     () => ({
       label: "Pages",
-      options: navSearchOptions(isAdminShell ? adminNav : userNav, query, t),
+      options: navSearchOptions(searchNav ?? (isAdminShell ? adminNav : userNav), query, t),
     }),
-    [isAdminShell, query, t],
+    [isAdminShell, query, t, searchNav],
   );
 
   // Debounced remote fetch. 250ms is tight enough to feel live without

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -106,6 +106,7 @@ export function AdminLayout() {
       <JabaliHeader
         showMenuButton={!isDesktop}
         onMenuClick={() => setDrawerOpen(true)}
+        searchNav={visibleNav}
       />
       <Layout>
         {isDesktop ? (

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -112,6 +112,7 @@ export function UserLayout() {
       <JabaliHeader
         showMenuButton={!isDesktop}
         onMenuClick={() => setDrawerOpen(true)}
+        searchNav={visibleNav}
       />
       <Layout>
         {isDesktop ? (


### PR DESCRIPTION
Follow-up on #455 (lxsdevcode): translation labels were fixed in #701; the remaining issue is the header **search still lists disabled features** (DNS, Docker on a server where they're off), which then dead-end at *"That feature isn't enabled on this server."*

The search built its "Pages" options from the full static `adminNav`/`userNav`, ignoring capabilities. The **sidebar** already hides disabled modules via the `/me/server-capabilities` filter (`visibleNav`). This passes that same capability-filtered nav into `JabaliHeader` as `searchNav`, so search results match what's actually available. Falls back to the full nav if the prop is omitted.

## Test plan
- [x] `tsc -b`, `eslint` (0 errors), JabaliHeader vitest, SPA build
- [ ] CI
- [ ] visual: disable DNS/Docker → search no longer surfaces them