### PR TITLE
fix(dns): stop the service-record prune from deleting a live MX target (JAB-226)

### DIFF
--- a/panel-api/cmd/server/dns_prune_service_cmd.go
+++ b/panel-api/cmd/server/dns_prune_service_cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -61,6 +62,7 @@ func newDNSPruneServiceCmd() *cobra.Command {
 
 			type victim struct{ zone, name, typ, id string }
 			var victims []victim
+			var kept []victim
 
 			for i := range zones {
 				z := zones[i]
@@ -72,14 +74,24 @@ func newDNSPruneServiceCmd() *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "  ! %s: list records: %v\n", z.Name, rErr)
 					continue
 				}
+
+				// Names this zone's MX records point at, and the names that have
+				// an address record of their own. See mxTargetLabels.
+				mxTargets, addressed := mailRoutingNames(z.Name, recs)
+
 				for _, r := range recs {
 					// Reuse the SAME predicates the importer now filters on, so
 					// the cleanup and the filter can never disagree about what
 					// counts as a service hostname.
-					if cpanel.IsCPanelServiceRecordName(r.Name) ||
-						cpanel.IsMailInfraRecordName(r.Name, r.Type) {
-						victims = append(victims, victim{z.Name, r.Name, r.Type, r.ID})
+					if !cpanel.IsCPanelServiceRecordName(r.Name) &&
+						!cpanel.IsMailInfraRecordName(r.Name, r.Type) {
+						continue
 					}
+					if wouldDanglingMX(r.Name, r.Type, mxTargets, addressed) {
+						kept = append(kept, victim{z.Name, r.Name, r.Type, r.ID})
+						continue
+					}
+					victims = append(victims, victim{z.Name, r.Name, r.Type, r.ID})
 				}
 			}
 
@@ -90,8 +102,42 @@ func newDNSPruneServiceCmd() *cobra.Command {
 				return victims[i].name < victims[j].name
 			})
 
+			sort.Slice(kept, func(i, j int) bool {
+				if kept[i].zone != kept[j].zone {
+					return kept[i].zone < kept[j].zone
+				}
+				return kept[i].name < kept[j].name
+			})
+
+			// Never silent about what was skipped: a cleanup that quietly leaves
+			// rows behind reads as "done" when it is not, and the operator needs
+			// to know these names still count toward the certificate SAN.
+			reportKept := func() {
+				if len(kept) == 0 {
+					return
+				}
+				zonesKept := map[string]bool{}
+				for _, k := range kept {
+					zonesKept[k.zone] = true
+				}
+				fmt.Fprintf(cmd.OutOrStdout(),
+					"\nKEPT %d record(s) across %d zone(s): an MX in the same zone points at them,\n"+
+						"and no other address record provides the name. Deleting them would leave the MX\n"+
+						"unresolvable and external senders could not deliver.\n"+
+						"Enable mail on these domains in the panel (which publishes jabali's own\n"+
+						"mail A record), then re-run — they will be prunable once the name has a\n"+
+						"replacement.\n", len(kept), len(zonesKept))
+				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "KEPT ZONE\tNAME\tTYPE")
+				for _, k := range kept {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", k.zone, k.name, k.typ)
+				}
+				_ = w.Flush()
+			}
+
 			if len(victims) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "No imported cPanel service records found.")
+				reportKept()
 				return nil
 			}
 
@@ -100,7 +146,14 @@ func newDNSPruneServiceCmd() *cobra.Command {
 				for _, v := range victims {
 					out = append(out, map[string]string{"zone": v.zone, "name": v.name, "type": v.typ})
 				}
-				return printJSON(map[string]any{"records": out, "total": len(victims), "applied": apply})
+				keptOut := make([]map[string]string, 0, len(kept))
+				for _, k := range kept {
+					keptOut = append(keptOut, map[string]string{"zone": k.zone, "name": k.name, "type": k.typ})
+				}
+				return printJSON(map[string]any{
+					"records": out, "total": len(victims), "applied": apply,
+					"kept_mx_targets": keptOut, "kept_total": len(kept),
+				})
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -115,6 +168,7 @@ func newDNSPruneServiceCmd() *cobra.Command {
 					"\n%d record(s) would be removed. This is a DRY RUN — nothing changed.\n"+
 						"Re-run with --apply to delete them, then let the reconciler push the zones.\n",
 					len(victims))
+				reportKept()
 				return nil
 			}
 
@@ -131,10 +185,79 @@ func newDNSPruneServiceCmd() *cobra.Command {
 			fmt.Fprintf(cmd.OutOrStdout(), "\nremoved %d record(s), %d failed.\n"+
 				"The reconciler rewrites each zone in PowerDNS on its next tick (upsert is a full\n"+
 				"replace), so the certificate SAN shrinks once that has run.\n", deleted, failed)
+			reportKept()
 			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&apply, "apply", false, "actually delete (default is a dry run)")
 	cmd.Flags().StringVar(&zoneFilter, "zone", "", "limit to one zone (default: every zone)")
 	return cmd
+}
+
+// mailRoutingNames returns, for one zone, the set of labels this zone's MX
+// records point at, and the set of labels that own an A or AAAA record.
+//
+// Both are zone-relative labels ("mail"), because that is how records are
+// stored, while MX content is an FQDN ("mail.example.com" or with a trailing
+// dot). An MX target outside the zone is irrelevant here — deleting a record in
+// THIS zone cannot break it.
+func mailRoutingNames(zone string, recs []models.DNSRecord) (mxTargets, addressed map[string]bool) {
+	mxTargets = map[string]bool{}
+	addressed = map[string]bool{}
+	suffix := "." + strings.ToLower(strings.TrimSuffix(zone, "."))
+
+	for _, r := range recs {
+		switch strings.ToUpper(r.Type) {
+		case "MX":
+			// Content may carry a priority prefix on some backends; the target
+			// is the last field either way.
+			f := strings.Fields(strings.TrimSpace(r.Content))
+			if len(f) == 0 {
+				continue
+			}
+			t := strings.ToLower(strings.TrimSuffix(f[len(f)-1], "."))
+			switch {
+			case t == strings.ToLower(strings.TrimSuffix(zone, ".")):
+				mxTargets["@"] = true
+			case strings.HasSuffix(t, suffix):
+				mxTargets[strings.TrimSuffix(t, suffix)] = true
+			}
+		case "A", "AAAA":
+			addressed[strings.ToLower(r.Name)] = true
+		}
+	}
+	return mxTargets, addressed
+}
+
+// wouldDanglingMX reports whether deleting this record would leave an MX in the
+// same zone pointing at a name that no longer resolves.
+//
+// This is the difference between a cosmetic cleanup and an outage. On a real
+// migrated host, 69 of 71 domains had their ONLY mail.<zone> record as the
+// cPanel-imported CNAME, and every one of those zones had MX -> mail.<zone>.
+// Deleting them as "cPanel service records" would have made the MX target
+// unresolvable, and external senders cannot deliver to a domain whose MX does
+// not resolve. The certificate problem this command exists to fix is worth
+// fixing; it is not worth trading for bounced mail.
+//
+// A record is safe to delete when something else still provides the name — an A
+// or AAAA that survives (the address records are never service-hostname
+// matches, so they are not in the deletion set).
+func wouldDanglingMX(name, typ string, mxTargets, addressed map[string]bool) bool {
+	n := strings.ToLower(name)
+	if !mxTargets[n] {
+		return false
+	}
+	// Deleting an address record for an MX target is only safe if another
+	// address record for the same name remains; we cannot tell them apart here,
+	// so treat any address record for an MX target as load-bearing.
+	switch strings.ToUpper(typ) {
+	case "A", "AAAA":
+		return true
+	case "CNAME":
+		// A CNAME is how cPanel points mail.<zone> at the apex. Safe to drop
+		// only if the name also has its own address record to fall back on.
+		return !addressed[n]
+	}
+	return false
 }

--- a/panel-api/cmd/server/dns_prune_service_mx_test.go
+++ b/panel-api/cmd/server/dns_prune_service_mx_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// The prune classifies "mail" as a cPanel service hostname because the IMPORTER
+// skips it — jabali publishes its own mail A record when mail is enabled on the
+// domain. For zones that were imported BEFORE that filter existed, jabali never
+// published one, so the imported CNAME is the only thing making the name
+// resolve.
+//
+// Measured on a live destination host: 69 of 71 migrated domains had their only
+// mail.<zone> record as that CNAME, and every one of those zones had
+// MX -> mail.<zone>. Pruning them would have made the MX target unresolvable,
+// and external senders cannot deliver to a domain whose MX does not resolve.
+//
+// That is a mail outage traded for a certificate cleanup. These tests pin the
+// refusal.
+
+func rec(name, typ, content string) models.DNSRecord {
+	return models.DNSRecord{Name: name, Type: typ, Content: content}
+}
+
+func TestWouldDanglingMX_ProductionShape(t *testing.T) {
+	// Verbatim from the live box: MX -> mail.4lion.com, and the only
+	// mail.4lion.com record is the imported CNAME to the apex.
+	recs := []models.DNSRecord{
+		rec("@", "MX", "mail.4lion.com"),
+		rec("mail", "CNAME", "4lion.com."),
+		rec("@", "A", "182.54.236.69"),
+		rec("cpanel", "A", "1.2.3.4"),
+		rec("webmail", "A", "1.2.3.4"),
+	}
+	mx, addressed := mailRoutingNames("4lion.com", recs)
+
+	if !mx["mail"] {
+		t.Fatalf("MX target not recognised: %v", mx)
+	}
+	if !wouldDanglingMX("mail", "CNAME", mx, addressed) {
+		t.Error("mail CNAME is the MX target's only record — deleting it breaks inbound mail")
+	}
+	// The genuinely dead cPanel names stay deletable; refusing everything would
+	// make the command useless and leave the certificate problem unfixed.
+	for _, n := range []string{"cpanel", "webmail"} {
+		if wouldDanglingMX(n, "A", mx, addressed) {
+			t.Errorf("%s is not an MX target and must still be pruned", n)
+		}
+	}
+}
+
+func TestWouldDanglingMX_SafeOnceJabaliPublishesItsOwn(t *testing.T) {
+	// Mail enabled in the panel: jabali publishes mail A -> the box. Now the
+	// imported CNAME is genuinely redundant and can go.
+	recs := []models.DNSRecord{
+		rec("@", "MX", "mail.example.com."),
+		rec("mail", "A", "203.0.113.10"),
+		rec("mail", "CNAME", "example.com."),
+	}
+	mx, addressed := mailRoutingNames("example.com", recs)
+
+	if !addressed["mail"] {
+		t.Fatal("mail A record not seen")
+	}
+	if wouldDanglingMX("mail", "CNAME", mx, addressed) {
+		t.Error("with a surviving mail A record the CNAME is redundant and prunable")
+	}
+	// The address record itself is never a service-hostname match, but if it
+	// ever became one, deleting the MX target's address is the same outage.
+	if !wouldDanglingMX("mail", "A", mx, addressed) {
+		t.Error("deleting an MX target's address record must be refused")
+	}
+}
+
+func TestMailRoutingNames_MXContentForms(t *testing.T) {
+	// MX content varies: trailing dot or not, and some backends prepend the
+	// priority into the content. Missing the target means the guard silently
+	// stops guarding — the failure mode is deletion, so parsing must be liberal.
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"bare", "mail.example.com"},
+		{"trailing dot", "mail.example.com."},
+		{"priority prefixed", "10 mail.example.com."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mx, _ := mailRoutingNames("example.com", []models.DNSRecord{rec("@", "MX", tc.content)})
+			if !mx["mail"] {
+				t.Fatalf("target not parsed from %q: %v", tc.content, mx)
+			}
+		})
+	}
+}
+
+func TestMailRoutingNames_ForeignAndApexTargets(t *testing.T) {
+	// An MX pointing outside the zone cannot be broken by deleting a record IN
+	// the zone, so it must not make local names undeletable.
+	mx, _ := mailRoutingNames("example.com", []models.DNSRecord{
+		rec("@", "MX", "aspmx.l.google.com."),
+		rec("webmail", "A", "1.2.3.4"),
+	})
+	if len(mx) != 0 {
+		t.Errorf("foreign MX target should register no local label, got %v", mx)
+	}
+	if wouldDanglingMX("webmail", "A", mx, map[string]bool{"webmail": true}) {
+		t.Error("Google-hosted mail must not block pruning local cPanel names")
+	}
+
+	// An apex MX target is recorded as "@" so an apex A is never pruned by a
+	// future predicate change.
+	mx2, _ := mailRoutingNames("example.com", []models.DNSRecord{rec("@", "MX", "example.com.")})
+	if !mx2["@"] {
+		t.Errorf("apex MX target not recorded: %v", mx2)
+	}
+}

--- a/panel-api/cmd/server/dns_prune_service_mx_test.go
+++ b/panel-api/cmd/server/dns_prune_service_mx_test.go
@@ -117,3 +117,40 @@ func TestMailRoutingNames_ForeignAndApexTargets(t *testing.T) {
 		t.Errorf("apex MX target not recorded: %v", mx2)
 	}
 }
+
+// The newzaps shape, which is NOT the aramapp shape and nearly caused a second
+// outage on the same day.
+//
+// There the mail record is an A, not a CNAME, and it is still the MX target:
+//
+//	hoff.co.il        MX  ->  mail.hoff.co.il
+//	mail.hoff.co.il   A   ->  <the box>
+//
+// 26 domains on that host looked like this, including the server's OWN mail
+// hostname. The pre-flight query that cleared the box asked for domains that had
+// a mail record but NO address record — which by construction excludes exactly
+// this set, so it returned zero and read as "safe".
+//
+// That is why the refusal belongs in the command and not in an operator's query:
+// the command sees the records it is about to delete, and cannot ask the wrong
+// question about them.
+func TestWouldDanglingMX_AddressRecordIsTheMXTarget(t *testing.T) {
+	recs := []models.DNSRecord{
+		rec("@", "MX", "mail.hoff.co.il"),
+		rec("mail", "A", "182.54.236.64"),
+		rec("autoconfig", "CNAME", "hoff.co.il."),
+		rec("autodiscover", "CNAME", "hoff.co.il."),
+	}
+	mx, addressed := mailRoutingNames("hoff.co.il", recs)
+
+	if !wouldDanglingMX("mail", "A", mx, addressed) {
+		t.Error("mail A is the MX target and its only provider — deleting it breaks inbound mail")
+	}
+	// The autodiscovery CNAMEs are not MX targets and stay prunable; refusing
+	// them too would leave the certificate-SAN problem unfixed.
+	for _, n := range []string{"autoconfig", "autodiscover"} {
+		if wouldDanglingMX(n, "CNAME", mx, addressed) {
+			t.Errorf("%s is not an MX target and must still be pruned", n)
+		}
+	}
+}


### PR DESCRIPTION
## What I found before running it

I was about to tell the operator to run `jabali dns prune-service-records --apply` on a production box. I checked the actual data first:

```
domains with a jabali-published  mail A record:  2
domains with ONLY the cPanel-imported mail CNAME: 69
   ...of those, with MX -> mail.<zone>:          69
```

**All 69 would have had their MX target deleted.** A domain whose MX doesn't resolve doesn't get slow mail — external senders cannot deliver to it at all.

Live shape, verbatim:

```
mail.4lion.com   CNAME   4lion.com.
4lion.com        MX      mail.4lion.com
```

There is no `mail A`. That CNAME is the only thing making the MX target resolve.

## Why the command had this hole

It reuses the importer's predicates so the filter and the cleanup can't disagree — and one of them matches `mail`.

That's **correct for the importer**: it skips `mail.<zone>` because jabali publishes its own `mail A` when mail is enabled on the domain. It's **wrong for a cleanup** of zones imported *before* that filter existed, because on those jabali never published one. The reasoning that makes the record redundant on import is exactly the reasoning that doesn't hold here.

## The fix

Refuse to delete a record an MX in the same zone points at, unless another address record still provides the name — and **print what was kept and why**. Silence would be worse than the bug: a clean run reads as "done", and the operator never learns those names still count toward the certificate SAN.

Scoped so the command stays useful:

- Only **same-zone** MX targets are protected — a Google-hosted MX can't be broken by deleting a local record, and must not make local cPanel names undeletable.
- `cpanel` / `whm` / `webdisk` / `ftp` / `cpcalendars` / `cpcontacts` / `webmail` are untouched by the guard. They're the bulk of the 834 records and none is an MX target.

MX content parsing is deliberately liberal — bare, trailing dot, priority-prefixed — because the failure mode of *not* recognising a target is deletion.

## The way out for the kept records

Enable mail on the domain; jabali publishes its own `mail A`; the prune then removes the now-redundant CNAME on a re-run. The output says this.

## Tests

Pin the production shape verbatim, plus: still prunes the genuinely dead names, becomes safe once a `mail A` exists, all three MX content forms, and foreign/apex targets.