### PR TITLE
fix(update): build Go binaries serially on low-RAM hosts

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1285,27 +1285,41 @@ test -x node_modules/.bin/tsc || {
 				" -X git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api.BuildTime=" + buildTime
 			ldflagsAgent := "-s -w -X main.version=" + shortSHA
 
+			// Low-RAM hosts build one binary at a time: three concurrent Go
+			// builds at GOMEMLIMIT=900MiB each overshoot a 2 GB box and the
+			// update dies mid-build (see serializeGoBuildsForMB).
+			serialBuilds := serializeGoBuilds()
 			var wg sync.WaitGroup
-			var apiErr, agentErr error
-			if !apiSkip {
+			spawn := func(fn func()) {
+				if serialBuilds {
+					fn()
+					return
+				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
+					fn()
+				}()
+			}
+			if serialBuilds {
+				fmt.Println("  (low RAM: building binaries one at a time)")
+			}
+			var apiErr, agentErr error
+			if !apiSkip {
+				spawn(func() {
 					apiArgs := []string{"build", "-trimpath"}
 					if demoBuild {
 						apiArgs = append(apiArgs, "-tags", "demo")
 					}
 					apiArgs = append(apiArgs, "-ldflags", ldflagsAPI, "-o", repoDir+"/bin/jabali-panel.new", "./panel-api/cmd/server")
 					apiErr = asUser(repoDir, goBin, apiArgs...)
-				}()
+				})
 			}
 			if !agentSkip {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				spawn(func() {
 					agentErr = asUser(repoDir, goBin, "build", "-trimpath", "-ldflags", ldflagsAgent,
 						"-o", repoDir+"/bin/jabali-agent.new", "./panel-agent/cmd/jabali-agent")
-				}()
+				})
 			}
 			// jabali-ssh-shell is a tiny binary built from the same
 			// panel-agent module; always rebuild it when buildSteps runs
@@ -1316,12 +1330,10 @@ test -x node_modules/.bin/tsc || {
 			// favour of this binary (filtered passwd + -c forwarding).
 			var sshShellErr error
 			if !agentSkip {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				spawn(func() {
 					sshShellErr = asUser(repoDir, goBin, "build", "-trimpath", "-ldflags", ldflagsAgent,
 						"-o", repoDir+"/bin/jabali-ssh-shell.new", "./panel-agent/cmd/jabali-ssh-shell")
-				}()
+				})
 			}
 			// jabali-mailhook: the loopback MTA-hook service (disclaimers, GH #233).
 			// Same panel-agent module; rebuild alongside the agent/ssh-shell.

--- a/panel-api/cmd/server/update_lowmem.go
+++ b/panel-api/cmd/server/update_lowmem.go
@@ -74,3 +74,29 @@ func shortSHA7(s string) string {
 	}
 	return s
 }
+
+// serializeGoBuildsForMB reports whether the updater must build its Go binaries
+// one at a time instead of concurrently.
+//
+// The updater builds THREE binaries in parallel — panel-api, panel-agent and
+// jabali-ssh-shell. lowRAMGoBuildEnvForMB caps each one at GOMEMLIMIT=900MiB on
+// a small box, but that is a per-process ceiling: three of them at once is a
+// 2700MiB ceiling on a host with 1973MB of RAM, and GOFLAGS=-p=1 does not help
+// because it limits parallelism WITHIN a build, not across builds.
+//
+// Observed on a 2 GB / 2-core box, where `jabali update` died with
+//
+//	go build ... ./panel-api/cmd/server: exit status 1
+//
+// and the identical build run on its own immediately afterwards succeeded.
+// Serial builds cost wall-clock (~30s → ~60s) and buy an update that finishes,
+// which is the better trade on exactly the hosts that cannot afford to fail.
+//
+// Uses the same 2560MB threshold as the tight GOMEMLIMIT tier: if a host needs
+// the aggressive per-process cap, it cannot afford three of them at once.
+func serializeGoBuildsForMB(memMB int) bool {
+	return memMB > 0 && memMB <= 2560
+}
+
+// serializeGoBuilds is the /proc-backed wrapper used by the updater.
+func serializeGoBuilds() bool { return serializeGoBuildsForMB(hostMemMB()) }

--- a/panel-api/cmd/server/update_lowmem_test.go
+++ b/panel-api/cmd/server/update_lowmem_test.go
@@ -57,3 +57,45 @@ func TestLowRAMGoBuildEnvForMB(t *testing.T) {
 		}
 	}
 }
+
+// The updater builds three Go binaries. lowRAMGoBuildEnvForMB caps each at
+// GOMEMLIMIT=900MiB, which is a PER-PROCESS ceiling — three at once is 2700MiB
+// on a host with under 2 GB. Observed killing `jabali update` on a 2 GB box
+// where the same build, run alone straight afterwards, succeeded.
+func TestSerializeGoBuildsForMB(t *testing.T) {
+	cases := []struct {
+		memMB int
+		want  bool
+		why   string
+	}{
+		{0, false, "unknown memory must not change behaviour"},
+		{1973, true, "the box that actually failed"},
+		{2048, true, "a 2 GB VPS cannot host three 900MiB builds"},
+		{2560, true, "same threshold as the tight GOMEMLIMIT tier"},
+		{2561, false, "above the tight tier, parallel is affordable"},
+		{8192, false, "a large host keeps the faster parallel build"},
+	}
+	for _, c := range cases {
+		if got := serializeGoBuildsForMB(c.memMB); got != c.want {
+			t.Errorf("serializeGoBuildsForMB(%d) = %v, want %v — %s", c.memMB, got, c.want, c.why)
+		}
+	}
+}
+
+// The serialization threshold must line up with the memory tuning: any host
+// getting the aggressive 900MiB per-process cap cannot afford three at once.
+func TestSerializeMatchesTightMemLimitTier(t *testing.T) {
+	for _, mb := range []int{512, 1024, 1973, 2048, 2560} {
+		env := lowRAMGoBuildEnvForMB(mb)
+		tight := false
+		for _, e := range env {
+			if e == "GOMEMLIMIT=900MiB" {
+				tight = true
+			}
+		}
+		if tight && !serializeGoBuildsForMB(mb) {
+			t.Errorf("%dMB gets the 900MiB cap but still builds in parallel — "+
+				"that is the combination that overshot the box", mb)
+		}
+	}
+}


### PR DESCRIPTION
`jabali update` died mid-build on a 2 GB / 2-core box (`192.168.100.165`):

```
✗ Update FAILED at "build panel-api + panel-agent (parallel)".
  go build ... ./panel-api/cmd/server: exit status 1
```

The identical build, run on its own immediately afterwards, **succeeded with zero errors**. The code was fine; the host was not.

## Root cause

The updater builds **three** binaries concurrently — `panel-api`, `panel-agent`, `jabali-ssh-shell`.

`lowRAMGoBuildEnvForMB` already caps a small host at `GOMEMLIMIT=900MiB`, but that is a **per-process** ceiling. Three at once is a 2700MiB ceiling on a machine with 1973MB of RAM, before the OS and the running panel get a byte. `GOFLAGS=-p=1` does not help — it limits parallelism *within* a build, not *across* builds.

So the low-RAM tuning was working exactly as designed and still overshot, because nothing accounted for the builds multiplying it.

## Change

Hosts at or below the 2560MB tier build one binary at a time. The threshold is deliberately the same one that selects the aggressive per-process cap: a host that needs 900MiB limits cannot afford three of them simultaneously. Larger hosts keep the parallel path unchanged.

Costs wall-clock (~30s → ~60s) and buys an update that finishes — the right trade on precisely the hosts that cannot afford to fail. The updater prints `(low RAM: building binaries one at a time)` so the slower run is explained rather than mysterious.

## Test plan

- [x] Threshold table incl. the exact failing box (1973MB → serial), boundaries 2560/2561, and 0 (unknown memory → unchanged behaviour)
- [x] Invariant test: any host receiving `GOMEMLIMIT=900MiB` must also serialize — the combination that overshot cannot recur
- [x] `go build ./...`, `go vet ./...`, `cmd/server` suite clean
- [x] Rebased onto `origin/main`
- [ ] Not yet re-run end-to-end on the 2 GB box — that is the natural next verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)