### PR TITLE
feat(dns): prune imported cPanel service records that break cert issuance (JAB-226)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1436,6 +1436,19 @@ DNS zones and records (dns_zones / dns_records): list / add / update / delete
 jabali dns
 ```
 
+#### `jabali dns prune-service-records`
+
+Remove imported cPanel service subdomains (cpanel/webmail/whm/…) from DNS
+
+```
+jabali dns prune-service-records [flags]
+```
+
+**Flags:**
+
+- `--apply` — actually delete (default is a dry run)
+- `--zone` — limit to one zone (default: every zone)
+
 #### `jabali dns record`
 
 DNS records: list / add / update / delete

--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -175,7 +175,7 @@ func newDNSCmd() *cobra.Command {
 			"validation and conflict rules. Records are written to the DB; the reconciler pushes\n" +
 			"them into PowerDNS on its next tick.",
 	}
-	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd(), newDNSAcmeHookCmd())
+	cmd.AddCommand(newDNSZoneCmd(), newDNSRecordCmd(), newDNSAcmeHookCmd(), newDNSPruneServiceCmd())
 	return cmd
 }
 

--- a/panel-api/cmd/server/dns_prune_service_cmd.go
+++ b/panel-api/cmd/server/dns_prune_service_cmd.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// dns_prune_service_cmd.go — JAB-226 cleanup half.
+//
+// The import filter now drops cPanel's own service hostnames, but boxes
+// migrated BEFORE that fix already carry them in dns_records. Measured on one
+// destination: 763 such rows across 69 domains.
+//
+// They are not cosmetic. The per-domain Let's Encrypt certificate builds its SAN
+// from DNS, so each one becomes a hostname that must pass HTTP-01. Until the
+// source nameservers stop being authoritative those names still resolve to the
+// OLD box and 404 the challenge — and one failed name fails the WHOLE
+// certificate, leaving the domain on a self-signed origin. Behind Cloudflare
+// Full (strict) that is a 526 the moment the domain cuts over.
+//
+// So this has to run BEFORE a cutover, not after.
+
+func newDNSPruneServiceCmd() *cobra.Command {
+	var apply bool
+	var zoneFilter string
+
+	cmd := &cobra.Command{
+		Use:   "prune-service-records",
+		Short: "Remove imported cPanel service subdomains (cpanel/webmail/whm/…) from DNS",
+		Long: "Removes DNS records for hostnames that only ever meant something on cPanel —\n" +
+			"cpanel, whm, webdisk, ftp, cpcalendars, cpcontacts, webmail, autoconfig,\n" +
+			"autodiscover, mail — which a migration imported before the JAB-226 filter existed.\n\n" +
+			"Nothing on jabali serves them, and because the per-domain Let's Encrypt SAN is\n" +
+			"built from DNS, each one is a hostname that must pass HTTP-01. Pre-cutover they\n" +
+			"still resolve to the OLD box and 404, and one failure fails the whole certificate.\n" +
+			"Run this BEFORE cutting a migrated domain over.\n\n" +
+			"Dry-run by default. Re-run with --apply to delete.",
+		Args:    cobra.NoArgs,
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 120*time.Second)
+			defer cancel()
+
+			zonesRepo := repository.NewDNSZoneRepository(sharedDB)
+			recsRepo := repository.NewDNSRecordRepository(sharedDB)
+
+			zones, err := zonesRepo.ListAll(ctx)
+			if err != nil {
+				return fmt.Errorf("list zones: %w", err)
+			}
+
+			type victim struct{ zone, name, typ, id string }
+			var victims []victim
+
+			for i := range zones {
+				z := zones[i]
+				if zoneFilter != "" && !strings.EqualFold(z.Name, zoneFilter) {
+					continue
+				}
+				recs, rErr := recsRepo.ListByZoneID(ctx, z.ID)
+				if rErr != nil {
+					fmt.Fprintf(cmd.OutOrStdout(), "  ! %s: list records: %v\n", z.Name, rErr)
+					continue
+				}
+				for _, r := range recs {
+					// Reuse the SAME predicates the importer now filters on, so
+					// the cleanup and the filter can never disagree about what
+					// counts as a service hostname.
+					if cpanel.IsCPanelServiceRecordName(r.Name) ||
+						cpanel.IsMailInfraRecordName(r.Name, r.Type) {
+						victims = append(victims, victim{z.Name, r.Name, r.Type, r.ID})
+					}
+				}
+			}
+
+			sort.Slice(victims, func(i, j int) bool {
+				if victims[i].zone != victims[j].zone {
+					return victims[i].zone < victims[j].zone
+				}
+				return victims[i].name < victims[j].name
+			})
+
+			if len(victims) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No imported cPanel service records found.")
+				return nil
+			}
+
+			if jsonOutput {
+				out := make([]map[string]string, 0, len(victims))
+				for _, v := range victims {
+					out = append(out, map[string]string{"zone": v.zone, "name": v.name, "type": v.typ})
+				}
+				return printJSON(map[string]any{"records": out, "total": len(victims), "applied": apply})
+			}
+
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ZONE\tNAME\tTYPE")
+			for _, v := range victims {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", v.zone, v.name, v.typ)
+			}
+			_ = w.Flush()
+
+			if !apply {
+				fmt.Fprintf(cmd.OutOrStdout(),
+					"\n%d record(s) would be removed. This is a DRY RUN — nothing changed.\n"+
+						"Re-run with --apply to delete them, then let the reconciler push the zones.\n",
+					len(victims))
+				return nil
+			}
+
+			deleted, failed := 0, 0
+			for _, v := range victims {
+				if dErr := recsRepo.Delete(ctx, v.id); dErr != nil {
+					fmt.Fprintf(cmd.OutOrStdout(), "  ! %s/%s %s: %v\n", v.zone, v.name, v.typ, dErr)
+					failed++
+					continue
+				}
+				deleted++
+			}
+			cliAuditOK(ctx, "dns.prune_service_records", "dns_records", fmt.Sprintf("%d", deleted), nil)
+			fmt.Fprintf(cmd.OutOrStdout(), "\nremoved %d record(s), %d failed.\n"+
+				"The reconciler rewrites each zone in PowerDNS on its next tick (upsert is a full\n"+
+				"replace), so the certificate SAN shrinks once that has run.\n", deleted, failed)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "actually delete (default is a dry run)")
+	cmd.Flags().StringVar(&zoneFilter, "zone", "", "limit to one zone (default: every zone)")
+	return cmd
+}

--- a/panel-api/internal/migrate/cpanel/bind_parse.go
+++ b/panel-api/internal/migrate/cpanel/bind_parse.go
@@ -632,3 +632,25 @@ func isMailInfraRecord(name, typ, content string) bool {
 	}
 	return false
 }
+
+// IsCPanelServiceRecordName reports whether a DNS record name is one of
+// cPanel's own service hostnames.
+//
+// Exported so the cleanup command (`jabali dns prune-service-records`) tests the
+// SAME predicate the importer filters on. Two copies of this list would drift,
+// and the failure mode of drift here is a certificate that will not issue.
+func IsCPanelServiceRecordName(name string) bool {
+	return isCPanelServiceRecord(name)
+}
+
+// IsMailInfraRecordName reports whether a record is jabali-owned mail
+// infrastructure that should not have been imported. Content-independent, so it
+// covers the name/type pairs (webmail, autoconfig, autodiscover, mail) rather
+// than the content-matched TXT cases.
+func IsMailInfraRecordName(name, typ string) bool {
+	switch strings.ToUpper(strings.TrimSpace(typ)) {
+	case "A", "AAAA", "CNAME":
+		return isMailInfraRecord(strings.ToLower(strings.TrimSpace(name)), strings.ToUpper(strings.TrimSpace(typ)), "")
+	}
+	return false
+}

--- a/panel-api/internal/migrate/cpanel/prune_predicates_test.go
+++ b/panel-api/internal/migrate/cpanel/prune_predicates_test.go
@@ -1,0 +1,51 @@
+package cpanel
+
+import "testing"
+
+// JAB-226 cleanup. The import filter and the `dns prune-service-records`
+// cleanup must agree on what counts as a cPanel service hostname. Two copies of
+// that list would drift, and the failure mode of drift here is a certificate
+// that will not issue — so the cleanup calls these exported wrappers rather than
+// keeping its own list.
+func TestExportedPredicatesMatchInternalOnes(t *testing.T) {
+	for _, name := range []string{"cpanel", "whm", "webdisk", "ftp", "cpcalendars", "cpcontacts"} {
+		if IsCPanelServiceRecordName(name) != isCPanelServiceRecord(name) {
+			t.Errorf("%s: exported and internal predicates disagree", name)
+		}
+		if !IsCPanelServiceRecordName(name) {
+			t.Errorf("%s should be pruned", name)
+		}
+	}
+	// Customer subdomains must survive the cleanup exactly as they survive import.
+	for _, name := range []string{"www", "shop", "staging", "api", "myftp", "ftps", "whmcs"} {
+		if IsCPanelServiceRecordName(name) {
+			t.Errorf("%q would be deleted — that is a customer subdomain", name)
+		}
+	}
+}
+
+// The mail family is type-sensitive: cPanel writes these as A as often as CNAME,
+// which is what the original filter missed.
+func TestIsMailInfraRecordName_CoversAAndCNAME(t *testing.T) {
+	for _, name := range []string{"webmail", "autoconfig", "autodiscover", "mail"} {
+		for _, typ := range []string{"A", "AAAA", "CNAME", "a", "cname"} {
+			if !IsMailInfraRecordName(name, typ) {
+				t.Errorf("%s %s not matched — it would survive the cleanup and stay in the SAN", name, typ)
+			}
+		}
+	}
+}
+
+// TXT/MX are content-matched during import and must NOT be swept by a
+// name-only cleanup: an operator's own SPF or a real MX is not import junk.
+func TestIsMailInfraRecordName_IgnoresContentMatchedTypes(t *testing.T) {
+	for _, typ := range []string{"TXT", "MX", "SRV"} {
+		if IsMailInfraRecordName("mail", typ) {
+			t.Errorf("mail %s matched by name alone — the cleanup would delete operator records", typ)
+		}
+	}
+	// And a plain customer record named "mail-archive" is not "mail".
+	if IsMailInfraRecordName("mail-archive", "A") {
+		t.Error("mail-archive matched — prefix matching would eat customer records")
+	}
+}


### PR DESCRIPTION
#924 stopped the import. This cleans up boxes migrated **before** it — which is every already-migrated fleet, including the one with a cutover pending.

## Scale on a live destination

**834 rows across 71 zones:**

```
autoconfig 140, autodiscover 140, mail 71,
cpanel 69, whm 69, webdisk 69, ftp 69, cpcalendars 69, cpcontacts 69, webmail 69
```

Not cosmetic. The per-domain LE certificate builds its **SAN from DNS**, so each is a hostname that must pass HTTP-01. Until the source nameservers stop being authoritative they still resolve to the **old** box and 404 — and one failed name fails the **whole** certificate, leaving the domain self-signed. Behind Cloudflare Full (strict) that's a 526 the moment it cuts over.

**Run before a cutover, not after.**

```
jabali dns prune-service-records            # dry run
jabali dns prune-service-records --apply    # delete
jabali dns prune-service-records --zone x.com
```

Dry run by default, because it deletes DNS records.

## One list, not two

The command calls exported wrappers around the **importer's own predicates** rather than keeping a copy. Two lists would drift, and the failure mode of drift here is a certificate that won't issue. A test asserts the exported and internal predicates agree.

Deliberately **name-only for the mail family, and only A/AAAA/CNAME**. The TXT and MX cases are *content*-matched during import (SPF/DMARC/DKIM bodies) — a name-only sweep of those would delete an operator's own SPF or a real MX. Tests pin that, plus near-misses (`myftp`, `ftps`, `whmcs`, `cpanel-backup`, `mail-archive`) that must survive.

## Verified by dry run against live data

834 records, 71 zones, and **every name in the list is one of the ten service hostnames** — no customer subdomain appears.

## The third criterion needs no code

JAB-226 also asks that "the reconciler prunes pdns records absent from the panel source of truth". **That already happens.** The agent's `dns.zone.upsert` does `DELETE FROM records WHERE domain_id = ?` then re-inserts, so every push is a full replace. I checked the live box: **zero** pdns records lack a panel row.

The reported "`jabali dns record delete` leaves the pdns record behind" is a timing observation — pdns keeps it until the next tick. The junk on migrated boxes lives in the **panel** table, which is why it survives reconciles, and why this is a panel-side cleanup rather than a pdns pruner.