### PR TITLE
feat(appsec): operator-managed CRS false-positive exclusions (JAB-227)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -334,6 +334,45 @@ CrowdSec AppSec config operator subcommands
 jabali appsec
 ```
 
+#### `jabali appsec exclusion`
+
+Manage operator CRS false-positive exclusions
+
+```
+jabali appsec exclusion
+```
+
+##### `jabali appsec exclusion add`
+
+Add an exclusion (host + path + rule are all required)
+
+```
+jabali appsec exclusion add [flags]
+```
+
+**Flags:**
+
+- `--host` — hostname the exclusion applies to (required)
+- `--note` — why this exclusion exists
+- `--rule` — CRS rule ID to exclude, e.g. 942100 (required)
+- `--uri-prefix` — URI prefix the exclusion applies to, e.g. /wp-json/x/ (required)
+
+##### `jabali appsec exclusion list`
+
+List operator CRS exclusions
+
+```
+jabali appsec exclusion list
+```
+
+##### `jabali appsec exclusion rm`
+
+Remove an exclusion by id
+
+```
+jabali appsec exclusion rm <id>
+```
+
 #### `jabali appsec explain`
 
 Show which CRS rules recently blocked requests (AppSec FP triage)

--- a/internal/appseccfg/exclusions.go
+++ b/internal/appseccfg/exclusions.go
@@ -1,0 +1,156 @@
+package appseccfg
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// exclusions.go — JAB-227. Operator-managed CRS false-positive exclusions,
+// rendered into the same before-plugin as the built-in ones.
+//
+// The built-in exclusions cover false positives jabali ships with. This covers
+// the ones only the operator can see: a customer's WhatsApp webhook whose
+// message bodies read as RFI, a plugin's REST route that trips libinjection on
+// ordinary content. Before this existed the only options were editing a file on
+// the box by hand — and knowing that only ctl:ruleRemoveById has any effect,
+// since the target-scoped forms are silent no-ops — or leaving the customer
+// blocked.
+//
+// Two invariants make this safe enough to expose:
+//
+//   - Scope is MANDATORY. ruleRemoveById drops the rule for the entire matched
+//     request, so an exclusion must name both a host and a URI prefix. There is
+//     deliberately no "whole host" or "whole server" form.
+//   - IDs live in 9,597,000-9,597,999, kept clear of the built-in 9,599,xxx
+//     range, so the WAF-hole guard can tell operator entries from shipped ones
+//     and hold them to their own rule.
+
+// OperatorExclusionIDBase is the first SecRule id used for operator-managed
+// exclusions. Distinct from the built-in 9,599,xxx range on purpose.
+const OperatorExclusionIDBase = 9597000
+
+// maxOperatorExclusions caps how many entries render. Each one is a SecRule
+// evaluated on every request, and an unbounded list is a performance problem
+// the operator cannot see. Exceeding it is reported, never silently truncated.
+const maxOperatorExclusions = 900
+
+// Exclusion is one operator-managed rule exclusion.
+type Exclusion struct {
+	Host      string
+	URIPrefix string
+	RuleID    string
+	Note      string
+}
+
+// ValidateExclusion rejects anything that would break the seclang literal or
+// widen the exclusion beyond its intended scope.
+//
+// The quoting checks are not cosmetic: these strings are interpolated into a
+// SecRule, so a stray double-quote would end the directive early and could turn
+// a scoped exclusion into something else entirely.
+func ValidateExclusion(e Exclusion) error {
+	host := strings.ToLower(strings.TrimSpace(e.Host))
+	if host == "" {
+		return fmt.Errorf("host is required — an unscoped exclusion would disable the rule server-wide")
+	}
+	if len(host) > 253 {
+		return fmt.Errorf("host too long")
+	}
+	for _, r := range host {
+		if !(r == '.' || r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return fmt.Errorf("host %q has invalid characters (want [a-z0-9.-])", e.Host)
+		}
+	}
+
+	uri := strings.TrimSpace(e.URIPrefix)
+	if uri == "" {
+		return fmt.Errorf("uri-prefix is required — an exclusion covering the whole host is a WAF hole")
+	}
+	if !strings.HasPrefix(uri, "/") {
+		return fmt.Errorf("uri-prefix %q must start with /", uri)
+	}
+	if len(uri) > 512 {
+		return fmt.Errorf("uri-prefix too long")
+	}
+	if strings.ContainsAny(uri, "\"\\\n\r") {
+		return fmt.Errorf("uri-prefix %q contains a quote, backslash or newline", uri)
+	}
+
+	id := strings.TrimSpace(e.RuleID)
+	n, err := strconv.Atoi(id)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("rule-id %q must be a positive integer", e.RuleID)
+	}
+	// Refuse to drop the anomaly-scoring machinery itself: removing 949110 or
+	// 980170 disables blocking for the path wholesale, which is a path-allow
+	// wearing a rule ID.
+	switch n {
+	case 949110, 949111, 980170:
+		return fmt.Errorf("rule %d is the anomaly-score blocker — excluding it disables the WAF for that path, which is not what an exclusion is for", n)
+	}
+	if n >= 9500000 {
+		return fmt.Errorf("rule %d is in the jabali/plugin reserved range, not a CRS detection rule", n)
+	}
+
+	if strings.ContainsAny(e.Note, "\"\n\r") {
+		return fmt.Errorf("note contains a quote or newline")
+	}
+	return nil
+}
+
+// RenderExclusions emits the operator-managed section of the before-plugin.
+//
+// Deterministic: sorted by (host, uri, rule) so an unchanged set renders
+// byte-identically and the write-on-diff reconcile stays quiet. Invalid entries
+// are skipped with a comment rather than dropped silently — a rule that vanished
+// without explanation is how an operator ends up debugging the wrong thing.
+func RenderExclusions(list []Exclusion) string {
+	if len(list) == 0 {
+		return ""
+	}
+	sorted := make([]Exclusion, len(list))
+	copy(sorted, list)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Host != sorted[j].Host {
+			return sorted[i].Host < sorted[j].Host
+		}
+		if sorted[i].URIPrefix != sorted[j].URIPrefix {
+			return sorted[i].URIPrefix < sorted[j].URIPrefix
+		}
+		return sorted[i].RuleID < sorted[j].RuleID
+	})
+
+	var b strings.Builder
+	b.WriteString("#\n# ---- operator-managed exclusions (JAB-227) ----\n")
+	b.WriteString("# Added via `jabali appsec exclusion add`. Each entry is scoped to ONE host and\n")
+	b.WriteString("# ONE URI prefix, because ctl:ruleRemoveById drops the rule for the whole\n")
+	b.WriteString("# matched request. Chained so the host is checked first: a URI prefix alone\n")
+	b.WriteString("# would apply the exclusion to every tenant that happens to use that path.\n")
+
+	id := OperatorExclusionIDBase
+	rendered := 0
+	for _, e := range sorted {
+		if rendered >= maxOperatorExclusions {
+			fmt.Fprintf(&b, "# !! %d further exclusion(s) NOT rendered — limit of %d reached.\n",
+				len(sorted)-rendered, maxOperatorExclusions)
+			break
+		}
+		if err := ValidateExclusion(e); err != nil {
+			fmt.Fprintf(&b, "# SKIPPED (%s %s rule %s): %v\n", e.Host, e.URIPrefix, e.RuleID, err)
+			continue
+		}
+		host := strings.ToLower(strings.TrimSpace(e.Host))
+		uri := strings.TrimSpace(e.URIPrefix)
+		if e.Note != "" {
+			fmt.Fprintf(&b, "# %s\n", strings.TrimSpace(e.Note))
+		}
+		fmt.Fprintf(&b, "SecRule REQUEST_HEADERS:Host \"@streq %s\" \"id:%d,phase:1,pass,nolog,chain\"\n", host, id)
+		fmt.Fprintf(&b, "    SecRule REQUEST_URI \"@beginsWith %s\" \"t:none,ctl:ruleRemoveById=%s\"\n",
+			uri, strings.TrimSpace(e.RuleID))
+		id++
+		rendered++
+	}
+	return b.String()
+}

--- a/internal/appseccfg/exclusions_test.go
+++ b/internal/appseccfg/exclusions_test.go
@@ -1,0 +1,201 @@
+package appseccfg
+
+import (
+	"strings"
+	"testing"
+)
+
+func validExclusion() Exclusion {
+	return Exclusion{
+		Host:      "arizot-e.com",
+		URIPrefix: "/wp-json/aramapp-leads/v1/inbound",
+		RuleID:    "931120",
+		Note:      "WhatsApp webhook: message text contains URLs",
+	}
+}
+
+// Scope is the whole safety argument. ruleRemoveById drops the rule for the
+// entire matched request, so an exclusion missing either half of its scope
+// would be a WAF hole rather than a false-positive fix.
+func TestValidateExclusion_ScopeIsMandatory(t *testing.T) {
+	for _, tc := range []struct {
+		name, wantErr string
+		mut           func(*Exclusion)
+	}{
+		{"no host", "host is required", func(e *Exclusion) { e.Host = "" }},
+		{"no uri", "uri-prefix is required", func(e *Exclusion) { e.URIPrefix = "" }},
+		{"relative uri", "must start with /", func(e *Exclusion) { e.URIPrefix = "wp-json/x" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validExclusion()
+			tc.mut(&e)
+			err := ValidateExclusion(e)
+			if err == nil {
+				t.Fatalf("want an error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The strings are interpolated into a SecRule. A stray quote would terminate
+// the directive early and could change what the rule does.
+func TestValidateExclusion_RejectsSeclangBreakingInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mut  func(*Exclusion)
+	}{
+		{"quote in uri", func(e *Exclusion) { e.URIPrefix = `/x" "@rx .*` }},
+		{"newline in uri", func(e *Exclusion) { e.URIPrefix = "/x\nSecAction" }},
+		{"backslash in uri", func(e *Exclusion) { e.URIPrefix = `/x\\` }},
+		{"quote in note", func(e *Exclusion) { e.Note = `oops" ` }},
+		{"newline in note", func(e *Exclusion) { e.Note = "a\nb" }},
+		{"bad host chars", func(e *Exclusion) { e.Host = "evil host!" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validExclusion()
+			tc.mut(&e)
+			if err := ValidateExclusion(e); err == nil {
+				t.Error("seclang-breaking input was accepted")
+			}
+		})
+	}
+}
+
+// Excluding the anomaly blocker is a path-allow wearing a rule ID — it turns
+// the WAF off for that path rather than silencing one false positive.
+func TestValidateExclusion_RefusesAnomalyBlockers(t *testing.T) {
+	for _, id := range []string{"949110", "949111", "980170"} {
+		e := validExclusion()
+		e.RuleID = id
+		err := ValidateExclusion(e)
+		if err == nil {
+			t.Errorf("rule %s accepted — that disables blocking for the path", id)
+			continue
+		}
+		if !strings.Contains(err.Error(), "disables the WAF") {
+			t.Errorf("rule %s rejected for the wrong reason: %v", id, err)
+		}
+	}
+}
+
+func TestValidateExclusion_RejectsNonCRSIDs(t *testing.T) {
+	for _, id := range []string{"0", "-1", "abc", "9599100", "9597000"} {
+		e := validExclusion()
+		e.RuleID = id
+		if err := ValidateExclusion(e); err == nil {
+			t.Errorf("rule id %q accepted", id)
+		}
+	}
+}
+
+func TestRenderExclusions_HostChainedAndScoped(t *testing.T) {
+	out := RenderExclusions([]Exclusion{validExclusion()})
+
+	// Host first, URI second — a URI-only match would hit every tenant using
+	// that path.
+	if !strings.Contains(out, `SecRule REQUEST_HEADERS:Host "@streq arizot-e.com"`) {
+		t.Errorf("host not matched first:\n%s", out)
+	}
+	if !strings.Contains(out, `SecRule REQUEST_URI "@beginsWith /wp-json/aramapp-leads/v1/inbound"`) {
+		t.Errorf("uri prefix missing:\n%s", out)
+	}
+	if !strings.Contains(out, "ctl:ruleRemoveById=931120") {
+		t.Errorf("wrong removal construct:\n%s", out)
+	}
+	if !strings.Contains(out, ",chain") {
+		t.Errorf("not chained — host and uri must BOTH be required:\n%s", out)
+	}
+	// Only the working construct may ever be emitted.
+	for _, dead := range []string{"ruleRemoveTargetById", "ruleRemoveTargetByTag", "SecRuleUpdateTarget"} {
+		if strings.Contains(out, dead) {
+			t.Errorf("emitted %s, which is a silent no-op", dead)
+		}
+	}
+	// The operator's note survives, so the file explains itself.
+	if !strings.Contains(out, "WhatsApp webhook") {
+		t.Errorf("note dropped:\n%s", out)
+	}
+}
+
+func TestRenderExclusions_EmptyIsEmpty(t *testing.T) {
+	if got := RenderExclusions(nil); got != "" {
+		t.Errorf("nil list rendered %q", got)
+	}
+}
+
+// Deterministic output keeps write-on-diff quiet: an unchanged set must render
+// byte-identically regardless of the order the rows come back from the DB.
+func TestRenderExclusions_Deterministic(t *testing.T) {
+	a := Exclusion{Host: "b.com", URIPrefix: "/z", RuleID: "942100"}
+	b := Exclusion{Host: "a.com", URIPrefix: "/y", RuleID: "931120"}
+	c := Exclusion{Host: "a.com", URIPrefix: "/y", RuleID: "930120"}
+
+	first := RenderExclusions([]Exclusion{a, b, c})
+	second := RenderExclusions([]Exclusion{c, a, b})
+	if first != second {
+		t.Errorf("output depends on input order:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+	// a.com sorts before b.com; within a.com, 930120 before 931120.
+	if strings.Index(first, "a.com") > strings.Index(first, "b.com") {
+		t.Error("hosts not sorted")
+	}
+	if strings.Index(first, "ruleRemoveById=930120") > strings.Index(first, "ruleRemoveById=931120") {
+		t.Error("rule ids not sorted within a host")
+	}
+}
+
+// Ids must not collide with the built-in 9,599,xxx range, or the two sets would
+// fight and CrowdSec would refuse to load with "duplicated rule id".
+func TestRenderExclusions_IDRangeDoesNotCollide(t *testing.T) {
+	var list []Exclusion
+	for i := 0; i < 5; i++ {
+		e := validExclusion()
+		e.URIPrefix = "/p" + string(rune('a'+i))
+		list = append(list, e)
+	}
+	out := RenderExclusions(list)
+	for i := 0; i < 5; i++ {
+		want := "id:" + itoa(OperatorExclusionIDBase+i)
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %s:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "id:9599") {
+		t.Error("operator ids collided with the built-in 9,599,xxx range")
+	}
+}
+
+// A malformed entry must be reported in the output, not silently dropped — a
+// rule that vanished without explanation is how an operator debugs the wrong
+// thing for an hour.
+func TestRenderExclusions_InvalidEntryIsReportedNotSwallowed(t *testing.T) {
+	bad := validExclusion()
+	bad.RuleID = "949110" // anomaly blocker
+	out := RenderExclusions([]Exclusion{validExclusion(), bad})
+
+	if !strings.Contains(out, "# SKIPPED") {
+		t.Errorf("invalid entry silently dropped:\n%s", out)
+	}
+	if strings.Contains(out, "ctl:ruleRemoveById=949110") {
+		t.Errorf("anomaly blocker rendered anyway:\n%s", out)
+	}
+	// The valid one still renders.
+	if !strings.Contains(out, "ctl:ruleRemoveById=931120") {
+		t.Errorf("valid entry lost:\n%s", out)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var d []byte
+	for n > 0 {
+		d = append([]byte{byte('0' + n%10)}, d...)
+		n /= 10
+	}
+	return string(d)
+}

--- a/panel-api/cmd/server/appsec_cmd.go
+++ b/panel-api/cmd/server/appsec_cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // newAppSecCmd is the operator-facing parent for AppSec config ops
@@ -21,6 +22,7 @@ func newAppSecCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAppSecRenderConfigCmd())
 	cmd.AddCommand(newAppSecExplainCmd())
+	cmd.AddCommand(newAppSecExclusionCmd())
 	return cmd
 }
 
@@ -188,6 +190,38 @@ func writeCRSPluginBefore(cmd *cobra.Command) error {
 		return nil // crowdsec not installed here — nothing to manage
 	}
 	body := appseccfg.CRSPluginBefore()
+
+	// JAB-227: append operator-managed exclusions. They live in the DB rather
+	// than in this static template because only the operator can see the false
+	// positives specific to their tenants' apps. Best-effort: a DB that is not
+	// reachable must not stop the built-in exclusions being written, but the
+	// operator has to be told their entries are missing from this render rather
+	// than left assuming they applied.
+	// render-config deliberately has no requireDB PreRunE: install.sh calls it
+	// early, before the database necessarily exists, and it must still write the
+	// built-in exclusions on such a host. So open the DB best-effort here and
+	// carry on without the operator section if it is not reachable.
+	if sharedDB == nil {
+		if err := initConfig(); err == nil {
+			_ = initDB()
+		}
+	}
+	if sharedDB != nil {
+		excl, err := repository.NewCRSRuleExclusionRepository(sharedDB).List(cmd.Context())
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"! operator CRS exclusions NOT rendered (%v) — built-in exclusions written without them\n", err)
+		} else if len(excl) > 0 {
+			list := make([]appseccfg.Exclusion, 0, len(excl))
+			for _, e := range excl {
+				list = append(list, appseccfg.Exclusion{
+					Host: e.Host, URIPrefix: e.URIPrefix, RuleID: e.RuleID, Note: e.Note,
+				})
+			}
+			body += appseccfg.RenderExclusions(list)
+		}
+	}
+
 	existing, _ := os.ReadFile(appseccfg.CRSPluginBeforePath)
 	if string(existing) == body {
 		return nil

--- a/panel-api/cmd/server/appsec_exclusion_cmd.go
+++ b/panel-api/cmd/server/appsec_exclusion_cmd.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/appseccfg"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// appsec_exclusion_cmd.go — JAB-227.
+//
+// Operator-managed CRS false-positive exclusions. The built-in set in
+// internal/appseccfg covers what jabali ships knowing about; this covers what
+// only the operator can see — a customer's webhook whose message bodies read as
+// RFI, a plugin route that trips libinjection on ordinary content.
+//
+// Before this, the options were hand-editing a file on the box (and knowing that
+// only ctl:ruleRemoveById has any effect, since the target-scoped forms are
+// silent no-ops) or leaving the customer blocked.
+
+func crsExclRepo() repository.CRSRuleExclusionRepository {
+	return repository.NewCRSRuleExclusionRepository(sharedDB)
+}
+
+func newAppSecExclusionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "exclusion",
+		Short: "Manage operator CRS false-positive exclusions",
+		Long: "Exclude a specific CRS rule for a specific host + path.\n\n" +
+			"Scope is mandatory. The only removal construct that works in CrowdSec's engine\n" +
+			"drops the rule for the whole matched request, so every exclusion must name both\n" +
+			"a host and a URI prefix — there is no whole-host or whole-server form.\n\n" +
+			"Find the rule to exclude with: cscli alerts inspect <id>  (look at rule_name).",
+	}
+	cmd.AddCommand(newAppSecExclusionAddCmd(), newAppSecExclusionListCmd(), newAppSecExclusionRmCmd())
+	return cmd
+}
+
+func newAppSecExclusionAddCmd() *cobra.Command {
+	var host, uriPrefix, ruleID, note string
+	cmd := &cobra.Command{
+		Use:     "add",
+		Short:   "Add an exclusion (host + path + rule are all required)",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+
+			e := appseccfg.Exclusion{Host: host, URIPrefix: uriPrefix, RuleID: ruleID, Note: note}
+			if err := appseccfg.ValidateExclusion(e); err != nil {
+				return err
+			}
+			row := &models.CRSRuleExclusion{
+				ID: ids.NewULID(), Host: host, URIPrefix: uriPrefix, RuleID: ruleID, Note: note,
+			}
+			if err := crsExclRepo().Create(ctx, row); err != nil {
+				return fmt.Errorf("save exclusion: %w", err)
+			}
+			cliAuditOK(ctx, "appsec.exclusion_add", "crs_rule_exclusion", row.ID, nil)
+			if jsonOutput {
+				return printJSON(map[string]any{"id": row.ID, "host": host, "uri_prefix": uriPrefix, "rule_id": ruleID})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"added %s — rule %s excluded for %s%s\n"+
+					"  apply with: jabali appsec render-config --reconcile\n",
+				row.ID, ruleID, host, uriPrefix)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&host, "host", "", "hostname the exclusion applies to (required)")
+	cmd.Flags().StringVar(&uriPrefix, "uri-prefix", "", "URI prefix the exclusion applies to, e.g. /wp-json/x/ (required)")
+	cmd.Flags().StringVar(&ruleID, "rule", "", "CRS rule ID to exclude, e.g. 942100 (required)")
+	cmd.Flags().StringVar(&note, "note", "", "why this exclusion exists")
+	_ = cmd.MarkFlagRequired("host")
+	_ = cmd.MarkFlagRequired("uri-prefix")
+	_ = cmd.MarkFlagRequired("rule")
+	return cmd
+}
+
+func newAppSecExclusionListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List operator CRS exclusions",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+			rows, err := crsExclRepo().List(ctx)
+			if err != nil {
+				return fmt.Errorf("list exclusions: %w", err)
+			}
+			if jsonOutput {
+				return printJSON(map[string]any{"exclusions": rows, "total": len(rows)})
+			}
+			if len(rows) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No operator CRS exclusions.")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tHOST\tURI PREFIX\tRULE\tNOTE")
+			for _, r := range rows {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.ID, r.Host, r.URIPrefix, r.RuleID, r.Note)
+			}
+			return w.Flush()
+		},
+	}
+}
+
+func newAppSecExclusionRmCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "rm <id>",
+		Short:   "Remove an exclusion by id",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+			if err := crsExclRepo().DeleteByID(ctx, args[0]); err != nil {
+				return fmt.Errorf("delete exclusion: %w", err)
+			}
+			cliAuditOK(ctx, "appsec.exclusion_rm", "crs_rule_exclusion", args[0], nil)
+			if jsonOutput {
+				return printJSON(map[string]any{"id": args[0], "deleted": true})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(),
+				"removed %s\n  apply with: jabali appsec render-config --reconcile\n", args[0])
+			return nil
+		},
+	}
+}

--- a/panel-api/internal/db/migrations/000251_crs_rule_exclusions.down.sql
+++ b/panel-api/internal/db/migrations/000251_crs_rule_exclusions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS crs_rule_exclusions;

--- a/panel-api/internal/db/migrations/000251_crs_rule_exclusions.up.sql
+++ b/panel-api/internal/db/migrations/000251_crs_rule_exclusions.up.sql
@@ -1,0 +1,22 @@
+-- JAB-227: operator-managed CRS false-positive exclusions.
+--
+-- Before this, excluding a CRS rule for one customer's endpoint meant editing a
+-- file on the box by hand (and knowing that only ctl:ruleRemoveById actually
+-- works in Coraza — the target-scoped forms are silent no-ops). Nothing survived
+-- `jabali update` unless it was placed in a directory jabali does not manage.
+--
+-- Scope is deliberately mandatory: an exclusion must name BOTH a host and a URI
+-- prefix. ruleRemoveById drops the rule for the whole matched request, so an
+-- unscoped entry would be a WAF hole for the entire server.
+CREATE TABLE crs_rule_exclusions (
+  id          varchar(26)  NOT NULL,
+  host        varchar(253) NOT NULL,
+  uri_prefix  varchar(512) NOT NULL,
+  rule_id     varchar(16)  NOT NULL,
+  note        varchar(512) NOT NULL DEFAULT '',
+  created_at  datetime(3)  NOT NULL,
+  updated_at  datetime(3)  NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_crs_excl (host, uri_prefix, rule_id),
+  KEY idx_crs_excl_host (host)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/models/crs_rule_exclusion.go
+++ b/panel-api/internal/models/crs_rule_exclusion.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// CRSRuleExclusion is an operator-managed CRS false-positive exclusion
+// (JAB-227). Host and URIPrefix are both required: the only removal construct
+// that works in Coraza (ctl:ruleRemoveById) drops the rule for the whole
+// matched request, so an unscoped entry would be a WAF hole rather than a
+// false-positive fix. Enforced in appseccfg.ValidateExclusion.
+type CRSRuleExclusion struct {
+	ID        string    `gorm:"column:id;primaryKey;type:varchar(26)"      json:"id"`
+	Host      string    `gorm:"column:host;type:varchar(253);not null"     json:"host"`
+	URIPrefix string    `gorm:"column:uri_prefix;type:varchar(512);not null" json:"uri_prefix"`
+	RuleID    string    `gorm:"column:rule_id;type:varchar(16);not null"   json:"rule_id"`
+	Note      string    `gorm:"column:note;type:varchar(512);not null"     json:"note"`
+	CreatedAt time.Time `gorm:"column:created_at"                          json:"created_at"`
+	UpdatedAt time.Time `gorm:"column:updated_at"                          json:"updated_at"`
+}
+
+func (CRSRuleExclusion) TableName() string { return "crs_rule_exclusions" }

--- a/panel-api/internal/repository/crs_rule_exclusion_repository.go
+++ b/panel-api/internal/repository/crs_rule_exclusion_repository.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// CRSRuleExclusionRepository stores operator-managed CRS exclusions (JAB-227).
+type CRSRuleExclusionRepository interface {
+	List(ctx context.Context) ([]models.CRSRuleExclusion, error)
+	Create(ctx context.Context, e *models.CRSRuleExclusion) error
+	DeleteByID(ctx context.Context, id string) error
+}
+
+type crsRuleExclusionRepo struct{ db *gorm.DB }
+
+func NewCRSRuleExclusionRepository(db *gorm.DB) CRSRuleExclusionRepository {
+	return &crsRuleExclusionRepo{db: db}
+}
+
+// List returns every exclusion, ordered so the rendered plugin is stable.
+func (r *crsRuleExclusionRepo) List(ctx context.Context) ([]models.CRSRuleExclusion, error) {
+	var out []models.CRSRuleExclusion
+	err := r.db.WithContext(ctx).
+		Order("host asc, uri_prefix asc, rule_id asc").
+		Find(&out).Error
+	return out, err
+}
+
+func (r *crsRuleExclusionRepo) Create(ctx context.Context, e *models.CRSRuleExclusion) error {
+	return r.db.WithContext(ctx).Create(e).Error
+}
+
+func (r *crsRuleExclusionRepo) DeleteByID(ctx context.Context, id string) error {
+	return r.db.WithContext(ctx).
+		Where("id = ?", id).
+		Delete(&models.CRSRuleExclusion{}).Error
+}


### PR DESCRIPTION
Closes the half of option 3 I still owed: the box-level fix for the WhatsApp webhook was hand-written config on newzaps; this is the durable mechanism.

## Why

The built-in exclusions cover false positives jabali ships knowing about. This covers the ones **only the operator can see** — a customer's WhatsApp webhook whose message bodies read as RFI, a plugin route that trips libinjection on ordinary editorial content.

Until now the options were: edit a file on the box by hand (and know that only `ctl:ruleRemoveById` has any effect, since the target-scoped forms are silent no-ops), or leave the customer blocked. Neither survives `jabali update` unless placed in a directory jabali doesn't manage.

```
jabali appsec exclusion add --host arizot-e.com \
    --uri-prefix /wp-json/aramapp-leads/v1/inbound \
    --rule 931120 --note "WhatsApp webhook: message text contains URLs"
jabali appsec render-config --reconcile
```

## Keeping it from being a footgun

`ruleRemoveById` drops the rule for the **whole matched request**, so:

- **Scope is mandatory.** Host *and* URI prefix both required — no whole-host or whole-server form. The rendered rule chains host first, then path, so both must match. A path-only match would hit every tenant using that path.
- **Anomaly-score blockers are refused** (`949110`/`949111`/`980170`). Excluding those is a path-allow wearing a rule ID — it turns the WAF off for the path rather than silencing one false positive.

Input is validated before it reaches seclang: quotes, backslashes and newlines in a URI or note are rejected, because these strings are interpolated into a `SecRule` and a stray quote would terminate the directive early. IDs render in **9,597,xxx**, clear of the built-in 9,599,xxx range, so the two sets can't collide into a `duplicated rule id` that refuses to load.

Invalid rows render as `# SKIPPED <reason>` rather than vanishing — a rule that disappeared without explanation is how an operator debugs the wrong thing for an hour. Output is sorted so an unchanged set renders byte-identically and write-on-diff stays quiet.

`render-config` still works on a host with no database (install.sh calls it before one necessarily exists) — it opens the DB best-effort and writes the built-in exclusions alone if it can't.

## Verified end to end on testserver, from a non-allowlisted source

```
/probe?c=' OR 1=1      ->  404    excluded path: WAF passed it
/notprobe?c=' OR 1=1   ->  403    same payload elsewhere: still blocked
```

It works where scoped **and** the scope holds — the behavioural check the placebo exclusions never had. Validation refusals confirmed live too:

```
$ jabali appsec exclusion add --host jabali.site --uri-prefix /probe --rule 949110
rule 949110 is the anomaly-score blocker — excluding it disables the WAF for that path,
which is not what an exclusion is for

$ jabali appsec exclusion add --host jabali.site --uri-prefix probe --rule 942100
uri-prefix "probe" must start with /
```

Tested **without** bumping `schema_migrations` on that box — the table was created directly and dropped afterwards, so testserver stays loadable by a `main`-built binary rather than acquiring the migration-ahead trap.

11 unit tests: mandatory scope, seclang-breaking input, anomaly-blocker refusal, non-CRS ids, host-chained rendering, determinism, id-range collision, and invalid-entry-reported-not-swallowed.