### PR TITLE
fix(ssl): Let's Encrypt option greyed out even when Admin Email is set (GH #738)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.test.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.test.tsx
@@ -1,0 +1,35 @@
+// DomainSSLSection.test.tsx — GH #738 regression: the admin-email lookup that
+// gates the "Let's Encrypt" option must hit GET /admin/settings (flat
+// admin_email), not the non-existent /system/settings (which 404'd → adminEmail
+// always undefined → LE permanently greyed even when an admin email was set).
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, expect, it, vi } from "vitest";
+
+import { DomainSSLSection } from "./DomainSSLSection";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  mocked.get.mockImplementation((url: string) => {
+    if (url === "/admin/settings") return Promise.resolve({ data: { admin_email: "admin@example.com" } });
+    if (url.endsWith("/ssl")) return Promise.resolve({ data: { status: "none" } });
+    return Promise.resolve({ data: { ssl_mode: "none" } }); // /domains/:id
+  });
+});
+
+it("reads admin_email from /admin/settings (not the 404 /system/settings) — GH #738", async () => {
+  render(
+    <DomainSSLSection domainId="dom1" domainName="example.com" sslEnabled={false} onToggled={() => {}} />,
+  );
+  await waitFor(() => {
+    expect(mocked.get).toHaveBeenCalledWith("/admin/settings");
+  });
+  const urls = mocked.get.mock.calls.map((c) => c[0] as string);
+  expect(urls).not.toContain("/system/settings");
+});

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -126,9 +126,14 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
 
   useEffect(() => {
     fetchCert();
+    // GH #738: admin_email lives at GET /admin/settings as a FLAT field. The
+    // old /system/settings path 404'd (no such route) and the .settings.*
+    // nesting was wrong too, so adminEmail was ALWAYS undefined — which left
+    // the "Let's Encrypt" option greyed out even when an admin email was set
+    // (the exact symptom in #738). Read the real endpoint + flat field.
     apiClient
-      .get<{ settings: ServerSettings }>("/system/settings")
-      .then((res) => setAdminEmail(res.data?.settings?.admin_email))
+      .get<ServerSettings>("/admin/settings")
+      .then((res) => setAdminEmail(res.data?.admin_email))
       .catch(() => undefined);
     apiClient
       .get<{ ssl_mode?: string; shared_certificate_id?: string }>(`/domains/${domainId}`)


### PR DESCRIPTION
Closes the last open piece of #738: the reporter set Admin Email, rebooted, updated — and the **"Let's Encrypt"** TLS mode stayed **greyed out**, so a domain switched to "None (HTTP only)" (after revoking) could never go back to LE in the UI.

## Root cause
`DomainSSLSection` fetched the admin email from `GET /system/settings` and read `res.data.settings.admin_email`. **That route doesn't exist** (404 → swallowed by `.catch`), and the shape is wrong — `admin_email` is a **flat** field on `GET /admin/settings`, not nested under `settings`. So `adminEmail` was *always* `undefined`, and the option's gate `disabled: !adminEmail && sslMode !== "le"` stayed on permanently regardless of the real setting.

## Fix
Read `admin_email` from `GET /admin/settings` (flat), matching every other admin-settings consumer (`DatabasesCard`, `DNSPermissionsCard`).

## Test
`DomainSSLSection.test.tsx` — asserts the component calls `/admin/settings` and never `/system/settings` (fails on the old code). tsc clean; full vitest suite green (167 tests).

## The rest of #738 is already on stable
The certbot lineage clobber + half-state cleanup (`clearStaleLineageDir`, #745/#747) and the `jabali ssl enable` → reconciler `Issue()` path already handle the missing-renewal-conf / `CertStorageError` case. This PR is the remaining UI greyout.