### PR TITLE
feat(logs): GET /logs/tail snapshot endpoint + document mail/logs

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -525,7 +525,7 @@ paths:
                 domain_id: { type: string, format: ulid }
                 kind:      { type: string, enum: [wordpress, joomla, drupal, moodle, ghost, opencart, prestashop, magento, drupal10, mediawiki, nextcloud, mautic, suitecrm, dolibarr, processmaker] }
                 path:      { type: string, default: "/", description: "Install path under doc-root." }
-      responses: { "201": { description: Install started — poll /applications/{id} for status } }
+      responses: { "201": { description: "Install started — poll /applications/{id} for status" } }
 
   # ----------------------------------------------------------- Backups ---
 
@@ -547,6 +547,35 @@ paths:
       responses: { "202": { description: Restore queued } }
 
   # --------------------------------------------------------- Databases ---
+
+  /mail/logs:
+    get:
+      tags: [Logs]
+      summary: List recent mail log entries for your domains (delivered/failed/queued)
+      parameters:
+        - { in: query, name: limit, schema: { type: integer, default: 50, description: "max entries" } }
+        - { in: query, name: offset, schema: { type: integer, default: 0 } }
+        - { in: query, name: sender, schema: { type: string, description: "filter by sender address" } }
+        - { in: query, name: recipient, schema: { type: string, description: "filter by recipient address" } }
+      responses:
+        "200":
+          description: Mail log page
+          content: { application/json: { schema: { type: object, properties: {
+            data: { type: array, items: { type: object } }, total: { type: integer }, page: { type: integer }, page_size: { type: integer } } } } }
+
+  /logs/tail:
+    get:
+      tags: [Logs]
+      summary: Tail a domain's nginx access or error log (last N lines, snapshot)
+      parameters:
+        - { in: query, name: domain_id, required: true, schema: { type: string, format: ulid, description: "the domain's ULID" } }
+        - { in: query, name: log_type, required: true, schema: { type: string, enum: [access, error] } }
+        - { in: query, name: lines, schema: { type: integer, default: 200, minimum: 1, maximum: 2000, description: "how many trailing lines" } }
+      responses:
+        "200":
+          description: Last log lines
+          content: { application/json: { schema: { type: object, properties: {
+            domain_id: { type: string }, log_type: { type: string }, lines: { type: array, items: { type: string } } } } } }
 
   /databases:
     get:

--- a/panel-api/internal/api/logs.go
+++ b/panel-api/internal/api/logs.go
@@ -1,11 +1,14 @@
 package api
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,6 +46,92 @@ func RegisterLogRoutes(g *gin.RouterGroup, cfg LogHandlerConfig) {
 	logs.POST("/access", h.createAccess)
 	logs.DELETE("/access/:stream_key", h.deleteAccess)
 	logs.GET("/types", h.listTypes)
+	logs.GET("/tail", h.tail)
+}
+
+// tail returns the last N lines of a domain's nginx access or error log as a
+// JSON snapshot — the request/response counterpart to the /logs/stream WebSocket
+// (which is a live follow, unusable from a stateless API client).
+//
+// It reuses the same vetted path resolver (logFilePathForDomain +
+// isSafeDomainSegment) and reads via `tail -n`, exactly like the streamer, so it
+// inherits the streamer's path-safety and file-access model. Ownership is
+// enforced: a non-admin can only read logs for a domain they own (404 on a
+// domain they don't, to avoid leaking existence).
+func (h *logHandler) tail(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+
+	logType := c.Query("log_type")
+	if logType != "access" && logType != "error" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "log_type must be 'access' or 'error'"})
+		return
+	}
+	domainID := c.Query("domain_id")
+	if domainID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "domain_id required"})
+		return
+	}
+	// Clamp lines to [1, 2000], default 200 — bounded so a client can never ask
+	// the server to buffer an unbounded log.
+	lines := 200
+	if v := c.Query("lines"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			lines = n
+		}
+	}
+	if lines < 1 {
+		lines = 1
+	}
+	if lines > 2000 {
+		lines = 2000
+	}
+
+	if h.cfg.Domains == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "domain service not available"})
+		return
+	}
+	domain, err := h.cfg.Domains.FindByID(c.Request.Context(), domainID)
+	if err != nil {
+		if err == repository.ErrNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "domain not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		}
+		return
+	}
+	if !claims.IsAdmin && domain.UserID != claims.UserID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "domain not found"})
+		return
+	}
+
+	logPath, err := logFilePathForDomain(domain.Name, logType)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid log request"})
+		return
+	}
+
+	cctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, "tail", "-n", strconv.Itoa(lines), logPath).Output()
+	if err != nil {
+		// Most commonly the file doesn't exist yet (no traffic). Treat as empty
+		// rather than a 500 — an empty log is a valid answer.
+		c.JSON(http.StatusOK, gin.H{
+			"domain_id": domainID, "log_type": logType, "lines": []string{},
+			"note": "log is empty or not yet created",
+		})
+		return
+	}
+	trimmed := strings.TrimRight(string(out), "\n")
+	var ls []string
+	if trimmed != "" {
+		ls = strings.Split(trimmed, "\n")
+	}
+	c.JSON(http.StatusOK, gin.H{"domain_id": domainID, "log_type": logType, "lines": ls})
 }
 
 // listTypes returns available log types and their descriptions

--- a/panel-api/internal/api/logs_tail_test.go
+++ b/panel-api/internal/api/logs_tail_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeDomains implements DomainRepository by embedding the interface (so every
+// method exists) and overriding only FindByID — the sole method tail uses.
+type fakeDomains struct {
+	repository.DomainRepository
+	d   *models.Domain
+	err error
+}
+
+func (f fakeDomains) FindByID(_ context.Context, _ string) (*models.Domain, error) {
+	return f.d, f.err
+}
+
+func tailRouter(t *testing.T, userID string, isAdmin bool, domains repository.DomainRepository) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: userID, IsAdmin: isAdmin})
+		c.Next()
+	})
+	RegisterLogRoutes(v1, LogHandlerConfig{Domains: domains})
+	return r
+}
+
+func TestLogTail(t *testing.T) {
+	owner := "01OWNER0000000000000000000"
+	dom := &models.Domain{ID: "01DOMAIN000000000000000000", UserID: owner, Name: "example.com"}
+
+	cases := []struct {
+		name    string
+		user    string
+		isAdmin bool
+		domains repository.DomainRepository
+		query   string
+		want    int
+	}{
+		{"bad log_type", owner, false, fakeDomains{d: dom}, "?domain_id=x&log_type=goaccess", http.StatusBadRequest},
+		{"missing domain_id", owner, false, fakeDomains{d: dom}, "?log_type=access", http.StatusBadRequest},
+		{"domain not found", owner, false, fakeDomains{err: repository.ErrNotFound}, "?domain_id=x&log_type=access", http.StatusNotFound},
+		{"cross-user is 404", "01OTHER0000000000000000000", false, fakeDomains{d: dom}, "?domain_id=x&log_type=access", http.StatusNotFound},
+		// Owner: ownership passes; the log file doesn't exist in the test env, so
+		// the handler returns 200 with an empty snapshot rather than a 500.
+		{"owner gets 200 empty", owner, false, fakeDomains{d: dom}, "?domain_id=x&log_type=access&lines=10", http.StatusOK},
+		{"admin any domain 200", "01ADMIN0000000000000000000", true, fakeDomains{d: dom}, "?domain_id=x&log_type=error", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tailRouter(t, tc.user, tc.isAdmin, tc.domains)
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/tail"+tc.query, nil)
+			r.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, tc.want, strings.TrimSpace(w.Body.String()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The web-log surface was WebSocket-stream only (`tail -f`), unusable from a stateless API client — an MCP tool, a script. Adds **`GET /logs/tail`**: the last N lines of a domain's nginx access/error log as a JSON snapshot (the request/response counterpart to the live-tail).

It reuses the WS streamer's vetted machinery — `logFilePathForDomain` + `isSafeDomainSegment` for path safety, `tail -n` to read — and mirrors `createAccess`'s ownership check: a non-admin can only read logs for a domain they own (**404** on one they don't, to avoid leaking existence). `lines` is clamped to 1..2000; a missing log file returns **200 empty**, not 500.

`openapi.yaml`: documents `GET /logs/tail` and the existing `GET /mail/logs` (both consumed by [jabali-mcp](https://github.com/shukiv/jabali-mcp)'s `tail_web_log` / `list_mail_logs` tools), and quotes the flow-style `{id}` description on line 528 so a strict YAML parser accepts the spec — **supersedes #955**.

## Test plan
- [x] `logs_tail_test.go`: bad `log_type`→400, missing `domain_id`→400, not-found→404, cross-user→404, owner/admin→200
- [x] `go build ./panel-api/...`, `go test -race`, `gofmt` clean
- [x] spec parses under a strict YAML parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)