### PR TITLE
fix(boot): order panel-api and the CLI timers after mariadb

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5540,8 +5540,8 @@ write_systemd_unit() {
   cat >"/etc/systemd/system/${SERVICE_NAME}.service" <<EOF
 [Unit]
 Description=Jabali Panel API
-After=network-online.target ${AGENT_SERVICE_NAME}.service redis-server.service
-Wants=network-online.target
+After=network-online.target ${AGENT_SERVICE_NAME}.service redis-server.service mariadb.service
+Wants=network-online.target mariadb.service
 # Panel hard-requires the agent at boot; without the socket we can't do
 # privileged ops. If the agent crashes post-boot the panel stays up —
 # individual handlers will return 503 with agent:unavailable.
@@ -5549,6 +5549,19 @@ Wants=network-online.target
 # Redis is a hard dep too (M14 / ADR-0056): the notification dispatcher
 # can't run without its stream. systemd will restart panel-api if
 # redis-server stops, so the ordering is symmetric with mariadb's.
+#
+# mariadb is in After=/Wants= but deliberately NOT in Requires=. The
+# first thing main() does is ping the DB and exit(1) if it fails, so
+# without the ordering panel-api reliably loses the race on a slow or
+# small host: measured on a 2 GB / 2 vCPU box, panel-api started 44s
+# before mariadb was ready and died with
+#
+#   Error: ping: dial unix /var/run/mysqld/mysqld.sock: no such file
+#
+# every single boot, recovering only via Restart=on-failure. Requires=
+# is the wrong tool for that — it would also stop the panel whenever
+# mariadb restarts, which is a worse outcome than handlers returning
+# errors for a few seconds. Ordering is the actual bug; coupling isn't.
 Requires=${AGENT_SERVICE_NAME}.service redis-server.service
 
 [Service]

--- a/install/systemd/jabali-backup-retention.service
+++ b/install/systemd/jabali-backup-retention.service
@@ -1,12 +1,27 @@
 [Unit]
 Description=Jabali backup retention sweep (M30 — restic forget + prune)
 Documentation=https://github.com/shukiv/jabali-panel/blob/main/docs/adr/0075-backup-restore-restic.md
-After=jabali-panel.service network-online.target
+After=jabali-panel.service network-online.target mariadb.service
 # No Requires=jabali-panel.service. The CLI reads server_settings to pick
 # up keep-daily/weekly/monthly knobs but the panel may be transiently down
 # during boot; install.sh enables this timer in the install foundation
 # step before the panel unit lands. A failed run is tolerated — the timer
 # fires again at 04:30 the next day. `Restart=no` matches the M22 reaper.
+#
+# mariadb.service is listed explicitly rather than relied on transitively
+# through jabali-panel.service. `jabali backup retention apply` opens its
+# own connection, so "the panel started" says nothing about whether the
+# socket is there yet. Without this the Persistent=true catch-up run — the
+# one that fires at boot after a host was off at 04:30 — loses the race
+# and dies with
+#
+#   open db: open mariadb: dial unix /var/run/mysqld/mysqld.sock:
+#   connect: no such file or directory
+#
+# Observed on a 2 GB / 2 vCPU host where mariadb took 44s to accept
+# connections. Restart=no means that run is simply lost, so on a host
+# that is powered off overnight retention can go indefinitely without
+# ever completing a sweep while looking merely "failed once" each boot.
 
 [Service]
 Type=oneshot

--- a/install/systemd/jabali-cache-doctor.service
+++ b/install/systemd/jabali-cache-doctor.service
@@ -1,7 +1,12 @@
 [Unit]
 Description=Jabali WordPress cache health drift auto-repair (GH #605)
 Documentation=https://github.com/shukiv/jabali-panel
-After=jabali-panel.service jabali-agent.service
+After=jabali-panel.service jabali-agent.service mariadb.service
+# mariadb.service is explicit, not inherited via jabali-panel.service:
+# this unit's CLI opens its own DB connection, so panel-api having
+# started proves nothing about socket readiness. Persistent=true means
+# it can fire at boot, which is exactly when mariadb may still be
+# starting (measured: 44s on a 2 GB / 2 vCPU host).
 # No Requires= — same rationale as jabali-sso-reaper.service: this timer is
 # enabled before the panel/agent units are written on first install. After=
 # keeps boot ordering; a transient failure while they're down is tolerated.

--- a/install/systemd/jabali-retention-sweep.service
+++ b/install/systemd/jabali-retention-sweep.service
@@ -1,7 +1,12 @@
 [Unit]
 Description=Jabali retention sweep (prune expired log/report table rows)
 Documentation=https://github.com/shukiv/jabali-panel/blob/main/panel-api/cmd/server/retention_sweep_cmd.go
-After=jabali-panel.service
+After=jabali-panel.service mariadb.service
+# mariadb.service is explicit, not inherited via jabali-panel.service:
+# this unit's CLI opens its own DB connection, so panel-api having
+# started proves nothing about socket readiness. Persistent=true means
+# it can fire at boot, which is exactly when mariadb may still be
+# starting (measured: 44s on a 2 GB / 2 vCPU host).
 # No Requires=: the sweep talks to the panel DB directly; a transient failure
 # during boot/restart is tolerated (next daily firing retries).
 

--- a/install/systemd/jabali-sso-reaper.service
+++ b/install/systemd/jabali-sso-reaper.service
@@ -1,7 +1,12 @@
 [Unit]
 Description=Jabali SSO file reaper (M22 — sweeps stale jabali-sso-*.php)
 Documentation=https://github.com/shukiv/jabali-panel/blob/main/docs/adr/0040-m22-sso-file.md
-After=jabali-panel.service jabali-agent.service
+After=jabali-panel.service jabali-agent.service mariadb.service
+# mariadb.service is explicit, not inherited via jabali-panel.service:
+# this unit's CLI opens its own DB connection, so panel-api having
+# started proves nothing about socket readiness. Persistent=true means
+# it can fire at boot, which is exactly when mariadb may still be
+# starting (measured: 44s on a 2 GB / 2 vCPU host).
 # No Requires= on jabali-agent.service: install.sh enables this timer
 # (install_sso_reaper_timer at step 7) BEFORE it writes the panel +
 # agent unit files (happens much later in the install flow). systemd

--- a/panel-agent/internal/commands/systemd_db_ordering_test.go
+++ b/panel-agent/internal/commands/systemd_db_ordering_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// jabaliCLIExecRe matches an ExecStart that shells out to the jabali CLI.
+// Every such unit opens its own MariaDB connection during startup, which is
+// what makes boot ordering load-bearing for it.
+var jabaliCLIExecRe = regexp.MustCompile(`(?m)^ExecStart=.*?/usr/local/bin/jabali\s`)
+
+var afterLineRe = regexp.MustCompile(`(?m)^After=(.*)$`)
+
+// TestCLIUnitsAreOrderedAfterMariaDB guards a boot race that is invisible on a
+// fast host and reliable on a slow one.
+//
+// `After=jabali-panel.service` looks like it implies the database is up, and it
+// does not: these units run /usr/local/bin/jabali, which dials
+// /var/run/mysqld/mysqld.sock itself. On a 2 GB / 2 vCPU host mariadb took 44
+// seconds to accept connections, and jabali-backup-retention.service — fired at
+// boot by its own Persistent=true catch-up — died with
+//
+//	open db: open mariadb: dial unix /var/run/mysqld/mysqld.sock:
+//	connect: no such file or directory
+//
+// It carries Restart=no, so that run was simply lost. A host powered off
+// overnight can therefore miss retention indefinitely while showing nothing
+// worse than one failed unit per boot.
+//
+// The check is written against the whole directory rather than a fixed list so
+// that a unit added later cannot quietly reintroduce it.
+func TestCLIUnitsAreOrderedAfterMariaDB(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	dir := filepath.Join(root, "install", "systemd")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".service") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		text := string(body)
+		if !jabaliCLIExecRe.MatchString(text) {
+			continue
+		}
+		checked++
+
+		m := afterLineRe.FindStringSubmatch(text)
+		if m == nil {
+			t.Errorf("%s runs the jabali CLI but has no After= line at all; "+
+				"it needs After=mariadb.service or it will race the database at boot",
+				e.Name())
+			continue
+		}
+		if !strings.Contains(m[1], "mariadb.service") {
+			t.Errorf("%s runs the jabali CLI but is only ordered %q. "+
+				"The CLI opens its own DB connection, so ordering after "+
+				"jabali-panel.service does not imply mysqld.sock exists — "+
+				"add mariadb.service to After=.", e.Name(), strings.TrimSpace(m[1]))
+		}
+	}
+
+	// A rename or a path change that stops matching jabaliCLIExecRe would
+	// otherwise turn this into a test that silently checks nothing.
+	if checked == 0 {
+		t.Fatal("matched no units invoking /usr/local/bin/jabali — the ExecStart " +
+			"pattern has drifted and this test is no longer checking anything")
+	}
+}
+
+// TestPanelUnitOrdersAfterMariaDB covers the same race for panel-api itself,
+// whose unit is generated inline by install.sh rather than shipped as a file.
+//
+// main() pings the database and exits(1) on failure, so without the ordering
+// panel-api hard-crashes on every boot of a slow host —
+//
+//	Error: ping: dial unix /var/run/mysqld/mysqld.sock: no such file
+//
+// — and comes back only because Restart=on-failure catches it. That is
+// recoverable, which is precisely why it can sit unnoticed for a long time.
+func TestPanelUnitOrdersAfterMariaDB(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	sh, err := os.ReadFile(filepath.Join(root, "install.sh"))
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+
+	idx := strings.Index(string(sh), "Description=Jabali Panel API")
+	if idx < 0 {
+		t.Fatal("could not find the panel unit block in install.sh — " +
+			"the Description= line moved and this test needs updating")
+	}
+	// The [Unit] section ends at the next section header.
+	rest := string(sh)[idx:]
+	if end := strings.Index(rest, "[Service]"); end > 0 {
+		rest = rest[:end]
+	}
+
+	m := afterLineRe.FindStringSubmatch(rest)
+	if m == nil {
+		t.Fatal("panel unit has no After= line")
+	}
+	if !strings.Contains(m[1], "mariadb.service") {
+		t.Errorf("panel unit is ordered %q with no mariadb.service; "+
+			"panel-api pings the DB at startup and exits nonzero if it is not "+
+			"reachable, so it will crash once on every boot of a host where "+
+			"mariadb is slow to come up", strings.TrimSpace(m[1]))
+	}
+}


### PR DESCRIPTION
Found on a freshly-provisioned 2 GB / 2 vCPU Debian 13 host, which had three failed units at boot. This is the first of them.

## The race

`jabali-panel.service` was never ordered after `mariadb.service`. panel-api pings the database in `main()` and exits nonzero if it can't reach it, so on a host where mariadb is slow the panel simply loses:

```
18:08:52  jabali-panel.service started
18:09:28  Error: ping: dial unix /var/run/mysqld/mysqld.sock: no such file
18:09:36  mariadb ready for connections
```

44 seconds. Every boot. It comes back only because `Restart=on-failure` catches it, which is exactly why this has gone unnoticed — the whole trace is one ERROR line and `NRestarts=1`.

## The unit that doesn't recover

`jabali-backup-retention.service` has `Restart=no`, and its timer is `Persistent=true`. So the catch-up run — the one that fires at boot after a host was powered off at 04:30 — hits the same race and is simply lost:

```
open db: open mariadb: dial unix /var/run/mysqld/mysqld.sock:
connect: no such file or directory
```

A host that's off overnight can go a long time without ever completing a retention sweep. It presents as one failed unit per boot, not as "backups are never pruned".

## Why `After=jabali-panel.service` wasn't enough

It reads like it implies the database is up. It doesn't — these units run `/usr/local/bin/jabali`, which opens its own connection. `jabali-migration-secrets-reap.service` already listed `mariadb.service` explicitly; the other four now match it. That's the complete set of units invoking the CLI.

## Ordering, not coupling

`mariadb` goes in `After=` and `Wants=`, deliberately not `Requires=`. The bug is sequencing. `Requires=` would additionally stop the panel whenever mariadb restarts, trading a bounded startup failure for an unbounded runtime one.

## Tests

Both scan `install/systemd/` rather than a fixed list, so a unit added later can't reintroduce this. Both fail against the pre-fix tree — verified by reverting each change in turn.

## Verified

Reboot on the affected host: **three failed units and `NRestarts=1` before, zero failed units and `NRestarts=0` after.**
