### PR TITLE
fix(install): RAM-aware on-box builds so a 2 GB VPS install doesn't OOM (GH #760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Service stack (single-node default):
 ## Requirements
 
 - Fresh Debian 13 install (no pre-existing web or mail stack)
-- 2 GB RAM minimum (4+ recommended; small VM gets auto-swap during build)
+- 2 GB RAM minimum, 4 GB recommended — the same guidance as cPanel (on a ≤4 GB host the installer adds swap and caps the on-box SPA/Go build memory so it doesn't OOM; on 2 GB the build is slower but completes)
 - A domain for panel + mail (with glue records if hosting DNS)
 - PTR (reverse DNS) for mail hostname
 - Open ports: 22, 80, 443, 8443, 25, 465, 587, 993, 995, 53

--- a/docs/site/installation.md
+++ b/docs/site/installation.md
@@ -15,6 +15,8 @@
 | Network | Public IPv4, ports 22/25/53/80/443/465/587/993/995 open | + outbound 53/udp+tcp |
 | OS | Debian 13 fresh install | — |
 
+The RAM guidance matches cPanel: **2 GB is the minimum, 4 GB is recommended.** The installer builds the panel (SPA + Go binaries) on the box, so on a ≤4 GB host it provisions a swap file and caps the build's memory (RAM-aware V8 heap + serialized `go build`) so compiling doesn't get OOM-killed — on 2 GB the build is slower but completes. Baseline services (MariaDB, CrowdSec) auto-size down on small hosts; on a very tight 2 GB box you can install without the `security` module to drop CrowdSec's ~500 MB WAF engine.
+
 If outbound `:53/udp` is blocked (some labs), set `JABALI_DNS_FORWARDER=<a-reachable-resolver>` so the recursor forwards over TCP.
 
 ## Install

--- a/install.sh
+++ b/install.sh
@@ -4783,10 +4783,21 @@ build_frontend() {
   # time on a fully-loaded box; ~0s on an idle one.
   local vite_demo=""
   [ "$(_deploy_profile)" = "demo" ] && { vite_demo="VITE_DEMO=1"; _log "demo profile active: building panel-ui with VITE_DEMO=1"; }
+  # Cap the V8 old-space RAM-aware (GH #760). A flat 2 GB heap lets node
+  # outgrow a small VPS and get OOM-killed mid-build even with the swap file
+  # above — the operator sees a cryptic 'Killed'. Scale the ceiling to host
+  # RAM so a 2 GB box keeps node under RAM+swap; big hosts keep the roomy cap.
+  #   ≤2 GB → 1024 MB   ≤4 GB → 1536 MB   >4 GB → 2048 MB
+  local node_heap_mb=2048 mem_mb_fe
+  mem_mb_fe=$(awk '/^MemTotal:/{print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 0)
+  if   [[ $mem_mb_fe -gt 0 && $mem_mb_fe -le 2048 ]]; then node_heap_mb=1024
+  elif [[ $mem_mb_fe -gt 0 && $mem_mb_fe -le 4096 ]]; then node_heap_mb=1536
+  fi
+  _log "panel-ui build: host=${mem_mb_fe}MB RAM → NODE --max-old-space-size=${node_heap_mb}"
   sudo -u "$SERVICE_USER" -H env \
     HOME="$REPO_DIR" \
     PATH="/usr/bin:/bin" \
-    NODE_OPTIONS="--max-old-space-size=2048" \
+    NODE_OPTIONS="--max-old-space-size=${node_heap_mb}" \
     $vite_demo \
     bash -c "cd '$REPO_DIR/panel-ui' && nice -n 19 ionice -c 3 npm run build"
   _ok "panel-ui built → $REPO_DIR/panel-ui/dist/"
@@ -4859,12 +4870,29 @@ build_backend() {
   panel_ld+=" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.Commit=$full_sha"
   panel_ld+=" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.BuildTime=$btime"
 
+  # Low-RAM hosts (GH #760): serialize package compilation (-p=1) and soft-cap
+  # the Go heap so building panel-api — a large binary whose default build
+  # parallelism (=nproc) fans out several compiler processes — can't OOM a 2 GB
+  # VPS. -p=1 is the big lever (one compile at a time); GOMEMLIMIT + a lower
+  # GOGC make each go tool's GC more aggressive. No effect >4 GB, so CI and
+  # real hosts build exactly as before (just slower on the tiny boxes).
+  local go_lowmem="" mem_mb_be
+  mem_mb_be=$(awk '/^MemTotal:/{print int($2/1024)}' /proc/meminfo 2>/dev/null || echo 0)
+  if [[ $mem_mb_be -gt 0 && $mem_mb_be -le 4096 ]]; then
+    if [[ $mem_mb_be -le 2560 ]]; then
+      go_lowmem="GOFLAGS=-p=1 GOMEMLIMIT=900MiB GOGC=40"
+    else
+      go_lowmem="GOFLAGS=-p=1 GOMEMLIMIT=1500MiB GOGC=50"
+    fi
+    _log "build-backend: low-RAM host (${mem_mb_be}MB) → serialize go build ($go_lowmem)"
+  fi
   # One invocation of go, three binaries — shared module, shared build cache.
   sudo -u "$SERVICE_USER" -H env \
     PATH="$GO_ROOT/bin:/usr/bin:/bin" \
     HOME="$REPO_DIR" \
     GOCACHE="$REPO_DIR/.cache/go-build" \
     GOMODCACHE="$REPO_DIR/.cache/go-mod" \
+    $go_lowmem \
     bash -c "cd '$REPO_DIR' && \
       go build -trimpath $panel_tags -ldflags '$panel_ld' -o '$tmp_panel' ./panel-api/cmd/server && \
       go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_agent' ./panel-agent/cmd/jabali-agent && \

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -110,13 +110,19 @@ func runUpdate(cmd *cobra.Command, args []string) (retErr error) {
 		serviceUser = "jabali"
 	}
 
+	// GH #760: on a low-RAM host, prepend GOFLAGS=-p=1 + GOMEMLIMIT so the
+	// from-source go build can't OOM the box (mirrors install.sh:build_backend).
+	// The vars are Go-specific, so passing them to git/npm too is harmless.
+	lowMemGoEnv := lowRAMGoBuildEnv()
 	asUser := func(dir string, name string, args ...string) error {
-		allArgs := append([]string{"-u", serviceUser, "-H", "env",
+		allArgs := []string{"-u", serviceUser, "-H", "env",
 			"HOME=" + repoDir,
 			"PATH=" + goRoot + "/bin:/usr/bin:/bin",
 			"GOCACHE=" + repoDir + "/.cache/go-build",
 			"GOMODCACHE=" + repoDir + "/.cache/go-mod",
-		}, name)
+		}
+		allArgs = append(allArgs, lowMemGoEnv...)
+		allArgs = append(allArgs, name)
 		allArgs = append(allArgs, args...)
 		return run(dir, "sudo", allArgs...)
 	}

--- a/panel-api/cmd/server/update_lowmem.go
+++ b/panel-api/cmd/server/update_lowmem.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// update_lowmem.go — GH #760. The from-source update path (`jabali update`
+// falling back to a local go build when no release tarball is available or
+// --from-source is set) runs the same `go build ./panel-api/...` that OOM-kills
+// a 2 GB VPS under Go's default build parallelism (=nproc). Mirror
+// install.sh:build_backend: on a low-RAM host, serialize compilation and
+// soft-cap the Go heap so the build survives (slower, not killed).
+
+// lowRAMGoBuildEnvForMB returns the extra env vars to prepend to an on-box
+// `go build` on a low-RAM host. -p=1 is the big lever (one compile action at a
+// time); GOMEMLIMIT + a lower GOGC make each go tool's GC more aggressive.
+// Empty on hosts >4 GB (and on unknown RAM) so CI and real hosts build exactly
+// as before. The brackets match install.sh:build_backend.
+func lowRAMGoBuildEnvForMB(memMB int) []string {
+	if memMB <= 0 || memMB > 4096 {
+		return nil
+	}
+	if memMB <= 2560 {
+		return []string{"GOFLAGS=-p=1", "GOMEMLIMIT=900MiB", "GOGC=40"}
+	}
+	return []string{"GOFLAGS=-p=1", "GOMEMLIMIT=1500MiB", "GOGC=50"}
+}
+
+// hostMemMB reads MemTotal from /proc/meminfo in MB; 0 on any error (which
+// lowRAMGoBuildEnvForMB treats as "don't tune").
+func hostMemMB() int {
+	b, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(line, "MemTotal:") {
+			var kb int
+			if _, err := fmt.Sscanf(line, "MemTotal: %d kB", &kb); err == nil && kb > 0 {
+				return kb / 1024
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
+// lowRAMGoBuildEnv is the /proc-backed wrapper used by the updater.
+func lowRAMGoBuildEnv() []string { return lowRAMGoBuildEnvForMB(hostMemMB()) }

--- a/panel-api/cmd/server/update_lowmem_test.go
+++ b/panel-api/cmd/server/update_lowmem_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// GH #760: the from-source update build must tune down on small hosts and stay
+// untouched on real ones. Brackets mirror install.sh:build_backend.
+func TestLowRAMGoBuildEnvForMB(t *testing.T) {
+	cases := []struct {
+		memMB int
+		want  []string
+	}{
+		{0, nil},                                                          // unknown RAM → don't tune
+		{-5, nil},                                                         // garbage → don't tune
+		{1990, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=900MiB", "GOGC=40"}},  // 2 GB VPS
+		{2048, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=900MiB", "GOGC=40"}},  // 2 GB
+		{2560, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=900MiB", "GOGC=40"}},  // 2.5 GB edge
+		{2561, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=1500MiB", "GOGC=50"}}, // just above
+		{3800, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=1500MiB", "GOGC=50"}}, // 3.8 GB
+		{4096, []string{"GOFLAGS=-p=1", "GOMEMLIMIT=1500MiB", "GOGC=50"}}, // 4 GB ceiling
+		{4097, nil}, // just over → untouched
+		{9914, nil}, // big host → untouched
+	}
+	for _, c := range cases {
+		got := lowRAMGoBuildEnvForMB(c.memMB)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("lowRAMGoBuildEnvForMB(%d) = %v, want %v", c.memMB, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
The reporter's real blocker on a 2 GB machine wasn't the runtime baseline — the **install itself OOM-killed while compiling**. `npm run build` (vite) and the four `go build`s run on the box; both peaked past 2 GB and got `Killed`.

Two causes, both fixed **RAM-aware and gated to ≤4 GB hosts** (CI + real boxes build exactly as before):

### `install.sh:build_frontend` — vite heap
Was a flat `NODE_OPTIONS=--max-old-space-size=2048`, which lets node outgrow a 2 GB box even with the swap file. Now scaled to host RAM: **≤2 GB → 1024, ≤4 GB → 1536, else 2048** (MB). Matches the comment that already claimed a ~1 GB ceiling, and the updater's vite step which was already RAM-aware.

### `install.sh:build_backend` — go build
Had **no** memory cap and fanned out `nproc` parallel compiler processes. On a low-RAM host now prepend `GOFLAGS=-p=1` (serialize compilation — the big lever) + `GOMEMLIMIT` + a lower `GOGC`. Verified the flags build panel-api cleanly.

### `update.go` — from-source update fallback
`jabali update` fetches prebuilt release binaries (fast path), but **falls back to a local go build** when no tarball is available / `--from-source`. That path (`asUser`) had no Go caps → same OOM. Wired the same `lowRAMGoBuildEnv()` through it so a 2 GB box can self-update from source too.

## Tests
`update_lowmem_test.go` locks the brackets (2 GB → serialize/900MiB/GOGC40; 2.5–4 GB → 1500MiB/GOGC50; >4 GB + unknown → untouched). `bash` syntax check clean; go build/vet/test green.

## Not box-tested on 2 GB
testserver is 9.9 GB, so the OOM-avoidance is **logic- and build-verified**, not reproduced on a real 2 GB host. `-p=1` is documented to serialize build actions (the key lever); the flags compile panel-api cleanly.

## Follow-up (noted, not here)
The robust long-term fix is to **fetch the prebuilt release binaries at install time** (the updater already does), skipping the on-box build entirely. This PR keeps the source build survivable on 2 GB now.