### PR TITLE
fix(appsec): CRS exclusions used a construct that does nothing (JAB-227)

### DIFF
--- a/internal/appseccfg/appseccfg.go
+++ b/internal/appseccfg/appseccfg.go
@@ -126,10 +126,20 @@ const CRSPluginBeforePath = "/var/lib/crowdsec/data/crs-plugins/jabali/jabali-be
 //
 // Jabali CRS-plugin SecRule id range: 9,599,000–9,599,999.
 //
-// Keep every exclusion as NARROW as the evidence: prefer
-// ctl:ruleRemoveTargetById=<rule>;ARGS:<arg> (drop one rule's
-// inspection of one argument) over ruleRemoveById (kills the rule
-// everywhere) or a path-allow (kills the whole WAF for that path).
+// Keep every exclusion as NARROW as the evidence. The construct that would
+// express that best — ctl:ruleRemoveTargetById=<rule>;ARGS:<arg>, dropping one
+// rule's inspection of ONE argument — is a SILENT NO-OP in CrowdSec's Coraza
+// engine. So is ruleRemoveTargetByTag, and so is SecRuleUpdateTargetByTag. All
+// three parse, pass `crowdsec -t`, load without error, and do nothing. Proven
+// 2026-08-04 by A/B on a single-rule payload with only the construct changed:
+// ruleRemoveTargetById left the request blocked (403), ruleRemoveById let it
+// through (404).
+//
+// ctl:ruleRemoveById is the only removal that works, and it drops the rule for
+// the WHOLE matched request. Narrowness therefore has to come from the MATCH:
+// scope the URI tightly, and chain on a wordpress_logged_in_ cookie where the
+// endpoint is authenticated, so unauthenticated traffic keeps full scoring.
+// (ctl: does propagate from a chain — verified.) A path-allow remains banned.
 func CRSPluginBefore() string {
 	return `# Managed by jabali — CRS "before" exclusion plugin.
 # DO NOT hand-edit. Written by ` + "`jabali appsec render-config`" + `.
@@ -151,9 +161,31 @@ func CRSPluginBefore() string {
 # Elementor saves post their payload under actions/data JSON blobs, so 942151
 # ("SQL function name", PL1/CRITICAL → +5 = anomaly threshold → bans alone)
 # still fires. The explicit attack-sqli;ARGS drop on the builder rules below is
-# what neutralizes the SQLi family on builder ARGS (broad on elementor/post.php;
-# Elementor-action-gated on admin-ajax — see 9599210 below).
+# what WOULD neutralize the SQLi family on builder ARGS — except that the
+# attack-sqli tag drop was ctl:ruleRemoveTargetByTag, a silent no-op, and has
+# been removed (JAB-227). That FP class is currently covered only by the
+# upstream plugin above plus the three working ruleRemoveById drops.
 SecAction "id:9599000,phase:1,nolog,pass,setvar:tx.wordpress-rule-exclusions-plugin_enabled=1"
+#
+# !! REMOVED, NOT CONVERTED — JAB-227 !!
+# 9599210 (Elementor SQLi on admin-ajax) and 9599220 (Code Snippets rce +
+# php-injection) expressed their whole effect through
+# ctl:ruleRemoveTargetByTag=<family>;ARGS, which is a SILENT NO-OP in Coraza.
+# They never worked, so they are deleted rather than converted: the working
+# construct drops a rule for the entire request, so saying "exclude the SQLi
+# family from these ARGS" would mean dropping ~19 rules (attack-sqli PL1) or
+# ~27 (attack-rce + attack-injection-php PL1) on those endpoints — a far bigger
+# hole than the false positive, and exactly what crs_plugin_test.go forbids.
+# The same tag drop was also stripped from 9599200/9599202.
+#
+# Consequence, stated plainly: those two false-positive classes are UNADDRESSED
+# again. They were never actually addressed; the directives only looked like it.
+# The ruleRemoveById drops that remain (911100/942550/932370) DO work and are
+# what really fixed GH #404, and the upstream crs-exclusion-plugin-wordpress
+# enabled just above covers much of the same ground.
+#
+# To fix properly: measure which INDIVIDUAL rules still fire on those endpoints
+# and drop those by ID, or get ruleRemoveTargetByTag supported upstream.
 #
 # Allow text/plain as a request Content-Type (arizot-e.com incident,
 # 2026-08-02). CRS 920420 blocks any CT outside tx.allowed_request_content_type
@@ -180,7 +212,8 @@ SecAction "id:9599001,phase:1,nolog,pass,setvar:'tx.allowed_request_content_type
 # Drop ONLY 933120's inspection of ONLY the _wp_http_referer arg, ONLY
 # under /wp-admin/. Body inspection, every other rule, and 933120 on
 # every other arg/path all stay active.
-SecRule REQUEST_URI "@beginsWith /wp-admin/"     "id:9599100,phase:1,pass,nolog,ctl:ruleRemoveTargetById=933120;ARGS:_wp_http_referer"
+SecRule REQUEST_URI "@beginsWith /wp-admin/" "id:9599100,phase:1,pass,nolog,chain"
+    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveById=933120"
 #
 # 911100 / 942550 / 932370 vs WordPress page builders (GH #404). Saving an
 # Elementor page POSTs arbitrary HTML/CSS/JSON markup that trips method-
@@ -203,17 +236,15 @@ SecRule REQUEST_URI "@beginsWith /wp-admin/"     "id:9599100,phase:1,pass,nolog,
 #    args into queries). A broad drop there removes SQLi-args coverage from a
 #    live unauthenticated surface. So on admin-ajax keep the narrow ById drops
 #    broad, and drop attack-sqli;ARGS ONLY when the action is Elementor's
-#    (chained phase:2 rule 9599210 — ARGS:action is parsed in phase 2;
+#    (this was chained phase:2 rule 9599210, now removed — ARGS:action is
 #    jabali-before loads before CRS, so the ctl disables the 942 ARGS target
 #    before those rules evaluate). elementor_ajax / elementor_save_builder both
 #    match ^elementor. Every other admin-ajax handler (incl. nopriv) keeps full
 #    SQLi-args inspection. Still surgical, ADR-0147-consistent: only attack-sqli,
 #    only ARGS; BODY/headers/cookies + every non-SQLi family stay active.
-SecRule REQUEST_URI "@rx ^/wp-json/elementor/"       "id:9599200,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS"
-SecRule REQUEST_URI "@rx ^/wp-admin/post\.php"       "id:9599202,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS"
+SecRule REQUEST_URI "@rx ^/wp-json/elementor/"       "id:9599200,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"
+SecRule REQUEST_URI "@rx ^/wp-admin/post\.php"       "id:9599202,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"
 SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599201,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"
-SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" "id:9599210,phase:2,pass,nolog,chain"
-    SecRule ARGS:action "@rx ^elementor" "t:none,t:lowercase,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS"
 #
 # Code Snippets plugin (JAB-193). POST /wp-json/code-snippets/v1/snippets/<id>
 # saves a PHP snippet, so the JSON body legitimately IS PHP source — <?php,
@@ -237,8 +268,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-admin/admin-ajax.php" "id:9599210,phase:
 #     other family (SQLi, XSS, LFI, traversal, scanner detection) stays fully
 #     active on this path.
 #   - v[0-9]+ so a future API version can't silently re-break saves.
-SecRule REQUEST_URI "@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,pass,nolog,chain"
-    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;REQUEST_BODY,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;REQUEST_BODY"
 # 942100 vs wp-admin/admin-ajax.php (newzaps, observed 2026-08-02..03).
 # admin-ajax.php is WordPress's general-purpose AJAX endpoint: every plugin
 # and the block editor POST arbitrary user-authored content through it —
@@ -263,7 +292,7 @@ SecRule REQUEST_URI "@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,p
 #     every other family, stays fully active on this path — a real injection in
 #     these args is still caught by the rest of the 942 group.
 SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599230,phase:1,pass,nolog,chain"
-    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveTargetById=942100;ARGS,ctl:ruleRemoveTargetById=942100;REQUEST_BODY"
+    SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_" "t:none,ctl:ruleRemoveById=942100"
 # 933120 vs WooCommerce checkout (arizot-e.com incident, 2026-08-02).
 # WooCommerce 8.5+ order attribution submits a field literally named
 # wc_order_attribution_user_agent with every checkout AJAX call — and
@@ -276,7 +305,7 @@ SecRule REQUEST_URI "@rx ^/wp-admin/admin-ajax\.php" "id:9599230,phase:1,pass,no
 # Drop ONLY 933120's inspection of ONLY those two args, ONLY on wc-ajax
 # endpoints. All other rules still inspect both args (a real attack value
 # there is still caught), and 933120 stays active everywhere else.
-SecRule REQUEST_URI "@contains wc-ajax=" "id:9599300,phase:1,pass,nolog,ctl:ruleRemoveTargetById=933120;ARGS:post_data,ctl:ruleRemoveTargetById=933120;ARGS:wc_order_attribution_user_agent"
+SecRule REQUEST_URI "@contains wc-ajax=" "id:9599300,phase:1,pass,nolog,ctl:ruleRemoveById=933120"
 `
 }
 

--- a/internal/appseccfg/appseccfg_test.go
+++ b/internal/appseccfg/appseccfg_test.go
@@ -194,7 +194,7 @@ func TestCRSPluginBefore_WordPressBuilderExclusions(t *testing.T) {
 	// wp/v2 is deliberately NOT excluded — public read surface stays fully inspected.
 	mustNotContain(t, out, `^/wp-json/wp/v2/`, "public wp/v2 REST must keep full CRS coverage")
 	// The original narrow 933120 exclusion is still present.
-	mustContain(t, out, "ctl:ruleRemoveTargetById=933120;ARGS:_wp_http_referer", "933120 _wp_http_referer exclusion intact")
+	mustContain(t, out, "ctl:ruleRemoveById=933120", "933120 wp-admin exclusion intact (now cookie-gated; the target-scoped form was a no-op)")
 	// GH #594: the upstream WordPress CRS-exclusion plugin is activated, which
 	// covers admin-ajax/builder false positives (incl. 942151) comprehensively.
 	mustContain(t, out, "tx.wordpress-rule-exclusions-plugin_enabled=1", "WP exclusion plugin activated")
@@ -202,52 +202,37 @@ func TestCRSPluginBefore_WordPressBuilderExclusions(t *testing.T) {
 	// 180/200/…) can't ban owners — broad on elementor/post.php, but on
 	// admin-ajax ONLY for action=^elementor (chained), so unauthenticated
 	// wp_ajax_nopriv_* handlers keep full SQLi-args inspection.
-	mustContain(t, out, `id:9599210,phase:2,pass,nolog,chain`, "admin-ajax SQLi drop is a chained phase-2 rule")
-	mustContain(t, out, `SecRule ARGS:action "@rx ^elementor"`, "chained on action=^elementor")
+	mustNotContain(t, out, `id:9599210`, "JAB-227: no-op-only rule removed, must not be resurrected")
+	mustNotContain(t, out, "ctl:ruleRemoveTargetByTag=attack-sqli", "JAB-227: dead construct must not return")
 	// admin-ajax phase-1 rule must NOT carry the broad tag drop (only narrow ById).
 	mustContain(t, out, `^/wp-admin/admin-ajax\.php" "id:9599201,phase:1,pass,nolog,ctl:ruleRemoveById=911100,ctl:ruleRemoveById=942550,ctl:ruleRemoveById=932370"`, "admin-ajax phase-1 keeps only narrow ById drops")
 	// Surgical, not blanket: no path-allow, no remediation override.
 	mustNotContain(t, out, `SetRemediation`, "before-plugin must not blanket-allow")
 }
 
-// JAB-193: the Code Snippets REST save carries literal PHP source, so the
-// rce + php-injection families have to stand down there — but ONLY there,
-// ONLY on the body, and ONLY for a request that already carries a WordPress
-// login cookie. An unauthenticated hit on the same path must stay fully
-// scored, which is the property that keeps this from being a path-allow.
-func TestCRSPluginBefore_CodeSnippetsExclusion(t *testing.T) {
+// JAB-193 / JAB-227: the Code Snippets exclusion (9599220) is GONE.
+//
+// It expressed "stand down rce + php-injection on this authenticated REST save"
+// entirely through ctl:ruleRemoveTargetByTag, which is a silent no-op in the
+// Coraza engine CrowdSec ships. It never worked. Converting it would mean
+// dropping ~27 rules (attack-rce + attack-injection-php at PL1) on that path — a
+// far bigger hole than the false positive it was fixing, and exactly what the
+// WAF-hole guard in crs_plugin_test.go exists to forbid.
+//
+// So that FP is unaddressed again, deliberately and visibly, rather than papered
+// over by a directive that reads like protection and provides none. Reopen with
+// per-rule evidence: which single rules actually fire on that endpoint.
+func TestCRSPluginBefore_CodeSnippetsExclusionRemoved(t *testing.T) {
 	out := CRSPluginBefore()
-	mustContain(t, out, `"@rx ^/wp-json/code-snippets/v[0-9]+/" "id:9599220,phase:1,pass,nolog,chain"`,
-		"code-snippets drop is a chained phase-1 rule scoped to the versioned REST path")
-	mustContain(t, out, `SecRule REQUEST_COOKIES_NAMES "@rx ^wordpress_logged_in_"`,
-		"chained on an authenticated WordPress session")
-	for _, tag := range []string{"attack-rce", "attack-injection-php"} {
-		mustContain(t, out, "ctl:ruleRemoveTargetByTag="+tag+";ARGS", tag+" dropped on ARGS")
-		mustContain(t, out, "ctl:ruleRemoveTargetByTag="+tag+";REQUEST_BODY", tag+" dropped on REQUEST_BODY")
-	}
-	// Surgical: the SQLi/XSS/LFI families keep inspecting this path, and the
-	// drop is target-scoped rather than a ruleRemoveById sweep.
-	mustNotContain(t, out, "ctl:ruleRemoveTargetByTag=attack-sqli;REQUEST_BODY",
-		"SQLi must keep inspecting bodies everywhere")
-	// An unversioned or unauthenticated variant must not exist as a
-	// standalone (unchained) exclusion.
-	mustNotContain(t, out, `"@rx ^/wp-json/code-snippets/" "id:`,
-		"no unchained, unversioned code-snippets exclusion")
+	mustNotContain(t, out, "id:9599220", "no-op-only rule must not be resurrected")
+	mustNotContain(t, out, "ctl:ruleRemoveTargetByTag=attack-rce", "dead construct must not return")
+	mustNotContain(t, out, "ctl:ruleRemoveTargetByTag=attack-injection-php", "dead construct must not return")
 }
 
-// 942100 vs wp-admin/admin-ajax.php (newzaps, 26 denies across 5 source
-// addresses, 2026-08-02..03 — including a consumer ISP address repeatedly
-// locked out of the site's own wp-admin).
-//
-// The exclusion must stay identity-scoped, not path-scoped: admin-ajax.php is
-// reachable unauthenticated for plugins registering nopriv_ actions, and that
-// is exactly where WordPress SQLi gets exploited. An unauthenticated request
-// therefore has to keep full libinjection scoring.
 func TestCRSPluginBefore_AdminAjaxLibinjectionIsCookieGated(t *testing.T) {
 	out := CRSPluginBefore()
 
-	mustContain(t, out, "ctl:ruleRemoveTargetById=942100;ARGS", "942100 dropped on ARGS")
-	mustContain(t, out, "ctl:ruleRemoveTargetById=942100;REQUEST_BODY", "942100 dropped on REQUEST_BODY")
+	mustContain(t, out, "ctl:ruleRemoveById=942100", "942100 dropped (ruleRemoveById — the target-scoped form is a silent no-op)")
 
 	// The drop must be chained on the logged-in cookie. Locate the rule and
 	// assert the chain, rather than trusting that the cookie appears anywhere

--- a/internal/appseccfg/crs_plugin_test.go
+++ b/internal/appseccfg/crs_plugin_test.go
@@ -13,14 +13,16 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 	mustContain := []string{
 		`SecRule REQUEST_URI "@beginsWith /wp-admin/"`,
 		`id:9599100`,
-		`ctl:ruleRemoveTargetById=933120;ARGS:_wp_http_referer`,
+		`ctl:ruleRemoveById=933120`, // was target-scoped (silent no-op); now cookie-gated
 		// WooCommerce checkout: order-attribution field name contains
 		// "user_agent" (a php-config-directives.data entry) — 933120 FP on
 		// every checkout. Target-scoped drop on wc-ajax endpoints only.
 		`SecRule REQUEST_URI "@contains wc-ajax="`,
 		`id:9599300`,
-		`ctl:ruleRemoveTargetById=933120;ARGS:post_data`,
-		`ctl:ruleRemoveTargetById=933120;ARGS:wc_order_attribution_user_agent`,
+		// Was two target-scoped drops; both were silent no-ops in Coraza, so the
+		// checkout FP was never actually fixed. ruleRemoveById is the only form
+		// that works, and "wc-ajax=" is narrow enough to contain it.
+		`ctl:ruleRemoveById=933120`,
 		// text/plain must be an allowed request content type (sendBeacon
 		// default; jQuery contentType habit) — pre-seeded WITH the full CRS
 		// default list, not as a lone value, or 901162 skips its defaults and
@@ -49,13 +51,35 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 	// builder false-positive rules and ONLY on a SecRule that is path-scoped
 	// by REQUEST_URI. A bare/global ruleRemoveById, or one targeting any
 	// other rule ID, is a WAF hole.
-	allowedDrops := map[string]bool{"911100": true, "942550": true, "932370": true}
-	for _, line := range strings.Split(body, "\n") {
+	// GH #404 allowed three builder rules. JAB-227 adds two more, because the
+	// target-scoped construct that used to express these narrowly turned out to
+	// be a silent no-op — see CRSPluginBefore's header. Anything outside the
+	// original trio must be CONTAINED: either a tight URI match or a logged-in
+	// cookie chain, asserted separately below.
+	allowedDrops := map[string]bool{
+		"911100": true, "942550": true, "932370": true,
+		"933120": true, // wp-admin referer FP + WooCommerce checkout FP
+		"942100": true, // libinjection vs wp-admin/admin-ajax.php
+	}
+	// Rules whose ctl sits on a chain's second line are URI-scoped by the
+	// chain's FIRST line; track that so the scoping check below stays honest.
+	chained := map[int]bool{}
+	{
+		lines := strings.Split(body, "\n")
+		for i, l := range lines {
+			if strings.HasPrefix(strings.TrimSpace(l), "SecRule REQUEST_URI") && strings.Contains(l, ",chain") {
+				if i+1 < len(lines) {
+					chained[i+1] = true
+				}
+			}
+		}
+	}
+	for i, line := range strings.Split(body, "\n") {
 		if !strings.Contains(line, "ruleRemoveById=") {
 			continue
 		}
-		if !strings.HasPrefix(strings.TrimSpace(line), "SecRule REQUEST_URI") {
-			t.Errorf("ruleRemoveById on a non-REQUEST_URI-scoped rule: %q", line)
+		if !strings.HasPrefix(strings.TrimSpace(line), "SecRule REQUEST_URI") && !chained[i] {
+			t.Errorf("ruleRemoveById on a rule scoped by neither REQUEST_URI nor a URI-scoped chain: %q", line)
 		}
 		// Every ruleRemoveById=<id> on the line must be an allowed builder rule.
 		for _, tok := range strings.Split(line, "ctl:ruleRemoveById=") {
@@ -77,5 +101,61 @@ func TestCRSPluginBefore_Surgical(t *testing.T) {
 	if !strings.Contains(body, "id:95990") && !strings.Contains(body, "id:95991") &&
 		!strings.Contains(body, "id:95992") && !strings.Contains(body, "id:9599") {
 		t.Error("CRSPluginBefore id outside reserved 9,599,000–9,599,999 range")
+	}
+}
+
+// Only ctl:ruleRemoveById has any effect in CrowdSec's Coraza engine. The
+// target-scoped and tag-scoped forms parse, pass `crowdsec -t`, load without
+// error, and then silently do nothing — proven 2026-08-04 by A/B on a
+// single-rule payload (/probe?c=' OR 1=1 -> 942100) from a non-allowlisted
+// source, changing only the construct: ruleRemoveTargetById left it blocked
+// (403), ruleRemoveById let it through (404).
+//
+// Four exclusions shipped for months as placebos because the tests asserted the
+// directive was PRESENT rather than that it WORKED. This guard cannot prove an
+// exclusion works — only a live box can — but it stops the dead forms being
+// reintroduced in the rules themselves.
+func TestCRSPluginBefore_NoDeadRemovalConstructsInRules(t *testing.T) {
+	for _, line := range strings.Split(CRSPluginBefore(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "SecRule") && !strings.HasPrefix(trimmed, "SecAction") {
+			continue // comments may (and do) discuss the dead forms on purpose
+		}
+		for _, dead := range []string{
+			"ctl:ruleRemoveTargetById",
+			"ctl:ruleRemoveTargetByTag",
+			"SecRuleUpdateTargetById",
+			"SecRuleUpdateTargetByTag",
+		} {
+			if strings.Contains(line, dead) {
+				t.Errorf("%s is a SILENT NO-OP in Coraza — the rule will read correctly and "+
+					"do nothing. Use ctl:ruleRemoveById and narrow the MATCH instead: %q", dead, line)
+			}
+		}
+	}
+}
+
+// Widening from per-argument to whole-rule removal is only acceptable because
+// the match compensates. Pin the containment: exclusions on authenticated
+// surfaces stay chained on the logged-in cookie, so an UNAUTHENTICATED request
+// to the same endpoint keeps full CRS scoring.
+func TestCRSPluginBefore_WholeRuleDropsStayContained(t *testing.T) {
+	body := CRSPluginBefore()
+	for _, tc := range []struct{ id, why string }{
+		{"9599100", "/wp-admin/ is authenticated; unauth traffic must keep 933120"},
+		{"9599230", "admin-ajax.php is reachable unauthenticated via nopriv_ actions"},
+	} {
+		idx := strings.Index(body, "id:"+tc.id)
+		if idx < 0 {
+			t.Errorf("rule %s missing", tc.id)
+			continue
+		}
+		seg := body[idx:]
+		if end := strings.Index(seg, "\n#"); end > 0 {
+			seg = seg[:end]
+		}
+		if !strings.Contains(seg, "chain") || !strings.Contains(seg, "wordpress_logged_in_") {
+			t.Errorf("rule %s drops a whole rule without a logged-in cookie gate — %s", tc.id, tc.why)
+		}
 	}
 }


### PR DESCRIPTION
## Every CRS false-positive exclusion was a placebo

They were all written with `ctl:ruleRemoveTargetById` or `ctl:ruleRemoveTargetByTag`. Both are **silent no-ops** in the Coraza engine CrowdSec ships — they parse, pass `crowdsec -t`, load without error, and do nothing.

Proven by A/B on a live box. Isolate a payload that blocks on exactly one rule (`/probe?c=' OR 1=1` → `942100`, confirmed via `cscli alerts inspect`), probe from a host **not** in `jabali-admin-allowlist`, change only the construct:

```
ctl:ruleRemoveTargetById=942100;ARGS   ->  403   (still blocked)
ctl:ruleRemoveById=942100              ->  404   (passed)
```

So `9599300` (WooCommerce checkout), `9599100` (wp-admin referer), `9599210` (Elementor SQLi), `9599220` (Code Snippets) and `9599230` (admin-ajax libinjection) have never worked. **The checkout FP was reported fixed and never was.**

## Not a mechanical conversion

`ruleRemoveById` is the only removal that works, and it drops the rule for the **whole matched request** rather than one argument — strictly coarser. Each exclusion was re-decided:

**Converted** — one rule on a tight scope is defensible:

| rule | drop | containment |
|---|---|---|
| `9599300` | `933120` | `wc-ajax=` only |
| `9599100` | `933120` | `/wp-admin/` + **now** chained on `wordpress_logged_in_` |
| `9599230` | `942100` | `admin-ajax.php` + keeps its cookie chain |

Narrowness now comes from the **match** instead of the target, so unauthenticated requests to those authenticated endpoints keep full CRS scoring. (`ctl:` does propagate from a chain — verified separately.)

**Removed** — converting them would be a security regression:

- `9599210` (attack-sqli on admin-ajax) → would drop ~19 PL1 rules
- `9599220` (attack-rce + attack-injection-php on code-snippets) → ~27 rules
- the attack-sqli tag drop on `9599200`/`9599202`

`crs_plugin_test.go` already forbids exactly that kind of sweep — **it correctly failed my first attempt at a mechanical conversion.** Those two FP classes are therefore unaddressed again, stated plainly in the file rather than left papered over by directives that read like protection and provide none. Fixing them properly needs per-rule evidence: which *individual* rules still fire there.

The working `ruleRemoveById` drops that remain (`911100`/`942550`/`932370`) are what actually fixed GH #404, and the upstream `crs-exclusion-plugin-wordpress` covers much of the same ground.

## Why this shipped at all

The tests asserted the directive was **present** in the rendered output. Presence is not effect. That's the whole bug.

New guards:
- no dead construct may appear in a `SecRule`/`SecAction` (comments may discuss them — they do, at length)
- whole-rule drops on authenticated surfaces must stay cookie-gated
- the WAF-hole allowlist gains `933120`/`942100`, and now understands that a `ctl:` on a chain's second line is URI-scoped by the chain's first

## Live verification

On testserver, from a non-allowlisted source, same `933120` payload:

```
without wc-ajax=  ->  403   (blocked)
with    wc-ajax=  ->  404   (passed)
```

First time that exclusion has ever worked. `crowdsec -t` valid, crowdsec restarts clean, 0 failed units.