### PR TITLE
fix(migrate): key app-config creds by source DB name so multi-DB WordPress migrations rewrite wp-config (GH #723)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_appconfigs_gh723_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs_gh723_test.go
@@ -1,0 +1,174 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #723 — migrated WordPress (and Joomla/Drupal/Magento) sites end up with a
+// broken DB config after migration. Reproduced on johnnyq's REAL HestiaCP
+// backup (notary.2026-07-27_12-55-08.tar): the account has two databases,
+// notary_45635 (WordPress, sewickleynotary.com) and notary_itflow (itFlow).
+//
+// johnnyq's actual wp-config.php DB block (verbatim from the backup):
+//
+//	define( 'DB_NAME', 'notary_45635' );
+//	define( 'DB_USER', 'notary_45635' );
+//	define( 'DB_PASSWORD', 'e4eb22f97bb143151c95' );
+//	define( 'DB_HOST', 'localhost' );
+//
+// Root cause: ImportDatabases keyed res.Credentials by the NAMESPACED
+// destination name (finalName = <target>_<logical>), but the app-config
+// rewriters look the credential up by the SOURCE DB name they read out of the
+// config file. Keying by finalName only ever matched when the target account
+// shared the source's name; a multi-DB account migrated into a differently
+// named account missed, the len(creds)==1 fallback couldn't save it, and
+// wp-config was left pointing at a DB that no longer exists.
+//
+// Fix: key res.Credentials by the source DB name (`base`); the value still
+// carries the namespaced DBName/DBUser + panel-managed password, so the rewrite
+// produces the panel-namespaced config (the intended behavior — namespacing is
+// always applied and the php files are rewritten to the namespaced creds).
+
+const gh723JohnnyqWPConfig = `<?php
+define( 'DB_NAME', 'notary_45635' );
+define( 'DB_USER', 'notary_45635' );
+define( 'DB_PASSWORD', 'e4eb22f97bb143151c95' );
+define( 'DB_HOST', 'localhost' );
+$table_prefix = 'wp_JV8O5_';
+require_once ABSPATH . 'wp-settings.php';
+`
+
+// TestGH723_RewriteWordPress_MultiDB_KeyedBySourceName is the rewriter-side
+// contract: given a credential map keyed by the SOURCE DB name (as the fixed
+// ImportDatabases now produces), johnnyq's real multi-DB wp-config is rewritten
+// to the namespaced destination credentials.
+func TestGH723_RewriteWordPress_MultiDB_KeyedBySourceName(t *testing.T) {
+	// Fixed keying: source DB name -> namespaced credential. Two DBs, target
+	// account "johnnyq" (differs from source "notary").
+	creds := map[string]DBCredential{
+		"notary_45635":  {DBName: "johnnyq_45635", DBUser: "johnnyq_45635", Password: "PANELPW_45635"},
+		"notary_itflow": {DBName: "johnnyq_itflow", DBUser: "johnnyq_itflow", Password: "PANELPW_itflow"},
+	}
+
+	out, changed := rewriteWordPress(gh723JohnnyqWPConfig, creds)
+	if !changed {
+		t.Fatalf("wp-config was NOT rewritten (GH #723 regression) — multi-DB lookup missed")
+	}
+	// Namespaced destination DB/user spliced in.
+	// RewriteWPConfigDB normalizes the define() to `define('KEY', 'val');`
+	// (no inner spaces) — that is the shared, proven rewriter's output.
+	for _, want := range []string{
+		"define('DB_NAME', 'johnnyq_45635');",
+		"define('DB_USER', 'johnnyq_45635');",
+		"define('DB_PASSWORD', 'PANELPW_45635');",
+		"define('DB_HOST', 'localhost');",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rewritten wp-config missing %q\n---\n%s", want, out)
+		}
+	}
+	// The dead source DB name / user must be gone.
+	if strings.Contains(out, "'notary_45635'") {
+		t.Errorf("rewritten wp-config still references the source DB notary_45635:\n%s", out)
+	}
+	if strings.Contains(out, "e4eb22f97bb143151c95") {
+		t.Errorf("rewritten wp-config still carries the source DB password")
+	}
+}
+
+// TestGH723_RewriteWordPress_FinalNameKeyingMisses documents WHY the map must
+// be keyed by the source name: with the OLD (namespaced) keying and >1 DB, the
+// rewrite silently no-ops and wp-config keeps the dead source DB name.
+func TestGH723_RewriteWordPress_FinalNameKeyingMisses(t *testing.T) {
+	oldKeying := map[string]DBCredential{
+		"johnnyq_45635":  {DBName: "johnnyq_45635", DBUser: "johnnyq_45635", Password: "PANELPW_45635"},
+		"johnnyq_itflow": {DBName: "johnnyq_itflow", DBUser: "johnnyq_itflow", Password: "PANELPW_itflow"},
+	}
+	_, changed := rewriteWordPress(gh723JohnnyqWPConfig, oldKeying)
+	if changed {
+		t.Fatalf("expected the pre-fix miss (multi-DB, finalName keys) to no-op; got changed=true")
+	}
+}
+
+// --- fakes for the ImportDatabases seam test -------------------------------
+
+type gh723DBRepo struct{ repository.DatabaseRepository }
+
+func (gh723DBRepo) ExistsByUserAndName(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+func (gh723DBRepo) Create(context.Context, *models.Database) error { return nil }
+
+type gh723DBUserRepo struct{ repository.DatabaseUserRepository }
+
+func (gh723DBUserRepo) Create(context.Context, *models.DatabaseUser) error { return nil }
+
+type gh723GrantRepo struct{ repository.DatabaseUserGrantRepository }
+
+func (gh723GrantRepo) Create(context.Context, *models.DatabaseUserGrant) error { return nil }
+
+// TestGH723_ImportDatabases_CredentialsKeyedBySourceName guards the fix at the
+// seam that actually had the bug: ImportDatabases must key res.Credentials by
+// the SOURCE DB name (what the config files reference), not the namespaced
+// destination name. Multi-DB account, target ("johnnyq") differs from source
+// ("notary") — the exact shape of johnnyq's notary backup.
+func TestGH723_ImportDatabases_CredentialsKeyedBySourceName(t *testing.T) {
+	extract := t.TempDir()
+	// Two dumps named like Hestia's: <source-db>.mysql.sql.
+	for _, db := range []string{"notary_45635", "notary_itflow"} {
+		if err := os.WriteFile(filepath.Join(extract, db+".mysql.sql"), []byte("-- dump\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	parsed := &ParsedTarball{
+		ExtractDir: extract,
+		SourceUser: "notary",
+		MySQLDumps: []string{
+			filepath.Join(extract, "notary_45635.mysql.sql"),
+			filepath.Join(extract, "notary_itflow.mysql.sql"),
+		},
+	}
+
+	res, err := ImportDatabases(
+		context.Background(),
+		gh723DBRepo{}, gh723DBUserRepo{}, gh723GrantRepo{},
+		&recordingAgent{},
+		parsed,
+		"01USERULID0000000000000000", "johnnyq", false,
+	)
+	if err != nil {
+		t.Fatalf("ImportDatabases: %v", err)
+	}
+
+	// Keys must be the SOURCE DB names the config files reference.
+	for _, srcName := range []string{"notary_45635", "notary_itflow"} {
+		cred, ok := res.Credentials[srcName]
+		if !ok {
+			t.Fatalf("res.Credentials missing source-name key %q (keys=%v) — GH #723 regression", srcName, keysOf(res.Credentials))
+		}
+		// Value still carries the namespaced destination name/user.
+		wantDest := "johnnyq_" + strings.TrimPrefix(srcName, "notary_")
+		if cred.DBName != wantDest || cred.DBUser != wantDest {
+			t.Errorf("cred for %q = {DBName:%q DBUser:%q}, want namespaced %q", srcName, cred.DBName, cred.DBUser, wantDest)
+		}
+	}
+	// Must NOT be keyed by the namespaced destination name (the old bug).
+	if _, ok := res.Credentials["johnnyq_45635"]; ok {
+		t.Errorf("res.Credentials keyed by namespaced name johnnyq_45635 — the rewriters look up by source name and would miss")
+	}
+}
+
+func keysOf(m map[string]DBCredential) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -278,10 +278,28 @@ func ImportDatabases(
 								// config-rewrite step can splice values
 								// into wp-config.php / configuration.php /
 								// settings.php / app/etc/env.php files.
+								//
+								// GH #723: key this map by the SOURCE DB name
+								// (`base`), NOT the namespaced destination name
+								// (`finalName`). The app-config rewriters
+								// (rewriteWordPress/Joomla/Drupal/Magento) look
+								// the credential up by the DB name they read out
+								// of the config file — which is the source name
+								// (e.g. `notary_45635`). Keying by `finalName`
+								// (`<target>_45635`) only ever matched when the
+								// target account shared the source's name; for a
+								// multi-DB account migrated into a differently
+								// named account the lookup missed and the
+								// `len(creds)==1` fallback couldn't save it, so
+								// wp-config was left pointing at a DB that no
+								// longer exists → "Error establishing a database
+								// connection". The value still carries the
+								// namespaced DBName/DBUser so the rewrite writes
+								// the panel-managed destination credentials.
 								if res.Credentials == nil {
 									res.Credentials = map[string]DBCredential{}
 								}
-								res.Credentials[finalName] = DBCredential{
+								res.Credentials[base] = DBCredential{
 									DBName:   finalName,
 									DBUser:   finalName,
 									Password: plainPwd,


### PR DESCRIPTION
## Problem (GH #723)

Migrated WordPress sites (and Joomla/Drupal/Magento) come up with a broken DB config after migration. johnnyq reported the wp-config password being reset to a random value "no matter what."

## Root cause

`ImportDatabases` stashes the per-DB credentials in `res.Credentials` keyed by the **namespaced destination** name (`finalName = <target>_<logical>`), but every app-config rewriter (`rewriteWordPress` / `rewriteJoomla` / `rewriteDrupal` / `rewriteMagento`) looks the credential up by the **source** DB name it reads out of the config file (e.g. wp-config's `DB_NAME`).

- Keying by `finalName` only matched when the target account happened to share the source's name.
- A **multi-DB** account migrated into a differently named account **missed**, and the `len(creds)==1` single-DB fallback could not paper over it.
- The rewrite then silently no-oped and wp-config was left pointing at a DB that no longer exists post-namespacing → *"Error establishing a database connection."*
- When target == source, the lookup happened to hit → rewrite fired → password replaced with the panel-managed random one (johnnyq's other symptom — **by design**: namespacing is always applied and configs are rewritten to the namespaced creds).

## Fix

Key `res.Credentials` by the **source** DB name (`base`). The value still carries the namespaced `DBName`/`DBUser` + panel-managed password, so the rewrite produces the panel-namespaced destination config. One-line behavior change; the design (namespace always + rewrite php config to the namespaced creds) is unchanged.

## Reproduced on real data

johnnyq's real HestiaCP backup (`notary`): 2 DBs — `notary_45635` (WordPress, sewickleynotary.com) + `notary_itflow` (itFlow). wp-config `DB_NAME=notary_45635`. With today's keying + 2 DBs the rewrite no-ops (confirmed).

## Tests

- `TestGH723_ImportDatabases_CredentialsKeyedBySourceName` — seam guard (fails if keyed by finalName again).
- `TestGH723_RewriteWordPress_MultiDB_KeyedBySourceName` — real wp-config → namespaced rewrite.
- `TestGH723_RewriteWordPress_FinalNameKeyingMisses` — documents the pre-fix multi-DB miss.

## Known follow-up (out of scope)

itFlow (`config.php`, `$dbusername = ...`) has no app-config rewriter, so a migrated itFlow site breaks the same way (DB name not rewritten). Adding itFlow to the supported rewriter set is a separate feature, not part of this WordPress fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)