### PR TITLE
fix(dns): repair existing SRV rows that carry the priority twice

### DIFF
--- a/panel-api/internal/db/migrations/000241_srv_priority_split.down.sql
+++ b/panel-api/internal/db/migrations/000241_srv_priority_split.down.sql
@@ -1,0 +1,8 @@
+-- Re-inline the priority, restoring the (broken) four-field content. Only
+-- touches rows that currently hold the repaired three-field shape, so this is
+-- likewise idempotent.
+UPDATE dns_records
+SET content  = CONCAT(priority, ' ', content),
+    priority = 0
+WHERE type = 'SRV'
+  AND content REGEXP '^[0-9]+ [0-9]+ [^ ]+$';

--- a/panel-api/internal/db/migrations/000241_srv_priority_split.up.sql
+++ b/panel-api/internal/db/migrations/000241_srv_priority_split.up.sql
@@ -1,0 +1,20 @@
+-- GH #813 follow-up: repair SRV rows written with the priority in BOTH the
+-- content string and the priority column.
+--
+-- PowerDNS's gmysql backend prepends the prio column to the content for SRV,
+-- so "0 1 465 mail.example.com" was assembled into a five-field record that
+-- pdns refuses to serve — every autodiscovery SRV returned an empty answer.
+-- The generator fix stops NEW rows being written that way; it does not touch
+-- rows that already exist, because syncEmailDNS skips any (name, type) pair
+-- already present (hasExistingM6Record). Without this migration every domain
+-- with email already enabled stays broken forever.
+--
+-- The predicate matches exactly the broken shape: four space-separated fields
+-- whose first three are numeric. A repaired row is three fields and no longer
+-- matches, so re-running this is a no-op — which also makes it safe on a host
+-- that already had rows fixed by hand.
+UPDATE dns_records
+SET priority = CAST(SUBSTRING_INDEX(content, ' ', 1) AS UNSIGNED),
+    content  = TRIM(SUBSTRING(content, LOCATE(' ', content) + 1))
+WHERE type = 'SRV'
+  AND content REGEXP '^[0-9]+ [0-9]+ [0-9]+ [^ ]+$';


### PR DESCRIPTION
Follow-up to #813 — and a correction to it.

## I claimed no migration was needed. That was wrong.

#813 said:

> **No migration needed:** the agent's pdns client `DELETE`s and reinserts the whole zone on every push, so hosts converge on the next reconcile.

Deploying to a real host is what caught it. The pdns client *does* rewrite pdns from `dns_records` — but `dns_records` still held the old four-field content, so there was nothing better to push. `syncEmailDNS` only creates records it doesn't already find:

```go
if hasExistingM6Record(existing, rec.Name, rec.Type) {
    continue
}
```

So a domain with email **already enabled** keeps its broken rows forever. The generator fix only ever helped domains enabled after it shipped — which is close to the opposite of what the PR promised.

After the update landed on testserver, `check-zone` still showed 71 errors across the fleet, and the panel DB still read:

```
_autodiscover._tcp    0 0 443 mail.mx.jabali-panel.com
```

## The migration

The predicate matches exactly the broken shape — four space-separated fields whose first three are numeric:

```sql
WHERE type = 'SRV'
  AND content REGEXP '^[0-9]+ [0-9]+ [0-9]+ [^ ]+$'
```

A repaired row is three fields and no longer matches, so re-running is a no-op. That also makes it safe on a host where rows were already fixed by hand — which mattered here, since I'd repaired jabali.site manually while diagnosing.

On the affected host it selected **14 rows and correctly left the 9 already-repaired ones alone**, and a second run reported `ROW_COUNT()=0`.

## Verified end to end

Every panel-managed zone went to zero SRV errors, with the reconciler pushing the repaired rows into pdns unattended:

| zone | before | after |
|---|---|---|
| `mx.jabali-panel.com` | 5 | **0** |
| `123123.com` | 9 | **0** |
| `jabali.site` | 0 | 0 |
| others | 0 | 0 |

## About the errors that remain on that host

`check-zone` still reports errors for `forum.mx.jabali-panel.com`, `ic2e2e.test`, `icubea/b.test`, `r633v.com`, `r634demo.com`. Those zones exist in pdns with **no `dns_zones` row** — 21 zones in pdns against 6 in the panel. They're orphans left behind by deleted test domains, so the panel neither manages nor should rewrite them, and this migration deliberately doesn't reach them.

Worth noting separately as a cleanup gap: deleting a domain evidently doesn't always reap its pdns zone. That's a different bug and I haven't chased it.
