### PR TITLE
fix(notifications): service.down floods for uninstalled modules (GH #726)

### DIFF
--- a/panel-api/internal/eventsources/service_down.go
+++ b/panel-api/internal/eventsources/service_down.go
@@ -116,8 +116,7 @@ func serviceDownPass(ctx context.Context, d Deps) {
 			// fresh install. service.down is for "should be running but
 			// isn't", not "is configured to start later".
 			enabled, _ := unitEnabled(ctx, unit)
-			switch enabled {
-			case "disabled", "static", "masked", "indirect", "alias", "linked-runtime", "transient":
+			if enabledStateSkips(enabled) {
 				continue
 			}
 		}
@@ -142,6 +141,22 @@ func serviceDownPass(ctx context.Context, d Deps) {
 		}
 		fireServiceDown(ctx, d, unit, state)
 	}
+}
+
+// enabledStateSkips reports whether a `systemctl is-enabled <unit>` result means
+// an inactive unit should NOT fire service.down. Beyond the operator-off states
+// (disabled/static/masked/...), it covers "not-found" and empty: a unit that
+// isn't installed at all. GH #726 -- a Custom install without mail/DNS/PostgreSQL
+// leaves those units absent (`is-enabled` -> "not-found", `is-active` ->
+// "inactive"), and the monitor flooded the inbox with service.down for modules
+// the operator never selected. service.down is for "an ENABLED unit that should
+// be running is down", not "this module was never installed".
+func enabledStateSkips(enabled string) bool {
+	switch enabled {
+	case "", "not-found", "disabled", "static", "masked", "indirect", "alias", "linked-runtime", "transient":
+		return true
+	}
+	return false
 }
 
 // unitEnabled returns the `systemctl is-enabled <unit>` string. Empty

--- a/panel-api/internal/eventsources/service_down_test.go
+++ b/panel-api/internal/eventsources/service_down_test.go
@@ -19,3 +19,26 @@ func TestServiceStateNotDown(t *testing.T) {
 		}
 	}
 }
+
+// TestEnabledStateSkips guards GH #726: a Custom install without mail/DNS/
+// PostgreSQL leaves those units absent, so `systemctl is-enabled` returns
+// "not-found". The monitor must SKIP them (not flood the inbox with
+// service.down for modules the operator never installed), while still firing
+// for a genuinely enabled unit that's down.
+func TestEnabledStateSkips(t *testing.T) {
+	// uninstalled / operator-off / transient-check-fail -> skip (no alert)
+	for _, s := range []string{
+		"", "not-found", "disabled", "static", "masked",
+		"indirect", "alias", "linked-runtime", "transient",
+	} {
+		if !enabledStateSkips(s) {
+			t.Errorf("enabledStateSkips(%q) = false, want true (uninstalled/disabled must not alert)", s)
+		}
+	}
+	// genuinely enabled (should be running) -> DO fire on inactive
+	for _, s := range []string{"enabled", "enabled-runtime", "generated"} {
+		if enabledStateSkips(s) {
+			t.Errorf("enabledStateSkips(%q) = true, want false (an enabled-but-down unit must alert)", s)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause
A **Custom** install without mail/DNS/PostgreSQL leaves those units absent. The `service.down` monitor already skipped operator-off states (`disabled`/`static`/`masked`/…) but **not `not-found`** — and a not-installed unit reports `is-enabled` → **`not-found`**, `is-active` → **`inactive`**. So the monitor fired `service.down` for `jabali-stalwart` / `pdns` / etc. that were never installed → 100+ alerts for modules the operator deliberately didn't select.

Confirmed on a real box:
```
systemctl is-enabled <absent-unit>  → not-found (exit 4)
systemctl is-active  <absent-unit>  → inactive
```

## Fix
Skip `not-found` (and empty — a transient `is-enabled` check failure) as well. Extracted the decision into a pure `enabledStateSkips()` so it's unit-tested:
- uninstalled (`not-found`) / operator-off (`disabled`/`static`/…) / transient (empty) → **skip**
- genuinely `enabled` (or `enabled-runtime`/`generated`) but down → **still fires**

## Test plan
- [x] Unit test `TestEnabledStateSkips` (uninstalled/disabled skip; enabled fires)
- [x] `go vet`, full panel-api build, existing `TestServiceStateNotDown` green
- [x] Verified real systemd behavior for an absent unit (`not-found`/`inactive`)

## Not in this PR
The issue's **secondary** ask — clicking a notification should open the **History** tab (and highlight the item) instead of the Notifications index — is a separate UX change (routing + highlight-by-id). Tracking as a follow-up.