### PR TITLE
fix(webmail): hide the dead 2FA login toggle and the version footer (GH #316)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12205,6 +12205,17 @@ _install_bulwark_impersonate_secrets() {
   local tmp
   tmp=$(mktemp)
   grep -v -E '^(BULWARK_JWT_AUTH_SECRET|BULWARK_STALWART_MASTER_USER|BULWARK_STALWART_MASTER_PASSWORD|BULWARK_JWT_AUTH_ISSUER)=' "$bulwark_env" > "$tmp" || true
+  # Trim trailing blank lines off the PRESERVED portion before appending. The
+  # heredoc below opens with a blank separator and `grep -v` strips only the
+  # managed KEYS, never blanks -- so every run left one more blank line sitting
+  # between the operator's own keys and our block. The sha therefore never
+  # matched, the "already in sync" fast path below never fired, and bulwark.env
+  # was rewritten (and grew a byte) on every install.sh / jabali update.
+  # $(< file) drops trailing newlines; printf puts exactly one back. Guarded so
+  # an empty preserved portion stays empty rather than becoming a blank line.
+  if [[ -s "$tmp" ]]; then
+    printf '%s\n' "$(< "$tmp")" > "${tmp}.norm" && mv "${tmp}.norm" "$tmp"
+  fi
   cat >> "$tmp" <<EOF
 
 # M6.6 — webmail SSO via GET /api/auth/impersonate (Bulwark 1.7.1+).
@@ -12218,6 +12229,32 @@ BULWARK_STALWART_MASTER_USER=admin
 BULWARK_STALWART_MASTER_PASSWORD=${master_pw}
 BULWARK_JWT_AUTH_ISSUER=jabali-panel/webmail-sso
 EOF
+
+  # Login-form flags (Bulwark >=1.7.8, bulwarkmail/webmail#520). Unlike the
+  # secrets above these are DEFAULTS, not managed values: seeded only when
+  # absent, so an operator who deliberately sets either one keeps their choice
+  # across install.sh and every jabali update.
+  #
+  # LOGIN_SHOW_TOTP — GH #316. Jabali runs Stalwart against an EXTERNAL SQL
+  # directory (accounts live in the panel DB, read-only), and Stalwart only
+  # enforces MFA for INTERNAL-directory accounts:
+  # crates/common/src/auth/authentication.rs calls verify_mfa_secret_hash() on
+  # that path alone. Our mailboxes therefore have no per-account TOTP and the
+  # manual toggle can never succeed -- it offers a 2FA flow that silently does
+  # nothing, which is worse than offering none. Server-REQUIRED TOTP is
+  # unaffected: the field still auto-shows when the server returns
+  # totp_required. Revisit if Stalwart gains external-directory MFA:
+  # https://support.stalw.art/t/enforce-totp-2fa-for-external-directory-sql-ldap-accounts/1003
+  #
+  # LOGIN_SHOW_VERSION — the footer prints the exact Bulwark build version to
+  # UNAUTHENTICATED visitors, handing a scanner the version to match CVEs
+  # against.
+  if ! grep -q '^LOGIN_SHOW_TOTP=' "$tmp"; then
+    printf 'LOGIN_SHOW_TOTP=false\n' >> "$tmp"
+  fi
+  if ! grep -q '^LOGIN_SHOW_VERSION=' "$tmp"; then
+    printf 'LOGIN_SHOW_VERSION=false\n' >> "$tmp"
+  fi
 
   local new_sha old_sha
   new_sha=$(sha256sum "$tmp" | awk '{print $1}')


### PR DESCRIPTION
Picks up the outstanding jabali-side action from GH #316 — *"hide/disable that toggle so it stops presenting a flow that can't work."*

Bulwark **1.7.8** added the flag for it (bulwarkmail/webmail#520), and we already pin 1.7.8, so this is two lines of config rather than an upstream wait.

## `LOGIN_SHOW_TOTP=false`

The #316 investigation established that jabali runs Stalwart against an **external SQL directory** (accounts live in the panel DB, read-only), and Stalwart only enforces MFA for **internal**-directory accounts — `crates/common/src/auth/authentication.rs` calls `verify_mfa_secret_hash()` on that path alone. Our mailboxes have no per-account TOTP, so the manual *"I have a 2FA code"* toggle can never succeed.

Upstream describes precisely this shape in #520:

> when Bulwark's mail server delegates auth to an external directory (LDAP/OIDC) and 2FA lives in the upstream IdP, the server has no per-account TOTP. The manual toggle then only ever leads to a failed login — dead, confusing UI.

This matters beyond tidiness: a user can come away believing their mailbox is protected by 2FA when nothing is enforcing it. A security control that appears to be on and isn't is worse than one that's plainly absent.

Server-*required* TOTP is unaffected — the field still auto-shows when the server returns `totp_required`.

## `LOGIN_SHOW_VERSION=false`

Unrelated to #316, but it's one line in the same file and both flags default to `true` upstream, so we were shipping both. The login footer printed the exact Bulwark build version to **unauthenticated** visitors, which hands a scanner the version to match CVEs against.

## Defaults, not managed values

The two flags are appended **only when absent**, so an operator who deliberately sets either one keeps their choice across `install.sh` and every `jabali update`. The `BULWARK_*` secrets above keep their existing strip-and-rewrite behaviour — those are ours to own; a UX/policy flag isn't.

## Pre-existing bug fixed along the way

Writing the idempotency test surfaced this: the heredoc opens with a blank separator and `grep -v` strips only the managed **keys**, never blanks. So every run left one more blank line between the operator's keys and our block, the sha never matched, the `"already in sync"` fast path could never fire, and `bulwark.env` was rewritten — growing a byte — on *every* `install.sh` and `jabali update`.

The preserved portion is now trailing-trimmed before the append. Verified over repeated renders:

```
A: existing operator key   run1 rewritten, run2 rewritten, run3 in-sync, run4 in-sync
B: empty file (fresh)      converges, single copy of each key
C: operator set TOTP=true  SURVIVES  -> LOGIN_SHOW_TOTP=true, other keys intact
D: rotated master password picked up correctly
```

## Scope

This does **not** make mailbox TOTP work. That needs external-directory MFA in Stalwart ([upstream request](https://support.stalw.art/t/enforce-totp-2fa-for-external-directory-sql-ldap-accounts/1003), linked in the code comment). It removes the flow that pretends it does, which is the part we control.

Config-only, no box run needed to review — though a webmail login page check after deploy would confirm both flags land.
