### PR TITLE
perf(reconciler): gate the DNS zone push on content instead of rewriting every zone every tick (OPT HI-1)

### DIFF
--- a/panel-api/internal/reconciler/dns_zone_dispatch_gate.go
+++ b/panel-api/internal/reconciler/dns_zone_dispatch_gate.go
@@ -1,0 +1,94 @@
+package reconciler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+)
+
+// dnsZoneDispatchState is what each zone's dnsZoneDispatchCache entry holds.
+// Hash covers the compiled record set plus the AXFR/NOTIFY lists — i.e.
+// everything the agent actually acts on. At is when we last pushed.
+type dnsZoneDispatchState struct {
+	Hash string
+	At   time.Time
+}
+
+// dnsZoneReDispatchInterval forces a push even when the hash matches, so
+// out-of-band drift in PowerDNS (operator editing the SQL backend directly,
+// a restored/rebuilt pdns database, a push that partially applied) is still
+// corrected on a bounded schedule. Same self-healing contract as
+// sshKeysReDispatchInterval — DB stays the source of truth; we just stop
+// asserting it sixty times an hour per zone.
+const dnsZoneReDispatchInterval = 10 * time.Minute
+
+// desiredDNSZoneHash computes a stable hash of what a zone push would do.
+//
+// The SOA serial is deliberately EXCLUDED. The serial was previously stamped
+// with time.Now() on every pass, which made the payload differ every tick by
+// construction — so no content compare could ever match and the zone was
+// rewritten forever. Content identity is what should drive a push; the serial
+// is an artefact of pushing, not an input to the decision.
+func desiredDNSZoneHash(records []dnscompile.Record, allowAXFR, alsoNotify []string) string {
+	lines := make([]string, 0, len(records))
+	for _, rec := range records {
+		if strings.EqualFold(rec.Type, "SOA") {
+			// The SOA rdata embeds the serial; comparing it would
+			// reintroduce the never-converges bug.
+			continue
+		}
+		// Every field the agent writes must be in the hash, or a change
+		// that only touches one of them (an MX priority edit, disabling a
+		// row) would be skipped as "unchanged".
+		lines = append(lines, fmt.Sprintf("%s|%s|%d|%d|%t|%s",
+			rec.Name, rec.Type, rec.TTL, rec.Priority, rec.Disabled, rec.Content))
+	}
+	// Order in the DB must not affect the decision.
+	sort.Strings(lines)
+
+	axfr := append([]string(nil), allowAXFR...)
+	notify := append([]string(nil), alsoNotify...)
+	sort.Strings(axfr)
+	sort.Strings(notify)
+
+	h := sha256.New()
+	// Counts are encoded separately so an empty set can't collide with a
+	// differently-shaped one.
+	fmt.Fprintf(h, "records:%d\n", len(lines))
+	for _, l := range lines {
+		h.Write([]byte(l))
+		h.Write([]byte{'\n'})
+	}
+	fmt.Fprintf(h, "axfr:%d\n%s\n", len(axfr), strings.Join(axfr, ","))
+	fmt.Fprintf(h, "notify:%d\n%s\n", len(notify), strings.Join(notify, ","))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// dnsZonePushNeeded reports whether the zone should be pushed this tick, and
+// is the single place that decides it. Returns true when the compiled content
+// changed, when this process has not pushed the zone yet (e.g. after a panel
+// restart), or when the self-heal interval has elapsed.
+func (r *Reconciler) dnsZonePushNeeded(zoneID, hash string, now time.Time) bool {
+	v, ok := r.dnsZoneDispatchCache.Load(zoneID)
+	if !ok {
+		return true
+	}
+	st, okT := v.(dnsZoneDispatchState)
+	if !okT {
+		return true
+	}
+	if st.Hash != hash {
+		return true
+	}
+	return now.Sub(st.At) >= dnsZoneReDispatchInterval
+}
+
+// dnsZonePushed records a successful push so the next tick can short-circuit.
+func (r *Reconciler) dnsZonePushed(zoneID, hash string, now time.Time) {
+	r.dnsZoneDispatchCache.Store(zoneID, dnsZoneDispatchState{Hash: hash, At: now})
+}

--- a/panel-api/internal/reconciler/dns_zone_dispatch_gate_test.go
+++ b/panel-api/internal/reconciler/dns_zone_dispatch_gate_test.go
@@ -1,0 +1,112 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+)
+
+func recs() []dnscompile.Record {
+	return []dnscompile.Record{
+		{Name: "example.com", Type: "A", Content: "203.0.113.10", TTL: 300},
+		{Name: "www.example.com", Type: "CNAME", Content: "example.com", TTL: 300},
+		{Name: "example.com", Type: "MX", Content: "mail.example.com", TTL: 300, Priority: 10},
+	}
+}
+
+// The SOA serial must NOT feed the hash. It used to be stamped with
+// time.Now() on every pass, so including it would make the payload differ
+// every tick by construction — which is exactly why the zone could never
+// converge and was rewritten in PowerDNS sixty times an hour.
+func TestDesiredDNSZoneHashIgnoresSOASerial(t *testing.T) {
+	base := recs()
+	withSOA1 := append(base, dnscompile.Record{
+		Name: "example.com", Type: "SOA", TTL: 300,
+		Content: "ns1.example.com. hostmaster.example.com. 1000 10800 3600 604800 3600",
+	})
+	withSOA2 := append(base, dnscompile.Record{
+		Name: "example.com", Type: "SOA", TTL: 300,
+		Content: "ns1.example.com. hostmaster.example.com. 2000 10800 3600 604800 3600",
+	})
+	if desiredDNSZoneHash(withSOA1, nil, nil) != desiredDNSZoneHash(withSOA2, nil, nil) {
+		t.Fatal("a changed SOA serial must not change the hash — including it " +
+			"reintroduces the never-converges bug")
+	}
+}
+
+// Record order in the DB must not cause a spurious push.
+func TestDesiredDNSZoneHashOrderIndependent(t *testing.T) {
+	a := recs()
+	b := []dnscompile.Record{a[2], a[0], a[1]}
+	if desiredDNSZoneHash(a, nil, nil) != desiredDNSZoneHash(b, nil, nil) {
+		t.Fatal("hash must not depend on record order")
+	}
+}
+
+// Every field the agent writes must be covered, or a change touching only
+// that field would be skipped as "unchanged" and never reach PowerDNS.
+func TestDesiredDNSZoneHashCoversEveryWrittenField(t *testing.T) {
+	baseline := desiredDNSZoneHash(recs(), nil, nil)
+
+	for name, mutate := range map[string]func([]dnscompile.Record){
+		"content":  func(r []dnscompile.Record) { r[0].Content = "203.0.113.99" },
+		"ttl":      func(r []dnscompile.Record) { r[0].TTL = 60 },
+		"priority": func(r []dnscompile.Record) { r[2].Priority = 20 },
+		"disabled": func(r []dnscompile.Record) { r[0].Disabled = true },
+		"name":     func(r []dnscompile.Record) { r[0].Name = "other.example.com" },
+		"type":     func(r []dnscompile.Record) { r[0].Type = "AAAA" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := recs()
+			mutate(m)
+			if desiredDNSZoneHash(m, nil, nil) == baseline {
+				t.Errorf("changing %s did not change the hash — that change would "+
+					"never be pushed to PowerDNS", name)
+			}
+		})
+	}
+
+	// AXFR / NOTIFY lists are part of the agent payload too.
+	if desiredDNSZoneHash(recs(), []string{"198.51.100.2"}, nil) == baseline {
+		t.Error("allow_axfr_from must affect the hash")
+	}
+	if desiredDNSZoneHash(recs(), nil, []string{"198.51.100.2"}) == baseline {
+		t.Error("also_notify must affect the hash")
+	}
+}
+
+func TestDNSZonePushGate(t *testing.T) {
+	r := &Reconciler{}
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	hash := desiredDNSZoneHash(recs(), nil, nil)
+
+	// Never pushed in this process → must push (covers panel restart).
+	if !r.dnsZonePushNeeded("zone-1", hash, now) {
+		t.Fatal("first sight of a zone must push")
+	}
+	r.dnsZonePushed("zone-1", hash, now)
+
+	// Unchanged content inside the self-heal window → skip.
+	if r.dnsZonePushNeeded("zone-1", hash, now.Add(time.Minute)) {
+		t.Error("unchanged content must not be re-pushed every tick")
+	}
+
+	// Changed content → push immediately, regardless of the window.
+	changed := recs()
+	changed[0].Content = "203.0.113.99"
+	if !r.dnsZonePushNeeded("zone-1", desiredDNSZoneHash(changed, nil, nil), now.Add(time.Minute)) {
+		t.Error("changed content must push immediately")
+	}
+
+	// Past the self-heal interval → push even though nothing changed, so
+	// out-of-band PowerDNS drift is still corrected.
+	if !r.dnsZonePushNeeded("zone-1", hash, now.Add(dnsZoneReDispatchInterval+time.Second)) {
+		t.Error("self-heal interval must force a periodic re-push")
+	}
+
+	// A different zone is tracked independently.
+	if !r.dnsZonePushNeeded("zone-2", hash, now.Add(time.Minute)) {
+		t.Error("a different zone must not inherit another zone's cache entry")
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -214,6 +214,17 @@ type Reconciler struct {
 	// sshKeysDispatchState. sync.Map = lock-free for the common
 	// "many readers, one writer per key" pattern.
 	sshKeysDispatchCache sync.Map
+
+	// dnsZoneDispatchCache: per-zone hash of the last-pushed record set +
+	// timestamp, same shape and rationale as sshKeysDispatchCache. Without
+	// it reconcileDNSZone rewrote the SOA serial, UPDATEd dns_zones, and
+	// pushed a full zone to the agent for EVERY enabled domain every tick —
+	// and the agent then DELETEs and re-INSERTs every record row in
+	// PowerDNS's SQL backend and shells out three times (purge auth cache,
+	// wipe recursor cache, NOTIFY slaves). Because the serial changed on
+	// every pass, the payload could never converge, so no downstream gate
+	// could ever fire. Keyed by zone ID; value type dnsZoneDispatchState.
+	dnsZoneDispatchCache sync.Map
 }
 
 // WithPanelCertificate injects the M32 panel-cert repo + routability
@@ -2140,10 +2151,6 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 	}
 	compiled := dnscompile.Compile(zone, records, srv)
 
-	// Bump serial on push.
-	zone.Serial = time.Now().UTC().Unix()
-	_ = r.dnsZones.Update(ctx, zone)
-
 	// Derive AXFR and NOTIFY lists from ServerSettings.
 	var allowAXFR, alsoNotify []string
 	if srv != nil && srv.NS2IPv4 != "" {
@@ -2155,6 +2162,26 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 	// `dig AXFR @127.0.0.1` — add that for debugging.
 	allowAXFR = append(allowAXFR, "127.0.0.1")
 
+	// Gate the whole push on a content compare. Unconditionally stamping the
+	// serial and pushing meant EVERY enabled domain, EVERY tick: one
+	// dns_zones UPDATE, plus an agent RPC that DELETEs and re-INSERTs every
+	// record row in PowerDNS's SQL backend and shells out three times (purge
+	// auth cache, wipe recursor cache, NOTIFY slaves). With a slave
+	// configured that also meant NOTIFY/AXFR churn every minute, and
+	// `rec_control wipe-cache` meant recursor entries for hosted zones never
+	// outlived one tick. dnsZonePushNeeded self-heals every
+	// dnsZoneReDispatchInterval, so out-of-band pdns drift is still corrected.
+	now := time.Now().UTC()
+	hash := desiredDNSZoneHash(compiled, allowAXFR, alsoNotify)
+	if !r.dnsZonePushNeeded(zone.ID, hash, now) {
+		return
+	}
+
+	// Bump the serial only when we are actually pushing changed content —
+	// a serial that moves every tick is what made this unconvergeable.
+	zone.Serial = now.Unix()
+	_ = r.dnsZones.Update(ctx, zone)
+
 	pushCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if _, err := r.agent.Call(pushCtx, "dns.zone.upsert", map[string]any{
@@ -2163,8 +2190,13 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 		"allow_axfr_from": allowAXFR,
 		"also_notify":     alsoNotify,
 	}); err != nil {
+		// Do NOT record the hash on failure: the agent may hold older
+		// content, so the next tick must retry rather than believe it is
+		// converged.
 		r.log.Error("dns.zone.upsert failed", "zone", zone.Name, "err", err)
+		return
 	}
+	r.dnsZonePushed(zone.ID, hash, now)
 }
 
 // reconcileDNSZoneDeleted tears down a DNS zone on the agent after its DB row


### PR DESCRIPTION
### HI-1 — the DNS zone push had no gate, and *could not* have had one

For **every enabled domain, every tick**, `reconcileDNSZone` stamped the SOA serial with `time.Now()`, UPDATEd `dns_zones`, and pushed the whole zone to the agent — which DELETEs and re-INSERTs every record row in PowerDNS's SQL backend, then shells out three times (`pdns_control purge`, `rec_control wipe-cache`, `pdns_control notify`). With a slave configured that's NOTIFY/AXFR churn every minute, and the recursor wipe meant cached answers for hosted zones never outlived one tick.

The key point: there was no content compare, and **there could not be one** — because the serial changed every pass, the payload differed every pass *by construction*, so no downstream gate could ever fire.

Now gated on a hash of the compiled records + AXFR/NOTIFY lists; the serial is bumped only on real content change.

Deliberate properties, each with a test:
- **Excludes the SOA serial** — including it reintroduces the never-converges bug.
- **Covers every field the agent writes** (name/type/ttl/priority/disabled/content), so an MX-priority-only edit still pushes.
- **Order-independent** — record order in the DB doesn't cause spurious pushes.
- **Nothing recorded on a failed push** — a failure retries next tick instead of being mistaken for convergence.
- **Self-heals** every `dnsZoneReDispatchInterval`, so out-of-band PowerDNS drift (operator SQL edit, rebuilt pdns DB, partially applied push) is still corrected. DB stays the source of truth; we just stop asserting it 60x/hour/zone.

Same shape as the existing `sshKeysDispatchCache`, a pattern already proven in this package.

### Scope change since the first push

This PR originally also memoized the singleton `server_settings` row (ME-6, ~300 redundant reads/min). **I've dropped that half**, and it's worth saying why rather than quietly re-pushing:

CI caught `TestPreviewStateCacheTTL` failing. The reconciler already has caches — `previewStateCached`, `standbyCached` — whose contract is *"when MY TTL expires, re-read settings fresh"*. A cache underneath them silently defeats that. The test was right and my change was wrong.

Doing ME-6 properly needs a deliberate design (an explicit fresh-read path for callers that manage their own invalidation), not a blanket memo, so it belongs in its own change.

I should also flag: I reported this branch as locally green when I first pushed it. That was a bad call — my local filter hid the failure and I read "no output" as "passing". CI caught what I should have.

### Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./panel-api/... ./panel-agent/...` — **0 failures**, verified by explicit FAIL count this time
- [x] Hash tests: SOA-serial-ignored, order-independent, one subtest per written field proving each triggers a push
- [x] Gate tests: first sight pushes (covers panel restart), unchanged skips, changed pushes immediately, self-heal forces periodic re-push, zones tracked independently
- [ ] Worth watching on a box: `dns_zones` UPDATE rate and `pdns_control` invocations should drop to near-zero in steady state

Remaining reconciler findings (ME-5, ME-6, ME-7, ME-14, LO-4, LO-5, LO-11) left for follow-ups.

Refs the optimization review at commit `735d7445`.
