### PR TITLE
fix(notifications): tolerate + self-heal a missing consumer group (NOGROUP)

### DIFF
--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,10 +21,10 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // AdminServerStatusHandlerConfig holds dependencies.
@@ -52,7 +53,9 @@ func RegisterAdminServerStatusRoutes(g *gin.RouterGroup, cfg AdminServerStatusHa
 	grp.GET("", h.get)
 }
 
-type adminServerStatusHandler struct{ cfg AdminServerStatusHandlerConfig }
+type adminServerStatusHandler struct {
+	cfg AdminServerStatusHandlerConfig
+}
 
 const (
 	subCallTimeout   = 5 * time.Second
@@ -90,8 +93,8 @@ type QueuesSlice struct {
 // drives the UI icon; detail is human-readable. Step 4 will add link
 // fields ("link": "/jabali-admin/updates") when applicable.
 type ServerStatusAlert struct {
-	Level  string `json:"level"`  // "warning" | "critical"
-	Kind   string `json:"kind"`   // "disk" | "service" | "load" | ...
+	Level  string `json:"level"` // "warning" | "critical"
+	Kind   string `json:"kind"`  // "disk" | "service" | "load" | ...
 	Detail string `json:"detail"`
 }
 
@@ -164,7 +167,12 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 			qLen := pipe.XLen(subCtx, notifications.StreamQueue)
 			dlqLen := pipe.XLen(subCtx, notifications.StreamDLQ)
 			pending := pipe.XPending(subCtx, notifications.StreamQueue, notifications.ConsumerGroup)
-			if _, err := pipe.Exec(subCtx); err != nil && !errors.Is(err, redis.Nil) {
+			// NOGROUP (missing consumer group / stream) is not a real error to
+			// surface: it just means the notifications queue is uninitialized —
+			// a fresh box, or a Redis wipe that Publish/Read self-heal. XLen
+			// tolerates the missing key (returns 0); only XPending errors. Treat
+			// it like redis.Nil and report zeros instead of a scary status banner.
+			if _, err := pipe.Exec(subCtx); err != nil && !errors.Is(err, redis.Nil) && !strings.Contains(err.Error(), "NOGROUP") {
 				mu.Lock()
 				errMap["queues"] = err.Error()
 				mu.Unlock()
@@ -397,7 +405,6 @@ func unitShouldBeRunning(unitFileState string) bool {
 	}
 	return false
 }
-
 
 // moduleGatedUnits maps an optional-module systemd unit to the ServerSettings
 // flag that must be ON for it to appear in the Services card (JAB request: hide

--- a/panel-api/internal/api/server_status_test.go
+++ b/panel-api/internal/api/server_status_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
@@ -37,14 +39,14 @@ func TestServerStatus_RBAC(t *testing.T) {
 func TestServerStatus_HappyPath(t *testing.T) {
 	mock := agent.NewMockClient().
 		On("system.info", map[string]any{
-			"hostname":      "test.local",
-			"os":            "Debian 13",
-			"kernel":        "6.12",
-			"cpu_count":     4,
-			"load_avg":      []float64{0.1, 0.1, 0.1},
-			"partitions":    []map[string]any{},
-			"mem_total_kb":  1000,
-			"mem_used_kb":   100,
+			"hostname":     "test.local",
+			"os":           "Debian 13",
+			"kernel":       "6.12",
+			"cpu_count":    4,
+			"load_avg":     []float64{0.1, 0.1, 0.1},
+			"partitions":   []map[string]any{},
+			"mem_total_kb": 1000,
+			"mem_used_kb":  100,
 		}).
 		On("system.cpu_usage", map[string]any{"usage_percent": 12.5, "warming_up": false}).
 		On("system.network", map[string]any{"interfaces": []any{}}).
@@ -163,4 +165,46 @@ func TestServerStatus_TimeoutDoesNotKillEnvelope(t *testing.T) {
 	assert.True(t, gotProcAlert, "expected agent-warning alert for failed sub-call")
 
 	_ = errors.Is // keep import
+}
+
+// TestServerStatus_QueuesTolerateNOGROUP: when the notifications consumer group
+// doesn't exist yet (fresh box / Redis wipe), the queues probe must report
+// zeros rather than surfacing a raw NOGROUP error as a status banner.
+func TestServerStatus_QueuesTolerateNOGROUP(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	// Deliberately do NOT create the stream/consumer group → XPending NOGROUPs.
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(injectAdminClaims(true))
+	api.RegisterAdminServerStatusRoutes(v1, api.AdminServerStatusHandlerConfig{
+		Agent: agent.NewMockClient(),
+		Redis: rdb,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var env struct {
+		Queues *struct {
+			NotificationsQueue   int64 `json:"notifications_queue"`
+			NotificationsPending int64 `json:"notifications_pending"`
+		} `json:"queues"`
+		Errors map[string]string `json:"errors"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, bad := env.Errors["queues"]; bad {
+		t.Errorf("queues probe surfaced a NOGROUP error banner: %q", env.Errors["queues"])
+	}
+	if env.Queues == nil {
+		t.Fatal("queues slice missing — should report zeros on an uninitialized group")
+	}
+	assert.Equal(t, int64(0), env.Queues.NotificationsPending)
 }

--- a/panel-api/internal/notifications/nogroup_selfheal_test.go
+++ b/panel-api/internal/notifications/nogroup_selfheal_test.go
@@ -1,0 +1,63 @@
+package notifications
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPublish_SelfHealsMissingGroup is the notifications-NOGROUP regression:
+// after Redis loses the stream/group (restart without persistence, flush,
+// maxmemory eviction), a Publish must recreate the group so the message is
+// consumable — instead of the dispatcher's XReadGroup NOGROUP-ing forever.
+func TestPublish_SelfHealsMissingGroup(t *testing.T) {
+	rdb, mr := newRedis(t)
+	q := NewQueue(rdb)
+	ctx := context.Background()
+
+	require.NoError(t, q.EnsureGroup(ctx))
+	// Simulate a Redis wipe: drop the whole stream key (takes the group with it).
+	mr.Del(StreamQueue)
+
+	// Publish must self-heal the group before appending.
+	id, err := q.Publish(ctx, Envelope{EventKind: "test.event"})
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+
+	// The dispatcher can now read the just-published message via the group.
+	streams, err := q.Read(ctx, "consumer-1", 10, 50*time.Millisecond)
+	require.NoError(t, err)
+	var count int
+	for _, s := range streams {
+		count += len(s.Messages)
+	}
+	require.Equal(t, 1, count, "message published after a wipe must be consumable")
+}
+
+// TestRead_RecoversFromNOGROUP: if the group vanishes while the consumer loops,
+// Read recreates it and returns "no work" instead of erroring.
+func TestRead_RecoversFromNOGROUP(t *testing.T) {
+	rdb, mr := newRedis(t)
+	q := NewQueue(rdb)
+	ctx := context.Background()
+
+	require.NoError(t, q.EnsureGroup(ctx))
+	mr.Del(StreamQueue) // group gone
+
+	streams, err := q.Read(ctx, "consumer-1", 10, 10*time.Millisecond)
+	require.NoError(t, err, "NOGROUP must be recovered, not surfaced")
+	require.Empty(t, streams)
+
+	// Group is back: a subsequent publish + read works.
+	_, err = q.Publish(ctx, Envelope{EventKind: "test.event"})
+	require.NoError(t, err)
+	streams, err = q.Read(ctx, "consumer-1", 10, 50*time.Millisecond)
+	require.NoError(t, err)
+	var count int
+	for _, s := range streams {
+		count += len(s.Messages)
+	}
+	require.Equal(t, 1, count)
+}

--- a/panel-api/internal/notifications/redis.go
+++ b/panel-api/internal/notifications/redis.go
@@ -12,15 +12,15 @@ import (
 // Stream + consumer-group names. Public so callers (tests, the producer
 // path in the API layer) can target the same keys without mis-typing.
 const (
-	StreamQueue    = "jabali:notifications:queue"
-	StreamDLQ      = "jabali:notifications:dlq"
+	StreamQueue = "jabali:notifications:queue"
+	StreamDLQ   = "jabali:notifications:dlq"
 	// Stream length caps (approximate, ~ trimming): a stuck channel or a
 	// producer flood can otherwise grow these unbounded (a real install hit
 	// 26549 DLQ entries). Approximate trimming is O(1)-ish on XADD.
-	maxQueueLen int64 = 20000
-	maxDLQLen   int64 = 5000
-	ConsumerGroup  = "dispatcher"
-	defaultRetries = 5
+	maxQueueLen    int64 = 20000
+	maxDLQLen      int64 = 5000
+	ConsumerGroup        = "dispatcher"
+	defaultRetries       = 5
 )
 
 // Queue wraps the Redis client with typed operations the dispatcher
@@ -57,6 +57,15 @@ func (q *Queue) EnsureGroup(ctx context.Context) error {
 // Publish enqueues one envelope. Returns the Redis-assigned ID so
 // producers can log + correlate with history rows.
 func (q *Queue) Publish(ctx context.Context, env Envelope) (string, error) {
+	// Self-heal the consumer group before adding. If Redis lost its data
+	// (restart without persistence, flush, or maxmemory eviction), the group
+	// vanishes; a bare XAdd recreates only the stream key, leaving the
+	// dispatcher's XReadGroup to NOGROUP indefinitely and the server-status
+	// probe to show a scary banner. EnsureGroup is idempotent (BUSYGROUP
+	// swallowed) and creates the group at the tail BEFORE this message is
+	// appended, so the message stays consumable. Best-effort: a genuine Redis
+	// outage surfaces on the XAdd below.
+	_ = q.EnsureGroup(ctx)
 	id, err := q.rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: StreamQueue,
 		MaxLen: maxQueueLen,
@@ -81,6 +90,13 @@ func (q *Queue) Read(ctx context.Context, consumer string, batch int, block time
 		Block:    block,
 	}).Result()
 	if errors.Is(err, redis.Nil) {
+		return nil, nil
+	}
+	// The group/stream was lost out from under us (Redis wipe). Recreate it and
+	// treat this tick as "no work"; the next Read consumes normally. Without
+	// this the consumer loop spin-errors on NOGROUP until a panel restart.
+	if err != nil && strings.Contains(err.Error(), "NOGROUP") {
+		_ = q.EnsureGroup(ctx)
 		return nil, nil
 	}
 	return res, err


### PR DESCRIPTION
Server Status was showing a scary banner on a live box:
> `agent sub-call 'queues': NOGROUP No such key 'jabali:notifications:queue' or consumer group 'dispatcher'`

## Cause
The `dispatcher` consumer group is created only at dispatcher startup (`EnsureGroup` → `XGROUP CREATE MKSTREAM`). If Redis loses its data mid-run — restart without persistence, flush, or **maxmemory eviction** (plausible on a no-swap box under memory pressure) — the group vanishes and nothing recreates it. The status probe's `XPENDING` then NOGROUPs (`XLEN` tolerates a missing key; `XPENDING` doesn't), and the dispatcher's `XReadGroup` spin-errors until a panel restart. Diagnosed from the deployed code + the `server_status.go` queues probe.

## Fix (three spots)
- **server_status queues probe**: treat NOGROUP like `redis.Nil` — report zeros (uninitialized) instead of an error banner.
- **`Queue.Publish`**: `EnsureGroup` before `XADD`, so a publish after a wipe recreates the group at the tail and the message stays consumable (idempotent — BUSYGROUP swallowed).
- **`Queue.Read`**: on NOGROUP, `EnsureGroup` + treat the tick as "no work" so the consumer loop recovers without a restart.

## Tests (miniredis)
`TestPublish_SelfHealsMissingGroup` + `TestRead_RecoversFromNOGROUP` (drop the stream key, then publish/read succeeds); `TestServerStatus_QueuesTolerateNOGROUP` (envelope reports zeros, no `queues` error, when the group is absent). `-race` green.

## Note
Separately worth checking newzaps' Redis memory config (no swap + ~81% RAM) — a maxmemory eviction policy that can evict the stream key would make this recur; the self-heal now recovers it either way.