### PR TITLE
fix(domains): normalize domain name to lowercase on create (GH #884)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -103,6 +103,16 @@ type createDomainRequest struct {
 	SSLMode string `json:"ssl_mode"`
 }
 
+// normalizeDomainName canonicalizes a domain for storage (GH #884): trim
+// edge whitespace and lowercase. Domain names are case-insensitive per DNS,
+// but jabali uses the stored string verbatim for the docroot path, cert
+// lineage, DNS zone, and nginx server_name, so a mixed-case entry (mobile
+// autocorrect) yields a site that never resolves. Callers still run
+// validateDomainName on the result to enforce RFC shape.
+func normalizeDomainName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
 // validateDomainName validates domain name for security and RFC compliance
 func validateDomainName(s string) error {
 	// Check for empty or whitespace
@@ -633,6 +643,15 @@ func (h *domainHandler) create(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": err.Error()})
 		return
 	}
+
+	// GH #884: normalize the domain to lowercase (and trim edge whitespace)
+	// before anything consumes it. DNS is case-insensitive, but the name is
+	// used verbatim for the docroot path, cert lineage, DNS zone, and vhost
+	// server_name — so a mobile keyboard's autocorrected "MyDomain.com" was
+	// accepted and then produced a site that didn't resolve. Normalizing
+	// here (the create source of truth) fixes every downstream consumer at
+	// once; validateDomainName still enforces RFC shape on the result.
+	req.Name = normalizeDomainName(req.Name)
 
 	// SECURITY: Validate domain name to prevent XSS and path traversal
 	if err := validateDomainName(req.Name); err != nil {

--- a/panel-api/internal/api/domains_normalize_test.go
+++ b/panel-api/internal/api/domains_normalize_test.go
@@ -1,0 +1,34 @@
+package api
+
+// GH #884: domain names must be stored lowercase — a mobile keyboard's
+// autocorrected capital produced a domain that was accepted but never
+// resolved. normalizeDomainName runs at the create source of truth; assert
+// it canonicalizes and that the result passes validateDomainName.
+
+import "testing"
+
+func TestNormalizeDomainName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Example.com", "example.com"},
+		{"EXAMPLE.COM", "example.com"},
+		{"MyDomain.Com", "mydomain.com"},
+		{"  spaced.com  ", "spaced.com"},
+		{"already-lower.com", "already-lower.com"},
+		{"Sub.Domain.Example.CO.UK", "sub.domain.example.co.uk"},
+	}
+	for _, tc := range cases {
+		if got := normalizeDomainName(tc.in); got != tc.want {
+			t.Errorf("normalizeDomainName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeDomainName_ResultValidates(t *testing.T) {
+	// The canonical form of a mixed-case FQDN must satisfy the RFC check,
+	// so create() proceeds instead of 400ing on the user's autocorrect.
+	for _, in := range []string{"MyDomain.COM", "Santa.Sergia.COM", "  App.Example.io  "} {
+		if err := validateDomainName(normalizeDomainName(in)); err != nil {
+			t.Errorf("validateDomainName(normalize(%q)) = %v, want nil", in, err)
+		}
+	}
+}

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -68,11 +68,14 @@ export const DomainCreate = () => {
         <Form.Item
           label={t("domaincreate.name")}
           name="name"
+          // GH #884: stored lowercase; normalize live so the admin sees the
+          // canonical value and an autocorrected capital can't slip through.
+          normalize={(v) => (typeof v === "string" ? v.toLowerCase() : v)}
           rules={[
             { required: true, message: "Domain name is required" },
             { max: 253, message: "Domain name cannot exceed 253 characters" },
             {
-              pattern: /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/,
+              pattern: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/,
               message: "Enter a valid domain name (e.g. example.com)",
             },
           ]}

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -60,11 +60,15 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
         <Form.Item
           label={t("userdomaindrawer.domain_name")}
           name="name"
+          // GH #884: domains are stored lowercase (the server normalizes too);
+          // lowercasing as the user types shows the canonical value and avoids
+          // a mobile-autocorrect capital slipping through.
+          normalize={(v) => (typeof v === "string" ? v.toLowerCase() : v)}
           rules={[
             { required: true, message: "Domain name is required" },
             { max: 253, message: "Domain name cannot exceed 253 characters" },
             {
-              pattern: /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/,
+              pattern: /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/,
               message: "Enter a valid domain name (e.g. example.com)",
             },
           ]}


### PR DESCRIPTION
Fixes #884: a domain entered with a capital (mobile-keyboard autocorrect) was accepted — the FQDN validator allowed `A-Z` — then stored verbatim. DNS is case-insensitive, but jabali uses the stored name for the docroot path, cert lineage, DNS zone, and nginx `server_name`, so the mixed-case site never resolved.

## What
- **panel-api**: `normalizeDomainName` (lowercase + trim) runs at the create source of truth, before `validateDomainName` and every downstream consumer — one point fixes docroot/cert/DNS/vhost at once.
- **UI**: both create forms (user drawer + admin) lowercase the field live via `Form.Item normalize` and tighten the regex to `a-z`, so the value the operator sees is what gets stored.

## Test plan
- [x] `TestNormalizeDomainName` (canonicalization table) + `TestNormalizeDomainName_ResultValidates` (normalized mixed-case passes the RFC check)
- [x] full panel-api suite; panel-ui build; domain UI vitest