### PR TITLE
feat(backup): tenant multi-schedule backups with an admin maintenance window (GH #454 7B)

### DIFF
--- a/internal/backup/window.go
+++ b/internal/backup/window.go
@@ -1,0 +1,190 @@
+// Package backup — tenant multi-schedule window model (GH #454 Phase 7B).
+//
+// The admin owns a maintenance WINDOW (server_settings.tenant_backup_window_*)
+// and tenants own a CADENCE per schedule. A window-governed schedule fires only
+// while the clock is inside the window, and a deterministic per-schedule offset
+// smears the firings across the window so N tenants that come due together do
+// not all hit window-open at once. This keeps the resource-planning guarantee
+// the single-slot model gave the admin while letting a tenant run several
+// differently-scoped backups.
+//
+// All arithmetic is UTC minute-of-day. Cadence is a fixed allow-list mapped to
+// an interval (never free cron), so a tenant can never choose a stampede minute.
+package backup
+
+import (
+	"hash/fnv"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Tenant backup cadences (GH #454 7B). Each maps to a fixed interval; the window
+// caps how many of those interval firings actually run per day.
+const (
+	CadenceHourly   = "hourly"
+	CadenceEvery6h  = "every_6h"
+	CadenceEvery12h = "every_12h"
+	CadenceDaily    = "daily"
+	CadenceWeekly   = "weekly"
+)
+
+// ValidCadence reports whether c is an accepted tenant cadence. The empty string
+// is NOT valid here — it is the discriminator for a legacy cron-governed
+// schedule and must never be accepted from the tenant multi-schedule surface.
+func ValidCadence(c string) bool {
+	switch c {
+	case CadenceHourly, CadenceEvery6h, CadenceEvery12h, CadenceDaily, CadenceWeekly:
+		return true
+	}
+	return false
+}
+
+// CadenceInterval maps a cadence to its firing interval. An unknown cadence
+// falls back to daily (24h) — the safest, least-frequent choice — so a bad
+// stored value can never produce a tight loop.
+func CadenceInterval(c string) time.Duration {
+	switch c {
+	case CadenceHourly:
+		return time.Hour
+	case CadenceEvery6h:
+		return 6 * time.Hour
+	case CadenceEvery12h:
+		return 12 * time.Hour
+	case CadenceWeekly:
+		return 7 * 24 * time.Hour
+	default: // daily + unknown
+		return 24 * time.Hour
+	}
+}
+
+// TenantWindow is the admin maintenance window as UTC minutes since midnight,
+// both in [0,1440). StartMin == EndMin means the window spans the whole day (no
+// gating). StartMin > EndMin is a wrap-around window (e.g. 22:00–04:00).
+type TenantWindow struct {
+	StartMin int
+	EndMin   int
+}
+
+// DefaultTenantWindow matches the migration column defaults (02:00–05:00 UTC).
+// Returned whenever a stored window value can't be parsed, so a corrupt settings
+// row degrades to a safe gated window rather than to "no window / fire anytime".
+var DefaultTenantWindow = TenantWindow{StartMin: 2 * 60, EndMin: 5 * 60}
+
+// ParseWindow builds a TenantWindow from two "HH:MM" strings. Any parse error in
+// either bound falls back to DefaultTenantWindow — never to an ungated window.
+func ParseWindow(start, end string) TenantWindow {
+	s, sok := parseHHMM(start)
+	e, eok := parseHHMM(end)
+	if !sok || !eok {
+		return DefaultTenantWindow
+	}
+	return TenantWindow{StartMin: s, EndMin: e}
+}
+
+// ValidHHMM reports whether s is a well-formed 24h "HH:MM" clock string. Used by
+// the admin settings validator to reject a bad window bound instead of silently
+// falling back to the default (which ParseWindow does at read time).
+func ValidHHMM(s string) bool {
+	_, ok := parseHHMM(s)
+	return ok
+}
+
+// parseHHMM parses "HH:MM" (24h) into minutes since midnight in [0,1440).
+func parseHHMM(s string) (int, bool) {
+	parts := strings.Split(strings.TrimSpace(s), ":")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	h, herr := strconv.Atoi(parts[0])
+	m, merr := strconv.Atoi(parts[1])
+	if herr != nil || merr != nil || h < 0 || h > 23 || m < 0 || m > 59 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+// spanMinutes is the window length. A whole-day window (start == end) is 1440.
+func (w TenantWindow) spanMinutes() int {
+	if w.StartMin == w.EndMin {
+		return 24 * 60
+	}
+	if w.EndMin > w.StartMin {
+		return w.EndMin - w.StartMin
+	}
+	return (24 * 60) - w.StartMin + w.EndMin // wrap-around
+}
+
+// Contains reports whether t's UTC minute-of-day is inside the window. The start
+// is inclusive, the end exclusive. A whole-day window contains every instant.
+func (w TenantWindow) Contains(t time.Time) bool {
+	if w.StartMin == w.EndMin {
+		return true
+	}
+	m := t.UTC().Hour()*60 + t.UTC().Minute()
+	if w.EndMin > w.StartMin {
+		return m >= w.StartMin && m < w.EndMin
+	}
+	// wrap-around: inside if at/after start OR before end
+	return m >= w.StartMin || m < w.EndMin
+}
+
+// NextOpen returns the earliest instant >= t at which the window is open. When t
+// is already inside the window it returns t unchanged (truncated to the minute).
+func (w TenantWindow) NextOpen(t time.Time) time.Time {
+	t = t.UTC().Truncate(time.Minute)
+	if w.Contains(t) {
+		return t
+	}
+	// Candidate = today's start boundary; roll forward a day until it is >= t.
+	midnight := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	open := midnight.Add(time.Duration(w.StartMin) * time.Minute)
+	for open.Before(t) {
+		open = open.Add(24 * time.Hour)
+	}
+	return open
+}
+
+// smearOffset returns a deterministic per-schedule offset in [0, capMinutes)
+// minutes, derived from the schedule ID via FNV-1a. Distinct schedule IDs get
+// distinct offsets, so schedules that come due together spread across the
+// window instead of stampeding window-open. Deterministic (not random) so a
+// schedule's smeared minute stays stable across restarts and resumes.
+func smearOffset(scheduleID string, capMinutes int) time.Duration {
+	if capMinutes <= 0 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(scheduleID))
+	return time.Duration(int(h.Sum32()%uint32(capMinutes))) * time.Minute
+}
+
+// NextTenantRun computes the next firing time (strictly after now) for a
+// window-governed tenant schedule. Rules:
+//   - one cadence interval out from now;
+//   - if that lands inside the window, keep it (interval firings inside the
+//     window preserve the schedule's smeared minute — no re-smear, no drift);
+//   - if it lands outside, jump to the next window opening and add the
+//     schedule's deterministic smear offset (bounded to the window span so it
+//     never lands past window-close).
+//
+// The smear cap is min(interval, windowSpan): capping at the interval keeps a
+// short-cadence schedule (hourly) smeared within its own hour; capping at the
+// window span keeps a long-cadence schedule spread across the whole window.
+func NextTenantRun(now time.Time, cadence string, w TenantWindow, scheduleID string) time.Time {
+	interval := CadenceInterval(cadence)
+	cand := now.UTC().Add(interval).Truncate(time.Minute)
+	if w.Contains(cand) {
+		return cand
+	}
+	open := w.NextOpen(cand)
+	capMin := int(interval / time.Minute)
+	if span := w.spanMinutes(); span < capMin {
+		capMin = span
+	}
+	smeared := open.Add(smearOffset(scheduleID, capMin))
+	if !w.Contains(smeared) {
+		return open
+	}
+	return smeared
+}

--- a/internal/backup/window_test.go
+++ b/internal/backup/window_test.go
@@ -1,0 +1,159 @@
+package backup
+
+import (
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return tm.UTC()
+}
+
+func TestParseHHMM(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"02:00", 120, true},
+		{"00:00", 0, true},
+		{"23:59", 23*60 + 59, true},
+		{" 05:30 ", 5*60 + 30, true},
+		{"24:00", 0, false},
+		{"12:60", 0, false},
+		{"noon", 0, false},
+		{"12", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseHHMM(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("parseHHMM(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestParseWindowFallsBackToDefault(t *testing.T) {
+	if w := ParseWindow("garbage", "05:00"); w != DefaultTenantWindow {
+		t.Errorf("bad start should fall back to default, got %+v", w)
+	}
+	if w := ParseWindow("02:00", ""); w != DefaultTenantWindow {
+		t.Errorf("bad end should fall back to default, got %+v", w)
+	}
+	if w := ParseWindow("01:15", "06:45"); w.StartMin != 75 || w.EndMin != 405 {
+		t.Errorf("good values should parse, got %+v", w)
+	}
+}
+
+func TestWindowContains(t *testing.T) {
+	w := TenantWindow{StartMin: 120, EndMin: 300} // 02:00–05:00
+	if !w.Contains(mustTime(t, "2026-08-05T02:00:00Z")) {
+		t.Error("start is inclusive")
+	}
+	if !w.Contains(mustTime(t, "2026-08-05T04:59:00Z")) {
+		t.Error("04:59 inside")
+	}
+	if w.Contains(mustTime(t, "2026-08-05T05:00:00Z")) {
+		t.Error("end is exclusive")
+	}
+	if w.Contains(mustTime(t, "2026-08-05T01:59:00Z")) {
+		t.Error("01:59 outside")
+	}
+}
+
+func TestWindowContainsWrapAndWholeDay(t *testing.T) {
+	wrap := TenantWindow{StartMin: 22 * 60, EndMin: 4 * 60} // 22:00–04:00
+	if !wrap.Contains(mustTime(t, "2026-08-05T23:30:00Z")) {
+		t.Error("23:30 inside wrap window")
+	}
+	if !wrap.Contains(mustTime(t, "2026-08-05T03:00:00Z")) {
+		t.Error("03:00 inside wrap window")
+	}
+	if wrap.Contains(mustTime(t, "2026-08-05T12:00:00Z")) {
+		t.Error("noon outside wrap window")
+	}
+	whole := TenantWindow{StartMin: 0, EndMin: 0}
+	if !whole.Contains(mustTime(t, "2026-08-05T13:37:00Z")) {
+		t.Error("whole-day window contains any instant")
+	}
+}
+
+func TestWindowNextOpen(t *testing.T) {
+	w := TenantWindow{StartMin: 120, EndMin: 300}
+	// Before today's window → today's open.
+	if got := w.NextOpen(mustTime(t, "2026-08-05T00:30:00Z")); !got.Equal(mustTime(t, "2026-08-05T02:00:00Z")) {
+		t.Errorf("before window: got %s", got)
+	}
+	// After today's window → tomorrow's open.
+	if got := w.NextOpen(mustTime(t, "2026-08-05T09:00:00Z")); !got.Equal(mustTime(t, "2026-08-06T02:00:00Z")) {
+		t.Errorf("after window: got %s", got)
+	}
+	// Inside window → unchanged (to the minute).
+	if got := w.NextOpen(mustTime(t, "2026-08-05T03:15:30Z")); !got.Equal(mustTime(t, "2026-08-05T03:15:00Z")) {
+		t.Errorf("inside window: got %s", got)
+	}
+}
+
+func TestValidCadenceAndInterval(t *testing.T) {
+	for _, c := range []string{CadenceHourly, CadenceEvery6h, CadenceEvery12h, CadenceDaily, CadenceWeekly} {
+		if !ValidCadence(c) {
+			t.Errorf("%q should be valid", c)
+		}
+	}
+	// Empty is the legacy-cron discriminator and must NOT be a valid tenant cadence.
+	if ValidCadence("") || ValidCadence("monthly") {
+		t.Error("empty/unknown cadence must be invalid")
+	}
+	if CadenceInterval(CadenceHourly) != time.Hour {
+		t.Error("hourly interval")
+	}
+	if CadenceInterval("nonsense") != 24*time.Hour {
+		t.Error("unknown cadence must fall back to daily/24h")
+	}
+}
+
+func TestNextTenantRunInWindowKeepsInterval(t *testing.T) {
+	w := TenantWindow{StartMin: 120, EndMin: 300} // 02:00–05:00
+	// Fired at 02:12 inside the window; hourly → 03:12, still inside → no re-smear.
+	got := NextTenantRun(mustTime(t, "2026-08-05T02:12:00Z"), CadenceHourly, w, "sched-A")
+	if !got.Equal(mustTime(t, "2026-08-05T03:12:00Z")) {
+		t.Errorf("hourly in-window should be +1h same minute, got %s", got)
+	}
+}
+
+func TestNextTenantRunOutOfWindowJumpsToOpenPlusSmear(t *testing.T) {
+	w := TenantWindow{StartMin: 120, EndMin: 300}
+	// Fired at 04:30 → +1h = 05:30 outside → next open tomorrow 02:00 + smear.
+	got := NextTenantRun(mustTime(t, "2026-08-05T04:30:00Z"), CadenceHourly, w, "sched-A")
+	open := mustTime(t, "2026-08-06T02:00:00Z")
+	if got.Before(open) || !w.Contains(got) {
+		t.Errorf("out-of-window fire must land in the next window, got %s", got)
+	}
+	if got.Sub(open) >= time.Hour {
+		t.Errorf("hourly smear must be < 1h into the window, got +%s", got.Sub(open))
+	}
+}
+
+func TestNextTenantRunSmearIsDeterministicAndPerSchedule(t *testing.T) {
+	w := TenantWindow{StartMin: 120, EndMin: 300}
+	now := mustTime(t, "2026-08-05T09:00:00Z") // well outside window
+	a1 := NextTenantRun(now, CadenceDaily, w, "sched-A")
+	a2 := NextTenantRun(now, CadenceDaily, w, "sched-A")
+	b := NextTenantRun(now, CadenceDaily, w, "sched-B")
+	if !a1.Equal(a2) {
+		t.Errorf("same schedule id must be deterministic: %s vs %s", a1, a2)
+	}
+	if !w.Contains(a1) || !w.Contains(b) {
+		t.Errorf("daily fires must land in the window: A=%s B=%s", a1, b)
+	}
+	// Different ids almost certainly get different smeared minutes across a
+	// 180-minute window; assert they are not identical (guards the per-schedule
+	// spreading that prevents a stampede).
+	if a1.Equal(b) {
+		t.Errorf("distinct schedule ids should smear to distinct minutes, both %s", a1)
+	}
+}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1288,6 +1288,14 @@ func RegisterMeBackupRoutes(rg *gin.RouterGroup, cfg MeBackupsHandlerConfig) {
 	if cfg.Schedules != nil && cfg.Settings != nil {
 		rg.GET("/me/backup-schedule", h.getSchedule)
 		rg.PUT("/me/backup-schedule", h.putSchedule)
+		// GH #454 7B: tenant multi-schedule surface (window-governed). Owner-
+		// scoped CRUD — every mutation re-verifies row.user_id == the session
+		// user, 404 on mismatch (no cross-tenant leak). Cap enforced from the
+		// hosting package's max_backup_schedules.
+		rg.GET("/me/backup-schedules", h.listSchedules)
+		rg.POST("/me/backup-schedules", h.createSchedule)
+		rg.PUT("/me/backup-schedules/:id", h.updateSchedule)
+		rg.DELETE("/me/backup-schedules/:id", h.deleteSchedule)
 	}
 }
 
@@ -1887,6 +1895,315 @@ func (h *meBackupHandler) putSchedule(c *gin.Context) {
 	}
 	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), sched.ID, dests); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// ---- GH #454 7B: tenant multi-schedule surface (window-governed) ----
+
+// meScheduleRow is one tenant-owned schedule in the multi-schedule list. The
+// firing times are read-only (the scheduler owns them); the tenant edits
+// content/cadence/destination/retention/on-off.
+type meScheduleRow struct {
+	ID            string  `json:"id"`
+	Enabled       bool    `json:"enabled"`
+	Content       string  `json:"content"`
+	Cadence       string  `json:"cadence"`
+	DestinationID string  `json:"destination_id,omitempty"`
+	KeepDaily     *int    `json:"keep_daily,omitempty"`
+	KeepWeekly    *int    `json:"keep_weekly,omitempty"`
+	KeepMonthly   *int    `json:"keep_monthly,omitempty"`
+	NextRunAt     *string `json:"next_run_at,omitempty"`
+	LastRunAt     *string `json:"last_run_at,omitempty"`
+}
+
+// meSchedulesView is the multi-schedule list payload: the tenant's own rows plus
+// the read-only caps + admin window the UI renders around them.
+type meSchedulesView struct {
+	Schedules               []meScheduleRow `json:"schedules"`
+	MaxBackupSchedules      int             `json:"max_backup_schedules"`
+	MaxBackups              uint32          `json:"max_backups"`
+	ScheduledBackupsEnabled bool            `json:"scheduled_backups_enabled"`
+	MultiEnabled            bool            `json:"multi_enabled"`
+	WindowStart             string          `json:"window_start"`
+	WindowEnd               string          `json:"window_end"`
+}
+
+// meScheduleUpsertRequest is the tenant-editable multi-schedule payload. Cadence
+// is a fixed allow-list (NOT free cron) so a tenant can never pick a stampede
+// minute; the admin owns the window the cadence fires inside.
+type meScheduleUpsertRequest struct {
+	Enabled       bool   `json:"enabled"`
+	Content       string `json:"content"`
+	Cadence       string `json:"cadence"`
+	DestinationID string `json:"destination_id"`
+	KeepDaily     *int   `json:"keep_daily"`
+	KeepWeekly    *int   `json:"keep_weekly"`
+	KeepMonthly   *int   `json:"keep_monthly"`
+}
+
+// ownedTenantSchedules returns the caller's OWN account_backup schedules.
+// ListForUser filters by the user_id column, which tenant-owned schedules always
+// set (admin fan-out schedules leave it NULL), so this can never surface another
+// tenant's or an admin's schedule.
+func (h *meBackupHandler) ownedTenantSchedules(ctx context.Context, userID string) []models.BackupSchedule {
+	rows, err := h.cfg.Schedules.ListForUser(ctx, userID)
+	if err != nil {
+		return nil
+	}
+	out := rows[:0]
+	for i := range rows {
+		if rows[i].Kind == models.BackupScheduleKindAccount {
+			out = append(out, rows[i])
+		}
+	}
+	return out
+}
+
+// findOwnedSchedule resolves one schedule by id, but only if it belongs to the
+// caller (kind=account_backup AND user_id == caller). Returns nil otherwise so
+// every caller can 404 without leaking whether the id exists for another tenant.
+func (h *meBackupHandler) findOwnedSchedule(ctx context.Context, userID, id string) *models.BackupSchedule {
+	s, err := h.cfg.Schedules.Get(ctx, id)
+	if err != nil || s == nil {
+		return nil
+	}
+	if s.Kind != models.BackupScheduleKindAccount || s.UserID == nil || *s.UserID != userID {
+		return nil
+	}
+	return s
+}
+
+func (h *meBackupHandler) tenantWindow(ctx context.Context) internalbackup.TenantWindow {
+	settings, err := h.cfg.Settings.Get(ctx)
+	if err != nil || settings == nil {
+		return internalbackup.DefaultTenantWindow
+	}
+	return internalbackup.ParseWindow(settings.TenantBackupWindowStart, settings.TenantBackupWindowEnd)
+}
+
+func (h *meBackupHandler) listSchedules(c *gin.Context) {
+	user, pkg, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	settings, serr := h.cfg.Settings.Get(c.Request.Context())
+	if serr != nil || settings == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "settings_unavailable"})
+		return
+	}
+	view := meSchedulesView{
+		Schedules:          []meScheduleRow{},
+		MaxBackupSchedules: 1,
+		WindowStart:        settings.TenantBackupWindowStart,
+		WindowEnd:          settings.TenantBackupWindowEnd,
+	}
+	if pkg != nil {
+		view.ScheduledBackupsEnabled = pkg.BackupsEnabled() && pkg.ScheduledBackupsEnabled
+		view.MaxBackups = pkg.MaxBackups
+		view.MaxBackupSchedules = pkg.MaxBackupSchedulesOrDefault()
+		view.MultiEnabled = pkg.TenantMultiScheduleEnabled()
+	}
+	for _, s := range h.ownedTenantSchedules(c.Request.Context(), user.ID) {
+		row := meScheduleRow{
+			ID:          s.ID,
+			Enabled:     s.Enabled,
+			Content:     models.NormalizeBackupContent(s.Content),
+			Cadence:     s.Cadence,
+			KeepDaily:   s.KeepDaily,
+			KeepWeekly:  s.KeepWeekly,
+			KeepMonthly: s.KeepMonthly,
+		}
+		if s.NextRunAt != nil {
+			v := s.NextRunAt.Format(time.RFC3339)
+			row.NextRunAt = &v
+		}
+		if s.LastRunAt != nil {
+			v := s.LastRunAt.Format(time.RFC3339)
+			row.LastRunAt = &v
+		}
+		if dests, derr := h.cfg.Schedules.GetDestinations(c.Request.Context(), s.ID); derr == nil && len(dests) > 0 {
+			row.DestinationID = dests[0].ID
+		}
+		view.Schedules = append(view.Schedules, row)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}
+
+// validateScheduleUpsert checks the shared body rules for create + update and,
+// on success, returns the normalized content + clamped keep_* + the destination
+// list to link. On failure it writes the error response and returns ok=false.
+func (h *meBackupHandler) validateScheduleUpsert(c *gin.Context, pkg *models.HostingPackage, req meScheduleUpsertRequest) (content string, keepDaily, keepWeekly, keepMonthly *int, dests []string, ok bool) {
+	if !internalbackup.ValidCadence(req.Cadence) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_cadence", "detail": "cadence must be hourly/every_6h/every_12h/daily/weekly"})
+		return
+	}
+	if !validBackupContent(req.Content) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_option", "detail": "content must be full/files/database/folders"})
+		return
+	}
+	content = models.NormalizeBackupContent(req.Content)
+	destID := strings.TrimSpace(req.DestinationID)
+	if destID != "" {
+		if h.cfg.Destinations == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "destination_lookup_unavailable"})
+			return
+		}
+		d, derr := h.cfg.Destinations.Get(c.Request.Context(), destID)
+		if derr != nil || d == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "unknown_destination", "detail": "no such backup destination"})
+			return
+		}
+		if !d.Enabled {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "destination_disabled", "detail": "that backup destination is disabled"})
+			return
+		}
+		if !pkg.AllowsBackupKind(d.Kind) {
+			c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "destination_not_allowed", "detail": fmt.Sprintf("your hosting plan does not allow the %q backup destination", d.Kind)})
+			return
+		}
+		dests = []string{destID}
+	}
+	if req.Enabled && destID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "destination_required", "detail": "pick a backup destination to enable a scheduled backup"})
+		return
+	}
+	maxKeep := int(pkg.MaxBackups)
+	clamp := func(v *int) *int {
+		if v == nil {
+			return nil
+		}
+		n := *v
+		if n < 0 {
+			n = 0
+		}
+		if n > maxKeep {
+			n = maxKeep
+		}
+		return &n
+	}
+	keepDaily, keepWeekly, keepMonthly = clamp(req.KeepDaily), clamp(req.KeepWeekly), clamp(req.KeepMonthly)
+	ok = true
+	return
+}
+
+func (h *meBackupHandler) createSchedule(c *gin.Context) {
+	user, pkg, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	if pkg == nil || !pkg.BackupsEnabled() || !pkg.ScheduledBackupsEnabled {
+		c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "scheduled_backups_not_enabled", "detail": "your hosting plan does not allow scheduled backups"})
+		return
+	}
+	// Cap enforcement: refuse the N+1th schedule (GH #454 7B). Counts the
+	// caller's OWN account_backup rows only.
+	existing := h.ownedTenantSchedules(c.Request.Context(), user.ID)
+	if len(existing) >= pkg.MaxBackupSchedulesOrDefault() {
+		c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "schedule_limit_reached", "detail": fmt.Sprintf("your hosting plan allows at most %d backup schedules", pkg.MaxBackupSchedulesOrDefault())})
+		return
+	}
+	var req meScheduleUpsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
+		return
+	}
+	content, keepDaily, keepWeekly, keepMonthly, dests, vok := h.validateScheduleUpsert(c, pkg, req)
+	if !vok {
+		return
+	}
+	uid := user.ID
+	id := ids.NewULID()
+	next := internalbackup.NextTenantRun(time.Now().UTC(), req.Cadence, h.tenantWindow(c.Request.Context()), id)
+	sched := &models.BackupSchedule{
+		ID:          id,
+		Kind:        models.BackupScheduleKindAccount,
+		UserID:      &uid,
+		Cadence:     req.Cadence,
+		Content:     content,
+		Enabled:     req.Enabled,
+		KeepDaily:   keepDaily,
+		KeepWeekly:  keepWeekly,
+		KeepMonthly: keepMonthly,
+		NextRunAt:   &next,
+	}
+	if err := h.cfg.Schedules.Create(c.Request.Context(), sched); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
+		return
+	}
+	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), id, []string{uid}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
+		return
+	}
+	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), id, dests); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"status": "ok", "id": id})
+}
+
+func (h *meBackupHandler) updateSchedule(c *gin.Context) {
+	user, pkg, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	if pkg == nil || !pkg.BackupsEnabled() || !pkg.ScheduledBackupsEnabled {
+		c.JSON(http.StatusForbidden, gin.H{"status": "error", "error": "scheduled_backups_not_enabled", "detail": "your hosting plan does not allow scheduled backups"})
+		return
+	}
+	id := c.Param("id")
+	sched := h.findOwnedSchedule(c.Request.Context(), user.ID, id)
+	if sched == nil {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "schedule_not_found"})
+		return
+	}
+	var req meScheduleUpsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_body", "detail": err.Error()})
+		return
+	}
+	content, keepDaily, keepWeekly, keepMonthly, dests, vok := h.validateScheduleUpsert(c, pkg, req)
+	if !vok {
+		return
+	}
+	uid := user.ID
+	next := internalbackup.NextTenantRun(time.Now().UTC(), req.Cadence, h.tenantWindow(c.Request.Context()), sched.ID)
+	sched.UserID = &uid
+	sched.Cadence = req.Cadence
+	sched.Content = content
+	sched.Enabled = req.Enabled
+	sched.KeepDaily, sched.KeepWeekly, sched.KeepMonthly = keepDaily, keepWeekly, keepMonthly
+	sched.NextRunAt = &next
+	if err := h.cfg.Schedules.Update(c.Request.Context(), sched); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_update"})
+		return
+	}
+	if err := h.cfg.Schedules.ReplaceUsers(c.Request.Context(), sched.ID, []string{uid}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_users"})
+		return
+	}
+	if err := h.cfg.Schedules.ReplaceDestinations(c.Request.Context(), sched.ID, dests); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_link_destinations"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (h *meBackupHandler) deleteSchedule(c *gin.Context) {
+	user, _, ok := h.meScheduleGate(c)
+	if !ok {
+		return
+	}
+	id := c.Param("id")
+	// Ownership check BEFORE delete: a non-owner (or admin targeting a tenant
+	// row through this path) gets 404, never a cross-tenant delete.
+	if sched := h.findOwnedSchedule(c.Request.Context(), user.ID, id); sched == nil {
+		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "schedule_not_found"})
+		return
+	}
+	if err := h.cfg.Schedules.Delete(c.Request.Context(), id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_delete"})
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/panel-api/internal/api/backups_me_schedules_test.go
+++ b/panel-api/internal/api/backups_me_schedules_test.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ---- in-memory fakes for the tenant multi-schedule handler tests (GH #454 7B) ----
+
+// schedStore is a tiny stateful BackupScheduleRepository: enough of the interface
+// for the /me/backup-schedules handlers, shared between two per-user routers so a
+// cross-tenant access attempt can be exercised against a real stored row.
+type schedStore struct {
+	repository.BackupScheduleRepository
+	rows  map[string]*models.BackupSchedule
+	dests map[string][]string
+	users map[string][]string
+}
+
+func newSchedStore() *schedStore {
+	return &schedStore{rows: map[string]*models.BackupSchedule{}, dests: map[string][]string{}, users: map[string][]string{}}
+}
+
+func (s *schedStore) Create(_ context.Context, m *models.BackupSchedule) error {
+	cp := *m
+	s.rows[m.ID] = &cp
+	return nil
+}
+func (s *schedStore) Get(_ context.Context, id string) (*models.BackupSchedule, error) {
+	if r, ok := s.rows[id]; ok {
+		return r, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (s *schedStore) ListForUser(_ context.Context, userID string) ([]models.BackupSchedule, error) {
+	var out []models.BackupSchedule
+	for _, r := range s.rows {
+		if r.UserID != nil && *r.UserID == userID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+func (s *schedStore) Update(_ context.Context, m *models.BackupSchedule) error {
+	if _, ok := s.rows[m.ID]; !ok {
+		return repository.ErrNotFound
+	}
+	cp := *m
+	s.rows[m.ID] = &cp
+	return nil
+}
+func (s *schedStore) Delete(_ context.Context, id string) error {
+	if _, ok := s.rows[id]; !ok {
+		return repository.ErrNotFound
+	}
+	delete(s.rows, id)
+	return nil
+}
+func (s *schedStore) GetDestinations(_ context.Context, id string) ([]models.BackupDestination, error) {
+	var out []models.BackupDestination
+	for _, d := range s.dests[id] {
+		out = append(out, models.BackupDestination{ID: d})
+	}
+	return out, nil
+}
+func (s *schedStore) ReplaceDestinations(_ context.Context, id string, d []string) error {
+	s.dests[id] = d
+	return nil
+}
+func (s *schedStore) ReplaceUsers(_ context.Context, id string, u []string) error {
+	s.users[id] = u
+	return nil
+}
+
+// usersMap resolves users by id so two distinct tenants can be modelled.
+type usersMap struct {
+	repository.UserRepository
+	m map[string]*models.User
+}
+
+func (u *usersMap) FindByID(_ context.Context, id string) (*models.User, error) { return u.m[id], nil }
+
+func schedTestPkg(cap uint32) *models.HostingPackage {
+	return &models.HostingPackage{
+		ID:                            "pkg1",
+		MaxBackups:                    5,
+		MaxBackupSchedules:            cap,
+		ScheduledBackupsEnabled:       true,
+		AllowedBackupDestinationKinds: "local",
+	}
+}
+
+func newSchedHandler(store *schedStore, users *usersMap, pkg *models.HostingPackage, dest *models.BackupDestination) *meBackupHandler {
+	return &meBackupHandler{cfg: MeBackupsHandlerConfig{
+		Users:        users,
+		Packages:     &fakePkgRepo{pkg: pkg},
+		Schedules:    store,
+		Settings:     &fakeSettingsRepo{s: &models.ServerSettings{ID: 1, TenantBackupWindowStart: "02:00", TenantBackupWindowEnd: "05:00"}},
+		Destinations: fakeDestRepo{dest: dest},
+	}}
+}
+
+func newSchedRouter(h *meBackupHandler, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: false})
+		c.Next()
+	})
+	r.GET("/me/backup-schedules", h.listSchedules)
+	r.POST("/me/backup-schedules", h.createSchedule)
+	r.PUT("/me/backup-schedules/:id", h.updateSchedule)
+	r.DELETE("/me/backup-schedules/:id", h.deleteSchedule)
+	return r
+}
+
+func doReq(t *testing.T, r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func pkgUser(id, pkgID string) *models.User {
+	p := pkgID
+	return &models.User{ID: id, Username: uname(id), IsAdmin: false, PackageID: &p}
+}
+
+func TestMeSchedules_CreateAndList(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(3), nil)
+	r := newSchedRouter(h, "userA")
+
+	rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"database","cadence":"hourly"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	// The stored row must be window-governed (cadence set) and owned by userA.
+	if len(store.rows) != 1 {
+		t.Fatalf("want 1 stored row, got %d", len(store.rows))
+	}
+	for _, row := range store.rows {
+		if row.Cadence != "hourly" || row.UserID == nil || *row.UserID != "userA" || row.NextRunAt == nil {
+			t.Errorf("row not correctly initialised: %+v", row)
+		}
+	}
+	rec = doReq(t, r, http.MethodGet, "/me/backup-schedules", "")
+	var listResp struct {
+		Data meSchedulesView `json:"data"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &listResp)
+	if len(listResp.Data.Schedules) != 1 || listResp.Data.MaxBackupSchedules != 3 {
+		t.Errorf("list = %+v", listResp.Data)
+	}
+	if listResp.Data.WindowStart != "02:00" || listResp.Data.WindowEnd != "05:00" {
+		t.Errorf("window not surfaced: %+v", listResp.Data)
+	}
+}
+
+func TestMeSchedules_CapEnforced(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(2), nil)
+	r := newSchedRouter(h, "userA")
+
+	body := `{"enabled":false,"content":"full","cadence":"daily"}`
+	if rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", body); rec.Code != http.StatusCreated {
+		t.Fatalf("1st create = %d", rec.Code)
+	}
+	if rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", body); rec.Code != http.StatusCreated {
+		t.Fatalf("2nd create = %d", rec.Code)
+	}
+	rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", body)
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "schedule_limit_reached") {
+		t.Fatalf("3rd create must hit the cap: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMeSchedules_InvalidCadenceRejected(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	h := newSchedHandler(store, users, schedTestPkg(3), nil)
+	r := newSchedRouter(h, "userA")
+
+	// Empty cadence is the legacy-cron discriminator — must not be accepted here.
+	for _, c := range []string{`"cadence":""`, `"cadence":"monthly"`, `"cadence":"* * * * *"`} {
+		rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"full",`+c+`}`)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("cadence %s should 400, got %d", c, rec.Code)
+		}
+	}
+	if len(store.rows) != 0 {
+		t.Errorf("no row should be created for bad cadence, got %d", len(store.rows))
+	}
+}
+
+func TestMeSchedules_DestinationKindGated(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{"userA": pkgUser("userA", "pkg1")}}
+	// Package allows only "local"; the destination is "sftp" → 403.
+	dest := &models.BackupDestination{ID: "d1", Kind: "sftp", Enabled: true}
+	h := newSchedHandler(store, users, schedTestPkg(3), dest)
+	r := newSchedRouter(h, "userA")
+
+	rec := doReq(t, r, http.MethodPost, "/me/backup-schedules", `{"enabled":true,"content":"full","cadence":"daily","destination_id":"d1"}`)
+	if rec.Code != http.StatusForbidden || !strings.Contains(rec.Body.String(), "destination_not_allowed") {
+		t.Fatalf("disallowed destination kind must 403: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMeSchedules_CrossTenantIsolation(t *testing.T) {
+	store := newSchedStore()
+	users := &usersMap{m: map[string]*models.User{
+		"userA": pkgUser("userA", "pkg1"),
+		"userB": pkgUser("userB", "pkg1"),
+	}}
+	pkg := schedTestPkg(3)
+	// userA creates a schedule.
+	ha := newSchedHandler(store, users, pkg, nil)
+	ra := newSchedRouter(ha, "userA")
+	if rec := doReq(t, ra, http.MethodPost, "/me/backup-schedules", `{"enabled":false,"content":"full","cadence":"daily"}`); rec.Code != http.StatusCreated {
+		t.Fatalf("userA create = %d", rec.Code)
+	}
+	var aID string
+	for id := range store.rows {
+		aID = id
+	}
+
+	// userB — same store — must NOT see, edit, or delete userA's schedule.
+	hb := newSchedHandler(store, users, pkg, nil)
+	rb := newSchedRouter(hb, "userB")
+
+	rec := doReq(t, rb, http.MethodGet, "/me/backup-schedules", "")
+	var listResp struct {
+		Data meSchedulesView `json:"data"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &listResp)
+	if len(listResp.Data.Schedules) != 0 {
+		t.Errorf("userB must not see userA's schedule, saw %d", len(listResp.Data.Schedules))
+	}
+	if rec := doReq(t, rb, http.MethodPut, "/me/backup-schedules/"+aID, `{"enabled":true,"content":"files","cadence":"hourly"}`); rec.Code != http.StatusNotFound {
+		t.Errorf("userB PUT on userA's schedule must 404, got %d", rec.Code)
+	}
+	if rec := doReq(t, rb, http.MethodDelete, "/me/backup-schedules/"+aID, ""); rec.Code != http.StatusNotFound {
+		t.Errorf("userB DELETE on userA's schedule must 404, got %d", rec.Code)
+	}
+	// The row must survive both cross-tenant attempts.
+	if _, ok := store.rows[aID]; !ok {
+		t.Error("userA's schedule was destroyed by a cross-tenant request")
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -886,6 +886,47 @@ paths:
       summary: Set your scheduled-backup content, destination, and on/off
       responses: { "200": { description: OK } }
 
+  /me/backup-schedules:
+    get:
+      tags: [Backups]
+      summary: List your backup schedules (multi-schedule plans) + the admin window
+      responses: { "200": { description: OK } }
+    post:
+      tags: [Backups]
+      summary: Create a backup schedule (content, cadence, destination, retention)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [content, cadence]
+              properties:
+                enabled:        { type: boolean }
+                content:        { type: string, enum: [full, files, database, folders] }
+                cadence:        { type: string, enum: [hourly, every_6h, every_12h, daily, weekly] }
+                destination_id: { type: string, format: ulid }
+                keep_daily:     { type: integer, nullable: true }
+      responses:
+        "201": { description: Created }
+        "403": { description: Cap reached or content/destination not allowed by your plan }
+
+  /me/backup-schedules/{id}:
+    put:
+      tags: [Backups]
+      summary: Update one of your backup schedules
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: ulid } } ]
+      responses:
+        "200": { description: OK }
+        "404": { description: Not found or not yours }
+    delete:
+      tags: [Backups]
+      summary: Delete one of your backup schedules
+      parameters: [ { in: path, name: id, required: true, schema: { type: string, format: ulid } } ]
+      responses:
+        "200": { description: OK }
+        "404": { description: Not found or not yours }
+
   /me/backups/{id}/restore:
     post:
       tags: [Backups]

--- a/panel-api/internal/api/packages.go
+++ b/panel-api/internal/api/packages.go
@@ -84,6 +84,7 @@ type createPackageRequest struct {
 	MaxPythonApps    uint32 `json:"max_python_apps"`
 	// Tenant backup limits (GH #454). 0 = backups not included on this plan.
 	MaxBackups                    uint32 `json:"max_backups"`
+	MaxBackupSchedules            uint32 `json:"max_backup_schedules"`
 	ScheduledBackupsEnabled       bool   `json:"scheduled_backups_enabled"`
 	AllowedBackupDestinationKinds string `json:"allowed_backup_destination_kinds"`
 	BackupRetentionPolicy         string `json:"backup_retention_policy"`
@@ -116,6 +117,7 @@ type updatePackageRequest struct {
 	MaxPythonApps    *uint32 `json:"max_python_apps"`
 	// Tenant backup limits (GH #454).
 	MaxBackups                    *uint32 `json:"max_backups"`
+	MaxBackupSchedules            *uint32 `json:"max_backup_schedules"`
 	ScheduledBackupsEnabled       *bool   `json:"scheduled_backups_enabled"`
 	AllowedBackupDestinationKinds *string `json:"allowed_backup_destination_kinds"`
 	BackupRetentionPolicy         *string `json:"backup_retention_policy"`
@@ -205,6 +207,7 @@ func (h *packageHandler) create(c *gin.Context) {
 		MaxPythonApps:    req.MaxPythonApps,
 
 		MaxBackups:                    req.MaxBackups,
+		MaxBackupSchedules:            req.MaxBackupSchedules,
 		ScheduledBackupsEnabled:       req.ScheduledBackupsEnabled,
 		AllowedBackupDestinationKinds: req.AllowedBackupDestinationKinds,
 		BackupRetentionPolicy:         req.BackupRetentionPolicy,
@@ -341,6 +344,11 @@ func (h *packageHandler) update(c *gin.Context) {
 	}
 	if req.MaxBackups != nil {
 		pkg.MaxBackups = *req.MaxBackups
+	}
+	if req.MaxBackupSchedules != nil {
+		// 0 is normalised to 1 (single-schedule) at read time via
+		// MaxBackupSchedulesOrDefault; store the admin's value verbatim.
+		pkg.MaxBackupSchedules = *req.MaxBackupSchedules
 	}
 	if req.ScheduledBackupsEnabled != nil {
 		pkg.ScheduledBackupsEnabled = *req.ScheduledBackupsEnabled

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -160,6 +160,11 @@ type updateServerSettingsRequest struct {
 	// backups run at. Tenants choose content + destination; only the admin sets
 	// the timing. Validated server-side via internalbackup.ParseCron.
 	TenantBackupCron *string `json:"tenant_backup_cron,omitempty"`
+	// TenantBackupWindow{Start,End} (GH #454 7B): the admin-owned UTC maintenance
+	// window ("HH:MM") that tenant window-governed multi-schedules fire inside.
+	// Validated server-side via internalbackup.ParseWindow round-trip.
+	TenantBackupWindowStart *string `json:"tenant_backup_window_start,omitempty"`
+	TenantBackupWindowEnd   *string `json:"tenant_backup_window_end,omitempty"`
 
 	// M13 SSH shell sandbox.
 	SSHSandboxMode            *string `json:"ssh_sandbox_mode,omitempty"`
@@ -545,6 +550,22 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 			return
 		}
 		current.TenantBackupCron = cronExpr
+	}
+	if req.TenantBackupWindowStart != nil {
+		v := strings.TrimSpace(*req.TenantBackupWindowStart)
+		if !internalbackup.ValidHHMM(v) {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_backup_window", "detail": "tenant_backup_window_start must be HH:MM (00:00–23:59)"})
+			return
+		}
+		current.TenantBackupWindowStart = v
+	}
+	if req.TenantBackupWindowEnd != nil {
+		v := strings.TrimSpace(*req.TenantBackupWindowEnd)
+		if !internalbackup.ValidHHMM(v) {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_backup_window", "detail": "tenant_backup_window_end must be HH:MM (00:00–23:59)"})
+			return
+		}
+		current.TenantBackupWindowEnd = v
 	}
 	if req.SSHSandboxMode != nil {
 		current.SSHSandboxMode = strings.TrimSpace(*req.SSHSandboxMode)

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -199,6 +199,13 @@ func (s *Scheduler) tickDispatch(ctx context.Context) {
 // firing, create queued backup_jobs rows for each fan-out target, mark
 // the schedule ran. The dispatcher tick then drains the queue.
 func (s *Scheduler) enqueue(ctx context.Context, sched models.BackupSchedule) {
+	// GH #454 7B: a non-empty cadence marks a window-governed tenant schedule —
+	// its timing comes from the admin maintenance window + interval, NOT cron.
+	if sched.Cadence != "" {
+		s.enqueueTenantWindow(ctx, sched)
+		return
+	}
+
 	logger := s.deps.Log.With(
 		"schedule_id", sched.ID,
 		"kind", sched.Kind,
@@ -231,6 +238,42 @@ func (s *Scheduler) enqueue(ctx context.Context, sched models.BackupSchedule) {
 
 	if err := s.deps.Schedules.MarkRan(ctx, sched.ID, time.Now().UTC(), next); err != nil {
 		logger.Error("schedule mark-ran failed", "err", err)
+	}
+}
+
+// enqueueTenantWindow handles a window-governed tenant schedule (GH #454 7B):
+// it only enqueues while the clock is inside the admin maintenance window, and
+// advances next_run_at to the next in-window opening (smeared per schedule) so
+// N tenants that come due together don't all fire at window open. The retention
+// cap + fan-out reuse the same enqueueBackup path as the cron schedules.
+func (s *Scheduler) enqueueTenantWindow(ctx context.Context, sched models.BackupSchedule) {
+	logger := s.deps.Log.With("schedule_id", sched.ID, "cadence", sched.Cadence, "user_id", strDeref(sched.UserID))
+	now := time.Now().UTC()
+	w := internalbackup.DefaultTenantWindow
+	if s.deps.Settings != nil {
+		if set, err := s.deps.Settings.Get(ctx); err == nil && set != nil {
+			w = internalbackup.ParseWindow(set.TenantBackupWindowStart, set.TenantBackupWindowEnd)
+		}
+	}
+	next := internalbackup.NextTenantRun(now, sched.Cadence, w, sched.ID)
+	if !w.Contains(now) {
+		// Due but outside the window — defer to the next (smeared) opening
+		// without enqueuing anything.
+		_ = s.deps.Schedules.UpdateNextRun(ctx, sched.ID, next)
+		return
+	}
+	enqueued, qErr := s.enqueueBackup(ctx, sched)
+	if qErr != nil {
+		logger.Error("tenant window enqueue failed", "err", qErr)
+		_ = s.deps.Schedules.UpdateNextRun(ctx, sched.ID, next)
+		return
+	}
+	if !enqueued {
+		_ = s.deps.Schedules.UpdateNextRun(ctx, sched.ID, next)
+		return
+	}
+	if err := s.deps.Schedules.MarkRan(ctx, sched.ID, now, next); err != nil {
+		logger.Error("tenant window mark-ran failed", "err", err)
 	}
 }
 

--- a/panel-api/internal/db/migrations/000253_tenant_multi_backup_schedules.down.sql
+++ b/panel-api/internal/db/migrations/000253_tenant_multi_backup_schedules.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE backup_schedules DROP COLUMN cadence;
+ALTER TABLE server_settings
+  DROP COLUMN tenant_backup_window_start,
+  DROP COLUMN tenant_backup_window_end;
+ALTER TABLE hosting_packages DROP COLUMN max_backup_schedules;

--- a/panel-api/internal/db/migrations/000253_tenant_multi_backup_schedules.up.sql
+++ b/panel-api/internal/db/migrations/000253_tenant_multi_backup_schedules.up.sql
@@ -1,0 +1,29 @@
+-- GH #454 Phase 7B: tenant multi-schedule backups, maintenance-window model.
+--
+-- hosting_packages.max_backup_schedules: how many backup schedules a tenant on
+--   this plan may own. Default 1 = the existing single-schedule behaviour, so no
+--   plan changes until an admin raises it. The tenant multi-schedule UI + the
+--   window-governed scheduler path activate for a tenant only once this is > 1.
+--
+-- server_settings.tenant_backup_window_{start,end}: the admin-owned UTC
+--   maintenance window (HH:MM) that tenant window-governed schedules fire inside.
+--   The scheduler enqueues a due tenant schedule only when now is within the
+--   window, and smears multiple due schedules across it so N tenants don't all
+--   fire at window open. Default 02:00-05:00. tenant_backup_cron (000232) stays
+--   for legacy single-schedule installs; the window supersedes it for schedules
+--   created through the multi-schedule surface (backup_schedules.cadence != '').
+--
+-- backup_schedules.cadence: a tenant's chosen firing cadence for a
+--   window-governed schedule (hourly / every_6h / every_12h / daily / weekly),
+--   from a fixed allow-list mapped to an interval — NOT free cron, so a tenant
+--   can never pick a stampede minute. Empty '' = a legacy cron-governed schedule
+--   (admin fan-out, system, or the pre-7B single tenant schedule); those keep
+--   using cron_expr + next_run_at unchanged. Non-empty routes the schedule
+--   through the window-guarded dispatch path.
+ALTER TABLE hosting_packages
+  ADD COLUMN max_backup_schedules INT UNSIGNED NOT NULL DEFAULT 1;
+ALTER TABLE server_settings
+  ADD COLUMN tenant_backup_window_start VARCHAR(5) NOT NULL DEFAULT '02:00',
+  ADD COLUMN tenant_backup_window_end   VARCHAR(5) NOT NULL DEFAULT '05:00';
+ALTER TABLE backup_schedules
+  ADD COLUMN cadence VARCHAR(16) NOT NULL DEFAULT '';

--- a/panel-api/internal/models/backup_schedule.go
+++ b/panel-api/internal/models/backup_schedule.go
@@ -25,7 +25,14 @@ type BackupSchedule struct {
 	// database / folders (GH #454). Default 'full' preserves the pre-feature
 	// behaviour. Used by the scheduler fan-out (wired in a follow-up) and set by
 	// tenants on their own schedule.
-	Content     string     `gorm:"column:content;type:varchar(16);not null;default:'full'" json:"content"`
+	Content string `gorm:"column:content;type:varchar(16);not null;default:'full'" json:"content"`
+	// Cadence (GH #454 7B) is the tenant's chosen firing cadence for a
+	// window-governed schedule (hourly / every_6h / every_12h / daily / weekly).
+	// Empty '' = a legacy cron-governed schedule (admin fan-out, system, or the
+	// pre-7B single tenant schedule) that keeps using CronExpr + NextRunAt. A
+	// non-empty cadence routes the schedule through the window-guarded dispatch
+	// path (internal/backup.NextTenantRun), where CronExpr is ignored.
+	Cadence     string     `gorm:"column:cadence;type:varchar(16);not null;default:''" json:"cadence"`
 	Enabled     bool       `gorm:"not null;default:1" json:"enabled"`
 	KeepDaily   *int       `gorm:"type:int" json:"keep_daily,omitempty"`
 	KeepWeekly  *int       `gorm:"type:int" json:"keep_weekly,omitempty"`

--- a/panel-api/internal/models/hosting_package.go
+++ b/panel-api/internal/models/hosting_package.go
@@ -51,8 +51,14 @@ type HostingPackage struct {
 	// owns the content within these limits. AllowedBackupDestinationKinds is a
 	// CSV of BackupDestinationKind* a tenant on this package may target; empty
 	// = none allowed.
-	MaxBackups                    uint32 `gorm:"column:max_backups;type:int unsigned;not null;default:0" json:"max_backups"`
-	ScheduledBackupsEnabled       bool   `gorm:"column:scheduled_backups_enabled;type:tinyint(1);not null;default:0" json:"scheduled_backups_enabled"`
+	MaxBackups              uint32 `gorm:"column:max_backups;type:int unsigned;not null;default:0" json:"max_backups"`
+	ScheduledBackupsEnabled bool   `gorm:"column:scheduled_backups_enabled;type:tinyint(1);not null;default:0" json:"scheduled_backups_enabled"`
+	// MaxBackupSchedules (GH #454 7B) caps how many scheduled backups a tenant on
+	// this plan may own. 1 = the original single-schedule behaviour (existing
+	// plans unchanged); > 1 unlocks the tenant multi-schedule surface + the
+	// window-governed dispatch path. Explicit column tag — GORM would otherwise
+	// mangle nothing here, but keep it consistent with the sibling backup fields.
+	MaxBackupSchedules            uint32 `gorm:"column:max_backup_schedules;type:int unsigned;not null;default:1" json:"max_backup_schedules"`
 	AllowedBackupDestinationKinds string `gorm:"column:allowed_backup_destination_kinds;type:varchar(255);not null;default:''" json:"allowed_backup_destination_kinds"`
 	// BackupRetentionPolicy (GH #454) chooses the behaviour when a tenant hits
 	// MaxBackups: "reject" (default, safe) blocks the new backup and notifies;
@@ -99,6 +105,23 @@ func (HostingPackage) TableName() string { return "hosting_packages" }
 // BackupsEnabled reports whether tenants on this package may use backups at all
 // (MaxBackups > 0). The tenant backup UI + API are gated on this (GH #454).
 func (p HostingPackage) BackupsEnabled() bool { return p.MaxBackups > 0 }
+
+// MaxBackupSchedulesOrDefault returns the per-tenant schedule cap, treating 0
+// (an unmigrated / cleared value) as 1 so a tenant always keeps at least the
+// single-schedule capability (GH #454 7B).
+func (p HostingPackage) MaxBackupSchedulesOrDefault() int {
+	if p.MaxBackupSchedules == 0 {
+		return 1
+	}
+	return int(p.MaxBackupSchedules)
+}
+
+// TenantMultiScheduleEnabled reports whether this plan unlocks the tenant
+// multi-schedule surface (cap > 1). Below that the tenant keeps the legacy
+// single-schedule card (GH #454 7B).
+func (p HostingPackage) TenantMultiScheduleEnabled() bool {
+	return p.BackupsEnabled() && p.ScheduledBackupsEnabled && p.MaxBackupSchedulesOrDefault() > 1
+}
 
 // AllowedBackupKinds parses AllowedBackupDestinationKinds (CSV) into a deduped,
 // lower-cased, order-preserving slice. Empty when none are allowed.

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -9,20 +9,20 @@ import (
 // DNS configuration. Operators edit these from the admin Settings page;
 // at first boot the row is seeded from the installer's config.toml.
 type ServerSettings struct {
-	ID         uint8  `gorm:"primaryKey;default:1"                json:"id"`
-	Hostname   string `gorm:"type:varchar(253);not null;default:''" json:"hostname"`
+	ID       uint8  `gorm:"primaryKey;default:1"                json:"id"`
+	Hostname string `gorm:"type:varchar(253);not null;default:''" json:"hostname"`
 	// PreviewBase (GH #836, migration 000244) overrides the derived
 	// preview-URL base. Empty = preview.<hostname>. Set a custom domain
 	// (preview.example.com) or a magic-DNS base (203-0-113-7.sslip.io)
 	// when the hostname does not resolve publicly.
 	PreviewBase string `gorm:"type:varchar(253);not null;default:''" json:"preview_base"`
-	PublicIPv4 string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv4"`
-	PublicIPv6 string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv6"`
-	NS1Name    string `gorm:"type:varchar(253);not null;default:''" json:"ns1_name"`
-	NS1IPv4    string `gorm:"type:varchar(45);not null;default:''"  json:"ns1_ipv4"`
-	NS2Name    string `gorm:"type:varchar(253);not null;default:''" json:"ns2_name"`
-	NS2IPv4    string `gorm:"type:varchar(45);not null;default:''"  json:"ns2_ipv4"`
-	AdminEmail string `gorm:"type:varchar(320);not null;default:''" json:"admin_email"`
+	PublicIPv4  string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv4"`
+	PublicIPv6  string `gorm:"type:varchar(45);not null;default:''"  json:"public_ipv6"`
+	NS1Name     string `gorm:"type:varchar(253);not null;default:''" json:"ns1_name"`
+	NS1IPv4     string `gorm:"type:varchar(45);not null;default:''"  json:"ns1_ipv4"`
+	NS2Name     string `gorm:"type:varchar(253);not null;default:''" json:"ns2_name"`
+	NS2IPv4     string `gorm:"type:varchar(45);not null;default:''"  json:"ns2_ipv4"`
+	AdminEmail  string `gorm:"type:varchar(320);not null;default:''" json:"admin_email"`
 	// DefaultDNSTTL is the TTL (seconds) applied to newly-created DNS
 	// records when the API caller doesn't pass one. Editable via
 	// Server Settings → DNS in the admin UI. Range 60–86400 enforced
@@ -282,6 +282,15 @@ type ServerSettings struct {
 	// their own scheduled backup; the admin owns the timing (resource
 	// planning). Default 03:00 daily.
 	TenantBackupCron string `gorm:"column:tenant_backup_cron;type:varchar(64);not null;default:'0 3 * * *'" json:"tenant_backup_cron"`
+	// TenantBackupWindowStart/End (GH #454 7B) is the admin-owned UTC maintenance
+	// window ("HH:MM") that tenant window-governed schedules fire inside. The
+	// scheduler enqueues a due tenant schedule only when now is within the window
+	// and smears multiple due schedules across it. Defaults 02:00–05:00.
+	// tenant_backup_cron stays authoritative for legacy single-schedule installs;
+	// the window governs schedules created through the multi-schedule surface
+	// (backup_schedules.cadence != '').
+	TenantBackupWindowStart string `gorm:"column:tenant_backup_window_start;type:varchar(5);not null;default:'02:00'" json:"tenant_backup_window_start"`
+	TenantBackupWindowEnd   string `gorm:"column:tenant_backup_window_end;type:varchar(5);not null;default:'05:00'" json:"tenant_backup_window_end"`
 
 	// BackupMaxConcurrentJobs caps how many backup_jobs the in-process
 	// dispatcher will keep in status=running at once. Scheduler ticks

--- a/panel-api/internal/repository/backup_schedule_repository.go
+++ b/panel-api/internal/repository/backup_schedule_repository.go
@@ -129,6 +129,7 @@ func (r *backupScheduleRepo) Update(ctx context.Context, s *models.BackupSchedul
 			"include_system_backup": s.IncludeSystemBackup,
 			"cron_expr":             s.CronExpr,
 			"content":               s.Content,
+			"cadence":               s.Cadence,
 			"enabled":               s.Enabled,
 			"keep_daily":            s.KeepDaily,
 			"keep_weekly":           s.KeepWeekly,

--- a/panel-api/internal/repository/backup_schedule_repository_test.go
+++ b/panel-api/internal/repository/backup_schedule_repository_test.go
@@ -85,8 +85,10 @@ func TestBackupSchedule_Update_PersistsContent(t *testing.T) {
 	repo := NewBackupScheduleRepository(db)
 
 	mock.ExpectBegin()
-	// Fails if `content` is missing from the SET clause (the bug).
-	mock.ExpectExec("UPDATE .backup_schedules. SET .content.=").
+	// Fails if `content` is missing from the SET clause (the bug). GORM orders
+	// the map columns alphabetically, so `content` no longer sits right after
+	// SET (`cadence` precedes it since GH #454 7B) — match it anywhere in SET.
+	mock.ExpectExec("UPDATE .backup_schedules. SET .*.content.=").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -247,7 +247,10 @@
     "max_concurrent_backup_jobs": "Max concurrent backup jobs",
     "tenant_scheduled_backup_time_cron": "Tenant scheduled-backup time (cron)",
     "tenants_choose_what_to_back_up_and_where_you": "Tenants choose what to back up and where; you own when. 5-field cron (min hour day-of-month month day-of-week), e.g. '0 3 * * *' = daily at 03:00 UTC.",
-    "the_dispatcher_runs_at_most_this_many_backup": "The dispatcher runs at most this many backup_jobs at once. Scheduled jobs queue and start as slots free."
+    "the_dispatcher_runs_at_most_this_many_backup": "The dispatcher runs at most this many backup_jobs at once. Scheduled jobs queue and start as slots free.",
+    "tenant_backup_window_start": "Tenant backup window start (UTC)",
+    "tenant_backup_window_end": "Tenant backup window end (UTC)",
+    "the_maintenance_window_multischedule_tenants": "The maintenance window multi-schedule tenants' backups fire inside. The scheduler only runs (and spreads) tenant backups within this window."
   },
   "createbackupdrawer": {
     "backups_run_as_a_goroutine_inside_panel_agen": "Backups run as a goroutine inside panel-agent.",
@@ -715,6 +718,7 @@
     "io_write_bandwidth_mb_s": "IO Write Bandwidth (MB/s)",
     "let_tenants_pick_a_safe_php_performance_mode": "Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized).",
     "max_backups": "Max Backups",
+    "max_backup_schedules": "Max Backup Schedules",
     "max_children_per_user_fpm_cap": "Max children per user (FPM cap)",
     "max_databases": "Max Databases",
     "max_docker_apps": "Max Docker Apps",
@@ -724,6 +728,7 @@
     "max_tasks": "Max Tasks",
     "memory_limit_mb": "Memory Limit (MB)",
     "name": "Name",
+    "how_many_scheduled_backups_a_tenant_may_own": "How many scheduled backups a tenant on this plan may own. 1 keeps the single-schedule card; more than 1 unlocks the multi-schedule list (fired inside the admin maintenance window).",
     "retention_cap_most_snapshots_a_tenant_on_thi": "Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included.",
     "scheduled_backups": "Scheduled Backups",
     "security_re_enables_php_exec_proc_open_shell": "Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs.",
@@ -747,6 +752,7 @@
     "io_write_bandwidth_mb_s": "IO Write Bandwidth (MB/s)",
     "let_tenants_pick_a_safe_php_performance_mode": "Let tenants pick a safe PHP Performance Mode (Balanced / Low-memory / High-traffic / WordPress-optimized).",
     "max_backups": "Max Backups",
+    "max_backup_schedules": "Max Backup Schedules",
     "max_children_per_user_fpm_cap": "Max children per user (FPM cap)",
     "max_databases": "Max Databases",
     "max_docker_apps": "Max Docker Apps",
@@ -756,6 +762,7 @@
     "max_tasks": "Max Tasks",
     "memory_limit_mb": "Memory Limit (MB)",
     "name": "Name",
+    "how_many_scheduled_backups_a_tenant_may_own": "How many scheduled backups a tenant on this plan may own. 1 keeps the single-schedule card; more than 1 unlocks the multi-schedule list (fired inside the admin maintenance window).",
     "retention_cap_most_snapshots_a_tenant_on_thi": "Retention cap — most snapshots a tenant on this plan may keep. 0 = tenant backups not included.",
     "scheduled_backups": "Scheduled Backups",
     "security_re_enables_php_exec_proc_open_shell": "Security: re-enables PHP exec/proc_open/shell_exec for ALL tenants on this package (GH #401 lockdown is OFF). Only enable for plans whose apps genuinely need shell-outs.",

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -14,12 +14,22 @@ interface BackupSettingsShape {
   // GH #454: the admin-owned time tenant scheduled backups run at. Tenants pick
   // content + destination; only the admin sets the cron.
   tenant_backup_cron: string;
+  // GH #454 7B: admin maintenance window (UTC HH:MM) that tenant multi-schedules
+  // fire inside. Governs plans with max_backup_schedules > 1; the cron above
+  // still governs legacy single-schedule plans.
+  tenant_backup_window_start: string;
+  tenant_backup_window_end: string;
 }
 
 interface ServerSettingsResponse {
   backup_max_concurrent_jobs?: number;
   tenant_backup_cron?: string;
+  tenant_backup_window_start?: string;
+  tenant_backup_window_end?: string;
 }
+
+// HH:MM (24h) — the format the API validates (internalbackup.ValidHHMM).
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 export const BackupSettingsTab = () => {
   const { t } = useTranslation();
@@ -36,6 +46,8 @@ export const BackupSettingsTab = () => {
         form.setFieldsValue({
           backup_max_concurrent_jobs: resp.data.backup_max_concurrent_jobs ?? 2,
           tenant_backup_cron: resp.data.tenant_backup_cron ?? "0 3 * * *",
+          tenant_backup_window_start: resp.data.tenant_backup_window_start ?? "02:00",
+          tenant_backup_window_end: resp.data.tenant_backup_window_end ?? "05:00",
         });
       } catch (err) {
         message.error(extractApiError(err, "Load failed"));
@@ -84,6 +96,22 @@ export const BackupSettingsTab = () => {
           extra="Runs in UTC (server time) — e.g. 0 3 * * * fires at 03:00 UTC. The tenant view shows the same UTC time."
         >
           <Input placeholder="0 3 * * *" style={{ fontFamily: "monospace" }} />
+        </Form.Item>
+        <Form.Item
+          name="tenant_backup_window_start"
+          label={t("backupsettingstab.tenant_backup_window_start")}
+          tooltip={t("backupsettingstab.the_maintenance_window_multischedule_tenants")}
+          rules={[{ required: true, pattern: HHMM, message: "Use HH:MM (UTC)" }]}
+          extra="UTC. Applies to plans that allow more than one schedule; the scheduler fires (and spreads) tenant backups within this window."
+        >
+          <Input placeholder="02:00" style={{ fontFamily: "monospace" }} />
+        </Form.Item>
+        <Form.Item
+          name="tenant_backup_window_end"
+          label={t("backupsettingstab.tenant_backup_window_end")}
+          rules={[{ required: true, pattern: HHMM, message: "Use HH:MM (UTC)" }]}
+        >
+          <Input placeholder="05:00" style={{ fontFamily: "monospace" }} />
         </Form.Item>
         <Form.Item>
           <Button type="primary" htmlType="submit" loading={saving} icon={<SaveOutlined />}>

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -46,6 +46,7 @@ type PackageCreateInput = {
   max_python_apps: number;
   // Tenant backup limits (GH #454).
   max_backups: number;
+  max_backup_schedules: number;
   scheduled_backups_enabled: boolean;
   allowed_backup_destination_kinds: string | string[];
   backup_retention_policy: string;
@@ -153,6 +154,7 @@ export const PackageCreate = () => {
           max_docker_apps: 0,
           max_python_apps: 0,
           max_backups: 0,
+          max_backup_schedules: 1,
           scheduled_backups_enabled: false,
           allowed_backup_destination_kinds: [],
           backup_retention_policy: "reject",
@@ -329,6 +331,15 @@ export const PackageCreate = () => {
               tooltip={t("packagecreate.allow_tenants_on_this_plan_to_enable_a_sched")}
             >
               <Switch />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label={t("packagecreate.max_backup_schedules")}
+              name="max_backup_schedules"
+              tooltip={t("packageedit.how_many_scheduled_backups_a_tenant_may_own")}
+            >
+              <InputNumber min={1} style={{ width: "100%" }} />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>

--- a/panel-ui/src/shells/admin/packages/PackageEdit.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageEdit.tsx
@@ -51,6 +51,7 @@ type PackageEditInput = {
   // string on the wire; the multi-Select binds an array (converted on load/save,
   // like docker_app_slugs).
   max_backups: number;
+  max_backup_schedules: number;
   scheduled_backups_enabled: boolean;
   allowed_backup_destination_kinds: string | string[];
   backup_retention_policy: string;
@@ -347,6 +348,15 @@ export const PackageEdit = () => {
               tooltip={t("packageedit.allow_tenants_on_this_plan_to_enable_a_sched")}
             >
               <Switch />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            <Form.Item
+              label={t("packageedit.max_backup_schedules")}
+              name="max_backup_schedules"
+              tooltip={t("packageedit.how_many_scheduled_backups_a_tenant_may_own")}
+            >
+              <InputNumber min={1} style={{ width: "100%" }} />
             </Form.Item>
           </Col>
           <Col xs={24} sm={12} md={8}>

--- a/panel-ui/src/shells/user/BackupSchedulesCard.tsx
+++ b/panel-ui/src/shells/user/BackupSchedulesCard.tsx
@@ -1,0 +1,305 @@
+// BackupSchedulesCard — tenant multi-schedule backup surface (GH #454 7B).
+// A tenant on a plan with max_backup_schedules > 1 manages a LIST of backup
+// schedules; each owns content + cadence + destination + retention + on/off.
+// The ADMIN owns the maintenance WINDOW (shown read-only) that these fire
+// inside — the tenant never picks a time, only a cadence, so no tenant can
+// choose a stampede minute. On a single-schedule plan this falls back to the
+// legacy MyProfileScheduleCard.
+import { useTranslation } from "react-i18next";
+import {
+  Alert,
+  Button,
+  Card,
+  Drawer,
+  Form,
+  InputNumber,
+  Popconfirm,
+  Select,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Typography,
+  message,
+} from "antd";
+import { ClockCircleOutlined, DeleteOutlined, EditOutlined, PlusOutlined } from "@icons";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../apiClient";
+import { extractApiError } from "../../apiErrors";
+import { shortDateTimeUTC } from "../../utils/datetime";
+import { MyProfileScheduleCard } from "./MyProfileScheduleCard";
+
+interface ScheduleRow {
+  id: string;
+  enabled: boolean;
+  content: string;
+  cadence: string;
+  destination_id?: string;
+  keep_daily?: number | null;
+  next_run_at?: string | null;
+  last_run_at?: string | null;
+}
+
+interface SchedulesView {
+  schedules: ScheduleRow[];
+  max_backup_schedules: number;
+  max_backups: number;
+  scheduled_backups_enabled: boolean;
+  multi_enabled: boolean;
+  window_start: string;
+  window_end: string;
+}
+
+interface DestOption {
+  id: string;
+  name: string;
+  kind: string;
+}
+
+const CONTENT_OPTIONS = [
+  { value: "full", label: "Full account" },
+  { value: "files", label: "Files only" },
+  { value: "database", label: "Databases only" },
+];
+
+const CADENCE_OPTIONS = [
+  { value: "hourly", label: "Hourly" },
+  { value: "every_6h", label: "Every 6 hours" },
+  { value: "every_12h", label: "Every 12 hours" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+];
+
+const contentLabel = (c: string) => CONTENT_OPTIONS.find((o) => o.value === c)?.label ?? c;
+const cadenceLabel = (c: string) => CADENCE_OPTIONS.find((o) => o.value === c)?.label ?? c;
+
+interface DrawerForm {
+  content: string;
+  cadence: string;
+  destination_id?: string;
+  keep_daily?: number | null;
+  enabled: boolean;
+}
+
+export const BackupSchedulesCard = () => {
+  const { t } = useTranslation();
+  const [form] = Form.useForm<DrawerForm>();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const listQuery = useQuery({
+    queryKey: ["me-backup-schedules"],
+    queryFn: async () => (await apiClient.get<{ data: SchedulesView }>("/me/backup-schedules")).data.data,
+  });
+  const destQuery = useQuery({
+    queryKey: ["me-backup-destinations"],
+    queryFn: async () =>
+      (await apiClient.get<{ data: DestOption[]; allow_local: boolean }>("/me/backups/destinations")).data,
+  });
+
+  const view = listQuery.data;
+  const dests = destQuery.data?.data ?? [];
+  const destOptions = dests.map((d) => ({ value: d.id, label: `${d.name} (${d.kind})` }));
+  const destName = (id?: string) => {
+    if (!id) return <Typography.Text type="secondary">—</Typography.Text>;
+    const d = dests.find((x) => x.id === id);
+    return d ? `${d.name} (${d.kind})` : id;
+  };
+
+  // A single-schedule plan keeps the original card — no behaviour change.
+  if (view && !view.multi_enabled) {
+    return <MyProfileScheduleCard />;
+  }
+
+  const openCreate = () => {
+    setEditingId(null);
+    form.setFieldsValue({ content: "full", cadence: "daily", destination_id: undefined, keep_daily: null, enabled: true });
+    setDrawerOpen(true);
+  };
+  const openEdit = (row: ScheduleRow) => {
+    setEditingId(row.id);
+    form.setFieldsValue({
+      content: row.content || "full",
+      cadence: row.cadence || "daily",
+      destination_id: row.destination_id,
+      keep_daily: row.keep_daily ?? null,
+      enabled: row.enabled,
+    });
+    setDrawerOpen(true);
+  };
+
+  const submitDrawer = async () => {
+    const values = await form.validateFields();
+    setSaving(true);
+    try {
+      const body = {
+        enabled: values.enabled,
+        content: values.content,
+        cadence: values.cadence,
+        destination_id: values.destination_id ?? "",
+        keep_daily: values.keep_daily ?? null,
+      };
+      if (editingId) {
+        await apiClient.put(`/me/backup-schedules/${editingId}`, body);
+      } else {
+        await apiClient.post("/me/backup-schedules", body);
+      }
+      message.success(editingId ? "Schedule updated" : "Schedule created");
+      setDrawerOpen(false);
+      listQuery.refetch();
+    } catch (err) {
+      message.error(extractApiError(err, "Save failed"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Inline enable/disable — PUTs the whole row (the API replaces, not patches),
+  // so carry the existing content/cadence/destination through.
+  const toggleEnabled = async (row: ScheduleRow, enabled: boolean) => {
+    try {
+      await apiClient.put(`/me/backup-schedules/${row.id}`, {
+        enabled,
+        content: row.content,
+        cadence: row.cadence,
+        destination_id: row.destination_id ?? "",
+        keep_daily: row.keep_daily ?? null,
+      });
+      listQuery.refetch();
+    } catch (err) {
+      message.error(extractApiError(err, "Update failed"));
+    }
+  };
+
+  const removeRow = async (id: string) => {
+    try {
+      await apiClient.delete(`/me/backup-schedules/${id}`);
+      message.success("Schedule removed");
+      listQuery.refetch();
+    } catch (err) {
+      message.error(extractApiError(err, "Delete failed"));
+    }
+  };
+
+  const atCap = !!view && view.schedules.length >= view.max_backup_schedules;
+
+  const columns = [
+    { title: "Type", dataIndex: "content", key: "content", render: (c: string) => contentLabel(c) },
+    { title: "Cadence", dataIndex: "cadence", key: "cadence", render: (c: string) => cadenceLabel(c) },
+    { title: "Destination", dataIndex: "destination_id", key: "destination_id", render: (id?: string) => destName(id) },
+    {
+      title: "Keep",
+      dataIndex: "keep_daily",
+      key: "keep_daily",
+      render: (k?: number | null) => (k ? `${k} copies` : <Typography.Text type="secondary">default</Typography.Text>),
+    },
+    {
+      title: "Next run",
+      dataIndex: "next_run_at",
+      key: "next_run_at",
+      render: (n?: string | null) =>
+        n ? shortDateTimeUTC(n) : <Typography.Text type="secondary">—</Typography.Text>,
+    },
+    {
+      title: "Enabled",
+      dataIndex: "enabled",
+      key: "enabled",
+      render: (enabled: boolean, row: ScheduleRow) => (
+        <Switch size="small" checked={enabled} onChange={(v) => toggleEnabled(row, v)} />
+      ),
+    },
+    {
+      title: "",
+      key: "actions",
+      render: (_: unknown, row: ScheduleRow) => (
+        <Space>
+          <Button size="small" icon={<EditOutlined />} onClick={() => openEdit(row)} />
+          <Popconfirm title="Remove this schedule?" okText="Remove" okButtonProps={{ danger: true }} onConfirm={() => removeRow(row.id)}>
+            <Button size="small" danger icon={<DeleteOutlined />} />
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <Card
+      title={
+        <span>
+          <ClockCircleOutlined style={{ marginRight: 8 }} />
+          Backup schedules
+        </span>
+      }
+      style={{ marginTop: 16 }}
+      loading={listQuery.isLoading}
+      extra={
+        <Button type="primary" icon={<PlusOutlined />} disabled={atCap} onClick={openCreate}>
+          New schedule
+        </Button>
+      }
+    >
+      {view && !view.scheduled_backups_enabled ? (
+        <Alert type="info" showIcon message={t("myprofileschedulecard.scheduled_backups_are_not_included_in_your_h")} />
+      ) : (
+        <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+            Your host runs scheduled backups between{" "}
+            <strong>
+              {view?.window_start}–{view?.window_end} UTC
+            </strong>
+            . You choose what to back up, where, and how often — your host sets the window they run in.{" "}
+            <Tag>
+              {view?.schedules.length ?? 0} / {view?.max_backup_schedules ?? 1}
+            </Tag>
+          </Typography.Paragraph>
+          <Table<ScheduleRow>
+            size="small"
+            rowKey="id"
+            columns={columns}
+            dataSource={view?.schedules ?? []}
+            pagination={false}
+            locale={{ emptyText: "No backup schedules yet — add one to run backups automatically." }}
+          />
+        </Space>
+      )}
+
+      <Drawer
+        title={editingId ? "Edit backup schedule" : "New backup schedule"}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        width={420}
+        destroyOnClose
+        extra={
+          <Button type="primary" loading={saving} onClick={submitDrawer}>
+            Save
+          </Button>
+        }
+      >
+        <Form<DrawerForm> form={form} layout="vertical">
+          <Form.Item label="What to back up" name="content" rules={[{ required: true }]}>
+            <Select options={CONTENT_OPTIONS} />
+          </Form.Item>
+          <Form.Item label="How often" name="cadence" rules={[{ required: true }]}>
+            <Select options={CADENCE_OPTIONS} />
+          </Form.Item>
+          <Form.Item
+            label="Destination"
+            name="destination_id"
+            tooltip="Required to enable a schedule."
+          >
+            <Select allowClear placeholder="Pick a destination" options={destOptions} notFoundContent="No allowed destinations" />
+          </Form.Item>
+          <Form.Item label="Copies to keep" name="keep_daily" tooltip={`Up to your plan limit (${view?.max_backups ?? 1}).`}>
+            <InputNumber min={1} max={view?.max_backups || 1} style={{ width: "100%" }} />
+          </Form.Item>
+          <Form.Item label="Enabled" name="enabled" valuePropName="checked">
+            <Switch checkedChildren="On" unCheckedChildren="Off" />
+          </Form.Item>
+        </Form>
+      </Drawer>
+    </Card>
+  );
+};

--- a/panel-ui/src/shells/user/backups/UserBackupsPage.tsx
+++ b/panel-ui/src/shells/user/backups/UserBackupsPage.tsx
@@ -7,7 +7,7 @@ import { Typography } from "antd";
 import { SaveOutlined } from "@icons";
 
 import { MyProfileBackupCard } from "../MyProfileBackupCard";
-import { MyProfileScheduleCard } from "../MyProfileScheduleCard";
+import { BackupSchedulesCard } from "../BackupSchedulesCard";
 
 export const UserBackupsPage = () => {
   return (
@@ -16,7 +16,7 @@ export const UserBackupsPage = () => {
         <SaveOutlined /> Backup / Restore
       </Typography.Title>
       <MyProfileBackupCard />
-      <MyProfileScheduleCard />
+      <BackupSchedulesCard />
     </div>
   );
 };


### PR DESCRIPTION
## What

Phase 7B of #454. Tenants on a plan with `max_backup_schedules > 1` can own several backup schedules (databases daily, files weekly, …), each with its own **content · cadence · destination · retention · on-off**. The admin keeps the resource-planning guarantee the single-slot model gave them, now as a **maintenance window**.

## Design — maintenance-window model

- Admin owns a UTC **window** (`server_settings.tenant_backup_window_start/end`, default 02:00–05:00).
- Tenant owns a **cadence** per schedule, from a fixed allow-list (`hourly / every_6h / every_12h / daily / weekly`) — never a raw cron minute.
- The scheduler enqueues a due tenant schedule **only while the clock is inside the window**, and **smears** multiple due schedules across it by a deterministic per-schedule ULID offset, so N tenants coming due together don't stampede at window-open.

## Changes

- **migration 000253** — `hosting_packages.max_backup_schedules` (default **1** = existing single-schedule behaviour, plans unchanged), `server_settings.tenant_backup_window_start/end`, `backup_schedules.cadence` (`''` = legacy cron-governed row).
- **`internal/backup/window.go`** — `TenantWindow` (`Contains`/`NextOpen`, wrap-around + whole-day), cadence→interval, deterministic smear, `NextTenantRun` (the window-guarded next-fire computation). Fully unit-tested.
- **owner-scoped CRUD** `GET/POST/PUT/:id/DELETE /me/backup-schedules` — cap enforced; content + destination-kind allow-list checked; **every mutation re-verifies `row.user_id == session user` → 404 on mismatch** (no cross-tenant leak). Legacy singular `/me/backup-schedule` kept for cap-1 plans.
- **scheduler** — a non-empty cadence routes a schedule through the window-guard path; cron schedules (admin fan-out, system, legacy single tenant) are untouched (no regression).
- **UI** — tenant *Backup Schedules* table + create/edit drawer (falls back to the single-schedule card below the cap); admin package `max_backup_schedules` field; server-settings backup **window** fields.

## Tests

- `internal/backup/window_test.go` — window math (contains/next-open/wrap/whole-day), cadence validity + interval, `NextTenantRun` in-window/out-of-window/smear determinism/per-schedule spread.
- `backups_me_schedules_test.go` — create+list, **cap enforcement** (N+1 → 403), invalid/empty cadence → 400, **destination-kind gating** → 403, **cross-tenant isolation** (B can't see/PUT/DELETE A's schedule → 404, row survives).
- repo regression: schedule-content persists through `Update` (column-order fix).

`go build ./...` clean, affected Go suites green, `npx tsc -b` + `npm run build` + eslint clean.

## Test plan

- [ ] Admin: set a package `max_backup_schedules` to 3, set the server-settings backup window.
- [ ] Tenant on that plan: create db-hourly / files-6h / full-daily schedules; confirm the cap blocks the 4th.
- [ ] Box: confirm each fires inside the window with a correctly-typed backup (also regression-proves 7A's scheduled path persists `content`).

Closes nothing (never auto-close); addresses #454 7B.