### PR TITLE
fix(migrate/plesk): read the real docroot from psa hosting.www_root (GH #429)

### DIFF
--- a/panel-api/internal/migrate/plesk/areas.go
+++ b/panel-api/internal/migrate/plesk/areas.go
@@ -53,18 +53,28 @@ func (d *Discoverer) describeDomains(ctx context.Context, s *session, account st
 		}
 	}
 
+	// GH #429: read each domain's REAL docroot from psa `hosting.www_root`
+	// instead of assuming /var/www/vhosts/<dom>/httpdocs. Plesk keeps a whole
+	// subscription under ONE vhost dir keyed by the main domain, so a
+	// subdomain/addon has a custom root (e.g. .../<main>/site1) and a no-hosting
+	// (mail/parked) domain has none. The old assumption pointed the rsync at an
+	// empty/nonexistent path. The JOIN yields no row for a no-hosting domain, so
+	// it simply has no docroot. (Validated on Plesk Obsidian 18.0.79.)
+	docroots := pleskDocroots(ctx, d, s, domains)
+
 	rows := make([]migrate.DomainSpec, 0, len(domains))
 	for _, dom := range domains {
+		root := docroots[dom]
 		spec := migrate.DomainSpec{
 			Name:      dom,
-			DocRoot:   fmt.Sprintf("%s/%s/httpdocs", pleskVhostRoot, dom),
+			DocRoot:   root,       // "" when the domain has no physical hosting
 			IsPrimary: dom == account,
-			HasPHP:    true,
+			HasPHP:    root != "", // no hosting => no PHP; refined below
 		}
 		if out, err := s.run(ctx, d.CommandTimeout, "plesk bin domain --info "+shellQuote(dom)); err == nil {
 			di := parsePleskInfo(string(out))
 			// Real Plesk exposes "PHP support: Yes" (not "php"); PHP version
-			// isn't in this block. Docroot stays the standard vhost path.
+			// isn't in this block.
 			if v := firstNonEmpty(di["php support"], di["php"]); v != "" {
 				spec.HasPHP = truthy(v)
 			}
@@ -75,6 +85,37 @@ func (d *Discoverer) describeDomains(ctx context.Context, s *session, account st
 		rows = append(rows, spec)
 	}
 	return rows, nil
+}
+
+// pleskDocroots batch-reads the real docroot for each domain from psa
+// `hosting.www_root` (GH #429). Domains with no hosting are absent from the
+// result. Best-effort: a query failure yields an empty map and the caller
+// records empty docroots (better than a wrong path).
+func pleskDocroots(ctx context.Context, d *Discoverer, s *session, domains []string) map[string]string {
+	out := map[string]string{}
+	if len(domains) == 0 {
+		return out
+	}
+	quoted := make([]string, len(domains))
+	for i, dn := range domains {
+		quoted[i] = sqlQuote(dn)
+	}
+	sql := "SELECT d.name, h.www_root FROM domains d JOIN hosting h ON d.id=h.dom_id WHERE d.name IN (" +
+		strings.Join(quoted, ",") + ")"
+	raw, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql))
+	if err != nil {
+		return out
+	}
+	for _, ln := range splitLines(string(raw)) {
+		parts := strings.SplitN(ln, "\t", 2)
+		if len(parts) == 2 {
+			name, root := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+			if name != "" && root != "" && root != "NULL" {
+				out[name] = root
+			}
+		}
+	}
+	return out
 }
 
 // describeDatabases lists the MySQL databases for each domain via

--- a/panel-api/internal/migrate/plesk/areas_test.go
+++ b/panel-api/internal/migrate/plesk/areas_test.go
@@ -65,7 +65,10 @@ func TestDescribeDomains_DocrootAndPHP(t *testing.T) {
 	s := fixtureSession(map[string]string{
 		// domains enumerated from the psa DB (primary + addon); key is a
 		// quote-free substring of the shell-escaped `plesk db` command.
-		"SELECT name FROM domains":          "example.com\naddon.example.net\n",
+		"SELECT name FROM domains": "example.com\naddon.example.net\n",
+		// GH #429: real docroots from psa hosting.www_root. The addon's root
+		// lives under the primary's vhost dir, not /var/www/vhosts/addon…/httpdocs.
+		"h.www_root FROM domains":           "example.com\t/var/www/vhosts/example.com/httpdocs\naddon.example.net\t/var/www/vhosts/example.com/addon\n",
 		"domain --info 'example.com'":       "PHP support:  Yes\n",
 		"domain --info 'addon.example.net'": "PHP support:  Yes\n",
 	})
@@ -80,13 +83,50 @@ func TestDescribeDomains_DocrootAndPHP(t *testing.T) {
 		t.Errorf("row0 primary/name wrong: %+v", rows[0])
 	}
 	if rows[0].DocRoot != "/var/www/vhosts/example.com/httpdocs" {
-		t.Errorf("primary docroot = %q, want default vhost path", rows[0].DocRoot)
+		t.Errorf("primary docroot = %q, want the real www_root", rows[0].DocRoot)
+	}
+	if rows[1].DocRoot != "/var/www/vhosts/example.com/addon" {
+		t.Errorf("addon docroot = %q, want the real www_root under the primary vhost", rows[1].DocRoot)
 	}
 	if !rows[0].HasPHP {
 		t.Error("primary should have PHP (PHP support: Yes)")
 	}
 	if rows[1].IsPrimary {
 		t.Error("addon domain must not be primary")
+	}
+}
+
+// TestDescribeDomains_RealPleskDocroots_GH429 uses the exact layout observed on
+// a live Plesk Obsidian 18.0.79 box (demolab.test): a subdomain's docroot is a
+// custom dir UNDER the main domain's vhost, and a second domain has NO hosting
+// (www_root NULL → excluded by the JOIN → empty docroot). The old
+// /var/www/vhosts/<dom>/httpdocs assumption silently dropped the subdomain's
+// web content and pointed the no-hosting domain at a nonexistent path.
+func TestDescribeDomains_RealPleskDocroots_GH429(t *testing.T) {
+	d := New()
+	s := fixtureSession(map[string]string{
+		"SELECT name FROM domains": "demolab.test\nshop.demolab.test\nsecond-demolab.test\n",
+		// The JOIN yields no row for second-demolab.test (no hosting).
+		"h.www_root FROM domains": "demolab.test\t/var/www/vhosts/demolab.test/httpdocs\n" +
+			"shop.demolab.test\t/var/www/vhosts/demolab.test/site1\n",
+		"domain --info": "PHP support: Yes\n",
+	})
+	rows, err := d.describeDomains(context.Background(), s, "demolab.test")
+	if err != nil {
+		t.Fatalf("describeDomains: %v", err)
+	}
+	byName := map[string]migrate.DomainSpec{}
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+	if got := byName["shop.demolab.test"].DocRoot; got != "/var/www/vhosts/demolab.test/site1" {
+		t.Errorf("subdomain docroot = %q, want the real .../demolab.test/site1", got)
+	}
+	if got := byName["second-demolab.test"].DocRoot; got != "" {
+		t.Errorf("no-hosting domain docroot = %q, want empty (skip web)", got)
+	}
+	if got := byName["demolab.test"].DocRoot; got != "/var/www/vhosts/demolab.test/httpdocs" {
+		t.Errorf("primary docroot = %q", got)
 	}
 }
 

--- a/panel-api/internal/migrate/plesk/backup.go
+++ b/panel-api/internal/migrate/plesk/backup.go
@@ -91,8 +91,15 @@ plesk db -Ne "SELECT db.name FROM data_bases db JOIN domains d ON db.dom_id=d.id
 plesk db -Ne "SELECT name FROM domains WHERE name='$SUB' OR webspace_id=(SELECT id FROM domains WHERE name='$SUB' LIMIT 1)" 2>/dev/null \
 | while read -r DOM; do
     [ -z "$DOM" ] && continue
-    DR="/var/www/vhosts/$DOM/httpdocs"
-    [ -d "$DR" ] && printf '%%s\t%%s\n' "$DOM" "$DR" >> "$TMP/cpmove-$SLUG/domains-paths.txt"
+    # GH #429: the docroot is NOT always /var/www/vhosts/<dom>/httpdocs. Plesk
+    # puts a whole subscription under ONE vhost dir keyed by the main domain,
+    # and a subdomain/addon has a custom root under it (e.g. .../<main>/site1);
+    # a no-hosting (mail/parked) domain has none. Read the real root from psa
+    # hosting.www_root — the JOIN yields nothing for no-hosting domains, so they
+    # are skipped. (Validated on Plesk Obsidian 18.0.79: shop.demolab.test ->
+    # /var/www/vhosts/demolab.test/site1, second-demolab.test -> NULL.)
+    DR=$(plesk db -Ne "SELECT h.www_root FROM domains d JOIN hosting h ON d.id=h.dom_id WHERE d.name='$DOM'" 2>/dev/null)
+    [ -n "$DR" ] && [ -d "$DR" ] && printf '%%s\t%%s\n' "$DOM" "$DR" >> "$TMP/cpmove-$SLUG/domains-paths.txt"
     touch "$TMP/cpmove-$SLUG/dnszones/$DOM.db"
   done
 


### PR DESCRIPTION
## What

First live test against a **Plesk Obsidian 18.0.79** box (thanks for the server) surfaced a real bug. The importer assumed every domain's docroot is `/var/www/vhosts/<domain>/httpdocs`, but Plesk keeps a whole subscription under **one** vhost dir keyed by the main domain — so a subdomain/addon has a custom root under it, and a no-hosting (mail/parked) domain has none.

Observed on the `demolab.test` subscription:

| Domain | assumed | **real** (`hosting.www_root`) |
|---|---|---|
| demolab.test | `…/demolab.test/httpdocs` | `…/demolab.test/httpdocs` ✓ |
| shop.demolab.test (subdomain) | `…/shop.demolab.test/httpdocs` | **`…/demolab.test/site1`** |
| second-demolab.test | `…/second-demolab.test/httpdocs` | **NULL (no hosting)** |

**Impact today:** the synthesize script's `[ -d /var/www/vhosts/shop…/httpdocs ]` check fails → the subdomain is **never** added to `domains-paths.txt` and its web content is **silently dropped**; the no-hosting domain points the rsync at a nonexistent path.

## Fix

Read the real docroot from the psa `hosting.www_root` column (INNER JOIN, so no-hosting domains have no row → skipped):
- **`backup.go`** synthesize script (the actual pull): `DR` now comes from the `www_root` query per domain.
- **`areas.go`** `describeDomains` (discovery): batch-reads `www_root` into a map; `DocRoot` is the real path or `""` for no-hosting domains.

## Validation

Live on the box, the fixed logic:
```
demolab.test        -> …/demolab.test/httpdocs   [INCLUDED, 21 entries]
shop.demolab.test   -> …/demolab.test/site1       [INCLUDED, 1 entry]   ← was DROPPED
second-demolab.test -> no hosting                 [SKIPPED correctly]  ← was a dead path
```

Unit tests use the exact observed layout as fixtures; existing describe tests updated; `go vet` + full `panel-api` build clean.

Note: the full pull→import→verify E2E still needs a jabali box on the same LAN as the Plesk source (testserver can't reach the private IP) — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)