### PR TITLE
fix(delete): reap nginx main + mail vhost on user/domain delete

### DIFF
--- a/panel-agent/internal/commands/domain_delete.go
+++ b/panel-agent/internal/commands/domain_delete.go
@@ -48,6 +48,16 @@ func domainDeleteHandler(ctx context.Context, params json.RawMessage) (any, erro
 	availablePath := filepath.Join("/etc/nginx/sites-available", p.Domain+".conf")
 	os.Remove(availablePath)
 
+	// Also reap the per-domain mail vhost (mail.<domain>, file
+	// `<domain>-mail.conf`). domain.delete is only ever invoked on a FULL
+	// domain teardown, so the mail vhost must go with it. reconcileWebmailVhosts
+	// only visits domains that still exist, so a deleted domain's mail vhost was
+	// otherwise never reaped — it orphaned in sites-available + sites-enabled on
+	// every delete path (HTTP via Reconciler.ReconcileDeleted and CLI
+	// `jabali user delete` alike). Same `<domain>-mail.conf` convention
+	// webmail.vhost_remove uses; the single reload below covers it.
+	removeMailVhostFiles(p.Domain)
+
 	// Reload nginx
 	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOutput bytes.Buffer
@@ -75,6 +85,28 @@ func domainDeleteHandler(ctx context.Context, params json.RawMessage) (any, erro
 		Domain:  p.Domain,
 		Deleted: true,
 	}, nil
+}
+
+// removeMailVhostFiles reaps the per-domain mail vhost (`<domain>-mail.conf`)
+// from sites-available + sites-enabled, using the same overridable path vars
+// webmail.vhost_remove uses. Idempotent; returns true if it removed anything so
+// the caller can decide whether an nginx reload is warranted. The caller drives
+// the reload (domain.delete reloads once for the main + mail vhost together).
+// domain is expected pre-validated (domainRegex) by the caller.
+func removeMailVhostFiles(domain string) bool {
+	changed := false
+	for _, p := range []string{
+		filepath.Join(mailVhostSitesEnabled, domain+"-mail.conf"),
+		filepath.Join(mailVhostSitesAvailable, domain+"-mail.conf"),
+	} {
+		if _, err := os.Lstat(p); err != nil {
+			continue // absent (or unreadable) — nothing to reap
+		}
+		if err := os.Remove(p); err == nil {
+			changed = true
+		}
+	}
+	return changed
 }
 
 func init() {

--- a/panel-agent/internal/commands/domain_delete_mail_vhost_test.go
+++ b/panel-agent/internal/commands/domain_delete_mail_vhost_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveMailVhostFiles covers domain.delete's mail-vhost reap: it removes
+// `<domain>-mail.conf` from BOTH sites-available and sites-enabled, is
+// idempotent, and never touches an unrelated domain's mail vhost.
+//
+// Regression: `jabali user delete` (and the HTTP delete via
+// Reconciler.ReconcileDeleted) orphaned the per-domain mail vhost, because
+// reconcileWebmailVhosts only visits domains that still exist — a deleted
+// domain's mail vhost was never reaped. domain.delete is the single teardown
+// chokepoint both paths route through, so the reap belongs here.
+func TestRemoveMailVhostFiles(t *testing.T) {
+	avail, enabl := wireMailVhostPaths(t)
+
+	const dom = "delete-me.test"
+	confA := filepath.Join(avail, dom+"-mail.conf")
+	confE := filepath.Join(enabl, dom+"-mail.conf")
+	// An unrelated domain whose mail vhost must survive the reap.
+	const keep = "keep.test"
+	keepA := filepath.Join(avail, keep+"-mail.conf")
+
+	for _, p := range []string{confA, confE, keepA} {
+		if err := os.WriteFile(p, []byte("server {}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// First call removes both target files and reports changed=true.
+	if changed := removeMailVhostFiles(dom); !changed {
+		t.Fatalf("removeMailVhostFiles(%q) = false, want true (files existed)", dom)
+	}
+	for _, p := range []string{confA, confE} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("mail vhost %s still present after reap (err=%v)", p, err)
+		}
+	}
+	// The unrelated domain's mail vhost must be untouched.
+	if _, err := os.Stat(keepA); err != nil {
+		t.Errorf("unrelated mail vhost %s was removed: %v", keepA, err)
+	}
+
+	// Idempotent: a second call finds nothing and reports changed=false.
+	if changed := removeMailVhostFiles(dom); changed {
+		t.Errorf("removeMailVhostFiles(%q) second call = true, want false (already gone)", dom)
+	}
+}

--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -100,6 +100,24 @@ func deleteUserDirect(ctx context.Context, userID string, purgeHome bool) error 
 			if err := domains.Delete(ctx, d.ID); err != nil {
 				slog.Warn("cli delete: cascade domain failed",
 					"user_id", userID, "domain_id", d.ID, "err", err)
+				continue
+			}
+			// Reap the nginx vhost now the row is gone: sites-enabled +
+			// sites-available <domain>.conf, reload, per-domain logs. The HTTP
+			// handler does this via Reconciler.ReconcileDeleted; the CLI has no
+			// reconciler, so it calls the agent's domain.delete RPC directly
+			// (same teardown the domain DELETE route drives). Without it,
+			// `jabali user delete` left orphan /etc/nginx/sites-*/<domain>.conf
+			// behind after the DB row + /home docroot were already gone — the
+			// vhost served a 404-docroot on the deleted domain's Host header.
+			// Best-effort: log + continue, matching the other agent cascades.
+			if sharedAgent != nil {
+				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				if _, err := sharedAgent.Call(agentCtx, "domain.delete", map[string]any{"domain": d.Name}); err != nil {
+					slog.Warn("cli delete: nginx vhost teardown failed",
+						"user_id", userID, "domain", d.Name, "err", err)
+				}
+				cancel()
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

`jabali user delete` left orphan nginx vhost configs behind. Spotted while tearing down Plesk-migration test scaffolding: the account cascade removed the OS user, /home, DBs and mail, but `/etc/nginx/sites-enabled/<domain>.conf` (+ sites-available) stayed — serving a 404-docroot on the deleted domain's Host header.

Two distinct gaps:

1. **CLI never reaped the vhost at all.** The HTTP delete handler tears down nginx via `Reconciler.ReconcileDeleted` (→ agent `domain.delete`). The CLI path (`deleteUserDirect`) has no reconciler and never called `domain.delete`, so the main vhost orphaned.

2. **The per-domain mail vhost (`<domain>-mail.conf`) was never reaped on _either_ path.** `reconcileWebmailVhosts` only visits domains that still exist, so a deleted domain's mail vhost is never visited. `ReconcileDeleted` only called `domain.delete` (main vhost). So both HTTP and CLI leaked the mail vhost.

## Fix

- **panel-api CLI** (`deleteUserDirect`): call `domain.delete` per owned domain in the cascade (parity with the HTTP path). Best-effort, log + continue.
- **panel-agent `domain.delete`**: also reap `<domain>-mail.conf` from sites-available + sites-enabled (`removeMailVhostFiles`), then the single existing reload covers both. `domain.delete` is the one teardown chokepoint both delete paths route through, so fixing it here closes the leak for HTTP and CLI at once.
- **test**: `TestRemoveMailVhostFiles` — removes both files, idempotent, never touches an unrelated domain's mail vhost.

## Verification (box E2E)

Create user + domain, wait for **both** `<domain>.conf` and `<domain>-mail.conf` to materialise, then `jabali user delete <user> --force`:

- **before**: `vhostfix-e2e3.test.conf` + `vhostfix-e2e3.test-mail.conf` (enabled)
- **after**: zero nginx leftovers, no dangling symlinks, domain row gone, OS account gone, `nginx -t` clean

`go build` + `go vet` + `-race` tests green on both modules.