### PR TITLE
fix(migration): keep secret + staging on a FAILED import so retry works (GH #746)

### DIFF
--- a/panel-api/cmd/server/migrate_reap_cmd.go
+++ b/panel-api/cmd/server/migrate_reap_cmd.go
@@ -76,15 +76,18 @@ daily cadence; operator can also invoke directly.`,
 					if !isTerminal(row.State) {
 						continue
 					}
+					secretReapOK := secretReapDue(row.State, row.EndedAt, row.UpdatedAt, stagingMaxAge, time.Now())
 					path := filepath.Join(migrationSecretsDir, row.ID+".env")
-					if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
-						if dryRun {
-							fmt.Fprintf(cmd.OutOrStdout(), "[dry-run] would remove %s (job state=%s)\n", path, row.State)
-							deleted++
-						} else if err := os.Remove(path); err != nil {
-							fmt.Fprintf(cmd.ErrOrStderr(), "remove %s: %v\n", path, err)
-						} else {
-							deleted++
+					if secretReapOK {
+						if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+							if dryRun {
+								fmt.Fprintf(cmd.OutOrStdout(), "[dry-run] would remove %s (job state=%s)\n", path, row.State)
+								deleted++
+							} else if err := os.Remove(path); err != nil {
+								fmt.Fprintf(cmd.ErrOrStderr(), "remove %s: %v\n", path, err)
+							} else {
+								deleted++
+							}
 						}
 					}
 					// Staging dir: tarball + extracted tree. Reap when
@@ -196,6 +199,24 @@ func reapOrphanStaging(stagingDir string, live map[string]struct{}, maxAge time.
 		deleted++
 	}
 	return deleted
+}
+
+// secretReapDue decides whether a terminal job's source-secret env file
+// (/etc/jabali-panel/migration-secrets/<id>.env, holding the SSH password/key)
+// should be reaped now. A FAILED job is retryable, so its secret is kept until
+// the same age grace as staging (GH #746) — otherwise every failed import
+// strands the retry, which must then re-upload creds AND re-pull. Other
+// terminal states (done/degraded/cancelled) are finished, so their secret reaps
+// immediately (security: don't leave source creds around longer than needed).
+func secretReapDue(state string, endedAt *time.Time, updatedAt time.Time, grace time.Duration, now time.Time) bool {
+	if state != models.MigrationStateFailed {
+		return true
+	}
+	ref := endedAt
+	if ref == nil || ref.IsZero() {
+		ref = &updatedAt
+	}
+	return now.Sub(*ref) >= grace
 }
 
 func isTerminal(state string) bool {

--- a/panel-api/cmd/server/migrate_reap_secret_grace_test.go
+++ b/panel-api/cmd/server/migrate_reap_secret_grace_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #746: a FAILED import must not have its source secret reaped immediately,
+// or the operator's retry has to re-upload creds AND re-pull. It gets the same
+// age grace as staging; done/degraded/cancelled reap at once.
+func TestSecretReapDue_GH746(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	grace := 7 * 24 * time.Hour
+	recent := now.Add(-1 * time.Hour)
+	old := now.Add(-8 * 24 * time.Hour)
+
+	cases := []struct {
+		name    string
+		state   string
+		ended   *time.Time
+		updated time.Time
+		want    bool
+	}{
+		{"failed within grace -> keep", models.MigrationStateFailed, &recent, recent, false},
+		{"failed past grace -> reap", models.MigrationStateFailed, &old, old, true},
+		{"failed, nil endedAt falls back to updatedAt (recent) -> keep", models.MigrationStateFailed, nil, recent, false},
+		{"done -> reap now", models.MigrationStateDone, &recent, recent, true},
+		{"cancelled -> reap now", models.MigrationStateCancelled, &recent, recent, true},
+		{"degraded -> reap now", models.MigrationStateDegraded, &recent, recent, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := secretReapDue(tc.state, tc.ended, tc.updated, grace, now); got != tc.want {
+				t.Errorf("secretReapDue(%s) = %v, want %v", tc.state, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -723,13 +723,18 @@ failed stage. Already-done stages are skipped.`,
 			// Staging-dir cleanup. Re-load the job so we see the
 			// terminal state the runner just stamped (done / failed).
 			// Operator can suppress via --keep-staging when debugging.
-			// JAB-43: degraded is terminal too — clean it like done/failed so a
+			// JAB-43: degraded is terminal too — clean it like done so a
 			// degraded restore doesn't silently leave GBs in /var/lib/jabali-
 			// migrations (pass --keep-staging to retain for debugging).
+			//
+			// GH #746: a FAILED import is retryable — keep its staging so the
+			// operator's retry doesn't re-pull the whole account (nor re-write
+			// the source secret). The reaper's age-based sweep still reaps
+			// abandoned failed staging after stagingMaxAge.
 			if !keepStaging {
 				if j, lerr := jobsRepo.FindByID(ctx, job.ID); lerr == nil && j != nil {
 					switch j.State {
-					case models.MigrationStateDone, models.MigrationStateFailed,
+					case models.MigrationStateDone,
 						models.MigrationStateCancelled, models.MigrationStateDegraded:
 						stagingDir := filepath.Join("/var/lib/jabali-migrations", job.ID)
 						if rmErr := os.RemoveAll(stagingDir); rmErr != nil {


### PR DESCRIPTION
Follow-up (#3) from the Plesk migration E2E. A **failed** import stranded every retry:

- the import wiped `/var/lib/jabali-migrations/<id>/` on failure -> retry needs a full re-pull of the account, and
- the reaper reaped `/etc/jabali-panel/migration-secrets/<id>.env` immediately for **any** terminal state incl. `failed` -> retry needs the SSH password/key re-uploaded.

Together, iterating on a broken import meant re-pull + re-write-secret every attempt.

## Fix

- `migrate_run_cmd`: drop `MigrationStateFailed` from the on-run staging cleanup. A failed import is retryable, so keep its staging. The reaper's age-based sweep still reaps abandoned failed staging after `stagingMaxAge`.
- `migrate_reap_cmd`: `secretReapDue()` keeps a **failed** job's source secret until the same age grace as staging; `done`/`degraded`/`cancelled` reap immediately (security — don't leave source creds around once the job is finished).

## Test plan

- [x] `go build ./... && go vet`, gofmt clean
- [x] `secretReapDue`: failed within grace keeps; failed past grace reaps; done/cancelled/degraded reap now
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
