### PR TITLE
feat(apps): short DB/user identifiers for app installs (GH #869)

### DIFF
--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -351,9 +351,9 @@ type provisionedDB struct {
 // wordPressHandler.create: panel rows + MariaDB CREATE DATABASE/USER/
 // GRANT via the agent. Each step rolls back the prior ones on failure
 // before returning the error.
-func provisionDBChain(ctx context.Context, cfg ApplicationHandlerConfig, userID, osUser, appType, fqdn, subdir, dbPassword string) (provisionedDB, error) {
+func provisionDBChain(ctx context.Context, cfg ApplicationHandlerConfig, userID, osUser, appType, dbPassword string) (provisionedDB, error) {
 	now := time.Now().UTC()
-	dbName, dbUsername, nameErr := allocateAppDBNames(ctx, cfg.Databases, cfg.DatabaseUsers, userID, osUser, appType, fqdn, subdir)
+	dbName, dbUsername, nameErr := allocateAppDBNames(ctx, cfg.Databases, cfg.DatabaseUsers, userID, osUser, appType)
 	if nameErr != nil {
 		return provisionedDB{}, fmt.Errorf("allocate db names: %w", nameErr)
 	}

--- a/panel-api/internal/api/applications_service.go
+++ b/panel-api/internal/api/applications_service.go
@@ -178,7 +178,7 @@ func InstallApplication(ctx context.Context, deps ApplicationHandlerConfig, p In
 		// password (GH #226). The admin password (above) is only for the
 		// app's admin account; the DB credential is independent.
 		dbPassword := ids.NewSecret()
-		chain, err = provisionDBChain(ctx, deps, p.UserID, osUser, descriptor.Name, domain.Name, p.Subdirectory, dbPassword)
+		chain, err = provisionDBChain(ctx, deps, p.UserID, osUser, descriptor.Name, dbPassword)
 		if err != nil {
 			slog.ErrorContext(ctx, "applications create: provision db chain", "err", err)
 			// JAB-114: err here is agent-origin (db.create) — logged above,

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -268,7 +268,7 @@ func (h *wordPressHandler) create(c *gin.Context) {
 	// database. Unique by construction ((domain, subdirectory) is unique);
 	// a short suffix is appended only if truncation/sanitisation collides.
 	dbID := ids.NewULID()
-	dbName, dbUsername, nameErr := allocateAppDBNames(ctx, h.cfg.Databases, h.cfg.DatabaseUsers, targetUserID, osUser, "wordpress", domain.Name, req.Subdirectory)
+	dbName, dbUsername, nameErr := allocateAppDBNames(ctx, h.cfg.Databases, h.cfg.DatabaseUsers, targetUserID, osUser, "wordpress")
 	if nameErr != nil {
 		slog.ErrorContext(ctx, "wordpress create: db name allocation failed", "err", nameErr)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -1459,42 +1459,45 @@ func appDBToken(appType string) string {
 	return "app"
 }
 
-// allocateAppDBNames builds the FQDN-based database + user names for a WordPress
-// install (GH #196): <osuser>_wp_<fqdn>[_<subdir>] with `_db` / `_user`
-// suffixes. Dots and any non-[a-z0-9] characters become underscores (the
-// DB-user validator forbids dashes), names are lowercased and truncated to
-// the 64-char MariaDB identifier limit. (domain, subdirectory) is unique so
-// the readable name is normally free; if a collision survives sanitisation
-// or truncation, a short random suffix is appended.
-func allocateAppDBNames(ctx context.Context, dbs repository.DatabaseRepository, users repository.DatabaseUserRepository, userID, osUser, appType, fqdn, subdir string) (dbName, dbUser string, err error) {
-	label := sanitizeDBLabel(fqdn)
-	if subdir != "" {
-		if sub := sanitizeDBLabel(subdir); sub != "" {
-			label += "_" + sub
-		}
+// shortAppDBName assembles <osuser>_<token>_<tail>, clamped to the 64-char
+// MariaDB identifier limit by truncating the osuser part — the random tail
+// is the uniqueness and must survive intact.
+func shortAppDBName(osUser, appType, tail string) string {
+	const max = 64
+	suffix := "_" + appDBToken(appType) + "_" + tail
+	user := sanitizeDBLabel(osUser)
+	if budget := max - len(suffix); len(user) > budget {
+		user = strings.Trim(user[:budget], "_")
 	}
-	prefix := sanitizeDBLabel(osUser) + "_" + appDBToken(appType) + "_"
+	return user + suffix
+}
+
+// allocateAppDBNames builds the database + user name for an app install:
+// <osuser>_<token>_<3 random chars>, the SAME identifier for the database
+// and its user (GH #869). This reverts the FQDN-based names of GH #196 —
+// descriptive names read well on paper but real installs produced 50+
+// character identifiers (<osuser>_wp_<full_fqdn>_<subdir>_db) that were
+// unusable in DB clients. Which site a database belongs to lives in the
+// panel's Application record, not the identifier. The random tail
+// distinguishes multiple installs of the same app under one account; on a
+// collision the loop just draws a fresh tail.
+func allocateAppDBNames(ctx context.Context, dbs repository.DatabaseRepository, users repository.DatabaseUserRepository, userID, osUser, appType string) (dbName, dbUser string, err error) {
 	for attempt := 0; attempt < 16; attempt++ {
-		l := label
-		if attempt > 0 {
-			u := ids.NewULID()
-			l = label + "_" + strings.ToLower(u[len(u)-4:])
-		}
-		db := fitDBName(prefix, l, "_db")
-		usr := fitDBName(prefix, l, "_user")
-		dbTaken, e := dbs.ExistsByUserAndName(ctx, userID, db)
+		u := ids.NewULID()
+		name := shortAppDBName(osUser, appType, strings.ToLower(u[len(u)-3:]))
+		dbTaken, e := dbs.ExistsByUserAndName(ctx, userID, name)
 		if e != nil {
 			return "", "", e
 		}
-		usrTaken, e := users.ExistsByUserAndUsername(ctx, userID, usr)
+		usrTaken, e := users.ExistsByUserAndUsername(ctx, userID, name)
 		if e != nil {
 			return "", "", e
 		}
 		if !dbTaken && !usrTaken {
-			return db, usr, nil
+			return name, name, nil
 		}
 	}
-	return "", "", fmt.Errorf("allocateAppDBNames: could not allocate a free name for %q", fqdn)
+	return "", "", fmt.Errorf("allocateAppDBNames: could not allocate a free name for %s/%s", osUser, appDBToken(appType))
 }
 
 // sanitizeDBLabel lowercases s and maps every non-[a-z0-9] rune to '_',

--- a/panel-api/internal/api/wordpress_dbname_test.go
+++ b/panel-api/internal/api/wordpress_dbname_test.go
@@ -38,6 +38,26 @@ func TestFitDBName(t *testing.T) {
 	}
 }
 
+// GH #869: app DB/user identifiers are short — <osuser>_<token>_<tail> —
+// not the FQDN-based GH #196 scheme that produced 50+ char names.
+func TestShortAppDBName(t *testing.T) {
+	if got := shortAppDBName("notary", "wordpress", "x4f"); got != "notary_wp_x4f" {
+		t.Errorf("wordpress: %q, want notary_wp_x4f", got)
+	}
+	if got := shortAppDBName("notary", "flarum", "k2p"); got != "notary_flarum_k2p" {
+		t.Errorf("flarum: %q, want notary_flarum_k2p", got)
+	}
+	// OS usernames pass through the same sanitiser as everything else.
+	if got := shortAppDBName("Notary.User", "drupal", "9aa"); got != "notary_user_drupal_9aa" {
+		t.Errorf("sanitised osuser: %q", got)
+	}
+	// Even an absurdly long OS user stays inside the 64-char identifier limit.
+	longUser := "averyveryverylongsystemusernamethatkeepsgoingandgoingandgoingyes"
+	if got := shortAppDBName(longUser, "wordpress", "x4f"); len(got) > 64 {
+		t.Errorf("len=%d > 64: %q", len(got), got)
+	}
+}
+
 // TestAppDBToken — GH #215: each app's DB/user name carries its OWN
 // token, not a blanket "wp". WordPress stays "wp" for continuity.
 func TestAppDBToken(t *testing.T) {


### PR DESCRIPTION
Implements johnnyq's ask on #869: app-provisioned DB + user names go from `<osuser>_wp_<full_fqdn>[_<subdir>]_db` / `_user` (GH #196 — 50+ chars on real installs) to **`<osuser>_<token>_<3 random chars>`**, one identifier shared by the database and its user, e.g. `notary_wp_x4f`, `notary_flarum_k2p`.

- WordPress keeps its short `wp` token (GH #215 machinery unchanged); every other app uses its own type token.
- Fresh random tail per collision-loop attempt; the osuser part — never the tail — truncates if an extreme username would pass MariaDB's 64-char limit.
- Existing installs keep their stored names; only new provisioning changes.
- Which site a DB belongs to remains visible in the panel's Application record.

Tests: `TestShortAppDBName` pins the format, sanitisation, and the length clamp.