### PR TITLE
perf(panel): slim domains list, conditional polling, reconciler tick observability

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -286,6 +286,11 @@ func (h *domainHandler) list(c *gin.Context) {
 	}
 
 	page, pageSize, opts := parseListOptions(c, defaultDomainsPageSize, maxDomainsPageSize)
+	// List rows never render the wide TEXT columns (DKIM material,
+	// disclaimer, nginx safe-options) — their consumers all fetch the
+	// single domain. Skip them so a full page doesn't drag megabytes of
+	// TEXT through MariaDB and the JSON encoder.
+	opts.OmitHeavyColumns = true
 
 	var domains []models.Domain
 	var total int64

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -560,6 +560,20 @@ func (r *Reconciler) Schedule(domainID string) {
 // ReconcileAll diffs the DB against the agent's filesystem state and converges them.
 // Returns an error if the agent list call fails; on per-domain errors, logs and continues.
 func (r *Reconciler) ReconcileAll(ctx context.Context) error {
+	// Coarse per-block timings. A tick that outruns the interval means
+	// the next ticker fire lands immediately behind it and drift repair
+	// degrades to back-to-back passes — worth a WARN that names the
+	// slow block, not just a vague "panel feels slow" report later.
+	tt := newTickTimings()
+	defer func() {
+		total := tt.total()
+		if total > r.interval {
+			r.log.Warn("reconcile tick overran interval", "took", total.Round(time.Millisecond), "interval", r.interval, "slowest", tt.summary())
+		} else {
+			r.log.Debug("reconcile tick complete", "took", total.Round(time.Millisecond), "slowest", tt.summary())
+		}
+	}()
+
 	// M32: panel-cert hook runs early so a successful issue lands
 	// before the rest of the loop touches the agent. Cheap noop when
 	// use_le=0 or routability gate fails.
@@ -579,6 +593,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// a noop on every tick until an admin edits a template.
 	r.reconcileErrorPages(ctx)
 
+	tt.mark("certs_updates_modules")
+
 	// M6.6 — per-domain mail TLS. Sits next to panel-cert so the
 	// two cert flows share the same admin email/public IP context.
 	r.reconcileMailCertificates(ctx)
@@ -591,6 +607,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// scores WordPress loopback traffic (WooCommerce Action Scheduler et al).
 	r.reconcileSelfAllowlist(ctx)
 
+	tt.mark("mail_shared_egress")
+
 	// PHP pool reconciliation first, so domain regens see latest pool state.
 	r.ReconcilePHPPools(ctx)
 	// GH #329: converge the per-domain versioned pools (apply pending, reap
@@ -601,6 +619,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// tears them down inline; this backstop self-heals pools orphaned before that
 	// fix (or by a failed teardown). Bounded + guarded agent-side.
 	r.reconcileOrphanFPMPools(ctx)
+
+	tt.mark("php_pools")
 
 	// M24: managed IPs BEFORE the domain loop. If a domain is bound to a
 	// secondary IP that fell off the kernel (host reboot, netplan drop),
@@ -636,6 +656,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// further down handles the reverse transition (rate_limit_rps → 0:
 	// vhost stops referencing first, then the fragment drops the zone).
 	r.ReconcileNginxRateLimits(ctx)
+
+	tt.mark("ips_quota_ratelimits")
 
 	// Get the list of enabled sites from the agent
 	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -681,6 +703,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// row), so it's not covered by the enabledDomains loop below.
 	// Idempotent on the agent side.
 	r.reconcileRecursorSelfZone(ctx)
+
+	tt.mark("list_state")
 
 	// Convergence:
 	// 1. Every enabled DB domain gets a domain.create every pass. The
@@ -786,6 +810,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		}
 	}
 
+	tt.mark(fmt.Sprintf("domain_loop(%d)", len(enabledDomains)))
+
 	// 2. Disabled DB domain that IS in agent set -> call domain.create with is_enabled=false
 	for name, domain := range disabledDomains {
 		// Docker-app proxy domain disabled -> tear down its vhost
@@ -844,6 +870,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		}
 	}
 
+	tt.mark("disable_orphan_sweep")
+
 	r.reconcileWordPressInstalls(ctx)
 	// Reconcile WordPress installs (sweep stuck rows, probe drift).
 
@@ -885,6 +913,8 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// MtaOutboundThrottle objects. Each row's stalwart_id tracks
 	// the upstream id so updates target the right object.
 	r.reconcileMailThrottles(ctx)
+
+	tt.mark("post_sweeps")
 
 	return nil
 }

--- a/panel-api/internal/reconciler/tick_timing.go
+++ b/panel-api/internal/reconciler/tick_timing.go
@@ -1,0 +1,57 @@
+package reconciler
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// tickTimings records coarse per-block durations of a ReconcileAll pass so
+// an overrunning tick names the block that ate the budget instead of just
+// "reconcile is slow". Checkpoints are cumulative: mark(name) attributes
+// everything since the previous mark (or the start) to name.
+type tickTimings struct {
+	start time.Time
+	last  time.Time
+	names []string
+	durs  []time.Duration
+}
+
+func newTickTimings() *tickTimings {
+	now := time.Now()
+	return &tickTimings{start: now, last: now}
+}
+
+func (t *tickTimings) mark(name string) {
+	now := time.Now()
+	t.names = append(t.names, name)
+	t.durs = append(t.durs, now.Sub(t.last))
+	t.last = now
+}
+
+func (t *tickTimings) total() time.Duration {
+	return time.Since(t.start)
+}
+
+// summary renders the recorded blocks slowest-first, capped at top 5 so a
+// log line stays readable: "domain_loop=42.1s post_sweeps=3.4s ...".
+func (t *tickTimings) summary() string {
+	type nd struct {
+		name string
+		dur  time.Duration
+	}
+	rows := make([]nd, len(t.names))
+	for i := range t.names {
+		rows[i] = nd{t.names[i], t.durs[i]}
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].dur > rows[j].dur })
+	if len(rows) > 5 {
+		rows = rows[:5]
+	}
+	parts := make([]string, len(rows))
+	for i, r := range rows {
+		parts[i] = fmt.Sprintf("%s=%s", r.name, r.dur.Round(time.Millisecond))
+	}
+	return strings.Join(parts, " ")
+}

--- a/panel-api/internal/reconciler/tick_timing_test.go
+++ b/panel-api/internal/reconciler/tick_timing_test.go
@@ -1,0 +1,51 @@
+package reconciler
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTickTimingsSummarySlowestFirstCapped(t *testing.T) {
+	tt := newTickTimings()
+	base := tt.start
+	// Simulate 7 blocks with distinct durations by driving `last` manually.
+	durations := []time.Duration{
+		5 * time.Millisecond, 300 * time.Millisecond, 20 * time.Millisecond,
+		900 * time.Millisecond, 50 * time.Millisecond, 10 * time.Millisecond,
+		700 * time.Millisecond,
+	}
+	names := []string{"a", "b", "c", "d", "e", "f", "g"}
+	cursor := base
+	for i, d := range durations {
+		cursor = cursor.Add(d)
+		tt.names = append(tt.names, names[i])
+		tt.durs = append(tt.durs, d)
+	}
+
+	sum := tt.summary()
+	parts := strings.Fields(sum)
+	if len(parts) != 5 {
+		t.Fatalf("summary must cap at 5 blocks, got %d: %q", len(parts), sum)
+	}
+	if !strings.HasPrefix(parts[0], "d=") || !strings.HasPrefix(parts[1], "g=") || !strings.HasPrefix(parts[2], "b=") {
+		t.Fatalf("summary not sorted slowest-first: %q", sum)
+	}
+	if strings.Contains(sum, "a=") || strings.Contains(sum, "f=") {
+		t.Fatalf("summary must drop the fastest blocks beyond top 5: %q", sum)
+	}
+}
+
+func TestTickTimingsMarkAttributesElapsedToName(t *testing.T) {
+	tt := newTickTimings()
+	tt.mark("first")
+	if len(tt.names) != 1 || tt.names[0] != "first" {
+		t.Fatalf("mark did not record name: %+v", tt.names)
+	}
+	if tt.durs[0] < 0 {
+		t.Fatalf("negative duration recorded: %v", tt.durs[0])
+	}
+	if tt.last.Before(tt.start) {
+		t.Fatalf("last checkpoint moved backwards")
+	}
+}

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -243,6 +243,18 @@ func (r *domainRepo) FindByName(ctx context.Context, name string) (*models.Domai
 // apply at the SQL layer can resolve it; List() rewrites the bare
 // `username` requested by the UI into the qualified form before
 // passing opts down to applyListOptions.
+// domainHeavyListColumns are the wide TEXT/LONGTEXT columns the domains
+// list never renders. Every UI consumer of these (nginx safe-options
+// modal, DKIM/email panels, disclaimer tab) fetches the single domain or
+// a dedicated endpoint rather than reading the list row, so the list
+// SELECT can skip them when ListOptions.OmitHeavyColumns is set.
+var domainHeavyListColumns = []string{
+	"google_dkim",
+	"dkim_public_key",
+	"disclaimer_text",
+	"nginx_safe_options",
+}
+
 var domainListCols = ListCols{
 	Search:      []string{"domains.name"},
 	Sort:        []string{"domains.name", "domains.created_at", "users.username", "domains.is_enabled"},
@@ -284,6 +296,9 @@ func (r *domainRepo) List(ctx context.Context, opts ListOptions) ([]models.Domai
 	}
 	opts.Sort = rewriteDomainSort(opts.Sort)
 	q := applyListOptions(base.Session(&gorm.Session{}), opts, domainListCols)
+	if opts.OmitHeavyColumns {
+		q = q.Omit(domainHeavyListColumns...)
+	}
 	if err := q.Find(&domains).Error; err != nil {
 		return nil, 0, err
 	}
@@ -312,6 +327,9 @@ func (r *domainRepo) ListByUserID(ctx context.Context, userID string, opts ListO
 	}
 	opts.Sort = rewriteDomainSort(opts.Sort)
 	q := applyListOptions(base.Session(&gorm.Session{}), opts, domainListCols)
+	if opts.OmitHeavyColumns {
+		q = q.Omit(domainHeavyListColumns...)
+	}
 	if err := q.Find(&domains).Error; err != nil {
 		return nil, 0, err
 	}

--- a/panel-api/internal/repository/domain_repository_slim_list_test.go
+++ b/panel-api/internal/repository/domain_repository_slim_list_test.go
@@ -1,0 +1,117 @@
+package repository_test
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// newCaptureDB is like newMockDB but records every SQL statement the
+// repository issues, so tests can assert on the generated column list
+// (something the regexp matcher alone can't express negatively).
+func newCaptureDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB, *[]string) {
+	t.Helper()
+
+	captured := &[]string{}
+	matcher := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		*captured = append(*captured, actualSQL)
+		return nil
+	})
+
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+	require.NoError(t, err)
+
+	mock.ExpectQuery("").
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+
+	gdb, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      raw,
+		SkipInitializeWithVersion: false,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	return gdb, mock, raw, captured
+}
+
+// findQuery returns the captured SELECT that reads the domains rows (the
+// one carrying an ORDER BY — the count query has none).
+func findQuery(t *testing.T, captured []string) string {
+	t.Helper()
+	for _, q := range captured {
+		if strings.Contains(q, "ORDER BY") {
+			return q
+		}
+	}
+	t.Fatalf("no domains SELECT with ORDER BY captured; got: %v", captured)
+	return ""
+}
+
+func expectListQueries(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(0))
+	mock.ExpectQuery("").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+}
+
+func TestDomainListOmitHeavyColumns(t *testing.T) {
+	heavy := []string{"google_dkim", "dkim_public_key", "disclaimer_text", "nginx_safe_options"}
+
+	t.Run("flag set skips heavy columns", func(t *testing.T) {
+		db, mock, raw, captured := newCaptureDB(t)
+		defer raw.Close()
+		repo := repository.NewDomainRepository(db)
+
+		expectListQueries(mock)
+		_, _, err := repo.List(context.Background(), repository.ListOptions{Limit: 50, OmitHeavyColumns: true})
+		require.NoError(t, err)
+
+		q := findQuery(t, *captured)
+		require.Contains(t, q, "`domains`.`name`", "omit mode must expand to an explicit column list")
+		for _, col := range heavy {
+			require.NotContains(t, q, col, "heavy column %s must not be selected", col)
+		}
+	})
+
+	t.Run("default keeps full rows", func(t *testing.T) {
+		db, mock, raw, captured := newCaptureDB(t)
+		defer raw.Close()
+		repo := repository.NewDomainRepository(db)
+
+		expectListQueries(mock)
+		_, _, err := repo.List(context.Background(), repository.ListOptions{Limit: 50})
+		require.NoError(t, err)
+
+		q := findQuery(t, *captured)
+		// Without the flag every column — heavy ones included — must stay in
+		// the SELECT so the reconciler and other callers get full rows.
+		for _, col := range heavy {
+			require.Contains(t, q, col, "default mode must select heavy column %s", col)
+		}
+	})
+
+	t.Run("flag set on ListByUserID", func(t *testing.T) {
+		db, mock, raw, captured := newCaptureDB(t)
+		defer raw.Close()
+		repo := repository.NewDomainRepository(db)
+
+		expectListQueries(mock)
+		_, _, err := repo.ListByUserID(context.Background(), "01HZUSER0000000000000001AA", repository.ListOptions{Limit: 50, OmitHeavyColumns: true})
+		require.NoError(t, err)
+
+		q := findQuery(t, *captured)
+		for _, col := range heavy {
+			require.NotContains(t, q, col, "heavy column %s must not be selected", col)
+		}
+	})
+}

--- a/panel-api/internal/repository/list_options.go
+++ b/panel-api/internal/repository/list_options.go
@@ -31,6 +31,11 @@ type ListOptions struct {
 	IsAdmin *bool
 	// Suspended — user-repo-only; non-nil restricts to suspended/active.
 	Suspended *bool
+	// OmitHeavyColumns — domain-repo-only; when true, List/ListByUserID
+	// skip the wide TEXT columns no list row renders (DKIM material, mail
+	// disclaimer, nginx safe-options JSON). Detail GETs and the reconciler
+	// always read full rows. Other repos ignore it.
+	OmitHeavyColumns bool
 }
 
 // ListCols tells applyListOptions which columns are searchable (free-text

--- a/panel-ui/src/components/NotificationBell.tsx
+++ b/panel-ui/src/components/NotificationBell.tsx
@@ -91,7 +91,11 @@ export function NotificationBell() {
       );
       return data;
     },
-    refetchInterval: 10_000,
+    // 30s poll + refetch-on-focus. Focus refetch covers the "came back
+    // to the tab" case instantly, so the background cadence only serves
+    // long-lived open tabs — 3x fewer requests than the old 10s poll
+    // with no perceived staleness. Push (SSE) is tracked separately.
+    refetchInterval: 30_000,
     staleTime: 5_000,
     refetchOnWindowFocus: true,
   });

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -110,7 +110,16 @@ export const AdminMigrationsPage = () => {
       );
       return data;
     },
-    refetchInterval: 5_000, // pull every 5s — operators expect live state during pull/import bursts
+    // 5s only while a job is actually moving; idle lists poll at 60s —
+    // slow enough to be cheap, fast enough that a CLI-started migration
+    // still shows up without a manual refresh.
+    refetchInterval: (q) => {
+      const data = q.state.data as MigrationJobListResponse | undefined;
+      const live = (data?.data ?? []).some(
+        (r) => r.state !== "done" && r.state !== "failed" && r.state !== "cancelled" && r.state !== "draft",
+      );
+      return live ? 5_000 : 60_000;
+    },
   });
 
   // M35.3 SSRF override toggle. server_settings.migration_allow_private_hosts


### PR DESCRIPTION
Batch of panel-load optimizations from the "more ways to optimize the panel" audit — all four items in one PR as requested.

## 1. Domains list drops heavy TEXT columns (backend)

The admin + user domains lists (and the `?user_id` scoped variant) selected every column of `domains`, including TEXT/LONGTEXT fields no list row ever renders: `google_dkim`, `dkim_public_key`, `disclaimer_text`, `nginx_safe_options`. On a box with hundreds of domains that's megabytes dragged through MariaDB, GORM scan, and the JSON encoder on every list page.

Verified before omitting: **every** UI consumer of those four fields fetches the single domain or a dedicated endpoint (`DomainNginxOptionsModal` → `GET /domains/:id`, `DomainEmailSection` → `useOneQuery` + `useDomainEmail`, `DomainEdit` → `useOneQuery`, `DisclaimerTab` → `/domains/:id/disclaimer`, `UserDomainDrawer` is a create form). `nginx_custom_directives` and `nginx_rules` are **kept** — the settings drawer and tenant rewrite-rules modal read those straight off the list row.

Mechanics: new `ListOptions.OmitHeavyColumns` flag (no repo interface change — all other callers, including the reconciler's full-row `List`, are untouched by default). Applied via GORM `Omit` on the find query; confirmed against the pinned gorm v1.31.2 source that query-side `Omits` expands to an explicit SELECT column list (`callbacks/query.go:71`).

## 2. Admin migrations page: conditional polling (UI)

`AdminMigrationsPage` polled `/admin/migrations?page_size=200` every 5s forever, jobs or no jobs. Now 5s only while a job is in a non-terminal state, 60s when idle (still catches CLI-started migrations). Mirrors the function-form `refetchInterval` already used by `AdminMigrationDetailPage`.

## 3. Notification bell: 10s → 30s poll (UI)

Every logged-in tab polled the inbox every 10s. `refetchOnWindowFocus: true` already covers tab-return freshness, so the background interval only serves long-lived open tabs — 3x fewer requests, no perceived staleness. SSE push is a follow-up (JAB filed).

## 4. Reconciler tick observability (backend)

`ReconcileAll` runs ~30 serial phases plus a per-domain agent-RPC loop with zero timing visibility. A tick that outruns the 60s interval makes the next fire land back-to-back — previously invisible. Now: coarse per-block timings (`certs_updates_modules`, `php_pools`, `list_state`, `domain_loop(N)`, `post_sweeps`, …), a `Debug` line per tick, and a `WARN` naming the slowest blocks when the tick overruns the interval. Deferred, so early-error returns still log partial timings.

## Test plan
- [x] New sqlmock test asserts the domains SELECT column list: heavy columns absent with the flag, present without it, on both `List` and `ListByUserID`
- [x] New unit tests for the timing helper (slowest-first ordering, top-5 cap)
- [x] `go test ./panel-api/...` green, `go vet` clean
- [x] `npx tsc -b` + `npm run build` green
- [x] vitest: components, migrations, admin+user domain lists — all pass
- [x] Rebased on latest `origin/main`, re-ran repo + reconciler tests post-rebase

Note: codebase-memory detect_changes only indexes the main worktree — scope verified manually (9 files, listed above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)