### PR TITLE
feat(python-apps): per-app static-asset split — Passenger public/ equivalent (GH #878)

### DIFF
--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1470,6 +1470,16 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string, format: ulid } } ]
       responses: { "200": { description: Saved } }
 
+  /python-apps/{id}/static:
+    put:
+      tags: [Python Apps]
+      summary: Set or clear a Python app's static-asset split (GH #878)
+      description: nginx serves base_uri+static_url directly from app_root/static_root instead of proxying to the app — the Passenger public/ equivalent. Both fields empty clears the mapping.
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: ulid } } ]
+      requestBody: { required: true, content: { application/json: { schema: { type: object, properties: { static_url: { type: string, example: /static }, static_root: { type: string, example: public } } } } } }
+      responses: { "200": { description: Saved }, "400": { description: Invalid static split } }
+
   /python-apps/{id}/control:
     post:
       tags: [Python Apps]

--- a/panel-api/internal/api/python_apps.go
+++ b/panel-api/internal/api/python_apps.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -51,6 +52,7 @@ func RegisterPythonAppRoutes(g *gin.RouterGroup, cfg PythonAppHandlerConfig) {
 	grp.POST("/:id/control", h.control)
 	grp.GET("/:id/logs", h.logs)
 	grp.PUT("/:id/env", h.putEnv)
+	grp.PUT("/:id/static", h.putStatic)
 }
 
 func (h *pythonAppHandler) requireEnabled(c *gin.Context) {
@@ -67,7 +69,34 @@ var (
 	baseURIRe    = regexp.MustCompile(`^/[A-Za-z0-9._/-]*$`)
 	pyVersionRe  = regexp.MustCompile(`^3\.(?:[0-9]|1[0-9])$`)
 	entrypointRe = regexp.MustCompile(`^[A-Za-z0-9_.]+:[A-Za-z0-9_]+$`)
+	// GH #878 static split. staticURLRe is a URL path under the mount
+	// ("/static", "/static/"); staticRootRe a relative dir under app_root
+	// ("public", "app/static"). Whitelists exclude spaces and nginx
+	// metacharacters; ".." is checked separately (the segment class admits
+	// consecutive dots).
+	staticURLRe  = regexp.MustCompile(`^/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*/?$`)
+	staticRootRe = regexp.MustCompile(`^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$`)
 )
+
+// validateStaticSplit checks the optional static-asset mapping (GH #878).
+// Both fields come together. The rendered location is base_uri+static_url and
+// the alias app_root/static_root/ — the whitelists guarantee neither can
+// escape the app tree or break the vhost.
+func validateStaticSplit(staticURL, staticRoot string) error {
+	if staticURL == "" && staticRoot == "" {
+		return nil
+	}
+	if staticURL == "" || staticRoot == "" {
+		return errors.New("static_url and static_root must be set together")
+	}
+	if !staticURLRe.MatchString(staticURL) || strings.Contains(staticURL, "..") {
+		return errors.New("static_url must be a URL path like /static (letters, digits, . _ -)")
+	}
+	if !staticRootRe.MatchString(staticRoot) || strings.Contains(staticRoot, "..") {
+		return errors.New("static_root must be a relative directory like public (letters, digits, . _ -)")
+	}
+	return nil
+}
 
 // loadOwned fetches the app and enforces owner/admin scope.
 func (h *pythonAppHandler) loadOwned(c *gin.Context) (*models.PythonApp, bool) {
@@ -138,6 +167,11 @@ type createPythonAppRequest struct {
 	// Framework, when set, is a marketplace slug (JAB-164). It derives
 	// app_type + entrypoint from the catalog and drives the one-shot scaffold.
 	Framework string `json:"framework,omitempty"`
+	// StaticURL/StaticRoot request a static-asset split (GH #878): nginx
+	// serves <base_uri><static_url> from <app_root>/<static_root> instead of
+	// proxying. Ignored when Framework is set (the catalog provides them).
+	StaticURL  string `json:"static_url,omitempty"`
+	StaticRoot string `json:"static_root,omitempty"`
 }
 
 func (h *pythonAppHandler) create(c *gin.Context) {
@@ -153,7 +187,6 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 	}
 	// JAB-164: a framework install derives app_type + entrypoint from the
 	// catalog entry and carries the static split for the nginx alias.
-	var fwStaticURL, fwStaticRoot string
 	if req.Framework != "" {
 		if h.cfg.Catalog == nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "framework_catalog_unavailable"})
@@ -171,7 +204,11 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		}
 		req.AppType = spec.AppType
 		req.Entrypoint = spec.Entrypoint
-		fwStaticURL, fwStaticRoot = spec.StaticURL, spec.StaticRoot
+		req.StaticURL, req.StaticRoot = spec.StaticURL, spec.StaticRoot
+	}
+	if err := validateStaticSplit(req.StaticURL, req.StaticRoot); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_static", "detail": err.Error()})
+		return
 	}
 	if req.AppType == "" {
 		req.AppType = "wsgi"
@@ -293,6 +330,8 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		AppType:       req.AppType,
 		Entrypoint:    req.Entrypoint,
 		BaseURI:       req.BaseURI,
+		StaticURL:     req.StaticURL,
+		StaticRoot:    req.StaticRoot,
 		LoopbackPort:  &port,
 		Framework:     req.Framework,
 		Status:        models.PythonAppStatusPending,
@@ -309,8 +348,8 @@ func (h *pythonAppHandler) create(c *gin.Context) {
 		_ = h.cfg.Apps.ReplaceEnv(ctx, app.ID, envMapToRows(req.Env))
 	}
 
-	// Attach the nginx proxy (+ framework static_alias) to the domain.
-	h.attachProxyRule(ctx, domain, app, fwStaticURL, fwStaticRoot)
+	// Attach the nginx proxy (+ static_alias when a split is set) to the domain.
+	h.attachProxyRule(ctx, domain, app)
 	if h.cfg.Reconciler != nil {
 		h.cfg.Reconciler.Schedule(domain.ID)
 	}
@@ -395,9 +434,52 @@ func (h *pythonAppHandler) putEnv(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
+// putStatic sets or clears the static-asset split on an existing app
+// (GH #878) — the Passenger public/ equivalent for hand-configured apps.
+// Both fields empty clears the mapping; nginx goes back to proxying
+// everything to the app.
+func (h *pythonAppHandler) putStatic(c *gin.Context) {
+	app, ok := h.loadOwned(c)
+	if !ok {
+		return
+	}
+	var req struct {
+		StaticURL  string `json:"static_url"`
+		StaticRoot string `json:"static_root"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	if err := validateStaticSplit(req.StaticURL, req.StaticRoot); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_static", "detail": err.Error()})
+		return
+	}
+	ctx := c.Request.Context()
+	domain, err := h.cfg.Domains.FindByID(ctx, app.DomainID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain_not_found"})
+		return
+	}
+	app.StaticURL, app.StaticRoot = req.StaticURL, req.StaticRoot
+	if err := h.cfg.Apps.Update(ctx, app); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// Re-attach: drop any previous static_alias for this app (its location
+	// may have changed), then upsert the new mapping. attachProxyRule
+	// persists the domain.
+	dropStaticRules(domain, app)
+	h.attachProxyRule(ctx, domain, app)
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(app.DomainID)
+	}
+	c.JSON(http.StatusOK, gin.H{"app": app})
+}
+
 // attachProxyRule appends a proxy_pass nginx rule (base_uri -> loopback port)
 // to the domain so the existing reconciler renders the vhost.
-func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp, staticURL, staticRoot string) {
+func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.Domain, app *models.PythonApp) {
 	rules := append(models.NginxRules{}, domain.NginxRules...)
 	upsert := func(rule models.NginxRule) {
 		for i := range rules {
@@ -410,16 +492,31 @@ func (h *pythonAppHandler) attachProxyRule(ctx context.Context, domain *models.D
 	}
 	ws := true
 	upsert(models.NginxRule{Type: "proxy_pass", Path: app.BaseURI, Target: proxyTargetFor(app), Websocket: &ws})
-	// Framework static split (Django STATIC_ROOT): serve <base><static_url> from
+	// Static split (GH #878): serve <base><static_url> from
 	// <app_root>/<static_root>. Django prefixes STATIC_URL with SCRIPT_NAME
 	// (=base_uri), so the location is base_uri + static_url.
-	if staticURL != "" && staticRoot != "" {
-		loc := strings.TrimSuffix(app.BaseURI, "/") + staticURL
-		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(staticRoot, "/") + "/"
+	if app.StaticURL != "" && app.StaticRoot != "" {
+		loc := strings.TrimSuffix(app.BaseURI, "/") + app.StaticURL
+		alias := strings.TrimSuffix(app.AppRoot, "/") + "/" + strings.Trim(app.StaticRoot, "/") + "/"
 		upsert(models.NginxRule{Type: "static_alias", Path: loc, Target: alias})
 	}
 	domain.NginxRules = rules
 	_ = h.cfg.Domains.Update(ctx, domain)
+}
+
+// dropStaticRules removes (in memory) every static_alias rule pointing into
+// this app's tree, so a changed or cleared split doesn't leave the old
+// location behind. The caller persists via attachProxyRule / Domains.Update.
+func dropStaticRules(domain *models.Domain, app *models.PythonApp) {
+	aliasPrefix := strings.TrimSuffix(app.AppRoot, "/") + "/"
+	var kept models.NginxRules
+	for _, r := range domain.NginxRules {
+		if r.Type == "static_alias" && app.AppRoot != "" && strings.HasPrefix(r.Target, aliasPrefix) {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	domain.NginxRules = kept
 }
 
 // frameworkDTO is the catalog projection the UI needs — no template bytes, and

--- a/panel-api/internal/api/python_apps_static_test.go
+++ b/panel-api/internal/api/python_apps_static_test.go
@@ -1,0 +1,186 @@
+package api
+
+// GH #878: per-app static-asset split — validation + the PUT /static
+// attach/replace/clear lifecycle against the domain's nginx rules.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	ginctx "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func TestValidateStaticSplit(t *testing.T) {
+	cases := []struct {
+		name, url, root string
+		wantErr         bool
+	}{
+		{"both empty ok", "", "", false},
+		{"passenger public", "/static", "public", false},
+		{"django style", "/static/", "staticfiles", false},
+		{"nested", "/assets", "app/static/dist", false},
+		{"url only", "/static", "", true},
+		{"root only", "", "public", true},
+		{"url no leading slash", "static", "public", true},
+		{"url traversal", "/../etc", "public", true},
+		{"url dotdot segment", "/a/../b", "public", true},
+		{"root traversal", "/static", "../../etc", true},
+		{"root absolute", "/static", "/etc", true},
+		{"url space", "/sta tic", "public", true},
+		{"url semicolon", "/static;", "public", true},
+		{"root brace", "/static", "pub{lic}", true},
+		{"url bare slash", "/", "public", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStaticSplit(tc.url, tc.root)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateStaticSplit(%q, %q) err = %v, wantErr %v", tc.url, tc.root, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+type staticFakeApps struct {
+	repository.PythonAppRepository
+	app *models.PythonApp
+}
+
+func (f *staticFakeApps) FindByID(_ context.Context, id string) (*models.PythonApp, error) {
+	return f.app, nil
+}
+func (f *staticFakeApps) Update(_ context.Context, app *models.PythonApp) error {
+	f.app = app
+	return nil
+}
+
+type staticFakeDomains struct {
+	repository.DomainRepository
+	domain *models.Domain
+}
+
+func (f *staticFakeDomains) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	return f.domain, nil
+}
+func (f *staticFakeDomains) Update(_ context.Context, d *models.Domain) error {
+	f.domain = d
+	return nil
+}
+
+func putStaticCtx(t *testing.T, appID string, body map[string]any) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	b, _ := json.Marshal(body)
+	c.Request = httptest.NewRequest("PUT", "/python-apps/"+appID+"/static", bytes.NewReader(b))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: appID}}
+	ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+	return c, w
+}
+
+func staticRulesOf(d *models.Domain) []models.NginxRule {
+	var out []models.NginxRule
+	for _, r := range d.NginxRules {
+		if r.Type == "static_alias" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestPutStatic_AttachReplaceClear(t *testing.T) {
+	port := 21000
+	apps := &staticFakeApps{app: &models.PythonApp{
+		ID: "app1", UserID: "u1", DomainID: "dom1",
+		AppRoot: "/home/u1/myapp", BaseURI: "/", LoopbackPort: &port,
+	}}
+	ws := true
+	domains := &staticFakeDomains{domain: &models.Domain{
+		ID: "dom1",
+		NginxRules: models.NginxRules{
+			{Type: "proxy_pass", Path: "/", Target: "http://127.0.0.1:21000", Websocket: &ws},
+		},
+	}}
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Apps: apps, Domains: domains}}
+
+	// Attach: /static -> public/
+	c, w := putStaticCtx(t, "app1", map[string]any{"static_url": "/static", "static_root": "public"})
+	h.putStatic(c)
+	if w.Code != 200 {
+		t.Fatalf("attach status = %d, body %s", w.Code, w.Body.String())
+	}
+	got := staticRulesOf(domains.domain)
+	if len(got) != 1 || got[0].Path != "/static" || got[0].Target != "/home/u1/myapp/public/" {
+		t.Fatalf("after attach rules = %+v", got)
+	}
+	if apps.app.StaticURL != "/static" || apps.app.StaticRoot != "public" {
+		t.Fatalf("app not persisted: %+v", apps.app)
+	}
+
+	// Replace: /assets -> dist/ — the old /static location must go away.
+	c, w = putStaticCtx(t, "app1", map[string]any{"static_url": "/assets", "static_root": "dist"})
+	h.putStatic(c)
+	if w.Code != 200 {
+		t.Fatalf("replace status = %d", w.Code)
+	}
+	got = staticRulesOf(domains.domain)
+	if len(got) != 1 || got[0].Path != "/assets" || got[0].Target != "/home/u1/myapp/dist/" {
+		t.Fatalf("after replace rules = %+v", got)
+	}
+
+	// Clear: both empty — static_alias gone, proxy_pass survives.
+	c, w = putStaticCtx(t, "app1", map[string]any{"static_url": "", "static_root": ""})
+	h.putStatic(c)
+	if w.Code != 200 {
+		t.Fatalf("clear status = %d", w.Code)
+	}
+	if got = staticRulesOf(domains.domain); len(got) != 0 {
+		t.Fatalf("after clear static rules = %+v", got)
+	}
+	proxies := 0
+	for _, r := range domains.domain.NginxRules {
+		if r.Type == "proxy_pass" {
+			proxies++
+		}
+	}
+	if proxies != 1 {
+		t.Fatalf("proxy_pass count = %d, want 1", proxies)
+	}
+}
+
+func TestPutStatic_RejectsInvalid(t *testing.T) {
+	apps := &staticFakeApps{app: &models.PythonApp{ID: "app1", UserID: "u1", DomainID: "dom1", AppRoot: "/home/u1/myapp", BaseURI: "/"}}
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Apps: apps, Domains: &staticFakeDomains{domain: &models.Domain{ID: "dom1"}}}}
+	c, w := putStaticCtx(t, "app1", map[string]any{"static_url": "/static", "static_root": "../../etc"})
+	h.putStatic(c)
+	if w.Code != 400 {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Error != "invalid_static" {
+		t.Errorf("error = %q, want invalid_static", body.Error)
+	}
+}
+
+func TestPutStatic_ForbidsOtherUsersApp(t *testing.T) {
+	apps := &staticFakeApps{app: &models.PythonApp{ID: "app1", UserID: "someone-else", DomainID: "dom1", AppRoot: "/home/x/app", BaseURI: "/"}}
+	h := &pythonAppHandler{cfg: PythonAppHandlerConfig{Apps: apps}}
+	c, w := putStaticCtx(t, "app1", map[string]any{"static_url": "/static", "static_root": "public"})
+	h.putStatic(c)
+	if w.Code != 403 {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}

--- a/panel-api/internal/db/migrations/000249_python_app_static.down.sql
+++ b/panel-api/internal/db/migrations/000249_python_app_static.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE python_apps
+  DROP COLUMN static_url,
+  DROP COLUMN static_root;

--- a/panel-api/internal/db/migrations/000249_python_app_static.up.sql
+++ b/panel-api/internal/db/migrations/000249_python_app_static.up.sql
@@ -1,0 +1,8 @@
+-- GH #878: per-app static-asset split for Python apps. nginx serves
+-- <base_uri><static_url> directly from <app_root>/<static_root> instead of
+-- proxying to gunicorn/uvicorn — the Passenger public/ equivalent for
+-- hand-configured apps. Framework installs seed these from the catalog;
+-- empty means everything proxies to the app (previous behavior).
+ALTER TABLE python_apps
+  ADD COLUMN static_url  varchar(255) NOT NULL DEFAULT '',
+  ADD COLUMN static_root varchar(512) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/python_app.go
+++ b/panel-api/internal/models/python_app.go
@@ -24,6 +24,13 @@ type PythonApp struct {
 	Entrypoint string `gorm:"type:varchar(255);not null" json:"entrypoint"`
 	// BaseURI is the mount point on the domain, "/" or "/app".
 	BaseURI string `gorm:"column:base_uri;type:varchar(255);not null;default:'/'" json:"base_uri"`
+	// StaticURL/StaticRoot describe the static-asset split (GH #878): nginx
+	// serves <base_uri><static_url> directly from <app_root>/<static_root>
+	// instead of proxying to the app — the Passenger public/ equivalent.
+	// Empty = everything proxies. Framework installs seed these from the
+	// catalog entry.
+	StaticURL  string `gorm:"column:static_url;type:varchar(255);not null" json:"static_url,omitempty"`
+	StaticRoot string `gorm:"column:static_root;type:varchar(512);not null" json:"static_root,omitempty"`
 	// LoopbackPort is the 127.0.0.1 port gunicorn/uvicorn binds; nginx
 	// proxy_passes to it. Allocated by the API on create (nil until then).
 	LoopbackPort *int `gorm:"column:loopback_port;type:int;null" json:"loopback_port,omitempty"`

--- a/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
+++ b/panel-ui/src/shells/user/python-apps/PythonAppsPage.tsx
@@ -16,7 +16,7 @@ import {
   Tooltip,
   Typography,
 } from "antd";
-import { ReloadOutlined, PauseCircleOutlined, FileTextOutlined, DeleteOutlined, SettingOutlined } from "@icons";
+import { ReloadOutlined, PauseCircleOutlined, FileTextOutlined, DeleteOutlined, SettingOutlined, FolderOpenOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
 import { PythonAppEnvDrawer } from "./PythonAppEnvDrawer";
 import { useEffect, useMemo, useState } from "react";
@@ -33,6 +33,7 @@ import {
   useFrameworks,
   usePythonApps,
   usePythonVersions,
+  useSetPythonAppStatic,
 } from "./usePythonApps";
 
 type DomainRow = { id: string; name: string };
@@ -113,6 +114,32 @@ export function PythonAppsPage() {
   const [logsApp, setLogsApp] = useState<PythonApp | null>(null);
   const [logsText, setLogsText] = useState("");
   const [envApp, setEnvApp] = useState<PythonApp | null>(null);
+  // GH #878: static-asset split editor (Passenger public/ equivalent).
+  const [staticApp, setStaticApp] = useState<PythonApp | null>(null);
+  const [staticForm] = Form.useForm<{ static_url: string; static_root: string }>();
+  const setStatic = useSetPythonAppStatic();
+  const openStatic = (app: PythonApp) => {
+    staticForm.setFieldsValue({
+      static_url: app.static_url ?? "",
+      static_root: app.static_root ?? "",
+    });
+    setStaticApp(app);
+  };
+  const submitStatic = async () => {
+    if (!staticApp) return;
+    const v = await staticForm.validateFields();
+    try {
+      await setStatic.mutateAsync({
+        id: staticApp.id,
+        static_url: v.static_url?.trim() ?? "",
+        static_root: v.static_root?.trim() ?? "",
+      });
+      message.success("Static file mapping saved");
+      setStaticApp(null);
+    } catch (e) {
+      message.error(e instanceof Error ? e.message : "Save failed");
+    }
+  };
 
   const submit = async () => {
     const values = await form.validateFields();
@@ -223,6 +250,7 @@ export function PythonAppsPage() {
                 { key: "stop", label: "Stop", icon: <PauseCircleOutlined />, onClick: () => void doControl(r.id, "stop") },
                 { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => void openLogs(r) },
                 { key: "env", label: "Environment", icon: <SettingOutlined />, onClick: () => setEnvApp(r) },
+                { key: "static", label: "Static files", icon: <FolderOpenOutlined />, onClick: () => openStatic(r) },
                 {
                   key: "delete",
                   label: "Delete",
@@ -358,6 +386,56 @@ export function PythonAppsPage() {
           )}
           <Form.Item name="app_root" label={t("pythonappspage.app_directory")} tooltip={t("pythonappspage.path_under_your_home_e_g_domains_example_com")} rules={[{ required: true }]}>
             <Input placeholder="domains/example.com/app" />
+          </Form.Item>
+          {!installFw && (
+            <Space style={{ width: "100%" }} size="middle">
+              <Form.Item
+                name="static_url"
+                label="Static URL path"
+                tooltip="Optional. Requests under this path are served by nginx directly instead of your app — the Passenger public/ equivalent. Set both fields or neither."
+              >
+                <Input placeholder="/static" />
+              </Form.Item>
+              <Form.Item
+                name="static_root"
+                label="Static directory"
+                tooltip="Directory relative to the app directory that holds the static files, e.g. public or staticfiles."
+              >
+                <Input placeholder="public" />
+              </Form.Item>
+            </Space>
+          )}
+        </Form>
+      </Modal>
+
+      <Modal
+        title={staticApp ? `Static files — ${staticApp.name}` : "Static files"}
+        open={staticApp !== null}
+        onCancel={() => setStaticApp(null)}
+        onOk={() => void submitStatic()}
+        okText="Save"
+        confirmLoading={setStatic.isPending}
+      >
+        <Typography.Paragraph type="secondary">
+          nginx serves the URL path below directly from a directory inside your
+          app — CSS/JS/images stop going through the Python process (what
+          Passenger did with public/). Clear both fields to proxy everything to
+          the app again.
+        </Typography.Paragraph>
+        <Form form={staticForm} layout="vertical">
+          <Form.Item
+            name="static_url"
+            label="Static URL path"
+            rules={[{ pattern: /^$|^\/[A-Za-z0-9._/-]+$/, message: "URL path like /static" }]}
+          >
+            <Input placeholder="/static" />
+          </Form.Item>
+          <Form.Item
+            name="static_root"
+            label="Static directory (relative to app directory)"
+            rules={[{ pattern: /^$|^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/, message: "Relative directory like public" }]}
+          >
+            <Input placeholder="public" />
           </Form.Item>
         </Form>
       </Modal>

--- a/panel-ui/src/shells/user/python-apps/usePythonApps.ts
+++ b/panel-ui/src/shells/user/python-apps/usePythonApps.ts
@@ -13,6 +13,10 @@ export type PythonApp = {
   app_type: "wsgi" | "asgi";
   entrypoint: string;
   base_uri: string;
+  // GH #878: nginx serves base_uri+static_url directly from
+  // app_root/static_root (Passenger public/ equivalent). Empty = proxy all.
+  static_url?: string;
+  static_root?: string;
   loopback_port?: number;
   status: string;
   last_error?: string;
@@ -31,6 +35,8 @@ export type CreatePythonAppInput = {
   base_uri: string;
   env?: Record<string, string>;
   framework?: string;
+  static_url?: string;
+  static_root?: string;
 };
 
 // Framework is a marketplace catalog entry (JAB-164), from GET
@@ -94,6 +100,22 @@ export function useDeletePythonApp() {
   return useMutation({
     mutationFn: async (id: string) => {
       await apiClient.delete(`/python-apps/${id}`);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+  });
+}
+
+// GH #878: set or clear the static-asset split on an existing app. Both
+// fields empty clears it (nginx goes back to proxying everything).
+export function useSetPythonAppStatic() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: { id: string; static_url: string; static_root: string }) => {
+      const { data } = await apiClient.put<{ app: PythonApp }>(
+        `/python-apps/${vars.id}/static`,
+        { static_url: vars.static_url, static_root: vars.static_root },
+      );
+      return data.app;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
   });


### PR DESCRIPTION
Fixes the "all static assets dropped out" problem from #878: Python apps proxy every request to gunicorn/uvicorn, and production WSGI apps don't serve static files (Passenger used to serve `public/` itself).

## What
- `python_apps.static_url` + `static_root` (migration 000249). nginx serves `base_uri+static_url` directly from `app_root/static_root` via the existing `static_alias` domain rule (long-cache, `^~`).
- `PUT /python-apps/{id}/static` — set, replace, or clear the split on an **existing** app (no recreate). Drops the stale `static_alias` location, upserts the new one, schedules the vhost reconcile.
- Create accepts the fields for custom apps; framework installs (Django/Wagtail) now persist their catalog split too.
- Validation: URL-path + relative-dir whitelists, no `..`, no nginx metacharacters — alias can never escape the app tree.
- UI: optional "Static URL path" / "Static directory" on custom create + a **Static files** row action.

## Test plan
- [x] `TestValidateStaticSplit` — 15-case table incl. traversal, absolute root, nginx metachars
- [x] `TestPutStatic_AttachReplaceClear` — rule lifecycle on the domain
- [x] `TestPutStatic_RejectsInvalid`, `TestPutStatic_ForbidsOtherUsersApp`
- [x] full panel-api suite + panel-ui build
- [ ] live E2E on testserver after merge (WSGI app + /static served by nginx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)