### PR TITLE
fix(mail): bound Stalwart's memory so a mail ingest cannot wedge the host (JAB-216)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,32 @@ jobs:
       - name: Run lint
         run: tools/lint-install-sh.sh
 
+  install-sh-tests:
+    name: install.sh regression tests
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run install/tests
+        # These are per-incident regression guards (OOM sizing, /etc/hosts
+        # loopback shadow, pdns upstream, socket helpers). They existed but
+        # were never wired into CI, so two of them sat red on main for weeks
+        # while asserting nothing. A guard nobody runs is not a guard.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          failed=0
+          for t in install/tests/*.sh; do
+            echo "::group::$(basename "$t")"
+            if bash "$t"; then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error file=$t::$(basename "$t") failed"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
   pinned-downloads:
     name: install.sh pinned downloads published
     runs-on: self-hosted

--- a/install.sh
+++ b/install.sh
@@ -2727,12 +2727,14 @@ OPC_EOF
 #
 # Idempotent: only writes when desired != on-disk; only restarts
 # when something actually changed.
-tune_mariadb_for_ram() {
-  local tuning_dropin="/etc/mysql/mariadb.conf.d/99-jabali-mariadb-tuning.cnf"
-  local oom_dropin="/etc/systemd/system/mariadb.service.d/15-jabali-oom.conf"
-  local mem_kb mem_mb pool_mb
-  mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
-  mem_mb=$((mem_kb / 1024))
+# mariadb_pool_size_mb <host-ram-mb> — prints the innodb_buffer_pool_size in MB.
+#
+# Split from tune_mariadb_for_ram so the brackets can be tested by running them
+# at every interesting host size. The test used to grep install.sh for bracket
+# literals, which silently stopped covering anything when #597 replaced the
+# bracket ladder with a percentage.
+mariadb_pool_size_mb() {
+  local mem_mb="$1" pool_mb
 
   if   [[ $mem_mb -le 2048 ]]; then pool_mb=128
   elif [[ $mem_mb -le 4096 ]]; then pool_mb=256
@@ -2740,6 +2742,18 @@ tune_mariadb_for_ram() {
     pool_mb=$((mem_mb * 35 / 100))
     [[ $pool_mb -lt 1024 ]] && pool_mb=1024   # #597 floor
   fi
+
+  printf '%s\n' "$pool_mb"
+}
+
+tune_mariadb_for_ram() {
+  local tuning_dropin="/etc/mysql/mariadb.conf.d/99-jabali-mariadb-tuning.cnf"
+  local oom_dropin="/etc/systemd/system/mariadb.service.d/15-jabali-oom.conf"
+  local mem_kb mem_mb pool_mb
+  mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+  mem_mb=$((mem_kb / 1024))
+
+  pool_mb=$(mariadb_pool_size_mb "$mem_mb")
   # NOTE: innodb_buffer_pool_instances was REMOVED in MariaDB 11.x (single
   # resizable buffer pool) — do NOT set it, MariaDB rejects the unknown var.
   _log "mariadb-tune: host=${mem_mb}MB RAM -> innodb_buffer_pool_size=${pool_mb}M"

--- a/install.sh
+++ b/install.sh
@@ -2804,6 +2804,140 @@ OOM_EOF
   fi
 }
 
+# bound_stalwart_memory caps how much memory Stalwart can take before the
+# kernel starts killing whatever else is on the box (JAB-216).
+#
+# Why: serial cPanel restores on a 7.7 GB host drove it into repeated global
+# OOM kills over four hours and finally into a full userspace wedge — sshd
+# stopped answering, nginx stopped serving, and the box needed a provider-
+# console reboot. The kernel's last kill was stalwart at ~888 MB anon-rss
+# while it ingested migrated mail. Stalwart runs unbounded (MemoryHigh and
+# MemoryMax both infinity), so a heavy ingest has nothing between it and the
+# host's last free page.
+#
+# The two limits do different jobs and BOTH are needed:
+#   MemoryHigh — soft. The kernel throttles allocation and reclaims harder
+#     above it. Nothing is killed; a busy server gets slower. This is the one
+#     that would have applied back-pressure long before the box died.
+#   MemoryMax — hard. Exceeding it OOM-kills inside Stalwart's OWN cgroup, so
+#     a genuine runaway costs mail delivery (and systemd restarts it) instead
+#     of costing the operator console access. Containing the blast radius is
+#     the entire point; a mail outage is recoverable over SSH, a wedged host
+#     is not.
+#
+# Sizing, mirroring tune_mariadb_for_ram: a fraction of host RAM so small VMs
+# stay conservative, with a floor so a tiny box still gets a workable mail
+# server, and a CEILING because past a few GB any further growth is runaway
+# rather than legitimate working set. Stalwart idles near 100 MB.
+#   MemoryHigh = 25 % of RAM, floor 512 MB,  ceiling 4096 MB
+#   MemoryMax  = 40 % of RAM, floor 768 MB,  ceiling 6144 MB
+# On the 7.7 GB box from the incident that is High=1927M / Max=3084M — the
+# fatal kill happened at 888 MB anon-rss, so reclaim pressure would have
+# started well before the host ran out.
+#
+# OOMScoreAdjust is deliberately NOT set here. With MemoryMax in place a
+# runaway is contained in-cgroup, and the global OOM order already prefers
+# tenant slices (oom_score_adj 100). sshd needs nothing either: OpenSSH sets
+# its listener to -1000 itself, verified on a live host, and a systemd
+# OOMScoreAdjust on ssh.service would apply to the whole cgroup — making
+# tenant SSH sessions un-killable, which is worse than the problem.
+#
+# Idempotent: only writes when desired != on-disk. Uses `set-property
+# --runtime` afterwards so the new bounds apply WITHOUT restarting a running
+# mail server; the drop-in is what makes them survive a reboot.
+# stalwart_mem_bounds_mb <host-ram-mb> — prints "<high_mb> <max_mb>".
+#
+# Split from bound_stalwart_memory so the brackets can be tested directly at
+# every interesting host size instead of only grepped for. Pure arithmetic:
+# no filesystem, no systemctl.
+stalwart_mem_bounds_mb() {
+  local mem_mb="$1" high_mb max_mb
+
+  high_mb=$((mem_mb * 25 / 100))
+  [[ $high_mb -lt 512  ]] && high_mb=512
+  [[ $high_mb -gt 4096 ]] && high_mb=4096
+  max_mb=$((mem_mb * 40 / 100))
+  [[ $max_mb -lt 768  ]] && max_mb=768
+  [[ $max_mb -gt 6144 ]] && max_mb=6144
+
+  # Guard, not a live branch: with the brackets above the soft limit is always
+  # under the hard one. It exists because that is a property of the CONSTANTS,
+  # not of the shape — raising the MemoryHigh floor past 768 would invert them,
+  # and systemd would then kill at Max having never throttled at High, silently
+  # removing the only mechanism that degrades gracefully. Cheaper to keep than
+  # to rediscover.
+  if [[ $high_mb -ge $max_mb ]]; then
+    high_mb=$((max_mb * 80 / 100))
+  fi
+
+  printf '%s %s\n' "$high_mb" "$max_mb"
+}
+
+bound_stalwart_memory() {
+  local dropin_dir="/etc/systemd/system/jabali-stalwart.service.d"
+  local dropin="${dropin_dir}/20-jabali-memory.conf"
+  local mem_kb mem_mb high_mb max_mb
+
+  # Nothing to bound on a host without the mail unit (modular install with
+  # mail disabled). Not an error.
+  if ! systemctl list-unit-files jabali-stalwart.service >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ ! -f /etc/systemd/system/jabali-stalwart.service ]]; then
+    return 0
+  fi
+
+  mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+  mem_mb=$((mem_kb / 1024))
+  if [[ $mem_mb -le 0 ]]; then
+    _warn "stalwart-mem: cannot read MemTotal; leaving Stalwart unbounded"
+    return 0
+  fi
+
+  read -r high_mb max_mb < <(stalwart_mem_bounds_mb "$mem_mb")
+
+  local desired
+  desired=$(cat <<STALWART_MEM_EOF
+# Managed by jabali install.sh -- sized to ${mem_mb} MB host RAM.
+# Do NOT hand-edit; install.sh rewrites on every run.
+# See install.sh:bound_stalwart_memory for the sizing brackets (JAB-216).
+[Service]
+MemoryAccounting=yes
+MemoryHigh=${high_mb}M
+MemoryMax=${max_mb}M
+STALWART_MEM_EOF
+)
+
+  if [[ -f "$dropin" ]] && cmp -s <(printf '%s\n' "$desired") "$dropin"; then
+    _log "stalwart-mem: drop-in already current (High=${high_mb}M Max=${max_mb}M)"
+    return 0
+  fi
+
+  mkdir -p "$dropin_dir"
+  local tmp
+  tmp="$(mktemp --tmpdir jabali-stalwart-mem.XXXXXX)"
+  printf '%s\n' "$desired" >"$tmp"
+  install -m 0644 -o root -g root "$tmp" "$dropin"
+  rm -f "$tmp"
+  systemctl daemon-reload
+  _log "stalwart-mem: wrote $dropin"
+
+  # Apply to the RUNNING unit without a restart. Bouncing Stalwart drops live
+  # IMAP/JMAP sessions and interrupts mail delivery, which is too much
+  # collateral for a limit change — and mid-migration, restarting the very
+  # service that is ingesting mail is exactly the wrong move.
+  if systemctl is-active --quiet jabali-stalwart.service; then
+    if systemctl set-property --runtime jabali-stalwart.service \
+         "MemoryHigh=${high_mb}M" "MemoryMax=${max_mb}M" >/dev/null 2>&1; then
+      _ok "stalwart-mem: MemoryHigh=${high_mb}M MemoryMax=${max_mb}M (host ${mem_mb}MB, applied live)"
+    else
+      _warn "stalwart-mem: drop-in written but live apply failed; bounds take effect on next restart"
+    fi
+  else
+    _ok "stalwart-mem: MemoryHigh=${high_mb}M MemoryMax=${max_mb}M (host ${mem_mb}MB, applies on next start)"
+  fi
+}
+
 
 
 # ensure_mariadb_socket_acl_for_jabali — POSIX ACL fallback so the
@@ -11599,6 +11733,12 @@ EOF
   install -m 0644 -o root -g root "${REPO_DIR}/install/systemd/jabali-stalwart.service" \
     /etc/systemd/system/jabali-stalwart.service
 
+  # JAB-216: bound the mail server's memory before step 3 starts it, so a
+  # fresh host never runs an unbounded Stalwart even for one boot. Must come
+  # after the unit is on disk (the drop-in directory is named for it) and
+  # before the enable --now below.
+  bound_stalwart_memory || _warn "stalwart memory bounds not applied (non-fatal)"
+
   # Spam-filter rules weekly refresh. Refresh script + timer + service.
   # Enabled+started here so a fresh install ends with the timer armed.
   local refresh_src="${REPO_DIR}/install/stalwart/jabali-spam-rules-refresh"
@@ -14174,6 +14314,14 @@ EOF
   # on-change; guarded on mariadb being installed.
   if declare -f tune_mariadb_for_ram >/dev/null 2>&1 && command -v mariadb >/dev/null 2>&1; then
     tune_mariadb_for_ram
+  fi
+
+  # Stalwart memory bounds (JAB-216) — self-heal on every update so hosts
+  # installed before this existed stop running an unbounded mail server. This
+  # is the fix for a real wedge, so existing fleets are exactly who needs it.
+  # Non-fatal: a limit that cannot be applied must not abort an update.
+  if declare -f bound_stalwart_memory >/dev/null 2>&1; then
+    bound_stalwart_memory || _warn "stalwart memory bounds not applied (non-fatal)"
   fi
 
 }

--- a/install/tests/test_etc_hosts_loopback_strip.sh
+++ b/install/tests/test_etc_hosts_loopback_strip.sh
@@ -50,11 +50,16 @@ else
   if [[ -z "$gate_open" || -z "$gate_close" || -z "$strip_line" ]]; then
     echo "FAIL: could not locate (gate_open=$gate_open, gate_close=$gate_close, strip_line=$strip_line)"
     fail=1
-  elif [[ "$strip_line" -le "$gate_close" ]]; then
-    echo "FAIL: /etc/hosts strip (line $strip_line) is inside the JABALI_HOSTNAME gate (closes at line $gate_close) — still gated, bug regressed"
+  # The requirement is that the strip is not INSIDE the gate. It can satisfy
+  # that from either side — this originally asserted "after the gate closes",
+  # but the strip was later moved to the top of the function instead, which is
+  # equally unconditional. Asserting one arrangement rather than the property
+  # made this test read a correct install.sh as a regression.
+  elif [[ "$strip_line" -ge "$gate_open" && "$strip_line" -le "$gate_close" ]]; then
+    echo "FAIL: /etc/hosts strip (line $strip_line) is inside the JABALI_HOSTNAME gate (lines $gate_open-$gate_close) — still gated, bug regressed"
     fail=1
   else
-    echo "ok: strip at line $strip_line is unconditional (gate closes at $gate_close)"
+    echo "ok: strip at line $strip_line is unconditional (gate spans $gate_open-$gate_close)"
   fi
 fi
 

--- a/install/tests/test_mariadb_tuning.sh
+++ b/install/tests/test_mariadb_tuning.sh
@@ -21,14 +21,59 @@ cd "$(dirname "$0")/../.."
 
 fail=0
 
-# --- 1. Function exists + has the bracket map. ---
+# --- 1. Function exists; the sizing is EXECUTED, not grepped. ---
+#
+# This previously asserted four bracket literals (-le 2048/4096/8192/16384).
+# #597 replaced the upper brackets with a percentage, so two of them stopped
+# matching and this test has been failing ever since — unnoticed, because
+# install/tests was not wired into CI. Grepping for constants stops covering
+# anything the moment the shape changes; running the arithmetic does not.
 if ! grep -q '^tune_mariadb_for_ram() {' install.sh; then
   echo "FAIL: tune_mariadb_for_ram function not defined in install.sh"
   fail=1
 fi
-for bracket in '\[\[ \$mem_mb -le 2048' '\[\[ \$mem_mb -le 4096' '\[\[ \$mem_mb -le 8192' '\[\[ \$mem_mb -le 16384'; do
-  if ! grep -Eq "$bracket" install.sh; then
-    echo "FAIL: missing bracket: $bracket"
+
+fn_src=$(awk '/^mariadb_pool_size_mb\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: mariadb_pool_size_mb not defined in install.sh"
+  exit 1
+fi
+eval "$fn_src"
+
+check_pool() {
+  local mem_mb="$1" want="$2" label="$3" got
+  got=$(mariadb_pool_size_mb "$mem_mb")
+  if [[ "$got" != "$want" ]]; then
+    echo "FAIL: ${mem_mb}MB host ($label): pool=${got}M, want ${want}M"
+    fail=1
+  fi
+}
+
+#          host    pool   why
+check_pool 1024    128    "tiny VM, OOM-critical"
+check_pool 2048    128    "top of the tiny bracket"
+check_pool 2049    256    "just over into the puzzle bracket"
+check_pool 3891    256    "the puzzle box (3.8 GB) that was OOM-killed twice"
+check_pool 4096    256    "top of the puzzle bracket"
+# The 1024 MB floor is unreachable with the brackets as they stand: it binds
+# only below ~2926 MB, and everything under 4096 MB is already caught by the
+# fixed brackets above. Left in place as a guard for future bracket edits —
+# same reason as the one in stalwart_mem_bounds_mb — so this asserts the 35%
+# that actually applies rather than the floor that does not.
+check_pool 4097    1433   "just over the bracket — 35%, floor does not bind"
+check_pool 8192    2867   "35% of RAM"
+check_pool 12288   4300   "35% of RAM"
+
+# The pool must never claim the whole box: this shares RAM with panel-api,
+# the agent, Stalwart, Kratos, PDNS, CrowdSec and every tenant PHP-FPM pool.
+for mb in 512 1024 2048 4096 8192 16384 32768 65536; do
+  pool=$(mariadb_pool_size_mb "$mb")
+  if [[ "$pool" -ge "$mb" ]]; then
+    echo "FAIL: ${mb}MB host: pool=${pool}M is not smaller than host RAM"
+    fail=1
+  fi
+  if [[ $((pool * 100 / mb)) -gt 40 ]]; then
+    echo "FAIL: ${mb}MB host: pool=${pool}M is over 40% of RAM, leaving no headroom"
     fail=1
   fi
 done

--- a/install/tests/test_stalwart_memory_bounds.sh
+++ b/install/tests/test_stalwart_memory_bounds.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# install/tests/test_stalwart_memory_bounds.sh — regression coverage for
+# JAB-216: serial cPanel restores on a 7.7 GB host drove it into repeated
+# global OOM kills and finally a full userspace wedge (sshd and nginx both
+# dead, provider-console reboot required). The kernel's last kill was
+# stalwart at ~888 MB anon-rss while ingesting migrated mail, and Stalwart
+# ran with MemoryHigh=infinity / MemoryMax=infinity — nothing stood between
+# a heavy ingest and the host's last free page.
+#
+# Asserts install.sh ships:
+#   1. The sizing brackets, executed at every interesting host size.
+#   2. MemoryHigh strictly below MemoryMax at ALL sizes — a soft limit at or
+#      above the hard one is silently useless.
+#   3. The bracket that actually covers the incident host.
+#   4. The drop-in written with both limits and MemoryAccounting.
+#   5. Bounds applied to the RUNNING unit, not deferred to a restart.
+#   6. Both wiring points: fresh install, and `jabali update` self-heal for
+#      the existing fleet that has the unbounded unit today.
+#
+# Run from repo root:
+#     bash install/tests/test_stalwart_memory_bounds.sh
+#
+# Exit 0 = pass.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# --- 1. Pull the pure arithmetic out of install.sh and run it. ---
+# Sourcing all of install.sh would execute its top-level setup, so extract
+# just the function under test.
+fn_src=$(awk '/^stalwart_mem_bounds_mb\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: stalwart_mem_bounds_mb not defined in install.sh"
+  exit 1
+fi
+eval "$fn_src"
+
+check() {
+  local mem_mb="$1" want_high="$2" want_max="$3" label="$4"
+  local got_high got_max
+  read -r got_high got_max < <(stalwart_mem_bounds_mb "$mem_mb")
+  if [[ "$got_high" != "$want_high" || "$got_max" != "$want_max" ]]; then
+    echo "FAIL: ${mem_mb}MB host ($label): got High=${got_high}M Max=${got_max}M, want High=${want_high}M Max=${want_max}M"
+    fail=1
+  fi
+}
+
+#     host    High   Max    why
+check 1024    512    768    "both floors bind"
+check 2048    512    819    "High floor binds, Max is 40%"
+check 4096    1024   1638   "straight percentages"
+check 7884    1971   3153   "the incident host (7.7 GB)"
+check 16384   4096   6144   "both ceilings bind"
+check 65536   4096   6144   "large host stays at the ceilings"
+
+# --- 2. The soft limit must stay under the hard one at EVERY size. ---
+# A MemoryHigh >= MemoryMax means the kernel reaches the kill threshold
+# without ever having applied reclaim pressure, which removes the only
+# mechanism that degrades gracefully.
+for mb in 256 512 768 1024 1536 2048 3072 4096 6144 7884 8192 12288 16384 32768 65536 131072; do
+  read -r h m < <(stalwart_mem_bounds_mb "$mb")
+  if [[ "$h" -ge "$m" ]]; then
+    echo "FAIL: ${mb}MB host: MemoryHigh=${h}M is not below MemoryMax=${m}M"
+    fail=1
+  fi
+  if [[ "$h" -le 0 || "$m" -le 0 ]]; then
+    echo "FAIL: ${mb}MB host: non-positive bound High=${h}M Max=${m}M"
+    fail=1
+  fi
+done
+
+# --- 3. The incident host would have been throttled before it died. ---
+# Stalwart was killed at ~888 MB anon-rss on a 7.7 GB box. MemoryHigh must
+# land above idle usage (~100 MB) and below that fatal figure's headroom, so
+# reclaim starts well before the host runs out.
+read -r inc_high inc_max < <(stalwart_mem_bounds_mb 7884)
+if [[ "$inc_high" -lt 512 ]]; then
+  echo "FAIL: incident host MemoryHigh=${inc_high}M would throttle normal operation (idle is ~100M)"
+  fail=1
+fi
+if [[ "$inc_max" -ge 7884 ]]; then
+  echo "FAIL: incident host MemoryMax=${inc_max}M does not bound anything below host RAM"
+  fail=1
+fi
+
+# --- 4. Drop-in carries both limits and enables accounting. ---
+for needle in '20-jabali-memory.conf' 'MemoryAccounting=yes' 'MemoryHigh=${high_mb}M' 'MemoryMax=${max_mb}M'; do
+  if ! grep -Fq "$needle" install.sh; then
+    echo "FAIL: drop-in missing: $needle"
+    fail=1
+  fi
+done
+
+# --- 5. Applied live, not deferred to a restart. ---
+# Bouncing Stalwart to pick up a limit drops live IMAP/JMAP sessions, and
+# mid-migration would restart the very service doing the ingest.
+if ! grep -q 'set-property --runtime jabali-stalwart.service' install.sh; then
+  echo "FAIL: bounds are not applied to the running unit (set-property --runtime missing)"
+  fail=1
+fi
+# Scoped to this function's body — install.sh restarts Stalwart legitimately
+# elsewhere (binary upgrade, plan re-apply); it is a limit change that must
+# not.
+body=$(awk '/^bound_stalwart_memory\(\) \{$/,/^\}$/' install.sh)
+if grep -q 'systemctl restart' <<<"$body"; then
+  echo "FAIL: bound_stalwart_memory restarts Stalwart; a limit change must not drop live sessions"
+  fail=1
+fi
+
+# --- 6. Wired on BOTH paths. ---
+# Fresh install alone would leave every existing host — the ones that have
+# the unbounded unit right now — unprotected.
+calls=$(grep -cE '^\s+bound_stalwart_memory( \|\||$)' install.sh || true)
+if [[ "$calls" -lt 2 ]]; then
+  echo "FAIL: bound_stalwart_memory called $calls time(s); expected >= 2 (fresh install + update self-heal)"
+  fail=1
+fi
+if ! grep -q 'declare -f bound_stalwart_memory' install.sh; then
+  echo "FAIL: not wired into the update self-heal path (no declare -f guard)"
+  fail=1
+fi
+
+# --- 7. Ordering: bound before the unit is started. ---
+unit_install=$(grep -n 'install -m 0644 -o root -g root "\${REPO_DIR}/install/systemd/jabali-stalwart.service"' install.sh | head -n1 | cut -d: -f1 || true)
+bound_call=$(grep -n '^\s\+bound_stalwart_memory ||' install.sh | head -n1 | cut -d: -f1 || true)
+enable_call=$(grep -n 'enabling + starting jabali-stalwart.service' install.sh | head -n1 | cut -d: -f1 || true)
+if [[ -z "$unit_install" || -z "$bound_call" || -z "$enable_call" ]]; then
+  echo "FAIL: could not locate install/bound/start sequence (unit=$unit_install bound=$bound_call start=$enable_call)"
+  fail=1
+elif [[ "$bound_call" -le "$unit_install" || "$bound_call" -ge "$enable_call" ]]; then
+  echo "FAIL: bound_stalwart_memory (line $bound_call) must sit between the unit install (line $unit_install) and the start (line $enable_call)"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo
+  echo "FAIL: Stalwart memory bounds regressed (JAB-216)"
+  exit 1
+fi
+
+echo "PASS: Stalwart memory bounds sized, ordered, and wired on both paths"


### PR DESCRIPTION
## The gap

Stalwart runs unbounded. Verified on a live host:

```
jabali-stalwart   High=infinity   Max=infinity   OOM=0
```

Serial cPanel restores on a 7.7 GB box drove it into repeated global OOM kills over four hours and then a full userspace wedge — sshd and nginx both dead, provider-console reboot required. The kernel's last kill was `stalwart` at ~888 MB anon-rss, ingesting migrated mail.

#929 refuses to *start* a restore on an already-full host. This bounds the consumer, which is what turns a bad hour into a bad mail queue instead of a dead box.

## Both limits, different jobs

| | | |
|---|---|---|
| `MemoryHigh` | soft | Kernel throttles allocation and reclaims harder. Nothing killed; a busy server gets slower. **This is the back-pressure that was missing.** |
| `MemoryMax` | hard | OOM-kill inside Stalwart's *own* cgroup. A runaway costs mail delivery (systemd restarts it) rather than the operator's ability to log in. |

Containing the blast radius is the point: **a mail outage is recoverable over SSH; a wedged host is not.**

## Sizing

Fraction of host RAM, mirroring `tune_mariadb_for_ram`. Floors so a small VM still gets a workable mail server; ceilings because past a few GB further growth is runaway, not working set (Stalwart idles near 100 MB).

```
MemoryHigh = 25% of RAM, floor 512 MB, ceiling 4096 MB
MemoryMax  = 40% of RAM, floor 768 MB, ceiling 6144 MB
```

On the incident's 7.7 GB host: **High=1971M / Max=3153M** — reclaim starts well before the box runs out.

## Applied without a restart

`systemctl set-property --runtime`. Bouncing Stalwart drops live IMAP/JMAP sessions, and mid-migration would restart the very service doing the ingest. The drop-in makes the bounds survive a reboot.

Wired on **both** paths: fresh install bounds the unit between installing and starting it (never unbounded, even for one boot), and `jabali update` re-applies it — the hosts running unbounded today are exactly who this is for.

## Not touching OOMScoreAdjust — including sshd

The issue suggests `OOMScoreAdjust=-1000` for sshd. **That premise doesn't hold.** OpenSSH already sets its listener itself:

```
1352    -1000  sshd: /usr/sbin/sshd -D [listener]
674014  0      sshd: root@notty
```

sshd is already OOM-immune where it matters. Worse, a systemd `OOMScoreAdjust` on `ssh.service` applies to the whole cgroup — making **tenant SSH sessions un-killable**, which is worse than the problem. Nothing to do here.

Stalwart likewise keeps `OOMScoreAdjust=0`: with `MemoryMax` a runaway is contained in-cgroup, and the global OOM order already prefers tenant slices (`oom_score_adj 100`).

## Tests

The brackets are split into a pure function so the test **executes** them at every interesting host size rather than grepping for constants — including the invariant that `MemoryHigh` stays strictly below `MemoryMax` at all 16 sizes. A soft limit at or above the hard one silently removes the throttle and leaves only the kill; that's the failure mode worth a permanent guard.

Also asserts ordering (bound between unit-install and start) and that the function never restarts Stalwart.

## JAB-216 status

- **#929** — pre-flight memory refusal
- **#936** — interrupted job resumes from its recorded stage
- **this** — core-service memory bounds; sshd needs nothing

## Second commit: these tests never ran

While adding the test I found `install/tests/*.sh` has **no CI job at all**. Two of the four guards in that directory had been failing on `main` — asserting nothing — for as long as nobody ran them by hand. A guard nobody runs is not a guard; it's a file that looks like safety.

Both were stale tests, not regressions, and both failed the same way: asserting a particular **arrangement** of install.sh rather than the property the incident was about.

- **`test_etc_hosts_loopback_strip`** — checked the `127.0.1.1` strip sits *after* the `JABALI_HOSTNAME` gate closes. The strip was later moved to the top of the function, equally ungated, and the test read a correct install.sh as *"bug regressed"*. Now asserts it isn't **inside** the gate, from either side.
- **`test_mariadb_tuning`** — asserted four bracket literals; #597 replaced two with a percentage. Now **executes** the sizing at eight host sizes (including the 3.8 GB box OOM-killed twice in one morning) plus the invariant that the buffer pool never exceeds 40% of RAM.

That needed the same split I did for Stalwart — `mariadb_pool_size_mb` extracted from `tune_mariadb_for_ram`. **No behavior change**: the arithmetic moved, the brackets didn't.

Writing those cases surfaced that #597's 1024 MB floor is **unreachable** — it binds only below ~2926 MB, and everything under 4096 MB is already caught by the fixed brackets. Left as a guard for future edits, with the test asserting the 35% that actually applies.
