### PR TITLE
fix(users): drop the per-user MariaDB shadow-admin account on user delete

### DIFF
--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -679,6 +679,29 @@ func (h *userHandler) delete(c *gin.Context) {
 		}
 	}
 
+	// Drop the per-user MariaDB shadow-admin account (<osuser>_mysqladmin).
+	// db.mysqladmin.ensure provisions it for tenant DB management, but it is
+	// NOT a database_users row, so the loop above never reaps it — leaving an
+	// orphaned MySQL login with a valid password after the account is gone
+	// (found live: ~20 <user>_mysqladmin accounts survived their deleted
+	// owners). Construct the canonical name from the OS username rather than
+	// the stored users.mysqladmin_username, which is null for accounts
+	// provisioned outside the API (e.g. migrated users) whose shadow account
+	// still exists. Reuse db_user.drop (idempotent DROP USER IF EXISTS), so a
+	// user without a shadow account is a harmless no-op.
+	if h.cfg.Agent != nil && username != "" {
+		shadowUser := username + "_mysqladmin"
+		agentCtx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+		_, dropErr := h.cfg.Agent.Call(agentCtx, "db_user.drop", map[string]any{
+			"db_user_name": shadowUser,
+		})
+		cancel()
+		if dropErr != nil {
+			slog.Warn("cascade delete: mysqladmin shadow drop failed",
+				"user_id", id, "mysqladmin_user", shadowUser, "err", dropErr)
+		}
+	}
+
 	// Cascade-tear-down the user's docker apps (M49, GH #170) BEFORE the panel
 	// row CASCADEs the docker_apps metadata. The FK drops the rows, but the
 	// CONTAINERS + data trees on the host outlive the DB without an explicit

--- a/panel-api/internal/api/users_delete_mysqladmin_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mysqladmin_cascade_test.go
@@ -1,0 +1,82 @@
+package api_test
+
+// Deleting a user must also drop the per-user MariaDB shadow-admin account
+// (<osuser>_mysqladmin). It is not a database_users row, so the generic
+// db_user.drop loop misses it — leaving an orphaned MySQL login with a valid
+// password after the account is gone (found live: ~20 orphans on a box).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+// dbUserDropAgent records every db_user.drop name (thread-safe: the cascade
+// may fire from background goroutines).
+type dbUserDropAgent struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (a *dbUserDropAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	if cmd == "db_user.drop" {
+		if m, ok := params.(map[string]any); ok {
+			if s, ok := m["db_user_name"].(string); ok {
+				a.mu.Lock()
+				a.seen = append(a.seen, s)
+				a.mu.Unlock()
+			}
+		}
+	}
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+func (a *dbUserDropAgent) dropped(name string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, s := range a.seen {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUserDelete_DropsMysqladminShadow(t *testing.T) {
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	repo.seed(admin)
+	victim := makeUser(t, "victim@example.com", false, "victimpassword")
+	uname := "victim"
+	victim.Username = &uname
+	repo.seed(victim)
+
+	ag := &dbUserDropAgent{}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	claims := &auth.AccessClaims{UserID: admin.ID, IsAdmin: true}
+	g := r.Group("/api/v1", func(c *gin.Context) {
+		ginctx.SetClaims(c, claims)
+		c.Next()
+	})
+	api.RegisterUserRoutes(g, api.UserHandlerConfig{
+		Repo:  repo,
+		Agent: ag,
+	})
+
+	rec := doJSON(t, r, http.MethodDelete, "/api/v1/users/"+victim.ID, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	require.True(t, ag.dropped("victim_mysqladmin"),
+		"user delete must drop the <osuser>_mysqladmin shadow account")
+}


### PR DESCRIPTION
Found while cleaning up after the #723 Hestia migration E2E: `jabali user delete` reaps a user's databases and `database_users` rows, but never the per-user `<osuser>_mysqladmin` MariaDB account that `db.mysqladmin.ensure` provisions for tenant DB management. It isn't a `database_users` row, so the cascade's `db_user.drop` loop skips it — leaving an **orphaned MySQL login with a valid password** after the account and its `/home` are gone.

Confirmed live on testserver: **~20 `<user>_mysqladmin` accounts survived their deleted owners** (only 4 live panel users at the time).

## Fix
Drop the shadow account in the delete cascade, reusing the idempotent `db_user.drop` (`DROP USER IF EXISTS`). The name is constructed as `<osuser>_mysqladmin` rather than read from `users.mysqladmin_username`, because that column is null for accounts provisioned outside the API (e.g. migrated users) whose shadow account still exists — which is exactly where an orphan was observed. A user with no shadow account is a harmless no-op.

Scope: only the MariaDB shadow orphans — no `_pgadmin`/`_pma` orphans exist on the box (checked).

## Test plan
- [x] `TestUserDelete_DropsMysqladminShadow` — asserts the cascade calls `db_user.drop` with `<username>_mysqladmin`
- [x] full panel-api suite
- [ ] live: delete a user, confirm `<user>_mysqladmin` is gone from `mysql.user`