### PR TITLE
feat(auth): WebAuthn security keys as a second factor (GH #917 follow-up)

### DIFF
--- a/install/kratos-identity-schema.json
+++ b/install/kratos-identity-schema.json
@@ -28,6 +28,9 @@
               },
               "passkey": {
                 "display_name": true
+              },
+              "webauthn": {
+                "identifier": true
               }
             }
           }

--- a/install/kratos.yml.tmpl
+++ b/install/kratos.yml.tmpl
@@ -142,6 +142,22 @@ selfservice:
           display_name: "Jabali Panel"
           origins:
             - "https://{{.PanelHostname}}{{.PanelPortSuffix}}"
+    webauthn:
+      # GH #917 follow-up: hardware security keys (YubiKey, etc.) and platform
+      # authenticators as a SECOND factor (AAL2), presented AFTER the password —
+      # distinct from `passkey` above, which is passwordless (AAL1). The
+      # passwordless:false flag is what makes Kratos treat a registered credential
+      # as MFA rather than a first factor; changing it would silently reclassify
+      # existing credentials, so it is pinned. Same RP (id = bare hostname, origins
+      # carry the panel port) as passkey.
+      enabled: true
+      config:
+        passwordless: false
+        rp:
+          id: "{{.PanelHostname}}"
+          display_name: "Jabali Panel"
+          origins:
+            - "https://{{.PanelHostname}}{{.PanelPortSuffix}}"
 
   flows:
     login:

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -87,7 +87,9 @@
     "submitSignIn": "Sign in",
     "passkeySignIn": "Sign in with a passkey",
     "passkeyError": "Passkey sign-in was cancelled or failed. Try again, or use your password.",
-    "orDivider": "or"
+    "orDivider": "or",
+    "webauthnSignIn": "Use your security key",
+    "webauthnError": "Security-key sign-in was cancelled or failed. Try again."
   },
   "menu": {
     "profile": "Profile",

--- a/panel-ui/src/pages/Login.test.tsx
+++ b/panel-ui/src/pages/Login.test.tsx
@@ -197,6 +197,60 @@ describe("LoginPage", () => {
     expect(screen.getByRole("button", { name: /verify/i })).toBeInTheDocument();
   });
 
+  // AAL2 flow whose only method is a webauthn security key (button-triggered).
+  function webauthn2faFlow(): kratos.KratosFlow {
+    const f = totpFlow();
+    f.ui.nodes = [
+      f.ui.nodes[0], // csrf
+      {
+        type: "input",
+        group: "webauthn",
+        attributes: {
+          name: "webauthn_login_trigger",
+          type: "button",
+          value: JSON.stringify({ publicKey: { challenge: "AQID", allowCredentials: [] } }),
+        },
+      },
+      {
+        type: "input",
+        group: "webauthn",
+        attributes: { name: "webauthn_login", type: "hidden" },
+      },
+    ];
+    return f;
+  }
+
+  it("offers a security-key button on an AAL2 webauthn step and submits method=webauthn", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    const get = vi.fn().mockResolvedValue({
+      id: "wk",
+      type: "public-key",
+      rawId: new Uint8Array([1]).buffer,
+      response: {
+        authenticatorData: new Uint8Array([2]).buffer,
+        clientDataJSON: new Uint8Array([3]).buffer,
+        signature: new Uint8Array([4]).buffer,
+        userHandle: null,
+      },
+    });
+    Object.defineProperty(globalThis.navigator, "credentials", { value: { get }, configurable: true });
+    vi.spyOn(kratos, "initLoginFlow").mockResolvedValue(webauthn2faFlow());
+    const submit = vi
+      .spyOn(kratos, "submitLoginFlow")
+      .mockResolvedValue({ kind: "error", message: "x" });
+
+    renderLogin();
+    const btn = await screen.findByRole("button", { name: /use your security key/i });
+    // No spurious "no credential method" warning for the ceremony-only step.
+    expect(screen.queryByText(/no credential method/i)).not.toBeInTheDocument();
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    const body = submit.mock.calls[0][1] as Record<string, string>;
+    expect(body.method).toBe("webauthn");
+    expect(JSON.parse(body.webauthn_login).id).toBe("wk");
+  });
+
   it("offers a passkey sign-in button when the flow advertises passkey", async () => {
     vi.stubGlobal("PublicKeyCredential", function () {});
     vi.spyOn(kratos, "initLoginFlow").mockResolvedValue(passkeyFlow());

--- a/panel-ui/src/pages/Login.tsx
+++ b/panel-ui/src/pages/Login.tsx
@@ -54,7 +54,9 @@ import {
 } from "../kratos";
 import {
   flowHasPasskeyLogin,
+  flowHasWebauthn2faLogin,
   passkeyLoginFields,
+  webauthn2faLoginFields,
   webauthnSupported,
 } from "../webauthn";
 
@@ -224,7 +226,26 @@ export const LoginPage = () => {
     }
   };
 
+  // GH #917 follow-up: AAL2 security-key (webauthn 2FA) step. After the password
+  // succeeds for an identity with a registered security key, Kratos returns an
+  // aal2 flow carrying a webauthn group. Like passkey, it's a button-triggered
+  // ceremony, not a field form — run get() and submit method=webauthn.
+  const onWebauthn2fa = async () => {
+    if (!flow) return;
+    setPasskeyBusy(true);
+    try {
+      const fields = await webauthn2faLoginFields(flow);
+      if (!fields) return;
+      await onFinish("webauthn", fields);
+    } catch {
+      showFlowError(t("login.webauthnError", "Security-key sign-in was cancelled or failed. Try again."));
+    } finally {
+      setPasskeyBusy(false);
+    }
+  };
+
   const passkeyAvailable = !!flow && webauthnSupported() && flowHasPasskeyLogin(flow);
+  const webauthn2faAvailable = !!flow && webauthnSupported() && flowHasWebauthn2faLogin(flow);
 
   return (
     <div
@@ -293,7 +314,13 @@ export const LoginPage = () => {
               />
             </Suspense>
           ) : null}
-          {flow && <FlowForm flow={flow} onFinish={onFinish} />}
+          {flow && (
+            <FlowForm
+              flow={flow}
+              onFinish={onFinish}
+              ceremonyAvailable={passkeyAvailable || webauthn2faAvailable}
+            />
+          )}
 
           {passkeyAvailable && (
             <>
@@ -310,6 +337,22 @@ export const LoginPage = () => {
               </Button>
             </>
           )}
+
+          {webauthn2faAvailable && (
+            <>
+              <Divider plain style={{ margin: "4px 0" }}>
+                {t("login.orDivider", "or")}
+              </Divider>
+              <Button
+                block
+                icon={<span aria-hidden>🔐</span>}
+                loading={passkeyBusy}
+                onClick={() => void onWebauthn2fa()}
+              >
+                {t("login.webauthnSignIn", "Use your security key")}
+              </Button>
+            </>
+          )}
         </Space>
       </Card>
     </div>
@@ -319,6 +362,10 @@ export const LoginPage = () => {
 type FlowFormProps = {
   flow: KratosFlow;
   onFinish: (group: string, values: Record<string, unknown>) => Promise<void>;
+  // True when a passkey / security-key button is rendered outside this form.
+  // Suppresses the "no credential method" warning for ceremony-only flows
+  // (e.g. an AAL2 step whose only method is a security key).
+  ceremonyAvailable?: boolean;
 };
 
 /**
@@ -329,12 +376,24 @@ type FlowFormProps = {
  * render as the active section; the "default" nodes are included as
  * hidden inputs on submission.
  */
-function FlowForm({ flow, onFinish }: FlowFormProps) {
+function FlowForm({ flow, onFinish, ceremonyAvailable }: FlowFormProps) {
   const { t } = useTranslation();
   const topErrors = flowMessages(flow);
   const activeGroup = pickActiveGroup(flow);
 
   if (!activeGroup) {
+    // A ceremony-only step (e.g. AAL2 with just a security key) has no field
+    // form — the passkey/security-key button outside this component drives it.
+    // Still surface any top-level flow errors so a failed attempt is visible.
+    if (ceremonyAvailable) {
+      return (
+        <>
+          {topErrors.map((msg, i) => (
+            <Alert key={i} message={msg} type="error" showIcon />
+          ))}
+        </>
+      );
+    }
     return (
       <Alert
         message={t("login.noCredentialMethod")}
@@ -369,12 +428,15 @@ function pickActiveGroup(flow: KratosFlow): string | null {
     if (node.group === "default") continue;
     if (!seen.has(node.group)) seen.add(node.group);
   }
-  // Preferred order if multiple groups show up at once.
-  const preferred = ["totp", "lookup_secret", "password", "webauthn"];
+  // Preferred order if multiple groups show up at once. passkey + webauthn are
+  // button-triggered ceremonies rendered outside the field form, so they are
+  // deliberately excluded here (never rendered as an input group).
+  const preferred = ["totp", "lookup_secret", "password"];
   for (const g of preferred) {
     if (seen.has(g)) return g;
   }
-  return seen.values().next().value ?? null;
+  const fieldGroups = [...seen].filter((g) => g !== "passkey" && g !== "webauthn");
+  return fieldGroups[0] ?? null;
 }
 
 type GroupFormProps = {

--- a/panel-ui/src/shells/user/MyProfile.test.tsx
+++ b/panel-ui/src/shells/user/MyProfile.test.tsx
@@ -247,6 +247,36 @@ describe("MyProfile 2FA", () => {
     );
   });
 
+  it("shows the security-key (webauthn 2FA) card with a name field + Add button", async () => {
+    vi.stubGlobal("PublicKeyCredential", function () {});
+    vi.spyOn(kratos, "getSettingsFlow").mockResolvedValue(
+      baseFlow([
+        {
+          type: "input",
+          group: "webauthn",
+          attributes: {
+            name: "webauthn_register_displayname",
+            type: "text",
+          },
+        },
+        {
+          type: "input",
+          group: "webauthn",
+          attributes: {
+            name: "webauthn_register_trigger",
+            type: "button",
+            value: JSON.stringify({ publicKey: { user: { id: "AQID" }, challenge: "AQID" } }),
+          },
+        },
+      ]),
+    );
+    renderProfile();
+    await waitFor(() =>
+      expect(screen.getByText("Security keys (two-factor)")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /add a security key/i })).toBeInTheDocument();
+  });
+
   it("submits the typed totp_code on TOTP enrolment (regression #140)", async () => {
     vi.spyOn(kratos, "getSettingsFlow").mockResolvedValue(
       baseFlow([

--- a/panel-ui/src/shells/user/MyProfile.tsx
+++ b/panel-ui/src/shells/user/MyProfile.tsx
@@ -27,7 +27,7 @@ import { useLocation, useNavigate } from "react-router";
 
 import { getIdentity, type Identity } from "../../identity";
 import { getActAs } from "../../impersonation";
-import { passkeyEnrolFields, webauthnSupported } from "../../webauthn";
+import { passkeyEnrolFields, webauthnEnrolFields, webauthnSupported } from "../../webauthn";
 import {
   csrfToken,
   flowMessages,
@@ -415,6 +415,106 @@ function PasskeySettingsCard({
   );
 }
 
+// WebauthnSettingsCard — GH #917 follow-up. Security key (webauthn) as a SECOND
+// factor. Adding one runs the WebAuthn create ceremony with a user-chosen name
+// (webauthn_register_displayname); removing one is a normal submit
+// (webauthn_remove=<credential id>).
+function WebauthnSettingsCard({
+  flow,
+  onSubmit,
+}: {
+  flow: KratosFlow;
+  onSubmit: (values: Record<string, unknown>) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [name, setName] = useState("");
+  const removals = renderableFields(flow, "webauthn").filter(
+    (f) => f.kind === "submit" && f.name === "webauthn_remove",
+  );
+  const supported = webauthnSupported();
+
+  const onAdd = async () => {
+    const displayName = name.trim() || "Security key";
+    setBusy(true);
+    try {
+      const fields = await webauthnEnrolFields(flow, displayName);
+      if (!fields) return;
+      await onSubmit(fields);
+      setName("");
+      message.success("Security key added");
+    } catch {
+      message.error("Security-key registration was cancelled or failed. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card type="inner" title="Security keys (two-factor)" size="small">
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        <Typography.Text type="secondary">
+          Add a hardware security key (e.g. YubiKey) or your device as a second
+          factor. After your password, you'll confirm sign-in with the key.
+        </Typography.Text>
+
+        {removals.length > 0 && (
+          <Space direction="vertical" size="small" style={{ width: "100%" }}>
+            {removals.map((f, i) => (
+              <Space
+                key={f.value || i}
+                style={{ width: "100%", justifyContent: "space-between" }}
+              >
+                <Typography.Text>Security key {i + 1}</Typography.Text>
+                <Button
+                  danger
+                  size="small"
+                  onClick={() =>
+                    Modal.confirm({
+                      title: "Remove this security key?",
+                      content:
+                        "This key will no longer work as your second factor. If it's your only 2FA method, you'll sign in with just your password until you add another.",
+                      okText: "Remove",
+                      okButtonProps: { danger: true },
+                      cancelText: "Cancel",
+                      onOk: () => onSubmit({ webauthn_remove: f.value }),
+                    })
+                  }
+                >
+                  Remove
+                </Button>
+              </Space>
+            ))}
+          </Space>
+        )}
+
+        {supported ? (
+          <Form layout="vertical" requiredMark={false} onFinish={() => void onAdd()}>
+            <Form.Item label="Name (to recognise this key later)" style={{ marginBottom: 12 }}>
+              <Input
+                placeholder="e.g. YubiKey 5C"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                maxLength={64}
+              />
+            </Form.Item>
+            <Form.Item style={{ marginBottom: 0 }}>
+              <Button type="primary" htmlType="submit" loading={busy}>
+                Add a security key
+              </Button>
+            </Form.Item>
+          </Form>
+        ) : (
+          <Alert
+            type="info"
+            showIcon
+            message="This browser does not support security keys."
+          />
+        )}
+      </Space>
+    </Card>
+  );
+}
+
 function SettingsGroupForm({ flow, group, onSubmit }: GroupFormProps) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
@@ -427,6 +527,9 @@ function SettingsGroupForm({ flow, group, onSubmit }: GroupFormProps) {
   // Remove reuses the normal submit path).
   if (group === "passkey") {
     return <PasskeySettingsCard flow={flow} onSubmit={onSubmit} />;
+  }
+  if (group === "webauthn") {
+    return <WebauthnSettingsCard flow={flow} onSubmit={onSubmit} />;
   }
 
   const submit = async (values: Record<string, unknown>) => {

--- a/panel-ui/src/webauthn.test.ts
+++ b/panel-ui/src/webauthn.test.ts
@@ -8,10 +8,37 @@ import {
   bufferEncode,
   flowHasPasskeyEnrol,
   flowHasPasskeyLogin,
+  flowHasWebauthn2faLogin,
+  flowHasWebauthnEnrol,
   passkeyEnrolFields,
   passkeyLoginFields,
+  webauthn2faLoginFields,
+  webauthnEnrolFields,
 } from "./webauthn";
 import type { KratosFlow } from "./kratos";
+
+// A flow with a single input node (name/value) in the given group. Used to build
+// the webauthn 2FA trigger-node flows (options live in the *_trigger value).
+function nodeFlow(group: string, name: string, value: string, type = "hidden"): KratosFlow {
+  return {
+    id: "n1",
+    type: "browser",
+    expires_at: "",
+    issued_at: "",
+    request_url: "",
+    ui: {
+      action: "/self-service/x?flow=n1",
+      method: "POST",
+      nodes: [
+        {
+          type: "input",
+          group,
+          attributes: { name, type: type as never, value },
+        },
+      ],
+    },
+  };
+}
 
 function u8(...bytes: number[]): ArrayBuffer {
   return new Uint8Array(bytes).buffer;
@@ -217,5 +244,72 @@ describe("passkeyEnrolFields", () => {
     const flow = enrolFlow({ publicKey: {} });
     flow.ui.nodes = [];
     expect(await passkeyEnrolFields(flow)).toBeNull();
+  });
+});
+
+describe("webauthn 2FA (security keys, AAL2)", () => {
+  it("detects the login trigger and enrol trigger nodes", () => {
+    const login = nodeFlow("webauthn", "webauthn_login_trigger", JSON.stringify({ publicKey: { challenge: "AQID" } }), "button");
+    expect(flowHasWebauthn2faLogin(login)).toBe(true);
+    expect(flowHasWebauthnEnrol(login)).toBe(false);
+    const enrol = nodeFlow("webauthn", "webauthn_register_trigger", JSON.stringify({ publicKey: { user: { id: "AQID" }, challenge: "AQID" } }), "button");
+    expect(flowHasWebauthnEnrol(enrol)).toBe(true);
+    expect(flowHasWebauthn2faLogin(enrol)).toBe(false);
+  });
+
+  it("runs the assertion from webauthn_login_trigger and returns webauthn_login", async () => {
+    const get = vi.fn().mockResolvedValue({
+      id: "wk",
+      type: "public-key",
+      rawId: u8(1),
+      response: {
+        authenticatorData: u8(2),
+        clientDataJSON: u8(3),
+        signature: u8(4),
+        userHandle: null,
+      },
+    });
+    vi.stubGlobal("navigator", { credentials: { get, create: vi.fn() } });
+
+    const flow = nodeFlow(
+      "webauthn",
+      "webauthn_login_trigger",
+      JSON.stringify({ publicKey: { challenge: "AQID", allowCredentials: [{ id: "AQID", type: "public-key" }] } }),
+      "button",
+    );
+    const out = await webauthn2faLoginFields(flow);
+    expect(out).not.toBeNull();
+    // allowCredentials id must be decoded before get.
+    expect(Array.from(new Uint8Array(get.mock.calls[0][0].publicKey.allowCredentials[0].id))).toEqual([1, 2, 3]);
+    const body = JSON.parse(out!.webauthn_login);
+    expect(body.id).toBe("wk");
+    expect(body.response.signature).toBe(bufferEncode(u8(4)));
+    expect(body.response.userHandle).toBe(""); // null → empty
+    expect(await webauthn2faLoginFields(nodeFlow("webauthn", "other", "{}"))).toBeNull();
+  });
+
+  it("runs registration and carries the display name", async () => {
+    const create = vi.fn().mockResolvedValue({
+      id: "wk-new",
+      type: "public-key",
+      rawId: u8(9),
+      response: { attestationObject: u8(1), clientDataJSON: u8(2) },
+    });
+    vi.stubGlobal("navigator", { credentials: { get: vi.fn(), create } });
+
+    const flow = nodeFlow(
+      "webauthn",
+      "webauthn_register_trigger",
+      JSON.stringify({ publicKey: { user: { id: "AQID", name: "a", displayName: "a" }, challenge: "BAUG" } }),
+      "button",
+    );
+    const out = await webauthnEnrolFields(flow, "YubiKey 5C");
+    expect(out).not.toBeNull();
+    expect(out!.webauthn_register_displayname).toBe("YubiKey 5C");
+    expect(Array.from(new Uint8Array(create.mock.calls[0][0].publicKey.challenge))).toEqual([4, 5, 6]);
+    const body = JSON.parse(out!.webauthn_register);
+    expect(body.id).toBe("wk-new");
+    expect(body.response.attestationObject).toBe(bufferEncode(u8(1)));
+    expect(await webauthnEnrolFields(nodeFlow("webauthn", "other", "{}"), "x")).toBeNull();
   });
 });

--- a/panel-ui/src/webauthn.ts
+++ b/panel-ui/src/webauthn.ts
@@ -1,4 +1,5 @@
-// webauthn.ts — GH #917: passkey (passwordless WebAuthn) ceremony for the SPA.
+// webauthn.ts — GH #917: passkey (passwordless AAL1) and WebAuthn security-key
+// (second-factor AAL2) ceremonies for the SPA.
 //
 // Kratos ships a browser helper (/.well-known/ory/webauthn.js) that runs the
 // WebAuthn ceremony and submits a hidden HTML form. Our SPA renders its own
@@ -9,11 +10,14 @@
 //
 // The encode/decode + result JSON shape below MIRROR Kratos's own webauthn.js
 // byte-for-byte (verified against the deployed v26.2.0 script): base64url
-// WITHOUT padding, and the exact field names Kratos's passkey strategy reads
-// (`passkey_challenge` / `passkey_login` for login, `passkey_create_data` /
-// `passkey_settings_register` for settings enrolment). Getting this wrong
-// silently breaks authentication, so it is kept deliberately faithful and is
-// covered by webauthn.test.ts.
+// WITHOUT padding, and the exact field names Kratos's strategies read.
+//   passkey  (AAL1): passkey_challenge / passkey_login (login),
+//                    passkey_create_data / passkey_settings_register (enrol).
+//   webauthn (AAL2): webauthn_login_trigger / webauthn_login (login),
+//                    webauthn_register_trigger / webauthn_register
+//                    (+ webauthn_register_displayname) (enrol).
+// Getting this wrong silently breaks authentication, so it is kept deliberately
+// faithful and is covered by webauthn.test.ts.
 import type { KratosFlow } from "./kratos";
 
 // base64url (no padding) → bytes. Mirrors __oryWebAuthnBufferDecode. Returns a
@@ -45,7 +49,8 @@ export function webauthnSupported(): boolean {
   return typeof window !== "undefined" && !!window.PublicKeyCredential;
 }
 
-// Read a Kratos node's input value by field name.
+// Read a Kratos node's input value by field name (works for hidden inputs and
+// the button-typed *_trigger nodes, whose `value` carries the options JSON).
 function nodeValue(flow: KratosFlow, name: string): string | undefined {
   for (const node of flow.ui.nodes) {
     if (node.type === "input" && node.attributes.name === name) {
@@ -56,22 +61,12 @@ function nodeValue(flow: KratosFlow, name: string): string | undefined {
   return undefined;
 }
 
-// A login flow offers passkey when Kratos injected the discoverable-login
-// challenge node; a settings flow offers enrolment via passkey_create_data.
-export function flowHasPasskeyLogin(flow: KratosFlow): boolean {
-  return nodeValue(flow, "passkey_challenge") !== undefined;
-}
-export function flowHasPasskeyEnrol(flow: KratosFlow): boolean {
-  return nodeValue(flow, "passkey_create_data") !== undefined;
-}
-
 // Kratos serialises the WebAuthn options as { publicKey: { challenge, ... } }
 // with base64url-encoded binary fields. We decode the binary fields the
 // authenticator needs as ArrayBuffers before calling navigator.credentials.
 type PublicKeyOptions = {
   publicKey: PublicKeyCredentialRequestOptions &
     PublicKeyCredentialCreationOptions & {
-      // Kratos ships these as base64url strings; we rewrite them to BufferSource.
       challenge: unknown;
       allowCredentials?: Array<{ id: unknown; type: string; transports?: string[] }>;
       excludeCredentials?: Array<{ id: unknown; type: string; transports?: string[] }>;
@@ -83,30 +78,21 @@ function decodeId<T extends { id: unknown }>(c: T): T {
   return { ...c, id: bufferDecode(String(c.id)) };
 }
 
-// passkeyLoginFields runs the discoverable-login ceremony and returns the
-// credential field to POST. `identifier` is empty: passkey login is
-// discoverable — the authenticator supplies the user handle, so the user
-// doesn't type a username. Returns null when the flow carries no passkey
-// challenge. Throws when the ceremony fails (no authenticator, user cancel).
-export async function passkeyLoginFields(
-  flow: KratosFlow,
-): Promise<{ passkey_login: string; identifier: string } | null> {
-  const raw = nodeValue(flow, "passkey_challenge");
-  if (raw === undefined) return null;
-
-  const opt = JSON.parse(raw) as PublicKeyOptions;
+// runGetCeremony: shared assertion (login) ceremony. Decodes the challenge +
+// allowCredentials, calls navigator.credentials.get, and encodes the assertion
+// into the exact JSON string Kratos's *_login fields expect.
+async function runGetCeremony(rawOptions: string): Promise<string> {
+  const opt = JSON.parse(rawOptions) as PublicKeyOptions;
   opt.publicKey.challenge = bufferDecode(String(opt.publicKey.challenge)) as BufferSource;
   if (opt.publicKey.allowCredentials) {
     opt.publicKey.allowCredentials = opt.publicKey.allowCredentials.map(decodeId);
   }
-
   const credential = (await navigator.credentials.get({
     publicKey: opt.publicKey as PublicKeyCredentialRequestOptions,
   })) as PublicKeyCredential | null;
-  if (!credential) throw new Error("No passkey credential was returned");
-
+  if (!credential) throw new Error("No credential was returned");
   const response = credential.response as AuthenticatorAssertionResponse;
-  const passkey_login = JSON.stringify({
+  return JSON.stringify({
     id: credential.id,
     rawId: bufferEncode(credential.rawId),
     type: credential.type,
@@ -117,22 +103,13 @@ export async function passkeyLoginFields(
       userHandle: bufferEncode(response.userHandle),
     },
   });
-  return { passkey_login, identifier: "" };
 }
 
-// passkeyEnrolFields runs the registration ceremony against the settings
-// flow's passkey_create_data and returns the field to POST. Kratos has
-// already set user.name/displayName from the identity's display-name trait
-// (the username, per the identity schema), so no display-name input is
-// needed. Returns null when the flow carries no create data. Throws on
-// ceremony failure.
-export async function passkeyEnrolFields(
-  flow: KratosFlow,
-): Promise<{ passkey_settings_register: string } | null> {
-  const raw = nodeValue(flow, "passkey_create_data");
-  if (raw === undefined) return null;
-
-  const opt = JSON.parse(raw) as PublicKeyOptions;
+// runCreateCeremony: shared attestation (registration) ceremony. Decodes
+// user.id + challenge + excludeCredentials, calls navigator.credentials.create,
+// and encodes the attestation into the JSON Kratos's *_register fields expect.
+async function runCreateCeremony(rawOptions: string): Promise<string> {
+  const opt = JSON.parse(rawOptions) as PublicKeyOptions;
   if (opt.publicKey.user) {
     opt.publicKey.user = { ...opt.publicKey.user, id: bufferDecode(String(opt.publicKey.user.id)) };
   }
@@ -140,14 +117,12 @@ export async function passkeyEnrolFields(
   if (opt.publicKey.excludeCredentials) {
     opt.publicKey.excludeCredentials = opt.publicKey.excludeCredentials.map(decodeId);
   }
-
   const credential = (await navigator.credentials.create({
     publicKey: opt.publicKey as PublicKeyCredentialCreationOptions,
   })) as PublicKeyCredential | null;
-  if (!credential) throw new Error("No passkey credential was created");
-
+  if (!credential) throw new Error("No credential was created");
   const response = credential.response as AuthenticatorAttestationResponse;
-  const passkey_settings_register = JSON.stringify({
+  return JSON.stringify({
     id: credential.id,
     rawId: bufferEncode(credential.rawId),
     type: credential.type,
@@ -156,5 +131,79 @@ export async function passkeyEnrolFields(
       clientDataJSON: bufferEncode(response.clientDataJSON),
     },
   });
-  return { passkey_settings_register };
+}
+
+// ---------------------------------------------------------------------------
+// passkey (passwordless, AAL1)
+// ---------------------------------------------------------------------------
+
+export function flowHasPasskeyLogin(flow: KratosFlow): boolean {
+  return nodeValue(flow, "passkey_challenge") !== undefined;
+}
+export function flowHasPasskeyEnrol(flow: KratosFlow): boolean {
+  return nodeValue(flow, "passkey_create_data") !== undefined;
+}
+
+// passkeyLoginFields runs the discoverable-login ceremony. `identifier` is empty:
+// passkey login is discoverable — the authenticator supplies the user handle, so
+// the user doesn't type a username. Returns null when the flow carries no passkey
+// challenge. Throws when the ceremony fails (no authenticator, user cancel).
+export async function passkeyLoginFields(
+  flow: KratosFlow,
+): Promise<{ passkey_login: string; identifier: string } | null> {
+  const raw = nodeValue(flow, "passkey_challenge");
+  if (raw === undefined) return null;
+  return { passkey_login: await runGetCeremony(raw), identifier: "" };
+}
+
+// passkeyEnrolFields runs registration against the settings flow's
+// passkey_create_data. Kratos has already set user.name/displayName from the
+// identity's display-name trait, so no display-name input is needed. Returns
+// null when the flow carries no create data. Throws on ceremony failure.
+export async function passkeyEnrolFields(
+  flow: KratosFlow,
+): Promise<{ passkey_settings_register: string } | null> {
+  const raw = nodeValue(flow, "passkey_create_data");
+  if (raw === undefined) return null;
+  return { passkey_settings_register: await runCreateCeremony(raw) };
+}
+
+// ---------------------------------------------------------------------------
+// webauthn (security key as a SECOND factor, AAL2)
+// ---------------------------------------------------------------------------
+
+export function flowHasWebauthn2faLogin(flow: KratosFlow): boolean {
+  return nodeValue(flow, "webauthn_login_trigger") !== undefined;
+}
+export function flowHasWebauthnEnrol(flow: KratosFlow): boolean {
+  return nodeValue(flow, "webauthn_register_trigger") !== undefined;
+}
+
+// webauthn2faLoginFields runs the AAL2 security-key assertion. The options live
+// in the webauthn_login_trigger node's value (Kratos's own webauthn.js reads it
+// the same way). No identifier — the user is already known from the AAL1 session.
+// Returns null when the flow carries no webauthn login trigger; throws on failure.
+export async function webauthn2faLoginFields(
+  flow: KratosFlow,
+): Promise<{ webauthn_login: string } | null> {
+  const raw = nodeValue(flow, "webauthn_login_trigger");
+  if (raw === undefined) return null;
+  return { webauthn_login: await runGetCeremony(raw) };
+}
+
+// webauthnEnrolFields runs security-key registration. The create options live in
+// the webauthn_register_trigger node's value; the user-chosen friendly name is
+// submitted alongside as webauthn_register_displayname (Kratos stores it as the
+// credential's label). Returns null when the flow carries no register trigger;
+// throws on ceremony failure.
+export async function webauthnEnrolFields(
+  flow: KratosFlow,
+  displayName: string,
+): Promise<{ webauthn_register: string; webauthn_register_displayname: string } | null> {
+  const raw = nodeValue(flow, "webauthn_register_trigger");
+  if (raw === undefined) return null;
+  return {
+    webauthn_register: await runCreateCeremony(raw),
+    webauthn_register_displayname: displayName,
+  };
 }


### PR DESCRIPTION
Follow-up to #947 (passwordless passkeys). Adds **WebAuthn security keys as a second factor** (AAL2): after the password, an identity with a registered key confirms sign-in with it (YubiKey, Touch ID/Windows Hello as 2FA, etc.).

## How
- `install/kratos.yml.tmpl` — enable `selfservice.methods.webauthn` with `passwordless: false` (credentials become MFA, not first-factor); same RP as passkey.
- `install/kratos-identity-schema.json` — re-add `webauthn.identifier` on the `username` trait.
- `panel-ui/src/webauthn.ts` — refactor the get()/create() ceremonies into shared helpers; add `webauthn2faLoginFields` + `webauthnEnrolFields`. Field names match Kratos's own `webauthn.js` (`webauthn_login_trigger`→`webauthn_login`; `webauthn_register_trigger`+`webauthn_register_displayname`→`webauthn_register`).
- `Login.tsx` — AAL2 "Use your security key" button. passkey + webauthn are button-triggered ceremonies, so `pickActiveGroup` no longer renders them as input forms, and a ceremony-only step no longer shows a spurious "no credential method" warning.
- `MyProfile.tsx` — security-key enrolment card (name it, add via the create ceremony, remove via the normal submit).

## Testing
- `webauthn.test.ts` pins the 2FA login + enrol field shapes (shared-ceremony refactor covered).
- `Login.test.tsx` covers the security-key button + method=webauthn submit + no spurious warning; `MyProfile.test.tsx` covers the enrolment card.
- Config validated against the real Kratos v26.2.0 binary on the test host.

## Test plan
- [ ] CI green
- [ ] Deploy; Kratos restarts clean; settings offers security-key enrol; AAL2 login offers the button
- [ ] Live: register a security key (software authenticator), then password + security-key login (AAL2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)