### PR TITLE
feat(cache): outcome-based health checks — block-cause, HIT ratio, spool probe (JAB-201)

### DIFF
--- a/panel-agent/internal/commands/wordpress_cache_health.go
+++ b/panel-agent/internal/commands/wordpress_cache_health.go
@@ -108,6 +108,7 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 	_ = json.Unmarshal([]byte(strings.TrimSpace(pl)), &plugins)
 	ttfbMs := 0
 	hitVerified := false
+	hitBlockCause, hitBlockEvidence := "", ""
 	risky := []string{}
 	host := strings.ToLower(strings.TrimSpace(p.Host))
 	if host != "" && probeDomainRe.MatchString(host) {
@@ -134,6 +135,12 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 			"--resolve", host+":443:127.0.0.1", "https://"+host+"/").Output()
 		cancel()
 		hitVerified = strings.Contains(strings.ToUpper(string(hdr)), "X-JABALI-CACHE: HIT")
+		// JAB-201: when the double-fetch does not verify, name the
+		// blocker from the same response's headers instead of leaving
+		// the advisor to guess "cookie/plugin or not warmed".
+		if !hitVerified {
+			hitBlockCause, hitBlockEvidence = classifyCacheBlock(string(hdr))
+		}
 		// Risky endpoints that must never be cached (WooCommerce/EDD/membership).
 		for _, ep := range []string{"/cart", "/checkout", "/my-account"} {
 			if code := curlLocal(ep, "%{http_code}"); code == "200" || code == "302" {
@@ -141,9 +148,20 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 			}
 		}
 	}
+	// JAB-201: cache OUTCOMES, not just config presence — the jcache
+	// log ratio and the purge-spool/jail assertions.
+	logHits, logMisses, logBypass, logOther, logOK := 0, 0, 0, 0, false
+	if host != "" && probeDomainRe.MatchString(host) {
+		logHits, logMisses, logBypass, logOther, logOK = tallyJcacheLogFile(host)
+	}
+	spoolOK, spoolDetail := probeSpool(p.OSUser)
 	return map[string]any{
 		"active_plugins": plugins, "wp_version": strings.TrimSpace(ver),
 		"ttfb_ms": ttfbMs, "page_hit_verified": hitVerified, "risky_endpoints": risky,
+		"hit_block_cause": hitBlockCause, "hit_block_evidence": hitBlockEvidence,
+		"log_ok": logOK, "log_hits": logHits, "log_misses": logMisses,
+		"log_bypass": logBypass, "log_other": logOther,
+		"spool_ok": spoolOK, "spool_detail": spoolDetail,
 	}, nil
 }
 

--- a/panel-agent/internal/commands/wordpress_cache_probe_jab201.go
+++ b/panel-agent/internal/commands/wordpress_cache_probe_jab201.go
@@ -1,0 +1,139 @@
+package commands
+
+// JAB-201 — cache health/advisor blind spots. Three additions to the
+// probe data so "green while ineffective" can't happen silently:
+//
+//  1. When the MISS→HIT double-fetch does NOT verify, classify WHY from
+//     the response headers instead of leaving the advisor guessing —
+//     the production case was a maintenance-mode plugin calling WP's
+//     nocache_headers() (Expires: 1984 signature) on every response,
+//     which the fail-closed gate (GH #637) correctly refuses to store.
+//  2. Tally the domain's jcache log ($upstream_cache_status, one token
+//     per line) so a cache_enabled site with 0% HIT over the log window
+//     is a visible red flag, not a silent no-op.
+//  3. Assert the purge-spool path from the tenant's perspective: the
+//     pool's open_basedir must include /run/jabali-wp-purge (the
+//     JAB-199 regression) and the spool dir must exist world-writable.
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// classifyCacheBlock inspects the raw response headers of the SECOND
+// (should-be-HIT) probe fetch and names the strongest reason the page
+// cache refused to store. Empty string = no known blocker found.
+func classifyCacheBlock(rawHeaders string) (cause, evidence string) {
+	for _, line := range strings.Split(rawHeaders, "\n") {
+		line = strings.TrimRight(line, "\r")
+		l := strings.ToLower(line)
+		switch {
+		case strings.HasPrefix(l, "expires:") && strings.Contains(l, "1984"):
+			// WP nocache_headers() emits "Expires: Wed, 11 Jan 1984 …" —
+			// the signature of maintenance/coming-soon plugins and
+			// wp_die pages. The strongest signal; return immediately.
+			return "wp_nocache_headers", strings.TrimSpace(line)
+		case strings.HasPrefix(l, "cache-control:") &&
+			(strings.Contains(l, "no-cache") || strings.Contains(l, "no-store") || strings.Contains(l, "private")):
+			if cause == "" {
+				cause, evidence = "upstream_cache_control", strings.TrimSpace(line)
+			}
+		case strings.HasPrefix(l, "vary:") && strings.TrimSpace(l) != "vary: accept-encoding":
+			if cause == "" {
+				cause, evidence = "vary_header", strings.TrimSpace(line)
+			}
+		case strings.HasPrefix(l, "set-cookie:"):
+			if cause == "" {
+				cause, evidence = "response_sets_cookie", strings.TrimSpace(line)
+			}
+		}
+	}
+	return cause, evidence
+}
+
+// tallyJcacheLog counts $upstream_cache_status tokens (log_format
+// jcache emits exactly one per request line).
+func tallyJcacheLog(r io.Reader) (hits, misses, bypass, other int) {
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		switch strings.TrimSpace(sc.Text()) {
+		case "HIT":
+			hits++
+		case "MISS":
+			misses++
+		case "BYPASS":
+			bypass++
+		case "", "-":
+			// non-cache location or unset — not a cache decision
+		default:
+			other++ // EXPIRED, STALE, UPDATING, REVALIDATED
+		}
+	}
+	return
+}
+
+// jcacheLogTailBytes bounds how much of the log one probe reads. The
+// file rotates daily; half a megabyte of one-token lines is thousands
+// of requests — plenty for a ratio.
+const jcacheLogTailBytes = 512 * 1024
+
+// tallyJcacheLogFile reads the bounded tail of the domain's jcache log.
+// ok=false when the log doesn't exist (cache never enabled / no traffic
+// yet) — callers must not read zeros as "0% HIT".
+func tallyJcacheLogFile(host string) (hits, misses, bypass, other int, ok bool) {
+	f, err := os.Open("/var/log/nginx/jcache-" + host + ".log")
+	if err != nil {
+		return 0, 0, 0, 0, false
+	}
+	defer f.Close()
+	if st, serr := f.Stat(); serr == nil && st.Size() > jcacheLogTailBytes {
+		if _, serr := f.Seek(st.Size()-jcacheLogTailBytes, io.SeekStart); serr == nil {
+			// Drop the (likely partial) first line after the seek.
+			br := bufio.NewReader(f)
+			_, _ = br.ReadString('\n')
+			hits, misses, bypass, other = tallyJcacheLog(br)
+			return hits, misses, bypass, other, true
+		}
+	}
+	hits, misses, bypass, other = tallyJcacheLog(f)
+	return hits, misses, bypass, other, true
+}
+
+// probeSpool checks the WP→nginx purge path from the tenant's
+// perspective: the spool dir must exist and be world-writable (tmpfiles
+// creates it 1777), and the user's FPM pool open_basedir must include
+// it — the exact line whose absence made every content-edit purge a
+// silent no-op fleet-wide (JAB-199).
+func probeSpool(osUser string) (ok bool, detail string) {
+	const spool = "/run/jabali-wp-purge"
+	st, err := os.Stat(spool)
+	if err != nil {
+		return false, "purge spool " + spool + " missing — WP content-edit purges are no-ops (re-run install.sh)"
+	}
+	if st.Mode().Perm()&0o002 == 0 {
+		return false, "purge spool " + spool + " not world-writable — tenant PHP cannot drop purge requests"
+	}
+	matches, _ := filepath.Glob("/etc/php/*/fpm/pool.d/jabali-" + osUser + ".conf")
+	if len(matches) == 0 {
+		// No pool conf (static site, custom pool name) — nothing to assert.
+		return true, ""
+	}
+	for _, conf := range matches {
+		b, rerr := os.ReadFile(conf)
+		if rerr != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "php_admin_value[open_basedir]") {
+				if !strings.Contains(line, spool) {
+					return false, "pool open_basedir in " + filepath.Base(conf) + " lacks " + spool +
+						" — the JAB-199 regression: WP purges of the page cache silently fail (run jabali update to reapply pools)"
+				}
+			}
+		}
+	}
+	return true, ""
+}

--- a/panel-agent/internal/commands/wordpress_cache_probe_jab201_test.go
+++ b/panel-agent/internal/commands/wordpress_cache_probe_jab201_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// JAB-201: the production blind spot — a maintenance plugin calling WP's
+// nocache_headers() on every response. Its Expires: 1984 signature must
+// win over the accompanying Cache-Control, because it names the CAUSE
+// (a plugin) rather than the mechanism.
+func TestClassifyCacheBlock_MaintenanceSignatureWins(t *testing.T) {
+	hdr := strings.Join([]string{
+		"HTTP/2 503",
+		"Cache-Control: no-cache, must-revalidate, max-age=0",
+		"Expires: Wed, 11 Jan 1984 05:00:00 GMT",
+		"X-Jabali-Cache: BYPASS",
+	}, "\r\n")
+	cause, evidence := classifyCacheBlock(hdr)
+	if cause != "wp_nocache_headers" {
+		t.Fatalf("cause = %q, want wp_nocache_headers", cause)
+	}
+	if !strings.Contains(evidence, "1984") {
+		t.Errorf("evidence should carry the header line, got %q", evidence)
+	}
+}
+
+func TestClassifyCacheBlock_Table(t *testing.T) {
+	cases := []struct {
+		name, hdr, want string
+	}{
+		{"cache-control private", "Cache-Control: private, max-age=0", "upstream_cache_control"},
+		{"no-store", "cache-control: no-store", "upstream_cache_control"},
+		{"vary cookie", "Vary: Cookie", "vary_header"},
+		{"vary accept-encoding is benign", "Vary: Accept-Encoding", ""},
+		{"set-cookie", "Set-Cookie: PHPSESSID=abc; path=/", "response_sets_cookie"},
+		{"clean response", "Cache-Control: max-age=600\r\nX-Jabali-Cache: MISS", ""},
+	}
+	for _, tc := range cases {
+		if got, _ := classifyCacheBlock(tc.hdr); got != tc.want {
+			t.Errorf("%s: cause = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestTallyJcacheLog(t *testing.T) {
+	log := "HIT\nMISS\nHIT\nBYPASS\n-\n\nEXPIRED\nMISS\n"
+	hits, misses, bypass, other := tallyJcacheLog(strings.NewReader(log))
+	if hits != 2 || misses != 2 || bypass != 1 || other != 1 {
+		t.Errorf("got hits=%d misses=%d bypass=%d other=%d", hits, misses, bypass, other)
+	}
+}
+
+func TestTallyJcacheLogFile_MissingIsNotZeroPercent(t *testing.T) {
+	// A missing log means "no data", never "0% HIT" — the advisor must
+	// not warn a fresh site into a panic.
+	_, _, _, _, ok := tallyJcacheLogFile("no-such-host.example")
+	if ok {
+		t.Fatal("missing log must report ok=false")
+	}
+}

--- a/panel-api/internal/api/applications_cache_settings.go
+++ b/panel-api/internal/api/applications_cache_settings.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -510,6 +511,15 @@ func (h *wordPressHandler) cacheAdvise(c *gin.Context) {
 		TTFBMs          int      `json:"ttfb_ms"`
 		PageHitVerified bool     `json:"page_hit_verified"`
 		RiskyEndpoints  []string `json:"risky_endpoints"`
+		// JAB-201 outcome telemetry.
+		HitBlockCause    string `json:"hit_block_cause"`
+		HitBlockEvidence string `json:"hit_block_evidence"`
+		LogOK            bool   `json:"log_ok"`
+		LogHits          int    `json:"log_hits"`
+		LogMisses        int    `json:"log_misses"`
+		LogBypass        int    `json:"log_bypass"`
+		SpoolOK          bool   `json:"spool_ok"`
+		SpoolDetail      string `json:"spool_detail"`
 	}
 	_ = json.Unmarshal(res, &probe)
 	profile, note := recommendCacheProfile(probe.ActivePlugins)
@@ -518,7 +528,37 @@ func (h *wordPressHandler) cacheAdvise(c *gin.Context) {
 		note += " Detected dynamic endpoints (" + strings.Join(probe.RiskyEndpoints, ", ") + ") — these must stay bypassed; the chosen profile already excludes them."
 	}
 	if inst.CacheEnabled && !probe.PageHitVerified {
-		note += " Warning: the homepage did not return a page-cache HIT on a repeat request — caching may be bypassed (a cookie/plugin) or not yet warmed."
+		// JAB-201: name the blocker when the probe identified one — the
+		// production case was a maintenance plugin's nocache_headers()
+		// making every check read green while nothing was ever cached.
+		switch probe.HitBlockCause {
+		case "wp_nocache_headers":
+			note += " Warning: the site opts out of caching on every response (" + probe.HitBlockEvidence +
+				" — WordPress nocache_headers(), typically a maintenance/coming-soon plugin). The page cache stores nothing until it is deactivated."
+		case "upstream_cache_control":
+			note += " Warning: the site sends " + probe.HitBlockEvidence +
+				" — the fail-closed gate refuses to store such responses; find the plugin emitting it."
+		case "vary_header":
+			note += " Warning: the site sends " + probe.HitBlockEvidence +
+				" — responses varying on more than Accept-Encoding are never stored."
+		case "response_sets_cookie":
+			note += " Warning: the homepage sets a cookie (" + probe.HitBlockEvidence +
+				") — cookie-carrying responses bypass the cache; check session/consent plugins."
+		default:
+			note += " Warning: the homepage did not return a page-cache HIT on a repeat request — caching may be bypassed (a cookie/plugin) or not yet warmed."
+		}
+	}
+	// JAB-201: outcome ratio from the live jcache log. Zero HITs across a
+	// meaningful sample is the "enabled but ineffective" signature.
+	if inst.CacheEnabled && probe.LogOK {
+		sample := probe.LogHits + probe.LogMisses + probe.LogBypass
+		if sample >= 50 && probe.LogHits == 0 {
+			note += fmt.Sprintf(" Warning: 0%% page-cache HIT over the last %d logged requests (%d MISS / %d BYPASS) — the cache is enabled but not serving.",
+				sample, probe.LogMisses, probe.LogBypass)
+		}
+	}
+	if inst.CacheEnabled && !probe.SpoolOK && probe.SpoolDetail != "" {
+		note += " Warning: " + probe.SpoolDetail + "."
 	}
 	// Redis eviction pressure (admin-privileged INFO).
 	evicted := 0


### PR DESCRIPTION
Implements JAB-201. The cache health surface verified *config presence* (plugin active, drop-in, constants, Redis reachable) but never *outcomes* — so a production site sat green while a maintenance plugin's `nocache_headers()` made the fail-closed gate (GH #637, correctly) store nothing, ever.

Three additions to `wordpress.cache_probe`, all surfaced as targeted Advisor notes (no UI change needed — notes flow through the existing advise response):

1. **Block-cause classification.** When the MISS→HIT double-fetch fails, the same response's headers now name the blocker: the `Expires: …1984…` signature of WP's `nocache_headers()` (maintenance/coming-soon plugins — the production case) wins over the mechanical `Cache-Control` line because it names the *cause*; also upstream `no-cache`/`no-store`/`private`, non-`Accept-Encoding` `Vary`, and cookie-setting responses. The generic "maybe not warmed" text remains only when nothing matches.
2. **jcache-log outcome ratio.** Bounded 512 KB tail of the per-domain `$upstream_cache_status` log; ≥50 logged requests with **0 HITs** warns "enabled but not serving" with the MISS/BYPASS split. A missing log reports no-data — a fresh site is never panicked with a fake 0%.
3. **Purge-spool probe.** `/run/jabali-wp-purge` must exist world-writable and the user's pool `open_basedir` must include it — the exact JAB-199 regression, now caught by the health surface instead of by production.

## Test plan
- [x] Classifier table tests incl. the 1984-signature-wins-over-Cache-Control case and benign `Vary: Accept-Encoding`
- [x] Log tally + missing-log-is-not-0% tests
- [x] Full `go test ./panel-api/... ./panel-agent/...` green
- [ ] Post-merge on testserver: advise on the cache-enabled WP install → notes include the log ratio; break the spool line in a pool conf → probe names JAB-199

🤖 Generated with [Claude Code](https://claude.com/claude-code)