### PR TITLE
fix(docker-apps): tell the operator when Update has nothing newer to pull (GH #794)

### DIFF
--- a/panel-agent/internal/commands/docker_app_update.go
+++ b/panel-agent/internal/commands/docker_app_update.go
@@ -51,7 +51,7 @@ type dockerAppUpdateParams struct {
 
 type dockerAppUpdateResponse struct {
 	Slug      string `json:"slug"`
-	Outcome   string `json:"outcome"`              // "updated" | "rolled_back"
+	Outcome   string `json:"outcome"`              // "updated" | "no_change" | "rolled_back"
 	NewImage  string `json:"new_image,omitempty"`
 	OldImage  string `json:"old_image,omitempty"`
 	SnapshotID string `json:"snapshot_id,omitempty"` // restic id when one was taken
@@ -146,6 +146,25 @@ func dockerAppUpdateHandler(ctx context.Context, params json.RawMessage) (any, e
 	}
 
 	newImage := currentImage(ctx, p.Slug)
+
+	// GH #794: distinguish "nothing changed" from a real upgrade. The catalog
+	// pins each image to a digest (post-#458), so an update only carries a
+	// newer version when the catalog itself was bumped. When it hasn't, the
+	// re-rendered compose is identical, `pull` is a no-op, and the container
+	// image is unchanged — the user pressed Update and rightly saw "no update
+	// happened". Report that as its own outcome so the panel can say the app
+	// is already on the latest catalog version instead of implying an upgrade.
+	if oldImage != "" && oldImage == newImage {
+		return dockerAppUpdateResponse{
+			Slug:       p.Slug,
+			Outcome:    "no_change",
+			OldImage:   oldImage,
+			NewImage:   newImage,
+			SnapshotID: snapshotID,
+			Detail:     "already on the latest catalog version; nothing to update",
+		}, nil
+	}
+
 	detail := ""
 	if snapshotErr != nil {
 		detail = fmt.Sprintf("update succeeded; pre-update snapshot was NOT taken (restic: %v)", snapshotErr)

--- a/panel-api/internal/api/docker_apps.go
+++ b/panel-api/internal/api/docker_apps.go
@@ -1507,6 +1507,13 @@ func (h *dockerAppHandler) updateImage(c *gin.Context) {
 					_ = h.cfg.Repo.UpdateCatalogVersion(persistCtx, appID, entry.Version)
 				}
 			}
+		case "no_change":
+			// GH #794: the image was already the catalog-pinned version, so
+			// nothing was upgraded. This is a clean success, not an error —
+			// clear last_error (the UI shows a red "err" tag when it's set)
+			// so the recreate doesn't look like a failure. The UI explains
+			// up-front (before dispatching) when no update is available.
+			_ = h.cfg.Repo.UpdateStatus(persistCtx, appID, models.DockerAppStatusRunning, nil)
 		case "rolled_back":
 			detail := resp.Detail
 			_ = h.cfg.Repo.UpdateStatus(persistCtx, appID, models.DockerAppStatusRunning, &detail)

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -111,8 +111,8 @@ export const AdminDockerAppsPage = () => {
     onSuccess: () => {
       // Async: the server returned 202 (update started). The row shows the
       // "updating" spinner and the 8s poll flips it to running/failed when
-      // the background pull + recreate finishes.
-      message.info("Update started — this can take a few minutes");
+      // the background pull + recreate finishes. The click handler already
+      // toasted the right message (update vs already-current, GH #794).
       qc.invalidateQueries({ queryKey: ["docker-apps-installed"] });
     },
     onError: (e: unknown) => message.error(e instanceof Error ? e.message : "Update failed"),
@@ -397,7 +397,25 @@ export const AdminDockerAppsPage = () => {
                           : { key: "start", label: "Start", icon: <PlayCircleOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "start" }) },
                         { key: "restart", label: "Restart", icon: <ReloadOutlined />, onClick: () => lifecycle.mutate({ id: r.id, action: "restart" }) },
                         { key: "edit", label: "Edit", icon: <EditOutlined />, disabled: running, onClick: () => setEditApp(r) },
-                        { key: "update", label: "Update", icon: <SyncOutlined />, onClick: () => updateImage.mutate(r.id) },
+                        {
+                          key: "update",
+                          label: "Update",
+                          icon: <SyncOutlined />,
+                          // GH #794: catalog images are pinned to a reviewed
+                          // digest, so a newer version only appears when the
+                          // catalog is bumped. Tell the operator up-front why
+                          // "Update" won't change the version when they're
+                          // already current (it still re-applies catalog config).
+                          onClick: () => {
+                            const hasUpdate = !!r.available_digest && r.available_digest !== (r.image_sha ?? "");
+                            message.info(
+                              hasUpdate
+                                ? "Update started — this can take a few minutes"
+                                : "Already on the latest catalog version — re-applying catalog config, but there's no newer version to pull yet. New app versions arrive when the catalog is bumped.",
+                            );
+                            updateImage.mutate(r.id);
+                          },
+                        },
                         { key: "logs", label: "Logs", icon: <FileTextOutlined />, onClick: () => setLogsAppId(r.id) },
                         { key: "creds", label: "Credentials", icon: <KeyOutlined />, onClick: () => setCredsAppId(r.id) },
                         { key: "exec", label: "Exec", icon: <CodeOutlined />, onClick: () => setExecAppId(r.id) },


### PR DESCRIPTION
Addresses the "manual update does nothing" half of #794 (@mrlp57).

## Cause
Catalog images are pinned to a reviewed digest (post-#458), so a newer version only appears when the **catalog is bumped** (the monthly cadence). The manual Update re-renders the compose from the current catalog and pulls — but when the pin hasn't moved, the image is unchanged, so it silently recreated the container on the same version, looking like a no-op. The user rightly saw "no update happened."

## Fix (no change to the pinned-catalog policy)
- **Agent:** `docker_app.update` now returns a distinct `no_change` outcome when the container image is identical before/after, instead of always `updated`.
- **Panel:** `no_change` is treated as a clean success — clears `last_error` (the row renders a red "err" tag when it's set) so a same-version recreate never looks like a failure.
- **UI:** the Update action explains up-front. When `available_digest === image_sha` it toasts *"Already on the latest catalog version — re-applying catalog config, but there's no newer version to pull yet; new versions arrive when the catalog is bumped"* instead of a bare "Update started".

The "update available" purple tag already reflects `available_digest !== image_sha` correctly, so this closes the gap between what the row shows and what the button does.

## Test plan
- [x] go builds (agent + api), tsc + panel-ui build
- [ ] live: Update a current app → clear "already on latest" toast, container recreates without a red err tag; a catalog-bumped app still updates normally