### PR TITLE
fix(openapi): quote a flow-style description containing {id}

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -525,7 +525,7 @@ paths:
                 domain_id: { type: string, format: ulid }
                 kind:      { type: string, enum: [wordpress, joomla, drupal, moodle, ghost, opencart, prestashop, magento, drupal10, mediawiki, nextcloud, mautic, suitecrm, dolibarr, processmaker] }
                 path:      { type: string, default: "/", description: "Install path under doc-root." }
-      responses: { "201": { description: Install started — poll /applications/{id} for status } }
+      responses: { "201": { description: "Install started — poll /applications/{id} for status" } }
 
   # ----------------------------------------------------------- Backups ---
 


### PR DESCRIPTION
`{ description: … poll /applications/{id} … }` on line 528 of `docs/api/openapi.yaml` is invalid YAML: the unquoted `{id}` inside a flow mapping is parsed as the start of a nested flow map, so a strict parser rejects the whole document (PyYAML `safe_load` and go-yaml both fail at this line; a lenient parser tolerated it before).

Quoting the description string fixes it. No change to the rendered API docs.

Found while vendoring this spec into an OpenAPI→tools generator — a strict parser choked on it.

## Test plan
- [x] PyYAML `safe_load` parses the full spec after the change (failed before at line 528)
- [ ] Any OpenAPI lint/validate step in CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)