### PR TITLE
docs(readme): drop the release-candidate notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@
 
 </div>
 
-> [!NOTE]
-> Jabali Panel is currently a release candidate. Expect rapid iteration and
-> breaking changes until 1.0.
-
 ## Demo and Website
 
 - Website: https://jabali-panel.com/


### PR DESCRIPTION
Removes the release-candidate / breaking-changes-until-1.0 NOTE callout from the README, as requested.