### PR TITLE
fix(nginx): intercept toggle must not unbrand the native missing-file 404 (GH #879)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -272,6 +272,17 @@ server {
     location = /jabali-err-404.html { internal; root /var/www/jabali-errors; }
     location = /jabali-err-403.html { internal; root /var/www/jabali-errors; }
     location = /jabali-err-500.html { internal; root /var/www/jabali-errors; }
+{{ if and .InterceptErrors .HasPHP }}
+    # GH #879: with interception on, the PHP locations carry a 50x-ONLY
+    # error_page set (so FPM 404s pass through to the app). That also
+    # detaches their try_files =404 existence guard from the branded 404 —
+    # so the guard falls back HERE instead, where the full-status branded
+    # 404 is back in scope.
+    location @jabali_missing {
+        error_page 404 /jabali-err-404.html;
+        return 404;
+    }
+{{ end }}
 {{ end }}
 {{ if .CacheEnabled }}
     # Long-cache static assets (immutable content; 30 days).
@@ -304,7 +315,11 @@ server {
     # of PHP-FPM's bare "File not found", so the branded error_page shows.
     # When it exists the app runs and owns its own error pages.
     location = /index.php {
+{{ if .InterceptErrors }}
+        try_files $uri @jabali_missing;
+{{ else }}
         try_files $uri =404;
+{{ end }}
         fastcgi_pass unix:{{.FPMSocket}};
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
@@ -408,7 +423,11 @@ server {
         # security.limit_extensions = .php (install/php/jabali-php-pool.conf.tmpl)
         # already rejects that, so this is the second lock on the same door --
         # it must not be removed on the assumption the pool setting is enough.
+{{ if .InterceptErrors }}
+        try_files $uri @jabali_missing;
+{{ else }}
         try_files $uri =404;
+{{ end }}
         fastcgi_pass unix:{{.FPMSocket}};
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;

--- a/panel-agent/internal/commands/domain_intercept_errors_test.go
+++ b/panel-agent/internal/commands/domain_intercept_errors_test.go
@@ -45,9 +45,26 @@ func TestInterceptErrors_On_RendersInBothPHPLocations(t *testing.T) {
 		// 2 location-scoped + 1 server-level (pre-existing)
 		t.Errorf("50x error_page count = %d, want 3\n%s", got, out)
 	}
-	if strings.Contains(out, "error_page 404 /jabali-err-404.html;\n        fastcgi_intercept_errors") ||
-		strings.Count(out, "error_page 404") != 1 {
-		t.Errorf("404 error_page must stay server-level only (count=%d)", strings.Count(out, "error_page 404"))
+	// Native missing-file 404s: the PHP locations' guards must fall back to
+	// the named location (their 50x-only error_page detached them from the
+	// branded 404), and the named location must re-brand with correct status.
+	if got := strings.Count(out, "try_files $uri @jabali_missing;"); got != 2 {
+		t.Errorf("@jabali_missing guard count = %d, want 2", got)
+	}
+	if !strings.Contains(out, "location @jabali_missing {") {
+		t.Error("named location @jabali_missing missing")
+	}
+	if !strings.Contains(out, "error_page 404 /jabali-err-404.html;\n        return 404;") {
+		t.Error("@jabali_missing must re-brand the 404 with correct status")
+	}
+	// server-level 404 + the one inside @jabali_missing — never inside the
+	// PHP locations (that would intercept the app's own FPM 404s).
+	if got := strings.Count(out, "error_page 404"); got != 2 {
+		t.Errorf("error_page 404 count = %d, want 2 (server-level + @jabali_missing)", got)
+	}
+	// Only the ACME challenge location keeps a bare =404 guard.
+	if got := strings.Count(out, "try_files $uri =404;"); got != 1 {
+		t.Errorf("bare =404 guard count = %d, want 1 (ACME only)", got)
 	}
 }
 
@@ -56,8 +73,15 @@ func TestInterceptErrors_Off_ByteIdentical(t *testing.T) {
 	if strings.Contains(out, "fastcgi_intercept_errors on;") {
 		t.Error("intercept off must not render the fastcgi_intercept_errors directive")
 	}
-	// Server-level branded pages unchanged.
+	// Server-level branded pages unchanged; guards back to plain =404.
 	if !strings.Contains(out, "error_page 500 502 503 504 /jabali-err-500.html;") {
 		t.Error("server-level 50x error_page missing")
+	}
+	if strings.Contains(out, "@jabali_missing") {
+		t.Error("named location must not render with intercept off")
+	}
+	// ACME + both PHP-location guards.
+	if got := strings.Count(out, "try_files $uri =404;"); got != 3 {
+		t.Errorf("=404 guard count = %d, want 3 (ACME + 2 PHP locations)", got)
 	}
 }

--- a/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
+++ b/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
@@ -82,6 +82,7 @@ server {
     location = /jabali-err-500.html { internal; root /var/www/jabali-errors; }
 
 
+
     # Long-cache static assets (immutable content; 30 days).
     location ~* \.(?:css|js|jpe?g|png|gif|ico|svg|webp|woff2?|ttf|eot)$ {
         expires 30d;
@@ -112,7 +113,9 @@ server {
     # of PHP-FPM's bare "File not found", so the branded error_page shows.
     # When it exists the app runs and owns its own error pages.
     location = /index.php {
+
         try_files $uri =404;
+
         fastcgi_pass unix:/run/php/jabali-u/fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
@@ -185,7 +188,9 @@ server {
         # security.limit_extensions = .php (install/php/jabali-php-pool.conf.tmpl)
         # already rejects that, so this is the second lock on the same door --
         # it must not be removed on the assumption the pool setting is enough.
+
         try_files $uri =404;
+
         fastcgi_pass unix:/run/php/jabali-u/fpm.sock;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
Follow-up to #898, caught in live E2E on testserver: with `intercept_errors` on, the PHP locations' 50x-only `error_page` set also detached their `try_files $uri =404` existence guard from the inherited branded 404 — a no-app PHP domain (e.g. static site with html_first) served nginx's **raw default 404 page**.

Fix: with the toggle on, the guards fall back to a named `location @jabali_missing` which re-brands the 404 with correct status (`error_page 404` + `return 404`). FPM-returned 404s (WordPress's own pages) still pass through — the PHP locations' error_page set stays 50x-only.

## Test plan
- [x] `TestInterceptErrors_On_RendersInBothPHPLocations` extended: named location present, guards route to it, `error_page 404` exactly twice (server-level + @jabali_missing), bare `=404` only in ACME
- [x] `TestInterceptErrors_Off_ByteIdentical`: no named location, plain guards restored
- [x] full panel-agent suite; qallow golden regenerated
- [ ] live E2E: no-app 404 branded again with toggle on

🤖 Generated with [Claude Code](https://claude.com/claude-code)