### PR TITLE
fix(migrate): stop a leftover index.html shadowing migrated WordPress (JAB-223)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1549,6 +1549,21 @@ func cpanelRestoreCallback(
 			warnings = append(warnings, "appconfigs: skipped (websites disabled in plan)")
 		}
 
+		// JAB-223: a leftover index.html in a WordPress docroot shadows
+		// index.php under `index index.html index.php;` and the site serves a
+		// parked page at HTTP 200. Run this even when ImportAppConfigs was
+		// skipped for want of credentials — the shadow does not care whether
+		// the database was re-credentialed.
+		if plan.Websites {
+			shadowRes := cpanel.QuarantineShadowingIndexHTML(ctx, restoreAgent, p.targetUserID, p.targetUsername, appDocroots)
+			warnings = append(warnings, fmt.Sprintf(
+				"index_shadow: quarantined=%d flagged=%d",
+				len(shadowRes.Quarantined), len(shadowRes.Flagged)))
+			warnings = append(warnings, shadowRes.Quarantined...)
+			warnings = append(warnings, shadowRes.Flagged...)
+			warnings = append(warnings, shadowRes.Skipped...)
+		}
+
 		extrasRes, err := cpanel.ImportExtras(ctx, domainsRepo, mbRepo, fwdRepo, arRepo, filtersRepo, phpPoolsRepo, restoreAgent, p.parsed, p.targetUserID, p.targetUsername, preserve.MailRouting)
 		if err != nil {
 			return bytes, warnings, fmt.Errorf("extras: %w", err)

--- a/panel-api/internal/migrate/cpanel/restore_index_shadow.go
+++ b/panel-api/internal/migrate/cpanel/restore_index_shadow.go
@@ -1,0 +1,191 @@
+// restore_index_shadow.go — JAB-223.
+//
+// jabali's vhost template lists `index index.html index.php;`, so a docroot
+// holding BOTH a WordPress install and a leftover index.html serves the
+// index.html and never reaches index.php. The request returns 200, which is
+// exactly why it survives verification: the site is "up", it is just serving
+// somebody else's parked page.
+//
+// Observed on amitiim.com after a fleet migration — a 741-byte "CyberPanel
+// Installed" page sitting in front of a live WooCommerce store, months old,
+// carried over verbatim by the rsync. It had been dormant on the source and
+// became authoritative the moment the docroot landed behind jabali's nginx.
+//
+// Only pages we can positively identify as a control-panel default get
+// quarantined. Anything else — a hand-written holding page, a deliberate
+// maintenance splash, a landing page someone actually wants — is left exactly
+// where it is and reported instead. Renaming a customer's file on a guess is a
+// worse failure than the shadow it would fix, and it is not reversible by
+// anyone who does not already know to look for it.
+
+package cpanel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+// quarantineSuffix is appended to a shadowing index.html rather than deleting
+// it. The name is deliberately self-describing: an operator who finds it a year
+// later should not have to guess what moved it.
+const quarantineSuffix = ".jabali-shadowed-bak"
+
+// flaggedRemedy is appended to every flag so the warning names a fix instead of
+// just a symptom. Both routes are non-destructive: index_priority=php_first is
+// the domain's own supported setting (see indexDirectiveFor in the agent), and
+// renaming the file is what an operator would do by hand anyway.
+const flaggedRemedy = "To resolve: set this domain's index priority to php_first, or rename the file."
+
+// maxIndexHTMLScan caps how much of an index.html we read to classify it, and
+// doubles as a size guard: control-panel default pages are a couple of KiB, so
+// anything larger is presumed to be a real page and only ever gets flagged.
+const maxIndexHTMLScan = 64 * 1024
+
+// parkedPageMarkers are substrings that positively identify a control-panel or
+// web-server default page. Matched case-insensitively against the file body.
+//
+// Every entry here must be specific enough that a real site would not contain
+// it by accident. Deliberately absent: "coming soon", "under construction",
+// "maintenance" — those are things a customer means to publish.
+var parkedPageMarkers = []string{
+	"cyberpanel installed",
+	"apache2 debian default page",
+	"apache2 ubuntu default page",
+	"welcome to nginx!",
+	"litespeed web server",
+	"web server's default page",
+	"future home of something quite cool", // cPanel's stock parked page
+	"this is the default web page for this server",
+	"apache is functioning normally",
+	"plesk default page",
+}
+
+// IndexShadowResult reports what the pass did. Quarantined and Flagged are kept
+// apart on purpose — one is an action taken, the other is a decision deferred to
+// the operator, and collapsing them would hide which is which.
+type IndexShadowResult struct {
+	Quarantined []string // docroots where a panel default page was renamed
+	Flagged     []string // docroots where an unrecognised index.html still shadows WordPress
+	Skipped     []string // human-readable reasons (unreadable file, rename failed, …)
+}
+
+// looksLikeParkedPage reports whether body is recognisably a control-panel or
+// web-server default page.
+func looksLikeParkedPage(body []byte) bool {
+	lower := strings.ToLower(string(body))
+	for _, m := range parkedPageMarkers {
+		if strings.Contains(lower, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// docrootHasWordPress reports whether docroot holds a WordPress install whose
+// front controller an index.html would shadow.
+//
+// wp-load.php is the discriminator rather than index.php alone: every PHP app
+// has an index.php, but only WordPress ships wp-load.php, and requiring both
+// means we never touch a docroot where index.html is legitimately the entry
+// point for a static site that happens to have a stray index.php.
+func docrootHasWordPress(docroot string) bool {
+	for _, marker := range []string{"wp-load.php", "index.php"} {
+		if _, err := os.Stat(filepath.Join(docroot, marker)); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// QuarantineShadowingIndexHTML walks the restored docroots and resolves
+// index.html files that would shadow a WordPress front controller.
+//
+// Deliberately independent of ImportAppConfigs: that pass returns early when
+// there are no database credentials to rewrite, and a WordPress site whose
+// credentials happened to carry over unchanged would then never be checked —
+// while being just as shadowed.
+func QuarantineShadowingIndexHTML(
+	ctx context.Context,
+	agentCli agent.AgentInterface,
+	targetUserID, targetUsername string,
+	docroots []string,
+) *IndexShadowResult {
+	res := &IndexShadowResult{}
+
+	for _, docroot := range docroots {
+		indexHTML := filepath.Join(docroot, "index.html")
+		st, err := os.Stat(indexHTML)
+		if err != nil || st.IsDir() {
+			continue
+		}
+		if !docrootHasWordPress(docroot) {
+			continue
+		}
+
+		// Oversized files are never auto-renamed — see maxIndexHTMLScan.
+		if st.Size() > maxIndexHTMLScan {
+			res.Flagged = append(res.Flagged, fmt.Sprintf(
+				"index_shadow_flag:%s:index.html (%d bytes) shadows WordPress index.php — too large to classify, left in place. %s",
+				indexHTML, st.Size(), flaggedRemedy))
+			continue
+		}
+
+		body, rerr := os.ReadFile(indexHTML)
+		if rerr != nil {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("index_shadow_read:%s:%v", indexHTML, rerr))
+			continue
+		}
+		if !looksLikeParkedPage(body) {
+			res.Flagged = append(res.Flagged, fmt.Sprintf(
+				"index_shadow_flag:%s:index.html shadows WordPress index.php — not a recognised default page, left in place. %s",
+				indexHTML, flaggedRemedy))
+			continue
+		}
+
+		// Never clobber a previous quarantine: if the parked name is taken, say
+		// so rather than overwrite whatever is already there.
+		target := indexHTML + quarantineSuffix
+		if _, serr := os.Stat(target); serr == nil {
+			res.Skipped = append(res.Skipped, fmt.Sprintf(
+				"index_shadow_skip:%s:%s already exists", indexHTML, target))
+			continue
+		}
+
+		if err := renameViaAgent(ctx, agentCli, targetUserID, targetUsername, indexHTML, target); err != nil {
+			res.Skipped = append(res.Skipped, fmt.Sprintf("index_shadow_rename:%s:%v", indexHTML, err))
+			continue
+		}
+		res.Quarantined = append(res.Quarantined, fmt.Sprintf(
+			"index_shadow_quarantined:%s -> %s (control-panel default page was shadowing WordPress)",
+			indexHTML, filepath.Base(target)))
+	}
+	return res
+}
+
+// renameViaAgent renames through the agent so the per-user scope guard and the
+// audit log both run, falling back to a direct rename the way the cache-clear
+// pass does — panel-api reaches /home/<user> via the www-data group, and a
+// missing audit line is a better outcome than leaving the site serving a parked
+// page.
+func renameViaAgent(
+	ctx context.Context,
+	agentCli agent.AgentInterface,
+	targetUserID, targetUsername, oldPath, newPath string,
+) error {
+	if agentCli != nil {
+		if _, err := agentCli.Call(ctx, "files.rename", map[string]any{
+			"user_id":  targetUserID,
+			"username": targetUsername,
+			"old_path": oldPath,
+			"new_path": newPath,
+		}); err == nil {
+			return nil
+		}
+	}
+	return os.Rename(oldPath, newPath)
+}

--- a/panel-api/internal/migrate/cpanel/restore_index_shadow_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_index_shadow_test.go
@@ -1,0 +1,184 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// wpDocroot builds a docroot that looks like a WordPress install, plus an
+// optional index.html body (skipped when body is nil).
+func wpDocroot(t *testing.T, indexHTML []byte, files ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if files == nil {
+		files = []string{"wp-load.php", "index.php"}
+	}
+	for _, f := range files {
+		if err := os.WriteFile(filepath.Join(dir, f), []byte("<?php\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", f, err)
+		}
+	}
+	if indexHTML != nil {
+		if err := os.WriteFile(filepath.Join(dir, "index.html"), indexHTML, 0o644); err != nil {
+			t.Fatalf("write index.html: %v", err)
+		}
+	}
+	return dir
+}
+
+// The bug as observed: a CyberPanel default page in front of a live WordPress
+// install. It must be renamed out of the way, not deleted.
+func TestQuarantine_CyberPanelDefaultIsQuarantined(t *testing.T) {
+	body := []byte(`<html><head><title>CyberPanel</title></head>
+<body><h1>CyberPanel Installed</h1><p>please remove this page</p></body></html>`)
+	dir := wpDocroot(t, body)
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+
+	if len(res.Quarantined) != 1 {
+		t.Fatalf("want 1 quarantined, got %d (flagged=%v skipped=%v)",
+			len(res.Quarantined), res.Flagged, res.Skipped)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "index.html")); !os.IsNotExist(err) {
+		t.Errorf("index.html should no longer shadow index.php, stat err = %v", err)
+	}
+	// Renamed, never destroyed — the operator has to be able to get it back.
+	preserved := filepath.Join(dir, "index.html"+quarantineSuffix)
+	got, err := os.ReadFile(preserved)
+	if err != nil {
+		t.Fatalf("quarantined file missing: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Error("quarantined file content was altered")
+	}
+}
+
+// Every marker must actually trigger — a typo in the table is a silent no-op
+// that only shows up as another customer serving a parked page.
+func TestQuarantine_EveryParkedMarkerMatches(t *testing.T) {
+	for _, marker := range parkedPageMarkers {
+		t.Run(marker, func(t *testing.T) {
+			// Upper-cased to pin the case-insensitive match too.
+			body := []byte("<html><body>" + strings.ToUpper(marker) + "</body></html>")
+			dir := wpDocroot(t, body)
+
+			res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+			if len(res.Quarantined) != 1 {
+				t.Fatalf("marker %q did not quarantine (flagged=%v skipped=%v)",
+					marker, res.Flagged, res.Skipped)
+			}
+		})
+	}
+}
+
+// The conservative half: an unrecognised page is a page somebody may have meant
+// to publish. Report it, never move it.
+func TestQuarantine_UnknownPageIsFlaggedNotMoved(t *testing.T) {
+	body := []byte(`<html><body><h1>Acme Ltd — back soon</h1></body></html>`)
+	dir := wpDocroot(t, body)
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+
+	if len(res.Quarantined) != 0 {
+		t.Fatalf("must not move an unrecognised page, quarantined=%v", res.Quarantined)
+	}
+	if len(res.Flagged) != 1 {
+		t.Fatalf("want 1 flagged, got %d", len(res.Flagged))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "index.html")); err != nil {
+		t.Errorf("unrecognised index.html must stay put: %v", err)
+	}
+}
+
+// A "coming soon" splash is a deliberate publish, not a leftover. Explicitly
+// pinned because it is the most tempting thing to add to the marker table.
+func TestQuarantine_ComingSoonIsNotTreatedAsParked(t *testing.T) {
+	dir := wpDocroot(t, []byte(`<html><body>Coming Soon! Under construction.</body></html>`))
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+	if len(res.Quarantined) != 0 {
+		t.Fatalf("coming-soon page must not be quarantined, got %v", res.Quarantined)
+	}
+}
+
+// No WordPress means no shadow to resolve — a static site's index.html is the
+// whole point of the site.
+func TestQuarantine_NonWordPressDocrootUntouched(t *testing.T) {
+	// index.php present but no wp-load.php: some other PHP app.
+	dir := wpDocroot(t, []byte("<html>CyberPanel Installed</html>"), "index.php")
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+
+	if len(res.Quarantined) != 0 || len(res.Flagged) != 0 {
+		t.Fatalf("non-WordPress docroot must be untouched: quarantined=%v flagged=%v",
+			res.Quarantined, res.Flagged)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "index.html")); err != nil {
+		t.Errorf("index.html must survive: %v", err)
+	}
+}
+
+// A WordPress docroot with no index.html at all is the common case and must
+// produce no output whatsoever.
+func TestQuarantine_NoIndexHTMLIsSilent(t *testing.T) {
+	dir := wpDocroot(t, nil)
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+	if len(res.Quarantined)+len(res.Flagged)+len(res.Skipped) != 0 {
+		t.Fatalf("clean docroot produced output: %+v", res)
+	}
+}
+
+// Size guard: a large index.html is a real page regardless of what strings it
+// happens to contain.
+func TestQuarantine_OversizedIndexIsFlaggedNotMoved(t *testing.T) {
+	big := append([]byte("<html>CyberPanel Installed"), make([]byte, maxIndexHTMLScan+1)...)
+	dir := wpDocroot(t, big)
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+
+	if len(res.Quarantined) != 0 {
+		t.Fatalf("oversized page must not be moved, got %v", res.Quarantined)
+	}
+	if len(res.Flagged) != 1 {
+		t.Fatalf("want 1 flagged, got %d (skipped=%v)", len(res.Flagged), res.Skipped)
+	}
+}
+
+// Re-running a restore must not clobber the file quarantined the first time.
+func TestQuarantine_ExistingBackupIsNotOverwritten(t *testing.T) {
+	dir := wpDocroot(t, []byte("<html>CyberPanel Installed</html>"))
+	preserved := filepath.Join(dir, "index.html"+quarantineSuffix)
+	if err := os.WriteFile(preserved, []byte("FIRST RUN"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+
+	if len(res.Quarantined) != 0 {
+		t.Fatalf("must not overwrite an existing quarantine, got %v", res.Quarantined)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("want 1 skipped, got %d", len(res.Skipped))
+	}
+	got, err := os.ReadFile(preserved)
+	if err != nil || string(got) != "FIRST RUN" {
+		t.Errorf("earlier quarantine was clobbered: %q err=%v", got, err)
+	}
+}
+
+// A directory named index.html must not be renamed.
+func TestQuarantine_DirectoryNamedIndexHTMLIgnored(t *testing.T) {
+	dir := wpDocroot(t, nil)
+	if err := os.Mkdir(filepath.Join(dir, "index.html"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	res := QuarantineShadowingIndexHTML(context.Background(), nil, "uid", "user", []string{dir})
+	if len(res.Quarantined)+len(res.Flagged) != 0 {
+		t.Fatalf("directory must be ignored: %+v", res)
+	}
+}


### PR DESCRIPTION
## The failure

jabali's vhost renders `index index.html index.php;` by default (`indexDirectiveFor`, `html_first`), so a docroot holding **both** a WordPress install and a leftover `index.html` serves the `index.html` and never reaches `index.php`.

The request returns **200**, which is exactly why it survives verification — the site is "up", it is just serving somebody else's parked page. On amitiim.com that was a 741-byte "CyberPanel Installed" page in front of a live WooCommerce store, months old, carried over verbatim by the rsync. Dormant on the source; authoritative the moment the docroot landed behind jabali's nginx.

**The panel already solves this for its own installer.** `removePlaceholderIndex` in `wordpress_install.go` deletes the placeholder `index.html` for precisely this reason, and its comment names the same directive:

> nginx's `index index.html index.php` directive serves it before WP's index.php, so it must go before the install completes

The migration restore path never got the equivalent. That's the whole gap.

## What this does

`QuarantineShadowingIndexHTML` renames `index.html` out of the way when — and only when — both hold:

1. the docroot has a WordPress install (`wp-load.php` **and** `index.php`), and
2. the file is positively identifiable as a control-panel / web-server default page.

Everything else is **reported and left untouched**. A hand-written holding page or a deliberate maintenance splash is something a customer meant to publish; renaming it on a guess is a worse failure than the shadow it would fix, and it isn't reversible by anyone who doesn't already know to look. `"coming soon"` / `"under construction"` are deliberately *not* markers, with a test pinning that.

Flags name the remedy — `index_priority=php_first` (the domain's own supported setting) or rename — rather than just the symptom.

Renamed, never deleted. An existing quarantine is never overwritten, so a re-run can't destroy what the first run set aside.

Called **independently of `ImportAppConfigs`** rather than folded into its walk: that pass returns early when there are no credentials to rewrite, so a WordPress site whose credentials carried over unchanged would never have been checked — while being just as shadowed.

## Verified against real data, not just fixtures

On testserver, the marker matches the **actual** CyberPanel default page byte-for-byte:

```
$ head -c 200 /home/cybe2e/domains/smoke.jabalitest.com/public_html/index.html
... <h1 ...>CyberPanel Installed</h1>
    <h2 ...>You have successfully installed CyberPanel, please remove this ...
$ grep -ci "cyberpanel installed" ...   # 1
```

Sweeping **all 10 docroots on the box: zero false positives.** The two real WordPress docroots (`jabali.site`, `demolab.test`) have no `index.html`; the eight docroots that do have one have no `wp-load.php` — including the CyberPanel page above, which is correctly left alone.

18 unit tests pass, covering: the incident case, every marker in the table (a typo there is a silent no-op), unknown-page-flagged-not-moved, coming-soon, non-WordPress docroot, no-index.html, oversized file, existing-quarantine-not-clobbered, and a directory named `index.html`.

## Scoped out

The issue's second acceptance criterion — post-restore checks should assert **content**, not just HTTP 200. There is no post-restore HTTP verification step in the codebase today to extend; building one needs pre-cutover name resolution against the new box and is its own change. Flagging rather than silently dropping it.