### PR TITLE
feat(ci): weekly auto-bump of the Docker-apps catalog (JAB-234)

### DIFF
--- a/.github/workflows/catalog-bump.yml
+++ b/.github/workflows/catalog-bump.yml
@@ -1,0 +1,107 @@
+# Weekly Docker-apps catalog bump (JAB-234). cmd/catalog-bump checks every
+# catalog entry against its upstream registry and rewrites app.yaml with the
+# newest matching tag + digest; this workflow turns the diff into ONE roll-up
+# PR on the fixed branch catalog-auto-bump. A human reviews (major bumps are
+# flagged ⚠ in the table) and merges — nothing ships without review.
+#
+# Token: prefers the CATALOG_BUMP_TOKEN secret (fine-grained PAT, contents +
+# pull-requests write). With only the built-in GITHUB_TOKEN, GitHub fires no
+# CI on the bot's PR — the PR body then carries a loud warning and the PR
+# must be closed/reopened (or the branch touched) to trigger checks.
+#
+# The self-hosted runner has curl + python3 but no gh CLI — REST over curl,
+# same as monthly-deps.yml / release.yml.
+name: Weekly catalog bump
+
+on:
+  schedule:
+    - cron: "30 6 * * 1" # 06:30 UTC every Monday
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  GO_VERSION: "1.25"
+
+jobs:
+  bump:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CATALOG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          # cache: false — see monthly-deps.yml: setup-go's cache layer
+          # conflicts with the runner's persistent GOMODCACHE and hangs the
+          # post-run step, wedging the single runner.
+          cache: false
+
+      - name: Check upstreams and rewrite the catalog
+        run: |
+          set -euo pipefail
+          cd panel-api
+          go run ./cmd/catalog-bump -catalog ../install/docker-apps | tee "$RUNNER_TEMP/bump-report.md"
+
+      - name: Open or update the bump PR
+        env:
+          GH_TOKEN: ${{ secrets.CATALOG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+          HAS_PAT: ${{ secrets.CATALOG_BUMP_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- install/docker-apps; then
+            echo "Catalog is up to date — no PR needed."
+            exit 0
+          fi
+
+          git config user.name "jabali-catalog-bot"
+          git config user.email "catalog-bot@users.noreply.github.com"
+          BRANCH="catalog-auto-bump"
+          git checkout -B "$BRANCH"
+          git add install/docker-apps
+          git commit -m "chore(docker-apps): weekly catalog version bumps"
+          # The bot owns this branch and force-pushes weekly — never park
+          # manual edits here; push fixups to a different branch instead.
+          git push -f origin "$BRANCH"
+
+          {
+            echo "_Auto-generated on $(date -u +'%Y-%m-%d') by \`.github/workflows/catalog-bump.yml\`._"
+            echo "_The bot force-pushes \`${BRANCH}\` weekly — do not park manual edits on this branch._"
+            echo
+            if [[ "$HAS_PAT" != "true" ]]; then
+              echo "> [!WARNING]"
+              echo "> **No CI ran on this PR** — it was pushed with the built-in \`GITHUB_TOKEN\`, which"
+              echo "> cannot trigger workflows. Close and reopen the PR to run checks, or add a"
+              echo "> \`CATALOG_BUMP_TOKEN\` repo secret (fine-grained PAT: contents + pull-requests"
+              echo "> write) so future bump PRs get CI automatically."
+              echo
+            fi
+            echo "Rows marked **⚠ MAJOR** change the app's major track — re-validate that entry's"
+            echo "ports/env/volumes (the catalog contract) before merging. Skipped rows are apps the"
+            echo "bumper cannot handle by design; re-pin them to versioned tags to bring them in."
+            echo
+            cat "$RUNNER_TEMP/bump-report.md"
+          } > "$RUNNER_TEMP/body.md"
+
+          API="https://api.github.com"
+          REPO="$GITHUB_REPOSITORY"
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          hdr=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+          TITLE="chore(docker-apps): weekly catalog version bumps"
+
+          NUM="$(curl -sS "${hdr[@]}" "${API}/repos/${REPO}/pulls?state=open&head=${OWNER}:${BRANCH}" \
+                 | python3 -c 'import json,sys; items=json.load(sys.stdin); print(items[0]["number"] if items else "")')"
+
+          PAYLOAD="$(python3 -c 'import json,sys; print(json.dumps({"title":sys.argv[1],"body":open(sys.argv[2]).read()}))' "$TITLE" "$RUNNER_TEMP/body.md")"
+
+          if [[ -n "$NUM" ]]; then
+            curl -sS "${hdr[@]}" -X PATCH "${API}/repos/${REPO}/pulls/${NUM}" -d "$PAYLOAD" >/dev/null
+            echo "Updated bump PR #${NUM}"
+          else
+            CREATE="$(python3 -c 'import json,sys; d=json.loads(sys.stdin.read()); d.update({"head":sys.argv[1],"base":"main"}); print(json.dumps(d))' "$BRANCH" <<<"$PAYLOAD")"
+            curl -sS "${hdr[@]}" -X POST "${API}/repos/${REPO}/pulls" -d "$CREATE" \
+              | python3 -c 'import json,sys; r=json.load(sys.stdin); print("Created bump PR #%s" % r.get("number", r))'
+          fi

--- a/install/docker-apps/enclosed/app.yaml
+++ b/install/docker-apps/enclosed/app.yaml
@@ -2,7 +2,7 @@ slug: enclosed
 tenant_installable: true
 name: Enclosed
 tags: ["Developer tools"]
-version: "latest"
+version: "1.16.0"
 description: |
   Minimalist, open-source web app for sending private and encrypted
   notes and files. Zero-knowledge: content is end-to-end encrypted in

--- a/install/docker-apps/n8n/app.yaml
+++ b/install/docker-apps/n8n/app.yaml
@@ -2,7 +2,7 @@ slug: n8n
 popularity: 88
 name: n8n
 tags: ["Automation", "Developer tools"]
-version: "2.25.5"
+version: "2.28.2"
 description: |
   Workflow automation tool. Build, run, and share workflows that
   connect APIs, databases, and services. Self-hosted, single

--- a/panel-api/cmd/catalog-bump/catalog.go
+++ b/panel-api/cmd/catalog-bump/catalog.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// bumpMode says how an entry's tag relates to its version field.
+type bumpMode int
+
+const (
+	// modePinned: the tag core equals the version field (forgejo 15.0.3).
+	// New release = a newer matching tag.
+	modePinned bumpMode = iota
+	// modeTrack: the tag is a rolling track (ghost 6-alpine, gitea 1.26)
+	// and the version field carries the resolved concrete version
+	// (6.44.1, 1.26.2). New release = the track tag's digest moving.
+	modeTrack
+)
+
+// appEntry is the classified state of one catalog app.yaml.
+type appEntry struct {
+	Slug    string
+	Path    string
+	Raw     string
+	Ref     imageRef
+	TagP    tagParts
+	Version string // version: field value
+	Mode    bumpMode
+
+	// Skip is the human-readable reason this app cannot be auto-bumped
+	// (unversioned tag scheme, version/tag mismatch, parse failure).
+	Skip string
+}
+
+var (
+	imageChannelLineRe = regexp.MustCompile(`(?m)^image_channel: (\S+)$`)
+	versionLineRe      = regexp.MustCompile(`(?m)^version: "([^"]*)"$`)
+)
+
+// classify decides, offline, whether an app.yaml is auto-bumpable. Every
+// non-bumpable state carries a named reason — no silent skips.
+func classify(slug, path, raw string) appEntry {
+	e := appEntry{Slug: slug, Path: path, Raw: raw}
+
+	im := imageChannelLineRe.FindStringSubmatch(raw)
+	if im == nil {
+		e.Skip = "no image_channel line"
+		return e
+	}
+	ref, err := parseImageRef(im[1])
+	if err != nil {
+		e.Skip = err.Error()
+		return e
+	}
+	e.Ref = ref
+
+	vm := versionLineRe.FindStringSubmatch(raw)
+	if vm == nil {
+		e.Skip = "no version line"
+		return e
+	}
+	e.Version = vm[1]
+
+	p, ok := parseTag(ref.Tag)
+	if !ok {
+		e.Skip = fmt.Sprintf("unversioned tag scheme %q — re-pin to a versioned tag to enable auto-bump", ref.Tag)
+		return e
+	}
+	e.TagP = p
+
+	// The panel offers updates by comparing the catalog version: field, so
+	// the tag/version pair must be coherent: either the tag core IS the
+	// version (pinned mode), or the tag is a track the version refines
+	// (6-alpine carrying 6.44.1). Anything else needs a human.
+	if e.Version == p.coreString() {
+		e.Mode = modePinned
+		return e
+	}
+	if vp, ok := parseTag(e.Version); ok && vp.Prefix == "" && vp.Suffix == "" &&
+		len(vp.Core) > len(p.Core) && compareCore(vp.Core[:len(p.Core)], p.Core) == 0 {
+		e.Mode = modeTrack
+		return e
+	}
+	e.Skip = fmt.Sprintf("version field %q != tag core %q — needs manual review", e.Version, p.coreString())
+	return e
+}
+
+// loadCatalog reads and classifies every app in the catalog dir, sorted.
+func loadCatalog(dir string) ([]appEntry, error) {
+	dirs, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read catalog %s: %w", dir, err)
+	}
+	var entries []appEntry
+	for _, d := range dirs {
+		if !d.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, d.Name(), "app.yaml")
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		entries = append(entries, classify(d.Name(), path, string(raw)))
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Slug < entries[j].Slug })
+	return entries, nil
+}
+
+// rewriteAppYaml returns raw with the version: value and the image_channel
+// tag@digest replaced, leaving every other byte untouched.
+func rewriteAppYaml(raw string, e appEntry, newTag, newCore, newDigest string) (string, error) {
+	oldPin := ":" + e.Ref.Tag + "@" + e.Ref.Digest
+	newPin := ":" + newTag + "@" + newDigest
+	if !strings.Contains(raw, oldPin) {
+		return "", fmt.Errorf("pin %q not found", oldPin)
+	}
+	out := strings.Replace(raw, oldPin, newPin, 1)
+
+	oldVer := `version: "` + e.Version + `"`
+	newVer := `version: "` + newCore + `"`
+	if !strings.Contains(out, oldVer) {
+		return "", fmt.Errorf("version line %q not found", oldVer)
+	}
+	out = strings.Replace(out, oldVer, newVer, 1)
+	return out, nil
+}

--- a/panel-api/cmd/catalog-bump/catalog_test.go
+++ b/panel-api/cmd/catalog-bump/catalog_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sounderYaml = `slug: jabali-sounder
+popularity: 38
+name: Jabali Sounder
+version: "0.5.17"
+icon: icon.svg
+
+image_channel: ghcr.io/shukiv/jabali-sounder:0.5.17@` + testDigest + `
+volume_owner: "10001:10001"
+update_mode: manual
+`
+
+func TestClassifyBumpable(t *testing.T) {
+	e := classify("jabali-sounder", "x", sounderYaml)
+	if e.Skip != "" {
+		t.Fatalf("unexpected skip: %s", e.Skip)
+	}
+	if e.Version != "0.5.17" || e.Ref.Tag != "0.5.17" || e.Ref.Host != "ghcr.io" || e.Mode != modePinned {
+		t.Fatalf("bad classify: %+v", e)
+	}
+}
+
+func TestClassifyTrackMode(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"ghost 6-alpine / 6.44.1",
+			"version: \"6.44.1\"\nimage_channel: ghost:6-alpine@" + testDigest + "\n"},
+		{"gitea 1.26 / 1.26.2",
+			"version: \"1.26.2\"\nimage_channel: gitea/gitea:1.26@" + testDigest + "\n"},
+		{"uptime-kuma 2 / 2.4.0",
+			"version: \"2.4.0\"\nimage_channel: louislam/uptime-kuma:2@" + testDigest + "\n"},
+	}
+	for _, c := range cases {
+		e := classify("x", "x", c.yaml)
+		if e.Skip != "" || e.Mode != modeTrack {
+			t.Errorf("%s: skip=%q mode=%v, want track mode", c.name, e.Skip, e.Mode)
+		}
+	}
+	// A version that does NOT refine the track (2.25.5 under tag 2.28.2)
+	// stays a mismatch — that's the n8n data bug this tool's corpus caught.
+	e := classify("x", "x", "version: \"2.25.5\"\nimage_channel: n8nio/n8n:2.28.2@"+testDigest+"\n")
+	if e.Skip == "" || !strings.Contains(e.Skip, "needs manual review") {
+		t.Errorf("non-refining version must skip, got %+v", e)
+	}
+}
+
+func TestClassifySkips(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string // substring of the skip reason
+	}{
+		{"unversioned latest",
+			"version: \"latest\"\nimage_channel: mediacms/mediacms:latest@" + testDigest + "\n",
+			"unversioned tag scheme"},
+		{"unversioned stable",
+			"version: \"stable\"\nimage_channel: mondedie/flarum:stable@" + testDigest + "\n",
+			"unversioned tag scheme"},
+		{"version/tag mismatch",
+			"version: \"9.9.9\"\nimage_channel: gitea/gitea:1.26@" + testDigest + "\n",
+			"needs manual review"},
+		{"unpinned image",
+			"version: \"1.0\"\nimage_channel: gitea/gitea:1.26\n",
+			"not digest-pinned"},
+		{"missing version line",
+			"image_channel: gitea/gitea:1.26@" + testDigest + "\n",
+			"no version line"},
+	}
+	for _, c := range cases {
+		e := classify("x", "x", c.yaml)
+		if e.Skip == "" || !strings.Contains(e.Skip, c.want) {
+			t.Errorf("%s: skip = %q, want containing %q", c.name, e.Skip, c.want)
+		}
+	}
+}
+
+func TestRewriteAppYaml(t *testing.T) {
+	e := classify("jabali-sounder", "x", sounderYaml)
+	newDigest := "sha256:" + strings.Repeat("ab", 32)
+	out, err := rewriteAppYaml(sounderYaml, e, "0.5.22", "0.5.22", newDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `version: "0.5.22"`) {
+		t.Error("version line not rewritten")
+	}
+	if !strings.Contains(out, "image_channel: ghcr.io/shukiv/jabali-sounder:0.5.22@"+newDigest) {
+		t.Error("image_channel not rewritten")
+	}
+	// Everything except the two rewritten values must be byte-identical —
+	// volume_owner's "10001:10001" especially must survive untouched.
+	restore := strings.Replace(out, "0.5.22@"+newDigest, "0.5.17@"+testDigest, 1)
+	restore = strings.Replace(restore, `version: "0.5.22"`, `version: "0.5.17"`, 1)
+	if restore != sounderYaml {
+		t.Error("rewrite touched bytes outside the two pinned values")
+	}
+}
+
+// TestCatalogCorpus walks the real shipped catalog and asserts every app
+// classifies into exactly one named bucket: auto-bumpable, or skipped with
+// a stated reason from the known-permanent set. A new app with a tag scheme
+// the bumper can't handle fails here instead of silently never updating.
+func TestCatalogCorpus(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "install", "docker-apps")
+	if _, err := os.Stat(root); err != nil {
+		t.Skipf("catalog dir not found: %v", err)
+	}
+	entries, err := loadCatalog(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 40 {
+		t.Fatalf("expected the full catalog, got %d apps", len(entries))
+	}
+
+	// Permanent, by-design skips. Re-pinning these to versioned tags would
+	// bring them under auto-bump — until then they are listed, not silent.
+	permanentSkips := map[string]string{
+		"mediacms": "unversioned tag scheme", // :latest
+		"flarum":   "unversioned tag scheme", // :stable
+		"dokuwiki": "unversioned tag scheme", // version-YYYY-MM-DD
+	}
+
+	for _, e := range entries {
+		if e.Skip == "" {
+			continue
+		}
+		want, known := permanentSkips[e.Slug]
+		if !known {
+			t.Errorf("%s: unexpected skip %q — extend the bumper or add a justified permanent skip", e.Slug, e.Skip)
+			continue
+		}
+		if !strings.Contains(e.Skip, want) {
+			t.Errorf("%s: skip reason %q, want containing %q", e.Slug, e.Skip, want)
+		}
+	}
+}

--- a/panel-api/cmd/catalog-bump/helpers_test.go
+++ b/panel-api/cmd/catalog-bump/helpers_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "os"
+
+func createApp(dir, appYaml string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dir+"/app.yaml", []byte(appYaml), 0o644)
+}
+
+func readFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	return string(b), err
+}

--- a/panel-api/cmd/catalog-bump/main.go
+++ b/panel-api/cmd/catalog-bump/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// result is the outcome of checking one app against its registry.
+type result struct {
+	appEntry
+	NewTag     string // tag to pin (may equal the current tag on a digest refresh)
+	NewVersion string
+	NewDigest  string
+	Major      bool
+	Refresh    bool   // same tag, upstream re-pushed it (new digest)
+	Unresolved bool   // track digest moved but no concrete tag matched it
+	Truncated  bool   // tag listing hit the page cap
+	Err        string // registry-side failure (kept per-app, run continues)
+}
+
+func (r result) action() string {
+	var s string
+	switch {
+	case r.Err != "":
+		return "❌ error: " + r.Err
+	case r.Skip != "":
+		return "⏭ skipped: " + r.Skip
+	case r.NewTag == "":
+		return "✅ up to date"
+	case r.Major:
+		s = "⚠ MAJOR bump — re-validate ports/env/volumes before merging"
+	case r.Refresh:
+		s = "↻ digest refresh (tag re-pushed upstream)"
+	default:
+		s = "⬆ bumped"
+	}
+	if r.Unresolved {
+		s += " — ⚠ resolved version unknown, version field left as-is; verify manually"
+	}
+	return s
+}
+
+func run(catalogDir string, dryRun bool, client *regClient, out *strings.Builder) (changed int, hadErr bool, err error) {
+	entries, err := loadCatalog(catalogDir)
+	if err != nil {
+		return 0, false, err
+	}
+
+	var results []result
+	for _, e := range entries {
+		r := result{appEntry: e}
+		if e.Skip == "" {
+			r = checkApp(e, client, dryRun)
+		}
+		if r.Err != "" {
+			hadErr = true
+		}
+		if r.NewTag != "" {
+			changed++
+		}
+		results = append(results, r)
+	}
+
+	fmt.Fprintf(out, "| App | Image tag | Version | Status |\n|---|---|---|---|\n")
+	for _, r := range results {
+		tagCol, verCol := "—", "—"
+		if r.Ref.Tag != "" {
+			tagCol = "`" + r.Ref.Tag + "`"
+			verCol = r.Version
+		}
+		if r.NewTag != "" && r.NewTag != r.Ref.Tag {
+			tagCol += " → `" + r.NewTag + "`"
+		}
+		if r.NewVersion != "" && r.NewVersion != r.Version {
+			verCol += " → " + r.NewVersion
+		}
+		fmt.Fprintf(out, "| %s | %s | %s | %s |\n", r.Slug, tagCol, verCol, r.action())
+		if r.Truncated {
+			fmt.Fprintf(out, "| | | | ⚠ tag listing truncated at page cap — newest tag may be missed |\n")
+		}
+	}
+	return changed, hadErr, nil
+}
+
+// checkApp queries the registry for one bumpable entry and, unless dryRun,
+// rewrites its app.yaml in place. Two update signals are checked for every
+// app: a newer matching tag (pickBestTag), and the current tag's digest
+// having moved upstream (rolling tracks like ghost:6-alpine, odoo:18.0).
+func checkApp(e appEntry, client *regClient, dryRun bool) result {
+	r := result{appEntry: e}
+	tags, truncated, err := client.tags(e.Ref.Host, e.Ref.Repo)
+	r.Truncated = truncated
+	if err != nil {
+		r.Err = err.Error()
+		return r
+	}
+
+	targetTag, targetParts := e.Ref.Tag, e.TagP
+	bestTag, bestParts, advance := pickBestTag(e.TagP, tags)
+	if advance {
+		targetTag, targetParts = bestTag, bestParts
+	}
+	liveDigest, err := client.digest(e.Ref.Host, e.Ref.Repo, targetTag)
+	if err != nil {
+		r.Err = err.Error()
+		return r
+	}
+	if !advance && liveDigest == e.Ref.Digest {
+		return r // up to date
+	}
+
+	newVersion := e.Version
+	switch e.Mode {
+	case modePinned:
+		if advance {
+			newVersion = targetParts.coreString()
+		}
+	case modeTrack:
+		if v := resolveConcrete(client, e.Ref.Host, e.Ref.Repo, targetParts, tags, liveDigest); v != "" {
+			newVersion = v
+		} else {
+			r.Unresolved = true
+		}
+	}
+
+	r.NewTag = targetTag
+	r.NewVersion = newVersion
+	r.NewDigest = liveDigest
+	r.Major = targetParts.Core[0] != e.TagP.Core[0]
+	r.Refresh = !advance
+	if dryRun {
+		return r
+	}
+	rewritten, err := rewriteAppYaml(e.Raw, e, targetTag, newVersion, liveDigest)
+	if err == nil {
+		err = os.WriteFile(e.Path, []byte(rewritten), 0o644)
+	}
+	if err != nil {
+		r.Err = err.Error()
+		r.NewTag, r.NewVersion, r.NewDigest = "", "", ""
+	}
+	return r
+}
+
+func main() {
+	catalogDir := flag.String("catalog", "../install/docker-apps", "path to the docker-apps catalog")
+	dryRun := flag.Bool("dry-run", false, "report only; do not rewrite app.yaml files")
+	flag.Parse()
+
+	var out strings.Builder
+	changed, hadErr, err := run(*catalogDir, *dryRun, newRegClient(), &out)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "catalog-bump:", err)
+		os.Exit(1)
+	}
+	fmt.Print(out.String())
+	fmt.Printf("\n%d app(s) with updates.\n", changed)
+	if hadErr {
+		// Per-app registry failures are visible in the table; a non-zero
+		// exit here would kill the whole weekly PR over one flaky registry.
+		fmt.Fprintln(os.Stderr, "catalog-bump: some apps failed — see table")
+	}
+}

--- a/panel-api/cmd/catalog-bump/ref.go
+++ b/panel-api/cmd/catalog-bump/ref.go
@@ -1,0 +1,153 @@
+// Command catalog-bump checks every Docker-apps catalog entry against its
+// upstream registry and rewrites app.yaml with the newest matching tag +
+// digest (JAB-234). It is run by .github/workflows/catalog-bump.yml; humans
+// review and merge the resulting PR.
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// imageRef is a parsed image_channel value: [host/]repo:tag@sha256:digest.
+type imageRef struct {
+	Host   string // registry host, e.g. ghcr.io / registry-1.docker.io
+	Repo   string // repository path, e.g. shukiv/jabali-sounder or library/ghost
+	Tag    string
+	Digest string // sha256:<64 hex>
+}
+
+var digestRe = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// parseImageRef splits an image_channel reference. Catalog policy (GH #458)
+// requires the digest, so a ref without @sha256:… is an error here too.
+func parseImageRef(s string) (imageRef, error) {
+	var r imageRef
+	name, digest, ok := strings.Cut(s, "@")
+	if !ok || !digestRe.MatchString(digest) {
+		return r, fmt.Errorf("ref %q is not digest-pinned", s)
+	}
+	r.Digest = digest
+
+	// The tag separator is the last ':' after the last '/'.
+	slash := strings.LastIndex(name, "/")
+	colon := strings.LastIndex(name, ":")
+	if colon <= slash {
+		return r, fmt.Errorf("ref %q has no tag", s)
+	}
+	r.Tag = name[colon+1:]
+	path := name[:colon]
+
+	// A first segment with a dot or port is a registry host; otherwise the
+	// ref lives on Docker Hub (official images get the library/ namespace).
+	first, rest, hasSlash := strings.Cut(path, "/")
+	if hasSlash && (strings.ContainsAny(first, ".:") || first == "localhost") {
+		r.Host = first
+		r.Repo = rest
+		// docker.io is the UI hostname, not the registry API endpoint.
+		if r.Host == "docker.io" || r.Host == "index.docker.io" {
+			r.Host = "registry-1.docker.io"
+		}
+	} else {
+		r.Host = "registry-1.docker.io"
+		if hasSlash {
+			r.Repo = path
+		} else {
+			r.Repo = "library/" + path
+		}
+	}
+	if r.Repo == "" {
+		return r, fmt.Errorf("ref %q has no repository", s)
+	}
+	return r, nil
+}
+
+// tagParts decomposes a tag into prefix ("v" or ""), numeric core components,
+// and a literal suffix, e.g. v8.2.1-trixie → "v", [8 2 1], "-trixie".
+type tagParts struct {
+	Prefix string
+	Core   []int
+	Suffix string
+}
+
+var tagRe = regexp.MustCompile(`^(v?)(\d+(?:\.\d+)*)(.*)$`)
+
+// hexSuffixRe marks build-hash suffixes (searxng's 2026.6.20-fd42d4fda):
+// these change every release, so candidates match the pattern, not the text.
+var hexSuffixRe = regexp.MustCompile(`^-[0-9a-f]{7,}$`)
+
+// parseTag returns ok=false for unversioned schemes (latest, stable,
+// version-2025-05-14b) — those entries are reported for manual handling.
+func parseTag(tag string) (tagParts, bool) {
+	m := tagRe.FindStringSubmatch(tag)
+	if m == nil {
+		return tagParts{}, false
+	}
+	var core []int
+	for _, c := range strings.Split(m[2], ".") {
+		n, err := strconv.Atoi(c)
+		if err != nil {
+			return tagParts{}, false
+		}
+		core = append(core, n)
+	}
+	return tagParts{Prefix: m[1], Core: core, Suffix: m[3]}, true
+}
+
+// coreString renders the numeric core (8.2.1) — the value the catalog's
+// version: field carries.
+func (p tagParts) coreString() string {
+	parts := make([]string, len(p.Core))
+	for i, n := range p.Core {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ".")
+}
+
+// compareCore returns -1/0/1 for a<b, a==b, a>b (equal component counts).
+func compareCore(a, b []int) int {
+	for i := range a {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// pickBestTag selects the highest tag that preserves the current tag's
+// pattern: same prefix, same component count (so a major-only track like
+// uptime-kuma's "2" only moves to "3", never to "2.1.3"), and the same
+// literal suffix (which is also what keeps -rc/-beta prereleases out).
+// Hash-style suffixes match by pattern instead. Returns ok=false when no
+// newer matching tag exists.
+func pickBestTag(cur tagParts, tags []string) (string, tagParts, bool) {
+	best := cur
+	bestTag := ""
+	hexMode := hexSuffixRe.MatchString(cur.Suffix)
+	for _, t := range tags {
+		p, ok := parseTag(t)
+		if !ok || p.Prefix != cur.Prefix || len(p.Core) != len(cur.Core) {
+			continue
+		}
+		if hexMode {
+			if !hexSuffixRe.MatchString(p.Suffix) {
+				continue
+			}
+		} else if p.Suffix != cur.Suffix {
+			continue
+		}
+		if compareCore(p.Core, best.Core) > 0 {
+			best = p
+			bestTag = t
+		}
+	}
+	if bestTag == "" {
+		return "", tagParts{}, false
+	}
+	return bestTag, best, true
+}

--- a/panel-api/cmd/catalog-bump/ref_test.go
+++ b/panel-api/cmd/catalog-bump/ref_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+const testDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestParseImageRef(t *testing.T) {
+	cases := []struct {
+		in   string
+		want imageRef
+	}{
+		{"ghost:6-alpine@" + testDigest,
+			imageRef{"registry-1.docker.io", "library/ghost", "6-alpine", testDigest}},
+		{"gitea/gitea:1.26@" + testDigest,
+			imageRef{"registry-1.docker.io", "gitea/gitea", "1.26", testDigest}},
+		{"ghcr.io/shukiv/jabali-sounder:0.5.22@" + testDigest,
+			imageRef{"ghcr.io", "shukiv/jabali-sounder", "0.5.22", testDigest}},
+		{"lscr.io/linuxserver/dokuwiki:version-2025-05-14b@" + testDigest,
+			imageRef{"lscr.io", "linuxserver/dokuwiki", "version-2025-05-14b", testDigest}},
+		{"codeberg.org/forgejo/forgejo:15.0.3@" + testDigest,
+			imageRef{"codeberg.org", "forgejo/forgejo", "15.0.3", testDigest}},
+		{"docker.io/searxng/searxng:2026.6.20-fd42d4fda@" + testDigest,
+			imageRef{"registry-1.docker.io", "searxng/searxng", "2026.6.20-fd42d4fda", testDigest}},
+	}
+	for _, c := range cases {
+		got, err := parseImageRef(c.in)
+		if err != nil {
+			t.Errorf("parseImageRef(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseImageRef(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseImageRefRejects(t *testing.T) {
+	for _, in := range []string{
+		"ghost:6-alpine",                          // no digest (violates GH #458 pin policy)
+		"ghost@" + testDigest,                     // no tag
+		"ghost:latest@sha256:short",               // malformed digest
+		"nginx:1.25@sha256:ZZZ" + testDigest[10:], // non-hex digest
+	} {
+		if _, err := parseImageRef(in); err == nil {
+			t.Errorf("parseImageRef(%q) should fail", in)
+		}
+	}
+}
+
+func TestParseTag(t *testing.T) {
+	cases := []struct {
+		in     string
+		ok     bool
+		prefix string
+		core   []int
+		suffix string
+	}{
+		{"0.5.22", true, "", []int{0, 5, 22}, ""},
+		{"v8.2.1-trixie", true, "v", []int{8, 2, 1}, "-trixie"},
+		{"6-alpine", true, "", []int{6}, "-alpine"},
+		{"2", true, "", []int{2}, ""},
+		{"18.0", true, "", []int{18, 0}, ""},
+		{"2026.6.20-fd42d4fda", true, "", []int{2026, 6, 20}, "-fd42d4fda"},
+		{"5-apache", true, "", []int{5}, "-apache"},
+		{"latest", false, "", nil, ""},
+		{"stable", false, "", nil, ""},
+		{"version-2025-05-14b", false, "", nil, ""},
+	}
+	for _, c := range cases {
+		got, ok := parseTag(c.in)
+		if ok != c.ok {
+			t.Errorf("parseTag(%q) ok=%v, want %v", c.in, ok, c.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got.Prefix != c.prefix || !reflect.DeepEqual(got.Core, c.core) || got.Suffix != c.suffix {
+			t.Errorf("parseTag(%q) = %+v, want {%q %v %q}", c.in, got, c.prefix, c.core, c.suffix)
+		}
+	}
+}
+
+func TestPickBestTag(t *testing.T) {
+	cases := []struct {
+		name string
+		cur  string
+		tags []string
+		want string // "" = no bump
+	}{
+		{"patch bump", "0.5.17",
+			[]string{"0.5.16", "0.5.17", "0.5.21", "0.5.22", "latest"}, "0.5.22"},
+		{"prefix preserved", "v2.11.0",
+			[]string{"2.12.0", "v2.12.0", "v2.11.0"}, "v2.12.0"},
+		{"suffix exact", "v8.2.1-trixie",
+			[]string{"v8.3.0", "v8.3.0-bookworm", "v8.3.0-trixie"}, "v8.3.0-trixie"},
+		{"prerelease excluded by suffix", "1.36.0",
+			[]string{"1.37.0-rc1", "1.36.0"}, ""},
+		{"major track only", "2",
+			[]string{"2", "2.1.3", "3", "3.0.1", "10-beta"}, "3"},
+		{"minor track keeps count", "1.26",
+			[]string{"1.26.3", "1.27", "1.26"}, "1.27"},
+		{"distro suffix track", "33-apache",
+			[]string{"34", "34-apache", "34-fpm"}, "34-apache"},
+		{"hash suffix wildcard", "2026.6.20-fd42d4fda",
+			[]string{"2026.7.4-ab12cd34e", "2026.7.5-notahash!", "2026.6.20-fd42d4fda"}, "2026.7.4-ab12cd34e"},
+		{"nothing newer", "9.4.0", []string{"9.4.0", "9.3.0"}, ""},
+		{"numeric compare not lexical", "0.9.9", []string{"0.10.0"}, "0.10.0"},
+	}
+	for _, c := range cases {
+		cur, ok := parseTag(c.cur)
+		if !ok {
+			t.Fatalf("%s: bad current tag %q", c.name, c.cur)
+		}
+		got, _, found := pickBestTag(cur, c.tags)
+		if !found {
+			got = ""
+		}
+		if got != c.want {
+			t.Errorf("%s: pickBestTag = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/panel-api/cmd/catalog-bump/registry.go
+++ b/panel-api/cmd/catalog-bump/registry.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// maxTagPages bounds tags/list pagination (Docker Hub's ghost repo has
+// thousands of tags). Hitting the cap is reported, never silent.
+const maxTagPages = 50
+
+const manifestAccept = "application/vnd.oci.image.index.v1+json, " +
+	"application/vnd.docker.distribution.manifest.list.v2+json, " +
+	"application/vnd.oci.image.manifest.v1+json, " +
+	"application/vnd.docker.distribution.manifest.v2+json"
+
+// regClient talks the OCI distribution API against any registry, discovering
+// the token endpoint from the /v2/ WWW-Authenticate challenge (works for
+// Docker Hub, ghcr.io, lscr.io, codeberg.org alike).
+type regClient struct {
+	http *http.Client
+	// scheme is overridable for httptest servers ("https" in production).
+	scheme string
+	tokens map[string]string // host|repo → bearer token
+}
+
+func newRegClient() *regClient {
+	return &regClient{
+		http:   &http.Client{Timeout: 30 * time.Second},
+		scheme: "https",
+		tokens: map[string]string{},
+	}
+}
+
+var challengeFieldRe = regexp.MustCompile(`(\w+)="([^"]*)"`)
+
+// token performs anonymous pull-scope auth for host/repo. Registries that
+// answer /v2/ with 200 need no token; the empty string means exactly that.
+func (c *regClient) token(host, repo string) (string, error) {
+	key := host + "|" + repo
+	if t, ok := c.tokens[key]; ok {
+		return t, nil
+	}
+	resp, err := c.http.Get(c.scheme + "://" + host + "/v2/")
+	if err != nil {
+		return "", fmt.Errorf("probe %s: %w", host, err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		c.tokens[key] = ""
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		return "", fmt.Errorf("probe %s: unexpected status %d", host, resp.StatusCode)
+	}
+	challenge := resp.Header.Get("Www-Authenticate")
+	if !strings.HasPrefix(challenge, "Bearer ") {
+		return "", fmt.Errorf("probe %s: unsupported auth challenge %q", host, challenge)
+	}
+	fields := map[string]string{}
+	for _, m := range challengeFieldRe.FindAllStringSubmatch(challenge, -1) {
+		fields[m[1]] = m[2]
+	}
+	realm := fields["realm"]
+	if realm == "" {
+		return "", fmt.Errorf("probe %s: challenge without realm", host)
+	}
+	q := url.Values{}
+	if s := fields["service"]; s != "" {
+		q.Set("service", s)
+	}
+	q.Set("scope", "repository:"+repo+":pull")
+	tokResp, err := c.http.Get(realm + "?" + q.Encode())
+	if err != nil {
+		return "", fmt.Errorf("token %s: %w", host, err)
+	}
+	defer tokResp.Body.Close()
+	if tokResp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token %s: status %d", host, tokResp.StatusCode)
+	}
+	var body struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(tokResp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("token %s: %w", host, err)
+	}
+	tok := body.Token
+	if tok == "" {
+		tok = body.AccessToken
+	}
+	if tok == "" {
+		return "", fmt.Errorf("token %s: empty token", host)
+	}
+	c.tokens[key] = tok
+	return tok, nil
+}
+
+func (c *regClient) get(host, repo, path string, head bool, accept string) (*http.Response, error) {
+	tok, err := c.token(host, repo)
+	if err != nil {
+		return nil, err
+	}
+	method := http.MethodGet
+	if head {
+		method = http.MethodHead
+	}
+	u := path
+	if !strings.HasPrefix(u, c.scheme+"://") {
+		u = c.scheme + "://" + host + path
+	}
+	req, err := http.NewRequest(method, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	return c.http.Do(req)
+}
+
+// tags lists every tag for host/repo, following RFC 5988 Link pagination.
+// truncated=true means the page cap was hit and the list is incomplete.
+func (c *regClient) tags(host, repo string) (tags []string, truncated bool, err error) {
+	path := "/v2/" + repo + "/tags/list?n=1000"
+	for page := 0; page < maxTagPages; page++ {
+		resp, err := c.get(host, repo, path, false, "")
+		if err != nil {
+			return nil, false, fmt.Errorf("tags %s/%s: %w", host, repo, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			return nil, false, fmt.Errorf("tags %s/%s: status %d", host, repo, resp.StatusCode)
+		}
+		var body struct {
+			Tags []string `json:"tags"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&body)
+		link := resp.Header.Get("Link")
+		resp.Body.Close()
+		if decodeErr != nil {
+			return nil, false, fmt.Errorf("tags %s/%s: %w", host, repo, decodeErr)
+		}
+		tags = append(tags, body.Tags...)
+		next := parseNextLink(link)
+		if next == "" {
+			return tags, false, nil
+		}
+		path = next
+	}
+	return tags, true, nil
+}
+
+var linkRe = regexp.MustCompile(`<([^>]+)>\s*;[^,]*rel="next"`)
+
+func parseNextLink(link string) string {
+	m := linkRe.FindStringSubmatch(link)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// digest resolves the manifest digest for a tag via a HEAD request.
+func (c *regClient) digest(host, repo, tag string) (string, error) {
+	resp, err := c.get(host, repo, "/v2/"+repo+"/manifests/"+tag, true, manifestAccept)
+	if err != nil {
+		return "", fmt.Errorf("digest %s/%s:%s: %w", host, repo, tag, err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("digest %s/%s:%s: status %d", host, repo, tag, resp.StatusCode)
+	}
+	d := resp.Header.Get("Docker-Content-Digest")
+	if !digestRe.MatchString(d) {
+		return "", fmt.Errorf("digest %s/%s:%s: bad digest header %q", host, repo, tag, d)
+	}
+	return d, nil
+}

--- a/panel-api/cmd/catalog-bump/registry_test.go
+++ b/panel-api/cmd/catalog-bump/registry_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// fakeRegistry serves the OCI distribution API surface the client uses:
+// token challenge on /v2/, paginated tags/list, manifest HEAD.
+type fakeRegistry struct {
+	mux       *http.ServeMux
+	srv       *httptest.Server
+	anonymous bool
+	tags      []string
+	digests   map[string]string
+	pageSize  int
+}
+
+func newFakeRegistry(t *testing.T, anonymous bool, tags []string, digests map[string]string, pageSize int) *fakeRegistry {
+	t.Helper()
+	f := &fakeRegistry{anonymous: anonymous, tags: tags, digests: digests, pageSize: pageSize}
+	f.mux = http.NewServeMux()
+	f.srv = httptest.NewServer(f.mux)
+	t.Cleanup(f.srv.Close)
+
+	host := strings.TrimPrefix(f.srv.URL, "http://")
+
+	f.mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/" {
+			http.NotFound(w, r)
+			return
+		}
+		if f.anonymous {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Www-Authenticate",
+			fmt.Sprintf(`Bearer realm="http://%s/token",service="fake.io"`, host))
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	f.mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("scope") != "repository:acme/app:pull" {
+			http.Error(w, "bad scope", http.StatusBadRequest)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"token": "fake-token"})
+	})
+	f.mux.HandleFunc("/v2/acme/app/tags/list", func(w http.ResponseWriter, r *http.Request) {
+		if !f.anonymous && r.Header.Get("Authorization") != "Bearer fake-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		last, _ := url.QueryUnescape(r.URL.Query().Get("last"))
+		start := 0
+		if last != "" {
+			for i, tg := range f.tags {
+				if tg == last {
+					start = i + 1
+				}
+			}
+		}
+		end := len(f.tags)
+		if f.pageSize > 0 && start+f.pageSize < end {
+			end = start + f.pageSize
+			w.Header().Set("Link",
+				fmt.Sprintf(`</v2/acme/app/tags/list?last=%s&n=%d>; rel="next"`,
+					url.QueryEscape(f.tags[end-1]), f.pageSize))
+		}
+		json.NewEncoder(w).Encode(map[string][]string{"tags": f.tags[start:end]})
+	})
+	f.mux.HandleFunc("/v2/acme/app/manifests/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			http.Error(w, "want HEAD", http.StatusMethodNotAllowed)
+			return
+		}
+		tag := strings.TrimPrefix(r.URL.Path, "/v2/acme/app/manifests/")
+		d, ok := f.digests[tag]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Docker-Content-Digest", d)
+		w.WriteHeader(http.StatusOK)
+	})
+	return f
+}
+
+func (f *fakeRegistry) host() string { return strings.TrimPrefix(f.srv.URL, "http://") }
+
+func testClient() *regClient {
+	c := newRegClient()
+	c.scheme = "http"
+	return c
+}
+
+func TestRegistryTokenFlowAndDigest(t *testing.T) {
+	d := "sha256:" + strings.Repeat("cd", 32)
+	f := newFakeRegistry(t, false, []string{"1.0.0", "1.1.0"}, map[string]string{"1.1.0": d}, 0)
+	c := testClient()
+
+	tags, truncated, err := c.tags(f.host(), "acme/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated || len(tags) != 2 {
+		t.Fatalf("tags = %v truncated=%v", tags, truncated)
+	}
+	got, err := c.digest(f.host(), "acme/app", "1.1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != d {
+		t.Fatalf("digest = %q, want %q", got, d)
+	}
+}
+
+func TestRegistryAnonymous(t *testing.T) {
+	f := newFakeRegistry(t, true, []string{"2.0"}, nil, 0)
+	tags, _, err := testClient().tags(f.host(), "acme/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 1 || tags[0] != "2.0" {
+		t.Fatalf("tags = %v", tags)
+	}
+}
+
+func TestRegistryPagination(t *testing.T) {
+	var all []string
+	for i := 0; i < 25; i++ {
+		all = append(all, fmt.Sprintf("1.0.%d", i))
+	}
+	f := newFakeRegistry(t, false, all, nil, 10)
+	tags, truncated, err := testClient().tags(f.host(), "acme/app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Fatal("unexpected truncation")
+	}
+	if len(tags) != 25 {
+		t.Fatalf("got %d tags across pages, want 25", len(tags))
+	}
+}
+
+func TestRunEndToEnd(t *testing.T) {
+	newDigest := "sha256:" + strings.Repeat("ef", 32)
+	f := newFakeRegistry(t, false,
+		[]string{"1.0.0", "1.2.0", "1.2.1", "2.0.0-rc1", "latest"},
+		map[string]string{"1.2.1": newDigest}, 0)
+
+	dir := t.TempDir()
+	appDir := dir + "/acmeapp"
+	if err := createApp(appDir, "version: \"1.0.0\"\nimage_channel: "+f.host()+"/acme/app:1.0.0@"+testDigest+"\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	changed, hadErr, err := run(dir, false, testClient(), &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hadErr || changed != 1 {
+		t.Fatalf("changed=%d hadErr=%v\n%s", changed, hadErr, out.String())
+	}
+	got, err := readFile(appDir + "/app.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "version: \"1.2.1\"\nimage_channel: " + f.host() + "/acme/app:1.2.1@" + newDigest + "\n"
+	if got != want {
+		t.Fatalf("rewritten app.yaml:\n%s\nwant:\n%s", got, want)
+	}
+	if !strings.Contains(out.String(), "⬆ bumped") {
+		t.Fatalf("summary missing bump row:\n%s", out.String())
+	}
+}

--- a/panel-api/cmd/catalog-bump/track.go
+++ b/panel-api/cmd/catalog-bump/track.go
@@ -1,0 +1,69 @@
+package main
+
+import "sort"
+
+// maxResolveHeads bounds the manifest HEADs spent resolving a track digest
+// to a concrete version tag.
+const maxResolveHeads = 15
+
+// concreteCandidates returns tags that could be the concrete version behind
+// a track tag: same prefix and suffix, more core components, and the track's
+// components as their numeric prefix (track 6-alpine → 6.44.1-alpine).
+// Sorted newest-first so the digest match is usually the first HEAD.
+func concreteCandidates(track tagParts, tags []string) []string {
+	type cand struct {
+		tag  string
+		core []int
+	}
+	var cands []cand
+	for _, t := range tags {
+		p, ok := parseTag(t)
+		if !ok || p.Prefix != track.Prefix || p.Suffix != track.Suffix {
+			continue
+		}
+		if len(p.Core) <= len(track.Core) {
+			continue
+		}
+		if compareCore(p.Core[:len(track.Core)], track.Core) != 0 {
+			continue
+		}
+		cands = append(cands, cand{t, p.Core})
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		a, b := cands[i].core, cands[j].core
+		n := len(a)
+		if len(b) < n {
+			n = len(b)
+		}
+		if c := compareCore(a[:n], b[:n]); c != 0 {
+			return c > 0
+		}
+		return len(a) > len(b)
+	})
+	out := make([]string, len(cands))
+	for i, c := range cands {
+		out[i] = c.tag
+	}
+	return out
+}
+
+// resolveConcrete finds the concrete version tag whose manifest digest equals
+// the track tag's digest. Returns "" when no candidate matches within the
+// HEAD budget — the caller reports that instead of guessing.
+func resolveConcrete(client *regClient, host, repo string, track tagParts, tags []string, trackDigest string) string {
+	cands := concreteCandidates(track, tags)
+	if len(cands) > maxResolveHeads {
+		cands = cands[:maxResolveHeads]
+	}
+	for _, t := range cands {
+		d, err := client.digest(host, repo, t)
+		if err != nil {
+			continue
+		}
+		if d == trackDigest {
+			p, _ := parseTag(t)
+			return p.coreString()
+		}
+	}
+	return ""
+}

--- a/panel-api/cmd/catalog-bump/track_test.go
+++ b/panel-api/cmd/catalog-bump/track_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestConcreteCandidates(t *testing.T) {
+	track, _ := parseTag("6-alpine")
+	got := concreteCandidates(track, []string{
+		"6-alpine", "6.44.0-alpine", "6.44.1-alpine", "6.44.1", "5.99.0-alpine",
+		"7.0.0-alpine", "6.44.1-alpine.arm", "latest",
+	})
+	// Same suffix, refines core 6, newest first. 6.44.1 (no suffix),
+	// 5.x and 7.x (different track), and 6-alpine itself are excluded.
+	want := []string{"6.44.1-alpine", "6.44.0-alpine"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidates = %v, want %v", got, want)
+	}
+}
+
+// Track flow end-to-end: the track tag's digest moved upstream; the bumper
+// refreshes the pin and resolves the version field from the concrete tag
+// sharing the new digest.
+func TestRunTrackDigestRefresh(t *testing.T) {
+	newDigest := "sha256:" + strings.Repeat("aa", 32)
+	f := newFakeRegistry(t, false,
+		[]string{"2", "2.4.0", "2.4.1", "2.5.0-beta1"},
+		map[string]string{
+			"2":     newDigest, // track moved off testDigest
+			"2.4.1": newDigest, // concrete twin
+			"2.4.0": "sha256:" + strings.Repeat("bb", 32),
+		}, 0)
+
+	dir := t.TempDir()
+	appDir := dir + "/kuma"
+	yaml := "version: \"2.4.0\"\nimage_channel: " + f.host() + "/acme/app:2@" + testDigest + "\n"
+	if err := createApp(appDir, yaml); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	changed, hadErr, err := run(dir, false, testClient(), &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hadErr || changed != 1 {
+		t.Fatalf("changed=%d hadErr=%v\n%s", changed, hadErr, out.String())
+	}
+	got, err := readFile(appDir + "/app.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "version: \"2.4.1\"\nimage_channel: " + f.host() + "/acme/app:2@" + newDigest + "\n"
+	if got != want {
+		t.Fatalf("rewritten:\n%s\nwant:\n%s", got, want)
+	}
+	if !strings.Contains(out.String(), "digest refresh") {
+		t.Fatalf("summary missing refresh row:\n%s", out.String())
+	}
+}
+
+// When no concrete tag shares the new digest, the version field is left
+// alone and the row is flagged — never guessed.
+func TestRunTrackUnresolved(t *testing.T) {
+	newDigest := "sha256:" + strings.Repeat("aa", 32)
+	f := newFakeRegistry(t, false,
+		[]string{"2", "2.4.0"},
+		map[string]string{
+			"2":     newDigest,
+			"2.4.0": "sha256:" + strings.Repeat("bb", 32),
+		}, 0)
+
+	dir := t.TempDir()
+	yaml := "version: \"2.4.0\"\nimage_channel: " + f.host() + "/acme/app:2@" + testDigest + "\n"
+	if err := createApp(dir+"/kuma", yaml); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if _, _, err := run(dir, false, testClient(), &out); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := readFile(dir + "/kuma/app.yaml")
+	if !strings.Contains(got, `version: "2.4.0"`) || !strings.Contains(got, newDigest) {
+		t.Fatalf("want digest bumped + version untouched:\n%s", got)
+	}
+	if !strings.Contains(out.String(), "resolved version unknown") {
+		t.Fatalf("summary missing unresolved flag:\n%s", out.String())
+	}
+}
+
+// A newer track tag (2 → 3) is an advance: tag, digest, and — when
+// resolvable — the version field all move, flagged as a major bump.
+func TestRunTrackAdvanceMajor(t *testing.T) {
+	d3 := "sha256:" + strings.Repeat("cc", 32)
+	f := newFakeRegistry(t, false,
+		[]string{"2", "3", "3.0.1", "2.4.0"},
+		map[string]string{
+			"3":     d3,
+			"3.0.1": d3,
+		}, 0)
+
+	dir := t.TempDir()
+	yaml := "version: \"2.4.0\"\nimage_channel: " + f.host() + "/acme/app:2@" + testDigest + "\n"
+	if err := createApp(dir+"/kuma", yaml); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if _, _, err := run(dir, false, testClient(), &out); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := readFile(dir + "/kuma/app.yaml")
+	if !strings.Contains(got, ":3@"+d3) || !strings.Contains(got, `version: "3.0.1"`) {
+		t.Fatalf("want track advance to 3 with resolved version:\n%s", got)
+	}
+	if !strings.Contains(out.String(), "MAJOR") {
+		t.Fatalf("summary missing major flag:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
## Summary
Renovate-style automation for the Docker-apps catalog (JAB-234 follow-up — the Sounder 0.5.17→0.5.22 lag, merged in #1035, showed the catalog silently falls behind upstream releases).

**`panel-api/cmd/catalog-bump`** — checks all 46 catalog entries against their upstream registries and rewrites `app.yaml` with the newest matching tag + digest:
- Works against any OCI registry (Docker Hub, ghcr.io, lscr.io, codeberg.org) via `/v2/` `WWW-Authenticate` token discovery; `docker.io` refs are normalized to `registry-1.docker.io`.
- **Pattern-preserving tag selection**: same prefix (`v`), same component count, same suffix. That keeps `uptime-kuma:2` on its major track, `nextcloud:33-apache` on `-apache`, and naturally excludes `-rc`/`-beta` prereleases. Hash-style suffixes (searxng's `2026.6.20-fd42d4fda`) match by pattern.
- **Two update signals**: a newer matching tag, and the *current tag's digest moving upstream* (rolling tracks: `ghost:6-alpine`, `odoo:18.0`). For track entries (tag `6-alpine`, version `6.44.1`) the new `version:` field is resolved by finding the concrete tag that shares the track's digest — never guessed; unresolvable rows are flagged.
- **No silent skips**: every app lands in exactly one bucket (bumped / up-to-date / skipped-with-reason / error), and a corpus test over the real catalog fails CI if a future entry doesn't classify.

**`.github/workflows/catalog-bump.yml`** — Mondays 06:30 UTC (+ manual dispatch): runs the tool, force-pushes the fixed `catalog-auto-bump` branch, opens/updates **one roll-up PR** (single PR avoids the E2E port-concurrency pile-up). Major bumps are flagged ⚠ in the table for re-validation of the entry's ports/env/volumes. REST-over-curl like monthly-deps.yml; `cache: false` on setup-go per the runner-wedge note.

**Catalog data fixes found by the corpus test**: `n8n` version field was stale at `2.25.5` against the `2.28.2` image; `enclosed` shipped `version: "latest"` against the `1.16.0` tag. Both hid updates from the panel's update-offer comparison.

> [!IMPORTANT]
> **One setup step only you can do**: add a `CATALOG_BUMP_TOKEN` repo secret (fine-grained PAT, contents + pull-requests write). Without it the bot's PRs are pushed with the built-in `GITHUB_TOKEN`, which triggers **no CI** — the PR body will carry a loud warning and need a close/reopen to run checks.

## Live dry-run (2026-08-10, all 46 upstreams)
| App | Image tag | Version | Status |
|---|---|---|---|
| answer | `2.0.1` → `2.0.2` | 2.0.1 → 2.0.2 | ⬆ bumped |
| bigcapital | `v0.25.20` → `v0.25.26` | 0.25.20 → 0.25.26 | ⬆ bumped |
| dailytxt | `2.6.1` → `2.6.2` | 2.6.1 → 2.6.2 | ⬆ bumped |
| dawarich | `1.10.0` → `1.11.0` | 1.10.0 → 1.11.0 | ⬆ bumped |
| dokuwiki | `version-2025-05-14b` | 2024-02-06b | ⏭ skipped: unversioned tag scheme |
| enclosed | `1.16.0` | 1.16.0 | ✅ up to date |
| erpnext | `v16.25.0` → `v16.31.1` | 16.25.0 → 16.31.1 | ⬆ bumped |
| flarum | `stable` | 1.8 | ⏭ skipped: unversioned tag scheme |
| forgejo | `15.0.3` → `16.0.2` | 15.0.3 → 16.0.2 | ⚠ MAJOR |
| fossbilling | `0.8.2` → `0.8.5` | 0.8.2 → 0.8.5 | ⬆ bumped |
| freshrss | `1.29.1` | 1.29.1 | ✅ up to date |
| ghost | `6-alpine` | 6.44.1 → 6.56.0 | ↻ digest refresh |
| gitea | `1.26` → `1.27` | 1.26.2 → 1.27.1 | ⬆ bumped |
| grafana | `13.0.2` | 13.0.2 | ✅ up to date |
| immich | `v2.7.5` → `v3.1.0` | 2.7.5 → 3.1.0 | ⚠ MAJOR |
| invoiceshelf | `2.4.1` → `2.4.2` | 2.4.1 → 2.4.2 | ⬆ bumped |
| jabali-sounder | `0.5.17` → `0.5.22` | 0.5.17 → 0.5.22 | ⬆ bumped (landed early via #1035) |
| joplin | `3.7.1` | 3.7.1 | ✅ up to date |
| karakeep | `0.32.0` → `0.33.1` | 0.32.0 → 0.33.1 | ⬆ bumped |
| linkwarden | `v2.14.1` → `v2.16.0` | 2.14.1 → 2.16.0 | ⬆ bumped |
| matomo | `5-apache` | 5.10.1 → 5.12.0 | ↻ digest refresh |
| mealie | `v3.19.2` → `v3.22.0` | 3.19.2 → 3.22.0 | ⬆ bumped |
| mediacms | `latest` | 2026.06.24 | ⏭ skipped: unversioned tag scheme |
| memos | `0.29.1` → `0.30.0` | 0.29.1 → 0.30.0 | ⬆ bumped |
| n8n | `2.28.2` → `2.34.4` | 2.28.2 → 2.34.4 | ⬆ bumped |
| nextcloud | `33-apache` → `34-apache` | 33.0.5 → 34.0.2 | ⚠ MAJOR |
| odoo | `18.0` → `19.0` | 18.0 → 19.0 | ⚠ MAJOR |
| onlyoffice | `9.4.0` | 9.4.0 | ✅ up to date |
| open-webui | `0.9.6` → `0.11.0` | 0.9.6 → 0.11.0 | ⬆ bumped |
| openemr | `8.0.0.3` | 8.0.0.3 | ↻ digest refresh |
| owncloud | `10.16.3` → `11.0.0` | 10.16.3 → 11.0.0 | ⚠ MAJOR |
| paperless-ngx | `2.20.15` → `3.0.5` | 2.20.15 → 3.0.5 | ⚠ MAJOR |
| peertube | `v8.2.1-trixie` → `v8.2.4-trixie` | 8.2.1 → 8.2.4 | ⬆ bumped |
| pgadmin | `9.16` → `9.17` | 9.16 → 9.17 | ⬆ bumped |
| plausible | `v3.2.1` | 3.2.1 | ✅ up to date |
| pocket-id | `v2.11.0` → `v2.13.0` | 2.11.0 → 2.13.0 | ⬆ bumped |
| privatebin | `2.0.4` → `2.0.6` | 2.0.4 → 2.0.6 | ⬆ bumped |
| rocketchat | `6.13.1` → `8.7.0` | 6.13.1 → 8.7.0 | ⚠ MAJOR |
| romm | `4` → `5` | 4.9.2 → 5.1.0 | ⚠ MAJOR |
| searxng | `2026.6.20-fd42d4fda` → `2026.8.5-1689cb1b5` | 2026.6.20 → 2026.8.5 | ⬆ bumped |
| snipe-it | `v8.6.3` | 8.6.3 | ✅ up to date |
| uptime-kuma | `2` | 2.4.0 → 2.5.0 | ↻ digest refresh |
| vaultwarden | `1.36.0` → `1.37.1` | 1.36.0 → 1.37.1 | ⬆ bumped |
| zitadel | `v4.15.0` → `v4.16.3` | 4.15.0 → 4.16.3 | ⬆ bumped |

34 apps have updates pending; the three permanent skips (mediacms `latest`, flarum `stable`, dokuwiki date-scheme) would come under auto-bump if re-pinned to versioned tags.

## Test plan
- [x] Unit: ref/tag parsing, pattern-preserving selection (tracks, suffixes, prerelease exclusion, hex-wildcard), rewrite byte-preservation, classify modes
- [x] Registry client against httptest fakes: token challenge flow, anonymous registries, Link-header pagination, manifest HEAD digests
- [x] Track flows end-to-end: digest refresh + version resolution, unresolved flagging, major track advance
- [x] Corpus test over the real 46-app catalog (also what caught the n8n/enclosed data bugs)
- [x] Live dry-run against all 46 upstreams — table above, zero errors
- [x] `go vet`, `gofmt`, `go test -race`, dockerapp digest-pin suite green post-rebase
- [ ] CI
- [ ] After merge: `workflow_dispatch` a first run, review bump PR #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
