### PR TITLE
fix(migrate/plesk): exclude the chroot shell template from the vhost-extra pass (GH #429)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1970,7 +1970,14 @@ func isHostnameLike(h string) bool {
 // migrate: logs/statistics are regenerable server artifacts, conf/.plesk/
 // system are Plesk internals that would leak source-panel config into the
 // destination account.
-var pleskSystemExcludes = []string{"logs/", "statistics/", "conf/", ".plesk/", "system/", "error_docs/"}
+var pleskSystemExcludes = []string{
+	"logs/", "statistics/", "conf/", ".plesk/", "system/", "error_docs/",
+	// Plesk chroot shell template (observed on Obsidian 18.0.79: the vhost
+	// root carries a full chroot toolchain). Copying it would land /bin,
+	// /lib64 etc. into ~/plesk-files. User data lives in private/ and
+	// custom-named dirs, which still copy.
+	"bin/", "dev/", "etc/", "lib/", "lib64/", "sbin/", "usr/", "var/", "tmp/",
+}
 
 // pleskExtraExcludes builds the --exclude list for the vhost-extra rsync
 // (GH #429 follow-up): every already-rsynced docroot, expressed RELATIVE to


### PR DESCRIPTION
Caught on a live Plesk Obsidian 18.0.79 box while preparing the #880 E2E: the subscription vhost root contains Plesk's chroot shell template (`bin/ dev/ etc/ lib/ lib64/ sbin/ usr/ var/ tmp/`). Without these excludes the vhost-extra pass copies a whole chroot toolchain into `~/plesk-files/`. User data (`private/`, custom dirs, loose files) still copies. Excludes remain shrink-only.