### PR TITLE
feat(mail): statistics with history + storage drilldown (GH #873)

### DIFF
--- a/panel-agent/internal/commands/mail_stats.go
+++ b/panel-agent/internal/commands/mail_stats.go
@@ -1,0 +1,234 @@
+package commands
+
+// mail.stats_sample — one sample of Stalwart's operational counters for the
+// mail-statistics history (GH #873).
+//
+// Source is Stalwart's Prometheus exporter (GET /metrics/prometheus on the
+// local admin listener). The exporter ships DISABLED; on first sample this
+// handler enables it via the x:Metrics registry singleton with a dedicated
+// generated Basic-auth credential and restarts jabali-stalwart once (the
+// exporter route only mounts at boot — probe-verified on 0.16.15).
+//
+// Auth is NOT optional: 8446 binds 127.0.0.1, but on a shared-hosting box
+// every tenant process can reach 127.0.0.1 — an unauthenticated exporter
+// would leak server-wide mail telemetry to tenants. The credential lives in
+// a root-only file and never leaves the box.
+//
+// The sample is name-agnostic: every counter and gauge the exporter emits
+// is returned as-is (Stalwart registers metrics lazily on first event, so
+// the set grows as traffic flows). The panel stores what it gets; naming
+// is resolved at display time.
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+const stalwartMetricsUser = "jabali-metrics"
+
+// stalwartMetricsSecretPathFunc is overridable for tests.
+var stalwartMetricsSecretPathFunc = func() string {
+	return "/etc/jabali-panel/stalwart-metrics.secret"
+}
+
+type mailStatsResponse struct {
+	// Metrics carries every counter and gauge from the exporter, verbatim.
+	Metrics map[string]float64 `json:"metrics"`
+	// QueueSize is the current QueuedMessage count.
+	QueueSize int64 `json:"queue_size"`
+	// EnabledNow is true when this call had to enable the exporter (and
+	// restart Stalwart) first.
+	EnabledNow bool `json:"enabled_now"`
+}
+
+func mailStatsSampleHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	metrics, enabledNow, err := scrapeStalwartMetrics(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var queueResult jmapQueryResult
+	if err := jmapCall(ctx, "x:QueuedMessage/query", map[string]any{"limit": 1}, &queueResult); err != nil {
+		return nil, err
+	}
+
+	return mailStatsResponse{
+		Metrics:    metrics,
+		QueueSize:  int64(queueResult.Total),
+		EnabledNow: enabledNow,
+	}, nil
+}
+
+// scrapeStalwartMetrics fetches and parses the exporter output, enabling
+// the exporter first when needed.
+func scrapeStalwartMetrics(ctx context.Context) (map[string]float64, bool, error) {
+	secret, haveSecret := readMetricsSecret()
+	if haveSecret {
+		if m, code, err := fetchMetrics(ctx, secret); err == nil && code == http.StatusOK {
+			return m, false, nil
+		} else if err != nil {
+			return nil, false, err
+		}
+		// 404 (exporter off) or 401 (secret drift): fall through and
+		// (re-)converge the exporter config below.
+	}
+	secret, err := ensureMetricsExporter(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	// The route mounts at boot — poll briefly after the restart.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		m, code, err := fetchMetrics(ctx, secret)
+		if err == nil && code == http.StatusOK {
+			return m, true, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, false, &agentwire.AgentError{
+				Code:    agentwire.CodeUnavailable,
+				Message: fmt.Sprintf("stalwart metrics endpoint not up after enable (last status %d, err %v)", code, err),
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func readMetricsSecret() (string, bool) {
+	b, err := os.ReadFile(stalwartMetricsSecretPathFunc())
+	if err != nil {
+		return "", false
+	}
+	s := strings.TrimSpace(string(b))
+	return s, s != ""
+}
+
+// ensureMetricsExporter generates (or re-reads) the scrape credential,
+// writes the registry singleton, and restarts Stalwart so the exporter
+// route mounts.
+func ensureMetricsExporter(ctx context.Context) (string, error) {
+	secret, ok := readMetricsSecret()
+	if !ok {
+		raw := make([]byte, 24)
+		if _, err := rand.Read(raw); err != nil {
+			return "", &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("generate metrics secret: %v", err)}
+		}
+		secret = hex.EncodeToString(raw)
+		if err := os.WriteFile(stalwartMetricsSecretPathFunc(), []byte(secret+"\n"), 0o600); err != nil {
+			return "", &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("write metrics secret: %v", err)}
+		}
+	}
+
+	args := map[string]any{
+		"update": map[string]any{
+			"singleton": map[string]any{
+				"prometheus": map[string]any{
+					"@type":        "Enabled",
+					"authUsername": stalwartMetricsUser,
+					"authSecret":   map[string]any{"@type": "Value", "secret": secret},
+				},
+			},
+		},
+	}
+	var result jmapSetResult
+	if err := jmapCall(ctx, "x:Metrics/set", args, &result); err != nil {
+		return "", err
+	}
+
+	if out, err := runSystemctl(ctx, "restart", "jabali-stalwart.service"); err != nil {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("restart jabali-stalwart after metrics enable: %v: %s", err, strings.TrimSpace(string(out))),
+		}
+	}
+	return secret, nil
+}
+
+// fetchMetrics GETs the exporter and parses counters + gauges. Histogram
+// series are skipped — the panel's rollup wants monotonic counters and
+// point-in-time gauges, not bucket vectors.
+func fetchMetrics(ctx context.Context, secret string) (map[string]float64, int, error) {
+	url := stalwartAdminURLFunc() + "/metrics/prometheus"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("build metrics request: %v", err)}
+	}
+	req.SetBasicAuth(stalwartMetricsUser, secret)
+	resp, err := stalwartHTTPClientFunc().Do(req)
+	if err != nil {
+		return nil, 0, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: fmt.Sprintf("stalwart metrics unreachable: %v", err)}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		return nil, resp.StatusCode, nil
+	}
+	m, perr := parsePrometheusText(resp.Body)
+	if perr != nil {
+		return nil, resp.StatusCode, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("parse metrics: %v", perr)}
+	}
+	return m, resp.StatusCode, nil
+}
+
+// parsePrometheusText reads the exposition format, keeping counter and
+// gauge samples and dropping histograms (and their _bucket/_sum/_count
+// series). Labelled samples keep the bare name and sum across label sets.
+func parsePrometheusText(r io.Reader) (map[string]float64, error) {
+	keep := map[string]bool{}
+	out := map[string]float64{}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "# TYPE ") {
+			fields := strings.Fields(line)
+			if len(fields) == 4 {
+				keep[fields[2]] = fields[3] == "counter" || fields[3] == "gauge"
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		sp := strings.LastIndexByte(line, ' ')
+		if sp <= 0 {
+			continue
+		}
+		name, valStr := line[:sp], line[sp+1:]
+		if i := strings.IndexByte(name, '{'); i > 0 {
+			name = name[:i]
+		}
+		name = strings.TrimSpace(name)
+		if !keep[name] {
+			continue
+		}
+		v, err := strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			continue
+		}
+		out[name] += v
+	}
+	return out, sc.Err()
+}
+
+func init() {
+	Default.Register("mail.stats_sample", mailStatsSampleHandler)
+}

--- a/panel-agent/internal/commands/mail_stats_test.go
+++ b/panel-agent/internal/commands/mail_stats_test.go
@@ -1,0 +1,224 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const sampleExposition = `# HELP smtp_active_connections x
+# TYPE smtp_active_connections gauge
+smtp_active_connections 3
+# TYPE message_ingest counter
+message_ingest{listener="smtp"} 10
+message_ingest{listener="lmtp"} 5
+# TYPE http_request_time histogram
+http_request_time_bucket{le="0.5"} 100
+http_request_time_sum 12.5
+http_request_time_count 100
+# TYPE domain_count gauge
+domain_count 4
+`
+
+func TestParsePrometheusText(t *testing.T) {
+	m, err := parsePrometheusText(strings.NewReader(sampleExposition))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m["smtp_active_connections"] != 3 {
+		t.Fatalf("gauge = %v", m["smtp_active_connections"])
+	}
+	if m["message_ingest"] != 15 {
+		t.Fatalf("labelled counter must sum across label sets, got %v", m["message_ingest"])
+	}
+	if m["domain_count"] != 4 {
+		t.Fatalf("domain_count = %v", m["domain_count"])
+	}
+	for _, histo := range []string{"http_request_time", "http_request_time_bucket", "http_request_time_sum", "http_request_time_count"} {
+		if _, ok := m[histo]; ok {
+			t.Fatalf("histogram series %q must be dropped", histo)
+		}
+	}
+}
+
+// statsTestServer speaks both /jmap and /metrics/prometheus. The exporter
+// starts "off" (404) when enabledAtStart is false and turns on after a
+// jabali-stalwart restart, mirroring the real mount-at-boot behaviour.
+func newStatsTestServer(t *testing.T, secret string, enabledAtStart bool) (*httptest.Server, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+	exporterUp := &atomic.Int32{}
+	if enabledAtStart {
+		exporterUp.Store(1)
+	}
+	metricsSet := &atomic.Int32{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metrics/prometheus":
+			if exporterUp.Load() == 0 {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			u, p, ok := r.BasicAuth()
+			if !ok || u != stalwartMetricsUser || p != secret {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Write([]byte(sampleExposition)) //nolint:errcheck
+		case jmapAPIPath:
+			var req jmapRequestBody
+			raw, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(raw, &req); err != nil || len(req.MethodCalls) != 1 {
+				http.Error(w, "bad body", http.StatusBadRequest)
+				return
+			}
+			var result any
+			switch req.MethodCalls[0].Name {
+			case "x:QueuedMessage/query":
+				result = map[string]any{"ids": []string{"q1"}, "total": 7}
+			case "x:Metrics/set":
+				metricsSet.Add(1)
+				result = map[string]any{"updated": map[string]any{"singleton": nil}}
+			default:
+				http.Error(w, "no route "+req.MethodCalls[0].Name, http.StatusBadRequest)
+				return
+			}
+			resp := jmapResponseBody{MethodResponses: []jmapMethodCall{{
+				Name: req.MethodCalls[0].Name, Args: result, CallID: req.MethodCalls[0].CallID,
+			}}}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+		default:
+			http.Error(w, "wrong path "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, exporterUp, metricsSet
+}
+
+func wireStatsSecret(t *testing.T, secret string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.secret")
+	if secret != "" {
+		if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig := stalwartMetricsSecretPathFunc
+	stalwartMetricsSecretPathFunc = func() string { return path }
+	t.Cleanup(func() { stalwartMetricsSecretPathFunc = orig })
+}
+
+// Steady state: exporter on, secret on disk — one scrape, no enable, no
+// restart, queue total carried through.
+func TestMailStatsSample_SteadyState(t *testing.T) {
+	server, _, metricsSet := newStatsTestServer(t, "s3cret", true)
+	wireJMAP(t, server)
+	wireStatsSecret(t, "s3cret")
+	origRestart := runSystemctl
+	restarts := 0
+	runSystemctl = func(ctx context.Context, args ...string) ([]byte, error) { restarts++; return nil, nil }
+	t.Cleanup(func() { runSystemctl = origRestart })
+
+	out, err := mailStatsSampleHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	resp := out.(mailStatsResponse)
+	if resp.EnabledNow || restarts != 0 || metricsSet.Load() != 0 {
+		t.Fatalf("steady state must not touch config (enabledNow=%v restarts=%d sets=%d)", resp.EnabledNow, restarts, metricsSet.Load())
+	}
+	if resp.QueueSize != 7 || resp.Metrics["message_ingest"] != 15 {
+		t.Fatalf("resp = %+v", resp)
+	}
+}
+
+// First run: exporter off, no secret — generate secret (0600), enable via
+// x:Metrics/set, restart once, then scrape succeeds.
+func TestMailStatsSample_EnablesExporterOnce(t *testing.T) {
+	var server *httptest.Server
+	var exporterUp *atomic.Int32
+	var metricsSet *atomic.Int32
+	// Secret is generated by the handler; the fake must accept whatever
+	// lands in the secret file. Wire with a placeholder, then swap the
+	// fake's expectation dynamically via file read inside auth check —
+	// easiest is to run the enable, then re-read the file for asserts.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "metrics.secret")
+	orig := stalwartMetricsSecretPathFunc
+	stalwartMetricsSecretPathFunc = func() string { return path }
+	t.Cleanup(func() { stalwartMetricsSecretPathFunc = orig })
+
+	exporterUp = &atomic.Int32{}
+	metricsSet = &atomic.Int32{}
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/metrics/prometheus":
+			if exporterUp.Load() == 0 {
+				http.Error(w, "not found", http.StatusNotFound)
+				return
+			}
+			u, p, ok := r.BasicAuth()
+			fileSecret, _ := os.ReadFile(path)
+			if !ok || u != stalwartMetricsUser || p != strings.TrimSpace(string(fileSecret)) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			w.Write([]byte(sampleExposition)) //nolint:errcheck
+		case jmapAPIPath:
+			var req jmapRequestBody
+			raw, _ := io.ReadAll(r.Body)
+			json.Unmarshal(raw, &req) //nolint:errcheck
+			var result any
+			switch req.MethodCalls[0].Name {
+			case "x:QueuedMessage/query":
+				result = map[string]any{"ids": []string{}, "total": 0}
+			case "x:Metrics/set":
+				metricsSet.Add(1)
+				result = map[string]any{"updated": map[string]any{"singleton": nil}}
+			default:
+				http.Error(w, "no route", http.StatusBadRequest)
+				return
+			}
+			resp := jmapResponseBody{MethodResponses: []jmapMethodCall{{
+				Name: req.MethodCalls[0].Name, Args: result, CallID: req.MethodCalls[0].CallID,
+			}}}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+		}
+	}))
+	t.Cleanup(server.Close)
+	wireJMAP(t, server)
+
+	origRestart := runSystemctl
+	restarts := 0
+	runSystemctl = func(ctx context.Context, args ...string) ([]byte, error) {
+		restarts++
+		exporterUp.Store(1) // exporter mounts on restart
+		return nil, nil
+	}
+	t.Cleanup(func() { runSystemctl = origRestart })
+
+	out, err := mailStatsSampleHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	resp := out.(mailStatsResponse)
+	if !resp.EnabledNow || restarts != 1 || metricsSet.Load() != 1 {
+		t.Fatalf("enable path wrong (enabledNow=%v restarts=%d sets=%d)", resp.EnabledNow, restarts, metricsSet.Load())
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("secret file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("secret file mode = %v, want 0600", info.Mode().Perm())
+	}
+}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -903,6 +903,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 		go reconciler.StartDomainExpiryTicker(ctx, sharedAgent, deps.Domains, log)
 	}
 
+	// GH #873: mail statistics sampler (Stalwart Prometheus + queue size).
+	if sharedAgent != nil && sharedDB != nil {
+		go reconciler.StartMailStatsTicker(ctx, reconciler.MailStatsTickerDeps{
+			Agent:    sharedAgent,
+			Stats:    repository.NewMailStatsRepository(sharedDB),
+			Settings: deps.ServerSettings,
+			Log:      log,
+		})
+	}
+
 	// GH #840: opt-in daily digest email (kind digest.daily, default off).
 	if deps.ServerSettings != nil && deps.NotificationQueue != nil && sharedDB != nil {
 		go reconciler.StartDigestTicker(ctx, reconciler.DigestTickerDeps{

--- a/panel-api/internal/api/admin_mail_stats.go
+++ b/panel-api/internal/api/admin_mail_stats.go
@@ -1,0 +1,94 @@
+package api
+
+// GH #873: admin mail statistics — history series from the mail stats
+// ticker's samples plus the mailbox-storage drilldown.
+//
+// The samples are stored name-agnostically (whatever Stalwart's exporter
+// emits), so the endpoint returns, per metric:
+//   - points: the raw sampled values (right for gauges: queue_size,
+//     *_active_connections, server_memory, ...)
+//   - rates:  positive deltas between consecutive samples (right for
+//     monotonic counters: message_ingest, auth_success, ...; clamped at 0
+//     so a Stalwart restart's counter reset shows as a flat spot, not a
+//     negative spike)
+// The SPA knows which representation each chart wants.
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type AdminMailStatsHandlerConfig struct {
+	Stats repository.MailStatsRepository
+}
+
+func RegisterAdminMailStatsRoutes(g *gin.RouterGroup, cfg AdminMailStatsHandlerConfig) {
+	h := &adminMailStatsHandler{cfg: cfg}
+	grp := g.Group("/admin/mail")
+	grp.Use(middleware.RequireAdmin())
+	grp.GET("/stats", h.stats)
+}
+
+type adminMailStatsHandler struct{ cfg AdminMailStatsHandlerConfig }
+
+// MailStatPoint is one charted point.
+type MailStatPoint struct {
+	T time.Time `json:"t"`
+	V float64   `json:"v"`
+}
+
+type mailStatsResponse struct {
+	// Points and Rates are keyed by metric name.
+	Points  map[string][]MailStatPoint     `json:"points"`
+	Rates   map[string][]MailStatPoint     `json:"rates"`
+	Current map[string]float64             `json:"current"`
+	Storage []repository.MailboxStorageRow `json:"storage"`
+}
+
+func (h *adminMailStatsHandler) stats(c *gin.Context) {
+	hours := 24
+	if raw := c.Query("hours"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 1 && v <= 2160 {
+			hours = v
+		}
+	}
+	since := time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
+
+	rows, err := h.cfg.Stats.Series(c.Request.Context(), since)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "series failed"})
+		return
+	}
+	storage, err := h.cfg.Stats.StorageDrilldown(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage failed"})
+		return
+	}
+
+	resp := mailStatsResponse{
+		Points:  map[string][]MailStatPoint{},
+		Rates:   map[string][]MailStatPoint{},
+		Current: map[string]float64{},
+		Storage: storage,
+	}
+	// rows arrive ordered (metric, time) — walk once.
+	for i := 0; i < len(rows); i++ {
+		r := rows[i]
+		resp.Points[r.Metric] = append(resp.Points[r.Metric], MailStatPoint{T: r.SampledAt, V: r.Value})
+		resp.Current[r.Metric] = r.Value
+		if i > 0 && rows[i-1].Metric == r.Metric {
+			delta := r.Value - rows[i-1].Value
+			if delta < 0 {
+				delta = 0 // counter reset (Stalwart restart)
+			}
+			resp.Rates[r.Metric] = append(resp.Rates[r.Metric], MailStatPoint{T: r.SampledAt, V: delta})
+		}
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/panel-api/internal/api/admin_mail_stats_test.go
+++ b/panel-api/internal/api/admin_mail_stats_test.go
@@ -1,0 +1,79 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeMailStatsSeriesRepo struct {
+	repository.MailStatsRepository
+	rows    []repository.MailStatSample
+	storage []repository.MailboxStorageRow
+}
+
+func (f *fakeMailStatsSeriesRepo) Series(context.Context, time.Time) ([]repository.MailStatSample, error) {
+	return f.rows, nil
+}
+func (f *fakeMailStatsSeriesRepo) StorageDrilldown(context.Context) ([]repository.MailboxStorageRow, error) {
+	return f.storage, nil
+}
+
+// GH #873: rates are positive deltas per metric, clamped at zero across a
+// Stalwart-restart counter reset; points and current carry raw values;
+// the storage drilldown rides along.
+func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
+	t0 := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	repo := &fakeMailStatsSeriesRepo{
+		rows: []repository.MailStatSample{
+			{Metric: "message_ingest", SampledAt: t0, Value: 100},
+			{Metric: "message_ingest", SampledAt: t0.Add(15 * time.Minute), Value: 130},
+			{Metric: "message_ingest", SampledAt: t0.Add(30 * time.Minute), Value: 10}, // restart reset
+			{Metric: "message_ingest", SampledAt: t0.Add(45 * time.Minute), Value: 25},
+			{Metric: "queue_size", SampledAt: t0, Value: 4},
+		},
+		storage: []repository.MailboxStorageRow{
+			{Username: "notary", DomainName: "n.example", Email: "a@n.example", UsageBytes: 1024, QuotaBytes: 4096},
+		},
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(injectAdminClaims(true))
+	api.RegisterAdminMailStatsRoutes(v1, api.AdminMailStatsHandlerConfig{Stats: repo})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/mail/stats?hours=24", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Points  map[string][]api.MailStatPoint `json:"points"`
+		Rates   map[string][]api.MailStatPoint `json:"rates"`
+		Current map[string]float64             `json:"current"`
+		Storage []repository.MailboxStorageRow `json:"storage"`
+	}
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	assert.Len(t, resp.Points["message_ingest"], 4)
+	rates := resp.Rates["message_ingest"]
+	if assert.Len(t, rates, 3) {
+		assert.Equal(t, float64(30), rates[0].V)
+		assert.Equal(t, float64(0), rates[1].V, "counter reset must clamp to 0, not go negative")
+		assert.Equal(t, float64(15), rates[2].V)
+	}
+	assert.Equal(t, float64(25), resp.Current["message_ingest"])
+	assert.Equal(t, float64(4), resp.Current["queue_size"])
+	if assert.Len(t, resp.Storage, 1) {
+		assert.Equal(t, "a@n.example", resp.Storage[0].Email)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3030,6 +3030,14 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/mail/stats:
+    get:
+      tags: [Mail]
+      summary: Mail statistics history + storage drilldown
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: query, name: hours, required: false, schema: { type: integer, minimum: 1, maximum: 2160, default: 24 } } ]
+      responses: { "200": { description: OK } }
+
   /admin/mail/queue:
     get:
       tags: [Mail]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -805,6 +805,12 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			ARFReports:      deps.ARFReports,
 			ServerSettings:  deps.ServerSettings,
 		})
+		// GH #873 — admin mail statistics (history + storage drilldown).
+		if deps.DB != nil {
+			api.RegisterAdminMailStatsRoutes(v1, api.AdminMailStatsHandlerConfig{
+				Stats: repository.NewMailStatsRepository(deps.DB),
+			})
+		}
 		// M47 Wave 3 — admin outbound-throttle CRUD.
 		api.RegisterAdminMailThrottlesRoutes(v1, api.AdminMailThrottlesHandlerConfig{
 			Policies:       deps.MailOutboundPolicies,

--- a/panel-api/internal/app/openapi_undocumented.golden
+++ b/panel-api/internal/app/openapi_undocumented.golden
@@ -1,1 +1,1 @@
-
+GET /admin/mail/stats

--- a/panel-api/internal/app/openapi_undocumented.golden
+++ b/panel-api/internal/app/openapi_undocumented.golden
@@ -1,1 +1,1 @@
-GET /admin/mail/stats
+

--- a/panel-api/internal/db/migrations/000248_mail_stats.down.sql
+++ b/panel-api/internal/db/migrations/000248_mail_stats.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE mail_stats_samples;

--- a/panel-api/internal/db/migrations/000248_mail_stats.up.sql
+++ b/panel-api/internal/db/migrations/000248_mail_stats.up.sql
@@ -1,0 +1,11 @@
+-- GH #873: mail statistics history. One row per (metric, sample time),
+-- fed every 15 minutes from Stalwart's Prometheus exporter by the mail
+-- stats ticker. Counters are stored cumulative (deltas are computed at
+-- query time, clamped >= 0 across Stalwart restarts); gauges are stored
+-- as-is. Pruned after 90 days by the same ticker.
+CREATE TABLE mail_stats_samples (
+  metric     varchar(64) NOT NULL,
+  sampled_at datetime(6) NOT NULL,
+  value      double      NOT NULL,
+  PRIMARY KEY (metric, sampled_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/reconciler/digest_ticker_test.go
+++ b/panel-api/internal/reconciler/digest_ticker_test.go
@@ -130,12 +130,19 @@ func TestDigestTick_PersistFailureSkipsSend(t *testing.T) {
 // call site, so it silently never ran. Pin that serve.go actually starts
 // the digest ticker.
 func TestServeWiresDigestTicker(t *testing.T) {
+	assertServeCalls(t, "reconciler.StartDigestTicker(")
+}
+
+// assertServeCalls fails unless serve.go contains the given call — the
+// JAB-203 regression shape (ticker written, never wired, silently dead).
+func assertServeCalls(t *testing.T, call string) {
+	t.Helper()
 	src, err := os.ReadFile(filepath.Join("..", "..", "cmd", "server", "serve.go"))
 	if err != nil {
 		t.Fatalf("read serve.go: %v", err)
 	}
-	if !strings.Contains(string(src), "reconciler.StartDigestTicker(") {
-		t.Fatal("serve.go does not call reconciler.StartDigestTicker — the digest would silently never run (JAB-203 shape)")
+	if !strings.Contains(string(src), call) {
+		t.Fatalf("serve.go does not call %s — the ticker would silently never run (JAB-203 shape)", call)
 	}
 }
 

--- a/panel-api/internal/reconciler/mail_stats_ticker.go
+++ b/panel-api/internal/reconciler/mail_stats_ticker.go
@@ -1,0 +1,98 @@
+package reconciler
+
+// GH #873: mail statistics collector. Every 15 minutes: one agent
+// mail.stats_sample call (Stalwart Prometheus counters + queue size),
+// stored verbatim into mail_stats_samples. Once a day it prunes samples
+// older than 90 days. Self-gating on the mail module: hosts without a
+// mail stack skip sampling entirely (the agent call would just fail
+// against a stopped Stalwart and warn-spam the log).
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const (
+	mailStatsInterval  = 15 * time.Minute
+	mailStatsRetention = 90 * 24 * time.Hour
+)
+
+type MailStatsTickerDeps struct {
+	Agent    agent.AgentInterface
+	Stats    repository.MailStatsRepository
+	Settings repository.ServerSettingsRepository
+	Log      bwTickerLogger
+}
+
+// StartMailStatsTicker runs until ctx is cancelled. Call in a goroutine.
+func StartMailStatsTicker(ctx context.Context, deps MailStatsTickerDeps) {
+	if deps.Agent == nil || deps.Stats == nil || deps.Log == nil {
+		return
+	}
+	deps.Log.Info("mail_stats_ticker starting", "interval", mailStatsInterval.String())
+	t := time.NewTicker(mailStatsInterval)
+	defer t.Stop()
+	lastPrune := time.Time{}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			mailStatsTick(ctx, deps)
+			if time.Since(lastPrune) > 24*time.Hour {
+				if n, err := deps.Stats.Prune(ctx, time.Now().UTC().Add(-mailStatsRetention)); err != nil {
+					deps.Log.Warn("mail stats: prune failed", "err", err)
+				} else if n > 0 {
+					deps.Log.Info("mail stats: pruned", "rows", n)
+				}
+				lastPrune = time.Now()
+			}
+		}
+	}
+}
+
+func mailStatsTick(ctx context.Context, deps MailStatsTickerDeps) {
+	if deps.Settings != nil {
+		sctx, scancel := context.WithTimeout(ctx, 5*time.Second)
+		srv, err := deps.Settings.Get(sctx)
+		scancel()
+		if err == nil && srv != nil && !srv.MailEnabled {
+			return
+		}
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	raw, err := deps.Agent.Call(cctx, "mail.stats_sample", map[string]any{})
+	cancel()
+	if err != nil {
+		deps.Log.Warn("mail stats: sample failed", "err", err)
+		return
+	}
+	var sample struct {
+		Metrics    map[string]float64 `json:"metrics"`
+		QueueSize  int64              `json:"queue_size"`
+		EnabledNow bool               `json:"enabled_now"`
+	}
+	if err := json.Unmarshal(raw, &sample); err != nil {
+		deps.Log.Warn("mail stats: decode sample failed", "err", err)
+		return
+	}
+	if sample.Metrics == nil {
+		sample.Metrics = map[string]float64{}
+	}
+	// Queue size rides along as a pseudo-gauge so history and charts get
+	// it with zero special-casing.
+	sample.Metrics["queue_size"] = float64(sample.QueueSize)
+
+	if err := deps.Stats.InsertSamples(ctx, time.Now().UTC(), sample.Metrics); err != nil {
+		deps.Log.Warn("mail stats: insert failed", "err", err)
+		return
+	}
+	if sample.EnabledNow {
+		deps.Log.Info("mail stats: stalwart prometheus exporter enabled (one-time)")
+	}
+}

--- a/panel-api/internal/reconciler/mail_stats_ticker_test.go
+++ b/panel-api/internal/reconciler/mail_stats_ticker_test.go
@@ -1,0 +1,72 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeMailStatsAgent struct {
+	calls int
+}
+
+func (f *fakeMailStatsAgent) Call(_ context.Context, method string, _ interface{}) (json.RawMessage, error) {
+	if method != "mail.stats_sample" {
+		return nil, nil
+	}
+	f.calls++
+	return json.RawMessage(`{"metrics":{"message_ingest":42,"smtp_active_connections":2},"queue_size":5,"enabled_now":false}`), nil
+}
+
+type fakeMailStatsRepo struct {
+	repository.MailStatsRepository
+	inserted map[string]float64
+}
+
+func (f *fakeMailStatsRepo) InsertSamples(_ context.Context, _ time.Time, metrics map[string]float64) error {
+	f.inserted = metrics
+	return nil
+}
+
+// GH #873: a tick stores every scraped metric plus queue_size as a
+// pseudo-gauge; hosts with the mail module off skip sampling entirely.
+func TestMailStatsTick_StoresMetricsAndQueue(t *testing.T) {
+	agent := &fakeMailStatsAgent{}
+	repo := &fakeMailStatsRepo{}
+	deps := MailStatsTickerDeps{
+		Agent:    agent,
+		Stats:    repo,
+		Settings: &fakeSettingsRepo{srv: &models.ServerSettings{MailEnabled: true}},
+		Log:      nopLogger{},
+	}
+	mailStatsTick(context.Background(), deps)
+	if agent.calls != 1 {
+		t.Fatalf("agent calls = %d", agent.calls)
+	}
+	if repo.inserted["message_ingest"] != 42 || repo.inserted["queue_size"] != 5 {
+		t.Fatalf("inserted = %v", repo.inserted)
+	}
+
+	// Mail module off: no agent call, no insert.
+	agent2 := &fakeMailStatsAgent{}
+	repo2 := &fakeMailStatsRepo{}
+	deps2 := MailStatsTickerDeps{
+		Agent:    agent2,
+		Stats:    repo2,
+		Settings: &fakeSettingsRepo{srv: &models.ServerSettings{MailEnabled: false}},
+		Log:      nopLogger{},
+	}
+	mailStatsTick(context.Background(), deps2)
+	if agent2.calls != 0 || repo2.inserted != nil {
+		t.Fatalf("mail-off host must not sample (calls=%d inserted=%v)", agent2.calls, repo2.inserted)
+	}
+}
+
+// JAB-203 shape guard for this ticker too.
+func TestServeWiresMailStatsTicker(t *testing.T) {
+	assertServeCalls(t, "reconciler.StartMailStatsTicker(")
+}

--- a/panel-api/internal/repository/mail_stats_repository.go
+++ b/panel-api/internal/repository/mail_stats_repository.go
@@ -1,0 +1,111 @@
+package repository
+
+// GH #873: storage for the mail-statistics samples the mail stats ticker
+// collects from Stalwart's Prometheus exporter.
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// MailStatSample is one (metric, time, value) point.
+type MailStatSample struct {
+	Metric    string    `gorm:"column:metric" json:"metric"`
+	SampledAt time.Time `gorm:"column:sampled_at" json:"sampled_at"`
+	Value     float64   `gorm:"column:value" json:"value"`
+}
+
+func (MailStatSample) TableName() string { return "mail_stats_samples" }
+
+// MailboxStorageRow is one mailbox with its owner chain, for the
+// Global -> User -> Domain -> Mailbox storage drilldown.
+type MailboxStorageRow struct {
+	Username   string `gorm:"column:username"    json:"username"`
+	DomainName string `gorm:"column:domain_name" json:"domain_name"`
+	Email      string `gorm:"column:email"       json:"email"`
+	UsageBytes uint64 `gorm:"column:usage_bytes" json:"usage_bytes"`
+	QuotaBytes uint64 `gorm:"column:quota_bytes" json:"quota_bytes"`
+}
+
+type MailStatsRepository interface {
+	// InsertSamples writes one row per metric at the given time.
+	InsertSamples(ctx context.Context, at time.Time, metrics map[string]float64) error
+	// Series returns all samples since `since`, ordered by metric then time.
+	Series(ctx context.Context, since time.Time) ([]MailStatSample, error)
+	// Prune deletes samples older than `olderThan`; returns rows removed.
+	Prune(ctx context.Context, olderThan time.Time) (int64, error)
+	// StorageDrilldown returns every mailbox with its usage and owner
+	// chain (usage is the mailbox-usage ticker's last sample).
+	StorageDrilldown(ctx context.Context) ([]MailboxStorageRow, error)
+}
+
+type mailStatsRepo struct{ db *gorm.DB }
+
+func NewMailStatsRepository(db *gorm.DB) MailStatsRepository {
+	return &mailStatsRepo{db: db}
+}
+
+func (r *mailStatsRepo) InsertSamples(ctx context.Context, at time.Time, metrics map[string]float64) error {
+	if len(metrics) == 0 {
+		return nil
+	}
+	rows := make([]MailStatSample, 0, len(metrics))
+	for m, v := range metrics {
+		rows = append(rows, MailStatSample{Metric: m, SampledAt: at, Value: v})
+	}
+	// Batch insert; the PK makes an accidental double-tick a conflict, not
+	// a duplicate — ignore those.
+	return r.db.WithContext(ctx).
+		Exec("INSERT IGNORE INTO mail_stats_samples (metric, sampled_at, value) VALUES "+
+			placeholders(len(rows)), flatten(rows)...).Error
+}
+
+func placeholders(n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			out += ","
+		}
+		out += "(?,?,?)"
+	}
+	return out
+}
+
+func flatten(rows []MailStatSample) []any {
+	out := make([]any, 0, len(rows)*3)
+	for _, r := range rows {
+		out = append(out, r.Metric, r.SampledAt, r.Value)
+	}
+	return out
+}
+
+func (r *mailStatsRepo) Series(ctx context.Context, since time.Time) ([]MailStatSample, error) {
+	var rows []MailStatSample
+	err := r.db.WithContext(ctx).
+		Where("sampled_at >= ?", since).
+		Order("metric ASC, sampled_at ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *mailStatsRepo) Prune(ctx context.Context, olderThan time.Time) (int64, error) {
+	res := r.db.WithContext(ctx).
+		Where("sampled_at < ?", olderThan).
+		Delete(&MailStatSample{})
+	return res.RowsAffected, res.Error
+}
+
+func (r *mailStatsRepo) StorageDrilldown(ctx context.Context) ([]MailboxStorageRow, error) {
+	var rows []MailboxStorageRow
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT u.username AS username, d.name AS domain_name,
+		       m.email_cached AS email, m.last_usage_bytes AS usage_bytes,
+		       m.quota_bytes AS quota_bytes
+		FROM mailboxes m
+		JOIN domains d ON d.id = m.domain_id
+		JOIN users   u ON u.id = d.user_id
+		ORDER BY u.username, d.name, m.email_cached`).Scan(&rows).Error
+	return rows, err
+}

--- a/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
+++ b/panel-ui/src/shells/admin/mail/AdminMailPage.tsx
@@ -36,6 +36,7 @@ import { ownerResourceCrumbs, ownerLabel, adminLinks } from "../../../components
 import type { Domain } from "../../user/domains/UserDomainList";
 import { EditMailboxModal } from "../../../components/mail/EditMailboxModal";
 import { AdminGroupsTab } from "./AdminGroupsTab";
+import { MailStatsTab } from "./MailStatsTab";
 import { CreateMailboxWizardModal } from "../../user/mail/CreateMailboxWizardModal";
 import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../components/PasswordInput";
@@ -198,11 +199,13 @@ export function AdminMailPage() {
         tabList={[
           { key: "mailboxes", tab: "Mailboxes" },
           { key: "groups", tab: "Groups" },
+          { key: "stats", tab: "Statistics" },
         ]}
         activeTabKey={tab}
         onTabChange={setTab}
       >
       {tab === "groups" && <AdminGroupsTab />}
+      {tab === "stats" && <MailStatsTab />}
       {tab === "mailboxes" && (
       <>
         <Space style={{ width: "100%", justifyContent: "flex-start", marginBottom: 16 }} wrap>

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
@@ -1,0 +1,228 @@
+// MailStatsTab — GH #873: mail statistics with history and a storage
+// drilldown (Global → User → Domain → Mailbox). Data comes from
+// GET /admin/mail/stats: `points` are raw sampled values (gauges),
+// `rates` are per-interval deltas (counters), both keyed by whatever
+// metric names Stalwart's exporter emits (it registers metrics lazily,
+// so charts appear as traffic flows).
+import { useMemo, useState } from "react";
+import { Alert, Card, Col, Radio, Row, Statistic, Table, Typography } from "antd";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../../apiClient";
+import { Sparkline, type SparklinePoint } from "../../../components/Sparkline";
+
+type Point = { t: string; v: number };
+
+type MailStats = {
+  points: Record<string, Point[]>;
+  rates: Record<string, Point[]>;
+  current: Record<string, number>;
+  storage: {
+    username: string;
+    domain_name: string;
+    email: string;
+    usage_bytes: number;
+    quota_bytes: number;
+  }[];
+};
+
+const fmtBytes = (n: number): string => {
+  if (n >= 1 << 30) return `${(n / (1 << 30)).toFixed(1)} GiB`;
+  if (n >= 1 << 20) return `${(n / (1 << 20)).toFixed(1)} MiB`;
+  if (n >= 1 << 10) return `${(n / (1 << 10)).toFixed(1)} KiB`;
+  return `${n} B`;
+};
+
+const toSpark = (pts: Point[] | undefined): SparklinePoint[] =>
+  (pts ?? []).map((p) => ({ x: p.t, y: p.v }));
+
+const ChartCard = ({
+  title,
+  data,
+  formatY,
+}: {
+  title: string;
+  data: SparklinePoint[];
+  formatY?: (n: number) => string;
+}) => (
+  <Card size="small" title={title}>
+    {data.length > 1 ? (
+      <Sparkline data={data} width={320} height={64} formatY={formatY} />
+    ) : (
+      <Typography.Text type="secondary">
+        Collecting — appears after a few samples.
+      </Typography.Text>
+    )}
+  </Card>
+);
+
+export const MailStatsTab = () => {
+  const [hours, setHours] = useState(24);
+  const stats = useQuery<MailStats>({
+    queryKey: ["admin", "mail", "stats", hours],
+    queryFn: async () =>
+      (await apiClient.get<MailStats>(`/admin/mail/stats?hours=${hours}`)).data,
+    refetchInterval: 60_000,
+  });
+
+  const s = stats.data;
+
+  // Storage drilldown: rows grouped client-side User → Domain → Mailbox.
+  const storageTree = useMemo(() => {
+    const users = new Map<
+      string,
+      { usage: number; domains: Map<string, { usage: number; boxes: MailStats["storage"] }> }
+    >();
+    for (const row of s?.storage ?? []) {
+      const u = users.get(row.username) ?? { usage: 0, domains: new Map() };
+      u.usage += row.usage_bytes;
+      const d = u.domains.get(row.domain_name) ?? { usage: 0, boxes: [] };
+      d.usage += row.usage_bytes;
+      d.boxes.push(row);
+      u.domains.set(row.domain_name, d);
+      users.set(row.username, u);
+    }
+    return [...users.entries()].map(([username, u]) => ({
+      key: username,
+      username,
+      usage: u.usage,
+      domains: [...u.domains.entries()].map(([domain, d]) => ({
+        key: `${username}/${domain}`,
+        domain,
+        usage: d.usage,
+        boxes: d.boxes,
+      })),
+    }));
+  }, [s?.storage]);
+
+  const totalStorage = storageTree.reduce((acc, u) => acc + u.usage, 0);
+
+  if (stats.isError) {
+    return <Alert type="error" message="Failed to load mail statistics" />;
+  }
+
+  return (
+    <>
+      <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
+        <Col xs={12} md={6}>
+          <Card size="small">
+            <Statistic title="Queue now" value={s?.current["queue_size"] ?? 0} />
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small">
+            <Statistic
+              title="SMTP connections"
+              value={s?.current["smtp_active_connections"] ?? 0}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small">
+            <Statistic
+              title="IMAP connections"
+              value={s?.current["imap_active_connections"] ?? 0}
+            />
+          </Card>
+        </Col>
+        <Col xs={12} md={6}>
+          <Card size="small">
+            <Statistic title="Mailbox storage" value={fmtBytes(totalStorage)} />
+          </Card>
+        </Col>
+      </Row>
+
+      <Radio.Group
+        value={hours}
+        onChange={(e) => setHours(e.target.value)}
+        style={{ marginBottom: 16 }}
+        options={[
+          { label: "24h", value: 24 },
+          { label: "7d", value: 168 },
+          { label: "30d", value: 720 },
+        ]}
+        optionType="button"
+      />
+
+      <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
+        <Col xs={24} md={8}>
+          <ChartCard
+            title="Messages processed"
+            data={toSpark(s?.rates["message_ingest"])}
+          />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard title="Queue size" data={toSpark(s?.points["queue_size"])} />
+        </Col>
+        <Col xs={24} md={8}>
+          <ChartCard
+            title="Successful logins"
+            data={toSpark(s?.rates["auth_success"])}
+          />
+        </Col>
+      </Row>
+
+      <Card size="small" title="Storage drilldown" loading={stats.isLoading}>
+        <Table
+          size="small"
+          rowKey="key"
+          pagination={false}
+          dataSource={storageTree}
+          columns={[
+            { title: "User", dataIndex: "username" },
+            {
+              title: "Usage",
+              dataIndex: "usage",
+              render: (v: number) => fmtBytes(v),
+              width: 140,
+            },
+          ]}
+          expandable={{
+            expandedRowRender: (user) => (
+              <Table
+                size="small"
+                rowKey="key"
+                pagination={false}
+                dataSource={user.domains}
+                columns={[
+                  { title: "Domain", dataIndex: "domain" },
+                  {
+                    title: "Usage",
+                    dataIndex: "usage",
+                    render: (v: number) => fmtBytes(v),
+                    width: 140,
+                  },
+                ]}
+                expandable={{
+                  expandedRowRender: (dom) => (
+                    <Table
+                      size="small"
+                      rowKey="email"
+                      pagination={false}
+                      dataSource={dom.boxes}
+                      columns={[
+                        { title: "Mailbox", dataIndex: "email" },
+                        {
+                          title: "Usage",
+                          dataIndex: "usage_bytes",
+                          render: (v: number) => fmtBytes(v),
+                          width: 140,
+                        },
+                        {
+                          title: "Quota",
+                          dataIndex: "quota_bytes",
+                          render: (v: number) => fmtBytes(v),
+                          width: 140,
+                        },
+                      ]}
+                    />
+                  ),
+                }}
+              />
+            ),
+          }}
+        />
+      </Card>
+    </>
+  );
+};


### PR DESCRIPTION
Phases 1+2 of #873 (johnnyq's mail analytics).

## What ships

- **Mail → Statistics tab**: queue-size / SMTP / IMAP connection / total-storage cards, 24h/7d/30d sparkline history (messages processed, queue size, logins), and a **User → Domain → Mailbox storage drilldown** table.
- **Collector**: agent `mail.stats_sample` scrapes Stalwart's Prometheus exporter (every counter + gauge, name-agnostic — Stalwart registers metrics lazily, so charts populate as traffic flows) plus the live `QueuedMessage` count. Panel ticker samples every 15 min into `mail_stats_samples` (migration 000248, 90-day retention, mail-module gated).
- **Exporter enablement is automatic and authenticated**: Stalwart ships it disabled; on first sample the agent enables it via the `x:Metrics` registry with a generated Basic-auth credential (root-only file) and restarts jabali-stalwart once (route mounts at boot — probe-verified on 0.16.15). Auth is non-negotiable: 8446 is localhost-only, but tenant processes reach localhost on a shared box, and an open exporter would leak server-wide mail telemetry.
- API returns raw points for gauges and positive per-interval deltas for counters (clamped at 0 across Stalwart-restart resets).

## Out of scope (Phase 3)

Per-domain/per-mailbox **traffic** drilldown — Stalwart's counters are server-wide only; that needs per-message event accounting and its own design pass.

## Tests

Agent: exposition parser (label summing, histogram drop), steady-state scrape (no config churn), first-run enable path (secret 0600, one x:Metrics/set, one restart). Panel: tick stores metrics + queue pseudo-gauge, mail-off gate, delta clamp at the API, serve.go call-site pin (JAB-203 shape). `-race` green on both modules; SPA builds.