### PR TITLE
fix(update): retry the vite build on a heap abort, not just an OOM-kill

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1127,16 +1127,53 @@ test -x node_modules/.bin/tsc || {
 			// (exit 137) mid-bundle. Capping at 50% of MemTotal keeps
 			// node within budget; transient garbage pressure rises but
 			// the build actually completes.
-			viteBuild := func() error {
+			// heapPct is the share of MemTotal V8 may use. 50 is the
+			// steady-state cap; the retry raises it — see below.
+			viteBuild := func(heapPct int) error {
 				viteEnv := ""
 				if demoBuild {
 					viteEnv = "VITE_DEMO=1 "
 				}
-				bashCmd := viteEnv + "NODE_OPTIONS=\"--max-old-space-size=$(awk '/MemTotal/{print int($2*0.5/1024)}' /proc/meminfo)\" npm run build"
+				bashCmd := fmt.Sprintf(
+					"%sNODE_OPTIONS=\"--max-old-space-size=$(awk '/MemTotal/{print int($2*%.2f/1024)}' /proc/meminfo)\" npm run build",
+					viteEnv, float64(heapPct)/100)
 				return asUser(repoDir+"/panel-ui", "bash", "-c", bashCmd)
 			}
-			buildErr := viteBuild()
+			buildErr := viteBuild(viteHeapPctDefault)
 			if buildErr == nil {
+				writeArtifactSHA("vite", want)
+				return nil
+			}
+			// Two different out-of-memory failures, and they need
+			// opposite remedies.
+			//
+			//   exit 137 — the KERNEL killed node. There was not enough
+			//              real memory; the answer is more swap.
+			//   exit 134 — V8 aborted ITSELF on reaching
+			//              --max-old-space-size ("JavaScript heap out of
+			//              memory"). Memory was available; the ceiling we
+			//              imposed was too low. More swap alone changes
+			//              nothing — the answer is a higher ceiling.
+			//
+			// Only 137 used to be handled, which made this worse over
+			// time: capping the heap to avoid the OOM-killer is exactly
+			// what converts a 137 into a 134, so the original fix turned
+			// the failure into a shape its own retry did not match. Seen
+			// on a 2 GB host where the cap lands at ~986 MB: the frontend
+			// bundle has outgrown that, and `jabali update` aborted with
+			// no retry at all.
+			if isHeapAbort(buildErr) {
+				// Ensure swap first so the larger heap has somewhere to
+				// spill; on a host that already has swap this is a clean
+				// no-op. Failure is not fatal — the retry may still fit.
+				if swapErr := ensureBuildSwap(); swapErr != nil {
+					fmt.Printf("  (vite build hit its heap ceiling; swap helper failed, retrying anyway: %v)\n", swapErr)
+				}
+				fmt.Printf("  (vite build hit its %d%% heap ceiling; retrying once at %d%% of RAM)\n",
+					viteHeapPctDefault, viteHeapPctRetry)
+				if err2 := viteBuild(viteHeapPctRetry); err2 != nil {
+					return err2
+				}
 				writeArtifactSHA("vite", want)
 				return nil
 			}
@@ -1144,13 +1181,13 @@ test -x node_modules/.bin/tsc || {
 			// died with exit 137 (SIGKILL — almost always OOM-killer
 			// on small VMs). Idempotent: skips if any swap already
 			// active OR the swap file already exists.
-			if strings.Contains(buildErr.Error(), "exit status 137") || strings.Contains(buildErr.Error(), "killed") {
+			if isOOMKilled(buildErr) {
 				if swapErr := ensureBuildSwap(); swapErr != nil {
 					fmt.Printf("  (vite build OOM-killed; swap helper failed: %v)\n", swapErr)
 					return buildErr
 				}
 				fmt.Println("  (vite build OOM-killed; added 2G swap, retrying once)")
-				if err2 := viteBuild(); err2 != nil {
+				if err2 := viteBuild(viteHeapPctDefault); err2 != nil {
 					return err2
 				}
 				writeArtifactSHA("vite", want)

--- a/panel-api/cmd/server/vite_oom.go
+++ b/panel-api/cmd/server/vite_oom.go
@@ -1,0 +1,50 @@
+package main
+
+import "strings"
+
+// Heap ceilings for the vite build, as a percentage of MemTotal.
+//
+// The default deliberately stays low: V8 sizes its heap from /proc/meminfo and
+// will happily grow past what a small VM can back, at which point the kernel
+// OOM-killer takes the process (exit 137) mid-bundle. Capping at half of RAM
+// forces harder GC and keeps node inside a budget the host can honour.
+//
+// The retry ceiling is what the default cannot be. Raising the steady-state cap
+// to 90% would reintroduce the very OOM-kill the cap exists to prevent on a
+// swapless host; using it only after a heap abort — and only once swap has been
+// ensured — keeps the safe path safe and gives the build room exactly when the
+// evidence says the ceiling, not the machine, was the limit.
+const (
+	viteHeapPctDefault = 50
+	viteHeapPctRetry   = 90
+)
+
+// isHeapAbort reports whether the build died because V8 hit
+// --max-old-space-size and aborted itself.
+//
+// Node raises SIGABRT for this, which surfaces as exit status 134, after
+// printing "FATAL ERROR: ... JavaScript heap out of memory". It is a different
+// failure from being OOM-killed and wants the opposite remedy: the machine had
+// memory, the ceiling we set was too low.
+//
+// Matching the message as well as the exit code because a build wrapper that
+// re-raises the failure can lose the signal number while keeping stderr.
+func isHeapAbort(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "exit status 134") ||
+		strings.Contains(msg, "javascript heap out of memory") ||
+		strings.Contains(msg, "heap out of memory")
+}
+
+// isOOMKilled reports whether the kernel killed the build — genuinely not
+// enough memory, which swap can fix.
+func isOOMKilled(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "exit status 137") || strings.Contains(msg, "killed")
+}

--- a/panel-api/cmd/server/vite_oom_test.go
+++ b/panel-api/cmd/server/vite_oom_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestHeapAbortVsOOMKilled pins the distinction the retry logic turns on.
+//
+// These are two different failures with opposite remedies, and conflating them
+// is what left `jabali update` unable to finish on a 2 GB host:
+//
+//	exit 137 — the KERNEL killed node; not enough real memory; add swap
+//	exit 134 — V8 aborted itself at --max-old-space-size; memory was there,
+//	           our ceiling was too low; raise the ceiling
+//
+// Only 137 was handled, and capping the heap to dodge the OOM-killer is
+// precisely what turns a 137 into a 134 — so the original mitigation converted
+// the failure into a shape its own retry did not match, and the build aborted
+// with no retry at all.
+func TestHeapAbortVsOOMKilled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		err        error
+		wantAbort  bool
+		wantKilled bool
+	}{
+		{
+			name:      "V8 self-abort exit code",
+			err:       errors.New("build frontend: ... npm run build: exit status 134"),
+			wantAbort: true,
+		},
+		{
+			name:      "V8 message without a usable exit code",
+			err:       errors.New("FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"),
+			wantAbort: true,
+		},
+		{
+			name:       "kernel OOM-kill exit code",
+			err:        errors.New("build frontend: ... npm run build: exit status 137"),
+			wantKilled: true,
+		},
+		{
+			name:       "kernel OOM-kill reported as signal text",
+			err:        errors.New("npm run build: signal: killed"),
+			wantKilled: true,
+		},
+		{
+			name: "an unrelated build failure is neither",
+			err:  errors.New("npm run build: exit status 1"),
+		},
+		{
+			name: "a type error is neither",
+			err:  errors.New("src/App.tsx:12:3 - error TS2322: Type 'string' is not assignable"),
+		},
+		{name: "nil is neither"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHeapAbort(tc.err); got != tc.wantAbort {
+				t.Errorf("isHeapAbort(%v) = %v, want %v", tc.err, got, tc.wantAbort)
+			}
+			if got := isOOMKilled(tc.err); got != tc.wantKilled {
+				t.Errorf("isOOMKilled(%v) = %v, want %v", tc.err, got, tc.wantKilled)
+			}
+		})
+	}
+}
+
+// TestHeapAbortMatchesRealExitError guards against the classifier working only
+// on hand-written strings. exec.ExitError formats its own message, and that is
+// what the build step actually returns.
+func TestHeapAbortMatchesRealExitError(t *testing.T) {
+	t.Parallel()
+
+	// 134 is SIGABRT (128+6) — what node exits with on a heap abort.
+	cmd := exec.Command("bash", "-c", "exit 134")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected a non-nil error from `exit 134`")
+	}
+	if !isHeapAbort(err) {
+		t.Errorf("isHeapAbort did not match a real exec error %q — the build step "+
+			"wraps exactly this, so a mismatch means no retry happens", err)
+	}
+	if isOOMKilled(err) {
+		t.Errorf("a 134 must not be treated as an OOM-kill: adding swap does not " +
+			"raise a heap ceiling, so the retry would fail the same way")
+	}
+
+	wrapped := fmt.Errorf("build frontend: %w", err)
+	if !isHeapAbort(wrapped) {
+		t.Error("classification must survive the error wrapping the build step applies")
+	}
+}
+
+// TestViteHeapPercentages pins the two ceilings and, more importantly, why they
+// differ — a future reader raising the default to "fix" a slow build would
+// reintroduce the OOM-kill the cap exists to prevent.
+func TestViteHeapPercentages(t *testing.T) {
+	t.Parallel()
+
+	if viteHeapPctDefault >= viteHeapPctRetry {
+		t.Errorf("the retry ceiling (%d%%) must exceed the default (%d%%) — the "+
+			"whole point of the retry is more headroom",
+			viteHeapPctRetry, viteHeapPctDefault)
+	}
+	if viteHeapPctDefault > 60 {
+		t.Errorf("default heap ceiling %d%% is too generous: V8 sizing itself "+
+			"from MemTotal is what gets the build OOM-killed on small VMs",
+			viteHeapPctDefault)
+	}
+	if viteHeapPctRetry > 95 {
+		t.Errorf("retry ceiling %d%% leaves nothing for the rest of the host",
+			viteHeapPctRetry)
+	}
+}
+
+// TestViteBuildCommandRendersBothCeilings checks the awk expression the build
+// actually runs, since the percentage reaches node through a shell string.
+func TestViteBuildCommandRendersBothCeilings(t *testing.T) {
+	t.Parallel()
+
+	render := func(pct int) string {
+		return fmt.Sprintf(
+			"NODE_OPTIONS=\"--max-old-space-size=$(awk '/MemTotal/{print int($2*%.2f/1024)}' /proc/meminfo)\" npm run build",
+			float64(pct)/100)
+	}
+
+	def := render(viteHeapPctDefault)
+	retry := render(viteHeapPctRetry)
+
+	if !strings.Contains(def, "*0.50/1024") {
+		t.Errorf("default ceiling did not render as a 0.50 multiplier: %s", def)
+	}
+	if !strings.Contains(retry, "*0.90/1024") {
+		t.Errorf("retry ceiling did not render as a 0.90 multiplier: %s", retry)
+	}
+	if def == retry {
+		t.Error("both ceilings rendered identically — the retry would repeat the failure")
+	}
+}


### PR DESCRIPTION
`jabali update` cannot finish on a 2 GB host. Found deploying today's merge batch to a fresh 2 GB Debian 13 box.

```
Error: build frontend: ... npm run build: exit status 134
```

No retry, no diagnostic, update aborts.

## Two OOMs, opposite remedies

The retry only ever matched one of them:

```go
if strings.Contains(buildErr.Error(), "exit status 137") ||
   strings.Contains(buildErr.Error(), "killed") {
```

| | what happened | remedy |
|---|---|---|
| **137** | the *kernel* killed node — not enough real memory | add swap |
| **134** | V8 aborted *itself* at `--max-old-space-size` | raise the ceiling |

Swap does nothing for a 134. The machine had memory; the ceiling we imposed was too low.

## The mitigation disabled its own fallback

Capping the heap is what *produces* the 134. PR #69 added the cap to stop the OOM-killer, and it works — it converts a 137 into a V8 self-abort. But that's a shape the retry it shipped alongside doesn't match, so the fallback silently stopped applying, and the failure only surfaced once the bundle outgrew the cap.

On a 2 GB host the cap lands at ~**986 MB**, which the frontend no longer fits in.

Swap wouldn't have helped even if 134 *had* matched: the affected host already had 3.4 GB active, so `ensureBuildSwap` correctly bails.

## Fix

On a heap abort: ensure swap (no-op where it exists, non-fatal if it fails — the retry may fit regardless) and retry once at **90%** of MemTotal instead of 50%.

The default stays at 50 deliberately. Raising it outright would reintroduce the OOM-kill the cap exists to prevent on a swapless host — the higher ceiling is used only *after* the evidence says the ceiling, not the machine, was the limit. That reasoning is in `vite_oom.go` and pinned by a test, because "just raise the default" is the obvious-looking change that would undo it.

## Verified on the affected host — and the number matters

- at the 50% cap (~986 MB): aborts within **seconds**
- at a raised cap: **completes, in `✓ built in 256m 13s`**

That is 4 hours 16 minutes, and I want to be blunt about what it does and does not buy. This PR turns an update that **cannot finish** into one that finishes — it does not make building on a 2 GB host reasonable. Nobody should wait four hours for `jabali update`.

So treat this as the last-resort path, not the fix for small hosts. The actual fix is #820: resolve the release tarball without the rate-limited API, so a 2 GB box downloads ~29 MB of prebuilt binaries and never runs vite at all. #818 exists for the genuine fallback cases — a freshly-pushed commit with no release yet, `--from-source`, a locally-modified repo — where a slow build still beats a failed one.

I originally wrote "runs to completion (slowly — it swaps, but it finishes)" here before the build had finished. "Slowly" was doing far too much work for 256 minutes; the measurement deserves to be stated outright.

## Tests

Both classifiers, against a real `exec.ExitError` as well as message text — a wrapper can lose the signal number while keeping stderr, so matching only the exit code would be fragile. Plus an explicit assertion that a 134 is **never** treated as an OOM-kill, since adding swap would make the retry fail in exactly the same way.
