### PR TITLE
fix(demo): mask server IP, friendly demo_mode toast, tighter banner (JAB-176/177/178)

### DIFF
--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -22,6 +22,11 @@ type MeHandlerConfig struct {
 	Packages       repository.PackageRepository
 	ServerSettings repository.ServerSettingsRepository
 	UIPrefs        repository.UserUIPrefRepository
+	// DemoEnabled mirrors cfg.Demo.Enabled. When set, server-capabilities
+	// masks the real public IPs with RFC 5737/3849 documentation-range
+	// placeholders so the public demo dashboard never exposes real infra
+	// (JAB-176). Off in production => the true IPs are returned unchanged.
+	DemoEnabled bool
 }
 
 // RegisterMeRoutes wires GET /api/v1/me and GET /api/v1/me/ssh-connection.
@@ -98,10 +103,29 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		"root_terminal_enabled": settings.RootTerminalEnabled,
 		// GH #361: surface the server's public IPv4/IPv6 so the user + admin
 		// dashboards can show them (already tracked for the panel cert + DNS;
-		// not per-user sensitive). Empty string when unset.
-		"public_ipv4": settings.PublicIPv4,
-		"public_ipv6": settings.PublicIPv6,
+		// not per-user sensitive). Empty string when unset. JAB-176: on the
+		// public demo, mask them so the dashboard never leaks the real infra IP.
+		"public_ipv4": demoMaskIPv4(h.cfg.DemoEnabled, settings.PublicIPv4),
+		"public_ipv6": demoMaskIPv6(h.cfg.DemoEnabled, settings.PublicIPv6),
 	})
+}
+
+// demoMaskIPv4 / demoMaskIPv6 replace a non-empty real IP with a
+// documentation-range placeholder (RFC 5737 TEST-NET-3 / RFC 3849) when the
+// public demo is enabled, so the demo dashboard shows a plausible but fake
+// address instead of the real host (JAB-176). An empty value stays empty.
+func demoMaskIPv4(demo bool, real string) string {
+	if demo && real != "" {
+		return "203.0.113.10"
+	}
+	return real
+}
+
+func demoMaskIPv6(demo bool, real string) string {
+	if demo && real != "" {
+		return "2001:db8::10"
+	}
+	return real
 }
 
 // meHandler is the bare claims-only fallback the test suite uses

--- a/panel-api/internal/api/me_demo_mask_test.go
+++ b/panel-api/internal/api/me_demo_mask_test.go
@@ -1,0 +1,31 @@
+package api
+
+import "testing"
+
+// JAB-176: server-capabilities must mask the real public IPs on the demo so
+// the public dashboard never leaks real infra, but leave them untouched in
+// production and never invent an IP where none is configured.
+func TestDemoMaskIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		demo       bool
+		v4, v6     string
+		wantV4     string
+		wantV6     string
+	}{
+		{"prod passes real IPs", false, "182.54.236.26", "2a01:4f8::1", "182.54.236.26", "2a01:4f8::1"},
+		{"demo masks real IPs", true, "182.54.236.26", "2a01:4f8::1", "203.0.113.10", "2001:db8::10"},
+		{"demo keeps empty empty", true, "", "", "", ""},
+		{"prod keeps empty empty", false, "", "", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := demoMaskIPv4(c.demo, c.v4); got != c.wantV4 {
+				t.Errorf("demoMaskIPv4(%v,%q) = %q, want %q", c.demo, c.v4, got, c.wantV4)
+			}
+			if got := demoMaskIPv6(c.demo, c.v6); got != c.wantV6 {
+				t.Errorf("demoMaskIPv6(%v,%q) = %q, want %q", c.demo, c.v6, got, c.wantV6)
+			}
+		})
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -492,6 +492,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			Packages:       deps.Packages,
 			ServerSettings: deps.ServerSettings,
 			UIPrefs:        repository.NewUserUIPrefRepository(deps.DB),
+			DemoEnabled:    cfg.Demo.Enabled, // JAB-176: mask real IPs in demo
 		})
 		// GH #256: per-user CLI default PHP version (self-service).
 		api.RegisterMePhpCliRoutes(v1, api.MePhpCliConfig{

--- a/panel-ui/src/apiClient.demo.test.ts
+++ b/panel-ui/src/apiClient.demo.test.ts
@@ -1,0 +1,40 @@
+// JAB-177: a demo write-guard rejection (403 {"error":"demo_mode"}) must be
+// rewritten to a friendly sentence so no rendering path — err.message,
+// response.data.error, or response.data.detail — ever shows the raw code.
+import { describe, expect, it } from "vitest";
+
+import { friendlyDemoError } from "./apiClient";
+
+describe("friendlyDemoError (GH JAB-177)", () => {
+  it("rewrites a bare demo_mode 403 to a friendly sentence", () => {
+    const data: { error?: string; detail?: string } = { error: "demo_mode" };
+    expect(friendlyDemoError(403, data)).toBe(true);
+    expect(data.error).not.toBe("demo_mode");
+    expect(data.error).toMatch(/read-only demo/i);
+    expect(data.detail).toBe(data.error);
+  });
+
+  it("prefers the backend-supplied banner detail when present", () => {
+    const data = { error: "demo_mode", detail: "Demo — nothing you do here persists." };
+    friendlyDemoError(403, data);
+    expect(data.error).toBe("Demo — nothing you do here persists.");
+    expect(data.detail).toBe("Demo — nothing you do here persists.");
+  });
+
+  it("ignores a detail that is itself the raw code", () => {
+    const data = { error: "demo_mode", detail: "demo_mode" };
+    friendlyDemoError(403, data);
+    expect(data.error).toMatch(/read-only demo/i);
+  });
+
+  it("leaves other errors untouched", () => {
+    const data = { error: "domain_already_exists", detail: "taken" };
+    expect(friendlyDemoError(403, data)).toBe(false);
+    expect(data.error).toBe("domain_already_exists");
+  });
+
+  it("no-ops on a non-403 or missing body", () => {
+    expect(friendlyDemoError(500, { error: "demo_mode" })).toBe(false);
+    expect(friendlyDemoError(403, undefined)).toBe(false);
+  });
+});

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -46,6 +46,14 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (resp) => resp,
   (err: AxiosError) => {
+    // JAB-177: rewrite a demo write-guard rejection to a friendly sentence at
+    // this one choke point (see friendlyDemoError) so every rendering path
+    // shows readable copy instead of the raw "demo_mode" code.
+    friendlyDemoError(
+      err.response?.status,
+      err.response?.data as { error?: string; detail?: string } | undefined,
+    );
+
     // A dead/expired/foreign act-as grant: drop the grant and bounce back to
     // the admin view rather than silently continuing as the admin.
     const data = err.response?.data as { error?: string } | undefined;
@@ -62,6 +70,29 @@ apiClient.interceptors.response.use(
     return Promise.reject(normalizeError(err));
   },
 );
+
+/**
+ * JAB-177: the demo write-guard rejects every write with
+ * 403 {"error":"demo_mode"}. Call sites vary — some show err.message
+ * (normalized below), some read response.data.error/.detail raw — so a handful
+ * surfaced the literal "demo_mode" code, which reads like a bug on the public
+ * demo. Rewrite the body IN PLACE to a friendly sentence (preferring the
+ * backend-supplied banner detail) so every rendering path shows readable copy.
+ * Returns true when it applied. Exported for tests.
+ */
+export function friendlyDemoError(
+  status: number | undefined,
+  data: { error?: string; detail?: string } | undefined,
+): boolean {
+  if (status !== 403 || !data || data.error !== "demo_mode") return false;
+  const friendly =
+    data.detail && data.detail !== "demo_mode"
+      ? data.detail
+      : "This is a read-only demo — changes are disabled.";
+  data.error = friendly;
+  data.detail = friendly;
+  return true;
+}
 
 /**
  * Normalize axios errors by extracting the backend's structured error response.

--- a/panel-ui/src/components/DemoBanner.tsx
+++ b/panel-ui/src/components/DemoBanner.tsx
@@ -13,7 +13,9 @@ import { useEffect } from "react";
 
 import { useServiceInfo } from "../useServiceInfo";
 
-const BANNER_HEIGHT_PX = 72;
+// JAB-178: tighter strip (was 72) so it reclaims vertical space; the copy is
+// bolded below for legibility at the smaller height.
+const BANNER_HEIGHT_PX = 40;
 
 export function DemoBanner() {
   const { data } = useServiceInfo();
@@ -63,7 +65,8 @@ export function DemoBanner() {
       type="warning"
       banner
       showIcon
-      message={message}
+      // JAB-178: heavier weight so the copy stays legible at the reduced height.
+      message={<span style={{ fontWeight: 600 }}>{message}</span>}
       style={{
         position: "fixed",
         top: 0,
@@ -71,6 +74,7 @@ export function DemoBanner() {
         right: 0,
         zIndex: 2000,
         height: BANNER_HEIGHT_PX,
+        paddingBlock: 0,
         display: "flex",
         alignItems: "center",
       }}


### PR DESCRIPTION
Three demo-mode polish items reported off the live public demo (`demo.jabali-panel.com`, JAB-159 build-tag mode).

### JAB-176 — Dashboard leaked the real Server IP
`GET /me/server-capabilities` returned the true `public_ipv4`/`public_ipv6`, which the admin **and** user dashboards render (copyable). When `cfg.Demo.Enabled`, mask them with **RFC 5737 / RFC 3849 documentation-range** placeholders (`203.0.113.10` / `2001:db8::10`) so the public demo never exposes real infra. Production returns the true IPs unchanged; an unset IP stays empty.

> Follow-up (noted, not in this PR): the IP can also surface on Server Status / DNS hints / per-domain listen IP / SSL. This PR masks the reported Dashboard source; a broader demo display-scrub can extend the same gate if wanted.

### JAB-177 — blocked writes showed a raw `demo_mode` toast
The write-guard returns `403 {"error":"demo_mode","detail":"<banner>"}`, but call sites vary (some show `err.message`, some read `response.data.error`/`.detail` raw), so a few surfaced the literal code — reads like a bug. `friendlyDemoError()` rewrites the body **in place at the single apiClient response-interceptor choke point** (preferring the backend banner detail) so every rendering path shows a readable sentence. No central toast → no double-toast risk. (Info-vs-error *styling* is per-call-site; left as a possible follow-up — the primary "raw code" complaint is fixed everywhere.)

### JAB-178 — demo banner too tall / too light
Height **72 → 40px** (`paddingBlock: 0`) and the copy **bolded** (`fontWeight: 600`) for legibility at the smaller size.

## Tests
- `me_demo_mask_test.go` — mask on/off, empty-stays-empty.
- `apiClient.demo.test.ts` — rewrite bare code, prefer detail, ignore raw-code detail, leave other errors + non-403 untouched.
- Go build/vet clean (incl. `-tags demo`); tsc + eslint clean; full vitest **174** green.