### PR TITLE
fix(apps): delete the files an app actually installed, not a hardcoded list (GH #946)

### DIFF
--- a/panel-agent/internal/commands/app_dispatch.go
+++ b/panel-agent/internal/commands/app_dispatch.go
@@ -96,12 +96,60 @@ func dispatchByAppType(table map[string]Handler, op string, ctx context.Context,
 	return h(ctx, params)
 }
 
+// appInstallHandler records what the install actually laid down (GH #946).
+//
+// The diff is taken around the per-app installer rather than from a static list,
+// because only the filesystem knows what upstream's tree contains today. On
+// delete this is what lets the cleanup remove exactly our files and nothing
+// else.
 func appInstallHandler(ctx context.Context, params json.RawMessage) (any, error) {
-	return dispatchByAppType(appInstallers, "install", ctx, params)
+	p := parseAppDispatchPaths(params)
+	root := p.installRoot()
+	before := topLevelEntries(root)
+
+	res, err := dispatchByAppType(appInstallers, "install", ctx, params)
+	if err != nil {
+		// A failed install may still have written files, but recording them as
+		// "the install" would be a lie, and the panel tears down a failed
+		// install by its own path. Leave no manifest.
+		return res, err
+	}
+
+	if root != "" {
+		var created []string
+		for name := range topLevelEntries(root) {
+			if !before[name] {
+				created = append(created, name)
+			}
+		}
+		writeAppManifest(root, p.AppType, created)
+	}
+	return res, nil
 }
 
+// appDeleteHandler sweeps the recorded entries before handing off to the
+// per-app deleter (GH #946).
+//
+// Sweep first, dispatch second: the per-app handlers finish by restoring the
+// default index page and dropping the nginx rewrite, and those must survive.
+// Running them last means a file the sweep removed can be legitimately put back.
+//
+// The per-app deleter still runs in full. It is the fallback for installs made
+// before manifests existed, and it owns the parts of teardown that are not file
+// removal.
 func appDeleteHandler(ctx context.Context, params json.RawMessage) (any, error) {
-	return dispatchByAppType(appDeleters, "delete", ctx, params)
+	p := parseAppDispatchPaths(params)
+	root := p.installRoot()
+
+	sweepAppManifest(ctx, p.OSUser, root)
+
+	res, err := dispatchByAppType(appDeleters, "delete", ctx, params)
+	if err != nil {
+		// Keep the manifest so a retried delete still knows what to remove.
+		return res, err
+	}
+	removeAppManifestFile(root)
+	return res, nil
 }
 
 func appCloneHandler(ctx context.Context, params json.RawMessage) (any, error) {

--- a/panel-agent/internal/commands/app_manifest.go
+++ b/panel-agent/internal/commands/app_manifest.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// app_manifest.go — GH #946.
+//
+// Deleting an app left files behind. Reported against ITFlow, but it is not an
+// ITFlow bug: thirteen app deleters remove a HARDCODED list of top-level entries
+// when the app is installed at the docroot root, e.g.
+//
+//	var itflowTopLevel = []string{".git", ".github", "admin", "api", ...}
+//
+// The list is a snapshot of what upstream's tree looked like when the deleter
+// was written. It cannot know about anything the app creates while running —
+// uploads, caches, logs, generated config — nor about directories upstream added
+// since. Every one of those survives the delete, and the operator is left
+// picking files out of public_html by hand.
+//
+// The list exists for a good reason: at the docroot root a blind `rm -rf` would
+// take a docroot that may hold other content with it. So the fix is not to
+// delete more aggressively, it is to know exactly what WE put there.
+//
+// This records the top-level entries an install actually created, by diffing the
+// install root immediately before and after the app's installer runs, and sweeps
+// them on delete. It sits in the app.install / app.delete dispatch, so all
+// thirteen apps get it without touching a single per-app handler — and the
+// per-app lists stay as the fallback for installs made before this existed.
+//
+// Keyed by install root rather than install ID: every installer already sends
+// docroot + subdirectory (the agent cannot install without them), whereas
+// install_id is plumbed per-app and not uniformly present.
+
+// appManifestDir holds one manifest per install root. Outside any docroot on
+// purpose: inside, it would itself become a file the app owns, tenant-writable
+// and liable to be swept by the very cleanup it describes.
+const appManifestDir = "/var/lib/jabali-panel/app-manifests"
+
+// appManifest is the on-disk record. Root is stored so a manifest can be read
+// back and understood without reversing the hash.
+type appManifest struct {
+	Root    string   `json:"root"`
+	AppType string   `json:"app_type,omitempty"`
+	Entries []string `json:"entries"`
+}
+
+// appDispatchPaths are the fields every app installer and deleter already
+// carries. Parsed loosely — a handler that omits one simply opts out.
+type appDispatchPaths struct {
+	AppType      string `json:"app_type"`
+	OSUser       string `json:"os_user"`
+	Docroot      string `json:"docroot"`
+	Subdirectory string `json:"subdirectory"`
+}
+
+func (p appDispatchPaths) installRoot() string {
+	if p.Docroot == "" {
+		return ""
+	}
+	sub := strings.Trim(p.Subdirectory, "/")
+	if sub == "" {
+		return filepath.Clean(p.Docroot)
+	}
+	return filepath.Join(filepath.Clean(p.Docroot), sub)
+}
+
+func parseAppDispatchPaths(params json.RawMessage) appDispatchPaths {
+	var p appDispatchPaths
+	_ = json.Unmarshal(params, &p)
+	return p
+}
+
+// manifestPathFor hashes the install root so the filename is fixed-length and
+// free of separators, whatever the docroot looks like.
+func manifestPathFor(root string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(root)))
+	return filepath.Join(appManifestDir, hex.EncodeToString(sum[:])+".json")
+}
+
+// topLevelEntries returns the names directly inside root. A missing root is not
+// an error — it means the installer is about to create it, and everything in it
+// afterwards is ours.
+func topLevelEntries(root string) map[string]bool {
+	out := map[string]bool{}
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return out
+	}
+	for _, e := range ents {
+		out[e.Name()] = true
+	}
+	return out
+}
+
+// writeAppManifest records the entries an install created.
+//
+// Best-effort: a manifest that cannot be written must never fail the install.
+// The cost of losing it is falling back to the per-app list, which is exactly
+// today's behaviour.
+func writeAppManifest(root, appType string, entries []string) {
+	if root == "" || len(entries) == 0 {
+		return
+	}
+	if err := os.MkdirAll(appManifestDir, 0o700); err != nil {
+		return
+	}
+	sort.Strings(entries)
+	b, err := json.Marshal(appManifest{Root: root, AppType: appType, Entries: entries})
+	if err != nil {
+		return
+	}
+	// Root-owned and root-only: the tenant must not be able to edit the list of
+	// paths a privileged delete will later remove.
+	_ = os.WriteFile(manifestPathFor(root), b, 0o600)
+}
+
+func readAppManifest(root string) (appManifest, bool) {
+	if root == "" {
+		return appManifest{}, false
+	}
+	b, err := os.ReadFile(manifestPathFor(root))
+	if err != nil {
+		return appManifest{}, false
+	}
+	var m appManifest
+	if json.Unmarshal(b, &m) != nil {
+		return appManifest{}, false
+	}
+	return m, len(m.Entries) > 0
+}
+
+func removeAppManifestFile(root string) {
+	if root == "" {
+		return
+	}
+	_ = os.Remove(manifestPathFor(root))
+}
+
+// safeManifestEntry rejects anything that is not a plain name directly inside
+// root.
+//
+// The manifest is written by this process from a directory listing, so entries
+// are already bare names — but this runs `rm -rf` as the tenant against whatever
+// it is handed, and a stored path that escapes the install root would be a
+// privileged delete of an arbitrary location. Cheap to check, catastrophic to
+// omit.
+func safeManifestEntry(root, name string) (string, bool) {
+	if name == "" || name == "." || name == ".." {
+		return "", false
+	}
+	if strings.ContainsRune(name, filepath.Separator) || strings.Contains(name, "\x00") {
+		return "", false
+	}
+	cleanRoot := filepath.Clean(root)
+	if cleanRoot == "" || cleanRoot == "/" {
+		return "", false
+	}
+	target := filepath.Join(cleanRoot, name)
+	if target == cleanRoot || !strings.HasPrefix(target, cleanRoot+string(filepath.Separator)) {
+		return "", false
+	}
+	return target, true
+}
+
+// sweepAppManifest removes the recorded entries that still exist.
+//
+// Runs as the tenant, like the per-app deleters, so ownership and AppArmor
+// confinement are unchanged. Returns how many entries it removed, for the log.
+func sweepAppManifest(ctx context.Context, osUser, root string) int {
+	if osUser == "" {
+		return 0
+	}
+	m, ok := readAppManifest(root)
+	if !ok {
+		return 0
+	}
+	removed := 0
+	for _, name := range m.Entries {
+		target, ok := safeManifestEntry(root, name)
+		if !ok {
+			continue
+		}
+		if _, err := os.Lstat(target); err != nil {
+			continue
+		}
+		cmd := buildSystemdRunCmd(ctx, osUser, "rm", "-rf", target)
+		if cmd.Run() == nil {
+			removed++
+		}
+	}
+	return removed
+}

--- a/panel-agent/internal/commands/app_manifest_test.go
+++ b/panel-agent/internal/commands/app_manifest_test.go
@@ -1,0 +1,154 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// GH #946: deleting an app left files behind. Reported against ITFlow, but
+// thirteen deleters share the same shape — a hardcoded list of top-level entries
+// that cannot know about anything the app created while running, or anything
+// upstream added since the list was written.
+//
+// The manifest records what an install actually laid down. These tests cover the
+// diff, and the path checks that matter because the sweep runs `rm -rf` as the
+// tenant against whatever the manifest holds.
+
+func TestInstallRoot(t *testing.T) {
+	cases := []struct {
+		name string
+		p    appDispatchPaths
+		want string
+	}{
+		{"docroot root", appDispatchPaths{Docroot: "/home/bob/public_html"}, "/home/bob/public_html"},
+		{"subdirectory", appDispatchPaths{Docroot: "/home/bob/public_html", Subdirectory: "crm"}, "/home/bob/public_html/crm"},
+		{"subdirectory with slashes", appDispatchPaths{Docroot: "/home/bob/public_html", Subdirectory: "/crm/"}, "/home/bob/public_html/crm"},
+		{"trailing slash on docroot", appDispatchPaths{Docroot: "/home/bob/public_html/"}, "/home/bob/public_html"},
+		// No docroot means the manifest opts out entirely rather than keying
+		// every app on the same empty root.
+		{"no docroot", appDispatchPaths{Subdirectory: "crm"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.installRoot(); got != tc.want {
+				t.Fatalf("installRoot() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeManifestEntry(t *testing.T) {
+	const root = "/home/bob/public_html"
+
+	// The sweep deletes as the tenant. A stored entry that escapes the install
+	// root would be a privileged delete of somewhere else on the box.
+	for _, bad := range []string{
+		"", ".", "..",
+		"../../etc/passwd",
+		"sub/dir",
+		"/etc/passwd",
+		"a\x00b",
+	} {
+		if _, ok := safeManifestEntry(root, bad); ok {
+			t.Errorf("entry %q was accepted; it must be rejected", bad)
+		}
+	}
+
+	for _, good := range []string{"admin", ".git", "config.php", "uploads"} {
+		got, ok := safeManifestEntry(root, good)
+		if !ok {
+			t.Errorf("entry %q rejected; it is a plain name inside the root", good)
+			continue
+		}
+		if want := filepath.Join(root, good); got != want {
+			t.Errorf("entry %q resolved to %q, want %q", good, got, want)
+		}
+	}
+
+	// Never operate on / even if a manifest somehow names it.
+	if _, ok := safeManifestEntry("/", "etc"); ok {
+		t.Error("root filesystem must never be a valid install root")
+	}
+}
+
+func TestManifestRoundTripRecordsOnlyWhatInstallCreated(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "public_html")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Content that was in the docroot BEFORE the install. This is the whole
+	// reason the deleters use a list instead of rm -rf, so it must survive.
+	for _, pre := range []string{"index.html", "family-photos"} {
+		if err := os.WriteFile(filepath.Join(root, pre), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := topLevelEntries(root)
+
+	// What the installer lays down, including a dotfile and a directory — the
+	// two shapes a hand-written list most often misses.
+	for _, made := range []string{"index.php", ".git", "uploads", "config.php"} {
+		if err := os.WriteFile(filepath.Join(root, made), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var created []string
+	for name := range topLevelEntries(root) {
+		if !before[name] {
+			created = append(created, name)
+		}
+	}
+	if len(created) != 4 {
+		t.Fatalf("diff found %d entries (%v), want the 4 the install created", len(created), created)
+	}
+	for _, pre := range []string{"index.html", "family-photos"} {
+		for _, c := range created {
+			if c == pre {
+				t.Errorf("pre-existing %q was recorded as part of the install", pre)
+			}
+		}
+	}
+
+	// The manifest path must not depend on anything but the root, or delete
+	// cannot find what install wrote.
+	if manifestPathFor(root) != manifestPathFor(root+"/") {
+		t.Error("manifest key is sensitive to a trailing slash; install and delete would disagree")
+	}
+	if manifestPathFor(root) == manifestPathFor(filepath.Join(dir, "other")) {
+		t.Error("different roots must not share a manifest")
+	}
+}
+
+func TestParseAppDispatchPathsToleratesPerAppShapes(t *testing.T) {
+	// Every app sends its own struct; the dispatcher reads a few common fields
+	// and must ignore the rest rather than failing the install.
+	raw := json.RawMessage(`{"app_type":"itflow","os_user":"bob","docroot":"/home/bob/public_html",
+	    "subdirectory":"","db_name":"x","admin_email":"a@b.c","version":"latest"}`)
+	p := parseAppDispatchPaths(raw)
+	if p.AppType != "itflow" || p.OSUser != "bob" || p.Docroot != "/home/bob/public_html" {
+		t.Fatalf("parsed %+v", p)
+	}
+
+	// Malformed params must not panic or produce a bogus root — the installer
+	// itself will reject them a moment later with a proper error.
+	if got := parseAppDispatchPaths(json.RawMessage(`not json`)).installRoot(); got != "" {
+		t.Fatalf("installRoot from bad params = %q, want empty", got)
+	}
+}
+
+func TestSweepIsANoOpWithoutAManifest(t *testing.T) {
+	// Installs made before manifests existed have none. The sweep must do
+	// nothing and leave the per-app deleter as the only cleanup, which is
+	// exactly today's behaviour.
+	if n := sweepAppManifest(t.Context(), "bob", t.TempDir()); n != 0 {
+		t.Fatalf("swept %d entries with no manifest present", n)
+	}
+	// No OS user means no way to run the removal as the tenant.
+	if n := sweepAppManifest(t.Context(), "", t.TempDir()); n != 0 {
+		t.Fatalf("swept %d entries without an os_user", n)
+	}
+}


### PR DESCRIPTION
Fixes #946.

## Not an ITFlow bug

Reported against ITFlow, but **thirteen app deleters share the same shape.** When the app sits at the docroot root they remove a hardcoded list of top-level entries:

```go
var itflowTopLevel = []string{".git", ".github", "admin", "api", ...}
```

That list is a snapshot of what upstream's tree looked like the day the deleter was written. It cannot know about:

- anything the app creates **while running** — uploads, caches, logs, generated config
- anything **upstream added since**

All of it survives the delete, and the operator picks files out of `public_html` by hand.

## Why not just `rm -rf`

The list exists for a good reason: at the docroot root a blind `rm -rf` takes a docroot that may hold unrelated content with it. Deleting more aggressively isn't the fix. **Knowing exactly what we put there is.**

So the install records the top-level entries it created — by diffing the install root immediately before and after the per-app installer runs — and the delete sweeps them. The filesystem is the only thing that knows what upstream ships today; a list in our source can only ever lag it.

## One change, thirteen apps

It lives in the `app.install` / `app.delete` dispatch, so every app gets it **without touching a single per-app handler**. The per-app deleters still run in full — they're the fallback for installs made before manifests existed, and they own the parts of teardown that aren't file removal.

**Sweep first, dispatch second.** The per-app handlers finish by restoring the default index page and dropping the nginx rewrite, and those must survive; running them last means anything the sweep removed can be legitimately put back.

**Keyed by install root, not install ID.** Every installer already sends `docroot` + `subdirectory` — the agent can't install without them. `install_id` is plumbed per-app and not uniformly present.

## Security

The sweep runs `rm -rf` **as the tenant**, so the manifest is a list of paths a privileged delete will act on:

- Stored outside every docroot. Inside one it would be tenant-writable *and* swept by the cleanup it describes.
- Root-owned, `0600`.
- Entries re-validated at sweep time as plain names resolving inside the install root — `..`, `sub/dir`, absolute paths and NUL are rejected, and `/` is never a valid root. Tested in both directions.

## Failure behaviour

Best-effort throughout, because a cleanup improvement must not become a new way for installs to fail:

| | |
|---|---|
| manifest unwritable | install proceeds; delete falls back to the per-app list (today's behaviour) |
| no manifest | sweep is a no-op |
| install failed | no manifest written — the panel tears those down by its own path, and recording partial files as "the install" would be a lie |
| delete failed | manifest kept, so a retry still knows what to remove |