### PR TITLE
feat(preview): configurable preview-URL base (GH #836)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -455,11 +455,13 @@ func (h *domainHandler) list(c *gin.Context) {
 			}
 		}
 		if needsPreview {
-			if srv, sErr := h.cfg.ServerSettings.Get(c.Request.Context()); sErr == nil && srv != nil && srv.Hostname != "" {
-				for i := range rows {
-					if rows[i].TempURLEnabled {
-						u := "https://" + models.PreviewHost(rows[i].Name, srv.Hostname)
-						rows[i].TempURL = &u
+			if srv, sErr := h.cfg.ServerSettings.Get(c.Request.Context()); sErr == nil && srv != nil {
+				if base := models.EffectivePreviewBase(srv); base != "" {
+					for i := range rows {
+						if rows[i].TempURLEnabled {
+							u := "https://" + models.PreviewHost(rows[i].Name, base)
+							rows[i].TempURL = &u
+						}
 					}
 				}
 			}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -91,6 +91,7 @@ func (h *serverSettingsHandler) get(c *gin.Context) {
 
 type updateServerSettingsRequest struct {
 	Hostname                 *string          `json:"hostname,omitempty"`
+	PreviewBase              *string          `json:"preview_base,omitempty"`
 	PublicIPv4               *string          `json:"public_ipv4,omitempty"`
 	PublicIPv6               *string          `json:"public_ipv6,omitempty"`
 	NS1Name                  *string          `json:"ns1_name,omitempty"`
@@ -285,6 +286,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 
 	if req.Hostname != nil {
 		current.Hostname = strings.TrimSpace(*req.Hostname)
+	}
+	if req.PreviewBase != nil {
+		current.PreviewBase = models.NormalizePreviewBase(*req.PreviewBase)
 	}
 	if req.PublicIPv4 != nil {
 		current.PublicIPv4 = strings.TrimSpace(*req.PublicIPv4)
@@ -996,6 +1000,11 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 func ValidateServerSettings(s *models.ServerSettings) error {
 	if s.Hostname != "" && !isValidHostname(s.Hostname) {
 		return fmt.Errorf("invalid hostname")
+	}
+	// GH #836: preview base must be a bare hostname (the wildcard label
+	// is implied; NormalizePreviewBase already stripped "*." and case).
+	if s.PreviewBase != "" && !isValidHostname(s.PreviewBase) {
+		return fmt.Errorf("preview_base: invalid hostname")
 	}
 	// IPv4
 	for label, v := range map[string]string{"public_ipv4": s.PublicIPv4, "ns1_ipv4": s.NS1IPv4, "ns2_ipv4": s.NS2IPv4} {

--- a/panel-api/internal/db/migrations/000244_preview_base.down.sql
+++ b/panel-api/internal/db/migrations/000244_preview_base.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN preview_base;

--- a/panel-api/internal/db/migrations/000244_preview_base.up.sql
+++ b/panel-api/internal/db/migrations/000244_preview_base.up.sql
@@ -1,0 +1,6 @@
+-- GH #836: configurable preview-URL base. Empty = derive
+-- preview.<hostname> (the default behavior). Set it to a custom domain
+-- (preview.example.com) or a magic-DNS base (203-0-113-7.sslip.io) on
+-- boxes whose hostname does not resolve publicly.
+ALTER TABLE server_settings
+  ADD COLUMN preview_base varchar(253) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/preview_url.go
+++ b/panel-api/internal/models/preview_url.go
@@ -16,23 +16,44 @@ func PreviewSlug(domainName string) string {
 	return strings.ReplaceAll(strings.ToLower(strings.TrimSuffix(domainName, ".")), ".", "-")
 }
 
-// PreviewHost returns the full preview hostname for a domain under the
-// panel hostname. Empty when hostname is unset — callers skip preview
-// wiring entirely in that case.
-func PreviewHost(domainName, panelHostname string) string {
-	if panelHostname == "" || domainName == "" {
+// EffectivePreviewBase resolves the base every preview host hangs off:
+// server_settings.preview_base when set (GH #836 — custom domain or
+// magic-DNS base like 203-0-113-7.sslip.io), else the derived
+// "preview.<hostname>". Empty when neither is configured — callers skip
+// preview wiring entirely in that case.
+func EffectivePreviewBase(srv *ServerSettings) string {
+	if srv == nil {
 		return ""
 	}
-	return PreviewSlug(domainName) + "." + PreviewWildcardBase(panelHostname)
+	if b := NormalizePreviewBase(srv.PreviewBase); b != "" {
+		return b
+	}
+	if srv.Hostname == "" {
+		return ""
+	}
+	return "preview." + strings.TrimSuffix(strings.ToLower(srv.Hostname), ".")
 }
 
-// PreviewWildcardBase is the label the wildcard DNS record + cert cover:
-// "preview.<hostname>".
-func PreviewWildcardBase(panelHostname string) string {
-	return "preview." + strings.TrimSuffix(strings.ToLower(panelHostname), ".")
+// NormalizePreviewBase canonicalises operator input: lowercase, no
+// leading "*." (the wildcard is implied), no trailing dot, no
+// whitespace.
+func NormalizePreviewBase(v string) string {
+	v = strings.TrimSpace(strings.ToLower(v))
+	v = strings.TrimPrefix(v, "*.")
+	return strings.TrimSuffix(v, ".")
 }
 
-// PreviewWildcardName is the DNS/SAN wildcard: "*.preview.<hostname>".
-func PreviewWildcardName(panelHostname string) string {
-	return "*." + PreviewWildcardBase(panelHostname)
+// PreviewHost returns the full preview hostname for a domain under the
+// given base. Empty when either is unset.
+func PreviewHost(domainName, base string) string {
+	if base == "" || domainName == "" {
+		return ""
+	}
+	return PreviewSlug(domainName) + "." + base
+}
+
+// PreviewWildcardName is the DNS/SAN wildcard covering every preview
+// host under base.
+func PreviewWildcardName(base string) string {
+	return "*." + base
 }

--- a/panel-api/internal/models/preview_url_test.go
+++ b/panel-api/internal/models/preview_url_test.go
@@ -9,14 +9,24 @@ func TestPreviewNaming(t *testing.T) {
 	if got := PreviewSlug("Example.COM."); got != "example-com" {
 		t.Errorf("slug must lowercase + strip trailing dot, got %q", got)
 	}
-	if got := PreviewHost("example.com", "host.tld"); got != "example-com.preview.host.tld" {
+	if got := PreviewHost("example.com", "preview.host.tld"); got != "example-com.preview.host.tld" {
 		t.Errorf("host = %q", got)
 	}
 	if got := PreviewHost("example.com", ""); got != "" {
-		t.Errorf("no hostname must yield empty preview host, got %q", got)
+		t.Errorf("no base must yield empty preview host, got %q", got)
 	}
-	if got := PreviewWildcardName("host.tld"); got != "*.preview.host.tld" {
+	if got := PreviewWildcardName("preview.host.tld"); got != "*.preview.host.tld" {
 		t.Errorf("wildcard = %q", got)
+	}
+	// GH #836: settings override wins over the derived hostname base.
+	if got := EffectivePreviewBase(&ServerSettings{Hostname: "host.tld"}); got != "preview.host.tld" {
+		t.Errorf("derived base = %q", got)
+	}
+	if got := EffectivePreviewBase(&ServerSettings{Hostname: "host.tld", PreviewBase: "*.Preview.Example.COM."}); got != "preview.example.com" {
+		t.Errorf("override base must normalize, got %q", got)
+	}
+	if got := EffectivePreviewBase(&ServerSettings{}); got != "" {
+		t.Errorf("no hostname, no base -> empty, got %q", got)
 	}
 }
 

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -11,6 +11,11 @@ import (
 type ServerSettings struct {
 	ID         uint8  `gorm:"primaryKey;default:1"                json:"id"`
 	Hostname   string `gorm:"type:varchar(253);not null;default:''" json:"hostname"`
+	// PreviewBase (GH #836, migration 000244) overrides the derived
+	// preview-URL base. Empty = preview.<hostname>. Set a custom domain
+	// (preview.example.com) or a magic-DNS base (203-0-113-7.sslip.io)
+	// when the hostname does not resolve publicly.
+	PreviewBase string `gorm:"type:varchar(253);not null;default:''" json:"preview_base"`
 	PublicIPv4 string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv4"`
 	PublicIPv6 string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv6"`
 	NS1Name    string `gorm:"type:varchar(253);not null;default:''" json:"ns1_name"`

--- a/panel-api/internal/reconciler/preview_urls.go
+++ b/panel-api/internal/reconciler/preview_urls.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
@@ -31,7 +32,7 @@ const previewManagedBy = "preview"
 const previewStateTTL = 45 * time.Second
 
 type previewState struct {
-	hostname string // panel hostname ("" = preview unavailable)
+	base     string // effective preview base ("" = preview unavailable)
 	certPath string // shared wildcard pair; empty until issued
 	keyPath  string
 }
@@ -48,9 +49,11 @@ func (r *Reconciler) previewStateCached(ctx context.Context) previewState {
 
 	st := previewState{}
 	if r.serverSettings != nil && r.sharedCerts != nil {
-		if srv, err := r.serverSettings.Get(ctx); err == nil && srv != nil && srv.Hostname != "" {
-			st.hostname = srv.Hostname
-			wildcard := models.PreviewWildcardName(srv.Hostname)
+		if srv, err := r.serverSettings.Get(ctx); err == nil && srv != nil {
+			st.base = models.EffectivePreviewBase(srv)
+		}
+		if st.base != "" {
+			wildcard := models.PreviewWildcardName(st.base)
 			if certs, err := r.sharedCerts.ListAll(ctx); err == nil {
 				for i := range certs {
 					if certs[i].Name != wildcard || certs[i].Source != models.SharedCertSourceACME {
@@ -89,55 +92,96 @@ func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[stri
 		return
 	}
 	srv, err := r.serverSettings.Get(ctx)
-	if err != nil || srv == nil || srv.Hostname == "" {
-		r.log.Warn("preview: domains have temp URLs enabled but no panel hostname is set")
+	if err != nil || srv == nil {
 		return
 	}
-	wildcard := models.PreviewWildcardName(srv.Hostname)
+	base := models.EffectivePreviewBase(srv)
+	if base == "" {
+		r.log.Warn("preview: domains have temp URLs enabled but neither preview_base nor a hostname is set")
+		return
+	}
+	wildcard := models.PreviewWildcardName(base)
+	// DNS + DNS-01 cert only make sense when a locally-hosted zone
+	// contains the base. A foreign base (sslip.io magic DNS, or a custom
+	// domain whose DNS lives elsewhere — GH #836) already resolves
+	// externally; previews then serve HTTP-only and the fallback vhost
+	// still applies.
+	zone := r.findZoneForPreviewBase(ctx, base)
 
 	// 1. Shared wildcard cert row (issued by reconcileAcmeSharedCerts).
-	certs, err := r.sharedCerts.ListAll(ctx)
-	if err == nil {
-		found := false
-		for i := range certs {
-			if certs[i].Name == wildcard {
-				found = true
-				break
+	// Skipped for foreign bases: DNS-01 places the challenge TXT through
+	// the local pdns, which cannot answer for a zone it does not host.
+	if zone != nil {
+		if certs, cerr := r.sharedCerts.ListAll(ctx); cerr == nil {
+			found := false
+			for i := range certs {
+				if certs[i].Name == wildcard {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			sansJSON := `["` + wildcard + `"]`
-			now := time.Now().UTC()
-			row := &models.SharedCertificate{
-				ID:        ids.NewULID(),
-				Name:      wildcard,
-				UserID:    nil, // server-wide
-				SANs:      &sansJSON,
-				Source:    models.SharedCertSourceACME,
-				CreatedAt: now,
-				UpdatedAt: now,
-			}
-			if cerr := r.sharedCerts.Create(ctx, row); cerr != nil {
-				r.log.Error("preview: create wildcard cert row failed", "err", cerr)
-			} else {
-				r.log.Info("preview: requested wildcard certificate", "name", wildcard)
+			if !found {
+				sansJSON := `["` + wildcard + `"]`
+				now := time.Now().UTC()
+				row := &models.SharedCertificate{
+					ID:        ids.NewULID(),
+					Name:      wildcard,
+					UserID:    nil, // server-wide
+					SANs:      &sansJSON,
+					Source:    models.SharedCertSourceACME,
+					CreatedAt: now,
+					UpdatedAt: now,
+				}
+				if cerr := r.sharedCerts.Create(ctx, row); cerr != nil {
+					r.log.Error("preview: create wildcard cert row failed", "err", cerr)
+				} else {
+					r.log.Info("preview: requested wildcard certificate", "name", wildcard)
+				}
 			}
 		}
 	}
 
-	// 2. Wildcard A/AAAA records in the hostname zone. The panel-primary
-	// domain's reconcileDNSZone pass pushes the zone every tick, so a row
-	// insert here is live on the next push.
-	zone, err := r.dnsZones.FindByName(ctx, srv.Hostname)
-	if err != nil {
-		r.log.Warn("preview: hostname zone not found in dns_zones — preview DNS cannot be published", "hostname", srv.Hostname, "err", err)
-		return
+	// 2. Wildcard A/AAAA records in the base's zone (local zones only).
+	if zone == nil {
+		r.log.Info("preview: base has no locally-hosted zone — DNS + cert are managed externally, previews serve via the external resolution", "base", base)
+	} else if rows, lerr := r.dnsRecords.ListByZoneID(ctx, zone.ID); lerr != nil {
+		r.log.Error("preview: list base zone records failed", "err", lerr)
+	} else {
+		r.ensurePreviewWildcardRecords(ctx, zone, wildcard, srv, rows)
 	}
-	rows, err := r.dnsRecords.ListByZoneID(ctx, zone.ID)
-	if err != nil {
-		r.log.Error("preview: list hostname zone records failed", "err", err)
-		return
+
+	// 3. Catch-all vhost — applies for EVERY base, foreign ones
+	// included: unknown slugs must land on the branded 404, not the
+	// default-vhost drop. Content-hash gated agent-side; re-sent each
+	// tick so a cert issued later upgrades it to TLS.
+	if r.agent != nil {
+		st := r.previewStateCached(ctx)
+		fbParams := map[string]any{"base": base}
+		// The fallback must join the IP-specific listen pools (M24
+		// per-domain binds) or nginx never considers it for connections
+		// to the public IP — see the agent-side comment.
+		if srv.PublicIPv4 != "" {
+			fbParams["listen_ipv4"] = srv.PublicIPv4
+		}
+		if srv.PublicIPv6 != "" {
+			fbParams["listen_ipv6"] = srv.PublicIPv6
+		}
+		if st.certPath != "" {
+			fbParams["ssl_cert_path"] = st.certPath
+			fbParams["ssl_key_path"] = st.keyPath
+		}
+		fbCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		if _, err := r.agent.Call(fbCtx, "preview.fallback_apply", fbParams); err != nil {
+			r.log.Warn("preview: fallback vhost apply failed", "err", err)
+		}
+		cancel()
 	}
+}
+
+// ensurePreviewWildcardRecords converges the wildcard A/AAAA rows for
+// base inside its locally-hosted zone. The zone's owning domain pushes
+// it to pdns every tick, so a row insert here is live on the next push.
+func (r *Reconciler) ensurePreviewWildcardRecords(ctx context.Context, zone *models.DNSZone, wildcard string, srv *models.ServerSettings, rows []models.DNSRecord) {
 	have := map[string]bool{}
 	for i := range rows {
 		if rows[i].Name == wildcard {
@@ -172,33 +216,20 @@ func (r *Reconciler) reconcilePreviewInfra(ctx context.Context, domains map[stri
 	if srv.PublicIPv6 != "" && !have["AAAA"] {
 		mk("AAAA", srv.PublicIPv6)
 	}
+}
 
-	// 3. Catch-all vhost for previews that don't exist (typo, disabled
-	// or deleted domain): branded 404 instead of the default-vhost drop.
-	// Content-hash gated agent-side — a per-tick no-op once in place;
-	// re-sent each tick so a cert issued later upgrades it to TLS.
-	if r.agent != nil {
-		st := r.previewStateCached(ctx)
-		fbParams := map[string]any{"base": models.PreviewWildcardBase(srv.Hostname)}
-		// The fallback must join the IP-specific listen pools (M24
-		// per-domain binds) or nginx never considers it for connections
-		// to the public IP — see the agent-side comment.
-		if srv.PublicIPv4 != "" {
-			fbParams["listen_ipv4"] = srv.PublicIPv4
+// findZoneForPreviewBase walks the base's parent chain until a local
+// dns_zones row matches ("preview.example.com" tries itself, then
+// "example.com", …). nil = no locally-hosted zone serves the base.
+func (r *Reconciler) findZoneForPreviewBase(ctx context.Context, base string) *models.DNSZone {
+	labels := strings.Split(strings.TrimSuffix(base, "."), ".")
+	for i := 0; i < len(labels)-1; i++ {
+		candidate := strings.Join(labels[i:], ".")
+		if z, err := r.dnsZones.FindByName(ctx, candidate); err == nil && z != nil {
+			return z
 		}
-		if srv.PublicIPv6 != "" {
-			fbParams["listen_ipv6"] = srv.PublicIPv6
-		}
-		if st.certPath != "" {
-			fbParams["ssl_cert_path"] = st.certPath
-			fbParams["ssl_key_path"] = st.keyPath
-		}
-		fbCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		if _, err := r.agent.Call(fbCtx, "preview.fallback_apply", fbParams); err != nil {
-			r.log.Warn("preview: fallback vhost apply failed", "err", err)
-		}
-		cancel()
 	}
+	return nil
 }
 
 // previewParams returns the agent payload additions for one domain, or
@@ -208,11 +239,11 @@ func (r *Reconciler) previewParams(ctx context.Context, domain *models.Domain) m
 		return nil
 	}
 	st := r.previewStateCached(ctx)
-	if st.hostname == "" {
+	if st.base == "" {
 		return nil
 	}
 	out := map[string]string{
-		"preview_host": models.PreviewHost(domain.Name, st.hostname),
+		"preview_host": models.PreviewHost(domain.Name, st.base),
 	}
 	if st.certPath != "" {
 		out["preview_cert_path"] = st.certPath

--- a/panel-api/internal/reconciler/preview_urls_test.go
+++ b/panel-api/internal/reconciler/preview_urls_test.go
@@ -204,23 +204,52 @@ func TestReconcilePreviewInfra_AppliesFallbackVhost(t *testing.T) {
 	}
 }
 
+// GH #836: a foreign base (magic DNS / externally-managed domain) skips
+// local DNS records and the DNS-01 cert row — both are impossible for a
+// zone pdns doesn't host — but the fallback vhost still applies with
+// that base, and previews serve via the external resolution.
+func TestReconcilePreviewInfra_ForeignBaseSkipsDNSAndCert(t *testing.T) {
+	certs := &fakePreviewCertRepo{}
+	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
+	recs := &fakePreviewRecordRepo{}
+	r := previewReconciler(certs, zones, recs)
+	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{
+		Hostname: "host.tld", PreviewBase: "203-0-113-7.sslip.io", PublicIPv4: "203.0.113.7",
+	}}
+	ag := &fakePreviewAgent{}
+	r.agent = ag
+
+	r.reconcilePreviewInfra(context.Background(), enabledPreviewDomains())
+
+	if len(certs.created) != 0 {
+		t.Errorf("foreign base must not create a DNS-01 cert row: %+v", certs.created)
+	}
+	if len(recs.created) != 0 {
+		t.Errorf("foreign base must not write local DNS records: %+v", recs.created)
+	}
+	if len(ag.calls) != 1 || ag.calls[0]["base"] != "203-0-113-7.sslip.io" {
+		t.Errorf("fallback vhost must still apply with the foreign base: %+v", ag.calls)
+	}
+}
+
 func TestPreviewStateCacheTTL(t *testing.T) {
 	certs := &fakePreviewCertRepo{}
 	zones := &fakePreviewZoneRepo{zone: &models.DNSZone{ID: "Z1", Name: "host.tld"}}
 	r := previewReconciler(certs, zones, &fakePreviewRecordRepo{})
 
 	st1 := r.previewStateCached(context.Background())
-	if st1.hostname != "host.tld" {
-		t.Fatalf("hostname = %q", st1.hostname)
+	if st1.base != "preview.host.tld" {
+		t.Fatalf("base = %q", st1.base)
 	}
 	// Mutate the underlying settings; within TTL the cache must hold.
 	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "other.tld"}}
-	if st2 := r.previewStateCached(context.Background()); st2.hostname != "host.tld" {
+	if st2 := r.previewStateCached(context.Background()); st2.base != "preview.host.tld" {
 		t.Error("cache must serve within TTL")
 	}
-	// Expire and re-read.
+	// Expire and re-read — and a preview_base override wins (GH #836).
+	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{Hostname: "other.tld", PreviewBase: "203-0-113-7.sslip.io"}}
 	r.previewAt = time.Now().Add(-2 * previewStateTTL)
-	if st3 := r.previewStateCached(context.Background()); st3.hostname != "other.tld" {
-		t.Error("expired cache must re-read settings")
+	if st3 := r.previewStateCached(context.Background()); st3.base != "203-0-113-7.sslip.io" {
+		t.Errorf("expired cache must re-read settings incl. preview_base, got %q", st3.base)
 	}
 }

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -82,6 +82,7 @@ import { LogRetentionCard } from "./LogRetentionCard";
 type ServerSettings = {
   id: number;
   hostname: string;
+  preview_base?: string;
   public_ipv4: string;
   public_ipv6: string;
   ns1_name: string;
@@ -159,6 +160,7 @@ const GeneralSettingsTab = () => {
     try {
       const resp = await apiClient.patch<ServerSettings>("/admin/settings", {
         hostname: values.hostname,
+        preview_base: values.preview_base || "",
         public_ipv4: values.public_ipv4,
         public_ipv6: values.public_ipv6 || "",
         admin_email: values.admin_email || "",
@@ -232,6 +234,30 @@ const GeneralSettingsTab = () => {
               extra="Fully-qualified name for this server (e.g. panel.example.com)."
             >
               <Input placeholder="panel.example.com" />
+            </Form.Item>
+            <Form.Item
+              label="Preview URL base"
+              name="preview_base"
+              rules={[
+                {
+                  pattern:
+                    /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+                  message: "Invalid hostname",
+                },
+              ]}
+              extra={
+                <>
+                  Domain previews serve at &lt;site&gt;.&lt;base&gt;. Empty ={" "}
+                  <code>preview.&lt;hostname&gt;</code>. If this server's
+                  hostname doesn't resolve publicly, set a custom domain you
+                  control (e.g. <code>preview.example.com</code>, wildcard
+                  pointed here) or a magic-DNS base like{" "}
+                  <code>203-0-113-7.sslip.io</code> (your IP with dashes —
+                  resolves without any DNS setup; previews serve over HTTP).
+                </>
+              }
+            >
+              <Input placeholder="preview.example.com (optional)" allowClear />
             </Form.Item>
           </Col>
           <Col xs={24} md={12}>


### PR DESCRIPTION
Implements GH #836 — all three of the reporter's suggested shapes with one setting:

**`server_settings.preview_base`** (Identity card, migration `000244`):
- **empty** → derived `preview.<hostname>` (current behavior, default)
- **custom domain** (`preview.example.com`) → if any locally-hosted zone contains it, the reconciler creates the wildcard A/AAAA records and the DNS-01 wildcard cert row *in that zone*; if the domain's DNS is managed externally, the admin points a wildcard at the box and previews just work
- **server-IP mode** via magic DNS: `203-0-113-7.sslip.io` (the IP with dashes) resolves to the box with **zero DNS configuration** — the practical version of "use the server IP", since raw IPs can't carry per-site subdomains

Foreign bases skip local DNS writes and the DNS-01 cert row (pdns can't answer a challenge for a zone it doesn't host) — previews then serve HTTP over the external resolution, and the catch-all branded-404 fallback still applies with the configured base. Operator input is normalized (case, implied `*.`, trailing dot) and validated as a bare hostname.

## Test plan
- [x] `EffectivePreviewBase` precedence + normalization tests
- [x] Reconciler: custom-base zone found by parent-chain suffix; foreign base skips DNS+cert but still applies the fallback vhost with that base; state-cache override test
- [x] Full `go test ./panel-api/...` green; `tsc -b` + `npm run build` + settings/domains vitest green
- [ ] Post-merge on testserver: set `preview_base` to a sslip.io base, confirm the preview link + fallback serve without any DNS records

🤖 Generated with [Claude Code](https://claude.com/claude-code)