### PR TITLE
feat(notifications): opt-in daily digest email (GH #840)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -903,6 +903,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 		go reconciler.StartDomainExpiryTicker(ctx, sharedAgent, deps.Domains, log)
 	}
 
+	// GH #840: opt-in daily digest email (kind digest.daily, default off).
+	if deps.ServerSettings != nil && deps.NotificationQueue != nil && sharedDB != nil {
+		go reconciler.StartDigestTicker(ctx, reconciler.DigestTickerDeps{
+			Stats:    repository.NewDigestStatsRepository(sharedDB),
+			Settings: deps.ServerSettings,
+			Queue:    deps.NotificationQueue,
+			Log:      log,
+		})
+	}
+
 	// GH #263: mailbox usage sampler -> mailboxes.last_usage_bytes (the
 	// mailbox.usage probe + UpdateUsage existed but were never wired).
 	if sharedAgent != nil && deps.Mailboxes != nil {

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1117,6 +1117,8 @@ func (f *fakeSettingsRepo) Upsert(ctx context.Context, s *models.ServerSettings)
 	f.s = s
 	return nil
 }
+func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+
 func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil
 }

--- a/panel-api/internal/api/notifications_webpush_test.go
+++ b/panel-api/internal/api/notifications_webpush_test.go
@@ -28,6 +28,8 @@ func (f *fakeWPSettingsRepo) Get(context.Context) (*models.ServerSettings, error
 	return f.row, nil
 }
 func (f *fakeWPSettingsRepo) Upsert(context.Context, *models.ServerSettings) error { return nil }
+func (f *fakeWPSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+
 func (f *fakeWPSettingsRepo) EnsureVAPID(context.Context, string) (bool, error)    { return false, nil }
 
 type fakeSubsRepo struct {

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -43,6 +43,8 @@ func (m *mockServerSettingsRepo) Upsert(ctx context.Context, s *models.ServerSet
 	return nil
 }
 
+func (m *mockServerSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+
 func (m *mockServerSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil
 }

--- a/panel-api/internal/db/migrations/000247_daily_digest.down.sql
+++ b/panel-api/internal/db/migrations/000247_daily_digest.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN digest_last_sent_date;

--- a/panel-api/internal/db/migrations/000247_daily_digest.up.sql
+++ b/panel-api/internal/db/migrations/000247_daily_digest.up.sql
@@ -1,0 +1,5 @@
+-- GH #840: daily digest email. The ticker records the last UTC day it
+-- sent for (YYYY-MM-DD) so a panel restart inside the send window can't
+-- double-send. Empty = never sent.
+ALTER TABLE server_settings
+  ADD COLUMN digest_last_sent_date varchar(10) NOT NULL DEFAULT '';

--- a/panel-api/internal/migrate/working_folder_test.go
+++ b/panel-api/internal/migrate/working_folder_test.go
@@ -18,6 +18,7 @@ type fakeServerSettings struct {
 func (f *fakeServerSettings) Get(_ context.Context) (*models.ServerSettings, error) {
 	return f.row, f.err
 }
+func (f *fakeServerSettings) SetDigestLastSent(context.Context, string) error { return nil }
 func (f *fakeServerSettings) Upsert(_ context.Context, _ *models.ServerSettings) error {
 	return nil
 }

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -248,6 +248,15 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		Severity:    "critical",
 		DefaultOn:   true,
 	},
+	// GH #840: opt-in Zimbra/Logwatch-style daily summary. Aggregated by
+	// the digest ticker; off by default so it never surprises anyone.
+	{
+		Kind:        "digest.daily",
+		Label:       "Daily digest",
+		Description: "One summary email a day: alerts by severity, backup outcomes, certificates expiring soon, and fleet counts for the last 24 hours.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
 }
 
 // LookupNotificationEventKind returns the metadata for a known kind

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -118,6 +118,11 @@ type ServerSettings struct {
 	// nginx domain options (GH #307). Default off.
 	TenantDomainOptionsEnabled bool `gorm:"column:tenant_domain_options_enabled;type:tinyint(1);not null;default:0" json:"tenant_domain_options_enabled"`
 
+	// DigestLastSentDate is the UTC day (YYYY-MM-DD) the daily digest last
+	// fired for (GH #840). Written by the digest ticker via
+	// SetDigestLastSent; empty = never sent.
+	DigestLastSentDate string `gorm:"column:digest_last_sent_date;type:varchar(10);not null;default:''" json:"digest_last_sent_date"`
+
 	// DKIM2SigningEnabled adds a DKIM2 chain-of-custody signature (GH #648,
 	// draft-ietf-dkim-dkim2) alongside the classic DKIM signature on every
 	// mail domain's outbound. Needs no DNS change — DKIM2 verifies against

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -557,6 +557,7 @@ type fakeSettings struct {
 func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) { return f.st, f.err }
 func (f *fakeSettings) Upsert(context.Context, *models.ServerSettings) error { return nil }
 func (f *fakeSettings) EnsureVAPID(context.Context, string) (bool, error)    { return false, nil }
+func (f *fakeSettings) SetDigestLastSent(context.Context, string) error      { return nil }
 
 // JAB-171 phase 4e: the master gate + kind allowlist are a LIVE delivery kill
 // switch, not just a create-time gate.

--- a/panel-api/internal/notifications/senders/webpush_test.go
+++ b/panel-api/internal/notifications/senders/webpush_test.go
@@ -28,6 +28,8 @@ func (f *fakeSettingsRepo) Get(ctx context.Context) (*models.ServerSettings, err
 	return f.row, f.err
 }
 func (f *fakeSettingsRepo) Upsert(ctx context.Context, s *models.ServerSettings) error { return nil }
+func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+
 func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil
 }

--- a/panel-api/internal/reconciler/digest_ticker.go
+++ b/panel-api/internal/reconciler/digest_ticker.go
@@ -1,0 +1,164 @@
+package reconciler
+
+// GH #840: Zimbra/Logwatch-style daily digest email. The ticker checks
+// every 15 minutes whether today's (UTC) digest is due — due means the
+// clock has passed 06:00 UTC and server_settings.digest_last_sent_date is
+// an earlier day — aggregates the previous 24h via DigestStatsRepository,
+// and publishes ONE digest.daily envelope. Delivery is entirely governed
+// by the notification pipeline: the kind defaults OFF, so nothing is sent
+// until an admin flips "Daily digest" on in notification settings, and it
+// then flows through whichever channels they configured.
+//
+// The last-sent day is persisted (targeted single-column UPDATE) BEFORE
+// publishing, so a crash between the two costs one digest instead of
+// sending twice — the digest is a convenience summary, dupes annoy more
+// than a gap hurts. JAB-203 note: TestServeWiresDigestTicker pins the
+// serve.go call site so this can't silently never run.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// digestSendHourUTC is when the digest becomes due each day. 06:00 UTC
+// lands in the morning across Europe/Africa/Americas-East where the
+// current fleet lives; configurable later if anyone asks.
+const digestSendHourUTC = 6
+
+// digestPublisher is the Publish subset of *notifications.Queue.
+type digestPublisher interface {
+	Publish(ctx context.Context, env notifications.Envelope) (string, error)
+}
+
+type DigestTickerDeps struct {
+	Stats    repository.DigestStatsRepository
+	Settings repository.ServerSettingsRepository
+	Queue    digestPublisher
+	Log      bwTickerLogger
+	// now is injectable for tests; nil means time.Now.
+	now func() time.Time
+}
+
+// StartDigestTicker runs until ctx is cancelled. Call in its own goroutine.
+func StartDigestTicker(ctx context.Context, deps DigestTickerDeps) {
+	if deps.Stats == nil || deps.Settings == nil || deps.Queue == nil || deps.Log == nil {
+		return
+	}
+	const interval = 15 * time.Minute
+	deps.Log.Info("digest_ticker starting", "interval", interval.String(), "send_hour_utc", digestSendHourUTC)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			digestTick(ctx, deps)
+		}
+	}
+}
+
+// digestTick sends today's digest if it is due. Split out for tests.
+func digestTick(ctx context.Context, deps DigestTickerDeps) {
+	nowFn := deps.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn().UTC()
+	if now.Hour() < digestSendHourUTC {
+		return
+	}
+	today := now.Format("2006-01-02")
+
+	srv, err := deps.Settings.Get(ctx)
+	if err != nil || srv == nil {
+		return
+	}
+	if srv.DigestLastSentDate == today {
+		return
+	}
+
+	stats, err := deps.Stats.Collect(ctx, now.Add(-24*time.Hour))
+	if err != nil {
+		deps.Log.Warn("digest: stats collect failed", "err", err)
+		return
+	}
+
+	// Persist-then-publish: a crash in between skips one digest rather
+	// than double-sending (see package comment).
+	if err := deps.Settings.SetDigestLastSent(ctx, today); err != nil {
+		deps.Log.Warn("digest: persist last-sent failed", "err", err)
+		return
+	}
+
+	title, body := renderDigest(now, stats)
+	if _, err := deps.Queue.Publish(ctx, notifications.Envelope{
+		EventKind: "digest.daily",
+		Severity:  "info",
+		Title:     title,
+		Body:      body,
+		Deeplink:  "/jabali-admin/notifications",
+	}); err != nil {
+		deps.Log.Warn("digest: publish failed", "err", err)
+		return
+	}
+	deps.Log.Info("digest: published", "day", today)
+}
+
+// renderDigest builds the plain-text digest. Deliberately plain — every
+// channel sender (mail, telegram, webhook...) can carry it verbatim.
+func renderDigest(now time.Time, s *repository.DigestStats) (title, body string) {
+	sev := func(k string) int64 { return s.AlertsBySeverity[k] }
+	alerts := sev("critical") + sev("error") + sev("warning") + sev("info")
+	backups := int64(0)
+	for _, n := range s.BackupsByStatus {
+		backups += n
+	}
+	title = fmt.Sprintf("Daily digest — %d alert%s, %d backup%s, %d cert%s expiring soon",
+		alerts, plural(alerts), backups, plural(backups), s.CertsExpiring14d, plural(s.CertsExpiring14d))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Summary for the 24h ending %s UTC.\n\n", now.Format("2006-01-02 15:04"))
+
+	fmt.Fprintf(&b, "Alerts: %d critical, %d error, %d warning, %d info\n",
+		sev("critical"), sev("error"), sev("warning"), sev("info"))
+	if len(s.TopKinds) > 0 {
+		b.WriteString("Busiest events:\n")
+		for _, k := range s.TopKinds {
+			fmt.Fprintf(&b, "  - %s: %d\n", k.EventKind, k.Count)
+		}
+	}
+
+	if backups == 0 {
+		b.WriteString("\nBackups: none ran\n")
+	} else {
+		keys := make([]string, 0, len(s.BackupsByStatus))
+		for k := range s.BackupsByStatus {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, fmt.Sprintf("%d %s", s.BackupsByStatus[k], k))
+		}
+		fmt.Fprintf(&b, "\nBackups: %s\n", strings.Join(parts, ", "))
+	}
+
+	fmt.Fprintf(&b, "Certificates expiring within 14 days: %d\n", s.CertsExpiring14d)
+	fmt.Fprintf(&b, "\nFleet: %d domain%s (%d enabled), %d user%s\n",
+		s.DomainsTotal, plural(s.DomainsTotal), s.DomainsEnabled, s.UsersTotal, plural(s.UsersTotal))
+	return title, b.String()
+}
+
+func plural(n int64) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/panel-api/internal/reconciler/digest_ticker_test.go
+++ b/panel-api/internal/reconciler/digest_ticker_test.go
@@ -1,0 +1,154 @@
+package reconciler
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeDigestStats struct {
+	stats *repository.DigestStats
+}
+
+func (f *fakeDigestStats) Collect(context.Context, time.Time) (*repository.DigestStats, error) {
+	return f.stats, nil
+}
+
+type fakeDigestSettings struct {
+	repository.ServerSettingsRepository
+	srv      *models.ServerSettings
+	setDays  []string
+	setFails bool
+}
+
+func (f *fakeDigestSettings) Get(context.Context) (*models.ServerSettings, error) {
+	return f.srv, nil
+}
+func (f *fakeDigestSettings) SetDigestLastSent(_ context.Context, day string) error {
+	if f.setFails {
+		return context.DeadlineExceeded
+	}
+	f.setDays = append(f.setDays, day)
+	f.srv.DigestLastSentDate = day
+	return nil
+}
+
+type fakeDigestQueue struct {
+	envs []notifications.Envelope
+}
+
+func (f *fakeDigestQueue) Publish(_ context.Context, env notifications.Envelope) (string, error) {
+	f.envs = append(f.envs, env)
+	return "1-1", nil
+}
+
+type nopLogger struct{}
+
+func (nopLogger) Info(string, ...interface{})  {}
+func (nopLogger) Warn(string, ...interface{})  {}
+func (nopLogger) Error(string, ...interface{}) {}
+
+func digestDeps(hourUTC int, lastSent string) (DigestTickerDeps, *fakeDigestQueue, *fakeDigestSettings) {
+	q := &fakeDigestQueue{}
+	settings := &fakeDigestSettings{srv: &models.ServerSettings{DigestLastSentDate: lastSent}}
+	deps := DigestTickerDeps{
+		Stats: &fakeDigestStats{stats: &repository.DigestStats{
+			AlertsBySeverity: map[string]int64{"error": 2, "warning": 5},
+			TopKinds:         []repository.DigestKindCount{{EventKind: "cert.renew.fail", Count: 2}},
+			BackupsByStatus:  map[string]int64{"succeeded": 3, "failed": 1},
+			CertsExpiring14d: 1,
+			DomainsTotal:     12, DomainsEnabled: 11, UsersTotal: 4,
+		}},
+		Settings: settings,
+		Queue:    q,
+		Log:      nopLogger{},
+		now: func() time.Time {
+			return time.Date(2026, 8, 2, hourUTC, 10, 0, 0, time.UTC)
+		},
+	}
+	return deps, q, settings
+}
+
+// GH #840: due once per UTC day, only after the send hour; the same day
+// never sends twice; the next day sends again.
+func TestDigestTick_DayGate(t *testing.T) {
+	// Before the send hour: nothing.
+	deps, q, _ := digestDeps(digestSendHourUTC-1, "")
+	digestTick(context.Background(), deps)
+	if len(q.envs) != 0 {
+		t.Fatal("digest sent before the send hour")
+	}
+
+	// After the send hour: exactly one send, day persisted.
+	deps, q, settings := digestDeps(digestSendHourUTC+1, "")
+	digestTick(context.Background(), deps)
+	digestTick(context.Background(), deps)
+	if len(q.envs) != 1 {
+		t.Fatalf("sends = %d, want exactly 1 for the day", len(q.envs))
+	}
+	if len(settings.setDays) != 1 || settings.setDays[0] != "2026-08-02" {
+		t.Fatalf("persisted days = %v", settings.setDays)
+	}
+
+	// Next day: due again.
+	deps.now = func() time.Time { return time.Date(2026, 8, 3, digestSendHourUTC+1, 0, 0, 0, time.UTC) }
+	digestTick(context.Background(), deps)
+	if len(q.envs) != 2 {
+		t.Fatalf("next-day sends = %d, want 2 total", len(q.envs))
+	}
+
+	env := q.envs[0]
+	if env.EventKind != "digest.daily" {
+		t.Fatalf("kind = %q", env.EventKind)
+	}
+	for _, want := range []string{"2 error", "5 warning", "cert.renew.fail: 2", "3 succeeded", "1 failed", "12 domains (11 enabled), 4 users", "Certificates expiring within 14 days: 1"} {
+		if !strings.Contains(env.Body, want) {
+			t.Fatalf("body missing %q:\n%s", want, env.Body)
+		}
+	}
+}
+
+// Persist-then-publish: a failed last-sent write must NOT send (dupes
+// annoy more than a gap hurts).
+func TestDigestTick_PersistFailureSkipsSend(t *testing.T) {
+	deps, q, settings := digestDeps(digestSendHourUTC+1, "")
+	settings.setFails = true
+	digestTick(context.Background(), deps)
+	if len(q.envs) != 0 {
+		t.Fatal("digest sent although the last-sent persist failed")
+	}
+}
+
+// JAB-203 regression shape: StartSSLTicker existed but was never wired to a
+// call site, so it silently never ran. Pin that serve.go actually starts
+// the digest ticker.
+func TestServeWiresDigestTicker(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "cmd", "server", "serve.go"))
+	if err != nil {
+		t.Fatalf("read serve.go: %v", err)
+	}
+	if !strings.Contains(string(src), "reconciler.StartDigestTicker(") {
+		t.Fatal("serve.go does not call reconciler.StartDigestTicker — the digest would silently never run (JAB-203 shape)")
+	}
+}
+
+// The digest kind must exist in the canonical event-kind list (the seed +
+// settings UI derive from it) and default OFF.
+func TestDigestKindRegisteredDefaultOff(t *testing.T) {
+	for _, k := range models.AllNotificationEventKinds {
+		if k.Kind == "digest.daily" {
+			if k.DefaultOn {
+				t.Fatal("digest.daily must default OFF — opt-in")
+			}
+			return
+		}
+	}
+	t.Fatal("digest.daily missing from AllNotificationEventKinds")
+}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -445,6 +445,8 @@ type fakeServerSettingsRepo struct {
 	settings *models.ServerSettings
 }
 
+func (f *fakeServerSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+
 func (f *fakeServerSettingsRepo) Get(ctx context.Context) (*models.ServerSettings, error) {
 	if f.settings == nil {
 		return nil, repository.ErrNotFound

--- a/panel-api/internal/repository/digest_stats_repository.go
+++ b/panel-api/internal/repository/digest_stats_repository.go
@@ -1,0 +1,115 @@
+package repository
+
+// GH #840: aggregation source for the daily digest email. One repository
+// with a handful of read-only aggregate queries instead of widening four
+// unrelated repositories — the digest is the only consumer.
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// DigestKindCount is one event kind's 24h volume.
+type DigestKindCount struct {
+	EventKind string `json:"event_kind"`
+	Count     int64  `json:"count"`
+}
+
+// DigestStats is everything the daily digest reports on.
+type DigestStats struct {
+	// AlertsBySeverity counts notification_history rows since the window
+	// start, keyed critical/error/warning/info. This rolls up everything
+	// the panel already alerts on (cert failures, disk, service.down,
+	// CrowdSec spikes, backups...) without re-querying each source.
+	AlertsBySeverity map[string]int64
+	// TopKinds is the five busiest event kinds in the window.
+	TopKinds []DigestKindCount
+	// BackupsByStatus counts backup_jobs created in the window by status.
+	BackupsByStatus map[string]int64
+	// CertsExpiring14d counts issued certificates expiring within 14 days.
+	CertsExpiring14d int64
+	DomainsTotal     int64
+	DomainsEnabled   int64
+	UsersTotal       int64
+}
+
+type DigestStatsRepository interface {
+	Collect(ctx context.Context, since time.Time) (*DigestStats, error)
+}
+
+type digestStatsRepo struct{ db *gorm.DB }
+
+func NewDigestStatsRepository(db *gorm.DB) DigestStatsRepository {
+	return &digestStatsRepo{db: db}
+}
+
+func (r *digestStatsRepo) Collect(ctx context.Context, since time.Time) (*DigestStats, error) {
+	out := &DigestStats{
+		AlertsBySeverity: map[string]int64{},
+		BackupsByStatus:  map[string]int64{},
+	}
+	db := r.db.WithContext(ctx)
+
+	var sevRows []struct {
+		Severity string
+		N        int64
+	}
+	// Envelope-level dedupe: the dispatcher writes one history row per
+	// TARGET (bell + each channel), so a single event with three channels
+	// would count as three alerts. Distinct envelope_id collapses that;
+	// rows without an envelope_id (legacy) count individually.
+	if err := db.Raw(`SELECT severity, COUNT(DISTINCT COALESCE(envelope_id, id)) AS n
+		FROM notification_history WHERE created_at >= ? GROUP BY severity`, since).
+		Scan(&sevRows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range sevRows {
+		out.AlertsBySeverity[r.Severity] = r.N
+	}
+
+	var kindRows []struct {
+		EventKind string
+		N         int64
+	}
+	if err := db.Raw(`SELECT event_kind, COUNT(DISTINCT COALESCE(envelope_id, id)) AS n
+		FROM notification_history WHERE created_at >= ? AND event_kind != 'digest.daily'
+		GROUP BY event_kind ORDER BY n DESC LIMIT 5`, since).
+		Scan(&kindRows).Error; err != nil {
+		return nil, err
+	}
+	for _, k := range kindRows {
+		out.TopKinds = append(out.TopKinds, DigestKindCount{EventKind: k.EventKind, Count: k.N})
+	}
+
+	var bkRows []struct {
+		Status string
+		N      int64
+	}
+	if err := db.Raw(`SELECT status, COUNT(*) AS n FROM backup_jobs
+		WHERE created_at >= ? GROUP BY status`, since).
+		Scan(&bkRows).Error; err != nil {
+		return nil, err
+	}
+	for _, b := range bkRows {
+		out.BackupsByStatus[b.Status] = b.N
+	}
+
+	if err := db.Raw(`SELECT COUNT(*) FROM ssl_certificates
+		WHERE status = 'issued' AND expires_at IS NOT NULL
+		AND expires_at BETWEEN NOW() AND DATE_ADD(NOW(), INTERVAL 14 DAY)`).
+		Scan(&out.CertsExpiring14d).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Raw(`SELECT COUNT(*) FROM domains`).Scan(&out.DomainsTotal).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Raw(`SELECT COUNT(*) FROM domains WHERE is_enabled = 1`).Scan(&out.DomainsEnabled).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Raw(`SELECT COUNT(*) FROM users`).Scan(&out.UsersTotal).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/panel-api/internal/repository/server_settings_repository.go
+++ b/panel-api/internal/repository/server_settings_repository.go
@@ -35,6 +35,11 @@ type ServerSettingsRepository interface {
 	// Empty hostname falls back to "mailto:admin@localhost" so first
 	// boot on a not-yet-configured host still succeeds.
 	EnsureVAPID(ctx context.Context, hostname string) (generated bool, err error)
+
+	// SetDigestLastSent records the UTC day (YYYY-MM-DD) the daily digest
+	// last fired for (GH #840). Targeted single-column UPDATE so it can
+	// never clobber a concurrent admin settings save.
+	SetDigestLastSent(ctx context.Context, day string) error
 }
 
 type serverSettingsRepo struct{ db *gorm.DB }
@@ -133,4 +138,13 @@ func (r *serverSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (
 		return false, ErrNotFound
 	}
 	return true, nil
+}
+
+// SetDigestLastSent — see the interface doc. The settings table is a
+// single row; an empty WHERE is intentional.
+func (r *serverSettingsRepo) SetDigestLastSent(ctx context.Context, day string) error {
+	return r.db.WithContext(ctx).
+		Model(&models.ServerSettings{}).
+		Where("1 = 1").
+		Update("digest_last_sent_date", day).Error
 }


### PR DESCRIPTION
Implements #840 (mailanetworks): a Zimbra/Logwatch-style daily summary email, delivered as a normal notification kind so it rides the existing channel machinery.

## Behaviour

- **Opt-in**: new `digest.daily` event kind, default OFF. Enable "Daily digest" in notification settings (the kind list is derived from `AllNotificationEventKinds`, so it appears automatically) and it flows through whichever channels are configured — mail, telegram, webhook, bell.
- **Once per UTC day** after 06:00 UTC. `digest_last_sent_date` (migration 000247) makes it restart-safe; persist-then-publish means a crash between the two skips a day rather than double-sending.
- **Content**: alerts by severity + 5 busiest event kinds over 24h (from `notification_history`, deduped by envelope so multi-channel fan-out doesn't inflate counts), backup outcomes by status, certs expiring within 14 days, fleet counts. Plain text — safe for every sender.

## JAB-203 guard

`StartSSLTicker` once shipped unwired and silently never ran. `TestServeWiresDigestTicker` reads serve.go and fails if the `StartDigestTicker` call site disappears.

## Tests

Day-gate (before/after send hour, same-day dedupe, next-day resend), body content pins, persist-failure-skips-send, kind-registered-default-off, call-site pin. Full `go test -race ./...` green on panel-api.