### PR TITLE
fix(backup): reconstruct the docker_apps panel row on account restore, not just the data (GH #954)

### DIFF
--- a/internal/backup/metadata.go
+++ b/internal/backup/metadata.go
@@ -51,14 +51,19 @@ type AccountMetadata struct {
 	// Application installs (WordPress, Joomla, Drupal, …).
 	AppInstalls []MetadataAppInstall `json:"app_installs,omitempty"`
 
+	// DockerApps are the account's tenant docker-app rows (GH #954). Their
+	// data trees ride the stage=docker snapshot (#1017); these rows make the
+	// restored apps panel-managed rather than orphaned.
+	DockerApps []MetadataDockerApp `json:"docker_apps,omitempty"`
+
 	// SSH keys + cron jobs hang off the user, not a domain.
 	SSHKeys  []MetadataSSHKey  `json:"ssh_keys,omitempty"`
 	CronJobs []MetadataCronJob `json:"cron_jobs,omitempty"`
 
 	// User-level egress + limit overrides (M18 / M34).
-	EgressPolicy   *MetadataEgressPolicy    `json:"egress_policy,omitempty"`
-	EgressRequests []MetadataEgressRequest  `json:"egress_requests,omitempty"`
-	LimitOverride  *MetadataLimitOverride   `json:"limit_override,omitempty"`
+	EgressPolicy   *MetadataEgressPolicy   `json:"egress_policy,omitempty"`
+	EgressRequests []MetadataEgressRequest `json:"egress_requests,omitempty"`
+	LimitOverride  *MetadataLimitOverride  `json:"limit_override,omitempty"`
 }
 
 // MetadataUser mirrors models.User. Pointers preserve NULL semantics
@@ -87,7 +92,6 @@ type MetadataKratos struct {
 	// Raw exported identity data from Kratos export API, stored as JSON
 	ExportedIdentity string `json:"exported_identity"`
 }
-
 
 // MetadataDomain mirrors models.Domain plus the per-domain children
 // (SSL cert, mailboxes, forwarders, autoresponders, mailbox shares,
@@ -128,14 +132,14 @@ type MetadataDomain struct {
 	DNSSECEnabledAt       string  `json:"dnssec_enabled_at,omitempty"`
 	CreatedAt             string  `json:"created_at,omitempty"`
 
-	SSLCertificate *MetadataSSLCert       `json:"ssl_certificate,omitempty"`
-	Mailboxes      []MetadataMailbox      `json:"mailboxes,omitempty"`
-	Forwarders     []MetadataForwarder    `json:"forwarders,omitempty"`
+	SSLCertificate *MetadataSSLCert    `json:"ssl_certificate,omitempty"`
+	Mailboxes      []MetadataMailbox   `json:"mailboxes,omitempty"`
+	Forwarders     []MetadataForwarder `json:"forwarders,omitempty"`
 	// DNSRecords (GH #267) captures the user-created DNS rows so a restore can
 	// re-insert them. Managed records (BootstrapRecords + mail) are excluded —
 	// they re-derive from domain config via the reconciler.
-	DNSRecords     []MetadataDNSRecord    `json:"dns_records,omitempty"`
-	DNSSECKeys     []MetadataDNSSECKey    `json:"dnssec_keys,omitempty"`
+	DNSRecords []MetadataDNSRecord `json:"dns_records,omitempty"`
+	DNSSECKeys []MetadataDNSSECKey `json:"dnssec_keys,omitempty"`
 }
 
 // MetadataSSLCert mirrors models.SSLCertificate (sans large per-cert
@@ -190,11 +194,11 @@ type MetadataDatabase struct {
 // (one DBUser → many DatabaseIDs). Restore preserves password_hash so
 // the user's existing MariaDB credentials keep working.
 type MetadataDatabaseUser struct {
-	ID           string                       `json:"id"`
-	Username     string                       `json:"username"`
-	PasswordHash string                       `json:"password_hash,omitempty"`
-	CreatedAt    string                       `json:"created_at,omitempty"`
-	Grants       []MetadataDatabaseUserGrant  `json:"grants,omitempty"`
+	ID           string                      `json:"id"`
+	Username     string                      `json:"username"`
+	PasswordHash string                      `json:"password_hash,omitempty"`
+	CreatedAt    string                      `json:"created_at,omitempty"`
+	Grants       []MetadataDatabaseUserGrant `json:"grants,omitempty"`
 }
 
 // MetadataDatabaseUserGrant pairs a database user with the database it
@@ -214,16 +218,16 @@ type MetadataDatabaseUserGrant struct {
 // autoresponder + share rows. PasswordEnc carries the AES-256-GCM
 // blob used by the webmail SSO flow — round-tripped as base64 in JSON.
 type MetadataMailbox struct {
-	ID             string                  `json:"id"`
-	LocalPart      string                  `json:"local_part"`
-	EmailCached    string                  `json:"email_cached,omitempty"`
-	PasswordHash   string                  `json:"password_hash,omitempty"`
-	PasswordEnc    []byte                  `json:"password_enc,omitempty"`
-	QuotaBytes     uint64                  `json:"quota_bytes"`
-	IsDisabled     bool                    `json:"is_disabled"`
-	CreatedAt      string                  `json:"created_at,omitempty"`
-	Autoresponder  *MetadataAutoresponder  `json:"autoresponder,omitempty"`
-	SharedWith     []MetadataMailboxShare  `json:"shared_with,omitempty"`
+	ID            string                 `json:"id"`
+	LocalPart     string                 `json:"local_part"`
+	EmailCached   string                 `json:"email_cached,omitempty"`
+	PasswordHash  string                 `json:"password_hash,omitempty"`
+	PasswordEnc   []byte                 `json:"password_enc,omitempty"`
+	QuotaBytes    uint64                 `json:"quota_bytes"`
+	IsDisabled    bool                   `json:"is_disabled"`
+	CreatedAt     string                 `json:"created_at,omitempty"`
+	Autoresponder *MetadataAutoresponder `json:"autoresponder,omitempty"`
+	SharedWith    []MetadataMailboxShare `json:"shared_with,omitempty"`
 }
 
 // MetadataForwarder mirrors models.EmailForwarder. Each forwarder
@@ -291,6 +295,42 @@ type MetadataAppInstall struct {
 	Status        string  `json:"status"`
 	AppType       string  `json:"app_type"`
 	CreatedAt     string  `json:"created_at,omitempty"`
+}
+
+// MetadataDockerApp mirrors models.DockerApp — the panel row for a tenant
+// docker-app install (GH #954). The app's DATA tree is a separate restic
+// stage=docker snapshot (#1017); this row is what makes the restored app
+// panel-managed instead of orphaned on-disk. The reverse-proxy domain link is
+// carried by the domain's own proxy_pass rule (reconstructed with the domain),
+// so preserving the app ID + published host ports keeps them consistent.
+type MetadataDockerApp struct {
+	ID             string  `json:"id"`
+	Slug           string  `json:"slug"`
+	InstanceSlug   string  `json:"instance_slug"`
+	Name           string  `json:"name"`
+	CatalogVersion string  `json:"catalog_version"`
+	ImageSHA       *string `json:"image_sha,omitempty"`
+	Status         string  `json:"status"`
+	UpdateMode     string  `json:"update_mode"`
+	CPULimit       *string `json:"cpu_limit,omitempty"`
+	MemoryLimit    *string `json:"memory_limit,omitempty"`
+	PIDsLimit      *int    `json:"pids_limit,omitempty"`
+	CreatedAt      string  `json:"created_at,omitempty"`
+	// Ports are the published-port rows (host_port pins the reverse-proxy
+	// target the migrated domain's proxy_pass points at).
+	Ports []MetadataDockerAppPort `json:"ports,omitempty"`
+}
+
+// MetadataDockerAppPort mirrors models.DockerAppPublishedPort.
+type MetadataDockerAppPort struct {
+	ID            string `json:"id"`
+	PortName      string `json:"port_name"`
+	ContainerPort int    `json:"container_port"`
+	BindInterface string `json:"bind_interface"`
+	HostPort      int    `json:"host_port"`
+	Protocol      string `json:"protocol"`
+	ReverseProxy  bool   `json:"reverse_proxy"`
+	Enabled       bool   `json:"enabled"`
 }
 
 // MetadataSSHKey mirrors models.SSHKey.

--- a/panel-api/cmd/server/account_restore_cmd.go
+++ b/panel-api/cmd/server/account_restore_cmd.go
@@ -51,6 +51,7 @@ func applyPanelMetadata(ctx context.Context, cmd *cobra.Command, raw json.RawMes
 		DatabaseUsers:  repository.NewDatabaseUserRepository(sharedDB),
 		DatabaseGrants: repository.NewDatabaseUserGrantRepository(sharedDB),
 		AppInstalls:    repository.NewApplicationInstallRepository(sharedDB),
+		DockerApps:     repository.NewDockerAppRepository(sharedDB),
 		SSLCerts:       repository.NewSSLCertificateRepository(sharedDB),
 		PHPPools:       repository.NewPHPPoolRepository(sharedDB),
 		PHPPoolIni:     repository.NewPHPPoolIniOverrideRepository(sharedDB),
@@ -73,6 +74,7 @@ func applyPanelMetadata(ctx context.Context, cmd *cobra.Command, raw json.RawMes
 	fmt.Fprintf(w, "  mailboxes:      %d (forwarders: %d)\n", r.Mailboxes, r.Forwarders)
 	fmt.Fprintf(w, "  databases:      %d (users: %d, grants: %d)\n", r.Databases, r.DatabaseUsers, r.DatabaseGrants)
 	fmt.Fprintf(w, "  app_installs:   %d\n", r.AppInstalls)
+	fmt.Fprintf(w, "  docker_apps:    %d\n", r.DockerApps)
 	fmt.Fprintf(w, "  ssh_keys:       %d\n", r.SSHKeys)
 	fmt.Fprintf(w, "  cron_jobs:      %d\n", r.CronJobs)
 	fmt.Fprintf(w, "  skipped:        %d (already present)\n", r.Skipped)

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1100,7 +1100,7 @@ func (cfg MeBackupsHandlerConfig) logErr(msg string, err error, kv ...any) {
 func (cfg BackupHandlerConfig) buildAccountMetadata(ctx context.Context, user *models.User) *internalbackup.AccountMetadata {
 	return backupmetadata.Build(ctx, user, backupmetadata.Deps{
 		Databases: cfg.Databases, DatabaseUsers: cfg.DatabaseUsers, DatabaseGrants: cfg.DatabaseGrants,
-		Domains: cfg.Domains, Mailboxes: cfg.Mailboxes, AppInstalls: cfg.AppInstalls,
+		Domains: cfg.Domains, Mailboxes: cfg.Mailboxes, AppInstalls: cfg.AppInstalls, DockerApps: cfg.DockerApps,
 		SSLCerts: cfg.SSLCerts, PHPPools: cfg.PHPPools, PHPPoolIni: cfg.PHPPoolIni,
 		Forwarders: cfg.Forwarders, Autoresponders: cfg.Autoresponders, MailboxShares: cfg.MailboxShares,
 		DNSSECKeys: cfg.DNSSECKeys, DNSZones: cfg.DNSZones, DNSRecords: cfg.DNSRecords, SSHKeys: cfg.SSHKeys, CronJobs: cfg.CronJobs,
@@ -1312,7 +1312,7 @@ func (cfg MeBackupsHandlerConfig) allUserDockerApps(ctx context.Context, userID 
 func (cfg MeBackupsHandlerConfig) buildAccountMetadata(ctx context.Context, user *models.User) *internalbackup.AccountMetadata {
 	return backupmetadata.Build(ctx, user, backupmetadata.Deps{
 		Databases: cfg.Databases, DatabaseUsers: cfg.DatabaseUsers, DatabaseGrants: cfg.DatabaseGrants,
-		Domains: cfg.Domains, Mailboxes: cfg.Mailboxes, AppInstalls: cfg.AppInstalls,
+		Domains: cfg.Domains, Mailboxes: cfg.Mailboxes, AppInstalls: cfg.AppInstalls, DockerApps: cfg.DockerApps,
 		SSLCerts: cfg.SSLCerts, PHPPools: cfg.PHPPools, PHPPoolIni: cfg.PHPPoolIni,
 		Forwarders: cfg.Forwarders, Autoresponders: cfg.Autoresponders, MailboxShares: cfg.MailboxShares,
 		DNSSECKeys: cfg.DNSSECKeys, DNSZones: cfg.DNSZones, DNSRecords: cfg.DNSRecords, SSHKeys: cfg.SSHKeys, CronJobs: cfg.CronJobs,

--- a/panel-api/internal/backupmetadata/apply.go
+++ b/panel-api/internal/backupmetadata/apply.go
@@ -42,6 +42,7 @@ type ApplyResult struct {
 	DatabaseUsers  int
 	DatabaseGrants int
 	AppInstalls    int
+	DockerApps     int
 	SSHKeys        int
 	CronJobs       int
 	Skipped        int
@@ -397,6 +398,41 @@ func Apply(ctx context.Context, m *internalbackup.AccountMetadata, d Deps) Apply
 				continue
 			}
 			r.AppInstalls++
+		}
+	}
+
+	// 5b) Docker apps (GH #954): rebuild the panel row + published ports so the
+	// restored app is panel-managed. The DATA tree + compose-up land via the
+	// stage=docker restore (#1017); without this row the app is orphaned on disk.
+	if d.DockerApps != nil {
+		for _, a := range m.DockerApps {
+			uid := m.User.ID
+			row := &models.DockerApp{
+				ID: a.ID, UserID: &uid, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
+				Name: a.Name, CatalogVersion: a.CatalogVersion, ImageSHA: a.ImageSHA,
+				Status: a.Status, UpdateMode: a.UpdateMode,
+				CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,
+				CreatedAt: now, UpdatedAt: now,
+			}
+			if err := d.DockerApps.Create(ctx, row); err != nil {
+				if errors.Is(err, repository.ErrConflict) {
+					r.Skipped++
+					continue
+				}
+				r.Errors = append(r.Errors, fmt.Sprintf("docker_app %s: create: %v", a.ID, err))
+				continue
+			}
+			for _, p := range a.Ports {
+				port := &models.DockerAppPublishedPort{
+					ID: p.ID, AppID: a.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
+					BindInterface: p.BindInterface, HostPort: p.HostPort, Protocol: p.Protocol,
+					ReverseProxy: p.ReverseProxy, Enabled: p.Enabled, CreatedAt: now,
+				}
+				if err := d.DockerApps.CreatePort(ctx, port); err != nil {
+					r.Errors = append(r.Errors, fmt.Sprintf("docker_app %s port %s: create: %v", a.ID, p.PortName, err))
+				}
+			}
+			r.DockerApps++
 		}
 	}
 

--- a/panel-api/internal/backupmetadata/builder.go
+++ b/panel-api/internal/backupmetadata/builder.go
@@ -42,6 +42,7 @@ type Deps struct {
 	Domains        repository.DomainRepository
 	Mailboxes      repository.MailboxRepository
 	AppInstalls    repository.ApplicationInstallRepository
+	DockerApps     repository.DockerAppRepository
 	SSLCerts       repository.SSLCertificateRepository
 	PHPPools       repository.PHPPoolRepository
 	PHPPoolIni     repository.PHPPoolIniOverrideRepository
@@ -151,8 +152,8 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 				ID: pool.ID, PHPVersion: pool.PHPVersion,
 				PmMode: pool.PmMode, PmMaxChildren: pool.PmMaxChildren,
 				ProcessIdleTimeoutSeconds: pool.ProcessIdleTimeoutSeconds,
-				Status:    pool.Status,
-				CreatedAt: timeRFC(pool.CreatedAt),
+				Status:                    pool.Status,
+				CreatedAt:                 timeRFC(pool.CreatedAt),
 			}
 			if d.PHPPoolIni != nil {
 				if overrides, ierr := d.PHPPoolIni.ListByPool(ctx, pool.ID); ierr == nil {
@@ -265,7 +266,7 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 							mbRow.SharedWith = append(mbRow.SharedWith,
 								internalbackup.MetadataMailboxShare{
 									ID: sh.ID, SharedWithMailboxID: sh.SharedWithMailboxID,
-									Rights: string(rights),
+									Rights:    string(rights),
 									CreatedAt: timeRFC(sh.CreatedAt),
 								})
 						}
@@ -331,6 +332,38 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 		}
 	}
 
+	// Docker apps (GH #954): capture the tenant docker-app rows + their
+	// published ports so a restore can rebuild the panel row. The DATA tree
+	// rides the stage=docker snapshot (#1017); without this row the restored
+	// app is orphaned on disk.
+	if d.DockerApps != nil {
+		apps, err := d.DockerApps.ListByUserID(ctx, user.ID)
+		if err != nil {
+			d.warn("metadata: list docker apps", err, "user_id", user.ID)
+		}
+		for _, a := range apps {
+			row := internalbackup.MetadataDockerApp{
+				ID: a.ID, Slug: a.Slug, InstanceSlug: a.InstanceSlug,
+				Name: a.Name, CatalogVersion: a.CatalogVersion,
+				ImageSHA: a.ImageSHA, Status: a.Status, UpdateMode: a.UpdateMode,
+				CPULimit: a.CPULimit, MemoryLimit: a.MemoryLimit, PIDsLimit: a.PIDsLimit,
+				CreatedAt: timeRFC(a.CreatedAt),
+			}
+			if ports, perr := d.DockerApps.ListPortsForApp(ctx, a.ID); perr == nil {
+				for _, p := range ports {
+					row.Ports = append(row.Ports, internalbackup.MetadataDockerAppPort{
+						ID: p.ID, PortName: p.PortName, ContainerPort: p.ContainerPort,
+						BindInterface: p.BindInterface, HostPort: p.HostPort,
+						Protocol: p.Protocol, ReverseProxy: p.ReverseProxy, Enabled: p.Enabled,
+					})
+				}
+			} else {
+				d.warn("metadata: list docker app ports", perr, "app_id", a.ID)
+			}
+			m.DockerApps = append(m.DockerApps, row)
+		}
+	}
+
 	if d.SSHKeys != nil {
 		keys, _ := d.SSHKeys.ListByUserID(ctx, user.ID)
 		for _, k := range keys {
@@ -361,7 +394,7 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 				DiskQuotaMB: lo.DiskQuotaMB, CPUQuotaPercent: lo.CPUQuotaPercent,
 				MemoryLimitMB: lo.MemoryLimitMB,
 				IOReadMbps:    lo.IOReadMbps, IOWriteMbps: lo.IOWriteMbps,
-				MaxTasks:      lo.MaxTasks,
+				MaxTasks: lo.MaxTasks,
 			}
 			break
 		}

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -760,6 +760,7 @@ func buildScheduleMetadata(ctx context.Context, deps Deps, user *models.User, lo
 		Domains:        deps.Domains,
 		Mailboxes:      deps.Mailboxes,
 		AppInstalls:    deps.AppInstalls,
+		DockerApps:     deps.DockerApps,
 		SSLCerts:       deps.SSLCerts,
 		PHPPools:       deps.PHPPools,
 		PHPPoolIni:     deps.PHPPoolIni,


### PR DESCRIPTION
## Problem (GH #954, follow-up to #1017)

#1017 added the docker-app **data tree** to the account backup (`stage=docker`), so an account's docker apps now travel with a Jabali→Jabali migration and DR. But the account_backup **metadata bundle** never captured the `docker_apps` **row**, and the restore had nothing to rebuild from — so a migrated/restored docker app landed as **orphaned data**: on disk, but no panel row, invisible in `docker-app list`, unmanaged, never brought up. That's exactly the reporter's follow-up on #954 ("docker apps didn't transfer… how would they get into the installed area to be managed?").

A 2-box/DR drill caught this precisely where unit tests couldn't (the #746 "moves zero files" trap, inverted: the files move now, but nothing wires them up).

## Fix — carry the row through the metadata bundle, mirroring `app_installs`/`domains`

- **`internal/backup/metadata.go`** — add `MetadataDockerApp` (+ `MetadataDockerAppPort`) and `AccountMetadata.DockerApps`.
- **`backupmetadata/builder.go`** — capture the account's tenant `docker_apps` rows + their published ports (`Deps.DockerApps`).
- **`backupmetadata/apply.go`** — reconstruct the `docker_apps` row owned by the target user + its published-port rows (`ApplyResult.DockerApps`). The app's reverse-proxy domain link rides the domain's own `proxy_pass` rule (reconstructed with the domain); preserving the app id + host ports keeps them consistent.
- Wire the `DockerApps` repo into the four Deps sites (admin + me backup handlers, the scheduler, and the account-restore apply) and print the count in the restore CLI.

Together with #1017's `stage=docker` data restore (which does `compose up`), a migrated tenant docker app now comes across fully — **row + ports + data + running, panel-managed on the destination**.

## Verification — DR drill on a real box

Deployed this build, enabled docker + tenant-docker, installed a tenant **uptime-kuma** for a user, seeded a marker in its data volume, then:
- account_backup → the meta bundle now carries **`docker_apps: 1`** (with its published port). *(Before: absent.)*
- delete the user → account-restore (DR path): **`docker_apps: 1`**, `docker-app list` shows the app **owned by the restored user** with its port, and the marker `J2J-DOCKER-ROWFIX-…` crossed over.
- **Before this fix**, the same drill produced `app_installs: 0`, no `docker_apps` row, empty `docker-app list` — orphaned.

The mail-body + login fixes from the original #954 also ride the same restore path.

## Notes

- `internal/backupmetadata` has no unit-test harness (pre-existing — only `apply.go`/`builder.go`). For a migration feature the DR drill is the acceptance gate; a fake-repo unit suite for the whole `Deps` is a reasonable follow-up.
- References **GH #954**; no auto-close keyword.
