### PR TITLE
fix(python-apps): stop the pip retry-storm + name the failing package (GH #357)

### DIFF
--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -197,19 +197,37 @@ func pythonAppApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("hash requirements.txt: %v", herr)}
 		}
 		prev, _ := os.ReadFile(reqMarker)
+		reqFailMarker := filepath.Join(pythonAppEnvDir, p.AppID+".reqfail")
 		if strings.TrimSpace(string(prev)) != sum {
-			if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", "-r", reqPath); err != nil {
-				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install requirements: %v: %s", err, lastLines(out, 12))}
+			// GH #357: a deterministically-failing build must not re-run pip on
+			// every converge tick (~60s) — one broken app stormed pip ~95
+			// times/hour. If the last FAILED attempt was for these SAME
+			// requirements and we're still inside the backoff, surface the
+			// cached error without touching pip. A requirements.txt edit (new
+			// sha) or the backoff elapsing retries.
+			if f := readReqFail(reqFailMarker); f.SHA == sum && time.Since(time.Unix(f.At, 0)) < pipRetryBackoff {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: f.Error}
+			}
+			// No -q: quiet mode hides the "Collecting <pkg>" lines that name the
+			// package pip was building when it failed, so a build error came back
+			// as a bare traceback ("KeyError: '__version__'") with no clue which
+			// dependency broke (GH #357). Success output is discarded, so the
+			// only effect of dropping -q is a more useful failure message.
+			if out, err := runAsUser(ctx, p.Username, pip, "install", "-r", reqPath); err != nil {
+				msg := fmt.Sprintf("pip install requirements: %v: %s", err, pipFailureContext(out))
+				writeReqFail(reqFailMarker, sum, msg, time.Now())
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: msg}
 			}
 			_ = os.WriteFile(reqMarker, []byte(sum), 0o640)
+			_ = os.Remove(reqFailMarker) // clear the cached failure on success
 			needsRestart = true
 		}
 	}
 
 	// App server: install only when its binary is missing from the venv.
 	if _, err := os.Stat(filepath.Join(venv, "bin", server)); err != nil {
-		if out, err := runAsUser(ctx, p.Username, pip, "install", "-q", server); err != nil {
-			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install %s: %v: %s", server, err, lastLines(out, 8))}
+		if out, err := runAsUser(ctx, p.Username, pip, "install", server); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pip install %s: %v: %s", server, err, pipFailureContext(out))}
 		}
 		needsRestart = true
 	}
@@ -404,6 +422,67 @@ func lastLines(s string, n int) string {
 		lines = lines[len(lines)-n:]
 	}
 	return strings.Join(lines, "\n")
+}
+
+// pipRetryBackoff caps how often a DETERMINISTICALLY-failing `pip install` is
+// retried for the SAME requirements. Without it the reconciler re-ran pip every
+// converge tick (~60s) forever on an app whose deps can't build (GH #357: ~95
+// failures/hour observed). A requirements.txt edit clears the failure and
+// retries immediately regardless of this backoff.
+const pipRetryBackoff = 15 * time.Minute
+
+// reqFailState is the cached record of the last failed `pip install -r
+// requirements.txt`, so a re-converge for the same requirements can surface the
+// error without re-running pip (GH #357 pip-storm).
+type reqFailState struct {
+	SHA   string `json:"sha"`   // sha256 of requirements.txt at the failed attempt
+	Error string `json:"error"` // the message to surface while backed off
+	At    int64  `json:"at"`    // unix seconds of the last attempt
+}
+
+func readReqFail(path string) reqFailState {
+	var s reqFailState
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &s)
+	}
+	return s
+}
+
+func writeReqFail(path, sha, errText string, now time.Time) {
+	b, err := json.Marshal(reqFailState{SHA: sha, Error: errText, At: now.Unix()})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, b, 0o640)
+}
+
+// pipFailureContext pulls the package-identifying lines out of pip's output
+// (the "Collecting <pkg>" / "Building wheel for <pkg>" lines pip prints while
+// processing the dep it then failed on) and appends the tail, so the stored
+// error names WHICH dependency broke — the plain last-N-lines tail dropped it
+// (GH #357). Requires pip to run without -q (quiet hides those lines).
+func pipFailureContext(out string) string {
+	var ids []string
+	for _, ln := range strings.Split(out, "\n") {
+		l := strings.TrimSpace(ln)
+		if strings.HasPrefix(l, "Collecting ") ||
+			strings.HasPrefix(l, "Building wheel for ") ||
+			strings.HasPrefix(l, "Failed building wheel for ") ||
+			strings.HasPrefix(l, "ERROR: Could not build wheels for") ||
+			strings.Contains(l, "wheel for ") {
+			ids = append(ids, l)
+		}
+	}
+	// Keep the last few — pip processes deps in order, so the tail of this list
+	// is the package it was on when it failed.
+	if len(ids) > 4 {
+		ids = ids[len(ids)-4:]
+	}
+	tail := lastLines(out, 12)
+	if len(ids) == 0 {
+		return tail
+	}
+	return strings.Join(ids, "\n") + "\n...\n" + tail
 }
 
 func init() {

--- a/panel-agent/internal/commands/python_app_pipfail_test.go
+++ b/panel-agent/internal/commands/python_app_pipfail_test.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// GH #357: pip build failures must name the offending package and must not
+// re-run pip every converge tick.
+
+func TestPipFailureContext_NamesPackage(t *testing.T) {
+	out := `Collecting django==2.2
+  Downloading Django-2.2.tar.gz
+Collecting wagtail==2.6
+  Downloading wagtail-2.6.tar.gz
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'error'
+  error: subprocess-exited-with-error
+
+  × Getting requirements to build wheel did not run successfully.
+  │ exit code: 1
+  ╰─> File "<string>", line 240, in get_version
+      KeyError: '__version__'`
+	ctx := pipFailureContext(out)
+	if !strings.Contains(ctx, "wagtail") {
+		t.Errorf("failing package not named in context:\n%s", ctx)
+	}
+	if !strings.Contains(ctx, "KeyError: '__version__'") {
+		t.Errorf("traceback tail missing:\n%s", ctx)
+	}
+}
+
+func TestPipFailureContext_FallbackWhenNoPackageLines(t *testing.T) {
+	// Quiet-mode-like output (no Collecting/wheel lines) still returns the tail.
+	out := "error: subprocess-exited-with-error\nKeyError: '__version__'"
+	ctx := pipFailureContext(out)
+	if !strings.Contains(ctx, "KeyError") {
+		t.Errorf("tail missing:\n%s", ctx)
+	}
+}
+
+func TestReqFailRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "app.reqfail")
+	now := time.Unix(1_700_000_000, 0)
+
+	writeReqFail(p, "abc123", "pip install requirements failed: wagtail", now)
+	f := readReqFail(p)
+	if f.SHA != "abc123" || !strings.Contains(f.Error, "wagtail") || f.At != now.Unix() {
+		t.Errorf("round-trip mismatch: %+v", f)
+	}
+	// Absent file → zero value (first attempt runs pip).
+	if z := readReqFail(filepath.Join(dir, "nope")); z.SHA != "" {
+		t.Errorf("absent marker should be zero value: %+v", z)
+	}
+}
+
+// TestPipRetryBackoffGate models the reconciler's decision: skip pip when the
+// last failure was for the SAME requirements and we're still inside the backoff.
+func TestPipRetryBackoffGate(t *testing.T) {
+	now := time.Now()
+
+	recent := reqFailState{SHA: "s", At: now.Add(-2 * time.Minute).Unix()}
+	if !(recent.SHA == "s" && time.Since(time.Unix(recent.At, 0)) < pipRetryBackoff) {
+		t.Error("a recent same-sha failure must be within backoff (skip pip)")
+	}
+	old := reqFailState{SHA: "s", At: now.Add(-30 * time.Minute).Unix()}
+	if old.SHA == "s" && time.Since(time.Unix(old.At, 0)) < pipRetryBackoff {
+		t.Error("a 30-min-old failure must be past backoff (retry pip)")
+	}
+	// Different requirements (sha changed) → never gated, always retry.
+	changed := reqFailState{SHA: "old", At: now.Unix()}
+	if changed.SHA == "new" {
+		t.Error("sanity: changed sha should not equal the current sum")
+	}
+}


### PR DESCRIPTION
## Context

Decrypting a stuck Python app's diagnostic bundle (webquest-nz, EOL Wagtail/Django stack) showed the app fails because one of the **user's dependencies can't build a wheel** under modern setuptools (`get_version → KeyError: '__version__'`). That's app-side — but the panel made it far more painful than it should be. Two papercuts:

## 1. Pip retry-storm

The requirements-hash marker (`.reqsha`) is only written on a **successful** `pip install`, so a **deterministically-failing** build was never gated — the reconciler re-ran pip on **every ~60s converge tick, forever** (~95 failures/hour in the captured journal).

Fix: cache the failed attempt (`.reqfail` = `{sha, error, at}`). A re-converge for the **same** requirements within a **15-minute backoff** surfaces the cached error without touching pip. Editing `requirements.txt` (new sha) clears it and retries immediately.

## 2. Unnamed failing package

The stored error kept only the last ~12 pip lines, and pip ran with `-q` — which hides the `Collecting <pkg>` line — so the failure came back as a bare `KeyError: '__version__'` traceback with **no clue which dependency broke**.

Fix: run the requirements install **without `-q`** (output is discarded on success, so the only effect is a better failure message), and `pipFailureContext()` pulls the package-identifying lines (`Collecting …` / `Building wheel for …`) out before the tail. Applied to the app-server install too.

## Tests

- `pipFailureContext` names the package + falls back to the tail when there are no package lines.
- `.reqfail` marker round-trip.
- backoff gate logic (recent same-sha → skip; 30-min-old → retry).
- existing python-app tests unchanged; `go vet` clean.

Separate from #735 (claim-code) — this is the panel-side robustness for #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)