### PR TITLE
fix(ssl): de-track certbot lineage before installing a custom cert (GH #738)

### DIFF
--- a/panel-agent/internal/commands/ssl_install_custom.go
+++ b/panel-agent/internal/commands/ssl_install_custom.go
@@ -72,6 +72,15 @@ func sslInstallCustomHandler(ctx context.Context, params json.RawMessage) (any, 
 		}
 	}
 
+	// Switching a domain to a custom cert must de-track any certbot-managed
+	// lineage for it FIRST. Writing regular fullchain.pem/privkey.pem over the
+	// LE symlinks while leaving /etc/letsencrypt/renewal/<domain>.conf in place
+	// makes `certbot renew` load the lineage, hit the now-non-symlink file, and
+	// abort the ENTIRE run with "expected ... cert.pem to be a symlink" — so
+	// every domain on the box stops auto-renewing (GH #738). Runs only after
+	// cert/key validation above, so a bad upload never destroys a working cert.
+	cleanupCertbotLineage(ctx, sslLERoot, p.Domain)
+
 	liveDir := filepath.Join(sslLERoot, "live", p.Domain)
 	if err := os.MkdirAll(liveDir, 0o755); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "mkdir live: " + err.Error()}
@@ -96,6 +105,30 @@ func sslInstallCustomHandler(ctx context.Context, params json.RawMessage) (any, 
 	}
 
 	return sslInstallCustomResponse{CertPath: certPath, KeyPath: keyPath}, nil
+}
+
+// cleanupCertbotLineage de-tracks any certbot-managed lineage named `domain`
+// under `root` before a custom cert is dropped into root/live/<domain>/. See
+// the call site (GH #738): an orphaned root/renewal/<domain>.conf pointing at
+// non-symlink live files makes `certbot renew` abort box-wide. `certbot delete`
+// removes the live symlinks, archive, and renewal conf as a unit; if certbot is
+// absent — or the lineage is already half-broken and `certbot delete` itself
+// fails (exactly the #738 state) — we remove the renewal conf directly so the
+// renew run stops choking on it. No-op when the domain was never certbot-managed.
+func cleanupCertbotLineage(ctx context.Context, root, domain string) {
+	renewalConf := filepath.Join(root, "renewal", domain+".conf")
+	if _, err := os.Stat(renewalConf); err != nil {
+		return // no certbot-managed lineage for this name — nothing to clean
+	}
+	if certbot, err := exec.LookPath("certbot"); err == nil {
+		cmd := exec.CommandContext(ctx, certbot, "delete",
+			"--cert-name", domain, "--config-dir", root, "--non-interactive")
+		if cmd.Run() == nil {
+			return
+		}
+		// fall through: remove the conf directly as a floor.
+	}
+	_ = os.Remove(renewalConf)
 }
 
 func parseLeafCert(blob string) (*x509.Certificate, error) {

--- a/panel-agent/internal/commands/ssl_install_custom_gh738_test.go
+++ b/panel-agent/internal/commands/ssl_install_custom_gh738_test.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// GH #738: installing a custom cert must de-track a certbot lineage first, or
+// the orphaned renewal/<domain>.conf makes `certbot renew` abort box-wide.
+func TestCleanupCertbotLineage_RemovesOrphanRenewalConf_GH738(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "renewal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	conf := filepath.Join(root, "renewal", "example.com.conf")
+	if err := os.WriteFile(conf, []byte("# certbot lineage\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// certbot delete (if certbot exists) can't find this name under the temp
+	// --config-dir and fails, so the direct-remove floor must clear the conf.
+	cleanupCertbotLineage(context.Background(), root, "example.com")
+
+	if _, err := os.Stat(conf); !os.IsNotExist(err) {
+		t.Fatalf("expected orphan renewal conf removed, stat err=%v", err)
+	}
+}
+
+func TestCleanupCertbotLineage_NoConfIsNoop_GH738(t *testing.T) {
+	root := t.TempDir()
+	// No renewal/ dir and no lineage: must be a clean no-op, never panic.
+	cleanupCertbotLineage(context.Background(), root, "never-managed.example")
+}


### PR DESCRIPTION
## Root cause (from a diagnostic bundle)

An operator diagnostic bundle for `panel.experienced.com.br` showed `certbot.service` **failing box-wide**:

```text
Renewal configuration file /etc/letsencrypt/renewal/mail.ecosolsolucoes.com.br.conf is broken.
The error was: expected /etc/letsencrypt/live/mail.ecosolsolucoes.com.br/cert.pem to be a symlink
…
0 renew failure(s), 2 parse failure(s)   → certbot.service exit 1
```

`ssl_install_custom.go` writes the custom cert as **regular files** (`fullchain.pem`, `privkey.pem`) into `/etc/letsencrypt/live/<domain>/`, overwriting the Let's Encrypt symlinks — but **leaves `/etc/letsencrypt/renewal/<domain>.conf` in place**. `certbot renew` then loads that lineage, hits the non-symlink file, and aborts the **entire** run. One custom-cert install over an LE domain stops auto-renewal for every domain on the box.

## Fix (agent-only)

`cleanupCertbotLineage(ctx, root, domain)` de-tracks the domain **before** the custom cert is written:

- `certbot delete --cert-name <domain> --config-dir <root>` removes the live symlinks, archive, and renewal conf as a unit.
- If certbot is absent, or the lineage is already half-broken so `certbot delete` itself fails (the exact #738 state), the renewal conf is removed directly as a floor.
- No-op when the domain was never certbot-managed.

Runs **after** cert/key validation, so a bad upload never destroys a working cert. Domain is regex-validated upstream (no traversal); certbot runs args-form (no shell); `--config-dir` pins the store.

## Test plan

- [x] `go build ./... && go vet` — clean, gofmt clean
- [x] `cleanupCertbotLineage` unit tests: orphan conf removed (temp `--config-dir`); no-conf is a clean no-op
- [x] existing agent SSL/cert tests pass
- [ ] CI

## Note

This **prevents** the corruption going forward. Already-corrupted boxes (like the reporter's) still need a one-off repair — `certbot delete --cert-name <broken-name>` for each broken lineage, then `certbot renew` goes green. I'll hand the operator those steps in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)