### PR TITLE
fix(users): drop Postgres databases and roles with the Postgres commands (GH #1013)

### DIFF
--- a/panel-api/internal/userops/db_engine_dispatch_test.go
+++ b/panel-api/internal/userops/db_engine_dispatch_test.go
@@ -1,0 +1,58 @@
+package userops
+
+// The delete cascade sends one agent command per database and per database
+// login. Both the command name and the payload key differ by engine, and
+// getting either wrong is silent: `db.drop` / `db_user.drop` reach MariaDB,
+// whose DROP ... IF EXISTS succeeds on a name that was never there. The
+// cascade's failure guard therefore never fires, the user row is deleted,
+// its metadata rows CASCADE away — and the real Postgres database or role
+// survives on the host with nothing left to name it (GH #1013).
+//
+// That makes this dispatch the whole fix, so it is pinned directly.
+
+import "testing"
+
+func TestDBUserDropCmd_DispatchesOnEngine(t *testing.T) {
+	if got := dbUserDropCmd("postgres"); got != "db.postgres.drop_role" {
+		t.Errorf("postgres login drop = %q, want db.postgres.drop_role — db_user.drop reaches MariaDB and no-ops", got)
+	}
+	for _, engine := range []string{"mariadb", "", "mysql"} {
+		if got := dbUserDropCmd(engine); got != "db_user.drop" {
+			t.Errorf("engine %q login drop = %q, want db_user.drop", engine, got)
+		}
+	}
+}
+
+// A Postgres drop_role reads "role"; sending the MariaDB "db_user_name"
+// shape leaves the role name empty, so the command is a no-op even when
+// the command NAME is right.
+func TestDBUserDropParams_KeyDiffersByEngine(t *testing.T) {
+	pg := dbUserDropParams("postgres", "alice_app")
+	if pg["role"] != "alice_app" {
+		t.Errorf("postgres params = %#v, want role=alice_app", pg)
+	}
+	if _, ok := pg["db_user_name"]; ok {
+		t.Error("postgres params must not carry db_user_name — drop_role ignores it")
+	}
+
+	my := dbUserDropParams("mariadb", "alice_app")
+	if my["db_user_name"] != "alice_app" {
+		t.Errorf("mariadb params = %#v, want db_user_name=alice_app", my)
+	}
+	if _, ok := my["role"]; ok {
+		t.Error("mariadb params must not carry role")
+	}
+}
+
+func TestDBDropCmd_DispatchesOnEngine(t *testing.T) {
+	if got := dbDropCmd("postgres"); got != "db.postgres.drop_db" {
+		t.Errorf("postgres database drop = %q, want db.postgres.drop_db — db.drop reaches "+
+			"MariaDB, whose DROP DATABASE IF EXISTS succeeds on a name that was never there, "+
+			"so the cascade's failure guard never fires", got)
+	}
+	for _, engine := range []string{"mariadb", "", "mysql"} {
+		if got := dbDropCmd(engine); got != "db.drop" {
+			t.Errorf("engine %q database drop = %q, want db.drop", engine, got)
+		}
+	}
+}

--- a/panel-api/internal/userops/userops_lifecycle.go
+++ b/panel-api/internal/userops/userops_lifecycle.go
@@ -259,6 +259,16 @@ func DeleteCascade(ctx context.Context, d Deps, dd DeleteDeps, target *models.Us
 		username = *target.Username
 	}
 
+	// dbUserDropCmd / dbUserDropParams mirror the canonical dispatch pair in
+	// api/database_users.go (dbUserCmd / dbUserDropParams), which is
+	// unexported and therefore unreachable from here. Two things differ per
+	// engine and BOTH matter: the command name, and the payload key.
+	//
+	// The MariaDB defaults were being used for every row, so a Postgres role
+	// survived the cascade — and because `db_user.drop` reaches MariaDB,
+	// whose DROP USER IF EXISTS succeeds on a name that was never there, the
+	// failure never surfaced (GH #1013).
+
 	// Cascade-drop MariaDB schemas + grants BEFORE the panel row goes
 	// (which CASCADEs the metadata rows). A failed drop is NOT best-effort:
 	// collect the failures and abort before the row delete below, so the panel
@@ -278,13 +288,22 @@ func DeleteCascade(ctx context.Context, d Deps, dd DeleteDeps, target *models.Us
 			}
 			for i := range dbs {
 				dbName := dbs[i].Name
+				// Dispatch on the engine the row was created with. Sending
+				// db.drop at a postgres row reaches MariaDB, whose
+				// `DROP DATABASE IF EXISTS` cheerfully succeeds on a name that
+				// was never there — so the abort below never fires and the real
+				// Postgres database is orphaned on the HAPPY path, with the
+				// panel row cascaded away behind it (GH #1013).
+				//
+				// databases.go's own delete already picks the command this way.
+				dropCmd := dbDropCmd(dbs[i].Engine)
 				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				_, dropErr := d.Agent.Call(agentCtx, "db.drop", map[string]any{"db_name": dbName})
+				_, dropErr := d.Agent.Call(agentCtx, dropCmd, map[string]any{"db_name": dbName})
 				cancel()
 				if dropErr != nil {
 					undropped = append(undropped, dbName)
-					logError(d, "cascade delete: db.drop failed — aborting so the row stays addressable",
-						"user_id", id, "db_name", dbName, "err", dropErr)
+					logError(d, "cascade delete: database drop failed — aborting so the row stays addressable",
+						"user_id", id, "db_name", dbName, "engine", dbs[i].Engine, "cmd", dropCmd, "err", dropErr)
 				}
 			}
 			if len(dbs) < batchSize {
@@ -305,13 +324,16 @@ func DeleteCascade(ctx context.Context, d Deps, dd DeleteDeps, target *models.Us
 			}
 			for i := range dbus {
 				duName := dbus[i].Username
+				// A Postgres ROLE is not dropped by db_user.drop, and the
+				// payload key differs too — see dbUserDropCmd/Params below.
+				cmd, params := dbUserDropCmd(dbus[i].Engine), dbUserDropParams(dbus[i].Engine, duName)
 				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				_, dropErr := d.Agent.Call(agentCtx, "db_user.drop", map[string]any{"db_user_name": duName})
+				_, dropErr := d.Agent.Call(agentCtx, cmd, params)
 				cancel()
 				if dropErr != nil {
 					undropped = append(undropped, duName)
-					logError(d, "cascade delete: db_user.drop failed — aborting so the row stays addressable",
-						"user_id", id, "db_user_name", duName, "err", dropErr)
+					logError(d, "cascade delete: database user drop failed — aborting so the row stays addressable",
+						"user_id", id, "db_user_name", duName, "engine", dbus[i].Engine, "cmd", cmd, "err", dropErr)
 				}
 			}
 			if len(dbus) < batchSize {
@@ -479,4 +501,33 @@ func logError(d Deps, msg string, args ...any) {
 	if d.Log != nil {
 		d.Log.Error(msg, args...)
 	}
+}
+
+// dbDropCmd returns the agent command that drops a DATABASE for the given
+// engine. Mirrors the dispatch in api/databases.go's delete handler.
+func dbDropCmd(engine string) string {
+	if engine == "postgres" {
+		return "db.postgres.drop_db"
+	}
+	return "db.drop"
+}
+
+// dbUserDropCmd returns the agent command that drops a database login for
+// the given engine. Mirrors api.dbUserCmd(engine, "drop").
+func dbUserDropCmd(engine string) string {
+	if engine == "postgres" {
+		return "db.postgres.drop_role"
+	}
+	return "db_user.drop"
+}
+
+// dbUserDropParams returns the payload shape that command expects. The key
+// differs by engine — a Postgres drop_role reads "role", not
+// "db_user_name", so sending the MariaDB shape is a silent no-op even when
+// the command name is right. Mirrors api.dbUserDropParams.
+func dbUserDropParams(engine, username string) map[string]any {
+	if engine == "postgres" {
+		return map[string]any{"role": username}
+	}
+	return map[string]any{"db_user_name": username}
 }


### PR DESCRIPTION
Closes the issue I filed at #1013.

## The bug

The user-delete cascade sent `db.drop` and `db_user.drop` for **every** row, whatever engine it was created with. Both reach MariaDB — and MariaDB's `DROP DATABASE IF EXISTS` / `DROP USER IF EXISTS` **succeed** on a name that was never there.

So the drop "succeeded", the failure guard added in #1010 never fired, the user row was deleted, its `databases` / `database_users` rows CASCADEd away — and the real Postgres database and role survived on the host with nothing left to name them: invisible to `jabali db list`, excluded from every backup, privileges intact.

The orphan happened on the **happy path**. Nothing logged it, and nothing downstream could find it again.

## Both halves of the dispatch matter

The second one is easy to miss:

| | MariaDB | Postgres |
|---|---|---|
| database | `db.drop` | `db.postgres.drop_db` |
| login | `db_user.drop` | `db.postgres.drop_role` |
| payload key | `db_user_name` | **`role`** |

`drop_role` reads `role`. Sending the MariaDB shape leaves the role name empty, so the command is a **no-op even when the command name is right** — which is why the fix pins the params, not just the command.

## Why the helpers are duplicated

`api/databases.go` and `api/database_users.go` already dispatch this way (`dbUserCmd` / `dbUserDropParams`). Those are unexported and `userops` cannot reach them, so this mirrors them locally with a comment naming the canonical pair. Exporting them would have touched files other people are working in right now; a five-line mirror seemed the better trade. Happy to swap it for a shared helper if you'd rather.

## Where the code lives now

Worth noting for review: the cascade moved out of `api/users.go` into `internal/userops/userops_lifecycle.go` (JAB-190 / ADR-0164) after #1010 merged. The `undropped` guard survived that move intact; this change sits on top of it.

## Test plan

- [x] `dbDropCmd` / `dbUserDropCmd` dispatch on engine, with the MariaDB default for `mariadb`, `mysql`, and empty
- [x] `dbUserDropParams` uses `role` for Postgres and `db_user_name` otherwise, and never carries the other key — the silent-no-op case
- [x] `go vet ./...` clean, `panel-api` suite 0 FAIL

Not covered: a live Postgres tenant delete. Postgres is a gated engine (`server_settings.postgres_enabled`) and testserver has it off, so this is verified at the dispatch layer rather than end-to-end. Flagging that explicitly rather than implying a box test happened.