### PR TITLE
fix(install): move the $REPO_DIR readers after clone_or_update_repo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13912,8 +13912,10 @@ main() {
   run_if_module security install_crowdsec_profiles
   run_if_module security install_login_allowlist_default_conf
   run_if_module security install_crowdsec_jabali_scenarios
-  run_if_module security install_crowdsec_jabali_stalwart_scenarios
-  run_if_module security install_crowdsec_jabali_kratos_scenarios
+  # The stalwart + kratos scenario installers are NOT here with their sibling:
+  # unlike install_crowdsec_jabali_scenarios, which carries its YAML inline,
+  # both copy from $REPO_DIR/install/crowdsec/, so they have to wait for
+  # clone_or_update_repo. They run just after it.
   run_if_module security install_crowdsec_blocklists
   cleanup_modsecurity
   run_if_module security install_malware_stack
@@ -13924,14 +13926,21 @@ main() {
   install_per_user_egress
   install_goaccess
   install_restart_drop_ins
-  install_logrotate
-  install_notify_template
   clone_or_update_repo
   # install_apparmor and install_aide run AFTER clone_or_update_repo because
   # both functions source profile/unit files from $REPO_DIR/install/; on a
   # fresh install that directory does not exist until the repo is cloned.
+  #
+  # install_logrotate and install_notify_template belong to that same group and
+  # used to run just above the clone, where $REPO_DIR/install/ cannot exist yet
+  # on a fresh host. Both source-check and return 0 with only a _warn, so the
+  # install stayed green while silently shipping neither file.
   run_if_module security install_apparmor
   run_if_module security install_aide
+  install_logrotate
+  install_notify_template
+  run_if_module security install_crowdsec_jabali_stalwart_scenarios
+  run_if_module security install_crowdsec_jabali_kratos_scenarios
   install_snuffleupagus
   protect_panel_docs
   # M25: source the socket-helper definitions now that the repo's install/

--- a/panel-agent/internal/commands/install_repo_dir_ordering_test.go
+++ b/panel-agent/internal/commands/install_repo_dir_ordering_test.go
@@ -1,0 +1,151 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	// mainFuncRe locates the start of main() in install.sh.
+	mainFuncRe = regexp.MustCompile(`(?m)^main\(\) \{`)
+
+	// installCallRe matches a call inside main(), with or without the
+	// run_if_module <module> prefix, and captures the function name.
+	installCallRe = regexp.MustCompile(`(?m)^[[:space:]]+(?:run_if_module [a-z_]+ )?([a-z_][a-z0-9_]*)[[:space:]]*$`)
+
+	// repoInstallRefRe matches a read of the repo's install/ tree, which does
+	// not exist until clone_or_update_repo has run.
+	repoInstallRefRe = regexp.MustCompile(`\$\{?REPO_DIR\}?/install/`)
+)
+
+// TestNoRepoDirReadsBeforeClone pins an ordering rule that install.sh states in
+// a comment but had no enforcement behind it:
+//
+//	install_apparmor and install_aide run AFTER clone_or_update_repo because
+//	both functions source profile/unit files from $REPO_DIR/install/; on a
+//	fresh install that directory does not exist until the repo is cloned.
+//
+// Four other functions read the same tree and were called before the clone.
+// Each guards its sources with a `_warn` and `return 0`, so a fresh install
+// finished green having silently shipped none of them. Confirmed absent on a
+// host installed from a release build:
+//
+//	/etc/logrotate.d/jabali                            (panel, agent and
+//	                                                    bulwark logs never
+//	                                                    rotate)
+//	/etc/systemd/system/jabali-notify@.service         (8 OnFailure drop-ins
+//	                                                    reference it; systemd
+//	                                                    logged 21 "Unit not
+//	                                                    found" errors in one
+//	                                                    boot, so no
+//	                                                    service-down
+//	                                                    notification can fire)
+//	/usr/local/bin/jabali-notify-onfailure
+//	/etc/crowdsec/acquis.d/jabali-panel.yaml           (panel-api's own logs
+//	                                                    are never ingested, so
+//	                                                    the JAB-106
+//	                                                    kratos_flow_rate_limited
+//	                                                    marker is unreachable)
+//	/etc/crowdsec/parsers/s01-parse/jabali-panel-kratos.yaml
+//	  plus the whole install/crowdsec/stalwart/ tree
+//
+// A commit already exists that re-runs two of these during `jabali update`,
+// which repairs an upgraded host and leaves a fresh one broken. This asserts
+// the ordering instead, so the gap cannot reappear via a newly added call.
+func TestNoRepoDirReadsBeforeClone(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "install.sh"))
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	script := string(raw)
+
+	loc := mainFuncRe.FindStringIndex(script)
+	if loc == nil {
+		t.Fatal("could not find main() in install.sh")
+	}
+	body := script[loc[1]:]
+
+	// Everything in main() up to the clone runs without $REPO_DIR/install/.
+	cloneIdx := strings.Index(body, "\n  clone_or_update_repo\n")
+	if cloneIdx < 0 {
+		t.Fatal("could not find the clone_or_update_repo call in main() — " +
+			"if it was renamed this test needs updating, and the ordering rule " +
+			"it protects still applies")
+	}
+	preClone := body[:cloneIdx]
+	postClone := body[cloneIdx:]
+
+	// A function called on both sides of the clone is fine: the pre-clone call
+	// does whatever does not need the repo, and the post-clone call fills in
+	// the rest. install_crowdsec_appsec is deliberately built this way — the
+	// early call installs the binary, the later one renders the acquis that
+	// lives in $REPO_DIR (GH #109). Its artifacts are present on a fresh host,
+	// which is the evidence that the second call really does heal it.
+	calledAfterClone := map[string]bool{}
+	for _, m := range installCallRe.FindAllStringSubmatch(postClone, -1) {
+		calledAfterClone[m[1]] = true
+	}
+
+	bodies := installShFunctionBodies(script)
+
+	seen := map[string]bool{}
+	checked := 0
+	for _, m := range installCallRe.FindAllStringSubmatch(preClone, -1) {
+		name := m[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if calledAfterClone[name] {
+			continue
+		}
+		fnBody, ok := bodies[name]
+		if !ok {
+			// Not a function defined in install.sh (a builtin, a variable
+			// assignment that looks like a call, etc.).
+			continue
+		}
+		checked++
+		if repoInstallRefRe.MatchString(fnBody) {
+			t.Errorf("%s() is called before clone_or_update_repo but reads "+
+				"$REPO_DIR/install/. On a fresh install that path does not "+
+				"exist yet, and the function warns and returns 0 rather than "+
+				"failing — so the install completes green with the files "+
+				"missing. Move the call to after clone_or_update_repo.", name)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("resolved no install.sh functions from main()'s pre-clone " +
+			"section — the call or definition pattern has drifted and this " +
+			"test is no longer checking anything")
+	}
+}
+
+// installShFunctionBodies maps every top-level `name() {` in install.sh to its
+// body, ending at the first line that is exactly "}". install.sh consistently
+// closes top-level functions in column 0, which makes that terminator reliable
+// without needing to balance braces.
+func installShFunctionBodies(script string) map[string]string {
+	defRe := regexp.MustCompile(`(?m)^([a-z_][a-z0-9_]*)\(\)[[:space:]]*\{$`)
+	out := map[string]string{}
+	for _, m := range defRe.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		rest := script[m[1]:]
+		if end := strings.Index(rest, "\n}"); end >= 0 {
+			out[name] = rest[:end]
+		} else {
+			out[name] = rest
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Second finding from the same freshly-provisioned host. This one is the reason several features were quietly absent on it.

## The rule already existed

install.sh states it in a comment:

> `install_apparmor` and `install_aide` run AFTER `clone_or_update_repo` because both functions source profile/unit files from `$REPO_DIR/install/`; on a fresh install that directory does not exist until the repo is cloned.

Four other functions read that same tree and were called **above** the clone. Each guards its sources with a `_warn` and `return 0`, so a fresh install finishes green having shipped none of them.

## What was actually missing

Confirmed absent on a host installed from a release build, two months after all of this landed:

| Path | Consequence |
|---|---|
| `/etc/logrotate.d/jabali` | `/var/log/jabali-panel`, `-agent`, `-bulwark` never rotate |
| `/etc/systemd/system/jabali-notify@.service` + helper | 8 OnFailure drop-ins point at it; **21** "Unit not found" errors in one boot |
| `install/crowdsec/stalwart/` (acquis + 5 scenarios) | mail brute-force / SMTP scan detection not wired |
| `/etc/crowdsec/acquis.d/jabali-panel.yaml` + kratos parser | panel-api logs never ingested, JAB-106 marker unreachable |

The notifier one is worth dwelling on: every `OnFailure=jabali-notify@%N.service` across the fleet is a silent no-op on any host that has never been updated. The M14 service-down notification path cannot fire at all. systemd logs it and moves on:

```
pdns.service: Failed to enqueue OnFailure=jabali-notify@pdns.service job,
ignoring: Unit jabali-notify@pdns.service not found.
```

## What is *not* affected

The panel's nginx-fed login brute-force scenarios (`jabali-panel-login-bf` and friends) are fine — they carry their YAML inline and filter on `http_access-log`. That's why this gap isn't visible from the Security dashboard, and why I checked before claiming otherwise.

## Prior art

Commit `70b7b31c` re-ran two of these during `jabali update`. That repairs an upgraded host and leaves a fresh one broken. Fixing the ordering covers both, so that re-run is now belt-and-braces rather than the only path.

## The test

Derives the call list from `main()` instead of hardcoding it, so a newly added call is caught too.

It exempts functions called on **both** sides of the clone — `install_crowdsec_appsec` is deliberately split that way (early call installs the binary, later one renders the acquis, GH #109). That exemption isn't a guess: its artifacts *are* present on the affected host, which is the evidence the second call really does heal it.

Against the pre-fix tree the test names exactly the four functions above.

## Verified

Ran the four functions in their new position on the affected host: logrotate config, notifier unit + helper, and the Stalwart acquis and five scenarios all appear; `jabali-notify@pdns.service` resolves; crowdsec stays active; `logrotate -d` parses the new config. The two panel/Kratos files stayed absent there only because that box's checkout predates them.
