### PR TITLE
fix(domains): reconcile a new domain immediately on create (GH #896)

### DIFF
--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -683,6 +683,17 @@ func (h *domainHandler) create(c *gin.Context) {
 		return
 	}
 
+	// GH #896: trigger an immediate targeted reconcile for the new domain so its
+	// DNS zone (and vhost) converge in SECONDS instead of waiting for the next
+	// periodic full reconcile. On an idle box the loop picks it up quickly, but
+	// on a box with many domains the full pass can lag minutes — during which a
+	// fresh domain doesn't resolve (dead page + certbot NXDOMAIN) even though the
+	// authoritative record is only a push away. This is the same Schedule the
+	// DNS-record and SSL-mode handlers already fire on a change.
+	if h.cfg.Reconciler != nil {
+		h.cfg.Reconciler.Schedule(dom.ID)
+	}
+
 	// EnableDomainEmailInline mutated domain in place on success so the response
 	// already carries email_enabled=true, dkim_selector, etc.
 	c.JSON(http.StatusCreated, dom)


### PR DESCRIPTION
## Root cause (GH #896)

The domain-**create** API handler was the **only** mutating domain/DNS handler that did **not** call `Reconciler.Schedule()`. The DNS-record handlers (`dns.go`) and the SSL-mode handler all do. So a freshly created domain's DNS zone + vhost only converged on the next **periodic full reconcile**, not immediately.

That explains johnnyq's exact asymmetry, reported repeatedly on this issue:
- **Manually-added DNS record → resolved instantly** (its handler Schedules an immediate targeted `ReconcileOne`).
- **New domain → dead page + certbot NXDOMAIN for minutes** (waits for the periodic loop).

On an idle box the loop picks a new domain up in a few seconds; on a box with many domains the full pass lags — minutes on a busy server — and during that window the new (sub)domain doesn't resolve at all.

## Fix

The create handler now fires the same `Schedule(domain.ID)` the sibling handlers do → an **immediate targeted reconcile** creates the DNS zone and pushes it to PowerDNS in seconds, regardless of how backed-up the periodic loop is. One-line change, matching the existing pattern (6 sibling call sites).

## Verification

- `go build` + `go test ./internal/api/ -run Domain` green.
- **Empirically confirmed the mechanism on a test host:** created a subdomain → the reconciler bootstrapped + pushed the zone ~6s later (loop was idle) → `dig @127.0.0.1` resolved. The test box's loop is uncongested, so it didn't reproduce the multi-minute lag directly — but that's the point: the fix removes the dependency on loop timing entirely by scheduling the domain the moment it's created.

## Note

Not unit-tested: `DomainHandlerConfig.Reconciler` is a concrete `*reconciler.Reconciler`, not an injectable interface, so the Schedule call can't be asserted in a handler test without a refactor. The change is a one-line Schedule mirroring the DNS/SSL handlers; behaviour is verified end-to-end (create → immediate reconcile in the journal).

GH #896