### PR TITLE
fix(files): downloading a folder streams a .tar.gz instead of 500 (GH #756)

### DIFF
--- a/panel-agent/internal/commands/files_read.go
+++ b/panel-agent/internal/commands/files_read.go
@@ -99,6 +99,17 @@ func filesReadHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}
 	defer file.Close()
 
+	// A directory opens fine O_RDONLY but io.ReadAll on it fails with a raw
+	// "is a directory" — which surfaced as an opaque HTTP 500 when a user hit
+	// "download" on a folder (GH #756). Detect it here and return a typed
+	// precondition error so the panel can fall back to archiving the folder.
+	if fi, statErr := file.Stat(); statErr == nil && fi.IsDir() {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: "path is a directory",
+		}
+	}
+
 	// Read with limit
 	limitedReader := io.LimitReader(file, p.Limit+1)
 	content, err := io.ReadAll(limitedReader)

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -544,6 +544,14 @@ func (h *filesHandler) download(c *gin.Context) {
 		UserID: userID, Username: username, Path: p, Limit: h.resolveMaxUploadBytes(c.Request.Context()),
 	})
 	if err != nil {
+		// GH #756: downloading a folder used to 500 (files.read can't read a
+		// directory). The agent now reports it as a precondition; transparently
+		// serve the folder as <name>.tar.gz — the expected "download folder" UX.
+		if strings.Contains(err.Error(), "path is a directory") {
+			c.Set("audit_target", p+" (archive)")
+			h.streamArchive(c, userID, username, []string{p}, filepath.Base(p)+".tar.gz")
+			return
+		}
 		respondAgentError(c, err)
 		return
 	}
@@ -921,8 +929,16 @@ func (h *filesHandler) archive(c *gin.Context) {
 		return
 	}
 	c.Set("audit_target", strings.Join(req.Paths, ", ")+" (archive)") // GH #658
+	h.streamArchive(c, userID, username, req.Paths, "archive.tar.gz")
+}
+
+// streamArchive asks the agent to build a tar.gz of the given scoped paths
+// into a panel-owned tmp file, streams it back with the given download name,
+// then unlinks the scratch file. Shared by the /files/archive endpoint and the
+// download handler's folder fallback (GH #756).
+func (h *filesHandler) streamArchive(c *gin.Context, userID, username string, paths []string, downloadName string) {
 	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.archive", filesArchiveAgentParams{
-		UserID: userID, Username: username, Paths: req.Paths,
+		UserID: userID, Username: username, Paths: paths,
 	})
 	if err != nil {
 		respondAgentError(c, err)
@@ -946,7 +962,7 @@ func (h *filesHandler) archive(c *gin.Context) {
 	defer f.Close()
 
 	c.Header("Content-Type", "application/gzip")
-	c.Header("Content-Disposition", `attachment; filename="archive.tar.gz"`)
+	c.Header("Content-Disposition", contentDisposition("attachment", downloadName))
 	c.Header("Content-Length", fmt.Sprintf("%d", result.Size))
 	if _, err := io.Copy(c.Writer, f); err != nil {
 		// Response already started — nothing useful to do, just log

--- a/panel-api/internal/api/files_download_folder_test.go
+++ b/panel-api/internal/api/files_download_folder_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFilesDownload_FolderFallsBackToArchive is the GH #756 regression: hitting
+// "download" on a folder used to 500 (files.read can't read a directory). The
+// agent now reports "path is a directory" and the handler transparently serves
+// the folder as <name>.tar.gz via the archive path.
+func TestFilesDownload_FolderFallsBackToArchive(t *testing.T) {
+	// A real scratch tar.gz on disk for streamArchive to open + stream.
+	scratch := filepath.Join(t.TempDir(), "arc.tar.gz")
+	if err := os.WriteFile(scratch, []byte("FAKE-TARGZ-BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	agent := &mockAgent{callFn: func(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+		switch cmd {
+		case "files.read":
+			// Mirror the agent's typed directory error.
+			return nil, errors.New("agent: failed_precondition: path is a directory")
+		case "files.archive":
+			b, _ := json.Marshal(filesArchiveAgentResult{ArchivePath: scratch, Size: 16})
+			return b, nil
+		default:
+			return nil, errors.New("unexpected command " + cmd)
+		}
+	}}
+	r := setupFilesRouter(t, "user1", agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/download?path=/home/alice/mydir", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200 (folder should fall back to archive, not 500)", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/gzip" {
+		t.Errorf("Content-Type: got %q want application/gzip", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, `filename="mydir.tar.gz"`) {
+		t.Errorf("Content-Disposition: got %q want mydir.tar.gz", cd)
+	}
+	if w.Body.String() != "FAKE-TARGZ-BYTES" {
+		t.Errorf("body: got %q", w.Body.String())
+	}
+	// scratch file must be unlinked after streaming.
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Errorf("scratch archive not cleaned up")
+	}
+}
+
+// TestFilesDownload_RealFileStillWorks: a plain file download is unaffected.
+func TestFilesDownload_RealFileStillWorks(t *testing.T) {
+	agent := agentReply(filesReadAgentResult{Path: "/home/alice/notes.txt", Content: "hi", Size: 2})
+	r := setupFilesRouter(t, "user1", agent)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/files/download?path=/home/alice/notes.txt", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || w.Body.String() != "hi" {
+		t.Fatalf("plain file download broke: code=%d body=%q", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
Fixes #756 — "Error trying to download folder or any file, 500 error."

## Root cause
The download handler calls the agent's `files.read`, which opens the path `O_RDONLY` (a **directory** opens fine) then `io.ReadAll`s it — yielding a raw `read <dir>: is a directory` that surfaced as `CodeInternal` → **HTTP 500**. Plain files were unaffected; the report's "any file" was folders. Reproduced on testserver via the agent socket: `files.read` on a dir → `internal: "read adir: is a directory"`.

## Fix
- **Agent `files.read`**: stat the opened fd; if it's a directory, return a typed `CodeFailedPrecondition "path is a directory"` instead of the opaque internal error.
- **Panel download handler**: on that condition, transparently serve the folder as `<name>.tar.gz` via the existing archive path — the expected "download folder" UX. Extracted the archive tmp-file streaming into a shared `streamArchive` helper (used by `/files/archive` and this fallback).

## Verification
- testserver: `files.read` on a directory now returns `failed_precondition "path is a directory"` (was `internal` → 500); a plain file still reads fine.
- Unit: `TestFilesDownload_FolderFallsBackToArchive` (200 + `application/gzip` + `<name>.tar.gz` + scratch file unlinked) and `TestFilesDownload_RealFileStillWorks`.