### PR TITLE
fix(php-pool): make the default-pool lookup deterministic (earliest row) (JAB-174)

### DIFF
--- a/panel-api/internal/repository/php_pool_repository.go
+++ b/panel-api/internal/repository/php_pool_repository.go
@@ -56,7 +56,11 @@ func (r *phpPoolRepo) FindByID(ctx context.Context, id string) (*models.PHPPool,
 
 func (r *phpPoolRepo) FindByUserID(ctx context.Context, userID string) (*models.PHPPool, error) {
 	var pool models.PHPPool
-	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).First(&pool).Error; err != nil {
+	// The DEFAULT pool is the earliest-created row (slug == username) — the
+	// same "pools[0]" convention domain_php_pool.go uses. Order by id ASC (ULIDs
+	// are time-ordered) so the default is deterministic and a later duplicate
+	// row can never win this lookup (JAB-174).
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("id ASC").First(&pool).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}

--- a/panel-api/internal/repository/php_pool_repository_test.go
+++ b/panel-api/internal/repository/php_pool_repository_test.go
@@ -106,7 +106,9 @@ func TestPHPPoolRepository_FindByUserID_Found(t *testing.T) {
 
 	repo := NewPHPPoolRepository(db)
 
-	mock.ExpectQuery("SELECT .* FROM `php_pools` WHERE user_id = \\?.*LIMIT").
+	// JAB-174: the default pool is the earliest row — the lookup must ORDER BY
+	// id ASC so a later duplicate can't win.
+	mock.ExpectQuery("SELECT .* FROM `php_pools` WHERE user_id = \\?.*ORDER BY .*id.* ASC.*LIMIT").
 		WithArgs("user1", 1).
 		WillReturnRows(sqlmock.NewRows(
 			[]string{"id", "user_id", "php_version", "pm_mode", "pm_max_children", "process_idle_timeout_seconds", "status", "last_error", "created_at", "updated_at"},


### PR DESCRIPTION
`FindByUserID` did `First()` with **no ORDER BY**, so on a user with more than one `php_pools` row it returned an arbitrary row — how `php pool get` and the reconciler could latch onto a **stale** pool. The default pool is by convention the **earliest-created** row (slug == username; `domain_php_pool.go` uses `pools[0]` the same way). Pin it with `ORDER BY id ASC` (ULIDs are time-ordered).

**Safe, no schema change** — only makes the existing "default = earliest" convention deterministic instead of relying on implicit PK order.

This is the no-risk slice of JAB-174. The substantive guard (see report): a `UNIQUE(user_id, php_version)` index — the correct invariant for the model the code actually implements (a default pool + separate per-version pools bound to domains, GH #329) — plus a dedup migration that **repoints domain bindings before retiring extras**, is a follow-up needing a schema migration + box verification.

Test: `FindByUserID_Found` asserts the query carries `ORDER BY id ASC`.