### PR TITLE
fix(panel-ui): one Actions entry point on both domain lists (GH #833)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -379,15 +379,20 @@ export const DomainList = () => {
             dataIndex="actions"
             render={(_, r) => (
               <Space>
-                <RowActionButton
-                  icon={<EditOutlined />}
-                  onClick={() => navigate(`/jabali-admin/domains/edit/${r.id}`)}
-                >
-                  Edit
-                </RowActionButton>
+                {/* GH #833: one entry point for every row action (admin and
+                    tenant lists use the same shape) — no per-view "which
+                    button is primary" decision, and new actions scale into
+                    the menu instead of widening the row. */}
                 <Dropdown
+                  trigger={["click"]}
                   menu={{
                     items: [
+                      {
+                        key: "edit",
+                        icon: <EditOutlined />,
+                        label: "Edit",
+                        onClick: () => navigate(`/jabali-admin/domains/edit/${r.id}`),
+                      },
                       {
                         key: "dns",
                         icon: <GlobalOutlined />,
@@ -455,7 +460,9 @@ export const DomainList = () => {
                     ],
                   }}
                 >
-                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label={t("domainlist.more_actions")} />
+                  <RowActionButton icon={<MoreOutlined />} aria-label={t("domainlist.more_actions")}>
+                    Actions
+                  </RowActionButton>
                 </Dropdown>
                 {activeModal?.domain.id === r.id && activeModal.type === "redirects" && (
                   <DomainRedirectsButton

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -315,16 +315,18 @@ export const UserDomainList = () => {
             render={(_, r) => (
               <>
                 <Space>
-                <RowActionButton
-                  icon={<GlobalOutlined />}
-                  onClick={() => navigate(`/jabali-panel/domains/${r.id}/dns`)}
-                >
-                  DNS
-                </RowActionButton>
+                {/* GH #833: single Actions entry point, mirroring the admin
+                    Domains list — same dropdown shape on both views. */}
                 <Dropdown
                   trigger={["click"]}
                   menu={{
                     items: [
+                      {
+                        key: "dns",
+                        label: "DNS",
+                        icon: <GlobalOutlined />,
+                        onClick: () => navigate(`/jabali-panel/domains/${r.id}/dns`),
+                      },
                       {
                         key: "redirects",
                         label: "Redirects",
@@ -421,7 +423,9 @@ export const UserDomainList = () => {
                     ],
                   }}
                 >
-                  <RowActionButton icon={<MoreOutlined />} color="default" aria-label={t("userdomainlist.more_actions")} />
+                  <RowActionButton icon={<MoreOutlined />} aria-label={t("userdomainlist.more_actions")}>
+                    Actions
+                  </RowActionButton>
                 </Dropdown>
                 </Space>
                 {activeModal?.domainId === r.id && activeModal.type === "redirects" && (


### PR DESCRIPTION
Implements the suggestion from #833 (follow-up of #351): instead of deciding per-view which row button is primary — admin led with **Edit**, tenant still led with **DNS** — both domain lists now expose a single labeled **Actions** dropdown with icons, identical shape in both views.

- Admin: Edit joins the menu as the first item (DNS, Information, Redirects, Index, Nginx, Caching, Enable/Disable, Delete follow, unchanged).
- Tenant: DNS joins the menu as the first item (Redirects, Index, Directory Privacy, Caching, capability-gated options, Enable/Disable, Delete follow, unchanged).
- Destructive entries keep the divider, danger styling, and confirm dialogs; the trigger is a filled `RowActionButton` per the row-actions convention.
- Scales: new actions land in the menu instead of widening the row or reopening the primary-button question.

Resolves GH #833 (and the tenant half of #351's follow-up).

## Test plan
- [x] `tsc -b` + `npm run build` green; domain-list vitest suites pass
- [x] E2E selector check (role-selector scar): every spec reaches DomainEdit via direct `page.goto`; none click the removed row buttons
- [ ] Post-merge visual check on testserver: both lists show the Actions dropdown, all entries fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)