### PR TITLE
feat(php): ionCube CLI parity + ADR-0161 (server-wide decision)

### DIFF
--- a/docs/adr/0161-ioncube-loader-server-wide.md
+++ b/docs/adr/0161-ioncube-loader-server-wide.md
@@ -1,0 +1,113 @@
+# ADR-0161 — ionCube Loader: server-wide per PHP version, composed into the PHP Extensions surface
+
+**Status:** Accepted. **Amends** [ADR-0031](0031-php-extensions-management.md)
+(PHP extensions — server-wide per version, live from dpkg, fixed allowlist).
+Shipped in serial, individually-reviewed slices: delivery (#757), a first
+per-user/per-domain cut (#755/#758) that was then **reverted** in favour of this
+server-wide design (#761), CLI parity + this ADR. Blueprint at
+`plans/gh-ioncube-loader.md`; mechanics in the memory note
+`reference_ioncube_loader_mechanics`.
+
+## Context
+
+Restoring/hosting WordPress sites that ship ionCube-encoded PHP (e.g. the
+`woocommerce-rivhit-sync` plugin on arizot-e.com) failed with the ionCube
+"Loader needs to be installed" notice: jabali had no way to install or enable the
+ionCube Loader `zend_extension`. Doing it by hand is a box-wide change on a shared
+host and never survives `jabali update`.
+
+Two things make ionCube different from the ADR-0031 extension catalogue:
+
+1. **It is not a dpkg package.** apcu/redis/intl/… are `php<v>-<ext>` Debian
+   packages managed by `apt install` + `phpenmod`. The ionCube Loader is a
+   closed-source blob downloaded from ionCube. So it cannot ride the ADR-0031
+   apt/phpenmod path.
+2. **Encoded files are PHP-version-locked**, so the loader is inherently a
+   per-version concern.
+
+ADR-0031 deliberately made extensions **server-wide per version** and rejected
+per-pool, reasoning "PHP-FPM shares a single module loader per master; per-pool
+extensions aren't a thing the runtime supports." Since then jabali runs a
+**per-user FPM master** (`jabali-fpm@<user>`), which *does* make per-tenant
+`zend_extension` loading technically possible (a per-user `PHP_INI_SCAN_DIR`).
+A first cut of this feature used exactly that. It was reverted (see below).
+
+## Decision
+
+**ionCube is managed server-wide per PHP version**, exactly like the rest of the
+extension catalogue, and is **surfaced as a row in the PHP Extensions tab** —
+not a separate page, not per-domain.
+
+- **Delivery** (kept from the first cut): panel-api fetches the official loaders
+  tarball, verifies each `.so` against a **pinned per-version sha256** catalogue
+  (`panel-api/internal/ioncube`, loader v15.5.0, PHP 7.4/8.1/8.2/8.3/8.4/8.5),
+  and hands the verified bytes to the agent — the agent has no outbound HTTPS
+  (ADR-0050). The agent re-verifies and writes to `/usr/lib/php/ioncube/<ver>/`
+  (already permitted by the `jabali-fpm-app` AppArmor `/usr/lib/php/** mr` rule —
+  no profile change).
+- **Enable** = agent `php.ioncube.server_set {version, enabled}` writes
+  `/etc/php/<ver>/fpm/conf.d/00-ioncube.ini` (named `00-` so it sorts before
+  `10-opcache.ini` — ionCube fatals unless its loader is the first
+  `zend_extension`) and reloads **every** FPM master on that version
+  (`reloadVersionFPMUnits`). conf.d is loaded natively by all pools of the
+  version — no per-user scan dir.
+- **State is live** (mirrors ADR-0031): loader-installed = the `.so` exists;
+  version-enabled = the conf.d ini exists. `php.ioncube.status` returns
+  `{installed_versions, enabled_versions}`. No DB row, no reconciler, no drift.
+- **The agent's dpkg `php.ext.*` path stays pure.** ionCube is composed in at the
+  **panel-api layer**: `GET /admin/php/versions/:v/extensions` appends an
+  `ioncube` pseudo-row from `php.ioncube.status`, and
+  `POST .../extensions/ioncube/apply` routes install→fetch+install,
+  enable/disable→`server_set`, remove→uninstall. The SPA renders the composed
+  row with the same Install/Enable/Disable/Remove controls as any extension —
+  zero SPA change. The CLI (`jabali php ext {list,install,remove,enable,disable}`)
+  intercepts `ioncube` the same way for parity.
+
+## Alternatives Considered
+
+### Per-user / per-domain isolation (the reverted first cut)
+- **What**: a per-user `PHP_INI_SCAN_DIR` in `fpm-exec` + a per-domain toggle, so
+  one tenant could load ionCube without its neighbours on the same version.
+- **Why not**: the ionCube Loader is a benign, trusted decoder — not
+  tenant-supplied code — so per-tenant isolation of it buys almost nothing, while
+  the version dimension alone already solves the encoded-app case (a site sets a
+  supported PHP version; the loader is enabled for that version). cPanel/Plesk
+  install ionCube server-wide too. The per-user machinery (scan-dir in
+  `fpm-exec`, `pool_set`, tenant `/domains/:id/php-ioncube`) was extra surface for
+  marginal value, so it was removed (#761).
+
+### A real dpkg row inside the ADR-0031 `php.ext.*` handlers
+- **Why not**: it would special-case a non-apt entry inside the agent's
+  dpkg-driven `ext.list`/`ext.apply`, breaking ADR-0031's "live from dpkg"
+  invariant. Composing at the panel-api layer keeps the agent path pure while
+  still presenting ionCube as a row.
+
+## Consequences
+
+### Positive
+- Solves the arizote case: set the site's PHP version, then Install + Enable
+  ionCube for that version in PHP Manager → PHP Extensions (or `jabali php ext`).
+- No AppArmor change, no migration, no reconciler, no drift.
+- ADR-0031's dpkg mechanism is untouched; all ionCube specialness is isolated to
+  `panel-api/internal/api/php_extensions.go` + `panel-api/internal/ioncube` +
+  three agent RPCs.
+
+### Negative
+- The loader catalogue (URL + per-version sha256) is pinned in Go, so a loader
+  bump upstream requires a panel release — same cadence contract as the ADR-0031
+  extension catalogue. A mismatched sha hard-fails install rather than installing
+  an unverified blob.
+- Enabling reloads every master on the version (a few seconds of USR2 reloads on
+  a busy box), the same blast radius as any server-wide ADR-0031 extension.
+
+## Implementation
+
+- `panel-api/internal/ioncube` — pinned catalogue + `Fetcher` (download, extract,
+  verify).
+- Agent `php.ioncube.install` / `uninstall` / `server_set` / `status`
+  (`panel-agent/internal/commands/php_ioncube_{install,serverwide}.go`).
+- panel-api row composition + apply routing in `php_extensions.go`; CLI parity in
+  `panel-api/cmd/server/php_cmd.go`.
+- Box-verified on testserver under `jabali-fpm-app` ENFORCE: install real 8.4
+  loader → enable → a site on 8.4 serves ionCube v15.5 with no per-user config →
+  uninstall blocked while enabled → disable → uninstall.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -163,6 +163,7 @@ This directory contains Architecture Decision Records (ADRs) documenting signifi
 | [0158](0158-cacheable-query-param-allowlist.md) | Per-domain cacheable query-param allowlist | Accepted |
 | [0159](0159-per-user-notification-channels.md) | Per-user notification channels + routing (JAB-171) | Accepted |
 | [0160](0160-build-tag-demo-mode.md) | Build-tag-gated demo mode on main (JAB-159) | Accepted |
+| [0161](0161-ioncube-loader-server-wide.md) | ionCube Loader — server-wide per PHP version, composed into PHP Extensions | Accepted |
 <!-- 0133-0140: numbers reserved during planning, no ADR file was ever written (JAB-161). -->
 <!-- /AUTO-GENERATED -->
 

--- a/panel-api/cmd/server/php_cmd.go
+++ b/panel-api/cmd/server/php_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/phpext"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ioncube"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -171,6 +173,12 @@ func newPHPExtListCmd() *cobra.Command {
 			for _, e := range resp.Extensions {
 				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Name, boolYN(e.Installed), boolYN(e.Enabled), boolYN(e.BuiltIn))
 			}
+			// ionCube is composed in (not a dpkg extension) — mirror the HTTP
+			// list so the CLI shows the same row.
+			if ioncube.ValidVersion(version) {
+				inst, en := ioncubeVersionStateCLI(ctx, version)
+				fmt.Fprintf(w, "ioncube\t%s\t%s\t%s\n", boolYN(inst), boolYN(en), boolYN(false))
+			}
 			return w.Flush()
 		},
 	}
@@ -189,6 +197,13 @@ func newPHPExtApplyCmd(action, short string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 			defer cancel()
+			// ionCube is not a dpkg extension — it appears as a row in the
+			// extension list but its actions route to the loader RPCs (parity
+			// with the HTTP ext-apply path in php_extensions.go). panel-api
+			// fetches the loader (ADR-0050); the agent installs the verified .so.
+			if args[0] == "ioncube" {
+				return applyIonCubeCLI(ctx, version, action)
+			}
 			// Built-ins are compiled into php<v>-common (always loaded).
 			// Agent has no mods-available file to enable/disable, so the
 			// agent call would fail with a misleading "ini file doesn't
@@ -228,6 +243,79 @@ func newPHPExtApplyCmd(action, short string) *cobra.Command {
 	cmd.Flags().StringVar(&version, "version", "", "PHP version (required)")
 	_ = cmd.MarkFlagRequired("version")
 	return cmd
+}
+
+// ioncubeVersionStateCLI reads live ionCube status for the list command.
+// Best-effort: a status hiccup renders the row as not-installed/not-enabled.
+func ioncubeVersionStateCLI(ctx context.Context, version string) (installed, enabled bool) {
+	raw, err := sharedAgent.Call(ctx, "php.ioncube.status", nil)
+	if err != nil {
+		return false, false
+	}
+	var status struct {
+		InstalledVersions []string `json:"installed_versions"`
+		EnabledVersions   []string `json:"enabled_versions"`
+	}
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return false, false
+	}
+	for _, v := range status.InstalledVersions {
+		if v == version {
+			installed = true
+		}
+	}
+	for _, v := range status.EnabledVersions {
+		if v == version {
+			enabled = true
+		}
+	}
+	return installed, enabled
+}
+
+// applyIonCubeCLI routes an ext-apply action for the ionCube pseudo-extension
+// to the loader RPCs. Mirrors applyIonCube in panel-api/internal/api so the CLI
+// and HTTP paths behave identically.
+func applyIonCubeCLI(ctx context.Context, version, action string) error {
+	if !ioncube.ValidVersion(version) {
+		return fmt.Errorf("ionCube loader not offered for PHP %s (supported: %v)", version, ioncube.SupportedVersions())
+	}
+	var raw json.RawMessage
+	var err error
+	switch action {
+	case "install":
+		sum, serr := ioncube.SHA256For(version)
+		if serr != nil {
+			return serr
+		}
+		fetchCtx, fcancel := context.WithTimeout(ctx, 2*time.Minute)
+		data, ferr := ioncube.Fetcher{}.FetchLoader(fetchCtx, version)
+		fcancel()
+		if ferr != nil {
+			return fmt.Errorf("fetch ionCube loader: %w", ferr)
+		}
+		raw, err = sharedAgent.Call(ctx, "php.ioncube.install", map[string]any{
+			"version": version, "sha256": sum, "so_b64": base64.StdEncoding.EncodeToString(data),
+		})
+	case "remove":
+		raw, err = sharedAgent.Call(ctx, "php.ioncube.uninstall", map[string]any{"version": version})
+	case "enable", "disable":
+		raw, err = sharedAgent.Call(ctx, "php.ioncube.server_set", map[string]any{
+			"version": version, "enabled": action == "enable",
+		})
+	default:
+		return fmt.Errorf("unknown action %q", action)
+	}
+	if err != nil {
+		return fmt.Errorf("php.ioncube.%s: %w", action, err)
+	}
+	if jsonOutput {
+		var v any
+		_ = json.Unmarshal(raw, &v)
+		return printJSON(v)
+	}
+	cliAuditOK(ctx, "php.ioncube_"+action, "php_extension", "ioncube@"+version, nil)
+	fmt.Printf("php%s %s ioncube: ok\n", version, action)
+	return nil
 }
 
 func newPHPPoolCmd() *cobra.Command {


### PR DESCRIPTION
Follow-ups to the ionCube server-wide pivot (#761): CLI parity + the ADR.

## CLI parity
`jabali php ext {list,install,remove,enable,disable}` now handle the `ioncube` pseudo-extension identically to the HTTP ext-apply path:
- `list` composes an `ioncube` row from `php.ioncube.status`
- `install` fetches + verifies the loader panel-side (ADR-0050), then `php.ioncube.install`
- `enable`/`disable` → `php.ioncube.server_set`
- `remove` → `php.ioncube.uninstall`

No new command or flag (ionCube rides the existing `ext` subcommands) → CLI reference golden unchanged.

## ADR-0161
Records the server-wide-per-version decision, amends ADR-0031 (ionCube = the non-dpkg exception, composed at the panel-api layer; why the per-user/per-domain first cut was reverted). README index updated.

## Verification — box (testserver, agent 3bbb60e2)
`jabali php ext install ioncube --version 8.4` fetches + installs the real loader → `list` shows `ioncube yes` → `enable` writes the server-wide conf.d → `remove` **blocked while enabled** (409) → `disable` → `remove`. Clean teardown, nginx healthy. Build/vet/CLI-golden green.