### PR TITLE
fix(cache): targeted purge left query-allowlist variants stale

### DIFF
--- a/panel-agent/internal/commands/nginx_cache_purge.go
+++ b/panel-agent/internal/commands/nginx_cache_purge.go
@@ -34,12 +34,29 @@ var cachePurgeMaxFiles = 250000
 // fastcgiCacheRoot is a var (not const) so tests can point the purge at a temp dir.
 var fastcgiCacheRoot = "/var/cache/nginx/jabali"
 
+// purgeVhostDir is where rendered vhosts live; a var so tests can stub it.
+var purgeVhostDir = "/etc/nginx/sites-enabled"
+
+// domainUsesQueryAllowlist reports whether the domain's rendered vhost carries
+// the GH #610 query-allowlist cache key (the $jabali_qkey marker). Such a
+// domain stores EXTRA cache entries per allowlisted query combination
+// ("...path?page=2&"), which the hash-based fast purge below cannot enumerate.
+func domainUsesQueryAllowlist(domain string) bool {
+	b, err := os.ReadFile(filepath.Join(purgeVhostDir, domain+".conf"))
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(b, []byte("$jabali_qkey"))
+}
+
 type nginxCachePurgeParams struct {
 	Domain string `json:"domain"`
 	// Paths (GH #619): optional targeted purge. When empty, the whole domain
-	// is purged (v1 behaviour). When set, only cached entries whose request_uri
-	// equals a path or begins with "<path>/" (prefix purge) are removed — so a
-	// small content change doesn't blow away the whole domain's hot cache.
+	// is purged (v1 behaviour). When set, the hash fast path removes each
+	// path's exact entries; domains with a cache_query_allowlist additionally
+	// get a bounded walk that also evicts the path's query-key variants and
+	// honours prefix matching ("<path>/..."). Callers wanting guaranteed
+	// prefix semantics on a non-allowlist domain purge the whole domain.
 	Paths []string `json:"paths,omitempty"`
 }
 
@@ -103,22 +120,45 @@ func nginxCachePurgeHandler(ctx context.Context, params json.RawMessage) (any, e
 				}
 			}
 		}
+		// GH #610 interaction: a domain with a cache_query_allowlist keys its
+		// allowlisted query combinations SEPARATELY ("...path?page=2&"), and
+		// those keys cannot be enumerated from the path alone — the hash fast
+		// path above only removed the clean-URL entries, leaving every query
+		// variant stale after a content edit. For those domains, additionally
+		// run the bounded KEY-line walk: uriMatchesAny strips the query, so
+		// the variants match their purge path.
+		if domainUsesQueryAllowlist(p.Domain) {
+			wp, truncated, werr := walkPurgeHostPaths(ctx, root, p.Domain, paths)
+			if werr != nil {
+				return nil, csInternal("walk cache dir", werr)
+			}
+			purged += wp
+			return map[string]any{"ok": true, "purged": purged, "domain": p.Domain, "truncated": truncated}, nil
+		}
 		return map[string]any{"ok": true, "purged": purged, "domain": p.Domain}, nil
 	}
 
-	// nginx stores a `KEY: <scheme><method><host><uri>` line in the cache file
-	// header (cache_key = $scheme$request_method$host$request_uri, concatenated
-	// with no delimiter). Match the HOST FIELD exactly — a raw substring match
-	// would evict another tenant whose host merely CONTAINS this domain
-	// ("a.com" ⊂ "sub.a.com") or whose URL path contains the string, a
-	// cross-tenant cache-eviction lever despite the owner-scoped REST (Gitea #418).
+	purged, truncated, werr := walkPurgeHostPaths(ctx, root, p.Domain, nil)
+	if werr != nil {
+		return nil, csInternal("walk cache dir", werr)
+	}
+	return map[string]any{"ok": true, "purged": purged, "domain": p.Domain, "truncated": truncated}, nil
+}
+
+// walkPurgeHostPaths removes cached entries whose KEY line matches host and
+// (when paths is non-empty) uriMatchesAny. nginx stores a
+// `KEY: <scheme><method><host><uri>` line in the cache file header,
+// concatenated with no delimiter. Match the HOST FIELD exactly — a raw
+// substring match would evict another tenant whose host merely CONTAINS this
+// domain ("a.com" ⊂ "sub.a.com") or whose URL path contains the string, a
+// cross-tenant cache-eviction lever despite the owner-scoped REST (Gitea #418).
+//
+// Bounded (JAB-67): a dedicated deadline + a scanned-file cap so a purge can
+// never block the agent proportional to total cross-tenant cache size.
+func walkPurgeHostPaths(ctx context.Context, root, host string, paths []string) (int, bool, error) {
 	needle := []byte("KEY: ")
-	host := p.Domain
 	purged := 0
 
-	// Bound the walk (JAB-67): a dedicated deadline + a scanned-file cap so this
-	// full purge can never block the agent proportional to total cross-tenant
-	// cache size.
 	walkCtx, cancel := context.WithTimeout(ctx, cachePurgeWalkDeadline)
 	defer cancel()
 	scanned := 0
@@ -162,16 +202,16 @@ func nginxCachePurgeHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil
 	})
 	if walkErr != nil && walkErr != context.Canceled && walkErr != context.DeadlineExceeded {
-		return nil, csInternal("walk cache dir", walkErr)
+		return purged, truncated, walkErr
 	}
 	if walkErr == context.DeadlineExceeded || walkCtx.Err() == context.DeadlineExceeded {
 		truncated = true
 	}
 	if truncated {
-		slog.Warn("nginx cache full-purge hit a bound; some entries left for nginx inactive-eviction",
+		slog.Warn("nginx cache purge walk hit a bound; some entries left for nginx inactive-eviction",
 			"domain", host, "scanned", scanned, "purged", purged)
 	}
-	return map[string]any{"ok": true, "purged": purged, "domain": p.Domain, "truncated": truncated}, nil
+	return purged, truncated, nil
 }
 
 // keyLineHost extracts the $host field from an nginx cache KEY line of the form

--- a/panel-agent/internal/commands/nginx_cache_purge_qallow_test.go
+++ b/panel-agent/internal/commands/nginx_cache_purge_qallow_test.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCacheEntry creates a cache file at the nginx levels=1:2 location for
+// key, containing the KEY: header line — the shape the walk purge parses.
+func writeCacheEntry(t *testing.T, root, key string) string {
+	t.Helper()
+	sum := md5.Sum([]byte(key))
+	h := hex.EncodeToString(sum[:])
+	dir := filepath.Join(root, h[31:32], h[29:31])
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fp := filepath.Join(dir, h)
+	if err := os.WriteFile(fp, []byte("HEADER\nKEY: "+key+"\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return fp
+}
+
+// GH #610 interaction: a domain with cache_query_allowlist stores separate
+// entries per allowlisted query combination; the hash fast path can't
+// enumerate them, so the handler must ALSO walk for such domains and evict
+// the query variants of a purged path.
+func TestTargetedPurgeEvictsQueryAllowlistVariants(t *testing.T) {
+	root := t.TempDir()
+	vhosts := t.TempDir()
+	oldRoot, oldVhosts := fastcgiCacheRoot, purgeVhostDir
+	fastcgiCacheRoot, purgeVhostDir = root, vhosts
+	defer func() { fastcgiCacheRoot, purgeVhostDir = oldRoot, oldVhosts }()
+
+	const dom = "shop.example.com"
+	if err := os.WriteFile(filepath.Join(vhosts, dom+".conf"),
+		[]byte("server {\n  fastcgi_cache_key \"$scheme$request_method$host$jabali_cache_path$jabali_qsep$jabali_qkey\";\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clean := writeCacheEntry(t, root, "httpsGET"+dom+"/shop")
+	variant1 := writeCacheEntry(t, root, "httpsGET"+dom+"/shop?paged=2&")
+	variant2 := writeCacheEntry(t, root, "httpsGET"+dom+"/shop?paged=3&")
+	otherPath := writeCacheEntry(t, root, "httpsGET"+dom+"/about")
+	otherHost := writeCacheEntry(t, root, "httpsGETother.example.com/shop?paged=2&")
+
+	out, err := nginxCachePurgeHandler(context.Background(),
+		json.RawMessage(`{"domain":"`+dom+`","paths":["/shop"]}`))
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	res := out.(map[string]any)
+	if got := res["purged"].(int); got != 3 {
+		t.Errorf("purged = %d, want 3 (clean + 2 query variants)", got)
+	}
+	for _, gone := range []string{clean, variant1, variant2} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("entry should be purged: %s", gone)
+		}
+	}
+	for _, kept := range []string{otherPath, otherHost} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("entry should survive: %s", kept)
+		}
+	}
+}
+
+// A domain WITHOUT the query allowlist keeps the fast path only: exact hash
+// unlinks, no walk (other entries untouched, no truncated field).
+func TestTargetedPurgeFastPathWithoutAllowlist(t *testing.T) {
+	root := t.TempDir()
+	vhosts := t.TempDir()
+	oldRoot, oldVhosts := fastcgiCacheRoot, purgeVhostDir
+	fastcgiCacheRoot, purgeVhostDir = root, vhosts
+	defer func() { fastcgiCacheRoot, purgeVhostDir = oldRoot, oldVhosts }()
+
+	const dom = "plain.example.com"
+	if err := os.WriteFile(filepath.Join(vhosts, dom+".conf"),
+		[]byte("server {\n  fastcgi_cache_key \"$scheme$request_method$host$jabali_cache_path\";\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	clean := writeCacheEntry(t, root, "httpsGET"+dom+"/page")
+	stray := writeCacheEntry(t, root, "httpsGET"+dom+"/page?paged=2&") // shouldn't exist for a non-qallow domain; must survive the fast path
+
+	out, err := nginxCachePurgeHandler(context.Background(),
+		json.RawMessage(`{"domain":"`+dom+`","paths":["/page"]}`))
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	res := out.(map[string]any)
+	if got := res["purged"].(int); got != 1 {
+		t.Errorf("purged = %d, want 1", got)
+	}
+	if _, err := os.Stat(clean); !os.IsNotExist(err) {
+		t.Errorf("clean entry should be purged")
+	}
+	if _, err := os.Stat(stray); err != nil {
+		t.Errorf("non-walk fast path must not touch other entries")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the WP-cache audit (#809). The GH #631 targeted-purge fast path unlinks entries by `md5(scheme+method+host+path)` — but domains using `cache_query_allowlist` (GH #610) store separate cache entries per allowlisted query combination (`...path?paged=2&`). Those keys can't be enumerated from the path, so every query variant survived a post-edit purge and served stale until TTL (600s default).

**Fix:** detect the allowlist from the rendered vhost (`$jabali_qkey` marker — root-owned file, same trust anchor as the spool watcher's GH #630 ownership check) and, for such domains only, additionally run the bounded KEY-line walk. `uriMatchesAny` already query-strips, so variants match their purge path. Plain domains keep the pure fast path (no new I/O).

Also: walk body extracted to `walkPurgeHostPaths` (shared with whole-domain purge, behaviour unchanged) and the `Paths` doc now states the real matching semantics — the old comment promised prefix purge the fast path never delivered.

## Test plan
- [x] New tests: qallow domain purge evicts clean entry + both query variants, spares other paths/hosts; non-qallow domain stays fast-path-only
- [x] Existing purge/host/bound tests green (walk refactor is behaviour-preserving)
- [x] `go vet` + full commands package green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)