### PR TITLE
fix(migrate): account for every message the mail import does not push (JAB-209)

### DIFF
--- a/panel-agent/internal/commands/migration_import_mailboxes.go
+++ b/panel-agent/internal/commands/migration_import_mailboxes.go
@@ -338,6 +338,13 @@ func importOneMailbox(ctx context.Context, destEmail, maildir string, allowedRoo
 func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string, _ *[]string, allowedRoots []string) (int64, int64, []string) {
 	var imported, bytes int64
 	var skipped []string
+	// JAB-209: every message that does NOT get imported has to be accounted
+	// for. Silent drops here are indistinguishable from mail loss, which is
+	// the one failure hosting customers cannot forgive — a 74k-message
+	// mailbox reported messages_found=74168 / messages_pushed=74167 with no
+	// error anywhere in the log, and the staging tree was deleted before
+	// anyone could ask which message it was.
+	var deduped int64
 	// Idempotency: Stalwart's Email/import does NOT dedup on Message-ID
 	// (a re-run would duplicate every message), so we skip any message
 	// whose Message-ID is already present in the target mailbox. The set
@@ -366,7 +373,12 @@ func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string,
 			}
 			if mid := messageIDFromFile(path, allowedRoots); mid != "" {
 				if seen[mid] {
-					continue // already in mailbox → idempotent skip
+					// Deliberate: Stalwart's Email/import does not dedup, so a
+					// re-run would duplicate every message. But this is a
+					// message counted as FOUND that will never be PUSHED, so it
+					// must be counted — not dropped on the floor.
+					deduped++
+					continue
 				}
 				seen[mid] = true
 			}
@@ -391,6 +403,14 @@ func pushMaildirSlots(ctx context.Context, accountID, mailboxID, maildir string,
 			imported++
 			bytes += n
 		}
+	}
+	if deduped > 0 {
+		// One line per mailbox rather than per message: a mailbox re-imported
+		// after a partial run legitimately dedups thousands, and that must not
+		// bury the genuine failures in the same list.
+		skipped = append(skipped, fmt.Sprintf(
+			"deduped:%d:%s — message(s) already present with the same Message-ID; not an error, but they are counted in messages_found",
+			deduped, maildir))
 	}
 	return imported, bytes, skipped
 }

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -207,6 +208,7 @@ func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.
 	if len(ag.Skipped) > 0 {
 		res.Skipped = append(res.Skipped, ag.Skipped...)
 	}
+	res.Skipped = append(res.Skipped, reconcileMailCounts(res.MessagesFound, res.MessagesPushed, ag.Skipped)...)
 
 	return res, nil
 }
@@ -520,7 +522,26 @@ func looksLikeMaildir(path string) (string, bool) {
 // countMaildirMessages walks cur/, new/, tmp/ inside a Maildir +
 // sums file count + bytes. Skips directories silently — Maildir's
 // spec says cur/new/tmp contain only regular files.
+// countMaildirMessages counts deliverable messages in a Maildir.
+//
+// JAB-209: this deliberately does NOT count tmp/. Per the Maildir spec tmp/
+// holds messages mid-delivery, and the importer only ever walks cur/ and new/ —
+// so counting tmp/ here made messages_found exceed messages_pushed by the
+// number of stale tmp/ files, with nothing logged, presenting exactly like
+// silent mail loss. A 74k-message mailbox reported 74168 found / 74167 pushed
+// and no error anywhere.
+//
+// A stale tmp/ file is an interrupted delivery, not a message the user has;
+// reporting it as findable-but-unpushed accused the importer of losing mail it
+// was never supposed to move. tmpFound is returned separately so the caller can
+// mention it without inflating the headline count.
 func countMaildirMessages(maildir string) (count int, bytes int64) {
+	c, b, _ := countMaildirMessagesDetailed(maildir)
+	return c, b
+}
+
+// countMaildirMessagesDetailed additionally reports how many files sit in tmp/.
+func countMaildirMessagesDetailed(maildir string) (count int, bytes int64, tmpFound int) {
 	for _, sub := range []string{"cur", "new", "tmp"} {
 		dir := filepath.Join(maildir, sub)
 		entries, err := os.ReadDir(dir)
@@ -540,9 +561,59 @@ func countMaildirMessages(maildir string) (count int, bytes int64) {
 			// any regular file rather than over-filter, since
 			// some clients store quirky names.
 			_ = strings.Contains(e.Name(), ":")
+			if sub == "tmp" {
+				tmpFound++
+				continue
+			}
 			count++
 			bytes += info.Size()
 		}
 	}
-	return count, bytes
+	return count, bytes, tmpFound
+}
+
+// reconcileMailCounts turns a found/pushed gap into a statement the operator
+// can act on, instead of two numbers in a stats line.
+//
+// JAB-209: a mailbox reported messages_found=74168 / messages_pushed=74167 with
+// zero occurrences of "error" or "fail" in the whole restore log, exit 0, and
+// no degraded flag — then staging was deleted, so the message could not even be
+// identified afterwards. One in 74k is survivable; a silent, unlogged gap means
+// a LARGER loss would present identically, and no operator can honestly tell a
+// customer their mail migrated.
+//
+// Most gaps are benign — a deduplicated duplicate, an oversized message we
+// declined — and those now report themselves from the agent. What must never
+// happen again is a gap nobody can explain, so anything left over after the
+// explained skips are subtracted is called out as unexplained.
+func reconcileMailCounts(found int, pushed int64, agentSkipped []string) []string {
+	gap := int64(found) - pushed
+	if gap <= 0 {
+		return nil
+	}
+	explained := int64(0)
+	for _, s := range agentSkipped {
+		switch {
+		case strings.HasPrefix(s, "deduped:"):
+			// "deduped:<n>:<maildir> — ...". The count is the SECOND field on
+			// purpose: a maildir path can itself contain a colon, so anything
+			// positioned after it cannot be parsed reliably.
+			parts := strings.SplitN(s, ":", 3)
+			if len(parts) >= 2 {
+				if n, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+					explained += n
+				}
+			}
+		case strings.HasPrefix(s, "oversized:"):
+			explained++
+		}
+	}
+	if explained >= gap {
+		return []string{fmt.Sprintf(
+			"mail: %d message(s) found but not imported — all accounted for (deduplicated or oversized; see the lines above)",
+			gap)}
+	}
+	return []string{fmt.Sprintf(
+		"WARNING mail: %d of %d message(s) were NOT imported and %d of those are UNEXPLAINED — do not report this mailbox as fully migrated. Re-run the mail import for this account before deleting the source; the staging tree is removed when the job completes.",
+		gap, found, gap-explained)}
 }

--- a/panel-api/internal/migrate/cpanel/restore_mail_jab209_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_jab209_test.go
@@ -1,0 +1,124 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-209. A cPanel restore reported
+//
+//	mailboxes: count=1 messages_found=74168 messages_pushed=74167
+//
+// with zero occurrences of "error" or "fail" in the entire restore log, exit 0,
+// and no degraded flag — then deleted the staging tree, so the message could
+// not even be identified afterwards.
+//
+// One in 74k is survivable. The pattern is not: a silent, unlogged gap means a
+// LARGER loss would present identically, and no operator can honestly tell a
+// customer their mail migrated.
+
+func TestCountMaildirMessages_ExcludesTmp(t *testing.T) {
+	t.Parallel()
+
+	// tmp/ was counted as findable while the importer only ever walks cur/ and
+	// new/, so every stale tmp/ file inflated messages_found by one and looked
+	// exactly like a lost message. Per the Maildir spec tmp/ holds deliveries
+	// in progress — an interrupted one is not mail the user has.
+	md := t.TempDir()
+	for _, sub := range []string{"cur", "new", "tmp"} {
+		if err := os.MkdirAll(filepath.Join(md, sub), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(sub, name string) {
+		if err := os.WriteFile(filepath.Join(md, sub, name), []byte("From: a@b\r\n\r\nx"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("cur", "1700000000.M1:2,S")
+	write("cur", "1700000001.M2:2,S")
+	write("new", "1700000002.M3")
+	write("tmp", "1700000003.M4") // interrupted delivery
+
+	count, _, tmpFound := countMaildirMessagesDetailed(md)
+
+	if count != 3 {
+		t.Errorf("count = %d, want 3 (cur+new only) — counting tmp/ is what made "+
+			"found exceed pushed with nothing logged", count)
+	}
+	if tmpFound != 1 {
+		t.Errorf("tmpFound = %d, want 1 — tmp/ must still be visible to the "+
+			"caller, just not folded into the pushable total", tmpFound)
+	}
+}
+
+func TestReconcileMailCounts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no gap says nothing", func(t *testing.T) {
+		if got := reconcileMailCounts(100, 100, nil); got != nil {
+			t.Errorf("expected silence when everything imported, got %v", got)
+		}
+	})
+
+	t.Run("a fully explained gap is stated but not alarming", func(t *testing.T) {
+		msgs := reconcileMailCounts(10, 8, []string{
+			"deduped:2:/srv/mail/x — message(s) already present with the same Message-ID",
+		})
+		if len(msgs) != 1 {
+			t.Fatalf("want one line, got %v", msgs)
+		}
+		if strings.Contains(msgs[0], "WARNING") {
+			t.Errorf("a gap that is entirely deduplication must not read as loss: %s", msgs[0])
+		}
+		if !strings.Contains(msgs[0], "all accounted for") {
+			t.Errorf("should say the gap is understood: %s", msgs[0])
+		}
+	})
+
+	t.Run("an unexplained gap warns loudly and says not to trust the migration", func(t *testing.T) {
+		// This is the reported case: 74168 found, 74167 pushed, nothing skipped.
+		msgs := reconcileMailCounts(74168, 74167, nil)
+		if len(msgs) != 1 {
+			t.Fatalf("want one line, got %v", msgs)
+		}
+		got := msgs[0]
+		if !strings.Contains(got, "WARNING") {
+			t.Errorf("an unexplained missing message MUST warn — silence here is "+
+				"the whole bug: %s", got)
+		}
+		if !strings.Contains(got, "UNEXPLAINED") {
+			t.Errorf("should distinguish unexplained from deduped: %s", got)
+		}
+		if !strings.Contains(got, "do not report this mailbox as fully migrated") {
+			t.Errorf("the operator needs to be told what NOT to claim: %s", got)
+		}
+		if !strings.Contains(got, "before deleting the source") {
+			t.Errorf("staging is deleted on completion, so the guidance has to "+
+				"mention the source is the remaining copy: %s", got)
+		}
+	})
+
+	t.Run("partly explained still warns about the remainder", func(t *testing.T) {
+		// 3 missing, 2 deduped -> 1 genuinely unaccounted for.
+		msgs := reconcileMailCounts(10, 7, []string{
+			"deduped:2:/srv/mail/x — message(s) already present with the same Message-ID",
+		})
+		got := msgs[0]
+		if !strings.Contains(got, "WARNING") || !strings.Contains(got, "1 of those are UNEXPLAINED") {
+			t.Errorf("a partly-explained gap must still surface the remainder: %s", got)
+		}
+	})
+
+	t.Run("oversized messages count as explained", func(t *testing.T) {
+		msgs := reconcileMailCounts(10, 9, []string{
+			"oversized:/srv/mail/x/cur/huge:120000000",
+		})
+		if strings.Contains(msgs[0], "WARNING") {
+			t.Errorf("an oversized message is a reported decision, not a silent "+
+				"drop: %s", msgs[0])
+		}
+	})
+}


### PR DESCRIPTION
Fixes **JAB-209**. Silent mail loss is the one failure hosting customers can't forgive, so the goal here is that a gap can never again be invisible.

## The reported symptom

```
mailboxes: count=1 messages_found=74168 messages_pushed=74167
```

Zero occurrences of "error" or "fail" in the entire log, exit 0, no degraded flag — then staging deleted, so the message couldn't even be identified.

## It wasn't a push failure

Genuine push errors were **already** recorded per message with filename and error. Two *other* paths produced the gap, both silent:

**1. `tmp/` was counted as findable.** `countMaildirMessages` walked `cur`, `new` **and `tmp`**; the importer only ever walks `cur` and `new`. Per the Maildir spec `tmp/` holds deliveries in progress, so a single interrupted delivery inflated `messages_found` by one, permanently, with nothing logged.

**2. The Message-ID dedup skipped with a bare `continue`.** That skip is *correct* — Stalwart's `Email/import` doesn't dedup, so a re-run would duplicate every message — but it consumed a message counted in `messages_found` and said nothing.

So the likely truth is that **no mail was lost at all**: a stale `tmp/` file isn't mail the user has, and a deduped message is a duplicate. But the operator had no way to know that, which is exactly the bug — an actual loss would have looked identical.

## What changed

- `tmp/` no longer counts toward the pushable total; its tally is returned separately so it can still be mentioned.
- Dedup reports one line per mailbox — not per message, since a mailbox re-imported after a partial run legitimately dedups thousands and would bury the real failures.
- `reconcileMailCounts` subtracts the explained skips from the gap. Anything left prints:

> **WARNING mail:** N of M message(s) were NOT imported and K of those are **UNEXPLAINED** — do not report this mailbox as fully migrated. Re-run the mail import for this account **before deleting the source**; the staging tree is removed when the job completes.

That last clause matters: staging deletion is what made the reported case unrecoverable.

## One thing the tests caught

My first version put the dedup count *after* the maildir path in the summary line. A maildir path can contain a colon, so the parser couldn't read it back — two subtests failed. The count now sits in a fixed second field.

## Tests

`tmp/` exclusion; a fully-explained gap staying calm; a partly-explained gap still surfacing the remainder; oversized counting as explained; and the reported 74168/74167 shape warning loudly.

## Not verified on a box

I have no cPanel source with a 74k mailbox. The accounting is unit-tested against the exact numbers from the report, but a real restore is the honest confirmation.

**On the acceptance criteria**: this covers logging, the visible warning, and the non-silent exit path. It does **not** yet quarantine failed messages so they survive staging cleanup — that's a larger change to the staging lifecycle and I'd rather do it separately than bolt it on here. The warning now tells the operator to re-run before deleting the source, which closes the immediate danger.
