### PR TITLE
fix(cli): drop the mysqladmin shadow account in the CLI user-delete path too

### DIFF
--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -151,6 +151,21 @@ func deleteUserDirect(ctx context.Context, userID string, purgeHome bool) error 
 		}
 	}
 
+	// Drop the per-user MariaDB shadow-admin account (<osuser>_mysqladmin).
+	// It is provisioned by db.mysqladmin.ensure but is not a database_users
+	// row, so the loop above misses it — an orphaned MySQL login otherwise
+	// survives the deleted account. Mirrors the HTTP delete cascade. Reuses
+	// the idempotent db_user.drop (DROP USER IF EXISTS): a no-op when absent.
+	if sharedAgent != nil && target.Username != nil && *target.Username != "" {
+		shadowUser := *target.Username + "_mysqladmin"
+		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		if _, err := sharedAgent.Call(agentCtx, "db_user.drop", map[string]any{"db_user_name": shadowUser}); err != nil {
+			slog.Warn("cli delete: mysqladmin shadow drop failed",
+				"user_id", userID, "mysqladmin_user", shadowUser, "err", err)
+		}
+		cancel()
+	}
+
 	// Kratos identity delete (if linked).
 	if target.KratosIdentityID != nil && sharedCfg.Auth.Kratos.PublicURL != "" {
 		k := kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL)


### PR DESCRIPTION
Follow-up to #923. That fixed the **HTTP** delete cascade, but `jabali user delete` runs a *separate* `deleteUserDirect` path (the #754 dual-path scar) — so a CLI-deleted user still orphaned its `<osuser>_mysqladmin` MariaDB account.

Caught in the #923 live E2E: after #923 deployed, I created `gh923test`, confirmed `gh923test_mysqladmin` was provisioned, ran `jabali user delete gh923test`, and the shadow account **survived** (count still 1) — because the CLI never went through the fixed HTTP handler.

## Fix
Mirror the cascade in `deleteUserDirect`: after the `db_user.drop` loop, drop `<osuser>_mysqladmin` via the idempotent `db_user.drop`. No-op when absent.

## Test plan
- [x] build
- [ ] live: `jabali user delete` a fresh user → `<user>_mysqladmin` gone from `mysql.user` (the exact case that failed pre-fix)