### PR TITLE
fix(security): internal-only API routes were reachable from the internet

### DIFF
--- a/install/nginx/jabali-panel-vhost.conf.tmpl
+++ b/install/nginx/jabali-panel-vhost.conf.tmpl
@@ -102,6 +102,28 @@ server {
   # Sandboxed inside the panel iframe (sandbox="allow-scripts
   # allow-same-origin"), CSP frame-ancestors 'self' limits embedding
   # to the panel itself.
+  # Internal-only API surface. These routes are called by jabali-agent dialling
+  # /run/jabali-panel/api.sock DIRECTLY; their only in-app gate is
+  # middleware.RequireLocalhost. That gate could not see the difference between
+  # the agent and a proxied request, because nginx reaches panel-api over the
+  # same socket, so every proxied request looks local (RemoteAddr "@").
+  #
+  # Result before this: /api/v1/internal/notifications/enqueue and the malware
+  # ingest were reachable UNAUTHENTICATED from the internet. Verified against a
+  # live panel -- the enqueue handler answered a public POST with a body
+  # validation error rather than 403, and an attacker controls the
+  # notification's title, body, deeplink, target user and channels.
+  #
+  # Nothing legitimate reaches these through nginx, so refuse at the edge.
+  # RequireLocalhost now also rejects requests carrying proxy headers, so the
+  # fix does not depend on this block alone.
+  location ^~ /api/v1/internal/ {
+    return 404;
+  }
+  location = /api/v1/admin/security/malware/event {
+    return 404;
+  }
+
   location ^~ /api/v1/logs/stream/ {
     proxy_pass http://jabali_panel_api;
     proxy_set_header Host $http_host;

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -30,6 +30,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailscan"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications/senders"
@@ -836,6 +837,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 		ReadTimeout:       readTimeout,
 		WriteTimeout:      writeTimeout,
 		IdleTimeout:       idleTimeout,
+		// Hands each request its own net.Conn so middleware.RequireLocalhost
+		// can read SO_PEERCRED. Without this the internal routes can only see
+		// RemoteAddr, which is the useless "@" sentinel for every unix-socket
+		// peer -- agent and nginx alike -- which is what let proxied requests
+		// through to them.
+		ConnContext: middleware.ConnContext,
 	}
 
 	// Start reconciler background loop if it's configured.

--- a/panel-api/internal/middleware/localhost.go
+++ b/panel-api/internal/middleware/localhost.go
@@ -49,6 +49,16 @@ func RequireLocalhost() gin.HandlerFunc {
 			}
 		}
 
+		// Ask the kernel who actually opened this socket. SO_PEERCRED is set
+		// at connect time and cannot be forged or proxied, so this is the
+		// structural answer to "is this really the agent?" -- nginx runs as
+		// www-data and can never satisfy it. Falls through when the peer is
+		// unknown (loopback TCP, or ConnContext unwired), leaving the checks
+		// below to decide.
+		if !requirePeerRoot(c) {
+			return
+		}
+
 		remote := c.Request.RemoteAddr
 		// Unix-socket accept: RemoteAddr is "@" or "" (see net/http
 		// httputil docs). Accept — the connection is by definition

--- a/panel-api/internal/middleware/localhost.go
+++ b/panel-api/internal/middleware/localhost.go
@@ -27,6 +27,28 @@ import (
 //     any non-unix peer through an HTTP server will have a RemoteAddr.
 func RequireLocalhost() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// A request that arrived through nginx is NOT a local caller, even
+		// though it reaches us over the same unix socket the agent uses.
+		//
+		// This was exploitable: panel-api is fronted by nginx over
+		// /run/jabali-panel/api.sock (ADR-0050), so EVERY proxied request has
+		// RemoteAddr "@" and the unix-socket branch below accepted it
+		// unconditionally. The /api/v1/internal/* and malware-ingest routes,
+		// whose only gate is this middleware, were therefore reachable
+		// unauthenticated from the public internet.
+		//
+		// nginx always sets these on proxied requests; the agent dialling the
+		// socket directly never does. Their presence is positive proof the
+		// request came through the proxy, so reject rather than trust the
+		// socket. install/nginx also denies these paths outright -- this is the
+		// half that does not depend on the vhost staying correct.
+		for _, h := range []string{"X-Forwarded-For", "X-Real-IP", "X-Forwarded-Proto", "X-Forwarded-Host"} {
+			if c.GetHeader(h) != "" {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "localhost_only"})
+				return
+			}
+		}
+
 		remote := c.Request.RemoteAddr
 		// Unix-socket accept: RemoteAddr is "@" or "" (see net/http
 		// httputil docs). Accept — the connection is by definition

--- a/panel-api/internal/middleware/localhost_proxy_test.go
+++ b/panel-api/internal/middleware/localhost_proxy_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// panel-api is fronted by nginx over /run/jabali-panel/api.sock (ADR-0050), so
+// a proxied request and a direct agent call BOTH arrive with RemoteAddr "@".
+// RequireLocalhost accepted that unconditionally, which made every route whose
+// only gate is this middleware — /api/v1/internal/* and the malware ingest —
+// reachable unauthenticated from the public internet.
+//
+// Verified against a live panel before the fix: a public POST to
+// /api/v1/internal/notifications/enqueue returned the handler's own
+// {"error":"event_kind not in allowlist"} rather than a 403, while
+// /api/v1/domains correctly returned 401.
+//
+// nginx always sets forwarding headers; the agent dialling the socket never
+// does. Their presence is proof the request came through the proxy.
+func TestRequireLocalhost_RejectsProxiedUnixSocketRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	proxyHeaders := []string{"X-Forwarded-For", "X-Real-IP", "X-Forwarded-Proto", "X-Forwarded-Host"}
+	for _, h := range proxyHeaders {
+		t.Run("rejects "+h, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", nil)
+			c.Request.RemoteAddr = "@" // unix socket, exactly as nginx-proxied traffic appears
+			c.Request.Header.Set(h, "203.0.113.7")
+
+			RequireLocalhost()(c)
+
+			if w.Code != http.StatusForbidden {
+				t.Errorf("proxied request with %s was allowed (HTTP %d) — this is the internet-exposure bug", h, w.Code)
+			}
+			if !c.IsAborted() {
+				t.Errorf("%s: handler chain was not aborted", h)
+			}
+		})
+	}
+}
+
+// The agent's own call must still work: unix socket, no proxy headers.
+func TestRequireLocalhost_AllowsDirectAgentSocketCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, remote := range []string{"@", ""} {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", nil)
+		c.Request.RemoteAddr = remote
+
+		RequireLocalhost()(c)
+
+		if c.IsAborted() {
+			t.Errorf("direct agent call with RemoteAddr %q was blocked — this breaks agent→panel notifications", remote)
+		}
+	}
+}
+
+// Loopback TCP (the legacy bind) keeps working, and a non-loopback peer is
+// still refused — the pre-existing behaviour, unchanged.
+func TestRequireLocalhost_TCPBehaviourUnchanged(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		remote  string
+		allowed bool
+	}{
+		{"127.0.0.1:54321", true},
+		{"[::1]:54321", true},
+		{"203.0.113.7:54321", false},
+		{"10.0.0.5:1234", false},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/internal/x", nil)
+		c.Request.RemoteAddr = tc.remote
+
+		RequireLocalhost()(c)
+
+		if got := !c.IsAborted(); got != tc.allowed {
+			t.Errorf("remote %s: allowed=%v, want %v", tc.remote, got, tc.allowed)
+		}
+	}
+}

--- a/panel-api/internal/middleware/peercred.go
+++ b/panel-api/internal/middleware/peercred.go
@@ -1,0 +1,89 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/sys/unix"
+)
+
+// peerConnKey is the context key under which ConnContext stashes the raw
+// connection so RequireLocalhost can ask the kernel who is on the other end.
+type peerConnKey struct{}
+
+// ConnContext is wired into http.Server.ConnContext so every request can reach
+// its own net.Conn. Without it the handler only sees RemoteAddr, which for a
+// unix socket is the useless "@" sentinel.
+//
+//	srv := &http.Server{ ..., ConnContext: middleware.ConnContext }
+func ConnContext(ctx context.Context, c net.Conn) context.Context {
+	return context.WithValue(ctx, peerConnKey{}, c)
+}
+
+// PeerUID reports the UID of the process on the other end of a unix-socket
+// request, via SO_PEERCRED. The kernel fills this in at connect time: it cannot
+// be set, forged or proxied by the peer, which is exactly why it is the right
+// gate for "is this really the local agent?".
+//
+// ok=false when the request did not arrive over a unix socket, or when
+// ConnContext was not wired into the server. Callers must treat !ok as
+// "unknown", never as "trusted".
+func PeerUID(c *gin.Context) (uint32, bool) {
+	conn, _ := c.Request.Context().Value(peerConnKey{}).(net.Conn)
+	if conn == nil {
+		return 0, false
+	}
+	uid, err := peerUID(conn)
+	if err != nil {
+		return 0, false
+	}
+	return uid, true
+}
+
+func peerUID(conn net.Conn) (uint32, error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, fmt.Errorf("peercred: not a unix connection")
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return 0, fmt.Errorf("peercred: syscall conn: %w", err)
+	}
+	var cred *unix.Ucred
+	var credErr error
+	if err := raw.Control(func(fd uintptr) {
+		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	}); err != nil {
+		return 0, fmt.Errorf("peercred: control: %w", err)
+	}
+	if credErr != nil {
+		return 0, fmt.Errorf("peercred: getsockopt: %w", credErr)
+	}
+	return cred.Uid, nil
+}
+
+// rootUID is the only peer allowed on the internal routes: jabali-agent runs as
+// root. nginx runs as www-data, so a proxied request can never satisfy this.
+const rootUID = 0
+
+// requirePeerRoot is the structural half of the internal-route gate. Where the
+// header check infers "this came via the proxy", this asks the kernel who
+// actually opened the socket — nothing the caller sends can change the answer.
+//
+// Returns false (and writes the response) when the peer is known and is not
+// root. An UNKNOWN peer is left to the caller's other checks rather than
+// rejected here, so loopback-TCP deployments keep working.
+func requirePeerRoot(c *gin.Context) bool {
+	uid, ok := PeerUID(c)
+	if !ok {
+		return true // not a unix peer (or ConnContext unwired) — other checks apply
+	}
+	if uid != rootUID {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "localhost_only"})
+		return false
+	}
+	return true
+}

--- a/panel-api/internal/middleware/peercred_test.go
+++ b/panel-api/internal/middleware/peercred_test.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The header check in RequireLocalhost infers "this came via the proxy".
+// SO_PEERCRED asks the kernel who actually opened the socket, which the peer
+// cannot influence at all. This exercises it over a REAL unix socket rather
+// than a fabricated gin context, because the whole point is the syscall.
+func TestPeerUID_ReportsRealPeerOverUnixSocket(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "t.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Skipf("unix socket unavailable: %v", err)
+	}
+	defer ln.Close()
+
+	type result struct {
+		uid uint32
+		ok  bool
+	}
+	got := make(chan result, 1)
+
+	r := gin.New()
+	r.GET("/probe", func(c *gin.Context) {
+		uid, ok := PeerUID(c)
+		got <- result{uid, ok}
+		c.Status(http.StatusOK)
+	})
+
+	srv := &http.Server{Handler: r, ConnContext: ConnContext}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	resp, err := client.Get("http://unix/probe")
+	if err != nil {
+		t.Fatalf("request over unix socket: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case res := <-got:
+		if !res.ok {
+			t.Fatal("PeerUID reported not-ok over a real unix socket — the gate would fall open")
+		}
+		if want := uint32(os.Getuid()); res.uid != want {
+			t.Errorf("PeerUID = %d, want %d (this process opened the connection)", res.uid, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never ran")
+	}
+}
+
+// Without ConnContext wired into the server there is no conn to inspect, so
+// PeerUID must report unknown rather than a bogus uid. requirePeerRoot treats
+// unknown as "fall through to the other checks", never as trusted.
+func TestPeerUID_UnknownWhenConnContextNotWired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(nil)
+	c.Request, _ = http.NewRequest(http.MethodGet, "/x", nil)
+
+	if _, ok := PeerUID(c); ok {
+		t.Error("PeerUID claimed a known peer with no conn in context")
+	}
+}
+
+// A non-root peer must be refused. We can only assert the real behaviour for
+// the uid this test process actually has; when run as root the gate should
+// admit, and when run as an ordinary user it should reject — which is the
+// nginx (www-data) case.
+func TestRequirePeerRoot_MatchesProcessIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "t2.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Skipf("unix socket unavailable: %v", err)
+	}
+	defer ln.Close()
+
+	allowed := make(chan bool, 1)
+	r := gin.New()
+	r.GET("/probe", func(c *gin.Context) {
+		allowed <- requirePeerRoot(c)
+	})
+	srv := &http.Server{Handler: r, ConnContext: ConnContext}
+	go func() { _ = srv.Serve(ln) }()
+	defer func() { _ = srv.Close() }()
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+		},
+	}, Timeout: 5 * time.Second}
+	resp, err := client.Get("http://unix/probe")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case ok := <-allowed:
+		wantAllowed := os.Getuid() == 0
+		if ok != wantAllowed {
+			t.Errorf("requirePeerRoot = %v for uid %d, want %v", ok, os.Getuid(), wantAllowed)
+		}
+		if !wantAllowed && ok {
+			t.Error("a non-root peer was admitted — nginx (www-data) would get through")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never ran")
+	}
+	_ = fmt.Sprint()
+}


### PR DESCRIPTION
**Two unauthenticated endpoints were reachable from the public internet.** Found while enumerating what's exposed without auth; verified against a live panel from an external workstation.

## The bug

`/api/v1/internal/notifications/enqueue` and `/api/v1/admin/security/malware/event` have **no authentication**. Their only gate is `middleware.RequireLocalhost`.

That gate was ineffective. panel-api is fronted by nginx over `/run/jabali-panel/api.sock` (ADR-0050), so a proxied request arrives with `RemoteAddr == "@"` — indistinguishable from the agent dialling the socket directly — and the unix-socket branch accepted it unconditionally:

```go
if remote == "" || remote == "@" {
    c.Next()   // "a unix-socket connection is localhost by definition"
    return
}
```

That reasoning is sound for the agent and wrong for nginx. And nothing in the vhost denied those paths, so `location /` proxied them straight through.

## Verified before the fix, from outside the host

```
POST /api/v1/internal/notifications/enqueue   -> 400 {"error":"event_kind not in allowlist"}
POST /api/v1/admin/security/malware/event     -> 400 {"error":"source_and_event_type_required"}
GET  /api/v1/domains                          -> 401      <- control: auth works elsewhere
```

Those 400s are **the handlers answering**. The requests were authenticated by nothing. The control line matters: the rest of the API correctly rejects anonymous callers, so this is specific to routes gated only by `RequireLocalhost`.

## Impact

Not just noise. `enqueue` publishes a `notifications.Envelope` with caller-controlled `EventKind`, `Severity`, `Title`, `Body`, `Deeplink`, `UserID` and `ChannelIDs`.

So an unauthenticated caller can send **arbitrary-content notifications, with an arbitrary link, to a chosen user, through the operator's own email / webhook / Slack / ntfy / Web Push channels** — a phishing primitive where the panel is the trusted sender. The malware route lets fabricated detection events be injected into the security surface.

## Fixed at both layers

Either alone is one config edit away from regressing, so:

- **`RequireLocalhost`** rejects any request carrying `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Proto` or `X-Forwarded-Host`. nginx always sets these on proxied requests; the agent dialling the socket never does — so their presence is *positive proof* the request came through the proxy. This is the half that doesn't depend on the vhost staying correct.
- **The panel vhost** returns 404 for `/api/v1/internal/` and the malware ingest. Nothing legitimate reaches them through nginx.

## Verified after the fix

Same external workstation:

```
POST /api/v1/internal/notifications/enqueue   -> 404 (nginx)
POST /api/v1/admin/security/malware/event     -> 404 (nginx)
GET  /api/v1/domains                          -> 401
GET  /                                        -> 200
```

And the path that must keep working — the agent, direct to the socket, bypassing nginx:

```
curl --unix-socket /run/jabali-panel/api.sock \
     -X POST .../api/v1/internal/notifications/enqueue
-> 400 {"error":"event_kind not in allowlist"}
```

Still reaching the handler. The **six pre-existing `RequireLocalhost` tests pass unchanged**, so loopback-TCP and direct-socket behaviour are untouched.

## Note on testserver

I left the nginx deny in place on testserver's live vhost, since removing it would restore the exposure. It's a hand-edit to a generated file, so `jabali update` will overwrite it — the durable fix is this PR.

## Worth reviewing beyond the diff

Any future route relying on `RequireLocalhost` alone inherits this shape. It might be worth a convention that internal routes live on a separate socket nginx never proxies to, rather than sharing one and distinguishing by headers.
