### PR TITLE
fix(migrate): measure the tarball before refusing a restore for disk (JAB-219)

### DIFF
--- a/panel-api/internal/migrate/extract.go
+++ b/panel-api/internal/migrate/extract.go
@@ -90,26 +90,141 @@ func ExtractTarGz(tarPath, dest string) error {
 	return nil
 }
 
+// fallbackRatio is the compressed-size multiple used ONLY when the archive
+// cannot be measured. It is the pre-JAB-219 heuristic, kept as a last resort
+// because some estimate beats none when the tar index is unreadable.
+//
+// It is not used for a verdict on a readable archive, because measurements from
+// real cpmove tarballs show it wrong in BOTH directions:
+//
+//   - Too high for already-compressed accounts (media, WordPress uploads, old
+//     backup archives): the tree is roughly the tarball size, so ×5 demanded
+//     five times the real requirement. An 18 GiB account was refused twice on a
+//     host with 60-77 GiB free — the only failure in a 50-account program.
+//   - Too LOW for compressible accounts, which is the more dangerous error. A
+//     real cpmove tarball measured here: 3.47 GiB compressed expanding to 19.81
+//     GiB — a ratio of 5.71. With 18 GiB free, ×5 would have waved it through
+//     and then run out of disk mid-extract, which is precisely the half-extract
+//     failure this check exists to prevent (JAB-41).
+//
+// No fixed ratio can bound gzip expansion, so a verdict has to come from the
+// archive itself.
+const fallbackRatio = 5
+
+// extractMarginFraction and extractMarginFloor are the working headroom added
+// on top of the MEASURED uncompressed size: the restore writes its own copies
+// while unpacking, so "exactly the tree size" is not enough.
+// The floor is deliberately small. It exists so a tiny archive still gets some
+// slack, not as a fixed tax: a multi-gigabyte floor would refuse a 1 KiB
+// tarball on any host with a modest staging filesystem, which is the same class
+// of wrong answer this change is fixing. For anything above ~256 MiB the
+// fraction dominates anyway.
+const (
+	extractMarginFraction = 4        // needed += measured/4  (i.e. +25%)
+	extractMarginFloor    = 64 << 20 // ...but never less than 64 MiB
+)
+
+// MeasureUncompressedSize streams the tarball's index and sums every entry's
+// size, WITHOUT writing anything to disk. This is the real uncompressed
+// footprint rather than a guess derived from a compression ratio.
+//
+// It costs one decompression pass — tens of seconds for a multi-GiB account,
+// against a restore that then extracts, rsyncs and imports databases. Paying it
+// buys the only number that is right in both directions, and the alternative is
+// either refusing feasible migrations or half-extracting infeasible ones.
+func MeasureUncompressedSize(tarballPath string) (uint64, error) {
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	magic := make([]byte, 2)
+	if _, err := io.ReadFull(f, magic); err != nil {
+		return 0, fmt.Errorf("magic: %w", err)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	var src io.Reader = f
+	if magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return 0, fmt.Errorf("gunzip: %w", gerr)
+		}
+		defer gz.Close()
+		src = gz
+	}
+
+	var total uint64
+	tr := tar.NewReader(src)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, fmt.Errorf("read tar index: %w", err)
+		}
+		if h.Size > 0 {
+			total += uint64(h.Size)
+		}
+	}
+	return total, nil
+}
+
 // CheckExtractDiskSpace refuses to extract a backup when the destination
-// filesystem lacks room for the (estimated) uncompressed tree, so a low-disk
-// host fails FAST with a clear message instead of half-extracting and then
-// erroring deep in the restore pipeline (JAB-41). Estimate = compressed size ×5
-// (conservative gzip/zstd ratio; the multiplier is the headroom). Best-effort:
-// if the tarball or filesystem can't be stat'd, it does not block.
+// filesystem genuinely lacks room for the uncompressed tree, so a low-disk host
+// fails FAST with a clear message instead of half-extracting and then erroring
+// deep in the restore pipeline (JAB-41).
+//
+// The verdict comes from MEASURING the archive, never from a compression-ratio
+// guess (JAB-219) — see fallbackRatio for why every fixed multiple is wrong in
+// one direction or the other.
+//
+// Best-effort throughout: if the tarball or filesystem cannot be inspected it
+// does not block, because a check that cannot see is not entitled to veto a
+// migration. An archive too corrupt to measure is likewise waved through — the
+// extractor reports that far better than a disk estimator can.
 func CheckExtractDiskSpace(tarballPath, dest string) error {
 	fi, err := os.Stat(tarballPath)
 	if err != nil {
 		return nil
 	}
-	needed := uint64(fi.Size()) * 5
 	var st syscall.Statfs_t
 	if err := syscall.Statfs(dest, &st); err != nil {
 		return nil
 	}
 	free := st.Bavail * uint64(st.Bsize)
-	if free < needed {
-		return fmt.Errorf("insufficient disk space to extract %s: need ~%d MiB, only %d MiB free on %s (free up space or move staging)",
-			filepath.Base(tarballPath), needed>>20, free>>20, dest)
+
+	measured, merr := MeasureUncompressedSize(tarballPath)
+	if merr != nil {
+		// Could not read the index. Fall back to the old heuristic rather than
+		// dropping the check entirely, but only to catch the grossly-too-small
+		// case — and say which number this is, so nobody debugs the wrong one.
+		needed := uint64(fi.Size()) * fallbackRatio
+		if free < needed {
+			return fmt.Errorf(
+				"insufficient disk space to extract %s: could not measure contents (%v), estimating ~%d MiB from compressed size, only %d MiB free on %s (free up space or move staging)",
+				filepath.Base(tarballPath), merr, needed>>20, free>>20, dest)
+		}
+		return nil
 	}
-	return nil
+
+	needed := measured + extractMargin(measured)
+	if free >= needed {
+		return nil
+	}
+	return fmt.Errorf(
+		"insufficient disk space to extract %s: uncompressed contents measure %d MiB, need %d MiB including margin, only %d MiB free on %s (free up space or move staging)",
+		filepath.Base(tarballPath), measured>>20, needed>>20, free>>20, dest)
+}
+
+// extractMargin is the working headroom for a measured tree.
+func extractMargin(measured uint64) uint64 {
+	m := measured / extractMarginFraction
+	if m < extractMarginFloor {
+		m = extractMarginFloor
+	}
+	return m
 }

--- a/panel-api/internal/migrate/extract_disk_test.go
+++ b/panel-api/internal/migrate/extract_disk_test.go
@@ -1,0 +1,205 @@
+package migrate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTarball builds a tarball whose entries have the given sizes. compress
+// controls gzip; incompressible fills entries with varied bytes so the archive
+// barely shrinks, reproducing the media-heavy account the check used to refuse.
+func writeTarball(t *testing.T, sizes []int, compress, incompressible bool) string {
+	t.Helper()
+	var raw bytes.Buffer
+	var w *tar.Writer
+	var gz *gzip.Writer
+	if compress {
+		gz = gzip.NewWriter(&raw)
+		w = tar.NewWriter(gz)
+	} else {
+		w = tar.NewWriter(&raw)
+	}
+
+	for i, n := range sizes {
+		body := make([]byte, n)
+		if incompressible {
+			// Real random bytes. An arithmetic "pattern" is not enough — a
+			// periodic fill compresses ~250:1, which silently turns this into a
+			// test of the compressible case.
+			if _, err := rand.Read(body); err != nil {
+				t.Fatalf("rand: %v", err)
+			}
+		}
+		if err := w.WriteHeader(&tar.Header{
+			Name:     "file" + string(rune('a'+i)),
+			Mode:     0o644,
+			Size:     int64(n),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("header: %v", err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if gz != nil {
+		if err := gz.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "cpmove-test.tar.gz")
+	if err := os.WriteFile(path, raw.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	return path
+}
+
+func TestMeasureUncompressedSize_SumsEntriesNotArchiveSize(t *testing.T) {
+	sizes := []int{1 << 20, 2 << 20, 3 << 20} // 6 MiB of content
+	path := writeTarball(t, sizes, true, true)
+
+	got, err := MeasureUncompressedSize(path)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	if want := uint64(6 << 20); got != want {
+		t.Fatalf("measured %d, want %d", got, want)
+	}
+
+	// And it must differ from the on-disk archive size, or the test proves nothing.
+	fi, _ := os.Stat(path)
+	if uint64(fi.Size()) == got {
+		t.Skip("archive happened to equal content size; nothing to distinguish")
+	}
+}
+
+// The regression: an incompressible archive whose contents fit comfortably must
+// no longer be refused just because free space is below compressed×5.
+func TestCheckExtractDiskSpace_IncompressibleArchiveIsNotRefused(t *testing.T) {
+	// Contents ~6 MiB and barely compressible, so compressed ≈ 6 MiB. Under the
+	// old rule this demanded ~30 MiB; the real need is ~6 MiB + margin.
+	path := writeTarball(t, []int{2 << 20, 2 << 20, 2 << 20}, true, true)
+	fi, _ := os.Stat(path)
+
+	measured, err := MeasureUncompressedSize(path)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	// Guard the premise: this archive really is close to incompressible.
+	if uint64(fi.Size())*5 < measured {
+		t.Fatalf("premise broken: compressed=%d measured=%d", fi.Size(), measured)
+	}
+
+	// /tmp on CI has far more than 6 MiB + 2 GiB floor... which is the point of
+	// the next assertion: we only require that the check does not refuse when
+	// space is plentiful.
+	if err := CheckExtractDiskSpace(path, t.TempDir()); err != nil {
+		t.Fatalf("feasible restore was refused: %v", err)
+	}
+}
+
+// The other direction, and the more dangerous one. A real cpmove tarball
+// measured 3.47 GiB compressed against 19.81 GiB of contents — a ratio of 5.71.
+// Any fixed multiple of the compressed size therefore UNDER-estimates some real
+// accounts, and an under-estimate is an accept followed by a half-extract, which
+// is the failure this check exists to prevent. The verdict must come from the
+// measured index, so a highly-compressible archive must report far more than
+// compressed×fallbackRatio.
+func TestMeasureUncompressedSize_CatchesRatioAboveFallback(t *testing.T) {
+	// Zero-filled entries compress enormously — the compressible extreme.
+	path := writeTarball(t, []int{16 << 20, 16 << 20}, true, false)
+	fi, _ := os.Stat(path)
+
+	measured, err := MeasureUncompressedSize(path)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	if want := uint64(32 << 20); measured != want {
+		t.Fatalf("measured %d, want %d", measured, want)
+	}
+	guess := uint64(fi.Size()) * fallbackRatio
+	if guess >= measured {
+		t.Fatalf("fixture is not compressible enough to exercise the case: guess=%d measured=%d", guess, measured)
+	}
+	// The whole point: the guess would have allowed a restore that needs far more.
+	t.Logf("compressed=%d guess(x%d)=%d measured=%d — guess is %.1fx too small",
+		fi.Size(), fallbackRatio, guess, measured, float64(measured)/float64(guess))
+}
+
+func TestExtractMargin_FloorAndFraction(t *testing.T) {
+	// Small tree: the floor dominates.
+	if got := extractMargin(1 << 20); got != extractMarginFloor {
+		t.Errorf("small tree margin = %d, want floor %d", got, extractMarginFloor)
+	}
+	// Large tree: the fraction dominates.
+	big := uint64(100) << 30 // 100 GiB
+	if got, want := extractMargin(big), big/extractMarginFraction; got != want {
+		t.Errorf("large tree margin = %d, want %d", got, want)
+	}
+	// The fraction must actually exceed the floor at that size, or the case above
+	// is vacuous.
+	if big/extractMarginFraction <= extractMarginFloor {
+		t.Error("fraction never dominates the floor — margin constants are inconsistent")
+	}
+}
+
+// Best-effort contract: a check that cannot see must not veto a migration.
+func TestCheckExtractDiskSpace_UnreadableInputsDoNotBlock(t *testing.T) {
+	if err := CheckExtractDiskSpace("/nonexistent/x.tar.gz", t.TempDir()); err != nil {
+		t.Errorf("missing tarball must not block: %v", err)
+	}
+	real := writeTarball(t, []int{1 << 10}, true, false)
+	if err := CheckExtractDiskSpace(real, "/nonexistent/dest"); err != nil {
+		t.Errorf("unstattable dest must not block: %v", err)
+	}
+}
+
+// A corrupt archive must not be vetoed here — extraction reports it far better.
+func TestCheckExtractDiskSpace_CorruptArchiveDoesNotBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "broken.tar.gz")
+	// Valid gzip magic, garbage body.
+	if err := os.WriteFile(path, []byte{0x1f, 0x8b, 0x08, 0x00, 0xde, 0xad, 0xbe, 0xef}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := CheckExtractDiskSpace(path, t.TempDir()); err != nil {
+		t.Errorf("corrupt archive must not block the pipeline here: %v", err)
+	}
+}
+
+func TestMeasureUncompressedSize_UncompressedTarball(t *testing.T) {
+	path := writeTarball(t, []int{4 << 20}, false, false)
+	got, err := MeasureUncompressedSize(path)
+	if err != nil {
+		t.Fatalf("measure: %v", err)
+	}
+	if want := uint64(4 << 20); got != want {
+		t.Fatalf("measured %d, want %d", got, want)
+	}
+}
+
+// The refusal message must quote the measured number, so an operator can tell
+// the difference between "your box is too small" and "the estimator is wrong" —
+// which is exactly what cost two failed attempts in the field.
+func TestCheckExtractDiskSpace_RefusalNamesMeasuredSize(t *testing.T) {
+	// /proc has 0 blocks available, so any positive requirement fails there.
+	path := writeTarball(t, []int{1 << 20}, true, true)
+	err := CheckExtractDiskSpace(path, "/proc")
+	if err == nil {
+		t.Skip("/proc did not report zero free space on this platform")
+	}
+	for _, want := range []string{"uncompressed contents measure", "including margin", "free on"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal message missing %q: %v", want, err)
+		}
+	}
+}


### PR DESCRIPTION
## The `×5` is wrong in both directions

The extract pre-flight gated on `compressed_size × 5`. Measuring real cpmove tarballs shows that multiplier fails **both** ways, so it no longer decides anything.

**Too high** for already-compressed accounts — media, WordPress uploads, old backup archives. The tarball barely shrinks, so the tree is roughly the tarball size and ×5 demanded five times the real requirement. An 18 GiB account was refused twice on a host with **60–77 GiB free**: the only failure in a 50-account migration program, on exactly the accounts where migrating is already hardest. That's the reported bug.

**Too low** for compressible accounts — the more dangerous error, and *not* in the report. I measured a real cpmove tarball on the destination box:

| | |
|---|---|
| compressed | 3.47 GiB |
| uncompressed | **19.81 GiB** |
| ratio | **5.71×** |

With 18 GiB free, `×5` would have waved that through and then run out of disk **mid-extract** — precisely the half-extract failure this check exists to prevent (JAB-41). A synthetic worst case in the tests comes out **205× too small**.

I'd first written the fix keeping ×5 as a cheap "accept without looking" threshold. That real measurement is what killed it: no fixed ratio can bound gzip expansion, so it can't be trusted as an upper bound either.

## The fix

The verdict now comes from the archive itself. `MeasureUncompressedSize` streams the tar index and sums every entry, **writing nothing to disk**; the requirement is that plus a working margin (`measured/4`, floor 64 MiB).

It costs one decompression pass — tens of seconds for a multi-GiB account, against a restore that then extracts, rsyncs and imports databases.

The margin floor is deliberately small. An earlier draft used 2 GiB, which refused a **1 KiB** tarball on any host with a modest staging filesystem — the same class of wrong answer this change is fixing.

## Best-effort preserved

- Unreadable tarball or unstattable destination → does not block. A check that cannot see is not entitled to veto a migration.
- Index unreadable → falls back to the old heuristic to catch only the grossly-too-small case, and **the message says which number it's quoting** so nobody debugs the wrong one.
- Refusals name the measured size, the margin and the free space, so an operator can tell "your box is too small" from "the estimator is wrong" — what cost two failed attempts in the field.

## Tests

8 tests, including both failure directions. The incompressible fixture uses `crypto/rand`: my first version used an arithmetic pattern that gzip compressed **~250:1**, silently turning the regression test into a test of the compressible case. The premise guard caught it and is kept so it can't regress quietly.

## Scoped out — JAB-219 stays open

The check still runs *before* the migration job row is created, so a refusal leaves nothing to resume via `migrate import`. That's a job-lifecycle change rather than an estimator one.