### PR TITLE
fix(agent): stage the bouncer conf next to its target, not in /tmp (JAB-222)

### DIFF
--- a/panel-agent/internal/commands/atomic_write_exdev_test.go
+++ b/panel-agent/internal/commands/atomic_write_exdev_test.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-222 was an omission bug: one function staged its temp file in /tmp and
+// renamed it into /etc, which works on a dev box and fails with EXDEV on any
+// host where /tmp is a separate tmpfs. Nothing in the type system objects, the
+// unit tests passed, and the failure only appeared on a production box — where
+// it silently disabled a security control the operator believed was on.
+//
+// A point fix would not stop the next one, so this is a structural guard rather
+// than a behavioural test: it re-derives the audit from the source on every run
+// and fails on any NEW instance. The rule it enforces is narrow and mechanical —
+// a function must not both create a temp file with an empty directory argument
+// and call os.Rename. Those two together are the bug; either alone is fine.
+func TestNoTempFileRenamedAcrossFilesystems(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var offenders []string
+
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			var tempInDefaultDir, renames bool
+			var tempPos token.Pos
+
+			ast.Inspect(fn.Body, func(inner ast.Node) bool {
+				call, ok := inner.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "os" {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "CreateTemp", "MkdirTemp":
+					// Empty first argument means "use $TMPDIR / /tmp".
+					if len(call.Args) > 0 {
+						if lit, ok := call.Args[0].(*ast.BasicLit); ok &&
+							(lit.Value == `""` || lit.Value == `"/tmp"`) {
+							tempInDefaultDir = true
+							tempPos = call.Pos()
+						}
+					}
+				case "Rename":
+					renames = true
+				}
+				return true
+			})
+
+			if tempInDefaultDir && renames {
+				offenders = append(offenders, fset.Position(tempPos).String()+" in "+fn.Name.Name)
+			}
+			return true
+		})
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("temp file created in the default temp dir and renamed in the same function — "+
+			"rename(2) cannot cross filesystems and /tmp is often a separate tmpfs (JAB-222).\n"+
+			"Stage the temp file in the target's directory instead, e.g. writeAtomic():\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// writeAtomic is the sanctioned helper. Pin the property that matters: the temp
+// file must live on the same filesystem as the target, which for a same-dir
+// staging path is true by construction.
+func TestWriteAtomic_StagesInTargetDirectory(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "conf")
+
+	if err := writeAtomic(target, []byte("SITE_KEY=abc\n"), 0o600); err != nil {
+		t.Fatalf("writeAtomic: %v", err)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "SITE_KEY=abc\n" {
+		t.Errorf("content = %q", got)
+	}
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", fi.Mode().Perm())
+	}
+	// No .tmp left behind.
+	if _, err := os.Stat(target + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("temp file survived: %v", err)
+	}
+}
+
+// A leftover .tmp from an interrupted run must not donate its permissions to a
+// file that carries a secret.
+func TestWriteAtomic_TightensLeftoverTempPermissions(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "conf")
+	if err := os.WriteFile(target+".tmp", []byte("stale"), 0o666); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := writeAtomic(target, []byte("SECRET_KEY=xyz\n"), 0o600); err != nil {
+		t.Fatalf("writeAtomic: %v", err)
+	}
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("secret-bearing file left at %v — leftover temp permissions leaked through", fi.Mode().Perm())
+	}
+}

--- a/panel-agent/internal/commands/security_crowdsec.go
+++ b/panel-agent/internal/commands/security_crowdsec.go
@@ -1699,21 +1699,23 @@ func rewriteBouncerConfKeys(path string, updates map[string]string) error {
 		}
 	}
 	out := strings.Join(lines, "\n")
-	tmp, err := os.CreateTemp("", "bouncer-conf-*.tmp")
-	if err != nil {
-		return fmt.Errorf("mktemp: %w", err)
-	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.WriteString(out); err != nil {
-		tmp.Close()
-		return fmt.Errorf("write tmp: %w", err)
-	}
-	tmp.Close()
-	if err := os.Chmod(tmp.Name(), 0o600); err != nil {
-		return fmt.Errorf("chmod tmp: %w", err)
-	}
-	if err := os.Rename(tmp.Name(), path); err != nil {
-		return fmt.Errorf("rename: %w", err)
+	// JAB-222: stage the temp file NEXT TO the target, not in /tmp. rename(2)
+	// cannot cross filesystems, and /tmp is a separate tmpfs on any hardened
+	// host, so `os.CreateTemp("", …)` here failed with EXDEV:
+	//
+	//   rename /tmp/bouncer-conf-*.tmp /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf:
+	//   invalid cross-device link
+	//
+	// The panel had already written the setting to the database by then, so
+	// `crowdsec captcha get` reported captcha enabled while the bouncer conf
+	// still carried an empty SITE_KEY and FALLBACK_REMEDIATION=ban — a
+	// protection the operator believed was on, silently inactive at the edge,
+	// with the reconciler retrying the same doomed rename every tick.
+	//
+	// writeAtomic stages at path+".tmp", which is by construction on the target
+	// filesystem.
+	if err := writeAtomic(path, []byte(out), 0o600); err != nil {
+		return fmt.Errorf("write bouncer conf: %w", err)
 	}
 	return nil
 }

--- a/panel-agent/internal/commands/ssl_install_custom.go
+++ b/panel-agent/internal/commands/ssl_install_custom.go
@@ -194,9 +194,21 @@ func validateKeyMatchesCert(keyPEM string, leaf *x509.Certificate) error {
 	return nil
 }
 
+// writeAtomic writes data to path via a temp file in the SAME directory, so the
+// rename is always intra-filesystem. Staging in /tmp instead is the EXDEV trap:
+// rename(2) cannot cross devices, and /tmp is a separate tmpfs on any hardened
+// host (JAB-222).
 func writeAtomic(path string, data []byte, mode os.FileMode) error {
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, mode); err != nil {
+		return err
+	}
+	// WriteFile only applies mode when it CREATES the file. A leftover .tmp
+	// from an interrupted run would keep its old, possibly looser permissions —
+	// and some callers write secrets (bouncer conf carries a captcha secret
+	// key), so set the mode explicitly rather than inheriting whatever is there.
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := os.Rename(tmp, path); err != nil {


### PR DESCRIPTION
## The failure

The captcha apply built its temp file with `os.CreateTemp("", …)` — i.e. in `/tmp` — then renamed it onto `/etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf`. `rename(2)` cannot cross filesystems:

```
rename /tmp/bouncer-conf-*.tmp /etc/crowdsec/bouncers/crowdsec-nginx-bouncer.conf:
invalid cross-device link
```

**The damage is worse than a failed command.** The panel writes the setting to the database *before* calling the agent, so `crowdsec captcha get` reported captcha enabled and turnstile configured, while the bouncer conf still carried an empty `SITE_KEY` and `FALLBACK_REMEDIATION=ban`. A protection the operator believed was on was silently inactive at the edge — and the reconciler retried the same doomed rename every tick, so it could never converge.

**Not specific to one box.** `/tmp` is a separate device from `/etc/crowdsec/bouncers` on testserver too (36 vs 51714), so this fails on every jabali host with a tmpfs `/tmp`.

## The fix

Reuse `writeAtomic`, which stages at `path + ".tmp"` and is therefore on the target filesystem by construction. The geoblock writer a few functions above was already doing exactly that — this call site was the outlier.

`writeAtomic` is hardened while here: `os.WriteFile` only applies the mode when it **creates** the file, so a leftover `.tmp` from an interrupted run would donate its old, possibly looser permissions to the result. The bouncer conf carries a captcha **secret key**, so the mode is now set explicitly.

## The audit, made permanent

Audited every `os.CreateTemp("")` / `MkdirTemp("")` in the agent and panel. This was the **only** one whose function also renames — the rest write credentials or scratch files read in place and deleted.

That kind of audit rots, so `TestNoTempFileRenamedAcrossFilesystems` re-derives it from source on every run: it parses the package AST and fails on any function that both creates a temp file in the default temp dir and calls `os.Rename`.

**Verified the guard actually fires** by planting a violation:

```
--- FAIL: TestNoTempFileRenamedAcrossFilesystems
    temp file created in the default temp dir and renamed in the same function —
    rename(2) cannot cross filesystems and /tmp is often a separate tmpfs (JAB-222).
      zz_planted_exdev.go:7:14 in plantedExdevViolation
```

then removed it and confirmed it passes. A guard that has never fired proves nothing.

## Scoped out — JAB-222 stays open

An apply that fails at the agent still leaves the panel's database reporting the setting as applied. Fixing the EXDEV write removes *this* divergence, but the general ordering — DB first, agent second, no reconciliation of the difference — is untouched. That's the remaining acceptance criterion.

Note: the box-local workaround (`Environment=TMPDIR=/var/tmp` drop-in on newzaps) can be removed once this ships, but I've left it in place.