### PR TITLE
feat(notifications): SSE push for the bell inbox (JAB-204)

### DIFF
--- a/panel-api/internal/api/notifications_inbox.go
+++ b/panel-api/internal/api/notifications_inbox.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -48,12 +49,125 @@ func RegisterNotificationsInboxRoutes(g *gin.RouterGroup, cfg NotificationsInbox
 	}
 	h := &inboxHandler{cfg: cfg}
 	g.GET("/notifications/inbox", h.list)
+	g.GET("/notifications/inbox/stream", h.stream)
 	g.POST("/notifications/inbox/:id/read", h.markRead)
 	g.POST("/notifications/inbox/read-all", h.readAll)
 	g.DELETE("/notifications/inbox", h.clearAll)
 }
 
 type inboxHandler struct{ cfg NotificationsInboxHandlerConfig }
+
+// inboxStreamPollInterval is the server-side change-detection cadence for
+// the SSE stream. One indexed COUNT + one LIMIT-1 list per tick per open
+// tab — far cheaper than the REST poll it replaces (full list + DLQ
+// cross-reference through the whole middleware stack), and events reach
+// the bell within this interval instead of the old 30s client poll.
+const inboxStreamPollInterval = 5 * time.Second
+
+// inboxStreamMaxAge hard-caps one SSE connection; EventSource reconnects
+// transparently, so this just bounds zombie connections from abandoned
+// tabs the client never closed.
+const inboxStreamMaxAge = 30 * time.Minute
+
+// stream is the JAB-204 bell push channel: emits an "inbox" event with
+// {unread, latest_id} immediately on connect and then whenever the
+// fingerprint changes. Same server-side poll-and-stream shape as the
+// migrations SSE (ADR-0095 decision 4) — no in-process pub/sub to keep
+// coherent, works across multiple panel-api replicas, and the DB stays
+// the single source of truth.
+func (h *inboxHandler) stream(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil || claims.UserID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no") // disable nginx proxy_buffering
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "streaming_unsupported"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	fingerprint := func() (string, bool) {
+		var unread int64
+		var err error
+		if claims.IsAdmin {
+			unread, err = h.cfg.History.CountUnreadForAdminInbox(ctx, claims.UserID)
+		} else {
+			unread, err = h.cfg.History.CountUnreadForUser(ctx, claims.UserID)
+		}
+		if err != nil {
+			return "", false
+		}
+		// Latest row id catches the read-one-while-another-arrives case
+		// where the unread count alone stays flat.
+		var rows []models.NotificationHistory
+		if claims.IsAdmin {
+			rows, _, err = h.cfg.History.ListForAdminInbox(ctx, claims.UserID, repository.ListOptions{Limit: 1})
+		} else {
+			rows, _, err = h.cfg.History.ListForUser(ctx, claims.UserID, repository.ListOptions{Limit: 1})
+		}
+		if err != nil {
+			return "", false
+		}
+		latest := ""
+		if len(rows) > 0 {
+			latest = rows[0].ID
+		}
+		return fmt.Sprintf(`{"unread":%d,"latest_id":%q}`, unread, latest), true
+	}
+
+	emit := func(payload string) {
+		fmt.Fprintf(c.Writer, "event: inbox\ndata: %s\n\n", payload)
+		flusher.Flush()
+	}
+
+	last, ok := fingerprint()
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	emit(last)
+
+	ticker := time.NewTicker(inboxStreamPollInterval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(inboxStreamMaxAge)
+	defer deadline.Stop()
+	heartbeat := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline.C:
+			return // EventSource reconnects; bounds abandoned-tab zombies
+		case <-ticker.C:
+			cur, ok := fingerprint()
+			if !ok {
+				continue // transient DB error — keep the stream alive
+			}
+			if cur != last {
+				last = cur
+				emit(cur)
+				heartbeat = 0
+				continue
+			}
+			// SSE comment as keepalive so idle proxies don't reap the
+			// connection (~every 25s at the 5s tick).
+			heartbeat++
+			if heartbeat >= 5 {
+				heartbeat = 0
+				fmt.Fprint(c.Writer, ": keepalive\n\n")
+				flusher.Flush()
+			}
+		}
+	}
+}
 
 // inboxRow extends NotificationHistory with a transient is_dead_letter
 // flag the UI uses to badge the row. Computed per request from the

--- a/panel-api/internal/api/notifications_inbox_stream_test.go
+++ b/panel-api/internal/api/notifications_inbox_stream_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-204: the bell SSE stream must emit an initial "inbox" event with the
+// unread count + latest row id on connect, and close when the client goes
+// away. Change-detection over time is exercised by the fingerprint logic
+// this initial event shares; the ticker path just re-runs it.
+func TestInboxStream_InitialEventAndClientClose(t *testing.T) {
+	t.Parallel()
+	repo := &fakeHistoryRepo{rows: map[string]*models.NotificationHistory{
+		"n1": {ID: "n1", UserID: strPtrForTest("u1"), EventKind: "x", Title: "unread one"},
+		"n2": {ID: "n2", UserID: strPtrForTest("u2"), EventKind: "x", Title: "not mine"},
+	}}
+	r := newInboxRouter(t, repo, newUserCtx())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications/inbox/stream", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.ServeHTTP(rec, req)
+	}()
+	select {
+	case <-done:
+		// handler returned once the client context expired — correct.
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream handler did not return after client context cancellation")
+	}
+
+	require.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	require.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+	body := rec.Body.String()
+	require.Contains(t, body, "event: inbox")
+	// u1 has exactly one unread row (n1); n2 belongs to someone else.
+	require.Contains(t, body, `"unread":1`)
+	require.Contains(t, body, `"latest_id":"n1"`)
+}
+
+func TestInboxStream_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	repo := &fakeHistoryRepo{rows: map[string]*models.NotificationHistory{}}
+	r := newInboxRouter(t, repo, nil) // no claims middleware
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/notifications/inbox/stream", nil)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.NotContains(t, rec.Body.String(), "event: inbox")
+}
+
+func TestInboxStream_ContentTypeNotSetBeforeAuth(t *testing.T) {
+	t.Parallel()
+	// A 401 must be a JSON error, not a half-opened event stream.
+	repo := &fakeHistoryRepo{rows: map[string]*models.NotificationHistory{}}
+	r := newInboxRouter(t, repo, nil)
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/notifications/inbox/stream", nil)
+	require.False(t, strings.HasPrefix(rec.Header().Get("Content-Type"), "text/event-stream"))
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3854,6 +3854,12 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /notifications/inbox/stream:
+    get:
+      tags: [Notifications]
+      summary: SSE stream of inbox changes (unread count + latest id fingerprint)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: "text/event-stream — 'inbox' events on connect and on change" } }
   /notifications/inbox:
     delete:
       tags: [Notifications]

--- a/panel-ui/src/components/NotificationBell.tsx
+++ b/panel-ui/src/components/NotificationBell.tsx
@@ -91,14 +91,35 @@ export function NotificationBell() {
       );
       return data;
     },
-    // 30s poll + refetch-on-focus. Focus refetch covers the "came back
-    // to the tab" case instantly, so the background cadence only serves
-    // long-lived open tabs — 3x fewer requests than the old 10s poll
-    // with no perceived staleness. Push (SSE) is tracked separately.
-    refetchInterval: 30_000,
+    // SSE (below) is the primary delivery channel — this poll is the
+    // safety net for browsers/proxies that break EventSource. Focus
+    // refetch still covers the "came back to the tab" case instantly.
+    refetchInterval: 120_000,
     staleTime: 5_000,
     refetchOnWindowFocus: true,
   });
+
+  // JAB-204: server-push inbox updates. The stream emits an "inbox"
+  // event on connect and whenever the unread/latest fingerprint changes;
+  // each event just invalidates the query so the dropdown + badge reuse
+  // the normal fetch path. EventSource auto-reconnects on drops (the
+  // server also recycles connections every 30min); the 120s poll above
+  // covers the gaps.
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof EventSource === "undefined") return;
+    let es: EventSource | null = null;
+    try {
+      es = new EventSource("/api/v1/notifications/inbox/stream", { withCredentials: true });
+      es.addEventListener("inbox", () => {
+        qc.invalidateQueries({ queryKey: INBOX_KEY });
+      });
+    } catch {
+      // ctor threw (exotic embedders) — polling fallback carries on.
+    }
+    return () => {
+      es?.close();
+    };
+  }, [qc]);
 
   useEffect(() => {
     if (typeof navigator === "undefined" || !navigator.serviceWorker) return;


### PR DESCRIPTION
Implements JAB-204 using the house SSE pattern (migrations stream, ADR-0095 decision 4) — server-side poll-and-stream, no in-process pub/sub:

- **`GET /notifications/inbox/stream`** (session-authed): emits an `inbox` event (`{unread, latest_id}`) immediately on connect, then only when the fingerprint changes. Fingerprint = indexed unread COUNT + latest row id (`LIMIT 1`) every 5s — two cheap queries per open tab, replacing full REST list fetches through the whole middleware stack. Keepalive comment every ~25s so proxies don't reap idle streams; `X-Accel-Buffering: no` for nginx (same as the migrations stream). Connections recycle after 30 min — EventSource reconnects transparently, bounding abandoned-tab zombies. The latest-id half of the fingerprint catches the read-one-while-another-arrives case where the unread count stays flat.
- **Bell**: opens the stream and invalidates the inbox query per event — badge + dropdown reuse the normal fetch path. REST poll drops 30s → 120s safety net (EventSource-hostile embedders); refetch-on-focus unchanged.

Net: notifications land on the bell within ~5s instead of up to 30s, with fewer requests per open tab. Admin claims use the admin fingerprint (own + broadcast rows), mirroring the list scoping.

## Test plan
- [x] Stream handler: initial event carries the right unread count + latest id for the scoped user; handler returns when the client context ends; 401 stays JSON (no half-open stream)
- [x] OpenAPI coverage test green (route documented)
- [x] `go test ./panel-api/...` green; `tsc -b` + `npm run build` + vitest components green
- [ ] Post-merge on testserver: open two sessions, trigger a notification, watch the second session's bell update within ~5s without a poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)