### PR TITLE
fix(migrate): setgid the restored docroot subtree so tenant-created dirs work (JAB-229)

### DIFF
--- a/internal/fsperm/setgid_inherit_test.go
+++ b/internal/fsperm/setgid_inherit_test.go
@@ -1,0 +1,101 @@
+package fsperm
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// JAB-229. The property that actually matters is INHERITANCE, not the bits on
+// the directories the restore happened to create.
+//
+// jabali's isolation model assumes a docroot is setgid www-data, so anything the
+// tenant's PHP-FPM worker creates inherits group www-data — nginx serves as
+// www-data and has to traverse it. A migrated tree arrived with the source's
+// ownership and no setgid below public_html. Existing directories had been
+// chgrp'd, so the site looked healthy; the first directory WordPress created on
+// its own (a new uploads/YYYY/MM on the 1st) inherited the tenant's primary
+// group instead and came out drwxr-x--- <user>:<user> under umask 027. New
+// uploads 404'd as blank thumbnails while old media still served.
+//
+// So this asserts the inherited group of a NEWLY created subdirectory, which is
+// what breaks, rather than asserting the mode of what already exists.
+func TestRepairDocrootGroup_NewSubdirInheritsGroup(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("runs as an unprivileged user; chgrp to an arbitrary gid would succeed as root")
+	}
+	// Use one of our own supplementary groups as the stand-in for www-data —
+	// an unprivileged process may only chgrp to a group it belongs to.
+	groups, err := os.Getgroups()
+	if err != nil || len(groups) == 0 {
+		t.Skip("no supplementary groups available")
+	}
+	target := -1
+	for _, g := range groups {
+		if g != os.Getegid() {
+			target = g
+			break
+		}
+	}
+	if target < 0 {
+		t.Skip("no group distinct from the primary one to test inheritance against")
+	}
+
+	home := t.TempDir()
+	docroot := filepath.Join(home, "domains", "example.com", "public_html")
+	deep := filepath.Join(docroot, "wp-content", "uploads", "2026", "07")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("seed tree: %v", err)
+	}
+
+	if err := RepairDocrootGroup(home, docroot, target); err != nil {
+		t.Fatalf("RepairDocrootGroup: %v", err)
+	}
+
+	// The subtree — not just the top level — must carry setgid, or a directory
+	// created deeper down inherits the wrong group.
+	for _, dir := range []string{
+		docroot,
+		filepath.Join(docroot, "wp-content"),
+		filepath.Join(docroot, "wp-content", "uploads"),
+		deep,
+	} {
+		fi, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if fi.Mode()&os.ModeSetgid == 0 {
+			t.Errorf("%s is not setgid — a directory created under it inherits the tenant's group", dir)
+		}
+		st, ok := fi.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Fatal("no syscall.Stat_t")
+		}
+		if int(st.Gid) != target {
+			t.Errorf("%s group = %d, want %d", dir, st.Gid, target)
+		}
+	}
+
+	// The actual regression: create a NEW month folder the way WordPress would,
+	// under a restrictive umask, and check what it inherited.
+	old := syscall.Umask(0o027)
+	defer syscall.Umask(old)
+
+	newMonth := filepath.Join(deep, "..", "08")
+	if err := os.Mkdir(newMonth, 0o755); err != nil {
+		t.Fatalf("mkdir new month: %v", err)
+	}
+	fi, err := os.Stat(newMonth)
+	if err != nil {
+		t.Fatalf("stat new month: %v", err)
+	}
+	st := fi.Sys().(*syscall.Stat_t)
+	if int(st.Gid) != target {
+		t.Errorf("newly created month folder group = %d, want %d — this is the upload break: "+
+			"nginx (www-data) cannot traverse a dir owned by the tenant's primary group", st.Gid, target)
+	}
+	if fi.Mode()&os.ModeSetgid == 0 {
+		t.Error("new directory did not inherit setgid — the NEXT level down would break instead")
+	}
+}

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/fsperm"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"gorm.io/gorm"
@@ -1562,6 +1563,47 @@ func cpanelRestoreCallback(
 			warnings = append(warnings, shadowRes.Quarantined...)
 			warnings = append(warnings, shadowRes.Flagged...)
 			warnings = append(warnings, shadowRes.Skipped...)
+		}
+
+		// JAB-229: re-apply setgid + group www-data across every restored
+		// docroot, AFTER the files are on disk.
+		//
+		// jabali's isolation model relies on docroots being setgid www-data so
+		// that anything the tenant's PHP-FPM worker creates inherits group
+		// www-data — nginx serves as www-data and must be able to traverse it.
+		// The rsync'd tree arrives with the SOURCE's ownership and no setgid on
+		// the subtree, and the pipeline's own fix_perms stage cannot help: it
+		// runs BEFORE restore, and has no registered callback for cPanel at all
+		// ("a no-op for cPanel").
+		//
+		// The damage is delayed, which is what makes it expensive. Existing
+		// directories were chgrp'd by the restore, so the site looks fine. The
+		// first directory WordPress creates on its own — a new uploads/YYYY/MM
+		// on the 1st of the month, a plugin cache dir — inherits the tenant's
+		// primary group instead, and with the FPM umask (027) comes out
+		// drwxr-x--- <user>:<user>. nginx cannot traverse it, so new uploads
+		// 404 as blank thumbnails while old media still serves. A fleet sweep
+		// found every migrated account affected, each waiting on its own month
+		// rollover.
+		if plan.Websites && len(appDocroots) > 0 {
+			if gid, gerr := wwwDataGid(); gerr != nil {
+				warnings = append(warnings, fmt.Sprintf("docroot_perms: resolve www-data gid: %v", gerr))
+			} else {
+				fixed, failed := 0, 0
+				for _, dr := range appDocroots {
+					home := userHomeOf(dr)
+					if dr == "" || home == "" {
+						continue
+					}
+					if err := fsperm.RepairDocrootGroup(home, dr, gid); err != nil {
+						failed++
+						warnings = append(warnings, fmt.Sprintf("docroot_perms_skip:%s:%v", dr, err))
+						continue
+					}
+					fixed++
+				}
+				warnings = append(warnings, fmt.Sprintf("docroot_perms: setgid_www_data fixed=%d failed=%d", fixed, failed))
+			}
 		}
 
 		extrasRes, err := cpanel.ImportExtras(ctx, domainsRepo, mbRepo, fwdRepo, arRepo, filtersRepo, phpPoolsRepo, restoreAgent, p.parsed, p.targetUserID, p.targetUsername, preserve.MailRouting)


### PR DESCRIPTION
## Why nothing was applying setgid

jabali's isolation model relies on docroots being **setgid www-data**, so anything the tenant's PHP-FPM worker creates inherits group `www-data` — nginx serves as www-data and must traverse it. A migrated tree arrives with the **source's** ownership and no setgid below `public_html`.

The pipeline's own `fix_perms` stage can't help:

- it runs **before** restore, and
- for cPanel it has **no registered callback at all** — the runner documents it as *"a no-op for cPanel"*

So nothing has ever applied setgid to a restored tree.

## Why it went unnoticed for so long

The restore chgrp's the directories **it** creates, so a migrated site looks healthy and serves its existing media fine. The first directory WordPress creates on its **own** — a new `uploads/YYYY/MM` on the 1st of the month, a plugin cache dir — inherits the tenant's primary group instead, and under the FPM umask (027) comes out `drwxr-x--- <user>:<user>`.

nginx can't traverse it, so **new** uploads 404 as blank thumbnails while **old** media still works. That reads like a WordPress bug, not a migration one. A fleet sweep found every migrated account affected, each waiting on its own month rollover.

## The fix

The restore re-applies setgid + group www-data across every restored docroot as a final step, **after** the files are on disk, using the same symlink-safe `fsperm.RepairDocrootGroup` that `jabali domain fix-perms` uses. Per-docroot failures are reported and don't abort the restore.

## The test asserts inheritance, not the bits

The bits on directories the restore created were always correct — that's precisely why this went unnoticed. So the test seeds a tree, repairs it, then creates a new month folder under umask 027 the way WordPress would, and checks what the **new** directory inherited.

**Verified it fails without the fix:**

```
public_html is not setgid — a directory created under it inherits the tenant's group
public_html group = 1000, want 27
```

## Note for existing fleets

This stops new restores from joining the problem. Already-migrated accounts still need `jabali domain fix-perms <user>` once — per the issue that's already been applied to the 69 + 4 accounts on newaramaapp/newhighsite.