### PR TITLE
fix(backup): skip an absent system DB instead of failing it — no more Partial on a fresh DNS-less server (GH #502)

### DIFF
--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -893,11 +893,36 @@ func runSystemPanelDBStage(ctx context.Context, c *backup.Client, jobID, hostnam
 	return stages
 }
 
+// systemDBExists reports whether a MariaDB schema is present. Used to skip
+// the dump of an OPTIONAL system database that isn't installed (GH #502):
+// jabali_pdns only exists when the DNS module is enabled, so on a
+// DNS-less install mariadb-dump would exit 2 ("Unknown database") and mark
+// the whole system backup Partial for a database that was never supposed to
+// be there. A lookup failure returns true so we still attempt the dump
+// (fail loud rather than silently skip a real DB). Overridable for tests.
+var systemDBExists = func(ctx context.Context, db string) bool {
+	out, err := exec.CommandContext(ctx, "mariadb", "-N", "-B", "-e",
+		fmt.Sprintf("SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = '%s'", db)).Output()
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(string(out)) == db
+}
+
 func dumpOneSystemDB(ctx context.Context, c *backup.Client, jobID, hostname, scheduleID, db string) backup.ManifestStage {
 	st := backup.ManifestStage{
 		Name:  backup.StagePanelDB,
 		Tag:   fmt.Sprintf("stage=panel_db,db=%s", db),
 		Items: []string{db},
+	}
+	// Skip (not fail) an optional system DB that isn't installed — e.g.
+	// jabali_pdns on a server without the DNS module (GH #502). Dumping a
+	// non-existent DB exits 2 and would otherwise mark the whole backup
+	// Partial on an otherwise-clean fresh server.
+	if !systemDBExists(ctx, db) {
+		st.Status = backup.StageStatusSkipped
+		st.Warnings = []string{fmt.Sprintf("database %s not present — skipped (component not installed)", db)}
+		return st
 	}
 	cmd := exec.CommandContext(ctx, "mariadb-dump",
 		"--single-transaction", "--skip-lock-tables",

--- a/panel-agent/internal/commands/backup_system_paneldb_test.go
+++ b/panel-agent/internal/commands/backup_system_paneldb_test.go
@@ -1,0 +1,33 @@
+package commands
+
+// GH #502: a missing OPTIONAL system database (jabali_pdns on a DNS-less
+// install) must be SKIPPED, not failed — otherwise the whole system backup
+// is reported Partial on an otherwise-clean fresh server.
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+func TestDumpOneSystemDB_MissingDBSkips(t *testing.T) {
+	orig := systemDBExists
+	t.Cleanup(func() { systemDBExists = orig })
+	systemDBExists = func(_ context.Context, _ string) bool { return false }
+
+	st := dumpOneSystemDB(context.Background(), nil, "job1", "host", "", "jabali_pdns")
+
+	if st.Status != backup.StageStatusSkipped {
+		t.Fatalf("missing DB status = %q, want %q", st.Status, backup.StageStatusSkipped)
+	}
+	if st.Status == backup.StageStatusFailed {
+		t.Fatal("a missing optional DB must never be Failed (marks the backup Partial)")
+	}
+	if len(st.Warnings) == 0 {
+		t.Error("skip must carry a warning naming the absent DB")
+	}
+	if len(st.Items) != 1 || st.Items[0] != "jabali_pdns" {
+		t.Errorf("items = %v, want [jabali_pdns]", st.Items)
+	}
+}


### PR DESCRIPTION
Fixes the "System backup marked **Partial** on a clean fresh server" thread in #502 — the reporter traced it to the exact stage.

## Root cause
The system backup's `panel_db` stage dumps every name in `systemPanelDatabases` unconditionally, including `jabali_pdns`. That database only exists when the **DNS module** is installed, so on a DNS-less server:

```
stage=panel_db status=failed items=[jabali_pdns] warnings=[mariadb-dump jabali_pdns: exit status 2: mariadb-dump: Got error: 1049: "Unknown database 'jabali_pdns'"]
```

The stage is `Failed` → the finalizer reports the whole backup **Partial**, on an otherwise-clean server with nothing actually wrong.

## Fix
Mirror the skip-on-missing pattern the `service_config`/`security` stages already use: check schema presence (`information_schema.schemata`) first, and mark an absent DB **Skipped** (with a warning) rather than **Failed**. A lookup failure still attempts the dump, so a genuinely-missing *core* DB (`jabali_panel`) still fails loud. `Skipped` stages don't count toward the finalizer's `FailedStages`, so the backup is no longer Partial for an uninstalled optional component.

## Test plan
- [x] `TestDumpOneSystemDB_MissingDBSkips` — missing DB ⇒ Skipped (not Failed), warning present
- [x] full panel-agent commands suite
- [ ] live: system backup on a box without the DNS module → completes as Full, `jabali_pdns` leg Skipped