### PR TITLE
fix(cli): wire CronJobs so CLI app installs create their crons (GH #928 follow-up)

### DIFF
--- a/panel-api/cmd/server/cli_app_install.go
+++ b/panel-api/cmd/server/cli_app_install.go
@@ -47,11 +47,16 @@ func buildAppDeps() (api.ApplicationHandlerConfig, error) {
 		Domains:             repository.NewDomainRepository(sharedDB),
 		Users:               userRepo(),
 		Packages:            repository.NewPackageRepository(sharedDB),
-		Agent:               sharedAgent,
-		Apps:                registry,
-		Redis:               cacheRedis,
-		CacheTokenSecret:    cacheSecret,
-		CacheTokenSalts:     repository.NewCacheTokenSaltRepository(sharedDB),
+		// GH #928 follow-up: without CronJobs, createITFlowCrons early-returns,
+		// so a CLI-installed ITFlow (or any cron-needing app) never gets its
+		// cron and its background jobs never run. The HTTP path wires this;
+		// the CLI path forgot (the #754 dual-path class).
+		CronJobs:         repository.NewCronJobRepository(sharedDB),
+		Agent:            sharedAgent,
+		Apps:             registry,
+		Redis:            cacheRedis,
+		CacheTokenSecret: cacheSecret,
+		CacheTokenSalts:  repository.NewCacheTokenSaltRepository(sharedDB),
 	}, nil
 }
 


### PR DESCRIPTION
Found during the #928 live E2E: a CLI-installed ITFlow had **zero cron rows**, so its dispatcher (`cron.php`) never ran — mail queue, ticket parsing, and nightly tasks all silent.

## Cause
`buildAppDeps()` (cmd/server) assembles the `ApplicationHandlerConfig` for `jabali app install` but omitted `CronJobs`. `createITFlowCrons` guards on `cfg.CronJobs != nil` and early-returns, so the CLI path created no cron. The HTTP install path wires `CronJobs` (app.go) — the CLI path forgot. Same #754 dual-path class as the `mysqladmin` orphan fix earlier.

## Fix
Add `CronJobs: repository.NewCronJobRepository(sharedDB)` to `buildAppDeps` so CLI and HTTP installs behave identically.

## Test plan
- [x] go vet + build
- [ ] live: `jabali app install --app-type itflow …` → single `cron.php` cron row created (the case that was empty pre-fix)