### PR TITLE
fix(logrotate): rotate per-tenant php-fpm logs as root, not www-data

### DIFF
--- a/install/logrotate/jabali
+++ b/install/logrotate/jabali
@@ -69,7 +69,24 @@
     missingok
     notifempty
     copytruncate
-    su www-data www-data
+    # su root root, NOT www-data. This glob covers per-tenant pool logs, and
+    # each is owned <tenant>:<tenant> mode 0640 — www-data is neither the
+    # owner nor in the group, so dropping to it means logrotate cannot open
+    # any of them:
+    #
+    #   error: error opening /var/log/php-fpm-cybe2e.log: Permission denied
+    #
+    # Every per-tenant log therefore never rotated (maxsize 50M never
+    # applied) and logrotate.service exited 1 on every daily run, which also
+    # masked any other rotation problem behind a permanently-failed unit.
+    # Only php-fpm-pma.log, which happens to be www-data-owned, worked.
+    #
+    # su exists to protect against a log DIRECTORY writable by a non-root
+    # user; /var/log is root:root 0755, so root here is both correct and no
+    # weaker. copytruncate means no new file is created in place, so the live
+    # log keeps its tenant ownership and php-fpm keeps writing — verified on
+    # a host: after rotation the original was still <tenant>:<tenant>.
+    su root root
     postrotate
         # PHP-FPM reopens its log on SIGUSR1 — sends to every running
         # version on the host. copytruncate already keeps the writes

--- a/panel-agent/internal/commands/logrotate_su_test.go
+++ b/panel-agent/internal/commands/logrotate_su_test.go
@@ -1,0 +1,102 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var logrotateSuRe = regexp.MustCompile(`(?m)^\s*su\s+(\S+)\s+(\S+)\s*$`)
+
+// TestLogrotateNeverDropsToNonRootUser guards a failure that is silent in
+// exactly the way that matters: logs growing without bound.
+//
+// The php-fpm block carried `su www-data www-data`. That glob covers per-tenant
+// pool logs, each owned <tenant>:<tenant> mode 0640, so www-data is neither the
+// owner nor in the group and logrotate could not open a single one:
+//
+//	error: error opening /var/log/php-fpm-cybe2e.log: Permission denied
+//
+// Consequences on a real host: every per-tenant php-fpm log never rotated —
+// `maxsize 50M` never applied — and logrotate.service exited 1 on every daily
+// run, leaving a permanently-failed unit that would mask any other rotation
+// problem. Only php-fpm-pma.log rotated, because it happens to be www-data's.
+//
+// Verified by forcing a rotation both ways on that host: `su www-data www-data`
+// produced Permission denied for every tenant log and rotated none of them,
+// while `su root root` rotated them with no errors and left the live log still
+// owned by the tenant, so php-fpm kept writing.
+//
+// The invariant is that the su USER stays root. logrotate's su exists to
+// protect against a log DIRECTORY writable by a non-root user; everything this
+// file manages lives under root:root 0755 /var/log, so root is both correct and
+// no weaker. The group is not constrained — `su root adm` is fine, since it is
+// the uid that decides whether open() succeeds.
+func TestLogrotateNeverDropsToNonRootUser(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	path := filepath.Join(root, "install", "logrotate", "jabali")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	matches := logrotateSuRe.FindAllStringSubmatch(string(body), -1)
+	if len(matches) == 0 {
+		t.Fatal("found no su directives in install/logrotate/jabali — either " +
+			"they were removed (every block needs one) or the pattern drifted " +
+			"and this test is checking nothing")
+	}
+
+	for _, m := range matches {
+		if m[1] != "root" {
+			t.Errorf("su directive drops to user %q. Files under these globs can "+
+				"be owned by individual tenants (php-fpm pool logs are "+
+				"<tenant>:<tenant> 0640), so any non-root user hits Permission "+
+				"denied, rotates nothing, and fails logrotate.service daily. "+
+				"Use `su root %s`.", m[1], m[2])
+		}
+	}
+}
+
+// TestLogrotatePerTenantBlocksUseCopytruncate pins the other half of what makes
+// rotating a tenant-owned log safe.
+//
+// With copytruncate the live file is never replaced, so it keeps its inode,
+// mode and tenant ownership and php-fpm goes on writing to the same descriptor.
+// Rotating these as root WITHOUT copytruncate would create the replacement as
+// root:root and silently cut the tenant's pool off from its own log.
+func TestLogrotatePerTenantBlocksUseCopytruncate(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(repoRoot, "install", "logrotate", "jabali"))
+	if err != nil {
+		t.Fatalf("read logrotate config: %v", err)
+	}
+
+	const glob = "/var/log/php-fpm-*.log {"
+	start := strings.Index(string(body), glob)
+	if start < 0 {
+		t.Fatalf("could not find the %q block", glob)
+	}
+	block := string(body)[start:]
+	if end := strings.Index(block, "\n}"); end > 0 {
+		block = block[:end]
+	}
+
+	if !strings.Contains(block, "copytruncate") {
+		t.Error("the php-fpm block rotates tenant-owned logs as root; without " +
+			"copytruncate the replacement file is created root:root and the " +
+			"tenant's pool loses write access to its own log")
+	}
+}


### PR DESCRIPTION
Found while checking why `logrotate.service` was in the failed list on testserver. It's a different bug from #805 — the config is installed here, it just can't read the files it manages.

## The block couldn't open anything it was pointed at

`/var/log/php-fpm-*.log` carried `su www-data www-data`. That glob covers **per-tenant pool logs**, each owned `<tenant>:<tenant>` mode `0640`. www-data is neither the owner nor in the group:

```
error: error opening /var/log/php-fpm-cybe2e.log: Permission denied
error: error opening /var/log/php-fpm-clpe2e.log: Permission denied
error: error opening /var/log/php-fpm-cpmvrepro.log: Permission denied
logrotate.service: Main process exited, code=exited, status=1/FAILURE
```

Confirmed directly rather than inferred:

```
$ setpriv --reuid=www-data --regid=www-data --clear-groups head -c1 /var/log/php-fpm-cli8e2e.log
www-data CANNOT read
$ id www-data
uid=33(www-data) gid=33(www-data) groups=33(www-data),988(jabali-sockets)
```

## Two consequences, and the quiet one is worse

- **Per-tenant php-fpm logs never rotated.** `maxsize 50M` never applied. They grow until the disk does.
- **`logrotate.service` failed every daily run** — a permanently-failed unit that masks any *other* rotation problem behind noise everyone learns to ignore.

The one file in that glob that *did* rotate was `php-fpm-pma.log`, which happens to be www-data-owned. Enough for the block to look fine if you only checked one.

## Why root is correct here

logrotate's `su` exists to protect against a log **directory** writable by a non-root user. Everything in this file lives under `/var/log`, which is `root:root 0755` — so root is both correct and no weaker than what was there.

`copytruncate` means the live file is never replaced, so it keeps its inode, mode and tenant ownership and php-fpm keeps writing to the same descriptor.

## Verified by forcing a rotation both ways on the affected host

```
su www-data www-data  ->  Permission denied for every tenant log, none rotated
su root root          ->  no errors, logs rotated
```

And ownership survived, which is the part that would have been dangerous to get wrong:

```
-rw-r----- 1 cybe2e cybe2e      0 /var/log/php-fpm-cybe2e.log      <- live, still tenant-owned
-rw-r----- 1 cybe2e cybe2e 172904 /var/log/php-fpm-cybe2e.log.1
```

## Tests

The main one asserts the `su` **user** is root across *every* block rather than checking this one, so a new block can't reintroduce it. The group is deliberately unconstrained — `su root adm` elsewhere is fine, since the uid decides whether `open()` succeeds.

A second test pins `copytruncate` on the php-fpm block, because rotating tenant-owned logs as root *without* it would create the replacement `root:root` and cut the pool off from its own log — trading this bug for a worse one.
