### PR TITLE
fix(cron): restore the system dirs to ExecSearchPath so wp-cli jobs run (JAB-182)

### DIFF
--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/cronvalidate"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // cronApplyParams is the input for cron.apply command.
@@ -279,19 +279,37 @@ func buildCronServiceContent(jobID, name string, cmd *cronvalidate.Command, user
 		condDocroot = "ConditionPathIsDirectory=" + docroot + "\n"
 	}
 
-	// ExecSearchPath prepends the per-user wrapper dir to systemd's binary
+	// ExecSearchPath puts the per-user wrapper dir FIRST in systemd's binary
 	// search for ExecStart= (GH #299). systemd resolves the ExecStart binary
 	// against the MANAGER's path, NOT Environment=PATH — so a bare `php`
 	// resolved to /usr/bin/php (system default), ignoring the user's pinned
 	// version, and `php8.5` only worked because /usr/bin/php8.5 happened to
 	// exist. With .jabali/bin first, bare `php` follows the user's pinned
 	// wrapper (.jabali/bin/php -> their version) and `php8.5` follows
-	// .jabali/bin/php8.5, falling through to /usr/bin for anything not there.
-	// A version that is installed NOWHERE yields a clean 203/EXEC failure —
-	// never a silent wrong-version run. Environment=PATH is kept because wp's
-	// `#!/usr/bin/env php` shebang reads the running process's PATH, not
-	// ExecSearchPath. (GH #184, #256, #299.)
+	// .jabali/bin/php8.5. A version installed NOWHERE yields a clean 203/EXEC
+	// failure — never a silent wrong-version run.
+	//
+	// ExecSearchPath REPLACES the default search path, it does not prepend to
+	// it (JAB-182). Listing only binDir therefore made every bare command that
+	// is NOT a jabali wrapper unresolvable — `wp`, `git`, `rsync`, `node`,
+	// `composer` — each failing 203/EXEC before the job ran a single line.
+	// Measured on a host: 5,650 silent failures in 30 days. Only `php*` worked,
+	// because those are exactly the names .jabali/bin provides, which is what
+	// made it look like the path was falling through to /usr/bin when it was
+	// not. Verified with systemd 255:
+	//
+	//   systemd-run --property=ExecSearchPath=/tmp/empty --wait wp --version
+	//     -> 203     (and bare `git` likewise, though it is in /usr/bin)
+	//   systemd-run --wait wp --version
+	//     -> runs
+	//
+	// So the wrapper dir goes first and the standard system dirs follow — the
+	// same list as Environment=PATH, built from one variable so the two cannot
+	// drift apart again. Environment=PATH is still needed separately because
+	// wp's `#!/usr/bin/env php` shebang reads the running process's PATH, not
+	// ExecSearchPath. (GH #184, #256, #299, JAB-182.)
 	binDir := "/home/" + username + "/.jabali/bin"
+	searchPath := binDir + ":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 	return fmt.Sprintf(`[Unit]
 Description=Jabali cron job %s (%s)
 After=default.target
@@ -306,8 +324,8 @@ Environment=PATH=%s
 WorkingDirectory=%%h
 %s
 `, jobID, name, condDocroot,
-		binDir,
-		binDir+":/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
+		searchPath,
+		searchPath,
 		execStart)
 }
 

--- a/panel-agent/internal/commands/cron_apply_test.go
+++ b/panel-agent/internal/commands/cron_apply_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -274,9 +275,83 @@ func TestBuildCronServiceContent(t *testing.T) {
 	// path, not Environment=PATH, so the unit must add the per-user wrapper
 	// dir via ExecSearchPath for bare `php`/`php8.5` to follow the user's
 	// pinned version instead of /usr/bin/php.
-	if !contains(content, "ExecSearchPath=/home/testuser/.jabali/bin") {
-		t.Error("cron unit must set ExecSearchPath to the per-user .jabali/bin wrapper dir")
+	//
+	// JAB-182: assert the FULL value, not just the prefix. The prefix-only
+	// assertion this replaced passed happily while ExecSearchPath listed the
+	// wrapper dir and nothing else, which is what broke every non-php cron.
+	if !contains(content, "ExecSearchPath=/home/testuser/.jabali/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin\n") {
+		t.Error("cron unit ExecSearchPath must be the wrapper dir followed by the standard system dirs")
 	}
+}
+
+// TestCronExecSearchPathIncludesSystemDirs guards a failure whose whole
+// signature was silence: 5,650 cron jobs on one host exiting 203/EXEC in 30
+// days, having run no user code at all.
+//
+// ExecSearchPath REPLACES systemd's default binary search path — it does not
+// prepend to it. Listing only /home/<user>/.jabali/bin therefore made every
+// bare command that is not a jabali-provided wrapper unresolvable. `php` and
+// `php8.5` kept working, because those are precisely the names the wrapper dir
+// supplies, so the unit looked correct while `wp`, `git`, `rsync`, `node` and
+// `composer` all died before executing a line.
+//
+// Confirmed against systemd 255 rather than inferred from the docs:
+//
+//	systemd-run --property=ExecSearchPath=/tmp/empty --wait wp --version  -> 203
+//	systemd-run --property=ExecSearchPath=/tmp/empty --wait git --version -> 203
+//	systemd-run --wait wp --version                                       -> runs
+//
+// The wrapper dir must stay FIRST (that is GH #299's pinned-version fix), and
+// the system dirs must follow.
+func TestCronExecSearchPathIncludesSystemDirs(t *testing.T) {
+	cmd := &cronvalidate.Command{Argv: []string{"wp", "cron", "event", "run", "--due-now"}}
+	content := buildCronServiceContent("job1", "Nightly", cmd, "testuser", []string{"/var/www/site1"})
+
+	searchPath := unitDirectiveValue(content, "ExecSearchPath")
+	if searchPath == "" {
+		t.Fatal("cron unit has no ExecSearchPath — bare `php` would resolve to the " +
+			"system default instead of the user's pinned version (GH #299)")
+	}
+
+	dirs := strings.Split(searchPath, ":")
+	if dirs[0] != "/home/testuser/.jabali/bin" {
+		t.Errorf("ExecSearchPath starts with %q, want the per-user wrapper dir first "+
+			"so a bare `php` follows the user's pinned version", dirs[0])
+	}
+	for _, want := range []string{"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin"} {
+		found := false
+		for _, d := range dirs {
+			if d == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("ExecSearchPath is missing %s. It REPLACES systemd's default "+
+				"search path, so anything not listed here fails 203/EXEC before the "+
+				"job runs — wp, git, rsync, node, composer (JAB-182). Got: %s",
+				want, searchPath)
+		}
+	}
+
+	// The two must not drift: ExecSearchPath resolves the ExecStart binary,
+	// Environment=PATH is what a `#!/usr/bin/env php` shebang reads. A command
+	// resolvable by one and not the other fails in a way that looks like the
+	// script is broken.
+	if envPath := unitDirectiveValue(content, "Environment"); envPath != "PATH="+searchPath {
+		t.Errorf("Environment=%q and ExecSearchPath=%q disagree; a command found by "+
+			"one and not the other fails confusingly", envPath, searchPath)
+	}
+}
+
+// unitDirectiveValue returns the value of the first `key=` line in a systemd
+// unit, or "" when absent.
+func unitDirectiveValue(unit, key string) string {
+	for _, line := range strings.Split(unit, "\n") {
+		if strings.HasPrefix(line, key+"=") {
+			return strings.TrimPrefix(line, key+"=")
+		}
+	}
+	return ""
 }
 
 func TestBuildCronTimerContent(t *testing.T) {


### PR DESCRIPTION
`ExecSearchPath` **replaces** systemd's default binary search path — it does
not prepend to it. The cron unit listed only `/home/<user>/.jabali/bin`, so
every bare command that isn't a jabali-provided wrapper was unresolvable and
the job died 203/EXEC before running a line. One host logged **5,650 such
failures in 30 days**.

What hid it: `php` and `php8.5` *did* work, because those are exactly the
names `.jabali/bin` supplies — which is the whole point of GH #299. Everything
else a cron actually runs (`wp`, `git`, `rsync`, `node`, `composer`) did not.
The source comment even claimed the path fell "through to /usr/bin for
anything not there", which was never true.

Wrapper dir stays first (GH #299's pinned-version behaviour is unchanged),
standard system dirs follow, both built from one variable shared with
`Environment=PATH` so they can't drift apart again.

## Verification — on a real box, systemd 255

Reproduced the failure:

```
ExecSearchPath=/tmp/empty + bare wp   -> 203
ExecSearchPath=/tmp/empty + bare git  -> 203   (and git IS in /usr/bin)
no ExecSearchPath        + bare wp    -> runs
```

Then confirmed the fix with a unit file carrying the exact string this code
now emits:

```ini
ExecSearchPath=/home/nosuchuser/.jabali/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
ExecStart=git --version   # ran
ExecStart=wp --version    # ran — exited 1 on wp-cli's own root warning,
                          # which is proof it executed
```

A missing first entry is not an error: systemd accepts the list and finds
nothing there, which is what a user without a wrapper dir needs.

⚠️ **If you re-check this yourself:** `systemd-run --property=ExecSearchPath=a:b`
rejects *any* colon list as `Invalid ExecSearchPath` even when every directory
exists. That's a transient-property parsing quirk, not unit-file semantics.
Verify this directive with a real unit file or you will conclude the opposite.

## Why review didn't catch it

The old test asserted only the `ExecSearchPath=/home/testuser/.jabali/bin`
**prefix** — so a value consisting of nothing else passed. It now pins the
full value, plus a second test asserts each system dir is present and that
`ExecSearchPath` and `Environment=PATH` agree.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt` clean on the two touched files
- [x] Full `panel-agent/internal/commands` suite passes
- [x] Failure reproduced and fix confirmed on a real box (above)
- [x] Rebased onto `origin/main`, tests re-run after