### PR TITLE
feat(automation): auto-create the primary domain on account create (JAB-233, ADR-0164)

### DIFF
--- a/docs/adr/0164-billing-automation-endpoints.md
+++ b/docs/adr/0164-billing-automation-endpoints.md
@@ -80,3 +80,31 @@ Needs its own ADR (Kratos session minting) before any implementation.
 - `userops` grows three functions with the GUI handlers as thin shells —
   future callers (CLI, migrations) inherit them for free.
 - No schema changes; no migration.
+
+## Addendum — JAB-233: `domain` on create is now honored
+
+**Status:** accepted, 2026-08-08. Amends the "domain accepted but not
+auto-created in v1" deferral.
+
+`POST /automation/users` now creates the primary domain when the request
+carries `domain`. The deferral's real cost was that the ~265-line GUI
+domain-creation orchestration lived inline in `domainHandler.create`; it was
+extracted to `createDomainOp` (zero-behavior-change; GUI domain regression
+tests pass unmodified), which the automation handler now reuses.
+
+Semantics:
+- **Scope:** `domain` present requires `write:users` **and** `write:domains`
+  (both already in `AllowedAutomationScopes`). Absent → `write:users` only,
+  unchanged. New capability `domains.create` (advertised when wired).
+- **Order / atomicity:** the domain is pre-validated (scope, FQDN, global
+  name-conflict) BEFORE `userops.Create`, so a bad/taken domain fails fast
+  (403/400/409) and never leaves a half-created account. Inline SSL is skipped
+  on this path — the reconciler bootstraps the cert on its first tick (like
+  `jabali domain create`).
+- **Failure after the account exists** (agent down, insert race) does NOT roll
+  back: `201` + `domain_warning`, audited; the operator retries the domain.
+- **Idempotent retry** (`status:"exists"`): create the domain if the user
+  doesn't own it, no-op (return its id) if they do, `409` if owned by another.
+- **Delete:** unchanged — `userops.DeleteCascade` already purges owned domains.
+
+No schema changes; no migration.

--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -84,6 +84,11 @@ type AutomationConfig struct {
 	// nil-guard, never a bare *reconciler.Reconciler that might be nil).
 	LimitsReconciler userops.LimitsReconciler
 	DomainReconciler userops.DomainReconciler
+	// DomainCreate carries the same deps the GUI domain handler uses, so
+	// JAB-233 account-create-with-domain runs the exact createDomainOp
+	// orchestration. Nil-safe: when unset (or its repos nil), a create that
+	// carries `domain` degrades to a domain_warning rather than panicking.
+	DomainCreate DomainHandlerConfig
 	// Usage reads (bulk-safe: snapshots + one batched bw_daily query —
 	// the automation usage endpoints NEVER call the agent).
 	DiskSnapshots repository.DiskUsageSnapshotRepository

--- a/panel-api/internal/api/automation_billing.go
+++ b/panel-api/internal/api/automation_billing.go
@@ -106,6 +106,12 @@ func registerAutomationBilling(g *gin.RouterGroup, cfg AutomationConfig, wl *wri
 		caps = append(caps,
 			capability{"users.create", "POST", "/automation/users", "write:users", false},
 			capability{"users.password", "POST", "/automation/users/:id/password", "write:users", false})
+		// JAB-233: account-create can auto-create a primary domain when the
+		// request carries `domain` (needs write:domains too). Advertised only
+		// when the domain deps are wired.
+		if cfg.DomainCreate.Domains != nil {
+			caps = append(caps, capability{"domains.create", "POST", "/automation/users", "write:domains", false})
+		}
 
 		if cfg.Packages != nil {
 			g.PUT("/users/:id/package", wl.middleware(), requireWriteScope("write:users"), userPackageHandler(cfg))
@@ -180,6 +186,36 @@ func userCreateHandler(cfg AutomationConfig) gin.HandlerFunc {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
 
+		// JAB-233: optional primary-domain auto-create. Pre-validate the domain
+		// (scope + FQDN + global name-conflict) BEFORE the account exists, so a
+		// bad/taken domain fails fast and never leaves a half-created user.
+		// Absent `domain` → write:users only, unchanged from before.
+		var domName string
+		if strings.TrimSpace(req.Domain) != "" {
+			if !tok.Scopes.Has("write:domains") {
+				auditWrite(c, cfg.Audits, tok, action, "user", req.Email, models.AuditResultDenied)
+				autoErr(c, http.StatusForbidden, "scope_denied", "creating a domain requires the write:domains scope")
+				return
+			}
+			domName = normalizeDomainName(req.Domain)
+			if verr := validateDomainName(domName); verr != nil {
+				autoErr(c, http.StatusBadRequest, "validation", "invalid domain: "+verr.Error())
+				return
+			}
+			domName = htmlTagRe.ReplaceAllString(domName, "")
+			// Fail-fast conflict: taken by anyone other than the user this
+			// (possibly retried) create resolves to. The same-owner retry case
+			// falls through and is handled idempotently after the account
+			// resolves (createAutomationDomain).
+			if existing, ferr := cfg.DomainCreate.Domains.FindByName(ctx, domName); ferr == nil && existing != nil {
+				owner := findExactUserMatch(ctx, cfg.Users, req.Email, req.Username)
+				if owner == nil || existing.UserID != owner.ID {
+					autoErr(c, http.StatusConflict, "conflict", "domain already exists")
+					return
+				}
+			}
+		}
+
 		// is_admin is NOT exposed: automation can never mint an admin.
 		res, err := userops.Create(ctx, billingUserOpsDeps(cfg), userops.CreateInput{
 			Email:     req.Email,
@@ -194,7 +230,17 @@ func userCreateHandler(cfg AutomationConfig) gin.HandlerFunc {
 			if userIsErrTaken(err) {
 				if existing := findExactUserMatch(ctx, cfg.Users, req.Email, req.Username); existing != nil {
 					auditWrite(c, cfg.Audits, tok, action, "user", existing.ID, models.AuditResultOK)
-					c.JSON(http.StatusOK, gin.H{"ok": true, "status": "exists", "user_id": existing.ID, "message": "user already exists"})
+					resp := gin.H{"ok": true, "status": "exists", "user_id": existing.ID, "message": "user already exists"}
+					// JAB-233: idempotent domain on retry — create if the user
+					// doesn't own it yet, no-op (return its id) if they do.
+					if domName != "" {
+						if did, warn := createAutomationDomain(c, cfg, tok, existing.ID, domName); did != "" {
+							resp["domain_id"] = did
+						} else if warn != "" {
+							resp["domain_warning"] = warn
+						}
+					}
+					c.JSON(http.StatusOK, resp)
 					return
 				}
 				auditWrite(c, cfg.Audits, tok, action, "user", req.Email, models.AuditResultError)
@@ -213,8 +259,56 @@ func userCreateHandler(cfg AutomationConfig) gin.HandlerFunc {
 		if res.ProvisionWarning != "" {
 			msg = res.ProvisionWarning
 		}
-		c.JSON(http.StatusCreated, gin.H{"ok": true, "status": "created", "user_id": res.User.ID, "message": msg})
+		resp := gin.H{"ok": true, "status": "created", "user_id": res.User.ID, "message": msg}
+		// JAB-233: create the primary domain. A failure here does NOT roll back
+		// the account (ProvisionWarning precedent) — surface domain_warning on
+		// the 201 and let the operator retry the domain.
+		if domName != "" {
+			if did, warn := createAutomationDomain(c, cfg, tok, res.User.ID, domName); did != "" {
+				resp["domain_id"] = did
+			} else if warn != "" {
+				resp["domain_warning"] = warn
+			}
+		}
+		c.JSON(http.StatusCreated, resp)
 	}
+}
+
+// createAutomationDomain creates ownerID's primary domain via the shared GUI
+// orchestration (createDomainOp), with inline SSL skipped — the reconciler
+// bootstraps the cert on its first tick, exactly like `jabali domain create`.
+// Idempotent: if the owner already owns a domain of that name, returns its id
+// with no warning. A failure AFTER the account exists never rolls back; it
+// returns an empty id + a warning the caller surfaces as `domain_warning`.
+// Audits the domain-scoped write (success/failure) and bells on success.
+func createAutomationDomain(c *gin.Context, cfg AutomationConfig, tok *models.AutomationToken, ownerID, name string) (domainID, warning string) {
+	const action = "POST /automation/users (domain)"
+	ctx := c.Request.Context()
+	if cfg.DomainCreate.Domains == nil {
+		return "", "domain not created: domain support not wired on this panel"
+	}
+	// Idempotent no-op: owner already owns it.
+	if existing, err := cfg.DomainCreate.Domains.FindByName(ctx, name); err == nil && existing != nil {
+		if existing.UserID == ownerID {
+			return existing.ID, ""
+		}
+		auditWrite(c, cfg.Audits, tok, action, "domain", name, models.AuditResultDenied)
+		return "", "domain already exists"
+	}
+	h := &domainHandler{cfg: cfg.DomainCreate}
+	dom, oerr := createDomainOp(ctx, h, createDomainInput{OwnerID: ownerID, Name: name, SkipInlineSSL: true})
+	if oerr != nil {
+		auditWrite(c, cfg.Audits, tok, action, "domain", name, models.AuditResultError)
+		w := oerr.Code
+		if oerr.Detail != "" {
+			w = oerr.Code + ": " + oerr.Detail
+		}
+		return "", "domain not created: " + w
+	}
+	auditWrite(c, cfg.Audits, tok, action, "domain", dom.ID, models.AuditResultOK)
+	notifyWrite(cfg, "automation.domain.created", "info", "Automation created a domain",
+		"Domain "+dom.Name+" was created via the automation API.", "/jabali-panel/domains")
+	return dom.ID, ""
 }
 
 func userIsErrTaken(err error) bool {

--- a/panel-api/internal/api/automation_domain_create_test.go
+++ b/panel-api/internal/api/automation_domain_create_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-233 — account-create with an optional primary domain. These exercise the
+// userCreateHandler domain path end-to-end against createDomainOp, using a
+// minimal fake domain repo. The extraction itself (createDomainOp == the GUI
+// orchestration) is covered by the unchanged domain regression suite.
+
+type dcDomains struct {
+	repository.DomainRepository
+	byName    map[string]*models.Domain
+	createErr error
+	created   []*models.Domain
+}
+
+func newDCDomains() *dcDomains { return &dcDomains{byName: map[string]*models.Domain{}} }
+
+func (r *dcDomains) FindByName(_ context.Context, name string) (*models.Domain, error) {
+	if d, ok := r.byName[name]; ok {
+		return d, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (r *dcDomains) CountByUserID(_ context.Context, _ string) (int64, error) { return 0, nil }
+
+func (r *dcDomains) Create(_ context.Context, d *models.Domain) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.byName[d.Name] = d
+	r.created = append(r.created, d)
+	return nil
+}
+
+func billingCfgDom(users *abUsers, dom repository.DomainRepository) AutomationConfig {
+	cfg := billingCfg(users)
+	cfg.DomainCreate = DomainHandlerConfig{Users: users, Domains: dom}
+	return cfg
+}
+
+// scope gate: a token WITHOUT write:domains + a domain must 403 before any
+// account is created.
+func TestAutomationUserCreate_Domain_ScopeGate403(t *testing.T) {
+	users := newAbUsers()
+	cfg := billingCfgDom(users, newDCDomains())
+	body := `{"email":"a@example.com","password":"longenough1","username":"buyer","domain":"shop.example.com"}`
+	tok := billingTok("write:users") // note: no write:domains
+	r := abRouterWithBody(cfg, tok, body)
+	w := abReq(r, http.MethodPost, "/users", body, tok)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if decodeBody(t, w)["error"] != "scope_denied" {
+		t.Fatalf("want scope_denied, got %v", decodeBody(t, w))
+	}
+	if len(users.created) != 0 {
+		t.Fatalf("no account must be created when the domain scope is missing, got %d", len(users.created))
+	}
+}
+
+// invalid domain fails fast (400) before the account exists.
+func TestAutomationUserCreate_Domain_Invalid400(t *testing.T) {
+	users := newAbUsers()
+	cfg := billingCfgDom(users, newDCDomains())
+	body := `{"email":"a@example.com","password":"longenough1","username":"buyer","domain":"not a domain!!"}`
+	tok := billingTok("write:users", "write:domains")
+	r := abRouterWithBody(cfg, tok, body)
+	w := abReq(r, http.MethodPost, "/users", body, tok)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(users.created) != 0 {
+		t.Fatalf("no account must be created for an invalid domain, got %d", len(users.created))
+	}
+}
+
+// domain already owned by a DIFFERENT user → 409, fail-fast (no account).
+func TestAutomationUserCreate_Domain_TakenByOther409(t *testing.T) {
+	users := newAbUsers()
+	dom := newDCDomains()
+	dom.byName["taken.example.com"] = &models.Domain{ID: "d-other", UserID: "someone-else", Name: "taken.example.com"}
+	cfg := billingCfgDom(users, dom)
+	body := `{"email":"a@example.com","password":"longenough1","username":"buyer","domain":"taken.example.com"}`
+	tok := billingTok("write:users", "write:domains")
+	r := abRouterWithBody(cfg, tok, body)
+	w := abReq(r, http.MethodPost, "/users", body, tok)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(users.created) != 0 {
+		t.Fatalf("no account must be created when the domain is taken, got %d", len(users.created))
+	}
+}
+
+// happy path: account + primary domain created; envelope carries domain_id.
+func TestAutomationUserCreate_Domain_HappyPath(t *testing.T) {
+	users := newAbUsers()
+	dom := newDCDomains()
+	cfg := billingCfgDom(users, dom)
+	body := `{"email":"a@example.com","password":"longenough1","username":"buyer","domain":"shop.example.com"}`
+	tok := billingTok("write:users", "write:domains")
+	r := abRouterWithBody(cfg, tok, body)
+	w := abReq(r, http.MethodPost, "/users", body, tok)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeBody(t, w)
+	if resp["status"] != "created" || resp["user_id"] == "" {
+		t.Fatalf("bad envelope: %v", resp)
+	}
+	did, _ := resp["domain_id"].(string)
+	if did == "" {
+		t.Fatalf("expected domain_id in the response, got %v", resp)
+	}
+	if resp["domain_warning"] != nil {
+		t.Fatalf("no domain_warning expected on success, got %v", resp["domain_warning"])
+	}
+	if len(dom.created) != 1 || dom.created[0].Name != "shop.example.com" {
+		t.Fatalf("expected one domain created for shop.example.com, got %+v", dom.created)
+	}
+	if dom.created[0].UserID != resp["user_id"] {
+		t.Fatalf("domain owner %q != created user %v", dom.created[0].UserID, resp["user_id"])
+	}
+}
+
+// domain create failing AFTER the account exists → 201 + domain_warning, no rollback.
+func TestAutomationUserCreate_Domain_PostCreateFailureWarns(t *testing.T) {
+	users := newAbUsers()
+	dom := newDCDomains()
+	dom.createErr = repository.ErrConflict // e.g. insert race
+	cfg := billingCfgDom(users, dom)
+	body := `{"email":"a@example.com","password":"longenough1","username":"buyer","domain":"shop.example.com"}`
+	tok := billingTok("write:users", "write:domains")
+	r := abRouterWithBody(cfg, tok, body)
+	w := abReq(r, http.MethodPost, "/users", body, tok)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("want 201 (account still created), got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeBody(t, w)
+	if resp["status"] != "created" || resp["user_id"] == "" {
+		t.Fatalf("account must still be created, got %v", resp)
+	}
+	if resp["domain_id"] != nil {
+		t.Fatalf("no domain_id expected on domain failure, got %v", resp["domain_id"])
+	}
+	if warn, _ := resp["domain_warning"].(string); warn == "" {
+		t.Fatalf("expected a domain_warning on post-create failure, got %v", resp)
+	}
+	if len(users.created) != 1 {
+		t.Fatalf("account must exist despite the domain failure, got %d", len(users.created))
+	}
+}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -1,0 +1,240 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// domain_create_op.go — JAB-233. The domain-creation orchestration extracted
+// from domainHandler.create so a second caller (the billing automation
+// userCreateHandler) can create a primary domain with the EXACT same GUI
+// semantics. Zero-behavior-change: domainHandler.create is now a thin wrapper
+// that binds+normalizes the request and maps createDomainError back to the
+// same HTTP status/error/detail it emitted inline before.
+//
+// It stays in the api package (not a standalone domainops package) because it
+// depends on a cluster of api-package helpers — validateDomainName,
+// validateDocumentRoot, EnableDomainEmailInline, and the domainHandler methods
+// findCoveringSharedCert / previewSlugConflict — and the only new caller
+// (automation) also lives in this package. Reuse, not packaging, was the goal.
+
+// createDomainInput is the pre-normalized, pre-validated-shape input to
+// createDomainOp. Name MUST already be normalized (normalizeDomainName) and
+// HTML-stripped by the caller — the op validates it but does not re-normalize,
+// matching the create() source of truth.
+type createDomainInput struct {
+	OwnerID         string
+	Name            string
+	DocRoot         string // "" → derived under /home/<user>/domains/<name>/public_html
+	MailProvider    string // "" → jabali
+	M365Onmicrosoft string
+	GoogleDKIM      string
+	SSLMode         string // "" → le
+	CreateWWW       bool
+	TempURLEnabled  bool
+	// SkipInlineSSL omits the 30s inline ACME/self-signed attempt (JAB-233):
+	// the automation path lets the first reconciler tick bootstrap the cert,
+	// exactly like the `jabali domain create` CLI. GUI create leaves it false.
+	SkipInlineSSL bool
+}
+
+// createDomainError carries the exact HTTP shape the inline create() used, so
+// the extraction is byte-identical on the wire. Detail is optional.
+type createDomainError struct {
+	Status int
+	Code   string
+	Detail string
+}
+
+func (e *createDomainError) Error() string { return e.Code }
+
+// createDomainOp runs the full GUI domain-creation orchestration for `in`
+// against the handler's deps. On success it returns the created domain (with
+// any in-place mutations from shared-cert attach / inline email). On failure it
+// returns a createDomainError the caller renders verbatim.
+func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput) (*models.Domain, *createDomainError) {
+	// SECURITY: validate domain name (XSS / path traversal). Name is assumed
+	// already normalized + HTML-stripped by the caller.
+	if err := validateDomainName(in.Name); err != nil {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_domain_name", err.Error()}
+	}
+
+	if in.OwnerID == "" {
+		return nil, &createDomainError{http.StatusBadRequest, "user_id is required", ""}
+	}
+
+	user, err := h.cfg.Users.FindByID(ctx, in.OwnerID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, &createDomainError{http.StatusBadRequest, "user not found", ""}
+		}
+		return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
+	}
+
+	// Admins are panel-only — no /home/<name>, so domains can't host under them.
+	if user.IsAdmin {
+		return nil, &createDomainError{http.StatusBadRequest, "admin_cannot_host", "admin users are panel-only — create a regular user to host domains"}
+	}
+
+	// Suspended users can't acquire new domains — a fresh vhost would be live
+	// while the account stays locked, defeating the suspend cascade.
+	if user.Suspended {
+		return nil, &createDomainError{http.StatusConflict, "user_suspended", "user is suspended — unsuspend before adding domains"}
+	}
+
+	if user.Username == nil || *user.Username == "" {
+		return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
+	}
+
+	// Quota check.
+	if user.PackageID != nil && *user.PackageID != "" {
+		count, err := h.cfg.Domains.CountByUserID(ctx, in.OwnerID)
+		if err != nil {
+			return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
+		}
+		pkg, err := h.cfg.Packages.FindByID(ctx, *user.PackageID)
+		if err == nil && pkg.MaxDomains > 0 && count >= int64(pkg.MaxDomains) {
+			return nil, &createDomainError{http.StatusConflict, "domain_quota_exceeded", ""}
+		}
+	}
+
+	// SECURITY: validate custom document root path.
+	if err := validateDocumentRoot(in.DocRoot, *user.Username, in.Name); err != nil {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_document_root", err.Error()}
+	}
+
+	docRoot := in.DocRoot
+	if docRoot == "" {
+		docRoot = "/home/" + *user.Username + "/domains/" + in.Name + "/public_html"
+	}
+
+	// GH#181 mail provider: default jabali; EmailEnabled/SkipAutoSAN derived.
+	mailProvider := in.MailProvider
+	if mailProvider == "" {
+		mailProvider = models.MailProviderJabali
+	}
+	if !models.ValidMailProvider(mailProvider) {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_mail_provider", ""}
+	}
+	m365Tenant, err := dnscompile.NormaliseM365Onmicrosoft(in.M365Onmicrosoft)
+	if err != nil {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_m365_onmicrosoft", err.Error()}
+	}
+	googleDKIM, err := dnscompile.ValidateGoogleDKIM(in.GoogleDKIM)
+	if err != nil {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_google_dkim", err.Error()}
+	}
+	sslMode := in.SSLMode
+	if sslMode == "" {
+		sslMode = models.SSLModeLE
+	}
+	if !models.ValidSSLMode(sslMode) {
+		return nil, &createDomainError{http.StatusBadRequest, "invalid_ssl_mode", ""}
+	}
+	if sslMode == models.SSLModeCustom {
+		return nil, &createDomainError{http.StatusBadRequest, "ssl_mode_custom_requires_upload", "create the domain with le/self/none, then upload a custom cert via the SSL settings"}
+	}
+	if sslMode == models.SSLModeShared {
+		return nil, &createDomainError{http.StatusBadRequest, "ssl_mode_shared_requires_attach", "create the domain with le/self/none, then attach a shared cert via POST /domains/:id/ssl/shared"}
+	}
+
+	mailEnabled, mailSkipSAN := models.DeriveMailFlags(mailProvider)
+	// Email-enabled + no TLS is contradictory (MTA-STS / autoconfig need HTTPS).
+	if sslMode == models.SSLModeNone && mailEnabled {
+		return nil, &createDomainError{http.StatusBadRequest, "ssl_none_with_email", "a mail-enabled domain needs TLS; choose le/self or set mail provider to none"}
+	}
+
+	now := time.Now().UTC()
+	domain := &models.Domain{
+		ID:              ids.NewULID(),
+		UserID:          in.OwnerID,
+		Name:            in.Name,
+		DocRoot:         docRoot,
+		IsEnabled:       true,
+		SSLMode:         sslMode,
+		SSLEnabled:      models.SSLEnabledForMode(sslMode),
+		MailProvider:    mailProvider,
+		M365Onmicrosoft: strPtrOrNil(m365Tenant),
+		GoogleDKIM:      strPtrOrNil(googleDKIM),
+		EmailEnabled:    mailEnabled,
+		SkipAutoSAN:     mailSkipSAN,
+		CreateWWW:       in.CreateWWW,
+		TempURLEnabled:  in.TempURLEnabled,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	// Preview-slug collision (dots→dashes is not injective): refuse the second
+	// enable of a colliding pair — first-wins would silently serve the wrong site.
+	if domain.TempURLEnabled {
+		if other := h.previewSlugConflict(ctx, domain.Name, ""); other != "" {
+			return nil, &createDomainError{http.StatusConflict, "temp_url_slug_conflict", "preview URL would collide with " + other}
+		}
+	}
+
+	if err := h.cfg.Domains.Create(ctx, domain); err != nil {
+		if isConflict(err) {
+			return nil, &createDomainError{http.StatusConflict, "domain_already_exists", ""}
+		}
+		return nil, &createDomainError{http.StatusInternalServerError, "internal", ""}
+	}
+
+	// JAB-170 phase 5: auto-attach a covering shared cert (HTTPS instantly, no
+	// ACME) and skip the inline ACME below.
+	attachedShared := false
+	if h.cfg.SharedCerts != nil {
+		if cert := h.findCoveringSharedCert(ctx, domain.Name, domain.UserID); cert != nil {
+			if err := h.cfg.Domains.SetSharedCertificate(ctx, domain.ID, &cert.ID, models.SSLModeShared); err == nil {
+				domain.SSLMode = models.SSLModeShared
+				domain.SharedCertificateID = &cert.ID
+				attachedShared = true
+				if h.cfg.Reconciler != nil {
+					h.cfg.Reconciler.Schedule(domain.ID)
+				}
+			}
+		}
+	}
+
+	// Inline SSL (30s): ACME with self-signed fallback. Never errors — cert
+	// state is already in DB. JAB-233: automation skips this (SkipInlineSSL);
+	// the first reconciler tick bootstraps the cert instead.
+	if !attachedShared && !in.SkipInlineSSL && h.cfg.Reconciler != nil {
+		inlineCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		h.cfg.Reconciler.ReconcileSSLInline(inlineCtx, domain)
+		cancel()
+	}
+
+	// Auto-enable email (best-effort, ADR-0013). A failure degrades to
+	// email_enabled=0 + the UI retry switch; not returned in the response.
+	if mailProvider == models.MailProviderJabali && h.cfg.Agent != nil && h.cfg.DNSZones != nil && h.cfg.DNSRecords != nil {
+		if _, _, warnings, err := EnableDomainEmailInline(ctx, enableDomainEmailDeps{
+			Agent:          h.cfg.Agent,
+			Domains:        h.cfg.Domains,
+			DNSZones:       h.cfg.DNSZones,
+			DNSRecords:     h.cfg.DNSRecords,
+			ServerSettings: h.cfg.ServerSettings,
+			SSLCerts:       h.cfg.SSLCerts,
+			SSLReconciler:  h.cfg.Reconciler,
+		}, domain); err != nil {
+			slog.Warn("auto-enable email failed during domain.create (operator can retry from UI)",
+				"domain_id", domain.ID, "domain", domain.Name, "err", err)
+		} else if len(warnings) > 0 {
+			slog.Info("auto-enable email DNS autoconfig warnings",
+				"domain_id", domain.ID, "domain", domain.Name, "warnings", warnings)
+		}
+	}
+
+	// Schedule reconciliation — converges OS-level state (vhost, PHP pool, …)
+	// with DB state. Non-blocking, out-of-band.
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(domain.ID)
+	}
+
+	return domain, nil
+}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -644,259 +643,49 @@ func (h *domainHandler) create(c *gin.Context) {
 		return
 	}
 
-	// GH #884: normalize the domain to lowercase (and trim edge whitespace)
-	// before anything consumes it. DNS is case-insensitive, but the name is
-	// used verbatim for the docroot path, cert lineage, DNS zone, and vhost
-	// server_name — so a mobile keyboard's autocorrected "MyDomain.com" was
-	// accepted and then produced a site that didn't resolve. Normalizing
-	// here (the create source of truth) fixes every downstream consumer at
-	// once; validateDomainName still enforces RFC shape on the result.
+	// GH #884: normalize (lowercase + trim) before anything consumes the name.
 	req.Name = normalizeDomainName(req.Name)
 
-	// SECURITY: Validate domain name to prevent XSS and path traversal
+	// SECURITY: validate the name (XSS / path traversal) BEFORE the HTML strip
+	// so a name carrying tags is rejected rather than silently sanitized. The
+	// op re-validates the stripped name (defense + for the automation caller),
+	// a no-op here.
 	if err := validateDomainName(req.Name); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "invalid_domain_name",
-			"detail": err.Error(),
-		})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_domain_name", "detail": err.Error()})
 		return
 	}
-
-	// Sanitize domain name by removing any potential HTML tags
 	req.Name = htmlTagRe.ReplaceAllString(req.Name, "")
 
 	targetUserID := req.UserID
 	if !claims.IsAdmin {
 		targetUserID = claims.UserID
 	}
-	if targetUserID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
-		return
-	}
 
-	ctx := c.Request.Context()
-
-	user, err := h.cfg.Users.FindByID(ctx, targetUserID)
-	if err != nil {
-		if isNotFound(err) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	// Admins are panel-only — they have no /home/<name>, so domains
-	// can't be hosted under them. Bad request, not authz failure.
-	if user.IsAdmin {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "admin_cannot_host",
-			"detail": "admin users are panel-only — create a regular user to host domains",
-		})
-		return
-	}
-
-	// Suspended users can't acquire new domains — a fresh vhost would
-	// be live + reachable while the panel/SFTP/login stays locked,
-	// defeating the suspend cascade. Operator must unsuspend first.
-	if user.Suspended {
-		c.JSON(http.StatusConflict, gin.H{
-			"error":  "user_suspended",
-			"detail": "user is suspended — unsuspend before adding domains",
-		})
-		return
-	}
-
-	// Username should always be set for non-admin users.
-	if user.Username == nil || *user.Username == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-		return
-	}
-
-	// Quota check.
-	if user.PackageID != nil && *user.PackageID != "" {
-		count, err := h.cfg.Domains.CountByUserID(ctx, targetUserID)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-			return
-		}
-		pkg, err := h.cfg.Packages.FindByID(ctx, *user.PackageID)
-		if err == nil && pkg.MaxDomains > 0 && count >= int64(pkg.MaxDomains) {
-			c.JSON(http.StatusConflict, gin.H{"error": "domain_quota_exceeded"})
-			return
-		}
-	}
-
-	// SECURITY: Validate custom document root path
-	if err := validateDocumentRoot(req.DocRoot, *user.Username, req.Name); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":  "invalid_document_root",
-			"detail": err.Error(),
-		})
-		return
-	}
-
-	docRoot := req.DocRoot
-	if docRoot == "" {
-		// Per-domain subtree under /home/<user>/domains/<name>/ so sibling
-		// paths like logs/, ssl/, backups/ can live alongside public_html
-		// without polluting the user's home.
-		// SECURITY: Domain name is now validated, safe to use in path construction
-		docRoot = "/home/" + *user.Username + "/domains/" + req.Name + "/public_html"
-	}
-
-	// GH#181 mail provider: default jabali; validate + normalise tokens;
-	// EmailEnabled/SkipAutoSAN are DERIVED (never client-set directly).
-	mailProvider := req.MailProvider
-	if mailProvider == "" {
-		mailProvider = models.MailProviderJabali
-	}
-	if !models.ValidMailProvider(mailProvider) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_mail_provider"})
-		return
-	}
-	m365Tenant, err := dnscompile.NormaliseM365Onmicrosoft(req.M365Onmicrosoft)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_m365_onmicrosoft", "detail": err.Error()})
-		return
-	}
-	googleDKIM, err := dnscompile.ValidateGoogleDKIM(req.GoogleDKIM)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_google_dkim", "detail": err.Error()})
-		return
-	}
-	sslMode := req.SSLMode
-	if sslMode == "" {
-		sslMode = models.SSLModeLE
-	}
-	if !models.ValidSSLMode(sslMode) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_ssl_mode"})
-		return
-	}
-	if sslMode == models.SSLModeCustom {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ssl_mode_custom_requires_upload", "detail": "create the domain with le/self/none, then upload a custom cert via the SSL settings"})
-		return
-	}
-	if sslMode == models.SSLModeShared {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ssl_mode_shared_requires_attach", "detail": "create the domain with le/self/none, then attach a shared cert via POST /domains/:id/ssl/shared"})
-		return
-	}
-
-	mailEnabled, mailSkipSAN := models.DeriveMailFlags(mailProvider)
-	// Email-enabled + no TLS is contradictory (MTA-STS / autoconfig need HTTPS).
-	if sslMode == models.SSLModeNone && mailEnabled {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "ssl_none_with_email", "detail": "a mail-enabled domain needs TLS; choose le/self or set mail provider to none"})
-		return
-	}
-
-	now := time.Now().UTC()
-	domain := &models.Domain{
-		ID:         ids.NewULID(),
-		UserID:     targetUserID,
-		Name:       req.Name,
-		DocRoot:    docRoot,
-		IsEnabled:  true,
-		SSLMode:    sslMode,
-		SSLEnabled: models.SSLEnabledForMode(sslMode),
-		// ADR-0080: email on by default for new domains. Set explicitly
-		// rather than relying on the DB default so GORM emits
-		// email_enabled=1 in the INSERT (a Go zero-value bool would be
-		// elided, the DB default would still kick in, but explicit is
-		// clearer and unit-test fixtures that bypass DB defaults stay
-		// correct). Admin can opt-out per-domain via the existing
-		// disable endpoint.
-		MailProvider:    mailProvider,
-		M365Onmicrosoft: strPtrOrNil(m365Tenant),
-		GoogleDKIM:      strPtrOrNil(googleDKIM),
-		EmailEnabled:    mailEnabled,
-		SkipAutoSAN:     mailSkipSAN,
+	// JAB-233: the orchestration lives in createDomainOp so the automation
+	// account-create handler can reuse the exact GUI semantics.
+	dom, oerr := createDomainOp(c.Request.Context(), h, createDomainInput{
+		OwnerID:         targetUserID,
+		Name:            req.Name,
+		DocRoot:         req.DocRoot,
+		MailProvider:    req.MailProvider,
+		M365Onmicrosoft: req.M365Onmicrosoft,
+		GoogleDKIM:      req.GoogleDKIM,
+		SSLMode:         req.SSLMode,
 		CreateWWW:       req.CreateWWW,
 		TempURLEnabled:  req.TempURLEnabled,
-		CreatedAt:       now,
-		UpdatedAt:       now,
-	}
-
-	// Preview slugs flatten dots to dashes, which is not injective
-	// (my.site.com and my-site.com both slug to my-site-com). Refuse the
-	// second enable of a colliding pair — first-wins at the nginx layer
-	// would silently serve the wrong site.
-	if domain.TempURLEnabled {
-		if other := h.previewSlugConflict(ctx, domain.Name, ""); other != "" {
-			c.JSON(http.StatusConflict, gin.H{"error": "temp_url_slug_conflict", "detail": "preview URL would collide with " + other})
-			return
+	})
+	if oerr != nil {
+		body := gin.H{"error": oerr.Code}
+		if oerr.Detail != "" {
+			body["detail"] = oerr.Detail
 		}
-	}
-
-	if err := h.cfg.Domains.Create(ctx, domain); err != nil {
-		if isConflict(err) {
-			c.JSON(http.StatusConflict, gin.H{"error": "domain_already_exists"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		c.JSON(oerr.Status, body)
 		return
 	}
 
-	// JAB-170 phase 5: if a shared cert (server-wide or the owner's) covers the
-	// new hostname, auto-attach so a matching subdomain gets HTTPS instantly —
-	// no ACME, no upload — and skip the ACME inline below.
-	attachedShared := false
-	if h.cfg.SharedCerts != nil {
-		if cert := h.findCoveringSharedCert(ctx, domain.Name, domain.UserID); cert != nil {
-			if err := h.cfg.Domains.SetSharedCertificate(ctx, domain.ID, &cert.ID, models.SSLModeShared); err == nil {
-				domain.SSLMode = models.SSLModeShared
-				domain.SharedCertificateID = &cert.ID
-				attachedShared = true
-				if h.cfg.Reconciler != nil {
-					h.cfg.Reconciler.Schedule(domain.ID)
-				}
-			}
-		}
-	}
-
-	// Attempt SSL inline (30s timeout): try ACME first with fallback to self-signed.
-	// Never errors out — just logs; cert state is already in DB.
-	if !attachedShared && h.cfg.Reconciler != nil {
-		inlineCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		h.cfg.Reconciler.ReconcileSSLInline(inlineCtx, domain)
-		cancel()
-	}
-
-	// Auto-enable email. Best-effort per ADR-0013: a failure here (agent
-	// down, Stalwart refuses the name, DNS sync hiccup) degrades back to
-	// the pre-auto-enable model — email_enabled stays 0 and the operator
-	// sees the UI's "Enable email" retry switch on the domain's Email
-	// tab. DNS-autoconfig warnings aren't returned in the create
-	// response (that would change the wire shape); they're surfaced to
-	// the operator on the next GET /domains/:id/email poll, which
-	// computes live DNS status anyway. Hard errors go to slog.
-	if mailProvider == models.MailProviderJabali && h.cfg.Agent != nil && h.cfg.DNSZones != nil && h.cfg.DNSRecords != nil {
-		if _, _, warnings, err := EnableDomainEmailInline(ctx, enableDomainEmailDeps{
-			Agent:          h.cfg.Agent,
-			Domains:        h.cfg.Domains,
-			DNSZones:       h.cfg.DNSZones,
-			DNSRecords:     h.cfg.DNSRecords,
-			ServerSettings: h.cfg.ServerSettings,
-			SSLCerts:       h.cfg.SSLCerts,
-			SSLReconciler:  h.cfg.Reconciler,
-		}, domain); err != nil {
-			slog.Warn("auto-enable email failed during domain.create (operator can retry from UI)",
-				"domain_id", domain.ID, "domain", domain.Name, "err", err)
-		} else if len(warnings) > 0 {
-			slog.Info("auto-enable email DNS autoconfig warnings",
-				"domain_id", domain.ID, "domain", domain.Name, "warnings", warnings)
-		}
-	}
-
-	// Schedule reconciliation. The reconciler will converge the domain's
-	// OS-level state (nginx vhost, PHP pool, etc.) with the DB state.
-	// This is non-blocking and out-of-band.
-	if h.cfg.Reconciler != nil {
-		h.cfg.Reconciler.Schedule(domain.ID)
-	}
-
-	// EnableDomainEmailInline mutated domain in place on success so the
-	// response already carries email_enabled=true, dkim_selector, etc.
-	c.JSON(http.StatusCreated, domain)
+	// EnableDomainEmailInline mutated domain in place on success so the response
+	// already carries email_enabled=true, dkim_selector, etc.
+	c.JSON(http.StatusCreated, dom)
 }
 
 func (h *domainHandler) update(c *gin.Context) {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -25,10 +25,10 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/pyframeworks"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/sso"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/webmailsso"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/webui"
 	panelui "git.jabali-panel.com/shukivaknin/jabali2/panel-ui"
@@ -444,6 +444,23 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				DiskSnapshots:    repository.NewDiskUsageSnapshotRepository(deps.DB),
 				BWDaily:          deps.BWDaily,
 				Log:              deps.Log,
+				// JAB-233: the exact deps the GUI domain handler uses (mirrors
+				// the DomainHandlerConfig below), so account-create with a
+				// `domain` runs createDomainOp with identical semantics.
+				DomainCreate: api.DomainHandlerConfig{
+					Domains:        deps.Domains,
+					Users:          deps.Users,
+					Packages:       deps.Packages,
+					Agent:          deps.Agent,
+					Reconciler:     deps.Reconciler,
+					SSLCerts:       deps.SSLCerts,
+					SharedCerts:    deps.SharedCerts,
+					DNSZones:       deps.DNSZones,
+					DNSRecords:     deps.DNSRecords,
+					ManagedIPs:     deps.ManagedIPs,
+					ServerSettings: deps.ServerSettings,
+					BWDaily:        deps.BWDaily,
+				},
 			})
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #1020 (JAB-190 billing automation). When the billing/automation API creates an account, it now also provisions the customer's primary domain in the same call — the ADR-0164 addendum for a one-call account+domain lifecycle.

- **§4.1** — extract `createDomainOp` from `domainHandler.create` so the HTTP handler and the automation path share one domain-create write path (mirrors the ADR-0164 userops pattern).
- **§4.2** — automation account-create auto-creates the primary domain via that shared op.
- ADR-0164 addendum documenting the behavior.

Rebased cleanly onto main after #1020 (3 commits, no conflicts).

## Test plan

- [x] `go build ./...` + `go vet` clean
- [x] Full `go test ./panel-api/...` — **0 FAIL**
- [x] `automation_domain_create_test.go` + `domain_create_op` tests execute and pass
- [ ] CI green (Go, vitest, E2E)

GH: JAB-233. Builds on #1020.