### PR TITLE
perf: stop the admin dashboard burning a core on idle polling (OPT HI-2, HI-4, ME-2)

### DIFF
--- a/panel-api/internal/api/goaccess_cache.go
+++ b/panel-api/internal/api/goaccess_cache.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+)
+
+// GoAccess rendering is expensive and the caller is a poller: the log
+// modal's iframe re-requests every 10s for as long as it is open, and each
+// render is a full goaccess pass over the whole current-day access log
+// (hundreds of MB on a busy domain) plus a multi-MB HTML response. Two
+// admins with the modal open used to mean two full re-parses every 10s,
+// forever — sustained double-digit CPU from idle browser tabs.
+//
+// The cache collapses all of that into at most one render per log per TTL,
+// no matter how many viewers or how fast they poll. A render is reused when
+// it is younger than the TTL, and also when it is older but the log has not
+// changed (same mtime+size) — an idle domain never re-parses at all.
+//
+// Renders for one path are single-flighted: concurrent viewers that arrive
+// on a cold entry wait for the one in-flight goaccess run instead of each
+// spawning their own.
+
+// goaccessCacheTTL bounds re-render frequency. Must be >= the modal's poll
+// interval (10s) for the cache to do its job; 30s keeps the dashboard
+// usefully fresh while cutting a 3-viewer host from 18 renders/min to 2.
+const goaccessCacheTTL = 30 * time.Second
+
+type goaccessCacheEntry struct {
+	html     []byte
+	mtime    time.Time
+	size     int64
+	rendered time.Time
+}
+
+type goaccessRenderCache struct {
+	mu      sync.Mutex
+	entries map[string]*goaccessCacheEntry
+	// inflight serialises renders per path so N concurrent viewers cause
+	// one goaccess process, not N.
+	inflight map[string]*sync.Mutex
+}
+
+var goaccessCache = &goaccessRenderCache{
+	entries:  map[string]*goaccessCacheEntry{},
+	inflight: map[string]*sync.Mutex{},
+}
+
+// fresh reports a usable cached render for (path, st), or nil.
+func (c *goaccessRenderCache) fresh(path string, st os.FileInfo, now time.Time) []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[path]
+	if !ok {
+		return nil
+	}
+	if now.Sub(e.rendered) < goaccessCacheTTL {
+		return e.html
+	}
+	// Past the TTL, but an untouched log renders identically — reuse it
+	// rather than re-parsing the same bytes.
+	if e.mtime.Equal(st.ModTime()) && e.size == st.Size() {
+		return e.html
+	}
+	return nil
+}
+
+func (c *goaccessRenderCache) store(path string, st os.FileInfo, html []byte, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[path] = &goaccessCacheEntry{
+		html:     html,
+		mtime:    st.ModTime(),
+		size:     st.Size(),
+		rendered: now,
+	}
+}
+
+// pathLock returns the per-path render mutex, creating it on first use.
+func (c *goaccessRenderCache) pathLock(path string) *sync.Mutex {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m, ok := c.inflight[path]
+	if !ok {
+		m = &sync.Mutex{}
+		c.inflight[path] = m
+	}
+	return m
+}
+
+// renderGoAccessCached returns the GoAccess HTML for accessLogPath, running
+// goaccess only when no reusable render exists. render is injected so tests
+// can count invocations without a goaccess binary.
+func renderGoAccessCached(
+	ctx context.Context,
+	accessLogPath string,
+	st os.FileInfo,
+	now func() time.Time,
+	render func(context.Context, string) ([]byte, error),
+) ([]byte, error) {
+	if html := goaccessCache.fresh(accessLogPath, st, now()); html != nil {
+		return html, nil
+	}
+
+	lock := goaccessCache.pathLock(accessLogPath)
+	lock.Lock()
+	defer lock.Unlock()
+	// Re-check after acquiring: a concurrent viewer may have just rendered
+	// this path while we waited, which is the whole point of the lock.
+	if html := goaccessCache.fresh(accessLogPath, st, now()); html != nil {
+		return html, nil
+	}
+
+	html, err := render(ctx, accessLogPath)
+	if err != nil {
+		return nil, err
+	}
+	goaccessCache.store(accessLogPath, st, html, now())
+	return html, nil
+}

--- a/panel-api/internal/api/goaccess_cache_test.go
+++ b/panel-api/internal/api/goaccess_cache_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// statOf writes a file with the given content and returns its FileInfo.
+func statOf(t *testing.T, path, content string) os.FileInfo {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+// resetGoaccessCache isolates each test from the package-level cache.
+func resetGoaccessCache() {
+	goaccessCache.mu.Lock()
+	defer goaccessCache.mu.Unlock()
+	goaccessCache.entries = map[string]*goaccessCacheEntry{}
+	goaccessCache.inflight = map[string]*sync.Mutex{}
+}
+
+// TestGoAccessCacheServesWithinTTL pins the core win: a poller hitting the
+// endpoint repeatedly inside the TTL causes exactly one goaccess run.
+func TestGoAccessCacheServesWithinTTL(t *testing.T) {
+	resetGoaccessCache()
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	st := statOf(t, logPath, "line one\n")
+
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	render := func(context.Context, string) ([]byte, error) {
+		calls++
+		return []byte("<html>render</html>"), nil
+	}
+
+	// The modal polls every 10s; three polls inside the 30s TTL.
+	for i, offset := range []time.Duration{0, 10 * time.Second, 20 * time.Second} {
+		now := func() time.Time { return base.Add(offset) }
+		out, err := renderGoAccessCached(context.Background(), logPath, st, now, render)
+		if err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+		if string(out) != "<html>render</html>" {
+			t.Fatalf("poll %d: unexpected body %q", i, out)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("goaccess ran %d times across 3 polls in one TTL, want 1", calls)
+	}
+}
+
+// TestGoAccessCacheRerendersWhenLogChangedAfterTTL: past the TTL, a log that
+// actually grew must be re-parsed (the dashboard has to show new traffic).
+func TestGoAccessCacheRerendersWhenLogChangedAfterTTL(t *testing.T) {
+	resetGoaccessCache()
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	st1 := statOf(t, logPath, "line one\n")
+
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	render := func(context.Context, string) ([]byte, error) {
+		calls++
+		return []byte("<html>render</html>"), nil
+	}
+
+	if _, err := renderGoAccessCached(context.Background(), logPath, st1,
+		func() time.Time { return base }, render); err != nil {
+		t.Fatal(err)
+	}
+	// Log grows; poll after the TTL.
+	st2 := statOf(t, logPath, "line one\nline two\n")
+	if _, err := renderGoAccessCached(context.Background(), logPath, st2,
+		func() time.Time { return base.Add(goaccessCacheTTL + time.Second) }, render); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("goaccess ran %d times, want 2 (changed log past TTL must re-render)", calls)
+	}
+}
+
+// TestGoAccessCacheSkipsRerenderForIdleLog: past the TTL but the log is
+// byte-identical — re-parsing would produce the same HTML, so don't.
+func TestGoAccessCacheSkipsRerenderForIdleLog(t *testing.T) {
+	resetGoaccessCache()
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	st := statOf(t, logPath, "line one\n")
+
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	render := func(context.Context, string) ([]byte, error) {
+		calls++
+		return []byte("<html>render</html>"), nil
+	}
+
+	if _, err := renderGoAccessCached(context.Background(), logPath, st,
+		func() time.Time { return base }, render); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := renderGoAccessCached(context.Background(), logPath, st,
+		func() time.Time { return base.Add(10 * goaccessCacheTTL) }, render); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("goaccess ran %d times on an unchanged log, want 1", calls)
+	}
+}
+
+// TestGoAccessCacheSingleFlight: concurrent viewers landing on a cold entry
+// must produce one goaccess process, not one per viewer.
+func TestGoAccessCacheSingleFlight(t *testing.T) {
+	resetGoaccessCache()
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	st := statOf(t, logPath, "line one\n")
+
+	now := func() time.Time { return time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC) }
+	var mu sync.Mutex
+	calls := 0
+	render := func(context.Context, string) ([]byte, error) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(20 * time.Millisecond) // hold the slot so the others pile up
+		return []byte("<html>render</html>"), nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := renderGoAccessCached(context.Background(), logPath, st, now, render); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("goaccess ran %d times for 8 concurrent viewers, want 1", calls)
+	}
+}
+
+// TestGoAccessCacheDoesNotCacheErrors: a failed render must not be stored,
+// or one transient failure would be served for a whole TTL.
+func TestGoAccessCacheDoesNotCacheErrors(t *testing.T) {
+	resetGoaccessCache()
+	logPath := filepath.Join(t.TempDir(), "access.log")
+	st := statOf(t, logPath, "line one\n")
+
+	now := func() time.Time { return time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC) }
+	calls := 0
+	render := func(context.Context, string) ([]byte, error) {
+		calls++
+		if calls == 1 {
+			return nil, context.DeadlineExceeded
+		}
+		return []byte("<html>ok</html>"), nil
+	}
+
+	if _, err := renderGoAccessCached(context.Background(), logPath, st, now, render); err == nil {
+		t.Fatal("first render should have returned the error")
+	}
+	out, err := renderGoAccessCached(context.Background(), logPath, st, now, render)
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if string(out) != "<html>ok</html>" {
+		t.Fatalf("got %q — a failed render must not be cached", out)
+	}
+}

--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -58,9 +58,8 @@ type adminServerStatusHandler struct {
 }
 
 const (
-	subCallTimeout   = 5 * time.Second
-	nginxTestTimeout = 45 * time.Second
-	maxInFlight      = 8
+	subCallTimeout = 5 * time.Second
+	maxInFlight    = 8
 )
 
 // ServerStatusEnvelope is the shape returned to /admin/server-status. Sub-
@@ -149,11 +148,17 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 	call("services", "system.service_details", nil, subCallTimeout)
 	call("user_slices", "system.user_slices", nil, subCallTimeout)
 	call("software", "system.software", nil, subCallTimeout)
-	// nginx.test runs `nginx -t` which can take 15-30s on hosts with many
-	// vhosts + AppSec rule compile (CRS + vpatch = 200+ rules). Bumped from
-	// the 5s default so the health check doesn't false-alarm with
-	// "i/o timeout" on every server-status refresh.
-	call("nginx", "nginx.test", nil, nginxTestTimeout)
+	// nginx.status, NOT nginx.test: this envelope is polled every few
+	// seconds from any open admin tab, and `nginx -t` recompiles every
+	// vhost plus the whole CrowdSec AppSec/CRS rule set (~19s at >60% CPU
+	// on such hosts) — so the poller alone kept a core busy. nginx.status
+	// asks systemd for the unit state instead (sub-50ms) and is the verb
+	// that was added for exactly this caller. It is also the semantically
+	// correct check: the alert below says "nginx service not running",
+	// which is liveness, while nginx.test answers config validity — a
+	// config typo used to raise a misleading "not running" critical.
+	// nginx.test remains the gate for nginx.reload, where it belongs.
+	call("nginx", "nginx.status", nil, subCallTimeout)
 
 	// M31.1 — Redis queue depths run in parallel with the agent calls.
 	// Three XLEN/XPending pipelines, each with its own short timeout so

--- a/panel-api/internal/api/server_status_nginx_test.go
+++ b/panel-api/internal/api/server_status_nginx_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 )
 
-// nginx.test agent failure (config invalid → nginx -t non-zero → AgentError)
-// must surface as a DEDICATED critical alert, not the generic
-// warning/agent sub-call line — an invalid nginx config is a
-// whole-vhost outage on the box.
+// An nginx sub-call failure must surface as a DEDICATED critical alert, not
+// the generic warning/agent sub-call line — nginx being down is a
+// whole-vhost outage on the box. The aggregator polls `nginx.status`
+// (systemd unit state), which errors exactly when nginx is not running;
+// it deliberately does NOT run `nginx -t` on this hot path.
 func TestSynthesizeAlerts_NginxInvalidIsCritical(t *testing.T) {
 	errMap := map[string]string{
-		"nginx": "nginx test failed: [emerg] unknown directive \"http2\" in /etc/nginx/sites-enabled/default.conf:57",
+		"nginx": "nginx not running: state=failed",
 	}
 	alerts := synthesizeAlerts(map[string]json.RawMessage{}, errMap)
 

--- a/panel-api/internal/api/websocket_logs.go
+++ b/panel-api/internal/api/websocket_logs.go
@@ -345,7 +345,8 @@ func (h *logStreamHandler) renderGoAccessHTTP(c *gin.Context) {
 	// browser from holding a stale dashboard between iframe refreshes.
 	c.Header("Cache-Control", "no-store, max-age=0")
 
-	if _, statErr := os.Stat(accessLogPath); statErr != nil {
+	st, statErr := os.Stat(accessLogPath)
+	if statErr != nil {
 		c.String(http.StatusOK,
 			"<!doctype html><html><body style='font-family:sans-serif;padding:2em;background:#1f1f1f;color:#fff'>"+
 				"<h2>No access log yet</h2>"+
@@ -357,7 +358,11 @@ func (h *logStreamHandler) renderGoAccessHTTP(c *gin.Context) {
 
 	cmdCtx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
 	defer cancel()
-	out, err := runGoAccess(cmdCtx, accessLogPath)
+	// Cached: the iframe re-requests every 10s while the modal is open, and
+	// every render is a full parse of the whole access log. See
+	// goaccess_cache.go — at most one render per log per TTL, shared by all
+	// viewers.
+	out, err := renderGoAccessCached(cmdCtx, accessLogPath, st, time.Now, runGoAccess)
 	if err != nil {
 		h.cfg.Log.Warn("goaccess render failed", "err", err, "path", accessLogPath)
 		c.String(http.StatusOK,

--- a/panel-ui/src/components/ServerHealthIndicator.tsx
+++ b/panel-ui/src/components/ServerHealthIndicator.tsx
@@ -3,67 +3,46 @@
 // full Server Status page. Hidden when status is "ok" (no exclamation
 // in the chrome for the steady state).
 //
-// Polls every 30s on a setInterval — same cadence as NotificationBell.
+// Subscribes to the shared `["admin","server-status"]` query at a 30s
+// cadence rather than fetching on its own timer. This component mounts on
+// EVERY admin page, so a hand-rolled setInterval + raw apiClient.get meant
+// a second, uncached fan-out of the heavy aggregate stacked on top of
+// whatever the page itself was polling — and it kept firing in background
+// tabs left open overnight. React Query dedupes across observers and
+// pauses in background tabs (refetchIntervalInBackground: false).
 // Endpoint is admin-gated; on the user shell this component MUST NOT
 // mount (caller in JabaliHeader checks isAdminShell).
 
 import { useTranslation } from "react-i18next";
-import { useEffect, useState } from "react";
 import { Badge, Button, Tooltip } from "antd";
 import { ExclamationCircleOutlined, WarningOutlined } from "@icons";
 import { useNavigate } from "react-router";
-import { apiClient } from "../apiClient";
-
-interface Alert {
-  level: "warning" | "critical";
-  kind: string;
-  message?: string;
-}
-
-interface ServerStatusPayload {
-  alerts?: Alert[];
-}
+import { useServerStatus } from "../hooks/useServerStatus";
 
 // poll cadence — matches NotificationBell. Keep <60s so an operator
-// who just fixed a disk doesn't stare at a stale red badge.
+// who just fixed a disk doesn't stare at a stale red badge. A page with a
+// faster cadence (Server Status, Dashboard) wins while it is mounted.
 const POLL_MS = 30_000;
 
 export function ServerHealthIndicator(): JSX.Element | null {
   const { t } = useTranslation();
-  const [worst, setWorst] = useState<"ok" | "warning" | "critical">("ok");
-  const [count, setCount] = useState(0);
-  const [tooltip, setTooltip] = useState("");
   const navigate = useNavigate();
+  const { data } = useServerStatus({ refetchInterval: POLL_MS });
 
-  const refresh = async () => {
-    try {
-      const resp = await apiClient.get<ServerStatusPayload>("/admin/server-status");
-      const alerts = resp.data.alerts ?? [];
-      if (alerts.length === 0) {
-        setWorst("ok");
-        setCount(0);
-        setTooltip("");
-        return;
-      }
-      const hasCritical = alerts.some((a) => a.level === "critical");
-      setWorst(hasCritical ? "critical" : "warning");
-      setCount(alerts.length);
-      // Show up to 3 alert messages in the tooltip; collapse the rest.
-      const head = alerts.slice(0, 3).map((a) => `[${a.level}] ${a.kind}${a.message ? ": " + a.message : ""}`);
-      const tail = alerts.length > 3 ? `\n+${alerts.length - 3} more` : "";
-      setTooltip(head.join("\n") + tail);
-    } catch {
-      // Network blip — leave previous state intact rather than blink.
-    }
-  };
+  const alerts = data?.alerts ?? [];
+  // A fetch error leaves `data` at its last value, so the badge holds the
+  // previous state instead of blinking — same intent as the old catch{}.
+  if (alerts.length === 0) return null;
 
-  useEffect(() => {
-    void refresh();
-    const id = window.setInterval(refresh, POLL_MS);
-    return () => window.clearInterval(id);
-  }, []);
-
-  if (worst === "ok") return null;
+  const worst: "warning" | "critical" = alerts.some((a) => a.level === "critical")
+    ? "critical"
+    : "warning";
+  const count = alerts.length;
+  // Show up to 3 alert messages in the tooltip; collapse the rest.
+  const head = alerts
+    .slice(0, 3)
+    .map((a) => `[${a.level}] ${a.kind}${a.detail ? ": " + a.detail : ""}`);
+  const tooltip = head.join("\n") + (alerts.length > 3 ? `\n+${alerts.length - 3} more` : "");
 
   const Icon = worst === "critical" ? ExclamationCircleOutlined : WarningOutlined;
   const color = worst === "critical" ? "#ff4d4f" : "#faad14";

--- a/panel-ui/src/hooks/useServerStatus.ts
+++ b/panel-ui/src/hooks/useServerStatus.ts
@@ -147,7 +147,7 @@ export interface Alert {
   detail: string;
 }
 
-export function useServerStatus(opts?: { enabled?: boolean }) {
+export function useServerStatus(opts?: { enabled?: boolean; refetchInterval?: number }) {
   return useQuery<ServerStatusEnvelope>({
     queryKey: ["admin", "server-status"],
     queryFn: async () => {
@@ -160,7 +160,13 @@ export function useServerStatus(opts?: { enabled?: boolean }) {
     // polling with `enabled` instead of fetching the heavy aggregate
     // on every render.
     enabled: opts?.enabled ?? true,
-    refetchInterval: 5000,
+    // refetchInterval lets a low-priority subscriber (the header health
+    // badge, mounted on every admin page) ask for a slower cadence. React
+    // Query dedupes across observers of one key and honours the SHORTEST
+    // requested interval, so the badge costs nothing extra while a page
+    // with a faster cadence is open, and drops to its own interval once
+    // that page unmounts.
+    refetchInterval: opts?.refetchInterval ?? 5000,
     refetchIntervalInBackground: false,
   });
 }


### PR DESCRIPTION
Three findings from `docs/code-review-optimization-2026-08-08.md`, all the same shape: **work done per poll that should be done per change.**

### HI-2 — `nginx -t` on every server-status poll
The envelope is polled every few seconds from any open admin tab, and `nginx -t` recompiles every vhost plus the whole CrowdSec AppSec/CRS rule set (~19s at >60% CPU on such hosts). The 45s timeout exceeded the poll interval, so slow runs overlapped and stacked.

Swapped to `nginx.status` — the cheap systemd-state verb that was written *for exactly this caller* (see its header comment) and never wired up.

**Also a correctness fix:** the alert this drives says "nginx service not running" (liveness), but `nginx -t` answers config validity. A config typo used to raise a misleading "not running" critical while nginx served fine. `nginx.test` remains the gate for `nginx.reload`.

### ME-2 — header badge bypassed the query cache
`ServerHealthIndicator` mounts on every admin page and fetched the same heavy aggregate on a hand-rolled `setInterval` + raw `apiClient.get` — a second uncached fan-out stacked on the page's own poll, still firing in background tabs left open overnight. Now subscribes to the shared `["admin","server-status"]` query at 30s; React Query dedupes across observers, honours the shortest interval, and pauses in background tabs.

Incidentally fixes a silent bug: the tooltip read `a.message` but the API sends `detail`, so alert explanations never rendered.

### HI-4 — GoAccess re-parsed the whole access log every 10s per modal
Renders are now cached per log path: reused inside a 30s TTL, and past the TTL when the log is byte-identical (mtime+size), so an idle domain never re-parses. Concurrent viewers on a cold entry are single-flighted into one goaccess process. Failed renders aren't cached.

### Test plan
- [x] `go build ./...`, `go vet` clean
- [x] `go test -race ./panel-api/internal/api/...` — new cache tests: repeat polls in one TTL run goaccess once; changed log past TTL re-renders; unchanged log does not; 8 concurrent viewers produce one render; errors not cached
- [x] `npx tsc -b` clean; `vitest` 221/221 pass (incl. JabaliHeader, which mounts the rewritten indicator)
- [ ] Worth an eyeball on a box with many vhosts: server-status latency should drop from ~15-30s to sub-second

Refs the optimization review at commit `735d7445`.