### PR TITLE
fix(webmail): stop AND disable jabali-webmail when disabled, regardless of SSL wiring (GH #760)

### DIFF
--- a/panel-api/internal/reconciler/webmail_disable_test.go
+++ b/panel-api/internal/reconciler/webmail_disable_test.go
@@ -1,0 +1,64 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeWebmailAgent records service.* calls.
+type fakeWebmailAgent struct{ cmds []string }
+
+func (f *fakeWebmailAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	f.cmds = append(f.cmds, cmd)
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+func (f *fakeWebmailAgent) has(cmd string) bool {
+	for _, c := range f.cmds {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+// TestWebmailDisabled_StopsAndDisables_EvenWithoutSSLCerts is the #760
+// regression: disabling webmail must stop AND disable the jabali-webmail daemon
+// even when sslCerts is nil (an install without ACME wired). The old code
+// returned at the `sslCerts == nil` guard before ever stopping the daemon, so
+// the Node process kept running after the operator turned webmail off.
+func TestWebmailDisabled_StopsAndDisables_EvenWithoutSSLCerts(t *testing.T) {
+	ag := &fakeWebmailAgent{}
+	dr := newFakeDomainRepo()
+	r := New(dr, nil, ag, slog.Default(), Config{}) // NOTE: no WithSSLCerts → sslCerts stays nil
+	r.serverSettings = &fakeServerSettingsRepo{settings: &models.ServerSettings{WebmailEnabled: false}}
+
+	r.reconcileWebmailVhosts(context.Background())
+
+	assert.True(t, ag.has("service.stop"), "expected service.stop for jabali-webmail when disabled")
+	assert.True(t, ag.has("service.disable"), "expected service.disable for jabali-webmail when disabled")
+	assert.False(t, ag.has("service.start"), "must not start webmail while disabled")
+}
+
+// TestWebmailEnabled_StartsAndEnables: with an email+webmail-enabled domain and
+// SSL wired, the daemon is started AND enabled (survives reboot).
+func TestWebmailEnabled_StartsAndEnables(t *testing.T) {
+	ag := &fakeWebmailAgent{}
+	dr := newFakeDomainRepo()
+	dr.domains["d1"] = &models.Domain{ID: "d1", Name: "example.com", UserID: "u1", EmailEnabled: true, WebmailEnabled: true}
+	sc := newFakeSSLCertRepo()
+	r := New(dr, nil, ag, slog.Default(), Config{}).WithSSLCerts(sc)
+	r.serverSettings = &fakeServerSettingsRepo{settings: &models.ServerSettings{WebmailEnabled: true}}
+
+	r.reconcileWebmailVhosts(context.Background())
+
+	assert.True(t, ag.has("service.start"), "expected service.start when a webmail domain is active")
+	assert.True(t, ag.has("service.enable"), "expected service.enable so webmail survives reboot")
+	assert.False(t, ag.has("service.disable"), "must not disable while enabled")
+}

--- a/panel-api/internal/reconciler/webmail_reconcile.go
+++ b/panel-api/internal/reconciler/webmail_reconcile.go
@@ -38,33 +38,29 @@ const webmailAgentTimeout = 30 * time.Second
 
 // reconcileWebmailVhosts is invoked from ReconcileAll. Errors are
 // logged per-domain and don't abort the sweep; the next tick retries.
-func (r *Reconciler) reconcileWebmailVhosts(ctx context.Context) {
-	if r.sslCerts == nil {
-		// Without SSL cert paths we can't render the vhost (ssl_certificate
-		// directive is required). In an M5-less install this hook is a
-		// no-op — operators running without ACME won't have webmail
-		// either.
-		return
-	}
-	if r.domains == nil {
-		return
-	}
-
+// listWebmailDomains lists all domains for the webmail reconcile pass.
+func (r *Reconciler) listWebmailDomains(ctx context.Context) ([]models.Domain, error) {
 	domains, _, err := r.domains.List(ctx, repository.ListOptions{Limit: 10000})
-	if err != nil {
-		r.log.Error("webmail reconcile: list domains", "err", err)
-		return
-	}
+	return domains, err
+}
 
-	// GH #316: admins can disable the Bulwark webmail client server-wide. When
-	// off, tear down every webmail vhost, clear the AppSec allowlist, and stop
-	// the daemon — then skip the apply loop. Default is enabled (the column
-	// defaults to 1), so this is a no-op unless an admin turns it off.
-	if r.serverSettings != nil {
+func (r *Reconciler) reconcileWebmailVhosts(ctx context.Context) {
+	// GH #316 / #760: webmail disabled server-wide → stop AND disable the
+	// Bulwark daemon, clear the AppSec allowlist, tear down vhosts. This runs
+	// BEFORE the sslCerts/domains guards below: those guard only vhost
+	// RENDERING, but the daemon must be stopped regardless — otherwise, on an
+	// install without ACME/SSL wired (sslCerts == nil), disabling webmail left
+	// the Node process running (#760). `disable` (not just stop) so it also
+	// stays down across reboots.
+	if r.serverSettings != nil && r.agent != nil {
 		if s, sErr := r.serverSettings.Get(ctx); sErr == nil && s != nil && !s.WebmailEnabled {
-			for i := range domains {
-				if domains[i].EmailEnabled {
-					r.removeWebmailVhost(ctx, domains[i].Name)
+			if r.domains != nil {
+				if domains, err := r.listWebmailDomains(ctx); err == nil {
+					for i := range domains {
+						if domains[i].EmailEnabled {
+							r.removeWebmailVhost(ctx, domains[i].Name)
+						}
+					}
 				}
 			}
 			if _, werr := appseccfg.WriteWebmailHosts(appseccfg.WebmailHostsPath, nil); werr != nil {
@@ -75,8 +71,28 @@ func (r *Reconciler) reconcileWebmailVhosts(ctx context.Context) {
 			if _, err := r.agent.Call(stopCtx, "service.stop", map[string]any{"name": "jabali-webmail"}); err != nil {
 				r.log.Warn("webmail reconcile: service.stop jabali-webmail failed", "err", err)
 			}
+			if _, err := r.agent.Call(stopCtx, "service.disable", map[string]any{"name": "jabali-webmail"}); err != nil {
+				r.log.Warn("webmail reconcile: service.disable jabali-webmail failed", "err", err)
+			}
 			return
 		}
+	}
+
+	if r.sslCerts == nil {
+		// Without SSL cert paths we can't render the vhost (ssl_certificate
+		// directive is required). In an M5-less install this hook is a
+		// no-op — operators running without ACME won't have webmail
+		// either. (The disabled-teardown above already ran.)
+		return
+	}
+	if r.domains == nil {
+		return
+	}
+
+	domains, err := r.listWebmailDomains(ctx)
+	if err != nil {
+		r.log.Error("webmail reconcile: list domains", "err", err)
+		return
 	}
 
 	// GH #316: per-user webmail toggle AND-gates ALL of a user's domains. Build a
@@ -139,6 +155,13 @@ func (r *Reconciler) reconcileWebmailVhosts(ctx context.Context) {
 			"name": "jabali-webmail",
 		}); err != nil {
 			r.log.Error("webmail reconcile: service.start jabali-webmail failed", "err", err)
+		}
+		// Enable too (idempotent) so the daemon survives a reboot — symmetric
+		// with the disable on the off-path (#760).
+		if _, err := r.agent.Call(startCtx, "service.enable", map[string]any{
+			"name": "jabali-webmail",
+		}); err != nil {
+			r.log.Warn("webmail reconcile: service.enable jabali-webmail failed", "err", err)
 		}
 	}
 }


### PR DESCRIPTION
Part of #760 — "disabling Webmail in Settings → Email leaves the jabali-webmail Node process running."

## Root cause
`reconcileWebmailVhosts` put the "webmail disabled server-wide → tear down + stop daemon" block **after** the `sslCerts == nil` / `domains == nil` early returns. Those guards are only about vhost *rendering*, but they also short-circuited the daemon stop — so on any install without ACME/SSL wired, turning webmail off never stopped the Node process. It also only called `service.stop`, never `service.disable`, so even when it stopped it returned on reboot.

## Fix
- Hoist the disabled-teardown (remove vhosts, clear AppSec allowlist, stop daemon) **above** the SSL/domains guards → always runs when webmail is off.
- `service.disable` in addition to `service.stop` (stays down across reboots).
- Symmetric on the enabled path: `service.enable` alongside `service.start`.

## Test
`TestWebmailDisabled_StopsAndDisables_EvenWithoutSSLCerts` — the regression, fails on the old code (which returned at the `sslCerts` guard before stopping); `TestWebmailEnabled_StartsAndEnables`. Full reconciler package green under `-race`.

## Not in this PR
The other half of #760 — webmail/Node installed at all when the **mail module is not selected** at install — is a separate install.sh modular-gate issue (related to the #727 gating class). Tracked separately.