### PR TITLE
fix(ssl): stop retrying cap-exhausted certs every tick (JAB-226 follow-up)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2511,15 +2511,25 @@ func (r *Reconciler) reconcileSSLForDomain(ctx context.Context, domain *models.D
 		case cert.Status == models.SSLStatusPendingACMERetry && cert.NextRetryAt != nil && cert.NextRetryAt.Before(time.Now().UTC()):
 			r.tryACMEOrFallback(ctx, domain, cert)
 		// A cert that hit a hard failure (unparseable agent result, a self-sign
-		// error) had NO dispatch case — it stayed 'failed' forever: no :443, no
-		// retry, no self-signed fallback, stranding the domain on plain HTTP
-		// until an operator ran `jabali ssl renew` by hand. That is how a
-		// one-time SAN failure (JAB-226) became a permanent outage instead of a
-		// transient retry. Route 'failed' back through the ACME-or-self-sign
-		// path: tryACMEOrFallback either issues, or self-signs + moves the row
-		// to pending_acme_retry (scheduled, so no per-tick hammering). This also
-		// auto-heals rows already stuck in 'failed' once this ships.
-		case cert.Status == models.SSLStatusFailed:
+		// error) below the retry cap had NO dispatch case — it stayed 'failed'
+		// forever: no :443, no retry, no self-signed fallback, stranding the
+		// domain on plain HTTP until an operator ran `jabali ssl renew` by hand.
+		// That is how a one-time SAN failure (JAB-226) became a permanent outage
+		// instead of a transient retry. Route such rows back through the
+		// ACME-or-self-sign path: tryACMEOrFallback either issues, or self-signs
+		// + moves the row to pending_acme_retry (backoff-scheduled).
+		//
+		// But ONLY below the cap. Past acmeMaxRetries, status=failed is the
+		// deliberate TERMINAL state fallbackToSelfSignAndRetry parks a cert in so
+		// the reconciler stops hammering Let's Encrypt — which otherwise
+		// rate-limits the whole account ("too many failed authorizations (5) per
+		// hostname per hour"). Retrying a capped row every tick just re-caps it
+		// (newRetryCount = cap+1 ≥ cap → marked failed again) and hammers LE
+		// forever — observed on the aramapp fleet: ~45 hopeless Cloudflare-fronted
+		// domains cycling failed→retry→cap→failed every tick, retry_count climbing
+		// into the 60s. Capped rows wait for an operator "Retry" (which resets
+		// retry_count to 0 and flips status back to pending).
+		case cert.Status == models.SSLStatusFailed && cert.RetryCount < acmeMaxRetries:
 			r.tryACMEOrFallback(ctx, domain, cert)
 		case cert.Status == models.SSLStatusRenewing:
 			r.sslRenewForDomain(ctx, domain, cert)

--- a/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
+++ b/panel-api/internal/reconciler/ssl_mode_reconcile_test.go
@@ -71,10 +71,23 @@ func TestReconcileSSL_ModeRouting(t *testing.T) {
 	// previously had NO dispatch case and was never retried — the domain stayed
 	// on plain HTTP forever. It must now route back through ACME so a transient
 	// failure self-heals instead of stranding the site.
-	t.Run("le mode failed cert retries via ACME", func(t *testing.T) {
+	t.Run("le mode failed cert BELOW the cap retries via ACME", func(t *testing.T) {
 		cp, kp := "/etc/ssl/jabali-selfsigned/example.com/cert.pem", "/etc/ssl/jabali-selfsigned/example.com/key.pem"
-		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusFailed, CertPath: &cp, KeyPath: &kp})
-		require.True(t, hasCall(ag, "ssl.issue"), "a failed cert must be retried via ACME, not left stranded on HTTP")
+		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusFailed, RetryCount: 3, CertPath: &cp, KeyPath: &kp})
+		require.True(t, hasCall(ag, "ssl.issue"), "a sub-cap failed cert must be retried via ACME, not left stranded on HTTP")
+	})
+
+	// JAB-226 follow-up regression: once a cert EXHAUSTS the retry cap,
+	// fallbackToSelfSignAndRetry parks it in status=failed as a TERMINAL state so
+	// the reconciler stops hammering Let's Encrypt. The failed-cert dispatch must
+	// respect that cap — retrying a capped row every tick just re-caps it and
+	// churns LE into rate-limiting the whole account ("too many failed
+	// authorizations"). Observed live on the aramapp fleet: ~45 hopeless
+	// Cloudflare-fronted domains cycling failed→retry→cap→failed every tick.
+	t.Run("le mode failed cert AT the cap is terminal, no ACME hammer", func(t *testing.T) {
+		cp, kp := "/etc/ssl/jabali-selfsigned/example.com/cert.pem", "/etc/ssl/jabali-selfsigned/example.com/key.pem"
+		ag := run(models.SSLModeLE, &models.SSLCertificate{ID: "c1", Status: models.SSLStatusFailed, RetryCount: 20, CertPath: &cp, KeyPath: &kp})
+		require.False(t, hasCall(ag, "ssl.issue"), "a cap-exhausted failed cert must NOT be retried — it is terminal until an operator resets it")
 	})
 
 	t.Run("none mode revokes issued cert", func(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up to PR #1046 (JAB-226). That PR's commit 2 routed `status=failed`
certs back through `tryACMEOrFallback` so a one-off SAN failure would self-heal
instead of stranding the domain on plain HTTP. It fired for **every** failed
row — including ones that had already exhausted the retry cap.

`status=failed` past `acmeMaxRetries` is the deliberate **terminal** state
`fallbackToSelfSignAndRetry` parks a cert in so the reconciler stops hammering
Let's Encrypt. Retrying a capped row every tick just re-caps it
(`newRetryCount = cap+1 >= cap` → marked failed again) and hammers LE forever.

## Live evidence (aramapp fleet, after #1046 shipped to stable)

~45 hopeless Cloudflare-fronted domains (apex HTTP-01 blocked by CF at the edge,
403/404) cycling `failed → retry → cap → failed` every ~90s:

- ~41 ACME attempts **per hostname per hour**; ~950 certbot invocations/hr on one box
- `retry_count` climbing into the 60s
- LE returning `too many failed authorizations (5) for <host> in the last 1h` —
  the shared account's per-hostname failed-auth limit, tripped fleet-wide

## Fix

Gate the failed-cert dispatch on `retry_count < acmeMaxRetries`:

- **Sub-cap** failures still self-heal (JAB-226 goal preserved): one attempt,
  then `fallbackToSelfSignAndRetry` moves the row to backoff-scheduled
  `pending_acme_retry`.
- **Cap-exhausted** rows stay terminal until an operator "Retry" resets
  `retry_count` — the reconciler no longer touches them, so no LE hammer.

## Test plan

- `TestReconcileSSL_ModeRouting`:
  - new `le mode failed cert BELOW the cap retries via ACME` (retry_count=3 → `ssl.issue` called)
  - new `le mode failed cert AT the cap is terminal, no ACME hammer` (retry_count=20 → `ssl.issue` NOT called)
- Full `panel-api/internal/reconciler` suite green (0 failures).
- Deployed to newaramapp + newzaps: ACME churn dropped from ~950/hr to **0**;
  `retry_count` stops climbing; issued certs untouched.

JAB-226 follow-up. Does not change the SAN-filter logic from #1046.
