### PR TITLE
feat(mail): opt-in DKIM2 chain-of-custody signing (GH #648)

### DIFF
--- a/panel-agent/internal/commands/domain_email_dkim2.go
+++ b/panel-agent/internal/commands/domain_email_dkim2.go
@@ -1,0 +1,184 @@
+package commands
+
+// domain_email.dkim2_set — converge DKIM2 chain-of-custody signing for one
+// mail domain (GH #648).
+//
+// DKIM2 (draft-ietf-dkim-dkim2-spec) reuses the DKIM1 DNS record format
+// verbatim (draft-ietf-dkim-dkim2-dns: "DKIM2 reuses a subset of the DKIM
+// textual representation including this version number for compatibility
+// with existing key deployment"), so enabling it needs NO DNS change: the
+// Dkim2 signature reuses the domain's existing Ed25519 key AND the existing
+// `jabali` selector, and the already-published
+// jabali._domainkey.<domain> TXT verifies both signature generations.
+// DKIM1 keeps signing alongside as the fallback for legacy verifiers — the
+// coexistence is by design in the draft.
+//
+// The signature object shape was probe-verified against Stalwart 0.16.15:
+// Dkim2* variants accept only domainId/selector/privateKey/stage —
+// `canonicalization`, `report` and `headers` are DKIM1-era knobs the DKIM2
+// tagged-enum rejects with invalidPatch (the draft fixes canonicalization
+// and the signed-header set).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dkim"
+)
+
+const dkim2SignatureType = "Dkim2Ed25519Sha256"
+
+type dkim2SetParams struct {
+	DomainName string `json:"domain_name"`
+	Enabled    bool   `json:"enabled"`
+}
+
+type dkim2SetResponse struct {
+	Ok      bool `json:"ok"`
+	Changed bool `json:"changed"`
+}
+
+// dkim2SignatureIDs returns the ids of every Dkim2Ed25519Sha256 signature
+// bound to domainID. DkimSignature/get has no server-side filter for
+// domainId, so this fetches the (small) full list and filters client-side.
+func dkim2SignatureIDs(ctx context.Context, domainID string) ([]string, error) {
+	var result jmapGetResult
+	if err := jmapCall(ctx, "x:DkimSignature/get", map[string]any{}, &result); err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, raw := range result.List {
+		var sig struct {
+			ID       string `json:"id"`
+			Type     string `json:"@type"`
+			DomainID string `json:"domainId"`
+		}
+		if err := json.Unmarshal(raw, &sig); err != nil {
+			continue
+		}
+		if sig.Type == dkim2SignatureType && sig.DomainID == domainID {
+			ids = append(ids, sig.ID)
+		}
+	}
+	return ids, nil
+}
+
+func dkim2SetHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p dkim2SetParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("parse: %v", err),
+		}
+	}
+	if !domainRegex.MatchString(p.DomainName) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid domain_name %q", p.DomainName),
+		}
+	}
+
+	domainID, err := domainIDByName(ctx, p.DomainName)
+	if err != nil {
+		return nil, err
+	}
+	if domainID == "" {
+		if !p.Enabled {
+			// Nothing to remove for a domain Stalwart doesn't know.
+			return dkim2SetResponse{Ok: true, Changed: false}, nil
+		}
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeNotFound,
+			Message: fmt.Sprintf("domain %q has no Stalwart registry entry — is email enabled?", p.DomainName),
+		}
+	}
+
+	existing, err := dkim2SignatureIDs(ctx, domainID)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.Enabled {
+		if len(existing) > 0 {
+			return dkim2SetResponse{Ok: true, Changed: false}, nil
+		}
+		keyPath := filepath.Join(dkimKeyDirFunc(), p.DomainName+".key")
+		seed, err := dkim.LoadEd25519(keyPath)
+		if err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("load dkim key %s: %v", keyPath, err),
+			}
+		}
+		pemKey, err := dkim.SeedToPKCS8PEM(seed)
+		if err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("convert dkim key: %v", err),
+			}
+		}
+		if err := createDkim2Signature(ctx, domainID, dkimSelector, string(pemKey)); err != nil {
+			return nil, err
+		}
+		return dkim2SetResponse{Ok: true, Changed: true}, nil
+	}
+
+	if len(existing) == 0 {
+		return dkim2SetResponse{Ok: true, Changed: false}, nil
+	}
+	var result jmapSetResult
+	if err := jmapCall(ctx, "x:DkimSignature/set", map[string]any{"destroy": existing}, &result); err != nil {
+		return nil, err
+	}
+	if len(result.Destroyed) != len(existing) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("stalwart destroyed %d of %d dkim2 signatures", len(result.Destroyed), len(existing)),
+		}
+	}
+	return dkim2SetResponse{Ok: true, Changed: true}, nil
+}
+
+// createDkim2Signature creates the minimal probe-verified Dkim2 object.
+// Deliberately NOT merged with createDkimSignature: the DKIM1 creator's
+// canonicalization/headers/report fields are invalid on the Dkim2 variant.
+func createDkim2Signature(ctx context.Context, domainID, selector, pemPrivateKey string) error {
+	args := map[string]any{
+		"create": map[string]any{
+			"#sig2": map[string]any{
+				"@type":    dkim2SignatureType,
+				"domainId": domainID,
+				"selector": selector,
+				"privateKey": map[string]any{
+					"@type":  "Text",
+					"secret": pemPrivateKey,
+				},
+				"stage": "active",
+			},
+		},
+	}
+	var result jmapSetResult
+	if err := jmapCall(ctx, "x:DkimSignature/set", args, &result); err != nil {
+		return err
+	}
+	if _, ok := result.Created["#sig2"]; ok {
+		return nil
+	}
+	if reason, nok := result.NotCreated["#sig2"]; nok {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("stalwart x:DkimSignature/set dkim2 create refused: %s", string(reason)),
+		}
+	}
+	return &agentwire.AgentError{
+		Code:    agentwire.CodeInternal,
+		Message: "stalwart x:DkimSignature/set: unexpected response shape",
+	}
+}
+
+func init() {
+	Default.Register("domain_email.dkim2_set", dkim2SetHandler)
+}

--- a/panel-agent/internal/commands/domain_email_dkim2_test.go
+++ b/panel-agent/internal/commands/domain_email_dkim2_test.go
@@ -1,0 +1,170 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dkim"
+)
+
+// fakeDkim2Registry backs the JMAP routes with a mutable signature list so
+// one test can walk the full enable→noop→disable→noop cycle.
+type fakeDkim2Registry struct {
+	sigs      map[string]map[string]any // id -> object
+	nextID    int
+	lastCreIt map[string]any // last create payload, for shape asserts
+}
+
+func newDkim2TestServer(t *testing.T, reg *fakeDkim2Registry) {
+	t.Helper()
+	server := newJMAPServer(t, map[string]jmapHandler{
+		"x:Domain/query": func(json.RawMessage) (any, *jmapFakeError) {
+			return map[string]any{"ids": []string{"dom1"}, "total": 1}, nil
+		},
+		"x:DkimSignature/get": func(json.RawMessage) (any, *jmapFakeError) {
+			list := make([]map[string]any, 0, len(reg.sigs))
+			for _, s := range reg.sigs {
+				list = append(list, s)
+			}
+			return map[string]any{"list": list}, nil
+		},
+		"x:DkimSignature/set": func(raw json.RawMessage) (any, *jmapFakeError) {
+			var req struct {
+				Create  map[string]map[string]any `json:"create"`
+				Destroy []string                  `json:"destroy"`
+			}
+			if err := json.Unmarshal(raw, &req); err != nil {
+				return nil, &jmapFakeError{Type: "invalidArguments"}
+			}
+			created := map[string]any{}
+			for tempID, obj := range req.Create {
+				reg.nextID++
+				id := fmt.Sprintf("sig%d", reg.nextID)
+				obj["id"] = id
+				reg.sigs[id] = obj
+				reg.lastCreIt = obj
+				created[tempID] = map[string]any{"id": id}
+			}
+			var destroyed []string
+			for _, id := range req.Destroy {
+				if _, ok := reg.sigs[id]; ok {
+					delete(reg.sigs, id)
+					destroyed = append(destroyed, id)
+				}
+			}
+			return map[string]any{"created": created, "destroyed": destroyed}, nil
+		},
+	})
+	wireJMAP(t, server)
+}
+
+func writeTestDKIMKey(t *testing.T, domain string) {
+	t.Helper()
+	dir := t.TempDir()
+	orig := dkimKeyDirFunc
+	dkimKeyDirFunc = func() string { return dir }
+	t.Cleanup(func() { dkimKeyDirFunc = orig })
+	kp, err := dkim.GenerateEd25519()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	if err := dkim.WritePrivate(dir+"/"+domain+".key", kp.PrivateRawBase64); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+}
+
+func callDkim2Set(t *testing.T, domain string, enabled bool) (dkim2SetResponse, error) {
+	t.Helper()
+	raw, _ := json.Marshal(dkim2SetParams{DomainName: domain, Enabled: enabled})
+	out, err := dkim2SetHandler(context.Background(), raw)
+	if err != nil {
+		return dkim2SetResponse{}, err
+	}
+	return out.(dkim2SetResponse), nil
+}
+
+// GH #648: the full converge cycle — create once, steady-state noop,
+// destroy once, steady-state noop — and the created object carries ONLY
+// the fields the Dkim2 tagged-enum accepts (probe-verified on 0.16.15:
+// canonicalization/report/headers are rejected with invalidPatch).
+func TestDkim2Set_ConvergeCycleAndObjectShape(t *testing.T) {
+	reg := &fakeDkim2Registry{sigs: map[string]map[string]any{
+		// Pre-existing DKIM1 signature must be ignored by the dkim2 filter.
+		"sigdkim1": {"id": "sigdkim1", "@type": "Dkim1Ed25519Sha256", "domainId": "dom1", "selector": "jabali"},
+	}}
+	newDkim2TestServer(t, reg)
+	writeTestDKIMKey(t, "example.com")
+
+	resp, err := callDkim2Set(t, "example.com", true)
+	if err != nil || !resp.Changed {
+		t.Fatalf("enable: err=%v changed=%v, want changed", err, resp.Changed)
+	}
+	obj := reg.lastCreIt
+	if obj["@type"] != "Dkim2Ed25519Sha256" || obj["selector"] != "jabali" || obj["stage"] != "active" {
+		t.Fatalf("created object wrong: %v", obj)
+	}
+	for _, forbidden := range []string{"canonicalization", "report", "headers"} {
+		if _, ok := obj[forbidden]; ok {
+			t.Fatalf("created object carries %q — the Dkim2 variant rejects it (invalidPatch)", forbidden)
+		}
+	}
+	if _, ok := obj["privateKey"]; !ok {
+		t.Fatal("created object missing privateKey")
+	}
+
+	// Steady state: signature exists — no change.
+	resp, err = callDkim2Set(t, "example.com", true)
+	if err != nil || resp.Changed {
+		t.Fatalf("enable steady-state: err=%v changed=%v, want no change", err, resp.Changed)
+	}
+	if len(reg.sigs) != 2 {
+		t.Fatalf("signature count = %d, want 2 (dkim1 + dkim2)", len(reg.sigs))
+	}
+
+	// Disable: dkim2 destroyed, dkim1 untouched.
+	resp, err = callDkim2Set(t, "example.com", false)
+	if err != nil || !resp.Changed {
+		t.Fatalf("disable: err=%v changed=%v, want changed", err, resp.Changed)
+	}
+	if len(reg.sigs) != 1 {
+		t.Fatalf("signature count = %d after disable, want the dkim1 survivor", len(reg.sigs))
+	}
+	if _, ok := reg.sigs["sigdkim1"]; !ok {
+		t.Fatal("disable destroyed the DKIM1 signature — it must only touch Dkim2 objects")
+	}
+
+	// Steady state off: no change.
+	resp, err = callDkim2Set(t, "example.com", false)
+	if err != nil || resp.Changed {
+		t.Fatalf("disable steady-state: err=%v changed=%v, want no change", err, resp.Changed)
+	}
+}
+
+// A domain Stalwart doesn't know: disable is a friendly noop, enable is a
+// hard not_found (the reconciler shouldn't silently think it converged).
+func TestDkim2Set_UnknownDomain(t *testing.T) {
+	server := newJMAPServer(t, map[string]jmapHandler{
+		"x:Domain/query": func(json.RawMessage) (any, *jmapFakeError) {
+			return map[string]any{"ids": []string{}, "total": 0}, nil
+		},
+	})
+	wireJMAP(t, server)
+
+	resp, err := callDkim2Set(t, "ghost.example", false)
+	if err != nil || resp.Changed {
+		t.Fatalf("disable unknown: err=%v changed=%v, want clean noop", err, resp.Changed)
+	}
+
+	_, err = callDkim2Set(t, "ghost.example", true)
+	if err == nil {
+		t.Fatal("enable unknown: want not_found error")
+	}
+	var agentErr *agentwire.AgentError
+	if !errors.As(err, &agentErr) || agentErr.Code != agentwire.CodeNotFound {
+		t.Fatalf("enable unknown: err=%v, want code not_found", err)
+	}
+}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -140,6 +140,8 @@ type updateServerSettingsRequest struct {
 	// GH #860: opt-in branded page on the default catch-all for unknown
 	// hosts (default off = keep the 444 drop).
 	UnconfiguredPageEnabled *bool `json:"unconfigured_page_enabled,omitempty"`
+	// GH #648: opt-in DKIM2 signing alongside classic DKIM (default off).
+	DKIM2SigningEnabled *bool `json:"dkim2_signing_enabled,omitempty"`
 	// TenantNotificationKinds — admin-configurable tenant channel-kind allowlist
 	// (phase 4b).
 	TenantNotificationKinds *models.TenantNotificationKinds `json:"tenant_notification_kinds,omitempty"`
@@ -509,6 +511,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.UnconfiguredPageEnabled != nil {
 		current.UnconfiguredPageEnabled = *req.UnconfiguredPageEnabled
+	}
+	if req.DKIM2SigningEnabled != nil {
+		current.DKIM2SigningEnabled = *req.DKIM2SigningEnabled
 	}
 	if req.TenantNotificationKinds != nil {
 		// Sanitize drops unknown kinds, so a PATCH can never smuggle an

--- a/panel-api/internal/db/migrations/000246_dkim2_signing.down.sql
+++ b/panel-api/internal/db/migrations/000246_dkim2_signing.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN dkim2_signing_enabled;

--- a/panel-api/internal/db/migrations/000246_dkim2_signing.up.sql
+++ b/panel-api/internal/db/migrations/000246_dkim2_signing.up.sql
@@ -1,0 +1,5 @@
+-- GH #648: opt-in DKIM2 chain-of-custody signing (draft-ietf-dkim-dkim2).
+-- Default 0 while the spec is a working-group draft; the DNS side needs no
+-- changes (DKIM2 reuses the published DKIM1 TXT records verbatim).
+ALTER TABLE server_settings
+  ADD COLUMN dkim2_signing_enabled tinyint(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -118,6 +118,13 @@ type ServerSettings struct {
 	// nginx domain options (GH #307). Default off.
 	TenantDomainOptionsEnabled bool `gorm:"column:tenant_domain_options_enabled;type:tinyint(1);not null;default:0" json:"tenant_domain_options_enabled"`
 
+	// DKIM2SigningEnabled adds a DKIM2 chain-of-custody signature (GH #648,
+	// draft-ietf-dkim-dkim2) alongside the classic DKIM signature on every
+	// mail domain's outbound. Needs no DNS change — DKIM2 verifies against
+	// the already-published DKIM1 TXT records by design. Default off while
+	// the spec is a working-group draft; DKIM1 always keeps signing.
+	DKIM2SigningEnabled bool `gorm:"column:dkim2_signing_enabled;type:tinyint(1);not null;default:0" json:"dkim2_signing_enabled"`
+
 	// UnconfiguredPageEnabled serves the branded "domain not configured" page
 	// (page_templates.domain_unconfigured) on the default catch-all vhost for
 	// hosts nginx has no server block for (GH #860). Default off: the shipped

--- a/panel-api/internal/reconciler/dkim2_reconcile.go
+++ b/panel-api/internal/reconciler/dkim2_reconcile.go
@@ -1,0 +1,78 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// reconcileDKIM2 converges DKIM2 chain-of-custody signing (GH #648) across
+// every mail-enabled domain to server_settings.dkim2_signing_enabled: the
+// agent creates or removes the Dkim2Ed25519Sha256 signature in Stalwart's
+// registry (same key + selector as the classic DKIM signature, so the
+// published DNS already verifies it; the agent call is idempotent).
+//
+// Gated by an in-memory applied-state map instead of a single hash: a mail
+// domain enabled AFTER the toggle was applied still needs its own converge,
+// which one global hash can't see. First tick after boot converges every
+// domain once (cheap agent noops); after that only toggle flips and new
+// mail domains trigger calls. A failed call leaves the domain out of the
+// map, so the next tick retries it.
+func (r *Reconciler) reconcileDKIM2(ctx context.Context) {
+	if r.domains == nil || r.agent == nil || r.serverSettings == nil {
+		return
+	}
+	sctx, scancel := context.WithTimeout(ctx, 5*time.Second)
+	srv, err := r.serverSettings.Get(sctx)
+	scancel()
+	if err != nil || srv == nil {
+		return
+	}
+	enabled := srv.DKIM2SigningEnabled
+
+	domains, _, err := r.domains.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		r.log.Warn("dkim2: list domains failed", "error", err)
+		return
+	}
+
+	r.dkim2Mu.Lock()
+	if r.dkim2Applied == nil {
+		r.dkim2Applied = make(map[string]bool)
+	}
+	r.dkim2Mu.Unlock()
+
+	for i := range domains {
+		d := &domains[i]
+		if !d.EmailEnabled {
+			// A domain whose email was disabled loses its Stalwart registry
+			// entry (and with it the signature) via domain_email.disable —
+			// drop it from the cache so a later re-enable reconverges.
+			r.dkim2Mu.Lock()
+			delete(r.dkim2Applied, d.Name)
+			r.dkim2Mu.Unlock()
+			continue
+		}
+		r.dkim2Mu.Lock()
+		applied, seen := r.dkim2Applied[d.Name]
+		r.dkim2Mu.Unlock()
+		if seen && applied == enabled {
+			continue
+		}
+
+		cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		_, err := r.agent.Call(cctx, "domain_email.dkim2_set", map[string]any{
+			"domain_name": d.Name,
+			"enabled":     enabled,
+		})
+		cancel()
+		if err != nil {
+			r.log.Warn("dkim2: converge failed", "domain", d.Name, "enabled", enabled, "error", err)
+			continue
+		}
+		r.dkim2Mu.Lock()
+		r.dkim2Applied[d.Name] = enabled
+		r.dkim2Mu.Unlock()
+	}
+}

--- a/panel-api/internal/reconciler/dkim2_reconcile_test.go
+++ b/panel-api/internal/reconciler/dkim2_reconcile_test.go
@@ -1,0 +1,126 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeDkim2Agent struct {
+	calls []map[string]any
+	fail  bool
+}
+
+func (f *fakeDkim2Agent) Call(_ context.Context, method string, params interface{}) (json.RawMessage, error) {
+	if method != "domain_email.dkim2_set" {
+		return nil, nil
+	}
+	m, _ := params.(map[string]any)
+	f.calls = append(f.calls, m)
+	if f.fail {
+		return nil, fmt.Errorf("boom")
+	}
+	return json.RawMessage(`{"ok":true,"changed":true}`), nil
+}
+
+type fakeDkim2DomainRepo struct {
+	repository.DomainRepository
+	rows []models.Domain
+}
+
+func (f *fakeDkim2DomainRepo) List(context.Context, repository.ListOptions) ([]models.Domain, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+func dkim2Reconciler(agent *fakeDkim2Agent, srv *models.ServerSettings, domains []models.Domain) *Reconciler {
+	return &Reconciler{
+		domains:        &fakeDkim2DomainRepo{rows: domains},
+		serverSettings: &fakeSettingsRepo{srv: srv},
+		agent:          agent,
+		log:            slog.New(slog.DiscardHandler),
+	}
+}
+
+// GH #648: only mail-enabled domains converge; steady state is call-free;
+// a toggle flip re-converges every mail domain exactly once.
+func TestReconcileDKIM2_AppliedStateGating(t *testing.T) {
+	agent := &fakeDkim2Agent{}
+	srv := &models.ServerSettings{}
+	r := dkim2Reconciler(agent, srv, []models.Domain{
+		{Name: "mail1.example", EmailEnabled: true},
+		{Name: "mail2.example", EmailEnabled: true},
+		{Name: "web-only.example", EmailEnabled: false},
+	})
+	ctx := context.Background()
+
+	// First tick: both mail domains converge to off; web-only untouched.
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 2 {
+		t.Fatalf("first tick calls = %d, want 2", len(agent.calls))
+	}
+	for _, c := range agent.calls {
+		if c["enabled"] != false {
+			t.Fatalf("first tick must converge to disabled, got %v", c)
+		}
+		if c["domain_name"] == "web-only.example" {
+			t.Fatal("non-mail domain must not be converged")
+		}
+	}
+
+	// Steady state: no further calls.
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 2 {
+		t.Fatalf("steady state made calls (total=%d)", len(agent.calls))
+	}
+
+	// Toggle on: both re-converge with enabled=true.
+	srv.DKIM2SigningEnabled = true
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 4 {
+		t.Fatalf("toggle flip calls = %d, want 4 total", len(agent.calls))
+	}
+	if agent.calls[2]["enabled"] != true || agent.calls[3]["enabled"] != true {
+		t.Fatal("post-flip converge must carry enabled=true")
+	}
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 4 {
+		t.Fatal("second steady state made calls")
+	}
+}
+
+// A failed converge stays out of the applied map and retries next tick; a
+// domain whose email is later enabled converges without a toggle flip.
+func TestReconcileDKIM2_RetryAndLateMailDomain(t *testing.T) {
+	agent := &fakeDkim2Agent{fail: true}
+	srv := &models.ServerSettings{DKIM2SigningEnabled: true}
+	repo := &fakeDkim2DomainRepo{rows: []models.Domain{{Name: "mail1.example", EmailEnabled: true}}}
+	r := &Reconciler{
+		domains:        repo,
+		serverSettings: &fakeSettingsRepo{srv: srv},
+		agent:          agent,
+		log:            slog.New(slog.DiscardHandler),
+	}
+	ctx := context.Background()
+
+	r.reconcileDKIM2(ctx)
+	agent.fail = false
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 2 {
+		t.Fatalf("failed converge must retry (calls=%d)", len(agent.calls))
+	}
+
+	// New mail domain appears: converged on the next tick, existing one not re-called.
+	repo.rows = append(repo.rows, models.Domain{Name: "late.example", EmailEnabled: true})
+	r.reconcileDKIM2(ctx)
+	if len(agent.calls) != 3 {
+		t.Fatalf("late mail domain must converge exactly once (calls=%d)", len(agent.calls))
+	}
+	if agent.calls[2]["domain_name"] != "late.example" {
+		t.Fatalf("third call = %v, want late.example", agent.calls[2])
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -143,6 +143,10 @@ type Reconciler struct {
 	skelMu          sync.Mutex
 	skelWire        []map[string]any
 	skelAt          time.Time
+	// dkim2Applied caches, per mail domain, the DKIM2 signing state last
+	// converged to the agent (GH #648) — see dkim2_reconcile.go.
+	dkim2Mu      sync.Mutex
+	dkim2Applied map[string]bool
 	// errorPagesHash caches the last content hash synced to
 	// /var/www/jabali-errors so the per-tick reconcile only calls the
 	// agent when an admin actually edits an error template.
@@ -610,6 +614,10 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// editable page_template rows into /var/www/jabali-errors. Hash-gated:
 	// a noop on every tick until an admin edits a template.
 	r.reconcileErrorPages(ctx)
+
+	// GH #648: converge DKIM2 signing across mail domains to the
+	// server_settings toggle. Applied-state-gated — noop steady state.
+	r.reconcileDKIM2(ctx)
 
 	tt.mark("certs_updates_modules")
 

--- a/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { Card, Switch, Tag, Typography, notification } from "antd";
+
+import { apiClient } from "../../../apiClient";
+
+// Dkim2ToggleCard — Server Settings → Email: opt-in DKIM2 chain-of-custody
+// signing (GH #648, draft-ietf-dkim-dkim2). Needs no DNS change: DKIM2
+// verifies against the DKIM records the panel already publishes, and the
+// classic DKIM signature keeps signing alongside for legacy verifiers.
+export const Dkim2ToggleCard = () => {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiClient.get<{ dkim2_signing_enabled?: boolean }>("/admin/settings");
+        if (!cancelled) setEnabled(resp.data.dkim2_signing_enabled === true);
+      } catch {
+        if (!cancelled) notification.error({ message: "Failed to load DKIM2 setting" });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = async (next: boolean) => {
+    setSaving(true);
+    try {
+      await apiClient.patch("/admin/settings", { dkim2_signing_enabled: next });
+      setEnabled(next);
+      notification.success({
+        message: next ? "DKIM2 signing enabled" : "DKIM2 signing disabled",
+        description: next
+          ? "Every mail domain gets a DKIM2 signature on the next reconcile — no DNS changes needed."
+          : "DKIM2 signatures are being removed; classic DKIM keeps signing.",
+      });
+    } catch {
+      notification.error({ message: "Failed to update DKIM2 setting" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      title={
+        <>
+          DKIM2 signing <Tag color="orange">experimental</Tag>
+        </>
+      }
+      style={{ marginBottom: 16 }}
+      loading={loading}
+    >
+      <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
+        Add a DKIM2 chain-of-custody signature to outgoing mail on every
+        email-enabled domain, alongside the classic DKIM signature. Uses the
+        same keys and DNS records already published — nothing to change at
+        your registrar. DKIM2 is an IETF working-group draft; receivers that
+        don&apos;t support it ignore the extra header, and classic DKIM keeps
+        signing either way.
+      </Typography.Paragraph>
+      <Switch
+        checked={enabled}
+        loading={saving}
+        onChange={onToggle}
+        checkedChildren="On"
+        unCheckedChildren="Off"
+      />
+    </Card>
+  );
+};

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -67,6 +67,7 @@ import { DNSResolversCard } from "./DNSResolversCard";
 import { DNSPermissionsCard } from "./DNSPermissionsCard";
 import { EmailCard } from "./EmailCard";
 import { WebmailToggleCard } from "./WebmailToggleCard";
+import { Dkim2ToggleCard } from "./Dkim2ToggleCard";
 import { ModulesCard } from "./ModulesCard";
 import { StalwartWebadminCard } from "./StalwartWebadminCard";
 import { PageTemplatesCard } from "./PageTemplatesCard";
@@ -1024,6 +1025,7 @@ export const ServerSettingsPage = () => {
         <>
           <EmailCard />
           <WebmailToggleCard />
+          <Dkim2ToggleCard />
           <StalwartWebadminCard />
         </>
       ),


### PR DESCRIPTION
The signing half of #648. Fact-check first: the earlier issue comment said jabali boxes "already DKIM2-sign out of the box" — **not true**. Stalwart verifies DKIM2 inbound out of the box, but signing needs a `Dkim2*` signature object, and the panel only ever created `Dkim1Ed25519Sha256`. Verified live: 16/16 signatures on testserver were DKIM1.

## Why this is safe to ship despite draft status

- **Zero DNS changes**: `draft-ietf-dkim-dkim2-dns` deliberately reuses the DKIM1 TXT format — "existing DKIM1 records can be used for DKIM2 verification without modification". The Dkim2 signature reuses each domain's existing Ed25519 key + `jabali` selector, so the already-published records verify both generations.
- **Coexistence by design**: classic DKIM keeps signing alongside; receivers without DKIM2 ignore the extra header.
- **Opt-in, default OFF** (`server_settings.dkim2_signing_enabled`, migration 000246) while the spec is a WG draft (spec -04, dns -00).

## Mechanism

- Agent `domain_email.dkim2_set`: idempotent create/remove of the Dkim2 object. Shape **probe-verified on Stalwart 0.16.15**: the Dkim2 tagged-enum accepts only `domainId/selector/privateKey/stage` and rejects `canonicalization`/`report`/`headers` with `invalidPatch` (probe object created + destroyed on testserver).
- Reconciler `reconcileDKIM2`: converges every mail-enabled domain to the toggle via a per-domain applied-state map — steady state is call-free, failed converges retry, mail domains enabled later converge without a toggle flip.
- Server Settings → Email: "DKIM2 signing" card, tagged experimental.

## Tests

Agent: full enable→noop→disable→noop cycle, DKIM1 object untouched, forbidden-field shape pin, unknown-domain semantics. Reconciler: applied-state gating, toggle flip, retry, late mail domain. `-race` green both modules; SPA builds.