### PR TITLE
refactor(migrate): make bulk child jobs inherit by default, not by hand

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -963,21 +963,19 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 	//
 	// Inheriting from the draft rather than requiring the caller to send it
 	// keeps existing clients working — the wizard never sent a port here.
-	var draftPlan *string
-	var draftHostKey string
+	// The discovery draft is the template every child is built from — the plan,
+	// the host-key pin, the mode and the port all live on it. newBulkChildJob
+	// copies it wholesale so a field added later is inherited by default rather
+	// than silently dropped; only the port needs resolving here, because the
+	// request may supply one when there is no draft to inherit from.
+	var draftJob *models.MigrationJob
 	sourcePort := normalizeSourcePort(req.SourcePort)
 	if req.SourceJobID != "" {
 		if draft, derr := h.cfg.Jobs.FindByID(c.Request.Context(), req.SourceJobID); derr == nil {
-			draftPlan = draft.PlanJSON
+			draftJob = draft
 			if draft.SourcePort >= 1 && draft.SourcePort <= 65535 {
 				sourcePort = draft.SourcePort
 			}
-			// The host-key pin has to travel too, for the same reason as the
-			// port: children are what the pull actually runs against, and an
-			// empty pin means PinningHostKeyCallback accepts ANY host key.
-			// Without this the operator's fingerprint is enforced on
-			// discovery and quietly dropped for the transfer.
-			draftHostKey = draft.ExpectedHostKey
 		}
 	}
 
@@ -988,22 +986,19 @@ func (h *adminMigrationsHandler) bulkCreate(c *gin.Context) {
 	cloneCtx, cancelClone := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancelClone()
 	for _, acct := range req.Accounts {
-		row := &models.MigrationJob{
-			ID:              genULID(),
-			BatchID:         &batchID,
-			SourceKind:      req.SourceKind,
-			SourceHost:      req.SourceHost,
-			SourceUser:      acct,
-			SourcePort:      sourcePort,   // GH #429: inherit the draft's SSH port
-			ExpectedHostKey: draftHostKey, // inherit the draft's host-key pin
-			State:           finalState,
-			PlanJSON:        draftPlan, // GH #633/#634: inherit the wizard's preserve plan
-		}
-		if req.AccountTargets != nil {
-			if t := strings.TrimSpace(req.AccountTargets[acct]); t != "" {
-				row.TargetUserID = &t // map to existing user; else auto-create
-			}
-		}
+		// Inheritance is the default here on purpose — see the comment on
+		// newBulkChildJob. Four fields have been lost by writing this as a
+		// struct literal that opted each one in by hand.
+		row := newBulkChildJob(draftJob, childJobInputs{
+			ID:         genULID(),
+			BatchID:    &batchID,
+			Account:    acct,
+			State:      finalState,
+			TargetID:   resolveChildTarget(req.AccountTargets, acct),
+			SourceKind: req.SourceKind,
+			SourceHost: req.SourceHost,
+			SourcePort: sourcePort,
+		})
 		if err := h.cfg.Jobs.Create(c.Request.Context(), row); err != nil {
 			// Skip dupes silently — operator re-selected an account
 			// that already has an existing job under this host.

--- a/panel-api/internal/api/admin_migrations_child_job.go
+++ b/panel-api/internal/api/admin_migrations_child_job.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// The bulk handler builds one child migration job per selected account. Three
+// separate bugs have now been caused by the same thing: a field that lives on
+// the discovery draft, is needed by the pull, and was simply not written into
+// the child struct literal.
+//
+//	the SSH secret       — needed migration.secrets_clone
+//	the preserve plan    — GH #633/#634; passwords silently reset without it
+//	the SSH port         — GH #429; pull dialled 22 and timed out
+//	the host-key pin     — every transfer connection ran trust-on-first-use
+//
+// Each was invisible: an omitted field is the zero value, and for columns
+// carrying `gorm:"default:N"` the zero value quietly becomes N. Nothing fails,
+// nothing logs, and the symptom appears far from the cause.
+//
+// The literal made the wrong thing the default. Writing a field was opt-IN, so
+// forgetting one meant dropping it. newBulkChildJob inverts that: it starts
+// from a copy of the draft, so a field added to MigrationJob later is inherited
+// unless someone deliberately clears it. Dropping now takes an explicit act,
+// which is the direction the last four bugs argue for.
+//
+// Go cannot enforce exhaustiveness on a struct literal, so the second half of
+// the guard is TestBulkChildJobFieldsAreClassified: every exported field of
+// MigrationJob must be listed as inherited or per-child, and a new field fails
+// the build until someone decides which it is.
+
+// childJobInputs is everything the caller has to supply per child. Naming them
+// explicitly keeps the call site honest about what varies per account and what
+// merely rides along from the draft.
+type childJobInputs struct {
+	ID       string
+	BatchID  *string
+	Account  string
+	State    string
+	TargetID *string
+
+	// SourceKind and SourceHost come from the request rather than the draft
+	// because the bulk endpoint accepts them directly and validates them; the
+	// draft's copies are the same values.
+	SourceKind string
+	SourceHost string
+
+	// SourcePort is resolved by the caller: the draft's value when there is a
+	// draft, otherwise the request's, otherwise 22. Passed in rather than read
+	// here so the precedence lives in one visible place.
+	SourcePort int
+}
+
+// newBulkChildJob builds one child from the discovery draft. A nil draft is the
+// legacy path — a caller with no draft to inherit from — and yields a job with
+// only the explicitly supplied fields set.
+func newBulkChildJob(draft *models.MigrationJob, in childJobInputs) *models.MigrationJob {
+	row := &models.MigrationJob{}
+	if draft != nil {
+		// Copy first, override after. This is what makes inheritance the
+		// default: a field added to MigrationJob arrives here automatically.
+		*row = *draft
+	}
+
+	// ── per-child: identity and batch membership ──────────────────────────
+	row.ID = in.ID
+	row.BatchID = in.BatchID
+	row.SourceUser = in.Account
+	row.State = in.State
+	row.TargetUserID = in.TargetID
+
+	// ── per-child: request-supplied, validated by the handler ─────────────
+	row.SourceKind = in.SourceKind
+	row.SourceHost = in.SourceHost
+	row.SourcePort = in.SourcePort
+
+	// ── per-child: must NOT carry over from the draft ─────────────────────
+	// ManifestJSON is the draft's own discovery OUTPUT — each child discovers
+	// its own account, and inheriting it would describe the wrong subscription.
+	row.ManifestJSON = nil
+	// Lifecycle fields belong to this child's own run. GORM stamps CreatedAt /
+	// UpdatedAt on insert; clearing them keeps a copied draft from carrying a
+	// stale StartedAt into a job that has not started.
+	row.LastError = nil
+	row.EndedAt = nil
+	row.StartedAt = time.Time{}
+	row.CreatedAt = time.Time{}
+	row.UpdatedAt = time.Time{}
+	// Destination binding is resolved per account later in the flow.
+	row.DestUser = nil
+	row.DestDomain = nil
+
+	// Everything not touched above is inherited on purpose: Mode,
+	// ExpectedHostKey, SourcePath and PlanJSON.
+	return row
+}
+
+// resolveChildTarget maps an account to an existing target user when the
+// operator picked one; empty means "auto-create a new Jabali user".
+func resolveChildTarget(accountTargets map[string]string, acct string) *string {
+	if accountTargets == nil {
+		return nil
+	}
+	if t := strings.TrimSpace(accountTargets[acct]); t != "" {
+		return &t
+	}
+	return nil
+}

--- a/panel-api/internal/api/admin_migrations_child_job_test.go
+++ b/panel-api/internal/api/admin_migrations_child_job_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// inheritedFromDraft — fields a bulk child takes from the discovery draft.
+// Every one of these has been, or could have been, a silent-drop bug.
+var inheritedFromDraft = map[string]string{
+	"Mode":            "import vs refresh is a property of the whole migration, not one account",
+	"ExpectedHostKey": "an empty pin makes every transfer connection accept any host key",
+	"SourcePort":      "GH #429 — the pull dials this; 22 is a timeout on a custom-port source",
+	"SourcePath":      "wordpress_ssh control-input; harmless and more correct to carry over",
+	"PlanJSON":        "GH #633/#634 — without it preserve.credentials is lost and passwords reset",
+}
+
+// perChild — fields the child must own rather than inherit. The reason matters:
+// several of these would be actively wrong if copied.
+var perChild = map[string]string{
+	"ID":           "new identity",
+	"BatchID":      "set to the new batch",
+	"SourceKind":   "supplied and validated by the request",
+	"SourceHost":   "supplied and validated by the request",
+	"SourceUser":   "this is the account being migrated — the whole point of the fan-out",
+	"TargetUserID": "resolved per account from account_targets",
+	"State":        "children start pending or draft depending on secret inheritance",
+	"ManifestJSON": "the draft's discovery OUTPUT describes a different subscription",
+	"LastError":    "belongs to this child's own run",
+	"StartedAt":    "this child has not started",
+	"EndedAt":      "this child has not ended",
+	"CreatedAt":    "stamped on insert",
+	"UpdatedAt":    "stamped on insert",
+	"DestUser":     "destination binding is resolved per account later",
+	"DestDomain":   "destination binding is resolved per account later",
+}
+
+// TestBulkChildJobFieldsAreClassified is the exhaustiveness check Go will not
+// give us on a struct literal.
+//
+// Four fields have been silently dropped from bulk children over time — the SSH
+// secret, the preserve plan (GH #633/#634), the SSH port (GH #429) and the
+// host-key pin. Each was invisible: an omitted field is the zero value, and for
+// a column with `gorm:"default:N"` that zero quietly becomes N.
+//
+// newBulkChildJob now copies the draft and clears what must not carry over, so
+// a new field is inherited by default rather than dropped. This test closes the
+// other half: adding a field to MigrationJob fails here until someone states
+// which side it belongs on, with a reason.
+func TestBulkChildJobFieldsAreClassified(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(models.MigrationJob{})
+	var unclassified, both []string
+
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.PkgPath != "" {
+			continue // unexported
+		}
+		_, inh := inheritedFromDraft[f.Name]
+		_, own := perChild[f.Name]
+		switch {
+		case inh && own:
+			both = append(both, f.Name)
+		case !inh && !own:
+			unclassified = append(unclassified, f.Name)
+		}
+	}
+
+	sort.Strings(unclassified)
+	if len(unclassified) > 0 {
+		t.Errorf("MigrationJob field(s) %s are not classified for bulk children.\n"+
+			"Add each to inheritedFromDraft (carried over from the discovery "+
+			"draft) or perChild (owned by the child) in "+
+			"admin_migrations_child_job_test.go, with a reason.\n"+
+			"This is deliberate friction: four fields have already been lost by "+
+			"nobody making this decision.", strings.Join(unclassified, ", "))
+	}
+	for _, name := range both {
+		t.Errorf("%s is in both inheritedFromDraft and perChild — pick one", name)
+	}
+}
+
+// TestNewBulkChildJob_InheritsAndClears exercises the constructor against a
+// fully-populated draft, so a field that stops being copied (or starts being
+// copied when it should not be) shows up here rather than in production.
+func TestNewBulkChildJob_InheritsAndClears(t *testing.T) {
+	t.Parallel()
+
+	plan := `{"preserve":{"credentials":true}}`
+	manifest := `{"accounts":["someone-else"]}`
+	srcPath := "/var/www/wp"
+	lastErr := "previous failure"
+	destUser := "olduser"
+	destDomain := "old.example.com"
+	oldTarget := "OLDTARGET"
+	oldBatch := "OLDBATCH"
+	ended := time.Unix(1, 0).UTC()
+
+	draft := &models.MigrationJob{
+		ID: "DRAFT01", BatchID: &oldBatch,
+		SourceKind: "plesk", SourceHost: "plesk01", SourceUser: "__discovery__",
+		Mode: "refresh", ExpectedHostKey: "SHA256:pinned", SourcePort: 8404,
+		SourcePath: &srcPath, PlanJSON: &plan, ManifestJSON: &manifest,
+		TargetUserID: &oldTarget, State: models.MigrationStateDraft,
+		LastError: &lastErr, EndedAt: &ended,
+		StartedAt: time.Unix(2, 0).UTC(),
+		DestUser:  &destUser, DestDomain: &destDomain,
+	}
+
+	newBatch := "NEWBATCH"
+	target := "TARGET9"
+	got := newBulkChildJob(draft, childJobInputs{
+		ID: "CHILD01", BatchID: &newBatch, Account: "shop.example.com",
+		State: models.MigrationStatePending, TargetID: &target,
+		SourceKind: "plesk", SourceHost: "plesk01", SourcePort: 8404,
+	})
+
+	// Inherited.
+	if got.Mode != "refresh" {
+		t.Errorf("Mode = %q, want the draft's %q", got.Mode, "refresh")
+	}
+	if got.ExpectedHostKey != "SHA256:pinned" {
+		t.Errorf("ExpectedHostKey = %q, want the draft's pin", got.ExpectedHostKey)
+	}
+	if got.SourcePort != 8404 {
+		t.Errorf("SourcePort = %d, want 8404", got.SourcePort)
+	}
+	if got.PlanJSON == nil || *got.PlanJSON != plan {
+		t.Errorf("PlanJSON = %v, want the draft's plan", got.PlanJSON)
+	}
+	if got.SourcePath == nil || *got.SourcePath != srcPath {
+		t.Errorf("SourcePath = %v, want the draft's path", got.SourcePath)
+	}
+
+	// Per-child.
+	if got.ID != "CHILD01" || got.SourceUser != "shop.example.com" {
+		t.Errorf("identity not overridden: id=%q user=%q", got.ID, got.SourceUser)
+	}
+	if got.BatchID == nil || *got.BatchID != newBatch {
+		t.Errorf("BatchID = %v, want the new batch", got.BatchID)
+	}
+	if got.TargetUserID == nil || *got.TargetUserID != target {
+		t.Errorf("TargetUserID = %v, want the per-account target", got.TargetUserID)
+	}
+	if got.State != models.MigrationStatePending {
+		t.Errorf("State = %q, want pending", got.State)
+	}
+	// The dangerous ones: inheriting these would describe the wrong account or
+	// resurrect a finished run.
+	if got.ManifestJSON != nil {
+		t.Errorf("ManifestJSON must not be inherited — it is the draft's own "+
+			"discovery output and describes a different subscription; got %v",
+			*got.ManifestJSON)
+	}
+	if got.LastError != nil {
+		t.Errorf("LastError must not carry over; got %v", *got.LastError)
+	}
+	if got.EndedAt != nil {
+		t.Errorf("EndedAt must not carry over; got %v", *got.EndedAt)
+	}
+	if !got.StartedAt.IsZero() {
+		t.Errorf("StartedAt must be zero on a job that has not started; got %v", got.StartedAt)
+	}
+	if got.DestUser != nil || got.DestDomain != nil {
+		t.Errorf("destination binding must be resolved per account, not inherited: user=%v domain=%v",
+			got.DestUser, got.DestDomain)
+	}
+}
+
+// TestNewBulkChildJob_NilDraft covers the legacy path — no discovery draft to
+// inherit from — where only the supplied inputs should be set.
+func TestNewBulkChildJob_NilDraft(t *testing.T) {
+	t.Parallel()
+
+	batch := "B1"
+	got := newBulkChildJob(nil, childJobInputs{
+		ID: "CHILD01", BatchID: &batch, Account: "shop.example.com",
+		State:      models.MigrationStateDraft,
+		SourceKind: "plesk", SourceHost: "plesk01", SourcePort: 2222,
+	})
+
+	if got.SourcePort != 2222 || got.SourceUser != "shop.example.com" {
+		t.Errorf("supplied inputs not applied: port=%d user=%q", got.SourcePort, got.SourceUser)
+	}
+	if got.PlanJSON != nil || got.ExpectedHostKey != "" || got.Mode != "" {
+		t.Errorf("nothing should be inherited without a draft: plan=%v pin=%q mode=%q",
+			got.PlanJSON, got.ExpectedHostKey, got.Mode)
+	}
+}


### PR DESCRIPTION
> Stacked on #815 (base is `sec-migration-hostkey-pin`). Merge order: #814 → #815 → this.

Structural follow-up to #814 and #815. Those fixed two dropped fields; this removes the reason fields keep getting dropped.

## Four fields, one cause

| lost | consequence |
|---|---|
| the SSH secret | needed an explicit `migration.secrets_clone` |
| the preserve plan | GH #633/#634 — migrated passwords silently reset |
| the SSH port | GH #429 — pull dialled 22 and timed out |
| the host-key pin | every transfer connection ran trust-on-first-use |

Each time the child was built as a struct literal that opted every field in by hand. Writing a field was the exception; forgetting one was the default.

And the failure is invisible. An omitted field is the zero value, and for a column with `gorm:"default:N"` that zero quietly becomes `N`. Nothing errors, nothing logs, and the symptom lands far from the cause — the port bug surfaced as an SSH timeout during import, moments after discovery had succeeded **on that same port**. That's what made #429 read like a wizard-vs-pull mismatch, and it's why I misdiagnosed it twice.

## Invert the default

`newBulkChildJob` copies the discovery draft, then clears what must not carry over:

- `ManifestJSON` — the draft's own discovery output, describing a *different* subscription
- lifecycle timestamps and `LastError` — belong to this child's run
- `DestUser` / `DestDomain` — resolved per account later

So a field added to `MigrationJob` later is **inherited unless someone deliberately clears it**. Dropping becomes the explicit act. That's the direction four bugs argue for.

## The exhaustiveness half

Go can't enforce completeness on a struct literal, so `TestBulkChildJobFieldsAreClassified` reflects over `MigrationJob` and requires every exported field to appear in either `inheritedFromDraft` or `perChild` — each with a stated reason, so the next reader inherits the *why* and not just the list.

Adding a field fails by name until someone classifies it. Verified by injecting one:

```
field(s) NewlyAddedField are not classified for bulk children.
Add each to inheritedFromDraft (carried over from the discovery draft) or
perChild (owned by the child) in admin_migrations_child_job_test.go, with a reason.
This is deliberate friction: four fields have already been lost by nobody
making this decision.
```

The friction is the point.

## Behaviour

No change beyond the two fixes already in the stack, except that `Mode` and `SourcePath` now carry over too — which is what a child of that draft should have had all along. `Mode` in particular has a `default:'import'` column tag, so a `refresh` migration was quietly becoming an `import` for every child; that's the same trap that produced the port bug, sitting one field away.

`TestNewBulkChildJob_InheritsAndClears` drives a fully-populated draft through the constructor, so a field that stops being copied — or starts being copied when it shouldn't — fails here rather than in production.
