### PR TITLE
fix(migrate): bulk children inherit the source SSH port (GH #429)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -891,6 +891,10 @@ type bulkCreateRequest struct {
 	// them so the operator doesn't re-upload N times. Without this,
 	// jobs land as drafts the operator must resume one-by-one.
 	SourceJobID string `json:"source_job_id"`
+	// SourcePort (GH #429) — optional. Children normally inherit the port
+	// from the discovery draft named by SourceJobID; this is the fallback
+	// for a caller that has no draft to inherit from.
+	SourcePort int `json:"source_port,omitempty"`
 }
 
 type bulkCreateResponse struct {
@@ -944,10 +948,29 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 	// migrationPlanPreserve returns zero and source mailbox + MySQL-user
 	// passwords are silently reset. secrets_clone already carried the SSH creds
 	// across; the plan was the missing half.
+	// GH #429: the SSH port is the third thing children have to inherit
+	// explicitly, after the secrets and the plan above. Discovery runs against
+	// the draft, so a custom port works there and every operator reasonably
+	// concludes the connection is configured — then bulkCreate builds children
+	// without SourcePort, the `default:22` column tag turns that zero value
+	// into 22, and the auto-kicked pull-source dials 22:
+	//
+	//	pull-source: plesk.Connect: tcp dial <host>:22: i/o timeout
+	//
+	// It only bites the multi-account sources (Plesk subscriptions, WHM),
+	// because submitDraft reuses the discovery job rather than making a child,
+	// so single-account cPanel migrations on a custom port were unaffected.
+	//
+	// Inheriting from the draft rather than requiring the caller to send it
+	// keeps existing clients working — the wizard never sent a port here.
 	var draftPlan *string
+	sourcePort := normalizeSourcePort(req.SourcePort)
 	if req.SourceJobID != "" {
 		if draft, derr := h.cfg.Jobs.FindByID(c.Request.Context(), req.SourceJobID); derr == nil {
 			draftPlan = draft.PlanJSON
+			if draft.SourcePort >= 1 && draft.SourcePort <= 65535 {
+				sourcePort = draft.SourcePort
+			}
 		}
 	}
 
@@ -964,6 +987,7 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 			SourceKind: req.SourceKind,
 			SourceHost: req.SourceHost,
 			SourceUser: acct,
+			SourcePort: sourcePort, // GH #429: inherit the draft's SSH port
 			State:      finalState,
 			PlanJSON:   draftPlan, // GH #633/#634: inherit the wizard's preserve plan
 		}

--- a/panel-api/internal/api/admin_migrations_bulk_port_test.go
+++ b/panel-api/internal/api/admin_migrations_bulk_port_test.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestBulkCreate_ChildrenInheritDraftSourcePort guards GH #429.
+//
+// Reported symptom: the wizard connects and discovers subscriptions fine on a
+// custom SSH port, then the import fails seconds later with
+//
+//	pull-source: plesk.Connect: tcp dial <host>:22: i/o timeout
+//
+// Discovery runs against the DRAFT job, which does hold the custom port, so
+// everything up to that point confirms the connection is configured. bulkCreate
+// then built each child without SourcePort, the `default:22` column tag turned
+// that zero value into 22, and the auto-kicked pull-source dialled 22.
+//
+// This is the third thing children have to inherit explicitly, after the SSH
+// secret and the preserve plan (GH #633/#634) — same handler, same shape of
+// bug, found twice before this one.
+//
+// Only multi-account sources are affected. submitDraft reuses the discovery job
+// rather than creating children, so single-account cPanel migrations on a
+// custom port always worked, which is part of why this survived.
+func TestBulkCreate_ChildrenInheritDraftSourcePort(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+
+	draft := &models.MigrationJob{
+		ID: "DRAFT01", SourceKind: "plesk", SourceHost: "plesk01",
+		SourceUser: "__discovery__", SourcePort: 8404,
+	}
+	if err := jobs.Create(context.Background(), draft); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"source_kind":"plesk","source_host":"plesk01",` +
+		`"accounts":["shop.example.com","blog.example.com"],"source_job_id":"DRAFT01"}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	children := 0
+	for id, j := range jobs.byID {
+		if id == "DRAFT01" {
+			continue
+		}
+		children++
+		if j.SourcePort != 8404 {
+			t.Errorf("child %s (%s) has SourcePort=%d, want 8404 inherited from "+
+				"the draft — pull-source dials this port, so 22 here means the "+
+				"import fails with a connection timeout on a host that just "+
+				"discovered successfully", id, j.SourceUser, j.SourcePort)
+		}
+	}
+	if children != 2 {
+		t.Fatalf("expected 2 child jobs, got %d", children)
+	}
+}
+
+// TestBulkCreate_ExplicitSourcePortUsedWithoutDraft covers the caller that has
+// no discovery draft to inherit from — the legacy path where source_job_id is
+// absent and children land as drafts for manual resume.
+func TestBulkCreate_ExplicitSourcePortUsedWithoutDraft(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+
+	body := `{"source_kind":"plesk","source_host":"plesk01",` +
+		`"accounts":["shop.example.com"],"source_port":2222}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	for _, j := range jobs.byID {
+		if j.SourcePort != 2222 {
+			t.Errorf("child %s has SourcePort=%d, want the explicitly supplied 2222",
+				j.SourceUser, j.SourcePort)
+		}
+	}
+}
+
+// TestBulkCreate_DefaultsTo22WhenNothingSupplied pins that the fix did not turn
+// the common case into a surprise: no draft, no explicit port, still 22.
+func TestBulkCreate_DefaultsTo22WhenNothingSupplied(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+
+	body := `{"source_kind":"plesk","source_host":"plesk01","accounts":["shop.example.com"]}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	for _, j := range jobs.byID {
+		if j.SourcePort != 22 {
+			t.Errorf("child %s has SourcePort=%d, want the 22 default",
+				j.SourceUser, j.SourcePort)
+		}
+	}
+}
+
+// TestBulkCreate_DraftPortWinsOverExplicit pins the precedence. The draft is
+// what discovery actually connected with, so it is the value the operator has
+// already seen succeed; a stale or defaulted body field must not override it.
+func TestBulkCreate_DraftPortWinsOverExplicit(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+
+	draft := &models.MigrationJob{
+		ID: "DRAFT01", SourceKind: "plesk", SourceHost: "plesk01",
+		SourceUser: "__discovery__", SourcePort: 8404,
+	}
+	if err := jobs.Create(context.Background(), draft); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"source_kind":"plesk","source_host":"plesk01",` +
+		`"accounts":["shop.example.com"],"source_job_id":"DRAFT01","source_port":22}`
+	w := postJSON(h.bulkCreate, body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	for id, j := range jobs.byID {
+		if id == "DRAFT01" {
+			continue
+		}
+		if j.SourcePort != 8404 {
+			t.Errorf("child has SourcePort=%d, want the draft's 8404 to win over "+
+				"the body's 22 — the wizard sends no port here, so a defaulted "+
+				"body value must not undo discovery", j.SourcePort)
+		}
+	}
+}


### PR DESCRIPTION
Addresses the custom-SSH-port failure reported in #429.

**I got this wrong the first time.** I replied on the issue saying the port fix was already in #444/#463 and asked the reporter to update and create a fresh job. They came back on a dev build newer than both, with a brand-new job, and the same failure. They were right and my diagnosis was wrong — this is a live bug on current `main`.

## What actually happens

```
pull-source: plesk.Connect: tcp dial <host>:22: i/o timeout
```

Discovery runs against the **draft** job, which really does hold the custom port. So connecting, discovering subscriptions and listing accounts all work on `840x` — everything up to the import confirms the connection is configured. That's what makes it read like the pull ignoring the wizard.

It isn't. `bulkCreate` built each child job like this:

```go
row := &models.MigrationJob{
    ID: genULID(), BatchID: &batchID,
    SourceKind: req.SourceKind, SourceHost: req.SourceHost,
    SourceUser: acct, State: finalState,
    PlanJSON:   draftPlan,
}
```

No `SourcePort`. The Go zero value meets `gorm:"...default:22"`, so the column is written as **22** — and `bulkCreate` then auto-kicks `pull-source` against that child.

My earlier claim that "no code path resets the port" was technically true and completely beside the point. The port is never *reset*. It is never *inherited* by the job that actually runs the pull.

## Third time in this function

Children already have to inherit two things explicitly: the SSH secret (via `secrets_clone`), and the preserve plan. The comment sitting directly above the code I changed says of the latter:

> `secrets_clone` already carried the SSH creds across; the plan was the missing half.

The port was the other missing half. Same handler, same shape of bug, found three times now.

## Why single-account migrations were fine

`submitDraft` reuses the discovery job rather than creating children, so a single-account cPanel migration on a custom port always worked. Only the multi-account sources go through `bulkCreate` — **Plesk subscriptions and WHM**. That narrowness is a good part of why it survived earlier passes over the port plumbing, including mine.

## The fix

Inherit from the draft rather than requiring the caller to send a port. The wizard's bulk payload carries `source_kind`, `source_host`, `accounts`, `account_targets` and `source_job_id` — never a port — so a request-field-only fix would have needed a UI change and still left older clients broken.

`source_port` is accepted on the request as a fallback for a caller with no draft to inherit from. When both are present the **draft wins**: it is the value discovery already proved, and the wizard sends no port here, so a defaulted body field must not be able to undo it.

## Tests

Four cases: inheritance from the draft, the explicit fallback, the plain default staying `22`, and draft-beats-explicit precedence. The first fails against the pre-fix handler with `SourcePort=0` — the zero value the column default turns into 22.

## For the reporter

Once this lands, a **newly created** migration will carry the custom port through to the import. Existing child jobs already have `22` written to their row and won't be repaired by the upgrade — same caveat as before, but this time the fix is real.
