### PR TITLE
feat(support): public-safe claim code for diagnostic bundles (GH #357)

### DIFF
--- a/panel-agent/internal/commands/support_claim.go
+++ b/panel-agent/internal/commands/support_claim.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// support_claim.go — client side of the operator-run support-claim service
+// (see support-claim/ in the repo root). After a diagnostic bundle is uploaded
+// to enclosed, the agent optionally registers the {url, password} with the
+// claim service and gets back a short, public-safe code (JAB-XXXXXXXX). The
+// user can then paste the code — not the sensitive link+password — anywhere,
+// and the support team redeems it (authenticated) to get the bundle.
+
+// claimBaseURL is the operator-run support-claim service. Empty (the default)
+// means the diagnostic report skips claim registration and returns just the raw
+// enclosed link + password — so no request ever hits a non-existent host. Set
+// JABALI_CLAIM_URL on jabali-agent.service to enable it.
+func claimBaseURL() string {
+	return os.Getenv("JABALI_CLAIM_URL")
+}
+
+type claimIssueRequest struct {
+	URL      string `json:"url"`
+	Password string `json:"password"`
+	Host     string `json:"host,omitempty"`
+	NoteID   string `json:"note_id,omitempty"`
+	Bytes    int    `json:"byte_count,omitempty"`
+	Files    int    `json:"file_count,omitempty"`
+}
+
+// registerSupportClaim POSTs the bundle's {url, password, meta} to the claim
+// service and returns the short public code. Best-effort: any failure returns an
+// error the caller treats as "no code — fall back to link + password".
+func registerSupportClaim(ctx context.Context, base string, req claimIssueRequest) (string, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimRight(base, "/")+"/claims", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("claim service status %d", resp.StatusCode)
+	}
+	var out struct {
+		Code string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.Code == "" {
+		return "", fmt.Errorf("claim service returned an empty code")
+	}
+	return out.Code, nil
+}

--- a/panel-agent/internal/commands/support_claim_test.go
+++ b/panel-agent/internal/commands/support_claim_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRegisterSupportClaim: the agent POSTs the bundle's {url,password,meta} to
+// the claim service and returns the short code (GH #357 claim-code).
+func TestRegisterSupportClaim(t *testing.T) {
+	var got claimIssueRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/claims" || r.Method != http.MethodPost {
+			http.Error(w, "bad", http.StatusNotFound)
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":"JAB-7QX9K2P4","expires_at":"2026-08-11T00:00:00Z"}`))
+	}))
+	defer ts.Close()
+
+	code, err := registerSupportClaim(context.Background(), ts.URL, claimIssueRequest{
+		URL: "https://enclosed/#pw:k", Password: "pw123", Host: "mx", NoteID: "n1", Bytes: 1000, Files: 50,
+	})
+	if err != nil {
+		t.Fatalf("registerSupportClaim: %v", err)
+	}
+	if code != "JAB-7QX9K2P4" {
+		t.Errorf("code = %q", code)
+	}
+	// The sensitive fields were forwarded so the service can hand them back on
+	// authenticated redeem.
+	if got.URL != "https://enclosed/#pw:k" || got.Password != "pw123" || got.Files != 50 {
+		t.Errorf("forwarded payload mismatch: %+v", got)
+	}
+}
+
+// A non-200 from the claim service is an error (caller falls back to
+// link+password, leaving ClaimCode empty).
+func TestRegisterSupportClaim_ErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+	if _, err := registerSupportClaim(context.Background(), ts.URL, claimIssueRequest{URL: "u", Password: "p"}); err == nil {
+		t.Error("expected an error on non-200 claim status")
+	}
+}

--- a/panel-agent/internal/commands/system_diagnostic_report.go
+++ b/panel-agent/internal/commands/system_diagnostic_report.go
@@ -37,6 +37,10 @@ type systemDiagnosticReportResponse struct {
 	GeneratedAt    string `json:"generated_at"`
 	RedactionCount int    `json:"redaction_count"`
 	FileCount      int    `json:"file_count"`
+	// ClaimCode is a short, public-safe hand-off code (JAB-XXXXXXXX) minted by
+	// the operator-run support-claim service, present only when JABALI_CLAIM_URL
+	// is configured and registration succeeded. Empty => share url+password.
+	ClaimCode string `json:"claim_code,omitempty"`
 }
 
 func systemDiagnosticReportHandler(ctx context.Context, _ json.RawMessage) (any, error) {
@@ -60,7 +64,7 @@ func systemDiagnosticReportHandler(ctx context.Context, _ json.RawMessage) (any,
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("enclosed upload: %v", err)}
 	}
 
-	return systemDiagnosticReportResponse{
+	out := systemDiagnosticReportResponse{
 		URL:            res.URL,
 		Password:       res.Password,
 		NoteID:         res.NoteID,
@@ -68,7 +72,26 @@ func systemDiagnosticReportHandler(ctx context.Context, _ json.RawMessage) (any,
 		GeneratedAt:    bundle.GeneratedAt.Format(time.RFC3339),
 		RedactionCount: bundle.RedactionCount,
 		FileCount:      bundle.FileCount,
-	}, nil
+	}
+
+	// GH #357 follow-up: when a support-claim service is configured, register a
+	// short public-safe code so the user shares "JAB-XXXXXXXX" instead of the
+	// sensitive link+password. Best-effort — a failure just leaves ClaimCode
+	// empty and the caller falls back to url+password.
+	if base := claimBaseURL(); base != "" {
+		if code, cerr := registerSupportClaim(ctx, base, claimIssueRequest{
+			URL:      res.URL,
+			Password: res.Password,
+			Host:     hostname,
+			NoteID:   res.NoteID,
+			Bytes:    out.ByteCount,
+			Files:    out.FileCount,
+		}); cerr == nil {
+			out.ClaimCode = code
+		}
+	}
+
+	return out, nil
 }
 
 // safeHostname strips characters that would mess up a filename; falls

--- a/panel-api/cmd/server/system_diagnostic_cmd_test.go
+++ b/panel-api/cmd/server/system_diagnostic_cmd_test.go
@@ -49,3 +49,21 @@ func TestPrintDiagReport_BadTime(t *testing.T) {
 		t.Errorf("bad timestamp should be shown verbatim:\n%s", buf.String())
 	}
 }
+
+// TestPrintDiagReport_WithClaimCode: when a claim code is present, it leads as
+// the primary, public-safe hand-off (GH #357 claim-code).
+func TestPrintDiagReport_WithClaimCode(t *testing.T) {
+	var buf bytes.Buffer
+	printDiagReport(&buf, diagReport{
+		URL: "https://enclosed/#pw:k", Password: "pw", NoteID: "n1",
+		ByteCount: 1000, GeneratedAt: "2026-07-28T02:24:58Z", FileCount: 3,
+		ClaimCode: "JAB-7QX9K2P4",
+	})
+	out := buf.String()
+	if !strings.Contains(out, "JAB-7QX9K2P4") {
+		t.Errorf("claim code not shown:\n%s", out)
+	}
+	if !strings.Contains(out, "safe to share anywhere") {
+		t.Errorf("public-safe hint missing:\n%s", out)
+	}
+}

--- a/panel-api/cmd/server/system_ops_cmd.go
+++ b/panel-api/cmd/server/system_ops_cmd.go
@@ -96,6 +96,7 @@ type diagReport struct {
 	GeneratedAt    string `json:"generated_at"`
 	RedactionCount int    `json:"redaction_count"`
 	FileCount      int    `json:"file_count"`
+	ClaimCode      string `json:"claim_code"`
 }
 
 // printDiagReport renders a diagnostic bundle result as a human-readable block
@@ -110,8 +111,19 @@ func printDiagReport(w io.Writer, r diagReport) {
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "    %d files · %s · %d redactions\n", r.FileCount, humanBytes(uint64(r.ByteCount)), r.RedactionCount)
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, "  Give BOTH of these to Jabali support. Keep the password private —")
-	fmt.Fprintln(w, "  do NOT paste it into a public issue:")
+	if r.ClaimCode != "" {
+		// Preferred hand-off: a short code that's useless without support-team
+		// auth, so it's safe to paste anywhere — even a public issue.
+		fmt.Fprintln(w, "  Give Jabali support this code (safe to share anywhere, even a public issue):")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "      %s\n", r.ClaimCode)
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "  Advanced — the raw link + password (keep the password private, do NOT")
+		fmt.Fprintln(w, "  paste it in a public issue):")
+	} else {
+		fmt.Fprintln(w, "  Give BOTH of these to Jabali support. Keep the password private —")
+		fmt.Fprintln(w, "  do NOT paste it into a public issue:")
+	}
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "    Link       %s\n", r.URL)
 	fmt.Fprintf(w, "    Password   %s\n", r.Password)

--- a/panel-ui/src/hooks/useSupport.ts
+++ b/panel-ui/src/hooks/useSupport.ts
@@ -18,6 +18,10 @@ export interface DiagnosticReport {
   generated_at: string;
   redaction_count: number;
   file_count: number;
+  // Short, public-safe hand-off code (GH #357 claim-code). Present only when the
+  // operator configured a support-claim service (JABALI_CLAIM_URL); empty
+  // otherwise, in which case the link + password are the hand-off.
+  claim_code?: string;
 }
 
 export function useDiagnosticReport() {

--- a/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
+++ b/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
@@ -119,6 +119,36 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
             }
           />
 
+          {report.data.claim_code ? (
+            <Alert
+              type="success"
+              showIcon
+              message="Support claim code"
+              description={
+                <Space direction="vertical" size={8} style={{ width: "100%" }}>
+                  <Typography.Paragraph style={{ margin: 0 }}>
+                    Give this code to Jabali support — it&apos;s safe to share
+                    anywhere, even a public issue. The link + password below are
+                    only a fallback.
+                  </Typography.Paragraph>
+                  <Space.Compact style={{ display: "flex" }}>
+                    <Input
+                      value={report.data.claim_code}
+                      readOnly
+                      style={{ fontFamily: "monospace", fontWeight: 600 }}
+                    />
+                    <Button
+                      icon={<CopyOutlined />}
+                      onClick={() => copy("Claim code", report.data!.claim_code!)}
+                    >
+                      Copy
+                    </Button>
+                  </Space.Compact>
+                </Space>
+              }
+            />
+          ) : null}
+
           <div>
             <Typography.Text strong>Link</Typography.Text>
             <Space.Compact style={{ display: "flex", marginTop: 4 }}>

--- a/support-claim/.gitignore
+++ b/support-claim/.gitignore
@@ -1,0 +1,1 @@
+/support-claim

--- a/support-claim/README.md
+++ b/support-claim/README.md
@@ -1,0 +1,74 @@
+# support-claim
+
+A tiny operator-run service that turns a Jabali **diagnostic bundle**'s
+`{enclosed link + password}` into a short, **public-safe claim code** — so a user
+can paste `JAB-7QX9K2P4` into a GitHub issue instead of a long URL + password.
+
+## Why it exists
+
+`enclosed` (the diagnostic-bundle host) is **end-to-end encrypted** — its server
+never sees the decryption password. So it can't hand a password back on
+redemption, which means it can't be the thing that resolves a short code to the
+bundle. Something operator-side has to hold `{url, password}` and release it
+**only to the authenticated support team**. That is this service — nothing else.
+
+## Security model
+
+- **Issue** (`POST /claims`) is open. A caller can only shorten data they already
+  hold (their own bundle's url+password), so there's no inbound secret to guard.
+  Bounded by a 16 KiB body cap, a per-IP rate limit, and a short TTL.
+- **Redeem** (`GET /claims/{code}`) requires `Authorization: Bearer <token>`.
+  **The code alone is useless** — that's what makes it safe to paste in public.
+  The token is constant-time compared.
+- **Storage is in-memory** with a TTL sweeper. A restart drops pending claims
+  (fine — short-lived + regenerable). No secrets touch disk.
+
+## API
+
+```
+POST /claims
+  body: {"url","password","host","panel_sha","note_id","byte_count","file_count"}
+  200:  {"code":"JAB-7QX9K2P4","expires_at":"2026-08-11T02:24:58Z"}
+
+GET /claims/{code}          Authorization: Bearer <SUPPORT_CLAIM_TOKEN>
+  200: {"url","password","host","panel_sha","note_id","byte_count","file_count"}
+  401: missing/wrong token
+  404: unknown or expired code
+
+GET /healthz  ->  200 ok
+```
+
+## Run
+
+```bash
+go build -o support-claim ./...
+SUPPORT_CLAIM_TOKEN=<long-random-team-secret> \
+SUPPORT_CLAIM_LISTEN=:8088 \
+SUPPORT_CLAIM_TTL_HOURS=336 \
+SUPPORT_CLAIM_RATE_PER_MIN=30 \
+  ./support-claim
+```
+
+Put it behind TLS (a reverse proxy) next to your enclosed deployment, e.g.
+`https://claims.jabali-panel.com`.
+
+## Wire the panel to it
+
+Set `JABALI_CLAIM_URL` in the **jabali-agent** environment (drop-in on
+`jabali-agent.service`):
+
+```
+Environment=JABALI_CLAIM_URL=https://claims.jabali-panel.com
+```
+
+When set, `jabali system diagnostic` (and Support → Send Diagnostic Report)
+register a claim after uploading the bundle and show the short code as the
+primary hand-off. When unset, they fall back to the raw link + password — no
+request is made to a non-existent service.
+
+## Redeem (support side)
+
+```bash
+curl -s -H "Authorization: Bearer $SUPPORT_CLAIM_TOKEN" \
+  https://claims.jabali-panel.com/claims/JAB-7QX9K2P4 | jq
+```

--- a/support-claim/go.mod
+++ b/support-claim/go.mod
@@ -1,0 +1,6 @@
+// support-claim: standalone operator-run claim/redeem service for Jabali
+// diagnostic bundles. Stdlib-only; its own module so it builds + deploys
+// independently of the panel (the root go.mod's `go build ./...` ignores it).
+module git.jabali-panel.com/shukivaknin/jabali2/support-claim
+
+go 1.24

--- a/support-claim/main.go
+++ b/support-claim/main.go
@@ -1,0 +1,292 @@
+// support-claim is the tiny operator-run service that turns a Jabali diagnostic
+// bundle's {enclosed link + password} into a short, public-safe claim code.
+//
+// Why it exists: enclosed (enclosed.jabali-panel.com) is end-to-end encrypted —
+// its server never sees the decryption password, so it can't hand a password
+// back on redemption. To let a user share a *short* code publicly (e.g. paste
+// "JAB-7QX9K2" straight into a GitHub issue) instead of a long URL + password,
+// something operator-side has to hold the {url, password} and release it only to
+// the authenticated support team. That is this service, and nothing else.
+//
+// Security model:
+//   - Issue (POST /claims) is open: a caller can only shorten data they already
+//     hold (their own bundle url+password), so there's no secret to protect on
+//     the way in. Bounded by a body-size cap, a per-IP rate limit, and a short
+//     TTL.
+//   - Redeem (GET /claims/{code}) requires Authorization: Bearer <SUPPORT_TOKEN>.
+//     The code alone is useless — that's what makes it safe to paste in public.
+//     Redemption is constant-time-compared on the token and audited to stderr.
+//   - Storage is in-memory with a TTL sweeper. A restart drops pending claims;
+//     that's fine — they're short-lived and the user can regenerate. No secrets
+//     touch disk.
+//
+// Deploy: build this, run it behind TLS next to your enclosed deployment, set
+// SUPPORT_CLAIM_TOKEN, then point the panel at it with JABALI_CLAIM_URL in the
+// jabali-agent environment. See README.md.
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// codeAlphabet is Crockford base32 minus vowels/ambiguous chars, so a code
+	// is easy to read aloud and hard to typo (no O/0, I/1, L, U).
+	codeAlphabet = "23456789BCDFGHJKMNPQRSTVWXYZ"
+	codePrefix   = "JAB-"
+	codeLen      = 8
+	maxBodyBytes = 16 * 1024
+)
+
+// claim is one stored {url, password, metadata} keyed by a public code.
+type claim struct {
+	Payload   redeemPayload
+	ExpiresAt time.Time
+}
+
+// issueRequest is what the panel POSTs after uploading a bundle to enclosed.
+type issueRequest struct {
+	URL      string `json:"url"`
+	Password string `json:"password"`
+	Host     string `json:"host,omitempty"`
+	PanelSHA string `json:"panel_sha,omitempty"`
+	NoteID   string `json:"note_id,omitempty"`
+	Bytes    int64  `json:"byte_count,omitempty"`
+	Files    int    `json:"file_count,omitempty"`
+}
+
+// redeemPayload is what the support team receives on a valid, authenticated
+// redemption.
+type redeemPayload struct {
+	URL      string `json:"url"`
+	Password string `json:"password"`
+	Host     string `json:"host,omitempty"`
+	PanelSHA string `json:"panel_sha,omitempty"`
+	NoteID   string `json:"note_id,omitempty"`
+	Bytes    int64  `json:"byte_count,omitempty"`
+	Files    int    `json:"file_count,omitempty"`
+}
+
+type store struct {
+	mu     sync.Mutex
+	claims map[string]claim
+	ttl    time.Duration
+}
+
+func newStore(ttl time.Duration) *store {
+	return &store{claims: map[string]claim{}, ttl: ttl}
+}
+
+// put stores a payload under a fresh unique code and returns the code.
+func (s *store) put(p redeemPayload, now time.Time) (string, time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var code string
+	for i := 0; i < 8; i++ {
+		c, err := genCode()
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		if _, exists := s.claims[c]; !exists {
+			code = c
+			break
+		}
+	}
+	if code == "" {
+		return "", time.Time{}, fmt.Errorf("could not allocate a unique code")
+	}
+	exp := now.Add(s.ttl)
+	s.claims[code] = claim{Payload: p, ExpiresAt: exp}
+	return code, exp, nil
+}
+
+// get returns the payload for a code, or ok=false when it is unknown or expired.
+func (s *store) get(code string, now time.Time) (redeemPayload, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	c, ok := s.claims[code]
+	if !ok || now.After(c.ExpiresAt) {
+		if ok {
+			delete(s.claims, code) // lazy eviction
+		}
+		return redeemPayload{}, false
+	}
+	return c.Payload, true
+}
+
+// sweep evicts expired claims. Called periodically.
+func (s *store) sweep(now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for code, c := range s.claims {
+		if now.After(c.ExpiresAt) {
+			delete(s.claims, code)
+		}
+	}
+}
+
+// genCode returns a random public code like "JAB-7QX9K2P4".
+func genCode() (string, error) {
+	buf := make([]byte, codeLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	b.WriteString(codePrefix)
+	for _, x := range buf {
+		b.WriteByte(codeAlphabet[int(x)%len(codeAlphabet)])
+	}
+	return b.String(), nil
+}
+
+type server struct {
+	store *store
+	// token is the bearer secret the support team presents to redeem. Empty
+	// disables redemption (issue-only) — refuse to start in that state.
+	token string
+	limit *rateLimiter
+	now   func() time.Time
+}
+
+func (srv *server) handleIssue(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !srv.limit.allow(clientIP(r)) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+		return
+	}
+	var req issueRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+	if err := dec.Decode(&req); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if req.URL == "" || req.Password == "" {
+		http.Error(w, "url and password are required", http.StatusBadRequest)
+		return
+	}
+	code, exp, err := srv.store.put(redeemPayload(req), srv.now())
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	log.Printf("issued claim %s (host=%q note=%q expires=%s)", code, req.Host, req.NoteID, exp.UTC().Format(time.RFC3339))
+	writeJSON(w, http.StatusOK, map[string]any{
+		"code":       code,
+		"expires_at": exp.UTC().Format(time.RFC3339),
+	})
+}
+
+func (srv *server) handleRedeem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !srv.authorized(r) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	code := strings.TrimPrefix(r.URL.Path, "/claims/")
+	if code == "" || strings.Contains(code, "/") {
+		http.Error(w, "bad code", http.StatusBadRequest)
+		return
+	}
+	payload, ok := srv.store.get(code, srv.now())
+	if !ok {
+		http.Error(w, "not found or expired", http.StatusNotFound)
+		return
+	}
+	log.Printf("redeemed claim %s (host=%q)", code, payload.Host)
+	writeJSON(w, http.StatusOK, payload)
+}
+
+// authorized constant-time compares the request's bearer token to the secret.
+func (srv *server) authorized(r *http.Request) bool {
+	const p = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, p) {
+		return false
+	}
+	got := strings.TrimPrefix(h, p)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(srv.token)) == 1
+}
+
+func (srv *server) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/claims", srv.handleIssue)     // POST — issue
+	mux.HandleFunc("/claims/", srv.handleRedeem)   // GET /claims/{code} — redeem
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		return strings.TrimSpace(strings.Split(xff, ",")[0])
+	}
+	host := r.RemoteAddr
+	if i := strings.LastIndex(host, ":"); i >= 0 {
+		host = host[:i]
+	}
+	return host
+}
+
+func main() {
+	token := os.Getenv("SUPPORT_CLAIM_TOKEN")
+	if token == "" {
+		log.Fatal("SUPPORT_CLAIM_TOKEN is required (the bearer secret the support team redeems with)")
+	}
+	listen := envOr("SUPPORT_CLAIM_LISTEN", ":8088")
+	ttlHours, _ := strconv.Atoi(envOr("SUPPORT_CLAIM_TTL_HOURS", "336")) // 14 days
+	if ttlHours <= 0 {
+		ttlHours = 336
+	}
+	rpm, _ := strconv.Atoi(envOr("SUPPORT_CLAIM_RATE_PER_MIN", "30"))
+
+	st := newStore(time.Duration(ttlHours) * time.Hour)
+	srv := &server{store: st, token: token, limit: newRateLimiter(rpm), now: time.Now}
+
+	go func() {
+		t := time.NewTicker(time.Hour)
+		defer t.Stop()
+		for range t.C {
+			st.sweep(time.Now())
+		}
+	}()
+
+	log.Printf("support-claim listening on %s (ttl=%dh, rate=%d/min)", listen, ttlHours, rpm)
+	httpSrv := &http.Server{
+		Addr:              listen,
+		Handler:           srv.routes(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}

--- a/support-claim/main_test.go
+++ b/support-claim/main_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testServer(now time.Time) (*server, *httptest.Server) {
+	clock := now
+	srv := &server{
+		store: newStore(24 * time.Hour),
+		token: "s3cret-team-token",
+		limit: newRateLimiter(1000),
+		now:   func() time.Time { return clock },
+	}
+	return srv, httptest.NewServer(srv.routes())
+}
+
+func issue(t *testing.T, ts *httptest.Server, body string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/claims", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func redeem(t *testing.T, ts *httptest.Server, code, token string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/claims/"+code, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestIssueAndRedeem(t *testing.T) {
+	_, ts := testServer(time.Unix(1_700_000_000, 0))
+	defer ts.Close()
+
+	resp := issue(t, ts, `{"url":"https://enclosed/#pw:k","password":"pw123","host":"mx","note_id":"n1","byte_count":468480,"file_count":50}`)
+	if resp.StatusCode != 200 {
+		t.Fatalf("issue status = %d", resp.StatusCode)
+	}
+	var ir struct {
+		Code      string `json:"code"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&ir)
+	if !strings.HasPrefix(ir.Code, "JAB-") || len(ir.Code) != 4+codeLen {
+		t.Fatalf("bad code %q", ir.Code)
+	}
+
+	// Redeem with the team token → the full payload.
+	rr := redeem(t, ts, ir.Code, "s3cret-team-token")
+	if rr.StatusCode != 200 {
+		t.Fatalf("redeem status = %d", rr.StatusCode)
+	}
+	var p redeemPayload
+	_ = json.NewDecoder(rr.Body).Decode(&p)
+	if p.URL != "https://enclosed/#pw:k" || p.Password != "pw123" || p.Files != 50 {
+		t.Fatalf("payload mismatch: %+v", p)
+	}
+}
+
+func TestRedeemRequiresToken(t *testing.T) {
+	_, ts := testServer(time.Unix(1_700_000_000, 0))
+	defer ts.Close()
+	var ir struct {
+		Code string `json:"code"`
+	}
+	_ = json.NewDecoder(issue(t, ts, `{"url":"u","password":"p"}`).Body).Decode(&ir)
+
+	// No token → 401.
+	if r := redeem(t, ts, ir.Code, ""); r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("no-token redeem = %d, want 401", r.StatusCode)
+	}
+	// Wrong token → 401.
+	if r := redeem(t, ts, ir.Code, "wrong"); r.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong-token redeem = %d, want 401", r.StatusCode)
+	}
+}
+
+func TestRedeemUnknownAndExpired(t *testing.T) {
+	srv, ts := testServer(time.Unix(1_700_000_000, 0))
+	defer ts.Close()
+	// Unknown code → 404 (with valid auth).
+	if r := redeem(t, ts, "JAB-ZZZZZZZZ", "s3cret-team-token"); r.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown redeem = %d, want 404", r.StatusCode)
+	}
+	// Issue, then advance the clock past TTL → 404.
+	var ir struct {
+		Code string `json:"code"`
+	}
+	_ = json.NewDecoder(issue(t, ts, `{"url":"u","password":"p"}`).Body).Decode(&ir)
+	srv.now = func() time.Time { return time.Unix(1_700_000_000, 0).Add(48 * time.Hour) }
+	if r := redeem(t, ts, ir.Code, "s3cret-team-token"); r.StatusCode != http.StatusNotFound {
+		t.Errorf("expired redeem = %d, want 404", r.StatusCode)
+	}
+}
+
+func TestIssueValidatesRequired(t *testing.T) {
+	_, ts := testServer(time.Unix(1_700_000_000, 0))
+	defer ts.Close()
+	if r := issue(t, ts, `{"url":"","password":"p"}`); r.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing url = %d, want 400", r.StatusCode)
+	}
+	if r := issue(t, ts, `{"url":"u","password":""}`); r.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing password = %d, want 400", r.StatusCode)
+	}
+}
+
+func TestRateLimit(t *testing.T) {
+	srv := &server{
+		store: newStore(time.Hour),
+		token: "t",
+		limit: newRateLimiter(2), // 2/min
+		now:   time.Now,
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+	codes := 0
+	for i := 0; i < 5; i++ {
+		if issue(t, ts, `{"url":"u","password":"p"}`).StatusCode == 200 {
+			codes++
+		}
+	}
+	// The burst allows ~perMin issues, then 429s. Must not allow all 5.
+	if codes >= 5 {
+		t.Errorf("rate limiter let all %d through", codes)
+	}
+	if codes == 0 {
+		t.Errorf("rate limiter blocked everything")
+	}
+}

--- a/support-claim/ratelimit.go
+++ b/support-claim/ratelimit.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// rateLimiter is a tiny per-key (per-IP) token bucket: `perMin` tokens that
+// refill continuously, capped at `perMin`. Enough to blunt claim-issue spam
+// without a dependency. Not a security boundary — redemption auth is.
+type rateLimiter struct {
+	mu     sync.Mutex
+	perMin int
+	rate   float64 // tokens per second
+	bucket map[string]*tokenBucket
+	now    func() time.Time
+}
+
+type tokenBucket struct {
+	tokens float64
+	last   time.Time
+}
+
+func newRateLimiter(perMin int) *rateLimiter {
+	if perMin <= 0 {
+		perMin = 30
+	}
+	return &rateLimiter{
+		perMin: perMin,
+		rate:   float64(perMin) / 60.0,
+		bucket: map[string]*tokenBucket{},
+		now:    time.Now,
+	}
+}
+
+// allow consumes one token for key, returning false when the bucket is empty.
+func (rl *rateLimiter) allow(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := rl.now()
+	b, ok := rl.bucket[key]
+	if !ok {
+		rl.bucket[key] = &tokenBucket{tokens: float64(rl.perMin) - 1, last: now}
+		return true
+	}
+	elapsed := now.Sub(b.last).Seconds()
+	b.tokens += elapsed * rl.rate
+	if b.tokens > float64(rl.perMin) {
+		b.tokens = float64(rl.perMin)
+	}
+	b.last = now
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}


### PR DESCRIPTION
## What

Sharing a diagnostic bundle meant handing over a long `enclosed` link **and** a password — clumsy, and unsafe to paste in a public issue. This adds a short, **public-safe claim code** (`JAB-XXXXXXXX`) as the primary hand-off: the user shares the code; only the **authenticated support team** can redeem it for the bundle.

## Why a new service

`enclosed` is end-to-end encrypted — its server never sees the password, so it can't resolve a short code back to `{url, password}`. That store has to be operator-side, released only to the support team.

## Pieces

- **`support-claim/`** — standalone, **stdlib-only** reference service (its own Go module; the root `go build ./...` ignores it).
  - `POST /claims` issues a code — open (you can only shorten data you already hold), rate-limited, 16 KiB cap, TTL.
  - `GET /claims/{code}` redeems behind a **constant-time Bearer token** → the code alone is useless, which is what makes it public-safe.
  - In-memory (no secrets on disk), TTL-swept. README + tests (issue/redeem/auth/expiry/validation/rate-limit).
- **panel-agent** — after the enclosed upload, `system.diagnostic_report` optionally registers a claim and returns `claim_code`. **Opt-in via `JABALI_CLAIM_URL`** — unset ⇒ no request, raw link+password as before. Best-effort (failure ⇒ empty `claim_code`).
- **CLI** (`jabali system diagnostic`) — leads with the claim code when present ("safe to share anywhere, even a public issue"), link+password as fallback.
- **GUI** (Diagnostic Report modal) — a prominent "Support claim code" block with Copy when set; link/password/email stay as fallback.

## Deploy (operator)

Build + run `support-claim` behind TLS next to enclosed, set `SUPPORT_CLAIM_TOKEN`, then set `JABALI_CLAIM_URL=https://claims.jabali-panel.com` in the jabali-agent environment. See `support-claim/README.md`.

## Tests

- agent claim registration (forwarded payload + non-200 error path)
- CLI render (claim-code + no-code paths)
- reference service (5 cases)
- `tsc -b` + eslint clean; CLI golden unchanged (no new command/flag)

Note: `support-claim/` is a separate module, so the panel's CI "Go tests + vet" won't run its tests — verified locally (`cd support-claim && go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)