### PR TITLE
fix(snuffleupagus): drop dl + Reflection invoke hooks — they defer all destructors to shutdown (GH #897)

### DIFF
--- a/install/snuffleupagus/rules/00-base.rules
+++ b/install/snuffleupagus/rules/00-base.rules
@@ -43,8 +43,14 @@ sp.disable_function.function("show_source").drop();
 sp.disable_function.function("highlight_file").drop();
 sp.disable_function.function("phpinfo").drop();
 
-# Runtime extension load.
-sp.disable_function.function("dl").drop();
+# Runtime extension load: rule REMOVED (GH #897). Hooking dl() makes
+# Snuffleupagus defer destruction of discarded temporaries to script
+# shutdown (verified on PHP 8.4/8.5: a `new A;` statement's __destruct
+# stops firing at statement end), which silently breaks RAII patterns —
+# concretely, every Laravel Route::resource() registration (InvoiceShelf
+# lost all its CRUD API routes). Security loss is minimal: PHP-FPM's
+# SAPI hard-disables dl() natively (the serving path never had it), and
+# CLI abuse requires an attacker who already executes arbitrary PHP.
 
 # putenv LD_*/PATH/GCONV_*: privilege-escalation primitive.
 sp.disable_function.function("putenv").param("assignment").value_r("LD_").drop();
@@ -146,7 +152,16 @@ sp.disable_function.function("call_user_func_array").param("function").value_r("
 # because they route through the Reflection engine, not zend_call_function.
 # $r = new ReflectionFunction('system'); $r->invoke('id') is the canonical
 # webshell evasion pattern. Block both Function and Method flavours.
-sp.disable_function.function("ReflectionFunction::invoke").drop();
-sp.disable_function.function("ReflectionFunction::invokeArgs").drop();
-sp.disable_function.function("ReflectionMethod::invoke").drop();
-sp.disable_function.function("ReflectionMethod::invokeArgs").drop();
+# Reflection invoke rules REMOVED (GH #897): any Class::method hook makes
+# Snuffleupagus defer destruction of discarded temporaries to script
+# shutdown (PHP 8.4/8.5, verified with a minimal repro — see the dl()
+# note above), silently breaking destructor-timing patterns across
+# frameworks: Laravel's Route::resource() registrations vanished
+# (InvoiceShelf #897), and the same class of bug would hit destructor-
+# committed DB transactions and lock guards. Mirrors the GH #335
+# wrappers_whitelist removal: a rule that silently breaks legitimate
+# frameworks costs more than its marginal hardening. Compensating
+# controls that remain: the direct symbol bans on system/exec/… above,
+# the call_user_func string-literal bans, and eval_blacklist — the
+# Reflection evasion needs arbitrary-PHP execution already, at which
+# point those layers are the operative defenses.


### PR DESCRIPTION
Root-cause fix for #897 (InvoiceShelf "The route api/v1/units could not be found" on every nav click).

## Diagnosis chain (all live on testserver)
1. Reproduced: fresh InvoiceShelf install — `/api/v1/me` 401 (route exists) but every `Route::resource` endpoint 404s. `artisan route:list`: 157 routes, zero resource routes.
2. `->register()` appended inline to one resource line → its 7 routes appear ⇒ the pending-registration **destructor** never fires in time.
3. A/B without Snuffleupagus: 255 routes, all present.
4. Per-line bisect of the active ruleset: `sp.disable_function.function("dl")` and each of the four `Reflection*::invoke` hooks independently reproduce the loss.
5. Minimal repro: with such a hook loaded, `f();` discarding a `new A` prints `after` **before** `destructed` — discarded-temporary destructors defer to script shutdown (PHP 8.4 + 8.5, simulation mode included).

Laravel's `Route::resource()` relies on statement-end destruction, so every Laravel-13 app on a jabali box silently loses its resource routes. Same mechanism endangers destructor-committed DB transactions and lock guards.

## Security assessment
- **dl()**: PHP-FPM hard-disables `dl()` at the SAPI level — the web path never had it. CLI abuse presupposes code execution.
- **Reflection invoke bans**: the evasion they target requires arbitrary-PHP execution already; direct symbol bans + `call_user_func` literal bans + `eval_blacklist` remain. Follows the GH #335 wrappers_whitelist removal precedent (broad SP rule silently breaking legitimate frameworks).

No other rule is touched; mode/enforce semantics unchanged.

## Test plan
- [x] full panel-api + panel-agent suites
- [ ] deploy testserver → re-render active.rules → InvoiceShelf `/api/v1/units` returns 401 (route registered) through the live vhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)