### PR TITLE
fix(migrate): stop importing cPanel service subdomains that fail the cert (JAB-226)

### DIFF
--- a/panel-api/internal/migrate/cpanel/bind_parse.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse.go
@@ -401,6 +401,7 @@ func ImportDNS(
 		filtered := zone.Records[:0]
 		apexFiltered := false
 		mailFiltered := false
+		serviceFiltered := false
 		ipRewritten := false
 		for _, r := range zone.Records {
 			isApex := r.Name == zone.Origin || r.Name == "@"
@@ -419,11 +420,29 @@ func ImportDNS(
 			// CNAMEs) and regenerates them for THIS server whenever the domain uses
 			// jabali mail, so importing the source's would duplicate jabali's set
 			// and pin the OLD server's SPF ip4: / DKIM selector. A non-mail domain
-			// gets none (ImportDomains sets MailProvider "none"). The `mail` A is
-			// intentionally kept (rewriting its IP to this server is a follow-up):
-			// dropping it would leave the MX target unresolvable.
+			// gets none (ImportDomains sets MailProvider "none").
+			//
+			// JAB-226 reverses the previous "keep the `mail` record" decision.
+			// Its stated reason was that dropping it would leave the MX target
+			// unresolvable, and that does not hold: every imported MX is dropped
+			// unconditionally by the MX case below, and dnscompile/bootstrap.go
+			// generates BOTH `@ MX mail.<zone>` and `mail A <this server>` for a
+			// domain that uses jabali mail. So the imported record is redundant
+			// when jabali mail is on, and an orphan pointing at the OLD box when
+			// it is off — and either way it lands in the certificate SAN, where
+			// it 404s HTTP-01 and fails the whole cert. A source `mail` CNAME
+			// alongside jabali's generated `mail` A is also a CNAME-plus-other-
+			// data conflict.
 			if isMailInfraRecord(toPanelRecordName(r.Name, zone.Origin), r.Type, r.Content) {
 				mailFiltered = true
+				continue
+			}
+			// JAB-226: cPanel's own control-panel hostnames. Nothing on jabali
+			// serves cpanel./whm./webdisk./ftp./cpcalendars./cpcontacts., and
+			// leaving them in DNS puts them in the certificate SAN where they
+			// fail HTTP-01 and take the whole cert down with them.
+			if isCPanelServiceRecord(toPanelRecordName(r.Name, zone.Origin)) {
+				serviceFiltered = true
 				continue
 			}
 			// Repoint any A record that pointed at the old server (incl. the
@@ -439,6 +458,9 @@ func ImportDNS(
 		}
 		if mailFiltered {
 			res.Skipped = append(res.Skipped, "mail_infra_handled_by_jabali:"+zone.Origin)
+		}
+		if serviceFiltered {
+			res.Skipped = append(res.Skipped, "cpanel_service_subdomains_dropped:"+zone.Origin)
 		}
 		if ipRewritten {
 			res.Skipped = append(res.Skipped, "source_ip_repointed_to_this_server:"+zone.Origin)
@@ -499,11 +521,11 @@ func ImportDNS(
 				continue
 			}
 			rec := &models.DNSRecord{
-				ID:        ids.NewULID(),
-				ZoneID:    pz.ID,
-				Name:      pname,
-				Type:      r.Type,
-				Content:   r.Content,
+				ID:      ids.NewULID(),
+				ZoneID:  pz.ID,
+				Name:    pname,
+				Type:    r.Type,
+				Content: r.Content,
 				// GH #527: normalize migrated records to the panel's default
 				// TTL (fallback to the parsed source TTL only when no default
 				// is supplied) so a migrated zone is consistent with what the
@@ -555,13 +577,45 @@ func toPanelRecordName(name, origin string) string {
 // DMARC / client-service SRVs / autoconfig CNAMEs for THIS server. The `mail` A
 // is NOT dropped here (it is the MX target and jabali does not re-create it for
 // imported zones); repointing its IP to this server is a separate follow-up.
+// cpanelServiceHostnames are subdomains cPanel creates for its own control
+// panel and client-service endpoints. They are meaningless on jabali — nothing
+// serves them here — and importing them is actively harmful: the per-domain
+// Let's Encrypt SAN is built from DNS, so each one becomes a hostname that must
+// pass HTTP-01. Pre-cutover they still resolve to the source box and 404, which
+// fails the entire certificate (JAB-226).
+var cpanelServiceHostnames = map[string]bool{
+	"cpanel":      true,
+	"whm":         true,
+	"webdisk":     true,
+	"cpcalendars": true,
+	"cpcontacts":  true,
+	"ftp":         true,
+}
+
+// isCPanelServiceRecord reports whether a record is one of cPanel's own service
+// hostnames. Matched on the leaf label for every record type: cPanel writes some
+// as A and some as CNAME depending on the account's setup, and the reason to
+// drop them does not depend on the type.
+func isCPanelServiceRecord(name string) bool {
+	return cpanelServiceHostnames[strings.ToLower(strings.TrimSpace(name))]
+}
+
 func isMailInfraRecord(name, typ, content string) bool {
 	lc := strings.ToLower(strings.TrimSpace(content))
 	switch typ {
 	case "MX":
 		return true
-	case "CNAME":
-		return name == "webmail" || name == "autoconfig" || name == "autodiscover"
+	case "CNAME", "A", "AAAA":
+		// JAB-226: cPanel writes these as A records at least as often as CNAMEs.
+		// Matching only CNAME let the A variants through, and because the
+		// per-domain LE certificate builds its SAN from what is in DNS, every
+		// migrated domain then tried to validate autoconfig./autodiscover./
+		// webmail. — which still resolve to the OLD box until the source NS
+		// stops being authoritative, 404 the HTTP-01 challenge, and fail the
+		// WHOLE certificate. The domain is then stuck on a self-signed origin,
+		// which behind Cloudflare Full (strict) is a hard 526 outage.
+		return name == "webmail" || name == "autoconfig" ||
+			name == "autodiscover" || name == "mail"
 	case "TXT":
 		lc = strings.Trim(lc, `"`)
 		if strings.HasPrefix(lc, "v=spf1") || strings.HasPrefix(lc, "v=dmarc1") || strings.HasPrefix(lc, "v=tlsrptv1") {

--- a/panel-api/internal/migrate/cpanel/bind_parse_jab226_test.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse_jab226_test.go
@@ -1,0 +1,109 @@
+package cpanel
+
+import "testing"
+
+// JAB-226. The per-domain Let's Encrypt certificate builds its SAN from what is
+// in DNS, so every junk hostname imported from a cPanel zone becomes a name that
+// must pass HTTP-01. Before cutover completes they still resolve to the SOURCE
+// box and 404 the challenge — and one failed name fails the WHOLE certificate.
+// The domain then sits on a self-signed origin, which behind Cloudflare Full
+// (strict) is a hard 526.
+//
+// Observed on newhighsite: "Requesting a certificate for … and 3 more domains"
+// -> autoconfig./autodiscover./mail. 404 -> "Some challenges have failed".
+
+// The regression that let it happen: the mail-infra filter matched these names
+// only as CNAME, and cPanel writes them as A at least as often.
+func TestIsMailInfraRecord_DropsWebmailFamilyAsAAndCNAME(t *testing.T) {
+	for _, name := range []string{"webmail", "autoconfig", "autodiscover"} {
+		for _, typ := range []string{"CNAME", "A", "AAAA"} {
+			if !isMailInfraRecord(name, typ, "1.2.3.4") {
+				t.Errorf("%s %s not filtered — it lands in the cert SAN and 404s HTTP-01", name, typ)
+			}
+		}
+	}
+}
+
+func TestIsCPanelServiceRecord(t *testing.T) {
+	for _, name := range []string{"cpanel", "whm", "webdisk", "ftp", "cpcalendars", "cpcontacts"} {
+		if !isCPanelServiceRecord(name) {
+			t.Errorf("%s should be dropped — nothing on jabali serves it", name)
+		}
+		// Case must not matter; zone files are inconsistent.
+		if !isCPanelServiceRecord(upper(name)) {
+			t.Errorf("%s not matched case-insensitively", name)
+		}
+	}
+}
+
+// The filter must not eat a customer's real subdomain. "ftp" is the risky one —
+// it is a plausible real hostname — but on a cPanel source it is cPanel's own
+// service record, and jabali serves SFTP rather than a per-domain ftp host.
+// Everything that is not on the list must survive.
+func TestIsCPanelServiceRecord_LeavesRealSubdomainsAlone(t *testing.T) {
+	for _, name := range []string{
+		"www", "shop", "staging", "api", "app", "dev", "blog",
+		"cpanel-backup", "myftp", "ftps", "whmcs", // near-misses, must NOT match
+	} {
+		if isCPanelServiceRecord(name) {
+			t.Errorf("%q was dropped — that is a customer subdomain, not a cPanel service host", name)
+		}
+	}
+}
+
+// Apex must never be swallowed by the service filter.
+func TestIsCPanelServiceRecord_IgnoresApex(t *testing.T) {
+	for _, name := range []string{"", "@"} {
+		if isCPanelServiceRecord(name) {
+			t.Errorf("apex %q dropped", name)
+		}
+	}
+}
+
+func upper(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 32
+		}
+	}
+	return string(b)
+}
+
+// JAB-226 reverses an earlier deliberate choice to keep the source's `mail`
+// record. That reason ("dropping it would leave the MX target unresolvable")
+// does not hold: every imported MX is dropped unconditionally, and
+// dnscompile/bootstrap.go generates both `@ MX mail.<zone>` and
+// `mail A <this server>` when the domain uses jabali mail. The imported one is
+// redundant at best, an orphan pointing at the OLD box at worst — and it lands
+// in the certificate SAN either way.
+func TestIsMailInfraRecord_DropsImportedMailRecord(t *testing.T) {
+	for _, typ := range []string{"A", "AAAA", "CNAME"} {
+		if !isMailInfraRecord("mail", typ, "1.2.3.4") {
+			t.Errorf("mail %s survived import — it enters the cert SAN and 404s HTTP-01", typ)
+		}
+	}
+	// Imported MX is dropped regardless, which is why keeping `mail` bought
+	// nothing. Pin it so the justification above stays true.
+	if !isMailInfraRecord("@", "MX", "mail.example.com") {
+		t.Error("imported MX survived — the whole rationale for dropping `mail` rests on this")
+	}
+}
+
+// Every service hostname a real cPanel zone actually emits, verbatim from
+// /var/named/<domain>.db on a live source box. All of them are A records, which
+// is exactly what the CNAME-only filter missed.
+func TestRealCPanelZone_AllServiceHostnamesFiltered(t *testing.T) {
+	realZone := []struct{ name, typ string }{
+		{"mail", "CNAME"},
+		{"ftp", "A"}, {"webdisk", "A"}, {"cpcalendars", "A"}, {"cpcontacts", "A"},
+		{"webmail", "A"}, {"cpanel", "A"}, {"whm", "A"},
+		{"autodiscover", "A"}, {"autoconfig", "A"},
+	}
+	for _, r := range realZone {
+		if isMailInfraRecord(r.name, r.typ, "1.2.3.4") || isCPanelServiceRecord(r.name) {
+			continue
+		}
+		t.Errorf("%s %s would be imported — 9 such names in one zone is what failed the cert", r.name, r.typ)
+	}
+}


### PR DESCRIPTION
## Why one junk DNS record kills a whole certificate

The per-domain LE cert builds its **SAN from DNS**, so every hostname imported from a cPanel zone becomes a name that must pass HTTP-01. Before the source NS stops being authoritative they still resolve to the **old** box and 404 — and one failed name fails the **entire** certificate. The domain then sits on a self-signed origin, which behind Cloudflare Full (strict) is a hard 526.

Observed on newhighsite: `Requesting a certificate for … and 3 more domains` → `autoconfig./autodiscover./mail. 404` → `Some challenges have failed`.

## Two gaps, confirmed against a real zone

Pulled from `/var/named/<domain>.db` on a live cPanel source:

```
mail          IN CNAME
ftp           IN A
webdisk       IN A
cpcalendars   IN A
cpcontacts    IN A
webmail       IN A
cpanel        IN A
whm           IN A
autodiscover  IN A
autoconfig    IN A
```

**1. The mail-infra filter matched `webmail`/`autoconfig`/`autodiscover` only as `CNAME`.** cPanel writes them as `A`. All three sailed through — precisely the three names in the reported failure. Now matched for `A`/`AAAA`/`CNAME`.

**2. `cpanel`/`whm`/`webdisk`/`ftp`/`cpcalendars`/`cpcontacts` had no filter at all.** Nothing on jabali serves them. Dropped by leaf label for every record type, since cPanel emits them as A or CNAME depending on the account and the reason to drop doesn't depend on the type.

That's **9 junk SAN entries from a single zone**.

## Reversing an earlier decision, deliberately

The code kept the source's `mail` record, commented as *"dropping it would leave the MX target unresolvable"*. That no longer holds:

- every imported `MX` is dropped unconditionally by the `MX` case
- `dnscompile/bootstrap.go` generates **both** `@ MX mail.<zone>` **and** `mail A <this server>` for a domain using jabali mail

So the imported record is redundant when jabali mail is on, an orphan pointing at the old box when it's off, and a source `mail` CNAME beside jabali's generated `mail` A is a CNAME-plus-other-data conflict. The stale comment is replaced rather than left contradicting the code.

## Tests

The real zone is pinned verbatim — all ten hostnames with their actual record types — alongside near-miss names (`myftp`, `ftps`, `cpanel-backup`, `whmcs`) that must **not** be filtered, so the guard can't start eating customer subdomains.

## Still open on JAB-226

Limiting the SAN to hostnames jabali actually serves, and pruning pdns records absent from `dns_records`. This fixes the *source* of the junk; those two are about junk already present on migrated boxes.