### PR TITLE
fix(migration): Plesk import connects as root + auto-kick slugs the subscription (GH #746)

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -249,9 +249,20 @@ live source SSH. Use scp directly for that kind.`,
 			if sharedAgent != nil {
 				kickCtx, kickCancel := context.WithTimeout(ctx, 10*time.Second)
 				defer kickCancel()
+				// Plesk SourceUser is a subscription (a domain, e.g.
+				// "demolab.test"); the agent rejects it as target_user
+				// ("looks unsafe" — dots aren't valid in a unix username), so
+				// auto-import was always blocked and the operator had to run
+				// import manually. Slug it into a valid username
+				// (demolab.test -> demolab_test) so the auto-kick lands (GH
+				// #746). Other panels' SourceUser is already a valid login.
+				autoTargetUser := job.SourceUser
+				if job.SourceKind == models.MigrationSourcePlesk {
+					autoTargetUser = plesk.Slug(job.SourceUser)
+				}
 				if _, err := sharedAgent.Call(kickCtx, "migration.import_run", map[string]any{
 					"job_id":      jobID,
-					"target_user": job.SourceUser,
+					"target_user": autoTargetUser,
 				}); err != nil {
 					fmt.Fprintf(cmd.ErrOrStderr(),
 						"  (warning: could not auto-kick import: %v — run `jabali migrate import --job-id %s` manually)\n",

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1558,10 +1558,18 @@ func migrationSSHUser(job *models.MigrationJob) string {
 	// through this helper and inherited the account, so the online flow failed
 	// at `stage analyze: connect:` (verified end-to-end against a live CloudPanel
 	// source) even though pull-source succeeded as root.
+	//
+	// Plesk (GH #746, found in a live .88 E2E) is the SAME case and was the one
+	// panel left out of this switch: SourceUser is the subscription (a domain,
+	// e.g. "demolab.test"), and the `plesk` CLI needs a root/admin login. The
+	// pull forced root via --ssh-user, but the import's analyze inherited the
+	// subscription and died at `stage analyze: connect: plesk.Connect … [none
+	// publickey]` on a source where the account is not an SSH principal.
 	switch job.SourceKind {
 	case models.MigrationSourceHestia,
 		models.MigrationSourceCloudPanel,
-		models.MigrationSourceCyberPanel:
+		models.MigrationSourceCyberPanel,
+		models.MigrationSourcePlesk:
 		return "root"
 	}
 	if job.SourceUser != "" {

--- a/panel-api/cmd/server/migrate_ssh_user_test.go
+++ b/panel-api/cmd/server/migrate_ssh_user_test.go
@@ -26,6 +26,8 @@ func TestMigrationSSHUser(t *testing.T) {
 			&models.MigrationJob{SourceKind: models.MigrationSourceCloudPanel, SourceUser: "smokeuser"}, "root"},
 		{"cyberpanel account is the domain -> root (needs root for MySQL + /home read)",
 			&models.MigrationJob{SourceKind: models.MigrationSourceCyberPanel, SourceUser: "smoke.jabalitest.com"}, "root"},
+		{"plesk subscription is a domain, not an ssh login -> root (GH #746)",
+			&models.MigrationJob{SourceKind: models.MigrationSourcePlesk, SourceUser: "demolab.test"}, "root"},
 		{"cpanel account IS the ssh login",
 			&models.MigrationJob{SourceKind: models.MigrationSourceCpanel, SourceUser: "acct1"}, "acct1"},
 		{"directadmin uses the (pivoted) source user",


### PR DESCRIPTION
Two fixes found while completing a **live Plesk E2E** ( Plesk →  jabali), after the `--property` fix (#749) let the import actually run.

## #4 (blocker) — analyze connects to source as the wrong SSH user

`migrationSSHUser` already returns `root` for Hestia/CloudPanel/CyberPanel — whose `SourceUser` is the account/site, not an SSH login — **but Plesk was left out of the switch**. A Plesk `SourceUser` is a *subscription* (a domain, e.g. `demolab.test`), and the `plesk` CLI needs a root/admin login. Pull forced `root` via `--ssh-user`, but the import's analyze stage inherited the subscription and died:

```
stage analyze: connect: plesk.Connect: source SSH server rejected the supplied auth method … attempted methods [none publickey], no supported methods remain
```

Add `MigrationSourcePlesk` to the root-login switch. **Verified live:** with it, the import runs analyze → fix-perms → validate → restore to completion (auto-creates the user + Kratos identity).

## #2 — auto-kick derived an unsafe target_user

The pull auto-kicks `migration.import_run` with `target_user = job.SourceUser`. For Plesk that's a domain, which the agent rejects (`looksLikeUnixUsername` → "target_user looks unsafe"), so **auto-import was always blocked** and the operator had to run import manually. Slug the Plesk subscription (`demolab.test` → `demolab_test`, a valid unix username) for the auto-kick. Other panels' `SourceUser` is already a valid login.

## Test plan

- [x] `go build ./... && go vet`, gofmt clean
- [x] `TestMigrationSSHUser` extended: Plesk subscription → `root`
- [x] live E2E: import EXIT 0 (was blocked at analyze before)
- [ ] CI

Note: a full domain restore in the E2E was masked by a schema-lag artifact (hot-swapped newer binary vs the box's un-migrated DB → `Unknown column 'dmarc_np'`); resolved by a normal deploy. Related follow-up still open: the source secret + staging dir get reaped on a failed import, so a retry needs a re-pull (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)