### PR TITLE
fix(appsec): stop libinjection locking admins out of wp-admin/admin-ajax.php

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -239,6 +239,31 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" "id:9599210,phase:
 #   - v[0-9]+ so a future API version can't silently re-break saves.
 SecRule REQUEST_URI "@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,pass,nolog,chain"
     SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;REQUEST_BODY,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;REQUEST_BODY"
+# 942100 vs wp-admin/admin-ajax.php (newzaps, observed 2026-08-02..03).
+# admin-ajax.php is WordPress's general-purpose AJAX endpoint: every plugin
+# and the block editor POST arbitrary user-authored content through it —
+# post bodies, meta values, saved queries, form-builder field definitions.
+# CRS 942100 is libinjection, which scores on SQL-shaped text rather than a
+# fixed pattern, so ordinary editorial content ("... 1 or 2 items", quoted
+# fragments, anything resembling a boolean clause) reads as SQLi. Measured on
+# newzaps: 26 denies across 5 source addresses, including a consumer ISP
+# address repeatedly locked out of the site's own wp-admin.
+#
+# 9599201 above already drops 911100/942550/932370 here unconditionally, but
+# not 942100 — libinjection is a far more valuable detector and admin-ajax.php
+# is reachable UNAUTHENTICATED for plugins that register nopriv_ actions, which
+# is precisely where WordPress SQLi is exploited. So this is scoped on identity
+# rather than widened on the path:
+#   - Chained on a wordpress_logged_in_* cookie. An unauthenticated request to
+#     the same endpoint keeps FULL libinjection scoring. A forged cookie buys
+#     nothing on its own: admin-ajax dispatches to capability- and
+#     nonce-checked handlers, so the cookie only decides whether CRS scores the
+#     body, never whether the action runs.
+#   - Only 942100, and only on ARGS + REQUEST_BODY. Every other SQLi rule, and
+#     every other family, stays fully active on this path — a real injection in
+#     these args is still caught by the rest of the 942 group.
+SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599230,phase:1,pass,nolog,chain"
+    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetById=942100;ARGS,ctl:ruleRemoveTargetById=942100;REQUEST_BODY"
 # 933120 vs WooCommerce checkout (arizot-e.com incident, 2026-08-02).
 # WooCommerce 8.5+ order attribution submits a field literally named
 # wc_order_attribution_user_agent with every checkout AJAX call — and

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -234,3 +234,51 @@ func TestCRSPluginBefore_CodeSnippetsExclusion(t *testing.T) {
 	mustNotContain(t, out, `"@rx ^/wp-json/code-snippets/" "id:`,
 		"no unchained, unversioned code-snippets exclusion")
 }
+
+// 942100 vs wp-admin/admin-ajax.php (newzaps, 26 denies across 5 source
+// addresses, 2026-08-02..03 — including a consumer ISP address repeatedly
+// locked out of the site's own wp-admin).
+//
+// The exclusion must stay identity-scoped, not path-scoped: admin-ajax.php is
+// reachable unauthenticated for plugins registering nopriv_ actions, and that
+// is exactly where WordPress SQLi gets exploited. An unauthenticated request
+// therefore has to keep full libinjection scoring.
+func TestCRSPluginBefore_AdminAjaxLibinjectionIsCookieGated(t *testing.T) {
+	out := CRSPluginBefore()
+
+	mustContain(t, out, "ctl:ruleRemoveTargetById=942100;ARGS", "942100 dropped on ARGS")
+	mustContain(t, out, "ctl:ruleRemoveTargetById=942100;REQUEST_BODY", "942100 dropped on REQUEST_BODY")
+
+	// The drop must be chained on the logged-in cookie. Locate the rule and
+	// assert the chain, rather than trusting that the cookie appears anywhere
+	// in the file (it also appears in the code-snippets rule).
+	idx := strings.Index(out, "id:9599230")
+	if idx < 0 {
+		t.Fatal("admin-ajax 942100 rule (id:9599230) missing")
+	}
+	// Start at the beginning of that SecRule's line — the URI match sits
+	// before the id: on the same line.
+	if nl := strings.LastIndex(out[:idx], "\n"); nl >= 0 {
+		idx = nl + 1
+	}
+	rule := out[idx:]
+	if end := strings.Index(rule, "\n# "); end > 0 {
+		rule = rule[:end]
+	}
+	if !strings.Contains(rule, "chain") {
+		t.Error("942100 drop is not chained — it would apply to unauthenticated requests")
+	}
+	if !strings.Contains(rule, "wordpress_logged_in_") {
+		t.Error("942100 drop is not gated on the wordpress_logged_in_ cookie")
+	}
+	if !strings.Contains(rule, `^/wp-admin/admin-ajax`) {
+		t.Error("942100 drop is not scoped to admin-ajax.php")
+	}
+
+	// Narrowness: only 942100 is dropped by ID here. Removing the whole
+	// attack-sqli tag on this path would surrender libinjection everywhere on
+	// the endpoint, which is the thing this scoping exists to avoid.
+	if strings.Contains(rule, "ruleRemoveTargetByTag=attack-sqli") {
+		t.Error("admin-ajax rule removes the whole SQLi tag — too broad")
+	}
+}


### PR DESCRIPTION
## Evidence

Pulled live from newzaps — CRS `942100` on `/wp-admin/admin-ajax.php`, **26 denies across 5 source addresses** over two days:

```
2026-08-03T08:25:42 | 93.172.231.73     | www.arizot-e.com | /wp-admin/admin-ajax.php | deny
2026-08-03T08:27:14 | 93.172.231.73     | www.arizot-e.com | /wp-admin/admin-ajax.php | deny
...
distinct source IPs: 5 | top: 34.165.251.206 (9), 93.172.231.73 (8), 2a03:2880:ff:4c:: (4)
```

`93.172.231.73` is a consumer ISP address repeatedly blocked from the site's own wp-admin. `2a03:2880:ff:4c::` is Meta's crawler — that breaks Facebook link previews and catalog sync for a WooCommerce store.

## Why it fires

`admin-ajax.php` is WordPress's general-purpose AJAX endpoint — plugins and the block editor POST arbitrary user-authored content through it. `942100` is libinjection, which scores on SQL-**shaped** text rather than a fixed pattern, so ordinary editorial content reads as an injection attempt.

`9599201` already drops `911100`/`942550`/`932370` on this path unconditionally — but deliberately **not** `942100`.

## Why I didn't just widen that rule

The reason `942100` was left out still holds. libinjection is a far more valuable detector than the three builder-noise rules, and `admin-ajax.php` is reachable **unauthenticated** for plugins registering `nopriv_` actions — precisely where WordPress SQLi gets exploited. Widening on the path would surrender it exactly where it earns its keep.

So this scopes on **identity**, reusing the pattern ADR-0147 established for code-snippets:

```
SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599230,phase:1,pass,nolog,chain"
    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetById=942100;ARGS,ctl:ruleRemoveTargetById=942100;REQUEST_BODY"
```

An unauthenticated request keeps **full** libinjection scoring. A forged cookie buys nothing on its own — admin-ajax dispatches to capability- and nonce-checked handlers, so the cookie only decides whether CRS *scores* the body, never whether the action runs. Only `942100`, only on `ARGS` + `REQUEST_BODY`; every other SQLi rule and every other family stays active, so a real injection in those args is still caught.

## Verification

Validated against the live engine, not just golden tests:

```
$ jabali appsec render-config --reconcile
written /var/lib/crowdsec/data/crs-plugins/jabali/jabali-before.conf
$ crowdsec -t ; echo exit=$?
exit=0
$ systemctl restart crowdsec && systemctl is-active crowdsec
active            # no FATAL, no appsec errors
```

That check isn't ceremony — a malformed SecRule takes the whole inband engine down with `unable to initialize inband engine : invalid WAF config`, which I watched happen on this same box earlier today.

The golden test asserts **narrowness**, not just presence: it locates the rule, requires the chain and the cookie gate, and fails if anyone later swaps the ID drop for a whole-tag `attack-sqli` removal.

## Note on the WooCommerce FP

`9599300` (2026-08-02) is deployed on newzaps and the real checkout denies stop at its deploy time. There are 4 later hits on `?wc-ajax=checkout`, but they came from `192.0.2.20` — RFC-5737 documentation space, all within one second — i.e. a synthetic probe. It tripped `933140`, which `9599300` doesn't cover. Not treating that as a live regression; if real checkout traffic is seen tripping `933140`, that's a separate evidenced change.