### PR TITLE
feat(preview): expired-preview fallback vhost, tenant toggle, ACME give-up backoff

### DIFF
--- a/panel-agent/internal/commands/preview_fallback_vhost.go
+++ b/panel-agent/internal/commands/preview_fallback_vhost.go
@@ -1,0 +1,155 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// preview.fallback_apply — catch-all vhost for `*.preview.<hostname>`.
+//
+// Wildcard DNS resolves EVERY <anything>.preview.<hostname> to this box,
+// but only enabled domains render a preview server block. Without a
+// fallback, a mistyped slug or a preview whose domain was deleted falls
+// through to nginx's default vhost (connection drop / bare 444) — which
+// reads as "the server is broken" rather than "this preview doesn't
+// exist". This block catches the remainder and serves the branded 404
+// from /var/www/jabali-errors (converged by the reconciler's error-page
+// pass). Pattern borrowed from the operator's hostsclick preview fleet
+// (_preview-fallback.conf).
+//
+// TLS: served with the shared *.preview.<hostname> pair when it exists;
+// HTTP-only until then (same degradation as the per-domain preview
+// blocks). Specific server_name entries always win over the wildcard,
+// so this can never shadow a real preview.
+
+const previewFallbackConfName = "jabali-preview-fallback.conf"
+
+type previewFallbackApplyParams struct {
+	// Base is "preview.<hostname>" — the wildcard serves *.<Base>.
+	Base           string `json:"base"`
+	SSLCertPath    string `json:"ssl_cert_path,omitempty"`
+	SSLKeyPath     string `json:"ssl_key_path,omitempty"`
+	HTTP2Param     string `json:"-"`
+	HTTP2Directive string `json:"-"`
+}
+
+type previewFallbackResponse struct {
+	Ok      bool   `json:"ok"`
+	Path    string `json:"path"`
+	Changed bool   `json:"changed"`
+}
+
+const previewFallbackTemplate = `# Managed by jabali-agent (preview.fallback_apply) — do not edit.
+# Catch-all for *.{{.Base}}: previews that don't exist (typo, disabled
+# or deleted domain) get the branded 404 instead of the default-vhost drop.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name *.{{.Base}};
+{{ if .SSLCertPath }}
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl{{.HTTP2Param}};
+    listen [::]:443 ssl{{.HTTP2Param}};
+{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
+{{ end }}    server_name *.{{.Base}};
+    ssl_certificate {{.SSLCertPath}};
+    ssl_certificate_key {{.SSLKeyPath}};
+    ssl_protocols TLSv1.2 TLSv1.3;
+{{ end }}
+    add_header X-Robots-Tag "noindex, nofollow" always;
+    root /var/www/jabali-errors;
+    access_log /var/log/nginx/preview-fallback-access.log;
+
+    location / {
+        try_files /jabali-err-404.html =404;
+    }
+}
+`
+
+func previewFallbackApplyHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	if len(params) == 0 {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "params required"}
+	}
+	var p previewFallbackApplyParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if !domainRegex.MatchString(p.Base) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid base %q", p.Base),
+		}
+	}
+	// Cert paths travel together; a missing file downgrades to HTTP-only
+	// exactly like the per-domain preview blocks.
+	if p.SSLCertPath != "" {
+		if _, err := os.Stat(p.SSLCertPath); err != nil {
+			p.SSLCertPath, p.SSLKeyPath = "", ""
+		}
+	}
+
+	h2 := nginxHTTP2()
+	p.HTTP2Param, p.HTTP2Directive = h2.Param, h2.Directive
+	tmpl, err := template.New("previewfallback").Parse(previewFallbackTemplate)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("template parse: %v", err)}
+	}
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("template execute: %v", err)}
+	}
+
+	configPath := filepath.Join("/etc/nginx/sites-available", previewFallbackConfName)
+	enabledPath := filepath.Join("/etc/nginx/sites-enabled", previewFallbackConfName)
+
+	nginxOpMu.Lock()
+	defer nginxOpMu.Unlock()
+
+	if existing, err := os.ReadFile(configPath); err == nil && bytes.Equal(existing, rendered.Bytes()) {
+		if _, err := os.Lstat(enabledPath); os.IsNotExist(err) {
+			if err := os.Symlink(configPath, enabledPath); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-link enabled path: %v", err)}
+			}
+			if err := nginxTestAndReload(ctx); err != nil {
+				return nil, err
+			}
+			return previewFallbackResponse{Ok: true, Path: configPath, Changed: true}, nil
+		}
+		return previewFallbackResponse{Ok: true, Path: configPath, Changed: false}, nil
+	}
+
+	tmp := configPath + ".tmp"
+	if err := os.WriteFile(tmp, rendered.Bytes(), 0o644); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write tmp vhost: %v", err)}
+	}
+	if err := os.Rename(tmp, configPath); err != nil {
+		os.Remove(tmp)
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("rename vhost: %v", err)}
+	}
+	os.Remove(enabledPath)
+	if err := os.Symlink(configPath, enabledPath); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("symlink enabled: %v", err)}
+	}
+	if err := nginxTestAndReload(ctx); err != nil {
+		os.Remove(enabledPath)
+		os.Remove(configPath)
+		return nil, err
+	}
+	return previewFallbackResponse{Ok: true, Path: configPath, Changed: true}, nil
+}
+
+func init() {
+	Default.Register("preview.fallback_apply", previewFallbackApplyHandler)
+}

--- a/panel-agent/internal/commands/preview_fallback_vhost_test.go
+++ b/panel-agent/internal/commands/preview_fallback_vhost_test.go
@@ -1,0 +1,66 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"text/template"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func renderPreviewFallback(t *testing.T, p previewFallbackApplyParams) string {
+	t.Helper()
+	tmpl, err := template.New("t").Parse(previewFallbackTemplate)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, p); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}
+
+func TestPreviewFallbackTemplate_HTTPOnly(t *testing.T) {
+	out := renderPreviewFallback(t, previewFallbackApplyParams{Base: "preview.host.tld"})
+	if got := strings.Count(out, "server_name *.preview.host.tld;"); got != 1 {
+		t.Fatalf("want exactly one catch-all server block without a cert, got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, "root /var/www/jabali-errors;") {
+		t.Error("fallback must serve the branded error root")
+	}
+	if !strings.Contains(out, "try_files /jabali-err-404.html =404;") {
+		t.Error("every path must land on the branded 404")
+	}
+	if strings.Contains(out, "ssl_certificate") {
+		t.Error("no cert -> no ssl directives")
+	}
+}
+
+func TestPreviewFallbackTemplate_TLS(t *testing.T) {
+	out := renderPreviewFallback(t, previewFallbackApplyParams{
+		Base:        "preview.host.tld",
+		SSLCertPath: "/etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem",
+		SSLKeyPath:  "/etc/letsencrypt/live/wildcard.preview.host.tld/privkey.pem",
+	})
+	if got := strings.Count(out, "server_name *.preview.host.tld;"); got != 2 {
+		t.Fatalf("with a cert: HTTP-redirect + HTTPS blocks (2 server_name lines), got %d", got)
+	}
+	if !strings.Contains(out, "return 301 https://$host$request_uri;") {
+		t.Error("HTTP block must redirect to https when the cert exists")
+	}
+}
+
+func TestPreviewFallbackApply_RejectsBadBase(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{"base": "not a hostname!"})
+	_, err := previewFallbackApplyHandler(context.Background(), json.RawMessage(params))
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if ae, ok := err.(*agentwire.AgentError); !ok || ae.Code != agentwire.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v", err)
+	}
+}

--- a/panel-api/internal/reconciler/acme_shared_certs.go
+++ b/panel-api/internal/reconciler/acme_shared_certs.go
@@ -26,6 +26,13 @@ const (
 	acmeSharedRenewWindow = 30 * 24 * time.Hour
 	// acmeSharedRetryBackoff throttles retries of failed first issuance.
 	acmeSharedRetryBackoff = 15 * time.Minute
+	// acmeSharedGiveUpAfter: once a never-issued row has been failing this
+	// long, the cause is structural (hostname zone not publicly delegated,
+	// DNS module off) — retrying every 15min forever just burns LE's
+	// failed-validation quota. Drop to one attempt per day; a fixed
+	// environment succeeds on the next daily try (or immediately after
+	// the operator clears last_attempt_at).
+	acmeSharedGiveUpAfter = 24 * time.Hour
 	// acmeSharedRenewBackoff throttles renewal attempts of issued certs.
 	acmeSharedRenewBackoff = 24 * time.Hour
 	// acmeSharedIssueTimeout bounds one certbot DNS-01 run: two hook
@@ -60,6 +67,10 @@ func (r *Reconciler) reconcileAcmeSharedCerts(ctx context.Context) {
 			wait := acmeSharedRetryBackoff
 			if cert.CertPath != nil {
 				wait = acmeSharedRenewBackoff
+			} else if now.Sub(cert.CreatedAt) > acmeSharedGiveUpAfter {
+				// Still never issued after a day of 15-minute retries:
+				// structural failure — daily attempts from here.
+				wait = 24 * time.Hour
 			}
 			if now.Sub(*cert.LastAttemptAt) < wait {
 				continue

--- a/panel-api/internal/reconciler/acme_shared_certs_test.go
+++ b/panel-api/internal/reconciler/acme_shared_certs_test.go
@@ -155,6 +155,37 @@ func TestReconcileAcmeSharedCerts_RenewalUsesLongerBackoff(t *testing.T) {
 	}
 }
 
+func TestReconcileAcmeSharedCerts_GiveUpEscalatesToDaily(t *testing.T) {
+	// Never issued, failing for >24h, last attempt 2h ago: the 15min retry
+	// window has long passed, but the give-up escalation (daily) must hold
+	// the attempt back — structural failures should not burn LE quota.
+	attempt := time.Now().Add(-2 * time.Hour)
+	row := acmeRow("C1", &attempt, nil)
+	row.CreatedAt = time.Now().Add(-48 * time.Hour)
+	repo := newFakeAcmeSharedRepo(row)
+	ag := &fakeDNS01Agent{}
+	r := testReconcilerFor(repo, ag)
+
+	r.reconcileAcmeSharedCerts(context.Background())
+
+	if len(ag.calls) != 0 {
+		t.Error("give-up window must throttle to daily attempts")
+	}
+
+	// A day after the last attempt, it tries again.
+	dayOld := time.Now().Add(-25 * time.Hour)
+	repo2 := newFakeAcmeSharedRepo(func() models.SharedCertificate {
+		r2 := acmeRow("C2", &dayOld, nil)
+		r2.CreatedAt = time.Now().Add(-72 * time.Hour)
+		return r2
+	}())
+	r2 := testReconcilerFor(repo2, &fakeDNS01Agent{})
+	r2.reconcileAcmeSharedCerts(context.Background())
+	if len(repo2.issued) != 1 {
+		t.Error("daily retry must still fire once the day has passed")
+	}
+}
+
 func TestAcmeCertLineageName(t *testing.T) {
 	c := models.SharedCertificate{Name: "*.example.com"}
 	if got := c.ACMELineageName(); got != "wildcard.example.com" {

--- a/panel-api/internal/reconciler/preview_urls.go
+++ b/panel-api/internal/reconciler/preview_urls.go
@@ -78,14 +78,14 @@ func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[stri
 	if r.sharedCerts == nil || r.dnsZones == nil || r.dnsRecords == nil || r.serverSettings == nil {
 		return
 	}
-	any := false
+	enabled := false
 	for _, d := range domains {
 		if d.TempURLEnabled {
-			any = true
+			enabled = true
 			break
 		}
 	}
-	if !any {
+	if !enabled {
 		return
 	}
 	srv, err := r.serverSettings.Get(ctx)
@@ -171,6 +171,24 @@ func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[stri
 	}
 	if srv.PublicIPv6 != "" && !have["AAAA"] {
 		mk("AAAA", srv.PublicIPv6)
+	}
+
+	// 3. Catch-all vhost for previews that don't exist (typo, disabled
+	// or deleted domain): branded 404 instead of the default-vhost drop.
+	// Content-hash gated agent-side — a per-tick no-op once in place;
+	// re-sent each tick so a cert issued later upgrades it to TLS.
+	if r.agent != nil {
+		st := r.previewStateCached(ctx)
+		fbParams := map[string]any{"base": models.PreviewWildcardBase(srv.Hostname)}
+		if st.certPath != "" {
+			fbParams["ssl_cert_path"] = st.certPath
+			fbParams["ssl_key_path"] = st.keyPath
+		}
+		fbCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		if _, err := r.agent.Call(fbCtx, "preview.fallback_apply", fbParams); err != nil {
+			r.log.Warn("preview: fallback vhost apply failed", "err", err)
+		}
+		cancel()
 	}
 }
 

--- a/panel-api/internal/reconciler/preview_urls_test.go
+++ b/panel-api/internal/reconciler/preview_urls_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -48,6 +49,19 @@ func (f *fakePreviewCertRepo) ListAll(_ context.Context) ([]models.SharedCertifi
 func (f *fakePreviewCertRepo) Create(_ context.Context, c *models.SharedCertificate) error {
 	f.created = append(f.created, *c)
 	return nil
+}
+
+type fakePreviewAgent struct {
+	calls []map[string]any
+}
+
+func (f *fakePreviewAgent) Call(_ context.Context, method string, params interface{}) (json.RawMessage, error) {
+	if method != "preview.fallback_apply" {
+		return nil, nil
+	}
+	m, _ := params.(map[string]any)
+	f.calls = append(f.calls, m)
+	return json.RawMessage(`{"ok":true}`), nil
 }
 
 func previewReconciler(certs *fakePreviewCertRepo, zones *fakePreviewZoneRepo, recs *fakePreviewRecordRepo) *Reconciler {
@@ -157,6 +171,36 @@ func TestPreviewParams(t *testing.T) {
 	// stale answers past its TTL semantics for the enabled case.
 	if p := r.previewParams(context.Background(), &models.Domain{Name: "x.com"}); p != nil {
 		t.Errorf("temp URL off must yield nil params, got %+v", p)
+	}
+}
+
+func TestReconcilePreviewInfra_AppliesFallbackVhost(t *testing.T) {
+	certPath := "/etc/letsencrypt/live/wildcard.preview.host.tld/fullchain.pem"
+	keyPath := "/etc/letsencrypt/live/wildcard.preview.host.tld/privkey.pem"
+	certs := &fakePreviewCertRepo{rows: []models.SharedCertificate{{
+		Name: "*.preview.host.tld", Source: models.SharedCertSourceACME,
+		CertPath: &certPath, KeyPath: &keyPath,
+	}}}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	recs := &fakePreviewRecordRepo{existing: []models.DNSRecord{
+		{Name: "*.preview.host.tld", Type: "A"},
+		{Name: "*.preview.host.tld", Type: "AAAA"},
+	}}
+	r := previewReconciler(certs, zones, recs)
+	ag := &fakePreviewAgent{}
+	r.agent = ag
+
+	r.reconcilePreviewInfra(context.Background(), enabledPreviewDomains())
+
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected one preview.fallback_apply call, got %d", len(ag.calls))
+	}
+	call := ag.calls[0]
+	if call["base"] != "preview.host.tld" {
+		t.Errorf("base = %v", call["base"])
+	}
+	if call["ssl_cert_path"] != certPath {
+		t.Errorf("issued wildcard pair must ride along: %+v", call)
 	}
 }
 

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -5,6 +5,7 @@
 import { useTranslation } from "react-i18next";
 import {
   PlusSquareOutlined,
+  EyeOutlined,
   GlobalOutlined,
   MoreOutlined,
   SwapOutlined,
@@ -377,6 +378,30 @@ export const UserDomainList = () => {
                             },
                           ]
                         : []),
+                      {
+                        key: "preview-url",
+                        label: r.temp_url_enabled ? "Disable preview URL" : "Enable preview URL",
+                        icon: <EyeOutlined />,
+                        onClick: async () => {
+                          try {
+                            await apiClient.patch(`/domains/${r.id}`, {
+                              temp_url_enabled: !r.temp_url_enabled,
+                            });
+                            notification.success({
+                              message: r.temp_url_enabled
+                                ? "Preview URL disabled"
+                                : "Preview URL enabled — live within a minute",
+                            });
+                            qc.invalidateQueries({ queryKey: ["list", "domains"] });
+                          } catch (err) {
+                            const e = err as { response?: { data?: { detail?: string; error?: string } } };
+                            notification.error({
+                              message: "Failed to toggle preview URL",
+                              description: e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message,
+                            });
+                          }
+                        },
+                      },
                       {
                         key: "toggle",
                         label: r.is_enabled ? "Disable" : "Enable",


### PR DESCRIPTION
The three parked preview-URL follow-ups, in one PR:

## 1. Catch-all vhost for `*.preview.<hostname>`
Wildcard DNS resolves *every* preview name to the box, but only enabled domains render a preview block — a mistyped slug or a deleted domain's old preview link fell through to the default vhost's connection drop, which reads as "the server is broken" rather than "this preview doesn't exist". New agent command `preview.fallback_apply` (webmail-vhost shape: content-hash gated, `nginx -t` + rollback, global `nginxOpMu`) writes a catch-all block serving the branded 404 from `/var/www/jabali-errors`, HTTPS once the shared wildcard pair is on disk. Dispatched from `reconcilePreviewInfra` each tick (no-op when unchanged; re-send upgrades it to TLS after the cert lands). Specific `server_name` entries always beat the wildcard, so real previews are never shadowed. Pattern borrowed from the operator's production hostsclick preview fleet (`_preview-fallback.conf`).

## 2. Tenant post-create toggle
The PATCH handler always allowed owners to flip `temp_url_enabled` — only the UI entry point was missing. The tenant Actions dropdown (the #833 unified shape) gains **Enable/Disable preview URL**, with the slug-collision 409 surfaced in the error toast.

## 3. ACME first-issuance give-up backoff
A never-issued shared cert retried every 15 minutes forever. After 24 h of failures the cause is structural (hostname zone not publicly delegated, DNS module off — exactly testserver's state), so attempts now drop to daily. Issued-cert renewals keep the existing 24 h cadence; a fixed environment succeeds on the next daily attempt, or immediately if the operator clears `last_attempt_at`.

## Test plan
- [x] Agent template tests: HTTP-only single block, TLS redirect+443 pair, branded-404 root pinned; bad-base validation
- [x] Reconciler tests: infra pass dispatches `preview.fallback_apply` with base + issued pair; give-up window holds a 2h-old failure but fires after 25h
- [x] `go test -race` reconciler + agent commands green; `tsc -b` + `npm run build` + domain vitest green
- [ ] Post-merge on testserver: curl a nonexistent preview slug → branded 404 (not a dropped connection); tenant list shows the toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)