### PR TITLE
fix(files): folder-sizes instant 502 at home root (GH #657)

### DIFF
--- a/internal/filesafe/openat2_docroot_test.go
+++ b/internal/filesafe/openat2_docroot_test.go
@@ -1,0 +1,33 @@
+package filesafe
+
+import (
+	"os"
+	"testing"
+)
+
+// TestOpenDirInScope_AllowsDocroot guards GH #657.
+//
+// "Folder sizes" / du / list at the user's home ROOT must work. OpenInScope
+// refuses the docroot itself (rel == ".", "refusing to open docroot itself as a
+// file") — a guard meant for file opens. files.du used OpenInScope by mistake,
+// so a du at the home root (what the "Folder sizes" button hits by default)
+// 502'd instantly. OpenDirInScope MUST open the docroot; that is what
+// ReadDirInScope and the fixed files.du rely on.
+func TestOpenDirInScope_AllowsDocroot(t *testing.T) {
+	scope, docroot := funcScope(t)
+
+	// OpenDirInScope on the docroot itself must SUCCEED.
+	df, err := scope.OpenDirInScope(docroot)
+	if err != nil {
+		t.Fatalf("OpenDirInScope(docroot) = %v, want success (GH #657 regression)", err)
+	}
+	_ = df.Close()
+
+	// OpenInScope must STILL refuse the docroot — the file-open guard whose
+	// misuse caused the bug. If this ever starts succeeding, the
+	// OpenInScope-vs-OpenDirInScope distinction (and this fix's rationale) is
+	// gone and files.du could regress back to the wrong method silently.
+	if _, err := scope.OpenInScope(docroot, os.O_RDONLY, 0); err == nil {
+		t.Error("OpenInScope(docroot) unexpectedly succeeded — docroot file-open guard is gone")
+	}
+}

--- a/panel-agent/internal/commands/files_du.go
+++ b/panel-agent/internal/commands/files_du.go
@@ -71,7 +71,13 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	// string path. The fd is passed to the child via ExtraFiles (fd 3) so du
 	// traverses the pinned inode (/proc/self/fd/3) — a parent-directory swap
 	// between resolve and du can no longer redirect root's du outside scope.
-	df, derr := scope.OpenInScope(resolved, os.O_RDONLY, 0)
+	// GH #657: use OpenDirInScope (not OpenInScope). OpenInScope refuses the
+	// docroot itself ("refusing to open docroot itself as a file"), so a du at
+	// the home root — which the "Folder sizes" button hits by default — 502'd
+	// instantly. OpenDirInScope allows rel=="." (the home root) and opens
+	// O_DIRECTORY, exactly what du needs; the sibling ReadDirInScope below
+	// already relies on it for the same path.
+	df, derr := scope.OpenDirInScope(resolved)
 	if derr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("open dir: %v", derr)}
 	}


### PR DESCRIPTION
## Root cause (reproduced)
`files.du` opened the target directory via `scope.OpenInScope(resolved, …)` to hand `du` an escape-proof fd (GH #653). But `OpenInScope` **refuses the docroot itself** — `rel == "."` → `not_in_scope: refusing to open docroot itself as a file`, a guard meant for *file* opens. So a `du` at the user's **home root** — which the "Folder sizes" button hits by default — failed **instantly** with a 502 (which Cloudflare wrapped as its opaque "origin returned an invalid or incomplete response"). #696's 45s timeout guard never applied here: this fails *before* any walk starts. That's why the reporter saw an instant failure, not a timeout.

Reproduced on testserver:
```
GET /api/v1/me/disk-usage/files?path=/home/<user>
502 {"error":"files_du_failed","detail":"agent: internal: open dir: not_in_scope: refusing to open docroot itself as a file"}
```

## Fix
Use `OpenDirInScope`, which exists for exactly this — it **allows** `rel == "."` (the home root) and opens `O_DIRECTORY`, the fd `du` needs. The sibling `ReadDirInScope` call right below already relies on it for the same path, so the two now agree. One-line method swap; no behavior change for subfolders.

## Test plan
- [x] Repro'd the instant 502 on testserver
- [x] Regression test (`internal/filesafe`): `OpenDirInScope` opens the docroot; `OpenInScope` still refuses it
- [x] `go vet`, full build, existing `files.du` tests green
- [x] **Box-verified** with the fixed agent on testserver: `GET /me/disk-usage/files` at the home root → **200** (was 502), both explicit `?path` and default