### PR TITLE
fix(cron): edit modal keeps the job's real schedule; timestamped log lines (GH #854, #856)

### DIFF
--- a/panel-agent/internal/commands/cron_tail_log.go
+++ b/panel-agent/internal/commands/cron_tail_log.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -77,7 +78,10 @@ func cronTailLogHandler(ctx context.Context, params json.RawMessage) (any, error
 		"journalctl", "--user",
 		"-u", fmt.Sprintf("jabali-cron-%s.service", p.JobID),
 		"-n", fmt.Sprintf("%d", lines),
-		"-o", "cat",
+		// short-iso (not cat): the log is useless for "did my hourly job run
+		// at :00" questions without timestamps (GH #856). The hostname/unit
+		// prefix it adds is stripped per line below.
+		"-o", "short-iso",
 	)
 
 	var stdout, stderr bytes.Buffer
@@ -88,13 +92,32 @@ func cronTailLogHandler(ctx context.Context, params json.RawMessage) (any, error
 		// If journalctl fails (e.g., no logs yet), return empty log or error
 		// Most common: "No entries found" which is not an error condition
 		return &cronTailLogResponse{
-			Log: stdout.String(),
+			Log: stripJournalPrefix(stdout.String()),
 		}, nil
 	}
 
 	return &cronTailLogResponse{
-		Log: strings.TrimSpace(stdout.String()),
+		Log: strings.TrimSpace(stripJournalPrefix(stdout.String())),
 	}, nil
+}
+
+// journalShortISORe matches one short-iso journal line:
+// "2026-08-02T17:45:12+0300 host jabali-cron-x[123]: message". Capture the
+// timestamp and the message; drop the hostname + unit[pid] noise — the drawer
+// shows one job's log, so the unit adds nothing and steals width.
+var journalShortISORe = regexp.MustCompile(`^(\S+) \S+ [^:\[]+\[\d+\]: (.*)$`)
+
+// stripJournalPrefix rewrites "<ts> <host> <unit>[<pid>]: <msg>" lines to
+// "<ts> <msg>". Non-matching lines (journalctl notices, "-- Boot --" markers)
+// pass through untouched.
+func stripJournalPrefix(log string) string {
+	lines := strings.Split(log, "\n")
+	for i, l := range lines {
+		if m := journalShortISORe.FindStringSubmatch(l); m != nil {
+			lines[i] = m[1] + " " + m[2]
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func init() {

--- a/panel-agent/internal/commands/cron_tail_log_test.go
+++ b/panel-agent/internal/commands/cron_tail_log_test.go
@@ -97,6 +97,22 @@ func TestCronTailLogDefaultLines(t *testing.T) {
 	}
 }
 
+// GH #856: the cron log drawer needs timestamps; journalctl now runs with
+// -o short-iso and the hostname + unit[pid] prefix is stripped per line.
+func TestStripJournalPrefix(t *testing.T) {
+	in := "2026-08-02T17:45:12+0300 srv1 jabali-cron-01ABC[4242]: wp cron event run\n" +
+		"2026-08-02T17:45:13+0300 srv1 jabali-cron-01ABC[4242]: Executed the cron event\n" +
+		"-- No entries --\n" +
+		"plain line without journal shape"
+	want := "2026-08-02T17:45:12+0300 wp cron event run\n" +
+		"2026-08-02T17:45:13+0300 Executed the cron event\n" +
+		"-- No entries --\n" +
+		"plain line without journal shape"
+	if got := stripJournalPrefix(in); got != want {
+		t.Errorf("stripJournalPrefix:\n got %q\nwant %q", got, want)
+	}
+}
+
 func TestCronTailLogCustomLines(t *testing.T) {
 	currentUser := os.Getenv("USER")
 	if currentUser == "" {

--- a/panel-ui/src/shells/user/cron/CreateCronModal.tsx
+++ b/panel-ui/src/shells/user/cron/CreateCronModal.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Drawer,
   Form,
@@ -43,14 +43,26 @@ export const CreateCronModal = ({
   const { t } = useTranslation();
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
-  const [scheduleMode, setScheduleMode] = useState<string>(
-    initial ? (initial.schedule in SCHEDULE_PRESETS.map((p) => p.value) ? initial.schedule : "advanced") : "0 * * * *"
-  );
-  const [customSchedule, setCustomSchedule] = useState(
-    initial && !SCHEDULE_PRESETS.map((p) => p.value).includes(initial.schedule)
-      ? initial.schedule
-      : ""
-  );
+  const [scheduleMode, setScheduleMode] = useState<string>("0 * * * *");
+  const [customSchedule, setCustomSchedule] = useState("");
+
+  // Sync the schedule picker every time the drawer opens (GH #854). This
+  // component stays mounted across opens, so state initializers see only the
+  // very first `initial` (null on page load) — every edit then showed the
+  // "Hourly" default no matter what the job's real schedule was, and saving
+  // silently rewrote the schedule to hourly. destroyOnClose remounts only the
+  // Drawer's children (the Form), not this component's state.
+  useEffect(() => {
+    if (!open) return;
+    if (initial) {
+      const isPreset = SCHEDULE_PRESETS.some((p) => p.value === initial.schedule);
+      setScheduleMode(isPreset ? initial.schedule : "advanced");
+      setCustomSchedule(isPreset ? "" : initial.schedule);
+    } else {
+      setScheduleMode("0 * * * *");
+      setCustomSchedule("");
+    }
+  }, [open, initial]);
   const { message: antMessage } = App.useApp();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -137,7 +149,7 @@ export const CreateCronModal = ({
 
   const handleModalClose = () => {
     form.resetFields();
-    setScheduleMode(initial?.schedule || "0 * * * *");
+    setScheduleMode("0 * * * *");
     setCustomSchedule("");
     onClose();
   };


### PR DESCRIPTION
Two cron bugs reported by @johnnyq.

**GH #854 — edit modal defaults to Hourly + saving rewrites the schedule.**
The schedule picker's mode was set once in a `useState` initializer using `initial.schedule in SCHEDULE_PRESETS.map(p => p.value)` — JS `in` tests array **indexes**, not values, so it was always false. The modal also stays mounted across opens, so the initializer only ever saw the first `initial` (null on page load). Result: opening any job for edit showed "Hourly", and saving persisted `0 * * * *` over the real schedule — which is also why "cron set to every minute isn't running every minute": the user's last edit had quietly rewritten it to hourly.

Fixed with a `useEffect` keyed on `[open, initial]` that resyncs the picker each time the drawer opens (exact preset when the cron matches one, else `advanced` with the raw expression prefilled).

Confirmed on newzaps that the agent-side timer translation is correct (`* * * * *` → `OnCalendar=*-*-* *:0:00`, next run within the minute) — this was purely the edit modal.

**GH #856 — cron log has no timestamps.**
`journalctl` ran with `-o cat`. Switched to `-o short-iso`; `stripJournalPrefix` trims the hostname + `unit[pid]` prefix each line gains, leaving `<iso-ts> <message>`. Unit test covers the strip + passthrough of non-journal lines.

**Tests:** `TestStripJournalPrefix` (agent) green; `tsc -b` + `npm run build` clean.