### PR TITLE
fix(ssl): `ssl enable` now returns only once nginx serves the real cert (JAB-224)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4747,11 +4747,17 @@ jabali ssl disable <domain>
 
 #### `jabali ssl enable`
 
-Enable SSL for a domain (reconciler will issue cert within ≤60s)
+Enable SSL for a domain and wait until the vhost serves the real certificate
 
 ```
-jabali ssl enable <domain>
+jabali ssl enable <domain> [flags]
 ```
+
+**Flags:**
+
+- `--nginx-dir` — directory holding the enabled nginx vhosts (default `/etc/nginx/sites-enabled`)
+- `--no-wait` — return as soon as the domain is marked, without waiting for the certificate
+- `--wait-timeout` — how long to wait for the vhost to serve the real certificate (default `3m0s`)
 
 #### `jabali ssl list`
 

--- a/panel-api/cmd/server/ssl_cmd.go
+++ b/panel-api/cmd/server/ssl_cmd.go
@@ -14,6 +14,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sslorigin"
 )
 
 func sslRepoFromDB() repository.SSLCertificateRepository {
@@ -86,9 +87,18 @@ func newSSLListCmd() *cobra.Command {
 }
 
 func newSSLEnableCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "enable <domain>",
-		Short:   "Enable SSL for a domain (reconciler will issue cert within ≤60s)",
+	var noWait bool
+	var waitFor time.Duration
+	var nginxDir string
+
+	cmd := &cobra.Command{
+		Use:   "enable <domain>",
+		Short: "Enable SSL for a domain and wait until the vhost serves the real certificate",
+		Long: "Marks the domain for issuance and then WAITS until nginx is actually serving the\n" +
+			"Let's Encrypt certificate, because issuance and vhost repoint happen on separate\n" +
+			"reconciler ticks. Returning at the first tick reports success while the origin is\n" +
+			"still self-signed — which is what makes a Cloudflare Full (strict) cutover return\n" +
+			"526 (JAB-224). Use --no-wait for the old fire-and-forget behaviour.",
 		Args:    cobra.ExactArgs(1),
 		PreRunE: requireDB,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -124,18 +134,66 @@ func newSSLEnableCmd() *cobra.Command {
 					return fmt.Errorf("update cert status: %w", err)
 				}
 			}
-			if jsonOutput {
-				return printJSON(map[string]any{
-					"domain": dom.Name,
-					"status": models.SSLStatusPending,
-					"detail": "reconciler tick will issue cert",
-				})
-			}
 			cliAuditOK(ctx, "ssl.enable", "domain", dom.ID, &dom.UserID)
-			fmt.Printf("SSL enabled for %s — reconciler will issue cert within ≤60s.\n", dom.Name)
-			return nil
+
+			if noWait {
+				if jsonOutput {
+					return printJSON(map[string]any{
+						"domain": dom.Name,
+						"status": models.SSLStatusPending,
+						"detail": "marked for issuance; not waiting",
+					})
+				}
+				fmt.Printf("SSL enabled for %s — reconciler will issue cert within ≤60s (not waiting).\n", dom.Name)
+				return nil
+			}
+
+			// Wait for the END state, not the first tick. Issuance and the vhost
+			// repoint land on different reconciler passes, so a command that
+			// returns after marking the row reports success while the origin is
+			// still self-signed. The check reads the vhost — the file nginx
+			// actually serves — rather than the certificate row, because the row
+			// says "issued" one tick before the repoint happens.
+			if !jsonOutput {
+				fmt.Printf("SSL enabled for %s — waiting for nginx to serve the real certificate (up to %s)...\n",
+					dom.Name, waitFor)
+			}
+
+			deadline := time.Now().Add(waitFor)
+			var last sslorigin.Kind
+			for {
+				o := sslorigin.Classify(dom.Name, nginxDir)
+				if o.Kind != last && !jsonOutput {
+					fmt.Printf("  origin: %s\n", o.Kind)
+					last = o.Kind
+				}
+				if o.Kind == sslorigin.KindLetsEncrypt {
+					if jsonOutput {
+						return printJSON(map[string]any{
+							"domain": dom.Name, "status": models.SSLStatusIssued,
+							"origin": string(o.Kind), "cert_path": o.CertPath,
+						})
+					}
+					fmt.Printf("Done — %s is serving a Let's Encrypt certificate (%s).\n", dom.Name, o.CertPath)
+					return nil
+				}
+				if time.Now().After(deadline) {
+					return fmt.Errorf(
+						"timed out after %s: %s origin is still %q (%s).\n"+
+							"  The domain is marked for issuance, so the reconciler may still complete it —\n"+
+							"  re-check with: jabali ssl readiness --all\n"+
+							"  HTTP-01 cannot succeed until the domain resolves to THIS host, so if it has\n"+
+							"  not cut over yet this is expected, not a failure",
+						waitFor, dom.Name, o.Kind, o.Detail)
+				}
+				time.Sleep(5 * time.Second)
+			}
 		},
 	}
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "return as soon as the domain is marked, without waiting for the certificate")
+	cmd.Flags().DurationVar(&waitFor, "wait-timeout", 3*time.Minute, "how long to wait for the vhost to serve the real certificate")
+	cmd.Flags().StringVar(&nginxDir, "nginx-dir", defaultNginxSitesDir, "directory holding the enabled nginx vhosts")
+	return cmd
 }
 
 func newSSLDisableCmd() *cobra.Command {


### PR DESCRIPTION
## The gap

Issuance and the vhost repoint happen on **separate reconciler ticks**. `ssl enable` returned after marking the row, so it reported success while the origin was still the self-signed placeholder — exactly the window that makes a Cloudflare Full (strict) cutover answer **526**.

An operator following the obvious sequence — enable SSL, then move DNS — had no way to know they were pointing traffic at a self-signed origin.

## What changed

It now waits for the **end state**, and checks the **vhost** (the file nginx actually serves) rather than the certificate row — the row reads `issued` one tick *before* the repoint lands. Reuses `sslorigin.Classify` from the readiness report, so both commands answer the same question the same way.

The timeout is deliberately **not** framed as a failure: HTTP-01 can't succeed until the domain already resolves to this host, so a pre-cutover domain legitimately never completes. The message says so and points at `ssl readiness --all`.

`--no-wait` keeps the previous fire-and-forget behaviour. `--wait-timeout` (default 3m) and `--nginx-dir` are adjustable. **The `--json` path waits too** and reports the final origin + cert path — returning the old `"reconciler tick will issue cert"` payload immediately would have left JSON callers with precisely the misleading result this fixes.

## Verified live on testserver — all three paths

```
$ jabali ssl enable 123123.com
SSL enabled for 123123.com — waiting for nginx to serve the real certificate (up to 3m0s)...
  origin: letsencrypt
Done — 123123.com is serving a Let's Encrypt certificate (/etc/letsencrypt/live/123123.com/fullchain.pem).

$ jabali ssl enable demolab.test --wait-timeout 12s
timed out after 12s: demolab.test origin is still "self-signed" (jabali placeholder — Cloudflare Full (strict) will return 526).
  The domain is marked for issuance, so the reconciler may still complete it —
  re-check with: jabali ssl readiness --all
  HTTP-01 cannot succeed until the domain resolves to THIS host, so if it has
  not cut over yet this is expected, not a failure
exit=1

$ jabali ssl enable demolab.test --no-wait
SSL enabled for demolab.test — reconciler will issue cert within ≤60s (not waiting).
```

Test side-effects on that box reverted: `demolab.test` SSL disabled again, `123123.com`'s cert row restored to `issued`.

## Still open on JAB-224

The remaining criterion is issuing **at** cutover, or pre-issuing via DNS-01 so issuance doesn't depend on the domain already pointing here. This closes the "returns only after the vhost is repointed" criterion and makes the readiness report's worklist safe to act on.