### PR TITLE
feat(migrate): make a dirty schema diagnosable and recoverable

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -3287,6 +3287,14 @@ Database migration commands
 jabali migrate
 ```
 
+#### `jabali migrate force`
+
+Clear the dirty flag by asserting the schema is at <version> (runs no SQL)
+
+```
+jabali migrate force <version>
+```
+
 #### `jabali migrate imap`
 
 Migrate a remote IMAP mailbox into a jabali mailbox (GH #390/#374)
@@ -3411,6 +3419,14 @@ jabali migrate restore [flags]
 - `--target-package-id` — hosting package ULID (auto-create only)
 - `--target-password` — destination password (auto-create only; ≥10 chars)
 - `--target-user` — destination jabali username (default: the source account)
+
+#### `jabali migrate status`
+
+Show the schema version and whether it is dirty
+
+```
+jabali migrate status
+```
 
 #### `jabali migrate up`
 
@@ -4446,6 +4462,7 @@ jabali repair [flags]
 - `--crowdsec-bouncer-key` — Fix only: crowdsec-firewall-bouncer crash-loops with stale LAPI key
 - `--daemon-reload` — Fix only: systemd has unloaded unit-file changes on disk
 - `--diagnose` — Report broken conditions without fixing
+- `--dirty-migration` — Fix only: database schema is dirty — panel-api cannot start
 - `--docroot-www-data-group` — Fix only: web docroot files not group www-data / dirs not setgid (nginx 403 on newly uploaded media)
 - `--etc-jabali-perms` — Fix only: /etc/jabali not traversable by hosting users (SSH/SFTP locked out — sandbox-mode unreadable)
 - `--git-ownership` — Fix only: /opt/jabali-panel/.git owned by wrong user

--- a/panel-api/cmd/server/migrate_cmd.go
+++ b/panel-api/cmd/server/migrate_cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -14,6 +15,8 @@ func newMigrateCmd() *cobra.Command {
 		Short: "Database migration commands",
 	}
 	cmd.AddCommand(newMigrateUpCmd())
+	cmd.AddCommand(newMigrateStatusCmd())
+	cmd.AddCommand(newMigrateForceCmd())
 	// M35 account-import subcommand. Namespaced under `migrate` so
 	// the parent `jabali migrate` reads as 'migration verbs' (one
 	// schema, one account-import). Different scope from `up` which
@@ -50,6 +53,91 @@ func newMigrateUpCmd() *cobra.Command {
 			}
 
 			fmt.Println("Migrations up-to-date.")
+			return nil
+		},
+	}
+}
+
+// newMigrateStatusCmd reports the schema version and, crucially, whether
+// golang-migrate thinks a migration is still mid-flight.
+//
+// Worth its own subcommand because the dirty state takes the panel DOWN:
+// panel-api runs migrations at startup, refuses to boot on a dirty schema, and
+// systemd restart-loops it. The operator sees a crash loop and an error telling
+// them to "Fix and force version" — golang-migrate's phrasing for something the
+// CLI previously offered no way to inspect or clear.
+func newMigrateStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show the schema version and whether it is dirty",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := sharedCfg
+			if cfg.Database.URL == "" || cfg.Database.URL == "placeholder-until-phase-3" {
+				return fmt.Errorf("DATABASE_URL not configured")
+			}
+			st, err := db.State(cfg.Database.URL)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("version: %d\n", st.Version)
+			fmt.Printf("dirty:   %v\n", st.Dirty)
+			if st.Dirty {
+				fmt.Printf(`
+Migration %d started and never recorded completion — the process was killed
+part-way (an interrupted 'jabali update' is the usual cause). panel-api runs
+migrations at startup and refuses to boot while the schema is dirty, so it is
+restart-looping right now.
+
+Before clearing this, check whether migration %d actually applied — read
+panel-api/internal/db/migrations/%06d_*.up.sql and verify its columns/tables
+are present:
+
+  mysql jabali_panel -e 'SHOW COLUMNS FROM <table>'
+
+  applied in full  ->  jabali migrate force %d      (then restart jabali-panel)
+  applied partly   ->  undo its effects by hand first, then force %d
+
+Forcing forward on a half-applied migration skips the rest permanently.
+`, st.Version, st.Version, st.Version, st.Version, st.Version-1)
+			}
+			return nil
+		},
+	}
+}
+
+// newMigrateForceCmd rewrites golang-migrate's bookkeeping to assert the schema
+// is at a given version. It runs no SQL of its own.
+//
+// The version is a required argument rather than inferred from the dirty state
+// on purpose: whether to force FORWARD (migration completed) or BACK (it did
+// not) is a judgement only someone who has looked at the schema can make, and
+// guessing wrong silently leaves the database missing changes.
+func newMigrateForceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "force <version>",
+		Short: "Clear the dirty flag by asserting the schema is at <version> (runs no SQL)",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return initConfig()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := sharedCfg
+			if cfg.Database.URL == "" || cfg.Database.URL == "placeholder-until-phase-3" {
+				return fmt.Errorf("DATABASE_URL not configured")
+			}
+			v, err := strconv.Atoi(args[0])
+			if err != nil || v < 0 {
+				return fmt.Errorf("version must be a non-negative integer, got %q", args[0])
+			}
+			if err := db.ForceVersion(cfg.Database.URL, v); err != nil {
+				return err
+			}
+			fmt.Printf("Schema forced to version %d (dirty flag cleared).\n", v)
+			fmt.Println("Restart the panel so it can run any remaining migrations:")
+			fmt.Println("  systemctl restart jabali-panel")
 			return nil
 		},
 	}

--- a/panel-api/cmd/server/repair.go
+++ b/panel-api/cmd/server/repair.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/db"
 	"os"
 	"os/exec"
 	"os/user"
@@ -214,6 +215,14 @@ func runRepair(cmd *cobra.Command, args []string) error {
 			}
 		}
 		fmt.Printf("\n→ [%s] %s\n", s.id, s.label)
+		if s.fix == nil {
+			// Detect-only step: the condition is real but clearing it needs a
+			// judgement call this command must not make on the operator's
+			// behalf (see dirty-migration). Report and move on rather than
+			// pretending it was repaired.
+			fmt.Printf("  ! %s needs a manual decision — see the detail above\n", s.id)
+			continue
+		}
 		if err := s.fix(ctx); err != nil {
 			return fmt.Errorf("repair %s: %w", s.id, err)
 		}
@@ -250,6 +259,16 @@ func confirm(prompt string) (bool, error) {
 // fixes come before any check that would itself fail without ownership.
 func repairSteps() []repairStep {
 	return []repairStep{
+		{
+			// First: a dirty schema means the panel is already down, which
+			// makes every other finding secondary.
+			id:     "dirty-migration",
+			label:  "database schema is dirty — panel-api cannot start",
+			detect: detectDirtyMigration,
+			// No fix: see detectDirtyMigration. Forcing the wrong direction
+			// silently skips schema changes, so this stays operator-driven.
+			fix: nil,
+		},
 		{
 			id:          "git-pointer",
 			label:       "/opt/jabali-panel/.git is a corrupted worktree pointer",
@@ -1442,4 +1461,39 @@ func fixEtcJabaliPerms(_ repairCtx) error {
 		}
 	}
 	return nil
+}
+
+// detectDirtyMigration reports a schema golang-migrate considers mid-flight.
+//
+// This is the highest-impact thing repair can find: panel-api runs migrations
+// at startup and refuses to boot while the schema is dirty, so the panel is
+// DOWN and systemd is restart-looping it. Before this detector existed,
+// `jabali repair --diagnose` — the tool whose whole purpose is "a host in a
+// state that would block the next update" — reported all-green on exactly that
+// host, because nothing looked at the migration table.
+//
+// Deliberately has no fix. Clearing the flag means asserting whether the
+// migration completed, and forcing the wrong way silently leaves the schema
+// missing changes. The detector points at `jabali migrate status`, which
+// explains how to tell the two cases apart.
+func detectDirtyMigration(_ repairCtx) (bool, string, error) {
+	if err := initConfig(); err != nil {
+		return false, "", nil // config unreadable — other detectors report that
+	}
+	cfg := sharedCfg
+	if cfg.Database.URL == "" || cfg.Database.URL == "placeholder-until-phase-3" {
+		return false, "", nil
+	}
+	st, err := db.State(cfg.Database.URL)
+	if err != nil {
+		// A DB we cannot reach is its own problem, and one the operator will
+		// already be seeing; do not report it as a dirty migration.
+		return false, "", nil
+	}
+	if !st.Dirty {
+		return false, "", nil
+	}
+	return true, fmt.Sprintf(
+		"schema dirty at version %d — panel-api cannot start; run `jabali migrate status` for how to clear it",
+		st.Version), nil
 }

--- a/panel-api/internal/db/dirty.go
+++ b/panel-api/internal/db/dirty.go
@@ -1,0 +1,109 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/golang-migrate/migrate/v4"
+	mmysql "github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
+
+// MigrationState reports where the schema is and whether golang-migrate
+// considers it mid-flight.
+type MigrationState struct {
+	Version uint
+	Dirty   bool
+}
+
+// State reads the current schema version and dirty flag.
+//
+// Dirty means golang-migrate started a migration and never recorded that it
+// finished — the process died in between. Every later `migrate up` then refuses
+// to run, which on this codebase means panel-api exits at startup and systemd
+// restart-loops it:
+//
+//	Error: migrate up: Dirty database version 210. Fix and force version.
+//
+// The panel is down at that point, and until now nothing in the CLI could
+// report or clear it — `jabali repair --diagnose` returned all-green while the
+// panel was in a crash loop, because it had no detector for this.
+func State(dsn string) (MigrationState, error) {
+	m, closeFn, err := newMigrator(dsn)
+	if err != nil {
+		return MigrationState{}, err
+	}
+	defer closeFn()
+
+	v, dirty, err := m.Version()
+	if err == migrate.ErrNilVersion {
+		// Fresh database, nothing applied yet. Not an error and not dirty.
+		return MigrationState{Version: 0, Dirty: false}, nil
+	}
+	if err != nil {
+		return MigrationState{}, fmt.Errorf("read migration version: %w", err)
+	}
+	return MigrationState{Version: v, Dirty: dirty}, nil
+}
+
+// ForceVersion clears the dirty flag by asserting the schema really is at
+// `version`.
+//
+// This does NOT run or roll back any SQL — it only rewrites golang-migrate's
+// bookkeeping. That makes it the right tool when a migration completed and the
+// process died before the flag was cleared, and the WRONG tool when the
+// migration only half-applied: forcing forward there would skip the remainder
+// permanently, and the next `up` would carry on from a schema that is missing
+// columns nobody will notice until a query fails.
+//
+// Callers must therefore confirm the target migration's effects are actually
+// present before calling this, which is why the CLI gates it behind an explicit
+// version argument rather than inferring one.
+func ForceVersion(dsn string, version int) error {
+	m, closeFn, err := newMigrator(dsn)
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+
+	if err := m.Force(version); err != nil {
+		return fmt.Errorf("force version %d: %w", version, err)
+	}
+	return nil
+}
+
+// newMigrator builds a migrate instance over the embedded migrations, mirroring
+// Migrate's setup. Returns a close function rather than deferring internally so
+// the caller controls the lifetime.
+func newMigrator(dsn string) (*migrate.Migrate, func(), error) {
+	driverDSN, err := ToDriverDSN(dsn)
+	if err != nil {
+		return nil, nil, err
+	}
+	sqlDB, err := openRawSQL(driverDSN)
+	if err != nil {
+		return nil, nil, err
+	}
+	closeFn := func() { _ = sqlDB.Close() }
+
+	drv, err := mmysql.WithInstance(sqlDB, &mmysql.Config{})
+	if err != nil {
+		closeFn()
+		return nil, nil, fmt.Errorf("migrate driver: %w", err)
+	}
+	srcFS, err := migrationsFSRoot()
+	if err != nil {
+		closeFn()
+		return nil, nil, fmt.Errorf("migrations fs: %w", err)
+	}
+	src, err := iofs.New(srcFS, ".")
+	if err != nil {
+		closeFn()
+		return nil, nil, fmt.Errorf("migrations source: %w", err)
+	}
+	m, err := migrate.NewWithInstance("iofs", src, "mysql", drv)
+	if err != nil {
+		closeFn()
+		return nil, nil, fmt.Errorf("migrate new: %w", err)
+	}
+	return m, closeFn, nil
+}


### PR DESCRIPTION
Found while unsticking `.165` after its interrupted updates: the panel was restart-looping and there was no way to recover it from the CLI.

## A dirty schema takes the panel down with no way out

golang-migrate marks the schema dirty when a migration starts and never records completion — an interrupted `jabali update` is the usual cause. panel-api runs migrations at startup and refuses to boot while dirty, so systemd restart-loops it:

```
Error: migrate up: Dirty database version 210. Fix and force version.
```

"Fix and force version" is golang-migrate's phrasing for something **the CLI could not do** — `jabali migrate` had only `up`.

Worse, `jabali repair --diagnose` — whose stated purpose is finding *"a host in a state that would block the next update"* — reported **every check green** on a host whose panel was in a crash loop, because nothing looked at the migration table.

On the affected box, migration 210 had applied **in full** (all three columns present) and only the bookkeeping flag was wrong. Recovering still meant knowing golang-migrate internals and hand-editing `schema_migrations`.

## Three parts

| | |
|---|---|
| `jabali migrate status` | version + dirty, and when dirty, how to tell a complete migration from a half-applied one — naming the exact file to read and the exact command for each case |
| `jabali migrate force <version>` | rewrites the bookkeeping, runs no SQL |
| repair detector | surfaces it **first**: a dirty schema means the panel is already down, so every other finding is secondary |

## Deliberately not auto-fixed

Whether to force **forward** (migration completed) or **back** (it didn't) is a judgement only someone who has looked at the schema can make. Guessing wrong silently skips schema changes that nobody notices until a query fails.

So `force` takes a **required** version rather than inferring one from the dirty state, and the repair step is detect-only.

## A bug I introduced and caught

Making the step detect-only meant `fix` was nil — and the runner calls `s.fix(ctx)` unconditionally. That would have **panicked in `jabali repair --auto`**, turning a diagnostic tool into a crash. Guarded: a detect-only step now reports that it needs a manual decision rather than claiming a repair.

## Verified end to end on the affected host

```
✗ [dirty-migration] database schema is dirty — panel-api cannot start
   BROKEN — schema dirty at version 243 — panel-api cannot start;
   run `jabali migrate status` for how to clear it
```

`migrate status` prints the guidance, `migrate force 243` clears it, panel returns to `active`. I also confirmed status reports cleanly on a healthy schema, so the detector isn't just always-on.

CLI reference golden regenerated for the two new subcommands.
