### PR TITLE
fix(security): never execute hostname.env; reject unsafe values at every writer (SEC ME-5)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1107,6 +1107,14 @@ jh_free_hostname_flow() {
   done
   fqdn="$(jh_field "$body" fqdn)"; label="$(jh_field "$body" label)"; token="$(jh_field "$body" token)"
   [[ -z "$fqdn" || -z "$token" ]] && { echo "  malformed claim response — using a manual hostname" >&2; return 1; }
+  # Validate every field before it lands in hostname.env. The readers no longer
+  # `source` that file, but this is the boundary where remote data enters the
+  # box, and a value carrying shell metacharacters or a newline could still
+  # break or spoof a later parse. Reject rather than sanitize so a
+  # compromised/MITM'd service can't smuggle anything through.
+  [[ "$token" =~ ^[A-Za-z0-9_-]+$ ]] || { echo "  claim response token has an unexpected format — using a manual hostname" >&2; return 1; }
+  [[ "$label" =~ ^[A-Za-z0-9-]+$ ]]  || { echo "  claim response label has an unexpected format — using a manual hostname" >&2; return 1; }
+  [[ "$email" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$ ]] || { echo "  email has an unexpected format — using a manual hostname" >&2; return 1; }
   umask 077
   {
     printf 'LABEL=%s\nFQDN=%s\nEMAIL=%s\nTOKEN=%s\nAPI=%s\n' "$label" "$fqdn" "$email" "$token" "$JH_API"

--- a/install/hostname/certbot-auth-hook.sh
+++ b/install/hostname/certbot-auth-hook.sh
@@ -9,8 +9,17 @@ set -euo pipefail
 
 ENV=/etc/jabali-panel/hostname.env
 [[ -r "$ENV" ]] || { echo "certbot-auth-hook: $ENV missing — box has no free hostname" >&2; exit 1; }
-# shellcheck disable=SC1090
-source "$ENV"
+# Read values WITHOUT executing the file. `source` would run any shell
+# metacharacters the hosted service put in a value — this script runs as root
+# from a timer/renew hook, so a token containing $(...) or backticks would be
+# root code execution on every fire, forever. Parse instead.
+jh_env() {
+  local line
+  line="$(grep -m1 "^$1=" "$ENV" 2>/dev/null)" || return 1
+  printf '%s' "${line#*=}"
+}
+TOKEN="$(jh_env TOKEN)"
+API="$(jh_env API)"
 : "${TOKEN:?}" "${API:?}"
 
 code=$(curl -sS --max-time 30 -o /dev/null -w '%{http_code}' \

--- a/install/hostname/certbot-cleanup-hook.sh
+++ b/install/hostname/certbot-cleanup-hook.sh
@@ -6,8 +6,17 @@ set -euo pipefail
 
 ENV=/etc/jabali-panel/hostname.env
 [[ -r "$ENV" ]] || exit 0
-# shellcheck disable=SC1090
-source "$ENV"
+# Read values WITHOUT executing the file. `source` would run any shell
+# metacharacters the hosted service put in a value — this script runs as root
+# from a timer/renew hook, so a token containing $(...) or backticks would be
+# root code execution on every fire, forever. Parse instead.
+jh_env() {
+  local line
+  line="$(grep -m1 "^$1=" "$ENV" 2>/dev/null)" || return 1
+  printf '%s' "${line#*=}"
+}
+TOKEN="$(jh_env TOKEN)"
+API="$(jh_env API)"
 : "${TOKEN:?}" "${API:?}"
 
 curl -sS --max-time 30 -o /dev/null \

--- a/install/hostname/jabali-hostname-cert.sh
+++ b/install/hostname/jabali-hostname-cert.sh
@@ -14,8 +14,17 @@ set -euo pipefail
 
 ENV=/etc/jabali-panel/hostname.env
 [[ -r "$ENV" ]] || { echo "no free hostname on this box ($ENV missing)" >&2; exit 1; }
-# shellcheck disable=SC1090
-source "$ENV"
+# Read values WITHOUT executing the file. `source` would run any shell
+# metacharacters the hosted service put in a value — this script runs as root
+# from a timer/renew hook, so a token containing $(...) or backticks would be
+# root code execution on every fire, forever. Parse instead.
+jh_env() {
+  local line
+  line="$(grep -m1 "^$1=" "$ENV" 2>/dev/null)" || return 1
+  printf '%s' "${line#*=}"
+}
+FQDN="$(jh_env FQDN)"
+EMAIL="$(jh_env EMAIL)"
 : "${FQDN:?}" "${EMAIL:?}"
 
 HOOK_DIR=/usr/local/libexec/jabali

--- a/install/hostname/jabali-hostname-heartbeat.sh
+++ b/install/hostname/jabali-hostname-heartbeat.sh
@@ -7,8 +7,18 @@ set -euo pipefail
 
 ENV=/etc/jabali-panel/hostname.env
 [[ -r "$ENV" ]] || exit 0
-# shellcheck disable=SC1090
-source "$ENV"
+# Read values WITHOUT executing the file. `source` would run any shell
+# metacharacters the hosted service put in a value — this script runs as root
+# from a timer/renew hook, so a token containing $(...) or backticks would be
+# root code execution on every fire, forever. Parse instead.
+jh_env() {
+  local line
+  line="$(grep -m1 "^$1=" "$ENV" 2>/dev/null)" || return 1
+  printf '%s' "${line#*=}"
+}
+TOKEN="$(jh_env TOKEN)"
+API="$(jh_env API)"
+FQDN="$(jh_env FQDN)"
 [[ -n "${TOKEN:-}" && -n "${API:-}" ]] || exit 0
 
 resp="$(curl -sS --max-time 30 -w $'\n%{http_code}' -H 'Content-Type: application/json' \

--- a/installer/internal/tui/freehostname.go
+++ b/installer/internal/tui/freehostname.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -130,9 +131,34 @@ func (m fhModel) claimCmd(email, code string) tea.Cmd {
 	}
 }
 
+// Charset allowlists for every value written into hostname.env — see
+// writeCredential.
+var (
+	fhTokenRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,256}$`)
+	fhLabelRegex = regexp.MustCompile(`^[a-z0-9-]{1,63}$`)
+	fhFQDNRegex  = regexp.MustCompile(`^[a-z0-9.-]{1,253}$`)
+	fhEmailRegex = regexp.MustCompile(`^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+$`)
+)
+
 // writeCredential persists the token 0600 so install.sh's slice step enables
 // the heartbeat and the cert issues. Best-effort; the hostname still works.
 func (m fhModel) writeCredential() error {
+	// Validate before persisting: hostname.env is read by root-run scripts
+	// (heartbeat timer, certbot renew hooks), so a value carrying shell
+	// metacharacters or a newline — from a compromised or MITM'd hosted
+	// service — must never reach the file. Reject rather than sanitize.
+	if !fhTokenRegex.MatchString(m.token) {
+		return fmt.Errorf("claim response token has an unexpected format")
+	}
+	if !fhLabelRegex.MatchString(m.label) {
+		return fmt.Errorf("claim response label has an unexpected format")
+	}
+	if !fhFQDNRegex.MatchString(m.fqdn) {
+		return fmt.Errorf("claim response fqdn has an unexpected format")
+	}
+	if !fhEmailRegex.MatchString(m.email.Value()) {
+		return fmt.Errorf("email has an unexpected format")
+	}
 	content := fmt.Sprintf("LABEL=%s\nFQDN=%s\nEMAIL=%s\nTOKEN=%s\nAPI=%s\n",
 		m.label, m.fqdn, m.email.Value(), m.token, fhAPI())
 	if err := os.MkdirAll(filepath.Dir(m.tokenFile), 0o755); err != nil {

--- a/panel-agent/internal/commands/hostname_env_injection_test.go
+++ b/panel-agent/internal/commands/hostname_env_injection_test.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// /etc/jabali-panel/hostname.env holds values that came from a REMOTE service
+// (api.jabalihosted.com /v1/claim) and is read by scripts that run as root on
+// a timer and at every certbot renewal. Two rules keep that safe, and both are
+// pinned here because either one alone is a root-code-execution bug away:
+//
+//  1. No reader may `source` the file. `source` executes shell metacharacters
+//     in a value, so a token containing $(...) or backticks would run as root
+//     on every heartbeat, forever, and re-run after every reboot.
+//  2. Every writer must reject values outside a strict charset, so nothing
+//     dangerous is written in the first place.
+
+func TestHostnameEnvReadersDoNotSourceIt(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join("..", "..", "..", "install", "hostname")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sh") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		src := string(body)
+		if !strings.Contains(src, "hostname.env") {
+			continue
+		}
+		checked++
+		for _, bad := range []string{`source "$ENV"`, `. "$ENV"`, "source /etc/jabali-panel/hostname.env"} {
+			if strings.Contains(src, bad) {
+				t.Errorf("%s executes hostname.env via %q. Values in that file come "+
+					"from a remote service and this script runs as root — a token "+
+					"containing $(...) would be root code execution. Parse the file "+
+					"instead (see jh_env).", e.Name(), bad)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no hostname.env readers found — the layout changed and this test " +
+			"is no longer checking anything")
+	}
+}
+
+// The agent writer must reject a token carrying shell metacharacters. The
+// original check only excluded "\n\r ", which still permitted $(...).
+func TestFreeTokenRegexRejectsShellMetacharacters(t *testing.T) {
+	t.Parallel()
+
+	for _, bad := range []string{
+		"$(id)",
+		"`id`",
+		"${IFS}",
+		"tok;reboot",
+		"tok\nEXTRA=1",
+		"tok with space",
+		"tok\"quote",
+		"tok'quote",
+		"tok|pipe",
+		"tok&bg",
+		"", // empty
+	} {
+		if freeTokenRegex.MatchString(bad) {
+			t.Errorf("freeTokenRegex accepted %q — that value reaches a file read by root scripts", bad)
+		}
+	}
+	for _, good := range []string{
+		"abc123",
+		"a-b_c",
+		strings.Repeat("f", 64),
+	} {
+		if !freeTokenRegex.MatchString(good) {
+			t.Errorf("freeTokenRegex rejected a legitimate token %q", good)
+		}
+	}
+}

--- a/panel-agent/internal/commands/hostname_free_apply.go
+++ b/panel-agent/internal/commands/hostname_free_apply.go
@@ -37,6 +37,12 @@ var hostnameChown = os.Chown
 var freeFQDNRegex = regexp.MustCompile(`^[a-z0-9-]+\.jabalihosted\.com$`)
 var freeLabelRegex = regexp.MustCompile(`^[a-z0-9-]{1,63}$`)
 
+// freeTokenRegex allowlists the bearer token's charset. hostname.env is read
+// by root-run scripts, so the token must never be able to carry shell
+// metacharacters ($(...), backticks, ${...}) or a newline that could forge an
+// extra KEY=VALUE line.
+var freeTokenRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,256}$`)
+
 type hostnameFreeApplyParams struct {
 	FQDN  string `json:"fqdn"`
 	Label string `json:"label"`
@@ -62,8 +68,14 @@ func hostnameFreeApplyHandler(ctx context.Context, params json.RawMessage) (any,
 	if _, err := requireEmail(p.Email); err != nil {
 		return nil, err
 	}
-	if p.Token == "" || strings.ContainsAny(p.Token, "\n\r ") {
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "token required, single-line"}
+	// Allowlist the token's charset rather than excluding whitespace. The
+	// old "no \n\r or space" check still permitted $(...), backticks, and
+	// ${...} — and hostname.env is read by root-run scripts (heartbeat timer,
+	// certbot renew hooks). Those readers no longer `source` the file, but a
+	// writer is the right place to reject remote data outright, and this keeps
+	// the value safe for any future consumer.
+	if !freeTokenRegex.MatchString(p.Token) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "token must be [A-Za-z0-9_-]+"}
 	}
 	if !strings.HasPrefix(p.API, "https://") || strings.ContainsAny(p.API, "\n\r ") {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "api must be an https URL"}


### PR DESCRIPTION
`/etc/jabali-panel/hostname.env` holds `LABEL/FQDN/EMAIL/TOKEN/API` taken **verbatim from the `api.jabalihosted.com` /v1/claim response** (JAB-213). Four scripts that run as **root** then `source` it: the daily heartbeat timer, and the certbot auth/cleanup/issue hooks that re-run at every renewal.

`source` executes the file. **A token containing `$(…)` or backticks runs as root** — every heartbeat, every cert renewal, forever, surviving reboots, on every panel using a free hostname.

Only `fqdn` was validated. `TOKEN`, `LABEL` and the TUI-written `EMAIL` were not, and the agent-side writer excluded only `"\n\r "` — which still permits `$(…)`, backticks and `${…}`.

Reaching it requires a compromised/malicious hostname service or a TLS MITM of `JH_API`; the blast radius after that is total and persistent.

> **Severity:** the review rates this Medium. I'd call it **High** — remote-to-root on the whole free-hostname fleet, persistent, with no operator-visible signal. Flagging rather than silently re-rating.

### Fixed at both layers
Either layer alone is one edit away from reopening the hole, so both:

1. **Readers no longer source the file.** Each script parses just the value it needs (small grep + parameter-expansion helper), so nothing in the file is ever executed regardless of what a writer let through. ← the load-bearing fix
2. **Writers reject rather than sanitize.** `install.sh`, the TUI installer, and the agent's `hostname.free.apply` allowlist each field's charset before persisting, so remote data can't smuggle metacharacters or a newline that forges an extra `KEY=VALUE` line.

### The test pins the class, not the instances
It walks **every** `hostname.env` reader and fails if any sources the file — so a newly added reader is caught too. It also fails if the layout changes such that it stops checking anything (no silently-vacuous guard). Plus a table proving the token regex rejects `$(id)`, backticks, `${IFS}`, `;`, newlines, quotes, pipes.

### Test plan
- [x] `go build ./...`, `go vet` clean; `bash -n` on all four scripts + install.sh
- [x] `go test ./...` all pass
- [x] New tests pass; reader-guard verified to actually inspect the scripts (fails if none found)
- [ ] Worth a box check at next free-hostname install: heartbeat timer + `certbot renew --dry-run` still authenticate

Refs `docs/security/code-review-2026-08-08.md` ME-5.