### PR TITLE
fix(ssl): drop SANs that resolve somewhere other than this server (JAB-226)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2481,7 +2481,18 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 		// Drop unresolvable SAN names — they would otherwise fail
 		// HTTP-01 and tank the whole cert. The base name +
 		// www.<name> always remain (added agent-side).
-		if filtered := r.resolvableSANs(issueCtx, extras); len(filtered) > 0 {
+		filtered := r.resolvableSANs(issueCtx, extras)
+		// JAB-226: resolving is not enough. During a migration the helper
+		// names still answer with the SOURCE box's address until its
+		// nameservers stop being authoritative, so they pass the resolvable
+		// test, the challenge lands on the old server, and one 404 fails the
+		// whole certificate — apex included. Only applied on the ACME path:
+		// a self-signed cert covering a name that points elsewhere is
+		// harmless, and filtering it there would just churn the cert.
+		if len(filtered) > 0 {
+			filtered = r.reachableSANs(issueCtx, domain.Name, filtered)
+		}
+		if len(filtered) > 0 {
 			params["hostnames"] = filtered
 		}
 	}

--- a/panel-api/internal/reconciler/san_reachable.go
+++ b/panel-api/internal/reconciler/san_reachable.go
@@ -1,0 +1,136 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dnsverify"
+)
+
+// san_reachable.go — JAB-226.
+//
+// resolvableSANs keeps any SAN that resolves in public DNS AT ALL. That was the
+// right fix for its own incident (SANs with no record anywhere tanked the cert),
+// but it is not sufficient: a name can resolve perfectly and still point
+// somewhere else.
+//
+// That is the normal state of a migration. Until the source nameservers stop
+// being authoritative, mail./autoconfig./autodiscover.<domain> still answer with
+// the OLD box's address. They resolve, so they survive the filter, certbot asks
+// Let's Encrypt to validate them, the challenge lands on the old server and
+// 404s — and one failed name fails the WHOLE certificate, apex included. The
+// domain stays on a self-signed origin, which behind Cloudflare Full (strict) is
+// a 526. Observed on newhighsite: "Requesting a certificate for … and 3 more
+// domains" -> autoconfig./autodiscover./mail. 404 -> "Some challenges failed".
+//
+// So the question is not "does this name resolve" but "will a challenge for it
+// reach US".
+
+// sanReachability decides which SANs can plausibly pass HTTP-01 against this
+// server.
+//
+// A SAN is kept when either:
+//
+//   - it resolves to one of this server's public addresses — the direct case; or
+//   - it resolves to the same address(es) as the apex — the fronted case. When a
+//     domain sits behind a CDN or proxy, NOTHING resolves to us directly, yet
+//     HTTP-01 still succeeds because the proxy forwards the challenge. Requiring
+//     an exact match with our IP would drop every SAN on every proxied domain
+//     and break setups that work today.
+//
+// Dropping only the names that resolve somewhere OTHER than wherever the apex
+// lives is what separates "not cut over yet" from "behind Cloudflare".
+//
+// apexAddrs or ourAddrs being empty means we cannot make the judgement, so
+// everything is kept — this filter narrows, it never invents a reason to fail.
+func sanReachability(sanAddrs, apexAddrs, ourAddrs []string) bool {
+	if len(sanAddrs) == 0 {
+		return false // no DNS at all: the pre-existing resolvableSANs rule
+	}
+	if len(apexAddrs) == 0 && len(ourAddrs) == 0 {
+		return true // nothing to compare against — do not guess
+	}
+	if intersects(sanAddrs, ourAddrs) {
+		return true
+	}
+	if intersects(sanAddrs, apexAddrs) {
+		return true
+	}
+	return false
+}
+
+func intersects(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		set[x] = struct{}{}
+	}
+	for _, x := range a {
+		if _, ok := set[x]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// reachableSANs filters names to those a Let's Encrypt HTTP-01 challenge could
+// actually reach on this server. Layered on top of resolvableSANs' "must resolve
+// at all" rule rather than replacing it.
+//
+// Best-effort by construction: when the apex cannot be resolved and this
+// server's public address is unknown, every name is kept and the behaviour is
+// exactly what it was before.
+func (r *Reconciler) reachableSANs(ctx context.Context, apex string, names []string) []string {
+	if len(names) == 0 {
+		return nil
+	}
+
+	var ourAddrs []string
+	if r.serverSettings != nil {
+		if srv, err := r.serverSettings.Get(ctx); err == nil && srv != nil {
+			if srv.PublicIPv4 != "" {
+				ourAddrs = append(ourAddrs, srv.PublicIPv4)
+			}
+			if srv.PublicIPv6 != "" {
+				ourAddrs = append(ourAddrs, srv.PublicIPv6)
+			}
+		}
+	}
+
+	apexCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+	apexAddrs := dnsverify.LookupHostExternal(apexCtx, apex)
+	cancel()
+
+	if len(apexAddrs) == 0 && len(ourAddrs) == 0 {
+		return names // cannot judge — unchanged behaviour
+	}
+
+	type result struct {
+		name string
+		keep bool
+	}
+	resCh := make(chan result, len(names))
+	for _, n := range names {
+		go func(name string) {
+			lookupCtx, c := context.WithTimeout(ctx, 6*time.Second)
+			defer c()
+			addrs := dnsverify.LookupHostExternal(lookupCtx, name)
+			resCh <- result{name: name, keep: sanReachability(addrs, apexAddrs, ourAddrs)}
+		}(n)
+	}
+
+	keep := make([]string, 0, len(names))
+	for i := 0; i < len(names); i++ {
+		res := <-resCh
+		if res.keep {
+			keep = append(keep, res.name)
+			continue
+		}
+		r.log.Warn("ssl: skipping SAN — it resolves somewhere other than this server or the apex, "+
+			"so an HTTP-01 challenge for it would land elsewhere and fail the whole certificate",
+			"san", res.name, "apex", apex)
+	}
+	return keep
+}

--- a/panel-api/internal/reconciler/san_reachable_test.go
+++ b/panel-api/internal/reconciler/san_reachable_test.go
@@ -1,0 +1,88 @@
+package reconciler
+
+import "testing"
+
+// JAB-226. The pre-existing filter asks "does this name resolve". That is not
+// the question — a name can resolve perfectly and still point at somebody else's
+// server, which is the normal state of a migration until the source nameservers
+// stop being authoritative. The challenge then lands on the OLD box, 404s, and
+// one failed name fails the whole certificate including the apex.
+func TestSANReachability(t *testing.T) {
+	const (
+		ourIP    = "203.0.113.10"
+		oldBoxIP = "198.51.100.20"
+		cfIP1    = "104.16.1.1"
+		cfIP2    = "104.16.2.2"
+	)
+
+	for _, tc := range []struct {
+		name     string
+		san      []string
+		apex     []string
+		ours     []string
+		wantKeep bool
+		why      string
+	}{
+		{
+			name: "points at us directly", san: []string{ourIP},
+			apex: []string{ourIP}, ours: []string{ourIP},
+			wantKeep: true, why: "the ordinary case",
+		},
+		{
+			name: "still points at the source box", san: []string{oldBoxIP},
+			apex: []string{ourIP}, ours: []string{ourIP},
+			wantKeep: false, why: "THE BUG: resolves fine, challenge lands elsewhere, kills the whole cert",
+		},
+		{
+			name: "behind a proxy, same as apex", san: []string{cfIP1, cfIP2},
+			apex: []string{cfIP1, cfIP2}, ours: []string{ourIP},
+			wantKeep: true, why: "nothing resolves to us when proxied, but the proxy forwards the challenge",
+		},
+		{
+			name: "proxied apex, SAN left on the old box", san: []string{oldBoxIP},
+			apex: []string{cfIP1}, ours: []string{ourIP},
+			wantKeep: false, why: "exactly the newhighsite incident",
+		},
+		{
+			name: "no DNS at all", san: nil,
+			apex: []string{ourIP}, ours: []string{ourIP},
+			wantKeep: false, why: "pre-existing resolvableSANs rule preserved",
+		},
+		{
+			name: "cannot judge — keep", san: []string{oldBoxIP},
+			apex: nil, ours: nil,
+			wantKeep: true, why: "this filter narrows; it must never invent a reason to fail",
+		},
+		{
+			name: "partial overlap with apex counts", san: []string{cfIP2},
+			apex: []string{cfIP1, cfIP2}, ours: []string{ourIP},
+			wantKeep: true, why: "round-robin A records legitimately return subsets",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanReachability(tc.san, tc.apex, tc.ours); got != tc.wantKeep {
+				t.Errorf("keep = %v, want %v — %s", got, tc.wantKeep, tc.why)
+			}
+		})
+	}
+}
+
+// IPv6-only hosts must not be judged against an empty v4 list.
+func TestSANReachability_IPv6(t *testing.T) {
+	v6 := "2001:db8::1"
+	if !sanReachability([]string{v6}, nil, []string{v6}) {
+		t.Error("a SAN matching our IPv6 was dropped")
+	}
+}
+
+func TestIntersects(t *testing.T) {
+	if intersects(nil, []string{"a"}) || intersects([]string{"a"}, nil) {
+		t.Error("empty input must not intersect")
+	}
+	if !intersects([]string{"a", "b"}, []string{"b", "c"}) {
+		t.Error("shared element not detected")
+	}
+	if intersects([]string{"a"}, []string{"b"}) {
+		t.Error("disjoint sets reported as intersecting")
+	}
+}


### PR DESCRIPTION
Closes JAB-226's last criterion. The filter was asking the wrong question.

## Resolving isn't the same as reachable

`resolvableSANs` keeps any SAN that resolves in public DNS **at all**. That was right for its own incident — names with no record anywhere tanked the cert. But a name can resolve perfectly and still point at somebody else's server, and **that is the normal state of a migration**.

Until the source nameservers stop being authoritative, `mail.`/`autoconfig.`/`autodiscover.<domain>` answer with the **old box's** address. They resolve, so they survive the filter. certbot asks LE to validate them, the challenge lands on the source server and 404s — and one failed name fails the **whole** certificate, apex included.

Observed on newhighsite:

```
Requesting a certificate for … and 3 more domains
autoconfig./autodiscover./mail.: Invalid response … 404
Some challenges have failed.
```

## The rule

Keep a SAN when it resolves to one of this server's public addresses, **or** to the same address(es) as the apex.

**That second clause is load-bearing.** When a domain sits behind a CDN, *nothing* resolves to us directly — yet HTTP-01 still succeeds because the proxy forwards the challenge. Requiring an exact match with our own IP would drop every SAN on every proxied domain and break setups that work today.

Comparing against the apex is what separates *"not cut over yet"* from *"behind Cloudflare"*:

| SAN resolves to | apex resolves to | keep? |
|---|---|---|
| us | us | yes — ordinary |
| Cloudflare | Cloudflare | yes — proxy forwards the challenge |
| **old box** | **us or Cloudflare** | **no — this is the bug** |
| nothing | anything | no — pre-existing rule |
| anything | unknown, and our IP unknown | yes — never guess |

**ACME path only.** A self-signed cert covering a name that points elsewhere is harmless, and filtering it there would just churn the cert for no benefit.

Best-effort by construction: when the apex can't be resolved and our public address is unknown, everything is kept and behaviour is unchanged. This filter narrows; it must never invent a reason to fail.

## JAB-226 is now complete

- **#924** — stopped the import (9 junk names per zone, all `A` records the CNAME-only filter missed)
- **#933** — cleans boxes migrated before it (834 rows / 71 zones on one destination)
- **this** — stops any remaining unreachable name from failing the cert
- **third criterion** — needed no code: `dns.zone.upsert` already full-replaces, verified zero orphans on a live box