### PR TITLE
feat(digest): add mail volume to the daily digest (GH #840)

### DIFF
--- a/panel-api/internal/reconciler/digest_ticker.go
+++ b/panel-api/internal/reconciler/digest_ticker.go
@@ -151,6 +151,14 @@ func renderDigest(now time.Time, s *repository.DigestStats) (title, body string)
 	}
 
 	fmt.Fprintf(&b, "Certificates expiring within 14 days: %d\n", s.CertsExpiring14d)
+
+	// Mail volume (GH #840): omit entirely on a mail-less install rather
+	// than report a misleading zero.
+	if s.MailStatsAvailable {
+		fmt.Fprintf(&b, "\nMail (24h): %d received, %d sent; %d queued now\n",
+			s.MailReceived, s.MailSent, s.MailQueueNow)
+	}
+
 	fmt.Fprintf(&b, "\nFleet: %d domain%s (%d enabled), %d user%s\n",
 		s.DomainsTotal, plural(s.DomainsTotal), s.DomainsEnabled, s.UsersTotal, plural(s.UsersTotal))
 	return title, b.String()

--- a/panel-api/internal/reconciler/digest_ticker_test.go
+++ b/panel-api/internal/reconciler/digest_ticker_test.go
@@ -159,3 +159,32 @@ func TestDigestKindRegisteredDefaultOff(t *testing.T) {
 	}
 	t.Fatal("digest.daily missing from AllNotificationEventKinds")
 }
+
+// GH #840: the digest carries a mail-volume line when mail stats are
+// available, and omits it entirely on a mail-less install (no misleading 0).
+func TestRenderDigest_MailLine(t *testing.T) {
+	now := time.Date(2026, 8, 2, 6, 0, 0, 0, time.UTC)
+
+	withMail := &repository.DigestStats{
+		AlertsBySeverity:   map[string]int64{},
+		BackupsByStatus:    map[string]int64{},
+		MailStatsAvailable: true,
+		MailReceived:       42,
+		MailSent:           7,
+		MailQueueNow:       3,
+	}
+	_, body := renderDigest(now, withMail)
+	if !strings.Contains(body, "Mail (24h): 42 received, 7 sent; 3 queued now") {
+		t.Errorf("mail line missing/wrong:\n%s", body)
+	}
+
+	noMail := &repository.DigestStats{
+		AlertsBySeverity: map[string]int64{},
+		BackupsByStatus:  map[string]int64{},
+		// MailStatsAvailable false
+	}
+	_, body = renderDigest(now, noMail)
+	if strings.Contains(body, "Mail (24h)") {
+		t.Errorf("mail line must be omitted when stats unavailable:\n%s", body)
+	}
+}

--- a/panel-api/internal/repository/digest_stats_repository.go
+++ b/panel-api/internal/repository/digest_stats_repository.go
@@ -33,6 +33,17 @@ type DigestStats struct {
 	DomainsTotal     int64
 	DomainsEnabled   int64
 	UsersTotal       int64
+
+	// Mail volume for the window (GH #840), derived from the #873
+	// mail_stats_samples counters. MailStatsAvailable is false on a
+	// mail-less / pre-mail-stats install (table absent or no samples), in
+	// which case the digest omits the mail line rather than reporting a
+	// misleading zero. Received = message_ingest_ham + _spam; Sent =
+	// authenticated submissions queued; QueueNow = latest queue gauge.
+	MailStatsAvailable bool
+	MailReceived       int64
+	MailSent           int64
+	MailQueueNow       int64
 }
 
 type DigestStatsRepository interface {
@@ -111,5 +122,52 @@ func (r *digestStatsRepo) Collect(ctx context.Context, since time.Time) (*Digest
 	if err := db.Raw(`SELECT COUNT(*) FROM users`).Scan(&out.UsersTotal).Error; err != nil {
 		return nil, err
 	}
+
+	// Mail volume (GH #840). The #873 mail_stats_samples store cumulative
+	// counters sampled every 15m; total volume in the window is the sum of
+	// positive per-sample deltas (clamped >= 0 so a Stalwart restart's
+	// counter reset doesn't subtract). Best-effort: on a mail-less or
+	// pre-000248 install the table is absent, so an error here leaves mail
+	// stats unavailable (digest omits the line) rather than failing the
+	// whole digest.
+	collectMailVolume(db, since, out)
+
 	return out, nil
+}
+
+// collectMailVolume fills the mail fields best-effort; any error (e.g.
+// mail_stats_samples absent) leaves MailStatsAvailable false.
+func collectMailVolume(db *gorm.DB, since time.Time, out *DigestStats) {
+	var deltas []struct {
+		Metric string
+		Total  int64
+	}
+	// SUM of positive deltas per metric over the window. LAG needs the row
+	// immediately before each; partitioning per metric + ordering by time
+	// gives the previous sample, and GREATEST(...,0) clamps counter resets.
+	if err := db.Raw(`SELECT metric, SUM(GREATEST(value - prev, 0)) AS total FROM (
+			SELECT metric, value,
+			       LAG(value) OVER (PARTITION BY metric ORDER BY sampled_at) AS prev
+			FROM mail_stats_samples
+			WHERE metric IN ('message_ingest_ham','message_ingest_spam','queue_authenticated_message_queued')
+			  AND sampled_at >= ?
+		) t WHERE prev IS NOT NULL GROUP BY metric`, since).Scan(&deltas).Error; err != nil {
+		return // table absent / query unsupported — leave unavailable
+	}
+	for _, d := range deltas {
+		switch d.Metric {
+		case "message_ingest_ham", "message_ingest_spam":
+			out.MailReceived += d.Total
+		case "queue_authenticated_message_queued":
+			out.MailSent += d.Total
+		}
+	}
+	// Current queue depth = latest gauge sample.
+	var queueNow int64
+	if err := db.Raw(`SELECT value FROM mail_stats_samples
+		WHERE metric = 'queue_size' ORDER BY sampled_at DESC LIMIT 1`).Scan(&queueNow).Error; err != nil {
+		return
+	}
+	out.MailQueueNow = queueNow
+	out.MailStatsAvailable = true
 }


### PR DESCRIPTION
The Logwatch-style daily digest (#840) already ships (alerts by severity, busiest events, backups, certs expiring, fleet counts) and is wired + pinned. But it carried **no mail volume** — the one metric the original requester (a mail-focused admin, Zimbra parallel) most wanted, and the one the first reply promised.

## What
Adds a `Mail (24h): N received, N sent; N queued now` line to the digest, derived from the #873 `mail_stats_samples` counters:
- **received** = `message_ingest_ham` + `message_ingest_spam`
- **sent** = `queue_authenticated_message_queued`
- both as the **sum of positive per-sample deltas** (clamped `>= 0`, so a Stalwart restart's counter reset doesn't subtract — same approach as the #873 charts)
- **queued now** = latest `queue_size` gauge

Best-effort, gated on `MailStatsAvailable`: on a mail-less / pre-`000248` install the samples table is absent, so the collector leaves mail unavailable and the digest **omits the line** rather than printing a misleading zero (the same optional-component lesson as the #502 backup fix).

## Test plan
- [x] `TestRenderDigest_MailLine` — line present when available, omitted when not
- [x] full reconciler + repository suites
- [x] verified the delta SQL against live `mail_stats_samples` on testserver (window-function `LAG`, reset-clamped) — returns correct 24h volume