### PR TITLE
fix(installer): stay legible on 16-colour consoles (GH #353)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/websocket v1.5.3
+	github.com/muesli/termenv v0.16.0
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -78,7 +79,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
 github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=

--- a/installer/internal/tui/logo_test.go
+++ b/installer/internal/tui/logo_test.go
@@ -4,6 +4,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 var sgrRe = regexp.MustCompile(`\x1b\[([0-9;]*)m`)
@@ -122,7 +125,7 @@ func TestLogoIsSelfContainedDarkArt(t *testing.T) {
 // The welcome screen is the one place the full art is drawn; every other
 // screen gets the one-line brand so tall screens don't push it off the top.
 func TestBannerShowsFullLogoOnlyOnWelcome(t *testing.T) {
-	t.Parallel()
+	lipgloss.SetColorProfile(termenv.TrueColor)
 
 	welcome := bannerView(Model{screen: screenWelcome})
 	if !strings.Contains(welcome, strings.TrimRight(jabaliLogo, "\n")) {
@@ -132,6 +135,40 @@ func TestBannerShowsFullLogoOnlyOnWelcome(t *testing.T) {
 		if got := bannerView(Model{screen: s}); strings.Contains(got, "\x1b[48;2;") {
 			t.Errorf("screen %v renders block art in its banner; only the welcome "+
 				"screen should, or tall screens scroll the art away", s)
+		}
+	}
+}
+
+// GH #353 follow-up ("can't read bottom instructions"): a 16-colour terminal —
+// VPS web/serial consoles report exactly that — must never receive the
+// truecolor logo art (renders as garbage blocks) nor the ANSI-256 greys the
+// help/off/label styles use on capable terminals (nearest 16-colour match is
+// bright black: unreadable on any background). Under the ANSI profile the
+// greys degrade to plain white and the banner falls back to the text brand.
+func TestSixteenColourConsoleStaysLegible(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	t.Cleanup(func() { lipgloss.SetColorProfile(termenv.TrueColor) })
+
+	welcome := bannerView(Model{screen: screenWelcome})
+	if strings.Contains(welcome, "\x1b[38;2;") || strings.Contains(welcome, "\x1b[48;2;") {
+		t.Error("welcome banner leaks truecolor sequences on a 16-colour terminal")
+	}
+
+	for name, rendered := range map[string]string{
+		"help":  helpStyle.Render("enter: continue   q: quit"),
+		"off":   offStyle.Render("Mail suite"),
+		"label": fieldLabelStyle.Render("URL"),
+		"tag":   tagStyle.Render("JABALI PANEL"),
+		"box":   boxStyle.Render("log line"),
+	} {
+		if strings.Contains(rendered, "[38;5;") {
+			t.Errorf("%s style emits an ANSI-256 grey on a 16-colour terminal: %q", name, rendered)
+		}
+		if strings.Contains(rendered, "[90m") || strings.Contains(rendered, "[30m") {
+			t.Errorf("%s style degrades to (bright) black — invisible: %q", name, rendered)
+		}
+		if !strings.Contains(rendered, "[37m") {
+			t.Errorf("%s style must degrade to white (37) on a 16-colour terminal: %q", name, rendered)
 		}
 	}
 }

--- a/installer/internal/tui/model.go
+++ b/installer/internal/tui/model.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/installer/internal/modules"
 )
@@ -128,18 +129,29 @@ func (m Model) logLineWidth() int {
 // streamed-log pane didn't stand out). Solid black also blends with the
 // luminance-inverted logo art, whose untouched cells show the app background.
 var (
+	// The muted greys carry explicit per-profile values (GH #353 follow-up:
+	// "can't read bottom instructions"). Left to lipgloss's automatic
+	// degradation, 243/246/247/252 all land on ANSI "bright black" in an
+	// 8/16-colour terminal — VPS web/serial consoles report exactly that —
+	// which is unreadable on ANY background. On those terminals the muted
+	// hierarchy is unaffordable: degrade to plain white and stay legible.
+	grayHelp  = lipgloss.CompleteColor{TrueColor: "#949494", ANSI256: "246", ANSI: "7"}
+	grayOff   = lipgloss.CompleteColor{TrueColor: "#767676", ANSI256: "243", ANSI: "7"}
+	grayLabel = lipgloss.CompleteColor{TrueColor: "#9e9e9e", ANSI256: "247", ANSI: "7"}
+	grayBox   = lipgloss.CompleteColor{TrueColor: "#d0d0d0", ANSI256: "252", ANSI: "7"}
+
 	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("81"))
-	helpStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("246"))
+	helpStyle   = lipgloss.NewStyle().Foreground(grayHelp)
 	cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
 	onStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	offStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("243"))
+	offStyle    = lipgloss.NewStyle().Foreground(grayOff)
 	errStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("196"))
-	boxStyle    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1).Foreground(lipgloss.Color("252"))
-	bgDark      = lipgloss.Color("#000000")
-	fgLight     = lipgloss.Color("#e6e6e6")
+	boxStyle    = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1).Foreground(grayBox)
+	bgDark      = lipgloss.CompleteColor{TrueColor: "#000000", ANSI256: "16", ANSI: "0"}
+	fgLight     = lipgloss.CompleteColor{TrueColor: "#e6e6e6", ANSI256: "254", ANSI: "7"}
 	appStyle    = lipgloss.NewStyle().Padding(1, 2).Background(bgDark).Foreground(fgLight)
 	logoStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("81"))
-	tagStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("246"))
+	tagStyle    = lipgloss.NewStyle().Foreground(grayHelp)
 )
 
 // themeSGR is the app's foreground+background as a raw escape sequence, or ""
@@ -217,7 +229,12 @@ func bannerView(m Model) string {
 	// top of the terminal — the "hog is up" cutoff.
 	// The art is 17 rows; on a short terminal it pushes the prompt and help
 	// line past the bottom edge, where the container silently truncates them.
-	if m.screen == screenWelcome && !m.tightRows(lipgloss.Height(jabaliLogo)+11) {
+	// The art is raw 24-bit SGR (38;2;R;G;B). A terminal that didn't
+	// negotiate truecolor — VPS web/serial consoles in particular — renders
+	// those sequences as garbage blocks or drops them entirely (GH #353
+	// follow-up), so show it only where it can actually display.
+	if m.screen == screenWelcome && lipgloss.ColorProfile() == termenv.TrueColor &&
+		!m.tightRows(lipgloss.Height(jabaliLogo)+11) {
 		return strings.TrimRight(jabaliLogo, "\n") + "\n" + tag + "\n\n"
 	}
 	return tag + "\n\n"
@@ -937,7 +954,7 @@ func (m *Model) captureSummary(s string) {
 }
 
 var (
-	fieldLabelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("247")).Width(11)
+	fieldLabelStyle = lipgloss.NewStyle().Foreground(grayLabel).Width(11)
 	urlValueStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("81"))
 	credValueStyle  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("42"))
 	cardStyle       = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).
@@ -993,7 +1010,7 @@ var (
 	barOKStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
 	barWarnStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	barHotStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	statLabel    = lipgloss.NewStyle().Foreground(lipgloss.Color("247"))
+	statLabel    = lipgloss.NewStyle().Foreground(grayLabel)
 )
 
 // statBar renders a compact [████░░░░] bar coloured by load, plus the percent.


### PR DESCRIPTION
Follow-up to #855 — mrlp57's screenshots on #353 show the installer on a VPS web console (16-colour terminal): help lines, off-module labels and descriptions near-invisible, because every muted grey in the dark theme is an ANSI-256 code and lipgloss degrades them all to **bright black** on an ANSI terminal.

- Muted greys → `lipgloss.CompleteColor` with per-profile values: unchanged on truecolor/256-colour, **plain white** on 8/16-colour consoles (the muted hierarchy is unaffordable there; legibility wins).
- Theme bg/fg get explicit ANSI fallbacks (black/white).
- The welcome logo (raw 24-bit half-block art) is now gated on a negotiated TrueColor profile — on lesser terminals it rendered as garbage blocks; they get the text brand instead.

`TestSixteenColourConsoleStaysLegible` pins all of it under the ANSI profile.