### PR TITLE
fix(migration): Plesk file + DB restore — docroots, rsync guard, DB dumps (GH #746)

### DIFF
--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -30,6 +30,7 @@ type migrationRsyncRemoteHomeParams struct {
 	SecretPath string `json:"secret_path"` // /etc/jabali-panel/migration-secrets/<job>.env
 	SrcPath    string `json:"src_path"`    // absolute source path, e.g. /home/<acct>/domains/<dom>/public_html
 	SrcAccount string `json:"src_account"` // source cPanel/DA account; src_path must live under /home/<src_account>/ (JAB-45)
+	SrcRoot    string `json:"src_root"`    // GH #746: caller-provided allowed source root (Plesk: /var/www/vhosts, not under /home). Empty → legacy /home/<src_account> guard.
 	DestPath   string `json:"dest_path"`   // absolute dest path on this host
 	DestUser   string `json:"dest_user"`   // chown target after rsync
 	Port       int    `json:"port"`        // source SSH port; 0 → 22 (GH #429)
@@ -44,6 +45,34 @@ type migrationRsyncRemoteHomeResult struct {
 
 func init() {
 	Default.Register("migration.rsync_remote_home", migrationRsyncRemoteHomeHandler)
+}
+
+// resolveRsyncSrcRoot returns the absolute source root the rsync src_path must
+// live under, or a non-empty error message. A caller-provided srcRoot (GH #746:
+// Plesk passes /var/www/vhosts, whose docroots are NOT under /home) is honored,
+// failing closed on traversal or a root of "/"; otherwise the JAB-45 legacy
+// /home/<srcAccount> scope applies (cPanel/DA/Hestia/CyberPanel). The panel
+// already scoped SrcPath to the subscription's real docroots — this is
+// defence-in-depth against a tampered manifest pulling arbitrary paths.
+func resolveRsyncSrcRoot(srcRoot, srcAccount string) (string, string) {
+	if srcRoot != "" {
+		if strings.Contains(srcRoot, "..") {
+			return "", "src_root must not contain .."
+		}
+		clean := filepath.Clean(srcRoot)
+		if clean == "/" || clean == "." {
+			return "", "src_root resolves to filesystem root"
+		}
+		return clean, ""
+	}
+	if srcAccount == "" || strings.Contains(srcAccount, "/") || strings.Contains(srcAccount, "..") {
+		return "", "src_account required and must be a bare account name (no / or ..)"
+	}
+	clean := filepath.Clean("/home/" + srcAccount)
+	if clean == "/home" || !strings.HasPrefix(clean, "/home/") {
+		return "", "src_account resolves outside /home"
+	}
+	return clean, ""
 }
 
 func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -68,19 +97,14 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 	// account home is /home/<domain> (e.g. /home/smoke.example.com), so a bare
 	// no-dots rule wrongly refused every CyberPanel home rsync. filepath.Clean
 	// on srcRoot below + the srcRoot-prefix check keep this traversal-safe.
-	if p.SrcAccount == "" || strings.Contains(p.SrcAccount, "/") || strings.Contains(p.SrcAccount, "..") {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
-			Message: "src_account required and must be a bare account name (no / or ..)"}
-	}
-	srcRoot := filepath.Clean("/home/" + p.SrcAccount)
-	if srcRoot == "/home" || !strings.HasPrefix(srcRoot, "/home/") {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
-			Message: "src_account resolves outside /home"}
+	srcRoot, rootErr := resolveRsyncSrcRoot(p.SrcRoot, p.SrcAccount)
+	if rootErr != "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: rootErr}
 	}
 	cleanSrc := filepath.Clean(p.SrcPath)
 	if cleanSrc != srcRoot && !strings.HasPrefix(cleanSrc, srcRoot+"/") {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
-			Message: "src_path must be under /home/<src_account> on source"}
+			Message: "src_path must be under the allowed source root (" + srcRoot + ")"}
 	}
 	p.SrcPath = cleanSrc
 	// Bind the destination to the destination user's own home and resolve it

--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -103,8 +103,14 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 	}
 	cleanSrc := filepath.Clean(p.SrcPath)
 	if cleanSrc != srcRoot && !strings.HasPrefix(cleanSrc, srcRoot+"/") {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
-			Message: "src_path must be under the allowed source root (" + srcRoot + ")"}
+		// Keep the legacy /home/<src_account> wording for the JAB-45 path
+		// (existing callers + tests key on it); name the actual root for the
+		// caller-provided src_root case (GH #746).
+		msg := "src_path must be under /home/<src_account> on source"
+		if p.SrcRoot != "" {
+			msg = "src_path must be under the allowed source root (" + srcRoot + ")"
+		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: msg}
 	}
 	p.SrcPath = cleanSrc
 	// Bind the destination to the destination user's own home and resolve it

--- a/panel-agent/internal/commands/migration_rsync_srcroot_gh746_test.go
+++ b/panel-agent/internal/commands/migration_rsync_srcroot_gh746_test.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #746: the home-rsync guard hardcoded /home/<src_account>, refusing every
+// Plesk file rsync (Plesk docroots live under /var/www/vhosts). It now honors a
+// caller-provided src_root. Tests the real resolveRsyncSrcRoot + the src-path
+// containment the handler applies.
+func srcPathAllowed(srcRoot, srcAccount, srcPath string) bool {
+	root, errMsg := resolveRsyncSrcRoot(srcRoot, srcAccount)
+	if errMsg != "" {
+		return false
+	}
+	c := filepath.Clean(srcPath)
+	return c == root || strings.HasPrefix(c, root+"/")
+}
+
+func TestRsyncSrcRootGuard_GH746(t *testing.T) {
+	cases := []struct {
+		name             string
+		srcRoot, srcAcct string
+		srcPath          string
+		want             bool
+	}{
+		{"plesk vhost docroot allowed", "/var/www/vhosts", "demolab.test", "/var/www/vhosts/demolab.test/httpdocs", true},
+		{"plesk subdomain site1 allowed", "/var/www/vhosts", "demolab.test", "/var/www/vhosts/demolab.test/site1", true},
+		{"plesk path outside vhosts refused", "/var/www/vhosts", "demolab.test", "/etc/passwd", false},
+		{"plesk src_root traversal rejected", "/var/www/../etc", "demolab.test", "/etc/passwd", false},
+		{"legacy cpanel home allowed", "", "acct1", "/home/acct1/public_html", true},
+		{"legacy cross-tenant refused", "", "acct1", "/home/victim/secret", false},
+		{"legacy missing src_account refused", "", "", "/home/x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := srcPathAllowed(tc.srcRoot, tc.srcAcct, tc.srcPath); got != tc.want {
+				t.Errorf("srcPathAllowed(%q,%q,%q)=%v want %v", tc.srcRoot, tc.srcAcct, tc.srcPath, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -502,6 +502,14 @@ failed stage. Already-done stages are skipped.`,
 							parsed.DocRoots[dom] = filepath.Join("/home", *user.Username, "domains", dom, "public_html")
 						}
 					}
+					// GH #746: the Plesk pull STREAMS each database dump into
+					// cpmove-<slug>/mysql/<db>.sql AFTER extraction, so they are
+					// NOT in the metadata-only tarball ParseTarball streamed —
+					// MySQLDumps came back empty and no database migrated. Glob
+					// the mysql/ dir so ImportDatabases has the dumps.
+					if dumps, gerr := filepath.Glob(filepath.Join(extractDir, "cpmove-"+slug, "mysql", "*.sql")); gerr == nil {
+						parsed.MySQLDumps = append(parsed.MySQLDumps, dumps...)
+					}
 				} else {
 					return failJob(fmt.Errorf("plesk cpmove parse %s: %w", pleskTar, perr))
 				}
@@ -1146,6 +1154,17 @@ func cpanelRestoreCallback(
 				}
 				totalBytes := int64(0)
 				domCount := 0
+				// GH #746: Plesk docroots live under /var/www/vhosts, not
+				// /home/<account>, so the agent's JAB-45 /home/<src_account>
+				// guard refused every Plesk file rsync. Tell the agent the
+				// allowed source root; the panel already scoped each SrcPath to
+				// the subscription's real docroots (pleskAuthorizedDocroots).
+				// Empty for other kinds → agent keeps the /home/<src_account>
+				// guard.
+				srcRootOverride := ""
+				if job.SourceKind == models.MigrationSourcePlesk {
+					srcRootOverride = "/var/www/vhosts"
+				}
 				for _, r := range rsyncRows {
 					destPath := filepath.Join("/home", p.targetUsername, "domains", r.Dom, "public_html")
 					rawResp, rerr := restoreAgent.Call(ctx, "migration.rsync_remote_home", map[string]any{
@@ -1164,6 +1183,7 @@ func cpanelRestoreCallback(
 						"ssh_user":    remoteSSHUser,
 						"secret_path": secretPath,
 						"src_path":    r.SrcPath,
+						"src_root":    srcRootOverride,
 						"dest_path":   destPath,
 						"dest_user":   p.targetUsername,
 					})
@@ -1858,18 +1878,26 @@ func pleskAuthorizedDocroots(ctx context.Context, job *models.MigrationJob, db *
 		return nil, fmt.Errorf("connect: %w", err)
 	}
 	defer func() { _ = d.Close(ctx, sess) }()
-	doms, err := d.AuthoritativeDomains(ctx, sess, job.SourceUser)
+	// GH #746: read each domain's REAL docroot from psa hosting.www_root, not
+	// the /httpdocs assumption — a subscription domain can live at
+	// /var/www/vhosts/<sub>/site1, which the old httpdocs-only allowlist
+	// refused, so no files migrated.
+	docroots, err := d.AuthoritativeDocroots(ctx, sess, job.SourceUser)
 	if err != nil {
 		return nil, err
 	}
 	out := map[string]bool{}
-	for _, dom := range doms {
-		if isHostnameLike(dom) { // defence-in-depth on psa output
-			out["/var/www/vhosts/"+dom+"/httpdocs"] = true
+	for _, root := range docroots {
+		cl := filepath.Clean(root)
+		// Defence-in-depth on (untrusted) psa output: only allowlist real
+		// docroots physically under the Plesk vhost root — never /etc, /root,
+		// … even if psa were tampered.
+		if strings.HasPrefix(cl, "/var/www/vhosts/") {
+			out[cl] = true
 		}
 	}
 	if len(out) == 0 {
-		return nil, fmt.Errorf("source psa reported no domains for subscription %q", job.SourceUser)
+		return nil, fmt.Errorf("source psa reported no hosted domains (with a docroot) for subscription %q", job.SourceUser)
 	}
 	return out, nil
 }

--- a/panel-api/internal/migrate/plesk/customers.go
+++ b/panel-api/internal/migrate/plesk/customers.go
@@ -241,3 +241,22 @@ func (d *Discoverer) AuthoritativeDomains(ctx context.Context, raw migrate.Sessi
 	}
 	return splitLines(string(out)), nil
 }
+
+// AuthoritativeDocroots returns the REAL filesystem docroot (psa
+// hosting.www_root) for every domain the subscription owns — the set the
+// migration home-rsync guard allowlists. GH #746: a Plesk docroot is NOT always
+// /var/www/vhosts/<dom>/httpdocs (e.g. shop.demolab.test -> .../demolab.test/
+// site1), so the httpdocs-by-assumption allowlist wrongly refused those real
+// docroots and no files migrated. Domains with no hosting (www_root NULL) are
+// absent. Returns domain -> www_root.
+func (d *Discoverer) AuthoritativeDocroots(ctx context.Context, raw migrate.Session, sub string) (map[string]string, error) {
+	doms, err := d.AuthoritativeDomains(ctx, raw, sub)
+	if err != nil {
+		return nil, err
+	}
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, fmt.Errorf("AuthoritativeDocroots: wrong session type")
+	}
+	return pleskDocroots(ctx, d, s, doms), nil
+}


### PR DESCRIPTION
A live Plesk E2E (`.88` Plesk -> testserver jabali, via a tunnel) proved the migration **created domains but moved zero content**. Three cPanel-centric assumptions in the restore:

## 1. rsync guard (agent) hardcoded `/home/<src_account>`
`migration.rsync_remote_home` refused every Plesk file rsync — Plesk docroots live under `/var/www/vhosts`, not `/home`. Add a caller-provided `src_root`; the panel passes `/var/www/vhosts` for Plesk, empty (legacy `/home/<account>`) for others. Extracted `resolveRsyncSrcRoot` + unit test (Plesk docroot allowed, traversal/cross-tenant refused).

## 2. authoritative-docroot allowlist (panel) assumed `/httpdocs`
`pleskAuthorizedDocroots` allowlisted `/var/www/vhosts/<dom>/httpdocs`, but a subscription domain can live at `.../<sub>/site1` (real psa `hosting.www_root`) — so `shop.demolab.test` was refused as "not an authoritative docroot". Add `plesk.AuthoritativeDocroots` (reads the real `www_root`) and allowlist those.

## 3. DB dumps (panel) never picked up
The Plesk pull **streams** each dump into `cpmove-<slug>/mysql/<db>.sql` *after* extraction, so `ParseTarball` (which reads tarball contents) left `MySQLDumps` empty and 0 DBs imported. Glob the `mysql/` dir in the Plesk parse branch.

## Verified end-to-end (clean box)
- 3 domains created
- WordPress files: `canary.txt` sha256 **byte-for-byte match**, 94 MB / 3953 files, at the correct jabali docroot
- 2 databases (`demolab_test_demodb`, `demolab_test_7zsxu`); seeded row `migration_canary -> canary-db-4c1e77a9` migrated

## Test plan
- [x] `go build ./... && go vet`, gofmt clean
- [x] `resolveRsyncSrcRoot` guard unit test
- [x] live E2E canary match (file sha256 + DB row)
- [ ] CI

Depends on #752 (username underscore) to reach the restore stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
