### PR TITLE
fix(opencart): make Twig loader open_basedir-compatible so pages render (GH #953)

### DIFF
--- a/panel-agent/internal/commands/opencart_install.go
+++ b/panel-agent/internal/commands/opencart_install.go
@@ -354,6 +354,12 @@ func opencartInstallHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 
+	// GH #953: make OpenCart's Twig loader compatible with jabali's per-user
+	// open_basedir confinement before it ever renders a page.
+	if err := patchOpenCartOpenBasedir(ctx, req.OSUser, installPath); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("patch twig open_basedir: %v", err)}
+	}
+
 	if err := runOpenCartCLIInstaller(ctx, req, installPath); err != nil {
 		// Best-effort cleanup so re-install works.
 		_ = exec.CommandContext(ctx, "rm", "-f",
@@ -372,6 +378,47 @@ func opencartInstallHandler(ctx context.Context, params json.RawMessage) (any, e
 	}
 
 	return opencartInstallResp{Version: opencartVersion}, nil
+}
+
+// rewriteOpenCartTwigLoader rewrites OpenCart's hardcoded Twig base path (GH
+// #953). OpenCart 4.x builds its loader as
+//
+//	new \Twig\Loader\FilesystemLoader('/', $this->root)
+//
+// using "/" as the base search path. Under jabali's per-user open_basedir
+// confinement, PHP's is_dir('/') is denied, so every storefront and admin page
+// dies with `open_basedir restriction in effect. File(/) ... The "/" directory
+// does not exist`. $this->root is already the install web root — inside the
+// user's home, hence inside open_basedir — so pointing the loader at it renders
+// correctly while leaving the hardening intact (absolute template paths, which
+// OpenCart passes at render time, resolve the same either way).
+//
+// Returns the rewritten content and whether a change was made. A miss (upstream
+// changed the construction) is a no-op, not an error — we never guess at a
+// shape we don't recognise.
+func rewriteOpenCartTwigLoader(content string) (string, bool) {
+	const oldLoader = `new \Twig\Loader\FilesystemLoader('/', $this->root)`
+	const newLoader = `new \Twig\Loader\FilesystemLoader($this->root, $this->root)`
+	if !strings.Contains(content, oldLoader) {
+		return content, false
+	}
+	return strings.Replace(content, oldLoader, newLoader, 1), true
+}
+
+// patchOpenCartOpenBasedir applies rewriteOpenCartTwigLoader to the installed
+// system/library/template/twig.php, writing it back as the OS user. Idempotent
+// and a no-op when the marker is absent (already patched / upstream changed).
+func patchOpenCartOpenBasedir(ctx context.Context, osUser, installPath string) error {
+	twigPath := filepath.Join(installPath, "system", "library", "template", "twig.php")
+	raw, err := os.ReadFile(twigPath) // #nosec G304 — fixed path under the validated install root
+	if err != nil {
+		return fmt.Errorf("read twig.php: %w", err)
+	}
+	patched, changed := rewriteOpenCartTwigLoader(string(raw))
+	if !changed {
+		return nil
+	}
+	return dokuwikiWriteUserFile(ctx, osUser, twigPath, patched, "0644")
 }
 
 func init() {

--- a/panel-agent/internal/commands/opencart_twig_patch_test.go
+++ b/panel-agent/internal/commands/opencart_twig_patch_test.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #953: OpenCart's Twig loader stats "/" (open_basedir-denied under jabali's
+// per-user confinement). rewriteOpenCartTwigLoader must repoint it at the
+// install web root ($this->root) so pages render without relaxing the hardening.
+func TestRewriteOpenCartTwigLoader(t *testing.T) {
+	const in = "\t\t$this->loader = new \\Twig\\Loader\\FilesystemLoader('/', $this->root);\n"
+	out, changed := rewriteOpenCartTwigLoader(in)
+	if !changed {
+		t.Fatal("expected the hardcoded '/' loader to be rewritten")
+	}
+	if strings.Contains(out, "FilesystemLoader('/',") {
+		t.Errorf("must not stat '/', got: %q", out)
+	}
+	if !strings.Contains(out, `FilesystemLoader($this->root, $this->root)`) {
+		t.Errorf("must point the loader at the web root, got: %q", out)
+	}
+}
+
+// A shape we don't recognise (already patched / upstream change) is a no-op,
+// never a spurious rewrite.
+func TestRewriteOpenCartTwigLoader_NoMarkerIsNoop(t *testing.T) {
+	for _, in := range []string{
+		`$this->loader = new \Twig\Loader\FilesystemLoader($this->root, $this->root);`, // already patched
+		`$this->loader = new \Twig\Loader\ArrayLoader([]);`,                            // unrelated
+		"",
+	} {
+		out, changed := rewriteOpenCartTwigLoader(in)
+		if changed || out != in {
+			t.Errorf("expected no-op for %q, got changed=%v out=%q", in, changed, out)
+		}
+	}
+}


### PR DESCRIPTION
## GH #953 — OpenCart pages die under open_basedir (`is_dir('/')`)

OpenCart 4.x builds its Twig template loader as
`new \Twig\Loader\FilesystemLoader('/', $this->root)` — using `/` as the base
search path. Under jabali's per-user `open_basedir` confinement, PHP's
`is_dir('/')` is denied, so every storefront and admin page dies with:

```
Warning: is_dir(): open_basedir restriction in effect. File(/) is not within the
allowed path(s) … system/storage/vendor/twig/twig/src/Loader/FilesystemLoader.php
The "/" directory does not exist ("/").
```

The install itself succeeds — but the store never serves (matches the report).

### Fix
`$this->root` is already the install web root (inside the user's home, hence
inside `open_basedir`), so the installer now repoints the loader at it:
`FilesystemLoader($this->root, $this->root)`. OpenCart passes **absolute**
template paths at render time, so resolution is identical — this only removes the
`/` stat; the hardening is untouched. Idempotent; a no-op if upstream changes the
construction.

### Verified
Reproduced on testserver (install OK, storefront = the open_basedir error page),
then confirmed the rewrite makes the storefront render (`HTTP 200`, "Your Store").
Unit tests cover the rewrite + the no-op cases.
