### PR TITLE
fix(auth): forward the identifier on AAL2 webauthn (security-key) login

### DIFF
--- a/panel-ui/src/pages/Login.test.tsx
+++ b/panel-ui/src/pages/Login.test.tsx
@@ -204,6 +204,11 @@ describe("LoginPage", () => {
       f.ui.nodes[0], // csrf
       {
         type: "input",
+        group: "default",
+        attributes: { name: "identifier", type: "hidden", value: "alice" },
+      },
+      {
+        type: "input",
         group: "webauthn",
         attributes: {
           name: "webauthn_login_trigger",
@@ -248,6 +253,7 @@ describe("LoginPage", () => {
     await waitFor(() => expect(submit).toHaveBeenCalled());
     const body = submit.mock.calls[0][1] as Record<string, string>;
     expect(body.method).toBe("webauthn");
+    expect(body.identifier).toBe("alice"); // AAL2 flow requires the identifier
     expect(JSON.parse(body.webauthn_login).id).toBe("wk");
   });
 

--- a/panel-ui/src/webauthn.test.ts
+++ b/panel-ui/src/webauthn.test.ts
@@ -277,8 +277,16 @@ describe("webauthn 2FA (security keys, AAL2)", () => {
       JSON.stringify({ publicKey: { challenge: "AQID", allowCredentials: [{ id: "AQID", type: "public-key" }] } }),
       "button",
     );
+    // The AAL2 flow always carries the identifier node (pre-filled username);
+    // Kratos rejects the submit without it ("Property identifier is missing").
+    flow.ui.nodes.push({
+      type: "input",
+      group: "default",
+      attributes: { name: "identifier", type: "hidden", value: "alice" },
+    });
     const out = await webauthn2faLoginFields(flow);
     expect(out).not.toBeNull();
+    expect(out!.identifier).toBe("alice"); // must forward the identifier
     // allowCredentials id must be decoded before get.
     expect(Array.from(new Uint8Array(get.mock.calls[0][0].publicKey.allowCredentials[0].id))).toEqual([1, 2, 3]);
     const body = JSON.parse(out!.webauthn_login);

--- a/panel-ui/src/webauthn.ts
+++ b/panel-ui/src/webauthn.ts
@@ -181,14 +181,19 @@ export function flowHasWebauthnEnrol(flow: KratosFlow): boolean {
 
 // webauthn2faLoginFields runs the AAL2 security-key assertion. The options live
 // in the webauthn_login_trigger node's value (Kratos's own webauthn.js reads it
-// the same way). No identifier — the user is already known from the AAL1 session.
+// the same way). The AAL2 login flow ALSO requires the `identifier` field —
+// Kratos's webauthn.js submits the whole form, which carries the pre-filled
+// identifier node; omitting it fails with "Property identifier is missing".
 // Returns null when the flow carries no webauthn login trigger; throws on failure.
 export async function webauthn2faLoginFields(
   flow: KratosFlow,
-): Promise<{ webauthn_login: string } | null> {
+): Promise<{ webauthn_login: string; identifier: string } | null> {
   const raw = nodeValue(flow, "webauthn_login_trigger");
   if (raw === undefined) return null;
-  return { webauthn_login: await runGetCeremony(raw) };
+  return {
+    webauthn_login: await runGetCeremony(raw),
+    identifier: nodeValue(flow, "identifier") ?? "",
+  };
 }
 
 // webauthnEnrolFields runs security-key registration. The create options live in


### PR DESCRIPTION
Follow-up fix to #948. The AAL2 security-key login flow **requires the `identifier` field** submitted with `webauthn_login` (Kratos's own webauthn.js submits the whole form, which carries the pre-filled identifier node). `webauthn2faLoginFields` omitted it, so Kratos rejected the assertion with *"Property identifier is missing"* and bounced the flow back to `choose_method` — 2FA login was impossible.

Fix: forward the flow's `identifier` node value.

**Caught by a full software-authenticator round-trip against live Kratos** (register a security key → password login → AAL2 step-up): before, the assertion was rejected; after, the session upgrades to `AAL=aal2` with methods `[password, webauthn]`. Passkey (AAL1 discoverable) already sent an empty identifier and was unaffected.

Unit tests updated to assert the identifier is forwarded (webauthn.test.ts + Login.test.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)