### PR TITLE
fix(ui): route tenant-shell toasts through the themed feedback bridge (GH #970)

### DIFF
--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -4,7 +4,8 @@
 // scoped via /me/backups (auth-gated to caller's user_id).
 import { useTranslation } from "react-i18next";
 import { downloadUrl } from "../../utils/download";
-import { Button, Card, Grid, Input, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Button, Card, Grid, Input, Select, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { getActAs } from "../../impersonation";
 import { shortDateTime } from "../../utils/datetime";
 import { backupTypeColor, backupTypeLabel } from "../../utils/backupType";
@@ -93,11 +94,11 @@ export const MyProfileBackupCard = () => {
     setSavingExcl(true);
     try {
       await apiClient.put("/me/backups/exclusions", { patterns: exclusions });
-      message.success("Backup exclusions saved");
+      feedback.message.success("Backup exclusions saved");
       setExclDirty(false);
       exclQuery.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setSavingExcl(false);
     }
@@ -107,10 +108,10 @@ export const MyProfileBackupCard = () => {
     setSubmitting(true);
     try {
       await apiClient.post("/me/backups", { content, compression, destination_id: destinationId });
-      message.success("Backup queued");
+      feedback.message.success("Backup queued");
       query.refetch();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Create failed");
+      feedback.message.error(err instanceof Error ? err.message : "Create failed");
     } finally {
       setSubmitting(false);
     }
@@ -119,10 +120,10 @@ export const MyProfileBackupCard = () => {
   const handleDelete = async (id: string) => {
     try {
       await apiClient.delete(`/me/backups/${id}`);
-      message.success("Backup deleted");
+      feedback.message.success("Backup deleted");
       query.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Delete failed"));
+      feedback.message.error(extractApiError(err, "Delete failed"));
     }
   };
 

--- a/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileScheduleCard.tsx
@@ -5,7 +5,8 @@
 // card, a schedule needs a real destination row — the implicit "local default"
 // is skipped by the scheduler fan-out — so only concrete destinations are offered.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Card, InputNumber, Select, Space, Switch, Typography, message } from "antd";
+import { Alert, Button, Card, InputNumber, Select, Space, Switch, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { ClockCircleOutlined } from "@icons";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -70,10 +71,10 @@ export const MyProfileScheduleCard = () => {
         destination_id: destinationId,
         keep_daily: keepDaily,
       });
-      message.success("Schedule saved");
+      feedback.message.success("Schedule saved");
       schedQuery.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/user/databases/UserDatabaseDrawer.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseDrawer.tsx
@@ -2,7 +2,8 @@
 // /jabali-panel/databases/create page route). Backend prepends the
 // caller's username to the final database name.
 import { useTranslation } from "react-i18next";
-import { Button, Drawer, Form, Grid, Input, Segmented, Space, message } from "antd";
+import { Button, Drawer, Form, Grid, Input, Segmented, Space } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
@@ -43,10 +44,10 @@ export const UserDatabaseDrawer = ({ open, onClose }: UserDatabaseDrawerProps) =
   const handleFinish = async (values: UserDatabaseCreateInput) => {
     try {
       await createMutation.mutateAsync(values);
-      message.success("Database created");
+      feedback.message.success("Database created");
       onClose();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Failed to create database");
+      feedback.message.error(err instanceof Error ? err.message : "Failed to create database");
     }
   };
 

--- a/panel-ui/src/shells/user/domains/DomainDocRootModal.tsx
+++ b/panel-ui/src/shells/user/domains/DomainDocRootModal.tsx
@@ -4,7 +4,8 @@
 // entrypoint is a subdir (e.g. Laravel's public/). Surfaced only when the admin
 // has enabled tenant domain options; the backend re-validates regardless.
 import { useState } from "react";
-import { Modal, Form, Input, Typography, message } from "antd";
+import { Modal, Form, Input, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -35,13 +36,13 @@ export function DomainDocRootModal({ domainId, domainName, currentDocRoot, onClo
       await apiClient.patch(`/domains/${domainId}`, { doc_root: docRoot });
     },
     onSuccess: () => {
-      message.success("Document root updated");
+      feedback.message.success("Document root updated");
       void qc.invalidateQueries({ queryKey: ["list", "domains"] });
       onClose();
     },
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      message.error(detail?.detail ?? detail?.error ?? "Failed to update document root");
+      feedback.message.error(detail?.detail ?? detail?.error ?? "Failed to update document root");
     },
   });
 

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,7 +1,8 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space, message } from "antd";
+import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
 import { useCreateMutation } from "../../../hooks/useQueries";
@@ -40,10 +41,10 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
   const handleFinish = async (values: UserDomainCreateInput) => {
     try {
       await createMutation.mutateAsync(values);
-      message.success("Domain added");
+      feedback.message.success("Domain added");
       onClose();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Failed to add domain");
+      feedback.message.error(err instanceof Error ? err.message : "Failed to add domain");
     }
   };
 

--- a/panel-ui/src/shells/user/logs/UserLogsPage.tsx
+++ b/panel-ui/src/shells/user/logs/UserLogsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
-import { Card, Typography, Button, Space, Table, Tabs, message } from "antd";
+import { Card, Typography, Button, Space, Table, Tabs } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   ReloadOutlined,
   FileTextOutlined,
@@ -71,7 +72,7 @@ export const UserLogsPage = () => {
           ? // @ts-expect-error axios error shape
             error.response?.data?.error
           : undefined;
-      message.error(msg || "Failed to create log stream");
+      feedback.message.error(msg || "Failed to create log stream");
     }
   };
 

--- a/panel-ui/src/shells/user/mail/tabs/MailLogDetailDrawer.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailLogDetailDrawer.tsx
@@ -8,7 +8,8 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
-import { Drawer, Empty, Spin, Timeline, Typography, message } from "antd";
+import { Drawer, Empty, Spin, Timeline, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../../apiClient";
 
@@ -52,7 +53,7 @@ export const MailLogDetailDrawer = ({ queueId, open, onClose }: Props) => {
       .get<DetailResponse>(`/mail/logs/detail?queue_id=${encodeURIComponent(queueId)}`)
       .then((resp) => setData(resp.data))
       .catch((err) =>
-        message.error(err instanceof Error ? err.message : "Could not load trail"),
+        feedback.message.error(err instanceof Error ? err.message : "Could not load trail"),
       )
       .finally(() => setLoading(false));
   }, [open, queueId]);


### PR DESCRIPTION
## Follow-up sweep (GH #970)

The #970 house-style work (#1014) unified toast **position/size/duration** globally via `message.config`, and converted the reporter's named screens. This continues the sweep it promised: routing remaining **static** `message` call sites through the theme-aware `feedback` bridge.

### Why it still matters after #1014

`message.config` fixed placement/size for every call site, but AntD's **static** `message` renders *outside* the React tree — so it still ignores the `ConfigProvider` **theme + direction**. That's the light-background toast on an otherwise dark UI, and wrong side in RTL. Importing the App-scoped `feedback` bridge fixes both.

### This batch — 7 tenant-facing screens

`UserDatabaseDrawer`, `UserDomainDrawer`, `DomainDocRootModal`, `UserLogsPage`, `MailLogDetailDrawer`, `MyProfileBackupCard`, `MyProfileScheduleCard`.

Mechanical, per file: drop the static `message` from the `antd` import, add `import { feedback } from ".../lib/feedback"`, prefix the call sites (`message.success` → `feedback.message.success`). `err.message` is untouched. **No behaviour or copy change** → E2E selectors unaffected.

### Scope

- **`UserDatabaseList.tsx` deliberately excluded** — it's being changed in the open #1005 item-2 PR (#1022); sweeping it here would conflict. It'll fold in after #1022 lands.
- ~40 more static-`message` files remain (mostly admin shells); further batches to come.

### Test

`tsc -b` green; vitest **221 tests** green.

GH #970
