### PR TITLE
fix(ssl): defer ACME quietly when the webroot doesn't exist yet (GH #887)

### DIFF
--- a/panel-agent/internal/commands/ssl_issue.go
+++ b/panel-agent/internal/commands/ssl_issue.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/certbot"
 )
+
+// WebrootNotReadyMarker is the stable sentinel the panel reconciler matches on
+// to tell "the document root does not exist yet" apart from a real ACME failure
+// (GH #887). Keep it in the AgentError message so it survives the wire round-trip.
+const WebrootNotReadyMarker = "webroot_not_ready"
 
 // sslIssueParams is the input shape for ssl.issue.
 //
@@ -80,6 +86,24 @@ func sslIssueHandler(ctx context.Context, params json.RawMessage) (any, error) {
 				Code:    agentwire.CodeInvalidArgument,
 				Message: fmt.Sprintf("invalid hostname %q in hostnames[]", h),
 			}
+		}
+	}
+
+	// GH #887: on a fresh domain — especially a subdomain whose document root
+	// the panel provisions asynchronously — the webroot may not exist yet on an
+	// early ACME attempt. certbot's webroot plugin would fail with a raw
+	// "…/public_html does not exist or is not a directory" that the panel then
+	// surfaces as an alarming certificate error. Detect it here and return a
+	// typed, self-explanatory "not ready" signal instead: the reconciler treats
+	// it as a quiet retry (the domain keeps its self-signed cert meanwhile) so
+	// the challenge is deferred until the docroot is created, and no Let's
+	// Encrypt request is spent failing. Checked last, after the format
+	// validations above, so a malformed request still gets its precise error.
+	if fi, statErr := os.Stat(p.Webroot); statErr != nil || !fi.IsDir() {
+		return nil, &agentwire.AgentError{
+			Code: agentwire.CodeFailedPrecondition,
+			Message: fmt.Sprintf("%s: %s does not exist yet; deferring ACME until the document root is created",
+				WebrootNotReadyMarker, p.Webroot),
 		}
 	}
 

--- a/panel-agent/internal/commands/ssl_issue_test.go
+++ b/panel-agent/internal/commands/ssl_issue_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -177,6 +178,34 @@ func TestSSLIssueValidation_AllowedWebroots(t *testing.T) {
 		if result != tt.allowed {
 			t.Errorf("%s: expected %v, got %v", tt.name, tt.allowed, result)
 		}
+	}
+}
+
+// GH #887: a format-valid webroot that does not exist yet must return the typed
+// webroot_not_ready signal (CodeFailedPrecondition) — NOT run certbot and NOT a
+// generic failure — so the panel reconciler can quietly defer ACME.
+func TestSSLIssue_WebrootNotReady(t *testing.T) {
+	params := sslIssueParams{
+		Domain:  "sub.example.com",
+		Webroot: "/home/nobody-gh887/domains/sub.example.com/public_html", // does not exist
+		Email:   "admin@example.com",
+	}
+	paramsJSON, _ := json.Marshal(params)
+
+	result, err := sslIssueHandler(context.Background(), paramsJSON)
+	if err == nil || result != nil {
+		t.Fatalf("expected typed error, got result=%v err=%v", result, err)
+	}
+	agentErr, ok := err.(*agentwire.AgentError)
+	if !ok {
+		t.Fatalf("expected *agentwire.AgentError, got %T", err)
+	}
+	if agentErr.Code != agentwire.CodeFailedPrecondition {
+		t.Errorf("code = %s, want %s", agentErr.Code, agentwire.CodeFailedPrecondition)
+	}
+	if !strings.Contains(agentErr.Message, WebrootNotReadyMarker) {
+		t.Errorf("message %q must carry the %q marker so the reconciler can match it",
+			agentErr.Message, WebrootNotReadyMarker)
 	}
 }
 

--- a/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
+++ b/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
@@ -19,6 +19,9 @@ type fakeSSLCertRepo struct {
 	exhaustedErr error
 	rearmErr     error
 	rearmed      map[string]int
+	// GH #887: counts ACME-failure recordings so a test can assert a
+	// webroot_not_ready deferral records NO failure (quiet skip).
+	acmeFailures int
 }
 
 func newFakeSSLCertRepo() *fakeSSLCertRepo {
@@ -62,9 +65,11 @@ func (f *fakeSSLCertRepo) UpdateCustom(context.Context, string, string, string, 
 	return nil
 }
 func (f *fakeSSLCertRepo) UpdateAfterACMEFailure(context.Context, string, string, time.Time, int, *string, *string, *time.Time) error {
+	f.acmeFailures++
 	return nil
 }
 func (f *fakeSSLCertRepo) UpdateAfterACMEFailureCapped(context.Context, string, string, int, *string, *string, *time.Time) error {
+	f.acmeFailures++
 	return nil
 }
 func (f *fakeSSLCertRepo) MarkFailed(context.Context, string, string) error { return nil }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2568,8 +2568,27 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 		return
 	}
 
+	// GH #887: the document root isn't there yet (fresh domain / subdomain the
+	// panel is still provisioning). This is NOT a real ACME failure — recording
+	// it would surface a scary "…/public_html does not exist" cert error and bump
+	// the retry backoff. The domain already carries a self-signed cert (the
+	// bootstrap path), so HTTPS keeps working; just leave the row as-is and let
+	// the next tick retry once the docroot exists. No LE request was spent.
+	if isWebrootNotReady(err) {
+		r.log.Debug("ssl: webroot not ready, deferring ACME to next tick", "domain", domain.Name)
+		return
+	}
+
 	// ACME failed — fall through to self-sign + scheduled retry.
 	r.fallbackToSelfSignAndRetry(ctx, domain, cert, firstLine(err.Error()))
+}
+
+// isWebrootNotReady reports whether an ssl.issue error is the agent's typed
+// "the document root does not exist yet" signal (GH #887), as opposed to a real
+// ACME failure. Matched on the stable marker string the agent embeds in the
+// error message so it survives the NDJSON wire round-trip.
+func isWebrootNotReady(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "webroot_not_ready")
 }
 
 // fallbackToSelfSignAndRetry is the "ACME unavailable" path used by both

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -21,9 +21,10 @@ import (
 
 // fakeAgent mocks the agent.AgentInterface for testing.
 type fakeAgent struct {
-	mu         sync.Mutex // JAB-205: ReconcileAll now calls the agent from a worker pool
-	calls      []fakeCall
-	failMethod string // if set, Call returns an error for this method
+	mu          sync.Mutex // JAB-205: ReconcileAll now calls the agent from a worker pool
+	calls       []fakeCall
+	failMethod  string           // if set, Call returns an error for this method
+	errByMethod map[string]error // if set for a method, Call returns that exact error
 }
 
 type fakeCall struct {
@@ -36,6 +37,11 @@ func (f *fakeAgent) Call(ctx context.Context, method string, params interface{})
 	f.calls = append(f.calls, fakeCall{method, params})
 	f.mu.Unlock()
 
+	if f.errByMethod != nil {
+		if e, ok := f.errByMethod[method]; ok {
+			return nil, e
+		}
+	}
 	if method == f.failMethod {
 		return nil, fmt.Errorf("agent call failed for method: %s", method)
 	}

--- a/panel-api/internal/reconciler/ssl_webroot_not_ready_test.go
+++ b/panel-api/internal/reconciler/ssl_webroot_not_ready_test.go
@@ -1,0 +1,98 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// sslWebrootFixture wires a reconciler whose domain has a self-signed cert (so
+// reconcileSSLForDomain routes to the ACME-upgrade path) and an ssl.issue that
+// fails with the given error.
+func sslWebrootFixture(t *testing.T, issueErr error) (*Reconciler, *fakeAgent, *fakeSSLCertRepo, *models.Domain) {
+	t.Helper()
+	dr := newFakeDomainRepo()
+	sc := newFakeSSLCertRepo()
+	srv := &fakeServerSettingsRepo{settings: &models.ServerSettings{AdminEmail: "admin@example.com"}}
+	ag := &fakeAgent{errByMethod: map[string]error{"ssl.issue": issueErr}}
+
+	dom := &models.Domain{
+		ID: "d1", Name: "sub.example.com", UserID: "u1",
+		DocRoot: "/home/u1/domains/sub.example.com/public_html",
+		SSLMode: models.SSLModeLE, IsEnabled: true,
+	}
+	dr.domains[dom.ID] = dom
+	// A self-signed cert already exists (the #916 bootstrap), so HTTPS works and
+	// reconcileSSLForDomain takes the self_signed -> tryACMEOrFallback branch.
+	cp, kp := "/etc/ssl/self/sub.crt", "/etc/ssl/self/sub.key"
+	exp := time.Now().UTC().Add(300 * 24 * time.Hour)
+	sc.byDomain[dom.ID] = &models.SSLCertificate{
+		ID: "c1", DomainID: dom.ID, Status: models.SSLStatusSelfSigned,
+		CertPath: &cp, KeyPath: &kp, ExpiresAt: &exp,
+	}
+
+	r := New(dr, nil, ag, slog.Default(), Config{}).
+		WithSSLCerts(sc).
+		WithDNSRepos(nil, nil, srv)
+	return r, ag, sc, dom
+}
+
+func agentCalled(ag *fakeAgent, method string) bool {
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	for _, c := range ag.calls {
+		if c.method == method {
+			return true
+		}
+	}
+	return false
+}
+
+// GH #887: a webroot_not_ready ssl.issue error must be a QUIET deferral — no
+// recorded ACME failure (no scary "docroot does not exist" surfaced, no retry
+// bump), no self-sign churn. The domain keeps its cert and retries next tick.
+func TestReconcileSSL_WebrootNotReady_IsQuietSkip(t *testing.T) {
+	r, ag, sc, dom := sslWebrootFixture(t,
+		errors.New("agent: failed_precondition: webroot_not_ready: /home/u1/domains/sub.example.com/public_html does not exist yet"))
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("expected ssl.issue to be attempted")
+	}
+	if sc.acmeFailures != 0 {
+		t.Errorf("webroot_not_ready must record NO ACME failure, got %d", sc.acmeFailures)
+	}
+	if agentCalled(ag, "ssl.self_sign") {
+		t.Error("webroot_not_ready must not churn a self-sign fallback")
+	}
+}
+
+// Contrast: a real ACME error must still record a failure (retry scheduled).
+func TestReconcileSSL_RealACMEError_RecordsFailure(t *testing.T) {
+	r, ag, sc, dom := sslWebrootFixture(t,
+		errors.New("agent: internal: certbot issue failed (unauthorized): DNS problem"))
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("expected ssl.issue to be attempted")
+	}
+	if sc.acmeFailures == 0 {
+		t.Error("a real ACME failure must be recorded (retry scheduled)")
+	}
+}
+
+func TestIsWebrootNotReady(t *testing.T) {
+	if !isWebrootNotReady(errors.New("x: webroot_not_ready: /p does not exist")) {
+		t.Error("must match the marker")
+	}
+	if isWebrootNotReady(errors.New("certbot issue failed: rate limited")) {
+		t.Error("must not match a real failure")
+	}
+	if isWebrootNotReady(nil) {
+		t.Error("nil is not webroot_not_ready")
+	}
+}


### PR DESCRIPTION
## GH #887 — defer ACME quietly when the webroot doesn't exist yet

The #916 self-signed-first fix reordered only the **first** reconcile tick. The
`self_signed → ACME` upgrade (and pending) paths still ran certbot's webroot
challenge unconditionally, so on any box where the document root isn't present
when that tick fires — a fresh subdomain the panel provisions asynchronously, or
a slow/failed `domain.create` — certbot fails with a raw `.../public_html does
not exist or is not a directory`. The panel surfaces that as an alarming cert
error and bumps the retry backoff (johnnyq reported it persists after updating).

### Fix
- **Agent** `ssl.issue` stats the webroot before invoking certbot and returns a
  typed `failed_precondition` **`webroot_not_ready`** signal instead of letting
  certbot fail ugly. Checked after format validation, so malformed requests keep
  their precise errors.
- **Reconciler** treats `webroot_not_ready` as a quiet skip: no failure recorded,
  no retry bump, no self-sign churn, no Let's Encrypt request spent. The domain
  keeps its self-signed cert (HTTPS stays up) and retries next tick once the
  docroot exists.

### Tests
Agent returns the typed marker for a missing webroot; reconciler records **no**
failure on `webroot_not_ready` but still records a real ACME error; matcher unit test.
