### PR TITLE
fix(update): repair working-tree ownership, and stop printing raw git fatals

### DIFF
--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -352,6 +352,28 @@ func runUpdate(cmd *cobra.Command, args []string) (retErr error) {
 					repoDir+"/panel-ui/test-results "+
 					repoDir+"/panel-ui/playwright-report 2>/dev/null; "+
 					"true")
+			// …and the WORKING TREE, which the two chowns above never
+			// covered. Repo files are mode 0640/0660, so a single tracked
+			// file left owned by root breaks every git command that has to
+			// hash the tree — seen on a fresh install as a bare
+			// `fatal: cannot hash CLAUDE.md` mid-update. Tracked files only;
+			// node_modules and build caches keep whatever ownership they have.
+			rep, err := fixTrackedFileOwnership(cmd.Context(), repoDir, serviceUser)
+			if err != nil {
+				// Not fatal on its own: `git reset --hard` can still replace a
+				// root-owned file when the parent dir is writable. Say what
+				// happened rather than letting git fail cryptically later.
+				fmt.Printf("  (could not repair working-tree ownership: %v — "+
+					"a root-owned tracked file may make git fail below)\n", err)
+			} else if len(rep.Fixed) > 0 {
+				shown := rep.Fixed
+				if len(shown) > 5 {
+					shown = shown[:5]
+				}
+				fmt.Printf("  repaired ownership of %d tracked file(s) not owned by %s: %s%s\n",
+					len(rep.Fixed), serviceUser, strings.Join(shown, ", "),
+					map[bool]string{true: ", …", false: ""}[len(rep.Fixed) > len(shown)])
+			}
 			return nil
 		}},
 		{"ensure mail ACME webroot (/var/www/jabali-acme)", func() error {
@@ -439,13 +461,26 @@ chmod 0750 "$WR"`)
 			}
 			// Show diffstat of any local drift vs HEAD before we reset so
 			// the operator can see what was clobbered. Silent on clean tree.
-			_ = asUser(repoDir, "bash", "-c",
-				`d=$(git diff --stat HEAD); `+
-					`if [ -n "$d" ]; then `+
-					`  echo "  (discarding local modifications on deployment target:)"; `+
-					`  echo "$d" | sed "s/^/    /"; `+
-					`  echo "  (recover from reflog if this was a surprise: git reflog, git reset --hard <sha>)"; `+
-					`fi`)
+			// Capture rather than stream. This is a best-effort courtesy —
+			// showing the operator what drift is about to be discarded — but
+			// when it failed it printed git's raw stderr into the middle of an
+			// update with no context:
+			//
+			//   error: open("CLAUDE.md"): Permission denied
+			//   fatal: cannot hash CLAUDE.md
+			//
+			// which reads exactly like the update itself died. It had not; the
+			// reset below repaired the file and carried on. Name it instead.
+			if diffOut, diffErr := asUserOut(repoDir, "git", "diff", "--stat", "HEAD"); diffErr != nil {
+				fmt.Printf("  (could not compute local drift, continuing: %s)\n",
+					gitFailureLine(diffOut, diffErr))
+			} else if d := strings.TrimSpace(diffOut); d != "" {
+				fmt.Println("  (discarding local modifications on deployment target:)")
+				for _, l := range strings.Split(d, "\n") {
+					fmt.Println("    " + l)
+				}
+				fmt.Println("  (recover from reflog if this was a surprise: git reflog, git reset --hard <sha>)")
+			}
 			if err := asUser(repoDir, "git", "reset", "--hard", resetRef); err != nil {
 				// A reset that dies with "unable to unlink ... Permission
 				// denied" means a root-owned tracked file is in the repo (a

--- a/panel-api/cmd/server/update_repo_ownership.go
+++ b/panel-api/cmd/server/update_repo_ownership.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// repoOwnershipReport is what a self-heal pass found and fixed.
+type repoOwnershipReport struct {
+	Scanned int
+	Fixed   []string
+}
+
+// fixTrackedFileOwnership chowns TRACKED working-tree files that are not owned
+// by the service user.
+//
+// Why this exists: every git command in the updater runs as the service user
+// (`sudo -u jabali git …`), but the repo files are mode 0640/0660 — no world
+// read. So one tracked file left owned by root is enough to break git commands
+// that have to hash the working tree:
+//
+//	error: open("CLAUDE.md"): Permission denied
+//	fatal: cannot hash CLAUDE.md
+//
+// Seen on a fresh install. It is survivable — `git reset --hard` then unlinks
+// and recreates the file, because the parent directory IS writable by the
+// service user — but until that point the update prints a bare git `fatal:`
+// with no explanation, and any git operation that reads rather than replaces
+// the file fails outright.
+//
+// The existing self-heal (both here and install.sh) chowned only `.git`. That
+// covered the known case — a hand-run `git fetch` as root leaving root-owned
+// FETCH_HEAD/objects — and missed the working tree entirely.
+//
+// SCOPE IS DELIBERATE: only files git tracks. install.sh's chown carries the
+// note "so node_modules or other trees that may legitimately be group-owned
+// differently don't get clobbered", and that reasoning is right — a blanket
+// `chown -R` over the repo would take ownership of node_modules, build caches
+// and anything else living there. Tracked files are exactly the set git needs
+// to read and exactly the set `git reset --hard` will rewrite anyway.
+func fixTrackedFileOwnership(ctx context.Context, repoDir, serviceUser string) (repoOwnershipReport, error) {
+	var rep repoOwnershipReport
+
+	u, err := user.Lookup(serviceUser)
+	if err != nil {
+		return rep, fmt.Errorf("look up service user %q: %w", serviceUser, err)
+	}
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return rep, fmt.Errorf("service user %q has a non-numeric uid %q", serviceUser, u.Uid)
+	}
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return rep, fmt.Errorf("service user %q has a non-numeric gid %q", serviceUser, u.Gid)
+	}
+
+	// Run as root: enumerating the index must not itself trip over the
+	// permissions we are here to repair.
+	//
+	// -c safe.directory is required, not defensive — same reason as
+	// localHeadSHA (#841). The checkout is owned by the service user and this
+	// runs as root, so git's dubious-ownership guard refuses the repo with
+	// exit 128 and the repair silently does nothing. Verified on a box: without
+	// it this step reported "list tracked files: exit status 128" and left the
+	// root-owned file in place.
+	cmd := exec.CommandContext(ctx, "git",
+		"-c", "safe.directory="+repoDir,
+		"-C", repoDir, "ls-files", "-z")
+	out, err := cmd.Output()
+	if err != nil {
+		var stderr string
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		if stderr != "" {
+			return rep, fmt.Errorf("list tracked files: %w (%s)", err, stderr)
+		}
+		return rep, fmt.Errorf("list tracked files: %w", err)
+	}
+
+	for _, rel := range strings.Split(string(out), "\x00") {
+		if rel == "" {
+			continue
+		}
+		rep.Scanned++
+		path := filepath.Join(repoDir, rel)
+		// Lstat, not Stat: a tracked symlink must have the LINK's ownership
+		// fixed, and we must never follow it to chown something outside the
+		// repo.
+		fi, err := os.Lstat(path)
+		if err != nil {
+			continue // deleted from the worktree; reset will restore it
+		}
+		st, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok || (int(st.Uid) == uid && int(st.Gid) == gid) {
+			continue
+		}
+		if err := os.Lchown(path, uid, gid); err != nil {
+			return rep, fmt.Errorf("chown %s: %w", rel, err)
+		}
+		rep.Fixed = append(rep.Fixed, rel)
+	}
+	return rep, nil
+}
+
+// gitFailureLine reduces a command's combined output to the single most useful line
+// for an inline note — git puts the real cause on its `fatal:` line and pads
+// the rest with context the operator does not need mid-update.
+func gitFailureLine(out string, err error) string {
+	for _, l := range strings.Split(out, "\n") {
+		l = strings.TrimSpace(l)
+		if strings.HasPrefix(l, "fatal:") {
+			return l
+		}
+	}
+	for _, l := range strings.Split(out, "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			return l
+		}
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "unknown error"
+}

--- a/panel-api/cmd/server/update_repo_ownership_test.go
+++ b/panel-api/cmd/server/update_repo_ownership_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// initRepoWithTrackedFiles builds a throwaway git repo with the given tracked
+// files and returns its path.
+func initRepoWithTrackedFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	for name, body := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o640); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "init"}} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	return dir
+}
+
+// The scope decision matters as much as the repair: install.sh's chown is
+// deliberately narrow "so node_modules or other trees that may legitimately be
+// group-owned differently don't get clobbered". A blanket chown -R over the
+// repo would take ownership of node_modules and build caches. Only TRACKED
+// files may be touched.
+func TestOwnershipRepairOnlyConsidersTrackedFiles(t *testing.T) {
+	repo := initRepoWithTrackedFiles(t, map[string]string{
+		"CLAUDE.md":            "tracked",
+		"panel-ui/src/main.ts": "tracked",
+	})
+	// Untracked, and deliberately not in the index — node_modules stands in for
+	// anything with its own ownership.
+	untracked := filepath.Join(repo, "panel-ui", "node_modules", "pkg", "index.js")
+	if err := os.MkdirAll(filepath.Dir(untracked), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(untracked, []byte("x"), 0o640); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	me, err := user.Current()
+	if err != nil {
+		t.Fatalf("current user: %v", err)
+	}
+	rep, err := fixTrackedFileOwnership(context.Background(), repo, me.Username)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if rep.Scanned != 2 {
+		t.Errorf("scanned %d files, want the 2 TRACKED ones — an untracked file "+
+			"under node_modules must never be considered", rep.Scanned)
+	}
+	// Everything already belongs to the caller, so nothing needed changing.
+	if len(rep.Fixed) != 0 {
+		t.Errorf("nothing was mis-owned, but the pass reported fixing %v", rep.Fixed)
+	}
+}
+
+// A tracked file the service user cannot read is the whole bug: repo files are
+// mode 0640/0660, so one root-owned tracked file breaks every git command that
+// hashes the working tree.
+//
+//	error: open("CLAUDE.md"): Permission denied
+//	fatal: cannot hash CLAUDE.md
+//
+// Reproduced on a fresh install. Changing ownership needs root, so the repair
+// itself can only be exercised as root; the detection half is checked either
+// way.
+func TestOwnershipRepairDetectsForeignOwner(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root to create a file owned by another user")
+	}
+	repo := initRepoWithTrackedFiles(t, map[string]string{"CLAUDE.md": "tracked"})
+	target := filepath.Join(repo, "CLAUDE.md")
+	if err := os.Chown(target, 0, 0); err != nil {
+		t.Fatalf("chown root: %v", err)
+	}
+	if err := os.Chmod(target, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	nobody, err := user.Lookup("nobody")
+	if err != nil {
+		t.Skip("no nobody user")
+	}
+	rep, err := fixTrackedFileOwnership(context.Background(), repo, nobody.Username)
+	if err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+	if len(rep.Fixed) != 1 || rep.Fixed[0] != "CLAUDE.md" {
+		t.Fatalf("want CLAUDE.md repaired, got %v", rep.Fixed)
+	}
+}
+
+func TestOwnershipRepairRejectsUnknownUser(t *testing.T) {
+	repo := initRepoWithTrackedFiles(t, map[string]string{"a.txt": "x"})
+	if _, err := fixTrackedFileOwnership(context.Background(), repo, "definitely-not-a-user-12345"); err == nil {
+		t.Error("an unknown service user must be an error, not a silent no-op")
+	}
+}
+
+// A file that is tracked but missing from the working tree is normal mid-reset;
+// it must not abort the pass.
+func TestOwnershipRepairToleratesMissingWorktreeFile(t *testing.T) {
+	repo := initRepoWithTrackedFiles(t, map[string]string{"a.txt": "x", "b.txt": "y"})
+	if err := os.Remove(filepath.Join(repo, "a.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	me, _ := user.Current()
+	rep, err := fixTrackedFileOwnership(context.Background(), repo, me.Username)
+	if err != nil {
+		t.Fatalf("a deleted tracked file must not fail the pass: %v", err)
+	}
+	if rep.Scanned != 2 {
+		t.Errorf("scanned %d, want 2 (both still tracked)", rep.Scanned)
+	}
+}
+
+// The operator sees this line instead of git's raw stderr, so it has to carry
+// the actual cause.
+func TestGitFailureLinePrefersTheFatalLine(t *testing.T) {
+	out := "error: open(\"CLAUDE.md\"): Permission denied\nfatal: cannot hash CLAUDE.md\n"
+	if got := gitFailureLine(out, errors.New("exit status 128")); got != "fatal: cannot hash CLAUDE.md" {
+		t.Errorf("got %q, want the fatal: line — that is the one naming the cause", got)
+	}
+	if got := gitFailureLine("", errors.New("exit status 128")); !strings.Contains(got, "exit status 128") {
+		t.Errorf("with no output, fall back to the error: got %q", got)
+	}
+	if got := gitFailureLine("just a warning\n", nil); got != "just a warning" {
+		t.Errorf("got %q, want the first non-empty line", got)
+	}
+}


### PR DESCRIPTION
Reported from a **fresh install**:

```
→ git fetch + reset to release channel
  release channel: stable -> tracking the promoted `stable` tag
error: open("CLAUDE.md"): Permission denied
fatal: cannot hash CLAUDE.md
HEAD is now at 7085d502 …
```

## Root cause

Reproduced exactly on the reporting box: a **tracked** working-tree file owned
`root:root 0600`.

Every git command in the updater runs as the service user, and repo files are
mode `0640`/`0660` with **no world read** — so one root-owned tracked file
breaks any git operation that has to hash the tree.

It was survivable. The `git reset --hard` immediately after unlinks and
recreates the file (the parent dir *is* writable by the service user), which is
why the update completed and the file ended up `jabali`-owned. But the operator
sees a bare git `fatal:` mid-update with nothing saying whether it mattered.

Untracked files are irrelevant — `git diff` ignores them. My first repro attempt
used an untracked file and produced no error at all, which is what pointed at
the index as the discriminator.

## Fix 1 — the ownership self-heal missed the working tree

"fix repo ownership" exists for exactly this class of problem but chowned only
`.git` — the known case of a hand-run `git fetch` as root leaving root-owned
`FETCH_HEAD`/`objects`. It never touched the working tree. `install.sh` has the
same gap at the same place.

**Scope stays narrow on purpose: tracked files only.** install.sh's chown carries
the note *"so node_modules or other trees that may legitimately be group-owned
differently don't get clobbered"* — that reasoning is right, and a blanket
`chown -R` would take ownership of `node_modules` and build caches. Tracked files
are exactly the set git must read, and exactly the set `reset --hard` rewrites
anyway. `Lchown` not `Chown`, so a tracked symlink has the *link* repaired and is
never followed out of the repo.

`git ls-files` needs `-c safe.directory=<repo>`, and that is **not** defensive:
the checkout is owned by the service user while this runs as root, so git's
dubious-ownership guard refuses the repo. My first version shipped without it and
reported `list tracked files: exit status 128` on the box while silently
repairing nothing — the same trap as #841. Caught it by running the patched
binary on the box rather than trusting the unit tests.

## Fix 2 — legibility

The drift diffstat streamed git's stderr straight to the terminal. It's a
best-effort courtesy, so it now captures and prints one line naming the cause:

```
(could not compute local drift, continuing: fatal: cannot hash CLAUDE.md)
```

## Verified on the box

Two tracked files chowned to `root:root 0600`, then the patched updater:

```
→ fix repo ownership
  repaired ownership of 2 tracked file(s) not owned by jabali: CLAUDE.md, Makefile
```

`error:`/`fatal:` pair gone; both files back to `jabali:jabali`.

## Test plan

- [x] scope: an untracked file under `node_modules` is never considered
- [x] a tracked file missing from the worktree doesn't abort the pass
- [x] unknown service user is an error, not a silent no-op
- [x] `gitFailureLine` prefers git's `fatal:` line over surrounding noise
- [x] root-owned-file repair — needs root, so it **skips in CI**; verified
      manually on the box as shown above
- [x] `go build`, `go vet`, `gofmt`, `panel-api/...` green; rebased on `origin/main`