### PR TITLE
feat(apps): PrivateBin — zero-knowledge encrypted pastebin (GH #631)

### DIFF
--- a/panel-agent/internal/commands/app_install_path.go
+++ b/panel-agent/internal/commands/app_install_path.go
@@ -1,0 +1,25 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// appInstallPath joins docroot + subdirectory and REFUSES a join that
+// escapes the (already-validated) docroot. The subdirectory is validated
+// panel-side at create, but the agent runs as root and per CONVENTIONS
+// re-checks every boundary: a traversal subdirectory ("../..") fed to an
+// installer would write outside the docroot, and fed to a deleter would
+// `rm -rf` the join target as the OS user — up to and including their
+// whole home. Mirrors the containment check wordpress_delete.go carries.
+func appInstallPath(docroot, subdirectory string) (string, error) {
+	sub := strings.Trim(subdirectory, "/")
+	p := filepath.Join(docroot, sub)
+	rel, err := filepath.Rel(docroot, p)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("subdirectory escapes docroot: %q", subdirectory)
+	}
+	return p, nil
+}

--- a/panel-agent/internal/commands/dokuwiki_delete.go
+++ b/panel-agent/internal/commands/dokuwiki_delete.go
@@ -70,9 +70,10 @@ func dokuwikiDeleteHandler(ctx context.Context, params json.RawMessage) (any, er
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid docroot: %v", err)}
 	}
 
-	// Match the install handler's raw join (dokuwiki_install.go uses
-	// filepath.Join(Docroot, Subdirectory) directly, no compute helper).
-	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+	installPath, err := appInstallPath(req.Docroot, req.Subdirectory)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
 
 	if req.Subdirectory != "" {
 		cmd := buildSystemdRunCmd(ctx, req.OSUser, "rm", "-rf", installPath)

--- a/panel-agent/internal/commands/dokuwiki_install.go
+++ b/panel-agent/internal/commands/dokuwiki_install.go
@@ -96,7 +96,10 @@ func dokuwikiInstallHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
 	}
 
-	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+	installPath, err := appInstallPath(req.Docroot, req.Subdirectory)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
 
 	if req.Subdirectory != "" {
 		mk := buildSystemdRunCmd(ctx, req.OSUser, "mkdir", "-p", installPath)

--- a/panel-agent/internal/commands/privatebin_delete.go
+++ b/panel-agent/internal/commands/privatebin_delete.go
@@ -72,7 +72,10 @@ func privatebinDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid docroot: %v", err)}
 	}
 
-	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+	installPath, err := appInstallPath(req.Docroot, req.Subdirectory)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
 
 	if req.Subdirectory != "" {
 		cmd := buildSystemdRunCmd(ctx, req.OSUser, "rm", "-rf", installPath)

--- a/panel-agent/internal/commands/privatebin_delete.go
+++ b/panel-agent/internal/commands/privatebin_delete.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// privatebin_delete.go — removes a PrivateBin install (GH #631). Flat-file
+// like DokuWiki, but with one extra: the paste store lives OUTSIDE the
+// docroot (privatebinDataDir), so the deleter must reap it too or every
+// deleted install leaks an orphan privatebin-data dir of encrypted pastes.
+
+type privatebinDeleteReq struct {
+	AppType      string `json:"app_type"` // present, ignored
+	OSUser       string `json:"os_user"`
+	Docroot      string `json:"docroot"`
+	Subdirectory string `json:"subdirectory,omitempty"`
+	Domain       string `json:"domain,omitempty"`
+}
+
+type privatebinDeleteResp struct {
+	Status string `json:"status"`
+}
+
+// privatebinTopLevel lists every entry the upstream tarball lays down at
+// the install root after `tar --strip-components=1`, plus the
+// jabali-written cfg/conf.php (covered by cfg). For docroot installs we
+// enumerate instead of `rm -rf <docroot>` so user-uploaded sibling files
+// survive. Generated from PrivateBin 2.0.5; bump on release bumps.
+var privatebinTopLevel = []string{
+	".htaccess.disabled",
+	"CHANGELOG.md",
+	"CREDITS.md",
+	"LICENSE.md",
+	"Procfile",
+	"README.md",
+	"SECURITY.md",
+	"bin",
+	"cfg",
+	"composer.json",
+	"composer.lock",
+	"css",
+	"favicon.ico",
+	"i18n",
+	"img",
+	"index.php",
+	"js",
+	"lib",
+	"manifest.json",
+	"robots.txt",
+	"tpl",
+	"vendor",
+}
+
+func privatebinDeleteHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var req privatebinDeleteReq
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if req.OSUser == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "os_user is required"}
+	}
+	if req.Docroot == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "docroot is required"}
+	}
+	if err := validateDocrootPath(req.OSUser, req.Docroot); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("invalid docroot: %v", err)}
+	}
+
+	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+
+	if req.Subdirectory != "" {
+		cmd := buildSystemdRunCmd(ctx, req.OSUser, "rm", "-rf", installPath)
+		_ = cmd.Run()
+	} else {
+		for _, name := range privatebinTopLevel {
+			cmd := buildSystemdRunCmd(ctx, req.OSUser, "rm", "-rf", filepath.Join(installPath, name))
+			_ = cmd.Run()
+		}
+	}
+
+	// The outside-docroot paste store — same derivation the installer used.
+	dataDir := privatebinDataDir(req.Docroot, req.Subdirectory)
+	rmData := buildSystemdRunCmd(ctx, req.OSUser, "rm", "-rf", dataDir)
+	_ = rmData.Run()
+
+	if req.Subdirectory == "" && req.Domain != "" {
+		indexPath := filepath.Join(req.Docroot, "index.html")
+		if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+			_ = writeDefaultIndex(ctx, indexPath, req.OSUser, req.Domain, req.Docroot, "")
+		}
+	}
+
+	return privatebinDeleteResp{Status: "deleted"}, nil
+}
+
+func init() {
+	RegisterAppDeleter("privatebin", privatebinDeleteHandler)
+}

--- a/panel-agent/internal/commands/privatebin_install.go
+++ b/panel-agent/internal/commands/privatebin_install.go
@@ -85,7 +85,10 @@ func privatebinInstallHandler(ctx context.Context, params json.RawMessage) (any,
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
 	}
 
-	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+	installPath, err := appInstallPath(req.Docroot, req.Subdirectory)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
 	dataDir := privatebinDataDir(req.Docroot, req.Subdirectory)
 
 	if req.Subdirectory != "" {

--- a/panel-agent/internal/commands/privatebin_install.go
+++ b/panel-agent/internal/commands/privatebin_install.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// privatebin_install.go — installs PrivateBin, a zero-knowledge encrypted
+// pastebin (GH #631). No database, no user accounts: the release tarball is
+// self-contained (vendor/ bundled), so install = verified download + extract
+// + one INI config.
+//
+// The one security-relevant decision: the Filesystem model's data directory
+// lives OUTSIDE the docroot (sibling of public_html), so encrypted pastes,
+// the traffic limiter state and the purge queue are never directly
+// fetchable through nginx. PrivateBin's shipped .htaccess protections are
+// Apache-only and do nothing under our nginx vhosts.
+//
+// Upstream pins: the GitHub source tag archive (PrivateBin bundles vendor/
+// in the repo), verified by SHA-256 before extract, per the catalog's
+// no-floating-latest bar (GH #631 discussion).
+
+const (
+	// privatebinVersion is the pinned upstream release. Bump alongside the
+	// SHA256 (recompute from the tag archive) when moving to a newer release.
+	privatebinVersion    = "2.0.5"
+	privatebinTarballURL = "https://github.com/PrivateBin/PrivateBin/archive/refs/tags/" + privatebinVersion + ".tar.gz"
+	privatebinTarballSHA = "19903f421eaa1bd3e29e33706dddd41ffb0f77e03f2ad7ff9da15a5e734c957b"
+)
+
+type privatebinInstallReq struct {
+	AppType      string `json:"app_type"` // present, ignored
+	OSUser       string `json:"os_user"`
+	Docroot      string `json:"docroot"`
+	Subdirectory string `json:"subdirectory"`
+	SiteURL      string `json:"site_url"` // unused — PrivateBin auto-detects
+	SiteTitle    string `json:"site_title"`
+	UseWWW       bool   `json:"use_www"`
+}
+
+type privatebinInstallResp struct {
+	Version string `json:"version"`
+	DataDir string `json:"data_dir"`
+}
+
+// privatebinDataDir places the paste store OUTSIDE the docroot: a sibling
+// of the docroot's last element, suffixed with the subdirectory for
+// subdir installs so two instances under one domain can't collide.
+// e.g. docroot /home/u/domains/d/public_html, subdir ""      -> /home/u/domains/d/privatebin-data
+//      docroot /home/u/domains/d/public_html, subdir "paste" -> /home/u/domains/d/privatebin-data-paste
+func privatebinDataDir(docroot, subdirectory string) string {
+	base := filepath.Join(filepath.Dir(filepath.Clean(docroot)), "privatebin-data")
+	if subdirectory != "" {
+		base += "-" + strings.ReplaceAll(subdirectory, "/", "-")
+	}
+	return base
+}
+
+func privatebinInstallHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var req privatebinInstallReq
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("parse params: %v", err)}
+	}
+	if req.OSUser == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "os_user is required"}
+	}
+	if req.Docroot == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "docroot is required"}
+	}
+	if req.SiteTitle == "" {
+		req.SiteTitle = "PrivateBin"
+	}
+	if err := validateDocrootPath(req.OSUser, req.Docroot); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
+	}
+
+	installPath := filepath.Join(req.Docroot, req.Subdirectory)
+	dataDir := privatebinDataDir(req.Docroot, req.Subdirectory)
+
+	if req.Subdirectory != "" {
+		mk := buildSystemdRunCmd(ctx, req.OSUser, "mkdir", "-p", installPath)
+		if out, err := runBoundedOutput(mk, 0); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir %s: %v (%s)", installPath, err, truncateStr(string(out), 256))}
+		}
+	}
+	removePlaceholderIndex(ctx, installPath)
+
+	// Paste store outside the docroot, owned by the OS user, 0700 — only
+	// the PHP-FPM pool (running as the user) needs it.
+	mkData := buildSystemdRunCmd(ctx, req.OSUser, "mkdir", "-p", "-m", "0700", dataDir)
+	if out, err := runBoundedOutput(mkData, 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir data dir %s: %v (%s)", dataDir, err, truncateStr(string(out), 256))}
+	}
+
+	tmpDir, err := stagingMkdirTemp("privatebin-")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("staging mktemp: %v", err)}
+	}
+	defer os.RemoveAll(tmpDir)
+	tarball := filepath.Join(tmpDir, "privatebin.tar.gz")
+
+	dlCtx, dlCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer dlCancel()
+	if err := privatebinDownload(dlCtx, tarball); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	}
+	if err := os.Chmod(tarball, 0o644); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chmod tarball: %v", err)}
+	}
+
+	// Extract as the OS user (strip the PrivateBin-<ver>/ top dir).
+	extract := buildSystemdRunCmd(ctx, req.OSUser,
+		"tar", "--extract", "--gzip", "--strip-components=1",
+		"--file", tarball, "--directory", installPath)
+	if out, err := runBoundedOutput(extract, 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("tar extract: %v (%s)", err, truncateStr(string(out), 512))}
+	}
+
+	// cfg/conf.php — INI with the upstream sample's PHP exec guard on line
+	// one (a direct browser hit gets a 403 instead of the file body).
+	conf := ";<?php http_response_code(403); /*\n" +
+		"; Managed by jabali (GH #631). Full option reference: cfg/conf.sample.php\n" +
+		"[main]\n" +
+		"name = " + privatebinINIQuoted(req.SiteTitle) + "\n" +
+		"[model]\n" +
+		"class = Filesystem\n" +
+		"[model_options]\n" +
+		"dir = " + privatebinINIQuoted(dataDir) + "\n"
+	if err := dokuwikiWriteUserFile(ctx, req.OSUser, filepath.Join(installPath, "cfg", "conf.php"), conf, "0640"); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	}
+
+	return privatebinInstallResp{Version: privatebinVersion, DataDir: dataDir}, nil
+}
+
+// privatebinINIQuoted renders s as a double-quoted INI value. PHP's
+// parse_ini_file has no in-string escape for '"', so strip it (titles and
+// paths never legitimately carry one) along with newlines.
+func privatebinINIQuoted(s string) string {
+	s = strings.NewReplacer("\"", "", "\r", "", "\n", "").Replace(s)
+	return "\"" + s + "\""
+}
+
+func privatebinDownload(ctx context.Context, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, privatebinTarballURL, nil)
+	if err != nil {
+		return fmt.Errorf("privatebin download: build request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("privatebin download: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("privatebin download: HTTP %d from %s", resp.StatusCode, privatebinTarballURL)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("privatebin download: create %s: %w", dest, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(f, h), resp.Body); err != nil {
+		return fmt.Errorf("privatebin download: copy: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != privatebinTarballSHA {
+		return fmt.Errorf("privatebin download: SHA256 mismatch: got %s want %s", got, privatebinTarballSHA)
+	}
+	return nil
+}
+
+func init() {
+	RegisterAppInstaller("privatebin", privatebinInstallHandler)
+}

--- a/panel-agent/internal/commands/privatebin_install_test.go
+++ b/panel-agent/internal/commands/privatebin_install_test.go
@@ -34,3 +34,20 @@ func TestPrivatebinINIQuoted(t *testing.T) {
 		t.Errorf("plain title mangled: %q", got)
 	}
 }
+
+// Security-review finding on the first commit: the install/delete path
+// join must refuse a traversal subdirectory — fed to the deleter,
+// "../../.." would rm -rf the join target as the OS user (their whole
+// home). Applies to every flat-file app via the shared helper.
+func TestAppInstallPath_RejectsTraversal(t *testing.T) {
+	for _, bad := range []string{"..", "../..", "../../..", "a/../../b", "../outside"} {
+		if _, err := appInstallPath("/home/u/domains/d/public_html", bad); err == nil {
+			t.Errorf("appInstallPath accepted traversal subdirectory %q", bad)
+		}
+	}
+	for _, ok := range []string{"", "paste", "tools/paste", "a/b/c"} {
+		if _, err := appInstallPath("/home/u/domains/d/public_html", ok); err != nil {
+			t.Errorf("appInstallPath rejected safe subdirectory %q: %v", ok, err)
+		}
+	}
+}

--- a/panel-agent/internal/commands/privatebin_install_test.go
+++ b/panel-agent/internal/commands/privatebin_install_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #631: the paste store must land OUTSIDE the docroot (nginx must never
+// be able to serve it), and subdir installs must not collide.
+func TestPrivatebinDataDir(t *testing.T) {
+	cases := []struct{ docroot, subdir, want string }{
+		{"/home/u/domains/d.example/public_html", "", "/home/u/domains/d.example/privatebin-data"},
+		{"/home/u/domains/d.example/public_html", "paste", "/home/u/domains/d.example/privatebin-data-paste"},
+		{"/home/u/domains/d.example/public_html", "tools/paste", "/home/u/domains/d.example/privatebin-data-tools-paste"},
+	}
+	for _, c := range cases {
+		got := privatebinDataDir(c.docroot, c.subdir)
+		if got != c.want {
+			t.Errorf("privatebinDataDir(%q,%q) = %q, want %q", c.docroot, c.subdir, got, c.want)
+		}
+		if strings.HasPrefix(got, c.docroot+"/") {
+			t.Errorf("data dir %q is INSIDE the docroot — pastes would be nginx-fetchable", got)
+		}
+	}
+}
+
+// INI values must not be able to break out of their quotes or smuggle a
+// second line into cfg/conf.php.
+func TestPrivatebinINIQuoted(t *testing.T) {
+	if got := privatebinINIQuoted(`My "Bin"` + "\ninjected = true"); strings.ContainsAny(got[1:len(got)-1], "\"\n\r") {
+		t.Errorf("quotes/newlines survived: %q", got)
+	}
+	if got := privatebinINIQuoted("PrivateBin"); got != `"PrivateBin"` {
+		t.Errorf("plain title mangled: %q", got)
+	}
+}

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -1485,3 +1485,58 @@ func (h *applicationsHandler) scan(c *gin.Context) {
 		"report":  report,
 	})
 }
+
+// privateBinKickArgs — PrivateBin has no accounts and no DB (GH #631), so
+// the kick carries only the install-site coordinates + title.
+type privateBinKickArgs struct {
+	InstallID    string
+	OSUser       string
+	DocRoot      string
+	Subdirectory string
+	SiteURL      string
+	SiteTitle    string
+	UseWWW       bool
+}
+
+// createPrivateBinInstallAndKickAgent mirrors the DokuWiki kicker minus
+// every credential field.
+func createPrivateBinInstallAndKickAgent(parentCtx context.Context, args privateBinKickArgs, cfg ApplicationHandlerConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	if err := cfg.ApplicationInstalls.UpdateStatus(ctx, args.InstallID, "installing", nil, nil); err != nil {
+		return
+	}
+	if cfg.Agent == nil {
+		errMsg := "agent not configured"
+		cfg.ApplicationInstalls.UpdateStatus(ctx, args.InstallID, "failed", &errMsg, nil)
+		return
+	}
+
+	agentResp, err := cfg.Agent.Call(ctx, "app.install", map[string]any{
+		"app_type":     "privatebin",
+		"os_user":      args.OSUser,
+		"docroot":      args.DocRoot,
+		"subdirectory": args.Subdirectory,
+		"site_url":     args.SiteURL,
+		"site_title":   args.SiteTitle,
+		"use_www":      args.UseWWW,
+	})
+	if err != nil {
+		errMsg := truncateError(fmt.Sprintf("agent install failed: %v", err), 1024)
+		cfg.ApplicationInstalls.UpdateStatus(ctx, args.InstallID, "failed", &errMsg, nil)
+		return
+	}
+
+	var respMap map[string]any
+	if err := json.Unmarshal(agentResp, &respMap); err != nil {
+		errMsg := truncateError(fmt.Sprintf("failed to parse agent response: %v", err), 1024)
+		cfg.ApplicationInstalls.UpdateStatus(ctx, args.InstallID, "failed", &errMsg, nil)
+		return
+	}
+	version := ""
+	if v, ok := respMap["version"].(string); ok {
+		version = v
+	}
+	cfg.ApplicationInstalls.UpdateStatus(ctx, args.InstallID, "ready", nil, &version)
+}

--- a/panel-api/internal/api/applications_service.go
+++ b/panel-api/internal/api/applications_service.go
@@ -456,6 +456,17 @@ func dispatchInstallKicker(ctx context.Context, appName string, k kickContext, d
 			UseWWW:         k.UseWWW,
 		}, deps)
 		adminPassword = prestaPass
+	case "privatebin":
+		// No accounts, no DB — the smallest kick there is.
+		go createPrivateBinInstallAndKickAgent(ctx, privateBinKickArgs{
+			InstallID:    k.InstallID,
+			OSUser:       k.OSUser,
+			DocRoot:      k.DocRoot,
+			Subdirectory: k.Subdirectory,
+			SiteURL:      k.SiteURL,
+			SiteTitle:    paramOr(k.Params, "site_title", "PrivateBin"),
+			UseWWW:       k.UseWWW,
+		}, deps)
 	case "dokuwiki":
 		dokuPass := paramOr(k.Params, "admin_password", "")
 		if dokuPass == "" {

--- a/panel-api/internal/apps/privatebin.go
+++ b/panel-api/internal/apps/privatebin.go
@@ -1,0 +1,30 @@
+package apps
+
+// PrivateBin is the descriptor for PrivateBin — a minimalist, zero-knowledge
+// encrypted pastebin (GH #631). Everything is encrypted client-side; the
+// server never sees plaintext, and there are NO user accounts at all, so the
+// install schema carries no admin_username/email/password. RequiresDB=false:
+// the default Filesystem model stores pastes on disk — the agent installer
+// points it at a data directory OUTSIDE the docroot so pastes are never
+// directly fetchable through nginx.
+var PrivateBin = App{
+	Name:                 "privatebin",
+	DisplayName:          "PrivateBin",
+	Icon:                 "LockOutlined",
+	Description:          "Zero-knowledge encrypted pastebin — pastes are encrypted in the browser, the server never sees plaintext. No accounts, no database.",
+	Tags:                 []string{"Utility"},
+	DefaultSubdirectory:  "paste",
+	RequiresDB:           false,
+	SupportedPHPVersions: nil,
+	AgentInstallCmd:      "app.install",
+	AgentDeleteCmd:       "app.delete",
+	AgentCloneCmd:        "",
+	InstallParamSchema: map[string]ParamSpec{
+		"site_title": {
+			Type:        "string",
+			Required:    true,
+			Default:     "PrivateBin",
+			Description: "Instance name shown in the page header ([main] name in cfg/conf.php).",
+		},
+	},
+}

--- a/panel-api/internal/apps/wordpress.go
+++ b/panel-api/internal/apps/wordpress.go
@@ -106,5 +106,8 @@ func RegisterDefaults(r *Registry) error {
 	if err := r.Register(Moodle); err != nil {
 		return err
 	}
+	if err := r.Register(PrivateBin); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
First of the #631 non-docker PHP apps — the smallest possible catalog entry: no database, no user accounts (client-side encryption), release self-contained (vendor/ bundled).

- **Pinned + verified**: 2.0.5 tag archive, SHA-256 checked before extract (the no-floating-latest bar from the issue discussion).
- **Paste store outside the docroot**: `privatebin-data[-<subdir>]` sibling of `public_html`, 0700, pool-user-owned — encrypted pastes and limiter state are never nginx-fetchable (PrivateBin's shipped .htaccess protections are Apache-only and inert under our vhosts). The deleter reaps it too (and the installer/deleter parity test caught that the first commit forgot the deleter — the test earns its keep).
- `cfg/conf.php` INI with the upstream PHP exec-guard line (direct hit → 403); title/path values quote-and-newline-stripped so a site title can't smuggle INI keys.
- Descriptor (`RequiresDB=false`, single `site_title` param — the catalog UI derives everything else), dispatch case, credential-free kicker.

Tests: outside-docroot data-dir derivation (incl. subdir collision suffixing), INI sanitisation, dispatch parity. `-race` green both modules. Serving validation on testserver (FPM + Snuffleupagus) after merge, before the issue gets a reply.