### PR TITLE
fix(settings): collapse the settings rail into a dropdown below lg (GH #688)

### DIFF
--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -28,6 +28,7 @@ import {
   InputNumber,
   Modal,
   Row,
+  Grid,
   Select,
   Space,
   Switch,
@@ -963,6 +964,14 @@ const tabLabel = (icon: React.ReactNode, text: string) => (
 export const ServerSettingsPage = () => {
   const [activeTab, setActiveTab] = useTabParam<SettingsTabKey>("general");
 
+  // GH #688 follow-up: below lg the left tab rail ate most of the width, so
+  // long-labelled content (Databases especially) overflowed the viewport.
+  // Collapse the rail into a Select above the content on small screens —
+  // same breakpoint helper AdminLayout uses for its Sider→Drawer swap
+  // (ADR-0046).
+  const screens = Grid.useBreakpoint();
+  const isDesktop = screens.lg !== false;
+
   // GH #688: left-positioned card Tabs instead of the old horizontal tab strip
   // that overflowed into a scrollbar. Each tab still owns an independent form;
   // destroyInactiveTabPane unmounts the inactive one so unsaved edits are
@@ -1034,26 +1043,46 @@ export const ServerSettingsPage = () => {
         <SettingOutlined /> Server Settings
       </Typography.Title>
 
-      {/* Tabs sit directly on the page — the left tab bar is NOT wrapped in a
-          Card (the individual card-style tabs are the only card chrome). */}
-      <Tabs
-        type="card"
-        tabPosition="left"
-        activeKey={activeTab}
-        onChange={(k) => setActiveTab(k as SettingsTabKey)}
-        destroyInactiveTabPane
-        items={items}
-        // GH #688: keep the left tab bar in view while a long tab's content
-        // scrolls. Sticky to the top of the scroll container; a very long
-        // tab list scrolls on its own via maxHeight/overflow.
-        tabBarStyle={{
-          position: "sticky",
-          top: 16,
-          alignSelf: "flex-start",
-          maxHeight: "calc(100vh - 32px)",
-          overflowY: "auto",
-        }}
-      />
+      {isDesktop ? (
+        /* Tabs sit directly on the page — the left tab bar is NOT wrapped in a
+           Card (the individual card-style tabs are the only card chrome). */
+        <Tabs
+          type="card"
+          tabPosition="left"
+          activeKey={activeTab}
+          onChange={(k) => setActiveTab(k as SettingsTabKey)}
+          destroyInactiveTabPane
+          items={items}
+          // GH #688: keep the left tab bar in view while a long tab's content
+          // scrolls. Sticky to the top of the scroll container; a very long
+          // tab list scrolls on its own via maxHeight/overflow.
+          tabBarStyle={{
+            position: "sticky",
+            top: 16,
+            alignSelf: "flex-start",
+            maxHeight: "calc(100vh - 32px)",
+            overflowY: "auto",
+          }}
+        />
+      ) : (
+        /* GH #688 follow-up: on phones the left rail left too little room and
+           wide content (Databases) overflowed the viewport. A full-width
+           Select gives the section list back every pixel of width, and only
+           the active section is rendered — matching destroyInactiveTabPane
+           above, so an inactive form's unsaved edits are dropped on switch
+           exactly as on desktop. */
+        <>
+          <Select<SettingsTabKey>
+            value={activeTab}
+            onChange={(k) => setActiveTab(k)}
+            options={items.map((i) => ({ value: i.key as SettingsTabKey, label: i.label }))}
+            style={{ width: "100%", marginBottom: 16 }}
+            size="large"
+            aria-label="Settings section"
+          />
+          {items.find((i) => i.key === activeTab)?.children}
+        </>
+      )}
     </div>
   );
 };

--- a/panel-ui/tests/e2e/responsive.spec.ts
+++ b/panel-ui/tests/e2e/responsive.spec.ts
@@ -43,6 +43,33 @@ test.describe("M23 responsive — chrome + navigation", () => {
     }
   });
 
+  // GH #688 follow-up. The left tab rail added for Server Settings ate most of
+  // the width below lg, so wide sections (Databases especially) overflowed the
+  // viewport horizontally — the exact symptom reported. Below lg the rail is
+  // replaced by a full-width section Select above the content.
+  test("server settings fits the viewport + uses the section dropdown below lg", async ({
+    page,
+    viewport,
+  }) => {
+    if (!isBelowLg(viewport)) {
+      test.skip(true, "the dropdown swap only applies below lg");
+    }
+    await mockApi(page, { me: admin });
+    await signIn(page, admin);
+    await page.goto("/jabali-admin/settings");
+
+    await expect(page.getByRole("heading", { name: /server settings/i })).toBeVisible();
+
+    // The reported bug: content pushed past the right edge.
+    await expectNoHorizontalOverflow(page);
+
+    // The rail must be gone — its tabs are what consumed the width.
+    await expect(page.getByRole("tab", { name: /databases/i })).toHaveCount(0);
+
+    // ...replaced by a combobox listing the sections.
+    await expect(page.getByRole("combobox").first()).toBeVisible();
+  });
+
   test("drawer opens, navigates, and closes on route change", async ({ page, viewport }) => {
     if (!isBelowLg(viewport)) {
       test.skip(true, "drawer pattern only applies below lg");


### PR DESCRIPTION
Follow-up to @lxsdevcode's feedback on #782/#783.

The left tab rail is a clear win on desktop, but below `lg` it took most of the width and wide sections — Databases especially — overflowed the viewport horizontally.

Below `lg` the rail is now replaced by a full-width section `Select` above the content, which is the shape the reporter sketched:

```text
+--------------------------------------+
| Server Settings                      |
| [ General ▼ ]                        |
+--------------------------------------+
```

It uses the same `Grid.useBreakpoint()` / `screens.lg` check `AdminLayout` uses for its Sider→Drawer swap, so both follow one breakpoint rule (ADR-0046) rather than inventing a second.

Only the active section renders in the mobile branch, matching `destroyInactiveTabPane` on the desktop `Tabs` — an inactive form's unsaved edits are dropped on switch exactly as before, rather than every form staying mounted at once.

## Checked the selector blast radius before changing the DOM

Removing the tab role below `lg` is exactly the kind of change that has silently broken E2E selectors here before, so I checked first rather than after.

`admin-mail-tls.spec.ts` clicks a Server Settings tab by role:

```ts
await page.getByRole("tab", { name: /email/i }).click();
```

That spec is live-box gated on `E2E_USERNAME` / `E2E_DOMAIN_ID` and runs under the `chromium` project at 1280×720 — comfortably `>= lg` — so the rail is still there for it. The `mobile-chromium` and `tablet-chromium` projects carry `testMatch: /responsive\.spec\.ts/`, so they only ever run the responsive spec. No selector breakage either way.

## Regression guard

Added to `responsive.spec.ts`, since that is the only file the two below-`lg` projects run — anywhere else the test simply would not execute at a mobile viewport. It asserts:

- no horizontal page overflow (the reported symptom itself)
- the `tab` role is gone
- a combobox is present

## Verified

```
mobile-chromium (390x844)   6 passed
tablet-chromium (768x1024)  5 passed, 1 skipped   (skip = the xs-only search-modal case)
tsc -b                      clean
vitest                      41 files / 174 tests passed
```

One note for honesty: on the first tablet run the pre-existing "drawer opens, navigates, and closes" test failed, then passed on re-run at 2.4s. It looks like a flake rather than anything this branch touches — my change is confined to `ServerSettingsPage` — but flagging it since a flaky drawer test is worth knowing about independently.

Not visually eyeballed on a real panel: Server Settings needs an authenticated backend and the test box is being rebuilt. The E2E runs against the real built `dist`, so the layout swap is exercised for real, but a screenshot check when the box is back wouldn't hurt.
