### PR TITLE
feat(mail): tabbed side-car Add Mailbox drawer, matching Edit (GH #529)

### DIFF
--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.test.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.test.tsx
@@ -142,3 +142,29 @@ describe("CreateMailboxWizardModal — submit routing", () => {
     expect(onCreated).not.toHaveBeenCalled();
   });
 });
+
+describe("CreateMailboxWizardModal — GH #529 tabbed drawer", () => {
+  it("renders Account / Forwarding / Groups / Send As tabs (parity with Edit)", async () => {
+    renderModal();
+    await screen.findByRole("tab", { name: /account/i });
+    expect(screen.getByRole("tab", { name: /forwarding/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /groups/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /send as/i })).toBeInTheDocument();
+  });
+
+  it("Send As tab explains the grant is available only after the mailbox exists", async () => {
+    renderModal();
+    // Send As can't be granted pre-creation (no mailbox id yet); the tab
+    // must point the operator at Edit rather than offer a dead control.
+    fireEvent.click(await screen.findByRole("tab", { name: /send as/i }));
+    await screen.findByText(/only be granted after this mailbox exists/i);
+  });
+
+  it("keeps the domain-first gating: account fields stay hidden until a domain is picked", async () => {
+    renderModal();
+    // The Account tab is active by default; its cascade must still be gated.
+    await screen.findByRole("tab", { name: /account/i });
+    expect(screen.queryByLabelText(/email address/i)).toBeNull();
+    expect(screen.queryByLabelText(/^Password$/i)).toBeNull();
+  });
+});

--- a/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
+++ b/panel-ui/src/shells/user/mail/CreateMailboxWizardModal.tsx
@@ -7,11 +7,30 @@
 //         (local part, password, quota). Same submit button; now
 //         enabled once local_part is filled.
 //
+// GH #529: split into Account / Forwarding / Groups / Send As tabs to match
+// the Edit Mailbox drawer so Add and Edit look and feel the same. The account
+// fields still cascade in only after a domain is chosen (step-1/step-2). Send
+// As is post-create only (it needs the new mailbox's id), so on Add that tab
+// points the operator at Edit → Send As instead of a control that can't persist.
+//
 // The modal calls POST /domains/:id/mailboxes on submit and surfaces
 // the reveal-once password via the onCreated callback — the parent
 // page pops the DatabaseUserPasswordModal with it.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Checkbox, Drawer, Form, Grid, Input, InputNumber, Select, Space } from "antd";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Drawer,
+  Form,
+  Grid,
+  Input,
+  InputNumber,
+  Select,
+  Space,
+  Tabs,
+  Typography,
+} from "antd";
 
 import { PasswordInput } from "../../../components/PasswordInput";
 import { useMailGroups, useAddMailboxToGroup } from "../../../hooks/useMailGroups";
@@ -157,6 +176,168 @@ export const CreateMailboxWizardModal = ({
     onCancel();
   };
 
+  // Shown on the Forwarding/Groups tabs before a domain is chosen — those
+  // fields depend on the selected domain (groups are per-domain), so they
+  // stay gated behind the step-1 domain pick like the account fields.
+  const pickDomainFirst = (
+    <Typography.Text type="secondary">
+      Select a domain on the Account tab first.
+    </Typography.Text>
+  );
+
+  const accountTab = (
+    <>
+      <Form.Item
+        label={t("createmailboxwizardmodal.domain")}
+        name="domain_id"
+        rules={[{ required: true, message: "Pick a domain" }]}
+        tooltip={t("createmailboxwizardmodal.only_domains_with_email_enabled_appear_here")}
+      >
+        <Select
+          showSearch
+          optionFilterProp="label"
+          placeholder={t("createmailboxwizardmodal.select_a_domain")}
+          options={domains.map((d) => ({ value: d.id, label: d.name }))}
+        />
+      </Form.Item>
+
+      {chosenDomain && (
+        <>
+          <Form.Item
+            label={t("createmailboxwizardmodal.email_address")}
+            name="local_part"
+            rules={[
+              { required: true, message: "Required" },
+              {
+                pattern: /^[a-z0-9][a-z0-9._+-]*$/i,
+                message: "Letters, digits, dot/underscore/plus/hyphen only",
+              },
+              { max: 64, message: "64 characters max" },
+            ]}
+            extra="The part before the @ symbol."
+          >
+            <Input
+              placeholder="alice"
+              autoComplete="off"
+              addonAfter={`@${chosenDomain.name}`}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label={t("createmailboxwizardmodal.display_name")}
+            name="display_name"
+            tooltip={t("createmailboxwizardmodal.shown_as_the_sender_name_in_webmail_and_outg")}
+          >
+            <Input placeholder={t("createmailboxwizardmodal.alice_smith")} autoComplete="off" maxLength={255} />
+          </Form.Item>
+
+          <Form.Item
+            label={t("createmailboxwizardmodal.password")}
+            name="password"
+            tooltip={t("createmailboxwizardmodal.leave_blank_to_auto_generate_generated_passw")}
+            rules={[{ min: 8, message: "8 characters minimum" }]}
+          >
+            <PasswordInput
+              autoComplete="new-password"
+              placeholder="(auto-generate)"
+            />
+          </Form.Item>
+
+          <Form.Item
+            label={t("createmailboxwizardmodal.quota_mib")}
+            name="quota_mib"
+            tooltip={`Default ${QUOTA_DEFAULT_BYTES / 1024 / 1024} MiB. Minimum ${
+              QUOTA_MIN_BYTES / 1024 / 1024
+            } MiB.`}
+          >
+            <InputNumber
+              min={QUOTA_MIN_BYTES / 1024 / 1024}
+              max={1024 * 1024}
+              step={256}
+              style={{ width: 200 }}
+            />
+          </Form.Item>
+
+          <Form.Item
+            name="send_only"
+            valuePropName="checked"
+            tooltip={t("createmailboxwizardmodal.a_send_only_mailbox_can_authenticate_for_smt")}
+          >
+            <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
+          </Form.Item>
+        </>
+      )}
+
+      {!chosenDomain && domains.length === 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          message={t("createmailboxwizardmodal.no_email_enabled_domains")}
+          description={t("createmailboxwizardmodal.enable_email_on_at_least_one_domain_before_c")}
+        />
+      )}
+    </>
+  );
+
+  const forwardingTab = chosenDomain ? (
+    <>
+      <Form.Item
+        label={t("createmailboxwizardmodal.aliases_optional")}
+        name="aliases"
+        tooltip={t("createmailboxwizardmodal.extra_addresses_that_deliver_to_this_mailbox")}
+      >
+        <Input.TextArea
+          rows={2}
+          placeholder={`sales, info  (→ @${chosenDomain.name})`}
+          autoComplete="off"
+        />
+      </Form.Item>
+      <Form.Item
+        label={t("createmailboxwizardmodal.forward_to_optional")}
+        name="forward_target"
+        tooltip={t("createmailboxwizardmodal.redirect_a_copy_of_incoming_mail_to_an_exter")}
+        rules={[{ type: "email", message: "Must be a valid email" }]}
+      >
+        <Input placeholder="external@example.com" autoComplete="off" />
+      </Form.Item>
+      <Form.Item name="forward_keep_copy" valuePropName="checked" noStyle>
+        <Checkbox>Keep a copy in this mailbox when forwarding</Checkbox>
+      </Form.Item>
+    </>
+  ) : (
+    pickDomainFirst
+  );
+
+  const groupsTab = chosenDomain ? (
+    <Form.Item
+      label={t("createmailboxwizardmodal.add_to_groups")}
+      name="group_ids"
+      tooltip={t("createmailboxwizardmodal.the_mailbox_joins_these_groups_and_gains_the")}
+    >
+      <Select
+        mode="multiple"
+        allowClear
+        disabled={!domainGroups || domainGroups.length === 0}
+        placeholder={t("createmailboxwizardmodal.select_groups_optional")}
+        optionFilterProp="label"
+        options={(domainGroups ?? []).map((g) => ({ value: g.id, label: g.display_name || g.email }))}
+      />
+    </Form.Item>
+  ) : (
+    pickDomainFirst
+  );
+
+  // Send As can't be granted until the mailbox exists (it needs the new
+  // mailbox's id), so on Add this tab points the operator at Edit rather
+  // than a control that couldn't persist.
+  const sendAsTab = (
+    <Typography.Text type="secondary">
+      Send As lets one mailbox send as another. It can only be granted after
+      this mailbox exists — create it, then open it from the mailbox list and
+      use Edit → Send As.
+    </Typography.Text>
+  );
+
   return (
     <Drawer
       title={t("createmailboxwizardmodal.create_mailbox")}
@@ -179,133 +360,15 @@ export const CreateMailboxWizardModal = ({
         layout="vertical"
         initialValues={{ quota_mib: QUOTA_DEFAULT_BYTES / 1024 / 1024 }}
       >
-        <Form.Item
-          label={t("createmailboxwizardmodal.domain")}
-          name="domain_id"
-          rules={[{ required: true, message: "Pick a domain" }]}
-          tooltip={t("createmailboxwizardmodal.only_domains_with_email_enabled_appear_here")}
-        >
-          <Select
-            showSearch
-            optionFilterProp="label"
-            placeholder={t("createmailboxwizardmodal.select_a_domain")}
-            options={domains.map((d) => ({ value: d.id, label: d.name }))}
-          />
-        </Form.Item>
-
-        {chosenDomain && (
-          <>
-            <Form.Item
-              label={t("createmailboxwizardmodal.email_address")}
-              name="local_part"
-              rules={[
-                { required: true, message: "Required" },
-                {
-                  pattern: /^[a-z0-9][a-z0-9._+-]*$/i,
-                  message: "Letters, digits, dot/underscore/plus/hyphen only",
-                },
-                { max: 64, message: "64 characters max" },
-              ]}
-              extra="The part before the @ symbol."
-            >
-              <Input
-                placeholder="alice"
-                autoComplete="off"
-                addonAfter={`@${chosenDomain.name}`}
-              />
-            </Form.Item>
-
-            <Form.Item
-              label={t("createmailboxwizardmodal.display_name")}
-              name="display_name"
-              tooltip={t("createmailboxwizardmodal.shown_as_the_sender_name_in_webmail_and_outg")}
-            >
-              <Input placeholder={t("createmailboxwizardmodal.alice_smith")} autoComplete="off" maxLength={255} />
-            </Form.Item>
-
-            <Form.Item
-              label={t("createmailboxwizardmodal.password")}
-              name="password"
-              tooltip={t("createmailboxwizardmodal.leave_blank_to_auto_generate_generated_passw")}
-              rules={[{ min: 8, message: "8 characters minimum" }]}
-            >
-              <PasswordInput
-                autoComplete="new-password"
-                placeholder="(auto-generate)"
-              />
-            </Form.Item>
-
-            <Form.Item
-              label={t("createmailboxwizardmodal.quota_mib")}
-              name="quota_mib"
-              tooltip={`Default ${QUOTA_DEFAULT_BYTES / 1024 / 1024} MiB. Minimum ${
-                QUOTA_MIN_BYTES / 1024 / 1024
-              } MiB.`}
-            >
-              <InputNumber
-                min={QUOTA_MIN_BYTES / 1024 / 1024}
-                max={1024 * 1024}
-                step={256}
-                style={{ width: 200 }}
-              />
-            </Form.Item>
-
-            <Form.Item
-              name="send_only"
-              valuePropName="checked"
-              tooltip={t("createmailboxwizardmodal.a_send_only_mailbox_can_authenticate_for_smt")}
-            >
-              <Checkbox>Send-only (SMTP submission, no inbox)</Checkbox>
-            </Form.Item>
-
-            <Form.Item
-              label={t("createmailboxwizardmodal.add_to_groups")}
-              name="group_ids"
-              tooltip={t("createmailboxwizardmodal.the_mailbox_joins_these_groups_and_gains_the")}
-            >
-              <Select
-                mode="multiple"
-                allowClear
-                disabled={!domainGroups || domainGroups.length === 0}
-                placeholder={t("createmailboxwizardmodal.select_groups_optional")}
-                optionFilterProp="label"
-                options={(domainGroups ?? []).map((g) => ({ value: g.id, label: g.display_name || g.email }))}
-              />
-            </Form.Item>
-
-            <Form.Item
-              label={t("createmailboxwizardmodal.aliases_optional")}
-              name="aliases"
-              tooltip={t("createmailboxwizardmodal.extra_addresses_that_deliver_to_this_mailbox")}
-            >
-              <Input.TextArea
-                rows={2}
-                placeholder={chosenDomain ? `sales, info  (→ @${chosenDomain.name})` : "sales, info"}
-                autoComplete="off"
-              />
-            </Form.Item>
-            <Form.Item
-              label={t("createmailboxwizardmodal.forward_to_optional")}
-              name="forward_target"
-              tooltip={t("createmailboxwizardmodal.redirect_a_copy_of_incoming_mail_to_an_exter")}
-              rules={[{ type: "email", message: "Must be a valid email" }]}
-            >
-              <Input placeholder="external@example.com" autoComplete="off" />
-            </Form.Item>
-            <Form.Item name="forward_keep_copy" valuePropName="checked" noStyle>
-              <Checkbox>Keep a copy in this mailbox when forwarding</Checkbox>
-            </Form.Item>
-          </>
-        )}
-
-        {!chosenDomain && domains.length === 0 && (
-          <Alert
-            type="warning"
-            showIcon
-            message={t("createmailboxwizardmodal.no_email_enabled_domains")}
-            description={t("createmailboxwizardmodal.enable_email_on_at_least_one_domain_before_c")}
-          />
-        )}
+        <Tabs
+          defaultActiveKey="account"
+          items={[
+            { key: "account", label: "Account", forceRender: true, children: accountTab },
+            { key: "forwarding", label: "Forwarding", forceRender: true, children: forwardingTab },
+            { key: "groups", label: "Groups", forceRender: true, children: groupsTab },
+            { key: "sendas", label: "Send As", children: sendAsTab },
+          ]}
+        />
       </Form>
     </Drawer>
   );


### PR DESCRIPTION
## What (GH #529)

johnnyq asked for the tabbed side-car treatment shipped for **Edit Mailbox** (#704) to be applied to **Add** too:

> Awesome looks good but this treatment also needs to be done on add mailbox too

The Add drawer was one long flat form. This splits it into the same tabs as Edit — **Account / Forwarding / Groups / Send As** — so the two drawers look and feel the same.

## Tabs

- **Account** — domain + email / display-name / password / quota / send-only. The step-1/step-2 gating is preserved: the account fields still cascade in only after a domain is picked.
- **Forwarding** — create-time aliases + optional external forward (behavior unchanged, just relocated from the flat form).
- **Groups** — add-to-groups select (per-domain).
- **Send As** — informational. Send As needs the *new* mailbox's id to persist, which doesn't exist until after creation, so this tab points the operator at **Edit → Send As** instead of offering a control that can't save.

Forwarding/Groups sit behind the same domain-first gate (a "pick a domain first" hint until a domain is chosen). **No create-path logic changed** — `onOk` submits the same fields.

## Verification

- `npx tsc -b` + `eslint` clean.
- Vitest: existing step-gating + submit-routing tests unchanged and green; added GH #529 guards (4 tabs present, Send As hint, account cascade still gated). 7/7 pass.
- Browser check of the live drawer to follow on testserver after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)