### PR TITLE
fix(db): report the real size of a PostgreSQL database, not 0 B (GH #1005)

### DIFF
--- a/panel-agent/internal/commands/db_size.go
+++ b/panel-agent/internal/commands/db_size.go
@@ -15,6 +15,11 @@ import (
 // dbSizeParams is the input shape for db.size.
 type dbSizeParams struct {
 	DBName string `json:"db_name"`
+	// Engine selects the size query. "postgres" uses pg_database_size();
+	// "mariadb" / "mysql" / "" (a pre-#1005 panel that omits the field) use the
+	// MariaDB information_schema sum. GH #1005: without this a Postgres database
+	// was queried against MariaDB's information_schema and always summed to 0 B.
+	Engine string `json:"engine"`
 }
 
 // dbSizeResponse is the output shape for db.size.
@@ -22,10 +27,17 @@ type dbSizeResponse struct {
 	SizeBytes int64 `json:"size_bytes"`
 }
 
-// dbNameRegex validates MariaDB database name format.
-// Must start with letter, contain only letters, digits, underscores, hyphens.
-// Max 64 chars (MariaDB limit for unquoted identifiers).
+// dbSizeNameRegex validates a database name for both engines: start with a
+// letter, then letters/digits/underscores/hyphens, max 64 chars. Because a
+// valid name contains no quote or SQL metacharacter, it is safe to interpolate
+// as a literal into either the MariaDB or the Postgres query below.
 var dbSizeNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
+
+// dbSizeExec runs a size-query command and returns its stdout. Package var so
+// tests can fake DB access (GH #994); production shells out for real.
+var dbSizeExec = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).Output()
+}
 
 func dbSizeHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p dbSizeParams
@@ -36,7 +48,7 @@ func dbSizeHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
-	// Validate db_name format.
+	// Validate db_name format (shared by both engines).
 	if !dbSizeNameRegex.MatchString(p.DBName) {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
@@ -44,42 +56,54 @@ func dbSizeHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
-	// Escape the database name as a literal for use in the WHERE clause.
-	escapedDBName, err := EscapeMariaDBLiteral(p.DBName)
-	if err != nil {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: "invalid database name",
-		}
+	if p.Engine == "postgres" {
+		return dbSizeResponse{SizeBytes: dbSizePostgres(ctx, p.DBName)}, nil
 	}
+	return dbSizeResponse{SizeBytes: dbSizeMariaDB(ctx, p.DBName)}, nil
+}
 
-	// Query information_schema.tables to sum data_length and index_length.
-	// Use the escaped literal in the WHERE clause.
+// dbSizeMariaDB sums data_length+index_length across the database's tables.
+// Degrades to 0 (never errors) so the list endpoint can't 500 on one bad row.
+func dbSizeMariaDB(ctx context.Context, dbName string) int64 {
+	escapedDBName, err := EscapeMariaDBLiteral(dbName)
+	if err != nil {
+		return 0
+	}
 	sql := fmt.Sprintf(
 		"SELECT COALESCE(SUM(data_length+index_length),0) FROM information_schema.tables WHERE table_schema = %s",
 		escapedDBName,
 	)
-
-	cmd := exec.CommandContext(ctx, "mysql", "-Nse", sql)
-	output, err := cmd.Output()
+	out, err := dbSizeExec(ctx, "mysql", "-Nse", sql)
 	if err != nil {
-		// Even if the query fails or the database doesn't exist, we return size=0
-		// rather than failing. This ensures the list endpoint doesn't 500.
-		return dbSizeResponse{SizeBytes: 0}, nil
+		return 0
 	}
+	return parseSizeOutput(out)
+}
 
-	sizeStr := strings.TrimSpace(string(output))
-	if sizeStr == "" {
-		return dbSizeResponse{SizeBytes: 0}, nil
-	}
-
-	size, err := strconv.ParseInt(sizeStr, 10, 64)
+// dbSizePostgres reads pg_database_size over the local peer socket (same
+// `sudo -u postgres psql` path the other Postgres handlers use). dbName is
+// regex-validated above, so the single-quoted literal cannot inject. Degrades
+// to 0 on any error (missing DB, psql unavailable) exactly like the MariaDB path.
+func dbSizePostgres(ctx context.Context, dbName string) int64 {
+	sql := fmt.Sprintf("SELECT pg_database_size('%s')", dbName)
+	out, err := dbSizeExec(ctx, "sudo", "-u", "postgres", "psql", "-tAq", "-c", sql)
 	if err != nil {
-		// Malformed output: return 0 rather than fail.
-		return dbSizeResponse{SizeBytes: 0}, nil
+		return 0
 	}
+	return parseSizeOutput(out)
+}
 
-	return dbSizeResponse{SizeBytes: size}, nil
+// parseSizeOutput turns a single numeric line into an int64, or 0 if malformed.
+func parseSizeOutput(out []byte) int64 {
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 func init() {

--- a/panel-agent/internal/commands/db_size_test.go
+++ b/panel-agent/internal/commands/db_size_test.go
@@ -3,82 +3,90 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
-
-	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
 
-func TestDBSizeValidation(t *testing.T) {
-	tests := []struct {
-		name    string
-		dbName  string
-		wantErr bool
-	}{
-		{
-			name:    "valid name",
-			dbName:  "mydb",
-			wantErr: false,
-		},
-		{
-			name:    "valid name with numbers",
-			dbName:  "db123",
-			wantErr: false,
-		},
-		{
-			name:    "valid name with underscores",
-			dbName:  "my_db",
-			wantErr: false,
-		},
-		{
-			name:    "valid name with hyphens",
-			dbName:  "my-db",
-			wantErr: false,
-		},
-		{
-			name:    "invalid name: starts with number",
-			dbName:  "1mydb",
-			wantErr: true,
-		},
-		{
-			name:    "invalid name: starts with underscore",
-			dbName:  "_mydb",
-			wantErr: true,
-		},
-		{
-			name:    "invalid name: contains space",
-			dbName:  "my db",
-			wantErr: true,
-		},
-		{
-			name:    "invalid name: empty",
-			dbName:  "",
-			wantErr: true,
-		},
-		{
-			name:    "invalid name: too long",
-			dbName:  "a" + string(make([]byte, 64)),
-			wantErr: true,
-		},
+func TestDBSizeHandler_EngineRouting(t *testing.T) {
+	orig := dbSizeExec
+	defer func() { dbSizeExec = orig }()
+
+	var gotName, gotArgs string
+	dbSizeExec = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		gotName, gotArgs = name, strings.Join(args, " ")
+		return []byte("123456\n"), nil
+	}
+	call := func(engine string) dbSizeResponse {
+		raw, _ := json.Marshal(map[string]string{"db_name": "mydb", "engine": engine})
+		out, err := dbSizeHandler(context.Background(), raw)
+		if err != nil {
+			t.Fatalf("handler err: %v", err)
+		}
+		return out.(dbSizeResponse)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			params, err := json.Marshal(dbSizeParams{DBName: tt.dbName})
-			if err != nil {
-				t.Fatalf("failed to marshal params: %v", err)
-			}
+	t.Run("postgres uses pg_database_size", func(t *testing.T) {
+		resp := call("postgres")
+		if gotName != "sudo" || !strings.Contains(gotArgs, "psql") || !strings.Contains(gotArgs, "pg_database_size('mydb')") {
+			t.Errorf("postgres path wrong: %s %s", gotName, gotArgs)
+		}
+		if resp.SizeBytes != 123456 {
+			t.Errorf("size = %d, want 123456", resp.SizeBytes)
+		}
+	})
 
-			_, err = dbSizeHandler(context.Background(), params)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("expected error=%v, got %v", tt.wantErr, err)
-			}
-			if err != nil {
-				var ae *agentwire.AgentError
-				if _, ok := err.(*agentwire.AgentError); !ok {
-					t.Errorf("expected AgentError, got %T", err)
-				}
-				_ = ae
-			}
-		})
+	t.Run("mariadb uses information_schema", func(t *testing.T) {
+		resp := call("mariadb")
+		if gotName != "mysql" || !strings.Contains(gotArgs, "information_schema.tables") {
+			t.Errorf("mariadb path wrong: %s %s", gotName, gotArgs)
+		}
+		if resp.SizeBytes != 123456 {
+			t.Errorf("size = %d, want 123456", resp.SizeBytes)
+		}
+	})
+
+	t.Run("empty engine defaults to mariadb (pre-#1005 panel)", func(t *testing.T) {
+		call("")
+		if gotName != "mysql" {
+			t.Errorf("empty engine must use the MariaDB path, got %s", gotName)
+		}
+	})
+}
+
+func TestDBSizeHandler_DegradesToZero(t *testing.T) {
+	orig := dbSizeExec
+	defer func() { dbSizeExec = orig }()
+	dbSizeExec = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("boom")
+	}
+	raw, _ := json.Marshal(map[string]string{"db_name": "mydb", "engine": "postgres"})
+	out, err := dbSizeHandler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handler must not error on a failed size query: %v", err)
+	}
+	if out.(dbSizeResponse).SizeBytes != 0 {
+		t.Errorf("expected 0 B on exec error, got %d", out.(dbSizeResponse).SizeBytes)
+	}
+}
+
+func TestParseSizeOutput(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"123\n", 123}, {"  456  ", 456}, {"", 0}, {"notanumber", 0}, {"0", 0},
+	}
+	for _, c := range cases {
+		if got := parseSizeOutput([]byte(c.in)); got != c.want {
+			t.Errorf("parseSizeOutput(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDBSizeHandler_InvalidName(t *testing.T) {
+	raw, _ := json.Marshal(map[string]string{"db_name": "bad name!", "engine": "postgres"})
+	if _, err := dbSizeHandler(context.Background(), raw); err == nil {
+		t.Error("expected an error for an invalid database name")
 	}
 }

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -202,7 +202,10 @@ func (h *databaseHandler) list(c *gin.Context) {
 		rows[i] = databaseListRow{Database: db, SizeBytes: 0}
 
 		// Fetch size from agent
-		result, err := h.cfg.Agent.Call(ctx, "db.size", map[string]string{"db_name": db.Name})
+		// GH #1005: pass the engine so the agent uses pg_database_size() for a
+		// Postgres database instead of MariaDB's information_schema (which has
+		// no row for it and always summed to 0 B).
+		result, err := h.cfg.Agent.Call(ctx, "db.size", map[string]string{"db_name": db.Name, "engine": db.Engine})
 		if err != nil {
 			// Log at INFO and continue with size_bytes=0
 			slog.Info("failed to fetch database size",


### PR DESCRIPTION
## Problem (GH #1005, item 1)

The database list shows every **PostgreSQL** database as **`0 B`**, even when it holds data. The panel computes each row's size via the agent's `db.size`, which ran only:

```sql
SELECT SUM(data_length+index_length) FROM information_schema.tables WHERE table_schema = <name>
```

That is a MariaDB query. A Postgres database has no row in MariaDB's `information_schema`, so the sum is `0`.

## Fix

- `db.size` gains an `engine` param. `"postgres"` reads `pg_database_size()` over the local peer socket (`sudo -u postgres psql -tAq` — the exact path the other Postgres handlers already use). `"mariadb"` / `"mysql"` / `""` (a pre-change panel that omits the field) keep the existing `information_schema` sum, byte-for-byte, so a rolling update is safe.
- The panel passes `db.Engine` at the call site.
- The `db_name` regex (`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`) already forbids any quote or SQL metacharacter, so interpolating the name into `pg_database_size('<name>')` cannot inject. Both engines still degrade to `0` (never error) so the list endpoint can't 500 on one bad row.

## Verification

- Unit tests (exec behind an injectable seam, GH #994 — `go test` never touches a real DB): engine routing (postgres → `pg_database_size`, mariadb/empty → `information_schema`), output parsing, exec-error → `0`, invalid name → error. `go build` + `go vet` + `gofmt` clean; full `panel-agent/commands` and `panel-api/api` packages green.
- **Bug side live-confirmed:** the MariaDB query returns `0` for a Postgres database name.
- **Honesty:** the Postgres path was **not** run against a live Postgres — the test box has the postgres engine disabled and flipping `server_settings.postgres_enabled` alone doesn't provision it. It is unit-tested and uses the standard `pg_database_size()` function through the same `sudo -u postgres psql -tAq` invocation existing Postgres handlers rely on. Worth a live sanity check on a postgres-enabled box before/at merge.

## Scope

Fixes only the `0 B` size (issue item 1). The other #1005 items — Adminer as the primary action for Postgres, pgAdmin integration, and installing Docker apps on the host — are separate UI/feature work, left as follow-ups.

References **GH #1005**; no auto-close keyword (the issue's other items stay open).
