### PR TITLE
fix(services): treat jabali-kratos as a panel-critical service (GH #746)

### DIFF
--- a/panel-api/internal/api/admin_services.go
+++ b/panel-api/internal/api/admin_services.go
@@ -65,16 +65,20 @@ var (
 	// every panel session and DB-as-truth state; nginx is the reverse
 	// proxy the panel is served through (stop -> 502); redis-server is a
 	// hard dependency of jabali-panel (stop -> the panel process itself
-	// dies — GH #746). Reject these at the API layer so the agent stays a
+	// dies — GH #746). jabali-kratos is the identity provider every panel
+	// login and session refresh flows through — stopping it locks the
+	// operator out of the management plane just as effectively (GH #746
+	// follow-up). Reject these at the API layer so the agent stays a
 	// dumb obedient executor and never has to know about product-UX
 	// concerns. Keep this in sync with selfDestructUnits in the UI
 	// (ServicesSummaryCard.tsx) and jabaliUnits in service_down.go.
 	panelSelfDestructUnits = map[string]bool{
-		"jabali-panel": true,
-		"jabali-agent": true,
-		"mariadb":      true,
-		"nginx":        true,
-		"redis-server": true,
+		"jabali-panel":  true,
+		"jabali-agent":  true,
+		"jabali-kratos": true,
+		"mariadb":       true,
+		"nginx":         true,
+		"redis-server":  true,
 	}
 	panelSelfDestructActions = map[string]bool{
 		"stop":    true,
@@ -97,7 +101,7 @@ func (h *adminServicesHandler) action(c *gin.Context) {
 	if panelSelfDestructUnits[name] && panelSelfDestructActions[action] {
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "self_destruct_blocked",
-			"details": "stop/disable on panel-critical units (jabali-panel, jabali-agent, mariadb, nginx, redis-server) would brick the management plane — use systemctl from the shell if you really need to",
+			"details": "stop/disable on panel-critical units (jabali-panel, jabali-agent, jabali-kratos, mariadb, nginx, redis-server) would brick the management plane — use systemctl from the shell if you really need to",
 		})
 		return
 	}

--- a/panel-api/internal/api/admin_services_test.go
+++ b/panel-api/internal/api/admin_services_test.go
@@ -100,6 +100,10 @@ func TestAdminServices_SelfDestructBlocked(t *testing.T) {
 		{"nginx", "disable"},
 		{"redis-server", "stop"},
 		{"redis-server", "disable"},
+		// GH #746 follow-up: jabali-kratos is the identity provider —
+		// stopping it locks every operator out of the panel.
+		{"jabali-kratos", "stop"},
+		{"jabali-kratos", "disable"},
 	}
 	for _, c := range cases {
 		ag := &fakeAgent{}

--- a/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
@@ -1,8 +1,8 @@
 // ServicesSummaryCard — compact Service / Status / Action table for the
 // Server Status top section. Action column is a row of icon-only
 // Buttons each wrapped in a Tooltip explaining the verb. Self-destruct
-// panel-critical units (jabali-panel, jabali-agent, mariadb, nginx,
-// redis-server) hide Stop+Disable —
+// panel-critical units (jabali-panel, jabali-agent, jabali-kratos,
+// mariadb, nginx, redis-server) hide Stop+Disable —
 // those requests are 403'd at the API anyway. Destructive verbs
 // (stop/disable/restart) show a confirm Modal first.
 import { useState } from "react";
@@ -44,10 +44,12 @@ const reloadCapable = new Set([
 // Panel-critical units: stopping/disabling any of these from the UI would make
 // the panel inaccessible (GH #746). Kept in sync with panelSelfDestructUnits in
 // panel-api/internal/api/admin_services.go. nginx is the reverse proxy (stop ->
-// 502); redis-server is a hard jabali-panel dependency (stop -> the panel dies).
+// 502); redis-server is a hard jabali-panel dependency (stop -> the panel dies);
+// jabali-kratos is the identity provider every login/session flows through.
 const selfDestructUnits = new Set([
   "jabali-panel.service",
   "jabali-agent.service",
+  "jabali-kratos.service",
   "mariadb.service",
   "nginx.service",
   "redis-server.service",


### PR DESCRIPTION
Follow-up to the #746 self-destruct guard. After nginx / redis-server / jabali-panel were made panel-critical, a tester ([lxsdevcode](https://github.com/shukiv/jabali-panel/issues/746)) found that stopping **jabali-kratos** from the Services page *also* bricks the panel — Kratos is the identity provider every panel login and session refresh flows through, so with it down the panel is unreachable, same class of one-click lockout.

## Fix
Add `jabali-kratos` to the panel-critical set in both sync points:

- **panel-api** `admin_services.go` `panelSelfDestructUnits` — the API now **403s** `stop`/`disable` on `jabali-kratos`. Restart / Start / Reload / Enable stay available.
- **panel-ui** `ServicesSummaryCard.tsx` `selfDestructUnits` — the **Stop** and **Disable at boot** row actions are hidden for the `jabali-kratos` row.

The service-down monitor (`service_down.go` `jabaliUnits`) **already** watches `jabali-kratos.service`, so a Kratos outage already fires a `service.down` alert — no change needed there.

## Test
`admin_services_test.go` asserts `stop`/`disable` on `jabali-kratos` are 403'd and never reach the agent. Go tests + vet pass; panel-ui tsc + vitest green.