### PR TITLE
feat(repair): name the cause when a per-user PHP-FPM master is crash-looping (GH #889/#953)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4581,6 +4581,7 @@ jabali repair [flags]
 - `--dirty-migration` — Fix only: database schema is dirty — panel-api cannot start
 - `--docroot-www-data-group` — Fix only: web docroot files not group www-data / dirs not setgid (nginx 403 on newly uploaded media)
 - `--etc-jabali-perms` — Fix only: /etc/jabali not traversable by hosting users (SSH/SFTP locked out — sandbox-mode unreadable)
+- `--fpm-masters-down` — Fix only: a per-user PHP-FPM master is crash-looping (sites 500/502 with missing fpm.sock)
 - `--git-ownership` — Fix only: /opt/jabali-panel/.git owned by wrong user
 - `--git-pointer` — Fix only: /opt/jabali-panel/.git is a corrupted worktree pointer
 - `--git-stale-worktrees` — Fix only: /opt/jabali-panel/.git/worktrees has stale entries

--- a/panel-api/cmd/server/repair.go
+++ b/panel-api/cmd/server/repair.go
@@ -270,6 +270,18 @@ func repairSteps() []repairStep {
 			fix: nil,
 		},
 		{
+			// GH #889/#953: a crash-looping per-user PHP-FPM master 500/502s
+			// every site it serves. Name the cause here instead of asking each
+			// reporter to paste `journalctl -u jabali-fpm@<user>`.
+			id:     "fpm-masters-down",
+			label:  "a per-user PHP-FPM master is crash-looping (sites 500/502 with missing fpm.sock)",
+			detect: detectFPMMastersDown,
+			// Detect-only: the cause is a bad extension / php.ini / AppArmor
+			// deny / Snuffleupagus rule; a blind restart won't clear it and
+			// would mask the real problem. The reason string points at it.
+			fix: nil,
+		},
+		{
 			id:          "git-pointer",
 			label:       "/opt/jabali-panel/.git is a corrupted worktree pointer",
 			destructive: true,

--- a/panel-api/cmd/server/repair_fpm.go
+++ b/panel-api/cmd/server/repair_fpm.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// repair_fpm — GH #889/#953 self-diagnosis. A per-user PHP-FPM master
+// (jabali-fpm@<user>.service) that crash-loops never binds its socket, so nginx
+// answers /run/php/jabali-<user>/fpm.sock "No such file or directory" and the
+// site 500/502s. The exit reason lives in `journalctl -u jabali-fpm@<user>` —
+// which every such report currently costs a round-trip to ask the reporter to
+// paste. This detector enumerates every down master and names the likely cause
+// in one `jabali repair --diagnose`, no username needed.
+//
+// The unit is Type=simple + Restart=on-failure/RestartSec=5s, so `systemctl
+// restart` returns 0 even for a master that forks then immediately exits, and a
+// crash-looping unit reads as "activating (auto-restart)", not "failed". So we
+// judge health by the observed ActiveState/SubState (+ NRestarts as evidence),
+// never by a restart exit code.
+//
+// Detect-only (fix: nil): the cause is a bad extension / php.ini directive /
+// AppArmor deny / Snuffleupagus rule baked into the pool config — a blind
+// restart won't clear it, and guessing a fix would mask the real problem. The
+// reason string points the operator straight at it.
+
+// Injectable exec seams (GH #994): production runs the real host commands; unit
+// tests swap these for canned output so `go test` never touches systemd/journald.
+var fpmDiagListMasters = func() (string, error) {
+	out, err := exec.Command("systemctl", "list-units", "jabali-fpm@*.service",
+		"--all", "--no-legend", "--plain", "--no-pager").Output()
+	return string(out), err
+}
+
+var fpmDiagShow = func(unit string) (string, error) {
+	out, err := exec.Command("systemctl", "show", unit,
+		"-p", "ActiveState", "-p", "SubState", "-p", "Result",
+		"-p", "ExecMainStatus", "-p", "NRestarts").Output()
+	return string(out), err
+}
+
+// fpmDiagJournal returns the unit's recent log lines (message text only, -o cat).
+//
+// Deliberately NOT scoped to the current InvocationID: a Restart=on-failure
+// master crash-loops every RestartSec, so each read lands on a DIFFERENT (often
+// fresh, not-yet-errored) invocation and the current one's fatal isn't logged
+// yet — the InvocationID filter then returns nothing. The unit-scoped window
+// instead captures the last several crash cycles, which repeat the SAME config
+// fatal; extractFPMFailureReason scans newest-first so the current cause wins.
+// We only ever journal a master we've already found DOWN, so recent lines ARE
+// the current failure, not a stale one. journalctl exits non-zero on an empty
+// match; that is not an error here.
+var fpmDiagJournal = func(unit string) string {
+	out, _ := exec.Command("journalctl", "-u", unit, "-n", "80", "--no-pager", "-o", "cat").Output()
+	return string(out)
+}
+
+// fpmCausePatterns are SPECIFIC root-cause fatals (the thing an operator needs:
+// which extension/directive/rule broke). Preferred over consequence patterns.
+var fpmCausePatterns = []string{
+	"unable to load dynamic library",
+	"failed loading",
+	"cannot load",
+	"unknown entry",
+	"is not a valid",
+	"must be specified",
+	"cannot bind",
+	"address already in use",
+	"snuffleupagus",
+	"php fatal",
+	"fatal error",
+}
+
+// fpmConsequencePatterns are GENERIC downstream errors — useful only when no
+// specific cause line is present (e.g. "failed to load configuration file").
+var fpmConsequencePatterns = []string{
+	"failed to load configuration",
+	"fpm initialization failed",
+	"error:",
+}
+
+// extractFPMFailureReason pulls the decisive php-fpm error line(s) out of a
+// unit's journal text. Pure (no exec) so it is unit-tested with canned input.
+//
+// Two-tier: a crash on a bad directive logs the specific cause ("unknown entry
+// 'x'") THEN generic consequences ("failed to load configuration file", "FPM
+// initialization failed"). A naive newest-first scan returns the consequences
+// and buries the cause, so we prefer cause lines and fall back to consequence
+// lines only when none is present. Within a tier: newest-first (most recent
+// crash cycle wins), deduped, at most maxLines, presented chronologically.
+func extractFPMFailureReason(journalText string, maxLines int) string {
+	if maxLines < 1 {
+		maxLines = 1
+	}
+	lines := strings.Split(journalText, "\n")
+	pick := func(patterns []string) []string {
+		var hits []string
+		seen := map[string]bool{}
+		for i := len(lines) - 1; i >= 0 && len(hits) < maxLines; i-- {
+			line := strings.TrimSpace(lines[i])
+			if line == "" {
+				continue
+			}
+			low := strings.ToLower(line)
+			for _, p := range patterns {
+				if strings.Contains(low, p) {
+					if !seen[line] {
+						seen[line] = true
+						hits = append(hits, line)
+					}
+					break
+				}
+			}
+		}
+		// newest-first → chronological.
+		for i, j := 0, len(hits)-1; i < j; i, j = i+1, j-1 {
+			hits[i], hits[j] = hits[j], hits[i]
+		}
+		return hits
+	}
+	hits := pick(fpmCausePatterns)
+	if len(hits) == 0 {
+		hits = pick(fpmConsequencePatterns)
+	}
+	return strings.Join(hits, "; ")
+}
+
+func parseSystemctlShow(out string) map[string]string {
+	m := map[string]string{}
+	for _, l := range strings.Split(out, "\n") {
+		if i := strings.IndexByte(l, '='); i > 0 {
+			m[l[:i]] = strings.TrimSpace(l[i+1:])
+		}
+	}
+	return m
+}
+
+// fpmMasterDiagnostic reports whether a user's FPM master is unhealthy and, if
+// so, a one-line reason (state + evidence + the journal's fatal line).
+func fpmMasterDiagnostic(username string) (unhealthy bool, reason string) {
+	unit := "jabali-fpm@" + username + ".service"
+	props := parseSystemctlShow(func() string { s, _ := fpmDiagShow(unit); return s }())
+	active := props["ActiveState"]
+	sub := props["SubState"]
+	// Healthy is the only all-clear; everything else (activating/auto-restart,
+	// failed, inactive with no socket) is worth a line in a diagnostic run.
+	if active == "active" && sub == "running" {
+		return false, ""
+	}
+
+	cause := extractFPMFailureReason(fpmDiagJournal(unit), 2)
+	if cause == "" {
+		cause = "no php-fpm fatal matched in the journal — inspect: journalctl -u " + unit + " -n 80"
+	}
+
+	state := active
+	if sub != "" {
+		state = active + "/" + sub
+	}
+	if n := props["NRestarts"]; n != "" && n != "0" {
+		state += ", " + n + " restarts"
+	}
+	return true, fmt.Sprintf("%s [%s] — %s", unit, state, cause)
+}
+
+// detectFPMMastersDown enumerates every jabali-fpm@<user> master and reports the
+// unhealthy ones with their cause. Read-only.
+func detectFPMMastersDown(_ repairCtx) (bool, string, error) {
+	list, err := fpmDiagListMasters()
+	if err != nil {
+		// No masters registered, or systemctl unavailable (e.g. a container):
+		// nothing to diagnose, not a failure of the detector itself.
+		return false, "no per-user PHP-FPM masters found", nil
+	}
+	var down []string
+	for _, line := range strings.Split(list, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		unit := fields[0]
+		if !strings.HasPrefix(unit, "jabali-fpm@") || !strings.HasSuffix(unit, ".service") {
+			continue
+		}
+		user := strings.TrimSuffix(strings.TrimPrefix(unit, "jabali-fpm@"), ".service")
+		if user == "" {
+			continue
+		}
+		if bad, reason := fpmMasterDiagnostic(user); bad {
+			down = append(down, reason)
+		}
+	}
+	if len(down) == 0 {
+		return false, "all per-user PHP-FPM masters healthy", nil
+	}
+	sort.Strings(down)
+	return true, fmt.Sprintf("%d PHP-FPM master(s) unhealthy:\n    - %s",
+		len(down), strings.Join(down, "\n    - ")), nil
+}

--- a/panel-api/cmd/server/repair_fpm_test.go
+++ b/panel-api/cmd/server/repair_fpm_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFPMFailureReason(t *testing.T) {
+	cases := []struct {
+		name    string
+		journal string
+		want    string // substring that must appear; "" means expect empty result
+	}{
+		{
+			name: "ioncube loader not first / failed loading",
+			journal: "Starting Jabali PHP-FPM (user elusuario)...\n" +
+				"php-fpm: ERROR: Failed loading /usr/lib/php/20230831/ioncube_loader_lin_8.2.so:  /usr/lib/php/20230831/ioncube_loader_lin_8.2.so: cannot open shared object file\n" +
+				"php-fpm: failed to post process the configuration\n",
+			want: "Failed loading /usr/lib/php/20230831/ioncube_loader",
+		},
+		{
+			name: "unknown pool directive",
+			journal: "NOTICE: fpm is running, pid 12\n" +
+				"ERROR: [pool jabali-alice] unknown entry 'php_admin_valu'\n" +
+				"ERROR: failed to load configuration file '/etc/php/8.3/fpm/pool.d/jabali-alice.conf'\n",
+			want: "unknown entry 'php_admin_valu'",
+		},
+		{
+			name: "unable to load dynamic library",
+			journal: "PHP Warning:  PHP Startup: Unable to load dynamic library 'redis.so' (tried: /usr/lib/php/.../redis.so ...)\n" +
+				"[08-Aug-2026] NOTICE: ready to handle connections\n",
+			want: "Unable to load dynamic library 'redis.so'",
+		},
+		{
+			name: "prefers specific cause over trailing generic consequences",
+			journal: "[08-Aug 21:26:02] ERROR: [/etc/php/8.4/fpm/pool.d/jabali-z.conf:71] unknown entry 'totally_bogus_xyz'\n" +
+				"[08-Aug 21:26:02] ERROR: failed to load configuration file '/etc/jabali-panel/fpm/z.conf'\n" +
+				"[08-Aug 21:26:02] ERROR: FPM initialization failed\n",
+			want: "unknown entry 'totally_bogus_xyz'",
+		},
+		{
+			name:    "healthy journal — no fatal",
+			journal: "Starting Jabali PHP-FPM...\nNOTICE: fpm is running, pid 42\nNOTICE: ready to handle connections\n",
+			want:    "",
+		},
+		{
+			name:    "empty journal",
+			journal: "",
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractFPMFailureReason(tc.journal, 2)
+			if tc.want == "" {
+				if got != "" {
+					t.Errorf("expected no reason, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("reason %q does not contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractFPMFailureReason_NewestWinsAndDedup(t *testing.T) {
+	journal := "ERROR: [pool jabali-x] unknown entry 'old_one'\n" +
+		"ERROR: [pool jabali-x] unknown entry 'old_one'\n" + // dup
+		"ERROR: [pool jabali-x] unknown entry 'new_one'\n"
+	got := extractFPMFailureReason(journal, 2)
+	// maxLines=2, newest-first scan, dedup → should include new_one and one old_one,
+	// presented chronologically (old before new).
+	if !strings.Contains(got, "new_one") {
+		t.Errorf("most recent fatal missing: %q", got)
+	}
+	if strings.Count(got, "old_one") != 1 {
+		t.Errorf("duplicate not collapsed: %q", got)
+	}
+	if strings.Index(got, "old_one") > strings.Index(got, "new_one") {
+		t.Errorf("lines not chronological (old should precede new): %q", got)
+	}
+}
+
+func TestDetectFPMMastersDown(t *testing.T) {
+	// Fake the seams: two masters — one healthy, one crash-looping.
+	origList, origShow, origJournal := fpmDiagListMasters, fpmDiagShow, fpmDiagJournal
+	defer func() { fpmDiagListMasters, fpmDiagShow, fpmDiagJournal = origList, origShow, origJournal }()
+
+	fpmDiagListMasters = func() (string, error) {
+		return "jabali-fpm@alice.service loaded active running Jabali PHP-FPM (alice)\n" +
+			"jabali-fpm@bob.service   loaded activating auto-restart Jabali PHP-FPM (bob)\n", nil
+	}
+	fpmDiagShow = func(unit string) (string, error) {
+		if strings.Contains(unit, "alice") {
+			return "ActiveState=active\nSubState=running\nResult=success\nNRestarts=0\nInvocationID=aaa\n", nil
+		}
+		return "ActiveState=activating\nSubState=auto-restart\nResult=exit-code\nNRestarts=7\nInvocationID=bbb\n", nil
+	}
+	fpmDiagJournal = func(unit string) string {
+		if strings.Contains(unit, "bob") {
+			return "ERROR: [pool jabali-bob] unknown entry 'bad_directive'\nERROR: failed to load configuration file\n"
+		}
+		return ""
+	}
+
+	broken, detail, err := detectFPMMastersDown(repairCtx{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !broken {
+		t.Fatalf("expected broken=true (bob is down); detail=%q", detail)
+	}
+	if !strings.Contains(detail, "bob") || !strings.Contains(detail, "unknown entry 'bad_directive'") {
+		t.Errorf("detail must name the down master + cause, got:\n%s", detail)
+	}
+	if strings.Contains(detail, "alice") {
+		t.Errorf("healthy master must not be reported: %s", detail)
+	}
+	if !strings.Contains(detail, "7 restarts") {
+		t.Errorf("expected restart evidence in reason, got:\n%s", detail)
+	}
+}
+
+func TestDetectFPMMastersDown_AllHealthy(t *testing.T) {
+	origList, origShow := fpmDiagListMasters, fpmDiagShow
+	defer func() { fpmDiagListMasters, fpmDiagShow = origList, origShow }()
+	fpmDiagListMasters = func() (string, error) {
+		return "jabali-fpm@alice.service loaded active running Jabali PHP-FPM (alice)\n", nil
+	}
+	fpmDiagShow = func(unit string) (string, error) {
+		return "ActiveState=active\nSubState=running\nResult=success\nNRestarts=0\nInvocationID=aaa\n", nil
+	}
+	broken, _, err := detectFPMMastersDown(repairCtx{})
+	if err != nil || broken {
+		t.Fatalf("expected healthy (broken=false, no err), got broken=%v err=%v", broken, err)
+	}
+}


### PR DESCRIPTION
## Problem (helps GH #889, #953)

When a per-user PHP-FPM master (`jabali-fpm@<user>.service`) crash-loops, it never binds `/run/php/jabali-<user>/fpm.sock`, so nginx answers `connect() … fpm.sock … No such file or directory` and **every site that pool serves 500/502s**. The exit reason is in `journalctl -u jabali-fpm@<user>` — and today diagnosing it costs a round-trip asking the reporter to SSH in and paste it. #889 and #953 are both parked there, on one box.

## What this adds

An `fpm-masters-down` detector for `jabali repair --diagnose`. It enumerates every per-user master and, for each unhealthy one, prints its state plus the decisive php-fpm startup fatal from the journal — the specific bad extension / directive / rule — in one command, no username needed:

```
✗ [fpm-masters-down] a per-user PHP-FPM master is crash-looping (sites 500/502 with missing fpm.sock)
   BROKEN — 1 PHP-FPM master(s) unhealthy:
  - jabali-fpm@juancito.service [activating/auto-restart, 7 restarts] — ERROR: [/etc/php/8.3/fpm/pool.d/jabali-juancito.conf:71] unknown entry 'x'
```

## Design decisions (each learned live)

- **Health by observed state, not restart exit code.** The unit is `Type=simple` + `Restart=on-failure`/`RestartSec=5s`, so `systemctl restart` returns 0 even for a master that forks then immediately dies, and a crash-looper reads as `activating (auto-restart)`, not `failed`. The detector judges by `ActiveState`/`SubState`, with `NRestarts` as evidence.
- **Unit-scoped journal, not InvocationID-scoped.** First attempt scoped to the current `InvocationID`; the live test showed a 5s crash loop mints a new invocation faster than it can be read, so the query landed on a *fresh* invocation whose fatal wasn't logged yet and returned nothing. The unit-scoped window captures the repeating fatal across cycles; `extractFPMFailureReason` scans newest-first so the current cause wins. We only journal a master already found down, so recent lines *are* the current failure.
- **Two-tier extraction.** A bad directive logs the specific cause (`unknown entry 'x'`) then generic consequences (`failed to load configuration file`, `FPM initialization failed`). Naive newest-first surfaced the consequence and buried the cause, so cause patterns (ionCube/`Unable to load dynamic library`/`unknown entry`/Snuffleupagus/…) are preferred, with consequence patterns as fallback.
- **Detect-only** (`fix: nil`): the cause is baked into the pool config; a blind restart won't clear it and would mask the problem. The reason string points the operator at the fix.
- **Testable, host-safe.** All host exec goes through injectable seams (GH #994) so `go test` never touches systemd/journald; `extractFPMFailureReason` + the detector are unit-tested with canned journal text and faked seams.

## Verification

- Unit tests: `extractFPMFailureReason` (ionCube / unknown-entry / dynamic-library / two-tier-preference / newest-wins+dedup / no-match) + `detectFPMMastersDown` (mixed healthy/down via faked seams). `go build` + `go vet` + `gofmt` clean; full `cmd/server` package green; CLI-reference golden regenerated.
- **Live on a box:** broke a throwaway user's pool with an invalid directive; `jabali repair --diagnose` reported the master down and named `ERROR: [.../jabali-<u>.conf:71] unknown entry '<x>'`.

## Scope / follow-ups

- Covers a **down** master (no socket). Does **not** cover master-up-but-workers-die (a per-request Snuffleupagus-unreadable rule kills workers with the socket still present) — separate follow-up.
- True no-SSH self-serve — surfacing the reason in the panel UI, or fail-fast at pool-apply time — is a follow-up; this replaces the journal spelunking with one command but the operator still runs it on the host.

References **GH #889** and **GH #953**; no auto-close keyword (these stay open pending the reporters' captures / the follow-ups).
