### PR TITLE
perf: bound the log-stream buffer, back off idle polling, index the stale scans (OPT ME-12, LO-1, LO-3, LO-10)

### DIFF
--- a/panel-api/internal/api/mailbox_sendas.go
+++ b/panel-api/internal/api/mailbox_sendas.go
@@ -92,11 +92,18 @@ func (h *sendAsHandler) list(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
+	// Batch-load the grantor mailboxes in one query instead of a FindByID per
+	// row (JAB-147 pattern; mailboxMapByID already exists for exactly this).
+	grantorIDs := make([]string, 0, len(rows))
+	for _, d := range rows {
+		grantorIDs = append(grantorIDs, d.GrantorMailboxID)
+	}
+	grantorByID := mailboxMapByID(ctx, h.cfg.Mailboxes, grantorIDs)
+
 	out := make([]sendAsGrantorResponse, 0, len(rows))
 	for _, d := range rows {
-		gr, gErr := h.cfg.Mailboxes.FindByID(ctx, d.GrantorMailboxID)
 		grantorEmail := ""
-		if gErr == nil {
+		if gr := grantorByID[d.GrantorMailboxID]; gr != nil {
 			grantorEmail = gr.EmailCached
 		}
 		out = append(out, sendAsGrantorResponse{

--- a/panel-api/internal/db/migrations/000256_domain_stale_scan_indexes.down.sql
+++ b/panel-api/internal/db/migrations/000256_domain_stale_scan_indexes.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE domains
+  DROP INDEX idx_domains_ghost_checked_at,
+  DROP INDEX idx_domains_registrar_checked_at;

--- a/panel-api/internal/db/migrations/000256_domain_stale_scan_indexes.up.sql
+++ b/panel-api/internal/db/migrations/000256_domain_stale_scan_indexes.up.sql
@@ -1,0 +1,16 @@
+-- Index the two per-tick staleness scans over `domains`.
+--
+-- ListForGhostCheck filters on `ghost_checked_at` alone, but the only index
+-- covering that column is idx_domains_ghost_state (ghost_state,
+-- ghost_checked_at) — its LEFTMOST column never appears in the predicate, so
+-- MariaDB cannot use it and the query full-scans `domains` on every tick.
+-- ListForRegistrarRefresh filters the same way on `registrar_checked_at`,
+-- which had no index at all.
+--
+-- Both queries are `col IS NULL OR col < ?` ordered by the same column, which
+-- a single-column index serves for both the range and the sort.
+-- idx_domains_ghost_state is left in place: it still serves lookups that DO
+-- filter on ghost_state.
+ALTER TABLE domains
+  ADD INDEX idx_domains_ghost_checked_at (ghost_checked_at),
+  ADD INDEX idx_domains_registrar_checked_at (registrar_checked_at);

--- a/panel-ui/src/components/TasksIndicator.tsx
+++ b/panel-ui/src/components/TasksIndicator.tsx
@@ -1,7 +1,8 @@
 // TasksIndicator — topbar icon showing long-running operations in flight
 // (panel/system-package updates, backups, malware scans). Polls
-// /admin/active-tasks every 8s; spins + badges the count when tasks are
-// active, and lists them in a dropdown. Admin shell only.
+// /admin/active-tasks every 3s WHILE tasks are running and every 30s when
+// idle; spins + badges the count when tasks are active, and lists them in a
+// dropdown. Admin shell only.
 import { useTranslation } from "react-i18next";
 import { Badge, Button, Dropdown, Empty, Space, Tag, Tooltip, Typography } from "antd";
 import type { MenuProps } from "antd";
@@ -40,9 +41,14 @@ export function TasksIndicator() {
       const { data } = await apiClient.get<ActiveTasksResponse>("/admin/active-tasks");
       return data;
     },
-    // Poll every 3s so a task that starts (or finishes) shows/clears
-    // promptly. Cheap: two DB queries + one systemctl glob.
-    refetchInterval: 3000,
+    // Adaptive cadence. A flat 3s meant ~28k requests a day per always-open
+    // admin tab for a component that renders null ~99% of the time. Poll fast
+    // only while something is actually in flight — that is when "shows/clears
+    // promptly" matters — and back off to 30s when idle, which still notices a
+    // task an operator just started well within a human's attention span.
+    // (The previous comment claimed 8s; the code did 3s. Now they agree.)
+    refetchInterval: (query) =>
+      (query.state.data?.tasks?.length ?? 0) > 0 ? 3000 : 30000,
     retry: false,
   });
 

--- a/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
+++ b/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
@@ -16,6 +16,18 @@ interface LogStreamModalProps {
 // Trim a single trailing CR/LF (or both) — accommodates servers that
 // send "line\n", "line\r\n", or "line" interchangeably. Keeps inner
 // newlines untouched in case a single frame carries a multi-line block.
+// The stream is "recent lines", not an archive: without a ceiling every frame
+// appended to React state and each render re-joined the WHOLE array, so cost
+// grew quadratically over the stream's lifetime. On a moderately busy domain
+// (~10 lines/s) a 15-minute stream reaches ~9k lines and the tab janks within
+// minutes while memory keeps climbing. Keep the newest MAX_LOG_LINES, which is
+// far more than fits on screen and matches what the feature advertises.
+const MAX_LOG_LINES = 2000;
+
+function capLogLines(lines: string[]): string[] {
+  return lines.length > MAX_LOG_LINES ? lines.slice(-MAX_LOG_LINES) : lines;
+}
+
 const stripTrailingNewline = (s: string): string => {
   if (typeof s !== "string") return s;
   if (s.endsWith("\r\n")) return s.slice(0, -2);
@@ -145,10 +157,16 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
         } else {
           // Strip trailing CR/LF so the render-time join("\n") doesn't
           // double-space lines that arrived with their own newline.
-          setLogs(prev => [...prev, stripTrailingNewline(logLine)]);
+          setLogs(prev => capLogLines([...prev, stripTrailingNewline(logLine)]));
         }
       } else {
         pausedLogsRef.current.push(stripTrailingNewline(event.data));
+        // The paused buffer needs the same ceiling: a stream paused on a busy
+        // log otherwise grows unbounded in memory and then floods the view in
+        // one go when the operator resumes.
+        if (pausedLogsRef.current.length > MAX_LOG_LINES) {
+          pausedLogsRef.current = pausedLogsRef.current.slice(-MAX_LOG_LINES);
+        }
       }
     };
 
@@ -190,7 +208,7 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
 
     if (!newPaused && pausedLogsRef.current.length > 0) {
       // Resume: add paused logs to display
-      setLogs(prev => [...prev, ...pausedLogsRef.current]);
+      setLogs(prev => capLogLines([...prev, ...pausedLogsRef.current]));
       pausedLogsRef.current = [];
     }
   };


### PR DESCRIPTION
Four findings from the optimization review.

### ME-12 — log-stream modal grew without bound, O(n²) re-render
Every WebSocket frame appended to React state with no ceiling, and each render re-joined the **entire** array — cost grew quadratically over the stream's lifetime. On a moderately busy domain (~10 lines/s) a 15-minute stream reaches ~9k lines: the tab janks within minutes while memory keeps climbing.

Buffer now keeps the newest 2000 lines — far more than fits on screen, and it matches what the feature advertises ("recent lines").

The cap is applied on **all three** paths that grow the buffer: live append, the paused buffer, and the flush on resume. Capping only the live path (the obvious fix) would have left a paused stream on a busy log unbounded, then flooded the view on resume.

### LO-10 — TasksIndicator polled 3s from every admin page
~28k requests/day per always-open admin tab, for a component that renders `null` about 99% of the time. Its comment claimed 8s; the code said 3000.

Now adaptive: 3s **while a task is actually in flight** — which is when "shows/clears promptly" matters — backing off to 30s when idle, which still notices a newly started task well within a human's attention span. Comment and code now agree.

### LO-1 — send-as list N+1
Resolved each delegation's grantor with a per-row `FindByID`, though `mailboxMapByID` (JAB-147) exists for exactly this. Batched into one query.

### LO-3 — two per-tick scans were full table scans
`ListForGhostCheck` filters on `ghost_checked_at` alone, but the only index covering it is `idx_domains_ghost_state (ghost_state, ghost_checked_at)` — its **leftmost column never appears in the predicate**, so MariaDB can't use it. `ListForRegistrarRefresh` filters the same way on `registrar_checked_at`, which had no index at all.

Migration `000256` adds a single-column index for each, serving both the range and the `ORDER BY`. `idx_domains_ghost_state` is left in place — it still serves lookups that *do* filter on `ghost_state`.

### Test plan
- [x] `go build ./...`, `go vet ./...` clean; `go test ./...` — **0 failures**
- [x] `npx tsc -b` clean; `vitest` 221/221 pass
- [x] Migration numbering checked against the current head (000255) before adding 000256
- [ ] Migration applies on a box with data (index adds on `domains` are online in MariaDB 10.11+, but worth confirming on a large table)

Note: CI's Playwright E2E may show cancelled — the job is globally serialized on `group: e2e-port-4173`, and with several PRs in flight GitHub cancels the queued one. That is contention, not a test failure.

Refs the optimization review at commit `735d7445`.
