### PR TITLE
feat(backups): bulk delete-all-jobs for a run (GH #502)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -109,6 +109,7 @@ func RegisterBackupRoutes(rg *gin.RouterGroup, cfg BackupHandlerConfig) {
 	admin.POST("/backups/restore", h.restore)
 	admin.GET("/backup-runs", h.listRuns)
 	admin.GET("/backup-runs/:run_id/jobs", h.listRunJobs)
+	admin.DELETE("/backup-runs/:run_id/jobs", h.deleteRunJobs)
 	admin.POST("/system/backups", h.systemCreate)
 	admin.GET("/system/backups", h.systemList)
 	admin.POST("/system/backups/:job_id/cancel", h.systemCancel)
@@ -572,11 +573,24 @@ func (h *backupHandler) delete(c *gin.Context) {
 }
 
 // forgetBackup asks the agent to forget+prune the run's snapshots from its
-// destination repo. Resolves the job's destination for repo URL + creds; a job
-// with no destination (or a since-deleted one) falls back to the default local
-// repo. Returns a non-nil error (response already written) on hard failure.
+// destination repo. Returns a non-nil error (response already written) on
+// hard failure. Thin response-writing wrapper around forgetBackupErr so the
+// bulk run-jobs delete (GH #502) can reuse the same forget logic per job
+// without fighting over the response writer.
 func (h *backupHandler) forgetBackup(c *gin.Context, job *models.BackupJob) error {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), backupCallTimeout)
+	if err := h.forgetBackupErr(c.Request.Context(), job); err != nil {
+		status, body := translateAgentError(err)
+		c.JSON(status, body)
+		return err
+	}
+	return nil
+}
+
+// forgetBackupErr resolves the job's destination for repo URL + creds (a job
+// with no destination, or a since-deleted one, falls back to the default
+// local repo) and asks the agent to forget+prune the job's snapshots.
+func (h *backupHandler) forgetBackupErr(reqCtx context.Context, job *models.BackupJob) error {
+	ctx, cancel := context.WithTimeout(reqCtx, backupCallTimeout)
 	defer cancel()
 	params := map[string]any{"job_id": job.ID, "user_id": job.UserID, "kind": job.Kind}
 	var dest *models.BackupDestination
@@ -595,18 +609,60 @@ func (h *backupHandler) forgetBackup(c *gin.Context, job *models.BackupJob) erro
 		_, err := h.cfg.Agent.Call(ctx, "backup.forget", params)
 		return err
 	}
-	var ferr error
 	if dest != nil {
-		ferr = backupwrapperhelpers.WithDestPasswordFile(ctx, dest, h.cfg.Agent, h.cfg.SSOKey, call)
-	} else {
-		ferr = call("")
+		return backupwrapperhelpers.WithDestPasswordFile(ctx, dest, h.cfg.Agent, h.cfg.SSOKey, call)
 	}
-	if ferr != nil {
-		status, body := translateAgentError(ferr)
-		c.JSON(status, body)
-		return ferr
+	return call("")
+}
+
+// deleteRunJobs removes EVERY deletable job of a backup run behind one
+// confirmation (GH #502): a Full Server run holds a job per account, and
+// deleting hundreds of jobs one dialog at a time is not an operation, it
+// is a punishment. Per-job semantics match the single delete exactly —
+// forget-then-delete, so a failed forget leaves that row for retry.
+// Running/pending jobs are skipped (cancel them first); the response
+// reports deleted / skipped_running / failed so partial outcomes are
+// visible instead of silently half-done.
+func (h *backupHandler) deleteRunJobs(c *gin.Context) {
+	runID := c.Param("run_id")
+	jobs, err := h.cfg.Jobs.ListByRun(c.Request.Context(), runID)
+	if err != nil {
+		h.cfg.logErr("bulk delete: list run jobs", err, "run_id", runID)
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_list"})
+		return
 	}
-	return nil
+	if len(jobs) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
+		return
+	}
+	deleted, skippedRunning, failed := 0, 0, 0
+	for i := range jobs {
+		job := &jobs[i]
+		switch job.Status {
+		case models.BackupJobStatusRunning, models.BackupJobStatusQueued:
+			skippedRunning++
+			continue
+		}
+		if h.cfg.Agent != nil {
+			if ferr := h.forgetBackupErr(c.Request.Context(), job); ferr != nil {
+				h.cfg.logErr("bulk delete: forget failed", ferr, "job_id", job.ID)
+				failed++
+				continue
+			}
+		}
+		if derr := h.cfg.Jobs.Delete(c.Request.Context(), job.ID); derr != nil {
+			h.cfg.logErr("bulk delete: db delete failed", derr, "job_id", job.ID)
+			failed++
+			continue
+		}
+		deleted++
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":          "ok",
+		"deleted":         deleted,
+		"skipped_running": skippedRunning,
+		"failed":          failed,
+	})
 }
 
 func (h *backupHandler) get(c *gin.Context) {

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2150,6 +2150,15 @@ paths:
       responses: { "200": { description: OK } }
 
   /admin/backup-runs/{run_id}/jobs:
+    delete:
+      tags: [Backups]
+      summary: Delete every deletable job of a backup run (bulk cleanup, GH #502)
+      description: >
+        Forget-then-delete per job, same semantics as the single delete;
+        running/queued jobs are skipped. Response reports
+        deleted / skipped_running / failed.
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
     get:
       tags: [Backup Runs]
       summary: Jobs backup runs

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -318,6 +318,29 @@ export const AdminBackupsPage = () => {
     }
   };
 
+  // GH #502: delete EVERY deletable job of a run behind one confirmation —
+  // a Full Server run holds a job per account, and clearing hundreds of
+  // jobs one dialog at a time made cleanup impractical. Running/queued
+  // jobs are skipped server-side (cancel them first).
+  const handleDeleteRun = async (runID: string) => {
+    try {
+      const resp = await apiClient.delete<{ deleted: number; skipped_running: number; failed: number }>(
+        `/admin/backup-runs/${runID}/jobs`,
+      );
+      const { deleted, skipped_running, failed } = resp.data;
+      if (failed > 0 || skipped_running > 0) {
+        message.warning(
+          `Deleted ${deleted} job(s); ${skipped_running} running/queued skipped, ${failed} failed`,
+        );
+      } else {
+        message.success(`Deleted ${deleted} backup job(s)`);
+      }
+      void reload();
+    } catch (err) {
+      message.error(extractApiError(err, "Bulk delete failed"));
+    }
+  };
+
   const tableRows: TableRow[] = [
     ...runs.map<RunRow>((r) => ({ rowKey: `run:${r.run_id}`, isRun: true, run: r })),
     ...manual.map<ManualRow>((j) => ({ rowKey: `job:${j.id}`, isRun: false, job: j })),
@@ -603,9 +626,28 @@ export const AdminBackupsPage = () => {
                 title: "Actions",
                 render: (_: unknown, row: TableRow) =>
                   row.isRun ? (
-                    <Typography.Link style={{ fontSize: 12 }} onClick={() => toggleRowExpand(row)}>
-                      {expandedKeys.includes(row.rowKey) ? "Collapse" : "Expand to manage"}
-                    </Typography.Link>
+                    <Space>
+                      <Typography.Link style={{ fontSize: 12 }} onClick={() => toggleRowExpand(row)}>
+                        {expandedKeys.includes(row.rowKey) ? "Collapse" : "Expand to manage"}
+                      </Typography.Link>
+                      <RowActions
+                        actions={[
+                          {
+                            key: "delete-all",
+                            label: "Delete all jobs",
+                            icon: <DeleteOutlined />,
+                            danger: true,
+                            onClick: () => handleDeleteRun(row.run.run_id),
+                            confirm: {
+                              title: `Delete all ${row.run.total} job(s) of this run?`,
+                              description:
+                                "Permanently removes every finished job's snapshots from the repository. Running or queued jobs are skipped. Cannot be undone.",
+                              okText: "Delete all",
+                            },
+                          },
+                        ]}
+                      />
+                    </Space>
                   ) : (
                     <RowActions
                       actions={[


### PR DESCRIPTION
Implements the bulk-cleanup part of GH #502 (the reporter's latest comment): **`DELETE /admin/backup-runs/:run_id/jobs`** removes every deletable job of a run behind **one** confirmation — a Full Server run holds a job per account, and deleting hundreds of jobs one dialog at a time "is not an operation, it is a punishment".

- Per-job semantics identical to the single delete: forget-then-prune the restic snapshots, then drop the row — a failed forget leaves that job for retry (GH #294 posture preserved).
- Running/queued jobs are skipped server-side (cancel first); the response reports `deleted / skipped_running / failed`, and the UI surfaces partial outcomes as a warning toast instead of a false success.
- `forgetBackup` split into a response-free core + the existing response-writing wrapper so bulk and single share one forget path.
- UI: run rows gain a danger-confirmed **Delete all jobs** action beside "Expand to manage"; the per-job Delete stays for surgical cases.

The issue's remaining asks (Full Server backup option, split schedules) are design-sized and stay open on the issue.

## Test plan
- [x] `go test ./panel-api/internal/api/` green; OpenAPI coverage documented + green
- [x] `tsc -b` + `npm run build` + backups vitest green
- [ ] Post-merge on testserver: create a multi-job run, Delete all jobs → one dialog, jobs gone, counts reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)