### PR TITLE
fix(migrations): expose carry-over-passwords on the live-SSH import (GH #633, #634)

### DIFF
--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.driveimport.test.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.driveimport.test.tsx
@@ -1,0 +1,102 @@
+// AdminMigrationDetailPage.driveimport.test.tsx — GH #633/#634.
+//
+// Regression guard: the live-SSH "Run import" flow MUST write the plan's
+// `preserve.credentials` before dispatching the import when the operator ticks
+// "Carry over source passwords". The bug (GH #633/#634): this checkbox lived
+// ONLY in CreateMigrationDrawer (the cpmove/quick-create path), so the SSH
+// detail-page flow — pull-source → import — always ran preserve=OFF regardless
+// of intent, and migrated MySQL users + mailboxes silently got fresh passwords.
+//
+// Wire contract locked here (against admin_migrations.go):
+//   checked   → PUT /admin/migrations/:id/plan { preserve:{credentials:true} }
+//               BEFORE POST /admin/migrations/:id/import
+//   unchecked → POST /import only, NO plan write (preserve stays OFF = secure)
+//
+// Only apiClient is mocked; the real AntD Modal/Form/Checkbox run so an
+// AntD/React break surfaces here (tsc / build don't catch those).
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DriveCard } from "./AdminMigrationDetailPage";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { put: vi.fn(), post: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as {
+  put: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+const JOB_ID = "01JOBSSHTEST0000000000000";
+
+function renderDrive() {
+  const qc = new QueryClient();
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        {/* hestiacp = live-SSH (not whm_pkgacct offline) → import enabled */}
+        <DriveCard jobId={JOB_ID} jobState="ready" jobSourceKind="hestiacp" />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+async function openImportAndSetUser() {
+  fireEvent.click(await screen.findByText("3. Run import…"));
+  fireEvent.change(await screen.findByPlaceholderText("e.g. acme"), {
+    target: { value: "notary" },
+  });
+}
+
+describe("DriveCard SSH import — preserve passwords (GH #633/#634)", () => {
+  beforeEach(() => {
+    mocked.put.mockReset().mockResolvedValue({ data: { ok: true } });
+    mocked.post.mockReset().mockResolvedValue({ data: { unit: "unit.service" } });
+  });
+
+  it("writes preserve.credentials plan BEFORE import when the box is ticked", async () => {
+    renderDrive();
+    await openImportAndSetUser();
+    fireEvent.click(screen.getByRole("checkbox"));
+    // Modal OK button label is "Run import"
+    fireEvent.click(screen.getByRole("button", { name: "Run import" }));
+
+    await waitFor(() => expect(mocked.post).toHaveBeenCalled());
+
+    // plan written to the right endpoint with preserve.credentials
+    expect(mocked.put).toHaveBeenCalledWith(
+      `/admin/migrations/${JOB_ID}/plan`,
+      expect.objectContaining({
+        preserve: { credentials: true },
+        areas: expect.objectContaining({ databases: true, mailboxes: true }),
+      }),
+    );
+    // and import dispatched
+    expect(mocked.post).toHaveBeenCalledWith(
+      `/admin/migrations/${JOB_ID}/import`,
+      expect.objectContaining({ target_user: "notary" }),
+    );
+    // ordering: plan write precedes import dispatch
+    expect(mocked.put.mock.invocationCallOrder[0]).toBeLessThan(
+      mocked.post.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does NOT write a plan when the box is left unticked (preserve stays OFF)", async () => {
+    renderDrive();
+    await openImportAndSetUser();
+    fireEvent.click(screen.getByRole("button", { name: "Run import" }));
+
+    await waitFor(() => expect(mocked.post).toHaveBeenCalled());
+    expect(mocked.put).not.toHaveBeenCalled();
+    expect(mocked.post).toHaveBeenCalledWith(
+      `/admin/migrations/${JOB_ID}/import`,
+      expect.objectContaining({ target_user: "notary" }),
+    );
+  });
+});

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   Alert,
   Button,
   Card,
+  Checkbox,
   Collapse,
   Descriptions,
   Empty,
@@ -846,7 +847,10 @@ function FailedCard({ jobId, onDestroyed }: { jobId: string; onDestroyed: () => 
  * 409 anyway, but UI omitting the buttons is clearer than a flashing
  * error.
  */
-function DriveCard({
+// Exported for AdminMigrationDetailPage.driveimport.test.tsx (GH #633/#634):
+// locks the SSH-import wire contract so the preserve-passwords plan write can't
+// regress back to a plan-less import.
+export function DriveCard({
   jobId,
   jobState,
   jobSourceKind,
@@ -858,6 +862,13 @@ function DriveCard({
   const queryClient = useQueryClient();
   const [secretsOpen, setSecretsOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
+  // GH #633/#634: carry source mailbox + DB-user passwords across. Off by
+  // default (trusted same-owner migrations only). The SSH/pull-source flow had
+  // no such control — the checkbox lived only in CreateMigrationDrawer — so
+  // live-SSH imports always ran preserve=OFF regardless of intent. Writing the
+  // plan's `preserve.credentials` here is what the import's migrationPlanPreserve
+  // reads at restore time.
+  const [importPreservePasswords, setImportPreservePasswords] = useState(false);
   const [credKind, setCredKind] = useState<"password" | "private_key">(
     "password",
   );
@@ -919,6 +930,23 @@ function DriveCard({
       target_password?: string;
       target_package_id?: string;
     }) => {
+      // GH #633/#634: when carrying source passwords, write the plan's
+      // `preserve.credentials` BEFORE dispatching the import — the import unit
+      // reads it via migrationPlanPreserve at restore time. A plan with
+      // `preserve` but no `areas` would import NOTHING, so include every area.
+      if (importPreservePasswords) {
+        await apiClient.put(`/admin/migrations/${jobId}/plan`, {
+          areas: {
+            websites: true,
+            databases: true,
+            mailboxes: true,
+            dns: true,
+            ssl: true,
+            cron: true,
+          },
+          preserve: { credentials: true },
+        });
+      }
       const { data } = await apiClient.post(
         `/admin/migrations/${jobId}/import`,
         vals,
@@ -931,6 +959,7 @@ function DriveCard({
       );
       setImportOpen(false);
       importForm.resetFields();
+      setImportPreservePasswords(false);
       refresh();
     },
     onError: (e: unknown) => {
@@ -1166,6 +1195,20 @@ function DriveCard({
           >
             <Input placeholder="ULID — leave blank for default package" />
           </Form.Item>
+          <Checkbox
+            checked={importPreservePasswords}
+            onChange={(e) => setImportPreservePasswords(e.target.checked)}
+            style={{ marginBottom: 8 }}
+          >
+            Carry over source passwords (mailboxes + database users)
+          </Checkbox>
+          <Alert
+            type="warning"
+            showIcon
+            style={{ marginBottom: 8 }}
+            message="Off by default"
+            description="Only for trusted, same-owner migrations. When on, migrated mailboxes and MySQL users keep their ORIGINAL passwords so DB-backed apps (config.php / wp-config.php) keep working with no reset. When off, everything gets fresh passwords."
+          />
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
             Auto-create requires email + password. Pre-existing target
             user matched by username works without these.


### PR DESCRIPTION
## Root cause (GH #633 / #634)

The **"Carry over source passwords (mailboxes + database users)"** checkbox existed **only** in `CreateMigrationDrawer` (the cpmove/quick-create path, which POSTs `/import` directly). The **live-SSH** detail-page flow — *pull-source → run import* — had **no such control** and never called `PUT /plan`. So every SSH-source migration ran with `preserve=OFF` regardless of the operator's intent: migrated **MySQL users and mailboxes silently got fresh passwords**, breaking apps with hardcoded DB creds (`config.php` / `wp-config.php`) until manually reset.

### Confirmed, not guessed
Reproduced the parser against the reporter's **real HestiaCP `v-backup-user` tar**:
- `db/<db>/hestia/db.conf` ships the `mysql_native_password` hash in `MD5=` (`*A…`, 41 chars, `TYPE='mysql'`).
- `ParseDBCredentials` → 1 cred (`user=itflowapp_test hash=*A…len=41`), `normalizeHestiaDBHash` passes it verbatim, `db_user.create` applies it (fix #649's `ALTER USER` already present). **The parse + apply path is correct.**
- The reporter's own run log is the smoking gun:
  ```
  - compat_users: 2 source MySQL user(s) with original password hashes NOT recreated (opt in with --preserve-source-state; ...)
  - mailbox_rows: created ... with a NEW password — the ORIGINAL mail password was NOT migrated ...
  ```
  i.e. `migrationPlanPreserve(job)` returned zero because the job's `PlanJSON` had no `preserve.credentials` — the SSH UI never wrote it.

## Fix
Add the checkbox to the detail-page **Run import** modal and write the preserve plan **before** dispatching the import, mirroring the drawer:

```
PUT  /admin/migrations/:id/plan  { areas:{…all}, preserve:{ credentials:true } }
POST /admin/migrations/:id/import
```

- **Default OFF** (trusted same-owner migrations only) — security posture unchanged.
- One control fixes **both** #633 (DB users) and #634 (mailboxes): `preserve.credentials` gates `ImportDatabases` **and** `ImportMailboxes`.

## Test plan
- [x] `tsc -b` clean
- [x] eslint clean
- [x] `vite build` clean
- [x] New regression test `AdminMigrationDetailPage.driveimport.test.tsx` (real AntD Modal/Form/Checkbox, only `apiClient` mocked):
  - ticked → `PUT /plan` with `preserve.credentials` **before** `POST /import`
  - unticked → `POST /import` only, **no** plan write (preserve stays OFF)
- [ ] Box-verify on testserver: SSH migration with the box ticked → migrated MySQL user keeps source hash + mailbox keeps source password