### PR TITLE
fix(php): unblock WP purge spool from the FPM jail (JAB-199) + opcache sizing for real WP sites (JAB-200)

### DIFF
--- a/install/php/jabali-php-pool.conf.tmpl
+++ b/install/php/jabali-php-pool.conf.tmpl
@@ -38,7 +38,14 @@ security.limit_extensions = .php
 ; connection, not TCP) can reach it. Without it open_basedir blocks the
 ; socket and only 127.0.0.1 (TCP) works (GH#112). The socket file is
 ; root/mysql-owned and not user-writable, so it adds no jailbreak surface.
-php_admin_value[open_basedir] = /home/{{.User}}:/run/mysqld/mysqld.sock:/tmp:/var/tmp
+; /run/jabali-wp-purge is the WP->nginx cache-purge spool (GH #611/#619,
+; JAB-199): the jabali-cache plugin drops purge requests there for the
+; agent's spool watcher. Without it in open_basedir the plugin's is_dir()
+; guard trips the restriction on every wp-admin request and concludes
+; "not a Jabali host" -- every content-edit purge of the micro-cache was
+; a silent no-op fleet-wide. Spool dir only; the watcher validates every
+; request, so this adds no jailbreak surface.
+php_admin_value[open_basedir] = /home/{{.User}}:/run/mysqld/mysqld.sock:/tmp:/var/tmp:/run/jabali-wp-purge
 ; Tenant command-exec lockdown (GH #401). Tenants are SFTP-only, so PHP is
 ; their exec vector; without this a tenant shell_exec/proc_open runs arbitrary
 ; commands as their uid from any web request. php_admin_value (not overridable)
@@ -50,9 +57,17 @@ php_admin_value[open_basedir] = /home/{{.User}}:/run/mysqld/mysqld.sock:/tmp:/va
 {{- if .DisableFunctions }}
 php_admin_value[disable_functions] = {{ .DisableFunctions }}
 {{- end }}
-; Opcache SHM cap. Conservative 32MB per pool keeps total bounded on
-; shared-host boxes (20 users × 32MB = 640MB). Tune in the runbook.
-php_admin_value[opcache.memory_consumption] = 32
+; Opcache sizing (JAB-200). The old 32MB cap filled instantly on any real
+; WP site (WooCommerce + Elementor = 10k+ PHP files) and opcache does not
+; evict -- once full it stops caching new scripts and every request pays
+; recompilation, wp-admin hardest. 128MB fits such sites; SHM is mmap'd
+; and faulted lazily, so 20 idle pools do NOT hold 20x128MB of real RAM --
+; resident use tracks what each site actually compiles.
+; max_accelerated_files must exceed the site's file count or the key
+; table saturates the same way (default 10000 < one Woo+Elementor site);
+; PHP rounds 20000 up to the next prime.
+php_admin_value[opcache.memory_consumption] = 128
+php_admin_value[opcache.max_accelerated_files] = 20000
 ; Shared-hosting PHP defaults (GH #253). php_value (not php_admin_value) so a
 ; per-domain override below takes precedence; these apply only when the domain
 ; sets nothing. Stock PHP defaults (128M / 2M / 8M / 1000) are too small for

--- a/panel-agent/internal/commands/php_pool_template_repo_test.go
+++ b/panel-agent/internal/commands/php_pool_template_repo_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Pins the load-bearing lines of the REPO pool template (the box copy at
+// /etc/jabali-panel/php-pool.conf.tmpl is installed from it on every
+// `jabali update`). Two regressions this guards:
+//
+//   - JAB-199: /run/jabali-wp-purge missing from open_basedir made the
+//     jabali-cache purge spool invisible from the FPM jail — every WP
+//     content-edit purge of the nginx micro-cache was a silent no-op
+//     fleet-wide.
+//   - JAB-200: 32MB opcache with default max_accelerated_files saturated
+//     on any real WP site (10k+ files) and opcache does not evict —
+//     once full, every request recompiles.
+func TestRepoPoolTemplatePinsJailAndOpcache(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "install", "php", "jabali-php-pool.conf.tmpl")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read repo pool template: %v", err)
+	}
+	s := string(b)
+
+	base := ""
+	for _, line := range strings.Split(s, "\n") {
+		if strings.HasPrefix(line, "php_admin_value[open_basedir]") {
+			base = line
+			break
+		}
+	}
+	if base == "" {
+		t.Fatal("template has no open_basedir line — the jail is the whole tenant-isolation posture")
+	}
+	if !strings.Contains(base, ":/run/jabali-wp-purge") {
+		t.Errorf("open_basedir must include the WP purge spool (JAB-199): %s", base)
+	}
+	if !strings.Contains(base, "/home/{{.User}}") {
+		t.Errorf("open_basedir must stay anchored to the tenant home: %s", base)
+	}
+
+	if !strings.Contains(s, "php_admin_value[opcache.memory_consumption] = 128") {
+		t.Error("opcache.memory_consumption must be 128 (JAB-200 — 32 saturates on real WP sites)")
+	}
+	if !strings.Contains(s, "php_admin_value[opcache.max_accelerated_files] = 20000") {
+		t.Error("opcache.max_accelerated_files must be raised above one site's file count (JAB-200)")
+	}
+}


### PR DESCRIPTION
Two pool-template fixes from the brown-online.co.il cache investigation, both propagating automatically on `jabali update` (existing GH #401 template-reinstall + pool-reapply prelude).

## JAB-199 — WP→nginx purge was a silent no-op fleet-wide

`open_basedir` didn't include `/run/jabali-wp-purge`, so the jabali-cache plugin's `is_dir()` spool guard hit the restriction on every wp-admin request and returned "not a Jabali host" — every content-edit purge (save_post, comments, theme/permalink changes) never reached the agent's spool watcher. Visitors could see pages up to `cache_ttl` (600s default) stale after every edit. #809 silenced the per-request warning; this fixes the actual blockage. The spool dir is `1777 root:root` (tmpfiles.d) and the watcher validates every request, so whitelisting it adds no jailbreak surface — the ADR-0023 posture is unchanged.

## JAB-200 — opcache saturated on any real WP site

`opcache.memory_consumption = 32` with the default `max_accelerated_files` (10000): a stock WooCommerce + Elementor site is 10k+ PHP files (10,161 observed in production). opcache does not evict — once full it stops caching new scripts and every request pays recompilation, hitting wp-admin hardest (exactly the traffic no page cache can help). Now **128 MB + 20000 files**. opcache SHM is mmap'd and lazily faulted, so N idle pools do not pin N×128 MB of resident RAM; the old "20 users × 32 MB" comment math conflated virtual and resident. Package-level sizing knob (per the issue) stays a follow-up.

## Test plan
- [x] New repo-template regression test pins the open_basedir spool entry + both opcache values
- [x] Pool apply/render suites green (`go test ./panel-agent/...`)
- [ ] Post-merge on a live box: `jabali update`, then from a tenant FPM jail confirm the spool guard passes and a save_post purges the micro-cache (jcache log shows the PURGE); `opcache_get_status()` no longer reports memory full

🤖 Generated with [Claude Code](https://claude.com/claude-code)