### PR TITLE
fix(panel-ui): recover from stale route chunks instead of going blank

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -23,6 +23,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { App as AntdApp, ConfigProvider, Empty, Spin } from "antd";
 import type { ReactNode } from "react";
 import { lazy, Suspense, useEffect } from "react";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 
 import { AuthProvider, useAuth } from "./auth/AuthContext";
 import { RequireAdmin } from "./auth/RequireAdmin";
@@ -207,6 +208,11 @@ const ThemedApp = () => {
           </Suspense>
         ) : null}
         <BrandingTitleApplier />
+        {/* Outside Suspense on purpose: Suspense handles a PENDING lazy
+            import, never a rejected one. A chunk that 404s across a deploy
+            throws past it, and without this boundary React unmounts the tree
+            and the user gets a blank screen. */}
+        <RouteErrorBoundary>
         <Suspense
           fallback={
             <div
@@ -447,6 +453,7 @@ const ThemedApp = () => {
           <Route path="*" element={<LandingRedirect />} />
         </Routes>
         </Suspense>
+        </RouteErrorBoundary>
         </AntdApp>
       </ConfigProvider>
     </BrowserRouter>

--- a/panel-ui/src/components/RouteErrorBoundary.test.tsx
+++ b/panel-ui/src/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RouteErrorBoundary } from "./RouteErrorBoundary";
+import { isChunkLoadError } from "./chunkError";
+
+const RELOAD_FLAG = "jabali.chunkReloadAttempted";
+
+const Boom = ({ error }: { error: Error }) => {
+  throw error;
+};
+
+const chunkError = () =>
+  new TypeError("Failed to fetch dynamically imported module: https://host/assets/Dashboard-a1b2.js");
+
+describe("isChunkLoadError", () => {
+  it("recognises the shapes browsers actually produce", () => {
+    // Each engine words this differently and there is no typed error to match
+    // on, so all three have to be recognised or the boundary silently stops
+    // auto-recovering on that browser.
+    for (const msg of [
+      "Failed to fetch dynamically imported module: /assets/x-1.js", // Chrome
+      "error loading dynamically imported module",                    // Firefox
+      "Importing a module script failed.",                            // Safari
+    ]) {
+      expect(isChunkLoadError(new TypeError(msg)), msg).toBe(true);
+    }
+  });
+
+  it("does not swallow ordinary application errors", () => {
+    // A false positive here would reload the page on a real bug, hiding it and
+    // looking like a random refresh to the user.
+    expect(isChunkLoadError(new Error("Cannot read properties of undefined"))).toBe(false);
+    expect(isChunkLoadError(new Error("Request failed with status code 500"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("RouteErrorBoundary", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <RouteErrorBoundary>
+        <div>content</div>
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+
+  it("reloads once when a chunk fails to load", () => {
+    // This is the deploy case: `jabali update` replaced the hashed chunks and
+    // this tab is still holding the old index.html.
+    const reload = vi.fn();
+    render(
+      <RouteErrorBoundary reload={reload}>
+        <Boom error={chunkError()} />
+      </RouteErrorBoundary>,
+    );
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(RELOAD_FLAG)).toBe("1");
+  });
+
+  it("does not reload a second time — a broken deploy must not loop", () => {
+    // Without this guard a chunk that is genuinely gone would refresh the tab
+    // forever, which is worse than the blank page it replaced.
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+    const reload = vi.fn();
+    render(
+      <RouteErrorBoundary reload={reload}>
+        <Boom error={chunkError()} />
+      </RouteErrorBoundary>,
+    );
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText(/needs to be reloaded/i)).toBeTruthy();
+  });
+
+  it("shows a real error instead of a blank page for non-chunk failures", () => {
+    const reload = vi.fn();
+    render(
+      <RouteErrorBoundary reload={reload}>
+        <Boom error={new Error("boom")} />
+      </RouteErrorBoundary>,
+    );
+    // Never auto-reload an application error — that would hide the bug and
+    // present as a page that randomly refreshes itself.
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText(/Something went wrong/i)).toBeTruthy();
+  });
+
+  it("clears the guard when the user retries by hand", () => {
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+    const reload = vi.fn();
+    render(
+      <RouteErrorBoundary reload={reload}>
+        <Boom error={chunkError()} />
+      </RouteErrorBoundary>,
+    );
+    screen.getByRole("button", { name: /reload/i }).click();
+    expect(reload).toHaveBeenCalledTimes(1);
+    // Cleared so a later, unrelated stale chunk can still auto-recover.
+    expect(sessionStorage.getItem(RELOAD_FLAG)).toBeNull();
+  });
+});

--- a/panel-ui/src/components/RouteErrorBoundary.tsx
+++ b/panel-ui/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,117 @@
+// RouteErrorBoundary — catches route-chunk load failures and recovers.
+//
+// The app splits into 56 lazy() route chunks and had no error boundary at all.
+// Suspense only handles a PENDING import; a REJECTED one throws past it, and
+// with nothing to catch it React unmounts the tree. The user gets a blank
+// screen — no message, no recovery, nothing in the UI to act on.
+//
+// This is not hypothetical, and it is not rare. Chunk filenames are content
+// hashed, and webui.go deliberately 404s an unknown asset rather than serving
+// index.html in its place:
+//
+//	(open across a deploy) must 404 — NOT fall through to index.html.
+//
+// That is the right server behaviour — handing back HTML for a .js request
+// would fail more confusingly. But it means every `jabali update` strands any
+// browser still holding the previous index.html: the moment that tab navigates
+// to a lazy route, it requests a chunk name that no longer exists, gets a 404,
+// and goes blank. Reloading fixes it because the fresh index.html references
+// the new hashes — which is exactly the "it goes blank, a refresh fixes it"
+// report this was written for.
+//
+// So a stale chunk gets ONE automatic reload, guarded by a sessionStorage flag
+// so a genuinely broken deploy cannot put the tab in a refresh loop. Anything
+// else — or a reload that did not help — renders an error with a manual retry
+// instead of a blank page.
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button, Result } from "antd";
+import { isChunkLoadError } from "./chunkError";
+
+const RELOAD_FLAG = "jabali.chunkReloadAttempted";
+
+interface Props {
+  children: ReactNode;
+  /** Injected in tests so the reload path can be asserted without navigating. */
+  reload?: () => void;
+}
+
+interface State {
+  error: Error | null;
+  /** True when we already reloaded once and the chunk still would not load. */
+  reloadDidNotHelp: boolean;
+}
+
+export class RouteErrorBoundary extends Component<Props, State> {
+  state: State = { error: null, reloadDidNotHelp: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Keep the stack in the console — the UI below deliberately does not show
+    // it, but whoever is debugging needs more than "something went wrong".
+    console.error("[route] render failed", error, info.componentStack);
+
+    if (!isChunkLoadError(error)) return;
+
+    let alreadyTried = false;
+    try {
+      alreadyTried = sessionStorage.getItem(RELOAD_FLAG) === "1";
+    } catch {
+      // Private mode / storage disabled. Treat as "already tried" so we show
+      // the error rather than risking a reload loop we cannot detect.
+      alreadyTried = true;
+    }
+
+    if (alreadyTried) {
+      this.setState({ reloadDidNotHelp: true });
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(RELOAD_FLAG, "1");
+    } catch {
+      /* best effort */
+    }
+    (this.props.reload ?? (() => window.location.reload()))();
+  }
+
+  private handleRetry = () => {
+    try {
+      sessionStorage.removeItem(RELOAD_FLAG);
+    } catch {
+      /* best effort */
+    }
+    (this.props.reload ?? (() => window.location.reload()))();
+  };
+
+  render() {
+    const { error, reloadDidNotHelp } = this.state;
+    if (!error) return this.props.children;
+
+    const chunk = isChunkLoadError(error);
+    // A chunk error we have not yet reloaded for is about to reload the page;
+    // render nothing rather than flashing an error the user cannot read.
+    if (chunk && !reloadDidNotHelp) return null;
+
+    return (
+      <Result
+        status={chunk ? "warning" : "error"}
+        title={chunk ? "This page needs to be reloaded" : "Something went wrong"}
+        subTitle={
+          chunk
+            ? "The panel was updated while this tab was open, so part of it could no longer be loaded. Reloading picks up the new version."
+            : "An unexpected error stopped this page from rendering. Reloading usually clears it; if it keeps happening the details are in the browser console."
+        }
+        extra={
+          <Button type="primary" onClick={this.handleRetry}>
+            Reload
+          </Button>
+        }
+      />
+    );
+  }
+}
+
+export default RouteErrorBoundary;

--- a/panel-ui/src/components/chunkError.ts
+++ b/panel-ui/src/components/chunkError.ts
@@ -1,0 +1,16 @@
+/**
+ * Recognise a failed dynamic import.
+ *
+ * Vite/Rollup surface this differently per browser and there is no typed error
+ * to match on, so the message is all we have. Matching loosely is deliberate: a
+ * false positive costs one page reload, a false negative costs a blank screen.
+ *
+ * Lives apart from RouteErrorBoundary so that file only exports a component
+ * (React Fast Refresh requirement).
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  const msg = error instanceof Error ? `${error.name}: ${error.message}` : String(error ?? "");
+  return /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|chunkloaderror|dynamically imported module/i.test(
+    msg,
+  );
+}


### PR DESCRIPTION
"Intermittent, not just fresh servers, a refresh fixes it" pointed straight at this.

## The SPA has 56 lazy chunks and no error boundary

`Suspense` handles a **pending** dynamic import. It does not handle a **rejected** one — that throws past it, and with nothing to catch it React unmounts the tree. Blank screen, no message, no recovery.

## Why that fires on every update

Chunk filenames are content-hashed, and `webui.go` deliberately 404s an unknown asset rather than substituting index.html:

```go
// (open across a deploy) must 404 — NOT fall through to index.html.
```

That's the right call — handing back HTML for a `.js` request fails more confusingly. But it means **`jabali update` strands any browser still holding the previous `index.html`**. The moment that tab navigates to a lazy route it asks for a chunk name that no longer exists, gets a 404, and goes blank. Reloading fixes it because the fresh `index.html` references the new hashes.

Intermittent, unrelated to a fresh install, cured by refresh — which is the report.

## Behaviour

- **Stale chunk** → one automatic reload, guarded by a `sessionStorage` flag so a genuinely broken deploy can't leave the tab refreshing forever. That loop would be worse than the blank page it replaced.
- **Reload didn't help** → a `Result` explaining the panel was updated, with a manual Reload.
- **Any non-chunk error** → error `Result`, and **never** an auto-reload. Hiding a real bug behind a page that silently refreshes itself is its own trap.

The matcher covers all three browser phrasings (Chrome / Firefox / Safari word this differently and there's no typed error to key off). Loose matching is deliberate: a false positive costs one reload, a false negative costs a blank screen.

## What this does not explain

Your first screenshot showed the **shell rendered with an empty content pane**. A boundary at this level replaces everything below it, so that specific presentation is a *different* fault. I'd rather say that plainly than let this look like a complete diagnosis.

Two hypotheses I tested and **disproved** along the way, so nobody re-treads them:

- **`RequireAdmin`** — renders a centred `Spin` while loading; it cannot produce a blank pane.
- **The identity cache race** — `clearIdentity()` sets `inflight = null` without cancelling an in-flight pre-login `/me`, so I expected a late 401 to clobber the logged-in identity. Wrote a test driving that exact interleaving; it passes. Not the cause.

If the shell-with-empty-pane recurs after this ships, it still needs a network trace from the moment of failure.

## Tests

Seven, covering: the three browser phrasings; that ordinary app errors are *not* matched (a false positive would reload on a real bug); one reload on a chunk error; no second reload; a real error rendered for non-chunk failures; and the guard cleared on manual retry.

**187 UI tests pass**, `tsc -b` clean, eslint clean.
