### PR TITLE
fix(migrate): a job interrupted mid-restore can be resumed (JAB-216)

### DIFF
--- a/panel-api/internal/migrate/stage.go
+++ b/panel-api/internal/migrate/stage.go
@@ -10,10 +10,10 @@ import (
 // snake_case so they're URL-safe in the per-stage logs endpoint
 // (Step 8 UI exposes /admin/migrations/:id/stages/:stage/logs).
 const (
-	StageAnalyze   = "analyze"
-	StageFixPerms  = "fix_perms"
-	StageValidate  = "validate"
-	StageRestore   = "restore"
+	StageAnalyze  = "analyze"
+	StageFixPerms = "fix_perms"
+	StageValidate = "validate"
+	StageRestore  = "restore"
 )
 
 // AllStages is the canonical pipeline order. Importers seed
@@ -73,7 +73,26 @@ var jobTransitions = map[string]map[string]struct{}{
 		models.MigrationStateFailed:    {},
 		models.MigrationStateCancelled: {},
 	},
+	// Restoring is RESUMABLE (JAB-216), for the same reason failed and
+	// degraded are. A job only reaches this state while a runner is working,
+	// so it looks like an in-flight lock — but the state is written to the
+	// database, and the thing it describes is a process. When that process
+	// dies without warning the row keeps saying "restoring" forever.
+	//
+	// That is not hypothetical: a restore OOM-wedged its host, the box needed
+	// a console reboot, and the job was left mid-restore. Resume re-enters at
+	// analyze, the runner asked for restoring -> analyzing, this table said no,
+	// and the only way out was --retry-from-scratch (which writes the state
+	// directly and so never consulted this table) — i.e. redoing hours of work
+	// that had already succeeded.
+	//
+	// This does mean a second runner can be started against a job whose first
+	// runner is genuinely still alive. That risk is identical for failed and
+	// degraded above, the stages are idempotent, and "operator cannot recover
+	// after a host dies" is much the worse failure.
 	models.MigrationStateRestoring: {
+		models.MigrationStateAnalyzing: {},
+		models.MigrationStatePending:   {},
 		models.MigrationStateDone:      {},
 		models.MigrationStateFailed:    {},
 		models.MigrationStateCancelled: {},

--- a/panel-api/internal/migrate/stage_resume_test.go
+++ b/panel-api/internal/migrate/stage_resume_test.go
@@ -1,0 +1,68 @@
+package migrate
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-216. A restore OOM-wedged its host, the box needed a console reboot, and
+// the job was left in `restoring`. The runner re-enters a resume at analyze, the
+// transition table refused restoring -> analyzing, and the only way out was
+// --retry-from-scratch — redoing hours of work that had already succeeded.
+//
+// A state written to the database describing a process that no longer exists is
+// a stale marker, not a lock.
+func TestRestoringIsResumable(t *testing.T) {
+	if !IsValidJobTransition(models.MigrationStateRestoring, models.MigrationStateAnalyzing) {
+		t.Error("restoring -> analyzing refused: a job interrupted by host death cannot be resumed")
+	}
+	if !IsValidJobTransition(models.MigrationStateRestoring, models.MigrationStatePending) {
+		t.Error("restoring -> pending refused: --retry-from-scratch would depend on bypassing this table")
+	}
+}
+
+// The resumable states must behave alike — an operator should not have to know
+// which flavour of interruption they hit.
+func TestResumableStatesAgree(t *testing.T) {
+	for _, from := range []string{
+		models.MigrationStateFailed,
+		models.MigrationStateDegraded,
+		models.MigrationStateRestoring,
+	} {
+		if !IsValidJobTransition(from, models.MigrationStateAnalyzing) {
+			t.Errorf("%s -> analyzing refused, but %s is meant to be resumable", from, from)
+		}
+	}
+}
+
+// Terminal really is terminal — resumability must not have leaked into states
+// where a re-run would duplicate completed work or revive a cancelled job.
+func TestTerminalStatesStayTerminal(t *testing.T) {
+	for _, from := range []string{models.MigrationStateDone, models.MigrationStateCancelled} {
+		for _, to := range []string{
+			models.MigrationStateAnalyzing,
+			models.MigrationStateRestoring,
+			models.MigrationStatePending,
+		} {
+			if IsValidJobTransition(from, to) {
+				t.Errorf("%s -> %s allowed — terminal states must not restart", from, to)
+			}
+		}
+	}
+}
+
+// The forward path must be unchanged by the resume additions.
+func TestForwardPathIntact(t *testing.T) {
+	for _, step := range [][2]string{
+		{models.MigrationStatePending, models.MigrationStateAnalyzing},
+		{models.MigrationStateAnalyzing, models.MigrationStateFixPerms},
+		{models.MigrationStateFixPerms, models.MigrationStateValidating},
+		{models.MigrationStateValidating, models.MigrationStateRestoring},
+		{models.MigrationStateRestoring, models.MigrationStateDone},
+	} {
+		if !IsValidJobTransition(step[0], step[1]) {
+			t.Errorf("forward step %s -> %s broken", step[0], step[1])
+		}
+	}
+}


### PR DESCRIPTION
## The trap

A restore OOM-wedged its host, the box needed a provider-console reboot, and the job was left in state `restoring`.

Resuming re-enters the pipeline at analyze. The transition table refused `restoring → analyzing`. The only way forward was `--retry-from-scratch` — **redoing hours of work that had already succeeded.**

## Why it was wrong

`restoring` *looks* like an in-flight lock. It isn't. It's a row in the database describing a **process**, and when that process dies without warning the row keeps saying "restoring" forever.

The same reasoning already makes `failed` and `degraded` resumable — both are commented in that file as such. `restoring` was simply never given the same treatment.

## Why it stayed hidden

`--retry-from-scratch` writes the state directly and never consults the transition table. So **the destructive path worked and the gentle one didn't** — which is the worst way round for a bug to present, because the workaround that succeeds is the one that throws away good work.

## The exposure, stated

This allows a second runner to start against a job whose first runner is genuinely still alive. That exposure is **identical** for `failed` and `degraded` today, the stages are idempotent, and "the operator cannot recover after a host dies" is much the worse failure.

## Tests

- the three resumable states agree — an operator shouldn't need to know which flavour of interruption they hit
- `done`/`cancelled` stay terminal, so a re-run can't duplicate completed work or revive a cancelled job
- the forward path is unchanged

## JAB-216 status

- **#929** — memory pre-flight (refuse/warn before starting on a host with no headroom)
- **this** — interrupted job resumes cleanly
- **still open** — `MemoryHigh=`/`MemoryMax=` bounds on Stalwart and other core services
- **needed no change** — sshd already carries `oom_score_adj -1000` from OpenSSH itself, verified on a live box; the issue's suggested drop-in would have changed nothing