### PR TITLE
fix(backup): destination/schedule created disabled stays disabled (gorm default:1 scar)

### DIFF
--- a/panel-api/internal/models/backup_destination.go
+++ b/panel-api/internal/models/backup_destination.go
@@ -111,9 +111,14 @@ type BackupDestination struct {
 	PasswordEnc       []byte          `gorm:"type:varbinary(512)" json:"-"`
 	PasswordRotatedAt *time.Time      `gorm:"type:datetime(6)" json:"password_rotated_at,omitempty"`
 	ExtraOptions      json.RawMessage `gorm:"type:json" json:"extra_options,omitempty"`
-	Enabled           bool            `gorm:"not null;default:1" json:"enabled"`
-	CreatedAt         time.Time       `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt         time.Time       `gorm:"type:datetime(6);not null" json:"updated_at"`
+	// No gorm default:1 — a destination/schedule can be created --disabled
+	// (Enabled=false), and GORM binds the DB default for a zero-valued bool on
+	// INSERT, so default:1 would silently re-enable it. See
+	// feedback_gorm_default1_bool_zero_value. Every create site sets Enabled
+	// explicitly; the DB column keeps its DEFAULT 1 for raw inserts.
+	Enabled   bool      `gorm:"not null" json:"enabled"`
+	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (BackupDestination) TableName() string { return "backup_destinations" }

--- a/panel-api/internal/models/backup_schedule.go
+++ b/panel-api/internal/models/backup_schedule.go
@@ -32,8 +32,13 @@ type BackupSchedule struct {
 	// pre-7B single tenant schedule) that keeps using CronExpr + NextRunAt. A
 	// non-empty cadence routes the schedule through the window-guarded dispatch
 	// path (internal/backup.NextTenantRun), where CronExpr is ignored.
-	Cadence     string     `gorm:"column:cadence;type:varchar(16);not null;default:''" json:"cadence"`
-	Enabled     bool       `gorm:"not null;default:1" json:"enabled"`
+	Cadence string `gorm:"column:cadence;type:varchar(16);not null;default:''" json:"cadence"`
+	// No gorm default:1 — a destination/schedule can be created --disabled
+	// (Enabled=false), and GORM binds the DB default for a zero-valued bool on
+	// INSERT, so default:1 would silently re-enable it. See
+	// feedback_gorm_default1_bool_zero_value. Every create site sets Enabled
+	// explicitly; the DB column keeps its DEFAULT 1 for raw inserts.
+	Enabled     bool       `gorm:"not null" json:"enabled"`
 	KeepDaily   *int       `gorm:"type:int" json:"keep_daily,omitempty"`
 	KeepWeekly  *int       `gorm:"type:int" json:"keep_weekly,omitempty"`
 	KeepMonthly *int       `gorm:"type:int" json:"keep_monthly,omitempty"`

--- a/panel-api/internal/models/notification_channel.go
+++ b/panel-api/internal/models/notification_channel.go
@@ -31,13 +31,15 @@ type NotificationChannel struct {
 	// UserID scopes ownership (JAB-171): NULL = server-wide (admin-owned,
 	// existing behaviour); set = owned by that tenant. The dispatcher filters
 	// on this from phase 2 onward.
-	UserID    *string                   `gorm:"column:user_id;type:char(26)" json:"user_id,omitempty"`
-	Name      string                    `gorm:"type:varchar(120);not null" json:"name"`
-	Kind      string                    `gorm:"type:varchar(16);not null;index:idx_notification_channels_kind_enabled,priority:1" json:"kind"`
-	Config    NotificationChannelConfig `gorm:"column:config_json;type:json;not null" json:"config"`
-	Enabled   bool                      `gorm:"type:tinyint(1);not null;default:1;index:idx_notification_channels_kind_enabled,priority:2" json:"enabled"`
-	CreatedAt time.Time                 `gorm:"type:datetime(6);not null;default:CURRENT_TIMESTAMP(6)" json:"created_at"`
-	UpdatedAt time.Time                 `gorm:"type:datetime(6);not null;default:CURRENT_TIMESTAMP(6)" json:"updated_at"`
+	UserID *string                   `gorm:"column:user_id;type:char(26)" json:"user_id,omitempty"`
+	Name   string                    `gorm:"type:varchar(120);not null" json:"name"`
+	Kind   string                    `gorm:"type:varchar(16);not null;index:idx_notification_channels_kind_enabled,priority:1" json:"kind"`
+	Config NotificationChannelConfig `gorm:"column:config_json;type:json;not null" json:"config"`
+	// No gorm default:1 — a channel can be created --disabled; default:1 would
+	// bind true for a false struct value on INSERT (feedback_gorm_default1_bool_zero_value).
+	Enabled   bool      `gorm:"type:tinyint(1);not null;index:idx_notification_channels_kind_enabled,priority:2" json:"enabled"`
+	CreatedAt time.Time `gorm:"type:datetime(6);not null;default:CURRENT_TIMESTAMP(6)" json:"created_at"`
+	UpdatedAt time.Time `gorm:"type:datetime(6);not null;default:CURRENT_TIMESTAMP(6)" json:"updated_at"`
 }
 
 func (NotificationChannel) TableName() string { return "notification_channels" }

--- a/panel-api/internal/repository/enabled_flag_default1_test.go
+++ b/panel-api/internal/repository/enabled_flag_default1_test.go
@@ -1,0 +1,103 @@
+package repository
+
+// Regression for feedback_gorm_default1_bool_zero_value on the three
+// Enabled bools that can be created --disabled: backup_destination,
+// backup_schedule, notification_channel. With a gorm `default:1` tag GORM binds
+// the DB default (true) for a zero-valued bool on INSERT, so a row created with
+// Enabled=false landed enabled — for a backup destination/schedule that means a
+// backup the operator disabled silently runs. This asserts the emitted INSERT
+// writes enabled=false.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// insertedValue parses a ToSQL INSERT ("INSERT INTO t (a,b,c) VALUES (1,2,3)")
+// and returns the inlined value for the named column.
+func insertedValue(t *testing.T, sql, column string) string {
+	t.Helper()
+	m := regexp.MustCompile(`(?i)INSERT INTO\s+\S+\s+\(([^)]*)\)\s+VALUES\s+\((.*)\)`).FindStringSubmatch(sql)
+	require.Len(t, m, 3, "unparseable INSERT: %s", sql)
+	cols := strings.Split(m[1], ",")
+	vals := splitTopLevel(m[2])
+	require.Len(t, vals, len(cols), "col/val count mismatch")
+	for i, c := range cols {
+		if strings.Trim(strings.TrimSpace(c), "`") == column {
+			return strings.TrimSpace(vals[i])
+		}
+	}
+	t.Fatalf("column %q not in INSERT: %s", column, sql)
+	return ""
+}
+
+// splitTopLevel splits a VALUES body on commas that are not inside quotes.
+func splitTopLevel(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inQ := false
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		switch {
+		case ch == '\'':
+			inQ = !inQ
+			cur.WriteByte(ch)
+		case ch == ',' && !inQ:
+			out = append(out, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(ch)
+		}
+	}
+	out = append(out, cur.String())
+	return out
+}
+
+func newToSQLDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	raw, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { raw.Close() })
+	mock.ExpectQuery("SELECT VERSION").WillReturnRows(sqlmock.NewRows([]string{"v"}).AddRow("10.11.6-MariaDB"))
+	db, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	return db
+}
+
+func TestEnabledFalse_PersistsOnCreate(t *testing.T) {
+	db := newToSQLDB(t)
+
+	t.Run("backup_destination", func(t *testing.T) {
+		sql := db.ToSQL(func(tx *gorm.DB) *gorm.DB {
+			return tx.Create(&models.BackupDestination{ID: "d1", Name: "n", Kind: "local", URL: "/x", Enabled: false})
+		})
+		require.Equal(t, "false", insertedValue(t, sql, "enabled"),
+			"a destination created disabled must INSERT enabled=false (gorm default:1 scar)")
+	})
+
+	t.Run("backup_schedule", func(t *testing.T) {
+		sql := db.ToSQL(func(tx *gorm.DB) *gorm.DB {
+			return tx.Create(&models.BackupSchedule{ID: "s1", Kind: "account_backup", CronExpr: "0 3 * * *", Enabled: false})
+		})
+		require.Equal(t, "false", insertedValue(t, sql, "enabled"),
+			"a schedule created disabled must INSERT enabled=false")
+	})
+
+	t.Run("notification_channel", func(t *testing.T) {
+		sql := db.ToSQL(func(tx *gorm.DB) *gorm.DB {
+			return tx.Create(&models.NotificationChannel{ID: "c1", Kind: "webpush", Enabled: false})
+		})
+		require.Equal(t, "false", insertedValue(t, sql, "enabled"),
+			"a channel created disabled must INSERT enabled=false")
+	})
+}


### PR DESCRIPTION
## What

A backup **destination** or **schedule** created disabled (`Enabled=false`, e.g. the CLI disabled flag) silently landed **enabled** — a schedule the operator turned off would start running backups. `notification_channel.Enabled` had the same shape.

## Cause

The recurring `gorm:"default:1"`-on-a-bool scar, the same one just fixed for the mail-group feature flags (#971). GORM binds the DB default (`true`) for a zero-valued bool on INSERT, so `Enabled: false` was written as `enabled=1`.

## Fix

Drop the Go `default:1` tag from `Enabled` on all three models (the DB column keeps its `DEFAULT 1` from the migration for raw inserts).

**Audited every construction site before dropping the tag** — because a wrong fix here would silently *disable* a backup. All set `Enabled` explicitly: the API hardcodes `true` or binds `req.Enabled`; the CLI uses the disabled flag; DR uses `true`. So dropping the tag only affects the false path.

Regression test (`ToSQL`, order-independent) asserts a disabled create writes `enabled=false` for all three — it fails with the tag (binds true) and passes without it.

Refs feedback_gorm_default1_bool_zero_value.
