### PR TITLE
fix(nginx): raise client_max_body_size to match what the PHP pool accepts (JAB-228)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6193,7 +6193,7 @@ install_nginx_tunables() {
 # Server-wide nginx tunables (Server Settings → Nginx, M55).
 # http{}-scope defaults; individual vhosts may override per-directive.
 
-client_max_body_size 50m;
+client_max_body_size 512m;
 client_body_timeout 60s;
 client_header_timeout 60s;
 send_timeout 60s;

--- a/panel-api/internal/db/migrations/000252_nginx_body_size_matches_php.down.sql
+++ b/panel-api/internal/db/migrations/000252_nginx_body_size_matches_php.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE server_settings
+  MODIFY COLUMN nginx_client_max_body_size varchar(16) NOT NULL DEFAULT '50m';
+
+UPDATE server_settings
+   SET nginx_client_max_body_size = '50m'
+ WHERE nginx_client_max_body_size = '512m';

--- a/panel-api/internal/db/migrations/000252_nginx_body_size_matches_php.up.sql
+++ b/panel-api/internal/db/migrations/000252_nginx_body_size_matches_php.up.sql
@@ -1,0 +1,19 @@
+-- JAB-228: raise the default nginx client_max_body_size to match the PHP-FPM
+-- pool, which has always allowed 512M.
+--
+-- install/php/jabali-php-pool.conf.tmpl sets upload_max_filesize=512M and
+-- post_max_size=512M, while nginx capped request bodies at 50m. nginx therefore
+-- rejected anything over 50MB with 413 BEFORE PHP ever saw it — while WordPress
+-- read the PHP limits and advertised a much larger maximum to the user. Uploads
+-- failed mid-transfer with an opaque error, and retries produced duplicate
+-- attachments (name.jpg, name-1.jpg, name-2.jpg).
+--
+-- Only rows still holding the old default are moved. An operator who has
+-- deliberately set any other value keeps it — this is a wrong default, not a
+-- policy to override.
+UPDATE server_settings
+   SET nginx_client_max_body_size = '512m'
+ WHERE nginx_client_max_body_size = '50m';
+
+ALTER TABLE server_settings
+  MODIFY COLUMN nginx_client_max_body_size varchar(16) NOT NULL DEFAULT '512m';

--- a/panel-api/internal/models/nginx_php_upload_parity_test.go
+++ b/panel-api/internal/models/nginx_php_upload_parity_test.go
@@ -1,0 +1,100 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// JAB-228. nginx's client_max_body_size and the PHP-FPM pool's
+// upload_max_filesize/post_max_size are set in different files, in different
+// languages, by different components — and they must agree or uploads break in
+// a way nobody can diagnose.
+//
+// They drifted: the pool template allowed 512M while nginx capped bodies at
+// 50m, so nginx returned 413 before PHP ever saw the request. WordPress reads
+// the PHP limits and advertised 200MB, so the user was told a size the stack
+// would never accept. Uploads failed mid-transfer and retries left duplicate
+// attachments (name.jpg, name-1.jpg, name-2.jpg).
+//
+// This is the contract test that would have caught it: nginx must allow at
+// least what PHP will accept.
+
+var (
+	phpIniSizeRe   = regexp.MustCompile(`(?m)^php_value\[(upload_max_filesize|post_max_size)\]\s*=\s*(\d+)([MG])`)
+	nginxDefaultRe = regexp.MustCompile(`default:'(\d+)([mg])'`)
+)
+
+func parseMB(n string, unit string) int {
+	v, _ := strconv.Atoi(n)
+	switch strings.ToLower(unit) {
+	case "g":
+		return v * 1024
+	default:
+		return v
+	}
+}
+
+func TestNginxBodySizeCoversPHPUploadLimit(t *testing.T) {
+	root := repoRootFrom(t)
+
+	tmpl, err := os.ReadFile(filepath.Join(root, "install", "php", "jabali-php-pool.conf.tmpl"))
+	if err != nil {
+		t.Skipf("pool template not readable from this checkout: %v", err)
+	}
+	matches := phpIniSizeRe.FindAllStringSubmatch(string(tmpl), -1)
+	if len(matches) == 0 {
+		t.Fatal("no upload_max_filesize/post_max_size found in the pool template — regex or template changed")
+	}
+	phpMaxMB := 0
+	for _, m := range matches {
+		if mb := parseMB(m[2], m[3]); mb > phpMaxMB {
+			phpMaxMB = mb
+		}
+	}
+
+	src, err := os.ReadFile(filepath.Join(root, "panel-api", "internal", "models", "server_settings.go"))
+	if err != nil {
+		t.Fatalf("read server_settings.go: %v", err)
+	}
+	idx := strings.Index(string(src), "nginx_client_max_body_size")
+	if idx < 0 {
+		t.Fatal("nginx_client_max_body_size field not found")
+	}
+	line := string(src)[idx:]
+	if e := strings.Index(line, "\n"); e > 0 {
+		line = line[:e]
+	}
+	nm := nginxDefaultRe.FindStringSubmatch(line)
+	if nm == nil {
+		t.Fatalf("could not parse the nginx default from: %s", line)
+	}
+	nginxMB := parseMB(nm[1], nm[2])
+
+	if nginxMB < phpMaxMB {
+		t.Errorf("nginx client_max_body_size default is %dM but the PHP pool accepts %dM — "+
+			"nginx will 413 uploads PHP would have taken, and WordPress advertises the PHP "+
+			"number so users are told a size that cannot work (JAB-228)", nginxMB, phpMaxMB)
+	}
+}
+
+// repoRootFrom walks up until it finds go.mod, so the test works from any
+// checkout layout.
+func repoRootFrom(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Skip("repo root not found")
+	return ""
+}

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -369,7 +369,7 @@ type ServerSettings struct {
 	// → `server_tokens off` (hide version, secure default). NginxCustomHTTP is
 	// admin-supplied raw http{}-scope directives gated only by nginx -t; the UI
 	// warns it can destabilize the server. NginxWorkerProcesses is "auto" or int.
-	NginxClientMaxBodySize   string `gorm:"column:nginx_client_max_body_size;type:varchar(16);not null;default:'50m'"   json:"nginx_client_max_body_size"`
+	NginxClientMaxBodySize   string `gorm:"column:nginx_client_max_body_size;type:varchar(16);not null;default:'512m'"   json:"nginx_client_max_body_size"`
 	NginxKeepaliveTimeout    string `gorm:"column:nginx_keepalive_timeout;type:varchar(16);not null;default:'65s'"      json:"nginx_keepalive_timeout"`
 	NginxServerTokens        bool   `gorm:"column:nginx_server_tokens;type:tinyint(1);not null;default:0"               json:"nginx_server_tokens"`
 	NginxGzip                bool   `gorm:"column:nginx_gzip;type:tinyint(1);not null;default:1"                        json:"nginx_gzip"`


### PR DESCRIPTION
## A 10× mismatch nobody tied together

The per-user FPM pool has always allowed **512M** (`install/php/jabali-php-pool.conf.tmpl` sets `upload_max_filesize` and `post_max_size` to 512M) while nginx capped request bodies at **50m**. nginx returned **413** for anything over 50MB *before PHP ever saw the request*.

Confirmed on a live box:

```
/etc/php/7.4/fpm/pool.d/jabali-otzmaad-php7.4.conf:  upload_max_filesize = 512M
                                                     post_max_size       = 512M
/etc/nginx/conf.d/05-jabali-tunables.conf:           client_max_body_size 50m;
```

The reason it's hard to diagnose: **WordPress reads the PHP limits**, so the media page advertised 200MB — a size the stack would never accept. Uploads failed mid-transfer with an opaque error, and the customer's retries left duplicate attachments: `name.jpg`, `name-1.jpg`, `name-2.jpg`.

## The fix

Raised to `512m` in the three places that have to agree: the model default, a migration, and install.sh's seeded fragment.

Migration `000252` **only moves rows still holding the old default**. An operator who deliberately set another value keeps it — this is a wrong default, not a policy to override. install.sh's seed is already SEED-IF-ABSENT, so an existing box keeps its admin-managed file and picks the value up when the agent re-renders.

The second acceptance criterion — advertised max reflecting the real nginx∩PHP limit — is satisfied **by construction** rather than by adding a `min()` somewhere: with nginx ≥ PHP, the PHP number WordPress advertises *is* the effective one.

## The contract test

These two values live in different files, in different languages, owned by different components, and **nothing tied them together**. `TestNginxBodySizeCoversPHPUploadLimit` parses the pool template and the model default and fails when nginx allows less than PHP.

**Verified it fires** by reverting the default:

```
--- FAIL: TestNginxBodySizeCoversPHPUploadLimit
    nginx client_max_body_size default is 50M but the PHP pool accepts 512M —
    nginx will 413 uploads PHP would have taken
```

## Trade-off, stated

A 512m cap lets a client stream more before nginx rejects it. That headroom already existed at the PHP layer, so this removes an inconsistency rather than opening something new, and the limit stays operator-adjustable in Server Settings → Nginx.