### PR TITLE
fix(demo): redact host/visitor data from GET responses on the public demo (JAB-179)

### DIFF
--- a/panel-api/internal/api/demo_redaction.go
+++ b/panel-api/internal/api/demo_redaction.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"net"
+	"sync/atomic"
+)
+
+// demo_redaction.go — JAB-179. The demo build is write-block only and applied
+// NO redaction to GET responses, so the public demo leaked real third-party
+// visitor IPs (Users → Sessions), the host fingerprint + exact software
+// versions (Server Status), and infra paths. This is a small centralized layer
+// so every sensitive handler redacts through the same helpers and a new
+// endpoint that forgets to is the only way to regress.
+//
+// The flag is process-global (set once at startup from cfg.Demo.Enabled) rather
+// than threaded through every handler config, so read-side handlers can redact
+// without a config change. Off in production => every helper is a pass-through.
+
+var demoRedactionOn atomic.Bool
+
+// SetDemoRedaction enables/disables demo GET redaction. Called once from app
+// startup with cfg.Demo.Enabled.
+func SetDemoRedaction(on bool) { demoRedactionOn.Store(on) }
+
+// DemoRedactionEnabled reports whether demo redaction is active.
+func DemoRedactionEnabled() bool { return demoRedactionOn.Load() }
+
+// Documentation-range placeholders (RFC 5737 / RFC 3849) — plausible but fake.
+const (
+	demoPlaceholderIPv4 = "203.0.113.10"
+	demoPlaceholderIPv6 = "2001:db8::10"
+	demoRedactedText    = "redacted"
+)
+
+// demoMaskIP replaces a real IP with a documentation-range placeholder when
+// demo redaction is on. Preserves the v4/v6 shape; empty stays empty; a value
+// that doesn't parse as an IP is redacted to the v4 placeholder (fail closed).
+func demoMaskIP(ip string) string {
+	if !demoRedactionOn.Load() || ip == "" {
+		return ip
+	}
+	parsed := net.ParseIP(ip)
+	if parsed != nil && parsed.To4() == nil {
+		return demoPlaceholderIPv6
+	}
+	return demoPlaceholderIPv4
+}
+
+// demoRedact replaces an arbitrary sensitive string (user-agent, hostname,
+// version, path) with a fixed placeholder when demo redaction is on. Empty
+// stays empty so "unset" still reads as unset.
+func demoRedact(s string) string {
+	if !demoRedactionOn.Load() || s == "" {
+		return s
+	}
+	return demoRedactedText
+}

--- a/panel-api/internal/api/demo_redaction_test.go
+++ b/panel-api/internal/api/demo_redaction_test.go
@@ -1,0 +1,50 @@
+package api
+
+import "testing"
+
+// withDemoRedaction flips the process-global flag for one test and restores it,
+// so a leaked "on" state can't poison other tests in the package.
+func withDemoRedaction(t *testing.T, on bool) {
+	t.Helper()
+	prev := DemoRedactionEnabled()
+	SetDemoRedaction(on)
+	t.Cleanup(func() { SetDemoRedaction(prev) })
+}
+
+func TestDemoRedactionMaskIP(t *testing.T) {
+	t.Run("off is a pass-through", func(t *testing.T) {
+		withDemoRedaction(t, false)
+		if got := demoMaskIP("83.151.202.27"); got != "83.151.202.27" {
+			t.Errorf("off: got %q, want the real IP", got)
+		}
+	})
+	t.Run("on masks by family", func(t *testing.T) {
+		withDemoRedaction(t, true)
+		if got := demoMaskIP("83.151.202.27"); got != demoPlaceholderIPv4 {
+			t.Errorf("v4: got %q, want %q", got, demoPlaceholderIPv4)
+		}
+		if got := demoMaskIP("2601:6c1:4000::1"); got != demoPlaceholderIPv6 {
+			t.Errorf("v6: got %q, want %q", got, demoPlaceholderIPv6)
+		}
+		if got := demoMaskIP(""); got != "" {
+			t.Errorf("empty stays empty, got %q", got)
+		}
+		if got := demoMaskIP("not-an-ip"); got != demoPlaceholderIPv4 {
+			t.Errorf("unparseable fails closed to v4 placeholder, got %q", got)
+		}
+	})
+}
+
+func TestDemoRedact(t *testing.T) {
+	withDemoRedaction(t, true)
+	if got := demoRedact("Mozilla/5.0 …"); got != demoRedactedText {
+		t.Errorf("on: got %q, want %q", got, demoRedactedText)
+	}
+	if got := demoRedact(""); got != "" {
+		t.Errorf("empty stays empty, got %q", got)
+	}
+	withDemoRedaction(t, false)
+	if got := demoRedact("Mozilla/5.0 …"); got != "Mozilla/5.0 …" {
+		t.Errorf("off is a pass-through, got %q", got)
+	}
+}

--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -260,6 +260,20 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 			})
 		}
 	}
+	// JAB-179: the public demo must not expose the host fingerprint — hostname,
+	// internal IP, kernel, CPU model, disk sizes, exact software versions (a
+	// ready-made CVE list), or the process/user-slice lists. Rebuild an
+	// ALLOWLISTED envelope keeping only service health, alerts and queue
+	// counts, so a slice added later is dropped by default (fail closed).
+	if DemoRedactionEnabled() {
+		env = ServerStatusEnvelope{
+			AsOf:     env.AsOf,
+			Services: env.Services,
+			Queues:   env.Queues,
+			Alerts:   env.Alerts,
+			Errors:   env.Errors,
+		}
+	}
 	c.JSON(http.StatusOK, env)
 }
 

--- a/panel-api/internal/api/users_sessions.go
+++ b/panel-api/internal/api/users_sessions.go
@@ -91,6 +91,15 @@ func (h *userHandler) listSessions(c *gin.Context) {
 			}
 		}
 	}
+	// JAB-179: the public demo must never publish real visitors' source IPs
+	// or user-agents (third-party PII). Mask both for every row — Kratos and
+	// SSH sourced — at this single choke point. No-op in production.
+	if DemoRedactionEnabled() {
+		for i := range rows {
+			rows[i].IP = demoMaskIP(rows[i].IP)
+			rows[i].UserAgent = demoRedact(rows[i].UserAgent)
+		}
+	}
 	c.JSON(http.StatusOK, gin.H{"sessions": rows})
 }
 

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -263,6 +263,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		gin.SetMode(gin.DebugMode)
 	}
 
+	// JAB-179: turn on demo GET redaction when running the public demo so
+	// sensitive reads (visitor session IPs, host fingerprint, infra paths)
+	// are masked. No-op in production (Demo.Enabled=false).
+	api.SetDemoRedaction(cfg.Demo.Enabled)
+
 	// Apps registry. Built once per server. RegisterDefaults panics on
 	// programmer error (duplicate name, bad ParamSpec) — those are
 	// startup conditions we want surfaced loudly, not eaten by a

--- a/panel-ui/src/shells/admin/settings/SSOMaintenanceCard.tsx
+++ b/panel-ui/src/shells/admin/settings/SSOMaintenanceCard.tsx
@@ -8,6 +8,8 @@
 //   breaks phpMyAdmin SSO for every tenant. We surface the exact guarded
 //   procedure + rollback instead (the CLI-supported branch of #575).
 import { useTranslation } from "react-i18next";
+
+import { useServiceInfo } from "../../../useServiceInfo";
 import {
   Alert,
   App,
@@ -46,6 +48,7 @@ systemctl kill -s SIGHUP jabali-panel`;
 export function SSOMaintenanceCard() {
   const { t } = useTranslation();
   const { message } = App.useApp();
+  const { data: svcInfo } = useServiceInfo();
 
   const prune = useMutation({
     mutationFn: async () =>
@@ -54,6 +57,10 @@ export function SSOMaintenanceCard() {
     onError: (e: unknown) =>
       message.error(e instanceof Error ? e.message : "prune failed"),
   });
+
+  // JAB-179: the public demo must not display the SSO key-file paths + rotation
+  // runbook (infra path disclosure). Hide the whole card in demo.
+  if (svcInfo?.demo?.enabled) return null;
 
   return (
     <Card title={t("ssomaintenancecard.sso_maintenance_phpmyadmin")} style={{ marginBottom: 16 }}>

--- a/panel-ui/src/shells/admin/support/SupportPage.tsx
+++ b/panel-ui/src/shells/admin/support/SupportPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@icons";
 
 import { SUPPORT_LINKS } from "../../../config/support-links";
+import { useServiceInfo } from "../../../useServiceInfo";
 import { DiagnosticReportModal } from "./DiagnosticReportModal";
 import { CliOnlyRunbooks } from "./CliOnlyRunbooks";
 
@@ -77,6 +78,10 @@ const CARDS: CardSpec[] = [
 
 export const SupportPage = () => {
   const [modalOpen, setModalOpen] = useState(false);
+  // JAB-179: the public demo must not publish the internal CLI recovery
+  // runbook (admin command names + source-file refs).
+  const { data: svcInfo } = useServiceInfo();
+  const demo = !!svcInfo?.demo?.enabled;
 
   return (
     <div>
@@ -101,7 +106,7 @@ export const SupportPage = () => {
         ))}
       </Row>
 
-      <CliOnlyRunbooks />
+      {!demo && <CliOnlyRunbooks />}
 
       <DiagnosticReportModal
         open={modalOpen}


### PR DESCRIPTION
**SECURITY — High.** The demo build (`//go:build demo`, `middleware/demo.go`) is **write-block only** — it 403s writes but applied **no redaction to GET responses**, so the public demo (logged in as the seeded admin) exposed:

- **Real third-party visitor source IPs + user-agents** (Users → Sessions) — PII / GDPR weight.
- **Full host fingerprint + exact software versions** (Server Status) — a ready-made CVE list, plus hostname / internal IP / kernel / CPU / disk.
- **Internal CLI recovery runbook** (Support page).
- **SSO key-file paths** (Settings → SSO Maintenance).

## Fix — a small centralized redaction layer
`demo_redaction.go`: a process-global flag set once at startup from `cfg.Demo.Enabled` + `demoMaskIP` / `demoRedact` helpers. **Off in production → every helper is a pass-through**, so real hosts are byte-for-byte unchanged.

Applied at the sensitive reads:
| Surface | Redaction |
|---|---|
| Users → Sessions | mask every row's **IP** (RFC 5737/3849 placeholder) + **user-agent**, at one choke point (Kratos + SSH rows) |
| Server Status | rebuild an **allowlisted** envelope — keep only service health / alerts / queue counts; drop the entire host/CPU/network/software/nginx/process/user-slice fingerprint. **Fail closed** — a slice added later is omitted by default |
| Support page | hide the CLI recovery runbook in demo |
| SSO Maintenance card | hidden entirely in demo (prints key-file paths) |

Complements **JAB-176** (Dashboard public-IP mask, already shipped). Tenant content is seeded/fake and unaffected.

## Tests
`demo_redaction_test.go` — mask by IP family, empty-stays-empty, fail-closed on unparseable, off is a pass-through, global-state reset per test. go build/vet/test (incl. `-tags demo`) + tsc + eslint + vitest **174** green.