### PR TITLE
fix(security): only trust forwarding headers from a credentialed peer (SEC LO-5)

### DIFF
--- a/panel-api/internal/middleware/audit.go
+++ b/panel-api/internal/middleware/audit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -129,19 +130,43 @@ func AuditRecord(rec audit.Recorder) gin.HandlerFunc {
 // (e.g. the automation write audit). Same proxy-authoritative resolution.
 func RealClientIP(c *gin.Context) string { return clientIP(c) }
 
+// clientIP is the address every per-IP decision keys on: the Kratos
+// login/recovery rate limit, API rate tiers, the automation-token IP
+// allowlist, the login whitelist, and audit rows.
+//
+// Forwarding headers are honoured ONLY when the connection carries peer
+// credentials, i.e. it arrived over the unix socket where nginx sets X-Real-IP
+// itself (ADR-0050). A direct TCP client can never present peer credentials,
+// so it can no longer choose its own key.
+//
+// Trusting those headers from any peer meant that on a direct-bind deployment
+// a caller could rotate X-Real-IP per request to: brute-force logins without
+// ever tripping the per-IP Kratos limit, bypass API rate tiers, defeat an
+// automation token's IP allowlist with a stolen token, and write arbitrary
+// addresses into the audit log — the one record you consult after an
+// incident. Production is fronted by nginx, which overwrites the header, so
+// this closes the direct-bind case without changing the proxied one.
 func clientIP(c *gin.Context) string {
-	if xr := strings.TrimSpace(c.GetHeader("X-Real-IP")); xr != "" {
-		return xr
-	}
-	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
-		if i := strings.IndexByte(xff, ','); i >= 0 {
-			xff = xff[:i]
+	if _, viaLocalSocket := PeerUID(c); viaLocalSocket {
+		if xr := strings.TrimSpace(c.GetHeader("X-Real-IP")); xr != "" {
+			return xr
 		}
-		if xff = strings.TrimSpace(xff); xff != "" {
-			return xff
+		if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
+			if i := strings.IndexByte(xff, ','); i >= 0 {
+				xff = xff[:i]
+			}
+			if xff = strings.TrimSpace(xff); xff != "" {
+				return xff
+			}
 		}
 	}
-	return c.ClientIP()
+	// No peer credentials: the peer IS the client. gin's ClientIP would
+	// itself consult forwarding headers for trusted proxies, so take the
+	// socket address directly and leave nothing header-controlled.
+	if host, _, err := net.SplitHostPort(c.Request.RemoteAddr); err == nil {
+		return host
+	}
+	return c.Request.RemoteAddr
 }
 
 // deriveTarget is best-effort and informational only (target is not a

--- a/panel-api/internal/middleware/automation_guards_test.go
+++ b/panel-api/internal/middleware/automation_guards_test.go
@@ -63,36 +63,45 @@ func TestRequireAutomationHMAC_IPAllowlist(t *testing.T) {
 	}
 }
 
-// JAB-140 follow-up: behind the unix-socket nginx proxy the real client IP is in
-// X-Real-IP; the allowlist must match THAT, not the socket peer. Here the request
-// "arrives" from 192.0.2.1 (httptest default) but X-Real-IP says 203.0.113.5, and
-// the allowlist covers 203.0.113.0/24 → allowed.
-func TestRequireAutomationHMAC_IPAllowlistUsesXRealIP(t *testing.T) {
+// JAB-140 follow-up, revised: behind the unix-socket nginx proxy the real
+// client IP is in X-Real-IP and the allowlist must match THAT. But that header
+// is only believed from a peer that presented credentials (the socket) —
+// otherwise a stolen token plus a forged X-Real-IP satisfies any allowlist,
+// which defeats the point of having one.
+//
+// httptest supplies no peer credentials, so these cases exercise the
+// direct-connection path: the allowlist keys on the real peer address, and a
+// spoofed header gets no pass.
+func TestRequireAutomationHMAC_IPAllowlistIgnoresSpoofedHeader(t *testing.T) {
 	repo := &fakeAutoTokenRepo{tokens: map[string]*models.AutomationToken{}}
 	k := newTestKey(t)
 	id, secret := mintTestToken(t, repo, k, models.AutomationScopes{"read:*"})
 	repo.tokens[id].IPAllowlist = models.CIDRList{"203.0.113.0/24"}
 	r := setupHMACRouter(repo, k)
-
 	ts := fmt.Sprintf("%d", time.Now().Unix())
+
+	// Peer really IS in the allowlist -> allowed.
 	sig := signRequest(secret, "GET", "/p", ts, "")
 	req := httptest.NewRequest(http.MethodGet, "/p", nil)
 	req.Header.Set("Authorization", fmt.Sprintf("Jabali-HMAC kid=%s, ts=%s, sig=%s", id, ts, sig))
-	req.Header.Set("X-Real-IP", "203.0.113.5")
+	req.RemoteAddr = "203.0.113.5:41000"
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
-		t.Fatalf("X-Real-IP in allowlist: want 200, got %d", w.Code)
+		t.Fatalf("allowlisted peer: want 200, got %d", w.Code)
 	}
 
-	// A forwarded IP outside the allowlist is rejected even if the socket peer would pass.
-	req2 := httptest.NewRequest(http.MethodGet, "/p", nil)
+	// Peer is OUTSIDE the allowlist but claims an allowlisted X-Real-IP.
+	// Without peer credentials that header carries no authority: this is the
+	// stolen-token-plus-forged-header case and must be refused.
 	sig2 := signRequest(secret, "GET", "/p", ts, "")
+	req2 := httptest.NewRequest(http.MethodGet, "/p", nil)
 	req2.Header.Set("Authorization", fmt.Sprintf("Jabali-HMAC kid=%s, ts=%s, sig=%s", id, ts, sig2))
-	req2.Header.Set("X-Real-IP", "10.9.9.9")
+	req2.RemoteAddr = "10.9.9.9:41000"
+	req2.Header.Set("X-Real-IP", "203.0.113.5")
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	if w2.Code != http.StatusUnauthorized {
-		t.Fatalf("X-Real-IP outside allowlist: want 401, got %d", w2.Code)
+		t.Fatalf("spoofed X-Real-IP from an uncredentialed peer: want 401, got %d", w2.Code)
 	}
 }

--- a/panel-api/internal/middleware/ratelimit_test.go
+++ b/panel-api/internal/middleware/ratelimit_test.go
@@ -118,7 +118,11 @@ func TestKratosFlows_GatesCredentialPostsOnly(t *testing.T) {
 		r.Use(func(c *gin.Context) { c.Request.Header.Set("X-Forwarded-For", ip); c.Next() })
 		r.Any("/*any", mw, func(c *gin.Context) { c.Status(http.StatusOK) })
 		req := httptest.NewRequest(method, path, nil)
-		req.Header.Set("X-Forwarded-For", ip)
+		// Distinct peers, not distinct headers: clientIP only honours
+		// forwarding headers from a peer that presented credentials (the
+		// unix socket nginx uses). A header-only "IP" is exactly what an
+		// attacker would rotate to evade this limiter, so it must not key it.
+		req.RemoteAddr = ip + ":54321"
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		return w.Code


### PR DESCRIPTION
`clientIP` is the address **every per-IP decision keys on**: the Kratos login/recovery rate limit, API rate tiers, the automation-token IP allowlist, the login whitelist, and audit rows. It preferred `X-Real-IP`, then the first `X-Forwarded-For` hop, **with no check on who set them**.

Behind nginx that's correct — nginx overwrites `X-Real-IP`, so the value is authoritative. On a deployment binding `[host]:port` directly, **the client picks its own key**. Rotating `X-Real-IP` per request then lets a caller:

- brute-force logins without ever tripping the per-IP Kratos limit
- bypass API rate tiers
- defeat an automation token's IP allowlist with a stolen token
- write arbitrary addresses into the audit log — the record you consult *after* an incident, quietly poisoned

### Fix
Forwarding headers are honoured only when the connection carries **peer credentials**, i.e. it arrived over the unix socket where nginx sets them (ADR-0050). A direct TCP client can never present peer credentials, so it can't choose its own key; the peer address is used instead. **Proxied production behaviour is unchanged.**

The fallback deliberately does *not* use gin's `ClientIP`, which would itself consult forwarding headers for trusted proxies — it reads the socket address, leaving nothing header-controlled.

### Two tests encoded the old contract — updated, not deleted
- The rate-limit test simulated distinct clients with distinct `X-Forwarded-For` headers. A header-only "IP" is exactly what an attacker rotates to evade this limiter, so it must not key it; now uses distinct peers.
- `TestRequireAutomationHMAC_IPAllowlistUsesXRealIP` asserted the allowlist matches `X-Real-IP`. **Reframed to pin the property that actually matters:** an allowlisted *peer* passes, and a peer outside the allowlist claiming an allowlisted `X-Real-IP` is **refused** — the stolen-token-plus-forged-header case the allowlist exists to stop.

I'd rather change a test's premise explicitly and say why than leave a test asserting a behaviour we've decided is unsafe.

### Test plan
- [x] `go build ./...`, `go vet` clean
- [x] `go test ./...` — **0 failures** (explicit FAIL count)
- [x] New negative case: spoofed `X-Real-IP` from an uncredentialed peer → 401

Committed from a dedicated worktree, not the shared checkout (contended HEAD).
