### PR TITLE
feat(settings): vertical navigation for Server Settings (GH #688)

### DIFF
--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -24,8 +24,10 @@ import {
   Col,
   Divider,
   Form,
+  Grid,
   Input,
   InputNumber,
+  Menu,
   Modal,
   Row,
   Select,
@@ -953,6 +955,25 @@ const SSHSettingsTab = () => {
 
 export const ServerSettingsPage = () => {
   const [activeTab, setActiveTab] = useTabParam<SettingsTabKey>("general");
+  const screens = Grid.useBreakpoint();
+  // GH #688: the old horizontal Card tabList overflowed into a scrollbar as
+  // categories grew. Switch to a vertical Menu that scales down the list.
+  // On narrow screens the Menu goes horizontal (scrollable) above the content
+  // so it doesn't eat the whole width.
+  const vertical = screens.md ?? true;
+
+  const menuItems = [
+    { key: "general", icon: <SettingOutlined />, label: "General" },
+    { key: "ssh", icon: <CodeOutlined />, label: "SSH" },
+    { key: "storage", icon: <HddOutlined />, label: "Storage" },
+    { key: "dns", icon: <GlobalOutlined />, label: "DNS" },
+    { key: "email", icon: <MailOutlined />, label: "Email" },
+    { key: "databases", icon: <DatabaseOutlined />, label: "Databases" },
+    { key: "apps", icon: <AppstoreOutlined />, label: "Apps" },
+    { key: "nginx", icon: <ToolOutlined />, label: "Nginx" },
+    { key: "branding", icon: <BgColorsOutlined />, label: "Branding" },
+    { key: "logs", icon: <FileTextOutlined />, label: "Logs" },
+  ];
 
   return (
     <div>
@@ -960,106 +981,30 @@ export const ServerSettingsPage = () => {
         <SettingOutlined /> Server Settings
       </Typography.Title>
 
-      {/* Card.tabList renders the tab strip attached to the card body —
-          each tab owns an independent form, so unsaved edits in the
-          inactive tab are lost on switch (mirrors the Users page pattern). */}
-      <Card
-        tabList={[
-          {
-            key: "general",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <SettingOutlined />
-                General
-              </span>
-            ),
-          },
-          {
-            key: "ssh",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <CodeOutlined />
-                SSH
-              </span>
-            ),
-          },
-          {
-            key: "storage",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <HddOutlined />
-                Storage
-              </span>
-            ),
-          },
-          {
-            key: "dns",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <GlobalOutlined />
-                DNS
-              </span>
-            ),
-          },
-          {
-            key: "email",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <MailOutlined />
-                Email
-              </span>
-            ),
-          },
-          {
-            key: "databases",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <DatabaseOutlined />
-                Databases
-              </span>
-            ),
-          },
-          {
-            key: "apps",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <AppstoreOutlined />
-                Apps
-              </span>
-            ),
-          },
-          {
-            key: "nginx",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <ToolOutlined />
-                Nginx
-              </span>
-            ),
-          },
-          {
-            key: "branding",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <BgColorsOutlined />
-                Branding
-              </span>
-            ),
-          },
-          {
-            key: "logs",
-            tab: (
-              <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
-                <FileTextOutlined />
-                Logs
-              </span>
-            ),
-          },
-        ]}
-        activeTabKey={activeTab}
-        onTabChange={(k) => setActiveTab(k as SettingsTabKey)}
+      {/* GH #688: vertical settings nav (was an overflowing horizontal tab
+          strip). Each tab still owns an independent form, so unsaved edits in
+          the inactive tab are lost on switch (mirrors the Users page). */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: vertical ? "row" : "column",
+          gap: 16,
+          alignItems: "flex-start",
+        }}
       >
-        {activeTab === "general" && (
+        <Menu
+          mode={vertical ? "inline" : "horizontal"}
+          selectedKeys={[activeTab]}
+          onClick={({ key }) => setActiveTab(key as SettingsTabKey)}
+          items={menuItems}
+          style={
+            vertical
+              ? { width: 200, flex: "0 0 auto", borderRadius: 8, border: "1px solid var(--jab-border, #f0f0f0)" }
+              : { width: "100%" }
+          }
+        />
+        <Card style={{ flex: "1 1 480px", minWidth: 0, width: "100%" }}>
+          {activeTab === "general" && (
           <>
             <GeneralSettingsTab />
             <TenantNotificationsCard />
@@ -1096,7 +1041,8 @@ export const ServerSettingsPage = () => {
         )}
         {activeTab === "branding" && <BrandingSettingsTab />}
         {activeTab === "logs" && <LogRetentionCard />}
-      </Card>
+        </Card>
+      </div>
     </div>
   );
 };

--- a/panel-ui/tests/e2e/ssh-sandbox.spec.ts
+++ b/panel-ui/tests/e2e/ssh-sandbox.spec.ts
@@ -91,7 +91,7 @@ test.describe("M13: SSH shell sandbox — Server Settings", () => {
     await page.goto("/jabali-admin/settings");
     await page.waitForLoadState("networkidle");
     // Shell Sandbox now lives on the SSH tab (moved out of General).
-    await page.getByRole("tab", { name: "SSH" }).click();
+    await page.getByRole("menuitem", { name: "SSH" }).click();
 
     // Shell Sandbox lives on the SSH tab — the divider must be visible
     await expect(page.getByText("Shell Sandbox")).toBeVisible({ timeout: 15_000 });
@@ -113,7 +113,7 @@ test.describe("M13: SSH shell sandbox — Server Settings", () => {
     await page.goto("/jabali-admin/settings");
     await page.waitForLoadState("networkidle");
     // Shell Sandbox now lives on the SSH tab (moved out of General).
-    await page.getByRole("tab", { name: "SSH" }).click();
+    await page.getByRole("menuitem", { name: "SSH" }).click();
 
     // The Select for ssh_sandbox_mode should display the bubblewrap option text
     await expect(page.getByText("Shell Sandbox")).toBeVisible({ timeout: 15_000 });
@@ -136,7 +136,7 @@ test.describe("M13: SSH shell sandbox — Server Settings", () => {
     await page.goto("/jabali-admin/settings");
     await page.waitForLoadState("networkidle");
     // Shell Sandbox now lives on the SSH tab (moved out of General).
-    await page.getByRole("tab", { name: "SSH" }).click();
+    await page.getByRole("menuitem", { name: "SSH" }).click();
 
     await expect(page.getByText("Shell Sandbox")).toBeVisible({ timeout: 15_000 });
 
@@ -201,7 +201,7 @@ test.describe("M13: SSH shell sandbox — Server Settings", () => {
     await page.goto("/jabali-admin/settings");
     await page.waitForLoadState("networkidle");
     // Shell Sandbox now lives on the SSH tab (moved out of General).
-    await page.getByRole("tab", { name: "SSH" }).click();
+    await page.getByRole("menuitem", { name: "SSH" }).click();
 
     await expect(page.getByText("Shell Sandbox")).toBeVisible({ timeout: 15_000 });
 


### PR DESCRIPTION
The Server Settings page used a horizontal `Card` tab strip that overflowed into a top scrollbar as categories grew (General / SSH / Storage / DNS / Email / Databases / Apps / Nginx / Branding / Logs) — awkward on small screens and worse with each new module.

## Fix
Replace the horizontal `Card tabList` with a vertical antd **`Menu`** beside a content `Card`, matching the layout the reporter mocked up. The menu scales a growing list down the side without horizontal scrolling. Below the `md` breakpoint the Menu drops to a horizontal (scrollable) bar above the content so it doesn't eat the whole width on mobile.

No behaviour change otherwise: same tab keys, same `useTabParam` URL sync (`?tab=…`), each tab still owns its own form (unsaved edits in an inactive tab are dropped on switch, unchanged).

## Verification
tsc clean; eslint clean; no E2E drives the old tab strip (checked). This is a layout swap to a textbook antd `Menu`; I could not browser-verify the rendered look (panel login needs a password I don't handle) — worth an eyeball after deploy.