### PR TITLE
fix(ui): make every list's sort controls actually sort

### DIFF
--- a/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
+++ b/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
@@ -29,7 +29,7 @@ import {
   SearchOutlined,
 } from "@icons";
 import { RowActions } from "../../../components/RowActions";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useTableURL } from "../../../hooks/useTableURL";
@@ -168,19 +168,12 @@ export const AdminApplicationList = () => {
   const handleTableChange: React.ComponentProps<
     typeof Table<ApplicationInstall>
   >["onChange"] = (pagination, _filters, sorter) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<ApplicationInstall> | undefined)
-      : (sorter as SorterResult<ApplicationInstall>);
+    const { sort, order } = sorterToParams<ApplicationInstall>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -219,7 +212,7 @@ export const AdminApplicationList = () => {
             dataIndex="domain_name"
             title={t("adminapplicationlist.domain")}
             key="domain_name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             filterIcon={() => (
               <SearchOutlined
@@ -318,7 +311,7 @@ export const AdminApplicationList = () => {
             dataIndex="created_at"
             title={t("adminapplicationlist.created")}
             key="created_at"
-            sorter={{ multiple: 2 }}
+            sorter
             defaultSortOrder="descend"
             render={(date: string) => shortDateTime(date)}
           />

--- a/panel-ui/src/shells/admin/audit/AdminAuditList.tsx
+++ b/panel-ui/src/shells/admin/audit/AdminAuditList.tsx
@@ -36,6 +36,7 @@ import {
   useServerTz,
 } from "../../../components/AuditEventDetail";
 import { useTableURL } from "../../../hooks/useTableURL";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 // AuditMaintenanceCard — GH #571. Hash-chain integrity verification (read-only)
 // and retention pruning (destructive), surfaced from the Audit Log. Same core
@@ -142,12 +143,26 @@ export const AdminAuditList = () => {
     defaultOrder: "desc",
   });
 
+  // Project AntD's sorter into the URL params so the server does the
+  // ORDER BY. Without an onChange the sort arrows rendered but changed
+  // nothing at all — the columns declared a server-side sorter and no one
+  // was listening for it.
+  const handleTableChange: React.ComponentProps<typeof Table<AuditRow>>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter,
+  ) => {
+    const { sort, order } = sorterToParams<AuditRow>(sorter);
+    query.setParams({ sort, order, page: 1 });
+  };
+
   return (
     <div>
       <AuditMaintenanceCard />
       <Card>
         <SearchableTableStringQ<AuditRow>
           rowKey="id"
+          onChange={handleTableChange}
           loading={query.isLoading}
           dataSource={query.items}
           initialSearch={query.params.q}
@@ -173,7 +188,7 @@ export const AdminAuditList = () => {
             dataIndex="ts"
             title={`When (${tz})`}
             key="ts"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="descend"
             render={(ts: string) => <code>{fmtTSInTz(ts, tz)}</code>}
           />
@@ -194,7 +209,7 @@ export const AdminAuditList = () => {
           <Table.Column
             title={t("adminauditlist.action")}
             key="action"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(_: unknown, r: AuditRow) => <AuditActionLabel row={r} />}
           />
           <Table.Column
@@ -214,7 +229,7 @@ export const AdminAuditList = () => {
             dataIndex="result"
             title={t("adminauditlist.result")}
             key="result"
-            sorter={{ multiple: 1 }}
+            sorter
             render={resultTag}
           />
         </SearchableTableStringQ>

--- a/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
+++ b/panel-ui/src/shells/admin/database-users/DatabaseUsersList.tsx
@@ -21,6 +21,7 @@ import { columnSearchProps } from "../../../components/columnSearch";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useDeleteMutation } from "../../../hooks/useQueries";
 import { useTableURL } from "../../../hooks/useTableURL";
+import { sorterToParams } from "../../../utils/tableSorter";
 import { EngineTag } from "../../../components/EngineTag";
 import { DatabaseUserDrawer } from "./DatabaseUserDrawer";
 
@@ -136,6 +137,19 @@ export const DatabaseUsersList = () => {
     }
   };
 
+  // Project AntD's sorter into the URL params so the server does the
+  // ORDER BY. Without an onChange the sort arrows rendered but changed
+  // nothing — the columns declared a server-side sorter and nothing was
+  // listening for it.
+  const handleTableChange: React.ComponentProps<typeof Table<DatabaseUser>>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter,
+  ) => {
+    const { sort, order } = sorterToParams<DatabaseUser>(sorter);
+    query.setParams({ sort, order, page: 1 });
+  };
+
   return (
     <div>
       <Space
@@ -161,6 +175,7 @@ export const DatabaseUsersList = () => {
 
       <Card>
         <SearchableTableStringQ<DatabaseUser>
+          onChange={handleTableChange}
           rowKey="id"
           loading={query.isLoading}
           dataSource={query.items}
@@ -180,7 +195,7 @@ export const DatabaseUsersList = () => {
           <Table.Column<DatabaseUser>
             dataIndex="username"
             title={t("databaseuserslist.user")}
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<DatabaseUser>({
               placeholder: "Search by database user",
@@ -199,7 +214,7 @@ export const DatabaseUsersList = () => {
             dataIndex="engine"
             title={t("databaseuserslist.engine")}
             key="engine"
-            sorter={{ multiple: 1 }}
+            sorter
             width={140}
             render={(engine: string | undefined) => (
               <EngineTag engine={engine} />
@@ -246,7 +261,7 @@ export const DatabaseUsersList = () => {
           <Table.Column<DatabaseUser>
             dataIndex="created_at"
             title={t("databaseuserslist.created")}
-            sorter={{ multiple: 2 }}
+            sorter
             render={(date: string) => shortDateTime(date)}
             width={120}
           />

--- a/panel-ui/src/shells/admin/databases/DatabaseList.tsx
+++ b/panel-ui/src/shells/admin/databases/DatabaseList.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Button, Card, Space, Table, Tag, Typography } from "antd";
 import { shortDateTime } from "../../../utils/datetime";
 import { useNavigate } from "react-router";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { columnSearchProps } from "../../../components/columnSearch";
 import { RowDeleteButton } from "../../../components/RowDeleteButton";
@@ -43,19 +43,12 @@ export const DatabaseList = () => {
   const handleTableChange: React.ComponentProps<
     typeof Table<Database>
   >["onChange"] = (pagination, _filters, sorter) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<Database> | undefined)
-      : (sorter as SorterResult<Database>);
+    const { sort, order } = sorterToParams<Database>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -109,7 +102,7 @@ export const DatabaseList = () => {
             dataIndex="name"
             title={t("databaselist.database")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Database>({
               placeholder: "Search by database name",
@@ -137,7 +130,7 @@ export const DatabaseList = () => {
             dataIndex="created_at"
             title={t("databaselist.created")}
             key="created_at"
-            sorter={{ multiple: 2 }}
+            sorter
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<Database>

--- a/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/admin/dns/DNSZonesOverviewPage.tsx
@@ -16,6 +16,7 @@ import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
 import { useTableURL } from "../../../hooks/useTableURL";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 interface Domain {
   id: string;
@@ -88,6 +89,19 @@ const ZonesTab = () => {
     );
   };
 
+  // Project AntD's sorter into the URL params so the server does the
+  // ORDER BY. Without an onChange the sort arrows rendered but changed
+  // nothing — the columns declared a server-side sorter and nothing was
+  // listening for it.
+  const handleTableChange: React.ComponentProps<typeof Table<Domain>>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter,
+  ) => {
+    const { sort, order } = sorterToParams<Domain>(sorter);
+    query.setParams({ sort, order, page: 1 });
+  };
+
   return (
     <>
       <Alert
@@ -102,6 +116,7 @@ const ZonesTab = () => {
         <EmptyWithCTA description={t("dnszonesoverviewpage.no_dns_zones_yet_create_a_domain_to_manage_i")} ctaLabel="Create domain" onCta={() => navigate("/jabali-admin/domains/create")} />
       ) : (
         <SearchableTableStringQ<Domain>
+          onChange={handleTableChange}
           rowKey="id"
           loading={query.isLoading}
           dataSource={query.items}
@@ -119,7 +134,7 @@ const ZonesTab = () => {
             dataIndex="name"
             title={t("dnszonesoverviewpage.domain_name")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Domain>({
               placeholder: "Search by domain name",
@@ -131,7 +146,7 @@ const ZonesTab = () => {
             dataIndex="username"
             title={t("dnszonesoverviewpage.owner")}
             key="username"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(username: string | null | undefined, record: Domain) =>
               username ?? record.user_id.substring(0, 8)
             }

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -21,7 +21,7 @@ import {
 } from "@icons";
 import { useNavigate, useSearchParams, Link } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { apiClient } from "../../../apiClient";
 import { columnSearchProps } from "../../../components/columnSearch";
@@ -227,19 +227,12 @@ export const DomainList = () => {
     _filters,
     sorter,
   ) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<Domain> | undefined)
-      : (sorter as SorterResult<Domain>);
+    const { sort, order } = sorterToParams<Domain>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -311,7 +304,7 @@ export const DomainList = () => {
             dataIndex="name"
             title={t("domainlist.domain")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Domain>({
               placeholder: "Search by domain name",
@@ -341,7 +334,7 @@ export const DomainList = () => {
             dataIndex="username"
             title={t("domainlist.user")}
             key="username"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(username: string | null | undefined, record: Domain) => (
               <Link to={adminLinks.user(record.user_id)}>
                 {username ?? record.user_id.substring(0, 8)}
@@ -352,7 +345,7 @@ export const DomainList = () => {
             dataIndex="is_enabled"
             title={t("domainlist.status")}
             key="is_enabled"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(enabled: boolean) =>
               enabled ? (
                 <Tag color="green">active</Tag>

--- a/panel-ui/src/shells/admin/packages/PackageList.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageList.tsx
@@ -8,7 +8,7 @@ import { EditOutlined, PackageOpenOutlined, SearchOutlined, DeleteOutlined } fro
 
 import { RowActions } from "../../../components/RowActions";
 import { useNavigate } from "react-router";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { EmptyWithCTA } from "../../../components/EmptyWithCTA";
@@ -49,19 +49,12 @@ export const PackageList = () => {
     _filters,
     sorter,
   ) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<Package> | undefined)
-      : (sorter as SorterResult<Package>);
+    const { sort, order } = sorterToParams<Package>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -115,7 +108,7 @@ export const PackageList = () => {
             dataIndex="name"
             title={t("packagelist.name")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             filterIcon={() => (
               <SearchOutlined
@@ -141,42 +134,42 @@ export const PackageList = () => {
             dataIndex="disk_quota_mb"
             title={t("packagelist.disk_mb")}
             key="disk_quota_mb"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="bandwidth_quota_mb"
             title={t("packagelist.bandwidth_mb")}
             key="bandwidth_quota_mb"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="max_domains"
             title={t("packagelist.domains")}
             key="max_domains"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="max_email_accounts"
             title={t("packagelist.email")}
             key="max_email_accounts"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="max_databases"
             title="DB"
             key="max_databases"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(value: number) => formatQuota(value)}
           />
           <Table.Column
             dataIndex="ssh_enabled"
             title={t("packagelist.ssh")}
             key="ssh_enabled"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(enabled: boolean) =>
               enabled ? <Tag color="green">yes</Tag> : <Tag>no</Tag>
             }
@@ -185,7 +178,7 @@ export const PackageList = () => {
             dataIndex="php_exec_enabled"
             title={t("packagelist.php_exec")}
             key="php_exec_enabled"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(enabled: boolean) =>
               enabled ? <Tag color="red">on</Tag> : <Tag>off</Tag>
             }
@@ -194,7 +187,7 @@ export const PackageList = () => {
             dataIndex="created_at"
             title={t("packagelist.created")}
             key="created_at"
-            sorter={{ multiple: 1 }}
+            sorter
             render={(ts: string) => shortDateTime(ts)}
           />
           <Table.Column

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -37,7 +37,7 @@ import {
   SettingOutlined,
 } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { columnSearchProps } from "../../../components/columnSearch";
 import { RowActions } from "../../../components/RowActions";
@@ -352,19 +352,12 @@ export const UserApplicationList = () => {
   const handleTableChange: React.ComponentProps<
     typeof Table<ApplicationInstall>
   >["onChange"] = (pagination, _filters, sorter) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<ApplicationInstall> | undefined)
-      : (sorter as SorterResult<ApplicationInstall>);
+    const { sort, order } = sorterToParams<ApplicationInstall>(sorter);
     tableQuery.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -534,7 +527,7 @@ export const UserApplicationList = () => {
             dataIndex="domain_name"
             title={t("userapplicationlist.domain")}
             key="domain_name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<ApplicationInstall>({
               placeholder: "Search by domain",
@@ -610,7 +603,7 @@ export const UserApplicationList = () => {
             title={t("userapplicationlist.created")}
             responsive={["lg"]}
             key="created_at"
-            sorter={{ multiple: 2 }}
+            sorter
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<ApplicationInstall>

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -14,7 +14,7 @@ import {
   PlusSquareOutlined,
   ThunderboltOutlined,
 } from "@icons";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 import { ssoAdminer, ssoPhpMyAdmin } from "../../../apiClient";
 import { EngineTag } from "../../../components/EngineTag";
@@ -76,19 +76,12 @@ export const UserDatabaseList = () => {
   const handleTableChange: React.ComponentProps<
     typeof Table<Database>
   >["onChange"] = (pagination, _filters, sorter) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<Database> | undefined)
-      : (sorter as SorterResult<Database>);
+    const { sort, order } = sorterToParams<Database>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -218,7 +211,7 @@ export const UserDatabaseList = () => {
             dataIndex="name"
             title={t("userdatabaselist.database")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Database>({
               placeholder: "Search by database name",
@@ -248,7 +241,7 @@ export const UserDatabaseList = () => {
             dataIndex="created_at"
             title={t("userdatabaselist.created")}
             key="created_at"
-            sorter={{ multiple: 2 }}
+            sorter
             render={(date: string) => shortDateTime(date)}
           />
           <Table.Column<Database>

--- a/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
+++ b/panel-ui/src/shells/user/dns/UserDNSZonesOverviewPage.tsx
@@ -14,6 +14,7 @@ import { columnSearchProps } from "../../../components/columnSearch";
 import { DNSSECTable } from "../../../components/dnssec/DNSSECTable";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
 import { useTableURL } from "../../../hooks/useTableURL";
+import { sorterToParams } from "../../../utils/tableSorter";
 
 interface Domain {
   id: string;
@@ -85,6 +86,19 @@ const ZonesTab = () => {
     );
   };
 
+  // Project AntD's sorter into the URL params so the server does the
+  // ORDER BY. Without an onChange the sort arrows rendered but changed
+  // nothing — the columns declared a server-side sorter and nothing was
+  // listening for it.
+  const handleTableChange: React.ComponentProps<typeof Table<Domain>>["onChange"] = (
+    _pagination,
+    _filters,
+    sorter,
+  ) => {
+    const { sort, order } = sorterToParams<Domain>(sorter);
+    query.setParams({ sort, order, page: 1 });
+  };
+
   return (
     <>
       <Alert
@@ -99,6 +113,7 @@ const ZonesTab = () => {
         <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t("userdnszonesoverviewpage.no_domains_found")} />
       ) : (
         <SearchableTableStringQ<Domain>
+          onChange={handleTableChange}
           rowKey="id"
           loading={query.isLoading}
           dataSource={query.items}
@@ -116,7 +131,7 @@ const ZonesTab = () => {
             dataIndex="name"
             title={t("userdnszonesoverviewpage.domain_name")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Domain>({
               placeholder: "Search by domain name",

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -22,7 +22,7 @@ import { Button, Card, Dropdown, Space, Table, Tag, Tooltip, Typography } from "
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import type { SorterResult } from "antd/es/table/interface";
+import { sorterToParams } from "../../../utils/tableSorter";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { DomainDocRootModal } from "./DomainDocRootModal";
@@ -200,19 +200,12 @@ export const UserDomainList = () => {
     _filters,
     sorter,
   ) => {
-    const single = Array.isArray(sorter)
-      ? (sorter[0] as SorterResult<Domain> | undefined)
-      : (sorter as SorterResult<Domain>);
+    const { sort, order } = sorterToParams<Domain>(sorter);
     query.setParams({
       page: pagination.current ?? 1,
       pageSize: pagination.pageSize ?? 20,
-      sort: single?.columnKey ? String(single.columnKey) : undefined,
-      order:
-        single?.order === "ascend"
-          ? "asc"
-          : single?.order === "descend"
-            ? "desc"
-            : undefined,
+      sort,
+      order,
     });
   };
 
@@ -258,7 +251,7 @@ export const UserDomainList = () => {
             dataIndex="name"
             title={t("userdomainlist.domain")}
             key="name"
-            sorter={{ multiple: 1 }}
+            sorter
             defaultSortOrder="ascend"
             {...columnSearchProps<Domain>({
               placeholder: "Search by domain name",


### PR DESCRIPTION
Follow-up to #1025, which fixed this on the Users list. The same two defects were spread across the rest of the panel.

## Defect 1 — clicking a second column sent the first column's key

`sorter={{ multiple: 1 }}` declares **multi-column** sorting, so AntD hands `onChange` an **array** once more than one column is sorted. Seven handlers read `sorter[0]`. After any column had been sorted, every later click appended to that array, `[0]` stayed the **old** column, and `setParams` rewrote the same `?sort=` it already had.

The header toggled. The query never moved.

The backend cannot honour multi-column sort anyway — `repository.ListOptions` carries a single `Sort string`, whitelist-validated per repo. So `{ multiple: N }` was declaring a capability the server has never had.

## Defect 2 — four pages had sort controls wired to nothing

**admin DNS Zones, user DNS Zones, Database Users, Audit Log** declared sorters with **no `onChange` at all**. Those arrows were pure decoration: clicking them did nothing whatsoever, in either direction. They now project into the URL like every other list.

## The change

- Every column uses single-column server-side `sorter`, matching what the API implements
- Every handler goes through `sorterToParams()` (added in #1025, already covered by regression tests), which picks the most recently **activated** entry instead of `[0]` and **clears** the params when a sort is cancelled rather than pinning `ORDER BY` on a stale column

Seven copies of the same inline projection collapse into the shared helper — net **-49 lines** of logic, +4 newly-working tables.

## Affected pages

| Page | Was |
|---|---|
| admin Domains, Databases, Packages, Applications | `sorter[0]` — second column ignored |
| user Domains, Databases, Applications | same |
| admin DNS Zones, user DNS Zones, Database Users, Audit Log | no `onChange` — inert |

## Test plan

- [x] `sorterToParams` regression tests cover the array case, the cancel case, and entries left in the payload without an order
- [x] `npx tsc -b` clean
- [x] vitest: **48 files / 229 tests** pass
- [x] `npm run build` clean

Not done: clicking through all eleven pages on a live panel — that needs admin credentials I don't have. The projection itself is unit-tested, and Playwright covers the list views.

Deliberately UI-only, so it can be reviewed and reverted independently of the backend work.