### PR TITLE
fix(ui): one consistent house style for toasts across the panel (GH #970)

### DIFF
--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -24,6 +24,7 @@ import { App as AntdApp, ConfigProvider, Empty, Spin } from "antd";
 import type { ReactNode } from "react";
 import { lazy, Suspense, useEffect } from "react";
 import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
+import { FeedbackBridge } from "./lib/feedback";
 
 import { AuthProvider, useAuth } from "./auth/AuthContext";
 import { RequireAdmin } from "./auth/RequireAdmin";
@@ -197,7 +198,19 @@ const ThemedApp = () => {
         direction={isRTL(lng) ? "rtl" : "ltr"}
         renderEmpty={() => <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />}
       >
-        <AntdApp>
+        <AntdApp
+          // GH #970: one house style for every toast — slim, top-centre,
+          // capped so bursts don't stack. message has no placement (always
+          // top-centre); notification is pulled to `top` to sit with it. These
+          // config the App-scoped (hook + FeedbackBridge) instances; the static
+          // fallbacks are matched in main.tsx.
+          message={{ top: 24, duration: 3, maxCount: 3 }}
+          notification={{ placement: "top", top: 24, duration: 4.5, maxCount: 3 }}
+        >
+        {/* Binds the theme-aware message/notification/modal instances into
+            lib/feedback so any call site (incl. non-component code) is
+            consistent + themed (GH #970). Renders no DOM. */}
+        <FeedbackBridge />
         {/* JAB-159 phase 2: demo UI is compiled out of production bundles.
             VITE_DEMO is statically replaced by Vite; when it is not "1" the
             dynamic import above is tree-shaken, dropping DemoBanner +

--- a/panel-ui/src/lib/feedback.ts
+++ b/panel-ui/src/lib/feedback.ts
@@ -1,0 +1,40 @@
+// Centralised, theme-aware toast/dialog access (GH #970).
+//
+// AntD's static `message` / `notification` / `Modal` methods render OUTSIDE the
+// React tree, so they do NOT inherit the ConfigProvider theme or direction and
+// default to inconsistent placements (message top-center, notification
+// top-right). That is exactly why the panel showed toasts in different
+// positions, sizes, and light/dark backgrounds depending on the page.
+//
+// Import the App-scoped instances from here instead. They are theme- and
+// RTL-aware, honour the global config set on <App>, and — unlike the
+// `App.useApp()` hook — can be used from NON-component code too (query error
+// handlers, api interceptors) where hooks are illegal. This is AntD's own
+// documented "global scene" pattern.
+//
+// The instances are bound once by <FeedbackBridge> (rendered inside <App>).
+// Before that binding runs — during the very first paint, or in unit tests that
+// don't mount the bridge — the static fallbacks are used so no call ever throws.
+import { App, Modal, message as staticMessage, notification as staticNotification } from "antd";
+import { useEffect } from "react";
+
+type FeedbackApi = ReturnType<typeof App.useApp>;
+
+// Mutable holder. Import `feedback` and call `feedback.message.success(...)`.
+export const feedback = {
+  message: staticMessage,
+  notification: staticNotification,
+  modal: Modal,
+} as unknown as FeedbackApi;
+
+// FeedbackBridge swaps the static fallbacks for the App-scoped, theme-aware
+// instances. Render exactly once, INSIDE <App>. Renders no DOM.
+export function FeedbackBridge(): null {
+  const api = App.useApp();
+  useEffect(() => {
+    feedback.message = api.message;
+    feedback.notification = api.notification;
+    feedback.modal = api.modal;
+  }, [api]);
+  return null;
+}

--- a/panel-ui/src/main.tsx
+++ b/panel-ui/src/main.tsx
@@ -8,8 +8,18 @@ import "antd/dist/reset.css";
 import "./global.css";
 
 import "./i18n";
+import { message, notification } from "antd";
 import App from "./App";
 import { registerServiceWorker } from "./lib/registerServiceWorker";
+
+// GH #970: give the STATIC message/notification methods (still used across the
+// app) the same house style as the App-scoped config in App.tsx, so every toast
+// shares one placement + duration regardless of which mechanism a page uses.
+// message has no placement (always top-centre); notification is pulled to `top`
+// to sit with it. Theme/RTL awareness for static methods still needs the
+// lib/feedback bridge — see that file — but position is unified here.
+message.config({ top: 24, duration: 3, maxCount: 3 });
+notification.config({ placement: "top", top: 24, duration: 4.5, maxCount: 3 });
 
 // A dynamic import (lazy route chunk) failing almost always means the tab was
 // open across a panel deploy: the shell in memory references old asset hashes

--- a/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   Card,
   Input,
-  notification,
   Select,
   Space,
   Spin,
@@ -12,6 +11,7 @@ import {
   Tag,
   Typography,
 } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { ApiOutlined, DeleteOutlined, DownloadOutlined, PauseCircleOutlined, PlayCircleOutlined, SearchOutlined } from "@icons";
 import { apiClient } from "../../../apiClient";
 import { extractApiError } from "../../../apiErrors";
@@ -74,7 +74,7 @@ export const PHPExtensionsTab = () => {
           : installed[0] ?? null;
         setSelectedVersion(def);
       } catch (err) {
-        notification.error({
+        feedback.notification.error({
           message: "Failed to fetch PHP versions",
           description: extractApiError(err, "Unknown error"),
         });
@@ -101,7 +101,7 @@ export const PHPExtensionsTab = () => {
       );
       setExtensions(data.extensions);
     } catch (err) {
-      notification.error({
+      feedback.notification.error({
         message: `Failed to fetch extensions for PHP ${version}`,
         description: extractApiError(err, "Unknown error"),
       });
@@ -119,14 +119,14 @@ export const PHPExtensionsTab = () => {
         `/admin/php/versions/${selectedVersion}/extensions/${ext}/apply`,
         { action }
       );
-      notification.success({
+      feedback.notification.success({
         message: `${ext}: ${action} applied for PHP ${selectedVersion}`,
         duration: 2,
       });
       // Server is source of truth; refetch instead of optimistic update.
       await loadExtensions(selectedVersion);
     } catch (err) {
-      notification.error({
+      feedback.notification.error({
         message: `${action} ${ext} failed`,
         description: extractApiError(err, "Unknown error"),
         duration: 5,

--- a/panel-ui/src/shells/admin/settings/BrandingCard.tsx
+++ b/panel-ui/src/shells/admin/settings/BrandingCard.tsx
@@ -22,9 +22,9 @@ import {
   Space,
   Typography,
   Upload,
-  message,
 } from "antd";
 import type { UploadProps } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { DeleteOutlined, SaveOutlined, UploadOutlined } from "@icons";
@@ -57,7 +57,7 @@ export const BrandingCard = () => {
         if (cancelled) return;
         form.setFieldsValue({ panel_brand_text: resp.data.panel_brand_text ?? "" });
       } catch (err) {
-        message.error(err instanceof Error ? err.message : "Load failed");
+        feedback.message.error(err instanceof Error ? err.message : "Load failed");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -74,9 +74,9 @@ export const BrandingCard = () => {
         panel_brand_text: values.panel_brand_text ?? "",
       });
       qc.invalidateQueries({ queryKey: ["branding", "public"] });
-      message.success("Branding text saved");
+      feedback.message.success("Branding text saved");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     } finally {
       setSaving(false);
     }
@@ -88,7 +88,7 @@ export const BrandingCard = () => {
     showUploadList: false,
     beforeUpload: (file) => {
       if (file.size > MAX_LOGO_BYTES) {
-        message.error(`Logo must be <= ${Math.round(MAX_LOGO_BYTES / 1024)} KB`);
+        feedback.message.error(`Logo must be <= ${Math.round(MAX_LOGO_BYTES / 1024)} KB`);
         return Upload.LIST_IGNORE;
       }
       return true;
@@ -101,11 +101,11 @@ export const BrandingCard = () => {
           headers: { "Content-Type": "multipart/form-data" },
         });
         qc.invalidateQueries({ queryKey: ["branding", "public"] });
-        message.success(`${variant === "light" ? "Light" : "Dark"} logo uploaded`);
+        feedback.message.success(`${variant === "light" ? "Light" : "Dark"} logo uploaded`);
         onSuccess?.({} as unknown);
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Upload failed";
-        message.error(msg);
+        feedback.message.error(msg);
         onError?.(err as Error);
       }
     },
@@ -115,9 +115,9 @@ export const BrandingCard = () => {
     try {
       await apiClient.delete(`/admin/settings/branding/logo/${variant}`);
       qc.invalidateQueries({ queryKey: ["branding", "public"] });
-      message.success(`${variant === "light" ? "Light" : "Dark"} logo cleared`);
+      feedback.message.success(`${variant === "light" ? "Light" : "Dark"} logo cleared`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Clear failed");
+      feedback.message.error(err instanceof Error ? err.message : "Clear failed");
     }
   };
 

--- a/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
+++ b/panel-ui/src/shells/user/ssh-keys/UserSSHKeysPage.tsx
@@ -15,10 +15,10 @@ import {
   Modal,
   Form,
   Input,
-  message,
   Popconfirm,
   Tooltip,
 } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   PlusSquareOutlined,
   DeleteOutlined,
@@ -111,7 +111,7 @@ export const UserSSHKeysPage = () => {
       // Client-side validation
       const keyError = validatePublicKey(values.public_key);
       if (keyError) {
-        message.error(keyError);
+        feedback.message.error(keyError);
         return;
       }
 
@@ -120,21 +120,21 @@ export const UserSSHKeysPage = () => {
         public_key: values.public_key,
       });
 
-      message.success("SSH key added successfully");
+      feedback.message.success("SSH key added successfully");
       form.resetFields();
       setModalOpen(false);
       refetch();
     } catch (error: unknown) {
       const err = error as any;
       if (err?.response?.data?.error === "invalid_key") {
-        message.error(
+        feedback.message.error(
           "The public key could not be parsed. Make sure you paste the line from ~/.ssh/id_ed25519.pub (or similar), not a private key.",
         );
       } else if (err?.response?.data?.error === "duplicate_key") {
-        message.error("This key is already registered.");
+        feedback.message.error("This key is already registered.");
       } else {
         const msg = err?.message ?? "Failed to add SSH key";
-        message.error(msg);
+        feedback.message.error(msg);
       }
     } finally {
       setLoading(false);
@@ -150,16 +150,16 @@ export const UserSSHKeysPage = () => {
       setGeneratedName(values.name);
       setGenOpen(false);
       genForm.resetFields();
-      message.success("SSH key generated — save the private key now");
+      feedback.message.success("SSH key generated — save the private key now");
       refetch();
     } catch (error: unknown) {
       const err = error as { response?: { data?: { error?: string } }; message?: string };
       if (err?.response?.data?.error === "duplicate_key") {
         // Extraordinarily unlikely with 32 random bytes, but if the
         // user re-clicks fast enough we could race their own list.
-        message.error("This key is already registered — try again.");
+        feedback.message.error("This key is already registered — try again.");
       } else {
-        message.error(err?.message ?? "Failed to generate SSH key");
+        feedback.message.error(err?.message ?? "Failed to generate SSH key");
       }
     } finally {
       setGenerating(false);
@@ -185,9 +185,9 @@ export const UserSSHKeysPage = () => {
     if (!generatedPrivate) return;
     try {
       await navigator.clipboard.writeText(generatedPrivate);
-      message.success("Private key copied to clipboard");
+      feedback.message.success("Private key copied to clipboard");
     } catch {
-      message.error("Copy failed — select and copy manually");
+      feedback.message.error("Copy failed — select and copy manually");
     }
   };
 
@@ -195,11 +195,11 @@ export const UserSSHKeysPage = () => {
     setDeletingId(key.id);
     try {
       await deleteSSHKey(key.id);
-      message.success("SSH key deleted successfully");
+      feedback.message.success("SSH key deleted successfully");
       refetch();
     } catch (error) {
       const msg = (error as any)?.message ?? "Failed to delete SSH key";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setDeletingId(null);
     }


### PR DESCRIPTION
## Problem (GH #970)

Toast/notification feedback looked different on every page — different position, size, and light/dark background:

- **Settings → Branding:** top-centre, white
- **Settings → Nginx:** top-centre, dark
- **PHP Manager:** module toggle top-right (card), FPM edit top-centre (slim)
- **SSH keys:** white, top-centre

**Root cause:** pages mix AntD's **static** `message`/`notification` — which render *outside* the React tree, so they ignore the `ConfigProvider` theme + direction and default to different placements (message top-centre, notification top-right) — with the **context-aware** `App.useApp()` hook. Static + hook = the white-vs-dark; message vs notification = the position/size difference.

## Fix — three layers

**1. Global config, both surfaces.** `message.config()` + `notification.config()` (`main.tsx`) for the static call sites, and matching `<App message={…} notification={…}>` props (`App.tsx`) for the hook/bridge instances — same values: top-centre, `maxCount` capped so bursts don't stack. `message` has no `placement` (always top-centre), so `notification` is pulled to `top` to sit with it. This unifies **position + duration for all ~170 call sites with zero page churn**.

**2. `lib/feedback.ts` — a theme-aware bridge.** `<FeedbackBridge>` (rendered inside `<App>`) binds the App-scoped `message`/`notification`/`modal` instances into an exported `feedback` holder. Importing from there gives any call site — **including non-component code where hooks are illegal** (query error handlers, api interceptors) — themed, RTL-correct toasts. This is AntD's documented "global scene" pattern, and it turns the remaining conversion into a mechanical import swap.

**3. Converted the reporter's named screens** to `feedback.*`:
- `BrandingCard`, `UserSSHKeysPage` — static `message` → themed (fixes the white-on-dark).
- `PHPExtensionsTab` — `notification` → themed + top-centre. Kept as `notification` (not forced to `message`) because its errors carry a title **and** description: short feedback → message, rich title+body → notification is the documented rule of thumb.

## House standard

**Slim, top-centre** — matches the 147 `message` call sites and the reporter's stated preference for the slim style. It lives in one config spot and is fully reversible; flagged here so it can be **vetoed at review** if you'd rather standardise on top-right/notification.

## Verification

- `tsc -b` and `npm run build` green.
- antd **v6** `message.config` / `notification.config` / `<App>` config-prop APIs confirmed against the current AntD docs (message has no placement; notification `placement:'top'`).
- Toast **text is unchanged**, so E2E selectors are unaffected — CI's Playwright job (real backend) covers the functional path.
- **Not** done: authenticated-screen visual verification (four screens, light + dark). Logging into the panel requires entering a password, which I can't do. Worth a manual eyeball at review, or trust CI.

## Scope / follow-ups

- The full **~59-file** static→`feedback` sweep is a follow-up PR (the bridge makes it mechanical).
- `Modal.confirm` has the same out-of-context problem and is also deferred.

References **GH #970**; no auto-close keyword.
