### PR TITLE
fix(db): Postgres memory tunables need an explicit byte unit (GH #968)

### DIFF
--- a/internal/dbtuning/dbtuning.go
+++ b/internal/dbtuning/dbtuning.go
@@ -189,6 +189,15 @@ func RenderMariaDBDropIn(kv map[string]string) string {
 
 // PostgresStatements renders one `ALTER SYSTEM SET` per key (sorted).
 // Values are quoted; identifiers are allowlisted so no injection path.
+//
+// Bytes tunables are normalised to an explicit "<n>B" literal. A memory GUC
+// with a unit-less value is read by Postgres in the parameter's base unit
+// (8 kB blocks for these params), so a plain byte count like effective_cache_size's
+// 4 GiB default (4294967296) is parsed as 4294967296 * 8 kB and overflows the
+// int32 GUC ceiling — ALTER SYSTEM then rejects the statement and rolls the
+// whole apply back, even on the untouched defaults (GH #968). The "<n>B" form
+// also rescues a MariaDB-style single-letter suffix (4G) that Postgres would
+// not accept.
 func PostgresStatements(kv map[string]string) []string {
 	keys := make([]string, 0, len(kv))
 	for k := range kv {
@@ -197,7 +206,13 @@ func PostgresStatements(kv map[string]string) []string {
 	sort.Strings(keys)
 	out := make([]string, 0, len(keys))
 	for _, k := range keys {
-		v := strings.ReplaceAll(kv[k], "'", "''")
+		val := kv[k]
+		if p, ok := lookup("postgres", k); ok && p.Kind == KindBytes {
+			if b, err := parseBytes(val); err == nil {
+				val = strconv.FormatInt(int64(b), 10) + "B"
+			}
+		}
+		v := strings.ReplaceAll(val, "'", "''")
 		out = append(out, fmt.Sprintf("ALTER SYSTEM SET %s = '%s'", k, v))
 	}
 	return out

--- a/internal/dbtuning/dbtuning_test.go
+++ b/internal/dbtuning/dbtuning_test.go
@@ -65,6 +65,34 @@ func TestPostgresStatementsQuoting(t *testing.T) {
 	}
 }
 
+// TestPostgresBytesCarryUnit pins GH #968: memory GUCs must reach ALTER SYSTEM
+// with an explicit byte unit. Without it, effective_cache_size's 4 GiB default
+// (4294967296, unit-less) is read as 8 kB blocks and overflows the int32 GUC
+// ceiling, so the whole apply is rejected and rolled back.
+func TestPostgresBytesCarryUnit(t *testing.T) {
+	stmts := PostgresStatements(map[string]string{
+		"effective_cache_size": "4294967296", // 4 GiB default, plain bytes
+		"shared_buffers":       "4G",          // MariaDB-style suffix Postgres rejects
+		"max_connections":      "150",         // KindInt — must stay verbatim
+	})
+	got := strings.Join(stmts, "\n")
+	// bytes tunables normalised to an explicit "<n>B" literal
+	if !strings.Contains(got, "ALTER SYSTEM SET effective_cache_size = '4294967296B'") {
+		t.Errorf("effective_cache_size not rendered with a byte unit:\n%s", got)
+	}
+	if !strings.Contains(got, "ALTER SYSTEM SET shared_buffers = '4294967296B'") {
+		t.Errorf("shared_buffers 4G not normalised to bytes:\n%s", got)
+	}
+	// the old, broken form must not survive
+	if strings.Contains(got, "effective_cache_size = '4294967296'") {
+		t.Errorf("unit-less byte value still emitted (the #968 bug):\n%s", got)
+	}
+	// non-bytes params untouched
+	if !strings.Contains(got, "ALTER SYSTEM SET max_connections = '150'") {
+		t.Errorf("max_connections should stay verbatim:\n%s", got)
+	}
+}
+
 func TestRestartRequired(t *testing.T) {
 	if !RestartRequired("mariadb", map[string]string{"max_connections": "200"}) {
 		t.Fatal("max_connections is restart-required")


### PR DESCRIPTION
## GH #968 — PostgreSQL config cannot be saved

`Settings → Database → Database Configuration` → **Reapply** on the untouched Postgres defaults failed with a generic Cloudflare 502. @lxsdevcode dug out the real agent error:

```
ALTER SYSTEM failed: ERROR: invalid value for parameter "effective_cache_size": "4294967296"
HINT: Value exceeds integer range.
```

### Root cause
`dbtuning.PostgresStatements` rendered a bytes tunable as a quoted, **unit-less** value:

```
ALTER SYSTEM SET effective_cache_size = '4294967296'
```

Postgres reads a unit-less memory GUC in the parameter's base unit (8 kB blocks for these params), so the 4 GiB default was parsed as `4294967296 × 8 kB` and exceeded the int32 GUC ceiling (`2147483647`). Postgres rejected the statement and rolled the whole apply back — so even Reapply on defaults failed.

### Fix
Normalise every postgres `KindBytes` value to an explicit `<n>B` literal before rendering. Postgres accepts `B/kB/MB/GB/TB` (verified against current docs), so `'4294967296B'` applies as 4 GiB, well inside range. Also rescues a MariaDB-style single-letter suffix (`4G`) Postgres would reject. MariaDB rendering untouched.

### Not changed (already correct)
Failed applies **are** already audited — the agent-rejected path records to both `db_admin_audit` and the unified `audit_events`, and publishes the "config change rejected" notification (the one @lxsdevcode found). The opaque 502 + "only showed in notifications" fits a rollback/recovery run exceeding Cloudflare's request timeout: CF returns 502 while panel-api finishes server-side (auditing + notifying after CF gave up). With this fix the common trigger is gone; a genuinely bad user value is still caught by `dbtuning.ValidateSet` before it reaches the agent. The audit-view visibility (server-scoped admin rows) is worth a separate look but needs no change here.

### Test plan
- [x] `go test ./internal/dbtuning/...` — new `TestPostgresBytesCarryUnit` asserts the byte unit is emitted, the old unit-less form is gone, and non-bytes params stay verbatim
- [x] `go test ./panel-api/internal/api/...`, `go build ./...`, `go vet` clean

Refs GH #968.
