### PR TITLE
fix(ui): route UserDatabaseList toasts through the themed feedback bridge (GH #970)

### DIFF
--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
-import { Button, Card, Space, Table, Typography, message } from "antd";
+import { Button, Card, Space, Table, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   DatabaseOutlined,
   LinkOutlined,
@@ -115,7 +116,7 @@ export const UserDatabaseList = () => {
       if (tab) tab.close();
       const errorMsg =
         error instanceof Error ? error.message : "Could not open phpMyAdmin";
-      message.error(`Could not open phpMyAdmin: ${errorMsg}`);
+      feedback.message.error(`Could not open phpMyAdmin: ${errorMsg}`);
     } finally {
       setLoadingPhpMyAdminId(null);
     }
@@ -142,7 +143,7 @@ export const UserDatabaseList = () => {
       if (tab) tab.close();
       const errorMsg =
         error instanceof Error ? error.message : "Could not open Adminer";
-      message.error(`Could not open Adminer: ${errorMsg}`);
+      feedback.message.error(`Could not open Adminer: ${errorMsg}`);
     } finally {
       setLoadingAdminerId(null);
     }


### PR DESCRIPTION
Final fold-in for the #970 static-toast sweep. `UserDatabaseList` was the one file deliberately excluded (it was being changed by the Adminer-order PR #1022 at the time); now that #1022 has merged, its two SSO-failure toasts (open-phpMyAdmin / open-Adminer errors) move from AntD's static `message` to the App-scoped `feedback` bridge — theme- and RTL-correct like every other list.

Mechanical: drop `message` from the `antd` import, add `feedback`, prefix the two call sites. No copy or behaviour change → E2E selectors unaffected. `tsc -b` green; 0 static `message` callers remain in the file.

With this, the static-`message`/`notification`/`Modal` sweep for #970 is complete.

GH #970