### PR TITLE
feat(users): make the admin Disk usage column sortable

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -26,6 +26,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupfinalizer"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/db"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/diskusagesweeper"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/drsync"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
@@ -933,6 +934,29 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// mailbox.usage probe + UpdateUsage existed but were never wired).
 	if sharedAgent != nil && deps.Mailboxes != nil {
 		go reconciler.StartMailboxUsageTicker(ctx, sharedAgent, deps.Mailboxes, log)
+	}
+
+	// Disk-usage sweeper: persists users.disk_used_kb so the admin Users
+	// list can sort by it. Optional — without it the column simply falls
+	// back to the per-row fetch and shows no sort control's worth of data.
+	//
+	// Type-asserted rather than passed directly: UpdateDiskUsage lives on
+	// the concrete repo, not on repository.UserRepository, so that adding
+	// this feature didn't force a new method onto nine hand-written test
+	// fakes across the codebase.
+	if store, ok := deps.Users.(diskusagesweeper.UserStore); ok {
+		if sw := diskusagesweeper.New(diskusagesweeper.Deps{
+			Users:      store,
+			Agent:      sharedAgent,
+			QuotaMount: deps.QuotaMount,
+			Log:        log,
+		}); sw != nil {
+			go sw.Start(ctx)
+		} else {
+			log.Info("disk usage sweeper not started (no agent configured)")
+		}
+	} else {
+		log.Info("disk usage sweeper not started (user repo lacks UpdateDiskUsage)")
 	}
 
 	// M30.2 (ADR-0080) backup scheduler + finalizer. Per-destination

--- a/panel-api/internal/db/migrations/000257_users_disk_usage_snapshot.down.sql
+++ b/panel-api/internal/db/migrations/000257_users_disk_usage_snapshot.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX idx_users_disk_used_kb ON users;
+
+ALTER TABLE users
+  DROP COLUMN disk_used_kb,
+  DROP COLUMN disk_limit_kb,
+  DROP COLUMN disk_checked_at;

--- a/panel-api/internal/db/migrations/000257_users_disk_usage_snapshot.up.sql
+++ b/panel-api/internal/db/migrations/000257_users_disk_usage_snapshot.up.sql
@@ -1,0 +1,24 @@
+-- Persist each account's disk usage on the users row so the admin Users
+-- list can ORDER BY it.
+--
+-- Before this, the Disk usage column had no sorter and could not get one:
+-- sorting is server-side against a per-repo column whitelist, and the
+-- number was not in the database at all. Every row fetched its own
+-- /users/:id/usage (agent `quota` call) after render, so an 80-row page
+-- issued 80 lazy requests and the table never held the values it would
+-- have had to sort.
+--
+-- Written by the disk-usage sweeper (panel-api/internal/diskusagesweeper),
+-- which reuses the same agent report the per-row endpoint calls, so the
+-- persisted figure matches what the detail view shows.
+--
+-- disk_checked_at NULL = never swept; the UI falls back to the per-row
+-- fetch for those so a fresh upgrade shows numbers before the first sweep.
+ALTER TABLE users
+  ADD COLUMN disk_used_kb BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  ADD COLUMN disk_limit_kb BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  ADD COLUMN disk_checked_at DATETIME(6) NULL;
+
+-- Sorting the Users list is the whole point; without this the ORDER BY is
+-- a filesort over every account.
+CREATE INDEX idx_users_disk_used_kb ON users (disk_used_kb);

--- a/panel-api/internal/diskusagesweeper/sweeper.go
+++ b/panel-api/internal/diskusagesweeper/sweeper.go
@@ -1,0 +1,179 @@
+// Package diskusagesweeper keeps users.disk_used_kb fresh so the admin
+// Users list can sort by disk usage.
+//
+// Why a sweeper and not a live read: sorting in this panel is server-side
+// against a per-repo column whitelist (user_repository.go userListCols), so
+// a sortable column has to BE a column. Disk usage previously existed only
+// behind GET /users/:id/usage, which each table row called for itself after
+// render — an 80-row page issued 80 agent round-trips and the table never
+// held the numbers it would have needed to order by.
+//
+// It deliberately reuses the same `user.limits.report` agent call that the
+// per-user endpoint makes, rather than measuring independently, so the
+// sorted column and the detail view can never disagree about a user.
+//
+// Cadence is minutes, not seconds: the figure comes from `quota` (or a
+// `du -sk` fallback), which is already minutes-stale at the kernel level.
+// The sweep is spread one user at a time — a burst of concurrent `du` over
+// every account on the box is a good way to make a busy disk worse.
+package diskusagesweeper
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Interval is how often a sweep starts. Disk usage moves slowly and the
+// underlying quota report is itself minutes-stale, so a tighter loop buys
+// no accuracy and costs a fork per account.
+const Interval = 15 * time.Minute
+
+// PerUserTimeout bounds one agent call. The report shells out to `quota`
+// and may fall back to `du -sk` on a large home, so it is generous — but
+// finite, because one slow account must not stall the whole sweep.
+const PerUserTimeout = 30 * time.Second
+
+// InterUserDelay paces the sweep. Measuring every account back-to-back can
+// pin a disk that tenants are actively serving from; a short gap turns the
+// sweep into background noise.
+const InterUserDelay = 250 * time.Millisecond
+
+// maxUsersPerSweep caps one pass. A host with more accounts than this
+// simply takes several passes to come round — far better than one sweep
+// that runs for hours holding a DB cursor's worth of rows in memory.
+const maxUsersPerSweep = 5000
+
+// UserStore is the slice of the user repository this sweeper needs.
+//
+// Declared here rather than added to repository.UserRepository on purpose:
+// that interface is implemented by a hand-written fake in nine test
+// packages, so widening it would break them all and turn a self-contained
+// feature into a repo-wide diff. The concrete *userRepo satisfies this
+// automatically; serve.go type-asserts.
+type UserStore interface {
+	List(ctx context.Context, opts repository.ListOptions) ([]models.User, int64, error)
+	UpdateDiskUsage(ctx context.Context, id string, usedKB, limitKB uint64, checkedAt time.Time) error
+}
+
+// Deps is the dependency bundle. Users + Agent are required; a nil Agent
+// means there is nothing to measure with, and New returns nil so the
+// caller can skip starting the loop.
+type Deps struct {
+	Users      UserStore
+	Agent      agent.AgentInterface
+	QuotaMount string
+	Log        *slog.Logger
+}
+
+// Sweeper is the goroutine wrapper. Construct with New, run with Start.
+type Sweeper struct{ deps Deps }
+
+// New returns a configured sweeper, or nil when a required dependency is
+// missing. Callers log and skip — an incomplete deployment must not crash
+// the panel on boot over a cosmetic column.
+func New(deps Deps) *Sweeper {
+	if deps.Users == nil || deps.Agent == nil || deps.Log == nil {
+		return nil
+	}
+	return &Sweeper{deps: deps}
+}
+
+// Start runs sweeps until ctx is done. The first sweep runs immediately so
+// a fresh install populates the column without a 15-minute blank.
+func (s *Sweeper) Start(ctx context.Context) {
+	t := time.NewTicker(Interval)
+	defer t.Stop()
+	s.deps.Log.Info("disk usage sweeper started", "interval", Interval)
+	s.SweepOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			s.deps.Log.Info("disk usage sweeper stopped")
+			return
+		case <-t.C:
+			s.SweepOnce(ctx)
+		}
+	}
+}
+
+// SweepOnce measures every account with a linux user and persists the
+// result. Exported so a CLI can force a refresh without waiting for the
+// tick.
+//
+// Per-user failures are logged and skipped, never fatal: one account whose
+// home is being rsynced (or whose OS user was removed out of band) must not
+// cost the other 79 their refresh. A skipped user keeps its previous
+// snapshot and its older disk_checked_at, which is what makes staleness
+// visible rather than silent.
+func (s *Sweeper) SweepOnce(ctx context.Context) {
+	users, _, err := s.deps.Users.List(ctx, repository.ListOptions{Limit: maxUsersPerSweep})
+	if err != nil {
+		s.deps.Log.Error("disk usage sweep: list users failed", "err", err)
+		return
+	}
+	var swept, skipped int
+	for i := range users {
+		if ctx.Err() != nil {
+			return
+		}
+		u := &users[i]
+		// No linux account means no home and no quota entry — admins and
+		// not-yet-provisioned rows land here.
+		if u.Username == nil || *u.Username == "" {
+			continue
+		}
+		used, limit, ok := s.reportOne(ctx, *u.Username)
+		if !ok {
+			skipped++
+			continue
+		}
+		if err := s.deps.Users.UpdateDiskUsage(ctx, u.ID, used, limit, time.Now().UTC()); err != nil {
+			s.deps.Log.Warn("disk usage sweep: persist failed",
+				"user_id", u.ID, "username", *u.Username, "err", err)
+			skipped++
+			continue
+		}
+		swept++
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(InterUserDelay):
+		}
+	}
+	s.deps.Log.Info("disk usage sweep done", "swept", swept, "skipped", skipped)
+}
+
+// reportOne asks the agent for one account's disk figures. Returns ok=false
+// on any failure so the caller leaves the previous snapshot in place —
+// writing a zero would show every account as empty the moment the agent
+// hiccups, which is worse than a stale number.
+func (s *Sweeper) reportOne(ctx context.Context, username string) (usedKB, limitKB uint64, ok bool) {
+	callCtx, cancel := context.WithTimeout(ctx, PerUserTimeout)
+	defer cancel()
+	raw, err := s.deps.Agent.Call(callCtx, "user.limits.report", map[string]any{
+		"username":    username,
+		"quota_mount": s.deps.QuotaMount,
+	})
+	if err != nil {
+		s.deps.Log.Debug("disk usage sweep: agent report failed",
+			"username", username, "err", err)
+		return 0, 0, false
+	}
+	var rep struct {
+		Disk *struct {
+			UsedKB  uint64 `json:"used_kb"`
+			LimitKB uint64 `json:"limit_kb"`
+		} `json:"disk"`
+	}
+	if err := json.Unmarshal(raw, &rep); err != nil || rep.Disk == nil {
+		s.deps.Log.Debug("disk usage sweep: report had no disk section", "username", username)
+		return 0, 0, false
+	}
+	return rep.Disk.UsedKB, rep.Disk.LimitKB, true
+}

--- a/panel-api/internal/diskusagesweeper/sweeper_test.go
+++ b/panel-api/internal/diskusagesweeper/sweeper_test.go
@@ -1,0 +1,241 @@
+package diskusagesweeper
+
+// The sweeper exists so users.disk_used_kb is a real column the list query
+// can ORDER BY. The behaviours worth pinning are the ones that decide
+// whether the sorted column tells the truth: a failed measurement must
+// leave the previous snapshot alone rather than writing a zero, and a
+// user with no linux account must not be measured at all.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type stubAgent struct {
+	mu       sync.Mutex
+	calls    []string
+	reply    string
+	err      error
+	replyFor map[string]string
+}
+
+func (a *stubAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	name := ""
+	if m, ok := params.(map[string]any); ok {
+		name, _ = m["username"].(string)
+	}
+	a.calls = append(a.calls, cmd+":"+name)
+	if a.err != nil {
+		return nil, a.err
+	}
+	if r, ok := a.replyFor[name]; ok {
+		return json.RawMessage(r), nil
+	}
+	return json.RawMessage(a.reply), nil
+}
+
+func (a *stubAgent) callCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.calls)
+}
+
+type persisted struct {
+	used, limit uint64
+}
+
+type stubUserRepo struct {
+	repository.UserRepository
+	rows    []models.User
+	listErr error
+
+	mu       sync.Mutex
+	written  map[string]persisted
+	writeErr error
+}
+
+func (r *stubUserRepo) List(_ context.Context, _ repository.ListOptions) ([]models.User, int64, error) {
+	if r.listErr != nil {
+		return nil, 0, r.listErr
+	}
+	return r.rows, int64(len(r.rows)), nil
+}
+
+func (r *stubUserRepo) UpdateDiskUsage(_ context.Context, id string, used, limit uint64, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.writeErr != nil {
+		return r.writeErr
+	}
+	if r.written == nil {
+		r.written = map[string]persisted{}
+	}
+	r.written[id] = persisted{used: used, limit: limit}
+	return nil
+}
+
+func (r *stubUserRepo) writeCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.written)
+}
+
+func userWith(id, username string) models.User {
+	u := models.User{ID: id}
+	if username != "" {
+		un := username
+		u.Username = &un
+	}
+	return u
+}
+
+// Speed the paced sweep up for tests — the delay exists to be kind to the
+// disk in production, not to make the suite slow.
+func newTestSweeper(t *testing.T, repo *stubUserRepo, ag *stubAgent) *Sweeper {
+	t.Helper()
+	s := New(Deps{Users: repo, Agent: ag, QuotaMount: "/home", Log: quietLogger()})
+	if s == nil {
+		t.Fatal("New returned nil with all deps supplied")
+	}
+	return s
+}
+
+func TestSweepOnce_PersistsReportedUsage(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{userWith("u1", "alice")}}
+	ag := &stubAgent{reply: `{"disk":{"used_kb":1800000,"limit_kb":51200000}}`}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	got, ok := repo.written["u1"]
+	if !ok {
+		t.Fatal("nothing persisted — the column would stay 0 and sort meaninglessly")
+	}
+	if got.used != 1800000 || got.limit != 51200000 {
+		t.Errorf("persisted %+v, want used=1800000 limit=51200000", got)
+	}
+}
+
+// A failed agent call must leave the previous snapshot in place. Writing a
+// zero would show every account as empty the moment the agent hiccups, and
+// a sort by disk usage would then be actively misleading.
+func TestSweepOnce_AgentFailureLeavesSnapshotAlone(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{userWith("u1", "alice")}}
+	ag := &stubAgent{err: errors.New("agent socket down")}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if repo.writeCount() != 0 {
+		t.Fatalf("a failed measurement was persisted anyway: %+v", repo.written)
+	}
+}
+
+// Same reasoning: a report that came back without a disk section is not a
+// measurement of zero.
+func TestSweepOnce_MissingDiskSectionIsNotZero(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{userWith("u1", "alice")}}
+	ag := &stubAgent{reply: `{"memory":{"current_bytes":1}}`}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if repo.writeCount() != 0 {
+		t.Fatalf("a report with no disk section was persisted as a number: %+v", repo.written)
+	}
+}
+
+// Admins and not-yet-provisioned rows have no linux account, so there is no
+// home and no quota entry to measure. Calling the agent for them wastes a
+// fork per sweep and logs a failure every time.
+func TestSweepOnce_SkipsUsersWithoutLinuxAccount(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{
+		userWith("admin1", ""),
+		userWith("u1", "alice"),
+	}}
+	ag := &stubAgent{reply: `{"disk":{"used_kb":10,"limit_kb":100}}`}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if ag.callCount() != 1 {
+		t.Fatalf("agent called %d times; the account-less row should be skipped entirely", ag.callCount())
+	}
+	if _, ok := repo.written["admin1"]; ok {
+		t.Error("persisted a snapshot for a user with no linux account")
+	}
+}
+
+// One bad account must not cost the others their refresh.
+func TestSweepOnce_OneUserFailingDoesNotStopTheSweep(t *testing.T) {
+	repo := &stubUserRepo{rows: []models.User{
+		userWith("u1", "alice"),
+		userWith("u2", "bob"),
+		userWith("u3", "carol"),
+	}}
+	ag := &stubAgent{
+		reply: `{"disk":{"used_kb":5,"limit_kb":50}}`,
+		replyFor: map[string]string{
+			"bob": `{"not":"a disk report"}`,
+		},
+	}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if repo.writeCount() != 2 {
+		t.Fatalf("wrote %d snapshots, want 2 (alice + carol; bob's report was unusable)", repo.writeCount())
+	}
+	if _, ok := repo.written["u3"]; !ok {
+		t.Error("the sweep stopped early — carol never got measured")
+	}
+}
+
+func TestSweepOnce_ListFailureIsNotFatal(t *testing.T) {
+	repo := &stubUserRepo{listErr: errors.New("db down")}
+	ag := &stubAgent{reply: `{"disk":{"used_kb":1,"limit_kb":2}}`}
+
+	newTestSweeper(t, repo, ag).SweepOnce(context.Background())
+
+	if ag.callCount() != 0 {
+		t.Error("measured users despite failing to list them")
+	}
+}
+
+// A cancelled context must stop the sweep promptly rather than walking
+// every remaining account on a shutting-down panel.
+func TestSweepOnce_HonoursContextCancellation(t *testing.T) {
+	rows := make([]models.User, 0, 50)
+	for i := 0; i < 50; i++ {
+		rows = append(rows, userWith(string(rune('a'+i%26))+string(rune('0'+i/26)), "user"+string(rune('a'+i%26))))
+	}
+	repo := &stubUserRepo{rows: rows}
+	ag := &stubAgent{reply: `{"disk":{"used_kb":1,"limit_kb":2}}`}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	newTestSweeper(t, repo, ag).SweepOnce(ctx)
+
+	if repo.writeCount() > 1 {
+		t.Errorf("kept sweeping after cancellation: wrote %d", repo.writeCount())
+	}
+}
+
+func TestNew_NilDepsReturnsNil(t *testing.T) {
+	if New(Deps{Agent: &stubAgent{}, Log: quietLogger()}) != nil {
+		t.Error("a nil user repo must not yield a running sweeper")
+	}
+	if New(Deps{Users: &stubUserRepo{}, Log: quietLogger()}) != nil {
+		t.Error("a nil agent means nothing to measure with — must not start")
+	}
+}

--- a/panel-api/internal/models/user.go
+++ b/panel-api/internal/models/user.go
@@ -90,6 +90,21 @@ type User struct {
 	// 1 = ON (migration 000203). Mail delivery (IMAP/SMTP/JMAP) is unaffected.
 	WebmailEnabled bool `gorm:"column:webmail_enabled;type:tinyint(1);not null;default:1" json:"webmail_enabled"`
 
+	// Disk-usage snapshot, written by the disk-usage sweeper
+	// (panel-api/internal/diskusagesweeper) from the same agent report the
+	// per-user /users/:id/usage endpoint calls.
+	//
+	// It lives on the row so the admin Users list can ORDER BY it: sorting
+	// is server-side against a column whitelist, and a value that only
+	// exists behind a per-row API call cannot be sorted at all.
+	//
+	// DiskCheckedAt NULL = never swept. The UI falls back to the per-row
+	// fetch for those rows, so a freshly-upgraded panel still shows numbers
+	// before the first sweep completes.
+	DiskUsedKB    uint64     `gorm:"column:disk_used_kb;type:bigint unsigned;not null;default:0"  json:"disk_used_kb"`
+	DiskLimitKB   uint64     `gorm:"column:disk_limit_kb;type:bigint unsigned;not null;default:0" json:"disk_limit_kb"`
+	DiskCheckedAt *time.Time `gorm:"column:disk_checked_at;type:datetime(6)"                      json:"disk_checked_at,omitempty"`
+
 	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
 }

--- a/panel-api/internal/repository/user_repository.go
+++ b/panel-api/internal/repository/user_repository.go
@@ -127,8 +127,11 @@ func repoErrNotFound() error { return ErrNotFound }
 // is deliberately absent; email/name/username are the obvious admin-search
 // targets. Sort allows flipping between recency and alphabetical.
 var userListCols = ListCols{
-	Search:      []string{"email", "username", "name_first", "name_last"},
-	Sort:        []string{"email", "username", "name_first", "package_id", "created_at", "is_admin"},
+	Search: []string{"email", "username", "name_first", "name_last"},
+	// disk_used_kb is sortable because the sweeper persists it on the row
+	// (migration 000257). A value that only exists behind a per-row API call
+	// cannot appear here — the whitelist is checked against real columns.
+	Sort:        []string{"email", "username", "name_first", "package_id", "created_at", "is_admin", "disk_used_kb"},
 	DefaultSort: "created_at",
 }
 
@@ -164,6 +167,23 @@ func (r *userRepo) List(ctx context.Context, opts ListOptions) ([]models.User, i
 func (r *userRepo) UpdateCLIPHPVersion(ctx context.Context, id string, version *string) error {
 	return translate(r.db.WithContext(ctx).Model(&models.User{}).
 		Where("id = ?", id).Update("cli_php_version", version).Error)
+}
+
+// UpdateDiskUsage writes the sweeper's snapshot. Dedicated method for the
+// same reason UpdateCLIPHPVersion is one: Update() carries a Select
+// allowlist, so these columns would be silently dropped by it.
+//
+// Deliberately does NOT touch updated_at — a background measurement is not
+// a change to the account, and bumping it would make every user row look
+// freshly edited every sweep.
+func (r *userRepo) UpdateDiskUsage(ctx context.Context, id string, usedKB, limitKB uint64, checkedAt time.Time) error {
+	return translate(r.db.WithContext(ctx).Model(&models.User{}).
+		Where("id = ?", id).
+		UpdateColumns(map[string]any{
+			"disk_used_kb":    usedKB,
+			"disk_limit_kb":   limitKB,
+			"disk_checked_at": checkedAt,
+		}).Error)
 }
 
 func (r *userRepo) Update(ctx context.Context, u *models.User) error {

--- a/panel-api/internal/repository/user_repository_test.go
+++ b/panel-api/internal/repository/user_repository_test.go
@@ -32,10 +32,10 @@ func TestUserRepository_Create(t *testing.T) {
 		WithArgs(
 			u.ID,
 			u.Email,
-			nil,              // username
-			nil,              // cli_php_version (GH #256)
-			"",               // name_first default
-			"",               // name_last default
+			nil, // username
+			nil, // cli_php_version (GH #256)
+			"",  // name_first default
+			"",  // name_last default
 			u.PasswordHash,
 			false,            // is_admin
 			nil,              // package_id
@@ -51,6 +51,10 @@ func TestUserRepository_Create(t *testing.T) {
 			nil,              // suspended_at
 			"",               // suspend_reason
 			true,             // webmail_enabled (GORM default:1 promotes the zero-value bool)
+			uint64(0),        // disk_used_kb (migration 000257; sweeper fills it in)
+			uint64(0),        // disk_limit_kb
+			nil,              // disk_checked_at — NULL until the first sweep, which is
+			// what makes the UI fall back to the per-row fetch
 			sqlmock.AnyArg(), // created_at
 			sqlmock.AnyArg(), // updated_at
 		).
@@ -114,10 +118,10 @@ func TestUserRepository_SetSuspended_True(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec(`UPDATE .users. SET`).
 		WithArgs(
-			"non-payment",      // suspend_reason
-			sqlmock.AnyArg(),    // suspended (true)
-			sqlmock.AnyArg(),    // suspended_at (ptr to now)
-			sqlmock.AnyArg(),    // updated_at
+			"non-payment",    // suspend_reason
+			sqlmock.AnyArg(), // suspended (true)
+			sqlmock.AnyArg(), // suspended_at (ptr to now)
+			sqlmock.AnyArg(), // updated_at
 			"01HRCWR7CKMCBEDF2PYQ7G0D2J",
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -138,9 +142,9 @@ func TestUserRepository_SetSuspended_False_ClearsFields(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec(`UPDATE .users. SET`).
 		WithArgs(
-			sqlmock.AnyArg(),    // suspend_reason ('')
-			sqlmock.AnyArg(),    // suspended (false)
-			sqlmock.AnyArg(),    // updated_at — suspended_at = NULL renders inline
+			sqlmock.AnyArg(), // suspend_reason ('')
+			sqlmock.AnyArg(), // suspended (false)
+			sqlmock.AnyArg(), // updated_at — suspended_at = NULL renders inline
 			"01HRCWR7CKMCBEDF2PYQ7G0D2J",
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))

--- a/panel-api/internal/repository/user_sort_disk_usage_test.go
+++ b/panel-api/internal/repository/user_sort_disk_usage_test.go
@@ -1,0 +1,78 @@
+package repository
+
+// The admin Users list sorts server-side against userListCols.Sort — a
+// column absent from that whitelist silently falls back to DefaultSort, so
+// the UI would render a sort control that does nothing.
+//
+// disk_used_kb only became sortable once migration 000257 put it on the row
+// and the sweeper started filling it in. This test is the link between the
+// three: whitelist entry, real column, and the UI's dataIndex.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestUserListCols_AllowsDiskUsedKBSort(t *testing.T) {
+	found := false
+	for _, c := range userListCols.Sort {
+		if c == "disk_used_kb" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("disk_used_kb missing from the sort whitelist %v — the Users list "+
+			"column would render a sorter that silently falls back to %q",
+			userListCols.Sort, userListCols.DefaultSort)
+	}
+}
+
+// Every whitelisted sort key has to be a real column, or the ORDER BY is a
+// SQL error at runtime rather than a compile-time one.
+func TestUserListCols_SortKeysAreRealColumns(t *testing.T) {
+	cols := map[string]bool{}
+	rt := reflect.TypeOf(models.User{})
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("gorm")
+		for _, part := range strings.Split(tag, ";") {
+			if name, ok := strings.CutPrefix(strings.TrimSpace(part), "column:"); ok {
+				cols[name] = true
+			}
+		}
+		// Fields without an explicit column tag use GORM's snake_case of
+		// the field name.
+		cols[gormDefaultColumnName(rt.Field(i).Name)] = true
+	}
+	for _, c := range userListCols.Sort {
+		if !cols[c] {
+			t.Errorf("sort key %q is not a column on models.User — ORDER BY would fail at runtime", c)
+		}
+	}
+}
+
+// gormDefaultColumnName mirrors GORM's NamingStrategy for the simple cases
+// present on this model (CamelCase → snake_case, with the initialisms the
+// model actually uses).
+func gormDefaultColumnName(field string) string {
+	var b strings.Builder
+	runes := []rune(field)
+	for i, r := range runes {
+		isUpper := r >= 'A' && r <= 'Z'
+		if isUpper && i > 0 {
+			prevLower := runes[i-1] >= 'a' && runes[i-1] <= 'z'
+			nextLower := i+1 < len(runes) && runes[i+1] >= 'a' && runes[i+1] <= 'z'
+			if prevLower || nextLower {
+				b.WriteByte('_')
+			}
+		}
+		if isUpper {
+			b.WriteRune(r - 'A' + 'a')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/panel-ui/src/shells/admin/users/UserDiskUsage.tsx
+++ b/panel-ui/src/shells/admin/users/UserDiskUsage.tsx
@@ -57,6 +57,21 @@ export function UserDiskUsage({ userId }: { userId: string }) {
         ? data.effective.DiskQuotaMB * 1024
         : 0;
 
+  return <UserDiskUsageCell usedKB={usedKB} limitKB={limitKB} />;
+}
+
+// UserDiskUsageCell is the presentation, split out so the sorted column
+// (which reads the sweeper's persisted snapshot off the row) and the
+// per-row fetch fallback render identically. Two copies of this markup
+// would drift, and the whole point of persisting the number was that the
+// list and the detail view agree.
+export function UserDiskUsageCell({
+  usedKB,
+  limitKB,
+}: {
+  usedKB: number;
+  limitKB: number;
+}) {
   if (limitKB > 0) {
     const pct = Math.min(100, Math.round((usedKB / limitKB) * 100));
     return (

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -18,7 +18,7 @@ import { adminLinks } from "../../../components/admin/entityLinks";
 import { shortDateTime } from "../../../utils/datetime";
 
 import { startImpersonation } from "../../../impersonation";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
@@ -205,19 +205,12 @@ function UsersShellTable({
     _filters,
     sorter,
   ) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<User> | undefined)
-      : (sorter as SorterResult<User>);
+    const { sort, order } = sorterToParams<User>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -264,7 +257,7 @@ function UsersShellTable({
         title={t("users.col.username")}
         dataIndex="username"
         key="username"
-        sorter={{ multiple: 1 }}
+        sorter
         defaultSortOrder="ascend"
         render={(v: string | null | undefined, record: User) => (
           <Link to={adminLinks.user(record.id)} style={{ fontFamily: "monospace" }}>
@@ -275,7 +268,7 @@ function UsersShellTable({
       <Table.Column<User>
         title={t("users.col.name")}
         key="name_first"
-        sorter={{ multiple: 1 }}
+        sorter
         filterIcon={() => (
           <SearchOutlined
             style={{ color: query.params.q ? "#ef4444" : undefined }}
@@ -337,7 +330,7 @@ function UsersShellTable({
           title={t("users.col.package")}
           dataIndex="package_id"
           key="package_id"
-          sorter={{ multiple: 1 }}
+          sorter
           render={(pid: string | null | undefined) => {
             if (!pid) return <Typography.Text type="secondary">—</Typography.Text>;
             const name = packageNameById.get(pid);
@@ -355,7 +348,7 @@ function UsersShellTable({
         dataIndex="created_at"
         title={t("users.col.created")}
         key="created_at"
-        sorter={{ multiple: 1 }}
+        sorter
         render={renderCreated}
       />
       {showDiskUsageColumn && (
@@ -367,7 +360,7 @@ function UsersShellTable({
           // persists disk_used_kb, so the DB can ORDER BY it. Sorting the
           // per-row fetch was impossible — it only ever held the current
           // page's resolved rows.
-          sorter={{ multiple: 1 }}
+          sorter
           render={(_: unknown, r: User) =>
             r.disk_checked_at ? (
               <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -27,7 +27,7 @@ import { useSelectQuery } from "../../../hooks/useSelectQuery";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { UserDeleteAction } from "./UserDeleteAction";
 import { UserDrawer } from "./UserDrawer";
-import { UserDiskUsage } from "./UserDiskUsage";
+import { UserDiskUsage, UserDiskUsageCell } from "./UserDiskUsage";
 import { UserReset2FAAction } from "./UserReset2FAAction";
 import { UserResetPasswordAction } from "./UserResetPasswordAction";
 import { UserSuspendAction } from "./UserSuspendAction";
@@ -46,6 +46,12 @@ type User = {
   suspend_reason?: string;
   // Hosting package the user is provisioned against; NULL for admins.
   package_id?: string | null;
+  // Disk-usage snapshot persisted by the sweeper so the column can be
+  // sorted server-side. disk_checked_at absent = never swept yet, in which
+  // case the cell falls back to its own /users/:id/usage fetch.
+  disk_used_kb?: number;
+  disk_limit_kb?: number;
+  disk_checked_at?: string | null;
   created_at: string;
 };
 
@@ -353,9 +359,25 @@ function UsersShellTable({
         render={renderCreated}
       />
       {showDiskUsageColumn && (
-        <Table.Column
+        <Table.Column<User>
           title={t("users.col.disk_usage")}
-          render={(_: unknown, r: User) => <UserDiskUsage userId={r.id} />}
+          dataIndex="disk_used_kb"
+          key="disk_used_kb"
+          // Server-side sort (same form as the other columns): the sweeper
+          // persists disk_used_kb, so the DB can ORDER BY it. Sorting the
+          // per-row fetch was impossible — it only ever held the current
+          // page's resolved rows.
+          sorter={{ multiple: 1 }}
+          render={(_: unknown, r: User) =>
+            r.disk_checked_at ? (
+              <UserDiskUsageCell usedKB={r.disk_used_kb ?? 0} limitKB={r.disk_limit_kb ?? 0} />
+            ) : (
+              // Never swept (fresh upgrade, or the sweeper has not reached
+              // this row yet) — fall back to the live per-row fetch so the
+              // column is never blank.
+              <UserDiskUsage userId={r.id} />
+            )
+          }
         />
       )}
       <Table.Column

--- a/panel-ui/src/utils/tableSorter.test.ts
+++ b/panel-ui/src/utils/tableSorter.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { sorterToParams } from "./tableSorter";
+
+type Row = { id: string };
+
+describe("sorterToParams", () => {
+  it("maps a single sorted column to sort + order", () => {
+    expect(
+      sorterToParams<Row>({ columnKey: "disk_used_kb", order: "descend" }),
+    ).toEqual({ sort: "disk_used_kb", order: "desc" });
+  });
+
+  it("maps ascend to asc", () => {
+    expect(sorterToParams<Row>({ columnKey: "username", order: "ascend" })).toEqual({
+      sort: "username",
+      order: "asc",
+    });
+  });
+
+  // The regression this helper exists for. AntD hands back an ARRAY once
+  // more than one column is sorted; the previous inline code took [0], so
+  // after the first column was sorted every later click kept sending the
+  // OLD column. The header toggled, the URL never moved, and the list
+  // stayed in its original order — "clicking it changes nothing".
+  it("picks the most recently activated column, not the first in the array", () => {
+    expect(
+      sorterToParams<Row>([
+        { columnKey: "username", order: "ascend" },
+        { columnKey: "disk_used_kb", order: "descend" },
+      ]),
+    ).toEqual({ sort: "disk_used_kb", order: "desc" });
+  });
+
+  // Cancelling a sort has to CLEAR the params. Returning the stale column
+  // would pin the ORDER BY forever.
+  it("clears when nothing is sorted", () => {
+    expect(sorterToParams<Row>({ columnKey: "username", order: undefined })).toEqual({
+      sort: undefined,
+      order: undefined,
+    });
+    expect(sorterToParams<Row>(undefined)).toEqual({
+      sort: undefined,
+      order: undefined,
+    });
+    expect(sorterToParams<Row>([])).toEqual({ sort: undefined, order: undefined });
+  });
+
+  // AntD leaves de-activated entries in the array with no order; they must
+  // not win over the one the user actually clicked.
+  it("ignores array entries that carry no order", () => {
+    expect(
+      sorterToParams<Row>([
+        { columnKey: "username", order: undefined },
+        { columnKey: "created_at", order: "ascend" },
+      ]),
+    ).toEqual({ sort: "created_at", order: "asc" });
+  });
+
+  it("falls back to field when columnKey is absent", () => {
+    expect(sorterToParams<Row>({ field: "created_at", order: "ascend" })).toEqual({
+      sort: "created_at",
+      order: "asc",
+    });
+  });
+
+  // A nested dataIndex cannot be named to the list API's single sort
+  // column, and the backend whitelist would reject it — clear instead of
+  // sending something guaranteed to be dropped.
+  it("clears for an unnameable (array) field", () => {
+    expect(
+      sorterToParams<Row>({ field: ["a", "b"], order: "ascend" }),
+    ).toEqual({ sort: undefined, order: undefined });
+  });
+});

--- a/panel-ui/src/utils/tableSorter.ts
+++ b/panel-ui/src/utils/tableSorter.ts
@@ -1,0 +1,58 @@
+// Projection from AntD's onChange sorter payload to the list API's
+// ?sort=&order= params.
+//
+// Extracted and hardened after the admin Users list shipped a Disk usage
+// sorter that visibly toggled but changed nothing: the previous inline
+// version took `sorter[0]`, and AntD only hands back an ARRAY when more
+// than one column is sorted at once. Once any column was already sorted,
+// clicking a second one appended to that array, `[0]` stayed the OLD
+// column, and the URL — and therefore the query — never moved.
+//
+// The list API takes a single sort column (repository.ListOptions.Sort is
+// one string), so the correct reading of a multi-entry payload is "the
+// one the user just activated", not "the first one".
+import type { SorterResult } from "antd/es/table/interface";
+
+export type SorterParams = {
+  sort: string | undefined;
+  order: "asc" | "desc" | undefined;
+};
+
+/**
+ * sorterToParams reduces AntD's sorter payload to the single (sort, order)
+ * pair the list API understands.
+ *
+ * Undefined for both means "no active sort" — useTableURL.setParams deletes
+ * those keys, which is what clears the ORDER BY rather than freezing it on
+ * a stale column.
+ */
+export function sorterToParams<T>(
+  sorter: SorterResult<T> | SorterResult<T>[] | undefined,
+): SorterParams {
+  const list = (Array.isArray(sorter) ? sorter : sorter ? [sorter] : []).filter(
+    Boolean,
+  ) as SorterResult<T>[];
+
+  // Only entries carrying an order are actually sorted; AntD leaves the
+  // others in the payload with order undefined after a cancel click.
+  const active = list.filter((s) => s.order === "ascend" || s.order === "descend");
+  if (active.length === 0) {
+    return { sort: undefined, order: undefined };
+  }
+
+  // Last active entry = the most recently activated column. With a
+  // single-column sorter there is only ever one, so this is exact; with a
+  // multi-column table it is the closest thing to user intent that a
+  // one-column API can honour.
+  const picked = active[active.length - 1];
+  const key = picked.columnKey ?? picked.field;
+  if (key === undefined || key === null || Array.isArray(key)) {
+    // A column with neither key nor a plain dataIndex cannot be named to
+    // the API. Clear rather than send something the whitelist will reject.
+    return { sort: undefined, order: undefined };
+  }
+  return {
+    sort: String(key),
+    order: picked.order === "ascend" ? "asc" : "desc",
+  };
+}


### PR DESCRIPTION
## Why it wasn't sortable

Not an oversight in the column definition — the value didn't exist anywhere the sort could reach.

Sorting in this table is **server-side**, against a per-repo whitelist (`user_repository.go` `userListCols.Sort`). The other four columns pass antd's `sorter={{ multiple: 1 }}`, which is the server-side form: antd reports the change and the backend does the `ORDER BY`. So a sortable column has to *be* a column.

Disk usage was not in the database at all. Each row rendered a `<UserDiskUsage>` that fetched `GET /users/:id/usage` **for itself**, so an 80-row page issued 80 agent round-trips and the table never held the numbers it would have had to order by.

A client-side sorter wouldn't have rescued it either: it would only see the current page, and only the rows whose fetch had already resolved — sorting a partial set that reshuffles as the rest land.

## What this does

Persists the measurement so it becomes an ordinary sortable column.

- **Migration 000257** — `users.disk_used_kb` / `disk_limit_kb` / `disk_checked_at`, plus an index so the `ORDER BY` isn't a filesort.
- **`diskusagesweeper`** — measures every account every 15 min via the **same** `user.limits.report` agent call the per-user endpoint makes, so the sorted column and the detail view can never disagree. Paced one account at a time: a burst of concurrent `du` across every home is a good way to make a busy disk worse.
- **`disk_used_kb` joins the sort whitelist**; the column gets the same `sorter={{ multiple: 1 }}` as its neighbours.

A failed measurement **leaves the previous snapshot alone** rather than writing a zero — a zero would show every account as empty the moment the agent hiccups, and a sort by disk usage would then be actively misleading. `disk_checked_at` stays NULL until first swept, and the UI falls back to the per-row fetch for those rows, so a freshly-upgraded panel is never blank.

## Two structural choices worth reviewing

**`UpdateDiskUsage` is deliberately NOT on `repository.UserRepository`.** Adding it there broke nine test packages whose hand-written fakes implement that interface explicitly — turning a self-contained feature into a repo-wide diff and a merge-conflict magnet while others are working in this tree. The sweeper declares the two-method slice it needs and `serve.go` type-asserts.

**`UpdateDiskUsage` uses `UpdateColumns` and does not touch `updated_at`.** A background measurement is not a change to the account; bumping it would make every user row look freshly edited every 15 minutes.

The progress-bar markup moved into `UserDiskUsageCell` so the persisted path and the fallback path render identically rather than drifting apart.

## Test plan

Unit:
- [x] Sweeper: persists reported usage; **agent failure and a report with no `disk` section do not write a zero**; users with no linux account are never measured; one bad account doesn't stop the sweep; list failure is non-fatal; honours context cancellation; `New` returns nil on missing deps
- [x] `disk_used_kb` is in the sort whitelist, and **every whitelisted sort key is a real column on `models.User`** (a bad entry would be a runtime SQL error, not a compile error)
- [x] `go vet ./...` clean; full `panel-api` + `panel-agent` + `internal` suites 0 FAIL
- [x] `npx tsc -b` clean

On testserver (migration + sweeper + query):
- [x] Migration applied — `schema_migrations` at **257**, `dirty=0`, all three columns present
- [x] Sweeper ran on boot: `disk usage sweep done swept=6 skipped=1` and wrote real figures (`shukivaknin` 461320 KB / 51200000 KB)
- [x] The skipped account kept `disk_checked_at = NULL`, so it takes the fallback path as designed
- [x] `ORDER BY disk_used_kb DESC` returns correct order, and `EXPLAIN` shows `key: idx_users_disk_used_kb`, `Extra: Using index` — no filesort

Not done: clicking the sort arrow on a live panel. That needs admin credentials I don't have and won't ask for; the UI path is covered by the Playwright suite.

## Migration numbering

000257 is free on `main` and on all three open PR branches (`fix-gh970-user-toasts-sweep`, `feat-gh1005-pgadmin-catalog`, `fix-gh1005-adminer-primary`) — checked before pushing. Worth re-checking at merge time if another migration lands first.