### PR TITLE
fix(php): ionCube enable covers CLI SAPI (JAB-175); pool create rejects instead of orphaning (JAB-174)

### DIFF
--- a/panel-agent/internal/commands/php_ioncube_serverwide.go
+++ b/panel-agent/internal/commands/php_ioncube_serverwide.go
@@ -47,6 +47,21 @@ func ioncubeConfdIniPath(version string) string {
 	return filepath.Join(ioncubePHPEtcRoot(), version, "fpm", "conf.d", "00-ioncube.ini")
 }
 
+// ioncubeCliConfdIniPath is the CLI SAPI drop-in. JAB-175: enabling only the FPM
+// conf.d left wp-cli (CLI SAPI) without the loader, so activating / running an
+// ionCube-encoded plugin via wp-cli failed even though the site (FPM) worked.
+// Debian's phpenmod enables an extension for both SAPIs; ionCube must match.
+func ioncubeCliConfdIniPath(version string) string {
+	return filepath.Join(ioncubePHPEtcRoot(), version, "cli", "conf.d", "00-ioncube.ini")
+}
+
+// ioncubeConfdIniPaths returns every SAPI conf.d drop-in for a version (FPM +
+// CLI). The FPM one stays the canonical "enabled" marker (status + guards key
+// on it), but both are written/removed together.
+func ioncubeConfdIniPaths(version string) []string {
+	return []string{ioncubeConfdIniPath(version), ioncubeCliConfdIniPath(version)}
+}
+
 // ioncubeLoaderSoPath is where php.ioncube.install writes the loader .so.
 func ioncubeLoaderSoPath(version string) string {
 	return filepath.Join(ioncubeLoaderLibRoot(), version, "ioncube_loader_lin_"+version+".so")
@@ -83,7 +98,6 @@ func phpIoncubeServerSetHandler(ctx context.Context, params json.RawMessage) (an
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid PHP version %q (want X.Y)", p.Version)}
 	}
 
-	iniPath := ioncubeConfdIniPath(p.Version)
 	changed := false
 
 	if p.Enabled {
@@ -95,21 +109,26 @@ func phpIoncubeServerSetHandler(ctx context.Context, params json.RawMessage) (an
 			}
 		}
 		want := "zend_extension=" + soPath + "\n"
-		if cur, err := os.ReadFile(iniPath); err != nil || string(cur) != want {
-			if err := os.MkdirAll(filepath.Dir(iniPath), 0o755); err != nil {
-				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir conf.d: %v", err)}
+		// Enable for every SAPI (FPM + CLI) so wp-cli / cron load it too (JAB-175).
+		for _, iniPath := range ioncubeConfdIniPaths(p.Version) {
+			if cur, err := os.ReadFile(iniPath); err != nil || string(cur) != want {
+				if err := os.MkdirAll(filepath.Dir(iniPath), 0o755); err != nil {
+					return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir conf.d: %v", err)}
+				}
+				if err := writeFileAtomic(iniPath, []byte(want), 0o644); err != nil {
+					return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write ini: %v", err)}
+				}
+				changed = true
 			}
-			if err := writeFileAtomic(iniPath, []byte(want), 0o644); err != nil {
-				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write ini: %v", err)}
-			}
-			changed = true
 		}
 	} else {
-		if _, err := os.Stat(iniPath); err == nil {
-			if err := os.Remove(iniPath); err != nil {
-				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove ini: %v", err)}
+		for _, iniPath := range ioncubeConfdIniPaths(p.Version) {
+			if _, err := os.Stat(iniPath); err == nil {
+				if err := os.Remove(iniPath); err != nil {
+					return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove ini: %v", err)}
+				}
+				changed = true
 			}
-			changed = true
 		}
 	}
 

--- a/panel-agent/internal/commands/php_ioncube_serverwide_test.go
+++ b/panel-agent/internal/commands/php_ioncube_serverwide_test.go
@@ -74,9 +74,14 @@ func TestIoncubeServerSet_EnableThenDisable(t *testing.T) {
 	if !resp.Changed || !resp.Enabled {
 		t.Errorf("enable: changed=%v enabled=%v want true/true", resp.Changed, resp.Enabled)
 	}
-	body, err := os.ReadFile(ioncubeConfdIniPath("8.4"))
-	if err != nil || string(body) != "zend_extension="+ioncubeLoaderSoPath("8.4")+"\n" {
-		t.Fatalf("conf.d ini wrong: %q err=%v", string(body), err)
+	// JAB-175: enable must drop the loader into BOTH the FPM and CLI conf.d,
+	// so wp-cli (CLI SAPI) loads it too.
+	want := "zend_extension=" + ioncubeLoaderSoPath("8.4") + "\n"
+	for _, p := range []string{ioncubeConfdIniPath("8.4"), ioncubeCliConfdIniPath("8.4")} {
+		body, err := os.ReadFile(p)
+		if err != nil || string(body) != want {
+			t.Fatalf("conf.d ini %s wrong: %q err=%v", p, string(body), err)
+		}
 	}
 
 	if resp, _ := callServerSet(t, "8.4", true); resp.Changed {
@@ -87,8 +92,10 @@ func TestIoncubeServerSet_EnableThenDisable(t *testing.T) {
 	if ae != nil || !resp.Changed || resp.Enabled {
 		t.Fatalf("disable: resp=%+v ae=%v", resp, ae)
 	}
-	if _, err := os.Stat(ioncubeConfdIniPath("8.4")); !os.IsNotExist(err) {
-		t.Errorf("conf.d ini still present after disable")
+	for _, p := range []string{ioncubeConfdIniPath("8.4"), ioncubeCliConfdIniPath("8.4")} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("conf.d ini %s still present after disable", p)
+		}
 	}
 
 	if resp, _ := callServerSet(t, "8.4", false); resp.Changed {

--- a/panel-api/cmd/server/php_pool_parity_cmd.go
+++ b/panel-api/cmd/server/php_pool_parity_cmd.go
@@ -117,8 +117,18 @@ func newPHPPoolCreateCmd() *cobra.Command {
 				return err
 			}
 			repo := repository.NewPHPPoolRepository(sharedDB)
-			if existing, _ := repo.FindByUserAndVersion(ctx, u.ID, version); existing != nil {
-				return fmt.Errorf("pool already exists for %s php %s (id=%s)", user, version, existing.ID)
+			// JAB-174: a user already having a pool means `create` would leave a
+			// duplicate + orphan (the old row stays `active` with no on-disk
+			// config, and `pool get` returns it). Switching a user's PHP version
+			// is `pool set` (updates in place + re-applies); per-domain versions
+			// are `domain php-version set`. So refuse to create a second pool and
+			// point at the right command instead of silently orphaning one.
+			if existing, _ := repo.FindByUserID(ctx, u.ID); existing != nil {
+				if existing.PHPVersion == version {
+					return fmt.Errorf("pool already exists for %s php %s (id=%s)", user, version, existing.ID)
+				}
+				return fmt.Errorf("user %s already has a PHP pool on php %s (id=%s); to switch it use `jabali php pool set --user %s --version %s` (updates in place — no duplicate/orphan), or `jabali domain php-version set <domain> %s` for a per-domain version",
+					user, existing.PHPVersion, existing.ID, user, version, version)
 			}
 			pool := &models.PHPPool{
 				ID: ulid.Make().String(), UserID: u.ID, PHPVersion: version,


### PR DESCRIPTION
Two follow-ups from the arizot-e.com ionCube restore (#757/#761/#762, ADR-0161).

## JAB-175 — ionCube enable only covered FPM, not CLI SAPI
`php.ioncube.server_set` wrote only `/etc/php/<v>/fpm/conf.d/00-ioncube.ini`, so **wp-cli** (CLI SAPI) had no loader — activating/running an ionCube-encoded plugin via wp-cli (or cron) failed even though the site (FPM) worked and the UI said "Enabled". Debian's `phpenmod` enables an extension for both SAPIs; ionCube now matches: enable/disable/status write/remove the drop-in in **both** `fpm/conf.d` and `cli/conf.d`.

**Box-verified**: after `enable ioncube 8.4`, `php8.4 -v` (CLI) reports `ionCube PHP Loader v15.5.0`, and both conf.d files appear/disappear together.

## JAB-174 — `pool create` duplicated + orphaned instead of switching
`jabali php pool create` only rejected a *same-version* duplicate, so creating a different version for a user who already had a pool silently made a **second** `php_pools` row and orphaned the old one (`get` returned the stale row). The version switch is `jabali php pool set` (in-place update + re-apply) — which already exists. `pool create` now refuses when the user already has a pool and points at `pool set` (or `domain php-version set` for per-domain). The per-domain path creates per-version pools via the repo directly and is unaffected.

**Box-verified**: `pool set 8.4` then `pool create --php-version 8.1` → clear rejection, no orphan.

## Tests
Agent test asserts enable writes both SAPI conf.d files + disable removes both; `-race` green. pool-create rejection box-verified on testserver.