### PR TITLE
fix(ssl): www SAN only when the domain opted into the www record (GH #895)

### DIFF
--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -540,7 +540,9 @@ func (h *sslHandler) enrichCertRows(ctx context.Context, certs []repository.SSLC
 // [domain, www.domain] plus the auto-added names. Falls back to the
 // base pair if the domain can't be loaded.
 func (h *sslHandler) webCertSANs(ctx context.Context, c repository.SSLCertificateWithDomain) []string {
-	base := []string{c.DomainName, "www." + c.DomainName}
+	// Fallback when the domain row can't be loaded: report only the base
+	// name. www is opt-in (GH #895) and unknowable here, so don't claim it.
+	base := []string{c.DomainName}
 	if h.cfg.Domains == nil {
 		return base
 	}
@@ -553,8 +555,14 @@ func (h *sslHandler) webCertSANs(ctx context.Context, c repository.SSLCertificat
 
 // webCertSANsForDomain is the pure policy (extracted for testing) — it
 // MUST stay in lockstep with reconciler.sanHostnamesForDomain (ADR-0070).
+// www.<domain> is included ONLY when the domain opted into the www CNAME
+// (GH #895): otherwise there is no www DNS record, issuance omits it, and
+// listing it here over-reported coverage the cert never had.
 func webCertSANsForDomain(d *models.Domain) []string {
-	sans := []string{d.Name, "www." + d.Name}
+	sans := []string{d.Name}
+	if d.CreateWWW {
+		sans = append(sans, "www."+d.Name)
+	}
 	if d.SkipAutoSAN {
 		return sans
 	}

--- a/panel-api/internal/api/ssl_sans_test.go
+++ b/panel-api/internal/api/ssl_sans_test.go
@@ -14,23 +14,38 @@ func TestWebCertSANsForDomain(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "plain (no email)",
-			dom:  &models.Domain{Name: "example.com", EmailEnabled: false},
+			name: "plain, www opted out (GH #895)",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: false},
+			want: []string{"example.com"},
+		},
+		{
+			name: "plain, www opted in",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: true},
 			want: []string{"example.com", "www.example.com"},
 		},
 		{
-			name: "email adds mail/autoconfig/autodiscover",
-			dom:  &models.Domain{Name: "example.com", EmailEnabled: true},
+			name: "email adds mail/autoconfig/autodiscover, no www",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: false},
+			want: []string{"example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"},
+		},
+		{
+			name: "email + www opted in",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: true},
 			want: []string{"example.com", "www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"},
 		},
 		{
-			name: "mta-sts adds its SAN",
-			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true},
-			want: []string{"example.com", "www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com", "mta-sts.example.com"},
+			name: "mta-sts adds its SAN (www out)",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, CreateWWW: false},
+			want: []string{"example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com", "mta-sts.example.com"},
 		},
 		{
-			name: "SkipAutoSAN keeps only base pair",
-			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true},
+			name: "SkipAutoSAN, www out -> base only",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: false},
+			want: []string{"example.com"},
+		},
+		{
+			name: "SkipAutoSAN, www in -> base + www",
+			dom:  &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: true},
 			want: []string{"example.com", "www.example.com"},
 		},
 	}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2161,15 +2161,21 @@ func sanHostnamesForDomain(d *models.Domain) []string {
 	if d == nil {
 		return nil
 	}
-	// Tenant opt-out: when SkipAutoSAN is set, panel won't add ANY
-	// auto-derived SAN names (mail/autoconfig/mta-sts). Cert covers
-	// just <domain> + www.<domain>. Use this when the domain's mail
-	// runs elsewhere or the operator manages their own DNS without
-	// the helper subdomains.
-	if d.SkipAutoSAN {
-		return nil
-	}
 	var out []string
+	// www.<domain> is issued ONLY when the domain opted into the www CNAME
+	// (GH #895). It rides as an extra SAN (the base name is added agent-side
+	// from p.Domain); resolvableSANs drops it if the record isn't live yet,
+	// so it never tanks issuance. Placed before the SkipAutoSAN return so an
+	// opt-in www survives even when the helper subdomains are skipped.
+	if d.CreateWWW {
+		out = append(out, "www."+d.Name)
+	}
+	// Tenant opt-out: when SkipAutoSAN is set, panel won't add the
+	// auto-derived helper SANs (mail/autoconfig/mta-sts) — only the base
+	// name (agent-side) and www.<domain> when opted in.
+	if d.SkipAutoSAN {
+		return out
+	}
 	if d.EmailEnabled {
 		out = append(out, "mail."+d.Name, "autoconfig."+d.Name, "autodiscover."+d.Name)
 	}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2044,10 +2044,37 @@ func TestSANHostnamesForDomain(t *testing.T) {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
-	t.Run("email disabled", func(t *testing.T) {
-		d := &models.Domain{Name: "example.com", EmailEnabled: false}
+	t.Run("email disabled, www out", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: false}
 		if got := sanHostnamesForDomain(d); got != nil {
 			t.Errorf("got %v, want nil", got)
+		}
+	})
+	t.Run("www opt-in adds www (GH #895)", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: false, CreateWWW: true}
+		got := sanHostnamesForDomain(d)
+		if len(got) != 1 || got[0] != "www.example.com" {
+			t.Errorf("got %v, want [www.example.com]", got)
+		}
+	})
+	t.Run("www opt-in + email keeps www first", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: true, CreateWWW: true}
+		got := sanHostnamesForDomain(d)
+		want := []string{"www.example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i, w := range want {
+			if got[i] != w {
+				t.Errorf("[%d]: got %q, want %q", i, got[i], w)
+			}
+		}
+	})
+	t.Run("SkipAutoSAN + www opt-in keeps only www", func(t *testing.T) {
+		d := &models.Domain{Name: "example.com", EmailEnabled: true, MTASTSEnabled: true, SkipAutoSAN: true, CreateWWW: true}
+		got := sanHostnamesForDomain(d)
+		if len(got) != 1 || got[0] != "www.example.com" {
+			t.Errorf("got %v, want [www.example.com]", got)
 		}
 	})
 	t.Run("email enabled", func(t *testing.T) {


### PR DESCRIPTION
Fixes #895: a domain created with the www record **unchecked** still listed `www.<domain>` in its SSL certificate SANs.

## Root cause
The website-cert SAN policy hardcoded `[domain, www.domain]` regardless of `CreateWWW`:
- The **SSL-page display** (`webCertSANsForDomain`) always showed www — reporting coverage the real cert never had (issuance already omitted www).
- Had www ever been requested for an opted-out domain, it would fail HTTP-01 (no www DNS record) and tank the whole cert.

## Fix — gate www on `CreateWWW` in both halves of the ADR-0070 lockstep
- `webCertSANsForDomain` (display) lists www only when opted in; the domain-load fallback no longer assumes www.
- `sanHostnamesForDomain` (issuance) now **adds** www as an extra SAN when opted in (`resolvableSANs` still drops it if the record isn't live yet) — so an opted-in domain finally gets a cert that actually covers `www.<domain>`, which it never did before. Opted-out domains get no www record, no SAN, and no misleading display.

## Test plan
- [x] `TestWebCertSANsForDomain` — rewritten: www present iff CreateWWW, across plain/email/mta-sts/SkipAutoSAN
- [x] `TestSANHostnamesForDomain` — added www opt-in cases (incl. SkipAutoSAN + www)
- [x] full panel-api + reconciler suites
- [ ] live: opted-out domain shows no www SAN; opted-in domain's reissued cert covers www