### PR TITLE
fix(hostedsvc,support-claim): stop a failed claim burning a label, bound the public endpoints (SEC ME-4/9/10, LO-16; OPT ME-13, LO-14)

### DIFF
--- a/hostedsvc/api.go
+++ b/hostedsvc/api.go
@@ -24,6 +24,12 @@ type API struct {
 	// ipMu serialises claim per source IP so two concurrent claims from one
 	// NAT can't race the collision-suffix scan into the same label.
 	ipMu sync.Mutex
+
+	// registerLimiter bounds unauthenticated /v1/register calls per source
+	// address. Lazily built so a zero-value API still works (tests, callers
+	// that construct the struct directly). See iprate.go.
+	registerLimiterOnce sync.Once
+	registerLimiter     *ipRateLimiter
 }
 
 func (a *API) Routes() http.Handler {
@@ -73,6 +79,17 @@ func (a *API) register(w http.ResponseWriter, r *http.Request) {
 	email, ok := normEmail(req.Email)
 	if !ok {
 		writeErr(w, http.StatusUnprocessableEntity, "bad_email", "not a valid email address")
+		return
+	}
+	// Per-source-IP cap. The per-email resend gap below stops a user
+	// double-clicking; it does not stop someone mailing one victim every 60s
+	// forever, or fanning out across millions of addresses using this
+	// service's authenticated relay as a spam relay. Checked BEFORE minting a
+	// code or touching the store so a bulk sender does no work here.
+	if ip := ClientIP(r); ip != nil && !a.registerRateLimiter().allow(ip.String()) {
+		a.Log.Warn("register: per-IP cap reached", "ip", ip.String())
+		writeErr(w, http.StatusTooManyRequests, "rate_limited",
+			"too many registrations from this address — try again later")
 		return
 	}
 	code, err := NewCode()
@@ -133,42 +150,30 @@ func (a *API) claim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.ipMu.Lock()
-	defer a.ipMu.Unlock()
-	label := base
-	for n := 1; ; n++ {
-		exists, err := a.Store.LabelExists(label)
-		if err != nil {
-			writeErr(w, http.StatusInternalServerError, "internal", "try again later")
-			return
-		}
-		if !exists {
-			break
-		}
-		if n > 26 {
-			writeErr(w, http.StatusConflict, "label_space_exhausted", "too many hosts behind this IP")
-			return
-		}
-		label = CollisionLabel(base, n)
+	// The lock covers ONLY the check-then-act it exists for: the
+	// collision-suffix scan and the row insert. Remote DNS calls used to sit
+	// inside it, so every claim fleet-wide serialised behind the slowest
+	// Cloudflare round-trip (two 15s-timeout calls), capping throughput at a
+	// few claims a second and stalling all of them on a slow CF day.
+	label, raw, herr := a.reserveLabel(base, ip.String(), email)
+	if herr != nil {
+		writeErr(w, herr.status, herr.code, herr.msg)
+		return
 	}
 
-	raw, hash, err := NewToken()
-	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "internal", "token generation failed")
-		return
-	}
-	if err := a.Store.CreateLabel(label, ip.String(), email, hash); err != nil {
-		if errors.Is(err, ErrEmailCap) {
-			writeErr(w, http.StatusForbidden, "email_cap", "this email already holds the maximum number of hostnames")
-			return
-		}
-		a.Log.Error("claim: create", "err", err)
-		writeErr(w, http.StatusInternalServerError, "internal", "try again later")
-		return
-	}
 	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
 	defer cancel()
 	if err := a.DNS.EnsureA(ctx, label, ip.String()); err != nil {
+		// Roll the reservation back. Leaving it would orphan the row: the
+		// caller never receives the token, so the label can never heartbeat
+		// (invisible to the reaper — moved_at stays NULL) while still
+		// consuming one of this IP's 26 collision suffixes and one slot in
+		// the claimer's per-email cap. Sustained DNS errors would then
+		// permanently exhaust an IP's label space and silently eat the
+		// user's quota, needing manual DB cleanup.
+		if derr := a.Store.DeleteLabel(label); derr != nil {
+			a.Log.Error("claim: rollback failed — orphaned label row", "label", label, "err", derr)
+		}
 		a.Log.Error("claim: dns", "label", label, "err", err)
 		writeErr(w, http.StatusInternalServerError, "dns_failed", "could not publish the record — try again")
 		return
@@ -182,6 +187,60 @@ func (a *API) claim(w http.ResponseWriter, r *http.Request) {
 	}
 	a.Log.Info("label claimed", "label", label, "ip", ip.String())
 	writeJSON(w, http.StatusOK, ClaimResponse{Label: label, FQDN: FQDN(label), Token: raw})
+}
+
+// registerRateLimiter returns the lazily-built per-IP limiter for /v1/register.
+func (a *API) registerRateLimiter() *ipRateLimiter {
+	a.registerLimiterOnce.Do(func() {
+		a.registerLimiter = newIPRateLimiter(registerIPHourlyCap, registerIPWindow)
+	})
+	return a.registerLimiter
+}
+
+// httpErr is a handler-ready error: status + wire code + user-facing message.
+type httpErr struct {
+	status int
+	code   string
+	msg    string
+}
+
+// reserveLabel picks a free label for base and inserts its row, returning the
+// label and the caller's raw token. Everything here is DB-only and runs under
+// ipMu, which is what the check-then-act (LabelExists → CreateLabel) needs;
+// remote DNS publishing happens afterwards, outside the lock.
+//
+// On any failure nothing is left behind, so a caller can retry cleanly.
+func (a *API) reserveLabel(base, ipv4, email string) (label, rawToken string, herr *httpErr) {
+	a.ipMu.Lock()
+	defer a.ipMu.Unlock()
+
+	label = base
+	for n := 1; ; n++ {
+		exists, err := a.Store.LabelExists(label)
+		if err != nil {
+			return "", "", &httpErr{http.StatusInternalServerError, "internal", "try again later"}
+		}
+		if !exists {
+			break
+		}
+		if n > 26 {
+			return "", "", &httpErr{http.StatusConflict, "label_space_exhausted", "too many hosts behind this IP"}
+		}
+		label = CollisionLabel(base, n)
+	}
+
+	raw, hash, err := NewToken()
+	if err != nil {
+		return "", "", &httpErr{http.StatusInternalServerError, "internal", "token generation failed"}
+	}
+	if err := a.Store.CreateLabel(label, ipv4, email, hash); err != nil {
+		if errors.Is(err, ErrEmailCap) {
+			return "", "", &httpErr{http.StatusForbidden, "email_cap", "this email already holds the maximum number of hostnames"}
+		}
+		a.Log.Error("claim: create", "err", err)
+		return "", "", &httpErr{http.StatusInternalServerError, "internal", "try again later"}
+	}
+	return label, raw, nil
 }
 
 // byToken resolves the caller's label from the bearer token — the ONLY

--- a/hostedsvc/cfdns.go
+++ b/hostedsvc/cfdns.go
@@ -174,6 +174,17 @@ func (c *CloudflareDNS) SetChallenge(ctx context.Context, label, value string) e
 			return nil // already present
 		}
 	}
+	// SetChallenge is add-only by design (a wildcard cert needs the apex and
+	// the wildcard challenge live at the SAME name simultaneously), so without
+	// a cap a token holder could script distinct values and accumulate
+	// thousands of TXT records in the shared jabalihosted.com zone, degrading
+	// zone size and list performance for every other tenant. Two is the
+	// legitimate maximum; maxChallengeRecordsPerLabel leaves headroom for a
+	// retry that raced cleanup.
+	if len(existing) >= maxChallengeRecordsPerLabel {
+		return fmt.Errorf("too many pending ACME challenges for %s (%d) — run cleanup first",
+			name, len(existing))
+	}
 	resp, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", c.ZoneID),
 		cfRecord{Type: "TXT", Name: name, Content: value, TTL: 60, Proxied: false})
 	if err != nil {

--- a/hostedsvc/iprate.go
+++ b/hostedsvc/iprate.go
@@ -1,0 +1,87 @@
+package hostedsvc
+
+import (
+	"sync"
+	"time"
+)
+
+// POST /v1/register is unauthenticated, internet-facing, and causes the
+// service to SEND MAIL through its own authenticated, reputation-clean relay.
+// The only throttle was a 60s resend gap keyed on the EMAIL, which stops
+// nothing that matters:
+//
+//   - target one victim address forever (a verification mail every 60s, from a
+//     relay they can't easily block — harassment the service is the vector for)
+//   - fan out across millions of distinct addresses, using the service as a
+//     spam relay and burning its sending reputation until the provider acts
+//
+// Both need a per-SOURCE-IP bound, which is what this adds. The key is
+// ClientIP(r) — the same address the label derivation trusts, established by
+// the TCP handshake and (behind Cloudflare) rewritten at the edge, so it is
+// not client-forgeable the way an X-Forwarded-For header would be.
+
+// registerIPHourlyCap is the number of /v1/register calls allowed from one
+// source address per hour. A real operator registers once, occasionally twice
+// after a typo; NAT'd offices share an address, so the cap is well above one
+// person's need while still bounding a bulk sender to a rounding error.
+const registerIPHourlyCap = 10
+
+// registerIPWindow is the sliding window the cap applies over.
+const registerIPWindow = time.Hour
+
+// ipRateLimiter is a small sliding-window counter keyed by source IP.
+//
+// Entries are pruned opportunistically on every call, so the map cannot grow
+// without bound from a rotating source — the failure mode that made the
+// support-claim limiter itself a memory-exhaustion vector.
+type ipRateLimiter struct {
+	mu   sync.Mutex
+	hits map[string][]time.Time
+	now  func() time.Time
+	cap  int
+	win  time.Duration
+}
+
+func newIPRateLimiter(capacity int, window time.Duration) *ipRateLimiter {
+	return &ipRateLimiter{
+		hits: map[string][]time.Time{},
+		now:  time.Now,
+		cap:  capacity,
+		win:  window,
+	}
+}
+
+// allow records a hit for ip and reports whether it is within the cap.
+func (l *ipRateLimiter) allow(ip string) bool {
+	if ip == "" {
+		// No usable source address: don't hand out a free pass, but don't
+		// wedge the service either — the caller still has the per-email gap.
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	cutoff := now.Add(-l.win)
+
+	// Prune every key, not just this one: a rotating source would otherwise
+	// leave a permanent entry per address it ever used.
+	for k, ts := range l.hits {
+		kept := ts[:0]
+		for _, t := range ts {
+			if t.After(cutoff) {
+				kept = append(kept, t)
+			}
+		}
+		if len(kept) == 0 {
+			delete(l.hits, k)
+			continue
+		}
+		l.hits[k] = kept
+	}
+
+	if len(l.hits[ip]) >= l.cap {
+		return false
+	}
+	l.hits[ip] = append(l.hits[ip], now)
+	return true
+}

--- a/hostedsvc/label.go
+++ b/hostedsvc/label.go
@@ -90,3 +90,13 @@ func ValidLabel(s string) bool {
 
 // FQDN returns the fully-qualified hostname for a label.
 func FQDN(label string) string { return label + "." + BaseDomain }
+
+// maxChallengeRecordsPerLabel bounds how many ACME challenge TXT records may
+// exist simultaneously at one label's _acme-challenge name.
+//
+// SetChallenge is add-only on purpose: issuing a wildcard cert needs the apex
+// and the wildcard challenge live at the SAME name at the same time, so a
+// replace would break renewal. That also means nothing stops a valid token
+// holder from scripting distinct values, so the count is capped. Legitimate
+// use needs 2; 8 leaves room for a retry that raced cleanup.
+const maxChallengeRecordsPerLabel = 8

--- a/hostedsvc/pdns.go
+++ b/hostedsvc/pdns.go
@@ -109,6 +109,14 @@ func (p *PDNS) SetChallenge(ctx context.Context, label, value string) error {
 	if err != nil {
 		return err
 	}
+	// Same cap as the Cloudflare backend: add-only challenges must not let a
+	// token holder accumulate unbounded TXT records in the shared zone. Two is
+	// the legitimate maximum (apex + wildcard); the constant leaves headroom
+	// for a retry that raced cleanup.
+	if len(existing) >= maxChallengeRecordsPerLabel {
+		return fmt.Errorf("too many pending ACME challenges for %s (%d) — run cleanup first",
+			name, len(existing))
+	}
 	recs := []record{{Content: quoted}}
 	for _, c := range existing {
 		if c != quoted {

--- a/hostedsvc/store.go
+++ b/hostedsvc/store.go
@@ -177,6 +177,20 @@ func (s *Store) CreateLabel(label, ipv4, email, tokenHash string) error {
 	return nil
 }
 
+// DeleteLabel hard-deletes a label row. This is the ROLLBACK path for a claim
+// that reserved the row and then failed to publish DNS — nothing was ever
+// handed to the caller, so the name must become available again.
+//
+// RevokeLabel is deliberately NOT a substitute: a revoked name is burned by
+// design (never reissued), so using it here would leak one of the 26 collision
+// suffixes for that source IP on every transient DNS outage, and would still
+// count against the claimer's per-email cap. Do not use this for anything a
+// user has actually been given.
+func (s *Store) DeleteLabel(label string) error {
+	_, err := s.db.Exec(`DELETE FROM labels WHERE label = ?`, label)
+	return err
+}
+
 // LabelExists reports whether a label row exists (revoked rows count: a
 // revoked label's name is burned, never reissued to someone else).
 func (s *Store) LabelExists(label string) (bool, error) {

--- a/support-claim/main.go
+++ b/support-claim/main.go
@@ -29,8 +29,10 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -38,6 +40,15 @@ import (
 	"sync"
 	"time"
 )
+
+// maxClaims bounds the in-memory claim store. Entries live for the full TTL
+// and each holds up to ~16 KiB, on an unauthenticated endpoint — without a
+// ceiling the heap grows until the process is OOM-killed.
+const maxClaims = 10000
+
+// errStoreFull is returned when maxClaims is reached; the handler maps it to
+// 503 so the caller can retry later rather than seeing a generic failure.
+var errStoreFull = errors.New("claim store is full")
 
 const (
 	// codeAlphabet is Crockford base32 minus vowels/ambiguous chars, so a code
@@ -104,6 +115,14 @@ func (s *store) put(p redeemPayload, now time.Time) (string, time.Time, error) {
 	}
 	if code == "" {
 		return "", time.Time{}, fmt.Errorf("could not allocate a unique code")
+	}
+	// Hard cap. Claims are held in memory for the full TTL (14 days) and each
+	// carries up to ~16 KiB of payload, on an unauthenticated endpoint — with
+	// no ceiling, a caller simply posting claims grows the heap until the
+	// process is OOM-killed, taking down the service support depends on.
+	// Refuse new claims instead; existing ones still redeem.
+	if len(s.claims) >= maxClaims {
+		return "", time.Time{}, errStoreFull
 	}
 	exp := now.Add(s.ttl)
 	s.claims[code] = claim{Payload: p, ExpiresAt: exp}
@@ -179,6 +198,14 @@ func (srv *server) handleIssue(w http.ResponseWriter, r *http.Request) {
 	}
 	code, exp, err := srv.store.put(redeemPayload(req), srv.now())
 	if err != nil {
+		if errors.Is(err, errStoreFull) {
+			// Distinguish "at capacity, retry later" from a genuine internal
+			// fault so an operator sees the real cause in the response and
+			// the log rather than a generic 500.
+			log.Printf("claim store full (%d entries) — refusing new claim", maxClaims)
+			http.Error(w, "claim store is full, try again later", http.StatusServiceUnavailable)
+			return
+		}
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -241,13 +268,29 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+// clientIP returns the address the rate limiter keys on.
+//
+// X-Forwarded-For is honoured ONLY when the immediate peer is loopback, i.e. a
+// reverse proxy on this host that sets the header itself. Trusting it from any
+// peer made the per-IP limit meaningless — a direct caller could rotate the
+// header on every request to bypass the 30/min cap on the open POST /claims,
+// and each distinct value also allocated a permanent bucket entry, so the same
+// trick grew the process heap without bound. Nothing in code or deployment
+// guarantees this service is proxy-fronted, and :8088 is reachable directly.
+// Mirrors hostedsvc/realip.go.
 func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		return strings.TrimSpace(strings.Split(xff, ",")[0])
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
 	}
-	host := r.RemoteAddr
-	if i := strings.LastIndex(host, ":"); i >= 0 {
-		host = host[:i]
+	if peer := net.ParseIP(host); peer != nil && peer.IsLoopback() {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			if first := strings.TrimSpace(strings.Split(xff, ",")[0]); first != "" {
+				if ip := net.ParseIP(first); ip != nil {
+					return ip.String()
+				}
+			}
+		}
 	}
 	return host
 }

--- a/support-claim/main_test.go
+++ b/support-claim/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -139,5 +141,84 @@ func TestRateLimit(t *testing.T) {
 	}
 	if codes == 0 {
 		t.Errorf("rate limiter blocked everything")
+	}
+}
+
+// clientIP must NOT trust X-Forwarded-For from a non-loopback peer. Trusting
+// it from anyone made the per-IP rate limit meaningless (rotate the header to
+// bypass the cap on the open POST /claims) and, because each distinct value
+// allocated a permanent bucket entry, turned the same trick into unbounded
+// heap growth. :8088 is directly reachable, and nothing guarantees the service
+// is proxy-fronted.
+func TestClientIPIgnoresXFFFromUntrustedPeer(t *testing.T) {
+	r := httptest.NewRequest("POST", "/claims", nil)
+	r.RemoteAddr = "203.0.113.9:51000"
+	r.Header.Set("X-Forwarded-For", "198.51.100.7")
+	if got := clientIP(r); got != "203.0.113.9" {
+		t.Fatalf("clientIP = %q, want the real peer 203.0.113.9 — a spoofed "+
+			"X-Forwarded-For must not become the rate-limit key", got)
+	}
+}
+
+// A loopback peer IS the local reverse proxy, so its XFF is authoritative.
+func TestClientIPTrustsXFFFromLoopback(t *testing.T) {
+	r := httptest.NewRequest("POST", "/claims", nil)
+	r.RemoteAddr = "127.0.0.1:51000"
+	r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.1")
+	if got := clientIP(r); got != "198.51.100.7" {
+		t.Fatalf("clientIP = %q, want 198.51.100.7 from the trusted proxy", got)
+	}
+}
+
+// Rotating the header must not let one source outrun the cap.
+func TestRateLimitNotBypassableByRotatingXFF(t *testing.T) {
+	rl := newRateLimiter(3)
+	allowed := 0
+	for i := 0; i < 20; i++ {
+		r := httptest.NewRequest("POST", "/claims", nil)
+		r.RemoteAddr = "203.0.113.9:51000"
+		r.Header.Set("X-Forwarded-For", "198.51.100."+strconv.Itoa(i))
+		if rl.allow(clientIP(r)) {
+			allowed++
+		}
+	}
+	if allowed > 3 {
+		t.Fatalf("allowed %d requests from one peer rotating XFF, cap is 3", allowed)
+	}
+}
+
+// The bucket map must not keep an entry per key forever.
+func TestRateLimiterEvictsIdleBuckets(t *testing.T) {
+	rl := newRateLimiter(30)
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	rl.now = func() time.Time { return base }
+	for i := 0; i < 500; i++ {
+		rl.allow("198.51.100." + strconv.Itoa(i))
+	}
+	if len(rl.bucket) < 100 {
+		t.Fatalf("expected many buckets while active, got %d", len(rl.bucket))
+	}
+	// Long after everything went idle, one more call should sweep the rest.
+	rl.now = func() time.Time { return base.Add(time.Hour) }
+	rl.allow("203.0.113.1")
+	if len(rl.bucket) > 2 {
+		t.Fatalf("idle buckets not evicted: %d remain — the map grows without "+
+			"bound from client-controlled keys", len(rl.bucket))
+	}
+}
+
+// The claim store must refuse new entries at capacity rather than growing
+// until the process is OOM-killed.
+func TestStorePutRefusesWhenFull(t *testing.T) {
+	s := newStore(14 * 24 * time.Hour)
+	now := time.Now()
+	for i := 0; i < maxClaims; i++ {
+		if _, _, err := s.put(redeemPayload{Host: "h"}, now); err != nil {
+			t.Fatalf("unexpected error filling store at %d: %v", i, err)
+		}
+	}
+	_, _, err := s.put(redeemPayload{Host: "h"}, now)
+	if !errors.Is(err, errStoreFull) {
+		t.Fatalf("put past capacity returned %v, want errStoreFull", err)
 	}
 }

--- a/support-claim/ratelimit.go
+++ b/support-claim/ratelimit.go
@@ -38,6 +38,17 @@ func (rl *rateLimiter) allow(key string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 	now := rl.now()
+	// Evict idle buckets opportunistically. Without this the map grows by one
+	// permanent entry per distinct key ever seen — and since keys come from
+	// client-controlled input on a public endpoint, that was a slow
+	// memory-exhaustion vector on its own. A bucket that has been idle long
+	// enough to have fully refilled carries no state worth keeping.
+	idleFull := time.Duration(float64(time.Minute) * 2)
+	for k, b := range rl.bucket {
+		if k != key && now.Sub(b.last) > idleFull {
+			delete(rl.bucket, k)
+		}
+	}
 	b, ok := rl.bucket[key]
 	if !ok {
 		rl.bucket[key] = &tokenBucket{tokens: float64(rl.perMin) - 1, last: now}


### PR DESCRIPTION
Four findings across the two internet-facing, unauthenticated services.

### ME-9 — a failed claim permanently burned a label
The claim committed the label row **before** publishing DNS, so an `EnsureA` failure returned 500 with the row already inserted. The caller never receives the token, so that label can never heartbeat and is invisible to the reaper (`moved_at` stays NULL) — yet it still consumes one of the source IP's 26 collision suffixes and one slot in the claimer's per-email cap. Sustained DNS errors would permanently exhaust an IP's label space and silently eat a user's quota, needing manual DB cleanup.

The reservation is now rolled back with a hard `DeleteLabel` when DNS fails. **`RevokeLabel` is deliberately not used**: a revoked name is burned by design, so revoking here would leak a suffix on every transient outage — the exact damage being fixed.

### ME-13 — global mutex held across two remote DNS calls
The same handler held a single process-wide mutex across both Cloudflare round-trips (15s timeout each), so every claim fleet-wide serialised behind the slowest DNS publish — a few claims/sec at best, and a slow CF day stalled all of them.

The lock now covers only the check-then-act it exists for (collision scan + insert, both DB-local) and is released before any remote call.

**These two findings interact**, which is worth noting: fixing ME-9 the obvious way (publish DNS *before* the insert) would have forced DNS back inside the lock and undone ME-13. Reserving first and rolling back on failure satisfies both.

### ME-10 — /v1/register had no per-IP bound
Unauthenticated, and it makes the service **send mail through its own authenticated, reputation-clean relay**. The only throttle was a 60s resend gap keyed on the *email*, which stops a double-click and nothing else: a caller could mail one victim every 60s indefinitely (harassment the service is the vector for), or fan out across millions of addresses using it as a spam relay.

Added a per-source-IP cap over a sliding hour, checked *before* any code is minted or stored. The key is the same address label derivation already trusts (TCP handshake, rewritten at the CF edge) — not a client-settable header.

### LO-16 — unbounded ACME challenge records
`SetChallenge` is add-only by design (a wildcard cert needs apex + wildcard challenges live at the same name simultaneously), and nothing bounded it, so a valid token holder could script distinct values into thousands of TXT records in the shared zone. Capped in **both** DNS backends.

### support-claim (ME-4 / OPT LO-14) — unauthenticated OOM
`clientIP` trusted `X-Forwarded-For` from **any** peer, so rotating the header both bypassed the 30/min cap on the open `POST /claims` *and* allocated a permanent rate-limit bucket per distinct value. Combined with a claim store that had no entry ceiling (14-day TTL, ~16 KiB each), an unauthenticated caller could grow the heap until the process was OOM-killed — taking down the service support depends on. Nothing guarantees this service is proxy-fronted, and :8088 is directly reachable.

Fixed all three legs: XFF honoured only from a loopback peer (mirroring `hostedsvc/realip.go`), idle buckets evicted, and the store refuses new claims at capacity with 503 rather than growing without bound.

### Test plan
- [x] `go build ./...`, `go vet` clean; `go test ./...` and `support-claim` — **0 failures**
- [x] **XFF tests verified both ways**: they fail with the trust boundary removed (spoofed header becomes the rate-limit key, cap bypassed) and pass with it
- [x] Eviction test: 500 distinct keys, then one call after idle sweeps the map back to ≤2
- [x] Store-cap test: `put` past capacity returns `errStoreFull` rather than growing

Note: CI's Playwright E2E may show cancelled — the job is globally serialized on `group: e2e-port-4173`, and with several PRs in flight GitHub cancels the queued one. That is contention, not a test failure (`conclusion: cancelled`, zero failed steps).

Refs `docs/security/code-review-2026-08-08.md` ME-4/9/10/LO-16 and the optimization review ME-13/LO-14.
