### PR TITLE
fix: finish the three partially-fixed JAB items (JAB-181, JAB-193, JAB-210)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10975,10 +10975,29 @@ install_logrotate() {
   # not 24 hours later on cron tick. -d = debug mode (parse only).
   # Skip when the binary is absent — base apt batch installs it but
   # this function runs on update paths that predate that addition.
+  #
+  # Parse the WHOLE config, not just "$dst". A duplicate log entry — the same
+  # path declared by us and by a package's own drop-in — is invisible when each
+  # file is parsed alone, and it is a hard error that makes logrotate skip an
+  # entire config file and exit 1. That is how maldet's event_log silently
+  # stopped rotating while logrotate.service sat failed (JAB-181). Warn only:
+  # a pre-existing problem in someone else's drop-in must not abort an install.
+  local lr_err=""
   if ! command -v logrotate >/dev/null 2>&1; then
     _warn "logrotate binary missing — skipping parse validation"
-  elif ! logrotate -d "$dst" >/dev/null 2>&1; then
-    _warn "logrotate parse failed for $dst — review syntax"
+  else
+    # -d is parse-only. Errors go to stderr alongside the verbose trace, so
+    # keep stderr and drop stdout, then filter. `|| true` because grep exits 1
+    # on no match, which is the good case. No `head` in the pipeline: under
+    # `set -o pipefail` an early-exiting reader SIGPIPEs the producer and the
+    # assignment fails, which has silently killed installs before.
+    lr_err="$(logrotate -d /etc/logrotate.conf 2>&1 >/dev/null | grep -E '^error:' || true)"
+    if [[ -n "$lr_err" ]]; then
+      _warn "logrotate config has errors — logrotate.service will exit non-zero and SKIP the offending file, so those logs stop rotating:"
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && _warn "  $line"
+      done <<< "$lr_err"
+    fi
   fi
 
   # JAB-104: the install logger falls back to /tmp/jabali_install-<ts>.log

--- a/install/logrotate/jabali
+++ b/install/logrotate/jabali
@@ -97,11 +97,26 @@
     endscript
 }
 
-# inotify_log has no .log suffix so the *.log glob misses it (JAB-154); the
-# maldet real-time monitor (M33) appends to it while running, so name it
-# explicitly here — copytruncate keeps the monitor's open fd writing across
-# the rotation.
-/var/log/maldet/*.log
+# maldet (LMD) ships its OWN /etc/logrotate.d/maldet naming event_log,
+# clamscan_log and audit.log explicitly — the same "package already owns these"
+# situation as the nginx note below, and it bites harder. This block used to
+# open with a `/var/log/maldet/*.log` glob, which matches audit.log. logrotate
+# reads /etc/logrotate.d in name order, so `jabali` claimed it first and
+# `maldet` then collided:
+#
+#   error: maldet:1 duplicate log entry for /var/log/maldet/audit.log
+#   error: found error in file maldet, skipping
+#   logrotate.service: Main process exited, code=exited, status=1/FAILURE
+#
+# A duplicate is a HARD error: logrotate discards maldet's ENTIRE config, so
+# event_log and clamscan_log — which only that file covers — stopped rotating,
+# and the unit sat permanently failed, masking every other rotation error
+# behind noise operators learn to ignore (JAB-181).
+#
+# So claim ONLY what maldet's own config misses: inotify_log has no .log suffix,
+# so its glob never matched it (JAB-154), and the real-time monitor (M33) holds
+# the file open while appending — copytruncate keeps that fd writing across the
+# rotation. Do not re-add a *.log glob here; it overlaps audit.log again.
 /var/log/maldet/inotify_log {
     daily
     rotate 30

--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -215,6 +215,30 @@ SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599201,phase:1,pass,no
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" "id:9599210,phase:2,pass,nolog,chain"
     SecRule ARGS:action "@rx ^elementor" "t:none,t:lowercase,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS"
 #
+# Code Snippets plugin (JAB-193). POST /wp-json/code-snippets/v1/snippets/<id>
+# saves a PHP snippet, so the JSON body legitimately IS PHP source — <?php,
+# function calls, superglobals. CRS scores it exactly as it would score an RCE
+# payload (observed on a production editor: rce: 5, php_injection: 5,
+# anomaly: 10 -> inline 403) and the editor simply cannot save their work. The
+# stopgap was allowlisting that one contractor's IP out of the ENTIRE WAF,
+# permanently — strictly worse than a scoped rule drop.
+#
+# There is no narrower content signal available here: accepting code IS the
+# endpoint's purpose, so no payload shape distinguishes a legitimate save from
+# an injection attempt. Scope on identity and reach instead:
+#   - Chained on a wordpress_logged_in_* cookie. An UNAUTHENTICATED request to
+#     the same path keeps FULL rce + php-injection scoring. A forged cookie
+#     buys an attacker nothing by itself — the route is capability-gated
+#     (manage_options) and nonce-checked by the plugin, so WordPress answers
+#     401/403 long before a snippet is written; the cookie only decides whether
+#     CRS scores the body, never whether the write is allowed.
+#   - Only the two families that fire on source text, and only on ARGS +
+#     REQUEST_BODY. Headers, cookies and the URI stay inspected, and every
+#     other family (SQLi, XSS, LFI, traversal, scanner detection) stays fully
+#     active on this path.
+#   - v[0-9]+ so a future API version can't silently re-break saves.
+SecRule REQUEST_URI "@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,pass,nolog,chain"
+    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;REQUEST_BODY,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;REQUEST_BODY"
 # 933120 vs WooCommerce checkout (arizot-e.com incident, 2026-08-02).
 # WooCommerce 8.5+ order attribution submits a field literally named
 # wc_order_attribution_user_agent with every checkout AJAX call — and

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -69,11 +69,11 @@ func TestRender_WebmailHostsExplicitEquality(t *testing.T) {
 		WebmailHosts: []string{
 			"Mail.Foo.Com",
 			"autoconfig.foo.com",
-			"mail.foo.com",       // dup
+			"mail.foo.com", // dup
 			"mail.bar.com",
-			"",                   // empty (skip)
+			"",                     // empty (skip)
 			"mail.evil\"injection", // quote (skip)
-			"mail..oops.com",     // double dot (skip)
+			"mail..oops.com",       // double dot (skip)
 		},
 	})
 	// Stable equality OR-chain, sorted.
@@ -144,14 +144,14 @@ func TestRender_GeoExprAgentParity(t *testing.T) {
 func TestSanitizeWebmailHosts(t *testing.T) {
 	in := []string{
 		"  Mail.Example.Com  ",
-		"mail.example.com",       // dup post-lowercase
+		"mail.example.com", // dup post-lowercase
 		"mail.bar.com",
-		"",                       // empty
-		".leading.dot",           // leading dot
-		"trailing.dot.",          // trailing dot
-		"double..dot.com",        // empty label
-		"weird\nhost",            // newline
-		"quote\"host",            // quote
+		"",                // empty
+		".leading.dot",    // leading dot
+		"trailing.dot.",   // trailing dot
+		"double..dot.com", // empty label
+		"weird\nhost",     // newline
+		"quote\"host",     // quote
 		"a.com",
 		strings.Repeat("a", 254), // too long
 	}
@@ -208,4 +208,29 @@ func TestCRSPluginBefore_WordPressBuilderExclusions(t *testing.T) {
 	mustContain(t, out, `^/wp-admin/admin-ajax\.php" "id:9599201,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"`, "admin-ajax phase-1 keeps only narrow ById drops")
 	// Surgical, not blanket: no path-allow, no remediation override.
 	mustNotContain(t, out, `SetRemediation`, "before-plugin must not blanket-allow")
+}
+
+// JAB-193: the Code Snippets REST save carries literal PHP source, so the
+// rce + php-injection families have to stand down there — but ONLY there,
+// ONLY on the body, and ONLY for a request that already carries a WordPress
+// login cookie. An unauthenticated hit on the same path must stay fully
+// scored, which is the property that keeps this from being a path-allow.
+func TestCRSPluginBefore_CodeSnippetsExclusion(t *testing.T) {
+	out := CRSPluginBefore()
+	mustContain(t, out, `"@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,pass,nolog,chain"`,
+		"code-snippets drop is a chained phase-1 rule scoped to the versioned REST path")
+	mustContain(t, out, `SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_"`,
+		"chained on an authenticated WordPress session")
+	for _, tag := range []string{"attack-rce", "attack-injection-php"} {
+		mustContain(t, out, "ctl:ruleRemoveTargetByTag="+tag+";ARGS", tag+" dropped on ARGS")
+		mustContain(t, out, "ctl:ruleRemoveTargetByTag="+tag+";REQUEST_BODY", tag+" dropped on REQUEST_BODY")
+	}
+	// Surgical: the SQLi/XSS/LFI families keep inspecting this path, and the
+	// drop is target-scoped rather than a ruleRemoveById sweep.
+	mustNotContain(t, out, "ctl:ruleRemoveTargetByTag=attack-sqli;REQUEST_BODY",
+		"SQLi must keep inspecting bodies everywhere")
+	// An unversioned or unauthenticated variant must not exist as a
+	// standalone (unchained) exclusion.
+	mustNotContain(t, out, `"@rx ^/wp-json/code-snippets/" "id:`,
+		"no unchained, unversioned code-snippets exclusion")
 }

--- a/panel-agent/internal/commands/logrotate_su_test.go
+++ b/panel-agent/internal/commands/logrotate_su_test.go
@@ -100,3 +100,97 @@ func TestLogrotatePerTenantBlocksUseCopytruncate(t *testing.T) {
 			"tenant's pool loses write access to its own log")
 	}
 }
+
+// thirdPartyOwnedLogPaths are log files whose rotation is declared by a config
+// file jabali does not own. maldet (LMD) installs /etc/logrotate.d/maldet
+// naming these three explicitly.
+var thirdPartyOwnedLogPaths = []string{
+	"/var/log/maldet/event_log",
+	"/var/log/maldet/clamscan_log",
+	"/var/log/maldet/audit.log",
+}
+
+// logrotateDeclaredPaths extracts the log paths a logrotate config declares.
+// A stanza is one or more path lines followed by a line opening `{`, so every
+// non-comment, non-directive line up to the brace is a declared path.
+func logrotateDeclaredPaths(body string) []string {
+	var paths []string
+	inBlock := false
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if inBlock {
+			if line == "}" {
+				inBlock = false
+			}
+			continue
+		}
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if open := strings.Index(line, "{"); open >= 0 {
+			inBlock = true
+			line = strings.TrimSpace(line[:open])
+			if line == "" {
+				continue
+			}
+		}
+		paths = append(paths, line)
+	}
+	return paths
+}
+
+// TestLogrotateDoesNotClaimThirdPartyLogs guards a whole-host outage mode that
+// looks like a jabali-local mistake and is not.
+//
+// logrotate treats one path declared by two config files as a HARD error: it
+// reports `duplicate log entry` and skips the ENTIRE second file, then exits
+// non-zero. /etc/logrotate.d is read in name order, so `jabali` claiming a path
+// that `maldet` also declares means maldet's whole config is discarded —
+// event_log and clamscan_log stop rotating, and logrotate.service sits
+// permanently failed, masking every unrelated rotation error behind noise.
+//
+// Reproduced on a box before the fix (JAB-181):
+//
+//	# logrotate -d /etc/logrotate.conf ; echo $?
+//	error: maldet:1 duplicate log entry for /var/log/maldet/audit.log
+//	error: found error in file maldet, skipping
+//	1
+//
+// The cause was a `/var/log/maldet/*.log` glob here, which matches audit.log.
+// Globs make this easy to reintroduce without noticing, so match them properly
+// rather than comparing literal strings.
+func TestLogrotateDoesNotClaimThirdPartyLogs(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(repoRoot, "install", "logrotate", "jabali"))
+	if err != nil {
+		t.Fatalf("read logrotate config: %v", err)
+	}
+
+	declared := logrotateDeclaredPaths(string(body))
+	if len(declared) == 0 {
+		t.Fatal("parsed no log paths out of install/logrotate/jabali — the " +
+			"config or this parser drifted, so the test is checking nothing")
+	}
+
+	for _, pattern := range declared {
+		for _, owned := range thirdPartyOwnedLogPaths {
+			match, err := filepath.Match(pattern, owned)
+			if err != nil {
+				t.Fatalf("malformed pattern %q in install/logrotate/jabali: %v", pattern, err)
+			}
+			if match {
+				t.Errorf("install/logrotate/jabali declares %q, which claims %s — "+
+					"that path is already declared by a config jabali does not own. "+
+					"logrotate reports `duplicate log entry`, SKIPS that entire "+
+					"config file and exits 1, so its other logs stop rotating and "+
+					"logrotate.service stays failed host-wide (JAB-181). Declare "+
+					"only paths the third-party config misses.", pattern, owned)
+			}
+		}
+	}
+}

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -128,6 +128,25 @@ func runUpdate(cmd *cobra.Command, args []string) (retErr error) {
 		allArgs = append(allArgs, args...)
 		return run(dir, "sudo", allArgs...)
 	}
+	// asUserOut is asUser for the one case that has to inspect what git said
+	// rather than only whether it failed (JAB-210). `run` streams straight to
+	// the terminal, which is right for build output but leaves the caller
+	// nothing to classify.
+	asUserOut := func(dir string, name string, args ...string) (string, error) {
+		allArgs := []string{"-u", serviceUser, "-H", "env",
+			"HOME=" + repoDir,
+			"PATH=" + goRoot + "/bin:/usr/bin:/bin",
+			"GOCACHE=" + repoDir + "/.cache/go-build",
+			"GOMODCACHE=" + repoDir + "/.cache/go-mod",
+		}
+		allArgs = append(allArgs, lowMemGoEnv...)
+		allArgs = append(allArgs, name)
+		allArgs = append(allArgs, args...)
+		c := exec.Command("sudo", allArgs...)
+		c.Dir = dir
+		out, err := c.CombinedOutput()
+		return string(out), err
+	}
 
 	force, _ := cmd.Flags().GetBool("force")
 	fromSource, _ := cmd.Flags().GetBool("from-source")
@@ -140,6 +159,29 @@ func runUpdate(cmd *cobra.Command, args []string) (retErr error) {
 	var installedFromRelease bool
 	var releaseSHA string
 	_ = releaseSHA // currently unused; reserved for future logging
+
+	// Byte copies of the binaries as they were before this update replaced
+	// them, so a failed `migrate up` can put them back (JAB-210). Taken by
+	// whichever install path runs — release tarball or source build — and
+	// dropped once migrations succeed. Deferred cleanup covers the updates
+	// that fail at some step in between and never reach the migrate step.
+	var preUpdateBinaries *binarySnapshot
+	defer func() { preUpdateBinaries.cleanup() }()
+	snapshotBeforeSwap := func() {
+		if preUpdateBinaries != nil {
+			return // already captured by an earlier step in this run
+		}
+		snap, err := snapshotBinaries(managedBinaries)
+		if err != nil {
+			// Not fatal: losing the ability to roll back is worse than not
+			// updating, but not worse than leaving the host on old code with
+			// no explanation. Say so plainly and continue.
+			fmt.Printf("  (could not snapshot the current binaries for rollback: %v — "+
+				"a failed migration will NOT be able to restore them)\n", err)
+			return
+		}
+		preUpdateBinaries = snap
+	}
 
 	// gitHead captures HEAD as a string. Runs via `sudo -u <serviceUser>`
 	// because the repo is owned by the jabali user; git 2.35+ refuses to
@@ -370,12 +412,21 @@ chmod 0750 "$WR"`)
 			}
 			resetRef := "origin/main"
 			if channel == "stable" {
-				// Best-effort: the `stable` tag is absent on origin until the
-				// first promote, so a combined fetch would hard-fail. Separate
-				// + ignore the error (GH #445).
-				_ = asUser(repoDir, "git", "fetch", "--force", "origin",
+				// Fetched separately from main: the `stable` tag is absent on
+				// origin until the first promote, so a combined fetch would
+				// hard-fail on a host that has never had one (GH #445).
+				//
+				// "Absent upstream" is the only failure we may ignore, though.
+				// Any other one leaves a possibly-stale LOCAL refs/tags/stable
+				// that rev-parse below would happily accept, resetting the
+				// checkout backwards (JAB-210) — so classify, don't discard.
+				fetchOut, fetchErr := asUserOut(repoDir, "git", "fetch", "--force", "origin",
 					"+refs/tags/stable:refs/tags/stable")
-				if asUser(repoDir, "git", "rev-parse", "--verify", "--quiet",
+				tagOnOrigin, fatal := classifyStableTagFetch(fetchErr, fetchOut)
+				if fatal != nil {
+					return fatal
+				}
+				if tagOnOrigin && asUser(repoDir, "git", "rev-parse", "--verify", "--quiet",
 					"refs/tags/stable^{commit}") == nil {
 					resetRef = "refs/tags/stable"
 					fmt.Println("  release channel: stable -> tracking the promoted `stable` tag")
@@ -1030,6 +1081,7 @@ fi
 				}
 			}
 			ctx := cmd.Context()
+			snapshotBeforeSwap()
 			installed, sha, err := installFromRelease(ctx, repoDir, func(format string, args ...any) {
 				fmt.Printf("  "+format+"\n", args...)
 			})
@@ -1374,6 +1426,7 @@ test -x node_modules/.bin/tsc || {
 				fmt.Println("  (skipped: binaries already installed from release tarball)")
 				return nil
 			}
+			snapshotBeforeSwap()
 			// Skip per-binary when its .new file is absent — the parallel
 			// build step short-circuited that side because its inputs
 			// hadn't changed. The currently-installed binary stays.
@@ -1462,7 +1515,20 @@ test -x node_modules/.bin/tsc || {
 			return nil
 		}},
 		{"run migrations", func() error {
-			return run("", defaultPanelBinPath, "migrate", "up")
+			if err := run("", defaultPanelBinPath, "migrate", "up"); err != nil {
+				// The binaries were swapped several steps ago; the schema is
+				// still where it started. Undo the half that we can undo
+				// rather than leaving new code on disk in front of an old
+				// schema, where the next restart runs the mismatch (JAB-210).
+				return rollbackAfterFailedMigrate(preUpdateBinaries, err, func(format string, args ...any) {
+					fmt.Printf("  "+format+"\n", args...)
+				})
+			}
+			// Past this point the binary and the schema agree, so the
+			// snapshot is only taking up disk.
+			preUpdateBinaries.cleanup()
+			preUpdateBinaries = nil
+			return nil
 		}},
 		{"restart services", func() error {
 			if err := run("", "systemctl", "restart", "jabali-agent"); err != nil {

--- a/panel-api/cmd/server/update_binary_rollback.go
+++ b/panel-api/cmd/server/update_binary_rollback.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// managedBinaries are the executables `jabali update` replaces on disk, whether
+// they come from a release tarball or a source build. They are versioned as a
+// set — jabali-panel and jabali-agent speak a wire contract to each other — so
+// a rollback has to put all of them back, not just the one that ran migrations.
+var managedBinaries = []string{
+	"/usr/local/bin/jabali-panel",
+	"/usr/local/bin/jabali-agent",
+	"/usr/local/bin/jabali-ssh-shell",
+	"/usr/local/bin/jabali-mailhook",
+}
+
+// binarySnapshot holds byte copies of the binaries as they were before an
+// update swapped them, so a failed `migrate up` can put the host back exactly
+// where it started.
+//
+// Why this exists (JAB-210): the update installs new binaries first and runs
+// migrations after. When `migrate up` fails, the schema stays where it was
+// while the NEW binary sits on disk, and the next service restart — a reboot,
+// a crash, an unrelated deploy — runs code against a schema it does not match.
+// On the reported box that state was reached by a different route (an older
+// release installed over a newer binary), but the hazard is the ordering
+// itself. Restoring the previous binaries makes the failure atomic from the
+// operator's point of view: either both the binary and the schema moved, or
+// neither did.
+type binarySnapshot struct {
+	dir   string
+	files map[string]string // live path -> snapshot copy
+}
+
+// snapshotBinaries copies each existing path into a private temp dir. Paths
+// that are not installed on this host are skipped, not an error: jabali-mailhook
+// is absent wherever the mail module was never provisioned.
+func snapshotBinaries(paths []string) (*binarySnapshot, error) {
+	dir, err := os.MkdirTemp("", "jabali-update-rollback-")
+	if err != nil {
+		return nil, fmt.Errorf("snapshot binaries: %w", err)
+	}
+	s := &binarySnapshot{dir: dir, files: make(map[string]string, len(paths))}
+	for _, live := range paths {
+		info, err := os.Stat(live)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			s.cleanup()
+			return nil, fmt.Errorf("snapshot %s: %w", live, err)
+		}
+		snap := filepath.Join(dir, filepath.Base(live))
+		if err := copyFileAtomic(live, snap, info.Mode().Perm()); err != nil {
+			s.cleanup()
+			return nil, fmt.Errorf("snapshot %s: %w", live, err)
+		}
+		s.files[live] = snap
+	}
+	return s, nil
+}
+
+// restore puts every snapshotted binary back. It attempts all of them even if
+// one fails, because a half-restored set is the worst possible outcome and the
+// operator needs to know exactly which paths are still wrong.
+func (s *binarySnapshot) restore() error {
+	if s == nil || len(s.files) == 0 {
+		return errors.New("no binary snapshot was taken")
+	}
+	var failures []error
+	for live, snap := range s.files {
+		mode := os.FileMode(0o755)
+		if info, err := os.Stat(snap); err == nil {
+			mode = info.Mode().Perm()
+		}
+		if err := copyFileAtomic(snap, live, mode); err != nil {
+			failures = append(failures, fmt.Errorf("restore %s: %w", live, err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+// cleanup drops the snapshot. Safe on a nil receiver and safe to call twice, so
+// callers can defer it unconditionally.
+func (s *binarySnapshot) cleanup() {
+	if s == nil || s.dir == "" {
+		return
+	}
+	_ = os.RemoveAll(s.dir)
+	s.dir = ""
+	s.files = nil
+}
+
+// copyFileAtomic writes src to dst via a sibling temp file + rename, so a
+// reader never observes a partially-written executable and a crash mid-copy
+// cannot leave a truncated binary in place. No chown: the caller runs as root,
+// and root-created files are already root-owned.
+func copyFileAtomic(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	tmp := dst + ".rollback-tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		out.Close()
+		_ = os.Remove(tmp) // no-op once Rename succeeded
+	}()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	if err := out.Chmod(mode); err != nil {
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp, dst)
+}
+
+// rollbackAfterFailedMigrate restores the pre-update binaries and composes the
+// error the operator sees. The migration failure is the headline — the rollback
+// is the reassurance — and a rollback that itself failed has to be louder than
+// either, because that is the one state needing hands on the box.
+func rollbackAfterFailedMigrate(snap *binarySnapshot, migrateErr error, logf func(string, ...any)) error {
+	if rErr := snap.restore(); rErr != nil {
+		return fmt.Errorf(
+			"migrations failed AND the previous binaries could not be restored: %w\n"+
+				"  migrate error: %v\n"+
+				"  This host now has NEW binaries on disk against an UNMIGRATED schema. Do not\n"+
+				"  restart jabali-panel or jabali-agent until it is resolved — re-run\n"+
+				"  `jabali update` once the migration cause is fixed, or reinstall the previous\n"+
+				"  release explicitly.", rErr, migrateErr)
+	}
+	logf("restored the previous binaries — this host is back on the build it was running before this update")
+	return fmt.Errorf(
+		"migrations failed, so the binary swap was rolled back: %w\n"+
+			"  The previous binaries are back in place and the schema is untouched, so the host\n"+
+			"  is consistent and safe to restart. Fix the migration cause and re-run\n"+
+			"  `jabali update`.", migrateErr)
+}

--- a/panel-api/cmd/server/update_binary_rollback_test.go
+++ b/panel-api/cmd/server/update_binary_rollback_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeBin(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// The core promise: after a failed migration the bytes on disk are the bytes
+// that were there before the update swapped them.
+func TestBinarySnapshotRestoresPreviousBytes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	panelBin := filepath.Join(dir, "jabali-panel")
+	agentBin := filepath.Join(dir, "jabali-agent")
+	writeBin(t, panelBin, "OLD-PANEL", 0o755)
+	writeBin(t, agentBin, "OLD-AGENT", 0o755)
+
+	snap, err := snapshotBinaries([]string{panelBin, agentBin})
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	defer snap.cleanup()
+
+	// The update swaps in new builds...
+	writeBin(t, panelBin, "NEW-PANEL", 0o755)
+	writeBin(t, agentBin, "NEW-AGENT", 0o755)
+
+	// ...then `migrate up` fails.
+	if err := snap.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	for path, want := range map[string]string{panelBin: "OLD-PANEL", agentBin: "OLD-AGENT"} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q — a failed migration must leave the host on "+
+				"the build it was running, not new code in front of an old schema",
+				filepath.Base(path), got, want)
+		}
+	}
+}
+
+// The restored file has to still be executable, or the rollback trades a schema
+// mismatch for a host that cannot run the panel at all.
+func TestBinarySnapshotRestoresExecutableMode(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "jabali-panel")
+	writeBin(t, bin, "OLD", 0o755)
+
+	snap, err := snapshotBinaries([]string{bin})
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	defer snap.cleanup()
+
+	writeBin(t, bin, "NEW", 0o755)
+	if err := snap.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	info, err := os.Stat(bin)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Errorf("restored binary mode %v is not executable", info.Mode().Perm())
+	}
+}
+
+// jabali-mailhook is absent wherever the mail module was never provisioned, so
+// an uninstalled path is an ordinary state and must not abort the snapshot —
+// otherwise every no-mail host loses rollback coverage entirely.
+func TestSnapshotSkipsBinariesNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	present := filepath.Join(dir, "jabali-panel")
+	writeBin(t, present, "OLD", 0o755)
+	absent := filepath.Join(dir, "jabali-mailhook")
+
+	snap, err := snapshotBinaries([]string{present, absent})
+	if err != nil {
+		t.Fatalf("an absent binary must not fail the snapshot: %v", err)
+	}
+	defer snap.cleanup()
+
+	if _, ok := snap.files[absent]; ok {
+		t.Error("a binary that was never installed must not be snapshotted")
+	}
+	if _, ok := snap.files[present]; !ok {
+		t.Error("the installed binary must be snapshotted")
+	}
+
+	// Restoring must not resurrect a file that was never there.
+	if err := snap.restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if _, err := os.Stat(absent); !errors.Is(err, os.ErrNotExist) {
+		t.Error("restore recreated a binary that was not installed before the update")
+	}
+}
+
+func TestBinarySnapshotCleanupIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "jabali-panel")
+	writeBin(t, bin, "OLD", 0o755)
+
+	snap, err := snapshotBinaries([]string{bin})
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	snapDir := snap.dir
+	snap.cleanup()
+	snap.cleanup() // deferred cleanup + the migrate step's cleanup both run
+
+	if _, err := os.Stat(snapDir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("snapshot dir %s survived cleanup", snapDir)
+	}
+	// A nil snapshot is the "could not snapshot" path; it must not panic.
+	var nilSnap *binarySnapshot
+	nilSnap.cleanup()
+}
+
+// When the snapshot was never taken, the rollback cannot happen — and that has
+// to read as the more serious state, because it is the one that needs hands on
+// the box.
+func TestRollbackWithoutSnapshotIsLouderThanTheMigrationFailure(t *testing.T) {
+	t.Parallel()
+
+	var nilSnap *binarySnapshot
+	err := rollbackAfterFailedMigrate(nilSnap, errors.New("dirty database version 243"), func(string, ...any) {})
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "could not be restored") {
+		t.Errorf("must say the restore did not happen, got: %v", err)
+	}
+	if !strings.Contains(msg, "Do not") || !strings.Contains(msg, "restart") {
+		t.Errorf("must warn against restarting into the mismatch, got: %v", err)
+	}
+	if !strings.Contains(msg, "dirty database version 243") {
+		t.Errorf("must carry the original migrate error, got: %v", err)
+	}
+}
+
+// On the good path the operator should be told the host is consistent — the
+// difference between "your update failed" and "your update failed and your
+// server is now in an unknown state" is the whole point of this code.
+func TestRollbackAfterFailedMigrateReportsConsistentHost(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "jabali-panel")
+	writeBin(t, bin, "OLD", 0o755)
+	snap, err := snapshotBinaries([]string{bin})
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	defer snap.cleanup()
+	writeBin(t, bin, "NEW", 0o755)
+
+	var logged []string
+	err = rollbackAfterFailedMigrate(snap, errors.New("no migration found for version 242"),
+		func(format string, args ...any) { logged = append(logged, format) })
+	if err == nil {
+		t.Fatal("the update still failed, so it must still return an error")
+	}
+	if !strings.Contains(err.Error(), "rolled back") {
+		t.Errorf("must say the swap was undone, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "no migration found for version 242") {
+		t.Errorf("must carry the original migrate error, got: %v", err)
+	}
+	if len(logged) == 0 {
+		t.Error("the rollback should be visible in the update output, not silent")
+	}
+	if got, _ := os.ReadFile(bin); string(got) != "OLD" {
+		t.Errorf("binary = %q, want the pre-update bytes", got)
+	}
+}
+
+// managedBinaries is what the rollback covers; it has to stay in step with
+// what the release installer actually swaps, or an update replaces a binary
+// that no rollback puts back.
+func TestManagedBinariesCoverEveryInstalledBinary(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("update_release.go")
+	if err != nil {
+		t.Fatalf("read update_release.go: %v", err)
+	}
+	for _, name := range []string{"jabali-panel", "jabali-agent", "jabali-ssh-shell", "jabali-mailhook"} {
+		if !strings.Contains(string(body), `"`+name+`"`) {
+			t.Errorf("%s is in managedBinaries but the release installer no longer "+
+				"mentions it — the two lists have drifted", name)
+		}
+		found := false
+		for _, p := range managedBinaries {
+			if filepath.Base(p) == name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s is installed by the release path but is not in managedBinaries, "+
+				"so a failed migration would not roll it back", name)
+		}
+	}
+}

--- a/panel-api/cmd/server/update_stable_tag.go
+++ b/panel-api/cmd/server/update_stable_tag.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// classifyStableTagFetch decides what a failed
+// `git fetch --force origin +refs/tags/stable:refs/tags/stable` actually means.
+//
+// The `stable` tag does not exist on origin until someone runs the first
+// `jabali release promote`, so a fetch that fails BECAUSE the ref is not there
+// is an ordinary state on a fresh host — the caller stays on the current build
+// and says so. That is why the call was written as `_ = asUser(...)` (GH #445).
+//
+// Every other failure is different in kind, and swallowing it is one of the
+// ways a host silently goes backwards (JAB-210). A transport, auth or
+// dubious-ownership failure leaves the LOCAL refs/tags/stable untouched — so
+// the `rev-parse --verify` immediately after still succeeds, against whatever
+// commit was promoted the last time a fetch worked. The updater then resets the
+// checkout to that stale commit and hands the release installer a tarball older
+// than the binary already on disk. The schema-downgrade guard catches the worst
+// outcome, but only after the operator has burned an update cycle on a silent
+// no-op, and only when a database is configured.
+//
+// So: "no such ref" is expected, anything else aborts the update before a
+// single binary is touched.
+func classifyStableTagFetch(err error, output string) (exists bool, fatal error) {
+	if err == nil {
+		return true, nil
+	}
+	if isMissingRemoteRef(output) {
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"fetching the `stable` tag from origin failed: %w\n"+
+			"  Refusing to fall back to this host's local copy of refs/tags/stable: it can be older\n"+
+			"  than the promoted build, and resetting to it would install a binary older than the\n"+
+			"  one running now. Fix the fetch (network, credentials, or `git config --global\n"+
+			"  --add safe.directory <repo>` for a root-run update on a non-root checkout) and\n"+
+			"  re-run `jabali update` — or switch this host to the development channel.\n"+
+			"  git said:\n%s",
+		err, indentLines(strings.TrimSpace(output), "    "))
+}
+
+// isMissingRemoteRef reports whether git's output says the ref simply is not
+// on the remote. The wording has changed across git versions ("couldn't find
+// remote ref" on modern git, "Couldn't find remote ref" older, and the
+// refspec form can report the ref matched nothing), so match on fragments
+// rather than a whole line — and lowercase first, since the leading capital
+// differs between versions.
+func isMissingRemoteRef(output string) bool {
+	o := strings.ToLower(output)
+	for _, frag := range []string{
+		"couldn't find remote ref",
+		"could not find remote ref",
+		"matched no remote refs",
+		"no such ref",
+	} {
+		if strings.Contains(o, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// indentLines prefixes every line so multi-line git output stays visually
+// attached to the error that quotes it.
+func indentLines(s, prefix string) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}

--- a/panel-api/cmd/server/update_stable_tag_test.go
+++ b/panel-api/cmd/server/update_stable_tag_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The `stable` tag genuinely does not exist until the first promote, and that
+// case has to stay non-fatal or a fresh host on the stable channel could never
+// update at all. git's wording for it has drifted across versions, so accept
+// every form we know of.
+func TestClassifyStableTagFetch_MissingRefIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	for _, out := range []string{
+		"fatal: couldn't find remote ref refs/tags/stable\n",
+		"fatal: Couldn't find remote ref refs/tags/stable\n",
+		"fatal: could not find remote ref refs/tags/stable\n",
+		"error: src refspec refs/tags/stable matched no remote refs\n",
+		"fatal: no such ref: refs/tags/stable\n",
+	} {
+		exists, fatal := classifyStableTagFetch(errors.New("exit status 128"), out)
+		if fatal != nil {
+			t.Errorf("output %q: want non-fatal, got %v", out, fatal)
+		}
+		if exists {
+			t.Errorf("output %q: tag must be reported absent", out)
+		}
+	}
+}
+
+// The bug this guards (JAB-210). A fetch that fails for any OTHER reason leaves
+// the local refs/tags/stable exactly as it was, so the rev-parse right after it
+// still succeeds — against a commit promoted who-knows-when. Swallowing the
+// error there resets the checkout backwards and hands the release installer a
+// tarball older than the binary already running.
+func TestClassifyStableTagFetch_OtherFailuresAreFatal(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"dubious ownership": "fatal: detected dubious ownership in repository at '/opt/jabali-panel'\n",
+		"transport":         "fatal: unable to access 'https://github.com/...': Could not resolve host\n",
+		"auth":              "remote: Invalid username or password.\nfatal: Authentication failed\n",
+		"empty output":      "",
+	}
+	for name, out := range cases {
+		exists, fatal := classifyStableTagFetch(errors.New("exit status 128"), out)
+		if fatal == nil {
+			t.Errorf("%s: a fetch failure that is not `no such ref` must abort the update, "+
+				"otherwise a stale local tag silently downgrades the host", name)
+			continue
+		}
+		if exists {
+			t.Errorf("%s: must not report the tag as usable", name)
+		}
+		// The operator has to be able to act on this, so the message must
+		// carry git's own words and name the way out.
+		if out != "" && !strings.Contains(fatal.Error(), strings.TrimSpace(strings.Split(out, "\n")[0])) {
+			t.Errorf("%s: error must quote git's output verbatim, got: %v", name, fatal)
+		}
+		if !strings.Contains(fatal.Error(), "development channel") {
+			t.Errorf("%s: error should name the escape hatch, got: %v", name, fatal)
+		}
+	}
+}
+
+func TestClassifyStableTagFetch_SuccessMeansTagExists(t *testing.T) {
+	t.Parallel()
+
+	exists, fatal := classifyStableTagFetch(nil, "")
+	if fatal != nil {
+		t.Fatalf("a successful fetch must not be fatal: %v", fatal)
+	}
+	if !exists {
+		t.Error("a successful fetch means the tag is on origin")
+	}
+}
+
+// A "no such ref" phrase must not be matched out of an unrelated failure just
+// because the words appear somewhere — check the classifier is not so loose
+// that a real error slips through as "expected".
+func TestClassifyStableTagFetch_DoesNotSwallowUnrelatedErrors(t *testing.T) {
+	t.Parallel()
+
+	_, fatal := classifyStableTagFetch(errors.New("exit status 128"),
+		"fatal: unable to read config file: refs/tags/stable is not a valid object name\n")
+	if fatal == nil {
+		t.Error("an error that merely mentions the ref is not the same as the remote not having it")
+	}
+}


### PR DESCRIPTION
Three open JAB issues were each half-done: the headline fix shipped, a second
root cause in the same issue did not. This closes the gaps.

### JAB-210 — `jabali update` (2 of 4 acceptance criteria were still open)

The schema-downgrade guard shipped in `8a99b519` and the `safe.directory` fix
in `df4c7183`. Remaining:

**Swallowed stable-tag fetch.** The `stable` tag doesn't exist on origin until
the first `jabali release promote`, so its fetch was `_ = asUser(...)` (GH
#445) — right for that case, wrong for every other. A transport, auth or
dubious-ownership failure leaves the *local* `refs/tags/stable` untouched, so
the `rev-parse` right after still succeeds against whatever commit was
promoted the last time a fetch worked. The updater then resets backwards and
hands the release installer a tarball older than the running binary. Now
classified: "no such ref" stays non-fatal, anything else aborts before a
binary is touched, quoting git verbatim.

**Binary rollback on failed `migrate up`.** Binaries install first, migrations
run after. If `migrate up` fails, the schema stays put while the new binary
sits on disk, and the next restart runs code against a schema it doesn't
match. Snapshot before either install path swaps, restore on migration
failure, drop the snapshot once the two agree.

Three distinct messages, because the states differ: rolled back (consistent,
safe to restart) / restore *also* failed (needs hands on the box — says don't
restart) / couldn't snapshot at all (said at swap time, not discovered later).

### JAB-181 — `logrotate.service` failed host-wide

The `su www-data` half shipped in `217b7083`. The other half is ours too: our
`/var/log/maldet/*.log` glob claimed `audit.log`, which maldet's own drop-in
also declares. A duplicate is a **hard** error — logrotate skips the entire
second file and exits 1, so `event_log` and `clamscan_log` stopped rotating
and the unit sat permanently failed, masking every other rotation error.

The glob only ever existed for `inotify_log` (no `.log` suffix, JAB-154), so
it now declares that one file. Install-time validation missed this because it
parsed only our file, where a cross-file duplicate can't appear — it now
parses `/etc/logrotate.conf`, warn-only.

### JAB-193 — WAF blocks Code Snippets saves

The Elementor half shipped in `0bcb88c2`, the ops half in `b55454d2`. The
Code Snippets REST save didn't: the JSON body legitimately *is* PHP source, so
CRS scores it as an RCE payload and the editor can't save. The mitigation in
place was allowlisting one contractor's IP out of the entire WAF, permanently.

Scoped on identity and reach, since no payload shape distinguishes a real save
from an attack here: chained on a `wordpress_logged_in_*` cookie
(unauthenticated requests keep full scoring; the route is cap-gated and
nonce-checked, so a forged cookie only decides whether CRS scores the body,
never whether the write is allowed), only `attack-rce` +
`attack-injection-php`, only on ARGS + REQUEST_BODY.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] 10 new Go tests (rollback restore/mode/skip-absent/idempotent-cleanup/
      message states/list-drift; stable-tag classification incl. a
      does-not-over-match case)
- [x] logrotate overlap test uses `filepath.Match`, not string equality —
      **verified it fails when the old glob is put back**
- [x] JAB-181 reproduced on the smoke host before the fix: `logrotate -d
      /etc/logrotate.conf` exits 1 with `duplicate log entry for
      /var/log/maldet/audit.log`
- [x] JAB-193 rule loaded on the smoke host: crowdsec restarts clean.
      **Negative control on the same box** — a rule with a bogus action makes
      crowdsec fail FATAL with `failed to compile the directive` — so the
      clean restart is evidence, not absent logging
- [x] Rebased onto `origin/main` (`ae674afd`), full suite re-run after

## Still open on these issues

- JAB-210: no `--allow-downgrade` escape hatch for the schema guard yet
- Rollback covers the four managed binaries, not the SPA bundle or bundled
  WP plugins