### PR TITLE
fix(dns): re-derive pdns local-address at start so an IP change can't kill DNS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10861,6 +10861,76 @@ install_logrotate() {
   find /tmp -maxdepth 1 -name 'jabali_install-*.log' -type f -mtime +14 -delete 2>/dev/null || true
 }
 
+install_pdns_local_address_helper() {
+  # PowerDNS treats a bind failure as fatal, and install.sh bakes the host's
+  # addresses into local-address= at install time. When the address later
+  # changes — DHCP lease, restore onto a new host, cloud reassignment,
+  # failover — pdns dies on every start:
+  #
+  #   Fatal error: Unable to bind to UDP socket
+  #   pdns.service: Start request repeated too quickly.
+  #
+  # and authoritative DNS stays down until an operator re-runs install.sh.
+  # Seen on a host restored from an image onto a new address: 27 restarts,
+  # then the start limit, then silence.
+  #
+  # ExecStartPre re-derives the list in the one moment it matters, with no
+  # dependency on the database or the panel (both of which start after pdns).
+  #
+  # Reads $REPO_DIR/install/systemd/, so this must stay after
+  # clone_or_update_repo — TestNoRepoDirReadsBeforeClone enforces that.
+  local src="${REPO_DIR}/install/systemd/pdns-local-address"
+  local dst=/usr/local/libexec/jabali/pdns-local-address
+  local dropin_dir=/etc/systemd/system/pdns.service.d
+  local dropin="${dropin_dir}/20-jabali-local-address.conf"
+
+  if [[ ! -f "$src" ]]; then
+    _warn "pdns-local-address helper missing at $src — skipping"
+    return 0
+  fi
+  # No jabali pdns config means this host does not run our PowerDNS layout.
+  if [[ ! -f /etc/powerdns/pdns.d/01-jabali-mysql.conf ]]; then
+    return 0
+  fi
+
+  local changed=0
+  install -d -m 0755 /usr/local/libexec/jabali
+  if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+    install -m 0755 -o root -g root "$src" "$dst"
+    changed=1
+  fi
+
+  install -d -m 0755 "$dropin_dir"
+  local want
+  want="$(cat <<DROPIN
+# Managed by jabali-panel install.sh. Hand edits will be overwritten.
+#
+# Re-point local-address= at the addresses this host currently has, before
+# pdns binds them. Without this, any address change makes pdns fatal on
+# start and takes authoritative DNS down until install.sh is re-run.
+#
+# The leading '+' is load-bearing. Debian's pdns.service runs User=pdns with
+# ProtectSystem=full, so a plain ExecStartPre would run unprivileged with
+# /etc read-only and exit 1 — and a failed ExecStartPre keeps the service
+# down even when the config is fine, turning a self-heal into a second way
+# to break DNS. '+' runs the helper as root outside the sandbox.
+[Service]
+ExecStartPre=+${dst}
+DROPIN
+)"
+  if [[ ! -f "$dropin" ]] || [[ "$(cat "$dropin")" != "$want" ]]; then
+    printf '%s\n' "$want" > "$dropin"
+    chmod 0644 "$dropin"
+    changed=1
+  fi
+
+  if (( changed )); then
+    systemctl daemon-reload
+    _log "pdns local-address self-heal installed"
+  fi
+  _ok "pdns local-address helper ready"
+}
+
 install_notify_template() {
   _log "installing OnFailure notifier (M14)"
 
@@ -13939,6 +14009,7 @@ main() {
   run_if_module security install_aide
   install_logrotate
   install_notify_template
+  run_if_module dns install_pdns_local_address_helper
   run_if_module security install_crowdsec_jabali_stalwart_scenarios
   run_if_module security install_crowdsec_jabali_kratos_scenarios
   install_snuffleupagus

--- a/install/systemd/pdns-local-address
+++ b/install/systemd/pdns-local-address
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# pdns-local-address — re-point PowerDNS at the addresses this host actually
+# has, immediately before pdns binds them.
+#
+# Why this exists
+# ---------------
+# install.sh enumerates every global-scope address once, at install time, and
+# writes them into local-address= in 01-jabali-mysql.conf. PowerDNS treats a
+# bind failure as fatal, so the moment the host's address changes, pdns dies:
+#
+#   Fatal error: Unable to bind to UDP socket
+#   pdns.service: Start request repeated too quickly.
+#
+# and authoritative DNS stays down until an operator notices and re-runs
+# install.sh. Observed on a host whose address moved from 192.168.100.86 to
+# .165 after being restored from an image: 27 restart attempts, then the start
+# limit, then nothing.
+#
+# The address changing is not an exotic event — a DHCP lease change, a restore
+# onto a new host, a cloud reassignment or a failover all do it, and all of
+# them are exactly when DNS most needs to come back up unattended.
+#
+# Running as ExecStartPre on pdns.service means the file is corrected in the
+# one moment it matters and without needing the database or the panel, both of
+# which come up later than pdns.
+#
+# Interface skipping matches install.sh: LXC's lxcbr0, libvirt's virbr0 and
+# Docker's bridges all carry their own resolver on :53, and binding pdns there
+# collides with it.
+
+set -Eeuo pipefail
+
+CONF="${JABALI_PDNS_CONF:-/etc/powerdns/pdns.d/01-jabali-mysql.conf}"
+
+# No jabali-managed pdns config means this host does not run our PowerDNS
+# layout at all. Leave it completely alone.
+[[ -f "$CONF" ]] || exit 0
+
+skip_iface_re='^(lxcbr[0-9]+|virbr[0-9]+|docker[0-9]+|br-[0-9a-f]+|cni[0-9]+|veth.*|tailscale.*|wg[0-9]+)$'
+
+# Loopback:5300 is always emitted — it is the port pdns-recursor forwards
+# local queries into (ADR-0047), and it does not depend on any interface.
+addrs="$({
+  ip -4 -o addr show scope global 2>/dev/null \
+    | awk -v re="$skip_iface_re" '$2 !~ re { split($4,a,"/"); print a[1] ":53" }'
+  ip -6 -o addr show scope global 2>/dev/null \
+    | awk -v re="$skip_iface_re" '$2 !~ re { split($4,a,"/"); print "[" a[1] "]:53" }'
+  printf '127.0.0.1:5300\n[::1]:5300\n'
+} | sort -u | paste -sd ',' -)"
+
+# Defensive: the loopback entries above are unconditional, so this cannot
+# normally be empty. If it somehow is, changing nothing is strictly safer than
+# writing a local-address= line pdns will reject.
+if [[ -z "$addrs" ]]; then
+  echo "pdns-local-address: enumeration produced nothing; leaving $CONF unchanged" >&2
+  exit 0
+fi
+
+current="$(awk -F= '/^local-address=/{print $2; exit}' "$CONF")"
+if [[ "$current" == "$addrs" ]]; then
+  exit 0
+fi
+
+echo "pdns-local-address: ${current:-<unset>} -> ${addrs}" >&2
+
+# Rewrite via a temp file in the same directory so the replacement is atomic
+# and a crash mid-write cannot leave pdns with a truncated config.
+tmp="$(mktemp "${CONF}.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+cat "$CONF" > "$tmp"
+if grep -q '^local-address=' "$tmp"; then
+  # The value can contain '&' and '/', neither of which survives a bare sed
+  # replacement, so match the line and print the new one instead.
+  awk -v new="local-address=${addrs}" \
+    '/^local-address=/ && !done { print new; done=1; next } { print }' \
+    "$CONF" > "$tmp"
+else
+  printf 'local-address=%s\n' "$addrs" >> "$tmp"
+fi
+
+chmod --reference="$CONF" "$tmp" 2>/dev/null || chmod 0640 "$tmp"
+chown --reference="$CONF" "$tmp" 2>/dev/null || chown root:pdns "$tmp" 2>/dev/null || true
+mv -f "$tmp" "$CONF"
+trap - EXIT

--- a/panel-agent/internal/commands/pdns_local_address_test.go
+++ b/panel-agent/internal/commands/pdns_local_address_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helperPath is the shipped script that pdns.service runs as ExecStartPre.
+const helperPath = "install/systemd/pdns-local-address"
+
+func repoRootT(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return root
+}
+
+// TestPDNSLocalAddressDropInRunsPrivileged pins the '+' on the ExecStartPre
+// line, which is easy to lose in a reformat and expensive to lose in
+// production.
+//
+// Debian's pdns.service runs User=pdns with ProtectSystem=full. Without the
+// prefix the helper runs unprivileged against a read-only /etc, exits 1, and
+// systemd refuses to start the service at all — so a change meant to keep DNS
+// up after an address change instead becomes a second, unconditional way to
+// take it down. Confirmed on a live host: plain ExecStartPre left pdns in
+// activating with "Control process exited, code=exited, status=1/FAILURE";
+// adding '+' brought it to active on the same config.
+func TestPDNSLocalAddressDropInRunsPrivileged(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(filepath.Join(repoRootT(t), "install.sh"))
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	script := string(raw)
+
+	// Scope to the installer function: the drop-in interpolates $dst rather
+	// than spelling the helper path out, so matching on the path would silently
+	// find nothing.
+	const fn = "install_pdns_local_address_helper() {"
+	start := strings.Index(script, fn)
+	if start < 0 {
+		t.Fatalf("could not find %s in install.sh", fn)
+	}
+	body := script[start:]
+	if end := strings.Index(body, "\n}\n"); end > 0 {
+		body = body[:end]
+	}
+
+	idx := strings.Index(body, "ExecStartPre=")
+	if idx < 0 {
+		t.Fatal("install_pdns_local_address_helper writes no ExecStartPre line")
+	}
+	line := body[idx:]
+	if end := strings.IndexByte(line, '\n'); end > 0 {
+		line = line[:end]
+	}
+	if !strings.HasPrefix(line, "ExecStartPre=+") {
+		t.Errorf("pdns drop-in has %q; it needs the '+' prefix. "+
+			"pdns.service runs User=pdns with ProtectSystem=full, so without it "+
+			"the helper cannot write /etc/powerdns and its nonzero exit blocks "+
+			"pdns from starting at all.", line)
+	}
+}
+
+// TestPDNSLocalAddressHelperIsExecutableAndValid keeps the shipped helper
+// syntactically sound and executable — install.sh copies it with mode 0755 and
+// systemd execs it directly, so a syntax error surfaces as pdns failing to
+// start rather than as anything resembling a script problem.
+func TestPDNSLocalAddressHelperIsExecutableAndValid(t *testing.T) {
+	t.Parallel()
+
+	p := filepath.Join(repoRootT(t), helperPath)
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat %s: %v", helperPath, err)
+	}
+	if fi.Mode()&0o111 == 0 {
+		t.Errorf("%s is not executable (mode %v)", helperPath, fi.Mode())
+	}
+	if out, err := exec.Command("bash", "-n", p).CombinedOutput(); err != nil {
+		t.Errorf("bash -n %s failed: %v\n%s", helperPath, err, out)
+	}
+}
+
+// TestPDNSLocalAddressHelperRewritesStaleAddress drives the helper against a
+// throwaway config to pin the behaviour that matters: a local-address= naming
+// an address this host does not have is replaced, and loopback:5300 — the port
+// pdns-recursor forwards into (ADR-0047) — survives.
+//
+// The original failure was a host restored from an image onto a new address.
+// pdns cannot bind the old one, treats that as fatal, and burns its restart
+// limit: 27 attempts, then authoritative DNS stays down until an operator
+// re-runs install.sh by hand.
+func TestPDNSLocalAddressHelperRewritesStaleAddress(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("no `ip` binary; helper enumerates interfaces via iproute2")
+	}
+
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "01-jabali-mysql.conf")
+	const stale = "local-address=127.0.0.1:5300,203.0.113.99:53,[::1]:5300"
+	body := "launch=gmysql\n" + stale + "\ngmysql-dnssec=yes\n"
+	if err := os.WriteFile(conf, []byte(body), 0o640); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	cmd := exec.Command("bash", filepath.Join(repoRootT(t), helperPath))
+	cmd.Env = append(os.Environ(), "JABALI_PDNS_CONF="+conf)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("helper failed: %v\n%s", err, out)
+	}
+
+	got, err := os.ReadFile(conf)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	text := string(got)
+
+	if strings.Contains(text, "203.0.113.99") {
+		t.Errorf("stale address survived the rewrite:\n%s", text)
+	}
+	if !strings.Contains(text, "127.0.0.1:5300") || !strings.Contains(text, "[::1]:5300") {
+		t.Errorf("loopback:5300 must survive — pdns-recursor forwards into it "+
+			"(ADR-0047). got:\n%s", text)
+	}
+	// Everything else in the file must be untouched; the helper edits one line.
+	for _, keep := range []string{"launch=gmysql", "gmysql-dnssec=yes"} {
+		if !strings.Contains(text, keep) {
+			t.Errorf("helper dropped unrelated line %q:\n%s", keep, text)
+		}
+	}
+	if n := strings.Count(text, "local-address="); n != 1 {
+		t.Errorf("expected exactly one local-address= line, got %d:\n%s", n, text)
+	}
+}
+
+// TestPDNSLocalAddressHelperLeavesUnmanagedHostsAlone covers the case where a
+// host does not run the jabali PowerDNS layout at all: the helper must be a
+// no-op rather than inventing a config file.
+func TestPDNSLocalAddressHelperLeavesUnmanagedHostsAlone(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "absent.conf")
+	cmd := exec.Command("bash", filepath.Join(repoRootT(t), helperPath))
+	cmd.Env = append(os.Environ(), "JABALI_PDNS_CONF="+missing)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("helper should exit 0 when the config is absent: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Errorf("helper created %s; it must not fabricate a config", missing)
+	}
+}


### PR DESCRIPTION
> Stacked on #805 (base is `fix-install-repo-dir-ordering`) because the installer function must sit after `clone_or_update_repo`, and #805 is what makes that position correct. Merge #805 first.

Third finding from the same host, and the one with the widest blast radius: **authoritative DNS stays down permanently after the host's IP changes.**

## What happens

install.sh enumerates global-scope addresses once, at install time, and bakes them into `local-address=`. PowerDNS treats a bind failure as fatal:

```
Fatal error: Unable to bind to UDP socket
pdns.service: Start request repeated too quickly.
```

The host had been restored from an image onto a new address — config still said `192.168.100.86`, interface was `.165`. 27 restart attempts, start limit, then nothing. DNS just stayed down.

Nothing recovers it. The reconciler doesn't manage this file, and pdns starts long before panel-api, so nothing that *could* notice is running yet. It needs an operator to re-run install.sh by hand.

## Why this matters more than "someone changed an IP"

A DHCP lease change, a restore onto a new host, a cloud reassignment, a failover — all do this. Each one is precisely a moment where DNS needs to come back unattended.

## The fix

`ExecStartPre` is the one point where a fix is both possible and sufficient: after the network is up, before pdns binds, with no dependency on the database or the panel. The helper rewrites only the `local-address=` line, atomically, and no-ops when the value already matches or when the host doesn't run our pdns layout at all.

## The `+` is load-bearing

Debian's `pdns.service` is `User=pdns` with `ProtectSystem=full`. The plain `ExecStartPre=` form runs unprivileged against a read-only `/etc`, exits 1 — and **a failed ExecStartPre keeps the unit down regardless of the config.** That turns a self-heal into a second, unconditional way to break DNS.

Not hypothetical; it's what my first attempt did on the test host:

```
pdns.service: Control process exited, code=exited, status=1/FAILURE
```

`+` runs it as root outside the sandbox. It has its own test, because it's exactly the kind of character a reformat eats.

## Verified on the affected host, twice

**Restart:** poison `local-address` with an address the host doesn't have, restart —

```
pdns-local-address: 127.0.0.1:5300,10.99.99.99:53,[::1]:5300
  -> 127.0.0.1:5300,[::1]:5300,192.168.100.165:53
```

pdns reaches `active`, bound on the live address.

**Reboot:** poison the file, then reboot. Corrected during boot, pdns `active`, **zero failed units** on a host that started this session with three.
