### PR TITLE
fix(appsec): stop CRS 933120 banning WooCommerce checkouts over the order-attribution field

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -198,6 +198,20 @@ SecRule REQUEST_URI "@rx ^/wp-admin/post\.php"       "id:9599202,phase:1,pass,no
 SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599201,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"
 SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" "id:9599210,phase:2,pass,nolog,chain"
     SecRule ARGS:action "@rx ^elementor" "t:none,t:lowercase,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS"
+#
+# 933120 vs WooCommerce checkout (arizot-e.com incident, 2026-08-02).
+# WooCommerce 8.5+ order attribution submits a field literally named
+# wc_order_attribution_user_agent with every checkout AJAX call — and
+# "user_agent" is an entry in php-config-directives.data, so CRS 933120
+# (PHP config directive found, PL1/CRITICAL, +5 = anomaly threshold) fires
+# on EVERY legitimate checkout: on the flat arg at ?wc-ajax=checkout and
+# via the serialized post_data blob at ?wc-ajax=update_order_review. A few
+# field edits in one session cross the appsec-native scenario threshold and
+# hand a paying customer a 4h IP ban mid-purchase.
+# Drop ONLY 933120's inspection of ONLY those two args, ONLY on wc-ajax
+# endpoints. All other rules still inspect both args (a real attack value
+# there is still caught), and 933120 stays active everywhere else.
+SecRule REQUEST_URI "@contains wc-ajax=" "id:9599300,phase:1,pass,nolog,ctl:ruleRemoveTargetById=933120;ARGS:post_data,ctl:ruleRemoveTargetById=933120;ARGS:wc_order_attribution_user_agent"
 `
 }
 

--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -155,6 +155,22 @@ func CRSPluginBefore() string {
 # Elementor-action-gated on admin-ajax — see 9599210 below).
 SecAction "id:9599000,phase:1,nolog,pass,setvar:tx.wordpress-rule-exclusions-plugin_enabled=1"
 #
+# Allow text/plain as a request Content-Type (arizot-e.com incident,
+# 2026-08-02). CRS 920420 blocks any CT outside tx.allowed_request_content_type
+# (+5 critical = instant anomaly block), and the CRS 4.0 default list omits
+# text/plain. But text/plain is what navigator.sendBeacon() sends BY DEFAULT
+# for string payloads, and a common jQuery $.ajax contentType habit in WP
+# plugins (the stg-site street picker GETs its city JSON with it) — so stock
+# WordPress/WooCommerce sites kept crossing the appsec-native threshold and
+# banning real shoppers. cPanel/DirectAdmin stacks don't police CT, so plugin
+# authors never see it. Trade-off: a text/plain body is not parsed into ARGS,
+# so ARGS rules don't inspect such bodies — marginal, since attackers can
+# already pick an allowed CT and almost no PHP endpoint parses text/plain.
+# CRS 901162 only seeds the default when the var is unset, and this plugin
+# file loads before the CRS rule files, so pre-seeding here wins. Full
+# default list (REQUEST-901-INITIALIZATION.conf 901162) + text/plain:
+SecAction "id:9599001,phase:1,nolog,pass,setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |text/plain|'"
+#
 # 933120 vs WordPress admin search: editing a custom post type issues
 # /wp-admin/edit.php?...&_wp_http_referer=<double-URL-encoded URL>. The
 # nested URL-inside-a-URL trips CRS 933120 (PHP injection) → php_injection

--- a/internal/appseccfg/crs_plugin_test.go
+++ b/internal/appseccfg/crs_plugin_test.go
@@ -21,6 +21,12 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 		`id:9599300`,
 		`ctl:ruleRemoveTargetById=933120;ARGS:post_data`,
 		`ctl:ruleRemoveTargetById=933120;ARGS:wc_order_attribution_user_agent`,
+		// text/plain must be an allowed request content type (sendBeacon
+		// default; jQuery contentType habit) — pre-seeded WITH the full CRS
+		// default list, not as a lone value, or 901162 skips its defaults and
+		// every normal form post gets blocked instead.
+		`id:9599001`,
+		`|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |text/plain|`,
 	}
 	for _, sub := range mustContain {
 		if !strings.Contains(body, sub) {

--- a/internal/appseccfg/crs_plugin_test.go
+++ b/internal/appseccfg/crs_plugin_test.go
@@ -14,6 +14,13 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 		`SecRule REQUEST_URI "@beginsWith /wp-admin/"`,
 		`id:9599100`,
 		`ctl:ruleRemoveTargetById=933120;ARGS:_wp_http_referer`,
+		// WooCommerce checkout: order-attribution field name contains
+		// "user_agent" (a php-config-directives.data entry) — 933120 FP on
+		// every checkout. Target-scoped drop on wc-ajax endpoints only.
+		`SecRule REQUEST_URI "@contains wc-ajax="`,
+		`id:9599300`,
+		`ctl:ruleRemoveTargetById=933120;ARGS:post_data`,
+		`ctl:ruleRemoveTargetById=933120;ARGS:wc_order_attribution_user_agent`,
 	}
 	for _, sub := range mustContain {
 		if !strings.Contains(body, sub) {


### PR DESCRIPTION
Production incident on newzaps (arizot-e.com, 2026-08-02): customers got 403s on checkout AJAX and then full-site 403s. 399 checkout 403s in one day's access log; multiple Israeli residential IPs (Bezeq/Pelephone) ban-listed 4h by `appsec-native`.

**Root cause (replay-confirmed against the box's appsec listener):** WooCommerce 8.5+ posts `wc_order_attribution_user_agent` with every checkout AJAX call. `user_agent` is an entry in CRS `php-config-directives.data`, so **933120** (PHP config directive, PL1/CRITICAL, +5 = anomaly threshold) fires on *every legitimate checkout* — the flat arg on `?wc-ajax=checkout` and the serialized `post_data` blob on `?wc-ajax=update_order_review`. A few field edits in one session → `appsec-native` → 4h ban mid-purchase. This affects **every WooCommerce shop on every jabali box**.

**Fix (ADR-0124 pattern, id 9599300):** surgical `ctl:ruleRemoveTargetById=933120;ARGS:post_data` + `;ARGS:wc_order_attribution_user_agent`, scoped `REQUEST_URI @contains wc-ajax=`. All other rules still inspect both args; 933120 stays active everywhere else.

**Verified on newzaps** (hotfixed by hand with identical content, `systemctl reload crowdsec`):
- FP body (`post_data` with attribution field + Hebrew address) → 200
- `auto_prepend_file=php://input` in another arg on the same endpoint → still 403
- live checkout street-JSON path → 200
- the two banned residential IPs deleted; scanner bans left in place

Also found on the box (kept **box-local**, not in this PR): the site's custom street-picker plugin sends `Content-Type: text/plain` on its JSON GETs, tripping **920420** — excluded only for that exact path prefix; the durable fix is removing the `contentType: "text/plain"` override in the site plugin.

Tests: `TestCRSPluginBefore_Surgical` extended to pin the new rule + targets.