### PR TITLE
fix(ssl): retry issuance after cutover instead of giving up forever (JAB-224)

### DIFF
--- a/panel-api/internal/api/domains_ssl_badge_test.go
+++ b/panel-api/internal/api/domains_ssl_badge_test.go
@@ -211,3 +211,10 @@ func TestSSLBadgeForDomain_ModeAware(t *testing.T) {
 func (m *mockSSLCertsForBadge) RefreshObservedExpiry(context.Context, string, time.Time, time.Time) error {
 	return nil
 }
+
+// JAB-224 ssl_resurrect — unused by these tests.
+func (m *mockSSLCertsForBadge) ListExhaustedForSSLEnabledDomains(context.Context, time.Time, int) ([]models.SSLCertificate, error) {
+	return nil, nil
+}
+
+func (m *mockSSLCertsForBadge) RearmACME(context.Context, string, int, time.Time) error { return nil }

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -767,3 +767,12 @@ func (m *MockDomainRepository) ListForRegistrarRefresh(ctx context.Context, stal
 func (m *MockDomainRepository) SetRegistrarExpiry(ctx context.Context, id string, expiresAt *time.Time, checkedAt time.Time) error {
 	return nil
 }
+
+// JAB-224 ssl_resurrect — unused by these tests.
+func (m *MockSSLCertificateRepository) ListExhaustedForSSLEnabledDomains(context.Context, time.Time, int) ([]models.SSLCertificate, error) {
+	return nil, nil
+}
+
+func (m *MockSSLCertificateRepository) RearmACME(context.Context, string, int, time.Time) error {
+	return nil
+}

--- a/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
+++ b/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
@@ -14,6 +14,11 @@ import (
 type fakeSSLCertRepo struct {
 	byDomain map[string]*models.SSLCertificate
 	revoked  map[string]bool
+	// JAB-224 ssl_resurrect
+	exhausted    []models.SSLCertificate
+	exhaustedErr error
+	rearmErr     error
+	rearmed      map[string]int
 }
 
 func newFakeSSLCertRepo() *fakeSSLCertRepo {
@@ -73,5 +78,34 @@ func newFakeDomainRepo() *fakeDomainRepo {
 
 // RefreshObservedExpiry — JAB-203 observation pass; no behaviour needed here.
 func (f *fakeSSLCertRepo) RefreshObservedExpiry(context.Context, string, time.Time, time.Time) error {
+	return nil
+}
+
+// JAB-224 (ssl_resurrect): exhausted certificates re-armed for another attempt.
+func (f *fakeSSLCertRepo) ListExhaustedForSSLEnabledDomains(_ context.Context, before time.Time, limit int) ([]models.SSLCertificate, error) {
+	if f.exhaustedErr != nil {
+		return nil, f.exhaustedErr
+	}
+	var out []models.SSLCertificate
+	for _, c := range f.exhausted {
+		if c.LastAttemptAt != nil && c.LastAttemptAt.After(before) {
+			continue // still resting
+		}
+		out = append(out, c)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSSLCertRepo) RearmACME(_ context.Context, id string, retryCount int, now time.Time) error {
+	if f.rearmErr != nil {
+		return f.rearmErr
+	}
+	if f.rearmed == nil {
+		f.rearmed = map[string]int{}
+	}
+	f.rearmed[id] = retryCount
 	return nil
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -557,6 +557,10 @@ func (r *Reconciler) Start(ctx context.Context) {
 				continue
 			}
 			r.ReconcileSSLObservation(ctx)
+			// JAB-224: same cadence — an exhausted certificate on an
+			// SSL-enabled domain is re-armed so cutover is picked up without
+			// operator action. Rate-limited inside the pass.
+			r.ReconcileSSLResurrect(ctx)
 		case <-updateRunTicker.C:
 			if r.IsPaused() {
 				continue

--- a/panel-api/internal/reconciler/ssl_resurrect.go
+++ b/panel-api/internal/reconciler/ssl_resurrect.go
@@ -1,0 +1,86 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+)
+
+// ssl_resurrect.go — JAB-224.
+//
+// A certificate that exhausts its ACME attempts is parked at status='failed',
+// and ListDueForACMERetry deliberately skips those: "operator-only (manual reset
+// to 'pending')". That is the right call for a certificate that failed because
+// something is broken — retrying a misconfiguration forever just burns Let's
+// Encrypt quota.
+//
+// It is the wrong call for the case this panel creates constantly. A migrated
+// domain cannot pass HTTP-01 until its DNS points at this host, so before
+// cutover it fails EVERY attempt, by definition. It therefore always exhausts
+// its budget and parks at 'failed' — and then nothing retries it at the one
+// moment issuance would finally succeed: the cutover itself.
+//
+// The result is the 526: the domain goes live still serving jabali's self-signed
+// placeholder, and Cloudflare Full (strict) refuses it. The operator sees a
+// certificate that "failed" hours ago and no indication that it would work now.
+//
+// So: re-arm exhausted certificates on domains where SSL is still wanted, slowly
+// and in small increments, so cutover is picked up automatically without the
+// panel hammering the ACME endpoint for domains that will keep failing.
+
+const (
+	// sslResurrectAfter is how long an exhausted certificate rests before it is
+	// re-armed. It bounds the worst-case window between cutover and issuance.
+	sslResurrectAfter = 1 * time.Hour
+
+	// sslResurrectAttempts is how many attempts each re-arm buys. Let's Encrypt
+	// allows 5 failed validations per hostname per hour; granting 2 per hour
+	// stays well under that even when every domain in a migration batch is
+	// still pre-cutover and failing together.
+	sslResurrectAttempts = 2
+
+	// sslResurrectMaxRetryCount mirrors the giving-up threshold in the ACME
+	// retry path (20 failures -> failed). Re-arming sets the counter near that
+	// ceiling rather than zeroing it, so a re-armed certificate gets a couple of
+	// tries and parks again instead of receiving a full fresh budget every hour.
+	sslResurrectMaxRetryCount = 20
+
+	// sslResurrectBatch caps how many are re-armed per pass, so one tick cannot
+	// queue a whole fleet's worth of ACME work at once.
+	sslResurrectBatch = 25
+)
+
+// ReconcileSSLResurrect re-arms certificates that gave up while SSL is still
+// enabled on the domain, so a post-cutover retry happens without operator
+// action.
+//
+// Best-effort and deliberately quiet when there is nothing to do: on a settled
+// host this finds zero rows and logs nothing.
+func (r *Reconciler) ReconcileSSLResurrect(ctx context.Context) {
+	if r.sslCerts == nil {
+		return
+	}
+	now := time.Now().UTC()
+	certs, err := r.sslCerts.ListExhaustedForSSLEnabledDomains(ctx, now.Add(-sslResurrectAfter), sslResurrectBatch)
+	if err != nil {
+		r.log.Warn("ssl_resurrect: listing exhausted certificates failed", "error", err)
+		return
+	}
+	if len(certs) == 0 {
+		return
+	}
+
+	rearmed := 0
+	for _, c := range certs {
+		if err := r.sslCerts.RearmACME(ctx, c.ID, sslResurrectMaxRetryCount-sslResurrectAttempts, now); err != nil {
+			r.log.Warn("ssl_resurrect: re-arm failed", "cert_id", c.ID, "error", err)
+			continue
+		}
+		rearmed++
+	}
+	if rearmed > 0 {
+		r.log.Info("ssl_resurrect: re-armed exhausted certificates for another attempt",
+			"count", rearmed,
+			"attempts_each", sslResurrectAttempts,
+			"reason", "a pre-cutover domain fails ACME every time and would otherwise never retry after cutover")
+	}
+}

--- a/panel-api/internal/reconciler/ssl_resurrect_test.go
+++ b/panel-api/internal/reconciler/ssl_resurrect_test.go
@@ -1,0 +1,115 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func resurrectReconciler(f *fakeSSLCertRepo) *Reconciler {
+	return &Reconciler{
+		sslCerts: f,
+		log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func exhaustedCert(id string, lastAttempt time.Time) models.SSLCertificate {
+	return models.SSLCertificate{
+		ID:            id,
+		Status:        models.SSLStatusFailed,
+		RetryCount:    20,
+		LastAttemptAt: &lastAttempt,
+	}
+}
+
+// The whole point: a certificate that gave up while SSL is still wanted gets
+// another chance, so cutover is picked up without operator action.
+func TestReconcileSSLResurrect_RearmsExhaustedCert(t *testing.T) {
+	f := newFakeSSLCertRepo()
+	f.exhausted = []models.SSLCertificate{exhaustedCert("c1", time.Now().UTC().Add(-3*time.Hour))}
+
+	resurrectReconciler(f).ReconcileSSLResurrect(context.Background())
+
+	if len(f.rearmed) != 1 {
+		t.Fatalf("want 1 re-armed, got %d", len(f.rearmed))
+	}
+	// Re-arm must NOT zero the counter — that would hand out a full fresh
+	// budget every hour and could breach Let's Encrypt's failed-validation
+	// limits when a whole migration batch is pre-cutover and failing together.
+	got := f.rearmed["c1"]
+	if got == 0 {
+		t.Error("retry counter was zeroed — grants a full budget every cycle")
+	}
+	if want := sslResurrectMaxRetryCount - sslResurrectAttempts; got != want {
+		t.Errorf("retry_count = %d, want %d (i.e. %d attempts)", got, want, sslResurrectAttempts)
+	}
+}
+
+// Rate limiting: a cert that failed moments ago must rest, or the pass would
+// retry hot every tick.
+func TestReconcileSSLResurrect_RespectsRestInterval(t *testing.T) {
+	f := newFakeSSLCertRepo()
+	f.exhausted = []models.SSLCertificate{exhaustedCert("recent", time.Now().UTC().Add(-2*time.Minute))}
+
+	resurrectReconciler(f).ReconcileSSLResurrect(context.Background())
+
+	if len(f.rearmed) != 0 {
+		t.Errorf("re-armed a certificate that failed 2 minutes ago: %v", f.rearmed)
+	}
+}
+
+// One tick must not queue a whole fleet's worth of ACME work.
+func TestReconcileSSLResurrect_BatchCapped(t *testing.T) {
+	f := newFakeSSLCertRepo()
+	old := time.Now().UTC().Add(-6 * time.Hour)
+	for i := 0; i < sslResurrectBatch*3; i++ {
+		f.exhausted = append(f.exhausted, exhaustedCert(string(rune('a'+i%26))+string(rune('a'+i/26)), old))
+	}
+
+	resurrectReconciler(f).ReconcileSSLResurrect(context.Background())
+
+	if len(f.rearmed) > sslResurrectBatch {
+		t.Errorf("re-armed %d in one pass, cap is %d", len(f.rearmed), sslResurrectBatch)
+	}
+}
+
+// Best-effort: a repository error must not take the reconciler tick down.
+func TestReconcileSSLResurrect_SurvivesRepoErrors(t *testing.T) {
+	f := newFakeSSLCertRepo()
+	f.exhaustedErr = errors.New("db down")
+	resurrectReconciler(f).ReconcileSSLResurrect(context.Background()) // must not panic
+
+	f2 := newFakeSSLCertRepo()
+	f2.exhausted = []models.SSLCertificate{exhaustedCert("c1", time.Now().UTC().Add(-3*time.Hour))}
+	f2.rearmErr = errors.New("write failed")
+	resurrectReconciler(f2).ReconcileSSLResurrect(context.Background())
+	if len(f2.rearmed) != 0 {
+		t.Error("counted a re-arm that failed to write")
+	}
+}
+
+// A settled host has nothing to do and must stay quiet.
+func TestReconcileSSLResurrect_NoopWhenNothingExhausted(t *testing.T) {
+	f := newFakeSSLCertRepo()
+	resurrectReconciler(f).ReconcileSSLResurrect(context.Background())
+	if len(f.rearmed) != 0 {
+		t.Errorf("re-armed something on a clean host: %v", f.rearmed)
+	}
+}
+
+// The attempt budget must stay inside Let's Encrypt's failed-validation limit
+// (5 per hostname per hour). Pin the arithmetic so a future tweak to either
+// constant cannot quietly exceed it.
+func TestSSLResurrectStaysUnderLetsEncryptFailureLimit(t *testing.T) {
+	const leFailedValidationsPerHour = 5
+	perHour := float64(sslResurrectAttempts) * (float64(time.Hour) / float64(sslResurrectAfter))
+	if perHour > leFailedValidationsPerHour {
+		t.Errorf("re-arm grants %.1f failed validations/hour, Let's Encrypt allows %d",
+			perHour, leFailedValidationsPerHour)
+	}
+}

--- a/panel-api/internal/repository/ssl_certificate_repository.go
+++ b/panel-api/internal/repository/ssl_certificate_repository.go
@@ -63,6 +63,11 @@ type SSLCertificateRepository interface {
 	UpdateAfterACMEFailureCapped(ctx context.Context, id string, lastError string, retryCount int, fallbackCertPath, fallbackKeyPath *string, fallbackExpiresAt *time.Time) error
 	MarkFailed(ctx context.Context, id string, lastError string) error
 	ListDueForACMERetry(ctx context.Context, now time.Time, limit int) ([]models.SSLCertificate, error)
+	// ListExhaustedForSSLEnabledDomains returns certificates that gave up
+	// (status='failed') on domains where SSL is still wanted. JAB-224.
+	ListExhaustedForSSLEnabledDomains(ctx context.Context, before time.Time, limit int) ([]models.SSLCertificate, error)
+	// RearmACME puts an exhausted certificate back in the retry queue.
+	RearmACME(ctx context.Context, id string, retryCount int, now time.Time) error
 }
 
 type sslCertificateRepo struct{ db *gorm.DB }
@@ -369,4 +374,45 @@ func (r *sslCertificateRepo) FindByDomainIDs(ctx context.Context, domainIDs []st
 		return nil, err
 	}
 	return certs, nil
+}
+
+
+// ListExhaustedForSSLEnabledDomains returns certificates that exhausted their
+// ACME attempts (status='failed') while the domain still has SSL enabled, and
+// whose last attempt is older than `before`.
+//
+// JAB-224. These are the certificates ListDueForACMERetry deliberately ignores.
+// That exclusion is right for a cert that failed because something is broken,
+// and wrong for one that failed because the domain had not cut over yet: an
+// un-cut-over domain fails HTTP-01 every single time, by definition, so it
+// always exhausts its attempts and then stops retrying — including at the
+// moment cutover finally makes issuance possible.
+func (r *sslCertificateRepo) ListExhaustedForSSLEnabledDomains(ctx context.Context, before time.Time, limit int) ([]models.SSLCertificate, error) {
+	var certs []models.SSLCertificate
+	err := r.db.WithContext(ctx).
+		Joins("JOIN domains ON domains.id = ssl_certificates.domain_id").
+		Where("ssl_certificates.status = ?", models.SSLStatusFailed).
+		Where("domains.ssl_enabled = ?", true).
+		Where("ssl_certificates.last_attempt_at IS NULL OR ssl_certificates.last_attempt_at <= ?", before).
+		Order("ssl_certificates.last_attempt_at ASC").
+		Limit(limit).
+		Find(&certs).Error
+	return certs, err
+}
+
+// RearmACME moves an exhausted certificate back to pending_acme_retry, due now.
+//
+// retryCount is set rather than zeroed so the caller controls how many attempts
+// this round buys — re-arming to 0 would hand out a full fresh budget every
+// cycle and could push past Let's Encrypt's failed-validation limits.
+func (r *sslCertificateRepo) RearmACME(ctx context.Context, id string, retryCount int, now time.Time) error {
+	return r.db.WithContext(ctx).
+		Model(&models.SSLCertificate{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"status":        models.SSLStatusPendingACMERetry,
+			"retry_count":   retryCount,
+			"next_retry_at": now,
+			"updated_at":    now,
+		}).Error
 }


### PR DESCRIPTION
## The prevention gap, and why it isn't a design call after all

I'd flagged JAB-224's prevention half as needing a DNS-01 decision. It doesn't — the issue's *first* option is "issues (or **retries until it can issue**) the cert as part of/immediately after cutover", and that's a plain bug.

Two facts combine badly:

- after 20 failed ACME attempts a certificate parks at `status='failed'`
- `ListDueForACMERetry` **excludes `failed`** — *"operator-only (manual reset to 'pending')"*

That exclusion is correct for a certificate that failed because something is broken. It's wrong for the case this panel creates constantly: **a migrated domain cannot pass HTTP-01 until its DNS points at this host**, so before cutover it fails every attempt *by definition*. It always exhausts its budget, parks at `failed`, and then nothing retries it at the one moment issuance would succeed — the cutover itself.

That's the 526. The domain goes live still serving the self-signed placeholder, Cloudflare Full (strict) refuses it, and the operator sees a cert that "failed" hours ago with no hint it would work now.

## The fix

`ReconcileSSLResurrect` re-arms exhausted certificates on domains where SSL is still enabled, on the existing hourly SSL-observation tick.

**Rate limiting is the design**, because the failure mode being fixed is "every domain in a migration batch fails together":

| control | value | why |
|---|---|---|
| rest before re-arm | 1h | bounds the cutover→issuance window |
| attempts per re-arm | 2 | `retry_count` is **set** near the ceiling, not zeroed — a fresh budget every hour would breach LE limits |
| batch per pass | 25 | one tick can't queue a fleet's worth of ACME work |

2 attempts/hour/hostname stays under Let's Encrypt's **5 failed validations per hostname per hour**, and `TestSSLResurrectStaysUnderLetsEncryptFailureLimit` pins that arithmetic so a future tweak to either constant can't quietly exceed it.

6 tests: re-arms an exhausted cert, doesn't zero the counter, respects the rest interval, caps the batch, survives repo errors on both calls, and stays silent on a clean host.

## Still open on JAB-224

DNS-01 pre-issuance. That one *is* a design decision — it needs the panel to write TXT records for domains whose DNS it may not host — and it's untouched here.

## Note

`gofmt -w` on the reconciler package reformatted nine unrelated files (Go 1.19 doc comments). Those were reverted; this touches only the SSL resurrect path plus the two API mocks that had to satisfy the widened repository interface.