### PR TITLE
feat(security): jabali appsec explain — show which CRS rule blocked a request (JAB-193)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -334,6 +334,19 @@ CrowdSec AppSec config operator subcommands
 jabali appsec
 ```
 
+#### `jabali appsec explain`
+
+Show which CRS rules recently blocked requests (AppSec FP triage)
+
+```
+jabali appsec explain [flags]
+```
+
+**Flags:**
+
+- `--json` — emit raw JSON instead of the grouped report
+- `--limit` — how many recent AppSec alerts to inspect (max 200) (default `25`)
+
 #### `jabali appsec render-config`
 
 Write /etc/crowdsec/appsec-configs/jabali-appsec.yaml from internal/appseccfg.Render

--- a/panel-agent/internal/commands/security_appsec_events.go
+++ b/panel-agent/internal/commands/security_appsec_events.go
@@ -18,9 +18,12 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -51,8 +54,32 @@ type AppsecEvent struct {
 	ASNOrg     string   `json:"asn_org"`
 }
 
+// InlineBlock is a WAF denial that returned 403 but never became a ban, so it
+// produces NO cscli alert. JAB-193 hit exactly this: `cscli decisions list` and
+// `cscli alerts list` both showed nothing for a blocked editor, which is what
+// made the incident hard to diagnose.
+//
+// crowdsec.log records these, but with less detail than an alert — score
+// families and source IP, no rule id and no URI:
+//
+//	WAF block: anomaly score block: lfi: 5, anomaly: 8,  from 1.2.3.4 (127.0.0.1)
+//
+// Partial is still the difference between "invisible" and "correlate this IP
+// and timestamp against the vhost access log", which is how JAB-193 was
+// actually diagnosed by hand.
+type InlineBlock struct {
+	Timestamp string `json:"timestamp"`
+	SourceIP  string `json:"source_ip"`
+	// Scores is the raw family list, e.g. "lfi: 5, anomaly: 8".
+	Scores string `json:"scores"`
+}
+
 type appsecEventsResponse struct {
 	Events []AppsecEvent `json:"events"`
+	// InlineBlocks are 403s that never produced an alert. Reported separately
+	// because they carry no rule id — presenting them alongside alert-backed
+	// events would imply a precision they do not have.
+	InlineBlocks []InlineBlock `json:"inline_blocks"`
 	// AlertsScanned is how many alerts were inspected, so the caller can say
 	// "nothing found in the last N" rather than implying the box is clean.
 	AlertsScanned int `json:"alerts_scanned"`
@@ -98,7 +125,49 @@ func appsecEventsHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 		out = append(out, evs...)
 	}
-	return appsecEventsResponse{Events: out, AlertsScanned: len(alerts)}, nil
+	return appsecEventsResponse{
+		Events:        out,
+		InlineBlocks:  readInlineBlocks(crowdsecLogPath, limit),
+		AlertsScanned: len(alerts),
+	}, nil
+}
+
+const crowdsecLogPath = "/var/log/crowdsec.log"
+
+// inlineBlockRe pulls the score list and source IP out of the WAF block line.
+// Anchored on "WAF block:" so it never matches the `module=db` alert echo of
+// the same event, which would double-count.
+var inlineBlockRe = regexp.MustCompile(
+	`time="([^"]+)".*WAF block: anomaly score block: (.*?),\s+from ([0-9a-fA-F.:]+)`)
+
+// readInlineBlocks scans the tail of crowdsec.log for inline denials. Reads the
+// whole file and keeps the last n matches: the log is rotated, and a bounded
+// tail is simpler to get right than seeking backwards for an arbitrary count.
+func readInlineBlocks(path string, n int) []InlineBlock {
+	f, err := os.Open(path)
+	if err != nil {
+		return []InlineBlock{}
+	}
+	defer f.Close()
+
+	out := make([]InlineBlock, 0, n)
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		m := inlineBlockRe.FindStringSubmatch(sc.Text())
+		if m == nil {
+			continue
+		}
+		out = append(out, InlineBlock{
+			Timestamp: m[1],
+			Scores:    strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(m[2]), ",")),
+			SourceIP:  m[3],
+		})
+		if len(out) > n {
+			out = out[1:]
+		}
+	}
+	return out
 }
 
 // inspectAppsecAlert flattens one alert's events into AppsecEvent rows.

--- a/panel-agent/internal/commands/security_appsec_events.go
+++ b/panel-agent/internal/commands/security_appsec_events.go
@@ -1,0 +1,175 @@
+// security.crowdsec.appsec.events — surface WHICH CRS rule blocked a request.
+//
+// JAB-193 and its cluster (195/196/197/198) all stalled on the same thing: an
+// operator sees a 403 and has no way to learn which rule fired on which
+// variable. /var/log/crowdsec.log only records the outcome —
+//
+//	"crowdsecurity/appsec-native by ip 1.2.3.4 (IT/8075) : 4h ban on Ip 1.2.3.4"
+//
+// — with no rule, no URI, no matched variable. Writing a CRS exclusion from
+// that is guesswork, and ADR-0124 records what guesswork cost last time: the
+// first triage excluded 901340, which is the non-blocking body-inspection
+// enabler rather than the rule that scored.
+//
+// The data does exist. `cscli alerts inspect <id> -d` carries rule_ids,
+// rule_name, target_uri, target_host and source_ip in each event's meta. This
+// command collects it so `jabali appsec explain` can group it into the shape a
+// person needs to write a surgical exclusion.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// appsecScenario is the scenario cscli files AppSec inband blocks under.
+const appsecScenario = "crowdsecurity/appsec-native"
+
+// defaultAppsecEventLimit bounds how many alerts we inspect. Each alert costs
+// one cscli invocation, and a busy edge box accumulates thousands — the point
+// is a triage sample, not an export.
+const defaultAppsecEventLimit = 25
+
+type appsecEventsParams struct {
+	// Limit caps the alerts inspected (default 25, max 200).
+	Limit int `json:"limit,omitempty"`
+}
+
+// AppsecEvent is one blocked request, flattened from the alert meta.
+type AppsecEvent struct {
+	Timestamp  string   `json:"timestamp"`
+	SourceIP   string   `json:"source_ip"`
+	TargetHost string   `json:"target_host"`
+	TargetURI  string   `json:"target_uri"`
+	Action     string   `json:"action"`
+	RuleName   string   `json:"rule_name"`
+	RuleIDs    []string `json:"rule_ids"`
+	Country    string   `json:"country"`
+	ASNOrg     string   `json:"asn_org"`
+}
+
+type appsecEventsResponse struct {
+	Events []AppsecEvent `json:"events"`
+	// AlertsScanned is how many alerts were inspected, so the caller can say
+	// "nothing found in the last N" rather than implying the box is clean.
+	AlertsScanned int `json:"alerts_scanned"`
+}
+
+func appsecEventsHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	limit := defaultAppsecEventLimit
+	if len(params) > 0 {
+		var p appsecEventsParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, csInvalidArg(fmt.Sprintf("parse params: %v", err))
+		}
+		if p.Limit > 0 {
+			limit = p.Limit
+		}
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	raw, err := runCscliJSON(ctx, "alerts", "list", "--scenario", appsecScenario,
+		"--limit", strconv.Itoa(limit))
+	if err != nil {
+		// No AppSec alerts yet is a normal, healthy state and cscli exits
+		// nonzero for it. Report empty rather than an error the operator has
+		// to interpret.
+		return appsecEventsResponse{Events: []AppsecEvent{}}, nil
+	}
+
+	var alerts []struct {
+		ID int `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &alerts); err != nil {
+		return nil, csInternal("parse cscli alerts list", err)
+	}
+
+	out := make([]AppsecEvent, 0, len(alerts))
+	for _, a := range alerts {
+		evs, err := inspectAppsecAlert(ctx, a.ID)
+		if err != nil {
+			// One unreadable alert must not sink the whole triage run.
+			continue
+		}
+		out = append(out, evs...)
+	}
+	return appsecEventsResponse{Events: out, AlertsScanned: len(alerts)}, nil
+}
+
+// inspectAppsecAlert flattens one alert's events into AppsecEvent rows.
+func inspectAppsecAlert(ctx context.Context, id int) ([]AppsecEvent, error) {
+	raw, err := runCscliJSON(ctx, "alerts", "inspect", strconv.Itoa(id), "-d")
+	if err != nil {
+		return nil, err
+	}
+	var alert struct {
+		Events []struct {
+			Timestamp string `json:"timestamp"`
+			Meta      []struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+			} `json:"meta"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(raw, &alert); err != nil {
+		return nil, err
+	}
+
+	out := make([]AppsecEvent, 0, len(alert.Events))
+	for _, ev := range alert.Events {
+		m := make(map[string]string, len(ev.Meta))
+		for _, kv := range ev.Meta {
+			m[kv.Key] = kv.Value
+		}
+		// Only inband blocks are actionable for FP triage; an out-of-band
+		// scenario hit did not 403 anyone.
+		if m["log_type"] != "appsec-block" {
+			continue
+		}
+		out = append(out, AppsecEvent{
+			Timestamp:  ev.Timestamp,
+			SourceIP:   m["source_ip"],
+			TargetHost: m["target_host"],
+			TargetURI:  m["target_uri"],
+			Action:     m["appsec_action"],
+			RuleName:   m["rule_name"],
+			RuleIDs:    parseRuleIDs(m["rule_ids"]),
+			Country:    m["IsoCode"],
+			ASNOrg:     m["ASNOrg"],
+		})
+	}
+	return out, nil
+}
+
+// parseRuleIDs turns cscli's "[901340 1930792474]" into a slice.
+//
+// Both entries matter and neither alone is the answer. rule_name reports only
+// the FIRST id, and on a real block that is routinely 901340 — the CRS
+// body-inspection enabler, which scores nothing. ADR-0124 was written after
+// exactly that id was excluded to no effect. Returning the full list is what
+// lets the caller show the others, which are the rules that actually scored.
+func parseRuleIDs(s string) []string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	if s == "" {
+		return []string{}
+	}
+	parts := strings.Fields(s)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func init() {
+	Default.Register("security.crowdsec.appsec.events", appsecEventsHandler)
+}

--- a/panel-api/cmd/server/appsec_cmd.go
+++ b/panel-api/cmd/server/appsec_cmd.go
@@ -20,6 +20,7 @@ func newAppSecCmd() *cobra.Command {
 		Short: "CrowdSec AppSec config operator subcommands",
 	}
 	cmd.AddCommand(newAppSecRenderConfigCmd())
+	cmd.AddCommand(newAppSecExplainCmd())
 	return cmd
 }
 
@@ -93,11 +94,11 @@ gate a 'systemctl reload crowdsec' on real diffs.`,
 			}
 
 			body := appseccfg.Render(appseccfg.Opts{
-				Mode:               mode,
-				Countries:          countries,
-				Inband:             inband,
-				AdminAllowlist:     true,
-				WebmailHosts:       webmailHosts,
+				Mode:           mode,
+				Countries:      countries,
+				Inband:         inband,
+				AdminAllowlist: true,
+				WebmailHosts:   webmailHosts,
 			})
 
 			// Write-on-diff: cheap before any nginx/crowdsec reload

--- a/panel-api/cmd/server/appsec_explain_cmd.go
+++ b/panel-api/cmd/server/appsec_explain_cmd.go
@@ -55,6 +55,44 @@ func annotateRules(ids []string) (detections []string, infra []string) {
 	return detections, infra
 }
 
+// printInlineBlocks reports 403s that never became a ban.
+//
+// These are the ones that made JAB-193 hard: an inline denial creates no
+// decision and no alert, so `cscli decisions list` and `cscli alerts list` are
+// both empty for the affected IP and the operator concludes CrowdSec was not
+// involved. crowdsec.log is the only record, and it carries less than an alert
+// does — score families and source IP, no rule id and no URI.
+//
+// Kept in its own section, deliberately: presenting these next to the
+// alert-backed rows above would imply a precision they do not have.
+func printInlineBlocks(blocks []struct {
+	Timestamp string `json:"timestamp"`
+	SourceIP  string `json:"source_ip"`
+	Scores    string `json:"scores"`
+}) {
+	if len(blocks) == 0 {
+		return
+	}
+	byIP := map[string][]string{}
+	order := []string{}
+	for _, b := range blocks {
+		if _, seen := byIP[b.SourceIP]; !seen {
+			order = append(order, b.SourceIP)
+		}
+		byIP[b.SourceIP] = append(byIP[b.SourceIP], b.Scores)
+	}
+
+	fmt.Printf("\nInline 403s with no alert (%d): these never became a ban, so cscli\n", len(blocks))
+	fmt.Println("shows nothing for them. crowdsec.log records no rule id and no URI.")
+	for _, ip := range order {
+		scores := byIP[ip]
+		fmt.Printf("  %-42s %d block(s)   last: %s\n", ip, len(scores), scores[len(scores)-1])
+	}
+	fmt.Println("\nTo get the URI for these, correlate the IP and timestamp against the")
+	fmt.Println("tenant's nginx access log (403 responses). The score family above tells")
+	fmt.Println("you which CRS group to look in — sql_injection, rce, php_injection, lfi.")
+}
+
 func newAppSecExplainCmd() *cobra.Command {
 	var limit int
 	var jsonOut bool
@@ -96,6 +134,11 @@ usually another entry in the rule id list.`,
 					Country    string   `json:"country"`
 					ASNOrg     string   `json:"asn_org"`
 				} `json:"events"`
+				InlineBlocks []struct {
+					Timestamp string `json:"timestamp"`
+					SourceIP  string `json:"source_ip"`
+					Scores    string `json:"scores"`
+				} `json:"inline_blocks"`
 				AlertsScanned int `json:"alerts_scanned"`
 			}
 			if err := json.Unmarshal(raw, &resp); err != nil {
@@ -108,7 +151,7 @@ usually another entry in the rule id list.`,
 				return nil
 			}
 
-			if len(resp.Events) == 0 {
+			if len(resp.Events) == 0 && len(resp.InlineBlocks) == 0 {
 				fmt.Printf("No AppSec blocks found in the last %d alert(s).\n", resp.AlertsScanned)
 				fmt.Println("If a user is reporting a 403, confirm AppSec is in block mode and that the")
 				fmt.Println("request actually reached it — an nginx-level deny never becomes an alert.")
@@ -170,6 +213,7 @@ usually another entry in the rule id list.`,
 			fmt.Println("    reproduces — internal/appseccfg/appseccfg.go holds the jabali-before rules.")
 			fmt.Println("  - Many distinct source IPs on one URI reads as a false positive.")
 			fmt.Println("    One IP across many URIs usually reads as an actual attacker.")
+			printInlineBlocks(resp.InlineBlocks)
 			return nil
 		},
 	}

--- a/panel-api/cmd/server/appsec_explain_cmd.go
+++ b/panel-api/cmd/server/appsec_explain_cmd.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// newAppSecExplainCmd answers the question every AppSec false-positive report
+// starts with and nothing could previously answer: WHICH rule blocked this?
+//
+// /var/log/crowdsec.log records only the outcome —
+//
+//	"crowdsecurity/appsec-native by ip 1.2.3.4 (IT/8075) : 4h ban"
+//
+// — no rule, no URI, no matched variable. Every FP in the JAB-193 cluster
+// (195/196/197/198) stalled on that, and ADR-0124 documents the cost of
+// guessing instead: the first triage excluded 901340, which scores nothing.
+//
+// The data was there the whole time, in `cscli alerts inspect -d` meta. This
+// groups it by rule + URI so the pattern behind a complaint is visible, and an
+// exclusion can be written against a rule that actually fired.
+// crsInfraRules are the CRS rules that appear on almost every block but are
+// never the thing to exclude. Naming them inline is the point of this command:
+// a raw id list like "901340, 930130, 2546897341, 980170" gives no clue that
+// only one of those actually scored.
+//
+//	901340 — enables request-body inspection. Scores nothing. ADR-0124 exists
+//	         because this id was excluded in a first triage, to no effect.
+//	949110 — the inbound anomaly threshold rule. It is what returns 403, but it
+//	         is an effect of the score, not a detection. Excluding it disables
+//	         blocking wholesale.
+//	980170 — reports the final score. Bookkeeping.
+var crsInfraRules = map[string]string{
+	"901340": "body-inspection enabler — scores nothing, never exclude this",
+	"949110": "anomaly threshold reached — the blocker, not a detection",
+	"980170": "score reporting — bookkeeping",
+}
+
+// annotateRules splits an id list into the detections worth acting on and the
+// infrastructure rules that ride along on every block.
+func annotateRules(ids []string) (detections []string, infra []string) {
+	for _, id := range ids {
+		if note, ok := crsInfraRules[id]; ok {
+			infra = append(infra, id+" ("+note+")")
+			continue
+		}
+		detections = append(detections, id)
+	}
+	return detections, infra
+}
+
+func newAppSecExplainCmd() *cobra.Command {
+	var limit int
+	var jsonOut bool
+
+	cmd := &cobra.Command{
+		Use:   "explain",
+		Short: "Show which CRS rules recently blocked requests (AppSec FP triage)",
+		Long: `Groups recent CrowdSec AppSec inband blocks by rule and target URI.
+
+Use this before writing a CRS exclusion. The jabali-before plugin
+(ADR-0124) takes surgical ctl:ruleRemoveTargetById directives, and those
+are only correct if aimed at the rule that actually scored.
+
+Caution: the rule_name field reports only the FIRST matched id, which on a
+real block is routinely 901340 — the CRS body-inspection enabler, which
+contributes no score. Exclude that and nothing changes. The scoring rule is
+usually another entry in the rule id list.`,
+		PreRunE: requireAgent,
+		RunE: func(c *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+
+			raw, err := sharedAgent.Call(ctx, "security.crowdsec.appsec.events", map[string]any{
+				"limit": limit,
+			})
+			if err != nil {
+				return fmt.Errorf("query appsec events: %w", err)
+			}
+
+			var resp struct {
+				Events []struct {
+					Timestamp  string   `json:"timestamp"`
+					SourceIP   string   `json:"source_ip"`
+					TargetHost string   `json:"target_host"`
+					TargetURI  string   `json:"target_uri"`
+					Action     string   `json:"action"`
+					RuleName   string   `json:"rule_name"`
+					RuleIDs    []string `json:"rule_ids"`
+					Country    string   `json:"country"`
+					ASNOrg     string   `json:"asn_org"`
+				} `json:"events"`
+				AlertsScanned int `json:"alerts_scanned"`
+			}
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return fmt.Errorf("decode agent response: %w", err)
+			}
+
+			if jsonOut {
+				out, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Println(string(out))
+				return nil
+			}
+
+			if len(resp.Events) == 0 {
+				fmt.Printf("No AppSec blocks found in the last %d alert(s).\n", resp.AlertsScanned)
+				fmt.Println("If a user is reporting a 403, confirm AppSec is in block mode and that the")
+				fmt.Println("request actually reached it — an nginx-level deny never becomes an alert.")
+				return nil
+			}
+
+			type group struct {
+				rules  string
+				uri    string
+				host   string
+				count  int
+				ips    map[string]bool
+				sample string
+			}
+			groups := map[string]*group{}
+			for _, e := range resp.Events {
+				key := strings.Join(e.RuleIDs, ",") + "|" + e.TargetHost + "|" + e.TargetURI
+				g, ok := groups[key]
+				if !ok {
+					g = &group{
+						rules: strings.Join(e.RuleIDs, ", "),
+						uri:   e.TargetURI, host: e.TargetHost,
+						ips: map[string]bool{}, sample: e.Timestamp,
+					}
+					groups[key] = g
+				}
+				g.count++
+				g.ips[e.SourceIP] = true
+			}
+
+			ordered := make([]*group, 0, len(groups))
+			for _, g := range groups {
+				ordered = append(ordered, g)
+			}
+			sort.Slice(ordered, func(i, j int) bool { return ordered[i].count > ordered[j].count })
+
+			fmt.Printf("AppSec blocks across the last %d alert(s) — %d event(s), %d distinct pattern(s):\n\n",
+				resp.AlertsScanned, len(resp.Events), len(ordered))
+			for _, g := range ordered {
+				det, infra := annotateRules(strings.Split(g.rules, ", "))
+				fmt.Printf("  %d block(s), %d distinct source IP(s)\n", g.count, len(g.ips))
+				if len(det) > 0 {
+					fmt.Printf("    scored by: %s   <- exclude one of THESE\n", strings.Join(det, ", "))
+				} else {
+					fmt.Printf("    scored by: (none identified — only infrastructure rules matched)\n")
+				}
+				for _, i := range infra {
+					fmt.Printf("    also     : %s\n", i)
+				}
+				fmt.Printf("    host     : %s\n", g.host)
+				fmt.Printf("    uri      : %s\n", g.uri)
+				fmt.Printf("    first at : %s\n\n", g.sample)
+			}
+
+			fmt.Println("Writing an exclusion:")
+			fmt.Println("  - Ignore 901340 if present. It enables body inspection and scores nothing;")
+			fmt.Println("    excluding it changes nothing (ADR-0124 was written after that mistake).")
+			fmt.Println("  - Target the rule that scored, and scope it to the narrowest ARGS/URI that")
+			fmt.Println("    reproduces — internal/appseccfg/appseccfg.go holds the jabali-before rules.")
+			fmt.Println("  - Many distinct source IPs on one URI reads as a false positive.")
+			fmt.Println("    One IP across many URIs usually reads as an actual attacker.")
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&limit, "limit", 25, "how many recent AppSec alerts to inspect (max 200)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw JSON instead of the grouped report")
+	return cmd
+}


### PR DESCRIPTION
Addresses JAB-193 — the blocker underneath the whole WAF false-positive cluster.

## The problem

JAB-195, 196, 197 and 198 all stall on the same missing capability: an operator sees a 403 and **cannot find out which rule fired**. `/var/log/crowdsec.log` records only the outcome:

```
crowdsecurity/appsec-native by ip 1.2.3.4 (IT/8075) : 4h ban on Ip 1.2.3.4
```

No rule, no URI, no matched variable. JAB-197 says outright that rule IDs must be captured before an exclusion can be written. ADR-0124 records what happens without them — the first triage excluded **901340**, which scores nothing, and the FP continued.

## The data was already there

`cscli alerts inspect <id> -d` carries `rule_ids`, `rule_name`, `target_uri`, `target_host` and `source_ip` in each event's meta. Nothing surfaced it. This adds the agent command that collects it and a CLI that groups it by rule + URI.

## Output

```
  2 block(s), 2 distinct source IP(s)
    scored by: 930130, 2546897341   <- exclude one of THESE
    also     : 901340 (body-inspection enabler — scores nothing, never exclude this)
    also     : 980170 (score reporting — bookkeeping)
    host     : jabali.site
    uri      : /.git/config
```

Naming the infrastructure rules inline is the point. `901340`, `949110` and `980170` ride along on nearly every block, and a bare list —

```
rule ids: 901340, 930130, 2546897341, 980170
```

— gives no clue that only one of those actually scored. That's exactly how the ADR-0124 mistake happened. The warning now lives in the tool rather than in a document nobody reads mid-incident.

## Verified against real data

Run on a live AppSec host with ~23k events. The sample above is real output, and it shows something worth noting: `/.git/config` and `/backend/.env` probes blocked by `930130` are the WAF **working**. So the same command distinguishes a false positive from an actual attacker rather than only surfacing complaints:

- many distinct source IPs on one legitimate URI → reads as an FP
- one IP across many URIs → reads as a scanner

That heuristic is printed in the footer.

## Scope

This does **not** fix JAB-196 or 197. It makes them diagnosable, which they were not — both need the matched rule IDs from the affected host, and the reporting host is newzaps (production), so I didn't gather them.

The suggested next step for those two is to run `jabali appsec explain` there and write the exclusion against whatever `scored by` reports, using the surgical `ctl:ruleRemoveTargetById` pattern already in `internal/appseccfg/appseccfg.go`.

## Note

`TestCLIReferenceGolden` drifts on any new command; the generated reference is regenerated with `-update` in a second commit. Delta is only the new subcommand and its two flags.

## Correction: alerts alone were not enough

The first version of this read `cscli alerts` only, which misses the exact failure JAB-193 describes:

> Blocks were CrowdSec AppSec WAF inline denials — no ban decision was created, so `cscli decisions list` / `cscli alerts list` showed nothing for the IP, which made diagnosis non-obvious.

An inline denial returns 403 without creating a decision or an alert. The tool as first written would have reported *nothing* for the editor who was actually being blocked — worse than no tool, because it answers "no blocks found" to someone who is definitely being blocked.

`crowdsec.log` is the only record, and it carries less than an alert does:

```
WAF block: anomaly score block: lfi: 5, anomaly: 8,  from 1.2.3.4 (127.0.0.1)
```

Score families and source IP; no rule id, no URI. So these are reported in their own section rather than merged with the alert-backed rows — presenting them together would imply a precision they don't have:

```
Inline 403s with no alert (3): these never became a ban, so cscli
shows nothing for them. crowdsec.log records no rule id and no URI.
  172.105.23.240    1 block(s)   last: anomaly: 11
  172.105.23.113    1 block(s)   last: lfi: 5, anomaly: 8
  68.183.107.158    1 block(s)   last: anomaly: 8
```

The footer says how to close the remaining gap — correlate IP + timestamp against the tenant's nginx 403s — which is how JAB-193 was diagnosed by hand in the first place.

The regex anchors on `WAF block:` so it doesn't also match the `module=db` alert echo of the same event, which would double-count every block that *did* escalate.

Verified on a live host with 456 inline blocks in the log.
