### PR TITLE
feat(cache): probe whether caching actually happens, not just whether it is configured (JAB-201)

### DIFF
--- a/panel-api/internal/api/applications_cache_doctor.go
+++ b/panel-api/internal/api/applications_cache_doctor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/cacheprobe"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -248,6 +249,36 @@ func (h *wordPressHandler) doctorOneInstall(ctx context.Context, in *models.Appl
 	_ = json.Unmarshal(raw, &health)
 	item.Healthy = health.Healthy
 	item.Drifted = in.CacheEnabled && !health.Healthy
+
+	// JAB-201: configuration being right and caching working are different
+	// claims. The health check above verifies the first — plugin active, drop-in
+	// and constants present, Redis reachable — and reported green on a site whose
+	// page cache had never stored a single entry: maintenance mode emitted
+	// nocache_headers() on every response, so the fail-closed gate correctly
+	// refused to store anything, forever. Only MISS and BYPASS ever appeared in
+	// the jcache log.
+	//
+	// So when the configuration looks healthy, ask nginx whether caching is
+	// actually happening, and if it is not, say WHY — the cause is what the
+	// operator can act on.
+	if in.CacheEnabled && health.Healthy {
+		probeCtx, pcancel := context.WithTimeout(ctx, cacheDoctorInstallCallTimeout)
+		res, perr := cacheprobe.Probe(probeCtx, dom.Name)
+		pcancel()
+		switch {
+		case perr != nil:
+			// Could not probe — site down, TLS refused, no vhost on this box.
+			// That is NOT evidence of a cache fault, and surfacing it as an item
+			// error would turn "could not check" into "failed" for every install
+			// in an environment without a reachable vhost. Stay silent: this
+			// probe only ever ADDS a verdict, it never invents one.
+		case res.Verdict == cacheprobe.VerdictNotCaching:
+			item.Drifted = true
+			item.Healthy = false
+			item.Error = "configuration is correct but nothing is being cached — " + res.Reason
+		}
+	}
+
 	if !item.Drifted {
 		return item
 	}

--- a/panel-api/internal/cacheprobe/fetch.go
+++ b/panel-api/internal/cacheprobe/fetch.go
@@ -1,0 +1,70 @@
+package cacheprobe
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Probe fetches host's homepage twice, anonymously, and classifies the result.
+//
+// Anonymously is the point: a logged-in cookie or an Authorization header makes
+// nginx bypass the cache by design, so probing as anyone but a fresh visitor
+// would report BYPASS on a perfectly healthy site.
+//
+// The request goes to the loopback address with the Host header set, so it
+// exercises this box's own vhost rather than wherever public DNS currently
+// points — a pre-cutover domain still resolves to the old host, and probing that
+// would report on somebody else's server.
+func Probe(ctx context.Context, host string) (Result, error) {
+	cl := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			// Pin every connection to loopback regardless of DNS.
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, "127.0.0.1:443")
+			},
+			// The origin certificate may legitimately be the self-signed
+			// placeholder on a not-yet-cut-over domain. We are reading cache
+			// headers from our own box over loopback, not authenticating a peer.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+		},
+		// Cache status is a property of the response we asked for; following a
+		// redirect would report on a different URL than the operator sees.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+
+	get := func() (http.Header, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+host+"/", nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Host = host
+		req.Header.Set("User-Agent", "jabali-cache-probe/1")
+		// Ask for an uncompressed body so Vary handling is not muddied.
+		req.Header.Set("Accept-Encoding", "identity")
+		resp, err := cl.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		return resp.Header, nil
+	}
+
+	first, err := get()
+	if err != nil {
+		return Result{Verdict: VerdictUnknown, Reason: "probe request failed: " + err.Error()},
+			fmt.Errorf("cache probe %s: %w", host, err)
+	}
+	// A cacheable response has to be stored before it can be served, so the
+	// second fetch is the one that proves anything.
+	second, err := get()
+	if err != nil {
+		return Result{Verdict: VerdictUnknown, Reason: "second probe request failed: " + err.Error()},
+			fmt.Errorf("cache probe %s: %w", host, err)
+	}
+	return Classify(first, second), nil
+}

--- a/panel-api/internal/cacheprobe/probe.go
+++ b/panel-api/internal/cacheprobe/probe.go
@@ -1,0 +1,128 @@
+// Package cacheprobe answers the question the cache health check does not:
+// is this site ACTUALLY being cached?
+//
+// JAB-201. The existing check verifies configuration — plugin active, drop-in
+// and constants present, Redis reachable — and reports green on all of it. On
+// brown-online.co.il every one of those passed while the page cache had never
+// stored a single entry: the site was in maintenance mode, so WordPress emitted
+// nocache_headers() on every response and the fail-closed gate (GH #637)
+// correctly refused to store anything. The jcache log showed only MISS and
+// BYPASS, never HIT, for the life of the site.
+//
+// Configuration being right and caching working are different claims, and only
+// the second one matters to the operator. This makes the second claim testable:
+// fetch the page twice and look at what nginx reports.
+package cacheprobe
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Verdict is the outcome of a double-fetch probe.
+type Verdict string
+
+const (
+	// VerdictCaching — the second fetch was served from cache. Working.
+	VerdictCaching Verdict = "caching"
+	// VerdictNotCaching — repeated fetches never hit. The reason explains why.
+	VerdictNotCaching Verdict = "not_caching"
+	// VerdictUnknown — nginx did not report a cache status, so this site is not
+	// running the jabali cache vhost at all and the probe says nothing.
+	VerdictUnknown Verdict = "unknown"
+)
+
+// CacheStatusHeader is what the jabali vhost adds:
+//
+//	add_header X-Jabali-Cache $upstream_cache_status always;
+const CacheStatusHeader = "X-Jabali-Cache"
+
+// Result is a probe outcome plus the reason, phrased for an operator.
+type Result struct {
+	Verdict Verdict
+	// Reason names the CAUSE where one is detectable, not just the symptom.
+	// "page cache enabled but the site opts out" is actionable; "no HIT" is not.
+	Reason string
+	First  string // X-Jabali-Cache of the first fetch
+	Second string // ...and the second
+}
+
+// Classify decides the verdict from two responses' headers.
+//
+// Pure, so the interesting cases are testable without standing up nginx, a
+// tenant site and a maintenance-mode plugin.
+func Classify(first, second http.Header) Result {
+	f := strings.ToUpper(strings.TrimSpace(first.Get(CacheStatusHeader)))
+	s := strings.ToUpper(strings.TrimSpace(second.Get(CacheStatusHeader)))
+	r := Result{First: f, Second: s}
+
+	if f == "" && s == "" {
+		r.Verdict = VerdictUnknown
+		r.Reason = "no " + CacheStatusHeader + " header — this vhost is not running the jabali cache config"
+		return r
+	}
+	if s == "HIT" {
+		r.Verdict = VerdictCaching
+		return r
+	}
+
+	r.Verdict = VerdictNotCaching
+	// Prefer the upstream's own opt-out as the explanation: it is the cause,
+	// and the one an operator can act on. BYPASS only says the gate fired.
+	if why := upstreamOptOut(second); why != "" {
+		r.Reason = "the site tells caches not to store this response (" + why +
+			"). A maintenance/coming-soon or security plugin emitting nocache_headers() " +
+			"does this site-wide; the cache is working as designed by refusing to store it"
+		return r
+	}
+	if s == "BYPASS" {
+		r.Reason = "nginx bypassed the cache for this request — a skip gate matched " +
+			"(logged-in cookie, Authorization header, or an excluded URI)"
+		return r
+	}
+	if v := second.Get("Vary"); varyDefeatsCache(v) {
+		r.Reason = "the response varies on " + v + ", which prevents a shared cache entry"
+		return r
+	}
+	r.Reason = "two consecutive anonymous fetches both missed (" + f + " then " + s +
+		") — the response is reaching the cache but never being stored"
+	return r
+}
+
+// upstreamOptOut reports which directive tells caches not to store, or "".
+func upstreamOptOut(h http.Header) string {
+	cc := strings.ToLower(h.Get("Cache-Control"))
+	for _, tok := range []string{"no-store", "no-cache", "private"} {
+		if strings.Contains(cc, tok) {
+			return "Cache-Control: " + tok
+		}
+	}
+	// The classic maintenance-plugin signature: WordPress's nocache_headers()
+	// sends an Expires in the past, historically 1984.
+	if exp := h.Get("Expires"); exp != "" && strings.Contains(exp, "1984") {
+		return "Expires: " + exp
+	}
+	if strings.EqualFold(h.Get("Pragma"), "no-cache") {
+		return "Pragma: no-cache"
+	}
+	return ""
+}
+
+// varyDefeatsCache reports whether a Vary header prevents a shared entry.
+//
+// Vary on Accept-Encoding is normal and fine — nginx keys on it. Anything else
+// (Cookie, User-Agent, *) makes a shared cache entry useless.
+func varyDefeatsCache(vary string) bool {
+	v := strings.TrimSpace(vary)
+	if v == "" {
+		return false
+	}
+	for _, part := range strings.Split(v, ",") {
+		p := strings.ToLower(strings.TrimSpace(part))
+		if p == "" || p == "accept-encoding" {
+			continue
+		}
+		return true
+	}
+	return false
+}

--- a/panel-api/internal/cacheprobe/probe_test.go
+++ b/panel-api/internal/cacheprobe/probe_test.go
@@ -1,0 +1,116 @@
+package cacheprobe
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func hdr(kv ...string) http.Header {
+	h := http.Header{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		h.Set(kv[i], kv[i+1])
+	}
+	return h
+}
+
+func TestClassify_HitOnSecondFetchIsCaching(t *testing.T) {
+	r := Classify(hdr(CacheStatusHeader, "MISS"), hdr(CacheStatusHeader, "HIT"))
+	if r.Verdict != VerdictCaching {
+		t.Fatalf("verdict = %q, want %q (reason: %s)", r.Verdict, VerdictCaching, r.Reason)
+	}
+}
+
+// The brown-online.co.il case: every configuration check passed, and the site
+// had never cached a single response because maintenance mode emitted
+// nocache_headers() on every request. The probe has to name THAT, not just
+// report "no HIT" — the operator can act on the cause, not the symptom.
+func TestClassify_MaintenanceModeNamesTheCause(t *testing.T) {
+	second := hdr(
+		CacheStatusHeader, "BYPASS",
+		"Cache-Control", "no-cache, must-revalidate, max-age=0",
+		"Expires", "Wed, 11 Jan 1984 05:00:00 GMT",
+	)
+	r := Classify(hdr(CacheStatusHeader, "BYPASS"), second)
+
+	if r.Verdict != VerdictNotCaching {
+		t.Fatalf("verdict = %q, want %q", r.Verdict, VerdictNotCaching)
+	}
+	if !strings.Contains(r.Reason, "tells caches not to store") {
+		t.Errorf("reason does not name the cause: %s", r.Reason)
+	}
+	if !strings.Contains(r.Reason, "no-cache") {
+		t.Errorf("reason does not quote the offending directive: %s", r.Reason)
+	}
+	// It must also say the cache is behaving correctly — otherwise the operator
+	// goes looking for a cache bug that does not exist.
+	if !strings.Contains(r.Reason, "working as designed") {
+		t.Errorf("reason blames the cache instead of the site: %s", r.Reason)
+	}
+}
+
+// The 1984 Expires is WordPress's nocache_headers() signature and appears even
+// when Cache-Control has been stripped by a plugin.
+func TestClassify_DetectsNocacheHeadersByExpires1984(t *testing.T) {
+	second := hdr(CacheStatusHeader, "MISS", "Expires", "Wed, 11 Jan 1984 05:00:00 GMT")
+	r := Classify(hdr(CacheStatusHeader, "MISS"), second)
+	if !strings.Contains(r.Reason, "1984") {
+		t.Errorf("did not recognise the nocache_headers() signature: %s", r.Reason)
+	}
+}
+
+func TestClassify_BypassWithoutOptOutBlamesTheGate(t *testing.T) {
+	r := Classify(hdr(CacheStatusHeader, "BYPASS"), hdr(CacheStatusHeader, "BYPASS"))
+	if r.Verdict != VerdictNotCaching {
+		t.Fatalf("verdict = %q", r.Verdict)
+	}
+	if !strings.Contains(r.Reason, "skip gate") {
+		t.Errorf("reason = %s", r.Reason)
+	}
+}
+
+// Vary: Accept-Encoding is normal — nginx keys on it. Flagging it would send
+// operators chasing a non-problem on every gzip-enabled site.
+func TestClassify_VaryAcceptEncodingIsNotAProblem(t *testing.T) {
+	if varyDefeatsCache("Accept-Encoding") {
+		t.Error("Accept-Encoding flagged as cache-defeating")
+	}
+	if varyDefeatsCache("accept-encoding, Accept-Encoding") {
+		t.Error("case/duplicate handling wrong")
+	}
+	for _, v := range []string{"Cookie", "User-Agent", "*", "Accept-Encoding, Cookie"} {
+		if !varyDefeatsCache(v) {
+			t.Errorf("Vary: %s should defeat a shared cache entry", v)
+		}
+	}
+}
+
+// No header at all means this vhost is not running the jabali cache config, so
+// the probe must say nothing rather than claim the cache is broken.
+func TestClassify_NoHeaderIsUnknownNotFailure(t *testing.T) {
+	r := Classify(hdr(), hdr())
+	if r.Verdict != VerdictUnknown {
+		t.Fatalf("verdict = %q, want %q", r.Verdict, VerdictUnknown)
+	}
+	if !strings.Contains(r.Reason, "not running the jabali cache config") {
+		t.Errorf("reason = %s", r.Reason)
+	}
+}
+
+// Two misses with no detectable cause still has to say something useful.
+func TestClassify_RepeatedMissReportsBothStatuses(t *testing.T) {
+	r := Classify(hdr(CacheStatusHeader, "MISS"), hdr(CacheStatusHeader, "MISS"))
+	if r.Verdict != VerdictNotCaching {
+		t.Fatalf("verdict = %q", r.Verdict)
+	}
+	if !strings.Contains(r.Reason, "MISS") {
+		t.Errorf("reason should quote the observed statuses: %s", r.Reason)
+	}
+}
+
+func TestClassify_CaseAndWhitespaceInsensitive(t *testing.T) {
+	r := Classify(hdr(CacheStatusHeader, " miss "), hdr(CacheStatusHeader, " hit "))
+	if r.Verdict != VerdictCaching {
+		t.Fatalf("verdict = %q — header comparison must tolerate case and padding", r.Verdict)
+	}
+}


### PR DESCRIPTION
## Green health check, zero cached responses

The cache health check verifies **configuration** — plugin active, drop-in and constants present, Redis reachable — and reports green on all of it.

On brown-online.co.il every one of those passed while the page cache had **never stored a single entry**. The site was in maintenance mode, so WordPress emitted `nocache_headers()` on every response and the fail-closed gate (GH #637) *correctly* refused to store anything. The jcache log showed only MISS and BYPASS, never a HIT, for the life of the site.

Configuration being right and caching working are different claims, and only the second matters to the operator. This makes the second one testable.

## The probe

When the configuration looks healthy, fetch the homepage twice **anonymously** and ask nginx what happened.

- **Anonymously is load-bearing** — a logged-in cookie or `Authorization` header makes nginx bypass by design, so probing as anything but a fresh visitor reports BYPASS on a perfectly healthy site.
- **Pinned to loopback with the Host header set** — a pre-cutover domain still resolves to the *old* host, and probing that would report on somebody else's server.

## It names the cause, not the symptom

"No HIT" isn't actionable. This is:

> configuration is correct but nothing is being cached — the site tells caches not to store this response (Cache-Control: no-cache). A maintenance/coming-soon or security plugin emitting `nocache_headers()` does this site-wide; **the cache is working as designed by refusing to store it**

That last clause matters — otherwise the operator goes hunting for a cache bug that doesn't exist. It also catches WordPress's `nocache_headers()` signature via the **1984 `Expires`**, which survives even when a plugin has stripped `Cache-Control`.

`Vary: Accept-Encoding` is deliberately **not** flagged — nginx keys on it, so treating it as cache-defeating would send operators chasing a non-problem on every gzip-enabled site. Anything else in `Vary` does defeat a shared entry and is reported.

## A probe that can't run says nothing

Site down, TLS refused, no vhost on this box — that is **not** evidence of a cache fault. Surfacing it would turn "could not check" into "failed" for every install in an environment without a reachable vhost. The probe only ever *adds* a verdict; it never invents one.

My first version got this wrong and broke `TestCacheDoctorSweep_HealthySkipsDrift` — which is precisely the false failure it was warning about. Good test.

## Tests

Classification is pure, so the interesting cases are covered without nginx, a tenant site, or a maintenance-mode plugin: the maintenance-mode case, the 1984 signature, bypass-without-opt-out, Vary handling both ways, no-header-means-unknown, and case/whitespace tolerance.

## Still open on JAB-201

The jail-context Redis round-trip (the **object cache** half — needs execution inside the tenant FPM pool, not the agent's root context), HIT-ratio telemetry from the jcache logs, and the purge-spool writability probe.