### PR TITLE
fix(ui): lead with Adminer for Postgres in the database actions menu (GH #1005 item 2)

### DIFF
--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -259,26 +259,34 @@ export const UserDatabaseList = () => {
               const isLoading = loadingPhpMyAdminId === r.id;
               const isAdminerLoading = loadingAdminerId === r.id;
 
+              const pmaAction = {
+                key: "pma",
+                label: "Open in phpMyAdmin",
+                icon: <LinkOutlined />,
+                onClick: () => handleOpenPhpMyAdmin(r),
+                disabled: isPostgres || isLoading,
+                loading: isLoading,
+                tooltip: isPostgres ? "phpMyAdmin supports MySQL/MariaDB only" : undefined,
+              };
+              const adminerAction = {
+                key: "adminer",
+                label: "Open in Adminer",
+                icon: <LinkOutlined />,
+                onClick: () => handleOpenAdminer(r),
+                disabled: isAdminerLoading,
+                loading: isAdminerLoading,
+              };
+              // Adminer is the native admin tool for Postgres (phpMyAdmin
+              // is MariaDB-only and shows disabled), so lead with it there;
+              // MariaDB keeps phpMyAdmin first. (GH #1005)
+              const dbTools = isPostgres
+                ? [adminerAction, pmaAction]
+                : [pmaAction, adminerAction];
+
               return (
                 <RowActions
                   actions={[
-                    {
-                      key: "pma",
-                      label: "Open in phpMyAdmin",
-                      icon: <LinkOutlined />,
-                      onClick: () => handleOpenPhpMyAdmin(r),
-                      disabled: isPostgres || isLoading,
-                      loading: isLoading,
-                      tooltip: isPostgres ? "phpMyAdmin supports MySQL/MariaDB only" : undefined,
-                    },
-                    {
-                      key: "adminer",
-                      label: "Open in Adminer",
-                      icon: <LinkOutlined />,
-                      onClick: () => handleOpenAdminer(r),
-                      disabled: isAdminerLoading,
-                      loading: isAdminerLoading,
-                    },
+                    ...dbTools,
                     {
                       key: "delete",
                       label: "Delete",


### PR DESCRIPTION
## Problem (GH #1005, item 2)

For a **Postgres** database the row-actions menu listed **phpMyAdmin first** — even though phpMyAdmin is MariaDB-only and renders disabled for Postgres — with **Adminer** (which does support Postgres) second. The reporter asked that Adminer be the primary/first action for Postgres.

## Fix

`UserDatabaseList.tsx` — order the two admin-tool actions by engine:

- **Postgres:** Adminer first, phpMyAdmin second (still disabled, with the existing "MySQL/MariaDB only" tooltip).
- **MariaDB:** unchanged — phpMyAdmin first, Adminer second.
- **Delete** stays last for both.

Labels, click handlers, loading state and SSO wiring are all unchanged — only the array order differs for Postgres rows.

## Verification

- `tsc -b` green.
- No DOM role / label / text change → existing E2E selectors and CI's Playwright job are unaffected.

## Scope

This is **item 2 only** of #1005. Item 1 (the `0 B` size) already shipped in #1012. Items 3 (pgAdmin catalog app + "Open with pgAdmin" link) and 4 (host/server-level Docker installs) are larger feature work tracked separately on the issue.

GH #1005
