### PR TITLE
fix(migrate/plesk): detect the database engine instead of mysqldump'ing PostgreSQL (GH #429)

### DIFF
--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -693,13 +693,19 @@ func populatePleskDBsAfterExtract(ctx context.Context, sshUser string, job *mode
 	}
 	defer func() { _ = d.Close(ctx, s) }()
 	slug := plesk.Slug(job.SourceUser)
-	n, err := plesk.PopulatePleskDBs(extractDir, slug, func(cmd, dst string) error {
+	n, skipped, err := plesk.PopulatePleskDBs(extractDir, slug, func(cmd, dst string) error {
 		return d.StreamDBDump(ctx, s, cmd, dst)
 	})
 	if err != nil {
 		return err
 	}
 	fmt.Printf("  \u2192 streamed %d database(s) into the cpmove tree\n", n)
+	// GH #429: a database we could not carry across must be stated here and
+	// not just counted out of n. Reporting only the successes is how an
+	// operator ends up telling a customer everything migrated.
+	for _, sk := range skipped {
+		fmt.Printf("  \u2192 WARNING: %s\n", sk)
+	}
 	return nil
 }
 

--- a/panel-api/internal/migrate/plesk/areas.go
+++ b/panel-api/internal/migrate/plesk/areas.go
@@ -67,7 +67,7 @@ func (d *Discoverer) describeDomains(ctx context.Context, s *session, account st
 		root := docroots[dom]
 		spec := migrate.DomainSpec{
 			Name:      dom,
-			DocRoot:   root,       // "" when the domain has no physical hosting
+			DocRoot:   root, // "" when the domain has no physical hosting
 			IsPrimary: dom == account,
 			HasPHP:    root != "", // no hosting => no PHP; refined below
 		}
@@ -128,8 +128,12 @@ func (d *Discoverer) describeDatabases(ctx context.Context, s *session, domains 
 	warns := []migrate.Warning{}
 	for _, dom := range domains {
 		// `plesk bin database` has no list verb; enumerate via the psa DB.
+		// GH #429: db.type comes back too. Without it every database was
+		// labelled mysql and handed to mysqldump, so a PostgreSQL database
+		// failed the import with a bare `exit status 2` and nothing naming
+		// the cause.
 		sql := fmt.Sprintf(
-			"SELECT db.name FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name=%s",
+			"SELECT db.name, db.type FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name=%s",
 			sqlQuote(dom.Name))
 		out, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql))
 		if err != nil {
@@ -139,12 +143,32 @@ func (d *Discoverer) describeDatabases(ctx context.Context, s *session, domains 
 			})
 			continue
 		}
-		for _, name := range splitLines(string(out)) {
+		for _, line := range splitLines(string(out)) {
+			name, engine, _ := strings.Cut(line, "\t")
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			engine = strings.ToLower(strings.TrimSpace(engine))
+			if engine == "" {
+				engine = "mysql"
+			}
 			rows = append(rows, migrate.DatabaseSpec{
-				Engine:    "mysql",
+				Engine:    engine,
 				Name:      name,
 				GrantUser: "",
 			})
+			// Deliver on what this function's doc comment has always claimed:
+			// a non-MySQL database is recorded WITH a warning, so it shows up
+			// in discovery instead of failing later inside mysqldump.
+			if !isMySQLEngine(engine) {
+				warns = append(warns, migrate.Warning{
+					Code: "database_engine_unsupported",
+					Detail: fmt.Sprintf(
+						"%s: database %q uses %s — the migration importer restores MySQL/MariaDB only, "+
+							"so this database will NOT be migrated", dom.Name, name, engine),
+				})
+			}
 		}
 	}
 	return rows, warns, nil

--- a/panel-api/internal/migrate/plesk/backup.go
+++ b/panel-api/internal/migrate/plesk/backup.go
@@ -83,7 +83,10 @@ elif mysql -uroot -BN -e "SELECT 1" >/dev/null 2>&1; then
 else
   echo "WARN: no MySQL admin creds (tried /etc/psa/.psa.shadow, root) — restore DB dumps will be skipped" >&2
 fi
-plesk db -Ne "SELECT db.name FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name='$SUB'" 2>/dev/null \
+# GH #429: emit the engine as a second tab-separated column. Plesk records
+#    PostgreSQL databases in this same table, and dumping one with mysqldump
+#    fails at restore with a bare exit status 2 that names no cause.
+plesk db -Ne "SELECT db.name, db.type FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name='$SUB'" 2>/dev/null \
 | awk 'NF' > "$TMP/cpmove-$SLUG/databases.txt" || true
 
 # 3. domains-paths.txt — every domain of the subscription + its docroot,

--- a/panel-api/internal/migrate/plesk/restore.go
+++ b/panel-api/internal/migrate/plesk/restore.go
@@ -65,6 +65,37 @@ func parseLinesManifest(content string) []string {
 	return splitLines(content)
 }
 
+// DBManifestEntry is one line of databases.txt: a database and the engine it
+// actually lives in on the source.
+type DBManifestEntry struct {
+	Name   string
+	Engine string
+}
+
+// parseDatabasesManifest parses databases.txt as "<name>\t<engine>", falling
+// back to mysql for a bare name.
+//
+// GH #429: the manifest used to be names only, because every Plesk database
+// was assumed to be MySQL. A bare line can only have come from the older
+// backup script, which ran before any engine was recorded and only ever
+// produced MySQL databases — so mysql is the right and safe default for it.
+func parseDatabasesManifest(content string) []DBManifestEntry {
+	var out []DBManifestEntry
+	for _, line := range splitLines(content) {
+		name, engine, found := strings.Cut(line, "\t")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		engine = strings.ToLower(strings.TrimSpace(engine))
+		if !found || engine == "" {
+			engine = "mysql"
+		}
+		out = append(out, DBManifestEntry{Name: name, Engine: engine})
+	}
+	return out
+}
+
 // dbDumpCommand builds the READ-ONLY mysqldump command to run on the Plesk
 // source (over SSH) to stream one database to stdout. Plesk stashes the
 // admin DB password at /etc/psa/.psa.shadow; --single-transaction takes a
@@ -90,28 +121,54 @@ func docrootRemotePath(e ManifestEntry) string { return e.Path }
 // source. `stream` is injected so callers pass the live session's streamer
 // (and tests pass a fake). Returns the number of DBs dumped. A db name that
 // fails the charset guard is skipped (never used as an unchecked filename).
-func PopulatePleskDBs(extractDir, slug string, stream func(cmd, dstPath string) error) (int, error) {
+func PopulatePleskDBs(extractDir, slug string, stream func(cmd, dstPath string) error) (int, []string, error) {
 	base := filepath.Join(extractDir, "cpmove-"+slug)
 	mysqlDir := filepath.Join(base, "mysql")
 	if err := os.MkdirAll(mysqlDir, 0o750); err != nil {
-		return 0, fmt.Errorf("mkdir mysql dir: %w", err)
+		return 0, nil, fmt.Errorf("mkdir mysql dir: %w", err)
 	}
 	raw, err := os.ReadFile(filepath.Join(base, "databases.txt"))
 	if err != nil {
-		return 0, nil // no manifest → no DBs (not fatal)
+		return 0, nil, nil // no manifest → no DBs (not fatal)
 	}
 	n := 0
-	for _, db := range parseLinesManifest(string(raw)) {
-		if !validDBName(db) {
+	var skipped []string
+	for _, entry := range parseDatabasesManifest(string(raw)) {
+		if !validDBName(entry.Name) {
 			continue // refuse a suspicious name as a filename
 		}
-		dst := filepath.Join(mysqlDir, db+".sql")
-		if err := stream(dbDumpCommand(db), dst); err != nil {
-			return n, fmt.Errorf("stream db %s: %w", db, err)
+		// GH #429: only MySQL/MariaDB can be dumped with mysqldump and read
+		// back by the cpanel importer. Pointing mysqldump at a PostgreSQL
+		// database is what produced the reported bare `exit status 2`.
+		if !isMySQLEngine(entry.Engine) {
+			skipped = append(skipped, fmt.Sprintf(
+				"database %q (engine %s) was NOT migrated — jabali's migration importer "+
+					"can only restore MySQL/MariaDB. Move it across by hand (pg_dump on the "+
+					"source, then restore into a PostgreSQL database on this server) before "+
+					"decommissioning the source.",
+				entry.Name, entry.Engine))
+			continue
+		}
+		dst := filepath.Join(mysqlDir, entry.Name+".sql")
+		if err := stream(dbDumpCommand(entry.Name), dst); err != nil {
+			return n, skipped, fmt.Errorf("stream db %s: %w", entry.Name, err)
 		}
 		n++
 	}
-	return n, nil
+	return n, skipped, nil
+}
+
+// isMySQLEngine reports whether psa's data_bases.type names a MySQL-family
+// engine. Plesk writes "mysql"; the family is spelled several ways across
+// versions and adapters, so match generously and treat anything unrecognised
+// as NOT MySQL — guessing wrong in that direction produces the misleading
+// mysqldump failure this fix exists to remove.
+func isMySQLEngine(engine string) bool {
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case "", "mysql", "mariadb", "mysqli":
+		return true
+	}
+	return false
 }
 
 // StreamDBDump is the production streamer bound to a live pull session; the

--- a/panel-api/internal/migrate/plesk/restore_pg_test.go
+++ b/panel-api/internal/migrate/plesk/restore_pg_test.go
@@ -1,0 +1,133 @@
+package plesk
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #429. A Plesk subscription backed by PostgreSQL failed the import with
+//
+//	pull-source: plesk db populate: stream db db_name: ssh stream
+//	"MYSQL_PWD=\"$(cat /etc/psa/.psa.shadow)\" mysqldump -uadmin
+//	--skip-lock-tables --single-transaction 'db_name'":
+//	Process exited with status 2
+//
+// mysqldump was asked for a database that does not live in MySQL.
+//
+// describeDatabases already carried the right intent in its doc comment —
+// "Postgres databases are recorded with a warning (v1 restore is MySQL-only,
+// same as the other importers)" — but the code under it hardcoded
+// Engine: "mysql" on every row and never read psa's data_bases.type. So a
+// PostgreSQL database was relabelled MySQL and handed to mysqldump, and the
+// operator got a bare exit-2 with nothing pointing at the cause.
+//
+// Until the destination can actually take a PostgreSQL dump (the agent has
+// db.postgres.dump but no restore verb, and cpanel.ImportDatabases is
+// MySQL-only), the honest behaviour is to detect the engine, leave those
+// databases out of the mysqldump loop, and say so loudly enough that nobody
+// tells a customer their database migrated.
+
+func TestParseDatabasesManifest_CarriesEngine(t *testing.T) {
+	t.Parallel()
+
+	// New format is "<name>\t<engine>". Bare lines are pre-existing manifests
+	// from a box that ran the old backup script — those predate any Postgres
+	// awareness and were only ever produced for MySQL.
+	got := parseDatabasesManifest("shop_db\tmysql\nblog_pg\tpostgresql\nlegacy_db\n\n")
+
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d: %+v", len(got), got)
+	}
+	for i, want := range []struct {
+		name   string
+		engine string
+	}{
+		{"shop_db", "mysql"},
+		{"blog_pg", "postgresql"},
+		{"legacy_db", "mysql"},
+	} {
+		if got[i].Name != want.name || got[i].Engine != want.engine {
+			t.Errorf("entry %d = %+v, want {%s %s}", i, got[i], want.name, want.engine)
+		}
+	}
+}
+
+func TestPopulatePleskDBs_SkipsPostgresInsteadOfMysqldumpingIt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "cpmove-acct")
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "shop_db\tmysql\nblog_pg\tpostgresql\n"
+	if err := os.WriteFile(filepath.Join(base, "databases.txt"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var cmds []string
+	stream := func(cmd, dstPath string) error {
+		cmds = append(cmds, cmd)
+		return os.WriteFile(dstPath, []byte("-- dump\n"), 0o600)
+	}
+
+	n, skipped, err := PopulatePleskDBs(dir, "acct", stream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("streamed %d database(s), want 1 — only the MySQL one", n)
+	}
+	if len(cmds) != 1 || !strings.Contains(cmds[0], "'shop_db'") {
+		t.Fatalf("wrong command set: %v", cmds)
+	}
+	// The whole bug: mysqldump must never be pointed at the Postgres database.
+	for _, c := range cmds {
+		if strings.Contains(c, "blog_pg") {
+			t.Errorf("PostgreSQL database was handed to a dump command:\n%s", c)
+		}
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("want 1 skip record, got %v", skipped)
+	}
+	if !strings.Contains(skipped[0], "blog_pg") || !strings.Contains(skipped[0], "postgresql") {
+		t.Errorf("skip record must name the database and its engine: %q", skipped[0])
+	}
+	if !strings.Contains(strings.ToLower(skipped[0]), "not migrated") {
+		t.Errorf("skip record has to say the data did NOT come across — a "+
+			"customer must never be told this database migrated: %q", skipped[0])
+	}
+}
+
+func TestPopulatePleskDBs_AllMySQLReportsNoSkips(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := filepath.Join(dir, "cpmove-acct")
+	if err := os.MkdirAll(base, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "databases.txt"), []byte("a_db\tmysql\nb_db\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	n, skipped, err := PopulatePleskDBs(dir, "acct", func(cmd, dst string) error {
+		return os.WriteFile(dst, []byte("x"), 0o600)
+	})
+	if err != nil || n != 2 || len(skipped) != 0 {
+		t.Errorf("plain MySQL manifest regressed: n=%d skipped=%v err=%v", n, skipped, err)
+	}
+}
+
+func TestDBDumpCommand_UnchangedForMySQL(t *testing.T) {
+	t.Parallel()
+
+	// The MySQL path is the one that works today; it must not drift.
+	cmd := dbDumpCommand("shop_db")
+	for _, want := range []string{"mysqldump", "-uadmin", "--single-transaction", "'shop_db'", "/etc/psa/.psa.shadow"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("missing %q in:\n%s", want, cmd)
+		}
+	}
+}

--- a/panel-api/internal/migrate/plesk/restore_populate_test.go
+++ b/panel-api/internal/migrate/plesk/restore_populate_test.go
@@ -44,7 +44,7 @@ func TestPopulatePleskDBs_StreamsValidSkipsBad(t *testing.T) {
 		}
 		return os.WriteFile(dstPath, []byte("-- dump\n"), 0o640)
 	}
-	n, err := PopulatePleskDBs(extract, slug, fake)
+	n, _, err := PopulatePleskDBs(extract, slug, fake)
 	if err != nil {
 		t.Fatalf("PopulatePleskDBs: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestPopulatePleskDBs_NoManifestIsQuiet(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(extract, "cpmove-"+slug), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	n, err := PopulatePleskDBs(extract, slug, func(_, _ string) error { return nil })
+	n, _, err := PopulatePleskDBs(extract, slug, func(_, _ string) error { return nil })
 	if err != nil || n != 0 {
 		t.Errorf("no databases.txt → (0,nil), got (%d,%v)", n, err)
 	}


### PR DESCRIPTION
Reported by @lxsdevcode on #429: a Plesk subscription backed by **PostgreSQL** fails the import with

```
pull-source: plesk db populate: stream db db_name: ssh stream "MYSQL_PWD=\"$(cat /etc/psa/.psa.shadow)\" mysqldump -uadmin --skip-lock-tables --single-transaction 'db_name'": Process exited with status 2
```

Their diagnosis was correct: `mysqldump` was being pointed at a database that does not live in MySQL.

## Root cause

`describeDatabases` already **documented** the right behaviour:

> Postgres databases are recorded with a warning (v1 restore is MySQL-only, same as the other importers).

The code under that comment hardcoded `Engine: "mysql"` on every row and never read `psa.data_bases.type`. Both enumeration sites selected the name alone:

```sql
SELECT db.name FROM data_bases db JOIN domains d ON db.dom_id=d.id WHERE d.name=...
```

So a PostgreSQL database was relabelled MySQL, handed to `mysqldump`, and surfaced as a bare `exit status 2` with nothing naming the cause.

## Change

- Both queries (`areas.go` discovery, `backup.go` manifest builder) now select `db.type`.
- `databases.txt` gains a second tab-separated engine column. A bare line still parses as `mysql`, so a manifest written by the older backup script keeps working — it predates any engine awareness and only ever produced MySQL databases.
- A non-MySQL-family engine is left out of the dump loop and returned as a skip record, which `pull-source` prints as a `WARNING`.
- Discovery raises `database_engine_unsupported`, so it is visible **before** the import runs rather than during it.
- Unrecognised engines are treated as **not** MySQL. Guessing the other way reproduces the exact misleading failure this removes.

## What this does not do

**It does not migrate PostgreSQL databases.** It stops the confusing failure and states plainly that the data did not come across, so nobody reports the subscription as fully migrated.

Full support needs a destination path that does not exist yet: the agent has `db.postgres.create_db` / `create_role` / `grant` / `dump` / `list_dbs` but **no restore verb**, and `cpanel.ImportDatabases` is MySQL-only. jabali does have PostgreSQL 16 as an opt-in module and `databases.engine enum('mariadb','postgres')`, so the destination is capable — the migration wiring is the missing piece. Worth its own issue.

## Test plan

- [x] 4 new tests: engine parsed from the manifest, bare lines default to mysql, PostgreSQL is skipped and never reaches a dump command, an all-MySQL manifest reports zero skips, and the MySQL command itself is pinned unchanged
- [x] Pre-existing `restore_populate_test.go` / `restore_test.go` still pass
- [x] `go build ./...`, `go vet ./...`, full `panel-api` suite clean
- [x] Rebased onto `origin/main`, tests re-run post-rebase
- [ ] **Not box-verified** — no Plesk source with a PostgreSQL subscription available here. The reporter has one in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)