### PR TITLE
fix(security): enforce the migration host-key pin on transfer connections

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -113,7 +113,19 @@ live source SSH. Use scp directly for that kind.`,
 			if _, err := os.Stat(secretPath); err != nil {
 				return markPullFailed(fmt.Errorf("secrets file %s missing: %w (drop SSH_PASSWORD or SSH_PRIVATE_KEY there first)", secretPath, err))
 			}
-			secret := migrate.SecretRef{Path: secretPath}
+			// ExpectedHostKey is load-bearing and was missing here. An empty
+			// pin makes PinningHostKeyCallback return nil for ANY host key —
+			// deliberate TOFU for the first discover connection, but it was
+			// also what every pull and import connection got, because they
+			// built the SecretRef without the field.
+			//
+			// So an operator who supplied a fingerprint in the wizard had it
+			// enforced on the cheap discovery probe and silently ignored on
+			// the connection that carries the SSH credentials and pulls the
+			// databases, mail and site files. Six of the eight SecretRef
+			// construction sites were unpinned; the two that were not are the
+			// discovery paths in admin_migrations.go.
+			secret := migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey}
 
 			// Local destination paths
 			localDir := filepath.Join("/var/lib/jabali-migrations", jobID)

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1634,7 +1634,7 @@ func cpanelAnalyzeCallback(jobsRepo repository.MigrationJobRepository) migrate.S
 		// stage dialed the default 22 regardless (lxsdevcode: "stage
 		// analyze: connect: plesk.Connect: tcp dial remote_ip:22").
 		migrate.ApplyPort(disc, job.SourcePort)
-		s, err := disc.Connect(ctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath})
+		s, err := disc.Connect(ctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 		if err != nil {
 			return 0, nil, fmt.Errorf("connect: %w", err)
 		}
@@ -1750,7 +1750,7 @@ func preflightDAPivot(ctx context.Context, job *models.MigrationJob) (string, er
 	migrate.ApplyPort(disc, job.SourcePort)
 	subctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	s, err := disc.Connect(subctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath})
+	s, err := disc.Connect(subctx, job.SourceHost, migrationSSHUser(job), migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey})
 	if err != nil {
 		return "", nil
 	}
@@ -1872,7 +1872,7 @@ func pleskAuthorizedDocroots(ctx context.Context, job *models.MigrationJob, db *
 	d := plesk.New()
 	d.AllowPrivate = allowPrivate
 	d.Port = srcSSHPort(job)
-	secret := migrate.SecretRef{Path: fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID)}
+	secret := migrate.SecretRef{Path: fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID), ExpectedHostKey: job.ExpectedHostKey}
 	sess, err := d.Connect(ctx, job.SourceHost, migrationSSHUser(job), secret)
 	if err != nil {
 		return nil, fmt.Errorf("connect: %w", err)

--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -964,6 +964,7 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 	// Inheriting from the draft rather than requiring the caller to send it
 	// keeps existing clients working — the wizard never sent a port here.
 	var draftPlan *string
+	var draftHostKey string
 	sourcePort := normalizeSourcePort(req.SourcePort)
 	if req.SourceJobID != "" {
 		if draft, derr := h.cfg.Jobs.FindByID(c.Request.Context(), req.SourceJobID); derr == nil {
@@ -971,6 +972,12 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 			if draft.SourcePort >= 1 && draft.SourcePort <= 65535 {
 				sourcePort = draft.SourcePort
 			}
+			// The host-key pin has to travel too, for the same reason as the
+			// port: children are what the pull actually runs against, and an
+			// empty pin means PinningHostKeyCallback accepts ANY host key.
+			// Without this the operator's fingerprint is enforced on
+			// discovery and quietly dropped for the transfer.
+			draftHostKey = draft.ExpectedHostKey
 		}
 	}
 
@@ -982,14 +989,15 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 	defer cancelClone()
 	for _, acct := range req.Accounts {
 		row := &models.MigrationJob{
-			ID:         genULID(),
-			BatchID:    &batchID,
-			SourceKind: req.SourceKind,
-			SourceHost: req.SourceHost,
-			SourceUser: acct,
-			SourcePort: sourcePort, // GH #429: inherit the draft's SSH port
-			State:      finalState,
-			PlanJSON:   draftPlan, // GH #633/#634: inherit the wizard's preserve plan
+			ID:              genULID(),
+			BatchID:         &batchID,
+			SourceKind:      req.SourceKind,
+			SourceHost:      req.SourceHost,
+			SourceUser:      acct,
+			SourcePort:      sourcePort,   // GH #429: inherit the draft's SSH port
+			ExpectedHostKey: draftHostKey, // inherit the draft's host-key pin
+			State:           finalState,
+			PlanJSON:        draftPlan, // GH #633/#634: inherit the wizard's preserve plan
 		}
 		if req.AccountTargets != nil {
 			if t := strings.TrimSpace(req.AccountTargets[acct]); t != "" {

--- a/panel-api/internal/api/admin_migrations_bulk_port_test.go
+++ b/panel-api/internal/api/admin_migrations_bulk_port_test.go
@@ -143,3 +143,40 @@ func TestBulkCreate_DraftPortWinsOverExplicit(t *testing.T) {
 		}
 	}
 }
+
+// TestBulkCreate_ChildrenInheritHostKeyPin covers the security half of the
+// same omission. An empty ExpectedHostKey makes PinningHostKeyCallback accept
+// ANY host key, so a child created without the draft's pin runs the credential-
+// carrying pull under trust-on-first-use even though the operator supplied a
+// fingerprint in the wizard.
+func TestBulkCreate_ChildrenInheritHostKeyPin(t *testing.T) {
+	h, jobs := newIMAPHandler(nil)
+
+	const fp = "SHA256:AbCdEf0123456789AbCdEf0123456789AbCdEf01234"
+	draft := &models.MigrationJob{
+		ID: "DRAFT01", SourceKind: "plesk", SourceHost: "plesk01",
+		SourceUser: "__discovery__", SourcePort: 8404, ExpectedHostKey: fp,
+	}
+	if err := jobs.Create(context.Background(), draft); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"source_kind":"plesk","source_host":"plesk01",` +
+		`"accounts":["shop.example.com"],"source_job_id":"DRAFT01"}`
+	if w := postJSON(h.bulkCreate, body); w.Code != http.StatusCreated {
+		t.Fatalf("bulkCreate status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	jobs.mu.Lock()
+	defer jobs.mu.Unlock()
+	for id, j := range jobs.byID {
+		if id == "DRAFT01" {
+			continue
+		}
+		if j.ExpectedHostKey != fp {
+			t.Errorf("child %s has ExpectedHostKey=%q, want the draft's pin — "+
+				"an empty pin accepts any host key on the connection that "+
+				"carries the SSH credentials", id, j.ExpectedHostKey)
+		}
+	}
+}

--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -69,7 +69,7 @@ func (h *adminMigrationsHandler) testConnection(c *gin.Context) {
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 45*time.Second)
 	defer cancel()
-	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
+	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env"), ExpectedHostKey: job.ExpectedHostKey}
 
 	switch job.SourceKind {
 	case models.MigrationSourceWordPressPlugin:
@@ -197,7 +197,7 @@ func (h *adminMigrationsHandler) describeAccount(c *gin.Context) {
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 120*time.Second)
 	defer cancel()
-	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
+	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env"), ExpectedHostKey: job.ExpectedHostKey}
 	migrate.ApplyPort(d, job.SourcePort) // GH #429: test/describe previously ignored the custom SSH port (only the run path applied it)
 	sess, err := d.Connect(ctx, job.SourceHost, sshUserOrRoot(job.SourceUser), secret)
 	if err != nil {

--- a/panel-api/internal/api/tenant_migrations.go
+++ b/panel-api/internal/api/tenant_migrations.go
@@ -307,7 +307,7 @@ func (h *tenantMigrationsHandler) scanWP(c *gin.Context) {
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Minute)
 	defer cancel()
-	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env")}
+	secret := migrate.SecretRef{Path: filepath.Join(migrate.SecretsDir, job.ID+".env"), ExpectedHostKey: job.ExpectedHostKey}
 	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, secret, allowPrivate)
 	if err != nil {
 		respondMigrateConnectErr(c, err)
@@ -404,7 +404,7 @@ func (h *tenantMigrationsHandler) verify(c *gin.Context) {
 	if sshUser == "" || sshUser == "wp" {
 		sshUser = "root"
 	}
-	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, migrate.SecretRef{Path: secretPath}, allowPrivate)
+	sess, err := wordpressssh.Connect(ctx, job.SourceHost, 0, sshUser, migrate.SecretRef{Path: secretPath, ExpectedHostKey: job.ExpectedHostKey}, allowPrivate)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "connect_failed", "detail": "SSH connect failed — check host + credentials: " + err.Error()})
 		return

--- a/panel-api/internal/migrate/hostkey_pin_coverage_test.go
+++ b/panel-api/internal/migrate/hostkey_pin_coverage_test.go
@@ -1,0 +1,105 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// secretRefLiteralRe finds every construction of a SecretRef in the tree.
+var secretRefLiteralRe = regexp.MustCompile(`SecretRef\{[^}]*\}`)
+
+// TestEverySecretRefCarriesTheHostKeyPin is a coverage check rather than a
+// behaviour test, because the failure mode here is omission.
+//
+// PinningHostKeyCallback returns nil for ANY host key when the expected
+// fingerprint is empty:
+//
+//	if expected == "" {
+//	    return nil // TOFU: accept the discover connection.
+//	}
+//
+// That is a deliberate choice for the first discovery probe. The problem was
+// that six of the eight SecretRef construction sites left ExpectedHostKey
+// unset, and those six are the ones that matter: the pull-source CLI, the
+// three import/run stages, and both tenant migration paths. An operator who
+// pasted a SHA256 fingerprint into the wizard got it enforced on the cheap
+// discovery connection and silently ignored on the connection that carries the
+// SSH credentials and transfers databases, mail and site files.
+//
+// A missing field compiles, passes every functional test, and downgrades the
+// connection to trust-on-first-use without a word in the logs — so the guard
+// has to be structural.
+func TestEverySecretRefCarriesTheHostKeyPin(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	var offenders []string
+	checked := 0
+	err = filepath.Walk(root, func(path string, info os.FileInfo, werr error) error {
+		if werr != nil {
+			return nil // unreadable dir — not this test's problem
+		}
+		if info.IsDir() {
+			base := info.Name()
+			if base == ".git" || base == "node_modules" || base == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		body, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil
+		}
+		for _, lit := range secretRefLiteralRe.FindAllString(string(body), -1) {
+			checked++
+			if !strings.Contains(lit, "ExpectedHostKey") {
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+": "+lit)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if checked == 0 {
+		t.Fatal("found no SecretRef literals — the construction pattern has " +
+			"changed and this test is no longer checking anything")
+	}
+	for _, o := range offenders {
+		t.Errorf("SecretRef built without ExpectedHostKey — this connection "+
+			"accepts any host key even when the operator pinned a fingerprint:\n  %s", o)
+	}
+}
+
+// TestPinningHostKeyCallback_EmptyIsTOFU documents the behaviour the coverage
+// test exists to contain, so a future reader does not "simplify" the empty case
+// into something stricter or looser without seeing the tradeoff spelled out.
+func TestPinningHostKeyCallback_EmptyIsTOFU(t *testing.T) {
+	t.Parallel()
+
+	cb := PinningHostKeyCallback("")
+	if cb == nil {
+		t.Fatal("callback must never be nil — a nil HostKeyCallback panics in x/crypto/ssh")
+	}
+	// Intentionally not asserting acceptance by calling it with a fabricated
+	// key: the contract under test is that an EMPTY pin is permissive, which is
+	// exactly why every caller with a real pin available must pass it.
+	if got := normalizeFingerprint("SHA256:abc="); got != "abc" {
+		t.Errorf("normalizeFingerprint(%q) = %q, want %q", "SHA256:abc=", got, "abc")
+	}
+	if got := normalizeFingerprint("  abc  "); got != "abc" {
+		t.Errorf("normalizeFingerprint should trim whitespace, got %q", got)
+	}
+}


### PR DESCRIPTION
> Stacked on #814 (base is `fix-bulk-migration-source-port`) — it touches the same `bulkCreate` child literal. Merge #814 first.

Found by continuing the #429 sweep: if children weren't inheriting the SSH **port**, what else weren't they inheriting?

## The host-key pin is enforced on the wrong connection

`PinningHostKeyCallback` treats an empty fingerprint as trust-on-first-use:

```go
if expected == "" {
    return nil // TOFU: accept the discover connection.
}
```

Deliberate for the first discovery probe. The problem is that **8 of the 10** `SecretRef` construction sites never set `ExpectedHostKey` — and the unset ones are the connections that matter:

- `migrate_pull_cmd.go` — the pull that transfers everything
- `migrate_run_cmd.go` ×3 — the import/run stages
- `tenant_migrations.go` ×2 — both tenant paths
- `admin_migrations_testconn.go` ×2 — test-connection

Only the two discovery paths in `admin_migrations.go` passed it.

So an operator who pastes a SHA256 fingerprint into the wizard gets it enforced on the cheap discovery probe, and **silently ignored** on the connection that authenticates with their source-panel credentials and pulls databases, mail and site files. Anyone able to intercept that connection can present their own host key and be accepted.

Nothing surfaces it. A missing struct field compiles, passes every functional test, and downgrades the connection to TOFU without a line in the logs.

## Same omission in bulkCreate

Children didn't inherit the pin either — so even with the sites above fixed, a multi-account migration would still run unpinned, because children are what the pull actually executes against. That's the same shape as the port in #814, in the same struct literal.

## The guard has to be structural

A behavioural test can't catch a field nobody wrote. This walks the tree for `SecretRef` literals and requires `ExpectedHostKey` on each.

It earned its place immediately: **it found the two `admin_migrations_testconn.go` sites my manual grep had missed** — I'd truncated the output with `head` and reported 6. Against the pre-fix tree it reports all 8.

```
SecretRef built without ExpectedHostKey — this connection accepts any host key
even when the operator pinned a fingerprint:
  panel-api/internal/api/admin_migrations_testconn.go: SecretRef{Path: ...}
```

## Behaviour change to be aware of

Where an operator supplied a fingerprint, these connections now **fail closed** on mismatch instead of silently accepting. That's the intent, but it means a migration against a source whose host key legitimately changed (rebuild, IP reuse) will now error rather than proceed — which is the correct trade, and the error names the mismatch. An empty pin still means TOFU, so migrations without a supplied fingerprint behave exactly as before.
