### PR TITLE
fix(update): resolve the release for THIS commit, not just "latest"

### DIFF
--- a/panel-api/cmd/server/update_release.go
+++ b/panel-api/cmd/server/update_release.go
@@ -106,6 +106,10 @@ func installFromRelease(ctx context.Context, repoDir string, log func(string, ..
 	//    update_release_direct.go for the full rationale.
 	var fullSHA string
 	var tarName, sumName, tarURL, sumURL string
+	// usedDirect: URLs came from the "latest" CDN shortcut, which is only
+	// correct for a host following main. On a MANIFEST mismatch we re-resolve
+	// by commit rather than giving up.
+	usedDirect := false
 
 	fullSHA, err = localHeadSHA(ctx, repoDir)
 	if err == nil {
@@ -119,6 +123,7 @@ func installFromRelease(ctx context.Context, repoDir string, log func(string, ..
 		tarName = "jabali-release.tar.gz"
 		sumName = tarName + ".sha256"
 		tarURL, sumURL = latestDownloadURLs(webBase)
+		usedDirect = true
 	} else {
 		// No usable local checkout (bare install, relocated repo). Fall
 		// back to the API path, which still works when the quota allows.
@@ -151,56 +156,88 @@ func installFromRelease(ctx context.Context, repoDir string, log func(string, ..
 		}
 	}
 
-	// 3. Download tarball + sha256 sidecar into a staging tmpdir.
+	// 3. Download + verify + extract one candidate, and report whether its
+	//    MANIFEST is the build for the commit this host is on.
 	stage, err := os.MkdirTemp("/var/lib/jabali-panel", "release-stage-*")
 	if err != nil {
 		return false, "", fmt.Errorf("release: mkdir staging: %w", err)
 	}
 	defer os.RemoveAll(stage) // success path also cleans up
 
-	tarPath := filepath.Join(stage, tarName)
-	if err := downloadTo(ctx, tarURL, tarPath, releaseDownloadTimeout); err != nil {
-		return false, "", fmt.Errorf("release: download tarball: %w", err)
-	}
-	sumPath := filepath.Join(stage, sumName)
-	if err := downloadTo(ctx, sumURL, sumPath, releaseAPITimeout); err != nil {
-		return false, "", fmt.Errorf("release: download checksum: %w", err)
+	attempt := 0
+	stageAndCheck := func(tarURL, sumURL, tarName, sumName string) (string, bool, error) {
+		attempt++
+		dir := filepath.Join(stage, fmt.Sprintf("try%d", attempt))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", false, fmt.Errorf("release: mkdir staging: %w", err)
+		}
+		tarPath := filepath.Join(dir, tarName)
+		if err := downloadTo(ctx, tarURL, tarPath, releaseDownloadTimeout); err != nil {
+			return "", false, fmt.Errorf("release: download tarball: %w", err)
+		}
+		sumPath := filepath.Join(dir, sumName)
+		if err := downloadTo(ctx, sumURL, sumPath, releaseAPITimeout); err != nil {
+			return "", false, fmt.Errorf("release: download checksum: %w", err)
+		}
+		// Verify sha256. Hard-fail on mismatch — the caller MUST NOT fall
+		// back to source for a corrupted tarball.
+		if err := verifyTarballChecksum(tarPath, sumPath); err != nil {
+			return "", false, fmt.Errorf("release: checksum verification failed: %w", err)
+		}
+		log("release: sha256 verified")
+
+		extractDir := filepath.Join(dir, "extracted")
+		if err := os.Mkdir(extractDir, 0o755); err != nil {
+			return "", false, fmt.Errorf("release: mkdir extract: %w", err)
+		}
+		if err := extractTarball(ctx, tarPath, extractDir); err != nil {
+			return "", false, fmt.Errorf("release: extract: %w", err)
+		}
+		manifest, err := parseManifest(filepath.Join(extractDir, "MANIFEST"))
+		if err != nil {
+			return "", false, fmt.Errorf("release: parse MANIFEST: %w", err)
+		}
+		if manifest["full_sha"] != fullSHA {
+			log("release: this tarball is for %s but the host is on %s",
+				manifest["full_sha"], fullSHA)
+			return extractDir, false, nil
+		}
+		log("release: tarball MANIFEST: short=%s build_time=%s go=%s",
+			manifest["short_sha"], manifest["build_time"], manifest["go_version"])
+		return extractDir, true, nil
 	}
 
-	// 4. Verify sha256. Hard-fail on mismatch — caller MUST NOT fall
-	//    back to source for a corrupted tarball.
-	if err := verifyTarballChecksum(tarPath, sumPath); err != nil {
-		return false, "", fmt.Errorf("release: checksum verification failed: %w", err)
-	}
-	log("release: sha256 verified")
-
-	// 5. Extract into the staging dir and install binaries atomically.
-	extractDir := filepath.Join(stage, "extracted")
-	if err := os.Mkdir(extractDir, 0o755); err != nil {
-		return false, "", fmt.Errorf("release: mkdir extract: %w", err)
-	}
-	if err := extractTarball(ctx, tarPath, extractDir); err != nil {
-		return false, "", fmt.Errorf("release: extract: %w", err)
-	}
-
-	manifestPath := filepath.Join(extractDir, "MANIFEST")
-	manifest, err := parseManifest(manifestPath)
+	extractDir, matched, err := stageAndCheck(tarURL, sumURL, tarName, sumName)
 	if err != nil {
-		return false, "", fmt.Errorf("release: parse MANIFEST: %w", err)
+		return false, "", err
 	}
-	if manifest["full_sha"] != fullSHA {
-		// The newest published release is for a different commit than the
-		// one this host is on. That is ordinary right after a push — the
-		// release build has not finished yet — so fall back to a source
-		// build rather than installing binaries that do not match the
-		// checked-out tree. Not an error: the tarball is intact, it is
-		// simply not ours.
-		log("release: newest release is for %s but this host is on %s — falling back",
-			manifest["full_sha"], fullSHA)
-		return false, "", nil
+	if !matched {
+		// "latest" is only the right answer for a host following main. A host
+		// on a channel tag (stable) resets its checkout to the promoted commit,
+		// so latest will never match it — while the release it actually wants
+		// is usually published and reachable. Re-resolve BY COMMIT rather than
+		// giving up, or every channel host rebuilds from source forever.
+		if !usedDirect {
+			// Already resolved by commit and it still disagrees: that is a
+			// publisher bug, not a channel mismatch.
+			return false, "", fmt.Errorf("release: MANIFEST does not match HEAD %s — tag/build mismatch", fullSHA)
+		}
+		cTar, cSum, cTag, found := byCommitDownloadURLs(ctx, webBase, fullSHA, urlExists)
+		if !found {
+			log("release: no release published for %s yet — falling back to source", fullSHA[:7])
+			return false, "", nil
+		}
+		log("release: found %s for this commit", cTag)
+		asset := "jabali-release-" + strings.TrimPrefix(cTag, "release-") + ".tar.gz"
+		extractDir, matched, err = stageAndCheck(cTar, cSum, asset, asset+".sha256")
+		if err != nil {
+			return false, "", err
+		}
+		if !matched {
+			log("release: by-commit tarball still disagrees — falling back to source")
+			return false, "", nil
+		}
 	}
-	log("release: tarball MANIFEST: short=%s build_time=%s go=%s",
-		manifest["short_sha"], manifest["build_time"], manifest["go_version"])
 
 	// 6. Install binaries via the same path the source-build flow
 	//    uses (atomic rename, mode 0755, owner root). Caller is

--- a/panel-api/cmd/server/update_release_direct.go
+++ b/panel-api/cmd/server/update_release_direct.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os/exec"
 	"strings"
 )
@@ -65,4 +66,54 @@ func localHeadSHA(ctx context.Context, repoDir string) (string, error) {
 		return "", fmt.Errorf("git rev-parse returned an implausible HEAD %q", sha)
 	}
 	return sha, nil
+}
+
+// byCommitDownloadURLs resolves the release built for one specific commit,
+// still without touching the API.
+//
+// Needed because "latest" is only the right answer for hosts that follow main.
+// A host on the `stable` channel resets its checkout to the promoted tag, so
+// the newest release will never match it — while the release it actually wants
+// (release-7085d502f for that tag, say) sits published and reachable. Resolving
+// only by "latest" would send every channel host into a full source build
+// forever.
+//
+// The tag is release-<short_sha>, but the short length is whatever
+// build-release.sh produced and git's own --short drifts as the repo grows, so
+// it cannot be derived. Probe a small range instead, cheapest-first: a HEAD on
+// the tiny .sha256 sidecar costs nothing and the first hit wins. Observed
+// length today is 9; the range covers drift in either direction.
+func byCommitDownloadURLs(ctx context.Context, webBase, fullSHA string, head func(context.Context, string) bool) (tarURL, sumURL, tag string, ok bool) {
+	base := strings.TrimSuffix(webBase, "/") + "/releases/download/"
+	for _, n := range []int{9, 8, 10, 7, 11, 12} {
+		if n > len(fullSHA) {
+			continue
+		}
+		short := fullSHA[:n]
+		t := "release-" + short
+		asset := "jabali-release-" + short + ".tar.gz"
+		sum := base + t + "/" + asset + ".sha256"
+		if head(ctx, sum) {
+			return base + t + "/" + asset, sum, t, true
+		}
+	}
+	return "", "", "", false
+}
+
+// urlExists is the probe byCommitDownloadURLs uses. A HEAD on the sidecar is a
+// few hundred bytes of headers, so trying a handful of tag lengths is far
+// cheaper than either an API call or a wrong-guess full download.
+func urlExists(ctx context.Context, url string) bool {
+	cctx, cancel := context.WithTimeout(ctx, releaseAPITimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, http.MethodHead, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }

--- a/panel-api/cmd/server/update_release_direct_test.go
+++ b/panel-api/cmd/server/update_release_direct_test.go
@@ -94,3 +94,78 @@ func TestLocalHeadSHA_NotARepo(t *testing.T) {
 		t.Errorf("expected an error outside a git repo, got sha=%q", sha)
 	}
 }
+
+// TestByCommitDownloadURLs covers the resolver that keeps channel hosts off the
+// source-build path.
+//
+// "latest" is only correct for a host following main. A host on the `stable`
+// channel resets its checkout to the promoted tag, so the newest release never
+// matches its HEAD — while release-<that commit> is usually published and
+// perfectly reachable. Resolving only by "latest" would send every stable host
+// into a full source build forever, which on a small box means an update that
+// takes hours or does not finish at all.
+//
+// The tag's short-SHA length is whatever build-release.sh produced and git's
+// own --short drifts as the repo grows, so it cannot be derived — hence the
+// probe. The order matters: the observed length is tried first so the common
+// case costs one HEAD.
+func TestByCommitDownloadURLs(t *testing.T) {
+	t.Parallel()
+
+	const full = "7085d502f2a5cfe2a7e07bd1958ddeac4675b880"
+	const web = "https://github.com/shukiv/jabali-panel"
+
+	t.Run("finds the 9-char tag on the first probe", func(t *testing.T) {
+		var probes []string
+		head := func(_ context.Context, url string) bool {
+			probes = append(probes, url)
+			return strings.Contains(url, "release-7085d502f/")
+		}
+		tar, sum, tag, ok := byCommitDownloadURLs(context.Background(), web, full, head)
+		if !ok {
+			t.Fatalf("expected a hit; probed %v", probes)
+		}
+		if tag != "release-7085d502f" {
+			t.Errorf("tag = %q, want release-7085d502f", tag)
+		}
+		if len(probes) != 1 {
+			t.Errorf("expected the observed length to be probed first, got %d probes: %v", len(probes), probes)
+		}
+		wantTar := web + "/releases/download/release-7085d502f/jabali-release-7085d502f.tar.gz"
+		if tar != wantTar {
+			t.Errorf("tar = %q, want %q", tar, wantTar)
+		}
+		if sum != wantTar+".sha256" {
+			t.Errorf("sum = %q, want the tarball plus .sha256", sum)
+		}
+		if strings.Contains(tar, "api.github.com") {
+			t.Error("by-commit resolution must not use the rate-limited API host")
+		}
+	})
+
+	t.Run("falls through to another length when the tag is shorter", func(t *testing.T) {
+		head := func(_ context.Context, url string) bool {
+			return strings.Contains(url, "release-7085d50/")
+		}
+		_, _, tag, ok := byCommitDownloadURLs(context.Background(), web, full, head)
+		if !ok || tag != "release-7085d50" {
+			t.Errorf("expected the 7-char tag to be found, got ok=%v tag=%q", ok, tag)
+		}
+	})
+
+	t.Run("reports not-found rather than guessing", func(t *testing.T) {
+		head := func(_ context.Context, _ string) bool { return false }
+		_, _, _, ok := byCommitDownloadURLs(context.Background(), web, full, head)
+		if ok {
+			t.Error("no published release must report not-found so the caller falls back to source")
+		}
+	})
+
+	t.Run("a short SHA never slices out of range", func(t *testing.T) {
+		head := func(_ context.Context, _ string) bool { return false }
+		// Must not panic on a SHA shorter than the probe lengths.
+		if _, _, _, ok := byCommitDownloadURLs(context.Background(), web, "abc123", head); ok {
+			t.Error("unexpected hit")
+		}
+	})
+}


### PR DESCRIPTION
Fixes a regression I introduced in #820.

## What I broke

#820 resolves release assets through `/releases/latest/download/`. That's only the right answer for a host following `main`.

A host on a **channel tag** resets its checkout to the promoted commit, so "latest" is main's newest release and will never match its HEAD — and #820's MANIFEST check then sends it to a source build. The old API path looked the release up **by commit** and found it.

So for channel hosts I traded:

| | before #820 | after #820 |
|---|---|---|
| stable host | installs **main's** binaries (fast, **wrong**) | always rebuilds from source (correct, hours) |

Neither is acceptable — and the artifact those hosts need is published the whole time. `release-7085d502f` exists right now for the current `stable` tag.

This is exactly what a real host showed: `.165` tracks `stable`, and its update log reads

```
release: latest main = 14684398344b7f1d85bc1d5071ad3072aa03c0d7
release: no release tarball published yet for 1468439 — falling back
no release tarball available — falling back to source build
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

(That box additionally runs a pre-migration binary pointed at the old forge, which is why its "latest main" is a stale SHA — a separate problem — but the channel gap is real regardless.)

## Fix

On a MANIFEST mismatch, re-resolve **by commit** and retry once, still without the API.

The tag is `release-<short_sha>`, but the short length is whatever `build-release.sh` produced and git's own `--short` drifts as the repo grows, so it can't be derived. Probe a small range instead, cheapest-first — a HEAD on the tiny `.sha256` sidecar costs essentially nothing, and the observed length is tried first, so the common case is **one extra request, and only when latest already failed to match**.

A second mismatch *after* resolving by commit is a genuine publisher bug — a tarball tagged for one commit but built from another — so that stays a hard error rather than degrading to a silent source build.

Download / verify / extract / MANIFEST-check is now a closure run per candidate, each into its own staging subdirectory, so a retry can't reuse a half-extracted tree from the first attempt.

## Tests

Cover first-probe hit (asserting the common case really is one request), fall-through to a different tag length, honest not-found so the caller falls back rather than guessing, and a short SHA never slicing out of range. Plus the standing assertion that none of these URLs touch `api.github.com`.
