### PR TITLE
fix(ssl): serve fresh domains over plain HTTP until a trusted cert lands (GH #896/#887)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -49,6 +49,14 @@ type domainCreateParams struct {
 	// PHP apps (osTicket, …) that route through /script.php/extra/path URLs.
 	// false ⇒ vhost byte-identical (feature off).
 	PathInfo bool `json:"path_info"`
+	// RedirectHTTPS (GH #896) — whether the :80 vhost force-redirects to HTTPS
+	// (and, with it, whether the :443 block renders at all). The reconciler
+	// sets it false while an LE/auto-mode domain is still parked on its
+	// self-signed BOOTSTRAP placeholder, so the site serves plain HTTP + the
+	// ACME challenge (no cert-authority warning, no HSTS hard-fail) until a
+	// trusted cert issues. Pointer so a pre-#896 panel that omits the field
+	// falls back to the historical "redirect whenever a cert is present".
+	RedirectHTTPS *bool `json:"redirect_https,omitempty"`
 	// CacheEnabled (ADR-0108) — per-domain nginx FastCGI micro-cache
 	// opt-in. false ⇒ vhost byte-identical to the pre-0108 shape.
 	CacheEnabled bool   `json:"cache_enabled"`
@@ -80,8 +88,8 @@ type domainCreateParams struct {
 	PreviewHost     string `json:"preview_host,omitempty"`
 	PreviewCertPath string `json:"preview_cert_path,omitempty"`
 	PreviewKeyPath  string `json:"preview_key_path,omitempty"`
-	SSLCertPath         string   `json:"ssl_cert_path"`
-	SSLKeyPath          string   `json:"ssl_key_path"`
+	SSLCertPath     string `json:"ssl_cert_path"`
+	SSLKeyPath      string `json:"ssl_key_path"`
 	// PHP INI overrides: omitted if not set on the domain.
 	PHPMemoryLimit       string `json:"php_memory_limit,omitempty"`
 	PHPUploadMaxFilesize string `json:"php_upload_max_filesize,omitempty"`
@@ -189,10 +197,15 @@ const vhostTemplate = `server {
         auth_basic off;
     }
 {{ end }}
-{{ if .SSLCertPath }}
-    # Redirect HTTP to HTTPS when SSL is configured. Scoped to the
-    # default location so the ^~ ACME location above wins for
-    # challenge paths — see the rationale comment there.
+{{ if .RedirectHTTPS }}
+    # Redirect HTTP to HTTPS once a TRUSTED cert is serving. Gated on
+    # RedirectHTTPS (not merely "a cert exists") so a fresh LE-mode domain
+    # still on its self-signed bootstrap placeholder serves the docroot over
+    # plain HTTP — the shared tail below attaches to THIS :80 server when the
+    # :443 block is absent — instead of 301'ing browsers into a cert-authority
+    # warning (GH #896/#887). The redirect + :443 appear on the tick a real
+    # cert lands. Scoped to the default location so the ^~ ACME location above
+    # wins for challenge paths — see the rationale comment there.
     location / {
         return 301 https://$host$request_uri;
     }
@@ -641,23 +654,28 @@ server {
 {{ end }}`
 
 type vhostData struct {
-	Domain               string
-	PreviewHost          string
-	PreviewCertPath      string
-	PreviewKeyPath       string
-	PreviewUpstream      string
-	DocRoot              string
-	HasPHP               bool
-	PHPVersion           string
-	Username             string
-	FPMSocket            string
-	IndexDirective       string
-	RedirectDirectives   string
-	RuleDirectives       string
-	CustomDirectives     string
-	IsEnabled            bool
-	SSLCertPath          string
-	SSLKeyPath           string
+	Domain             string
+	PreviewHost        string
+	PreviewCertPath    string
+	PreviewKeyPath     string
+	PreviewUpstream    string
+	DocRoot            string
+	HasPHP             bool
+	PHPVersion         string
+	Username           string
+	FPMSocket          string
+	IndexDirective     string
+	RedirectDirectives string
+	RuleDirectives     string
+	CustomDirectives   string
+	IsEnabled          bool
+	SSLCertPath        string
+	SSLKeyPath         string
+	// RedirectHTTPS (GH #896) gates the HTTP→HTTPS redirect AND the :443
+	// server block. When false the shared tail (root/PHP/locations) attaches
+	// to the :80 server so the docroot is served over plain HTTP — the
+	// self-signed bootstrap window. Always false when SSLCertPath is empty.
+	RedirectHTTPS        bool
 	PHPMemoryLimit       string
 	PHPUploadMaxFilesize string
 	PHPPostMaxSize       string
@@ -946,7 +964,7 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS bool) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -974,6 +992,14 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 			sslKeyPath = ""
 		}
 	}
+	// GH #896/#213: the redirect + :443 block only renders when RedirectHTTPS
+	// is set, and a redirect is meaningless (and #213-dangerous) without a cert
+	// file on disk. If the stat-fallback above just zeroed the cert path, force
+	// the redirect off too so we never emit `ssl_certificate <empty>;` — the
+	// :80 ACME location + docroot then serve HTTP-only until the cert re-lands.
+	if sslCertPath == "" {
+		redirectHTTPS = false
+	}
 	// Same missing-file fallback for the preview wildcard pair: the shared
 	// *.preview.<hostname> cert may not be issued yet when the first
 	// preview-enabled domain converges — serve the preview HTTP-only until
@@ -1000,7 +1026,11 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		if listenIPv4 != "" {
 			upstreamAddr = listenIPv4
 		}
-		if sslCertPath != "" {
+		// Hairpin to https only when the main vhost actually serves a :443
+		// block — i.e. RedirectHTTPS (GH #896). During the self-signed
+		// bootstrap window the main vhost is HTTP-only, so the preview must
+		// proxy over http or it would hit a dead :443.
+		if redirectHTTPS {
 			previewUpstream = "https://" + upstreamAddr + ":443"
 		} else {
 			previewUpstream = "http://" + upstreamAddr + ":80"
@@ -1037,6 +1067,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		IsEnabled:                  isEnabled,
 		SSLCertPath:                sslCertPath,
 		SSLKeyPath:                 sslKeyPath,
+		RedirectHTTPS:              redirectHTTPS,
 		PHPMemoryLimit:             phpMemLimit,
 		PHPUploadMaxFilesize:       phpUploadMax,
 		PHPPostMaxSize:             phpPostMax,
@@ -1285,7 +1316,15 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		}
 	}
 	dirPrivacyDirectives := buildDirectoryPrivacyDirectives(p.DirectoryPrivacyRules)
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo)
+	// GH #896: default to the historical "redirect whenever a cert is present"
+	// so a pre-#896 panel that omits redirect_https keeps working. A current
+	// panel always sends the field; writeVhost still forces it false if the
+	// cert file turns out to be missing on disk (#213).
+	redirectHTTPS := p.SSLCertPath != ""
+	if p.RedirectHTTPS != nil {
+		redirectHTTPS = *p.RedirectHTTPS
+	}
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_gh896_test.go
+++ b/panel-agent/internal/commands/domain_create_gh896_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// gh896VhostData is a minimal enabled PHP domain; the caller flips RedirectHTTPS
+// and the cert paths to model the self-signed bootstrap vs the trusted-cert
+// state.
+func gh896VhostData(redirect bool) vhostData {
+	vd := vhostData{
+		Domain:         "example.com",
+		DocRoot:        "/home/u/domains/example.com/public_html",
+		Username:       "u",
+		PHPVersion:     "8.3",
+		FPMSocket:      "/run/php/jabali-u/fpm.sock",
+		IndexDirective: "index index.php index.html;",
+		IsEnabled:      true,
+		HasPHP:         true,
+		// A cert exists on disk in BOTH states (the self-signed placeholder is
+		// still written); RedirectHTTPS is what gates the :443 + redirect.
+		SSLCertPath:   "/etc/ssl/jabali-selfsigned/example.com/fullchain.pem",
+		SSLKeyPath:    "/etc/ssl/jabali-selfsigned/example.com/privkey.pem",
+		RedirectHTTPS: redirect,
+	}
+	return vd
+}
+
+// TestVhostGH896_SelfSignedBootstrapServesHTTP verifies the fix: with
+// RedirectHTTPS=false (a fresh LE-mode domain still on its self-signed
+// placeholder), the :80 vhost serves the docroot directly — no HTTP→HTTPS
+// redirect, no :443 block — while still exposing the ACME challenge location.
+func TestVhostGH896_SelfSignedBootstrapServesHTTP(t *testing.T) {
+	out := mustRenderVhost(t, gh896VhostData(false))
+
+	mustNotContain := map[string]string{
+		"return 301 https":                     "must not redirect to HTTPS while self-signed",
+		"listen 443 ssl":                       "must not open a :443 listener while self-signed",
+		"listen [::]:443 ssl":                  "must not open a :443 IPv6 listener while self-signed",
+		"ssl_certificate /etc/ssl/jabali-self": "must not reference the self-signed cert in a :443 block",
+	}
+	for needle, why := range mustNotContain {
+		if strings.Contains(out, needle) {
+			t.Errorf("%s — found %q in:\n%s", why, needle, out)
+		}
+	}
+
+	mustContain := map[string]string{
+		"location ^~ /.well-known/acme-challenge/":     "ACME challenge must still be served on :80",
+		"root /home/u/domains/example.com/public_html": "docroot must be served on the :80 server",
+		"listen 80;": "must listen on :80",
+	}
+	for needle, why := range mustContain {
+		if !strings.Contains(out, needle) {
+			t.Errorf("%s — missing %q in:\n%s", why, needle, out)
+		}
+	}
+}
+
+// TestVhostGH896_TrustedCertRedirects verifies the other half: once a trusted
+// cert lands (RedirectHTTPS=true) the :80 vhost 301s to HTTPS and the :443
+// block renders — the historical behavior, unchanged.
+func TestVhostGH896_TrustedCertRedirects(t *testing.T) {
+	out := mustRenderVhost(t, gh896VhostData(true))
+
+	for _, needle := range []string{
+		"return 301 https://$host$request_uri",
+		"listen 443 ssl",
+		"ssl_certificate /etc/ssl/jabali-selfsigned/example.com/fullchain.pem;",
+		"location ^~ /.well-known/acme-challenge/",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Errorf("trusted-cert vhost missing %q in:\n%s", needle, out)
+		}
+	}
+}

--- a/panel-agent/internal/commands/domain_create_root_override_test.go
+++ b/panel-agent/internal/commands/domain_create_root_override_test.go
@@ -192,6 +192,7 @@ func TestVhost_RuleBuilderRootProxyDoesNotDuplicateLocation(t *testing.T) {
 		IsEnabled:      true,
 		SSLCertPath:    "/etc/ssl/x.crt",
 		SSLKeyPath:     "/etc/ssl/x.key",
+		RedirectHTTPS:  true, // GH #896: :443 + :80-redirect block gated on this
 		ListenIPv4:     "1.2.3.4",
 		RuleDirectives: ruleBlock,
 		RootOverridden: directivesOverrideRoot("", ruleBlock),

--- a/panel-agent/internal/commands/vhost_listen_ip_test.go
+++ b/panel-agent/internal/commands/vhost_listen_ip_test.go
@@ -30,6 +30,10 @@ func renderVhost(t *testing.T, v4, v6 string, ssl bool) string {
 	if ssl {
 		vd.SSLCertPath = "/etc/ssl/example.com.pem"
 		vd.SSLKeyPath = "/etc/ssl/example.com.key"
+		// GH #896: the redirect + :443 block is now gated on RedirectHTTPS
+		// (a trusted cert), not merely on SSLCertPath. ssl=true here models a
+		// domain serving HTTPS, so set it.
+		vd.RedirectHTTPS = true
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, vd); err != nil {

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/redirects"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/services"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sslorigin"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sso"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
@@ -1846,8 +1847,20 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 	// JAB-170: a shared-cert domain serves the ONE shared pair by path,
 	// independent of any per-domain ssl_certificates row. The agent stats the
 	// path and falls back to HTTP if the shared cert is not on disk yet.
+	// GH #896: redirectHTTPS decides whether the agent renders the :80→:443
+	// redirect (and the :443 block). Default: redirect whenever a trusted cert
+	// is on disk. Suppress ONLY while an LE/auto-mode domain is still on its
+	// self-signed BOOTSTRAP placeholder — redirecting there throws a
+	// cert-authority warning (the reporter's "can't access until LE"), and an
+	// HSTS-pinned browser hard-fails on the self-signed cert just the same.
+	// Serve plain HTTP + the ACME challenge until a real cert lands. Always set
+	// explicitly (false in the no-cert branch too) so a current panel never
+	// sends nil.
+	redirectHTTPS := false
 	if domain.SSLMode == models.SSLModeShared && domain.SharedCertificateID != nil && *domain.SharedCertificateID != "" {
-		params["ssl_cert_path"], params["ssl_key_path"] = sharedCertPaths(*domain.SharedCertificateID)
+		certPath, keyPath := sharedCertPaths(*domain.SharedCertificateID)
+		params["ssl_cert_path"], params["ssl_key_path"] = certPath, keyPath
+		redirectHTTPS = redirectHTTPSForCert(domain.SSLMode, certPath)
 	} else if r.sslCerts != nil {
 		sslCtx, sslCancel := context.WithTimeout(ctx, 10*time.Second)
 		cert, err := r.sslCerts.FindByDomainID(sslCtx, domain.ID)
@@ -1856,8 +1869,10 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			cert.CertPath != nil && cert.KeyPath != nil {
 			params["ssl_cert_path"] = *cert.CertPath
 			params["ssl_key_path"] = *cert.KeyPath
+			redirectHTTPS = redirectHTTPSForCert(domain.SSLMode, *cert.CertPath)
 		}
 	}
+	params["redirect_https"] = redirectHTTPS
 
 	// Preview URL params (temp URLs) — nil when disabled or no hostname.
 	for k, v := range r.previewParams(ctx, domain) {
@@ -1874,6 +1889,35 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			"domain", domain.Name,
 			"err", err)
 	}
+}
+
+// redirectHTTPSForCert decides whether the agent should render the :80→:443
+// redirect (and the :443 block) for a domain, given its SSL mode and the cert
+// path that will actually be served.
+//
+// GH #896/#887: default is to redirect whenever a cert is on disk. The one case
+// we suppress it — serving the docroot over plain HTTP + the ACME challenge
+// instead — is an LE/auto-mode domain still parked on its self-signed BOOTSTRAP
+// placeholder. Redirecting there sends browsers to an untrusted cert (the
+// reporter's "can't access until LE" warning); an HSTS-pinned visitor hard-fails
+// on that self-signed cert just the same. The redirect (and HSTS) begin on the
+// tick a real cert lands.
+//
+// The decision is by PATH, not row status: a renewal-failing domain that still
+// has a VALID Let's Encrypt cert on disk keeps redirecting, while one dropped to
+// a self-signed fallback correctly serves HTTP. SSLModeSelf and SSLModeCustom
+// may point at the same self-signed directory, but there the placeholder is the
+// operator's deliberate choice — so the carve-out is gated on the LE/legacy-empty
+// auto modes only, which are the ones for which self-signed is transient.
+func redirectHTTPSForCert(mode, certPath string) bool {
+	if certPath == "" {
+		return false
+	}
+	if (mode == models.SSLModeLE || mode == "") &&
+		sslorigin.KindForPath(certPath) == sslorigin.KindSelfSigned {
+		return false
+	}
+	return true
 }
 
 // sharedCertDir mirrors the agent's sslSharedRoot: /etc/jabali/ssl/shared/<id>

--- a/panel-api/internal/reconciler/redirect_https_test.go
+++ b/panel-api/internal/reconciler/redirect_https_test.go
@@ -1,0 +1,56 @@
+package reconciler
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// TestRedirectHTTPSForCert covers GH #896/#887: a fresh LE/auto-mode domain on
+// its self-signed bootstrap placeholder must NOT redirect to HTTPS (serve plain
+// HTTP + ACME until a trusted cert lands), while every trusted-cert state — and
+// the operator's deliberate self/custom/shared choices — keep redirecting.
+func TestRedirectHTTPSForCert(t *testing.T) {
+	const (
+		selfSigned = "/etc/ssl/jabali-selfsigned/example.com/fullchain.pem"
+		leCert     = "/etc/letsencrypt/live/example.com/fullchain.pem"
+		sharedCert = "/etc/jabali/ssl/shared/01ABC/fullchain.pem"
+		customCert = "/etc/nginx/ssl/operator.example.com.pem"
+	)
+	cases := []struct {
+		name     string
+		mode     string
+		certPath string
+		want     bool
+	}{
+		// The fix: fresh LE bootstrap placeholder → HTTP only.
+		{"le mode self-signed bootstrap", models.SSLModeLE, selfSigned, false},
+		{"legacy-empty mode self-signed bootstrap", "", selfSigned, false},
+		// A pending_acme_retry that dropped to a self-signed fallback is the
+		// same served-cert as the bootstrap: HTTP only (path is authoritative).
+		{"le mode acme-retry self-signed fallback", models.SSLModeLE, selfSigned, false},
+
+		// Trusted certs always redirect.
+		{"le mode issued LE cert", models.SSLModeLE, leCert, true},
+		{"legacy-empty mode issued LE cert", "", leCert, true},
+		// Renewal-in-progress still has the valid LE cert on disk → keep redirecting.
+		{"le mode renewing with valid LE cert on disk", models.SSLModeLE, leCert, true},
+
+		// Operator-chosen modes keep serving HTTPS even from the self-signed dir.
+		{"self mode self-signed is the chosen cert", models.SSLModeSelf, selfSigned, true},
+		{"custom mode operator cert", models.SSLModeCustom, customCert, true},
+		// A shared LE wildcard is trusted.
+		{"shared mode wildcard cert", models.SSLModeShared, sharedCert, true},
+
+		// No cert on disk: no :443, redirect is meaningless — :80 serves the docroot.
+		{"le mode no cert", models.SSLModeLE, "", false},
+		{"self mode no cert", models.SSLModeSelf, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redirectHTTPSForCert(tc.mode, tc.certPath); got != tc.want {
+				t.Errorf("redirectHTTPSForCert(%q, %q) = %v, want %v", tc.mode, tc.certPath, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/sslorigin/classify.go
+++ b/panel-api/internal/sslorigin/classify.go
@@ -80,6 +80,13 @@ func certPathFromVhost(body string) string {
 	return ""
 }
 
+// KindForPath classifies a certificate purely by its on-disk location, without
+// reading the file. jabali owns both directory layouts, so the path is
+// authoritative for its own certificates. Exported for the reconciler's GH #896
+// redirect decision: a cert under jabaliSelfSignedDir is the self-signed
+// bootstrap placeholder, one under letsEncryptLiveDir is a real LE cert.
+func KindForPath(path string) Kind { return kindForPath(path) }
+
 // kindForPath classifies purely by where the certificate lives. jabali owns both
 // directory layouts, so the path is authoritative for its own certificates.
 func kindForPath(path string) Kind {


### PR DESCRIPTION
## Problem (GH #896, #887)

A brand-new domain gets a self-signed placeholder cert on its first reconcile tick (#916), and the vhost then **force-redirects `:80` → `:443` to that self-signed cert**. Browsers block it with a cert-authority warning, and HSTS-pinned visitors hard-fail on it — so the site reads as *"can't access until Let's Encrypt kicks in"* even though a cert is technically present. #916 made HTTPS reachable-but-untrusted; it did not resolve the reporter's actual experience (johnnyq re-tested and still hit an error in the pre-LE window, which is why #896 was reopened).

The tracked plan: **serve the docroot + the ACME challenge over plain HTTP during the self-signed bootstrap window, and only redirect to HTTPS (with `:443` + HSTS) once a CA-trusted cert lands.**

## What changed

**panel-agent** (`domain_create.go`)
- `domain.create` gains a `redirect_https` param (`*bool`). The main vhost's `location / { return 301 }` **and** the entire `:443` server block are now gated on `{{ if .RedirectHTTPS }}` instead of `{{ if .SSLCertPath }}`. When false, the shared tail (root/PHP/locations) attaches to the `:80` server, so the docroot is served over plain HTTP.
- Nil (a pre-change panel that omits the field) falls back to the historical *"redirect whenever a cert is present"* — rolling-update safe.
- `writeVhost` still forces `redirect_https` false when the cert file is missing on disk, preserving the #213 HTTP-only fallback (never emits `ssl_certificate <empty>`).
- Preview upstream now follows `redirect_https`, so it never hairpins to a `:443` that isn't rendered.

**panel-api** (`reconciler.go`, `sslorigin/classify.go`)
- `createDomainOnAgent` sets `redirect_https` via a new pure helper `redirectHTTPSForCert(mode, certPath)`: default true when a cert is on disk, **false only when** the mode is LE / legacy-empty auto **and** `sslorigin.KindForPath(certPath) == KindSelfSigned`.
- The decision keys off the **served cert path**, not the row status — so a renewal-failing domain that still has a valid LE cert on disk keeps redirecting, while one dropped to the self-signed fallback correctly serves HTTP.
- `SSLModeSelf` / `SSLModeCustom` / `SSLModeShared` are carved out (their self-signed/operator cert is a deliberate choice, not a placeholder).
- Exported `sslorigin.KindForPath`.

## Why it's safe

- **HSTS**: an LE-mode domain only reaches a self-signed *served path* on the fresh bootstrap. An issued cert failing renewal goes to `renewing`/`pending_acme_retry` keeping its LE path (→ keeps redirecting), or is clobbered to a self-signed path (→ HTTP is correct, since a pinned browser hard-fails on self-signed either way). So the suppression can never strand an HSTS-pinned visitor.
- **Rolling compat**: the `*bool` nil-default preserves old behavior, proven by every existing vhost golden staying **byte-identical**.
- **#213**: the missing-cert-file guard is preserved.

## Test plan

- [x] `panel-api/internal/reconciler` — new `TestRedirectHTTPSForCert` matrix (shared / custom / self / le+self_signed / le+issued / le+renewing-valid-LE / le+acme-retry-fallback / no-cert); full package green, `-race` clean.
- [x] `panel-agent/internal/commands` — new `TestVhostGH896_SelfSignedBootstrapServesHTTP` + `TestVhostGH896_TrustedCertRedirects`; full package green.
- [x] Existing vhost goldens byte-identical (the 3 direct-`vhostData` constructors set `RedirectHTTPS` alongside `SSLCertPath`).
- [x] `go vet` + `gofmt` clean on all touched files.
- [x] **Live-verified on a box (both binaries deployed):**
  - **State A** — fresh domain (cert `self_signed`): vhost has `0` `listen 443`, `0` `return 301`, docroot `root` on `:80`, ACME location present, `nginx -t` ok, `curl http://` → **200** (placeholder), `https://` → connection refused (no listener → no warning possible).
  - **State B** — flip cert row to `issued` + an LE path: next tick rewrites the vhost with `listen 443` + `return 301` + the LE cert path, `curl http://` → **301**, `curl -k https://` → **200**.

## Notes

- References **GH #896** and **GH #887**; intentionally uses no auto-close keyword (issues are closed manually here).
- CI is currently down (unrelated infra) — checks will be red until that's restored.
