### PR TITLE
fix(migrations): multi-account bulk drops the preserve plan (GH #633, #634)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -938,6 +938,19 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 		finalState = models.MigrationStatePending
 	}
 
+	// GH #633/#634: the wizard writes the import plan (selected areas +
+	// preserve.credentials) onto the discovery DRAFT job. Bulk children must
+	// INHERIT it — otherwise every multi-account import runs plan-less, so
+	// migrationPlanPreserve returns zero and source mailbox + MySQL-user
+	// passwords are silently reset. secrets_clone already carried the SSH creds
+	// across; the plan was the missing half.
+	var draftPlan *string
+	if req.SourceJobID != "" {
+		if draft, derr := h.cfg.Jobs.FindByID(c.Request.Context(), req.SourceJobID); derr == nil {
+			draftPlan = draft.PlanJSON
+		}
+	}
+
 	batchID := genULID()
 	out := make([]models.MigrationJob, 0, len(req.Accounts))
 	createdIDs := make([]string, 0, len(req.Accounts))
@@ -952,6 +965,7 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 			SourceHost: req.SourceHost,
 			SourceUser: acct,
 			State:      finalState,
+			PlanJSON:   draftPlan, // GH #633/#634: inherit the wizard's preserve plan
 		}
 		if req.AccountTargets != nil {
 			if t := strings.TrimSpace(req.AccountTargets[acct]); t != "" {

--- a/panel-api/internal/api/admin_migrations_bulk_preserve_test.go
+++ b/panel-api/internal/api/admin_migrations_bulk_preserve_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// FindByID lets bulkCreate read the discovery draft's plan (GH #633/#634).
+// Defined on the shared fakeIMAPJobs (admin_migrations_imap_test.go).
+func (f *fakeIMAPJobs) FindByID(_ context.Context, id string) (*models.MigrationJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if j, ok := f.byID[id]; ok {
+		return j, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+// TestBulkCreate_ChildrenInheritDraftPreservePlan guards GH #633/#634.
+//
+// The wizard writes the import plan — selected areas + preserve.credentials —
+// onto the discovery DRAFT job. The multi-account bulk handler must copy that
+// PlanJSON into every child job. The original bug: it cloned only the SSH
+// secret, never the plan, so each child imported with PlanJSON=nil →
+// migrationPlanPreserve returned zero → migrated mailbox + MySQL-user passwords
+// were silently reset even though the operator ticked "Carry over source
+// passwords". This is the path a HestiaCP multi-account SSH migration uses.
+func TestBulkCreate_ChildrenInheritDraftPreservePlan(t *testing.T) {
+	// Agent=nil → inheritSecrets=false, so the secrets_clone precondition is
+	// skipped; the draftPlan copy is gated only on source_job_id, so it still runs.
+	h, jobs := newIMAPHandler(nil)
+
+	plan := `{"areas":{"databases":true,"mailboxes":true},"preserve":{"credentials":true}}`
+	draft := &models.MigrationJob{
+		ID: "DRAFT01", SourceKind: "hestiacp", SourceHost: "web01",
+		SourceUser: "__discovery__", PlanJSON: &plan,
+	}
+	if err := jobs.Create(context.Background(), draft); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"source_kind":"hestiacp","source_host":"web01",` +
+		`"accounts":["notary","acme"],"source_job_id":"DRAFT01"}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	got := 0
+	for id, j := range jobs.byID {
+		if id == "DRAFT01" {
+			continue // the discovery draft itself
+		}
+		if j.PlanJSON == nil {
+			t.Errorf("child %s (%s): PlanJSON is nil — preserve plan NOT inherited", id, j.SourceUser)
+			continue
+		}
+		if *j.PlanJSON != plan {
+			t.Errorf("child %s (%s): PlanJSON=%q, want draft plan %q", id, j.SourceUser, *j.PlanJSON, plan)
+			continue
+		}
+		got++
+	}
+	if got != 2 {
+		t.Fatalf("expected 2 children carrying the draft's preserve plan, got %d", got)
+	}
+}
+
+// TestBulkCreate_NoSourceJob_NoPlan confirms the inheritance is scoped: without
+// a source_job_id there is no draft to copy from, so children stay plan-less
+// (import defaults to all-areas, preserve OFF = secure default).
+func TestBulkCreate_NoSourceJob_NoPlan(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+	body := `{"source_kind":"hestiacp","source_host":"web01","accounts":["solo"]}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	for _, j := range jobs.byID {
+		if j.PlanJSON != nil {
+			t.Errorf("child %s: PlanJSON=%q, want nil (no draft to inherit)", j.ID, *j.PlanJSON)
+		}
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -315,6 +315,11 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
   // ── Step 4: bulk create from selection (WHM) ────────────────────────
   const bulk = useMutation({
     mutationFn: async () => {
+      // GH #633/#634: persist the plan (selected areas + preserve.credentials)
+      // onto the draft FIRST, so the bulk handler can copy it into every child
+      // job. Without this the multi-account path drops the preserve checkbox and
+      // migrated mailbox/MySQL passwords silently reset.
+      await savePlan();
       const { data } = await apiClient.post<{ batch_id: string }>(
         "/admin/migrations/bulk",
         {


### PR DESCRIPTION
## Follow-up to #719 — the reporter still failed after it merged

#719 fixed the **single-account detail-page** path. But the reporter (johnnyq) uses the **multi-account wizard** (HestiaCP discovery → bulk create), and it *still* ran `preserve=OFF`. His run log after updating: `compat_users: … NOT recreated` + mailboxes got NEW passwords — same symptom, different code path.

## Two bugs, both required for the wizard bulk path

1. **API — `bulkCreate` never copied the draft's plan.** It clones the SSH secret to each child (`secrets_clone`) but created each child `MigrationJob` with `PlanJSON=nil`. So every child imported plan-less → `migrationPlanPreserve` = zero → source mailbox + MySQL-user passwords silently reset even with the box ticked. **Fix:** each child inherits the discovery draft's `PlanJSON`.
2. **UI — the wizard's bulk mutation never called `savePlan()`.** `savePlan()` (which writes `preserve.credentials` onto the draft) ran *only* in the single-account `/submit` path — the `/bulk` path dropped the checkbox value before any plan was written. **Fix:** bulk calls `savePlan()` before `POST /bulk`.

Both halves needed: (2) writes preserve onto the draft; (1) propagates it to the children the batch actually imports. One control still covers **#633** (DB users) and **#634** (mailboxes) via `preserve.credentials`.

## Test plan
- [x] `go build ./...`, `go vet ./internal/api/`
- [x] New Go test `TestBulkCreate_ChildrenInheritDraftPreservePlan` — children carry the draft's preserve plan; `TestBulkCreate_NoSourceJob_NoPlan` — no `source_job_id` → plan-less (secure default). Runs the real `bulkCreate` handler (only the repo faked).
- [x] `tsc -b`, eslint, vitest green
- [ ] Box-verify on testserver: draft + preserve plan → `POST /bulk` with `source_job_id` → child jobs carry `plan_json` in the DB