### PR TITLE
fix(mail): mail-group feature flags ignore 'unchecked' at create (gorm default:1 scar)

### DIFF
--- a/panel-api/internal/models/mail_group.go
+++ b/panel-api/internal/models/mail_group.go
@@ -25,10 +25,17 @@ type MailGroup struct {
 	DisplayName    string    `gorm:"column:display_name;type:varchar(255);not null;default:''" json:"display_name"`
 	Description    string    `gorm:"type:varchar(255);not null;default:''" json:"description"`
 	GroupKind      string    `gorm:"column:group_kind;type:varchar(16);not null;default:'resource'" json:"group_kind"`
-	HasMailbox     bool      `gorm:"column:has_mailbox;type:tinyint(1);not null;default:1" json:"has_mailbox"`
-	HasCalendar    bool      `gorm:"column:has_calendar;type:tinyint(1);not null;default:1" json:"has_calendar"`
-	HasAddressbook bool      `gorm:"column:has_addressbook;type:tinyint(1);not null;default:1" json:"has_addressbook"`
-	HasFiles       bool      `gorm:"column:has_files;type:tinyint(1);not null;default:1" json:"has_files"`
+	// NOTE: NO gorm `default:1` on these four bools. GORM substitutes the DB
+	// default for a Go zero value (false) on INSERT — see
+	// feedback_gorm_default1_bool_zero_value — so with `default:1` a group
+	// created with a feature UNCHECKED (e.g. has_files=false) silently landed
+	// enabled. Every create site sets all four explicitly (API via
+	// boolOr(req, true); CLI hardcodes true), so the tag was pure footgun. The
+	// DB column keeps its DEFAULT 1 from the migration for raw/non-app inserts.
+	HasMailbox     bool      `gorm:"column:has_mailbox;type:tinyint(1);not null" json:"has_mailbox"`
+	HasCalendar    bool      `gorm:"column:has_calendar;type:tinyint(1);not null" json:"has_calendar"`
+	HasAddressbook bool      `gorm:"column:has_addressbook;type:tinyint(1);not null" json:"has_addressbook"`
+	HasFiles       bool      `gorm:"column:has_files;type:tinyint(1);not null" json:"has_files"`
 	InternalOnly   bool      `gorm:"column:internal_only;type:tinyint(1);not null;default:0" json:"internal_only"` // GH #348
 	CreatedAt      time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt      time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`

--- a/panel-api/internal/repository/mail_group_create_flags_test.go
+++ b/panel-api/internal/repository/mail_group_create_flags_test.go
@@ -1,0 +1,55 @@
+package repository
+
+// Regression for feedback_gorm_default1_bool_zero_value: the four MailGroup
+// feature flags carried gorm `default:1`, so GORM substituted the DB default
+// (true) for an intentional false on INSERT. A mail group created with a
+// feature UNCHECKED landed with it enabled. This asserts the emitted INSERT
+// binds the actual struct values — false stays false.
+
+import (
+	"context"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestMailGroup_Create_PersistsFalseFeatureFlags(t *testing.T) {
+	raw, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer raw.Close()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
+		WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("10.11.6-MariaDB"))
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	repo := NewMailGroupRepository(gdb)
+
+	mock.ExpectBegin()
+	// Column order: id,domain_id,local_part,email_cached,display_name,
+	// description,group_kind,has_mailbox,has_calendar,has_addressbook,has_files,
+	// internal_only,created_at,updated_at. The four has_* MUST bind false — with
+	// the old `default:1` tag GORM bound true here and this fails.
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `mail_groups`")).
+		WithArgs(
+			"g1", "d1", "team", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			false, false, false, false, // has_mailbox, has_calendar, has_addressbook, has_files
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	g := &models.MailGroup{
+		ID: "g1", DomainID: "d1", LocalPart: "team",
+		HasMailbox: false, HasCalendar: false, HasAddressbook: false, HasFiles: false,
+	}
+	require.NoError(t, repo.Create(context.Background(), g))
+	require.NoError(t, mock.ExpectationsWereMet(),
+		"a MailGroup created with feature flags false must INSERT them as false (gorm default:1 scar)")
+}


### PR DESCRIPTION
## What

Creating a mail group with a feature **unchecked** (has_mailbox / has_calendar / has_addressbook / has_files = false) silently landed with that feature **enabled**.

## Cause

The recurring `gorm:"default:1"`-on-a-bool scar (previously fixed for `CronJob.Enabled` and `Domain.EmailEnabled`). GORM substitutes the DB default for a Go zero value on INSERT, so `HasFiles: false` was written as `has_files=1`.

Confirmed against the current GORM (not just from the old note): the INSERT lists the column but binds `true` for a `false` struct field —
```
argument 7 expected [bool - false] does not match actual [bool - true]
```

## Fix

Drop the Go `default:1` tag from the four flags (the DB column keeps its `DEFAULT 1` from the migration for raw inserts). Both create sites already set all four explicitly — API via `boolOr(req, true)`, CLI hardcodes `true` — so the tag was pure footgun; the true path is unchanged.

Regression test binds the four flags false and asserts the emitted INSERT carries false: it **fails with the old tag** (binds true) and passes without it.

## Note

Audited all 31 `default:1` bools. Three more are the same shape and can be intentionally false at create — `backup_destination.Enabled`, `backup_schedule.Enabled`, `notification_channel.Enabled` (all via a `--disabled` create). Those are deliberately **not** in this PR: dropping their tag is only safe once every construction site is confirmed to set `Enabled` explicitly (a wrong fix would silently disable a backup), so they get their own audited change.

Refs feedback_gorm_default1_bool_zero_value.
