### PR TITLE
fix(agent): validate the migration secret path instead of prefix-matching it

### DIFF
--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -131,11 +131,27 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 			Message: fmt.Sprintf("dest_path %q must resolve under %s: %v", p.DestPath, homeRoot, rsErr)}
 	}
 	p.DestPath = resolvedDest
-	// Secret path must live in the panel's migration-secrets dir.
-	if !strings.HasPrefix(p.SecretPath, "/etc/jabali-panel/migration-secrets/") {
+	// Secret path must resolve to exactly <secrets-dir>/<job-ulid>.env.
+	//
+	// A bare strings.HasPrefix is not enough: it happily accepts
+	// "/etc/jabali-panel/migration-secrets/../../shadow", and the file is read
+	// below with os.ReadFile as root. Clean the path first, then require the
+	// directory to match exactly and the basename to be a validated job id --
+	// the same shape migration_admin_run.go already enforces, which takes a
+	// job_id and builds the path itself rather than trusting one.
+	//
+	// Not reachable today: every caller builds this from a server-generated
+	// genULID() job id. This is the boundary check CONVENTIONS.md asks for
+	// regardless of who the caller is, on a root-side arbitrary-file read.
+	cleanSecret := filepath.Clean(p.SecretPath)
+	secretBase := strings.TrimSuffix(filepath.Base(cleanSecret), ".env")
+	if filepath.Dir(cleanSecret) != migrationSecretsBaseDir ||
+		!strings.HasSuffix(cleanSecret, ".env") ||
+		!migrationJobIDRe.MatchString(secretBase) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
-			Message: "secret_path must live under /etc/jabali-panel/migration-secrets/"}
+			Message: "secret_path must be <job-id>.env directly under " + migrationSecretsBaseDir}
 	}
+	p.SecretPath = cleanSecret
 
 	subctx, cancel := context.WithTimeout(ctx, 4*time.Hour)
 	defer cancel()

--- a/panel-agent/internal/commands/migration_rsync_secret_path_test.go
+++ b/panel-agent/internal/commands/migration_rsync_secret_path_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The agent reads the migration secret file as root. The original guard was a
+// bare strings.HasPrefix on the caller-supplied path, which accepts traversal:
+// "/etc/jabali-panel/migration-secrets/../../shadow" has the right prefix and
+// resolves to /etc/shadow.
+//
+// Not reachable through shipped callers — every one builds the path from a
+// server-generated genULID() job id — but it is a root-side arbitrary-file read
+// sitting behind a string test, and the sibling command in this package
+// (migration_admin_run.go) already does it properly by taking a job_id and
+// constructing the path itself.
+//
+// This mirrors the accept/reject decision the handler makes so the rule is
+// pinned independently of the surrounding rsync plumbing.
+func secretPathAllowed(in string) bool {
+	clean := filepath.Clean(in)
+	base := strings.TrimSuffix(filepath.Base(clean), ".env")
+	return filepath.Dir(clean) == migrationSecretsBaseDir &&
+		strings.HasSuffix(clean, ".env") &&
+		migrationJobIDRe.MatchString(base)
+}
+
+func TestMigrationSecretPath_RejectsTraversal(t *testing.T) {
+	t.Parallel()
+	const good = migrationSecretsBaseDir + "/01JABCDEFGHJKMNPQRSTVWXYZ0.env"
+
+	if !secretPathAllowed(good) {
+		t.Fatalf("a legitimate secret path was rejected: %s", good)
+	}
+
+	bad := []struct{ name, path string }{
+		{"traversal to /etc/shadow", migrationSecretsBaseDir + "/../../shadow"},
+		{"traversal with .env suffix", migrationSecretsBaseDir + "/../../etc/shadow.env"},
+		{"nested subdirectory", migrationSecretsBaseDir + "/sub/01JABCDEFGHJKMNPQRSTVWXYZ0.env"},
+		{"prefix-matching sibling dir", "/etc/jabali-panel/migration-secrets-evil/x.env"},
+		{"absolute elsewhere", "/etc/shadow"},
+		{"no .env suffix", migrationSecretsBaseDir + "/01JABCDEFGHJKMNPQRSTVWXYZ0"},
+		{"basename not a job id", migrationSecretsBaseDir + "/passwd.env"},
+		{"short basename", migrationSecretsBaseDir + "/abc.env"},
+		{"empty", ""},
+		{"dir itself", migrationSecretsBaseDir},
+		{"trailing slash traversal", migrationSecretsBaseDir + "/../"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			if secretPathAllowed(tc.path) {
+				t.Errorf("accepted %q — the agent would os.ReadFile this as root", tc.path)
+			}
+		})
+	}
+}
+
+// The specific string the old guard let through, called out on its own so the
+// regression is unmistakable if anyone reverts to a prefix test.
+func TestMigrationSecretPath_OldPrefixGuardWasInsufficient(t *testing.T) {
+	t.Parallel()
+	const attack = "/etc/jabali-panel/migration-secrets/../../shadow"
+
+	if !strings.HasPrefix(attack, "/etc/jabali-panel/migration-secrets/") {
+		t.Fatal("test premise wrong: the attack string should satisfy the old prefix check")
+	}
+	if got := filepath.Clean(attack); got != "/etc/shadow" {
+		t.Fatalf("expected the traversal to resolve to /etc/shadow, got %s", got)
+	}
+	if secretPathAllowed(attack) {
+		t.Error("the hardened guard still accepts the traversal")
+	}
+}


### PR DESCRIPTION
Found while auditing migration credential handling — the area where we store SSH passwords and private keys for customers' *other* hosting providers.

## The gap

`migration.rsync_remote_home` guarded the caller-supplied `secret_path` like this:

```go
if !strings.HasPrefix(p.SecretPath, "/etc/jabali-panel/migration-secrets/") {
    return nil, &agentwire.AgentError{...}
}
```

…then read that path with `os.ReadFile` **as root**.

A prefix test accepts traversal:

```
/etc/jabali-panel/migration-secrets/../../shadow
```

has the required prefix and `filepath.Clean`s to `/etc/shadow`. It also accepts a prefix-matching *sibling directory* — `/etc/jabali-panel/migration-secrets-evil/x.env` — since there's no separator boundary check.

## Reachability — not a live hole

Every shipped caller builds the path from a server-generated `genULID()` job id (`admin_migrations.go`, `tenant_migrations.go`, `migrate_run_cmd.go`), so nothing attacker-controlled reaches this field today. I'd class it the same as the `try_files` guard in #789: a boundary check on a dangerous primitive, not an exploit.

It's still worth closing. It's a root-side arbitrary-file read sitting behind a string comparison, and CONVENTIONS.md is explicit that validation belongs at the boundary *regardless* of who the caller is.

## The fix is the pattern already in this package

`migration_admin_run.go` — same directory — already does it correctly: it takes a `job_id`, validates against `^[0-9A-Za-z]{26}$`, and builds the path itself rather than trusting one. So `rsync_remote_home` was the outlier.

This makes it consistent: clean the path, then require the directory to match exactly and the basename to be a validated job id. The wire field is unchanged, so there's no contract change and no caller needs touching.

## Tests

Pin the accept/reject rule directly, including the exact string the old guard let through:

```
traversal to /etc/shadow          rejected
traversal with .env suffix        rejected
nested subdirectory               rejected
prefix-matching sibling dir       rejected   <- HasPrefix accepted this too
absolute elsewhere                rejected
basename not a job id             rejected
legitimate <ulid>.env             accepted
```

Plus a test asserting the premise itself — that the attack string *does* satisfy the old prefix check and *does* resolve to `/etc/shadow` — so the regression is unmistakable if anyone reverts to a prefix test.

Full `panel-agent` suite green, `go vet` clean.

## Rest of the audit

The surrounding credential handling looks sound: `SecretsDir` is `0750 root:jabali` with `0640 root:jabali` files, `WipeJobSecret` validates the job id before unlinking and is called on terminal state plus a daily reaper sweep, and secrets go to the agent by path rather than on the wire. This was the one rough edge.
