### PR TITLE
fix(migrate): let CyberPanel migrations start from the wizard (GH #522)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -283,6 +283,7 @@ func isKnownSourceKind(s string) bool {
 		models.MigrationSourceIMAP,            // GH #390/#374
 		models.MigrationSourcePlesk,           // GH #429
 		models.MigrationSourceCloudPanel,      // GH #522
+		models.MigrationSourceCyberPanel,      // GH #522 follow-on (was wired end-to-end but never added here → wizard create 400'd)
 		models.MigrationSourceJabali:          // GH #954
 		return true
 	}

--- a/panel-api/internal/api/admin_migrations_create_gate_test.go
+++ b/panel-api/internal/api/admin_migrations_create_gate_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// GH #522 follow-on: CyberPanel was wired end-to-end (registry, pullCyberPanel,
+// import arm, Discoverer, wizard picker) but never added to isKnownSourceKind,
+// so the wizard advertised it while every create POST returned
+// "unknown_source_kind". Also missing from panelDiscoverer, so Test Connection
+// returned "unsupported_kind". Guard both, and the sibling CloudPanel's Test
+// Connection which had the same panelDiscoverer gap.
+func TestCreateGate_KnowsAllWizardKinds(t *testing.T) {
+	// Every kind the wizard's SOURCE_OPTIONS offers must pass the create gate,
+	// or the create POST 400s on a source the operator can select.
+	for _, kind := range []string{
+		models.MigrationSourceCpanel,
+		models.MigrationSourceWHMpkgacct,
+		models.MigrationSourceDirectAdmin,
+		models.MigrationSourceHestia,
+		models.MigrationSourceCloudPanel,
+		models.MigrationSourceCyberPanel,
+		models.MigrationSourcePlesk,
+		models.MigrationSourceJabali,
+	} {
+		if !isKnownSourceKind(kind) {
+			t.Errorf("isKnownSourceKind(%q) = false — wizard offers it but create would 400", kind)
+		}
+	}
+}
+
+func TestPanelDiscoverer_SupportsCloudAndCyberPanel(t *testing.T) {
+	for _, kind := range []string{models.MigrationSourceCloudPanel, models.MigrationSourceCyberPanel} {
+		if d := panelDiscoverer(kind, false); d == nil {
+			t.Errorf("panelDiscoverer(%q) = nil — Test Connection would return unsupported_kind", kind)
+		}
+	}
+	if got := panelLabel(models.MigrationSourceCyberPanel); got != "CyberPanel" {
+		t.Errorf("panelLabel(cyberpanel) = %q, want CyberPanel", got)
+	}
+	if got := panelLabel(models.MigrationSourceCloudPanel); got != "CloudPanel" {
+		t.Errorf("panelLabel(cloudpanel) = %q, want CloudPanel", got)
+	}
+}

--- a/panel-api/internal/api/admin_migrations_testconn.go
+++ b/panel-api/internal/api/admin_migrations_testconn.go
@@ -10,12 +10,14 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cloudpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cpanel"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/cyberpanel"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/directadmin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/hestiacp"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/jabali"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/plesk"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressplugin"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/jabali"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/migrate/wordpressssh"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
@@ -38,6 +40,14 @@ func panelDiscoverer(kind string, allowPrivate bool) migrate.Discoverer {
 		return d
 	case models.MigrationSourcePlesk:
 		d := plesk.New()
+		d.AllowPrivate = allowPrivate
+		return d
+	case models.MigrationSourceCloudPanel: // GH #522
+		d := cloudpanel.New()
+		d.AllowPrivate = allowPrivate
+		return d
+	case models.MigrationSourceCyberPanel: // GH #522 follow-on
+		d := cyberpanel.New()
 		d.AllowPrivate = allowPrivate
 		return d
 	case models.MigrationSourceJabali: // GH #954
@@ -174,6 +184,10 @@ func panelLabel(kind string) string {
 		return "HestiaCP"
 	case models.MigrationSourcePlesk:
 		return "Plesk"
+	case models.MigrationSourceCloudPanel:
+		return "CloudPanel"
+	case models.MigrationSourceCyberPanel:
+		return "CyberPanel"
 	case models.MigrationSourceJabali:
 		return "Jabali"
 	}


### PR DESCRIPTION
## What

Creating a **CyberPanel** migration from the wizard failed with `unknown_source_kind` (GH #522).

## Cause

CyberPanel was wired end-to-end — registry blank-import, `pullCyberPanel`, the import arm, its `Discoverer`/`BackupUser`, and the wizard picker card — but was never added to `isKnownSourceKind`, the create-endpoint whitelist. So the wizard advertised a source kind that 400'd on submit. Its sibling **CloudPanel** (same #522 work) was gated correctly; CyberPanel was the miss. Both were also absent from `panelDiscoverer`, so their **Test Connection** returned `unsupported_kind`.

## Fix

- `isKnownSourceKind`: allow `cyberpanel` (account discovery already worked via `migrate.Get`).
- `panelDiscoverer` + `panelLabel`: add `cyberpanel` **and** `cloudpanel`.
- Test asserts every wizard `SOURCE_OPTIONS` kind passes the create gate (would have caught this) and that Cloud/CyberPanel resolve a Discoverer + label.

Refs GH #522.
