### PR TITLE
fix(apparmor): allow PHP under any custom document root, not just public_html (GH #1001)

### DIFF
--- a/install/apparmor/usr.local.libexec.jabali.fpm-exec
+++ b/install/apparmor/usr.local.libexec.jabali.fpm-exec
@@ -68,13 +68,23 @@ profile jabali-fpm-app /usr/local/libexec/jabali/fpm-exec flags=(attach_disconne
 
   # Tenant docroots (POSIX perms enforce per-user isolation; this layer bounds
   # escape to system files, not cross-tenant). Two layouts: native jabali +
-  # cPanel/DA use domains/<dom>/public_html; HestiaCP-migrated accounts use
-  # web/<dom>/public_html (JAB-37 — the enforced profile denied restored Nextcloud
-  # PHP under web/ even though POSIX perms + open_basedir allowed it).
+  # cPanel/DA use domains/<dom>/; HestiaCP-migrated accounts use web/<dom>/
+  # (JAB-37 — the enforced profile denied restored Nextcloud PHP under web/
+  # even though POSIX perms + open_basedir allowed it).
+  #
+  # GH #1001: the whole per-domain tree is granted, not just <dom>/public_html.
+  # A custom document root (admin GH #265 / tenant GH #526) may point at the
+  # domain base itself or a sibling of public_html — e.g. a Laravel/Symfony app
+  # whose docroot is .../public, or an app that keeps shared code one level up.
+  # Scoping the read to public_html/** made every such docroot 403 with
+  # "Unable to open primary script ... (Permission denied)" even though the
+  # panel accepted the docroot and POSIX perms + open_basedir allowed it. The
+  # tree is the tenant's own space; cross-tenant isolation is still POSIX, and
+  # the deny rules below still bound escape to system files.
   /home/*/domains/*/ r,
-  /home/*/domains/*/public_html/** rwkl,
+  /home/*/domains/*/** rwkl,
   /home/*/web/*/ r,
-  /home/*/web/*/public_html/** rwkl,
+  /home/*/web/*/** rwkl,
   # Tenant PHP error logs (cPanel/DA convention ~/logs/php.error.log —
   # tenants point error_log there via php.ini/ini_set; migrated accounts
   # arrive with it preset). Owner-scoped: a worker only touches its own

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -583,6 +583,30 @@ chmod 0750 "$WR"`)
 			}
 			return nil
 		}},
+		{"sync AppArmor profiles (GH #1001 custom docroot)", func() error {
+			// The FPM AppArmor profile scoped PHP file access to
+			// <domain>/public_html/**, so a custom document root pointing
+			// anywhere else in the domain tree (admin GH #265 / tenant GH #526,
+			// e.g. a Laravel app rooted at .../public) 403'd with "Unable to
+			// open primary script ... Permission denied" — an AppArmor deny,
+			// not POSIX or open_basedir (GH #1001). The broadened rule ships in
+			// install/apparmor/, but jabali update never re-applied AppArmor
+			// profiles — only fresh installs ran install_apparmor — so the fix
+			// would never reach existing hosts. Re-apply here (PRELUDE, every
+			// update, incl. the fast path) so it lands. apply_apparmor_profiles
+			// re-copies each profile, reloads via apparmor_parser -r, and
+			// PRESERVES the current complain/enforce mode; it no-ops in
+			// containers and when AppArmor is disabled. Idempotent.
+			installSh := repoDir + "/install.sh"
+			if _, err := os.Stat(installSh); err != nil {
+				return nil
+			}
+			if err := run("", "bash", "-c",
+				"source "+installSh+" && apply_apparmor_profiles 0"); err != nil {
+				fmt.Printf("  (apply_apparmor_profiles failed: %v -- continuing)\n", err)
+			}
+			return nil
+		}},
 		{"self-heal panel-hostname vhost + landing (GH#135)", func() error {
 			// jabali update never re-renders the server-scope nginx vhosts
 			// (only fresh installs run install_nginx_default_vhost), so the


### PR DESCRIPTION
## Problem (GH #1001)

A custom document root that points anywhere in the domain tree other than `<domain>/public_html` — the domain base itself, or a sibling like a Laravel/Symfony app rooted at `.../public` — returns **403** with, in the domain error log:

```
PHP Request Startup: Failed to open stream: Permission denied ...
Unable to open primary script: /home/<u>/domains/<d>/index.php (Permission denied)
```

`.../public_html/index.php` serves fine; the base-dir `index.php` does not.

## Root cause — AppArmor, not POSIX or open_basedir

The panel accepts the docroot (`validateTenantDocumentRoot`, GH #526, explicitly allows the domain base and sub-dirs), POSIX perms are correct (the agent chmods the whole docroot chain to `2750 <user>:www-data`), and `open_basedir` spans the entire home. PHP-FPM (running as the tenant) can reach the file by every DAC/`open_basedir` measure.

The block is the `jabali-fpm-app` AppArmor profile, which granted PHP file access only under `.../public_html/**`. Confirmed on a box via the audit trail:

```
apparmor="DENIED" operation="open" class="file" profile="jabali-fpm-app"
name="/home/dr1/domains/dr1.../index.php" requested_mask="r" denied_mask="r"
```

## Fix

**1. `install/apparmor/usr.local.libexec.jabali.fpm-exec`** — broaden the grant from `<domain>/public_html/**` to the whole per-domain tree, for both layouts:

```
- /home/*/domains/*/public_html/** rwkl,
+ /home/*/domains/*/** rwkl,
- /home/*/web/*/public_html/** rwkl,
+ /home/*/web/*/** rwkl,
```

Security posture is unchanged: this is a **shared** workload-class profile that never enforced cross-tenant isolation (that's POSIX ownership — comment lines 15–18), and the domain tree is the tenant's own space. The hard denies for `/etc/shadow`, `/root/**`, `~/.ssh/**`, and `migration-secrets/**` are untouched, so the profile still bounds escape to system files. The `jabali-sendmail` child profile is unchanged.

**2. `panel-api/cmd/server/update.go`** — add a PRELUDE step that runs `apply_apparmor_profiles` on every `jabali update`. AppArmor profiles were only (re)applied by `install_apparmor` on **fresh installs**, never on update — so without this the broadened rule would never reach existing hosts (the recurring "ships in repo ≠ deploys on update" trap). `apply_apparmor_profiles` re-copies + `apparmor_parser -r` reloads each profile, **preserves** the current complain/enforce mode, and no-ops in containers / when AppArmor is disabled.

## Verification

- **Live on a box, both states:** a domain with `doc_root` set to the base dir returned 403 "Access denied" (PHP "Permission denied" opening the script) under the shipped profile; after broadening the rule + `apparmor_parser -r`, the **same request served the PHP output**. `public_html` docroots and the deny rules are unaffected.
- `make aa-smoke` (the profile file's documented pre-ship gate): the only profile from this file that the corpus exercises is `jabali-sendmail` → **passes** (`OK: tcp:127.0.0.1:587`). `jabali-fpm-app` has no backing-service socket and isn't in the corpus; it's covered by the live PHP-serving test above.
- `go build` + `go vet` + `gofmt` clean.

## Notes

- References **GH #1001**; no auto-close keyword (issues are closed manually here).
- Out of scope but worth a separate ticket: `make aa-smoke` is red on any current box because its corpus still lists `jabali-agent` and `jabali-kratos`, which were intentionally dropped (M40.2/M40.3).
