### PR TITLE
fix(packages): persist Max Backup Schedules on package edit (GH #454)

### DIFF
--- a/panel-api/internal/repository/package_repository.go
+++ b/panel-api/internal/repository/package_repository.go
@@ -118,7 +118,10 @@ func (r *packageRepo) Update(ctx context.Context, p *models.HostingPackage) erro
 		// update handler but missed here, so the admin's backup-limit changes
 		// reported success yet silently never persisted (reverted on reload) —
 		// the allowlist silent-drop scar exactly as warned above.
-		"max_backups", "scheduled_backups_enabled",
+		// GH #454 7B: max_backup_schedules was added later than the other four
+		// and missed here too — editing "Max Backup Schedules" on a package
+		// reported success but reverted on reload (same silent-drop scar).
+		"max_backups", "max_backup_schedules", "scheduled_backups_enabled",
 		"allowed_backup_destination_kinds", "backup_retention_policy",
 		"updated_at",
 	).Updates(p).Error; err != nil {

--- a/panel-api/internal/repository/package_repository_test.go
+++ b/panel-api/internal/repository/package_repository_test.go
@@ -119,6 +119,9 @@ func TestPackage_Update_PersistsPHPExecEnabled(t *testing.T) {
 // appears in the emitted UPDATE (each would be absent with the old allowlist).
 func TestPackage_Update_PersistsBackupLimits(t *testing.T) {
 	updatePersistsColumn(t, "max_backups")
+	// GH #454 7B: this one was the actual reported bug — editing Max Backup
+	// Schedules on a package saved-with-success but reverted on reload.
+	updatePersistsColumn(t, "max_backup_schedules")
 	updatePersistsColumn(t, "scheduled_backups_enabled")
 	updatePersistsColumn(t, "allowed_backup_destination_kinds")
 	updatePersistsColumn(t, "backup_retention_policy")


### PR DESCRIPTION
## What

Editing a hosting package's **Max Backup Schedules** reported success but reverted on reload (GH #454).

## Cause

Same allow-list silent-drop scar as #170 / #402 / #339: `packageRepo.Update` enumerates every persistable column in a GORM `Select()` allow-list, and `max_backup_schedules` (added in the #454 7B multi-schedule work, after the other four backup columns) was missed — so GORM dropped it from the UPDATE and the admin's change never hit the row.

## Fix

Add `max_backup_schedules` to the allow-list. Extend `TestPackage_Update_PersistsBackupLimits` to assert it appears in the emitted UPDATE — the test **fails without the fix** (sqlmock shows the column absent from the SET clause) and passes with it.

Refs GH #454.
