### PR TITLE
feat(dr): DR standby node — one-way async warm standby with manual promotion (GH #331)

### DIFF
--- a/docs/runbooks/dr-standby.md
+++ b/docs/runbooks/dr-standby.md
@@ -1,0 +1,145 @@
+# Disaster-recovery standby — operator runbook
+
+Covers the GH #331 DR standby: a **one-way async warm standby with manual
+promotion**. There is no automatic failover, no quorum, and no active/active —
+the operator pointing traffic at the promoted box is the fencing step. Read the
+blueprint at `plans/gh331-dr-standby-node.md` for the design rationale.
+
+## What it is (and is not)
+
+A standby is a **read-only replica** of a primary's control plane. It pulls the
+primary's system backups from a shared read-only backup destination and restores
+the panel database, panel config, and TLS material into a **non-serving** posture.
+It serves no live traffic and refuses tenant-provisioning writes until an operator
+runs `jabali dr promote`.
+
+It is NOT a load balancer, NOT a hot failover, and NOT a substitute for backups.
+The standby never holds a primary-mutating credential — the only channel between
+the two boxes is the one-way backup destination (least privilege).
+
+## Quick reference
+
+| What | Where |
+|---|---|
+| Role flag | `server_settings.server_role` = `primary` (default) \| `standby` |
+| Pairing | `server_settings.dr_destination_id` / `dr_peer_label` / `dr_paired_at` |
+| Sync liveness | `server_settings.dr_last_sync_at` / `dr_last_snapshot_id` / `dr_last_sync_status` / `dr_last_sync_error` |
+| CLI | `jabali dr status \| pair \| unpair \| feed \| promote` |
+| Write refusal | `middleware.StandbyReadOnly` — a standby 409s mutating API calls (allowlist: `/admin/dr`, `/admin/settings`) |
+| Pull loop | `panel-api/internal/drsync` — restores newest `system_backup` each tick; inert unless `server_role=standby` |
+| Reconciler gate | a standby's `ReconcileAll`/`ReconcileOne`/SSL loops early-return (no serving config, no ACME) |
+| Banner | `/me/server-capabilities` → `is_standby`; `DRStandbyBanner` renders on every page |
+| Migrations | `000254` (role + pairing), `000255` (sync liveness) |
+
+## Prerequisites
+
+1. A shared backup destination both boxes can reach, created on the PRIMARY with
+   `jabali backup destination create` (S3/B2/SFTP/etc). This is the DR channel.
+2. The standby box installed with the same Jabali version as the primary. A
+   standby running an older binary against a newer schema will fail to apply the
+   restore — keep versions in lockstep.
+
+## Setup
+
+### On the primary — start shipping to the DR channel
+
+```
+jabali dr feed --destination <dest-id>            # default: hourly
+jabali dr feed --destination <dest-id> --cron "*/30 * * * *"   # tune freshness
+```
+
+`dr feed` ensures an enabled `system_backup` schedule ships to the DR destination.
+It is idempotent — re-running just re-enables the existing schedule. Freshness of
+the standby is bounded by this cadence (how often a new manifest appears) plus the
+standby's 60s pull interval.
+
+### On the standby — pair it
+
+```
+jabali dr pair --destination <dest-id> --peer-label <primary-hostname>
+jabali dr status                                  # role=standby, destination set
+```
+
+Pairing flips `server_role` to `standby`. From this point:
+
+- the drsync loop begins pulling: it lists the DR destination's `system_backup`
+  manifests and, when a newer one exists than it last applied, runs
+  `system.restore {apply:true, include_accounts:false}` (panel DB + config + TLS);
+- the reconciler goes dormant (no serving config, no ACME certificate issuance);
+- the API refuses tenant writes with `409 server_is_standby`;
+- every page shows the read-only DR banner.
+
+Watch convergence with `jabali dr status` — `Last sync status` should reach `ok`
+(applied a snapshot) or `current` (already newest). `waiting` means the primary
+has not shipped a manifest yet; check `jabali dr feed` ran on the primary.
+
+## Promotion (disaster)
+
+Promotion is **irreversible** and the one action that can cause split-brain, so it
+is confirm-gated and guarded.
+
+**Before promoting, confirm the old primary is DOWN** — powered off or
+network-isolated. Two live boxes serving the same domains is the exact failure this
+design exists to avoid.
+
+```
+jabali dr promote
+```
+
+Sequence:
+
+1. Refuses if this box is not a standby.
+2. **Split-brain guard**: TCP-probes the peer (`dr_peer_label`, ports 443/22). If
+   the old primary still answers, promotion is refused unless `--force`.
+3. Interactive confirmation (`--yes` to script it).
+4. **Final account-inclusive restore** from the DR destination:
+   `system.restore {apply:true, include_accounts:true}` — brings home dirs, mail,
+   and per-user databases online (the periodic sync deliberately skipped these).
+   `--skip-restore` flips the role without this step.
+5. **Role flip** to `primary`. This stops the drsync loop (it re-reads the role),
+   lets writes through again, and wakes the reconciler.
+6. Within ~1 minute the reconciler builds every domain's nginx vhost, DNS zone,
+   and certificate from the replicated database.
+
+Flags:
+
+- `--force` — promote even if the old primary still answers (operator asserts it
+  is isolated). Use only after confirming the old box is truly down.
+- `--yes` — skip the interactive confirmation (scriptable).
+- `--skip-restore` — role flip only, no final restore.
+
+### Cut traffic over
+
+The panel cannot move DNS you host elsewhere. After promotion:
+
+- Point the domains' **A/AAAA** records (and **NS** if the zones are self-hosted)
+  at the promoted box's IP.
+- Point **MX** at the promoted box if it runs mail.
+- Verify: `jabali dr status` shows `role: primary`; `systemctl status jabali-panel`
+  is active; a test domain serves from the new box.
+
+## Reverting a standby to primary (no disaster)
+
+If you paired a box by mistake, or are decommissioning the standby:
+
+```
+jabali dr unpair        # role → primary, clears pairing; reconciler resumes
+```
+
+## Failure modes & checks
+
+| Symptom | Check |
+|---|---|
+| `dr status` sync status `waiting` forever | `jabali dr feed` ran on the primary? Destination reachable from the standby? |
+| `dr status` sync status `error` | `dr_last_sync_error` names it — usually destination unreachable or a version skew restore failure. |
+| Standby accepts a write | It should 409. If not, confirm `server_role=standby` in `server_settings` and that `StandbyReadOnly` is wired (`panel-api/internal/app/app.go`). |
+| Promotion refused "primary still answers" | The old primary is reachable on 443/22. Confirm it is down, or `--force` if you have isolated it. |
+| Post-promote: domains 404 | Give the reconciler a tick, then `systemctl status jabali-panel`; force with the reconciler's periodic pass or restart the service. |
+
+## Testing note
+
+Steps 2–4 ship behind unit/integration coverage only: a real pull-restore +
+promotion drill needs a second host, which the CI/testserver environment does not
+have. Do a live drill on two throwaway VMs before relying on this in production —
+in particular, verify the final account-inclusive restore and the DNS/MX cutover
+against a real domain.

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2291,6 +2291,20 @@ jabali dr pair [flags]
 - `--destination` — backup destination ID used as the read-only DR channel
 - `--peer-label` — human label for the primary this box replicates (e.g. its hostname)
 
+#### `jabali dr promote`
+
+Promote this DR standby to the live primary (GH #331)
+
+```
+jabali dr promote [flags]
+```
+
+**Flags:**
+
+- `--force` — promote even if the old primary still answers (operator asserts it is down)
+- `--skip-restore` — skip the final account-inclusive restore (role flip only)
+- `--yes` — skip the interactive confirmation (scriptable)
+
 #### `jabali dr status`
 
 Show this box's DR role + pairing

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2257,6 +2257,43 @@ WHOIS lookup for a domain
 jabali domain whois <domain-name|domain-id>
 ```
 
+### `jabali dr`
+
+Disaster-recovery standby: pair, status, promote (GH #331)
+
+```
+jabali dr
+```
+
+#### `jabali dr pair`
+
+Designate this box a DR standby of a primary
+
+```
+jabali dr pair [flags]
+```
+
+**Flags:**
+
+- `--destination` — backup destination ID used as the read-only DR channel
+- `--peer-label` — human label for the primary this box replicates (e.g. its hostname)
+
+#### `jabali dr status`
+
+Show this box's DR role + pairing
+
+```
+jabali dr status
+```
+
+#### `jabali dr unpair`
+
+Revert this box to a primary (clears standby role)
+
+```
+jabali dr unpair
+```
+
 ### `jabali files`
 
 Scoped tenant file manager (list/read/mkdir/move/chmod/archive/…) — same policy as the GUI

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2265,6 +2265,19 @@ Disaster-recovery standby: pair, status, promote (GH #331)
 jabali dr
 ```
 
+#### `jabali dr feed`
+
+Primary side: ship system backups to the DR destination on a cadence
+
+```
+jabali dr feed [flags]
+```
+
+**Flags:**
+
+- `--cron` — cron cadence for the DR feed (default hourly, "0 * * * *")
+- `--destination` — DR backup destination ID to ship system backups to
+
 #### `jabali dr pair`
 
 Designate this box a DR standby of a primary

--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -31,8 +34,12 @@ func newDRCmd() *cobra.Command {
 			"primary's state from a read-only backup destination and serves no live " +
 			"traffic until `dr promote`. No automatic failover, no split-brain.",
 	}
-	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd())
+	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd(), newDRFeedCmd())
 	return cmd
+}
+
+func scheduleRepoFromDB() repository.BackupScheduleRepository {
+	return repository.NewBackupScheduleRepository(sharedDB)
 }
 
 func newDRStatusCmd() *cobra.Command {
@@ -59,13 +66,21 @@ func newDRStatusCmd() *cobra.Command {
 			if s.DRPairedAt != nil {
 				paired = s.DRPairedAt.UTC().Format(time.RFC3339)
 			}
+			lastSync := ""
+			if s.DRLastSyncAt != nil {
+				lastSync = s.DRLastSyncAt.UTC().Format(time.RFC3339)
+			}
 			if jsonOutput {
 				return printJSON(map[string]any{
-					"server_role":       s.IsStandby(),
-					"role":              orDefault(s.ServerRole, models.ServerRolePrimary),
-					"dr_peer_label":     s.DRPeerLabel,
-					"dr_destination_id": strOrEmpty(s.DRDestinationID),
-					"dr_paired_at":      paired,
+					"server_role":         s.IsStandby(),
+					"role":                orDefault(s.ServerRole, models.ServerRolePrimary),
+					"dr_peer_label":       s.DRPeerLabel,
+					"dr_destination_id":   strOrEmpty(s.DRDestinationID),
+					"dr_paired_at":        paired,
+					"dr_last_sync_at":     lastSync,
+					"dr_last_snapshot_id": s.DRLastSnapshotID,
+					"dr_last_sync_status": s.DRLastSyncStatus,
+					"dr_last_sync_error":  s.DRLastSyncError,
 				})
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -73,6 +88,16 @@ func newDRStatusCmd() *cobra.Command {
 			fmt.Fprintf(w, "Peer:\t%s\n", orDefault(s.DRPeerLabel, "-"))
 			fmt.Fprintf(w, "DR destination:\t%s\n", orDefault(destLabel, "-"))
 			fmt.Fprintf(w, "Paired at:\t%s\n", orDefault(paired, "-"))
+			// Sync liveness is only meaningful on a standby (the loop is inert
+			// on a primary), so only surface it there.
+			if s.IsStandby() {
+				fmt.Fprintf(w, "Last sync:\t%s\n", orDefault(lastSync, "never"))
+				fmt.Fprintf(w, "Last sync status:\t%s\n", orDefault(s.DRLastSyncStatus, "-"))
+				fmt.Fprintf(w, "Applied snapshot:\t%s\n", orDefault(s.DRLastSnapshotID, "-"))
+				if s.DRLastSyncError != "" {
+					fmt.Fprintf(w, "Last sync error:\t%s\n", s.DRLastSyncError)
+				}
+			}
 			return w.Flush()
 		},
 	}
@@ -146,6 +171,106 @@ func newDRUnpairCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// newDRFeedCmd runs on the PRIMARY. It ensures a system_backup schedule ships
+// the primary's control-plane state to the DR destination on a cadence, which is
+// exactly what the standby's drsync loop pulls from. Idempotent: a re-run against
+// a destination already fed just re-enables the existing schedule.
+func newDRFeedCmd() *cobra.Command {
+	var destID, cron string
+	cmd := &cobra.Command{
+		Use:   "feed",
+		Short: "Primary side: ship system backups to the DR destination on a cadence",
+		Long: "Run on the PRIMARY. Ensures an enabled system_backup schedule targets the " +
+			"DR backup destination so the standby always has a fresh manifest to pull. " +
+			"Idempotent — re-running re-enables the existing schedule rather than adding a " +
+			"duplicate. The standby reads this same destination; it is never given a " +
+			"primary-mutating credential.",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if destID == "" {
+				return fmt.Errorf("--destination is required (the DR backup destination to ship to)")
+			}
+			cron = strings.TrimSpace(cron)
+			if cron == "" {
+				cron = "0 * * * *" // hourly — a sane DR freshness default; tune with --cron
+			}
+			if _, err := internalbackup.NextFire(cron, time.Now().UTC()); err != nil {
+				return fmt.Errorf("invalid --cron %q: %w", cron, err)
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+
+			dest, derr := backupDestinationRepoFromDB().Get(ctx, destID)
+			if derr != nil || dest == nil {
+				return fmt.Errorf("backup destination %q not found; create it first with `jabali backup destination create`", destID)
+			}
+
+			schedRepo := scheduleRepoFromDB()
+			// Idempotency: reuse an existing system_backup schedule already
+			// linked to this destination rather than stacking duplicates.
+			existing, ferr := findSystemScheduleForDest(ctx, schedRepo, destID)
+			if ferr != nil {
+				return ferr
+			}
+			if existing != nil {
+				if !existing.Enabled {
+					existing.Enabled = true
+					if err := schedRepo.Update(ctx, existing); err != nil {
+						return fmt.Errorf("re-enable existing DR feed schedule: %w", err)
+					}
+				}
+				fmt.Printf("DR feed already configured (schedule %s → %s); ensured enabled.\n", existing.ID, dest.Name)
+				return nil
+			}
+
+			next, _ := internalbackup.NextFire(cron, time.Now().UTC())
+			s := &models.BackupSchedule{
+				ID:        ids.NewULID(),
+				Kind:      models.BackupScheduleKindSystem,
+				CronExpr:  cron,
+				Enabled:   true,
+				NextRunAt: &next,
+			}
+			if err := schedRepo.Create(ctx, s); err != nil {
+				return fmt.Errorf("create DR feed schedule: %w", err)
+			}
+			if err := schedRepo.ReplaceDestinations(ctx, s.ID, []string{destID}); err != nil {
+				return fmt.Errorf("link DR feed schedule to destination: %w", err)
+			}
+			fmt.Printf("DR feed configured: system_backup schedule %s ships to %s on cron %q.\n", s.ID, dest.Name, cron)
+			fmt.Println("Pair the standby against this same destination with `jabali dr pair --destination <id>`.")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&destID, "destination", "", "DR backup destination ID to ship system backups to")
+	cmd.Flags().StringVar(&cron, "cron", "", "cron cadence for the DR feed (default hourly, \"0 * * * *\")")
+	return cmd
+}
+
+// findSystemScheduleForDest returns the first enabled-or-disabled system_backup
+// schedule whose destination set includes destID, or nil if none exists.
+func findSystemScheduleForDest(ctx context.Context, repo repository.BackupScheduleRepository, destID string) (*models.BackupSchedule, error) {
+	all, err := repo.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list backup schedules: %w", err)
+	}
+	for i := range all {
+		if all[i].Kind != models.BackupScheduleKindSystem {
+			continue
+		}
+		dests, derr := repo.GetDestinations(ctx, all[i].ID)
+		if derr != nil {
+			return nil, fmt.Errorf("read schedule destinations: %w", derr)
+		}
+		for _, d := range dests {
+			if d.ID == destID {
+				return &all[i], nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 func orDefault(v, def string) string {

--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -34,7 +34,7 @@ func newDRCmd() *cobra.Command {
 			"primary's state from a read-only backup destination and serves no live " +
 			"traffic until `dr promote`. No automatic failover, no split-brain.",
 	}
-	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd(), newDRFeedCmd())
+	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd(), newDRFeedCmd(), newDRPromoteCmd())
 	return cmd
 }
 

--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #331 — DR / standby node CLI. `dr pair` designates this box a one-way async
+// standby that pulls the primary's state from a read-only backup destination;
+// `dr status` reports the role; `dr unpair` reverts to primary. Promotion lives
+// in `dr promote` (Step 4). Pairing issues NO primary-mutating credential — the
+// standby only ever reads/restores from the shared destination (least privilege).
+
+func serverSettingsRepoFromDB() repository.ServerSettingsRepository {
+	return repository.NewServerSettingsRepository(sharedDB)
+}
+
+func newDRCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dr",
+		Short: "Disaster-recovery standby: pair, status, promote (GH #331)",
+		Long: "One-way async DR standby with manual promotion. A standby pulls the " +
+			"primary's state from a read-only backup destination and serves no live " +
+			"traffic until `dr promote`. No automatic failover, no split-brain.",
+	}
+	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd())
+	return cmd
+}
+
+func newDRStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "status",
+		Short:   "Show this box's DR role + pairing",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			s, err := serverSettingsRepoFromDB().Get(ctx)
+			if err != nil || s == nil {
+				return fmt.Errorf("read server settings: %w", err)
+			}
+			destLabel := ""
+			if s.DRDestinationID != nil {
+				if d, derr := backupDestinationRepoFromDB().Get(ctx, *s.DRDestinationID); derr == nil && d != nil {
+					destLabel = fmt.Sprintf("%s (%s)", d.Name, d.Kind)
+				} else {
+					destLabel = *s.DRDestinationID
+				}
+			}
+			paired := ""
+			if s.DRPairedAt != nil {
+				paired = s.DRPairedAt.UTC().Format(time.RFC3339)
+			}
+			if jsonOutput {
+				return printJSON(map[string]any{
+					"server_role":       s.IsStandby(),
+					"role":              orDefault(s.ServerRole, models.ServerRolePrimary),
+					"dr_peer_label":     s.DRPeerLabel,
+					"dr_destination_id": strOrEmpty(s.DRDestinationID),
+					"dr_paired_at":      paired,
+				})
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintf(w, "Role:\t%s\n", orDefault(s.ServerRole, models.ServerRolePrimary))
+			fmt.Fprintf(w, "Peer:\t%s\n", orDefault(s.DRPeerLabel, "-"))
+			fmt.Fprintf(w, "DR destination:\t%s\n", orDefault(destLabel, "-"))
+			fmt.Fprintf(w, "Paired at:\t%s\n", orDefault(paired, "-"))
+			return w.Flush()
+		},
+	}
+}
+
+func newDRPairCmd() *cobra.Command {
+	var destID, peerLabel string
+	cmd := &cobra.Command{
+		Use:   "pair",
+		Short: "Designate this box a DR standby of a primary",
+		Long: "Flip this box to a standby replica. --destination is an existing backup " +
+			"destination (the DR channel: the primary ships system backups to it, this " +
+			"standby pulls from it). The standby serves no live traffic until `dr promote`.",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if destID == "" {
+				return fmt.Errorf("--destination is required (the read-only DR backup destination)")
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			// The DR destination must exist — a standby that can't reach the feed
+			// is useless, and we never want to record a dangling pointer.
+			dest, derr := backupDestinationRepoFromDB().Get(ctx, destID)
+			if derr != nil || dest == nil {
+				return fmt.Errorf("backup destination %q not found; create it first with `jabali backup destination create`", destID)
+			}
+			repo := serverSettingsRepoFromDB()
+			s, err := repo.Get(ctx)
+			if err != nil || s == nil {
+				return fmt.Errorf("read server settings: %w", err)
+			}
+			now := time.Now().UTC()
+			s.ServerRole = models.ServerRoleStandby
+			s.DRDestinationID = &destID
+			s.DRPeerLabel = peerLabel
+			s.DRPairedAt = &now
+			if err := repo.Upsert(ctx, s); err != nil {
+				return fmt.Errorf("save DR pairing: %w", err)
+			}
+			fmt.Printf("This box is now a DR STANDBY (peer=%q, destination=%s).\n", orDefault(peerLabel, "unlabelled"), dest.Name)
+			fmt.Println("It will refuse tenant-provisioning writes and serve no live traffic until `jabali dr promote`.")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&destID, "destination", "", "backup destination ID used as the read-only DR channel")
+	cmd.Flags().StringVar(&peerLabel, "peer-label", "", "human label for the primary this box replicates (e.g. its hostname)")
+	return cmd
+}
+
+func newDRUnpairCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "unpair",
+		Short:   "Revert this box to a primary (clears standby role)",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			repo := serverSettingsRepoFromDB()
+			s, err := repo.Get(ctx)
+			if err != nil || s == nil {
+				return fmt.Errorf("read server settings: %w", err)
+			}
+			s.ServerRole = models.ServerRolePrimary
+			s.DRDestinationID = nil
+			s.DRPeerLabel = ""
+			s.DRPairedAt = nil
+			if err := repo.Upsert(ctx, s); err != nil {
+				return fmt.Errorf("clear DR pairing: %w", err)
+			}
+			fmt.Println("This box is now a PRIMARY. DR pairing cleared.")
+			return nil
+		},
+	}
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func strOrEmpty(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/panel-api/cmd/server/dr_promote.go
+++ b/panel-api/cmd/server/dr_promote.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #331 Step 4 — `jabali dr promote`. Turns a DR standby into the live primary:
+// a final account-inclusive restore, then the role flip that (a) stops the drsync
+// loop, (b) lets StandbyReadOnly pass writes again, and (c) wakes the reconciler
+// to build every domain's serving config from the replicated DB. This is the ONE
+// deliberately-irreversible DR action, so it is confirm-gated and guarded against
+// split-brain: if the old primary still answers, promotion is refused without
+// --force (two live primaries for the same domains is the failure this whole
+// design exists to avoid — the operator points traffic, and must first ensure the
+// old primary is down).
+
+// peerAliveProbe reports whether the paired primary still answers on the network.
+// Injectable so promotionGate's decision can be unit-tested without a live peer.
+var peerAliveProbe = tcpPeerAlive
+
+// peerProbePorts are the TCP ports a live primary would answer on. A successful
+// connect to any of them means the box is up (443 = panel/nginx, 22 = sshd).
+var peerProbePorts = []string{"443", "22"}
+
+func newDRPromoteCmd() *cobra.Command {
+	var yes, force, skipRestore bool
+	cmd := &cobra.Command{
+		Use:   "promote",
+		Short: "Promote this DR standby to the live primary (GH #331)",
+		Long: "Promote this standby: run a final account-inclusive restore from the DR " +
+			"destination, then flip the role to primary. The drsync loop stops, tenant " +
+			"writes are accepted again, and the reconciler builds every domain's serving " +
+			"config from the replicated database on its next tick.\n\n" +
+			"SPLIT-BRAIN GUARD: if the old primary still answers on the network, promotion " +
+			"is refused unless --force. Point DNS/MX at this box only AFTER the old primary " +
+			"is confirmed down. This action is irreversible.",
+		PreRunE: requireDBAndAgent,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
+			defer cancel()
+
+			repo := serverSettingsRepoFromDB()
+			s, err := repo.Get(ctx)
+			if err != nil || s == nil {
+				return fmt.Errorf("read server settings: %w", err)
+			}
+			if !s.IsStandby() {
+				return fmt.Errorf("this box is not a DR standby (role=%s); nothing to promote", orDefault(s.ServerRole, models.ServerRolePrimary))
+			}
+
+			// Split-brain guard. Only probe when not forcing — --force is the
+			// operator asserting the old primary is already down.
+			peerAlive := false
+			if !force {
+				peerAlive = peerAliveProbe(ctx, s.DRPeerLabel)
+			}
+			allowed, reason := promotionGate(s.IsStandby(), peerAlive, force)
+			if !allowed {
+				return fmt.Errorf("%s", reason)
+			}
+
+			// Confirmation. --yes is the scriptable bypass.
+			if !yes {
+				fmt.Printf("About to promote this DR standby to PRIMARY (peer=%s).\n", orDefault(s.DRPeerLabel, "unlabelled"))
+				if peerAlive {
+					fmt.Println("WARNING: the old primary still appears to answer; --force was given. Ensure it is truly isolated.")
+				} else {
+					fmt.Println("Could not confirm the old primary is alive. Promoting TWO live primaries causes split-brain —")
+					fmt.Println("make sure the old primary is powered off or network-isolated before continuing.")
+				}
+				ok, cerr := confirmYes(os.Stdin, "Type 'yes' to promote (anything else aborts): ")
+				if cerr != nil {
+					return cerr
+				}
+				if !ok {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
+
+			// Final account-inclusive restore so home dirs, mail, and per-user DBs
+			// land (drsync only applied panel_db+config+tls during replication).
+			if !skipRestore {
+				if err := promoteRestoreAccounts(ctx, s); err != nil {
+					return fmt.Errorf("final restore failed (box NOT promoted; fix and re-run, or --skip-restore to promote without it): %w", err)
+				}
+			}
+
+			// Flip the role. Clearing the DR pairing makes drsync inert (it re-reads
+			// role each tick) and StandbyReadOnly pass again; the reconciler wakes on
+			// its next tick and converges serving config. Last-sync history is kept.
+			s.ServerRole = models.ServerRolePrimary
+			s.DRDestinationID = nil
+			s.DRPairedAt = nil
+			if err := repo.Upsert(ctx, s); err != nil {
+				return fmt.Errorf("flip role to primary: %w", err)
+			}
+
+			fmt.Println("PROMOTED: this box is now the PRIMARY.")
+			fmt.Println("Next:")
+			fmt.Println("  • The reconciler will build nginx vhosts, DNS zones, and certificates within a minute.")
+			fmt.Println("  • Point DNS A/AAAA (and NS if self-hosted) + MX at this box's IP to take live traffic.")
+			fmt.Println("  • Verify with `jabali dr status` (role=primary) and `systemctl status jabali-panel`.")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip the interactive confirmation (scriptable)")
+	cmd.Flags().BoolVar(&force, "force", false, "promote even if the old primary still answers (operator asserts it is down)")
+	cmd.Flags().BoolVar(&skipRestore, "skip-restore", false, "skip the final account-inclusive restore (role flip only)")
+	return cmd
+}
+
+// promotionGate is the pure split-brain decision. Separated from I/O so the
+// safety logic is unit-tested. A standby whose old primary still answers is
+// refused unless the operator forces it.
+func promotionGate(isStandby, peerAlive, force bool) (allowed bool, reason string) {
+	if !isStandby {
+		return false, "this box is not a DR standby; nothing to promote"
+	}
+	if peerAlive && !force {
+		return false, "the paired primary still answers on the network — promoting now risks split-brain. " +
+			"Confirm the old primary is powered off or isolated, then re-run with --force."
+	}
+	return true, ""
+}
+
+// promoteRestoreAccounts dispatches a final system.restore with apply + accounts
+// from the DR destination, resolving the newest manifest. Mirrors drsync's
+// restore but includes account data (home + mail + per-user DBs).
+func promoteRestoreAccounts(ctx context.Context, s *models.ServerSettings) error {
+	if s.DRDestinationID == nil || *s.DRDestinationID == "" {
+		return fmt.Errorf("standby has no DR destination; cannot run the final restore (use --skip-restore to promote anyway)")
+	}
+	dest, derr := backupDestinationRepoFromDB().Get(ctx, *s.DRDestinationID)
+	if derr != nil || dest == nil {
+		return fmt.Errorf("DR destination %s not found", *s.DRDestinationID)
+	}
+	fmt.Println("Running final account-inclusive restore from the DR destination (this can take a while)…")
+	return backupwrapperhelpers.WithDestPasswordFile(ctx, dest, sharedAgent, ssoKeyForCLI(),
+		func(passwordFile string) error {
+			params := map[string]any{
+				"job_id":               ids.NewULID(),
+				"manifest_snapshot_id": "latest",
+				"apply":                true,
+				"include_accounts":     true,
+				"repo_url":             dest.URL,
+				"destination_kind":     dest.Kind,
+				"sftp":                 backupwrapperhelpers.SFTPWireParams(dest),
+			}
+			if dest.CredentialsRef != nil {
+				params["credentials_ref"] = *dest.CredentialsRef
+			}
+			if passwordFile != "" {
+				params["password_file"] = passwordFile
+			}
+			_, err := sharedAgent.Call(ctx, "system.restore", params)
+			return err
+		})
+}
+
+// tcpPeerAlive reports whether the peer answers a TCP connect on any well-known
+// port — the truest "is the box up" signal without decrypting anything. Only a
+// dial failure/timeout on every port (or an unusable label) counts as "not
+// alive". A raw connect is deliberately used over HTTP so there is no TLS trust
+// to weaken; identity doesn't matter here, only reachability.
+func tcpPeerAlive(ctx context.Context, peerLabel string) bool {
+	host := strings.TrimSpace(peerLabel)
+	// A freeform/empty label we can't turn into a host:port → cannot confirm alive.
+	if host == "" || strings.ContainsAny(host, " /:") {
+		return false
+	}
+	var d net.Dialer
+	for _, port := range peerProbePorts {
+		cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		conn, err := d.DialContext(cctx, "tcp", net.JoinHostPort(host, port))
+		cancel()
+		if err == nil {
+			_ = conn.Close()
+			return true // the box answered → up
+		}
+	}
+	return false
+}
+
+// confirmYes reads a line and returns true only when it is exactly "yes"
+// (case-insensitive, trimmed).
+func confirmYes(in *os.File, prompt string) (bool, error) {
+	fmt.Print(prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && line == "" {
+		return false, err
+	}
+	return strings.EqualFold(strings.TrimSpace(line), "yes"), nil
+}

--- a/panel-api/cmd/server/dr_promote_test.go
+++ b/panel-api/cmd/server/dr_promote_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+// GH #331 Step 4: the split-brain gate is the safety-critical part of promote.
+func TestPromotionGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		isStandby   bool
+		peerAlive   bool
+		force       bool
+		wantAllowed bool
+	}{
+		{"not a standby is refused", false, false, false, false},
+		{"not a standby refused even with force", false, false, true, false},
+		{"standby, peer down → promote", true, false, false, true},
+		{"standby, peer ALIVE, no force → refuse (split-brain)", true, true, false, false},
+		{"standby, peer alive, force → promote", true, true, true, true},
+		{"standby, peer down, force → promote", true, false, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			allowed, reason := promotionGate(c.isStandby, c.peerAlive, c.force)
+			if allowed != c.wantAllowed {
+				t.Fatalf("promotionGate(standby=%v,alive=%v,force=%v) allowed=%v want %v (reason=%q)",
+					c.isStandby, c.peerAlive, c.force, allowed, c.wantAllowed, reason)
+			}
+			if !allowed && reason == "" {
+				t.Error("a refusal must carry a reason")
+			}
+			if allowed && reason != "" {
+				t.Errorf("an allow must have no reason, got %q", reason)
+			}
+		})
+	}
+}
+
+// tcpPeerAlive must treat an unusable label as "not alive" without dialing, so a
+// missing/freeform peer label never blocks promotion on its own.
+func TestTCPPeerAlive_UnusableLabel(t *testing.T) {
+	for _, bad := range []string{"", "   ", "not a host", "host/with/slash", "host:1234"} {
+		if tcpPeerAlive(t.Context(), bad) {
+			t.Errorf("label %q must be treated as not-alive", bad)
+		}
+	}
+}

--- a/panel-api/cmd/server/root.go
+++ b/panel-api/cmd/server/root.go
@@ -157,6 +157,7 @@ func newRootCmd() *cobra.Command {
 		newIPManagerCmd(),
 		newServiceCmd(),
 		newMailAdminCmd(),
+		newDRCmd(),
 	)
 	rejectUnknownSubcommands(cmd)
 

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -27,6 +27,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/db"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/drsync"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailscan"
@@ -977,6 +978,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 		go fin.Start(ctx)
 	} else {
 		log.Info("backup finalizer not started — required deps missing")
+	}
+
+	// GH #331 Step 2: DR standby pull-restore loop. Inert on a primary (it
+	// re-reads server_role each tick), so it is always safe to start; on a
+	// standby it converges the panel DB/config/TLS from the DR destination.
+	if syncer := drsync.New(drsync.Deps{
+		Settings:     deps.ServerSettings,
+		Destinations: deps.BackupDestinations,
+		Agent:        deps.Agent,
+		SSOKey:       deps.SSOKey,
+		Log:          log,
+	}); syncer != nil {
+		go syncer.Start(ctx)
+	} else {
+		log.Info("DR sync loop not started — required deps missing")
 	}
 
 	// M33.2 (ADR-0079): mail YARA scanner tick. Off by default; the tick

--- a/panel-api/internal/api/automation_standby_test.go
+++ b/panel-api/internal/api/automation_standby_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #331: the Automation API mounts outside the auth-protected v1 group, so it
+// carries its own StandbyReadOnly guard (app.go). A standby must refuse an
+// automation WRITE — otherwise a headless provisioning call would diverge from
+// the primary and be discarded by the next sync. Reads still pass (the guard
+// only blocks mutating methods).
+func awStandbyRouter(t *testing.T, role string, cfg AutomationConfig) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("")
+	grp.Use(middleware.StandbyReadOnly(
+		&mockServerSettingsRepo{getResult: &models.ServerSettings{ServerRole: role}}, nil))
+	grp.Use(func(c *gin.Context) { c.Set("jabali_automation_token", writeTok()); c.Next() })
+	registerAutomationWrites(grp, cfg)
+	return r
+}
+
+func TestAutomationWrite_StandbyRefuses(t *testing.T) {
+	ag := &awAgent{}
+	r := awStandbyRouter(t, models.ServerRoleStandby, AutomationConfig{Agent: ag, Audits: &awAudit{}})
+	w := awPost(r, "/services/nginx/restart")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("standby must 409 an automation write, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("standby must not reach the handler (no agent call), got %v", ag.calls)
+	}
+}
+
+func TestAutomationWrite_PrimaryAllows(t *testing.T) {
+	ag := &awAgent{}
+	r := awStandbyRouter(t, models.ServerRolePrimary, AutomationConfig{Agent: ag, Audits: &awAudit{}})
+	if code := awPost(r, "/services/nginx/restart").Code; code != http.StatusOK {
+		t.Fatalf("primary must pass the automation write, got %d", code)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("primary must reach the handler, agent calls = %v", ag.calls)
+	}
+}
+
+// A read-only automation call is allowed even on a standby.
+func TestAutomationRead_StandbyAllows(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("")
+	grp.Use(middleware.StandbyReadOnly(
+		&mockServerSettingsRepo{getResult: &models.ServerSettings{ServerRole: models.ServerRoleStandby}}, nil))
+	hit := false
+	grp.GET("/status/health", func(c *gin.Context) { hit = true; c.Status(http.StatusOK) })
+	req := httptest.NewRequest(http.MethodGet, "/status/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !hit {
+		t.Fatalf("standby must allow an automation READ, got %d hit=%v", w.Code, hit)
+	}
+}

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1117,7 +1117,8 @@ func (f *fakeSettingsRepo) Upsert(ctx context.Context, s *models.ServerSettings)
 	f.s = s
 	return nil
 }
-func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error            { return nil }
+func (f *fakeSettingsRepo) RecordDRSync(context.Context, string, string, string) error { return nil }
 
 func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -60,7 +60,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": ""})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": ""})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -107,6 +107,11 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		// public demo, mask them so the dashboard never leaks the real infra IP.
 		"public_ipv4": demoMaskIPv4(h.cfg.DemoEnabled, settings.PublicIPv4),
 		"public_ipv6": demoMaskIPv6(h.cfg.DemoEnabled, settings.PublicIPv6),
+		// GH #331 Step 3: DR standby banner. Every signed-in user's SPA reads
+		// this to render a read-only-replica banner; a standby also 409s their
+		// mutations (middleware.StandbyReadOnly), so the banner explains why.
+		"is_standby":    settings.IsStandby(),
+		"dr_peer_label": settings.DRPeerLabel,
 	})
 }
 

--- a/panel-api/internal/api/me_dr_capability_test.go
+++ b/panel-api/internal/api/me_dr_capability_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #331 Step 3: /me/server-capabilities exposes is_standby (+ peer label) so
+// every signed-in user's SPA can render the read-only-replica banner.
+func TestServerCapabilities_DRStandbyFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	call := func(role, peer string) map[string]any {
+		h := &meExtHandler{cfg: MeHandlerConfig{
+			ServerSettings: &mockServerSettingsRepo{getResult: &models.ServerSettings{
+				ID: 1, ServerRole: role, DRPeerLabel: peer,
+			}},
+		}}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/me/server-capabilities", nil)
+		h.serverCapabilities(c)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body
+	}
+
+	standby := call(models.ServerRoleStandby, "primary-mx.example.com")
+	if standby["is_standby"] != true {
+		t.Errorf("standby: is_standby = %v, want true", standby["is_standby"])
+	}
+	if standby["dr_peer_label"] != "primary-mx.example.com" {
+		t.Errorf("standby: dr_peer_label = %v", standby["dr_peer_label"])
+	}
+
+	primary := call(models.ServerRolePrimary, "")
+	if primary["is_standby"] != false {
+		t.Errorf("primary: is_standby = %v, want false", primary["is_standby"])
+	}
+}

--- a/panel-api/internal/api/notifications_webpush_test.go
+++ b/panel-api/internal/api/notifications_webpush_test.go
@@ -28,9 +28,12 @@ func (f *fakeWPSettingsRepo) Get(context.Context) (*models.ServerSettings, error
 	return f.row, nil
 }
 func (f *fakeWPSettingsRepo) Upsert(context.Context, *models.ServerSettings) error { return nil }
-func (f *fakeWPSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+func (f *fakeWPSettingsRepo) SetDigestLastSent(context.Context, string) error      { return nil }
+func (f *fakeWPSettingsRepo) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
 
-func (f *fakeWPSettingsRepo) EnsureVAPID(context.Context, string) (bool, error)    { return false, nil }
+func (f *fakeWPSettingsRepo) EnsureVAPID(context.Context, string) (bool, error) { return false, nil }
 
 type fakeSubsRepo struct {
 	mu           sync.Mutex

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -44,6 +44,9 @@ func (m *mockServerSettingsRepo) Upsert(ctx context.Context, s *models.ServerSet
 }
 
 func (m *mockServerSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+func (m *mockServerSettingsRepo) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
 
 func (m *mockServerSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -401,6 +401,15 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		// group so the path matcher hits the unauth group first.
 		if deps.AutomationTokens != nil && deps.SSOKey != nil {
 			autoGroup := r.Group("/api/v1")
+			// GH #331: the Automation API is a headless write path that mounts
+			// OUTSIDE the v1 group, so it needs its own DR-standby guard — a
+			// standby's DB is a replica, and an automation-driven provisioning
+			// write here would diverge from the primary and be discarded by the
+			// next sync. Reads (read:status/read:mail) stay allowed (the guard
+			// only blocks mutating methods). Nil ServerSettings (tests) → ungated.
+			if deps.ServerSettings != nil {
+				autoGroup.Use(middleware.StandbyReadOnly(deps.ServerSettings, deps.Log))
+			}
 			api.RegisterAutomation(autoGroup, api.AutomationConfig{
 				AutomationTokens: deps.AutomationTokens,
 				Key:              deps.SSOKey,

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -480,6 +480,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		// the body). No-op when AuditRecorder is nil (no Redis).
 		v1.Use(middleware.AuditRecord(deps.AuditRecorder))
 
+		// GH #331 — DR standby read-only guard. When this box is a standby its
+		// panel DB is a replica; refuse tenant-mutating writes (they'd diverge
+		// and be overwritten by the next sync). No-op on a primary (the default),
+		// so every normal install is unaffected.
+		if deps.ServerSettings != nil {
+			v1.Use(middleware.StandbyReadOnly(deps.ServerSettings, deps.Log))
+		}
+
 		// M353 Phase 1 (GH #353): module guards. A disabled module's routes must
 		// 409, not just be hidden in the UI. Build one guard factory (shared TTL
 		// cache) and mount each module's routes on a guarded sub-group. Fails

--- a/panel-api/internal/db/migrations/000254_dr_server_role.down.sql
+++ b/panel-api/internal/db/migrations/000254_dr_server_role.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE server_settings
+  DROP COLUMN server_role,
+  DROP COLUMN dr_paired_at,
+  DROP COLUMN dr_peer_label,
+  DROP COLUMN dr_destination_id;

--- a/panel-api/internal/db/migrations/000254_dr_server_role.up.sql
+++ b/panel-api/internal/db/migrations/000254_dr_server_role.up.sql
@@ -1,0 +1,17 @@
+-- GH #331 DR standby, Step 1: server role + one-way pairing foundation.
+--
+-- server_role: 'primary' (default — every existing install is unchanged and
+--   fully active) or 'standby' (a one-way async DR replica that pulls the
+--   primary's state and does not serve live traffic until manually promoted).
+--   The whole DR feature is inert until an operator runs `jabali dr pair`.
+-- dr_paired_at / dr_peer_label: when this box was paired + a human label for the
+--   peer it replicates from (primary's hostname, for the admin readout).
+-- dr_destination_id: the backup_destination this box uses as the one-way DR
+--   channel — the primary SHIPS system backups to it, the standby PULLS from it.
+--   NULL on a primary that hasn't configured DR. Read/restore-only for a standby;
+--   the standby never holds a primary-mutating credential (least privilege).
+ALTER TABLE server_settings
+  ADD COLUMN server_role       VARCHAR(16)  NOT NULL DEFAULT 'primary',
+  ADD COLUMN dr_paired_at      DATETIME(6)  NULL,
+  ADD COLUMN dr_peer_label     VARCHAR(255) NOT NULL DEFAULT '',
+  ADD COLUMN dr_destination_id CHAR(26)     NULL;

--- a/panel-api/internal/db/migrations/000255_dr_sync_state.down.sql
+++ b/panel-api/internal/db/migrations/000255_dr_sync_state.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE server_settings
+  DROP COLUMN dr_last_sync_at,
+  DROP COLUMN dr_last_snapshot_id,
+  DROP COLUMN dr_last_sync_status,
+  DROP COLUMN dr_last_sync_error;

--- a/panel-api/internal/db/migrations/000255_dr_sync_state.up.sql
+++ b/panel-api/internal/db/migrations/000255_dr_sync_state.up.sql
@@ -1,0 +1,20 @@
+-- GH #331 DR standby, Step 2: standby pull-restore liveness state.
+--
+-- The drsync loop (panel-api/internal/drsync) runs only on a standby: each tick
+-- it lists the primary's system_backup manifests on the DR destination and, if a
+-- newer one exists than it last applied, runs `system.restore {apply:true,
+-- include_accounts:false}` to converge the panel DB + config + TLS. These columns
+-- record the outcome so `jabali dr status` (and, later, the admin banner) can show
+-- how fresh the replica is.
+--
+-- dr_last_sync_at: when the loop last completed a tick (any outcome).
+-- dr_last_snapshot_id: the system_backup manifest snapshot this box last applied
+--   (restic short/long id). Empty until the first successful restore.
+-- dr_last_sync_status: '' (never run) | ok (applied a new snapshot) | current
+--   (already at newest) | waiting (destination has no manifest yet) | error.
+-- dr_last_sync_error: last error string (truncated), empty on success.
+ALTER TABLE server_settings
+  ADD COLUMN dr_last_sync_at     DATETIME(6)   NULL,
+  ADD COLUMN dr_last_snapshot_id VARCHAR(64)   NOT NULL DEFAULT '',
+  ADD COLUMN dr_last_sync_status VARCHAR(16)   NOT NULL DEFAULT '',
+  ADD COLUMN dr_last_sync_error  VARCHAR(1024) NOT NULL DEFAULT '';

--- a/panel-api/internal/drsync/syncer.go
+++ b/panel-api/internal/drsync/syncer.go
@@ -1,0 +1,313 @@
+// Package drsync implements the DR standby pull-restore loop (GH #331 Step 2).
+//
+// A DR standby is a one-way async replica: it never mutates the primary and
+// never holds a primary-mutating credential (least privilege). Its whole job is
+// to keep its own control plane converged with the primary's, so that a manual
+// `jabali dr promote` (Step 4) brings a near-current box online.
+//
+// The loop runs on every box but is INERT unless server_settings.server_role is
+// 'standby' — it re-reads the role each tick, so pairing/unpairing at runtime
+// takes effect without a restart, and a primary pays only one settings read per
+// tick. On a standby it:
+//
+//  1. lists the primary's system_backup manifest snapshots on the read-only DR
+//     backup destination (system.restore_list_manifests);
+//  2. if the newest snapshot differs from the one it last applied, runs
+//     system.restore {apply:true, include_accounts:false} — which loads panel_db
+//     + rsyncs panel_config + rsyncs tls, and leaves the heavier account-data
+//     stages staged-not-applied (those converge at promote time);
+//  3. records the outcome on server_settings (DRLastSync*) for `jabali dr status`.
+//
+// SECURITY: the destination the standby reads is the same restic repo the
+// primary ships to; the standby only ever lists + restores from it. It issues no
+// write to the primary and mints no token. A restore OVERWRITES this box's panel
+// DB/config/TLS every time a new snapshot lands — which is exactly the point of a
+// replica, and why StandbyReadOnly (Step 1) refuses tenant writes here: anything
+// written to a standby would be silently discarded by the next converge.
+package drsync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// settingsStore is the subset of repository.ServerSettingsRepository the loop
+// needs. Declared here (accept interfaces) so tests can supply a fake.
+type settingsStore interface {
+	Get(ctx context.Context) (*models.ServerSettings, error)
+	RecordDRSync(ctx context.Context, snapshotID, status, syncErr string) error
+}
+
+// destinationStore is the subset of repository.BackupDestinationRepository the
+// loop needs.
+type destinationStore interface {
+	Get(ctx context.Context, id string) (*models.BackupDestination, error)
+}
+
+// Deps are the syncer's collaborators. Settings, Destinations, and Agent are
+// required; New returns nil without them so serve.go logs and skips the loop.
+type Deps struct {
+	Settings     settingsStore
+	Destinations destinationStore
+	Agent        agent.AgentInterface
+	// SSOKey unseals a per-destination restic password. May be nil — only
+	// needed for destinations that carry a sealed password (WithDestPasswordFile
+	// falls back to the agent's shared password file otherwise).
+	SSOKey *ssokey.Key
+	Log    *slog.Logger
+
+	// Interval between ticks. Zero → DefaultInterval. Ticks are sequential
+	// (a slow restore delays the next tick; they never overlap).
+	Interval time.Duration
+	// TickTimeout bounds one whole SyncOnce (list + restore). Zero →
+	// DefaultTickTimeout. system.restore over a slow remote can take minutes,
+	// so this is generous; the agent client honours the ctx deadline.
+	TickTimeout time.Duration
+}
+
+const (
+	// DefaultInterval is the standby's convergence cadence. A minute keeps the
+	// replica fresh without hammering the destination; restic dedup makes a
+	// no-op tick cheap and system.restore is skipped when already current.
+	DefaultInterval = 60 * time.Second
+	// DefaultTickTimeout bounds one list+restore cycle.
+	DefaultTickTimeout = 15 * time.Minute
+)
+
+// Syncer runs the standby pull-restore loop.
+type Syncer struct {
+	deps        Deps
+	interval    time.Duration
+	tickTimeout time.Duration
+}
+
+// New returns a Syncer, or nil if a required dependency is missing (so the
+// caller can log-and-skip exactly like the backup scheduler does).
+func New(deps Deps) *Syncer {
+	if deps.Settings == nil || deps.Destinations == nil || deps.Agent == nil {
+		return nil
+	}
+	if deps.Log == nil {
+		deps.Log = slog.Default()
+	}
+	interval := deps.Interval
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+	tt := deps.TickTimeout
+	if tt <= 0 {
+		tt = DefaultTickTimeout
+	}
+	return &Syncer{deps: deps, interval: interval, tickTimeout: tt}
+}
+
+// Start runs the loop until ctx is cancelled. Ticks are sequential: the next
+// tick waits for the current SyncOnce to return, so a long restore never
+// overlaps the next convergence.
+func (s *Syncer) Start(ctx context.Context) {
+	s.deps.Log.Info("DR sync loop started", "interval", s.interval)
+	for {
+		s.tick(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(s.interval):
+		}
+	}
+}
+
+// tick runs one SyncOnce under the per-tick timeout and logs the outcome. It
+// never propagates — the loop must survive a transient failure.
+func (s *Syncer) tick(parent context.Context) {
+	ctx, cancel := context.WithTimeout(parent, s.tickTimeout)
+	defer cancel()
+	res, err := s.SyncOnce(ctx)
+	if err != nil {
+		s.deps.Log.Warn("DR sync tick failed", "err", err)
+		return
+	}
+	if res.Skipped {
+		return // primary — inert, no log noise
+	}
+	switch res.Status {
+	case models.DRSyncStatusOK:
+		s.deps.Log.Info("DR sync applied a newer snapshot", "snapshot_id", res.SnapshotID)
+	case models.DRSyncStatusError:
+		s.deps.Log.Warn("DR sync error", "detail", res.Detail)
+	default:
+		s.deps.Log.Debug("DR sync tick", "status", res.Status, "snapshot_id", res.SnapshotID)
+	}
+}
+
+// Result reports what one SyncOnce did, for tests and the tick logger.
+type Result struct {
+	// Skipped is true when the box is not a standby — the loop did nothing and
+	// recorded nothing.
+	Skipped bool
+	// Status is one of models.DRSyncStatus* when a tick ran on a standby.
+	Status string
+	// SnapshotID is the manifest snapshot applied (ok) or already current.
+	SnapshotID string
+	// Detail carries the error string for a status=error tick.
+	Detail string
+}
+
+// SyncOnce runs a single convergence step. It is the testable core of the loop.
+// On a primary (or unseeded settings) it returns Result{Skipped:true} and does
+// nothing. On a standby it lists + (conditionally) restores, records the
+// outcome, and returns it. It returns a non-nil error ONLY for an unexpected
+// settings-read failure the caller should log; recorded per-tick errors
+// (destination down, restore failure) come back as Result{Status:error}, nil so
+// the loop keeps running.
+func (s *Syncer) SyncOnce(ctx context.Context) (Result, error) {
+	settings, err := s.deps.Settings.Get(ctx)
+	if err != nil {
+		return Result{}, fmt.Errorf("read server settings: %w", err)
+	}
+	if settings == nil || !settings.IsStandby() {
+		return Result{Skipped: true}, nil
+	}
+	if settings.DRDestinationID == nil || *settings.DRDestinationID == "" {
+		// pair requires a destination, so this is a corrupted pairing.
+		return s.recordResult(ctx, Result{
+			Status: models.DRSyncStatusError,
+			Detail: "standby has no DR destination configured; re-run `jabali dr pair`",
+		}), nil
+	}
+	dest, err := s.deps.Destinations.Get(ctx, *settings.DRDestinationID)
+	if err != nil || dest == nil {
+		detail := fmt.Sprintf("DR destination %s not found", *settings.DRDestinationID)
+		if err != nil {
+			detail = fmt.Sprintf("load DR destination %s: %v", *settings.DRDestinationID, err)
+		}
+		return s.recordResult(ctx, Result{Status: models.DRSyncStatusError, Detail: detail}), nil
+	}
+	if !dest.Enabled {
+		return s.recordResult(ctx, Result{
+			Status: models.DRSyncStatusError,
+			Detail: fmt.Sprintf("DR destination %s is disabled", dest.ID),
+		}), nil
+	}
+
+	res := s.pullRestore(ctx, settings, dest)
+	return s.recordResult(ctx, res), nil
+}
+
+// pullRestore does the two agent calls under a single per-destination password
+// tempfile: list the manifests, and (only if the newest differs from the one we
+// last applied) restore it with apply=true.
+func (s *Syncer) pullRestore(ctx context.Context, settings *models.ServerSettings, dest *models.BackupDestination) Result {
+	var res Result
+	err := backupwrapperhelpers.WithDestPasswordFile(ctx, dest, s.deps.Agent, s.deps.SSOKey,
+		func(passwordFile string) error {
+			newest, lerr := s.latestManifest(ctx, dest, passwordFile)
+			if lerr != nil {
+				return lerr
+			}
+			if newest == "" {
+				// Fresh pairing — the primary has shipped no system backup yet.
+				res = Result{Status: models.DRSyncStatusWaiting}
+				return nil
+			}
+			if newest == settings.DRLastSnapshotID {
+				res = Result{Status: models.DRSyncStatusCurrent, SnapshotID: newest}
+				return nil
+			}
+			if rerr := s.restore(ctx, dest, passwordFile, newest); rerr != nil {
+				return rerr
+			}
+			res = Result{Status: models.DRSyncStatusOK, SnapshotID: newest}
+			return nil
+		})
+	if err != nil {
+		return Result{Status: models.DRSyncStatusError, Detail: err.Error()}
+	}
+	return res
+}
+
+// latestManifest asks the agent for the newest system_backup manifest snapshot
+// on the destination. Empty string (nil error) means the repo holds none yet.
+func (s *Syncer) latestManifest(ctx context.Context, dest *models.BackupDestination, passwordFile string) (string, error) {
+	params := destWireParams(dest)
+	if passwordFile != "" {
+		params["password_file"] = passwordFile
+	}
+	raw, err := s.deps.Agent.Call(ctx, "system.restore_list_manifests", params)
+	if err != nil {
+		return "", fmt.Errorf("list manifests: %w", err)
+	}
+	var resp struct {
+		Manifests []struct {
+			SnapshotID string `json:"snapshot_id"`
+		} `json:"manifests"`
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("parse manifests: %w", err)
+	}
+	if resp.Total == 0 || len(resp.Manifests) == 0 {
+		return "", nil
+	}
+	// The agent returns manifests newest-first.
+	return resp.Manifests[0].SnapshotID, nil
+}
+
+// restore runs system.restore for one snapshot with apply=true and
+// include_accounts=false (panel_db + panel_config + tls only; account data
+// converges at promote time).
+func (s *Syncer) restore(ctx context.Context, dest *models.BackupDestination, passwordFile, snapshotID string) error {
+	params := destWireParams(dest)
+	params["job_id"] = ids.NewULID()
+	params["manifest_snapshot_id"] = snapshotID
+	params["include_accounts"] = false
+	params["apply"] = true
+	if passwordFile != "" {
+		params["password_file"] = passwordFile
+	}
+	if _, err := s.deps.Agent.Call(ctx, "system.restore", params); err != nil {
+		return fmt.Errorf("system.restore %s: %w", snapshotID, err)
+	}
+	return nil
+}
+
+// recordResult persists a non-skipped Result to server_settings and returns it
+// unchanged. Recording uses a fresh short context so an expired per-tick
+// deadline (e.g. after a slow restore) can't stop the outcome being written.
+func (s *Syncer) recordResult(_ context.Context, res Result) Result {
+	rctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// Only stamp the applied snapshot on success; a failed/waiting tick keeps
+	// the last-known applied snapshot intact.
+	snap := ""
+	if res.Status == models.DRSyncStatusOK {
+		snap = res.SnapshotID
+	}
+	if err := s.deps.Settings.RecordDRSync(rctx, snap, res.Status, res.Detail); err != nil {
+		s.deps.Log.Warn("DR sync: record sync state failed", "err", err)
+	}
+	return res
+}
+
+// destWireParams projects a destination into the agent JSON keys. Mirrors
+// backupscheduler.destWireParams but stays local so the two packages don't
+// couple; SFTPWireParams already yields the full typed SFTP block.
+func destWireParams(d *models.BackupDestination) map[string]any {
+	out := map[string]any{
+		"repo_url":         d.URL,
+		"destination_kind": d.Kind,
+		"sftp":             backupwrapperhelpers.SFTPWireParams(d),
+	}
+	if d.CredentialsRef != nil {
+		out["credentials_ref"] = *d.CredentialsRef
+	}
+	return out
+}

--- a/panel-api/internal/drsync/syncer_test.go
+++ b/panel-api/internal/drsync/syncer_test.go
@@ -1,0 +1,270 @@
+package drsync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeAgent maps a command name to a handler so each test wires only the
+// commands it exercises. An unmapped command returns an error, which surfaces
+// as a recorded status=error — exactly what a real missing/failed call does.
+type fakeAgent struct {
+	handlers map[string]func(params any) (json.RawMessage, error)
+	calls    []string
+}
+
+func (a *fakeAgent) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	a.calls = append(a.calls, command)
+	h, ok := a.handlers[command]
+	if !ok {
+		return nil, errors.New("unexpected agent command: " + command)
+	}
+	return h(params)
+}
+
+func manifestsJSON(ids ...string) func(any) (json.RawMessage, error) {
+	return func(any) (json.RawMessage, error) {
+		type row struct {
+			SnapshotID string `json:"snapshot_id"`
+		}
+		rows := make([]row, 0, len(ids))
+		for _, id := range ids {
+			rows = append(rows, row{SnapshotID: id})
+		}
+		b, _ := json.Marshal(map[string]any{"manifests": rows, "total": len(rows)})
+		return b, nil
+	}
+}
+
+// fakeSettings is a one-row settings store capturing the last RecordDRSync args.
+type fakeSettings struct {
+	s      *models.ServerSettings
+	getErr error
+
+	recorded      bool
+	recSnapshotID string
+	recStatus     string
+	recErr        string
+}
+
+func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) {
+	return f.s, f.getErr
+}
+
+func (f *fakeSettings) RecordDRSync(_ context.Context, snapshotID, status, syncErr string) error {
+	f.recorded = true
+	f.recSnapshotID, f.recStatus, f.recErr = snapshotID, status, syncErr
+	return nil
+}
+
+type fakeDests struct {
+	byID map[string]*models.BackupDestination
+	err  error
+}
+
+func (d *fakeDests) Get(_ context.Context, id string) (*models.BackupDestination, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	return d.byID[id], nil // nil => not found
+}
+
+func standbySettings(destID, lastSnap string) *models.ServerSettings {
+	id := destID
+	return &models.ServerSettings{
+		ServerRole:       models.ServerRoleStandby,
+		DRDestinationID:  &id,
+		DRLastSnapshotID: lastSnap,
+	}
+}
+
+func enabledDest(id string) *models.BackupDestination {
+	return &models.BackupDestination{ID: id, URL: "sftp:host:/repo", Kind: models.BackupDestinationKindLocal, Enabled: true}
+}
+
+func newSyncer(t *testing.T, s settingsStore, d destinationStore, a *fakeAgent) *Syncer {
+	t.Helper()
+	sy := New(Deps{Settings: s, Destinations: d, Agent: a})
+	if sy == nil {
+		t.Fatal("New returned nil with all required deps present")
+	}
+	return sy
+}
+
+func TestSyncOnce_PrimaryIsInert(t *testing.T) {
+	fs := &fakeSettings{s: &models.ServerSettings{ServerRole: models.ServerRolePrimary}}
+	fa := &fakeAgent{}
+	res, err := newSyncer(t, fs, &fakeDests{}, fa).SyncOnce(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Skipped {
+		t.Errorf("primary must be skipped, got %+v", res)
+	}
+	if fs.recorded {
+		t.Error("primary must not record any sync state")
+	}
+	if len(fa.calls) != 0 {
+		t.Errorf("primary must make no agent calls, made %v", fa.calls)
+	}
+}
+
+func TestSyncOnce_UnseededIsInert(t *testing.T) {
+	fs := &fakeSettings{s: &models.ServerSettings{}} // role "" → primary
+	res, err := newSyncer(t, fs, &fakeDests{}, &fakeAgent{}).SyncOnce(context.Background())
+	if err != nil || !res.Skipped {
+		t.Fatalf("unseeded row must be skipped: res=%+v err=%v", res, err)
+	}
+}
+
+func TestSyncOnce_SettingsReadErrorPropagates(t *testing.T) {
+	fs := &fakeSettings{getErr: errors.New("db down")}
+	res, err := newSyncer(t, fs, &fakeDests{}, &fakeAgent{}).SyncOnce(context.Background())
+	if err == nil {
+		t.Fatal("settings read error must propagate to caller for logging")
+	}
+	if res.Skipped {
+		t.Error("a read error is not a skip")
+	}
+}
+
+func TestSyncOnce_StandbyWithoutDestinationRecordsError(t *testing.T) {
+	fs := &fakeSettings{s: &models.ServerSettings{ServerRole: models.ServerRoleStandby}} // DRDestinationID nil
+	res, _ := newSyncer(t, fs, &fakeDests{}, &fakeAgent{}).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusError {
+		t.Errorf("want error status, got %q", res.Status)
+	}
+	if !fs.recorded || fs.recStatus != models.DRSyncStatusError {
+		t.Errorf("error must be recorded, got recorded=%v status=%q", fs.recorded, fs.recStatus)
+	}
+}
+
+func TestSyncOnce_DestinationNotFoundRecordsError(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "")}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{}}, &fakeAgent{}).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusError || fs.recStatus != models.DRSyncStatusError {
+		t.Errorf("missing destination must record error, got %+v", res)
+	}
+}
+
+func TestSyncOnce_DisabledDestinationRecordsError(t *testing.T) {
+	d := enabledDest("D1")
+	d.Enabled = false
+	fs := &fakeSettings{s: standbySettings("D1", "")}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": d}}, &fakeAgent{}).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusError {
+		t.Errorf("disabled destination must record error, got %q", res.Status)
+	}
+}
+
+func TestSyncOnce_NoManifestYetIsWaiting(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON(), // empty
+	}}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusWaiting {
+		t.Errorf("empty repo must be waiting, got %q", res.Status)
+	}
+	for _, c := range fa.calls {
+		if c == "system.restore" {
+			t.Error("must NOT restore when there is no manifest")
+		}
+	}
+	if fs.recStatus != models.DRSyncStatusWaiting {
+		t.Errorf("waiting must be recorded, got %q", fs.recStatus)
+	}
+}
+
+func TestSyncOnce_AlreadyCurrentSkipsRestore(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "SNAP_A")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_A"),
+	}}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusCurrent {
+		t.Errorf("want current, got %q", res.Status)
+	}
+	for _, c := range fa.calls {
+		if c == "system.restore" {
+			t.Error("must NOT restore when already at newest snapshot")
+		}
+	}
+}
+
+func TestSyncOnce_NewerSnapshotRestoresAndRecords(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "SNAP_OLD")}
+	var restoreParams map[string]any
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_NEW", "SNAP_OLD"),
+		"system.restore": func(p any) (json.RawMessage, error) {
+			restoreParams, _ = p.(map[string]any)
+			return json.RawMessage(`{"job_id":"x"}`), nil
+		},
+	}}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusOK || res.SnapshotID != "SNAP_NEW" {
+		t.Fatalf("want ok/SNAP_NEW, got %+v", res)
+	}
+	if restoreParams["manifest_snapshot_id"] != "SNAP_NEW" {
+		t.Errorf("restore must target newest snapshot, got %v", restoreParams["manifest_snapshot_id"])
+	}
+	if restoreParams["apply"] != true {
+		t.Errorf("restore must apply:true, got %v", restoreParams["apply"])
+	}
+	if restoreParams["include_accounts"] != false {
+		t.Errorf("standby restore must NOT include accounts, got %v", restoreParams["include_accounts"])
+	}
+	if fs.recStatus != models.DRSyncStatusOK || fs.recSnapshotID != "SNAP_NEW" {
+		t.Errorf("ok must record the applied snapshot, got status=%q snap=%q", fs.recStatus, fs.recSnapshotID)
+	}
+}
+
+func TestSyncOnce_ListErrorRecordsErrorNotSnapshot(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "SNAP_OLD")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": func(any) (json.RawMessage, error) {
+			return nil, errors.New("destination unreachable")
+		},
+	}}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusError {
+		t.Errorf("list failure must be error, got %q", res.Status)
+	}
+	if fs.recSnapshotID != "" {
+		t.Errorf("a failed tick must not stamp an applied snapshot, got %q", fs.recSnapshotID)
+	}
+}
+
+func TestSyncOnce_RestoreErrorDoesNotAdvanceSnapshot(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "SNAP_OLD")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_NEW"),
+		"system.restore": func(any) (json.RawMessage, error) {
+			return nil, errors.New("restic restore failed")
+		},
+	}}
+	res, _ := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if res.Status != models.DRSyncStatusError {
+		t.Errorf("restore failure must be error, got %q", res.Status)
+	}
+	if fs.recSnapshotID != "" {
+		t.Errorf("failed restore must not advance last-applied snapshot, got %q", fs.recSnapshotID)
+	}
+}
+
+func TestNew_NilWhenRequiredDepMissing(t *testing.T) {
+	if New(Deps{Destinations: &fakeDests{}, Agent: &fakeAgent{}}) != nil {
+		t.Error("nil Settings must yield nil Syncer")
+	}
+	if New(Deps{Settings: &fakeSettings{}, Agent: &fakeAgent{}}) != nil {
+		t.Error("nil Destinations must yield nil Syncer")
+	}
+	if New(Deps{Settings: &fakeSettings{}, Destinations: &fakeDests{}}) != nil {
+		t.Error("nil Agent must yield nil Syncer")
+	}
+}

--- a/panel-api/internal/middleware/standby_guard.go
+++ b/panel-api/internal/middleware/standby_guard.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// StandbyReadOnly (GH #331) blocks state-mutating API requests when this box is
+// a DR standby. A standby's panel DB is a REPLICA of the primary — any tenant
+// provisioning written here would diverge from the primary and be silently
+// overwritten by the next sync, so the safe behaviour is to refuse the write
+// outright (409) rather than accept-then-lose it. Read requests always pass, so
+// the operator can inspect the replica; the DR-control + settings routes are
+// allowlisted so they can still promote or re-pair the box.
+//
+// Fail-safe direction is toward "active primary": an unseeded row or a settings
+// read error is treated as primary and lets writes through, because wrongly
+// freezing a real live primary during a DB blip is far worse than a standby
+// briefly accepting a write that the next sync discards anyway.
+
+// standbyAllowlist is the set of /api/v1 path prefixes whose mutations are
+// permitted even on a standby — the operator must be able to promote, unpair,
+// and adjust the settings that drive those actions.
+var standbyAllowlist = []string{
+	"/api/v1/admin/dr",
+	"/api/v1/admin/settings",
+}
+
+type standbyCache struct {
+	mu      sync.RWMutex
+	repo    repository.ServerSettingsRepository
+	cached  *models.ServerSettings
+	fetched time.Time
+	ttl     time.Duration
+	nowFunc func() time.Time
+}
+
+func (c *standbyCache) role(ctx *gin.Context) *models.ServerSettings {
+	now := c.nowFunc()
+	c.mu.RLock()
+	if c.cached != nil && now.Sub(c.fetched) < c.ttl {
+		s := c.cached
+		c.mu.RUnlock()
+		return s
+	}
+	c.mu.RUnlock()
+	if c.repo == nil {
+		return nil
+	}
+	s, err := c.repo.Get(ctx.Request.Context())
+	if err != nil || s == nil {
+		// Fail safe: reuse the last-known value, else nil → treated as primary.
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		return c.cached
+	}
+	c.mu.Lock()
+	c.cached, c.fetched = s, now
+	c.mu.Unlock()
+	return s
+}
+
+func standbyAllowed(path string) bool {
+	for _, p := range standbyAllowlist {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// StandbyReadOnly returns the guard middleware bound to a short-TTL settings
+// cache so a hot route doesn't issue a DB read per request.
+func StandbyReadOnly(repo repository.ServerSettingsRepository, log *slog.Logger) gin.HandlerFunc {
+	cache := &standbyCache{repo: repo, ttl: 5 * time.Second, nowFunc: time.Now}
+	return func(c *gin.Context) {
+		if !isMutating(c.Request.Method) {
+			c.Next()
+			return
+		}
+		s := cache.role(c)
+		if s == nil || !s.IsStandby() {
+			c.Next()
+			return
+		}
+		if standbyAllowed(c.Request.URL.Path) {
+			c.Next()
+			return
+		}
+		if log != nil {
+			log.Warn("standby refused a mutating request",
+				"method", c.Request.Method, "path", c.Request.URL.Path)
+		}
+		c.AbortWithStatusJSON(http.StatusConflict, gin.H{
+			"error":  "server_is_standby",
+			"detail": "This server is a DR standby (read-only replica). Promote it with `jabali dr promote` before making changes.",
+		})
+	}
+}

--- a/panel-api/internal/middleware/standby_guard_test.go
+++ b/panel-api/internal/middleware/standby_guard_test.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// drSettingsRepo is a minimal ServerSettingsRepository returning a fixed row
+// (or an error, to exercise the fail-open path).
+type drSettingsRepo struct {
+	repository.ServerSettingsRepository
+	s   *models.ServerSettings
+	err error
+}
+
+func (r drSettingsRepo) Get(context.Context) (*models.ServerSettings, error) {
+	return r.s, r.err
+}
+
+func newStandbyRouter(repo repository.ServerSettingsRepository) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(StandbyReadOnly(repo, nil))
+	ok := func(c *gin.Context) { c.String(http.StatusOK, "ok") }
+	v1.GET("/domains", ok)
+	v1.POST("/domains", ok)
+	v1.DELETE("/domains/:id", ok)
+	v1.POST("/admin/dr/promote", ok)
+	v1.PUT("/admin/settings", ok)
+	return r
+}
+
+func req(t *testing.T, r *gin.Engine, method, path string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(method, path, strings.NewReader("{}")))
+	return rec.Code
+}
+
+func TestStandbyGuard_PrimaryAllowsWrites(t *testing.T) {
+	r := newStandbyRouter(drSettingsRepo{s: &models.ServerSettings{ServerRole: "primary"}})
+	if code := req(t, r, http.MethodPost, "/api/v1/domains"); code != http.StatusOK {
+		t.Errorf("primary POST should pass, got %d", code)
+	}
+}
+
+func TestStandbyGuard_StandbyBlocksTenantWrites(t *testing.T) {
+	r := newStandbyRouter(drSettingsRepo{s: &models.ServerSettings{ServerRole: "standby"}})
+	if code := req(t, r, http.MethodPost, "/api/v1/domains"); code != http.StatusConflict {
+		t.Errorf("standby POST /domains should 409, got %d", code)
+	}
+	if code := req(t, r, http.MethodDelete, "/api/v1/domains/x"); code != http.StatusConflict {
+		t.Errorf("standby DELETE /domains should 409, got %d", code)
+	}
+}
+
+func TestStandbyGuard_StandbyAllowsReads(t *testing.T) {
+	r := newStandbyRouter(drSettingsRepo{s: &models.ServerSettings{ServerRole: "standby"}})
+	if code := req(t, r, http.MethodGet, "/api/v1/domains"); code != http.StatusOK {
+		t.Errorf("standby GET must always pass, got %d", code)
+	}
+}
+
+func TestStandbyGuard_StandbyAllowsDRAndSettings(t *testing.T) {
+	r := newStandbyRouter(drSettingsRepo{s: &models.ServerSettings{ServerRole: "standby"}})
+	if code := req(t, r, http.MethodPost, "/api/v1/admin/dr/promote"); code != http.StatusOK {
+		t.Errorf("standby must allow DR control writes (promote), got %d", code)
+	}
+	if code := req(t, r, http.MethodPut, "/api/v1/admin/settings"); code != http.StatusOK {
+		t.Errorf("standby must allow settings writes, got %d", code)
+	}
+}
+
+func TestStandbyGuard_ReadErrorFailsOpen(t *testing.T) {
+	// A settings read error must NOT freeze a box — default toward active primary.
+	r := newStandbyRouter(drSettingsRepo{err: errors.New("db down")})
+	if code := req(t, r, http.MethodPost, "/api/v1/domains"); code != http.StatusOK {
+		t.Errorf("settings read error must fail open (allow), got %d", code)
+	}
+}

--- a/panel-api/internal/migrate/working_folder_test.go
+++ b/panel-api/internal/migrate/working_folder_test.go
@@ -19,6 +19,9 @@ func (f *fakeServerSettings) Get(_ context.Context) (*models.ServerSettings, err
 	return f.row, f.err
 }
 func (f *fakeServerSettings) SetDigestLastSent(context.Context, string) error { return nil }
+func (f *fakeServerSettings) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
 func (f *fakeServerSettings) Upsert(_ context.Context, _ *models.ServerSettings) error {
 	return nil
 }

--- a/panel-api/internal/models/dr.go
+++ b/panel-api/internal/models/dr.go
@@ -27,3 +27,20 @@ func IsValidServerRole(r string) bool {
 	}
 	return false
 }
+
+// DR standby sync outcomes (GH #331 Step 2). Recorded on server_settings by the
+// drsync loop after each tick so `jabali dr status` and the admin banner can show
+// how fresh the replica is. Empty (”) means the loop has never recorded a tick.
+const (
+	// DRSyncStatusOK — the loop applied a newer system_backup manifest this tick.
+	DRSyncStatusOK = "ok"
+	// DRSyncStatusCurrent — the newest manifest on the destination was already
+	// applied; nothing to do.
+	DRSyncStatusCurrent = "current"
+	// DRSyncStatusWaiting — the DR destination holds no system_backup manifest
+	// yet (the primary hasn't shipped one). Not an error — a fresh pairing.
+	DRSyncStatusWaiting = "waiting"
+	// DRSyncStatusError — the tick failed (destination unreachable, restore
+	// error). DRLastSyncError carries the detail.
+	DRSyncStatusError = "error"
+)

--- a/panel-api/internal/models/dr.go
+++ b/panel-api/internal/models/dr.go
@@ -1,0 +1,29 @@
+package models
+
+// DR / standby node roles (GH #331). A box is either an active primary or a
+// one-way async standby replica that is manually promoted during a disaster.
+// There is no automatic failover and no active/active — the operator pointing
+// traffic at the standby is the fencing step.
+const (
+	ServerRolePrimary = "primary"
+	ServerRoleStandby = "standby"
+)
+
+// IsStandby reports whether this box is a DR standby replica. Any value other
+// than the explicit "standby" — including the empty string on an unseeded row —
+// is treated as primary, so a missing/garbled role never wrongly parks a live
+// box in read-only mode (fail safe toward "active primary").
+func (s ServerSettings) IsStandby() bool { return s.ServerRole == ServerRoleStandby }
+
+// IsPrimary is the inverse of IsStandby.
+func (s ServerSettings) IsPrimary() bool { return !s.IsStandby() }
+
+// IsValidServerRole validates an operator-supplied role. The empty string is
+// accepted and means the primary default.
+func IsValidServerRole(r string) bool {
+	switch r {
+	case "", ServerRolePrimary, ServerRoleStandby:
+		return true
+	}
+	return false
+}

--- a/panel-api/internal/models/dr_test.go
+++ b/panel-api/internal/models/dr_test.go
@@ -1,0 +1,37 @@
+package models
+
+import "testing"
+
+func TestServerRoleHelpers(t *testing.T) {
+	cases := []struct {
+		role      string
+		isStandby bool
+	}{
+		{"", false}, // unseeded → primary (fail safe)
+		{"primary", false},
+		{"standby", true},
+		{"garbage", false}, // unknown → primary, never wrongly park a live box
+	}
+	for _, c := range cases {
+		s := ServerSettings{ServerRole: c.role}
+		if s.IsStandby() != c.isStandby {
+			t.Errorf("role %q: IsStandby()=%v want %v", c.role, s.IsStandby(), c.isStandby)
+		}
+		if s.IsPrimary() == c.isStandby {
+			t.Errorf("role %q: IsPrimary() must be the inverse of IsStandby()", c.role)
+		}
+	}
+}
+
+func TestIsValidServerRole(t *testing.T) {
+	for _, ok := range []string{"", "primary", "standby"} {
+		if !IsValidServerRole(ok) {
+			t.Errorf("%q should be valid", ok)
+		}
+	}
+	for _, bad := range []string{"secondary", "PRIMARY", "replica"} {
+		if IsValidServerRole(bad) {
+			t.Errorf("%q should be invalid", bad)
+		}
+	}
+}

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -292,6 +292,17 @@ type ServerSettings struct {
 	TenantBackupWindowStart string `gorm:"column:tenant_backup_window_start;type:varchar(5);not null;default:'02:00'" json:"tenant_backup_window_start"`
 	TenantBackupWindowEnd   string `gorm:"column:tenant_backup_window_end;type:varchar(5);not null;default:'05:00'" json:"tenant_backup_window_end"`
 
+	// DR / standby (GH #331). ServerRole is 'primary' (default — box is fully
+	// active) or 'standby' (a one-way async replica: pulls the primary's state,
+	// serves no live traffic until manually promoted). The whole DR feature is
+	// inert until `jabali dr pair` flips this. DRDestinationID is the read-only
+	// backup destination the standby pulls from / the primary ships to; the
+	// standby never holds a primary-mutating credential (least privilege).
+	ServerRole      string     `gorm:"column:server_role;type:varchar(16);not null;default:'primary'" json:"server_role"`
+	DRPairedAt      *time.Time `gorm:"column:dr_paired_at;type:datetime(6)" json:"dr_paired_at,omitempty"`
+	DRPeerLabel     string     `gorm:"column:dr_peer_label;type:varchar(255);not null;default:''" json:"dr_peer_label"`
+	DRDestinationID *string    `gorm:"column:dr_destination_id;type:char(26)" json:"dr_destination_id,omitempty"`
+
 	// BackupMaxConcurrentJobs caps how many backup_jobs the in-process
 	// dispatcher will keep in status=running at once. Scheduler ticks
 	// enqueue rows as queued; the dispatcher drains them under this

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -302,6 +302,13 @@ type ServerSettings struct {
 	DRPairedAt      *time.Time `gorm:"column:dr_paired_at;type:datetime(6)" json:"dr_paired_at,omitempty"`
 	DRPeerLabel     string     `gorm:"column:dr_peer_label;type:varchar(255);not null;default:''" json:"dr_peer_label"`
 	DRDestinationID *string    `gorm:"column:dr_destination_id;type:char(26)" json:"dr_destination_id,omitempty"`
+	// DR standby sync liveness (GH #331 Step 2, migration 000255). Written only
+	// by the drsync loop on a standby; a primary leaves these at their defaults.
+	// See models.DRSyncStatus* for the status vocabulary.
+	DRLastSyncAt     *time.Time `gorm:"column:dr_last_sync_at;type:datetime(6)" json:"dr_last_sync_at,omitempty"`
+	DRLastSnapshotID string     `gorm:"column:dr_last_snapshot_id;type:varchar(64);not null;default:''" json:"dr_last_snapshot_id"`
+	DRLastSyncStatus string     `gorm:"column:dr_last_sync_status;type:varchar(16);not null;default:''" json:"dr_last_sync_status"`
+	DRLastSyncError  string     `gorm:"column:dr_last_sync_error;type:varchar(1024);not null;default:''" json:"dr_last_sync_error"`
 
 	// BackupMaxConcurrentJobs caps how many backup_jobs the in-process
 	// dispatcher will keep in status=running at once. Scheduler ticks

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -54,8 +54,8 @@ func (f *fakeSender) Send(ctx context.Context, ch models.NotificationChannel, en
 // --- fake repos ---
 
 type fakeChannels struct {
-	mu     sync.Mutex
-	byID   map[string]*models.NotificationChannel
+	mu      sync.Mutex
+	byID    map[string]*models.NotificationChannel
 	enabled []models.NotificationChannel
 }
 
@@ -135,8 +135,8 @@ var errNotFound = errors.New("not found")
 // ListAll wrapper below.
 
 type fakeHistory struct {
-	mu     sync.Mutex
-	rows   map[string]*models.NotificationHistory
+	mu       sync.Mutex
+	rows     map[string]*models.NotificationHistory
 	outcomes []string
 }
 
@@ -161,7 +161,7 @@ func (f *fakeHistory) UpdateOutcome(ctx context.Context, id, outcome, errMsg str
 	f.outcomes = append(f.outcomes, outcome)
 	return nil
 }
-func (f *fakeHistory) MarkRead(ctx context.Context, id string) error              { return nil }
+func (f *fakeHistory) MarkRead(ctx context.Context, id string) error                   { return nil }
 func (f *fakeHistory) MarkAllReadForUser(ctx context.Context, u string) (int64, error) { return 0, nil }
 func (f *fakeHistory) DeleteAllForUser(ctx context.Context, u string, b bool) (int64, error) {
 	return 0, nil
@@ -192,10 +192,10 @@ func (f *fakeHistory) ListRecentByEvent(ctx context.Context, kind string, since 
 }
 
 type fakeWebhook struct {
-	mu         sync.Mutex
-	failures   map[string]int
-	lastError  map[string]string
-	successes  map[string]int
+	mu        sync.Mutex
+	failures  map[string]int
+	lastError map[string]string
+	successes map[string]int
 }
 
 func (f *fakeWebhook) ensure() {
@@ -476,7 +476,9 @@ type fakeUserRoutes struct {
 	routes map[string]map[string][]string
 }
 
-func (f *fakeUserRoutes) Create(ctx context.Context, r *models.UserNotificationRoute) error { return nil }
+func (f *fakeUserRoutes) Create(ctx context.Context, r *models.UserNotificationRoute) error {
+	return nil
+}
 func (f *fakeUserRoutes) ListByUser(ctx context.Context, userID string) ([]models.UserNotificationRoute, error) {
 	return nil, nil
 }
@@ -487,7 +489,7 @@ func (f *fakeUserRoutes) ListByUserEvent(ctx context.Context, userID, eventKind 
 	}
 	return out, nil
 }
-func (f *fakeUserRoutes) Delete(ctx context.Context, id string) error            { return nil }
+func (f *fakeUserRoutes) Delete(ctx context.Context, id string) error                 { return nil }
 func (f *fakeUserRoutes) DeleteByChannel(ctx context.Context, channelID string) error { return nil }
 
 func ptr(s string) *string { return &s }
@@ -501,9 +503,9 @@ func ids(chs []models.NotificationChannel) map[string]bool {
 }
 
 func TestResolveTargets_PerUserRouting(t *testing.T) {
-	g1 := models.NotificationChannel{ID: "G1", Enabled: true, UserID: nil}                 // server-wide
-	a1 := models.NotificationChannel{ID: "A1", Enabled: true, UserID: ptr("userA")}        // tenant A owns
-	b1 := models.NotificationChannel{ID: "B1", Enabled: true, UserID: ptr("userB")}        // tenant B owns
+	g1 := models.NotificationChannel{ID: "G1", Enabled: true, UserID: nil}          // server-wide
+	a1 := models.NotificationChannel{ID: "A1", Enabled: true, UserID: ptr("userA")} // tenant A owns
+	b1 := models.NotificationChannel{ID: "B1", Enabled: true, UserID: ptr("userB")} // tenant B owns
 	fc := &fakeChannels{
 		byID:    map[string]*models.NotificationChannel{"G1": &g1, "A1": &a1, "B1": &b1},
 		enabled: []models.NotificationChannel{g1, a1, b1},
@@ -554,10 +556,11 @@ type fakeSettings struct {
 	err error
 }
 
-func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) { return f.st, f.err }
-func (f *fakeSettings) Upsert(context.Context, *models.ServerSettings) error { return nil }
-func (f *fakeSettings) EnsureVAPID(context.Context, string) (bool, error)    { return false, nil }
-func (f *fakeSettings) SetDigestLastSent(context.Context, string) error      { return nil }
+func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error)        { return f.st, f.err }
+func (f *fakeSettings) Upsert(context.Context, *models.ServerSettings) error       { return nil }
+func (f *fakeSettings) EnsureVAPID(context.Context, string) (bool, error)          { return false, nil }
+func (f *fakeSettings) SetDigestLastSent(context.Context, string) error            { return nil }
+func (f *fakeSettings) RecordDRSync(context.Context, string, string, string) error { return nil }
 
 // JAB-171 phase 4e: the master gate + kind allowlist are a LIVE delivery kill
 // switch, not just a create-time gate.

--- a/panel-api/internal/notifications/senders/webpush_test.go
+++ b/panel-api/internal/notifications/senders/webpush_test.go
@@ -28,7 +28,8 @@ func (f *fakeSettingsRepo) Get(ctx context.Context) (*models.ServerSettings, err
 	return f.row, f.err
 }
 func (f *fakeSettingsRepo) Upsert(ctx context.Context, s *models.ServerSettings) error { return nil }
-func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+func (f *fakeSettingsRepo) SetDigestLastSent(context.Context, string) error            { return nil }
+func (f *fakeSettingsRepo) RecordDRSync(context.Context, string, string, string) error { return nil }
 
 func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil

--- a/panel-api/internal/reconciler/digest_ticker_test.go
+++ b/panel-api/internal/reconciler/digest_ticker_test.go
@@ -39,6 +39,9 @@ func (f *fakeDigestSettings) SetDigestLastSent(_ context.Context, day string) er
 	f.srv.DigestLastSentDate = day
 	return nil
 }
+func (f *fakeDigestSettings) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
 
 type fakeDigestQueue struct {
 	envs []notifications.Envelope

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -70,6 +70,17 @@ type Reconciler struct {
 	socketReady func(ctx context.Context, socketPath string, timeout, pollInterval time.Duration) bool
 	// paused is an atomic flag to pause reconciliation (for SSO key rotation)
 	paused atomic.Bool
+
+	// standby* back the DR standby gate (GH #331 Step 3). A standby's reconciler
+	// stays DORMANT: it builds no serving config and issues no ACME certificate,
+	// so the box serves no live traffic and never fails a challenge for the
+	// primary's domains (which would burn Let's Encrypt rate limits). The role is
+	// cached with a short TTL so runtime pairing/promotion takes effect within a
+	// tick without a per-call DB read. serverSettings nil or a read error →
+	// treated as primary (fail toward active), matching middleware.StandbyReadOnly.
+	standbyMu      sync.Mutex
+	standbyCached  bool
+	standbyFetched time.Time
 	// ssoTokens holds reference to the SSO token repository for nightly prune
 	ssoTokens repository.PhpMyAdminSSOTokenRepository
 	// wordPressInstalls holds reference to the WordPress installs repository
@@ -489,6 +500,32 @@ func (r *Reconciler) IsPaused() bool {
 	return r.paused.Load()
 }
 
+// isStandby reports whether this box is a DR standby (GH #331 Step 3). A
+// standby's automatic reconcile loops early-return so it builds no serving
+// config and issues no ACME certificate. Cached with a short TTL so promotion
+// (role → primary) takes effect within a tick; a nil repo or a read error is
+// treated as primary so a DB blip never wrongly parks a live box. This gates the
+// AUTOMATIC loops only — the explicit ReconcileAllForce path (used by promote)
+// stays ungated so it always converges regardless of the cached role.
+func (r *Reconciler) isStandby(ctx context.Context) bool {
+	if r.serverSettings == nil {
+		return false
+	}
+	const ttl = 5 * time.Second
+	r.standbyMu.Lock()
+	defer r.standbyMu.Unlock()
+	if !r.standbyFetched.IsZero() && time.Since(r.standbyFetched) < ttl {
+		return r.standbyCached
+	}
+	s, err := r.serverSettings.Get(ctx)
+	if err != nil || s == nil {
+		return r.standbyCached // keep last-known; fail toward active primary
+	}
+	r.standbyCached = s.IsStandby()
+	r.standbyFetched = time.Now()
+	return r.standbyCached
+}
+
 // Start blocks until ctx is cancelled, running ReconcileAll every interval
 // and draining the out-of-band queue. Must be called once per process.
 func (r *Reconciler) Start(ctx context.Context) {
@@ -597,6 +634,15 @@ func (r *Reconciler) Schedule(domainID string) {
 const domainLoopWorkers = 4
 
 func (r *Reconciler) ReconcileAll(ctx context.Context) error {
+	// GH #331 Step 3: a DR standby stays dormant — no serving config, no ACME.
+	// The whole convergence loop below (panel/mail/shared certs, per-domain
+	// SSL + nginx vhosts, DNS zone push, module installs) is suppressed so the
+	// box serves nothing until `jabali dr promote`. Config is (re)built from the
+	// replicated DB at promote time via ReconcileAllForce.
+	if r.isStandby(ctx) {
+		r.log.Debug("reconcile all skipped — DR standby (not serving)")
+		return nil
+	}
 	// Coarse per-block timings. A tick that outruns the interval means
 	// the next ticker fire lands immediately behind it and drift repair
 	// degrades to back-to-back passes — worth a WARN that names the
@@ -910,6 +956,12 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 // ReconcileOne converges a single domain ID. If the domain doesn't exist in the DB,
 // it is treated as deleted and we call domain.disable on the agent.
 func (r *Reconciler) ReconcileOne(ctx context.Context, domainID string) error {
+	// GH #331 Step 3: a DR standby serves no traffic — skip single-domain
+	// convergence too (same posture as ReconcileAll).
+	if r.isStandby(ctx) {
+		r.log.Debug("reconcile one skipped — DR standby", "domain_id", domainID)
+		return nil
+	}
 	domain, err := r.domains.FindByID(ctx, domainID)
 	if err != nil {
 		// Domain not found in DB (e.g., it was deleted). Assume it's supposed to be gone.
@@ -2701,6 +2753,9 @@ func (r *Reconciler) ReconcileSSLInline(ctx context.Context, domain *models.Doma
 func (r *Reconciler) RetrySSLDueForACME(ctx context.Context) {
 	if r.sslCerts == nil {
 		return // SSL feature not wired — skip
+	}
+	if r.isStandby(ctx) {
+		return // DR standby issues no ACME (GH #331 Step 3)
 	}
 
 	certs, err := r.sslCerts.ListDueForACMERetry(ctx, time.Now().UTC(), 10)

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -2,7 +2,6 @@ package reconciler
 
 import (
 	"context"
-	"sync"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -446,6 +446,9 @@ type fakeServerSettingsRepo struct {
 }
 
 func (f *fakeServerSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
+func (f *fakeServerSettingsRepo) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
 
 func (f *fakeServerSettingsRepo) Get(ctx context.Context) (*models.ServerSettings, error) {
 	if f.settings == nil {

--- a/panel-api/internal/reconciler/ssl_observe.go
+++ b/panel-api/internal/reconciler/ssl_observe.go
@@ -123,6 +123,9 @@ func (r *Reconciler) ReconcileSSLObservation(ctx context.Context) {
 	if r.sslCerts == nil {
 		return
 	}
+	if r.isStandby(ctx) {
+		return // DR standby's cert rows are a replica; drsync owns them (GH #331 Step 3)
+	}
 	certs, err := r.sslCerts.ListAll(ctx)
 	if err != nil {
 		r.log.Warn("ssl_observe: listing certificates failed", "error", err)

--- a/panel-api/internal/reconciler/ssl_resurrect.go
+++ b/panel-api/internal/reconciler/ssl_resurrect.go
@@ -59,6 +59,9 @@ func (r *Reconciler) ReconcileSSLResurrect(ctx context.Context) {
 	if r.sslCerts == nil {
 		return
 	}
+	if r.isStandby(ctx) {
+		return // DR standby issues no ACME (GH #331 Step 3)
+	}
 	now := time.Now().UTC()
 	certs, err := r.sslCerts.ListExhaustedForSSLEnabledDomains(ctx, now.Add(-sslResurrectAfter), sslResurrectBatch)
 	if err != nil {

--- a/panel-api/internal/reconciler/standby_gate_test.go
+++ b/panel-api/internal/reconciler/standby_gate_test.go
@@ -1,0 +1,81 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// buildGateReconciler wires a reconciler with one enabled domain and a
+// server_settings repo carrying the given role, so a ReconcileAll on a PRIMARY
+// reaches the agent (domain.list) but on a STANDBY must short-circuit.
+func buildGateReconciler(t *testing.T, role string) (*Reconciler, *fakeAgent) {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := &fakeAgent{}
+	domainRepo := &fakeDomainRepo{domains: make(map[string]*models.Domain)}
+	userRepo := &fakeUserRepo{users: make(map[string]*models.User)}
+
+	now := time.Now().UTC()
+	username := "alice"
+	userRepo.users["user-1"] = &models.User{ID: "user-1", Email: "a@example.com", Username: &username}
+	domainRepo.domains["domain-1"] = &models.Domain{
+		ID: "domain-1", UserID: "user-1", Name: "warm.example.com",
+		DocRoot:   "/home/alice/domains/warm.example.com/public_html",
+		IsEnabled: true, CreatedAt: now, UpdatedAt: now,
+	}
+
+	srv := &fakeServerSettingsRepo{settings: &models.ServerSettings{ServerRole: role}}
+	r := New(domainRepo, userRepo, agent, log, Config{Interval: 1 * time.Second}).
+		WithDNSRepos(nil, nil, srv)
+	return r, agent
+}
+
+func TestReconcileAll_StandbyIsDormant(t *testing.T) {
+	r, agent := buildGateReconciler(t, models.ServerRoleStandby)
+	require.NoError(t, r.ReconcileAll(context.Background()))
+	agent.mu.Lock()
+	defer agent.mu.Unlock()
+	require.Empty(t, agent.calls, "a DR standby must make no agent calls in ReconcileAll (builds no serving config)")
+}
+
+func TestReconcileAll_PrimaryConverges(t *testing.T) {
+	r, agent := buildGateReconciler(t, models.ServerRolePrimary)
+	require.NoError(t, r.ReconcileAll(context.Background()))
+	agent.mu.Lock()
+	defer agent.mu.Unlock()
+	require.NotEmpty(t, agent.calls, "a primary must still converge (reach the agent)")
+	require.Equal(t, "domain.list", filterCallsByPrefix(agent.calls, "domain.")[0].method)
+}
+
+func TestReconcileOne_StandbyIsDormant(t *testing.T) {
+	r, agent := buildGateReconciler(t, models.ServerRoleStandby)
+	require.NoError(t, r.ReconcileOne(context.Background(), "domain-1"))
+	agent.mu.Lock()
+	defer agent.mu.Unlock()
+	require.Empty(t, agent.calls, "a DR standby must not converge a single domain either")
+}
+
+// A missing settings row (or nil repo) must NOT freeze a live box: isStandby
+// fails toward active primary, so ReconcileAll runs.
+func TestReconcileAll_UnseededSettingsRunsAsPrimary(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := &fakeAgent{}
+	domainRepo := &fakeDomainRepo{domains: make(map[string]*models.Domain)}
+	userRepo := &fakeUserRepo{users: make(map[string]*models.User)}
+	now := time.Now().UTC()
+	domainRepo.domains["d1"] = &models.Domain{ID: "d1", UserID: "u1", Name: "x.example.com", IsEnabled: true, CreatedAt: now, UpdatedAt: now}
+	// serverSettings repo with nil row → Get returns ErrNotFound.
+	srv := &fakeServerSettingsRepo{}
+	r := New(domainRepo, userRepo, agent, log, Config{Interval: 1 * time.Second}).WithDNSRepos(nil, nil, srv)
+	require.NoError(t, r.ReconcileAll(context.Background()))
+	agent.mu.Lock()
+	defer agent.mu.Unlock()
+	require.NotEmpty(t, agent.calls, "unseeded settings must be treated as primary, not park the box")
+}

--- a/panel-api/internal/repository/server_settings_repository.go
+++ b/panel-api/internal/repository/server_settings_repository.go
@@ -40,6 +40,14 @@ type ServerSettingsRepository interface {
 	// last fired for (GH #840). Targeted single-column UPDATE so it can
 	// never clobber a concurrent admin settings save.
 	SetDigestLastSent(ctx context.Context, day string) error
+
+	// RecordDRSync records the outcome of one drsync tick on a standby (GH
+	// #331 Step 2): the timestamp, status (models.DRSyncStatus*), and error
+	// string. snapshotID is written only when non-empty (i.e. a snapshot was
+	// actually applied) so a failed/waiting tick doesn't erase the last-known
+	// applied snapshot. Targeted UPDATE so it never clobbers a concurrent
+	// settings save.
+	RecordDRSync(ctx context.Context, snapshotID, status, syncErr string) error
 }
 
 type serverSettingsRepo struct{ db *gorm.DB }
@@ -147,4 +155,26 @@ func (r *serverSettingsRepo) SetDigestLastSent(ctx context.Context, day string) 
 		Model(&models.ServerSettings{}).
 		Where("1 = 1").
 		Update("digest_last_sent_date", day).Error
+}
+
+// RecordDRSync — see the interface doc. Empty WHERE targets the single
+// settings row. syncErr is truncated to the column width (1024) so a long
+// restic error string can never fail the UPDATE.
+func (r *serverSettingsRepo) RecordDRSync(ctx context.Context, snapshotID, status, syncErr string) error {
+	const maxErr = 1024
+	if len(syncErr) > maxErr {
+		syncErr = syncErr[:maxErr]
+	}
+	updates := map[string]any{
+		"dr_last_sync_at":     time.Now().UTC(),
+		"dr_last_sync_status": status,
+		"dr_last_sync_error":  syncErr,
+	}
+	if snapshotID != "" {
+		updates["dr_last_snapshot_id"] = snapshotID
+	}
+	return r.db.WithContext(ctx).
+		Model(&models.ServerSettings{}).
+		Where("1 = 1").
+		Updates(updates).Error
 }

--- a/panel-ui/src/components/DRStandbyBanner.tsx
+++ b/panel-ui/src/components/DRStandbyBanner.tsx
@@ -1,0 +1,30 @@
+// DRStandbyBanner (GH #331 Step 3) — a persistent warning shown on every page
+// when this box is a DR standby (read-only replica). It explains why mutations
+// are refused (middleware.StandbyReadOnly 409s them) and points at the promote
+// path. Rendered by both layouts; renders nothing on a primary.
+import { Alert } from "antd";
+import { useTranslation } from "react-i18next";
+
+import { useServerCapabilities } from "../hooks/useServerCapabilities";
+
+export function DRStandbyBanner() {
+  const { t } = useTranslation();
+  const { data: caps } = useServerCapabilities();
+  if (!caps?.is_standby) {
+    return null;
+  }
+  const peer = caps.dr_peer_label.trim();
+  const description = peer
+    ? t("dr.standby_banner_desc", { peer })
+    : t("dr.standby_banner_desc_nopeer");
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      banner
+      message={t("dr.standby_banner_title")}
+      description={description}
+      style={{ marginBottom: 16 }}
+    />
+  );
+}

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -25,6 +25,10 @@ export interface ServerCapabilities {
   public_ipv4: string;
   /** GH #361: the server's public IPv6, for the dashboard. "" when unset. */
   public_ipv6: string;
+  /** GH #331: this box is a DR standby (read-only replica). Drives the banner. */
+  is_standby: boolean;
+  /** GH #331: human label for the primary this standby replicates. "" when unset. */
+  dr_peer_label: string;
 }
 
 export function useServerCapabilities() {
@@ -47,6 +51,8 @@ export function useServerCapabilities() {
         root_terminal_enabled: !!data.root_terminal_enabled,
         public_ipv4: data.public_ipv4 ?? "",
         public_ipv6: data.public_ipv6 ?? "",
+        is_standby: !!data.is_standby,
+        dr_peer_label: data.dr_peer_label ?? "",
       };
     },
     staleTime: 60_000,

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1684,5 +1684,10 @@
     "this_is_the_highest_risk_feature_in_the_panel_le": "This is the highest-risk feature in the panel. Leave off unless actively needed.",
     "timezone": "Timezone",
     "working_folder": "Working Folder"
+  },
+  "dr": {
+    "standby_banner_title": "DR standby — read-only replica",
+    "standby_banner_desc": "This server is a disaster-recovery standby of {{peer}}. It mirrors the primary and serves no live traffic; changes are disabled until it is promoted with `jabali dr promote`.",
+    "standby_banner_desc_nopeer": "This server is a disaster-recovery standby. It mirrors the primary and serves no live traffic; changes are disabled until it is promoted with `jabali dr promote`."
   }
 }

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -9,6 +9,7 @@ import { Drawer, Grid, Layout, Menu, Tooltip, theme } from "antd";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { useServerCapabilities } from "../hooks/useServerCapabilities";
+import { DRStandbyBanner } from "../components/DRStandbyBanner";
 import { JabaliFooter } from "../components/JabaliFooter";
 import { JabaliHeader } from "../components/JabaliHeader";
 import { JabaliTitle } from "../components/JabaliTitle";
@@ -188,6 +189,7 @@ export function AdminLayout() {
               overflowX: "hidden",
             }}
           >
+            <DRStandbyBanner />
             <BreadcrumbProvider>
               <RouteBreadcrumb nav={adminNav} homePath="/jabali-admin/dashboard" homeLabel="Dashboard" />
               <Outlet />

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -8,6 +8,7 @@ import { LeftOutlined, RightOutlined } from "@icons";
 import { ConfigProvider, Drawer, Grid, Layout, Menu, theme } from "antd";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
+import { DRStandbyBanner } from "../components/DRStandbyBanner";
 import { JabaliFooter } from "../components/JabaliFooter";
 import { ImpersonationBanner } from "../components/ImpersonationBanner";
 import { JabaliHeader } from "../components/JabaliHeader";
@@ -187,6 +188,7 @@ export function UserLayout() {
               overflowX: "hidden",
             }}
           >
+            <DRStandbyBanner />
             <BreadcrumbProvider>
               <RouteBreadcrumb nav={userNav} homePath="/jabali-panel/dashboard" homeLabel="Dashboard" />
               <Outlet />


### PR DESCRIPTION
## GH #331 — DR standby node (one-way async warm standby, manual promotion)

A disaster-recovery standby: a read-only replica that pulls the primary's control
plane from a shared backup destination and is manually promoted during a disaster.
No auto-failover, no quorum, no active/active — the operator pointing traffic is the
fencing step. **Dormant on every existing box** (role defaults `primary`; the loop,
reconciler gate, and write-guard all early-return), so it is zero behaviour change
until an operator runs `jabali dr pair`.

### What lands (Steps 1–4 + a security fix)

- **Step 1** — `server_role` flag + `dr pair/status/unpair` CLI + `StandbyReadOnly`
  middleware (a standby 409s tenant mutations; DR/settings routes allowlisted).
- **Step 2** — `internal/drsync`: standby loop that lists the primary's
  `system_backup` manifests and, when a newer one lands, runs
  `system.restore {apply:true, include_accounts:false}` (panel DB + config + TLS).
  `dr feed` (primary side) ships to the DR destination; sync liveness recorded.
- **Step 3** — warm-not-serving posture: the reconciler stays dormant on a standby
  (no serving config, **no ACME issuance** for the primary's domains) + a read-only
  banner on every page.
- **Step 4** — `jabali dr promote`: split-brain guard (refuses while the old primary
  still answers a TCP probe unless `--force`), confirm-gated, final account-inclusive
  restore, role flip. Operator runbook in `docs/runbooks/dr-standby.md`.
- **Fix** — the Automation API mounts outside the `v1` group, so `StandbyReadOnly`
  didn't cover it; a standby would have accepted headless provisioning writes that
  diverge from the primary. Now guarded (reads still pass).

### Security

One-way least-privilege pull: the standby only lists/restores from the shared
destination and never holds a primary-mutating credential. The promote split-brain
guard uses a raw TCP probe (no TLS trust weakened — reachability is all that matters).

### Testing

Unit/integration only — a real cross-host pull-restore + promotion + DNS/MX cutover
needs a second host (documented in the runbook). Full `go test ./panel-api/...`
green incl. OpenAPI + CLI-reference + migration goldens; `tsc -b` + `vite build`
clean. New tests: drsync (10 cases), reconciler gate, promote split-brain gate,
standby capability field, automation-guard regression.

**Single-box mechanics drill on testserver** (2026-08-06): migrations apply clean,
`dr pair/status/unpair/feed` round-trip, drsync ticks live + records outcome,
`StandbyReadOnly` + automation-guard 409 live. Box reverted to as-found. The drill is
what surfaced the automation-guard gap.

### Not covered (needs a 2nd box)

Real cross-host pull-restore onto a fresh box, promotion with account restore, and
DNS/MX cutover. Run a two-VM drill before relying on this in production.
