### PR TITLE
fix(invoiceshelf): cache routes at install so FPM serves the resource routes (GH #897)

### DIFF
--- a/panel-agent/internal/commands/invoiceshelf_install.go
+++ b/panel-agent/internal/commands/invoiceshelf_install.go
@@ -235,6 +235,23 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("finalise admin: %v (%s)", err, truncateStr(string(out), 1024))}
 	}
 
+	// Cache the route table (GH #897). This is Laravel's production
+	// best-practice, and here it is load-bearing: jabali's Snuffleupagus
+	// hooks override zend_execute_ex, which under the PHP-FPM SAPI defers
+	// a discarded temporary's __destruct to script shutdown. Laravel
+	// registers every Route::resource() from exactly that pattern
+	// (PendingResourceRegistration::__destruct), so under FPM the CRUD
+	// routes land AFTER route matching and every /api/v1/<resource> 404s
+	// ("route could not be found" on each nav click). route:cache is built
+	// here in the CLI SAPI — where destructor timing is correct — and FPM
+	// then serves the baked table without re-running registration, so the
+	// resource routes exist. Fatal on failure: without a valid cache the app
+	// serves 404s on every CRUD route, so a broken cache is a broken install
+	// and must surface here rather than ship silently.
+	if err := artisan(2*time.Minute, "route:cache"); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
+	}
+
 	if err := writeInvoiceShelfNginx(ctx, domain, req.OSUser, req.Subdirectory); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("nginx snippet: %v", err)}
 	}


### PR DESCRIPTION
Second half of the #897 fix (pairs with #911). #911 removed the SP rules that broke destructor timing **in the CLI SAPI**; this fixes the **FPM serving path**.

## Why #911 alone wasn't enough
Snuffleupagus overrides `zend_execute_ex` (upstream jvoisin/snuffleupagus#441). Under the **PHP-FPM SAPI** that defers a discarded temporary's `__destruct` to script shutdown — verified live on testserver, **both PHP 8.4 and 8.5**, opcache on or off. The CLI SAPI does not defer. Laravel's `Route::resource()` registers via `PendingResourceRegistration::__destruct`, so under FPM every resource route lands *after* route matching → "The route api/v1/units could not be found" on each nav click, while `Route::get/post` routes work (157 vs 255 routes).

## Fix
Run `artisan route:cache` as the final install step. The cache is built in the **CLI SAPI** (correct destructor timing, given #911) and FPM serves the baked route table without re-running registration. This is also Laravel's documented production practice.

Live proof on testserver (`123123.com/gh897`): after `route:cache`, `/api/v1/units`, `/customers`, `/items`, `/invoices/templates` all flip **404 → 401** (route present, auth required). Route cache file contains the resource routes (9 `api/v1/units` refs).

Fatal on failure — a bad cache means a broken app; must not ship silently.

## Test plan
- [x] agent build + invoiceshelf tests
- [x] `route:cache` by hand on a live install → resource routes serve (404→401)
- [ ] fresh install through the agent (post-merge deploy) reproduces it end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)