### PR TITLE
fix(docker-apps): n8n catalog — volume_owner 1000:1000 + 1024m memory default

### DIFF
--- a/install/docker-apps/n8n/app.yaml
+++ b/install/docker-apps/n8n/app.yaml
@@ -14,9 +14,16 @@ documentation: https://docs.n8n.io/
 image_channel: n8nio/n8n:2.28.2@sha256:08b9411994c0d091c5cc0969ee9edcb85b5e79f26640703c0c342076ac6f2b17
 update_mode: manual
 
+# The image runs as node (uid 1000); without volume_owner the bind-mounted
+# data dir stays owned by container-root and n8n crash-loops on
+# EACCES /home/node/.n8n/config under docker userns-remap.
+volume_owner: "1000:1000"
+
 resources:
   cpu: "1.0"
-  memory: "512m"
+  # n8n 2.x does not survive startup module loading inside 512m — V8 dies
+  # with "Ineffective mark-compacts near heap limit" before first listen.
+  memory: "1024m"
   pids: 200
 
 volumes:


### PR DESCRIPTION
Final two bugs from the production n8n install saga (after #828 fixed the render and #829 fixed the recovery sentinel), both hit in sequence on a real box:

1. **`volume_owner: "1000:1000"`** — the n8nio image runs as `node` (uid 1000). Without the field the agent leaves the bind-mounted data dir owned by container-root, and under docker userns-remap n8n crash-loops on `EACCES /home/node/.n8n/config`. Same pattern gitea/forgejo/erpnext already declare.

2. **`memory: 512m → 1024m`** — n8n 2.x does not survive startup module loading in 512m: V8 dies with `Ineffective mark-compacts near heap limit` after `n8n ready`, before the healthcheck ever passes. Every default-resource install crash-looped.

Verified live: with ownership + 1024m applied by hand on the affected box, the container reports healthy and the site serves 200 over TLS.

## Test plan
- [x] catalog render suite green (`go test ./panel-api/internal/dockerapp/`)
- [x] the exact values verified end-to-end on the production install this came from

🤖 Generated with [Claude Code](https://claude.com/claude-code)