### PR TITLE
fix(docker-apps): bump Jabali Sounder catalog to 0.5.22 (JAB-234)

### DIFF
--- a/install/docker-apps/jabali-sounder/app.yaml
+++ b/install/docker-apps/jabali-sounder/app.yaml
@@ -2,7 +2,7 @@ slug: jabali-sounder
 popularity: 38
 name: Jabali Sounder
 tags: ["Monitoring"]
-version: "0.5.17"
+version: "0.5.22"
 description: |
   Control plane for managing multiple Jabali Panel servers from one
   place: enroll panels, monitor their health, and run remediation.
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/shukiv/jabali-sounder
 documentation: https://github.com/shukiv/jabali-sounder/blob/main/docs/DOCKER.md
 
-image_channel: ghcr.io/shukiv/jabali-sounder:0.5.17@sha256:03f982343f03c2674ac83ffa09d9d2608f8f055b461847c2b4f24e291b85c0ed
+image_channel: ghcr.io/shukiv/jabali-sounder:0.5.22@sha256:28f10ba9d95661b3fb25c1b671da094c6acdc7e2df20a752cd45c953728e3de9
 volume_owner: "10001:10001"
 update_mode: manual
 


### PR DESCRIPTION
## Summary
The Docker Apps catalog pinned Jabali Sounder at **0.5.17** while upstream shipped through **0.5.22** (latest release, 2026-08-09), so installed instances reported "already on the latest catalog version" with no update offered. Reported via the Sounder tracker (sounder GH #6), tracked as JAB-234.

- `version`: 0.5.17 → 0.5.22
- `image_channel`: retagged + re-pinned to `0.5.22@sha256:28f10ba9…` — digest fetched directly from ghcr.io (`docker-content-digest` for tag 0.5.22), not taken on faith from the report
- `update_mode: manual` unchanged — users still click Update; `/data` volume persists

## Test plan
- [x] `go test ./internal/dockerapp/` (catalog render + digest-pin tests) green on the bumped file
- [x] Digest verified against ghcr.io manifest HEAD for tag 0.5.22
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)