### PR TITLE
feat(updates): tell the operator on the dashboard when the panel is behind (JAB-221)

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -137,6 +137,16 @@
       "title_one": "{{count}} critical issue on host",
       "title_other": "{{count}} critical issues on host",
       "action": "Open Server Status to investigate →"
+    },
+    "updates_pending": {
+      "title_one": "Panel is {{count}} commit behind",
+      "title_other": "Panel is {{count}} commits behind",
+      "title_auto_one": "Panel is {{count}} commit behind — auto-update is on",
+      "title_auto_other": "Panel is {{count}} commits behind — auto-update is on",
+      "body": "Auto-update is off, so nothing will apply these on its own. This matters more than it looks: config templates are built into the panel binary, so an out-of-date host rewrites its own config from the old template — a fix you already merged gets undone on the next render.",
+      "body_auto": "Auto-update will apply these at {{time}}. No action needed.",
+      "action": "Review and update",
+      "action_auto": "Open Updates"
     }
   },
   "users": {

--- a/panel-ui/src/shells/admin/Dashboard.tsx
+++ b/panel-ui/src/shells/admin/Dashboard.tsx
@@ -15,6 +15,7 @@ import { StatCard } from "../../components/StatCard";
 import { useListQuery } from "../../hooks/useQueries";
 import { useServerStatus } from "../../hooks/useServerStatus";
 import { useServerCapabilities } from "../../hooks/useServerCapabilities";
+import { UpdatesPendingBanner } from "./updates/UpdatesPendingBanner";
 
 interface UserRow {
   id: string;
@@ -106,6 +107,11 @@ export const Dashboard = () => {
 
   return (
     <div>
+      {/* JAB-221: above the stat cards, not in the Masonry below. The
+          commits-behind count existed only inside the Updates Center, and two
+          production incidents came from boxes silently running builds that
+          predated an already-merged fix. */}
+      <UpdatesPendingBanner />
       <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
         <Col xs={24} sm={8}>
           <StatCard

--- a/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.test.tsx
+++ b/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.test.tsx
@@ -1,0 +1,98 @@
+// JAB-221: the dashboard must say when the box is behind, because the
+// commits-behind count lived only inside the Updates Center and two production
+// incidents came from hosts silently running builds that predated an
+// already-merged fix.
+//
+// The cases that matter are the SILENT ones. A banner that shows up while
+// loading, or because a query failed, gets dismissed by reflex — and then it is
+// not there on the day it counts.
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UpdatesPendingBanner } from "./UpdatesPendingBanner";
+
+const mockState = vi.fn();
+const mockAuto = vi.fn();
+
+vi.mock("../../../hooks/useSystemUpdates", () => ({
+  useUpdateState: () => mockState(),
+  useAutoupdateConfig: () => mockAuto(),
+}));
+
+const renderBanner = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <UpdatesPendingBanner />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const ok = (jabali_behind: number) => ({
+  data: { jabali_behind, apt_total: 0, apt_security: 0 },
+  isLoading: false,
+  isError: false,
+});
+
+describe("UpdatesPendingBanner (JAB-221)", () => {
+  beforeEach(() => {
+    mockState.mockReset();
+    mockAuto.mockReset();
+    mockAuto.mockReturnValue({ data: { jabali_enabled: false, jabali_time: "04:30" } });
+  });
+
+  it("says nothing when the box is up to date", () => {
+    mockState.mockReturnValue(ok(0));
+    const { container } = renderBanner();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("says nothing while the check is still loading", () => {
+    mockState.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const { container } = renderBanner();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("says nothing when the state query failed", () => {
+    // A failed query is not evidence of being behind. Warning on it would put a
+    // permanent banner on every dashboard where the endpoint is unreachable.
+    mockState.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    const { container } = renderBanner();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("warns with the count, and explains that an old binary undoes merged fixes", () => {
+    mockState.mockReturnValue(ok(7));
+    renderBanner();
+
+    expect(screen.getByText(/7 commits behind/i)).toBeInTheDocument();
+    // The count alone reads as cosmetic. The reason it is not — embedded
+    // templates rewriting a fixed config back to the broken version — is the
+    // part an operator cannot infer, so it must be on screen.
+    expect(screen.getByText(/gets undone on the next render/i)).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/jabali-admin/updates");
+  });
+
+  it("uses singular wording for a single commit", () => {
+    mockState.mockReturnValue(ok(1));
+    renderBanner();
+    expect(screen.getByText(/1 commit behind/i)).toBeInTheDocument();
+    expect(screen.queryByText(/commits behind/i)).not.toBeInTheDocument();
+  });
+
+  it("drops to informational once auto-update is on, and names the time", () => {
+    // Same drift, different advice: it converges tonight, so this must not read
+    // as an unattended problem or it becomes noise on a healthy fleet.
+    mockState.mockReturnValue(ok(4));
+    mockAuto.mockReturnValue({ data: { jabali_enabled: true, jabali_time: "04:30" } });
+    renderBanner();
+
+    expect(screen.getByText(/auto-update is on/i)).toBeInTheDocument();
+    expect(screen.getByText(/04:30/)).toBeInTheDocument();
+    expect(screen.queryByText(/gets undone on the next render/i)).not.toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.tsx
+++ b/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.tsx
@@ -1,0 +1,69 @@
+// UpdatesPendingBanner — JAB-221.
+//
+// The Updates Center already knows the box is behind: the reconciler refreshes
+// update_state every 6 hours. Nothing surfaced it outside that page, so two
+// production incidents in three weeks came from boxes running builds that
+// predated an already-merged fix — including one where a WooCommerce checkout
+// WAF exclusion was inert for a day after merging, and real customers got
+// banned mid-checkout.
+//
+// The non-obvious part is WHY being behind bites: config templates are embedded
+// in the binary, so a host with an old binary actively REWRITES a fixed config
+// back to the broken version on its next render. Being behind is not "missing
+// out on new features", it is "a fix you already merged is being undone". The
+// banner says that, because an operator who does not know it reads a
+// commits-behind count as cosmetic.
+//
+// Two states, because the advice differs:
+//   auto-update OFF — warning. Nothing will fix this on its own.
+//   auto-update ON  — info. It converges tonight; say when, and stop nagging.
+import { Alert, Button, Space, Typography } from "antd";
+import { Link } from "react-router";
+import { useTranslation } from "react-i18next";
+
+import { useAutoupdateConfig, useUpdateState } from "../../../hooks/useSystemUpdates";
+
+export const UpdatesPendingBanner = () => {
+  const { t } = useTranslation();
+  const state = useUpdateState();
+  const auto = useAutoupdateConfig();
+
+  const behind = state.data?.jabali_behind ?? 0;
+
+  // Silent unless there is something to say. A dashboard banner that appears
+  // while loading, or because a query failed, trains operators to dismiss it —
+  // and then it is not there when it matters.
+  if (state.isLoading || state.isError || behind <= 0) return null;
+
+  const enabled = auto.data?.jabali_enabled ?? false;
+  const time = auto.data?.jabali_time ?? "04:30";
+
+  return (
+    <Alert
+      type={enabled ? "info" : "warning"}
+      showIcon
+      style={{ marginBottom: 16 }}
+      message={
+        enabled
+          ? t("dashboard.updates_pending.title_auto", { count: behind })
+          : t("dashboard.updates_pending.title", { count: behind })
+      }
+      description={
+        <Space direction="vertical" size={8} style={{ width: "100%" }}>
+          <Typography.Text>
+            {enabled
+              ? t("dashboard.updates_pending.body_auto", { time })
+              : t("dashboard.updates_pending.body")}
+          </Typography.Text>
+          <Link to="/jabali-admin/updates">
+            <Button size="small" type={enabled ? "default" : "primary"}>
+              {enabled
+                ? t("dashboard.updates_pending.action_auto")
+                : t("dashboard.updates_pending.action")}
+            </Button>
+          </Link>
+        </Space>
+      }
+    />
+  );
+};


### PR DESCRIPTION
## The panel already knew

`update_state.jabali_behind` is refreshed **every 6 hours** by the reconciler — accurate without anyone clicking *Check now*. It was just never shown outside the Updates Center.

Two production incidents in three weeks came from boxes silently running builds that predated an already-merged fix. In the second, a WooCommerce checkout WAF exclusion merged the day before was inert on the box, and **real customers were banned mid-checkout**.

## Placement

Above the stat cards, not in the Masonry below — the existing critical-alert card renders **last**, which is exactly the "buried in the Updates Center" the issue is about.

## It says *why*, not just the count

The non-obvious part, and the one an operator can't infer:

> config templates are built into the panel binary, so an out-of-date host rewrites its own config from the old template — a fix you already merged gets undone on the next render.

Without that sentence, a commits-behind number reads as *"missing new features"* rather than *"a fix you already merged is being reverted"*. The docs section from #932 is the long form; this is the line that makes someone go read it.

## Two states, because the advice differs

| auto-update | severity | message |
|---|---|---|
| **off** | warning | Nothing will apply these on its own. |
| **on** | info | Names the time it will run. |

A converging fleet shouldn't carry a standing alarm — that's how banners get trained into invisibility.

## Silent by default

Nothing at zero, nothing while loading, **nothing when the query fails**. A banner that appears because an endpoint was unreachable gets dismissed by reflex, and then it isn't there on the day it matters. Those three cases are most of what the tests cover.

Verified against the real dashboard E2E: the banner's queries `ECONNREFUSED` and it renders nothing — test still passes.

## Not changing the default

Whether `jabali_enabled` should ship `true` is a **product posture call** — ADR-0118 decision 1 made it opt-in deliberately, because a bad self-update can brick the panel. This makes the current posture *visible* rather than quietly deciding it.

## JAB-221 status

- **docs** — shipped in #932 ("why your fixed bug came back")
- **panel banner** — this
- **install.sh default/prompt** — left open; yours to call

English only: `en/common.json` is the source language and Weblate owns the rest.