### PR TITLE
fix(disk-usage): size Postgres databases on the Disk Usage page too (GH #1005)

### DIFF
--- a/panel-api/internal/api/me_disk_usage.go
+++ b/panel-api/internal/api/me_disk_usage.go
@@ -9,8 +9,10 @@
 //     no live agent call needed). Mail lives in Stalwart's store,
 //     NOT under /home, so it doesn't double-count files.
 //
-//   - Databases — per-database size via `db.size` (MariaDB). PostgreSQL has no
-//     size verb yet, so those report 0 for now.
+//   - Databases — per-database size via `db.size`, for both engines. The
+//     row's engine is forwarded so Postgres is sized with
+//     pg_database_size() rather than a MariaDB information_schema sum that
+//     has no row for it (GH #1005).
 //
 //     GET /api/v1/me/disk-usage -> { total_bytes, quota_bytes, files, email, databases }
 package api
@@ -183,12 +185,18 @@ func (h *meDiskUsageHandler) compute(ctx context.Context, userID string) (diskUs
 		}
 	}
 
-	// --- Databases: per-db size (MariaDB; PostgreSQL has no size verb yet) ---
+	// --- Databases: per-db size, both engines ---
+	//
+	// This used to gate on engine == "mariadb", so every Postgres database
+	// reported 0 B here even after #1012 taught db.size to read
+	// pg_database_size(). The Databases page was fixed; this page kept
+	// skipping them, which is exactly what the reporter saw under
+	// Disk Usage → Databases (GH #1005).
 	if dbs, _, derr := h.cfg.Databases.ListByUserID(ctx, userID, opts); derr == nil {
 		for i := range dbs {
 			var sz uint64
-			if dbs[i].Engine == "mariadb" && h.cfg.Agent != nil {
-				sz = h.dbSize(ctx, dbs[i].Name)
+			if h.cfg.Agent != nil {
+				sz = h.dbSize(ctx, dbs[i].Name, dbs[i].Engine)
 			}
 			resp.Databases.Bytes += sz
 			resp.Databases.Items = append(resp.Databases.Items, diskUsageItem{
@@ -276,11 +284,16 @@ func (h *meDiskUsageHandler) homeUsage(ctx context.Context, username string) (ui
 	return v.Disk.UsedKB * 1024, v.Disk.LimitKB * 1024
 }
 
-// dbSize returns a MariaDB database's size in bytes (0 on any error).
-func (h *meDiskUsageHandler) dbSize(ctx context.Context, name string) uint64 {
+// dbSize returns a database's size in bytes (0 on any error).
+//
+// engine MUST be forwarded: db.size picks pg_database_size() for postgres
+// and the MariaDB information_schema sum otherwise, and information_schema
+// has no row for a Postgres database — it sums to 0 with no error, so the
+// zero looks like an empty database rather than a wrong query (GH #1005).
+func (h *meDiskUsageHandler) dbSize(ctx context.Context, name, engine string) uint64 {
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	raw, err := h.cfg.Agent.Call(cctx, "db.size", map[string]any{"db_name": name})
+	raw, err := h.cfg.Agent.Call(cctx, "db.size", map[string]any{"db_name": name, "engine": engine})
 	if err != nil {
 		return 0
 	}

--- a/panel-api/internal/api/me_disk_usage_postgres_test.go
+++ b/panel-api/internal/api/me_disk_usage_postgres_test.go
@@ -1,0 +1,130 @@
+package api
+
+// GH #1005: a Postgres database reported 0 B under Disk Usage → Databases.
+//
+// #1012 fixed the Databases page by teaching the agent's db.size to read
+// pg_database_size() when it is handed engine="postgres". This page kept
+// two bugs that made that fix invisible here:
+//
+//  1. it gated the size call on engine == "mariadb", so Postgres rows were
+//     never sized at all, and
+//  2. dbSize did not forward the engine, so even an ungated call would have
+//     been answered from MariaDB's information_schema — which has no row for
+//     a Postgres database and sums to 0 with NO error. The wrong query looks
+//     exactly like an empty database.
+//
+// Both are pinned here: the engine has to reach the agent, and both engines
+// have to be sized.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// duEngineAgent answers db.size per engine and records what it was asked,
+// so the test can assert the engine actually crossed the wire.
+type duEngineAgent struct {
+	mu    sync.Mutex
+	seen  map[string]string // db_name -> engine received
+	sizes map[string]int64  // engine -> size to report
+}
+
+func (a *duEngineAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	switch method {
+	case "user.limits.report":
+		return json.Marshal(map[string]any{"disk": map[string]uint64{"used_kb": 0, "limit_kb": 10240}})
+	case "db.size":
+		m, _ := params.(map[string]any)
+		name, _ := m["db_name"].(string)
+		engine, _ := m["engine"].(string)
+		a.mu.Lock()
+		if a.seen == nil {
+			a.seen = map[string]string{}
+		}
+		a.seen[name] = engine
+		a.mu.Unlock()
+		// Mirror the real agent: a Postgres database asked for with the
+		// MariaDB query sums to 0 rather than erroring.
+		if engine == "postgres" {
+			return json.Marshal(map[string]int64{"size_bytes": a.sizes["postgres"]})
+		}
+		return json.Marshal(map[string]int64{"size_bytes": a.sizes["mariadb"]})
+	}
+	return nil, fmt.Errorf("unexpected agent call %q", method)
+}
+
+func (a *duEngineAgent) engineFor(db string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.seen[db]
+}
+
+func TestMeDiskUsage_SizesPostgresDatabases(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	uname := "alice"
+	ag := &duEngineAgent{sizes: map[string]int64{"mariadb": 2048, "postgres": 4096}}
+	cfg := DiskUsageConfig{
+		Users:     &duUserRepo{u: &models.User{ID: "u1", Username: &uname}},
+		Domains:   &duDomainRepo{},
+		Mailboxes: &duMailboxRepo{},
+		Databases: &duDatabaseRepo{dbs: []models.Database{
+			{Name: "alice_shop", Engine: "mariadb"},
+			{Name: "alice_pg", Engine: "postgres"},
+		}},
+		Agent:      ag,
+		QuotaMount: "/home",
+	}
+
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"})
+		c.Next()
+	})
+	RegisterMeDiskUsageRoutes(v1, cfg)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/me/disk-usage/refresh", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh returned %d: %s", rec.Code, rec.Body.String())
+	}
+	var got diskUsageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+
+	// The engine must reach the agent, or db.size answers from
+	// information_schema and returns a silent 0.
+	if e := ag.engineFor("alice_pg"); e != "postgres" {
+		t.Errorf("db.size for the Postgres database was called with engine=%q, want \"postgres\" — "+
+			"without it the agent sums MariaDB's information_schema and reports 0 B", e)
+	}
+	if e := ag.engineFor("alice_shop"); e != "mariadb" {
+		t.Errorf("db.size for the MariaDB database was called with engine=%q, want \"mariadb\"", e)
+	}
+
+	byName := map[string]uint64{}
+	for _, it := range got.Databases.Items {
+		byName[it.Name] = it.Bytes
+	}
+	if byName["alice_pg"] != 4096 {
+		t.Errorf("Postgres database reported %d B, want 4096 — this is the 0 B the issue reported", byName["alice_pg"])
+	}
+	if byName["alice_shop"] != 2048 {
+		t.Errorf("MariaDB database reported %d B, want 2048 (regression in the path that already worked)", byName["alice_shop"])
+	}
+	if got.Databases.Bytes != 6144 {
+		t.Errorf("databases total = %d, want 6144 — the Postgres row must count toward the total too", got.Databases.Bytes)
+	}
+}


### PR DESCRIPTION
Picks up the reporter's follow-up on #1005:

> I also noticed that the same issue occurs under **Disk Usage → Databases**: PostgreSQL databases are shown as `0 B` there as well.

That was still true after #1012.

## Why the first fix didn't cover it

#1012 taught the agent's `db.size` to read `pg_database_size()` when handed `engine="postgres"`, and fixed the **Databases** page. The **Disk Usage** page had two separate reasons to keep showing `0 B`:

1. It gated the size call on `engine == "mariadb"`, so Postgres rows were never sized at all.
2. `dbSize()` didn't forward the engine, so even an ungated call would have been answered from MariaDB's `information_schema`.

The second is the nastier half: `information_schema` has **no row** for a Postgres database, so it sums to `0` with **no error**. The wrong query is indistinguishable from an empty database — which is exactly why the first fix looked complete.

`databases.go` already passed the engine. This was the one caller that didn't.

## Test plan

- [x] New test drives both engines through the handler: a MariaDB row and a Postgres row
- [x] Asserts **the engine reaches the agent**, not just that the byte count is right — a size that happens to be correct while the engine is dropped would pass a weaker assertion and regress the moment the agent's default changes
- [x] Asserts the Postgres row counts toward the databases total, not just its own line
- [x] **Verified RED against the pre-fix file**: reports `engine=""`, `0 B`, and a total of 2048 instead of 6144 — precisely the symptom in the issue
- [x] `go vet ./...` clean, `panel-api` suite 0 FAIL

Not verified end-to-end: Postgres is a gated engine (`server_settings.postgres_enabled`) and testserver has it off, so there's no live Postgres database to measure. The agent side was already proven by #1012; this change is about what the panel asks it.

## Remaining on #1005

Items 2 (Adminer first for Postgres) and 3 (pgAdmin catalog app + Open-pgAdmin link) landed in #1022 and #1023. With this, item 1 is fully closed. Item 4 — installing Docker apps against the host's own services — is still open and is a larger piece of work.