### PR TITLE
fix(migrate,crowdsec): close the two half-done acceptance criteria (JAB-219, JAB-222)

### DIFF
--- a/panel-api/cmd/server/crowdsec_apply_order_test.go
+++ b/panel-api/cmd/server/crowdsec_apply_order_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// JAB-222: a settings-backed knob must APPLY TO THE AGENT before it persists to
+// server_settings. The reverse order lets a failed apply leave the database
+// advertising a protection that is not in force — `crowdsec captcha get`
+// reported enabled=true provider=turnstile on a host whose bouncer conf still
+// had an empty SITE_KEY and FALLBACK_REMEDIATION=ban.
+//
+// The REST handler got this right in GH #685; the CLI kept the inverted order
+// for captcha (geoblock was already correct). Same CLI-vs-HTTP parity gap as the
+// delete-cascade divergence in #754, which is why this is a structural guard
+// rather than a one-line fix: the next settings-backed verb should not be able
+// to reintroduce it quietly.
+//
+// Rule enforced: within a single function, if both repo.Upsert(...) and an
+// agent Call(...) appear, the Call must come first.
+func TestCrowdSecCLI_AgentApplyPrecedesSettingsPersist(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "crowdsec_cmd.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		var upsertPos, callPos token.Pos
+
+		ast.Inspect(fn.Body, func(inner ast.Node) bool {
+			call, ok := inner.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Upsert":
+				if upsertPos == token.NoPos {
+					upsertPos = call.Pos()
+				}
+			case "Call":
+				// Only the agent dispatch counts.
+				if x, ok := sel.X.(*ast.Ident); ok && strings.Contains(x.Name, "Agent") {
+					if callPos == token.NoPos {
+						callPos = call.Pos()
+					}
+				}
+			}
+			return true
+		})
+
+		if upsertPos != token.NoPos && callPos != token.NoPos && upsertPos < callPos {
+			t.Errorf("%s persists to server_settings at %s BEFORE dispatching to the agent at %s — "+
+				"a failed apply would leave the database advertising a protection that is not in "+
+				"force (JAB-222). Dispatch first, persist on success.",
+				fn.Name.Name, fset.Position(upsertPos), fset.Position(callPos))
+		}
+		return true
+	})
+}

--- a/panel-api/cmd/server/crowdsec_cmd.go
+++ b/panel-api/cmd/server/crowdsec_cmd.go
@@ -1,8 +1,10 @@
 // CrowdSec + AppSec operational CLI (Gitea #551). Each verb dispatches the same
 // agent command the Security REST handlers use (security_crowdsec.go), so
 // validation/reload/apply stay agent-authoritative. Settings-backed knobs
-// (geoblock, captcha) persist to server_settings then push to the agent, exactly
-// as the handlers do. Mutations are CLI-audited (#537).
+// (geoblock, captcha) APPLY TO THE AGENT FIRST and persist to server_settings
+// only on success, exactly as the handlers do — the reverse order lets a failed
+// apply leave the database advertising a protection that is not in force
+// (JAB-222). Mutations are CLI-audited (#537).
 package main
 
 import (
@@ -496,14 +498,27 @@ func newCsCaptchaSetCmd() *cobra.Command {
 			if enabled && s.CrowdSecCaptchaSecretKey == "" {
 				return fmt.Errorf("--secret-key is required when enabling captcha")
 			}
-			if err := repo.Upsert(ctx, s); err != nil {
-				return fmt.Errorf("persist captcha settings: %w", err)
-			}
+			// JAB-222: apply to the bouncer FIRST, persist only on success.
+			//
+			// This used to Upsert first, so a failed agent apply left
+			// server_settings claiming captcha was enabled while the bouncer conf
+			// was untouched — `jabali crowdsec captcha get` reported
+			// enabled=true provider=turnstile on a host whose SITE_KEY was still
+			// empty and FALLBACK_REMEDIATION still ban. A protection the operator
+			// believed was on, silently inactive at the edge.
+			//
+			// The REST handler has done it in this order since GH #685; the CLI
+			// simply never got the same treatment — the same CLI-vs-HTTP parity
+			// gap as the delete-cascade one in #754. geoblock above already
+			// applies-then-persists; captcha was the outlier.
 			if _, err := sharedAgent.Call(ctx, "security.crowdsec.captcha.apply", map[string]any{
 				"enabled": s.CrowdSecCaptchaEnabled, "provider": s.CrowdSecCaptchaProvider,
 				"site_key": s.CrowdSecCaptchaSiteKey, "secret_key": s.CrowdSecCaptchaSecretKey,
 			}); err != nil {
 				return err
+			}
+			if err := repo.Upsert(ctx, s); err != nil {
+				return fmt.Errorf("persist captcha settings: %w", err)
 			}
 			cliAuditOK(ctx, "crowdsec.captcha_set", "server_settings", "1", nil)
 			fmt.Fprintf(cmd.OutOrStdout(), "captcha enabled=%v provider=%s\n", s.CrowdSecCaptchaEnabled, s.CrowdSecCaptchaProvider)

--- a/panel-api/cmd/server/migrate_restore_cmd.go
+++ b/panel-api/cmd/server/migrate_restore_cmd.go
@@ -140,14 +140,11 @@ same command to resume a failed job.`,
 			if fi.IsDir() {
 				return fmt.Errorf("--file %q is a directory", abs)
 			}
-			// JAB-41: disk preflight BEFORE creating the job, staging the tarball,
-			// or auto-creating the target user — so a low-disk host fails clean
-			// with nothing half-provisioned. ParseTarball re-checks as a backstop.
-			if err := os.MkdirAll("/var/lib/jabali-migrations", 0o750); err == nil {
-				if derr := migrate.CheckExtractDiskSpace(abs, "/var/lib/jabali-migrations"); derr != nil {
-					return derr
-				}
-			}
+			// The disk preflight used to run here, before the job row existed.
+			// It now runs just below, after find-or-create and before staging —
+			// see the JAB-219 note there for why. Ensure the parent staging dir
+			// exists either way so the check has something to statfs.
+			_ = os.MkdirAll("/var/lib/jabali-migrations", 0o750)
 
 			su := sourceUser
 			if su == "" {
@@ -205,6 +202,32 @@ same command to resume a failed job.`,
 				}
 				jobID = row.ID
 				fmt.Printf("  → created migration job %s (%s/%s)\n", jobID, kind, su)
+			}
+
+			// Disk preflight. Position is deliberate and satisfies two issues that
+			// pull in opposite directions:
+			//
+			//   JAB-41 wanted the refusal BEFORE anything is provisioned, so a
+			//   low-disk host does not half-extract and strand a tarball or a
+			//   half-created target user. Staging begins on the next line, so that
+			//   still holds — nothing has been written yet.
+			//
+			//   JAB-219 wanted the refusal to leave something RESUMABLE. Running
+			//   before the job row existed meant migration_jobs had no row at all,
+			//   so the operator could not free space and continue; they had to
+			//   restart the whole command and hope. The job row is metadata, not
+			//   provisioning, so creating it first costs nothing and makes the
+			//   refusal recoverable.
+			//
+			// The job is marked failed with the measured numbers, so `migrate list`
+			// shows why rather than leaving a pending job with no explanation.
+			if derr := migrate.CheckExtractDiskSpace(abs, "/var/lib/jabali-migrations"); derr != nil {
+				msg := derr.Error()
+				if uerr := jobsRepo.UpdateState(ctx, jobID, models.MigrationStateFailed, &msg); uerr != nil {
+					fmt.Printf("  ! could not record the failure on job %s: %v\n", jobID, uerr)
+				}
+				return fmt.Errorf("%w\n  job %s left resumable — free space, then: jabali migrate import --job-id %s",
+					derr, jobID, jobID)
 			}
 
 			staging := filepath.Join("/var/lib/jabali-migrations", jobID)


### PR DESCRIPTION
Both issues shipped with one acceptance criterion left open. This closes them.

## JAB-219 — a refused restore left nothing to resume

The extract disk preflight ran **before** the `migration_jobs` row was created, so a refusal produced no job at all. The operator couldn't free space and continue — they had to restart the whole command.

That position was itself deliberate: JAB-41 put it there so a low-disk host wouldn't half-extract and strand a staged tarball or a half-created target user. The two requirements look opposed, but both hold if the check moves a few lines later — after find-or-create, **before** staging:

- nothing has been written when the check runs, so JAB-41's property is intact
- the job row exists, so the refusal is recoverable

A job row is metadata, not provisioning. The job is now marked `failed` with the measured numbers, and the error names the exact resume command:

```
insufficient disk space to extract cpmove-x.tar.gz: uncompressed contents measure …
  job 01K… left resumable — free space, then: jabali migrate import --job-id 01K…
```

## JAB-222 — the CLI advertised a protection that was not in force

`jabali crowdsec captcha set` persisted to `server_settings` **before** dispatching to the agent. A failed apply therefore left the database claiming captcha was enabled while the bouncer conf was untouched — `crowdsec captcha get` reporting `enabled=true provider=turnstile` on a host whose `SITE_KEY` was still empty and `FALLBACK_REMEDIATION` still `ban`.

The REST handler has applied-then-persisted since GH #685. The CLI never got the same treatment. `geoblock` in the same file was already correct — captcha was the outlier.

That's the same CLI-vs-HTTP parity gap as the delete-cascade divergence in #754, so it's paired with a structural guard rather than left as a one-line swap. `TestCrowdSecCLI_AgentApplyPrecedesSettingsPersist` parses the file and fails any function calling `repo.Upsert` before the agent `Call`.

**Verified the guard fires** by inverting the fix:

```
--- FAIL: TestCrowdSecCLI_AgentApplyPrecedesSettingsPersist
    newCsCaptchaSetCmd persists to server_settings at crowdsec_cmd.go:514:14 BEFORE
    dispatching to the agent at crowdsec_cmd.go:517:17 — a failed apply would leave
    the database advertising a protection that is not in force (JAB-222).
```

then restored and confirmed it passes. A guard that has never fired proves nothing.

The file header also described the wrong pattern — *"persist to server_settings then push to the agent"* — which is presumably how the CLI came to be written that way. Corrected.