### PR TITLE
fix(backup): actionable error when a repo exists but cannot be decrypted (GH #454)

### DIFF
--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -133,6 +133,40 @@ func bkResticConfigWithPassword(repoURL, credentialsRef, passwordFile string, sf
 	return cfg, nil
 }
 
+// repoProbeClass classifies the stderr of a failed `restic snapshots` probe so
+// bkEnsureRepoReady can tell "repo isn't there yet, go init it" apart from
+// "repo is there but we can't open it" (GH #454) apart from anything else.
+type repoProbeClass int
+
+const (
+	repoProbeOther      repoProbeClass = iota // unknown failure — surface raw
+	repoProbeMissing                          // no repo at the location → init
+	repoProbeUnopenable                       // repo exists but can't be decrypted/read
+)
+
+// classifyRepoProbe maps a lowercased restic stderr to a repoProbeClass. Strings
+// are the verbatim messages restic 0.16 emits (captured against 0.16.4):
+//   - missing:    "unable to open config file: … no such file …" / "repository does not exist"
+//   - unopenable: "wrong password or no key found" (foreign/rotated password),
+//                 "config or key <id> is damaged: ciphertext verification failed" (corrupt/foreign)
+//
+// Order matters: the missing case also contains "config file", so check the
+// unopenable signals (which never co-occur with a missing repo) first is not
+// required — the missing markers are specific — but we check missing explicitly.
+func classifyRepoProbe(lowerStderr string) repoProbeClass {
+	if strings.Contains(lowerStderr, "wrong password or no key found") ||
+		strings.Contains(lowerStderr, "ciphertext verification failed") ||
+		strings.Contains(lowerStderr, "is damaged") {
+		return repoProbeUnopenable
+	}
+	if strings.Contains(lowerStderr, "repository does not exist") ||
+		strings.Contains(lowerStderr, "unable to open config file") ||
+		strings.Contains(lowerStderr, "is there a repository at") {
+		return repoProbeMissing
+	}
+	return repoProbeOther
+}
+
 // bkEnsureRepoReady probes the remote and runs mkdir -p (SFTP only) +
 // `restic init` if the repo doesn't exist yet. Idempotent — succeeds
 // on already-initialized repos. Local destinations get the parent dir
@@ -154,11 +188,23 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind st
 		return nil
 	}
 	lower := strings.ToLower(strings.TrimSpace(string(snapStderr)))
-	if !strings.Contains(lower, "repository does not exist") &&
-		!strings.Contains(lower, "unable to open config file") {
-		// Not a missing-repo signal — surface up.
+	switch classifyRepoProbe(lower) {
+	case repoProbeUnopenable:
+		// A repository that EXISTS but cannot be opened (GH #454). Actionable
+		// message instead of the raw restic dump — see classifyRepoProbe.
+		return fmt.Errorf("backup repository at %q exists but this server cannot open it (%s).\n"+
+			"This usually means the server (or /etc/jabali-panel/restic-repo.password) was reinstalled or "+
+			"regenerated while the repository directory was preserved, so the snapshots are sealed with a "+
+			"password this server no longer has (or the repo's config/key files are corrupted). To recover: "+
+			"(a) restore the ORIGINAL /etc/jabali-panel/restic-repo.password from before the reinstall, or "+
+			"(b) point this backup destination at a FRESH empty directory to start a new repository — the old "+
+			"snapshots stay on disk but are unreadable without their original password.",
+			repoURL, lower)
+	case repoProbeOther:
+		// Not a missing-repo signal, not a known unopenable signal — surface raw.
 		return fmt.Errorf("snapshots probe: %w (stderr: %s)", snapErr, lower)
 	}
+	// repoProbeMissing → fall through to init below.
 	if destKind == "sftp" && sftp != nil && sftp.Host != "" {
 		if _, err := backup.MkdirRemoteSFTP(ctx, backup.SFTPInputs{
 			Host:    sftp.Host,

--- a/panel-agent/internal/commands/backup_repo_probe_test.go
+++ b/panel-agent/internal/commands/backup_repo_probe_test.go
@@ -1,0 +1,51 @@
+package commands
+
+// GH #454: a restic repo that EXISTS but can't be opened (host reinstall
+// regenerated the box password while a /backups disk was preserved, or the
+// config/key files are corrupt) used to surface as a raw "snapshots probe:
+// exit status 1 (stderr: …)" that read as "backups are broken". classifyRepoProbe
+// separates that from a genuinely-missing repo (→ init) so the operator gets an
+// actionable recovery message. These strings are verbatim restic 0.16.4 output.
+
+import "testing"
+
+func TestClassifyRepoProbe(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   repoProbeClass
+	}{
+		{
+			name:   "missing local repo",
+			stderr: "fatal: unable to open config file: stat /backups/config: no such file or directory\nis there a repository at the following location?\n/backups",
+			want:   repoProbeMissing,
+		},
+		{
+			name:   "missing (older phrasing)",
+			stderr: "fatal: repository does not exist: unable to open config file",
+			want:   repoProbeMissing,
+		},
+		{
+			name:   "wrong/rotated password (the #454 reinstall case)",
+			stderr: "fatal: wrong password or no key found",
+			want:   repoProbeUnopenable,
+		},
+		{
+			name:   "damaged config — the reporter's exact error",
+			stderr: "fatal: config or key eece3d748ff57531b620a3cd0441eb7cde4d1334762dab8c943efeba35c92397 is damaged: ciphertext verification failed",
+			want:   repoProbeUnopenable,
+		},
+		{
+			name:   "unknown failure surfaces raw",
+			stderr: "fatal: unable to connect: connection refused",
+			want:   repoProbeOther,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyRepoProbe(c.stderr); got != c.want {
+				t.Errorf("classifyRepoProbe(%q) = %d, want %d", c.stderr, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`bkEnsureRepoReady` gave a raw restic dump when a backup repository **exists but can't be decrypted**, which read as "backups are broken" (GH #454):

```
ensure_repo_failed=snapshots probe: restic snapshots: exit status 1
(stderr: Fatal: config or key <id> is damaged: ciphertext verification failed)
```

## Cause

The probe only split "repo missing" (→ init) from "everything else" (→ raw error). A repo that exists but can't be opened fell into the raw path. This is the reinstall scenario: a full OS reinstall regenerates `/etc/jabali-panel/restic-repo.password` (install.sh creates it only when absent), but a preserved local backup dir (e.g. a separate `/backups` disk) still holds a repo sealed with the previous password.

## Fix

`classifyRepoProbe()` → missing / unopenable / other (match strings captured verbatim from restic 0.16.4). The unopenable case returns an actionable message naming the likely reinstall cause and the two recovery paths. Also adds restic 0.16's `Is there a repository at…` to the missing signals so a fresh local destination still auto-inits.

## Test

Unit test pins the classifier against the three verbatim restic messages. Verified end-to-end on a real box: sealed a `/backups` repo with a different password, ran an account_backup — orchestrator now logs the actionable message + both recovery options instead of the raw dump.

Refs GH #454.
