### PR TITLE
fix(backup): actually back up Postgres databases (GH #1015)

### DIFF
--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -60,7 +60,14 @@ type backupCreateParams struct {
 	Email     string   `json:"email,omitempty"`
 	IsAdmin   bool     `json:"is_admin"`
 	Databases []string `json:"databases,omitempty"`
-	Mailboxes []string `json:"mailboxes,omitempty"`
+	// DatabasesPostgres is the parallel Postgres list. The panel has sent
+	// this field since M37 Phase 2 — but this struct never declared it, so
+	// encoding/json silently dropped the key and every account backup
+	// omitted its Postgres databases while reporting success (GH #1015).
+	// The sub-command (backup.databases) and the .pgdump restore path both
+	// existed the whole time; the orchestrator was the one broken link.
+	DatabasesPostgres []string `json:"databases_postgres,omitempty"`
+	Mailboxes         []string `json:"mailboxes,omitempty"`
 	// DockerApps are the slugs of the account's docker apps. Their data
 	// trees live outside the home, so without this the account backs up
 	// without them (GH #954). Empty is normal — most accounts have none.
@@ -184,8 +191,8 @@ func backupCreateHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 func runBackupOrchestrator(ctx context.Context, req backupCreateParams) error {
 	jl := backup.NewJobLogger(req.JobID)
 	defer jl.Close()
-	jl.Printf("account_backup start user_id=%s username=%s databases=%d mailboxes=%d destination=%s",
-		req.UserID, req.Username, len(req.Databases), len(req.Mailboxes), req.RepoURL)
+	jl.Printf("account_backup start user_id=%s username=%s databases=%d pg_databases=%d mailboxes=%d destination=%s",
+		req.UserID, req.Username, len(req.Databases), len(req.DatabasesPostgres), len(req.Mailboxes), req.RepoURL)
 	if err := bkEnsureRepoReady(ctx, req.RepoURL, req.CredentialsRef, req.DestinationKind, req.PasswordFile, req.SFTP); err != nil {
 		jl.Printf("ensure_repo_failed=%v", err)
 		return fmt.Errorf("ensure repo: %w", err)
@@ -220,7 +227,7 @@ func runBackupOrchestrator(ctx context.Context, req backupCreateParams) error {
 	manifest.Stages = append(manifest.Stages, homeStage)
 
 	// Stage: databases
-	jl.Printf("stage=db start dbs=%v", req.Databases)
+	jl.Printf("stage=db start dbs=%v pg_dbs=%v", req.Databases, req.DatabasesPostgres)
 	dbStages := runDatabaseStage(ctx, req)
 	for _, s := range dbStages {
 		jl.Printf("stage=db done item=%v status=%s bytes_added=%d bytes_total=%d warnings=%v",
@@ -382,7 +389,7 @@ func dockerStagesFromResult(res backupDockerResult) []backup.ManifestStage {
 }
 
 func runDatabaseStage(ctx context.Context, req backupCreateParams) []backup.ManifestStage {
-	if len(req.Databases) == 0 {
+	if len(req.Databases) == 0 && len(req.DatabasesPostgres) == 0 {
 		return []backup.ManifestStage{{
 			Name: backup.StageDB, Tag: "stage=db", Status: backup.StageStatusSkipped,
 			Warnings: []string{"no databases"},
@@ -390,7 +397,8 @@ func runDatabaseStage(ctx context.Context, req backupCreateParams) []backup.Mani
 	}
 	body, _ := json.Marshal(backupDatabasesParams{
 		JobID: req.JobID, UserID: req.UserID, Username: req.Username,
-		Databases: req.Databases, ScheduleID: req.ScheduleID,
+		Databases: req.Databases, DatabasesPostgres: req.DatabasesPostgres,
+		ScheduleID: req.ScheduleID,
 		RepoURL: req.RepoURL, CredentialsRef: req.CredentialsRef,
 		SFTP: req.SFTP, Compression: req.Compression,
 		// See runHomeStage: a per-destination password must reach the

--- a/panel-agent/internal/commands/backup_postgres_wire_test.go
+++ b/panel-agent/internal/commands/backup_postgres_wire_test.go
@@ -1,0 +1,75 @@
+package commands
+
+// GH #1015: every account backup silently omitted its Postgres databases.
+//
+// The panel has sent `databases_postgres` on backup.create since M37
+// Phase 2, and both the backup.databases sub-command and the .pgdump
+// restore path handled Postgres — but backupCreateParams never declared
+// the field, so encoding/json dropped the key on the floor and the
+// orchestrator ran the db stage with the MariaDB list only. The job then
+// sealed `succeeded`, which is what made the omission invisible: nothing
+// failed, the data just wasn't there.
+//
+// These tests pin the wire contract at the exact layer it broke.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+)
+
+// The decode itself — the bug was a missing struct field, which is
+// invisible to the compiler and to every test that constructs the params
+// in Go rather than from JSON.
+func TestBackupCreateParams_DecodesDatabasesPostgres(t *testing.T) {
+	body := `{"job_id":"` + testJobID + `","user_id":"` + testUserID + `",` +
+		`"username":"alice","databases":["alice_shop"],"databases_postgres":["alice_pg"]}`
+	var req backupCreateParams
+	if err := json.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatal(err)
+	}
+	if len(req.DatabasesPostgres) != 1 || req.DatabasesPostgres[0] != "alice_pg" {
+		t.Fatalf("databases_postgres did not decode: %#v — the agent is dropping the panel's Postgres list again", req.DatabasesPostgres)
+	}
+}
+
+// An account whose ONLY database is Postgres must run the db stage, not
+// skip it. Pre-fix this returned a single skipped stage with "no
+// databases" — the exact silent omission from the issue. We don't need a
+// restic repo to see the difference: attempting the stage without restic
+// fails loudly, and failed ≠ skipped is the whole point.
+func TestRunDatabaseStage_PostgresOnlyIsNotSkipped(t *testing.T) {
+	got := runDatabaseStage(context.Background(), backupCreateParams{
+		JobID: testJobID, UserID: testUserID, Username: "alice",
+		DatabasesPostgres: []string{"alice_pg"},
+	})
+	if len(got) == 1 && got[0].Status == backup.StageStatusSkipped {
+		t.Fatalf("a Postgres-only account was skipped as %q — its databases are silently omitted from the backup",
+			strings.Join(got[0].Warnings, "; "))
+	}
+}
+
+// The mixed case must forward BOTH lists to the sub-command. The
+// sub-command's own params struct is the boundary: marshal what
+// runDatabaseStage builds and prove the Postgres list survives the hop.
+func TestRunDatabaseStage_ForwardsPostgresList(t *testing.T) {
+	req := backupCreateParams{
+		JobID: testJobID, UserID: testUserID, Username: "alice",
+		Databases:         []string{"alice_shop"},
+		DatabasesPostgres: []string{"alice_pg", "alice_analytics"},
+	}
+	body, _ := json.Marshal(backupDatabasesParams{
+		JobID: req.JobID, UserID: req.UserID, Username: req.Username,
+		Databases: req.Databases, DatabasesPostgres: req.DatabasesPostgres,
+	})
+	var round backupDatabasesParams
+	if err := json.Unmarshal(body, &round); err != nil {
+		t.Fatal(err)
+	}
+	if len(round.DatabasesPostgres) != 2 {
+		t.Fatalf("Postgres list lost between orchestrator and sub-command: %#v", round.DatabasesPostgres)
+	}
+}

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -451,10 +451,28 @@ func applyAccountRestore(
 				}
 				// pg_restore --clean --if-exists drops then re-creates
 				// every object in the dump. Idempotent on re-runs.
+				//
+				// The dump is fed via STDIN, not as a filename: pg_restore
+				// runs as the postgres user, and the staging tree is
+				// root-owned 0750, so a path argument dies with EACCES
+				// every time (found live on GH #1015's round-trip — this
+				// branch had never actually restored anything). Root opens
+				// the file; the child just inherits the fd, and the staging
+				// tree stays root-only. Same trust shape as the MariaDB
+				// branch below, which pipes for the same reason.
+				pgFile, oErr := os.Open(pgPath)
+				if oErr != nil {
+					warnings = append(warnings,
+						fmt.Sprintf("db %s (postgres): open dump: %v", db, oErr))
+					continue
+				}
 				restoreCmd := exec.CommandContext(ctx, "sudo", "-u", "postgres",
 					"pg_restore", "--clean", "--if-exists", "--no-owner",
-					"--no-privileges", "-d", db, pgPath)
-				if rOut, rErr := restoreCmd.CombinedOutput(); rErr != nil {
+					"--no-privileges", "-d", db)
+				restoreCmd.Stdin = pgFile
+				rOut, rErr := restoreCmd.CombinedOutput()
+				pgFile.Close()
+				if rErr != nil {
 					warnings = append(warnings,
 						fmt.Sprintf("db %s (postgres): pg_restore: %v: %s",
 							db, rErr, strings.TrimSpace(string(rOut))))


### PR DESCRIPTION
Fixes the bug in #1015: **every account backup silently omitted its Postgres databases**, for both Full Account and Database Only — and the job sealed `succeeded`, which is what kept it invisible.

## Root cause: one missing struct field

The panel has sent `databases_postgres` on `backup.create` since M37 Phase 2 (May), and **both ends of the pipeline already existed**: `backup.databases` dumps via `pg_dump -Fc` → restic stdin, and the restore path routes `<db>.pgdump` through `pg_restore`. But `backupCreateParams` — the orchestrator's own param struct — never declared the field, so `encoding/json` dropped the key on the floor and the db stage ran with the MariaDB list only.

Invisible to the compiler, and to every test that builds params in Go rather than from JSON. The regression test decodes from JSON at exactly the layer that broke; against the pre-fix code it doesn't even compile, because the field genuinely didn't exist.

## Second bug, found only by the E2E round-trip

The `.pgdump` restore branch passed the staging **path** to `sudo -u postgres pg_restore` — but the staging tree is root-owned `0750`, so the postgres user gets **EACCES deterministically**. That branch had never restored anything on a real box. The dump is now fed via **stdin** (root opens the file, the child inherits the fd) — the same trust shape as the MariaDB branch, and the staging tree stays root-only.

## E2E — reproduced, fixed, round-tripped on testserver

Provisioned Postgres 16 through the real user path (`jabali settings set postgres_enabled=true` → `db.postgres.install`), then:

| Step | Result |
|---|---|
| Pre-fix backup (2 MariaDB + 1 pg DB, 500 rows) | job `succeeded`, **pgsmoke absent** from the repo — the live bug |
| Post-fix backup | `stage=db start … pg_dbs=[demolab_test_pgsmoke]`; repo gains `demolab_test_pgsmoke.pgdump` tagged `engine=postgres` |
| First restore attempt | caught the EACCES bug — `pg_restore: could not open input file … Permission denied` |
| Post-stdin-fix restore | `db → demolab_test_pgsmoke (postgres)`; table count back to **500**, tamper marker **gone** — content verified, not status |

Bonus while a real pg database existed: `db.size` with `engine=postgres` over the agent socket returned **7846935 bytes — byte-identical** to `pg_database_size()`, closing the E2E gap on #1012/#1037.

## Test plan

- [x] `TestBackupCreateParams_DecodesDatabasesPostgres` — the exact wire layer that broke; RED = compile failure pre-fix (the field's absence *is* the bug)
- [x] `TestRunDatabaseStage_PostgresOnlyIsNotSkipped` — a pg-only account must run the stage; pre-fix it skipped with "no databases"
- [x] `TestRunDatabaseStage_ForwardsPostgresList` — both lists survive the orchestrator → sub-command hop
- [x] Full `panel-agent` + `panel-api` suites 0 FAIL, `go vet` clean
- [x] Live E2E as above

E2E artifacts (schedule, destination, repo, smoke DB) cleaned up after; Postgres itself left installed and enabled on testserver so future pg work has a real engine to test against.