### PR TITLE
feat(backups): schedule System-only and Full-Server backups from the admin UI (GH #502)

### DIFF
--- a/panel-ui/src/shells/admin/backups/SchedulesTab.scope.test.tsx
+++ b/panel-ui/src/shells/admin/backups/SchedulesTab.scope.test.tsx
@@ -1,0 +1,120 @@
+// SchedulesTab.scope.test.tsx — regression for GH #502.
+//
+// The reporter could create scheduled backups for "all users + system"
+// only: the schedule drawer hard-coded kind=account_backup and forced a
+// user pick, so there was no way to schedule a System/Panel-only or an
+// explicit Full-Server backup — even though the backend + scheduler
+// already support both.
+//
+// These tests lock the drawer's Type -> wire mapping:
+//   System      -> POST {kind:"system_backup"}          (no user fan-out)
+//   Full Server -> POST {kind:"account_backup", user_ids:[],
+//                        include_system_backup:true}     (all accounts + system)
+// and that picking "System" hides the account-only Users field.
+// Only apiClient is mocked; AntD Form/Drawer run for real.
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+import { SchedulesTab } from "./SchedulesTab";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+// SchedulesTab loads schedules + destinations + users on mount.
+function mockLists() {
+  mocked.get.mockImplementation(async (url: string) => {
+    if (url.startsWith("/admin/backup-schedules")) {
+      return { data: { data: [] } };
+    }
+    if (url.includes("/backup-destinations")) {
+      return {
+        data: { data: [{ id: "d1", name: "off-site", kind: "sftp", enabled: true }] },
+      };
+    }
+    if (url.startsWith("/users")) {
+      return {
+        data: {
+          data: [{ id: "u1", username: "alice", email: "alice@example.com", is_admin: false }],
+        },
+      };
+    }
+    throw new Error(`unexpected GET ${url}`);
+  });
+}
+
+// openDrawerAndPickDest opens "New schedule" and selects the one
+// destination (required for save), returning once the drawer is up.
+async function openDrawer() {
+  render(<SchedulesTab />);
+  // "New schedule" is disabled until at least one destination loads.
+  const btn = await screen.findByRole("button", { name: /new schedule/i });
+  await waitFor(() => expect(btn).not.toBeDisabled());
+  fireEvent.click(btn);
+  // The drawer's Type radios confirm it opened (avoid matching the
+  // table's "Type" column header, which shares the text).
+  await screen.findByRole("radio", { name: "Full Server" });
+}
+
+async function pickDestination() {
+  // The Destinations Select is a multi-select; open it and click the option.
+  const dest = document.querySelector<HTMLInputElement>("#destination_ids");
+  expect(dest).toBeTruthy();
+  fireEvent.mouseDown(dest as HTMLElement);
+  fireEvent.click(await screen.findByText(/off-site \(sftp\)/i));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLists();
+  mocked.post.mockResolvedValue({ data: {} });
+});
+
+describe("SchedulesTab scope (GH #502)", () => {
+  it("System scope hides the Users field and posts kind=system_backup", async () => {
+    await openDrawer();
+
+    // Account is the default: Users field is present.
+    expect(screen.getByLabelText("Users")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("radio", { name: "System" }));
+
+    // Users field is gone in System scope.
+    await waitFor(() => expect(screen.queryByLabelText("Users")).toBeNull());
+
+    await pickDestination();
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => expect(mocked.post).toHaveBeenCalled());
+    const [url, body] = mocked.post.mock.calls[0];
+    expect(url).toBe("/admin/backup-schedules");
+    expect(body.kind).toBe("system_backup");
+  });
+
+  it("Full Server scope posts account_backup + all users + include_system_backup", async () => {
+    await openDrawer();
+    fireEvent.click(screen.getByRole("radio", { name: "Full Server" }));
+
+    // No account-only Users picker in Full Server scope.
+    await waitFor(() => expect(screen.queryByLabelText("Users")).toBeNull());
+
+    await pickDestination();
+    fireEvent.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => expect(mocked.post).toHaveBeenCalled());
+    const [, body] = mocked.post.mock.calls[0];
+    expect(body.kind).toBe("account_backup");
+    expect(body.user_ids).toEqual([]); // empty = all non-admin users
+    expect(body.include_system_backup).toBe(true);
+  });
+});

--- a/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
+++ b/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   InputNumber,
   Modal,
+  Radio,
   Segmented,
   Select,
   Space,
@@ -73,6 +74,25 @@ interface User {
 const ALL_USERS = "__all__";
 
 type Freq = "daily" | "weekly" | "monthly";
+
+// Scope is the schedule's backup TYPE, mirroring the on-demand
+// "Create backup" drawer (GH #502). It maps onto the wire fields the
+// backend already understands (kind + user_ids + include_system_backup):
+//   account_backup — per-account fan-out ("All users" or selected accounts),
+//                     optionally + a system backup via the include switch.
+//   system_backup  — panel/system only, no account fan-out.
+//   full_server    — every account PLUS the system, in one schedule
+//                    (kind=account_backup, all users, include_system=true).
+type Scope = "account_backup" | "system_backup" | "full_server";
+
+// scopeOf derives the drawer's Scope from an existing schedule row so
+// editing reopens on the right type.
+const scopeOf = (s: BackupSchedule): Scope => {
+  if (s.kind === "system_backup") return "system_backup";
+  const hasSelected = (s.user_ids ?? []).length > 0;
+  if (!hasSelected && s.include_system_backup) return "full_server";
+  return "account_backup";
+};
 
 interface ScheduleSpec {
   freq: Freq;
@@ -161,6 +181,7 @@ function ScheduleDrawer({
   const [form] = Form.useForm();
   const [busy, setBusy] = useState(false);
   const freq = (Form.useWatch("freq", form) ?? "daily") as Freq;
+  const scope = (Form.useWatch("scope", form) ?? "account_backup") as Scope;
 
   useEffect(() => {
     if (open) {
@@ -174,6 +195,7 @@ function ScheduleDrawer({
           ? editing.user_ids
           : [ALL_USERS];
         form.setFieldsValue({
+          scope: scopeOf(editing),
           user_ids: editingIDs,
           freq: spec.freq,
           time: spec.time,
@@ -191,6 +213,7 @@ function ScheduleDrawer({
         });
       } else {
         form.setFieldsValue({
+          scope: "account_backup" as Scope,
           user_ids: [ALL_USERS],
           freq: "daily" as Freq,
           time: dayjs().hour(3).minute(0).second(0),
@@ -213,18 +236,35 @@ function ScheduleDrawer({
     }
     setBusy(true);
     try {
-      const selected: string[] = values.user_ids ?? [];
-      const hasAll = selected.includes(ALL_USERS);
-      // ALL_USERS sentinel collapses to an empty list, which the
-      // backend interprets as "every non-admin user" at tick time.
-      // Any explicit picks while ALL_USERS is also selected are
-      // dropped — operator either backs up everyone or a specific
-      // subset, not both.
-      const userIDs = hasAll ? [] : selected.filter((u) => u !== ALL_USERS);
-      if (!hasAll && userIDs.length === 0) {
-        message.error("Pick at least one user, or 'All users'");
-        setBusy(false);
-        return;
+      // Resolve the wire fields (kind / user_ids / include_system_backup)
+      // from the chosen Scope (GH #502). Only the "account_backup" scope
+      // reads the Users select; system_backup and full_server are
+      // self-describing so their user list / system flag are fixed here.
+      const scopeVal: Scope = values.scope ?? "account_backup";
+      let kind = "account_backup";
+      let userIDs: string[] = [];
+      let includeSystem = false;
+      if (scopeVal === "system_backup") {
+        kind = "system_backup"; // panel/system only, no account fan-out
+      } else if (scopeVal === "full_server") {
+        // Every non-admin account + the system, in one schedule.
+        userIDs = []; // empty = "all non-admin users" at tick time
+        includeSystem = true;
+      } else {
+        const selected: string[] = values.user_ids ?? [];
+        const hasAll = selected.includes(ALL_USERS);
+        // ALL_USERS sentinel collapses to an empty list, which the
+        // backend interprets as "every non-admin user" at tick time.
+        // Any explicit picks while ALL_USERS is also selected are
+        // dropped — operator either backs up everyone or a specific
+        // subset, not both.
+        userIDs = hasAll ? [] : selected.filter((u) => u !== ALL_USERS);
+        if (!hasAll && userIDs.length === 0) {
+          message.error("Pick at least one user, or 'All users'");
+          setBusy(false);
+          return;
+        }
+        includeSystem = !!values.include_system_backup;
       }
       if (values.freq === "weekly" && (!values.weekdays || values.weekdays.length === 0)) {
         message.error("Pick at least one weekday");
@@ -238,12 +278,12 @@ function ScheduleDrawer({
         dom: values.dom,
       });
       const body: Record<string, unknown> = {
-        kind: "account_backup",
+        kind,
         cron_expr: cron,
         enabled: values.enabled,
         destination_ids: values.destination_ids ?? [],
         user_ids: userIDs,
-        include_system_backup: !!values.include_system_backup,
+        include_system_backup: includeSystem,
       };
       // Retention is one knob, scoped to the chosen frequency. The
       // matching keep_* column is set; the other two stay null so
@@ -285,36 +325,58 @@ function ScheduleDrawer({
     >
       <Form form={form} layout="vertical">
         <Form.Item
-          name="user_ids"
-          label="Users"
-          rules={[{ required: true, message: "Pick at least one user, or 'All users'" }]}
-          extra="Select 'All users' OR pick specific accounts. Admins are excluded from the list."
+          name="scope"
+          label="Type"
+          rules={[{ required: true }]}
+          extra={
+            scope === "system_backup"
+              ? "Panel/system only — panel DBs, service config, mail state. No account files."
+              : scope === "full_server"
+                ? "Every account (home, databases, mailboxes) PLUS the system, in one schedule. Disaster recovery."
+                : "Per-account backup — all accounts or a chosen subset. Add the system with the switch below."
+          }
         >
-          <Select
-            mode="multiple"
-            showSearch
-            allowClear
-            placeholder="Pick users (or 'All users')"
-            optionFilterProp="label"
-            options={[
-              { value: ALL_USERS, label: "All users (every non-admin)" },
-              ...users
-                .filter((u) => !u.is_admin)
-                .map((u) => ({
-                  value: u.id,
-                  label: `${u.username} (${u.email})`,
-                })),
-            ]}
-          />
+          <Radio.Group optionType="button" buttonStyle="solid">
+            <Radio.Button value="account_backup">Accounts</Radio.Button>
+            <Radio.Button value="system_backup">System</Radio.Button>
+            <Radio.Button value="full_server">Full Server</Radio.Button>
+          </Radio.Group>
         </Form.Item>
-        <Form.Item
-          name="include_system_backup"
-          label="Include system backup"
-          valuePropName="checked"
-          extra="Also fire a system backup (panel DBs + service config + mail state + …) every time this schedule runs."
-        >
-          <Switch />
-        </Form.Item>
+        {scope === "account_backup" && (
+          <>
+            <Form.Item
+              name="user_ids"
+              label="Users"
+              rules={[{ required: true, message: "Pick at least one user, or 'All users'" }]}
+              extra="Select 'All users' OR pick specific accounts. Admins are excluded from the list."
+            >
+              <Select
+                mode="multiple"
+                showSearch
+                allowClear
+                placeholder="Pick users (or 'All users')"
+                optionFilterProp="label"
+                options={[
+                  { value: ALL_USERS, label: "All users (every non-admin)" },
+                  ...users
+                    .filter((u) => !u.is_admin)
+                    .map((u) => ({
+                      value: u.id,
+                      label: `${u.username} (${u.email})`,
+                    })),
+                ]}
+              />
+            </Form.Item>
+            <Form.Item
+              name="include_system_backup"
+              label="Include system backup"
+              valuePropName="checked"
+              extra="Also fire a system backup (panel DBs + service config + mail state + …) every time this schedule runs."
+            >
+              <Switch />
+            </Form.Item>
+          </>
+        )}
         <Form.Item
           name="freq"
           label="Frequency"
@@ -496,6 +558,19 @@ export function SchedulesTab() {
         pagination={false}
         scroll={{ x: "max-content" }}
       >
+        <Table.Column<BackupSchedule>
+          title="Type"
+          render={(_, row) => {
+            const sc = scopeOf(row);
+            if (sc === "system_backup") return <Tag color="purple">System</Tag>;
+            if (sc === "full_server") return <Tag color="purple">Full Server</Tag>;
+            return (
+              <Tag color="blue">
+                {row.include_system_backup ? "Accounts + system" : "Accounts"}
+              </Tag>
+            );
+          }}
+        />
         <Table.Column<BackupSchedule>
           title={t("schedulestab.users")}
           render={(_, row) => {


### PR DESCRIPTION
Closes the remaining half of #502. On-demand full-server / system backups already shipped; the reporter came back saying **scheduled** backups still only did "all users + system" together, with no way to pick a type.

## Root cause
The schedule drawer hard-coded `kind: "account_backup"` and required at least one user. The backend + scheduler already support every variant (`system_backup` kind, per-schedule user list, `include_system_backup` fan-out) — the UI just never exposed them.

## Fix (UI only — no API/scheduler change)
Add a **Type** selector to the schedule drawer, mirroring the on-demand "Create backup" drawer:

| Type | Wire | Meaning |
|------|------|---------|
| **Accounts** | `account_backup`, users select, optional include-system switch | all users or a chosen subset |
| **System** | `system_backup` | panel/system only — Users field hidden |
| **Full Server** | `account_backup`, `user_ids: []` (all), `include_system_backup: true` | every account + the system |

Yields all four strategies from the issue, each with its own cron / retention / destinations:
- Panel/System only → Type=System
- All users only → Type=Accounts, Users=All, include-system off
- Full server → Type=Full Server
- Selected users → Type=Accounts, Users=subset

Editing derives the Type from the row (`scopeOf`); the schedule list gains a **Type** column.

## Test
`SchedulesTab.scope.test.tsx` locks the Type→wire mapping (System posts `kind=system_backup` and hides Users; Full Server posts `account_backup` + empty `user_ids` + `include_system_backup=true`). tsc clean; full vitest suite green (169).