### PR TITLE
fix(dns): stop writing SRV priority twice, which made all 9 records unresolvable

### DIFF
--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -59,10 +59,10 @@ type dnsHandler struct {
 }
 
 type updateZoneRequest struct {
-	RefreshSeconds *int `json:"refresh_seconds,omitempty"`
-	RetrySeconds   *int `json:"retry_seconds,omitempty"`
-	ExpireSeconds  *int `json:"expire_seconds,omitempty"`
-	MinimumTTL     *int `json:"minimum_ttl,omitempty"`
+	RefreshSeconds *int  `json:"refresh_seconds,omitempty"`
+	RetrySeconds   *int  `json:"retry_seconds,omitempty"`
+	ExpireSeconds  *int  `json:"expire_seconds,omitempty"`
+	MinimumTTL     *int  `json:"minimum_ttl,omitempty"`
 	IsEnabled      *bool `json:"is_enabled,omitempty"`
 }
 
@@ -124,7 +124,7 @@ func (h *dnsHandler) getZone(c *gin.Context) {
 	if err != nil {
 		if isNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{
-				"error": "zone_not_provisioned",
+				"error":  "zone_not_provisioned",
 				"detail": "DNS zone not yet provisioned. The reconciler will create it on next sync.",
 			})
 			return
@@ -174,7 +174,7 @@ func (h *dnsHandler) updateZone(c *gin.Context) {
 	if err != nil {
 		if isNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{
-				"error": "zone_not_provisioned",
+				"error":  "zone_not_provisioned",
 				"detail": "DNS zone not yet provisioned. The reconciler will create it on next sync.",
 			})
 			return
@@ -257,7 +257,7 @@ func (h *dnsHandler) listRecords(c *gin.Context) {
 	if err != nil {
 		if isNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{
-				"error": "zone_not_provisioned",
+				"error":  "zone_not_provisioned",
 				"detail": "DNS zone not yet provisioned. The reconciler will create it on next sync.",
 			})
 			return
@@ -353,7 +353,7 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 	if err != nil {
 		if isNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{
-				"error": "zone_not_provisioned",
+				"error":  "zone_not_provisioned",
 				"detail": "DNS zone not yet provisioned. The reconciler will create it on next sync.",
 			})
 			return
@@ -364,14 +364,14 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 
 	// Build record from request
 	record := &models.DNSRecord{
-		ID:     ids.NewULID(),
-		ZoneID: zone.ID,
-		Name:   req.Name,
-		Type:   req.Type,
-		Content: req.Content,
-		TTL:    h.defaultRecordTTL(c.Request.Context()),
-		Priority: 0,
-		Managed: false,
+		ID:        ids.NewULID(),
+		ZoneID:    zone.ID,
+		Name:      req.Name,
+		Type:      req.Type,
+		Content:   req.Content,
+		TTL:       h.defaultRecordTTL(c.Request.Context()),
+		Priority:  0,
+		Managed:   false,
 		IsEnabled: true,
 	}
 
@@ -385,6 +385,8 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 	if req.IsEnabled != nil {
 		record.IsEnabled = *req.IsEnabled
 	}
+
+	normaliseSRVRecord(record, req.Priority)
 
 	// Validate record
 	if err := ValidateDNSRecord(record); err != nil {
@@ -508,6 +510,8 @@ func (h *dnsHandler) updateRecord(c *gin.Context) {
 	if req.IsEnabled != nil {
 		record.IsEnabled = *req.IsEnabled
 	}
+
+	normaliseSRVRecord(record, req.Priority)
 
 	// Per-type permission gate for non-admin tenants (GH #466): editing the
 	// record needs the edit right on its current type, and changing its type
@@ -659,6 +663,38 @@ func IsValidDNSType(t string) bool {
 	return false
 }
 
+// normaliseSRVRecord moves an inline SRV priority into the priority column.
+//
+// PowerDNS's gmysql backend prepends the prio column to SRV content, so a
+// record carrying the priority in BOTH places assembles into a five-field
+// value that pdns refuses to serve — the record silently does not resolve at
+// all. JAB-28 fixed exactly this in the cPanel BIND importer; the panel's own
+// create/update path still accepted, and in fact required, the doubled form.
+//
+// Every DNS tutorial and every zone file writes SRV as the full RFC 2782
+// "priority weight port target", so rejecting that would be user-hostile.
+// Accept it, split the priority out, and leave the already-correct
+// three-field form untouched. An explicit priority in the request wins, since
+// that is the caller being unambiguous.
+func normaliseSRVRecord(r *models.DNSRecord, explicitPriority *int) {
+	if r.Type != "SRV" {
+		return
+	}
+	fields := strings.Fields(r.Content)
+	if len(fields) != 4 {
+		return
+	}
+	prio, err := strconv.Atoi(fields[0])
+	if err != nil || prio < 0 || prio > 65535 {
+		// Leave it alone; ValidateDNSRecord reports the real problem.
+		return
+	}
+	r.Content = fields[1] + " " + fields[2] + " " + fields[3]
+	if explicitPriority == nil {
+		r.Priority = prio
+	}
+}
+
 func ValidateDNSRecord(r *models.DNSRecord) error {
 	r.Type = strings.ToUpper(strings.TrimSpace(r.Type))
 	r.Name = strings.TrimSpace(r.Name)
@@ -707,14 +743,30 @@ func ValidateDNSRecord(r *models.DNSRecord) error {
 			return fmt.Errorf("TXT content exceeds 4000 chars")
 		}
 	case "SRV":
-		// content format: "priority weight port target"
+		// Stored content is "weight port target"; the priority lives in the
+		// priority column, exactly as MX stores its hostname. PowerDNS
+		// prepends the column when assembling the record, so a priority left
+		// in content produces a five-field value the server will not serve at
+		// all (JAB-28).
+		//
+		// This used to require the four-field form, which meant every SRV
+		// created through the panel was unresolvable and a caller supplying
+		// the correct three fields was rejected. normaliseSRVRecord now
+		// splits a pasted RFC 2782 string before validation, so both shapes
+		// reach here as three fields.
 		fields := strings.Fields(r.Content)
-		if len(fields) != 4 {
-			return fmt.Errorf("SRV content must be \"priority weight port target\"")
+		if len(fields) != 3 {
+			return fmt.Errorf("SRV content must be \"weight port target\" with the priority in the priority field (a full \"priority weight port target\" string is also accepted and split automatically)")
 		}
-		port, err := strconv.Atoi(fields[2])
+		if _, err := strconv.Atoi(fields[0]); err != nil {
+			return fmt.Errorf("SRV weight must be a number")
+		}
+		port, err := strconv.Atoi(fields[1])
 		if err != nil || port < 1 || port > 65535 {
 			return fmt.Errorf("SRV port must be 1-65535")
+		}
+		if r.Priority < 0 || r.Priority > 65535 {
+			return fmt.Errorf("SRV priority must be 0-65535")
 		}
 	case "CAA":
 		// content format: "<flags> <tag> \"<value>\"" per RFC 8659,
@@ -738,18 +790,17 @@ func ValidateDNSRecord(r *models.DNSRecord) error {
 	return nil
 }
 
-
 // CheckDNSRecordConflict enforces RFC 1034 §3.6.2 (CNAME exclusivity)
 // and prevents exact-duplicate rows.
 //
 // Rules:
-//   1. Exact duplicate (same zone+name+type+content) → rejected.
-//   2. CNAME at a name MUST be the only record at that name.
-//      - Adding CNAME when ANY other record (A/AAAA/MX/TXT/SRV/CNAME)
-//        already exists at the same name → rejected.
-//      - Adding A/AAAA/MX/TXT/SRV when a CNAME already exists at the
-//        same name → rejected.
-//   3. Multiple CNAMEs at the same name → rejected (only one allowed).
+//  1. Exact duplicate (same zone+name+type+content) → rejected.
+//  2. CNAME at a name MUST be the only record at that name.
+//     - Adding CNAME when ANY other record (A/AAAA/MX/TXT/SRV/CNAME)
+//     already exists at the same name → rejected.
+//     - Adding A/AAAA/MX/TXT/SRV when a CNAME already exists at the
+//     same name → rejected.
+//  3. Multiple CNAMEs at the same name → rejected (only one allowed).
 //
 // excludeID is the record being updated (skip self-conflict on edit);
 // pass "" on create.

--- a/panel-api/internal/api/dns_srv_normalise_test.go
+++ b/panel-api/internal/api/dns_srv_normalise_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func intPtr(i int) *int { return &i }
+
+// TestNormaliseSRVRecord covers the user-facing half of the SRV priority bug.
+//
+// PowerDNS prepends the priority column to SRV content, so a record carrying
+// the priority in both places assembles into five fields and is not served at
+// all — the record simply does not resolve. The panel's validator used to
+// REQUIRE the four-field form, which meant every SRV created through the UI or
+// API was broken, and a caller supplying the correct three fields was rejected.
+//
+// JAB-28 fixed this same bug in the cPanel BIND importer. The panel's own
+// create/update path was missed.
+//
+// Every DNS tutorial and every zone file writes the full RFC 2782 string, so
+// the fix accepts it and splits the priority out rather than rejecting it.
+func TestNormaliseSRVRecord(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		in          models.DNSRecord
+		explicit    *int
+		wantContent string
+		wantPrio    int
+	}{
+		{
+			name:        "full RFC form is split",
+			in:          models.DNSRecord{Type: "SRV", Content: "10 1 465 mail.example.com"},
+			wantContent: "1 465 mail.example.com",
+			wantPrio:    10,
+		},
+		{
+			name:        "already-correct three fields are untouched",
+			in:          models.DNSRecord{Type: "SRV", Content: "1 465 mail.example.com", Priority: 10},
+			wantContent: "1 465 mail.example.com",
+			wantPrio:    10,
+		},
+		{
+			// The caller being explicit is the caller being unambiguous.
+			name:        "explicit priority wins over the inline one",
+			in:          models.DNSRecord{Type: "SRV", Content: "10 1 465 mail.example.com", Priority: 20},
+			explicit:    intPtr(20),
+			wantContent: "1 465 mail.example.com",
+			wantPrio:    20,
+		},
+		{
+			name:        "priority zero is preserved, not treated as unset",
+			in:          models.DNSRecord{Type: "SRV", Content: "0 1 465 mail.example.com"},
+			wantContent: "1 465 mail.example.com",
+			wantPrio:    0,
+		},
+		{
+			// Left alone so ValidateDNSRecord reports the real problem rather
+			// than this silently mangling it first.
+			name:        "non-numeric leading field is left for the validator",
+			in:          models.DNSRecord{Type: "SRV", Content: "abc 1 465 mail.example.com"},
+			wantContent: "abc 1 465 mail.example.com",
+			wantPrio:    0,
+		},
+		{
+			name:        "out-of-range priority is left for the validator",
+			in:          models.DNSRecord{Type: "SRV", Content: "70000 1 465 mail.example.com"},
+			wantContent: "70000 1 465 mail.example.com",
+			wantPrio:    0,
+		},
+		{
+			name:        "non-SRV types are never touched",
+			in:          models.DNSRecord{Type: "TXT", Content: "10 1 465 mail.example.com"},
+			wantContent: "10 1 465 mail.example.com",
+			wantPrio:    0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tc.in
+			normaliseSRVRecord(&rec, tc.explicit)
+			if rec.Content != tc.wantContent {
+				t.Errorf("content = %q, want %q", rec.Content, tc.wantContent)
+			}
+			if rec.Priority != tc.wantPrio {
+				t.Errorf("priority = %d, want %d", rec.Priority, tc.wantPrio)
+			}
+		})
+	}
+}
+
+// TestValidateDNSRecord_SRVShape pins that the validator now wants the stored
+// shape. Accepting four fields here would let the doubled priority back
+// through for any caller that skips normalisation.
+func TestValidateDNSRecord_SRVShape(t *testing.T) {
+	t.Parallel()
+
+	ok := &models.DNSRecord{Type: "SRV", Name: "_imaps._tcp", Content: "1 993 mail.example.com", Priority: 0}
+	if err := ValidateDNSRecord(ok); err != nil {
+		t.Errorf("three-field SRV content should validate, got: %v", err)
+	}
+
+	doubled := &models.DNSRecord{Type: "SRV", Name: "_imaps._tcp", Content: "0 1 993 mail.example.com"}
+	if err := ValidateDNSRecord(doubled); err == nil {
+		t.Error("four-field SRV content must be rejected at validation — " +
+			"PowerDNS prepends the priority column, so storing it would " +
+			"produce a record that never resolves")
+	}
+
+	badPort := &models.DNSRecord{Type: "SRV", Name: "_imaps._tcp", Content: "1 0 mail.example.com"}
+	if err := ValidateDNSRecord(badPort); err == nil {
+		t.Error("port 0 should be rejected")
+	}
+}

--- a/panel-api/internal/api/domain_email_test.go
+++ b/panel-api/internal/api/domain_email_test.go
@@ -283,9 +283,9 @@ func TestDomainEmail_Enable_InsertsM6DNSRecords(t *testing.T) {
 	require.Len(t, got, 14, "expected 14 M6 record keys, got %v", got)
 	require.Equal(t, `"v=DKIM1;k=ed25519;p=AAAA"`, got["TXT:jabali._domainkey"])
 	require.Equal(t, "mail.example.com", got["CNAME:autoconfig"])
-	require.Equal(t, "0 0 443 mail.example.com", got["SRV:_autodiscover._tcp"])
-	require.Equal(t, "0 1 443 mail.example.com", got["SRV:_caldavs._tcp"])
-	require.Equal(t, "0 1 443 mail.example.com", got["SRV:_carddavs._tcp"])
+	require.Equal(t, "0 443 mail.example.com", got["SRV:_autodiscover._tcp"])
+	require.Equal(t, "1 443 mail.example.com", got["SRV:_caldavs._tcp"])
+	require.Equal(t, "1 443 mail.example.com", got["SRV:_carddavs._tcp"])
 }
 
 // Disable must remove every ManagedBy="m6" row — and nothing else. We

--- a/panel-api/internal/dnscompile/email_records.go
+++ b/panel-api/internal/dnscompile/email_records.go
@@ -37,7 +37,7 @@ const EmailRecordsSelector = "jabali"
 //	jabali._domainkey  TXT    "v=DKIM1; k=ed25519; p=<pubkey>"
 //	autoconfig         CNAME  mail
 //	autodiscover       CNAME  mail
-//	_autodiscover._tcp SRV    0 0 443 mail
+//	_autodiscover._tcp SRV    0 0 443 mail   (priority in the column, see below)
 //	_caldav(s)/_carddav(s)._tcp SRV ...
 //	_imap/_imaps/_submission/_submissions._tcp SRV ...  (RFC 6186)
 //	_smtp._tls         TXT    "v=TLSRPTv1; rua=mailto:postmaster@<zone>"
@@ -86,14 +86,34 @@ func BuildEmailRecords(
 		}
 	}
 	mailTarget := "mail." + zoneName
+	// SRV content is "weight port target" — the PRIORITY belongs in the
+	// priority column, never in the content string, exactly as MX is written
+	// (`mk("@", "MX", "mail."+zone, 10)`).
+	//
+	// These carried the priority in BOTH places. PowerDNS's gmysql backend on
+	// this schema prepends the prio column to the content for MX and SRV, so
+	// "0 1 465 mail.example.com" became a five-field record:
+	//
+	//	pdnsutil check-zone:
+	//	  Error was: When parsing SRV trailing data was not parsed: ' mail...'
+	//
+	// and pdns refused to serve it. Every one of these nine records returned
+	// an EMPTY answer — verified with dig against the authoritative server —
+	// which silently disables SRV-based mail client autoconfiguration
+	// (Thunderbird, Outlook, iOS) and CalDAV/CardDAV discovery on every
+	// email-enabled domain. MX was unaffected because it was already written
+	// the correct way.
+	//
+	// No migration needed: the agent's pdns client DELETEs and reinserts the
+	// whole zone on each push, so hosts converge on the next reconcile.
 	return []models.DNSRecord{
 		mk(selector+"._domainkey", "TXT", `"`+dkimPublicKey+`"`, 0),
 		mk("autoconfig", "CNAME", mailTarget, 0),
-		mk("_autodiscover._tcp", "SRV", "0 0 443 "+mailTarget, 0),
-		mk("_caldavs._tcp", "SRV", "0 1 443 "+mailTarget, 0),
-		mk("_carddavs._tcp", "SRV", "0 1 443 "+mailTarget, 0),
-		mk("_caldav._tcp", "SRV", "0 1 80 "+mailTarget, 0),
-		mk("_carddav._tcp", "SRV", "0 1 80 "+mailTarget, 0),
+		mk("_autodiscover._tcp", "SRV", "0 443 "+mailTarget, 0),
+		mk("_caldavs._tcp", "SRV", "1 443 "+mailTarget, 0),
+		mk("_carddavs._tcp", "SRV", "1 443 "+mailTarget, 0),
+		mk("_caldav._tcp", "SRV", "1 80 "+mailTarget, 0),
+		mk("_carddav._tcp", "SRV", "1 80 "+mailTarget, 0),
 		// --- GH #134: full Stalwart-recommended mail record set ---
 		// autodiscover CNAME — the Outlook/Exchange autodiscovery
 		// flavour, alongside the _autodiscover._tcp SRV above.
@@ -101,10 +121,10 @@ func BuildEmailRecords(
 		// Client-service SRV records (RFC 6186) — let MUAs auto-discover
 		// the IMAP + submission ports Stalwart listens on. weight 1 so a
 		// resolver picks them deterministically.
-		mk("_imap._tcp", "SRV", "0 1 143 "+mailTarget, 0),
-		mk("_imaps._tcp", "SRV", "0 1 993 "+mailTarget, 0),
-		mk("_submission._tcp", "SRV", "0 1 587 "+mailTarget, 0),
-		mk("_submissions._tcp", "SRV", "0 1 465 "+mailTarget, 0),
+		mk("_imap._tcp", "SRV", "1 143 "+mailTarget, 0),
+		mk("_imaps._tcp", "SRV", "1 993 "+mailTarget, 0),
+		mk("_submission._tcp", "SRV", "1 587 "+mailTarget, 0),
+		mk("_submissions._tcp", "SRV", "1 465 "+mailTarget, 0),
 		// TLS-RPT (RFC 8460) — where receivers send aggregate reports of
 		// TLS negotiation failures delivering to this domain.
 		mk("_smtp._tls", "TXT", `"v=TLSRPTv1; rua=mailto:postmaster@`+zoneName+`"`, 0),

--- a/panel-api/internal/dnscompile/email_records_test.go
+++ b/panel-api/internal/dnscompile/email_records_test.go
@@ -49,22 +49,22 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 	// the same reason as the CNAME above.
 	require.Equal(t, "_autodiscover._tcp", recs[2].Name)
 	require.Equal(t, "SRV", recs[2].Type)
-	require.Equal(t, "0 0 443 mail.example.com", recs[2].Content)
+	require.Equal(t, "0 443 mail.example.com", recs[2].Content)
 
 	// Records 3-6 — CalDAV/CardDAV SRV for RFC 6764 (HTTPS on 443,
 	// plain HTTP on 80 as fallback).
 	require.Equal(t, "_caldavs._tcp", recs[3].Name)
 	require.Equal(t, "SRV", recs[3].Type)
-	require.Equal(t, "0 1 443 mail.example.com", recs[3].Content)
+	require.Equal(t, "1 443 mail.example.com", recs[3].Content)
 	require.Equal(t, "_carddavs._tcp", recs[4].Name)
 	require.Equal(t, "SRV", recs[4].Type)
-	require.Equal(t, "0 1 443 mail.example.com", recs[4].Content)
+	require.Equal(t, "1 443 mail.example.com", recs[4].Content)
 	require.Equal(t, "_caldav._tcp", recs[5].Name)
 	require.Equal(t, "SRV", recs[5].Type)
-	require.Equal(t, "0 1 80 mail.example.com", recs[5].Content)
+	require.Equal(t, "1 80 mail.example.com", recs[5].Content)
 	require.Equal(t, "_carddav._tcp", recs[6].Name)
 	require.Equal(t, "SRV", recs[6].Type)
-	require.Equal(t, "0 1 80 mail.example.com", recs[6].Content)
+	require.Equal(t, "1 80 mail.example.com", recs[6].Content)
 
 	// GH #134 additions (appended after the existing set).
 	require.Equal(t, "autodiscover", recs[7].Name)
@@ -72,13 +72,13 @@ func TestBuildEmailRecords_ShapeAndContent(t *testing.T) {
 	require.Equal(t, "mail.example.com", recs[7].Content)
 
 	require.Equal(t, "_imap._tcp", recs[8].Name)
-	require.Equal(t, "0 1 143 mail.example.com", recs[8].Content)
+	require.Equal(t, "1 143 mail.example.com", recs[8].Content)
 	require.Equal(t, "_imaps._tcp", recs[9].Name)
-	require.Equal(t, "0 1 993 mail.example.com", recs[9].Content)
+	require.Equal(t, "1 993 mail.example.com", recs[9].Content)
 	require.Equal(t, "_submission._tcp", recs[10].Name)
-	require.Equal(t, "0 1 587 mail.example.com", recs[10].Content)
+	require.Equal(t, "1 587 mail.example.com", recs[10].Content)
 	require.Equal(t, "_submissions._tcp", recs[11].Name)
-	require.Equal(t, "0 1 465 mail.example.com", recs[11].Content)
+	require.Equal(t, "1 465 mail.example.com", recs[11].Content)
 
 	require.Equal(t, "_smtp._tls", recs[12].Name)
 	require.Equal(t, "TXT", recs[12].Type)

--- a/panel-api/internal/dnscompile/srv_priority_test.go
+++ b/panel-api/internal/dnscompile/srv_priority_test.go
@@ -1,0 +1,98 @@
+package dnscompile
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestSRVAndMXContentCarryNoPriority pins the field split that made nine
+// records unresolvable.
+//
+// PowerDNS's gmysql backend on this schema prepends the prio column to the
+// content for MX and SRV. The email records carried the priority in BOTH
+// places, so "0 1 465 mail.example.com" was assembled into a five-field SRV:
+//
+//	pdnsutil check-zone:
+//	  Error was: When parsing SRV trailing data was not parsed: ' mail...'
+//
+// and pdns served nothing at all for them. Verified against a live
+// authoritative server: `dig _imaps._tcp.<zone> SRV` returned an empty answer,
+// and the same record with the priority moved out of content answered
+// correctly. That silently disables SRV-based mail client autoconfiguration
+// (Thunderbird, Outlook, iOS) and CalDAV/CardDAV discovery on every
+// email-enabled domain.
+//
+// The per-record literal assertions in email_records_test.go were updated
+// alongside the fix, which is exactly why this test exists too: those encode
+// the values, this encodes the rule, and it was the rule that was wrong.
+func TestSRVAndMXContentCarryNoPriority(t *testing.T) {
+	t.Parallel()
+
+	for _, rec := range emailRecordsForTest(t) {
+		switch rec.Type {
+		case "SRV":
+			// RFC 2782 wire format is "priority weight port target"; with the
+			// priority in its own column, content must be the remaining three.
+			fields := strings.Fields(rec.Content)
+			if len(fields) != 3 {
+				t.Errorf("%s SRV content %q has %d fields, want 3 "+
+					"(weight port target). PowerDNS prepends the prio column, "+
+					"so a priority left in content produces a malformed record "+
+					"that is not served at all.",
+					rec.Name, rec.Content, len(fields))
+				continue
+			}
+			// A bare target in the port slot means the fields shifted.
+			if strings.ContainsAny(fields[1], "abcdefghijklmnopqrstuvwxyz") {
+				t.Errorf("%s SRV content %q: port field %q is not numeric — "+
+					"fields look shifted", rec.Name, rec.Content, fields[1])
+			}
+		case "MX":
+			// MX was always written correctly; assert it stays that way, since
+			// the same prepending applies.
+			if len(strings.Fields(rec.Content)) != 1 {
+				t.Errorf("%s MX content %q should be the exchange hostname "+
+					"alone, with priority in the priority column",
+					rec.Name, rec.Content)
+			}
+		}
+	}
+}
+
+// TestSRVPriorityIsSetInTheColumn is the other half: moving the priority out of
+// content is only correct if it actually lands in the column, otherwise every
+// SRV silently becomes priority 0.
+func TestSRVPriorityIsSetInTheColumn(t *testing.T) {
+	t.Parallel()
+
+	seen := 0
+	for _, rec := range emailRecordsForTest(t) {
+		if rec.Type != "SRV" {
+			continue
+		}
+		seen++
+		if rec.Priority < 0 {
+			t.Errorf("%s SRV has negative priority %d", rec.Name, rec.Priority)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no SRV records generated — the email record set changed shape " +
+			"and this test is no longer checking anything")
+	}
+}
+
+func emailRecordsForTest(t *testing.T) []models.DNSRecord {
+	t.Helper()
+	n := 0
+	idNew := func() string {
+		n++
+		return "id" + string(rune('A'+n))
+	}
+	return BuildEmailRecords(
+		"zone1", "example.com", "jabali", "v=DKIM1; k=ed25519; p=AAAA",
+		nil, idNew, time.Unix(0, 0).UTC(),
+	)
+}


### PR DESCRIPTION
Found while running `pdnsutil check-zone` on testserver after restoring a zone. Nine errors, all the same shape.

## The records were never served

M6 puts the SRV priority in the content string **and** leaves the priority column set. PowerDNS's gmysql backend on this schema prepends the prio column to the content for MX and SRV, so:

```
content "0 1 465 mail.example.com" + prio 0
```

becomes a five-field record:

```
$ pdnsutil check-zone jabali.site
[Error] Error was: When parsing SRV trailing data was not parsed: ' mail.jabali.site'
Checked 29 records of 'jabali.site', 9 errors, 0 warnings.
```

pdns then refuses to serve it. Not degraded — **absent**:

```
$ dig +short @127.0.0.1 -p 5300 _imaps._tcp.jabali.site SRV
(empty)
```

## Why this matters

Those nine are the mail-client autoconfiguration set. Thunderbird, Outlook and iOS look up `_imaps._tcp`, `_submission._tcp`, `_submissions._tcp` and `_autodiscover._tcp`; `_caldav(s)`/`_carddav(s)` are RFC 6764 calendar and contact discovery. On every domain with email enabled, none of them resolve.

Nothing surfaces it. The panel lists the records as present and correct. Only a manual `dig` or `check-zone` shows the nameserver never answers.

## The fix is to follow what MX already does

MX was unaffected — `mk("@", "MX", "mail."+zone, 10)` puts the hostname in content and the priority in the column. The SRV calls just didn't follow their own sibling. Correct split is content = `weight port target`, priority in the column.

**No migration needed:** the agent's pdns client `DELETE`s and reinserts the whole zone on every push, so hosts converge on the next reconcile.

## About the tests

The per-record assertions in `email_records_test.go` and `domain_email_test.go` encoded the broken values — that's how this survived. Updating them to match the fix is not enough on its own, so `srv_priority_test.go` asserts the **rule** instead:

- SRV content must be exactly three fields (`weight port target`)
- MX content must be exactly one (the exchange hostname)

It fails against the pre-fix generator with `has 4 fields, want 3`, on all nine.

## Verified end to end on a live host

| | before | after |
|---|---|---|
| SRV records resolving | **0 / 9** | **9 / 9** |
| `pdnsutil check-zone` | 9 errors | 0 errors |

```
_autodiscover    0 0 443 mail.jabali.site.
_imaps           0 1 993 mail.jabali.site.
_submissions     0 1 465 mail.jabali.site.
...
```

Wire format is right: priority, weight, port, target — with the priority arriving from the column exactly once.


---

## Second commit: the user-facing path had it too, and *enforced* it

After fixing the generator I swept for other SRV writers. The panel's own create/update path had the same bug — and there it was mandatory:

```go
case "SRV":
    // content format: "priority weight port target"
    fields := strings.Fields(r.Content)
    if len(fields) != 4 {
        return fmt.Errorf("SRV content must be \"priority weight port target\"")
    }
```

while the handler *also* accepted a separate `priority` field. So every SRV a user created through the UI or API stored the priority twice and never resolved — and a caller supplying the correct three fields was rejected outright.

### This was already known

`internal/migrate/cpanel/bind_parse.go` carries the rule verbatim:

> **JAB-28:** PowerDNS stores SRV priority in the dedicated prio column; content is "weight port target" ONLY. Stuffing the priority into content (with prio=0) makes pdns serve a malformed SRV that doesn't resolve. Split it out like MX above.

The importer was fixed. The generator and the panel's own create path were not. Same shape as #805, where a known ordering rule was applied in one place and left in three others.

### Why accept the four-field form instead of rejecting it

Every DNS tutorial and every zone file writes the full RFC 2782 string, and that is what people paste. `normaliseSRVRecord` accepts it, moves the priority into the column, and leaves an already-correct three-field record untouched. An explicit `priority` in the request wins. Anything malformed passes through untouched so `ValidateDNSRecord` reports the real problem rather than this mangling it first.

Validation now wants the *stored* shape, so a caller bypassing normalisation can't put the doubled form back into the database, and the error message names the accepted alternative rather than just refusing.

Tests cover the split, the already-correct case, explicit-priority precedence, priority `0` surviving (a valid priority, not "unset"), malformed input being left for the validator, and non-SRV types never being touched.
