### PR TITLE
fix(migration): remap source-layout php.ini paths (JAB-211) + count Maildir++ subfolders (JAB-212)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_appconfigs.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs.go
@@ -139,7 +139,7 @@ func ImportAppConfigs(
 			filepath.Join(docroot, "php.ini"),
 			filepath.Join(docroot, ".user.ini"),
 		} {
-			n, sk := sanitizePhpIniFile(ctx, agentCli, targetUserID, targetUsername, ini, res)
+			n, sk := sanitizePhpIniFile(ctx, agentCli, targetUserID, targetUsername, ini, docroot, res)
 			if n > 0 {
 				res.PhpIniFixed += n
 			} else if sk != "" {
@@ -272,7 +272,7 @@ var (
 // jail (sanitizePhpIni), and writes it back. Returns (1, "") on a real
 // rewrite, (0, "") when absent/clean, (0, note) on an error. The per-
 // directive changes are appended to res.Skipped as manifest notes.
-func sanitizePhpIniFile(ctx context.Context, agentCli agent.AgentInterface, targetUserID, targetUsername, path string, res *AppConfigsResult) (int, string) {
+func sanitizePhpIniFile(ctx context.Context, agentCli agent.AgentInterface, targetUserID, targetUsername, path, docroot string, res *AppConfigsResult) (int, string) {
 	if _, err := os.Stat(path); err != nil {
 		return 0, ""
 	}
@@ -291,7 +291,7 @@ func sanitizePhpIniFile(ctx context.Context, agentCli agent.AgentInterface, targ
 	if jErr := json.Unmarshal(raw, &r); jErr != nil || r.IsBinary {
 		return 0, fmt.Sprintf("php_ini_decode_skip:%s", path)
 	}
-	updated, notes, changed := sanitizePhpIni(r.Content, targetUsername)
+	updated, notes, changed := sanitizePhpIni(r.Content, targetUsername, docroot, nil)
 	if !changed {
 		return 0, ""
 	}

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -527,7 +527,46 @@ func looksLikeMaildir(path string) (string, bool) {
 			return dapath, true
 		}
 	}
+	// Subfolder-only mailbox: no root cur/new, but a Maildir++ ".<Sub>" still
+	// holds mail. The agent's looksLikeMailMaildir accepts this shape, so the
+	// mailbox IS imported; without the same rule here it was missing from both
+	// count= and messages_found= while its messages showed up in
+	// messages_pushed= — one of the two ways JAB-212 produced pushed > found.
+	if maildirSubfolders(path) != nil {
+		return path, true
+	}
 	return "", false
+}
+
+// maildirSubfolders lists the Maildir++ subfolder directories of a maildir —
+// direct children starting with "." that themselves contain cur/ or new/.
+//
+// Mirrors the agent's rule in importOneMailbox exactly (dot prefix, skip the
+// cur/new/tmp spec dirs). The two must not drift: whatever the agent imports is
+// what the panel has to count, and the divergence between them is the whole of
+// JAB-212.
+func maildirSubfolders(maildir string) []string {
+	entries, err := os.ReadDir(maildir)
+	if err != nil {
+		return nil
+	}
+	var subs []string
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() || !strings.HasPrefix(name, ".") {
+			continue
+		}
+		if name == "cur" || name == "new" || name == "tmp" {
+			continue
+		}
+		sub := filepath.Join(maildir, name)
+		// A dot-dir without cur/new is not a mail folder (.nfs junk, editor
+		// state); the agent never visits it, so neither do we.
+		if existsDir(filepath.Join(sub, "cur")) || existsDir(filepath.Join(sub, "new")) {
+			subs = append(subs, sub)
+		}
+	}
+	return subs
 }
 
 // countMaildirMessages walks cur/, new/, tmp/ inside a Maildir +
@@ -552,7 +591,27 @@ func countMaildirMessages(maildir string) (count int, bytes int64) {
 }
 
 // countMaildirMessagesDetailed additionally reports how many files sit in tmp/.
+//
+// JAB-212: this counts the INBOX slots AND every Maildir++ subfolder, because
+// that is precisely what the agent imports. Counting only the root cur/new made
+// every Sent/Trash/Archive message a push with no matching find, and the
+// account summary reported messages_pushed=787 against messages_found=760 — a
+// counter exceeding its own denominator, days after JAB-209 made operators rely
+// on found==pushed as the attestation that nothing was lost.
 func countMaildirMessagesDetailed(maildir string) (count int, bytes int64, tmpFound int) {
+	count, bytes, tmpFound = countMaildirSlots(maildir)
+	for _, sub := range maildirSubfolders(maildir) {
+		c, b, t := countMaildirSlots(sub)
+		count += c
+		bytes += b
+		tmpFound += t
+	}
+	return count, bytes, tmpFound
+}
+
+// countMaildirSlots counts the cur/ and new/ of a single Maildir level,
+// reporting tmp/ separately (see the JAB-209 note above).
+func countMaildirSlots(maildir string) (count int, bytes int64, tmpFound int) {
 	for _, sub := range []string{"cur", "new", "tmp"} {
 		dir := filepath.Join(maildir, sub)
 		entries, err := os.ReadDir(dir)
@@ -599,8 +658,21 @@ func countMaildirMessagesDetailed(maildir string) (count int, bytes int64, tmpFo
 // explained skips are subtracted is called out as unexplained.
 func reconcileMailCounts(found int, pushed int64, agentSkipped []string) []string {
 	gap := int64(found) - pushed
-	if gap <= 0 {
+	if gap == 0 {
 		return nil
+	}
+	if gap < 0 {
+		// JAB-212. Returning nil here is what let messages_pushed=787 sit next
+		// to messages_found=760 with nothing said. It is not mail loss, so it
+		// deliberately avoids the WARNING wording reserved for that — using it
+		// on a benign accounting mismatch would teach operators to skim past
+		// the word on the runs where it does mean loss.
+		return []string{fmt.Sprintf(
+			"mail: %d more message(s) were imported than were found in staging (found=%d pushed=%d). "+
+				"No mail was lost. Most often this is a re-run importing into a mailbox that already "+
+				"held messages; if this was a first run, the counters are out of step and the numbers "+
+				"above should not be quoted to the customer.",
+			-gap, found, pushed)}
 	}
 	explained := int64(0)
 	for _, s := range agentSkipped {

--- a/panel-api/internal/migrate/cpanel/restore_mail_jab212_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_jab212_test.go
@@ -1,0 +1,186 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-212. Account soomcoil restored with
+//
+//	mailboxes: count=2 messages_found=760 messages_pushed=787
+//
+// — 27 MORE messages pushed than were found, with no explanatory line, right
+// after JAB-209 established that found==pushed is the attestation operators
+// rely on. A counter that can exceed its own denominator is worth no more than
+// no counter at all.
+//
+// The issue guessed cross-mailbox duplicate delivery. It is simpler and worse
+// than that: the two sides walk different trees.
+//
+//   - The agent (importMaildirTree → importOneMailbox) imports the INBOX
+//     *and every Maildir++ subfolder* — ".Sent", ".Trash", ".INBOX.Archive" —
+//     each a sibling of cur/new holding its own cur/new.
+//   - The panel-side counter walked only the root cur/ and new/.
+//
+// So every message in a Sent or Trash folder was pushed but never found. It
+// takes a mailbox with subfolders to show up, which is why single-mailbox
+// accounts in the same batch reconciled exactly.
+//
+// The same divergence has a second face: the agent's looksLikeMailMaildir
+// treats a mailbox whose root cur/new are absent but which has a populated
+// ".Sub" as a real maildir; the panel's looksLikeMaildir did not, so such a
+// mailbox was missing from BOTH count= and messages_found= while its mail was
+// imported regardless.
+
+// writeSubfolderMsg creates a Maildir message file under maildir/sub.
+func writeSubfolderMsg(t *testing.T, maildir, sub, name string) {
+	t.Helper()
+	dir := filepath.Join(maildir, sub)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("From: a@b\r\n\r\nbody"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCountMaildirMessages_CountsMaildirPlusPlusSubfolders(t *testing.T) {
+	t.Parallel()
+
+	md := t.TempDir()
+	writeSubfolderMsg(t, md, "cur", "1700000000.M1:2,S")
+	writeSubfolderMsg(t, md, "new", "1700000001.M2")
+	// Subfolders the agent imports and the counter used to ignore.
+	writeSubfolderMsg(t, md, ".Sent/cur", "1700000002.M3:2,S")
+	writeSubfolderMsg(t, md, ".Sent/new", "1700000003.M4")
+	writeSubfolderMsg(t, md, ".Trash/cur", "1700000004.M5:2,S")
+	// Nested Maildir++ hierarchy — ".Parent.Child" is one flat directory.
+	writeSubfolderMsg(t, md, ".INBOX.Archive.2024/cur", "1700000005.M6:2,S")
+
+	count, bytes, _ := countMaildirMessagesDetailed(md)
+
+	if count != 6 {
+		t.Errorf("count = %d, want 6 (2 root + 4 in subfolders) — subfolder "+
+			"messages are pushed by the agent, so not counting them is exactly "+
+			"what made messages_pushed exceed messages_found", count)
+	}
+	if bytes == 0 {
+		t.Error("bytes must include subfolder messages too")
+	}
+}
+
+func TestCountMaildirMessages_SubfolderTmpStillExcluded(t *testing.T) {
+	t.Parallel()
+
+	// The JAB-209 rule has to hold inside subfolders as well, or the fix for
+	// one direction re-creates the gap in the other.
+	md := t.TempDir()
+	writeSubfolderMsg(t, md, "cur", "1700000000.M1:2,S")
+	writeSubfolderMsg(t, md, ".Sent/cur", "1700000001.M2:2,S")
+	writeSubfolderMsg(t, md, ".Sent/tmp", "1700000002.M3") // interrupted delivery
+
+	count, _, tmpFound := countMaildirMessagesDetailed(md)
+
+	if count != 2 {
+		t.Errorf("count = %d, want 2 — tmp/ inside a subfolder is still an "+
+			"interrupted delivery, not mail the user has", count)
+	}
+	if tmpFound != 1 {
+		t.Errorf("tmpFound = %d, want 1 — subfolder tmp/ must stay visible to "+
+			"the caller", tmpFound)
+	}
+}
+
+func TestCountMaildirMessages_IgnoresNonMaildirDotDirs(t *testing.T) {
+	t.Parallel()
+
+	// A dot-dir with no cur/new is not a Maildir++ folder; counting stray
+	// files in it would push found above pushed in the other direction.
+	md := t.TempDir()
+	writeSubfolderMsg(t, md, "cur", "1700000000.M1:2,S")
+	if err := os.MkdirAll(filepath.Join(md, ".nfs-junk"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(md, ".nfs-junk", "stray"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if count, _, _ := countMaildirMessagesDetailed(md); count != 1 {
+		t.Errorf("count = %d, want 1 — a dot-dir without cur/new is not a "+
+			"subfolder and the agent never visits it", count)
+	}
+}
+
+func TestLooksLikeMaildir_SubfolderOnlyMailbox(t *testing.T) {
+	t.Parallel()
+
+	// Empty INBOX, mail only in .Archive. The agent imports this; the panel
+	// used to not even count it, so the mailbox was absent from count= and
+	// messages_found= while its messages landed in messages_pushed=.
+	md := t.TempDir()
+	writeSubfolderMsg(t, md, ".Archive/cur", "1700000000.M1:2,S")
+
+	got, ok := looksLikeMaildir(md)
+	if !ok {
+		t.Fatal("subfolder-only mailbox not recognised — its mail is imported " +
+			"but never counted, which reads as pushed > found")
+	}
+	if got != md {
+		t.Errorf("maildir path = %q, want %q", got, md)
+	}
+	if count, _, _ := countMaildirMessagesDetailed(md); count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+func TestLooksLikeMaildir_StillRejectsNonMaildir(t *testing.T) {
+	t.Parallel()
+
+	// Guard against the subfolder probe turning every directory into a
+	// mailbox — that would invent maildirs out of ordinary home folders.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "notes"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".config"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := looksLikeMaildir(dir); ok {
+		t.Error("a plain directory with a dotfile dir must not look like a maildir")
+	}
+}
+
+func TestReconcileMailCounts_PushedExceedsFound(t *testing.T) {
+	t.Parallel()
+
+	// The reported shape: 760 found, 787 pushed. Before this it returned nil —
+	// gap <= 0 was treated as "nothing to say" — so the operator saw two
+	// numbers that could not both be right and no explanation at all.
+	msgs := reconcileMailCounts(760, 787, nil)
+
+	if len(msgs) != 1 {
+		t.Fatalf("an inequality in EITHER direction needs a line, got %v", msgs)
+	}
+	got := msgs[0]
+	if !strings.Contains(got, "27") {
+		t.Errorf("must state the size of the discrepancy: %s", got)
+	}
+	// Not mail loss — saying WARNING here would train operators to ignore the
+	// word on the runs where it does mean loss.
+	if strings.Contains(got, "do not report this mailbox as fully migrated") {
+		t.Errorf("pushed>found is an accounting mismatch, not loss: %s", got)
+	}
+	if !strings.Contains(got, "more message(s) were imported than") {
+		t.Errorf("should say plainly that more was imported than staged: %s", got)
+	}
+}
+
+func TestReconcileMailCounts_EqualStaysSilent(t *testing.T) {
+	t.Parallel()
+
+	if got := reconcileMailCounts(500, 500, nil); got != nil {
+		t.Errorf("equality is the normal case and must stay silent, got %v", got)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/sanitize_php_ini.go
+++ b/panel-api/internal/migrate/cpanel/sanitize_php_ini.go
@@ -2,6 +2,8 @@ package cpanel
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -11,7 +13,9 @@ import (
 // OUTSIDE the per-user FPM pool's open_basedir
 // (/home/<u>:/run/mysqld/mysqld.sock:/tmp:/var/tmp, ADR-0023) breaks
 // the site under jabali's jail — e.g.
-//   session.save_path = "/var/cpanel/php/sessions/ea-php83"
+//
+//	session.save_path = "/var/cpanel/php/sessions/ea-php83"
+//
 // triggers an open_basedir PHP warning on every request and $_SESSION
 // silently stops persisting (logins/carts break).
 var phpIniPathDirectives = map[string]bool{
@@ -22,6 +26,33 @@ var phpIniPathDirectives = map[string]bool{
 	"upload_tmp_dir":      true,
 	"extension_dir":       true,
 	"soap.wsdl_cache_dir": true,
+	"auto_prepend_file":   true,
+	"auto_append_file":    true,
+	"include_path":        true,
+}
+
+// phpIniDocrootDirectives name a file (or list of paths) that must actually
+// RESOLVE, as opposed to merely sitting inside the open_basedir jail.
+//
+// JAB-211: cPanel security/caching plugins (MalCare, Wordfence, WP Rocket)
+// write an absolute source-layout path into .user.ini —
+//
+//	auto_prepend_file = '/home/<user>/public_html/malcare-waf.php'
+//
+// On jabali the docroot is /home/<user>/domains/<domain>/public_html, so that
+// path does not exist and PHP fatals with "Failed opening required" before
+// running a line: the site serves a bare 500 while the restore summary stays
+// green.
+//
+// pathInJail cannot catch this. The path IS under /home/<user>, so jail
+// membership reports true and the directive sails through. For these
+// directives existence is the test, and the repair is to remap the source
+// docroot onto the destination one — NOT to delete the line. Deleting also
+// stops the 500, but it silently disarms the site's WAF, which trades a
+// visible outage for an invisible security regression.
+var phpIniDocrootDirectives = map[string]bool{
+	"auto_prepend_file": true,
+	"auto_append_file":  true,
 }
 
 var iniDirectiveRe = regexp.MustCompile(`^(\s*)([A-Za-z0-9_.]+)\s*=\s*(.*?)\s*$`)
@@ -42,23 +73,93 @@ func pathInJail(p, username string) bool {
 	return false
 }
 
+// docrootCandidates maps an absolute source-layout path onto docroot, most
+// specific first.
+//
+// cPanel serves out of /home/<user>/public_html, jabali out of
+// /home/<user>/domains/<domain>/public_html, so the useful part of a migrated
+// path is whatever follows the source docroot. Returns nil when there is
+// nothing to work with (no docroot, or a relative value) so callers degrade to
+// the pre-JAB-211 behaviour instead of synthesising a path off "/".
+func docrootCandidates(p, username, docroot string) []string {
+	if docroot == "" || !strings.HasPrefix(p, "/") {
+		return nil
+	}
+	var cands []string
+	add := func(rel string) {
+		rel = strings.TrimPrefix(rel, "/")
+		if rel == "" {
+			return
+		}
+		c := filepath.Join(docroot, rel)
+		for _, existing := range cands {
+			if existing == c {
+				return
+			}
+		}
+		cands = append(cands, c)
+	}
+	// Tail after the LAST public_html is the docroot-relative part — and the
+	// last one matters because the destination docroot itself ends in
+	// public_html, so an already-correct path must map to itself.
+	if i := strings.LastIndex(p, "/public_html/"); i >= 0 {
+		add(p[i+len("/public_html/"):])
+	}
+	if home := "/home/" + username + "/"; strings.HasPrefix(p, home) {
+		add(strings.TrimPrefix(p, home))
+	}
+	add(filepath.Base(p))
+	return cands
+}
+
+// remapFile finds the migrated copy of a source-layout file under docroot.
+func remapFile(p, username, docroot string, exists func(string) bool) (string, bool) {
+	for _, c := range docrootCandidates(p, username, docroot) {
+		if exists(c) {
+			return c, true
+		}
+	}
+	return "", false
+}
+
+// remapUnder finds a path under docroot whose PARENT exists — for values like
+// error_log where the file is created on demand but the directory is not.
+func remapUnder(p, username, docroot string, exists func(string) bool) (string, bool) {
+	for _, c := range docrootCandidates(p, username, docroot) {
+		if exists(filepath.Dir(c)) {
+			return c, true
+		}
+	}
+	return "", false
+}
+
 // sanitizePhpIni neutralizes path-valued PHP directives in a migrated
 // php.ini / .user.ini that resolve outside the user's open_basedir
 // jail, preserving every benign tunable (memory_limit, upload_max_
 // filesize, …) verbatim. Returns the rewritten content + a per-change
 // note list for the manifest. changed=false ⇒ content untouched.
 //
-//   session.save_path outside jail → rewritten to /tmp (in jail, always
-//       present, session files are 0600 so cross-tenant read is blocked;
-//       matches jabali's own sso.php). Dropping it isn't safe — the
-//       system php.ini default (/var/lib/php/sessions) is also outside
-//       the jail.
-//   open_basedir → always dropped (the pool hard-codes it; a migrated
-//       value only conflicts).
-//   error_log / sys_temp_dir / upload_tmp_dir / extension_dir /
-//       soap.wsdl_cache_dir with an absolute path outside the jail →
-//       dropped (PHP falls back to an in-jail default).
-func sanitizePhpIni(content, username string) (string, []string, bool) {
+//	session.save_path outside jail → rewritten to /tmp (in jail, always
+//	    present, session files are 0600 so cross-tenant read is blocked;
+//	    matches jabali's own sso.php). Dropping it isn't safe — the
+//	    system php.ini default (/var/lib/php/sessions) is also outside
+//	    the jail.
+//	open_basedir → always dropped (the pool hard-codes it; a migrated
+//	    value only conflicts).
+//	sys_temp_dir / upload_tmp_dir / extension_dir / soap.wsdl_cache_dir
+//	    with an absolute path outside the jail → dropped (PHP falls back
+//	    to an in-jail default).
+//	auto_prepend_file / auto_append_file / error_log / include_path →
+//	    judged by whether the path RESOLVES, not by jail membership, and
+//	    remapped onto docroot when the source docroot layout explains the
+//	    miss (JAB-211). See phpIniDocrootDirectives.
+//
+// docroot is the destination docroot; "" disables remapping. exists defaults
+// to os.Stat and is injected by tests.
+func sanitizePhpIni(content, username, docroot string, exists func(string) bool) (string, []string, bool) {
+	if exists == nil {
+		exists = func(p string) bool { _, err := os.Stat(p); return err == nil }
+	}
 	lines := strings.Split(content, "\n")
 	var notes []string
 	for i, line := range lines {
@@ -85,7 +186,87 @@ func sanitizePhpIni(content, username string) (string, []string, bool) {
 		case "open_basedir":
 			lines[i] = indent + "; jabali-migration: removed open_basedir (pool-managed) ; was: " + val
 			notes = append(notes, "open_basedir removed (pool sets it)")
+
+		case "error_log":
+			// Keep non-paths (error_log = syslog) and stay with the old
+			// removal for anything outside the jail. What is new is the
+			// in-jail-but-stale case: /home/<u>/public_html/php_errors.log
+			// passes pathInJail yet its directory does not exist here, so PHP
+			// drops the log on the floor.
+			v := strings.Trim(val, `"' `)
+			if !strings.HasPrefix(v, "/") {
+				continue
+			}
+			if !pathInJail(v, username) {
+				lines[i] = indent + "; jabali-migration: removed " + key + " (path outside open_basedir) ; was: " + val
+				notes = append(notes, fmt.Sprintf("%s removed (path %q outside open_basedir)", kl, v))
+				continue
+			}
+			if exists(filepath.Dir(v)) {
+				continue
+			}
+			if np, ok := remapUnder(v, username, docroot, exists); ok {
+				lines[i] = indent + key + " = " + np
+				notes = append(notes, fmt.Sprintf("error_log %q → %q (source docroot layout)", v, np))
+			}
+			// Unresolvable: leave it. A missing error_log is not fatal, and
+			// churning it would add manifest noise for no gain.
+
+		case "include_path":
+			v := strings.Trim(val, `"' `)
+			var kept, dropped []string
+			for _, part := range strings.Split(v, ":") {
+				p := strings.TrimSpace(part)
+				switch {
+				case p == "":
+					// Trailing/duplicate separator — drop silently.
+				case !strings.HasPrefix(p, "/"):
+					kept = append(kept, p) // "." and friends stay verbatim
+				case exists(p):
+					kept = append(kept, p)
+				default:
+					if np, ok := remapFile(p, username, docroot, exists); ok {
+						kept = append(kept, np)
+					} else {
+						dropped = append(dropped, p)
+					}
+				}
+			}
+			rebuilt := strings.Join(kept, ":")
+			if rebuilt == v {
+				continue
+			}
+			lines[i] = indent + key + ` = "` + rebuilt + `"`
+			if len(dropped) > 0 {
+				notes = append(notes, fmt.Sprintf("include_path dropped unresolvable %v", dropped))
+			} else {
+				notes = append(notes, fmt.Sprintf("include_path %q → %q (source docroot layout)", v, rebuilt))
+			}
+
 		default:
+			if phpIniDocrootDirectives[kl] {
+				// auto_prepend_file / auto_append_file: existence decides, not
+				// jail membership. An unresolvable value here is a hard fatal
+				// on EVERY request (JAB-211).
+				v := strings.Trim(val, `"' `)
+				if !strings.HasPrefix(v, "/") || exists(v) {
+					continue
+				}
+				if np, ok := remapFile(v, username, docroot, exists); ok {
+					lines[i] = indent + key + " = " + np
+					notes = append(notes, fmt.Sprintf("%s %q → %q (source docroot layout)", kl, v, np))
+					continue
+				}
+				// Nothing to point at. Commenting out costs whatever the file
+				// did — often a WAF — so this note has to be loud enough that
+				// the operator re-arms it by hand.
+				lines[i] = indent + "; jabali-migration: disabled " + key + " (target not migrated) ; was: " + val
+				notes = append(notes, fmt.Sprintf(
+					"%s DISABLED — %q was not migrated; every request fataled until this was "+
+						"commented out. If it was a security plugin (MalCare/Wordfence), the site "+
+						"is now running WITHOUT it — reinstall the plugin to re-arm.", kl, v))
+				continue
+			}
 			v := strings.Trim(val, `"' `)
 			if strings.HasPrefix(v, "/") && !pathInJail(v, username) {
 				lines[i] = indent + "; jabali-migration: removed " + key + " (path outside open_basedir) ; was: " + val

--- a/panel-api/internal/migrate/cpanel/sanitize_php_ini_docroot_test.go
+++ b/panel-api/internal/migrate/cpanel/sanitize_php_ini_docroot_test.go
@@ -1,0 +1,217 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+// JAB-211. Account wineworldc restored green — DB credentials checked out, the
+// summary was clean — and every request returned a bare HTTP 500 with an empty
+// body. The migrated .user.ini held
+//
+//	auto_prepend_file = '/home/wineworldc/public_html/malcare-waf.php'
+//
+// which is the SOURCE cPanel layout. On jabali the docroot is
+// /home/<user>/domains/<domain>/public_html, so the file was not there and PHP
+// fataled with "Failed opening required" before executing a single line.
+//
+// Two separate gaps let it through:
+//
+//  1. auto_prepend_file was not in phpIniPathDirectives, so the loop skipped
+//     the line entirely.
+//  2. Even listed, it would still have passed: pathInJail reports TRUE for
+//     /home/wineworldc/..., because the path IS under the user's home. Jail
+//     membership is the wrong question for a prepend file — the right one is
+//     whether the file EXISTS. A path can be perfectly in-jail and still fatal
+//     the site.
+//
+// The file itself had been migrated and was present at the new docroot, so the
+// sanitizer must remap rather than delete: deleting works around the 500 but
+// silently disarms the site's WAF, which is a security regression dressed up
+// as a fix.
+
+// destDocroot is the jabali-layout docroot used across these tests.
+const destDocroot = "/home/wineworldc/domains/wineworld.co.il/public_html"
+
+// existsOnly builds an exists func that reports true for exactly these paths.
+func existsOnly(paths ...string) func(string) bool {
+	set := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		set[p] = true
+	}
+	return func(p string) bool { return set[p] }
+}
+
+func TestSanitizePhpIni_RemapsAutoPrependIntoDestDocroot(t *testing.T) {
+	t.Parallel()
+
+	in := `auto_prepend_file = '/home/wineworldc/public_html/malcare-waf.php'`
+	want := destDocroot + "/malcare-waf.php"
+
+	out, notes, changed := sanitizePhpIni(in, "wineworldc", destDocroot,
+		existsOnly(want))
+
+	if !changed {
+		t.Fatal("expected changed=true — an unresolvable auto_prepend_file is a " +
+			"hard 500 on every request")
+	}
+	if !strings.Contains(out, want) {
+		t.Errorf("auto_prepend_file not remapped to the destination docroot:\n%s", out)
+	}
+	if strings.Contains(out, "/home/wineworldc/public_html/malcare-waf.php") {
+		t.Errorf("source-layout path survived:\n%s", out)
+	}
+	// Deleting the directive would also stop the 500 — and disable MalCare's
+	// WAF. The whole point of remapping is that the file was migrated.
+	if strings.Contains(out, "jabali-migration: disabled") {
+		t.Errorf("directive was disabled even though the target exists:\n%s", out)
+	}
+	if len(notes) == 0 {
+		t.Error("a rewritten directive must appear in the manifest — parity with " +
+			"the existing php_ini_sanitized lines")
+	}
+}
+
+func TestSanitizePhpIni_DisablesAutoPrependWhenTargetMissing(t *testing.T) {
+	t.Parallel()
+
+	// The plugin directory was excluded from the migration, so nothing can be
+	// remapped. Leaving the directive would keep the site at 500 forever.
+	in := `auto_prepend_file = "/home/wineworldc/public_html/wordfence-waf.php"`
+
+	out, notes, changed := sanitizePhpIni(in, "wineworldc", destDocroot,
+		existsOnly( /* nothing exists */ ))
+
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if !strings.Contains(out, "jabali-migration: disabled auto_prepend_file") {
+		t.Errorf("unresolvable directive must be commented out, not left to fatal:\n%s", out)
+	}
+	// Commented out, so PHP never sees it.
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "auto_prepend_file") {
+			t.Errorf("directive still live:\n%s", out)
+		}
+	}
+	// This one is a real functional loss (the WAF is now off), so it has to be
+	// loud rather than a silent cleanup.
+	joined := strings.Join(notes, "\n")
+	if !strings.Contains(joined, "wordfence-waf.php") || !strings.Contains(joined, "not migrated") {
+		t.Errorf("note must name the missing file and say why it was disabled: %v", notes)
+	}
+}
+
+func TestSanitizePhpIni_LeavesResolvableAutoPrependAlone(t *testing.T) {
+	t.Parallel()
+
+	// Already correct for the jabali layout — must not be touched.
+	live := destDocroot + "/guard.php"
+	in := "auto_prepend_file = " + live
+
+	out, notes, changed := sanitizePhpIni(in, "wineworldc", destDocroot, existsOnly(live))
+
+	if changed || out != in || notes != nil {
+		t.Errorf("a directive that already resolves must be left verbatim; "+
+			"changed=%v notes=%v out=%q", changed, notes, out)
+	}
+}
+
+func TestSanitizePhpIni_AutoAppendGetsSameTreatment(t *testing.T) {
+	t.Parallel()
+
+	want := destDocroot + "/footer.php"
+	in := `auto_append_file = /home/wineworldc/public_html/footer.php`
+
+	out, _, changed := sanitizePhpIni(in, "wineworldc", destDocroot, existsOnly(want))
+
+	if !changed || !strings.Contains(out, want) {
+		t.Errorf("auto_append_file must be remapped like auto_prepend_file:\n%s", out)
+	}
+}
+
+func TestSanitizePhpIni_RemapsErrorLogDirectory(t *testing.T) {
+	t.Parallel()
+
+	// error_log is already in phpIniPathDirectives, but pathInJail says TRUE
+	// for the source path, so it survived and PHP then failed to open it. The
+	// directory is what has to exist, not the file.
+	in := `error_log = /home/wineworldc/public_html/php_errors.log`
+	want := destDocroot + "/php_errors.log"
+
+	out, _, changed := sanitizePhpIni(in, "wineworldc", destDocroot, existsOnly(destDocroot))
+
+	if !changed || !strings.Contains(out, want) {
+		t.Errorf("in-jail-but-stale error_log path not remapped:\n%s", out)
+	}
+}
+
+func TestSanitizePhpIni_IncludePathDropsOnlyDeadElements(t *testing.T) {
+	t.Parallel()
+
+	// include_path is a list. A dead element is not fatal on its own, but it
+	// costs a failed stat on every include, and the live elements must survive
+	// untouched — including the relative "." entry.
+	live := destDocroot + "/lib"
+	in := `include_path = ".:/home/wineworldc/public_html/lib:/home/wineworldc/public_html/gone"`
+
+	out, notes, changed := sanitizePhpIni(in, "wineworldc", destDocroot, existsOnly(live))
+
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if !strings.Contains(out, live) {
+		t.Errorf("remappable include_path element was lost:\n%s", out)
+	}
+	if !strings.Contains(out, ".") {
+		t.Errorf("relative element must be preserved:\n%s", out)
+	}
+	if strings.Contains(out, "/public_html/gone") {
+		t.Errorf("unresolvable element kept:\n%s", out)
+	}
+	if len(notes) == 0 {
+		t.Error("expected a manifest note for the rewritten include_path")
+	}
+}
+
+// The docroot-aware pass must not disturb anything the original sanitizer did.
+func TestSanitizePhpIni_ExistingBehaviourUnchanged(t *testing.T) {
+	t.Parallel()
+
+	in := strings.Join([]string{
+		`session.save_path = "/var/cpanel/php/sessions/ea-php83"`,
+		`open_basedir = "/home/old:/usr/local/cpanel"`,
+		`memory_limit = 256M`,
+	}, "\n")
+
+	out, _, changed := sanitizePhpIni(in, "migdaleinav", "/home/migdaleinav/domains/x/public_html",
+		existsOnly())
+
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if !strings.Contains(out, "session.save_path = /tmp") {
+		t.Errorf("session.save_path regressed:\n%s", out)
+	}
+	if !strings.Contains(out, "jabali-migration: removed open_basedir") {
+		t.Errorf("open_basedir regressed:\n%s", out)
+	}
+	if !strings.Contains(out, "memory_limit = 256M") {
+		t.Errorf("benign tunable clobbered:\n%s", out)
+	}
+}
+
+// An empty docroot (caller could not determine one) must degrade to the old
+// behaviour rather than remapping onto "/…".
+func TestSanitizePhpIni_NoDocrootDoesNotInventPaths(t *testing.T) {
+	t.Parallel()
+
+	in := `auto_prepend_file = /home/wineworldc/public_html/malcare-waf.php`
+
+	out, _, changed := sanitizePhpIni(in, "wineworldc", "", existsOnly())
+
+	if changed && strings.Contains(out, "auto_prepend_file = /malcare-waf.php") {
+		t.Errorf("empty docroot produced a bogus absolute path:\n%s", out)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/sanitize_php_ini_test.go
+++ b/panel-api/internal/migrate/cpanel/sanitize_php_ini_test.go
@@ -17,7 +17,7 @@ func TestSanitizePhpIni(t *testing.T) {
 		`extension_dir = "/opt/cpanel/ea-php83/root/usr/lib64/php/modules"`,
 	}, "\n")
 
-	out, notes, changed := sanitizePhpIni(in, "migdaleinav")
+	out, notes, changed := sanitizePhpIni(in, "migdaleinav", "/home/migdaleinav/domains/x/public_html", func(string) bool { return false })
 	if !changed {
 		t.Fatal("expected changed=true")
 	}
@@ -56,7 +56,7 @@ func TestSanitizePhpIni(t *testing.T) {
 
 func TestSanitizePhpIni_NoOp(t *testing.T) {
 	in := "memory_limit = 512M\nupload_max_filesize = 64M\nsession.save_path = /home/u/sessions\n"
-	out, notes, changed := sanitizePhpIni(in, "u")
+	out, notes, changed := sanitizePhpIni(in, "u", "/home/u/domains/x/public_html", func(string) bool { return true })
 	if changed || out != in || notes != nil {
 		t.Errorf("clean ini should be untouched; changed=%v notes=%v", changed, notes)
 	}


### PR DESCRIPTION
Both found on the live aramapp fleet migration (build `2817f583`).

## JAB-211 — migrated site serves a bare 500, summary stays green

`wineworldc` restored clean — DB credentials checked out, no warnings — and every request returned HTTP 500 with an empty body. The migrated `.user.ini` held MalCare's

```
auto_prepend_file = '/home/wineworldc/public_html/malcare-waf.php'
```

which is the **source cPanel layout**. On jabali the docroot is `/home/<user>/domains/<domain>/public_html`, so PHP fataled with `Failed opening required` before executing a line.

Two independent gaps let it through:

1. `auto_prepend_file` was not in `phpIniPathDirectives`, so the loop `continue`d past the line.
2. Even listed, it would still have passed: `pathInJail("/home/wineworldc/public_html/malcare-waf.php", "wineworldc")` returns **true** — the path *is* under the user's home. Jail membership is the wrong question for a prepend file; the right one is whether the path **resolves**.

`auto_prepend_file`, `auto_append_file`, `error_log` and `include_path` are now judged on existence and remapped onto the destination docroot when the source layout explains the miss.

**Remap, not delete.** Deleting the directive also stops the 500 — and silently disarms the site's WAF, trading a visible outage for an invisible security regression. The file had been migrated and was sitting at the new docroot. When nothing can be remapped the directive is commented out with a note loud enough that the operator knows the site is now running without its security plugin.

## JAB-212 — `messages_pushed` exceeds `messages_found`

`soomcoil` reported `messages_found=760 messages_pushed=787` with no explanatory line — a counter exceeding its own denominator, days after JAB-209 made `found==pushed` the attestation operators quote to customers.

The reported guess was cross-mailbox duplicate delivery. The actual cause is that the two sides walk different trees:

- the agent (`importOneMailbox`) imports the INBOX **and every Maildir++ subfolder** — `.Sent`, `.Trash`, `.INBOX.Archive`;
- the panel-side counter walked only the root `cur/` and `new/`.

Every Sent/Trash/Archive message was therefore pushed and never found. Single-mailbox accounts in the same batch reconciled exactly because they had no subfolders — not because of the mailbox count.

Same divergence, second face: the agent's `looksLikeMailMaildir` accepts a mailbox whose root `cur`/`new` are absent but which has a populated `.Sub`; the panel's `looksLikeMaildir` did not, so such a mailbox was missing from **both** `count=` and `messages_found=` while its mail was imported anyway.

Fixes:
- `countMaildirMessagesDetailed` walks subfolders under the agent's exact rule (dot prefix, has `cur`/`new`, skip the `cur`/`new`/`tmp` spec dirs).
- `looksLikeMaildir` accepts the subfolder-only mailbox.
- `reconcileMailCounts` reports an inequality in **either** direction. `pushed>found` deliberately avoids the `WARNING` wording reserved for possible loss — using it on a benign accounting mismatch would teach operators to skim past the word on the runs where it does mean loss.
- `tmp/` stays excluded at every level, including inside subfolders (JAB-209 holds).

## Test plan

- [x] 10 new sanitizer tests + 8 new mail-counting tests, all green
- [x] Pre-existing `TestSanitizePhpIni`, `TestSanitizePhpIni_NoOp`, `TestCountMaildirMessages_ExcludesTmp`, `TestReconcileMailCounts` still pass unchanged
- [x] `go build ./...` + `go vet ./...` clean on panel-api and panel-agent
- [x] Rebased onto `origin/main`, tests re-run post-rebase
- [ ] **Not box-verified** — no live cPanel source with a MalCare `.user.ini` or a multi-subfolder mailbox was available. Both fixes are unit-tested only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)