### PR TITLE
feat(redis): per-tenant Redis credentials in tenant settings (GH #1016)

### DIFF
--- a/panel-api/internal/api/applications_cache.go
+++ b/panel-api/internal/api/applications_cache.go
@@ -123,6 +123,10 @@ func revokeAllUserCacheACLs(ctx context.Context, rdb *redis.Client, osUser strin
 		return nil
 	}
 	_ = rdb.Do(ctx, "ACL", "DELUSER", "wp_"+osUser).Err() // legacy shared user
+	// GH #1016: the general per-tenant Redis credential (t_<osUser>) shares this
+	// tenant's OS user, so tear it down on the same delete path — a recycled
+	// username must not inherit the old principal + keyspace.
+	_ = rdb.Do(ctx, "ACL", "DELUSER", tenantRedisACLUser(osUser)).Err()
 	lines, err := rdb.Do(ctx, "ACL", "LIST").StringSlice()
 	if err != nil {
 		return err

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3453,6 +3453,20 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /me/redis-access:
+    get:
+      tags: [Me]
+      summary: Get your Redis access credentials
+      description: |
+        Returns a ready-to-use, scoped Redis credential for the calling
+        tenant (GH #1016): unix socket path, ACL username `t_<osuser>`,
+        password, and the key prefix `jt:<osuser>:` your keys must use. The
+        credential can only read/write keys under that prefix; keyspace-scan
+        and admin commands are denied. Provisioned on first request
+        (idempotent). Redis has no TCP listener — socket only.
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /me/php-cli-version:
     get:
       tags: [Me]
@@ -5219,6 +5233,17 @@ paths:
       responses:
         "201": { description: Created, content: { application/json: { schema: { $ref: "#/components/schemas/User" } } } }
         "422": { description: Validation error, content: { application/json: { schema: { $ref: "#/components/schemas/Error" } } } }
+
+  /users/{id}/redis-access:
+    get:
+      tags: [Users]
+      summary: Get a tenant's Redis access credentials (admin)
+      description: |
+        Admin view of a specific tenant's scoped Redis credential (GH #1016).
+        Same payload as /me/redis-access. Admin only.
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
 
   /users/{id}:
     delete:

--- a/panel-api/internal/api/tenant_redis.go
+++ b/panel-api/internal/api/tenant_redis.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+)
+
+// Tenant Redis access (GH #1016). Jabali locks Redis behind ACL auth (ADR-0148):
+// the `default` no-AUTH user is disabled, so a migrated app that used to connect
+// unauthenticated (`127.0.0.1:6379`, raw keys) now gets `NOAUTH Authentication
+// required` with no obvious way to obtain credentials. This endpoint hands each
+// tenant a scoped, ready-to-use Redis credential.
+//
+// It generalises the per-install WP-cache ACL primitive (applications_cache.go)
+// to a per-TENANT credential:
+//
+//   - user      t_<osuser>
+//   - keyspace  ~jt:<osuser>:*   (namespaced so it can never overlap the panel's
+//               own jabali:* / automation:* keys, nor the WP-cache jc:* keys)
+//   - commands  a curated allowlist of the data-type commands a cache / session /
+//               queue app needs — deliberately WITHOUT the keyspace-level
+//               enumeration/admin commands (KEYS, SCAN, RANDOMKEY, DBSIZE,
+//               FLUSH*, CONFIG, scripting, pub/sub). Those either ignore the
+//               key-pattern fence entirely (Redis does not pattern-scope SCAN /
+//               RANDOMKEY / DBSIZE — Gitea #413) or let one tenant enumerate
+//               another's key names. Per-key scans (HSCAN/SSCAN/ZSCAN) operate
+//               on a single fenced key and ARE safe, so they stay.
+//
+// The password is an HMAC of (global secret, osuser, per-tenant salt) — never
+// stored, recomputed on demand, so "show me my credentials" and "re-apply the
+// ACL" are the same idempotent operation. Rotating one tenant = rotating its
+// salt, no effect on any other tenant.
+//
+// Transport is the unix socket only: jabali Redis has NO TCP listener (port 0,
+// ADR-0059), and every tenant OS user is already in jabali-redis-clients, so the
+// socket is reachable from their PHP-FPM / CLI without any further grant.
+
+// tenantRedisACLUser is the per-tenant Redis ACL username.
+func tenantRedisACLUser(osUser string) string { return "t_" + osUser }
+
+// tenantRedisKeyPattern fences the tenant to its own namespace. The `jt:` prefix
+// (jabali-tenant) guarantees no overlap with jabali:* / automation:* / jc:*,
+// even for an osuser that happened to equal one of those words.
+func tenantRedisKeyPattern(osUser string) string { return "~jt:" + osUser + ":*" }
+
+// tenantRedisKeyPrefix is the string the tenant must set as their client's key
+// prefix so their keys land inside the fence.
+func tenantRedisKeyPrefix(osUser string) string { return "jt:" + osUser + ":" }
+
+// tenantRedisToken derives the per-tenant ACL password. Mirrors
+// cacheInstallToken but with its own domain-separation label so a tenant's
+// general credential and its WP-cache install credential never collide.
+func tenantRedisToken(secret, osUser, salt string) string {
+	m := hmac.New(sha256.New, []byte(secret))
+	m.Write([]byte("tenant-redis:" + osUser + ":" + salt))
+	return hex.EncodeToString(m.Sum(nil))
+}
+
+// tenantRedisCommands is the curated allowlist. Covers strings, hashes, lists,
+// sets, sorted sets, bitmaps, hyperloglog, geo, per-key scans, per-key expiry,
+// transactions, and connection — the commands a caching / session / queue
+// workload needs. It intentionally omits: keyspace-level SCAN/KEYS/RANDOMKEY/
+// DBSIZE (not pattern-scoped → cross-tenant enumeration), FLUSHDB/FLUSHALL/
+// SWAPDB, CONFIG/CLIENT/ACL/CLUSTER/DEBUG/SHUTDOWN/SAVE (admin), EVAL/FUNCTION
+// (scripting), and SUBSCRIBE/PUBLISH (channels are reset). MULTI/EXEC only queue
+// the commands above, which stay individually ACL-checked.
+var tenantRedisCommands = []string{
+	// strings
+	"+GET", "+SET", "+SETEX", "+PSETEX", "+SETNX", "+GETSET", "+GETDEL", "+GETEX",
+	"+APPEND", "+STRLEN", "+GETRANGE", "+SETRANGE", "+MGET", "+MSET", "+MSETNX",
+	"+INCR", "+INCRBY", "+INCRBYFLOAT", "+DECR", "+DECRBY",
+	// generic key ops (all fenced to the tenant's pattern)
+	"+DEL", "+UNLINK", "+EXISTS", "+TYPE", "+EXPIRE", "+PEXPIRE", "+EXPIREAT",
+	"+PEXPIREAT", "+EXPIRETIME", "+PEXPIRETIME", "+TTL", "+PTTL", "+PERSIST",
+	"+RENAME", "+RENAMENX", "+TOUCH", "+DUMP", "+RESTORE", "+OBJECT",
+	// hashes
+	"+HSET", "+HSETNX", "+HGET", "+HMGET", "+HMSET", "+HDEL", "+HGETALL",
+	"+HKEYS", "+HVALS", "+HLEN", "+HEXISTS", "+HINCRBY", "+HINCRBYFLOAT",
+	"+HSTRLEN", "+HRANDFIELD", "+HSCAN",
+	// lists
+	"+LPUSH", "+RPUSH", "+LPUSHX", "+RPUSHX", "+LPOP", "+RPOP", "+LRANGE",
+	"+LLEN", "+LINDEX", "+LSET", "+LREM", "+LTRIM", "+LINSERT", "+RPOPLPUSH",
+	"+LMOVE", "+LPOS",
+	// sets
+	"+SADD", "+SREM", "+SMEMBERS", "+SISMEMBER", "+SMISMEMBER", "+SCARD",
+	"+SPOP", "+SRANDMEMBER", "+SSCAN", "+SUNION", "+SINTER", "+SDIFF",
+	"+SUNIONSTORE", "+SINTERSTORE", "+SDIFFSTORE", "+SMOVE",
+	// sorted sets
+	"+ZADD", "+ZREM", "+ZRANGE", "+ZREVRANGE", "+ZRANGEBYSCORE",
+	"+ZREVRANGEBYSCORE", "+ZRANGEBYLEX", "+ZREVRANGEBYLEX", "+ZCARD", "+ZSCORE",
+	"+ZMSCORE", "+ZRANK", "+ZREVRANK", "+ZINCRBY", "+ZCOUNT", "+ZLEXCOUNT",
+	"+ZPOPMIN", "+ZPOPMAX", "+ZRANDMEMBER", "+ZSCAN", "+ZRANGESTORE",
+	"+ZREMRANGEBYRANK", "+ZREMRANGEBYSCORE", "+ZREMRANGEBYLEX",
+	// bitmaps / hyperloglog / geo (all key-scoped)
+	"+SETBIT", "+GETBIT", "+BITCOUNT", "+BITPOS", "+BITOP", "+BITFIELD",
+	"+PFADD", "+PFCOUNT", "+PFMERGE",
+	"+GEOADD", "+GEOPOS", "+GEODIST", "+GEOSEARCH", "+GEOSEARCHSTORE",
+	// transactions (only queue the above)
+	"+MULTI", "+EXEC", "+DISCARD", "+WATCH", "+UNWATCH",
+	// connection / handshake
+	"+PING", "+AUTH", "+HELLO", "+SELECT", "+ECHO", "+RESET", "+COMMAND",
+}
+
+// redisAccessResponse is what a tenant needs to configure their Redis client.
+type redisAccessResponse struct {
+	Socket          string   `json:"socket"`
+	Host            string   `json:"host"` // "" — no TCP listener (socket only)
+	Port            int      `json:"port"` // 0 — no TCP listener
+	Username        string   `json:"username"`
+	Password        string   `json:"password"`
+	Database        int      `json:"database"`
+	KeyPrefix       string   `json:"key_prefix"`
+	AllowedCommands []string `json:"allowed_commands"`
+	Note            string   `json:"note"`
+}
+
+// redisAccessHandler serves the tenant Redis-access endpoints. Reuses
+// ApplicationHandlerConfig for Redis + the cache-token secret/salts + Users.
+type redisAccessHandler struct{ cfg ApplicationHandlerConfig }
+
+// RegisterRedisAccessRoutes wires the tenant + admin endpoints off the v1 group
+// (which already carries RequireKratosSession, mirroring RegisterAuditRoutes).
+// /me/redis-access is session-scoped to the caller; the admin view of a specific
+// tenant's credentials adds RequireAdmin on its own route.
+func RegisterRedisAccessRoutes(g *gin.RouterGroup, cfg ApplicationHandlerConfig) {
+	h := &redisAccessHandler{cfg: cfg}
+	g.GET("/me/redis-access", h.meRedisAccess)
+	g.GET("/users/:id/redis-access", middleware.RequireAdmin(), h.userRedisAccess)
+}
+
+func (h *redisAccessHandler) meRedisAccess(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil || claims.UserID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	h.serve(c, claims.UserID)
+}
+
+func (h *redisAccessHandler) userRedisAccess(c *gin.Context) {
+	h.serve(c, c.Param("id"))
+}
+
+// serve resolves the tenant, provisions (idempotently) their Redis ACL, and
+// returns the ready-to-use credentials.
+func (h *redisAccessHandler) serve(c *gin.Context, userID string) {
+	ctx := c.Request.Context()
+	if h.cfg.Redis == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "redis_unavailable", "detail": "Redis is not configured on this host"})
+		return
+	}
+	u, err := h.cfg.Users.FindByID(ctx, userID)
+	if err != nil || u == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
+		return
+	}
+	// Redis access is a TENANT feature: it needs a Linux account to scope the
+	// keyspace to and to reach the socket. Admins have no OS user.
+	if u.Username == nil || *u.Username == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "no_linux_user", "detail": "Redis access is only available for hosting users (admins have no Linux account)"})
+		return
+	}
+	osUser := *u.Username
+
+	salt := ""
+	if h.cfg.CacheTokenSalts != nil {
+		s, sErr := h.cfg.CacheTokenSalts.GetOrCreate(ctx, userID)
+		if sErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		salt = s
+	}
+	token := tenantRedisToken(h.cfg.CacheTokenSecret, osUser, salt)
+
+	if err := tenantRedisProvision(h, ctx, osUser, token); err != nil {
+		slog.ErrorContext(ctx, "tenant redis access: ACL provision failed", "user_id", userID, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "acl_provision_failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, redisAccessResponse{
+		Socket:          "/run/redis/redis.sock",
+		Host:            "",
+		Port:            0,
+		Username:        tenantRedisACLUser(osUser),
+		Password:        token,
+		Database:        0,
+		KeyPrefix:       tenantRedisKeyPrefix(osUser),
+		AllowedCommands: tenantRedisCommands,
+		Note: "Redis is reachable ONLY over the unix socket (no TCP). Authenticate with the " +
+			"username + password above, and set your client's key prefix to \"" + tenantRedisKeyPrefix(osUser) +
+			"\" — your credential can only read and write keys under that prefix. " +
+			"Keyspace-scanning and admin commands (KEYS, SCAN, FLUSHDB, CONFIG, …) are not permitted.",
+	})
+}
+
+// tenantRedisSetUserArgs builds the exact `ACL SETUSER` argument vector for a
+// tenant. Pure + unit-tested: `reset` makes the rule absolute on every re-apply
+// (idempotent), `resetchannels` denies all pub/sub, the fence is the tenant's
+// namespace, and only the curated commands are granted.
+func tenantRedisSetUserArgs(osUser, token string) []any {
+	args := []any{"ACL", "SETUSER", tenantRedisACLUser(osUser),
+		"reset",
+		"on", ">" + token,
+		"resetchannels",
+		tenantRedisKeyPattern(osUser),
+	}
+	for _, cmd := range tenantRedisCommands {
+		args = append(args, cmd)
+	}
+	return args
+}
+
+// provisionTenantRedisACL creates/updates the per-tenant ACL user, then persists
+// the aclfile so it survives a redis restart.
+func (h *redisAccessHandler) provisionTenantRedisACL(ctx context.Context, osUser, token string) error {
+	if err := h.cfg.Redis.Do(ctx, tenantRedisSetUserArgs(osUser, token)...).Err(); err != nil {
+		return err
+	}
+	return h.cfg.Redis.Do(ctx, "ACL", "SAVE").Err()
+}
+
+// tenantRedisProvision is a seam: handler tests override it to exercise serve()
+// without a Redis that implements ACL SETUSER (miniredis does not). Production
+// wiring is the real method.
+var tenantRedisProvision = func(h *redisAccessHandler, ctx context.Context, osUser, token string) error {
+	return h.provisionTenantRedisACL(ctx, osUser, token)
+}
+
+// The t_<osuser> user is torn down on account delete by revokeAllUserCacheACLs
+// (applications_cache.go), which the userops delete cascade already invokes as
+// RevokeCacheACLs — so a recycled username can't inherit the old principal.

--- a/panel-api/internal/api/tenant_redis_test.go
+++ b/panel-api/internal/api/tenant_redis_test.go
@@ -1,0 +1,252 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- Security invariants (no Redis needed) ------------------------------------
+
+// The tenant credential must NEVER equal the WP-cache install credential for the
+// same tenant — different domain-separation labels — or a leaked general
+// credential would also unlock the WP-cache keyspace.
+func TestTenantRedisToken_DomainSeparatedFromWPCache(t *testing.T) {
+	const secret, osUser, salt = "s3cr3t", "bob", "saltysalt"
+	gen := tenantRedisToken(secret, osUser, salt)
+	wp := cacheInstallToken(secret, osUser, "01ABCDEFGHIJKLMNOPQRSTUVWX", salt)
+	if gen == wp {
+		t.Fatal("tenant token collides with a WP-cache install token")
+	}
+	// Deterministic: same inputs → same token (so "show creds" == "re-apply ACL").
+	if gen != tenantRedisToken(secret, osUser, salt) {
+		t.Fatal("tenant token is not deterministic")
+	}
+	// Salt changes the token (per-tenant rotation without a global secret change).
+	if gen == tenantRedisToken(secret, osUser, "different-salt") {
+		t.Fatal("salt does not affect the token")
+	}
+}
+
+// The keyspace fence must be namespaced under jt: so it can never overlap the
+// panel's own keys (jabali:*, automation:*) or the WP-cache keys (jc:*), even
+// for an osuser literally named "jabali".
+func TestTenantRedisKeyspace_NamespacedAndNonOverlapping(t *testing.T) {
+	for _, osUser := range []string{"bob", "jabali", "automation", "jc"} {
+		pat := tenantRedisKeyPattern(osUser)
+		if !strings.HasPrefix(pat, "~jt:") {
+			t.Fatalf("fence %q for %q is not under the jt: namespace", pat, osUser)
+		}
+		if strings.HasPrefix(pat, "~jabali:") || strings.HasPrefix(pat, "~automation:") || strings.HasPrefix(pat, "~jc:") {
+			t.Fatalf("fence %q overlaps a reserved namespace", pat)
+		}
+		if tenantRedisKeyPrefix(osUser) != "jt:"+osUser+":" {
+			t.Fatalf("prefix mismatch for %q: %q", osUser, tenantRedisKeyPrefix(osUser))
+		}
+	}
+	if tenantRedisACLUser("bob") != "t_bob" {
+		t.Fatalf("unexpected ACL user %q", tenantRedisACLUser("bob"))
+	}
+}
+
+// The allowlist must exclude every command that ignores the key-pattern fence
+// (keyspace enumeration) or is administrative — a tenant must not be able to
+// read other tenants' key names or touch server state.
+func TestTenantRedisCommands_ExcludeDangerous(t *testing.T) {
+	banned := []string{
+		"KEYS", "SCAN", "RANDOMKEY", "DBSIZE", "FLUSHDB", "FLUSHALL", "SWAPDB",
+		"CONFIG", "SHUTDOWN", "DEBUG", "SAVE", "BGSAVE", "BGREWRITEAOF",
+		"CLIENT", "ACL", "CLUSTER", "SLAVEOF", "REPLICAOF", "MONITOR", "SLOWLOG",
+		"EVAL", "EVALSHA", "FUNCTION", "FCALL", "SUBSCRIBE", "PUBLISH", "MOVE",
+		"MIGRATE", "WAIT", "LASTSAVE", "LATENCY", "MEMORY", "FAILOVER",
+	}
+	have := map[string]bool{}
+	for _, c := range tenantRedisCommands {
+		have[strings.ToUpper(strings.TrimPrefix(c, "+"))] = true
+	}
+	for _, b := range banned {
+		if have[b] {
+			t.Errorf("allowlist must NOT contain the dangerous/enumeration command %q", b)
+		}
+	}
+	// Sanity: the everyday caching commands ARE present.
+	for _, want := range []string{"GET", "SET", "DEL", "EXPIRE", "HSET", "PING", "AUTH", "MULTI"} {
+		if !have[want] {
+			t.Errorf("allowlist is missing the expected command %q", want)
+		}
+	}
+	// Per-key cursor scans are safe (single fenced key) and should be allowed…
+	for _, want := range []string{"HSCAN", "SSCAN", "ZSCAN"} {
+		if !have[want] {
+			t.Errorf("per-key scan %q should be allowed", want)
+		}
+	}
+	// …but the keyspace-level SCAN must not be.
+	if have["SCAN"] {
+		t.Error("keyspace-level SCAN must not be in the allowlist")
+	}
+}
+
+// --- Handler behaviour --------------------------------------------------------
+
+type redisAccessStubUsers struct {
+	repository.UserRepository
+	user *models.User
+	err  error
+}
+
+func (s *redisAccessStubUsers) FindByID(_ context.Context, _ string) (*models.User, error) {
+	return s.user, s.err
+}
+
+func newRedisAccessRouter(t *testing.T, cfg ApplicationHandlerConfig, claims *auth.AccessClaims) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		if claims != nil {
+			ginctx.SetClaims(c, claims)
+		}
+		c.Next()
+	})
+	RegisterRedisAccessRoutes(v1, cfg)
+	return r
+}
+
+func ptr(s string) *string { return &s }
+
+func TestMeRedisAccess_Unauthorized(t *testing.T) {
+	r := newRedisAccessRouter(t, ApplicationHandlerConfig{}, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/me/redis-access", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMeRedisAccess_AdminHasNoLinuxUser(t *testing.T) {
+	mr, rdb := newMiniRedis(t)
+	defer mr.Close()
+	cfg := ApplicationHandlerConfig{
+		Redis: rdb,
+		Users: &redisAccessStubUsers{user: &models.User{ID: "admin-1", IsAdmin: true, Username: nil}},
+	}
+	r := newRedisAccessRouter(t, cfg, &auth.AccessClaims{UserID: "admin-1", IsAdmin: true})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/me/redis-access", nil))
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "no_linux_user") {
+		t.Fatalf("want 409 no_linux_user, got %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMeRedisAccess_RedisUnavailable(t *testing.T) {
+	cfg := ApplicationHandlerConfig{
+		Redis: nil,
+		Users: &redisAccessStubUsers{user: &models.User{ID: "u1", Username: ptr("bob")}},
+	}
+	r := newRedisAccessRouter(t, cfg, &auth.AccessClaims{UserID: "u1"})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/me/redis-access", nil))
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "redis_unavailable") {
+		t.Fatalf("want 503 redis_unavailable, got %d %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMeRedisAccess_HappyPath(t *testing.T) {
+	mr, rdb := newMiniRedis(t)
+	defer mr.Close()
+
+	// miniredis has no ACL SETUSER; capture the provisioning via the seam and
+	// assert it was invoked with the resolved osuser + derived token.
+	orig := tenantRedisProvision
+	t.Cleanup(func() { tenantRedisProvision = orig })
+	var gotOSUser, gotToken string
+	tenantRedisProvision = func(_ *redisAccessHandler, _ context.Context, osUser, token string) error {
+		gotOSUser, gotToken = osUser, token
+		return nil
+	}
+
+	cfg := ApplicationHandlerConfig{
+		Redis:            rdb,
+		CacheTokenSecret: "test-secret",
+		Users:            &redisAccessStubUsers{user: &models.User{ID: "u1", Username: ptr("bob")}},
+	}
+	r := newRedisAccessRouter(t, cfg, &auth.AccessClaims{UserID: "u1"})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/me/redis-access", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d %s", rec.Code, rec.Body.String())
+	}
+	var got redisAccessResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "t_bob" {
+		t.Errorf("username = %q, want t_bob", got.Username)
+	}
+	if got.KeyPrefix != "jt:bob:" {
+		t.Errorf("key_prefix = %q, want jt:bob:", got.KeyPrefix)
+	}
+	if got.Socket != "/run/redis/redis.sock" {
+		t.Errorf("socket = %q", got.Socket)
+	}
+	if got.Host != "" || got.Port != 0 {
+		t.Errorf("expected no TCP (host empty, port 0), got host=%q port=%d", got.Host, got.Port)
+	}
+	want := tenantRedisToken("test-secret", "bob", "")
+	if got.Password == "" || got.Password != want {
+		t.Errorf("password not the derived token")
+	}
+	if gotOSUser != "bob" || gotToken != want {
+		t.Errorf("provision seam got (%q,%q), want (bob, derived token)", gotOSUser, gotToken)
+	}
+}
+
+// The generated ACL SETUSER rule must reset first, enable the user with the
+// token, deny channels, fence to the tenant namespace, and grant only the
+// curated commands.
+func TestTenantRedisSetUserArgs(t *testing.T) {
+	args := tenantRedisSetUserArgs("bob", "tok")
+	if len(args) < 8 {
+		t.Fatalf("too few args: %v", args)
+	}
+	if args[0] != "ACL" || args[1] != "SETUSER" || args[2] != "t_bob" {
+		t.Fatalf("head = %v", args[:3])
+	}
+	joined := make([]string, len(args))
+	for i, a := range args {
+		joined[i] = a.(string)
+	}
+	s := strings.Join(joined, " ")
+	for _, want := range []string{"reset", "on", ">tok", "resetchannels", "~jt:bob:*", "+GET", "+SET"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("SETUSER args missing %q: %s", want, s)
+		}
+	}
+	// The absolute `reset` must come before any grant.
+	if idxReset, idxGet := strings.Index(s, "reset"), strings.Index(s, "+GET"); idxReset > idxGet {
+		t.Error("reset must precede grants for an authoritative re-apply")
+	}
+}
+
+func newMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mr, redis.NewClient(&redis.Options{Addr: mr.Addr()})
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1215,6 +1215,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			}
 			api.RegisterApplicationRoutes(v1, appCfg)
 
+			// GH #1016: per-tenant Redis credentials (reuses appCfg's Redis +
+			// cache-token secret/salts + Users).
+			api.RegisterRedisAccessRoutes(v1, appCfg)
+
 			// Log access routes (M13)
 			if deps.LogAccessStreams != nil && deps.Domains != nil && deps.Users != nil {
 				api.RegisterLogRoutes(v1, api.LogHandlerConfig{

--- a/panel-ui/src/shells/user/databases/RedisAccessCard.test.tsx
+++ b/panel-ui/src/shells/user/databases/RedisAccessCard.test.tsx
@@ -1,0 +1,61 @@
+// RedisAccessCard.test.tsx — GH #1016. Locks the reveal flow: the card fetches
+// /me/redis-access only when asked, and renders the scoped credential + the
+// key-prefix instruction. Only apiClient is mocked; the real AntD Card/
+// Descriptions/Alert run so a runtime React/AntD break surfaces here.
+import { App } from "antd";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RedisAccessCard } from "./RedisAccessCard";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as { get: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("RedisAccessCard", () => {
+  it("reveals scoped credentials on demand and shows the required key prefix", async () => {
+    mocked.get.mockResolvedValue({
+      data: {
+        socket: "/run/redis/redis.sock",
+        host: "",
+        port: 0,
+        username: "t_bob",
+        password: "deadbeef",
+        database: 0,
+        key_prefix: "jt:bob:",
+        allowed_commands: ["+GET", "+SET"],
+        note: "socket only",
+      },
+    });
+
+    render(
+      <App>
+        <RedisAccessCard />
+      </App>,
+    );
+
+    // Nothing fetched until the user asks.
+    expect(mocked.get).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /show my redis credentials/i }));
+
+    await waitFor(() => {
+      expect(mocked.get).toHaveBeenCalledWith("/me/redis-access");
+    });
+
+    // Username, socket, and the required prefix all render.
+    expect(await screen.findByText("t_bob")).toBeInTheDocument();
+    expect(screen.getByText("/run/redis/redis.sock")).toBeInTheDocument();
+    // "jt:bob:" appears both in the Descriptions and the prefix Alert.
+    expect(screen.getAllByText("jt:bob:").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Set your client's key prefix/i)).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/databases/RedisAccessCard.tsx
+++ b/panel-ui/src/shells/user/databases/RedisAccessCard.tsx
@@ -1,0 +1,115 @@
+// Tenant Redis access card (GH #1016). Jabali locks Redis behind ACL auth, so a
+// migrated app that connected unauthenticated now gets "NOAUTH Authentication
+// required". This card hands the tenant a scoped, ready-to-use credential.
+//
+// Reveal-on-click: GET /me/redis-access provisions the tenant's ACL user
+// (idempotent) and returns the credential — so we don't fetch a secret until
+// the user asks for it.
+import { useState } from "react";
+import { Card, Button, Descriptions, Typography, Alert, message } from "antd";
+import { apiClient } from "../../../apiClient";
+
+const { Text, Paragraph } = Typography;
+
+interface RedisAccess {
+  socket: string;
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  database: number;
+  key_prefix: string;
+  allowed_commands: string[];
+  note: string;
+}
+
+export const RedisAccessCard = () => {
+  const [creds, setCreds] = useState<RedisAccess | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const reveal = async () => {
+    setLoading(true);
+    try {
+      const resp = await apiClient.get<RedisAccess>("/me/redis-access");
+      setCreds(resp.data);
+    } catch {
+      message.error("Could not load your Redis credentials.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card
+      title="Redis access"
+      extra={
+        !creds && (
+          <Button type="primary" loading={loading} onClick={reveal}>
+            Show my Redis credentials
+          </Button>
+        )
+      }
+    >
+      <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+        Redis on this server requires authentication. Use the credentials below
+        to connect from your applications — for example{" "}
+        <Text code>$redis-&gt;connect('/run/redis/redis.sock')</Text> then{" "}
+        <Text code>$redis-&gt;auth([$username, $password])</Text>.
+      </Paragraph>
+
+      {creds && (
+        <>
+          <Descriptions column={1} bordered size="small">
+            <Descriptions.Item label="Socket">
+              <Text copyable code>
+                {creds.socket}
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="TCP">
+              <Text type="secondary">
+                Not available — Redis listens on the unix socket only.
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="Username">
+              <Text copyable code>
+                {creds.username}
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="Password">
+              <Text copyable code>
+                {creds.password}
+              </Text>
+            </Descriptions.Item>
+            <Descriptions.Item label="Database">{creds.database}</Descriptions.Item>
+            <Descriptions.Item label="Required key prefix">
+              <Text copyable code>
+                {creds.key_prefix}
+              </Text>
+            </Descriptions.Item>
+          </Descriptions>
+
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginTop: 16 }}
+            message="Set your client's key prefix"
+            description={
+              <>
+                Your credential can only read and write keys under{" "}
+                <Text code>{creds.key_prefix}</Text>. Set your Redis client's key
+                prefix to that value — e.g. phpredis{" "}
+                <Text code>
+                  setOption(Redis::OPT_PREFIX, '{creds.key_prefix}')
+                </Text>{" "}
+                or Laravel <Text code>REDIS_PREFIX</Text>. Keyspace-scanning and
+                admin commands (<Text code>KEYS</Text>, <Text code>SCAN</Text>,{" "}
+                <Text code>FLUSHDB</Text>, <Text code>CONFIG</Text>, …) are not
+                permitted.
+              </>
+            }
+          />
+        </>
+      )}
+    </Card>
+  );
+};

--- a/panel-ui/src/shells/user/databases/UserDatabasesPage.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabasesPage.tsx
@@ -5,10 +5,12 @@
 // scoped to its own username prefix.
 import { UserDatabaseList } from "./UserDatabaseList";
 import { UserDatabaseUsersList } from "../database-users/UserDatabaseUsersList";
+import { RedisAccessCard } from "./RedisAccessCard";
 
 export const UserDatabasesPage = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
     <UserDatabaseList />
     <UserDatabaseUsersList />
+    <RedisAccessCard />
   </div>
 );


### PR DESCRIPTION
Closes the gap reported in #1016: a migrated app that connected to Redis unauthenticated now fails with `NOAUTH Authentication required`, and the tenant had no way to obtain credentials.

## What it does

Gives each tenant a **scoped, ready-to-use Redis credential**, surfaced on the Databases page and via the API. It generalises the per-install WP-cache ACL primitive (`applications_cache.go`, ADR-0148) to a per-tenant one:

- **user** `t_<osuser>`, **HMAC-derived password** (recomputable, never stored — "show creds" and "re-apply ACL" are one idempotent op; a per-tenant salt allows rotating a single tenant without touching the global secret)
- **keyspace fenced** to `~jt:<osuser>:*` — namespaced under `jt:` so it can **never** overlap the panel's `jabali:*`/`automation:*` keys or the WP-cache `jc:*` keys, even for an osuser literally named `jabali`
- **curated command allowlist** (strings/hashes/lists/sets/zsets/bitmaps/HLL/geo/per-key scans/transactions/connection) that deliberately **excludes** the keyspace-level enumeration commands `SCAN`/`KEYS`/`RANDOMKEY`/`DBSIZE` (Redis does **not** pattern-scope these — Gitea #413, so they'd leak other tenants' key names), plus `FLUSH*`, `CONFIG`/`CLIENT`/`ACL`/admin, scripting, and pub/sub.

## Surface

- `GET /me/redis-access` (tenant, session) and `GET /users/:id/redis-access` (admin). Provision-on-demand; returns `{socket, host:"", port:0, username, password, database, key_prefix, allowed_commands, note}`.
- **Transport is the unix socket only** — jabali Redis has no TCP listener (`port 0`, ADR-0059), and every tenant is already in `jabali-redis-clients`, so `/run/redis/redis.sock` is reachable from their FPM/CLI with no extra grant.
- `t_<osuser>` is torn down on account delete via `revokeAllUserCacheACLs` (already invoked by the userops delete cascade).
- **UI:** a "Redis access" card on the tenant Databases page — reveal-on-click, copy buttons, and the required key-prefix instruction.

## The one honest constraint

Secure shared Redis needs both auth **and** a key-prefix fence, so the tenant must set their client's key prefix to `jt:<osuser>:` (phpredis `OPT_PREFIX`, Laravel `REDIS_PREFIX` — a one-line config). There's no secure way to hand out unprefixed/cross-tenant access; the card and the API `note` say so.

## Test plan

- [x] Go: token domain-separation + determinism, keyspace non-overlap (incl. reserved-word osusers), dangerous-command exclusion, the `SETUSER` arg builder, handler 401/409/503/200 paths. Full `go test ./panel-api/...` — 0 FAIL. `go vet` clean.
- [x] OpenAPI coverage green (both routes documented).
- [x] panel-ui build + card reveal-flow vitest + eslint clean.

Follow-up (not in this PR): a `jabali redis-access <user>` CLI for scripted migrations.

GH #1016.