### PR TITLE
feat(ssl): report domains whose origin would 526 behind Cloudflare (JAB-224)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4765,6 +4765,19 @@ jabali ssl list [flags]
 
 - `--user` — filter by user (id|email|username)
 
+#### `jabali ssl readiness`
+
+Report domains whose origin certificate would fail Cloudflare Full (strict)
+
+```
+jabali ssl readiness [flags]
+```
+
+**Flags:**
+
+- `--all` — list every domain, not only the ones that would fail
+- `--nginx-dir` — directory holding the enabled nginx vhosts (default `/etc/nginx/sites-enabled`)
+
 #### `jabali ssl renew`
 
 Renew SSL cert via certbot (synchronous, calls agent)

--- a/panel-api/cmd/server/ssl_cmd.go
+++ b/panel-api/cmd/server/ssl_cmd.go
@@ -32,6 +32,7 @@ func newSSLCmd() *cobra.Command {
 		newSSLRenewCmd(),
 		newSSLSetCustomCmd(),
 		newSSLSharedCmd(),
+		newSSLReadinessCmd(),
 	)
 	return cmd
 }

--- a/panel-api/cmd/server/ssl_readiness_cmd.go
+++ b/panel-api/cmd/server/ssl_readiness_cmd.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sslorigin"
+)
+
+// ssl_readiness_cmd.go — JAB-224.
+//
+// Before pointing a migrated domain's DNS at this box, the operator needs one
+// answer: will Cloudflare accept what nginx is about to serve? A domain still
+// on jabali's self-signed placeholder answers every proxied request with
+// "Error 526 Invalid SSL certificate" the instant it cuts over, and there is no
+// way to notice beforehand — the origin serves the site perfectly to anyone who
+// asks it directly.
+//
+// Reads the vhost rather than the ssl_certificates table on purpose: a domain
+// that never had a certificate issued has no row, and those are precisely the
+// domains that will 526.
+
+const defaultNginxSitesDir = "/etc/nginx/sites-enabled"
+
+func newSSLReadinessCmd() *cobra.Command {
+	var nginxDir string
+	var allDomains bool
+
+	cmd := &cobra.Command{
+		Use:   "readiness",
+		Short: "Report domains whose origin certificate would fail Cloudflare Full (strict)",
+		Long: "Inspects each domain's nginx vhost and reports the certificate it actually serves.\n" +
+			"Domains still on the jabali self-signed placeholder will return HTTP 526 through\n" +
+			"Cloudflare Full (strict) the moment they cut over. Run this BEFORE moving DNS.\n\n" +
+			"Exits non-zero when any domain is not ready, so it can gate a cutover script.",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
+			defer cancel()
+
+			domainsRepo := repository.NewDomainRepository(sharedDB)
+			doms, _, err := domainsRepo.List(ctx, repository.ListOptions{Limit: 10000, Sort: "name", Order: "asc"})
+			if err != nil {
+				return fmt.Errorf("list domains: %w", err)
+			}
+
+			var origins []sslorigin.Origin
+			for _, d := range doms {
+				origins = append(origins, sslorigin.Classify(d.Name, nginxDir))
+			}
+			sort.Slice(origins, func(i, j int) bool { return origins[i].Domain < origins[j].Domain })
+
+			var notReady []sslorigin.Origin
+			for _, o := range origins {
+				if !o.Kind.SafeForStrictTLS() {
+					notReady = append(notReady, o)
+				}
+			}
+
+			if jsonOutput {
+				if err := printJSON(map[string]any{
+					"domains":   origins,
+					"total":     len(origins),
+					"not_ready": len(notReady),
+				}); err != nil {
+					return err
+				}
+				if len(notReady) > 0 {
+					return fmt.Errorf("%d domain(s) not ready for Cloudflare Full (strict)", len(notReady))
+				}
+				return nil
+			}
+
+			shown := notReady
+			if allDomains {
+				shown = origins
+			}
+			if len(shown) == 0 {
+				fmt.Printf("All %d domain(s) ready for Cloudflare Full (strict).\n", len(origins))
+				return nil
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "DOMAIN\tORIGIN\tDETAIL")
+			for _, o := range shown {
+				detail := o.Detail
+				if detail == "" {
+					detail = o.CertPath
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\n", o.Domain, o.Kind, detail)
+			}
+			if err := w.Flush(); err != nil {
+				return err
+			}
+
+			if len(notReady) > 0 {
+				fmt.Printf("\n%d of %d domain(s) would fail Cloudflare Full (strict).\n", len(notReady), len(origins))
+				fmt.Println("Issue a real certificate before cutting DNS over:")
+				for _, o := range notReady {
+					if o.Kind == sslorigin.KindSelfSigned {
+						fmt.Printf("  jabali ssl enable %s\n", o.Domain)
+					}
+				}
+				return fmt.Errorf("%d domain(s) not ready for Cloudflare Full (strict)", len(notReady))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&nginxDir, "nginx-dir", defaultNginxSitesDir, "directory holding the enabled nginx vhosts")
+	cmd.Flags().BoolVar(&allDomains, "all", false, "list every domain, not only the ones that would fail")
+	return cmd
+}

--- a/panel-api/internal/sslorigin/classify.go
+++ b/panel-api/internal/sslorigin/classify.go
@@ -1,0 +1,162 @@
+// Package sslorigin answers one question: what certificate is nginx actually
+// serving for a domain, and will Cloudflare accept it?
+//
+// JAB-224. A migrated domain lands on the destination behind jabali's
+// self-signed placeholder, because Let's Encrypt HTTP-01 cannot succeed until
+// the domain already resolves to this box — and nothing issues a certificate at
+// the moment of cutover. A domain proxied through Cloudflare in Full (strict)
+// therefore goes live pointing at a self-signed origin and Cloudflare answers
+// every request with "Error 526 Invalid SSL certificate". The origin is healthy;
+// the site is simply dark.
+//
+// This is invisible before cutover: the origin serves the site fine over its
+// self-signed certificate, so any check that talks straight to the box passes.
+// It only fails once real traffic arrives through Cloudflare, which is the worst
+// possible moment to discover it. Measured on a live destination box: 70
+// self-signed lineages against 21 real ones.
+//
+// So classification reads the VHOST — the file nginx actually loads — rather
+// than the panel's ssl_certificates table. A domain that has never had a
+// certificate issued has no row at all, and those are exactly the domains that
+// will 526.
+package sslorigin
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Kind is what sort of certificate a vhost points at.
+type Kind string
+
+const (
+	KindLetsEncrypt Kind = "letsencrypt" // /etc/letsencrypt/live/<d>/ — Cloudflare-strict safe
+	KindSelfSigned  Kind = "self-signed" // jabali placeholder — 526 behind Cloudflare strict
+	KindCustom      Kind = "custom"      // operator-supplied path; trusted unless the cert says otherwise
+	KindNone        Kind = "none"        // no ssl_certificate directive — plain HTTP only
+	KindUnknown     Kind = "unknown"     // vhost missing or unreadable; refuse to guess
+)
+
+// SafeForStrictTLS reports whether an origin of this kind will satisfy a
+// Cloudflare Full (strict) connection.
+//
+// KindUnknown is deliberately NOT safe: a readiness check that reports "fine"
+// because it could not look is worse than one that says nothing.
+func (k Kind) SafeForStrictTLS() bool {
+	return k == KindLetsEncrypt || k == KindCustom
+}
+
+// jabaliSelfSignedDir is where the panel parks its placeholder lineages.
+const jabaliSelfSignedDir = "/etc/ssl/jabali-selfsigned/"
+
+// letsEncryptLiveDir is certbot's lineage directory.
+const letsEncryptLiveDir = "/etc/letsencrypt/live/"
+
+// sslCertificateRe matches nginx's `ssl_certificate <path>;`, and must NOT match
+// `ssl_certificate_key`, `ssl_certificate_by_lua_block`, or a commented line.
+// The negative lookahead Go's regexp lacks is expressed as "next char is space".
+var sslCertificateRe = regexp.MustCompile(`(?m)^[^#\n]*\bssl_certificate[ \t]+([^;\s]+)[ \t]*;`)
+
+// Origin is the verdict for one domain.
+type Origin struct {
+	Domain   string
+	CertPath string
+	Kind     Kind
+	Detail   string // why, when the answer is not obvious from Kind alone
+}
+
+// certPathFromVhost extracts the ssl_certificate path from an nginx config body.
+// Returns "" when the vhost serves no TLS.
+func certPathFromVhost(body string) string {
+	for _, m := range sslCertificateRe.FindAllStringSubmatch(body, -1) {
+		if len(m) > 1 && m[1] != "" {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// kindForPath classifies purely by where the certificate lives. jabali owns both
+// directory layouts, so the path is authoritative for its own certificates.
+func kindForPath(path string) Kind {
+	switch {
+	case path == "":
+		return KindNone
+	case strings.HasPrefix(path, jabaliSelfSignedDir):
+		return KindSelfSigned
+	case strings.HasPrefix(path, letsEncryptLiveDir):
+		return KindLetsEncrypt
+	default:
+		return KindCustom
+	}
+}
+
+// isSelfSignedCert reports whether the leaf certificate is self-issued.
+//
+// Only consulted for KindCustom: an operator-supplied certificate can itself be
+// self-signed, and that 526s exactly the same as jabali's placeholder. Reading
+// the first PEM block is deliberate — fullchain.pem is leaf-first, and the
+// issuer above it is a real CA whose subject would never match.
+func isSelfSignedCert(path string) (bool, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false, false
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return false, false
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, false
+	}
+	return c.Issuer.String() == c.Subject.String(), true
+}
+
+// ClassifyBody is the pure half: given a vhost body, decide the origin kind.
+// checkCert is injected so tests need no filesystem.
+func ClassifyBody(domain, body string, checkCert func(string) (bool, bool)) Origin {
+	path := certPathFromVhost(body)
+	kind := kindForPath(path)
+	o := Origin{Domain: domain, CertPath: path, Kind: kind}
+
+	switch kind {
+	case KindNone:
+		o.Detail = "vhost serves no TLS"
+	case KindSelfSigned:
+		o.Detail = "jabali placeholder — Cloudflare Full (strict) will return 526"
+	case KindCustom:
+		// A custom path may still hold a self-signed certificate.
+		if selfSigned, ok := checkCert(path); ok && selfSigned {
+			o.Kind = KindSelfSigned
+			o.Detail = "custom certificate is self-issued — Cloudflare Full (strict) will return 526"
+		} else if !ok {
+			o.Detail = "custom certificate could not be read; assuming it is valid"
+		}
+	}
+	return o
+}
+
+// Classify reads the vhost for a domain from nginxDir and classifies it.
+//
+// Both <domain>.conf and <domain> are probed because the enabled-site filename
+// convention has varied; a domain whose vhost cannot be found is reported as
+// KindUnknown rather than assumed fine.
+func Classify(domain, nginxDir string) Origin {
+	for _, name := range []string{domain + ".conf", domain} {
+		body, err := os.ReadFile(filepath.Join(nginxDir, name))
+		if err != nil {
+			continue
+		}
+		return ClassifyBody(domain, string(body), isSelfSignedCert)
+	}
+	return Origin{
+		Domain: domain,
+		Kind:   KindUnknown,
+		Detail: "no vhost found in " + nginxDir,
+	}
+}

--- a/panel-api/internal/sslorigin/classify_test.go
+++ b/panel-api/internal/sslorigin/classify_test.go
@@ -1,0 +1,145 @@
+package sslorigin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// realSelfSignedVhost is copied from a live destination box — the shape that
+// produces the 526 (JAB-224).
+const realSelfSignedVhost = `server {
+    listen 443 ssl;
+    server_name 4lion.com www.4lion.com;
+    ssl_certificate /etc/ssl/jabali-selfsigned/4lion.com/fullchain.pem;
+    ssl_certificate_key /etc/ssl/jabali-selfsigned/4lion.com/privkey.pem;
+    root /home/x/domains/4lion.com/public_html;
+}`
+
+const realLEVhost = `server {
+    listen 443 ssl;
+    server_name good.com;
+    ssl_certificate /etc/letsencrypt/live/good.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/good.com/privkey.pem;
+}`
+
+// neverSelfSigned stands in for "the cert file said it is CA-issued".
+func neverSelfSigned(string) (bool, bool) { return false, true }
+
+// unreadable stands in for "could not open the cert".
+func unreadable(string) (bool, bool) { return false, false }
+
+func TestClassifyBody_SelfSignedIsUnsafe(t *testing.T) {
+	o := ClassifyBody("4lion.com", realSelfSignedVhost, neverSelfSigned)
+
+	if o.Kind != KindSelfSigned {
+		t.Fatalf("kind = %q, want %q", o.Kind, KindSelfSigned)
+	}
+	if o.CertPath != "/etc/ssl/jabali-selfsigned/4lion.com/fullchain.pem" {
+		t.Errorf("cert path = %q", o.CertPath)
+	}
+	if o.Kind.SafeForStrictTLS() {
+		t.Error("self-signed must not be reported as strict-TLS safe")
+	}
+}
+
+func TestClassifyBody_LetsEncryptIsSafe(t *testing.T) {
+	o := ClassifyBody("good.com", realLEVhost, neverSelfSigned)
+	if o.Kind != KindLetsEncrypt || !o.Kind.SafeForStrictTLS() {
+		t.Fatalf("kind = %q safe = %v", o.Kind, o.Kind.SafeForStrictTLS())
+	}
+}
+
+// ssl_certificate_key must never be mistaken for ssl_certificate — matching the
+// key path would classify by the wrong directory and, worse, read a PRIVATE KEY.
+func TestClassifyBody_DoesNotMatchCertificateKey(t *testing.T) {
+	body := `server {
+    ssl_certificate_key /etc/letsencrypt/live/x.com/privkey.pem;
+    ssl_certificate /etc/ssl/jabali-selfsigned/x.com/fullchain.pem;
+}`
+	o := ClassifyBody("x.com", body, neverSelfSigned)
+	if o.CertPath != "/etc/ssl/jabali-selfsigned/x.com/fullchain.pem" {
+		t.Fatalf("matched the wrong directive: %q", o.CertPath)
+	}
+}
+
+// A commented-out directive is not configuration.
+func TestClassifyBody_IgnoresCommentedDirective(t *testing.T) {
+	body := `server {
+    # ssl_certificate /etc/letsencrypt/live/x.com/fullchain.pem;
+    ssl_certificate /etc/ssl/jabali-selfsigned/x.com/fullchain.pem;
+}`
+	o := ClassifyBody("x.com", body, neverSelfSigned)
+	if o.Kind != KindSelfSigned {
+		t.Fatalf("commented line won: kind=%q path=%q", o.Kind, o.CertPath)
+	}
+}
+
+func TestClassifyBody_NoTLSIsNone(t *testing.T) {
+	o := ClassifyBody("plain.com", "server { listen 80; }", neverSelfSigned)
+	if o.Kind != KindNone || o.Kind.SafeForStrictTLS() {
+		t.Fatalf("kind = %q", o.Kind)
+	}
+}
+
+// A custom path holding a self-issued cert 526s exactly like the placeholder.
+func TestClassifyBody_CustomButSelfIssuedIsUnsafe(t *testing.T) {
+	body := `server { ssl_certificate /etc/ssl/mine/x.pem; }`
+	o := ClassifyBody("x.com", body, func(string) (bool, bool) { return true, true })
+
+	if o.Kind != KindSelfSigned {
+		t.Fatalf("kind = %q, want self-signed", o.Kind)
+	}
+	if o.Kind.SafeForStrictTLS() {
+		t.Error("self-issued custom cert must not be strict-TLS safe")
+	}
+}
+
+// A custom cert we cannot read is assumed valid — refusing to read an
+// operator's cert is not evidence against it.
+func TestClassifyBody_CustomUnreadableAssumedValid(t *testing.T) {
+	body := `server { ssl_certificate /etc/ssl/mine/x.pem; }`
+	o := ClassifyBody("x.com", body, unreadable)
+
+	if o.Kind != KindCustom || !o.Kind.SafeForStrictTLS() {
+		t.Fatalf("kind = %q", o.Kind)
+	}
+	if o.Detail == "" {
+		t.Error("unreadable custom cert should say so")
+	}
+}
+
+// "I could not look" must never read as "it is fine".
+func TestClassify_MissingVhostIsUnknownNotSafe(t *testing.T) {
+	o := Classify("ghost.com", t.TempDir())
+
+	if o.Kind != KindUnknown {
+		t.Fatalf("kind = %q, want unknown", o.Kind)
+	}
+	if o.Kind.SafeForStrictTLS() {
+		t.Error("unknown must not be reported as strict-TLS safe")
+	}
+}
+
+func TestClassify_ReadsVhostFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "4lion.com.conf"), []byte(realSelfSignedVhost), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if o := Classify("4lion.com", dir); o.Kind != KindSelfSigned {
+		t.Fatalf("kind = %q", o.Kind)
+	}
+}
+
+// Some boxes name the enabled site without .conf.
+func TestClassify_FallsBackToUnsuffixedFilename(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "good.com"), []byte(realLEVhost), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if o := Classify("good.com", dir); o.Kind != KindLetsEncrypt {
+		t.Fatalf("kind = %q", o.Kind)
+	}
+}


### PR DESCRIPTION
## The failure

A migrated domain lands behind jabali's **self-signed placeholder**, because Let's Encrypt HTTP-01 can't succeed until the domain already resolves to this box — and nothing issues a certificate *at* cutover. A domain proxied through Cloudflare **Full (strict)** therefore goes live pointing at a self-signed origin, and Cloudflare answers every request with `Error 526 Invalid SSL certificate`. The origin is healthy; the site is simply dark.

What makes it bite at the worst possible moment: **it's invisible before cutover.** The origin serves the site fine over its self-signed cert, so every check that talks straight to the box passes. It only fails once real traffic arrives through Cloudflare.

## What this adds

`jabali ssl readiness` answers the one question an operator needs before moving DNS: *will Cloudflare accept what nginx is about to serve?*

```
DOMAIN                     ORIGIN       DETAIL
4lion.com                  self-signed  jabali placeholder — Cloudflare Full (strict) will return 526
agent.pension-order.co.il  self-signed  jabali placeholder — Cloudflare Full (strict) will return 526
aramapp.com                unknown      no vhost found in /etc/nginx/sites-enabled
...

50 of 71 domain(s) would fail Cloudflare Full (strict).
Issue a real certificate before cutting DNS over:
  jabali ssl enable 4lion.com
  ...
```

Exits **non-zero** when any domain would fail, so it can gate a cutover script.

## Reads the vhost, not the database

A domain that never had a certificate issued has **no `ssl_certificates` row at all** — and those are precisely the domains that will 526. A table-driven check would call them clean. So classification parses the file nginx actually loads.

Three parsing rules are load-bearing, each with a test:

- `ssl_certificate_key` must **never** match — classifying by the key path would mean opening a **private key**.
- A commented-out directive is not configuration.
- A *custom* certificate that is itself self-issued 526s exactly like the placeholder, so it's reported as self-signed.

And **"I could not look" is never reported as "it is fine"**: a missing vhost is `KindUnknown`, and `KindUnknown` is not `SafeForStrictTLS`.

`sslorigin.ClassifyBody` is pure and takes the cert reader as a parameter, so the rules are tested without a filesystem.

## Verified on the box where the 526s happened

Built and run against the live destination:

| | |
|---|---|
| total domains | 71 |
| letsencrypt | 21 |
| self-signed | 49 |
| no vhost | 1 |
| **not ready** | **50**, exit 1 |

Every one of those 50 would have gone dark on cutover. (Test binary removed from the box afterwards; nothing installed there.)

10 unit tests, built from a verbatim self-signed vhost copied off that box.

## Scoped out — JAB-224 stays open

This makes the failure **visible before it happens**; it does not yet prevent it. Still open:

- issuing the cert **at** cutover, or pre-issuing via **DNS-01** so issuance doesn't depend on the domain already pointing here;
- collapsing the two-tick lag between cert-issued and vhost-repointed, so `jabali ssl enable` is complete when it returns.