### PR TITLE
fix(update): resolve releases without api.github.com, which was rate-limited

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1009,7 +1009,7 @@ fi
 				return nil
 			}
 			ctx := cmd.Context()
-			installed, sha, err := installFromRelease(ctx, func(format string, args ...any) {
+			installed, sha, err := installFromRelease(ctx, repoDir, func(format string, args ...any) {
 				fmt.Printf("  "+format+"\n", args...)
 			})
 			if err != nil {

--- a/panel-api/cmd/server/update_release.go
+++ b/panel-api/cmd/server/update_release.go
@@ -86,45 +86,69 @@ type releaseResponse struct {
 // mismatch, file install failure, migration error) — those should NOT
 // transparently fall back because they indicate corruption or a
 // systemic problem.
-func installFromRelease(ctx context.Context, log func(string, ...any)) (installed bool, sha string, err error) {
+func installFromRelease(ctx context.Context, repoDir string, log func(string, ...any)) (installed bool, sha string, err error) {
 	base := os.Getenv("JABALI_RELEASE_API_BASE")
 	if base == "" {
 		base = defaultReleaseAPIBase
 	}
-
-	// 1. Discover the current main SHA via the Gitea API. Cheaper +
-	//    more reliable than `git ls-remote` on a host that may have
-	//    DNS or auth problems with the SSH/HTTPS git endpoint.
-	fullSHA, err := fetchLatestMainSHA(ctx, base)
-	if err != nil {
-		log("release: lookup of main HEAD failed: %v", err)
-		return false, "", nil
-	}
-	log("release: latest main = %s", fullSHA)
-
-	// Pre-skip check is done by the caller (compares against
-	// lastBuiltSHA) — but the caller passed control here, so go.
-
-	// 2. Look up the release for this commit by SCANNING releases
-	//    for a target_commitish match. Earlier code did a direct
-	//    GET /releases/tags/release-<short_sha> using a truncated
-	//    7-char short SHA, but git's `--short` flag returns
-	//    whatever length is unique in the repo (8 chars here) and
-	//    drifts as the repo grows. Scanning by commit SHA is the
-	//    only stable lookup.
-	rel, shortSHA, err := findReleaseForCommit(ctx, base, fullSHA)
-	if err != nil {
-		log("release: no release tarball published yet for %s (%v) — falling back", fullSHA[:7], err)
-		return false, "", nil
+	webBase := os.Getenv("JABALI_RELEASE_WEB_BASE")
+	if webBase == "" {
+		webBase = defaultReleaseWebBase
 	}
 
-	tarName := fmt.Sprintf("jabali-release-%s.tar.gz", shortSHA)
-	sumName := tarName + ".sha256"
-	tarURL := pickAssetURL(rel, tarName)
-	sumURL := pickAssetURL(rel, sumName)
-	if tarURL == "" || sumURL == "" {
-		log("release: release %s is missing %s or %s asset — falling back", rel.TagName, tarName, sumName)
-		return false, "", nil
+	// 1. Discover the commit we are updating to.
+	//
+	//    Read it from the local checkout, not GET /branches/main. This
+	//    step runs after "git fetch + reset to release channel", so the
+	//    working tree already IS the channel tip — free, offline, and
+	//    not subject to the 60/hour unauthenticated API quota that was
+	//    silently forcing every update into a full source build. See
+	//    update_release_direct.go for the full rationale.
+	var fullSHA string
+	var tarName, sumName, tarURL, sumURL string
+
+	fullSHA, err = localHeadSHA(ctx, repoDir)
+	if err == nil {
+		log("release: local HEAD = %s", fullSHA)
+		// 2. Resolve assets through the release CDN's fixed-name path.
+		//    github.com/.../releases/latest/download/<asset> redirects to
+		//    the newest release without touching the API. The MANIFEST
+		//    check below still verifies it is the build for THIS commit,
+		//    so a host sitting on an older commit falls through rather
+		//    than silently installing something else.
+		tarName = "jabali-release.tar.gz"
+		sumName = tarName + ".sha256"
+		tarURL, sumURL = latestDownloadURLs(webBase)
+	} else {
+		// No usable local checkout (bare install, relocated repo). Fall
+		// back to the API path, which still works when the quota allows.
+		log("release: local HEAD unreadable (%v) — asking the API instead", err)
+		fullSHA, err = fetchLatestMainSHA(ctx, base)
+		if err != nil {
+			log("release: lookup of main HEAD failed: %v", err)
+			return false, "", nil
+		}
+		log("release: latest main = %s", fullSHA)
+
+		// Look up the release for this commit by SCANNING releases for a
+		// target_commitish match. A direct GET /releases/tags/release-<short>
+		// is not usable: git's short-SHA length is whatever is unique in the
+		// repo and drifts as it grows, so the tag name cannot be derived.
+		var rel *releaseResponse
+		var shortSHA string
+		rel, shortSHA, err = findReleaseForCommit(ctx, base, fullSHA)
+		if err != nil {
+			log("release: no release tarball published yet for %s (%v) — falling back", fullSHA[:7], err)
+			return false, "", nil
+		}
+		tarName = fmt.Sprintf("jabali-release-%s.tar.gz", shortSHA)
+		sumName = tarName + ".sha256"
+		tarURL = pickAssetURL(rel, tarName)
+		sumURL = pickAssetURL(rel, sumName)
+		if tarURL == "" || sumURL == "" {
+			log("release: release %s is missing %s or %s asset — falling back", rel.TagName, tarName, sumName)
+			return false, "", nil
+		}
 	}
 
 	// 3. Download tarball + sha256 sidecar into a staging tmpdir.
@@ -165,10 +189,15 @@ func installFromRelease(ctx context.Context, log func(string, ...any)) (installe
 		return false, "", fmt.Errorf("release: parse MANIFEST: %w", err)
 	}
 	if manifest["full_sha"] != fullSHA {
-		// Catch a publisher bug early: tarball was built for a
-		// different SHA than the tag claims.
-		return false, "", fmt.Errorf("release: MANIFEST full_sha=%s but main HEAD=%s — tag/build mismatch",
+		// The newest published release is for a different commit than the
+		// one this host is on. That is ordinary right after a push — the
+		// release build has not finished yet — so fall back to a source
+		// build rather than installing binaries that do not match the
+		// checked-out tree. Not an error: the tarball is intact, it is
+		// simply not ours.
+		log("release: newest release is for %s but this host is on %s — falling back",
 			manifest["full_sha"], fullSHA)
+		return false, "", nil
 	}
 	log("release: tarball MANIFEST: short=%s build_time=%s go=%s",
 		manifest["short_sha"], manifest["build_time"], manifest["go_version"])

--- a/panel-api/cmd/server/update_release_direct.go
+++ b/panel-api/cmd/server/update_release_direct.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Release resolution that does not touch api.github.com.
+//
+// The API path costs two unauthenticated calls per update (GET /branches/main
+// and a GET /releases scan). Unauthenticated GitHub API is 60 requests/hour
+// PER IP, shared by every host behind the same egress — so on a NAT'd network,
+// a CI runner, or a cloud provider's shared outbound address it runs out. When
+// it does, fetchLatestMainSHA gets a 403, installFromRelease reports "no
+// release available", and the update silently does a full source build instead:
+//
+//	{"message":"API rate limit exceeded for 181.79.81.248. ..."}
+//	"limit": 60, "remaining": 0
+//
+// On a small host that is not merely slower — it is an update that cannot
+// finish, because the frontend build exceeds the heap ceiling there. Observed
+// on a 2 GB box whose release tarball had been published four minutes before
+// the update ran: the artifact existed, the lookup just could not see it.
+//
+// bootstrap.sh already solved exactly this (reference: installer release
+// resolution, 2026-07-21) by resolving through
+// github.com/<owner>/<repo>/releases/latest/download/<asset>. That path is
+// served by github.com and its release CDN, NOT api.github.com, so it does not
+// consume the API quota. release.yml publishes fixed-name jabali-release.tar.gz
+// and .sha256 assets alongside the sha-named pair precisely so that URL
+// resolves. `jabali update` never got the same treatment.
+//
+// Correctness is not weakened by dropping the API. The old flow asked GitHub
+// for main's HEAD and required the release to match it; but this step runs
+// AFTER "git fetch + reset to release channel", so the local checkout already
+// IS the channel tip — a more trustworthy answer than a network round-trip,
+// and one that cannot be rate-limited. The tarball's MANIFEST still has to
+// agree with it, so a publisher bug is caught exactly as before.
+
+// defaultReleaseWebBase is the non-API origin used for release downloads.
+// Overridable alongside JABALI_RELEASE_API_BASE for forks and mirrors.
+const defaultReleaseWebBase = "https://github.com/shukiv/jabali-panel"
+
+// latestDownloadURLs returns the fixed-name asset URLs GitHub redirects to the
+// newest release. No API call, no quota.
+func latestDownloadURLs(webBase string) (tarURL, sumURL string) {
+	base := strings.TrimSuffix(webBase, "/") + "/releases/latest/download/"
+	return base + "jabali-release.tar.gz", base + "jabali-release.tar.gz.sha256"
+}
+
+// localHeadSHA reads the commit the working tree is actually on.
+//
+// Used instead of GET /branches/main. The update resets the repo to the
+// release channel earlier in the run, so this is the same value the API would
+// return — except it is free, offline, and immune to rate limiting.
+func localHeadSHA(ctx context.Context, repoDir string) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD in %s: %w", repoDir, err)
+	}
+	sha := strings.TrimSpace(string(out))
+	if len(sha) < releaseShortSHALen {
+		return "", fmt.Errorf("git rev-parse returned an implausible HEAD %q", sha)
+	}
+	return sha, nil
+}

--- a/panel-api/cmd/server/update_release_direct_test.go
+++ b/panel-api/cmd/server/update_release_direct_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestLatestDownloadURLs pins the exact shape that keeps release resolution off
+// api.github.com.
+//
+// The distinction is the whole point: api.github.com enforces 60 unauthenticated
+// requests per hour PER IP, and github.com/.../releases/latest/download/ does
+// not. When the quota ran out, the update silently fell back to a full source
+// build — on a 2 GB host, one that cannot finish. A well-meaning "tidy-up" that
+// routes these through the API would restore that failure invisibly, since
+// everything still works until an IP happens to be over quota.
+func TestLatestDownloadURLs(t *testing.T) {
+	t.Parallel()
+
+	tarURL, sumURL := latestDownloadURLs("https://github.com/shukiv/jabali-panel")
+
+	if strings.Contains(tarURL, "api.github.com") || strings.Contains(sumURL, "api.github.com") {
+		t.Errorf("release URLs must not use the API host (60 req/hour/IP):\n  %s\n  %s", tarURL, sumURL)
+	}
+	const wantTar = "https://github.com/shukiv/jabali-panel/releases/latest/download/jabali-release.tar.gz"
+	if tarURL != wantTar {
+		t.Errorf("tar URL = %q, want %q", tarURL, wantTar)
+	}
+	if sumURL != wantTar+".sha256" {
+		t.Errorf("sum URL = %q, want the tarball URL plus .sha256", sumURL)
+	}
+}
+
+// TestLatestDownloadURLs_TrailingSlash covers an override supplied with a
+// trailing slash, which would otherwise produce a double slash in the path.
+func TestLatestDownloadURLs_TrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	tarURL, _ := latestDownloadURLs("https://example.test/org/repo/")
+	if strings.Contains(tarURL, "repo//releases") {
+		t.Errorf("double slash in %q", tarURL)
+	}
+	if !strings.HasPrefix(tarURL, "https://example.test/org/repo/releases/latest/download/") {
+		t.Errorf("unexpected URL for an overridden base: %q", tarURL)
+	}
+}
+
+// TestLocalHeadSHA reads the commit from a real throwaway repo, because the
+// point of this helper is replacing a network lookup with the local truth — a
+// stubbed test would not show that `git rev-parse` behaves as assumed.
+func TestLocalHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "seed"},
+	} {
+		cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	got, err := localHeadSHA(ctx, dir)
+	if err != nil {
+		t.Fatalf("localHeadSHA: %v", err)
+	}
+	if len(got) != 40 {
+		t.Errorf("HEAD = %q, want a 40-char SHA", got)
+	}
+	if strings.ContainsAny(got, " \n\t") {
+		t.Errorf("HEAD %q still has whitespace — it is used to build a URL and compared to MANIFEST", got)
+	}
+}
+
+// TestLocalHeadSHA_NotARepo must fail rather than return something empty: the
+// caller uses the error to fall back to the API path, and an empty SHA would
+// instead be compared against the MANIFEST and mismatch confusingly.
+func TestLocalHeadSHA_NotARepo(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if sha, err := localHeadSHA(context.Background(), t.TempDir()); err == nil {
+		t.Errorf("expected an error outside a git repo, got sha=%q", sha)
+	}
+}


### PR DESCRIPTION
Answers "how can the update be optimized" — the answer turned out to be a bug, not tuning.

## The fast path was never running

`installFromRelease` exists to skip `npm ci`, the vite build **and** both Go builds when a release tarball matches main. It spends two unauthenticated GitHub API calls to find that tarball: `GET /branches/main`, then a `GET /releases` scan.

Unauthenticated GitHub API is **60 requests/hour per IP**, shared by every host behind the same egress. Once exhausted:

```
{"message":"API rate limit exceeded for 181.79.81.248. ..."}
"limit": 60, "remaining": 0
```

`fetchLatestMainSHA` 403s, `installFromRelease` reports "no release available", and the update **silently builds from source**.

On a small host that isn't merely slower — it's an update that *cannot finish*, because the frontend build exceeds the heap ceiling there (#818). Caught deploying to a 2 GB box whose tarball had been published **four minutes before** the update started. The artifact existed; the lookup couldn't see it.

## We already solved this once

`bootstrap.sh` hit the identical failure in July. The fix, recorded at the time:

> resolve via `https://github.com/…/releases/latest/download/…` — served by **github.com, NOT api.github.com**, so it does not consume the 60/hr API limit

`release.yml` publishes fixed-name `jabali-release.tar.gz` + `.sha256` assets precisely so that URL resolves. **`jabali update` never got the same treatment.** This gives it the same one.

## Local HEAD instead of the API

The commit under test now comes from `git rev-parse HEAD`. That's not a downgrade — this step runs *after* "git fetch + reset to release channel", so the working tree already **is** the channel tip. More direct than a network round-trip, and impossible to rate-limit. The API path stays as a fallback for a host with no usable checkout.

## One behavioural change, stated plainly

A MANIFEST `full_sha` disagreeing with local HEAD is **no longer a hard error**.

Previously the tarball was looked up *by* the commit, so a mismatch could only mean a publisher bug — worth failing on. Resolving through `latest/download` can legitimately return a release newer than the host is on, which is normal in the minutes after a push. That case now logs and falls back to a source build, rather than failing the update or installing binaries that don't match the checked-out tree.

## Verified end to end on the affected host

```
downloaded: 29032149 bytes
want: df7e844ec10cd4aecf5f59aea9798f63cc585b51c053c9a6c61161b22037fad4
got : df7e844ec10cd4aecf5f59aea9798f63cc585b51c053c9a6c61161b22037fad4
==> CHECKSUM MATCHES
MANIFEST: full_sha=db5db2ae7adb18e6d964a98ac4a09bd4a8565dd1
```

I checked the one assumption that could have bitten: the sidecar names the *sha-named* asset while we download the *fixed-name* one. `verifyTarballChecksum` reads only `fields[0]`, and the two tarballs are byte-identical, so it verifies correctly.

## Tests

Assert the resolved URLs never contain `api.github.com` — the failure is invisible until an IP happens to be over quota, so a future tidy-up routing these back through the API would silently restore it. Plus `localHeadSHA` against a real throwaway repo, including the not-a-repo case, since the caller uses that error to choose the fallback.

## Impact

Where a release exists, update goes from a multi-minute build plus a 1–2 GB memory peak to a ~29 MB download. #818 makes the source path survivable when it's genuinely needed; this means most hosts stop taking it at all.
