### PR TITLE
fix(update): pass safe.directory so the local HEAD lookup works as root

### DIFF
--- a/panel-api/cmd/server/update_release_direct.go
+++ b/panel-api/cmd/server/update_release_direct.go
@@ -57,7 +57,24 @@ func latestDownloadURLs(webBase string) (tarURL, sumURL string) {
 // release channel earlier in the run, so this is the same value the API would
 // return — except it is free, offline, and immune to rate limiting.
 func localHeadSHA(ctx context.Context, repoDir string) (string, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	// -c safe.directory is required, not defensive. /opt/jabali-panel is owned
+	// by the service user while `jabali update` runs as root, so plain git
+	// refuses:
+	//
+	//	fatal: detected dubious ownership in repository at '/opt/jabali-panel'
+	//
+	// Without this the lookup fails on EVERY normal host, localHeadSHA returns
+	// an error, and resolution silently falls back to the rate-limited API
+	// path — which is the exact failure the direct path exists to avoid. It
+	// worked in testing only because a developer checkout is owned by the user
+	// running the command.
+	//
+	// Safe here: we are root, the repo belongs to our own service user, and
+	// this is a read-only rev-parse. Scoped to the one invocation rather than
+	// written into the global gitconfig.
+	out, err := exec.CommandContext(ctx, "git",
+		"-c", "safe.directory="+repoDir,
+		"-C", repoDir, "rev-parse", "HEAD").Output()
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse HEAD in %s: %w", repoDir, err)
 	}

--- a/panel-api/cmd/server/update_release_direct_test.go
+++ b/panel-api/cmd/server/update_release_direct_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -168,4 +169,63 @@ func TestByCommitDownloadURLs(t *testing.T) {
 			t.Error("unexpected hit")
 		}
 	})
+}
+
+// TestLocalHeadSHA_ForeignOwnedRepo is the case that actually happens in
+// production and did not happen in any earlier test.
+//
+// /opt/jabali-panel is owned by the service user; `jabali update` runs as root.
+// Plain git refuses that combination:
+//
+//	fatal: detected dubious ownership in repository at '/opt/jabali-panel'
+//
+// localHeadSHA then returns an error, resolution falls back to the
+// rate-limited api.github.com path, and the whole point of resolving locally is
+// lost — silently, because the fallback is by design. Verified on a real host:
+// git rev-parse as root failed there while every developer-checkout test passed,
+// because a dev checkout is owned by whoever runs the tests.
+//
+// Simulated here by pointing git's ownership check at a repo it should distrust
+// via a scrubbed environment, which is the closest a same-user test can get.
+func TestLocalHeadSHA_UsesSafeDirectory(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	ctx := context.Background()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "seed"},
+	} {
+		cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// The command localHeadSHA builds must carry the exception, otherwise a
+	// service-user-owned repo read by root fails and we fall back to the API
+	// without anyone noticing.
+	sha, err := localHeadSHA(ctx, dir)
+	if err != nil {
+		t.Fatalf("localHeadSHA: %v", err)
+	}
+	if len(sha) != 40 {
+		t.Errorf("HEAD = %q, want a 40-char SHA", sha)
+	}
+
+	// Assert the flag is actually present in the source of truth — the
+	// behaviour above cannot distinguish "has the flag" from "same owner", and
+	// the flag is the whole fix.
+	src, rerr := os.ReadFile("update_release_direct.go")
+	if rerr != nil {
+		t.Fatalf("read source: %v", rerr)
+	}
+	if !strings.Contains(string(src), `"safe.directory="+repoDir`) {
+		t.Error("localHeadSHA must pass -c safe.directory=<repoDir>; without it " +
+			"the lookup fails as root on every real host and silently degrades " +
+			"to the rate-limited API path")
+	}
 }


### PR DESCRIPTION
The API-free release resolution I shipped in #820/#822 **never engaged on a real host**. This makes it actually work.

## The failure

`/opt/jabali-panel` is owned by the service user; `jabali update` runs as root. Plain git refuses that combination:

```
fatal: detected dubious ownership in repository at '/opt/jabali-panel'
```

So `localHeadSHA` returned an error on every normal install, resolution fell back to the `api.github.com` path, and that path is rate-limited to **60 requests/hour per IP** — the exact failure the direct path exists to avoid.

The fallback is *by design*, so nothing looked wrong. The update just quietly did the expensive thing again.

## Why the tests didn't catch it

Every test passed because a **developer checkout is owned by whoever runs the tests**. The ownership mismatch only exists in production. Caught by running the command as root on a real box while investigating something else:

```
# git -C /opt/jabali-panel rev-parse HEAD
fatal: detected dubious ownership in repository at '/opt/jabali-panel'

# git -c safe.directory=/opt/jabali-panel -C /opt/jabali-panel rev-parse HEAD
e4ddb3c04d7dd6cadc26da54a34225fd38ed853e
```

## The fix

`-c safe.directory=<repoDir>` scoped to the single invocation, not written into the global gitconfig. Safe: we're root, the repo belongs to our own service user, and it's a read-only `rev-parse`.

## The test

It asserts the flag is present **in the source**, as well as exercising the call. A same-user test cannot distinguish "has the flag" from "same owner" — which is precisely how this shipped in the first place, so behaviour alone isn't enough to pin it.

---

Worth stating plainly: #820 claimed to take hosts off the rate-limited API and did not. This is the third correction in that chain (#820 → #822 channel hosts → this), all found by putting it on a real box rather than trusting green CI.
