### PR TITLE
feat(php): per-user ionCube Loader primitive — fpm-exec scan dir + agent RPC

### DIFF
--- a/install/systemd/fpm-exec
+++ b/install/systemd/fpm-exec
@@ -16,6 +16,19 @@ verfile="/run/php/jabali-${user}/phpver"
 ver=$(cat "$verfile")
 [[ "$ver" =~ ^[0-9]+\.[0-9]+$ ]] || { echo "fpm-exec: malformed version '$ver' in $verfile" >&2; exit 1; }
 
+# Per-user PHP extension scan dir: an extra ini directory scanned ONLY for
+# this user's master. The agent's php.ioncube.pool_set drops a
+# 00-ioncube.ini here to load the ionCube Loader (a version-locked
+# zend_extension) for this tenant alone, not box-wide. The dir is placed
+# FIRST (leading path, trailing ":" appends the compiled-in default scan
+# dir) because ionCube fatals unless its loader is the first zend_extension
+# parsed — OPcache et al. still load from the default dir after it. Benign
+# when the dir is absent/empty: php-fpm just scans nothing extra. Path lives
+# under /etc/php/** so the jabali-fpm-app AppArmor profile already permits
+# reading it (and the loader .so under /usr/lib/php/** mr) with no profile
+# change. user + ver are validated above, so the path carries no injection.
+export PHP_INI_SCAN_DIR="/etc/php/${ver}/fpm/jabali-ext/${user}:"
+
 # --nodaemonize (-F) keeps php-fpm in foreground so systemd supervises
 # it with Type=simple. --fpm-config points at the per-user FPM config
 # so only this user's pool is loaded (fixes the glob-includes-all-pools bug).

--- a/panel-agent/internal/commands/php_ioncube_pool.go
+++ b/panel-agent/internal/commands/php_ioncube_pool.go
@@ -1,0 +1,176 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// php_ioncube_pool.go — per-user (per-pool) ionCube Loader enable/disable, plus
+// live status. The ionCube Loader is a version-locked, closed-source
+// zend_extension; jabali loads it for a SINGLE tenant's FPM master (never
+// box-wide) by dropping a `00-ioncube.ini` into that user's per-version scan
+// dir, which fpm-exec exposes via PHP_INI_SCAN_DIR. See
+// docs/adr (per-user-master amendment of ADR-0031) + the spike notes.
+//
+// State is LIVE, not persisted (mirrors ADR-0031): loader-installed = the .so
+// exists under /usr/lib/php/ioncube/<ver>/; pool-enabled = the per-user ini
+// exists. No DB row, no reconciler, no drift.
+
+// ionCube path roots. Overridable for tests; production defaults match the
+// AppArmor-permitted locations (/etc/php/** r, /usr/lib/php/** mr — no profile
+// change needed).
+func ioncubePHPEtcRoot() string {
+	if v := os.Getenv("JABALI_PHP_ETC_ROOT"); v != "" {
+		return v
+	}
+	return "/etc/php"
+}
+
+func ioncubeLoaderLibRoot() string {
+	if v := os.Getenv("JABALI_IONCUBE_LIB_ROOT"); v != "" {
+		return v
+	}
+	return "/usr/lib/php/ioncube"
+}
+
+// ioncubeScanDir is the per-user extra-ini directory fpm-exec points
+// PHP_INI_SCAN_DIR at: /etc/php/<ver>/fpm/jabali-ext/<user>.
+func ioncubeScanDir(version, username string) string {
+	return filepath.Join(ioncubePHPEtcRoot(), version, "fpm", "jabali-ext", username)
+}
+
+// ioncubeIniPath is the drop-in that enables the loader for one user's master.
+func ioncubeIniPath(version, username string) string {
+	return filepath.Join(ioncubeScanDir(version, username), "00-ioncube.ini")
+}
+
+// ioncubeLoaderSoPath is where php.ioncube.install writes the loader .so.
+func ioncubeLoaderSoPath(version string) string {
+	return filepath.Join(ioncubeLoaderLibRoot(), version, "ioncube_loader_lin_"+version+".so")
+}
+
+type ioncubePoolSetParams struct {
+	Username string `json:"username"`
+	Version  string `json:"version"`
+	Enabled  bool   `json:"enabled"`
+}
+
+type ioncubePoolSetResponse struct {
+	Username string `json:"username"`
+	Version  string `json:"version"`
+	Enabled  bool   `json:"enabled"`
+	Changed  bool   `json:"changed"`
+}
+
+// phpIoncubePoolSetHandler enables/disables the ionCube Loader for one user's
+// FPM master on a specific PHP version. Enable requires the loader .so to
+// already be installed for that version (CodeFailedPrecondition otherwise);
+// the panel gates on this too, but the agent re-checks at the trust boundary.
+func phpIoncubePoolSetHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ioncubePoolSetParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if !looksLikeUnixUsername(p.Username) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid username %q", p.Username)}
+	}
+	if !phpVersionRegex.MatchString(p.Version) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid PHP version %q (want X.Y)", p.Version)}
+	}
+
+	iniPath := ioncubeIniPath(p.Version, p.Username)
+	changed := false
+
+	if p.Enabled {
+		soPath := ioncubeLoaderSoPath(p.Version)
+		if _, err := os.Stat(soPath); err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeFailedPrecondition,
+				Message: fmt.Sprintf("ionCube Loader is not installed for PHP %s (missing %s); an admin must install it first", p.Version, soPath),
+			}
+		}
+		// Idempotent: only write + reload when the desired content differs.
+		want := "zend_extension=" + soPath + "\n"
+		if cur, err := os.ReadFile(iniPath); err != nil || string(cur) != want {
+			if err := os.MkdirAll(ioncubeScanDir(p.Version, p.Username), 0o755); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir scan dir: %v", err)}
+			}
+			if err := os.WriteFile(iniPath, []byte(want), 0o644); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write ini: %v", err)}
+			}
+			changed = true
+		}
+	} else {
+		if _, err := os.Stat(iniPath); err == nil {
+			if err := os.Remove(iniPath); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove ini: %v", err)}
+			}
+			changed = true
+		}
+	}
+
+	// Reload the user's master so the zend_extension set takes effect. Only
+	// when something changed — a no-op set shouldn't bounce a live pool.
+	if changed {
+		if err := restartOrReloadUserFPM(ctx, p.Username, p.Version, p.Version); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("reload FPM for %s: %v", p.Username, err)}
+		}
+	}
+
+	return ioncubePoolSetResponse{Username: p.Username, Version: p.Version, Enabled: p.Enabled, Changed: changed}, nil
+}
+
+type ioncubeStatusResponse struct {
+	// InstalledVersions is every PHP version with a loader .so on disk.
+	InstalledVersions []string `json:"installed_versions"`
+	// Enabled maps username -> sorted list of versions the user has enabled.
+	Enabled map[string][]string `json:"enabled"`
+}
+
+// phpIoncubeStatusHandler reports live state: which versions have the loader
+// installed, and which users have it enabled on which versions. Pure fs read.
+func phpIoncubeStatusHandler(_ context.Context, _ json.RawMessage) (any, error) {
+	resp := ioncubeStatusResponse{InstalledVersions: []string{}, Enabled: map[string][]string{}}
+
+	// Installed loaders: /usr/lib/php/ioncube/<ver>/ioncube_loader_lin_<ver>.so
+	if matches, _ := filepath.Glob(filepath.Join(ioncubeLoaderLibRoot(), "*", "ioncube_loader_lin_*.so")); len(matches) > 0 {
+		seen := map[string]bool{}
+		for _, m := range matches {
+			ver := filepath.Base(filepath.Dir(m))
+			if phpVersionRegex.MatchString(ver) && !seen[ver] {
+				seen[ver] = true
+				resp.InstalledVersions = append(resp.InstalledVersions, ver)
+			}
+		}
+		sort.Strings(resp.InstalledVersions)
+	}
+
+	// Enabled pools: /etc/php/<ver>/fpm/jabali-ext/<user>/00-ioncube.ini
+	if matches, _ := filepath.Glob(filepath.Join(ioncubePHPEtcRoot(), "*", "fpm", "jabali-ext", "*", "00-ioncube.ini")); len(matches) > 0 {
+		for _, m := range matches {
+			user := filepath.Base(filepath.Dir(m))
+			// .../<ver>/fpm/jabali-ext/<user>/00-ioncube.ini → version is 4 dirs up.
+			ver := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(m)))))
+			if !phpVersionRegex.MatchString(ver) || !looksLikeUnixUsername(user) {
+				continue
+			}
+			resp.Enabled[user] = append(resp.Enabled[user], ver)
+		}
+		for u := range resp.Enabled {
+			sort.Strings(resp.Enabled[u])
+		}
+	}
+
+	return resp, nil
+}
+
+func init() {
+	Default.Register("php.ioncube.pool_set", phpIoncubePoolSetHandler)
+	Default.Register("php.ioncube.status", phpIoncubeStatusHandler)
+}

--- a/panel-agent/internal/commands/php_ioncube_pool_test.go
+++ b/panel-agent/internal/commands/php_ioncube_pool_test.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// wireIoncubeTestRoots points the /etc/php and /usr/lib/php/ioncube roots at
+// temp dirs and skips the systemctl reload, so the handler runs without root.
+func wireIoncubeTestRoots(t *testing.T) (etcRoot, libRoot string) {
+	t.Helper()
+	etcRoot = filepath.Join(t.TempDir(), "php")
+	libRoot = filepath.Join(t.TempDir(), "ioncube")
+	t.Setenv("JABALI_PHP_ETC_ROOT", etcRoot)
+	t.Setenv("JABALI_IONCUBE_LIB_ROOT", libRoot)
+	t.Setenv("JABALI_PHP_POOL_SKIP_RELOAD", "1")
+	return etcRoot, libRoot
+}
+
+func installFakeLoader(t *testing.T, libRoot, version string) {
+	t.Helper()
+	so := filepath.Join(libRoot, version, "ioncube_loader_lin_"+version+".so")
+	if err := os.MkdirAll(filepath.Dir(so), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(so, []byte("\x7fELF-fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func callPoolSet(t *testing.T, user, version string, enabled bool) (ioncubePoolSetResponse, *agentwire.AgentError) {
+	t.Helper()
+	raw, _ := json.Marshal(ioncubePoolSetParams{Username: user, Version: version, Enabled: enabled})
+	out, err := phpIoncubePoolSetHandler(context.Background(), raw)
+	if err != nil {
+		var ae *agentwire.AgentError
+		if errors.As(err, &ae) {
+			return ioncubePoolSetResponse{}, ae
+		}
+		t.Fatalf("unexpected non-agent error: %v", err)
+	}
+	resp, ok := out.(ioncubePoolSetResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", out)
+	}
+	return resp, nil
+}
+
+// TestIoncubePoolSet_EnableRequiresInstalledLoader: enabling before the loader
+// .so exists is a precondition failure, not a silent no-op.
+func TestIoncubePoolSet_EnableRequiresInstalledLoader(t *testing.T) {
+	wireIoncubeTestRoots(t)
+	_, ae := callPoolSet(t, "arizote", "8.1", true)
+	if ae == nil {
+		t.Fatal("expected CodeFailedPrecondition when loader not installed, got success")
+	}
+	if ae.Code != agentwire.CodeFailedPrecondition {
+		t.Errorf("code = %q, want %q", ae.Code, agentwire.CodeFailedPrecondition)
+	}
+	if _, err := os.Stat(ioncubeIniPath("8.1", "arizote")); !os.IsNotExist(err) {
+		t.Errorf("ini should not have been written on a failed enable")
+	}
+}
+
+// TestIoncubePoolSet_EnableThenDisable: the happy path — enable writes the ini
+// pointing at the loader, disable removes it. Both idempotent.
+func TestIoncubePoolSet_EnableThenDisable(t *testing.T) {
+	_, libRoot := wireIoncubeTestRoots(t)
+	installFakeLoader(t, libRoot, "8.1")
+
+	// Enable → writes ini, changed=true.
+	resp, ae := callPoolSet(t, "arizote", "8.1", true)
+	if ae != nil {
+		t.Fatalf("enable failed: %v", ae)
+	}
+	if !resp.Changed || !resp.Enabled {
+		t.Errorf("enable: got changed=%v enabled=%v, want true/true", resp.Changed, resp.Enabled)
+	}
+	iniPath := ioncubeIniPath("8.1", "arizote")
+	body, err := os.ReadFile(iniPath)
+	if err != nil {
+		t.Fatalf("ini not written: %v", err)
+	}
+	if string(body) != "zend_extension="+ioncubeLoaderSoPath("8.1")+"\n" {
+		t.Errorf("ini body = %q", string(body))
+	}
+
+	// Enable again → idempotent, changed=false.
+	if resp, _ := callPoolSet(t, "arizote", "8.1", true); resp.Changed {
+		t.Errorf("second enable should be a no-op (changed=false), got changed=true")
+	}
+
+	// Disable → removes ini, changed=true.
+	resp, ae = callPoolSet(t, "arizote", "8.1", false)
+	if ae != nil {
+		t.Fatalf("disable failed: %v", ae)
+	}
+	if !resp.Changed || resp.Enabled {
+		t.Errorf("disable: got changed=%v enabled=%v, want true/false", resp.Changed, resp.Enabled)
+	}
+	if _, err := os.Stat(iniPath); !os.IsNotExist(err) {
+		t.Errorf("ini still present after disable")
+	}
+
+	// Disable again → idempotent, changed=false.
+	if resp, _ := callPoolSet(t, "arizote", "8.1", false); resp.Changed {
+		t.Errorf("second disable should be a no-op (changed=false), got changed=true")
+	}
+}
+
+// TestIoncubePoolSet_RejectsBadInput: username/version validated at the trust
+// boundary before any filesystem path is built.
+func TestIoncubePoolSet_RejectsBadInput(t *testing.T) {
+	wireIoncubeTestRoots(t)
+	for _, tc := range []struct{ user, version string }{
+		{"../etc", "8.1"},
+		{"arizote", "8.1; rm -rf"},
+		{"arizote", "../../8.1"},
+		{"", "8.1"},
+	} {
+		if _, ae := callPoolSet(t, tc.user, tc.version, true); ae == nil || ae.Code != agentwire.CodeInvalidArgument {
+			t.Errorf("user=%q ver=%q: want CodeInvalidArgument, got %+v", tc.user, tc.version, ae)
+		}
+	}
+}
+
+// TestIoncubeStatus_ReportsLiveState: status reflects installed loaders +
+// enabled pools purely from the filesystem.
+func TestIoncubeStatus_ReportsLiveState(t *testing.T) {
+	_, libRoot := wireIoncubeTestRoots(t)
+	installFakeLoader(t, libRoot, "8.1")
+	installFakeLoader(t, libRoot, "8.3")
+	if _, ae := callPoolSet(t, "arizote", "8.1", true); ae != nil {
+		t.Fatalf("enable arizote: %v", ae)
+	}
+
+	out, err := phpIoncubeStatusHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	st := out.(ioncubeStatusResponse)
+	if len(st.InstalledVersions) != 2 || st.InstalledVersions[0] != "8.1" || st.InstalledVersions[1] != "8.3" {
+		t.Errorf("installed = %v, want [8.1 8.3]", st.InstalledVersions)
+	}
+	if got := st.Enabled["arizote"]; len(got) != 1 || got[0] != "8.1" {
+		t.Errorf("enabled[arizote] = %v, want [8.1]", got)
+	}
+}


### PR DESCRIPTION
Phase 1 of ionCube Loader support (plan: `plans/gh-ioncube-loader.md`). The load-bearing primitive: enable the ionCube Loader for **one tenant's** per-user FPM master, never box-wide.

## Why this works (spike-verified under ENFORCE)

ADR-0031 rejected per-pool extensions because "PHP-FPM shares one module loader per master." But jabali runs a **per-user master** (`jabali-fpm@<user>` via `fpm-exec`) — exactly the per-pool master that unlocks per-tenant isolation. A per-user `PHP_INI_SCAN_DIR` loads the loader for that master alone.

## Changes

- **`install/systemd/fpm-exec`**: `export PHP_INI_SCAN_DIR="/etc/php/<ver>/fpm/jabali-ext/<user>:"` — per-user dir FIRST (ionCube must be the first `zend_extension`; trailing `:` keeps the compiled default so OPcache still loads). Benign when the dir is absent. Path under `/etc/php/**` + loader under `/usr/lib/php/**` are **already** allowed by the `jabali-fpm-app` AppArmor profile → **no profile change**.
- **`php.ioncube.pool_set {username, version, enabled}`**: writes/removes `00-ioncube.ini` + reloads that user's master. Enable requires the loader `.so` installed for the version (`CodeFailedPrecondition`). Idempotent. Re-validates username/version agent-side.
- **`php.ioncube.status`**: live fs read of installed loaders + enabled pools. No DB, no reconciler, no drift (mirrors ADR-0031 live-state).

## Verification — box E2E (testserver, `jabali-fpm-app` ENFORCE)

Two users on PHP 8.4, loader installed for 8.4, enable via the RPC for **one**:

| User | ionCube enabled | HTTP `extension_loaded('ionCube Loader')` |
|---|---|---|
| icubea | yes (RPC) | **YES v15.5** |
| icubeb | no | **NO** |

- disable → flips back to `NO`; status reflects it
- enable on uninstalled version (8.5) → `failed_precondition` with a clear message
- **no AppArmor denial** on the `.so`
- unit tests: precondition, idempotency, input validation, live status — all green (`-race`)

## Not in this PR (later phases)

Loader delivery (panel-api fetch + sha256 + agent install), orchestration API (admin install + tenant enable, ownership + version gating + openapi), UI, CLI + ADR amendment.