### PR TITLE
feat(files): current-directory total + sizes-calculated confirmation (GH #657)

### DIFF
--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -340,6 +340,9 @@ export const FileManagerPage = () => {
   const [folderSizes, setFolderSizes] = useState<Record<string, number>>({});
   const [sizingAll, setSizingAll] = useState(false);
   const [sizingPaths, setSizingPaths] = useState<Set<string>>(new Set());
+  // GH #657: recursive total of the CURRENT directory's contents, from the
+  // same files.du pass. null = not yet calculated for this directory.
+  const [dirTotal, setDirTotal] = useState<number | null>(null);
   const [listLoading, setListLoading] = useState(false);
   const [treeData, setTreeData] = useState<TreeNode[]>([]);
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
@@ -453,6 +456,7 @@ export const FileManagerPage = () => {
     setSelectedNames([]);
     // Folder sizes are per-directory; drop them so a new folder starts blank.
     setFolderSizes({});
+    setDirTotal(null);
   }, [currentPath, reloadList]);
 
   // GH #657: compute REAL recursive sizes for every folder in the current
@@ -467,6 +471,12 @@ export const FileManagerPage = () => {
         if (e.is_dir) next[joinPath(currentPath, e.name)] = e.size;
       }
       setFolderSizes((prev) => ({ ...prev, ...next }));
+      // GH #657: surface the current directory's own recursive total (already
+      // returned by files.du) and confirm the operation finished — larger
+      // trees can take a while, so the explicit success + total is the signal
+      // the reporter asked for.
+      setDirTotal(resp.total);
+      message.success(`Folder sizes calculated — this folder totals ${formatBytes(resp.total)}`);
     } catch (err) {
       message.error(`Size calculation failed: ${errMessage(err)}`);
     } finally {
@@ -1320,6 +1330,13 @@ export const FileManagerPage = () => {
               Folder sizes
             </Button>
           </Tooltip>
+          {dirTotal !== null && (
+            <Tooltip title="Total recursive size of everything in this directory">
+              <Tag color="blue" icon={<HddOutlined />} style={{ marginInlineStart: 4 }}>
+                This folder: {formatBytes(dirTotal)}
+              </Tag>
+            </Tooltip>
+          )}
           <Button icon={<ReloadOutlined />} onClick={handleRefresh} />
         </Space>
       </div>


### PR DESCRIPTION
Follow-up to the File Manager folder-size feature. Two small asks from the reporter:

1. A **confirmation** that the size pass finished — folder sizes just appeared silently, which is unclear for larger directories.
2. The **total size of the current directory's contents** — "how much space does this folder use / would I free by emptying it?".

## Fix (UI only — no backend/agent change)
`files.du` already returns a `total` (the directory's own recursive byte size); the UI was discarding it. "Folder sizes" now also:
- sets a current-directory total and renders it as a **`This folder: <size>`** tag beside the button, and
- pops a success message — *"Folder sizes calculated — this folder totals `<size>`"* — so completion is explicit.

The total clears on navigation (per-directory, like the per-folder sizes).

## Tests
No backend change — the `files.du` wire (incl. `total`) is already covered by `filesApi.test.ts` (green). The change is presentational (surfaces an already-returned field + a toast); `FileManagerPage` has no existing render harness (1968 lines, lazy monaco), so a bespoke page-render test would be disproportionate. tsc clean; existing files tests green.