### PR TITLE
deps: bump Stalwart to 0.16.15 for the scoped-credential privilege escalation (GH #625)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10824,7 +10824,7 @@ install_notify_template() {
 # STALWART_VERSION is the single pin for the Stalwart Mail server binary,
 # consumed by both install_stalwart (fresh install) and upgrade_stalwart_binary
 # (the jabali update path). Bump here + install/stalwart.sha256 together.
-STALWART_VERSION="0.16.14"
+STALWART_VERSION="0.16.15"
 
 # upgrade_stalwart_binary is the jabali-update entry point for the Stalwart
 # server binary (GH #525). install.sh's full install_stalwart runs on fresh

--- a/install/stalwart.sha256
+++ b/install/stalwart.sha256
@@ -1,9 +1,15 @@
-# Stalwart Mail Server v0.16.14 SHA-256 checksum for stalwart-x86_64-unknown-linux-gnu.tar.gz
-# Source: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.14
-# Captured 2026-07-21 directly from the GitHub release artifact (GH #525;
-# bumped past the requested 0.16.13 to the latest stable 0.16.14). Both
-# releases are drop-in binary replacements from v0.16.x (bugfix-only; no
-# config/JMAP-management changes per upstream notes).
+# Stalwart Mail Server v0.16.15 SHA-256 checksum for stalwart-x86_64-unknown-linux-gnu.tar.gz
+# Source: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.15
+# Captured 2026-07-31 directly from the GitHub release artifact (GH #625).
+# 0.16.15 is a drop-in binary replacement from v0.16.x -- upstream says
+# "replace the binary" for any 0.16.x, no config/JMAP-management migration.
+#
+# Taken for a SECURITY fix, not routine currency: upstream 0.16.15 fixes
+# "Scoped credentials with SysApiKeyCreate or SysApiKeyUpdate permissions can
+# regain its own account's full rights" -- a privilege escalation out of a
+# scoped API key. It also stops encrypting appended messages for accounts that
+# never opted into encryptOnAppend, and fixes an MTA panic when MTA-STS is
+# disabled and a remote MTA fetches /.well-known/mta-sts.txt.
 #
 # Stalwart v0.16.x replaced its REST API with a JMAP management API
 # (see ADR-0041 + plan #1). SQL directory is supported against MariaDB
@@ -13,4 +19,4 @@
 #   curl -sSL https://github.com/stalwartlabs/stalwart/releases/download/v<x.y.z>/stalwart-x86_64-unknown-linux-gnu.tar.gz | sha256sum
 # install.sh `_die`s if the placeholder PLACEHOLDER_CAPTURE_ON_FIRST_DEPLOY
 # survives — matches the DokuWiki/MediaWiki tarball precedent.
-05da156fc7a13ffc7ffc940013d12f0d7b7ba935a66bd73af7696dac7db82a98  stalwart-x86_64-unknown-linux-gnu.tar.gz
+6f23c6217f0f9710bafde889b7efbc349c7cfa613c4b14b8b365245799373676  stalwart-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
Security bump for Stalwart, plus a status correction on GH #625.

## The bump

Stalwart `0.16.14` → `0.16.15`. Upstream fixes:

> **Auth:** Scoped credentials with `SysApiKeyCreate` or `SysApiKeyUpdate` permissions can regain its own account's full rights.

That's a privilege escalation out of a scoped API key, so this is a security bump rather than routine currency. The same release also stops encrypting appended messages for accounts that never opted into `encryptOnAppend`, and fixes an MTA panic when MTA-STS is disabled and a remote MTA fetches `/.well-known/mta-sts.txt`.

Drop-in within 0.16.x — upstream's upgrade note for any 0.16.x is "replace the binary", no config or JMAP-management migration. Pin and checksum move together as `install.sh` requires, and the SHA-256 was captured with the exact command the sidecar documents.

## GH #625 is already done — the issue is stale

It was auto-generated 2026-07-23. Every item in it has since landed:

| pin | issue said | on main now |
|---|---|---|
| `stalwart-cli` | 1.0.8 → 1.0.11 | **1.0.11** ✅ |
| `bulwark` | 1.7.7 → 1.7.8 | **1.7.8** ✅ |
| `lmd` | 2.0.1-rc4 → 2.0.1 | **2.0.1** ✅ |
| `yara-x` | 1.17.0 → 1.19.0 | **1.19.0** ✅ |

The Go-module list is stale too — `go.mod` already carries gin 1.12.0, crypto 0.54.0, go-redis 9.21.0, gorm 1.31.2.

So I re-checked all nine pins against upstream today rather than working the issue's list. Everything is current except the two below.

## stalwart-cli 1.0.12 — deliberately NOT bumped

1.0.12 is available but carries breaking `apply` semantics, and one of them is genuinely dangerous:

> **Breaking:** `apply` now rejects any unrecognised top-level key in a plan operation instead of ignoring it.
>
> `reconcile` on a multi-variant type now converges the whole type, not only the variants named in the plan; use `scope` to narrow it.

I checked our exposure. The `reconcile` change does **not** affect us — jabali emits no `reconcile` or `upsert` ops, and `install.sh` says so itself: *"stalwart-cli apply is create-only and cannot delete or replace them."*

The strict unknown-key rejection is the real risk: any key in our rendered plan that 1.0.12 doesn't recognise now hard-fails `apply` instead of being ignored, which would break mail setup during install. That needs the rendered plan validated against 1.0.12 before bumping, and it shouldn't ride along with a security fix. Worth its own PR.

## Not yet verified on a box

Mail is high blast radius and the test VM is being rebuilt. Before merge this wants an install plus a send/receive round-trip. I've done the pin and checksum work; I haven't run it.
