### PR TITLE
fix(backup): stop the job queue wedging permanently, and stop prune orphaning snapshots (OPT HI-3, ME-10, LO-8; SEC ME-3, LO-9)

### DIFF
--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -115,10 +115,23 @@ type agentStatus struct {
 }
 
 func (f *Finalizer) tickOnce(ctx context.Context) {
-	rows, _, err := f.deps.Jobs.ListAll(ctx, MaxJobsPerTick, 0)
+	// Query running jobs directly. Paging the newest MaxJobsPerTick rows of
+	// ANY status and filtering here used to drop the oldest-created running
+	// jobs of a large fan-out — the dispatcher admits work oldest-first, so
+	// those are exactly the running ones — and a dropped job could then
+	// neither be finalized nor stall-timed-out. It stayed `running` forever,
+	// holding a dispatcher slot, until the whole backup queue deadlocked.
+	rows, err := f.deps.Jobs.ListRunning(ctx, MaxJobsPerTick)
 	if err != nil {
 		f.deps.Log.Error("finalizer list-running failed", "err", err)
 		return
+	}
+	if len(rows) == MaxJobsPerTick {
+		// Never silently cap coverage: if there are more running jobs than
+		// one tick handles, say so — the rest are picked up next tick
+		// (oldest-started first, so nothing starves).
+		f.deps.Log.Info("finalizer tick full; remaining running jobs deferred to next tick",
+			"limit", MaxJobsPerTick)
 	}
 	now := time.Now().UTC()
 	for _, j := range rows {

--- a/panel-api/internal/backupfinalizer/finalizer_worklist_test.go
+++ b/panel-api/internal/backupfinalizer/finalizer_worklist_test.go
@@ -1,0 +1,174 @@
+package backupfinalizer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// pagingJobs models the real repository's paging semantics:
+//   - ListAll pages the newest rows across ALL statuses (created_at DESC)
+//   - ListRunning queries status='running' directly (started_at ASC)
+//
+// The dispatcher admits queued work oldest-first, so in a big fan-out the
+// RUNNING jobs are the oldest-created ones — precisely the rows that fall
+// off the end of a newest-N page.
+type pagingJobs struct {
+	repository.BackupJobRepository
+	all         []models.BackupJob // newest-first, as ListAll returns
+	finishedIDs []string
+	statusCalls int
+}
+
+func (j *pagingJobs) ListAll(_ context.Context, limit, _ int) ([]models.BackupJob, int64, error) {
+	if limit > len(j.all) {
+		limit = len(j.all)
+	}
+	return j.all[:limit], int64(len(j.all)), nil
+}
+
+func (j *pagingJobs) ListRunning(_ context.Context, limit int) ([]models.BackupJob, error) {
+	var out []models.BackupJob
+	for _, job := range j.all {
+		if job.Status == models.BackupJobStatusRunning {
+			out = append(out, job)
+		}
+	}
+	// started_at ASC — oldest-started first.
+	for i, k := 0, len(out)-1; i < k; i, k = i+1, k-1 {
+		out[i], out[k] = out[k], out[i]
+	}
+	if limit > 0 && limit < len(out) {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (j *pagingJobs) MarkFinished(_ context.Context, id, _ string, _, _ string,
+	_, _ uint64, _, _ json.RawMessage, _ string) error {
+	j.finishedIDs = append(j.finishedIDs, id)
+	return nil
+}
+
+type countingAgent struct {
+	reply string
+	jobs  *pagingJobs
+}
+
+func (a *countingAgent) Call(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+	a.jobs.statusCalls++
+	return json.RawMessage(a.reply), nil
+}
+
+// TestTickOnce_FinalizesRunningJobsBeyondTheNewestPage is the queue-wedge
+// regression.
+//
+// Scenario: one schedule fans out; two jobs started running (created first),
+// then 30 more jobs were created and sit queued. The finalizer's page size is
+// 25. Under the old ListAll(25) + filter-in-Go, the newest 25 rows are all
+// queued, so the two running jobs are invisible: they can never be finalized
+// AND never stall-timed-out, they hold their dispatcher slots forever, and
+// every subsequent scheduled backup silently stops.
+func TestTickOnce_FinalizesRunningJobsBeyondTheNewestPage(t *testing.T) {
+	started := time.Now().Add(-2 * time.Minute)
+	var all []models.BackupJob
+	// Newest-first: 30 queued rows created after the running ones.
+	for i := 0; i < 30; i++ {
+		all = append(all, models.BackupJob{
+			ID:     "01HQUEUED" + string(rune('A'+i%26)) + "000000000000000",
+			Kind:   models.BackupJobKindAccountBackup,
+			Status: models.BackupJobStatusQueued,
+		})
+	}
+	// ...and the two oldest rows, which are the ones actually running.
+	for _, id := range []string{"01HRUNNING1000000000000000", "01HRUNNING2000000000000000"} {
+		all = append(all, models.BackupJob{
+			ID:        id,
+			UserID:    "01HUSERUSERUSERUSERUSER000",
+			Kind:      models.BackupJobKindAccountBackup,
+			Status:    models.BackupJobStatusRunning,
+			StartedAt: &started,
+		})
+	}
+
+	jobs := &pagingJobs{all: all}
+	// Manifest present ⇒ each running job should be sealed.
+	agent := &countingAgent{
+		jobs:  jobs,
+		reply: `{"manifest_found":true,"snapshots":[{"id":"snapM","tags":["stage=manifest"]}]}`,
+	}
+	f := &Finalizer{deps: Deps{
+		Jobs:  jobs,
+		Agent: agent,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+
+	f.tickOnce(context.Background())
+
+	if len(jobs.finishedIDs) != 2 {
+		t.Fatalf("finalized %v, want both running jobs sealed. A running job outside "+
+			"the newest-page window is never finalized and never stall-failed, so it "+
+			"holds a dispatcher slot forever and wedges the backup queue.",
+			jobs.finishedIDs)
+	}
+	if jobs.statusCalls != 2 {
+		t.Errorf("backup.status called %d times, want 2 (one per running job)", jobs.statusCalls)
+	}
+}
+
+// A job past the stall timeout is still failed rather than polled forever.
+func TestTickOnce_StallTimeoutStillApplies(t *testing.T) {
+	stale := time.Now().Add(-(StallTimeout + time.Hour))
+	jobs := &pagingJobs{all: []models.BackupJob{{
+		ID:        "01HSTALLED00000000000000AA",
+		Kind:      models.BackupJobKindAccountBackup,
+		Status:    models.BackupJobStatusRunning,
+		StartedAt: &stale,
+	}}}
+	agent := &countingAgent{jobs: jobs, reply: `{"manifest_found":false}`}
+	f := &Finalizer{deps: Deps{
+		Jobs:  jobs,
+		Agent: agent,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+
+	f.tickOnce(context.Background())
+
+	if len(jobs.finishedIDs) != 1 {
+		t.Fatalf("stalled job should be marked failed, got %v", jobs.finishedIDs)
+	}
+	if jobs.statusCalls != 0 {
+		t.Errorf("a stalled job should not be polled, got %d status calls", jobs.statusCalls)
+	}
+}
+
+// Restore jobs are sealed synchronously by the API handler; the finalizer
+// must skip them even though they appear as running.
+func TestTickOnce_SkipsRestoreJobs(t *testing.T) {
+	started := time.Now().Add(-time.Minute)
+	jobs := &pagingJobs{all: []models.BackupJob{{
+		ID:        "01HRESTORE00000000000000AA",
+		Kind:      models.BackupJobKindAccountRestore,
+		Status:    models.BackupJobStatusRunning,
+		StartedAt: &started,
+	}}}
+	agent := &countingAgent{jobs: jobs, reply: `{"manifest_found":true}`}
+	f := &Finalizer{deps: Deps{
+		Jobs:  jobs,
+		Agent: agent,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+
+	f.tickOnce(context.Background())
+
+	if len(jobs.finishedIDs) != 0 || jobs.statusCalls != 0 {
+		t.Errorf("restore job should be skipped; finished=%v statusCalls=%d",
+			jobs.finishedIDs, jobs.statusCalls)
+	}
+}

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -343,8 +343,15 @@ func (s *Scheduler) enqueueBackup(ctx context.Context, sched models.BackupSchedu
 		}
 		for i := range targets {
 			u := &targets[i]
+			// Resolve the hosting package ONCE per user, not once per
+			// (user, destination): it is the same static row for every
+			// destination, and on a large host this loop ran
+			// users × destinations lookups inside the 60s enqueue tick.
+			// The cap check itself stays per-pair — each enqueue adds a job,
+			// so the count it reads genuinely changes.
+			pkg := s.userPackage(ctx, u)
 			for j := range enabledDests {
-				if ok := s.enqueueAccountBackup(ctx, sched, u, &enabledDests[j], runID); ok {
+				if ok := s.enqueueAccountBackup(ctx, sched, u, pkg, &enabledDests[j], runID); ok {
 					anyUser = true
 				}
 			}
@@ -376,14 +383,16 @@ func (s *Scheduler) enqueueBackup(ctx context.Context, sched models.BackupSchedu
 // enqueueAccountBackup creates one backup_jobs row in status=queued
 // for the given (user, destination) pair. Per ADR-0080 the destination
 // is a first-class field on backup_jobs.
-func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.BackupSchedule, user *models.User, dest *models.BackupDestination, runID string) bool {
+// pkg is the user's hosting package, resolved once by the caller for all of
+// that user's destinations (nil when unresolvable or not wired).
+func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.BackupSchedule, user *models.User, pkg *models.HostingPackage, dest *models.BackupDestination, runID string) bool {
 	logger := s.deps.Log.With("schedule_id", sched.ID, "user_id", user.ID, "destination_id", dest.ID, "run_id", runID)
 	// Retention cap (GH #454): honour the tenant's package policy on scheduled
 	// backups, matching the on-demand path. Only enforced when the package repo
 	// is wired AND the plan actually caps backups; otherwise the scheduled
 	// backup proceeds unchanged (no regression for uncapped/unresolvable plans).
 	if s.deps.Packages != nil {
-		if pkg := s.userPackage(ctx, user); pkg != nil && pkg.BackupsEnabled() && s.atOrOverCap(ctx, user.ID, int(pkg.MaxBackups)) {
+		if pkg != nil && pkg.BackupsEnabled() && s.atOrOverCap(ctx, user.ID, int(pkg.MaxBackups)) {
 			if pkg.BackupRetentionPrunes() && s.pruneOldestForUser(ctx, user, int(pkg.MaxBackups)) {
 				s.notifyBackupLimit(ctx, user, "prune", pkg.MaxBackups)
 			} else {
@@ -435,7 +444,10 @@ func (s *Scheduler) userPackage(ctx context.Context, user *models.User) *models.
 
 // atOrOverCap reports whether the user already holds >= maxBackups jobs.
 func (s *Scheduler) atOrOverCap(ctx context.Context, userID string, maxBackups int) bool {
-	_, total, err := s.deps.Jobs.ListForUser(ctx, userID, 1, 0)
+	// COUNT only. This used to call ListForUser(userID, 1, 0), which runs a
+	// COUNT(*) *and* a LIMIT 1 SELECT just to read the total — paid once per
+	// (user, destination) pair inside the 60s enqueue tick.
+	total, err := s.deps.Jobs.CountForUser(ctx, userID)
 	if err != nil {
 		return false
 	}
@@ -446,8 +458,15 @@ func (s *Scheduler) atOrOverCap(ctx context.Context, userID string, maxBackups i
 // under maxBackups. Owner-scoped: OldestAccountBackupForUser filters by
 // user_id, so a scheduled prune only ever touches the target tenant's own
 // backups. Returns true once under the cap (GH #454).
+// maxPrunesPerTick bounds how many snapshots one enqueue tick will forget.
+// Each backup.forget is a synchronous `restic forget` (30s timeout) that
+// takes the repo lock, so an unbounded loop — e.g. after an operator lowers
+// a plan's cap from 10 to 2 — blocked the 60s tick for minutes and contended
+// with any running backup. Whatever is left over is pruned on the next tick.
+const maxPrunesPerTick = 5
+
 func (s *Scheduler) pruneOldestForUser(ctx context.Context, user *models.User, maxBackups int) bool {
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < maxPrunesPerTick; i++ {
 		if !s.atOrOverCap(ctx, user.ID, maxBackups) {
 			return true
 		}
@@ -457,16 +476,33 @@ func (s *Scheduler) pruneOldestForUser(ctx context.Context, user *models.User, m
 		}
 		if s.deps.Agent != nil {
 			fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-			_, _ = s.deps.Agent.Call(fctx, "backup.forget", map[string]any{
+			_, ferr := s.deps.Agent.Call(fctx, "backup.forget", map[string]any{
 				"job_id": oldest.ID, "user_id": oldest.UserID, "kind": oldest.Kind,
 			})
 			cancel()
+			if ferr != nil {
+				// Do NOT delete the row when the snapshot is still in the
+				// repo. Dropping it would orphan the data: the repo keeps
+				// growing while the panel's retention accounting believes
+				// the tenant is under cap, and nothing ever revisits it.
+				// Leave the row so a later tick retries the forget.
+				s.deps.Log.Error("retention prune: backup.forget failed; keeping job row for retry",
+					"user_id", user.ID, "job_id", oldest.ID, "snapshot_id", oldest.SnapshotID, "err", ferr)
+				return false
+			}
 		}
 		if derr := s.deps.Jobs.Delete(ctx, oldest.ID); derr != nil {
 			return false
 		}
 	}
-	return false
+	// Still over cap after this tick's budget — report that so the caller
+	// rejects rather than silently proceeding, and the next tick continues.
+	if s.atOrOverCap(ctx, user.ID, maxBackups) {
+		s.deps.Log.Info("retention prune hit the per-tick budget; continuing next tick",
+			"user_id", user.ID, "pruned", maxPrunesPerTick)
+		return false
+	}
+	return true
 }
 
 // notifyBackupLimit fires backup.limit.reached to the tenant's inbox

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -39,6 +39,10 @@ func (f *fakeBackupJobs) MarkFinished(context.Context, string, string, string, s
 	return nil
 }
 func (f *fakeBackupJobs) CountByStatus(context.Context, string) (int64, error) { return 0, nil }
+func (f *fakeBackupJobs) ListRunning(context.Context, int) ([]models.BackupJob, error) {
+	return nil, nil
+}
+func (f *fakeBackupJobs) CountForUser(context.Context, string) (int64, error) { return 0, nil }
 func (f *fakeBackupJobs) ListQueuedOldest(context.Context, int) ([]models.BackupJob, error) {
 	return nil, nil
 }

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -39,6 +39,14 @@ type BackupJobRepository interface {
 	// dispatches at server_settings.backup_max_concurrent_jobs.
 	CountByStatus(ctx context.Context, status string) (int64, error)
 	ListQueuedOldest(ctx context.Context, limit int) ([]models.BackupJob, error)
+	// ListRunning is the finalizer's worklist. It must query status
+	// directly: paging the newest N of ALL statuses and filtering in Go
+	// loses the oldest-created running jobs of a big fan-out, which then
+	// wedge the queue permanently. See the method comment.
+	ListRunning(ctx context.Context, limit int) ([]models.BackupJob, error)
+	// CountForUser counts a user's jobs for the retention cap without
+	// materialising rows.
+	CountForUser(ctx context.Context, userID string) (int64, error)
 
 	// Run grouping — admin UI rolls scheduler-fired jobs under one
 	// header per run_id. ListRuns aggregates jobs that share a run_id;
@@ -270,6 +278,50 @@ func (r *backupJobRepo) ListByRun(ctx context.Context, runID string) ([]models.B
 
 func (r *backupJobRepo) ListManual(ctx context.Context, limit, offset int) ([]models.BackupJob, int64, error) {
 	return r.list(ctx, "run_id IS NULL", nil, limit, offset)
+}
+
+// ListRunning returns jobs currently in `running`, oldest-started first.
+//
+// The finalizer MUST use this rather than filtering ListAll in memory.
+// ListAll pages `created_at DESC`, while the dispatcher admits work via
+// ListQueuedOldest (`created_at ASC`) — so the running jobs are the
+// OLDEST-created of a fan-out batch and fall outside the newest-N page as
+// soon as a schedule creates more than N jobs. Those jobs could then be
+// neither finalized nor stall-timed-out: they stayed `running` forever,
+// CountByStatus(running) stayed at the cap, and the whole backup queue
+// deadlocked until someone edited the DB by hand.
+//
+// Indexed by idx_backup_jobs_status.
+func (r *backupJobRepo) ListRunning(ctx context.Context, limit int) ([]models.BackupJob, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var out []models.BackupJob
+	err := r.db.WithContext(ctx).
+		Where("status = ?", models.BackupJobStatusRunning).
+		Order("started_at ASC").
+		Limit(limit).
+		Find(&out).Error
+	if err != nil {
+		return nil, translate(err)
+	}
+	return out, nil
+}
+
+// CountForUser counts a user's jobs without materialising any rows. The
+// retention cap check used ListForUser(userID, 1, 0), which runs a COUNT(*)
+// AND a LIMIT 1 SELECT purely to read the total — once per (user,
+// destination) pair inside the enqueue tick.
+func (r *backupJobRepo) CountForUser(ctx context.Context, userID string) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).
+		Model(&models.BackupJob{}).
+		Where("user_id = ?", userID).
+		Count(&n).Error
+	if err != nil {
+		return 0, translate(err)
+	}
+	return n, nil
 }
 
 func (r *backupJobRepo) ListQueuedOldest(ctx context.Context, limit int) ([]models.BackupJob, error) {


### PR DESCRIPTION
### The wedge (OPT HI-3 / SEC ME-3)

The finalizer listed the **newest 25 rows of any status** and filtered `running` in Go. The dispatcher admits queued work **oldest-first** (`ListQueuedOldest`, `created_at ASC`), so the running jobs are the *oldest-created* — exactly the rows that fall off a newest-25 page once one schedule creates >25 jobs (13 tenants × 2 destinations does it).

Those jobs were then invisible: never finalized, and never stall-timed-out either, because that check lives in the same loop. They stayed `running` forever → `CountByStatus(running)` pinned at the cap → `slots <= 0` → **every subsequent scheduled backup silently stopped**, with no error, until someone edited the DB by hand.

`ListRunning(limit)` queries status directly, oldest-started first (indexed by `idx_backup_jobs_status`), and drops the full-table `COUNT(*)` the paginated helper ran every 30s. A tick that fills its budget now logs that the rest are deferred instead of silently covering part of the work.

> The two reviews rated this differently — **High** in the optimization doc, **Medium** in the security doc. High is right: with >25 fanned-out jobs the running set is *guaranteed* outside the window, not merely likely.

### Prune was orphaning snapshot data (SEC LO-9)

`pruneOldestForUser` called `backup.forget`, **ignored the result** (`_, _ =`), then deleted the `backup_jobs` row regardless. On a transient repo failure the snapshot stays in the repo but its row is gone — the repo grows unboundedly while retention accounting believes the tenant is under cap, and nothing revisits it. Now the row is deleted only when forget succeeded; otherwise it's logged with the snapshot id and kept for retry.

### Prune blocked the tick (OPT LO-8)
Up to 1000 serial `restic forget` calls (30s each, each taking the repo lock) ran synchronously inside the 60s enqueue tick — lowering a cap 10→2 blocked it for minutes while contending with running backups. Bounded to 5/tick, remainder continues next tick.

### Enqueue N+1s (OPT ME-10)
Hosting package resolved once per **user** instead of once per (user, destination) — same static row for every destination. Cap check uses a new `CountForUser` instead of `ListForUser(userID, 1, 0)`, which ran a `COUNT(*)` *and* a `LIMIT 1` SELECT just to read the total. The cap check stays per-pair: each enqueue adds a job and genuinely changes the count.

### Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./panel-api/... ./panel-agent/...` all pass
- [x] **Wedge test verified both ways** — fails against the old `ListAll` paging (finalizes nothing, reproducing the deadlock), passes with `ListRunning`
- [x] Stall-timeout and restore-job-skip behaviour pinned so the rewrite didn't regress them

Refs both 2026-08-08 reviews.