### PR TITLE
fix(backup): carry the per-destination restic password through the whole backup path (SEC HI-1/2/3)

### DIFF
--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -148,6 +148,14 @@ func backupCreateHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 	// (status endpoint + journal-tail websocket) is wired.
 	go func() {
 		defer defaultJobSlots.release("backup", req.UserID, req.RepoURL)
+		// The per-destination password tempfile belongs to THIS job, not to
+		// the RPC that started it. backup.create is fire-and-forget — it
+		// returns as soon as this goroutine is spawned — so the caller
+		// cannot own the file's lifetime: panel-api's deferred cleanup used
+		// to unlink it seconds in, while the orchestrator below still needed
+		// it for every stage and for the manifest snapshot (up to 90
+		// minutes). Clean it up when the job actually ends.
+		defer func() { _ = removePasswordTempFile(req.PasswordFile) }()
 		ctxBg, cancel := context.WithTimeout(context.Background(), 90*time.Minute)
 		defer cancel()
 		if err := runBackupOrchestrator(ctxBg, req); err != nil {
@@ -174,7 +182,7 @@ func runBackupOrchestrator(ctx context.Context, req backupCreateParams) error {
 	defer jl.Close()
 	jl.Printf("account_backup start user_id=%s username=%s databases=%d mailboxes=%d destination=%s",
 		req.UserID, req.Username, len(req.Databases), len(req.Mailboxes), req.RepoURL)
-	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP); err != nil {
+	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.PasswordFile, req.SFTP); err != nil {
 		jl.Printf("ensure_repo_failed=%v", err)
 		return fmt.Errorf("ensure repo: %w", err)
 	}
@@ -270,6 +278,11 @@ func runHomeStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 		ScheduleID: req.ScheduleID, RepoURL: req.RepoURL,
 		CredentialsRef: req.CredentialsRef, SFTP: req.SFTP,
 		Compression: req.Compression, Folders: req.Folders,
+		// PasswordFile MUST be forwarded: a destination with its own
+		// sealed restic password (M30.2.x) is unopenable with the legacy
+		// shared file, and omitting it here silently falls back to that
+		// file — the stage then fails against a rotated destination.
+		PasswordFile: req.PasswordFile,
 	})
 	out, err := backupHomeHandler(ctx, body)
 	if err != nil {
@@ -301,6 +314,9 @@ func runDatabaseStage(ctx context.Context, req backupCreateParams) []backup.Mani
 		Databases: req.Databases, ScheduleID: req.ScheduleID,
 		RepoURL: req.RepoURL, CredentialsRef: req.CredentialsRef,
 		SFTP: req.SFTP, Compression: req.Compression,
+		// See runHomeStage: a per-destination password must reach the
+		// stage or it falls back to the legacy shared file.
+		PasswordFile: req.PasswordFile,
 	})
 	out, err := backupDatabasesHandler(ctx, body)
 	if err != nil {
@@ -442,6 +458,9 @@ func runMailStage(ctx context.Context, req backupCreateParams) backup.ManifestSt
 		Mailboxes: req.Mailboxes, ScheduleID: req.ScheduleID,
 		RepoURL: req.RepoURL, CredentialsRef: req.CredentialsRef,
 		SFTP: req.SFTP, Compression: req.Compression,
+		// See runHomeStage: a per-destination password must reach the
+		// stage or it falls back to the legacy shared file.
+		PasswordFile: req.PasswordFile,
 	})
 	out, err := backupMailboxesHandler(ctx, body)
 	if err != nil {

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -171,9 +171,18 @@ func classifyRepoProbe(lowerStderr string) repoProbeClass {
 // `restic init` if the repo doesn't exist yet. Idempotent — succeeds
 // on already-initialized repos. Local destinations get the parent dir
 // created if missing; failures bubble up.
-func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind string, sftp *backupSFTPInputs) error {
+func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, passwordFile string, sftp *backupSFTPInputs) error {
 	if repoURL == "" {
 		return nil
+	}
+	// A destination with its own sealed password (M30.2.x) must be probed
+	// AND initialised with THAT password. Probing with the legacy shared
+	// file made a rotated destination look unopenable — and once the
+	// reconciler purges the legacy file (all destinations migrated), this
+	// probe hard-failed before any stage could run.
+	pwFile := passwordFile
+	if pwFile == "" {
+		pwFile = backup.DefaultPasswordFile
 	}
 	var extraEnv []string
 	if credentialsRef != "" {
@@ -183,7 +192,7 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind st
 		}
 		extraEnv = env
 	}
-	_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, bkResticOptions(sftp))
+	_, snapStderr, snapErr := backup.SnapshotsRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
 	if snapErr == nil {
 		return nil
 	}
@@ -217,7 +226,10 @@ func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind st
 			return fmt.Errorf("ssh mkdir: %w", err)
 		}
 	}
-	_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, backup.DefaultPasswordFile, extraEnv, bkResticOptions(sftp))
+	// Init with the SAME password the probe used: a fresh repo for a
+	// destination that carries its own sealed password must be created under
+	// that password, or every later open fails.
+	_, initStderr, initErr := backup.InitRemote(ctx, nil, repoURL, pwFile, extraEnv, bkResticOptions(sftp))
 	if initErr != nil {
 		ls := strings.ToLower(strings.TrimSpace(string(initStderr)))
 		if strings.Contains(ls, "already initialized") ||

--- a/panel-agent/internal/commands/backup_password_threading_test.go
+++ b/panel-agent/internal/commands/backup_password_threading_test.go
@@ -1,0 +1,132 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The per-destination restic password (M30.2.x) reaches the agent as
+// `password_file` on backup.create / system.backup. Every code path that
+// opens the destination repo must carry it forward: a stage that omits it
+// silently falls back to the legacy shared
+// /etc/jabali-panel/restic-repo.password, which cannot open a rotated
+// destination's repo. The failure is quiet — the stage fails, and the job
+// can still seal a "partial" manifest a tenant later restores and finds
+// empty.
+//
+// These tests marshal each stage's params the way the orchestrator does and
+// assert password_file survives. They fail if a future edit drops the field
+// from one of the re-marshals again.
+
+// TestStageMarshalsForwardPasswordFile reads the orchestrator's source and
+// asserts every stage-dispatch marshal forwards PasswordFile.
+//
+// A value-level test can't catch this regression: each stage builds a fresh
+// params struct from `req`, so a test that constructs its own literal would
+// pass while the real marshal drops the field. Asserting on the source is
+// what actually pins the behaviour — same approach as
+// TestNoRepoDirReadsBeforeClone, which guards an equivalent
+// silently-degrading ordering rule in install.sh.
+func TestStageMarshalsForwardPasswordFile(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("backup_create.go")
+	if err != nil {
+		t.Fatalf("read backup_create.go: %v", err)
+	}
+	body := string(src)
+
+	for _, fn := range []string{"runHomeStage", "runDatabaseStage", "runMailStage"} {
+		start := strings.Index(body, "func "+fn+"(")
+		if start < 0 {
+			t.Fatalf("could not find %s in backup_create.go — if it was renamed, "+
+				"this test needs updating and the rule it protects still applies", fn)
+		}
+		// Bound the search at the next top-level func so one stage's marshal
+		// can't satisfy the assertion for another.
+		end := strings.Index(body[start+1:], "\nfunc ")
+		region := body[start:]
+		if end >= 0 {
+			region = body[start : start+1+end]
+		}
+		marshalAt := strings.Index(region, "json.Marshal(")
+		if marshalAt < 0 {
+			t.Errorf("%s: no json.Marshal call found", fn)
+			continue
+		}
+		if !strings.Contains(region, "PasswordFile: req.PasswordFile") {
+			t.Errorf("%s does not forward PasswordFile into its stage params. "+
+				"The stage then falls back to the legacy shared password file and "+
+				"cannot open a destination with its own sealed password (M30.2.x), "+
+				"failing silently against a rotated destination.", fn)
+		}
+	}
+}
+
+// bkEnsureRepoReady probes AND initialises the repo, so it must use the
+// destination's own password too — probing with the legacy shared file made
+// a rotated destination look unopenable, and hard-failed once the reconciler
+// purged that file.
+func TestEnsureRepoReadyTakesPasswordFile(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("backup_helpers.go")
+	if err != nil {
+		t.Fatalf("read backup_helpers.go: %v", err)
+	}
+	body := string(src)
+	sig := "func bkEnsureRepoReady(ctx context.Context, repoURL, credentialsRef, destKind, passwordFile string"
+	if !strings.Contains(body, sig) {
+		t.Errorf("bkEnsureRepoReady must accept a passwordFile parameter; want signature starting %q", sig)
+	}
+	// The hardcoded default must not be what the probe/init use directly.
+	if strings.Contains(body, "SnapshotsRemote(ctx, nil, repoURL, backup.DefaultPasswordFile") ||
+		strings.Contains(body, "InitRemote(ctx, nil, repoURL, backup.DefaultPasswordFile") {
+		t.Error("bkEnsureRepoReady still hardcodes backup.DefaultPasswordFile for the " +
+			"probe/init; it must use the destination's password when one is supplied")
+	}
+}
+
+// system.backup writes to the same destinations as account backups, so its
+// params must accept password_file too — it previously had no field at all
+// and built its restic config without a password.
+func TestSystemBackupParamsAcceptPasswordFile(t *testing.T) {
+	const pw = "/run/jabali/restic-pw/destpw-sys"
+	raw := []byte(`{
+		"job_id":"01JABALIJOB0000000000000AA",
+		"repo_url":"sftp:backup@host:/srv/repo",
+		"password_file":"` + pw + `"
+	}`)
+	var req systemBackupParams
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.PasswordFile != pw {
+		t.Fatalf("systemBackupParams.PasswordFile = %q, want %q", req.PasswordFile, pw)
+	}
+}
+
+// removePasswordTempFile is what gives the tempfile the job's lifetime. It
+// must refuse paths outside the agent-owned directory (it runs as root) and
+// treat a blank path as a no-op (the legacy shared-password path).
+func TestRemovePasswordTempFileRefusesForeignPaths(t *testing.T) {
+	if err := removePasswordTempFile(""); err != nil {
+		t.Errorf("blank path should be a no-op, got %v", err)
+	}
+	for _, bad := range []string{
+		"/etc/jabali-panel/restic-repo.password",
+		"/etc/shadow",
+		"/run/jabali/restic-pw-elsewhere/x",
+		"/run/jabali/restic-pw/../../etc/shadow",
+	} {
+		if err := removePasswordTempFile(bad); err == nil {
+			t.Errorf("removePasswordTempFile(%q) should have been refused", bad)
+		}
+	}
+	// A path under the owned dir is accepted (missing file is not an error).
+	if err := removePasswordTempFile(passwordTempDir + "/destpw-does-not-exist"); err != nil {
+		t.Errorf("owned path should be accepted, got %v", err)
+	}
+}

--- a/panel-agent/internal/commands/backup_repo_password_writetemp.go
+++ b/panel-agent/internal/commands/backup_repo_password_writetemp.go
@@ -94,22 +94,38 @@ func backupRepoPasswordCleanupTempHandler(ctx context.Context, raw json.RawMessa
 			Message: fmt.Sprintf("malformed JSON: %v", err),
 		}
 	}
-	// Belt-and-suspenders: only allow removal of files we own
-	// underneath passwordTempDir. Prevents a misbehaving caller from
-	// asking the agent to unlink anything else on disk.
-	clean := filepath.Clean(p.Path)
+	if err := removePasswordTempFile(p.Path); err != nil {
+		return nil, err
+	}
+	return map[string]any{"ok": true}, nil
+}
+
+// removePasswordTempFile unlinks a per-destination password tempfile.
+//
+// Belt-and-suspenders: only allow removal of files we own underneath
+// passwordTempDir. Prevents a misbehaving caller from asking the agent to
+// unlink anything else on disk. A blank path is a no-op (the legacy
+// shared-password path never writes a tempfile).
+//
+// Shared with the async backup orchestrator, which owns the file for the
+// lifetime of its job — see runBackupOrchestrator.
+func removePasswordTempFile(path string) *agentwire.AgentError {
+	if path == "" {
+		return nil
+	}
+	clean := filepath.Clean(path)
 	if !strings.HasPrefix(clean, passwordTempDir+string(os.PathSeparator)) {
-		return nil, &agentwire.AgentError{
+		return &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
 			Message: "path must be under " + passwordTempDir,
 		}
 	}
 	if err := os.Remove(clean); err != nil && !os.IsNotExist(err) {
-		return nil, &agentwire.AgentError{
+		return &agentwire.AgentError{
 			Code: agentwire.CodeInternal, Message: err.Error(),
 		}
 	}
-	return map[string]any{"ok": true}, nil
+	return nil
 }
 
 func init() {

--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -61,6 +61,12 @@ type systemBackupParams struct {
 	CredentialsRef  string            `json:"credentials_ref,omitempty"`
 	DestinationKind string            `json:"destination_kind,omitempty"`
 	SFTP            *backupSFTPInputs `json:"sftp,omitempty"`
+	// PasswordFile points at the destination's own sealed restic password
+	// (M30.2.x), written by the agent under /run/jabali/restic-pw/. Blank
+	// means the legacy shared /etc/jabali-panel/restic-repo.password. A
+	// system backup writes to the same destinations as account backups, so
+	// it needs this too — without it a rotated destination fails outright.
+	PasswordFile string `json:"password_file,omitempty"`
 }
 
 type systemBackupResult struct {
@@ -96,11 +102,11 @@ func runSystemBackupOrchestrator(ctx context.Context, req systemBackupParams) er
 	jl := backup.NewJobLogger(req.JobID)
 	defer jl.Close()
 	jl.Printf("system_backup start include_accounts=%v destination=%s", req.IncludeAccounts, req.RepoURL)
-	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.SFTP); err != nil {
+	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.PasswordFile, req.SFTP); err != nil {
 		jl.Printf("ensure_repo_failed=%v", err)
 		return fmt.Errorf("ensure repo: %w", err)
 	}
-	cfg, cerr := bkResticConfig(req.RepoURL, req.CredentialsRef, req.SFTP)
+	cfg, cerr := bkResticConfigWithPassword(req.RepoURL, req.CredentialsRef, req.PasswordFile, req.SFTP)
 	if cerr != nil {
 		return fmt.Errorf("restic config: %w", cerr)
 	}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -978,6 +978,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Schedules:    deps.BackupSchedules,
 		Destinations: deps.BackupDestinations,
 		Agent:        deps.Agent,
+		SSOKey:       deps.SSOKey,
 		Log:          log,
 	}); fin != nil {
 		go fin.Start(ctx)

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -326,14 +326,24 @@ func (h *backupHandler) resolveDest(c *gin.Context, destID string) (*models.Back
 // Without this the download always opened the local repo and 404'd remote
 // backups with "no snapshots for job" (GH #462).
 func materializeDestParams(ctx context.Context, dests repository.BackupDestinationRepository, job *models.BackupJob) map[string]any {
+	_, params := materializeDest(ctx, dests, job)
+	return params
+}
+
+// materializeDest is materializeDestParams plus the destination row itself,
+// which the caller needs to bridge a per-destination restic password
+// (M30.2.x) into the download. Without that password the agent cannot open a
+// rotated destination's repo, so the download fails even though the backup
+// is fine.
+func materializeDest(ctx context.Context, dests repository.BackupDestinationRepository, job *models.BackupJob) (*models.BackupDestination, map[string]any) {
 	if dests == nil || job.DestinationID == nil || *job.DestinationID == "" {
-		return nil
+		return nil, nil
 	}
 	d, err := dests.Get(ctx, *job.DestinationID)
 	if err != nil || d == nil {
-		return nil
+		return nil, nil
 	}
-	return destWireParams(d)
+	return d, destWireParams(d)
 }
 
 // destWireParams projects a destination into the JSON keys the agent
@@ -743,7 +753,21 @@ func (h *backupHandler) download(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "no_completed_snapshot"})
 		return
 	}
-	streamBackupArtifact(c, h.cfg.Agent, job, materializeDestParams(c.Request.Context(), h.cfg.Destinations, job), h.cfg.logErr)
+	dest, destParams := materializeDest(c.Request.Context(), h.cfg.Destinations, job)
+	// Bridge the destination's own restic password (M30.2.x) for the
+	// materialize call; without it a rotated destination's snapshot cannot
+	// be opened and the download fails. No-op for legacy/local jobs.
+	_ = backupwrapperhelpers.WithOptionalDestPassword(c.Request.Context(), dest, h.cfg.Agent, h.cfg.SSOKey,
+		func(passwordFile string) error {
+			if passwordFile != "" {
+				if destParams == nil {
+					destParams = map[string]any{}
+				}
+				destParams["password_file"] = passwordFile
+			}
+			streamBackupArtifact(c, h.cfg.Agent, job, destParams, h.cfg.logErr)
+			return nil
+		})
 }
 
 // streamBackupArtifact materializes a SUCCEEDED backup job's restic snapshot
@@ -1199,6 +1223,11 @@ type MeBackupsHandlerConfig struct {
 	// are non-nil, so a deployment without them simply lacks tenant scheduling.
 	Schedules repository.BackupScheduleRepository
 	Settings  repository.ServerSettingsRepository
+
+	// SSOKey unseals a destination's per-row restic password (M30.2.x) so a
+	// tenant download can open a rotated destination's repo. Optional: nil
+	// falls back to the agent's shared password file.
+	SSOKey *ssokey.Key
 
 	Log *slog.Logger
 }
@@ -2602,5 +2631,19 @@ func (h *meBackupHandler) download(c *gin.Context) {
 	// returned job metadata as JSON, so the browser's <a href> download
 	// got a JSON blob, never a file). Same agent-materialize path as the
 	// admin handler, scoped to the caller's own job by the check above.
-	streamBackupArtifact(c, h.cfg.Agent, job, materializeDestParams(c.Request.Context(), h.cfg.Destinations, job), h.cfg.logErr)
+	dest, destParams := materializeDest(c.Request.Context(), h.cfg.Destinations, job)
+	// Bridge the destination's own restic password (M30.2.x) for the
+	// materialize call; without it a rotated destination's snapshot cannot
+	// be opened and the download fails. No-op for legacy/local jobs.
+	_ = backupwrapperhelpers.WithOptionalDestPassword(c.Request.Context(), dest, h.cfg.Agent, h.cfg.SSOKey,
+		func(passwordFile string) error {
+			if passwordFile != "" {
+				if destParams == nil {
+					destParams = map[string]any{}
+				}
+				destParams["password_file"] = passwordFile
+			}
+			streamBackupArtifact(c, h.cfg.Agent, job, destParams, h.cfg.logErr)
+			return nil
+		})
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1048,6 +1048,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Agent:          deps.Agent,
 				Jobs:           deps.BackupJobs,
 				Destinations:   deps.BackupDestinations,
+				SSOKey:         deps.SSOKey,
 				Users:          deps.Users,
 				Packages:       deps.Packages,
 				Databases:      deps.Databases,

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -25,12 +25,19 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 const (
 	TickInterval   = 30 * time.Second
 	StallTimeout   = 4 * time.Hour
 	MaxJobsPerTick = 25
+	// statusCallTimeout must exceed a cold remote-repo probe: backup.status
+	// runs `restic snapshots` against the destination, which on SFTP/S3
+	// opens a fresh session and lists the index. At the old 10s the probe
+	// timed out and retried on the next tick, so a remote-destination job
+	// could never be sealed while doubling the repo churn.
+	statusCallTimeout = 30 * time.Second
 )
 
 type Deps struct {
@@ -38,10 +45,28 @@ type Deps struct {
 	Schedules    repository.BackupScheduleRepository
 	Destinations repository.BackupDestinationRepository
 	Agent        agent.AgentInterface
-	Log          *slog.Logger
+	// SSOKey unseals a destination's per-row restic password (M30.2.x).
+	// Without it backup.status cannot open a rotated destination's repo,
+	// so a finished backup is never sealed — it sits "running" until the
+	// stall timeout marks it failed.
+	SSOKey *ssokey.Key
+	Log    *slog.Logger
 }
 
 type Finalizer struct{ deps Deps }
+
+// withDestPassword bridges a destination's per-row restic password to the
+// agent for the duration of fn. Legacy rows (no destination, or no sealed
+// password) invoke fn("") and the agent falls back to the shared file.
+// Synchronous: backup.status returns before fn does, so the helper's
+// deferred tempfile cleanup is correct here.
+func (f *Finalizer) withDestPassword(
+	ctx context.Context,
+	dest *models.BackupDestination,
+	fn func(passwordFile string) error,
+) error {
+	return backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, f.deps.Agent, f.deps.SSOKey, fn)
+}
 
 func New(deps Deps) *Finalizer {
 	if deps.Jobs == nil || deps.Destinations == nil ||
@@ -125,9 +150,11 @@ func (f *Finalizer) checkOne(ctx context.Context, j models.BackupJob) {
 	// against. Legacy rows (NULL destination_id) fall back to the
 	// agent's local default.
 	statusParams := map[string]any{"job_id": j.ID}
+	var dest *models.BackupDestination
 	if j.DestinationID != nil && *j.DestinationID != "" {
-		dest, err := f.deps.Destinations.Get(ctx, *j.DestinationID)
-		if err == nil && dest != nil {
+		d, err := f.deps.Destinations.Get(ctx, *j.DestinationID)
+		if err == nil && d != nil {
+			dest = d
 			statusParams["repo_url"] = dest.URL
 			statusParams["sftp"] = backupwrapperhelpers.SFTPWireParams(dest)
 			if dest.CredentialsRef != nil {
@@ -135,9 +162,21 @@ func (f *Finalizer) checkOne(ctx context.Context, j models.BackupJob) {
 			}
 		}
 	}
-	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	callCtx, cancel := context.WithTimeout(ctx, statusCallTimeout)
 	defer cancel()
-	raw, err := f.deps.Agent.Call(callCtx, "backup.status", statusParams)
+	// A destination with its own sealed password (M30.2.x) can only be
+	// probed with THAT password. Without this bridge the poll fails
+	// forever against a rotated destination, so a backup that actually
+	// succeeded is never sealed and eventually stall-fails.
+	var raw json.RawMessage
+	err := f.withDestPassword(callCtx, dest, func(passwordFile string) error {
+		if passwordFile != "" {
+			statusParams["password_file"] = passwordFile
+		}
+		out, callErr := f.deps.Agent.Call(callCtx, "backup.status", statusParams)
+		raw = out
+		return callErr
+	})
 	if err != nil {
 		logger.Debug("backup.status query failed; will retry", "err", err)
 		return

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -585,7 +585,11 @@ func (s *Scheduler) dispatchAccount(ctx context.Context, j models.BackupJob) {
 	for k, v := range destWireParams(dest) {
 		params[k] = v
 	}
-	err = backupwrapperhelpers.WithDestPasswordFile(callCtx, dest, s.deps.Agent, s.deps.SSOKey,
+	// Async variant: backup.create returns as soon as the agent spawns its
+	// orchestrator, so the password tempfile must outlive this call — the
+	// agent unlinks it when the job ends. The synchronous helper unlinked it
+	// here, seconds into a job that needs it for up to 90 minutes.
+	err = backupwrapperhelpers.WithDestPasswordFileAsync(callCtx, dest, s.deps.Agent, s.deps.SSOKey,
 		func(passwordFile string) error {
 			if passwordFile != "" {
 				params["password_file"] = passwordFile
@@ -630,7 +634,18 @@ func (s *Scheduler) dispatchSystem(ctx context.Context, j models.BackupJob) {
 	for k, v := range destWireParams(dest) {
 		params[k] = v
 	}
-	if _, err := s.deps.Agent.Call(callCtx, "system.backup", params); err != nil {
+	// A system backup writes to the same destinations as account backups, so
+	// it needs the same per-destination password bridging — without it a
+	// rotated destination fails outright. Async, like backup.create: the
+	// agent owns the tempfile for the life of the job.
+	if err := backupwrapperhelpers.WithDestPasswordFileAsync(callCtx, dest, s.deps.Agent, s.deps.SSOKey,
+		func(passwordFile string) error {
+			if passwordFile != "" {
+				params["password_file"] = passwordFile
+			}
+			_, callErr := s.deps.Agent.Call(callCtx, "system.backup", params)
+			return callErr
+		}); err != nil {
 		if isAgentConflict(err) {
 			_ = s.deps.Jobs.MarkFinished(ctx, j.ID, models.BackupJobStatusCancelled,
 				"", "", 0, 0, nil, nil, "skipped: prior system backup still running")

--- a/panel-api/internal/backupwrapperhelpers/dest_password.go
+++ b/panel-api/internal/backupwrapperhelpers/dest_password.go
@@ -41,6 +41,60 @@ func WithDestPasswordFile(
 	ssoKey *ssokey.Key,
 	fn func(passwordFile string) error,
 ) error {
+	return withDestPasswordFile(ctx, dest, agentClient, ssoKey, true, fn)
+}
+
+// WithDestPasswordFileAsync is WithDestPasswordFile for agent calls that
+// return BEFORE the work needing the password has finished — today that
+// means backup.create, which spawns its orchestrator goroutine (up to 90
+// minutes) and replies immediately.
+//
+// It does NOT unlink the tempfile when fn returns: doing so removed the
+// password seconds into a long job, so every stage and the manifest
+// snapshot failed to open a per-destination repo. Ownership passes to the
+// agent, whose orchestrator unlinks the file when the job actually ends
+// (removePasswordTempFile in backup_create.go). /run is tmpfs and the
+// agent's RuntimeDirectory is preserved=no, so even a crashed job leaks
+// nothing past reboot.
+//
+// Use WithDestPasswordFile for synchronous calls (restore, status,
+// materialize) — there the deferred cleanup is correct and tighter.
+func WithDestPasswordFileAsync(
+	ctx context.Context,
+	dest *models.BackupDestination,
+	agentClient agent.AgentInterface,
+	ssoKey *ssokey.Key,
+	fn func(passwordFile string) error,
+) error {
+	return withDestPasswordFile(ctx, dest, agentClient, ssoKey, false, fn)
+}
+
+// WithOptionalDestPassword is WithDestPasswordFile for callers that may not
+// have a destination at all (a legacy job with NULL destination_id) or that
+// run without an SSO key. Those cases invoke fn("") — the agent then falls
+// back to the shared password file — instead of erroring, so a caller can
+// wrap unconditionally without repeating the nil dance.
+func WithOptionalDestPassword(
+	ctx context.Context,
+	dest *models.BackupDestination,
+	agentClient agent.AgentInterface,
+	ssoKey *ssokey.Key,
+	fn func(passwordFile string) error,
+) error {
+	if dest == nil || len(dest.PasswordEnc) == 0 || ssoKey == nil || agentClient == nil {
+		return fn("")
+	}
+	return WithDestPasswordFile(ctx, dest, agentClient, ssoKey, fn)
+}
+
+func withDestPasswordFile(
+	ctx context.Context,
+	dest *models.BackupDestination,
+	agentClient agent.AgentInterface,
+	ssoKey *ssokey.Key,
+	cleanup bool,
+	fn func(passwordFile string) error,
+) error {
 	if dest == nil {
 		return errors.New("dest required")
 	}
@@ -70,14 +124,16 @@ func WithDestPasswordFile(
 	if err := json.Unmarshal(raw, &resp); err != nil || resp.Path == "" {
 		return fmt.Errorf("agent write_temp: bad response %s", string(raw))
 	}
-	defer func() {
-		// Best-effort cleanup. Path-prefix check on the agent side
-		// keeps a misbehaving caller from asking it to unlink anything
-		// outside /run/jabali/restic-pw/, so the worst case here is a
-		// stale tmpfs file that vanishes on reboot.
-		_, _ = agentClient.Call(context.Background(),
-			"backup.repo.password.cleanup_temp",
-			map[string]any{"path": resp.Path})
-	}()
+	if cleanup {
+		defer func() {
+			// Best-effort cleanup. Path-prefix check on the agent side
+			// keeps a misbehaving caller from asking it to unlink anything
+			// outside /run/jabali/restic-pw/, so the worst case here is a
+			// stale tmpfs file that vanishes on reboot.
+			_, _ = agentClient.Call(context.Background(),
+				"backup.repo.password.cleanup_temp",
+				map[string]any{"path": resp.Path})
+		}()
+	}
 	return fn(resp.Path)
 }


### PR DESCRIPTION
The three High findings from `docs/security/code-review-2026-08-08.md`. One root cause, five breaks.

Rotating a destination to its own sealed password — the intended M30.2.x flow, which the reconciler actively pushes hosts toward — **silently broke backups**. The password was bridged into `backup.create` and then lost at every subsequent hop. Worse than a clean failure: where the manifest snapshot still landed, the finalizer could seal a **"partial" backup that a tenant later restores and finds empty**.

### The five breaks
1. **Stage re-marshal dropped it.** `runHomeStage`/`runDatabaseStage`/`runMailStage` rebuilt params without `PasswordFile` — the field existed on every stage struct, just never populated — so each stage fell back to the legacy shared password file.
2. **Tempfile deleted before the job could use it.** `WithDestPasswordFile` cleans up on `defer` when the agent call returns, but `backup.create` is fire-and-forget (spawns a 90-min orchestrator, replies immediately). Ownership now passes to the agent, which unlinks when the job actually ends.
3. **System backups had no bridging at all** — `dispatchSystem` never wrapped, `systemBackupParams` had no field, so `runSystemBackupOrchestrator` built its restic config with no password.
4. **`bkEnsureRepoReady` hardcoded the legacy file** for both probe *and* init. Pre-purge: a rotated destination misreported as "exists but cannot be opened". Post-purge (reconciler deletes the shared file): hard-fail before any stage runs.
5. **Finalizer + download never sent it.** A completed backup was never sealed (sat `running` until the 4h stall timeout marked it failed) and its snapshot couldn't be downloaded.

### Also
Finalizer `backup.status` timeout 10s → 30s: a cold remote-repo probe (fresh SFTP session + index listing) routinely exceeded 10s, so the poll timed out and retried forever, doubling repo churn (OPT ME-9's timeout half).

### On the tests
Stage threading is asserted against the orchestrator's **source**, not values: each stage builds a fresh struct from `req`, so a value-level test constructing its own literal would pass while the real marshal drops the field. Same approach as `TestNoRepoDirReadsBeforeClone`.

That guard earned its keep immediately — **it caught a real miss while I was writing this**: I'd fixed the probe's password but left `InitRemote` still using the legacy one.

### Test plan
- [x] `go build ./...`, `go vet` clean
- [x] `go test ./panel-agent/... ./panel-api/...` all pass
- [ ] **Needs a box:** one live rotated-destination round-trip (backup → finalize → download → restore) before the next release. Static review can't confirm a data-loss fix.

Refs GH #454-adjacent backup work; security review at commit `fda13d89`.