### PR TITLE
feat(apps): update ITFlow to the 2026-08 stable + single dispatcher cron (GH #928)

### DIFF
--- a/panel-agent/internal/commands/itflow_install.go
+++ b/panel-agent/internal/commands/itflow_install.go
@@ -30,10 +30,10 @@ import (
 // correct source under jabali's nginx->FPM/FastCGI (no reverse-proxy XFF
 // hop), so we no longer write that define (GH #226).
 //
-// The three cron jobs ITFlow needs (cron.php daily, mail_queue.php +
-// ticket_email_parser.php per-minute) are created panel-side after this
-// returns ready (see api.createITFlowInstallAndKickAgent) — they're just
-// `php <docroot>/cron/<file>.php`, which the jabali cron allowlist accepts.
+// The single cron ITFlow needs (GH #928) — cron.php run every minute as
+// the dispatcher — is created panel-side after this returns ready (see
+// api.createITFlowInstallAndKickAgent). It's just `php <docroot>/cron/cron.php`,
+// which the jabali cron allowlist accepts.
 
 type itflowInstallReq struct {
 	AppType      string `json:"app_type"`
@@ -68,13 +68,16 @@ const itflowRepoURL = "https://github.com/itflow-org/itflow.git"
 // reset the working tree to this reviewed SHA at install time and verify HEAD
 // matches — installs are reproducible and never pull an unreviewed master tip.
 // Bump deliberately (code review) when adopting a newer ITFlow.
-const itflowMasterPinnedCommit = "698135d53d652e7fcbbd1ea48454ef3de7a3418b"
+// 2026-08 stable (GH #928): the major release that makes cron.php a
+// dispatcher (single every-minute crontab entry).
+const itflowMasterPinnedCommit = "ccaa45b0ae9900ad731a6491559f65ff8d87a8f3"
 
 // itflowDevelopPinnedCommit pins the `develop` branch (GH #332). develop is
 // ITFlow's active dev branch  bleeding-edge and NOT security-reviewed; we pin
 // it (like master) so installs are reproducible and never drift to a raw tip,
 // but the UI labels it unreviewed. Bump deliberately when adopting newer dev.
-const itflowDevelopPinnedCommit = "78c3dd0eedec25186f82951fca33b5a372a8a560"
+// Bumped alongside the 2026-08 master stable (GH #928).
+const itflowDevelopPinnedCommit = "cbf8922f5b79287ab874cede0f97e0e34f6b328f"
 
 // itflowResolveBranch maps the requested branch to (branch, pinnedCommit),
 // defaulting to master. Any unknown value falls back to master (fail-safe).

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -1072,13 +1072,16 @@ func appInstallPath(docRoot, subdirectory string) string {
 	return docRoot
 }
 
-// itflowCronSpec is the fixed set of cron jobs ITFlow needs (#206).
+// itflowCronSpec is the cron ITFlow needs. As of the 2026-08 stable
+// (GH #928) cron.php is a DISPATCHER: it is the only crontab entry — run
+// every minute, it wakes, works out which jobs are due from the cron_jobs
+// table (edited under Maintenance > Cron), and runs them in-process. The
+// old per-job crons (mail_queue.php, ticket_email_parser.php) are no longer
+// scheduled directly; the dispatcher invokes them.
 var itflowCronSpec = []struct {
 	name, schedule, file string
 }{
-	{"ITFlow Maintenance", "0 3 * * *", "cron.php"},
-	{"ITFlow Mail Queue", "* * * * *", "mail_queue.php"},
-	{"ITFlow Ticket Email Parser", "* * * * *", "ticket_email_parser.php"},
+	{"ITFlow Cron", "* * * * *", "cron.php"},
 }
 
 func createITFlowCrons(ctx context.Context, args itflowKickArgs, cfg ApplicationHandlerConfig) {

--- a/panel-api/internal/api/applications_itflow_cron_test.go
+++ b/panel-api/internal/api/applications_itflow_cron_test.go
@@ -1,0 +1,21 @@
+package api
+
+// GH #928: ITFlow's 2026-08 stable makes cron.php a dispatcher — the ONLY
+// crontab entry, run every minute. Guard against re-introducing the old
+// per-job crons (mail_queue.php / ticket_email_parser.php), which the
+// dispatcher now invokes itself.
+
+import "testing"
+
+func TestITFlowCronSpec_SingleDispatcher(t *testing.T) {
+	if len(itflowCronSpec) != 1 {
+		t.Fatalf("itflowCronSpec has %d entries, want 1 (cron.php dispatcher)", len(itflowCronSpec))
+	}
+	c := itflowCronSpec[0]
+	if c.file != "cron.php" {
+		t.Errorf("cron file = %q, want cron.php", c.file)
+	}
+	if c.schedule != "* * * * *" {
+		t.Errorf("cron schedule = %q, want every minute", c.schedule)
+	}
+}


### PR DESCRIPTION
Fixes #928 (thanks @johnnyq). ITFlow's 2026-08 major stable turns `cron.php` into a dispatcher — verified against upstream: its header reads *"The only entry that belongs in the crontab: `* * * * * php /path/to/itflow/cron/cron.php`"*, jobs configured under Maintenance > Cron.

## What
- **Pins bumped:** master `698135d5` → `ccaa45b0` (the stable merge that introduces the dispatcher, 2026-08-04), develop `78c3dd0e` → `cbf8922f`.
- **Crons 3 → 1:** the panel now creates a single `cron.php` every-minute job instead of three (`cron.php` daily + `mail_queue.php` + `ticket_email_parser.php` per-minute). The dispatcher runs those itself.

Existing installs keep their extra crons — harmless (redundant) once they self-update in-app; a follow-up can reap them if desired.

## Test plan
- [x] `TestITFlowCronSpec_SingleDispatcher` guards the single-dispatcher spec
- [x] both builds
- [ ] live install E2E on testserver: new pin installs + serves, single `cron.php` cron created