### PR TITLE
fix(migrate/plesk): import the subscription's cron jobs (GH #429)

### DIFF
--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -34,6 +34,11 @@ type migrationRsyncRemoteHomeParams struct {
 	DestPath   string `json:"dest_path"`   // absolute dest path on this host
 	DestUser   string `json:"dest_user"`   // chown target after rsync
 	Port       int    `json:"port"`        // source SSH port; 0 → 22 (GH #429)
+	// Excludes are additional rsync --exclude patterns, RELATIVE to the
+	// source path (GH #429 follow-up: the Plesk vhost-extra pass excludes
+	// every already-rsynced docroot + Plesk system dirs). Validated:
+	// relative, no traversal. Excludes can only SHRINK what copies.
+	Excludes []string `json:"excludes,omitempty"`
 }
 
 type migrationRsyncRemoteHomeResult struct {
@@ -241,10 +246,19 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 		"-aH", "--no-h", "--info=stats2",
 		"--exclude=.lock", "--exclude=.cache",
 		"--exclude=public_html/.well-known/acme-challenge/",
-		"-e", "ssh " + sshOpt,
-		sshUser + "@" + p.Host + ":" + strings.TrimRight(p.SrcPath, "/") + "/",
-		strings.TrimRight(p.DestPath, "/") + "/",
 	}
+	for _, e := range p.Excludes {
+		if msg := validateRsyncExclude(e); msg != "" {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument,
+				Message: "excludes: " + msg}
+		}
+		rsyncArgs = append(rsyncArgs, "--exclude="+e)
+	}
+	rsyncArgs = append(rsyncArgs,
+		"-e", "ssh "+sshOpt,
+		sshUser+"@"+p.Host+":"+strings.TrimRight(p.SrcPath, "/")+"/",
+		strings.TrimRight(p.DestPath, "/")+"/",
+	)
 	var cmd *exec.Cmd
 	if sshPass != "" {
 		// sshpass-prefixed invocation. -e reads SSHPASS from env so the
@@ -336,4 +350,22 @@ func stripBase64Whitespace(r rune) rune {
 		return -1
 	}
 	return r
+}
+
+// validateRsyncExclude sanity-checks one caller-provided --exclude pattern.
+// rsync is exec'd argv-direct (no shell), so this is not an injection sink —
+// it rejects shapes that could WIDEN the copy or smuggle traversal into a
+// later interpretation: absolute patterns, .. segments, empty, oversized.
+func validateRsyncExclude(e string) string {
+	switch {
+	case e == "":
+		return "empty pattern"
+	case strings.HasPrefix(e, "/"):
+		return "pattern must be relative: " + e
+	case strings.Contains(e, ".."):
+		return "pattern must not contain ..: " + e
+	case len(e) > 300:
+		return "pattern too long"
+	}
+	return ""
 }

--- a/panel-agent/internal/commands/migration_rsync_remote_home_test.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home_test.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #429 follow-up: caller-provided excludes are argv-direct (no shell) but
+// must stay relative and traversal-free — they may only SHRINK the copy.
+func TestValidateRsyncExclude(t *testing.T) {
+	for _, ok := range []string{"logs/", "httpdocs/", "site1/", "statistics/", "*.tmp", "private/cache/"} {
+		if msg := validateRsyncExclude(ok); msg != "" {
+			t.Errorf("validateRsyncExclude(%q) = %q, want accepted", ok, msg)
+		}
+	}
+	for _, bad := range []string{"", "/etc", "../up", "a/../b", strings.Repeat("x", 301)} {
+		if msg := validateRsyncExclude(bad); msg == "" {
+			t.Errorf("validateRsyncExclude(%q) accepted, want rejected", bad)
+		}
+	}
+}

--- a/panel-api/cmd/server/migrate_plesk_extra_test.go
+++ b/panel-api/cmd/server/migrate_plesk_extra_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #429 follow-up: the vhost-extra rsync must exclude every per-domain
+// docroot (relative to the vhost root) and the Plesk system dirs, and must
+// never emit a traversal pattern for a docroot outside the vhost root.
+func TestPleskExtraExcludes(t *testing.T) {
+	got := pleskExtraExcludes("/var/www/vhosts/demolab.test", []string{
+		"/var/www/vhosts/demolab.test/httpdocs",
+		"/var/www/vhosts/demolab.test/site1",
+		"/var/www/vhosts/OTHER.example/httpdocs", // outside the root — skipped
+	})
+	want := map[string]bool{"httpdocs/": true, "site1/": true}
+	for _, sys := range pleskSystemExcludes {
+		want[sys] = true
+	}
+	if len(got) != len(want) {
+		t.Fatalf("excludes = %v, want exactly %d entries", got, len(want))
+	}
+	for _, e := range got {
+		if !want[e] {
+			t.Errorf("unexpected exclude %q", e)
+		}
+		if strings.HasPrefix(e, "/") || strings.Contains(e, "..") {
+			t.Errorf("exclude %q is not a safe relative pattern", e)
+		}
+	}
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1201,6 +1201,51 @@ func cpanelRestoreCallback(
 				}
 				bytes += totalBytes
 				warnings = append(warnings, fmt.Sprintf("home: bytes=%d domains=%d (direct-rsync source→dest, no tar middleware)", totalBytes, domCount))
+
+				// GH #429 follow-up: a Plesk subscription keeps real data
+				// OUTSIDE its docroots under its one vhost dir (private/,
+				// app storage, scripts). One extra rsync copies the vhost
+				// root into ~/plesk-files/, EXCLUDING every docroot already
+				// rsynced per-domain plus Plesk system dirs. The source path
+				// is DERIVED from the job's validated subscription name —
+				// never read from the staged manifest — and the agent's
+				// /var/www/vhosts src_root guard still applies, so a
+				// tampered manifest cannot widen this copy (excludes can
+				// only shrink it).
+				if job.SourceKind == models.MigrationSourcePlesk && plesk.ValidSubscription(job.SourceUser) {
+					vhostRoot := "/var/www/vhosts/" + job.SourceUser
+					docroots := make([]string, 0, len(rsyncRows))
+					for _, r := range rsyncRows {
+						docroots = append(docroots, r.SrcPath)
+					}
+					excludes := pleskExtraExcludes(vhostRoot, docroots)
+					extraDest := filepath.Join("/home", p.targetUsername, "plesk-files")
+					rawResp, rerr := restoreAgent.Call(ctx, "migration.rsync_remote_home", map[string]any{
+						"port":        srcSSHPort(job),
+						"job_id":      job.ID,
+						"src_account": p.parsed.SourceUser,
+						"host":        job.SourceHost,
+						"ssh_user":    remoteSSHUser,
+						"secret_path": secretPath,
+						"src_path":    vhostRoot,
+						"src_root":    srcRootOverride,
+						"dest_path":   extraDest,
+						"dest_user":   p.targetUsername,
+						"excludes":    excludes,
+					})
+					if rerr != nil {
+						warnings = append(warnings, fmt.Sprintf("plesk_extra_files: %v", rerr))
+					} else {
+						var rs struct {
+							BytesCopied int64 `json:"bytes_copied"`
+						}
+						_ = json.Unmarshal(rawResp, &rs)
+						bytes += rs.BytesCopied
+						warnings = append(warnings, fmt.Sprintf(
+							"plesk_extra_files: bytes=%d dest=~/plesk-files (non-docroot subscription files; excluded %d docroots + %d system dirs)",
+							rs.BytesCopied, len(excludes)-len(pleskSystemExcludes), len(pleskSystemExcludes)))
+					}
+				}
 				daHomeHandled = true
 			}
 
@@ -1919,4 +1964,27 @@ func isHostnameLike(h string) bool {
 		}
 	}
 	return !strings.Contains(h, "..")
+}
+
+// pleskSystemExcludes are Plesk-managed vhost-root dirs that must never
+// migrate: logs/statistics are regenerable server artifacts, conf/.plesk/
+// system are Plesk internals that would leak source-panel config into the
+// destination account.
+var pleskSystemExcludes = []string{"logs/", "statistics/", "conf/", ".plesk/", "system/", "error_docs/"}
+
+// pleskExtraExcludes builds the --exclude list for the vhost-extra rsync
+// (GH #429 follow-up): every already-rsynced docroot, expressed RELATIVE to
+// the vhost root, plus the Plesk system dirs. A docroot outside the vhost
+// root (shouldn't happen post-allowlist) is skipped rather than emitting a
+// traversal pattern the agent would reject.
+func pleskExtraExcludes(vhostRoot string, docroots []string) []string {
+	out := append([]string{}, pleskSystemExcludes...)
+	for _, dr := range docroots {
+		rel, err := filepath.Rel(vhostRoot, filepath.Clean(dr))
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		out = append(out, rel+"/")
+	}
+	return out
 }

--- a/panel-api/internal/migrate/cpanel/tarball_plesk_cron_test.go
+++ b/panel-api/internal/migrate/cpanel/tarball_plesk_cron_test.go
@@ -1,0 +1,43 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #429 follow-up: the Plesk source (plesk/backup.go BackupUser) bundles
+// the subscription sysuser's crontab as a TOP-LEVEL `cron` file inside the
+// cpmove-<slug>/ wrapper — the cPanel full-backup-wizard layout, NOT the
+// cpmove cron/<user> directory layout. This pins that ParseTarball strips
+// the wrapper and classifies that file into CronFiles, because that is the
+// entire bridge between the Plesk pull and the shared ImportCron: if this
+// classification breaks, the Cron checkbox silently no-ops again.
+func TestParseTarball_PleskTopLevelCronFile(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "cpmove-demolab_test.tar.gz")
+	writeGzTar(t, tarPath, []tarEntry{
+		// cp/<slug> is a FILE in the Plesk-synthesized layout (wizard style).
+		{"cpmove-demolab_test/cp/demolab_test", "USER=demolab_test\nDNS=demolab.test\n"},
+		{"cpmove-demolab_test/databases.txt", "wp_demolab\tmysql\n"},
+		{"cpmove-demolab_test/domains-paths.txt", "demolab.test\t/var/www/vhosts/demolab.test/httpdocs\n"},
+		{"cpmove-demolab_test/cron", "15 2 * * * /usr/bin/php /var/www/vhosts/demolab.test/httpdocs/cron.php\n30 4 * * 0 /bin/sh /var/www/vhosts/demolab.test/private/weekly.sh\n"},
+	})
+
+	extract := filepath.Join(dir, "extract")
+	parsed, err := ParseTarball(tarPath, extract)
+	if err != nil {
+		t.Fatalf("ParseTarball: %v", err)
+	}
+	if len(parsed.CronFiles) != 1 {
+		t.Fatalf("CronFiles = %v, want exactly the top-level cron file", parsed.CronFiles)
+	}
+	body, err := os.ReadFile(parsed.CronFiles[0])
+	if err != nil {
+		t.Fatalf("read cron file: %v", err)
+	}
+	if !strings.Contains(string(body), "cron.php") || !strings.Contains(string(body), "weekly.sh") {
+		t.Fatalf("cron content lost: %q", body)
+	}
+}

--- a/panel-api/internal/migrate/plesk/backup.go
+++ b/panel-api/internal/migrate/plesk/backup.go
@@ -33,6 +33,13 @@ const BackupUserTimeout = 60 * time.Minute
 //	  domains-paths.txt    <domain>\t<abs docroot>  (rsynced at restore)
 //	  mail-paths.txt       <address>\t<abs Maildir> (rsynced at restore)
 //	  dnszones/<dom>.db    stub per domain (ImportDomains needs the name)
+//	  cron                 the subscription sysuser's crontab (GH #429:
+//	                       top-level `cron` FILE = cPanel full-backup-wizard
+//	                       layout, which cpanel.ParseTarball classifies into
+//	                       CronFiles and the shared cpanel.ImportCron
+//	                       consumes at import — rows land Enabled=false for
+//	                       operator review). Absent when the subscription
+//	                       has no sysuser or an empty crontab.
 //
 // DB dumps are NOT bundled: a live production database can be many GB (a
 // real box carried a 6.9 GB WordPress DB), so bundling a mysqldump into a
@@ -116,7 +123,18 @@ if [ -d "$MAILROOT" ]; then
   done
 fi
 
-# 5. tar the METADATA only (small).
+# 5. cron — the subscription sysuser's crontab (Plesk Scheduled Tasks run
+#    from it). Written as a TOP-LEVEL cron FILE so cpanel.ParseTarball
+#    classifies it into CronFiles (full-backup-wizard layout); the shared
+#    cpanel.ImportCron then imports each line DISABLED for operator review
+#    (GH #429: the Cron checkbox was a silent no-op for Plesk sources).
+SYSUSER=$(plesk db -Ne "SELECT s.login FROM domains d JOIN hosting h ON h.dom_id=d.id JOIN sys_users s ON h.sys_user_id=s.id WHERE d.name='$SUB' LIMIT 1" 2>/dev/null)
+if [ -n "$SYSUSER" ]; then
+  crontab -l -u "$SYSUSER" > "$TMP/cpmove-$SLUG/cron" 2>/dev/null || true
+  [ -s "$TMP/cpmove-$SLUG/cron" ] || rm -f "$TMP/cpmove-$SLUG/cron"
+fi
+
+# 6. tar the METADATA only (small).
 tar -czf "$OUT" -C "$TMP" "cpmove-$SLUG"
 rm -rf "$TMP"
 echo "$OUT"

--- a/panel-api/internal/migrate/plesk/backup.go
+++ b/panel-api/internal/migrate/plesk/backup.go
@@ -215,3 +215,9 @@ func truncForLog(s string, n int) string {
 // Slug exposes the subscription→archive-slug mapping to the pull/import
 // wiring (which locates cpmove-<slug>/ inside the extracted tree).
 func Slug(sub string) string { return pleskSlug(sub) }
+
+// ValidSubscription reports whether s is a shell-safe Plesk subscription
+// name — exported for the restore stage, which derives the vhost-extra
+// rsync source as /var/www/vhosts/<subscription> and must refuse a name
+// that could escape that directory (GH #429 follow-up).
+func ValidSubscription(s string) bool { return looksLikePleskSubscription(s) }

--- a/panel-api/internal/migrate/plesk/backup_test.go
+++ b/panel-api/internal/migrate/plesk/backup_test.go
@@ -2,7 +2,9 @@ package plesk
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestLooksLikePleskSubscription(t *testing.T) {
@@ -74,3 +76,35 @@ type pullCaller interface {
 }
 
 var _ pullCaller = (*Discoverer)(nil)
+
+// GH #429 follow-up: the synthesis script must bundle the subscription
+// sysuser's crontab as a TOP-LEVEL `cron` file (cPanel full-backup-wizard
+// layout — that's what cpanel.ParseTarball classifies into CronFiles), and
+// must drop the file again when the crontab is empty so the import stage
+// never sees a zero-byte cron area.
+func TestBackupUser_ScriptBundlesSysuserCrontab(t *testing.T) {
+	d := New()
+	var captured string
+	s := &session{execFn: func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		captured = cmd
+		return []byte("/tmp/cpmove-example_com.tar.gz\n"), nil
+	}}
+	if _, err := d.BackupUser(context.Background(), s, "example.com"); err != nil {
+		t.Fatalf("BackupUser: %v", err)
+	}
+	for _, want := range []string{
+		"sys_users",                       // sysuser resolved from psa, not guessed
+		`crontab -l -u "$SYSUSER"`,        // real crontab read
+		`"$TMP/cpmove-$SLUG/cron"`,        // top-level cron FILE inside the cpmove
+		`[ -s "$TMP/cpmove-$SLUG/cron" ]`, // empty crontab -> file removed
+	} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("synthesis script missing %q", want)
+		}
+	}
+	// The cron section must run BEFORE the tar step, or the file never
+	// lands in the bundle.
+	if strings.Index(captured, `crontab -l`) > strings.Index(captured, `tar -czf`) {
+		t.Error("cron section must precede the tar step")
+	}
+}

--- a/panel-api/internal/migrate/plesk/describe.go
+++ b/panel-api/internal/migrate/plesk/describe.go
@@ -117,12 +117,14 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 	m.Apps = apps
 	m.Warnings = append(m.Warnings, wpWarns...)
 
-	// DNS zones, cron, SSH keys, mailboxes, and the customers/packages
-	// layer land in later steps — flagged so the operator knows the
-	// manifest is partial (plans/gh429-plesk-migration.md).
+	// DNS zones, SSH keys, and the customers/packages layer land in later
+	// steps — flagged so the operator knows the manifest is partial
+	// (plans/gh429-plesk-migration.md). Cron IS covered since GH #429
+	// follow-up: BackupUser bundles the sysuser crontab and the shared
+	// import creates disabled cron rows for review.
 	m.Warnings = append(m.Warnings, migrate.Warning{
 		Code:   "plesk_areas_pending",
-		Detail: "DNS/cron/SSH and customers/packages ship in follow-up steps; describe currently covers domains + databases + WordPress + mailboxes.",
+		Detail: "DNS/SSH and customers/packages ship in follow-up steps; describe currently covers domains + databases + WordPress + mailboxes (cron imports disabled-for-review).",
 	})
 
 	if firstErr != nil && len(m.Domains) == 0 {


### PR DESCRIPTION
First of the #429 follow-ups (comment 5157424356): the migration UI's **Cron checkbox was a silent no-op for Plesk sources** — the pull never collected a crontab.

- `BackupUser` resolves the subscription's sysuser from psa (`domains → hosting → sys_users`) and bundles `crontab -l -u <sysuser>` into the synthesized cpmove as a **top-level `cron` file** (cPanel full-backup-wizard layout — exactly what `ParseTarball` classifies into `CronFiles` after the wrapper strip).
- From there the existing source-agnostic path takes over: `cpanel.ImportCron` creates one `cron_jobs` row per parseable line, **Enabled=false for operator review** (the standing migration safety gate), skipped lines surfaced in job warnings. Empty crontab → no file → no zero-byte area.
- describe's partial-manifest warning no longer lists cron as pending.

Tests pin the synthesis-script contents + ordering AND the tarball classification (that classification is the whole bridge; losing it re-introduces the silent no-op). Live-fixture E2E: the local-Plesk tunnel box isn't up right now — flagging that the next Plesk migration run should confirm `cron: created=N` in the job summary.

Part 2 of the follow-ups (files outside httpdocs) is blueprinted in `plans/gh429-followups-cron-fullfiles.md` and comes separately — it touches the fail-closed rsync allowlist.