### PR TITLE
fix(ui): route static Modal.confirm + notification toasts through feedback (GH #970)

### DIFF
--- a/panel-ui/src/components/RowActions.tsx
+++ b/panel-ui/src/components/RowActions.tsx
@@ -4,7 +4,7 @@
 // icon. This keeps dense tables narrow and uniform across the whole panel — the
 // default shape for any row that has more than one action.
 //
-// Destructive actions pass `confirm` (a Modal.confirm pops before onClick), so
+// Destructive actions pass `confirm` (a feedback.modal.confirm pops before onClick), so
 // the menu can hold a Delete without nesting a Popconfirm inside the dropdown.
 //
 // Usage:
@@ -17,7 +17,8 @@
 //   ]} />
 
 import type { ReactNode } from "react";
-import { Dropdown, Modal, Space, Tooltip } from "antd";
+import { Dropdown, Space, Tooltip } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { MoreOutlined } from "@icons";
 import { RowActionButton } from "./RowActionButton";
 
@@ -36,7 +37,7 @@ export interface RowAction {
   hidden?: boolean;
   /** Tooltip for the first button (e.g. why it's disabled). */
   tooltip?: string;
-  /** When set, a Modal.confirm pops before onClick runs. */
+  /** When set, a feedback.modal.confirm pops before onClick runs. */
   confirm?: { title?: string; description?: ReactNode; okText?: string };
 }
 
@@ -45,7 +46,7 @@ function run(a: RowAction) {
     a.onClick?.();
     return;
   }
-  Modal.confirm({
+  feedback.modal.confirm({
     title: a.confirm.title ?? "Are you sure?",
     content: a.confirm.description,
     okText: a.confirm.okText ?? "OK",

--- a/panel-ui/src/hooks/useSecurityUfw.ts
+++ b/panel-ui/src/hooks/useSecurityUfw.ts
@@ -3,7 +3,7 @@
 //
 // Enable / disable POST bodies MUST include {"confirm":"YES"} —
 // returning 400 confirmation_required otherwise. The UI surfaces a
-// Modal.confirm with a typed YES gate before invoking these hooks.
+// feedback.modal.confirm with a typed YES gate before invoking these hooks.
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../apiClient";

--- a/panel-ui/src/shells/DomainIndexButton.tsx
+++ b/panel-ui/src/shells/DomainIndexButton.tsx
@@ -3,7 +3,8 @@
 // `index ...;` directives; see indexDirectiveFor() in the agent.
 import { useEffect, useState } from "react";
 import { FileTextOutlined, CheckOutlined } from "@icons";
-import { Button, Modal, Radio, Typography, notification } from "antd";
+import { Button, Modal, Radio, Typography } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../apiClient";
@@ -71,7 +72,7 @@ export const DomainIndexButton = ({
       await apiClient.patch(`/domains/${domain.id}`, {
         index_priority: value,
       });
-      notification.success({ message: "Index priority saved" });
+      feedback.notification.success({ message: "Index priority saved" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleClose();
@@ -80,7 +81,7 @@ export const DomainIndexButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to save",
         description: e.response?.data?.detail ?? e.message ?? "Unknown error",
       });

--- a/panel-ui/src/shells/DomainToggleButton.tsx
+++ b/panel-ui/src/shells/DomainToggleButton.tsx
@@ -4,7 +4,8 @@
 // disabled page (or the tenant's docroot) as appropriate.
 import { useState } from "react";
 import { PauseCircleOutlined, PlayCircleOutlined } from "@icons";
-import { Button, notification } from "antd";
+import { Button } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../apiClient";
@@ -26,13 +27,13 @@ export const DomainToggleButton = ({ domain }: { domain: DomainToggleTarget }) =
       await apiClient.patch(`/domains/${domain.id}`, {
         is_enabled: !domain.is_enabled,
       });
-      notification.success({
+      feedback.notification.success({
         message: domain.is_enabled ? "Domain disabled" : "Domain enabled",
       });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
     } catch (err) {
-      notification.error({
+      feedback.notification.error({
         message: "Failed to toggle",
         description: (err as Error).message,
       });

--- a/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
@@ -8,24 +8,8 @@
 // "Generate new key" inline action that calls the same endpoint with
 // POST.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Drawer,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Radio,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-  notification,
-} from "antd";
+import { Alert, Button, Drawer, Form, Input, InputNumber, Modal, Radio, Select, Space, Switch, Table, Tag, Typography, message } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../components/RowActions";
 import {
   CheckCircleOutlined,
@@ -228,7 +212,7 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
             resp.data.detail ? `Saved + tested OK — ${resp.data.detail}` : "Saved + tested OK",
           );
         } catch (testErr) {
-          notification.error({
+          feedback.notification.error({
             message: editing ? "Saved, but test failed" : "Created, but test failed",
             description: extractApiError(testErr, "Test failed"),
             duration: 0,
@@ -606,7 +590,7 @@ export function DestinationsTab() {
   }, []);
 
   const handleDelete = async (row: BackupDestination) => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: `Delete destination "${row.name}"?`,
       content:
         "Existing backups copied to this destination remain on the remote (panel does not " +
@@ -626,7 +610,7 @@ export function DestinationsTab() {
   };
 
   const handleRotatePassword = async (row: BackupDestination) => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: `Rotate restic password for "${row.name}"?`,
       content: (
         <div>
@@ -652,7 +636,7 @@ export function DestinationsTab() {
             password: string;
             password_rotated_at: string;
           }>(`/admin/backup-destinations/${row.id}/rotate-password`, {});
-          Modal.info({
+          feedback.modal.info({
             title: `New restic password — ${row.name}`,
             width: 560,
             content: (

--- a/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
+++ b/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
@@ -1,26 +1,8 @@
 // M30.1 Schedules admin tab. Lists every backup_schedules row, drawer
 // for create/edit, multi-select destinations, "Run now" button.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Drawer,
-  Form,
-  InputNumber,
-  Modal,
-  Radio,
-  Segmented,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  TimePicker,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Checkbox, Drawer, Form, InputNumber, Radio, Segmented, Select, Space, Switch, Table, Tag, TimePicker, Tooltip, Typography, message } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../components/RowActions";
 import { shortDateTime } from "../../../utils/datetime";
 import dayjs, { type Dayjs } from "dayjs";
@@ -502,7 +484,7 @@ export function SchedulesTab() {
   }, []);
 
   const handleDelete = async (row: BackupSchedule) => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: `Delete schedule?`,
       content: `Backups already produced by this schedule remain. Future runs will not fire.`,
       okType: "danger",

--- a/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/AdminDockerAppsPage.tsx
@@ -1,7 +1,8 @@
 // AdminDockerAppsPage — landing page for the M48 marketplace.
 // Two tabs: Catalog (browse + install) and Installed (lifecycle).
 import { useTranslation } from "react-i18next";
-import { Alert, App, Avatar, Button, Col, Drawer, Empty, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { Alert, App, Avatar, Button, Col, Drawer, Empty, Input, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useTabParam } from "../../../hooks/useTabParam";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { humanBytes } from "../../../utils/bytes";
@@ -384,7 +385,7 @@ export const AdminDockerAppsPage = () => {
                     render: (_, r) => {
                       const running = r.status === "running";
                       const confirmDelete = () =>
-                        Modal.confirm({
+                        feedback.modal.confirm({
                           title: `Uninstall ${r.name}?`,
                           content: "Volumes will be purged. This cannot be undone.",
                           okText: "Uninstall",

--- a/panel-ui/src/shells/admin/docker-apps/MaintenanceTab.tsx
+++ b/panel-ui/src/shells/admin/docker-apps/MaintenanceTab.tsx
@@ -2,7 +2,8 @@
 // volumes / build cache. Backed by docker.disk_usage + docker.prune
 // agent verbs (see panel-agent/internal/commands/docker_lifecycle.go).
 import { useTranslation } from "react-i18next";
-import { App, Button, Card, Col, Modal, Row, Space, Statistic, Switch, Typography } from "antd";
+import { App, Button, Card, Col, Row, Space, Statistic, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -67,7 +68,7 @@ export const MaintenanceTab = () => {
   });
 
   const confirmPrune = () => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: "Run docker prune?",
       content: (
         <div>

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -3,7 +3,8 @@
 // "..." overflow with Info/Redirects/Index/Settings/Caching/Toggle/Delete.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import { Button, Card, Dropdown, Modal, Space, Table, Tag, Tooltip, Typography, notification } from "antd";
+import { Button, Card, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   DeleteOutlined,
   MoreOutlined,
@@ -211,11 +212,11 @@ export const DomainList = () => {
     setTogglingId(r.id);
     try {
       await apiClient.patch(`/domains/${r.id}`, { is_enabled: !r.is_enabled });
-      notification.success({ message: r.is_enabled ? "Domain disabled" : "Domain enabled" });
+      feedback.notification.success({ message: r.is_enabled ? "Domain disabled" : "Domain enabled" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", r.id] });
     } catch (err) {
-      notification.error({ message: "Failed to toggle", description: (err as Error).message });
+      feedback.notification.error({ message: "Failed to toggle", description: (err as Error).message });
     } finally {
       setTogglingId(null);
     }
@@ -447,7 +448,7 @@ export const DomainList = () => {
                               label: "Delete",
                               danger: true,
                               onClick: () =>
-                                Modal.confirm({
+                                feedback.modal.confirm({
                                   title: `Delete domain "${r.name}"?`,
                                   okText: "Delete",
                                   okButtonProps: { danger: true },

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -20,26 +20,8 @@
 // migrating it into the wizard is M35.2 work.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Tag,
-  Collapse,
-  Select,
-  Drawer,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Radio,
-  Card,
-  Space,
-  Spin,
-  Steps,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Checkbox, Tag, Collapse, Select, Drawer, Form, Input, InputNumber, Radio, Card, Space, Spin, Steps, Typography, message } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -278,7 +260,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
       // existing draft" action instead of dead-ending the operator.
       if (resp?.error === "host_user_kind_in_use" && resp.existing_job_id && draftId) {
         const existing = resp.existing_job_id;
-        Modal.confirm({
+        feedback.modal.confirm({
           title: "An existing draft already owns this source",
           content:
             "A migration job is already configured for this (host, user, source kind). Switch to that draft and discard the new one?",
@@ -373,7 +355,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
     },
     onSuccess: (data) => {
       if (data?.next_step === "upload_tarball") {
-        Modal.info({
+        feedback.modal.info({
           title: "Migration submitted — manual upload required",
           width: 560,
           content: (

--- a/panel-ui/src/shells/admin/php/VersionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/VersionsTab.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Alert, notification, Spin, Table, Tag, Tooltip } from "antd";
+import { Alert, Spin, Table, Tag, Tooltip } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   CheckCircleOutlined,
   DeleteOutlined,
@@ -52,7 +53,7 @@ export const VersionsTab = () => {
       );
       setStatusData(response.data);
     } catch (error) {
-      notification.error({
+      feedback.notification.error({
         message: "Failed to fetch PHP versions",
         description: extractApiError(error, "Unknown error occurred"),
         duration: 5,
@@ -75,7 +76,7 @@ export const VersionsTab = () => {
       while (true) {
         await new Promise((r) => setTimeout(r, 5000));
         if (Date.now() > deadline) {
-          notification.warning({
+          feedback.notification.warning({
             message: `PHP ${version} is still installing`,
             description:
               "The install is taking longer than expected; it will continue in the background. Refresh to check.",
@@ -92,7 +93,7 @@ export const VersionsTab = () => {
         const v = st.data.versions.find((x) => x.version === version);
         if (v?.installed) {
           setStatusData(st.data);
-          notification.success({
+          feedback.notification.success({
             message: `PHP ${version} installed successfully`,
             duration: 3,
           });
@@ -100,7 +101,7 @@ export const VersionsTab = () => {
         }
       }
     } catch (error) {
-      notification.error({
+      feedback.notification.error({
         message: `Failed to install PHP ${version}`,
         description: extractApiError(error, "Installation failed"),
         duration: 5,
@@ -118,13 +119,13 @@ export const VersionsTab = () => {
       await apiClient.delete(`/admin/php/versions/${version}`, {
         timeout: 5 * 60 * 1000,
       });
-      notification.success({
+      feedback.notification.success({
         message: `PHP ${version} uninstalled`,
         duration: 3,
       });
       await fetchStatus();
     } catch (error) {
-      notification.error({
+      feedback.notification.error({
         message: `Failed to uninstall PHP ${version}`,
         description: extractApiError(error, "Uninstall failed"),
         duration: 5,
@@ -138,14 +139,14 @@ export const VersionsTab = () => {
     setReloadingVersion(version);
     try {
       await apiClient.post(`/admin/php/versions/${version}/reload`);
-      notification.success({
+      feedback.notification.success({
         message: `PHP ${version} reloaded successfully`,
         duration: 3,
       });
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Reload failed";
-      notification.error({
+      feedback.notification.error({
         message: `Failed to reload PHP ${version}`,
         description: errorMsg,
         duration: 5,
@@ -159,7 +160,7 @@ export const VersionsTab = () => {
     setSettingDefaultVersion(version);
     try {
       await apiClient.post(`/admin/php/versions/${version}/default`);
-      notification.success({
+      feedback.notification.success({
         message: `PHP ${version} is now the default`,
         duration: 3,
       });
@@ -169,7 +170,7 @@ export const VersionsTab = () => {
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Request failed";
-      notification.error({
+      feedback.notification.error({
         message: `Could not set PHP ${version} as default`,
         description: errorMsg,
         duration: 5,

--- a/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
@@ -4,24 +4,8 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  Alert,
-  Descriptions,
-  Drawer,
-  Button,
-  Card,
-  Input,
-  Modal,
-  Popconfirm,
-  Radio,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Descriptions, Drawer, Button, Card, Input, Modal, Popconfirm, Radio, Space, Switch, Table, Tag, Tooltip, Typography, message } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import {
   type SnuffleupagusIncident,
@@ -124,7 +108,7 @@ export function AdminSecuritySnuffleupagus() {
             onChange={(e) => {
               const next = e.target.value as SnuffleupagusMode;
               if (next === "enforce") {
-                Modal.confirm({
+                feedback.modal.confirm({
                   title: "Switch PHP Defense to enforce mode?",
                   content:
                     "Tenant requests that match a hardening rule will be blocked. Run a soak in simulation first if you haven't already.",

--- a/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
@@ -3,28 +3,12 @@
 // typed-YES Modal gate.
 //
 // Conventions: Drawer (not Modal) for create per CONVENTIONS.md.
-// Tables consume <Table.Column> children. Modal.confirm stays for the
+// Tables consume <Table.Column> children. feedback.modal.confirm stays for the
 // enable/disable typed-YES gate — that's a destructive confirmation,
 // not a create form, so it's the right antd primitive.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Drawer,
-  Empty,
-  Form,
-  Grid,
-  Input,
-  message,
-  Modal,
-  Popconfirm,
-  Select,
-  Space,
-  Table,
-  Tag,
-  Typography,
-} from "antd";
+import { Alert, Button, Card, Drawer, Empty, Form, Grid, Input, message, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 
 import { DeleteOutlined } from "@icons";
@@ -110,7 +94,7 @@ export const AdminSecurityUfw = () => {
 
   const openToggleModal = (enable: boolean) => {
     let typed = "";
-    Modal.confirm({
+    feedback.modal.confirm({
       title: enable ? "Enable firewall" : "Disable firewall",
       content: (
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>

--- a/panel-ui/src/shells/admin/settings/DatabasesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DatabasesCard.tsx
@@ -20,18 +20,8 @@ import {
   ExclamationCircleOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
-import {
-  Alert,
-  Button,
-  Card,
-  Modal,
-  Skeleton,
-  Space,
-  Switch,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Skeleton, Space, Switch, Tag, Typography, message } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
@@ -142,7 +132,7 @@ export function DatabasesCard() {
   };
 
   const handleUninstall = () => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: "Uninstall PostgreSQL?",
       icon: <ExclamationCircleOutlined />,
       content:

--- a/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Card, Switch, Tag, Typography, notification } from "antd";
+import { Card, Switch, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -19,7 +20,7 @@ export const Dkim2ToggleCard = () => {
         const resp = await apiClient.get<{ dkim2_signing_enabled?: boolean }>("/admin/settings");
         if (!cancelled) setEnabled(resp.data.dkim2_signing_enabled === true);
       } catch {
-        if (!cancelled) notification.error({ message: "Failed to load DKIM2 setting" });
+        if (!cancelled) feedback.notification.error({ message: "Failed to load DKIM2 setting" });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -34,14 +35,14 @@ export const Dkim2ToggleCard = () => {
     try {
       await apiClient.patch("/admin/settings", { dkim2_signing_enabled: next });
       setEnabled(next);
-      notification.success({
+      feedback.notification.success({
         message: next ? "DKIM2 signing enabled" : "DKIM2 signing disabled",
         description: next
           ? "Every mail domain gets a DKIM2 signature on the next reconcile — no DNS changes needed."
           : "DKIM2 signatures are being removed; classic DKIM keeps signing.",
       });
     } catch {
-      notification.error({ message: "Failed to update DKIM2 setting" });
+      feedback.notification.error({ message: "Failed to update DKIM2 setting" });
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DockerMarketplaceCard.tsx
@@ -6,7 +6,8 @@
 // Flip false: panel-api dispatches `docker.disable` (stops + disables
 //   docker units). Data under /var/lib/jabali/docker-apps/ stays.
 import { useTranslation } from "react-i18next";
-import { App, Alert, Button, Card, Checkbox, Modal, Space, Spin, Switch, Tag, Typography } from "antd";
+import { App, Alert, Button, Card, Checkbox, Space, Spin, Switch, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
@@ -163,7 +164,7 @@ export function DockerMarketplaceCard() {
 
   const onToggleForUsers = (v: boolean) => {
     if (v) {
-      Modal.confirm({
+      feedback.modal.confirm({
         title: "Enable Docker Apps for users?",
         okText: "Enable",
         okButtonProps: { danger: true },

--- a/panel-ui/src/shells/admin/settings/FreeHostnameCard.tsx
+++ b/panel-ui/src/shells/admin/settings/FreeHostnameCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Alert, Button, Card, Form, Input, Space, Tag, Typography, notification } from "antd";
+import { Alert, Button, Card, Form, Input, Space, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -45,9 +46,9 @@ export const FreeHostnameCard = () => {
     try {
       await apiClient.post("/admin/settings/free-hostname/register", { email: email.trim() });
       setStep("code_sent");
-      notification.success({ message: `Verification code sent to ${email.trim()}` });
+      feedback.notification.success({ message: `Verification code sent to ${email.trim()}` });
     } catch (e: unknown) {
-      notification.error({ message: errText(e, "Could not send the code") });
+      feedback.notification.error({ message: errText(e, "Could not send the code") });
     } finally {
       setSending(false);
     }
@@ -63,13 +64,13 @@ export const FreeHostnameCard = () => {
       setHostname(resp.data.fqdn);
       setStep("idle");
       setCode("");
-      notification.success({
+      feedback.notification.success({
         message: `Hostname activated: ${resp.data.fqdn}`,
         description:
           "DNS + TLS are provisioning. The panel URL will change to the new hostname shortly.",
       });
     } catch (e: unknown) {
-      notification.error({ message: errText(e, "Could not claim the hostname") });
+      feedback.notification.error({ message: errText(e, "Could not claim the hostname") });
     } finally {
       setClaiming(false);
     }

--- a/panel-ui/src/shells/admin/settings/ModulesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/ModulesCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useRef, useState } from "react";
-import { Button, Card, Space, Spin, Switch, Tag, Typography, notification } from "antd";
+import { Button, Card, Space, Spin, Switch, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { ReloadOutlined } from "@ant-design/icons";
 
 import { apiClient } from "../../../apiClient";
@@ -82,7 +83,7 @@ export const ModulesCard = () => {
           });
         }
       } catch {
-        if (mounted.current) notification.error({ message: "Failed to load module settings" });
+        if (mounted.current) feedback.notification.error({ message: "Failed to load module settings" });
       } finally {
         if (mounted.current) setLoading(false);
       }
@@ -118,7 +119,7 @@ export const ModulesCard = () => {
       await apiClient.patch("/admin/settings", { [key]: next });
       setState((prev) => ({ ...prev, [key]: next }));
       const statusKey = STATUS_KEY[key];
-      notification.success({
+      feedback.notification.success({
         message: `${label} ${next ? "enabled" : "disabled"}`,
         description:
           next && statusKey
@@ -129,7 +130,7 @@ export const ModulesCard = () => {
       });
       if (next && statusKey) void pollUntilUp(statusKey);
     } catch {
-      notification.error({ message: `Failed to update ${label}` });
+      feedback.notification.error({ message: `Failed to update ${label}` });
     } finally {
       setSaving(null);
     }
@@ -138,10 +139,10 @@ export const ModulesCard = () => {
   const onRetry = async (statusKey: string, label: string) => {
     try {
       await apiClient.post("/admin/settings/modules/install", { key: statusKey });
-      notification.info({ message: `Reinstalling ${label}…` });
+      feedback.notification.info({ message: `Reinstalling ${label}…` });
       void pollUntilUp(statusKey);
     } catch {
-      notification.error({ message: `Failed to start install for ${label}` });
+      feedback.notification.error({ message: `Failed to start install for ${label}` });
     }
   };
 

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -17,29 +17,12 @@ import {
   AppstoreOutlined,
   ToolOutlined,
 } from "@icons";
-import {
-  Alert,
-  Button,
-  Card,
-  Col,
-  Divider,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Row,
-  Grid,
-  Select,
-  Space,
-  Switch,
-  Tabs,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Button, Card, Col, Divider, Form, Input, InputNumber, Row, Grid, Select, Space, Switch, Tabs, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 // Post-M21 notify shim: matches the Refine useNotification().open
 // contract (`{ type, message, description }`) so callers don't have
-// to change. Forwards to AntD's native `notification.open`.
+// to change. Forwards to AntD's native `feedback.notification.open`.
 type NotifyInput = {
   type?: "success" | "error" | "warning" | "info";
   message: string;
@@ -47,7 +30,7 @@ type NotifyInput = {
 };
 function useNotify() {
   return (input: NotifyInput) => {
-    notification.open({
+    feedback.notification.open({
       message: input.message,
       description: input.description,
       type: input.type,
@@ -940,7 +923,7 @@ const SSHSettingsTab = () => {
               currentSSHUserPasswordAuth !== originalSSHUserPasswordAuth;
 
             if (sshPortChanged || sshAuthChanged || sshUserAuthChanged) {
-              Modal.confirm({
+              feedback.modal.confirm({
                 title: "Confirm SSH Configuration Change",
                 content: (
                   <Alert

--- a/panel-ui/src/shells/admin/settings/StalwartWebadminCard.tsx
+++ b/panel-ui/src/shells/admin/settings/StalwartWebadminCard.tsx
@@ -4,6 +4,7 @@
 // this is the only door. Default off. Lives on the Server Settings → Email tab.
 import { useTranslation } from "react-i18next";
 import { App, Alert, Button, Card, Input, Modal, Space, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { apiClient } from "../../../apiClient";
@@ -65,7 +66,7 @@ export function StalwartWebadminCard() {
 
   const onToggle = (val: boolean) => {
     if (val) {
-      Modal.confirm({
+      feedback.modal.confirm({
         title: "Expose the Stalwart WebAdmin to the internet?",
         okText: "Enable",
         okButtonProps: { danger: true },
@@ -119,7 +120,7 @@ export function StalwartWebadminCard() {
   };
 
   const confirmRotateAdmin = () =>
-    Modal.confirm({
+    feedback.modal.confirm({
       title: "Rotate the Stalwart admin password?",
       okText: "Rotate",
       okButtonProps: { danger: true },

--- a/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Card, Switch, Typography, notification } from "antd";
+import { Card, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -25,7 +26,7 @@ export const TenantDomainOptionsCard = () => {
           setDocroot(resp.data.tenant_docroot_editable !== false);
         }
       } catch {
-        if (!cancelled) notification.error({ message: "Failed to load tenant domain options setting" });
+        if (!cancelled) feedback.notification.error({ message: "Failed to load tenant domain options setting" });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -40,9 +41,9 @@ export const TenantDomainOptionsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_domain_options_enabled: next });
       setEnabled(next);
-      notification.success({ message: next ? "Tenant domain options enabled" : "Tenant domain options disabled" });
+      feedback.notification.success({ message: next ? "Tenant domain options enabled" : "Tenant domain options disabled" });
     } catch {
-      notification.error({ message: "Failed to update setting" });
+      feedback.notification.error({ message: "Failed to update setting" });
     } finally {
       setSaving(false);
     }
@@ -53,9 +54,9 @@ export const TenantDomainOptionsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_docroot_editable: next });
       setDocroot(next);
-      notification.success({ message: next ? "Tenant document-root editing enabled" : "Tenant document-root editing disabled" });
+      feedback.notification.success({ message: next ? "Tenant document-root editing enabled" : "Tenant document-root editing disabled" });
     } catch {
-      notification.error({ message: "Failed to update setting" });
+      feedback.notification.error({ message: "Failed to update setting" });
     } finally {
       setSavingDocroot(false);
     }

--- a/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Alert, Card, Select, Space, Switch, Typography, notification } from "antd";
+import { Alert, Card, Select, Space, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 import { kindLabels, type ChannelKind } from "../notifications/channelKindConfig";
@@ -44,7 +45,7 @@ export const TenantNotificationsCard = () => {
           setKinds(resp.data.tenant_notification_kinds ?? []);
         }
       } catch {
-        if (!cancelled) notification.error({ message: "Failed to load notification settings" });
+        if (!cancelled) feedback.notification.error({ message: "Failed to load notification settings" });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -59,9 +60,9 @@ export const TenantNotificationsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_notifications_enabled: next });
       setEnabled(next);
-      notification.success({ message: next ? "Tenant notifications enabled" : "Tenant notifications disabled" });
+      feedback.notification.success({ message: next ? "Tenant notifications enabled" : "Tenant notifications disabled" });
     } catch {
-      notification.error({ message: "Failed to update setting" });
+      feedback.notification.error({ message: "Failed to update setting" });
     } finally {
       setSavingToggle(false);
     }
@@ -75,9 +76,9 @@ export const TenantNotificationsCard = () => {
       });
       // The server sanitizes (drops unknown kinds) and returns the effective set.
       setKinds(resp.data.tenant_notification_kinds ?? next);
-      notification.success({ message: "Allowed channel kinds updated" });
+      feedback.notification.success({ message: "Allowed channel kinds updated" });
     } catch {
-      notification.error({ message: "Failed to update allowed kinds" });
+      feedback.notification.error({ message: "Failed to update allowed kinds" });
     } finally {
       setSavingKinds(false);
     }

--- a/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Card, Switch, Typography, notification } from "antd";
+import { Card, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 
@@ -20,7 +21,7 @@ export const WebmailToggleCard = () => {
         const resp = await apiClient.get<{ webmail_enabled?: boolean }>("/admin/settings");
         if (!cancelled) setEnabled(resp.data.webmail_enabled !== false);
       } catch {
-        if (!cancelled) notification.error({ message: "Failed to load webmail setting" });
+        if (!cancelled) feedback.notification.error({ message: "Failed to load webmail setting" });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -35,14 +36,14 @@ export const WebmailToggleCard = () => {
     try {
       await apiClient.patch("/admin/settings", { webmail_enabled: next });
       setEnabled(next);
-      notification.success({
+      feedback.notification.success({
         message: next ? "Webmail enabled" : "Webmail disabled",
         description: next
           ? "The webmail vhosts will be (re)served on the next reconcile."
           : "Webmail vhosts are being torn down and the webmail service stopped.",
       });
     } catch {
-      notification.error({ message: "Failed to update webmail setting" });
+      feedback.notification.error({ message: "Failed to update webmail setting" });
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/user/MyProfile.tsx
+++ b/panel-ui/src/shells/user/MyProfile.tsx
@@ -8,20 +8,8 @@
 // sees `?flow=<id>` it fetches the flow and renders the Kratos node
 // tree inline inside the Security card — no extra page, no extra tab.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Descriptions,
-  Form,
-  Input,
-  Modal,
-  Space,
-  Spin,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Descriptions, Form, Input, Space, Spin, Typography, message } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
@@ -381,7 +369,7 @@ function PasskeySettingsCard({
                   danger
                   size="small"
                   onClick={() =>
-                    Modal.confirm({
+                    feedback.modal.confirm({
                       title: "Remove this passkey?",
                       content:
                         "This device or key will no longer be able to sign you in. If it's your only passkey, make sure you still know your password.",
@@ -469,7 +457,7 @@ function WebauthnSettingsCard({
                   danger
                   size="small"
                   onClick={() =>
-                    Modal.confirm({
+                    feedback.modal.confirm({
                       title: "Remove this security key?",
                       content:
                         "This key will no longer work as your second factor. If it's your only 2FA method, you'll sign in with just your password until you add another.",
@@ -627,7 +615,7 @@ function SettingsGroupForm({ flow, group, onSubmit }: GroupFormProps) {
                         onPress();
                         return;
                       }
-                      Modal.confirm({
+                      feedback.modal.confirm({
                         title: confirmTitle(f.name),
                         content: confirmBody(f.name),
                         okText: "Yes, disable",

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -18,7 +18,8 @@ import {
   ToolOutlined,
   FolderOutlined,
 } from "@icons";
-import { Button, Card, Dropdown, Modal, Space, Table, Tag, Tooltip, Typography, notification } from "antd";
+import { Button, Card, Dropdown, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import type { SorterResult } from "antd/es/table/interface";
@@ -387,7 +388,7 @@ export const UserDomainList = () => {
                             await apiClient.patch(`/domains/${r.id}`, {
                               temp_url_enabled: !r.temp_url_enabled,
                             });
-                            notification.success({
+                            feedback.notification.success({
                               message: r.temp_url_enabled
                                 ? "Preview URL disabled"
                                 : "Preview URL enabled — live within a minute",
@@ -395,7 +396,7 @@ export const UserDomainList = () => {
                             qc.invalidateQueries({ queryKey: ["list", "domains"] });
                           } catch (err) {
                             const e = err as { response?: { data?: { detail?: string; error?: string } } };
-                            notification.error({
+                            feedback.notification.error({
                               message: "Failed to toggle preview URL",
                               description: e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message,
                             });
@@ -413,13 +414,13 @@ export const UserDomainList = () => {
                             await apiClient.patch(`/domains/${r.id}`, {
                               is_enabled: !r.is_enabled,
                             });
-                            notification.success({
+                            feedback.notification.success({
                               message: r.is_enabled ? "Domain disabled" : "Domain enabled",
                             });
                             qc.invalidateQueries({ queryKey: ["list", "domains"] });
                             qc.invalidateQueries({ queryKey: ["one", "domains", r.id] });
                           } catch (err) {
-                            notification.error({
+                            feedback.notification.error({
                               message: "Failed to toggle",
                               description: (err as Error).message,
                             });
@@ -435,7 +436,7 @@ export const UserDomainList = () => {
                         icon: <DeleteOutlined />,
                         danger: true,
                         onClick: () =>
-                          Modal.confirm({
+                          feedback.modal.confirm({
                             title: `Delete domain "${r.name}"?`,
                             content: "This cannot be undone.",
                             okText: "Delete",

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -19,26 +19,8 @@ import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
-import {
-  Breadcrumb,
-  Button,
-  Card,
-  Drawer,
-  Dropdown,
-  Empty,
-  Grid,
-  Input,
-  Modal,
-  Space,
-  Spin,
-  Table,
-  Tag,
-  Tooltip,
-  Tree,
-  Typography,
-  message,
-  theme,
-} from "antd";
+import { Breadcrumb, Button, Card, Drawer, Dropdown, Empty, Grid, Input, Modal, Space, Spin, Table, Tag, Tooltip, Tree, Typography, message, theme } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { DataNode } from "antd/es/tree";
 import {
   DeleteOutlined,
@@ -590,7 +572,7 @@ export const FileManagerPage = () => {
   };
 
   const confirmDelete = (entry: FileEntry) => {
-    Modal.confirm({
+    feedback.modal.confirm({
       title: `Delete "${entry.name}"?`,
       content: entry.is_dir ? "Folder and everything inside will be removed." : undefined,
       okText: "Delete",
@@ -818,7 +800,7 @@ export const FileManagerPage = () => {
   const handleBulkDelete = useCallback(() => {
     if (selectedPaths.length === 0) return;
     const anyDir = selectedEntries.some((e) => e.is_dir);
-    Modal.confirm({
+    feedback.modal.confirm({
       title: `Delete ${selectedPaths.length} item${selectedPaths.length === 1 ? "" : "s"}?`,
       content: anyDir
         ? "Folders will be removed with everything inside them. This cannot be undone."

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -5,19 +5,8 @@
 // client-side and provides password rotation, SSO mint, and delete actions.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  Empty,
-  Form,
-  Modal,
-  Progress,
-  Skeleton,
-  Space,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Button, Empty, Form, Modal, Progress, Skeleton, Space, Tag, Tooltip, Typography, message } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../../components/RowActions";
 import { SearchableTableStringQ } from "../../../../components/SearchableTable";
 import {
@@ -462,7 +451,7 @@ export const MailboxesTab = () => {
                     icon: <DeleteOutlined />,
                     danger: true,
                     onClick: () => {
-                      Modal.confirm({
+                      feedback.modal.confirm({
                         title: `Delete ${row.email}?`,
                         content: "All mail in this mailbox will be removed. This cannot be undone.",
                         okText: "Delete",


### PR DESCRIPTION
## Sweep batch 3 — static Modal + notification (GH #970)

Final batch of the #970 toast sweep. Converts the remaining **static `Modal.confirm`/`Modal.info`… dialogs** and **static `notification.*` toasts** (27 files) to the theme-aware `feedback` bridge.

### Why

Same root cause as the `message` batches: AntD's static `Modal.*` and `notification.*` render *outside* the React tree, so they ignore the `ConfigProvider` theme + direction. `feedback.modal.*` / `feedback.notification.*` are the App-scoped, themed, RTL-correct instances.

Includes the shared **`RowActions`** confirm dialog — used across the panel — so every row-level "are you sure?" is themed in one change.

### Change

Mechanical, per file:
- `Modal.confirm(` → `feedback.modal.confirm(`, `notification.error(` → `feedback.notification.error(`, etc.
- drop `notification` (import-only static singleton) from the `antd` import;
- drop `Modal` **only** where no `<Modal>` component / type / `useModal` usage remains (kept where the component is still used);
- add the `feedback` import.

`err.message` / `(err as Error).message` untouched. **No behaviour or copy change** → E2E selectors unaffected.

### Verification

- `tsc -b` green (incl. no unused-import errors — the 6 files where `Modal` became unused had it removed).
- vitest **221 tests** green.
- Post-sweep scan: **0** static `notification.<m>` and **0** static `Modal.<method>` callers remain in the changed files.

### Scope — sweep complete

With **#1024** (7 tenant `message`) and **#1027** (40 admin `message`), the static-toast sweep for #970 is now complete. `UserDatabaseList.tsx` still rides #1005 item-2 PR #1022 (excluded to avoid a conflict); it folds in after that lands.

GH #970
