### PR TITLE
fix(api): server-status returns alerts:[] not null on a healthy server

### DIFF
--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -282,7 +282,11 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 // minimum that catches obvious failures; Step 4 will extend with
 // service-specific rules and a link to the relevant remediation page.
 func synthesizeAlerts(results map[string]json.RawMessage, errMap map[string]string) []ServerStatusAlert {
-	var alerts []ServerStatusAlert
+	// Init non-nil: a HEALTHY server produces no alerts, and a nil slice marshals
+	// as JSON `null`, not `[]` (feedback_go_nil_slice_json_null_spa_crash). The SPA
+	// guards `alerts` with `?? []`, but non-SPA API clients (jabali-mcp,
+	// integrations, curl) get `null` and break on a list operation. Return `[]`.
+	alerts := []ServerStatusAlert{}
 
 	for name, msg := range errMap {
 		if name == "nginx" {

--- a/panel-api/internal/api/server_status_alerts_internal_test.go
+++ b/panel-api/internal/api/server_status_alerts_internal_test.go
@@ -1,0 +1,26 @@
+package api
+
+// Regression for feedback_go_nil_slice_json_null_spa_crash: a HEALTHY server
+// (no agent errors, no failed/inactive services, no disk/load thresholds)
+// produced a nil alerts slice, which marshals as JSON `null` instead of `[]`.
+// The SPA guards it, but non-SPA API clients (jabali-mcp, integrations) break on
+// a list op against null. synthesizeAlerts must return a non-nil empty slice.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSynthesizeAlerts_HealthyServerReturnsEmptyNotNil(t *testing.T) {
+	got := synthesizeAlerts(map[string]json.RawMessage{}, map[string]string{})
+	if got == nil {
+		t.Fatal("synthesizeAlerts returned nil on a healthy server → marshals as JSON null")
+	}
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(b) != "[]" {
+		t.Errorf("healthy-server alerts must marshal as [], got %s", b)
+	}
+}


### PR DESCRIPTION
## What

The admin **server-status** endpoint returns `"alerts": null` on a healthy server instead of `[]`. Confirmed live on a healthy box.

## Cause

`synthesizeAlerts` builds its slice with `var alerts []ServerStatusAlert` and only appends when something is wrong. A healthy server (no agent errors, no failed/inactive services, no disk/load thresholds) appends nothing, so it returns nil — which marshals as JSON `null`, not `[]` (`feedback_go_nil_slice_json_null_spa_crash`).

## Impact

**Low — no user-facing crash.** The SPA guards it (`AlertsBanner` checks `!alerts`; callers use `?? []`). The value is for **non-SPA API clients** — jabali-mcp, integrations, curl scripts — which receive `null` and break on a list operation.

## Fix

Init the slice non-nil at the source (`alerts := []ServerStatusAlert{}`). Regression test asserts a healthy server marshals `alerts` as `[]`, not null.

## Note

Audited the nil-slice class broadly: GORM's `Find` returns a **non-nil** empty slice on zero rows, so the ~108 repo-backed list endpoints are already safe. This hand-built slice was the residual case.

Refs feedback_go_nil_slice_json_null_spa_crash.
