### PR TITLE
feat(nginx): server-wide default for the branded application-error page (GH #879)

### DIFF
--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -140,6 +140,9 @@ type updateServerSettingsRequest struct {
 	// GH #860: opt-in branded page on the default catch-all for unknown
 	// hosts (default off = keep the 444 drop).
 	UnconfiguredPageEnabled *bool `json:"unconfigured_page_enabled,omitempty"`
+	// GH #879: server-wide default for the branded application-error page;
+	// domains override via nginx_safe_options.intercept_errors.
+	InterceptAppErrorsDefault *bool `json:"intercept_app_errors_default,omitempty"`
 	// GH #648: opt-in DKIM2 signing alongside classic DKIM (default off).
 	DKIM2SigningEnabled *bool `json:"dkim2_signing_enabled,omitempty"`
 	// TenantNotificationKinds — admin-configurable tenant channel-kind allowlist
@@ -511,6 +514,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.UnconfiguredPageEnabled != nil {
 		current.UnconfiguredPageEnabled = *req.UnconfiguredPageEnabled
+	}
+	if req.InterceptAppErrorsDefault != nil {
+		current.InterceptAppErrorsDefault = *req.InterceptAppErrorsDefault
 	}
 	if req.DKIM2SigningEnabled != nil {
 		current.DKIM2SigningEnabled = *req.DKIM2SigningEnabled

--- a/panel-api/internal/db/migrations/000250_intercept_errors_default.down.sql
+++ b/panel-api/internal/db/migrations/000250_intercept_errors_default.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN intercept_app_errors_default;

--- a/panel-api/internal/db/migrations/000250_intercept_errors_default.up.sql
+++ b/panel-api/internal/db/migrations/000250_intercept_errors_default.up.sql
@@ -1,0 +1,5 @@
+-- GH #879 follow-up: server-wide default for the branded application-error
+-- page. Per-domain nginx_safe_options.intercept_errors becomes a tri-state
+-- override (absent = inherit this default).
+ALTER TABLE server_settings
+  ADD COLUMN intercept_app_errors_default tinyint(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/nginx_safe_options.go
+++ b/panel-api/internal/models/nginx_safe_options.go
@@ -30,13 +30,15 @@ type NginxSafeOptions struct {
 	Gzip bool `json:"gzip,omitempty"`
 	// InterceptErrors (GH #879) shows the branded 500 page when the PHP app
 	// returns a 5xx. A PHP fatal is a 500 with an EMPTY body, so without this
-	// visitors get the browser's raw error screen. Off by default: apps like
-	// WordPress render their own error pages (recovery-mode notice) and API
-	// endpoints return JSON error bodies — interception replaces those.
+	// visitors get the browser's raw error screen. Tri-state override of
+	// server_settings.intercept_app_errors_default: nil = inherit, true/false
+	// = force per-domain. The default matters because apps like WordPress
+	// render their own error pages (recovery-mode notice) and API endpoints
+	// return JSON error bodies — interception replaces those.
 	// NOT rendered by Render(): it must sit INSIDE the vhost's PHP locations
 	// (location-scoped, 50x-only error_page so app 404/403 pages survive),
 	// so the reconciler plumbs it as its own domain.create param instead.
-	InterceptErrors bool `json:"intercept_errors,omitempty"`
+	InterceptErrors *bool `json:"intercept_errors,omitempty"`
 }
 
 // maxBodyCapMB bounds client_max_body_size so a tenant can't set an absurd

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -138,6 +138,14 @@ type ServerSettings struct {
 	// deliberate trade of that stealth for a branded operator page.
 	UnconfiguredPageEnabled bool `gorm:"column:unconfigured_page_enabled;type:tinyint(1);not null;default:0" json:"unconfigured_page_enabled"`
 
+	// InterceptAppErrorsDefault (GH #879) — server-wide default for the
+	// branded application-error page: nginx serves the themed 500 when a
+	// PHP app returns a 5xx (a fatal is a 500 with an empty body). Domains
+	// can override either way via nginx_safe_options.intercept_errors
+	// (nil = inherit this). Default off: apps that render their own error
+	// screens (WordPress recovery notice, JSON APIs) keep them.
+	InterceptAppErrorsDefault bool `gorm:"column:intercept_app_errors_default;type:tinyint(1);not null;default:0" json:"intercept_app_errors_default"`
+
 	// TenantDocrootEditable lets a non-admin owner repoint their own domain's
 	// document root within the domain's own tree (GH #526). Default ON — the
 	// edit is confined to /home/<user>/domains/<domain>/, many apps (Laravel et

--- a/panel-api/internal/reconciler/intercept_errors_test.go
+++ b/panel-api/internal/reconciler/intercept_errors_test.go
@@ -1,0 +1,41 @@
+package reconciler
+
+// GH #879: server-wide branded-app-error default with per-domain tri-state
+// override — the resolution matrix must hold or a domain silently loses (or
+// gains) interception on the next reconcile.
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestEffectiveInterceptErrors(t *testing.T) {
+	on, off := true, false
+	cases := []struct {
+		name       string
+		serverOn   bool
+		override   *bool
+		noSettings bool
+		want       bool
+	}{
+		{"inherit server off", false, nil, false, false},
+		{"inherit server on", true, nil, false, true},
+		{"override on beats server off", false, &on, false, true},
+		{"override off beats server on", true, &off, false, false},
+		{"no settings repo defaults off", false, nil, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Reconciler{}
+			if !tc.noSettings {
+				r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{InterceptAppErrorsDefault: tc.serverOn}}
+			}
+			d := &models.Domain{NginxSafeOptions: models.NginxSafeOptions{InterceptErrors: tc.override}}
+			if got := r.effectiveInterceptErrors(context.Background(), d); got != tc.want {
+				t.Errorf("effectiveInterceptErrors = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1502,6 +1502,22 @@ func (r *Reconciler) ensureDomainPHPBinding(ctx context.Context, domain *models.
 		"domain_id", domain.ID, "domain", domain.Name, "pool_id", pool.ID)
 }
 
+// effectiveInterceptErrors resolves the branded-application-error toggle for
+// a domain (GH #879): the per-domain nginx_safe_options.intercept_errors
+// override wins when set; otherwise the server-wide
+// intercept_app_errors_default applies (false when settings are unavailable).
+func (r *Reconciler) effectiveInterceptErrors(ctx context.Context, domain *models.Domain) bool {
+	if o := domain.NginxSafeOptions.InterceptErrors; o != nil {
+		return *o
+	}
+	if r.serverSettings != nil {
+		if s, err := r.serverSettings.Get(ctx); err == nil && s != nil {
+			return s.InterceptAppErrorsDefault
+		}
+	}
+	return false
+}
+
 func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Domain) {
 	user, err := r.users.FindByID(ctx, domain.UserID)
 	if err != nil {
@@ -1685,7 +1701,8 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 
 	// GH #879: branded 500 for app errors — location-scoped in the vhost's
 	// PHP blocks, so it travels as its own param rather than via Render().
-	params["intercept_errors"] = domain.NginxSafeOptions.InterceptErrors
+	// Server-wide default with a per-domain tri-state override.
+	params["intercept_errors"] = r.effectiveInterceptErrors(ctx, domain)
 
 	params["redirect_directives"] = redirects.Compile(domain)
 	params["rule_directives"] = nginxrules.Compile(domain)

--- a/panel-ui/src/components/DomainNginxOptionsModal.tsx
+++ b/panel-ui/src/components/DomainNginxOptionsModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Checkbox, Form, InputNumber, Modal, Typography, message } from "antd";
+import { Checkbox, Form, InputNumber, Modal, Select, Typography, message } from "antd";
 
 import { apiClient } from "../apiClient";
 
@@ -9,8 +9,17 @@ interface SafeOptions {
   hsts?: boolean;
   security_headers?: boolean;
   gzip?: boolean;
-  intercept_errors?: boolean;
+  // GH #879 tri-state: absent/null = inherit the server-wide default
+  // (Server Settings → Page Templates), true/false = force per-domain.
+  intercept_errors?: boolean | null;
 }
+
+// The form's Select uses string values; map to the wire tri-state.
+type InterceptChoice = "inherit" | "on" | "off";
+const interceptToChoice = (v: boolean | null | undefined): InterceptChoice =>
+  v === true ? "on" : v === false ? "off" : "inherit";
+const choiceToIntercept = (c: InterceptChoice | undefined): boolean | null =>
+  c === "on" ? true : c === "off" ? false : null;
 
 export interface DomainNginxOptionsModalProps {
   domainId: string;
@@ -22,7 +31,7 @@ export interface DomainNginxOptionsModalProps {
 // panel renders these to fixed, vetted directives; no raw config.
 export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOptionsModalProps) => {
   const { t } = useTranslation();
-  const [form] = Form.useForm<SafeOptions>();
+  const [form] = Form.useForm<SafeOptions & { intercept_choice?: InterceptChoice }>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -31,7 +40,13 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
     (async () => {
       try {
         const resp = await apiClient.get<{ nginx_safe_options?: SafeOptions }>(`/domains/${domainId}`);
-        if (!cancelled) form.setFieldsValue(resp.data.nginx_safe_options ?? {});
+        if (!cancelled) {
+          const opts = resp.data.nginx_safe_options ?? {};
+          form.setFieldsValue({
+            ...opts,
+            intercept_choice: interceptToChoice(opts.intercept_errors),
+          });
+        }
       } catch {
         if (!cancelled) message.error("Failed to load domain options");
       } finally {
@@ -53,7 +68,7 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
           hsts: !!values.hsts,
           security_headers: !!values.security_headers,
           gzip: !!values.gzip,
-          intercept_errors: !!values.intercept_errors,
+          intercept_errors: choiceToIntercept(values.intercept_choice),
         },
       });
       message.success("Domain options saved — applied on the next reconcile");
@@ -89,11 +104,18 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
           <Checkbox>Enable gzip compression for text content</Checkbox>
         </Form.Item>
         <Form.Item
-          name="intercept_errors"
-          valuePropName="checked"
-          tooltip="A crashed PHP script normally returns an empty 500, so visitors see the browser's raw error screen. This serves the branded 500 page instead (editable under Server Settings → Page Templates). The site keeps its own 404/403 pages. Note: apps that render their own error screens (e.g. WordPress's recovery notice) or return JSON errors will show the branded page instead."
+          name="intercept_choice"
+          label="Branded error page when the application fails (500-class errors)"
+          tooltip="A crashed PHP script normally returns an empty 500, so visitors see the browser's raw error screen. When on, nginx serves the branded 500 page instead (editable under Server Settings → Page Templates); the site keeps its own 404/403 pages. Apps that render their own error screens (e.g. WordPress's recovery notice) or return JSON errors will show the branded page instead — turn it off for those. 'Server default' follows the switch under Server Settings → Page Templates."
+          initialValue="inherit"
         >
-          <Checkbox>Show branded error page when the application fails (500-class errors)</Checkbox>
+          <Select
+            options={[
+              { value: "inherit", label: "Server default" },
+              { value: "on", label: "On" },
+              { value: "off", label: "Off" },
+            ]}
+          />
         </Form.Item>
       </Form>
     </Modal>

--- a/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
@@ -40,6 +40,10 @@ const MAX_BYTES = 128 * 1024;
 // the shipped default drops unknown hosts without a response (444).
 const UNCONFIGURED_KEY = "domain_unconfigured";
 
+// GH #879: server-wide default for serving the branded 500 when the app
+// itself fails (PHP fatal = empty-body 500). Domains can override either way.
+const ERROR500_KEY = "error_500";
+
 export const PageTemplatesCard = () => {
   const { t } = useTranslation();
   const qc = useQueryClient();
@@ -57,11 +61,15 @@ export const PageTemplatesCard = () => {
     },
   });
 
-  const settings = useQuery<{ unconfigured_page_enabled: boolean }>({
+  const settings = useQuery<{
+    unconfigured_page_enabled: boolean;
+    intercept_app_errors_default: boolean;
+  }>({
     queryKey: SETTINGS_KEY,
     queryFn: async () => {
       const { data } = await apiClient.get<{
         unconfigured_page_enabled: boolean;
+        intercept_app_errors_default: boolean;
       }>("/admin/settings");
       return data;
     },
@@ -84,6 +92,27 @@ export const PageTemplatesCard = () => {
       message.error(err instanceof Error ? err.message : "Toggle failed");
     } finally {
       setTogglingUnconfigured(false);
+    }
+  };
+
+  const [togglingIntercept, setTogglingIntercept] = useState(false);
+
+  const toggleIntercept = async (checked: boolean) => {
+    setTogglingIntercept(true);
+    try {
+      await apiClient.patch("/admin/settings", {
+        intercept_app_errors_default: checked,
+      });
+      qc.invalidateQueries({ queryKey: SETTINGS_KEY });
+      message.success(
+        checked
+          ? "Branded page enabled for application errors on all domains (applies within a few minutes; domains can override under Domain → Options)"
+          : "Application errors pass through again — apps serve their own 500s",
+      );
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : "Toggle failed");
+    } finally {
+      setTogglingIntercept(false);
     }
   };
 
@@ -163,6 +192,29 @@ export const PageTemplatesCard = () => {
                               togglingUnconfigured || settings.isLoading
                             }
                             onChange={toggleUnconfigured}
+                          />
+                        </Space>
+                      </Tooltip>,
+                    ]
+                  : []),
+                ...(row.key === ERROR500_KEY
+                  ? [
+                      <Tooltip
+                        key="intercept"
+                        title="Off (default): a crashed app serves its own error response — a PHP fatal is an empty 500, so visitors see the browser's raw error screen; apps like WordPress show their recovery notice. On: nginx serves this branded page for application 500/502/503/504 on every domain (each domain can override under Domain → Options). Native nginx errors always show this page regardless."
+                      >
+                        <Space size={6}>
+                          <Typography.Text type="secondary">
+                            App errors
+                          </Typography.Text>
+                          <Switch
+                            size="small"
+                            checked={
+                              settings.data?.intercept_app_errors_default ??
+                              false
+                            }
+                            loading={togglingIntercept || settings.isLoading}
+                            onChange={toggleIntercept}
                           />
                         </Space>
                       </Tooltip>,


### PR DESCRIPTION
Follow-up to #898/#899 from operator feedback: branding is server-level policy — the branded-500-for-app-errors switch belongs next to the page templates, not buried per domain.

## What
- `server_settings.intercept_app_errors_default` (migration 000250) — an "App errors" switch on the `error_500` row of **Server Settings → Page Templates** (mirrors the GH #860 unconfigured-page toggle pattern).
- `nginx_safe_options.intercept_errors` becomes a **tri-state** (`*bool`): absent = inherit the server default; true/false = per-domain force. Rationale for keeping the override: domains serving JSON APIs or apps with their own error screens want it off even when the server default is on.
- Reconciler resolves override → default per domain (`effectiveInterceptErrors`); the periodic full pass converges all vhosts after the server switch flips.
- **Domain → Options**: checkbox replaced with a Server default / On / Off select.

## Test plan
- [x] `TestEffectiveInterceptErrors` — 5-case resolution matrix (inherit on/off, override beats default both ways, nil settings repo)
- [x] full panel-api suite; panel-ui build
- [ ] live E2E on testserver: server switch on → branded 500 on a domain with no override; per-domain Off beats server On

🤖 Generated with [Claude Code](https://claude.com/claude-code)