### PR TITLE
feat(mail-stats): per-domain traffic drilldown (GH #873 round 3)

### DIFF
--- a/panel-agent/internal/commands/mail_stats_domain.go
+++ b/panel-agent/internal/commands/mail_stats_domain.go
@@ -1,0 +1,161 @@
+package commands
+
+// mail.stats_domain_sample — per-domain mail TRAFFIC counts for the round-3
+// statistics drilldown (GH #873).
+//
+// Stalwart's Prometheus exporter only exposes server-WIDE counters (that is
+// what mail.stats_sample scrapes). Per-domain traffic isn't in the metrics at
+// all, so this verb derives it from the delivery log the mail-logs feature
+// already parses. It is deliberately stateless: the panel drives the window by
+// passing `since` (the timestamp of its last domain sample); this handler
+// counts the events in (since, now] and returns them as deltas, plus the `now`
+// it used so the panel can advance its watermark with no gap or overlap.
+//
+// Only LOCAL domains are counted — the panel passes its domain set in
+// `local_domains`; a message to/from a remote domain contributes nothing, so
+// the store never bloats with third-party domains.
+//
+// Admin-only for now (per GH #873 round-3 scope): the panel keeps this behind
+// RequireAdmin. Per-user and tenant-scoped views are a later round.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type mailStatsDomainArgs struct {
+	// Since is the RFC3339 lower bound (exclusive). Empty → last 15 minutes.
+	Since string `json:"since"`
+	// LocalDomains is the set of panel-managed domains to attribute traffic to.
+	LocalDomains []string `json:"local_domains"`
+}
+
+// mailStatsDomainCount is one (domain, metric) delta for the window.
+type mailStatsDomainCount struct {
+	Domain string `json:"domain"`
+	Metric string `json:"metric"` // sent | received | delivered | failed
+	Count  int64  `json:"count"`
+}
+
+type mailStatsDomainResponse struct {
+	// SampledAt is the upper bound of the counted window (RFC3339, UTC). The
+	// panel stores the counts at this time and uses it as the next `since`.
+	SampledAt string                 `json:"sampled_at"`
+	Counts    []mailStatsDomainCount `json:"counts"`
+}
+
+// domainStatMaxLookback caps how far back a single sample will parse, so a
+// long panel downtime (stale watermark) can't make one tick walk months of
+// rotated logs. Traffic older than this is simply not backfilled.
+const domainStatMaxLookback = 48 * time.Hour
+
+func mailStatsDomainSampleHandler(_ context.Context, raw json.RawMessage) (any, error) {
+	var args mailStatsDomainArgs
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "bad mail.stats_domain_sample args: " + err.Error()}
+		}
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-15 * time.Minute)
+	if args.Since != "" {
+		if t, err := time.Parse(time.RFC3339, args.Since); err == nil {
+			since = t.UTC()
+		}
+	}
+	if since.Before(now.Add(-domainStatMaxLookback)) {
+		since = now.Add(-domainStatMaxLookback)
+	}
+
+	local := make(map[string]bool, len(args.LocalDomains))
+	for _, d := range args.LocalDomains {
+		d = strings.ToLower(strings.TrimSpace(d))
+		if d != "" {
+			local[d] = true
+		}
+	}
+
+	// counts[domain][metric] = n; seen dedupes an event line's contribution so
+	// a message with two recipients in one domain counts that domain once.
+	counts := map[string]map[string]int64{}
+	seen := map[string]bool{}
+	bump := func(domain, metric, qid string) {
+		if domain == "" || !local[domain] {
+			return
+		}
+		key := metric + "|" + domain + "|" + qid
+		if qid != "" {
+			if seen[key] {
+				return
+			}
+			seen[key] = true
+		}
+		m := counts[domain]
+		if m == nil {
+			m = map[string]int64{}
+			counts[domain] = m
+		}
+		m[metric]++
+	}
+
+	for _, path := range mailLogFiles() {
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			p, ok := parseMailLogLine(sc.Text())
+			if !ok || !p.ts.After(since) || p.ts.After(now) {
+				continue
+			}
+			switch {
+			case p.queued:
+				bump(domainOfAddr(p.entry.From), "sent", p.queueID)
+				for _, r := range p.recipients {
+					bump(domainOfAddr(r), "received", p.queueID)
+				}
+			case p.rank == 2: // delivery.completed
+				for _, r := range p.recipients {
+					bump(domainOfAddr(r), "delivered", p.queueID)
+				}
+			case p.rank == 1: // delivery.failed
+				for _, r := range p.recipients {
+					bump(domainOfAddr(r), "failed", p.queueID)
+				}
+			}
+		}
+		f.Close()
+	}
+
+	out := make([]mailStatsDomainCount, 0, len(counts))
+	for domain, metrics := range counts {
+		for metric, n := range metrics {
+			out = append(out, mailStatsDomainCount{Domain: domain, Metric: metric, Count: n})
+		}
+	}
+	return mailStatsDomainResponse{SampledAt: now.Format(time.RFC3339), Counts: out}, nil
+}
+
+// domainOfAddr returns the lowercased domain part of an email address, or ""
+// when the address has no "@".
+func domainOfAddr(addr string) string {
+	addr = strings.TrimSpace(strings.Trim(addr, `"`))
+	at := strings.LastIndexByte(addr, '@')
+	if at < 0 || at == len(addr)-1 {
+		return ""
+	}
+	return strings.ToLower(addr[at+1:])
+}
+
+func init() {
+	Default.Register("mail.stats_domain_sample", mailStatsDomainSampleHandler)
+}

--- a/panel-agent/internal/commands/mail_stats_domain.go
+++ b/panel-agent/internal/commands/mail_stats_domain.go
@@ -106,6 +106,13 @@ func mailStatsDomainSampleHandler(_ context.Context, raw json.RawMessage) (any, 
 	}
 
 	for _, path := range mailLogFiles() {
+		// Skip rotated files whose newest line predates the window — bounds the
+		// per-tick work to the current (and any in-window) log instead of
+		// re-parsing every archived file forever. mtime is the last append, so
+		// mtime < since means no line in this file is in (since, now].
+		if fi, serr := os.Stat(path); serr == nil && fi.ModTime().Before(since) {
+			continue
+		}
 		f, err := os.Open(path)
 		if err != nil {
 			continue

--- a/panel-agent/internal/commands/mail_stats_domain_test.go
+++ b/panel-agent/internal/commands/mail_stats_domain_test.go
@@ -1,0 +1,93 @@
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// dline builds a Stalwart delivery-tracer log line parseMailLogLine understands.
+func dline(ts time.Time, event, from string, to []string, qid string) string {
+	quoted := make([]string, len(to))
+	for i, r := range to {
+		quoted[i] = `"` + r + `"`
+	}
+	return ts.UTC().Format(time.RFC3339) + ` INFO msg (` + event + `) queueId = ` + qid +
+		`, from = "` + from + `", to = [` + strings.Join(quoted, ", ") + `], size = 10, total = 1`
+}
+
+func runDomainSample(t *testing.T, since time.Time, local []string) map[string]int64 {
+	t.Helper()
+	resp, err := mailStatsDomainSampleHandler(context.Background(),
+		mustJSON(t, map[string]any{"since": since.UTC().Format(time.RFC3339), "local_domains": local}))
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	out := map[string]int64{}
+	for _, c := range resp.(mailStatsDomainResponse).Counts {
+		out[c.Metric+"|"+c.Domain] = c.Count
+	}
+	return out
+}
+
+func TestMailStatsDomain_AttributesSentReceivedDeliveredFailed(t *testing.T) {
+	now := time.Now().UTC()
+	ts := now.Add(-1 * time.Hour) // inside the 48h lookback + the window
+	lines := strings.Join([]string{
+		// local -> local: sent for a.test, received for b.test
+		dline(ts, "queue.message-queued", "u@a.test", []string{"v@b.test"}, "1"),
+		// inbound from remote -> local: received for b.test only (remote sender not counted)
+		dline(ts, "queue.message-queued", "ext@remote.example", []string{"v@b.test"}, "2"),
+		// outbound to remote: sent for a.test only (remote recipient not counted)
+		dline(ts, "queue.message-queued", "u@a.test", []string{"x@remote.example"}, "3"),
+		// terminal events
+		dline(ts, "delivery.completed", "u@a.test", []string{"v@b.test"}, "4"),
+		dline(ts, "delivery.failed", "ext@remote.example", []string{"v@b.test"}, "5"),
+	}, "\n") + "\n"
+	withMailLogDir(t, "delivery.now", lines)
+
+	got := runDomainSample(t, now.Add(-2*time.Hour), []string{"a.test", "b.test"})
+	want := map[string]int64{
+		"sent|a.test":      2, // qid 1 + qid 3
+		"received|b.test":  2, // qid 1 + qid 2
+		"delivered|b.test": 1, // qid 4
+		"failed|b.test":    1, // qid 5
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s = %d, want %d (all: %v)", k, got[k], v, got)
+		}
+	}
+	// remote.example must never appear (not a local domain).
+	for k := range got {
+		if strings.Contains(k, "remote.example") {
+			t.Errorf("remote domain leaked into counts: %s", k)
+		}
+	}
+}
+
+func TestMailStatsDomain_DedupesMultiRecipientSameDomain(t *testing.T) {
+	now := time.Now().UTC()
+	ts := now.Add(-30 * time.Minute)
+	// two recipients in the SAME local domain on one message => received counts once.
+	line := dline(ts, "queue.message-queued", "ext@remote.example", []string{"a@b.test", "b@b.test"}, "77") + "\n"
+	withMailLogDir(t, "delivery.now", line)
+
+	got := runDomainSample(t, now.Add(-1*time.Hour), []string{"b.test"})
+	if got["received|b.test"] != 1 {
+		t.Errorf("received|b.test = %d, want 1 (dedup by queueId+domain); all: %v", got["received|b.test"], got)
+	}
+}
+
+func TestMailStatsDomain_ExcludesLinesBeforeWindow(t *testing.T) {
+	now := time.Now().UTC()
+	old := dline(now.Add(-5*time.Hour), "queue.message-queued", "u@a.test", []string{"v@a.test"}, "9")
+	fresh := dline(now.Add(-10*time.Minute), "queue.message-queued", "u@a.test", []string{"v@a.test"}, "10")
+	withMailLogDir(t, "delivery.now", old+"\n"+fresh+"\n")
+
+	got := runDomainSample(t, now.Add(-1*time.Hour), []string{"a.test"}) // window starts 1h ago
+	if got["sent|a.test"] != 1 {
+		t.Errorf("sent|a.test = %d, want 1 (only the fresh line is inside the window); all: %v", got["sent|a.test"], got)
+	}
+}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -915,6 +915,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			Agent:    sharedAgent,
 			Stats:    repository.NewMailStatsRepository(sharedDB),
 			Settings: deps.ServerSettings,
+			Domains:  deps.Domains,
 			Log:      log,
 		})
 	}

--- a/panel-api/internal/api/admin_mail_stats.go
+++ b/panel-api/internal/api/admin_mail_stats.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -43,12 +44,26 @@ type MailStatPoint struct {
 	V float64   `json:"v"`
 }
 
+// DomainTrafficRow is one domain's traffic totals over the selected range
+// (GH #873 round 3). Powers the per-domain traffic drilldown — "which domains
+// generate the mail volume".
+type DomainTrafficRow struct {
+	Domain    string `json:"domain"`
+	Sent      int64  `json:"sent"`
+	Received  int64  `json:"received"`
+	Delivered int64  `json:"delivered"`
+	Failed    int64  `json:"failed"`
+}
+
 type mailStatsResponse struct {
 	// Points and Rates are keyed by metric name.
 	Points  map[string][]MailStatPoint     `json:"points"`
 	Rates   map[string][]MailStatPoint     `json:"rates"`
 	Current map[string]float64             `json:"current"`
 	Storage []repository.MailboxStorageRow `json:"storage"`
+	// Traffic is the per-domain send/receive breakdown for the range, busiest
+	// first. Empty until the per-domain sampler has collected a window.
+	Traffic []DomainTrafficRow `json:"traffic"`
 }
 
 func (h *adminMailStatsHandler) stats(c *gin.Context) {
@@ -70,12 +85,18 @@ func (h *adminMailStatsHandler) stats(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "storage failed"})
 		return
 	}
+	domainRows, err := h.cfg.Stats.DomainSeries(c.Request.Context(), since)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "traffic failed"})
+		return
+	}
 
 	resp := mailStatsResponse{
 		Points:  map[string][]MailStatPoint{},
 		Rates:   map[string][]MailStatPoint{},
 		Current: map[string]float64{},
 		Storage: storage,
+		Traffic: aggregateDomainTraffic(domainRows),
 	}
 	// rows arrive ordered (metric, time) — walk once.
 	for i := 0; i < len(rows); i++ {
@@ -91,4 +112,40 @@ func (h *adminMailStatsHandler) stats(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// aggregateDomainTraffic sums the per-domain delta samples into one row per
+// domain over the whole range, busiest first (by sent+received), ties broken
+// by domain name for a stable listing.
+func aggregateDomainTraffic(rows []repository.DomainStatSample) []DomainTrafficRow {
+	byDomain := map[string]*DomainTrafficRow{}
+	for _, r := range rows {
+		d := byDomain[r.Domain]
+		if d == nil {
+			d = &DomainTrafficRow{Domain: r.Domain}
+			byDomain[r.Domain] = d
+		}
+		switch r.Metric {
+		case "sent":
+			d.Sent += r.Value
+		case "received":
+			d.Received += r.Value
+		case "delivered":
+			d.Delivered += r.Value
+		case "failed":
+			d.Failed += r.Value
+		}
+	}
+	out := make([]DomainTrafficRow, 0, len(byDomain))
+	for _, d := range byDomain {
+		out = append(out, *d)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		li, lj := out[i].Sent+out[i].Received, out[j].Sent+out[j].Received
+		if li != lj {
+			return li > lj
+		}
+		return out[i].Domain < out[j].Domain
+	})
+	return out
 }

--- a/panel-api/internal/api/admin_mail_stats_test.go
+++ b/panel-api/internal/api/admin_mail_stats_test.go
@@ -17,8 +17,9 @@ import (
 
 type fakeMailStatsSeriesRepo struct {
 	repository.MailStatsRepository
-	rows    []repository.MailStatSample
-	storage []repository.MailboxStorageRow
+	rows       []repository.MailStatSample
+	storage    []repository.MailboxStorageRow
+	domainRows []repository.DomainStatSample
 }
 
 func (f *fakeMailStatsSeriesRepo) Series(context.Context, time.Time) ([]repository.MailStatSample, error) {
@@ -26,6 +27,9 @@ func (f *fakeMailStatsSeriesRepo) Series(context.Context, time.Time) ([]reposito
 }
 func (f *fakeMailStatsSeriesRepo) StorageDrilldown(context.Context) ([]repository.MailboxStorageRow, error) {
 	return f.storage, nil
+}
+func (f *fakeMailStatsSeriesRepo) DomainSeries(context.Context, time.Time) ([]repository.DomainStatSample, error) {
+	return f.domainRows, nil
 }
 
 // GH #873: rates are positive deltas per metric, clamped at zero across a
@@ -44,6 +48,15 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 		storage: []repository.MailboxStorageRow{
 			{Username: "notary", DomainName: "n.example", Email: "a@n.example", UsageBytes: 1024, QuotaBytes: 4096},
 		},
+		// Two windows of per-domain deltas; the handler sums them per domain and
+		// orders busiest-first (by sent+received).
+		domainRows: []repository.DomainStatSample{
+			{Domain: "busy.example", Metric: "sent", SampledAt: t0, Value: 3},
+			{Domain: "busy.example", Metric: "sent", SampledAt: t0.Add(15 * time.Minute), Value: 2},
+			{Domain: "busy.example", Metric: "received", SampledAt: t0, Value: 4},
+			{Domain: "quiet.example", Metric: "received", SampledAt: t0, Value: 1},
+			{Domain: "quiet.example", Metric: "failed", SampledAt: t0, Value: 2},
+		},
 	}
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -61,6 +74,7 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 		Rates   map[string][]api.MailStatPoint `json:"rates"`
 		Current map[string]float64             `json:"current"`
 		Storage []repository.MailboxStorageRow `json:"storage"`
+		Traffic []api.DomainTrafficRow         `json:"traffic"`
 	}
 	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 
@@ -75,5 +89,14 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 	assert.Equal(t, float64(4), resp.Current["queue_size"])
 	if assert.Len(t, resp.Storage, 1) {
 		assert.Equal(t, "a@n.example", resp.Storage[0].Email)
+	}
+	// Per-domain traffic: summed across windows, busiest first.
+	if assert.Len(t, resp.Traffic, 2) {
+		assert.Equal(t, "busy.example", resp.Traffic[0].Domain, "busiest domain first")
+		assert.Equal(t, int64(5), resp.Traffic[0].Sent)     // 3 + 2
+		assert.Equal(t, int64(4), resp.Traffic[0].Received) // 4
+		assert.Equal(t, "quiet.example", resp.Traffic[1].Domain)
+		assert.Equal(t, int64(1), resp.Traffic[1].Received)
+		assert.Equal(t, int64(2), resp.Traffic[1].Failed)
 	}
 }

--- a/panel-api/internal/db/migrations/000257_mail_stats_domain.down.sql
+++ b/panel-api/internal/db/migrations/000257_mail_stats_domain.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE mail_stats_domain_samples;

--- a/panel-api/internal/db/migrations/000257_mail_stats_domain.up.sql
+++ b/panel-api/internal/db/migrations/000257_mail_stats_domain.up.sql
@@ -1,0 +1,16 @@
+-- GH #873 (round 3): per-domain mail TRAFFIC history. One row per
+-- (domain, metric, sample time). Unlike mail_stats_samples (server-wide
+-- Stalwart counters), these are DELTAS — the count of events attributed to
+-- a local domain in the 15-minute window ending at sampled_at, derived from
+-- the delivery log by the agent's mail.stats_domain_sample verb. metric is
+-- one of: sent, received, delivered, failed. Summed over a range at query
+-- time. Pruned after 90 days by the mail stats ticker, same as the
+-- server-wide samples.
+CREATE TABLE mail_stats_domain_samples (
+  domain     varchar(255) NOT NULL,
+  metric     varchar(16)  NOT NULL,
+  sampled_at datetime(6)  NOT NULL,
+  value      bigint       NOT NULL,
+  PRIMARY KEY (domain, metric, sampled_at),
+  KEY idx_msds_sampled_at (sampled_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/reconciler/mail_stats_domain_ticker_test.go
+++ b/panel-api/internal/reconciler/mail_stats_domain_ticker_test.go
@@ -1,0 +1,107 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeDomainStatsAgent struct {
+	domainCalls int
+	lastArgs    map[string]any
+}
+
+func (f *fakeDomainStatsAgent) Call(_ context.Context, method string, args interface{}) (json.RawMessage, error) {
+	if method != "mail.stats_domain_sample" {
+		return nil, nil
+	}
+	f.domainCalls++
+	if m, ok := args.(map[string]any); ok {
+		f.lastArgs = m
+	}
+	return json.RawMessage(`{"sampled_at":"2026-08-10T00:00:00Z","counts":[` +
+		`{"domain":"a.test","metric":"sent","count":3},` +
+		`{"domain":"a.test","metric":"received","count":1}]}`), nil
+}
+
+type fakeDomainStatsRepo struct {
+	repository.MailStatsRepository
+	inserted   []repository.DomainCount
+	insertedAt time.Time
+}
+
+func (f *fakeDomainStatsRepo) LastDomainSampleAt(context.Context) (time.Time, error) {
+	return time.Time{}, nil // first run
+}
+func (f *fakeDomainStatsRepo) InsertDomainSamples(_ context.Context, at time.Time, c []repository.DomainCount) error {
+	f.insertedAt = at
+	f.inserted = c
+	return nil
+}
+
+type fakeDomainsRepo struct {
+	repository.DomainRepository
+	names []string
+}
+
+func (f *fakeDomainsRepo) List(context.Context, repository.ListOptions) ([]models.Domain, int64, error) {
+	out := make([]models.Domain, len(f.names))
+	for i, n := range f.names {
+		out[i] = models.Domain{Name: n}
+	}
+	return out, int64(len(out)), nil
+}
+
+// GH #873 round 3: the domain tick passes the local-domain set, stores the
+// agent's per-domain counts at the returned sampled_at, and gates on the mail
+// module.
+func TestDomainStatsTick_StoresPerDomainCounts(t *testing.T) {
+	agent := &fakeDomainStatsAgent{}
+	repo := &fakeDomainStatsRepo{}
+	deps := MailStatsTickerDeps{
+		Agent:    agent,
+		Stats:    repo,
+		Domains:  &fakeDomainsRepo{names: []string{"a.test", "b.test"}},
+		Settings: &fakeSettingsRepo{srv: &models.ServerSettings{MailEnabled: true}},
+		Log:      nopLogger{},
+	}
+	domainStatsTick(context.Background(), deps)
+
+	if agent.domainCalls != 1 {
+		t.Fatalf("domain agent calls = %d, want 1", agent.domainCalls)
+	}
+	// local_domains forwarded to the agent.
+	ld, _ := agent.lastArgs["local_domains"].([]string)
+	if len(ld) != 2 || ld[0] != "a.test" {
+		t.Fatalf("local_domains = %v", agent.lastArgs["local_domains"])
+	}
+	// first run: no watermark passed.
+	if _, ok := agent.lastArgs["since"]; ok {
+		t.Errorf("first run must not send a since watermark: %v", agent.lastArgs["since"])
+	}
+	// counts stored at the agent's sampled_at.
+	if len(repo.inserted) != 2 {
+		t.Fatalf("inserted = %v", repo.inserted)
+	}
+	if !repo.insertedAt.Equal(time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("insertedAt = %v, want the agent's sampled_at", repo.insertedAt)
+	}
+
+	// Mail module off: no agent call, no insert.
+	agent2 := &fakeDomainStatsAgent{}
+	repo2 := &fakeDomainStatsRepo{}
+	domainStatsTick(context.Background(), MailStatsTickerDeps{
+		Agent:    agent2,
+		Stats:    repo2,
+		Domains:  &fakeDomainsRepo{names: []string{"a.test"}},
+		Settings: &fakeSettingsRepo{srv: &models.ServerSettings{MailEnabled: false}},
+		Log:      nopLogger{},
+	})
+	if agent2.domainCalls != 0 || repo2.inserted != nil {
+		t.Fatalf("mail-off host must not sample (calls=%d inserted=%v)", agent2.domainCalls, repo2.inserted)
+	}
+}

--- a/panel-api/internal/reconciler/mail_stats_ticker.go
+++ b/panel-api/internal/reconciler/mail_stats_ticker.go
@@ -25,7 +25,11 @@ type MailStatsTickerDeps struct {
 	Agent    agent.AgentInterface
 	Stats    repository.MailStatsRepository
 	Settings repository.ServerSettingsRepository
-	Log      bwTickerLogger
+	// Domains supplies the local-domain set for the per-domain traffic
+	// sample (GH #873 round 3). Nil disables that half; the server-wide
+	// sample still runs.
+	Domains repository.DomainRepository
+	Log     bwTickerLogger
 }
 
 // StartMailStatsTicker runs until ctx is cancelled. Call in a goroutine.
@@ -43,11 +47,18 @@ func StartMailStatsTicker(ctx context.Context, deps MailStatsTickerDeps) {
 			return
 		case <-t.C:
 			mailStatsTick(ctx, deps)
+			domainStatsTick(ctx, deps)
 			if time.Since(lastPrune) > 24*time.Hour {
-				if n, err := deps.Stats.Prune(ctx, time.Now().UTC().Add(-mailStatsRetention)); err != nil {
+				cutoff := time.Now().UTC().Add(-mailStatsRetention)
+				if n, err := deps.Stats.Prune(ctx, cutoff); err != nil {
 					deps.Log.Warn("mail stats: prune failed", "err", err)
 				} else if n > 0 {
 					deps.Log.Info("mail stats: pruned", "rows", n)
+				}
+				if n, err := deps.Stats.PruneDomain(ctx, cutoff); err != nil {
+					deps.Log.Warn("mail stats: domain prune failed", "err", err)
+				} else if n > 0 {
+					deps.Log.Info("mail stats: pruned domain rows", "rows", n)
 				}
 				lastPrune = time.Now()
 			}
@@ -94,5 +105,84 @@ func mailStatsTick(ctx context.Context, deps MailStatsTickerDeps) {
 	}
 	if sample.EnabledNow {
 		deps.Log.Info("mail stats: stalwart prometheus exporter enabled (one-time)")
+	}
+}
+
+// domainStatsTick derives per-domain traffic deltas (GH #873 round 3). It reads
+// the current local-domain set, asks the agent to count delivery-log events
+// since the last domain sample, and stores the deltas. The panel drives the
+// window (LastDomainSampleAt -> agent's returned sampled_at) so there is no gap
+// or overlap between ticks. Mail-module gating is inherited from mailStatsTick,
+// which runs first in the same tick and returns early on a mail-less host.
+func domainStatsTick(ctx context.Context, deps MailStatsTickerDeps) {
+	if deps.Domains == nil {
+		return
+	}
+	if deps.Settings != nil {
+		sctx, scancel := context.WithTimeout(ctx, 5*time.Second)
+		srv, err := deps.Settings.Get(sctx)
+		scancel()
+		if err == nil && srv != nil && !srv.MailEnabled {
+			return
+		}
+	}
+
+	domains, _, err := deps.Domains.List(ctx, repository.ListOptions{Limit: 100000, OmitHeavyColumns: true})
+	if err != nil {
+		deps.Log.Warn("mail stats: list domains failed", "err", err)
+		return
+	}
+	if len(domains) == 0 {
+		return
+	}
+	names := make([]string, 0, len(domains))
+	for _, d := range domains {
+		if d.Name != "" {
+			names = append(names, d.Name)
+		}
+	}
+
+	since, err := deps.Stats.LastDomainSampleAt(ctx)
+	if err != nil {
+		deps.Log.Warn("mail stats: domain watermark failed", "err", err)
+		return
+	}
+	args := map[string]any{"local_domains": names}
+	if !since.IsZero() {
+		args["since"] = since.UTC().Format(time.RFC3339)
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	raw, err := deps.Agent.Call(cctx, "mail.stats_domain_sample", args)
+	cancel()
+	if err != nil {
+		deps.Log.Warn("mail stats: domain sample failed", "err", err)
+		return
+	}
+	var sample struct {
+		SampledAt string `json:"sampled_at"`
+		Counts    []struct {
+			Domain string `json:"domain"`
+			Metric string `json:"metric"`
+			Count  int64  `json:"count"`
+		} `json:"counts"`
+	}
+	if err := json.Unmarshal(raw, &sample); err != nil {
+		deps.Log.Warn("mail stats: decode domain sample failed", "err", err)
+		return
+	}
+	if len(sample.Counts) == 0 {
+		return
+	}
+	at, err := time.Parse(time.RFC3339, sample.SampledAt)
+	if err != nil {
+		at = time.Now().UTC()
+	}
+	counts := make([]repository.DomainCount, 0, len(sample.Counts))
+	for _, c := range sample.Counts {
+		counts = append(counts, repository.DomainCount{Domain: c.Domain, Metric: c.Metric, Count: c.Count})
+	}
+	if err := deps.Stats.InsertDomainSamples(ctx, at.UTC(), counts); err != nil {
+		deps.Log.Warn("mail stats: insert domain samples failed", "err", err)
 	}
 }

--- a/panel-api/internal/repository/mail_stats_repository.go
+++ b/panel-api/internal/repository/mail_stats_repository.go
@@ -29,6 +29,25 @@ type MailboxStorageRow struct {
 	QuotaBytes uint64 `gorm:"column:quota_bytes" json:"quota_bytes"`
 }
 
+// DomainStatSample is one per-domain traffic delta point (GH #873 round 3).
+// Value is the count of `Metric` events (sent|received|delivered|failed)
+// attributed to `Domain` in the window ending at `SampledAt`.
+type DomainStatSample struct {
+	Domain    string    `gorm:"column:domain"     json:"domain"`
+	Metric    string    `gorm:"column:metric"     json:"metric"`
+	SampledAt time.Time `gorm:"column:sampled_at" json:"sampled_at"`
+	Value     int64     `gorm:"column:value"      json:"value"`
+}
+
+func (DomainStatSample) TableName() string { return "mail_stats_domain_samples" }
+
+// DomainCount is one (domain, metric, count) delta to persist for a window.
+type DomainCount struct {
+	Domain string
+	Metric string
+	Count  int64
+}
+
 type MailStatsRepository interface {
 	// InsertSamples writes one row per metric at the given time.
 	InsertSamples(ctx context.Context, at time.Time, metrics map[string]float64) error
@@ -39,6 +58,18 @@ type MailStatsRepository interface {
 	// StorageDrilldown returns every mailbox with its usage and owner
 	// chain (usage is the mailbox-usage ticker's last sample).
 	StorageDrilldown(ctx context.Context) ([]MailboxStorageRow, error)
+
+	// InsertDomainSamples writes the per-domain traffic deltas for one window
+	// (all rows share `at`). No-op on an empty slice.
+	InsertDomainSamples(ctx context.Context, at time.Time, counts []DomainCount) error
+	// DomainSeries returns per-domain samples since `since`, ordered by
+	// domain, metric, then time.
+	DomainSeries(ctx context.Context, since time.Time) ([]DomainStatSample, error)
+	// LastDomainSampleAt returns the newest domain sample time, or zero time
+	// when the table is empty (first run). Drives the collector's watermark.
+	LastDomainSampleAt(ctx context.Context) (time.Time, error)
+	// PruneDomain deletes per-domain samples older than `olderThan`.
+	PruneDomain(ctx context.Context, olderThan time.Time) (int64, error)
 }
 
 type mailStatsRepo struct{ db *gorm.DB }
@@ -94,6 +125,53 @@ func (r *mailStatsRepo) Prune(ctx context.Context, olderThan time.Time) (int64, 
 	res := r.db.WithContext(ctx).
 		Where("sampled_at < ?", olderThan).
 		Delete(&MailStatSample{})
+	return res.RowsAffected, res.Error
+}
+
+func (r *mailStatsRepo) InsertDomainSamples(ctx context.Context, at time.Time, counts []DomainCount) error {
+	if len(counts) == 0 {
+		return nil
+	}
+	vals := make([]any, 0, len(counts)*4)
+	ph := ""
+	for i, c := range counts {
+		if i > 0 {
+			ph += ","
+		}
+		ph += "(?,?,?,?)"
+		vals = append(vals, c.Domain, c.Metric, at, c.Count)
+	}
+	// INSERT IGNORE so a retried tick at the same sampled_at is a no-op rather
+	// than a double-count.
+	return r.db.WithContext(ctx).
+		Exec("INSERT IGNORE INTO mail_stats_domain_samples (domain, metric, sampled_at, value) VALUES "+ph, vals...).Error
+}
+
+func (r *mailStatsRepo) DomainSeries(ctx context.Context, since time.Time) ([]DomainStatSample, error) {
+	var rows []DomainStatSample
+	err := r.db.WithContext(ctx).
+		Where("sampled_at >= ?", since).
+		Order("domain ASC, metric ASC, sampled_at ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *mailStatsRepo) LastDomainSampleAt(ctx context.Context) (time.Time, error) {
+	var t *time.Time
+	err := r.db.WithContext(ctx).
+		Model(&DomainStatSample{}).
+		Select("MAX(sampled_at)").
+		Scan(&t).Error
+	if err != nil || t == nil {
+		return time.Time{}, err
+	}
+	return *t, nil
+}
+
+func (r *mailStatsRepo) PruneDomain(ctx context.Context, olderThan time.Time) (int64, error) {
+	res := r.db.WithContext(ctx).
+		Where("sampled_at < ?", olderThan).
+		Delete(&DomainStatSample{})
 	return res.RowsAffected, res.Error
 }
 

--- a/panel-api/internal/repository/mail_stats_repository.go
+++ b/panel-api/internal/repository/mail_stats_repository.go
@@ -5,6 +5,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"gorm.io/gorm"
@@ -157,15 +158,17 @@ func (r *mailStatsRepo) DomainSeries(ctx context.Context, since time.Time) ([]Do
 }
 
 func (r *mailStatsRepo) LastDomainSampleAt(ctx context.Context) (time.Time, error) {
-	var t *time.Time
+	// sql.NullTime (not *time.Time) so an empty table's NULL MAX() scans
+	// cleanly on MariaDB rather than relying on GORM's **time.Time handling.
+	var nt sql.NullTime
 	err := r.db.WithContext(ctx).
 		Model(&DomainStatSample{}).
 		Select("MAX(sampled_at)").
-		Scan(&t).Error
-	if err != nil || t == nil {
+		Scan(&nt).Error
+	if err != nil || !nt.Valid {
 		return time.Time{}, err
 	}
-	return *t, nil
+	return nt.Time, nil
 }
 
 func (r *mailStatsRepo) PruneDomain(ctx context.Context, olderThan time.Time) (int64, error) {

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
@@ -268,6 +268,11 @@ export const MailStatsTab = () => {
             mail flows.
           </Typography.Text>
         ) : (
+          <>
+          <Typography.Paragraph type="secondary" style={{ marginTop: 0, fontSize: 12 }}>
+            Counted from the delivery log by envelope sender/recipient, so totals
+            won't exactly match the server-wide tiles above.
+          </Typography.Paragraph>
           <Table
             size="small"
             rowKey="domain"
@@ -296,6 +301,7 @@ export const MailStatsTab = () => {
               },
             ]}
           />
+          </>
         )}
       </Card>
 

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
@@ -31,6 +31,15 @@ type MailStats = {
     usage_bytes: number;
     quota_bytes: number;
   }[];
+  // GH #873 round 3: per-domain traffic totals over the selected range,
+  // busiest first. Empty until the per-domain sampler has collected a window.
+  traffic: {
+    domain: string;
+    sent: number;
+    received: number;
+    delivered: number;
+    failed: number;
+  }[];
 };
 
 const fmtBytes = (n: number): string => {
@@ -246,6 +255,49 @@ export const MailStatsTab = () => {
           />
         </Col>
       </Row>
+
+      <Card
+        size="small"
+        title={`Traffic by domain (${hours >= 168 ? `${hours / 24}d` : `${hours}h`})`}
+        style={{ marginBottom: 16 }}
+        loading={stats.isLoading}
+      >
+        {(s?.traffic?.length ?? 0) === 0 ? (
+          <Typography.Text type="secondary">
+            Collecting — per-domain counts appear after the first sample once
+            mail flows.
+          </Typography.Text>
+        ) : (
+          <Table
+            size="small"
+            rowKey="domain"
+            pagination={false}
+            dataSource={s?.traffic ?? []}
+            columns={[
+              { title: "Domain", dataIndex: "domain" },
+              { title: "Sent", dataIndex: "sent", width: 100, align: "right" },
+              {
+                title: "Received",
+                dataIndex: "received",
+                width: 110,
+                align: "right",
+              },
+              {
+                title: "Delivered",
+                dataIndex: "delivered",
+                width: 110,
+                align: "right",
+              },
+              {
+                title: "Failed",
+                dataIndex: "failed",
+                width: 100,
+                align: "right",
+              },
+            ]}
+          />
+        )}
+      </Card>
 
       <Card size="small" title="Storage drilldown" loading={stats.isLoading}>
         <Table


### PR DESCRIPTION
## Feature (GH #873, round 3) — per-domain mail traffic drilldown

The reporter (johnnyq) asked for per-domain traffic — "which domains are using mail the most". This adds a **per-domain traffic breakdown** to the admin **Mail → Statistics** tab.

**Scope (confirmed):** admin-only per-domain for now. Per-user and tenant-scoped views are a deliberate later round (tenant exposure of mail volume is security-sensitive and wants its own reviewed change).

### How

Stalwart's Prometheus exporter (what rounds 1–2 scrape) only has **server-wide** counters — there is no per-domain traffic in the metrics. So this derives it from the **delivery log** the mail-logs feature already parses:

- **Agent — new `mail.stats_domain_sample` verb.** Parses log lines in `(since, now]`, buckets by **local** domain × `{sent, received, delivered, failed}`, dedupes by `queueId`, returns per-window **deltas** plus the `now` it used. Stateless — the panel drives the window and passes its domain set, so remote domains never enter the store. Reuses `parseMailLogLine` (already box-tested by the shipped mail-logs feature). 48h lookback cap so a stale watermark can't walk months of rotated logs.
- **Migration 000257** — `mail_stats_domain_samples (domain, metric, sampled_at, value)`. Stores the deltas (survives log rotation, unlike parsing live), pruned at 90d alongside the server-wide samples.
- **Ticker** — `domainStatsTick` reads the local-domain set + last watermark (`MAX(sampled_at)`), calls the verb, stores the deltas at the returned time so windows are contiguous with no gap/overlap. Mail-module gated, same as the global sampler.
- **API** — `GET /admin/mail/stats` gains a `traffic` array: per-domain totals over the selected range, busiest first. **No new route.**
- **UI** — a "Traffic by domain" table on the Statistics tab, with the same "Collecting…" empty-state as the existing charts.

### Tests

- **Agent:** attribution (sent=sender domain, received=recipient domain), local-domain filter (remote domains excluded), multi-recipient dedup, out-of-window exclusion.
- **Ticker:** stores per-domain counts at the agent's `sampled_at`, forwards `local_domains`, omits `since` on first run, and skips when the mail module is off.
- **API:** per-domain aggregation through the handler (summed across windows, busiest first).
- `go build ./...` + `go test` (agent commands, api, reconciler, repository, db) + `tsc -b` all green. Migrations-completeness test passes.

### Known behaviour

- The per-domain table is **envelope-attributed from the delivery log** (sent = envelope sender's domain, received = recipient's domain). It will **not** exactly equal the server-wide "Sent"/"Received" tiles above, which count Stalwart's global counters — local→local mail and forwarded/forged local senders differ between the two. Noted in the UI under the table.

### Honest notes

- **Live migration apply** wasn't run here (no DB in this session) — the DDL mirrors the proven `mail_stats_samples` migration; CI + the fleet's real apply validate it.
- **Live log-format parsing** is inherited from the shipped mail-logs feature (same `parseMailLogLine`), so bucketing is unit-tested against the real format.
- **Final box verification (gates the issue reply):** a **two-tick** check on a real box — tick 1 (no watermark) applies the migration and inserts rows; **tick 2** must pass `since` to the agent and land a contiguous next window (this is what exercises the `LastDomainSampleAt` watermark scan against MariaDB). Send/receive a few messages between ticks and confirm `mail_stats_domain_samples` fills per domain.

GH #873
