### PR TITLE
fix(cache): WP-cache audit batch — probe methods, purge gating, Redis client edge cases

### DIFF
--- a/panel-agent/internal/commands/wordpress_cache_health.go
+++ b/panel-agent/internal/commands/wordpress_cache_health.go
@@ -128,7 +128,9 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 		// Page-cache HIT verification: prime once, then read X-Jabali-Cache.
 		_ = curlLocal("/", "")
 		cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
-		hdr, _ := exec.CommandContext(cctx, "curl", "-ksI", "--max-time", "8",
+		// GET, not HEAD (-I): the nginx cache key embeds $request_method, so a
+		// HEAD can never HIT the GET-primed entry and this probe always read MISS.
+		hdr, _ := exec.CommandContext(cctx, "curl", "-ks", "-o", "/dev/null", "-D", "-", "--max-time", "8",
 			"--resolve", host+":443:127.0.0.1", "https://"+host+"/").Output()
 		cancel()
 		hitVerified = strings.Contains(strings.ToUpper(string(hdr)), "X-JABALI-CACHE: HIT")

--- a/wp-plugins/jabali-cache/includes/class-admin.php
+++ b/wp-plugins/jabali-cache/includes/class-admin.php
@@ -34,7 +34,7 @@ class Jabali_Cache_Admin {
 		add_action( 'admin_notices', array( $this, 'notices' ) );
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar' ), 100 );
 		add_filter(
-			'plugin_action_links_' . plugin_basename( $plugin_file ),
+			'plugin_action_links_' . plugin_basename( $this->plugin_file ),
 			array( $this, 'action_links' )
 		);
 	}
@@ -128,7 +128,7 @@ class Jabali_Cache_Admin {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		$on_page = $screen && false !== strpos( (string) $screen->id, self::SLUG );
 
-		$health = $this->health();
+		$health = $this->health_cached();
 		if ( ! $health['enabled'] ) {
 			return;
 		}
@@ -236,7 +236,7 @@ class Jabali_Cache_Admin {
 		$this->kv( 'Serializer', esc_html( $health['serializer'] ) );
 		$this->kv( 'Target', '<code>' . esc_html( $health['target'] ) . '</code> (db ' . (int) $s['database'] . ')' );
 		$this->kv( 'Key prefix', '<code class="jc-ellipsis">' . esc_html( $health['prefix'] ) . '</code>' );
-		$this->kv( 'Keys for this site', $health['connected'] ? (int) $health['keys'] : '—' );
+		$this->kv( 'Keys for this site', $health['connected'] ? ( (int) $health['keys'] . ( ! empty( $health['keys_approx'] ) ? '+' : '' ) ) : '—' );
 		if ( null !== $hits ) {
 			$this->kv( 'Cache hits (this request)', esc_html( $hits['h'] . ' hits / ' . $hits['m'] . ' misses (' . $hits['rate'] . '%)' ) );
 		}
@@ -526,6 +526,21 @@ class Jabali_Cache_Admin {
 	// ------------------------------------------------------------------
 
 	/**
+	 * 60s-cached health for admin_notices: the full health() does live Redis
+	 * work (INFO + a key scan) and admin_notices runs on EVERY wp-admin
+	 * request, so the uncached path must not run per-pageview.
+	 */
+	private function health_cached() {
+		$t = get_transient( 'jabali_cache_admin_health' );
+		if ( is_array( $t ) ) {
+			return $t;
+		}
+		$h = $this->health();
+		set_transient( 'jabali_cache_admin_health', $h, MINUTE_IN_SECONDS );
+		return $h;
+	}
+
+	/**
 	 * @return array<string,mixed>
 	 */
 	private function health() {
@@ -553,7 +568,9 @@ class Jabali_Cache_Admin {
 		if ( $client->connect() ) {
 			$out['connected']  = true;
 			$out['driver']     = $client->driver();
-			$out['keys']       = $client->count_keys( $cfg['prefix'] );
+			$kc                 = $client->stats_key_count( $cfg['prefix'] );
+			$out['keys']        = (int) $kc['count'];
+			$out['keys_approx'] = ! empty( $kc['approx'] );
 			$out['server']     = $this->parse_info( $client->info() );
 			$client->close();
 		} else {
@@ -577,9 +594,11 @@ class Jabali_Cache_Admin {
 			return $cached;
 		}
 		$out  = array();
-		$resp = wp_remote_head(
+		// GET, not HEAD: the nginx micro-cache key embeds $request_method, so a
+		// HEAD probe can never observe a HIT for the GET entries real visitors use.
+		$resp = wp_remote_get(
 			home_url( '/' ),
-			array( 'timeout' => 3, 'redirection' => 0, 'sslverify' => false, 'headers' => array( 'Accept' => 'text/html' ) )
+			array( 'timeout' => 3, 'redirection' => 0, 'sslverify' => false, 'limit_response_size' => 1048576, 'headers' => array( 'Accept' => 'text/html' ) )
 		);
 		if ( ! is_wp_error( $resp ) ) {
 			$xjc = wp_remote_retrieve_header( $resp, 'x-jabali-cache' );

--- a/wp-plugins/jabali-cache/includes/class-page-cache.php
+++ b/wp-plugins/jabali-cache/includes/class-page-cache.php
@@ -285,10 +285,12 @@ class Jabali_Cache_Page_Cache {
 			return $body;
 		}
 		if ( ! $this->is_cacheable_response( $body ) ) {
+			$this->release_regen_lock(); // nothing stored — don't hold the lock for LOCK_TTL.
 			return $body;
 		}
 		// JAB-92: don't cache an oversized body — it would evict useful keys.
 		if ( ! self::is_storable_size( $body ) ) {
+			$this->release_regen_lock();
 			return $body;
 		}
 
@@ -379,7 +381,21 @@ class Jabali_Cache_Page_Cache {
 		$scheme = ( isset( $u['scheme'] ) && 'https' === $u['scheme'] ) ? 'https' : 'http';
 		$host   = $u['host'] . ( isset( $u['port'] ) ? ':' . $u['port'] : '' );
 
-		$keys = $this->keys_for_paths( $paths, $scheme, $host );
+		// Entries are keyed by the VISITOR'S HTTP_HOST; a site reachable on both
+		// apex and www stores two variants. Purge the sibling host too so the
+		// other variant never lingers stale.
+		$hosts = array( $host );
+		$sib   = ( 0 === strpos( $host, 'www.' ) ) ? substr( $host, 4 ) : 'www.' . $host;
+		if ( '' !== $sib && $sib !== $host ) {
+			$hosts[] = $sib;
+		}
+		$keys = array();
+		foreach ( $hosts as $h ) {
+			foreach ( $this->keys_for_paths( $paths, $scheme, $h ) as $k ) {
+				$keys[] = $k;
+			}
+		}
+		$keys = array_values( array_unique( $keys ) );
 		if ( empty( $keys ) ) {
 			return 0;
 		}
@@ -560,7 +576,9 @@ class Jabali_Cache_Page_Cache {
 	}
 
 	private function only_safe_query_params( $qs ) {
-		$safe = array( 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'fbclid', 'gclid', 'ref' );
+		// No 'ref' here: referral/affiliate plugins render content from it, so
+		// collapsing ?ref= onto the clean-URL entry can cache the wrong page.
+		$safe = array( 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'fbclid', 'gclid' );
 		parse_str( $qs, $params );
 		foreach ( array_keys( (array) $params ) as $k ) {
 			if ( ! in_array( $k, $safe, true ) ) {

--- a/wp-plugins/jabali-cache/includes/lib.php
+++ b/wp-plugins/jabali-cache/includes/lib.php
@@ -608,7 +608,11 @@ class Jabali_Cache_Client {
 				return false;
 			}
 		}
-		if ( null === $this->cmd( array( 'SELECT', (string) (int) $this->cfg['database'] ) ) && $this->dead ) {
+		$sel = $this->cmd( array( 'SELECT', (string) (int) $this->cfg['database'] ) );
+		if ( 'OK' !== $sel && true !== $sel ) {
+			// An -ERR/-NOPERM reply must be fatal: continuing would silently
+			// operate on the connection's default DB 0 (the panel's) instead of ours.
+			$this->fail( 'SELECT ' . (int) $this->cfg['database'] . ' rejected: ' . $this->last_error );
 			return false;
 		}
 		$pong = $this->cmd( array( 'PING' ) );
@@ -1097,6 +1101,10 @@ class Jabali_Cache_Client {
 		$steps   = 0;
 		if ( 'phpredis' === $this->driver ) {
 			try {
+				// SCAN_RETRY: without it scan() returns false on an EMPTY iteration
+				// and the loop exits early with an undercount. (pconnect pools the
+				// handle, so never rely on another method having set this option.)
+				$this->redis->setOption( \Redis::OPT_SCAN, \Redis::SCAN_RETRY );
 				$it = null;
 				while ( false !== ( $keys = $this->redis->scan( $it, $pattern, 1000 ) ) ) {
 					$count += count( $keys );
@@ -1180,6 +1188,7 @@ class Jabali_Cache_Client {
 		$keys    = array();
 		if ( 'phpredis' === $this->driver ) {
 			try {
+				$this->redis->setOption( \Redis::OPT_SCAN, \Redis::SCAN_RETRY ); // see count_keys().
 				$it = null;
 				while ( false !== ( $batch = $this->redis->scan( $it, $pattern, 1000 ) ) ) {
 					foreach ( $batch as $k ) {
@@ -1212,8 +1221,14 @@ class Jabali_Cache_Client {
 		if ( $n <= $maxKeys ) {
 			return 0;
 		}
-		$excess = array_slice( $keys, 0, $n - $maxKeys );
-		return (int) $this->del( $excess );
+		$excess  = array_slice( $keys, 0, $n - $maxKeys );
+		$removed = 0;
+		// UNLINK in bounded chunks (GH #608): async memory reclaim, and no
+		// single mega-command against the shared instance.
+		foreach ( array_chunk( $excess, 1000 ) as $chunk ) {
+			$removed += (int) $this->unlink( $chunk );
+		}
+		return $removed;
 	}
 
 	public function close( $force = false ) {

--- a/wp-plugins/jabali-cache/jabali-cache.php
+++ b/wp-plugins/jabali-cache/jabali-cache.php
@@ -25,6 +25,9 @@ if ( ! defined( 'JABALI_CACHE_PLUGIN_FILE' ) ) {
 if ( ! defined( 'JABALI_CACHE_PLUGIN_DIR' ) ) {
 	define( 'JABALI_CACHE_PLUGIN_DIR', __DIR__ );
 }
+if ( ! defined( 'JABALI_CACHE_NGINX_SPOOL' ) ) {
+	define( 'JABALI_CACHE_NGINX_SPOOL', '/run/jabali-wp-purge' );
+}
 
 require_once __DIR__ . '/includes/lib.php';
 require_once __DIR__ . '/includes/class-settings.php';
@@ -133,7 +136,11 @@ function jabali_cache_register_purge_hooks() {
 	// Redis full-page purge inside these hooks self-gates on page_cache (#603),
 	// and the nginx purge (jabali_cache_purge_nginx) is a cheap no-op off Jabali.
 	$cfg = Jabali_Cache_Config::load();
-	if ( empty( $cfg['enabled'] ) ) {
+	// #611 intent: nginx micro-cache purges must fire even when the plugin's
+	// master (object-cache) toggle is off — the spool dir existing is the
+	// "panel page cache present" signal. The Redis-side purges keep
+	// self-gating on enabled/page_cache inside their helpers.
+	if ( empty( $cfg['enabled'] ) && ! @is_dir( JABALI_CACHE_NGINX_SPOOL ) ) {
 		return;
 	}
 	$purge = 'jabali_cache_purge_pages';
@@ -173,8 +180,8 @@ function jabali_cache_purge_redis() {
  * @param array<int,string> $paths URL paths to purge; empty = whole domain.
  */
 function jabali_cache_purge_nginx( $paths = array() ) {
-	$dir = '/run/jabali-wp-purge';
-	if ( ! is_dir( $dir ) || ! is_writable( $dir ) ) {
+	$dir = JABALI_CACHE_NGINX_SPOOL;
+	if ( ! @is_dir( $dir ) || ! @is_writable( $dir ) ) { // @: open_basedir may hide /run (JAB-199) — treat as absent, no per-request warning.
 		return; // not on a Jabali host, or spool not provisioned.
 	}
 	$host = wp_parse_url( home_url(), PHP_URL_HOST );
@@ -213,6 +220,16 @@ function jabali_cache_purge_pages() {
  * @param int $post_id
  */
 function jabali_cache_purge_post( $post_id ) {
+	// Autosaves and revisions fire save_post too (Elementor autosaves every
+	// ~minute while editing). Purging on each one churns the warm cache and
+	// floods the purge spool for content no anonymous visitor can see yet.
+	if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+		return;
+	}
+	$jc_status = get_post_status( $post_id );
+	if ( in_array( $jc_status, array( 'auto-draft', 'inherit' ), true ) ) {
+		return;
+	}
 	// JAB-91: build the affected paths first (home + the post permalink), then
 	// purge ONLY those from the Redis page cache — a single post edit must not
 	// discard the whole site's warm cache. Whole-site Redis purge stays for


### PR DESCRIPTION
## Summary

12 of the 14 findings from the jabali-cache / micro-cache audit (Plane JAB-199/200/201 companions). One commit, 5 files, no behavior change for correctly-working paths — every fix makes an existing intent actually hold.

### Probes that could never succeed
- **Agent cache probe** primed with GET but verified with `curl -I` (HEAD). The nginx cache key embeds `$request_method`, so `page_hit_verified` was structurally always false. Now GET (`-D -`).
- **Plugin `probe_page_cache()`** used `wp_remote_head()` — same flaw. Now GET with `limit_response_size`.

### Purge correctness
- `save_post` purges skip autosaves/revisions/`auto-draft`/`inherit` (Elementor autosaves purged home+post every ~minute).
- Purge hooks armed when the nginx purge spool exists even if the plugin master toggle is off — object-cache-off + page-cache-on sites never purged on content change (GH #611 intent).
- Redis page-cache targeted purge covers the www/apex sibling host.

### Redis client (lib.php)
- Pure-PHP `SELECT` failure is fatal (was: silent fallthrough onto DB 0 — the panel's DB).
- `OPT_SCAN=SCAN_RETRY` set in `count_keys()`/`trim_to_budget()` (early-exit undercounts, nondeterministic under pconnect).
- `trim_to_budget()`: chunked `UNLINK` instead of one blocking `DEL` of up to 5000 keys (GH #608 rationale).

### Perf / hygiene
- `admin_notices` no longer does a full shared-keyspace SCAN + INFO per wp-admin pageview (60s transient + bounded JAB-94 stats path).
- Regen lock released on uncacheable/oversized renders (was held LOCK_TTL=20s).
- `ref` dropped from page-cache safe query params.
- `plugin_action_links_` undefined-variable warning fixed (`$this->plugin_file`) — this is the PHP warning visible on every wp-admin request in production.
- Spool `is_dir` warnings suppressed while open_basedir hides `/run` (pool-template fix tracked in JAB-199).

### Deferred (by design, tracked)
- Device-variant micro-cache key — changes the nginx key format the targeted-purge parser + goldens depend on; needs its own PR.
- FPM-jail-context health probe — needs a security-reviewed diagnostics endpoint (JAB-201).

## Test plan
- [x] `php -l` all touched plugin files
- [x] Plugin standalone harnesses: test-lib, test-object-cache, test-page-cache, test-object-cache-multisite — 86 checks green
- [x] `go build ./panel-agent/...`, `go vet`, `go test ./panel-agent/internal/commands/` green
- [x] Rebased on latest origin/main; re-ran tests post-rebase
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)