### PR TITLE
fix(ssl): don't fire certbot at a name that doesn't resolve yet (GH #896)

### DIFF
--- a/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
+++ b/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
@@ -64,8 +64,20 @@ func (f *fakeSSLCertRepo) UpdateSelfSigned(context.Context, string, string, stri
 func (f *fakeSSLCertRepo) UpdateCustom(context.Context, string, string, string, time.Time) error {
 	return nil
 }
-func (f *fakeSSLCertRepo) UpdateAfterACMEFailure(context.Context, string, string, time.Time, int, *string, *string, *time.Time) error {
+func (f *fakeSSLCertRepo) UpdateAfterACMEFailure(_ context.Context, id, lastError string, nextRetryAt time.Time, retryCount int, _, _ *string, _ *time.Time) error {
 	f.acmeFailures++
+	// Record onto the row so tests can assert what the reconciler wrote —
+	// the DNS pre-flight tests (GH #896) check the reason, the retry count,
+	// and the next-retry time.
+	for _, c := range f.byDomain {
+		if c.ID == id {
+			le := lastError
+			nr := nextRetryAt
+			c.LastError = &le
+			c.NextRetryAt = &nr
+			c.RetryCount = retryCount
+		}
+	}
 	return nil
 }
 func (f *fakeSSLCertRepo) UpdateAfterACMEFailureCapped(context.Context, string, string, int, *string, *string, *time.Time) error {

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -43,13 +43,18 @@ type Reconciler struct {
 	dnsRecords     repository.DNSRecordRepository
 	sslCerts       repository.SSLCertificateRepository
 	serverSettings repository.ServerSettingsRepository
-	phpPools       repository.PHPPoolRepository
-	sso            sso.SSOInterface
-	cfg            *config.Config
-	agent          agent.AgentInterface
-	dbAdmin        repository.DBAdminRepository
-	log            *slog.Logger
-	interval       time.Duration
+	// dnsPreflight resolves a hostname against EXTERNAL resolvers before an
+	// ACME attempt (GH #896 follow-up). Injectable so unit tests are not
+	// network-dependent; production default is
+	// dnsverify.LookupHostExternalResult (set in New).
+	dnsPreflight func(ctx context.Context, host string) (addrs []string, queried bool)
+	phpPools     repository.PHPPoolRepository
+	sso          sso.SSOInterface
+	cfg          *config.Config
+	agent        agent.AgentInterface
+	dbAdmin      repository.DBAdminRepository
+	log          *slog.Logger
+	interval     time.Duration
 
 	// sslIssueMu serialises certbot-touching work across the JAB-205
 	// domain worker pool AND the out-of-band ReconcileOne path: certbot
@@ -435,12 +440,13 @@ func New(domains repository.DomainRepository, users repository.UserRepository, a
 		cfg.QueueLen = 100
 	}
 	r := &Reconciler{
-		domains:  domains,
-		users:    users,
-		agent:    agentClient,
-		log:      log,
-		interval: cfg.Interval,
-		queue:    make(chan string, cfg.QueueLen),
+		domains:      domains,
+		users:        users,
+		agent:        agentClient,
+		log:          log,
+		dnsPreflight: dnsverify.LookupHostExternalResult,
+		interval:     cfg.Interval,
+		queue:        make(chan string, cfg.QueueLen),
 	}
 	// Initialize default socketReady function
 	r.socketReady = r.waitSocketReady
@@ -2615,6 +2621,39 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 		return
 	}
 
+	// GH #896 follow-up: pre-flight the BASE name before handing it to
+	// certbot. A freshly created (sub)domain routinely has no public
+	// A/AAAA yet — the operator adds the record at their DNS host minutes
+	// or hours later — and attempting issuance anyway guarantees a
+	// certbot NXDOMAIN failure that surfaces in the panel as a raw
+	// internal error ("certbot issue failed (dns_resolve_failed): …"),
+	// which is exactly what the #896 reporter hit on a fresh subdomain.
+	// The SANs already get this treatment (resolvableSANs); the base
+	// name never did.
+	//
+	// Skipping costs nothing at Let's Encrypt (no attempt = no rate-limit
+	// hit), so a DNS wait deliberately does NOT count toward the
+	// 20-attempt cap and retries on a short fixed delay — DNS propagates
+	// in minutes, and burning the cap while the operator sets up their
+	// records would strand the domain on "failed" without a single real
+	// ACME attempt.
+	// Park ONLY on a definitive empty answer (queried=true): an
+	// inconclusive lookup — every external resolver unreachable, e.g.
+	// outbound :53 blocked — must fall through to the ACME attempt, or a
+	// resolver outage on our side would strand every domain on "waiting
+	// for DNS" without ever trying.
+	{
+		preCtx, preCancel := context.WithTimeout(ctx, 6*time.Second)
+		addrs, queried := r.dnsPreflight(preCtx, domain.Name)
+		preCancel()
+		if queried && len(addrs) == 0 {
+			r.selfSignAndWaitForDNS(ctx, domain, cert,
+				"waiting for DNS: "+domain.Name+" has no public A/AAAA record yet — "+
+					"Let's Encrypt is not attempted until the name resolves (it would fail with NXDOMAIN); retrying automatically")
+			return
+		}
+	}
+
 	staging := false
 	if r.cfg != nil {
 		staging = r.cfg.ACME.StagingOnly
@@ -2702,45 +2741,68 @@ func isWebrootNotReady(err error) bool {
 //
 // The cert row stays in 'pending_acme_retry' status forever until ACME
 // succeeds; the SSL ticker will pick it up at next_retry_at.
-func (r *Reconciler) fallbackToSelfSignAndRetry(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate, lastError string) {
-	var fallbackCertPath *string
-	var fallbackKeyPath *string
-	var fallbackExpiresAt *time.Time
+// ensureSelfSignFallback generates the self-signed placeholder when the cert
+// row has no files yet, so HTTPS answers while ACME is pending. Returns nils
+// when a cert file already exists (nothing to replace) or self-sign failed
+// (logged; the row keeps whatever it had).
+func (r *Reconciler) ensureSelfSignFallback(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate) (certPath, keyPath *string, expiresAt *time.Time) {
+	if cert.CertPath != nil {
+		return nil, nil, nil
+	}
+	selfSignCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
-	if cert.CertPath == nil {
-		// No cert file yet; generate self-signed fallback so HTTPS works
-		// while we keep retrying ACME.
-		selfSignCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-
-		ssParams := map[string]any{
-			"domain": domain.Name,
-			"days":   365,
-		}
-		if extras := sanHostnamesForDomain(domain); len(extras) > 0 {
-			// Self-sign uses the SAME SAN filter so the fallback
-			// cert covers exactly what ACME will retry next tick.
-			if filtered := r.resolvableSANs(selfSignCtx, extras); len(filtered) > 0 {
-				ssParams["hostnames"] = filtered
-			}
-		}
-		raw, sErr := r.agent.Call(selfSignCtx, "ssl.self_sign", ssParams)
-		if sErr != nil {
-			r.log.Warn("ssl: self_sign fallback failed", "domain", domain.Name, "err", sErr)
-		} else {
-			var res sslSelfSignResult
-			if pErr := json.Unmarshal(raw, &res); pErr != nil {
-				r.log.Warn("ssl: parse self_sign result failed", "domain", domain.Name, "err", pErr)
-			} else if expiresAt, tErr := time.Parse(time.RFC3339, res.ExpiresAt); tErr != nil {
-				r.log.Warn("ssl: parse self_sign expires_at failed", "domain", domain.Name, "err", tErr)
-			} else {
-				fallbackCertPath = &res.CertPath
-				fallbackKeyPath = &res.KeyPath
-				fallbackExpiresAt = &expiresAt
-				r.log.Info("ssl: self-signed fallback generated", "domain", domain.Name, "expires_at", expiresAt.Format(time.RFC3339))
-			}
+	ssParams := map[string]any{
+		"domain": domain.Name,
+		"days":   365,
+	}
+	if extras := sanHostnamesForDomain(domain); len(extras) > 0 {
+		// Self-sign uses the SAME SAN filter so the fallback
+		// cert covers exactly what ACME will retry next tick.
+		if filtered := r.resolvableSANs(selfSignCtx, extras); len(filtered) > 0 {
+			ssParams["hostnames"] = filtered
 		}
 	}
+	raw, sErr := r.agent.Call(selfSignCtx, "ssl.self_sign", ssParams)
+	if sErr != nil {
+		r.log.Warn("ssl: self_sign fallback failed", "domain", domain.Name, "err", sErr)
+		return nil, nil, nil
+	}
+	var res sslSelfSignResult
+	if pErr := json.Unmarshal(raw, &res); pErr != nil {
+		r.log.Warn("ssl: parse self_sign result failed", "domain", domain.Name, "err", pErr)
+		return nil, nil, nil
+	}
+	exp, tErr := time.Parse(time.RFC3339, res.ExpiresAt)
+	if tErr != nil {
+		r.log.Warn("ssl: parse self_sign expires_at failed", "domain", domain.Name, "err", tErr)
+		return nil, nil, nil
+	}
+	r.log.Info("ssl: self-signed fallback generated", "domain", domain.Name, "expires_at", exp.Format(time.RFC3339))
+	return &res.CertPath, &res.KeyPath, &exp
+}
+
+// dnsWaitRetryDelay paces re-checks while a domain's DNS record does not
+// exist yet. Short and flat: DNS propagates in minutes, the check is a
+// resolver query (no Let's Encrypt quota involved), and the next passing
+// check goes straight to a real ACME attempt.
+const dnsWaitRetryDelay = 5 * time.Minute
+
+// selfSignAndWaitForDNS parks an LE-mode cert in pending_acme_retry while
+// the base name has no public A/AAAA record, WITHOUT counting toward the
+// acmeMaxRetries cap: no ACME attempt was made, so no Let's Encrypt quota
+// was spent, and a slow DNS setup must not strand the domain on "failed"
+// before its first real attempt (GH #896 follow-up).
+func (r *Reconciler) selfSignAndWaitForDNS(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate, reason string) {
+	fallbackCertPath, fallbackKeyPath, fallbackExpiresAt := r.ensureSelfSignFallback(ctx, domain, cert)
+	nextRetry := time.Now().UTC().Add(dnsWaitRetryDelay)
+	_ = r.sslCerts.UpdateAfterACMEFailure(ctx, cert.ID, reason, nextRetry, cert.RetryCount, fallbackCertPath, fallbackKeyPath, fallbackExpiresAt)
+	r.log.Info("ssl: waiting for DNS before attempting ACME",
+		"domain", domain.Name, "next_check_at", nextRetry.Format(time.RFC3339))
+}
+
+func (r *Reconciler) fallbackToSelfSignAndRetry(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate, lastError string) {
+	fallbackCertPath, fallbackKeyPath, fallbackExpiresAt := r.ensureSelfSignFallback(ctx, domain, cert)
 
 	newRetryCount := cert.RetryCount + 1
 

--- a/panel-api/internal/reconciler/ssl_dns_preflight_test.go
+++ b/panel-api/internal/reconciler/ssl_dns_preflight_test.go
@@ -1,0 +1,74 @@
+package reconciler
+
+// GH #896 follow-up. A freshly created (sub)domain routinely has no public
+// A/AAAA record yet, and firing certbot at it guarantees an NXDOMAIN failure
+// that surfaces in the panel as a raw internal error — the reporter's
+// second complaint on retest. The pre-flight parks the cert with a calm
+// "waiting for DNS" reason instead of attempting ACME.
+//
+// Three properties matter, and each has a failure mode this file pins:
+//
+//  1. No records (definitive) → NO ssl.issue call, calm reason, and the
+//     retry count is NOT consumed — no LE attempt happened, so a slow DNS
+//     setup must not burn through acmeMaxRetries and strand on "failed".
+//  2. Resolves → ACME proceeds exactly as before.
+//  3. Inconclusive (all external resolvers unreachable) → ACME proceeds.
+//     Parking on an inconclusive answer would mean an outbound-:53 outage
+//     on OUR side silently stops all issuance forever.
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSLPreflight_NoDNS_ParksWithoutBurningRetries(t *testing.T) {
+	r, ag, sc, dom := sslWebrootFixture(t, nil)
+	sc.byDomain[dom.ID].RetryCount = 3
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return nil, true // definitive: public DNS has no record
+	}
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if agentCalled(ag, "ssl.issue") {
+		t.Fatal("ssl.issue was attempted for a name with no public DNS record — guaranteed NXDOMAIN, scary error, wasted LE quota")
+	}
+	cert := sc.byDomain[dom.ID]
+	if cert.RetryCount != 3 {
+		t.Errorf("retry count %d, want 3 (unchanged) — a DNS wait is not an ACME attempt and must not consume the cap", cert.RetryCount)
+	}
+	if cert.LastError == nil || !strings.Contains(*cert.LastError, "waiting for DNS") {
+		t.Errorf("last error should be the calm waiting-for-DNS reason, got %v", cert.LastError)
+	}
+	if cert.NextRetryAt == nil || time.Until(*cert.NextRetryAt) > dnsWaitRetryDelay+time.Minute {
+		t.Errorf("next retry should be ~%s out, got %v", dnsWaitRetryDelay, cert.NextRetryAt)
+	}
+}
+
+func TestSSLPreflight_Resolves_AttemptsACME(t *testing.T) {
+	r, ag, _, dom := sslWebrootFixture(t, nil)
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return []string{"192.0.2.1"}, true
+	}
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("a resolving domain must proceed to the ACME attempt")
+	}
+}
+
+func TestSSLPreflight_InconclusiveLookup_AttemptsACME(t *testing.T) {
+	r, ag, _, dom := sslWebrootFixture(t, nil)
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return nil, false // every external resolver unreachable
+	}
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("an INCONCLUSIVE lookup must fall through to ACME — parking on it turns a resolver outage on our side into a permanent issuance freeze")
+	}
+}

--- a/panel-api/internal/reconciler/ssl_webroot_not_ready_test.go
+++ b/panel-api/internal/reconciler/ssl_webroot_not_ready_test.go
@@ -38,6 +38,13 @@ func sslWebrootFixture(t *testing.T, issueErr error) (*Reconciler, *fakeAgent, *
 	r := New(dr, nil, ag, slog.Default(), Config{}).
 		WithSSLCerts(sc).
 		WithDNSRepos(nil, nil, srv)
+	// The DNS pre-flight (GH #896 follow-up) would otherwise do a REAL
+	// external lookup for sub.example.com — authoritative NXDOMAIN — and
+	// park the cert before ssl.issue is ever attempted, which is not what
+	// these tests exercise. Stub it as "resolves".
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return []string{"192.0.2.1"}, true
+	}
 	return r, ag, sc, dom
 }
 


### PR DESCRIPTION
Follow-up to the #896 retest ([comment](https://github.com/shukiv/jabali-panel/issues/896#issuecomment-5235473260)): the reporter created a fresh subdomain and immediately got a raw internal error — `certbot issue failed (dns_resolve_failed): NXDOMAIN…`.

## Two findings from reproducing their exact conditions

**1. #1004's HTTP-first serving works.** Created a fresh LE-mode subdomain with non-resolving DNS on testserver (the reporter's exact state): the docroot serves **200 over plain HTTP** while the cert sits in `pending_acme_retry` — no redirect, no cert warning. The reporter's "dead page" is explained by their subdomain's **NXDOMAIN DNS**: their *browser* couldn't resolve the name either, which looks identical to a server fault and clears at roughly the moment LE also succeeds. (Their build may also have predated #1004 — `stable` didn't contain it until late Aug 9.)

**2. The scary error is real and ours.** Firing ACME at a name public DNS can't see *guarantees* an NXDOMAIN failure on the first tick of every freshly created domain whose operator hasn't added the DNS record yet — a completely routine sequence. The SANs already had a resolvability filter (`resolvableSANs`); the base name never did.

## The fix

A DNS pre-flight against external resolvers before every ACME attempt:

| Lookup result | Behaviour |
|---|---|
| Definitive empty | Park in `pending_acme_retry` with **"waiting for DNS: \<name> has no public A/AAAA record yet"**, self-signed fallback as before, re-check every 5 min |
| Resolves | ACME proceeds exactly as before |
| **Inconclusive** (all resolvers unreachable) | ACME proceeds — parking here would turn an outbound-:53 outage on our side into a permanent issuance freeze |

The wait deliberately does **not** count toward `acmeMaxRetries`: no attempt reached Let's Encrypt, so no quota was spent — and an operator who finishes their DNS setup hours later must not find the domain stranded on "failed" before its first real attempt.

`r.dnsPreflight` is injectable so unit tests aren't network-dependent. (The existing webroot fixtures needed the stub — their `sub.example.com` NXDOMAINs for real, which is itself a nice confirmation the gate works.)

## Test plan

- [x] Park on definitive-empty: no `ssl.issue` call, calm reason, retry count **unchanged**, ~5 min next check
- [x] Resolving name → ACME attempted
- [x] Inconclusive lookup → ACME attempted (the resolver-outage failure mode)
- [x] Existing webroot-not-ready + real-ACME-error tests still pass with the stub
- [x] `go vet` clean, full `panel-api` suite 0 FAIL
- [x] **Live E2E**: a cert row carrying the raw NXDOMAIN error at `retry_count=2` was parked with the calm reason within one tick, count still 2, no certbot run; plain HTTP served 200 throughout