### PR TITLE
fix(install): report the line that actually failed, plus a call trace

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,13 +68,31 @@ set -Eeuo pipefail
 __on_err() {
   local rc=$?
   local cmd="$BASH_COMMAND"
-  local line="$LINENO"
+  # BASH_LINENO[0], not LINENO. Inside a trap handler $LINENO is the handler's
+  # OWN line, so this always reported a line inside __on_err rather than the
+  # failing one -- every "install.sh died" diagnostic pointed at the same dead
+  # spot. BASH_LINENO[0] is the line of the caller frame, i.e. where the failure
+  # actually happened. (Cost real time chasing a phantom "line 71" during the
+  # GH #731 work; install.sh is ~13k lines, so a wrong line number is worse than
+  # none.) FUNCNAME[1] was already correct -- FUNCNAME[0] is __on_err itself.
+  local line="${BASH_LINENO[0]:-0}"
   local func="${FUNCNAME[1]:-main}"
   printf "\033[1;31m[jabali-install]\033[0m install.sh died:\n" >&2
   printf "    exit_code : %d\n" "$rc" >&2
   printf "    function  : %s\n" "$func" >&2
   printf "    line      : %d\n" "$line" >&2
   printf "    command   : %s\n" "$cmd" >&2
+  # Call trace. The handler exists to make an operator's bug report actionable,
+  # and in a file this size one frame rarely is: the same helper gets called
+  # from a dozen places and the interesting question is which caller. Frame 0 is
+  # __on_err, so start at 1.
+  if (( ${#FUNCNAME[@]} > 2 )); then
+    printf "    trace     :\n" >&2
+    local _i
+    for (( _i = 1; _i < ${#FUNCNAME[@]} - 1 && _i <= 8; _i++ )); do
+      printf "        %s() at line %s\n" "${FUNCNAME[$_i]}" "${BASH_LINENO[$((_i - 1))]}" >&2
+    done
+  fi
   # When the failing command was a systemctl reload/restart/start,
   # dump journalctl + status for the unit so the operator sees the
   # real reason without having to ask for log files.

--- a/install.sh
+++ b/install.sh
@@ -4928,7 +4928,15 @@ build_backend() {
   for _bakbase in jabali-panel jabali-agent; do
     while IFS= read -r _old; do
       [[ -n "$_old" ]] && rm -f "$_old" && _pruned=$((_pruned + 1))
-    done < <(ls -1t "/usr/local/bin/${_bakbase}".bak.* 2>/dev/null | tail -n +4)
+    # `|| true`: with no .bak.* files the glob stays literal and ls exits 2.
+    # Under `set -o pipefail` (line 58) that becomes the pipeline's status, and
+    # `set -E` propagates ERR into this process substitution — so __on_err fired
+    # and printed a full "install.sh died" report on every host that had no old
+    # backups to prune, which is most of them (the install above uses `install`,
+    # which leaves none). The install then carried on and succeeded, so the
+    # message was pure noise — and noise on the one line operators are supposed
+    # to trust when something really does fail.
+    done < <({ ls -1t "/usr/local/bin/${_bakbase}".bak.* 2>/dev/null || true; } | tail -n +4)
   done
   (( _pruned > 0 )) && _ok "pruned $_pruned old binary backup(s) from /usr/local/bin"
   # M13 Step 1: jabali-ssh-shell ships at 0755 root:root. The wrapper


### PR DESCRIPTION
`__on_err` has been reporting a line number that has nothing to do with the failure.

```bash
local line="$LINENO"
```

Inside a trap handler `$LINENO` is the **handler's own line**, so every `install.sh died` diagnostic pointed at a fixed spot inside `__on_err`. `BASH_LINENO[0]` is the caller frame — the line that actually failed. (`FUNCNAME[1]` was already correct; `FUNCNAME[0]` is `__on_err` itself.)

## Before / after

Same synthetic failure, where the failing command is on **line 5**:

```
BEFORE                        AFTER
function : inner_helper       function : inner_helper
line     : 4                  line     : 5
command  : false              command  : false
                              trace    :
                                  inner_helper() at line 5
                                  middle_caller() at line 8
```

Worth being clear that the old number isn't off-by-one — it tracks edits to `__on_err` and bears no relationship to the failure. It just happened to land near 5 in this small harness.

## Call trace

Also adds a trace, capped at 8 frames. The handler's own comment says it exists so *"the GitHub issue starts with full context"*, and in a ~13k-line file a single frame rarely provides that: the same helper gets called from a dozen places and the useful question is **which caller**. Frame 0 is `__on_err`, so the walk starts at 1.

## How this surfaced

Chasing a phantom "line 71" during the GH #731 box run. That's precisely the failure mode this bug creates — in a file this size a wrong line number is worse than printing none, because you go read the wrong code and conclude something false about it.

Verified by extracting the real handler from both `origin/main` and this branch and running each against an identical failure, so the comparison is the shipping code rather than a paraphrase. `bash -n` clean, `tools/lint-install-sh.sh` passing.
