### PR TITLE
feat(php): ionCube orchestration API — admin install + tenant enable

### DIFF
--- a/panel-api/internal/api/domain_php_ioncube.go
+++ b/panel-api/internal/api/domain_php_ioncube.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// DomainIonCubeHandlerConfig wires the per-domain ionCube enable route.
+type DomainIonCubeHandlerConfig struct {
+	Domains  repository.DomainRepository
+	PHPPools repository.PHPPoolRepository
+	Users    repository.UserRepository
+	Agent    agent.AgentInterface
+}
+
+// RegisterDomainIonCubeRoutes adds the tenant-facing ionCube toggle:
+//
+//	PUT /domains/:id/php-ioncube   {"enabled": true|false}
+//
+// Ownership-scoped: a tenant may toggle ONLY their own domains (admin may
+// toggle any). The loader-installed gate is enforced agent-side by
+// php.ioncube.pool_set's precondition (translated to 409 here) so there is a
+// single source of truth for "is the loader present for this version".
+func RegisterDomainIonCubeRoutes(g *gin.RouterGroup, cfg DomainIonCubeHandlerConfig) {
+	h := &domainIonCubeHandler{cfg: cfg}
+	g.PUT("/domains/:id/php-ioncube", h.put)
+}
+
+type domainIonCubeHandler struct{ cfg DomainIonCubeHandlerConfig }
+
+type domainIonCubeRequest struct {
+	Enabled *bool `json:"enabled" binding:"required"`
+}
+
+func (h *domainIonCubeHandler) put(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	var req domainIonCubeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_argument", "detail": err.Error()})
+		return
+	}
+
+	ctx := c.Request.Context()
+	dom, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return
+		}
+		slog.ErrorContext(ctx, "ioncube toggle: load domain", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	// Ownership: owner or admin only. Never let a tenant touch another's domain.
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	// Resolve the pool bound to this domain (or the owner's pool) → PHP version.
+	// ionCube is per-(user × version); the domain's version determines which
+	// pool's master the loader is toggled on.
+	version := h.resolveVersion(ctx, dom)
+	if version == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "no_php_version", "detail": "set a PHP version for this domain before enabling ionCube"})
+		return
+	}
+
+	// Resolve the domain owner's unix username (the FPM master's %i). Admin
+	// users have no username — but an admin-owned domain shouldn't reach here
+	// with tenant PHP anyway.
+	owner, err := h.cfg.Users.FindByID(ctx, dom.UserID)
+	if err != nil || owner == nil || owner.Username == nil || *owner.Username == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "no_unix_account", "detail": "domain owner has no unix account for a PHP pool"})
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(callCtx, "php.ioncube.pool_set", map[string]any{
+		"username": *owner.Username,
+		"version":  version,
+		"enabled":  *req.Enabled,
+	})
+	if err != nil {
+		// The agent's precondition (loader not installed for this version)
+		// surfaces as CodeFailedPrecondition → 409 with a clear message.
+		status, body := translateAgentError(err)
+		c.JSON(status, body)
+		return
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
+}
+
+// resolveVersion returns the PHP version driving this domain's pool: the bound
+// pool's version if the domain is bound, else the owner's pool version
+// (ADR-0023: one pool per user). Empty when neither exists.
+func (h *domainIonCubeHandler) resolveVersion(ctx context.Context, dom *models.Domain) string {
+	if dom.PHPPoolID != nil && *dom.PHPPoolID != "" {
+		if pool, err := h.cfg.PHPPools.FindByID(ctx, *dom.PHPPoolID); err == nil && pool != nil {
+			return pool.PHPVersion
+		}
+	}
+	if pool, err := h.cfg.PHPPools.FindByUserID(ctx, dom.UserID); err == nil && pool != nil {
+		return pool.PHPVersion
+	}
+	return ""
+}

--- a/panel-api/internal/api/domain_php_ioncube_test.go
+++ b/panel-api/internal/api/domain_php_ioncube_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- minimal repo fakes (embed the interface, override what the handler uses) ---
+
+type icDomainRepo struct {
+	repository.DomainRepository
+	dom *models.Domain
+}
+
+func (r *icDomainRepo) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	if r.dom == nil || r.dom.ID != id {
+		return nil, repository.ErrNotFound
+	}
+	return r.dom, nil
+}
+
+type icPoolRepo struct {
+	repository.PHPPoolRepository
+	pool *models.PHPPool
+}
+
+func (r *icPoolRepo) FindByID(_ context.Context, _ string) (*models.PHPPool, error) {
+	return r.pool, nil
+}
+func (r *icPoolRepo) FindByUserID(_ context.Context, _ string) (*models.PHPPool, error) {
+	return r.pool, nil
+}
+
+type icUserRepo struct {
+	repository.UserRepository
+	user *models.User
+}
+
+func (r *icUserRepo) FindByID(_ context.Context, _ string) (*models.User, error) {
+	return r.user, nil
+}
+
+func strp(s string) *string { return &s }
+
+func icRouter(cfg DomainIonCubeHandlerConfig, userID string, admin bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: admin})
+		c.Next()
+	})
+	RegisterDomainIonCubeRoutes(v1, cfg)
+	return r
+}
+
+func doPut(r *gin.Engine, id string, enabled bool) *httptest.ResponseRecorder {
+	body := `{"enabled":` + map[bool]string{true: "true", false: "false"}[enabled] + `}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/domains/"+id+"/php-ioncube", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func baseCfg(mock agent.AgentInterface) DomainIonCubeHandlerConfig {
+	return DomainIonCubeHandlerConfig{
+		Domains:  &icDomainRepo{dom: &models.Domain{ID: "dom1", UserID: "owner1", PHPPoolID: strp("pool1")}},
+		PHPPools: &icPoolRepo{pool: &models.PHPPool{PHPVersion: "8.4"}},
+		Users:    &icUserRepo{user: &models.User{Username: strp("arizote")}},
+		Agent:    mock,
+	}
+}
+
+// TestIonCube_Toggle_HappyPath: owner enables → pool_set called with the
+// resolved username + version.
+func TestIonCube_Toggle_HappyPath(t *testing.T) {
+	mock := agent.NewMockClient().On("php.ioncube.pool_set", map[string]any{"username": "arizote", "version": "8.4", "enabled": true, "changed": true})
+	r := icRouter(baseCfg(mock), "owner1", false)
+	rec := doPut(r, "dom1", true)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "arizote", body["username"])
+	assert.Equal(t, "8.4", body["version"])
+}
+
+// TestIonCube_Toggle_ForbiddenForNonOwner: a tenant cannot toggle another's domain.
+func TestIonCube_Toggle_ForbiddenForNonOwner(t *testing.T) {
+	mock := agent.NewMockClient() // must NOT be called
+	r := icRouter(baseCfg(mock), "intruder", false)
+	rec := doPut(r, "dom1", true)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestIonCube_Toggle_AdminCanToggleAny: admin may toggle any domain.
+func TestIonCube_Toggle_AdminCanToggleAny(t *testing.T) {
+	mock := agent.NewMockClient().On("php.ioncube.pool_set", map[string]any{"ok": true})
+	r := icRouter(baseCfg(mock), "someadmin", true)
+	rec := doPut(r, "dom1", true)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestIonCube_Toggle_NoVersion409: a domain whose owner has no pool → 409.
+func TestIonCube_Toggle_NoVersion409(t *testing.T) {
+	cfg := baseCfg(agent.NewMockClient())
+	cfg.Domains = &icDomainRepo{dom: &models.Domain{ID: "dom1", UserID: "owner1"}} // no PHPPoolID
+	cfg.PHPPools = &icPoolRepo{pool: nil}
+	r := icRouter(cfg, "owner1", false)
+	rec := doPut(r, "dom1", true)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// TestIonCube_Toggle_LoaderNotInstalled409: the agent's precondition
+// (loader not installed for the version) surfaces as 409.
+func TestIonCube_Toggle_LoaderNotInstalled409(t *testing.T) {
+	mock := agent.NewMockClient().OnError("php.ioncube.pool_set", &agent.AgentError{
+		Code:    agent.CodeFailedPrecondition,
+		Message: "ionCube Loader is not installed for PHP 8.4",
+	})
+	r := icRouter(baseCfg(mock), "owner1", false)
+	rec := doPut(r, "dom1", true)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+// TestIonCube_Toggle_NotFound: unknown domain → 404.
+func TestIonCube_Toggle_NotFound(t *testing.T) {
+	r := icRouter(baseCfg(agent.NewMockClient()), "owner1", false)
+	rec := doPut(r, "nope", true)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4017,6 +4017,29 @@ paths:
       parameters: [ { in: path, name: version, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /admin/php/ioncube:
+    get:
+      tags: [Php]
+      summary: ionCube loader status (installed + enabled + supported)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/php/ioncube/versions/{version}/install:
+    post:
+      tags: [Php]
+      summary: Install the ionCube loader for a PHP version
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: version, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
+  /admin/php/ioncube/versions/{version}:
+    delete:
+      tags: [Php]
+      summary: Uninstall the ionCube loader for a PHP version
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: version, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
   /php/versions:
     get:
       tags: [Php]
@@ -4141,6 +4164,14 @@ paths:
     patch:
       tags: [Php Settings]
       summary: Php Settings domains
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
+  /domains/{id}/php-ioncube:
+    put:
+      tags: [Php Settings]
+      summary: Enable or disable the ionCube loader for a domain's pool
       security: [ { KratosSession: [] } ]
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }

--- a/panel-api/internal/api/php_ioncube_admin.go
+++ b/panel-api/internal/api/php_ioncube_admin.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ioncube"
+)
+
+// LoaderFetcher downloads + verifies an ionCube loader for a PHP version.
+// ioncube.Fetcher satisfies it; tests inject a fake.
+type LoaderFetcher interface {
+	FetchLoader(ctx context.Context, version string) ([]byte, error)
+}
+
+// RegisterIonCubeAdminRoutes mounts admin-only ionCube loader management. The
+// group already carries RequireAuth + RequireAdmin.
+//
+//	GET    /php/ioncube                         — installed + enabled + supported
+//	POST   /php/ioncube/versions/:version/install
+//	DELETE /php/ioncube/versions/:version
+//
+// panel-api owns the download (ADR-0050: the agent has no outbound HTTPS); the
+// version is validated against the pinned catalogue BEFORE any fetch or socket
+// call. Agent errors translate through translateAgentError (CodeFailedPrecondition
+// → 409 — e.g. uninstall refused while a pool is still enabled).
+func RegisterIonCubeAdminRoutes(rg *gin.RouterGroup, cli agent.AgentInterface, fetcher LoaderFetcher) {
+	php := rg.Group("/php")
+
+	php.GET("/ioncube", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), phpVersionCallTimeout)
+		defer cancel()
+		raw, err := cli.Call(ctx, "php.ioncube.status", nil)
+		if err != nil {
+			status, body := translateAgentError(err)
+			c.JSON(status, body)
+			return
+		}
+		// Merge the live agent status with the catalogue's supported set so the
+		// UI can offer "install" for versions not yet on the box.
+		var status struct {
+			InstalledVersions []string            `json:"installed_versions"`
+			Enabled           map[string][]string `json:"enabled"`
+		}
+		_ = json.Unmarshal(raw, &status)
+		if status.InstalledVersions == nil {
+			status.InstalledVersions = []string{}
+		}
+		if status.Enabled == nil {
+			status.Enabled = map[string][]string{}
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"installed_versions": status.InstalledVersions,
+			"enabled":            status.Enabled,
+			"supported_versions": ioncube.SupportedVersions(),
+			"loader_version":     ioncube.LoaderVersion,
+		})
+	})
+
+	php.POST("/ioncube/versions/:version/install", func(c *gin.Context) {
+		version := c.Param("version")
+		if !ioncube.ValidVersion(version) {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_argument", "detail": "ionCube loader not offered for this PHP version"})
+			return
+		}
+		sum, err := ioncube.SHA256For(version)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_argument", "detail": err.Error()})
+			return
+		}
+		// Fetch + verify against the catalogue (panel-api side).
+		fetchCtx, fcancel := context.WithTimeout(c.Request.Context(), ioncubeFetchTimeout)
+		defer fcancel()
+		data, err := fetcher.FetchLoader(fetchCtx, version)
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"status": "error", "error": "loader_fetch_failed", "detail": err.Error()})
+			return
+		}
+		// Hand the verified bytes to the agent, which re-verifies + installs.
+		ctx, cancel := context.WithTimeout(c.Request.Context(), adminActionTimeout)
+		defer cancel()
+		raw, err := cli.Call(ctx, "php.ioncube.install", map[string]string{
+			"version": version,
+			"sha256":  sum,
+			"so_b64":  base64.StdEncoding.EncodeToString(data),
+		})
+		if err != nil {
+			status, body := translateAgentError(err)
+			c.JSON(status, body)
+			return
+		}
+		c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
+	})
+
+	php.DELETE("/ioncube/versions/:version", func(c *gin.Context) {
+		version := c.Param("version")
+		if !ioncube.ValidVersion(version) {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_argument", "detail": "ionCube loader not offered for this PHP version"})
+			return
+		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), adminActionTimeout)
+		defer cancel()
+		raw, err := cli.Call(ctx, "php.ioncube.uninstall", map[string]string{"version": version})
+		if err != nil {
+			status, body := translateAgentError(err)
+			c.JSON(status, body)
+			return
+		}
+		c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
+	})
+}

--- a/panel-api/internal/api/php_ioncube_admin_test.go
+++ b/panel-api/internal/api/php_ioncube_admin_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+type fakeFetcher struct {
+	data []byte
+	err  error
+}
+
+func (f fakeFetcher) FetchLoader(_ context.Context, _ string) ([]byte, error) {
+	return f.data, f.err
+}
+
+func icAdminRouter(mock agent.AgentInterface, fetcher LoaderFetcher) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "admin", IsAdmin: true})
+		c.Next()
+	})
+	RegisterIonCubeAdminRoutes(v1, mock, fetcher)
+	return r
+}
+
+func TestIonCubeAdmin_Status_MergesCatalogue(t *testing.T) {
+	mock := agent.NewMockClient().On("php.ioncube.status", map[string]any{
+		"installed_versions": []any{"8.4"},
+		"enabled":            map[string]any{"arizote": []any{"8.4"}},
+	})
+	r := icAdminRouter(mock, fakeFetcher{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/php/ioncube", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Contains(t, body, "supported_versions")
+	assert.Equal(t, "15.5.0", body["loader_version"])
+	assert.Equal(t, []any{"8.4"}, body["installed_versions"])
+}
+
+func TestIonCubeAdmin_Install_FetchesAndCallsAgent(t *testing.T) {
+	mock := agent.NewMockClient().On("php.ioncube.install", map[string]any{"version": "8.4", "installed": true, "changed": true})
+	r := icAdminRouter(mock, fakeFetcher{data: []byte("\x7fELF loader")})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/php/ioncube/versions/8.4/install", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestIonCubeAdmin_Install_BadVersion_NoFetch(t *testing.T) {
+	// version 8.0 is not in the catalogue → 400 before any fetch/agent call.
+	r := icAdminRouter(agent.NewMockClient(), fakeFetcher{err: errors.New("should not be called")})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/php/ioncube/versions/8.0/install", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestIonCubeAdmin_Install_FetchFailure_502(t *testing.T) {
+	r := icAdminRouter(agent.NewMockClient(), fakeFetcher{err: errors.New("network down")})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/php/ioncube/versions/8.4/install", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestIonCubeAdmin_Uninstall_BlockedTranslates409(t *testing.T) {
+	mock := agent.NewMockClient().OnError("php.ioncube.uninstall", &agent.AgentError{
+		Code:    agent.CodeFailedPrecondition,
+		Message: "still enabled on 1 pool(s)",
+	})
+	r := icAdminRouter(mock, fakeFetcher{})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/php/ioncube/versions/8.4", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}

--- a/panel-api/internal/api/php_versions.go
+++ b/panel-api/internal/api/php_versions.go
@@ -21,6 +21,11 @@ const phpVersionCallTimeout = 10 * time.Second
 // adminActionTimeout bounds admin-only install/reload operations.
 const adminActionTimeout = 5 * time.Minute
 
+// ioncubeFetchTimeout bounds the panel-api download of the ionCube loaders
+// tarball (~29 MB) before the .so is extracted, verified, and handed to the
+// agent. Generous for a slow link; the fetch runs inside the admin action.
+const ioncubeFetchTimeout = 2 * time.Minute
+
 // reloadTimeout bounds the reload operation specifically.
 const reloadTimeout = 30 * time.Second
 

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -20,6 +20,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/config"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ioncube"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
@@ -188,7 +189,7 @@ type Deps struct {
 	// user-scoped envelope also reaches the recipient's own routed channels.
 	UserNotificationRoutes repository.UserNotificationRouteRepository
 	WebhookEndpoints       repository.WebhookEndpointRepository
-	WebPushSubs          repository.WebPushSubscriptionRepository
+	WebPushSubs            repository.WebPushSubscriptionRepository
 	// NotificationQueue is the dispatcher's publish end — the internal
 	// enqueue endpoint (RequireLocalhost) and in-process event sources
 	// write to this Queue. Nil when Redis is not configured; handlers
@@ -1123,6 +1124,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				PHPPools: deps.PHPPools,
 			})
 		}
+		if deps.Domains != nil && deps.PHPPools != nil && deps.Users != nil && deps.Agent != nil {
+			api.RegisterDomainIonCubeRoutes(v1, api.DomainIonCubeHandlerConfig{
+				Domains:  deps.Domains,
+				PHPPools: deps.PHPPools,
+				Users:    deps.Users,
+				Agent:    deps.Agent,
+			})
+		}
 		if deps.Domains != nil {
 			api.RegisterDomainHtaccessRoutes(v1, api.DomainHtaccessHandlerConfig{
 				Domains: deps.Domains,
@@ -1296,6 +1305,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			admin := v1.Group("/admin", middleware.RequireAdmin())
 			api.RegisterPHPVersionAdminRoutes(admin, deps.Agent, deps.ServerSettings)
 			api.RegisterPHPExtensionAdminRoutes(admin, deps.Agent)
+			api.RegisterIonCubeAdminRoutes(admin, deps.Agent, ioncube.Fetcher{})
 		}
 
 		// M45 root web terminal (ADR-0096). Off by default; the handler

--- a/panel-api/internal/ioncube/fetch.go
+++ b/panel-api/internal/ioncube/fetch.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"path"
 	"strings"
-	"time"
 )
 
 // maxLoaderBytes bounds a single extracted .so (loaders are ~2.5 MB; 16 MB is a
@@ -43,7 +42,11 @@ func (f Fetcher) FetchLoader(ctx context.Context, version string) ([]byte, error
 	}
 	client := f.Client
 	if client == nil {
-		client = &http.Client{Timeout: 60 * time.Second}
+		// No client-level Timeout: the request is bound to ctx (below), so the
+		// caller's deadline (ioncubeFetchTimeout, 2m) governs the whole
+		// download. A hardcoded client Timeout would silently cap that shorter
+		// and truncate a slow 29 MB download.
+		client = &http.Client{}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)


### PR DESCRIPTION
Phase 3 of ionCube Loader support (plan: `plans/gh-ioncube-loader.md`). Builds on #755 (primitive) + #757 (delivery). Wires the agent RPCs into HTTP.

## Admin (RequireAdmin)

- `GET /admin/php/ioncube` — live status (installed + enabled) merged with the catalogue's supported versions + loader version
- `POST /admin/php/ioncube/versions/{version}/install` — panel-api fetches + verifies the loader (ADR-0050: agent has no outbound HTTPS), hands bytes to `php.ioncube.install`
- `DELETE /admin/php/ioncube/versions/{version}` — `php.ioncube.uninstall` (409 while a pool is still enabled)

Version validated against the pinned catalogue **before** any fetch/socket call.

## Tenant

- `PUT /domains/{id}/php-ioncube {enabled}` — resolves the domain's pool → PHP version + owner's unix username, then `php.ioncube.pool_set`. **Ownership-scoped**: a tenant may toggle only their own domains (admin any) → 403 otherwise. The loader-installed gate is the agent precondition (`CodeFailedPrecondition` → 409), so there's one source of truth.

## Notes

- **openapi.yaml**: 4 routes documented; coverage golden unchanged.
- **Fix found by box-testing**: `ioncube.Fetcher` hardcoded a 60s client `Timeout` that silently capped the handler's 2m context and would truncate a slow 29 MB download. Now ctx-bound — the caller's deadline governs.

## Verification

- Handler unit tests (`-race`): ownership 403, admin-any, no-version 409, precondition 409, 404, admin install fetch→agent, bad-version-no-fetch, fetch-failure 502, uninstall 409-translate.
- openapi coverage green.
- **Fetcher proven against LIVE ionCube on a real-bandwidth host** (testserver): 8.4 (2532200 B) + 8.1 (2424648 B) download, extract, and match the pinned sha256.

## Not in this PR

UI (admin install button + tenant toggle), CLI + ADR amendment, arizote-case E2E (Phases 4-5).