### PR TITLE
feat(auth): passwordless passkey (WebAuthn) login and enrolment (GH #917)

### DIFF
--- a/install/kratos-identity-schema.json
+++ b/install/kratos-identity-schema.json
@@ -25,6 +25,9 @@
             "credentials": {
               "password": {
                 "identifier": true
+              },
+              "passkey": {
+                "display_name": true
               }
             }
           }

--- a/install/kratos.yml.tmpl
+++ b/install/kratos.yml.tmpl
@@ -122,6 +122,26 @@ selfservice:
       # regeneration; codes are hashed at rest and marked used after
       # redemption. Surfaced once in the settings flow response.
       enabled: true
+    passkey:
+      # GH #917: passwordless login with platform authenticators (Touch ID,
+      # Face ID, Windows Hello) and roaming FIDO2 keys (YubiKey). `passkey` is
+      # Kratos's dedicated *passwordless* method — it completes AAL1 on its own
+      # (no password), unlike `webauthn` which is a second factor (AAL2). Users
+      # enrol a passkey in the settings flow and can then sign in with it alone.
+      #
+      # rp.id is the Relying Party ID: the BARE panel hostname (no scheme, no
+      # port) — WebAuthn scopes a credential to this registrable domain. origins
+      # carry the FULL origin including the panel port, because the browser's
+      # WebAuthn origin check compares the exact scheme+host+port the SPA runs
+      # on (":8443" by default, or portless when fronted by a :443 reverse proxy
+      # — the same PanelPortSuffix the login/return URLs above use).
+      enabled: true
+      config:
+        rp:
+          id: "{{.PanelHostname}}"
+          display_name: "Jabali Panel"
+          origins:
+            - "https://{{.PanelHostname}}{{.PanelPortSuffix}}"
 
   flows:
     login:

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -84,7 +84,10 @@
     "backupCodeHint": "Enter one of your backup codes.",
     "webauthnHint": "Use your security key to sign in.",
     "submitVerify": "Verify",
-    "submitSignIn": "Sign in"
+    "submitSignIn": "Sign in",
+    "passkeySignIn": "Sign in with a passkey",
+    "passkeyError": "Passkey sign-in was cancelled or failed. Try again, or use your password.",
+    "orDivider": "or"
   },
   "menu": {
     "profile": "Profile",

--- a/panel-ui/src/pages/Login.test.tsx
+++ b/panel-ui/src/pages/Login.test.tsx
@@ -120,6 +120,22 @@ function totpFlow(): kratos.KratosFlow {
   };
 }
 
+// GH #917: a password flow that ALSO carries the passkey discoverable-login
+// challenge Kratos injects when the passkey method is enabled.
+function passkeyFlow(): kratos.KratosFlow {
+  const f = passwordFlow();
+  f.ui.nodes.push({
+    type: "input",
+    group: "passkey",
+    attributes: {
+      name: "passkey_challenge",
+      type: "hidden",
+      value: JSON.stringify({ publicKey: { challenge: "AQID", allowCredentials: [] } }),
+    },
+  });
+  return f;
+}
+
 describe("LoginPage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -179,6 +195,52 @@ describe("LoginPage", () => {
       expect(screen.getByLabelText(/authentication code/i)).toBeInTheDocument();
     });
     expect(screen.getByRole("button", { name: /verify/i })).toBeInTheDocument();
+  });
+
+  it("offers a passkey sign-in button when the flow advertises passkey", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    vi.spyOn(kratos, "initLoginFlow").mockResolvedValue(passkeyFlow());
+
+    renderLogin();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /sign in with a passkey/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("runs the passkey ceremony and submits method=passkey", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    const get = vi.fn().mockResolvedValue({
+      id: "cred",
+      type: "public-key",
+      rawId: new Uint8Array([1]).buffer,
+      response: {
+        authenticatorData: new Uint8Array([2]).buffer,
+        clientDataJSON: new Uint8Array([3]).buffer,
+        signature: new Uint8Array([4]).buffer,
+        userHandle: new Uint8Array([5]).buffer,
+      },
+    });
+    Object.defineProperty(globalThis.navigator, "credentials", {
+      value: { get },
+      configurable: true,
+    });
+    vi.spyOn(kratos, "initLoginFlow").mockResolvedValue(passkeyFlow());
+    const submit = vi
+      .spyOn(kratos, "submitLoginFlow")
+      .mockResolvedValue({ kind: "continue", flow: totpFlow() });
+
+    renderLogin();
+
+    const btn = await screen.findByRole("button", { name: /sign in with a passkey/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    const body = submit.mock.calls[0][1] as Record<string, string>;
+    expect(body.method).toBe("passkey");
+    expect(body.identifier).toBe("");
+    expect(JSON.parse(body.passkey_login).id).toBe("cred");
+    expect(get).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces top-level flow errors into an alert", async () => {

--- a/panel-ui/src/pages/Login.tsx
+++ b/panel-ui/src/pages/Login.tsx
@@ -18,6 +18,7 @@ import {
   Alert,
   Button,
   Card,
+  Divider,
   Form,
   Input,
   Space,
@@ -51,6 +52,11 @@ import {
   type KratosFlow,
   type RenderableField,
 } from "../kratos";
+import {
+  flowHasPasskeyLogin,
+  passkeyLoginFields,
+  webauthnSupported,
+} from "../webauthn";
 
 // JAB-159: demo-only quick-enter buttons. VITE_DEMO is a build-time
 // constant, so a non-demo build dead-code-eliminates the import() and
@@ -74,6 +80,7 @@ export const LoginPage = () => {
   const [flow, setFlow] = useState<KratosFlow | null>(null);
   const [loadingFlow, setLoadingFlow] = useState(true);
   const [initError, setInitError] = useState<string | null>(null);
+  const [passkeyBusy, setPasskeyBusy] = useState(false);
 
   // GH#177: Kratos is same-origin — login cookies, CSRF tokens, and allowed
   // return URLs are all bound to the panel hostname. Signing in over the raw
@@ -111,6 +118,22 @@ export const LoginPage = () => {
       cancelled = true;
     };
   }, []);
+
+  // Surface a one-off error into the flow's messages so the renderer shows it
+  // uniformly (used for both submit failures and the passkey ceremony).
+  const showFlowError = (msg: string) => {
+    setFlow((prev) =>
+      prev
+        ? {
+            ...prev,
+            ui: {
+              ...prev.ui,
+              messages: [...(prev.ui.messages ?? []), { id: 0, text: msg, type: "error" }],
+            },
+          }
+        : prev,
+    );
+  };
 
   const onFinish = async (group: string, values: Record<string, unknown>) => {
     if (!flow) return;
@@ -179,17 +202,29 @@ export const LoginPage = () => {
     }
     // Error — surface into the flow messages via a local synthetic flow so
     // the renderer path handles it uniformly.
-    setFlow({
-      ...flow,
-      ui: {
-        ...flow.ui,
-        messages: [
-          ...(flow.ui.messages ?? []),
-          { id: 0, text: result.message, type: "error" },
-        ],
-      },
-    });
+    showFlowError(result.message);
   };
+
+  // GH #917: passwordless passkey sign-in. Runs the WebAuthn discoverable-login
+  // ceremony (no username typed — the authenticator supplies the user handle),
+  // then reuses onFinish's "passkey" submit + result handling. A user cancel or
+  // missing authenticator throws from navigator.credentials.get; we surface a
+  // friendly message rather than the raw DOMException.
+  const onPasskey = async () => {
+    if (!flow) return;
+    setPasskeyBusy(true);
+    try {
+      const fields = await passkeyLoginFields(flow);
+      if (!fields) return;
+      await onFinish("passkey", fields);
+    } catch {
+      showFlowError(t("login.passkeyError", "Passkey sign-in was cancelled or failed. Try again, or use your password."));
+    } finally {
+      setPasskeyBusy(false);
+    }
+  };
+
+  const passkeyAvailable = !!flow && webauthnSupported() && flowHasPasskeyLogin(flow);
 
   return (
     <div
@@ -259,6 +294,22 @@ export const LoginPage = () => {
             </Suspense>
           ) : null}
           {flow && <FlowForm flow={flow} onFinish={onFinish} />}
+
+          {passkeyAvailable && (
+            <>
+              <Divider plain style={{ margin: "4px 0" }}>
+                {t("login.orDivider", "or")}
+              </Divider>
+              <Button
+                block
+                icon={<span aria-hidden>🔑</span>}
+                loading={passkeyBusy}
+                onClick={() => void onPasskey()}
+              >
+                {t("login.passkeySignIn", "Sign in with a passkey")}
+              </Button>
+            </>
+          )}
         </Space>
       </Card>
     </div>

--- a/panel-ui/src/shells/user/MyProfile.test.tsx
+++ b/panel-ui/src/shells/user/MyProfile.test.tsx
@@ -198,6 +198,55 @@ describe("MyProfile 2FA", () => {
     expect(screen.getByText(/ccccc-ddddd/)).toBeInTheDocument();
   });
 
+  it("shows the passkey enrolment card with an Add button (GH #917)", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    vi.spyOn(kratos, "getSettingsFlow").mockResolvedValue(
+      baseFlow([
+        {
+          type: "input",
+          group: "passkey",
+          attributes: {
+            name: "passkey_create_data",
+            type: "hidden",
+            value: JSON.stringify({ publicKey: { user: { id: "AQID" }, challenge: "AQID" } }),
+          },
+        },
+      ]),
+    );
+    renderProfile();
+    await waitFor(() =>
+      expect(screen.getByText("Passkeys (passwordless)")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /add a passkey/i })).toBeInTheDocument();
+  });
+
+  it("lists a Remove button for each registered passkey (GH #917)", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    vi.spyOn(kratos, "getSettingsFlow").mockResolvedValue(
+      baseFlow([
+        {
+          type: "input",
+          group: "passkey",
+          attributes: {
+            name: "passkey_create_data",
+            type: "hidden",
+            value: JSON.stringify({ publicKey: {} }),
+          },
+        },
+        {
+          type: "input",
+          group: "passkey",
+          attributes: { name: "passkey_remove", type: "submit", value: "cred-abc" },
+          meta: { label: { text: "Remove" } },
+        },
+      ]),
+    );
+    renderProfile();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^remove$/i })).toBeInTheDocument(),
+    );
+  });
+
   it("submits the typed totp_code on TOTP enrolment (regression #140)", async () => {
     vi.spyOn(kratos, "getSettingsFlow").mockResolvedValue(
       baseFlow([

--- a/panel-ui/src/shells/user/MyProfile.tsx
+++ b/panel-ui/src/shells/user/MyProfile.tsx
@@ -27,6 +27,7 @@ import { useLocation, useNavigate } from "react-router";
 
 import { getIdentity, type Identity } from "../../identity";
 import { getActAs } from "../../impersonation";
+import { passkeyEnrolFields, webauthnSupported } from "../../webauthn";
 import {
   csrfToken,
   flowMessages,
@@ -315,8 +316,8 @@ function collectGroups(flow: KratosFlow): string[] {
     seen.add(node.group);
     order.push(node.group);
   }
-  // Stable ordering: password first, then 2FA methods.
-  const preferred = ["password", "totp", "lookup_secret", "webauthn"];
+  // Stable ordering: password first, then passwordless passkeys, then 2FA methods.
+  const preferred = ["password", "passkey", "totp", "lookup_secret", "webauthn"];
   return [...preferred.filter((p) => seen.has(p)), ...order.filter((g) => !preferred.includes(g))];
 }
 
@@ -326,12 +327,107 @@ type GroupFormProps = {
   onSubmit: (values: Record<string, unknown>) => Promise<void>;
 };
 
+// PasskeySettingsCard — GH #917 passwordless passkey enrolment. The passkey
+// settings group can't be a plain form POST: adding a passkey runs the
+// WebAuthn *create* ceremony in the browser first, then submits the encoded
+// credential. Removing one is a normal submit (passkey_remove=<credential id>),
+// so we reuse onSubmit for that.
+function PasskeySettingsCard({
+  flow,
+  onSubmit,
+}: {
+  flow: KratosFlow;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  // Each registered passkey surfaces a submit node named "passkey_remove"
+  // whose value is that credential's id.
+  const removals = renderableFields(flow, "passkey").filter(
+    (f) => f.kind === "submit" && f.name === "passkey_remove",
+  );
+  const supported = webauthnSupported();
+
+  const onAdd = async () => {
+    setBusy(true);
+    try {
+      const fields = await passkeyEnrolFields(flow);
+      if (!fields) return;
+      await onSubmit(fields);
+      message.success("Passkey added");
+    } catch {
+      message.error("Passkey registration was cancelled or failed. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card type="inner" title="Passkeys (passwordless)" size="small">
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Text type="secondary">
+          Sign in without a password using Touch ID, Face ID, Windows Hello, or a
+          security key. You can register more than one.
+        </Typography.Text>
+
+        {removals.length > 0 && (
+          <Space direction="vertical" size="small" style={{ width: "100%" }}>
+            {removals.map((f, i) => (
+              <Space
+                key={f.value || i}
+                style={{ width: "100%", justifyContent: "space-between" }}
+              >
+                <Typography.Text>Passkey {i + 1}</Typography.Text>
+                <Button
+                  danger
+                  size="small"
+                  onClick={() =>
+                    Modal.confirm({
+                      title: "Remove this passkey?",
+                      content:
+                        "This device or key will no longer be able to sign you in. If it's your only passkey, make sure you still know your password.",
+                      okText: "Remove",
+                      okButtonProps: { danger: true },
+                      cancelText: "Cancel",
+                      onOk: () => onSubmit({ passkey_remove: f.value }),
+                    })
+                  }
+                >
+                  Remove
+                </Button>
+              </Space>
+            ))}
+          </Space>
+        )}
+
+        {supported ? (
+          <Button type="primary" loading={busy} onClick={() => void onAdd()}>
+            Add a passkey
+          </Button>
+        ) : (
+          <Alert
+            type="info"
+            showIcon
+            message="This browser does not support passkeys."
+          />
+        )}
+      </Space>
+    </Card>
+  );
+}
+
 function SettingsGroupForm({ flow, group, onSubmit }: GroupFormProps) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
   const fields = renderableFields(flow, group);
   const totpDisplay = group === "totp" ? totpEnrolmentDisplay(flow) : null;
   const recoveryCodes = group === "lookup_secret" ? lookupSecretReveal(flow) : null;
+
+  // Passkey enrolment needs the WebAuthn create ceremony, not a plain form
+  // POST — render it with its own card (Add runs navigator.credentials.create;
+  // Remove reuses the normal submit path).
+  if (group === "passkey") {
+    return <PasskeySettingsCard flow={flow} onSubmit={onSubmit} />;
+  }
 
   const submit = async (values: Record<string, unknown>) => {
     setSubmitting(true);

--- a/panel-ui/src/webauthn.test.ts
+++ b/panel-ui/src/webauthn.test.ts
@@ -1,0 +1,221 @@
+// webauthn.test.ts — GH #917. The encode/decode + result JSON shape MUST match
+// Kratos's own webauthn.js exactly, or authentication silently breaks. These
+// tests pin that contract (verified against the deployed v26.2.0 script).
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  bufferDecode,
+  bufferEncode,
+  flowHasPasskeyEnrol,
+  flowHasPasskeyLogin,
+  passkeyEnrolFields,
+  passkeyLoginFields,
+} from "./webauthn";
+import type { KratosFlow } from "./kratos";
+
+function u8(...bytes: number[]): ArrayBuffer {
+  return new Uint8Array(bytes).buffer;
+}
+
+// Minimal login flow carrying a passkey discoverable-login challenge, exactly
+// as Kratos serialises it: { publicKey: { challenge: <b64url>, ... } }.
+function loginFlow(challengeB64url: string): KratosFlow {
+  return {
+    id: "f1",
+    type: "browser",
+    expires_at: "",
+    issued_at: "",
+    request_url: "",
+    ui: {
+      action: "/self-service/login?flow=f1",
+      method: "POST",
+      nodes: [
+        {
+          type: "input",
+          group: "passkey",
+          attributes: {
+            name: "passkey_challenge",
+            type: "hidden",
+            value: JSON.stringify({
+              publicKey: { challenge: challengeB64url, allowCredentials: [], timeout: 60000 },
+            }),
+          },
+        },
+      ],
+    },
+  };
+}
+
+function enrolFlow(createData: unknown): KratosFlow {
+  return {
+    id: "s1",
+    type: "browser",
+    expires_at: "",
+    issued_at: "",
+    request_url: "",
+    ui: {
+      action: "/self-service/settings?flow=s1",
+      method: "POST",
+      nodes: [
+        {
+          type: "input",
+          group: "passkey",
+          attributes: {
+            name: "passkey_create_data",
+            type: "hidden",
+            value: JSON.stringify(createData),
+          },
+        },
+      ],
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("base64url codec (mirrors Kratos webauthn.js)", () => {
+  it("encodes to URL-safe base64 without padding", () => {
+    // bytes 0xfb 0xff → std base64 "+/8=" → url "-_8" (no padding)
+    expect(bufferEncode(u8(0xfb, 0xff))).toBe("-_8");
+    // bytes 1,2,3 → "AQID" (no + / or padding involved)
+    expect(bufferEncode(u8(1, 2, 3))).toBe("AQID");
+  });
+
+  it("returns empty string for null/undefined (userHandle can be null)", () => {
+    expect(bufferEncode(null)).toBe("");
+    expect(bufferEncode(undefined)).toBe("");
+  });
+
+  it("decodes URL-safe base64 (padded or not) back to bytes", () => {
+    expect(Array.from(bufferDecode("-_8"))).toEqual([0xfb, 0xff]);
+    expect(Array.from(bufferDecode("AQID"))).toEqual([1, 2, 3]);
+  });
+
+  it("round-trips arbitrary bytes", () => {
+    const bytes = [0, 1, 62, 63, 127, 128, 200, 254, 255];
+    expect(Array.from(bufferDecode(bufferEncode(new Uint8Array(bytes).buffer)))).toEqual(bytes);
+  });
+});
+
+describe("flow detection", () => {
+  it("detects a passkey login challenge", () => {
+    expect(flowHasPasskeyLogin(loginFlow("AQID"))).toBe(true);
+    expect(flowHasPasskeyEnrol(loginFlow("AQID"))).toBe(false);
+  });
+  it("detects a passkey enrolment create-data node", () => {
+    expect(flowHasPasskeyEnrol(enrolFlow({ publicKey: {} }))).toBe(true);
+    expect(flowHasPasskeyLogin(enrolFlow({ publicKey: {} }))).toBe(false);
+  });
+});
+
+describe("passkeyLoginFields", () => {
+  it("returns null when the flow has no passkey challenge", async () => {
+    const flow = loginFlow("AQID");
+    flow.ui.nodes = [];
+    expect(await passkeyLoginFields(flow)).toBeNull();
+  });
+
+  it("runs credentials.get and encodes the assertion exactly like Kratos", async () => {
+    const get = vi.fn().mockResolvedValue({
+      id: "cred-id",
+      type: "public-key",
+      rawId: u8(1, 2, 3),
+      response: {
+        authenticatorData: u8(4, 5, 6),
+        clientDataJSON: u8(7, 8, 9),
+        signature: u8(10, 11, 12),
+        userHandle: u8(13, 14, 15),
+      },
+    });
+    vi.stubGlobal("navigator", { credentials: { get, create: vi.fn() } });
+    vi.stubGlobal("PublicKeyCredential", function () {});
+
+    const out = await passkeyLoginFields(loginFlow("AQID"));
+    expect(out).not.toBeNull();
+    expect(out!.identifier).toBe(""); // discoverable login: no username typed
+
+    // The challenge must reach the authenticator as decoded bytes.
+    const passed = get.mock.calls[0][0].publicKey;
+    expect(Array.from(new Uint8Array(passed.challenge))).toEqual([1, 2, 3]); // "AQID"
+
+    const body = JSON.parse(out!.passkey_login);
+    expect(body).toEqual({
+      id: "cred-id",
+      rawId: bufferEncode(u8(1, 2, 3)),
+      type: "public-key",
+      response: {
+        authenticatorData: bufferEncode(u8(4, 5, 6)),
+        clientDataJSON: bufferEncode(u8(7, 8, 9)),
+        signature: bufferEncode(u8(10, 11, 12)),
+        userHandle: bufferEncode(u8(13, 14, 15)),
+      },
+    });
+  });
+
+  it("encodes a null userHandle as an empty string", async () => {
+    const get = vi.fn().mockResolvedValue({
+      id: "c",
+      type: "public-key",
+      rawId: u8(1),
+      response: {
+        authenticatorData: u8(2),
+        clientDataJSON: u8(3),
+        signature: u8(4),
+        userHandle: null,
+      },
+    });
+    vi.stubGlobal("navigator", { credentials: { get, create: vi.fn() } });
+    const out = await passkeyLoginFields(loginFlow("AQID"));
+    expect(JSON.parse(out!.passkey_login).response.userHandle).toBe("");
+  });
+});
+
+describe("passkeyEnrolFields", () => {
+  it("runs credentials.create and encodes the attestation like Kratos", async () => {
+    const create = vi.fn().mockResolvedValue({
+      id: "new-cred",
+      type: "public-key",
+      rawId: u8(9, 9, 9),
+      response: {
+        attestationObject: u8(1, 1, 1),
+        clientDataJSON: u8(2, 2, 2),
+      },
+    });
+    vi.stubGlobal("navigator", { credentials: { get: vi.fn(), create } });
+
+    const flow = enrolFlow({
+      publicKey: {
+        user: { id: "AQID", name: "alice", displayName: "alice" },
+        challenge: "BAUG", // bytes 4,5,6
+        excludeCredentials: [],
+        pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      },
+    });
+    const out = await passkeyEnrolFields(flow);
+    expect(out).not.toBeNull();
+
+    // user.id + challenge must be decoded to bytes before create.
+    const passed = create.mock.calls[0][0].publicKey;
+    expect(Array.from(new Uint8Array(passed.user.id))).toEqual([1, 2, 3]);
+    expect(Array.from(new Uint8Array(passed.challenge))).toEqual([4, 5, 6]);
+
+    const body = JSON.parse(out!.passkey_settings_register);
+    expect(body).toEqual({
+      id: "new-cred",
+      rawId: bufferEncode(u8(9, 9, 9)),
+      type: "public-key",
+      response: {
+        attestationObject: bufferEncode(u8(1, 1, 1)),
+        clientDataJSON: bufferEncode(u8(2, 2, 2)),
+      },
+    });
+  });
+
+  it("returns null when the flow has no create data", async () => {
+    const flow = enrolFlow({ publicKey: {} });
+    flow.ui.nodes = [];
+    expect(await passkeyEnrolFields(flow)).toBeNull();
+  });
+});

--- a/panel-ui/src/webauthn.ts
+++ b/panel-ui/src/webauthn.ts
@@ -1,0 +1,160 @@
+// webauthn.ts — GH #917: passkey (passwordless WebAuthn) ceremony for the SPA.
+//
+// Kratos ships a browser helper (/.well-known/ory/webauthn.js) that runs the
+// WebAuthn ceremony and submits a hidden HTML form. Our SPA renders its own
+// AntD forms and talks to Kratos over XHR/JSON, so that script's
+// form.submit() model doesn't fit. Instead we perform the ceremony directly
+// with `navigator.credentials` and hand the resulting field back to the
+// existing kratos.ts submit path (which adds csrf_token + method).
+//
+// The encode/decode + result JSON shape below MIRROR Kratos's own webauthn.js
+// byte-for-byte (verified against the deployed v26.2.0 script): base64url
+// WITHOUT padding, and the exact field names Kratos's passkey strategy reads
+// (`passkey_challenge` / `passkey_login` for login, `passkey_create_data` /
+// `passkey_settings_register` for settings enrolment). Getting this wrong
+// silently breaks authentication, so it is kept deliberately faithful and is
+// covered by webauthn.test.ts.
+import type { KratosFlow } from "./kratos";
+
+// base64url (no padding) → bytes. Mirrors __oryWebAuthnBufferDecode. Returns a
+// Uint8Array backed by a plain ArrayBuffer (not ArrayBufferLike) so it is
+// directly assignable to WebAuthn's BufferSource fields.
+export function bufferDecode(value: string): Uint8Array<ArrayBuffer> {
+  let b64 = value.replaceAll("-", "+").replaceAll("_", "/");
+  // Re-pad to a multiple of 4: Kratos emits unpadded base64url and relies on
+  // the browser's lenient atob; padding here works in strict environments too.
+  b64 += "=".repeat((4 - (b64.length % 4)) % 4);
+  const bin = atob(b64);
+  const buf = new ArrayBuffer(bin.length);
+  const out = new Uint8Array(buf);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// bytes → base64url (no padding). Mirrors __oryWebAuthnBufferEncode.
+export function bufferEncode(value: ArrayBuffer | null | undefined): string {
+  if (!value) return "";
+  const bytes = new Uint8Array(value);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+// Is WebAuthn usable in this browser at all?
+export function webauthnSupported(): boolean {
+  return typeof window !== "undefined" && !!window.PublicKeyCredential;
+}
+
+// Read a Kratos node's input value by field name.
+function nodeValue(flow: KratosFlow, name: string): string | undefined {
+  for (const node of flow.ui.nodes) {
+    if (node.type === "input" && node.attributes.name === name) {
+      const v = node.attributes.value;
+      return v == null ? undefined : String(v);
+    }
+  }
+  return undefined;
+}
+
+// A login flow offers passkey when Kratos injected the discoverable-login
+// challenge node; a settings flow offers enrolment via passkey_create_data.
+export function flowHasPasskeyLogin(flow: KratosFlow): boolean {
+  return nodeValue(flow, "passkey_challenge") !== undefined;
+}
+export function flowHasPasskeyEnrol(flow: KratosFlow): boolean {
+  return nodeValue(flow, "passkey_create_data") !== undefined;
+}
+
+// Kratos serialises the WebAuthn options as { publicKey: { challenge, ... } }
+// with base64url-encoded binary fields. We decode the binary fields the
+// authenticator needs as ArrayBuffers before calling navigator.credentials.
+type PublicKeyOptions = {
+  publicKey: PublicKeyCredentialRequestOptions &
+    PublicKeyCredentialCreationOptions & {
+      // Kratos ships these as base64url strings; we rewrite them to BufferSource.
+      challenge: unknown;
+      allowCredentials?: Array<{ id: unknown; type: string; transports?: string[] }>;
+      excludeCredentials?: Array<{ id: unknown; type: string; transports?: string[] }>;
+      user?: { id: unknown; name: string; displayName: string };
+    };
+};
+
+function decodeId<T extends { id: unknown }>(c: T): T {
+  return { ...c, id: bufferDecode(String(c.id)) };
+}
+
+// passkeyLoginFields runs the discoverable-login ceremony and returns the
+// credential field to POST. `identifier` is empty: passkey login is
+// discoverable — the authenticator supplies the user handle, so the user
+// doesn't type a username. Returns null when the flow carries no passkey
+// challenge. Throws when the ceremony fails (no authenticator, user cancel).
+export async function passkeyLoginFields(
+  flow: KratosFlow,
+): Promise<{ passkey_login: string; identifier: string } | null> {
+  const raw = nodeValue(flow, "passkey_challenge");
+  if (raw === undefined) return null;
+
+  const opt = JSON.parse(raw) as PublicKeyOptions;
+  opt.publicKey.challenge = bufferDecode(String(opt.publicKey.challenge)) as BufferSource;
+  if (opt.publicKey.allowCredentials) {
+    opt.publicKey.allowCredentials = opt.publicKey.allowCredentials.map(decodeId);
+  }
+
+  const credential = (await navigator.credentials.get({
+    publicKey: opt.publicKey as PublicKeyCredentialRequestOptions,
+  })) as PublicKeyCredential | null;
+  if (!credential) throw new Error("No passkey credential was returned");
+
+  const response = credential.response as AuthenticatorAssertionResponse;
+  const passkey_login = JSON.stringify({
+    id: credential.id,
+    rawId: bufferEncode(credential.rawId),
+    type: credential.type,
+    response: {
+      authenticatorData: bufferEncode(response.authenticatorData),
+      clientDataJSON: bufferEncode(response.clientDataJSON),
+      signature: bufferEncode(response.signature),
+      userHandle: bufferEncode(response.userHandle),
+    },
+  });
+  return { passkey_login, identifier: "" };
+}
+
+// passkeyEnrolFields runs the registration ceremony against the settings
+// flow's passkey_create_data and returns the field to POST. Kratos has
+// already set user.name/displayName from the identity's display-name trait
+// (the username, per the identity schema), so no display-name input is
+// needed. Returns null when the flow carries no create data. Throws on
+// ceremony failure.
+export async function passkeyEnrolFields(
+  flow: KratosFlow,
+): Promise<{ passkey_settings_register: string } | null> {
+  const raw = nodeValue(flow, "passkey_create_data");
+  if (raw === undefined) return null;
+
+  const opt = JSON.parse(raw) as PublicKeyOptions;
+  if (opt.publicKey.user) {
+    opt.publicKey.user = { ...opt.publicKey.user, id: bufferDecode(String(opt.publicKey.user.id)) };
+  }
+  opt.publicKey.challenge = bufferDecode(String(opt.publicKey.challenge)) as BufferSource;
+  if (opt.publicKey.excludeCredentials) {
+    opt.publicKey.excludeCredentials = opt.publicKey.excludeCredentials.map(decodeId);
+  }
+
+  const credential = (await navigator.credentials.create({
+    publicKey: opt.publicKey as PublicKeyCredentialCreationOptions,
+  })) as PublicKeyCredential | null;
+  if (!credential) throw new Error("No passkey credential was created");
+
+  const response = credential.response as AuthenticatorAttestationResponse;
+  const passkey_settings_register = JSON.stringify({
+    id: credential.id,
+    rawId: bufferEncode(credential.rawId),
+    type: credential.type,
+    response: {
+      attestationObject: bufferEncode(response.attestationObject),
+      clientDataJSON: bufferEncode(response.clientDataJSON),
+    },
+  });
+  return { passkey_settings_register };
+}


### PR DESCRIPTION
Closes the ask in #917: expose Kratos's passkey/WebAuthn capability in the panel.

## What
Passwordless **passkey** sign-in (Touch ID / Face ID / Windows Hello / FIDO2 keys):
- **Login**: a "Sign in with a passkey" button on the login page. Discoverable login — the user doesn't type a username; the authenticator supplies the handle.
- **Enrolment**: a passkey card in **Profile → Security** (add via the WebAuthn create ceremony; remove via the normal settings submit).

## How
- `install/kratos.yml.tmpl` — enable `selfservice.methods.passkey`. `rp.id` = the bare panel hostname (the registrable WebAuthn domain); `origins` = the full panel origin incl. port, so the browser origin check passes on `:8443` (portless behind a `:443` reverse proxy, matching the existing login/return URLs).
- `install/kratos-identity-schema.json` — map `passkey.display_name` onto the `username` trait so Kratos can name enrolled passkeys.
- `panel-ui/src/webauthn.ts` — `navigator.credentials` get()/create() ceremony helpers that **mirror Kratos's own `webauthn.js` encoding byte-for-byte** (base64url, no padding; exact `passkey_login` / `passkey_settings_register` result shapes, verified against the deployed v26.2.0 script). They return just the credential field and reuse the existing Kratos submit + result handling. Hand-rolled, so **no remote-script injection and no CSP change**.
- `Login.tsx` / `MyProfile.tsx` wired to the helpers.

## Scope
Passwordless **passkey** only. `webauthn` as a *second factor* (security keys at AAL2) is a deliberate follow-up — its enrolment needs a separate ceremony and UI.

## Testing
- `webauthn.test.ts` pins the encode/decode + result-JSON contract against Kratos (11 tests).
- `Login.test.tsx` covers the passkey button + method=passkey submit; `MyProfile.test.tsx` covers the enrolment card + remove buttons.
- Config validated against the real Kratos v26.2.0 binary on the test host (advances past config-schema validation).

## Test plan
- [ ] CI green (unit + build)
- [ ] Deploy to test host; Kratos restarts clean; login flow returns passkey nodes and settings flow offers enrolment
- [ ] Live: register a passkey (virtual authenticator), log out, sign in passwordless

🤖 Generated with [Claude Code](https://claude.com/claude-code)