### PR TITLE
fix(docker-apps): duplicate env keys broke n8n compose parse — plus render guard and memory-unit fix

### DIFF
--- a/install/docker-apps/mealie/compose.yml.tmpl
+++ b/install/docker-apps/mealie/compose.yml.tmpl
@@ -17,7 +17,10 @@ services:
 {{- end }}
       BASE_URL: "https://{{ .Domain }}"
 {{- range $name, $val := .Env }}
-{{- if not (hasPrefix $name "SMTP_") }}
+{{- /* BASE_URL is template-owned above — re-emitting it from .Env
+       renders duplicate YAML keys docker compose refuses (same class
+       as the n8n N8N_HOST failure). */}}
+{{- if not (or (hasPrefix $name "SMTP_") (eq $name "BASE_URL")) }}
       {{ $name }}: {{ q $val }}
 {{- end }}
 {{- end }}

--- a/install/docker-apps/n8n/compose.yml.tmpl
+++ b/install/docker-apps/n8n/compose.yml.tmpl
@@ -19,7 +19,11 @@ services:
       WEBHOOK_URL: "https://{{ .Domain }}/"
       N8N_EDITOR_BASE_URL: "https://{{ .Domain }}/"
 {{- range $name, $val := .Env }}
-{{- if not (hasPrefix $name "SMTP_") }}
+{{- /* SMTP_* map onto N8N_SMTP_* above; N8N_HOST / WEBHOOK_URL /
+       N8N_EDITOR_BASE_URL are template-owned — re-emitting them here
+       produced duplicate YAML keys docker compose refuses to parse
+       (GH: n8n install failed with "mapping key already defined"). */}}
+{{- if not (or (hasPrefix $name "SMTP_") (eq $name "N8N_HOST") (eq $name "WEBHOOK_URL") (eq $name "N8N_EDITOR_BASE_URL")) }}
       {{ $name }}: {{ q $val }}
 {{- end }}
 {{- end }}

--- a/panel-api/internal/dockerapp/render.go
+++ b/panel-api/internal/dockerapp/render.go
@@ -106,15 +106,47 @@ func Render(entry Entry, params RenderParams) (string, error) {
 	// in jabali's single-box model, so runtime.NumCPU() is the daemon's
 	// CPU count.
 	params.CPULimit = clampCPULimit(params.CPULimit, runtime.NumCPU())
+	// A bare number in deploy.resources.limits.memory means BYTES to
+	// docker compose — an operator typing "1024" (meaning MB) gets a
+	// 1 KiB limit and an instantly-OOM-killed container. Catalog
+	// defaults carry a unit ("512m"); normalise unitless operator input
+	// to megabytes at the same chokepoint as the CPU clamp.
+	params.MemoryLimit = normalizeMemoryLimit(params.MemoryLimit)
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, params); err != nil {
 		return "", fmt.Errorf("execute compose template for %q: %w", entry.Slug, err)
 	}
+	// Reject invalid YAML at render time — most importantly duplicate
+	// mapping keys, which a template emits when it hardcodes an env var
+	// that also arrives via .Env (the n8n N8N_HOST incident: docker
+	// compose refused the file and the install failed as an opaque
+	// "pull exit status 1"). yaml.v3 errors on duplicates by default,
+	// so this turns a broken install into a clear render error.
+	var probe map[string]any
+	if err := yaml.Unmarshal(buf.Bytes(), &probe); err != nil {
+		return "", fmt.Errorf("rendered compose for %q is not valid YAML: %w", entry.Slug, err)
+	}
 	if params.TenantHardening != nil {
 		return applyTenantHardening(buf.String(), *params.TenantHardening)
 	}
 	return buf.String(), nil
+}
+
+// normalizeMemoryLimit appends "m" to an all-digit memory limit so the
+// operator's "1024" means megabytes, not bytes. Values with a unit (or
+// empty) pass through untouched.
+func normalizeMemoryLimit(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return v
+	}
+	for _, r := range v {
+		if r < '0' || r > '9' {
+			return v
+		}
+	}
+	return v + "m"
 }
 
 // applyTenantHardening re-parses the rendered compose and injects the M49

--- a/panel-api/internal/dockerapp/render_dup_env_test.go
+++ b/panel-api/internal/dockerapp/render_dup_env_test.go
@@ -1,0 +1,109 @@
+package dockerapp
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression for the n8n install failure on production: the install flow
+// materialises catalog env defaults (N8N_HOST, WEBHOOK_URL) into .Env,
+// and the template ALSO hardcodes those keys — both were emitted, docker
+// compose refused the duplicate mapping keys, and the install died as an
+// opaque "docker compose pull failed: exit status 1".
+func TestRender_N8N_NoDuplicateEnvKeys(t *testing.T) {
+	cat, _ := LoadDir(repoCatalogDir(t))
+	a, ok := cat.Get("n8n")
+	if !ok {
+		t.Fatal("n8n missing from catalog")
+	}
+	out, err := Render(a, RenderParams{
+		Slug: "n8n", Name: "aaautomation", Domain: "auto.example.com",
+		ImageChannel: "n8nio/n8n:2.28.2",
+		DataRoot:     "/var/lib/jabali/docker-apps/n8n-aaautomation",
+		CPULimit:     "2.0", MemoryLimit: "1024",
+		Ports: map[string]RuntimePort{"http": {HostPort: 10000, ContainerPort: 5678, BindInterface: "127.0.0.1", Protocol: "tcp"}},
+		// Exactly the .Env shape from the failed production install.
+		Env: map[string]string{
+			"N8N_HOST":         "auto.example.com",
+			"WEBHOOK_URL":      "https://auto.example.com/",
+			"GENERIC_TIMEZONE": "Asia/Jerusalem",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, key := range []string{"N8N_HOST:", "WEBHOOK_URL:", "N8N_EDITOR_BASE_URL:"} {
+		if got := strings.Count(out, key); got != 1 {
+			t.Errorf("%s appears %d times, want exactly 1:\n%s", key, got, out)
+		}
+	}
+	// The template-owned values win; the pass-through key survives.
+	if !strings.Contains(out, `N8N_HOST: "0.0.0.0"`) {
+		t.Error("template-owned N8N_HOST value must win")
+	}
+	if !strings.Contains(out, `GENERIC_TIMEZONE: "Asia/Jerusalem"`) {
+		t.Error("non-conflicting env keys must still pass through")
+	}
+	// The bare "1024" memory limit means BYTES to compose — must be
+	// normalised to megabytes.
+	if !strings.Contains(out, "memory: 1024m") {
+		t.Error("unitless memory limit must render with an m suffix")
+	}
+}
+
+func TestRender_Mealie_NoDuplicateBaseURL(t *testing.T) {
+	cat, _ := LoadDir(repoCatalogDir(t))
+	a, ok := cat.Get("mealie")
+	if !ok {
+		t.Skip("mealie not in catalog")
+	}
+	out, err := Render(a, RenderParams{
+		Slug: "mealie", Name: "recipes", Domain: "food.example.com",
+		ImageChannel: a.ImageChannel,
+		DataRoot:     "/var/lib/jabali/docker-apps/mealie-recipes",
+		CPULimit:     "1.0", MemoryLimit: "512m",
+		Ports: map[string]RuntimePort{"http": {HostPort: 10001, ContainerPort: 9000, BindInterface: "127.0.0.1", Protocol: "tcp"}},
+		Env:   map[string]string{"BASE_URL": "https://food.example.com"},
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got := strings.Count(out, "BASE_URL:"); got != 1 {
+		t.Errorf("BASE_URL appears %d times, want exactly 1", got)
+	}
+}
+
+// The render-time YAML probe turns any future duplicate-key template bug
+// into a clear error instead of a failed install.
+func TestRenderRejectsDuplicateKeysAtRenderTime(t *testing.T) {
+	e := Entry{
+		Slug: "duptest",
+		composeTmpl: `services:
+  app:
+    image: x
+    environment:
+      A: "1"
+      A: "2"
+`,
+	}
+	if _, err := Render(e, RenderParams{}); err == nil {
+		t.Fatal("expected a render error for duplicate mapping keys")
+	} else if !strings.Contains(err.Error(), "not valid YAML") {
+		t.Errorf("error should name the YAML problem, got: %v", err)
+	}
+}
+
+func TestNormalizeMemoryLimit(t *testing.T) {
+	cases := map[string]string{
+		"1024":  "1024m",
+		"512m":  "512m",
+		"1g":    "1g",
+		"":      "",
+		" 256 ": "256m",
+	}
+	for in, want := range cases {
+		if got := normalizeMemoryLimit(in); got != want {
+			t.Errorf("normalizeMemoryLimit(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Root-caused from a failed n8n install on a production box (`auto.aramapp.co.il`): `docker_apps.last_error` said only `docker compose pull failed: exit status 1`; the real error was

```
failed to parse compose.yml: yaml: construct errors: mapping key "N8N_HOST" already defined at line 7
```

## Three fixes

1. **n8n + mealie templates — duplicate env keys.** The install flow materialises catalog env defaults into `.Env` (`N8N_HOST`, `WEBHOOK_URL`; mealie: `BASE_URL`), and the templates *also* hardcode those keys before the generic `.Env` pass-through range — so both were emitted and docker compose refused the file. The range now excludes template-owned keys (template values win, non-conflicting keys like `GENERIC_TIMEZONE` still pass through).

2. **Render-time strict YAML probe.** `Render()` now parses its own output with yaml.v3 (which rejects duplicate mapping keys) before returning — any future template/`.Env` collision fails at render time with a clear error naming the problem, instead of a failed install with an opaque pull error. The full-catalog render test suite passes the probe, so no other app currently trips it.

3. **Memory-unit normalisation.** The same failed install carried `memory: 1024` — a bare number means **bytes** to compose, so once the parse error was fixed the container would have started with a 1 KiB limit and been OOM-killed instantly. All-digit memory limits now render with an `m` suffix (operator "1024" = megabytes), at the same chokepoint as the CPU clamp (GH#178 precedent); values with units pass through untouched.

## Test plan
- [x] New regression test renders n8n with the exact `.Env` shape from the failed production install: every key appears exactly once, template-owned values win, `memory: 1024m`
- [x] mealie `BASE_URL` single-emission test
- [x] Duplicate-key probe test (synthetic template) + `normalizeMemoryLimit` table test
- [x] Full `go test ./panel-api/...` green post-rebase (includes the whole-catalog render tests against the new strict probe)
- [ ] After merge + deploy on the affected box: reset the failed app row to pending and let the reconciler re-dispatch the install

🤖 Generated with [Claude Code](https://claude.com/claude-code)