### PR TITLE
sec(release): verify a minisign signature in jabali update; document the trust root (JAB-190)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ concurrency:
   group: release-main
   cancel-in-progress: true
 
+# Signing is NOT done here, on purpose (JAB-190 / ADR-0162). The release key is
+# held offline so that a compromise of this workflow, its token, or the release
+# storage cannot produce artifacts that boxes will install. After this workflow
+# publishes, run `tools/sign-release.sh <tag>` on the machine holding the key.
 permissions:
   contents: write
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,6 +103,14 @@ expected="$(awk '{print $1}' "$tmp/release.sha256")"
 actual="$(sha256sum "$tmp/release.tar.gz" | awk '{print $1}')"
 [[ "$expected" == "$actual" ]] || die "checksum mismatch (expected $expected, got $actual)"
 log "checksum verified"
+# NOTE (JAB-190 / ADR-0162): this checksum comes from the SAME origin as the
+# tarball, so it proves the download was not corrupted — not that the release is
+# genuine. Anyone who can publish a release can publish a matching .sha256. A
+# fresh `curl | bash` install is trust-on-first-use by nature: verifying a
+# signature here would mean first fetching a verifier, which needs trust of its
+# own. `jabali update` DOES verify a minisign signature against a key embedded
+# in the panel binary, so every update after this install is cryptographically
+# checked even though this first fetch is not.
 
 # Extract the whole bin/ — not just the installer. GH #731: the tarball already
 # contains compiled jabali-panel / jabali-agent / jabali-ssh-shell /

--- a/docs/adr/0162-release-signing.md
+++ b/docs/adr/0162-release-signing.md
@@ -1,0 +1,135 @@
+# ADR-0162 — Release artifact signing and the update trust root
+
+- Status: Accepted
+- Date: 2026-08-02
+- Tracks: JAB-190
+
+## Context
+
+Both install paths verified the release tarball against a SHA-256 sidecar
+fetched from **the same origin as the tarball itself**:
+
+- `bootstrap.sh` — fresh install via `curl -fsSL https://get.jabali-panel.com | sudo bash`
+- `panel-api/cmd/server/update_release.go` — every `jabali update`
+
+Both hard-fail on mismatch, and the update path explicitly refuses to fall back
+to a source build when the checksum fails. The control was implemented
+correctly. It just answers a different question than the one that matters.
+
+A same-origin checksum detects **corruption and truncation**. It cannot detect a
+**malicious publisher**, because anyone who can publish a release can publish a
+matching `.sha256` next to a trojaned tarball. The tarball ships prebuilt
+binaries including `bin/jabali-agent`, which runs as root. A trojaned release is
+therefore root on every host that installs or updates, with no further
+exploitation required.
+
+This was never a coding defect — it was an unstated trust assumption. The reason
+to resolve it is that the entire update path rested on it and it was written
+down nowhere.
+
+## Decision
+
+**Releases are signed with an Ed25519 key held offline, and `jabali update`
+verifies that signature before installing anything.**
+
+1. **Format: minisign.** The operator signs with the standard, audited minisign
+   CLI, which keeps the private key password-protected. Only the *verifier*
+   lives in this repository (`internal/releasesig`) — roughly a hundred lines
+   that parse the signature, check the key ID, and check two Ed25519 signatures.
+
+2. **The private key never enters CI.** Nothing in this repository and nothing
+   in GitHub Actions can produce a valid signature. This is the property that
+   makes the signature worth having: it survives a compromise of the Actions
+   pipeline, the release storage, or a maintainer's GitHub account, none of
+   which the checksum survived.
+
+3. **Verification is mandatory, and its state is set at compile time.** The
+   public key is a constant in the panel binary. While it is empty, verification
+   is off and the tarball is accepted on its checksum alone — the pre-JAB-190
+   posture. Once it is populated, verification is unconditional: a **missing**
+   `.minisig` is a hard failure, not a skip.
+
+   That distinction is the point. The issue warned that "a signature check that
+   silently skips when the signature is absent provides no defense", and it is
+   right — an attacker substituting the tarball also controls whether a
+   signature is present, so *absent* must never mean *fine*. Compile-time is not
+   reachable by an attacker; runtime absence is.
+
+4. **Signatures are checked before extraction.** Extracting first would run
+   `tar` over attacker-controlled bytes and write them to disk on the strength
+   of a checksum alone.
+
+## What this does not cover
+
+**Fresh installs remain trust-on-first-use.** `curl | bash` on a bare Debian box
+has no verifier: to check a signature you must first fetch minisign or cosign,
+which itself needs trust. Fetching a verifier from an independent origin
+(sigstore, Debian) does raise the bar — two separate compromises instead of one
+— but it does not eliminate TOFU, it relocates it. Stating that plainly is
+better than implying `bootstrap.sh` is verified when it is not.
+
+The asymmetry is deliberate. The install happens once, with an operator present,
+often on a host they just created. The **update** path runs unattended on every
+box forever, and that is where the recurring exposure is. It is also the path
+that can be fixed cleanly: `jabali update` runs an already-installed,
+already-trusted binary, so the key can be embedded and the check done with the
+standard library — no external tool, no bootstrap problem.
+
+**A compromised release with no signature is refused, not silently accepted** —
+but only on builds that have the key. A box still running an older binary
+verifies nothing, so the fleet becomes protected as it updates, not at the
+moment this lands.
+
+## Release procedure
+
+1. CI builds and publishes the release as it does today (tarball + `.sha256`).
+2. On the machine holding the key: `tools/sign-release.sh release-<short-sha>`.
+   It re-verifies the checksum locally before signing — signing a corrupted
+   artifact is worse than not signing — signs every `.tar.gz` on the release,
+   uploads each `.minisig`, and verifies its own output against the public key.
+3. Both the per-commit asset and the fixed-name `jabali-release.tar.gz` copy get
+   signed. `jabali update` fetches one or the other depending on how it resolved
+   the release, so signing only one would leave part of the fleet unable to
+   verify.
+
+**There is a window between publish and signature upload.** A box updating in
+that window fetches a tarball whose `.minisig` does not exist yet and refuses to
+install — it stays on its current build and retries later, which is the safe
+failure. Keep the window short; publishing as a draft and releasing after
+signing removes it entirely and is the better long-term shape.
+
+## Key ceremony
+
+```
+minisign -G -p jabali-release.pub -s jabali-release.key   # offline machine
+```
+
+- Private key: offline, password-protected, backed up separately from any
+  machine that can publish a release.
+- Public key: the base64 line from the `.pub` file goes into
+  `releaseSigningPublicKey` in `panel-api/cmd/server/update_release_signature.go`.
+
+**Rotation:** a box trusts exactly one key, so a rotation must ship in a binary
+before the first release signed with the new key. Sequence: publish the new
+public key in a release signed with the *old* key, let the fleet update onto it,
+then switch signing. Rotating in the other order strands every box on
+`ErrKeyMismatch` — which the error message calls out explicitly, since a
+rotation that skipped a step and an attack look identical from the box.
+
+## Alternatives considered
+
+**Sigstore / cosign keyless.** No key custody and a public transparency log,
+which is genuinely attractive. Rejected as the primary control because it signs
+with the Actions OIDC identity — so a compromised workflow or token produces
+valid signatures, and that is precisely the scenario driving this ADR. Worth
+revisiting *in addition* for the transparency log.
+
+**Key in a GitHub secret.** No release-time manual step and no publish/sign
+window. Rejected for the same reason: it puts the key inside the blast radius it
+is supposed to survive. Releases here are infrequent enough that the manual step
+is cheap.
+
+**Accept and document only.** A legitimate option, and the honest default for
+most self-hosted panels. Rejected because the marginal cost here was small: the
+verifier is stdlib-only, the signing tool is a shell script, and the update path
+is high-value enough to justify both.

--- a/internal/releasesig/verify.go
+++ b/internal/releasesig/verify.go
@@ -1,0 +1,171 @@
+// Package releasesig verifies minisign signatures on release artifacts.
+//
+// WHY THIS EXISTS (JAB-190). Both install paths verified the release tarball
+// against a SHA-256 sidecar fetched from the SAME origin as the tarball. That
+// detects corruption and truncation, not a malicious publisher: anyone able to
+// publish a GitHub release can upload a matching .sha256 next to a trojaned
+// tarball and every box accepts it. The tarball carries bin/jabali-agent, so a
+// trojaned release is root on every host that installs or updates, with no
+// further exploitation needed.
+//
+// A signature moves the trust root off the artifact host. The private key lives
+// offline — never in CI — so compromising the Actions pipeline or the release
+// storage is no longer enough to ship code that boxes will run.
+//
+// WHY MINISIGN RATHER THAN A BESPOKE FORMAT: the operator signs with the
+// standard, audited minisign CLI, which keeps the private key password-
+// protected and gives a well-specified format. Only the VERIFIER lives here,
+// and it is deliberately small: parse, check the key ID, check two Ed25519
+// signatures. Signing stays out of this codebase entirely, which is the point —
+// nothing in the repo or in CI can produce a valid signature.
+package releasesig
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// Errors callers may want to distinguish. A missing signature is deliberately
+// NOT a distinct "skip me" case — see Verify.
+var (
+	ErrMalformedKey = errors.New("releasesig: malformed public key")
+	ErrMalformedSig = errors.New("releasesig: malformed signature")
+	ErrKeyMismatch  = errors.New("releasesig: signature was made by a different key")
+	ErrBadSignature = errors.New("releasesig: signature does not match the file")
+)
+
+const (
+	algPure      = "Ed" // signature over the file bytes
+	algPrehashed = "ED" // signature over BLAKE2b-512 of the file bytes
+)
+
+// PublicKey is a parsed minisign public key.
+type PublicKey struct {
+	keyID [8]byte
+	key   ed25519.PublicKey
+}
+
+// ParsePublicKey accepts either a full minisign .pub file (comment line +
+// base64 line) or the bare base64 line on its own, which is the form embedded
+// in the binary.
+func ParsePublicKey(s string) (*PublicKey, error) {
+	line := ""
+	for _, l := range strings.Split(strings.TrimSpace(s), "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" || strings.HasPrefix(l, "untrusted comment:") {
+			continue
+		}
+		line = l
+		break
+	}
+	if line == "" {
+		return nil, fmt.Errorf("%w: no base64 payload", ErrMalformedKey)
+	}
+	raw, err := base64.StdEncoding.DecodeString(line)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrMalformedKey, err)
+	}
+	// 2-byte algorithm + 8-byte key ID + 32-byte Ed25519 key.
+	if len(raw) != 2+8+ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: got %d bytes, want %d", ErrMalformedKey, len(raw), 2+8+ed25519.PublicKeySize)
+	}
+	if string(raw[:2]) != algPure {
+		return nil, fmt.Errorf("%w: unsupported algorithm %q", ErrMalformedKey, raw[:2])
+	}
+	pk := &PublicKey{key: ed25519.PublicKey(raw[10:])}
+	copy(pk.keyID[:], raw[2:10])
+	return pk, nil
+}
+
+// Verify checks sigFile (the contents of a minisign .minisig) against the
+// artifact bytes.
+//
+// There is no "signature absent, carry on" path here by design: the caller
+// decides whether signatures are required, and when they are, a missing file is
+// a hard failure at the call site. A verifier that silently passes when the
+// signature is missing provides no defence at all, since the attacker
+// substituting the artifact also controls whether a signature is present.
+func (pk *PublicKey) Verify(artifact []byte, sigFile string) error {
+	if pk == nil || len(pk.key) != ed25519.PublicKeySize {
+		return ErrMalformedKey
+	}
+	sigLine, trustedComment, globalLine, err := parseSigFile(sigFile)
+	if err != nil {
+		return err
+	}
+	raw, err := base64.StdEncoding.DecodeString(sigLine)
+	if err != nil {
+		return fmt.Errorf("%w: signature line: %v", ErrMalformedSig, err)
+	}
+	if len(raw) != 2+8+ed25519.SignatureSize {
+		return fmt.Errorf("%w: signature is %d bytes, want %d", ErrMalformedSig, len(raw), 2+8+ed25519.SignatureSize)
+	}
+	alg := string(raw[:2])
+	if !bytes.Equal(raw[2:10], pk.keyID[:]) {
+		// Names the situation rather than "bad signature": a key rotation that
+		// forgot to re-sign looks identical to an attack otherwise.
+		return fmt.Errorf("%w: signature key ID %x, trusted key ID %x", ErrKeyMismatch, raw[2:10], pk.keyID)
+	}
+	sig := raw[10:]
+
+	var signed []byte
+	switch alg {
+	case algPure:
+		signed = artifact
+	case algPrehashed:
+		h := blake2b.Sum512(artifact)
+		signed = h[:]
+	default:
+		return fmt.Errorf("%w: unsupported algorithm %q", ErrMalformedSig, alg)
+	}
+	if !ed25519.Verify(pk.key, signed, sig) {
+		return ErrBadSignature
+	}
+
+	// The trusted comment is covered by a second signature over
+	// (signature || comment). Without checking it, the comment could be
+	// rewritten at will — and it is the field operators actually read.
+	global, err := base64.StdEncoding.DecodeString(globalLine)
+	if err != nil {
+		return fmt.Errorf("%w: global signature: %v", ErrMalformedSig, err)
+	}
+	if len(global) != ed25519.SignatureSize {
+		return fmt.Errorf("%w: global signature is %d bytes, want %d", ErrMalformedSig, len(global), ed25519.SignatureSize)
+	}
+	if !ed25519.Verify(pk.key, append(append([]byte{}, sig...), []byte(trustedComment)...), global) {
+		return fmt.Errorf("%w: trusted comment is not covered by the global signature", ErrBadSignature)
+	}
+	return nil
+}
+
+// parseSigFile pulls the four fields out of a .minisig:
+//
+//	untrusted comment: <text>
+//	<base64 signature>
+//	trusted comment: <text>
+//	<base64 global signature>
+func parseSigFile(s string) (sigLine, trustedComment, globalLine string, err error) {
+	lines := strings.Split(strings.ReplaceAll(strings.TrimSpace(s), "\r\n", "\n"), "\n")
+	if len(lines) < 4 {
+		return "", "", "", fmt.Errorf("%w: want 4 lines, got %d", ErrMalformedSig, len(lines))
+	}
+	sigLine = strings.TrimSpace(lines[1])
+	const marker = "trusted comment:"
+	third := strings.TrimSpace(lines[2])
+	if !strings.HasPrefix(third, marker) {
+		return "", "", "", fmt.Errorf("%w: third line is not a trusted comment", ErrMalformedSig)
+	}
+	trustedComment = strings.TrimPrefix(third, marker)
+	trustedComment = strings.TrimPrefix(trustedComment, " ")
+	globalLine = strings.TrimSpace(lines[3])
+	if sigLine == "" || globalLine == "" {
+		return "", "", "", fmt.Errorf("%w: empty signature line", ErrMalformedSig)
+	}
+	return sigLine, trustedComment, globalLine, nil
+}

--- a/internal/releasesig/verify_test.go
+++ b/internal/releasesig/verify_test.go
@@ -1,0 +1,183 @@
+package releasesig
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// testKeypair mints a minisign-shaped keypair and a signer. Signing lives only
+// in the test: the production code must never be able to produce a valid
+// signature, or the offline-key property is fiction.
+type testKeypair struct {
+	pubLine string
+	priv    ed25519.PrivateKey
+	keyID   [8]byte
+}
+
+func newTestKeypair(t *testing.T) testKeypair {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	var id [8]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		t.Fatalf("key id: %v", err)
+	}
+	raw := append(append([]byte(algPure), id[:]...), pub...)
+	return testKeypair{pubLine: base64.StdEncoding.EncodeToString(raw), priv: priv, keyID: id}
+}
+
+// sign produces a .minisig exactly as the minisign CLI would.
+func (k testKeypair) sign(artifact []byte, alg, trustedComment string) string {
+	signed := artifact
+	if alg == algPrehashed {
+		h := blake2b.Sum512(artifact)
+		signed = h[:]
+	}
+	sig := ed25519.Sign(k.priv, signed)
+	sigLine := base64.StdEncoding.EncodeToString(append(append([]byte(alg), k.keyID[:]...), sig...))
+	global := ed25519.Sign(k.priv, append(append([]byte{}, sig...), []byte(trustedComment)...))
+	return fmt.Sprintf("untrusted comment: signature from jabali release key\n%s\ntrusted comment: %s\n%s\n",
+		sigLine, trustedComment, base64.StdEncoding.EncodeToString(global))
+}
+
+func TestVerifyAcceptsGenuineSignature(t *testing.T) {
+	t.Parallel()
+	k := newTestKeypair(t)
+	pk, err := ParsePublicKey(k.pubLine)
+	if err != nil {
+		t.Fatalf("parse key: %v", err)
+	}
+	artifact := []byte("a release tarball's bytes")
+
+	// minisign defaults to prehashed these days but still emits legacy pure
+	// signatures with -S on older versions; both must verify.
+	for _, alg := range []string{algPure, algPrehashed} {
+		if err := pk.Verify(artifact, k.sign(artifact, alg, "timestamp:1 file:jabali-release.tar.gz")); err != nil {
+			t.Errorf("alg %s: genuine signature rejected: %v", alg, err)
+		}
+	}
+}
+
+// The whole point: a tampered artifact must fail even though the signature file
+// is perfectly well-formed.
+func TestVerifyRejectsTamperedArtifact(t *testing.T) {
+	t.Parallel()
+	k := newTestKeypair(t)
+	pk, _ := ParsePublicKey(k.pubLine)
+	sig := k.sign([]byte("genuine tarball"), algPrehashed, "timestamp:1")
+
+	if err := pk.Verify([]byte("trojaned tarball"), sig); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("tampered artifact must fail with ErrBadSignature, got %v", err)
+	}
+}
+
+// An attacker who can publish releases can also publish a signature — made with
+// THEIR key. Only the embedded key may satisfy the check.
+func TestVerifyRejectsSignatureFromAnotherKey(t *testing.T) {
+	t.Parallel()
+	trusted := newTestKeypair(t)
+	attacker := newTestKeypair(t)
+	pk, _ := ParsePublicKey(trusted.pubLine)
+	artifact := []byte("trojaned tarball")
+
+	err := pk.Verify(artifact, attacker.sign(artifact, algPrehashed, "timestamp:1"))
+	if !errors.Is(err, ErrKeyMismatch) {
+		t.Errorf("a signature from an untrusted key must be refused, got %v", err)
+	}
+}
+
+// Same key ID as ours but a different private key — the key-ID check alone must
+// not be what carries the security.
+func TestVerifyRejectsForgedKeyID(t *testing.T) {
+	t.Parallel()
+	trusted := newTestKeypair(t)
+	forger := newTestKeypair(t)
+	forger.keyID = trusted.keyID // pretend to be us
+	pk, _ := ParsePublicKey(trusted.pubLine)
+	artifact := []byte("trojaned tarball")
+
+	if err := pk.Verify(artifact, forger.sign(artifact, algPrehashed, "timestamp:1")); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("matching key ID with a different key must still fail, got %v", err)
+	}
+}
+
+// The trusted comment is what an operator reads when inspecting a release, so
+// it has to be covered by the global signature rather than free-form text.
+func TestVerifyRejectsRewrittenTrustedComment(t *testing.T) {
+	t.Parallel()
+	k := newTestKeypair(t)
+	pk, _ := ParsePublicKey(k.pubLine)
+	artifact := []byte("tarball")
+	sig := k.sign(artifact, algPrehashed, "timestamp:1 file:jabali-release.tar.gz")
+
+	tampered := strings.Replace(sig, "file:jabali-release.tar.gz", "file:something-else.tar.gz", 1)
+	if tampered == sig {
+		t.Fatal("test did not modify the comment")
+	}
+	if err := pk.Verify(artifact, tampered); !errors.Is(err, ErrBadSignature) {
+		t.Errorf("a rewritten trusted comment must fail, got %v", err)
+	}
+}
+
+func TestVerifyRejectsMalformedInput(t *testing.T) {
+	t.Parallel()
+	k := newTestKeypair(t)
+	pk, _ := ParsePublicKey(k.pubLine)
+
+	for name, sig := range map[string]string{
+		"empty":            "",
+		"too few lines":    "untrusted comment: x\nAAAA\n",
+		"not base64":       "untrusted comment: x\n!!!!\ntrusted comment: t\nAAAA\n",
+		"missing trusted":  "untrusted comment: x\nAAAA\nnope\nAAAA\n",
+		"truncated sig":    "untrusted comment: x\n" + base64.StdEncoding.EncodeToString([]byte("Ed")) + "\ntrusted comment: t\nAAAA\n",
+		"empty sig line":   "untrusted comment: x\n\ntrusted comment: t\nAAAA\n",
+		"whitespace only ": "   \n \n \n \n",
+	} {
+		if err := pk.Verify([]byte("tarball"), sig); err == nil {
+			t.Errorf("%s: malformed signature accepted", name)
+		}
+	}
+}
+
+func TestParsePublicKeyRejectsGarbage(t *testing.T) {
+	t.Parallel()
+	for name, in := range map[string]string{
+		"empty":            "",
+		"comment only":     "untrusted comment: jabali\n",
+		"not base64":       "!!!!not-base64!!!!",
+		"wrong length":     base64.StdEncoding.EncodeToString([]byte("Edshort")),
+		"wrong algorithm":  base64.StdEncoding.EncodeToString(append(append([]byte("XX"), make([]byte, 8)...), make([]byte, 32)...)),
+		"key from nowhere": "AAAA",
+	} {
+		if _, err := ParsePublicKey(in); err == nil {
+			t.Errorf("%s: garbage accepted as a public key", name)
+		}
+	}
+}
+
+// The embedded form is the bare base64 line; the on-disk form has a comment
+// header. Both must parse to the same key.
+func TestParsePublicKeyAcceptsBothForms(t *testing.T) {
+	t.Parallel()
+	k := newTestKeypair(t)
+	bare, err := ParsePublicKey(k.pubLine)
+	if err != nil {
+		t.Fatalf("bare: %v", err)
+	}
+	full, err := ParsePublicKey("untrusted comment: minisign public key ABC\n" + k.pubLine + "\n")
+	if err != nil {
+		t.Fatalf("full: %v", err)
+	}
+	if !bare.key.Equal(full.key) || bare.keyID != full.keyID {
+		t.Error("the .pub file and the embedded line must parse to the same key")
+	}
+}

--- a/panel-api/cmd/server/update_release.go
+++ b/panel-api/cmd/server/update_release.go
@@ -186,6 +186,16 @@ func installFromRelease(ctx context.Context, repoDir string, log func(string, ..
 		}
 		log("release: sha256 verified")
 
+		// JAB-190: the sha256 sidecar comes from the same origin as the
+		// tarball, so it proves the download was not corrupted and nothing
+		// more — whoever can publish one can publish the other. The signature
+		// is checked here, BEFORE extraction, so attacker-controlled bytes are
+		// never written to disk by tar on the strength of a checksum alone.
+		// No-op on builds with no embedded key; mandatory once there is one.
+		if err := verifyReleaseSignature(ctx, tarPath, releaseSignatureURL(tarURL), log); err != nil {
+			return "", false, fmt.Errorf("release: %w", err)
+		}
+
 		extractDir := filepath.Join(dir, "extracted")
 		if err := os.Mkdir(extractDir, 0o755); err != nil {
 			return "", false, fmt.Errorf("release: mkdir extract: %w", err)

--- a/panel-api/cmd/server/update_release_signature.go
+++ b/panel-api/cmd/server/update_release_signature.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/releasesig"
+)
+
+// releaseSigningPublicKey is the minisign public key releases are signed with —
+// the bare base64 line from the .pub file, WITHOUT the comment header.
+//
+// EMPTY means signature verification is not yet in force: the tarball is
+// accepted on its sha256 alone, which is where this project stood before
+// JAB-190. That is a compile-time state, not a runtime one — an attacker cannot
+// reach it by omitting a file, which is the failure mode the issue specifically
+// called out ("a signature check that silently skips when the signature is
+// absent provides no defense"). Once this constant is populated, verification is
+// unconditional and a MISSING signature is a hard failure.
+//
+// The matching private key is held offline and never enters CI. Nothing in this
+// repository can produce a signature; see docs/adr/0162-release-signing.md for
+// the key ceremony and the release procedure.
+const releaseSigningPublicKey = ""
+
+// releaseSignatureRequired reports whether this build enforces signatures.
+func releaseSignatureRequired() bool {
+	return strings.TrimSpace(releaseSigningPublicKey) != ""
+}
+
+// verifyReleaseSignature checks the release tarball against the embedded
+// public key.
+//
+// Called AFTER the sha256 check and BEFORE the tarball is extracted or any
+// binary is installed. The sha256 sidecar comes from the same origin as the
+// tarball, so it proves the download was not corrupted in transit and nothing
+// more; whoever can publish the tarball can publish a matching checksum. The
+// signature is what makes a trojaned release fail, because the signing key is
+// not on the machine that publishes it.
+//
+// The order matters: verify before extract. Extracting first would run tar over
+// attacker-controlled bytes and write them to disk before we had decided
+// whether to trust them.
+func verifyReleaseSignature(ctx context.Context, tarPath, sigURL string, log func(string, ...any)) error {
+	return verifyReleaseSignatureWith(ctx, releaseSigningPublicKey, tarPath, sigURL, log)
+}
+
+// verifyReleaseSignatureWith is the body of verifyReleaseSignature with the
+// trusted key passed in, so tests can exercise enforcement without a build-tag
+// dance. The production path always supplies the embedded constant.
+func verifyReleaseSignatureWith(ctx context.Context, pubKey, tarPath, sigURL string, log func(string, ...any)) error {
+	if strings.TrimSpace(pubKey) == "" {
+		return nil
+	}
+	pk, err := releasesig.ParsePublicKey(pubKey)
+	if err != nil {
+		// A build that claims to enforce signatures but cannot parse its own
+		// key must refuse to install anything, not fall through to unverified.
+		return fmt.Errorf("embedded release signing key is unusable: %w", err)
+	}
+
+	sigPath := tarPath + ".minisig"
+	dctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	if err := downloadTo(dctx, sigURL, sigPath, 60*time.Second); err != nil {
+		return fmt.Errorf("this build requires signed releases and the signature could not be fetched from %s: %w\n"+
+			"  Refusing to install an unverified tarball. If the release is genuinely unsigned it must be "+
+			"re-published with its .minisig, not installed as-is", sigURL, err)
+	}
+	sigBody, err := os.ReadFile(sigPath)
+	if err != nil {
+		return fmt.Errorf("read signature: %w", err)
+	}
+	artifact, err := os.ReadFile(tarPath)
+	if err != nil {
+		return fmt.Errorf("read tarball: %w", err)
+	}
+	if err := pk.Verify(artifact, string(sigBody)); err != nil {
+		switch {
+		case errors.Is(err, releasesig.ErrKeyMismatch):
+			return fmt.Errorf("release signature was made by a DIFFERENT key than this build trusts: %w\n"+
+				"  Either the signing key was rotated (update the panel from a source build first) or this "+
+				"tarball did not come from the jabali release process", err)
+		case errors.Is(err, releasesig.ErrBadSignature):
+			return fmt.Errorf("release signature does not match the tarball: %w\n"+
+				"  The tarball's sha256 matched its sidecar, so this is not corruption — the artifact and "+
+				"its checksum were both replaced. Do not install this release", err)
+		default:
+			return fmt.Errorf("release signature verification failed: %w", err)
+		}
+	}
+	log("release: signature verified against the embedded release key")
+	return nil
+}
+
+// releaseSignatureURL is the .minisig companion for a tarball URL. minisign
+// appends its own suffix rather than replacing the extension.
+func releaseSignatureURL(tarURL string) string { return tarURL + ".minisig" }

--- a/panel-api/cmd/server/update_release_signature_test.go
+++ b/panel-api/cmd/server/update_release_signature_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// signFor produces a minisign-format signature. Signing exists only in tests —
+// production code must not be able to make one, or the offline-key property is
+// fiction (ADR-0162).
+func signFor(t *testing.T, artifact []byte) (pubLine, sigFile string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	var id [8]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		t.Fatalf("keyid: %v", err)
+	}
+	pubLine = base64.StdEncoding.EncodeToString(append(append([]byte("Ed"), id[:]...), pub...))
+	h := blake2b.Sum512(artifact)
+	sig := ed25519.Sign(priv, h[:])
+	sigLine := base64.StdEncoding.EncodeToString(append(append([]byte("ED"), id[:]...), sig...))
+	global := ed25519.Sign(priv, append(append([]byte{}, sig...), []byte("t")...))
+	sigFile = fmt.Sprintf("untrusted comment: x\n%s\ntrusted comment: t\n%s\n",
+		sigLine, base64.StdEncoding.EncodeToString(global))
+	return pubLine, sigFile
+}
+
+// serveSig hands out the signature at any path, or 404s when body is empty —
+// standing in for a release that has not been signed.
+func serveSig(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if body == "" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func writeTarball(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "jabali-release.tar.gz")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// THE test for this change: with a key embedded, a release that has no
+// signature must NOT install.
+//
+// The issue was explicit that "a signature check that silently skips when the
+// signature is absent provides no defense" — and it is right, because an
+// attacker who substitutes the tarball also controls whether a .minisig is
+// there. Absent must never mean fine.
+func TestMissingSignatureIsFatalWhenKeyIsEmbedded(t *testing.T) {
+	tar := writeTarball(t, "trojaned tarball")
+	pubLine, _ := signFor(t, []byte("genuine tarball"))
+	srv := serveSig(t, "") // release carries no .minisig
+
+	err := verifyReleaseSignatureWith(context.Background(), pubLine, tar, srv.URL+"/x.minisig", func(string, ...any) {})
+	if err == nil {
+		t.Fatal("a missing signature must abort the update, not be treated as unsigned-and-fine")
+	}
+	if !strings.Contains(err.Error(), "signature could not be fetched") {
+		t.Errorf("error should say the signature was unavailable, got: %v", err)
+	}
+}
+
+func TestGenuineSignatureInstalls(t *testing.T) {
+	const body = "genuine tarball"
+	tar := writeTarball(t, body)
+	pubLine, sig := signFor(t, []byte(body))
+	srv := serveSig(t, sig)
+
+	var logged []string
+	if err := verifyReleaseSignatureWith(context.Background(), pubLine, tar, srv.URL+"/x.minisig",
+		func(f string, a ...any) { logged = append(logged, fmt.Sprintf(f, a...)) }); err != nil {
+		t.Fatalf("genuine signature rejected: %v", err)
+	}
+	if len(logged) == 0 || !strings.Contains(strings.Join(logged, " "), "signature verified") {
+		t.Error("a verified signature should be visible in the update output")
+	}
+}
+
+// The scenario the whole ADR is about: attacker replaces BOTH the tarball and
+// its checksum. The checksum check passes; the signature must not.
+func TestTamperedTarballWithValidChecksumFails(t *testing.T) {
+	pubLine, sig := signFor(t, []byte("genuine tarball"))
+	tar := writeTarball(t, "trojaned tarball") // checksum sidecar would match this
+	srv := serveSig(t, sig)
+
+	err := verifyReleaseSignatureWith(context.Background(), pubLine, tar, srv.URL+"/x.minisig", func(string, ...any) {})
+	if err == nil {
+		t.Fatal("a tarball that does not match its signature must be refused")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("error should name the mismatch, got: %v", err)
+	}
+}
+
+// A build whose embedded key is corrupt must refuse to install, not quietly
+// degrade to unverified — that would turn a typo into a silent loss of the
+// control.
+func TestUnparsableEmbeddedKeyRefusesToInstall(t *testing.T) {
+	const body = "tarball"
+	tar := writeTarball(t, body)
+	_, sig := signFor(t, []byte(body))
+	srv := serveSig(t, sig)
+
+	err := verifyReleaseSignatureWith(context.Background(), "!!!not-a-key!!!", tar, srv.URL+"/x.minisig", func(string, ...any) {})
+	if err == nil {
+		t.Fatal("an unusable embedded key must abort, not fall through to unverified")
+	}
+	if !strings.Contains(err.Error(), "unusable") {
+		t.Errorf("error should name the bad key, got: %v", err)
+	}
+}
+
+// With no key compiled in, this build predates enforcement: the checksum is the
+// only control and the update proceeds. That state is reachable only at build
+// time, never by an attacker omitting a file.
+func TestNoEmbeddedKeyMeansNoEnforcement(t *testing.T) {
+	tar := writeTarball(t, "anything")
+	srv := serveSig(t, "")
+	if err := verifyReleaseSignatureWith(context.Background(), "", tar, srv.URL+"/x.minisig", func(string, ...any) {}); err != nil {
+		t.Fatalf("a build with no embedded key must not require signatures: %v", err)
+	}
+}
+
+// The .minisig URL is derived by appending, not by replacing the extension —
+// getting this wrong would 404 on every release and brick updates fleet-wide.
+func TestReleaseSignatureURL(t *testing.T) {
+	for in, want := range map[string]string{
+		"https://x/jabali-release.tar.gz":         "https://x/jabali-release.tar.gz.minisig",
+		"https://x/jabali-release-1a2b3c4.tar.gz": "https://x/jabali-release-1a2b3c4.tar.gz.minisig",
+	} {
+		if got := releaseSignatureURL(in); got != want {
+			t.Errorf("releaseSignatureURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Guards the shipped default. If a key is ever committed, this test is the
+// reminder to also confirm a signed release exists — otherwise every box hard-
+// fails its next update.
+func TestShippedBuildSignatureState(t *testing.T) {
+	if releaseSignatureRequired() {
+		t.Log("NOTE: this build enforces release signatures. Every release must " +
+			"carry a .minisig made by the matching key, or updates will refuse to install.")
+	}
+}

--- a/tools/sign-release.sh
+++ b/tools/sign-release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Sign a published release with the offline jabali release key (JAB-190).
+#
+#   tools/sign-release.sh release-1a2b3c4
+#
+# Run this on the machine that holds the private key — NOT in CI, and not on a
+# server. The whole value of the signature is that the key is somewhere the
+# release pipeline cannot reach: if CI could sign, a compromised Actions token
+# would produce signatures that every box accepts, which is the attack the
+# signature exists to stop.
+#
+# What it does:
+#   1. downloads the release's tarball + .sha256
+#   2. re-verifies the checksum locally (catches a corrupted download before
+#      you sign it — signing a bad artifact is worse than not signing)
+#   3. signs the tarball with minisign
+#   4. uploads the .minisig back onto the release
+#
+# Requires: minisign, gh (authenticated), curl.
+set -euo pipefail
+
+TAG="${1:-}"
+KEY="${JABALI_MINISIGN_KEY:-$HOME/.minisign/jabali-release.key}"
+REPO="${JABALI_REPO:-shukiv/jabali-panel}"
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+log() { printf '\033[34m==>\033[0m %s\n' "$*"; }
+
+[[ -n "$TAG" ]] || die "usage: $0 <release-tag>   (e.g. release-1a2b3c4)"
+command -v minisign >/dev/null 2>&1 || die "minisign not installed (apt install minisign / brew install minisign)"
+command -v gh >/dev/null 2>&1 || die "gh not installed"
+[[ -f "$KEY" ]] || die "private key not found at $KEY — set JABALI_MINISIGN_KEY"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Sign every tarball the release carries: the per-commit asset and the
+# fixed-name copy the CDN "latest" path serves. `jabali update` fetches one or
+# the other depending on how it resolved the release, so signing only one
+# leaves half the fleet unable to verify.
+mapfile -t assets < <(gh release view "$TAG" --repo "$REPO" --json assets \
+  --jq '.assets[].name | select(endswith(".tar.gz"))')
+[[ ${#assets[@]} -gt 0 ]] || die "release $TAG has no .tar.gz assets"
+
+for asset in "${assets[@]}"; do
+  log "downloading $asset"
+  gh release download "$TAG" --repo "$REPO" --pattern "$asset" --dir "$tmp" --clobber
+  gh release download "$TAG" --repo "$REPO" --pattern "${asset}.sha256" --dir "$tmp" --clobber \
+    || die "$asset has no .sha256 — refusing to sign an artifact the release itself cannot vouch for"
+
+  log "verifying checksum before signing"
+  expected="$(awk '{print $1}' "$tmp/${asset}.sha256")"
+  actual="$(sha256sum "$tmp/$asset" | awk '{print $1}')"
+  [[ "$expected" == "$actual" ]] \
+    || die "checksum mismatch for $asset (expected $expected, got $actual) — do NOT sign this"
+
+  log "signing $asset"
+  # The trusted comment is covered by minisign's second signature, so it cannot
+  # be rewritten after the fact; put the identifying facts in it.
+  minisign -S -s "$KEY" -m "$tmp/$asset" \
+    -t "jabali release $TAG file:$asset sha256:$actual"
+
+  log "uploading ${asset}.minisig"
+  gh release upload "$TAG" --repo "$REPO" "$tmp/${asset}.minisig" --clobber
+done
+
+log "verifying the uploaded signatures against the public key"
+pub="${JABALI_MINISIGN_PUB:-$HOME/.minisign/jabali-release.pub}"
+if [[ -f "$pub" ]]; then
+  for asset in "${assets[@]}"; do
+    minisign -V -p "$pub" -m "$tmp/$asset" >/dev/null \
+      || die "self-verification failed for $asset — the release is NOT correctly signed"
+  done
+  log "all signatures verify"
+else
+  printf '\033[33mwarning:\033[0m public key not at %s — skipped self-verification\n' "$pub" >&2
+fi
+
+log "done. $TAG is signed."


### PR DESCRIPTION
Both install paths verified the release tarball against a SHA-256 sidecar fetched
from **the same origin as the tarball**. That detects corruption, not a malicious
publisher — anyone who can publish a release can publish a matching `.sha256`
beside a trojaned tarball. The tarball ships `bin/jabali-agent`, which runs as
root, so a trojaned release is root on every host that installs or updates.

## The decision

**Offline key.** The private key never enters CI. Nothing in this repository and
nothing in Actions can produce a valid signature — that's the property worth
having, because it survives a compromise of the pipeline, the release storage, or
a maintainer account, none of which the checksum survived.

That's why the two convenient options were rejected: **cosign keyless** signs
with the Actions OIDC identity and **a key in a GitHub secret** puts the key in
CI. Both sign with an identity inside the blast radius this is meant to survive.
Cost is a manual step per release, which is cheap at this release cadence.

## Mandatory, and set at compile time

The public key is a constant in the panel binary.

| state | behaviour |
|---|---|
| empty | enforcement off — the pre-JAB-190 posture |
| populated | verification unconditional; a **missing** `.minisig` is a hard failure |

The issue warned that "a signature check that silently skips when the signature
is absent provides no defense". Exactly right: an attacker substituting the
tarball also controls whether a signature is present, so *absent* must never mean
*fine*. Compile-time is not reachable by an attacker; runtime absence is. A build
whose embedded key fails to parse **refuses to install** rather than degrading to
unverified.

Verification runs **after the checksum and before extraction** — extracting first
would run `tar` over attacker-controlled bytes and write them to disk on the
strength of a checksum alone.

## What this does not cover — stated, not implied

**Fresh `curl | bash` installs stay trust-on-first-use.** A bare box has no
verifier, so checking a signature there means first fetching one, which needs
trust of its own. Fetching from an independent origin raises the bar (two
compromises instead of one) but relocates TOFU rather than removing it.

The asymmetry is deliberate: install happens once with an operator present;
update runs unattended on every box forever, and it's the path that can be fixed
cleanly because it runs an already-trusted binary. `bootstrap.sh` now says this
at the checksum line instead of leaving it implied.

The fleet becomes protected as it updates, not when this lands.

## Pieces

- `internal/releasesig` — verifier only, stdlib + blake2b. Checks both Ed25519
  signatures, including the global one covering the trusted comment, so the
  field operators actually read can't be rewritten
- `tools/sign-release.sh` — re-verifies the checksum **before** signing, signs
  every `.tar.gz` on the release (both the per-commit asset and the fixed-name
  copy `latest/download` serves — signing one would leave part of the fleet
  unable to verify), then self-verifies against the public key
- `docs/adr/0162-release-signing.md` — trust root, threat model, key ceremony,
  **rotation ordering** (a box trusts exactly one key, so the new public key must
  ship in a release signed with the *old* one), and the publish-then-sign window
- `.github/workflows/release.yml` — comment stating signing is deliberately not
  done here

## Test plan

Tests cover the cases that matter, not the happy path:

- [x] tampered tarball whose checksum still matches → refused
- [x] signature from another key → refused
- [x] forged key ID with a different private key → refused (the ID check isn't
      what carries the security)
- [x] rewritten trusted comment → refused
- [x] **missing signature with a key embedded → fatal**
- [x] unparsable embedded key → aborts, doesn't fall through
- [x] no key embedded → no enforcement (compile-time state only)
- [x] both minisign algorithms (`Ed` pure, `ED` prehashed) verify
- [x] `go build`, `go vet`, `gofmt`, full suite green; rebased on `origin/main`

Signing exists **only in the tests** — if production code could sign, the
offline-key property would be fiction.

## Not yet active

`releaseSigningPublicKey` ships empty. To turn it on: generate the keypair
offline, paste the public line into `update_release_signature.go`, and make sure
a signed release exists **before** the fleet updates onto that binary — otherwise
every box hard-fails its next update. ADR-0162 has the sequence.