### PR TITLE
fix(security): snuffleupagus off-mode emits invalid sp.global.enable → FPM 500 (GH #718)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12715,9 +12715,11 @@ install_snuffleupagus() {
   install -d -m 0755 /etc/jabali/snuffleupagus
   if [[ ! -f /etc/jabali/snuffleupagus/active.rules ]]; then
     cat > /etc/jabali/snuffleupagus/active.rules <<'EOF_RULES'
-# Jabali Snuffleupagus — placeholder (mode=off). Reconciler overwrites
-# this file when the operator flips mode to simulation or enforce.
-sp.global.enable(0);
+# Jabali Snuffleupagus active rules -- RENDERED, do not edit.
+# mode=off
+# Placeholder empty ruleset. Snuffleupagus v0.13 has no master switch;
+# sp.global.enable is invalid and crashes PHP-FPM (GH #718). The reconciler
+# overwrites this file when the operator flips mode to simulation or enforce.
 EOF_RULES
     chmod 0644 /etc/jabali/snuffleupagus/active.rules
   fi

--- a/install/snuffleupagus/rules/README.md
+++ b/install/snuffleupagus/rules/README.md
@@ -13,7 +13,7 @@ by the panel reconciler into `/etc/jabali/snuffleupagus/active.rules`.
 
 ## Mode rendering
 
-- `mode=off`   →   reconciler emits `sp.global.enable(0);` only.
+- `mode=off`   →   comment-only empty ruleset (no directive; `sp.global.enable` is invalid in v0.13 and fatals PHP-FPM, GH #718).
 - `mode=simulation` → every rule above is wrapped with `.simulation()`
   so it logs without enforcing.
 - `mode=enforce` → rules apply as written.

--- a/panel-agent/internal/commands/security_snuffleupagus.go
+++ b/panel-agent/internal/commands/security_snuffleupagus.go
@@ -54,10 +54,12 @@ func snuffleupagusStatusHandler(ctx context.Context, _ json.RawMessage) (any, er
 	if data, err := os.ReadFile(snuffleupagusActiveRulesPath); err == nil {
 		sum := sha256.Sum256(data)
 		resp.ActiveRulesSha256 = hex.EncodeToString(sum[:])
-		// Heuristic mode read: file starts with "sp.global.enable(0);"
-		// in off mode; otherwise parse `mode=` header line.
+		// Mode read: off is a comment-only (empty) ruleset carrying the
+		// `# mode=off` header (GH #718 — `sp.global.enable(0);` fatals FPM and
+		// is no longer emitted). The legacy `sp.global.enable(0);` marker is
+		// still recognised so a host mid-update reports off correctly.
 		switch {
-		case bytes.Contains(data, []byte("sp.global.enable(0);")):
+		case bytes.Contains(data, []byte("# mode=off")) || bytes.Contains(data, []byte("sp.global.enable(0);")):
 			resp.Mode = "off"
 		case bytes.Contains(data, []byte(".simulation();")):
 			resp.Mode = "simulation"

--- a/panel-api/internal/reconciler/snuffleupagus.go
+++ b/panel-api/internal/reconciler/snuffleupagus.go
@@ -93,7 +93,8 @@ func (r *SnuffleupagusReconciler) Reconcile(ctx context.Context) error {
 }
 
 // renderActiveRules composes the rule bundle for the given mode.
-//   - mode=off:        emit `sp.global.enable(0);` only.
+//   - mode=off:        comment-only (empty ruleset); no directive —
+//                      `sp.global.enable` is invalid in v0.13 and fatals FPM (GH #718).
 //   - mode=simulation: concat the bundle, wrap each rule with .simulation()
 //                      where the directive supports it (drop, default action).
 //   - mode=enforce:    concat the bundle as-is.
@@ -117,7 +118,12 @@ func renderActiveRules(mode models.SnuffleupagusMode, overrides []models.Snuffle
 	buf.WriteString(fmt.Sprintf("# mode=%s rendered_at=%s\n\n", mode, time.Now().UTC().Format(time.RFC3339)))
 
 	if mode == models.SnuffleupagusModeOff {
-		buf.WriteString("sp.global.enable(0);\n")
+		// Snuffleupagus v0.13 has NO master switch: `sp.global.enable(0)` is not
+		// a valid directive — it fatals "Unexpected keyword 'enable'", which
+		// crashes PHP-FPM and 500s every site on the pool (GH #718). "Off" is an
+		// EMPTY ruleset — the extension loads but enforces nothing. The
+		// `# mode=off` header written above is the marker the agent status
+		// handler reads to report the mode.
 		return buf.Bytes(), nil
 	}
 

--- a/panel-api/internal/reconciler/snuffleupagus_offmode_test.go
+++ b/panel-api/internal/reconciler/snuffleupagus_offmode_test.go
@@ -1,0 +1,50 @@
+package reconciler
+
+import (
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestRenderActiveRules_OffModeIsValidEmpty guards GH #718.
+//
+// mode=off must NOT emit `sp.global.enable(0);`. That directive is not valid in
+// the shipped Snuffleupagus (v0.13 — no master switch); it fatals PHP-FPM with
+// "Unexpected keyword 'enable' ... Invalid configuration file ... Could not
+// startup" and 500s every WordPress/PHP site on the pool. "Off" is a
+// comment-only (empty) ruleset carrying the `# mode=off` marker the agent's
+// status handler reads.
+func TestRenderActiveRules_OffModeIsValidEmpty(t *testing.T) {
+	out, err := renderActiveRules(models.SnuffleupagusModeOff, nil)
+	if err != nil {
+		t.Fatalf("renderActiveRules(off): %v", err)
+	}
+	s := string(out)
+
+	if strings.Contains(s, "sp.global.enable") {
+		t.Errorf("off render still emits the invalid sp.global.enable directive:\n%s", s)
+	}
+	if !strings.Contains(s, "# mode=off") {
+		t.Errorf("off render missing the `# mode=off` marker the agent reads:\n%s", s)
+	}
+
+	// Every non-blank line must be a comment — an "off" ruleset carries no
+	// active directive at all (empty ruleset = enforce nothing).
+	for _, ln := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		t.Errorf("off render has a non-comment directive line %q — off must be empty", trimmed)
+	}
+
+	// ASCII-only: any byte > 0x7f (em-dash, smart quote) corrupts the
+	// snuffleupagus lexer and silently swallows subsequent rules.
+	for i := 0; i < len(out); i++ {
+		if out[i] > 0x7f {
+			t.Errorf("off render has non-ASCII byte 0x%x at offset %d — lexer corruption risk", out[i], i)
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Root cause
`mode=off` rendered `active.rules` as `sp.global.enable(0);`. The shipped Snuffleupagus (v0.13) has **no master switch** — that directive is invalid and fatals PHP-FPM:

```
[snuffleupagus][config][log] Unexpected keyword 'enable' on line 4
[snuffleupagus][config][log] Invalid configuration file
Could not startup.
```

Every WordPress/PHP site on an off-mode pool then returns **500**, and Fleet cache doctor shows `Drifted` + `repair failed: agent_failed` — the FPM pool can't start at all, so there's nothing to repair. Reproduced the exact fatal on the shipped `.so` (php8.4); a comment-only ruleset loads clean.

## Fix
"Off" = an **empty ruleset** (extension loads, enforces nothing) carrying a `# mode=off` header marker.
- **reconciler** `renderActiveRules(off)`: drop the directive, return the header only.
- **agent** status handler: detect off via the `# mode=off` header (legacy `sp.global.enable(0);` marker still recognised so a host mid-update reports off correctly).
- **install.sh** placeholder: comment-only + `# mode=off`; also removes a stray **em-dash** (non-ASCII corrupts the snuffleupagus lexer — same scar class).
- **README**: documents the empty-ruleset off form.

## Recovery for already-broken hosts
Self-heals on `jabali update`: boot-reconcile re-renders (new SHA ≠ last-applied) → agent `apply_rules` writes the fixed file **and reloads every per-user FPM pool** → sites come back.

## Test plan
- [x] Repro'd the exact FPM fatal on the shipped snuffleupagus; confirmed comment-only loads clean
- [x] Regression test: off render has no `sp.global.enable`, carries `# mode=off`, is comment-only + ASCII-only
- [x] `go vet`, both binaries build, `bash` syntax + `tools/lint-install-sh.sh` OK
- [x] **Box-verified**: emitted the real off render → loads on testserver's snuffleupagus (php8.4) without the fatal
- [ ] Post-merge: deploy to testserver, flip a site to off, confirm FPM stays up