### PR TITLE
fix(install): use the release's prebuilt binaries instead of compiling on the box (GH #731)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -104,10 +104,28 @@ actual="$(sha256sum "$tmp/release.tar.gz" | awk '{print $1}')"
 [[ "$expected" == "$actual" ]] || die "checksum mismatch (expected $expected, got $actual)"
 log "checksum verified"
 
-# Extract only what the bootstrap needs.
-tar -C "$tmp" -xzf "$tmp/release.tar.gz" bin/jabali-installer install.sh \
-  || die "release tarball is missing bin/jabali-installer or install.sh (rebuild the release)"
-chmod +x "$tmp/bin/jabali-installer"
+# Extract the whole bin/ — not just the installer. GH #731: the tarball already
+# contains compiled jabali-panel / jabali-agent / jabali-ssh-shell /
+# jabali-mailhook, and jabali-panel has the built SPA embedded. Handing those to
+# install.sh lets it skip `npm ci` + `vite build` + four `go build`s, which is
+# what OOM-kills a 2 GB VPS. We used to extract two files and then recompile
+# everything we had just downloaded.
+tar -C "$tmp" -xzf "$tmp/release.tar.gz" bin install.sh \
+  || die "release tarball is missing bin/ or install.sh (rebuild the release)"
+[[ -x "$tmp/bin/jabali-installer" ]] || chmod +x "$tmp/bin/jabali-installer" 2>/dev/null || true
+[[ -f "$tmp/bin/jabali-installer" ]] \
+  || die "release tarball is missing bin/jabali-installer (rebuild the release)"
+chmod +x "$tmp/bin"/* 2>/dev/null || true
+
+# MANIFEST carries the release short_sha so the installed binary reports the
+# commit it was actually built from. Optional: older tarballs predate it, and
+# install.sh falls back to a source build if anything here is missing.
+manifest=""
+tar -C "$tmp" -xzf "$tmp/release.tar.gz" MANIFEST 2>/dev/null && manifest="$tmp/MANIFEST"
 
 log "launching installer"
-exec env JABALI_INSTALL_SH="$tmp/install.sh" "$tmp/bin/jabali-installer" "$@"
+exec env \
+  JABALI_INSTALL_SH="$tmp/install.sh" \
+  JABALI_PREBUILT_BIN="$tmp/bin" \
+  JABALI_RELEASE_MANIFEST="$manifest" \
+  "$tmp/bin/jabali-installer" "$@"

--- a/install.sh
+++ b/install.sh
@@ -4753,7 +4753,47 @@ _deploy_profile() {
   [ -r "$f" ] && tr -d "[:space:]" < "$f" 2>/dev/null || true
 }
 
+# GH #731: the release tarball already ships compiled linux/amd64 binaries, and
+# jabali-panel embeds the built SPA (//go:embed all:dist in panel-ui/embed.go).
+# bootstrap.sh hands us their directory in JABALI_PREBUILT_BIN. Using them lets a
+# small host skip `npm ci` + `vite build` + four `go build`s entirely — the vite
+# step alone is what OOM-kills 2 GB VPSes (see ensure_swap's own warning), and
+# ensure_swap soft-returns 0 on containerized hosts where swapon is blocked, so
+# on those there is no swap to save it.
+#
+# Fail-SAFE by design: any doubt returns non-zero and we build from source, which
+# is exactly what every existing host already does. The smoke test runs the real
+# binary, because a truncated download or corrupt tarball would otherwise only
+# surface at first boot.
+_prebuilt_ready() {
+  local d="${JABALI_PREBUILT_BIN:-}"
+  [[ -n "$d" && -d "$d" ]] || return 1
+  local b
+  for b in jabali-panel jabali-agent jabali-ssh-shell jabali-mailhook; do
+    [[ -s "$d/$b" && -x "$d/$b" ]] || return 1
+  done
+  "$d/jabali-panel" version >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# _prebuilt_version reads the release short SHA from the tarball MANIFEST, so the
+# installed binary reports the commit it was actually built from. The git clone
+# can sit on a newer commit than the release, so rev-parse would lie here.
+_prebuilt_version() {
+  local mf="${JABALI_RELEASE_MANIFEST:-}"
+  if [[ -n "$mf" && -r "$mf" ]]; then
+    local v
+    v="$(awk -F= '/^short_sha=/{print $2; exit}' "$mf" 2>/dev/null)"
+    [[ -n "$v" ]] && { printf '%s' "$v"; return 0; }
+  fi
+  printf 'prebuilt'
+}
+
 build_frontend() {
+  if _prebuilt_ready; then
+    _ok "prebuilt release binaries present — skipping npm ci + vite build (the SPA is already embedded in jabali-panel)"
+    return 0
+  fi
   ensure_swap
   _log "building panel-ui (npm ci + npm run build)"
   # npm ci needs lock + no partial node_modules. Run as the service user so
@@ -4850,6 +4890,14 @@ build_backend() {
   local version full_sha btime
   version="$(sudo -u "$SERVICE_USER" -H git -C "$REPO_DIR" rev-parse --short HEAD)"
   full_sha="$(sudo -u "$SERVICE_USER" -H git -C "$REPO_DIR" rev-parse HEAD)"
+  # GH #731: with prebuilt binaries the version must come from the release, not
+  # from the clone -- the clone tracks the branch and can already be ahead of the
+  # tarball, which would make `jabali version` report a commit the running binary
+  # was never built from.
+  if _prebuilt_ready; then
+    version="$(_prebuilt_version)"
+    full_sha="$version"
+  fi
   btime="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   install -d -m 0755 -o "$SERVICE_USER" -g "$SERVICE_USER" "$REPO_DIR/bin"
@@ -4886,18 +4934,29 @@ build_backend() {
     fi
     _log "build-backend: low-RAM host (${mem_mb_be}MB) → serialize go build ($go_lowmem)"
   fi
-  # One invocation of go, three binaries — shared module, shared build cache.
-  sudo -u "$SERVICE_USER" -H env \
-    PATH="$GO_ROOT/bin:/usr/bin:/bin" \
-    HOME="$REPO_DIR" \
-    GOCACHE="$REPO_DIR/.cache/go-build" \
-    GOMODCACHE="$REPO_DIR/.cache/go-mod" \
-    $go_lowmem \
-    bash -c "cd '$REPO_DIR' && \
-      go build -trimpath $panel_tags -ldflags '$panel_ld' -o '$tmp_panel' ./panel-api/cmd/server && \
-      go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_agent' ./panel-agent/cmd/jabali-agent && \
-      go build -trimpath -ldflags '-s -w' -o '$tmp_sshshell' ./panel-agent/cmd/jabali-ssh-shell && \
-      go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_mailhook' ./panel-agent/cmd/jabali-mailhook"
+  if _prebuilt_ready; then
+    # GH #731: copy the release binaries into the same .new paths the source
+    # build would have produced, so every step below -- install, backup pruning,
+    # catalog sync, wp-plugin bundling, the `jabali` symlink -- runs unchanged.
+    _log "installing prebuilt release binaries (version=$version) — no on-box compile"
+    install -m 0755 "$JABALI_PREBUILT_BIN/jabali-panel"     "$tmp_panel"
+    install -m 0755 "$JABALI_PREBUILT_BIN/jabali-agent"     "$tmp_agent"
+    install -m 0755 "$JABALI_PREBUILT_BIN/jabali-ssh-shell" "$tmp_sshshell"
+    install -m 0755 "$JABALI_PREBUILT_BIN/jabali-mailhook"  "$tmp_mailhook"
+  else
+    # One invocation of go, three binaries — shared module, shared build cache.
+    sudo -u "$SERVICE_USER" -H env \
+      PATH="$GO_ROOT/bin:/usr/bin:/bin" \
+      HOME="$REPO_DIR" \
+      GOCACHE="$REPO_DIR/.cache/go-build" \
+      GOMODCACHE="$REPO_DIR/.cache/go-mod" \
+      $go_lowmem \
+      bash -c "cd '$REPO_DIR' && \
+        go build -trimpath $panel_tags -ldflags '$panel_ld' -o '$tmp_panel' ./panel-api/cmd/server && \
+        go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_agent' ./panel-agent/cmd/jabali-agent && \
+        go build -trimpath -ldflags '-s -w' -o '$tmp_sshshell' ./panel-agent/cmd/jabali-ssh-shell && \
+        go build -trimpath -ldflags '-s -w -X main.version=$version' -o '$tmp_mailhook' ./panel-agent/cmd/jabali-mailhook"
+  fi
 
   install -m 0755 "$tmp_panel" "$BIN_PATH"
   install -m 0755 "$tmp_agent" "$AGENT_BIN_PATH"


### PR DESCRIPTION
Closes the OOM half of GH #731.

## The actual problem

A 2 GB host OOMs on fresh install. It never needed to build anything.

`tools/build-release.sh` puts compiled `jabali-panel`, `jabali-agent`, `jabali-ssh-shell` and `jabali-mailhook` in the release tarball, and `jabali-panel` has the built SPA embedded via `//go:embed all:dist`. But `bootstrap.sh` extracted two files:

```
tar -C "$tmp" -xzf release.tar.gz bin/jabali-installer install.sh
```

…threw the rest away, and `install.sh` then git-cloned the repo and recompiled everything we'd just downloaded — `npm ci`, `vite build`, and four `go build`s. The vite step is what kills the box; `ensure_swap`'s own warning says so, and it soft-returns 0 on containerized hosts where `swapon` is blocked, so there's often no swap to save it.

## Why this shape

`jabali update` already reached this conclusion. From `update_release.go`:

> None of that work is per-host: the binaries produced are byte-identical regardless of where they were built, and panel-ui/dist is embedded into jabali-panel via //go:embed.

Fresh install was the one path still doing it the old way. This applies the existing policy rather than inventing one.

## Changes

- **`bootstrap.sh`** extracts the whole `bin/` plus `MANIFEST`, and passes `JABALI_PREBUILT_BIN` + `JABALI_RELEASE_MANIFEST`. Both installer entry points already use `os.Environ()`, so there is no Go-side change.
- **`build_frontend`** returns early — the SPA is already inside the binary.
- **`build_backend`** copies the release binaries into the same `.new` paths the compile would have produced, so install, backup pruning, `sync_app_catalogs`, wp-plugin bundling and the `jabali` symlink all run untouched.

Version comes from `MANIFEST`, not `git rev-parse`. The clone tracks the branch and can already sit ahead of the release, so rev-parse would make `jabali version` report a commit the running binary was never built from.

## Fail-safe

Any doubt falls back to the source build — i.e. exactly what every existing host does today. Verified all eight paths:

```
1 no env var .................. source-build
2 empty dir ................... source-build
3 all four present + runnable .. PREBUILT
4 one not executable .......... source-build
5 zero-byte panel binary ...... source-build
6 panel binary fails to run ... source-build
7 one binary missing .......... source-build
8 restored .................... PREBUILT
```

The smoke test runs the real binary, so a truncated download or corrupt tarball is caught here rather than at first boot.

## Verified against the live release

Not a mock — the actual published tarball, using the patched extract logic:

```
extract: OK
bin/: jabali-agent jabali-installer jabali-mailhook jabali-panel jabali-ssh-shell
short_sha: ff9eb92dd

$ bin/jabali-panel version
version:     ff9eb92dd
commit:      ff9eb92dd8608e7dd896dbf7caf124e426ddef98
build_time:  2026-07-31T14:35:18Z
go_version:  go1.25.12

detector -> ACCEPTED (skips compile), version -> ff9eb92dd
```

MANIFEST `short_sha` matches what the binary reports, which is the case rev-parse would have got wrong.

`bash -n` clean on both scripts, `tools/lint-install-sh.sh` passing.

## Review notes

**This touches the fresh-install path, so it deserves a real box run before merge** — ideally a 2 GB host, which is the whole point. I've exercised the logic and the artifact handling, but not a full end-to-end install.

The git clone stays: `install.sh` still needs the nginx/php/apparmor templates and migrations. Cloning doesn't OOM; compiling does.

Follow-up worth considering separately: on the prebuilt path the Go toolchain and node are still installed and never used. Dropping that saves bandwidth and disk on small hosts, but it touches shared dependency ordering, so it shouldn't ride along here.
