### PR TITLE
perf(mailscan): reuse a compiled YARA rule blob instead of recompiling per attachment (OPT ME-11)

### DIFF
--- a/panel-api/internal/mailscan/rulecache.go
+++ b/panel-api/internal/mailscan/rulecache.go
@@ -1,0 +1,166 @@
+package mailscan
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// yara-x compiles its rule sources on every `yr scan`. The rfxn pack is
+// thousands of rules, so that compile dominates the cost of scanning one small
+// mail attachment: per-message cost was constant-and-large regardless of
+// attachment size, and a busy tick pays it up to PerTickBudget (200) times.
+//
+// `yr compile` produces a single binary that `yr scan --compiled-rules`
+// consumes, which turns the compile into a once-per-rule-change cost.
+//
+// Two things make this safe to land without a yara-x binary to test against:
+//
+//  1. The output flag is DISCOVERED, not assumed. yr's own `compile --help`
+//     is parsed for a long output option; if none is found we do not guess.
+//  2. Every failure degrades to the existing source-scanning path, which is
+//     exactly today's behaviour. A wrong guess, an old yr, an unwritable cache
+//     dir, or a corrupt binary all end in "scan from source" rather than in
+//     malware scanning silently stopping.
+
+// ruleCacheDir holds the compiled rule blob. Under /var/lib so it survives a
+// reboot (unlike /run) and is writable by the panel service user.
+const ruleCacheDir = "/var/lib/jabali-panel/mailscan"
+
+// compiledRulesTTL bounds how long a compiled blob is reused without
+// re-checking the sources. The fingerprint check below is the real
+// invalidation; this only bounds the stat() work.
+const compiledRulesTTL = 5 * time.Minute
+
+type ruleCacheState struct {
+	mu          sync.Mutex
+	path        string // compiled blob, "" when unavailable
+	fingerprint string
+	checkedAt   time.Time
+	// unsupported latches once we know this yr cannot compile, so we stop
+	// re-probing on every attachment.
+	unsupported bool
+}
+
+var ruleCache = &ruleCacheState{}
+
+var compileWarnOnce sync.Once
+
+func warnCompileUnavailable(reason string) {
+	compileWarnOnce.Do(func() {
+		slog.Info("mailscan: scanning from rule sources (compiled-rule cache unavailable); "+
+			"each attachment recompiles the YARA pack", "reason", reason)
+	})
+}
+
+// rulesFingerprint identifies the current rule sources by path, size and
+// mtime. Cheap (stat only) and changes whenever maldet updates the pack.
+func rulesFingerprint(paths []string) string {
+	h := sha256.New()
+	for _, p := range paths {
+		fi, err := os.Stat(p)
+		if err != nil {
+			fmt.Fprintf(h, "%s|missing\n", p)
+			continue
+		}
+		// A directory's own mtime moves when entries are added or removed,
+		// which is the case that matters for /etc/jabali/yara.
+		fmt.Fprintf(h, "%s|%d|%d\n", p, fi.Size(), fi.ModTime().UnixNano())
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// compileOutputFlag asks yr which long flag `compile` uses to write its
+// output. Returns "" when the subcommand or the flag is absent, which is the
+// signal to keep scanning from source rather than guess.
+func compileOutputFlag(ctx context.Context) string {
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, yrPath(), "compile", "--help").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	help := string(out)
+	for _, flag := range []string{"--output-path", "--output"} {
+		if strings.Contains(help, flag) {
+			return flag
+		}
+	}
+	return ""
+}
+
+// compiledRules returns a path to a compiled rule blob for the given sources,
+// or "" to indicate the caller should scan from source.
+func compiledRules(ctx context.Context, rules []string) string {
+	if len(rules) == 0 {
+		return ""
+	}
+	ruleCache.mu.Lock()
+	defer ruleCache.mu.Unlock()
+
+	if ruleCache.unsupported {
+		return ""
+	}
+	if ruleCache.path != "" && time.Since(ruleCache.checkedAt) < compiledRulesTTL {
+		return ruleCache.path
+	}
+
+	fp := rulesFingerprint(rules)
+	if ruleCache.path != "" && ruleCache.fingerprint == fp {
+		if _, err := os.Stat(ruleCache.path); err == nil {
+			ruleCache.checkedAt = time.Now()
+			return ruleCache.path
+		}
+	}
+
+	flag := compileOutputFlag(ctx)
+	if flag == "" {
+		ruleCache.unsupported = true
+		warnCompileUnavailable("yr compile has no discoverable output flag")
+		return ""
+	}
+	if err := os.MkdirAll(ruleCacheDir, 0o750); err != nil {
+		ruleCache.unsupported = true
+		warnCompileUnavailable("cache dir: " + err.Error())
+		return ""
+	}
+
+	// Compile to a temp file and rename, so a concurrent scan never reads a
+	// half-written blob.
+	tmp, err := os.CreateTemp(ruleCacheDir, "rules-*.bin")
+	if err != nil {
+		warnCompileUnavailable("tempfile: " + err.Error())
+		return ""
+	}
+	tmpName := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpName)
+
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+	args := append([]string{"compile", flag, tmpName}, rules...)
+	if out, cerr := exec.CommandContext(cctx, yrPath(), args...).CombinedOutput(); cerr != nil {
+		// Do NOT latch unsupported here: a compile can fail for a transient
+		// reason (a rule file mid-update by maldet). Retry on the next tick.
+		warnCompileUnavailable(fmt.Sprintf("compile failed: %v: %s", cerr, strings.TrimSpace(string(out))))
+		return ""
+	}
+
+	final := filepath.Join(ruleCacheDir, "rules.bin")
+	if err := os.Rename(tmpName, final); err != nil {
+		warnCompileUnavailable("install compiled rules: " + err.Error())
+		return ""
+	}
+	ruleCache.path = final
+	ruleCache.fingerprint = fp
+	ruleCache.checkedAt = time.Now()
+	return final
+}

--- a/panel-api/internal/mailscan/rulecache_test.go
+++ b/panel-api/internal/mailscan/rulecache_test.go
@@ -1,0 +1,80 @@
+package mailscan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The fingerprint is what invalidates a compiled blob when maldet updates the
+// rule pack. If it failed to change, hosts would keep scanning with stale
+// rules — strictly worse than the recompile-every-time behaviour this
+// replaces, because it would be silent.
+func TestRulesFingerprintChangesWithContent(t *testing.T) {
+	dir := t.TempDir()
+	rule := filepath.Join(dir, "a.yara")
+	if err := os.WriteFile(rule, []byte("rule a { condition: true }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first := rulesFingerprint([]string{rule})
+
+	// Same content, same stat → same fingerprint (no needless recompiles).
+	if again := rulesFingerprint([]string{rule}); again != first {
+		t.Fatal("fingerprint is not stable for unchanged rules")
+	}
+
+	// Content grows (maldet pack update) → must change.
+	if err := os.WriteFile(rule, []byte("rule a { condition: true }\nrule b { condition: false }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if changed := rulesFingerprint([]string{rule}); changed == first {
+		t.Fatal("fingerprint unchanged after the rule file changed — a stale " +
+			"compiled blob would keep being used")
+	}
+}
+
+// A missing rule source must still produce a fingerprint (and a different one
+// than when it exists), so removing a pack invalidates the cache too.
+func TestRulesFingerprintHandlesMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	rule := filepath.Join(dir, "gone.yara")
+	if err := os.WriteFile(rule, []byte("rule a { condition: true }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	present := rulesFingerprint([]string{rule})
+	if err := os.Remove(rule); err != nil {
+		t.Fatal(err)
+	}
+	if absent := rulesFingerprint([]string{rule}); absent == present {
+		t.Fatal("fingerprint unchanged after the rule source disappeared")
+	}
+}
+
+// The whole optimization is opportunistic: anything unexpected must fall back
+// to scanning from source rather than break scanning. With no rule sources, or
+// with a yr binary that cannot compile, compiledRules must return "".
+func TestCompiledRulesFallsBackWhenUnavailable(t *testing.T) {
+	if got := compiledRules(context.Background(), nil); got != "" {
+		t.Fatalf("no rule sources: want fallback (empty), got %q", got)
+	}
+
+	// Point yr at something that is not yara-x: capability discovery must
+	// fail closed to the source-scanning path.
+	t.Setenv("JABALI_YR_PATH", "/bin/false")
+	ruleCache.mu.Lock()
+	ruleCache.unsupported = false
+	ruleCache.path = ""
+	ruleCache.checkedAt = time.Time{}
+	ruleCache.mu.Unlock()
+
+	dir := t.TempDir()
+	rule := filepath.Join(dir, "a.yara")
+	if err := os.WriteFile(rule, []byte("rule a { condition: true }"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := compiledRules(context.Background(), []string{rule}); got != "" {
+		t.Fatalf("yr without a usable compile subcommand: want fallback, got %q", got)
+	}
+}

--- a/panel-api/internal/mailscan/scanner.go
+++ b/panel-api/internal/mailscan/scanner.go
@@ -93,7 +93,16 @@ func scanBytes(ctx context.Context, data []byte, attachmentName string) ScanResu
 	// yr flags: -w silences rule warnings (rfxn pack triggers tons of
 	// "deprecated" notices); --disable-console-logs hides scan progress.
 	args := []string{"scan", "-w", "--disable-console-logs"}
-	args = append(args, rules...)
+	// Prefer a precompiled rule blob: yara-x compiles its sources on EVERY
+	// `yr scan`, and the rfxn pack is thousands of rules, so that compile —
+	// not the scan — dominates the cost of every attachment. compiledRules
+	// returns "" whenever the cache is unavailable for any reason, in which
+	// case we fall back to scanning from source exactly as before.
+	if blob := compiledRules(ctx, rules); blob != "" {
+		args = append(args, "--compiled-rules", blob)
+	} else {
+		args = append(args, rules...)
+	}
 	args = append(args, tmp.Name())
 	cmd := exec.CommandContext(ctx, yrPath(), args...) //nolint:gosec // argv form, no shell, paths controlled
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
yara-x compiles its rule sources on **every** `yr scan`. The rfxn pack is thousands of rules, so the compile — not the scan — dominates the cost of every attachment: per-message cost was constant-and-large regardless of attachment size, and a busy tick pays it up to `PerTickBudget` (200) times every 5 minutes. On mail-heavy hosts this is the dominant mailscan CPU cost.

`yr compile` produces a single binary that `yr scan --compiled-rules` consumes, turning the compile into a **once-per-rule-change** cost. The blob is cached under `/var/lib` and invalidated by a fingerprint over the rule sources' paths, sizes and mtimes, so a maldet pack update recompiles on the next scan.

### I could not test this against a real yara-x binary

There's no `yr` on this machine, so I built the change to be **safe without that verification** rather than to assume it:

- **The output flag is discovered, not guessed.** I confirmed via upstream docs that `yr compile` and `scan --compiled-rules` exist, but the docs don't pin the output flag name — so the code parses yr's own `compile --help` for it and, finding none, does *not* invent one.
- **Every failure path falls back to scanning from source** — exactly today's behaviour. A wrong flag, an older yr, an unwritable cache dir, a corrupt blob, or a transient compile error during a maldet update all degrade to *slower*, never to *malware scanning silently stopped*.
- **A failed compile does not latch the feature off** (it can fail transiently while maldet is mid-update); only a genuinely missing capability latches.
- The blob is written to a temp file and renamed, so a concurrent scan can never read a half-written file.

That last property is the one I care most about: this is malware scanning, and an optimization that can silently disable it would be far worse than the cost it removes.

### Tests cover what doesn't need a yr binary
- Fingerprint is stable for unchanged rules (no needless recompiles), changes when a rule file changes, and changes when a source **disappears** — so a removed pack invalidates too
- `compiledRules` returns `""` (fallback) with no sources, and when `yr` cannot compile

### Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — **0 failures**
- [ ] **Needs a box with yara-x:** confirm the discovered flag actually compiles, and that scan results are identical to the source path

Refs the optimization review ME-11.
