### PR TITLE
fix(ui): finish the #970 toast sweep — 72 files, and a guard so it stays finished

### DIFF
--- a/panel-ui/src/components/DomainCacheSection.tsx
+++ b/panel-ui/src/components/DomainCacheSection.tsx
@@ -4,17 +4,8 @@
 // re-renders the vhost), and exposes a manual purge button.
 import { useTranslation } from "react-i18next";
 import { useCallback, useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  InputNumber,
-  Popconfirm,
-  Select,
-  Skeleton,
-  Space,
-  Switch,
-  message,
-} from "antd";
+import { Alert, Button, InputNumber, Popconfirm, Select, Skeleton, Space, Switch } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined, ThunderboltOutlined } from "@icons";
 
 import { apiClient } from "../apiClient";
@@ -58,7 +49,7 @@ export const DomainCacheSection = ({ domainId }: Props) => {
       setTtl(res.data.ttl_seconds ?? 600);
       setQAllow(res.data.cache_query_allowlist ?? []);
     } catch {
-      message.error("Failed to load cache status");
+      feedback.message.error("Failed to load cache status");
     } finally {
       setLoading(false);
     }
@@ -76,13 +67,13 @@ export const DomainCacheSection = ({ domainId }: Props) => {
       });
       setState(res.data);
       setTtl(res.data.ttl_seconds ?? 600);
-      message.success(
+      feedback.message.success(
         next
           ? "Caching enabled — applying to the site's nginx config"
           : "Caching disabled",
       );
     } catch {
-      message.error("Failed to toggle caching");
+      feedback.message.error("Failed to toggle caching");
       await fetchState();
     } finally {
       setToggling(false);
@@ -98,9 +89,9 @@ export const DomainCacheSection = ({ domainId }: Props) => {
       });
       setState(res.data);
       setTtl(res.data.ttl_seconds ?? 600);
-      message.success(`Cache TTL set to ${res.data.ttl_seconds}s — re-rendering nginx`);
+      feedback.message.success(`Cache TTL set to ${res.data.ttl_seconds}s — re-rendering nginx`);
     } catch {
-      message.error("Failed to update cache TTL");
+      feedback.message.error("Failed to update cache TTL");
       await fetchState();
     } finally {
       setSavingTtl(false);
@@ -113,11 +104,11 @@ export const DomainCacheSection = ({ domainId }: Props) => {
     );
     const bad = cleaned.find((n) => !QALLOW_NAME_RE.test(n));
     if (bad) {
-      message.error(`Invalid param "${bad}": use lower-case letters, digits, underscore (max 32 chars)`);
+      feedback.message.error(`Invalid param "${bad}": use lower-case letters, digits, underscore (max 32 chars)`);
       return;
     }
     if (cleaned.length > QALLOW_MAX) {
-      message.error(`Too many params (${cleaned.length}); max ${QALLOW_MAX}`);
+      feedback.message.error(`Too many params (${cleaned.length}); max ${QALLOW_MAX}`);
       return;
     }
     setSavingQAllow(true);
@@ -128,13 +119,13 @@ export const DomainCacheSection = ({ domainId }: Props) => {
       });
       setState(res.data);
       setQAllow(res.data.cache_query_allowlist ?? []);
-      message.success(
+      feedback.message.success(
         cleaned.length
           ? "Cacheable query params saved — re-rendering nginx"
           : "Query-param caching disabled",
       );
     } catch {
-      message.error("Failed to save cacheable query params");
+      feedback.message.error("Failed to save cacheable query params");
       await fetchState();
     } finally {
       setSavingQAllow(false);
@@ -145,9 +136,9 @@ export const DomainCacheSection = ({ domainId }: Props) => {
     setPurging(true);
     try {
       await apiClient.post(`/domains/${domainId}/cache/purge`);
-      message.success("Cache purged");
+      feedback.message.success("Cache purged");
     } catch {
-      message.error("Failed to purge cache");
+      feedback.message.error("Failed to purge cache");
     } finally {
       setPurging(false);
     }

--- a/panel-ui/src/components/dnssec/DNSSECTable.tsx
+++ b/panel-ui/src/components/dnssec/DNSSECTable.tsx
@@ -7,20 +7,8 @@
 //
 // The admin variant shows an "Owner" column by passing showOwner.
 import { useMemo, useState } from "react";
-import {
-  Alert,
-  Button,
-  Empty,
-  Modal,
-  Space,
-  Spin,
-  Switch,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Empty, Modal, Space, Spin, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 
 import { ShieldCheckOutlined } from "@icons";
 
@@ -182,10 +170,10 @@ function DNSSECToggle({ domainID }: { domainID: string }) {
       onChange={async (checked) => {
         try {
           await mutation.mutateAsync(checked);
-          message.success(checked ? "DNSSEC enabled" : "DNSSEC disabled");
+          feedback.message.success(checked ? "DNSSEC enabled" : "DNSSEC disabled");
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : "Failed";
-          message.error(msg);
+          feedback.message.error(msg);
         }
       }}
     />

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -1,20 +1,8 @@
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  Input,
-  Table,
-  Tag,
-  Button,
-  Popconfirm,
-  message,
-  Empty,
-  Space,
-  Tooltip,
-  Typography,
-  Modal,
-  Descriptions,
-} from "antd";
+import { Input, Table, Tag, Button, Popconfirm, Empty, Space, Tooltip, Typography, Modal, Descriptions } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import {
   ReloadOutlined,
   DeleteOutlined,
@@ -166,11 +154,11 @@ export const SSLManagerTable = ({
       await apiClient.post(`/domains/${domainId}/ssl/renew`);
     },
     onSuccess: () => {
-      message.success("Certificate renewal initiated");
+      feedback.message.success("Certificate renewal initiated");
       queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
     onError: () => {
-      message.error("Failed to renew certificate");
+      feedback.message.error("Failed to renew certificate");
     },
   });
 
@@ -180,11 +168,11 @@ export const SSLManagerTable = ({
       await apiClient.delete(`/domains/${domainId}/ssl`);
     },
     onSuccess: () => {
-      message.success("Certificate revoked");
+      feedback.message.success("Certificate revoked");
       queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
     onError: () => {
-      message.error("Failed to revoke certificate");
+      feedback.message.error("Failed to revoke certificate");
     },
   });
 
@@ -194,15 +182,15 @@ export const SSLManagerTable = ({
       await apiClient.post(`/domains/${domainId}/ssl/retry`);
     },
     onSuccess: () => {
-      message.success("Retry queued");
+      feedback.message.success("Retry queued");
       queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
     onError: (error: unknown) => {
       const status = (error as { response?: { status?: number; data?: { error?: string } } })?.response;
       if (status?.status === 409) {
-        message.info("Already retryable — will attempt on next tick");
+        feedback.message.info("Already retryable — will attempt on next tick");
       } else {
-        message.error("Failed to queue retry");
+        feedback.message.error("Failed to queue retry");
       }
     },
   });
@@ -214,11 +202,11 @@ export const SSLManagerTable = ({
       await apiClient.post(`/domains/${domainId}/mail-certificate/reissue`);
     },
     onSuccess: () => {
-      message.success("Mail certificate reissue queued");
+      feedback.message.success("Mail certificate reissue queued");
       queryClient.invalidateQueries({ queryKey: ["ssl-manager", endpoint] });
     },
     onError: () => {
-      message.error("Failed to reissue mail certificate");
+      feedback.message.error("Failed to reissue mail certificate");
     },
   });
 

--- a/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
+++ b/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
@@ -1,23 +1,8 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Card,
-  Empty,
-  Input,
-  Modal,
-  Popconfirm,
-  Select,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  Upload,
-  message,
-} from "antd";
+import { Alert, Button, Card, Empty, Input, Modal, Popconfirm, Select, Space, Table, Tag, Tooltip, Typography, Upload } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import type { UploadFile } from "antd";
 import { DeleteOutlined, PlusOutlined, SafetyCertificateOutlined, UploadOutlined } from "@icons";
 
@@ -122,14 +107,14 @@ export const SharedCertificatesCard = () => {
       });
     },
     onSuccess: () => {
-      message.success("Wildcard certificate requested — issuance runs within a minute");
+      feedback.message.success("Wildcard certificate requested — issuance runs within a minute");
       setAcmeOpen(false);
       setAcmeDomainId(undefined);
       queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
     },
     onError: (err: unknown) => {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "Failed to request certificate");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to request certificate");
     },
   });
 
@@ -148,14 +133,14 @@ export const SharedCertificatesCard = () => {
       });
     },
     onSuccess: () => {
-      message.success("Shared certificate uploaded");
+      feedback.message.success("Shared certificate uploaded");
       setUploadOpen(false);
       resetForm();
       queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
     },
     onError: (err: unknown) => {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "Failed to upload certificate");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to upload certificate");
     },
   });
 
@@ -164,26 +149,26 @@ export const SharedCertificatesCard = () => {
       await apiClient.delete(`/admin/certificates/shared/${id}`);
     },
     onSuccess: () => {
-      message.success("Shared certificate deleted");
+      feedback.message.success("Shared certificate deleted");
       queryClient.invalidateQueries({ queryKey: ["shared-certificates"] });
     },
     onError: (err: unknown) => {
       const status = (err as { response?: { status?: number } })?.response?.status;
       if (status === 409) {
-        message.info("Detach every domain from this certificate first");
+        feedback.message.info("Detach every domain from this certificate first");
       } else {
-        message.error("Failed to delete certificate");
+        feedback.message.error("Failed to delete certificate");
       }
     },
   });
 
   const submitUpload = () => {
     if (!name.trim()) {
-      message.error("Give the certificate a name");
+      feedback.message.error("Give the certificate a name");
       return;
     }
     if (!certPem.trim() || !keyPem.trim()) {
-      message.error("Paste both the certificate and the private key");
+      feedback.message.error("Paste both the certificate and the private key");
       return;
     }
     uploadMutation.mutate();
@@ -384,7 +369,7 @@ export const SharedCertificatesCard = () => {
                 beforeUpload={(file: UploadFile & File) => {
                   readFileText(file)
                     .then((text) => setCertPem(text))
-                    .catch(() => message.error("Could not read the certificate file"));
+                    .catch(() => feedback.message.error("Could not read the certificate file"));
                   return false;
                 }}
               >
@@ -411,7 +396,7 @@ export const SharedCertificatesCard = () => {
                 beforeUpload={(file: UploadFile & File) => {
                   readFileText(file)
                     .then((text) => setKeyPem(text))
-                    .catch(() => message.error("Could not read the key file"));
+                    .catch(() => feedback.message.error("Could not read the key file"));
                   return false;
                 }}
               >

--- a/panel-ui/src/lib/feedback.guard.test.ts
+++ b/panel-ui/src/lib/feedback.guard.test.ts
@@ -1,0 +1,86 @@
+// GH #970 regression gate. AntD's STATIC `message` / `notification` /
+// `Modal.confirm`-style methods render outside the React tree: they ignore
+// the ConfigProvider theme and direction and fall back to their own default
+// placements. That is exactly how the panel ended up with toasts in
+// different positions, sizes, and light/dark backgrounds depending on the
+// page — and how it crept back twice after the first sweep, because the
+// old sweeps only grepped single-line imports and 62 multiline `import {`
+// blocks slipped through.
+//
+// The rule: components either use `App.useApp()` (inside a component) or
+// `feedback` from lib/feedback (anywhere). Nobody imports `message` or
+// `notification` from antd, and nobody calls the static Modal methods.
+//
+// If this fires on new code: replace `message.x(...)` with
+// `feedback.message.x(...)` (import { feedback } from ".../lib/feedback")
+// or destructure from App.useApp() inside the component.
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC = join(__dirname, "..");
+
+// The only two legitimate touchpoints for the static instances:
+// main.tsx applies the global position/size config to them; lib/feedback
+// wraps them as the pre-bridge fallback.
+const ALLOWED = new Set(["main.tsx", "lib" + sep + "feedback.ts"]);
+
+const importRe = /import \{([^}]*)\} from "antd"/gs;
+const staticModalRe = /(?<![.\w])Modal\.(confirm|info|success|error|warning)\(/;
+
+function sourceFiles(): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|tsx)$/.test(e.name)) continue;
+      if (/\.test\.|\.d\.ts$/.test(e.name)) continue;
+      out.push(relative(SRC, full));
+    }
+  };
+  walk(SRC);
+  return out;
+}
+
+describe("feedback guard (GH #970)", () => {
+  it("no file imports the static message/notification from antd", () => {
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const f of sourceFiles()) {
+      if (ALLOWED.has(f)) continue;
+      const src = readFileSync(join(SRC, f), "utf8");
+      checked++;
+      for (const m of src.matchAll(importRe)) {
+        const names = m[1].split(",").map((s) => s.trim());
+        if (names.includes("message") || names.includes("notification")) {
+          offenders.push(relative(SRC, join(SRC, f)));
+        }
+      }
+    }
+    // The layout changing under the scanner must fail loudly, not pass
+    // silently by scanning nothing.
+    expect(checked).toBeGreaterThan(100);
+    expect(
+      offenders,
+      "static antd toasts render outside the theme — use feedback from lib/feedback or App.useApp()",
+    ).toEqual([]);
+  });
+
+  it("no file calls the static Modal methods", () => {
+    const offenders: string[] = [];
+    for (const f of sourceFiles()) {
+      if (ALLOWED.has(f)) continue;
+      const src = readFileSync(join(SRC, f), "utf8");
+      const m = src.match(staticModalRe);
+      if (m) offenders.push(`${f}: Modal.${m[1]}(`);
+    }
+    expect(
+      offenders,
+      "static Modal dialogs render outside the theme — use feedback.modal or App.useApp().modal",
+    ).toEqual([]);
+  });
+});

--- a/panel-ui/src/shells/DomainRedirectsButton.tsx
+++ b/panel-ui/src/shells/DomainRedirectsButton.tsx
@@ -11,18 +11,8 @@ import {
   PlusOutlined,
   DragOutlined,
 } from "@icons";
-import {
-  Button,
-  Modal,
-  Switch,
-  Row,
-  Col,
-  Input,
-  Select,
-  Card,
-  Typography,
-  notification,
-} from "antd";
+import { Button, Modal, Switch, Row, Col, Input, Select, Card, Typography } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
@@ -296,7 +286,7 @@ export const DomainRedirectsButton = ({
       if (wholeToggle) {
         const url = wholeUrl.trim();
         if (!url) {
-          notification.error({ message: "Enter a redirect URL" });
+          feedback.notification.error({ message: "Enter a redirect URL" });
           setIsSaving(false);
           return;
         }
@@ -323,7 +313,7 @@ export const DomainRedirectsButton = ({
       body.page_redirects = clean.filter((pr) => pr.source && pr.destination);
 
       await apiClient.patch(`/domains/${domain.id}`, body);
-      notification.success({ message: "Redirects saved" });
+      feedback.notification.success({ message: "Redirects saved" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleCloseModal();
@@ -332,7 +322,7 @@ export const DomainRedirectsButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to save",
         description: e.response?.data?.detail ?? e.message ?? "Unknown error",
       });

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -16,22 +16,8 @@ import {
   MenuOutlined,
   UpOutlined,
 } from "@icons";
-import {
-  Button,
-  Modal,
-  Alert,
-  Tabs,
-  Input,
-  Typography,
-  Card,
-  Select,
-  Switch,
-  Row,
-  Col,
-  Dropdown,
-  Tag,
-  notification,
-} from "antd";
+import { Button, Modal, Alert, Tabs, Input, Typography, Card, Select, Switch, Row, Col, Dropdown, Tag } from "antd";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 import {
   DndContext,
@@ -835,7 +821,7 @@ const HtaccessImport = ({
         response?: { data?: { error?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Could not convert .htaccess",
         description: e.response?.data?.error ?? e.message ?? "Unknown error",
       });
@@ -847,7 +833,7 @@ const HtaccessImport = ({
   const handleAdd = () => {
     if (!preview || preview.rules.length === 0) return;
     onRulesChange([...rules, ...preview.rules]);
-    notification.success({
+    feedback.notification.success({
       message: `Added ${preview.rules.length} rule(s) to the Rule Builder`,
       description: "Review them on the Rule Builder tab, then Save / Apply.",
     });
@@ -1030,7 +1016,7 @@ export const DomainSettingsButton = ({
         nginx_custom_directives: directivesValue,
         nginx_rules: rules,
       });
-      notification.success({ message: "Nginx config saved" });
+      feedback.notification.success({ message: "Nginx config saved" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleCloseModal();
@@ -1039,7 +1025,7 @@ export const DomainSettingsButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to save",
         description: e.response?.data?.detail ?? e.message ?? "Unknown error",
       });
@@ -1166,7 +1152,7 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
         nginx_custom_directives: directivesValue,
         nginx_rules: rules,
       });
-      notification.success({ message: "Nginx config saved" });
+      feedback.notification.success({ message: "Nginx config saved" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
     } catch (err) {
@@ -1174,7 +1160,7 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to save",
         description: e.response?.data?.detail ?? e.message ?? "Unknown error",
       });
@@ -1284,7 +1270,7 @@ export const TenantNginxRulesButton = ({
     try {
       // Send ONLY nginx_rules — never nginx_custom_directives (admin-only).
       await apiClient.patch(`/domains/${domain.id}`, { nginx_rules: rules });
-      notification.success({ message: "Rewrite rules saved — applied on the next reconcile" });
+      feedback.notification.success({ message: "Rewrite rules saved — applied on the next reconcile" });
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       close();
@@ -1293,7 +1279,7 @@ export const TenantNginxRulesButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to save rules",
         description: e.response?.data?.detail ?? e.message ?? "Unknown error",
       });

--- a/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
+++ b/panel-ui/src/shells/admin/applications/AdminApplicationList.tsx
@@ -9,16 +9,8 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  Card,
-  Input,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Card, Input, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   AppstoreOutlined,
   LoadingOutlined,
@@ -98,13 +90,13 @@ const AdminActionsCell = ({
     setDeleting(true);
     try {
       await apiClient.delete(`/applications/${record.id}`);
-      message.success(
+      feedback.message.success(
         `Deleting ${record.domain_name || record.domain_id}\u2026`,
       );
       qc.invalidateQueries({ queryKey: ["list", "applications"] });
       qc.invalidateQueries({ queryKey: ["list", "databases"] });
     } catch (err) {
-      message.error(
+      feedback.message.error(
         (err as Error)?.message ?? "Failed to delete application",
       );
     } finally {
@@ -120,9 +112,9 @@ const AdminActionsCell = ({
         "_blank",
         "noopener,noreferrer"
       );
-      message.success("Admin login link opened");
+      feedback.message.success("Admin login link opened");
     } catch {
-      message.error(magicLinkError || "Failed to generate admin login link");
+      feedback.message.error(magicLinkError || "Failed to generate admin login link");
     }
   };
 

--- a/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
+++ b/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
@@ -12,24 +12,8 @@ import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Drawer,
-  Form,
-  Input,
-  Modal,
-  Popconfirm,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-  theme,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Drawer, Form, Input, Modal, Popconfirm, Space, Switch, Table, Tag, Typography, theme } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { KeyOutlined, PlusOutlined, DeleteOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -147,7 +131,7 @@ export const AdminAutomationTokensPage = () => {
     try {
       await mint.mutateAsync(values);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Mint failed");
+      feedback.message.error(err instanceof Error ? err.message : "Mint failed");
     }
   };
 
@@ -155,9 +139,9 @@ export const AdminAutomationTokensPage = () => {
     if (!revealSecret) return;
     try {
       await navigator.clipboard.writeText(revealSecret);
-      message.success("Secret copied to clipboard");
+      feedback.message.success("Secret copied to clipboard");
     } catch {
-      message.error("Clipboard access blocked — copy manually");
+      feedback.message.error("Clipboard access blocked — copy manually");
     }
   };
 

--- a/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
@@ -8,7 +8,7 @@
 // "Generate new key" inline action that calls the same endpoint with
 // POST.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Drawer, Form, Input, InputNumber, Modal, Radio, Select, Space, Switch, Table, Tag, Typography, message } from "antd";
+import { Alert, Button, Drawer, Form, Input, InputNumber, Modal, Radio, Select, Space, Switch, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../components/RowActions";
 import {
@@ -114,7 +114,7 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
       );
       setSshKeys(resp.data.data ?? []);
     } catch (err) {
-      message.error(extractApiError(err, "ssh-key list failed"));
+      feedback.message.error(extractApiError(err, "ssh-key list failed"));
     } finally {
       setKeysLoading(false);
     }
@@ -175,7 +175,7 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
         };
         if (values.sftp_auth === "password") {
           if (!values.sftp_password && !editing?.has_credentials) {
-            message.error("password is required for SFTP password auth");
+            feedback.message.error("password is required for SFTP password auth");
             setBusy(false);
             return;
           }
@@ -208,7 +208,7 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
             `/admin/backup-destinations/${savedID}/test`,
             {},
           );
-          message.success(
+          feedback.message.success(
             resp.data.detail ? `Saved + tested OK — ${resp.data.detail}` : "Saved + tested OK",
           );
         } catch (testErr) {
@@ -221,11 +221,11 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
           return;
         }
       } else {
-        message.success(editing ? "Destination updated" : "Destination created");
+        feedback.message.success(editing ? "Destination updated" : "Destination created");
       }
       onSaved();
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setBusy(false);
     }
@@ -474,7 +474,7 @@ function GenerateKeyModal({ open, onClose, onGenerated }: GenerateKeyModalProps)
         has_passphrase: false,
       });
     } catch (err) {
-      message.error(extractApiError(err, "key generation failed"));
+      feedback.message.error(extractApiError(err, "key generation failed"));
     } finally {
       setBusy(false);
     }
@@ -579,7 +579,7 @@ export function DestinationsTab() {
       );
       setRows(resp.data.data ?? []);
     } catch (err) {
-      message.error(extractApiError(err, "Load failed"));
+      feedback.message.error(extractApiError(err, "Load failed"));
     } finally {
       setLoading(false);
     }
@@ -600,10 +600,10 @@ export function DestinationsTab() {
       onOk: async () => {
         try {
           await apiClient.delete(`/admin/backup-destinations/${row.id}`);
-          message.success(`Deleted ${row.name}`);
+          feedback.message.success(`Deleted ${row.name}`);
           void reload();
         } catch (err) {
-          message.error(extractApiError(err, "Delete failed"));
+          feedback.message.error(extractApiError(err, "Delete failed"));
         }
       },
     });
@@ -652,7 +652,7 @@ export function DestinationsTab() {
                   size="small"
                   onClick={() => {
                     void navigator.clipboard.writeText(resp.data.password);
-                    message.success("Copied to clipboard");
+                    feedback.message.success("Copied to clipboard");
                   }}
                 >
                   Copy
@@ -662,7 +662,7 @@ export function DestinationsTab() {
           });
           await reload();
         } catch (err) {
-          message.error(extractApiError(err, "Rotate failed"));
+          feedback.message.error(extractApiError(err, "Rotate failed"));
         } finally {
           setRotatingId(null);
         }
@@ -671,7 +671,7 @@ export function DestinationsTab() {
   };
 
   const handleTest = async (row: BackupDestination) => {
-    const hide = message.loading(`Testing ${row.name}…`, 0);
+    const hide = feedback.message.loading(`Testing ${row.name}…`, 0);
     try {
       const resp = await apiClient.post<{ status: string; detail?: string }>(
         `/admin/backup-destinations/${row.id}/test`,
@@ -679,10 +679,10 @@ export function DestinationsTab() {
       );
       hide();
       const detail = resp.data.detail;
-      message.success(detail ? `OK — ${detail}` : "Connection OK");
+      feedback.message.success(detail ? `OK — ${detail}` : "Connection OK");
     } catch (err) {
       hide();
-      message.error(extractApiError(err, "Test failed"));
+      feedback.message.error(extractApiError(err, "Test failed"));
     }
   };
 

--- a/panel-ui/src/shells/admin/backups/EncryptionKeyCard.tsx
+++ b/panel-ui/src/shells/admin/backups/EncryptionKeyCard.tsx
@@ -7,14 +7,8 @@
 // loads the secret. Copy + Download buttons let the operator stash
 // it in a password manager / printed sheet / off-host vault.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Input,
-  Space,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Input, Space, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   CopyOutlined,
   DownloadOutlined,
@@ -54,7 +48,7 @@ export function EncryptionKeyCard() {
       setSecret(resp.data);
       setRevealed(true);
     } catch (err) {
-      message.error(extractApiError(err, "reveal failed"));
+      feedback.message.error(extractApiError(err, "reveal failed"));
     } finally {
       setBusy(false);
     }
@@ -64,9 +58,9 @@ export function EncryptionKeyCard() {
     if (!secret) return;
     try {
       await navigator.clipboard.writeText(secret.password);
-      message.success("password copied to clipboard");
+      feedback.message.success("password copied to clipboard");
     } catch {
-      message.error("clipboard access denied — copy manually from the field");
+      feedback.message.error("clipboard access denied — copy manually from the field");
     }
   };
 

--- a/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
+++ b/panel-ui/src/shells/admin/backups/SchedulesTab.tsx
@@ -1,7 +1,7 @@
 // M30.1 Schedules admin tab. Lists every backup_schedules row, drawer
 // for create/edit, multi-select destinations, "Run now" button.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Checkbox, Drawer, Form, InputNumber, Radio, Segmented, Select, Space, Switch, Table, Tag, TimePicker, Tooltip, Typography, message } from "antd";
+import { Alert, Button, Checkbox, Drawer, Form, InputNumber, Radio, Segmented, Select, Space, Switch, Table, Tag, TimePicker, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../components/RowActions";
 import { shortDateTime } from "../../../utils/datetime";
@@ -242,14 +242,14 @@ function ScheduleDrawer({
         // subset, not both.
         userIDs = hasAll ? [] : selected.filter((u) => u !== ALL_USERS);
         if (!hasAll && userIDs.length === 0) {
-          message.error("Pick at least one user, or 'All users'");
+          feedback.message.error("Pick at least one user, or 'All users'");
           setBusy(false);
           return;
         }
         includeSystem = !!values.include_system_backup;
       }
       if (values.freq === "weekly" && (!values.weekdays || values.weekdays.length === 0)) {
-        message.error("Pick at least one weekday");
+        feedback.message.error("Pick at least one weekday");
         setBusy(false);
         return;
       }
@@ -276,14 +276,14 @@ function ScheduleDrawer({
 
       if (editing) {
         await apiClient.patch(`/admin/backup-schedules/${editing.id}`, body);
-        message.success("Schedule updated");
+        feedback.message.success("Schedule updated");
       } else {
         await apiClient.post("/admin/backup-schedules", body);
-        message.success("Schedule created");
+        feedback.message.success("Schedule created");
       }
       onSaved();
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setBusy(false);
     }
@@ -473,7 +473,7 @@ export function SchedulesTab() {
       setDestinations(d.data.data ?? []);
       setUsers(u.data.data ?? []);
     } catch (err) {
-      message.error(extractApiError(err, "Load failed"));
+      feedback.message.error(extractApiError(err, "Load failed"));
     } finally {
       setLoading(false);
     }
@@ -491,10 +491,10 @@ export function SchedulesTab() {
       onOk: async () => {
         try {
           await apiClient.delete(`/admin/backup-schedules/${row.id}`);
-          message.success("Schedule deleted");
+          feedback.message.success("Schedule deleted");
           void reload();
         } catch (err) {
-          message.error(extractApiError(err, "Delete failed"));
+          feedback.message.error(extractApiError(err, "Delete failed"));
         }
       },
     });
@@ -503,10 +503,10 @@ export function SchedulesTab() {
   const handleRunNow = async (row: BackupSchedule) => {
     try {
       await apiClient.post(`/admin/backup-schedules/${row.id}/run-now`, {});
-      message.success("Schedule queued for the next tick (within 60s)");
+      feedback.message.success("Schedule queued for the next tick (within 60s)");
       void reload();
     } catch (err) {
-      message.error(extractApiError(err, "Run-now failed"));
+      feedback.message.error(extractApiError(err, "Run-now failed"));
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainDirectoryPrivacySection.tsx
@@ -6,18 +6,8 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Form,
-  Input,
-  Popconfirm,
-  Skeleton,
-  Space,
-  Table,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Form, Input, Popconfirm, Skeleton, Space, Table, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, FolderOpenOutlined, PlusOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -87,23 +77,23 @@ export const DomainDirectoryPrivacySection = ({
           rule.id,
         ],
       });
-      message.success("Protected directory created");
+      feedback.message.success("Protected directory created");
       form.resetFields();
       setAdding(false);
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string } } })
         ?.response?.data;
       const fallback = err instanceof Error ? err.message : "Failed to add rule";
-      message.error(resp?.error ?? fallback);
+      feedback.message.error(resp?.error ?? fallback);
     }
   };
 
   const onDeleteRule = async (ruleId: string) => {
     try {
       await deleteRule.mutateAsync({ ruleId });
-      message.success("Rule deleted");
+      feedback.message.success("Rule deleted");
     } catch {
-      message.error("Failed to delete rule");
+      feedback.message.error("Failed to delete rule");
     }
   };
 
@@ -286,22 +276,22 @@ const DirectoryPrivacyCredentialsTable = ({
   const onAdd = async (values: CreateCredentialInput) => {
     try {
       await create.mutateAsync(values);
-      message.success("User added");
+      feedback.message.success("User added");
       form.resetFields();
       setAdding(false);
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string } } })
         ?.response?.data;
-      message.error(resp?.error ?? "Failed to add user");
+      feedback.message.error(resp?.error ?? "Failed to add user");
     }
   };
 
   const onDelete = async (credId: string) => {
     try {
       await remove.mutateAsync({ credId });
-      message.success("User deleted");
+      feedback.message.success("User deleted");
     } catch {
-      message.error("Failed to delete user");
+      feedback.message.error("Failed to delete user");
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainEdit.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEdit.tsx
@@ -4,19 +4,8 @@
 // (name/doc_root/enabled/custom directives + Save).
 import { useTranslation } from "react-i18next";
 import { useEffect } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Form,
-  Input,
-  Space,
-  Spin,
-  Switch,
-  Tabs,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Form, Input, Space, Spin, Switch, Tabs, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router";
@@ -93,12 +82,12 @@ export const DomainEdit = () => {
     if (!id) return;
     try {
       await updateMutation.mutateAsync({ id, input: values });
-      message.success("Domain updated");
+      feedback.message.success("Domain updated");
       navigate("/jabali-admin/domains");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to update domain";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainEmailSection.tsx
@@ -9,20 +9,8 @@
 // render as static instructions (empty `status` column).
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Alert,
-  Button,
-  Popconfirm,
-  Card,
-  Select,
-  Skeleton,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Popconfirm, Card, Select, Skeleton, Space, Switch, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CopyOutlined } from "@icons";
 
 import {
@@ -42,9 +30,9 @@ type Props = {
 async function copyText(text: string) {
   try {
     await navigator.clipboard.writeText(text);
-    message.success("Copied to clipboard");
+    feedback.message.success("Copied to clipboard");
   } catch {
-    message.error("Copy failed — select the field and copy manually");
+    feedback.message.error("Copy failed — select the field and copy manually");
   }
 }
 
@@ -73,10 +61,10 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     try {
       await apiClient.post(`/domains/${domainId}/email/dkim-rotate`);
       qc.invalidateQueries({ queryKey: ["one", "domain-email", domainId] });
-      message.success("DKIM rotated — new key published; allow time for DNS propagation");
+      feedback.message.success("DKIM rotated — new key published; allow time for DNS propagation");
     } catch (err) {
       const resp = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "DKIM rotation failed");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "DKIM rotation failed");
     } finally {
       setRotating(false);
     }
@@ -86,9 +74,9 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     try {
       await apiClient.patch(`/domains/${domainId}`, { webmail_enabled: next });
       qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
-      message.success(next ? "Webmail enabled for this domain" : "Webmail disabled for this domain");
+      feedback.message.success(next ? "Webmail enabled for this domain" : "Webmail disabled for this domain");
     } catch {
-      message.error("Failed to toggle webmail");
+      feedback.message.error("Failed to toggle webmail");
     } finally {
       setWmFlipping(false);
     }
@@ -100,10 +88,10 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     try {
       await apiClient.patch(`/domains/${domainId}`, patch);
       qc.invalidateQueries({ queryKey: ["one", "domains", domainId] });
-      message.success("DMARC settings saved");
+      feedback.message.success("DMARC settings saved");
     } catch (err) {
       const resp = (err as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "Failed to save DMARC settings");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to save DMARC settings");
     } finally {
       setDmarcSaving(false);
     }
@@ -114,15 +102,15 @@ export const DomainEmailSection = ({ domainId }: Props) => {
     try {
       if (next) {
         await enableMutation.mutateAsync({ domainId });
-        message.success("Email enabled — publish the DNS records below");
+        feedback.message.success("Email enabled — publish the DNS records below");
       } else {
         await disableMutation.mutateAsync({ domainId });
-        message.success("Email disabled");
+        feedback.message.success("Email disabled");
       }
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })
         ?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "Failed to toggle email");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to toggle email");
     } finally {
       setFlipping(false);
     }

--- a/panel-ui/src/shells/admin/domains/DomainIPACLSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainIPACLSection.tsx
@@ -4,21 +4,8 @@
 // inside the server block; lower priority = higher precedence.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Alert,
-  Button,
-  Form,
-  Input,
-  InputNumber,
-  Popconfirm,
-  Select,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Form, Input, InputNumber, Popconfirm, Select, Skeleton, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, PlusOutlined } from "@icons";
 
 import {
@@ -64,22 +51,22 @@ export const DomainIPACLSection = ({ domainId }: Props) => {
         priority: values.priority ?? 0,
         comment: values.comment ?? "",
       });
-      message.success("Rule added");
+      feedback.message.success("Rule added");
       form.resetFields();
       setAdding(false);
     } catch (err: unknown) {
       const resp = (err as { response?: { data?: { error?: string } } })
         ?.response?.data;
-      message.error(resp?.error ?? "Failed to add rule");
+      feedback.message.error(resp?.error ?? "Failed to add rule");
     }
   };
 
   const onDelete = async (aclID: string) => {
     try {
       await remove.mutateAsync({ aclID });
-      message.success("Rule deleted");
+      feedback.message.success("Rule deleted");
     } catch {
-      message.error("Failed to delete rule");
+      feedback.message.error("Failed to delete rule");
     }
   };
 

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -8,25 +8,8 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { RowActions } from "../../../components/RowActions";
-import {
-  Alert,
-  Button,
-  Card,
-  Form,
-  Input,
-  Checkbox,
-  InputNumber,
-  Modal,
-  Progress,
-  Select,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Form, Input, Checkbox, InputNumber, Modal, Progress, Select, Skeleton, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   DeleteOutlined,
   KeyOutlined,
@@ -148,11 +131,11 @@ export const DomainMailboxesSection = ({
     const onEnable = async () => {
       try {
         await enableMutation.mutateAsync({ domainId });
-        message.success("Email enabled");
+        feedback.message.success("Email enabled");
       } catch (err) {
         const resp = (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data;
-        message.error(resp?.detail ?? resp?.error ?? "Failed to enable email");
+        feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to enable email");
       }
     };
     return (
@@ -186,13 +169,13 @@ export const DomainMailboxesSection = ({
           title: "New mailbox password (rotation)",
         });
       } else {
-        message.success("Password rotated");
+        feedback.message.success("Password rotated");
       }
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
         "Failed to rotate password";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setRotatingId(null);
     }
@@ -206,7 +189,7 @@ export const DomainMailboxesSection = ({
   const openWebmail = (row: Mailbox) => {
     const popup = window.open("about:blank", "_blank");
     if (!popup) {
-      message.warning(
+      feedback.message.warning(
         "Browser blocked the webmail popup — allow popups for this site or click again.",
       );
       return;
@@ -225,13 +208,13 @@ export const DomainMailboxesSection = ({
           // pre-Step-8 mailboxes (password_enc is NULL) — surface the
           // remediation so the user knows what to do.
           if (resp?.error === "sso_unavailable_rotate_password") {
-            message.warning(
+            feedback.message.warning(
               resp.detail ??
                 "Rotate the mailbox password to enable webmail SSO.",
             );
             return;
           }
-          message.error(resp?.detail ?? resp?.error ?? "Failed to open webmail");
+          feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to open webmail");
         },
       },
     );
@@ -267,12 +250,12 @@ export const DomainMailboxesSection = ({
           title: "New mailbox password",
         });
       } else {
-        message.success(`Mailbox ${resp.email} created`);
+        feedback.message.success(`Mailbox ${resp.email} created`);
       }
     } catch (err) {
       const resp = (err as { response?: { data?: { error?: string; detail?: string } } })
         ?.response?.data;
-      message.error(resp?.detail ?? resp?.error ?? "Failed to create mailbox");
+      feedback.message.error(resp?.detail ?? resp?.error ?? "Failed to create mailbox");
     }
   };
 
@@ -377,10 +360,10 @@ export const DomainMailboxesSection = ({
                       onClick: async () => {
                         try {
                           await deleteMutation.mutateAsync({ id: row.id, domainId });
-                          message.success("Mailbox deleted");
+                          feedback.message.success("Mailbox deleted");
                         } catch (err) {
                           const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ?? "Failed to delete";
-                          message.error(msg);
+                          feedback.message.error(msg);
                         }
                       },
                       confirm: { title: `Delete ${row.email}?`, description: "All mail in this mailbox will be removed. This cannot be undone.", okText: "Delete" },

--- a/panel-ui/src/shells/admin/ips/AdminIPDrawer.tsx
+++ b/panel-ui/src/shells/admin/ips/AdminIPDrawer.tsx
@@ -4,19 +4,8 @@
 // page routes with a Drawer. Per docs/CONVENTIONS.md, create + edit
 // share a single Drawer surface; address is read-only on edit (delete
 // + re-add to change).
-import {
-  Alert,
-  Button,
-  Drawer,
-  Form,
-  Grid,
-  Input,
-  Space,
-  Spin,
-  Switch,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Drawer, Form, Grid, Input, Space, Spin, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
 import { CheckOutlined, CloseOutlined } from "@icons";
@@ -110,7 +99,7 @@ export function AdminIPDrawer({ open, onClose, editingId }: AdminIPDrawerProps) 
             is_default: values.is_default ?? false,
           },
         });
-        message.success("IP updated");
+        feedback.message.success("IP updated");
         onClose();
       } else {
         const result = await create.mutateAsync({
@@ -120,14 +109,14 @@ export function AdminIPDrawer({ open, onClose, editingId }: AdminIPDrawerProps) 
         });
         if (result.warnings && result.warnings.length > 0) {
           setWarnings(result.warnings);
-          message.warning("IP added with warnings — review below");
+          feedback.message.warning("IP added with warnings — review below");
           return;
         }
-        message.success("IP added to pool");
+        feedback.message.success("IP added to pool");
         onClose();
       }
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationDetailPage.tsx
@@ -7,26 +7,8 @@
 // operator sees stages advance live while the cobra CLI runs.
 import { useTranslation } from "react-i18next";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Collapse,
-  Descriptions,
-  Empty,
-  Form,
-  Input,
-  message,
-  Modal,
-  Radio,
-  Space,
-  Spin,
-  Progress,
-  Steps,
-  Tag,
-  Typography,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Collapse, Descriptions, Empty, Form, Input, Modal, Radio, Space, Spin, Progress, Steps, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   ClockCircleOutlined,
   DatabaseOutlined,
@@ -770,11 +752,11 @@ function FailedCard({ jobId, onDestroyed }: { jobId: string; onDestroyed: () => 
       );
     },
     onSuccess: () => {
-      message.success("Retry queued — runner will pick up the job on the next tick.");
+      feedback.message.success("Retry queued — runner will pick up the job on the next tick.");
     },
     onError: (e: unknown) => {
       const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      message.error(detail ?? "Retry failed");
+      feedback.message.error(detail ?? "Retry failed");
     },
   });
   const destroy = useMutation({
@@ -782,12 +764,12 @@ function FailedCard({ jobId, onDestroyed }: { jobId: string; onDestroyed: () => 
       await apiClient.post(`/admin/migrations/${jobId}/destroy`);
     },
     onSuccess: () => {
-      message.success("Job destroyed.");
+      feedback.message.success("Job destroyed.");
       onDestroyed();
     },
     onError: (e: unknown) => {
       const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      message.error(detail ?? "Destroy failed");
+      feedback.message.error(detail ?? "Destroy failed");
     },
   });
 
@@ -890,12 +872,12 @@ export function DriveCard({
       return data;
     },
     onSuccess: () => {
-      message.success("Secrets uploaded.");
+      feedback.message.success("Secrets uploaded.");
       setSecretsOpen(false);
       secretsForm.resetFields();
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         `Secrets upload failed: ${(e as Error)?.message ?? "unknown"}`,
       );
     },
@@ -910,7 +892,7 @@ export function DriveCard({
       return data as { unit?: string };
     },
     onSuccess: (d) => {
-      message.success(`Pull started: ${d?.unit ?? "(unit name unavailable)"}`);
+      feedback.message.success(`Pull started: ${d?.unit ?? "(unit name unavailable)"}`);
       refresh();
     },
     onError: (e: unknown) => {
@@ -919,7 +901,7 @@ export function DriveCard({
         (e as { response?: { data?: { error?: string } } })?.response?.data?.error ??
         (e as Error)?.message ??
         "unknown";
-      message.error(`Pull failed to start: ${detail}`);
+      feedback.message.error(`Pull failed to start: ${detail}`);
     },
   });
 
@@ -954,7 +936,7 @@ export function DriveCard({
       return data as { unit?: string };
     },
     onSuccess: (d) => {
-      message.success(
+      feedback.message.success(
         `Import started: ${d?.unit ?? "(unit name unavailable)"}`,
       );
       setImportOpen(false);
@@ -963,7 +945,7 @@ export function DriveCard({
       refresh();
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         `Import failed to start: ${(e as Error)?.message ?? "unknown"}`,
       );
     },
@@ -1011,7 +993,7 @@ export function DriveCard({
       return data as { path: string; size_bytes: number };
     },
     onSuccess: (d) => {
-      message.success(
+      feedback.message.success(
         `Tarball uploaded (${(d.size_bytes / (1024 * 1024)).toFixed(1)} MiB)`,
       );
       queryClient.invalidateQueries({
@@ -1019,7 +1001,7 @@ export function DriveCard({
       });
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         `Tarball upload failed: ${(e as Error)?.message ?? "unknown"}`,
       );
     },

--- a/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
+++ b/panel-ui/src/shells/admin/migrations/AdminMigrationsPage.tsx
@@ -13,22 +13,8 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
-import {
-  Grid,
-  Alert,
-  Button,
-  Card,
-  Empty,
-  List,
-  Popconfirm,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Grid, Alert, Button, Card, Empty, List, Popconfirm, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
@@ -140,7 +126,7 @@ export const AdminMigrationsPage = () => {
       });
     },
     onSuccess: async (_d, vars) => {
-      message.success(
+      feedback.message.success(
         vars.enabled
           ? "Private-host SSRF override ENABLED (restart panel + agent to pick up)"
           : "Private-host SSRF override disabled",
@@ -151,7 +137,7 @@ export const AdminMigrationsPage = () => {
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Update failed");
+      feedback.message.error(detail ?? "Update failed");
     },
   });
 
@@ -160,14 +146,14 @@ export const AdminMigrationsPage = () => {
       await apiClient.delete(`/admin/migrations/batches/${batchId}`);
     },
     onSuccess: async () => {
-      message.success("Batch cancelled");
+      feedback.message.success("Batch cancelled");
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
     },
     onError: (err) => {
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Batch cancel failed");
+      feedback.message.error(detail ?? "Batch cancel failed");
     },
   });
 
@@ -176,14 +162,14 @@ export const AdminMigrationsPage = () => {
       await apiClient.delete(`/admin/migrations/${id}`);
     },
     onSuccess: async () => {
-      message.success("Cancelled");
+      feedback.message.success("Cancelled");
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
     },
     onError: (err) => {
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Cancel failed");
+      feedback.message.error(detail ?? "Cancel failed");
     },
   });
 
@@ -192,14 +178,14 @@ export const AdminMigrationsPage = () => {
       await apiClient.post(`/admin/migrations/${id}/pull-source`);
     },
     onSuccess: async () => {
-      message.success("Pull-source re-dispatched");
+      feedback.message.success("Pull-source re-dispatched");
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
     },
     onError: (err) => {
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Re-kick failed");
+      feedback.message.error(detail ?? "Re-kick failed");
     },
   });
 
@@ -208,14 +194,14 @@ export const AdminMigrationsPage = () => {
       await apiClient.post(`/admin/migrations/${id}/destroy`);
     },
     onSuccess: async () => {
-      message.success("Destroyed");
+      feedback.message.success("Destroyed");
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
     },
     onError: (err) => {
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Destroy failed");
+      feedback.message.error(detail ?? "Destroy failed");
     },
   });
 

--- a/panel-ui/src/shells/admin/migrations/BulkWhmDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/BulkWhmDrawer.tsx
@@ -8,16 +8,8 @@
 // that returns the cPanel account list from a live WHM API session.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Alert,
-  Button,
-  Drawer,
-  Form,
-  Input,
-  Space,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Drawer, Form, Input, Space, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
@@ -57,13 +49,13 @@ export const BulkWhmDrawer = ({ open, onClose, onCreated }: Props) => {
     },
     onSuccess: (data) => {
       setResult(data);
-      message.success(`Batch ${data.batch_id} — ${data.jobs.length} jobs queued`);
+      feedback.message.success(`Batch ${data.batch_id} — ${data.jobs.length} jobs queued`);
       onCreated?.(data.batch_id);
     },
     onError: (e: unknown) => {
       const detail = (e as { response?: { data?: { detail?: string } } })?.response
         ?.data?.detail;
-      message.error(detail ?? "Bulk create failed");
+      feedback.message.error(detail ?? "Bulk create failed");
     },
   });
 

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationDrawer.tsx
@@ -3,22 +3,8 @@
 // Step 2+: source-specific drive steps (upload / pull / import) — no CLI needed.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Drawer,
-  Form,
-  Input,
-  InputNumber,
-  Card,
-  Space,
-  Steps,
-  Tabs,
-  Typography,
-  Upload,
-  message,
-} from "antd";
+import { Alert, Button, Checkbox, Drawer, Form, Input, InputNumber, Card, Space, Steps, Tabs, Typography, Upload } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { FormInstance } from "antd";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -119,13 +105,13 @@ function SecretsStep({ jobId, kind, onDone }: { jobId: string; kind?: string; on
       await apiClient.post(`/admin/migrations/${jobId}/secrets`, vals);
     },
     onSuccess: () => {
-      message.success("Credentials saved");
+      feedback.message.success("Credentials saved");
       onDone();
     },
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { detail?: string } } })
         ?.response?.data?.detail;
-      message.error(detail ?? "Failed to save credentials");
+      feedback.message.error(detail ?? "Failed to save credentials");
     },
   });
 
@@ -282,13 +268,13 @@ function PullStep({ jobId, onDone }: { jobId: string; onDone: () => void }) {
       await apiClient.post(`/admin/migrations/${jobId}/pull-source`, vals);
     },
     onSuccess: () => {
-      message.success("Pull started — running in the background");
+      feedback.message.success("Pull started — running in the background");
       onDone();
     },
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { detail?: string } } })
         ?.response?.data?.detail;
-      message.error(detail ?? "Failed to start pull");
+      feedback.message.error(detail ?? "Failed to start pull");
     },
   });
 
@@ -338,12 +324,12 @@ function TarballStep({ jobId, onDone }: { jobId: string; onDone: () => void }) {
       await apiClient.post(`/admin/migrations/${jobId}/tarball`, fd, {
         headers: { "Content-Type": "multipart/form-data" },
       });
-      message.success("Tarball uploaded successfully");
+      feedback.message.success("Tarball uploaded successfully");
       onDone();
     } catch (err: unknown) {
       const detail = (err as { response?: { data?: { detail?: string; error?: string } } })
         ?.response?.data?.detail;
-      message.error(detail ?? "Upload failed");
+      feedback.message.error(detail ?? "Upload failed");
     } finally {
       setUploading(false);
     }
@@ -398,13 +384,13 @@ function ImportStep({ jobId, onDone }: { jobId: string; onDone: () => void }) {
       await apiClient.post(`/admin/migrations/${jobId}/import`, vals);
     },
     onSuccess: () => {
-      message.success("Import started — running in the background");
+      feedback.message.success("Import started — running in the background");
       onDone();
     },
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { detail?: string } } })
         ?.response?.data?.detail;
-      message.error(detail ?? "Failed to start import");
+      feedback.message.error(detail ?? "Failed to start import");
     },
   });
 
@@ -477,12 +463,12 @@ function WordPressImportStep({ jobId, onDone }: { jobId: string; onDone: () => v
       await apiClient.post(`/admin/migrations/${jobId}/import-wp`, vals);
     },
     onSuccess: () => {
-      message.success("Import started");
+      feedback.message.success("Import started");
       onDone();
     },
     onError: (err: unknown) => {
       const detail = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
-      message.error(detail ?? "Import failed to start");
+      feedback.message.error(detail ?? "Import failed to start");
     },
   });
   return (
@@ -556,7 +542,7 @@ export const CreateMigrationDrawer = ({
       return data;
     },
     onSuccess: async (job) => {
-      message.success("Migration job created");
+      feedback.message.success("Migration job created");
       setCreated(job);
       setDriveStep(job.source_kind === "whm_pkgacct" ? "tarball" : "secrets");
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
@@ -565,7 +551,7 @@ export const CreateMigrationDrawer = ({
       const detail =
         (err as { response?: { data?: { error?: string; detail?: string } } })
           ?.response?.data?.detail;
-      message.error(detail ?? "Create failed");
+      feedback.message.error(detail ?? "Create failed");
     },
   });
 

--- a/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
+++ b/panel-ui/src/shells/admin/migrations/CreateMigrationWizard.tsx
@@ -20,7 +20,7 @@
 // migrating it into the wizard is M35.2 work.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Alert, Button, Checkbox, Tag, Collapse, Select, Drawer, Form, Input, InputNumber, Radio, Card, Space, Spin, Steps, Typography, message } from "antd";
+import { Alert, Button, Checkbox, Tag, Collapse, Select, Drawer, Form, Input, InputNumber, Radio, Card, Space, Spin, Steps, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQuery } from "@tanstack/react-query";
 
@@ -222,7 +222,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
       }
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
           "Draft create failed",
       );
@@ -283,7 +283,7 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
         });
         return;
       }
-      message.error(resp?.detail ?? "Connection step failed");
+      feedback.message.error(resp?.detail ?? "Connection step failed");
     },
   });
 
@@ -328,12 +328,12 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
       return data;
     },
     onSuccess: (d) => {
-      message.success(`Batch ${d.batch_id.slice(-6)} queued`);
+      feedback.message.success(`Batch ${d.batch_id.slice(-6)} queued`);
       onCreated?.(d.batch_id);
       handleClose();
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
           "Bulk create failed",
       );
@@ -379,15 +379,15 @@ export const CreateMigrationWizard = ({ open, onClose, onCreated }: Props) => {
           ),
         });
       } else if (data?.pull_started) {
-        message.success("Migration submitted — runner pulling now.");
+        feedback.message.success("Migration submitted — runner pulling now.");
       } else {
-        message.success("Migration submitted.");
+        feedback.message.success("Migration submitted.");
       }
       onCreated?.(null);
       handleClose();
     },
     onError: (e: unknown) => {
-      message.error(
+      feedback.message.error(
         (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
           "Submit failed",
       );

--- a/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
+++ b/panel-ui/src/shells/admin/migrations/MigrateImapDrawer.tsx
@@ -10,21 +10,8 @@
 // IMAP carries its own remote login per mailbox and never uploads a
 // tarball. The app-password is sent per-request and never persisted.
 import { useState } from "react";
-import {
-  Alert,
-  Button,
-  Collapse,
-  Drawer,
-  Form,
-  Input,
-  InputNumber,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Collapse, Drawer, Form, Input, InputNumber, Space, Switch, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 
@@ -86,13 +73,13 @@ export function MigrateImapDrawer({ open, onClose }: Props) {
     },
     onSuccess: (f) => {
       setFolders(f);
-      message.success(`Found ${f.length} folder(s) on the remote account`);
+      feedback.message.success(`Found ${f.length} folder(s) on the remote account`);
     },
     onError: (err: AxiosError<{ error?: string }>) => {
       if (err.response?.status === 401) {
-        message.error("The remote server rejected the credentials — check the app-password.");
+        feedback.message.error("The remote server rejected the credentials — check the app-password.");
       } else {
-        message.error("Could not connect to the remote IMAP account.");
+        feedback.message.error("Could not connect to the remote IMAP account.");
       }
     },
   });
@@ -106,18 +93,18 @@ export function MigrateImapDrawer({ open, onClose }: Props) {
       return data;
     },
     onSuccess: async (d) => {
-      message.success(`Migration started (job ${d.job_id}). Track progress in the list below.`);
+      feedback.message.success(`Migration started (job ${d.job_id}). Track progress in the list below.`);
       await qc.invalidateQueries({ queryKey: ["admin-migrations"] });
       handleClose();
     },
     onError: (err: AxiosError<{ error?: string; existing_job_id?: string }>) => {
       const body = err.response?.data;
       if (err.response?.status === 409) {
-        message.error(`A migration is already running for this account (job ${body?.existing_job_id ?? "?"}).`);
+        feedback.message.error(`A migration is already running for this account (job ${body?.existing_job_id ?? "?"}).`);
       } else if (err.response?.status === 401) {
-        message.error("The remote server rejected the credentials — check the app-password.");
+        feedback.message.error("The remote server rejected the credentials — check the app-password.");
       } else {
-        message.error("Could not start the migration.");
+        feedback.message.error("Could not start the migration.");
       }
     },
   });

--- a/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
+++ b/panel-ui/src/shells/admin/notifications/AdminChannelDrawer.tsx
@@ -3,18 +3,8 @@
 // new channel type is a single-file diff.
 import { useEffect, useMemo } from "react";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
-import {
-  Alert,
-  Button,
-  Drawer,
-  Form,
-  Grid,
-  Input,
-  InputNumber,
-  Select,
-  Switch,
-  message,
-} from "antd";
+import { Alert, Button, Drawer, Form, Grid, Input, InputNumber, Select, Switch } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../../apiClient";
 import { useCreateMutation, useUpdateMutation } from "../../../hooks/useQueries";
@@ -92,15 +82,15 @@ export function AdminChannelDrawer({ open, onClose, existing }: AdminChannelDraw
     try {
       if (isEdit && existing) {
         await update.mutateAsync({ id: existing.id, input: values });
-        message.success(`Channel "${values.name}" updated`);
+        feedback.message.success(`Channel "${values.name}" updated`);
       } else {
         await create.mutateAsync(values);
-        message.success(`Channel "${values.name}" created`);
+        feedback.message.success(`Channel "${values.name}" created`);
       }
       onClose();
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Save failed";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -108,10 +98,10 @@ export function AdminChannelDrawer({ open, onClose, existing }: AdminChannelDraw
     if (!existing) return;
     try {
       await apiClient.post(`/${RESOURCE}/${existing.id}/test`);
-      message.success(`Test envelope fired for "${existing.name}"`);
+      feedback.message.success(`Test envelope fired for "${existing.name}"`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Test failed";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/notifications/DLQTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/DLQTab.tsx
@@ -6,17 +6,8 @@
 // the stream via XTRIM MAXLEN 0.
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Button,
-  Empty,
-  Popconfirm,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Button, Empty, Popconfirm, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 
 import { DeleteOutlined, ReloadOutlined, RedoOutlined } from "@icons";
@@ -72,12 +63,12 @@ export const DLQTab = () => {
     setBusyID(row.id);
     try {
       await apiClient.post(`/admin/notifications/dlq/${row.id}/replay`);
-      message.success("Re-queued for delivery");
+      feedback.message.success("Re-queued for delivery");
       qc.invalidateQueries({ queryKey: ["notifications", "dlq"] });
     } catch (err) {
       const apiMsg =
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
-      message.error(apiMsg ?? (err instanceof Error ? err.message : "Replay failed"));
+      feedback.message.error(apiMsg ?? (err instanceof Error ? err.message : "Replay failed"));
     } finally {
       setBusyID(null);
     }
@@ -87,10 +78,10 @@ export const DLQTab = () => {
     setBusyID(row.id);
     try {
       await apiClient.delete(`/admin/notifications/dlq/${row.id}`);
-      message.success("Entry dropped");
+      feedback.message.success("Entry dropped");
       qc.invalidateQueries({ queryKey: ["notifications", "dlq"] });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Drop failed");
+      feedback.message.error(err instanceof Error ? err.message : "Drop failed");
     } finally {
       setBusyID(null);
     }
@@ -99,10 +90,10 @@ export const DLQTab = () => {
   const clearAll = async () => {
     try {
       await apiClient.delete("/admin/notifications/dlq");
-      message.success("DLQ cleared");
+      feedback.message.success("DLQ cleared");
       qc.invalidateQueries({ queryKey: ["notifications", "dlq"] });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Clear failed");
+      feedback.message.error(err instanceof Error ? err.message : "Clear failed");
     }
   };
 
@@ -118,10 +109,10 @@ export const DLQTab = () => {
         data.skipped > 0
           ? `Replayed ${data.replayed}, skipped ${data.skipped} legacy entries`
           : `Replayed ${data.replayed} envelopes`;
-      message.success(msg);
+      feedback.message.success(msg);
       qc.invalidateQueries({ queryKey: ["notifications", "dlq"] });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Replay all failed");
+      feedback.message.error(err instanceof Error ? err.message : "Replay all failed");
     } finally {
       setReplayingAll(false);
     }

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -3,20 +3,8 @@
 // Form.useForm + useCreateMutation; layout matches the old Refine
 // version (grid of resource limits + feature quotas + two switches).
 import { useTranslation } from "react-i18next";
-import {
-  Button,
-  Card,
-  Col,
-  Divider,
-  Form,
-  Input,
-  InputNumber,
-  Row,
-  Select,
-  Switch,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Col, Divider, Form, Input, InputNumber, Row, Select, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined } from "@icons";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
@@ -116,12 +104,12 @@ export const PackageCreate = () => {
           : (values.allowed_backup_destination_kinds ?? ""),
       } as unknown as PackageCreateInput;
       await createMutation.mutateAsync(payload);
-      message.success("Package created");
+      feedback.message.success("Package created");
       navigate("/jabali-admin/packages");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to create package";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/packages/PackageEdit.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageEdit.tsx
@@ -4,21 +4,8 @@
 // and seed the Form once they arrive.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Button,
-  Card,
-  Col,
-  Divider,
-  Form,
-  Input,
-  InputNumber,
-  Row,
-  Select,
-  Spin,
-  Switch,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Col, Divider, Form, Input, InputNumber, Row, Select, Spin, Switch, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined } from "@icons";
 import { useNavigate, useParams } from "react-router";
 
@@ -144,12 +131,12 @@ export const PackageEdit = () => {
           : (values.allowed_backup_destination_kinds ?? ""),
       } as unknown as PackageEditInput;
       await updateMutation.mutateAsync({ id, input });
-      message.success("Package updated");
+      feedback.message.success("Package updated");
       navigate("/jabali-admin/packages");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to update package";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/php-pools/PHPPoolEdit.tsx
+++ b/panel-ui/src/shells/admin/php-pools/PHPPoolEdit.tsx
@@ -5,22 +5,8 @@
 // useListQuery + direct apiClient POST/DELETE calls.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Button,
-  Card,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Select,
-  Space,
-  Spin,
-  Table,
-  Tag,
-  Typography,
-  message,
-  theme,
-} from "antd";
+import { Button, Card, Form, Input, InputNumber, Modal, Select, Space, Spin, Table, Tag, Typography, theme } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useNavigate, useParams } from "react-router";
 
 import { DeleteOutlined } from "@icons";
@@ -99,12 +85,12 @@ export const PHPPoolEdit = () => {
     if (!id) return;
     try {
       await updateMutation.mutateAsync({ id, input: values });
-      message.success("Pool updated");
+      feedback.message.success("Pool updated");
       navigate("/jabali-admin/php-pools");
     } catch (err: unknown) {
       const msg =
         err instanceof Error ? err.message : "Failed to update pool";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -123,7 +109,7 @@ export const PHPPoolEdit = () => {
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Failed to add override";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -137,7 +123,7 @@ export const PHPPoolEdit = () => {
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Failed to delete override";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
@@ -9,33 +9,8 @@
 // these endpoints are not the standard {data,total,page,page_size}
 // list shape; they're agent passthroughs.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Col,
-  Descriptions,
-  Drawer,
-  Empty,
-  Form,
-  Grid,
-  Input,
-  InputNumber,
-  message,
-  Popconfirm,
-  Radio,
-  Segmented,
-  Row,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tabs,
-  Tag,
-  Tooltip,
-  Typography,
-  Flex,
-} from "antd";
+import { Alert, Button, Card, Col, Descriptions, Drawer, Empty, Form, Grid, Input, InputNumber, Popconfirm, Radio, Segmented, Row, Select, Space, Switch, Table, Tabs, Tag, Tooltip, Typography, Flex } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -141,20 +116,20 @@ export const AdminSecurityCrowdsec = () => {
   const submitAdd = async (values: AddDecisionFormValues) => {
     try {
       await addDecision.mutateAsync(values);
-      message.success(`Decision added: ${values.scope}=${values.value}`);
+      feedback.message.success(`Decision added: ${values.scope}=${values.value}`);
       setAddOpen(false);
       addForm.resetFields();
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to add decision");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to add decision");
     }
   };
 
   const onDeleteDecision = async (row: CrowdsecDecision) => {
     try {
       await deleteDecision.mutateAsync(row.id);
-      message.success(`Removed ban on ${row.ip}`);
+      feedback.message.success(`Removed ban on ${row.ip}`);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to remove decision");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to remove decision");
     }
   };
 
@@ -166,9 +141,9 @@ export const AdminSecurityCrowdsec = () => {
         reason: `Whitelisted from active decisions (${row.scenario})`.slice(0, 200),
       });
       await deleteDecision.mutateAsync(row.id);
-      message.success(`Whitelisted ${row.ip} and removed the ban`);
+      feedback.message.success(`Whitelisted ${row.ip} and removed the ban`);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to whitelist IP");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to whitelist IP");
     }
   };
 
@@ -518,9 +493,9 @@ const AppSecGeoblockCard = () => {
   const apply = async () => {
     try {
       await updateGeoblock.mutateAsync({ mode, countries });
-      message.success("AppSec geoblock updated and crowdsec reloaded");
+      feedback.message.success("AppSec geoblock updated and crowdsec reloaded");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to apply geoblock");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to apply geoblock");
     }
   };
 
@@ -717,20 +692,20 @@ const AllowlistsCard = () => {
   const onSubmit = async (values: AllowlistFormValues) => {
     try {
       await addEntry.mutateAsync(values);
-      message.success(`Allowlisted ${values.value}`);
+      feedback.message.success(`Allowlisted ${values.value}`);
       setAddOpen(false);
       form.resetFields();
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to allowlist");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to allowlist");
     }
   };
 
   const onRemove = async (row: CrowdsecAllowlistEntry) => {
     try {
       await removeEntry.mutateAsync(row.value);
-      message.success(`Removed ${row.value} from allowlist`);
+      feedback.message.success(`Removed ${row.value} from allowlist`);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to remove");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to remove");
     }
   };
 
@@ -1027,9 +1002,9 @@ const CaptchaRemediationCard = () => {
         secret_key: values.secret_key, // "" = keep existing
       });
       form.setFieldValue("secret_key", "");
-      message.success("Captcha settings saved");
+      feedback.message.success("Captcha settings saved");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Save failed");
+      feedback.message.error(e instanceof Error ? e.message : "Save failed");
     }
   };
 
@@ -1166,9 +1141,9 @@ const ProfilesCard = () => {
     try {
       await update.mutateAsync(overrides);
       setDraft({});
-      message.success("Profiles saved — crowdsec reloaded");
+      feedback.message.success("Profiles saved — crowdsec reloaded");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Save failed");
+      feedback.message.error(e instanceof Error ? e.message : "Save failed");
     }
   };
 
@@ -1362,9 +1337,9 @@ const RecommendedHubCard = ({
     setPending(`${item.type}:${item.name}`);
     try {
       await install.mutateAsync({ type: item.type, name: item.name });
-      message.success(`Installed ${item.name}`);
+      feedback.message.success(`Installed ${item.name}`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Install failed");
+      feedback.message.error(err instanceof Error ? err.message : "Install failed");
     } finally {
       setPending(null);
     }
@@ -1374,9 +1349,9 @@ const RecommendedHubCard = ({
     setPending(`${item.type}:${item.name}`);
     try {
       await remove.mutateAsync({ type: item.type, name: item.name });
-      message.success(`Removed ${item.name}`);
+      feedback.message.success(`Removed ${item.name}`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Remove failed");
+      feedback.message.error(err instanceof Error ? err.message : "Remove failed");
     } finally {
       setPending(null);
     }
@@ -2061,11 +2036,11 @@ const SensitivityCard = () => {
       await apiClient.patch("/admin/settings", { crowdsec_sensitivity: newLevel });
     },
     onSuccess: () => {
-      message.success("Sensitivity preset applied — CrowdSec reloaded");
+      feedback.message.success("Sensitivity preset applied — CrowdSec reloaded");
       qc.invalidateQueries({ queryKey: ["admin-settings"] });
     },
     onError: (e: unknown) => {
-      message.error(e instanceof Error ? e.message : "Failed to apply");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to apply");
     },
   });
 
@@ -2144,11 +2119,11 @@ const BouncerModeCard = () => {
       await apiClient.patch("/admin/settings", { crowdsec_bouncer_mode: newMode });
     },
     onSuccess: () => {
-      message.success("Bouncer mode applied — nginx reloaded");
+      feedback.message.success("Bouncer mode applied — nginx reloaded");
       qc.invalidateQueries({ queryKey: ["admin-settings"] });
     },
     onError: (e: unknown) => {
-      message.error(e instanceof Error ? e.message : "Failed to apply");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to apply");
     },
   });
 
@@ -2232,11 +2207,11 @@ const LoginAllowlistCard = () => {
       });
     },
     onSuccess: () => {
-      message.success("Login allowlist policy applied");
+      feedback.message.success("Login allowlist policy applied");
       qc.invalidateQueries({ queryKey: ["admin-settings"] });
     },
     onError: (e: unknown) => {
-      message.error(e instanceof Error ? e.message : "Failed to apply");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to apply");
     },
   });
 

--- a/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityEgress.tsx
@@ -4,23 +4,8 @@
 //
 // Backed by panel-api/internal/api/user_egress.go.
 import { useTranslation } from "react-i18next";
-import {
-  App,
-  Alert,
-  Button,
-  Card,
-  Drawer,
-  Form,
-  Input,
-  InputNumber,
-  Select,
-  Space,
-  Statistic,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Drawer, Form, Input, InputNumber, Select, Space, Statistic, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CheckOutlined, CloseOutlined } from "@icons";
 import { shortDateTime } from "../../../utils/datetime";
 import { RowActions } from "../../../components/RowActions";
@@ -208,7 +193,6 @@ const DropEventsDrawer = ({
     enabled: open,
   });
   const qc = useQueryClient();
-  const { message } = App.useApp();
   // GH #713 Phase 2: one-click "allow this destination" — fetch the policy,
   // append to allowed_extra (preserving state), PUT it back.
   const allow = useMutation({
@@ -229,10 +213,10 @@ const DropEventsDrawer = ({
       });
     },
     onSuccess: () => {
-      message.success("Destination allowed — the reconciler applies it shortly");
+      feedback.message.success("Destination allowed — the reconciler applies it shortly");
       void qc.invalidateQueries({ queryKey: ["admin/users", userID, "egress/drop-events"] });
     },
-    onError: (e) => message.error(String((e as Error).message)),
+    onError: (e) => feedback.message.error(String((e as Error).message)),
   });
   // GH #713 Phase 2: client-side filters (dest substring + protocol).
   const [destFilter, setDestFilter] = useState("");
@@ -367,10 +351,10 @@ const UserEgressDrawer = ({ open, userID, onClose }: UserEgressDrawerProps) => {
           protocol: e.protocol ?? "tcp",
         })),
       });
-      message.success("Egress policy updated");
+      feedback.message.success("Egress policy updated");
       onClose();
     } catch (e) {
-      message.error("Failed to update policy");
+      feedback.message.error("Failed to update policy");
     }
   };
 
@@ -486,7 +470,7 @@ const PendingRequestsTable = ({ rows }: { rows: EgressRequest[] }) => {
                 onClick: () =>
                   decide.mutate(
                     { id: r.id, decision: "approve" },
-                    { onSuccess: () => message.success("Request approved") },
+                    { onSuccess: () => feedback.message.success("Request approved") },
                   ),
                 confirm: { title: "Approve and add to user's allowlist?", okText: "Approve" },
               },
@@ -498,7 +482,7 @@ const PendingRequestsTable = ({ rows }: { rows: EgressRequest[] }) => {
                 onClick: () =>
                   decide.mutate(
                     { id: r.id, decision: "deny" },
-                    { onSuccess: () => message.info("Request denied") },
+                    { onSuccess: () => feedback.message.info("Request denied") },
                   ),
                 confirm: { title: "Deny request?", okText: "Deny" },
               },

--- a/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
@@ -4,28 +4,8 @@
 //
 // Sub-tabs: Overview / Quarantine / Events / ManualScan / YARA / Settings.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Col,
-  Descriptions,
-  Drawer,
-  Form,
-  InputNumber,
-  Popconfirm,
-  Radio,
-  Row,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tabs,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Col, Descriptions, Drawer, Form, InputNumber, Popconfirm, Radio, Row, Select, Space, Switch, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { SearchableTableStringQ } from "../../../components/SearchableTable";
@@ -158,8 +138,8 @@ function OverviewCard() {
           loading={updateSigs.isPending}
           onClick={() => {
             updateSigs.mutate(undefined, {
-              onSuccess: () => message.success("Signature update started"),
-              onError: () => message.error("Signature update failed"),
+              onSuccess: () => feedback.message.success("Signature update started"),
+              onError: () => feedback.message.error("Signature update failed"),
             });
           }}
         >
@@ -427,8 +407,8 @@ function QuarantineCard() {
                 danger: true,
                 onClick: () =>
                   del.mutate(row.id, {
-                    onSuccess: () => message.success("Deleted"),
-                    onError: () => message.error("Delete failed"),
+                    onSuccess: () => feedback.message.success("Deleted"),
+                    onError: () => feedback.message.error("Delete failed"),
                   }),
                 confirm: {
                   title: "Delete quarantined file permanently?",
@@ -483,10 +463,10 @@ function QuarantineCard() {
                   { id: restoreOpen.id, reason: restoreReason },
                   {
                     onSuccess: () => {
-                      message.success("Restored");
+                      feedback.message.success("Restored");
                       setRestoreOpen(null);
                     },
-                    onError: () => message.error("Restore failed"),
+                    onError: () => feedback.message.error("Restore failed"),
                   },
                 );
               }}
@@ -574,7 +554,7 @@ function ManualScanCard() {
   const submitPath = () => {
     const value = pathValue.trim();
     if (!value) {
-      message.warning("Provide a path");
+      feedback.message.warning("Provide a path");
       return;
     }
     start.mutate(
@@ -582,22 +562,22 @@ function ManualScanCard() {
       {
         onSuccess: (resp) => {
           setSessions((prev) => [...prev, { id: resp.session_id, label: value }]);
-          message.success("Scan started");
+          feedback.message.success("Scan started");
         },
-        onError: () => message.error("Failed to start scan"),
+        onError: () => feedback.message.error("Failed to start scan"),
       },
     );
   };
 
   const submitUsers = () => {
     if (selectedUsernames.length === 0) {
-      message.warning("Select at least one user");
+      feedback.message.warning("Select at least one user");
       return;
     }
     const toScan = selectedUsernames.filter((u) => !runningUsernames.has(u));
     const skipped = selectedUsernames.length - toScan.length;
     if (toScan.length === 0) {
-      message.warning("All selected users already have a scan running");
+      feedback.message.warning("All selected users already have a scan running");
       return;
     }
     toScan.forEach((username) => {
@@ -607,11 +587,11 @@ function ManualScanCard() {
           onSuccess: (resp) => {
             setSessions((prev) => [...prev, { id: resp.session_id, label: `user: ${username}` }]);
           },
-          onError: () => message.error(`Failed to start scan for ${username}`),
+          onError: () => feedback.message.error(`Failed to start scan for ${username}`),
         },
       );
     });
-    message.success(
+    feedback.message.success(
       skipped > 0
         ? `Started ${toScan.length} scan(s) — ${skipped} skipped (already running)`
         : `Started ${toScan.length} scan(s)`,
@@ -948,8 +928,8 @@ function SettingsCard() {
         initialValues={data}
         onFinish={(values) => {
           update.mutate({ ...data, ...values }, {
-            onSuccess: () => message.success("Settings saved"),
-            onError: () => message.error("Save failed"),
+            onSuccess: () => feedback.message.success("Settings saved"),
+            onError: () => feedback.message.error("Save failed"),
           });
         }}
       >
@@ -1075,8 +1055,8 @@ function BuiltinYARACard() {
           loading={updateSigs.isPending}
           onClick={() =>
             updateSigs.mutate(undefined, {
-              onSuccess: () => message.success("Signature update started"),
-              onError: () => message.error("Signature update failed"),
+              onSuccess: () => feedback.message.success("Signature update started"),
+              onError: () => feedback.message.error("Signature update failed"),
             })
           }
         >
@@ -1191,7 +1171,7 @@ function YARACard() {
                   onChange={(checked) =>
                     toggle.mutate(
                       { filename: row.filename, enabled: checked },
-                      { onError: () => message.error("Toggle failed") },
+                      { onError: () => feedback.message.error("Toggle failed") },
                     )
                   }
                 />
@@ -1210,8 +1190,8 @@ function YARACard() {
                   title={`Delete ${row.filename}?`}
                   onConfirm={() =>
                     del.mutate(row.filename, {
-                      onSuccess: () => message.success("Deleted"),
-                      onError: () => message.error("Delete failed"),
+                      onSuccess: () => feedback.message.success("Deleted"),
+                      onError: () => feedback.message.error("Delete failed"),
                     })
                   }
                 >
@@ -1242,13 +1222,13 @@ function YARACard() {
                   { filename, content },
                   {
                     onSuccess: () => {
-                      message.success("Uploaded + parse-validated");
+                      feedback.message.success("Uploaded + parse-validated");
                       reset();
                     },
                     onError: (err: unknown) => {
                       const detail =
                         err instanceof Error ? err.message : "Upload failed";
-                      message.error(detail);
+                      feedback.message.error(detail);
                     },
                   },
                 )

--- a/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecuritySnuffleupagus.tsx
@@ -4,7 +4,7 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Alert, Descriptions, Drawer, Button, Card, Input, Modal, Popconfirm, Radio, Space, Switch, Table, Tag, Tooltip, Typography, message } from "antd";
+import { Alert, Descriptions, Drawer, Button, Card, Input, Modal, Popconfirm, Radio, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import {
@@ -116,14 +116,14 @@ export function AdminSecuritySnuffleupagus() {
                   okType: "danger",
                   onOk: () =>
                     setMode.mutateAsync(next).then(() => {
-                      void message.success("Mode set to enforce");
+                      void feedback.message.success("Mode set to enforce");
                       void qc.invalidateQueries({ queryKey: ["security", "snuffleupagus"] });
                     }),
                 });
                 return;
               }
               setMode.mutateAsync(next).then(() => {
-                void message.success(`Mode set to ${next}`);
+                void feedback.message.success(`Mode set to ${next}`);
                 void qc.invalidateQueries({ queryKey: ["security", "snuffleupagus"] });
               });
             }}
@@ -251,7 +251,7 @@ export function AdminSecuritySnuffleupagus() {
                       toggleRule
                         .mutateAsync({ name: row.name, enabled: true })
                         .then(() => {
-                          void message.success("Rule enabled");
+                          void feedback.message.success("Rule enabled");
                           void qc.invalidateQueries({ queryKey: ["security", "snuffleupagus"] });
                         })
                     }
@@ -339,7 +339,7 @@ export function AdminSecuritySnuffleupagus() {
           void toggleRule
             .mutateAsync({ name: disabling.name, enabled: false, reason: disabling.reason.trim() })
             .then(() => {
-              void message.success("Rule disabled");
+              void feedback.message.success("Rule disabled");
               void qc.invalidateQueries({ queryKey: ["security", "snuffleupagus"] });
               setDisabling(null);
             });

--- a/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityUfw.tsx
@@ -7,7 +7,7 @@
 // enable/disable typed-YES gate — that's a destructive confirmation,
 // not a create form, so it's the right antd primitive.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Card, Drawer, Empty, Form, Grid, Input, message, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
+import { Alert, Button, Card, Drawer, Empty, Form, Grid, Input, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useState } from "react";
 
@@ -75,20 +75,20 @@ export const AdminSecurityUfw = () => {
         // M43 Step 6: `from` is intentionally not sent. UFW UI is
         // port-policy-only. IP decisions go through CrowdSec.
       });
-      message.success("Rule added");
+      feedback.message.success("Rule added");
       addForm.resetFields();
       setAddOpen(false);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to add rule");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to add rule");
     }
   };
 
   const onDelete = async (rule: UfwRule) => {
     try {
       await deleteRule.mutateAsync(rule.num);
-      message.success(`Removed rule #${rule.num}`);
+      feedback.message.success(`Removed rule #${rule.num}`);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "Failed to delete rule");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to delete rule");
     }
   };
 
@@ -127,14 +127,14 @@ export const AdminSecurityUfw = () => {
       okButtonProps: { danger: !enable },
       onOk: async () => {
         if (typed !== "YES") {
-          message.warning('Type "YES" exactly to confirm');
+          feedback.message.warning('Type "YES" exactly to confirm');
           return Promise.reject(new Error("not confirmed"));
         }
         try {
           await toggle.mutateAsync({ enable });
-          message.success(enable ? "Firewall enabled" : "Firewall disabled");
+          feedback.message.success(enable ? "Firewall enabled" : "Firewall disabled");
         } catch (e: unknown) {
-          message.error(e instanceof Error ? e.message : "Toggle failed");
+          feedback.message.error(e instanceof Error ? e.message : "Toggle failed");
           throw e;
         }
       },

--- a/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/ServicesSummaryCard.tsx
@@ -6,13 +6,8 @@
 // those requests are 403'd at the API anyway. Destructive verbs
 // (stop/disable/restart) show a confirm Modal first.
 import { useState } from "react";
-import {
-  Card,
-  Modal,
-  Table,
-  Tag,
-  message,
-} from "antd";
+import { Card, Modal, Table, Tag } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -80,10 +75,10 @@ export function ServicesSummaryCard({ services }: Props) {
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["admin", "server-status"] });
-      message.success("Done");
+      feedback.message.success("Done");
     },
     onError: (e: unknown) => {
-      message.error(e instanceof Error ? e.message : "Service action failed");
+      feedback.message.error(e instanceof Error ? e.message : "Service action failed");
     },
   });
 

--- a/panel-ui/src/shells/admin/settings/AccountSkeletonCard.tsx
+++ b/panel-ui/src/shells/admin/settings/AccountSkeletonCard.tsx
@@ -4,19 +4,8 @@
 // (stored base64) at an operator-chosen relative path.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Button,
-  Card,
-  Input,
-  List,
-  Modal,
-  Popconfirm,
-  Progress,
-  Space,
-  Typography,
-  Upload,
-  message,
-} from "antd";
+import { Button, Card, Input, List, Modal, Popconfirm, Progress, Space, Typography, Upload } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { UploadFile } from "antd";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -74,7 +63,7 @@ export const AccountSkeletonCard = () => {
       await apiClient.put("/admin/settings/account-skeleton/file", { rel_path: path, content_base64 });
     },
     onSuccess: () => {
-      message.success("File added to the skeleton");
+      feedback.message.success("File added to the skeleton");
       setAdding(false);
       setRelPath("");
       setPending(null);
@@ -82,7 +71,7 @@ export const AccountSkeletonCard = () => {
     },
     onError: (e: unknown) => {
       const detail = (e as { response?: { data?: { detail?: string; error?: string } } })?.response?.data;
-      message.error(detail?.detail ?? detail?.error ?? "Upload failed");
+      feedback.message.error(detail?.detail ?? detail?.error ?? "Upload failed");
     },
   });
 
@@ -90,10 +79,10 @@ export const AccountSkeletonCard = () => {
     mutationFn: async (p: string) =>
       apiClient.delete(`/admin/settings/account-skeleton/file`, { params: { path: p } }),
     onSuccess: () => {
-      message.success("Removed");
+      feedback.message.success("Removed");
       qc.invalidateQueries({ queryKey: LIST_KEY });
     },
-    onError: () => message.error("Delete failed"),
+    onError: () => feedback.message.error("Delete failed"),
   });
 
   const data = list.data;

--- a/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
@@ -1,15 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Space,
-  Table,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Space, Table, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { SaveOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -67,7 +59,7 @@ export function DNSPermissionsCard() {
         if (!cancelled) setPolicy(normalize(resp.data.dns_user_record_policy));
       } catch {
         if (!cancelled) {
-          notification.error({ message: "Failed to load DNS permissions" });
+          feedback.notification.error({ message: "Failed to load DNS permissions" });
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -89,9 +81,9 @@ export function DNSPermissionsCard() {
         dns_user_record_policy: policy,
       });
       setPolicy(normalize(resp.data.dns_user_record_policy));
-      notification.success({ message: "DNS permissions saved" });
+      feedback.notification.success({ message: "DNS permissions saved" });
     } catch {
-      notification.error({ message: "Failed to save DNS permissions" });
+      feedback.notification.error({ message: "Failed to save DNS permissions" });
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
@@ -1,18 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Col,
-  Form,
-  Input,
-  Row,
-  Space,
-  Tag,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Button, Card, Col, Form, Input, Row, Space, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { SaveOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
@@ -176,7 +165,7 @@ export const DNSResolversCard = () => {
   const [current, setCurrent] = useState<string[]>([]);
   const activePreset = matchingProviderKey(current);
   const notify: NotifyFn = (input) =>
-    notification.open({
+    feedback.notification.open({
       message: input.message,
       description: input.description,
       type: input.type,

--- a/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
+++ b/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
@@ -12,23 +12,8 @@ import {
   SettingOutlined,
   ToolOutlined,
 } from "@icons";
-import {
-  Button,
-  Card,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Popconfirm,
-  Segmented,
-  Select,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Form, Input, InputNumber, Modal, Popconfirm, Segmented, Select, Skeleton, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -62,7 +47,7 @@ function RootPasswordSection() {
       );
       setRevealed({ engine, password: res.data.password });
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Could not rotate ${ENGINE_LABEL[engine]} password: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -173,7 +158,7 @@ function ConfigTunerSection() {
         Object.fromEntries(res.data.data.map((p) => [p.name, p.value])),
       );
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Could not load ${e} config: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -200,10 +185,10 @@ function ConfigTunerSection() {
     setSaving(true);
     try {
       await apiClient.put("/admin/databases/config", { engine, settings });
-      message.success(`${engine} configuration applied.`);
+      feedback.message.success(`${engine} configuration applied.`);
       void load(engine);
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Apply failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
@@ -334,7 +319,7 @@ function AdminDbConsoleSection() {
       const res = await apiClient.post<{ redirect_url: string }>(path, {});
       window.open(res.data.redirect_url, "_blank", "noopener,noreferrer");
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Could not open ${label}: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -428,11 +413,11 @@ function MaintenanceSection() {
         { engine, scope: "all" },
       );
       void poll(res.data.job_id);
-      message.success("Maintenance started.");
+      feedback.message.success("Maintenance started.");
     } catch (err) {
       const status = (err as { response?: { status?: number } })?.response
         ?.status;
-      message.error(
+      feedback.message.error(
         status === 409
           ? "A maintenance job is already running for this engine."
           : `Could not start maintenance: ${
@@ -549,10 +534,10 @@ function ProcessesSection() {
   const kill = async (id: string) => {
     try {
       await apiClient.post("/admin/databases/processes/kill", { engine, id });
-      message.success(`Signalled ${id}.`);
+      feedback.message.success(`Signalled ${id}.`);
       void refresh(engine);
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Kill failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }

--- a/panel-ui/src/shells/admin/settings/DatabasesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DatabasesCard.tsx
@@ -20,7 +20,7 @@ import {
   ExclamationCircleOutlined,
   ReloadOutlined,
 } from "@ant-design/icons";
-import { Alert, Button, Card, Skeleton, Space, Switch, Tag, Typography, message } from "antd";
+import { Alert, Button, Card, Skeleton, Space, Switch, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 
@@ -55,7 +55,7 @@ export function DatabasesCard() {
       );
       setStatus(st.data);
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Could not load PostgreSQL status: ${
           err instanceof Error ? err.message : String(err)
         }`,
@@ -93,9 +93,9 @@ export function DatabasesCard() {
           // keep polling — install may still be running
         }
       }
-      message.success("PostgreSQL installed.");
+      feedback.message.success("PostgreSQL installed.");
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Install failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
@@ -116,13 +116,13 @@ export function DatabasesCard() {
       await persistFlag(next);
       await new Promise((r) => setTimeout(r, 2500));
       await refresh();
-      message.success(
+      feedback.message.success(
         next
           ? "PostgreSQL enabled."
           : "PostgreSQL disabled (data preserved).",
       );
     } catch (err) {
-      message.error(
+      feedback.message.error(
         `Toggle failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
@@ -146,10 +146,10 @@ export function DatabasesCard() {
         try {
           await apiClient.post("/admin/databases/postgres/uninstall", {});
           await persistFlag(false);
-          message.success("PostgreSQL uninstalled and data removed.");
+          feedback.message.success("PostgreSQL uninstalled and data removed.");
           await refresh();
         } catch (err) {
-          message.error(
+          feedback.message.error(
             `Uninstall failed: ${
               err instanceof Error ? err.message : String(err)
             }`,

--- a/panel-ui/src/shells/admin/settings/LookAndFeelCard.tsx
+++ b/panel-ui/src/shells/admin/settings/LookAndFeelCard.tsx
@@ -4,20 +4,8 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
-import {
-  Button,
-  Card,
-  Col,
-  ColorPicker,
-  Form,
-  Row,
-  Segmented,
-  Space,
-  Tooltip,
-  Typography,
-  Divider,
-  message,
-} from "antd";
+import { Button, Card, Col, ColorPicker, Form, Row, Segmented, Space, Tooltip, Typography, Divider } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 
 import { QuestionCircleOutlined, SaveOutlined } from "@icons";
@@ -77,7 +65,7 @@ export const LookAndFeelCard = () => {
         for (const f of COLOR_FIELDS) values[f] = resp.data[f] ?? "";
         form.setFieldsValue(values as Partial<FormShape>);
       } catch (err) {
-        message.error(err instanceof Error ? err.message : "Load failed");
+        feedback.message.error(err instanceof Error ? err.message : "Load failed");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -96,9 +84,9 @@ export const LookAndFeelCard = () => {
       for (const f of COLOR_FIELDS) payload[f] = toHex(values[f]);
       await apiClient.patch("/admin/settings", payload);
       qc.invalidateQueries({ queryKey: ["branding", "public"] });
-      message.success("Look and feel saved");
+      feedback.message.success("Look and feel saved");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PageTemplatesCard.tsx
@@ -3,20 +3,8 @@
 // edit in a Modal with a textarea.
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Button,
-  Card,
-  Input,
-  List,
-  Modal,
-  Popconfirm,
-  Space,
-  Switch,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Input, List, Modal, Popconfirm, Space, Switch, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { EditOutlined, ReloadOutlined } from "@icons";
@@ -83,13 +71,13 @@ export const PageTemplatesCard = () => {
         unconfigured_page_enabled: checked,
       });
       qc.invalidateQueries({ queryKey: SETTINGS_KEY });
-      message.success(
+      feedback.message.success(
         checked
           ? "Unconfigured-domain page enabled — unknown hosts now get the branded page"
           : "Unconfigured-domain page disabled — unknown hosts are dropped without a response",
       );
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Toggle failed");
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
     } finally {
       setTogglingUnconfigured(false);
     }
@@ -104,13 +92,13 @@ export const PageTemplatesCard = () => {
         intercept_app_errors_default: checked,
       });
       qc.invalidateQueries({ queryKey: SETTINGS_KEY });
-      message.success(
+      feedback.message.success(
         checked
           ? "Branded page enabled for application errors on all domains (applies within a few minutes; domains can override under Domain → Options)"
           : "Application errors pass through again — apps serve their own 500s",
       );
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Toggle failed");
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
     } finally {
       setTogglingIntercept(false);
     }
@@ -129,7 +117,7 @@ export const PageTemplatesCard = () => {
   const save = async () => {
     if (!editing) return;
     if (new TextEncoder().encode(draft).length > MAX_BYTES) {
-      message.error(`Content exceeds ${Math.round(MAX_BYTES / 1024)} KB`);
+      feedback.message.error(`Content exceeds ${Math.round(MAX_BYTES / 1024)} KB`);
       return;
     }
     setSaving(true);
@@ -138,10 +126,10 @@ export const PageTemplatesCard = () => {
         content: draft,
       });
       qc.invalidateQueries({ queryKey: LIST_KEY });
-      message.success(`${editing.label} saved`);
+      feedback.message.success(`${editing.label} saved`);
       close();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     } finally {
       setSaving(false);
     }
@@ -151,9 +139,9 @@ export const PageTemplatesCard = () => {
     try {
       await apiClient.post(`/admin/settings/page-templates/${row.key}/reset`);
       qc.invalidateQueries({ queryKey: LIST_KEY });
-      message.success(`${row.label} reset to default`);
+      feedback.message.success(`${row.label} reset to default`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Reset failed");
+      feedback.message.error(err instanceof Error ? err.message : "Reset failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
@@ -11,17 +11,8 @@ import {
   ReloadOutlined,
   SafetyOutlined,
 } from "@icons";
-import {
-  Alert,
-  Button,
-  Card,
-  Popconfirm,
-  Space,
-  Switch,
-  Tag,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Button, Card, Popconfirm, Space, Switch, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   type PanelCertKind,
   type PanelCertificate,
@@ -157,9 +148,9 @@ export function PanelSSLCard() {
 
   const doIssue = (kind: PanelCertKind) =>
     issue.mutate(kind, {
-      onSuccess: () => notification.success({ message: `${kind} cert: issued` }),
+      onSuccess: () => feedback.notification.success({ message: `${kind} cert: issued` }),
       onError: (e) =>
-        notification.error({
+        feedback.notification.error({
           message: `${kind} cert: issue failed`,
           description: String((e as Error).message),
         }),
@@ -215,13 +206,13 @@ export function PanelSSLCard() {
                 { use_le: v },
                 {
                   onSuccess: () =>
-                    notification.success({
+                    feedback.notification.success({
                       message: v
                         ? "Let's Encrypt enabled — issuance runs on the next reconciler tick"
                         : "Let's Encrypt disabled — existing certs stay until expiry",
                     }),
                   onError: (e) =>
-                    notification.error({
+                    feedback.notification.error({
                       message: "Failed to update toggle",
                       description: String((e as Error).message),
                     }),

--- a/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
+++ b/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
@@ -8,17 +8,8 @@
 // client (mailto:) with a pre-filled subject + body containing the link
 // + password — the team gets it via inbox.
 import { useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Input,
-  Modal,
-  Space,
-  Spin,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Input, Modal, Space, Spin, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { CopyOutlined, ExportOutlined, MailOutlined } from "@icons";
 
@@ -48,9 +39,9 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
   const copy = async (label: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      message.success(`${label} copied`);
+      feedback.message.success(`${label} copied`);
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "copy failed");
+      feedback.message.error(e instanceof Error ? e.message : "copy failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -6,27 +6,8 @@
 // so the page shows real numbers immediately instead of empty placeholders.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState, type CSSProperties } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Collapse,
-  Col,
-  Empty,
-  Row,
-  Segmented,
-  Space,
-  Spin,
-  Switch,
-  Table,
-  Tag,
-  TimePicker,
-  Timeline,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Collapse, Col, Empty, Row, Segmented, Space, Spin, Switch, Table, Tag, TimePicker, Timeline, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import dayjs from "dayjs";
 
 import {
@@ -64,10 +45,10 @@ const ReleaseChannelCard = () => {
     setSaving(true);
     try {
       await apiClient.patch("/admin/settings", { release_channel: next });
-      message.success(`Release channel set to ${next}`);
+      feedback.message.success(`Release channel set to ${next}`);
     } catch (e) {
       setChannel(prev);
-      message.error(e instanceof Error ? e.message : "Failed to set release channel");
+      feedback.message.error(e instanceof Error ? e.message : "Failed to set release channel");
     } finally {
       setSaving(false);
     }
@@ -172,9 +153,9 @@ export const SystemUpdatesPage = () => {
     try {
       await Promise.all([jabali.mutateAsync(), apt.mutateAsync()]);
       await state.refetch();
-      message.success("Checked for updates");
+      feedback.message.success("Checked for updates");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "check failed");
+      feedback.message.error(e instanceof Error ? e.message : "check failed");
     }
   };
 
@@ -390,17 +371,17 @@ function JabaliPanelCard({ check }: { check: ReturnType<typeof useJabaliCheck> }
     try {
       const r = await run.mutateAsync();
       setSince(r.started_at);
-      message.success("Update started");
+      feedback.message.success("Update started");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "run failed");
+      feedback.message.error(e instanceof Error ? e.message : "run failed");
     }
   };
   const onStop = async () => {
     try {
       await stop.mutateAsync();
-      message.success("Stop signal sent");
+      feedback.message.success("Stop signal sent");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "stop failed");
+      feedback.message.error(e instanceof Error ? e.message : "stop failed");
     }
   };
 
@@ -725,17 +706,17 @@ function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }
     try {
       const r = await run.mutateAsync();
       setSince(r.started_at);
-      message.success("Apt upgrade started");
+      feedback.message.success("Apt upgrade started");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "run failed");
+      feedback.message.error(e instanceof Error ? e.message : "run failed");
     }
   };
   const onStop = async () => {
     try {
       await stop.mutateAsync();
-      message.success("Stop signal sent");
+      feedback.message.success("Stop signal sent");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "stop failed");
+      feedback.message.error(e instanceof Error ? e.message : "stop failed");
     }
   };
 
@@ -899,9 +880,9 @@ function AutomaticUpdatesCard() {
     try {
       await save.mutateAsync(cfg);
       setDraft(null);
-      message.success("Automatic updates saved");
+      feedback.message.success("Automatic updates saved");
     } catch (e: unknown) {
-      message.error(e instanceof Error ? e.message : "save failed");
+      feedback.message.error(e instanceof Error ? e.message : "save failed");
     }
   };
 

--- a/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
+++ b/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
@@ -12,20 +12,8 @@
 // cgroup/quota state on its next tick (DB is the source of truth), so there is
 // no separate "apply" button here — a saved override takes effect shortly after.
 import { useState } from "react";
-import {
-  Button,
-  Card,
-  Drawer,
-  Form,
-  InputNumber,
-  Popconfirm,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-  message,
-} from "antd";
+import { Button, Card, Drawer, Form, InputNumber, Popconfirm, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { ColumnsType } from "antd/es/table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -109,10 +97,10 @@ export function UserLimitsCard({ userId }: { userId: string }) {
       await apiClient.delete(`/users/${userId}/limit-overrides`);
     },
     onSuccess: async () => {
-      message.success("Overrides cleared — reconciler will apply shortly");
+      feedback.message.success("Overrides cleared — reconciler will apply shortly");
       await qc.invalidateQueries({ queryKey: ["user-usage", userId] });
     },
-    onError: () => message.error("Failed to clear overrides"),
+    onError: () => feedback.message.error("Failed to clear overrides"),
   });
 
   const rows: Row[] = FIELDS.map((f) => {
@@ -254,14 +242,14 @@ function EditOverridesDrawer({
       await apiClient.put(`/users/${userId}/limit-overrides`, payload);
     },
     onSuccess: () => {
-      message.success("Overrides saved — reconciler will apply shortly");
+      feedback.message.success("Overrides saved — reconciler will apply shortly");
       onSaved();
       onClose();
     },
     onError: (err: unknown) => {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      message.error(detail ? `Validation failed: ${detail}` : "Failed to save overrides");
+      feedback.message.error(detail ? `Validation failed: ${detail}` : "Failed to save overrides");
     },
   });
 

--- a/panel-ui/src/shells/dns/DNSRecordsPage.tsx
+++ b/panel-ui/src/shells/dns/DNSRecordsPage.tsx
@@ -10,28 +10,8 @@ import {
   PlusOutlined,
 } from "@icons";
 import { RowActions } from "../../components/RowActions";
-import {
-  Button,
-  Drawer,
-  Flex,
-  Space,
-  Table,
-  Tag,
-  Typography,
-  Card,
-  Input,
-  Select,
-  InputNumber,
-  Collapse,
-  Switch,
-  Row,
-  Col,
-  Spin,
-  Empty,
-  notification,
-  Tooltip,
-  Grid,
-} from "antd";
+import { Button, Drawer, Flex, Space, Table, Tag, Typography, Card, Input, Select, InputNumber, Collapse, Switch, Row, Col, Spin, Empty, Tooltip, Grid } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { useLocation, useNavigate, useParams } from "react-router";
 
 // Post-M21 notify shim — matches the Refine useNotification().open
@@ -50,7 +30,7 @@ type NotifyInput = {
   description?: React.ReactNode;
 };
 const stableNotifyOpen = (input: NotifyInput) => {
-  notification.open({
+  feedback.notification.open({
     message: input.message,
     description: input.description,
     type: input.type,

--- a/panel-ui/src/shells/shared/APIDocsPage.tsx
+++ b/panel-ui/src/shells/shared/APIDocsPage.tsx
@@ -10,20 +10,8 @@
 // rendering the JSON ourselves.
 
 import { useEffect, useMemo, useState } from "react";
-import {
-  Alert,
-  Anchor,
-  Card,
-  Collapse,
-  Layout,
-  Space,
-  Spin,
-  Tag,
-  Tooltip,
-  Typography,
-  Grid,
-  notification,
-} from "antd";
+import { Alert, Anchor, Card, Collapse, Layout, Space, Spin, Tag, Tooltip, Typography, Grid } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { LinkOutlined, DownloadOutlined, LockOutlined } from "@ant-design/icons";
 import { apiClient } from "../../apiClient";
 import { MiniMarkdown } from "../../components/MiniMarkdown";
@@ -88,7 +76,7 @@ export function APIDocsPage(): JSX.Element {
         setSpec(resp.data);
       } catch (err) {
         const e = err as { message?: string };
-        notification.error({
+        feedback.notification.error({
           message: "Failed to load API documentation",
           description: e.message ?? "Unknown error",
         });

--- a/panel-ui/src/shells/user/BackupSchedulesCard.tsx
+++ b/panel-ui/src/shells/user/BackupSchedulesCard.tsx
@@ -6,22 +6,8 @@
 // choose a stampede minute. On a single-schedule plan this falls back to the
 // legacy MyProfileScheduleCard.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Drawer,
-  Form,
-  InputNumber,
-  Popconfirm,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Drawer, Form, InputNumber, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { ClockCircleOutlined, DeleteOutlined, EditOutlined, PlusOutlined } from "@icons";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -147,11 +133,11 @@ export const BackupSchedulesCard = () => {
       } else {
         await apiClient.post("/me/backup-schedules", body);
       }
-      message.success(editingId ? "Schedule updated" : "Schedule created");
+      feedback.message.success(editingId ? "Schedule updated" : "Schedule created");
       setDrawerOpen(false);
       listQuery.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Save failed"));
+      feedback.message.error(extractApiError(err, "Save failed"));
     } finally {
       setSaving(false);
     }
@@ -170,17 +156,17 @@ export const BackupSchedulesCard = () => {
       });
       listQuery.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Update failed"));
+      feedback.message.error(extractApiError(err, "Update failed"));
     }
   };
 
   const removeRow = async (id: string) => {
     try {
       await apiClient.delete(`/me/backup-schedules/${id}`);
-      message.success("Schedule removed");
+      feedback.message.success("Schedule removed");
       listQuery.refetch();
     } catch (err) {
-      message.error(extractApiError(err, "Delete failed"));
+      feedback.message.error(extractApiError(err, "Delete failed"));
     }
   };
 

--- a/panel-ui/src/shells/user/MyProfile.tsx
+++ b/panel-ui/src/shells/user/MyProfile.tsx
@@ -8,7 +8,7 @@
 // sees `?flow=<id>` it fetches the flow and renders the Kratos node
 // tree inline inside the Security card — no extra page, no extra tab.
 import { useTranslation } from "react-i18next";
-import { Alert, Button, Card, Checkbox, Descriptions, Form, Input, Space, Spin, Typography, message } from "antd";
+import { Alert, Button, Card, Checkbox, Descriptions, Form, Input, Space, Spin, Typography } from "antd";
 import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
@@ -135,12 +135,12 @@ export function MyProfile() {
       setFlow(result.flow);
       const successMsg = (result.flow.ui.messages ?? []).find((m) => m.type === "success");
       if (successMsg) {
-        message.success(successMsg.text);
+        feedback.message.success(successMsg.text);
       }
       return;
     }
     if (result.kind === "error") {
-      message.error(result.message);
+      feedback.message.error(result.message);
       return;
     }
   };
@@ -341,9 +341,9 @@ function PasskeySettingsCard({
       const fields = await passkeyEnrolFields(flow);
       if (!fields) return;
       await onSubmit(fields);
-      message.success("Passkey added");
+      feedback.message.success("Passkey added");
     } catch {
-      message.error("Passkey registration was cancelled or failed. Please try again.");
+      feedback.message.error("Passkey registration was cancelled or failed. Please try again.");
     } finally {
       setBusy(false);
     }
@@ -429,9 +429,9 @@ function WebauthnSettingsCard({
       if (!fields) return;
       await onSubmit(fields);
       setName("");
-      message.success("Security key added");
+      feedback.message.success("Security key added");
     } catch {
-      message.error("Security-key registration was cancelled or failed. Please try again.");
+      feedback.message.error("Security-key registration was cancelled or failed. Please try again.");
     } finally {
       setBusy(false);
     }

--- a/panel-ui/src/shells/user/RestoreDrawer.tsx
+++ b/panel-ui/src/shells/user/RestoreDrawer.tsx
@@ -9,16 +9,8 @@
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 
-import {
-  Alert,
-  Button,
-  Checkbox,
-  Drawer,
-  Space,
-  Spin,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Checkbox, Drawer, Space, Spin, Typography } from "antd";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 
 import { apiClient } from "../../apiClient";
 
@@ -85,7 +77,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
         setDnsDomains(resp.data.dns_domains ?? []);
       })
       .catch((err) =>
-        message.error(
+        feedback.message.error(
           err instanceof Error ? err.message : "Could not read backup contents",
         ),
       )
@@ -103,10 +95,10 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
       );
       setResult(resp.data);
       const n = resp.data.applied?.length ?? 0;
-      if (n > 0) message.success(`Restored ${n} item${n === 1 ? "" : "s"}`);
-      else message.warning("Nothing was restored — see details");
+      if (n > 0) feedback.message.success(`Restored ${n} item${n === 1 ? "" : "s"}`);
+      else feedback.message.warning("Nothing was restored — see details");
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Restore failed");
+      feedback.message.error(err instanceof Error ? err.message : "Restore failed");
     } finally {
       setSubmitting(false);
     }

--- a/panel-ui/src/shells/user/api-tokens/DDNSSetupGuide.tsx
+++ b/panel-ui/src/shells/user/api-tokens/DDNSSetupGuide.tsx
@@ -6,17 +6,8 @@
 // existing GET /nic/update shim (api/ddns.go).
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Input,
-  Space,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Input, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { KeyOutlined, ThunderboltOutlined } from "@icons";
 
 const { Paragraph, Text } = Typography;
@@ -76,7 +67,7 @@ export function DDNSSetupGuide(): JSX.Element {
 
   const runTest = async () => {
     if (!token.trim()) {
-      message.warning("Paste a DDNS-scoped token to test");
+      feedback.message.warning("Paste a DDNS-scoped token to test");
       return;
     }
     setTesting(true);

--- a/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
+++ b/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
@@ -12,25 +12,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Checkbox,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Popconfirm,
-  Radio,
-  Space,
-  Table,
-  Tabs,
-  Tag,
-  Tooltip,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Button, Card, Checkbox, Form, Input, InputNumber, Modal, Popconfirm, Radio, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { ColumnsType } from "antd/es/table";
 
 // GH #245 / ADR-0144: per-area permissions. Empty scopes = full access (the
@@ -134,7 +117,7 @@ export function UserAPITokensPage(): JSX.Element {
       setRows(resp.data.items ?? []);
     } catch (err) {
       const e = err as { message?: string };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to load API tokens",
         description: e.message ?? "Unknown error",
       });
@@ -173,7 +156,7 @@ export function UserAPITokensPage(): JSX.Element {
         if (ddnsSel) scopes.push("ddns");
         if (ddnsSel && ddnsRecordId.trim()) scopes.push(`record:${ddnsRecordId.trim()}`);
         if (scopes.length === 0) {
-          notification.error({
+          feedback.notification.error({
             message: "Select at least one permission",
             description: "Pick some permissions, or choose Full access.",
           });
@@ -190,7 +173,7 @@ export function UserAPITokensPage(): JSX.Element {
       // validateFields throws with a list of errors; nothing to toast.
       if ((err as { errorFields?: unknown }).errorFields) return;
       const e = err as { message?: string };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to create token",
         description: e.message ?? "Unknown error",
       });
@@ -200,11 +183,11 @@ export function UserAPITokensPage(): JSX.Element {
   const onRevoke = async (t: UserAPIToken) => {
     try {
       await apiClient.delete(`/me/api-tokens/${t.id}`);
-      notification.success({ message: `Token "${t.name}" revoked` });
+      feedback.notification.success({ message: `Token "${t.name}" revoked` });
       void load();
     } catch (err) {
       const e = err as { message?: string };
-      notification.error({
+      feedback.notification.error({
         message: "Failed to revoke token",
         description: e.message ?? "Unknown error",
       });
@@ -214,9 +197,9 @@ export function UserAPITokensPage(): JSX.Element {
   const copy = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      notification.success({ message: "Copied to clipboard" });
+      feedback.notification.success({ message: "Copied to clipboard" });
     } catch {
-      notification.error({
+      feedback.notification.error({
         message: "Copy failed",
         description: "Select the secret and copy manually.",
       });

--- a/panel-ui/src/shells/user/applications/CloneApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/CloneApplicationModal.tsx
@@ -6,14 +6,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Modal,
-  Form,
-  Select,
-  Button,
-  message,
-  Typography,
-} from "antd";
+import { Modal, Form, Select, Button, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
 
@@ -82,7 +76,7 @@ export const CloneApplicationModal = ({
       })
       .catch((err) => {
         if (!alive) return;
-        message.error(extractError(err, "Failed to load domains"));
+        feedback.message.error(extractError(err, "Failed to load domains"));
       })
       .finally(() => {
         if (alive) setLoadingDomains(false);
@@ -113,11 +107,11 @@ export const CloneApplicationModal = ({
       await apiClient.post(`/applications/${installId}/clone`, {
         dest_domain_id: vals.dest_domain_id,
       });
-      message.success("Cloning started…");
+      feedback.message.success("Cloning started…");
       refreshLists();
       handleClose();
     } catch (err) {
-      message.error(extractError(err as ApiError, "Failed to clone application"));
+      feedback.message.error(extractError(err as ApiError, "Failed to clone application"));
     } finally {
       setSubmitting(false);
     }

--- a/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
@@ -14,20 +14,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useState, useEffect, useMemo } from "react";
-import {
-  Drawer,
-  Form,
-  Grid,
-  Input,
-  Button,
-  Select,
-  Space,
-  Typography,
-  message,
-  Alert,
-  Tooltip,
-  Switch,
-} from "antd";
+import { Drawer, Form, Grid, Input, Button, Select, Space, Typography, Alert, Tooltip, Switch } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { AppstoreOutlined, CheckCircleTwoTone, CheckOutlined, CloseOutlined, CopyOutlined } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
@@ -387,7 +375,7 @@ export const InstallApplicationModal = ({
       })
       .catch((err) => {
         if (!alive) return;
-        message.error(extractError(err, "Failed to load domains"));
+        feedback.message.error(extractError(err, "Failed to load domains"));
       })
       .finally(() => {
         if (alive) setLoadingDomains(false);
@@ -513,7 +501,7 @@ export const InstallApplicationModal = ({
           },
         ]);
       } else {
-        message.error(extractError(err, "Failed to install application"));
+        feedback.message.error(extractError(err, "Failed to install application"));
       }
     } finally {
       setSubmitting(false);
@@ -523,9 +511,9 @@ export const InstallApplicationModal = ({
   const copy = async (label: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      message.success(`${label} copied`);
+      feedback.message.success(`${label} copied`);
     } catch {
-      message.error(`Could not copy ${label.toLowerCase()}`);
+      feedback.message.error(`Could not copy ${label.toLowerCase()}`);
     }
   };
 

--- a/panel-ui/src/shells/user/applications/MigrateRemoteDrawer.tsx
+++ b/panel-ui/src/shells/user/applications/MigrateRemoteDrawer.tsx
@@ -1,20 +1,6 @@
 import { useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Card,
-  Drawer,
-  Form,
-  Input,
-  Select,
-  Space,
-  Steps,
-  Spin,
-  Radio,
-  Tabs,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Drawer, Form, Input, Select, Space, Steps, Spin, Radio, Tabs, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CloudServerOutlined, ApiOutlined } from "@icons";
 import { apiClient } from "../../../apiClient";
 
@@ -89,7 +75,7 @@ export function MigrateRemoteDrawer({ open, onClose, onSuccess }: Props) {
       setDestDomain(v.dest_domain);
       setStep(2);
     } catch (e) {
-      message.error(errText(e) ?? "Create failed");
+      feedback.message.error(errText(e) ?? "Create failed");
     } finally {
       setBusy(false);
     }
@@ -103,7 +89,7 @@ export function MigrateRemoteDrawer({ open, onClose, onSuccess }: Props) {
       await apiClient.post(`/migrations/${jobId}/secrets`, v);
       setStep(3);
     } catch (e) {
-      message.error(errText(e) ?? "Failed to save credentials");
+      feedback.message.error(errText(e) ?? "Failed to save credentials");
     } finally {
       setBusy(false);
     }
@@ -149,9 +135,9 @@ export function MigrateRemoteDrawer({ open, onClose, onSuccess }: Props) {
         {},
       );
       setInstalls(data.installs ?? []);
-      if (!data.installs?.length) message.info("No WordPress installs found on the source.");
+      if (!data.installs?.length) feedback.message.info("No WordPress installs found on the source.");
     } catch (e) {
-      message.error(errText(e) ?? "Scan failed");
+      feedback.message.error(errText(e) ?? "Scan failed");
     } finally {
       setScanning(false);
     }
@@ -160,9 +146,9 @@ export function MigrateRemoteDrawer({ open, onClose, onSuccess }: Props) {
     if (!jobId) return;
     try {
       await apiClient.post(`/migrations/${jobId}/source-path`, { source_path: root });
-      message.success("Selected " + root);
+      feedback.message.success("Selected " + root);
     } catch (e) {
-      message.error(errText(e) ?? "Could not select");
+      feedback.message.error(errText(e) ?? "Could not select");
     }
   };
 
@@ -172,9 +158,9 @@ export function MigrateRemoteDrawer({ open, onClose, onSuccess }: Props) {
     try {
       await apiClient.post(`/migrations/${jobId}/pull-source`, { ssh_user: "root" });
       setStarted(true);
-      message.success("Migration started in the background.");
+      feedback.message.success("Migration started in the background.");
     } catch (e) {
-      message.error(errText(e) ?? "Failed to start the migration");
+      feedback.message.error(errText(e) ?? "Failed to start the migration");
     } finally {
       setBusy(false);
     }

--- a/panel-ui/src/shells/user/applications/UserApplicationList.tsx
+++ b/panel-ui/src/shells/user/applications/UserApplicationList.tsx
@@ -7,20 +7,8 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useTabParam } from "../../../hooks/useTabParam";
-import {
-  Button,
-  Tabs,
-  Col,
-  Empty,
-  Row,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-  Tooltip,
-} from "antd";
+import { Button, Tabs, Col, Empty, Row, Space, Switch, Table, Tag, Typography, Tooltip } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   AppstoreOutlined,
   PlusSquareOutlined,
@@ -125,9 +113,9 @@ const ActionsCell = ({
         "_blank",
         "noopener,noreferrer"
       );
-      message.success("Admin login link opened");
+      feedback.message.success("Admin login link opened");
     } catch {
-      message.error(magicLinkError || "Failed to generate admin login link");
+      feedback.message.error(magicLinkError || "Failed to generate admin login link");
     }
   };
 
@@ -137,14 +125,14 @@ const ActionsCell = ({
     setPurging(true);
     try {
       await apiClient.post(`/domains/${record.domain_id}/cache/purge`);
-      message.success("Page cache purged");
+      feedback.message.success("Page cache purged");
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ??
         (err as { message?: string })?.message ??
         "Purge failed";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setPurging(false);
     }
@@ -155,14 +143,14 @@ const ActionsCell = ({
     setWarming(true);
     try {
       await apiClient.post(`/applications/${record.id}/cache-warmup`);
-      message.success("Cache warmup started — crawling the site in the background");
+      feedback.message.success("Cache warmup started — crawling the site in the background");
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ??
         (err as { message?: string })?.message ??
         "Warmup failed";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setWarming(false);
     }
@@ -262,13 +250,13 @@ export const UserApplicationList = () => {
       }>("/applications/scan");
       const { scanned, added } = res.data;
       if (added > 0) {
-        message.success(
+        feedback.message.success(
           `Found ${scanned} app${scanned === 1 ? "" : "s"}, registered ${added} new.`,
         );
       } else if (scanned > 0) {
-        message.info(`Found ${scanned} app${scanned === 1 ? "" : "s"}, all already registered.`);
+        feedback.message.info(`Found ${scanned} app${scanned === 1 ? "" : "s"}, all already registered.`);
       } else {
-        message.info("No applications found on disk.");
+        feedback.message.info("No applications found on disk.");
       }
       qc.invalidateQueries({ queryKey: ["list", "applications"] });
       tableQuery.refetch();
@@ -280,7 +268,7 @@ export const UserApplicationList = () => {
           ?.error ??
         (err as { message?: string })?.message ??
         "Scan failed";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setScanning(false);
     }
@@ -306,7 +294,7 @@ export const UserApplicationList = () => {
     setDeletingId(row.id);
     try {
       await apiClient.delete(`/applications/${row.id}`);
-      message.success(`Deleting ${row.domain_name || row.domain_id}…`);
+      feedback.message.success(`Deleting ${row.domain_name || row.domain_id}…`);
       qc.invalidateQueries({ queryKey: ["list", "applications"] });
       qc.invalidateQueries({ queryKey: ["list", "databases"] });
     } catch (err) {
@@ -319,7 +307,7 @@ export const UserApplicationList = () => {
           ?.error ??
         (err as { message?: string })?.message ??
         "Delete failed";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setDeletingId(null);
     }
@@ -331,7 +319,7 @@ export const UserApplicationList = () => {
     setCachingId(row.id);
     try {
       await apiClient.put(`/applications/${row.id}/cache`, { enabled });
-      message.success(
+      feedback.message.success(
         enabled
           ? `Caching enabled for ${row.domain_name || row.domain_id}`
           : `Caching disabled for ${row.domain_name || row.domain_id}`,
@@ -343,7 +331,7 @@ export const UserApplicationList = () => {
           ?.error ??
         (err as { message?: string })?.message ??
         "Failed to toggle caching";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setCachingId(null);
     }

--- a/panel-ui/src/shells/user/cron/CronLogDrawer.tsx
+++ b/panel-ui/src/shells/user/cron/CronLogDrawer.tsx
@@ -1,14 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
-import {
-  Drawer,
-  Button,
-  Space,
-  Card,
-  Select,
-  Spin,
-  message,
-} from "antd";
+import { Drawer, Button, Space, Card, Select, Spin } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   CopyOutlined,
   ReloadOutlined,
@@ -42,7 +35,7 @@ export const CronLogDrawer = ({
 
   const handleCopyToClipboard = () => {
     navigator.clipboard.writeText(logResponse.log).then(() => {
-      message.success("Log copied to clipboard");
+      feedback.message.success("Log copied to clipboard");
     });
   };
 

--- a/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
+++ b/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
@@ -13,18 +13,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import {
-  Modal,
-  Form,
-  Input,
-  Button,
-  Segmented,
-  Space,
-  Typography,
-  message,
-  Alert,
-  Tooltip,
-} from "antd";
+import { Modal, Form, Input, Button, Segmented, Space, Typography, Alert, Tooltip } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { CopyOutlined, CheckCircleTwoTone } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
@@ -121,7 +111,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
         username = userResp.data.username;
         password = userResp.data.password;
       } catch (err) {
-        message.error(
+        feedback.message.error(
           `Database "${dbName}" was created, but user creation failed: ${extractError(err, "unknown")}. You can delete the database from the list.`,
         );
         refreshLists();
@@ -134,7 +124,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
           privileges: ["ALL"],
         });
       } catch (err) {
-        message.warning(
+        feedback.message.warning(
           `Database "${dbName}" and user "${username}" were created, but the grant failed: ${extractError(err, "unknown")}. You can add the grant manually.`,
         );
         setResult({ databaseName: dbName, username, password });
@@ -145,7 +135,7 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
       setResult({ databaseName: dbName, username, password });
       refreshLists();
     } catch (err) {
-      message.error(extractError(err, "Failed to create database"));
+      feedback.message.error(extractError(err, "Failed to create database"));
     } finally {
       setSubmitting(false);
     }
@@ -154,9 +144,9 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
   const copy = async (label: string, value: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      message.success(`${label} copied`);
+      feedback.message.success(`${label} copied`);
     } catch {
-      message.error(`Could not copy ${label.toLowerCase()}`);
+      feedback.message.error(`Could not copy ${label.toLowerCase()}`);
     }
   };
 

--- a/panel-ui/src/shells/user/databases/RedisAccessCard.tsx
+++ b/panel-ui/src/shells/user/databases/RedisAccessCard.tsx
@@ -6,7 +6,8 @@
 // (idempotent) and returns the credential — so we don't fetch a secret until
 // the user asks for it.
 import { useState } from "react";
-import { Card, Button, Descriptions, Typography, Alert, message } from "antd";
+import { Card, Button, Descriptions, Typography, Alert } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { apiClient } from "../../../apiClient";
 
 const { Text, Paragraph } = Typography;
@@ -33,7 +34,7 @@ export const RedisAccessCard = () => {
       const resp = await apiClient.get<RedisAccess>("/me/redis-access");
       setCreds(resp.data);
     } catch {
-      message.error("Could not load your Redis credentials.");
+      feedback.message.error("Could not load your Redis credentials.");
     } finally {
       setLoading(false);
     }

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -7,26 +7,8 @@ import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { RowActions } from "../../../components/RowActions";
 import { CatalogCard, CatalogGrid, CategoryFilter } from "../../../components/catalog";
-import {
-  Alert,
-  Avatar,
-  Button,
-  AutoComplete,
-  Col,
-  Descriptions,
-  Empty,
-  Form,
-  Input,
-  Modal,
-  Row,
-  Space,
-  Table,
-  Tabs,
-  Tag,
-  Tooltip,
-  Typography,
-  notification,
-} from "antd";
+import { Alert, Avatar, Button, AutoComplete, Col, Descriptions, Empty, Form, Input, Modal, Row, Space, Table, Tabs, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import {
   AppstoreOutlined,
   DeleteOutlined,
@@ -110,7 +92,7 @@ export const UserDockerAppsPage = () => {
       lifecycleAction(id, action),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["user-docker-installed"] }),
     onError: (e: AxiosError<{ detail?: string }>) =>
-      notification.error({ message: "Action failed", description: e.response?.data?.detail }),
+      feedback.notification.error({ message: "Action failed", description: e.response?.data?.detail }),
   });
   const remove = useMutation({
     mutationFn: (id: string) => deleteApp(id),
@@ -452,12 +434,12 @@ const InstallModal = ({
     mutationFn: (v: { name: string; domain: string }) =>
       installApp({ slug: entry!.slug, name: v.name, domain: v.domain }),
     onSuccess: () => {
-      notification.success({ message: "Install started" });
+      feedback.notification.success({ message: "Install started" });
       form.resetFields();
       onInstalled();
     },
     onError: (e: AxiosError<{ detail?: string; error?: string }>) =>
-      notification.error({
+      feedback.notification.error({
         message: "Install failed",
         description: e.response?.data?.detail || e.response?.data?.error,
       }),

--- a/panel-ui/src/shells/user/files/FileManagerPage.tsx
+++ b/panel-ui/src/shells/user/files/FileManagerPage.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from "react-i18next";
 import type { ReactNode } from "react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
-import { Breadcrumb, Button, Card, Drawer, Dropdown, Empty, Grid, Input, Modal, Space, Spin, Table, Tag, Tooltip, Tree, Typography, message, theme } from "antd";
+import { Breadcrumb, Button, Card, Drawer, Dropdown, Empty, Grid, Input, Modal, Space, Spin, Table, Tag, Tooltip, Tree, Typography, theme } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { DataNode } from "antd/es/tree";
 import {
@@ -389,7 +389,7 @@ export const FileManagerPage = () => {
           );
         }
       } catch (err) {
-        message.error(`Cannot open file manager: ${errMessage(err)}`);
+        feedback.message.error(`Cannot open file manager: ${errMessage(err)}`);
       }
     })();
   }, []);
@@ -408,7 +408,7 @@ export const FileManagerPage = () => {
       const resp = await filesList(path);
       setEntries(sortEntries(resp.entries));
     } catch (err) {
-      message.error(`List failed: ${errMessage(err)}`);
+      feedback.message.error(`List failed: ${errMessage(err)}`);
       setEntries([]);
     } finally {
       setListLoading(false);
@@ -442,9 +442,9 @@ export const FileManagerPage = () => {
       // trees can take a while, so the explicit success + total is the signal
       // the reporter asked for.
       setDirTotal(resp.total);
-      message.success(`Folder sizes calculated — this folder totals ${formatBytes(resp.total)}`);
+      feedback.message.success(`Folder sizes calculated — this folder totals ${formatBytes(resp.total)}`);
     } catch (err) {
-      message.error(`Size calculation failed: ${errMessage(err)}`);
+      feedback.message.error(`Size calculation failed: ${errMessage(err)}`);
     } finally {
       setSizingAll(false);
     }
@@ -460,7 +460,7 @@ export const FileManagerPage = () => {
         const resp = await filesDu(full);
         setFolderSizes((prev) => ({ ...prev, [full]: resp.total }));
       } catch (err) {
-        message.error(`Size calculation failed: ${errMessage(err)}`);
+        feedback.message.error(`Size calculation failed: ${errMessage(err)}`);
       } finally {
         setSizingPaths((prev) => {
           const n = new Set(prev);
@@ -497,7 +497,7 @@ export const FileManagerPage = () => {
       }));
       setTreeData((prev) => updateTreeNode(prev, node.path, children));
     } catch (err) {
-      message.error(`Tree load failed: ${errMessage(err)}`);
+      feedback.message.error(`Tree load failed: ${errMessage(err)}`);
     }
   }, []);
 
@@ -544,7 +544,7 @@ export const FileManagerPage = () => {
       const resp = await filesPreview(path);
       setPreviewContent(resp.content);
     } catch (err) {
-      message.error(`Preview failed: ${errMessage(err)}`);
+      feedback.message.error(`Preview failed: ${errMessage(err)}`);
       setPreviewOpen(false);
     } finally {
       setPreviewLoading(false);
@@ -564,10 +564,10 @@ export const FileManagerPage = () => {
     const path = joinPath(currentPath, entry.name);
     try {
       await filesDelete(path, entry.is_dir);
-      message.success(`Deleted ${entry.name}`);
+      feedback.message.success(`Deleted ${entry.name}`);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Delete failed: ${errMessage(err)}`);
+      feedback.message.error(`Delete failed: ${errMessage(err)}`);
     }
   };
 
@@ -608,14 +608,14 @@ export const FileManagerPage = () => {
         // Refuse anything that is not editable text. See isPreviewEditable --
         // extracted so the rule is unit-tested rather than buried in a callback.
         if (!isPreviewEditable(resp)) {
-          message.error("Cannot edit: file is not editable text (binary or non-UTF-8 encoding)");
+          feedback.message.error("Cannot edit: file is not editable text (binary or non-UTF-8 encoding)");
           setEditTarget(null);
           return;
         }
         setEditContent(resp.content);
         setEditOriginal(resp.content);
       } catch (err) {
-        message.error(`Load failed: ${errMessage(err)}`);
+        feedback.message.error(`Load failed: ${errMessage(err)}`);
         setEditTarget(null);
       } finally {
         setEditLoading(false);
@@ -630,17 +630,17 @@ export const FileManagerPage = () => {
     // from a hex dump? browser extension?) refuse rather than silently
     // corrupting what's on disk.
     if (editContent.includes("\u0000")) {
-      message.error("Refusing to save: content contains NUL bytes");
+      feedback.message.error("Refusing to save: content contains NUL bytes");
       return;
     }
     setEditSaving(true);
     try {
       await filesWrite(editTarget, editContent);
-      message.success("Saved");
+      feedback.message.success("Saved");
       setEditTarget(null);
       if (currentPath) void reloadList(currentPath);
     } catch (err) {
-      message.error(`Save failed: ${errMessage(err)}`);
+      feedback.message.error(`Save failed: ${errMessage(err)}`);
     } finally {
       setEditSaving(false);
     }
@@ -650,17 +650,17 @@ export const FileManagerPage = () => {
     if (!chmodTarget || !currentPath) return;
     const mode = chmodTargetMode.trim();
     if (!/^[0-7]{3,4}$/.test(mode)) {
-      message.error("Mode must be an octal string like 644 or 0755");
+      feedback.message.error("Mode must be an octal string like 644 or 0755");
       return;
     }
     const path = joinPath(currentPath, chmodTarget.name);
     try {
       await filesChmod(path, mode);
-      message.success(`Permissions updated`);
+      feedback.message.success(`Permissions updated`);
       setChmodTarget(null);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Chmod failed: ${errMessage(err)}`);
+      feedback.message.error(`Chmod failed: ${errMessage(err)}`);
     }
   };
 
@@ -668,18 +668,18 @@ export const FileManagerPage = () => {
     if (!currentPath || !renameTarget || renameSubmitting.current) return;
     const newName = renameNewName.trim();
     if (!newName || newName.includes("/") || newName === "." || newName === "..") {
-      message.error("Invalid new name");
+      feedback.message.error("Invalid new name");
       return;
     }
     renameSubmitting.current = true;
     try {
       const path = joinPath(currentPath, renameTarget.name);
       await filesRename(path, newName);
-      message.success(`Renamed to ${newName}`);
+      feedback.message.success(`Renamed to ${newName}`);
       setRenameOpen(false);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Rename failed: ${errMessage(err)}`);
+      feedback.message.error(`Rename failed: ${errMessage(err)}`);
     } finally {
       renameSubmitting.current = false;
     }
@@ -694,17 +694,17 @@ export const FileManagerPage = () => {
     if (!currentPath || mkdirSubmitting.current) return;
     const name = mkdirName.trim();
     if (!name || name.includes("/") || name === "." || name === "..") {
-      message.error("Invalid folder name");
+      feedback.message.error("Invalid folder name");
       return;
     }
     mkdirSubmitting.current = true;
     try {
       await filesMkdir(joinPath(currentPath, name));
-      message.success(`Created ${name}`);
+      feedback.message.success(`Created ${name}`);
       setMkdirOpen(false);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Create folder failed: ${errMessage(err)}`);
+      feedback.message.error(`Create folder failed: ${errMessage(err)}`);
     } finally {
       mkdirSubmitting.current = false;
     }
@@ -719,22 +719,22 @@ export const FileManagerPage = () => {
     if (!currentPath || newFileSubmitting.current) return;
     const name = newFileName.trim();
     if (!name || name.includes("/") || name === "." || name === "..") {
-      message.error("Invalid file name");
+      feedback.message.error("Invalid file name");
       return;
     }
     // Guard: never overwrite an existing entry with an empty file.
     if (entries.some((e) => e.name === name)) {
-      message.error(`"${name}" already exists`);
+      feedback.message.error(`"${name}" already exists`);
       return;
     }
     newFileSubmitting.current = true;
     try {
       await filesWrite(joinPath(currentPath, name), "");
-      message.success(`Created ${name}`);
+      feedback.message.success(`Created ${name}`);
       setNewFileOpen(false);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Create file failed: ${errMessage(err)}`);
+      feedback.message.error(`Create file failed: ${errMessage(err)}`);
     } finally {
       newFileSubmitting.current = false;
     }
@@ -779,11 +779,11 @@ export const FileManagerPage = () => {
       const ok = results.filter((r) => r.status === "fulfilled").length;
       const fail = results.length - ok;
       if (fail === 0) {
-        message.success(`${verb} ${ok} item${ok === 1 ? "" : "s"}`);
+        feedback.message.success(`${verb} ${ok} item${ok === 1 ? "" : "s"}`);
       } else if (ok === 0) {
-        message.error(`${verb} failed for all ${fail} items`);
+        feedback.message.error(`${verb} failed for all ${fail} items`);
       } else {
-        message.warning(`${verb} ${ok}/${results.length} — ${fail} failed`);
+        feedback.message.warning(`${verb} ${ok}/${results.length} — ${fail} failed`);
       }
       // Log failures for debug — the toast can't surface per-item detail.
       results.forEach((r, i) => {
@@ -820,7 +820,7 @@ export const FileManagerPage = () => {
   const handleBulkMove = useCallback(async () => {
     const dest = bulkMoveDest.trim();
     if (!dest || !dest.startsWith("/")) {
-      message.error("Destination must be an absolute path starting with /");
+      feedback.message.error("Destination must be an absolute path starting with /");
       return;
     }
     setBulkMoveOpen(false);
@@ -831,7 +831,7 @@ export const FileManagerPage = () => {
   const handleBulkChmod = useCallback(async () => {
     const mode = bulkChmodMode.trim();
     if (!/^[0-7]{3,4}$/.test(mode)) {
-      message.error("Mode must be an octal string like 644 or 0755");
+      feedback.message.error("Mode must be an octal string like 644 or 0755");
       return;
     }
     setBulkChmodOpen(false);
@@ -854,16 +854,16 @@ export const FileManagerPage = () => {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      message.success(`Archived ${selectedPaths.length} items`);
+      feedback.message.success(`Archived ${selectedPaths.length} items`);
     } catch (err) {
-      message.error(`Archive failed: ${errMessage(err)}`);
+      feedback.message.error(`Archive failed: ${errMessage(err)}`);
     }
   }, [selectedPaths]);
 
   const handleCopyToClipboard = useCallback(() => {
     if (selectedPaths.length === 0) return;
     setClipboard(selectedPaths);
-    message.success(
+    feedback.message.success(
       `Copied ${selectedPaths.length} item${selectedPaths.length === 1 ? "" : "s"} — switch folders and Paste`,
     );
     setSelectedNames([]);
@@ -886,10 +886,10 @@ export const FileManagerPage = () => {
       if (srcParent === destDir) return;
       try {
         await filesMove(srcPath, destDir);
-        message.success("Moved");
+        feedback.message.success("Moved");
         if (currentPath) void reloadList(currentPath);
       } catch (err) {
-        message.error(`Move failed: ${errMessage(err)}`);
+        feedback.message.error(`Move failed: ${errMessage(err)}`);
       }
     },
     [currentPath, reloadList],
@@ -934,10 +934,10 @@ export const FileManagerPage = () => {
       const res = await filesExtract(path);
       const skipped =
         res.skipped > 0 ? `, ${res.skipped} unsafe entr(y/ies) skipped` : "";
-      message.success(`Extracted ${res.extracted} file(s)${skipped}`);
+      feedback.message.success(`Extracted ${res.extracted} file(s)${skipped}`);
       void reloadList(currentPath);
     } catch (err) {
-      message.error(`Extract failed: ${errMessage(err)}`);
+      feedback.message.error(`Extract failed: ${errMessage(err)}`);
     }
   };
 

--- a/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
+++ b/panel-ui/src/shells/user/mail/AutoReplyModal.tsx
@@ -4,16 +4,8 @@
 // to match the Microsoft 365 wording.
 import { useTranslation } from "react-i18next";
 import { useEffect } from "react";
-import {
-  Button,
-  DatePicker,
-  Form,
-  Input,
-  message,
-  Modal,
-  Popconfirm,
-  Switch,
-} from "antd";
+import { Button, DatePicker, Form, Input, Modal, Popconfirm, Switch } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import dayjs, { type Dayjs } from "dayjs";
 
 import {
@@ -80,26 +72,26 @@ export const AutoReplyModal = ({
           html_body: vals.html_body || null,
         },
       });
-      message.success("Automatic replies saved");
+      feedback.message.success("Automatic replies saved");
       onClose();
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ?? "Failed to save automatic replies";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
   const turnOff = async () => {
     try {
       await deleteMut.mutateAsync(mailboxId);
-      message.success("Automatic replies turned off");
+      feedback.message.success("Automatic replies turned off");
       onClose();
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data
           ?.error ?? "Failed to turn off";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/CatchAllTab.tsx
@@ -5,20 +5,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  
-  Empty,
-  Form,
-  message,
-  Modal,
-  Select,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Typography,
-} from "antd";
+import { Button, Empty, Form, Modal, Select, Skeleton, Space, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, EditOutlined, PlusOutlined } from "@icons";
 import { RowActions } from "../../../../components/RowActions";
 import { useQueries, useQuery } from "@tanstack/react-query";
@@ -110,12 +98,12 @@ export const CatchAllTab = () => {
     const vals = await form.validateFields();
     try {
       await updateMut.mutateAsync({ domainID: vals.domain_id, target: vals.target });
-      message.success("Catch-all updated");
+      feedback.message.success("Catch-all updated");
       setEditOpen(false);
     } catch (err) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
         ?? "Failed to update catch-all";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -202,11 +190,11 @@ export const CatchAllTab = () => {
                       onClick: async () => {
                         try {
                           await deleteMut.mutateAsync(row.domain_id);
-                          message.success("Catch-all cleared");
+                          feedback.message.success("Catch-all cleared");
                         } catch (err) {
                           const msg = (err as { response?: { data?: { error?: string } } })?.response
                             ?.data?.error ?? "Failed to clear";
-                          message.error(msg);
+                          feedback.message.error(msg);
                         }
                       },
                       confirm: { title: `Clear catch-all for ${row.domain_name}?`, okText: "Clear" },

--- a/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/DisclaimerTab.tsx
@@ -3,22 +3,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  
-  Empty,
-  Form,
-  Input,
-  message,
-  Modal,
-  Skeleton,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-} from "antd";
+import { Button, Empty, Form, Input, Modal, Skeleton, Space, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { EditOutlined, FileTextOutlined } from "@icons";
 import { useQueries } from "@tanstack/react-query";
 
@@ -73,12 +59,12 @@ export const DisclaimerTab = () => {
         enabled: vals.enabled,
         text: vals.text,
       });
-      message.success("Disclaimer saved");
+      feedback.message.success("Disclaimer saved");
       setOpen(false);
     } catch (err) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
         ?? "Failed to save disclaimer";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 

--- a/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/ForwardersTab.tsx
@@ -2,24 +2,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  
-  Empty,
-  Form,
-  Input,
-  message,
-  Modal,
-  Popconfirm,
-  Radio,
-  Select,
-  Skeleton,
-  Space,
-  Table,
-  Tag,
-  Tooltip,
-  Typography,
-} from "antd";
+import { Button, Empty, Form, Input, Modal, Popconfirm, Radio, Select, Skeleton, Space, Table, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, PlusOutlined } from "@icons";
 import { useQueries, useQuery } from "@tanstack/react-query";
 
@@ -110,13 +94,13 @@ export const ForwardersTab = () => {
         localPart: vals.type === "alias" ? vals.local_part : undefined,
         target: vals.target,
       });
-      message.success("Forwarder created");
+      feedback.message.success("Forwarder created");
       setOpen(false);
       form.resetFields();
     } catch (err) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
         ?? "Failed to create forwarder";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -184,11 +168,11 @@ export const ForwardersTab = () => {
                   onConfirm={async () => {
                     try {
                       await deleteMut.mutateAsync(row.id);
-                      message.success("Forwarder removed");
+                      feedback.message.success("Forwarder removed");
                     } catch (err) {
                       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
                         ?? "Failed to remove";
-                      message.error(msg);
+                      feedback.message.error(msg);
                     }
                   }}
                   okText={t("forwarderstab.remove")}

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -5,7 +5,7 @@
 // client-side and provides password rotation, SSO mint, and delete actions.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import { Button, Empty, Form, Modal, Progress, Skeleton, Space, Tag, Tooltip, Typography, message } from "antd";
+import { Button, Empty, Form, Modal, Progress, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
 import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { RowActions } from "../../../../components/RowActions";
 import { SearchableTableStringQ } from "../../../../components/SearchableTable";
@@ -195,13 +195,13 @@ export const MailboxesTab = () => {
           title: "New mailbox password (auto-generated)",
         });
       } else {
-        message.success("Password updated");
+        feedback.message.success("Password updated");
       }
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
         "Failed to reset password";
-      message.error(msg);
+      feedback.message.error(msg);
     } finally {
       setRotatingId(null);
     }
@@ -230,11 +230,11 @@ export const MailboxesTab = () => {
             ?.data?.error;
           popup?.close();
           if (code === "sso_unavailable_rotate_password") {
-            message.error(
+            feedback.message.error(
               "Rotate the mailbox password first — SSO material is populated on rotation.",
             );
           } else {
-            message.error("Failed to open webmail");
+            feedback.message.error("Failed to open webmail");
           }
         },
       },
@@ -459,12 +459,12 @@ export const MailboxesTab = () => {
                         onOk: async () => {
                           try {
                             await deleteMutation.mutateAsync({ id: row.id, domainId: row.domain_id });
-                            message.success("Mailbox deleted");
+                            feedback.message.success("Mailbox deleted");
                           } catch (err) {
                             const msg =
                               (err as { response?: { data?: { detail?: string } } })?.response?.data
                                 ?.detail ?? "Failed to delete";
-                            message.error(msg);
+                            feedback.message.error(msg);
                           }
                         },
                       });

--- a/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedFoldersTab.tsx
@@ -2,22 +2,8 @@
 
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  
-  Checkbox,
-  Empty,
-  Form,
-  message,
-  Modal,
-  Popconfirm,
-  Select,
-  Skeleton,
-  Space,
-  Tag,
-  Tooltip,
-  Typography,
-} from "antd";
+import { Button, Checkbox, Empty, Form, Modal, Popconfirm, Select, Skeleton, Space, Tag, Tooltip, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { DeleteOutlined, PlusOutlined } from "@icons";
 import { RowActionButton } from "../../../../components/RowActionButton";
 import { useQueries } from "@tanstack/react-query";
@@ -112,13 +98,13 @@ export const SharedFoldersTab = () => {
         sharedWithMailboxID: vals.shared_with_mailbox_id,
         rights,
       });
-      message.success("Share created");
+      feedback.message.success("Share created");
       setOpen(false);
       form.resetFields();
     } catch (err) {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
         ?? "Failed to create share";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
 
@@ -198,11 +184,11 @@ export const SharedFoldersTab = () => {
                         ownerMailboxID: row.owner_mailbox_id,
                         shareID: row.id,
                       });
-                      message.success("Share removed");
+                      feedback.message.success("Share removed");
                     } catch (err) {
                       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
                         ?? "Failed to remove";
-                      message.error(msg);
+                      feedback.message.error(msg);
                     }
                   }}
                   okText={t("sharedfolderstab.remove")}

--- a/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/SharedResourcesTab.tsx
@@ -4,21 +4,8 @@
 // is intentionally not offered here yet — its send-as path is pending.
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
-import {
-  Button,
-  Flex,
-  Empty,
-  Form,
-  Input,
-  message,
-  Modal,
-  Segmented,
-  Select,
-  Skeleton,
-  Space,
-  Tag,
-  Typography,
-} from "antd";
+import { Button, Flex, Empty, Form, Input, Modal, Segmented, Select, Skeleton, Space, Tag, Typography } from "antd";
+import { feedback } from "../../../../lib/feedback"; // GH #970: themed toasts
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { DeleteOutlined, PlusOutlined, TeamOutlined } from "@icons";
 
@@ -157,9 +144,9 @@ export const SharedResourcesTab = () => {
                     onClick: async () => {
                       try {
                         await deleteMut.mutateAsync({ id: row.id });
-                        message.success("Deleted");
+                        feedback.message.success("Deleted");
                       } catch {
-                        message.error("Delete failed");
+                        feedback.message.error("Delete failed");
                       }
                     },
                     confirm: { title: `Delete ${row.display_name || row.email}?`, description: "Removes the shared collection and all its grants.", okText: "Delete" },
@@ -197,13 +184,13 @@ function CreateModal({
     const v = await form.validateFields();
     try {
       await createMut.mutateAsync(v);
-      message.success("Shared resource created");
+      feedback.message.success("Shared resource created");
       onClose();
     } catch (err) {
       const msg =
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ??
         "Create failed";
-      message.error(msg);
+      feedback.message.error(msg);
     }
   };
   return (
@@ -277,10 +264,10 @@ function GrantsModal({ resource, onClose }: { resource: Row; onClose: () => void
     ];
     try {
       await setGrants.mutateAsync({ id: resource.id, grants });
-      message.success("Grants saved — apply on next sync");
+      feedback.message.success("Grants saved — apply on next sync");
       onClose();
     } catch {
-      message.error("Save failed");
+      feedback.message.error("Save failed");
     }
   };
 

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
@@ -4,18 +4,8 @@
 // tenant-creatable kinds. Secrets are write-only: an edit leaves a secret
 // field blank to keep the stored (sealed) value — the placeholder says so.
 import { useEffect, useMemo } from "react";
-import {
-  Alert,
-  Button,
-  Drawer,
-  Form,
-  Grid,
-  Input,
-  InputNumber,
-  Select,
-  Switch,
-  message,
-} from "antd";
+import { Alert, Button, Drawer, Form, Grid, Input, InputNumber, Select, Switch } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
 import { apiClient } from "../../../apiClient";
@@ -91,14 +81,14 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
     try {
       if (isEdit && existing) {
         await update.mutateAsync({ id: existing.id, input: values });
-        message.success(`Channel "${values.name}" updated`);
+        feedback.message.success(`Channel "${values.name}" updated`);
       } else {
         await create.mutateAsync(values);
-        message.success(`Channel "${values.name}" created`);
+        feedback.message.success(`Channel "${values.name}" created`);
       }
       onClose();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Save failed");
+      feedback.message.error(err instanceof Error ? err.message : "Save failed");
     }
   };
 
@@ -106,9 +96,9 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
     if (!existing) return;
     try {
       await apiClient.post(`/${RESOURCE}/${existing.id}/test`);
-      message.success(`Test sent to "${existing.name}"`);
+      feedback.message.success(`Test sent to "${existing.name}"`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Test failed");
+      feedback.message.error(err instanceof Error ? err.message : "Test failed");
     }
   };
 

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -10,20 +10,8 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Card,
-  Empty,
-  Popconfirm,
-  Select,
-  Space,
-  Switch,
-  Table,
-  Tag,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Empty, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import type { AxiosError } from "axios";
 
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
@@ -119,26 +107,26 @@ export function MyNotificationsPage(): JSX.Element {
     try {
       await updateMutation.mutateAsync({ id: row.id, input: { enabled: next } });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Toggle failed");
+      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
     }
   };
 
   const removeChannel = async (row: MyChannel) => {
     try {
       await deleteMutation.mutateAsync({ id: row.id });
-      message.success(`Deleted ${row.name}`);
+      feedback.message.success(`Deleted ${row.name}`);
       qc.invalidateQueries({ queryKey: ["list", RT_RESOURCE] });
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Delete failed");
+      feedback.message.error(err instanceof Error ? err.message : "Delete failed");
     }
   };
 
   const testChannel = async (row: MyChannel) => {
     try {
       await apiClient.post(`/${CH_RESOURCE}/${row.id}/test`);
-      message.success(`Test sent to ${row.name}`);
+      feedback.message.success(`Test sent to ${row.name}`);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Test failed");
+      feedback.message.error(err instanceof Error ? err.message : "Test failed");
     }
   };
 
@@ -157,7 +145,7 @@ export function MyNotificationsPage(): JSX.Element {
         await apiClient.delete(`/${RT_RESOURCE}/${r.routeId}`);
       }
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Routing update failed");
+      feedback.message.error(err instanceof Error ? err.message : "Routing update failed");
     } finally {
       routesQ.refetch();
     }

--- a/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPPerformanceCard.tsx
@@ -5,19 +5,8 @@
 // This replaces the old raw UserPHPPoolCard (removed in PR #34) with the
 // package-gated, preset-based model.
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Button,
-  Card,
-  Collapse,
-  Form,
-  InputNumber,
-  Select,
-  Space,
-  Spin,
-  Typography,
-  message,
-} from "antd";
+import { Alert, Button, Card, Collapse, Form, InputNumber, Select, Space, Spin, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { apiClient } from "../../../apiClient";
@@ -64,11 +53,11 @@ export const UserPHPPerformanceCard = ({
     setSaving(true);
     try {
       await apiClient.put("/me/php-performance-mode", { php_version: version, mode });
-      message.success(`Performance mode set to ${mode}`);
+      feedback.message.success(`Performance mode set to ${mode}`);
       qc.invalidateQueries({ queryKey: ["me-fpm-policy"] });
     } catch (e) {
       const err = e as { response?: { data?: { error?: string; detail?: string } } };
-      message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
+      feedback.message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
     } finally {
       setSaving(false);
     }
@@ -79,11 +68,11 @@ export const UserPHPPerformanceCard = ({
     setSaving(true);
     try {
       await apiClient.put("/me/php-pool-tuning", { php_version: version, ...vals });
-      message.success("Advanced FPM settings applied (clamped to your plan)");
+      feedback.message.success("Advanced FPM settings applied (clamped to your plan)");
       qc.invalidateQueries({ queryKey: ["me-fpm-policy"] });
     } catch (e) {
       const err = e as { response?: { data?: { error?: string; detail?: string } } };
-      message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
+      feedback.message.error(err.response?.data?.detail ?? err.response?.data?.error ?? "Failed");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
+++ b/panel-ui/src/shells/user/php-settings/UserPHPSettingsPage.tsx
@@ -1,18 +1,6 @@
 import { useTranslation } from "react-i18next";
-import {
-  Tabs,
-  Alert,
-  Button,
-  Card,
-  Form,
-  Row,
-  Col,
-  Select,
-  Space,
-  Spin,
-  Typography,
-  message,
-} from "antd";
+import { Tabs, Alert, Button, Card, Form, Row, Col, Select, Space, Spin, Typography } from "antd";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect, useState } from "react";
 import { CodeOutlined } from "@icons";
 import { UserPHPPerformanceCard } from "./UserPHPPerformanceCard";
@@ -132,7 +120,7 @@ export function UserPHPSettingsPage() {
         );
         setDomains(resp.data?.data ?? []);
       } catch (err) {
-        message.error("Failed to load domains");
+        feedback.message.error("Failed to load domains");
       }
 
       try {
@@ -160,14 +148,14 @@ export function UserPHPSettingsPage() {
     try {
       await apiClient.put("/me/php-cli-version", { version });
       setCliVersion(version);
-      message.success(
+      feedback.message.success(
         version
           ? `CLI default set to PHP ${version}`
           : "CLI default reverted to automatic",
       );
     } catch (err) {
       const e = err as { response?: { data?: { detail?: string; error?: string } } };
-      message.error(
+      feedback.message.error(
         e.response?.data?.detail ?? e.response?.data?.error ?? "Failed to set CLI PHP version",
       );
     } finally {
@@ -186,7 +174,7 @@ export function UserPHPSettingsPage() {
           php_version: version,
         });
       }
-      message.success(
+      feedback.message.success(
         version
           ? `Switched to PHP ${version}`
           : "Reverted to server default PHP version",
@@ -200,7 +188,7 @@ export function UserPHPSettingsPage() {
         response?: { data?: { error?: string } };
         message?: string;
       };
-      message.error(
+      feedback.message.error(
         e.response?.data?.error ?? e.message ?? "Failed to change PHP version",
       );
     } finally {
@@ -233,7 +221,7 @@ export function UserPHPSettingsPage() {
           php_max_input_time: resp.data.php_max_input_time,
         });
       } catch (err) {
-        message.error("Failed to load PHP settings");
+        feedback.message.error("Failed to load PHP settings");
       } finally {
         setLoading(false);
       }
@@ -253,7 +241,7 @@ export function UserPHPSettingsPage() {
         php_max_execution_time: values.php_max_execution_time,
         php_max_input_time: values.php_max_input_time,
       });
-      message.success("PHP settings updated successfully");
+      feedback.message.success("PHP settings updated successfully");
       // Reload settings to confirm
       if (selectedDomain) {
         const resp = await apiClient.get<DomainPHPSettings>(
@@ -262,7 +250,7 @@ export function UserPHPSettingsPage() {
         setPhpSettings(resp.data);
       }
     } catch (err) {
-      message.error("Failed to update PHP settings");
+      feedback.message.error("Failed to update PHP settings");
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
The reply on #970 promised "a handful of screens still make the old static call and are being swept over in a follow-up." It wasn't a handful.

## Why the previous sweeps kept missing files

#1014/#1024/#1027/#1028/#1038 all searched for **single-line** `import { …, message, … } from "antd"`. **62 files import antd across multiple lines** — they passed every scan while still calling the static, theme-blind toasts. Plus 10 more single-line files missed or added since. Total: **72 files, 417 call sites**, all now routed through the themed feedback bridge.

This only affects theme/RTL correctness on those screens (white toast on a dark panel, wrong side in RTL) — the global position/size config from #1014 already applied everywhere, which is why the earlier claim about position consistency stays true.

## The guard is the real deliverable

`feedback.guard.test.ts` — this is the third time this class of bug has been "finished", so the sweep now comes with a gate:

- Walks every source file directly — **no grep, no single-line assumption**, the exact blind spot that ate the previous sweeps
- Fails on any `message`/`notification` import from antd outside the two legitimate touchpoints (`main.tsx` for the global config, `lib/feedback` for the pre-bridge fallback)
- Fails on any static `Modal.confirm/info/success/error/warning(` call
- Fails if it ever scans suspiciously few files — a directory-layout change can't turn it into a silent no-op

## One hand-fix worth reviewing

`AdminSecurityEgress.tsx` consumed `App.useApp()`'s message **and** imported the static one. The sweep re-pointed its call sites at the bridge — same App instance, identical behaviour — leaving the destructure unused; removed it. Everything else is the mechanical transform.

## Test plan

- [x] Guard passes post-sweep; audit script confirms **0 offenders** repo-wide
- [x] `npx tsc -b` clean
- [x] vitest: 48 → **49 files, 231 tests** pass
- [x] `npm run build` clean

Not re-verified per-screen in a browser: 72 screens is beyond what I can click through, and the transform is mechanical (`message.x(` → `feedback.message.x(`) with types enforcing the shape. Playwright E2E covers the main flows in CI.