### PR TITLE
fix(migrate): retry-from-scratch no longer reports DEGRADED on healthy databases (JAB-215)

### DIFF
--- a/panel-api/cmd/server/migrate_degraded_test.go
+++ b/panel-api/cmd/server/migrate_degraded_test.go
@@ -10,14 +10,35 @@ import (
 // treated as degraded, not done. Lock the exact thresholds + the downgrade gate.
 func TestMigrationCriticalThresholds(t *testing.T) {
 	t.Run("db dumps present but none imported is critical", func(t *testing.T) {
-		if !dbDumpsAllSkipped(1, 0) {
-			t.Error("1 dump, 0 created should be critical")
+		if !dbDumpsAllSkipped(1, 0, 0) {
+			t.Error("1 dump, 0 created, 0 already present should be critical")
 		}
-		if dbDumpsAllSkipped(0, 0) {
+		if dbDumpsAllSkipped(0, 0, 0) {
 			t.Error("no dumps is not a failure")
 		}
-		if dbDumpsAllSkipped(2, 2) {
+		if dbDumpsAllSkipped(2, 2, 0) {
 			t.Error("all imported is not a failure")
+		}
+	})
+
+	// JAB-215: --retry-from-scratch wipes the job's stages but does NOT drop the
+	// tenant databases the previous run created, so the re-run finds them
+	// already present and imports nothing. That used to end
+	// "DEGRADED: 1 dump(s) present but 0 imported", exit non-zero, on a box
+	// whose databases were complete and healthy — training operators to reach
+	// for --allow-degraded, which then means nothing when a DB is really gone.
+	t.Run("databases left in place by a previous run are handled, not degraded", func(t *testing.T) {
+		if dbDumpsAllSkipped(1, 0, 1) {
+			t.Error("1 dump already present from an earlier run must NOT be critical — " +
+				"this is the retry-from-scratch false degrade (JAB-215)")
+		}
+		if dbDumpsAllSkipped(3, 1, 2) {
+			t.Error("a mix of re-imported and verified-existing must not be critical")
+		}
+		// The guarantee still has teeth: nothing imported AND nothing already
+		// there is still a core failure.
+		if !dbDumpsAllSkipped(2, 0, 0) {
+			t.Error("dumps present, none imported, none pre-existing is still critical")
 		}
 	})
 

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -785,7 +785,16 @@ type cpanelRunPayload struct {
 
 // Core-area failure thresholds (JAB-31). Each returns true when an area ran but
 // produced nothing usable — a "done" job in that state is misleading.
-func dbDumpsAllSkipped(dumps, created int) bool        { return dumps > 0 && created == 0 }
+// dbDumpsAllSkipped reports the JAB-31 core failure: dumps were present and
+// NONE of them ended up as a database on this box.
+//
+// JAB-215: a database left in place by an earlier run of the same account
+// counts as handled. Otherwise every recovery re-run of an account that got
+// past the DB stage ends degraded even though its databases are complete —
+// the flag then means nothing when a database is genuinely missing.
+func dbDumpsAllSkipped(dumps, created, alreadyPresent int) bool {
+	return dumps > 0 && created == 0 && alreadyPresent == 0
+}
 func mailFoundNonePushed(found int, pushed int64) bool { return found > 0 && pushed == 0 }
 
 // shouldDowngradeToDegraded gates the done→degraded transition: the runner
@@ -970,11 +979,12 @@ func cpanelRestoreCallback(
 			if err != nil {
 				return bytes, warnings, fmt.Errorf("databases: %w", err)
 			}
-			warnings = append(warnings, fmt.Sprintf("databases: created=%d", dbsRes.Created))
+			warnings = append(warnings, fmt.Sprintf("databases: created=%d verified_existing=%d",
+				dbsRes.Created, dbsRes.AlreadyPresent))
 			warnings = append(warnings, dbsRes.Skipped...)
 			// JAB-31: DB dumps present but none imported is a core failure, not a
 			// warning — a "done" job here has no databases.
-			if dbDumpsAllSkipped(len(p.parsed.MySQLDumps), dbsRes.Created) {
+			if dbDumpsAllSkipped(len(p.parsed.MySQLDumps), dbsRes.Created, dbsRes.AlreadyPresent) {
 				p.criticals = append(p.criticals, fmt.Sprintf(
 					"databases: %d dump(s) present but 0 imported", len(p.parsed.MySQLDumps)))
 			}

--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -20,7 +20,21 @@ import (
 // progress reporting + manifest update.
 type DBImportResult struct {
 	Created int
-	Skipped []string
+	// AlreadyPresent counts dumps whose target database was already imported by
+	// an earlier run of the SAME account and left in place.
+	//
+	// JAB-215: these used to be indistinguishable from a failure. A
+	// --retry-from-scratch wipes the job's stages but does NOT drop the tenant
+	// databases the previous run created, so every dump hit the
+	// "already imported" branch, Created stayed 0, and the run ended
+	// "DEGRADED: N dump(s) present but 0 imported" with a non-zero exit — on a
+	// box whose databases were complete and healthy. That trains operators to
+	// reach for --allow-degraded, which defeats the flag for real failures.
+	//
+	// Counted separately rather than folded into Created so the summary can say
+	// which databases were re-imported and which were verified-existing.
+	AlreadyPresent int
+	Skipped        []string
 	// Credentials captures (db_name → DBCredential) for each DB +
 	// user pair created during this restore pass. ImportAppConfigs
 	// reads it to rewrite WordPress/Drupal/Joomla/Magento config
@@ -145,7 +159,9 @@ func ImportDatabases(
 			return res, fmt.Errorf("collision check %s: %w", finalName, err)
 		}
 		if exists {
-			res.Skipped = append(res.Skipped, fmt.Sprintf("%s: %q already imported", dumpPath, finalName))
+			res.AlreadyPresent++
+			res.Skipped = append(res.Skipped, fmt.Sprintf(
+				"%s: %q verified existing — left in place, not re-imported", dumpPath, finalName))
 			continue
 		}
 


### PR DESCRIPTION
`--retry-from-scratch` wipes the job's stages and re-runs the pipeline, but it
does **not** drop the tenant databases the previous run created. The DB import
then finds every dump's target already present, skips it, leaves `Created` at 0,
and the run ends:

```
DEGRADED: databases: 1 dump(s) present but 0 imported     (exit non-zero)
```

…on a box whose database was complete and healthy — 16 tables, users and grants
intact, WordPress connecting, site serving 200.

**The damage isn't the red exit, it's what the red exit teaches.** Every recovery
re-run of an account that got past the DB stage ends degraded, so operators learn
to reach for `--allow-degraded` by reflex — and then the flag says nothing on the
run where a database really is missing.

## Fix

`DBImportResult` counts `AlreadyPresent` separately from `Created`, and the
JAB-31 core-failure check treats a database left in place by an earlier run as
handled. The threshold keeps its teeth: dumps present with **nothing imported
and nothing pre-existing** is still critical.

Summary now reads `databases: created=N verified_existing=M`, and the per-database
line says `verified existing — left in place, not re-imported` rather than the
ambiguous `already imported`.

## Why option (b), not (a)

The issue offers two self-consistent fixes: (a) retry-from-scratch drops and
recreates the databases it owns, or (b) the import detects the existing database
and reports it.

Took (b). A retry is often triggered by something unrelated to the DB stage —
**JAB-214's vhost failure is exactly that case** — and dropping a healthy tenant
database with live data to satisfy a status field is a bad trade. (b) is also
what the acceptance criteria describe: an explicit line per database saying how
it was handled.

## Limit — stated because it matters

`verified existing` means **the panel has a `databases` row** for that name under
this user. It does **not** re-validate the contents. A row pointing at an empty
or half-restored schema will now report verified-existing instead of degrading.

The issue asks that degraded stay reserved for *"absent, partial, or mismatched"*.
Absent is covered. **Partial is not** — closing that needs a table/row check
against the live server rather than a panel row lookup. Worth a follow-up; not
smuggled in here.

## Test plan

- [x] a dump already present from an earlier run is **not** critical
- [x] a mix of re-imported and verified-existing is not critical
- [x] dumps present, none imported, none pre-existing **is still critical**
- [x] **negative control**: restoring the old two-argument threshold fails the
      new subtest by name
- [x] `go build`, `go vet`, full `panel-api/...` green; rebased on `origin/main`