### PR TITLE
fix(update): skip mail convergence buildSteps on no-mail hosts (GH #727)

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1375,6 +1376,10 @@ test -x node_modules/.bin/tsc || {
 			if _, err := os.Stat(installSh); err != nil {
 				return nil // dev environment, no install.sh
 			}
+			if !mailModuleInstalled() {
+				fmt.Println("  (mail module not installed on this host — skipping)")
+				return nil
+			}
 			if err := run("", "bash", "-c", "source "+installSh+" && install_jabali_mailhook"); err != nil {
 				fmt.Printf("  (install_jabali_mailhook failed: %v — continuing)\n", err)
 			}
@@ -1440,6 +1445,10 @@ test -x node_modules/.bin/tsc || {
 			if _, err := os.Stat(installSh); err != nil {
 				return nil
 			}
+			if !mailModuleInstalled() {
+				fmt.Println("  (mail module not installed on this host — skipping)")
+				return nil
+			}
 			// Version-bump aware: install_bulwark writes the pinned version to
 			// /opt/jabali-webmail/VERSION. If the repo pins a newer Bulwark than
 			// what's installed, re-run the FULL install_bulwark (download + verify
@@ -1471,6 +1480,10 @@ test -x node_modules/.bin/tsc || {
 			if _, err := os.Stat(installSh); err != nil {
 				return nil
 			}
+			if !mailModuleInstalled() {
+				fmt.Println("  (mail module not installed on this host — skipping)")
+				return nil
+			}
 			if err := run("", "bash", "-c",
 				"source "+installSh+" && upgrade_stalwart_binary"); err != nil {
 				fmt.Printf("  (stalwart binary upgrade failed: %v — continuing)\n", err)
@@ -1493,6 +1506,10 @@ test -x node_modules/.bin/tsc || {
 			// converge that. Non-fatal here either way.
 			installSh := repoDir + "/install.sh"
 			if _, err := os.Stat(installSh); err != nil {
+				return nil
+			}
+			if !mailModuleInstalled() {
+				fmt.Println("  (mail module not installed on this host — skipping)")
 				return nil
 			}
 			if err := run("", "bash", "-c",
@@ -1769,6 +1786,26 @@ test -x node_modules/.bin/tsc || {
 
 // run executes a command with inherited stdout/stderr so the user sees
 // build output and errors in real time.
+// groupExists reports whether a system group of the given name resolves.
+// Split out from mailModuleInstalled so the gate logic is unit-testable
+// without provisioning a real group.
+func groupExists(name string) bool {
+	_, err := user.LookupGroup(name)
+	return err == nil
+}
+
+// mailModuleInstalled reports whether the Stalwart/mail module was provisioned
+// on this host. install_stalwart creates the jabali-mail group up front (its
+// service user's primary group) and every mail file is owned by it. On a
+// Custom / no-mail install the group never exists, so re-running the mail
+// convergence buildSteps (stalwart binary, spam-filter rules, mailhook,
+// bulwark) on `jabali update` dies at `install -g jabali-mail` (GH #727).
+// Update converges what is installed; enabling mail later is an explicit
+// `--install-module mail` via Server Settings, which creates the group itself.
+func mailModuleInstalled() bool {
+	return groupExists("jabali-mail")
+}
+
 func run(dir string, name string, args ...string) error {
 	c := exec.Command(name, args...)
 	if dir != "" {

--- a/panel-api/cmd/server/update_gh727_test.go
+++ b/panel-api/cmd/server/update_gh727_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+// GH #727: on a Custom / no-mail install the jabali-mail group never exists, so
+// the mail convergence buildSteps (stalwart binary, spam-filter rules,
+// mailhook, bulwark) must be skipped on `jabali update` — otherwise
+// _install_spam_rules dies at `install -g jabali-mail`.
+func TestGroupExists_GH727(t *testing.T) {
+	// The root group exists on every Linux host the updater runs on.
+	if !groupExists("root") {
+		t.Error("expected the root group to exist")
+	}
+	// A group name that cannot exist -> false: this is the no-mail host case
+	// that used to let the mail buildSteps run and crash.
+	if groupExists("jabali-no-such-group-gh727-xyz") {
+		t.Error("expected a bogus group to be reported absent")
+	}
+}
+
+func TestMailModuleInstalled_TracksJabaliMailGroup_GH727(t *testing.T) {
+	if mailModuleInstalled() != groupExists("jabali-mail") {
+		t.Error("mailModuleInstalled must track presence of the jabali-mail group")
+	}
+}


### PR DESCRIPTION
## Context

Follow-up to #727. #728 gated install.sh main()'s `run_if_mail` mail block on `server_settings.mail_enabled`, and lxsdevcode confirmed `jabali update --force` no longer *aborts*. But the underlying symptom remained — on a Custom / no-mail install, update still ran the Stalwart bootstrap and died:

```text
[i] downloading Stalwart spam-filter rules v3.0.0
install: invalid group 'jabali-mail'
[jabali-install] install.sh died: function _install_spam_rules … command install -m 0640 -o root -g jabali-mail
```

## Cause

The death is **not** in install.sh's gated mail block — it's in `jabali update`'s own buildSteps (`panel-api/cmd/server/update.go`). Four mail-module convergence steps ran **unconditionally on every update**, with no check for whether mail is installed:

- `sync stalwart binary` → `upgrade_stalwart_binary`
- `sync stalwart spam-filter rules` → `_install_spam_rules`  ← the crash
- `setup jabali-mailhook service` → `install_jabali_mailhook`
- `sync bulwark systemd + env` → `install_bulwark` / `_install_bulwark_systemd`

On a no-mail host the `jabali-mail` group never exists, so `_install_spam_rules` fails, and the updater needlessly provisioned Stalwart/Bulwark/webmail (the "jabali-webmail.service installed" lines lxsdevcode saw).

## Fix

Gate all four steps on `mailModuleInstalled()` — presence of the `jabali-mail` group, exactly the resource `_install_spam_rules` needs. These buildSteps are **update-only** (fresh installs run install.sh main(), which creates the group inside `install_stalwart`), so there's no fresh-install chicken-and-egg. Enabling mail later stays an explicit `--install-module mail` via Server Settings → Modules, which creates the group itself.

A no-mail host now logs `(mail module not installed on this host — skipping)` and updates cleanly.

## Test plan

- [x] `go build ./... && go vet ./cmd/server` — clean
- [x] `groupExists` / `mailModuleInstalled` unit tests (root present, bogus absent, tracks jabali-mail)
- [x] `TestCLIReferenceGolden` — unaffected (no command/flag change)
- [ ] CI (Go tests+vet, Playwright, install lints)

Note: this stops update from crashing and from provisioning mail on a no-mail host. If a host's `server_settings.mail_enabled` is a stale `1` (older install), the UI may still show mail as enabled — toggle it off in Server Settings → Modules; that's independent of this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)