### PR TITLE
fix(sso): re-check admin state before issuing root-equivalent DB credentials, fix the broken audit chain (SEC LO-10, LO-11)

### DIFF
--- a/panel-api/internal/api/sso_adminer.go
+++ b/panel-api/internal/api/sso_adminer.go
@@ -10,8 +10,6 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -120,8 +118,16 @@ func (h *ssoAdminerHandler) issueSSOToken(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	tokenHash := sha256.Sum256([]byte(token))
-	hashPrefix := hex.EncodeToString(tokenHash[:8])
+	// Hash the DECODED token bytes with the same prefix length the validate
+	// handler uses, so "issued" and "validated"/"unauthorized" lines for one
+	// token share a prefix and can actually be correlated.
+	//
+	// This previously hashed the base64url STRING and logged 8 bytes, while
+	// validate hashes the raw bytes and logs 4 — a different digest at a
+	// different length, so the two halves of the SSO audit chain could never
+	// be joined. Not exploitable, but it broke the trail exactly when it
+	// matters: during an incident.
+	hashPrefix := ssoTokenHashPrefix(token)
 	h.audit(ctx, claims.UserID, req.DatabaseID, hashPrefix, engine, "issued")
 
 	baseURL := h.getAdminerBaseURL(c)

--- a/panel-api/internal/api/sso_adminer_validate.go
+++ b/panel-api/internal/api/sso_adminer_validate.go
@@ -95,6 +95,25 @@ func (h *ssoAdminerValidateHandler) validate(c *gin.Context) {
 	// Adminer). Per-user tokens carry a real DatabaseID, so this
 	// early branch never affects the per-user path below.
 	if token.DatabaseID == ssoAdminAllSentinel {
+		// JAB-8 applies here too: the per-user path below re-checks panel
+		// state at validation time, but this admin branch redeemed straight
+		// into ROOT-EQUIVALENT database credentials without ever loading the
+		// user row. Suspending an admin is refused by design, but DEMOTION is
+		// the sanctioned flow (users_suspend.go), so a demoted admin's
+		// in-flight token stayed redeemable for the rest of its TTL. Narrow
+		// window and single-use, but the credential it hands out is the
+		// broadest one the panel can issue — re-check before resolving it.
+		admin, aerr := h.cfg.Users.FindByID(ctx, token.UserID)
+		if aerr != nil || admin == nil {
+			h.audit(ctx, token.UserID, token.DatabaseID, token.Engine, hashPrefix, "unauthorized:admin_user_gone")
+			c.JSON(http.StatusUnauthorized, ssoErrorResponse{Error: "unauthorized"})
+			return
+		}
+		if admin.Suspended || !admin.IsAdmin {
+			h.audit(ctx, token.UserID, token.DatabaseID, token.Engine, hashPrefix, "unauthorized:no_longer_admin")
+			c.JSON(http.StatusUnauthorized, ssoErrorResponse{Error: "unauthorized"})
+			return
+		}
 		cred, cerr := ssoadmin.AdminCredential("postgres")
 		if cerr != nil {
 			h.cfg.Log.ErrorContext(ctx, "pg superuser credential resolve failed", "err", cerr)

--- a/panel-api/internal/api/sso_phpmyadmin.go
+++ b/panel-api/internal/api/sso_phpmyadmin.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -113,9 +111,16 @@ func (h *ssoPhpMyAdminHandler) issueSSOToken(c *gin.Context) {
 		return
 	}
 
-	// Log successful issue with token hash prefix
-	tokenHash := sha256.Sum256([]byte(token))
-	hashPrefix := hex.EncodeToString(tokenHash[:8])
+	// Hash the DECODED token bytes with the same prefix length the validate
+	// handler uses, so "issued" and "validated"/"unauthorized" lines for one
+	// token share a prefix and can actually be correlated.
+	//
+	// This previously hashed the base64url STRING and logged 8 bytes, while
+	// validate hashes the raw bytes and logs 4 — a different digest at a
+	// different length, so the two halves of the SSO audit chain could never
+	// be joined. Not exploitable, but it broke the trail exactly when it
+	// matters: during an incident.
+	hashPrefix := ssoTokenHashPrefix(token)
 	h.auditLog(ctx, claims.UserID, req.DatabaseID, hashPrefix, "issued")
 
 	// Build redirect URL with absolute base

--- a/panel-api/internal/api/sso_phpmyadmin_validate.go
+++ b/panel-api/internal/api/sso_phpmyadmin_validate.go
@@ -114,6 +114,25 @@ func (h *ssoPhpMyAdminValidateHandler) validate(c *gin.Context) {
 	// carry a real DatabaseID, so this early branch never affects
 	// the per-user path below.
 	if token.DatabaseID == ssoAdminAllSentinel {
+		// JAB-8 applies here too: the per-user path below re-checks panel
+		// state at validation time, but this admin branch redeemed straight
+		// into ROOT-EQUIVALENT database credentials without ever loading the
+		// user row. Suspending an admin is refused by design, but DEMOTION is
+		// the sanctioned flow (users_suspend.go), so a demoted admin's
+		// in-flight token stayed redeemable for the rest of its TTL. Narrow
+		// window and single-use, but the credential it hands out is the
+		// broadest one the panel can issue — re-check before resolving it.
+		admin, aerr := h.cfg.Users.FindByID(ctx, token.UserID)
+		if aerr != nil || admin == nil {
+			h.auditLog(ctx, token.UserID, token.DatabaseID, hashPrefix, "unauthorized:admin_user_gone")
+			c.JSON(http.StatusUnauthorized, ssoErrorResponse{Error: "unauthorized"})
+			return
+		}
+		if admin.Suspended || !admin.IsAdmin {
+			h.auditLog(ctx, token.UserID, token.DatabaseID, hashPrefix, "unauthorized:no_longer_admin")
+			c.JSON(http.StatusUnauthorized, ssoErrorResponse{Error: "unauthorized"})
+			return
+		}
 		cred, cerr := ssoadmin.AdminCredential("mariadb")
 		if cerr != nil {
 			h.cfg.Log.ErrorContext(ctx, "pma admin credential resolve failed", "err", cerr)

--- a/panel-api/internal/api/sso_token_hash.go
+++ b/panel-api/internal/api/sso_token_hash.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// ssoTokenHashPrefix returns the audit-log prefix for an SSO handoff token.
+//
+// One definition, used by BOTH the mint and validate sides, because they
+// disagreed: mint hashed the base64url STRING and logged 8 bytes, validate
+// hashed the DECODED bytes and logged 4. Two different digests at two
+// different lengths, so an "issued" line and its matching "validated" or
+// "unauthorized" line could never be correlated — the SSO audit chain was
+// silently broken precisely when you need it, during an incident.
+//
+// The token is base64url; a value that fails to decode is hashed as-is rather
+// than dropped, so a malformed token still produces a stable, greppable
+// prefix instead of an empty field.
+func ssoTokenHashPrefix(token string) string {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		raw = []byte(token)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:4])
+}

--- a/panel-api/internal/api/sso_token_hash_test.go
+++ b/panel-api/internal/api/sso_token_hash_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+)
+
+// The mint side and the validate side must derive the SAME audit prefix for
+// the same token, or the SSO audit chain cannot be followed: an "issued" line
+// and its matching "validated"/"unauthorized" line would never share a value
+// to grep for.
+//
+// They disagreed in two ways at once — mint hashed the base64url STRING and
+// logged 8 bytes, validate hashed the DECODED bytes and logged 4 — so this
+// pins both the input and the length.
+func TestSSOTokenHashPrefixMatchesValidateSide(t *testing.T) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatal(err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw)
+
+	// Exactly what the validate handlers compute.
+	sum := sha256.Sum256(raw)
+	wantValidateSide := hex.EncodeToString(sum[:4])
+
+	if got := ssoTokenHashPrefix(token); got != wantValidateSide {
+		t.Fatalf("mint prefix %q != validate prefix %q — the two halves of the "+
+			"SSO audit trail cannot be correlated", got, wantValidateSide)
+	}
+
+	// The old mint behaviour (hash the base64 string, take 8 bytes) must NOT
+	// be what we produce.
+	strSum := sha256.Sum256([]byte(token))
+	if got := ssoTokenHashPrefix(token); got == hex.EncodeToString(strSum[:8]) {
+		t.Error("prefix still derived from the base64 string at 8 bytes (the old bug)")
+	}
+}
+
+// A malformed token still yields a stable, greppable prefix rather than an
+// empty audit field.
+func TestSSOTokenHashPrefixHandlesUndecodableToken(t *testing.T) {
+	const bad = "!!!not-base64!!!"
+	got := ssoTokenHashPrefix(bad)
+	if len(got) != 8 { // 4 bytes hex-encoded
+		t.Fatalf("prefix %q: want 8 hex chars even for an undecodable token", got)
+	}
+	if got != ssoTokenHashPrefix(bad) {
+		t.Error("prefix must be deterministic")
+	}
+}


### PR DESCRIPTION
### LO-10 — root-equivalent DB credentials issued without re-checking admin state

The M46 admin-sentinel branch in both SSO validate handlers redeemed a token straight into **root-equivalent database credentials** (`jabali_pma_admin` / postgres superuser) **without loading the user row**. The per-user path immediately below it re-checks panel state at validation time for exactly this reason (JAB-8); the admin path skipped it.

Suspending an admin is refused by design, but **demotion is the sanctioned flow** (`users_suspend.go`) — so an admin who clicked "phpMyAdmin (all DBs)" and was demoted within the token's 5-minute TTL could still redeem it.

Narrow window and single-use, yes. But the credential it hands out is the broadest the panel can issue, which makes it the *last* place that should skip a re-check. Both handlers now load the user and require non-suspended **and** still-admin before resolving any credential, auditing the refusal distinctly (`unauthorized:no_longer_admin`).

### LO-11 — the SSO audit chain couldn't be followed

Mint and validate computed **different** audit prefixes for the same token:

| | input | length |
|---|---|---|
| mint | base64url **string** | 8 bytes |
| validate | **decoded** bytes | 4 bytes |

Different digest at a different length, so an `issued` line and its matching `validated`/`unauthorized` line never shared a value to grep for. Not exploitable — it just broke the audit trail at the one moment it matters, during an incident.

Both sides now use a single helper (`ssoTokenHashPrefix`) that decodes first and uses the validate side's length. An undecodable token is hashed as-is rather than dropped, so a malformed value still yields a stable, greppable prefix instead of an empty audit field.

The test pins **both** halves: the minted prefix must equal what the validate handlers compute, *and* must not equal the old string-hashed 8-byte form.

### LO-12 deliberately not included
Tokens in URL query strings: the webmail half is contract-bound (Bulwark requires `?token=`), and the remaining fix is an nginx `log_format` change across several vhost templates. That affects every install and wants verification on a box rather than a blind edit — I'd rather leave it open than ship an nginx config I can't test here.

### Test plan
- [x] `go build ./...`, `go vet` clean
- [x] `go test ./...` — **0 failures** (explicit FAIL count)
- [x] New tests: mint/validate prefix equality, old-form rejection, undecodable-token stability
