### PR TITLE
fix(migration): accept underscore in target username (validate/agent mismatch, GH #746)

### DIFF
--- a/panel-api/internal/migrate/username_gh746_test.go
+++ b/panel-api/internal/migrate/username_gh746_test.go
@@ -1,0 +1,31 @@
+package migrate
+
+import "testing"
+
+// GH #746: the validate stage rejected underscore, but the agent creates
+// underscore users (looksLikeUnixUsername allows it) and the Plesk auto-kick
+// slug produces demolab.test -> demolab_test. The mismatch failed the import
+// after the account already existed. Underscore is a valid unix username char.
+func TestIsValidUnixUsername_GH746(t *testing.T) {
+	valid := []string{"demolab", "demolab_test", "demolab-test", "a", "u1", "wp_7zsxu", "acct1"}
+	invalid := []string{
+		"",             // empty
+		"demolab.test", // dot
+		"1abc",         // starts with digit
+		"-abc",         // starts with hyphen
+		"_abc",         // starts with underscore
+		"Demolab",      // uppercase
+		"foo bar",      // space
+		"toolongusernamethatexceedsthirtytwochars_x", // > 32
+	}
+	for _, s := range valid {
+		if !isValidUnixUsername(s) {
+			t.Errorf("expected %q valid", s)
+		}
+	}
+	for _, s := range invalid {
+		if isValidUnixUsername(s) {
+			t.Errorf("expected %q invalid", s)
+		}
+	}
+}

--- a/panel-api/internal/migrate/validate.go
+++ b/panel-api/internal/migrate/validate.go
@@ -15,9 +15,9 @@ import (
 type ConflictKind string
 
 const (
-	ConflictTargetUserExists  ConflictKind = "target_user_exists"
-	ConflictDomainTaken       ConflictKind = "domain_taken"
-	ConflictUsernameInvalid   ConflictKind = "username_invalid"
+	ConflictTargetUserExists ConflictKind = "target_user_exists"
+	ConflictDomainTaken      ConflictKind = "domain_taken"
+	ConflictUsernameInvalid  ConflictKind = "username_invalid"
 )
 
 // Conflict is one row in the validation report. The Detail is a
@@ -92,13 +92,13 @@ func Validate(ctx context.Context, deps ValidateDeps, m *AccountManifest, target
 	rpt.Projections.CronToCreate = len(m.Cron)
 	rpt.Projections.SSHKeysToCreate = len(m.SSH)
 
-	// Username sanity. POSIX-compatible, 1-32 chars, lowercase,
-	// alnum or hyphen. Stricter than PHP-era panels — refuse
-	// anything that wouldn't survive a useradd.
+	// Username sanity. POSIX-compatible, 1-32 chars, start with a-z,
+	// then lowercase alnum / hyphen / underscore — refuse anything
+	// that wouldn't survive a useradd.
 	if !isValidUnixUsername(targetUsername) {
 		rpt.Blockers = append(rpt.Blockers, Conflict{
 			Kind:   ConflictUsernameInvalid,
-			Detail: fmt.Sprintf("target username %q must be 1-32 chars, lowercase alnum + hyphen", targetUsername),
+			Detail: fmt.Sprintf("target username %q must be 1-32 chars, start with a-z, then lowercase alnum, hyphen or underscore", targetUsername),
 		})
 	}
 
@@ -145,10 +145,13 @@ func Validate(ctx context.Context, deps ValidateDeps, m *AccountManifest, target
 }
 
 // isValidUnixUsername mirrors the rules useradd applies on Debian:
-// start with a lowercase letter, then lowercase / digits / hyphen,
-// 1..32 chars total. Rejects underscores (cPanel allows them, jabali
-// doesn't — restore stage rewrites underscores to hyphens and
-// records the rewrite as a warning).
+// start with a lowercase letter, then lowercase / digits / hyphen /
+// underscore, 1..32 chars total. GH #746: this used to reject
+// underscore, but the agent's looksLikeUnixUsername allows it (and
+// creates such users), and the Plesk auto-kick slug produces one
+// (demolab.test -> demolab_test) — so the mismatch failed imports at
+// validate AFTER the account already existed. Underscore is a valid
+// useradd char, so accept it and stay consistent with the agent.
 func isValidUnixUsername(s string) bool {
 	if len(s) == 0 || len(s) > 32 {
 		return false
@@ -161,6 +164,13 @@ func isValidUnixUsername(s string) bool {
 		case r >= 'a' && r <= 'z':
 		case r >= '0' && r <= '9':
 		case r == '-':
+		// GH #746: underscore is a valid unix username char (useradd allows
+		// it) and the agent's looksLikeUnixUsername accepts it — so the agent
+		// happily CREATES an underscore user, then this validate stage rejected
+		// it, failing the import after the account already exists. It's also
+		// what the Plesk auto-kick slug produces (demolab.test -> demolab_test).
+		// Allow it here to match the agent + actual unix rules.
+		case r == '_':
 		default:
 			return false
 		}


### PR DESCRIPTION
Found in a live Plesk E2E (`.88` Plesk -> testserver jabali).

The panel-side **validate** stage rejected underscore in target usernames, but the **agent**'s `looksLikeUnixUsername` accepts it — and *creates* such users — and the Plesk auto-kick slug produces one (`demolab.test` -> `demolab_test`). So the agent minted the account, then validate blocked the import:

```
stage validate: target username "demolab_test" must be 1-32 chars, lowercase alnum + hyphen
```

The migration failed **after** the user already existed. Underscore is a valid `useradd` char, and the docstring claimed a restore-time underscore->hyphen rewrite that was never implemented. Allow underscore in `isValidUnixUsername` to match the agent + unix.

## Test plan
- [x] `go build`, gofmt, `go test ./internal/migrate`
- [x] `isValidUnixUsername` accepts `demolab_test`/`wp_7zsxu`; rejects dots, leading digit/hyphen/underscore, uppercase, >32
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)