### PR TITLE
fix(security): AppArmor denials invisible — panel read journal while auditd owns the AVC stream

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -280,6 +280,14 @@ profile jabali-panel flags=(attach_disconnected) {
   /run/log/journal/**          r,
   # cscli reads tetragon cgroup export + per-process cgroup/mountinfo.
   /run/tetragon/**             r,
+  # cscli/systemd helpers spawned by the panel read the service's OWN
+  # cgroup limits (cpu.max, memory.max) for capacity checks. Scoped to
+  # the jabali-panel service subtree; live enforce denial observed
+  # 2026-08-01 (comm=cscli, /sys/fs/cgroup/system.slice/jabali-panel.service/cpu.max).
+  /sys/fs/cgroup/              r,
+  /sys/fs/cgroup/system.slice/ r,
+  /sys/fs/cgroup/system.slice/jabali-panel.service/   r,
+  /sys/fs/cgroup/system.slice/jabali-panel.service/** r,
 
   /proc/                       r,
   /proc/loadavg                r,

--- a/install/apparmor/usr.local.bin.stalwart-mail
+++ b/install/apparmor/usr.local.bin.stalwart-mail
@@ -71,6 +71,9 @@ profile stalwart-mail /opt/stalwart/stalwart {
 
   /proc/sys/net/core/somaxconn  r,
   /proc/*/status                r,
+  # tokio runtime memory accounting reads its own smaps (owner-scoped —
+  # smaps of other processes stays denied). Live enforce denial 2026-08-01.
+  owner /proc/*/smaps           r,
 
   /etc/jabali-panel/stalwart-admin.token r,
   /etc/jabali-panel/dkim/               r,

--- a/install/apparmor/usr.local.libexec.jabali.fpm-exec
+++ b/install/apparmor/usr.local.libexec.jabali.fpm-exec
@@ -69,6 +69,12 @@ profile jabali-fpm-app /usr/local/libexec/jabali/fpm-exec flags=(attach_disconne
   /home/*/domains/*/public_html/** rwkl,
   /home/*/web/*/ r,
   /home/*/web/*/public_html/** rwkl,
+  # Tenant PHP error logs (cPanel/DA convention ~/logs/php.error.log —
+  # tenants point error_log there via php.ini/ini_set; migrated accounts
+  # arrive with it preset). Owner-scoped: a worker only touches its own
+  # user's logs dir. No exec. Live enforce denial observed 2026-08-01.
+  owner /home/*/logs/ r,
+  owner /home/*/logs/** rw,
 
   # Temp + sessions.
   /tmp/ r,

--- a/panel-agent/internal/commands/security_apparmor.go
+++ b/panel-agent/internal/commands/security_apparmor.go
@@ -12,11 +12,12 @@
 package commands
 
 import (
-	"os"
 	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	osexec "os/exec"
 	"regexp"
 	"strings"
@@ -188,75 +189,105 @@ func mwApparmorStatusHandler(ctx context.Context, _ json.RawMessage) (any, error
 	return resp, nil
 }
 
-// apparmorDeniedRe matches the audit-line format kernel emits for
-// AppArmor denials. Sample:
+// AppArmor AVC audit-line format the kernel emits. Sample:
 //
-//   audit: type=1400 audit(1746371982.123:567): apparmor="DENIED"
-//   operation="open" profile="jabali-panel" name="/etc/shadow"
-//   pid=1234 comm="jabali-panel" requested_mask="r" denied_mask="r"
-//   fsuid=0 ouid=0
+//	type=AVC msg=audit(1746371982.123:567): apparmor="DENIED"
+//	operation="open" profile="jabali-panel" name="/etc/shadow"
+//	pid=1234 comm="jabali-panel" requested_mask="r" denied_mask="r"
+//	fsuid=0 ouid=0
 //
-// The fields appear in a stable order across kernel 6.x releases but
-// we extract by named regex per field — robust to extra/missing
-// trailing fields. profile= is mandatory; everything else is optional.
+// Fields are extracted per-key so extra/missing trailing fields are fine.
+// Quoted values may contain spaces (tenant paths do) — the field regex has a
+// quoted alternative so such values aren't truncated at the first space.
 var (
-	apparmorDeniedLineRe = regexp.MustCompile(`apparmor="DENIED"`)
-	apparmorFieldRe      = regexp.MustCompile(`(\w+)="?([^"\s]*)"?`)
-	apparmorAuditTSRe    = regexp.MustCompile(`audit\((\d+)\.\d+:\d+\)`)
+	apparmorFieldRe   = regexp.MustCompile(`(\w+)="([^"]*)"|(\w+)=([^\s"]+)`)
+	apparmorAuditTSRe = regexp.MustCompile(`audit\((\d+)\.\d+:\d+\)`)
 )
 
-// readApparmorDenials shells out to journalctl --grep'd against
-// apparmor="DENIED" and returns up to maxApparmorDenials rows. We use
-// journalctl rather than dmesg so the lookup honors --since reliably;
-// dmesg ring-buffer rotation could swallow older denials we still want.
 const (
-	apparmorDenialsWindow = "24 hours ago"
+	apparmorDenialsWindow = 24 * time.Hour
 	maxApparmorDenials    = 50
+	// apparmorAuditLogPath is auditd's store. With auditd running (jabali
+	// installs it — ADR-0085), the kernel routes AppArmor AVC records to the
+	// audit subsystem: they land HERE and never reach the kernel journal, so
+	// `journalctl -k --grep apparmor=` is structurally empty on every jabali
+	// box while enforce-mode denials are actively happening. Read this first;
+	// journalctl stays as the fallback for hosts without auditd.
+	apparmorAuditLogPath   = "/var/log/audit/audit.log"
+	apparmorAuditTailBytes = 8 << 20 // bounded tail per scrape
 )
 
+// readApparmorEvents returns the most recent AppArmor events with the given
+// status ("DENIED" enforce blocks | "ALLOWED" complain would-deny), newest
+// first, from the last 24h.
 func readApparmorEvents(ctx context.Context, status string) []apparmorDenial {
-	out := []apparmorDenial{}
+	since := time.Now().Add(-apparmorDenialsWindow)
+	if f, err := os.Open(apparmorAuditLogPath); err == nil {
+		defer f.Close()
+		if fi, serr := f.Stat(); serr == nil && fi.Size() > apparmorAuditTailBytes {
+			_, _ = f.Seek(fi.Size()-apparmorAuditTailBytes, io.SeekStart)
+		}
+		if events := parseApparmorEventLines(f, status, since, maxApparmorDenials); len(events) > 0 {
+			return events
+		}
+		// audit.log present but nothing in-window: fall through to the journal —
+		// auditd may be installed but stopped, with fresh lines in the journal.
+	}
+	return readApparmorEventsJournal(ctx, status, since)
+}
+
+func readApparmorEventsJournal(ctx context.Context, status string, since time.Time) []apparmorDenial {
 	if _, err := osexec.LookPath("journalctl"); err != nil {
-		return out
+		return []apparmorDenial{}
 	}
 	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
 	cmd := osexec.CommandContext(cctx,
 		"journalctl",
 		"-k",
-		"--since", apparmorDenialsWindow,
+		"--since", "24 hours ago",
 		"--no-pager",
 		"-q",
 		"--grep", `apparmor="`+status+`"`,
 	)
 	stdout, err := cmd.Output()
 	if err != nil {
-		return out
+		return []apparmorDenial{}
 	}
+	return parseApparmorEventLines(strings.NewReader(string(stdout)), status, since, maxApparmorDenials)
+}
 
-	scanner := bufio.NewScanner(strings.NewReader(string(stdout)))
+// parseApparmorEventLines scans chronological audit/journal lines and returns
+// up to max in-window rows with the requested status, NEWEST FIRST. (The old
+// implementation kept the first 50 chronological rows — on a noisy day the
+// panel showed the OLDEST denials and the fresh ones were invisible.)
+func parseApparmorEventLines(r io.Reader, status string, since time.Time, max int) []apparmorDenial {
+	needle := `apparmor="` + status + `"`
+	events := []apparmorDenial{}
+	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.Contains(line, `apparmor="`+status+`"`) {
+		if !strings.Contains(line, needle) {
 			continue
 		}
 		row := apparmorDenial{}
-		// audit timestamp epoch seconds
 		if m := apparmorAuditTSRe.FindStringSubmatch(line); len(m) == 2 {
-			if epoch, err := time.Parse("1136239445", m[1]); err == nil {
-				_ = epoch // unused — fall through to ParseInt path below
-			}
-			// time.Parse with epoch layout doesn't work; use Unix.
 			var sec int64
-			fmt.Sscanf(m[1], "%d", &sec)
+			_, _ = fmt.Sscanf(m[1], "%d", &sec)
 			if sec > 0 {
-				row.Timestamp = time.Unix(sec, 0).UTC().Format(time.RFC3339)
+				ts := time.Unix(sec, 0).UTC()
+				if ts.Before(since) {
+					continue
+				}
+				row.Timestamp = ts.Format(time.RFC3339)
 			}
 		}
-		// Field extraction.
 		for _, fm := range apparmorFieldRe.FindAllStringSubmatch(line, -1) {
 			key, val := fm[1], fm[2]
+			if key == "" {
+				key, val = fm[3], fm[4]
+			}
 			switch key {
 			case "profile":
 				row.Profile = val
@@ -278,17 +309,23 @@ func readApparmorEvents(ctx context.Context, status string) []apparmorDenial {
 				row.FSUID = val
 			}
 		}
-		// Skip rows without a profile — those are unrelated audit lines
-		// the journalctl --grep happened to surface (rare).
+		// Rows without a profile are unrelated audit lines the grep surfaced.
 		if row.Profile == "" {
 			continue
 		}
-		out = append(out, row)
-		if len(out) >= maxApparmorDenials {
-			break
+		events = append(events, row)
+		// Bound memory on a huge tail: only the newest max matter.
+		if len(events) > 4*max {
+			events = events[len(events)-max:]
 		}
 	}
-	return out
+	if len(events) > max {
+		events = events[len(events)-max:]
+	}
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
 }
 
 type apparmorSetModeRequest struct {

--- a/panel-agent/internal/commands/security_apparmor_events_test.go
+++ b/panel-agent/internal/commands/security_apparmor_events_test.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Real-shape auditd AVC lines (source: production audit.log). The parser must
+// read these — with auditd running, AppArmor events land in audit.log and
+// never reach `journalctl -k` (the bug this file guards against regressing).
+const auditLogSample = `type=AVC msg=audit(1785547714.640:276519): apparmor="DENIED" operation="open" class="file" profile="jabali-fpm-app" name="/home/hlpcoll/logs/php.error.log" pid=3076079 comm="php-fpm8.4" requested_mask="w" denied_mask="w" fsuid=5012 ouid=5012
+type=AVC msg=audit(1785547775.636:276624): apparmor="DENIED" operation="open" class="file" profile="stalwart-mail" name="/proc/1052443/smaps" pid=1052443 comm="tokio-rt-worker" requested_mask="r" denied_mask="r" fsuid=990 ouid=990
+type=USER_LOGIN msg=audit(1785547800.000:276700): pid=9 uid=0 auid=0 ses=1 res=success
+type=AVC msg=audit(1785547836.936:276780): apparmor="ALLOWED" operation="open" class="file" profile="jabali-bulwark" name="/etc/hosts" pid=42 comm="node" requested_mask="r" denied_mask="r" fsuid=991 ouid=0
+`
+
+func TestParseApparmorEventLinesDenied(t *testing.T) {
+	since := time.Unix(1785500000, 0)
+	got := parseApparmorEventLines(strings.NewReader(auditLogSample), "DENIED", since, 50)
+	if len(got) != 2 {
+		t.Fatalf("want 2 DENIED rows, got %d: %+v", len(got), got)
+	}
+	// Newest first.
+	if got[0].Profile != "stalwart-mail" || got[1].Profile != "jabali-fpm-app" {
+		t.Fatalf("want newest-first [stalwart-mail jabali-fpm-app], got [%s %s]", got[0].Profile, got[1].Profile)
+	}
+	fpm := got[1]
+	if fpm.Path != "/home/hlpcoll/logs/php.error.log" {
+		t.Errorf("path: got %q", fpm.Path)
+	}
+	if fpm.Operation != "open" || fpm.RequestedMask != "w" || fpm.DeniedMask != "w" {
+		t.Errorf("fields: %+v", fpm)
+	}
+	if fpm.Comm != "php-fpm8.4" || fpm.PID != "3076079" || fpm.FSUID != "5012" {
+		t.Errorf("comm/pid/fsuid: %+v", fpm)
+	}
+	if fpm.Timestamp != time.Unix(1785547714, 0).UTC().Format(time.RFC3339) {
+		t.Errorf("timestamp: got %q", fpm.Timestamp)
+	}
+}
+
+func TestParseApparmorEventLinesAllowedOnly(t *testing.T) {
+	got := parseApparmorEventLines(strings.NewReader(auditLogSample), "ALLOWED", time.Unix(0, 0), 50)
+	if len(got) != 1 || got[0].Profile != "jabali-bulwark" {
+		t.Fatalf("want 1 ALLOWED jabali-bulwark row, got %+v", got)
+	}
+}
+
+func TestParseApparmorEventLinesQuotedPathWithSpaces(t *testing.T) {
+	line := `type=AVC msg=audit(1785547900.000:1): apparmor="DENIED" operation="open" profile="jabali-fpm-app" name="/home/u/domains/d/public_html/wp content/My File.php" pid=7 comm="php-fpm8.4" requested_mask="r" denied_mask="r"` + "\n"
+	got := parseApparmorEventLines(strings.NewReader(line), "DENIED", time.Unix(0, 0), 50)
+	if len(got) != 1 {
+		t.Fatalf("want 1 row, got %d", len(got))
+	}
+	if got[0].Path != "/home/u/domains/d/public_html/wp content/My File.php" {
+		t.Errorf("quoted path with spaces truncated: %q", got[0].Path)
+	}
+}
+
+func TestParseApparmorEventLinesWindowFilter(t *testing.T) {
+	since := time.Unix(1785547800, 0) // between the two DENIED samples
+	got := parseApparmorEventLines(strings.NewReader(auditLogSample), "DENIED", since, 50)
+	if len(got) != 0 {
+		t.Fatalf("both DENIED rows predate since; got %+v", got)
+	}
+}
+
+func TestParseApparmorEventLinesKeepsNewestOverCap(t *testing.T) {
+	var b strings.Builder
+	for i := 0; i < 120; i++ {
+		// Monotonic timestamps so "newest" is well-defined.
+		b.WriteString(`type=AVC msg=audit(17855` + string(rune('0'+i%10)) + `0000.000:1): apparmor="DENIED" operation="open" profile="p" name="/f" pid=1 comm="c"` + "\n")
+	}
+	// A distinguishable final (newest) line.
+	b.WriteString(`type=AVC msg=audit(1785599999.000:2): apparmor="DENIED" operation="open" profile="newest" name="/last" pid=2 comm="c"` + "\n")
+	got := parseApparmorEventLines(strings.NewReader(b.String()), "DENIED", time.Unix(0, 0), 50)
+	if len(got) != 50 {
+		t.Fatalf("cap: want 50, got %d", len(got))
+	}
+	if got[0].Profile != "newest" {
+		t.Fatalf("newest row must survive the cap and sort first; got %+v", got[0])
+	}
+}


### PR DESCRIPTION
## Summary

**The Security tab's AppArmor denials/violations were structurally empty on every jabali box.** jabali installs auditd (ADR-0085); with auditd running, the kernel routes AppArmor AVC records to the audit subsystem — `/var/log/audit/audit.log` — and they never reach the kernel journal. `security.apparmor.status` scraped `journalctl -k --grep apparmor=`, i.e. the wrong source. The ADR-0086 complain-soak gate was blind the same way: a profile could show "0 violations" and be promoted to enforce while violating constantly.

**Production evidence** (read-only): 961 `apparmor=` lines in `audit.log{,.1}` vs **0** in `journalctl -k` over the same window — with live enforce DENIEDs:
- `jabali-fpm-app` blocking `/home/<user>/logs/php.error.log` writes (tenant PHP error logging silently dead — cPanel/DA-migrated accounts use `~/logs/`)
- `jabali-panel` blocked reading its own service cgroup `cpu.max` (comm=cscli)
- `stalwart-mail` blocked reading its own `/proc/<pid>/smaps`

## Changes
- `readApparmorEvents`: tail `/var/log/audit/audit.log` (bounded 8 MB) first; `journalctl -k` fallback for hosts without auditd.
- Parser extracted (`parseApparmorEventLines`) + unit tests, fixing on the way: newest-50 retention (old code kept the *oldest* 50 in-window — fresh denials invisible on a noisy day), quoted values with spaces no longer truncate, dead code removed.
- Profile allows for the three live denials, each narrowly scoped (`owner /home/*/logs/** rw`, own-service cgroup subtree read, `owner /proc/*/smaps r`). Per the security-over-functionality rule these widen nothing beyond each daemon's own resources; edit-site comments reference the observed denials.

## Test plan
- [x] 5 new parser unit tests (real audit.log line shapes, window filter, newest-first cap, space-in-path)
- [x] `go vet` + full `./panel-agent/internal/commands` suite green
- [x] `apparmor_parser -Q` clean for all three profiles (run on testserver, not production)
- [x] Rebased on origin/main, tests re-run
- [ ] CI
- [ ] Post-merge: `jabali update` on testserver, then `aa-smoke` + confirm panel Security tab shows the denial rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)