### PR TITLE
fix(security): allowlist the host's own public IPs so AppSec stops blocking it (JAB-195)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -587,6 +587,9 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// M34: per-user PHP-FPM egress firewall. Cheap noop when the repo
 	// isn't wired (test fixtures) or when there are zero policies.
 	r.reconcileUserEgress(ctx)
+	// JAB-195: keep this host's own public IPs allowlisted so AppSec never
+	// scores WordPress loopback traffic (WooCommerce Action Scheduler et al).
+	r.reconcileSelfAllowlist(ctx)
 
 	// PHP pool reconciliation first, so domain regens see latest pool state.
 	r.ReconcilePHPPools(ctx)

--- a/panel-api/internal/reconciler/self_allowlist_reconcile.go
+++ b/panel-api/internal/reconciler/self_allowlist_reconcile.go
@@ -1,0 +1,135 @@
+// Package reconciler — JAB-195: keep the host's own public IPs out of the
+// CrowdSec AppSec WAF's scoring path.
+//
+// WordPress makes loopback calls to itself (WooCommerce Action Scheduler,
+// wp-cron, Elementor migrations, the theme-editor scrape check). Those requests
+// leave the box and come back in via the public IP, so AppSec sees them as
+// ordinary inbound traffic and scores them. On a production host they were
+// scoring rce:15 / anomaly:18 and getting an inline 403 roughly hourly.
+//
+// The failure is silent. WooCommerce's queue just stops: delayed order emails,
+// webhooks, scheduled actions and image regeneration quietly stop happening,
+// and the only evidence is a 403 in the vhost access log and /var/log/crowdsec.
+// Nothing surfaces in the panel.
+//
+// Server-to-self traffic should never be WAF-scored, so this pass keeps the
+// host's own public IPs in the jabali-managed allowlist. Doing it on the
+// reconciler rather than as a one-off entry means it re-asserts itself if the
+// allowlist is cleared and follows the host to a new address when public_ipv4
+// changes — an operator hand-entry would silently rot at that point.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+)
+
+// selfAllowlistReason is written as the allowlist entry's description. Kept
+// stable and recognisable so an operator reading `cscli allowlists inspect`
+// can see why the entry exists and that it is machine-managed.
+const selfAllowlistReason = "jabali: server's own public IP (loopback/self-originated traffic, JAB-195)"
+
+// reconcileSelfAllowlist ensures every public IP this host owns is present in
+// the jabali-managed CrowdSec allowlist, with no expiration.
+//
+// Idempotent by construction: it lists first and only adds what is missing, so
+// a converged host performs one read per tick and no writes.
+func (r *Reconciler) reconcileSelfAllowlist(ctx context.Context) {
+	if r.agent == nil || r.serverSettings == nil {
+		return
+	}
+	settings, err := r.serverSettings.Get(ctx)
+	if err != nil || settings == nil {
+		r.log.Debug("self-allowlist reconcile skipped: server_settings unavailable", "error", err)
+		return
+	}
+	// Security module owns CrowdSec. With it off there is no allowlist to
+	// maintain and cscli may not even be installed.
+	if !settings.SecurityEnabled {
+		return
+	}
+
+	want := selfPublicIPs(settings.PublicIPv4, settings.PublicIPv6)
+	if len(want) == 0 {
+		return
+	}
+
+	have, err := r.currentAllowlistValues(ctx)
+	if err != nil {
+		// A missing allowlist surfaces as an empty list, not an error, so a
+		// real error here means cscli is unavailable. Skip quietly and retry
+		// next tick rather than spamming the log every interval.
+		r.log.Debug("self-allowlist reconcile skipped: cannot read allowlist", "error", err)
+		return
+	}
+
+	for _, ip := range want {
+		if have[ip] {
+			continue
+		}
+		if _, err := r.agent.Call(ctx, "security.crowdsec.allowlists.add", map[string]any{
+			"value":  ip,
+			"reason": selfAllowlistReason,
+			// No expiration: the host does not stop being itself.
+		}); err != nil {
+			r.log.Warn("self-allowlist add failed; WAF may block this host's own loopback requests",
+				"ip", ip, "error", err)
+			continue
+		}
+		r.log.Info("allowlisted this host's own public IP for CrowdSec AppSec", "ip", ip)
+	}
+}
+
+// currentAllowlistValues returns the values already present, as a set.
+func (r *Reconciler) currentAllowlistValues(ctx context.Context) (map[string]bool, error) {
+	raw, err := r.agent.Call(ctx, "security.crowdsec.allowlists.list", map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Items []struct {
+			Value string `json:"value"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(resp.Items))
+	for _, it := range resp.Items {
+		if v := strings.TrimSpace(it.Value); v != "" {
+			out[v] = true
+		}
+	}
+	return out, nil
+}
+
+// selfPublicIPs normalises the configured addresses into the set worth
+// allowlisting. Parsing rather than trusting the column keeps a malformed or
+// placeholder value from reaching cscli, where the agent would reject it
+// anyway — better to notice here than to log a failed add every tick.
+//
+// Loopback and unspecified addresses are dropped: they never appear as an
+// AppSec source, so allowlisting them is noise that only widens the entry list.
+func selfPublicIPs(v4, v6 string) []string {
+	seen := make(map[string]bool, 2)
+	out := make([]string, 0, 2)
+	for _, raw := range []string{v4, v6} {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		ip := net.ParseIP(s)
+		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+			continue
+		}
+		norm := ip.String()
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		out = append(out, norm)
+	}
+	return out
+}

--- a/panel-api/internal/reconciler/self_allowlist_reconcile_test.go
+++ b/panel-api/internal/reconciler/self_allowlist_reconcile_test.go
@@ -1,0 +1,108 @@
+package reconciler
+
+import (
+	"reflect"
+	"testing"
+)
+
+// JAB-195. The set that gets allowlisted decides whether the host's own
+// loopback traffic is WAF-scored, so the filtering is worth pinning directly.
+func TestSelfPublicIPs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		v4, v6 string
+		want   []string
+	}{
+		{
+			name: "the reported production shape",
+			v4:   "182.54.236.64",
+			want: []string{"182.54.236.64"},
+		},
+		{
+			name: "v4 and v6 both allowlisted",
+			v4:   "182.54.236.64",
+			v6:   "2a01:4f8:1c1c:1::1",
+			want: []string{"182.54.236.64", "2a01:4f8:1c1c:1::1"},
+		},
+		{
+			name: "unset columns produce nothing to do",
+			want: []string{},
+		},
+		// A blank or placeholder public_ipv4 is normal on a freshly installed
+		// host. Filtering here keeps the reconciler from calling cscli with
+		// garbage every tick and logging a failed add each time.
+		{
+			name: "malformed value is dropped rather than sent to cscli",
+			v4:   "not-an-ip",
+			want: []string{},
+		},
+		{
+			name: "whitespace is tolerated",
+			v4:   "  182.54.236.64  ",
+			want: []string{"182.54.236.64"},
+		},
+		// Loopback never appears as an AppSec source, so allowlisting it only
+		// widens the entry list for no benefit.
+		{
+			name: "loopback dropped",
+			v4:   "127.0.0.1",
+			v6:   "::1",
+			want: []string{},
+		},
+		{
+			name: "unspecified dropped",
+			v4:   "0.0.0.0",
+			v6:   "::",
+			want: []string{},
+		},
+		// Same address in both columns must not produce two identical entries.
+		{
+			name: "duplicates collapse",
+			v4:   "182.54.236.64",
+			v6:   "182.54.236.64",
+			want: []string{"182.54.236.64"},
+		},
+		// Equivalent v6 spellings normalise to one entry.
+		{
+			name: "v6 spellings normalise",
+			v4:   "2A01:4F8:1C1C:1:0:0:0:1",
+			v6:   "2a01:4f8:1c1c:1::1",
+			want: []string{"2a01:4f8:1c1c:1::1"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selfPublicIPs(tc.v4, tc.v6)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("selfPublicIPs(%q, %q) = %v, want %v", tc.v4, tc.v6, got, tc.want)
+			}
+		})
+	}
+}
+
+// The reason string lands in `cscli allowlists inspect` output, where it is the
+// only clue an operator has about why the entry exists. Pinned so it stays
+// self-explanatory and traceable rather than drifting to something terse.
+func TestSelfAllowlistReason_IsTraceable(t *testing.T) {
+	t.Parallel()
+	for _, want := range []string{"jabali", "JAB-195"} {
+		if !contains(selfAllowlistReason, want) {
+			t.Errorf("allowlist reason %q should mention %q so an operator can trace it",
+				selfAllowlistReason, want)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}


### PR DESCRIPTION
Addresses JAB-195 (urgent).

## What's happening

WordPress calls itself — WooCommerce Action Scheduler, wp-cron, Elementor migrations, the theme-editor scrape check. Those requests leave the box and come back in via the **public IP**, so CrowdSec AppSec sees ordinary inbound traffic and scores it.

On the reporting host they scored `rce:15 / anomaly:18` and took an inline 403 roughly hourly — ~27 blocks in two days.

## Why it matters more than the block count suggests

It's silent. WooCommerce's queue just stops: delayed order emails, webhooks, scheduled actions and image regeneration never run. The only evidence is a 403 in the vhost access log and `/var/log/crowdsec`. Nothing surfaces to the operator, so the site looks fine while orders quietly stop being processed.

## Fix

Server-to-self traffic should never be WAF-scored, so a reconciler pass keeps this host's own public IPs in the jabali-managed allowlist, with no expiration.

**On the reconciler rather than as a one-off entry, deliberately.** It re-asserts itself if the allowlist is cleared, and it follows the host when `public_ipv4` changes. A hand-added entry would silently rot at exactly that moment — and the symptom would return looking like a brand-new bug, which is the worst possible failure mode for something this quiet.

Details worth noting:

- **Idempotent by construction** — lists first, adds only what's missing. A converged host does one read per tick and no writes.
- **Skips when the security module is off**, since CrowdSec and `cscli` may not be installed at all.
- **Filters before calling cscli.** A blank or placeholder `public_ipv4` is normal on a freshly installed host; without filtering the pass would attempt a doomed add and log a failure every single tick. Loopback and unspecified are dropped too — they never appear as an AppSec source, so allowlisting them only widens the entry list.
- **Duplicates and v6 spellings collapse** (`2A01:...:0:0:0:1` and `2a01:...::1` are one entry).

## Tests

Pin the filtering, including the exact production shape from the report:

```
the reported production shape          182.54.236.64        -> allowlisted
v4 and v6 both allowlisted             -> both
malformed value dropped                "not-an-ip"          -> nothing sent to cscli
loopback / unspecified dropped         127.0.0.1, ::, 0.0.0.0
duplicates collapse                    same IP in both cols -> one entry
v6 spellings normalise                 -> one entry
```

Plus one asserting the reason string stays traceable — it's the only clue an operator gets from `cscli allowlists inspect` about why the entry exists and that it's machine-managed.

## Not verified on a box

The reporting host is **newzaps, which is production**, so I didn't touch it. The logic is unit-tested and the agent commands it calls (`security.crowdsec.allowlists.list` / `.add`) are existing, in-use handlers. Worth confirming on a non-production host with the security module enabled that the entry appears in `cscli allowlists inspect` after a tick.

## Related

This is the durable half of the fix direction in the issue. The stopgap (hand-allowlisting the IP) is unnecessary once this lands. The third suggestion — surfacing "the server blocked itself" as a health-monitor warning — is a separate piece of work; this PR removes the cause rather than reporting it, but a detector would still be worth having for the cases this doesn't cover.

JAB-193/196/197/198 are the rest of the WAF false-positive cluster and are untouched here.
