### PR TITLE
feat(backups): tenant-editable backup exclusions via ~/.backupignore (GH #454)

### DIFF
--- a/internal/backup/restic.go
+++ b/internal/backup/restic.go
@@ -200,6 +200,11 @@ type BackupOpts struct {
 	StdinName    string    // virtual filename for stdin snapshots
 	Tags         []Tag     // appended via --tag flags
 	ExcludeFile  string    // path to --exclude-file
+	// ExtraExcludeFiles are additional --exclude-file paths appended after
+	// ExcludeFile. restic honours multiple --exclude-file flags; this lets a
+	// caller layer a per-account exclude list (e.g. a tenant's ~/.backupignore,
+	// GH #454) on top of the install-managed global list.
+	ExtraExcludeFiles []string
 	ExcludeArgs  []string  // additional --exclude=PATTERN
 	Hostname     string    // override --host (default: real hostname)
 }
@@ -216,6 +221,11 @@ func (c *Client) Backup(ctx context.Context, opts BackupOpts) (*BackupSummary, e
 	}
 	if opts.ExcludeFile != "" {
 		args = append(args, "--exclude-file", opts.ExcludeFile)
+	}
+	for _, f := range opts.ExtraExcludeFiles {
+		if f != "" {
+			args = append(args, "--exclude-file", f)
+		}
 	}
 	for _, p := range opts.ExcludeArgs {
 		args = append(args, "--exclude", p)

--- a/internal/backup/restic_test.go
+++ b/internal/backup/restic_test.go
@@ -256,3 +256,29 @@ func TestForgetIDs_EmptyIsNoop(t *testing.T) {
 		t.Fatalf("empty ids must not invoke restic, got %d calls", len(r.calls))
 	}
 }
+
+// TestBackup_ExtraExcludeFiles guards GH #454: a per-account exclude file
+// (~/.backupignore) is layered onto the global one as a second --exclude-file,
+// and empty entries are dropped.
+func TestBackup_ExtraExcludeFiles(t *testing.T) {
+	r := &fakeRunner{stdout: []byte(`{"message_type":"summary","snapshot_id":"s1","total_bytes_processed":1,"data_added":1}` + "\n")}
+	c := newClient(t, r)
+	_, _ = c.Backup(context.Background(), BackupOpts{
+		Paths:             []string{"/home/u"},
+		ExcludeFile:       "/etc/jabali-panel/restic-excludes.list",
+		ExtraExcludeFiles: []string{"/home/u/.backupignore", ""},
+	})
+	if len(r.calls) == 0 {
+		t.Fatal("restic was not invoked")
+	}
+	args := strings.Join(r.calls[0].args, " ")
+	if !strings.Contains(args, "--exclude-file /etc/jabali-panel/restic-excludes.list") {
+		t.Errorf("global exclude-file missing:\n%s", args)
+	}
+	if !strings.Contains(args, "--exclude-file /home/u/.backupignore") {
+		t.Errorf("per-account exclude-file missing (GH #454):\n%s", args)
+	}
+	if strings.HasSuffix(strings.TrimSpace(args), "--exclude-file") {
+		t.Errorf("empty ExtraExcludeFiles entry leaked a bare flag:\n%s", args)
+	}
+}

--- a/panel-agent/internal/commands/backup_home.go
+++ b/panel-agent/internal/commands/backup_home.go
@@ -25,6 +25,31 @@ import (
 // the file may not exist; missing exclude file is non-fatal).
 const HomeExcludeFile = "/etc/jabali-panel/restic-excludes.list"
 
+// BackupIgnoreFile is the per-account, tenant-editable exclude list at the home
+// root (GH #454). Patterns use restic's --exclude-file syntax; the tenant edits
+// it via the backup UI or drops it in like a .gitignore.
+const BackupIgnoreFile = ".backupignore"
+
+// homeBackupIgnoreFile returns <home>/.backupignore when it is a usable regular
+// file. It rejects a symlink, directory, or absurdly large file: the file is
+// user-writable and the backup agent reads it as root, so a symlink must never
+// redirect that read, and an exclude list is tiny. Absent/unusable => ("", false)
+// and the backup proceeds with only the global list.
+func homeBackupIgnoreFile(homePath string) (string, bool) {
+	p := filepath.Join(homePath, BackupIgnoreFile)
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return "", false
+	}
+	if !fi.Mode().IsRegular() {
+		return "", false
+	}
+	if fi.Size() > 256*1024 {
+		return "", false
+	}
+	return p, true
+}
+
 type backupHomeParams struct {
 	JobID          string   `json:"job_id"`
 	UserID         string   `json:"user_id"`
@@ -118,6 +143,12 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	}
 	if _, err := os.Stat(HomeExcludeFile); err == nil {
 		opts.ExcludeFile = HomeExcludeFile
+	}
+	// GH #454: layer the tenant's own ~/.backupignore on top of the global
+	// list so they can skip regenerable dirs (cache/, node_modules/, vendor/,
+	// *.log, …). Only a real regular file is honoured (see homeBackupIgnoreFile).
+	if userIgnore, ok := homeBackupIgnoreFile(homePath); ok {
+		opts.ExtraExcludeFiles = append(opts.ExtraExcludeFiles, userIgnore)
 	}
 	summary, err := c.Backup(ctx, opts)
 	if err != nil {

--- a/panel-agent/internal/commands/backup_home_ignore_test.go
+++ b/panel-agent/internal/commands/backup_home_ignore_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHomeBackupIgnoreFile guards GH #454: the per-account ~/.backupignore is
+// honoured only when it's a real regular file. It is user-writable and the
+// backup agent reads it as root, so a symlink, directory, or oversized file
+// must be rejected (defence in depth) and an absent file is a no-op.
+func TestHomeBackupIgnoreFile(t *testing.T) {
+	home := t.TempDir()
+	p := filepath.Join(home, BackupIgnoreFile)
+
+	// absent -> ("", false)
+	if got, ok := homeBackupIgnoreFile(home); ok {
+		t.Errorf("absent .backupignore: got (%q,%v), want (\"\",false)", got, ok)
+	}
+
+	// regular file -> (path, true)
+	if err := os.WriteFile(p, []byte("cache/\nnode_modules/\n*.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := homeBackupIgnoreFile(home); !ok || got != p {
+		t.Errorf("regular .backupignore: got (%q,%v), want (%q,true)", got, ok, p)
+	}
+
+	// symlink -> rejected (must not let a user redirect the root read)
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, "real.txt")
+	if err := os.WriteFile(target, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, p); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := homeBackupIgnoreFile(home); ok {
+		t.Error("symlink .backupignore must be rejected (GH #454 security)")
+	}
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+
+	// oversized -> rejected
+	if err := os.WriteFile(p, make([]byte, 256*1024+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := homeBackupIgnoreFile(home); ok {
+		t.Error("oversized .backupignore must be rejected")
+	}
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+
+	// directory -> rejected
+	if err := os.Mkdir(p, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := homeBackupIgnoreFile(home); ok {
+		t.Error("directory .backupignore must be rejected")
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1217,6 +1217,10 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	g.GET("/:id/manifest", h.manifest)
 	g.POST("/:id/restore", h.restoreSelective)
 	g.GET("/destinations", h.destinations)
+	// GH #454: tenant-editable backup exclusions (~/.backupignore). Owner-scoped
+	// via the session user; layered onto the global exclude list at backup time.
+	g.GET("/exclusions", h.getExclusions)
+	g.PUT("/exclusions", h.putExclusions)
 	// Tenant scheduled-backup card (GH #454 Step 4). Mounted only when the
 	// schedule repo + server settings (the admin-owned cron time) are wired.
 	if cfg.Schedules != nil && cfg.Settings != nil {
@@ -1313,6 +1317,125 @@ func (h *meBackupHandler) delete(c *gin.Context) {
 	}
 	if err := h.cfg.Jobs.Delete(c.Request.Context(), jobID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_delete"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// backupIgnoreFilename is the per-account, tenant-editable restic exclude list
+// at the home root. Mirrors panel-agent commands.BackupIgnoreFile; kept as a
+// local literal to avoid importing the agent package (GH #454).
+const backupIgnoreFilename = ".backupignore"
+
+// maxBackupExclusionsBytes caps the .backupignore the tenant may save. A pattern
+// list is tiny; the agent's home backup ignores the file above 256 KiB anyway.
+const maxBackupExclusionsBytes = 64 * 1024
+
+// backupExclusionsFileNotFound reports whether an agent files.read error is just
+// "the file isn't there yet" (the common case for an account that never set
+// exclusions) — files.read collapses ENOENT into a generic CodeInternal
+// "failed to open file: … no such file or directory", so match on the message.
+func backupExclusionsFileNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	m := strings.ToLower(err.Error())
+	return strings.Contains(m, "no such file") ||
+		strings.Contains(m, "does not exist") ||
+		strings.Contains(m, "enoent")
+}
+
+// getExclusions returns the caller's own ~/.backupignore contents (empty when
+// the file doesn't exist yet). Owner-scoped: the username is resolved from the
+// session user, never the request, so a tenant can only ever read their own file.
+func (h *meBackupHandler) getExclusions(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "error": "unauthenticated"})
+		return
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil || user.Username == nil || *user.Username == "" {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "user_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "agent_unavailable"})
+		return
+	}
+	path := filepath.Join("/home", *user.Username, backupIgnoreFilename)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), backupCallTimeout)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(ctx, "files.read", map[string]any{
+		"user_id":  claims.UserID,
+		"username": *user.Username,
+		"path":     path,
+	})
+	if err != nil {
+		if backupExclusionsFileNotFound(err) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok", "patterns": ""})
+			return
+		}
+		status, body := translateAgentError(err)
+		c.JSON(status, body)
+		return
+	}
+	var r struct {
+		Content  string `json:"content"`
+		IsBinary bool   `json:"is_binary"`
+	}
+	_ = json.Unmarshal(raw, &r)
+	if r.IsBinary {
+		// A binary .backupignore is nonsense; surface empty so the editor can
+		// replace it rather than rendering garbage.
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "patterns": ""})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "patterns": r.Content})
+}
+
+// putExclusions overwrites the caller's own ~/.backupignore with the supplied
+// restic exclude patterns (owner-scoped, session-derived username). An empty
+// body clears the list (writes an empty file). The home backup layers this on
+// top of the global exclude list (GH #454).
+func (h *meBackupHandler) putExclusions(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "error": "unauthenticated"})
+		return
+	}
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), claims.UserID)
+	if err != nil || user == nil || user.Username == nil || *user.Username == "" {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "user_not_found"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "agent_unavailable"})
+		return
+	}
+	var body struct {
+		Patterns string `json:"patterns"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body"})
+		return
+	}
+	if len(body.Patterns) > maxBackupExclusionsBytes {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "too_large", "detail": "exclude list exceeds 64 KiB"})
+		return
+	}
+	path := filepath.Join("/home", *user.Username, backupIgnoreFilename)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), backupCallTimeout)
+	defer cancel()
+	if _, err := h.cfg.Agent.Call(ctx, "files.write", map[string]any{
+		"user_id":  claims.UserID,
+		"username": *user.Username,
+		"path":     path,
+		"content":  body.Patterns,
+		"mode":     "overwrite",
+	}); err != nil {
+		status, respBody := translateAgentError(err)
+		c.JSON(status, respBody)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/panel-api/internal/api/backups_exclusions_test.go
+++ b/panel-api/internal/api/backups_exclusions_test.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// exclAgent records the last files.read/files.write dispatch and returns canned
+// results — enough to assert the /me/backups/exclusions handlers are owner-scoped.
+type exclAgent struct {
+	cmd      string
+	params   map[string]any
+	readResp string
+	readErr  error
+	writeErr error
+}
+
+func (f *exclAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	f.cmd = command
+	if m, ok := params.(map[string]any); ok {
+		f.params = m
+	}
+	switch command {
+	case "files.read":
+		if f.readErr != nil {
+			return nil, f.readErr
+		}
+		b, _ := json.Marshal(map[string]any{"content": f.readResp})
+		return b, nil
+	case "files.write":
+		if f.writeErr != nil {
+			return nil, f.writeErr
+		}
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func exclHandler(ag *exclAgent) *meBackupHandler {
+	return &meBackupHandler{cfg: MeBackupsHandlerConfig{
+		Agent: ag,
+		Users: &fakeUserRepo{user: &models.User{ID: "u1", Username: uname("alice")}},
+	}}
+}
+
+func exclCtx(t *testing.T, method, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(method, "/api/v1/me/backups/exclusions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	// Session user is "u1" (fakeUserRepo resolves it to username "alice").
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: false})
+	return c, rec
+}
+
+func TestMeBackupExclusions_GetReturnsContent(t *testing.T) {
+	ag := &exclAgent{readResp: "cache/\nnode_modules/\n"}
+	c, rec := exclCtx(t, http.MethodGet, "")
+	exclHandler(ag).getExclusions(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Patterns string `json:"patterns"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Patterns != "cache/\nnode_modules/\n" {
+		t.Errorf("patterns = %q", resp.Patterns)
+	}
+	// Owner-scoped: the read targets the SESSION user's own home.
+	if ag.cmd != "files.read" {
+		t.Errorf("cmd = %q, want files.read", ag.cmd)
+	}
+	if ag.params["username"] != "alice" || ag.params["path"] != "/home/alice/.backupignore" {
+		t.Errorf("read params = %v; want username=alice path=/home/alice/.backupignore", ag.params)
+	}
+}
+
+func TestMeBackupExclusions_GetMissingFileIsEmpty(t *testing.T) {
+	ag := &exclAgent{readErr: errors.New("failed to open file: open /home/alice/.backupignore: no such file or directory")}
+	c, rec := exclCtx(t, http.MethodGet, "")
+	exclHandler(ag).getExclusions(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (absent file = empty); body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Patterns string `json:"patterns"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Patterns != "" {
+		t.Errorf("absent .backupignore must yield empty patterns, got %q", resp.Patterns)
+	}
+}
+
+func TestMeBackupExclusions_PutIsOwnerScoped(t *testing.T) {
+	ag := &exclAgent{}
+	// A user_id/username smuggled in the body MUST be ignored — the handler
+	// binds only `patterns`, and the write is scoped to the session user.
+	c, rec := exclCtx(t, http.MethodPut, `{"patterns":"logs/\n","user_id":"victim","username":"victim"}`)
+	exclHandler(ag).putExclusions(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ag.cmd != "files.write" {
+		t.Fatalf("cmd = %q, want files.write", ag.cmd)
+	}
+	if ag.params["username"] != "alice" || ag.params["path"] != "/home/alice/.backupignore" {
+		t.Errorf("write went to %v — must be the session user's own home, not the body's", ag.params)
+	}
+	if ag.params["content"] != "logs/\n" {
+		t.Errorf("content = %v, want %q", ag.params["content"], "logs/\n")
+	}
+	if ag.params["mode"] != "overwrite" {
+		t.Errorf("mode = %v, want overwrite", ag.params["mode"])
+	}
+}
+
+func TestMeBackupExclusions_PutTooLargeRejected(t *testing.T) {
+	ag := &exclAgent{}
+	big := strings.Repeat("x", 64*1024+1)
+	c, rec := exclCtx(t, http.MethodPut, `{"patterns":"`+big+`"}`)
+	exclHandler(ag).putExclusions(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (over 64 KiB)", rec.Code)
+	}
+	if ag.cmd == "files.write" {
+		t.Error("oversized exclusions must not reach the agent")
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -866,6 +866,16 @@ paths:
       summary: List backup destinations your hosting plan allows
       responses: { "200": { description: OK } }
 
+  /me/backups/exclusions:
+    get:
+      tags: [Backups]
+      summary: Your backup exclude patterns (~/.backupignore)
+      responses: { "200": { description: OK } }
+    put:
+      tags: [Backups]
+      summary: Set your backup exclude patterns (~/.backupignore)
+      responses: { "200": { description: OK } }
+
   /me/backup-schedule:
     get:
       tags: [Backups]

--- a/panel-ui/src/shells/user/MyProfileBackupCard.exclusions.test.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.exclusions.test.tsx
@@ -1,0 +1,68 @@
+// MyProfileBackupCard.exclusions.test.tsx — GH #454 backup exclusions editor.
+//
+// The tenant edits ~/.backupignore via the card: it seeds a textarea from
+// GET /me/backups/exclusions and saves with PUT. Only apiClient is mocked;
+// the real AntD card renders.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MyProfileBackupCard } from "./MyProfileBackupCard";
+
+vi.mock("../../apiClient", () => ({
+  apiClient: { get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../../apiClient";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <MyProfileBackupCard />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocked.get.mockReset().mockImplementation((url: string) => {
+    if (url.startsWith("/me/backups/exclusions")) {
+      return Promise.resolve({ data: { patterns: "cache/\nnode_modules/\n" } });
+    }
+    if (url.startsWith("/me/backups/destinations")) {
+      return Promise.resolve({ data: { data: [], allow_local: false } });
+    }
+    return Promise.resolve({ data: { data: [] } });
+  });
+  mocked.put.mockReset().mockResolvedValue({ data: {} });
+});
+
+describe("MyProfileBackupCard exclusions (GH #454)", () => {
+  it("seeds the exclusions textarea from GET and saves edits via PUT", async () => {
+    renderCard();
+
+    // Seeded from GET /me/backups/exclusions.
+    const ta = await screen.findByDisplayValue(/cache\//);
+    expect(ta).toBeInTheDocument();
+
+    // Edit + save.
+    fireEvent.change(ta, { target: { value: "logs/\n*.tmp\n" } });
+    fireEvent.click(screen.getByRole("button", { name: /save exclusions/i }));
+
+    await waitFor(() =>
+      expect(mocked.put).toHaveBeenCalledWith("/me/backups/exclusions", {
+        patterns: "logs/\n*.tmp\n",
+      }),
+    );
+  });
+});

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -4,13 +4,13 @@
 // scoped via /me/backups (auth-gated to caller's user_id).
 import { useTranslation } from "react-i18next";
 import { downloadUrl } from "../../utils/download";
-import { Button, Card, Grid, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Button, Card, Grid, Input, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
 import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
 import { RowActions } from "../../components/RowActions";
 import { DeleteOutlined, DownloadOutlined, ReloadOutlined, SaveOutlined, WarningOutlined } from "@icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../apiClient";
@@ -72,6 +72,36 @@ export const MyProfileBackupCard = () => {
     ...(allowLocal ? [{ value: "", label: "Local (default)" }] : []),
     ...dests.map((d) => ({ value: d.id, label: `${d.name} (${d.kind})` })),
   ];
+
+  // GH #454: tenant-editable backup exclusions (~/.backupignore). Loaded from
+  // and saved to the caller's own home file; layered onto the global exclude
+  // list at backup time. `exclDirty` stops a background refetch from clobbering
+  // in-progress edits.
+  const [exclusions, setExclusions] = useState<string>("");
+  const [exclDirty, setExclDirty] = useState(false);
+  const [savingExcl, setSavingExcl] = useState(false);
+  const exclQuery = useQuery({
+    queryKey: ["me-backup-exclusions"],
+    queryFn: async () =>
+      (await apiClient.get<{ patterns: string }>("/me/backups/exclusions")).data,
+  });
+  useEffect(() => {
+    if (exclQuery.data && !exclDirty) setExclusions(exclQuery.data.patterns ?? "");
+  }, [exclQuery.data, exclDirty]);
+
+  const handleSaveExclusions = async () => {
+    setSavingExcl(true);
+    try {
+      await apiClient.put("/me/backups/exclusions", { patterns: exclusions });
+      message.success("Backup exclusions saved");
+      setExclDirty(false);
+      exclQuery.refetch();
+    } catch (err) {
+      message.error(extractApiError(err, "Save failed"));
+    } finally {
+      setSavingExcl(false);
+    }
+  };
 
   const handleCreate = async () => {
     setSubmitting(true);
@@ -228,6 +258,37 @@ export const MyProfileBackupCard = () => {
           },
         ]}
       />
+      <div style={{ marginTop: 20 }}>
+        <Typography.Text strong>Backup exclusions</Typography.Text>
+        <Typography.Paragraph type="secondary" style={{ marginTop: 4, marginBottom: 8 }}>
+          Paths to skip in your backups — one pattern per line (restic exclude
+          syntax). Ideal for regenerable directories, e.g. <code>cache/</code>,{" "}
+          <code>node_modules/</code>, <code>vendor/</code>, <code>*.log</code>.
+          Saved to <code>~/.backupignore</code> and applied to every backup of
+          your account.
+        </Typography.Paragraph>
+        <Input.TextArea
+          rows={5}
+          value={exclusions}
+          onChange={(e) => {
+            setExclusions(e.target.value);
+            setExclDirty(true);
+          }}
+          placeholder={"cache/\nnode_modules/\nvendor/\n*.log"}
+          disabled={exclQuery.isLoading}
+          style={{ fontFamily: "monospace" }}
+        />
+        <div style={{ marginTop: 8 }}>
+          <Button
+            icon={<SaveOutlined />}
+            loading={savingExcl}
+            disabled={!exclDirty}
+            onClick={handleSaveExclusions}
+          >
+            Save exclusions
+          </Button>
+        </div>
+      </div>
       <RestoreDrawer
         backupId={restoreId}
         open={restoreId !== null}


### PR DESCRIPTION
## What (GH #454)

lxsdevcode asked for **file/directory exclusions** in the tenant backup system — both a **project file** and a **UI**:

> exclusions could be configured in two ways: (1) through the UI … (2) through a project file (similar to .gitignore) … `cache/`, `logs/`, `node_modules/`, `vendor/` …

This delivers both with **one source of truth**: a per-account `~/.backupignore` (restic exclude-file syntax); the UI is just an editor for it. No schema change.

## Layers

- **`internal/backup`** — `BackupOpts.ExtraExcludeFiles`. restic honours multiple `--exclude-file` flags, so a per-account list layers onto the global install-managed one.
- **`panel-agent` (`backup.home`)** — honours `/home/<user>/.backupignore` as an extra exclude-file. **Guarded**: only a real regular file ≤256 KiB is used; a symlink, directory, or oversized file is ignored — the file is user-writable and the agent reads it as **root**, so a symlink must never redirect that read.
- **`panel-api`** — `GET`/`PUT /me/backups/exclusions`. **Owner-scoped**: the username comes from the **session** user, never the request body, so a tenant can only ever touch their own `~/.backupignore`. `GET` returns empty when absent; `PUT` overwrites (64 KiB cap). openapi entries added.
- **`panel-ui`** — an exclusions editor in `MyProfileBackupCard`: a textarea seeded from `GET`, saved via `PUT`, with the common presets (`cache/`, `node_modules/`, `vendor/`, `*.log`) called out and `~/.backupignore` named.

The restic engine already supported excludes (global list); this surfaces **per-tenant** control.

## Tests

- **backup pkg** — both exclude-files emitted; empty entries dropped.
- **agent** — `homeBackupIgnoreFile`: regular ✓; symlink / dir / oversized / absent rejected.
- **API** — owner-scoping (session username used, body `user_id` ignored); absent file → empty; 64 KiB cap → 400.
- **UI** — seed from `GET`, save via `PUT`.
- `tsc -b` + eslint clean; openapi coverage passes.

## Note

The rest of the #454 blueprint (package limits, tenant read/on-demand/schedule/restore) already shipped in prior PRs; this closes lxsdevcode's remaining exclusions ask. Browser check of the editor to follow on testserver after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)