### PR TITLE
feat(php): default the full extension set for every panel-installed PHP version

### DIFF
--- a/panel-agent/internal/commands/php_version_install.go
+++ b/panel-agent/internal/commands/php_version_install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,8 +60,21 @@ func isFPMAlreadyInstalled(version string) bool {
 // phpRequiredExts are the extension packages every supported one-click app
 // (WordPress, Drupal, Joomla, MediaWiki) and most migrated sites need. mysql
 // provides mysqli + pdo_mysql; a version installed without it 500s on every
-// mysqli_connect() (GH #531).
-var phpRequiredExts = []string{"mysql", "mbstring", "zip", "gd", "curl", "xml"}
+// mysqli_connect() (GH #531). intl is required too: idn_to_ascii backs IDN
+// handling in commercial panels (WiseCP) and Laravel/Symfony apps, and every
+// sury build 7.4–8.5 ships php<v>-intl.
+//
+// Keep this list and phpOptionalExts in sync with install.sh's
+// install_base_packages + provision_php_extensions — install.sh converges the
+// fleet on `jabali update`; these lists close the gap for versions added via
+// the panel between updates.
+var phpRequiredExts = []string{"mysql", "mbstring", "zip", "gd", "curl", "xml", "intl"}
+
+// phpOptionalExts are installed when the apt archive for the version has them,
+// and skipped otherwise (packaging drifts between sury versions — 8.5 folds
+// opcache into -common). redis + igbinary back WordPress object caching
+// (GH #606); sqlite3 backs restored Nextcloud instances (JAB-39).
+var phpOptionalExts = []string{"bcmath", "opcache", "redis", "igbinary", "sqlite3"}
 
 // isPkgInstalled reports whether a dpkg package is installed and fully
 // configured. Used to backfill only the missing required extensions instead of
@@ -73,36 +87,85 @@ func isPkgInstalled(pkg string) bool {
 	return strings.Contains(string(out), "install ok installed")
 }
 
-// ensureRequiredPHPExts installs any mandatory extension package (php<v>-mysql
-// etc.) that is missing for an ALREADY-installed version. isFPMAlreadyInstalled
+// ensureRequiredPHPExts installs any extension package (php<v>-mysql etc.)
+// that is missing for an ALREADY-installed version. isFPMAlreadyInstalled
 // only checks for php<v> on PATH, so a version pulled in as a dependency,
 // apt-installed by hand without -mysql, or left partial by an interrupted
 // install can satisfy that check yet still lack mysqli — and a migrated domain
 // binding to its pool then 500s (GH #531). dpkg-checks each package first so a
 // complete version is a no-op (no apt invocation).
+//
+// Required extensions failing to install fails the call; optional ones only
+// log. When anything was installed, tenant FPM masters pinned to the version
+// are reloaded so the running runtime actually gains the extension.
+// Seams for ensureRequiredPHPExts tests — the function's batching and
+// failure semantics matter (a flaky optional package must never fail the
+// call) and the real implementations shell out to dpkg/apt/systemctl.
+var (
+	isPkgInstalledFunc        = isPkgInstalled
+	probePackageFunc          = probePackage
+	installPackagesFunc       = installPackages
+	reloadVersionFPMUnitsFunc = reloadVersionFPMUnits
+)
+
 func ensureRequiredPHPExts(ctx context.Context, version string) error {
-	var missing []string
-	for _, ext := range phpRequiredExts {
-		pkg := fmt.Sprintf("php%s-%s", version, ext)
-		if isPkgInstalled(pkg) {
-			continue
+	missingPkgs := func(exts []string) []string {
+		var missing []string
+		for _, ext := range exts {
+			pkg := fmt.Sprintf("php%s-%s", version, ext)
+			if isPkgInstalledFunc(pkg) {
+				continue
+			}
+			if !probePackageFunc(pkg) {
+				continue // not in apt sources for this version — mirror base-install skip
+			}
+			missing = append(missing, pkg)
 		}
-		if !probePackage(pkg) {
-			continue // not in apt sources for this version — mirror base-install skip
-		}
-		missing = append(missing, pkg)
+		return missing
 	}
-	if len(missing) == 0 {
+
+	install := func(pkgs []string) error {
+		done := make(chan error, 1)
+		go func() { done <- installPackagesFunc(pkgs) }()
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout installing %v", pkgs)
+		case err := <-done:
+			return err
+		}
+	}
+
+	required := missingPkgs(phpRequiredExts)
+	optional := missingPkgs(phpOptionalExts)
+	if len(required) == 0 && len(optional) == 0 {
 		return nil
 	}
-	done := make(chan error, 1)
-	go func() { done <- installPackages(missing) }()
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("timeout installing %v", missing)
-	case err := <-done:
-		return err
+
+	// Required and optional install separately so a flaky optional package
+	// (redis, sqlite3, …) can never fail the call for a version whose required
+	// runtime is intact.
+	if len(required) > 0 {
+		if err := install(required); err != nil {
+			return err
+		}
 	}
+	if len(optional) > 0 {
+		if err := install(optional); err != nil {
+			slog.Warn("optional PHP extensions failed to install", "version", version, "err", err)
+			optional = nil
+		}
+	}
+
+	// The dpkg postinst enables the new inis, but tenant masters already
+	// running on this version keep the old runtime until reloaded. Best-effort:
+	// a master that fails reload is a unit problem, not an extension problem.
+	if len(required) > 0 || len(optional) > 0 {
+		if _, failures := reloadVersionFPMUnitsFunc(ctx, version); len(failures) > 0 {
+			slog.Warn("FPM reload after extension backfill failed for some units",
+				"version", version, "failures", strings.Join(failures, "; "))
+		}
+	}
+	return nil
 }
 
 // ensureRequiredPHPExtsFunc is a seam for tests.
@@ -291,12 +354,12 @@ func phpVersionInstallHandler(ctx context.Context, params json.RawMessage) (any,
 		}
 	}
 
-	// Build package list. mysql + mbstring + xml + curl + gd + zip are
-	// mandatory: every supported one-click app (WordPress, Drupal,
-	// Joomla, MediaWiki) refuses to install without them, and the
-	// operator sees an opaque "missing MySQL extension" error months
-	// later instead of a clear failure here. intl/bcmath/opcache are
-	// optional (nice-to-have, distros sometimes bundle into -common).
+	// Build package list. phpRequiredExts are mandatory: every supported
+	// one-click app (WordPress, Drupal, Joomla, MediaWiki) refuses to
+	// install without them, and the operator sees an opaque "missing
+	// MySQL extension" error months later instead of a clear failure
+	// here. phpOptionalExts are probed per version (distros sometimes
+	// bundle them into -common).
 	required := []string{
 		fmt.Sprintf("php%s-fpm", p.Version),
 		fmt.Sprintf("php%s-cli", p.Version),
@@ -320,9 +383,8 @@ func phpVersionInstallHandler(ctx context.Context, params json.RawMessage) (any,
 		}
 	}
 
-	optionalNames := []string{"intl", "bcmath", "opcache"}
 	var optional []string
-	for _, ext := range optionalNames {
+	for _, ext := range phpOptionalExts {
 		pkg := fmt.Sprintf("php%s-%s", p.Version, ext)
 		if probePackage(pkg) {
 			optional = append(optional, pkg)

--- a/panel-agent/internal/commands/php_version_install_test.go
+++ b/panel-agent/internal/commands/php_version_install_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,6 +96,127 @@ func TestPHPVersionInstall_AlreadyInstalled_ExtEnsureError(t *testing.T) {
 	_, err := phpVersionInstallHandler(context.Background(), params)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ensure required extensions")
+}
+
+// The agent's extension lists and install.sh's provision_php_extensions must
+// name the same set. install.sh converges every installed version on each
+// `jabali update` (04:30 fleet-wide); the agent closes the same-day window for
+// versions added via the panel. If the sets drift, a version behaves
+// differently depending on which path touched it last.
+func TestPHPExtListsMatchInstallSh(t *testing.T) {
+	t.Parallel()
+
+	b, err := os.ReadFile(filepath.Join("..", "..", "..", "install.sh"))
+	require.NoError(t, err, "read repo install.sh")
+
+	var quoted string
+	for _, line := range strings.Split(string(b), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(trimmed, `local exts="`); ok {
+			quoted = strings.TrimSuffix(rest, `"`)
+			break
+		}
+	}
+	require.NotEmpty(t, quoted, `install.sh provision_php_extensions 'local exts="…"' line not found`)
+
+	shSet := map[string]bool{}
+	for _, e := range strings.Fields(quoted) {
+		shSet[e] = true
+	}
+	goSet := map[string]bool{}
+	for _, e := range append(append([]string{}, phpRequiredExts...), phpOptionalExts...) {
+		goSet[e] = true
+	}
+	assert.Equal(t, shSet, goSet,
+		"phpRequiredExts+phpOptionalExts must match install.sh provision_php_extensions")
+}
+
+// intl is required, not optional: idn_to_ascii backs IDN handling in
+// commercial panels (WiseCP) and framework apps, and a version without it
+// passes install yet fails those apps at runtime.
+func TestPHPRequiredExtsIncludeIntl(t *testing.T) {
+	t.Parallel()
+	assert.Contains(t, phpRequiredExts, "intl")
+}
+
+func setExtSeams(t *testing.T, installed func(string) bool, probe func(string) bool,
+	install func([]string) error, reload func(context.Context, string) ([]string, []string)) {
+	t.Helper()
+	origInstalled, origProbe := isPkgInstalledFunc, probePackageFunc
+	origInstall, origReload := installPackagesFunc, reloadVersionFPMUnitsFunc
+	t.Cleanup(func() {
+		isPkgInstalledFunc, probePackageFunc = origInstalled, origProbe
+		installPackagesFunc, reloadVersionFPMUnitsFunc = origInstall, origReload
+	})
+	isPkgInstalledFunc, probePackageFunc = installed, probe
+	installPackagesFunc, reloadVersionFPMUnitsFunc = install, reload
+}
+
+// A flaky optional package (redis, sqlite3, …) must never fail the backfill —
+// only a required package may. And once anything installed, the version's
+// tenant masters must be reloaded or the running runtime never gains the
+// extension.
+func TestEnsureRequiredPHPExts_OptionalFailureNotFatal(t *testing.T) {
+	var batches [][]string
+	reloaded := false
+	setExtSeams(t,
+		func(string) bool { return false }, // nothing installed
+		func(string) bool { return true },  // everything in apt
+		func(pkgs []string) error {
+			batches = append(batches, pkgs)
+			for _, p := range pkgs {
+				if strings.HasSuffix(p, "-redis") {
+					return fmt.Errorf("apt boom on optional")
+				}
+			}
+			return nil
+		},
+		func(context.Context, string) ([]string, []string) {
+			reloaded = true
+			return []string{"jabali-fpm@bob.service"}, nil
+		},
+	)
+
+	err := ensureRequiredPHPExts(context.Background(), "8.2")
+	require.NoError(t, err, "optional install failure must not fail the call")
+	require.Len(t, batches, 2, "required and optional must install as separate apt batches")
+	assert.Contains(t, batches[0], "php8.2-intl", "intl belongs to the required batch")
+	assert.Contains(t, batches[1], "php8.2-redis")
+	assert.True(t, reloaded, "masters must reload after the required batch landed")
+}
+
+func TestEnsureRequiredPHPExts_RequiredFailureFatal(t *testing.T) {
+	reloaded := false
+	setExtSeams(t,
+		func(string) bool { return false },
+		func(string) bool { return true },
+		func(pkgs []string) error { return fmt.Errorf("apt boom") },
+		func(context.Context, string) ([]string, []string) {
+			reloaded = true
+			return nil, nil
+		},
+	)
+
+	err := ensureRequiredPHPExts(context.Background(), "8.2")
+	require.Error(t, err)
+	assert.False(t, reloaded, "no reload when the required batch failed")
+}
+
+func TestEnsureRequiredPHPExts_CompleteVersionIsNoop(t *testing.T) {
+	setExtSeams(t,
+		func(string) bool { return true }, // everything already installed
+		func(string) bool { return true },
+		func(pkgs []string) error {
+			t.Errorf("apt must not run for a complete version, got %v", pkgs)
+			return nil
+		},
+		func(context.Context, string) ([]string, []string) {
+			t.Error("no reload for a no-op backfill")
+			return nil, nil
+		},
+	)
+
+	require.NoError(t, ensureRequiredPHPExts(context.Background(), "8.2"))
 }
 
 func TestVersionSupportValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

A PHP version added via the panel got fewer default extensions than install.sh gives the base version: `intl` was only optional, and `redis`/`igbinary`/`sqlite3` were absent entirely until the nightly `jabali update` ran `provision_php_extensions`. Same-day result: an app needing `idn_to_ascii` (WiseCP-class commercial panels, Laravel/Symfony) or WP redis object caching lands on an incomplete runtime until 04:30.

Surfaced while diagnosing a WiseCP install on wisecp.jabali.site — that box turned out fine (all modules loaded; the red requirements table was WiseCP's own detection failing under our hardening), but the audit exposed the list drift between install.sh and the agent.

## Changes

- **`intl` promoted to `phpRequiredExts`** — every sury build 7.4–8.5 ships `php<v>-intl`. Behavior note: the fresh-install path hard-errors when a *required* ext is missing from apt sources, so a repo genuinely lacking `-intl` now fails loudly instead of soft-skipping. That is the intent — required means required.
- **Optional set aligned with install.sh**: `bcmath opcache redis igbinary sqlite3` (was `intl bcmath opcache`).
- **Backfill widened**: the already-installed path now also installs missing optional exts. Required failures stay fatal; optional failures only log — a flaky redis package must not fail a healthy version's install call. Separate apt batches enforce that.
- **Reload after backfill**: when the backfill installed anything, the version's tenant FPM masters (`jabali-fpm@*` pinned to it) reload via `reloadVersionFPMUnits`, so running runtimes actually gain the extension instead of waiting for the next restart.
- **Drift guard test**: parses install.sh's `provision_php_extensions` ext list and pins set equality with `phpRequiredExts + phpOptionalExts`, so the two paths can't diverge silently again.

## Test plan

- [x] `go build ./panel-agent/...`, `go vet`
- [x] New unit tests: list-sync guard, intl-required pin, optional-failure-not-fatal, required-failure-fatal, complete-version-noop (incl. no spurious reload)
- [x] Full `go test ./panel-agent/...` — 0 FAIL

GH #531 follow-up; complements install.sh `provision_php_extensions` (JAB-39).