### PR TITLE
fix(notifications): click no-deeplink alerts open focused History (GH #726 pt2)

### DIFF
--- a/panel-ui/src/components/NotificationBell.tsx
+++ b/panel-ui/src/components/NotificationBell.tsx
@@ -17,6 +17,8 @@ import { cloneElement, useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
+import { notificationTarget } from "../utils/notificationTarget";
+
 import { useAuth } from "../auth/AuthContext";
 
 import { BellOutlined, CheckOutlined, DeleteOutlined } from "@icons";
@@ -138,9 +140,10 @@ export function NotificationBell() {
     } catch {
       // Silent — clicking through shouldn't block navigation.
     }
-    if (row.deeplink) {
-      navigate(row.deeplink);
-    }
+    // GH #726: notifications without a dedicated deeplink (service.down and
+    // other Error alerts) used to dead-end on click; notificationTarget falls
+    // back to the History tab, focused on this row.
+    navigate(notificationTarget(row.id, row.deeplink));
   };
 
   const pushToggle = (() => {

--- a/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
@@ -7,8 +7,8 @@
 import { useTranslation } from "react-i18next";
 import { Button, Descriptions, Modal, Popconfirm, Space, Table, Tag, Tooltip, Typography, message } from "antd";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
-import { useNavigate } from "react-router";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 
 import { CheckOutlined, DeleteOutlined, EyeOutlined } from "@icons";
 import { RowActionButton } from "../../../components/RowActionButton";
@@ -68,6 +68,11 @@ export const HistoryTab = () => {
   const navigate = useNavigate();
   const qc = useQueryClient();
 
+  // GH #726: the notification bell links here with ?focus=<id> for alerts that
+  // have no dedicated destination. Scroll that row into view and highlight it.
+  const [searchParams] = useSearchParams();
+  const focusId = searchParams.get("focus");
+
   const listKey = ["notifications", "history", page, pageSize] as const;
 
   const query = useQuery<InboxListResponse>({
@@ -85,6 +90,14 @@ export const HistoryTab = () => {
   const rows = query.data?.data ?? [];
   const total = query.data?.total ?? 0;
   const unread = query.data?.unread ?? 0;
+
+  // Once the focused row is on the page (antd stamps data-row-key on each <tr>),
+  // scroll it into view. Recent alerts land on page 1, so this usually hits.
+  useEffect(() => {
+    if (!focusId || rows.length === 0) return;
+    const el = document.querySelector(`[data-row-key="${CSS.escape(focusId)}"]`);
+    el?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [focusId, rows.length]);
 
   const markAllRead = async () => {
     try {
@@ -185,7 +198,14 @@ export const HistoryTab = () => {
           onClick: () => handleRowClick(row),
           style: {
             cursor: row.deeplink ? "pointer" : "default",
-            background: row.read_at ? undefined : "rgba(24,144,255,0.04)",
+            // GH #726: the notification the bell sent us to (?focus=<id>) gets a
+            // stronger amber tint so it stands out from the unread blue wash.
+            background:
+              row.id === focusId
+                ? "rgba(250,173,20,0.18)"
+                : row.read_at
+                  ? undefined
+                  : "rgba(24,144,255,0.04)",
           },
         })}
       >

--- a/panel-ui/src/utils/notificationTarget.test.ts
+++ b/panel-ui/src/utils/notificationTarget.test.ts
@@ -1,0 +1,23 @@
+// GH #726: every notification click must land somewhere; alerts without a
+// dedicated deeplink fall back to the focused History tab.
+import { describe, expect, it } from "vitest";
+
+import { notificationTarget } from "./notificationTarget";
+
+describe("notificationTarget (GH #726)", () => {
+  it("uses the dedicated deeplink when present", () => {
+    expect(notificationTarget("01ABC", "/jabali-admin/updates")).toBe("/jabali-admin/updates");
+  });
+
+  it("falls back to focused History when deeplink is missing", () => {
+    expect(notificationTarget("01ABC")).toBe("/jabali-admin/notifications/history?focus=01ABC");
+  });
+
+  it("treats an empty-string deeplink as missing", () => {
+    expect(notificationTarget("01ABC", "")).toBe("/jabali-admin/notifications/history?focus=01ABC");
+  });
+
+  it("treats null (server-omitted) deeplink as missing", () => {
+    expect(notificationTarget("01ABC", null)).toBe("/jabali-admin/notifications/history?focus=01ABC");
+  });
+});

--- a/panel-ui/src/utils/notificationTarget.ts
+++ b/panel-ui/src/utils/notificationTarget.ts
@@ -1,0 +1,11 @@
+// notificationTarget — GH #726: every notification needs a click destination.
+//
+// Kinds with a dedicated deeplink use it (panel update -> Updates, ssh_login ->
+// Security). Kinds without one — service.down and other Error-severity alerts —
+// used to dead-end on the dashboard when clicked. Fall back to the admin
+// Notifications > History tab, focused on this row, so the click always lands
+// somewhere useful.
+export function notificationTarget(id: string, deeplink?: string | null): string {
+  if (deeplink) return deeplink;
+  return `/jabali-admin/notifications/history?focus=${encodeURIComponent(id)}`;
+}


### PR DESCRIPTION
## Context

Part 2 of #726. **Part 1** — the `service.down` notification flood on modular/Custom installs (health monitor alerting on units from never-installed modules) — already shipped as #728 and lxsdevcode [confirmed](https://github.com/shukiv/jabali-panel/issues/726) it resolved.

This handles the remaining **click-routing** point. lxsdevcode narrowed it precisely:

> Some notification types already redirect correctly (Panel update -> Updates, SSH login -> Security). However **service.down** (or other **Error** notifications) simply redirect to / refresh the dashboard … opening the notification history (and ideally highlighting the selected notification) would make the most sense.

## Cause

The notification bell's click handler navigated `row.deeplink` when present and did **nothing** otherwise. Kinds emitted without a deeplink (`service.down` and other Error alerts from the health monitor) therefore dead-ended.

## Fix (UI-only, no API change)

- New pure helper `notificationTarget(id, deeplink)`: returns the deeplink if set, else `/jabali-admin/notifications/history?focus=<id>`.
- `NotificationBell.handleItemClick` always navigates via the helper — deeplinked kinds unchanged, everything else lands on the **History** tab.
- `HistoryTab` reads `?focus=<id>`, scrolls that row into view (antd stamps `data-row-key`), and gives it an amber highlight to distinguish it from the unread-blue wash.

Matches the route the bell's existing "view all" link already uses.

## Test plan

- [x] `tsc -b` clean, `eslint` clean
- [x] `notificationTarget.test.ts` — 4 cases (deeplink kept; missing/empty/null -> focused History)
- [ ] Playwright + vitest (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)