### PR TITLE
fix(migrate): create cPanel subdomains as panel domains (JAB-220)

### DIFF
--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -1569,8 +1569,8 @@ func cpanelRestoreCallback(
 			return bytes, warnings, fmt.Errorf("extras: %w", err)
 		}
 		warnings = append(warnings, fmt.Sprintf(
-			"extras: catchalls=%d subdomains=%d forwarders=%d forwarders_orphan=%d autoresponders=%d autoresponders_orphan=%d filters=%d php_pools=%d php_domains_bound=%d php_version=%s ftp_accounts=%d dkim_keys=%d",
-			extrasRes.CatchallsSet, extrasRes.SubdomainsCreated,
+			"extras: catchalls=%d subdomains=%d/%d forwarders=%d forwarders_orphan=%d autoresponders=%d autoresponders_orphan=%d filters=%d php_pools=%d php_domains_bound=%d php_version=%s ftp_accounts=%d dkim_keys=%d",
+			extrasRes.CatchallsSet, extrasRes.SubdomainsCreated, extrasRes.SubdomainsDetected,
 			extrasRes.ForwardersCreated, extrasRes.ForwardersOrphaned,
 			extrasRes.AutorespondersCreated, extrasRes.AutorespondersOrphaned,
 			extrasRes.FiltersImported,

--- a/panel-api/internal/migrate/cpanel/restore_extras.go
+++ b/panel-api/internal/migrate/cpanel/restore_extras.go
@@ -37,7 +37,8 @@ import (
 // Counters are summed into the parent restore manifest by the caller.
 type ExtrasResult struct {
 	CatchallsSet           int      // domains where catchall_target was written
-	SubdomainsCreated      int      // panel domain rows added from SUB_DOMAINS
+	SubdomainsDetected     int      // JAB-220: subdomains found on the source (created + skipped)
+	SubdomainsCreated      int      // panel domain rows added for those subdomains
 	ForwardersCreated      int      // mail forwarder rows added (M6.5)
 	ForwardersOrphaned     int      // alias lines whose local mailbox isn't in panel
 	AutorespondersCreated  int      // vacation auto-replies restored (M6.5)
@@ -80,10 +81,10 @@ func ImportExtras(
 	userdataPath := findUserdataFile(parsed.ExtractDir, parsed.SourceUser)
 
 	// ---- P5: subdomains ----
-	if userdataPath != "" {
-		raw := extractKV(userdataPath, "SUB_DOMAINS")
-		for _, name := range splitCpanelList(raw) {
-			n := strings.ToLower(strings.TrimSpace(name))
+	{
+		subs := detectSubDomains(parsed, userdataPath)
+		res.SubdomainsDetected = len(subs)
+		for _, n := range subs {
 			if n == "" {
 				continue
 			}
@@ -92,7 +93,18 @@ func ImportExtras(
 				continue
 			}
 			domainID := ids.NewULID()
-			docRoot := filepath.Join("/home", targetUsername, "public_html", n)
+			// jabali convention — and, more to the point, exactly where
+			// ImportHomeSplit rsynced this subdomain's files. The previous
+			// /home/<user>/public_html/<sub> mirrored the cpanel source layout,
+			// so even a subdomain that got created would have pointed its vhost
+			// at an empty directory (JAB-220). parsed.DocRoots wins when the
+			// source resolved a path itself, matching ImportDomains' docRootFor.
+			docRoot := filepath.Join("/home", targetUsername, "domains", n, "public_html")
+			if parsed.DocRoots != nil {
+				if override, ok := parsed.DocRoots[n]; ok && override != "" {
+					docRoot = override
+				}
+			}
 			if _, err := agentCli.Call(ctx, "domain.create", map[string]any{
 				"domain_id":      domainID,
 				"domain":         n,
@@ -643,6 +655,117 @@ func parseAliases(path string) (string, []aliasForward, []string) {
 	return catchAll, forwards, warnings
 }
 
+// userdataRoots returns the candidate locations of the source's userdata dir
+// inside an extracted cpmove tree, in probe order. Shared so every reader looks
+// in the same places.
+func userdataRoots(parsed *ParsedTarball) []string {
+	return []string{
+		filepath.Join(parsed.ExtractDir, "cpmove-"+parsed.SourceUser, "userdata"),
+		filepath.Join(parsed.ExtractDir, "userdata"),
+		filepath.Join(parsed.ExtractDir, "cp", parsed.SourceUser, "userdata"),
+	}
+}
+
+// detectSubDomains returns the account's subdomains, lower-cased and
+// de-duplicated.
+//
+// Read from `<userdata>/main`, which is cpanel's own manifest:
+//
+//	addon_domains: {}
+//	main_domain: bbestgun.co.il
+//	parked_domains: []
+//	sub_domains:
+//	  - staging.bbestgun.co.il
+//
+// An earlier revision read a `SUB_DOMAINS=` key out of the `cp/<user>` file
+// instead. That key does not exist — checked against a live cpanel account,
+// whose user file carries DNS/DNS1/DNS2… and no SUB_DOMAINS at all — so the
+// subdomain pass found nothing on every migration ever run, and the summary's
+// `subdomains=0` was indistinguishable from an account that genuinely had none
+// (JAB-220).
+//
+// Subdomains matter here specifically because ImportDomains cannot see them:
+// it builds its list from zone files, and a cpanel subdomain has no zone of its
+// own — it is a record inside the parent's zone. So the files get restored, the
+// php-ini sanitizer walks them, and nothing ever serves them.
+//
+// The legacy key is still honoured as a fallback in case some cpanel build does
+// emit it.
+func detectSubDomains(parsed *ParsedTarball, userdataPath string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(raw string) {
+		n := strings.ToLower(strings.TrimSpace(raw))
+		n = strings.Trim(n, `"'`)
+		if n == "" || seen[n] {
+			return
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+
+	for _, root := range userdataRoots(parsed) {
+		for _, name := range parseYAMLStringList(filepath.Join(root, "main"), "sub_domains") {
+			add(name)
+		}
+		if len(out) > 0 {
+			break
+		}
+	}
+	// Legacy fallback.
+	if len(out) == 0 && userdataPath != "" {
+		for _, name := range splitCpanelList(extractKV(userdataPath, "SUB_DOMAINS")) {
+			add(name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// parseYAMLStringList pulls a simple `key:` block-sequence out of a cpanel
+// manifest:
+//
+//	sub_domains:
+//	  - one.example.com
+//	  - two.example.com
+//
+// Hand-rolled rather than pulling in a YAML dependency: these manifests are
+// machine-written by cpanel and only ever use this one flat shape. An inline
+// empty list (`sub_domains: []`) yields nothing, which is the correct answer.
+func parseYAMLStringList(path, key string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var out []string
+	inBlock := false
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			// cpanel writes "sub_domains:" and sometimes "sub_domains: " —
+			// anything with a value on the same line is not a block sequence.
+			if strings.HasPrefix(trimmed, key+":") &&
+				strings.TrimSpace(strings.TrimPrefix(trimmed, key+":")) == "" {
+				inBlock = true
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- ") {
+			out = append(out, strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")))
+			continue
+		}
+		if trimmed == "" {
+			continue // blank lines inside the block are harmless
+		}
+		break // a new key ends the sequence
+	}
+	return out
+}
+
 // userdataNonDomainFiles are the fixed-name entries cpanel keeps in the
 // userdata dir alongside the per-domain files.
 var userdataNonDomainFiles = map[string]bool{
@@ -694,11 +817,7 @@ func isPlainDomainUserdata(name string) bool {
 // one stat per domain and covers any cpanel build that does write the key
 // there — but the plain file is now the primary source.
 func scanUserdataPHPVersions(parsed *ParsedTarball) map[string][]string {
-	roots := []string{
-		filepath.Join(parsed.ExtractDir, "cpmove-"+parsed.SourceUser, "userdata"),
-		filepath.Join(parsed.ExtractDir, "userdata"),
-		filepath.Join(parsed.ExtractDir, "cp", parsed.SourceUser, "userdata"),
-	}
+	roots := userdataRoots(parsed)
 	out := map[string][]string{}
 	for _, root := range roots {
 		entries, err := os.ReadDir(root)

--- a/panel-api/internal/migrate/cpanel/restore_extras_subdomains_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_extras_subdomains_test.go
@@ -1,0 +1,144 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// realMainManifest is a verbatim cpanel <userdata>/main from a live account
+// that has a subdomain. This is where sub_domains actually lives; the
+// cp/<user> file the old code read has no SUB_DOMAINS key at all (JAB-220).
+const realMainManifest = `---
+addon_domains: {}
+
+main_domain: bbestgun.co.il
+parked_domains: []
+
+sub_domains:
+  - staging.bbestgun.co.il
+`
+
+// realMainNoSubs is the same manifest for an account with none — an inline
+// empty list, which must yield nothing rather than a bogus entry.
+const realMainNoSubs = `---
+addon_domains: {}
+main_domain: old.arizot-e.com
+parked_domains: []
+sub_domains: []
+`
+
+func writeMain(t *testing.T, body string) *ParsedTarball {
+	t.Helper()
+	extract := t.TempDir()
+	root := filepath.Join(extract, "cpmove-someuser", "userdata")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write main: %v", err)
+	}
+	return &ParsedTarball{ExtractDir: extract, SourceUser: "someuser"}
+}
+
+// The regression: the real manifest must yield the subdomain.
+func TestDetectSubDomains_ReadsRealMainManifest(t *testing.T) {
+	got := detectSubDomains(writeMain(t, realMainManifest), "")
+	if !reflect.DeepEqual(got, []string{"staging.bbestgun.co.il"}) {
+		t.Fatalf("got %#v, want [staging.bbestgun.co.il]", got)
+	}
+}
+
+// `sub_domains: []` is a real answer, not a parse failure.
+func TestDetectSubDomains_InlineEmptyListYieldsNothing(t *testing.T) {
+	if got := detectSubDomains(writeMain(t, realMainNoSubs), ""); len(got) != 0 {
+		t.Fatalf("want none, got %#v", got)
+	}
+}
+
+func TestDetectSubDomains_MultipleAndSortedAndDeduped(t *testing.T) {
+	body := `---
+main_domain: example.com
+sub_domains:
+  - shop.example.com
+  - dev.example.com
+  - shop.example.com
+  - APP.example.com
+parked_domains: []
+`
+	got := detectSubDomains(writeMain(t, body), "")
+	want := []string{"app.example.com", "dev.example.com", "shop.example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v want %#v", got, want)
+	}
+}
+
+// The block must stop at the next key, not swallow the rest of the file.
+func TestDetectSubDomains_StopsAtNextKey(t *testing.T) {
+	body := `---
+sub_domains:
+  - one.example.com
+parked_domains:
+  - parked.example.com
+addon_domains: {}
+`
+	got := detectSubDomains(writeMain(t, body), "")
+	if !reflect.DeepEqual(got, []string{"one.example.com"}) {
+		t.Fatalf("leaked past the block: %#v", got)
+	}
+}
+
+// Legacy fallback: honour a SUB_DOMAINS= key if some build emits one.
+func TestDetectSubDomains_LegacyKeyFallback(t *testing.T) {
+	parsed := writeMain(t, realMainNoSubs)
+	legacy := filepath.Join(t.TempDir(), "cpuser")
+	if err := os.WriteFile(legacy, []byte("USER=x\nSUB_DOMAINS=a.example.com,b.example.com\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := detectSubDomains(parsed, legacy)
+	if !reflect.DeepEqual(got, []string{"a.example.com", "b.example.com"}) {
+		t.Fatalf("legacy fallback failed: %#v", got)
+	}
+}
+
+// The manifest wins over the legacy key when both are present, so a stale
+// SUB_DOMAINS cannot override cpanel's own list.
+func TestDetectSubDomains_ManifestBeatsLegacyKey(t *testing.T) {
+	parsed := writeMain(t, realMainManifest)
+	legacy := filepath.Join(t.TempDir(), "cpuser")
+	if err := os.WriteFile(legacy, []byte("SUB_DOMAINS=stale.example.com\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := detectSubDomains(parsed, legacy)
+	if !reflect.DeepEqual(got, []string{"staging.bbestgun.co.il"}) {
+		t.Fatalf("legacy key overrode the manifest: %#v", got)
+	}
+}
+
+// A missing manifest and no legacy file must be empty, not a panic.
+func TestDetectSubDomains_NoSourcesIsEmpty(t *testing.T) {
+	parsed := &ParsedTarball{ExtractDir: t.TempDir(), SourceUser: "nobody"}
+	if got := detectSubDomains(parsed, ""); len(got) != 0 {
+		t.Fatalf("want none, got %#v", got)
+	}
+}
+
+func TestParseYAMLStringList_IgnoresOtherKeys(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "main")
+	body := `---
+other_list:
+  - not.me
+sub_domains:
+  - yes.me
+`
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := parseYAMLStringList(p, "sub_domains"); !reflect.DeepEqual(got, []string{"yes.me"}) {
+		t.Fatalf("got %#v", got)
+	}
+}


### PR DESCRIPTION
## Two bugs, both required for a subdomain to serve

A cPanel account's subdomains restored their **files** correctly — the php-ini sanitizer even walked them — but got no `domains` row and no nginx vhost, so requests fell through to the default vhost. The summary said `subdomains=0`, indistinguishable from an account that had none.

### 1. Detection read a key that doesn't exist

The pass pulled `SUB_DOMAINS=` out of `cp/<user>`. Checked against a live cPanel account — that file carries `DNS`/`DNS1`/`DNS2`… and **no `SUB_DOMAINS` at all**:

```
$ grep -oP '^[A-Z_0-9]+(?==)' /var/cpanel/users/bbestgunco | tr '\n' ' '
BACKUP BWLIMIT ... DNS DNS1 FEATURELIST ...      # no SUB_DOMAINS
$ grep -E '^(DNS|XDNS)' /var/cpanel/users/bbestgunco
DNS=bbestgun.co.il
DNS1=staging.bbestgun.co.il
```

So the pass found nothing on **every migration ever run**. cPanel's own manifest is `<userdata>/main`:

```yaml
addon_domains: {}
main_domain: bbestgun.co.il
parked_domains: []
sub_domains:
  - staging.bbestgun.co.il
```

`detectSubDomains` reads that, keeping the legacy key as a fallback.

### 2. The docroot was wrong

It used `/home/<user>/public_html/<sub>` — the cPanel **source** layout — while `ImportHomeSplit` rsyncs into `/home/<user>/domains/<sub>/public_html`. Confirmed on the destination box:

```
/home/bbestgunco/domains/bbestgun.co.il/public_html
/home/bbestgunco/domains/staging.bbestgun.co.il/public_html
```

A subdomain that *did* get created would have pointed its vhost at an empty directory. Now uses the jabali convention with the same `parsed.DocRoots` override `ImportDomains` honours.

## Why subdomains need their own pass

`ImportDomains` can't see them: it builds its list from **zone files**, and a cPanel subdomain has no zone of its own — it's a record inside the parent's zone. That's why the account reported `domains: created=1` with the subdomain nowhere.

## Summary line

Now `subdomains=<created>/<detected>`. "Found none" and "found some, created none" are finally distinguishable — the whole reason this stayed invisible.

`parseYAMLStringList` is hand-rolled rather than adding a YAML dependency: these manifests are machine-written by cPanel in one flat shape, and an inline `sub_domains: []` correctly yields nothing.

## Verification

Ran the detector against **real cPanel manifests** pulled from the live source box:

```
bbestgunco   -> []string{"staging.bbestgun.co.il"}   # the exact domain an operator hand-created
arizotse22a  -> []string(nil)                        # manifest says sub_domains: []
```

Fleet-wide: **3 of 150 accounts** carry subdomains. Low incidence, total loss per hit.

8 unit tests: real manifest, inline empty list, multiple/sorted/deduped/case-folded, block stops at the next key, legacy fallback, manifest-beats-legacy, no-sources, and key isolation.