### PR TITLE
feat(php): ionCube loader delivery — panel-api fetch + verify + agent install

### DIFF
--- a/panel-agent/internal/commands/php_ioncube_install.go
+++ b/panel-agent/internal/commands/php_ioncube_install.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// php_ioncube_install.go — install/uninstall the ionCube Loader .so for a PHP
+// version. panel-api fetches + verifies the loader (ADR-0050: the agent has no
+// outbound HTTPS) and passes the bytes base64-encoded plus the expected sha256;
+// the agent re-verifies the bytes before writing them to the AppArmor-permitted
+// /usr/lib/php/ioncube/<ver>/ path (root:root 0644). Uninstall refuses while any
+// pool is still enabled on that version, so a live site can't lose its loader
+// out from under it.
+
+type ioncubeInstallParams struct {
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+	SoB64   string `json:"so_b64"`
+}
+
+type ioncubeInstallResponse struct {
+	Version   string `json:"version"`
+	Installed bool   `json:"installed"`
+	Path      string `json:"path"`
+	Changed   bool   `json:"changed"`
+}
+
+func phpIoncubeInstallHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p ioncubeInstallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if !phpVersionRegex.MatchString(p.Version) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid PHP version %q (want X.Y)", p.Version)}
+	}
+	if len(p.SHA256) != 64 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "sha256 must be 64 hex chars"}
+	}
+	data, err := base64.StdEncoding.DecodeString(p.SoB64)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("decode so_b64: %v", err)}
+	}
+	if len(data) == 0 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "so_b64 is empty"}
+	}
+	// Re-verify at the trust boundary: the bytes must match the sha the panel
+	// verified against its pinned catalogue. Never write an unverified blob.
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); !strings.EqualFold(got, p.SHA256) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("loader sha256 mismatch: bytes=%s param=%s", got, p.SHA256)}
+	}
+
+	soPath := ioncubeLoaderSoPath(p.Version)
+	// Idempotent: if an identical .so is already installed, no-op.
+	if cur, err := os.ReadFile(soPath); err == nil {
+		curSum := sha256.Sum256(cur)
+		if hex.EncodeToString(curSum[:]) == strings.ToLower(p.SHA256) {
+			return ioncubeInstallResponse{Version: p.Version, Installed: true, Path: soPath, Changed: false}, nil
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(soPath), 0o755); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir loader dir: %v", err)}
+	}
+	if err := writeFileAtomic(soPath, data, 0o644); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write loader: %v", err)}
+	}
+	return ioncubeInstallResponse{Version: p.Version, Installed: true, Path: soPath, Changed: true}, nil
+}
+
+type ioncubeUninstallParams struct {
+	Version string `json:"version"`
+}
+
+type ioncubeUninstallResponse struct {
+	Version   string `json:"version"`
+	Installed bool   `json:"installed"`
+	Changed   bool   `json:"changed"`
+}
+
+func phpIoncubeUninstallHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p ioncubeUninstallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if !phpVersionRegex.MatchString(p.Version) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid PHP version %q (want X.Y)", p.Version)}
+	}
+
+	// Refuse while any pool still has the loader enabled on this version — the
+	// pool's 00-ioncube.ini would point at a now-missing .so and the master
+	// would fatal on reload.
+	if users := ioncubeEnabledUsersForVersion(p.Version); len(users) > 0 {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: fmt.Sprintf("ionCube is still enabled for PHP %s on %d pool(s): %s; disable them first", p.Version, len(users), strings.Join(users, ", ")),
+		}
+	}
+
+	soPath := ioncubeLoaderSoPath(p.Version)
+	if _, err := os.Stat(soPath); err != nil {
+		return ioncubeUninstallResponse{Version: p.Version, Installed: false, Changed: false}, nil
+	}
+	if err := os.Remove(soPath); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove loader: %v", err)}
+	}
+	return ioncubeUninstallResponse{Version: p.Version, Installed: false, Changed: true}, nil
+}
+
+// ioncubeEnabledUsersForVersion lists users whose pool has ionCube enabled on
+// the given version (a 00-ioncube.ini under that version's jabali-ext dir).
+func ioncubeEnabledUsersForVersion(version string) []string {
+	matches, _ := filepath.Glob(filepath.Join(ioncubePHPEtcRoot(), version, "fpm", "jabali-ext", "*", "00-ioncube.ini"))
+	users := make([]string, 0, len(matches))
+	for _, m := range matches {
+		u := filepath.Base(filepath.Dir(m))
+		if looksLikeUnixUsername(u) {
+			users = append(users, u)
+		}
+	}
+	return users
+}
+
+func init() {
+	Default.Register("php.ioncube.install", phpIoncubeInstallHandler)
+	Default.Register("php.ioncube.uninstall", phpIoncubeUninstallHandler)
+}

--- a/panel-agent/internal/commands/php_ioncube_install_test.go
+++ b/panel-agent/internal/commands/php_ioncube_install_test.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func callInstall(t *testing.T, version, sha, b64 string) (ioncubeInstallResponse, *agentwire.AgentError) {
+	t.Helper()
+	raw, _ := json.Marshal(ioncubeInstallParams{Version: version, SHA256: sha, SoB64: b64})
+	out, err := phpIoncubeInstallHandler(context.Background(), raw)
+	if err != nil {
+		var ae *agentwire.AgentError
+		if errors.As(err, &ae) {
+			return ioncubeInstallResponse{}, ae
+		}
+		t.Fatalf("non-agent error: %v", err)
+	}
+	return out.(ioncubeInstallResponse), nil
+}
+
+func callUninstall(t *testing.T, version string) (ioncubeUninstallResponse, *agentwire.AgentError) {
+	t.Helper()
+	raw, _ := json.Marshal(ioncubeUninstallParams{Version: version})
+	out, err := phpIoncubeUninstallHandler(context.Background(), raw)
+	if err != nil {
+		var ae *agentwire.AgentError
+		if errors.As(err, &ae) {
+			return ioncubeUninstallResponse{}, ae
+		}
+		t.Fatalf("non-agent error: %v", err)
+	}
+	return out.(ioncubeUninstallResponse), nil
+}
+
+// TestIoncubeInstall_VerifyWriteIdempotent: install writes the .so after a
+// sha match; a second identical install is a no-op; a sha mismatch is rejected.
+func TestIoncubeInstall_VerifyWriteIdempotent(t *testing.T) {
+	wireIoncubeTestRoots(t)
+	blob := []byte("\x7fELF fake loader")
+	sum := sha256.Sum256(blob)
+	shaHex := hex.EncodeToString(sum[:])
+	b64 := base64.StdEncoding.EncodeToString(blob)
+
+	// Install → changed=true, .so present with correct bytes.
+	resp, ae := callInstall(t, "8.4", shaHex, b64)
+	if ae != nil {
+		t.Fatalf("install: %v", ae)
+	}
+	if !resp.Installed || !resp.Changed {
+		t.Errorf("install: installed=%v changed=%v want true/true", resp.Installed, resp.Changed)
+	}
+	got, err := os.ReadFile(ioncubeLoaderSoPath("8.4"))
+	if err != nil || string(got) != string(blob) {
+		t.Fatalf("loader not written correctly: %v", err)
+	}
+
+	// Re-install identical → idempotent no-op.
+	if resp, _ := callInstall(t, "8.4", shaHex, b64); resp.Changed {
+		t.Errorf("second identical install should be changed=false")
+	}
+
+	// sha mismatch → rejected, invalid argument.
+	if _, ae := callInstall(t, "8.4", hex.EncodeToString(sha256.New().Sum(nil)), b64); ae == nil || ae.Code != agentwire.CodeInvalidArgument {
+		t.Errorf("sha mismatch: want CodeInvalidArgument, got %+v", ae)
+	}
+}
+
+// TestIoncubeUninstall_BlockedWhileEnabled: uninstall must refuse while a pool
+// is enabled on that version, then succeed once it's disabled.
+func TestIoncubeUninstall_BlockedWhileEnabled(t *testing.T) {
+	wireIoncubeTestRoots(t)
+	blob := []byte("loader")
+	sum := sha256.Sum256(blob)
+	callInstall(t, "8.4", hex.EncodeToString(sum[:]), base64.StdEncoding.EncodeToString(blob))
+
+	// Enable a pool on 8.4.
+	if _, ae := callPoolSet(t, "arizote", "8.4", true); ae != nil {
+		t.Fatalf("enable pool: %v", ae)
+	}
+
+	// Uninstall blocked.
+	if _, ae := callUninstall(t, "8.4"); ae == nil || ae.Code != agentwire.CodeFailedPrecondition {
+		t.Errorf("uninstall while enabled: want CodeFailedPrecondition, got %+v", ae)
+	}
+
+	// Disable, then uninstall succeeds.
+	if _, ae := callPoolSet(t, "arizote", "8.4", false); ae != nil {
+		t.Fatalf("disable pool: %v", ae)
+	}
+	resp, ae := callUninstall(t, "8.4")
+	if ae != nil {
+		t.Fatalf("uninstall after disable: %v", ae)
+	}
+	if resp.Installed || !resp.Changed {
+		t.Errorf("uninstall: installed=%v changed=%v want false/true", resp.Installed, resp.Changed)
+	}
+	if _, err := os.Stat(ioncubeLoaderSoPath("8.4")); !os.IsNotExist(err) {
+		t.Errorf("loader still present after uninstall")
+	}
+}
+
+func TestIoncubeInstall_RejectsBadInput(t *testing.T) {
+	wireIoncubeTestRoots(t)
+	// bad version
+	if _, ae := callInstall(t, "8", "aa", "eA=="); ae == nil || ae.Code != agentwire.CodeInvalidArgument {
+		t.Errorf("bad version: want CodeInvalidArgument, got %+v", ae)
+	}
+	// bad sha length
+	if _, ae := callInstall(t, "8.4", "short", "eA=="); ae == nil || ae.Code != agentwire.CodeInvalidArgument {
+		t.Errorf("bad sha: want CodeInvalidArgument, got %+v", ae)
+	}
+}

--- a/panel-api/internal/ioncube/catalogue.go
+++ b/panel-api/internal/ioncube/catalogue.go
@@ -1,0 +1,77 @@
+// Package ioncube is the pinned catalogue + fetch logic for the ionCube
+// Loader. panel-api owns the download (ADR-0050: the agent has no outbound
+// HTTPS); the agent receives verified bytes and installs the .so.
+//
+// State is live (mirrors ADR-0031): the catalogue only pins WHAT a trusted
+// loader is (URL + per-version sha256), never WHICH versions a box has
+// installed — that is read from the filesystem by the agent.
+package ioncube
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+// LoaderVersion is the ionCube Loader release this catalogue's checksums pin.
+// Bumping the loader = new tarball → new per-version sha256 → a panel release
+// (same cadence contract as the ADR-0031 extension catalogue).
+const LoaderVersion = "15.5.0"
+
+// TarballURL is ionCube's official Linux x86-64 loaders archive. It is a
+// rolling "latest" URL; integrity is enforced by verifying each extracted .so
+// against SHA256ByVersion below, NOT by trusting the URL. A loader bump upstream
+// makes the sha mismatch → install hard-fails with a clear "catalogue out of
+// date" message rather than installing an unverified blob.
+const TarballURL = "https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz"
+
+// soNameFor is the file name of the non-thread-safe Linux x86-64 loader for a
+// PHP version inside the tarball's ioncube/ directory.
+func soNameFor(version string) string {
+	return "ioncube_loader_lin_" + version + ".so"
+}
+
+// SHA256ByVersion pins the sha256 of each shipped loader .so (ionCube Loader
+// v15.5.0, non-TS, lin x86-64). Keys are the PHP versions jabali offers ionCube
+// for. Adding a PHP version or bumping the loader updates this map + the
+// LoaderVersion constant in the same change.
+var sha256ByVersion = map[string]string{
+	"7.4": "c02556b30a25f4370b4e7ece73f83db5952068d4ee8a1165f8baf9df79070258",
+	"8.1": "380f2ecad4ba295f66ebd88a758b55a75fc567b17b852e95f4788b0b588ebf98",
+	"8.2": "8b6c18809f5d83a0f69cc29e7e0c05a6e21ae6f484e5e8db7d6aca140aefa68a",
+	"8.3": "5698913066b2f205fe3d14d32d908df322262237c7890f8ccbbd99ad9af801ce",
+	"8.4": "e2a653cad6623968e82ca19a9031039d85808cf07a7ac929b222c25af8eabcf1",
+	"8.5": "ad4b4e37cb2a270cb736ba8676521121ba3b56a7bc82287808b46b046d9ba3d4",
+}
+
+var versionRegex = regexp.MustCompile(`^\d+\.\d+$`)
+
+// ValidVersion reports whether jabali ships an ionCube loader for a PHP version.
+// Panel-api pre-validates here; the agent re-validates the version format at the
+// trust boundary.
+func ValidVersion(version string) bool {
+	if !versionRegex.MatchString(version) {
+		return false
+	}
+	_, ok := sha256ByVersion[version]
+	return ok
+}
+
+// SupportedVersions returns the PHP versions with a pinned loader, sorted.
+func SupportedVersions() []string {
+	vs := make([]string, 0, len(sha256ByVersion))
+	for v := range sha256ByVersion {
+		vs = append(vs, v)
+	}
+	sort.Strings(vs)
+	return vs
+}
+
+// SHA256For returns the pinned loader sha256 for a PHP version.
+func SHA256For(version string) (string, error) {
+	sum, ok := sha256ByVersion[version]
+	if !ok {
+		return "", fmt.Errorf("ionCube loader not cataloged for PHP %s (supported: %v)", version, SupportedVersions())
+	}
+	return sum, nil
+}

--- a/panel-api/internal/ioncube/fetch.go
+++ b/panel-api/internal/ioncube/fetch.go
@@ -1,0 +1,105 @@
+package ioncube
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+)
+
+// maxLoaderBytes bounds a single extracted .so (loaders are ~2.5 MB; 16 MB is a
+// generous ceiling that still stops a malicious/oversized member from being
+// buffered into memory).
+const maxLoaderBytes = 16 << 20
+
+// Fetcher downloads + extracts a verified ionCube loader. URL and Client are
+// overridable so tests can serve a synthetic tarball without hitting the
+// network. Zero value uses the pinned TarballURL + a 60s http client.
+type Fetcher struct {
+	URL    string
+	Client *http.Client
+}
+
+// FetchLoader downloads the loaders tarball, extracts the .so for the given PHP
+// version, verifies it against the pinned catalogue sha256, and returns the raw
+// bytes. panel-api hands these to the agent's php.ioncube.install (ADR-0050: the
+// agent never fetches). A sha mismatch is a hard error — the caller MUST NOT
+// install unverified bytes.
+func (f Fetcher) FetchLoader(ctx context.Context, version string) ([]byte, error) {
+	want, err := SHA256For(version)
+	if err != nil {
+		return nil, err
+	}
+	url := f.URL
+	if url == "" {
+		url = TarballURL
+	}
+	client := f.Client
+	if client == nil {
+		client = &http.Client{Timeout: 60 * time.Second}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download loaders tarball: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download loaders tarball: unexpected status %d", resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gunzip tarball: %w", err)
+	}
+	defer gz.Close()
+
+	target := soNameFor(version)
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tarball: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		// Match the loader by base name regardless of the archive's top dir.
+		if path.Base(hdr.Name) != target {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxLoaderBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read loader %s: %w", target, err)
+		}
+		if len(data) > maxLoaderBytes {
+			return nil, fmt.Errorf("loader %s exceeds %d bytes", target, maxLoaderBytes)
+		}
+		got := hex.EncodeToString(sha256Sum(data))
+		if !strings.EqualFold(got, want) {
+			return nil, fmt.Errorf("loader %s sha256 mismatch: got %s, want %s (ionCube may have updated the loader; the catalogue needs a panel release)", target, got, want)
+		}
+		return data, nil
+	}
+	return nil, fmt.Errorf("loader %s not found in tarball", target)
+}
+
+func sha256Sum(b []byte) []byte {
+	h := sha256.New()
+	h.Write(b)
+	return h.Sum(nil)
+}

--- a/panel-api/internal/ioncube/ioncube_test.go
+++ b/panel-api/internal/ioncube/ioncube_test.go
@@ -1,0 +1,124 @@
+package ioncube
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestValidVersion(t *testing.T) {
+	for _, v := range []string{"7.4", "8.1", "8.4", "8.5"} {
+		if !ValidVersion(v) {
+			t.Errorf("ValidVersion(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"8.0", "9.9", "8", "8.4.1", "../8.4", ""} {
+		if ValidVersion(v) {
+			t.Errorf("ValidVersion(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestSupportedVersionsSorted(t *testing.T) {
+	got := SupportedVersions()
+	if len(got) != 6 {
+		t.Fatalf("SupportedVersions len = %d, want 6", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("SupportedVersions not sorted: %v", got)
+		}
+	}
+}
+
+// makeTarball builds a gzip'd tar containing one member named for the loader
+// plus a decoy, and returns (bytes, sha256-of-loader-hex).
+func makeTarball(t *testing.T, version string, loader []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	write := func(name string, body []byte) {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("ioncube/README.txt", []byte("decoy"))
+	write("ioncube/"+soNameFor(version), loader)
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func serveBytes(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// withCatalogueEntry temporarily pins a sha for a test version, restoring after.
+func withCatalogueEntry(t *testing.T, version, sha string) {
+	t.Helper()
+	orig, had := sha256ByVersion[version]
+	sha256ByVersion[version] = sha
+	t.Cleanup(func() {
+		if had {
+			sha256ByVersion[version] = orig
+		} else {
+			delete(sha256ByVersion, version)
+		}
+	})
+}
+
+func TestFetchLoader_VerifiesAndExtracts(t *testing.T) {
+	loader := []byte("\x7fELF fake ioncube loader body")
+	sum := sha256.Sum256(loader)
+	withCatalogueEntry(t, "8.4", hex.EncodeToString(sum[:]))
+
+	tarball := makeTarball(t, "8.4", loader)
+	srv := serveBytes(t, tarball)
+
+	got, err := Fetcher{URL: srv.URL, Client: srv.Client()}.FetchLoader(context.Background(), "8.4")
+	if err != nil {
+		t.Fatalf("FetchLoader: %v", err)
+	}
+	if !bytes.Equal(got, loader) {
+		t.Errorf("extracted bytes mismatch")
+	}
+}
+
+func TestFetchLoader_RejectsShaMismatch(t *testing.T) {
+	loader := []byte("real loader")
+	// Pin a wrong-but-valid-length sha for 8.4 so extraction succeeds but the
+	// integrity check fails (the "ionCube updated the loader" case).
+	withCatalogueEntry(t, "8.4", "deadbeef00000000000000000000000000000000000000000000000000000000")
+
+	srv := serveBytes(t, makeTarball(t, "8.4", loader))
+	_, err := Fetcher{URL: srv.URL, Client: srv.Client()}.FetchLoader(context.Background(), "8.4")
+	if err == nil {
+		t.Fatal("expected sha256 mismatch error, got nil")
+	}
+}
+
+func TestFetchLoader_MissingVersion(t *testing.T) {
+	srv := serveBytes(t, makeTarball(t, "8.4", []byte("x")))
+	if _, err := (Fetcher{URL: srv.URL, Client: srv.Client()}).FetchLoader(context.Background(), "9.9"); err == nil {
+		t.Fatal("expected error for uncataloged version")
+	}
+}


### PR DESCRIPTION
Phase 2 of ionCube Loader support (plan: `plans/gh-ioncube-loader.md`). Builds on Phase 1 (#755). panel-api fetches the loader; the agent installs verified bytes.

## Design

Per **ADR-0050** the agent has no outbound HTTPS, so **panel-api** downloads + verifies, and the agent receives bytes.

- **`panel-api/internal/ioncube`** — pinned catalogue: loader **v15.5.0** tarball URL + per-version sha256 for PHP **7.4 / 8.1 / 8.2 / 8.3 / 8.4 / 8.5**. `Fetcher.FetchLoader` downloads the tarball, extracts the one `.so`, verifies against the pinned sha256. The upstream URL is rolling "latest" — a loader bump makes the sha mismatch and **hard-fails** ("catalogue needs a panel release") rather than installing an unverified blob. URL + client injectable for tests (synthetic tarball, no network).
- **`php.ioncube.install {version, sha256, so_b64}`** — agent decodes bytes, **re-verifies sha256** at the trust boundary, writes the `.so` atomically to `/usr/lib/php/ioncube/<ver>/` (root:root 0644; AppArmor already permits `/usr/lib/php/** mr`). Idempotent. Bytes over the socket (2.5 MB → ~3.4 MB base64, under the 8 MB cap) — no shared writable dir, no path-traversal surface.
- **`php.ioncube.uninstall {version}`** — refuses while any pool has ionCube **enabled** on that version (`CodeFailedPrecondition`, names the pools), so a live master can't lose its loader on reload.

## Verification — box E2E (testserver, `jabali-fpm-app` ENFORCE)

- install real 8.4 loader via RPC → **on-disk sha256 matches the pin**; idempotent re-install = no-op
- enable a pool (Phase 1) → site serves **ionCube v15.5**
- uninstall **blocked** while pool enabled → after disable, **succeeds**, loader gone, site back to `NO`
- unit tests: catalogue validation, fetch verify/mismatch/missing, install verify/idempotent/bad-input, uninstall-guard — all `-race` green

## Not in this PR

Orchestration API (admin install + tenant enable, ownership + version gating + openapi), UI, CLI + ADR amendment.