### PR TITLE
fix(migrate): Plesk/SSH wizard — secret-before-test, testconn timeout, clear key errors (GH #429)

### DIFF
--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -54,13 +54,20 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 		return
 	}
+	// GH #429: a slow source SSH handshake (e.g. sshd reverse-DNS stall) made
+	// test-connection exceed the server's 30s WriteTimeout, so the response was
+	// severed mid-flight and the SPA saw a generic Cloudflare 52x instead of the
+	// real error. Clear this request's write deadline so the handler always
+	// returns a clean JSON result/error within its own ctx, and bound that ctx
+	// well under the gateway's ~100s edge timeout.
+	_ = http.NewResponseController(c.Writer).SetWriteDeadline(time.Time{})
 	allowPrivate := false
 	if h.cfg.Settings != nil {
 		if st, sErr := h.cfg.Settings.Get(c.Request.Context()); sErr == nil && st != nil {
 			allowPrivate = st.MigrationAllowPrivateHosts
 		}
 	}
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 90*time.Second)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
 	defer cancel()
 	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
 

--- a/panel-api/internal/migrate/plesk/discover.go
+++ b/panel-api/internal/migrate/plesk/discover.go
@@ -153,9 +153,9 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		case "SSH_PASSWORD":
 			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
 		case "SSH_PRIVATE_KEY":
-			signer, perr := ssh.ParsePrivateKey([]byte(v))
+			signer, perr := parsePEMSigner([]byte(v))
 			if perr != nil {
-				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY: %w", perr)
+				return nil, fmt.Errorf("SSH_PRIVATE_KEY: %w", perr)
 			}
 			auths = append(auths, ssh.PublicKeys(signer))
 		case "SSH_PRIVATE_KEY_B64":
@@ -163,10 +163,10 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 			if derr != nil {
 				return nil, fmt.Errorf("base64-decode SSH_PRIVATE_KEY_B64: %w", derr)
 			}
-			signer, perr := ssh.ParsePrivateKey(pem)
+			signer, perr := parsePEMSigner(pem)
 			zero(pem)
 			if perr != nil {
-				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY_B64: %w", perr)
+				return nil, fmt.Errorf("SSH_PRIVATE_KEY_B64: %w", perr)
 			}
 			auths = append(auths, ssh.PublicKeys(signer))
 		}
@@ -175,6 +175,28 @@ func loadSecret(path string) ([]ssh.AuthMethod, error) {
 		return nil, errors.New("no SSH_PASSWORD / SSH_PRIVATE_KEY / SSH_PRIVATE_KEY_B64 in secret file")
 	}
 	return auths, nil
+}
+
+// parsePEMSigner parses an SSH private-key PEM into a Signer (GH #429). It
+// tolerates a CRLF-pasted key — a browser <textarea> often submits \r\n, which
+// corrupts the PEM base64 body and makes ssh.ParsePrivateKey fail even though
+// the key is valid — and returns a clear message for a passphrase-protected
+// key, which migrations (unattended) cannot decrypt.
+func parsePEMSigner(pem []byte) (ssh.Signer, error) {
+	norm := bytes.ReplaceAll(pem, []byte("\r\n"), []byte("\n"))
+	norm = bytes.ReplaceAll(norm, []byte("\r"), []byte("\n"))
+	if n := len(norm); n > 0 && norm[n-1] != '\n' {
+		norm = append(norm, '\n')
+	}
+	signer, err := ssh.ParsePrivateKey(norm)
+	if err != nil {
+		var pmErr *ssh.PassphraseMissingError
+		if errors.As(err, &pmErr) {
+			return nil, errors.New("the private key is passphrase-protected; migrations run unattended and need an UNENCRYPTED key (strip the passphrase with: ssh-keygen -p -f <keyfile>)")
+		}
+		return nil, fmt.Errorf("not a valid SSH private key (%w); paste the full PEM including the BEGIN/END lines", err)
+	}
+	return signer, nil
 }
 
 func zero(b []byte) {

--- a/panel-api/internal/migrate/plesk/parse_key_test.go
+++ b/panel-api/internal/migrate/plesk/parse_key_test.go
@@ -1,0 +1,42 @@
+package plesk
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// GH #429: a private key pasted from a browser textarea often arrives CRLF, and
+// ssh.ParsePrivateKey fails on that even though the key is valid — the reporter's
+// "publickey rejected" class. parsePEMSigner must normalize CRLF and still parse.
+func TestParsePEMSigner_ToleratesCRLF(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lf := pem.EncodeToMemory(block)
+
+	// LF (baseline) must parse.
+	if _, err := parsePEMSigner(lf); err != nil {
+		t.Fatalf("LF key should parse: %v", err)
+	}
+	// CRLF (textarea paste) must ALSO parse after normalization.
+	crlf := bytes.ReplaceAll(lf, []byte("\n"), []byte("\r\n"))
+	if _, err := parsePEMSigner(crlf); err != nil {
+		t.Fatalf("CRLF key should parse after normalization: %v", err)
+	}
+}
+
+func TestParsePEMSigner_RejectsGarbageClearly(t *testing.T) {
+	if _, err := parsePEMSigner([]byte("not a key")); err == nil {
+		t.Fatal("garbage should be rejected")
+	}
+}

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -19,6 +19,7 @@ import {
   Upload,
   message,
 } from "antd";
+import type { FormInstance } from "antd";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -196,17 +197,39 @@ function SecretsStep({ jobId, kind, onDone }: { jobId: string; kind?: string; on
       <Button type="primary" htmlType="submit" loading={mut.isPending}>
         Save credentials
       </Button>
-      <TestConnection jobId={jobId} />
+      <TestConnection jobId={jobId} form={form} credKind={credKind} />
     </Form>
   );
 }
 
 // TestConnection (GH #665 mockup 03) — handshake the source, show detected
 // counts/version or the error, before pulling.
-function TestConnection({ jobId }: { jobId: string }) {
+function TestConnection({
+  jobId,
+  form,
+  credKind,
+}: {
+  jobId: string;
+  form: FormInstance<SecretsInput>;
+  credKind: "password" | "key";
+}) {
   const [res, setRes] = useState<Record<string, unknown> | null>(null);
   const mut = useMutation({
     mutationFn: async () => {
+      // GH #429: test-connection reads the ON-DISK secret, so testing before
+      // "Save credentials" failed "secret missing". Upload the credential the
+      // operator just typed FIRST, then test.
+      const vals = form.getFieldsValue();
+      const cred =
+        credKind === "password" ? vals.ssh_password?.trim() : vals.ssh_private_key?.trim();
+      if (!cred) {
+        throw new Error(
+          credKind === "password" ? "Enter the SSH password first" : "Paste the SSH private key first",
+        );
+      }
+      await apiClient.post(`/admin/migrations/${jobId}/secrets`, {
+        [credKind === "password" ? "ssh_password" : "ssh_private_key"]: cred,
+      });
       const { data } = await apiClient.post<Record<string, unknown>>(
         `/admin/migrations/${jobId}/test-connection`,
         {},
@@ -216,7 +239,8 @@ function TestConnection({ jobId }: { jobId: string }) {
     onSuccess: (d) => setRes(d),
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      setRes({ ok: false, error: detail?.detail ?? detail?.error ?? "Connection failed" });
+      const local = err instanceof Error ? err.message : undefined;
+      setRes({ ok: false, error: detail?.detail ?? detail?.error ?? local ?? "Connection failed" });
     },
   });
   return (


### PR DESCRIPTION
Reproduced lxsdevcode's reports live against a real Plesk source + a jabali dest. `pull-source` itself is correct (custom port + SSH key both work); every bug is in the connect / secret-upload flow.

## Fixes
- **2a — "secret missing" on Test Connection** (`CreateMigrationDrawer.tsx`): the button POSTed `/test-connection` (reads the on-disk secret) *before* the operator's credential was saved. Now uploads the typed credential first, then tests (save-then-test); clear message when the field is empty.
- **2c — "Cloudflare invalid response"** (`admin_migrations_testconn.go`): a slow source SSH handshake ran past the server's 30s WriteTimeout → response severed → generic 52x. Clear the request write deadline so the handler always returns clean JSON; bound ctx to 45s (under the ~100s gateway edge).
- **2b — key handling** (`plesk/discover.go`): passphrase-protected key now returns an actionable error ("strip the passphrase with `ssh-keygen -p`") instead of a raw parse failure; `parsePEMSigner` normalizes CRLF defensively. (Box-verified Go's `ParsePrivateKey` already tolerates CRLF — so the reporter's "server rejected publickey" is most likely a passphrase key or a key absent from the source's `authorized_keys`, i.e. user-side; the existing handshake error already says so.)
- **1 — custom SSH port**: already fixed on current main; verified live (`pull-source` connected on custom port 2222). Reporter hit it on an older build.

## Verified
`pull-source` connected + pulled + extracted from the live Plesk source on custom port 2222 with an SSH key; `parse_key_test` (CRLF tolerance + clear reject); `go build`/`vet`/`test` + `tsc` clean.

Closes nothing automatically — leaving #429 open for reporter confirmation.