### PR TITLE
feat(migrate): refuse to start a restore on a host that is out of memory (JAB-216)

### DIFF
--- a/panel-api/cmd/server/migrate_restore_cmd.go
+++ b/panel-api/cmd/server/migrate_restore_cmd.go
@@ -221,6 +221,20 @@ same command to resume a failed job.`,
 			//
 			// The job is marked failed with the measured numbers, so `migrate list`
 			// shows why rather than leaving a pending job with no explanation.
+			// JAB-216: memory, same position and same contract as the disk check
+			// below — after the job row exists so a refusal is resumable, before
+			// anything is staged so nothing is half-provisioned.
+			if mwarn, merr := migrate.CheckRestoreMemory(); merr != nil {
+				msg := merr.Error()
+				if uerr := jobsRepo.UpdateState(ctx, jobID, models.MigrationStateFailed, &msg); uerr != nil {
+					fmt.Printf("  ! could not record the failure on job %s: %v\n", jobID, uerr)
+				}
+				return fmt.Errorf("%w\n  job %s left resumable — free memory, then: jabali migrate import --job-id %s",
+					merr, jobID, jobID)
+			} else if mwarn != "" {
+				fmt.Printf("  ! %s\n", mwarn)
+			}
+
 			if derr := migrate.CheckExtractDiskSpace(abs, "/var/lib/jabali-migrations"); derr != nil {
 				msg := derr.Error()
 				if uerr := jobsRepo.UpdateState(ctx, jobID, models.MigrationStateFailed, &msg); uerr != nil {

--- a/panel-api/internal/migrate/memcheck.go
+++ b/panel-api/internal/migrate/memcheck.go
@@ -1,0 +1,107 @@
+package migrate
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// memcheck.go — JAB-216.
+//
+// Serial restores on a 7.7 GB host drove it into repeated global OOM kills over
+// four hours and finally into a full userspace wedge: sshd stopped answering,
+// nginx stopped serving, and the box needed a provider-console reboot. The
+// kernel's last kill was Stalwart (~888 MB anon-rss) ingesting migrated mail.
+//
+// Nothing in the pipeline looked at memory. It checks disk before extracting —
+// which is why a low-disk host fails clean — and then starts a job whose peak
+// working set is dominated by mail ingest with no idea whether the host has room
+// for it.
+//
+// This is the memory equivalent of that disk check, and it is deliberately a
+// FLOOR rather than an estimate. Predicting a restore's peak is not honest work:
+// it depends on mailbox count, message sizes, Stalwart's ingest batching and
+// what else the box is serving. What can be said with confidence is that
+// starting a heavy, hours-long job on a host that is ALREADY nearly out of
+// memory is how the incident began.
+
+const (
+	// memRefuseBelowMB is the hard floor. Below this a restore is refused: the
+	// host has no room for the job, and starting anyway is how a destination box
+	// takes its cut-over tenants down with it.
+	memRefuseBelowMB = 512
+
+	// memWarnBelowMB is where the operator is told to expect a slow, pressured
+	// run. Not a refusal — a 1 GB box CAN complete a small account, and refusing
+	// it would block legitimate work.
+	memWarnBelowMB = 1536
+)
+
+// AvailableMemMB reports MemAvailable from /proc/meminfo in MB.
+//
+// MemAvailable rather than MemFree on purpose: MemFree excludes reclaimable page
+// cache and would report a healthy host as nearly empty, making the check fire
+// constantly on exactly the boxes that are fine.
+//
+// Returns 0 when it cannot be read, which callers treat as "unknown, do not
+// block" — a check that cannot see must not veto a migration.
+func AvailableMemMB() int {
+	b, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	return parseMemAvailableMB(string(b))
+}
+
+// parseMemAvailableMB is split out so the parsing is testable without /proc.
+func parseMemAvailableMB(meminfo string) int {
+	for _, line := range strings.Split(meminfo, "\n") {
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		f := strings.Fields(line)
+		// "MemAvailable:   1234567 kB"
+		if len(f) < 2 {
+			return 0
+		}
+		kb, err := strconv.Atoi(f[1])
+		if err != nil || kb < 0 {
+			return 0
+		}
+		return kb / 1024
+	}
+	return 0
+}
+
+// CheckRestoreMemory refuses a restore when the host is already out of memory,
+// and returns a warning string when it is merely tight.
+//
+// Best-effort: an unreadable /proc/meminfo yields ("", nil) — no warning, no
+// refusal. Consistent with the disk check, which also declines to block when it
+// cannot measure.
+func CheckRestoreMemory() (warning string, err error) {
+	return checkRestoreMemoryFor(AvailableMemMB())
+}
+
+// checkRestoreMemoryFor is the decision split from the measurement so the
+// thresholds are testable without pretending to be a low-memory host.
+func checkRestoreMemoryFor(avail int) (warning string, err error) {
+	if avail <= 0 {
+		return "", nil // cannot measure — do not block
+	}
+	if avail < memRefuseBelowMB {
+		return "", fmt.Errorf(
+			"insufficient available memory to start a restore: %d MiB available, need at least %d MiB. "+
+				"A restore's peak is dominated by mail ingest, and starting one on a host this "+
+				"close to its limit is what OOM-killed Stalwart and wedged a box mid-migration. "+
+				"Free memory (or add some) and re-run", avail, memRefuseBelowMB)
+	}
+	if avail < memWarnBelowMB {
+		return fmt.Sprintf(
+			"low memory: %d MiB available (comfortable is %d MiB+). The restore will run, but mail "+
+				"ingest may be slow and the host will be under pressure — avoid running restores in "+
+				"parallel on this box", avail, memWarnBelowMB), nil
+	}
+	return "", nil
+}

--- a/panel-api/internal/migrate/memcheck_test.go
+++ b/panel-api/internal/migrate/memcheck_test.go
@@ -1,0 +1,80 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+)
+
+// MemAvailable, not MemFree: MemFree excludes reclaimable page cache, so a
+// perfectly healthy host reports nearly nothing free and the check would fire on
+// exactly the boxes that are fine.
+func TestParseMemAvailableMB_PrefersMemAvailableOverMemFree(t *testing.T) {
+	meminfo := `MemTotal:        8039132 kB
+MemFree:          201332 kB
+MemAvailable:    6100480 kB
+Buffers:          104928 kB
+`
+	if got, want := parseMemAvailableMB(meminfo), 6100480/1024; got != want {
+		t.Fatalf("got %d MB, want %d", got, want)
+	}
+}
+
+// Unreadable or unexpected input must be reported as "unknown" (0), which the
+// caller treats as do-not-block. A check that cannot see must not veto.
+func TestParseMemAvailableMB_UnknownOnBadInput(t *testing.T) {
+	for name, in := range map[string]string{
+		"empty":        "",
+		"no field":     "MemTotal: 8039132 kB\nMemFree: 201332 kB\n",
+		"not a number": "MemAvailable:    banana kB\n",
+		"truncated":    "MemAvailable:\n",
+		"negative":     "MemAvailable:    -5 kB\n",
+	} {
+		if got := parseMemAvailableMB(in); got != 0 {
+			t.Errorf("%s: got %d, want 0 (unknown)", name, got)
+		}
+	}
+}
+
+func TestCheckRestoreMemory_Thresholds(t *testing.T) {
+	// The constants must stay ordered, or "warn" would be unreachable and a
+	// tight-but-workable host would be refused outright.
+	if memRefuseBelowMB >= memWarnBelowMB {
+		t.Fatalf("refuse floor (%d) must be below the warn threshold (%d)", memRefuseBelowMB, memWarnBelowMB)
+	}
+}
+
+// The refusal has to say what to do about it. The incident this came from was
+// diagnosed from kernel logs after a console reboot; an operator hitting the
+// guard should not need that.
+func TestCheckRestoreMemory_RefusalIsActionable(t *testing.T) {
+	// Exercise the message via the same formatting path the caller sees.
+	_, err := checkRestoreMemoryFor(memRefuseBelowMB - 1)
+	if err == nil {
+		t.Fatal("expected a refusal below the floor")
+	}
+	for _, want := range []string{"available", "need at least", "Free memory"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestCheckRestoreMemory_WarnsButAllowsWhenTight(t *testing.T) {
+	warn, err := checkRestoreMemoryFor(memWarnBelowMB - 1)
+	if err != nil {
+		t.Fatalf("a tight-but-workable host must not be refused: %v", err)
+	}
+	if warn == "" {
+		t.Error("expected a warning between the floor and the comfortable threshold")
+	}
+}
+
+func TestCheckRestoreMemory_SilentWhenHealthyOrUnknown(t *testing.T) {
+	if warn, err := checkRestoreMemoryFor(memWarnBelowMB + 1); warn != "" || err != nil {
+		t.Errorf("healthy host: warn=%q err=%v", warn, err)
+	}
+	// 0 == could not measure.
+	if warn, err := checkRestoreMemoryFor(0); warn != "" || err != nil {
+		t.Errorf("unmeasurable host must not block: warn=%q err=%v", warn, err)
+	}
+}


### PR DESCRIPTION
## The incident

Serial restores on a 7.7 GB host drove it into repeated global OOM kills over four hours and finally into a full userspace wedge — sshd stopped answering, nginx stopped serving, and the box needed a **provider-console reboot**. The kernel's fatal kill was Stalwart (~888 MB anon-rss) ingesting migrated mail.

Nothing in the pipeline looked at memory. It checks **disk** before extracting — which is why a low-disk host fails clean — then starts a job whose peak working set is dominated by mail ingest, with no idea whether the host has room for it.

## What this adds

The memory equivalent of that disk check, in the same position and with the same contract: **after** the job row exists so a refusal is resumable (JAB-219), **before** anything is staged so nothing is half-provisioned (JAB-41).

Deliberately a **floor, not an estimate.** Predicting a restore's peak isn't honest work — it depends on mailbox count, message sizes, Stalwart's ingest batching, and whatever else the box is serving. What *can* be said with confidence is that starting a heavy, hours-long job on a host already near its limit is how the incident began.

| available | behaviour |
|---|---|
| < 512 MiB | **refuse** — resumable, names the remedy |
| < 1536 MiB | warn, proceed |
| above | silent |

A 1 GB box can still complete a small account; refusing it would block legitimate work.

**`MemAvailable`, not `MemFree`** — MemFree excludes reclaimable page cache, so a healthy host reports nearly nothing free and the check would fire on exactly the boxes that are fine. Sanity-checked against real hosts: testserver **8028 MiB**, newzaps **14233 MiB** — both far above the thresholds, so no spurious firing.

Unreadable `/proc/meminfo` yields no warning and no refusal, matching the disk check: a check that cannot see must not veto a migration.

The refusal names the remedy — the incident it came from was diagnosed from kernel logs *after* a console reboot, and an operator who trips this guard shouldn't need that.

## Still open on JAB-216

- memory bounds (`MemoryHigh=`/`MemoryMax=`) on Stalwart and other core services
- clean resume of a job interrupted by host death

**On sshd:** the issue suggests `OOMScoreAdjust=-1000`, but I checked a live box — the running sshd already reports `oom_score_adj -1000` (OpenSSH sets it for its own listener; `systemctl show ssh` reports `OOMScoreAdjust=0` because systemd isn't the one doing it). So that half is largely already in place and a unit drop-in would have changed little in this incident. Worth knowing before someone spends time on it.