### PR TITLE
fix(php-pool): clean error when switching the default to an already-existing version (JAB-174)

### DIFF
--- a/panel-api/cmd/server/php_cmd.go
+++ b/panel-api/cmd/server/php_cmd.go
@@ -445,6 +445,22 @@ func newPHPPoolSetCmd() *cobra.Command {
 				}
 				created = true
 			} else {
+				// JAB-174: switching the default pool to a version the user
+				// ALREADY has as a separate per-version pool (per-domain
+				// binding, GH #329) would collide with uniq_user_phpver on the
+				// UPDATE below and surface as a raw duplicate-key error. Detect
+				// it and return an actionable message instead.
+				if pool.PHPVersion != version {
+					if other, ferr := repo.FindByUserAndVersion(ctx, u.ID, version); ferr == nil && other != nil && other.ID != pool.ID {
+						return fmt.Errorf(
+							"user %s already has a separate PHP %s pool (%s), likely bound to specific domains; "+
+								"the default pool can't switch to a version that already exists as its own pool. "+
+								"Delete that pool first (jabali php pool delete %s) or rebind its domains, then retry",
+							u.ID, version, other.ID, other.ID)
+					} else if ferr != nil && !errors.Is(ferr, repository.ErrNotFound) {
+						return fmt.Errorf("check existing pool for version %s: %w", version, ferr)
+					}
+				}
 				pool.PHPVersion = version
 				// Mark pending so the reconciler re-applies. Without this
 				// the pool stays `active`, and ReconcilePHPPools skips

--- a/panel-api/internal/api/domain_php_settings.go
+++ b/panel-api/internal/api/domain_php_settings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -250,6 +251,21 @@ func (h *domainPHPSettingsHandler) patch(c *gin.Context) {
 			return
 		}
 		if pool != nil && pool.PHPVersion != *req.PHPVersion {
+			// JAB-174: if the user already has a separate per-version pool for
+			// the target version (per-domain binding, GH #329), switching the
+			// default row to it collides with uniq_user_phpver → a raw 500.
+			// Return a clean, actionable 409 instead.
+			if other, ferr := h.cfg.PHPPools.FindByUserAndVersion(ctx, dom.UserID, *req.PHPVersion); ferr == nil && other != nil && other.ID != pool.ID {
+				c.JSON(http.StatusConflict, gin.H{
+					"error":  "version_pool_exists",
+					"detail": fmt.Sprintf("this user already has a separate PHP %s pool (bound to specific domains); delete it or rebind its domains before switching the default to %s", *req.PHPVersion, *req.PHPVersion),
+				})
+				return
+			} else if ferr != nil && !errors.Is(ferr, repository.ErrNotFound) {
+				slog.ErrorContext(ctx, "patch php-settings: check version pool", "error", ferr, "user_id", dom.UserID)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+				return
+			}
 			pool.PHPVersion = *req.PHPVersion
 			pool.Status = "pending"
 			if uerr := h.cfg.PHPPools.Update(ctx, pool); uerr != nil {


### PR DESCRIPTION
Last edge of JAB-174. The unique index `uniq_user_phpver(user_id, php_version)` (migration 000129) already prevents two pools of the same version per user. But the version-switch paths — CLI `jabali php pool set` and the domain PHP-settings API — update the **default** pool's `php_version` in place, which **collides** with that index when the user already has a **separate per-version pool** for the target version (per-domain binding, GH #329).

Before: raw `Error 1062 ... Duplicate entry '…-8.1' for key 'uniq_user_phpver'` (CLI) / a 500 (API).

## Fix
Detect the collision first (`FindByUserAndVersion`) and return an actionable message:
> user already has a separate PHP `<v>` pool (`<id>`) … delete it first (`jabali php pool delete <id>`) or rebind its domains, then retry

CLI → clean error; API → `409 version_pool_exists`.

## Box-verified on testserver
Throwaway user with a default `8.3` + a separate `8.1` pool, `php pool set --version 8.1`:
- **deployed binary** → `Error 1062 … Duplicate entry … uniq_user_phpver`
- **patched binary** → the clean actionable error

(Throwaway user cleaned up; pools cascaded.)

## JAB-174 status
- constraint (`uniq_user_phpver`) — already in (#129)
- `pool create` dup — rejected (#766)
- deterministic default lookup — (#780)
- **this** — the last switch-collision edge.