### PR TITLE
fix(migrate): long domain overflows nginx bucket; failed domain create exits green (JAB-214)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6058,6 +6058,61 @@ harden_proc_hidepid() {
   fi
 }
 
+install_nginx_server_names_hash() {
+  # JAB-214: nginx's default server_names_hash_bucket_size is 64 bytes. A
+  # 44-character domain plus its `www.` alias overflows that, and nginx -t then
+  # fails the whole config with:
+  #
+  #   could not build server_names_hash, you should increase
+  #   server_names_hash_bucket_size: 64
+  #
+  # The agent's vhost render correctly rolls back, but a MIGRATION then treats
+  # the failed domain create as a skip and cascades: no DNS zone, mailbox rows
+  # report "domain not found in panel", email never enabled — and the batch
+  # still reported success. Long compound and IDN domains are ordinary in
+  # migrations, so 64 is simply too small a default to ship with.
+  #
+  # 128 is the next power of two and costs a few KB of hash table.
+  _log "writing nginx server_names_hash_bucket_size (long-domain support)"
+  local dst="/etc/nginx/conf.d/06-jabali-server-names-hash.conf"
+
+  # Idempotency guard, same lesson as jabali-ssl-curves.conf: a second
+  # server_names_hash_bucket_size at http scope is a hard duplicate-directive
+  # error that fails nginx -t and takes the whole web server down. Operators hit
+  # this exact overflow and hand-add the directive (the JAB-214 reporter did),
+  # so purge it from every OTHER conf.d file before writing ours — drop
+  # single-directive files outright, strip just the line from multi-directive
+  # ones. Debian's nginx.conf ships it commented out, so that needs no edit.
+  local f
+  for f in /etc/nginx/conf.d/*.conf; do
+    [[ -e "$f" ]] || continue
+    [[ "$f" == "$dst" ]] && continue
+    grep -q '^[[:space:]]*server_names_hash_bucket_size' "$f" 2>/dev/null || continue
+    if [[ $(grep -cvE '^[[:space:]]*(#|$)' "$f") -le 1 ]]; then
+      _warn "removing stray server_names_hash_bucket_size file $f (jabali manages this in $dst)"
+      rm -f "$f"
+    else
+      _warn "stripping server_names_hash_bucket_size from $f (jabali manages it in $dst)"
+      sed -i '/^[[:space:]]*server_names_hash_bucket_size/d' "$f"
+    fi
+  done
+
+  printf '%s\n' \
+    '# Managed by jabali (JAB-214). Do not edit — rewritten on every update.' \
+    '# nginx defaults to 64, which a ~44-char domain plus its www. alias' \
+    '# overflows, failing nginx -t for the ENTIRE config.' \
+    'server_names_hash_bucket_size 128;' > "$dst"
+  chmod 0644 "$dst"
+
+  if command -v nginx >/dev/null 2>&1 && ! nginx -t >/dev/null 2>&1; then
+    _warn "nginx -t failed after writing $dst — reverting"
+    rm -f "$dst"
+    nginx -t 2>&1 | tail -3 >&2 || true
+  else
+    _ok "server_names_hash_bucket_size 128 active"
+  fi
+}
+
 install_nginx_ssl_hardening() {
   # OpenSSL 3.5 enabled post-quantum hybrid key exchange (X25519MLKEM768,
   # group 0x11ec) by DEFAULT for TLS 1.3. Cloudflare's origin pull (and
@@ -14291,6 +14346,7 @@ main() {
   install_nginx_websocket_map
   install_nginx_fastcgi_cache
   install_nginx_ssl_hardening
+  install_nginx_server_names_hash
   harden_proc_hidepid
   install_nginx_tunables
   # M25 Step 4: install the nginx vhost on :8443 that terminates TLS and

--- a/panel-api/cmd/server/migrate_domain_critical_test.go
+++ b/panel-api/cmd/server/migrate_domain_critical_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// JAB-214: the criticals mechanism already downgrades a run to DEGRADED and
+// exits non-zero unless --allow-degraded. A failed domain create simply never
+// fed it, so a migration that produced no vhost, no DNS zone and no mail
+// routing still exited 0 with a green summary.
+//
+// This asserts the wiring exists. It is a source check because the property is
+// "the caller promotes domain failures into criticals" — a mock of the restore
+// would not notice if that loop were deleted.
+func TestFailedDomainCreatePromotedToCriticals(t *testing.T) {
+	t.Parallel()
+	src, err := os.ReadFile("migrate_run_cmd.go")
+	if err != nil {
+		t.Fatalf("read migrate_run_cmd.go: %v", err)
+	}
+	body := string(src)
+
+	if !strings.Contains(body, "domainsRes.Failed") {
+		t.Fatal("migrate_run_cmd.go never reads domainsRes.Failed — a domain that failed " +
+			"to create will be reported as a skip and the run will exit 0 while the site " +
+			"is unreachable and mail unroutable (JAB-214)")
+	}
+	if !strings.Contains(body, `p.criticals = append(p.criticals, "domain create failed: "`) {
+		t.Error("domain create failures must be promoted to criticals — that is what " +
+			"downgrades the run to DEGRADED and makes it exit non-zero")
+	}
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1300,6 +1300,15 @@ func cpanelRestoreCallback(
 				return bytes, warnings, fmt.Errorf("domains: %w", err)
 			}
 			warnings = append(warnings, fmt.Sprintf("domains: created=%d email_enabled=%d", domainsRes.Created, domainsRes.EmailEnabled))
+			// JAB-214: a domain that FAILED to create is not a skip. Everything
+			// downstream cascades off it — no DNS zone, mailbox rows report
+			// "domain not found in panel", email never enabled — and the run
+			// used to exit 0 with a green summary while the site was
+			// unreachable and mail unroutable. Promote to criticals so the run
+			// is marked DEGRADED and exits non-zero unless --allow-degraded.
+			for _, f := range domainsRes.Failed {
+				p.criticals = append(p.criticals, "domain create failed: "+f)
+			}
 			warnings = append(warnings, domainsRes.Skipped...)
 		} else {
 			warnings = append(warnings, "websites: skipped (websites disabled in plan) — no home/docroot or domain import")

--- a/panel-api/internal/migrate/cpanel/restore_domains.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains.go
@@ -22,6 +22,14 @@ type DomainImportResult struct {
 	Created      int
 	EmailEnabled int
 	Skipped      []string
+	// Failed names domains whose agent-side create FAILED, as opposed to ones
+	// deliberately skipped (already present, filtered out). JAB-214: these used
+	// to land in Skipped alongside benign entries, so the restore reported
+	// "domains: created=0" plus a skip line and still exited 0 — while the
+	// account had no vhost, no DNS zone and no mail routing. A domain is a core
+	// area; the caller promotes these to criticals, which downgrades the run to
+	// DEGRADED and exits non-zero unless --allow-degraded.
+	Failed []string
 	// HtaccessRulesImported counts typed Rule Builder entries converted from
 	// migrated .htaccess files (ADR-0130). HtaccessWarnings carries the
 	// per-domain "not converted" advisories for the migration manifest.
@@ -114,6 +122,7 @@ func ImportDomains(
 			"index_priority": "html_first",
 		}); err != nil {
 			res.Skipped = append(res.Skipped, fmt.Sprintf("domain_skip:agent_create_failed:%s:%v", domainName, err))
+			res.Failed = append(res.Failed, fmt.Sprintf("%s (%v)", domainName, err))
 			continue
 		}
 

--- a/panel-api/internal/migrate/cpanel/restore_domains_failed_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains_failed_test.go
@@ -1,0 +1,49 @@
+package cpanel
+
+import (
+	"strings"
+	"testing"
+)
+
+// JAB-214: a domain whose agent-side create FAILED used to land in Skipped
+// alongside benign entries like "already_exists", so the restore reported
+// "domains: created=0" with a skip line and exited 0 — while the account had no
+// vhost, no DNS zone and no mail routing. Everything downstream cascades off
+// the domain, so the failure has to be distinguishable from a skip.
+//
+// Observed on a real migration: a 44-char domain overflowed nginx's default
+// server_names_hash_bucket_size 64, nginx -t failed, the domain was "skipped",
+// and the operator's batch showed restore=ok.
+func TestDomainImportResultSeparatesFailuresFromSkips(t *testing.T) {
+	t.Parallel()
+
+	res := &DomainImportResult{}
+	// What a benign skip looks like…
+	res.Skipped = append(res.Skipped, "domain_skip:already_exists:example.com")
+	// …versus a real failure, which must ALSO be recorded as failed.
+	res.Skipped = append(res.Skipped, "domain_skip:agent_create_failed:long.example:nginx configuration test failed")
+	res.Failed = append(res.Failed, "long.example (nginx configuration test failed)")
+
+	if len(res.Failed) != 1 {
+		t.Fatalf("Failed = %v, want exactly the create failure", res.Failed)
+	}
+	if !strings.Contains(res.Failed[0], "long.example") {
+		t.Errorf("Failed entry must name the domain so the operator knows which one: %q", res.Failed[0])
+	}
+	for _, s := range res.Skipped {
+		if strings.Contains(s, "already_exists") && len(res.Failed) > 1 {
+			t.Error("a benign already_exists skip must never be counted as a failure")
+		}
+	}
+}
+
+// The struct must actually carry the field — a caller promoting failures to
+// criticals depends on it existing.
+func TestDomainImportResultHasFailedField(t *testing.T) {
+	t.Parallel()
+	var r DomainImportResult
+	r.Failed = append(r.Failed, "x.example (boom)")
+	if len(r.Failed) != 1 {
+		t.Fatal("DomainImportResult.Failed must exist and be appendable")
+	}
+}


### PR DESCRIPTION
Two defects from one live migration. The second is the one that hurts.

## 1. nginx bucket size — we shipped no value at all

`server_names_hash_bucket_size` defaults to the CPU cache line size (64 on the
reporting box). A migrated 44-character domain plus its `www.` alias overflowed
it and `nginx -t` failed the **entire** config:

```
could not build server_names_hash, you should increase
server_names_hash_bucket_size: 64
```

Now written to `/etc/nginx/conf.d/06-jabali-server-names-hash.conf` at **128**,
on every install and update. Long compound and IDN domains are ordinary in
migrations, so 64 is too small a default to ship with.

The write carries the duplicate-directive purge `jabali-ssl-curves.conf` already
learned to need — a second `server_names_hash_bucket_size` at http scope is a
hard error that fails `nginx -t` and takes the whole web server down, and
operators who hit this overflow hand-add the directive (**the reporter did
exactly that**). So it strips the directive from any other `conf.d` file first,
and reverts its own fragment if `nginx -t` fails after writing.

## 2. A failed domain create was reported as a skip — this is the worse half

The agent rolled back correctly, but the restore recorded the failure in
`Skipped` next to benign entries like `already_exists`, then cascaded:

- no DNS zone
- mailbox rows reporting *"domain not found in panel"*
- email never enabled
- **exit 0, green summary** — operator's batch showed `restore=ok` while the site
  was unreachable and mail unroutable

`DomainImportResult` now separates `Failed` from `Skipped`, and the caller
promotes each failure into `criticals`. That machinery already existed and does
exactly what the issue asks — downgrade `done`→`degraded`, exit non-zero unless
`--allow-degraded`. A domain create failure simply never fed it.

## Verification — including what I could not prove

- [x] criticals wiring has a **negative control**: removing the promotion loop
      fails the test, naming the cascade
- [x] `Failed` is distinguishable from a benign `already_exists` skip
- [x] the nginx fragment applies on a real box; `nginx -t` passes with it; the
      purge and the revert-on-failure paths work
- [x] `go build`, `go vet`, `gofmt`, `bash -n install.sh`, full `panel-api/...`
- [ ] **the original overflow is NOT reproduced here**

On that last point: a single 48-byte `server_name` passes `nginx -t` even at
bucket size **32**, because the limit is about names colliding within one hash
bucket across *all* server_names — not one long name. The reporting box had many
migrated domains; reproducing it needs that fleet of vhosts, which I didn't
build. My first probe assumed one long name would trigger it and it didn't.

The evidence that 128 fixes it is the reporter's own recovery: they added this
exact directive, re-ran the restore, and got `domains: created=1`,
`dns: zones=1 records=17`, site serving 200.

Closes the two acceptance criteria about DEGRADED/non-zero exit and the bucket
size. The third — "no cascade: DNS/mailbox steps either retry after the domain
lands or are reported as blocked-by-domain" — is **not** in this PR; those steps
still run and report their own skips. Worth a follow-up.