### PR TITLE
fix(preview): fallback vhost must join the IP-specific listen pools

### DIFF
--- a/panel-agent/internal/commands/preview_fallback_vhost.go
+++ b/panel-agent/internal/commands/preview_fallback_vhost.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -33,9 +34,17 @@ const previewFallbackConfName = "jabali-preview-fallback.conf"
 
 type previewFallbackApplyParams struct {
 	// Base is "preview.<hostname>" — the wildcard serves *.<Base>.
-	Base           string `json:"base"`
-	SSLCertPath    string `json:"ssl_cert_path,omitempty"`
-	SSLKeyPath     string `json:"ssl_key_path,omitempty"`
+	Base        string `json:"base"`
+	SSLCertPath string `json:"ssl_cert_path,omitempty"`
+	SSLKeyPath  string `json:"ssl_key_path,omitempty"`
+	// ListenIPv4/ListenIPv6: the box's public IPs. nginx picks server
+	// blocks from the MOST specific matching listen socket — per-domain
+	// vhosts bind explicit IPs (M24), so a connection to the public IP
+	// never considers a bare `listen 80` server. The fallback must join
+	// the IP-specific pools too or it silently never matches (found on
+	// the first live verify: bogus preview slug → connection drop).
+	ListenIPv4     string `json:"listen_ipv4,omitempty"`
+	ListenIPv6     string `json:"listen_ipv6,omitempty"`
 	HTTP2Param     string `json:"-"`
 	HTTP2Directive string `json:"-"`
 }
@@ -52,7 +61,9 @@ const previewFallbackTemplate = `# Managed by jabali-agent (preview.fallback_app
 server {
     listen 80;
     listen [::]:80;
-    server_name *.{{.Base}};
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:80;
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:80;
+{{ end }}    server_name *.{{.Base}};
 {{ if .SSLCertPath }}
     location / {
         return 301 https://$host$request_uri;
@@ -62,7 +73,9 @@ server {
 server {
     listen 443 ssl{{.HTTP2Param}};
     listen [::]:443 ssl{{.HTTP2Param}};
-{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
 {{ end }}    server_name *.{{.Base}};
     ssl_certificate {{.SSLCertPath}};
     ssl_certificate_key {{.SSLKeyPath}};
@@ -91,6 +104,12 @@ func previewFallbackApplyHandler(ctx context.Context, params json.RawMessage) (a
 			Code:    agentwire.CodeInvalidArgument,
 			Message: fmt.Sprintf("invalid base %q", p.Base),
 		}
+	}
+	if p.ListenIPv4 != "" && net.ParseIP(p.ListenIPv4) == nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid listen_ipv4 %q", p.ListenIPv4)}
+	}
+	if p.ListenIPv6 != "" && net.ParseIP(p.ListenIPv6) == nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid listen_ipv6 %q", p.ListenIPv6)}
 	}
 	// Cert paths travel together; a missing file downgrades to HTTP-only
 	// exactly like the per-domain preview blocks.

--- a/panel-agent/internal/commands/preview_fallback_vhost_test.go
+++ b/panel-agent/internal/commands/preview_fallback_vhost_test.go
@@ -54,6 +54,41 @@ func TestPreviewFallbackTemplate_TLS(t *testing.T) {
 	}
 }
 
+// The regression the first live verify caught: per-domain vhosts bind
+// explicit IPs (M24), so nginx only considers IP-bound servers for
+// connections to the public IP — a bare `listen 80` fallback silently
+// never matched. The fallback must join the IP-specific pools.
+func TestPreviewFallbackTemplate_JoinsIPListenPools(t *testing.T) {
+	out := renderPreviewFallback(t, previewFallbackApplyParams{
+		Base:        "preview.host.tld",
+		ListenIPv4:  "203.0.113.7",
+		ListenIPv6:  "2001:db8::7",
+		SSLCertPath: "/etc/letsencrypt/live/x/fullchain.pem",
+		SSLKeyPath:  "/etc/letsencrypt/live/x/privkey.pem",
+	})
+	for _, want := range []string{
+		"listen 203.0.113.7:80;",
+		"listen [2001:db8::7]:80;",
+		"listen 203.0.113.7:443 ssl",
+		"listen [2001:db8::7]:443 ssl",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+}
+
+func TestPreviewFallbackApply_RejectsBadIP(t *testing.T) {
+	params, _ := json.Marshal(map[string]any{"base": "preview.host.tld", "listen_ipv4": "not-an-ip"})
+	_, err := previewFallbackApplyHandler(context.Background(), json.RawMessage(params))
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if ae, ok := err.(*agentwire.AgentError); !ok || ae.Code != agentwire.CodeInvalidArgument {
+		t.Fatalf("expected CodeInvalidArgument, got %v", err)
+	}
+}
+
 func TestPreviewFallbackApply_RejectsBadBase(t *testing.T) {
 	params, _ := json.Marshal(map[string]any{"base": "not a hostname!"})
 	_, err := previewFallbackApplyHandler(context.Background(), json.RawMessage(params))

--- a/panel-api/internal/reconciler/preview_urls.go
+++ b/panel-api/internal/reconciler/preview_urls.go
@@ -180,6 +180,15 @@ func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[stri
 	if r.agent != nil {
 		st := r.previewStateCached(ctx)
 		fbParams := map[string]any{"base": models.PreviewWildcardBase(srv.Hostname)}
+		// The fallback must join the IP-specific listen pools (M24
+		// per-domain binds) or nginx never considers it for connections
+		// to the public IP — see the agent-side comment.
+		if srv.PublicIPv4 != "" {
+			fbParams["listen_ipv4"] = srv.PublicIPv4
+		}
+		if srv.PublicIPv6 != "" {
+			fbParams["listen_ipv6"] = srv.PublicIPv6
+		}
 		if st.certPath != "" {
 			fbParams["ssl_cert_path"] = st.certPath
 			fbParams["ssl_key_path"] = st.keyPath


### PR DESCRIPTION
Live-verify follow-up to #845: the catch-all worked in `nginx -T` but a bogus preview slug still got the default-vhost connection drop. Cause: nginx picks candidate server blocks from the **most specific matching listen socket** — per-domain vhosts bind explicit public IPs (M24), so for connections to the public IP the fallback's bare `listen 80` was never in the candidate pool at all.

The fallback now renders explicit `listen <ip>:80` / `listen <ip>:443 ssl` lines for the box's public IPv4/IPv6 (threaded from server settings by `reconcilePreviewInfra`), joining the IP-specific pools alongside the wildcard binds. IPs are validated agent-side (`net.ParseIP`); a new template test pins all four listen lines, and the earlier tests still pin the branded-404 + TLS shapes.

## Test plan
- [x] Template test: IPv4/IPv6 listen lines on both :80 and :443
- [x] Invalid-IP param rejected as invalid-argument
- [x] Full `go test ./panel-api/... ./panel-agent/...` green
- [ ] Post-merge on testserver: `curl -H "Host: no-such.preview.<hostname>" http://<public-ip>/` → branded 404 (this exact command produced 000 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)