### PR TITLE
feat(php): ionCube UI — admin install tab + per-domain tenant toggle

### DIFF
--- a/panel-api/internal/api/domain_php_ioncube.go
+++ b/panel-api/internal/api/domain_php_ioncube.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -33,6 +34,7 @@ type DomainIonCubeHandlerConfig struct {
 // single source of truth for "is the loader present for this version".
 func RegisterDomainIonCubeRoutes(g *gin.RouterGroup, cfg DomainIonCubeHandlerConfig) {
 	h := &domainIonCubeHandler{cfg: cfg}
+	g.GET("/domains/:id/php-ioncube", h.get)
 	g.PUT("/domains/:id/php-ioncube", h.put)
 }
 
@@ -40,6 +42,80 @@ type domainIonCubeHandler struct{ cfg DomainIonCubeHandlerConfig }
 
 type domainIonCubeRequest struct {
 	Enabled *bool `json:"enabled" binding:"required"`
+}
+
+// domainIonCubeState is the GET response driving the tenant toggle: the domain's
+// PHP version, whether the loader is installed for it (toggle enabled only when
+// true), and whether ionCube is currently on for this domain's pool.
+type domainIonCubeState struct {
+	Version         string `json:"version"`
+	LoaderInstalled bool   `json:"loader_installed"`
+	Enabled         bool   `json:"enabled"`
+}
+
+// get returns the current ionCube state for a domain (ownership-scoped). Reads
+// live agent status; never mutates.
+func (h *domainIonCubeHandler) get(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ctx := c.Request.Context()
+	dom, err := h.cfg.Domains.FindByID(ctx, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+			return
+		}
+		slog.ErrorContext(ctx, "ioncube get: load domain", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if !claims.IsAdmin && dom.UserID != claims.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	version := h.resolveVersion(ctx, dom)
+	state := domainIonCubeState{Version: version}
+	if version == "" {
+		c.JSON(http.StatusOK, state) // no pool yet → toggle stays disabled client-side
+		return
+	}
+	owner, err := h.cfg.Users.FindByID(ctx, dom.UserID)
+	if err != nil || owner == nil || owner.Username == nil {
+		c.JSON(http.StatusOK, state)
+		return
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(callCtx, "php.ioncube.status", nil)
+	if err != nil {
+		// Best-effort: report version-only state; the toggle stays disabled
+		// rather than the whole page erroring on a transient agent hiccup.
+		c.JSON(http.StatusOK, state)
+		return
+	}
+	var status struct {
+		InstalledVersions []string            `json:"installed_versions"`
+		Enabled           map[string][]string `json:"enabled"`
+	}
+	_ = json.Unmarshal(raw, &status)
+	for _, v := range status.InstalledVersions {
+		if v == version {
+			state.LoaderInstalled = true
+			break
+		}
+	}
+	for _, v := range status.Enabled[*owner.Username] {
+		if v == version {
+			state.Enabled = true
+			break
+		}
+	}
+	c.JSON(http.StatusOK, state)
 }
 
 func (h *domainIonCubeHandler) put(c *gin.Context) {

--- a/panel-api/internal/api/domain_php_ioncube_test.go
+++ b/panel-api/internal/api/domain_php_ioncube_test.go
@@ -142,3 +142,31 @@ func TestIonCube_Toggle_NotFound(t *testing.T) {
 	rec := doPut(r, "nope", true)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+// TestIonCube_Get_ReportsState: GET reflects the agent status (loader
+// installed for the version + this owner enabled), ownership-scoped.
+func TestIonCube_Get_ReportsState(t *testing.T) {
+	mock := agent.NewMockClient().On("php.ioncube.status", map[string]any{
+		"installed_versions": []any{"8.4"},
+		"enabled":            map[string]any{"arizote": []any{"8.4"}},
+	})
+	r := icRouter(baseCfg(mock), "owner1", false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/domains/dom1/php-ioncube", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var st map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &st))
+	assert.Equal(t, "8.4", st["version"])
+	assert.Equal(t, true, st["loader_installed"])
+	assert.Equal(t, true, st["enabled"])
+}
+
+// TestIonCube_Get_ForbiddenForNonOwner: GET is ownership-scoped too.
+func TestIonCube_Get_ForbiddenForNonOwner(t *testing.T) {
+	r := icRouter(baseCfg(agent.NewMockClient()), "intruder", false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/domains/dom1/php-ioncube", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4169,6 +4169,12 @@ paths:
       responses: { "200": { description: OK } }
 
   /domains/{id}/php-ioncube:
+    get:
+      tags: [Php Settings]
+      summary: Current ionCube state for a domain (version, loader_installed, enabled)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
     put:
       tags: [Php Settings]
       summary: Enable or disable the ionCube loader for a domain's pool

--- a/panel-ui/src/shells/admin/php/IonCubeTab.tsx
+++ b/panel-ui/src/shells/admin/php/IonCubeTab.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Popconfirm,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+  notification,
+} from "antd";
+import { DownloadOutlined, DeleteOutlined } from "@icons";
+import { apiClient } from "../../../apiClient";
+import { extractApiError } from "../../../apiErrors";
+
+// Mirrors the GET /admin/php/ioncube response (php_ioncube_admin.go).
+interface IonCubeStatus {
+  installed_versions: string[];
+  enabled: Record<string, string[]>;
+  supported_versions: string[];
+  loader_version: string;
+}
+
+interface VersionRow {
+  version: string;
+  installed: boolean;
+  enabledPools: number;
+}
+
+export const IonCubeTab = () => {
+  const [status, setStatus] = useState<IonCubeStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const { data } = await apiClient.get<IonCubeStatus>("/admin/php/ioncube");
+      setStatus(data);
+    } catch (err) {
+      notification.error({
+        message: "Failed to load ionCube status",
+        description: extractApiError(err, "Unknown error"),
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const install = async (version: string) => {
+    setBusy(version);
+    try {
+      await apiClient.post(`/admin/php/ioncube/versions/${version}/install`);
+      notification.success({ message: `ionCube installed for PHP ${version}` });
+      await load();
+    } catch (err) {
+      notification.error({
+        message: `Install failed for PHP ${version}`,
+        description: extractApiError(err, "Unknown error"),
+      });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const uninstall = async (version: string) => {
+    setBusy(version);
+    try {
+      await apiClient.delete(`/admin/php/ioncube/versions/${version}`);
+      notification.success({ message: `ionCube uninstalled for PHP ${version}` });
+      await load();
+    } catch (err) {
+      notification.error({
+        message: `Uninstall failed for PHP ${version}`,
+        description: extractApiError(err, "Unknown error"),
+      });
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: "center", padding: 40 }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  const installed = new Set(status?.installed_versions ?? []);
+  const enabledByVersion = (v: string) =>
+    Object.values(status?.enabled ?? {}).filter((vers) => vers.includes(v)).length;
+  const rows: VersionRow[] = (status?.supported_versions ?? []).map((version) => ({
+    version,
+    installed: installed.has(version),
+    enabledPools: enabledByVersion(version),
+  }));
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Alert
+        type="info"
+        showIcon
+        message="ionCube Loader"
+        description={
+          <Typography.Text type="secondary">
+            Install the ionCube Loader per PHP version so encoded applications can
+            run. Installing here only places the loader on the server — each site
+            enables it individually under its PHP settings (per-pool, not
+            server-wide). Loader {status?.loader_version ? `v${status.loader_version}` : ""}.
+          </Typography.Text>
+        }
+      />
+      <Table<VersionRow>
+        rowKey="version"
+        dataSource={rows}
+        pagination={false}
+        columns={[
+          {
+            title: "PHP Version",
+            dataIndex: "version",
+            render: (v: string) => <Typography.Text strong>{v}</Typography.Text>,
+          },
+          {
+            title: "Loader",
+            dataIndex: "installed",
+            render: (inst: boolean) =>
+              inst ? <Tag color="green">Installed</Tag> : <Tag>Not installed</Tag>,
+          },
+          {
+            title: "Sites using it",
+            dataIndex: "enabledPools",
+            render: (n: number) => (n > 0 ? <Tag color="blue">{n}</Tag> : <span>—</span>),
+          },
+          {
+            title: "Action",
+            key: "action",
+            render: (_: unknown, row: VersionRow) =>
+              row.installed ? (
+                <Popconfirm
+                  title={`Uninstall ionCube for PHP ${row.version}?`}
+                  description={
+                    row.enabledPools > 0
+                      ? `${row.enabledPools} site(s) still use it — disable them first.`
+                      : "The loader file will be removed."
+                  }
+                  okText="Uninstall"
+                  okButtonProps={{ danger: true }}
+                  onConfirm={() => uninstall(row.version)}
+                >
+                  <Button
+                    danger
+                    size="small"
+                    icon={<DeleteOutlined />}
+                    loading={busy === row.version}
+                  >
+                    Uninstall
+                  </Button>
+                </Popconfirm>
+              ) : (
+                <Button
+                  type="primary"
+                  size="small"
+                  icon={<DownloadOutlined />}
+                  loading={busy === row.version}
+                  onClick={() => install(row.version)}
+                >
+                  Install
+                </Button>
+              ),
+          },
+        ]}
+      />
+    </Space>
+  );
+};

--- a/panel-ui/src/shells/admin/php/PHPVersionsPage.tsx
+++ b/panel-ui/src/shells/admin/php/PHPVersionsPage.tsx
@@ -4,8 +4,9 @@ import { CodeOutlined } from "@icons";
 import { VersionsTab } from "./VersionsTab";
 import { PHPExtensionsTab } from "./PHPExtensionsTab";
 import { FPMPoolsTab } from "./FPMPoolsTab";
+import { IonCubeTab } from "./IonCubeTab";
 
-type TabKey = "versions" | "extensions" | "pools";
+type TabKey = "versions" | "extensions" | "pools" | "ioncube";
 
 export const PHPVersionsPage = () => {
   const [active, setActive] = useTabParam<TabKey>("versions");
@@ -23,6 +24,7 @@ export const PHPVersionsPage = () => {
           { key: "versions", tab: "PHP Versions" },
           { key: "extensions", tab: "PHP Extensions" },
           { key: "pools", tab: "FPM Pools" },
+          { key: "ioncube", tab: "ionCube" },
         ]}
         activeTabKey={active}
         onTabChange={(k) => setActive(k as TabKey)}
@@ -31,8 +33,10 @@ export const PHPVersionsPage = () => {
           <VersionsTab />
         ) : active === "extensions" ? (
           <PHPExtensionsTab />
-        ) : (
+        ) : active === "pools" ? (
           <FPMPoolsTab />
+        ) : (
+          <IonCubeTab />
         )}
       </Card>
     </div>

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   Space,
   Spin,
+  Switch,
   Typography,
   message,
 } from "antd";
@@ -45,6 +46,13 @@ type PHPSettingsFormData = {
   php_max_input_vars?: number | null;
   php_max_execution_time?: number | null;
   php_max_input_time?: number | null;
+};
+
+// Mirrors GET/PUT /domains/:id/php-ioncube (domain_php_ioncube.go).
+type IonCubeState = {
+  version: string;
+  loader_installed: boolean;
+  enabled: boolean;
 };
 
 const MEMORY_LIMIT_OPTIONS = [
@@ -114,6 +122,8 @@ export function UserPHPSettingsPage() {
   const [phpSettings, setPhpSettings] = useState<DomainPHPSettings | null>(null);
   const [availableVersions, setAvailableVersions] = useState<string[]>([]);
   const [versionSaving, setVersionSaving] = useState(false);
+  const [ioncube, setIoncube] = useState<IonCubeState | null>(null);
+  const [ioncubeSaving, setIoncubeSaving] = useState(false);
   const [cliVersion, setCliVersion] = useState<string>(""); // "" = auto
   const [cliSaving, setCliSaving] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -175,6 +185,36 @@ export function UserPHPSettingsPage() {
     }
   };
 
+  const onToggleIoncube = async (enabled: boolean) => {
+    if (!selectedDomain) return;
+    setIoncubeSaving(true);
+    try {
+      const { data } = await apiClient.put<IonCubeState>(
+        `/domains/${selectedDomain}/php-ioncube`,
+        { enabled },
+      );
+      // PUT returns pool_set's {enabled}; re-read full state for loader_installed.
+      const resp = await apiClient.get<IonCubeState>(
+        `/domains/${selectedDomain}/php-ioncube`,
+      );
+      setIoncube(resp.data);
+      message.success(
+        (data?.enabled ?? enabled)
+          ? "ionCube Loader enabled for this site"
+          : "ionCube Loader disabled for this site",
+      );
+    } catch (err) {
+      const e = err as { response?: { data?: { detail?: string; error?: string } } };
+      message.error(
+        e.response?.data?.detail ??
+          e.response?.data?.error ??
+          "Failed to change ionCube setting",
+      );
+    } finally {
+      setIoncubeSaving(false);
+    }
+  };
+
   const onChangePHPVersion = async (version: string | null) => {
     if (!selectedDomain) return;
     setVersionSaving(true);
@@ -212,6 +252,7 @@ export function UserPHPSettingsPage() {
   useEffect(() => {
     if (!selectedDomain) {
       setPhpSettings(null);
+      setIoncube(null);
       form.resetFields();
       return;
     }
@@ -223,6 +264,15 @@ export function UserPHPSettingsPage() {
           `/domains/${selectedDomain}/php-settings`,
         );
         setPhpSettings(resp.data);
+        // ionCube state is a separate read (best-effort — never block the page).
+        try {
+          const ic = await apiClient.get<IonCubeState>(
+            `/domains/${selectedDomain}/php-ioncube`,
+          );
+          setIoncube(ic.data);
+        } catch {
+          setIoncube(null);
+        }
         form.setFieldsValue({
           domain_id: selectedDomain,
           php_memory_limit: resp.data.php_memory_limit,
@@ -373,6 +423,22 @@ export function UserPHPSettingsPage() {
                           value: v,
                         })),
                       ]}
+                    />
+                  </Form.Item>
+
+                  <Form.Item
+                    label="ionCube Loader"
+                    extra={
+                      ioncube && !ioncube.loader_installed
+                        ? `ionCube is not installed for PHP ${ioncube.version ?? phpSettings.php_version ?? ""} on this server — ask an administrator to install it before enabling.`
+                        : "Required for applications shipped as ionCube-encoded PHP. Applies to this site's pool only."
+                    }
+                  >
+                    <Switch
+                      checked={!!ioncube?.enabled}
+                      loading={ioncubeSaving}
+                      disabled={ioncubeSaving || !ioncube?.loader_installed}
+                      onChange={(v) => onToggleIoncube(v)}
                     />
                   </Form.Item>
 


### PR DESCRIPTION
Phase 4 of ionCube Loader support (plan: `plans/gh-ioncube-loader.md`). Builds on #755/#757/#758. Surfaces the API in panel-ui.

## Admin — PHP Manager → new "ionCube" tab
`IonCubeTab.tsx`: table of the catalogue's supported PHP versions with Installed / Not-installed state, a count of sites using each, and Install / Uninstall (Popconfirm) actions → `/admin/php/ioncube[/versions/{v}/install|]`. Uninstall warns when sites still use it (agent also refuses → 409).

## Tenant — PHP Settings → per-domain "ionCube Loader" Switch
Next to the domain's PHP version selector. Reflects live state; **disabled with a hint** ("ask an administrator to install ionCube for PHP X") when the loader isn't installed for that version.

## Backend
`GET /domains/{id}/php-ioncube` — ownership-scoped read returning `{version, loader_installed, enabled}` to drive the toggle's initial state (mirrors the PUT's ownership + version resolution). openapi documented.

## Verification
- `tsc` clean, `vite build` OK, **vitest 166/166**.
- Backend handler tests (`-race`) incl. the new GET: state report + ownership 403.
- openapi coverage green.
- Full visual + authenticated end-to-end is folded into **Phase 5**'s arizote deploy (avoids deploying the SPA twice).

## Not in this PR
CLI, ADR amendment, and the real encoded-plugin E2E (Phase 5).