### PR TITLE
fix(update): make a failed rebuild legible instead of a bare "signal: killed"

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1772,6 +1772,21 @@ test -x node_modules/.bin/tsc || {
 	for _, s := range buildSteps {
 		fmt.Printf("→ %s\n", s.name)
 		if err := s.fn(); err != nil {
+			// The prelude already advanced the checkout to postHEAD, but this
+			// build/install step failed — so the RUNNING binary is unchanged
+			// (still lastBuilt) while the code on disk is at postHEAD. Make
+			// that half-state explicit and flag the most common cause (the
+			// go/vite build getting OOM-killed on a low-RAM box), so the
+			// operator knows the binary did NOT update and simply re-runs
+			// after freeing memory — instead of a bare "signal: killed" that
+			// reads as noise (GH #760 follow-up).
+			oomHint := ""
+			if isLikelyOOM(err) {
+				oomHint = "\n  Looks like the build was killed for memory (OOM). Free RAM or add swap, then re-run `jabali update`."
+			}
+			fmt.Fprintf(os.Stderr,
+				"\n✗ Update FAILED at %q.\n  The running binary was NOT changed (still %s); the code is now at %s.\n  Re-run `jabali update` after fixing the cause.%s\n",
+				s.name, shortSHA7(lastBuilt), shortSHA7(postHEAD), oomHint)
 			return fmt.Errorf("%s: %w", s.name, err)
 		}
 	}

--- a/panel-api/cmd/server/update_lowmem.go
+++ b/panel-api/cmd/server/update_lowmem.go
@@ -49,3 +49,28 @@ func hostMemMB() int {
 
 // lowRAMGoBuildEnv is the /proc-backed wrapper used by the updater.
 func lowRAMGoBuildEnv() []string { return lowRAMGoBuildEnvForMB(hostMemMB()) }
+
+// isLikelyOOM reports whether a build error looks like the process was killed
+// for memory — the common low-RAM `jabali update` failure, where the go/vite
+// build gets OOM-killed. Used to add a "free RAM / add swap" hint to the
+// failure message (GH #760 follow-up) so the operator knows why the binary
+// didn't update.
+func isLikelyOOM(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "signal: killed") ||
+		strings.Contains(s, "cannot allocate memory") ||
+		strings.Contains(s, "out of memory") ||
+		strings.Contains(s, "Killed")
+}
+
+// shortSHA7 truncates a git SHA to 7 chars for display; passes through anything
+// shorter.
+func shortSHA7(s string) string {
+	if len(s) > 7 {
+		return s[:7]
+	}
+	return s
+}

--- a/panel-api/cmd/server/update_lowmem_test.go
+++ b/panel-api/cmd/server/update_lowmem_test.go
@@ -1,9 +1,36 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
+
+// A failed build must be diagnosable: OOM-shaped errors get the memory hint,
+// unrelated errors don't.
+func TestIsLikelyOOM(t *testing.T) {
+	oom := []string{"signal: killed", "fork/exec: cannot allocate memory", "out of memory", "Killed"}
+	for _, m := range oom {
+		if !isLikelyOOM(errors.New(m)) {
+			t.Errorf("%q should read as OOM", m)
+		}
+	}
+	notOOM := []error{nil, errors.New("go build: undefined: foo"), errors.New("permission denied")}
+	for _, e := range notOOM {
+		if isLikelyOOM(e) {
+			t.Errorf("%v should NOT read as OOM", e)
+		}
+	}
+}
+
+func TestShortSHA7(t *testing.T) {
+	if got := shortSHA7("ce9d98dbe7c8bae4"); got != "ce9d98d" {
+		t.Errorf("shortSHA7 = %q, want ce9d98d", got)
+	}
+	if got := shortSHA7("abc"); got != "abc" {
+		t.Errorf("short input should pass through, got %q", got)
+	}
+}
 
 // GH #760: the from-source update build must tune down on small hosts and stay
 // untouched on real ones. Brackets mirror install.sh:build_backend.


### PR DESCRIPTION
Follow-up to the newzaps incident. `jabali update` pulled new code (the prelude git-reset advances the checkout) but the `go build` was **OOM-killed** on a low-RAM box, leaving the running binary stale — repo at HEAD, binary behind (`repo_head` ≠ `last_built_sha`).

The build step *did* return an error and *didn't* advance `last-built-sha` (so it self-heals on the next run), but the operator only saw a bare `signal: killed` and **didn't realise the binary hadn't changed** — so they added RAM + rebooted (which just restarts the same old binary) instead of re-running the update.

## Fix
On any buildStep failure, print an explicit summary to stderr:
> ✗ Update FAILED at "…".
>   The running binary was NOT changed (still `<old>`); the code is now at `<new>`.
>   Re-run `jabali update` after fixing the cause.
>   *(+ "Looks like the build was killed for memory (OOM). Free RAM or add swap…" when the error is OOM-shaped.)*

Pairs with the RAM-aware build caps already added for #760 (#774): the caps make the build **survive** on a small box; this makes a genuine failure **obvious**.

## Tests
`isLikelyOOM` (OOM-shaped vs unrelated errors), `shortSHA7`. go build/vet/test green.