### PR TITLE
fix(docker-apps): agent honors the RECOVERY compose sentinel instead of writing it to disk

### DIFF
--- a/panel-agent/internal/commands/docker_app.go
+++ b/panel-agent/internal/commands/docker_app.go
@@ -13,6 +13,7 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -99,6 +100,11 @@ type dockerAppInstallResponse struct {
 // subdirectories, and runs `docker compose up -d`. When
 // wait_healthy=true, blocks until the container reports healthy or
 // the healthcheck_timeout_seconds budget runs out.
+// dockerAppComposeRecovery is the sentinel the reconciler's recovery
+// dispatch sends in compose_yml — wire contract with
+// panel-api/internal/reconciler/docker_apps.go dispatchInstall.
+const dockerAppComposeRecovery = "RECOVERY"
+
 func dockerAppInstallHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p dockerAppInstallParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -118,6 +124,23 @@ func dockerAppInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 	}
 
 	dir := filepath.Join(dockerAppDataRoot, p.Slug)
+	// Recovery dispatch (reconciler): the panel cannot re-render the
+	// compose file — the install env (user inputs, generated secrets) is
+	// not persisted on the row — so it sends the sentinel and the agent
+	// reuses the compose.yml the original REST install wrote. Until this
+	// branch existed, the sentinel string itself was written OVER the
+	// on-disk compose.yml and every reconciler recovery destroyed the
+	// install (found on a production n8n: compose.yml == "RECOVERY").
+	recovery := p.ComposeYML == dockerAppComposeRecovery
+	if recovery {
+		onDisk, rerr := os.ReadFile(filepath.Join(dir, "compose.yml"))
+		if rerr != nil || len(bytes.TrimSpace(onDisk)) == 0 || string(bytes.TrimSpace(onDisk)) == dockerAppComposeRecovery {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeNotFound,
+				Message: fmt.Sprintf("recovery dispatch for %q but no usable compose.yml on disk — re-install from the panel", p.Slug),
+			}
+		}
+	}
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir %s: %v", dir, err)}
 	}
@@ -184,8 +207,12 @@ func dockerAppInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 
 	// Atomic write: tmp + rename so a crashed install never leaves a
 	// partial compose.yml that docker compose would try to parse.
-	if err := writeAtomicDockerApp(filepath.Join(dir, "compose.yml"), []byte(p.ComposeYML), 0o640); err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	// Skipped on recovery — the on-disk file (validated above) is the
+	// only surviving copy of the rendered install.
+	if !recovery {
+		if err := writeAtomicDockerApp(filepath.Join(dir, "compose.yml"), []byte(p.ComposeYML), 0o640); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+		}
 	}
 	if p.EnvFile != "" {
 		if err := writeAtomicDockerApp(filepath.Join(dir, ".env"), []byte(p.EnvFile), 0o600); err != nil {

--- a/panel-agent/internal/commands/docker_app_recovery_test.go
+++ b/panel-agent/internal/commands/docker_app_recovery_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// The reconciler's recovery dispatch sends compose_yml="RECOVERY",
+// meaning "reuse the compose.yml the original REST install wrote".
+// Before the sentinel branch existed the agent wrote the literal string
+// over the on-disk compose and every recovery destroyed the install
+// (production n8n: compose.yml == "RECOVERY", up failed with
+// `cannot construct !!str RECOVERY`).
+func TestDockerAppInstall_RecoveryWithoutOnDiskComposeFailsClearly(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{
+		"slug":        "definitely-not-installed-zz",
+		"compose_yml": "RECOVERY",
+	})
+	_, err := dockerAppInstallHandler(context.Background(), json.RawMessage(params))
+	if err == nil {
+		t.Fatal("expected an error for a recovery dispatch with no on-disk compose.yml")
+	}
+	ae, ok := err.(*agentwire.AgentError)
+	if !ok {
+		t.Fatalf("expected AgentError, got %T: %v", err, err)
+	}
+	if ae.Code != agentwire.CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %s (%s)", ae.Code, ae.Message)
+	}
+	if !strings.Contains(ae.Message, "re-install from the panel") {
+		t.Errorf("error must tell the operator the way out, got: %s", ae.Message)
+	}
+}
+
+func TestDockerAppInstall_EmptyComposeStillRejected(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{"slug": "x-app", "compose_yml": ""})
+	_, err := dockerAppInstallHandler(context.Background(), json.RawMessage(params))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if ae, ok := err.(*agentwire.AgentError); !ok || ae.Code != agentwire.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #828, found while recovering the production n8n install: resetting a failed `docker_apps` row to `pending` routes through the reconciler's recovery dispatch, which sends `compose_yml: "RECOVERY"` — a sentinel meaning "reuse the on-disk compose.yml" (the panel can't re-render it: install env + generated secrets aren't persisted). The agent never implemented the sentinel: it wrote the literal string over `compose.yml` and ran compose, so **every reconciler recovery dispatch destroyed the install it was recovering**:

```
yaml: construct errors: line 1: cannot construct !!str `RECOVERY` into cli.named
```

## Fix
`docker_app.install` now branches on the sentinel:
- recovery → validate + reuse the on-disk compose; refuse with a clear `CodeNotFound` ("re-install from the panel") when the file is missing, empty, or itself the sentinel (a victim of the old behaviour) — placed before `MkdirAll`, so a bad recovery creates nothing
- normal installs byte-identical

## Test plan
- [x] recovery dispatch with no usable on-disk compose → `CodeNotFound` naming the way out
- [x] empty `compose_yml` still rejected as invalid-argument
- [x] `go test ./panel-agent/... ` + reconciler suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)