### PR TITLE
feat(migrate): Jabali → Jabali account migration (GH #954)

### DIFF
--- a/internal/kratosclient/admin.go
+++ b/internal/kratosclient/admin.go
@@ -631,65 +631,164 @@ type ExportedIdentity struct {
 	UpdatedAt           string          `json:"updated_at"`
 }
 
-// ExportIdentities exports all identities from Kratos using the official export API.
-// Returns the raw export data that can be saved to backup and later imported.
+// ExportIdentities returns every identity WITH its password credential (the
+// bcrypt hash), suitable for embedding in a backup bundle and re-importing via
+// ImportIdentities.
+//
+// GH #954 post-mortem: the old implementation did one GET with `?export=true` —
+// but `export=true` is not a Kratos API parameter (silently ignored) and list
+// responses NEVER include credentials, so every backup's "exported identity"
+// lacked the password hash and the restored user could not log in. The real
+// contract (verified against Kratos v26.2.0): list to enumerate ids, then
+// re-fetch each with `?include_credential=password`, which DOES return
+// credentials.password.config.hashed_password.
 func (c *Client) ExportIdentities(ctx context.Context) ([]ExportedIdentity, error) {
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		c.adminURL+"/admin/identities?export=true", nil)
-	if err != nil {
-		return nil, fmt.Errorf("exportidentities: request: %w", err)
+	var out []ExportedIdentity
+	token := ""
+	for {
+		page, next, err := c.ListIdentitiesPage(ctx, 250, token)
+		if err != nil {
+			return nil, fmt.Errorf("exportidentities: %w", err)
+		}
+		for _, id := range page {
+			full, err := c.getExportedIdentity(ctx, id.ID)
+			if err != nil {
+				return nil, fmt.Errorf("exportidentities: identity %s: %w", id.ID, err)
+			}
+			out = append(out, *full)
+		}
+		if next == "" {
+			break
+		}
+		token = next
 	}
-
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("exportidentities: do: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("exportidentities: status %d: %s", resp.StatusCode, string(errBody))
-	}
-
-	var exports []ExportedIdentity
-	if err := json.NewDecoder(resp.Body).Decode(&exports); err != nil {
-		return nil, fmt.Errorf("exportidentities: decode: %w", err)
-	}
-
-	return exports, nil
+	return out, nil
 }
 
-// ImportIdentities imports identities to Kratos using the official import API.
-// The identities parameter should contain data previously exported by ExportIdentities.
-func (c *Client) ImportIdentities(ctx context.Context, identities []ExportedIdentity) error {
-	if len(identities) == 0 {
-		return nil
-	}
-
-	body, err := json.Marshal(identities)
+// getExportedIdentity fetches one identity including its password credential.
+func (c *Client) getExportedIdentity(ctx context.Context, identityID string) (*ExportedIdentity, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.adminURL+"/admin/identities/"+url.PathEscape(identityID)+"?include_credential=password", nil)
 	if err != nil {
-		return fmt.Errorf("importidentities: marshal: %w", err)
+		return nil, fmt.Errorf("request: %w", err)
 	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		c.adminURL+"/admin/identities/import", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("importidentities: request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("importidentities: do: %w", err)
+		return nil, fmt.Errorf("do: %w", err)
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("importidentities: status %d: %s", resp.StatusCode, string(errBody))
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, string(errBody))
 	}
+	var full ExportedIdentity
+	if err := json.NewDecoder(resp.Body).Decode(&full); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &full, nil
+}
 
+// exportedPasswordHash extracts credentials.password.config.hashed_password
+// from an exported identity's raw credentials blob. Empty when the blob is
+// missing, malformed, or carries no password credential (old backups made
+// before ExportIdentities captured credentials).
+func exportedPasswordHash(credentials json.RawMessage) string {
+	if len(credentials) == 0 {
+		return ""
+	}
+	var creds struct {
+		Password struct {
+			Config struct {
+				HashedPassword string `json:"hashed_password"`
+			} `json:"config"`
+		} `json:"password"`
+	}
+	if err := json.Unmarshal(credentials, &creds); err != nil {
+		return ""
+	}
+	return creds.Password.Config.HashedPassword
+}
+
+// ImportIdentities re-creates previously exported identities.
+//
+// GH #954 post-mortem: the old implementation POSTed the batch to
+// `/admin/identities/import` — a route that does not exist in Kratos (the
+// router matches /admin/identities/{id} with id="import", where POST is not
+// allowed → 405 on every restore, ever). The real contract is one
+// POST /admin/identities per identity with a CreateIdentityBody: only the
+// fields Kratos accepts on create, with the password credential transformed
+// from the exported shape (password.config.hashed_password) into the create
+// shape (credentials.password.config.hashed_password).
+//
+// An identity whose traits already exist (409 conflict) is skipped, not an
+// error — restore re-runs and same-box drills hit this constantly.
+func (c *Client) ImportIdentities(ctx context.Context, identities []ExportedIdentity) error {
+	for _, id := range identities {
+		schemaID := id.SchemaID
+		if schemaID == "" {
+			schemaID = "default"
+		}
+		payload := map[string]any{
+			"schema_id": schemaID,
+			"traits":    id.Traits,
+		}
+		if id.State != "" {
+			payload["state"] = id.State
+		}
+		if len(id.MetadataPublic) > 0 && string(id.MetadataPublic) != "null" {
+			payload["metadata_public"] = id.MetadataPublic
+		}
+		if len(id.MetadataAdmin) > 0 && string(id.MetadataAdmin) != "null" {
+			payload["metadata_admin"] = id.MetadataAdmin
+		}
+		if hash := exportedPasswordHash(id.Credentials); hash != "" {
+			payload["credentials"] = map[string]any{
+				"password": map[string]any{
+					"config": map[string]any{"hashed_password": hash},
+				},
+			}
+		}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("importidentities: marshal: %w", err)
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			c.adminURL+"/admin/identities", bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("importidentities: request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		resp, err := c.httpClient.Do(httpReq)
+		if err != nil {
+			return fmt.Errorf("importidentities: do: %w", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		status := resp.StatusCode
+		if cerr := resp.Body.Close(); cerr != nil && status < 300 {
+			return fmt.Errorf("importidentities: close body: %w", cerr)
+		}
+		if status == http.StatusConflict {
+			continue // identity already present — restore re-run / same-box drill
+		}
+		if status != http.StatusCreated && status != http.StatusOK {
+			return fmt.Errorf("importidentities: status %d", status)
+		}
+	}
 	return nil
+}
+
+// IdentityHasPassword reports whether the identity has a password credential
+// set (a stored hash). Restore flows use it to decide whether the account can
+// actually log in or needs a recovery link.
+func (c *Client) IdentityHasPassword(ctx context.Context, identityID string) (bool, error) {
+	if identityID == "" {
+		return false, ErrIdentityNotFound
+	}
+	full, err := c.getExportedIdentity(ctx, identityID)
+	if err != nil {
+		return false, fmt.Errorf("identityhaspassword: %w", err)
+	}
+	return exportedPasswordHash(full.Credentials) != "", nil
 }
 
 // randomCanarySuffix returns a hex-encoded random token for constructing a

--- a/internal/kratosclient/export_import_test.go
+++ b/internal/kratosclient/export_import_test.go
@@ -1,0 +1,170 @@
+package kratosclient
+
+// GH #954: the export/import pair was doubly broken — export used a
+// nonexistent `?export=true` param (credentials silently absent from every
+// backup) and import POSTed to /admin/identities/import (a route Kratos
+// doesn't have → 405 on every restore). These tests pin the REAL contract,
+// verified against a live Kratos v26.2.0: export = list + per-identity
+// re-fetch with include_credential=password; import = one
+// POST /admin/identities per identity with the credential transformed into
+// the create shape, 409 = already-present = skip.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestExportIdentities_FetchesCredentials(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/admin/identities":
+			// List page: NO credentials here — that's the point.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"id":"id-1","traits":{"email":"a@x.com"}},{"id":"id-2","traits":{"email":"b@x.com"}}]`))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/admin/identities/"):
+			if r.URL.Query().Get("include_credential") != "password" {
+				t.Errorf("per-identity fetch must ask include_credential=password, got %q", r.URL.RawQuery)
+			}
+			id := strings.TrimPrefix(r.URL.Path, "/admin/identities/")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"` + id + `","schema_id":"default","state":"active","traits":{"email":"` + id + `@x.com"},"credentials":{"password":{"type":"password","config":{"hashed_password":"$2a$10$hash-` + id + `"}}}}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	exports, err := newAdminClient(srv).ExportIdentities(context.Background())
+	if err != nil {
+		t.Fatalf("ExportIdentities: %v", err)
+	}
+	if len(exports) != 2 {
+		t.Fatalf("want 2 identities, got %d", len(exports))
+	}
+	for _, e := range exports {
+		if hash := exportedPasswordHash(e.Credentials); !strings.HasPrefix(hash, "$2a$10$hash-") {
+			t.Errorf("identity %s: credentials not captured (hash=%q)", e.ID, hash)
+		}
+	}
+}
+
+func TestImportIdentities_CreatesWithTransformedCredential(t *testing.T) {
+	t.Parallel()
+	var captured []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The ONLY correct route: POST /admin/identities (per identity).
+		// /admin/identities/import does not exist in Kratos.
+		if r.Method != http.MethodPost || r.URL.Path != "/admin/identities" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "no such route", http.StatusMethodNotAllowed)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var p map[string]any
+		_ = json.Unmarshal(body, &p)
+		captured = append(captured, p)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"new-id"}`))
+	}))
+	defer srv.Close()
+
+	ids := []ExportedIdentity{{
+		ID:          "src-id",
+		SchemaID:    "default",
+		State:       "active",
+		Traits:      json.RawMessage(`{"email":"a@x.com","username":"a"}`),
+		Credentials: json.RawMessage(`{"password":{"type":"password","identifiers":["a@x.com"],"config":{"hashed_password":"$2a$10$abc"}}}`),
+	}}
+	if err := newAdminClient(srv).ImportIdentities(context.Background(), ids); err != nil {
+		t.Fatalf("ImportIdentities: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("want 1 create call, got %d", len(captured))
+	}
+	p := captured[0]
+	// Exported credential shape must be TRANSFORMED into the create shape —
+	// only config.hashed_password survives; type/identifiers must not ride.
+	creds, _ := p["credentials"].(map[string]any)
+	pw, _ := creds["password"].(map[string]any)
+	cfg, _ := pw["config"].(map[string]any)
+	if cfg["hashed_password"] != "$2a$10$abc" {
+		t.Errorf("hashed_password not carried: %v", p["credentials"])
+	}
+	if _, has := pw["type"]; has {
+		t.Error("exported-only field 'type' must not be sent to create")
+	}
+	if _, has := p["id"]; has {
+		t.Error("source identity id must not be sent to create (Kratos assigns)")
+	}
+}
+
+func TestImportIdentities_NoCredential_OmitsCredentials(t *testing.T) {
+	t.Parallel()
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"new-id"}`))
+	}))
+	defer srv.Close()
+
+	// Old bundle: identity exported before credentials capture — no password.
+	ids := []ExportedIdentity{{Traits: json.RawMessage(`{"email":"a@x.com"}`)}}
+	if err := newAdminClient(srv).ImportIdentities(context.Background(), ids); err != nil {
+		t.Fatalf("ImportIdentities: %v", err)
+	}
+	if _, has := captured["credentials"]; has {
+		t.Error("credential-less export must create WITHOUT a credentials block")
+	}
+	if captured["schema_id"] != "default" {
+		t.Errorf("empty schema_id must default, got %v", captured["schema_id"])
+	}
+}
+
+func TestImportIdentities_ConflictIsSkip(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"code":409}}`, http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	ids := []ExportedIdentity{{Traits: json.RawMessage(`{"email":"a@x.com"}`)}}
+	if err := newAdminClient(srv).ImportIdentities(context.Background(), ids); err != nil {
+		t.Fatalf("409 must be treated as already-present (restore re-run), got %v", err)
+	}
+}
+
+func TestIdentityHasPassword(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("include_credential") != "password" {
+			t.Errorf("must ask include_credential=password, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/with-pw") {
+			_, _ = w.Write([]byte(`{"id":"with-pw","credentials":{"password":{"config":{"hashed_password":"$2a$10$x"}}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"no-pw","credentials":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newAdminClient(srv)
+	if has, err := c.IdentityHasPassword(context.Background(), "with-pw"); err != nil || !has {
+		t.Errorf("with-pw: want true, got %v %v", has, err)
+	}
+	if has, err := c.IdentityHasPassword(context.Background(), "no-pw"); err != nil || has {
+		t.Errorf("no-pw: want false, got %v %v", has, err)
+	}
+	if _, err := c.IdentityHasPassword(context.Background(), ""); err == nil {
+		t.Error("empty id must error")
+	}
+}

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -488,7 +488,15 @@ func applyAccountRestore(
 				warnings = append(warnings, "mail: Stalwart inactive — message import skipped")
 				continue
 			}
-			impRes, impErr := importMaildirTree(ctx, mailTree, "", migrationStagingRoots)
+			// GH #954: scope filesafe to THIS restore's staging dir, not
+			// migrationStagingRoots. The mail tree materializes under
+			// /var/lib/jabali-backups/restore-staging/<job>/mail, which is NOT a
+			// migration root — so openMaildirFileInStaging refused every message
+			// file's open, and every account-restore silently imported 0 bodies
+			// (the "messages not replayed" symptom). stagingRoot is agent-owned,
+			// not tenant-writable; RESOLVE_BENEATH under it still blocks symlink
+			// escape inside the restored tree.
+			impRes, impErr := importMaildirTree(ctx, mailTree, "", []string{stagingRoot})
 			if impErr != nil {
 				warnings = append(warnings, fmt.Sprintf("mail: import: %v", impErr))
 				continue

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -49,7 +49,16 @@ type backupRestoreParams struct {
 	Overwrite      bool              `json:"overwrite"`
 	RepoURL        string            `json:"repo_url,omitempty"`
 	CredentialsRef string            `json:"credentials_ref,omitempty"`
-	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
+	// PasswordFile lets the caller point restic at a repo password other
+	// than the box-wide /etc/jabali-panel/restic-repo.password. GH #954
+	// (Jabali→Jabali migration): the pulled source repo is encrypted with
+	// the SOURCE box's restic password, so the import stages it and passes
+	// that password's path here — reading the foreign repo without rekeying
+	// it. Empty falls back to the box-wide file (every existing caller).
+	// Exact parity with backup.account_list_manifests, which already threads
+	// this field.
+	PasswordFile string            `json:"password_file,omitempty"`
+	SFTP         *backupSFTPInputs `json:"sftp,omitempty"`
 	// ApplyStaged: when false the handler stops after materializing
 	// stages into /var/lib/jabali-backups/restore-staging/<job_id>/
 	// (recon mode). Default true → home+db are applied onto the live
@@ -118,7 +127,7 @@ func backupRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	}
 	defer syscall.Flock(int(lf.Fd()), syscall.LOCK_UN)
 
-	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.SFTP)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -291,7 +291,10 @@ func applySelectiveMail(ctx context.Context, stagingRoot string, mailboxes []str
 			warnings = append(warnings, "mail "+mb+": not found in this backup — skipped")
 			continue
 		}
-		n, _, _, ierr := importOneMailbox(ctx, mb, md, migrationStagingRoots)
+		// GH #954: scope filesafe to this restore's staging dir (see
+		// backup_restore.go) — the tree lives under restore-staging, not a
+		// migration root, so migrationStagingRoots refused every open.
+		n, _, _, ierr := importOneMailbox(ctx, mb, md, []string{stagingRoot})
 		if ierr != nil {
 			warnings = append(warnings, "mail "+mb+": import: "+ierr.Error())
 			continue

--- a/panel-agent/internal/commands/mail_restore_staging_root_test.go
+++ b/panel-agent/internal/commands/mail_restore_staging_root_test.go
@@ -1,0 +1,60 @@
+package commands
+
+// GH #954 regression: account-restore materializes the mail Maildir under
+// /var/lib/jabali-backups/restore-staging/<job>/mail, but importMaildirTree was
+// called with migrationStagingRoots (only the /var/lib/…/migrations paths).
+// filesafe.OpenInScope then refused every message-file open, so every
+// account-restore + Jabali→Jabali migration silently imported 0 message bodies.
+// These tests pin the fix: the staged message opens (and its Message-ID reads)
+// ONLY when the staging root is in allowedRoots, and NOT under migrationStagingRoots.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// stageAMessage lays down restore-staging-shaped Maildir with one message and
+// returns (stagingRoot, messageFilePath).
+func stageAMessage(t *testing.T) (string, string) {
+	t.Helper()
+	stagingRoot := t.TempDir()
+	newDir := filepath.Join(stagingRoot, "mail", "run", "jabali-backup", "JOB", "mail", "ex.com", "box", "new")
+	if err := os.MkdirAll(newDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	msg := filepath.Join(newDir, "eaaaaab.jabali,620")
+	if err := os.WriteFile(msg, []byte("Message-ID: <mark@ex.com>\r\nSubject: hi\r\n\r\nbody\r\n"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	return stagingRoot, msg
+}
+
+func TestMailRestore_OpensOnlyUnderStagingRoot(t *testing.T) {
+	stagingRoot, msg := stageAMessage(t)
+
+	// Correct wiring (the fix): the job's own staging root is allowed → open works.
+	f, err := openMaildirFileInStaging(msg, []string{stagingRoot})
+	if err != nil {
+		t.Fatalf("with stagingRoot allowed, open must succeed, got %v", err)
+	}
+	_ = f.Close()
+
+	// The bug: migrationStagingRoots does NOT contain restore-staging → refused.
+	if _, err := openMaildirFileInStaging(msg, migrationStagingRoots); err == nil {
+		t.Error("with migrationStagingRoots (the old wiring), the staged message must be refused — that was the 0-messages bug")
+	}
+}
+
+func TestMailRestore_MessageIDReadsOnlyInScope(t *testing.T) {
+	stagingRoot, msg := stageAMessage(t)
+
+	if mid := messageIDFromFile(msg, []string{stagingRoot}); mid != "mark@ex.com" {
+		t.Errorf("in-scope Message-ID must read, got %q", mid)
+	}
+	// Out of scope → open fails → "" (dedup silently disabled, and — the real
+	// bug — uploadBlob would fail too, dropping the message).
+	if mid := messageIDFromFile(msg, migrationStagingRoots); mid != "" {
+		t.Errorf("out-of-scope must yield empty Message-ID, got %q", mid)
+	}
+}

--- a/panel-api/cmd/server/account_restore_cmd.go
+++ b/panel-api/cmd/server/account_restore_cmd.go
@@ -102,11 +102,10 @@ func applyPanelMetadata(ctx context.Context, cmd *cobra.Command, raw json.RawMes
 		}
 	}
 
-	fmt.Fprintln(w, "Note: mailbox + forwarder ROWS are reconstructed above — accounts")
-	fmt.Fprintln(w, "authenticate again via the Stalwart SQL directory. Stored Maildir")
-	fmt.Fprintln(w, "MESSAGES are NOT replayed by account-restore yet; migrate old mail")
-	fmt.Fprintln(w, "separately. DNSSEC keys are not in this bundle — re-enable with")
-	fmt.Fprintln(w, "`jabali pdns dnssec enable`.")
+	fmt.Fprintln(w, "Note: mailbox + forwarder ROWS are reconstructed above and their stored")
+	fmt.Fprintln(w, "Maildir MESSAGES are replayed into Stalwart via JMAP (see the mail →")
+	fmt.Fprintln(w, "line in the agent output for the count). DNSSEC keys are not in this")
+	fmt.Fprintln(w, "bundle — re-enable with `jabali pdns dnssec enable`.")
 }
 
 func boolMark(b bool) string {

--- a/panel-api/cmd/server/account_restore_cmd.go
+++ b/panel-api/cmd/server/account_restore_cmd.go
@@ -76,6 +76,15 @@ func applyPanelMetadata(ctx context.Context, cmd *cobra.Command, raw json.RawMes
 	fmt.Fprintf(w, "  ssh_keys:       %d\n", r.SSHKeys)
 	fmt.Fprintf(w, "  cron_jobs:      %d\n", r.CronJobs)
 	fmt.Fprintf(w, "  skipped:        %d (already present)\n", r.Skipped)
+	// GH #954: definitive login status — resolved against live Kratos after
+	// the apply, not inferred from which restore path ran.
+	if r.LoginNote != "" {
+		mark := "NOT restored"
+		if r.LoginRestored {
+			mark = "restored"
+		}
+		fmt.Fprintf(w, "  login:          %s — %s\n", mark, r.LoginNote)
+	}
 	for _, e := range r.Errors {
 		fmt.Fprintf(w, "  ERR: %s\n", e)
 	}

--- a/panel-api/cmd/server/migrate_pull_cmd.go
+++ b/panel-api/cmd/server/migrate_pull_cmd.go
@@ -43,6 +43,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cyberpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/jabali"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressplugin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressssh"
@@ -174,6 +175,20 @@ live source SSH. Use scp directly for that kind.`,
 			// API (no SSH). Stages dump.sql + files.tar.gz, then operator-gated.
 			if job.SourceKind == models.MigrationSourceWordPressPlugin {
 				if err := pullWordPressPlugin(ctx, job, secret, localDir, allowPrivate, repo); err != nil {
+					return markPullFailed(err)
+				}
+				return nil
+			}
+
+			// GH #954 jabali: Path-Y transport. Drive the source's OWN jabali CLI
+			// to produce a restic account_backup, pull the repo + its box password
+			// into staging, then STOP — the import arm restores it via the DR
+			// account-restore path (reads the foreign-password repo through
+			// backup.restore's password_file field; no rekey). Non-tarball shaped,
+			// so it's handled here before the tarball switch, like the wordpress
+			// kinds above.
+			if job.SourceKind == models.MigrationSourceJabali {
+				if err := pullJabali(ctx, sshUser, job, secret, localDir, allowPrivate, repo); err != nil {
 					return markPullFailed(err)
 				}
 				return nil
@@ -622,6 +637,103 @@ func readPluginToken(path string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("PLUGIN_TOKEN not found in secret file")
+}
+
+// pullJabali (GH #954) drives a Jabali source over SSH to back up one account
+// into a throwaway restic destination, streams that repo + the source box's
+// restic password into the job staging dir, then stops in validating state. The
+// dest-side import arm (runJabaliImport) restores it via the DR account-restore
+// path. Read-only on the source EXCEPT the per-job throwaway
+// destination/schedule/repo, which CleanupSource removes before returning.
+func pullJabali(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool, repo repository.MigrationJobRepository) error {
+	d := jabali.New()
+	d.AllowPrivate = allowPrivate
+	d.Port = srcSSHPort(job)
+	sess, err := d.Connect(ctx, job.SourceHost, sshUser, secret)
+	if err != nil {
+		return fmt.Errorf("jabali.Connect: %w", err)
+	}
+	defer func() { _ = d.Close(ctx, sess) }()
+
+	_ = repo.UpdateState(ctx, job.ID, models.MigrationStateAnalyzing, nil)
+	stAnalyze := wpMigStartStage(ctx, repo, job.ID, "analyze")
+
+	fmt.Printf("  → running source account_backup for %s (restic; may take many minutes for a large account)...\n", job.SourceUser)
+	sb, err := jabali.RunSourceBackup(ctx, sess, job.SourceUser, job.ID)
+	// Always attempt cleanup of the throwaway source dest/schedule/repo, even on
+	// error (RunSourceBackup returns the partial SourceBackup so we can). Use a
+	// fresh context so a cancelled/expired ctx doesn't skip cleanup and leave a
+	// broken daily schedule on the source.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		for _, e := range jabali.CleanupSource(cleanupCtx, sess, sb) {
+			fmt.Printf("  (warning: source cleanup: %v)\n", e)
+		}
+	}()
+	if err != nil {
+		return fmt.Errorf("source account_backup: %w", err)
+	}
+
+	// Stream the source restic repo back + read its box password.
+	repoTar := filepath.Join(localDir, "jabali-repo.tar.gz")
+	fmt.Printf("  → pulling source restic repo...\n")
+	if err := jabali.PullRepo(ctx, sess, sb.RepoDir, repoTar); err != nil {
+		return fmt.Errorf("pull source repo: %w", err)
+	}
+	boxPW, err := jabali.ReadBoxPassword(ctx, sess)
+	if err != nil {
+		return err
+	}
+
+	// Extract the repo into <localDir>/repo (disk preflight first).
+	repoDir := filepath.Join(localDir, "repo")
+	if err := os.MkdirAll(repoDir, 0o750); err != nil {
+		return fmt.Errorf("mkdir repo dir: %w", err)
+	}
+	if derr := migrate.CheckExtractDiskSpace(repoTar, repoDir); derr != nil {
+		return fmt.Errorf("disk preflight before repo extract: %w", derr)
+	}
+	if err := migrate.ExtractTarGz(repoTar, repoDir); err != nil {
+		return fmt.Errorf("extract source repo: %w", err)
+	}
+	_ = os.Remove(repoTar) // extracted; the tarball is now redundant
+
+	// Persist the source box password to staging (0600) for the import arm's
+	// password_file. It never crosses the agent socket — the agent runs as root
+	// and reads this jabali-owned staging file directly. NOTE: on a FAILED import
+	// the staging (incl. this password) is kept for retry (GH #746), so the
+	// source's restic password lingers on disk until retry/reaper — same exposure
+	// class as the SSH secret in migration-secrets/<job>.env, and staging already
+	// holds the account data itself.
+	pwPath := filepath.Join(localDir, "source-restic.password")
+	if err := os.WriteFile(pwPath, []byte(boxPW), 0o600); err != nil {
+		return fmt.Errorf("write source password: %w", err)
+	}
+
+	wpMigDoneStage(ctx, repo, stAnalyze)
+	_ = repo.UpdateState(ctx, job.ID, models.MigrationStateValidating, nil)
+	fmt.Printf("  → source account staged (restic repo at %s)\n", repoDir)
+
+	// Auto-kick the import so the operator's "discover → continue → done"
+	// expectation lands at done, not at validating-with-repo. Best-effort: a
+	// dispatch failure leaves the job staged so a manual `jabali migrate import`
+	// still works. The import arm's collision preflight makes auto-kick safe.
+	if sharedAgent != nil {
+		kickCtx, kickCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer kickCancel()
+		if _, err := sharedAgent.Call(kickCtx, "migration.import_run", map[string]any{
+			"job_id":      job.ID,
+			"target_user": job.SourceUser,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"  (warning: could not auto-kick import: %v — run `jabali migrate import --job-id %s` manually)\n",
+				err, job.ID)
+		} else {
+			fmt.Printf("  → import dispatched (systemd unit jabali-migrate-import-%s.service)\n", job.ID)
+		}
+	}
+	return nil
 }
 
 func pullDirectAdmin(ctx context.Context, sshUser string, job *models.MigrationJob, secret migrate.SecretRef, localDir string, allowPrivate bool) (string, error) {

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -950,9 +950,9 @@ func runJabaliImport(
 
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"✓ jabali migration complete: user %s restored (source id %s preserved).\n"+
-			"  NOTE: the migrated user cannot log in yet — set a password with\n"+
-			"    jabali user password %s --link\n"+
-			"  and mailbox MESSAGES (Maildir bodies) are not replayed by account-restore;\n"+
+			"  NOTE: check the \"login:\" line above — when it says NOT restored, issue a\n"+
+			"  password-reset link with: jabali user password %s --link\n"+
+			"  Mailbox MESSAGES (Maildir bodies) are not replayed by account-restore;\n"+
 			"  migrate old mail separately.\n",
 		targetUser, sourceULID, targetUser)
 

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -952,8 +952,8 @@ func runJabaliImport(
 		"✓ jabali migration complete: user %s restored (source id %s preserved).\n"+
 			"  NOTE: check the \"login:\" line above — when it says NOT restored, issue a\n"+
 			"  password-reset link with: jabali user password %s --link\n"+
-			"  Mailbox MESSAGES (Maildir bodies) are not replayed by account-restore;\n"+
-			"  migrate old mail separately.\n",
+			"  Mailbox message bodies are replayed into Stalwart (see the mail → line for\n"+
+			"  the count); a source mailbox with no messages simply shows 0.\n",
 		targetUser, sourceULID, targetUser)
 
 	// Staging cleanup (mirrors the tarball path). This also removes the staged

--- a/panel-api/cmd/server/migrate_run_cmd.go
+++ b/panel-api/cmd/server/migrate_run_cmd.go
@@ -32,6 +32,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"gorm.io/gorm"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
@@ -104,6 +105,21 @@ failed stage. Already-done stages are skipped.`,
 					fmt.Fprintf(cmd.ErrOrStderr(), "warning: mark job failed: %v\n", uErr)
 				}
 				return err
+			}
+
+			// GH #954 jabali: Path-Y import. The source account was backed up to a
+			// restic repo pulled into staging; restore it via the DR account-restore
+			// path, which CREATES the destination user (with the source's ULID) and
+			// reconstructs its domains/DBs/etc. This BYPASSES the cpanel tarball
+			// pipeline below, so it MUST branch out here — before the user-resolution
+			// block auto-creates the target user. Pre-creating it makes the DR restore
+			// hit a create-conflict and land the data ORPHANED (no panel rows / no
+			// vhost) — the drill's #1 failure. Do NOT move this after L~214.
+			if job.SourceKind == models.MigrationSourceJabali {
+				if err := runJabaliImport(ctx, cmd, job, jobsRepo, usersRepo, domainsRepo, targetUser, keepStaging); err != nil {
+					return failJob(err)
+				}
+				return nil
 			}
 
 			// DA preflight pivot: SSH principals (root/admin) aren't
@@ -769,6 +785,197 @@ failed stage. Already-done stages are skipped.`,
 	cmd.Flags().StringVar(&targetPassword, "target-password", "", "destination user password (only used when auto-creating; ≥10 chars)")
 	cmd.Flags().StringVar(&targetPackageID, "target-package-id", "", "hosting package ULID (only used when auto-creating)")
 	return cmd
+}
+
+// runJabaliImport (GH #954) is the dest-side import arm for a Jabali source. The
+// pull stage staged a restic account_backup repo (+ the source box's restic
+// password) under /var/lib/jabali-migrations/<job>/. This restores it via the DR
+// account-restore path: list the account's manifest snapshot, preflight for
+// collisions, dispatch backup.restore with target_user_id=<source ULID> (so the
+// user is CREATED, not looked up), then reconstruct the panel rows from the meta
+// bundle — the step that makes the migrated resources panel-managed rather than
+// orphaned. Bypasses migrate.Runner entirely, so it stamps its own state +
+// migration_stages rows.
+func runJabaliImport(
+	ctx context.Context,
+	cmd *cobra.Command,
+	job *models.MigrationJob,
+	jobsRepo repository.MigrationJobRepository,
+	usersRepo repository.UserRepository,
+	domainsRepo repository.DomainRepository,
+	targetUserFlag string,
+	keepStaging bool,
+) error {
+	localDir := filepath.Join("/var/lib/jabali-migrations", job.ID)
+	repoDir := filepath.Join(localDir, "repo")
+	pwPath := filepath.Join(localDir, "source-restic.password")
+	if _, err := os.Stat(repoDir); err != nil {
+		return fmt.Errorf("jabali import: staged repo %s missing — run `jabali migrate pull-source --job-id %s` first: %w", repoDir, job.ID, err)
+	}
+	if _, err := os.Stat(pwPath); err != nil {
+		return fmt.Errorf("jabali import: staged source password %s missing — re-run pull-source: %w", pwPath, err)
+	}
+
+	// Destination username = the source account username (1:1), unless the
+	// operator overrode it. Never a reserved system account.
+	targetUser := targetUserFlag
+	if targetUser == "" {
+		targetUser = job.SourceUser
+	}
+	if migrate.IsReservedAccount(targetUser) {
+		return fmt.Errorf("jabali import: refusing to migrate into reserved system user %q", targetUser)
+	}
+
+	_ = jobsRepo.UpdateState(ctx, job.ID, models.MigrationStateRestoring, nil)
+	stRestore := wpMigStartStage(ctx, jobsRepo, job.ID, "restore")
+
+	// Synthetic in-memory local destination over the pulled repo — no persisted
+	// backup_destinations row (nothing to clean up). buildRestoreParams +
+	// account_list_manifests only read .URL/.Kind/.Name off it.
+	picked := &models.BackupDestination{
+		Kind: models.BackupDestinationKindLocal,
+		URL:  repoDir,
+		Name: "jabali-migrate-" + job.ID,
+	}
+
+	ag := agent.NewClient(agent.Config{Timeout: 1 * time.Hour})
+
+	// 1. List the account's manifest snapshots in the pulled repo, opening it
+	//    with the SOURCE box password via password_file (no rekey).
+	listCtx, listCancel := context.WithTimeout(ctx, 5*time.Minute)
+	rawList, err := ag.Call(listCtx, "backup.account_list_manifests", map[string]any{
+		"repo_url":      repoDir,
+		"password_file": pwPath,
+	})
+	listCancel()
+	if err != nil {
+		return fmt.Errorf("jabali import: list account manifests: %w", err)
+	}
+	var listResp struct {
+		Manifests []accountManifestRow `json:"manifests"`
+		Total     int                  `json:"total"`
+	}
+	if err := json.Unmarshal(rawList, &listResp); err != nil {
+		return fmt.Errorf("jabali import: decode manifests: %w", err)
+	}
+	// The repo carries exactly one freshly-backed-up account. 0 manifests ⇒ the
+	// source backup did not finish; >1 distinct user_id ⇒ wrong/dirty repo. Fail
+	// loudly rather than silently restore the wrong thing (GH #327 scar).
+	userIDs := map[string]bool{}
+	for _, m := range listResp.Manifests {
+		if m.UserID != "" {
+			userIDs[m.UserID] = true
+		}
+	}
+	if len(listResp.Manifests) == 0 || len(userIDs) == 0 {
+		return fmt.Errorf("jabali import: no account manifests in the staged repo — the source backup did not complete; re-run pull-source")
+	}
+	if len(userIDs) > 1 {
+		return fmt.Errorf("jabali import: staged repo carries %d distinct users — expected exactly 1; refusing", len(userIDs))
+	}
+	// Manifests are newest-first from the agent.
+	snap := listResp.Manifests[0]
+	sourceULID := snap.UserID
+	snapshotID := snap.SnapshotID
+	if sourceULID == "" || snapshotID == "" {
+		return fmt.Errorf("jabali import: manifest missing user_id/snapshot_id (got user_id=%q snapshot=%q)", sourceULID, snapshotID)
+	}
+
+	// 2. Collision preflight (this replaces the bypassed Validate stage). Neither
+	//    the target username NOR the source ULID may already exist on this box —
+	//    the DR restore CREATES both, and a collision would clobber a live account.
+	if u, lookupErr := usersRepo.FindByUsername(ctx, targetUser); lookupErr == nil && u != nil {
+		return fmt.Errorf("jabali import: destination username %q already exists (id=%s) — pick a different --target-user or remove it first", targetUser, u.ID)
+	} else if lookupErr != nil && !errors.Is(lookupErr, repository.ErrNotFound) {
+		return fmt.Errorf("jabali import: lookup username %q: %w", targetUser, lookupErr)
+	}
+	if u, lookupErr := usersRepo.FindByID(ctx, sourceULID); lookupErr == nil && u != nil {
+		return fmt.Errorf("jabali import: a user with the source's id %s already exists here — refusing (would collide). Migrate to a fresh box or remove it first", sourceULID)
+	} else if lookupErr != nil && !errors.Is(lookupErr, repository.ErrNotFound) {
+		return fmt.Errorf("jabali import: lookup id %s: %w", sourceULID, lookupErr)
+	}
+
+	// 3. Restore via the DR path (creates the user + reconstructs resources).
+	restoreJobID := ids.NewULID()
+	params := buildRestoreParams(restoreJobID, snapshotID, sourceULID, targetUser, true, picked)
+	params["password_file"] = pwPath // open the foreign-password repo (no rekey)
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"→ jabali account-restore job=%s target_user=%s(id=%s) snapshot=%s\n",
+		restoreJobID, targetUser, sourceULID, snapshotID)
+	callCtx, callCancel := context.WithTimeout(ctx, 1*time.Hour)
+	rawRestore, err := ag.Call(callCtx, "backup.restore", params)
+	callCancel()
+	if err != nil {
+		return fmt.Errorf("jabali import: agent backup.restore: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "✓ agent backup.restore returned")
+
+	// 4. Reconstruct the panel-DB rows from the meta stage. WITHOUT this the data
+	//    lands on disk but no panel rows exist (orphaned) — the account-restore CLI
+	//    runs the same step after its agent call, and so must we.
+	var resp struct {
+		User     accountRestoreUserBlock `json:"user"`
+		Metadata json.RawMessage         `json:"metadata"`
+		Applied  []string                `json:"applied"`
+		Warnings []string                `json:"warnings"`
+	}
+	if jerr := json.Unmarshal(rawRestore, &resp); jerr == nil {
+		if len(resp.Metadata) > 0 {
+			applyPanelMetadata(ctx, cmd, resp.Metadata)
+		} else if resp.User.ID != "" {
+			if cerr := ensurePanelUserRow(ctx, cmd, resp.User); cerr != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "WARNING: panel user row reconstruction failed: %v\n", cerr)
+			}
+		}
+		for _, w := range resp.Warnings {
+			fmt.Fprintf(cmd.OutOrStdout(), "  restore warning: %s\n", w)
+		}
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: decode restore reply: %v (data may be applied but panel rows unverified)\n", jerr)
+	}
+
+	wpMigDoneStage(ctx, jobsRepo, stRestore)
+	_ = jobsRepo.UpdateState(ctx, job.ID, models.MigrationStateDone, nil)
+
+	// JAB-87 observability: stamp dest_user + dest_domain so the admin Migrations
+	// list shows where it landed.
+	if uerr := jobsRepo.UpdateDestUser(ctx, job.ID, targetUser); uerr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: record dest_user: %v\n", uerr)
+	}
+	if dom := firstDomainForUser(ctx, domainsRepo, sourceULID); dom != "" {
+		if derr := jobsRepo.UpdateDestDomain(ctx, job.ID, dom); derr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: record dest_domain: %v\n", derr)
+		}
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"✓ jabali migration complete: user %s restored (source id %s preserved).\n"+
+			"  NOTE: the migrated user cannot log in yet — set a password with\n"+
+			"    jabali user password %s --link\n"+
+			"  and mailbox MESSAGES (Maildir bodies) are not replayed by account-restore;\n"+
+			"  migrate old mail separately.\n",
+		targetUser, sourceULID, targetUser)
+
+	// Staging cleanup (mirrors the tarball path). This also removes the staged
+	// source restic password. --keep-staging retains it for debugging.
+	if !keepStaging {
+		if rmErr := os.RemoveAll(localDir); rmErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: staging cleanup failed for %s: %v\n", localDir, rmErr)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "staging dir %s removed (pass --keep-staging to retain)\n", localDir)
+		}
+	}
+	return nil
+}
+
+// firstDomainForUser returns the name of the user's first domain (JAB-87
+// observability best-effort), or "" if none / on error.
+func firstDomainForUser(ctx context.Context, domainsRepo repository.DomainRepository, userID string) string {
+	doms, _, err := domainsRepo.ListByUserID(ctx, userID, repository.ListOptions{Limit: 1})
+	if err != nil || len(doms) == 0 {
+		return ""
+	}
+	return doms[0].Name
 }
 
 // cpanelRunPayload is the opaque payload threaded through every

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -54,6 +54,7 @@ import (
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cyberpanel"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/jabali"
 	_ "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 )
 

--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -282,7 +282,8 @@ func isKnownSourceKind(s string) bool {
 		models.MigrationSourceWordPressPlugin, // GH #648
 		models.MigrationSourceIMAP,            // GH #390/#374
 		models.MigrationSourcePlesk,           // GH #429
-		models.MigrationSourceCloudPanel:      // GH #522
+		models.MigrationSourceCloudPanel,      // GH #522
+		models.MigrationSourceJabali:          // GH #954
 		return true
 	}
 	return false

--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -15,6 +15,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressplugin"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/jabali"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressssh"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
@@ -37,6 +38,10 @@ func panelDiscoverer(kind string, allowPrivate bool) migrate.Discoverer {
 		return d
 	case models.MigrationSourcePlesk:
 		d := plesk.New()
+		d.AllowPrivate = allowPrivate
+		return d
+	case models.MigrationSourceJabali: // GH #954
+		d := jabali.New()
 		d.AllowPrivate = allowPrivate
 		return d
 	}
@@ -169,6 +174,8 @@ func panelLabel(kind string) string {
 		return "HestiaCP"
 	case models.MigrationSourcePlesk:
 		return "Plesk"
+	case models.MigrationSourceJabali:
+		return "Jabali"
 	}
 	return kind
 }

--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -46,6 +46,13 @@ type ApplyResult struct {
 	CronJobs       int
 	Skipped        int
 	Errors         []string
+	// LoginRestored is true when the user's Kratos identity exists AND has a
+	// password credential after the apply — i.e. the account can actually sign
+	// in with its old password. When false, LoginNote says why + what to do
+	// (typically: issue a recovery link). Both are set only when a KratosClient
+	// was provided and the bundle carried a user email.
+	LoginRestored bool
+	LoginNote     string
 }
 
 // Apply walks the metadata bundle and inserts missing rows into the
@@ -449,9 +456,54 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 		} else {
 			if err := d.KratosClient.ImportIdentities(ctx, []kratosclient.ExportedIdentity{exportedIdentity}); err != nil {
 				r.Errors = append(r.Errors, fmt.Sprintf("kratos identity: import: %v", err))
+			}
+		}
+	}
+
+	// 9) Login verification (GH #954). The steps above can each half-succeed
+	// (applyUser creates an identity only when the panel hash is a usable
+	// bcrypt; the bundle's exported identity may predate credential capture;
+	// an identity may exist from a prior run). Resolve the ground truth —
+	// does an identity exist for this email, and does it hold a password? —
+	// so the operator gets a definitive login status instead of a swallowed
+	// warning, and a fresh (password-less) identity is minted when none
+	// exists so a recovery link can actually be issued.
+	if d.KratosClient != nil && m.User.Email != "" {
+		username := ""
+		if m.User.Username != nil {
+			username = *m.User.Username
+		}
+		id, err := d.KratosClient.IdentityIDByEmail(ctx, m.User.Email)
+		switch {
+		case err != nil:
+			r.LoginNote = fmt.Sprintf("kratos lookup failed (%v) — verify Kratos is up, then issue a recovery link", err)
+		case id == "":
+			// No identity at all. Mint one so the account is recoverable:
+			// with the panel bcrypt when the bundle carried a usable one
+			// (login works immediately), otherwise credential-less (login
+			// needs a recovery link).
+			pwd := m.User.PasswordHash
+			if pwd != "" && pwd != "!" && len(pwd) >= 59 {
+				traits := kratosclient.AdminTraits{Email: m.User.Email, Username: username, IsAdmin: m.User.IsAdmin}
+				if _, cerr := d.KratosClient.CreateIdentityWithPassword(ctx, traits, pwd); cerr == nil || errors.Is(cerr, kratosclient.ErrIdentityExisted) {
+					r.LoginRestored = true
+					r.LoginNote = "identity created with the preserved password — the user signs in with their old password"
+				} else {
+					r.LoginNote = fmt.Sprintf("identity create failed (%v) — issue a recovery link after fixing", cerr)
+				}
 			} else {
-				// Successfully imported Kratos identity
-				r.UserCreated = true // User was restored to Kratos
+				r.LoginNote = "no identity and no usable password hash in the bundle — issue a recovery link: jabali user password " + username + " --link"
+			}
+		default:
+			hasPW, herr := d.KratosClient.IdentityHasPassword(ctx, id)
+			switch {
+			case herr != nil:
+				r.LoginNote = fmt.Sprintf("identity %s present but password check failed (%v)", id, herr)
+			case hasPW:
+				r.LoginRestored = true
+				r.LoginNote = "identity present with a password credential — the user signs in with their old password"
+			default:
+				r.LoginNote = "identity present but has NO password credential — issue a recovery link: jabali user password " + username + " --link"
 			}
 		}
 	}

--- a/panel-api/internal/backupmetadata/builder.go
+++ b/panel-api/internal/backupmetadata/builder.go
@@ -22,6 +22,11 @@ import (
 type KratosClient interface {
 	CreateIdentityWithPassword(ctx context.Context, traits kratosclient.AdminTraits, passwordHash string) (string, error)
 	ImportIdentities(ctx context.Context, identities []kratosclient.ExportedIdentity) error
+	// IdentityIDByEmail + IdentityHasPassword back the login-verification
+	// step (GH #954): after restore, resolve whether the account can
+	// actually sign in, and mint a recoverable identity when none exists.
+	IdentityIDByEmail(ctx context.Context, email string) (string, error)
+	IdentityHasPassword(ctx context.Context, identityID string) (bool, error)
 }
 
 // Deps is the union of repos the producer reads. Every field is

--- a/panel-api/internal/migrate/jabali/discover.go
+++ b/panel-api/internal/migrate/jabali/discover.go
@@ -118,6 +118,54 @@ type jabaliUserList struct {
 	Users []jabaliUser `json:"users"`
 }
 
+// domainRe is the strict allow-list a source domain must match before it is
+// interpolated into a `jabali mailbox list --domain <name>` argument. Values
+// come from the source's own domain list, never operator free-text, but we
+// validate anyway (defence in depth) and drop anything that doesn't match.
+var domainRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]{0,253})$`)
+
+// Parse shapes — the subset of each `jabali … list --json` row we consume.
+type jabaliDomain struct {
+	UserID       string `json:"user_id"`
+	Name         string `json:"name"`
+	DocRoot      string `json:"doc_root"`
+	PHPPoolID    string `json:"php_pool_id"`
+	EmailEnabled bool   `json:"email_enabled"`
+}
+type jabaliDomainList struct {
+	Domains []jabaliDomain `json:"domains"`
+}
+
+// db list returns a bare JSON array.
+type jabaliDB struct {
+	Name   string `json:"name"`
+	Engine string `json:"engine"`
+}
+
+type jabaliMailbox struct {
+	Email          string `json:"email"`
+	QuotaBytes     int64  `json:"quota_bytes"`
+	LastUsageBytes int64  `json:"last_usage_bytes"`
+}
+type jabaliMailboxList struct {
+	Mailboxes []jabaliMailbox `json:"mailboxes"`
+}
+
+type jabaliCronJob struct {
+	Name     string `json:"name"`
+	Command  string `json:"command"`
+	Schedule string `json:"schedule"`
+}
+type jabaliCronList struct {
+	Jobs []jabaliCronJob `json:"jobs"`
+}
+
+// shellSingleQuote wraps s in single quotes, escaping embedded single quotes, so
+// it is safe as one shell argument in an SSH command string.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 // Connect dials the source over SSH, verifies the host key, and validates the
 // connection with a single read: `jabali version --json`. A successful parse
 // proves (a) the SSH creds work, (b) the `jabali` CLI is present, and (c) this
@@ -268,7 +316,7 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 	if s.client != nil {
 		host = s.client.RemoteAddr().String()
 	}
-	return &migrate.AccountManifest{
+	m := &migrate.AccountManifest{
 		SchemaVersion: migrate.ManifestSchemaVersion,
 		Source: migrate.SourceRef{
 			Kind: models.MigrationSourceJabali,
@@ -279,7 +327,162 @@ func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, a
 		Mailboxes: []migrate.MailboxSpec{},
 		Databases: []migrate.DatabaseSpec{},
 		Warnings:  []migrate.Warning{},
-	}, nil
+	}
+
+	// Resolve the account's user_id — domains are filtered client-side by it
+	// (domain list has no --user flag), while db/cron accept --user <username>.
+	userID, uerr := s.resolveUserID(ctx, accountID)
+	if uerr != nil {
+		return nil, fmt.Errorf("jabali.DescribeAccount: resolve user id for %q: %w", accountID, uerr)
+	}
+	m.Domains = s.buildDomains(ctx, userID, &m.Warnings)
+	m.Databases = s.buildDatabases(ctx, accountID, &m.Warnings)
+	m.Mailboxes = s.buildMailboxes(ctx, m.Domains, &m.Warnings)
+	m.Cron = s.buildCron(ctx, accountID, &m.Warnings)
+	return m, nil
+}
+
+// resolveUserID maps a source username to its ULID via `jabali user list --json`.
+func (s *session) resolveUserID(ctx context.Context, username string) (string, error) {
+	out, err := s.run(ctx, s.commandTimeout, "jabali user list --json")
+	if err != nil {
+		return "", err
+	}
+	var list jabaliUserList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return "", fmt.Errorf("parse user list: %w", err)
+	}
+	for _, u := range list.Users {
+		if u.Username == username {
+			return u.ID, nil
+		}
+	}
+	return "", fmt.Errorf("user %q not found on source", username)
+}
+
+// buildDomains returns the account's domains (domain list filtered by user_id).
+// The first domain is flagged primary (Jabali has no per-user primary marker);
+// import treats each independently regardless.
+func (s *session) buildDomains(ctx context.Context, userID string, warns *[]migrate.Warning) []migrate.DomainSpec {
+	out := []migrate.DomainSpec{}
+	b, err := s.run(ctx, s.commandTimeout, "jabali domain list --json")
+	if err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_domains", Detail: err.Error()})
+		return out
+	}
+	var list jabaliDomainList
+	if err := json.Unmarshal(b, &list); err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_domains", Detail: "parse: " + err.Error()})
+		return out
+	}
+	first := true
+	for _, dom := range list.Domains {
+		if dom.UserID != userID || strings.TrimSpace(dom.Name) == "" {
+			continue
+		}
+		spec := migrate.DomainSpec{
+			Name:      dom.Name,
+			DocRoot:   dom.DocRoot,
+			IsPrimary: first,
+			HasPHP:    strings.TrimSpace(dom.PHPPoolID) != "",
+		}
+		out = append(out, spec)
+		first = false
+	}
+	return out
+}
+
+// buildDatabases returns the account's MariaDB databases. Postgres is skipped in
+// v1 (a warning per skipped DB); the spec's engine vocabulary is mysql|postgres,
+// so a mariadb source engine is normalised to "mysql". DB users/grants are a
+// Phase-3 (import) concern and left empty here.
+func (s *session) buildDatabases(ctx context.Context, username string, warns *[]migrate.Warning) []migrate.DatabaseSpec {
+	out := []migrate.DatabaseSpec{}
+	cmd := "jabali db list --user " + shellSingleQuote(username) + " --json"
+	b, err := s.run(ctx, s.commandTimeout, cmd)
+	if err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_databases", Detail: err.Error()})
+		return out
+	}
+	var dbs []jabaliDB
+	if err := json.Unmarshal(b, &dbs); err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_databases", Detail: "parse: " + err.Error()})
+		return out
+	}
+	for _, db := range dbs {
+		if strings.TrimSpace(db.Name) == "" {
+			continue
+		}
+		if db.Engine == "postgres" {
+			*warns = append(*warns, migrate.Warning{Code: "jabali_postgres_skipped", Detail: "postgres database " + db.Name + " skipped (v1 migrates MariaDB only)"})
+			continue
+		}
+		out = append(out, migrate.DatabaseSpec{Engine: "mysql", Name: db.Name})
+	}
+	return out
+}
+
+// buildMailboxes returns every mailbox on the account's domains. mailbox list is
+// per-domain (no --user), so we fan out over the domains DescribeAccount already
+// resolved. A domain with mail disabled simply yields none.
+func (s *session) buildMailboxes(ctx context.Context, domains []migrate.DomainSpec, warns *[]migrate.Warning) []migrate.MailboxSpec {
+	out := []migrate.MailboxSpec{}
+	for _, dom := range domains {
+		if !domainRe.MatchString(dom.Name) {
+			continue
+		}
+		cmd := "jabali mailbox list --domain " + shellSingleQuote(dom.Name) + " --json"
+		b, err := s.run(ctx, s.commandTimeout, cmd)
+		if err != nil {
+			// A mail-disabled domain returns an error/empty; note it, keep going.
+			*warns = append(*warns, migrate.Warning{Code: "jabali_mailboxes", Detail: dom.Name + ": " + err.Error()})
+			continue
+		}
+		var list jabaliMailboxList
+		if err := json.Unmarshal(b, &list); err != nil {
+			*warns = append(*warns, migrate.Warning{Code: "jabali_mailboxes", Detail: dom.Name + ": parse: " + err.Error()})
+			continue
+		}
+		for _, mb := range list.Mailboxes {
+			if strings.TrimSpace(mb.Email) == "" {
+				continue
+			}
+			out = append(out, migrate.MailboxSpec{
+				Address:    mb.Email,
+				QuotaBytes: mb.QuotaBytes,
+				BytesUsed:  mb.LastUsageBytes,
+			})
+		}
+	}
+	return out
+}
+
+// buildCron returns the account user's cron jobs (`cron list --user`).
+func (s *session) buildCron(ctx context.Context, username string, warns *[]migrate.Warning) []migrate.CronSpec {
+	out := []migrate.CronSpec{}
+	cmd := "jabali cron list --user " + shellSingleQuote(username) + " --json"
+	b, err := s.run(ctx, s.commandTimeout, cmd)
+	if err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_cron", Detail: err.Error()})
+		return out
+	}
+	var list jabaliCronList
+	if err := json.Unmarshal(b, &list); err != nil {
+		*warns = append(*warns, migrate.Warning{Code: "jabali_cron", Detail: "parse: " + err.Error()})
+		return out
+	}
+	for _, j := range list.Jobs {
+		if strings.TrimSpace(j.Command) == "" {
+			continue
+		}
+		out = append(out, migrate.CronSpec{
+			Name:     j.Name,
+			Schedule: j.Schedule,
+			Command:  j.Command,
+			RunAs:    username,
+		})
+	}
+	return out
 }
 
 // Close releases the SSH client. Best-effort.

--- a/panel-api/internal/migrate/jabali/discover.go
+++ b/panel-api/internal/migrate/jabali/discover.go
@@ -1,0 +1,379 @@
+// Package jabali implements the Jabali→Jabali Discoverer (+ Restorer, later
+// phases) for the migration engine (GH #954). The source is itself a Jabali
+// install, so — unlike the cpanel/plesk/cyberpanel importers, which read a
+// foreign panel's database — discovery talks to the source's OWN `jabali … list
+// --json` CLI over SSH. That is authoritative (the CLI reads the source's live
+// state) and version-tolerant (it adapts to the source's schema, so a minor
+// version skew between the two boxes doesn't break enumeration).
+//
+// One source account = one NON-admin Jabali user, which maps 1:1 onto a
+// destination Jabali user. Admins are skipped: they own no hosting home.
+//
+// SSH-based connect (parity with the sibling importers); the SSH user is root so
+// the source `jabali` CLI can read the panel database. We only ever run READ
+// subcommands (`version`, `user list`); no mutating command touches the source.
+//
+// Phase 1 (this file) ships the Discoverer scaffold + Connect + ListAccounts and
+// returns a valid (SchemaVersion + Source) empty manifest that the Phase 2
+// per-area builders fill — the same incremental shape the sibling importers took.
+package jabali
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// usernameRe is the strict allow-list a source Jabali username must match before
+// it is ever interpolated into a later `jabali … --user <name>` shell argument.
+// Lowercase Linux-username shape; anything outside is rejected, not escaped, so
+// no shell/SQL metacharacter can reach the source (defence in depth — the value
+// also comes from the source's own CLI, never operator free-text).
+var usernameRe = regexp.MustCompile(`^[a-z_][a-z0-9._-]{0,63}$`)
+
+// Discoverer is the Jabali-source implementation of migrate.Discoverer.
+type Discoverer struct {
+	// AllowPrivate — when true the SSRF guard permits RFC1918 / ULA targets.
+	// Default false; the admin toggle (migration_allow_private_hosts) sets it
+	// via migrate.ApplyAllowPrivate.
+	AllowPrivate bool
+	// Port is the source SSH port. Default 22.
+	Port int
+	// CommandTimeout bounds each remote command. Default 30s.
+	CommandTimeout time.Duration
+}
+
+// New returns a Discoverer with sensible defaults.
+func New() *Discoverer {
+	return &Discoverer{Port: 22, CommandTimeout: 30 * time.Second}
+}
+
+// Compile-time interface assertions.
+var (
+	_ migrate.Discoverer         = (*Discoverer)(nil)
+	_ migrate.AllowPrivateSetter = (*Discoverer)(nil)
+	_ migrate.PortSetter         = (*Discoverer)(nil)
+)
+
+// SetAllowPrivate — see cpanel/discover.go for rationale.
+func (d *Discoverer) SetAllowPrivate(b bool) { d.AllowPrivate = b }
+
+// SetPort sets the source SSH port; ApplyPort calls it via PortSetter. Ports
+// outside 1..65535 keep the default 22.
+func (d *Discoverer) SetPort(p int) {
+	if p >= 1 && p <= 65535 {
+		d.Port = p
+	}
+}
+
+// runnerFunc executes one command on the source and returns stdout. Real
+// sessions run over SSH (session.sshRun); tests inject a fake so the JSON-parsing
+// logic in ListAccounts is exercised without a live host.
+type runnerFunc func(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error)
+
+type session struct {
+	client         *ssh.Client
+	connectedUser  string
+	commandTimeout time.Duration
+	// run is the command executor. Connect wires it to sshRun; tests set it
+	// directly on a hand-built session.
+	run runnerFunc
+}
+
+func (s *session) Kind() string { return models.MigrationSourceJabali }
+
+// jabaliVersion is the subset of `jabali version --json` we read to prove the
+// source is a Jabali box and (later) to warn on a large version skew.
+type jabaliVersion struct {
+	RepoHead string `json:"repo_head"`
+	Commit   string `json:"commit"`
+	OS       string `json:"os"`
+}
+
+// jabaliUser is the subset of one `jabali user list --json` row we need.
+type jabaliUser struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	Username  string `json:"username"`
+	IsAdmin   bool   `json:"is_admin"`
+	Suspended bool   `json:"suspended"`
+}
+
+type jabaliUserList struct {
+	Total int          `json:"total"`
+	Users []jabaliUser `json:"users"`
+}
+
+// Connect dials the source over SSH, verifies the host key, and validates the
+// connection with a single read: `jabali version --json`. A successful parse
+// proves (a) the SSH creds work, (b) the `jabali` CLI is present, and (c) this
+// really is a Jabali host — all before returning.
+func (d *Discoverer) Connect(ctx context.Context, host, user string, secret migrate.SecretRef) (migrate.Session, error) {
+	port := d.Port
+	if port == 0 {
+		port = 22
+	}
+	auth, err := loadSecret(secret.Path)
+	if err != nil {
+		return nil, fmt.Errorf("jabali.Connect: load secret: %w", err)
+	}
+	cfg := &ssh.ClientConfig{
+		User:            user,
+		Auth:            auth,
+		HostKeyCallback: migrate.PinningHostKeyCallback(secret.ExpectedHostKey),
+		Timeout:         15 * time.Second,
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	conn, err := migrate.DialTCP(ctx, host, port, d.AllowPrivate, 15*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("jabali.Connect: tcp dial %s: %w", addr, err)
+	}
+	c, ch, reqs, err := ssh.NewClientConn(conn, addr, cfg)
+	if err != nil {
+		conn.Close()
+		if strings.Contains(err.Error(), "unable to authenticate") || strings.Contains(err.Error(), "no supported methods remain") {
+			return nil, fmt.Errorf("jabali.Connect: source SSH server rejected the credentials for user %q — check the password or key is correct for that user, that the user exists on the source, and note the server may have PasswordAuthentication=no (upload an SSH PRIVATE KEY in the wizard's Connection step instead): %w", user, err)
+		}
+		return nil, fmt.Errorf("jabali.Connect: ssh handshake: %w", err)
+	}
+	client := ssh.NewClient(c, ch, reqs)
+	s := &session{client: client, connectedUser: user, commandTimeout: d.CommandTimeout}
+	s.run = s.sshRun
+
+	subctx, cancel := context.WithTimeout(ctx, d.CommandTimeout)
+	defer cancel()
+	if err := probeJabali(subctx, s, d.CommandTimeout); err != nil {
+		client.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// probeJabali proves the source is a Jabali host with the CLI on PATH. It tries
+// `jabali version --json` first, but falls back to plain `jabali version` when
+// that fails — an OLDER source (exactly what people migrate FROM) may predate
+// the global --json flag or print plain text, and rejecting it would make the
+// version-tolerant CLI approach fail against the very hosts it exists to serve.
+// Either a parseable JSON version or a plain "version:" line proves Jabali.
+func probeJabali(ctx context.Context, s *session, timeout time.Duration) error {
+	if out, err := s.run(ctx, timeout, "jabali version --json"); err == nil {
+		var ver jabaliVersion
+		if json.Unmarshal(out, &ver) == nil && (ver.RepoHead != "" || ver.Commit != "" || ver.OS != "") {
+			return nil
+		}
+	}
+	// Fallback: plain `jabali version` (the human-readable "version:  <sha>" form).
+	out, err := s.run(ctx, timeout, "jabali version")
+	if err != nil {
+		return fmt.Errorf("jabali.Connect: read probe failed — is this a Jabali host with the `jabali` CLI on PATH for the SSH user (need root)? %w", err)
+	}
+	if !strings.Contains(strings.ToLower(string(out)), "version:") {
+		return fmt.Errorf("jabali.Connect: `jabali version` did not look like a Jabali install (unexpected output); the source may not be a Jabali host")
+	}
+	return nil
+}
+
+// ListAccounts returns one row per NON-admin Jabali user on the source. Cheap
+// mode — no per-account size lookup here; that lands on DescribeAccount /
+// SizeProber (Phase 2). The command is static (no user input) so it needs no
+// sanitisation.
+func (d *Discoverer) ListAccounts(ctx context.Context, raw migrate.Session) ([]migrate.AccountSummary, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("jabali.ListAccounts: wrong session type")
+	}
+	out, err := s.run(ctx, s.commandTimeout, "jabali user list --json")
+	if err != nil {
+		return nil, fmt.Errorf("jabali.ListAccounts: `jabali user list --json`: %w", err)
+	}
+	var list jabaliUserList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil, fmt.Errorf("jabali.ListAccounts: parse user list: %w", err)
+	}
+	rows := []migrate.AccountSummary{}
+	for _, u := range list.Users {
+		// Admins own no hosting home; skip. A hosting user without a username
+		// can't own a Linux account either, so it isn't a migratable account.
+		if u.IsAdmin || strings.TrimSpace(u.Username) == "" {
+			continue
+		}
+		rows = append(rows, migrate.AccountSummary{
+			ID:        u.Username,
+			Login:     u.Username,
+			Email:     u.Email,
+			Suspended: u.Suspended,
+		})
+	}
+	return rows, nil
+}
+
+// DescribeAccount returns a manifest scaffold for one source Jabali user. The
+// per-area builders (Domains / Databases / Mailboxes / DNS / Cron) ship in Phase
+// 2. The account is validated against the Go-side account list (no user input
+// reaches the source) plus a strict format check so later interpolating builders
+// are safe.
+func (d *Discoverer) DescribeAccount(ctx context.Context, raw migrate.Session, accountID string) (*migrate.AccountManifest, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("jabali.DescribeAccount: wrong session type")
+	}
+	if accountID == "" {
+		return nil, errors.New("jabali.DescribeAccount: accountID empty")
+	}
+	if !usernameRe.MatchString(accountID) {
+		return nil, fmt.Errorf("jabali.DescribeAccount: invalid account id %q (must be a source Jabali username)", accountID)
+	}
+
+	accounts, err := d.ListAccounts(ctx, s)
+	if err != nil {
+		return nil, fmt.Errorf("jabali.DescribeAccount: enumerate accounts: %w", err)
+	}
+	found := false
+	for _, a := range accounts {
+		if a.ID == accountID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		switch len(accounts) {
+		case 0:
+			return nil, fmt.Errorf("no non-admin Jabali users found on source; %q is not a hosting account", accountID)
+		case 1:
+			accountID = accounts[0].ID // single-tenant source — pivot to the only account
+		default:
+			names := make([]string, 0, len(accounts))
+			for _, a := range accounts {
+				names = append(names, a.ID)
+			}
+			return nil, fmt.Errorf("user %q is not a Jabali hosting account; pick one of: %s", accountID, strings.Join(names, ", "))
+		}
+	}
+
+	host := ""
+	if s.client != nil {
+		host = s.client.RemoteAddr().String()
+	}
+	return &migrate.AccountManifest{
+		SchemaVersion: migrate.ManifestSchemaVersion,
+		Source: migrate.SourceRef{
+			Kind: models.MigrationSourceJabali,
+			Host: host,
+			User: accountID,
+		},
+		Domains:   []migrate.DomainSpec{},
+		Mailboxes: []migrate.MailboxSpec{},
+		Databases: []migrate.DatabaseSpec{},
+		Warnings:  []migrate.Warning{},
+	}, nil
+}
+
+// Close releases the SSH client. Best-effort.
+func (d *Discoverer) Close(ctx context.Context, raw migrate.Session) error {
+	s, ok := raw.(*session)
+	if !ok || s.client == nil {
+		return nil
+	}
+	return s.client.Close()
+}
+
+// sshRun executes one command via SSH and returns stdout. Hard timeout via
+// context; SIGKILL on expiry so a stuck command doesn't pin the session.
+func (s *session) sshRun(ctx context.Context, timeout time.Duration, cmd string) ([]byte, error) {
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	subctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("ssh new session: %w", err)
+	}
+	defer sess.Close()
+
+	var stdout, stderr bytes.Buffer
+	sess.Stdout = &stdout
+	sess.Stderr = &stderr
+
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(cmd) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return nil, fmt.Errorf("ssh exec %q: %w (stderr=%q)", cmd, err, stderr.String())
+		}
+		return stdout.Bytes(), nil
+	case <-subctx.Done():
+		_ = sess.Signal(ssh.SIGKILL)
+		return nil, fmt.Errorf("ssh exec %q: timed out after %s", cmd, timeout)
+	}
+}
+
+// loadSecret matches the sibling importers' loadSecret semantics:
+// SSH_PASSWORD=<plaintext> or SSH_PRIVATE_KEY[_B64]=<PEM|base64-PEM>. Raw is
+// zeroed before returning so the plaintext doesn't linger in the heap.
+func loadSecret(path string) ([]ssh.AuthMethod, error) {
+	if path == "" {
+		return nil, errors.New("secret path empty")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer zero(raw)
+
+	var auths []ssh.AuthMethod
+	for _, line := range strings.Split(string(raw), "\n") {
+		k, v, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "SSH_PASSWORD":
+			auths = append(auths, migrate.SSHPasswordAuthMethods(v)...)
+		case "SSH_PRIVATE_KEY":
+			signer, perr := ssh.ParsePrivateKey([]byte(v))
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		case "SSH_PRIVATE_KEY_B64":
+			pem, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(v))
+			if derr != nil {
+				return nil, fmt.Errorf("base64-decode SSH_PRIVATE_KEY_B64: %w", derr)
+			}
+			signer, perr := ssh.ParsePrivateKey(pem)
+			zero(pem)
+			if perr != nil {
+				return nil, fmt.Errorf("parse SSH_PRIVATE_KEY_B64: %w", perr)
+			}
+			auths = append(auths, ssh.PublicKeys(signer))
+		}
+	}
+	if len(auths) == 0 {
+		return nil, errors.New("no SSH_PASSWORD / SSH_PRIVATE_KEY / SSH_PRIVATE_KEY_B64 in secret file")
+	}
+	return auths, nil
+}
+
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/panel-api/internal/migrate/jabali/discover_test.go
+++ b/panel-api/internal/migrate/jabali/discover_test.go
@@ -1,0 +1,150 @@
+package jabali
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// fakeSession answers `jabali user list --json` with the given JSON body; any
+// other command returns empty. Exercises the JSON-parsing logic without SSH.
+func fakeSession(userListJSON string) *session {
+	s := &session{commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		if strings.Contains(cmd, "user list") {
+			return []byte(userListJSON), nil
+		}
+		return []byte("{}"), nil
+	}
+	return s
+}
+
+const twoTenants = `{"total":4,"users":[
+  {"id":"01A","email":"alice@x.com","username":"alice","is_admin":false,"suspended":false},
+  {"id":"01B","email":"admin@x.com","username":"root_admin","is_admin":true},
+  {"id":"01C","email":"bob@x.com","username":"bob","is_admin":false,"suspended":true},
+  {"id":"01D","email":"noname@x.com","username":"","is_admin":false}
+]}`
+
+func TestListAccounts_SkipsAdminsAndUsernameless(t *testing.T) {
+	d := New()
+	accts, err := d.ListAccounts(context.Background(), fakeSession(twoTenants))
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	// Only alice + bob: admin (root_admin) and the username-less row are dropped.
+	if len(accts) != 2 {
+		t.Fatalf("want 2 accounts, got %d: %+v", len(accts), accts)
+	}
+	byID := map[string]migrate.AccountSummary{}
+	for _, a := range accts {
+		byID[a.ID] = a
+	}
+	if _, ok := byID["alice"]; !ok {
+		t.Error("alice must be listed")
+	}
+	if b, ok := byID["bob"]; !ok || !b.Suspended {
+		t.Errorf("bob must be listed and suspended, got %+v", b)
+	}
+	if _, ok := byID["root_admin"]; ok {
+		t.Error("admin must NOT be listed")
+	}
+}
+
+func TestDescribeAccount_ScaffoldForValid(t *testing.T) {
+	d := New()
+	m, err := d.DescribeAccount(context.Background(), fakeSession(twoTenants), "alice")
+	if err != nil {
+		t.Fatalf("DescribeAccount: %v", err)
+	}
+	if m.SchemaVersion != migrate.ManifestSchemaVersion {
+		t.Errorf("schema version = %d, want %d", m.SchemaVersion, migrate.ManifestSchemaVersion)
+	}
+	if m.Source.Kind != models.MigrationSourceJabali || m.Source.User != "alice" {
+		t.Errorf("bad source ref: %+v", m.Source)
+	}
+	// Phase 1 returns empty (non-nil) area slices for the Phase 2 builders.
+	if m.Domains == nil || m.Databases == nil || m.Mailboxes == nil {
+		t.Error("area slices must be non-nil scaffolds")
+	}
+}
+
+func TestDescribeAccount_RejectsBadUsername(t *testing.T) {
+	d := New()
+	if _, err := d.DescribeAccount(context.Background(), fakeSession(twoTenants), "bad name!"); err == nil {
+		t.Error("a non-username id must be rejected before any source call")
+	}
+}
+
+func TestDescribeAccount_UnknownAmongManyErrors(t *testing.T) {
+	d := New()
+	_, err := d.DescribeAccount(context.Background(), fakeSession(twoTenants), "carol")
+	if err == nil || !strings.Contains(err.Error(), "pick one of") {
+		t.Errorf("unknown account among several must list choices, got %v", err)
+	}
+}
+
+func TestDescribeAccount_SingleTenantPivots(t *testing.T) {
+	single := `{"total":1,"users":[{"id":"01A","email":"solo@x.com","username":"solo","is_admin":false}]}`
+	d := New()
+	m, err := d.DescribeAccount(context.Background(), fakeSession(single), "wrongname")
+	if err != nil {
+		t.Fatalf("single-tenant source must pivot to the only account, got %v", err)
+	}
+	if m.Source.User != "solo" {
+		t.Errorf("must pivot to 'solo', got %q", m.Source.User)
+	}
+}
+
+// probeSession routes the two version commands so probeJabali can be exercised
+// without SSH: --json returns jsonOut, plain returns plainOut (empty = error).
+func probeSession(jsonOut, plainOut string, plainErr bool) *session {
+	s := &session{commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		if strings.Contains(cmd, "version --json") {
+			if jsonOut == "" {
+				return nil, context.Canceled // simulate old CLI: --json unsupported
+			}
+			return []byte(jsonOut), nil
+		}
+		if plainErr {
+			return nil, context.Canceled
+		}
+		return []byte(plainOut), nil
+	}
+	return s
+}
+
+func TestProbeJabali(t *testing.T) {
+	ctx := context.Background()
+	// Modern source: --json parses.
+	if err := probeJabali(ctx, probeSession(`{"repo_head":"abc","os":"linux"}`, "", false), time.Second); err != nil {
+		t.Errorf("json version must pass: %v", err)
+	}
+	// Old source: --json unsupported, plain `jabali version` proves it.
+	if err := probeJabali(ctx, probeSession("", "version:        42f145db\n", false), time.Second); err != nil {
+		t.Errorf("plain-version fallback must pass: %v", err)
+	}
+	// Not Jabali: --json empty AND plain output has no version marker.
+	if err := probeJabali(ctx, probeSession("", "bash: jabali: command not found", false), time.Second); err == nil {
+		t.Error("non-Jabali output must be rejected")
+	}
+	// Both commands error (no CLI at all).
+	if err := probeJabali(ctx, probeSession("", "", true), time.Second); err == nil {
+		t.Error("a missing CLI must be rejected")
+	}
+}
+
+func TestJabaliRegisteredInRegistry(t *testing.T) {
+	d, err := migrate.Get(models.MigrationSourceJabali)
+	if err != nil {
+		t.Fatalf("jabali kind must be registered: %v", err)
+	}
+	if d == nil {
+		t.Fatal("registry returned nil discoverer")
+	}
+}

--- a/panel-api/internal/migrate/jabali/discover_test.go
+++ b/panel-api/internal/migrate/jabali/discover_test.go
@@ -139,6 +139,73 @@ func TestProbeJabali(t *testing.T) {
 	}
 }
 
+// routedSession answers each builder command independently from a substring map.
+func routedSession(routes map[string]string) *session {
+	s := &session{commandTimeout: time.Second}
+	s.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		for sub, out := range routes {
+			if strings.Contains(cmd, sub) {
+				return []byte(out), nil
+			}
+		}
+		return []byte("{}"), nil
+	}
+	return s
+}
+
+func TestDescribeAccount_Phase2Builders(t *testing.T) {
+	routes := map[string]string{
+		"user list": twoTenants, // alice → 01A, bob → 01C
+		// One domain for alice (01A), one for bob (01C) — bob's must be filtered out.
+		"domain list": `{"domains":[
+			{"user_id":"01A","name":"alice.com","doc_root":"/home/alice/domains/alice.com/public_html","php_pool_id":"p1","email_enabled":true},
+			{"user_id":"01C","name":"bob.com","doc_root":"/home/bob/x","php_pool_id":"","email_enabled":false}
+		]}`,
+		"db list":      `[{"name":"alice_wp","engine":"mariadb"},{"name":"alice_pg","engine":"postgres"}]`,
+		"mailbox list": `{"domain":"alice.com","mailboxes":[{"email":"info@alice.com","quota_bytes":1073741824,"last_usage_bytes":2048}]}`,
+		"cron list":    `{"jobs":[{"name":"nightly","command":"/usr/bin/php /home/alice/cron.php","schedule":"0 3 * * *"}]}`,
+	}
+	m, err := New().DescribeAccount(context.Background(), routedSession(routes), "alice")
+	if err != nil {
+		t.Fatalf("DescribeAccount: %v", err)
+	}
+
+	// Domains: only alice's, flagged primary, with PHP + docroot.
+	if len(m.Domains) != 1 || m.Domains[0].Name != "alice.com" {
+		t.Fatalf("want 1 alice domain, got %+v", m.Domains)
+	}
+	if !m.Domains[0].IsPrimary || !m.Domains[0].HasPHP || m.Domains[0].DocRoot == "" {
+		t.Errorf("domain fields wrong: %+v", m.Domains[0])
+	}
+
+	// Databases: mariadb kept (as mysql), postgres skipped + a warning.
+	if len(m.Databases) != 1 || m.Databases[0].Name != "alice_wp" || m.Databases[0].Engine != "mysql" {
+		t.Fatalf("want 1 mysql db, got %+v", m.Databases)
+	}
+	if !hasWarn(m.Warnings, "jabali_postgres_skipped") {
+		t.Error("skipped postgres db must add a warning")
+	}
+
+	// Mailboxes: fanned out over alice.com.
+	if len(m.Mailboxes) != 1 || m.Mailboxes[0].Address != "info@alice.com" || m.Mailboxes[0].BytesUsed != 2048 {
+		t.Fatalf("want info@alice.com mailbox, got %+v", m.Mailboxes)
+	}
+
+	// Cron: run-as the account user.
+	if len(m.Cron) != 1 || m.Cron[0].Command == "" || m.Cron[0].RunAs != "alice" {
+		t.Fatalf("want 1 cron run-as alice, got %+v", m.Cron)
+	}
+}
+
+func hasWarn(ws []migrate.Warning, code string) bool {
+	for _, w := range ws {
+		if w.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
 func TestJabaliRegisteredInRegistry(t *testing.T) {
 	d, err := migrate.Get(models.MigrationSourceJabali)
 	if err != nil {

--- a/panel-api/internal/migrate/jabali/init.go
+++ b/panel-api/internal/migrate/jabali/init.go
@@ -1,0 +1,12 @@
+package jabali
+
+import (
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func init() {
+	migrate.Register(models.MigrationSourceJabali, func() migrate.Discoverer {
+		return New()
+	})
+}

--- a/panel-api/internal/migrate/jabali/pull.go
+++ b/panel-api/internal/migrate/jabali/pull.go
@@ -1,0 +1,256 @@
+// Phase 3 (GH #954) — the Path-Y transport half of the Jabali→Jabali importer.
+//
+// Both sides are Jabali, so instead of re-implementing resource recreation we
+// reuse the account backup/restore engine (the same one #331 DR uses). This file
+// drives the SOURCE's own `jabali backup …` CLI over the existing SSH session to
+// produce a restic account_backup of one user, then streams the repo (and the
+// source box's restic password) back to the dest staging dir. The dest-side
+// import arm (migrate_run_cmd.go) then restores it via the DR account-restore
+// path — reading the foreign-password repo through backup.restore's password_file
+// field (no rekey, no repo mutation).
+//
+// Everything here is scoped to a per-job throwaway destination/schedule/repo on
+// the source that CleanupSource removes afterwards; the account's own data and
+// schedules are never touched.
+package jabali
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+)
+
+// sourceBoxPasswordPath is the source box's box-wide restic password. Local
+// backup destinations encrypt their repo with it; it is root-readable over SSH
+// and carried to the dest so the import can open the pulled repo.
+const sourceBoxPasswordPath = "/etc/jabali-panel/restic-repo.password"
+
+// SourceBackup records the throwaway artifacts RunSourceBackup created on the
+// source, so the caller can pull the repo and then remove them via CleanupSource.
+type SourceBackup struct {
+	DestName   string // backup destination name created on the source
+	DestID     string // its ULID (best-effort; parsed from --json)
+	ScheduleID string // account_backup schedule ULID
+	RepoDir    string // absolute restic repo dir on the source
+}
+
+// shortID lowercases the first 8 chars of a ULID for use in per-job source
+// destination/schedule names + the repo dir. 8 chars is unique enough for a
+// throwaway name and keeps the shell argument short + shape-safe.
+func shortID(jobID string) string {
+	s := strings.ToLower(jobID)
+	if len(s) > 8 {
+		s = s[:8]
+	}
+	if s == "" {
+		s = "job"
+	}
+	return s
+}
+
+// RunSourceBackup drives the source's OWN jabali CLI to back up one account into
+// a fresh local restic destination, then waits for the manifest snapshot to land.
+// Read+write on the source, but every write is a per-job throwaway CleanupSource
+// removes. Returns the SourceBackup even on error so the caller can still clean
+// up whatever got created.
+func RunSourceBackup(ctx context.Context, raw migrate.Session, sourceUser, jobID string) (*SourceBackup, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return nil, errors.New("jabali.RunSourceBackup: wrong session type")
+	}
+	if !usernameRe.MatchString(sourceUser) {
+		return nil, fmt.Errorf("jabali.RunSourceBackup: invalid source user %q", sourceUser)
+	}
+	short := shortID(jobID)
+	sb := &SourceBackup{
+		DestName: "migrate-" + short,
+		RepoDir:  "/var/lib/jabali-migrate-src/" + short,
+	}
+
+	// 1. Create the repo dir (jabali-owned, 0750 — matching what the CLI's
+	//    local-dest preflight expects) + register a local destination over it.
+	mk := "install -d -o jabali -g jabali -m 0750 " + shellSingleQuote(sb.RepoDir)
+	if _, err := s.run(ctx, s.commandTimeout, mk); err != nil {
+		return sb, fmt.Errorf("create source repo dir %s: %w", sb.RepoDir, err)
+	}
+	destCreate := "jabali backup destination create --name " + shellSingleQuote(sb.DestName) +
+		" --kind local --url " + shellSingleQuote(sb.RepoDir) + " --json"
+	out, err := s.run(ctx, s.commandTimeout, destCreate)
+	if err != nil {
+		return sb, fmt.Errorf("source backup destination create: %w", err)
+	}
+	var destRow struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(out, &destRow) // id is best-effort; cleanup can use the name
+	sb.DestID = destRow.ID
+
+	// 2. Create an account_backup schedule restricted to just this user → dest.
+	schedCreate := "jabali backup schedule create --kind account_backup --user " +
+		shellSingleQuote(sourceUser) + " --destination " + shellSingleQuote(sb.DestName) +
+		" --cron '0 3 * * *' --json"
+	out, err = s.run(ctx, s.commandTimeout, schedCreate)
+	if err != nil {
+		return sb, fmt.Errorf("source schedule create: %w", err)
+	}
+	var schedRow struct {
+		ID string `json:"id"`
+	}
+	if e := json.Unmarshal(out, &schedRow); e != nil || schedRow.ID == "" {
+		return sb, fmt.Errorf("source schedule create: could not read schedule id from output %q", strings.TrimSpace(string(out)))
+	}
+	sb.ScheduleID = schedRow.ID
+
+	// 3. Fire it now, then tick + poll until the manifest snapshot appears.
+	if _, err := s.run(ctx, s.commandTimeout, "jabali backup schedule run-now "+shellSingleQuote(sb.ScheduleID)); err != nil {
+		return sb, fmt.Errorf("source schedule run-now: %w", err)
+	}
+	if err := s.waitForManifest(ctx, sb.RepoDir); err != nil {
+		return sb, err
+	}
+	return sb, nil
+}
+
+// manifestPollInterval / manifestMaxWait bound the tick-and-poll loop. Big
+// accounts back up for many minutes; the pull command's 90m context is the hard
+// ceiling, this is the softer per-account budget. Vars (not consts) so tests can
+// shrink the interval without waiting real seconds.
+var (
+	manifestPollInterval = 15 * time.Second
+	manifestMaxWait      = 75 * time.Minute
+)
+
+// waitForManifest ticks the source scheduler (so the due account_backup actually
+// runs) and polls the fresh repo for a stage=manifest snapshot — the last
+// snapshot an account_backup writes, so its presence means the backup finished.
+// The repo carries only this one account, so any manifest snapshot is ours.
+func (s *session) waitForManifest(ctx context.Context, repoDir string) error {
+	listCmd := "restic -r " + shellSingleQuote(repoDir) +
+		" --password-file " + shellSingleQuote(sourceBoxPasswordPath) +
+		" snapshots --json 2>/dev/null"
+	deadline := time.Now().Add(manifestMaxWait)
+	ticks := 0
+	for {
+		// Tick advances the due schedule; harmless to repeat (once fired,
+		// next_run_at moves to the next cron slot until 03:00).
+		_, _ = s.run(ctx, s.commandTimeout, "jabali backup scheduler tick")
+		ticks++
+		if out, err := s.run(ctx, s.commandTimeout, listCmd); err == nil {
+			var snaps []struct {
+				Tags []string `json:"tags"`
+			}
+			if json.Unmarshal(out, &snaps) == nil {
+				for _, sn := range snaps {
+					for _, t := range sn.Tags {
+						if strings.Contains(t, "manifest") {
+							return nil
+						}
+					}
+				}
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("source account_backup: no manifest snapshot after %d ticks (~%s) — the account may be very large or the source scheduler is not running", ticks, manifestMaxWait)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("source account_backup: context cancelled before the manifest snapshot landed: %w", ctx.Err())
+		case <-time.After(manifestPollInterval):
+		}
+	}
+}
+
+// ReadBoxPassword returns the source box's restic password (root-readable over
+// SSH). Carried to the dest so the import can open the pulled repo.
+func ReadBoxPassword(ctx context.Context, raw migrate.Session) (string, error) {
+	s, ok := raw.(*session)
+	if !ok {
+		return "", errors.New("jabali.ReadBoxPassword: wrong session type")
+	}
+	out, err := s.run(ctx, s.commandTimeout, "cat "+shellSingleQuote(sourceBoxPasswordPath))
+	if err != nil {
+		return "", fmt.Errorf("read source restic password: %w", err)
+	}
+	pw := strings.TrimRight(string(out), "\r\n")
+	if pw == "" {
+		return "", errors.New("source restic password file is empty")
+	}
+	return pw, nil
+}
+
+// PullRepo streams the source restic repo dir back as a gzip tarball to localTar.
+// It uses a streamed `tar czf -` (never buffering the repo in memory — a real
+// account's repo is GBs), mirroring wordpressssh.PullFilesTarball. The caller
+// extracts localTar to obtain the repo tree.
+func PullRepo(ctx context.Context, raw migrate.Session, repoDir, localTar string) error {
+	s, ok := raw.(*session)
+	if !ok {
+		return errors.New("jabali.PullRepo: wrong session type")
+	}
+	cmd := "tar czf - -C " + shellSingleQuote(repoDir) + " . 2>/dev/null"
+	return s.streamToFile(ctx, manifestMaxWait, cmd, localTar)
+}
+
+// streamToFile runs cmd on the source and writes its stdout straight to
+// localPath (streamed, not buffered). Mirrors wordpressssh's helper.
+func (s *session) streamToFile(ctx context.Context, timeout time.Duration, cmd, localPath string) error {
+	subctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return fmt.Errorf("ssh new session: %w", err)
+	}
+	defer sess.Close()
+	f, err := os.OpenFile(localPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return fmt.Errorf("open local %s: %w", localPath, err)
+	}
+	defer f.Close()
+	sess.Stdout = f
+	done := make(chan error, 1)
+	go func() { done <- sess.Run(cmd) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("ssh stream %q: %w", cmd, err)
+		}
+		return nil
+	case <-subctx.Done():
+		return fmt.Errorf("ssh stream %q: timed out after %s", cmd, timeout)
+	}
+}
+
+// CleanupSource removes the throwaway destination/schedule/repo RunSourceBackup
+// created on the source. Order matters: schedule FIRST (a surviving daily
+// schedule pointed at a deleted repo dir would fail forever on the source), then
+// the destination, then the repo dir. Best-effort — returns every error so the
+// caller can warn without aborting.
+func CleanupSource(ctx context.Context, raw migrate.Session, sb *SourceBackup) []error {
+	s, ok := raw.(*session)
+	if !ok || sb == nil {
+		return nil
+	}
+	var errs []error
+	if sb.ScheduleID != "" {
+		if _, err := s.run(ctx, s.commandTimeout, "jabali backup schedule delete "+shellSingleQuote(sb.ScheduleID)+" --force"); err != nil {
+			errs = append(errs, fmt.Errorf("delete source schedule %s: %w", sb.ScheduleID, err))
+		}
+	}
+	if sb.DestName != "" {
+		if _, err := s.run(ctx, s.commandTimeout, "jabali backup destination delete "+shellSingleQuote(sb.DestName)+" --force"); err != nil {
+			errs = append(errs, fmt.Errorf("delete source destination %s: %w", sb.DestName, err))
+		}
+	}
+	if sb.RepoDir != "" {
+		if _, err := s.run(ctx, s.commandTimeout, "rm -rf -- "+shellSingleQuote(sb.RepoDir)); err != nil {
+			errs = append(errs, fmt.Errorf("remove source repo dir %s: %w", sb.RepoDir, err))
+		}
+	}
+	return errs
+}

--- a/panel-api/internal/migrate/jabali/pull_test.go
+++ b/panel-api/internal/migrate/jabali/pull_test.go
@@ -1,0 +1,186 @@
+package jabali
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// recordingSession captures every command run and answers from a substring
+// router. A route value may be a func(callNo int) string so a command's answer
+// can change across calls (e.g. snapshots empty, then carrying a manifest).
+type recordingSession struct {
+	*session
+	cmds  []string
+	calls map[string]int
+}
+
+func newRecordingSession(routes map[string]any) *recordingSession {
+	rs := &recordingSession{
+		session: &session{commandTimeout: time.Second},
+		calls:   map[string]int{},
+	}
+	rs.session.run = func(_ context.Context, _ time.Duration, cmd string) ([]byte, error) {
+		rs.cmds = append(rs.cmds, cmd)
+		for sub, out := range routes {
+			if !strings.Contains(cmd, sub) {
+				continue
+			}
+			rs.calls[sub]++
+			switch v := out.(type) {
+			case string:
+				return []byte(v), nil
+			case func(int) string:
+				return []byte(v(rs.calls[sub])), nil
+			}
+		}
+		return []byte("{}"), nil
+	}
+	return rs
+}
+
+func (rs *recordingSession) ran(sub string) bool {
+	for _, c := range rs.cmds {
+		if strings.Contains(c, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// orderOf returns the index of the first command containing sub, or -1.
+func (rs *recordingSession) orderOf(sub string) int {
+	for i, c := range rs.cmds {
+		if strings.Contains(c, sub) {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestRunSourceBackup_Sequence(t *testing.T) {
+	old := manifestPollInterval
+	manifestPollInterval = time.Millisecond
+	defer func() { manifestPollInterval = old }()
+
+	rs := newRecordingSession(map[string]any{
+		"destination create": `{"id":"01DEST"}`,
+		"schedule create":    `{"id":"01SCHED"}`,
+		"scheduler tick":     ``, // routed so rs.calls counts it
+		// snapshots: empty on the first poll, manifest present on the second —
+		// exercises the tick+poll loop rather than a lucky first hit.
+		"snapshots --json": func(n int) string {
+			if n < 2 {
+				return `[]`
+			}
+			return `[{"tags":["kind=account_backup","stage=manifest","user-id=01SRC"]}]`
+		},
+	})
+
+	sb, err := RunSourceBackup(context.Background(), rs.session, "alice", "01JOBULIDXXXXXXXXXXXXXXXXX")
+	if err != nil {
+		t.Fatalf("RunSourceBackup: %v", err)
+	}
+	if sb.DestName != "migrate-01jobuli" {
+		t.Errorf("dest name = %q, want migrate-01jobuli", sb.DestName)
+	}
+	if sb.ScheduleID != "01SCHED" || sb.DestID != "01DEST" {
+		t.Errorf("ids not parsed: %+v", sb)
+	}
+	if !strings.HasPrefix(sb.RepoDir, "/var/lib/jabali-migrate-src/") {
+		t.Errorf("repo dir = %q", sb.RepoDir)
+	}
+
+	// The account_backup schedule must be restricted to the one user + created
+	// dir before the destination (local dest requires an existing dir).
+	if !rs.ran("install -d") {
+		t.Error("must create the repo dir before the destination")
+	}
+	if rs.orderOf("install -d") > rs.orderOf("destination create") {
+		t.Error("repo dir must be created before `destination create`")
+	}
+	if !strings.Contains(rs.cmds[rs.orderOf("schedule create")], "--kind account_backup --user 'alice'") {
+		t.Errorf("schedule must be account_backup scoped to alice, got %q", rs.cmds[rs.orderOf("schedule create")])
+	}
+	if !rs.ran("run-now '01SCHED'") {
+		t.Error("must run-now the created schedule by id")
+	}
+	if rs.calls["scheduler tick"] < 2 {
+		t.Errorf("must tick until the manifest lands (>=2), ticked %d", rs.calls["scheduler tick"])
+	}
+}
+
+func TestRunSourceBackup_RejectsBadUser(t *testing.T) {
+	rs := newRecordingSession(map[string]any{})
+	if _, err := RunSourceBackup(context.Background(), rs.session, "bad name!", "01JOB"); err == nil {
+		t.Error("an invalid source username must be rejected before any source write")
+	}
+	if len(rs.cmds) != 0 {
+		t.Errorf("no source command may run for a bad username, ran %v", rs.cmds)
+	}
+}
+
+func TestRunSourceBackup_ScheduleIDParseFail(t *testing.T) {
+	rs := newRecordingSession(map[string]any{
+		"destination create": `{"id":"01DEST"}`,
+		"schedule create":    `{}`, // no id
+	})
+	_, err := RunSourceBackup(context.Background(), rs.session, "alice", "01JOB")
+	if err == nil || !strings.Contains(err.Error(), "schedule id") {
+		t.Errorf("a schedule create without an id must fail loudly, got %v", err)
+	}
+}
+
+func TestWaitForManifest_TimesOut(t *testing.T) {
+	oldI, oldW := manifestPollInterval, manifestMaxWait
+	manifestPollInterval, manifestMaxWait = time.Millisecond, 5*time.Millisecond
+	defer func() { manifestPollInterval, manifestMaxWait = oldI, oldW }()
+
+	rs := newRecordingSession(map[string]any{
+		"snapshots --json": `[]`, // manifest never appears
+	})
+	err := rs.session.waitForManifest(context.Background(), "/var/lib/jabali-migrate-src/x")
+	if err == nil || !strings.Contains(err.Error(), "no manifest snapshot") {
+		t.Errorf("must time out when the manifest never lands, got %v", err)
+	}
+}
+
+func TestReadBoxPassword(t *testing.T) {
+	rs := newRecordingSession(map[string]any{
+		"cat '/etc/jabali-panel/restic-repo.password'": "s3cr3t-pw\n",
+	})
+	pw, err := ReadBoxPassword(context.Background(), rs.session)
+	if err != nil {
+		t.Fatalf("ReadBoxPassword: %v", err)
+	}
+	if pw != "s3cr3t-pw" {
+		t.Errorf("password not trimmed: %q", pw)
+	}
+
+	empty := newRecordingSession(map[string]any{
+		"cat '/etc/jabali-panel/restic-repo.password'": "\n",
+	})
+	if _, err := ReadBoxPassword(context.Background(), empty.session); err == nil {
+		t.Error("an empty password file must error")
+	}
+}
+
+func TestCleanupSource_Order(t *testing.T) {
+	rs := newRecordingSession(map[string]any{})
+	sb := &SourceBackup{DestName: "migrate-01jobuli", ScheduleID: "01SCHED", RepoDir: "/var/lib/jabali-migrate-src/01jobuli"}
+	if errs := CleanupSource(context.Background(), rs.session, sb); len(errs) != 0 {
+		t.Fatalf("cleanup errors: %v", errs)
+	}
+	sched := rs.orderOf("schedule delete '01SCHED' --force")
+	dest := rs.orderOf("destination delete 'migrate-01jobuli' --force")
+	rm := rs.orderOf("rm -rf -- '/var/lib/jabali-migrate-src/01jobuli'")
+	if sched < 0 || dest < 0 || rm < 0 {
+		t.Fatalf("missing cleanup command(s): sched=%d dest=%d rm=%d (%v)", sched, dest, rm, rs.cmds)
+	}
+	// Schedule FIRST (a live daily schedule pointed at a deleted repo dir would
+	// fail forever on the source), then destination, then the repo dir.
+	if !(sched < dest && dest < rm) {
+		t.Errorf("cleanup order must be schedule → destination → repo: sched=%d dest=%d rm=%d", sched, dest, rm)
+	}
+}

--- a/panel-api/internal/models/migration_job.go
+++ b/panel-api/internal/models/migration_job.go
@@ -53,6 +53,12 @@ const (
 	// are part of the manifest. Restore reuses the cpanel writers via cpmove
 	// synthesis (DirectAdmin/CloudPanel strategy).
 	MigrationSourceCyberPanel = "cyberpanel"
+	// MigrationSourceJabali (GH #954) — migrate a hosting account from ANOTHER
+	// Jabali install. The source is itself a Jabali box, so discovery talks to
+	// its own `jabali … list --json` CLI over SSH (version-tolerant, authoritative)
+	// rather than screen-scraping a foreign schema. One source account = one
+	// non-admin Jabali user, which maps 1:1 onto a destination user.
+	MigrationSourceJabali = "jabali"
 )
 
 // MigrationState is the per-job lifecycle. Stage transitions are

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -68,6 +68,7 @@ const SOURCE_DESC: Record<string, string> = {
   cloudpanel: "Live SSH — web sites, PHP, databases, cron, SSH keys (no mail)",
   cyberpanel: "Live SSH — web sites, databases, cron, SSH keys, DNS, mail",
   plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
+  jabali: "Live SSH from another Jabali box — full account: files, DBs, mail bodies, cron; login + user id preserved",
   wordpress_ssh: "Cloudways / VPS / generic SSH — single WP site (files + DB + wp-config rewrite)",
   wordpress_plugin: "No SSH — jabali-migrator plugin on the source pushes over a token-authed API",
 };
@@ -104,6 +105,7 @@ const SOURCE_OPTIONS = [
   { value: "cloudpanel", label: "CloudPanel (live SSH source)" },
   { value: "cyberpanel", label: "CyberPanel (live SSH source)" },
   { value: "plesk", label: "Plesk (live SSH source)" },
+  { value: "jabali", label: "Jabali (live SSH source)" },
 ];
 
 // ─── sub-step components ───────────────────────────────────────────────────────

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -74,6 +74,7 @@ const SOURCE_OPTIONS = [
   { value: "cloudpanel", label: "CloudPanel (site users)" },
   { value: "cyberpanel", label: "CyberPanel (websites)" },
   { value: "plesk", label: "Plesk (subscriptions)" },
+  { value: "jabali", label: "Jabali (accounts)" },
 ];
 
 const SOURCE_DESC: Record<string, string> = {
@@ -84,6 +85,7 @@ const SOURCE_DESC: Record<string, string> = {
   cloudpanel: "Live SSH — web sites, PHP, databases, cron, SSH keys (no mail)",
   cyberpanel: "Live SSH — web sites, databases, cron, SSH keys, DNS, mail",
   plesk: "Live SSH — subscriptions, WordPress, DBs (streamed), mail, DNS",
+  jabali: "Live SSH from another Jabali box — full account: files, DBs, mail bodies, cron; login password + user id preserved",
   wordpress_ssh: "Cloudways / VPS / generic SSH — a single WordPress site",
 };
 
@@ -105,6 +107,10 @@ const MULTI_ACCOUNT_KINDS = new Set([
   // created a bogus `root` user importing nothing. The picker lets the operator
   // choose the real subscription(s); a reseller can select several at once.
   "plesk",
+  // GH #954: Jabali source enumerates its own non-admin users via
+  // `jabali user list --json` (Discoverer.ListAccounts), so it goes through the
+  // account picker — pick one (or several) real accounts, never the SSH root.
+  "jabali",
 ]);
 function isMultiAccount(kind: string) {
   return MULTI_ACCOUNT_KINDS.has(kind);


### PR DESCRIPTION
## Jabali → Jabali account migration (GH #954)

Migrate one hosting account from another Jabali box, end to end. The source is itself Jabali, so discovery drives the source's own `jabali … --json` CLI over SSH, and the transport reuses the account backup/restore engine (same as #331 DR) rather than re-implementing resource recreation.

### What lands
- **Discovery + account picker** — enumerates the source's non-admin users; per-area manifest builders (domains, DBs, mailboxes, cron) via the source CLI.
- **Path-Y transport** — the source backs the account up to restic (throwaway per-job destination/schedule, cleaned up after); this box pulls the repo (streamed) + the source box password into staging; import restores via the DR `account-restore` path (`--target-user-id <source ULID> --target-username`), which CREATES the user and reconstructs domains/DBs/php-pools. Branches out **before** the cpanel user-resolution so it never pre-creates the target (which would conflict + orphan data).
- **Foreign-password repo** read via a new `password_file` field on `backup.restore` (parity with `account_list_manifests`) — no rekey, no repo mutation.
- **Login preserved** — Kratos export/import fixed (it never captured credentials and POSTed to a nonexistent route → 405 on every restore); restore now verifies login and reports `login: restored / NOT restored`.
- **Mail bodies replayed** — the restore mail import was silently scoped to the wrong staging root, importing 0 messages on every account-restore; fixed to the job's own staging dir.
- **Wizard** lists **Jabali** as a source kind (picker + create-gate + Test Connection).

### Verified
Two-box drills (source 192.168.100.165 → testserver): a real account crossed over with files + DB content verified on the destination, source ULID preserved, login password verified at the hash level (bcrypt round-trip), and a delivered mailbox message replayed and confirmed over IMAP. The Kratos + mail fixes also benefit #331 DR and every account-restore.

Refs GH #954. Post-merge: reindex `main` (new `internal/migrate/jabali` package).
