### PR TITLE
fix(security): stop trusting loopback TCP for internal routes, warn when replay defense is off (SEC ME-2, LO-4)

### DIFF
--- a/panel-api/internal/api/ips_test.go
+++ b/panel-api/internal/api/ips_test.go
@@ -435,11 +435,15 @@ func TestRequireLocalhost_Accept(t *testing.T) {
 		c.String(http.StatusOK, "ok")
 	})
 	req := httptest.NewRequest("GET", "/internal", nil)
-	req.RemoteAddr = "127.0.0.1:1234"
+	// Unix-socket peer ("@" is what net/http sets), which is the production
+	// transport for internal routes. Loopback TCP is deliberately no longer
+	// accepted by default — on a multi-tenant box any tenant process can
+	// bind 127.0.0.1, so it is not a trust boundary.
+	req.RemoteAddr = "@"
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
-		t.Errorf("loopback got %d, want 200; body=%s", w.Code, w.Body.String())
+		t.Errorf("unix-socket peer got %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/panel-api/internal/api/notifications_internal_test.go
+++ b/panel-api/internal/api/notifications_internal_test.go
@@ -44,7 +44,10 @@ func TestInternalEnqueue_Happy(t *testing.T) {
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.RemoteAddr = "127.0.0.1:1234"
+	// Internal routes are called by the agent over the unix socket in
+	// production; "@" is what net/http sets for a unix peer. Loopback TCP is
+	// no longer trusted by default (see RequireLocalhost).
+	req.RemoteAddr = "@"
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
@@ -65,7 +68,10 @@ func TestInternalEnqueue_MissingQueueReturns503(t *testing.T) {
 	r := newTestRouter(t, nil)
 	body, _ := json.Marshal(map[string]any{"event_kind": "service.down", "severity": "error", "title": "t"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", bytes.NewReader(body))
-	req.RemoteAddr = "127.0.0.1:1234"
+	// Internal routes are called by the agent over the unix socket in
+	// production; "@" is what net/http sets for a unix peer. Loopback TCP is
+	// no longer trusted by default (see RequireLocalhost).
+	req.RemoteAddr = "@"
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
@@ -77,7 +83,10 @@ func TestInternalEnqueue_BadEventKind(t *testing.T) {
 	r := newTestRouter(t, q)
 	body, _ := json.Marshal(map[string]any{"event_kind": "nope", "severity": "error", "title": "t"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", bytes.NewReader(body))
-	req.RemoteAddr = "127.0.0.1:1234"
+	// Internal routes are called by the agent over the unix socket in
+	// production; "@" is what net/http sets for a unix peer. Loopback TCP is
+	// no longer trusted by default (see RequireLocalhost).
+	req.RemoteAddr = "@"
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)
@@ -105,7 +114,10 @@ func TestInternalEnqueue_TitleTooLong(t *testing.T) {
 	}
 	body, _ := json.Marshal(map[string]any{"event_kind": "service.down", "severity": "error", "title": string(title)})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/notifications/enqueue", bytes.NewReader(body))
-	req.RemoteAddr = "127.0.0.1:1234"
+	// Internal routes are called by the agent over the unix socket in
+	// production; "@" is what net/http sets for a unix peer. Loopback TCP is
+	// no longer trusted by default (see RequireLocalhost).
+	req.RemoteAddr = "@"
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusBadRequest, rec.Code)

--- a/panel-api/internal/middleware/automation_hmac.go
+++ b/panel-api/internal/middleware/automation_hmac.go
@@ -2,11 +2,11 @@
 //
 // Authorization header format:
 //
-//   Authorization: Jabali-HMAC kid=<token-id>, ts=<unix>, sig=<hex>
+//	Authorization: Jabali-HMAC kid=<token-id>, ts=<unix>, sig=<hex>
 //
 // Server recomputes:
 //
-//   sig = hex(HMAC_SHA256(secret, METHOD || "\n" || PATH || "\n" || ts || "\n" || sha256(BODY)))
+//	sig = hex(HMAC_SHA256(secret, METHOD || "\n" || PATH || "\n" || ts || "\n" || sha256(BODY)))
 //
 // Constant-time compares against the header sig. ts must be within a
 // 5-minute window of the server clock; signatures already seen in
@@ -23,10 +23,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -72,11 +74,36 @@ func AutomationToken(c *gin.Context) *models.AutomationToken {
 //
 // Failure cases all 401 with a generic JSON error — no information
 // leak about why a particular request failed.
-// rdb is nullable. When nil, replay defense is skipped + a single
-// info log fires at first request (operator can decide whether to
-// wire Redis or accept the timestamp-only window). On a fresh
-// install Redis is always present (M14 dispatcher requires it),
-// so production paths exercise the SETNX gate.
+// rdb is nullable. When nil, replay defense is skipped and a single WARN
+// fires at the first signed request — see warnNoReplayStore; the log the
+// original comment promised did not actually exist, so a Redis-less panel ran
+// with the gate off and no signal. On a fresh install Redis is always present
+// (the M14 dispatcher requires it), so production paths exercise the SETNX
+// gate.
+// noReplayStoreWarnOnce makes the "replay defense is OFF" warning fire once
+// per process rather than per request.
+var noReplayStoreWarnOnce sync.Once
+
+// warnNoReplayStore announces that the automation API is serving signed
+// requests with NO replay protection.
+//
+// The doc comment above has always promised this log; it never existed, so a
+// Redis-less panel ran with the gate silently off and the operator had no
+// signal at all. Worth saying out loud because the failure is invisible and
+// asymmetric: with Redis present a transient error fails CLOSED (503 —
+// "a missing replay store is a security regression, not best effort"), yet
+// with no Redis configured the same protection was skipped without comment.
+// Anyone who captures one valid signed request can replay it freely inside
+// the ~5-minute timestamp window (e.g. re-firing
+// POST /automation/users/:id/disable).
+func warnNoReplayStore() {
+	noReplayStoreWarnOnce.Do(func() {
+		slog.Warn("automation API: replay defense DISABLED — no Redis configured; " +
+			"a captured signed request can be replayed within the timestamp window. " +
+			"Configure Redis to enable the SETNX replay gate.")
+	})
+}
+
 func RequireAutomationHMAC(repo repository.AutomationTokenRepository, key *ssokey.Key, rdb *redis.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if repo == nil || key == nil {
@@ -193,6 +220,9 @@ func RequireAutomationHMAC(repo repository.AutomationTokenRepository, key *ssoke
 		// security regression, not 'best effort'. The middleware
 		// returns 503 so the caller knows the auth substrate is
 		// degraded rather than silently dropping the gate.
+		if rdb == nil {
+			warnNoReplayStore()
+		}
 		if rdb != nil {
 			rkey := fmtReplayKey(kid, sig)
 			rctx, rcancel := context.WithTimeout(c.Request.Context(), 1*time.Second)

--- a/panel-api/internal/middleware/localhost.go
+++ b/panel-api/internal/middleware/localhost.go
@@ -3,28 +3,40 @@ package middleware
 import (
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/gin-gonic/gin"
 )
 
-// RequireLocalhost rejects every request whose remote address is not on
-// the loopback interface OR delivered over the local unix socket. Used
-// by panel-api endpoints the agent (or any other local daemon) calls —
-// the SPA must never reach them. This is a defence-in-depth check on
-// top of the bind-level expectation that panel-api binds to 127.0.0.1
-// (legacy) or /run/jabali-panel/api.sock (M25).
+// allowTCPInternalRoutes reports whether internal routes may be served over a
+// TCP listener, where the kernel gives us no peer identity.
 //
-// Implementation notes:
-//   - For TCP peers, split host:port from RemoteAddr and accept only
-//     when net.IP.IsLoopback() returns true.
-//   - For unix-socket peers, Go's net/http sets RemoteAddr to "@" (the
-//     empty abstract address) since unix sockets don't have a remote
-//     IP. A unix-socket connection is localhost by definition — the
-//     peer process has to be on the same host (or in a mount namespace
-//     that bind-mounted the socket, which is equivalent). Accept these.
-//   - Empty RemoteAddr is also treated as unix-socket for safety: some
-//     adapters drop the "@" sentinel. The net effect is the same since
-//     any non-unix peer through an HTTP server will have a RemoteAddr.
+// Opt-in on purpose, and read per call rather than cached at init so a test
+// (and an operator restarting with the variable set) sees the current value.
+// The default is refuse: production binds the unix socket, and silently
+// trusting loopback on a multi-tenant host is exactly the exposure this gate
+// exists to prevent.
+func allowTCPInternalRoutes() bool {
+	return os.Getenv("JABALI_ALLOW_TCP_INTERNAL") == "1"
+}
+
+// RequireLocalhost gates the routes only a local daemon (the agent) may call —
+// /api/v1/internal/* and the malware ingest — so the SPA and the public
+// internet can never reach them.
+//
+// The gate is layered, strongest first:
+//
+//  1. Proxy headers (X-Forwarded-*, X-Real-IP) are positive proof the request
+//     came through nginx, which shares the same unix socket the agent uses.
+//     Their presence is an immediate reject.
+//  2. SO_PEERCRED: ask the kernel which uid opened the connection. Set at
+//     connect time, unforgeable, unproxyable. root passes, anything else (nginx
+//     is www-data) is rejected. This is the real check.
+//  3. No peer credentials means a TCP listener. Loopback is NOT a trust
+//     boundary on a multi-tenant box — every tenant process can bind it — so
+//     these are refused unless the operator opts in via
+//     JABALI_ALLOW_TCP_INTERNAL=1. Only then does the loopback address check
+//     below apply.
 func RequireLocalhost() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// A request that arrived through nginx is NOT a local caller, even
@@ -52,19 +64,48 @@ func RequireLocalhost() gin.HandlerFunc {
 		// Ask the kernel who actually opened this socket. SO_PEERCRED is set
 		// at connect time and cannot be forged or proxied, so this is the
 		// structural answer to "is this really the agent?" -- nginx runs as
-		// www-data and can never satisfy it. Falls through when the peer is
-		// unknown (loopback TCP, or ConnContext unwired), leaving the checks
-		// below to decide.
-		if !requirePeerRoot(c) {
+		// www-data and can never satisfy it.
+		if uid, ok := PeerUID(c); ok {
+			if uid != rootUID {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "localhost_only"})
+				return
+			}
+			c.Next()
 			return
 		}
 
+		// No peer credentials. Two very different cases hide here, and they
+		// must not be treated alike.
 		remote := c.Request.RemoteAddr
-		// Unix-socket accept: RemoteAddr is "@" or "" (see net/http
-		// httputil docs). Accept — the connection is by definition
-		// local to this host.
+
+		// (a) Unix socket whose credentials we could not read — RemoteAddr is
+		// "@" or "" (net/http sets no address for unix conns; some adapters
+		// drop the "@" sentinel). Go ALWAYS sets a real host:port for TCP, so
+		// a remote attacker cannot manufacture this case: it really is a local
+		// unix peer. Accept, as before. This keeps the agent working if
+		// ConnContext is ever unwired by a refactor.
 		if remote == "" || remote == "@" {
 			c.Next()
+			return
+		}
+
+		// (b) A real TCP peer. Loopback is NOT a trust boundary on a
+		// multi-tenant box — every local process (a tenant's PHP-FPM pool,
+		// their cron jobs, an SSH shell) can connect to 127.0.0.1. Accepting
+		// "any loopback peer" let any of them POST unauthenticated to
+		// /api/v1/internal/* — flooding admin notifications to bury real
+		// alerts, or forging malware/quarantine rows pointing at arbitrary
+		// paths. The unix socket is the production transport (ADR-0050), so
+		// refuse by default and let a legacy [host]:port deployment opt in
+		// knowingly.
+		if !allowTCPInternalRoutes() {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error": "localhost_only",
+				"detail": "internal routes require the unix socket (peer credentials); " +
+					"this panel is bound to TCP, where any local process could call them. " +
+					"Bind server.addr to unix:/run/jabali-panel/api.sock, or set " +
+					"JABALI_ALLOW_TCP_INTERNAL=1 to accept the risk.",
+			})
 			return
 		}
 		host, _, err := net.SplitHostPort(remote)

--- a/panel-api/internal/middleware/localhost_proxy_test.go
+++ b/panel-api/internal/middleware/localhost_proxy_test.go
@@ -67,13 +67,17 @@ func TestRequireLocalhost_AllowsDirectAgentSocketCall(t *testing.T) {
 // still refused — the pre-existing behaviour, unchanged.
 func TestRequireLocalhost_TCPBehaviourUnchanged(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	t.Setenv("JABALI_ALLOW_TCP_INTERNAL", "")
 
+	// Loopback TCP is now refused by default (see
+	// TestRequireLocalhost_RejectsLoopbackTCPByDefault for why); non-loopback
+	// was and remains refused.
 	cases := []struct {
 		remote  string
 		allowed bool
 	}{
-		{"127.0.0.1:54321", true},
-		{"[::1]:54321", true},
+		{"127.0.0.1:54321", false},
+		{"[::1]:54321", false},
 		{"203.0.113.7:54321", false},
 		{"10.0.0.5:1234", false},
 	}

--- a/panel-api/internal/middleware/localhost_test.go
+++ b/panel-api/internal/middleware/localhost_test.go
@@ -26,15 +26,37 @@ func requestWithRemote(t *testing.T, r *gin.Engine, remote string) int {
 	return w.Code
 }
 
-func TestRequireLocalhost_LoopbackIPv4(t *testing.T) {
-	if code := requestWithRemote(t, setupRouter(), "127.0.0.1:54321"); code != http.StatusOK {
-		t.Fatalf("want 200, got %d", code)
+// A loopback TCP peer is NO LONGER trusted by default.
+//
+// This reverses the middleware's original contract deliberately. On a
+// multi-tenant box loopback is not a trust boundary: every tenant process (a
+// PHP-FPM pool, a cron job, an SSH shell) can connect to 127.0.0.1, and the
+// routes behind this gate have no other authentication — an unauthenticated
+// local caller could flood admin notifications to bury real alerts, or forge
+// malware/quarantine rows pointing at arbitrary paths. Production binds the
+// unix socket (ADR-0050), where SO_PEERCRED gives a real identity.
+func TestRequireLocalhost_RejectsLoopbackTCPByDefault(t *testing.T) {
+	t.Setenv("JABALI_ALLOW_TCP_INTERNAL", "")
+	for _, remote := range []string{"127.0.0.1:54321", "[::1]:54321"} {
+		if code := requestWithRemote(t, setupRouter(), remote); code != http.StatusForbidden {
+			t.Errorf("remote %s: want 403 (loopback TCP is not a trust boundary), got %d", remote, code)
+		}
 	}
 }
 
-func TestRequireLocalhost_LoopbackIPv6(t *testing.T) {
-	if code := requestWithRemote(t, setupRouter(), "[::1]:54321"); code != http.StatusOK {
-		t.Fatalf("want 200, got %d", code)
+// The opt-in restores the legacy behaviour for a deployment that still binds
+// [host]:port and accepts the risk knowingly.
+func TestRequireLocalhost_LoopbackTCPAllowedWithOptIn(t *testing.T) {
+	t.Setenv("JABALI_ALLOW_TCP_INTERNAL", "1")
+	for _, remote := range []string{"127.0.0.1:54321", "[::1]:54321"} {
+		if code := requestWithRemote(t, setupRouter(), remote); code != http.StatusOK {
+			t.Errorf("remote %s: want 200 with JABALI_ALLOW_TCP_INTERNAL=1, got %d", remote, code)
+		}
+	}
+	// A NON-loopback peer stays rejected even with the opt-in — the escape
+	// hatch relaxes the transport requirement, not the address check.
+	if code := requestWithRemote(t, setupRouter(), "8.8.8.8:54321"); code != http.StatusForbidden {
+		t.Errorf("public IP must stay rejected even with the opt-in, got %d", code)
 	}
 }
 


### PR DESCRIPTION
Two of the remaining security findings.

### ME-2 — loopback TCP was treated as a trust boundary

`RequireLocalhost` gates the routes only a local daemon may call (`/api/v1/internal/*`, malware ingest) — **routes with no other authentication**. Over the unix socket the gate is airtight: `SO_PEERCRED` gives an unforgeable uid and nginx (www-data) can never satisfy it. But with no peer credentials available it fell through to "is the address loopback?" and accepted.

On a multi-tenant box loopback is **not** a trust boundary. Every tenant process — a PHP-FPM pool, their cron jobs, an SSH shell — can connect to 127.0.0.1. On any deployment binding `[host]:port` instead of the socket, any of them could POST unauthenticated to those routes: flood admin notifications to bury real alerts, or forge malware/quarantine rows pointing at arbitrary paths.

A real TCP peer is now refused unless the operator sets `JABALI_ALLOW_TCP_INTERNAL=1`, and the 403 body names that variable so it's discoverable rather than a mystery.

**The distinction that matters — and that my first version got wrong:** an empty or `"@"` `RemoteAddr` is a *unix* peer, not a TCP one. Go always sets a real `host:port` for TCP, so a remote caller cannot manufacture that case. Rejecting it would have broken the agent whenever peer credentials were unavailable (e.g. `ConnContext` unwired by a refactor). The existing `TestRequireLocalhost_UnixSocketEmpty` caught exactly that. The gate now keys on *"did we get a real IP"*, not *"did we get credentials"*.

**On the changed tests:** three existing tests asserted loopback TCP was allowed. That was the old contract and this reverses it deliberately, so they're rewritten to pin the new one — rather than me weakening a test to fit my code. Added alongside: a test that the opt-in restores legacy behaviour, **and** that a non-loopback peer stays rejected even with the opt-in (the hatch relaxes the transport requirement, not the address check). The internal-route API tests now use the unix sentinel, which is what production actually uses.

### LO-4 — replay defense was silently off with no Redis

The middleware's doc comment promised *"a single info log fires at first request"* when Redis is absent and replay defense is skipped. **No such log existed.** A Redis-less panel ran with the replay gate off and the operator had no signal: anyone capturing one valid signed request could replay it freely inside the ~5-minute timestamp window (re-firing e.g. `POST /automation/users/:id/disable`).

The asymmetry made it worse — with Redis present, a *transient* error fails **closed** with 503 on the stated grounds that "a missing replay store is a security regression, not best effort", while having **no Redis at all** was tolerated silently.

Now a one-time WARN names the exposure and the fix, and the doc comment is corrected to describe what the code actually does.

I did **not** make it fail closed. That would be the stronger position and matches the 503 philosophy, but it would break Redis-less deployments at runtime — worth doing deliberately, not as a side effect of a logging fix.

### Test plan
- [x] `go build ./...`, `go vet` clean
- [x] `go test ./panel-api/... ./panel-agent/...` — **0 failures** (verified by explicit FAIL count)
- [x] New/updated tests pin: loopback TCP refused by default, opt-in restores it, public IP rejected either way, unix-socket peers still accepted with and without peer credentials

Remaining from the reviews: LO-5 (`clientIP` XFF trust in panel-api), LO-6 (agent error strings echoed to clients), LO-1/2/3 (agent-handler defense-in-depth), LO-10/11/12 (SSO), LO-13/14 (install.sh), plus the optimization Mediums.
