### PR TITLE
fix(updates): suppress benign transient-unit log noise after apt (GH #739)

### DIFF
--- a/panel-agent/internal/commands/system_unit_status.go
+++ b/panel-agent/internal/commands/system_unit_status.go
@@ -60,7 +60,7 @@ func systemUnitStatusFor(unit string) func(context.Context, json.RawMessage) (an
 		resp := systemUnitStatusResponse{
 			Unit:      unit,
 			Status:    status,
-			LogTail:   string(journalOut),
+			LogTail:   stripTransientNoise(string(journalOut), unit),
 			FetchedAt: time.Now().UTC().Format(time.RFC3339Nano),
 		}
 
@@ -76,6 +76,30 @@ func systemUnitStatusFor(unit string) func(context.Context, json.RawMessage) (an
 		}
 		return resp, nil
 	}
+}
+
+// stripTransientNoise drops systemd's own benign "Failed to open
+// /run/systemd/transient/<unit>: No such file or directory" lines from a unit's
+// journal tail (GH #739). We run apt/update in a `systemd-run --no-block`
+// transient unit; a package postinst's `systemctl daemon-reload` races the
+// cleanup of that transient unit, so systemd logs the open-failure while
+// re-reading the just-removed transient file. The update itself succeeds — the
+// lines are pure noise that made operators think a package update half-failed.
+// Scoped to this unit's transient path so unrelated log lines are untouched.
+func stripTransientNoise(logTail, unit string) string {
+	needle := "Failed to open /run/systemd/transient/" + unit
+	if !strings.Contains(logTail, needle) {
+		return logTail
+	}
+	lines := strings.Split(logTail, "\n")
+	kept := lines[:0]
+	for _, ln := range lines {
+		if strings.Contains(ln, needle) {
+			continue
+		}
+		kept = append(kept, ln)
+	}
+	return strings.Join(kept, "\n")
 }
 
 func init() {

--- a/panel-agent/internal/commands/system_unit_status_gh739_test.go
+++ b/panel-agent/internal/commands/system_unit_status_gh739_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripTransientNoise_GH739 uses the exact lines lxsdevcode saw at the end
+// of a successful package update: the benign systemd "Failed to open
+// /run/systemd/transient/…" spam must be removed, real apt/unit output kept.
+func TestStripTransientNoise_GH739(t *testing.T) {
+	unit := "jabali-apt-oneshot.service"
+	logTail := strings.Join([]string{
+		"jabali-apt-oneshot.service: Deactivated successfully.",
+		"jabali-apt-oneshot.service: Consumed 2.596s CPU time, 153.5M memory peak.",
+		"jabali-apt-oneshot.service: Failed to open /run/systemd/transient/jabali-apt-oneshot.service: No such file or directory",
+		"jabali-apt-oneshot.service: Failed to open /run/systemd/transient/jabali-apt-oneshot.service: No such file or directory",
+		"jabali-apt-oneshot.service: Failed to open /run/systemd/transient/jabali-apt-oneshot.service: No such file or directory",
+		"Setting up somepkg (1.2.3) ...",
+	}, "\n")
+
+	got := stripTransientNoise(logTail, unit)
+	if strings.Contains(got, "Failed to open /run/systemd/transient") {
+		t.Errorf("transient-GC noise not stripped:\n%s", got)
+	}
+	for _, want := range []string{"Deactivated successfully", "Consumed 2.596s", "Setting up somepkg"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stripped real content %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestStripTransientNoise_ScopedAndNoOp(t *testing.T) {
+	unit := "jabali-apt-oneshot.service"
+
+	// A clean log is returned unchanged (no allocation churn either).
+	clean := "Setting up foo\njabali-apt-oneshot.service: Deactivated successfully.\n"
+	if got := stripTransientNoise(clean, unit); got != clean {
+		t.Errorf("clean log changed:\n%q", got)
+	}
+
+	// Scoped: a DIFFERENT unit's transient line must NOT be stripped.
+	other := "other.service: Failed to open /run/systemd/transient/other.service: No such file or directory\n"
+	if got := stripTransientNoise(other, unit); got != other {
+		t.Errorf("stripped an unrelated unit's line:\n%q", got)
+	}
+}


### PR DESCRIPTION
## What (GH #739)

A **successful** package update ended its log with:

```
jabali-apt-oneshot.service: Deactivated successfully.
jabali-apt-oneshot.service: Consumed 2.596s CPU time, 153.5M memory peak.
jabali-apt-oneshot.service: Failed to open /run/systemd/transient/jabali-apt-oneshot.service: No such file or directory   ×5
```

which reads like a failure but is pure systemd noise.

## Root cause

We run apt in a `systemd-run --no-block` transient unit (`jabali-apt-oneshot`). apt's package **postinst scripts fire `systemctl daemon-reload` repeatedly**, and those race the cleanup of that transient unit — so systemd logs the open-failure while re-reading the just-removed transient file (~one line per racing reload). The update itself succeeds. (Reproduced the reasoning by ruling out `show`/`is-active`/`daemon-reload`/`daemon-reexec` on a GC'd unit in isolation — none log it; only the concurrent-with-cleanup reload does.)

`--collect` would avoid the race but is **intentionally omitted** so a *failed* unit lingers for the reconciler to read its exit code — so it can't be used here.

## Fix

Strip these systemd-internal `Failed to open /run/systemd/transient/<unit>` lines from the journal tail the panel surfaces (`system.apt_status` / `update_status` / `repair_status` / `nspawn_build_status` share the handler). Scoped to the unit's own transient path, so unrelated log lines are untouched.

## Tests

- The exact #739 lines are stripped; real apt/unit output (`Deactivated`, `Consumed`, `Setting up …`) kept.
- A clean log is returned unchanged.
- A **different** unit's transient line is NOT stripped (scoping).

Agent-only; `go vet` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)