### PR TITLE
fix(install): run the /tmp hardening on update, not only on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14263,6 +14263,12 @@ provision_new_software() {
   # anything else in the provision chain touches PHP.
   ensure_jabali_panel_dir_traversable
   ensure_snuffleupagus_loadable
+  # Also on UPDATE, not just fresh install: `jabali update` runs this trimmed
+  # path, not main(), so wiring the call only into main() left every EXISTING
+  # host — the ones that have been downloading to predictable /tmp paths for
+  # months — without the protection. Caught on the testserver deploy: the
+  # function was present in install.sh and had simply never run.
+  ensure_tmp_hardening
 
   # Keep the app-marketplace catalogs current on `jabali update` (build_backend,
   # which also calls this, is NOT in the update path). New docker-app /


### PR DESCRIPTION
Follow-up to #1000, found by verifying the testserver deploy rather than trusting `✓ Update complete`.

`ensure_tmp_hardening` was wired into `main()` only. **`jabali update` runs a trimmed path** (`provision_new_software`), not `main()` — so the function shipped to every host and **never executed on any of them**. The hosts that have been downloading to predictable `/tmp` paths for months got nothing.

### How it surfaced
On testserver after the deploy:
- the function *was* present in the deployed `install.sh` ✅
- `fs.protected_symlinks=1`, `protected_regular=2` — but those are **Debian defaults**, not our doing
- `/etc/sysctl.d/60-jabali-tmp-hardening.conf` **did not exist**
- **0** occurrences of `tmp hardening` in the install log

The sysctls reading "correct" is what would have made this easy to miss — the values looked right for the wrong reason.

### Fix
Called from `provision_new_software` alongside the other `ensure_*` self-heal steps (`ensure_jabali_panel_dir_traversable`, `ensure_snuffleupagus_loadable`), which is the established pattern for "existing hosts converge on update". Idempotent, so running on both paths is free.

### Test plan
- [x] `bash -n install.sh`; `go test ./...` — 0 failures
- [x] Confirmed the call now sits inside `provision_new_software`
- [ ] Next `jabali update` on testserver should print `tmp hardening: ...enforced` and create the sysctl drop-in

This is the general trap worth remembering: adding a step to `main()` does **not** mean it runs on update.