### PR TITLE
fix(ui): route admin-shell toasts through the themed feedback bridge (GH #970)

### DIFF
--- a/panel-ui/src/components/AddGrantModal.tsx
+++ b/panel-ui/src/components/AddGrantModal.tsx
@@ -5,7 +5,8 @@
 // ro → "Read only") or custom privileges. Supports granular privilege
 // checkbox set (SELECT/INSERT/UPDATE/DELETE/CREATE/DROP/ALTER/INDEX).
 import { useEffect, useState } from "react";
-import { Alert, Form, Modal, Radio, Select, Checkbox, Space, message } from "antd";
+import { Alert, Form, Modal, Radio, Select, Checkbox, Space } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../apiClient";
 import { useListQuery } from "../hooks/useQueries";
@@ -87,14 +88,14 @@ export function AddGrantModal({
       }
 
       await apiClient.post(`/database-users/${userId}/grants`, payload);
-      message.success("Access granted");
+      feedback.message.success("Access granted");
       onSuccess();
       onClose();
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ?? "Failed to grant access";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setSubmitting(false);
     }

--- a/panel-ui/src/components/CapabilityRoute.tsx
+++ b/panel-ui/src/components/CapabilityRoute.tsx
@@ -12,7 +12,8 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Spin, message } from "antd";
+import { Spin } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { Navigate } from "react-router";
 
 import { useServerCapabilities, type ServerCapabilities } from "../hooks/useServerCapabilities";
@@ -25,7 +26,7 @@ interface CapabilityRouteProps {
 
 function DisabledRedirect({ fallback }: { fallback: string }) {
   useEffect(() => {
-    message.info("That feature isn't enabled on this server.");
+    feedback.message.info("That feature isn't enabled on this server.");
   }, []);
   return <Navigate to={fallback} replace />;
 }

--- a/panel-ui/src/components/DatabaseUserPasswordModal.tsx
+++ b/panel-ui/src/components/DatabaseUserPasswordModal.tsx
@@ -6,7 +6,8 @@
 // fallback so the password isn't casually left on screen.
 import { useState } from "react";
 import { CopyOutlined, EyeInvisibleOutlined, EyeOutlined } from "@icons";
-import { Alert, Button, Input, Modal, Space, Typography, message } from "antd";
+import { Alert, Button, Input, Modal, Space, Typography } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 
 interface DatabaseUserPasswordModalProps {
   open: boolean;
@@ -28,9 +29,9 @@ export function DatabaseUserPasswordModal({
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(password);
-      message.success("Password copied to clipboard");
+      feedback.message.success("Password copied to clipboard");
     } catch {
-      message.error("Copy failed — select the field and copy manually");
+      feedback.message.error("Copy failed — select the field and copy manually");
     }
   };
 

--- a/panel-ui/src/components/DomainNginxOptionsModal.tsx
+++ b/panel-ui/src/components/DomainNginxOptionsModal.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Checkbox, Form, InputNumber, Modal, Select, Typography, message } from "antd";
+import { Checkbox, Form, InputNumber, Modal, Select, Typography } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../apiClient";
 
@@ -50,7 +51,7 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
           });
         }
       } catch {
-        if (!cancelled) message.error("Failed to load domain options");
+        if (!cancelled) feedback.message.error("Failed to load domain options");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -74,10 +75,10 @@ export const DomainNginxOptionsModal = ({ domainId, onClose }: DomainNginxOption
           path_info: !!values.path_info,
         },
       });
-      message.success("Domain options saved — applied on the next reconcile");
+      feedback.message.success("Domain options saved — applied on the next reconcile");
       onClose();
     } catch {
-      message.error("Failed to save domain options");
+      feedback.message.error("Failed to save domain options");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/components/NotificationBell.tsx
+++ b/panel-ui/src/components/NotificationBell.tsx
@@ -10,7 +10,8 @@
 // (colorBgElevated / borderRadiusLG / boxShadowSecondary) so the
 // popup is visually identical to every other AntD dropdown.
 import { useTranslation } from "react-i18next";
-import { Badge, Button, Divider, Dropdown, Empty, Grid, Popconfirm, Space, Tag, Tooltip, Typography, message, theme } from "antd";
+import { Badge, Button, Divider, Dropdown, Empty, Grid, Popconfirm, Space, Tag, Tooltip, Typography, theme } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import type { MenuProps } from "antd";
 import type { CSSProperties, ReactElement } from "react";
 import { cloneElement, useEffect, useState } from "react";
@@ -142,7 +143,7 @@ export function NotificationBell() {
       await apiClient.post("/notifications/inbox/read-all");
       qc.invalidateQueries({ queryKey: ["notifications"] });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Mark all failed");
+      feedback.message.error(err instanceof Error ? err.message : "Mark all failed");
     }
   };
 
@@ -150,9 +151,9 @@ export function NotificationBell() {
     try {
       await apiClient.delete("/notifications/inbox");
       qc.invalidateQueries({ queryKey: ["notifications"] });
-      message.success("All notifications cleared");
+      feedback.message.success("All notifications cleared");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Clear failed");
+      feedback.message.error(err instanceof Error ? err.message : "Clear failed");
     }
   };
 
@@ -193,7 +194,7 @@ export function NotificationBell() {
         size="small"
         onClick={() => {
           if (webpush.error) {
-            message.error(webpush.error);
+            feedback.message.error(webpush.error);
             return;
           }
           void webpush.subscribe();

--- a/panel-ui/src/components/RowDeleteButton.tsx
+++ b/panel-ui/src/components/RowDeleteButton.tsx
@@ -13,7 +13,8 @@
 // /email/ }).getByRole("button", ...)) rather than encoding the row
 // identity into the button label.
 import { DeleteOutlined } from "@icons";
-import { Button, Popconfirm, message } from "antd";
+import { Button, Popconfirm } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 
 interface RowDeleteButtonProps {
   onConfirm: () => Promise<void>;
@@ -34,14 +35,14 @@ export function RowDeleteButton({
   const handleConfirm = async () => {
     try {
       await onConfirm();
-      message.success(successMessage);
+      feedback.message.success(successMessage);
     } catch (err: unknown) {
       if (onError) {
         onError(err);
         return;
       }
       const msg = err instanceof Error ? err.message : "Delete failed";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -1,7 +1,8 @@
 // AdminBackupsPage — admin overview of every backup run.
 // Scheduler-fired jobs roll up under their run_id (one parent row,
 // expandable to per-user children). Manual creates render flat.
-import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Badge, Button, Card, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { downloadUrl } from "../../../utils/download";
 import { backupTypeColor, backupTypeLabel, runScopeSummary } from "../../../utils/backupType";
 import { shortDateTime } from "../../../utils/datetime";
@@ -213,7 +214,7 @@ export const AdminBackupsPage = () => {
         });
       }
     } catch (err) {
-      message.error(extractApiError(err, "Load failed"));
+      feedback.message.error(extractApiError(err, "Load failed"));
     } finally {
       setLoading(false);
     }
@@ -247,7 +248,7 @@ export const AdminBackupsPage = () => {
       );
       setRunJobs((m) => ({ ...m, [runID]: resp.data.data ?? [] }));
     } catch (err) {
-      message.error(extractApiError(err, "Load run failed"));
+      feedback.message.error(extractApiError(err, "Load run failed"));
     }
   };
 
@@ -268,7 +269,7 @@ export const AdminBackupsPage = () => {
     // GH #502: a `partial` backup has a valid snapshot too (a non-critical
     // stage failed but the manifest was written) — allow downloading it.
     if (row.status !== "succeeded" && row.status !== "partial") {
-      message.warning("Backup must complete before download");
+      feedback.message.warning("Backup must complete before download");
       return;
     }
     // GH #462: anchor-download, not window.location.href — navigating aborts the
@@ -279,10 +280,10 @@ export const AdminBackupsPage = () => {
   const handleCancel = async (row: BackupJob) => {
     try {
       await apiClient.post(`/admin/backups/${row.id}/cancel`);
-      message.success(`Cancellation requested for ${row.id}`);
+      feedback.message.success(`Cancellation requested for ${row.id}`);
       void reload();
     } catch (err) {
-      message.error(extractApiError(err, "Cancel failed"));
+      feedback.message.error(extractApiError(err, "Cancel failed"));
     }
   };
 
@@ -299,10 +300,10 @@ export const AdminBackupsPage = () => {
         overwrite: true,
         destination_id: row.destination_id,
       });
-      message.success(`Restore queued for ${usernameById(row.user_id)}`);
+      feedback.message.success(`Restore queued for ${usernameById(row.user_id)}`);
       void reload();
     } catch (err) {
-      message.error(extractApiError(err, "Restore failed"));
+      feedback.message.error(extractApiError(err, "Restore failed"));
     }
   };
 
@@ -311,10 +312,10 @@ export const AdminBackupsPage = () => {
   const handleDelete = async (row: BackupJob) => {
     try {
       await apiClient.delete(`/admin/backups/${row.id}`);
-      message.success("Backup deleted");
+      feedback.message.success("Backup deleted");
       void reload();
     } catch (err) {
-      message.error(extractApiError(err, "Delete failed"));
+      feedback.message.error(extractApiError(err, "Delete failed"));
     }
   };
 
@@ -329,15 +330,15 @@ export const AdminBackupsPage = () => {
       );
       const { deleted, skipped_running, failed } = resp.data;
       if (failed > 0 || skipped_running > 0) {
-        message.warning(
+        feedback.message.warning(
           `Deleted ${deleted} job(s); ${skipped_running} running/queued skipped, ${failed} failed`,
         );
       } else {
-        message.success(`Deleted ${deleted} backup job(s)`);
+        feedback.message.success(`Deleted ${deleted} backup job(s)`);
       }
       void reload();
     } catch (err) {
-      message.error(extractApiError(err, "Bulk delete failed"));
+      feedback.message.error(extractApiError(err, "Bulk delete failed"));
     }
   };
 

--- a/panel-ui/src/shells/admin/backups/BackupLogModal.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupLogModal.tsx
@@ -3,7 +3,8 @@
 // account_restore route to /admin/backups/:id/logs; system_backup +
 // system_restore go to /admin/system/backups/:id/logs (same agent
 // command on the other side, just different mount point).
-import { Button, Modal, Spin, Tag, Typography, message } from "antd";
+import { Button, Modal, Spin, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { ReloadOutlined } from "@icons";
 import { useEffect, useState } from "react";
 
@@ -47,7 +48,7 @@ export const BackupLogModal = ({ job, onClose }: BackupLogModalProps) => {
       const resp = await apiClient.get<{ data: LogResponse }>(logsPathFor(job.kind, job.id));
       setData(resp.data?.data ?? null);
     } catch (err) {
-      message.error(extractApiError(err, "Failed to load logs"));
+      feedback.message.error(extractApiError(err, "Failed to load logs"));
     } finally {
       setLoading(false);
     }

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -2,7 +2,8 @@
 // scheduler/dispatcher. Backed by server_settings (PATCH /admin/settings).
 // Retention is per-schedule (Schedules tab) — not server-wide.
 import { useTranslation } from "react-i18next";
-import { Button, Form, Input, InputNumber, Spin, message } from "antd";
+import { Button, Form, Input, InputNumber, Spin } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { SaveOutlined } from "@icons";
 import { useEffect, useState } from "react";
 
@@ -50,7 +51,7 @@ export const BackupSettingsTab = () => {
           tenant_backup_window_end: resp.data.tenant_backup_window_end ?? "05:00",
         });
       } catch (err) {
-        message.error(extractApiError(err, "Load failed"));
+        feedback.message.error(extractApiError(err, "Load failed"));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -64,9 +65,9 @@ export const BackupSettingsTab = () => {
     setSaving(true);
     try {
       await apiClient.patch("/admin/settings", values);
-      message.success("Settings saved");
+      feedback.message.success("Settings saved");
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/backups/CreateBackupDrawer.tsx
+++ b/panel-ui/src/shells/admin/backups/CreateBackupDrawer.tsx
@@ -3,7 +3,8 @@
 // orchestrator runs the actual stages; the panel just creates the
 // workflow row + dispatches.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Drawer, Form, Grid, Input, Radio, Select, Space, message } from "antd";
+import { Alert, Button, Drawer, Form, Grid, Input, Radio, Select, Space } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
@@ -70,7 +71,7 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
     setSubmitting(true);
     try {
       if (!values.destination_id) {
-        message.error("Pick a destination");
+        feedback.message.error("Pick a destination");
         return;
       }
       if (values.kind === "system_backup" || values.kind === "full_server") {
@@ -82,12 +83,12 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
           include_accounts: full,
           destination_id: values.destination_id,
         });
-        message.success(full ? "Full server backup queued" : "System backup queued");
+        feedback.message.success(full ? "Full server backup queued" : "System backup queued");
         onCreated();
         return;
       }
       if (!values.user_id) {
-        message.error("Pick a user");
+        feedback.message.error("Pick a user");
         return;
       }
       const payload = {
@@ -105,10 +106,10 @@ export const CreateBackupDrawer = ({ open, onClose, onCreated }: CreateBackupDra
         compression: values.compression ?? "",
       };
       await apiClient.post(`/admin/users/${values.user_id}/backups`, payload);
-      message.success("Backup queued");
+      feedback.message.success("Backup queued");
       onCreated();
     } catch (err) {
-      message.error(extractApiError(err, "Create failed"));
+      feedback.message.error(extractApiError(err, "Create failed"));
     } finally {
       setSubmitting(false);
     }

--- a/panel-ui/src/shells/admin/database-users/DatabaseUserDrawer.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUserDrawer.tsx
@@ -4,7 +4,8 @@
 // modal isn't trapped inside it.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Button, Drawer, Form, Grid, Input, Segmented, Space, message } from "antd";
+import { Button, Drawer, Form, Grid, Input, Segmented, Space } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 import { DatabaseUserPasswordModal } from "../../../components/DatabaseUserPasswordModal";
@@ -52,7 +53,7 @@ export const DatabaseUserDrawer = ({
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
         "Failed to create database user";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setSubmitting(false);
     }

--- a/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
@@ -8,7 +8,8 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
-import { Button, Card, Space, Table, Tag, Typography, message } from "antd";
+import { Button, Card, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { KeyOutlined, PlusOutlined, UserOutlined, DeleteOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
 import { useQueryClient } from "@tanstack/react-query";
@@ -111,7 +112,7 @@ export const DatabaseUsersList = () => {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ?? "Failed to rotate password";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setRotatingId(null);
     }
@@ -121,7 +122,7 @@ export const DatabaseUsersList = () => {
     setRevokingId(grant.id);
     try {
       await apiClient.delete(`/database-user-grants/${grant.id}`);
-      message.success(
+      feedback.message.success(
         `Revoked ${grantLabel(grant).toLowerCase()} on ${grant.database_name}`,
       );
       refresh();
@@ -129,7 +130,7 @@ export const DatabaseUsersList = () => {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ?? "Failed to revoke grant";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setRevokingId(null);
     }

--- a/panel-ui/src/shells/admin/databases/DatabaseCreate.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseCreate.tsx
@@ -3,7 +3,8 @@
 // on the server (see panel-api/internal/api/databases.go). Admins
 // create without a prefix. The helper text reflects that distinction.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Form, Input, Typography, message } from "antd";
+import { Button, Card, Form, Input, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useNavigate } from "react-router";
 
 import { useCreateMutation } from "../../../hooks/useQueries";
@@ -25,12 +26,12 @@ export const DatabaseCreate = () => {
   const handleFinish = async (values: DatabaseCreateInput) => {
     try {
       await createMutation.mutateAsync(values);
-      message.success("Database created");
+      feedback.message.success("Database created");
       navigate("/jabali-admin/databases");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to create database";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -4,7 +4,8 @@
 // auto-generates doc_root when blank. Post-M21: Form.useForm +
 // useCreateMutation, no Refine wrappers.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Checkbox, Form, Input, Select, Typography, message } from "antd";
+import { Button, Card, Checkbox, Form, Input, Select, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
 import { useNavigate } from "react-router";
@@ -46,12 +47,12 @@ export const DomainCreate = () => {
   const handleFinish = async (values: DomainCreateInput) => {
     try {
       await createMutation.mutateAsync(values);
-      message.success("Domain created");
+      feedback.message.success("Domain created");
       navigate("/jabali-admin/domains");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to create domain";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainListenIPSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainListenIPSection.tsx
@@ -2,7 +2,8 @@
 // (M24 Step 9). Two AntD Selects with a "use server default" sentinel
 // option per family. Submitting "default" PATCHes listen_ipv*_id: null,
 // which the API resolves to the family default at render time.
-import { Button, Form, Select, Space, Tag, Typography, message } from "antd";
+import { Button, Form, Select, Space, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
 import { useListQuery, useUpdateMutation } from "../../../hooks/useQueries";
@@ -87,9 +88,9 @@ export const DomainListenIPSection = ({
     };
     try {
       await updateMutation.mutateAsync({ id: domainId, input: patch });
-      message.success("Listen-IP binding updated");
+      feedback.message.success("Listen-IP binding updated");
     } catch (err: unknown) {
-      message.error(err instanceof Error ? err.message : "Failed to update binding");
+      feedback.message.error(err instanceof Error ? err.message : "Failed to update binding");
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainMTASTSSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMTASTSSection.tsx
@@ -12,7 +12,8 @@
 // operator knows the toggle worked and the wait is intentional.
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Skeleton, Space, Switch, Typography, message } from "antd";
+import { Alert, Skeleton, Space, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined, SafetyOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -40,7 +41,7 @@ export const DomainMTASTSSection = ({ domainId }: Props) => {
       const res = await apiClient.get<MTAStsState>(`/domains/${domainId}/mta-sts`);
       setState(res.data);
     } catch {
-      message.error("Failed to load MTA-STS status");
+      feedback.message.error("Failed to load MTA-STS status");
     } finally {
       setLoading(false);
     }
@@ -57,13 +58,13 @@ export const DomainMTASTSSection = ({ domainId }: Props) => {
         enabled: next,
       });
       setState(res.data);
-      message.success(
+      feedback.message.success(
         next
           ? "MTA-STS enabled — DNS records published"
           : "MTA-STS disabled — records removed",
       );
     } catch {
-      message.error("Failed to toggle MTA-STS");
+      feedback.message.error("Failed to toggle MTA-STS");
       await fetchState();
     } finally {
       setToggling(false);

--- a/panel-ui/src/shells/admin/domains/DomainMailProviderSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailProviderSection.tsx
@@ -4,7 +4,8 @@
 // DNS and reissues the cert on the next reconcile.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Alert, Button, Input, Select, Space, Typography, message } from "antd";
+import { Alert, Button, Input, Select, Space, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -52,9 +53,9 @@ export const DomainMailProviderSection = ({
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ["domains"] });
-      message.success("Mail provider updated — DNS and cert reconcile shortly");
+      feedback.message.success("Mail provider updated — DNS and cert reconcile shortly");
     },
-    onError: () => message.error("Failed to update mail provider"),
+    onError: () => feedback.message.error("Failed to update mail provider"),
   });
 
   return (

--- a/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailTLSSection.tsx
@@ -12,7 +12,8 @@
 //   POST   /api/v1/domains/:id/mail-certificate/reissue
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Skeleton, Space, Switch, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Alert, Button, Skeleton, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { ReloadOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -73,7 +74,7 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
       const res = await apiClient.get<MailCertResponse>(`/domains/${domainId}/mail-certificate`);
       setCert(res.data);
     } catch {
-      message.error("Failed to load mail TLS status");
+      feedback.message.error("Failed to load mail TLS status");
     } finally {
       setLoading(false);
     }
@@ -88,15 +89,15 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
     try {
       if (next) {
         await apiClient.post(`/domains/${domainId}/mail-certificate/enable`);
-        message.success("Mail TLS enabled — reconciler will request a Let's Encrypt cert shortly");
+        feedback.message.success("Mail TLS enabled — reconciler will request a Let's Encrypt cert shortly");
       } else {
         await apiClient.post(`/domains/${domainId}/mail-certificate/disable`);
-        message.success("Mail TLS disabled");
+        feedback.message.success("Mail TLS disabled");
       }
       await fetchStatus();
     } catch (err: unknown) {
       const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      message.error(detail ?? "Toggle failed");
+      feedback.message.error(detail ?? "Toggle failed");
     } finally {
       setBusy(false);
     }
@@ -106,10 +107,10 @@ export const DomainMailTLSSection = ({ domainId }: Props) => {
     setBusy(true);
     try {
       await apiClient.post(`/domains/${domainId}/mail-certificate/reissue`);
-      message.success("Re-issue queued — reconciler will retry on the next tick");
+      feedback.message.success("Re-issue queued — reconciler will retry on the next tick");
       await fetchStatus();
     } catch {
-      message.error("Re-issue failed");
+      feedback.message.error("Re-issue failed");
     } finally {
       setBusy(false);
     }

--- a/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSSLSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Input, Modal, Select, Skeleton, Space, Tag, Tooltip, message } from "antd";
+import { Alert, Button, Input, Modal, Select, Skeleton, Space, Tag, Tooltip } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { ReloadOutlined } from "@icons";
 import { Link } from "react-router";
 
@@ -117,7 +118,7 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
         setCert(null);
         setCertMissing(true);
       } else {
-        message.error("Failed to load SSL status");
+        feedback.message.error("Failed to load SSL status");
       }
     } finally {
       setLoading(false);
@@ -154,13 +155,13 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
       setCovering(all.filter((c) => certCoversHost(c, domainName)));
     } catch {
       setCovering([]);
-      message.error("Failed to load shared certificates");
+      feedback.message.error("Failed to load shared certificates");
     }
   };
 
   const attachShared = async () => {
     if (!selectedShared) {
-      message.error("Choose a shared certificate");
+      feedback.message.error("Choose a shared certificate");
       return;
     }
     setSharedBusy(true);
@@ -171,12 +172,12 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
       setSslMode("shared");
       setSharedCertId(selectedShared);
       setSharedPickerOpen(false);
-      message.success("Shared certificate attached");
+      feedback.message.success("Shared certificate attached");
       onToggled();
       await fetchCert();
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
-      message.error(resp?.detail ?? "Failed to attach shared certificate");
+      feedback.message.error(resp?.detail ?? "Failed to attach shared certificate");
     } finally {
       setSharedBusy(false);
     }
@@ -188,11 +189,11 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
       await apiClient.delete(`/domains/${domainId}/ssl/shared`);
       setSslMode("le");
       setSharedCertId(undefined);
-      message.success("Shared certificate detached (reverted to Let's Encrypt)");
+      feedback.message.success("Shared certificate detached (reverted to Let's Encrypt)");
       onToggled();
       await fetchCert();
     } catch {
-      message.error("Failed to detach shared certificate");
+      feedback.message.error("Failed to detach shared certificate");
     } finally {
       setSharedBusy(false);
     }
@@ -211,12 +212,12 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
     try {
       await apiClient.patch(`/domains/${domainId}`, { ssl_mode: mode });
       setSslMode(mode);
-      message.success("Certificate mode updated");
+      feedback.message.success("Certificate mode updated");
       onToggled();
       await fetchCert();
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
-      message.error(resp?.detail ?? "Failed to change certificate mode");
+      feedback.message.error(resp?.detail ?? "Failed to change certificate mode");
     } finally {
       setModeChanging(false);
     }
@@ -224,7 +225,7 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
 
   const uploadCustom = async () => {
     if (!certPem.trim() || !keyPem.trim()) {
-      message.error("Paste both the certificate and the private key");
+      feedback.message.error("Paste both the certificate and the private key");
       return;
     }
     setUploading(true);
@@ -237,12 +238,12 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
       setCustomOpen(false);
       setCertPem("");
       setKeyPem("");
-      message.success("Custom certificate installed");
+      feedback.message.success("Custom certificate installed");
       onToggled();
       await fetchCert();
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
-      message.error(resp?.detail ?? "Failed to install custom certificate");
+      feedback.message.error(resp?.detail ?? "Failed to install custom certificate");
     } finally {
       setUploading(false);
     }
@@ -252,10 +253,10 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
     setRenewing(true);
     try {
       await apiClient.post(`/domains/${domainId}/ssl/renew`);
-      message.success("Renewal scheduled");
+      feedback.message.success("Renewal scheduled");
       await fetchCert();
     } catch {
-      message.error("Failed to schedule renewal");
+      feedback.message.error("Failed to schedule renewal");
     } finally {
       setRenewing(false);
     }
@@ -265,10 +266,10 @@ export const DomainSSLSection = ({ domainId, domainName, sslEnabled, onToggled }
     setRenewing(true);
     try {
       await apiClient.post(`/domains/${domainId}/ssl/retry`);
-      message.success("Retry queued");
+      feedback.message.success("Retry queued");
       await fetchCert();
     } catch {
-      message.error("Failed to queue retry");
+      feedback.message.error("Failed to queue retry");
     } finally {
       setRenewing(false);
     }

--- a/panel-ui/src/shells/admin/domains/DomainSkipAutoSANToggle.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainSkipAutoSANToggle.tsx
@@ -5,7 +5,8 @@
 // or the helper subdomains aren't DNS-resolvable.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Alert, Skeleton, Space, Switch, Typography, message } from "antd";
+import { Alert, Skeleton, Space, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -46,13 +47,13 @@ export const DomainSkipAutoSANToggle = ({ domainId }: Props) => {
       await qc.invalidateQueries({
         queryKey: ["domain-skip-auto-san", domainId],
       });
-      message.success(
+      feedback.message.success(
         resp.enabled
           ? "Auto-SAN disabled — cert will cover only the base domain"
           : "Auto-SAN enabled — cert will include mail / autoconfig",
       );
     },
-    onError: () => message.error("Failed to update"),
+    onError: () => feedback.message.error("Failed to update"),
   });
 
   if (isLoading) return <Skeleton active paragraph={{ rows: 1 }} />;

--- a/panel-ui/src/shells/admin/ips/AdminIPList.tsx
+++ b/panel-ui/src/shells/admin/ips/AdminIPList.tsx
@@ -4,7 +4,8 @@
 // RowDeleteButton. Delete handles the 409 ip_in_use case by surfacing
 // the affected-domains list returned by the API.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Modal, Space, Table, Tag, Typography, message } from "antd";
+import { Button, Card, Modal, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, EditOutlined, EthernetPortOutlined } from "@icons";
 import { RowActions } from "../../../components/RowActions";
 import { useState } from "react";
@@ -79,7 +80,7 @@ export const AdminIPList = () => {
   const handleDelete = async (row: ManagedIP) => {
     try {
       await deleteMutation.mutateAsync({ id: String(row.id) });
-      message.success(`Removed ${row.address} from the pool`);
+      feedback.message.success(`Removed ${row.address} from the pool`);
     } catch (err: unknown) {
       // Conflict surfaces the affected-domains list in a Modal — admin
       // needs to reassign those domains before deleting.
@@ -88,7 +89,7 @@ export const AdminIPList = () => {
         setConflictModal(body);
         return;
       }
-      message.error(err instanceof Error ? err.message : "Delete failed");
+      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
+++ b/panel-ui/src/shells/admin/logs/DomainLogsTab.tsx
@@ -3,7 +3,8 @@
 // one tab of the consolidated Logs & Statistics page.
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
-import { Card, Typography, Button, Space, Table, message } from "antd";
+import { Card, Typography, Button, Space, Table } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   ReloadOutlined,
   FileTextOutlined,
@@ -71,7 +72,7 @@ export const DomainLogsTab = () => {
           ? // @ts-expect-error axios error shape
             error.response?.data?.error
           : undefined;
-      message.error(msg || "Failed to create log stream");
+      feedback.message.error(msg || "Failed to create log stream");
     }
   };
 

--- a/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
+++ b/panel-ui/src/shells/admin/logs/LogStreamModal.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useState, useEffect, useRef } from "react";
-import { Modal, Typography, Button, Space, message, Spin, theme } from "antd";
+import { Modal, Typography, Button, Space, Spin, theme } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { PauseOutlined, PlayCircleOutlined, ClearOutlined } from "@ant-design/icons";
 
 const { Text } = Typography;
@@ -135,7 +136,7 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
     ws.onopen = () => {
       setConnected(true);
       setConnecting(false);
-      message.success("Connected to log stream");
+      feedback.message.success("Connected to log stream");
       console.log("WebSocket connected");
     };
 
@@ -174,16 +175,16 @@ export const LogStreamModal = ({ visible, onClose, streamUrl, title, logType }: 
       setConnected(false);
       setConnecting(false);
       if (event.code === 1000) {
-        message.info("Log stream ended");
+        feedback.message.info("Log stream ended");
       } else {
-        message.error("Connection lost");
+        feedback.message.error("Connection lost");
       }
       console.log("WebSocket closed", event.code, event.reason);
     };
 
     ws.onerror = (error) => {
       setConnecting(false);
-      message.error("WebSocket connection error");
+      feedback.message.error("WebSocket connection error");
       console.error("WebSocket error:", error);
     };
 

--- a/panel-ui/src/shells/admin/mail/MailThrottlesPage.tsx
+++ b/panel-ui/src/shells/admin/mail/MailThrottlesPage.tsx
@@ -8,7 +8,8 @@ import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Alert, Button, Drawer, Form, Input, InputNumber, Select, Space, Switch, Table, Tag, Typography, message } from "antd";
+import { Alert, Button, Drawer, Form, Input, InputNumber, Select, Space, Switch, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { EditOutlined, DeleteOutlined } from "@icons";
 import type { ColumnsType } from "antd/es/table";
 
@@ -43,17 +44,17 @@ export const MailThrottlesPage = () => {
     mutationFn: (body: Partial<Policy>) => apiClient.post("/admin/mail/throttles", body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "mail", "throttles"] });
-      message.success("Throttle created — reconciler will push to Stalwart on next tick");
+      feedback.message.success("Throttle created — reconciler will push to Stalwart on next tick");
       setDrawer({ open: false });
     },
-    onError: (e: any) => message.error(e?.response?.data?.error ?? "create failed"),
+    onError: (e: any) => feedback.message.error(e?.response?.data?.error ?? "create failed"),
   });
 
   const updateMut = useMutation({
     mutationFn: (b: { id: string; body: Partial<Policy> }) => apiClient.put(`/admin/mail/throttles/${b.id}`, b.body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "mail", "throttles"] });
-      message.success("Throttle updated");
+      feedback.message.success("Throttle updated");
       setDrawer({ open: false });
     },
   });
@@ -62,7 +63,7 @@ export const MailThrottlesPage = () => {
     mutationFn: (id: string) => apiClient.delete(`/admin/mail/throttles/${id}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "mail", "throttles"] });
-      message.success("Throttle removed");
+      feedback.message.success("Throttle removed");
     },
   });
 

--- a/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/ChannelsTab.tsx
@@ -4,7 +4,8 @@
 // page-level header; the "Add channel" button stays here because it's
 // tab-specific (the History tab has a different action).
 import { useTranslation } from "react-i18next";
-import { Button, Space, Switch, Table, Tag, message } from "antd";
+import { Button, Space, Switch, Table, Tag } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
@@ -39,16 +40,16 @@ export const ChannelsTab = () => {
     try {
       await updateMutation.mutateAsync({ id: row.id, input: { enabled: next } });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Toggle failed");
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
     }
   };
 
   const handleDelete = async (row: NotificationChannel) => {
     try {
       await deleteMutation.mutateAsync({ id: row.id });
-      message.success(`Deleted ${row.name}`);
+      feedback.message.success(`Deleted ${row.name}`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Delete failed");
+      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
     }
   };
 
@@ -56,13 +57,13 @@ export const ChannelsTab = () => {
     try {
       const res = await apiClient.post<{ delivered?: boolean }>(`/${RESOURCE}/${row.id}/test`);
       if (res.data?.delivered) {
-        message.success(`Test delivered to ${row.name}`);
+        feedback.message.success(`Test delivered to ${row.name}`);
       } else {
-        message.success(`Test queued for ${row.name} — see the History tab for the result`);
+        feedback.message.success(`Test queued for ${row.name} — see the History tab for the result`);
       }
     } catch (err) {
       // Synchronous send surfaces the real delivery error (e.g. SMTP auth).
-      message.error(err instanceof Error ? err.message : "Test failed");
+      feedback.message.error(err instanceof Error ? err.message : "Test failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/notifications/EventsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.tsx
@@ -2,7 +2,8 @@
 // toggle. Defaults seeded by panel-api first-boot per
 // models.AllNotificationEventKinds (important = on).
 import { useTranslation } from "react-i18next";
-import { Switch, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -46,7 +47,7 @@ export const EventsTab = () => {
       });
       qc.invalidateQueries({ queryKey: LIST_KEY });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Toggle failed");
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/HistoryTab.tsx
@@ -5,7 +5,8 @@
 // NULL) via ListForAdminInbox on the backend. Click a row to mark it
 // read and (if a deeplink exists) navigate there.
 import { useTranslation } from "react-i18next";
-import { Button, Descriptions, Modal, Popconfirm, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Button, Descriptions, Modal, Popconfirm, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -103,9 +104,9 @@ export const HistoryTab = () => {
     try {
       await apiClient.post("/notifications/inbox/read-all");
       qc.invalidateQueries({ queryKey: ["notifications"] });
-      message.success("Marked all as read");
+      feedback.message.success("Marked all as read");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Mark-all failed");
+      feedback.message.error(err instanceof Error ? err.message : "Mark-all failed");
     }
   };
 
@@ -113,9 +114,9 @@ export const HistoryTab = () => {
     try {
       await apiClient.delete("/notifications/inbox");
       qc.invalidateQueries({ queryKey: ["notifications"] });
-      message.success("All notifications cleared");
+      feedback.message.success("All notifications cleared");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Clear failed");
+      feedback.message.error(err instanceof Error ? err.message : "Clear failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/notifications/WebPushTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/WebPushTab.tsx
@@ -7,7 +7,8 @@
 // its own enable click anyway. This tab exposes the same toggle the
 // bell dropdown footer offers, with a bit more context around it.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Card, Space, Typography, message } from "antd";
+import { Alert, Button, Card, Space, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { BellOutlined } from "@icons";
 
 import { useWebPushSubscription } from "../../../hooks/useWebPushSubscription";
@@ -19,18 +20,18 @@ export const WebPushTab = () => {
   const handleEnable = async () => {
     try {
       await webpush.subscribe();
-      message.success("Browser push enabled");
+      feedback.message.success("Browser push enabled");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Subscribe failed");
+      feedback.message.error(err instanceof Error ? err.message : "Subscribe failed");
     }
   };
 
   const handleDisable = async () => {
     try {
       await webpush.unsubscribe();
-      message.success("Browser push disabled");
+      feedback.message.success("Browser push disabled");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Unsubscribe failed");
+      feedback.message.error(err instanceof Error ? err.message : "Unsubscribe failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityAide.tsx
@@ -3,7 +3,8 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { apiClient } from "../../../apiClient";
-import { Alert, Badge, Button, Card, Popconfirm, Select, Space, Statistic, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Alert, Badge, Button, Card, Popconfirm, Select, Space, Statistic, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import {
   type AideSampleRow,
@@ -86,7 +87,7 @@ export const AdminSecurityAide = () => {
                   "/admin/security/aide/report",
                 );
                 if (!data.available || !data.report) {
-                  void message.warning("No AIDE report available yet");
+                  void feedback.message.warning("No AIDE report available yet");
                   return;
                 }
                 const blob = new Blob([data.report], { type: "text/plain" });
@@ -97,7 +98,7 @@ export const AdminSecurityAide = () => {
                 a.click();
                 URL.revokeObjectURL(url);
               } catch {
-                void message.error("Report download failed");
+                void feedback.message.error("Report download failed");
               }
             }}
           >
@@ -109,8 +110,8 @@ export const AdminSecurityAide = () => {
             loading={runCheck.isPending}
             onClick={() =>
               runCheck.mutate(undefined, {
-                onSuccess: () => message.success("Check complete"),
-                onError: () => message.error("Check failed — see agent logs"),
+                onSuccess: () => feedback.message.success("Check complete"),
+                onError: () => feedback.message.error("Check failed — see agent logs"),
               })
             }
           >
@@ -121,8 +122,8 @@ export const AdminSecurityAide = () => {
             loading={runRebuild.isPending}
             onClick={() =>
               runRebuild.mutate(true, {
-                onSuccess: (d) => message.info(`Dry run: would run ${d.plan ?? "aideinit -y -f"}`),
-                onError: () => message.error("Dry run failed — see agent logs"),
+                onSuccess: (d) => feedback.message.info(`Dry run: would run ${d.plan ?? "aideinit -y -f"}`),
+                onError: () => feedback.message.error("Dry run failed — see agent logs"),
               })
             }
           >
@@ -135,8 +136,8 @@ export const AdminSecurityAide = () => {
             okButtonProps={{ danger: true }}
             onConfirm={() =>
               runRebuild.mutate(false, {
-                onSuccess: () => message.success("Baseline rebuilt"),
-                onError: () => message.error("Rebuild failed — see agent logs"),
+                onSuccess: () => feedback.message.success("Baseline rebuilt"),
+                onError: () => feedback.message.error("Rebuild failed — see agent logs"),
               })
             }
           >

--- a/panel-ui/src/shells/admin/security/AdminSecurityAppArmor.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityAppArmor.tsx
@@ -4,7 +4,8 @@
 // 50 rows) below the profile table — answers "what did AppArmor
 // actually drop?" without dropping to journalctl.
 import { useTranslation } from "react-i18next";
-import { Alert, Badge, Button, Card, Checkbox, Descriptions, Drawer, Empty, Modal, Select, Space, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Alert, Badge, Button, Card, Checkbox, Descriptions, Drawer, Empty, Modal, Select, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 
 import {
@@ -280,10 +281,10 @@ export const AdminSecurityAppArmor = () => {
             { profile: pendingFlip.profile, mode: pendingFlip.nextMode },
             {
               onSuccess: () => {
-                message.success(`${pendingFlip.profile} → ${pendingFlip.nextMode}`);
+                feedback.message.success(`${pendingFlip.profile} → ${pendingFlip.nextMode}`);
                 setPendingFlip(null);
               },
-              onError: () => message.error("Flip failed — check agent logs"),
+              onError: () => feedback.message.error("Flip failed — check agent logs"),
             },
           );
         }}

--- a/panel-ui/src/shells/admin/server-status/NetworkTable.tsx
+++ b/panel-ui/src/shells/admin/server-status/NetworkTable.tsx
@@ -1,4 +1,5 @@
-import { Card, Space, Table, Tag, Typography, message } from "antd";
+import { Card, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { GlobalOutlined } from "@ant-design/icons";
 
 import type { NetworkInterface } from "../../../hooks/useServerStatus";
@@ -67,7 +68,7 @@ function IPChips({ ips }: { ips: string[] }) {
           onClick={async () => {
             try {
               await navigator.clipboard.writeText(ip);
-              message.success("Copied " + ip);
+              feedback.message.success("Copied " + ip);
             } catch {
               // ignore
             }

--- a/panel-ui/src/shells/admin/server-status/ProcessesCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/ProcessesCard.tsx
@@ -4,7 +4,8 @@
 // Kill icon buttons (SIGTERM / SIGKILL) with confirm Modal. The agent
 // owns the denylist.
 import { useState } from "react";
-import { Button, Card, Modal, Space, Statistic, Table, message } from "antd";
+import { Button, Card, Modal, Space, Statistic, Table } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { CloseOutlined, ThunderboltOutlined } from "@icons";
@@ -30,10 +31,10 @@ export function ProcessesCard({ processes }: Props) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "server-status"] });
-      message.success("Signal sent");
+      feedback.message.success("Signal sent");
     },
     onError: (e: unknown) => {
-      message.error(e instanceof Error ? e.message : "Kill failed");
+      feedback.message.error(e instanceof Error ? e.message : "Kill failed");
     },
   });
 

--- a/panel-ui/src/shells/admin/settings/PHPPerformanceModesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PHPPerformanceModesCard.tsx
@@ -2,7 +2,8 @@
 // PHP Performance Mode presets that L1 users select from. Edits are the ceiling
 // templates; per-package clamping happens at apply.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Collapse, Form, InputNumber, Select, Typography, message } from "antd";
+import { Button, Card, Collapse, Form, InputNumber, Select, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { apiClient } from "../../../apiClient";
@@ -30,11 +31,11 @@ const ModeForm = ({ mode }: { mode: Mode }) => {
     setSaving(true);
     try {
       await apiClient.put(`/php-performance-modes/${mode.mode}`, vals);
-      message.success(`${mode.mode} preset saved`);
+      feedback.message.success(`${mode.mode} preset saved`);
       qc.invalidateQueries({ queryKey: ["php-performance-modes"] });
     } catch (e) {
       const err = e as { response?: { data?: { detail?: string; error?: string } } };
-      message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
+      feedback.message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
+++ b/panel-ui/src/shells/admin/users/AdminUserOverview.tsx
@@ -33,7 +33,8 @@ import {
   UserOutlined,
 } from "@icons";
 import { useQuery } from "@tanstack/react-query";
-import { Alert, Button, Card, Col, Row, Skeleton, Space, Statistic, Tag, Typography, message } from "antd";
+import { Alert, Button, Card, Col, Row, Skeleton, Space, Statistic, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 import { Link, useParams } from "react-router";
 
@@ -132,7 +133,7 @@ export function AdminUserOverview() {
       await startImpersonation(id);
       window.location.assign(path);
     } catch {
-      message.error("Could not open the user panel as this user");
+      feedback.message.error("Could not open the user panel as this user");
       setImpersonating(false);
     }
   };

--- a/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
@@ -4,7 +4,8 @@
 // jobs, OS account, /home, related rows). Parent (UserList RowActions)
 // drives `open` via its dropdown menu.
 import { useState } from "react";
-import { Button, Modal, message } from "antd";
+import { Button, Modal } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -30,7 +31,7 @@ export const UserDeleteAction = ({
     try {
       await apiClient.delete(`/users/${encodeURIComponent(recordItemId)}`);
 
-      message.success(`User "${userEmail}" and all related data deleted`);
+      feedback.message.success(`User "${userEmail}" and all related data deleted`);
 
       // Invalidate every ["list", "users", *] variant so admin tabs
       // and the parent badge counters all refetch after a delete.
@@ -41,7 +42,7 @@ export const UserDeleteAction = ({
     } catch (err: unknown) {
       const errMsg =
         err instanceof Error ? err.message : "Failed to delete user";
-      message.error(errMsg);
+      feedback.message.error(errMsg);
     } finally {
       setIsLoading(false);
     }

--- a/panel-ui/src/shells/admin/users/UserDrawer.tsx
+++ b/panel-ui/src/shells/admin/users/UserDrawer.tsx
@@ -6,7 +6,8 @@
 //
 // Validation rules mirror the server's so the form rejects early.
 // Password on edit is optional — blank means "keep current".
-import { Button, Drawer, Form, Grid, Input, Select, Space, Spin, Switch, message } from "antd";
+import { Button, Drawer, Form, Grid, Input, Select, Space, Spin, Switch } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
 import { CheckOutlined, CloseOutlined } from "@icons";
@@ -92,14 +93,14 @@ export function UserDrawer({ open, onClose, editingId }: UserDrawerProps) {
           payload.package_id = "" as unknown as string;
         }
         await update.mutateAsync({ id: editingId, input: payload });
-        message.success("User updated");
+        feedback.message.success("User updated");
       } else {
         await create.mutateAsync(values);
-        message.success("User created");
+        feedback.message.success("User created");
       }
       onClose();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -9,7 +9,8 @@
 // total stays correct per tab.
 import { useState } from "react";
 import { useTabParam } from "../../../hooks/useTabParam";
-import { Badge, Button, Card, Input, message, Segmented, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { Badge, Button, Card, Input, Segmented, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, EditOutlined, LoginOutlined, PauseCircleOutlined, PlayCircleOutlined, SafetyOutlined, SearchOutlined, TeamOutlined } from "@icons";
 import { RowActions, type RowAction } from "../../../components/RowActions";
 import { Link } from "react-router";
@@ -81,7 +82,7 @@ function UserRowActions({
       await startImpersonation(user.id);
       window.location.assign("/jabali-panel");
     } catch {
-      message.error(t("users.error.login_as"));
+      feedback.message.error(t("users.error.login_as"));
     }
   };
 

--- a/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
@@ -7,7 +7,8 @@
 // action modals and the dropdown items can use stock AntD styling.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import { Modal, message } from "antd";
+import { Modal } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -31,12 +32,12 @@ export const UserReset2FAAction = ({
     setIsLoading(true);
     try {
       await apiClient.post(`/admin/users/${encodeURIComponent(userId)}/2fa/reset`);
-      message.success(`Two-factor authentication reset for "${userEmail}"`);
+      feedback.message.success(`Two-factor authentication reset for "${userEmail}"`);
       onClose();
     } catch (err: unknown) {
       const errMsg =
         err instanceof Error ? err.message : "Failed to reset two-factor authentication";
-      message.error(errMsg);
+      feedback.message.error(errMsg);
     } finally {
       setIsLoading(false);
     }

--- a/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
@@ -5,7 +5,8 @@
 // parent (UserList RowActions) drives `open`.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import { Modal, Typography, message } from "antd";
+import { Modal, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -28,9 +29,9 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
         `/admin/users/${encodeURIComponent(userId)}/password/reset`,
       );
       setTempPassword(res.data.password);
-      message.success(`Password reset for "${userEmail}"`);
+      feedback.message.success(`Password reset for "${userEmail}"`);
     } catch (err: unknown) {
-      message.error(err instanceof Error ? err.message : "Failed to reset password");
+      feedback.message.error(err instanceof Error ? err.message : "Failed to reset password");
     } finally {
       setIsLoading(false);
     }

--- a/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
@@ -7,7 +7,8 @@
 // facing audit text visible on the row. Parent (UserList RowActions)
 // drives `open` via its dropdown menu.
 import { useState } from "react";
-import { Input, Modal, message } from "antd";
+import { Input, Modal } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -50,19 +51,19 @@ export const UserSuspendAction = ({
       }>(`/admin/users/${encodeURIComponent(userId)}/${endpoint}`, body);
       const data = res.data;
       if (suspended) {
-        message.success(
+        feedback.message.success(
           `Unsuspended "${userEmail}" — ${data.domains_enabled ?? 0} domain(s) re-enabled.`,
         );
       } else {
-        message.success(
+        feedback.message.success(
           `Suspended "${userEmail}" — ${data.domains_disabled ?? 0} domain(s) disabled.`,
         );
       }
       if (data.kratos_warning) {
-        message.warning(`Kratos: ${data.kratos_warning}`);
+        feedback.message.warning(`Kratos: ${data.kratos_warning}`);
       }
       if (data.domain_warning) {
-        message.warning(`Domains: ${data.domain_warning}`);
+        feedback.message.warning(`Domains: ${data.domain_warning}`);
       }
       qc.invalidateQueries({ queryKey: ["list", "users"] });
       handleClose();
@@ -73,7 +74,7 @@ export const UserSuspendAction = ({
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ??
         (err instanceof Error ? err.message : "Action failed");
-      message.error(errMsg);
+      feedback.message.error(errMsg);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Sweep batch 2 — admin shells (GH #970)

Completes the static-`message` → themed-`feedback` sweep started for the tenant shells (sibling PR #1024). This converts the remaining **40** admin-shell + shared-component screens.

### Why (recap)

`message.config` (#1014) unified toast **position/size/duration** globally, but AntD's **static** `message` renders *outside* the React tree, so it still ignores the `ConfigProvider` **theme + direction** — the light toast on a dark UI, wrong side in RTL. Routing through the App-scoped `feedback` bridge fixes both.

### Change

Purely mechanical, per file:
- drop the static `message` from the `antd` import,
- add `import { feedback } from ".../lib/feedback"`,
- prefix the call sites (`message.error` → `feedback.message.error`).

`err.message` is untouched. `Modal`/`<Modal>` and `notification` imports are left alone (none of these files make static `Modal.*`/`notification.*` calls). **No behaviour or copy change** → E2E selectors unaffected.

### Verification

- `tsc -b` green.
- vitest **221 tests** green.
- Post-sweep scan: **0** static `message.<toast>` callers remain across these files; none still import `message` from `antd`.

### Scope / after this

- `UserDatabaseList.tsx` stays with #1005 item-2 PR #1022 (would conflict); it folds in after that lands.
- With this + #1024, the static-`message` sweep is complete. `Modal.confirm`/`notification` static callers (a separate, smaller set) can be a later pass if wanted.

GH #970
