### PR TITLE
fix(migrate/plesk): mailboxes never migrated — rsync Maildirs from the source (JAB-152)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1350,6 +1350,73 @@ func cpanelRestoreCallback(
 		// The agent copies <Maildir>/ CONTENTS (trailing slash), so cur/new/tmp
 		// land directly under <local>/ — exactly the layout ImportMailboxes
 		// walks. Point MailRoot there so the generic import below picks it up.
+		// JAB-152: Plesk has the SAME shape as CyberPanel here — Maildirs live
+		// outside the account home (/var/qmail/mailnames/<domain>/<local>/
+		// Maildir) and the Plesk tarball is metadata-only by design, so
+		// ImportMailboxes below finds nothing to walk. The live E2E against a
+		// Plesk Obsidian 18.0.79 box migrated files and databases correctly and
+		// silently moved ZERO of 3 mailboxes, reporting the job done. Reuse the
+		// same rsync-then-point-MailRoot approach; the source paths differ, and
+		// for Plesk they are verified against the source psa DB rather than the
+		// staged manifest.
+		if plan.Mailboxes && job.SourceKind == models.MigrationSourcePlesk && job.SourceHost != "" {
+			mailManifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+plesk.Slug(job.SourceUser), "mail-paths.txt")
+			raw, rerr := os.ReadFile(mailManifest)
+			if rerr != nil {
+				warnings = append(warnings, "mail_rsync: no mail-paths.txt in the Plesk tarball — no mailboxes to migrate")
+			} else if allowed, aerr := pleskAuthorizedMaildirs(ctx, job, sharedDB); aerr != nil {
+				// FAIL CLOSED, and loudly: silently skipping mail is exactly the
+				// failure this fix exists to remove.
+				p.criticals = append(p.criticals, fmt.Sprintf(
+					"security: could not verify Plesk mailboxes from source psa (%v) — mail rsync refused (fail-closed)", aerr))
+			} else {
+				secretPath := fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID)
+				remoteSSHUser := migrationSSHUser(job)
+				destMailRoot := filepath.Join("/home", p.targetUsername, "mail")
+				mboxCount := 0
+				for _, line := range strings.Split(string(raw), "\n") {
+					parts := strings.SplitN(strings.TrimSpace(line), "\t", 2)
+					if len(parts) != 2 {
+						continue
+					}
+					addr, srcMaildir := strings.TrimSpace(parts[0]), filepath.Clean(strings.TrimSpace(parts[1]))
+					at := strings.LastIndex(addr, "@")
+					if at < 1 {
+						continue
+					}
+					// The manifest may name a path; only the SOURCE decides
+					// which paths are ours.
+					if want, ok := allowed[addr]; !ok || want != srcMaildir {
+						p.criticals = append(p.criticals, fmt.Sprintf(
+							"security: mail source %q for %q is not an authoritative Maildir of subscription %q — refused",
+							srcMaildir, addr, job.SourceUser))
+						continue
+					}
+					local, mdom := addr[:at], addr[at+1:]
+					if _, mrErr := restoreAgent.Call(ctx, "migration.rsync_remote_home", map[string]any{
+						"port":        srcSSHPort(job),
+						"job_id":      job.ID,
+						"src_account": p.parsed.SourceUser,
+						"src_root":    "/var/qmail/mailnames",
+						"host":        job.SourceHost,
+						"ssh_user":    remoteSSHUser,
+						"secret_path": secretPath,
+						"src_path":    srcMaildir,
+						"dest_path":   filepath.Join(destMailRoot, mdom, local),
+						"dest_user":   p.targetUsername,
+					}); mrErr != nil {
+						warnings = append(warnings, fmt.Sprintf("mail_rsync: %s: %v", addr, mrErr))
+						continue
+					}
+					mboxCount++
+				}
+				if mboxCount > 0 {
+					p.parsed.MailRoot = destMailRoot
+					warnings = append(warnings, fmt.Sprintf("mail: rsynced %d maildir(s) -> %s (Plesk /var/qmail/mailnames)", mboxCount, destMailRoot))
+				}
+			}
+		}
+
 		if plan.Mailboxes && job.SourceKind == models.MigrationSourceCyberPanel && job.SourceHost != "" {
 			mailManifest := filepath.Join(p.parsed.ExtractDir, "cpmove-"+p.parsed.SourceUser, "mail-paths.txt")
 			if raw, rerr := os.ReadFile(mailManifest); rerr == nil {
@@ -1909,6 +1976,41 @@ func primaryDomainFromManifest(manifestJSON *string) string {
 // (authoritative — not the staged manifest). The import rsync guard rsyncs
 // ONLY paths under these. Returns an error (→ fail-closed refuse-all) when
 // the source can't be reached/verified or reports zero domains.
+// pleskAuthorizedMaildirs returns address -> Maildir for every mailbox the
+// subscription owns, read fresh from the SOURCE psa DB. Mail counterpart of
+// pleskAuthorizedDocroots and fail-closed for the same reason: the rsync runs
+// as root over SSH and every Plesk subscription's mail sits side by side under
+// /var/qmail/mailnames/, so a manifest-trusting import could pull another
+// tenant's mail (JAB-152).
+func pleskAuthorizedMaildirs(ctx context.Context, job *models.MigrationJob, db *gorm.DB) (map[string]string, error) {
+	allowPrivate := false
+	if s, err := repository.NewServerSettingsRepository(db).Get(ctx); err == nil && s != nil {
+		allowPrivate = s.MigrationAllowPrivateHosts
+	}
+	d := plesk.New()
+	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
+	secret := migrate.SecretRef{Path: fmt.Sprintf("/etc/jabali-panel/migration-secrets/%s.env", job.ID), ExpectedHostKey: job.ExpectedHostKey}
+	sess, err := d.Connect(ctx, job.SourceHost, migrationSSHUser(job), secret)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, sess) }()
+	boxes, err := d.AuthoritativeMaildirs(ctx, sess, job.SourceUser)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]string{}
+	for addr, md := range boxes {
+		// Defence in depth on (untrusted) psa output: only Maildirs physically
+		// under the Plesk mailnames root, never /etc, /root, …
+		if cl := filepath.Clean(md); strings.HasPrefix(cl, "/var/qmail/mailnames/") {
+			out[addr] = cl
+		}
+	}
+	return out, nil
+}
+
 func pleskAuthorizedDocroots(ctx context.Context, job *models.MigrationJob, db *gorm.DB) (map[string]bool, error) {
 	allowPrivate := false
 	if s, err := repository.NewServerSettingsRepository(db).Get(ctx); err == nil && s != nil {

--- a/panel-api/internal/migrate/cpanel/restore_mail.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail.go
@@ -71,18 +71,26 @@ func ImportMailboxes(ctx context.Context, parsed *ParsedTarball, agentCli agent.
 		return nil, fmt.Errorf("ImportMailboxes: parsed nil")
 	}
 	res := &MailImportResult{}
-	if parsed.HomeDir == "" {
-		// No homedir → no Maildir tree. Not fatal; record + return.
-		res.Skipped = append(res.Skipped, "mailbox_skip:no_homedir_in_tarball")
-		return res, nil
-	}
 
 	// MailRoot is set by per-importer parsers (cpanel: HomeDir/mail,
-	// DA: HomeDir/email via the directadmin adapter). Fallback to
-	// HomeDir/mail when caller didn't set it (legacy callers + cpanel
-	// pre-MailRoot tarballs).
+	// DA: HomeDir/email via the directadmin adapter) and by the callers that
+	// rsync Maildirs in from outside the tarball. Fallback to HomeDir/mail
+	// when neither applies (legacy callers + cpanel pre-MailRoot tarballs).
+	//
+	// JAB-152: this used to return early whenever HomeDir was empty, which made
+	// mail import IMPOSSIBLE for any source whose tarball is metadata-only. The
+	// Plesk tarball is exactly that by design (see plesk/backup.go: "the homedir
+	// and Maildirs are NOT bundled"), so a live Plesk migration moved files and
+	// databases correctly and silently moved ZERO mailboxes while reporting the
+	// job done. An explicit MailRoot is a complete answer on its own — the
+	// homedir check only ever existed to derive HomeDir/mail.
 	mailRoot := parsed.MailRoot
 	if mailRoot == "" {
+		if parsed.HomeDir == "" {
+			// Nothing to derive a mail tree from. Not fatal; record + return.
+			res.Skipped = append(res.Skipped, "mailbox_skip:no_homedir_in_tarball")
+			return res, nil
+		}
 		mailRoot = filepath.Join(parsed.HomeDir, "mail")
 	}
 	if !existsDir(mailRoot) {

--- a/panel-api/internal/migrate/cpanel/restore_mail_mailroot_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_mail_mailroot_test.go
@@ -1,0 +1,69 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-152: ImportMailboxes used to return early whenever HomeDir was empty,
+// which made mail import IMPOSSIBLE for any source whose tarball is
+// metadata-only. Plesk's is exactly that by design — plesk/backup.go states
+// "the homedir (docroots) and Maildirs are NOT bundled" — so a live Plesk
+// migration moved 85 MB of files and 2 databases correctly and silently moved
+// ZERO of 3 mailboxes, while reporting the job done.
+//
+// An explicit MailRoot is a complete answer on its own; the HomeDir check only
+// ever existed to derive HomeDir/mail.
+func TestImportMailboxesAcceptsExplicitMailRootWithoutHomeDir(t *testing.T) {
+	t.Parallel()
+
+	// A Maildir tree rsynced in from outside the tarball, exactly as the Plesk
+	// and CyberPanel paths produce: <mailroot>/<domain>/<local>/{cur,new,tmp}.
+	root := t.TempDir()
+	box := filepath.Join(root, "example.com", "info")
+	for _, sub := range []string{"cur", "new", "tmp"} {
+		if err := os.MkdirAll(filepath.Join(box, sub), 0o750); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(box, "cur", "1.msg"), []byte("From: a@b\n\nhi\n"), 0o640); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	parsed := &ParsedTarball{MailRoot: root} // HomeDir deliberately empty
+
+	// agentCli nil = observation-only; enough to prove we get PAST the gate.
+	res, err := ImportMailboxes(context.Background(), parsed, nil, "job1", nil, nil, false, "target")
+	if err != nil {
+		t.Fatalf("ImportMailboxes: %v", err)
+	}
+	for _, s := range res.Skipped {
+		if strings.Contains(s, "no_homedir_in_tarball") {
+			t.Fatalf("an explicit MailRoot must satisfy the gate, but import skipped with %q — "+
+				"this is the bug that made Plesk mail migration impossible", s)
+		}
+	}
+}
+
+// With neither a MailRoot nor a HomeDir there is genuinely nothing to walk, and
+// the skip must still be recorded rather than silently passing.
+func TestImportMailboxesStillSkipsWithNeitherRoot(t *testing.T) {
+	t.Parallel()
+
+	res, err := ImportMailboxes(context.Background(), &ParsedTarball{}, nil, "job1", nil, nil, false, "target")
+	if err != nil {
+		t.Fatalf("ImportMailboxes: %v", err)
+	}
+	found := false
+	for _, s := range res.Skipped {
+		if strings.Contains(s, "no_homedir_in_tarball") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("with no MailRoot and no HomeDir the skip must be recorded, not silent")
+	}
+}

--- a/panel-api/internal/migrate/plesk/mail.go
+++ b/panel-api/internal/migrate/plesk/mail.go
@@ -69,3 +69,54 @@ func parseFirstInt(s string) int64 {
 	}
 	return n
 }
+
+// AuthoritativeMaildirs returns the Maildir path for every mailbox the
+// subscription owns, keyed by full address, read fresh from the SOURCE's psa
+// database.
+//
+// This is the mail counterpart of AuthoritativeDocroots and exists for the same
+// reason (GH #746 / JAB-152): the migration rsyncs as ROOT over SSH, so the set
+// of source paths it may read must never come from a staged manifest an
+// attacker or a stale run could have written. A Plesk host has no
+// per-subscription filesystem root — every subscription's mail sits side by side
+// under /var/qmail/mailnames/<domain>/ — so without an allowlist derived from
+// the source itself, one tenant's migration could pull another tenant's mail.
+//
+// Callers FAIL CLOSED on error: refuse every mail rsync rather than fall back to
+// trusting the manifest.
+func (d *Discoverer) AuthoritativeMaildirs(ctx context.Context, raw migrate.Session, sub string) (map[string]string, error) {
+	doms, err := d.AuthoritativeDomains(ctx, raw, sub)
+	if err != nil {
+		return nil, err
+	}
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, fmt.Errorf("AuthoritativeMaildirs: wrong session type")
+	}
+	out := map[string]string{}
+	for _, dom := range doms {
+		dom = strings.TrimSpace(dom)
+		if dom == "" {
+			continue
+		}
+		// psa is the authority on which mail names exist for the domain; the
+		// filesystem is the authority on where the Maildir is. Query psa so a
+		// stray directory left behind by a deleted mailbox is not migrated.
+		sql := fmt.Sprintf(
+			"SELECT m.mail_name FROM mail m JOIN domains d ON m.dom_id=d.id WHERE d.name=%s",
+			sqlQuote(dom))
+		outRaw, err := s.run(ctx, d.CommandTimeout, "plesk db -Ne "+shellQuote(sql))
+		if err != nil {
+			return nil, fmt.Errorf("query psa mailboxes for %s: %w", dom, err)
+		}
+		for _, local := range splitLines(string(outRaw)) {
+			local = strings.TrimSpace(local)
+			if local == "" || strings.ContainsAny(local, "/\\") || strings.Contains(local, "..") {
+				continue // never let a mail name shape a path
+			}
+			md := pleskMailnamesRoot + "/" + dom + "/" + local + "/Maildir"
+			out[local+"@"+dom] = md
+		}
+	}
+	return out, nil
+}

--- a/panel-api/internal/migrate/plesk/mail_authoritative_test.go
+++ b/panel-api/internal/migrate/plesk/mail_authoritative_test.go
@@ -1,0 +1,68 @@
+package plesk
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The mail rsync runs as ROOT over SSH, and every Plesk subscription's mail
+// sits side by side under /var/qmail/mailnames/. So the set of source paths the
+// migration may read must be derived from the SOURCE, never from the staged
+// manifest — the same reasoning as the docroot guard after GH #746.
+//
+// These pin the query shape, because that is what decides which paths are
+// considered ours. A query that dropped the domain join would allowlist every
+// mailbox on the host.
+func TestAuthoritativeMaildirsQueryIsScopedToTheDomain(t *testing.T) {
+	t.Parallel()
+	src := readSourceFile(t, "mail.go")
+
+	for _, want := range []string{
+		"FROM mail m JOIN domains d ON m.dom_id=d.id",
+		"WHERE d.name=",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("AuthoritativeMaildirs must scope its psa query with %q — without it "+
+				"the allowlist would cover every mailbox on the source host", want)
+		}
+	}
+	if !strings.Contains(src, "sqlQuote(dom)") {
+		t.Error("the domain must go through sqlQuote — it reaches a shell-quoted `plesk db` invocation")
+	}
+}
+
+// A mail name is used to build a filesystem path that root then rsyncs from.
+func TestAuthoritativeMaildirsRejectsPathShapedMailNames(t *testing.T) {
+	t.Parallel()
+	src := readSourceFile(t, "mail.go")
+	if !strings.Contains(src, `strings.ContainsAny(local, "/\\")`) || !strings.Contains(src, `strings.Contains(local, "..")`) {
+		t.Error("a psa mail_name must never be allowed to contain a path separator or traversal — " +
+			"it is concatenated into a path that root rsyncs from")
+	}
+}
+
+// The Maildir layout is Plesk's, not a guess: <root>/<domain>/<local>/Maildir.
+func TestAuthoritativeMaildirsBuildsThePleskLayout(t *testing.T) {
+	t.Parallel()
+	src := readSourceFile(t, "mail.go")
+	if !strings.Contains(src, `pleskMailnamesRoot + "/" + dom + "/" + local + "/Maildir"`) {
+		t.Error("Maildir path must be <mailnames root>/<domain>/<local>/Maildir")
+	}
+	if !strings.Contains(src, `const pleskMailnamesRoot = "/var/qmail/mailnames"`) {
+		t.Error("the mailnames root constant moved; the rsync guard's prefix check depends on it")
+	}
+}
+
+// readSourceFile reads a file from this package. These tests assert on the
+// SQL and path construction rather than round-tripping a live Plesk box,
+// because the property that matters — "the allowlist comes from the source and
+// is scoped to this subscription" — is a property of the query text.
+func readSourceFile(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Found by the **live source→dest E2E that JAB-152 was parked waiting for**, run
against a non-production Plesk Obsidian 18.0.79.4.

Files and databases migrate correctly:

```
databases: created=2      (1 table + 12 tables, verified on disk)
home:      85,575,868 bytes across 2 domains
domains:   created=3      appconfigs: wordpress=1
health_probe: 2/2 domains healthy
```

…and **zero of the subscription's 3 mailboxes moved, while the job reported
`done`.**

## Two independent causes

**1. Nothing consumed `mail-paths.txt`.** `plesk/backup.go` writes it
(address → absolute Maildir) precisely so restore can rsync each Maildir — the
Plesk tarball is metadata-only by design, its own comment says *"the homedir
(docroots) and Maildirs are NOT bundled"*. `domains-paths.txt` has a consumer
and drove the docroot rsync that worked. `mail-paths.txt` had none.

CyberPanel already solved the identical shape (Maildirs outside the home) by
rsyncing each one in and pointing `MailRoot` at the result, so this reuses that
path rather than inventing a second one.

**2. `ImportMailboxes` returned early whenever `HomeDir` was empty** — so even
with Maildirs staged it would still have skipped. That check only ever existed
to derive `HomeDir/mail`; an explicit `MailRoot` is a complete answer on its
own. As written it made mail import impossible for **any** source whose tarball
is metadata-only — a class, not a Plesk quirk.

## Security

The rsync runs as **root over SSH**, and every Plesk subscription's mail sits
side by side under `/var/qmail/mailnames/` — so a manifest-trusting import could
pull another tenant's mail.

`pleskAuthorizedMaildirs` re-derives the allowed set from the **source psa DB**
on every run; the import refuses any manifest row that doesn't match, and
**fails closed** on any error. Same shape as `pleskAuthorizedDocroots` after
GH #746. psa output is treated as untrusted too: a `mail_name` containing a path
separator or traversal is dropped, and only paths physically under
`/var/qmail/mailnames/` are allowlisted.

## Verification — now done live

**Verified end to end against a real Plesk Obsidian 18.0.79.4 box.** With this
build on a clean destination:

```
mail: rsynced 3 maildir(s) -> /home/demolab_test/mail (Plesk /var/qmail/mailnames)
mailboxes: count=3
databases: created=2
home: 85,575,868 bytes across 2 domains
domains: created=3
```

Previously **0 of 3** mailboxes migrated. The Maildirs are on disk with the full
Plesk structure — `cur`, `tmp`, `.Sent`, `.Trash`, `.Spam` — under
`/home/<user>/mail/<domain>/<local>`, which is the layout `ImportMailboxes`
walks.

`messages_pushed=0` is correct here, not a gap: the source mailboxes are empty.
Source and destination both show one file per mailbox and it is `maildirsize`, a
Plesk quota bookkeeping file, not a message. The rsync copied everything that
was there.

### Retraction

An earlier revision of this description claimed an agent-side bug in
`migration_rsync_remote_home.go`, where the dest scope check reported:

```
not_in_scope: path "/home" is not within owned docroots: [/home/demolab_test]
```

**That was wrong.** The cause was my test destination: a leftover OS account
survived `userdel` because live processes held it, while its home had already
been removed, so user provisioning failed with `already_exists` and
`/home/demolab_test` was never created. `filesafe.Scope.Resolve` walks to the
nearest existing ancestor, so a missing home resolves to `/home`, correctly out
of scope. The agent behaved properly throughout, and PR #880 never needed
avoiding.

## Test plan

- [x] explicit `MailRoot` satisfies the gate — **verified failing against the
      old gate** (`mailbox_skip:no_homedir_in_tarball`)
- [x] the skip is still recorded when there is neither `MailRoot` nor `HomeDir`
- [x] the psa query stays scoped to the subscription's domains; path-shaped mail
      names rejected
- [x] `go build`, `go vet`, full `panel-api/internal/migrate/...` green
- [x] **live E2E on a real Plesk box: 3/3 Maildirs migrated**
