### PR TITLE
feat(ssl): ACME DNS-01 wildcard certificates (shared certs) — part 1 of preview URLs

### DIFF
--- a/panel-agent/internal/certbot/runner.go
+++ b/panel-agent/internal/certbot/runner.go
@@ -186,6 +186,113 @@ func (r *Runner) Issue(domain, webroot, email string, staging bool, extraHostnam
 	}, nil
 }
 
+// IssueDNS01 runs certbot with the manual DNS-01 authenticator. This is
+// the only challenge type Let's Encrypt accepts for wildcard names, so it
+// is what backs `*.<domain>` shared certificates and the panel's
+// `*.preview.<hostname>` cert.
+//
+// certName pins the lineage directory (LERoot/live/<certName>) and MUST
+// NOT contain `*` — pass a sanitised name (e.g. "wildcard.example.com")
+// and put the wildcard in sans. sans is the full SAN list including the
+// primary name; entries may carry a single leading "*." label.
+//
+// authHook/cleanupHook are the commands certbot runs per name to place
+// and remove the _acme-challenge TXT record. On a jabali box they invoke
+// the panel binary's `dns acme-hook` subcommand, which writes the record
+// through the panel's DNS tables and pushes the zone to PowerDNS —
+// keeping the panel DB authoritative even for ephemeral challenge rows.
+// certbot persists both hooks in the renewal conf, so `certbot renew`
+// keeps working without the caller re-supplying them.
+func (r *Runner) IssueDNS01(certName string, sans []string, email string, staging bool, authHook, cleanupHook string) (*Result, error) {
+	if len(sans) == 0 {
+		return nil, fmt.Errorf("certbot dns-01: at least one SAN required")
+	}
+	r.clearStaleLineageDir(certName)
+
+	args := []string{
+		"certonly",
+		"--cert-name", certName,
+		"--manual",
+		"--preferred-challenges", "dns",
+		"--manual-auth-hook", authHook,
+		"--manual-cleanup-hook", cleanupHook,
+	}
+	seen := map[string]struct{}{}
+	requested := make([]string, 0, len(sans))
+	for _, h := range sans {
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		requested = append(requested, h)
+		args = append(args, "-d", h)
+	}
+	args = append(args,
+		"-m", email,
+		"--agree-tos",
+		"--non-interactive",
+		"--keep-until-expiring",
+		// RSA for the same Cloudflare-origin compatibility reason as
+		// the webroot path above (error 525 on EC-only chains).
+		"--key-type", "rsa",
+	)
+	if existingCertMissingAny(fmt.Sprintf("%s/live/%s/fullchain.pem", r.LERoot, certName), requested) {
+		args = append(args, "--expand")
+	}
+	if staging {
+		args = append(args, "--staging")
+	}
+
+	cmd := exec.Command(r.Binary, args...)
+	cmd.Env = r.Env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	combinedOutput := stdout.String() + "\n" + stderr.String()
+	noop := func(out string) bool {
+		for _, m := range []string{
+			"not yet due for renewal",
+			"Keeping the existing certificate",
+			"no action taken",
+		} {
+			if strings.Contains(out, m) {
+				return true
+			}
+		}
+		return false
+	}(combinedOutput)
+
+	reason := ""
+	if err != nil {
+		reason = classifyStderr([]byte(combinedOutput))
+	}
+
+	cert, certErr := r.readCert(certName)
+	if err != nil && certErr != nil {
+		return &Result{
+			Reason: reason,
+			Stderr: truncateStderr(combinedOutput, 4096),
+		}, fmt.Errorf("certbot dns-01 issue failed: %w", err)
+	}
+	if certErr != nil {
+		return &Result{
+			Reason: "unknown",
+			Stderr: truncateStderr(combinedOutput, 4096),
+		}, fmt.Errorf("failed to read issued certificate: %w", certErr)
+	}
+
+	return &Result{
+		CertPath:  cert.CertPath,
+		KeyPath:   cert.KeyPath,
+		IssuedAt:  cert.IssuedAt,
+		ExpiresAt: cert.ExpiresAt,
+		Skipped:   noop,
+	}, nil
+}
+
 // Renew runs certbot to renew an existing certificate.
 func (r *Runner) Renew(domain string, force bool) (*Result, error) {
 	args := []string{

--- a/panel-agent/internal/certbot/runner_dns01_test.go
+++ b/panel-agent/internal/certbot/runner_dns01_test.go
@@ -1,0 +1,133 @@
+package certbot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupDNS01FakeCertbot writes a fake certbot that records its argv to
+// args.txt and materialises a lineage under LERoot/live/<cert-name>/ so
+// readCert succeeds. Reuses the same self-signed PEM the other runner
+// tests generate (createTestCertPEM).
+func setupDNS01FakeCertbot(t *testing.T, tmp string) *Runner {
+	t.Helper()
+	certbotPath := filepath.Join(tmp, "certbot")
+	script := fmt.Sprintf(`#!/bin/bash
+printf '%%s\n' "$@" > %s/args.txt
+name=""
+i=1
+for a in "$@"; do
+  if [[ "$a" == "--cert-name" ]]; then name="${@:$((i+1)):1}"; break; fi
+  i=$((i+1))
+done
+mkdir -p "%s/letsencrypt/live/$name"
+cat > "%s/letsencrypt/live/$name/fullchain.pem" << 'EOF'
+%s
+EOF
+touch "%s/letsencrypt/live/$name/privkey.pem"
+exit 0
+`, tmp, tmp, tmp, string(createTestCertPEM(t)), tmp)
+	if err := os.WriteFile(certbotPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &Runner{
+		Binary:  certbotPath,
+		OpenSSL: "openssl",
+		LERoot:  filepath.Join(tmp, "letsencrypt"),
+	}
+}
+
+func capturedArgs(t *testing.T, tmp string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(tmp, "args.txt"))
+	if err != nil {
+		t.Fatalf("fake certbot did not record args: %v", err)
+	}
+	return string(b)
+}
+
+func TestIssueDNS01ArgShape(t *testing.T) {
+	tmp := t.TempDir()
+	runner := setupDNS01FakeCertbot(t, tmp)
+
+	result, err := runner.IssueDNS01(
+		"wildcard.preview.host.tld",
+		[]string{"*.preview.host.tld"},
+		"admin@host.tld",
+		false,
+		"/usr/local/bin/jabali-panel dns acme-hook auth",
+		"/usr/local/bin/jabali-panel dns acme-hook cleanup",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.CertPath == "" || result.KeyPath == "" {
+		t.Fatalf("missing cert/key paths in result: %+v", result)
+	}
+
+	args := capturedArgs(t, tmp)
+	for _, want := range []string{
+		"--manual",
+		"--preferred-challenges\ndns",
+		"--manual-auth-hook\n/usr/local/bin/jabali-panel dns acme-hook auth",
+		"--manual-cleanup-hook\n/usr/local/bin/jabali-panel dns acme-hook cleanup",
+		"-d\n*.preview.host.tld",
+		"--cert-name\nwildcard.preview.host.tld",
+		"--key-type\nrsa",
+		"--non-interactive",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("certbot args missing %q:\n%s", want, args)
+		}
+	}
+	// DNS-01 must not carry a webroot — that is the HTTP-01 authenticator,
+	// and certbot rejects mixing the two.
+	for _, forbidden := range []string{"--webroot", "-w\n"} {
+		if strings.Contains(args, forbidden) {
+			t.Errorf("certbot args must not contain %q for dns-01:\n%s", forbidden, args)
+		}
+	}
+	if strings.Contains(args, "--staging") {
+		t.Error("staging flag present on a non-staging issue")
+	}
+}
+
+func TestIssueDNS01StagingAndDedup(t *testing.T) {
+	tmp := t.TempDir()
+	runner := setupDNS01FakeCertbot(t, tmp)
+
+	_, err := runner.IssueDNS01(
+		"wildcard.example.com",
+		[]string{"example.com", "*.example.com", "example.com"},
+		"a@example.com",
+		true,
+		"auth-hook", "cleanup-hook",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := capturedArgs(t, tmp)
+	if !strings.Contains(args, "--staging") {
+		t.Error("staging flag missing")
+	}
+	if strings.Count(args, "example.com\n")+strings.Count(args, "example.com") == 0 {
+		t.Fatal("no -d entries recorded")
+	}
+	// The duplicate apex must collapse to a single -d.
+	if got := strings.Count(args, "-d\nexample.com"); got != 1 {
+		t.Errorf("apex -d appears %d times, want 1:\n%s", got, args)
+	}
+	if got := strings.Count(args, "-d\n*.example.com"); got != 1 {
+		t.Errorf("wildcard -d appears %d times, want 1:\n%s", got, args)
+	}
+}
+
+func TestIssueDNS01RequiresSANs(t *testing.T) {
+	runner := NewRunner()
+	if _, err := runner.IssueDNS01("x", nil, "a@b.co", false, "h", "h"); err == nil {
+		t.Fatal("expected an error for empty SAN list")
+	}
+}

--- a/panel-agent/internal/commands/ssl_issue_dns01.go
+++ b/panel-agent/internal/commands/ssl_issue_dns01.go
@@ -1,0 +1,118 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/certbot"
+)
+
+// acmeDNSHookAuth / acmeDNSHookCleanup are the commands certbot runs to
+// place and remove the _acme-challenge TXT record for each name. They
+// call back into the panel binary, which writes the record through the
+// panel's own DNS tables and pushes the zone to PowerDNS — the panel DB
+// stays authoritative even for ephemeral challenge rows, and certbot
+// persists these commands in the renewal conf so `certbot renew` keeps
+// working unattended.
+const (
+	acmeDNSHookAuth    = "/usr/local/bin/jabali-panel dns acme-hook auth"
+	acmeDNSHookCleanup = "/usr/local/bin/jabali-panel dns acme-hook cleanup"
+)
+
+// sslIssueDNS01Params is the input shape for ssl.issue_dns01.
+//
+// CertName pins the certbot lineage (must be a plain FQDN-ish label —
+// no `*`). SANs is the full name list; each entry may carry a single
+// leading "*." (that is the point of DNS-01: LE only grants wildcards
+// over it). The DNS zones for every SAN must be served by this panel's
+// PowerDNS — the hook refuses foreign zones, which fails the challenge
+// with a clear error instead of a timeout.
+type sslIssueDNS01Params struct {
+	CertName string   `json:"cert_name"`
+	SANs     []string `json:"sans"`
+	Email    string   `json:"email"`
+	Staging  bool     `json:"staging"`
+}
+
+type sslIssueDNS01Response struct {
+	CertPath  string `json:"cert_path"`
+	KeyPath   string `json:"key_path"`
+	IssuedAt  string `json:"issued_at"`
+	ExpiresAt string `json:"expires_at"`
+	Staging   bool   `json:"staging"`
+	Skipped   bool   `json:"skipped"`
+}
+
+func sslIssueDNS01Handler(ctx context.Context, params json.RawMessage) (any, error) {
+	if len(params) == 0 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "params required"}
+	}
+	var p sslIssueDNS01Params
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("parse params: %v", err),
+		}
+	}
+
+	if !sslDomainRegex.MatchString(p.CertName) || strings.Contains(p.CertName, "*") {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid cert_name %q: must be a plain name with no wildcard", p.CertName),
+		}
+	}
+	if len(p.SANs) == 0 {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "sans[] must not be empty",
+		}
+	}
+	for _, san := range p.SANs {
+		bare := strings.TrimPrefix(san, "*.")
+		// After stripping ONE wildcard label the rest must be a plain
+		// FQDN — "*.*.x", "*x" and a bare "*" are all rejected.
+		if bare == "" || strings.Contains(bare, "*") || !sslDomainRegex.MatchString(bare) {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInvalidArgument,
+				Message: fmt.Sprintf("invalid SAN %q: must be a FQDN with at most one leading '*.' label", san),
+			}
+		}
+	}
+	if !emailRegex.MatchString(p.Email) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid email %q", p.Email),
+		}
+	}
+
+	runner := certbot.NewRunner()
+	result, err := runner.IssueDNS01(p.CertName, p.SANs, p.Email, p.Staging, acmeDNSHookAuth, acmeDNSHookCleanup)
+	if err != nil {
+		msg := fmt.Sprintf("dns-01 issue failed: %v", err)
+		if result != nil && result.Reason != "" {
+			msg = fmt.Sprintf("dns-01 issue failed (%s): %v", result.Reason, err)
+		}
+		if result != nil && result.Stderr != "" {
+			if detail := certbot.ExtractActionableDetail(result.Stderr); detail != "" {
+				msg = fmt.Sprintf("%s — %s", msg, detail)
+			}
+		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: msg}
+	}
+
+	return sslIssueDNS01Response{
+		CertPath:  result.CertPath,
+		KeyPath:   result.KeyPath,
+		IssuedAt:  result.IssuedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ExpiresAt: result.ExpiresAt.Format("2006-01-02T15:04:05Z07:00"),
+		Staging:   p.Staging,
+		Skipped:   result.Skipped,
+	}, nil
+}
+
+func init() {
+	Default.Register("ssl.issue_dns01", sslIssueDNS01Handler)
+}

--- a/panel-agent/internal/commands/ssl_issue_dns01_test.go
+++ b/panel-agent/internal/commands/ssl_issue_dns01_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// Validation-layer tests only — the certbot invocation itself is covered
+// by certbot.TestIssueDNS01* against a fake binary.
+
+func callDNS01(t *testing.T, params string) (any, error) {
+	t.Helper()
+	return sslIssueDNS01Handler(context.Background(), json.RawMessage(params))
+}
+
+func wantInvalidArgument(t *testing.T, err error, fragment string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	ae, ok := err.(*agentwire.AgentError)
+	if !ok {
+		t.Fatalf("expected AgentError, got %T: %v", err, err)
+	}
+	if ae.Code != agentwire.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %s (%s)", ae.Code, ae.Message)
+	}
+	if fragment != "" && !strings.Contains(ae.Message, fragment) {
+		t.Errorf("error %q does not mention %q", ae.Message, fragment)
+	}
+}
+
+func TestSSLIssueDNS01_RejectsWildcardCertName(t *testing.T) {
+	_, err := callDNS01(t, `{"cert_name":"*.example.com","sans":["*.example.com"],"email":"a@b.co"}`)
+	wantInvalidArgument(t, err, "cert_name")
+}
+
+func TestSSLIssueDNS01_RejectsBadSANs(t *testing.T) {
+	cases := []string{
+		`{"cert_name":"wildcard.example.com","sans":[],"email":"a@b.co"}`,
+		`{"cert_name":"wildcard.example.com","sans":["*.*.example.com"],"email":"a@b.co"}`,
+		`{"cert_name":"wildcard.example.com","sans":["*"],"email":"a@b.co"}`,
+		`{"cert_name":"wildcard.example.com","sans":["exa mple.com"],"email":"a@b.co"}`,
+	}
+	for _, c := range cases {
+		if _, err := callDNS01(t, c); err == nil {
+			t.Errorf("params %s: expected validation error", c)
+		}
+	}
+}
+
+func TestSSLIssueDNS01_RejectsBadEmail(t *testing.T) {
+	_, err := callDNS01(t, `{"cert_name":"wildcard.example.com","sans":["*.example.com"],"email":"nope"}`)
+	wantInvalidArgument(t, err, "email")
+}
+
+func TestSSLIssueDNS01_AcceptsSingleWildcardSAN(t *testing.T) {
+	// Passes validation and reaches certbot — which is absent in CI, so a
+	// CodeInternal (not CodeInvalidArgument) proves validation let it through.
+	_, err := callDNS01(t, `{"cert_name":"wildcard.example.com","sans":["example.com","*.example.com"],"email":"a@b.co"}`)
+	if err == nil {
+		t.Skip("real certbot present and succeeded — validation clearly passed")
+	}
+	if ae, ok := err.(*agentwire.AgentError); ok && ae.Code == agentwire.CodeInvalidArgument {
+		t.Fatalf("valid params rejected at validation: %s", ae.Message)
+	}
+}

--- a/panel-api/cmd/server/dns_acme_hook_cmd.go
+++ b/panel-api/cmd/server/dns_acme_hook_cmd.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// `jabali dns acme-hook auth|cleanup` — certbot manual DNS-01 hooks.
+//
+// certbot invokes these (as root, via the agent's ssl.issue_dns01) with
+// CERTBOT_DOMAIN and CERTBOT_VALIDATION in the environment, once per
+// requested name. auth writes the _acme-challenge TXT record through the
+// panel's dns_records table and pushes the zone to PowerDNS immediately;
+// cleanup removes every row this subsystem owns for that name and pushes
+// again. Going through the panel tables (rather than poking the pdns DB)
+// keeps the DB-as-truth invariant: a reconciler tick between hook and
+// validation re-pushes the SAME record set instead of wiping the
+// challenge.
+//
+// Rows are tagged managed_by=acmeDNS01ManagedBy so cleanup can never
+// touch operator records, and a crashed run's leftovers are identifiable.
+const acmeDNS01ManagedBy = "acme-dns01"
+
+// acmeChallengeTTL is deliberately tiny — the record only needs to exist
+// for the seconds between hook and LE validation.
+const acmeChallengeTTL = 60
+
+func newDNSAcmeHookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "acme-hook",
+		Short:  "certbot manual DNS-01 hooks (writes _acme-challenge TXT via panel DNS)",
+		Hidden: true, // machine-invoked by certbot, not an operator surface
+	}
+	mk := func(use string, fn func(ctx context.Context, domain, validation string) error) *cobra.Command {
+		return &cobra.Command{
+			Use:     use,
+			Args:    cobra.NoArgs,
+			PreRunE: requireDBAndAgent,
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				domain := strings.TrimPrefix(strings.TrimSpace(os.Getenv("CERTBOT_DOMAIN")), "*.")
+				validation := strings.TrimSpace(os.Getenv("CERTBOT_VALIDATION"))
+				if domain == "" || validation == "" {
+					return fmt.Errorf("CERTBOT_DOMAIN and CERTBOT_VALIDATION must be set (certbot invokes this hook)")
+				}
+				ctx, cancel := context.WithTimeout(cmd.Context(), 90*time.Second)
+				defer cancel()
+				return fn(ctx, domain, validation)
+			},
+		}
+	}
+	cmd.AddCommand(
+		mk("auth", acmeHookAuth),
+		mk("cleanup", acmeHookCleanup),
+	)
+	return cmd
+}
+
+// findZoneForName walks the name's parent chain until a local dns_zones
+// row matches: "sub.example.com" tries itself, then "example.com", …
+// Refusing names with no local zone makes a DNS-01 attempt against a
+// foreign-DNS domain fail fast with a clear message instead of certbot
+// timing out on a TXT record that never appears.
+func findZoneForName(ctx context.Context, zones repository.DNSZoneRepository, name string) (*models.DNSZone, error) {
+	labels := strings.Split(strings.TrimSuffix(name, "."), ".")
+	for i := 0; i < len(labels)-1; i++ {
+		candidate := strings.Join(labels[i:], ".")
+		z, err := zones.FindByName(ctx, candidate)
+		if err == nil {
+			return z, nil
+		}
+		if !isNotFound(err) {
+			return nil, fmt.Errorf("look up zone %s: %w", candidate, err)
+		}
+	}
+	return nil, fmt.Errorf("no local DNS zone serves %q — DNS-01 needs the domain's DNS hosted on this panel", name)
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, repository.ErrNotFound)
+}
+
+// acmeChallengeName returns the FQDN record name for a validated domain.
+// Stored fully-qualified; dnscompile.expandName passes FQDNs through.
+func acmeChallengeName(domain string) string {
+	return "_acme-challenge." + domain
+}
+
+func acmeHookAuth(ctx context.Context, domain, validation string) error {
+	zones := dnsZoneRepoFromDB()
+	records := dnsRecordRepoFromDB()
+
+	zone, err := findZoneForName(ctx, zones, domain)
+	if err != nil {
+		return err
+	}
+
+	managedBy := acmeDNS01ManagedBy
+	now := time.Now().UTC()
+	rec := &models.DNSRecord{
+		ID:     ids.NewULID(),
+		ZoneID: zone.ID,
+		Name:   acmeChallengeName(domain),
+		Type:   "TXT",
+		// pdns wants TXT content quoted — same convention as the DMARC
+		// compiler (BuildDMARCString).
+		Content:   fmt.Sprintf("%q", validation),
+		TTL:       acmeChallengeTTL,
+		Managed:   true,
+		ManagedBy: &managedBy,
+		IsEnabled: true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := records.Create(ctx, rec); err != nil {
+		return fmt.Errorf("create challenge record: %w", err)
+	}
+	if err := pushZoneToPdns(ctx, zone); err != nil {
+		return err
+	}
+	// Settle: PowerDNS serves straight from the backend after the upsert
+	// (the agent purges its cache), but give LE's first query a moment —
+	// a failed validation costs a rate-limited retry, a short sleep is free.
+	time.Sleep(3 * time.Second)
+	fmt.Printf("acme-hook: TXT %s set in zone %s\n", rec.Name, zone.Name)
+	return nil
+}
+
+func acmeHookCleanup(ctx context.Context, domain, validation string) error {
+	zones := dnsZoneRepoFromDB()
+	records := dnsRecordRepoFromDB()
+
+	zone, err := findZoneForName(ctx, zones, domain)
+	if err != nil {
+		return err
+	}
+	rows, err := records.ListByZoneID(ctx, zone.ID)
+	if err != nil {
+		return fmt.Errorf("list zone records: %w", err)
+	}
+	wantName := acmeChallengeName(domain)
+	removed := 0
+	for i := range rows {
+		r := &rows[i]
+		// Only rows this subsystem created, only for this name. Content
+		// is deliberately NOT matched: certbot runs cleanup once per
+		// auth, but a crashed earlier run may have stranded a different
+		// validation value under the same name — reap those too.
+		if r.Type != "TXT" || r.Name != wantName {
+			continue
+		}
+		if r.ManagedBy == nil || *r.ManagedBy != acmeDNS01ManagedBy {
+			continue
+		}
+		if err := records.Delete(ctx, r.ID); err != nil {
+			return fmt.Errorf("delete challenge record %s: %w", r.ID, err)
+		}
+		removed++
+	}
+	if err := pushZoneToPdns(ctx, zone); err != nil {
+		return err
+	}
+	fmt.Printf("acme-hook: removed %d challenge record(s) for %s\n", removed, wantName)
+	return nil
+}
+
+// pushZoneToPdns compiles the zone from the panel tables and pushes it
+// through the agent — the exact flow the reconciler's reconcileDNSZone
+// runs, so the hook's push and the next tick's push are idempotent
+// twins rather than two competing writers.
+func pushZoneToPdns(ctx context.Context, zone *models.DNSZone) error {
+	zones := dnsZoneRepoFromDB()
+	records := dnsRecordRepoFromDB()
+	srv, _ := repository.NewServerSettingsRepository(sharedDB).Get(ctx)
+
+	rows, err := records.ListByZoneID(ctx, zone.ID)
+	if err != nil {
+		return fmt.Errorf("list records for push: %w", err)
+	}
+	compiled := dnscompile.Compile(zone, rows, srv)
+
+	zone.Serial = time.Now().UTC().Unix()
+	_ = zones.Update(ctx, zone)
+
+	var allowAXFR, alsoNotify []string
+	if srv != nil && srv.NS2IPv4 != "" {
+		allowAXFR = []string{srv.NS2IPv4}
+		alsoNotify = []string{srv.NS2IPv4}
+	}
+	allowAXFR = append(allowAXFR, "127.0.0.1")
+
+	pushCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := sharedAgent.Call(pushCtx, "dns.zone.upsert", map[string]any{
+		"zone":            zone.Name,
+		"records":         compiled,
+		"allow_axfr_from": allowAXFR,
+		"also_notify":     alsoNotify,
+	}); err != nil {
+		return fmt.Errorf("dns.zone.upsert %s: %w", zone.Name, err)
+	}
+	return nil
+}

--- a/panel-api/cmd/server/dns_acme_hook_cmd_test.go
+++ b/panel-api/cmd/server/dns_acme_hook_cmd_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeZoneByNameRepo struct {
+	repository.DNSZoneRepository
+	zones map[string]*models.DNSZone
+}
+
+func (f *fakeZoneByNameRepo) FindByName(_ context.Context, name string) (*models.DNSZone, error) {
+	if z, ok := f.zones[name]; ok {
+		return z, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func TestFindZoneForName_WalksParentChain(t *testing.T) {
+	repo := &fakeZoneByNameRepo{zones: map[string]*models.DNSZone{
+		"example.com": {ID: "Z1", Name: "example.com"},
+		"host.tld":    {ID: "Z2", Name: "host.tld"},
+	}}
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		wantID string
+	}{
+		// certbot passes CERTBOT_DOMAIN without the "*." for wildcards, so
+		// a *.example.com challenge arrives as "example.com".
+		{"example.com", "Z1"},
+		{"_acme-challenge.example.com", "Z1"},
+		{"preview.host.tld", "Z2"},
+		{"deep.sub.preview.host.tld", "Z2"},
+	}
+	for _, tc := range cases {
+		z, err := findZoneForName(ctx, repo, tc.name)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.name, err)
+			continue
+		}
+		if z.ID != tc.wantID {
+			t.Errorf("%s: matched zone %s, want %s", tc.name, z.ID, tc.wantID)
+		}
+	}
+}
+
+func TestFindZoneForName_RefusesForeignZone(t *testing.T) {
+	repo := &fakeZoneByNameRepo{zones: map[string]*models.DNSZone{}}
+	if _, err := findZoneForName(context.Background(), repo, "elsewhere.net"); err == nil {
+		t.Fatal("expected an error for a name with no local zone")
+	}
+}
+
+func TestAcmeChallengeName(t *testing.T) {
+	if got := acmeChallengeName("preview.host.tld"); got != "_acme-challenge.preview.host.tld" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -175,7 +175,7 @@ func newDNSCmd() *cobra.Command {
 			"validation and conflict rules. Records are written to the DB; the reconciler pushes\n" +
 			"them into PowerDNS on its next tick.",
 	}
-	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd())
+	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd(), newDNSAcmeHookCmd())
 	return cmd
 }
 

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4653,6 +4653,16 @@ paths:
       summary: List shared certificates
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
+  /admin/certificates/shared/acme:
+    post:
+      tags: [Ssl Certificates]
+      summary: Request an ACME DNS-01 shared wildcard certificate for a domain
+      description: >
+        Inserts a pending shared-certificate row with SANs [name, *.name];
+        the reconciler issues it via certbot DNS-01 against the local
+        PowerDNS. Requires the domain's DNS zone to be hosted on this panel.
+      security: [ { KratosSession: [] } ]
+      responses: { "202": { description: Accepted — issuance runs on the next reconcile tick } }
   /admin/certificates/shared/{id}:
     put:
       tags: [Ssl Certificates]

--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -34,6 +34,9 @@ type SSLHandlerConfig struct {
 	PanelCerts     repository.PanelCertificateRepository
 	MailCerts      repository.MailCertificateRepository
 	ServerSettings repository.ServerSettingsRepository
+	// DNSZones is optional — required only for the ACME DNS-01 shared-cert
+	// flow; nil degrades that endpoint to 503.
+	DNSZones repository.DNSZoneRepository
 	Reconciler     SSLScheduler
 	Config         *config.Config
 	Agent          agent.AgentInterface
@@ -85,6 +88,7 @@ func RegisterSSLRoutes(g *gin.RouterGroup, cfg SSLHandlerConfig) {
 	// Shared certificates (JAB-170): admin upload/list/delete of a
 	// wildcard/multi-SAN cert served from many domains.
 	g.POST("/admin/certificates/shared", middleware.RequireAdmin(), h.uploadSharedCert)
+	g.POST("/admin/certificates/shared/acme", middleware.RequireAdmin(), h.requestAcmeSharedCert)
 	g.GET("/admin/certificates/shared", middleware.RequireAdmin(), h.listSharedCerts)
 	g.PUT("/admin/certificates/shared/:id", middleware.RequireAdmin(), h.replaceSharedCert)
 	g.DELETE("/admin/certificates/shared/:id", middleware.RequireAdmin(), h.deleteSharedCert)

--- a/panel-api/internal/api/ssl_shared.go
+++ b/panel-api/internal/api/ssl_shared.go
@@ -30,6 +30,12 @@ type sharedCertView struct {
 	SANs            []string `json:"sans"`
 	ExpiresAt       string   `json:"expires_at,omitempty"`
 	AttachedDomains int64    `json:"attached_domains"`
+	// Source: 'uploaded' or 'acme'. ACME rows also surface issuance state:
+	// Pending (no cert yet), Staging, and the last failed attempt.
+	Source    string `json:"source"`
+	Pending   bool   `json:"pending"`
+	Staging   bool   `json:"staging,omitempty"`
+	LastError string `json:"last_error,omitempty"`
 }
 
 // uploadSharedCert validates + installs a server-wide shared cert. The agent
@@ -122,7 +128,16 @@ func (h *sslHandler) listSharedCerts(c *gin.Context) {
 	}
 	out := make([]sharedCertView, 0, len(certs))
 	for i := range certs {
-		v := sharedCertView{ID: certs[i].ID, Name: certs[i].Name}
+		v := sharedCertView{
+			ID:      certs[i].ID,
+			Name:    certs[i].Name,
+			Source:  certs[i].Source,
+			Pending: certs[i].Source == models.SharedCertSourceACME && certs[i].CertPath == nil,
+			Staging: certs[i].Staging,
+		}
+		if certs[i].LastError != nil {
+			v.LastError = *certs[i].LastError
+		}
 		if certs[i].SANs != nil {
 			_ = json.Unmarshal([]byte(*certs[i].SANs), &v.SANs)
 		}
@@ -157,7 +172,15 @@ func (h *sslHandler) deleteSharedCert(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	_, _ = h.cfg.Agent.Call(ctx, "ssl.delete_shared", map[string]any{"id": id})
+	if cert.Source == models.SharedCertSourceACME {
+		// ACME rows live as a certbot lineage, not the shared-certs dir.
+		// Revoke + delete the lineage (best-effort) so `certbot renew`
+		// stops renewing a cert nobody serves — its DNS hooks would keep
+		// writing challenge records forever.
+		_, _ = h.cfg.Agent.Call(ctx, "ssl.revoke", map[string]any{"domain": cert.ACMELineageName()})
+	} else {
+		_, _ = h.cfg.Agent.Call(ctx, "ssl.delete_shared", map[string]any{"id": id})
+	}
 	c.JSON(http.StatusOK, gin.H{"deleted": id})
 }
 

--- a/panel-api/internal/api/ssl_shared_acme.go
+++ b/panel-api/internal/api/ssl_shared_acme.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ssl_shared_acme.go — request a panel-ISSUED shared certificate via ACME
+// DNS-01 (wildcards), as opposed to the upload flow in ssl_shared.go.
+//
+// The handler only validates and inserts a pending row; the actual
+// certbot run happens on the reconciler's next tick (LE DNS-01 takes
+// tens of seconds — far too long to hold an HTTP request open against
+// the agent socket). The UI watches the shared-cert list for the row to
+// gain cert paths (issued) or a last_error.
+
+type sharedCertAcmeRequest struct {
+	// DomainID names the domain the wildcard should cover; the resulting
+	// SAN set is [name, *.name]. The domain's DNS zone must be hosted on
+	// this panel — DNS-01 places TXT records through the local pdns.
+	DomainID string `json:"domain_id"`
+	// Staging issues against the LE staging CA (untrusted; testing only).
+	Staging bool `json:"staging"`
+}
+
+func (h *sslHandler) requestAcmeSharedCert(c *gin.Context) {
+	if h.cfg.SharedCerts == nil || h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "unavailable"})
+		return
+	}
+	if h.cfg.DNSZones == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "dns_unavailable", "detail": "DNS module is not enabled — DNS-01 needs the domain's zone hosted here"})
+		return
+	}
+	var req sharedCertAcmeRequest
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.DomainID) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "domain_id_required"})
+		return
+	}
+	ctx := c.Request.Context()
+	domain, err := h.cfg.Domains.FindByID(ctx, req.DomainID)
+	if err != nil || domain == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+		return
+	}
+	zone, err := h.cfg.DNSZones.FindByDomainID(ctx, domain.ID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "dns_zone_not_local", "detail": "the domain's DNS zone is not hosted on this panel — DNS-01 cannot place the challenge record"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if !zone.IsEnabled {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "dns_zone_disabled"})
+		return
+	}
+	if h.cfg.ServerSettings != nil {
+		if srv, serr := h.cfg.ServerSettings.Get(ctx); serr != nil || srv == nil || strings.TrimSpace(srv.AdminEmail) == "" {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "admin_email_required", "detail": "set the admin email in server settings — Let's Encrypt requires a contact address"})
+			return
+		}
+	}
+
+	sans := []string{domain.Name, "*." + domain.Name}
+	sansBytes, _ := json.Marshal(sans)
+	sansJSON := string(sansBytes)
+	now := time.Now().UTC()
+	owner := domain.UserID
+	cert := &models.SharedCertificate{
+		ID:        ids.NewULID(),
+		Name:      "*." + domain.Name,
+		UserID:    &owner,
+		SANs:      &sansJSON,
+		Source:    models.SharedCertSourceACME,
+		Staging:   req.Staging,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := h.cfg.SharedCerts.Create(ctx, cert); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{
+		"id":     cert.ID,
+		"name":   cert.Name,
+		"sans":   sans,
+		"source": cert.Source,
+		"status": "pending",
+		"detail": "issuance runs on the next reconcile tick; watch the shared-certificates list",
+	})
+}

--- a/panel-api/internal/api/ssl_shared_acme_test.go
+++ b/panel-api/internal/api/ssl_shared_acme_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type acmeTestDomainRepo struct {
+	repository.DomainRepository
+	byID map[string]*models.Domain
+}
+
+func (r *acmeTestDomainRepo) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	if d, ok := r.byID[id]; ok {
+		return d, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type acmeTestZoneRepo struct {
+	repository.DNSZoneRepository
+	byDomainID map[string]*models.DNSZone
+}
+
+func (r *acmeTestZoneRepo) FindByDomainID(_ context.Context, domainID string) (*models.DNSZone, error) {
+	if z, ok := r.byDomainID[domainID]; ok {
+		return z, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type acmeTestSettingsRepo struct {
+	repository.ServerSettingsRepository
+	srv *models.ServerSettings
+}
+
+func (r *acmeTestSettingsRepo) Get(_ context.Context) (*models.ServerSettings, error) {
+	return r.srv, nil
+}
+
+func acmeTestHandler(zones repository.DNSZoneRepository, shared *fakeSharedRepo) *sslHandler {
+	return &sslHandler{cfg: SSLHandlerConfig{
+		Domains: &acmeTestDomainRepo{byID: map[string]*models.Domain{
+			"D1": {ID: "D1", Name: "example.com", UserID: "U1"},
+		}},
+		SharedCerts:    shared,
+		DNSZones:       zones,
+		Agent:          &fakeSharedAgent{},
+		ServerSettings: &acmeTestSettingsRepo{srv: &models.ServerSettings{AdminEmail: "admin@host.tld"}},
+	}}
+}
+
+func postAcme(t *testing.T, h *sslHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/api/v1/admin/certificates/shared/acme", bytes.NewReader([]byte(body)))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.requestAcmeSharedCert(c)
+	return w
+}
+
+func TestRequestAcmeSharedCert_CreatesPendingRow(t *testing.T) {
+	shared := &fakeSharedRepo{}
+	zones := &acmeTestZoneRepo{byDomainID: map[string]*models.DNSZone{
+		"D1": {ID: "Z1", DomainID: "D1", Name: "example.com", IsEnabled: true},
+	}}
+	w := postAcme(t, acmeTestHandler(zones, shared), `{"domain_id":"D1"}`)
+
+	require.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+	require.Len(t, shared.created, 1)
+	row := shared.created[0]
+	require.Equal(t, models.SharedCertSourceACME, row.Source)
+	require.Equal(t, "*.example.com", row.Name)
+	require.NotNil(t, row.UserID)
+	require.Equal(t, "U1", *row.UserID)
+	require.Nil(t, row.CertPath, "row must be pending — issuance happens on the reconcile tick")
+
+	var sans []string
+	require.NotNil(t, row.SANs)
+	require.NoError(t, json.Unmarshal([]byte(*row.SANs), &sans))
+	require.Equal(t, []string{"example.com", "*.example.com"}, sans)
+}
+
+func TestRequestAcmeSharedCert_RefusesForeignZone(t *testing.T) {
+	shared := &fakeSharedRepo{}
+	zones := &acmeTestZoneRepo{byDomainID: map[string]*models.DNSZone{}}
+	w := postAcme(t, acmeTestHandler(zones, shared), `{"domain_id":"D1"}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code, w.Body.String())
+	require.Contains(t, w.Body.String(), "dns_zone_not_local")
+	require.Empty(t, shared.created)
+}
+
+func TestRequestAcmeSharedCert_NilZonesRepoDegrades(t *testing.T) {
+	shared := &fakeSharedRepo{}
+	w := postAcme(t, acmeTestHandler(nil, shared), `{"domain_id":"D1"}`)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestRequestAcmeSharedCert_RequiresAdminEmail(t *testing.T) {
+	shared := &fakeSharedRepo{}
+	zones := &acmeTestZoneRepo{byDomainID: map[string]*models.DNSZone{
+		"D1": {ID: "Z1", DomainID: "D1", Name: "example.com", IsEnabled: true},
+	}}
+	h := acmeTestHandler(zones, shared)
+	h.cfg.ServerSettings = &acmeTestSettingsRepo{srv: &models.ServerSettings{}}
+	w := postAcme(t, h, `{"domain_id":"D1"}`)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	require.Contains(t, w.Body.String(), "admin_email_required")
+}

--- a/panel-api/internal/api/ssl_shared_test.go
+++ b/panel-api/internal/api/ssl_shared_test.go
@@ -109,6 +109,13 @@ func (r *fakeSharedRepo) CountAttachedDomains(_ context.Context, id string) (int
 func (r *fakeSharedRepo) ListExpiring(_ context.Context, _ time.Time) ([]models.SharedCertificate, error) {
 	return nil, nil
 }
+func (r *fakeSharedRepo) ListACMEDue(_ context.Context, _ time.Time) ([]models.SharedCertificate, error) {
+	return nil, nil
+}
+func (r *fakeSharedRepo) MarkACMEAttempt(_ context.Context, _ string, _ *string) error { return nil }
+func (r *fakeSharedRepo) UpdateACMEIssued(_ context.Context, _, _, _, _ string, _ time.Time, _ bool) error {
+	return nil
+}
 
 // JAB-170 phase 4: upload validates + installs, stores the parsed SANs + expiry.
 func TestUploadSharedCert(t *testing.T) {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -843,6 +843,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Domains:        deps.Domains,
 				SSLCerts:       deps.SSLCerts,
 				SharedCerts:    deps.SharedCerts,
+				DNSZones:       deps.DNSZones,
 				Agent:          deps.Agent,
 				PanelCerts:     deps.PanelCerts,
 				MailCerts:      deps.MailCerts,

--- a/panel-api/internal/db/migrations/000242_shared_cert_acme_source.down.sql
+++ b/panel-api/internal/db/migrations/000242_shared_cert_acme_source.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE shared_certificates
+  DROP COLUMN source,
+  DROP COLUMN last_error,
+  DROP COLUMN staging,
+  DROP COLUMN last_attempt_at;

--- a/panel-api/internal/db/migrations/000242_shared_cert_acme_source.up.sql
+++ b/panel-api/internal/db/migrations/000242_shared_cert_acme_source.up.sql
@@ -1,0 +1,13 @@
+-- DNS-01 wildcard issuance for shared certificates (preview URLs + tenant
+-- wildcards). `source` records how the cert material came to exist:
+--   'uploaded' — operator pasted cert+key (JAB-170 original flow)
+--   'acme'     — panel issued it via certbot DNS-01; renewals are driven
+--                by certbot (hooks persisted in the renewal conf) with a
+--                daily panel sweep syncing row expiry from disk.
+-- last_error surfaces the most recent failed ACME attempt; staging marks
+-- Let's Encrypt staging-CA certs so the UI can badge them as untrusted.
+ALTER TABLE shared_certificates
+  ADD COLUMN source varchar(16) NOT NULL DEFAULT 'uploaded',
+  ADD COLUMN last_error text NULL,
+  ADD COLUMN staging tinyint(1) NOT NULL DEFAULT 0,
+  ADD COLUMN last_attempt_at datetime(6) NULL;

--- a/panel-api/internal/models/shared_certificate.go
+++ b/panel-api/internal/models/shared_certificate.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // SharedCertificate is a wildcard / multi-SAN TLS certificate uploaded once and
 // served from MANY domains (JAB-170), instead of re-uploading the same cert per
@@ -20,10 +23,39 @@ type SharedCertificate struct {
 	KeyPath  *string `gorm:"type:varchar(512)"                              json:"key_path,omitempty"`
 	// SANs is a JSON array of the certificate's Subject Alternative Names,
 	// parsed at upload and used for wildcard-aware attach matching.
-	SANs      *string    `gorm:"column:sans;type:text"                          json:"sans,omitempty"`
+	SANs *string `gorm:"column:sans;type:text"                          json:"sans,omitempty"`
+	// Source distinguishes operator-uploaded material ('uploaded') from
+	// panel-issued ACME DNS-01 certs ('acme'). ACME rows renew via
+	// certbot; uploaded rows only warn on expiry.
+	Source string `gorm:"type:varchar(16);not null;default:'uploaded'"   json:"source"`
+	// LastError holds the most recent failed ACME attempt, cleared on
+	// success. Always nil for uploaded certs.
+	LastError *string `gorm:"type:text"                                      json:"last_error,omitempty"`
+	// Staging marks a Let's Encrypt staging-CA cert (untrusted by
+	// browsers — issued that way for testing only).
+	Staging bool `gorm:"type:tinyint(1);not null;default:0"             json:"staging"`
+	// LastAttemptAt is the most recent ACME issue/renew attempt (success
+	// or failure) — the reconciler's backoff anchor. Nil until first try.
+	LastAttemptAt *time.Time `gorm:"type:datetime(6)"                              json:"last_attempt_at,omitempty"`
 	ExpiresAt *time.Time `gorm:"type:datetime(6);index:ix_shared_cert_expires"  json:"expires_at,omitempty"`
 	CreatedAt time.Time  `gorm:"type:datetime(6);not null"                      json:"created_at"`
 	UpdatedAt time.Time  `gorm:"type:datetime(6);not null"                      json:"updated_at"`
 }
+
+// ACMELineageName is the certbot --cert-name for this row: certbot
+// forbids '*' in lineage names, so "*.example.com" pins as
+// "wildcard.example.com". Non-wildcard names pass through.
+func (c *SharedCertificate) ACMELineageName() string {
+	if strings.HasPrefix(c.Name, "*.") {
+		return "wildcard." + strings.TrimPrefix(c.Name, "*.")
+	}
+	return c.Name
+}
+
+// SharedCertificate.Source values.
+const (
+	SharedCertSourceUploaded = "uploaded"
+	SharedCertSourceACME     = "acme"
+)
 
 func (SharedCertificate) TableName() string { return "shared_certificates" }

--- a/panel-api/internal/reconciler/acme_shared_certs.go
+++ b/panel-api/internal/reconciler/acme_shared_certs.go
@@ -1,0 +1,118 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// ACME DNS-01 shared-certificate issuance (wildcards).
+//
+// The HTTP handler only inserts a pending shared_certificates row
+// (source='acme', cert_path NULL) — a Let's Encrypt DNS-01 round trip
+// takes tens of seconds, which belongs on the reconcile loop, not in an
+// open HTTP request. This sweep drives every due row through the agent's
+// ssl.issue_dns01, which runs certbot with the panel's acme-hook writing
+// the _acme-challenge TXT records through the panel DNS tables.
+//
+// Renewals: certbot persists the manual hooks in the renewal conf, so
+// `certbot renew` (systemd timer) renews the lineage on its own. This
+// sweep re-issues as a belt-and-braces path when a cert still nears
+// expiry (timer missing or broken) — --keep-until-expiring makes the
+// overlap harmless — and refreshes the row's expiry either way.
+const (
+	// acmeSharedRenewWindow: rows expiring within this window count as due.
+	acmeSharedRenewWindow = 30 * 24 * time.Hour
+	// acmeSharedRetryBackoff throttles retries of failed first issuance.
+	acmeSharedRetryBackoff = 15 * time.Minute
+	// acmeSharedRenewBackoff throttles renewal attempts of issued certs.
+	acmeSharedRenewBackoff = 24 * time.Hour
+	// acmeSharedIssueTimeout bounds one certbot DNS-01 run: two hook
+	// invocations with settle sleeps per name, plus LE's validation poll.
+	acmeSharedIssueTimeout = 4 * time.Minute
+)
+
+func (r *Reconciler) reconcileAcmeSharedCerts(ctx context.Context) {
+	if r.sharedCerts == nil || r.agent == nil || r.serverSettings == nil {
+		return
+	}
+	due, err := r.sharedCerts.ListACMEDue(ctx, time.Now().Add(acmeSharedRenewWindow))
+	if err != nil {
+		r.log.Error("acme shared certs: list due failed", "err", err)
+		return
+	}
+	if len(due) == 0 {
+		return
+	}
+	srv, err := r.serverSettings.Get(ctx)
+	if err != nil || srv == nil || strings.TrimSpace(srv.AdminEmail) == "" {
+		r.log.Warn("acme shared certs: due rows exist but no admin email is set — cannot issue")
+		return
+	}
+
+	now := time.Now()
+	for i := range due {
+		cert := &due[i]
+		// Backoff. First issuance retries every acmeSharedRetryBackoff;
+		// renewals once per acmeSharedRenewBackoff.
+		if cert.LastAttemptAt != nil {
+			wait := acmeSharedRetryBackoff
+			if cert.CertPath != nil {
+				wait = acmeSharedRenewBackoff
+			}
+			if now.Sub(*cert.LastAttemptAt) < wait {
+				continue
+			}
+		}
+		var sans []string
+		if cert.SANs == nil || json.Unmarshal([]byte(*cert.SANs), &sans) != nil || len(sans) == 0 {
+			msg := "row has no usable SAN list"
+			_ = r.sharedCerts.MarkACMEAttempt(ctx, cert.ID, &msg)
+			r.log.Error("acme shared certs: unusable SANs", "id", cert.ID, "name", cert.Name)
+			continue
+		}
+
+		issueCtx, cancel := context.WithTimeout(ctx, acmeSharedIssueTimeout)
+		raw, err := r.agent.Call(issueCtx, "ssl.issue_dns01", map[string]any{
+			"cert_name": cert.ACMELineageName(),
+			"sans":      sans,
+			"email":     srv.AdminEmail,
+			"staging":   cert.Staging,
+		})
+		cancel()
+		if err != nil {
+			msg := err.Error()
+			if len(msg) > 2048 {
+				msg = msg[:2048]
+			}
+			_ = r.sharedCerts.MarkACMEAttempt(ctx, cert.ID, &msg)
+			r.log.Warn("acme shared certs: issue failed", "id", cert.ID, "name", cert.Name, "err", err)
+			continue
+		}
+		var res struct {
+			CertPath  string `json:"cert_path"`
+			KeyPath   string `json:"key_path"`
+			ExpiresAt string `json:"expires_at"`
+		}
+		if jerr := json.Unmarshal(raw, &res); jerr != nil || res.CertPath == "" {
+			msg := "agent returned an unusable ssl.issue_dns01 response"
+			_ = r.sharedCerts.MarkACMEAttempt(ctx, cert.ID, &msg)
+			r.log.Error("acme shared certs: bad agent response", "id", cert.ID, "err", jerr)
+			continue
+		}
+		expiresAt := time.Now().Add(90 * 24 * time.Hour)
+		if t, perr := time.Parse(time.RFC3339, res.ExpiresAt); perr == nil {
+			expiresAt = t
+		}
+		sansJSON := ""
+		if cert.SANs != nil {
+			sansJSON = *cert.SANs
+		}
+		if uerr := r.sharedCerts.UpdateACMEIssued(ctx, cert.ID, res.CertPath, res.KeyPath, sansJSON, expiresAt, cert.Staging); uerr != nil {
+			r.log.Error("acme shared certs: record issued cert failed", "id", cert.ID, "err", uerr)
+			continue
+		}
+		r.log.Info("acme shared certs: issued", "id", cert.ID, "name", cert.Name, "expires_at", expiresAt.UTC().Format(time.RFC3339))
+	}
+}

--- a/panel-api/internal/reconciler/acme_shared_certs_test.go
+++ b/panel-api/internal/reconciler/acme_shared_certs_test.go
@@ -1,0 +1,167 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeAcmeSharedRepo struct {
+	repository.SharedCertificateRepository
+	due      []models.SharedCertificate
+	issued   map[string]string // id -> cert_path recorded via UpdateACMEIssued
+	attempts map[string]string // id -> last error message ("" = cleared)
+}
+
+func newFakeAcmeSharedRepo(due ...models.SharedCertificate) *fakeAcmeSharedRepo {
+	return &fakeAcmeSharedRepo{due: due, issued: map[string]string{}, attempts: map[string]string{}}
+}
+
+func (f *fakeAcmeSharedRepo) ListACMEDue(_ context.Context, _ time.Time) ([]models.SharedCertificate, error) {
+	return f.due, nil
+}
+func (f *fakeAcmeSharedRepo) MarkACMEAttempt(_ context.Context, id string, errMsg *string) error {
+	if errMsg == nil {
+		f.attempts[id] = ""
+	} else {
+		f.attempts[id] = *errMsg
+	}
+	return nil
+}
+func (f *fakeAcmeSharedRepo) UpdateACMEIssued(_ context.Context, id, certPath, _, _ string, _ time.Time, _ bool) error {
+	f.issued[id] = certPath
+	return nil
+}
+
+type fakeSettingsRepo struct {
+	repository.ServerSettingsRepository
+	srv *models.ServerSettings
+}
+
+func (f *fakeSettingsRepo) Get(_ context.Context) (*models.ServerSettings, error) {
+	return f.srv, nil
+}
+
+type fakeDNS01Agent struct {
+	calls []map[string]any
+	fail  bool
+}
+
+func (f *fakeDNS01Agent) Call(_ context.Context, method string, params interface{}) (json.RawMessage, error) {
+	if method != "ssl.issue_dns01" {
+		return nil, nil
+	}
+	m, _ := params.(map[string]any)
+	f.calls = append(f.calls, m)
+	if f.fail {
+		return nil, fmt.Errorf("dns-01 issue failed (dns): no local zone")
+	}
+	return json.Marshal(map[string]any{
+		"cert_path":  "/etc/letsencrypt/live/wildcard.example.com/fullchain.pem",
+		"key_path":   "/etc/letsencrypt/live/wildcard.example.com/privkey.pem",
+		"expires_at": time.Now().Add(90 * 24 * time.Hour).Format(time.RFC3339),
+	})
+}
+
+func strPtr(s string) *string { return &s }
+
+func acmeRow(id string, lastAttempt *time.Time, certPath *string) models.SharedCertificate {
+	return models.SharedCertificate{
+		ID:            id,
+		Name:          "*.example.com",
+		Source:        models.SharedCertSourceACME,
+		SANs:          strPtr(`["example.com","*.example.com"]`),
+		LastAttemptAt: lastAttempt,
+		CertPath:      certPath,
+	}
+}
+
+func testReconcilerFor(repo repository.SharedCertificateRepository, ag *fakeDNS01Agent) *Reconciler {
+	return &Reconciler{
+		sharedCerts:    repo,
+		agent:          ag,
+		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{AdminEmail: "admin@example.com"}},
+		log:            slog.New(slog.DiscardHandler),
+	}
+}
+
+func TestReconcileAcmeSharedCerts_IssuesPendingRow(t *testing.T) {
+	repo := newFakeAcmeSharedRepo(acmeRow("C1", nil, nil))
+	ag := &fakeDNS01Agent{}
+	r := testReconcilerFor(repo, ag)
+
+	r.reconcileAcmeSharedCerts(context.Background())
+
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	call := ag.calls[0]
+	if call["cert_name"] != "wildcard.example.com" {
+		t.Errorf("cert_name = %v — certbot forbids '*' in lineage names", call["cert_name"])
+	}
+	sans, _ := call["sans"].([]string)
+	if len(sans) != 2 || sans[1] != "*.example.com" {
+		t.Errorf("sans = %v, want [example.com *.example.com]", call["sans"])
+	}
+	if repo.issued["C1"] == "" {
+		t.Error("successful issue was not recorded via UpdateACMEIssued")
+	}
+}
+
+func TestReconcileAcmeSharedCerts_FailureRecordsError(t *testing.T) {
+	repo := newFakeAcmeSharedRepo(acmeRow("C1", nil, nil))
+	ag := &fakeDNS01Agent{fail: true}
+	r := testReconcilerFor(repo, ag)
+
+	r.reconcileAcmeSharedCerts(context.Background())
+
+	if repo.attempts["C1"] == "" {
+		t.Error("failed issue must record last_error via MarkACMEAttempt")
+	}
+	if len(repo.issued) != 0 {
+		t.Error("nothing should be recorded as issued on failure")
+	}
+}
+
+func TestReconcileAcmeSharedCerts_BackoffSkipsRecentFailure(t *testing.T) {
+	recent := time.Now().Add(-time.Minute)
+	repo := newFakeAcmeSharedRepo(acmeRow("C1", &recent, nil))
+	ag := &fakeDNS01Agent{}
+	r := testReconcilerFor(repo, ag)
+
+	r.reconcileAcmeSharedCerts(context.Background())
+
+	if len(ag.calls) != 0 {
+		t.Errorf("row attempted %v ago must wait out the %v backoff", time.Minute, acmeSharedRetryBackoff)
+	}
+}
+
+func TestReconcileAcmeSharedCerts_RenewalUsesLongerBackoff(t *testing.T) {
+	attempt := time.Now().Add(-2 * time.Hour) // past retry backoff, inside renew backoff
+	repo := newFakeAcmeSharedRepo(acmeRow("C1", &attempt, strPtr("/etc/letsencrypt/live/wildcard.example.com/fullchain.pem")))
+	ag := &fakeDNS01Agent{}
+	r := testReconcilerFor(repo, ag)
+
+	r.reconcileAcmeSharedCerts(context.Background())
+
+	if len(ag.calls) != 0 {
+		t.Error("issued cert attempted 2h ago must respect the 24h renewal backoff")
+	}
+}
+
+func TestAcmeCertLineageName(t *testing.T) {
+	c := models.SharedCertificate{Name: "*.example.com"}
+	if got := c.ACMELineageName(); got != "wildcard.example.com" {
+		t.Errorf("got %q", got)
+	}
+	c.Name = "preview-cert.host.tld"
+	if got := c.ACMELineageName(); got != "preview-cert.host.tld" {
+		t.Errorf("non-wildcard name must pass through, got %q", got)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -887,6 +887,9 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	r.reconcileDockerApps(ctx)
 	r.reconcilePythonApps(ctx)
 	r.checkSharedCertExpiry(ctx)
+	// Drive pending/renewing ACME shared certs (DNS-01 wildcards)
+	// through the agent — see acme_shared_certs.go.
+	r.reconcileAcmeSharedCerts(ctx)
 
 	r.reconcileSSHKeysForAllUsers(ctx)
 	// Reconcile SSH keys: sync authorized_keys files for all users.

--- a/panel-api/internal/repository/shared_certificate_repository.go
+++ b/panel-api/internal/repository/shared_certificate_repository.go
@@ -32,6 +32,14 @@ type SharedCertificateRepository interface {
 	// CountAttachedDomains reports how many domains currently point at this cert
 	// (so delete can refuse to strand attached domains).
 	CountAttachedDomains(ctx context.Context, id string) (int64, error)
+	// ListACMEDue returns source='acme' rows that need certbot work: never
+	// issued (cert_path NULL) or expiring before renewBefore. Oldest first.
+	ListACMEDue(ctx context.Context, renewBefore time.Time) ([]models.SharedCertificate, error)
+	// MarkACMEAttempt stamps last_attempt_at=now and records the failure
+	// (nil errMsg clears last_error).
+	MarkACMEAttempt(ctx context.Context, id string, errMsg *string) error
+	// UpdateACMEIssued records a successful DNS-01 issuance.
+	UpdateACMEIssued(ctx context.Context, id, certPath, keyPath, sansJSON string, expiresAt time.Time, staging bool) error
 }
 
 type sharedCertificateRepo struct{ db *gorm.DB }
@@ -80,6 +88,37 @@ func (r *sharedCertificateRepo) UpdateInstalled(ctx context.Context, id, certPat
 		"sans":       sansJSON,
 		"expires_at": expiresAt,
 		"updated_at": time.Now().UTC(),
+	}).Error
+}
+
+func (r *sharedCertificateRepo) ListACMEDue(ctx context.Context, renewBefore time.Time) ([]models.SharedCertificate, error) {
+	var cs []models.SharedCertificate
+	err := r.db.WithContext(ctx).
+		Where("source = ?", models.SharedCertSourceACME).
+		Where("cert_path IS NULL OR expires_at < ?", renewBefore).
+		Order("created_at ASC").
+		Find(&cs).Error
+	return cs, err
+}
+
+func (r *sharedCertificateRepo) MarkACMEAttempt(ctx context.Context, id string, errMsg *string) error {
+	return r.db.WithContext(ctx).Model(&models.SharedCertificate{}).Where("id = ?", id).Updates(map[string]any{
+		"last_attempt_at": time.Now().UTC(),
+		"last_error":      errMsg,
+		"updated_at":      time.Now().UTC(),
+	}).Error
+}
+
+func (r *sharedCertificateRepo) UpdateACMEIssued(ctx context.Context, id, certPath, keyPath, sansJSON string, expiresAt time.Time, staging bool) error {
+	return r.db.WithContext(ctx).Model(&models.SharedCertificate{}).Where("id = ?", id).Updates(map[string]any{
+		"cert_path":       certPath,
+		"key_path":        keyPath,
+		"sans":            sansJSON,
+		"expires_at":      expiresAt,
+		"staging":         staging,
+		"last_error":      nil,
+		"last_attempt_at": time.Now().UTC(),
+		"updated_at":      time.Now().UTC(),
 	}).Error
 }
 

--- a/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
+++ b/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Modal,
   Popconfirm,
+  Select,
   Space,
   Table,
   Tag,
@@ -18,7 +19,7 @@ import {
   message,
 } from "antd";
 import type { UploadFile } from "antd";
-import { DeleteOutlined, PlusOutlined, UploadOutlined } from "@icons";
+import { DeleteOutlined, PlusOutlined, SafetyCertificateOutlined, UploadOutlined } from "@icons";
 
 import { apiClient } from "../../apiClient";
 
@@ -34,6 +35,15 @@ interface SharedCert {
   sans: string[];
   expires_at?: string;
   attached_domains: number;
+  source?: "uploaded" | "acme";
+  pending?: boolean;
+  staging?: boolean;
+  last_error?: string;
+}
+
+interface DomainOption {
+  id: string;
+  name: string;
 }
 
 const daysUntil = (iso?: string): number | null => {
@@ -79,12 +89,47 @@ export const SharedCertificatesCard = () => {
   const [name, setName] = useState("");
   const [certPem, setCertPem] = useState("");
   const [keyPem, setKeyPem] = useState("");
+  const [acmeOpen, setAcmeOpen] = useState(false);
+  const [acmeDomainId, setAcmeDomainId] = useState<string>();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["shared-certificates"],
     queryFn: async () => {
       const res = await apiClient.get("/admin/certificates/shared");
       return (res.data?.data ?? []) as SharedCert[];
+    },
+    // Poll while an ACME row is still issuing (the reconciler drives the
+    // certbot run); stop once nothing is pending.
+    refetchInterval: (q) => {
+      const rows = q.state.data as SharedCert[] | undefined;
+      return rows?.some((r) => r.pending) ? 10_000 : false;
+    },
+  });
+
+  const domainsQuery = useQuery({
+    queryKey: ["shared-cert-acme-domains"],
+    enabled: acmeOpen,
+    queryFn: async () => {
+      const res = await apiClient.get("/domains?page_size=500");
+      return (res.data?.data ?? []) as DomainOption[];
+    },
+  });
+
+  const acmeMutation = useMutation({
+    mutationFn: async () => {
+      await apiClient.post("/admin/certificates/shared/acme", {
+        domain_id: acmeDomainId,
+      });
+    },
+    onSuccess: () => {
+      message.success("Wildcard certificate requested — issuance runs within a minute");
+      setAcmeOpen(false);
+      setAcmeDomainId(undefined);
+      queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
+    },
+    onError: (err: unknown) => {
+      const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
+      message.error(resp?.detail ?? resp?.error ?? "Failed to request certificate");
     },
   });
 
@@ -177,6 +222,22 @@ export const SharedCertificatesCard = () => {
       },
     },
     {
+      title: "Status",
+      key: "status",
+      render: (_: unknown, r: SharedCert) => {
+        if (r.source !== "acme") return <Tag>Uploaded</Tag>;
+        if (r.last_error) {
+          return (
+            <Tooltip title={r.last_error}>
+              <Tag color="red">Issue failed</Tag>
+            </Tooltip>
+          );
+        }
+        if (r.pending) return <Tag color="processing">Issuing…</Tag>;
+        return <Tag color="green">{r.staging ? "Let's Encrypt (staging)" : "Let's Encrypt"}</Tag>;
+      },
+    },
+    {
       title: "Expires",
       dataIndex: "expires_at",
       key: "expires_at",
@@ -219,9 +280,14 @@ export const SharedCertificatesCard = () => {
     <Card
       title={t("sharedcertificates.title")}
       extra={
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
-          Upload shared certificate
-        </Button>
+        <Space>
+          <Button icon={<SafetyCertificateOutlined />} onClick={() => setAcmeOpen(true)}>
+            Request wildcard (Let&apos;s Encrypt)
+          </Button>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+            Upload shared certificate
+          </Button>
+        </Space>
       }
     >
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
@@ -247,6 +313,38 @@ export const SharedCertificatesCard = () => {
           scroll={{ x: "max-content" }}
         />
       )}
+
+      <Modal
+        open={acmeOpen}
+        title="Request wildcard certificate"
+        okText="Request"
+        okButtonProps={{ disabled: !acmeDomainId }}
+        confirmLoading={acmeMutation.isPending}
+        onOk={() => acmeMutation.mutate()}
+        onCancel={() => {
+          setAcmeOpen(false);
+          setAcmeDomainId(undefined);
+        }}
+        destroyOnClose
+      >
+        <Space direction="vertical" style={{ width: "100%" }}>
+          <Alert
+            type="info"
+            showIcon
+            message="Issues a Let's Encrypt certificate covering the domain and *.domain via DNS-01. The domain's DNS zone must be hosted on this server — the challenge record is placed in the local PowerDNS."
+          />
+          <Select
+            style={{ width: "100%" }}
+            placeholder="Select a domain"
+            showSearch
+            optionFilterProp="label"
+            loading={domainsQuery.isLoading}
+            value={acmeDomainId}
+            onChange={setAcmeDomainId}
+            options={(domainsQuery.data ?? []).map((d) => ({ value: d.id, label: d.name }))}
+          />
+        </Space>
+      </Modal>
 
       <Modal
         open={uploadOpen}

--- a/panel-ui/src/icons/index.tsx
+++ b/panel-ui/src/icons/index.tsx
@@ -226,6 +226,7 @@ export const LogoutOutlined = shim(LogOut);
 export const MenuOutlined = shim(Menu);
 export const MoreOutlined = shim(MoreHorizontal);
 export const PoweroffOutlined = shim(Power);
+export const SafetyCertificateOutlined = shim(ShieldCheck);
 export const SafetyOutlined = shim(ShieldCheck);
 export const ShieldCheckOutlined = shim(ShieldCheck);
 export const CalendarCheckOutlined = shim(CalendarCheck);

--- a/plans/preview-url-wildcard-dns01.md
+++ b/plans/preview-url-wildcard-dns01.md
@@ -1,0 +1,71 @@
+# Preview URLs + DNS-01 wildcard certificates
+
+User decisions (2026-08-01):
+- Temp URL shape: `<slug>.preview.<hostname>` (slug = domain name, dots→dashes)
+- Per-domain **opt-in** toggle (default OFF)
+- TLS: **one wildcard cert** `*.preview.<hostname>` via DNS-01
+- DNS-01/wildcard plumbing must be **generic** — regular tenant domains can
+  also request `*.<domain>` certs (their zone must be served by this panel's pdns)
+
+## Existing machinery this builds on
+
+- `shared_certificates` (JAB-170): wildcard/multi-SAN cert stored once, attached
+  to many domains via `domains.ssl_mode='shared'` + `shared_certificate_id`.
+  Today upload-only. Vhost render for attached domains already ships.
+- pdns self-zone for `<hostname>` seeded at install (`bootstrap_pdns_self_zone`),
+  panel-primary domain row + reconciler already write records into it.
+- Agent certbot runner (`panel-agent/internal/certbot/runner.go`) — HTTP-01
+  webroot only today; SAN-expand + lineage pinning already handled.
+- `checkSharedCertExpiry` reconciler pass — warns on expiry today.
+- Scars to honour: pdns cache purge after backend writes; GORM bool default:1
+  trap (opt-in default-false is zero-value-safe); delete-cascade parity via the
+  shared agent `domain.delete`; wire-contract verification for new UI fields;
+  per-tick idempotent reconciler steps.
+
+## PR 1 — DNS-01 plumbing + ACME shared certs (generic wildcard)
+
+1. **ACME DNS hook** (panel binary subcommand, invoked by certbot as root):
+   `jabali-panel dns acme-hook auth|cleanup` reading `CERTBOT_DOMAIN` /
+   `CERTBOT_VALIDATION` env. Writes/removes TXT `_acme-challenge.<domain>` in
+   the pdns records table, purges pdns cache, short settle wait. Refuses
+   domains whose zone is not served locally.
+2. **Agent RPC** `ssl.issue_dns01` (or `challenge:"dns-01"` param on the
+   existing issue command): runs
+   `certbot certonly --manual --preferred-challenges dns
+    --manual-auth-hook <hook> --manual-cleanup-hook <hook>` with the SAN list
+   (supports `*.name`). Lineage pinned like HTTP-01. Renewal conf keeps the
+   hooks, so `certbot renew` keeps working.
+3. **SharedCertificate gains `source`** (`uploaded` | `acme`) + issue flow:
+   admin/tenant "Request wildcard cert (*.domain)" → panel validates the zone
+   is local → agent DNS-01 issue → row stores paths/SANs/expiry.
+   `checkSharedCertExpiry`: for `source=acme`, trigger renew via agent instead
+   of only warning.
+4. Attach/detach + vhost render: unchanged (JAB-170 path).
+
+## PR 2 — Preview URLs
+
+1. **Server-side bootstrap (lazy, on first enable)**: wildcard `A`/`AAAA`
+   `*.preview.<hostname>` in the self-zone + one server-wide shared cert row
+   (`UserID NULL`, `source=acme`, SAN `*.preview.<hostname>`) issued via PR 1
+   machinery.
+2. **Per-domain**: `domains.temp_url_enabled` (tinyint, default 0, opt-in).
+   Reconciler/domain.create payload gains `preview_host` + preview cert paths.
+3. **Agent**: renders an extra server block per enabled domain —
+   `server_name <slug>.preview.<hostname>`, same docroot + PHP pool socket,
+   TLS from the shared preview cert, HTTP→HTTPS redirect. Content-hash gated.
+   Teardown in shared `domain.delete` + on toggle-off.
+4. **UI**: toggle in domain create drawer + settings drawer; copy-chip with the
+   preview URL in the domain lists.
+5. **Caveats (docs)**: WordPress canonical-redirects away from the preview
+   host; preview only resolves publicly when the hostname zone is delegated to
+   this server; cookie-scope note (tenant preview sites share the hostname's
+   registrable domain — panel session cookie must stay host-only).
+
+## Verification
+
+- Unit: hook TXT write/remove + zone-locality refusal; certbot arg construction
+  (SAN with wildcard, hooks present, no webroot); shared-cert source lifecycle;
+  agent preview-block render golden.
+- Box (testserver): issue `*.preview.<hostname>` end-to-end (LE staging first),
+  enable preview on a real domain, curl the preview URL over HTTPS pre-cutover.
+- `dig` + pdns check-zone after record writes (SRV-priority scar).


### PR DESCRIPTION
Part 1 of the temporary/preview-URL feature (plan: `plans/preview-url-wildcard-dns01.md`): generic DNS-01 plumbing so the panel can issue **wildcard** certificates — usable today for regular domains, and the foundation `*.preview.<hostname>` builds on in part 2.

## What's here

**DNS-01 challenge plumbing**
- `certbot` runner gains `IssueDNS01` (manual authenticator, `--manual-auth-hook`/`--manual-cleanup-hook`, lineage pinned to a sanitized name since certbot forbids `*` in `--cert-name`). Hooks persist into the renewal conf, so plain `certbot renew` renews unattended.
- New agent RPC `ssl.issue_dns01` (wildcard-aware SAN validation — at most one leading `*.` label).
- New hidden CLI `jabali dns acme-hook auth|cleanup` — what certbot invokes. It writes the `_acme-challenge` TXT row **through the panel `dns_records` table** (`managed_by=acme-dns01`) and pushes the zone via the agent's `dns.zone.upsert`. DB-as-truth holds: a reconcile tick firing between hook and LE validation re-pushes the same record set instead of wiping the challenge. Names with no locally-hosted zone are refused with a clear error.

**Shared certificates (JAB-170) learn to self-issue**
- `shared_certificates` gains `source` (`uploaded`|`acme`), `staging`, `last_error`, `last_attempt_at` (migration `000242`).
- `POST /admin/certificates/shared/acme {domain_id}` validates the domain's DNS zone is hosted on this panel + admin email is set, then inserts a **pending** row with SANs `[name, *.name]`. A DNS-01 round trip takes tens of seconds — too long for an open HTTP request — so the new reconciler sweep `reconcileAcmeSharedCerts` drives issuance through the agent (15 min retry backoff, 24 h renew backoff, 30-day renew window as certbot-timer backstop).
- Deleting an ACME row revokes + deletes the certbot lineage (best-effort) so `certbot renew` stops maintaining a cert nobody serves — with live DNS hooks, that would keep writing challenge records forever.
- Attach/detach + vhost render: untouched — the existing shared-cert path just works once the row has paths.

**UI**
- Shared-certificates card: "Request wildcard (Let's Encrypt)" with a searchable domain picker, new Status column (`Issuing…` / `Issue failed` with error tooltip / staging badge / `Uploaded`), list polls at 10 s only while a row is pending.

## Test plan
- [x] certbot arg-shape tests against a fake binary: manual/dns flags + both hooks present, no webroot, `-d *.name`, staging, SAN dedup
- [x] agent RPC validation tests (wildcard cert_name rejected, `*.*.x` rejected, single `*.` accepted)
- [x] CLI hook: zone longest-suffix matching walks parents, refuses foreign zones; challenge-name shape
- [x] handler tests: 202 + pending row with right SANs/owner, 422 foreign zone, 422 no admin email, 503 DNS unwired
- [x] reconciler sweep tests: issues pending row (lineage name, SANs), records failures, retry + renew backoffs honoured
- [x] `go test ./panel-api/... ./panel-agent/...` green post-rebase; `go vet` clean; migration numbering verified against latest main (000242 unique)
- [x] panel-ui `tsc -b` + `npm run build` + vitest green
- [ ] Box E2E on testserver (LE staging → real): request `*.<domain>` for a locally-hosted zone, watch TXT appear/vanish via `dig`, cert issued + attachable — planned together with part 2's preview E2E

Part 2 (branch stacks on this): `*.preview.<hostname>` bootstrap + per-domain opt-in preview URLs + agent preview vhost + UI toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)