### PR TITLE
fix(ssl): self-sign placeholder on first tick — HTTPS reachable immediately (GH #896, #887)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2330,8 +2330,19 @@ func (r *Reconciler) reconcileSSLForDomain(ctx context.Context, domain *models.D
 		r.sslEnsureSelfSigned(ctx, domain, cert)
 	default: // SSLModeLE and legacy empty mode
 		switch {
+		// GH #896/#887: on the FIRST reconcile of a fresh domain there is no
+		// cert file yet, and the docroot/vhost is created later in this SAME
+		// ReconcileOne (SSL runs before createDomainOnAgent). Attempting ACME
+		// now fails on a missing webroot (the #887 "docroot does not exist"),
+		// and leaves the site with no :443 during the wait (#896). Instead
+		// bootstrap a self-signed placeholder (no webroot needed): the vhost
+		// step later in this tick re-reads the cert row and serves HTTPS
+		// immediately, and the next tick's self_signed branch upgrades to
+		// Let's Encrypt once the docroot exists.
 		case cert == nil:
-			r.tryACMEOrFallback(ctx, domain, nil)
+			r.sslEnsureSelfSigned(ctx, domain, nil)
+		case cert.Status == models.SSLStatusPending && cert.RetryCount == 0 && cert.CertPath == nil:
+			r.sslEnsureSelfSigned(ctx, domain, cert)
 		case cert.Status == models.SSLStatusPending && cert.RetryCount == 0:
 			r.tryACMEOrFallback(ctx, domain, cert)
 		case cert.Status == models.SSLStatusPendingACMERetry && cert.NextRetryAt != nil && cert.NextRetryAt.Before(time.Now().UTC()):

--- a/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
+++ b/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
@@ -25,7 +25,7 @@ func TestReconcileSSL_ModeRouting(t *testing.T) {
 		ag := &fakeAgent{}
 		dr := &fakeDomainRepo{domains: map[string]*models.Domain{}}
 		sc := newFakeSSLCertRepo()
-		ss := &fakeServerSettingsRepo{settings: &models.ServerSettings{Hostname: "host.example.com"}}
+		ss := &fakeServerSettingsRepo{settings: &models.ServerSettings{Hostname: "host.example.com", AdminEmail: "admin@example.com"}}
 		r := New(dr, nil, ag, slog.Default(), Config{}).WithSSLCerts(sc)
 		r.serverSettings = ss
 		dom := &models.Domain{ID: "d1", Name: "example.com", SSLMode: mode}
@@ -41,6 +41,30 @@ func TestReconcileSSL_ModeRouting(t *testing.T) {
 		ag := run(models.SSLModeSelf, nil)
 		require.True(t, hasCall(ag, "ssl.self_sign"), "self mode must call ssl.self_sign")
 		require.False(t, hasCall(ag, "ssl.issue"), "self mode must NOT attempt ACME")
+	})
+
+	// GH #896/#887: a fresh LE domain (no cert row) must bootstrap a
+	// self-signed placeholder on the first tick — NOT attempt ACME, whose
+	// webroot (the domain's docroot) is created later in the same tick.
+	t.Run("le mode bootstraps self-signed on first tick", func(t *testing.T) {
+		ag := run(models.SSLModeLE, nil)
+		require.True(t, hasCall(ag, "ssl.self_sign"), "le first tick must bootstrap self-signed")
+		require.False(t, hasCall(ag, "ssl.issue"), "le first tick must NOT attempt ACME before the docroot exists")
+	})
+
+	// A fresh pending row with no cert file yet takes the same bootstrap path.
+	t.Run("le mode fresh pending row bootstraps self-signed", func(t *testing.T) {
+		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusPending, RetryCount: 0})
+		require.True(t, hasCall(ag, "ssl.self_sign"))
+		require.False(t, hasCall(ag, "ssl.issue"))
+	})
+
+	// Once a self-signed placeholder exists, the next tick upgrades to LE
+	// (the docroot exists by now), so ACME is attempted.
+	t.Run("le mode self_signed upgrades via ACME", func(t *testing.T) {
+		cp, kp := "/etc/ssl/jabali-selfsigned/example.com/cert.pem", "/etc/ssl/jabali-selfsigned/example.com/key.pem"
+		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusSelfSigned, CertPath: &cp, KeyPath: &kp})
+		require.True(t, hasCall(ag, "ssl.issue"), "self_signed le domain must attempt the LE upgrade")
 	})
 
 	t.Run("none mode revokes issued cert", func(t *testing.T) {


### PR DESCRIPTION
Fixes #896 and #887 — same root cause.

## Root cause
In `ReconcileOne` the order is DNS → **SSL** → `createDomainOnAgent` (which creates the docroot + vhost). So on a fresh domain's first tick:
- The first ACME attempt runs against a webroot (`…/public_html`) that doesn't exist yet → **#887** "does not exist or is not a directory" (hit on new subdomains).
- Until LE eventually succeeds there's no `:443` block → the site is unreachable over HTTPS → **#896**.

## Fix (operator-approved approach)
Bootstrap a **self-signed placeholder** on the first reconcile instead of attempting ACME (reuses `ssl.self_sign` — no webroot needed). The vhost step later in the *same* tick re-reads the cert row (`createDomainOnAgent` already re-fetches SSL paths) and serves HTTPS immediately. The next tick's existing `self_signed → tryACMEOrFallback` branch upgrades to Let's Encrypt once the docroot exists (~60s, the reconcile interval).

Net: every new domain is reachable over HTTPS right away, and certbot never runs before its webroot exists. Tradeoff (approved): a brief self-signed cert until LE upgrades — exactly what the #896 reporter asked for.

## Test plan
- [x] `TestReconcileSSL_ModeRouting` — added: LE first tick bootstraps self-signed (no ssl.issue); fresh pending row same; self_signed row upgrades via ssl.issue
- [x] full reconciler suite
- [ ] live: create a subdomain → HTTPS reachable immediately with self-signed → upgrades to LE within a minute, no "docroot does not exist"