### PR TITLE
fix(services): guard nginx + redis-server as panel-critical + monitor core deps (GH #746)

### DIFF
--- a/panel-api/internal/api/admin_services.go
+++ b/panel-api/internal/api/admin_services.go
@@ -58,17 +58,23 @@ var (
 	// agent.
 	serviceNameRe = regexp.MustCompile(`^[a-zA-Z0-9._@-]+$`)
 
-	// panelSelfDestructUnits is the trio that, if stopped or disabled,
-	// would lock the operator out of the management plane mid-request:
+	// panelSelfDestructUnits are the units that, if stopped or disabled,
+	// lock the operator out of the management plane mid-request:
 	// jabali-panel hosts the very HTTP this request rode in on; the agent
 	// is the only path back to systemctl on the host; mariadb backs
-	// every panel session and DB-as-truth state. Reject these at the
-	// API layer so the agent stays a dumb obedient executor and never
-	// has to know about product-UX concerns.
+	// every panel session and DB-as-truth state; nginx is the reverse
+	// proxy the panel is served through (stop -> 502); redis-server is a
+	// hard dependency of jabali-panel (stop -> the panel process itself
+	// dies — GH #746). Reject these at the API layer so the agent stays a
+	// dumb obedient executor and never has to know about product-UX
+	// concerns. Keep this in sync with selfDestructUnits in the UI
+	// (ServicesSummaryCard.tsx) and jabaliUnits in service_down.go.
 	panelSelfDestructUnits = map[string]bool{
 		"jabali-panel": true,
 		"jabali-agent": true,
 		"mariadb":      true,
+		"nginx":        true,
+		"redis-server": true,
 	}
 	panelSelfDestructActions = map[string]bool{
 		"stop":    true,
@@ -91,7 +97,7 @@ func (h *adminServicesHandler) action(c *gin.Context) {
 	if panelSelfDestructUnits[name] && panelSelfDestructActions[action] {
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "self_destruct_blocked",
-			"details": "stop/disable on panel-critical units (jabali-panel, jabali-agent, mariadb) would brick the management plane",
+			"details": "stop/disable on panel-critical units (jabali-panel, jabali-agent, mariadb, nginx, redis-server) would brick the management plane — use systemctl from the shell if you really need to",
 		})
 		return
 	}

--- a/panel-api/internal/api/admin_services_test.go
+++ b/panel-api/internal/api/admin_services_test.go
@@ -51,10 +51,13 @@ func doPost(t *testing.T, r *gin.Engine, path string) *httptest.ResponseRecorder
 }
 
 func TestAdminServices_AllowedActions(t *testing.T) {
+	// cron is a non-panel-critical unit — every action is allowed on it.
+	// (nginx/redis-server used to stand in here but are now stop/disable-
+	// blocked, GH #746.)
 	for _, action := range []string{"restart", "start", "stop", "reload", "enable", "disable"} {
 		ag := &fakeAgent{}
 		r := newAdminServicesTestRouter(t, ag)
-		w := doPost(t, r, "/v1/admin/services/nginx/"+action)
+		w := doPost(t, r, "/v1/admin/services/cron/"+action)
 		if w.Code != http.StatusOK {
 			t.Errorf("action %s: got %d, want 200; body=%s", action, w.Code, w.Body.String())
 		}
@@ -91,6 +94,12 @@ func TestAdminServices_SelfDestructBlocked(t *testing.T) {
 		{"jabali-agent", "disable"},
 		{"mariadb", "stop"},
 		{"mariadb", "disable"},
+		// GH #746: nginx (reverse proxy -> 502) and redis-server (hard
+		// jabali-panel dep -> panel dies) are also panel-critical.
+		{"nginx", "stop"},
+		{"nginx", "disable"},
+		{"redis-server", "stop"},
+		{"redis-server", "disable"},
 	}
 	for _, c := range cases {
 		ag := &fakeAgent{}

--- a/panel-api/internal/api/system.go
+++ b/panel-api/internal/api/system.go
@@ -86,7 +86,11 @@ func RegisterSystemRoutes(rg *gin.RouterGroup, cli agent.AgentInterface) {
 				})
 				return
 			}
-			if selfDestructGuard && (name == "jabali-panel" || name == "jabali-agent") {
+			// Same panel-critical set as the /admin/services guard
+			// (panelSelfDestructUnits): stopping any of these bricks the
+			// management plane (GH #746: nginx -> 502, redis-server -> the
+			// panel process dies).
+			if selfDestructGuard && panelSelfDestructUnits[name] {
 				c.JSON(http.StatusConflict, gin.H{
 					"status": "error",
 					"error":  "self_destruct_refused",

--- a/panel-api/internal/eventsources/service_down.go
+++ b/panel-api/internal/eventsources/service_down.go
@@ -40,6 +40,17 @@ var jabaliUnits = []string{
 	"jabali-stalwart.service",
 	"pdns.service",
 	"pdns-recursor.service",
+	// Core panel dependencies (GH #746): these aren't jabali-* units but
+	// the panel is dead in the water without them, so an operator must be
+	// alerted when they go down. nginx = reverse proxy (its downtime is
+	// exactly when the 502 hides the UI, so the push/ntfy/email alert is
+	// the only signal); mariadb = DB-as-truth; redis-server = jabali-panel
+	// hard dep. (redis down also takes down the Redis-backed dispatcher +
+	// often jabali-panel itself, so that alert is best-effort — it fires
+	// only if the panel survives the tick.)
+	"nginx.service",
+	"mariadb.service",
+	"redis-server.service",
 }
 
 // runServiceDown polls systemctl is-active for each configured

--- a/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
@@ -1,7 +1,8 @@
 // ServicesSummaryCard — compact Service / Status / Action table for the
 // Server Status top section. Action column is a row of icon-only
 // Buttons each wrapped in a Tooltip explaining the verb. Self-destruct
-// trio (jabali-panel, jabali-agent, mariadb) hides Stop+Disable —
+// panel-critical units (jabali-panel, jabali-agent, mariadb, nginx,
+// redis-server) hide Stop+Disable —
 // those requests are 403'd at the API anyway. Destructive verbs
 // (stop/disable/restart) show a confirm Modal first.
 import { useState } from "react";
@@ -40,10 +41,16 @@ const reloadCapable = new Set([
   "pdns-recursor.service",
 ]);
 
+// Panel-critical units: stopping/disabling any of these from the UI would make
+// the panel inaccessible (GH #746). Kept in sync with panelSelfDestructUnits in
+// panel-api/internal/api/admin_services.go. nginx is the reverse proxy (stop ->
+// 502); redis-server is a hard jabali-panel dependency (stop -> the panel dies).
 const selfDestructUnits = new Set([
   "jabali-panel.service",
   "jabali-agent.service",
   "mariadb.service",
+  "nginx.service",
+  "redis-server.service",
 ]);
 
 type Action = "restart" | "reload" | "start" | "stop" | "enable" | "disable";


### PR DESCRIPTION
## Context

Reporter stopped services from the Services page and hit two problems.

## 1. Service safety — nginx / redis-server could brick the panel

The panel-critical set that blocks Stop/Disable was `{jabali-panel, jabali-agent, mariadb}` — but **nginx** (reverse proxy → 502) and **redis-server** (hard `jabali-panel` dependency → the panel process dies) were not in it, so the UI showed the buttons and the API accepted them. Stopping either leaves the operator recovering from the CLI.

Both now join `panelSelfDestructUnits`:
- `POST /admin/services/:name/{stop,disable}` → **403** for nginx/redis-server
- `/system/services` guard aligned to the same set (was only panel/agent)
- UI hides Stop + Disable (`selfDestructUnits` in `ServicesSummaryCard`)

Restart/start/reload/enable stay available.

## 2. No `service.down` alert for nginx/redis

The monitor (`service_down.go`) only watched `jabali-*` units (plus pdns), so a core-dependency outage never alerted. Added `nginx.service`, `mariadb.service`, `redis-server.service` to `jabaliUnits`.

- **nginx** is the important case: its downtime is exactly when the 502 hides the UI, so the push/ntfy/email alert is the *only* signal — and it delivers, because the monitor runs in panel-api (alive behind the dead proxy) and dispatch doesn't go through nginx.
- **redis-server** stays best-effort: it also kills the Redis-backed dispatcher and often `jabali-panel` itself, so the alert only fires if the panel survives the tick. Noted in the code.

## Test plan

- [x] `go build ./... && go vet` clean, gofmt clean
- [x] nginx/redis-server `stop`/`disable` → 403; `cron` (non-critical) keeps all actions
- [x] eventsources suite green; `tsc`/`eslint`/vitest clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)