### PR TITLE
fix(ssl): stop a proxied mail-helper SAN from taking a site's cert down, and recover certs stuck in 'failed' (JAB-226)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2510,6 +2510,17 @@ func (r *Reconciler) reconcileSSLForDomain(ctx context.Context, domain *models.D
 			r.tryACMEOrFallback(ctx, domain, cert)
 		case cert.Status == models.SSLStatusPendingACMERetry && cert.NextRetryAt != nil && cert.NextRetryAt.Before(time.Now().UTC()):
 			r.tryACMEOrFallback(ctx, domain, cert)
+		// A cert that hit a hard failure (unparseable agent result, a self-sign
+		// error) had NO dispatch case — it stayed 'failed' forever: no :443, no
+		// retry, no self-signed fallback, stranding the domain on plain HTTP
+		// until an operator ran `jabali ssl renew` by hand. That is how a
+		// one-time SAN failure (JAB-226) became a permanent outage instead of a
+		// transient retry. Route 'failed' back through the ACME-or-self-sign
+		// path: tryACMEOrFallback either issues, or self-signs + moves the row
+		// to pending_acme_retry (scheduled, so no per-tick hammering). This also
+		// auto-heals rows already stuck in 'failed' once this ships.
+		case cert.Status == models.SSLStatusFailed:
+			r.tryACMEOrFallback(ctx, domain, cert)
 		case cert.Status == models.SSLStatusRenewing:
 			r.sslRenewForDomain(ctx, domain, cert)
 		case cert.Status == models.SSLStatusSelfSigned:
@@ -2574,16 +2585,6 @@ func (r *Reconciler) sslEnsureSelfSigned(ctx context.Context, domain *models.Dom
 		return
 	}
 	r.log.Info("ssl: self-signed (self mode)", "domain", domain.Name, "expires_at", expiresAt.Format(time.RFC3339))
-}
-
-// needsIssue returns true when a certificate should be issued fresh: either
-// there is no cert row yet, or the row is in a state that wants to try again
-// (pending after API enable, or failed from a prior attempt).
-func needsIssue(cert *models.SSLCertificate) bool {
-	if cert == nil {
-		return true
-	}
-	return cert.Status == models.SSLStatusPending || cert.Status == models.SSLStatusFailed
 }
 
 // tryACMEOrFallback attempts ACME issuance; on failure, calls ssl.self_sign

--- a/panel-api/internal/reconciler/san_reachable.go
+++ b/panel-api/internal/reconciler/san_reachable.go
@@ -25,6 +25,16 @@ import (
 //
 // So the question is not "does this name resolve" but "will a challenge for it
 // reach US".
+//
+// And "reach us" is not the same test for every name. The apex and www.<apex>
+// are served from the domain docroot certbot writes the token into, so their
+// challenge survives a CDN — they keep the fronted (apex-match) allowance. The
+// mail helpers (mail./autoconfig./autodiscover./mta-sts.) are served from a
+// different vhost + webroot (/var/www/jabali-acme) and carry their own cert via
+// ssl_mail_issue; behind a proxy the token 404s even though they resolve like
+// the apex. So helpers must resolve DIRECTLY to us — see
+// webNameKeepsFrontedAllowance. (arizot-e.com: mail. resolved to Cloudflare
+// like the apex, passed the fronted test, 404'd, and failed the whole cert.)
 
 // sanReachability decides which SANs can plausibly pass HTTP-01 against this
 // server.
@@ -57,6 +67,27 @@ func sanReachability(sanAddrs, apexAddrs, ourAddrs []string) bool {
 		return true
 	}
 	return false
+}
+
+// webNameKeepsFrontedAllowance reports whether a SAN is a website name — the
+// apex or www.<apex> — that is served from the domain docroot certbot writes
+// the HTTP-01 token into, so its challenge reaches us even behind a CDN. Those
+// keep the fronted (apex-match) allowance.
+//
+// Everything else here is an auto-derived mail helper (mail./autoconfig./
+// autodiscover./mta-sts.<apex>, from sanHostnamesForDomain). Those are NOT
+// served from the domain docroot — they have their own vhost rooted at
+// /var/www/jabali-acme and their own certificate via ssl_mail_issue — so
+// "resolves to the apex's CDN" does NOT mean an HTTP-01 challenge for them
+// reaches this server: the proxy forwards it to the origin, the origin's mail
+// vhost serves the token dir from a different webroot, and it 404s. One such
+// failure fails the WHOLE web cert, apex included (arizot-e.com behind
+// Cloudflare: mail. resolved to CF like the apex, survived the fronted test,
+// and 404'd — taking the site's cert down with it). Helpers must therefore
+// resolve DIRECTLY to us to ride the web cert; otherwise they are dropped and
+// stay the mail cert's responsibility.
+func webNameKeepsFrontedAllowance(name, apex string) bool {
+	return name == apex || name == "www."+apex
 }
 
 func intersects(a, b []string) bool {
@@ -117,7 +148,16 @@ func (r *Reconciler) reachableSANs(ctx context.Context, apex string, names []str
 			lookupCtx, c := context.WithTimeout(ctx, 6*time.Second)
 			defer c()
 			addrs := dnsverify.LookupHostExternal(lookupCtx, name)
-			resCh <- result{name: name, keep: sanReachability(addrs, apexAddrs, ourAddrs)}
+			// Web names (apex, www.<apex>) keep the fronted allowance; the mail
+			// helpers must resolve directly to us — see
+			// webNameKeepsFrontedAllowance. Passing nil apex to sanReachability
+			// gives direct-only while preserving its fail-open when ourAddrs is
+			// also empty.
+			apexForName := apexAddrs
+			if !webNameKeepsFrontedAllowance(name, apex) {
+				apexForName = nil
+			}
+			resCh <- result{name: name, keep: sanReachability(addrs, apexForName, ourAddrs)}
 		}(n)
 	}
 

--- a/panel-api/internal/reconciler/san_reachable_test.go
+++ b/panel-api/internal/reconciler/san_reachable_test.go
@@ -75,6 +75,62 @@ func TestSANReachability_IPv6(t *testing.T) {
 	}
 }
 
+// webNameKeepsFrontedAllowance: apex and www keep the CDN allowance; the mail
+// helpers do not (they are served from a different webroot and their own cert,
+// so a proxied helper's challenge 404s and would tank the whole web cert).
+func TestWebNameKeepsFrontedAllowance(t *testing.T) {
+	const apex = "arizot-e.com"
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{apex, true},
+		{"www." + apex, true},
+		{"mail." + apex, false},
+		{"autoconfig." + apex, false},
+		{"autodiscover." + apex, false},
+		{"mta-sts." + apex, false},
+	} {
+		if got := webNameKeepsFrontedAllowance(tc.name, apex); got != tc.want {
+			t.Errorf("webNameKeepsFrontedAllowance(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// The arizot-e.com incident, expressed through the two reachability calls
+// reachableSANs makes per name. Behind Cloudflare the helper and the apex both
+// resolve to CF; www rides the fronted allowance (kept) while mail. is forced
+// to the direct test (dropped) so it cannot fail the whole cert.
+func TestHelperVsWebSANDecision(t *testing.T) {
+	const (
+		ourIP = "203.0.113.10"
+		cf1   = "104.16.1.1"
+		cf2   = "104.16.2.2"
+	)
+	apexAddrs := []string{cf1, cf2}
+	ours := []string{ourIP}
+	proxied := []string{cf1} // helper + www both sit behind the same CDN
+
+	// www.<apex>: fronted allowance applies -> kept.
+	if !sanReachability(proxied, apexAddrs, ours) {
+		t.Error("www behind the apex CDN was dropped — proxied web names must be kept")
+	}
+	// mail.<apex>: helper, direct-only (nil apex) -> dropped, since it resolves
+	// to CF, not to us. This is the fix: the proxied helper no longer rides the
+	// apex match, so it cannot 404 and kill the apex's cert.
+	if sanReachability(proxied, nil, ours) {
+		t.Error("proxied mail helper was kept — it must be dropped (direct-only)")
+	}
+	// Helper that DOES point straight at us stays on the web cert.
+	if !sanReachability([]string{ourIP}, nil, ours) {
+		t.Error("helper resolving directly to us was dropped")
+	}
+	// Fail-open preserved: unknown ourAddrs -> keep the helper rather than guess.
+	if !sanReachability([]string{cf1}, nil, nil) {
+		t.Error("helper dropped when we cannot judge — filter must never invent a failure")
+	}
+}
+
 func TestIntersects(t *testing.T) {
 	if intersects(nil, []string{"a"}) || intersects([]string{"a"}, nil) {
 		t.Error("empty input must not intersect")

--- a/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
+++ b/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
@@ -67,6 +67,16 @@ func TestReconcileSSL_ModeRouting(t *testing.T) {
 		require.True(t, hasCall(ag, "ssl.issue"), "self_signed le domain must attempt the LE upgrade")
 	})
 
+	// JAB-226 follow-up: a cert stuck in 'failed' (e.g. a hard ACME error)
+	// previously had NO dispatch case and was never retried — the domain stayed
+	// on plain HTTP forever. It must now route back through ACME so a transient
+	// failure self-heals instead of stranding the site.
+	t.Run("le mode failed cert retries via ACME", func(t *testing.T) {
+		cp, kp := "/etc/ssl/jabali-selfsigned/example.com/cert.pem", "/etc/ssl/jabali-selfsigned/example.com/key.pem"
+		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusFailed, CertPath: &cp, KeyPath: &kp})
+		require.True(t, hasCall(ag, "ssl.issue"), "a failed cert must be retried via ACME, not left stranded on HTTP")
+	})
+
 	t.Run("none mode revokes issued cert", func(t *testing.T) {
 		ag := run(models.SSLModeNone, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusIssued})
 		require.True(t, hasCall(ag, "ssl.revoke"), "none mode must revoke an issued cert")


### PR DESCRIPTION
## Why

A production WooCommerce site (arizot-e.com, behind Cloudflare Full-strict) went **down (CF 520)**: its Let's Encrypt cert had failed and never recovered, so the origin served no `:443`. Root-caused to two distinct bugs on the SSL path — one lets a helper SAN tank the whole cert, the other makes that failure **permanent**.

Relates to **JAB-226 / GH #935** (do not auto-close).

## What

**Commit 1 — helper SANs must resolve directly, not just like the apex.**
`reachableSANs` kept any SAN resolving to the apex's addresses (the CDN "fronted" case), assuming the proxy forwards the HTTP-01 challenge to us. That holds for the website names (apex, `www`) — served from the domain docroot certbot writes the token into — but **not** for the auto-derived mail helpers (`mail.` / `autoconfig.` / `autodiscover.` / `mta-sts.`). Those are served from a different vhost + webroot (`/var/www/jabali-acme`) and carry their own cert via `ssl_mail_issue`, so behind a proxy their challenge 404s. One failing name fails the **whole** cert, apex included.

_arizot-e.com: `mail.arizot-e.com` resolved to Cloudflare like the apex → survived the fronted test → 404'd → killed the site's cert and its `:443`._

Fix: website names keep the fronted allowance; helpers must resolve **directly** to this server. Fail-open preserved (unknown addrs keep the name).

**Commit 2 — retry certs stuck in `failed` instead of stranding the domain on HTTP.**
The dispatch switch in `reconcileSSLForDomain` had cases for `nil / pending / pending_acme_retry / renewing / self_signed` but **none for `failed`**. A cert that hit a hard failure stayed `failed` forever — no `:443`, no retry, no self-signed fallback — until an operator ran `jabali ssl renew` by hand. `needsIssue()` documented the intent to retry a `failed` row but was **dead code**, never wired in. This dead-end is what turned commit 1's one-time SAN failure into a *permanent* outage.

Fix: add a `failed` case routing back through `tryACMEOrFallback` (issue, or self-sign + schedule a retry via `pending_acme_retry` — no per-tick hammering). Removed the now-implemented dead `needsIssue`. **On deploy this auto-heals rows already stuck in `failed`.**

## Test plan

- [x] `go build ./panel-api/...`, `go vet`, full `reconciler` package green.
- [x] Unit: `webNameKeepsFrontedAllowance` (apex/www keep fronted, helpers don't); the arizot scenario through `sanReachability` (proxied helper dropped, proxied www kept, direct helper kept, fail-open preserved).
- [x] Unit: `reconcileSSLForDomain` dispatches a `failed` cert to `ssl.issue` (was previously a no-op).
- [ ] Verify on **testserver** with the `staging` ACME param: migrate a domain with mail enabled behind a proxy → web cert issues (apex+www) without the helper SANs; force a `failed` row → next tick retries.

## Notes / not in scope

- Heals nothing retroactively beyond the `failed`-row auto-recovery: the live boxes still need the ops sweep (existing `:443` gaps on newaramaapp are gated on a disk resize; arizot's sibling domains; a cert I revoked during triage).
- No closing keyword — JAB-226 stays open until the fleet is verified.
