### PR TITLE
feat(backups): collapsed Full Server run row shows 'system + N accounts' (GH #502)

### DIFF
--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -66,6 +66,10 @@ type BackupRunSummary struct {
 	Kind          string    `json:"kind"`
 	Content       string    `json:"content"`
 	HasAccounts   bool      `json:"has_accounts"`
+	// Accounts is the number of per-account snapshots in the run (GH #502) — so
+	// the UI can label a Full Server run "system + N accounts" on the collapsed
+	// row instead of making the admin expand it to count.
+	Accounts      int       `json:"accounts"`
 	Total         int       `json:"total"`
 	Succeeded     int       `json:"succeeded"`
 	Failed        int       `json:"failed"`
@@ -184,6 +188,7 @@ func (r *backupJobRepo) ListRuns(ctx context.Context, limit, offset int) ([]Back
 		Kind          string
 		Content       string
 		HasAccounts   bool
+		Accounts      int
 		Total         int
 		Succeeded     int
 		Failed        int
@@ -204,6 +209,7 @@ SELECT run_id                                                             AS run
        CASE WHEN COUNT(DISTINCT content) = 1 THEN MAX(content)
             ELSE 'full' END                                              AS content,
        SUM(kind = 'account_backup') > 0                                  AS has_accounts,
+       SUM(kind = 'account_backup')                                      AS accounts,
        COUNT(*)                                                           AS total,
        SUM(status = 'succeeded')                                          AS succeeded,
        SUM(status = 'failed')                                             AS failed,
@@ -233,6 +239,7 @@ SELECT run_id                                                             AS run
 			Kind:          x.Kind,
 			Content:       x.Content,
 			HasAccounts:   x.HasAccounts,
+			Accounts:      x.Accounts,
 			Total:         x.Total,
 			Succeeded:     x.Succeeded,
 			Failed:        x.Failed,

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -3,7 +3,7 @@
 // expandable to per-user children). Manual creates render flat.
 import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { downloadUrl } from "../../../utils/download";
-import { backupTypeColor, backupTypeLabel } from "../../../utils/backupType";
+import { backupTypeColor, backupTypeLabel, runScopeSummary } from "../../../utils/backupType";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
 import { RowActions } from "../../../components/RowActions";
@@ -58,6 +58,7 @@ interface BackupRun {
   run_id: string;
   schedule_id?: string;
   has_accounts?: boolean;
+  accounts?: number;
   kind: string;
   content?: string;
   total: number;
@@ -539,8 +540,16 @@ export const AdminBackupsPage = () => {
                   const kind = row.isRun ? row.run.kind : row.job.kind;
                   const content = row.isRun ? row.run.content : row.job.content;
                   const hasAccounts = row.isRun ? row.run.has_accounts : false;
+                  const scope = row.isRun ? runScopeSummary(row.run.total, row.run.accounts ?? 0) : "";
                   return (
-                    <Tag color={backupTypeColor(kind, content)}>{backupTypeLabel(kind, content, hasAccounts)}</Tag>
+                    <Space direction="vertical" size={0}>
+                      <Tag color={backupTypeColor(kind, content)}>{backupTypeLabel(kind, content, hasAccounts)}</Tag>
+                      {scope && (
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          {scope}
+                        </Typography.Text>
+                      )}
+                    </Space>
                   );
                 },
               },

--- a/panel-ui/src/utils/backupType.runscope.test.ts
+++ b/panel-ui/src/utils/backupType.runscope.test.ts
@@ -1,0 +1,23 @@
+// GH #502: the collapsed Full Server run row summarizes its scope so an admin
+// sees "one server backup", not hundreds of account rows.
+import { describe, expect, it } from "vitest";
+
+import { runScopeSummary } from "./backupType";
+
+describe("runScopeSummary (GH #502)", () => {
+  it("full server: system + N accounts", () => {
+    expect(runScopeSummary(13, 12)).toBe("system + 12 accounts");
+  });
+
+  it("singular account is not pluralized", () => {
+    expect(runScopeSummary(2, 1)).toBe("system + 1 account");
+  });
+
+  it("accounts-only run (no system job)", () => {
+    expect(runScopeSummary(5, 5)).toBe("5 accounts");
+  });
+
+  it("system-only run -> empty (the type tag already says it)", () => {
+    expect(runScopeSummary(1, 0)).toBe("");
+  });
+});

--- a/panel-ui/src/utils/backupType.ts
+++ b/panel-ui/src/utils/backupType.ts
@@ -33,6 +33,21 @@ export function backupTypeLabel(kind: string, content?: string | null, hasAccoun
   }
 }
 
+// runScopeSummary (GH #502): a one-line scope summary for a collapsed backup
+// RUN row, so a Full Server backup reads as one logical backup
+// ("system + N accounts") without expanding it to count the child snapshots.
+// `total` is all jobs in the run; `accounts` is the per-account snapshot count.
+export function runScopeSummary(total: number, accounts: number): string {
+  const hasSystem = total > accounts; // non-account jobs = the system backup
+  if (accounts > 0 && hasSystem) {
+    return `system + ${accounts} account${accounts === 1 ? "" : "s"}`;
+  }
+  if (accounts > 0) {
+    return `${accounts} account${accounts === 1 ? "" : "s"}`;
+  }
+  return ""; // system-only run — the type tag already says it
+}
+
 // backupTypeColor picks an AntD Tag color for the label.
 export function backupTypeColor(kind: string, content?: string | null): string {
   if (kind === "system_backup") return "purple";


### PR DESCRIPTION
## What

A manual **Full Server** backup fans out one `system_backup` job plus a per-account `account_backup` job, all sharing a `run_id`. `ListRuns` already groups them into one expandable run row (#703 fan-out + #715 labels). But the **collapsed** row showed only the type tag, so an admin had to expand it to learn the run captured N accounts.

This adds a one-line scope summary to the collapsed run row:

> **Full Server Backup**
> system + 12 accounts

## Changes

- **backend** `ListRuns`: `SUM(kind = 'account_backup') AS accounts` in the run aggregate → new `BackupRunSummary.Accounts`. Additive JSON field, no route change (OpenAPI coverage unaffected).
- **ui** `runScopeSummary(total, accounts)` in `utils/backupType.ts` (kept out of the page file for a clean fast-refresh boundary); rendered as a secondary `Typography.Text` line under the Type tag on run rows only.
- Manual (ungrouped) jobs and system-only runs render no extra line — the tag already says it.

## Test plan

- [x] `go build ./... && go vet` — clean
- [x] backup api/repository tests + OpenAPI coverage — pass
- [x] `tsc -b` clean, `eslint` clean (no fast-refresh warning)
- [x] `backupType.runscope.test.ts` — 4 cases (system+N, singular, accounts-only, system-only empty)
- [ ] Playwright (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)