### PR TITLE
fix(apps): seed osTicket's admin with the stored username, not a sysadmin fallback

### DIFF
--- a/panel-api/internal/api/applications_kicker_test.go
+++ b/panel-api/internal/api/applications_kicker_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// kickerAgentFake records agent calls and signals when app.install arrives.
+type kickerAgentFake struct {
+	mu     sync.Mutex
+	params map[string]any
+	done   chan struct{}
+}
+
+func (f *kickerAgentFake) Call(_ context.Context, command string, params any) (json.RawMessage, error) {
+	if command == "app.install" {
+		f.mu.Lock()
+		f.params, _ = params.(map[string]any)
+		f.mu.Unlock()
+		close(f.done)
+	}
+	return json.RawMessage(`{"version":"1.18.4"}`), nil
+}
+
+// kickerInstallsFake absorbs the kicker's status writes. Every other repo
+// method panics via the embedded nil interface — the kicker must not need it.
+type kickerInstallsFake struct {
+	repository.ApplicationInstallRepository
+}
+
+func (f *kickerInstallsFake) UpdateStatus(context.Context, string, string, *string, *string) error {
+	return nil
+}
+
+// The osTicket kicker must seed the SAME admin username the service stored on
+// the install row (shown in the UI and CLI). It used to re-derive from Params
+// with a "sysadmin" fallback, so every install without an explicit
+// admin_username displayed a generated name that could not log in — caught by
+// the JAB-231 box E2E (panel showed "ebwxhl", osTicket seeded "sysadmin").
+func TestOsTicketKicker_SeedsStoredAdminUsername(t *testing.T) {
+	ag := &kickerAgentFake{done: make(chan struct{})}
+	deps := ApplicationHandlerConfig{
+		ApplicationInstalls: &kickerInstallsFake{},
+		Agent:               ag,
+		// CronJobs nil → cron creation skipped inside the kicker.
+	}
+
+	pass := dispatchInstallKicker(context.Background(), "osticket", kickContext{
+		InstallID:     "01TESTINSTALLID000000000000",
+		OSUser:        "bob",
+		DocRoot:       "/home/bob/public_html",
+		SiteURL:       "https://helpdesk.example.com",
+		AdminUsername: "zqxwvu", // what the service generated AND stored
+		AdminEmail:    "admin@example.com",
+		Params:        map[string]any{"helpdesk_email": "help@example.com"},
+	}, deps)
+
+	select {
+	case <-ag.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("agent app.install was never called")
+	}
+
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	if got := ag.params["admin_username"]; got != "zqxwvu" {
+		t.Fatalf("agent seeded admin_username %v; the stored credential is %q — the UI shows the stored one", got, "zqxwvu")
+	}
+	if pass == "" || ag.params["admin_pass"] != pass {
+		t.Fatalf("returned admin password %q must be what the agent seeds (%v)", pass, ag.params["admin_pass"])
+	}
+}

--- a/panel-api/internal/api/applications_service.go
+++ b/panel-api/internal/api/applications_service.go
@@ -451,7 +451,12 @@ func dispatchInstallKicker(ctx context.Context, appName string, k kickContext, d
 			AdminFirst:    paramOr(k.Params, "admin_first_name", "Admin"),
 			AdminLast:     paramOr(k.Params, "admin_last_name", "User"),
 			AdminEmail:    k.AdminEmail,
-			AdminUsername: paramOr(k.Params, "admin_username", "sysadmin"),
+			// k.AdminUsername is the stored install credential (generated
+			// server-side, or the operator's admin_username param — the
+			// service already folded that in). Re-deriving from Params here
+			// seeded "sysadmin" while the UI showed the generated name, so
+			// the displayed login never worked (JAB-231 E2E).
+			AdminUsername: k.AdminUsername,
 			AdminPass:     ostPass,
 		}, deps)
 		adminPassword = ostPass

--- a/panel-api/internal/apps/osticket.go
+++ b/panel-api/internal/apps/osticket.go
@@ -66,9 +66,12 @@ var OSTicket = App{
 		"admin_username": {
 			Type:     "string",
 			Required: false,
-			Default:  "sysadmin",
+			Pattern:  &adminUsernamePattern,
+			// No default: blank means the service's generated username is
+			// used AND stored — a "sysadmin" default here diverged from the
+			// generated credential the UI displays (JAB-231 E2E).
 			// osTicket bans admin/admins/username/osticket as the login name.
-			Description: "Administrator login username for the agent panel (/scp). Cannot be 'admin', 'admins', 'username' or 'osticket'.",
+			Description: "Administrator login username for the agent panel (/scp). Leave blank for a random one. Cannot be 'admin', 'admins', 'username' or 'osticket'.",
 		},
 		"admin_password": {
 			Type:        "password",


### PR DESCRIPTION
## Summary

JAB-231's fresh-install box E2E caught this: the panel reported admin username `ebwxhl` (generated + stored + displayed), but osTicket's staff table held `sysadmin` — the kicker re-derived the username from raw Params with a `sysadmin` fallback instead of using the stored credential (`applications_service.go:454`). Every osTicket install without an explicit `admin_username` displayed a login that could not log in.

Every other app branch already passes `k.AdminUsername`; osTicket was the sole offender.

## Changes

- osTicket kicker: `AdminUsername: k.AdminUsername` — the value the service generated (or the operator chose) and stored on the install row.
- Descriptor: drop the `sysadmin` default (blank = generated name, which now matches what gets seeded), add the shared `adminUsernamePattern` validation.
- Regression test drives `dispatchInstallKicker("osticket", …)` with a recording agent fake: **red on the old code** (`seeded admin_username sysadmin; the stored credential is "zqxwvu"`), green on the fix. Also pins that the returned shown-once password is what the agent seeds.

## Test plan

- [x] New test red on old code / green on fix (`-race`)
- [x] `go test ./panel-api/...` — 0 FAIL
- [x] Box E2E on testserver (osticket-e2e.jabali.site): fresh install ready; `/scp/` 302→login; authed `/scp/ajax.php/config/scp` **HTTP 200 JSON** with the seeded credentials (login confirmed by hand after reading the staff row)

JAB-231 follow-up; GH #962.