### PR TITLE
fix(page-templates): reject an unparsable default-index template at save time (GH #860)

### DIFF
--- a/panel-api/internal/api/page_templates.go
+++ b/panel-api/internal/api/page_templates.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"text/template"
 
 	"github.com/gin-gonic/gin"
 
@@ -12,6 +13,28 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
+
+// validatePageTemplateContent rejects a body that the agent could not use.
+// GH #860: domain_default_index is expanded as a Go text/template at
+// docroot-write time; if it fails to parse, the agent silently falls back to
+// the built-in default, so an operator's edit "did nothing". Validating at
+// SAVE time makes that failure visible (the editor shows the parse error)
+// instead of a silent no-op on every future domain. Error pages are static
+// HTML, so they are not parsed. Returns "" when the content is acceptable.
+func validatePageTemplateContent(key, content string) string {
+	if key != models.PageTemplateDomainDefaultIndex {
+		return ""
+	}
+	if _, err := template.New("index").Parse(content); err != nil {
+		// The Go error carries the position (line/token). Prefix it so the
+		// toast reads as guidance, not a bare parser dump — the usual cause is
+		// a literal {{ }} that isn't one of the supported placeholders.
+		return "Template not saved — it has a syntax error. Only {{.Domain}}, " +
+			"{{.Username}} and {{.DocRoot}} are valid; a literal {{ }} from " +
+			"another framework will break it. Details: " + err.Error()
+	}
+	return ""
+}
 
 // MaxPageTemplateBytes caps the accepted template body. Large enough
 // for complex error pages with inline CSS; small enough that an
@@ -163,6 +186,12 @@ func (h *pageTemplatesHandler) update(c *gin.Context) {
 	}
 	if len(req.Content) > MaxPageTemplateBytes {
 		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "content too large"})
+		return
+	}
+	if detail := validatePageTemplateContent(key, req.Content); detail != "" {
+		// GH #860: reject a template that won't parse instead of letting the
+		// agent silently fall back to the built-in default on every new domain.
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "template_parse_error", "detail": detail})
 		return
 	}
 	if err := h.cfg.Repo.Upsert(c.Request.Context(), key, req.Content); err != nil {

--- a/panel-api/internal/api/page_templates_parse_test.go
+++ b/panel-api/internal/api/page_templates_parse_test.go
@@ -1,0 +1,99 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakePageTemplateRepo records the last upserted content so tests can assert a
+// rejected save never reached the store.
+type fakePageTemplateRepo struct {
+	lastContent  string
+	upsertCalled bool
+}
+
+func (f *fakePageTemplateRepo) List(context.Context) ([]models.PageTemplate, error) {
+	return nil, nil
+}
+func (f *fakePageTemplateRepo) Get(context.Context, string) (*models.PageTemplate, error) {
+	return &models.PageTemplate{}, nil
+}
+func (f *fakePageTemplateRepo) Upsert(_ context.Context, _, content string) error {
+	f.upsertCalled = true
+	f.lastContent = content
+	return nil
+}
+func (f *fakePageTemplateRepo) EnsureDefaults(context.Context) (int, error) { return 0, nil }
+
+func newPageTemplatesRouter(repo *fakePageTemplateRepo) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(injectAdminClaims(true))
+	api.RegisterPageTemplatesRoutes(v1, api.PageTemplatesHandlerConfig{Repo: repo})
+	return r
+}
+
+// GH #860: a domain_default_index body that won't parse as a Go template must
+// be rejected at save time — not silently accepted and then dropped by the
+// agent (which falls back to its built-in default on every new domain).
+func TestPageTemplates_RejectsUnparsableDefaultIndex(t *testing.T) {
+	repo := &fakePageTemplateRepo{}
+	r := newPageTemplatesRouter(repo)
+
+	body := `{"content":"<h1>{{.Domain}}</h1><script>var x={{ oops }}</script>"}`
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/admin/settings/page-templates/"+models.PageTemplateDomainDefaultIndex,
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "template_parse_error")
+	assert.False(t, repo.upsertCalled, "a broken template must not be persisted")
+}
+
+// A valid template with the supported placeholders saves normally.
+func TestPageTemplates_AcceptsValidDefaultIndex(t *testing.T) {
+	repo := &fakePageTemplateRepo{}
+	r := newPageTemplatesRouter(repo)
+
+	body := `{"content":"<h1>{{.Domain}}</h1><p>{{.DocRoot}} {{.Username}}</p>"}`
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/admin/settings/page-templates/"+models.PageTemplateDomainDefaultIndex,
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.upsertCalled)
+}
+
+// Error pages are static HTML, not Go templates — a literal {{ }} in one is
+// content, not a parse target, and must save without objection.
+func TestPageTemplates_ErrorPageAllowsBraces(t *testing.T) {
+	repo := &fakePageTemplateRepo{}
+	r := newPageTemplatesRouter(repo)
+
+	body := `{"content":"<html><body>404 {{ not a template }}</body></html>"}`
+	req := httptest.NewRequest(http.MethodPatch,
+		"/api/v1/admin/settings/page-templates/"+models.PageTemplateError404,
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.upsertCalled)
+}


### PR DESCRIPTION
Part 1 of #860 — the "I edited a page template but new domains still serve the old/default one" bug reported by @lxsdevcode.

**Cause:** `domain_default_index` is expanded as a Go `text/template` when the agent writes `index.html` into a fresh docroot. If the saved body fails to parse, `writeDefaultIndex` silently falls back to the built-in default. So a template containing a literal `{{ }}` that isn't `{{.Domain}}`/`{{.Username}}`/`{{.DocRoot}}` (a JS/Vue/Handlebars snippet, an unclosed brace) was accepted by the editor but produced the default on every new domain — looking exactly like "my edit was ignored".

**Fix:** validate the parse in the PATCH handler, for `domain_default_index` only (error pages are static HTML — a literal `{{ }}` there is content, not a template target). A body that won't parse is rejected with `422 template_parse_error` and a message naming the supported placeholders, so the failure is visible in the editor instead of a silent no-op later. The broken body never reaches the store.

**Tests:** unparsable default-index → 422, not persisted; valid placeholders → 204; error page with literal `{{ }}` → 204 (not parsed).

Not in this PR (separate feature, tracked on the issue): template types for **Disabled** and **Unconfigured** domains — those pages are served from fixed markup today, so wiring them to the template store is its own change.