### PR TITLE
fix(ssl): clean stale lineage on LE issue + explain greyed-out LE option (GH #738)

### DIFF
--- a/panel-agent/internal/certbot/runner.go
+++ b/panel-agent/internal/certbot/runner.go
@@ -5,7 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -52,6 +54,14 @@ func NewRunner() *Runner {
 // would silently reuse the narrower existing cert and the new
 // hostnames would never appear on the wire.
 func (r *Runner) Issue(domain, webroot, email string, staging bool, extraHostnames []string) (*Result, error) {
+	// A prior custom-cert install (ssl.install.custom) or a half-broken lineage
+	// can leave LERoot/live/<domain>/ as a plain dir with NO
+	// renewal/<domain>.conf. `certbot certonly --cert-name <domain>` then can't
+	// adopt that dir and issues a duplicate <domain>-0001 lineage instead
+	// (GH #738). Clear the stale live/archive dirs first — only when the name is
+	// NOT certbot-managed — so issuance lands under the exact name.
+	r.clearStaleLineageDir(domain)
+
 	args := []string{
 		"certonly",
 		// --cert-name pins the lineage explicitly. Without it certbot
@@ -342,6 +352,21 @@ func parsePEM(pemBytes []byte) (*x509.Certificate, error) {
 	}
 
 	return cert, nil
+}
+
+// clearStaleLineageDir removes a stale, non-certbot-managed live/archive dir
+// for `domain` under LERoot so `certbot certonly --cert-name <domain>` issues
+// under the exact name instead of spawning a <domain>-0001 duplicate (GH #738).
+// It only acts when there is NO renewal/<domain>.conf — a real certbot-managed
+// lineage is left untouched so certbot can renew/reuse it. Best-effort: removal
+// errors are non-fatal (issuance surfaces any real problem).
+func (r *Runner) clearStaleLineageDir(domain string) {
+	renewalConf := filepath.Join(r.LERoot, "renewal", domain+".conf")
+	if _, err := os.Stat(renewalConf); err == nil {
+		return // certbot-managed lineage — let certbot renew/reuse it
+	}
+	_ = os.RemoveAll(filepath.Join(r.LERoot, "live", domain))
+	_ = os.RemoveAll(filepath.Join(r.LERoot, "archive", domain))
 }
 
 // existingCertMissingAny reads the cert at certPath (if any) and returns

--- a/panel-agent/internal/certbot/runner_gh738_test.go
+++ b/panel-agent/internal/certbot/runner_gh738_test.go
@@ -1,0 +1,67 @@
+package certbot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeManagedRenewalConf marks live/<domain> as a real certbot-managed lineage
+// (renewal/<domain>.conf present) so Issue()'s GH #738 stale-dir clear leaves it
+// in place — the state any legit --expand / --keep-until-expiring flow is in.
+func writeManagedRenewalConf(t *testing.T, leRoot, domain string) {
+	t.Helper()
+	dir := filepath.Join(leRoot, "renewal")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, domain+".conf"), []byte("# managed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// GH #738: a stale non-certbot-managed live dir (left by a custom-cert install)
+// must be cleared before `certbot certonly` so it doesn't spawn a <domain>-0001
+// duplicate — but a real managed lineage (has a renewal conf) must be kept.
+func TestClearStaleLineageDir_GH738(t *testing.T) {
+	mkLineage := func(root, domain string) {
+		for _, sub := range []string{"live", "archive"} {
+			if err := os.MkdirAll(filepath.Join(root, sub, domain), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Run("stale dir (no renewal conf) is removed", func(t *testing.T) {
+		root := t.TempDir()
+		mkLineage(root, "example.com")
+		r := &Runner{LERoot: root}
+
+		r.clearStaleLineageDir("example.com")
+
+		for _, sub := range []string{"live", "archive"} {
+			if _, err := os.Stat(filepath.Join(root, sub, "example.com")); !os.IsNotExist(err) {
+				t.Errorf("expected %s/example.com removed, err=%v", sub, err)
+			}
+		}
+	})
+
+	t.Run("managed lineage (renewal conf present) is kept", func(t *testing.T) {
+		root := t.TempDir()
+		mkLineage(root, "example.com")
+		if err := os.MkdirAll(filepath.Join(root, "renewal"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		conf := filepath.Join(root, "renewal", "example.com.conf")
+		if err := os.WriteFile(conf, []byte("# managed\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		r := &Runner{LERoot: root}
+
+		r.clearStaleLineageDir("example.com")
+
+		if _, err := os.Stat(filepath.Join(root, "live", "example.com")); err != nil {
+			t.Errorf("managed lineage live dir must be preserved, err=%v", err)
+		}
+	})
+}

--- a/panel-agent/internal/certbot/runner_test.go
+++ b/panel-agent/internal/certbot/runner_test.go
@@ -371,6 +371,7 @@ func TestIssueAddsExpandWhenExistingCertMissesSAN(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), createTestCertPEM(t), 0644); err != nil {
 		t.Fatal(err)
 	}
+	writeManagedRenewalConf(t, filepath.Join(tmp, "letsencrypt"), "example.com")
 
 	_, err := r.Issue("example.com", "/var/www/example", "a@b.com", false,
 		[]string{"mail.example.com"})
@@ -407,6 +408,7 @@ func TestIssueSkipsExpandWhenExistingCertCovers(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(certDir, "fullchain.pem"), certPEM, 0644); err != nil {
 		t.Fatal(err)
 	}
+	writeManagedRenewalConf(t, filepath.Join(tmp, "letsencrypt"), "example.com")
 
 	_, err := r.Issue("example.com", "/var/www/example", "a@b.com", false,
 		[]string{"mail.example.com"})

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -379,6 +379,24 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
         )}
       </Space>
 
+      {/* GH #738: the "Let's Encrypt" option greys out with no explanation when
+          no admin email is set (it's the required ACME contact). Tell the
+          operator why + where to fix it, so they aren't stuck. */}
+      {!adminEmail && sslMode !== "le" && (
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginTop: 12 }}
+          message={
+            <>
+              Let&apos;s Encrypt needs an admin email (the ACME contact address).
+              Set one in <Link to="/jabali-admin/settings">Server Settings</Link>,
+              then select Let&apos;s Encrypt here.
+            </>
+          }
+        />
+      )}
+
       <Modal
         open={customOpen}
         title={t("domainsslsection.upload_custom_certificate")}


### PR DESCRIPTION
Two follow-ups to the #738 custom-cert corruption fix (#745).

## 1. LE issue path no longer spawns `-000N` duplicate lineages (agent)

A prior custom-cert install (or a half-broken lineage) leaves `/etc/letsencrypt/live/<domain>/` as a plain dir with **no** `renewal/<domain>.conf`. `certbot certonly --cert-name <domain>` can't adopt that dir and issues a duplicate `<domain>-0001` lineage instead — exactly the `mail.ecosolsolucoes.com.br-0001…0006` dupes in the #738 diagnostic.

`Runner.clearStaleLineageDir(domain)` runs at the top of `Issue()`: if there's **no** renewal conf for the name, it removes the stale `live/` + `archive/` dirs so certbot issues cleanly under the exact name. A real certbot-managed lineage (renewal conf present) is left untouched for certbot to renew/reuse — so `--expand` / `--keep-until-expiring` are unaffected.

## 2. Explain the greyed-out "Let's Encrypt" option (UI)

`DomainSSLSection` disables the "Let's Encrypt" TLS option when no admin email is set (it's the required ACME contact), with no explanation — operators read it as "no way back to LE" (the mailanetworks report). Adds an info Alert linking to Server Settings to set the email, then select LE.

## Test plan

- [x] `go build ./... && go vet` — clean, gofmt clean
- [x] `clearStaleLineageDir`: stale dir removed; managed lineage (renewal conf) preserved
- [x] existing `--expand`/`--keep-until-expiring` fixtures updated to realistic managed-lineage state; full certbot suite green
- [x] `tsc -b` + `eslint` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)