### PR TITLE
fix(dns): stop the service-record prune deleting the mail records jabali itself published (JAB-226)

### DIFF
--- a/panel-api/cmd/server/dns_prune_service_cmd.go
+++ b/panel-api/cmd/server/dns_prune_service_cmd.go
@@ -60,9 +60,18 @@ func newDNSPruneServiceCmd() *cobra.Command {
 				return fmt.Errorf("list zones: %w", err)
 			}
 
+			mailOn, mErr := mailEnabledZones(ctx)
+			if mErr != nil {
+				// Without this set the command cannot tell jabali's own mail
+				// records from imported ones, and the difference is whether it
+				// deletes working autodiscovery. Refuse rather than guess.
+				return fmt.Errorf("read mail-enabled domains: %w", mErr)
+			}
+
 			type victim struct{ zone, name, typ, id string }
 			var victims []victim
 			var kept []victim
+			var ours []victim
 
 			for i := range zones {
 				z := zones[i]
@@ -87,6 +96,10 @@ func newDNSPruneServiceCmd() *cobra.Command {
 						!cpanel.IsMailInfraRecordName(r.Name, r.Type) {
 						continue
 					}
+					if mailOn[strings.ToLower(z.Name)] && jabaliPublishesMailRecord(r.Name, r.Type) {
+						ours = append(ours, victim{z.Name, r.Name, r.Type, r.ID})
+						continue
+					}
 					if wouldDanglingMX(r.Name, r.Type, mxTargets, addressed) {
 						kept = append(kept, victim{z.Name, r.Name, r.Type, r.ID})
 						continue
@@ -109,10 +122,28 @@ func newDNSPruneServiceCmd() *cobra.Command {
 				return kept[i].name < kept[j].name
 			})
 
+			sort.Slice(ours, func(i, j int) bool {
+				if ours[i].zone != ours[j].zone {
+					return ours[i].zone < ours[j].zone
+				}
+				return ours[i].name < ours[j].name
+			})
+
 			// Never silent about what was skipped: a cleanup that quietly leaves
 			// rows behind reads as "done" when it is not, and the operator needs
 			// to know these names still count toward the certificate SAN.
 			reportKept := func() {
+				if len(ours) > 0 {
+					zn := map[string]bool{}
+					for _, o := range ours {
+						zn[o.zone] = true
+					}
+					fmt.Fprintf(cmd.OutOrStdout(),
+						"\nSKIPPED %d record(s) across %d mail-enabled zone(s): jabali publishes these\n"+
+							"itself (MX, mail, autodiscovery, DKIM/SPF/DMARC). They are not imported cPanel\n"+
+							"leftovers, and deleting them would break mail-client autoconfiguration with\n"+
+							"nothing to republish them.\n", len(ours), len(zn))
+				}
 				if len(kept) == 0 {
 					return
 				}
@@ -150,9 +181,14 @@ func newDNSPruneServiceCmd() *cobra.Command {
 				for _, k := range kept {
 					keptOut = append(keptOut, map[string]string{"zone": k.zone, "name": k.name, "type": k.typ})
 				}
+				oursOut := make([]map[string]string, 0, len(ours))
+				for _, o := range ours {
+					oursOut = append(oursOut, map[string]string{"zone": o.zone, "name": o.name, "type": o.typ})
+				}
 				return printJSON(map[string]any{
 					"records": out, "total": len(victims), "applied": apply,
 					"kept_mx_targets": keptOut, "kept_total": len(kept),
+					"skipped_jabali_published": oursOut, "skipped_total": len(ours),
 				})
 			}
 
@@ -192,6 +228,49 @@ func newDNSPruneServiceCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&apply, "apply", false, "actually delete (default is a dry run)")
 	cmd.Flags().StringVar(&zoneFilter, "zone", "", "limit to one zone (default: every zone)")
 	return cmd
+}
+
+// mailEnabledZones returns the lowercased names of domains that have mail
+// enabled in the panel.
+//
+// On those, jabali publishes the mail infrastructure itself (dnscompile's
+// bootstrap + email records), so the same hostnames the importer skips are the
+// ones WE authored. Deleting them is not a cleanup, it is breaking live mail.
+func mailEnabledZones(ctx context.Context) (map[string]bool, error) {
+	var names []string
+	if err := sharedDB.WithContext(ctx).
+		Model(&models.Domain{}).
+		Where("email_enabled = ?", true).
+		Pluck("name", &names).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(names))
+	for _, n := range names {
+		out[strings.ToLower(strings.TrimSuffix(n, "."))] = true
+	}
+	return out, nil
+}
+
+// jabaliPublishesMailRecord reports whether, on a mail-enabled domain, this
+// record is one jabali publishes for itself.
+//
+// The list is dnscompile's: the mail A/AAAA and MX from bootstrap, and the
+// autodiscovery CNAMEs, client-service SRVs, DKIM/SPF/DMARC/TLS-RPT TXTs from
+// the email record set. That is everything IsMailInfraRecordName matches EXCEPT
+// webmail — jabali publishes no webmail record, so an imported one is still a
+// dead cPanel hostname and still belongs in the SAN cleanup.
+//
+// Measured on a production host: all 26 zones the prune targeted were
+// mail-enabled, and every remaining record was one of ours — 26 mail A records
+// (held back by the dangling-MX guard) plus 51 autoconfig/autodiscover CNAMEs
+// pointing at them, at the TTL dnscompile writes. The honest answer for that
+// box was zero records to remove, not 51. Nothing would have republished them:
+// the zone push is a full replace from dns_records.
+func jabaliPublishesMailRecord(name, typ string) bool {
+	if strings.EqualFold(name, "webmail") {
+		return false
+	}
+	return cpanel.IsMailInfraRecordName(name, typ)
 }
 
 // mailRoutingNames returns, for one zone, the set of labels this zone's MX

--- a/panel-api/cmd/server/dns_prune_service_mx_test.go
+++ b/panel-api/cmd/server/dns_prune_service_mx_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
+
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -151,6 +153,60 @@ func TestWouldDanglingMX_AddressRecordIsTheMXTarget(t *testing.T) {
 	for _, n := range []string{"autoconfig", "autodiscover"} {
 		if wouldDanglingMX(n, "CNAME", mx, addressed) {
 			t.Errorf("%s is not an MX target and must still be pruned", n)
+		}
+	}
+}
+
+// The second flaw of the same kind, found on a production host the same night.
+//
+// #941 stopped the prune deleting a record an MX depended on. It did not stop it
+// deleting records jabali PUBLISHED. On that box every one of the 26 zones the
+// prune targeted was mail-enabled, and the whole remaining target set was ours:
+// 26 mail A records (held back by the dangling-MX guard) and 51
+// autoconfig/autodiscover CNAMEs pointing at them, at dnscompile's own TTL.
+// The honest answer for that box was ZERO records to remove, not 51 — and
+// nothing would have republished them, because the zone push is a full replace
+// from dns_records.
+//
+// Root cause is the same as #941: IsMailInfraRecordName was written to tell the
+// IMPORTER "skip these, we publish our own". Reused as a cleanup on a domain
+// where we did publish our own, it selects exactly those for deletion.
+func TestJabaliPublishesMailRecord(t *testing.T) {
+	// The hostname records dnscompile writes for a mail-enabled domain. These
+	// are the ones actually at risk: the prune only ever classifies A, AAAA and
+	// CNAME (IsMailInfraRecordName returns false for anything else), so MX, the
+	// DKIM/SPF/DMARC/TLS-RPT TXTs and the client-service SRVs are outside its
+	// reach entirely and were never in danger.
+	for _, tc := range []struct{ name, typ string }{
+		{"mail", "A"}, {"mail", "AAAA"},
+		{"autoconfig", "CNAME"}, {"autodiscover", "CNAME"},
+	} {
+		if !jabaliPublishesMailRecord(tc.name, tc.typ) {
+			t.Errorf("%s %s is published by jabali and must never be pruned on a mail-enabled zone", tc.name, tc.typ)
+		}
+	}
+
+	// Pin that boundary, so widening the classifier later cannot silently pull
+	// DKIM or the MX into the deletion set without this failing first.
+	for _, tc := range []struct{ name, typ string }{
+		{"@", "MX"}, {"_dmarc", "TXT"}, {"jabali._domainkey", "TXT"}, {"_imaps._tcp", "SRV"},
+	} {
+		if cpanel.IsMailInfraRecordName(tc.name, tc.typ) {
+			t.Errorf("%s %s is outside the prune's scope; classifying it brings it into the deletion set", tc.name, tc.typ)
+		}
+	}
+
+	// webmail is the exception: jabali publishes no webmail record, so an
+	// imported one is still a dead cPanel hostname inflating the certificate
+	// SAN. Excluding it too would leave the problem this command exists for.
+	if jabaliPublishesMailRecord("webmail", "A") {
+		t.Error("webmail is not published by jabali and must stay prunable")
+	}
+
+	// The pure cPanel names are not mail infrastructure at all.
+	for _, n := range []string{"cpanel", "whm", "webdisk", "ftp", "cpcalendars", "cpcontacts"} {
+		if jabaliPublishesMailRecord(n, "A") {
+			t.Errorf("%s is a cPanel service hostname, not ours", n)
 		}
 	}
 }


### PR DESCRIPTION
## The same mistake, one layer up

#941 stopped the prune deleting a record an **MX depended on**. It did not stop it deleting records **jabali authored**.

After #941 shipped and deployed, the dry run on a production host still offered to remove 51 records. Then:

```
mail_enabled=1 : 26 zones   (all of them)
mail_enabled=0 : none
```

Every zone it targeted has mail enabled. On a mail-enabled domain `dnscompile` publishes exactly this set — `mail` A/AAAA and MX from bootstrap, `autoconfig`/`autodiscover` CNAMEs pointing at `mail.<zone>`, plus the DKIM/SPF/DMARC/TLS-RPT TXTs and client-service SRVs:

```go
mk("autoconfig",   "CNAME", mailTarget, 0),
mk("autodiscover", "CNAME", mailTarget, 0),
```

The 51 were those CNAMEs, at dnscompile's own TTL, pointing at the 26 `mail` A records #941's guard had just held back.

**The honest answer for that box was zero records to remove.** Deleting them breaks mail-client autoconfiguration (Outlook, Thunderbird, iOS) on 26 live domains, with nothing to put them back — the zone push is a full replace from `dns_records`.

## Root cause — #941's, repeated

`IsMailInfraRecordName` exists to tell the **importer**: *"skip these, we publish our own."* Reused as a cleanup on a domain where we **did** publish our own, it selects precisely those for deletion.

The predicate is right. Inheriting its conclusion without its precondition is not. That's twice now in the same command, so it's worth naming as a pattern rather than patching case by case.

## The fix

Read which domains have mail enabled; skip the records jabali publishes for them; **report the count and the reason** rather than silently shrinking the list. Failing to read that state aborts instead of guessing — the difference between "imported leftover" and "our live mail record" is the entire question.

`webmail` stays prunable: jabali publishes no webmail record, so an imported one is still a dead cPanel hostname inflating the SAN, which is what this command is for.

## Boundary pinned

`IsMailInfraRecordName` only answers for **A / AAAA / CNAME**, so MX, the DKIM/SPF/DMARC TXTs and the SRVs are outside the prune's reach and were never at risk. A test now pins that — widening the classifier later fails a test instead of quietly enlarging the deletion set.

I got this wrong in my first test draft, asserting DKIM was protected by the new guard when in fact it was never reachable. The test now documents the real boundary.

## Net effect on the measured host

| | before | after |
|---|---|---|
| newzaps | 51 offered | **0** — all jabali-published |