### PR TITLE
feat(cli): add a hostname key to `jabali settings set`

### DIFF
--- a/panel-api/cmd/server/settings_cmd.go
+++ b/panel-api/cmd/server/settings_cmd.go
@@ -164,6 +164,7 @@ func runSettingsSet(cmd *cobra.Command, args []string) error {
 // sideEffectState captures the pre-change values that decide which host side
 // effects fire (mirrors the REST handler's prev* locals).
 type sideEffectState struct {
+	hostname       string
 	postgres       bool
 	dockerMarket   bool
 	dockerForUsers bool
@@ -172,6 +173,7 @@ type sideEffectState struct {
 
 func sideEffectSnapshot(s *models.ServerSettings) sideEffectState {
 	return sideEffectState{
+		hostname:       s.Hostname,
 		postgres:       s.PostgresEnabled,
 		dockerMarket:   s.DockerMarketplaceEnabled,
 		dockerForUsers: s.DockerAppsForUsersEnabled,
@@ -184,6 +186,18 @@ func sideEffectSnapshot(s *models.ServerSettings) sideEffectState {
 // failure (the DB is already persisted at this point).
 func applySettingsSideEffects(ctx context.Context, cmd *cobra.Command, repo repository.ServerSettingsRepository, s *models.ServerSettings, prev sideEffectState) error {
 	out := cmd.OutOrStdout()
+
+	// Hostname → apply to the OS. Mirrors the REST PATCH, which dispatches
+	// system.set_hostname when Hostname changes (there in a background
+	// goroutine; here synchronous like the rest of this command so the operator
+	// sees the result inline). The panel-cert reconciler reissues the panel
+	// certificate for the new name on its next pass — same as the UI flow.
+	if s.Hostname != prev.hostname {
+		fmt.Fprintf(out, "Applying hostname change (system.set_hostname %s)…\n", s.Hostname)
+		if err := callAgentTimeout(ctx, 30*time.Second, "system.set_hostname", map[string]any{"hostname": s.Hostname}); err != nil {
+			return fmt.Errorf("DB updated, but system.set_hostname failed: %w", err)
+		}
+	}
 
 	if s.PostgresEnabled != prev.postgres {
 		method := "db.postgres.disable"
@@ -324,6 +338,25 @@ func nginxBoolKey(help string, set func(*models.ServerSettings, bool)) settingDe
 // the keys with clear CLI semantics + the acceptance-criteria toggles/tunables.
 // It is NOT full-model coverage (branding/colors/VAPID/etc. stay UI-only).
 var settableKeys = map[string]settingDef{
+	// hostname: the one field that previously had NO CLI writer, so the
+	// free-hostname (JAB-213) conversion couldn't be driven headlessly — the
+	// panel only serves on a name once its stored hostname is that name, and
+	// that write lived only behind the settings PATCH / free-hostname claim
+	// endpoints (admin session). Setting it here runs the same OS apply
+	// (system.set_hostname) the REST PATCH fires; the panel-cert reconciler then
+	// reissues the panel cert for the new name, exactly as the UI path does.
+	// FQDN-format validation is enforced by api.ValidateServerSettings below.
+	"hostname": settingDef{
+		help: "panel hostname / FQDN (applies to the OS via system.set_hostname; the panel-cert reconciler reissues the cert)",
+		apply: func(s *models.ServerSettings, raw string) error {
+			v := strings.TrimSpace(raw)
+			if v == "" {
+				return fmt.Errorf("hostname cannot be empty")
+			}
+			s.Hostname = v
+			return nil
+		},
+	},
 	"postgres_enabled":              boolKey("enable/disable Postgres (installs/stops the engine)", func(s *models.ServerSettings, b bool) { s.PostgresEnabled = b }),
 	"webmail_enabled":               boolKey("enable/disable webmail (DB flag)", func(s *models.ServerSettings, b bool) { s.WebmailEnabled = b }),
 	"docker_marketplace_enabled":    boolKey("enable/disable the Docker marketplace (installs/stops Docker)", func(s *models.ServerSettings, b bool) { s.DockerMarketplaceEnabled = b }),

--- a/panel-api/cmd/server/settings_cmd_test.go
+++ b/panel-api/cmd/server/settings_cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -46,6 +47,12 @@ func TestSettingsRegistryApply(t *testing.T) {
 		{name: "nginx worker_connections invalid", key: "nginx_worker_connections", val: "lots", wantErr: true},
 		{name: "dns preset valid", key: "dns_user_record_policy_preset", val: "hosting-safe"},
 		{name: "dns preset invalid", key: "dns_user_record_policy_preset", val: "nope", wantErr: true},
+		{name: "hostname fqdn", key: "hostname", val: "  182-54-236-60-b.jabalihosted.com  ", check: func(t *testing.T, s *models.ServerSettings) {
+			if s.Hostname != "182-54-236-60-b.jabalihosted.com" {
+				t.Fatalf("want trimmed fqdn, got %q", s.Hostname)
+			}
+		}},
+		{name: "hostname empty rejected", key: "hostname", val: "   ", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -54,7 +61,7 @@ func TestSettingsRegistryApply(t *testing.T) {
 			if !ok {
 				t.Fatalf("key %q not in registry", tc.key)
 			}
-			s := &models.ServerSettings{ID: 1}
+			s := &models.ServerSettings{ID: 1, SSHPort: 22}
 			err := def.apply(s, tc.val)
 			if tc.wantErr {
 				if err == nil {
@@ -72,11 +79,63 @@ func TestSettingsRegistryApply(t *testing.T) {
 	}
 }
 
+// TestSettingsHostnameParity covers the JAB-213 CLI gap: `settings set
+// hostname=` must (1) reach the same FQDN validation the REST PATCH uses via
+// api.ValidateServerSettings, and (2) be detectable as a change so the
+// system.set_hostname side effect fires. Without a CLI writer for hostname the
+// free-hostname conversion could not be driven headlessly.
+func TestSettingsHostnameParity(t *testing.T) {
+	def := settableKeys["hostname"]
+
+	t.Run("valid fqdn passes shared validation", func(t *testing.T) {
+		s := &models.ServerSettings{ID: 1, SSHPort: 22}
+		if err := def.apply(s, "182-54-236-60-b.jabalihosted.com"); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if err := api.ValidateServerSettings(s); err != nil {
+			t.Fatalf("ValidateServerSettings rejected a valid fqdn: %v", err)
+		}
+	})
+
+	t.Run("invalid fqdn rejected by shared validation", func(t *testing.T) {
+		s := &models.ServerSettings{ID: 1, SSHPort: 22}
+		// Passes the setter's non-empty guard but must fail hostnameRE.
+		if err := def.apply(s, "bad host!name"); err != nil {
+			t.Fatalf("apply should defer format checks to ValidateServerSettings: %v", err)
+		}
+		if err := api.ValidateServerSettings(s); err == nil {
+			t.Fatal("ValidateServerSettings accepted an invalid hostname")
+		}
+	})
+
+	t.Run("change is detectable for the side effect", func(t *testing.T) {
+		s := &models.ServerSettings{ID: 1, SSHPort: 22, Hostname: "mx.jabali-panel.com"}
+		prev := sideEffectSnapshot(s)
+		if err := def.apply(s, "182-54-236-60-b.jabalihosted.com"); err != nil {
+			t.Fatal(err)
+		}
+		if s.Hostname == prev.hostname {
+			t.Fatal("hostname change not detectable — system.set_hostname would not fire")
+		}
+	})
+
+	t.Run("hostname key does not flip nginxDirty", func(t *testing.T) {
+		nginxDirty = false
+		s := &models.ServerSettings{ID: 1, SSHPort: 22}
+		if err := def.apply(s, "host.example.com"); err != nil {
+			t.Fatal(err)
+		}
+		if nginxDirty {
+			t.Fatal("hostname must not trigger the nginx side effect")
+		}
+	})
+}
+
 // TestSettingsNginxDirtyFlag verifies nginx-key setters flip nginxDirty so the
 // nginx.tunables.apply side effect fires, while non-nginx keys do not.
 func TestSettingsNginxDirtyFlag(t *testing.T) {
 	nginxDirty = false
-	s := &models.ServerSettings{ID: 1}
+	s := &models.ServerSettings{ID: 1, SSHPort: 22}
 	if err := settableKeys["webmail_enabled"].apply(s, "true"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

The panel hostname was the **only** server-setting with no CLI writer — it could be changed exclusively through the settings PATCH / free-hostname `claim` endpoints, both of which require an admin browser session. This surfaced while running the JAB-213 free-hostname phase-4 E2E: a headless/CLI conversion could reach OS identity (`hostnamectl`) + a real wildcard cert, but **never the panel-serving step**, because the panel only serves its UI on a name once its *stored* (`server_settings`) hostname is that name — and `jabali settings set` had no `hostname` key.

## Changes

- New `hostname` settable key: trims input, rejects empty. **FQDN-format validation reuses `api.ValidateServerSettings`** (already called by `settings set`) — the exact rule the REST PATCH applies (`hostnameRE`, ≤253 chars).
- On change, dispatches `system.set_hostname` **synchronously**, mirroring the REST PATCH (which does it in a background goroutine). The panel-cert reconciler then reissues the panel cert for the new name — identical to the UI path.
- Captured `hostname` in `sideEffectSnapshot` so the change is detectable.

## Test plan

- [x] `hostname` valid FQDN passes shared validation; invalid FQDN rejected by it; empty rejected; change detectable for the side effect; no nginx side effect
- [x] `go test ./panel-api/cmd/server/ ./panel-api/internal/api/` — pass
- [x] `go build ./...`, `go vet`
- [x] cli-reference golden unaffected (captures static help, not the dynamic key list)

Follow-up to JAB-213: makes the free-hostname conversion fully scriptable + CI-testable (no browser session).