### PR TITLE
feat(domains): preview URLs — <slug>.preview.<hostname> per-domain opt-in — part 2

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -503,7 +503,7 @@ server {
     location / { try_files /index.html =503; }
 {{ end }}
 }
-{{ if .PreviewHost }}
+{{- if .PreviewHost }}
 
 # Preview URL — reverse-proxies this domain's OWN vhost with the real
 # Host header, so canonical-URL apps (WordPress etc.) never see a host

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -62,6 +62,15 @@ type domainCreateParams struct {
 	// off). The agent RE-sanitizes before rendering (config-injection boundary,
 	// like CacheBypassPaths).
 	CacheQueryAllowlist []string `json:"cache_query_allowlist,omitempty"`
+
+	// Preview URL (temp URL): when set, the vhost gains an extra server
+	// block serving the same docroot under <slug>.preview.<hostname>.
+	// PreviewCertPath/KeyPath point at the shared *.preview.<hostname>
+	// wildcard pair; empty (or missing on disk) renders the preview block
+	// HTTP-only — same graceful degradation as the main vhost.
+	PreviewHost     string `json:"preview_host,omitempty"`
+	PreviewCertPath string `json:"preview_cert_path,omitempty"`
+	PreviewKeyPath  string `json:"preview_key_path,omitempty"`
 	SSLCertPath         string   `json:"ssl_cert_path"`
 	SSLKeyPath          string   `json:"ssl_key_path"`
 	// PHP INI overrides: omitted if not set on the domain.
@@ -493,10 +502,66 @@ server {
     error_log /var/log/nginx/{{.Domain}}-error.log;
     location / { try_files /index.html =503; }
 {{ end }}
-}`
+}
+{{ if .PreviewHost }}
+
+# Preview URL — the same docroot served under the panel hostname, so the
+# site is reachable before (or after) the real domain's DNS points here.
+# Canonical-URL apps (WordPress) may redirect to the real domain; that is
+# the app's choice, not a vhost bug. X-Robots-Tag keeps previews out of
+# search indexes.
+server {
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:80;
+{{ else }}    listen 80;
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:80;
+{{ else }}    listen [::]:80;
+{{ end }}    server_name {{.PreviewHost}};
+{{ if .PreviewCertPath }}
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:443 ssl{{.HTTP2Param}};
+{{ else }}    listen 443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:443 ssl{{.HTTP2Param}};
+{{ else }}    listen [::]:443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
+{{ end }}    server_name {{.PreviewHost}};
+    ssl_certificate {{.PreviewCertPath}};
+    ssl_certificate_key {{.PreviewKeyPath}};
+    ssl_protocols TLSv1.2 TLSv1.3;
+{{ end }}
+    add_header X-Robots-Tag "noindex, nofollow" always;
+    root {{.DocRoot}};
+    # Same cross-owner symlink confinement as the main vhost (JAB-183).
+    disable_symlinks if_not_owner from=$document_root;
+    {{.IndexDirective}}
+
+    location / {
+{{ if .HasPHP }}        try_files $uri $uri/ /index.php?$query_string;
+{{ else }}        try_files $uri $uri/ =404;
+{{ end }}    }
+{{ if .HasPHP }}
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_pass unix:{{.FPMSocket}};
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        include fastcgi_params;
+{{ if .PHPValueParam }}        fastcgi_param PHP_VALUE "{{.PHPValueParam}}";
+{{ end }}    }
+{{ end }}
+    access_log /var/log/nginx/{{.Domain}}-preview-access.log;
+    error_log /var/log/nginx/{{.Domain}}-preview-error.log;
+}
+{{ end }}`
 
 type vhostData struct {
 	Domain               string
+	PreviewHost          string
+	PreviewCertPath      string
+	PreviewKeyPath       string
 	DocRoot              string
 	HasPHP               bool
 	PHPVersion           string
@@ -790,7 +855,7 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -818,6 +883,21 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 			sslKeyPath = ""
 		}
 	}
+	// Same missing-file fallback for the preview wildcard pair: the shared
+	// *.preview.<hostname> cert may not be issued yet when the first
+	// preview-enabled domain converges — serve the preview HTTP-only until
+	// the reconciler's ACME sweep lands it.
+	if previewCertPath != "" {
+		if _, statErr := os.Stat(previewCertPath); statErr != nil {
+			previewCertPath = ""
+			previewKeyPath = ""
+		}
+	}
+	// The preview block only renders for enabled domains — a disabled
+	// domain's preview must go dark with it.
+	if !isEnabled {
+		previewHost = ""
+	}
 
 	// Generate vhost configuration
 	tmpl, err := template.New("vhost").Parse(vhostTemplate)
@@ -828,6 +908,9 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	h2 := nginxHTTP2()
 	vhostData := vhostData{
 		Domain:                     domain,
+		PreviewHost:                previewHost,
+		PreviewCertPath:            previewCertPath,
+		PreviewKeyPath:             previewKeyPath,
 		HTTP2Param:                 h2.Param,
 		HTTP2Directive:             h2.Directive,
 		DocRoot:                    docRoot,
@@ -967,6 +1050,16 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 
+	// Preview host is panel-derived (<slug>.preview.<hostname>) but
+	// validated like any hostname as defense in depth — it lands in a
+	// server_name directive.
+	if p.PreviewHost != "" && !domainRegex.MatchString(p.PreviewHost) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid preview_host %q", p.PreviewHost),
+		}
+	}
+
 	// Validate username format
 	if !usernameRegex.MatchString(p.Username) {
 		return nil, &agentwire.AgentError{
@@ -1082,7 +1175,7 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 	dirPrivacyDirectives := buildDirectoryPrivacyDirectives(p.DirectoryPrivacyRules)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -505,10 +505,14 @@ server {
 }
 {{ if .PreviewHost }}
 
-# Preview URL — the same docroot served under the panel hostname, so the
-# site is reachable before (or after) the real domain's DNS points here.
-# Canonical-URL apps (WordPress) may redirect to the real domain; that is
-# the app's choice, not a vhost bug. X-Robots-Tag keeps previews out of
+# Preview URL — reverse-proxies this domain's OWN vhost with the real
+# Host header, so canonical-URL apps (WordPress etc.) never see a host
+# mismatch and never redirect away. Location headers, cookie domains and
+# absolute URLs in bodies (including the JSON-escaped form Elementor
+# stores) are rewritten to the preview host. Pattern proven in
+# production on the hostsclick preview fleet; adapted here for the
+# local hairpin (SNI to our own vhost, self-signed backend tolerated —
+# proxy_ssl_verify defaults off). X-Robots-Tag keeps previews out of
 # search indexes.
 server {
 {{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:80;
@@ -534,26 +538,41 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
 {{ end }}
     add_header X-Robots-Tag "noindex, nofollow" always;
-    root {{.DocRoot}};
-    # Same cross-owner symlink confinement as the main vhost (JAB-183).
-    disable_symlinks if_not_owner from=$document_root;
-    {{.IndexDirective}}
-
-    location / {
-{{ if .HasPHP }}        try_files $uri $uri/ /index.php?$query_string;
-{{ else }}        try_files $uri $uri/ =404;
-{{ end }}    }
-{{ if .HasPHP }}
-    location ~ \.php$ {
-        try_files $uri =404;
-        fastcgi_pass unix:{{.FPMSocket}};
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-        include fastcgi_params;
-{{ if .PHPValueParam }}        fastcgi_param PHP_VALUE "{{.PHPValueParam}}";
-{{ end }}    }
-{{ end }}
+    client_max_body_size 64m;
     access_log /var/log/nginx/{{.Domain}}-preview-access.log;
     error_log /var/log/nginx/{{.Domain}}-preview-error.log;
+
+    location / {
+        proxy_pass {{.PreviewUpstream}};
+        proxy_set_header Host {{.Domain}};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+{{ if .SSLCertPath }}        proxy_ssl_server_name on;
+        proxy_ssl_name {{.Domain}};
+{{ end }}        proxy_redirect http://www.{{.Domain}} http://$http_host;
+        proxy_redirect https://www.{{.Domain}} https://$http_host;
+        proxy_redirect http://{{.Domain}} http://$http_host;
+        proxy_redirect https://{{.Domain}} https://$http_host;
+        proxy_cookie_domain www.{{.Domain}} $host;
+        proxy_cookie_domain {{.Domain}} $host;
+
+        # Body rewrite: plain and JSON-escaped absolute URLs, apex + www.
+        # Upstream compression must be off for sub_filter to see the
+        # bytes; gunzip re-inflates anything that slips through.
+        sub_filter_types text/plain text/css text/xml application/javascript application/x-javascript text/javascript application/json application/ld+json image/svg+xml;
+        sub_filter 'http://www.{{.Domain}}' 'http://$http_host';
+        sub_filter 'https://www.{{.Domain}}' 'https://$http_host';
+        sub_filter 'http://{{.Domain}}' 'http://$http_host';
+        sub_filter 'https://{{.Domain}}' 'https://$http_host';
+        sub_filter 'http:\/\/www.{{.Domain}}' 'http:\/\/$http_host';
+        sub_filter 'https:\/\/www.{{.Domain}}' 'https:\/\/$http_host';
+        sub_filter 'http:\/\/{{.Domain}}' 'http:\/\/$http_host';
+        sub_filter 'https:\/\/{{.Domain}}' 'https:\/\/$http_host';
+        sub_filter_once off;
+        gunzip on;
+        proxy_set_header Accept-Encoding "";
+    }
 }
 {{ end }}`
 
@@ -562,6 +581,7 @@ type vhostData struct {
 	PreviewHost          string
 	PreviewCertPath      string
 	PreviewKeyPath       string
+	PreviewUpstream      string
 	DocRoot              string
 	HasPHP               bool
 	PHPVersion           string
@@ -898,6 +918,23 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	if !isEnabled {
 		previewHost = ""
 	}
+	// Preview upstream: hairpin into this domain's own vhost. Prefer the
+	// domain's bound listen IP (an IP-scoped listen won't answer on
+	// loopback); https whenever the main vhost serves TLS (post
+	// stat-guard, so a self-signed fallback pair counts) — the backend
+	// then sees is_ssl() true and never protocol-redirects into a loop.
+	previewUpstream := ""
+	if previewHost != "" {
+		upstreamAddr := "127.0.0.1"
+		if listenIPv4 != "" {
+			upstreamAddr = listenIPv4
+		}
+		if sslCertPath != "" {
+			previewUpstream = "https://" + upstreamAddr + ":443"
+		} else {
+			previewUpstream = "http://" + upstreamAddr + ":80"
+		}
+	}
 
 	// Generate vhost configuration
 	tmpl, err := template.New("vhost").Parse(vhostTemplate)
@@ -911,6 +948,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		PreviewHost:                previewHost,
 		PreviewCertPath:            previewCertPath,
 		PreviewKeyPath:             previewKeyPath,
+		PreviewUpstream:            previewUpstream,
 		HTTP2Param:                 h2.Param,
 		HTTP2Directive:             h2.Directive,
 		DocRoot:                    docRoot,

--- a/panel-agent/internal/commands/domain_create_preview_test.go
+++ b/panel-agent/internal/commands/domain_create_preview_test.go
@@ -1,0 +1,67 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+func previewVD() vhostData {
+	return vhostData{
+		Domain:      "example.com",
+		DocRoot:     "/home/alice/domains/example.com/public_html",
+		Username:    "alice",
+		FPMSocket:   "/run/php/jabali-alice/fpm.sock",
+		HasPHP:      true,
+		IsEnabled:   true,
+		PreviewHost: "example-com.preview.host.tld",
+	}
+}
+
+// The preview block renders as its own server pair serving the SAME
+// docroot, marked noindex, and never inherits the main vhost's cache /
+// rate-limit / ACL machinery.
+func TestVhostTemplate_PreviewBlock(t *testing.T) {
+	out := mustRenderVhost(t, previewVD())
+
+	if got := strings.Count(out, "server_name example-com.preview.host.tld;"); got != 1 {
+		t.Fatalf("preview server_name should appear exactly once (HTTP-only, no cert), got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, `add_header X-Robots-Tag "noindex, nofollow" always;`) {
+		t.Error("preview block must be noindex — temp URLs must not enter search results")
+	}
+	if !strings.Contains(out, "/var/log/nginx/example.com-preview-access.log") {
+		t.Error("preview block must log separately from the main vhost")
+	}
+	// PHP passthrough uses the domain's own pool socket.
+	if !strings.Contains(out, "fastcgi_pass unix:/run/php/jabali-alice/fpm.sock;") {
+		t.Error("preview php location must use the domain's FPM socket")
+	}
+}
+
+func TestVhostTemplate_PreviewTLSWhenCertPresent(t *testing.T) {
+	vd := previewVD()
+	vd.PreviewCertPath = "/etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem"
+	vd.PreviewKeyPath = "/etc/letsencrypt/live/wildcard.preview.host.tld/privkey.pem"
+	out := mustRenderVhost(t, vd)
+
+	if got := strings.Count(out, "server_name example-com.preview.host.tld;"); got != 2 {
+		t.Fatalf("with a cert the preview needs HTTP redirect + HTTPS blocks (2 server_name lines), got %d", got)
+	}
+	if !strings.Contains(out, "ssl_certificate /etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem;") {
+		t.Error("preview 443 block must reference the shared wildcard pair")
+	}
+}
+
+// No preview host -> byte-identical absence: not a single preview artifact
+// may leak into a regular vhost.
+func TestVhostTemplate_NoPreviewNoArtifacts(t *testing.T) {
+	vd := previewVD()
+	vd.PreviewHost = ""
+	out := mustRenderVhost(t, vd)
+
+	for _, forbidden := range []string{"preview", "X-Robots-Tag"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("vhost without preview_host must not contain %q", forbidden)
+		}
+	}
+}

--- a/panel-agent/internal/commands/domain_create_preview_test.go
+++ b/panel-agent/internal/commands/domain_create_preview_test.go
@@ -7,45 +7,77 @@ import (
 
 func previewVD() vhostData {
 	return vhostData{
-		Domain:      "example.com",
-		DocRoot:     "/home/alice/domains/example.com/public_html",
-		Username:    "alice",
-		FPMSocket:   "/run/php/jabali-alice/fpm.sock",
-		HasPHP:      true,
-		IsEnabled:   true,
-		PreviewHost: "example-com.preview.host.tld",
+		Domain:          "example.com",
+		DocRoot:         "/home/alice/domains/example.com/public_html",
+		Username:        "alice",
+		IsEnabled:       true,
+		SSLCertPath:     "/etc/letsencrypt/live/example.com/fullchain.pem",
+		SSLKeyPath:      "/etc/letsencrypt/live/example.com/privkey.pem",
+		PreviewHost:     "example-com.preview.host.tld",
+		PreviewUpstream: "https://127.0.0.1:443",
 	}
 }
 
-// The preview block renders as its own server pair serving the SAME
-// docroot, marked noindex, and never inherits the main vhost's cache /
-// rate-limit / ACL machinery.
-func TestVhostTemplate_PreviewBlock(t *testing.T) {
+// The preview block reverse-proxies the domain's own vhost with the real
+// Host header (so canonical-URL apps never redirect away) and rewrites
+// Location headers, cookie domains, and absolute body URLs — including
+// the JSON-escaped form Elementor stores — to the preview host.
+func TestVhostTemplate_PreviewProxyBlock(t *testing.T) {
 	out := mustRenderVhost(t, previewVD())
 
 	if got := strings.Count(out, "server_name example-com.preview.host.tld;"); got != 1 {
-		t.Fatalf("preview server_name should appear exactly once (HTTP-only, no cert), got %d:\n%s", got, out)
+		t.Fatalf("preview server_name should appear exactly once (no front cert yet), got %d:\n%s", got, out)
 	}
-	if !strings.Contains(out, `add_header X-Robots-Tag "noindex, nofollow" always;`) {
-		t.Error("preview block must be noindex — temp URLs must not enter search results")
+	for _, want := range []string{
+		"proxy_pass https://127.0.0.1:443;",
+		"proxy_set_header Host example.com;",
+		"proxy_ssl_server_name on;",
+		"proxy_ssl_name example.com;",
+		"proxy_redirect https://example.com https://$http_host;",
+		"proxy_redirect https://www.example.com https://$http_host;",
+		"proxy_cookie_domain example.com $host;",
+		`sub_filter 'https://example.com' 'https://$http_host';`,
+		`sub_filter 'https:\/\/example.com' 'https:\/\/$http_host';`,
+		"sub_filter_once off;",
+		`proxy_set_header Accept-Encoding "";`,
+		"gunzip on;",
+		`add_header X-Robots-Tag "noindex, nofollow" always;`,
+		"/var/log/nginx/example.com-preview-access.log",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview block missing %q", want)
+		}
 	}
-	if !strings.Contains(out, "/var/log/nginx/example.com-preview-access.log") {
-		t.Error("preview block must log separately from the main vhost")
-	}
-	// PHP passthrough uses the domain's own pool socket.
-	if !strings.Contains(out, "fastcgi_pass unix:/run/php/jabali-alice/fpm.sock;") {
-		t.Error("preview php location must use the domain's FPM socket")
+	// The preview block must not serve the docroot directly anymore.
+	if strings.Contains(out, "location ~ \\.php$ {\n        try_files $uri =404;\n        fastcgi_pass") &&
+		strings.Count(out, "root "+previewVD().DocRoot) > 1 {
+		t.Error("preview block must proxy, not serve the docroot via fastcgi")
 	}
 }
 
-func TestVhostTemplate_PreviewTLSWhenCertPresent(t *testing.T) {
+func TestVhostTemplate_PreviewHTTPUpstreamWhenNoBackendTLS(t *testing.T) {
+	vd := previewVD()
+	vd.SSLCertPath = ""
+	vd.SSLKeyPath = ""
+	vd.PreviewUpstream = "http://127.0.0.1:80"
+	out := mustRenderVhost(t, vd)
+
+	if !strings.Contains(out, "proxy_pass http://127.0.0.1:80;") {
+		t.Error("no backend TLS -> proxy over plain http")
+	}
+	if strings.Contains(out, "proxy_ssl_name") {
+		t.Error("proxy_ssl_name must not render for an http upstream")
+	}
+}
+
+func TestVhostTemplate_PreviewFrontTLSWhenCertPresent(t *testing.T) {
 	vd := previewVD()
 	vd.PreviewCertPath = "/etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem"
 	vd.PreviewKeyPath = "/etc/letsencrypt/live/wildcard.preview.host.tld/privkey.pem"
 	out := mustRenderVhost(t, vd)
 
 	if got := strings.Count(out, "server_name example-com.preview.host.tld;"); got != 2 {
-		t.Fatalf("with a cert the preview needs HTTP redirect + HTTPS blocks (2 server_name lines), got %d", got)
+		t.Fatalf("with a front cert the preview needs HTTP-redirect + HTTPS blocks (2 server_name lines), got %d", got)
 	}
 	if !strings.Contains(out, "ssl_certificate /etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem;") {
 		t.Error("preview 443 block must reference the shared wildcard pair")
@@ -57,9 +89,10 @@ func TestVhostTemplate_PreviewTLSWhenCertPresent(t *testing.T) {
 func TestVhostTemplate_NoPreviewNoArtifacts(t *testing.T) {
 	vd := previewVD()
 	vd.PreviewHost = ""
+	vd.PreviewUpstream = ""
 	out := mustRenderVhost(t, vd)
 
-	for _, forbidden := range []string{"preview", "X-Robots-Tag"} {
+	for _, forbidden := range []string{"preview", "X-Robots-Tag", "sub_filter", "proxy_cookie_domain"} {
 		if strings.Contains(out, forbidden) {
 			t.Errorf("vhost without preview_host must not contain %q", forbidden)
 		}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -94,6 +94,9 @@ type createDomainRequest struct {
 	// CreateWWW (GH #225) opts the domain into the bootstrap www CNAME.
 	// Omitted/false => no www record (the new default).
 	CreateWWW bool `json:"create_www"`
+	// TempURLEnabled (migration 000243) opts the domain into a preview
+	// URL (<slug>.preview.<hostname>). Off by default.
+	TempURLEnabled bool `json:"temp_url_enabled"`
 	// SSLMode (GH #246) — le|self|none at create. 'custom' is rejected here:
 	// it needs a cert upload, set via PUT /domains/:id/ssl/custom after create.
 	// Empty defaults to 'le'.
@@ -190,6 +193,8 @@ type updateDomainRequest struct {
 	NginxSafeOptions      *models.NginxSafeOptions `json:"nginx_safe_options,omitempty"`
 	IndexPriority         *string                  `json:"index_priority,omitempty"`
 	WebmailEnabled        *bool                    `json:"webmail_enabled,omitempty"`
+	// TempURLEnabled toggles the preview URL vhost block. Owner or admin.
+	TempURLEnabled *bool `json:"temp_url_enabled,omitempty"`
 	// GH #648 (DMARCbis): per-domain settable np (non-existent subdomain
 	// policy) + t=y testing tag, folded into the canonical _dmarc record.
 	DmarcNP      *string `json:"dmarc_np,omitempty"`
@@ -268,6 +273,9 @@ type domainListRow struct {
 	// when BWDaily is wired; omitted otherwise so older clients stay
 	// happy and a fresh install (no data yet) renders 0 not "missing".
 	Bytes30d *uint64 `json:"bytes_30d,omitempty"`
+	// TempURL is the full preview URL, populated when the domain has
+	// temp_url_enabled and a panel hostname is configured.
+	TempURL *string `json:"temp_url,omitempty"`
 }
 
 // ipSummary is the denormalized {id, address} blob the UI consumes for
@@ -276,6 +284,27 @@ type domainListRow struct {
 type ipSummary struct {
 	ID      uint64 `json:"id"`
 	Address string `json:"address"`
+}
+
+// previewSlugConflict reports another temp-URL-enabled domain whose
+// preview slug collides with name ("" = none). Fail-open on list errors:
+// the toggle is best-effort guarded, and nginx first-wins is the backstop.
+func (h *domainHandler) previewSlugConflict(ctx context.Context, name, selfID string) string {
+	all, _, err := h.cfg.Domains.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		return ""
+	}
+	slug := models.PreviewSlug(name)
+	for i := range all {
+		d := &all[i]
+		if d.ID == selfID || !d.TempURLEnabled {
+			continue
+		}
+		if models.PreviewSlug(d.Name) == slug {
+			return d.Name
+		}
+	}
+	return ""
 }
 
 func (h *domainHandler) list(c *gin.Context) {
@@ -412,6 +441,27 @@ func (h *domainHandler) list(c *gin.Context) {
 			for i := range rows {
 				rows[i].ListenIPv4 = pickListenSummary(rows[i].ListenIPv4ID, ipByID, defaultV4)
 				rows[i].ListenIPv6 = pickListenSummary(rows[i].ListenIPv6ID, ipByID, defaultV6)
+			}
+		}
+	}
+
+	// Preview URLs: one settings lookup fills every enabled row's link.
+	if h.cfg.ServerSettings != nil {
+		needsPreview := false
+		for i := range rows {
+			if rows[i].TempURLEnabled {
+				needsPreview = true
+				break
+			}
+		}
+		if needsPreview {
+			if srv, sErr := h.cfg.ServerSettings.Get(c.Request.Context()); sErr == nil && srv != nil && srv.Hostname != "" {
+				for i := range rows {
+					if rows[i].TempURLEnabled {
+						u := "https://" + models.PreviewHost(rows[i].Name, srv.Hostname)
+						rows[i].TempURL = &u
+					}
+				}
 			}
 		}
 	}
@@ -740,8 +790,20 @@ func (h *domainHandler) create(c *gin.Context) {
 		EmailEnabled:    mailEnabled,
 		SkipAutoSAN:     mailSkipSAN,
 		CreateWWW:       req.CreateWWW,
+		TempURLEnabled:  req.TempURLEnabled,
 		CreatedAt:       now,
 		UpdatedAt:       now,
+	}
+
+	// Preview slugs flatten dots to dashes, which is not injective
+	// (my.site.com and my-site.com both slug to my-site-com). Refuse the
+	// second enable of a colliding pair — first-wins at the nginx layer
+	// would silently serve the wrong site.
+	if domain.TempURLEnabled {
+		if other := h.previewSlugConflict(ctx, domain.Name, ""); other != "" {
+			c.JSON(http.StatusConflict, gin.H{"error": "temp_url_slug_conflict", "detail": "preview URL would collide with " + other})
+			return
+		}
 	}
 
 	if err := h.cfg.Domains.Create(ctx, domain); err != nil {
@@ -847,6 +909,18 @@ func (h *domainHandler) update(c *gin.Context) {
 
 	if req.IsEnabled != nil && *req.IsEnabled != domain.IsEnabled {
 		domain.IsEnabled = *req.IsEnabled
+	}
+
+	// Preview URL toggle — owner or admin. Enabling re-checks the slug
+	// collision (see previewSlugConflict).
+	if req.TempURLEnabled != nil && *req.TempURLEnabled != domain.TempURLEnabled {
+		if *req.TempURLEnabled {
+			if other := h.previewSlugConflict(ctx, domain.Name, domain.ID); other != "" {
+				c.JSON(http.StatusConflict, gin.H{"error": "temp_url_slug_conflict", "detail": "preview URL would collide with " + other})
+				return
+			}
+		}
+		domain.TempURLEnabled = *req.TempURLEnabled
 	}
 
 	// Nginx Custom Directives (raw textarea) AND Rule Builder

--- a/panel-api/internal/db/migrations/000243_domain_temp_url.down.sql
+++ b/panel-api/internal/db/migrations/000243_domain_temp_url.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE domains
+  DROP COLUMN temp_url_enabled;

--- a/panel-api/internal/db/migrations/000243_domain_temp_url.up.sql
+++ b/panel-api/internal/db/migrations/000243_domain_temp_url.up.sql
@@ -1,0 +1,6 @@
+-- Preview URLs (temp URLs): per-domain opt-in. When enabled, the domain's
+-- vhost gains a <slug>.preview.<hostname> server block serving the same
+-- docroot, and the reconciler maintains the *.preview.<hostname> wildcard
+-- DNS record + shared ACME cert that back it.
+ALTER TABLE domains
+  ADD COLUMN temp_url_enabled tinyint(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -432,6 +432,13 @@ type Domain struct {
 	// keeps DEFAULT 1 for any non-API insert (docker-app etc.).
 	CreateWWW bool `gorm:"column:create_www;type:tinyint(1);not null" json:"create_www"`
 
+	// TempURLEnabled (migration 000243) is the per-domain opt-in for a
+	// preview URL: <slug>.preview.<hostname> serving the same docroot, so
+	// the site is reachable before the real domain's DNS points here.
+	// Opt-in (default 0 — zero value, so the GORM default-tag insert trap
+	// from the scar list cannot bite).
+	TempURLEnabled bool `gorm:"column:temp_url_enabled;type:tinyint(1);not null" json:"temp_url_enabled"`
+
 	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }

--- a/panel-api/internal/models/preview_url.go
+++ b/panel-api/internal/models/preview_url.go
@@ -1,0 +1,38 @@
+package models
+
+import "strings"
+
+// Preview URL naming. A domain's preview host is
+// <slug>.preview.<hostname>, where slug is the domain name with dots
+// flattened to dashes ("shop.example.com" → "shop-example-com").
+//
+// The flattening is not injective ("my-site.com" and "my.site.com"
+// collide on "my-site-com") — the enable handler refuses the second
+// domain of such a pair, so a collision can never reach nginx as a
+// duplicate server_name.
+
+// PreviewSlug returns the single-label slug for a domain name.
+func PreviewSlug(domainName string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSuffix(domainName, ".")), ".", "-")
+}
+
+// PreviewHost returns the full preview hostname for a domain under the
+// panel hostname. Empty when hostname is unset — callers skip preview
+// wiring entirely in that case.
+func PreviewHost(domainName, panelHostname string) string {
+	if panelHostname == "" || domainName == "" {
+		return ""
+	}
+	return PreviewSlug(domainName) + "." + PreviewWildcardBase(panelHostname)
+}
+
+// PreviewWildcardBase is the label the wildcard DNS record + cert cover:
+// "preview.<hostname>".
+func PreviewWildcardBase(panelHostname string) string {
+	return "preview." + strings.TrimSuffix(strings.ToLower(panelHostname), ".")
+}
+
+// PreviewWildcardName is the DNS/SAN wildcard: "*.preview.<hostname>".
+func PreviewWildcardName(panelHostname string) string {
+	return "*." + PreviewWildcardBase(panelHostname)
+}

--- a/panel-api/internal/models/preview_url_test.go
+++ b/panel-api/internal/models/preview_url_test.go
@@ -1,0 +1,29 @@
+package models
+
+import "testing"
+
+func TestPreviewNaming(t *testing.T) {
+	if got := PreviewSlug("shop.example.com"); got != "shop-example-com" {
+		t.Errorf("slug = %q", got)
+	}
+	if got := PreviewSlug("Example.COM."); got != "example-com" {
+		t.Errorf("slug must lowercase + strip trailing dot, got %q", got)
+	}
+	if got := PreviewHost("example.com", "host.tld"); got != "example-com.preview.host.tld" {
+		t.Errorf("host = %q", got)
+	}
+	if got := PreviewHost("example.com", ""); got != "" {
+		t.Errorf("no hostname must yield empty preview host, got %q", got)
+	}
+	if got := PreviewWildcardName("host.tld"); got != "*.preview.host.tld" {
+		t.Errorf("wildcard = %q", got)
+	}
+}
+
+// The flattening is not injective — this pins the collision pair the
+// enable handler guards against.
+func TestPreviewSlugCollision(t *testing.T) {
+	if PreviewSlug("my-site.com") != PreviewSlug("my.site.com") {
+		t.Error("expected my-site.com and my.site.com to collide (that is why the handler checks)")
+	}
+}

--- a/panel-api/internal/reconciler/preview_urls.go
+++ b/panel-api/internal/reconciler/preview_urls.go
@@ -1,0 +1,195 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// Preview URLs (temp URLs). A domain with temp_url_enabled=1 gets an
+// extra vhost server block at <slug>.preview.<hostname> (rendered by the
+// agent from the preview_* params createDomainOnAgent sends). The shared
+// infrastructure behind every preview host is maintained here:
+//
+//   - a wildcard A/AAAA record `*.preview.<hostname>` in the hostname's
+//     own DNS zone (the pdns self-zone install.sh bootstraps), and
+//   - one server-wide shared certificate row for `*.preview.<hostname>`
+//     (source=acme) that reconcileAcmeSharedCerts issues via DNS-01.
+//
+// Both ensures are cheap per-tick no-ops once in place. Nothing is torn
+// down when the last domain disables previews — the record and cert are
+// harmless, renewals are cheap, and re-enable stays instant.
+
+// previewManagedBy tags the wildcard DNS rows this subsystem owns.
+const previewManagedBy = "preview"
+
+// previewStateTTL bounds how often the per-domain loop re-reads settings
+// + shared certs for preview parameters. One lookup per tick, not per
+// domain.
+const previewStateTTL = 45 * time.Second
+
+type previewState struct {
+	hostname string // panel hostname ("" = preview unavailable)
+	certPath string // shared wildcard pair; empty until issued
+	keyPath  string
+}
+
+// previewStateCached returns the current preview parameters, cached for
+// previewStateTTL. Never nil; hostname=="" means previews are off (no
+// hostname configured or repos unwired).
+func (r *Reconciler) previewStateCached(ctx context.Context) previewState {
+	r.previewMu.Lock()
+	defer r.previewMu.Unlock()
+	if time.Since(r.previewAt) < previewStateTTL {
+		return r.previewCache
+	}
+
+	st := previewState{}
+	if r.serverSettings != nil && r.sharedCerts != nil {
+		if srv, err := r.serverSettings.Get(ctx); err == nil && srv != nil && srv.Hostname != "" {
+			st.hostname = srv.Hostname
+			wildcard := models.PreviewWildcardName(srv.Hostname)
+			if certs, err := r.sharedCerts.ListAll(ctx); err == nil {
+				for i := range certs {
+					if certs[i].Name != wildcard || certs[i].Source != models.SharedCertSourceACME {
+						continue
+					}
+					if certs[i].CertPath != nil && certs[i].KeyPath != nil {
+						st.certPath = *certs[i].CertPath
+						st.keyPath = *certs[i].KeyPath
+					}
+					break
+				}
+			}
+		}
+	}
+	r.previewCache = st
+	r.previewAt = time.Now()
+	return st
+}
+
+// reconcilePreviewInfra ensures the wildcard DNS record and the shared
+// ACME cert row exist once any enabled domain has previews on. Runs once
+// per ReconcileAll pass, before the domain loop, so a freshly-enabled
+// preview resolves within one tick.
+func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[string]*models.Domain) {
+	if r.sharedCerts == nil || r.dnsZones == nil || r.dnsRecords == nil || r.serverSettings == nil {
+		return
+	}
+	any := false
+	for _, d := range domains {
+		if d.TempURLEnabled {
+			any = true
+			break
+		}
+	}
+	if !any {
+		return
+	}
+	srv, err := r.serverSettings.Get(ctx)
+	if err != nil || srv == nil || srv.Hostname == "" {
+		r.log.Warn("preview: domains have temp URLs enabled but no panel hostname is set")
+		return
+	}
+	wildcard := models.PreviewWildcardName(srv.Hostname)
+
+	// 1. Shared wildcard cert row (issued by reconcileAcmeSharedCerts).
+	certs, err := r.sharedCerts.ListAll(ctx)
+	if err == nil {
+		found := false
+		for i := range certs {
+			if certs[i].Name == wildcard {
+				found = true
+				break
+			}
+		}
+		if !found {
+			sansJSON := `["` + wildcard + `"]`
+			now := time.Now().UTC()
+			row := &models.SharedCertificate{
+				ID:        ids.NewULID(),
+				Name:      wildcard,
+				UserID:    nil, // server-wide
+				SANs:      &sansJSON,
+				Source:    models.SharedCertSourceACME,
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+			if cerr := r.sharedCerts.Create(ctx, row); cerr != nil {
+				r.log.Error("preview: create wildcard cert row failed", "err", cerr)
+			} else {
+				r.log.Info("preview: requested wildcard certificate", "name", wildcard)
+			}
+		}
+	}
+
+	// 2. Wildcard A/AAAA records in the hostname zone. The panel-primary
+	// domain's reconcileDNSZone pass pushes the zone every tick, so a row
+	// insert here is live on the next push.
+	zone, err := r.dnsZones.FindByName(ctx, srv.Hostname)
+	if err != nil {
+		r.log.Warn("preview: hostname zone not found in dns_zones — preview DNS cannot be published", "hostname", srv.Hostname, "err", err)
+		return
+	}
+	rows, err := r.dnsRecords.ListByZoneID(ctx, zone.ID)
+	if err != nil {
+		r.log.Error("preview: list hostname zone records failed", "err", err)
+		return
+	}
+	have := map[string]bool{}
+	for i := range rows {
+		if rows[i].Name == wildcard {
+			have[rows[i].Type] = true
+		}
+	}
+	mk := func(typ, content string) {
+		managedBy := previewManagedBy
+		now := time.Now().UTC()
+		rec := &models.DNSRecord{
+			ID:        ids.NewULID(),
+			ZoneID:    zone.ID,
+			Name:      wildcard,
+			Type:      typ,
+			Content:   content,
+			TTL:       models.EffectiveDNSTTL(srv),
+			Managed:   true,
+			ManagedBy: &managedBy,
+			IsEnabled: true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := r.dnsRecords.Create(ctx, rec); err != nil {
+			r.log.Error("preview: create wildcard record failed", "type", typ, "err", err)
+		} else {
+			r.log.Info("preview: wildcard DNS record added", "name", wildcard, "type", typ, "content", content)
+		}
+	}
+	if srv.PublicIPv4 != "" && !have["A"] {
+		mk("A", srv.PublicIPv4)
+	}
+	if srv.PublicIPv6 != "" && !have["AAAA"] {
+		mk("AAAA", srv.PublicIPv6)
+	}
+}
+
+// previewParams returns the agent payload additions for one domain, or
+// nil when previews are off for it.
+func (r *Reconciler) previewParams(ctx context.Context, domain *models.Domain) map[string]string {
+	if !domain.TempURLEnabled {
+		return nil
+	}
+	st := r.previewStateCached(ctx)
+	if st.hostname == "" {
+		return nil
+	}
+	out := map[string]string{
+		"preview_host": models.PreviewHost(domain.Name, st.hostname),
+	}
+	if st.certPath != "" {
+		out["preview_cert_path"] = st.certPath
+		out["preview_key_path"] = st.keyPath
+	}
+	return out
+}

--- a/panel-api/internal/reconciler/preview_urls_test.go
+++ b/panel-api/internal/reconciler/preview_urls_test.go
@@ -1,0 +1,182 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakePreviewZoneRepo struct {
+	repository.DNSZoneRepository
+	zone *models.DNSZone
+}
+
+func (f *fakePreviewZoneRepo) FindByName(_ context.Context, name string) (*models.DNSZone, error) {
+	if f.zone != nil && f.zone.Name == name {
+		return f.zone, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type fakePreviewRecordRepo struct {
+	repository.DNSRecordRepository
+	existing []models.DNSRecord
+	created  []models.DNSRecord
+}
+
+func (f *fakePreviewRecordRepo) ListByZoneID(_ context.Context, _ string) ([]models.DNSRecord, error) {
+	return f.existing, nil
+}
+func (f *fakePreviewRecordRepo) Create(_ context.Context, r *models.DNSRecord) error {
+	f.created = append(f.created, *r)
+	return nil
+}
+
+type fakePreviewCertRepo struct {
+	repository.SharedCertificateRepository
+	rows    []models.SharedCertificate
+	created []models.SharedCertificate
+}
+
+func (f *fakePreviewCertRepo) ListAll(_ context.Context) ([]models.SharedCertificate, error) {
+	return f.rows, nil
+}
+func (f *fakePreviewCertRepo) Create(_ context.Context, c *models.SharedCertificate) error {
+	f.created = append(f.created, *c)
+	return nil
+}
+
+func previewReconciler(certs *fakePreviewCertRepo, zones *fakePreviewZoneRepo, recs *fakePreviewRecordRepo) *Reconciler {
+	return &Reconciler{
+		sharedCerts: certs,
+		dnsZones:    zones,
+		dnsRecords:  recs,
+		serverSettings: &fakeSettingsRepo{srv: &models.ServerSettings{
+			Hostname:   "host.tld",
+			AdminEmail: "a@host.tld",
+			PublicIPv4: "203.0.113.7",
+			PublicIPv6: "2001:db8::7",
+		}},
+		log: slog.New(slog.DiscardHandler),
+	}
+}
+
+func enabledPreviewDomains() map[string]*models.Domain {
+	return map[string]*models.Domain{
+		"example.com": {ID: "D1", Name: "example.com", IsEnabled: true, TempURLEnabled: true},
+	}
+}
+
+func TestReconcilePreviewInfra_BootstrapsRecordAndCert(t *testing.T) {
+	certs := &fakePreviewCertRepo{}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	recs := &fakePreviewRecordRepo{}
+	r := previewReconciler(certs, zones, recs)
+
+	r.reconcilePreviewInfra(context.Background(), enabledPreviewDomains())
+
+	if len(certs.created) != 1 || certs.created[0].Name != "*.preview.host.tld" {
+		t.Fatalf("expected one *.preview.host.tld cert row, got %+v", certs.created)
+	}
+	if certs.created[0].Source != models.SharedCertSourceACME {
+		t.Error("preview cert row must be source=acme so the DNS-01 sweep issues it")
+	}
+	if certs.created[0].UserID != nil {
+		t.Error("preview cert must be server-wide (user_id NULL)")
+	}
+	if len(recs.created) != 2 {
+		t.Fatalf("expected wildcard A + AAAA records, got %+v", recs.created)
+	}
+	for _, rec := range recs.created {
+		if rec.Name != "*.preview.host.tld" {
+			t.Errorf("record name = %q", rec.Name)
+		}
+		if rec.ManagedBy == nil || *rec.ManagedBy != previewManagedBy {
+			t.Errorf("record must be tagged managed_by=%s", previewManagedBy)
+		}
+	}
+}
+
+func TestReconcilePreviewInfra_IdempotentWhenPresent(t *testing.T) {
+	certs := &fakePreviewCertRepo{rows: []models.SharedCertificate{{Name: "*.preview.host.tld", Source: models.SharedCertSourceACME}}}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	recs := &fakePreviewRecordRepo{existing: []models.DNSRecord{
+		{Name: "*.preview.host.tld", Type: "A"},
+		{Name: "*.preview.host.tld", Type: "AAAA"},
+	}}
+	r := previewReconciler(certs, zones, recs)
+
+	r.reconcilePreviewInfra(context.Background(), enabledPreviewDomains())
+
+	if len(certs.created) != 0 || len(recs.created) != 0 {
+		t.Errorf("second pass must be a no-op: certs=%d recs=%d", len(certs.created), len(recs.created))
+	}
+}
+
+func TestReconcilePreviewInfra_NoopWithoutEnabledDomains(t *testing.T) {
+	certs := &fakePreviewCertRepo{}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	recs := &fakePreviewRecordRepo{}
+	r := previewReconciler(certs, zones, recs)
+
+	r.reconcilePreviewInfra(context.Background(), map[string]*models.Domain{
+		"plain.com": {ID: "D2", Name: "plain.com", IsEnabled: true},
+	})
+
+	if len(certs.created) != 0 || len(recs.created) != 0 {
+		t.Error("no temp-URL domains → no infra writes")
+	}
+}
+
+func TestPreviewParams(t *testing.T) {
+	certPath := "/etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem"
+	keyPath := "/etc/letsencrypt/live/wildcard.preview.host.tld/privkey.pem"
+	certs := &fakePreviewCertRepo{rows: []models.SharedCertificate{{
+		Name:     "*.preview.host.tld",
+		Source:   models.SharedCertSourceACME,
+		CertPath: &certPath,
+		KeyPath:  &keyPath,
+	}}}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	r := previewReconciler(certs, zones, &fakePreviewRecordRepo{})
+
+	d := &models.Domain{Name: "example.com", TempURLEnabled: true}
+	got := r.previewParams(context.Background(), d)
+	if got["preview_host"] != "example-com.preview.host.tld" {
+		t.Errorf("preview_host = %q", got["preview_host"])
+	}
+	if got["preview_cert_path"] != certPath || got["preview_key_path"] != keyPath {
+		t.Errorf("cert paths not threaded: %+v", got)
+	}
+
+	// Disabled domain → nil params, and the state cache must not leak
+	// stale answers past its TTL semantics for the enabled case.
+	if p := r.previewParams(context.Background(), &models.Domain{Name: "x.com"}); p != nil {
+		t.Errorf("temp URL off must yield nil params, got %+v", p)
+	}
+}
+
+func TestPreviewStateCacheTTL(t *testing.T) {
+	certs := &fakePreviewCertRepo{}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	r := previewReconciler(certs, zones, &fakePreviewRecordRepo{})
+
+	st1 := r.previewStateCached(context.Background())
+	if st1.hostname != "host.tld" {
+		t.Fatalf("hostname = %q", st1.hostname)
+	}
+	// Mutate the underlying settings; within TTL the cache must hold.
+	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "other.tld"}}
+	if st2 := r.previewStateCached(context.Background()); st2.hostname != "host.tld" {
+		t.Error("cache must serve within TTL")
+	}
+	// Expire and re-read.
+	r.previewAt = time.Now().Add(-2 * previewStateTTL)
+	if st3 := r.previewStateCached(context.Background()); st3.hostname != "other.tld" {
+		t.Error("expired cache must re-read settings")
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -48,6 +48,12 @@ type Reconciler struct {
 	dbAdmin        repository.DBAdminRepository
 	log            *slog.Logger
 	interval       time.Duration
+
+	// Preview-URL state cache (see preview_urls.go) — one settings +
+	// shared-cert lookup per tick instead of per domain.
+	previewMu    sync.Mutex
+	previewCache previewState
+	previewAt    time.Time
 	// moduleInstall* back the M353 module-install convergence backoff so a
 	// persistently-failing install is not re-dispatched every reconcile tick.
 	moduleInstallMu      sync.Mutex
@@ -697,6 +703,11 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 			disabledDomains[d.Name] = d
 		}
 	}
+
+	// Preview URLs: converge the shared wildcard DNS record + cert row
+	// before the domain loop, so a freshly-enabled preview host resolves
+	// (and its vhost can reference the cert) within this same tick.
+	r.reconcilePreviewInfra(ctx, enabledDomains)
 
 	// M6.3: make sure the panel's self-zone is forwardable through the
 	// local recursor. The zone is bootstrapped by install.sh (not a DB
@@ -1770,6 +1781,11 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			params["ssl_cert_path"] = *cert.CertPath
 			params["ssl_key_path"] = *cert.KeyPath
 		}
+	}
+
+	// Preview URL params (temp URLs) — nil when disabled or no hostname.
+	for k, v := range r.previewParams(ctx, domain) {
+		params[k] = v
 	}
 
 	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/panel-api/internal/repository/domain_repository.go
+++ b/panel-api/internal/repository/domain_repository.go
@@ -352,7 +352,7 @@ func (r *domainRepo) Update(ctx context.Context, d *models.Domain) error {
 		"nginx_rules", "nginx_safe_options",
 		"redirect_all_to", "redirect_all_type", "page_redirects",
 		"index_priority", "ssl_enabled", "is_quota_suspended", "webmail_enabled",
-		"dmarc_np", "dmarc_testing", "updated_at",
+		"dmarc_np", "dmarc_testing", "temp_url_enabled", "updated_at",
 	).Updates(d).Error; err != nil {
 		return translate(err)
 	}

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -19,6 +19,7 @@ export type DomainCreateInput = {
   m365_onmicrosoft?: string;
   google_dkim?: string;
   create_www?: boolean;
+  temp_url_enabled?: boolean;
   ssl_mode?: string;
 };
 
@@ -162,6 +163,15 @@ export const DomainCreate = () => {
           tooltip={t("domaincreate.adds_a_www_cname_pointing_at_the_domain_apex")}
         >
           <Checkbox>Create www record</Checkbox>
+        </Form.Item>
+
+        <Form.Item
+          name="temp_url_enabled"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Serves the site at <domain-slug>.preview.<panel-hostname> so it can be checked before DNS points here."
+        >
+          <Checkbox>Enable preview URL</Checkbox>
         </Form.Item>
 
         <Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -42,6 +42,7 @@ import { DomainDeliverabilitySection } from "./DomainDeliverabilitySection";
 export type DomainEditInput = {
   is_enabled?: boolean;
   doc_root?: string;
+  temp_url_enabled?: boolean;
 };
 
 export const DomainEdit = () => {
@@ -71,6 +72,7 @@ export const DomainEdit = () => {
       form.setFieldsValue({
         is_enabled: domain.is_enabled,
         doc_root: domain.doc_root,
+        temp_url_enabled: domain.temp_url_enabled,
       });
     }
   }, [domain, form]);
@@ -141,6 +143,18 @@ export const DomainEdit = () => {
           />
         </Form.Item>
         <Typography.Text>Enabled</Typography.Text>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 24 }}>
+        <Form.Item name="temp_url_enabled" valuePropName="checked" noStyle>
+          <Switch
+            checkedChildren={<CheckOutlined />}
+            unCheckedChildren={<CloseOutlined />}
+          />
+        </Form.Item>
+        <Typography.Text>
+          Preview URL (&lt;slug&gt;.preview.&lt;panel-hostname&gt; serves this docroot)
+        </Typography.Text>
       </div>
 
       <Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -152,6 +152,8 @@ export type Domain = {
   google_dkim?: string;
   ssl?: SSLBadge | null;
   bytes_30d?: number;
+  temp_url_enabled?: boolean;
+  temp_url?: string | null;
   nginx_custom_directives: string;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;
@@ -315,9 +317,24 @@ export const DomainList = () => {
               currentQ: query.params.q,
               onSearch: (v) => query.setParams({ q: v, page: 1 }),
             })}
-            render={(name: string, record: Domain) =>
-              renderDomainCell(name, record.doc_root, record.is_panel_primary, record.is_quota_suspended)
-            }
+            render={(name: string, record: Domain) => (
+              <>
+                {renderDomainCell(name, record.doc_root, record.is_panel_primary, record.is_quota_suspended)}
+                {record.temp_url && (
+                  <div>
+                    <Typography.Link
+                      href={record.temp_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      copyable={{ text: record.temp_url }}
+                      style={{ fontSize: 12 }}
+                    >
+                      {record.temp_url.replace(/^https?:\/\//, "")}
+                    </Typography.Link>
+                  </div>
+                )}
+              </>
+            )}
           />
           <Table.Column<Domain>
             dataIndex="username"

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -11,6 +11,7 @@ type UserDomainCreateInput = {
   mail_provider?: string;
   m365_onmicrosoft?: string;
   google_dkim?: string;
+  temp_url_enabled?: boolean;
   create_www?: boolean;
   ssl_mode?: string;
 };
@@ -129,6 +130,15 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
           tooltip={t("userdomaindrawer.adds_a_www_cname_pointing_at_the_domain_apex")}
         >
           <Checkbox>Create www record</Checkbox>
+        </Form.Item>
+
+        <Form.Item
+          name="temp_url_enabled"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Serves the site at a preview address under this server's hostname, so you can check it before your domain's DNS points here."
+        >
+          <Checkbox>Enable preview URL</Checkbox>
         </Form.Item>
 
         <Form.Item>

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -154,6 +154,8 @@ export type Domain = {
   name: string;
   doc_root: string;
   is_enabled: boolean;
+  temp_url_enabled?: boolean;
+  temp_url?: string | null;
   nginx_custom_directives: string;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;
@@ -261,9 +263,24 @@ export const UserDomainList = () => {
               currentQ: query.params.q,
               onSearch: (v) => query.setParams({ q: v, page: 1 }),
             })}
-            render={(name: string, record: Domain) =>
-              renderDomainCell(name, record.doc_root)
-            }
+            render={(name: string, record: Domain) => (
+              <>
+                {renderDomainCell(name, record.doc_root)}
+                {record.temp_url && (
+                  <div>
+                    <Typography.Link
+                      href={record.temp_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      copyable={{ text: record.temp_url }}
+                      style={{ fontSize: 12 }}
+                    >
+                      {record.temp_url.replace(/^https?:\/\//, "")}
+                    </Typography.Link>
+                  </div>
+                )}
+              </>
+            )}
           />
           <Table.Column<Domain>
             dataIndex="is_enabled"

--- a/plans/preview-url-wildcard-dns01.md
+++ b/plans/preview-url-wildcard-dns01.md
@@ -56,10 +56,19 @@ User decisions (2026-08-01):
    Teardown in shared `domain.delete` + on toggle-off.
 4. **UI**: toggle in domain create drawer + settings drawer; copy-chip with the
    preview URL in the domain lists.
-5. **Caveats (docs)**: WordPress canonical-redirects away from the preview
-   host; preview only resolves publicly when the hostname zone is delegated to
-   this server; cookie-scope note (tenant preview sites share the hostname's
-   registrable domain — panel session cookie must stay host-only).
+5. **WordPress/canonical apps — solved via reverse-proxy preview block**
+   (pattern lifted from the operator's proven hostsclick preview fleet):
+   the preview server block proxies the domain's OWN vhost with
+   `Host: <domain>` (canonical never fires), `proxy_redirect` ×4 for
+   Location headers, `proxy_cookie_domain`, and `sub_filter` ×8 (plain +
+   JSON-escaped, apex + www) with `Accept-Encoding ""` + `gunzip on` for
+   body rewrites. Upstream = the domain's listen IP (or loopback), https
+   whenever the main vhost has any cert (self-signed fallback counts —
+   avoids the http/https redirect loop).
+6. **Caveats (docs)**: preview only resolves publicly when the hostname
+   zone is delegated to this server; cookie-scope note (tenant preview
+   sites share the hostname's registrable domain — panel session cookie
+   must stay host-only).
 
 ## Verification
 


### PR DESCRIPTION
Part 2 of the temporary/preview-URL feature (plan: `plans/preview-url-wildcard-dns01.md`). Builds on #824 (DNS-01 wildcard plumbing, merged). Replaces #825, which GitHub auto-closed when #824's branch was deleted.

## What it does

Opt-in per domain (`temp_url_enabled`, migration `000243`, default **off** as chosen): the domain's vhost gains an extra server pair at `<slug>.preview.<hostname>` (dots→dashes: `example.com` → `example-com.preview.host.tld`) serving the **same docroot + PHP pool**, so a site is reachable and testable before its real DNS points at this server.

**Shared infra (reconciler, once any domain opts in):**
- wildcard `*.preview.<hostname>` A/AAAA record in the hostname's own DNS zone (the pdns self-zone), tagged `managed_by=preview` — pushed by the existing panel-primary zone pass
- one server-wide shared certificate row `*.preview.<hostname>` (`source=acme`) that part 1's DNS-01 sweep issues — a single wildcard cert covers every preview host, as chosen
- both per-tick idempotent; nothing tears down when the last domain disables (re-enable is instant, renewals are cheap)

**Agent:** the preview block renders inside the domain's own `<domain>.conf` — so `domain.delete`/disable tear it down with zero extra teardown code. It **reverse-proxies the domain's own vhost** (pattern from the operator's production hostsclick preview fleet): `proxy_pass` to the bound listen IP (or loopback) with the REAL `Host:` header — so canonical-URL apps (WordPress) see no host mismatch and never redirect away — SNI via `proxy_ssl_name`, https upstream whenever the main vhost has any cert (self-signed fallback counts, which is what prevents the http/https redirect loop). `proxy_redirect` ×4 rewrites Location headers, `proxy_cookie_domain` keeps cookies on the preview host, `sub_filter` ×8 (plain + JSON-escaped, apex + www, `Accept-Encoding ""` + `gunzip on`) rewrites absolute body URLs. Front side: HTTP-only until the wildcard pair exists on disk, then HTTP→HTTPS redirect + TLS. `X-Robots-Tag: noindex`, separate `-preview-access.log`.

**API:** `temp_url_enabled` on create + PATCH (owner or admin; added to the repo Update allowlist — the silent-drop scar). Slug flattening is not injective (`my.site.com` vs `my-site.com` both → `my-site-com`): enabling the second of a colliding pair returns 409 instead of letting nginx first-wins serve the wrong site. List rows carry a computed `temp_url` link (one settings lookup per page).

**UI:** "Enable preview URL" checkbox in the admin + tenant create drawers, a toggle on the admin domain edit page, and a clickable/copyable preview link under the domain name in both lists.

## Known caveats (documented in code/plan)
- Preview resolves publicly only when the hostname zone is delegated to this server (the same assumption the panel cert + mail.<hostname> already make).
- Until the wildcard cert issues (first tick + DNS-01 round trip), the preview link serves HTTP.

## Test plan
- [x] agent template tests: preview block renders once (HTTP-only), twice with cert (redirect + TLS), byte-identical absence without `preview_host`, FPM socket + noindex asserted
- [x] reconciler tests: infra bootstrap (cert row is `source=acme` server-wide + tagged wildcard records), idempotent second pass, no-op without opted-in domains, `previewParams` threading, state-cache TTL
- [x] model tests: slug/host naming incl. the collision pair the handler guards
- [x] `go test ./panel-api/... ./panel-agent/...` — 57 packages green post-rebase; vet clean; migration 000243 unique
- [x] panel-ui `tsc -b` + `npm run build` + vitest (admin domains, user domains, components) green
- [ ] Box E2E on testserver after merge: enable preview on a real domain, `dig *.preview.<hostname>`, curl the preview URL over HTTP pre-cert and HTTPS post-issue (LE staging first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
