### PR TITLE
fix(db): keep the panel row when the host-side drop fails

### DIFF
--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -462,9 +462,26 @@ func rollbackDBChain(ctx context.Context, cfg ApplicationHandlerConfig, chain pr
 	if chain.DBID == "" {
 		return
 	}
+	// The agent calls were fire-and-forget: the rows went whether or not the
+	// host-side objects did, so a failed drop left an unreferenced MariaDB
+	// database and login behind. Keep the rows when a drop fails — an
+	// unattached database the owner can see and retry beats one nothing
+	// names.
 	if cfg.Agent != nil {
-		cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": chain.DBUsername})
-		cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": chain.DBName})
+		dropFailed := false
+		if _, err := cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": chain.DBUsername}); err != nil {
+			dropFailed = true
+			slog.ErrorContext(ctx, "app install rollback: db_user.drop failed — keeping the panel rows so the account stays visible instead of becoming an orphan",
+				"err", err, "db_user", chain.DBUsername)
+		}
+		if _, err := cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": chain.DBName}); err != nil {
+			dropFailed = true
+			slog.ErrorContext(ctx, "app install rollback: db.drop failed — keeping the panel rows so the database stays visible instead of becoming an orphan",
+				"err", err, "db_name", chain.DBName)
+		}
+		if dropFailed {
+			return
+		}
 	}
 	cfg.DatabaseGrants.Delete(ctx, chain.GrantID)
 	cfg.DatabaseUsers.Delete(ctx, chain.DBUserID)

--- a/panel-api/internal/api/db_orphan_drop_test.go
+++ b/panel-api/internal/api/db_orphan_drop_test.go
@@ -1,0 +1,264 @@
+package api
+
+// A panel row for a MariaDB object must outlive a failed host-side drop.
+//
+// The delete/rollback paths used to log the agent failure and delete the row
+// anyway. Because the agent call is a root RPC, an agent restart, a timeout,
+// or a long-call 502 is enough to fail it — and once the row is gone the
+// MariaDB database and login have nothing left to name them: they do not
+// appear in `jabali db list`, no account backup includes them, and their
+// grants stay live. Four such orphan pairs were found on testserver, two of
+// them complete WordPress schemas (75 and 64 tables) that no backup covered.
+//
+// databases.go's own delete already gets this right (drop failure → 502, row
+// kept); these tests hold the other paths to the same rule.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// dropFailAgent fails the named commands and records every call.
+type dropFailAgent struct {
+	mu       sync.Mutex
+	failCmds map[string]bool
+	calls    []string
+}
+
+func (a *dropFailAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.mu.Lock()
+	a.calls = append(a.calls, cmd)
+	fail := a.failCmds[cmd]
+	a.mu.Unlock()
+	if fail {
+		return nil, errors.New("agent unavailable")
+	}
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+func (a *dropFailAgent) called(cmd string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, c := range a.calls {
+		if c == cmd {
+			return true
+		}
+	}
+	return false
+}
+
+// Repo fakes: embed the interface so only the methods these paths touch need
+// implementing — anything else would panic loudly rather than pass silently.
+
+type fakeInstallRepo struct {
+	repository.ApplicationInstallRepository
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (r *fakeInstallRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *fakeInstallRepo) UpdateStatus(_ context.Context, _, _ string, _, _ *string) error {
+	return nil
+}
+
+type fakeDBRepo struct {
+	repository.DatabaseRepository
+	row     *models.Database
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (r *fakeDBRepo) FindByID(_ context.Context, _ string) (*models.Database, error) {
+	if r.row == nil {
+		return nil, repository.ErrNotFound
+	}
+	return r.row, nil
+}
+
+func (r *fakeDBRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *fakeDBRepo) deleteCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deleted)
+}
+
+type fakeDBUserRepo struct {
+	repository.DatabaseUserRepository
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (r *fakeDBUserRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *fakeDBUserRepo) deleteCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deleted)
+}
+
+type fakeGrantRepo struct {
+	repository.DatabaseUserGrantRepository
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (r *fakeGrantRepo) ListByDatabaseUserID(_ context.Context, _ string) ([]models.DatabaseUserGrant, error) {
+	return []models.DatabaseUserGrant{{ID: "grant-1"}}, nil
+}
+
+func (r *fakeGrantRepo) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *fakeGrantRepo) deleteCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deleted)
+}
+
+func newDeleteFixture(ag *dropFailAgent) (ApplicationHandlerConfig, *fakeInstallRepo, *fakeDBRepo, *fakeDBUserRepo, *fakeGrantRepo) {
+	installs := &fakeInstallRepo{}
+	dbs := &fakeDBRepo{row: &models.Database{ID: "db-1", Name: "alice_wp_abc123"}}
+	dbUsers := &fakeDBUserRepo{}
+	grants := &fakeGrantRepo{}
+	return ApplicationHandlerConfig{
+		ApplicationInstalls: installs,
+		Databases:           dbs,
+		DatabaseUsers:       dbUsers,
+		DatabaseGrants:      grants,
+		Agent:               ag,
+	}, installs, dbs, dbUsers, grants
+}
+
+func runDelete(cfg ApplicationHandlerConfig) {
+	createDeleteAndKickAgent(
+		context.Background(),
+		"install-1", "user-1", "wordpress", "",
+		"db-1", "dbuser-1",
+		"alice", "/home/alice/public_html", "example.com", "alice_wp_abc123",
+		cfg,
+	)
+}
+
+func TestWordPressDelete_KeepsPanelRowsWhenDatabaseDropFails(t *testing.T) {
+	ag := &dropFailAgent{failCmds: map[string]bool{"db.drop": true}}
+	cfg, installs, dbs, dbUsers, grants := newDeleteFixture(ag)
+
+	runDelete(cfg)
+
+	if dbs.deleteCount() != 0 {
+		t.Errorf("databases row deleted after db.drop failed — the MariaDB schema is now an orphan nothing can name")
+	}
+	if dbUsers.deleteCount() != 0 {
+		t.Errorf("database_users row deleted after db.drop failed")
+	}
+	if grants.deleteCount() != 0 {
+		t.Errorf("grant rows deleted after db.drop failed — they are the record of the surviving privileges")
+	}
+	// The install's files are gone, so its row must still go: leaving it
+	// would make the app look installed and block a re-install.
+	if len(installs.deleted) != 1 {
+		t.Errorf("install row should be deleted regardless (files already removed); got %d deletes", len(installs.deleted))
+	}
+}
+
+func TestWordPressDelete_KeepsPanelRowsWhenUserDropFails(t *testing.T) {
+	ag := &dropFailAgent{failCmds: map[string]bool{"db_user.drop": true}}
+	cfg, _, dbs, dbUsers, grants := newDeleteFixture(ag)
+
+	runDelete(cfg)
+
+	if dbUsers.deleteCount() != 0 {
+		t.Errorf("database_users row deleted after db_user.drop failed — the MySQL login survives with a valid password and no panel row")
+	}
+	if dbs.deleteCount() != 0 {
+		t.Errorf("databases row deleted although db_user.drop failed; the pair must be kept together so the retry can reach both")
+	}
+	if grants.deleteCount() != 0 {
+		t.Errorf("grant rows deleted after db_user.drop failed")
+	}
+}
+
+func TestWordPressDelete_RemovesPanelRowsWhenDropsSucceed(t *testing.T) {
+	ag := &dropFailAgent{}
+	cfg, installs, dbs, dbUsers, grants := newDeleteFixture(ag)
+
+	runDelete(cfg)
+
+	if !ag.called("db.drop") || !ag.called("db_user.drop") {
+		t.Fatalf("delete must attempt both host-side drops; calls=%v", ag.calls)
+	}
+	if dbs.deleteCount() != 1 {
+		t.Errorf("databases row should be deleted once the drop succeeded; got %d", dbs.deleteCount())
+	}
+	if dbUsers.deleteCount() != 1 {
+		t.Errorf("database_users row should be deleted once the drop succeeded; got %d", dbUsers.deleteCount())
+	}
+	if grants.deleteCount() != 1 {
+		t.Errorf("grant rows should be deleted once the drops succeeded; got %d", grants.deleteCount())
+	}
+	if len(installs.deleted) != 1 {
+		t.Errorf("install row should be deleted; got %d", len(installs.deleted))
+	}
+}
+
+func TestRollbackDBChain_KeepsPanelRowsWhenDropFails(t *testing.T) {
+	ag := &dropFailAgent{failCmds: map[string]bool{"db.drop": true}}
+	cfg, _, dbs, dbUsers, grants := newDeleteFixture(ag)
+
+	rollbackDBChain(context.Background(), cfg, provisionedDB{
+		DBID:       "db-1",
+		DBName:     "alice_wp_abc123",
+		DBUserID:   "dbuser-1",
+		DBUsername: "alice_wp_def456",
+		GrantID:    "grant-1",
+	})
+
+	if dbs.deleteCount() != 0 || dbUsers.deleteCount() != 0 || grants.deleteCount() != 0 {
+		t.Errorf("install rollback deleted panel rows after a failed drop; the freshly created MariaDB objects are now unreferenced")
+	}
+}
+
+func TestRollbackDBChain_RemovesPanelRowsWhenDropsSucceed(t *testing.T) {
+	ag := &dropFailAgent{}
+	cfg, _, dbs, dbUsers, grants := newDeleteFixture(ag)
+
+	rollbackDBChain(context.Background(), cfg, provisionedDB{
+		DBID:       "db-1",
+		DBName:     "alice_wp_abc123",
+		DBUserID:   "dbuser-1",
+		DBUsername: "alice_wp_def456",
+		GrantID:    "grant-1",
+	})
+
+	if dbs.deleteCount() != 1 || dbUsers.deleteCount() != 1 || grants.deleteCount() != 1 {
+		t.Errorf("install rollback must clear the panel rows once the host side is gone; db=%d user=%d grant=%d",
+			dbs.deleteCount(), dbUsers.deleteCount(), grants.deleteCount())
+	}
+}

--- a/panel-api/internal/api/db_orphan_drop_test.go
+++ b/panel-api/internal/api/db_orphan_drop_test.go
@@ -245,6 +245,95 @@ func TestRollbackDBChain_KeepsPanelRowsWhenDropFails(t *testing.T) {
 	}
 }
 
+// --- clone rollback (cloneCore) ---
+//
+// The clone provisions the MariaDB database + user through the agent BEFORE
+// it writes the install row. When that write fails, the unwind has to take
+// the host side with it — and stop short of deleting the panel rows if it
+// couldn't.
+
+type cloneInstallRepo struct {
+	repository.ApplicationInstallRepository
+	source *models.WordPressInstall
+}
+
+func (r *cloneInstallRepo) FindByIDAndUserID(_ context.Context, _, _ string) (*models.WordPressInstall, error) {
+	return r.source, nil
+}
+
+func (r *cloneInstallRepo) FindByDomainAndSubdirectory(_ context.Context, _, _ string) (*models.WordPressInstall, error) {
+	return nil, repository.ErrNotFound
+}
+
+func (r *cloneInstallRepo) Create(_ context.Context, _ *models.WordPressInstall) error {
+	return errors.New("install row write failed")
+}
+
+type cloneDomainRepo struct {
+	repository.DomainRepository
+	userID string
+}
+
+func (r *cloneDomainRepo) FindByID(_ context.Context, id string) (*models.Domain, error) {
+	return &models.Domain{ID: id, UserID: r.userID, Name: "dest.example.com"}, nil
+}
+
+type cloneUserRepo struct {
+	repository.UserRepository
+}
+
+func (r *cloneUserRepo) FindByID(_ context.Context, id string) (*models.User, error) {
+	uname := "alice"
+	return &models.User{ID: id, Username: &uname}, nil
+}
+
+func (r *fakeDBRepo) Create(_ context.Context, _ *models.Database) error { return nil }
+
+func (r *fakeDBUserRepo) Create(_ context.Context, _ *models.DatabaseUser) error { return nil }
+
+func (r *fakeGrantRepo) Create(_ context.Context, _ *models.DatabaseUserGrant) error { return nil }
+
+func runCloneRollback(t *testing.T, ag *dropFailAgent) (*fakeDBRepo, *fakeDBUserRepo, *fakeGrantRepo) {
+	t.Helper()
+	dbs := &fakeDBRepo{}
+	dbUsers := &fakeDBUserRepo{}
+	grants := &fakeGrantRepo{}
+	h := &wordPressHandler{cfg: ApplicationHandlerConfig{
+		ApplicationInstalls: &cloneInstallRepo{source: &models.WordPressInstall{ID: "src-1", UserID: "user-1", DomainID: "dom-src"}},
+		Domains:             &cloneDomainRepo{userID: "user-1"},
+		Users:               &cloneUserRepo{},
+		Databases:           dbs,
+		DatabaseUsers:       dbUsers,
+		DatabaseGrants:      grants,
+		Agent:               ag,
+	}}
+	if _, err := h.cloneCore(context.Background(), "src-1", "dom-dest", false, "user-1", false); err == nil {
+		t.Fatal("expected the clone to fail on the install-row write")
+	}
+	return dbs, dbUsers, grants
+}
+
+func TestCloneRollback_KeepsPanelRowsWhenDropFails(t *testing.T) {
+	dbs, dbUsers, grants := runCloneRollback(t, &dropFailAgent{failCmds: map[string]bool{"db.drop": true}})
+
+	if dbs.deleteCount() != 0 || dbUsers.deleteCount() != 0 || grants.deleteCount() != 0 {
+		t.Errorf("clone rollback deleted panel rows after a failed drop; the database and login it just created are now unreferenced")
+	}
+}
+
+func TestCloneRollback_RemovesPanelRowsWhenDropsSucceed(t *testing.T) {
+	ag := &dropFailAgent{}
+	dbs, dbUsers, grants := runCloneRollback(t, ag)
+
+	if !ag.called("db.drop") || !ag.called("db_user.drop") {
+		t.Fatalf("clone rollback must unwind the MariaDB side; calls=%v", ag.calls)
+	}
+	if dbs.deleteCount() != 1 || dbUsers.deleteCount() != 1 || grants.deleteCount() != 1 {
+		t.Errorf("clone rollback must clear the panel rows once the host side is gone; db=%d user=%d grant=%d",
+			dbs.deleteCount(), dbUsers.deleteCount(), grants.deleteCount())
+	}
+}
+
 func TestRollbackDBChain_RemovesPanelRowsWhenDropsSucceed(t *testing.T) {
 	ag := &dropFailAgent{}
 	cfg, _, dbs, dbUsers, grants := newDeleteFixture(ag)

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -622,9 +622,18 @@ func (h *userHandler) delete(c *gin.Context) {
 	}
 
 	// Cascade-drop MariaDB schemas + grants on the data plane BEFORE the
-	// panel row goes (which CASCADEs the metadata rows). Best-effort: any
-	// per-DB failure is logged, never blocks the user delete. Operator
-	// chose destructive — every panel-managed artefact must follow.
+	// panel row goes (which CASCADEs the metadata rows). Operator chose
+	// destructive — every panel-managed artefact must follow.
+	//
+	// A failed drop is NOT best-effort any more. Deleting the users row
+	// cascades the databases/database_users rows away, so a drop that failed
+	// leaves the MariaDB schema and login on the host with nothing left to
+	// name them: invisible to `jabali db list`, excluded from every backup,
+	// grants still live. Collect the failures instead and abort before
+	// h.cfg.Repo.Delete below, which keeps those rows addressable. Retrying
+	// the delete is safe — the domain/docker/ACL steps above are idempotent
+	// and re-list empty on the second run.
+	var undropped []string
 	if h.cfg.Databases != nil && h.cfg.Agent != nil && username != "" {
 		const batchSize = 500
 		for {
@@ -645,7 +654,8 @@ func (h *userHandler) delete(c *gin.Context) {
 				})
 				cancel()
 				if dropErr != nil {
-					slog.Warn("cascade delete: db.drop failed",
+					undropped = append(undropped, dbName)
+					slog.Error("cascade delete: db.drop failed — aborting the user delete so the row stays addressable",
 						"user_id", id, "db_name", dbName, "err", dropErr)
 				}
 			}
@@ -674,7 +684,8 @@ func (h *userHandler) delete(c *gin.Context) {
 				})
 				cancel()
 				if dropErr != nil {
-					slog.Warn("cascade delete: db_user.drop failed",
+					undropped = append(undropped, duName)
+					slog.Error("cascade delete: db_user.drop failed — aborting the user delete so the row stays addressable",
 						"user_id", id, "db_user_name", duName, "err", dropErr)
 				}
 			}
@@ -772,6 +783,21 @@ func (h *userHandler) delete(c *gin.Context) {
 				"user_id", id, "username", username, "err", rErr)
 		}
 		rcancel()
+	}
+
+	// Point of no return: this CASCADEs databases/database_users away. If any
+	// host-side drop above failed, stop here — the panel rows are the only
+	// remaining handle on those MariaDB objects.
+	if len(undropped) > 0 {
+		slog.Error("cascade delete: aborted, host-side drops failed",
+			"user_id", id, "objects", undropped)
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error":   "db_cleanup_failed",
+			"objects": undropped,
+			"detail": "the MariaDB database(s)/user(s) listed could not be dropped, so the account was kept; " +
+				"deleting it now would leave them on the host with no panel row to reach them. Retry the delete once the agent is healthy.",
+		})
+		return
 	}
 
 	if err := h.cfg.Repo.Delete(c.Request.Context(), id); err != nil {

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -713,7 +713,12 @@ func (h *userHandler) delete(c *gin.Context) {
 		})
 		cancel()
 		if dropErr != nil {
-			slog.Warn("cascade delete: mysqladmin shadow drop failed",
+			// Counts toward the abort like any other login. This account has
+			// a valid password and is not a database_users row, so nothing
+			// downstream would ever find it again — it is the orphan class
+			// the comment above was written for.
+			undropped = append(undropped, shadowUser)
+			slog.Error("cascade delete: mysqladmin shadow drop failed — aborting the user delete so the login is not orphaned",
 				"user_id", id, "mysqladmin_user", shadowUser, "err", dropErr)
 		}
 	}

--- a/panel-api/internal/api/users_delete_db_drop_failure_test.go
+++ b/panel-api/internal/api/users_delete_db_drop_failure_test.go
@@ -127,6 +127,25 @@ func TestUserDelete_AbortsWhenDatabaseUserDropFails(t *testing.T) {
 	require.NotNil(t, got)
 }
 
+// The per-user shadow admin (<osuser>_mysqladmin) is not a database_users
+// row, so the loops above never see it. Leaving Databases/DatabaseUsers nil
+// isolates it: the only db_user.drop the handler issues is the shadow one.
+func TestUserDelete_AbortsWhenMysqladminShadowDropFails(t *testing.T) {
+	repo, admin, victim := seedAdminAndVictim(t)
+
+	code := runUserDelete(t, api.UserHandlerConfig{
+		Repo:  repo,
+		Agent: &cascadeDropAgent{failCmd: "db_user.drop"},
+	}, admin.ID, victim.ID)
+
+	require.Equal(t, http.StatusBadGateway, code,
+		"a failed <osuser>_mysqladmin drop must abort — that login has a valid password and no row would be left to find it")
+
+	got, err := repo.FindByID(context.Background(), victim.ID)
+	require.NoError(t, err, "the user row must survive")
+	require.NotNil(t, got)
+}
+
 func TestUserDelete_ProceedsWhenDropsSucceed(t *testing.T) {
 	repo, admin, victim := seedAdminAndVictim(t)
 

--- a/panel-api/internal/api/users_delete_db_drop_failure_test.go
+++ b/panel-api/internal/api/users_delete_db_drop_failure_test.go
@@ -1,0 +1,145 @@
+package api_test
+
+// Deleting a user CASCADEs its databases/database_users rows away, so those
+// rows are the only remaining handle on the MariaDB objects while the drops
+// are still in flight. If a drop fails and the user row goes anyway, the
+// schema and login survive on the host unnamed: absent from `jabali db list`,
+// excluded from every backup, grants still live.
+//
+// The cascade used to log the failure and continue ("best-effort: never
+// blocks the user delete"). It now aborts before the point of no return, so
+// the operator can retry once the agent is healthy — the domain/docker/ACL
+// steps ahead of it are idempotent and re-list empty on the second run.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// cascadeDropAgent fails the named command; everything else succeeds.
+type cascadeDropAgent struct {
+	failCmd string
+	mu      sync.Mutex
+	calls   []string
+}
+
+func (a *cascadeDropAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.mu.Lock()
+	a.calls = append(a.calls, cmd)
+	a.mu.Unlock()
+	if cmd == a.failCmd {
+		return nil, errors.New("agent unavailable")
+	}
+	return json.RawMessage(`{"ok":true}`), nil
+}
+
+// oneDatabaseRepo reports a single tenant database for any user.
+type oneDatabaseRepo struct {
+	repository.DatabaseRepository
+	name string
+}
+
+func (r *oneDatabaseRepo) ListByUserID(_ context.Context, userID string, _ repository.ListOptions) ([]models.Database, int64, error) {
+	return []models.Database{{ID: "db-1", UserID: userID, Name: r.name}}, 1, nil
+}
+
+// oneDatabaseUserRepo reports a single tenant MySQL login for any user.
+type oneDatabaseUserRepo struct {
+	repository.DatabaseUserRepository
+	username string
+}
+
+func (r *oneDatabaseUserRepo) ListByUserID(_ context.Context, userID string, _ repository.ListOptions) ([]models.DatabaseUser, int64, error) {
+	return []models.DatabaseUser{{ID: "dbuser-1", UserID: userID, Username: r.username}}, 1, nil
+}
+
+func runUserDelete(t *testing.T, cfg api.UserHandlerConfig, adminID, victimID string) int {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	claims := &auth.AccessClaims{UserID: adminID, IsAdmin: true}
+	g := r.Group("/api/v1", func(c *gin.Context) {
+		ginctx.SetClaims(c, claims)
+		c.Next()
+	})
+	api.RegisterUserRoutes(g, cfg)
+	return doJSON(t, r, http.MethodDelete, "/api/v1/users/"+victimID, nil).Code
+}
+
+func seedAdminAndVictim(t *testing.T) (*memUserRepo, *models.User, *models.User) {
+	t.Helper()
+	repo := newMemUserRepo()
+	admin := makeUser(t, "admin@example.com", true, "adminpassword")
+	repo.seed(admin)
+	victim := makeUser(t, "victim@example.com", false, "victimpassword")
+	uname := "victim"
+	victim.Username = &uname
+	repo.seed(victim)
+	return repo, admin, victim
+}
+
+func TestUserDelete_AbortsWhenDatabaseDropFails(t *testing.T) {
+	repo, admin, victim := seedAdminAndVictim(t)
+
+	code := runUserDelete(t, api.UserHandlerConfig{
+		Repo:          repo,
+		Agent:         &cascadeDropAgent{failCmd: "db.drop"},
+		Databases:     &oneDatabaseRepo{name: "victim_shop"},
+		DatabaseUsers: &oneDatabaseUserRepo{username: "victim_shop"},
+	}, admin.ID, victim.ID)
+
+	require.Equal(t, http.StatusBadGateway, code,
+		"a failed db.drop must abort the delete, not report success")
+
+	got, err := repo.FindByID(context.Background(), victim.ID)
+	require.NoError(t, err, "the user row must survive — it is what keeps the databases row addressable")
+	require.NotNil(t, got)
+}
+
+func TestUserDelete_AbortsWhenDatabaseUserDropFails(t *testing.T) {
+	repo, admin, victim := seedAdminAndVictim(t)
+
+	code := runUserDelete(t, api.UserHandlerConfig{
+		Repo:          repo,
+		Agent:         &cascadeDropAgent{failCmd: "db_user.drop"},
+		Databases:     &oneDatabaseRepo{name: "victim_shop"},
+		DatabaseUsers: &oneDatabaseUserRepo{username: "victim_shop"},
+	}, admin.ID, victim.ID)
+
+	require.Equal(t, http.StatusBadGateway, code,
+		"a failed db_user.drop must abort the delete")
+
+	got, err := repo.FindByID(context.Background(), victim.ID)
+	require.NoError(t, err, "the user row must survive so the orphaned login stays reachable")
+	require.NotNil(t, got)
+}
+
+func TestUserDelete_ProceedsWhenDropsSucceed(t *testing.T) {
+	repo, admin, victim := seedAdminAndVictim(t)
+
+	code := runUserDelete(t, api.UserHandlerConfig{
+		Repo:          repo,
+		Agent:         &cascadeDropAgent{},
+		Databases:     &oneDatabaseRepo{name: "victim_shop"},
+		DatabaseUsers: &oneDatabaseUserRepo{username: "victim_shop"},
+	}, admin.ID, victim.ID)
+
+	require.Equal(t, http.StatusNoContent, code,
+		"the abort must not fire when every host-side drop succeeded")
+
+	_, err := repo.FindByID(context.Background(), victim.ID)
+	require.Error(t, err, "the user row should be gone on the success path")
+}

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -946,9 +946,24 @@ func (h *wordPressHandler) cloneCore(ctx context.Context, sourceInstallID, destD
 		// above had just created with nothing left to reference them — the
 		// same invisible orphan the delete path produced, made silently
 		// (it did not even log a drop attempt).
+		//
+		// Same rule as everywhere else: the rows only go once the host-side
+		// objects actually did.
 		if h.cfg.Agent != nil {
-			h.cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": destDBUsername})
-			h.cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": destDBName})
+			dropFailed := false
+			if _, dErr := h.cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": destDBUsername}); dErr != nil {
+				dropFailed = true
+				slog.ErrorContext(ctx, "wordpress clone rollback: db_user.drop failed — keeping the panel rows so the account stays visible instead of becoming an orphan",
+					"err", dErr, "db_user", destDBUsername)
+			}
+			if _, dErr := h.cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": destDBName}); dErr != nil {
+				dropFailed = true
+				slog.ErrorContext(ctx, "wordpress clone rollback: db.drop failed — keeping the panel rows so the database stays visible instead of becoming an orphan",
+					"err", dErr, "db_name", destDBName)
+			}
+			if dropFailed {
+				return nil, fmt.Errorf("create clone install: %w", err)
+			}
 		}
 		h.cfg.DatabaseGrants.Delete(ctx, destGrantID)
 		h.cfg.DatabaseUsers.Delete(ctx, destDBUserID)

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -941,6 +941,15 @@ func (h *wordPressHandler) cloneCore(ctx context.Context, sourceInstallID, destD
 		UpdatedAt:     now,
 	}
 	if err := h.cfg.ApplicationInstalls.Create(ctx, cloneInstall); err != nil {
+		// Unwind the MariaDB side too. This path used to drop only the panel
+		// rows, leaving the database and user that the three agent calls
+		// above had just created with nothing left to reference them — the
+		// same invisible orphan the delete path produced, made silently
+		// (it did not even log a drop attempt).
+		if h.cfg.Agent != nil {
+			h.cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": destDBUsername})
+			h.cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": destDBName})
+		}
 		h.cfg.DatabaseGrants.Delete(ctx, destGrantID)
 		h.cfg.DatabaseUsers.Delete(ctx, destDBUserID)
 		h.cfg.Databases.Delete(ctx, destDBID)
@@ -1212,42 +1221,67 @@ func createDeleteAndKickAgent(parentCtx context.Context, installID, userID, appT
 		removeAppCrons(ctx, cfg, userID, osUser, appType, appInstallPath(docroot, subdirectory))
 	}
 
-	// Best-effort DB-side cleanup. Drop the mariadb database + user on the
-	// host via the agent and remove the panel-side rows so the slot is
-	// freed up. Order matters:
-	//   grants → users → wp install row → database
-	// because fk_wpinstalls_db is RESTRICT — deleting the databases row
-	// before the wordpress_installs row that references it fails (silently,
-	// since the error is swallowed) and leaves an orphan databases row.
+	// DB-side cleanup: drop the mariadb database + user on the host via the
+	// agent, then remove the panel-side rows so the slot is freed up.
+	//
+	// The panel row is only removed once the host-side object is actually
+	// gone. This used to log the drop failure and delete the row anyway,
+	// which is how an invisible orphan is made: the agent call is a root RPC
+	// and an agent restart, a timeout, or a long-call 502 is enough to fail
+	// it, after which the MariaDB database and user survive with no panel row
+	// left to name them — absent from `jabali db list`, absent from the
+	// account backup, still holding their grants. testserver carries four
+	// such orphan pairs, two of them complete WordPress schemas (75 and 64
+	// tables) that no backup has ever covered.
+	//
+	// Keeping the rows instead leaves an ordinary, visible database the owner
+	// can retry from the Databases page, and databases.go's delete refuses to
+	// remove the row unless its own drop succeeds — so the retry cannot
+	// reintroduce the orphan.
+	dropFailed := false
+
+	// The agent command is `db_user.drop` with `db_user_name` — NOT
+	// `mysql.user.delete` (which doesn't exist; the prior call silently
+	// no-op'd and the account survived every WP delete).
+	if dbUserID != "" && dbUserUsername != "" {
+		if _, agentErr := cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": dbUserUsername}); agentErr != nil {
+			dropFailed = true
+			slog.ErrorContext(ctx, "wordpress delete: db_user.drop failed — keeping the panel rows so the account stays visible instead of becoming an orphan",
+				"err", agentErr, "db_user", dbUserUsername)
+		}
+	}
+
+	// Agent command is `db.drop` with `db_name` — NOT
+	// `mysql.database.delete` (same silent-no-op bug as above, the schema
+	// survived every delete).
+	if databaseID != "" {
+		if db, dbErr := cfg.Databases.FindByID(ctx, databaseID); dbErr == nil && db != nil {
+			if _, agentErr := cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": db.Name}); agentErr != nil {
+				dropFailed = true
+				slog.ErrorContext(ctx, "wordpress delete: db.drop failed — keeping the panel rows so the database stays visible instead of becoming an orphan",
+					"err", agentErr, "db_name", db.Name)
+			}
+		}
+	}
+
+	// The install's files are gone (the app.delete above succeeded or we
+	// returned), so its row goes either way. Deleting it before the databases
+	// row also releases fk_wpinstalls_db, which is RESTRICT.
+	cfg.ApplicationInstalls.Delete(ctx, installID)
+
+	if dropFailed {
+		return
+	}
+
 	if dbUserID != "" {
 		if grants, gErr := cfg.DatabaseGrants.ListByDatabaseUserID(ctx, dbUserID); gErr == nil {
 			for _, g := range grants {
 				cfg.DatabaseGrants.Delete(ctx, g.ID)
 			}
 		}
-		// Drop the mariadb user on the host. The agent command is
-		// `db_user.drop` with `db_user_name` — NOT `mysql.user.delete`
-		// (which doesn't exist; the prior call silently no-op'd and the
-		// account survived every WP delete).
-		if dbUserUsername != "" {
-			if _, agentErr := cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": dbUserUsername}); agentErr != nil {
-				slog.WarnContext(ctx, "wordpress delete: db_user.drop failed", "err", agentErr, "db_user", dbUserUsername)
-			}
-		}
 		cfg.DatabaseUsers.Delete(ctx, dbUserID)
 	}
-	// Delete the WP install row BEFORE the database panel row so the
-	// fk_wpinstalls_db RESTRICT constraint releases.
-	cfg.ApplicationInstalls.Delete(ctx, installID)
 	if databaseID != "" {
-		if db, dbErr := cfg.Databases.FindByID(ctx, databaseID); dbErr == nil && db != nil {
-			// Agent command is `db.drop` with `db_name` — NOT
-			// `mysql.database.delete` (same silent-no-op bug as above,
-			// the schema survived every delete).
-			if _, agentErr := cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": db.Name}); agentErr != nil {
-				slog.WarnContext(ctx, "wordpress delete: db.drop failed", "err", agentErr, "db_name", db.Name)
-			}
-		}
 		cfg.Databases.Delete(ctx, databaseID)
 	}
 }


### PR DESCRIPTION
## What

A `databases` / `database_users` row is the only handle the panel has on the MariaDB object it names. Four delete paths dropped the host object best-effort and deleted the row **regardless**, so any failed drop left an orphan:

- absent from `jabali db list`
- excluded from every account backup
- grants still live
- counting against no quota

The agent call is a root RPC, so an agent restart, a timeout, or a long-call 502 is enough to trigger it.

## How it was found

Chasing a `partial` backup on testserver. The job warning was:

```
db: mariadb-dump cybe2e_smokedb: exit status 2
    Got error: 1049: "Unknown database 'cybe2e_smokedb'"
```

That is the *inverse* drift — a panel row whose database is gone, which makes every subsequent account backup for that user land `partial` forever. Auditing the paths that produce drift turned up the orphan direction too. testserver currently carries:

| Direction | Objects |
|---|---|
| Panel row, no MariaDB DB | `cybe2e_smokedb` |
| MariaDB DB, no panel row | `shukivaknin_wp_bxx9x6` `_gcttzt` `_r33zjm` `_rdhwph` |
| MariaDB user, no panel row | `shukivaknin_wp_3t47x3` `_n016t2` `_qw2nz9` `_zbypcs` |

Two of the orphan databases are complete WordPress schemas (75 and 64 tables, 7.5 MB and 4.6 MB) that no backup has ever covered.

Note: the journal only reaches back to 2026-08-06 and these clones are from June/July, so the code gaps are confirmed from source — the attribution of *these particular* orphans is not.

## The rule

`databases.go` already had it right: drop fails → 502, row kept. This applies the same rule to the rest.

| Path | Before | After |
|---|---|---|
| `wordpress.go` delete | warn, delete rows anyway | rows kept if either drop fails |
| `wordpress.go` clone rollback | deleted rows, **never dropped** the DB/user it just created, logged nothing | drops both, then unwinds |
| `users.go` cascade | warn, `Repo.Delete` cascades rows away | aborts with 502 naming the objects |
| `applications.go` `rollbackDBChain` | fire-and-forget drops | rows kept if either fails |

A kept row is an ordinary visible database the owner can retry from the Databases page, and `databases.go` refuses to delete it unless its own drop succeeds — so the retry cannot reintroduce the orphan.

The WP install row still goes on the delete path: its files are already removed, and deleting it first releases `fk_wpinstalls_db` (RESTRICT).

Retrying a user delete is safe — the domain/docker/ACL steps ahead of the abort are idempotent and re-list empty on the second run.

## Not changed, deliberately

The backup's `partial` on a missing database. That strictness is currently the **only** thing on the box that detects panel↔MariaDB drift — softening it to a skip would turn an accidentally-dropped tenant database into a green backup.

## Test plan

- [x] `TestWordPressDelete_KeepsPanelRowsWhen{Database,User}DropFails` — rows survive, install row still goes
- [x] `TestWordPressDelete_RemovesPanelRowsWhenDropsSucceed` — success path unchanged
- [x] `TestRollbackDBChain_KeepsPanelRowsWhenDropFails` / `_RemovesPanelRowsWhenDropsSucceed`
- [x] `TestUserDelete_AbortsWhen{Database,DatabaseUser}DropFails` — 502, user row survives
- [x] `TestUserDelete_ProceedsWhenDropsSucceed` — abort does not fire spuriously
- [x] Each test verified RED against the pre-fix file (reverted, ran, restored)
- [x] `go vet ./...` clean, full `panel-api` suite 0 FAIL
- [ ] testserver orphan cleanup — separate, needs the data dumped first

GH #1001 sibling in spirit: same "half the delete paths were fixed" shape as #754.