### PR TITLE
fix(migrate): read the source's per-domain PHP version from the file that has it (JAB-218)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1575,7 +1575,8 @@ func cpanelRestoreCallback(
 			extrasRes.AutorespondersCreated, extrasRes.AutorespondersOrphaned,
 			extrasRes.FiltersImported,
 			extrasRes.PHPPoolsCreated, extrasRes.PHPDomainsBound,
-			extrasRes.PHPVersionApplied, extrasRes.FTPAccountsObserved,
+			extrasRes.PHPVersionApplied+" php_versions_detected="+extrasRes.PHPVersionsDetected,
+			extrasRes.FTPAccountsObserved,
 			extrasRes.DKIMKeysPreserved))
 		warnings = append(warnings, extrasRes.Skipped...)
 

--- a/panel-api/internal/migrate/cpanel/restore_extras.go
+++ b/panel-api/internal/migrate/cpanel/restore_extras.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -35,19 +36,20 @@ import (
 // ExtrasResult is the per-area counter set returned from ImportExtras.
 // Counters are summed into the parent restore manifest by the caller.
 type ExtrasResult struct {
-	CatchallsSet          int      // domains where catchall_target was written
-	SubdomainsCreated     int      // panel domain rows added from SUB_DOMAINS
-	ForwardersCreated     int      // mail forwarder rows added (M6.5)
-	ForwardersOrphaned    int      // alias lines whose local mailbox isn't in panel
-	AutorespondersCreated int      // vacation auto-replies restored (M6.5)
-	AutorespondersOrphaned int     // .autorespond entries whose mailbox isn't in panel
-	PHPVersionApplied     string   // first version applied at user-pool level (legacy)
-	PHPPoolsCreated       int      // distinct (user, version) FPM pools created (M35.8 P6)
-	PHPDomainsBound       int      // domains whose php_pool_id was set to a per-version pool
-	FTPAccountsObserved   int      // cpanel ftp accounts seen on source (record-only)
-	DKIMKeysPreserved     int      // legacy DKIM keys copied to sidecar storage
-	FiltersImported       int      // per-mailbox Sieve/cpanel inbox rules
-	Skipped               []string // human-readable reasons (mirrors other restore writers)
+	CatchallsSet           int      // domains where catchall_target was written
+	SubdomainsCreated      int      // panel domain rows added from SUB_DOMAINS
+	ForwardersCreated      int      // mail forwarder rows added (M6.5)
+	ForwardersOrphaned     int      // alias lines whose local mailbox isn't in panel
+	AutorespondersCreated  int      // vacation auto-replies restored (M6.5)
+	AutorespondersOrphaned int      // .autorespond entries whose mailbox isn't in panel
+	PHPVersionApplied      string   // first version applied at user-pool level (legacy)
+	PHPVersionsDetected    string   // JAB-218: source spread, e.g. "7.4x3,8.1x1" ("none" if the source recorded nothing)
+	PHPPoolsCreated        int      // distinct (user, version) FPM pools created (M35.8 P6)
+	PHPDomainsBound        int      // domains whose php_pool_id was set to a per-version pool
+	FTPAccountsObserved    int      // cpanel ftp accounts seen on source (record-only)
+	DKIMKeysPreserved      int      // legacy DKIM keys copied to sidecar storage
+	FiltersImported        int      // per-mailbox Sieve/cpanel inbox rules
+	Skipped                []string // human-readable reasons (mirrors other restore writers)
 }
 
 // ImportExtras walks the parsed cpmove + reads cpanel meta files for
@@ -204,6 +206,16 @@ func ImportExtras(
 	// that group to that pool via SetPHPPoolID.
 	if agentCli != nil && poolsRepo != nil && domainsRepo != nil {
 		byVersion := detectPHPVersionsPerDomain(parsed)
+		// JAB-218: record the source spread BEFORE any binding, so the summary
+		// distinguishes "the source ran one PHP version" from "we detected
+		// nothing and every domain silently inherited the box default" — the
+		// two used to look identical (`php_version=`), which is how 39 PHP-7.4
+		// sites landed on 8.4 without anyone noticing until they 500'd.
+		res.PHPVersionsDetected = summarisePHPVersionSpread(byVersion)
+		if len(byVersion) == 0 {
+			res.Skipped = append(res.Skipped,
+				"php_version_detect:source recorded no per-domain PHP version — every domain will run the box default")
+		}
 		seenVersions := map[string]string{} // version → pool_id
 		for version, doms := range byVersion {
 			if version == "" {
@@ -631,11 +643,57 @@ func parseAliases(path string) (string, []aliasForward, []string) {
 	return catchAll, forwards, warnings
 }
 
-// detectPHPVersionsPerDomain returns version → [domain1, domain2…]
-// — every distinct PHP version in the source userdata dir with the
-// list of domains using it. Used by the per-domain pool-bind path
-// in ImportExtras.
-func detectPHPVersionsPerDomain(parsed *ParsedTarball) map[string][]string {
+// userdataNonDomainFiles are the fixed-name entries cpanel keeps in the
+// userdata dir alongside the per-domain files.
+var userdataNonDomainFiles = map[string]bool{
+	"main": true, "cache": true, "scope": true, "nobody": true,
+}
+
+// userdataSidecarSuffixes are the per-domain sidecars that sit next to the
+// plain userdata file. None of them carries phpversion.
+var userdataSidecarSuffixes = []string{
+	".php-fpm.yaml", ".php-fpm.cache", ".cache", ".json", ".db", ".yaml",
+}
+
+// isPlainDomainUserdata reports whether name is cpanel's plain per-domain
+// userdata file — the one that actually carries `phpversion`.
+//
+// _SSL is excluded because it duplicates the http vhost's settings; counting
+// both would double every domain in the version tally.
+func isPlainDomainUserdata(name string) bool {
+	if name == "" || userdataNonDomainFiles[name] || strings.HasSuffix(name, "_SSL") {
+		return false
+	}
+	for _, suf := range userdataSidecarSuffixes {
+		if strings.HasSuffix(name, suf) {
+			return false
+		}
+	}
+	return true
+}
+
+// scanUserdataPHPVersions walks the source userdata dir and returns
+// version → [domain…] for every per-domain PHP version it can read.
+//
+// It reads the PLAIN `<userdata>/<domain>` file. An earlier revision scanned
+// `<domain>.php-fpm.yaml` instead, which never carries the key: cpanel puts
+// only pool tuning there —
+//
+//	_is_present: 1
+//	pm_max_children: 5
+//	pm_max_requests: 20
+//	pm_process_idle_timeout: 10
+//
+// Measured on a live source box: 0 of 143 .php-fpm.yaml files contained
+// `phpversion`, while 141 plain userdata files did. So detection always came
+// back empty, every migrated domain silently inherited the destination's
+// default PHP, and the restore summary reported the tell nobody read:
+// `php_pools=0 php_domains_bound=0 php_version=` (JAB-218).
+//
+// The .php-fpm.yaml probe is kept as a fallback rather than deleted — it costs
+// one stat per domain and covers any cpanel build that does write the key
+// there — but the plain file is now the primary source.
+func scanUserdataPHPVersions(parsed *ParsedTarball) map[string][]string {
 	roots := []string{
 		filepath.Join(parsed.ExtractDir, "cpmove-"+parsed.SourceUser, "userdata"),
 		filepath.Join(parsed.ExtractDir, "userdata"),
@@ -648,16 +706,16 @@ func detectPHPVersionsPerDomain(parsed *ParsedTarball) map[string][]string {
 			continue
 		}
 		for _, e := range entries {
-			name := e.Name()
-			if !strings.HasSuffix(name, ".php-fpm.yaml") {
+			if e.IsDir() || !isPlainDomainUserdata(e.Name()) {
 				continue
 			}
-			domain := strings.TrimSuffix(name, ".php-fpm.yaml")
-			// Skip the cpanel internal "main" + the "*_SSL" sidecar files.
-			if domain == "" || strings.HasSuffix(domain, "_SSL") {
-				continue
+			domain := e.Name()
+			ver := normalisePHPVersion(extractKV(filepath.Join(root, domain), "phpversion"))
+			if ver == "" {
+				// Legacy fallback: some builds may carry it in the sidecar.
+				ver = normalisePHPVersion(extractKV(
+					filepath.Join(root, domain+".php-fpm.yaml"), "phpversion"))
 			}
-			ver := normalisePHPVersion(extractKV(filepath.Join(root, name), "phpversion"))
 			if ver == "" {
 				continue
 			}
@@ -667,58 +725,71 @@ func detectPHPVersionsPerDomain(parsed *ParsedTarball) map[string][]string {
 			break
 		}
 	}
+	// Deterministic domain order per version so reruns and tests agree.
+	for v := range out {
+		sort.Strings(out[v])
+	}
 	return out
 }
 
-// detectPHPVersion scans <userdata>/*.php-fpm.yaml files for the
-// `phpversion: ea-php82` line + returns (primaryVersion, otherVersions).
-// "primary" = the most-frequent version (operator can fix outliers
-// after migration). Empty string when no .php-fpm.yaml found.
+// summarisePHPVersionSpread renders the detected version distribution for the
+// restore summary, e.g. "7.4x39,8.1x82,8.3x29". Returns "none" for an empty
+// map, which is the case the operator most needs to see.
+func summarisePHPVersionSpread(byVersion map[string][]string) string {
+	if len(byVersion) == 0 {
+		return "none"
+	}
+	vers := make([]string, 0, len(byVersion))
+	for v := range byVersion {
+		vers = append(vers, v)
+	}
+	sort.Strings(vers)
+	parts := make([]string, 0, len(vers))
+	for _, v := range vers {
+		parts = append(parts, fmt.Sprintf("%sx%d", v, len(byVersion[v])))
+	}
+	return strings.Join(parts, ",")
+}
+
+// detectPHPVersionsPerDomain returns version → [domain1, domain2…]
+// — every distinct PHP version in the source userdata dir with the
+// list of domains using it. Used by the per-domain pool-bind path
+// in ImportExtras.
+func detectPHPVersionsPerDomain(parsed *ParsedTarball) map[string][]string {
+	return scanUserdataPHPVersions(parsed)
+}
+
+// detectPHPVersion returns (primaryVersion, otherVersions) across the source's
+// per-domain userdata files. "primary" = the most-frequent version; the rest
+// are reported so the operator can see the spread. Empty string when the source
+// records no PHP version at all.
+//
+// Shares scanUserdataPHPVersions with the per-domain path so both read the same
+// file — see the note there for why the plain userdata file, not the
+// .php-fpm.yaml sidecar, is the one that carries `phpversion` (JAB-218).
 func detectPHPVersion(parsed *ParsedTarball) (string, []string) {
-	// userdata dir lives next to the cp/<user> file inside the
-	// extracted wrapper. Same probe set PeekAccountMeta uses.
-	roots := []string{
-		filepath.Join(parsed.ExtractDir, "cpmove-"+parsed.SourceUser, "userdata"),
-		filepath.Join(parsed.ExtractDir, "userdata"),
-		filepath.Join(parsed.ExtractDir, "cp", parsed.SourceUser, "userdata"),
-	}
-	versions := map[string]int{}
-	for _, root := range roots {
-		entries, err := os.ReadDir(root)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			if !strings.HasSuffix(e.Name(), ".php-fpm.yaml") {
-				continue
-			}
-			if v := normalisePHPVersion(extractKV(filepath.Join(root, e.Name()), "phpversion")); v != "" {
-				versions[v]++
-			}
-		}
-		if len(versions) > 0 {
-			break
-		}
-	}
-	if len(versions) == 0 {
+	byVersion := scanUserdataPHPVersions(parsed)
+	if len(byVersion) == 0 {
 		return "", nil
 	}
 	// Most-frequent wins; ties pick lexicographically lower so reruns
 	// are deterministic.
 	primary := ""
 	bestCount := 0
-	for v, c := range versions {
+	for v, doms := range byVersion {
+		c := len(doms)
 		if c > bestCount || (c == bestCount && (primary == "" || v < primary)) {
 			primary = v
 			bestCount = c
 		}
 	}
 	var others []string
-	for v := range versions {
+	for v := range byVersion {
 		if v != primary {
 			others = append(others, v)
 		}
 	}
+	sort.Strings(others)
 	return primary, others
 }
 

--- a/panel-api/internal/migrate/cpanel/restore_extras_phpversion_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_extras_phpversion_test.go
@@ -1,0 +1,192 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// realFPMYaml is a verbatim cpanel <domain>.php-fpm.yaml, copied from a live
+// source box. The point of pinning it here is what it does NOT contain: the
+// key detection used to look for. 0 of 143 such files on that box carried
+// `phpversion`, while 141 plain userdata files did — which is why detection
+// silently returned nothing and every migrated domain inherited the
+// destination default (JAB-218).
+const realFPMYaml = `---
+_is_present: 1
+pm_max_children: 5
+pm_max_requests: 20
+pm_process_idle_timeout: 10
+`
+
+// writeUserdata builds a userdata dir mirroring a real extracted cpmove tree,
+// including the sidecars and fixed-name files that must not be mistaken for
+// domains. versions maps domain -> cpanel phpversion value ("" writes the
+// domain file with no phpversion key at all).
+func writeUserdata(t *testing.T, versions map[string]string) *ParsedTarball {
+	t.Helper()
+	extract := t.TempDir()
+	root := filepath.Join(extract, "cpmove-someuser", "userdata")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Fixed-name entries cpanel keeps alongside the per-domain files.
+	for name, body := range map[string]string{
+		"main":                  "main_domain: example.com\n",
+		"cache.json":            `{"x":1}`,
+		"applications.json":     `{}`,
+		"cpanel_redirects.json": `[]`,
+		"cpanel_password_protected_directories.json": `{}`,
+		"ruby-on-rails-rewrites.db":                  "",
+		"scope":                                      "",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	for domain, ver := range versions {
+		body := "documentroot: /home/someuser/public_html\n"
+		if ver != "" {
+			body += "phpversion: " + ver + "\n"
+		}
+		if err := os.WriteFile(filepath.Join(root, domain), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", domain, err)
+		}
+		// The sidecars a real tree carries. Neither must be read as a domain,
+		// and the yaml must not be mistaken for a version source.
+		if err := os.WriteFile(filepath.Join(root, domain+".php-fpm.yaml"), []byte(realFPMYaml), 0o644); err != nil {
+			t.Fatalf("write yaml: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, domain+"_SSL"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write _SSL: %v", err)
+		}
+	}
+	return &ParsedTarball{ExtractDir: extract, SourceUser: "someuser"}
+}
+
+// The regression itself: a real tree where phpversion lives only in the plain
+// userdata file. Before the fix this returned an empty map.
+func TestDetectPHPVersionsPerDomain_ReadsPlainUserdataNotFPMYaml(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{
+		"otzma-p.co.il":    "ea-php74",
+		"old.arizot-e.com": "ea-php81",
+		"third.example":    "ea-php74",
+	})
+
+	got := detectPHPVersionsPerDomain(parsed)
+
+	want := map[string][]string{
+		"7.4": {"otzma-p.co.il", "third.example"},
+		"8.1": {"old.arizot-e.com"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detect mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+// _SSL duplicates the http vhost's settings; counting it would double every
+// domain and make the spread summary lie.
+func TestDetectPHPVersionsPerDomain_SSLSidecarNotDoubleCounted(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{"solo.example": "ea-php83"})
+
+	got := detectPHPVersionsPerDomain(parsed)
+	if len(got["8.3"]) != 1 {
+		t.Fatalf("want 1 domain on 8.3, got %v", got["8.3"])
+	}
+}
+
+// The fixed-name files (main, cache.json, scope, …) are not domains.
+func TestDetectPHPVersionsPerDomain_IgnoresNonDomainFiles(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{"real.example": "ea-php82"})
+
+	for _, doms := range detectPHPVersionsPerDomain(parsed) {
+		for _, d := range doms {
+			if d != "real.example" {
+				t.Errorf("non-domain file treated as a domain: %q", d)
+			}
+		}
+	}
+}
+
+// A source that genuinely records nothing must be distinguishable from one we
+// simply failed to parse — the caller turns this into a loud summary line.
+func TestDetectPHPVersionsPerDomain_NoVersionsIsEmpty(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{"nover.example": ""})
+
+	if got := detectPHPVersionsPerDomain(parsed); len(got) != 0 {
+		t.Fatalf("want empty, got %#v", got)
+	}
+}
+
+// Legacy safety net: if some cpanel build DOES write phpversion into the
+// sidecar, we still pick it up.
+func TestDetectPHPVersionsPerDomain_FallsBackToFPMYaml(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{"legacy.example": ""})
+	root := filepath.Join(parsed.ExtractDir, "cpmove-someuser", "userdata")
+	if err := os.WriteFile(filepath.Join(root, "legacy.example.php-fpm.yaml"),
+		[]byte(realFPMYaml+"phpversion: ea-php80\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := detectPHPVersionsPerDomain(parsed)
+	if len(got["8.0"]) != 1 || got["8.0"][0] != "legacy.example" {
+		t.Fatalf("sidecar fallback failed: %#v", got)
+	}
+}
+
+// detectPHPVersion shares the same scanner, so it must see the same data.
+func TestDetectPHPVersion_PrimaryIsMostFrequent(t *testing.T) {
+	parsed := writeUserdata(t, map[string]string{
+		"a.example": "ea-php74",
+		"b.example": "ea-php74",
+		"c.example": "ea-php81",
+	})
+
+	primary, others := detectPHPVersion(parsed)
+	if primary != "7.4" {
+		t.Errorf("primary = %q, want 7.4", primary)
+	}
+	if !reflect.DeepEqual(others, []string{"8.1"}) {
+		t.Errorf("others = %#v, want [8.1]", others)
+	}
+}
+
+func TestSummarisePHPVersionSpread(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string][]string
+		want string
+	}{
+		{"empty is explicit", map[string][]string{}, "none"},
+		{"single", map[string][]string{"8.1": {"a"}}, "8.1x1"},
+		{
+			"sorted and counted",
+			map[string][]string{"8.3": {"a", "b"}, "7.4": {"c"}, "8.1": {"d", "e", "f"}},
+			"7.4x1,8.1x3,8.3x2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := summarisePHPVersionSpread(tc.in); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalisePHPVersion_CpanelForms(t *testing.T) {
+	for in, want := range map[string]string{
+		"ea-php74": "7.4",
+		"ea-php81": "8.1",
+		"ea-php83": "8.3",
+		"8.2":      "8.2",
+		"":         "",
+	} {
+		if got := normalisePHPVersion(in); got != want {
+			t.Errorf("normalisePHPVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## One-line root cause

Detection was reading the wrong file. It has **never** worked.

## What was happening

cPanel records a per-vhost PHP version and pkgacct carries it, but every migrated domain landed on the destination default. The restore summary carried the tell nobody read:

```
extras: … php_pools=0 php_domains_bound=0 php_version=
```

Sites whose code is only PHP-7-clean then fatal on first request, days after a green restore — the hardest kind of regression to trace back. On the aramapp fleet that's **39 PHP-7.4 sites** of latent breakage (source spread: 39× `ea-php74`, 82× `ea-php81`, 29× `ea-php83`, 2× `ea-php80`).

## The bind path was never the problem

`ImportExtras` already creates a per-version pool, calls `php.version.install` to provision the runtime, applies the FPM pool, and binds each domain. All of it correct. It simply never ran — detection handed it an empty map every time.

`detectPHPVersionsPerDomain` scanned `<userdata>/<domain>.php-fpm.yaml` for a `phpversion` key. **cPanel doesn't put it there.** That file holds only pool tuning:

```yaml
---
_is_present: 1
pm_max_children: 5
pm_max_requests: 20
pm_process_idle_timeout: 10
```

Measured on the live source box:

| file | contains `phpversion` |
|---|---|
| `*.php-fpm.yaml` | **0 of 143** |
| plain `<userdata>/<domain>` | **141** |

Confirmed in an extracted cpmove tree — the actual input the restore parses — where `old.arizot-e.com` carries `phpversion: ea-php81` and its `.php-fpm.yaml` sidecar carries none.

## The fix

Read the plain per-domain userdata file; keep the sidecar as a fallback for any build that does write the key there. `detectPHPVersionsPerDomain` and `detectPHPVersion` now share one scanner so they can't disagree about where the version lives. `_SSL` sidecars and cpanel's fixed-name files (`main`, `scope`, `cache.json`, …) are excluded — the first because it would double every domain in the tally.

Also adds `php_versions_detected=7.4x39,8.1x82,8.3x29` (or `none`) to the summary, plus a loud skip line when the source recorded no version at all. "The source ran one version" and "we detected nothing and every domain silently inherited the box default" used to render **identically** as `php_version=` — which is exactly how this went unnoticed.

## Verification

Ran the fixed detector against the **real extracted tarball** on the destination box:

```
detected: map[string][]string{"8.1":[]string{"old.arizot-e.com"}}
spread:   8.1x1
```

Previously: empty. Old code path on the same tree — `grep -l phpversion *.php-fpm.yaml` → **0 hits**.

10 unit tests, built from the real tree layout (sidecars, `_SSL`, `main`, `cache.json`, `scope`, `ruby-on-rails-rewrites.db` all present), covering the regression itself, no-double-count, non-domain files ignored, empty-source, sidecar fallback, primary-most-frequent, and the spread renderer.

## Note on AC3

The issue's third criterion — `jabali domain php-version set` should install a missing version or refuse actionably. The restore path already calls `php.version.install` before `php.pool.apply`, so migrations are covered. The standalone CLI command is a separate surface and isn't touched here.