### PR TITLE
fix(migrate): cron import re-run dedupe + anchored vhost-extra excludes (GH #429)

### DIFF
--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -354,14 +354,16 @@ func stripBase64Whitespace(r rune) rune {
 
 // validateRsyncExclude sanity-checks one caller-provided --exclude pattern.
 // rsync is exec'd argv-direct (no shell), so this is not an injection sink —
-// it rejects shapes that could WIDEN the copy or smuggle traversal into a
-// later interpretation: absolute patterns, .. segments, empty, oversized.
+// it rejects shapes that could smuggle traversal into a later
+// interpretation: .. segments, empty, oversized. A leading "/" is ALLOWED
+// and encouraged: in rsync exclude semantics it anchors the pattern to the
+// TRANSFER root (not the filesystem root), which is how the Plesk
+// vhost-extra pass pins its excludes so a user's own private/bin/ deeper
+// in the tree still copies. Excludes can only SHRINK the copy either way.
 func validateRsyncExclude(e string) string {
 	switch {
 	case e == "":
 		return "empty pattern"
-	case strings.HasPrefix(e, "/"):
-		return "pattern must be relative: " + e
 	case strings.Contains(e, ".."):
 		return "pattern must not contain ..: " + e
 	case len(e) > 300:

--- a/panel-agent/internal/commands/migration_rsync_remote_home_test.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home_test.go
@@ -8,12 +8,12 @@ import (
 // GH #429 follow-up: caller-provided excludes are argv-direct (no shell) but
 // must stay relative and traversal-free — they may only SHRINK the copy.
 func TestValidateRsyncExclude(t *testing.T) {
-	for _, ok := range []string{"logs/", "httpdocs/", "site1/", "statistics/", "*.tmp", "private/cache/"} {
+	for _, ok := range []string{"/logs", "/httpdocs", "/site1", "/bin", "*.tmp", "private/cache/"} {
 		if msg := validateRsyncExclude(ok); msg != "" {
 			t.Errorf("validateRsyncExclude(%q) = %q, want accepted", ok, msg)
 		}
 	}
-	for _, bad := range []string{"", "/etc", "../up", "a/../b", strings.Repeat("x", 301)} {
+	for _, bad := range []string{"", "../up", "a/../b", "/..", strings.Repeat("x", 301)} {
 		if msg := validateRsyncExclude(bad); msg == "" {
 			t.Errorf("validateRsyncExclude(%q) accepted, want rejected", bad)
 		}

--- a/panel-api/cmd/server/migrate_plesk_extra_test.go
+++ b/panel-api/cmd/server/migrate_plesk_extra_test.go
@@ -14,7 +14,7 @@ func TestPleskExtraExcludes(t *testing.T) {
 		"/var/www/vhosts/demolab.test/site1",
 		"/var/www/vhosts/OTHER.example/httpdocs", // outside the root — skipped
 	})
-	want := map[string]bool{"httpdocs/": true, "site1/": true}
+	want := map[string]bool{"/httpdocs": true, "/site1": true}
 	for _, sys := range pleskSystemExcludes {
 		want[sys] = true
 	}
@@ -25,8 +25,11 @@ func TestPleskExtraExcludes(t *testing.T) {
 		if !want[e] {
 			t.Errorf("unexpected exclude %q", e)
 		}
-		if strings.HasPrefix(e, "/") || strings.Contains(e, "..") {
-			t.Errorf("exclude %q is not a safe relative pattern", e)
+		if !strings.HasPrefix(e, "/") {
+			t.Errorf("exclude %q must be anchored to the transfer root", e)
+		}
+		if strings.Contains(e, "..") {
+			t.Errorf("exclude %q carries traversal", e)
 		}
 	}
 }

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1970,13 +1970,18 @@ func isHostnameLike(h string) bool {
 // migrate: logs/statistics are regenerable server artifacts, conf/.plesk/
 // system are Plesk internals that would leak source-panel config into the
 // destination account.
+// Patterns are ANCHORED to the transfer root (leading /) and carry no
+// trailing slash — E2E on the live box showed the chroot template's
+// bin/lib/lib64 are SYMLINKS, which a "name/" pattern does not match
+// (dirs only), and an unanchored "bin/" would also wrongly exclude a
+// user's own private/bin/ deeper in the tree.
 var pleskSystemExcludes = []string{
-	"logs/", "statistics/", "conf/", ".plesk/", "system/", "error_docs/",
+	"/logs", "/statistics", "/conf", "/.plesk", "/system", "/error_docs",
 	// Plesk chroot shell template (observed on Obsidian 18.0.79: the vhost
-	// root carries a full chroot toolchain). Copying it would land /bin,
-	// /lib64 etc. into ~/plesk-files. User data lives in private/ and
-	// custom-named dirs, which still copy.
-	"bin/", "dev/", "etc/", "lib/", "lib64/", "sbin/", "usr/", "var/", "tmp/",
+	// root carries a full chroot toolchain, partly as symlinks). Copying
+	// it would land /bin, /lib64 etc. into ~/plesk-files. User data lives
+	// in private/ and custom-named dirs, which still copy.
+	"/bin", "/dev", "/etc", "/lib", "/lib64", "/sbin", "/usr", "/var", "/tmp",
 }
 
 // pleskExtraExcludes builds the --exclude list for the vhost-extra rsync
@@ -1991,7 +1996,7 @@ func pleskExtraExcludes(vhostRoot string, docroots []string) []string {
 		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
 			continue
 		}
-		out = append(out, rel+"/")
+		out = append(out, "/"+rel)
 	}
 	return out
 }

--- a/panel-api/internal/migrate/cpanel/restore_cron.go
+++ b/panel-api/internal/migrate/cpanel/restore_cron.go
@@ -61,6 +61,19 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 	}
 	res := &CronImportResult{}
 
+	// GH #429 E2E finding: import re-runs are a designed flow ("re-run
+	// after fixing, or pass --allow-degraded"), and every re-run used to
+	// duplicate the whole imported cron set. Dedupe against the target
+	// user's existing rows by (schedule, command) — the identity of an
+	// imported line — so a re-run is a clean noop for already-imported
+	// crons.
+	existing := map[string]bool{}
+	if rows, lErr := repo.ListByUserID(ctx, targetUserID); lErr == nil {
+		for _, r := range rows {
+			existing[r.Schedule+"\x00"+r.Command] = true
+		}
+	}
+
 	// The account's own domains + their DEST docroots. Used by the
 	// curl/wget self-target rewrite for (a) the same-origin host gate
 	// and (b) resolving the URL path to a php file under the docroot.
@@ -139,7 +152,7 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 					res.Skipped = append(res.Skipped, fmt.Sprintf(
 						"%s:%d cron_disabled_import (curl_not_rewritable: %s): %s",
 						cronPath, lineNum, reason, origCommand))
-					if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+					if cErr := createCronRowDeduped(ctx, repo, targetUserID, schedule, origCommand, res, existing, cronPath, lineNum); cErr != nil {
 						_ = f.Close()
 						return res, cErr
 					}
@@ -152,7 +165,7 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 					res.Skipped = append(res.Skipped, fmt.Sprintf(
 						"%s:%d cron_disabled_import (rewrite_revalidate_failed: %s): %s",
 						cronPath, lineNum, vErr.Error(), origCommand))
-					if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+					if cErr := createCronRowDeduped(ctx, repo, targetUserID, schedule, origCommand, res, existing, cronPath, lineNum); cErr != nil {
 						_ = f.Close()
 						return res, cErr
 					}
@@ -160,7 +173,7 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 				}
 				res.Skipped = append(res.Skipped, fmt.Sprintf(
 					"%s:%d cron rewritten curl→php: %s → %s", cronPath, lineNum, origCommand, rewritten))
-				if cErr := createCronRow(ctx, repo, targetUserID, schedule, rewritten, res); cErr != nil {
+				if cErr := createCronRowDeduped(ctx, repo, targetUserID, schedule, rewritten, res, existing, cronPath, lineNum); cErr != nil {
 					_ = f.Close()
 					return res, cErr
 				}
@@ -173,13 +186,13 @@ func ImportCron(ctx context.Context, repo repository.CronJobRepository, parsed *
 				res.Skipped = append(res.Skipped, fmt.Sprintf(
 					"%s:%d cron_disabled_import (command: %s): %s",
 					cronPath, lineNum, vErr.Error(), origCommand))
-				if cErr := createCronRow(ctx, repo, targetUserID, schedule, origCommand, res); cErr != nil {
+				if cErr := createCronRowDeduped(ctx, repo, targetUserID, schedule, origCommand, res, existing, cronPath, lineNum); cErr != nil {
 					_ = f.Close()
 					return res, cErr
 				}
 				continue
 			}
-			if cErr := createCronRow(ctx, repo, targetUserID, schedule, command, res); cErr != nil {
+			if cErr := createCronRowDeduped(ctx, repo, targetUserID, schedule, command, res, existing, cronPath, lineNum); cErr != nil {
 				_ = f.Close()
 				return res, cErr
 			}
@@ -231,6 +244,22 @@ func isCronEnvLine(line string) bool {
 
 // createCronRow inserts one imported cron_jobs row (always Enabled=false
 // — the operator reviews + flips after migration) and bumps res.Created.
+// createCronRowDeduped skips (with a note) when an identical
+// (schedule, command) row already exists for the user — see the re-run
+// dedupe in ImportCron.
+func createCronRowDeduped(ctx context.Context, repo repository.CronJobRepository, userID, schedule, command string, res *CronImportResult, existing map[string]bool, cronPath string, lineNum int) error {
+	key := schedule + "\x00" + command
+	if existing[key] {
+		res.Skipped = append(res.Skipped, fmt.Sprintf("%s:%d already_imported (re-run dedupe): %s", cronPath, lineNum, command))
+		return nil
+	}
+	if err := createCronRow(ctx, repo, userID, schedule, command, res); err != nil {
+		return err
+	}
+	existing[key] = true
+	return nil
+}
+
 func createCronRow(ctx context.Context, repo repository.CronJobRepository, userID, schedule, command string, res *CronImportResult) error {
 	row := &models.CronJob{
 		ID:        ids.NewULID(),


### PR DESCRIPTION
Live E2E of #880/#881 against a real Plesk Obsidian 18.0.79 box (tunneled to testserver) surfaced two defects; both fixed and unit-pinned:

1. **ImportCron duplicated rows on re-run.** Re-running an import is a designed flow (degraded jobs say "re-run after fixing") — and every pass re-inserted the whole imported cron set (observed: 4 rows from 2 lines). Now dedupes by `(schedule, command)` against the user's existing rows; re-runs log `already_imported (re-run dedupe)`.
2. **Vhost-extra excludes missed chroot symlinks + over-matched.** On real boxes `bin/lib/lib64` in the vhost root are *symlinks* — `name/` patterns match directories only, so dangling symlinks landed in `~/plesk-files`; unanchored patterns would also have wrongly excluded a user's own `private/bin/`. Patterns are now **anchored to the transfer root** (`/bin`, `/httpdocs`, no trailing slash); the agent validator allows the leading `/` (rsync anchors it to the transfer root, not the filesystem — excludes remain shrink-only).

E2E evidence from the run that caught these: `cron: created=2` (disabled, honest skip reasons), `plesk_extra_files: bytes=390` with `private/keepme.txt` canary delivered; the two criticals in that run were pre-existing fixture DBs (documented idempotency artifact) and the WP health probe. Re-running the E2E after this merges to confirm clean.