### PR TITLE
feat(mail-stats): per-user + tenant-scoped traffic (GH #873 round 4)

### DIFF
--- a/panel-api/internal/api/admin_mail_stats.go
+++ b/panel-api/internal/api/admin_mail_stats.go
@@ -55,6 +55,19 @@ type DomainTrafficRow struct {
 	Failed    int64  `json:"failed"`
 }
 
+// UserTrafficRow rolls a tenant's domains' traffic up to one row (GH #873
+// round 4) — "which users generate the mail volume", with their domains nested
+// for the drilldown. Username is null for admin-owned domains.
+type UserTrafficRow struct {
+	Username  *string            `json:"username"`
+	UserID    string             `json:"user_id"`
+	Sent      int64              `json:"sent"`
+	Received  int64              `json:"received"`
+	Delivered int64              `json:"delivered"`
+	Failed    int64              `json:"failed"`
+	Domains   []DomainTrafficRow `json:"domains"`
+}
+
 type mailStatsResponse struct {
 	// Points and Rates are keyed by metric name.
 	Points  map[string][]MailStatPoint     `json:"points"`
@@ -64,6 +77,9 @@ type mailStatsResponse struct {
 	// Traffic is the per-domain send/receive breakdown for the range, busiest
 	// first. Empty until the per-domain sampler has collected a window.
 	Traffic []DomainTrafficRow `json:"traffic"`
+	// ByUser rolls Traffic up per owning tenant (GH #873 round 4), busiest
+	// first, each with their domains nested.
+	ByUser []UserTrafficRow `json:"by_user"`
 }
 
 func (h *adminMailStatsHandler) stats(c *gin.Context) {
@@ -90,6 +106,11 @@ func (h *adminMailStatsHandler) stats(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "traffic failed"})
 		return
 	}
+	owners, err := h.cfg.Stats.DomainOwners(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "owners failed"})
+		return
+	}
 
 	resp := mailStatsResponse{
 		Points:  map[string][]MailStatPoint{},
@@ -97,6 +118,7 @@ func (h *adminMailStatsHandler) stats(c *gin.Context) {
 		Current: map[string]float64{},
 		Storage: storage,
 		Traffic: aggregateDomainTraffic(domainRows),
+		ByUser:  aggregateUserTraffic(domainRows, owners),
 	}
 	// rows arrive ordered (metric, time) — walk once.
 	for i := 0; i < len(rows); i++ {
@@ -146,6 +168,45 @@ func aggregateDomainTraffic(rows []repository.DomainStatSample) []DomainTrafficR
 			return li > lj
 		}
 		return out[i].Domain < out[j].Domain
+	})
+	return out
+}
+
+// aggregateUserTraffic rolls the per-domain rows up to one row per owning user
+// (GH #873 round 4), each with their domains nested, busiest first. Domains
+// with no current owner (removed since the sample) are dropped.
+func aggregateUserTraffic(rows []repository.DomainStatSample, owners []repository.DomainOwner) []UserTrafficRow {
+	ownerByDomain := make(map[string]repository.DomainOwner, len(owners))
+	for _, o := range owners {
+		ownerByDomain[o.Domain] = o
+	}
+	byUser := map[string]*UserTrafficRow{}
+	for _, dr := range aggregateDomainTraffic(rows) { // busiest-first per domain
+		o, ok := ownerByDomain[dr.Domain]
+		if !ok {
+			continue
+		}
+		u := byUser[o.UserID]
+		if u == nil {
+			u = &UserTrafficRow{Username: o.Username, UserID: o.UserID}
+			byUser[o.UserID] = u
+		}
+		u.Sent += dr.Sent
+		u.Received += dr.Received
+		u.Delivered += dr.Delivered
+		u.Failed += dr.Failed
+		u.Domains = append(u.Domains, dr)
+	}
+	out := make([]UserTrafficRow, 0, len(byUser))
+	for _, u := range byUser {
+		out = append(out, *u)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		li, lj := out[i].Sent+out[i].Received, out[j].Sent+out[j].Received
+		if li != lj {
+			return li > lj
+		}
+		return out[i].UserID < out[j].UserID
 	})
 	return out
 }

--- a/panel-api/internal/api/admin_mail_stats_test.go
+++ b/panel-api/internal/api/admin_mail_stats_test.go
@@ -20,6 +20,7 @@ type fakeMailStatsSeriesRepo struct {
 	rows       []repository.MailStatSample
 	storage    []repository.MailboxStorageRow
 	domainRows []repository.DomainStatSample
+	owners     []repository.DomainOwner
 }
 
 func (f *fakeMailStatsSeriesRepo) Series(context.Context, time.Time) ([]repository.MailStatSample, error) {
@@ -30,6 +31,9 @@ func (f *fakeMailStatsSeriesRepo) StorageDrilldown(context.Context) ([]repositor
 }
 func (f *fakeMailStatsSeriesRepo) DomainSeries(context.Context, time.Time) ([]repository.DomainStatSample, error) {
 	return f.domainRows, nil
+}
+func (f *fakeMailStatsSeriesRepo) DomainOwners(context.Context) ([]repository.DomainOwner, error) {
+	return f.owners, nil
 }
 
 // GH #873: rates are positive deltas per metric, clamped at zero across a
@@ -57,6 +61,11 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 			{Domain: "quiet.example", Metric: "received", SampledAt: t0, Value: 1},
 			{Domain: "quiet.example", Metric: "failed", SampledAt: t0, Value: 2},
 		},
+		// Round 4: owners roll domain traffic up per user.
+		owners: []repository.DomainOwner{
+			{Domain: "busy.example", UserID: "u_alice", Username: strptr("alice")},
+			{Domain: "quiet.example", UserID: "u_bob", Username: strptr("bob")},
+		},
 	}
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -75,6 +84,7 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 		Current map[string]float64             `json:"current"`
 		Storage []repository.MailboxStorageRow `json:"storage"`
 		Traffic []api.DomainTrafficRow         `json:"traffic"`
+		ByUser  []api.UserTrafficRow           `json:"by_user"`
 	}
 	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 
@@ -99,4 +109,17 @@ func TestAdminMailStats_SeriesAndDeltaClamp(t *testing.T) {
 		assert.Equal(t, int64(1), resp.Traffic[1].Received)
 		assert.Equal(t, int64(2), resp.Traffic[1].Failed)
 	}
+	// Round 4: per-user rollup, busiest user first, domains nested.
+	if assert.Len(t, resp.ByUser, 2) {
+		assert.Equal(t, "alice", *resp.ByUser[0].Username, "busiest user first")
+		assert.Equal(t, int64(5), resp.ByUser[0].Sent)
+		assert.Equal(t, int64(4), resp.ByUser[0].Received)
+		if assert.Len(t, resp.ByUser[0].Domains, 1) {
+			assert.Equal(t, "busy.example", resp.ByUser[0].Domains[0].Domain)
+		}
+		assert.Equal(t, "bob", *resp.ByUser[1].Username)
+		assert.Equal(t, int64(2), resp.ByUser[1].Failed)
+	}
 }
+
+func strptr(s string) *string { return &s }

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -3143,6 +3143,14 @@ paths:
       parameters: [ { in: query, name: hours, required: false, schema: { type: integer, minimum: 1, maximum: 2160, default: 24 } } ]
       responses: { "200": { description: OK } }
 
+  /mail/stats:
+    get:
+      tags: [Mail]
+      summary: Tenant mail traffic — per-domain totals for the caller's own domains (GH #873 round 4)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: query, name: hours, required: false, schema: { type: integer, minimum: 1, maximum: 2160, default: 24 } } ]
+      responses: { "200": { description: OK } }
+
   /admin/mail/queue:
     get:
       tags: [Mail]

--- a/panel-api/internal/api/user_mail_stats.go
+++ b/panel-api/internal/api/user_mail_stats.go
@@ -1,0 +1,62 @@
+package api
+
+// GH #873 round 4 — tenant-scoped mail traffic. A tenant sees the per-domain
+// send/receive breakdown for ONLY their own domains. The scope is enforced at
+// the SQL layer (DomainSeriesForUser filters on domains.user_id = caller), and
+// the caller id is always taken from the authenticated claims, never the
+// request — a tenant can never widen it to another tenant's domains.
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type TenantMailStatsHandlerConfig struct {
+	Stats repository.MailStatsRepository
+}
+
+// RegisterTenantMailStatsRoutes mounts GET /mail/stats for authenticated
+// tenants. `g` is expected to already carry tenant auth + the mail-module gate.
+func RegisterTenantMailStatsRoutes(g *gin.RouterGroup, cfg TenantMailStatsHandlerConfig) {
+	if cfg.Stats == nil {
+		return
+	}
+	h := &tenantMailStatsHandler{cfg: cfg}
+	g.GET("/mail/stats", h.stats)
+}
+
+type tenantMailStatsHandler struct{ cfg TenantMailStatsHandlerConfig }
+
+type tenantMailStatsResponse struct {
+	// Traffic is the caller's per-domain totals over the range, busiest first.
+	Traffic []DomainTrafficRow `json:"traffic"`
+}
+
+func (h *tenantMailStatsHandler) stats(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil || claims.UserID == "" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return
+	}
+
+	hours := 24
+	if raw := c.Query("hours"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 1 && v <= 2160 {
+			hours = v
+		}
+	}
+	since := time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
+
+	rows, err := h.cfg.Stats.DomainSeriesForUser(c.Request.Context(), since, claims.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "traffic failed"})
+		return
+	}
+	c.JSON(http.StatusOK, tenantMailStatsResponse{Traffic: aggregateDomainTraffic(rows)})
+}

--- a/panel-api/internal/api/user_mail_stats_test.go
+++ b/panel-api/internal/api/user_mail_stats_test.go
@@ -1,0 +1,81 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeTenantStatsRepo struct {
+	repository.MailStatsRepository
+	gotUserID string
+	rows      []repository.DomainStatSample
+}
+
+func (f *fakeTenantStatsRepo) DomainSeriesForUser(_ context.Context, _ time.Time, userID string) ([]repository.DomainStatSample, error) {
+	f.gotUserID = userID
+	return f.rows, nil
+}
+
+// GH #873 round 4: the tenant traffic endpoint scopes to the CALLER's domains,
+// and the scope comes from the authenticated claims — there is no request
+// parameter a tenant could set to see another tenant's domains.
+func TestTenantMailStats_ScopedToCaller(t *testing.T) {
+	t0 := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	repo := &fakeTenantStatsRepo{rows: []repository.DomainStatSample{
+		{Domain: "alice.example", Metric: "sent", SampledAt: t0, Value: 7},
+		{Domain: "alice.example", Metric: "received", SampledAt: t0, Value: 2},
+	}}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u_alice", IsAdmin: false})
+		c.Next()
+	})
+	api.RegisterTenantMailStatsRoutes(v1, api.TenantMailStatsHandlerConfig{Stats: repo})
+
+	// A user param on the request must NOT change the scope.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mail/stats?hours=24&user_id=u_bob", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "u_alice", repo.gotUserID, "scope MUST come from claims, not the request")
+
+	var resp struct {
+		Traffic []api.DomainTrafficRow `json:"traffic"`
+	}
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	if assert.Len(t, resp.Traffic, 1) {
+		assert.Equal(t, "alice.example", resp.Traffic[0].Domain)
+		assert.Equal(t, int64(7), resp.Traffic[0].Sent)
+		assert.Equal(t, int64(2), resp.Traffic[0].Received)
+	}
+}
+
+func TestTenantMailStats_Unauthenticated401(t *testing.T) {
+	repo := &fakeTenantStatsRepo{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1") // no claims injected
+	api.RegisterTenantMailStatsRoutes(v1, api.TenantMailStatsHandlerConfig{Stats: repo})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mail/stats", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Empty(t, repo.gotUserID, "no repo query without a caller")
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -783,6 +783,12 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			SharedResources: srRepo,
 			SendDelegations: sendDelegRepo,
 		})
+		// GH #873 round 4 — tenant-scoped mail traffic (own domains only).
+		if deps.DB != nil {
+			api.RegisterTenantMailStatsRoutes(mailGroup, api.TenantMailStatsHandlerConfig{
+				Stats: repository.NewMailStatsRepository(deps.DB),
+			})
+		}
 		// DNSSEC per-domain (ADR-0076). Standalone mount; not part of M6.5.
 		api.RegisterDomainDNSSECRoutes(v1, api.DomainDNSSECHandlerConfig{
 			Agent:   deps.Agent,

--- a/panel-api/internal/repository/mail_stats_domain_scope_test.go
+++ b/panel-api/internal/repository/mail_stats_domain_scope_test.go
@@ -1,0 +1,46 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDomainSeriesForUser_ScopesByOwner is the security guard for GH #873
+// round 4: the tenant traffic query MUST restrict to the caller's own domains
+// via a `domain IN (SELECT name FROM domains WHERE user_id = ?)` subquery, with
+// the caller id bound as a parameter. It asserts the rendered SQL + args so a
+// refactor (or GORM upgrade) that drops the scope fails here instead of leaking
+// one tenant's mail volume to another.
+func TestDomainSeriesForUser_ScopesByOwner(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+	repo := NewMailStatsRepository(db)
+
+	since := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT \* FROM .mail_stats_domain_samples. WHERE sampled_at >= \? AND domain IN \(SELECT .name. FROM .domains. WHERE user_id = \?\)`).
+		WithArgs(since, "u_alice").
+		WillReturnRows(sqlmock.NewRows([]string{"domain", "metric", "sampled_at", "value"}).
+			AddRow("alice.example", "sent", since, int64(3)))
+
+	rows, err := repo.DomainSeriesForUser(context.Background(), since, "u_alice")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "alice.example", rows[0].Domain)
+	require.NoError(t, mock.ExpectationsWereMet(), "the scoping subquery must render exactly")
+}
+
+// An empty caller id must NOT run a query (and never returns unscoped rows).
+func TestDomainSeriesForUser_EmptyUserNoQuery(t *testing.T) {
+	db, _, raw := newMockDB(t)
+	defer raw.Close()
+	repo := NewMailStatsRepository(db)
+
+	rows, err := repo.DomainSeriesForUser(context.Background(), time.Now(), "")
+	require.NoError(t, err)
+	require.Empty(t, rows)
+	// No mock.ExpectQuery registered → any query would fail ExpectationsWereMet.
+}

--- a/panel-api/internal/repository/mail_stats_repository.go
+++ b/panel-api/internal/repository/mail_stats_repository.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"time"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"gorm.io/gorm"
 )
 
@@ -49,6 +50,14 @@ type DomainCount struct {
 	Count  int64
 }
 
+// DomainOwner maps a domain to its owning tenant (GH #873 round 4). Username is
+// NULL for admin-owned domains. Used to roll per-domain traffic up per user.
+type DomainOwner struct {
+	Domain   string  `gorm:"column:domain"   json:"domain"`
+	UserID   string  `gorm:"column:user_id"  json:"user_id"`
+	Username *string `gorm:"column:username" json:"username"`
+}
+
 type MailStatsRepository interface {
 	// InsertSamples writes one row per metric at the given time.
 	InsertSamples(ctx context.Context, at time.Time, metrics map[string]float64) error
@@ -66,6 +75,13 @@ type MailStatsRepository interface {
 	// DomainSeries returns per-domain samples since `since`, ordered by
 	// domain, metric, then time.
 	DomainSeries(ctx context.Context, since time.Time) ([]DomainStatSample, error)
+	// DomainSeriesForUser is DomainSeries scoped to the domains owned by
+	// `userID` (GH #873 round 4 tenant view). A tenant only ever sees traffic
+	// for their own domains; an empty domain set yields no rows.
+	DomainSeriesForUser(ctx context.Context, since time.Time, userID string) ([]DomainStatSample, error)
+	// DomainOwners returns every domain with its owning user (GH #873 round 4),
+	// so the admin per-user drilldown can roll domain traffic up per tenant.
+	DomainOwners(ctx context.Context) ([]DomainOwner, error)
 	// LastDomainSampleAt returns the newest domain sample time, or zero time
 	// when the table is empty (first run). Drives the collector's watermark.
 	LastDomainSampleAt(ctx context.Context) (time.Time, error)
@@ -154,6 +170,32 @@ func (r *mailStatsRepo) DomainSeries(ctx context.Context, since time.Time) ([]Do
 		Where("sampled_at >= ?", since).
 		Order("domain ASC, metric ASC, sampled_at ASC").
 		Find(&rows).Error
+	return rows, err
+}
+
+func (r *mailStatsRepo) DomainSeriesForUser(ctx context.Context, since time.Time, userID string) ([]DomainStatSample, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	var rows []DomainStatSample
+	// Scope to the caller's domains by subquery on domains.user_id — a tenant
+	// never sees another tenant's traffic. domain is matched by name, the same
+	// key the sampler stores.
+	err := r.db.WithContext(ctx).
+		Where("sampled_at >= ? AND domain IN (?)",
+			since,
+			r.db.Model(&models.Domain{}).Select("name").Where("user_id = ?", userID)).
+		Order("domain ASC, metric ASC, sampled_at ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *mailStatsRepo) DomainOwners(ctx context.Context) ([]DomainOwner, error) {
+	var rows []DomainOwner
+	err := r.db.WithContext(ctx).Raw(`
+		SELECT d.name AS domain, d.user_id AS user_id, u.username AS username
+		FROM domains d
+		JOIN users u ON u.id = d.user_id`).Scan(&rows).Error
 	return rows, err
 }
 

--- a/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
+++ b/panel-ui/src/shells/admin/mail/MailStatsTab.tsx
@@ -33,14 +33,34 @@ type MailStats = {
   }[];
   // GH #873 round 3: per-domain traffic totals over the selected range,
   // busiest first. Empty until the per-domain sampler has collected a window.
-  traffic: {
-    domain: string;
+  traffic: DomainTraffic[];
+  // GH #873 round 4: the same traffic rolled up per owning user, each with
+  // their domains nested. Busiest user first.
+  by_user: {
+    username: string | null;
+    user_id: string;
     sent: number;
     received: number;
     delivered: number;
     failed: number;
+    domains: DomainTraffic[];
   }[];
 };
+
+type DomainTraffic = {
+  domain: string;
+  sent: number;
+  received: number;
+  delivered: number;
+  failed: number;
+};
+
+const TRAFFIC_COLUMNS = [
+  { title: "Sent", dataIndex: "sent", width: 90, align: "right" as const },
+  { title: "Received", dataIndex: "received", width: 100, align: "right" as const },
+  { title: "Delivered", dataIndex: "delivered", width: 100, align: "right" as const },
+  { title: "Failed", dataIndex: "failed", width: 90, align: "right" as const },
+];
 
 const fmtBytes = (n: number): string => {
   if (n >= 1 << 30) return `${(n / (1 << 30)).toFixed(1)} GiB`;
@@ -302,6 +322,49 @@ export const MailStatsTab = () => {
             ]}
           />
           </>
+        )}
+      </Card>
+
+      <Card
+        size="small"
+        title={`Traffic by user (${hours >= 168 ? `${hours / 24}d` : `${hours}h`})`}
+        style={{ marginBottom: 16 }}
+        loading={stats.isLoading}
+      >
+        {(s?.by_user?.length ?? 0) === 0 ? (
+          <Typography.Text type="secondary">
+            Collecting — per-user totals appear once mail flows for a user's
+            domains.
+          </Typography.Text>
+        ) : (
+          <Table
+            size="small"
+            rowKey="user_id"
+            pagination={false}
+            dataSource={s?.by_user ?? []}
+            columns={[
+              {
+                title: "User",
+                dataIndex: "username",
+                render: (u: string | null) => u ?? "(admin)",
+              },
+              ...TRAFFIC_COLUMNS,
+            ]}
+            expandable={{
+              expandedRowRender: (u) => (
+                <Table
+                  size="small"
+                  rowKey="domain"
+                  pagination={false}
+                  dataSource={u.domains}
+                  columns={[
+                    { title: "Domain", dataIndex: "domain" },
+                    ...TRAFFIC_COLUMNS,
+                  ]}
+                />
+              ),
+            }}
+          />
         )}
       </Card>
 

--- a/panel-ui/src/shells/user/mail/MailTabsPage.tsx
+++ b/panel-ui/src/shells/user/mail/MailTabsPage.tsx
@@ -16,9 +16,10 @@ import { DisclaimerTab } from "./tabs/DisclaimerTab";
 import { SharedFoldersTab } from "./tabs/SharedFoldersTab";
 import { SharedResourcesTab } from "./tabs/SharedResourcesTab";
 import { LogsTab } from "./tabs/LogsTab";
+import { StatisticsTab } from "./tabs/StatisticsTab";
 import { CreateMailboxWizardModal } from "./CreateMailboxWizardModal";
 
-const TAB_KEYS = ["mailboxes", "groups", "forwarders", "catchall", "disclaimer", "shared", "resources", "logs"] as const;
+const TAB_KEYS = ["mailboxes", "groups", "forwarders", "catchall", "disclaimer", "shared", "resources", "logs", "statistics"] as const;
 type TabKey = (typeof TAB_KEYS)[number];
 const DEFAULT_TAB: TabKey = "mailboxes";
 
@@ -31,6 +32,7 @@ const TAB_LABELS: Record<TabKey, string> = {
   shared: "Shared Folders",
   resources: "Shared Resources",
   logs: "Logs",
+  statistics: "Statistics",
 };
 
 export const MailTabsPage = () => {
@@ -66,6 +68,8 @@ export const MailTabsPage = () => {
         return <SharedResourcesTab />;
       case "logs":
         return <LogsTab />;
+      case "statistics":
+        return <StatisticsTab />;
     }
   };
 

--- a/panel-ui/src/shells/user/mail/tabs/StatisticsTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/StatisticsTab.tsx
@@ -1,0 +1,87 @@
+// StatisticsTab — GH #873 round 4: tenant-scoped mail traffic. Shows the
+// per-domain send/receive breakdown for ONLY the caller's own domains
+// (GET /mail/stats is scoped server-side to the authenticated user). Read-only.
+import { useState } from "react";
+import { Alert, Card, Radio, Table, Typography } from "antd";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "../../../../apiClient";
+
+type DomainTraffic = {
+  domain: string;
+  sent: number;
+  received: number;
+  delivered: number;
+  failed: number;
+};
+
+type TenantStats = { traffic: DomainTraffic[] };
+
+const rangeLabel = (hours: number) =>
+  hours >= 168 ? `${hours / 24}d` : `${hours}h`;
+
+export const StatisticsTab = () => {
+  const [hours, setHours] = useState(24);
+  const stats = useQuery<TenantStats>({
+    queryKey: ["mail", "stats", hours],
+    queryFn: async () =>
+      (await apiClient.get<TenantStats>(`/mail/stats?hours=${hours}`)).data,
+    refetchInterval: 60_000,
+  });
+
+  if (stats.isError) {
+    return <Alert type="error" message="Failed to load mail statistics" />;
+  }
+
+  const traffic = stats.data?.traffic ?? [];
+
+  return (
+    <>
+      <Radio.Group
+        value={hours}
+        onChange={(e) => setHours(e.target.value)}
+        style={{ marginBottom: 16 }}
+        options={[
+          { label: "24h", value: 24 },
+          { label: "7d", value: 168 },
+          { label: "30d", value: 720 },
+        ]}
+        optionType="button"
+      />
+
+      <Card
+        size="small"
+        title={`Traffic by domain (${rangeLabel(hours)})`}
+        loading={stats.isLoading}
+      >
+        {traffic.length === 0 ? (
+          <Typography.Text type="secondary">
+            Collecting — your per-domain mail counts appear here once mail flows.
+          </Typography.Text>
+        ) : (
+          <>
+            <Typography.Paragraph
+              type="secondary"
+              style={{ marginTop: 0, fontSize: 12 }}
+            >
+              Counted from the mail delivery log by sender/recipient domain.
+            </Typography.Paragraph>
+            <Table
+              size="small"
+              rowKey="domain"
+              pagination={false}
+              dataSource={traffic}
+              columns={[
+                { title: "Domain", dataIndex: "domain" },
+                { title: "Sent", dataIndex: "sent", width: 90, align: "right" },
+                { title: "Received", dataIndex: "received", width: 100, align: "right" },
+                { title: "Delivered", dataIndex: "delivered", width: 100, align: "right" },
+                { title: "Failed", dataIndex: "failed", width: 90, align: "right" },
+              ]}
+            />
+          </>
+        )}
+      </Card>
+    </>
+  );
+};


### PR DESCRIPTION
## Feature (GH #873, round 4) — per-user + tenant-scoped mail traffic

Round 4 completes what johnnyq asked for on top of round 3's per-domain traffic: a **per-user** breakdown for admins, and a **tenant-scoped** view so each tenant sees their own domains' traffic. **No new sampling** — domains carry `user_id`, so both roll up from the existing `mail_stats_domain_samples` deltas.

### Admin — per-user drilldown
`/admin/mail/stats` gains a `by_user` array: each owning user with their domains nested, busiest first. New **Traffic by user** table on Mail → Statistics (expand a user to see their domains).

### Tenant — scoped view (security-critical)
New `GET /mail/stats` returns **only the caller's domains' traffic**:
- Scope enforced at the **SQL layer** — `DomainSeriesForUser` filters on `domains.user_id = caller`.
- The caller id always comes from the **authenticated claims, never the request** — a `user_id` query param is ignored, so a tenant can't widen scope to another tenant.
- New **Statistics** tab in the user Mail area.

### Repo
`DomainSeriesForUser` (scoped series) + `DomainOwners` (domain→owner map for the admin rollup).

### Tests
- **Tenant scoping**: the scope comes from claims — a request `user_id=other` is ignored (asserts the repo received the *claims* uid); unauthenticated → **401**, no repo query.
- **Admin `by_user`**: rollup sums per owner, busiest first, domains nested.
- `go build` + `go test` (api, reconciler, repository, app incl. **OpenAPI coverage** — `/mail/stats` documented, golden stays zero-debt) + `tsc -b` + vitest **229** all green.

Built on round-3 data, so it's live wherever round 3 is. Admin rollup and tenant view are independent surfaces and can be reviewed separately.

GH #873

---

### Verification notes

- **Scope is SQL-tested:** `DomainSeriesForUser` is exercised via sqlmock — the rendered query asserts `domain IN (SELECT name FROM domains WHERE user_id = ?)` with the caller's id bound, and that an empty caller runs no query. The isolation control itself (not just the plumbing) is locked against refactors/GORM upgrades.
- **Not done by me — the live tenant-session check.** Confirming `/mail/stats` in a real browser as an authenticated tenant needs a logged-in tenant session, which I can't do (password + session rules). The admin `by_user` side and the SQL shape are covered; the tenant-session eyeball is a manual/authorized step before the round-4 reply.

### Known behaviour

- Samples are keyed by **domain name**, so history follows the domain's **current owner**: a domain transferred between tenants (or deleted and re-created under another) shows its pre-transfer counts to the new owner — in both the tenant view and the admin `by_user` rollup — until the 90-day prune. Volume counts only; noted so it isn't filed as a leak.