### PR TITLE
fix(migration): systemd-run --property before the command in import (GH #746)

### DIFF
--- a/panel-agent/internal/commands/migration_admin_run.go
+++ b/panel-agent/internal/commands/migration_admin_run.go
@@ -252,6 +252,28 @@ type migrationImportRunParams struct {
 	TargetPackageID string `json:"target_package_id,omitempty"`
 }
 
+// importSystemdRunArgs assembles the systemd-run argv for a migration import.
+// runProps are extra systemd-run options (e.g. --property=EnvironmentFile=…)
+// that MUST come before the command; cmdOpts are extra `jabali migrate import`
+// flags. Keeping --property in runProps (never in the command tail) is the
+// whole point: a systemd-run flag placed after /usr/local/bin/jabali is handed
+// to jabali's argv and dies with "unknown flag: --property" (GH #746).
+func importSystemdRunArgs(jobID, targetUser string, runProps, cmdOpts []string) []string {
+	args := []string{
+		"--unit=" + fmt.Sprintf("jabali-migrate-import-%s.service", jobID),
+		"--no-block",
+		"--collect",
+	}
+	args = append(args, runProps...)
+	args = append(args,
+		"/usr/local/bin/jabali", "migrate", "import",
+		"--job-id="+jobID,
+		"--target-user="+targetUser,
+	)
+	args = append(args, cmdOpts...)
+	return args
+}
+
 func migrationImportRunHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	var p migrationImportRunParams
 	if err := json.Unmarshal(raw, &p); err != nil {
@@ -263,16 +285,9 @@ func migrationImportRunHandler(ctx context.Context, raw json.RawMessage) (any, e
 	if !looksLikeUnixUsername(p.TargetUser) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "target_user looks unsafe"}
 	}
-	args := []string{
-		"--unit=" + fmt.Sprintf("jabali-migrate-import-%s.service", p.JobID),
-		"--no-block",
-		"--collect",
-		"/usr/local/bin/jabali", "migrate", "import",
-		"--job-id=" + p.JobID,
-		"--target-user=" + p.TargetUser,
-	}
+	var runProps, cmdOpts []string
 	if p.TargetEmail != "" {
-		args = append(args, "--target-email="+p.TargetEmail)
+		cmdOpts = append(cmdOpts, "--target-email="+p.TargetEmail)
 	}
 	if p.TargetPassword != "" {
 		// Reject control chars so a crafted password can't inject extra
@@ -291,11 +306,14 @@ func migrationImportRunHandler(ctx context.Context, raw json.RawMessage) (any, e
 		if werr := os.WriteFile(envPath, []byte(content), 0o600); werr != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write target-password env: %v", werr)}
 		}
-		args = append(args, "--property=EnvironmentFile="+envPath)
+		// --property is a systemd-run flag — it lands in runProps (before the
+		// command), NOT in cmdOpts.
+		runProps = append(runProps, "--property=EnvironmentFile="+envPath)
 	}
 	if p.TargetPackageID != "" {
-		args = append(args, "--target-package-id="+p.TargetPackageID)
+		cmdOpts = append(cmdOpts, "--target-package-id="+p.TargetPackageID)
 	}
+	args := importSystemdRunArgs(p.JobID, p.TargetUser, runProps, cmdOpts)
 	unit := fmt.Sprintf("jabali-migrate-import-%s.service", p.JobID)
 	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", unit).Run()
 	startedAt := time.Now().UTC()

--- a/panel-agent/internal/commands/migration_admin_run_gh746_test.go
+++ b/panel-agent/internal/commands/migration_admin_run_gh746_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #746: a systemd-run --property flag placed AFTER /usr/local/bin/jabali is
+// handed to `jabali migrate import` and dies with "unknown flag: --property",
+// which broke every auto-create import (the only path that sets it). The
+// EnvironmentFile property must sit before the command.
+func TestImportSystemdRunArgs_PropertyBeforeCommand_GH746(t *testing.T) {
+	args := importSystemdRunArgs(
+		"01KYNJ4TMHTYQH133SKARBZ4R2", "demolab",
+		[]string{"--property=EnvironmentFile=/run/jabali-migrate-x.env"},
+		[]string{"--target-email=a@b.test"},
+	)
+
+	idxProp, idxJabali := -1, -1
+	for i, a := range args {
+		switch a {
+		case "--property=EnvironmentFile=/run/jabali-migrate-x.env":
+			idxProp = i
+		case "/usr/local/bin/jabali":
+			idxJabali = i
+		}
+	}
+	if idxProp == -1 {
+		t.Fatalf("--property not present in args: %v", args)
+	}
+	if idxJabali == -1 {
+		t.Fatalf("jabali binary not present in args: %v", args)
+	}
+	if idxProp > idxJabali {
+		t.Errorf("--property (idx %d) must come BEFORE /usr/local/bin/jabali (idx %d); args=%v",
+			idxProp, idxJabali, args)
+	}
+}
+
+func TestImportSystemdRunArgs_NoPropertyWhenNoPassword_GH746(t *testing.T) {
+	args := importSystemdRunArgs("01KYNJ4TMHTYQH133SKARBZ4R2", "demolab", nil, nil)
+	for _, a := range args {
+		if strings.HasPrefix(a, "--property") {
+			t.Errorf("no --property expected without a password; args=%v", args)
+		}
+	}
+	// The command tail is still well-formed.
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "/usr/local/bin/jabali migrate import --job-id=01KYNJ4TMHTYQH133SKARBZ4R2 --target-user=demolab") {
+		t.Errorf("malformed import command: %v", args)
+	}
+}


### PR DESCRIPTION
## The bug (found in a live Plesk migration E2E)

`migration.import_run` (the agent handler behind the **Run import** button) launches:

```
systemd-run --unit=… --no-block --collect /usr/local/bin/jabali migrate import --job-id=… --target-user=… [--target-email=…] [--property=EnvironmentFile=…]
```

When a **target password** is supplied — i.e. the operator is **auto-creating** the destination account — the handler added `--property=EnvironmentFile=<envfile>` (the #496 mechanism that keeps the password off the process argv) by **appending to the arg slice, after the command**. systemd-run treats everything after `/usr/local/bin/jabali` as the command, so the flag was passed to jabali:

```
jabali migrate import … --property=EnvironmentFile=/run/….env
Error: unknown flag: --property        → exit 1/FAILURE
```

**Every auto-create import failed**, for all source kinds (cPanel/Plesk/Hestia/DA/…), not just Plesk. Imports onto a **pre-existing** user (no password → no `--property`) were unaffected, which hid it.

## Fix

Extract `importSystemdRunArgs(jobID, targetUser, runProps, cmdOpts)`: systemd-run options (including `--property`) are assembled **before** the command by construction; `jabali migrate import` flags after. The env-file write + control-char rejection (#496) are unchanged — only the placement is fixed.

## Test plan

- [x] `go build ./... && go vet` clean, gofmt clean
- [x] unit: `--property` index < `/usr/local/bin/jabali` index; no `--property` when no password; command tail well-formed
- [x] existing migration import tests pass
- [ ] CI + re-run the Plesk E2E on the fixed agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)