### PR TITLE
feat(migrate): rewrite ITFlow config.php DB credentials on migration (GH #723)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1410,8 +1410,8 @@ func cpanelRestoreCallback(
 				warnings = append(warnings, fmt.Sprintf("appconfigs: %v", aerr))
 			} else {
 				warnings = append(warnings, fmt.Sprintf(
-					"appconfigs: wordpress=%d joomla=%d drupal=%d magento=%d caches_cleared=%d php_ini_fixed=%d",
-					appRes.WordPress, appRes.Joomla, appRes.Drupal, appRes.Magento, appRes.CachesCleared, appRes.PhpIniFixed))
+					"appconfigs: wordpress=%d joomla=%d drupal=%d magento=%d itflow=%d caches_cleared=%d php_ini_fixed=%d",
+					appRes.WordPress, appRes.Joomla, appRes.Drupal, appRes.Magento, appRes.ITFlow, appRes.CachesCleared, appRes.PhpIniFixed))
 				warnings = append(warnings, appRes.Skipped...)
 			}
 		} else {

--- a/panel-api/internal/migrate/cpanel/restore_appconfigs.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs.go
@@ -12,6 +12,7 @@
 //   configuration.php    — Joomla public $db, $user, $password
 //   sites/default/settings.php — Drupal databases array
 //   app/etc/env.php      — Magento 2 'db' => ['connection' => ...]
+//   config.php           — ITFlow $dbhost / $dbusername / $dbpassword / $database
 //
 // Strategy: read file content, regex-replace the value (preserving
 // surrounding syntax), write back. If a single file matches more
@@ -40,6 +41,7 @@ type AppConfigsResult struct {
 	Joomla        int      // configuration.php files rewritten
 	Drupal        int      // settings.php files rewritten
 	Magento       int      // app/etc/env.php files rewritten
+	ITFlow        int      // config.php files rewritten
 	CachesCleared int      // cache directories wiped (WP Rocket / LiteSpeed / W3TC / Joomla / Drupal etc.)
 	PhpIniFixed   int      // php.ini/.user.ini files whose out-of-jail path directives were neutralized
 	Skipped       []string // human-readable reasons (file unreadable, no match, etc.)
@@ -113,6 +115,16 @@ func ImportAppConfigs(
 		magento := filepath.Join(docroot, "app", "etc", "env.php")
 		if n, sk := rewriteOne(ctx, agentCli, targetUserID, targetUsername, magento, creds, rewriteMagento); n > 0 {
 			res.Magento += n
+		} else if sk != "" {
+			res.Skipped = append(res.Skipped, sk)
+		}
+
+		// ITFlow (GH #723). config.php is a very common filename, so
+		// rewriteITFlow refuses anything without ITFlow's own signature —
+		// see the guard there.
+		itflow := filepath.Join(docroot, "config.php")
+		if n, sk := rewriteOne(ctx, agentCli, targetUserID, targetUsername, itflow, creds, rewriteITFlow); n > 0 {
+			res.ITFlow += n
 		} else if sk != "" {
 			res.Skipped = append(res.Skipped, sk)
 		}
@@ -367,6 +379,70 @@ func rewriteJoomla(text string, creds map[string]DBCredential) (string, bool) {
 			return fmt.Sprintf("public $password = '%s';", phpEscape(cred.Password))
 		case "host":
 			return "public $host = 'localhost';"
+		}
+		return line
+	})
+	return out, out != text
+}
+
+var (
+	// itflowAssignRe matches ITFlow's config.php lines. Its setup writes them
+	// with var_export(), i.e. single-quoted, but accept double quotes too since
+	// operators hand-edit this file.
+	itflowAssignRe = regexp.MustCompile(`(?m)^\s*\$(dbhost|dbusername|dbpassword|database)\s*=\s*['"]([^'"]*)['"]\s*;`)
+
+	// itflowSignatureRe is the guard. "config.php" is one of the most common
+	// filenames in PHP hosting, and a false positive here would corrupt an
+	// unrelated app's config. ITFlow's setup always emits this connect line
+	// verbatim right after the four assignments, so requiring it means we only
+	// touch files ITFlow itself wrote.
+	itflowSignatureRe = regexp.MustCompile(`mysqli_connect\s*\(\s*\$dbhost\s*,\s*\$dbusername\s*,\s*\$dbpassword\s*,\s*\$database\s*\)`)
+)
+
+// rewriteITFlow points an ITFlow config.php at the destination credentials
+// (GH #723). Jabali ships an ITFlow installer, so a migrated ITFlow site left
+// on the source's DB name — which no longer exists once jabali namespaces it —
+// is a site that simply doesn't load.
+//
+// Mirrors rewriteJoomla: match the source DB name to pick the right credential
+// on a multi-database account, falling back to the sole credential when there
+// is exactly one.
+func rewriteITFlow(text string, creds map[string]DBCredential) (string, bool) {
+	// Guard first: never rewrite a config.php that isn't ITFlow's.
+	if !itflowSignatureRe.MatchString(text) {
+		return text, false
+	}
+	if !itflowAssignRe.MatchString(text) {
+		return text, false
+	}
+	var sourceDB string
+	for _, m := range itflowAssignRe.FindAllStringSubmatch(text, -1) {
+		if m[1] == "database" {
+			sourceDB = m[2]
+			break
+		}
+	}
+	cred, ok := creds[sourceDB]
+	if !ok && len(creds) == 1 {
+		for _, c := range creds {
+			cred = c
+			ok = true
+		}
+	}
+	if !ok {
+		return text, false
+	}
+	out := itflowAssignRe.ReplaceAllStringFunc(text, func(line string) string {
+		m := itflowAssignRe.FindStringSubmatch(line)
+		switch m[1] {
+		case "database":
+			return fmt.Sprintf("$database = '%s';", phpEscape(cred.DBName))
+		case "dbusername":
+			return fmt.Sprintf("$dbusername = '%s';", phpEscape(cred.DBUser))
+		case "dbpassword":
+			return fmt.Sprintf("$dbpassword = '%s';", phpEscape(cred.Password))
+		case "dbhost":
+			return "$dbhost = 'localhost';"
 		}
 		return line
 	})

--- a/panel-api/internal/migrate/cpanel/restore_appconfigs_itflow_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs_itflow_test.go
@@ -1,0 +1,143 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #723 follow-up. The original report was answered with a caveat:
+//
+//	"your itFlow site uses config.php (not a wp-config.php-style file), which
+//	 jabali doesn't auto-rewrite yet — after migrating you may need to update
+//	 its DB name/user/password by hand."
+//
+// That gap is worth closing rather than documenting: jabali ships an ITFlow
+// installer, and jabali always namespaces databases to <account>_<name>, so a
+// migrated ITFlow site is left pointing at a DB that no longer exists — the
+// site simply doesn't load.
+//
+// The shape below is what ITFlow's own scripts/setup_cli.php emits at the
+// commit we pin (itflowMasterPinnedCommit): var_export()'d single-quoted
+// values followed by the mysqli_connect line.
+const itflowConfigPHP = `<?php
+$dbhost = 'localhost';
+$dbusername = 'notary_itflow';
+$dbpassword = 'sourcepw123';
+$database = 'notary_itflow';
+$mysqli = mysqli_connect($dbhost, $dbusername, $dbpassword, $database) or die('Database Connection Failed');
+`
+
+// Same multi-database account as the GH #723 WordPress test — johnnyq's real
+// HestiaCP backup carries BOTH notary_45635 (WordPress) and notary_itflow.
+// Credentials are keyed by SOURCE db name, per the #723 fix.
+func itflowCreds() map[string]DBCredential {
+	return map[string]DBCredential{
+		"notary_45635":  {DBName: "johnnyq_45635", DBUser: "johnnyq_45635", Password: "PANELPW_45635"},
+		"notary_itflow": {DBName: "johnnyq_itflow", DBUser: "johnnyq_itflow", Password: "PANELPW_ITFLOW"},
+	}
+}
+
+func TestRewriteITFlow_MultiDBPicksItsOwnCredential(t *testing.T) {
+	out, changed := rewriteITFlow(itflowConfigPHP, itflowCreds())
+	if !changed {
+		t.Fatal("itflow config.php was NOT rewritten")
+	}
+	for _, want := range []string{
+		"$database = 'johnnyq_itflow';",
+		"$dbusername = 'johnnyq_itflow';",
+		"$dbpassword = 'PANELPW_ITFLOW';",
+		"$dbhost = 'localhost';",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+	// It must not have grabbed the WordPress credential from the same account.
+	if strings.Contains(out, "johnnyq_45635") || strings.Contains(out, "PANELPW_45635") {
+		t.Errorf("picked the WordPress credential instead of its own\n--- got ---\n%s", out)
+	}
+	// The connect line is what keys detection — it must survive intact.
+	if !strings.Contains(out, "mysqli_connect($dbhost, $dbusername, $dbpassword, $database)") {
+		t.Error("the mysqli_connect line was mangled")
+	}
+}
+
+// The safety-critical case. config.php is one of the most common filenames in
+// PHP hosting, and this rewriter is pointed at <docroot>/config.php on every
+// migrated site. Touching a file that merely happens to be named config.php
+// would corrupt an unrelated app, so detection keys on ITFlow's own
+// mysqli_connect signature rather than the filename.
+func TestRewriteITFlow_IgnoresForeignConfigPHP(t *testing.T) {
+	foreign := []struct{ name, body string }{
+		{"unrelated app with similar var names", `<?php
+$dbhost = 'localhost';
+$dbusername = 'someapp';
+$dbpassword = 'secret';
+$database = 'someapp_db';
+$pdo = new PDO("mysql:host=$dbhost;dbname=$database", $dbusername, $dbpassword);
+`},
+		{"generic settings file", `<?php
+return ['debug' => true, 'name' => 'My App'];
+`},
+		{"php file with no db config at all", "<?php\n// nothing here\n"},
+		{"empty", ""},
+	}
+	for _, f := range foreign {
+		t.Run(f.name, func(t *testing.T) {
+			out, changed := rewriteITFlow(f.body, itflowCreds())
+			if changed {
+				t.Errorf("rewrote a NON-ITFlow config.php — this corrupts unrelated apps\n--- got ---\n%s", out)
+			}
+			if out != f.body {
+				t.Error("body was modified despite changed=false")
+			}
+		})
+	}
+}
+
+// Single-database accounts have nothing to match against, so the sole
+// credential is used — same fallback the WordPress and Joomla rewriters apply.
+func TestRewriteITFlow_SingleCredentialFallback(t *testing.T) {
+	// Source DB name deliberately absent from the map.
+	creds := map[string]DBCredential{
+		"something_else": {DBName: "acct_itflow", DBUser: "acct_itflow", Password: "PW"},
+	}
+	out, changed := rewriteITFlow(itflowConfigPHP, creds)
+	if !changed {
+		t.Fatal("single-credential fallback did not fire")
+	}
+	if !strings.Contains(out, "$database = 'acct_itflow';") {
+		t.Errorf("fallback credential not applied\n--- got ---\n%s", out)
+	}
+}
+
+// With several credentials and no name match there is no safe choice, so the
+// file must be left alone rather than guessed at.
+func TestRewriteITFlow_NoMatchMultiCredentialLeavesFileAlone(t *testing.T) {
+	creds := map[string]DBCredential{
+		"other_a": {DBName: "a", DBUser: "a", Password: "x"},
+		"other_b": {DBName: "b", DBUser: "b", Password: "y"},
+	}
+	out, changed := rewriteITFlow(itflowConfigPHP, creds)
+	if changed {
+		t.Errorf("guessed a credential with no name match\n--- got ---\n%s", out)
+	}
+	if out != itflowConfigPHP {
+		t.Error("body modified despite changed=false")
+	}
+}
+
+// A password containing a quote must not break out of the generated PHP
+// string literal — phpEscape handles it, same as the other rewriters.
+func TestRewriteITFlow_EscapesQuotesInPassword(t *testing.T) {
+	creds := map[string]DBCredential{
+		"notary_itflow": {DBName: "d", DBUser: "u", Password: `pa'ss\x`},
+	}
+	out, changed := rewriteITFlow(itflowConfigPHP, creds)
+	if !changed {
+		t.Fatal("not rewritten")
+	}
+	if strings.Contains(out, `$dbpassword = 'pa'ss`) {
+		t.Errorf("unescaped quote broke the PHP literal\n--- got ---\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes out the caveat left on GH #723.

The original fix covered WordPress, Joomla, Drupal and Magento, and the reply to the reporter said:

> your itFlow site uses `config.php` (not a `wp-config.php`-style file), which jabali doesn't auto-rewrite yet — after migrating you may need to update its DB name/user/password by hand.

That's worth closing rather than documenting. Jabali ships an ITFlow installer, and jabali always namespaces databases to `<account>_<name>`, so a migrated ITFlow site is left pointing at a database that no longer exists — the site just doesn't load. The reporter's own backup is the case in point: that account carries **both** `notary_45635` (WordPress) and `notary_itflow`.

## Field names came from the pinned upstream, not memory

ITFlow's `scripts/setup_cli.php` at the commit we already pin (`itflowMasterPinnedCommit`) writes:

```php
$new_config .= "\$dbhost = "     . var_export($host, true)     . ";\n";
$new_config .= "\$dbusername = " . var_export($username, true) . ";\n";
$new_config .= "\$dbpassword = " . var_export($password, true) . ";\n";
$new_config .= "\$database = "   . var_export($database, true) . ";\n";
$new_config .= "\$mysqli = mysqli_connect(\$dbhost, \$dbusername, \$dbpassword, \$database) or die(...);\n";
```

So single-quoted values plus a distinctive connect line.

## Detection does not key on the filename

This is the part worth reviewing closely. `config.php` is one of the most common filenames in PHP hosting, and the rewriter runs against `<docroot>/config.php` on **every** migrated site. Rewriting a file that merely shares the name would corrupt an unrelated app.

The guard therefore requires ITFlow's own `mysqli_connect($dbhost, $dbusername, $dbpassword, $database)` signature. A test asserts four foreign `config.php` shapes come back byte-identical — including the nastiest one, an app using the **same four variable names** but connecting via PDO:

```php
$dbhost = 'localhost';
$dbusername = 'someapp';
$dbpassword = 'secret';
$database = 'someapp_db';
$pdo = new PDO("mysql:host=$dbhost;dbname=$database", $dbusername, $dbpassword);
```

Variable-name matching alone would have rewritten that one.

## Credential selection

Mirrors `rewriteJoomla`: match on the source DB name, fall back to the sole credential when there's exactly one, and — when several credentials exist and none match — leave the file alone rather than guess. Tests cover the multi-DB case picking its *own* credential (not the WordPress one from the same account), the fallback, the no-match case, and quote escaping in the password.

## Operator visibility

The count is added to the `appconfigs:` summary next to the other four, so a rewrite that happened is visible rather than silent.

Full `panel-api` suite green, `go vet` clean.
