### PR TITLE
perf: stop recomputing verdicts that cannot have changed, stream the audit chain (OPT ME-14, LO-2, LO-11, LO-12)

### DIFF
--- a/panel-api/internal/api/audit.go
+++ b/panel-api/internal/api/audit.go
@@ -72,17 +72,40 @@ func RegisterAuditRoutes(g *gin.RouterGroup, cfg AuditHandlerConfig) {
 // verify recomputes the tamper-evidence hash chain over every audit row
 // (read-only) and reports the checked/total counts + the first broken row.
 func (h *auditHandler) verify(c *gin.Context) {
-	rows, err := h.cfg.Repo.AllForVerify(c.Request.Context())
-	if err != nil {
+	ctx := c.Request.Context()
+	anchor, _ := h.cfg.Repo.ChainAnchor(ctx)
+
+	// Stream the chain in batches rather than materialising the whole
+	// append-only table. It can reach hundreds of thousands of rows between
+	// prunes, and this was the one endpoint that loaded all of them into
+	// memory for a single admin request. The chain state is scalar, so a fold
+	// over batches gives an identical answer at bounded memory.
+	var (
+		prev     = anchor
+		checked  int
+		total    int
+		brokenID string
+		ok       = true
+	)
+	err := h.cfg.Repo.EachForVerify(ctx, 1000, func(batch []models.AuditEvent) bool {
+		total += len(batch)
+		bID, n, nextPrev, batchOK := audit.VerifyChainBatch(batch, prev)
+		checked += n
+		prev = nextPrev
+		if !batchOK {
+			brokenID, ok = bID, false
+			return false // stop early: the chain is already broken
+		}
+		return true
+	})
+	if err != nil && !repository.IsVerifyStop(err) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	anchor, _ := h.cfg.Repo.ChainAnchor(c.Request.Context())
-	brokenID, checked, ok := audit.VerifyChain(rows, anchor)
 	c.JSON(http.StatusOK, gin.H{
 		"ok":        ok,
 		"checked":   checked,
-		"total":     len(rows),
+		"total":     total,
 		"broken_id": brokenID,
 	})
 }

--- a/panel-api/internal/audit/verify.go
+++ b/panel-api/internal/audit/verify.go
@@ -24,6 +24,20 @@ import "git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 // prune (JAB-105), so the surviving chain verifies against the pruned tail's
 // last sealed hash.
 func VerifyChain(rows []models.AuditEvent, startPrev string) (brokenID string, checked int, ok bool) {
+	brokenID, checked, _, ok = VerifyChainBatch(rows, startPrev)
+	return brokenID, checked, ok
+}
+
+// VerifyChainBatch verifies one contiguous slice of the chain and returns the
+// hash to continue from, so a caller can walk the table in batches instead of
+// loading all of it.
+//
+// The chain state is scalar (the previous row hash plus a count), which is why
+// streaming is possible at all: the audit table is append-only and can reach
+// hundreds of thousands of rows between prunes, and verify was the one
+// endpoint that materialised every one of them at once — O(table) memory on a
+// box the panel shares with everything else.
+func VerifyChainBatch(rows []models.AuditEvent, startPrev string) (brokenID string, checked int, nextPrev string, ok bool) {
 	prev := startPrev
 	for i := range rows {
 		r := &rows[i]
@@ -31,10 +45,10 @@ func VerifyChain(rows []models.AuditEvent, startPrev string) (brokenID string, c
 			continue // pre-chain (folded/historical/fallback-pending)
 		}
 		if want := computeRowHash(prev, r); *r.RowHash != want {
-			return r.ID, checked, false
+			return r.ID, checked, prev, false
 		}
 		checked++
 		prev = *r.RowHash
 	}
-	return "", checked, true
+	return "", checked, prev, true
 }

--- a/panel-api/internal/audit/verify_test.go
+++ b/panel-api/internal/audit/verify_test.go
@@ -80,3 +80,55 @@ func TestVerifyChain_PrunedTailVerifiesFromAnchor(t *testing.T) {
 	require.Equal(t, "", broken)
 	require.Equal(t, 1, checked)
 }
+
+// Verifying in batches must give byte-identical answers to verifying the
+// whole slice at once. That equivalence is what lets the API stream the
+// append-only table instead of loading every row into memory for one admin
+// request.
+func TestVerifyChainBatch_MatchesWholeSliceVerification(t *testing.T) {
+	var rows []models.AuditEvent
+	prev := ""
+	for i := 1; i <= 25; i++ {
+		r := sealed(string(rune('a'+i%26))+"row", int64(i), prev)
+		prev = *r.RowHash
+		rows = append(rows, r)
+	}
+
+	wantBroken, wantChecked, wantOK := VerifyChain(rows, "")
+
+	// Fold the same rows in batches of 4, threading the chain state.
+	gotPrev, gotChecked, gotOK, gotBroken := "", 0, true, ""
+	for i := 0; i < len(rows); i += 4 {
+		end := i + 4
+		if end > len(rows) {
+			end = len(rows)
+		}
+		b, n, next, ok := VerifyChainBatch(rows[i:end], gotPrev)
+		gotChecked += n
+		gotPrev = next
+		if !ok {
+			gotBroken, gotOK = b, false
+			break
+		}
+	}
+	require.Equal(t, wantOK, gotOK)
+	require.Equal(t, wantBroken, gotBroken)
+	require.Equal(t, wantChecked, gotChecked, "batched verification must check the same number of rows")
+}
+
+// A break mid-stream must be reported with the same row id, and the batched
+// walk must be able to stop there rather than reading the rest of the table.
+func TestVerifyChainBatch_ReportsBreakAndStops(t *testing.T) {
+	r1 := sealed("01", 1, "")
+	r2 := sealed("02", 2, *r1.RowHash)
+	tampered := r2
+	bad := "deadbeef"
+	tampered.RowHash = &bad
+	r3 := sealed("03", 3, *r2.RowHash)
+
+	broken, checked, next, ok := VerifyChainBatch([]models.AuditEvent{r1, tampered, r3}, "")
+	require.False(t, ok)
+	require.Equal(t, "02", broken, "must name the first bad row")
+	require.Equal(t, 1, checked, "only the rows before the break count as checked")
+	require.Equal(t, *r1.RowHash, next, "chain state stops at the last good row")
+}

--- a/panel-api/internal/mailscan/tick.go
+++ b/panel-api/internal/mailscan/tick.go
@@ -210,8 +210,15 @@ func scanMailbox(ctx context.Context, client *Client, deps Deps, cfg Settings, p
 		return 0, fmt.Errorf("Email/query: %w", err)
 	}
 	if len(emailIDs) == 0 {
-		state.ScannedAt = time.Now().UTC()
-		_ = deps.State.Upsert(ctx, state)
+		// Nothing new: do NOT write. This branch used to bump ScannedAt and
+		// Upsert on every idle mailbox, every 5 minutes, forever — one DB
+		// write per mailbox per tick purely to record "still nothing".
+		//
+		// Safe to skip because the scan cursor is LastReceivedAt, not
+		// ScannedAt: `since` above reads LastReceivedAt, and nothing else in
+		// the codebase consumes ScannedAt. A brand-new mailbox with no state
+		// row also stays unwritten until it actually has mail to scan, which
+		// is when the row starts carrying information.
 		return 0, nil
 	}
 

--- a/panel-api/internal/reconciler/bandwidth_quota_enforce.go
+++ b/panel-api/internal/reconciler/bandwidth_quota_enforce.go
@@ -28,6 +28,11 @@ import (
 const (
 	bwSuspendCritPercent = 100.0
 	bwSuspendWarnPercent = 80.0
+
+	// bwEnforceInterval bounds how often the suspension sweep runs. bw_daily
+	// is written once a day, so anything faster is recomputing a verdict that
+	// cannot have changed.
+	bwEnforceInterval = time.Hour
 )
 
 // reconcileBandwidthQuotaEnforce is the per-tick suspension loop.
@@ -42,6 +47,20 @@ func (r *Reconciler) reconcileBandwidthQuotaEnforce(ctx context.Context) {
 		return
 	}
 
+	// Evaluate hourly, not every tick. The input (bw_daily) is written once a
+	// day by the bandwidth ticker, so 1439 of every 1440 evaluations recompute
+	// an identical answer — and each one costs, per eligible user, a package
+	// lookup, a join+SUM over month-to-date bandwidth, and a domain list.
+	// Suspension still lands within an hour of the daily rollup, which is the
+	// only moment the verdict can actually change.
+	r.bwEnforceMu.Lock()
+	if !r.bwEnforceLastRun.IsZero() && time.Since(r.bwEnforceLastRun) < bwEnforceInterval {
+		r.bwEnforceMu.Unlock()
+		return
+	}
+	r.bwEnforceLastRun = time.Now()
+	r.bwEnforceMu.Unlock()
+
 	users, _, err := r.users.List(ctx, repository.ListOptions{Limit: 10000})
 	if err != nil {
 		r.log.Warn("bandwidth_quota_enforce: list users failed", "err", err)
@@ -50,13 +69,25 @@ func (r *Reconciler) reconcileBandwidthQuotaEnforce(ctx context.Context) {
 
 	now := time.Now().UTC()
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	pkgByID := make(map[string]*models.HostingPackage)
 
 	for _, u := range users {
 		if u.IsAdmin || u.PackageID == nil || *u.PackageID == "" {
 			continue
 		}
-		pkg, err := r.packages.FindByID(ctx, *u.PackageID)
-		if err != nil || pkg == nil || pkg.BandwidthQuotaMB == 0 {
+		// Package rows are a small static table and many users share one, so
+		// resolve each distinct id once per pass instead of once per user.
+		pkg, ok := pkgByID[*u.PackageID]
+		if !ok {
+			p, perr := r.packages.FindByID(ctx, *u.PackageID)
+			if perr != nil || p == nil {
+				pkgByID[*u.PackageID] = nil
+				continue
+			}
+			pkgByID[*u.PackageID] = p
+			pkg = p
+		}
+		if pkg == nil || pkg.BandwidthQuotaMB == 0 {
 			continue
 		}
 		bytesByDomain, err := r.bwDaily.SumByDomainForUser(ctx, u.ID, monthStart, now)

--- a/panel-api/internal/reconciler/phases/m65_mailbox_share.go
+++ b/panel-api/internal/reconciler/phases/m65_mailbox_share.go
@@ -45,14 +45,41 @@ func (p *mailboxSharePhase) ReconcileMailbox(ctx context.Context, mb *models.Mai
 	}
 
 	// Build target email → rights map.
+	//
+	// Batch the lookups (JAB-147 pattern): resolving each grant with its own
+	// FindByID pair ran 2 queries per share on the 60s reconcile hot path,
+	// even though FindByIDs already exists on both repositories.
+	targetIDs := make([]string, 0, len(shares))
+	for _, s := range shares {
+		targetIDs = append(targetIDs, s.SharedWithMailboxID)
+	}
+	targets, terr := p.mailboxes.FindByIDs(ctx, targetIDs)
+	if terr != nil {
+		return fmt.Errorf("batch-load share targets: %w", terr)
+	}
+	targetByID := make(map[string]models.Mailbox, len(targets))
+	domIDs := make([]string, 0, len(targets))
+	for _, t := range targets {
+		targetByID[t.ID] = t
+		domIDs = append(domIDs, t.DomainID)
+	}
+	targetDomains, derr := p.domains.FindByIDs(ctx, domIDs)
+	if derr != nil {
+		return fmt.Errorf("batch-load share target domains: %w", derr)
+	}
+	domByID := make(map[string]models.Domain, len(targetDomains))
+	for _, d := range targetDomains {
+		domByID[d.ID] = d
+	}
+
 	sharesByEmail := make(map[string]models.Rights, len(shares))
 	for _, s := range shares {
-		target, err := p.mailboxes.FindByID(ctx, s.SharedWithMailboxID)
-		if err != nil {
+		target, ok := targetByID[s.SharedWithMailboxID]
+		if !ok {
 			continue
 		}
-		tdom, err := p.domains.FindByID(ctx, target.DomainID)
-		if err != nil {
+		tdom, ok := domByID[target.DomainID]
+		if !ok {
 			continue
 		}
 		sharesByEmail[target.LocalPart+"@"+tdom.Name] = s.Rights

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -206,6 +206,13 @@ type Reconciler struct {
 	// dispatch omits directory_privacy_rules → no htpasswd files
 	// written, no auth_basic location blocks rendered.
 	domainDirPrivacy repository.DomainDirectoryPrivacyRepository
+	// bwEnforce* rate-limits the bandwidth-quota suspension sweep to
+	// bwEnforceInterval. Its input (bw_daily) is written once a day, so
+	// running it every 60s recomputed an identical verdict ~1439 times out of
+	// 1440 — at a cost of several queries per eligible user each time.
+	bwEnforceMu      sync.Mutex
+	bwEnforceLastRun time.Time
+
 	// sshKeysDispatchCache: per-user hash of last-applied SSH keys +
 	// timestamp. Lets ReconcileSSHKeysForUser skip the agent IPC when
 	// the desired state hasn't changed since the last dispatch. Self-

--- a/panel-api/internal/repository/audit_event_repository.go
+++ b/panel-api/internal/repository/audit_event_repository.go
@@ -73,6 +73,8 @@ type AuditEventRepository interface {
 	// panel scale; a very large log would need chunked streaming
 	// verification (future, tracked in ADR-0106 §risks).
 	AllForVerify(ctx context.Context) ([]models.AuditEvent, error)
+	// EachForVerify streams the chain in batches (see implementation).
+	EachForVerify(ctx context.Context, batchSize int, fn func([]models.AuditEvent) bool) error
 
 	// PruneOlderThan deletes rows with ts < cutoff and returns the
 	// count. ADR-0106's eventual target is a whole-partition DROP
@@ -251,6 +253,37 @@ func (r *auditEventRepo) ListUnsealed(ctx context.Context, limit int) ([]models.
 	return rows, nil
 }
 
+// EachForVerify walks the whole chain in id/ts order, handing the caller one
+// batch at a time. fn returns false to stop early (a broken row is found).
+//
+// AllForVerify below loads the entire append-only table into memory; on a busy
+// box that is hundreds of thousands of rows and O(table) memory for a single
+// admin request. The chain state is scalar, so verification does not need the
+// rows all at once.
+func (r *auditEventRepo) EachForVerify(ctx context.Context, batchSize int, fn func([]models.AuditEvent) bool) error {
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	var batch []models.AuditEvent
+	return r.db.WithContext(ctx).
+		Order("ts ASC, id ASC").
+		FindInBatches(&batch, batchSize, func(tx *gorm.DB, _ int) error {
+			if !fn(batch) {
+				// Returning an error is how FindInBatches stops; translate it
+				// back to "clean stop" in the caller.
+				return errVerifyStop
+			}
+			return nil
+		}).Error
+}
+
+// errVerifyStop signals an intentional early exit from EachForVerify.
+var errVerifyStop = errors.New("verify: stop")
+
+// IsVerifyStop reports whether an EachForVerify error is the intentional
+// early-exit sentinel rather than a real failure.
+func IsVerifyStop(err error) bool { return errors.Is(err, errVerifyStop) }
+
 func (r *auditEventRepo) AllForVerify(ctx context.Context) ([]models.AuditEvent, error) {
 	var rows []models.AuditEvent
 	err := r.db.WithContext(ctx).
@@ -316,4 +349,3 @@ func (r *auditEventRepo) ChainAnchor(ctx context.Context) (string, error) {
 	}
 	return *row.AuditChainAnchor, nil
 }
-


### PR DESCRIPTION
Four findings, all the same shape: **work repeated on inputs that did not move.**

### LO-2 — audit verify loaded the entire table into memory
The verify endpoint ran an unbounded `Find` over the whole append-only `audit_events` table to recompute the tamper-evidence hash chain. That table reaches hundreds of thousands of rows between prunes, making this **the one endpoint that could OOM-spike the API** on a busy box.

The chain state is scalar — a previous row hash plus a count — so the rows never needed to be present at once. Added `VerifyChainBatch` (returning the hash to continue from) and a repository `EachForVerify` that walks in batches of 1000; the handler folds over them and **stops early on a break** instead of reading the rest of the table. `VerifyChain` stays as a thin wrapper, so existing callers and tests are untouched.

The test proves the equivalence that makes this safe: batched verification returns the same `ok` / `broken_id` / `checked` as verifying the whole slice, and a mid-stream break is reported with the same row id.

### LO-11 — bandwidth quota recomputed every 60s against daily data
Per tick, per eligible user: a package lookup, a join+SUM over month-to-date bandwidth, and a domain list. Its input (`bw_daily`) is written **once a day**, so 1439 of every 1440 evaluations recomputed an identical verdict.

Now gated to hourly — still catching a breach within an hour of the only moment the answer can change — plus package rows resolved once per distinct id per pass rather than once per user.

### LO-12 — a DB write per mailbox per tick to record "still nothing"
mailscan bumped `ScannedAt` and upserted for **every** mailbox **every** 5-minute tick even when the JMAP query returned zero new emails.

**Verified before removing it** that the scan cursor is `LastReceivedAt`, not `ScannedAt`, and that nothing else in the codebase reads `ScannedAt` — so skipping the idle write cannot lose a cursor or trigger a re-scan. That check was the actual work; the deletion is one line.

### ME-14 — per-grant N+1 on the 60s hot path
The mailbox-share reconcile phase resolved every grant with its own `FindByID` pair — two queries per share — although `FindByIDs` already exists on both repositories (the JAB-147 pattern). Batched into two queries per tick.

### Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — **0 failures** (explicit FAIL count)
- [x] New tests: batched chain verification matches whole-slice verification; a mid-stream break reports the same row id and stops the walk

> CI note: the self-hosted runner is currently failing every Go job at `actions/setup-go` with `EACCES: permission denied, mkdir '/home/runner/go/bin'` — before any test runs. Red checks here are that, not this change. Verified locally instead.
