### PR TITLE
fix(backups): download a partial System backup + clickable "Expand to manage" (GH #502)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -702,7 +702,13 @@ func (h *backupHandler) download(c *gin.Context) {
 // materializes the snapshot under /var/lib/jabali-backups/downloads/<job_id>/ as
 // root:jabali 0750 for the tar to read without elevated privileges.
 func streamBackupArtifact(c *gin.Context, ag agent.AgentInterface, job *models.BackupJob, destParams map[string]any, logErr func(string, error, ...any)) {
-	if job.Status != models.BackupJobStatusSucceeded {
+	// A `partial` backup still produced a valid manifest snapshot (one
+	// non-critical stage failed but the rest, incl. the manifest, were
+	// captured) — the operator must be able to download it (GH #502): the
+	// system leg of a Full Server backup is commonly `partial` yet its
+	// snapshot is real. The SnapshotID guard below is the true gate; queued/
+	// running/failed/cancelled have no snapshot and 404 here.
+	if job.Status != models.BackupJobStatusSucceeded && job.Status != models.BackupJobStatusPartial {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "no_completed_snapshot"})
 		return
 	}

--- a/panel-api/internal/api/backups_download_gate_test.go
+++ b/panel-api/internal/api/backups_download_gate_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #502: the system leg of a Full Server backup is commonly `partial` (a
+// non-critical stage failed) yet its manifest snapshot is real and must be
+// downloadable. streamBackupArtifact must pass a partial+snapshot job through
+// the status gate — the SnapshotID check is the true gate — and only 404 the
+// states that truly have no snapshot.
+func newGateCtx() (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/x", nil)
+	return c, w
+}
+
+func noopLogErr(string, error, ...any) {}
+
+func TestStreamBackupArtifact_AllowsPartial(t *testing.T) {
+	c, w := newGateCtx()
+	job := &models.BackupJob{Status: models.BackupJobStatusPartial, SnapshotID: "snap1"}
+	// nil agent: a job that PASSES the status+snapshot gates reaches the
+	// agent-nil check → 503. A 404 would mean the status gate rejected it.
+	streamBackupArtifact(c, nil, job, nil, noopLogErr)
+	if w.Code == http.StatusNotFound {
+		t.Fatalf("partial+snapshot must not 404 at the status gate")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 (gate passed, nil agent), got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestStreamBackupArtifact_RejectsFailed(t *testing.T) {
+	c, w := newGateCtx()
+	job := &models.BackupJob{Status: models.BackupJobStatusFailed, SnapshotID: "snap1"}
+	streamBackupArtifact(c, nil, job, nil, noopLogErr)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("failed job must 404, got %d", w.Code)
+	}
+}
+
+func TestStreamBackupArtifact_PartialNeedsSnapshot(t *testing.T) {
+	c, w := newGateCtx()
+	job := &models.BackupJob{Status: models.BackupJobStatusPartial, SnapshotID: ""}
+	streamBackupArtifact(c, nil, job, nil, noopLogErr)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("partial without a snapshot must 422, got %d", w.Code)
+	}
+}

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -145,6 +145,9 @@ export const AdminBackupsPage = () => {
   const [manual, setManual] = useState<BackupJob[]>([]);
   const [loading, setLoading] = useState(false);
   const [runJobs, setRunJobs] = useState<Record<string, BackupJob[]>>({});
+  // GH #502: control row expansion so the "Expand to manage" cell can toggle it
+  // (previously only the +/- icon did, which the text falsely implied was clickable).
+  const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   // Mirror runJobs into a ref so the polling reload (whose closure
   // captures state from effect-setup time) can read the LATEST set
   // of expanded runs, not a stale snapshot.
@@ -248,8 +251,23 @@ export const AdminBackupsPage = () => {
     }
   };
 
+  // GH #502: toggle a row's expansion from anywhere (the +/- icon and the
+  // "Expand to manage" cell both call this). Lazy-loads a run's child jobs
+  // on open, mirroring the icon's previous onExpand behaviour.
+  const toggleRowExpand = (row: TableRow) => {
+    setExpandedKeys((keys) => {
+      if (keys.includes(row.rowKey)) {
+        return keys.filter((k) => k !== row.rowKey);
+      }
+      if (row.isRun) void expandRun(row.run.run_id);
+      return [...keys, row.rowKey];
+    });
+  };
+
   const handleDownload = (row: BackupJob) => {
-    if (row.status !== "succeeded") {
+    // GH #502: a `partial` backup has a valid snapshot too (a non-critical
+    // stage failed but the manifest was written) — allow downloading it.
+    if (row.status !== "succeeded" && row.status !== "partial") {
       message.warning("Backup must complete before download");
       return;
     }
@@ -364,7 +382,7 @@ export const AdminBackupsPage = () => {
                 // GH #502: Download is the most common action after a backup completes —
                 // make it the primary (first, visible) action; Log + the rest collapse
                 // into the overflow menu.
-                { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: row.status !== "succeeded", onClick: () => handleDownload(row) },
+                { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: row.status !== "succeeded" && row.status !== "partial", onClick: () => handleDownload(row) },
                 { key: "log", label: "Log", icon: <FileTextOutlined />, onClick: () => setLogJob(row) },
                 {
                   key: "restore",
@@ -491,9 +509,8 @@ export const AdminBackupsPage = () => {
             pagination={{ pageSize: 25 }}
             scroll={{ x: "max-content" }}
             expandable={{
-              onExpand: (expanded, row) => {
-                if (expanded && row.isRun) void expandRun(row.run.run_id);
-              },
+              expandedRowKeys: expandedKeys,
+              onExpand: (_expanded, row) => toggleRowExpand(row),
               expandedRowRender: (row) =>
                 row.isRun ? (
                   runJobs[row.run.run_id] ? (
@@ -586,7 +603,9 @@ export const AdminBackupsPage = () => {
                 title: "Actions",
                 render: (_: unknown, row: TableRow) =>
                   row.isRun ? (
-                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>expand to manage</Typography.Text>
+                    <Typography.Link style={{ fontSize: 12 }} onClick={() => toggleRowExpand(row)}>
+                      {expandedKeys.includes(row.rowKey) ? "Collapse" : "Expand to manage"}
+                    </Typography.Link>
                   ) : (
                     <RowActions
                       actions={[


### PR DESCRIPTION
Two of the three Full-Server backup follow-ups from @lxsdevcode:

### 2. System backup has no Download action
The system leg of a Full Server backup is commonly marked **`partial`** (a non-critical stage failed but the manifest snapshot *was* written). Both the download endpoint and the UI action gated strictly on `succeeded`, so the System backup showed only **Logs**, never **Download**. A partial backup's snapshot is real and restorable — allow it:
- `streamBackupArtifact` (shared admin + `/me` handler) now accepts `succeeded` **or** `partial`; the `SnapshotID` check stays the true gate, so queued/running/failed/cancelled (no snapshot) still 404.
- The admin **Download** row-action + `handleDownload` guard mirror it.

### 3. "Expand to manage" wasn't clickable
The Actions cell on a run row rendered plain text *"expand to manage"*, but only the `+`/`-` icon expanded the row — confusing. Expansion is now **controlled** (`expandedKeys`) and the cell is a **link** that toggles it (and lazy-loads the run's child jobs), reading *"Expand to manage" / "Collapse"*. The icon routes through the same toggle.

### 1. "System backup marked Partial on a fresh server" — NOT in this PR
`partial` means a stage genuinely reported **failed**. Every path stage is already missing-safe (marked *skipped*, not failed), and restic's exit-3 (changed-during-read) is treated as success-with-warnings — so the failing stage is **config-specific**. I need the reporter's **Logs / error text** (it names the stage: *"incomplete backup — stage(s) failed: X"*) before making that stage skip-safe. Asked on the issue.

## Tests
`backups_download_gate_test.go`: partial+snapshot passes the status gate (nil agent → 503, not 404); failed → 404; partial without a snapshot → 422. go build/vet/test + tsc + eslint + vitest all green.