### PR TITLE
fix(migrate): restore left wp-config and the DB user with different passwords (JAB-207, JAB-208)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_appconfigs.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs.go
@@ -340,7 +340,14 @@ func rewriteWordPress(text string, creds map[string]DBCredential) (string, bool)
 	// so the cPanel restore and the wordpress_ssh import apply one identical,
 	// proven rewriter (no drift). Behavior-preserving (same regex + php-escape,
 	// DB_HOST -> localhost).
-	return migrate.RewriteWPConfigDB(text, cred.DBName, cred.DBUser, cred.Password, "localhost")
+	// JAB-207: when a preserved compat user owns this MySQL account, the
+	// original password in the config is the one that authenticates — pass nil
+	// so DB_PASSWORD is left exactly as the source wrote it.
+	pass := &cred.Password
+	if cred.KeepSourcePassword {
+		pass = nil
+	}
+	return migrate.RewriteWPConfigDBFields(text, cred.DBName, cred.DBUser, pass, "localhost")
 }
 
 var (
@@ -376,6 +383,9 @@ func rewriteJoomla(text string, creds map[string]DBCredential) (string, bool) {
 		case "user":
 			return fmt.Sprintf("public $user = '%s';", phpEscape(cred.DBUser))
 		case "password":
+			if cred.KeepSourcePassword {
+				return m[0] // JAB-207: preserved compat hash owns this account
+			}
 			return fmt.Sprintf("public $password = '%s';", phpEscape(cred.Password))
 		case "host":
 			return "public $host = 'localhost';"

--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -36,6 +36,21 @@ type DBCredential struct {
 	DBName   string
 	DBUser   string
 	Password string // plaintext temp_pwd printed in the manifest line
+
+	// KeepSourcePassword suppresses the password rewrite in app configs.
+	//
+	// Set when a --preserve-source-state compat user takes over the MySQL
+	// account this credential names, which happens whenever the source DB
+	// user is spelled the same as the panel-managed one (JAB-207). The
+	// agent's db_user.create runs an unconditional ALTER USER for the hash
+	// path — deliberately, so the preserved hash wins (GH #633) — so the
+	// account ends up authenticating with the ORIGINAL password while
+	// Password here holds a temp one that now matches nothing.
+	//
+	// The source config already carries the original password and it matched
+	// that hash on the source, so the correct move is to leave it alone:
+	// rewrite DB name/user/host, do not touch the password.
+	KeepSourcePassword bool
 }
 
 // dbRestoreNameRe mirrors the agent's db.restore validation
@@ -108,6 +123,10 @@ func ImportDatabases(
 	// compat-user path, fix for the "migrated app sees Access denied"
 	// scar).
 	sourceToFinalDB := map[string]string{}
+	// managedUserToSourceDB maps a panel-managed MySQL user we create in this
+	// run back to the SOURCE db name its credential is keyed by. Used below to
+	// detect a compat user about to take over the same account (JAB-207).
+	managedUserToSourceDB := map[string]string{}
 	for _, dumpPath := range parsed.MySQLDumps {
 		finalName, base, ok := deriveDestDBName(dumpPath, targetUsername)
 		if !ok {
@@ -304,6 +323,10 @@ func ImportDatabases(
 									DBUser:   finalName,
 									Password: plainPwd,
 								}
+								// Remember which MySQL account this credential
+								// owns, so the compat pass below can tell when
+								// it is about to take that same account over.
+								managedUserToSourceDB[finalName] = base
 							}
 						}
 					}
@@ -362,6 +385,28 @@ func ImportDatabases(
 			if ucErr != nil {
 				res.Skipped = append(res.Skipped, fmt.Sprintf("compat_user %s: db_user.create: %v", u.Name, ucErr))
 				continue
+			}
+			// JAB-207. When the source MySQL user is spelled the same as the
+			// panel-managed one — the norm when the destination account keeps
+			// the source's name — the call above did not create a second
+			// account. It ALTERed the one the dump loop just made, replacing
+			// the temp password with the source hash. That is intended (GH
+			// #633: the preserved hash must win), but it silently invalidates
+			// the temp password the app-config rewriter is about to publish,
+			// and the migrated site then fails to connect while the summary
+			// reports success.
+			//
+			// The source config still holds the original password, which
+			// matched this hash on the source. So keep it: rewrite the DB
+			// name/user/host and leave the password alone.
+			if srcDB, collides := managedUserToSourceDB[u.Name]; collides {
+				if cred, have := res.Credentials[srcDB]; have {
+					cred.KeepSourcePassword = true
+					res.Credentials[srcDB] = cred
+				}
+				res.Skipped = append(res.Skipped, fmt.Sprintf(
+					"compat_user %s: shares the panel-managed user name — the source password hash is now authoritative for this account, so %s keeps its ORIGINAL password in app configs (the temp password reported above no longer applies)",
+					u.Name, u.Name))
 			}
 			grantedDBs := 0
 			for _, g := range u.Grant {

--- a/panel-api/internal/migrate/cpanel/restore_dbs_jab207_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs_jab207_test.go
@@ -1,0 +1,142 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// JAB-207. A cPanel restore with --preserve-source-state left every migrated
+// WordPress serving "Error establishing a database connection" while the
+// summary reported success.
+//
+// Two steps own the same MySQL account whenever the source DB user is spelled
+// the same as the panel-managed one — the norm when the destination account
+// keeps the source's name (vidoflexco_db -> vidoflexco_db):
+//
+//  1. the dump loop creates it with a fresh TEMP password and hands that to
+//     the app-config rewriter, which writes it into wp-config.php;
+//  2. the compat pass then calls db_user.create with the source hash, whose
+//     unconditional ALTER USER (deliberate — GH #633, the preserved hash must
+//     win) replaces that temp password.
+//
+// The account then authenticates with the ORIGINAL password while wp-config
+// holds the temp one. Neither step is wrong on its own, which is why the
+// summary was green.
+//
+// The source config already carries the original password and it matched that
+// hash on the source, so the fix keeps it: rewrite DB name/user/host, leave the
+// password untouched.
+func TestRewriteWordPress_KeepsSourcePasswordWhenCompatUserOwnsAccount(t *testing.T) {
+	t.Parallel()
+
+	const wpConfig = `<?php
+define('DB_NAME', 'vidoflexco_db');
+define('DB_USER', 'vidoflexco_db');
+define('DB_PASSWORD', 'origPass14chr');
+define('DB_HOST', 'localhost');
+`
+
+	creds := map[string]DBCredential{
+		"vidoflexco_db": {
+			DBName:   "vidoflexco_db",
+			DBUser:   "vidoflexco_db",
+			Password: "TEMPgenerated26charvalue00",
+			// Set by the compat pass on a name collision.
+			KeepSourcePassword: true,
+		},
+	}
+
+	out, changed := rewriteWordPress(wpConfig, creds)
+
+	if strings.Contains(out, "TEMPgenerated26charvalue00") {
+		t.Errorf("wp-config was rewritten to the temp password, which the compat "+
+			"ALTER USER has already invalidated — this is the exact failure "+
+			"JAB-207 reported:\n%s", out)
+	}
+	if !strings.Contains(out, "define('DB_PASSWORD', 'origPass14chr');") {
+		t.Errorf("the original password must survive — it is what the preserved "+
+			"hash authenticates:\n%s", out)
+	}
+	// The rest still has to be rewritten; only the password is special.
+	if !strings.Contains(out, "define('DB_HOST', 'localhost');") {
+		t.Errorf("DB_HOST should still be normalised:\n%s", out)
+	}
+	_ = changed
+}
+
+// The default path must be unaffected: with no collision the rewriter still
+// publishes the panel-managed temp password, which is what the freshly created
+// user authenticates with.
+func TestRewriteWordPress_WritesTempPasswordWhenNoCollision(t *testing.T) {
+	t.Parallel()
+
+	const wpConfig = `<?php
+define('DB_NAME', 'src_db');
+define('DB_USER', 'src_user');
+define('DB_PASSWORD', 'origPass');
+define('DB_HOST', 'localhost');
+`
+	creds := map[string]DBCredential{
+		"src_db": {DBName: "tgt_db", DBUser: "tgt_db", Password: "tempPW"},
+	}
+
+	out, _ := rewriteWordPress(wpConfig, creds)
+
+	for _, want := range []string{
+		"define('DB_NAME', 'tgt_db');",
+		"define('DB_USER', 'tgt_db');",
+		"define('DB_PASSWORD', 'tempPW');",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q — the non-preserve path must still rewrite all "+
+				"three:\n%s", want, out)
+		}
+	}
+}
+
+// The shared rewriter is used by the wordpress_ssh import too, so its nil
+// contract is pinned directly rather than only through the cPanel caller.
+func TestRewriteWPConfigDBFields_NilPasswordLeavesItAlone(t *testing.T) {
+	t.Parallel()
+
+	const in = `<?php
+define('DB_NAME', 'a');
+define('DB_USER', 'b');
+define('DB_PASSWORD', 'keepme');
+define('DB_HOST', 'oldhost');
+`
+	out, changed := migrate.RewriteWPConfigDBFields(in, "newdb", "newuser", nil, "localhost")
+
+	if !strings.Contains(out, "define('DB_PASSWORD', 'keepme');") {
+		t.Errorf("nil password must leave DB_PASSWORD untouched:\n%s", out)
+	}
+	if !strings.Contains(out, "define('DB_NAME', 'newdb');") ||
+		!strings.Contains(out, "define('DB_USER', 'newuser');") ||
+		!strings.Contains(out, "define('DB_HOST', 'localhost');") {
+		t.Errorf("the other three constants must still be rewritten:\n%s", out)
+	}
+	if !changed {
+		t.Error("changed should be true — name/user/host did change")
+	}
+}
+
+// A password that happens to contain a quote must still round-trip through the
+// escaper on the normal path; nil must not accidentally disable escaping for
+// everyone.
+func TestRewriteWPConfigDBFields_EscapesWhenPasswordSupplied(t *testing.T) {
+	t.Parallel()
+
+	const in = `<?php
+define('DB_NAME', 'a');
+define('DB_USER', 'b');
+define('DB_PASSWORD', 'x');
+define('DB_HOST', 'h');
+`
+	pw := `pa'ss`
+	out, _ := migrate.RewriteWPConfigDBFields(in, "d", "u", &pw, "localhost")
+	if !strings.Contains(out, `define('DB_PASSWORD', 'pa\'ss');`) {
+		t.Errorf("quote in the password was not escaped:\n%s", out)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -388,9 +388,20 @@ func insertOneMailboxRow(
 	}
 	// Loud, explicit notice — a plain "temp password set" read as harmless and
 	// the operator handed a locked-out mailbox to the tenant.
-	return []string{fmt.Sprintf(
-		"mailbox_rows: created %s@%s with a NEW password — the ORIGINAL mail password was NOT migrated; the mailbox owner is locked out until you reset it in the panel (use --preserve-source-state on a trusted same-owner migration to carry the source password)",
-		localPart, domainName)}
+	//
+	// JAB-208: the reason matters. Telling an operator who ALREADY passed
+	// --preserve-source-state to pass it reads as a plumbing failure and costs
+	// them a re-run of the whole restore to find out nothing changed. There are
+	// two distinct causes and only one of them is actionable:
+	//
+	//   flag off        -> preservation was never attempted; the hint is right.
+	//   flag on, no hash -> nothing portable existed to carry. A cPanel
+	//                       system-account mailbox authenticates against
+	//                       /etc/shadow, so ~/etc/<domain>/shadow holds no
+	//                       entry for it; non-bcrypt schemes are dropped for
+	//                       the same reason (Stalwart cannot verify them).
+	//                       Re-running changes nothing.
+	return []string{mailboxLockoutNotice(localPart, domainName, preserveCreds)}
 }
 
 // loadSourceMailPasswords reads a HestiaCP dovecot passwd-file at
@@ -545,4 +556,21 @@ func countMaildirMessages(maildir string) (count int, bytes int64) {
 		}
 	}
 	return count, bytes
+}
+
+// mailboxLockoutNotice builds the "password not carried" summary line.
+//
+// preserveActive distinguishes the two causes: with the flag off the operator
+// can act on the hint, with it on there was simply no portable hash and saying
+// otherwise sends them to re-run a restore that cannot behave differently
+// (JAB-208).
+func mailboxLockoutNotice(localPart, domainName string, preserveActive bool) string {
+	if preserveActive {
+		return fmt.Sprintf(
+			"mailbox_rows: created %s@%s with a NEW password — the source had no portable password hash for this mailbox (a cPanel system-account mailbox authenticates against the system password, not a mail hash), so --preserve-source-state had nothing to carry; the mailbox owner is locked out until you reset it in the panel. Re-running the restore will not change this.",
+			localPart, domainName)
+	}
+	return fmt.Sprintf(
+		"mailbox_rows: created %s@%s with a NEW password — the ORIGINAL mail password was NOT migrated; the mailbox owner is locked out until you reset it in the panel (use --preserve-source-state on a trusted same-owner migration to carry the source password)",
+		localPart, domainName)
 }

--- a/panel-api/internal/migrate/cpanel/restore_mail_jab208_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_jab208_test.go
@@ -1,0 +1,44 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+// JAB-208. With --preserve-source-state active, a mailbox whose password could
+// not be carried printed the generic notice ending "use --preserve-source-state
+// … to carry the source password" — advice the operator had already followed.
+// During a fleet migration that reads as a flag-plumbing failure and costs a
+// re-run of the whole restore to establish that nothing was broken.
+//
+// A cPanel system-account mailbox authenticates against /etc/shadow, so
+// ~/etc/<domain>/shadow carries no entry for it and there is genuinely nothing
+// portable to preserve. The fallback is correct; only the guidance was wrong.
+func TestMailboxLockoutNotice_DistinguishesNoHashFromFlagOff(t *testing.T) {
+	t.Parallel()
+
+	withFlag := mailboxLockoutNotice("vidoflexco", "vidoflex.com", true)
+	if strings.Contains(withFlag, "use --preserve-source-state") {
+		t.Errorf("must not suggest a flag that is already active:\n%s", withFlag)
+	}
+	if !strings.Contains(withFlag, "no portable password hash") {
+		t.Errorf("should state why preservation was impossible:\n%s", withFlag)
+	}
+	if !strings.Contains(withFlag, "will not change this") {
+		t.Errorf("should say a re-run is pointless — that is the cost being avoided:\n%s", withFlag)
+	}
+
+	withoutFlag := mailboxLockoutNotice("vidoflexco", "vidoflex.com", false)
+	if !strings.Contains(withoutFlag, "use --preserve-source-state") {
+		t.Errorf("with the flag off the hint is correct and must stay:\n%s", withoutFlag)
+	}
+
+	// Both must still name the mailbox and say the owner is locked out — that
+	// loudness was itself a fix (a quiet "temp password set" got a locked-out
+	// mailbox handed to a tenant).
+	for _, msg := range []string{withFlag, withoutFlag} {
+		if !strings.Contains(msg, "vidoflexco@vidoflex.com") || !strings.Contains(msg, "locked out") {
+			t.Errorf("notice lost the mailbox identity or the lockout warning:\n%s", msg)
+		}
+	}
+}

--- a/panel-api/internal/migrate/wpconfig.go
+++ b/panel-api/internal/migrate/wpconfig.go
@@ -26,7 +26,21 @@ func phpSingleQuoteEscape(s string) string {
 // the file and writes it back (via the agent), exactly like the cPanel restore.
 // Shared by the cPanel restore and the wordpress_ssh import so both apply the
 // identical, proven rewrite. Values are PHP single-quote escaped.
+// RewriteWPConfigDB rewrites all four DB constants.
 func RewriteWPConfigDB(text, dbName, dbUser, dbPass, dbHost string) (string, bool) {
+	return RewriteWPConfigDBFields(text, dbName, dbUser, &dbPass, dbHost)
+}
+
+// RewriteWPConfigDBFields rewrites the DB constants, leaving DB_PASSWORD alone
+// when dbPass is nil.
+//
+// Needed because a migrated site can legitimately have to KEEP the password
+// already in its config: under --preserve-source-state a compat user restores
+// the source password hash onto the very account the restore also manages, so
+// the original password is the one that authenticates and any value written in
+// its place would break the site (JAB-207). Writing a password that does not
+// work is strictly worse than writing none.
+func RewriteWPConfigDBFields(text, dbName, dbUser string, dbPass *string, dbHost string) (string, bool) {
 	if !strings.Contains(text, "DB_NAME") {
 		return text, false
 	}
@@ -38,7 +52,10 @@ func RewriteWPConfigDB(text, dbName, dbUser, dbPass, dbHost string) (string, boo
 		case "DB_USER":
 			return fmt.Sprintf("define('DB_USER', '%s');", phpSingleQuoteEscape(dbUser))
 		case "DB_PASSWORD":
-			return fmt.Sprintf("define('DB_PASSWORD', '%s');", phpSingleQuoteEscape(dbPass))
+			if dbPass == nil {
+				return line // keep whatever the source config had
+			}
+			return fmt.Sprintf("define('DB_PASSWORD', '%s');", phpSingleQuoteEscape(*dbPass))
 		case "DB_HOST":
 			return fmt.Sprintf("define('DB_HOST', '%s');", phpSingleQuoteEscape(dbHost))
 		}


### PR DESCRIPTION
Fixes **JAB-207** (high) and **JAB-208** (low) — both from the same production fleet-migration run, one commit each.

---

## JAB-207 — every migrated WordPress served "Database Error" behind a green summary

Two steps own the same MySQL account whenever the source DB user is spelled the same as the panel-managed one — the norm when the destination account keeps the source's name (`vidoflexco_db` → `vidoflexco_db`):

1. the dump loop creates it with a fresh **temp** password and hands that to the app-config rewriter, which writes it into `wp-config.php`;
2. the compat pass then calls `db_user.create` with the **source hash**, whose unconditional `ALTER USER` replaces that temp password.

**Neither step is wrong on its own**, which is exactly why nothing reported a problem. The `ALTER` is deliberate — GH #633 added it *precisely* so a preserved hash wins over a panel-managed user of the same name:

```go
// ALTER forces the hash on whether the user was just created or pre-existed
```

And the rewriter is right to publish the credential it was handed. They simply disagree about which password the account ends up with — and the summary prints both claims side by side, the second reading *"migrated apps with hardcoded creds keep working"*.

### Fix

The source config already holds the original password, and it matched that hash on the source. So keep it: the compat pass marks the credential when it takes over a managed account, and the rewriters skip the **password** while still rewriting DB name, user and host.

Writing a password that doesn't authenticate is strictly worse than writing none.

`RewriteWPConfigDBFields` takes the password as a pointer — nil means "keep whatever is there". `RewriteWPConfigDB` keeps its old signature and delegates, so the `wordpress_ssh` importer is untouched. Joomla's rewriter honours the same flag.

### Matches the reported evidence

Job `01KYZEAPVGSAV81AC86Q38PFF8`, source account `vidoflexco`: destination `mysql.user` carried the source hash byte-identical while `wp-config.php` held a 26-char generated value hashing to something matching nothing. Restoring the source password by hand turned the site from 500 to 200 — which is precisely what this now does automatically.

### Tests

The collision case is **red without the fix** (`wp-config was rewritten to the temp password`). Also covered: the ordinary no-collision path still publishing the temp password, the shared rewriter's nil contract, and that supplying a password still escapes quotes.

---

## JAB-208 — advice the operator had already followed

A restore run **with** `--preserve-source-state` still printed:

> …locked out until you reset it in the panel (use `--preserve-source-state` on a trusted same-owner migration to carry the source password)

Two distinct causes reached the same message, and only one is actionable:

| | |
|---|---|
| flag **off** | preservation never attempted — the hint is right |
| flag **on**, no hash | nothing portable existed. A cPanel system-account mailbox authenticates against `/etc/shadow`, so `~/etc/<domain>/shadow` holds no entry for it. **Re-running changes nothing.** |

The fallback itself was correct; only the guidance was wrong. The notice now names the real reason and says plainly that a re-run won't change it.

Extracted into `mailboxLockoutNotice` so both branches are testable — the message *is* the behaviour here. The test also pins what must not regress: both branches still name the mailbox and say the owner is locked out, loudness that was itself an earlier fix after a quiet "temp password set" got a locked-out mailbox handed to a tenant.

---

Full Go suite green (73 packages), `go vet` clean.

**Not verified on a box** — I have no cPanel source to restore from. The collision logic is unit-tested against the exact shapes from the report, but a real restore of a same-named WP account would be the definitive check before this goes near the rest of that fleet.
