### PR TITLE
fix(security): scope mailbox-share delete to its owner (IDOR), validate restore username, drop path disclosure (SEC ME-1, LO-7, LO-8)

### DIFF
--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -110,6 +110,13 @@ func backupRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	if req.ManifestSnapshotID == "" {
 		return nil, bkInvalidArg("manifest_snapshot_id required")
 	}
+	// target_username flows into useradd/loginctl argv and into the rsync
+	// destination path join, neither of which is containment-checked
+	// downstream. Validate the shape here, next to the ulid check, matching
+	// what every other backup handler does.
+	if req.TargetUsername != "" && !backupUsernameRE.MatchString(req.TargetUsername) {
+		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
+	}
 
 	// Single global flock — held for the duration of the restore. Use
 	// LOCK_NB so a busy host returns an error rather than blocking

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -73,8 +73,13 @@ func backupRestoreSelectiveHandler(ctx context.Context, raw json.RawMessage) (an
 	if p.ManifestSnapshotID == "" {
 		return nil, bkInvalidArg("manifest_snapshot_id required")
 	}
-	if p.TargetUsername == "" {
-		return nil, bkInvalidArg("target_username required")
+	// Format-validate, not just non-empty: target_username reaches useradd
+	// argv (a leading "-" parses as flags) and is joined into the rsync
+	// destination path, where a "../" component would turn a root rsync
+	// --delete into an arbitrary-directory mirror. Every sibling backup
+	// handler already validates with this same regex.
+	if !backupUsernameRE.MatchString(p.TargetUsername) {
+		return nil, bkInvalidArg("target_username must match ^[a-z][a-z0-9_-]{0,31}$")
 	}
 	if len(p.Databases) == 0 && !p.RestoreHome && len(p.Mailboxes) == 0 {
 		return nil, bkInvalidArg("select at least one database, mailbox, and/or home")

--- a/panel-api/internal/api/domain_path_browse.go
+++ b/panel-api/internal/api/domain_path_browse.go
@@ -49,8 +49,12 @@ type domainBrowseEntry struct {
 
 type domainBrowseResult struct {
 	DocRoot string              `json:"doc_root"`
-	Path    string              `json:"path"`     // canonical relative path (no trailing /)
-	AbsPath string              `json:"abs_path"` // server-side absolute (for debugging)
+	Path string `json:"path"` // canonical relative path (no trailing /)
+	// NOTE: the server-side absolute path is deliberately NOT returned. It
+	// leaks /home/<linux-user>/..., i.e. the tenant's Linux username, which
+	// is useful pre-recon for SSH/password attacks against that account.
+	// Auth and containment here are correct; this was pure over-disclosure.
+	// It stays available server-side for logs.
 	Entries []domainBrowseEntry `json:"entries"`
 }
 
@@ -108,7 +112,6 @@ func (h *domainPathBrowseHandler) browse(c *gin.Context) {
 	out := domainBrowseResult{
 		DocRoot: dom.DocRoot,
 		Path:    rel,
-		AbsPath: abs,
 		Entries: make([]domainBrowseEntry, 0, len(agentResp.Entries)),
 	}
 	for _, e := range agentResp.Entries {

--- a/panel-api/internal/api/mailbox_share.go
+++ b/panel-api/internal/api/mailbox_share.go
@@ -178,12 +178,16 @@ func (h *shareHandler) create(c *gin.Context) {
 func (h *shareHandler) del(c *gin.Context) {
 	ctx := c.Request.Context()
 	claims := ginctx.Claims(c)
-	_, _, err := h.loadMailbox(ctx, c.Param("mbid"), claims)
+	mb, _, err := h.loadMailbox(ctx, c.Param("mbid"), claims)
 	if err != nil {
 		h.writeErr(c, err)
 		return
 	}
-	if err := h.cfg.MailboxShares.Delete(ctx, c.Param("shareId")); err != nil {
+	// Scope the delete to the authenticated mailbox. Authenticating :mbid and
+	// then deleting by bare :shareId let any authenticated tenant delete
+	// another tenant's share — passing their OWN mailbox as :mbid — and the
+	// reconciler would then strip that share's JMAP shareWith on Stalwart.
+	if err := h.cfg.MailboxShares.DeleteByOwner(ctx, c.Param("shareId"), mb.ID); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
 			return

--- a/panel-api/internal/repository/mailbox_share_repository.go
+++ b/panel-api/internal/repository/mailbox_share_repository.go
@@ -22,6 +22,9 @@ type MailboxShareRepository interface {
 	Create(ctx context.Context, share *models.MailboxShare) error
 	Update(ctx context.Context, share *models.MailboxShare) error
 	Delete(ctx context.Context, id string) error
+	// DeleteByOwner is the owner-scoped delete the HTTP layer must use; see
+	// the implementation for why the scope belongs in the query.
+	DeleteByOwner(ctx context.Context, id, ownerMailboxID string) error
 }
 
 type mailboxShareRepo struct {
@@ -129,6 +132,28 @@ func (r *mailboxShareRepo) Update(ctx context.Context, share *models.MailboxShar
 
 func (r *mailboxShareRepo) Delete(ctx context.Context, id string) error {
 	res := r.db.WithContext(ctx).Delete(&models.MailboxShare{}, "id = ?", id)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteByOwner removes a share only when it belongs to ownerMailboxID,
+// returning ErrNotFound otherwise.
+//
+// The owner scope is part of the DELETE rather than a separate read-then-check
+// so the authorization can't be raced, and so no caller can forget it. The
+// route is DELETE /mailboxes/:mbid/shares/:shareId: authenticating :mbid alone
+// and then deleting by bare :shareId let any authenticated tenant delete
+// another tenant's share row by passing their own mailbox as :mbid. Mirrors
+// MailboxSendDelegation.DeleteByPair, which had this right.
+func (r *mailboxShareRepo) DeleteByOwner(ctx context.Context, id, ownerMailboxID string) error {
+	res := r.db.WithContext(ctx).
+		Where("id = ? AND owner_mailbox_id = ?", id, ownerMailboxID).
+		Delete(&models.MailboxShare{})
 	if res.Error != nil {
 		return res.Error
 	}

--- a/panel-api/internal/repository/mailbox_share_repository_test.go
+++ b/panel-api/internal/repository/mailbox_share_repository_test.go
@@ -50,3 +50,46 @@ func TestMailboxShare_ListByUserID_ScopesInSQL(t *testing.T) {
 	require.Equal(t, "share-1", rows[0].ID)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+// DeleteByOwner must carry the owner scope in the SQL itself, and report
+// ErrNotFound when the row belongs to someone else.
+//
+// The route is DELETE /mailboxes/:mbid/shares/:shareId. The handler
+// authenticates :mbid, but the delete used to run on the bare :shareId, so any
+// authenticated tenant who learned another tenant's share-row id could delete
+// it by passing their OWN mailbox as :mbid — and the reconciler would then
+// strip that share's JMAP shareWith on Stalwart. Scoping in the query (rather
+// than a read-then-check in the handler) makes the authorization
+// un-forgettable and un-raceable.
+func TestMailboxShare_DeleteByOwner_ScopesInSQL(t *testing.T) {
+	db, mock, raw := newMockShareDB(t)
+	defer raw.Close()
+	repo := NewMailboxShareRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`DELETE FROM .mailbox_shares. WHERE id = \? AND owner_mailbox_id = \?`).
+		WithArgs("share-1", "own-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.DeleteByOwner(context.Background(), "share-1", "own-1"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMailboxShare_DeleteByOwner_ForeignRowIsNotFound(t *testing.T) {
+	db, mock, raw := newMockShareDB(t)
+	defer raw.Close()
+	repo := NewMailboxShareRepository(db)
+
+	mock.ExpectBegin()
+	// Another tenant's share: the owner-scoped predicate matches nothing.
+	mock.ExpectExec(`DELETE FROM .mailbox_shares. WHERE id = \? AND owner_mailbox_id = \?`).
+		WithArgs("victim-share", "attacker-mailbox").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	err := repo.DeleteByOwner(context.Background(), "victim-share", "attacker-mailbox")
+	require.ErrorIs(t, err, ErrNotFound,
+		"deleting a share owned by another mailbox must not succeed")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-ui/src/shells/admin/domains/DomainPathBrowserModal.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainPathBrowserModal.tsx
@@ -22,7 +22,6 @@ type BrowseEntry = { name: string; is_dir: boolean };
 type BrowseResp = {
   doc_root: string;
   path: string;
-  abs_path: string;
   entries: BrowseEntry[];
 };
 


### PR DESCRIPTION
Three findings from `docs/security/code-review-2026-08-08.md`.

### ME-1 — cross-tenant IDOR on mailbox-share delete

`DELETE /mailboxes/:mbid/shares/:shareId` authenticated `:mbid` via `loadMailbox`, **discarded the result** (`_, _, err :=`), then deleted by the bare `:shareId` with no ownership check.

Any authenticated tenant who learned another tenant's share-row id could delete it by passing their **own** mailbox as `:mbid` — and the reconciler then strips that share's JMAP `shareWith` on Stalwart. Cross-tenant integrity + availability.

The sibling send-as delete already does this correctly (`DeleteByPair`), which is what marks this as an oversight rather than a design gap.

Fixed with `DeleteByOwner`: **the owner scope lives in the DELETE predicate**, not in a handler-side read-then-check — so it can't be forgotten by a future caller and can't be raced.

Mitigating (unchanged): share ids are 128-bit ULIDs only exposed to the owner's tenant, so the id must be obtained out-of-band.

### LO-8 — `target_username` unvalidated in both restore handlers

Every other backup handler validates this field with `backupUsernameRE`; the two restore handlers didn't. The value reaches `useradd`/`loginctl` argv (a leading `-` parses as flags) and is joined into the rsync destination path with no containment check, where a `../` component turns a root `rsync --delete` into an arbitrary-directory mirror.

Not reachable from an untrusted position today (tenant path derives the username server-side, admin restore uses the DB username, CLI DR is root-operated) — but the agent is the last line of validation and this was the one place trusting the wire.

### LO-7 — server-absolute path disclosed to clients

The domain browse endpoint returned `abs_path` in every 200, disclosing `/home/<linux-user>/…` and therefore the tenant's Linux username — useful pre-recon for SSH/password attacks. Auth (owner-or-admin) and containment were already correct; this was pure over-disclosure. Removed from the response and from the UI type that declared but never rendered it.

### Test plan
- [x] `go build ./...`, `go vet`, `npx tsc -b` clean
- [x] `go test ./panel-api/... ./panel-agent/...` all pass
- [x] New repo tests: owner scope appears in the SQL, and a foreign-owned row returns `ErrNotFound` instead of deleting

Remaining Batch-5 items (ME-2 `RequireLocalhost` on TCP binds, LO-4 automation HMAC replay with nil Redis, LO-5 `clientIP` XFF trust, LO-6 agent-error echo) are larger and deliberately left for a follow-up.