### PR TITLE
feat(cli): human-readable `jabali system diagnostic` output

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4878,8 +4878,12 @@ jabali system
 Generate a redacted, encrypted diagnostic bundle for support handoff
 
 ```
-jabali system diagnostic
+jabali system diagnostic [flags]
 ```
+
+**Flags:**
+
+- `--json` — print the raw JSON result (for scripting)
 
 #### `jabali system info`
 

--- a/panel-api/cmd/server/system_diagnostic_cmd_test.go
+++ b/panel-api/cmd/server/system_diagnostic_cmd_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestPrintDiagReport checks the CLI renders `jabali system diagnostic` as a
+// readable block (not raw JSON), using the real response shape.
+func TestPrintDiagReport(t *testing.T) {
+	var buf bytes.Buffer
+	printDiagReport(&buf, diagReport{
+		URL:            "https://enclosed.jabali-panel.com/01kyk8m8y79w2y0pns2ywkqg75#pw:oCypiWiUFu6kSnaJSN0BeLf93bftBMUv9aelT_HQlgg",
+		Password:       "Uh9LoSe2h6zL1aBydukkjMcfirs",
+		NoteID:         "01kyk8m8y79w2y0pns2ywkqg75",
+		ByteCount:      468480,
+		GeneratedAt:    "2026-07-28T02:24:58Z",
+		RedactionCount: 0,
+		FileCount:      50,
+	})
+	out := buf.String()
+
+	for _, want := range []string{
+		"Diagnostic bundle uploaded",
+		"expires in 7 days",
+		"50 files",
+		"0 redactions",
+		"https://enclosed.jabali-panel.com/01kyk8m8y79w2y0pns2ywkqg75#pw:", // full link, key intact
+		"Uh9LoSe2h6zL1aBydukkjMcfirs",                                      // password shown
+		"2026-07-28 02:24 UTC",                                             // formatted time, not raw RFC3339
+		"do NOT paste it into a public issue",                             // privacy warning
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diagnostic output missing %q\n---\n%s", want, out)
+		}
+	}
+	// Must no longer be raw JSON.
+	if strings.Contains(out, `"byte_count"`) || strings.Contains(out, `"note_id"`) {
+		t.Errorf("output still looks like raw JSON:\n%s", out)
+	}
+}
+
+// A malformed generated_at must degrade gracefully (show it as-is, not crash).
+func TestPrintDiagReport_BadTime(t *testing.T) {
+	var buf bytes.Buffer
+	printDiagReport(&buf, diagReport{URL: "https://x/#pw:y", Password: "p", GeneratedAt: "not-a-time"})
+	if !strings.Contains(buf.String(), "not-a-time") {
+		t.Errorf("bad timestamp should be shown verbatim:\n%s", buf.String())
+	}
+}

--- a/panel-api/cmd/server/system_ops_cmd.go
+++ b/panel-api/cmd/server/system_ops_cmd.go
@@ -10,7 +10,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/netip"
 	"os"
 	"strconv"
@@ -84,11 +86,46 @@ func newSystemResolverSetCmd() *cobra.Command {
 
 // ---- #581 support diagnostic ----
 
+// diagReport mirrors the system.diagnostic_report agent response (the shape the
+// CLI prints for support handoff).
+type diagReport struct {
+	URL            string `json:"url"`
+	Password       string `json:"password"`
+	NoteID         string `json:"note_id"`
+	ByteCount      int64  `json:"byte_count"`
+	GeneratedAt    string `json:"generated_at"`
+	RedactionCount int    `json:"redaction_count"`
+	FileCount      int    `json:"file_count"`
+}
+
+// printDiagReport renders a diagnostic bundle result as a human-readable block
+// instead of raw JSON. Kept separate from the command so it's unit-testable.
+func printDiagReport(w io.Writer, r diagReport) {
+	when := r.GeneratedAt
+	if t, err := time.Parse(time.RFC3339, r.GeneratedAt); err == nil {
+		when = t.UTC().Format("2006-01-02 15:04 MST")
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  ✓ Diagnostic bundle uploaded — encrypted, expires in 7 days.")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "    %d files · %s · %d redactions\n", r.FileCount, humanBytes(uint64(r.ByteCount)), r.RedactionCount)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Give BOTH of these to Jabali support. Keep the password private —")
+	fmt.Fprintln(w, "  do NOT paste it into a public issue:")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "    Link       %s\n", r.URL)
+	fmt.Fprintf(w, "    Password   %s\n", r.Password)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Generated %s · note %s\n", when, r.NoteID)
+	fmt.Fprintln(w)
+}
+
 func newSystemDiagnosticCmd() *cobra.Command {
-	return &cobra.Command{
+	var asJSON bool
+	cmd := &cobra.Command{
 		Use:     "diagnostic",
 		Short:   "Generate a redacted, encrypted diagnostic bundle for support handoff",
-		Long:    "Collects + redacts host diagnostics and uploads an encrypted bundle. Prints the share URL and one-time password — hand them to support. The bundle is encrypted; the CLI never emails anything.",
+		Long:    "Collects + redacts host diagnostics and uploads an encrypted bundle. Prints the share link and one-time password — hand both to support. The bundle is encrypted; the CLI never emails anything. Use --json for the raw result.",
 		Args:    cobra.NoArgs,
 		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -99,11 +136,26 @@ func newSystemDiagnosticCmd() *cobra.Command {
 				return fmt.Errorf("diagnostic report (agent timeout/upload failure?): %w", err)
 			}
 			cliAuditOK(ctx, "system.diagnostic_report", "system", "diagnostic", nil)
-			os.Stdout.Write(raw)
-			os.Stdout.Write([]byte{'\n'})
+
+			if asJSON {
+				os.Stdout.Write(raw)
+				os.Stdout.Write([]byte{'\n'})
+				return nil
+			}
+
+			var r diagReport
+			if jErr := json.Unmarshal(raw, &r); jErr != nil || r.URL == "" {
+				// Shape changed or partial — never hide the payload; fall back to raw.
+				os.Stdout.Write(raw)
+				os.Stdout.Write([]byte{'\n'})
+				return nil
+			}
+			printDiagReport(cmd.OutOrStdout(), r)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print the raw JSON result (for scripting)")
+	return cmd
 }
 
 // ---- #566 admin process kill ----


### PR DESCRIPTION
## What

`jabali system diagnostic` dumped the raw agent JSON as one unreadable line:

```
{"url":"https://enclosed.jabali-panel.com/01kyk8…#pw:oCyp…","password":"Uh9Lo…","note_id":"01kyk8…","byte_count":468480,"generated_at":"2026-07-28T02:24:58Z","redaction_count":0,"file_count":50}
```

Now it renders a readable block:

```
  ✓ Diagnostic bundle uploaded — encrypted, expires in 7 days.

    50 files · 457.50 KB · 0 redactions

  Give BOTH of these to Jabali support. Keep the password private —
  do NOT paste it into a public issue:

    Link       https://enclosed.jabali-panel.com/01kyk8…#pw:oCyp…
    Password   Uh9LoSe2h6zL1aBydukkjMcfirs

  Generated 2026-07-28 02:24 UTC · note 01kyk8m8y79w2y0pns2ywkqg75
```

- `--json` still prints the raw payload (scripting).
- Parse failure / shape change → falls back to raw so the payload is never hidden.
- Formatting extracted to `printDiagReport(io.Writer, diagReport)` — unit-tested (real shape + malformed-timestamp fallback).

Small UX fix; the GUI dialog was already readable. The larger "claim-code" hand-off idea is tracked separately (it needs an operator-side claim/redeem service since `enclosed` is E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)