### PR TITLE
fix(skeleton): lay account skeleton only on docroot creation; stage-coded diagnostic errors (GH #465)

### DIFF
--- a/agentwire/wire.go
+++ b/agentwire/wire.go
@@ -60,16 +60,22 @@ func (e *AgentError) Error() string {
 
 // Well-known error codes. Additive growth is OK; renames are not.
 const (
-	CodeInvalidArgument    = "invalid_argument"
-	CodeNotFound           = "not_found"
-	CodeAlreadyExists      = "already_exists"
-	CodePermissionDenied   = "permission_denied"
-	CodeUnavailable        = "unavailable"
-	CodeDeadlineExceeded   = "deadline_exceeded"
-	CodeInternal           = "internal"
-	CodeUnknownCommand     = "unknown_command"
-	CodeMalformedEnvelope  = "malformed_envelope"
-	CodeFailedPrecondition = "failed_precondition"
+	CodeInvalidArgument  = "invalid_argument"
+	CodeNotFound         = "not_found"
+	CodeAlreadyExists    = "already_exists"
+	CodePermissionDenied = "permission_denied"
+	CodeUnavailable      = "unavailable"
+	// CodeUpstreamUnavailable: the agent itself is fine but an external
+	// upstream it must reach (e.g. the enclosed note service) is not.
+	// Distinct from CodeUnavailable, which the panel's client also uses for
+	// "can't dial the local agent socket" — conflating the two would make an
+	// egress problem look like a dead agent.
+	CodeUpstreamUnavailable = "upstream_unavailable"
+	CodeDeadlineExceeded    = "deadline_exceeded"
+	CodeInternal            = "internal"
+	CodeUnknownCommand      = "unknown_command"
+	CodeMalformedEnvelope   = "malformed_envelope"
+	CodeFailedPrecondition  = "failed_precondition"
 )
 
 // ErrMalformedResponse is raised by the client when response bytes don't

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -1125,7 +1125,8 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	if scErr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "scope init: " + scErr.Error()}
 	}
-	if _, err := docScope.MkdirInScope(p.DocRoot, true, 0o755); err != nil {
+	docrootCreated, err := docScope.MkdirInScope(p.DocRoot, true, 0o755)
+	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: fmt.Sprintf("mkdir failed: %v", err),
@@ -1178,10 +1179,8 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// BEFORE the default index, so a skeleton-provided index.html wins (the
 	// default-index block below skips when index.html already exists). Never
 	// clobbers an existing path; a bad file warns but doesn't fail create.
-	if len(p.Skeleton) > 0 {
-		for _, w := range writeSkeleton(docScope, p.DocRoot, p.Username, docUID, wwwGID, p.Skeleton) {
-			log.Printf("domain.create: skeleton %s: %s", p.Domain, w)
-		}
+	for _, w := range layAccountSkeleton(docScope, docrootCreated, p.DocRoot, p.Username, docUID, wwwGID, p.Skeleton) {
+		log.Printf("domain.create: skeleton %s: %s", p.Domain, w)
 	}
 
 	indexPath := filepath.Join(p.DocRoot, "index.html")
@@ -1238,6 +1237,19 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 type skeletonFileParam struct {
 	RelPath string `json:"rel_path"`
 	Content []byte `json:"content"`
+}
+
+// layAccountSkeleton writes the skeleton tree only when THIS call actually
+// created the docroot. domain.create is re-run by the reconciler every tick;
+// an unconditional write resurrected every skeleton file the user had deleted
+// (the #465 reopen — "I press delete ... when refreshing the file reappears").
+// O_EXCL in writeSkeleton protects edited files but not deleted ones;
+// docrootCreated is the "this is a new account/domain" signal.
+func layAccountSkeleton(scope *filesafe.Scope, docrootCreated bool, docRoot, username string, docUID, wwwGID int, files []skeletonFileParam) []string {
+	if !docrootCreated || len(files) == 0 {
+		return nil
+	}
+	return writeSkeleton(scope, docRoot, username, docUID, wwwGID, files)
 }
 
 // writeSkeleton lays each skeleton file into the fresh docroot through the

--- a/panel-agent/internal/commands/domain_create_skeleton_test.go
+++ b/panel-agent/internal/commands/domain_create_skeleton_test.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+)
+
+// GH #465 reopen: domain.create re-runs every reconcile tick, and the skeleton
+// used to be re-laid unconditionally — a user-deleted skeleton file reappeared
+// ~30s later. The skeleton must be written only by the call that created the
+// docroot.
+func TestLayAccountSkeleton_OnlyOnFreshDocroot(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	docRoot := filepath.Join(home, "domains", "example.com", "public_html")
+	scope := filesafe.NewScopeForTest("u", "alice", home)
+	if _, err := scope.MkdirInScope(docRoot, true, 0o755); err != nil {
+		t.Fatalf("mkdir docroot: %v", err)
+	}
+	uid, gid := os.Getuid(), os.Getgid()
+	files := []skeletonFileParam{
+		{RelPath: "welcome.html", Content: []byte("<h1>hi</h1>")},
+		{RelPath: "assets/site.css", Content: []byte("body{}")},
+	}
+
+	// Create tick: docroot was just created — skeleton lands.
+	if warns := layAccountSkeleton(scope, true, docRoot, "alice", uid, gid, files); len(warns) != 0 {
+		t.Fatalf("unexpected warnings on fresh docroot: %v", warns)
+	}
+	got, err := os.ReadFile(filepath.Join(docRoot, "welcome.html"))
+	if err != nil {
+		t.Fatalf("skeleton file not written: %v", err)
+	}
+	if string(got) != "<h1>hi</h1>" {
+		t.Errorf("skeleton content = %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(docRoot, "assets", "site.css")); err != nil {
+		t.Errorf("nested skeleton file not written: %v", err)
+	}
+
+	// User deletes a skeleton file, then the reconciler re-runs domain.create
+	// (docroot already exists) — the file must STAY deleted.
+	if err := os.Remove(filepath.Join(docRoot, "welcome.html")); err != nil {
+		t.Fatal(err)
+	}
+	if warns := layAccountSkeleton(scope, false, docRoot, "alice", uid, gid, files); warns != nil {
+		t.Fatalf("reconcile pass wrote skeleton: %v", warns)
+	}
+	if _, err := os.Stat(filepath.Join(docRoot, "welcome.html")); !os.IsNotExist(err) {
+		t.Error("deleted skeleton file was resurrected by a reconcile pass")
+	}
+}
+
+// A fresh-create pass must never clobber a file that already exists at a
+// skeleton path — writeSkeleton silently skips it (Lstat pre-check, O_EXCL
+// backstop).
+func TestLayAccountSkeleton_NeverClobbersExisting(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	docRoot := filepath.Join(home, "public_html")
+	scope := filesafe.NewScopeForTest("u", "alice", home)
+	if _, err := scope.MkdirInScope(docRoot, true, 0o755); err != nil {
+		t.Fatalf("mkdir docroot: %v", err)
+	}
+	existing := filepath.Join(docRoot, "index.html")
+	if err := os.WriteFile(existing, []byte("user content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := []skeletonFileParam{{RelPath: "index.html", Content: []byte("skeleton")}}
+
+	warns := layAccountSkeleton(scope, true, docRoot, "alice", os.Getuid(), os.Getgid(), files)
+	if len(warns) != 0 {
+		t.Fatalf("existing path should be skipped silently, got %v", warns)
+	}
+	got, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "user content" {
+		t.Errorf("existing file clobbered: %q", got)
+	}
+}

--- a/panel-agent/internal/commands/system_diagnostic_report.go
+++ b/panel-agent/internal/commands/system_diagnostic_report.go
@@ -61,7 +61,10 @@ func systemDiagnosticReportHandler(ctx context.Context, _ json.RawMessage) (any,
 	const ttlSeconds = 7 * 24 * 3600
 	res, err := client.UploadFile(ctx, fileName, "application/x-tar", bundle.TarBytes, ttlSeconds)
 	if err != nil {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("enclosed upload: %v", err)}
+		// upstream_unavailable (not internal): GH #465 follow-up — the panel
+		// maps this to an actionable "server can't reach enclosed" message
+		// instead of the generic "agent error" that left the reporter blind.
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUpstreamUnavailable, Message: fmt.Sprintf("enclosed upload: %v", err)}
 	}
 
 	out := systemDiagnosticReportResponse{

--- a/panel-api/internal/api/admin_support.go
+++ b/panel-api/internal/api/admin_support.go
@@ -3,11 +3,13 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 )
@@ -44,7 +46,25 @@ func (h *adminSupportHandler) diagnostic(c *gin.Context) {
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "system.diagnostic_report", nil)
 	if err != nil {
-		respondAgentErr(c, "agent_error", err)
+		// GH #465 follow-up: "agent error" alone left a reporter with no way
+		// to tell an egress problem from a dead agent — and Send Report IS the
+		// diagnostic tool, so it must explain its own failures. Map the
+		// agent's typed codes to stage-level, non-leaking error codes the UI
+		// turns into actionable text. Detail still lands in the server log.
+		code := "agent_error"
+		var ae *agent.AgentError
+		if errors.As(err, &ae) {
+			switch ae.Code {
+			case agentwire.CodeUpstreamUnavailable:
+				code = "upload_unreachable"
+			case agentwire.CodeDeadlineExceeded:
+				code = "agent_timeout"
+			}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			code = "agent_timeout"
+		}
+		respondAgentErr(c, code, err)
 		return
 	}
 	var data any

--- a/panel-api/internal/api/admin_support_test.go
+++ b/panel-api/internal/api/admin_support_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 )
@@ -47,4 +48,34 @@ func TestAdminSupport_Diagnostic_HappyPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"redaction_count":7`)
 	assert.Contains(t, rec.Body.String(), `"password":"supersecret"`)
+}
+
+// GH #465 follow-up: the diagnostic endpoint is itself the diagnostic tool, so
+// its failures must be stage-coded, not a generic "agent_error" — the UI turns
+// these codes into actionable text (egress problem vs dead agent vs timeout).
+func TestAdminSupport_Diagnostic_ErrorCodes(t *testing.T) {
+	cases := []struct {
+		name     string
+		agentErr error
+		wantCode string
+	}{
+		{"enclosed unreachable", &agent.AgentError{Code: agentwire.CodeUpstreamUnavailable, Message: "enclosed upload: dial tcp: timeout"}, "upload_unreachable"},
+		{"agent deadline", &agent.AgentError{Code: agentwire.CodeDeadlineExceeded, Message: "deadline"}, "agent_timeout"},
+		{"agent internal", &agent.AgentError{Code: agentwire.CodeInternal, Message: "collect: boom"}, "agent_error"},
+		{"agent socket down", &agent.AgentError{Code: agentwire.CodeUnavailable, Message: "dial agent: no such file"}, "agent_error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := agent.NewMockClient().OnError("system.diagnostic_report", tc.agentErr)
+			r := newSupportRouter(mock, true)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/support/diagnostic", nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusBadGateway, rec.Code)
+			assert.Contains(t, rec.Body.String(), `"error":"`+tc.wantCode+`"`)
+			// Leak-suppression: the agent's message must not reach the client.
+			assert.NotContains(t, rec.Body.String(), "dial")
+			assert.NotContains(t, rec.Body.String(), "boom")
+		})
+	}
 }

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -145,6 +145,11 @@ function humanizeErrorCode(code: string): string {
     identity_service_unavailable: "Identity service temporarily unavailable — try again shortly",
     validation_failed: "Some fields are invalid",
     internal: "Something went wrong on the server",
+    agent_error:
+      "The server's host agent failed — details are in the server logs (journalctl -u jabali-panel / -u jabali-agent)",
+    upload_unreachable:
+      "The server could not reach the report upload service (enclosed.jabali-panel.com) — check outbound HTTPS/DNS from the server, then retry",
+    agent_timeout: "The operation timed out on the server — try again shortly",
   };
   return messages[code] ?? code.replace(/_/g, " ");
 }


### PR DESCRIPTION
Fixes both problems from the #465 reopen (2026-07-30).

**1. Skeleton files reappear after the user deletes them**

Not a permissions problem — skeleton files are chowned `<user>:www-data` and the user's delete succeeds. The reconciler re-runs `domain.create` every tick, and `writeSkeleton` ran unconditionally: the `Lstat`/`O_EXCL` guards protect *edited* files but a *deleted* file was recreated on the next pass (~30s later), which is exactly "I press delete and say that I delete it, but when refreshing the file reappears".

Fix: `MkdirInScope` already reports whether the docroot was actually created; the skeleton is now laid only by the call that created the docroot (`layAccountSkeleton` gate). Deleted skeleton files stay deleted; new domains/accounts still get the full tree.

**2. Send Report dies with a bare "agent error"**

Send Report is itself the diagnostic tool, so it has to explain its own failures. Chain now:

- agent: enclosed-upload failure returns new agentwire code `upstream_unavailable` (distinct from `unavailable`, which the panel's client also uses for "can't dial the local agent socket" — conflating them makes an egress problem look like a dead agent).
- panel-api: maps agent codes to stage-level, non-leaking response codes: `upload_unreachable`, `agent_timeout`, `agent_error`. Raw agent detail still goes to the server log only (leak-suppression preserved — asserted in tests).
- panel-ui: humanizes each code — "server could not reach the report upload service (check outbound HTTPS/DNS)" vs "timed out" vs "host agent failed, see journalctl".

(enclosed.jabali-panel.com itself is up and validating — probed during triage — so the reporter's failure is box-local; next release will tell them which stage.)

**Tests**
- `TestLayAccountSkeleton_OnlyOnFreshDocroot` — skeleton lands on create tick; a deleted file stays deleted on the reconcile tick.
- `TestLayAccountSkeleton_NeverClobbersExisting` — existing path silently skipped, content intact.
- `TestAdminSupport_Diagnostic_ErrorCodes` — all four agent-error shapes map to the right response code; agent messages never reach the client.
- Full suites green: agentwire, internal, panel-agent, panel-api (`go test`), panel-ui (`npm run build` + 195 vitest).