### PR TITLE
docs(readme): drop the release-candidate status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 </p>
 
 <p>
-  <img src="https://img.shields.io/badge/status-release_candidate-f59e0b" alt="Release candidate">
   <img src="https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white" alt="Go 1.25">
   <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black" alt="React 19">
   <img src="https://img.shields.io/badge/Ant_Design-5-0170FE?logo=antdesign&logoColor=white" alt="Ant Design 5">


### PR DESCRIPTION
Follow-up to the RC-notice removal: also drops the `status-release_candidate` header badge so the README no longer advertises release-candidate status.