### PR TITLE
fix(dns): retry the recursor forwarder probe so a fresh zone isn't rolled back (GH #896)

### DIFF
--- a/panel-agent/internal/pdnsrecursor/manager.go
+++ b/panel-agent/internal/pdnsrecursor/manager.go
@@ -54,6 +54,16 @@ type Options struct {
 	// Prober probes "zone NS" against the recursor's loopback bind. Default:
 	// netResolverProbe querying 127.0.0.1:53 with 2s timeout.
 	Prober Prober
+	// ProbeAttempts is how many times a post-add probe is retried before the
+	// forwarder is rolled back (GH #896). A freshly-created authoritative zone
+	// can take a couple of seconds after `rec_control reload-zones` to answer
+	// the recursor's NS query; a single attempt used to roll the forwarder
+	// back on that race, so the zone stayed unresolvable until the next
+	// reconcile pass re-added it. Default 5.
+	ProbeAttempts int
+	// ProbeGap is the wait between probe attempts. Default 2s. Tests set it to
+	// 0 for speed.
+	ProbeGap time.Duration
 	// Clock is injectable for deterministic tests; default time.Now.
 	Clock func() time.Time
 	// FileMode for the forwards file; default 0640.
@@ -91,8 +101,8 @@ type Prober interface {
 
 // Manager serializes writes + reloads against recursor.forwards.
 type Manager struct {
-	mu    sync.Mutex
-	opts  Options
+	mu   sync.Mutex
+	opts Options
 }
 
 // New constructs a Manager with defaults applied.
@@ -118,6 +128,12 @@ func New(opts Options) (*Manager, error) {
 	}
 	if opts.Clock == nil {
 		opts.Clock = time.Now
+	}
+	if opts.ProbeAttempts < 1 {
+		opts.ProbeAttempts = 5
+	}
+	if opts.ProbeGap == 0 {
+		opts.ProbeGap = 2 * time.Second
 	}
 	if opts.FileMode == 0 {
 		opts.FileMode = 0o640
@@ -297,19 +313,16 @@ func (m *Manager) applyChange(ctx context.Context, desired map[string]Entry, zon
 		m.rollback()
 		return fmt.Errorf("rec_control reload-zones: %w", err)
 	}
-	// Wipe cached answers for the zone that just got its forwarder
-	// (re-)bound. Without this, recursor's positive cache returns the
-	// PRE-forwarder-change answer until cache-ttl evicts (same class
-	// of bug as PRs #86/#87/#88 on pdns-server). Add path only — the
-	// remove path's negative cache is short-lived (~10s default).
+	// Post-probe only on add (zoneToProbe != nil). Retry with a short backoff:
+	// a freshly-created authoritative zone can take a couple of seconds after
+	// reload-zones to answer the recursor's NS query, and a single-shot probe
+	// used to roll the forwarder back on that race — leaving the zone
+	// unresolvable until the NEXT reconcile pass re-added it (GH #896: a fresh
+	// (sub)domain dead for up to minutes). probeForwarder wipes the cache
+	// before each attempt so a just-cached NXDOMAIN can't pin every retry to
+	// failure. Removals need no positive signal — absent zone = success.
 	if zoneToProbe != nil && *zoneToProbe != "" {
-		_, _ = m.opts.Exec.Run(ctx, "rec_control", "wipe-cache", *zoneToProbe+"$")
-	}
-
-	// Post-probe only on add (zoneToProbe != nil). Removals need no
-	// positive signal — absent zone = successful removal.
-	if zoneToProbe != nil {
-		if err := m.opts.Prober.ProbeZone(ctx, *zoneToProbe); err != nil {
+		if err := m.probeForwarder(ctx, *zoneToProbe); err != nil {
 			m.rollback()
 			// Re-reload after rollback to re-unload any half-applied state.
 			_, _ = m.opts.Exec.Run(ctx, "rec_control", "reload-zones")
@@ -317,6 +330,35 @@ func (m *Manager) applyChange(ctx context.Context, desired map[string]Entry, zon
 		}
 	}
 	return nil
+}
+
+// probeForwarder verifies the just-added forwarder answers for the zone,
+// retrying up to ProbeAttempts times (ProbeGap apart) and wiping the recursor
+// cache before each attempt. Returns nil on the first success, or the last
+// error after exhausting attempts. Context cancellation aborts early.
+func (m *Manager) probeForwarder(ctx context.Context, zone string) error {
+	var err error
+	for i := 0; i < m.opts.ProbeAttempts; i++ {
+		// Clear any cached (possibly negative) answer so this attempt reflects
+		// the current auth state, not a stale NXDOMAIN from before the zone
+		// finished loading. Also clears the positive PRE-forwarder answer on
+		// a re-bind (the original single-wipe rationale, PRs #86/#87/#88).
+		_, _ = m.opts.Exec.Run(ctx, "rec_control", "wipe-cache", zone+"$")
+		if err = m.opts.Prober.ProbeZone(ctx, zone); err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if i < m.opts.ProbeAttempts-1 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(m.opts.ProbeGap):
+			}
+		}
+	}
+	return err
 }
 
 // rollback moves .bak back to live. Best-effort; if there's no .bak (first

--- a/panel-agent/internal/pdnsrecursor/manager_test.go
+++ b/panel-agent/internal/pdnsrecursor/manager_test.go
@@ -33,17 +33,19 @@ func (f *fakeExec) Run(_ context.Context, name string, args ...string) ([]byte, 
 }
 
 type fakeProbe struct {
-	mu      sync.Mutex
-	calls   []string
-	fail    bool
-	failErr error
+	mu        sync.Mutex
+	calls     []string
+	fail      bool
+	failFirst int // fail the first N calls, then succeed (GH #896 retry test)
+	failErr   error
 }
 
 func (f *fakeProbe) ProbeZone(_ context.Context, zone string) error {
 	f.mu.Lock()
 	f.calls = append(f.calls, zone)
+	n := len(f.calls)
 	f.mu.Unlock()
-	if f.fail {
+	if f.fail || (f.failFirst > 0 && n <= f.failFirst) {
 		if f.failErr != nil {
 			return f.failErr
 		}
@@ -66,6 +68,7 @@ func newTestManager(t *testing.T) (*Manager, *fakeExec, *fakeProbe, string) {
 		Prober:       probe,
 		SkipChown:    true, // no pdns/pdns-recursor group on CI boxes
 		Clock:        func() time.Time { return time.Unix(1700000000, 0) },
+		ProbeGap:     time.Millisecond, // keep the GH #896 retry loop instant in tests
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -159,6 +162,51 @@ func TestAddZone_RollbackOnProbeFail(t *testing.T) {
 	after := readLive(t, m)
 	if after != before {
 		t.Errorf("rollback failed.\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+// GH #896: a freshly-created zone's forwarder must survive an INITIAL probe
+// failure — the probe is retried and the forwarder is KEPT once the auth
+// catches up, instead of rolling back and leaving the zone unresolvable until
+// the next reconcile pass (the dead-domain window johnnyq reported).
+func TestAddZone_ProbeRetry_KeepsForwarderWhenAuthCatchesUp(t *testing.T) {
+	m, _, probe, _ := newTestManager(t)
+	ctx := context.Background()
+
+	// Fail the first 2 probes, then answer — mimics a fresh auth zone that
+	// takes a moment after reload-zones to respond.
+	probe.failFirst = 2
+	changed, err := m.AddZone(ctx, Entry{"fresh.example", "127.0.0.1", 5300})
+	if err != nil {
+		t.Fatalf("AddZone should succeed once the probe retries into a good answer: %v", err)
+	}
+	if !changed {
+		t.Error("AddZone should report Changed=true")
+	}
+	if got := len(probe.calls); got != 3 {
+		t.Errorf("expected 3 probe attempts (2 fail + 1 pass); got %d", got)
+	}
+	if !strings.Contains(readLive(t, m), "fresh.example=127.0.0.1:5300") {
+		t.Errorf("forwarder must be KEPT after the probe eventually succeeds; live=%q", readLive(t, m))
+	}
+}
+
+// A forwarder whose probe NEVER answers still rolls back after exhausting the
+// retries — the safety the rollback provides is preserved.
+func TestAddZone_ProbeRetry_RollsBackWhenNeverAnswers(t *testing.T) {
+	m, _, probe, _ := newTestManager(t)
+	ctx := context.Background()
+
+	probe.fail = true
+	_, err := m.AddZone(ctx, Entry{"dead.example", "127.0.0.1", 5300})
+	if err == nil {
+		t.Fatal("AddZone with a permanently-failing probe must error")
+	}
+	if got := len(probe.calls); got != m.opts.ProbeAttempts {
+		t.Errorf("expected %d probe attempts before giving up; got %d", m.opts.ProbeAttempts, got)
+	}
+	if strings.Contains(readLive(t, m), "dead.example") {
+		t.Errorf("forwarder must be rolled back when the probe never answers; live=%q", readLive(t, m))
 	}
 }
 

--- a/panel-api/internal/reconciler/reconciler_pdns_recursor.go
+++ b/panel-api/internal/reconciler/reconciler_pdns_recursor.go
@@ -20,7 +20,11 @@ func (r *Reconciler) reconcileRecursorForward(ctx context.Context, zone string) 
 	if zone == "" {
 		return
 	}
-	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	// 30s (was 10s): the agent's AddZone now retries the post-add probe with a
+	// short backoff so a freshly-created zone's forwarder isn't rolled back on
+	// the first racy probe (GH #896). The retry budget must fit inside this
+	// timeout. Existing zones still confirm on the first probe (~1-2s).
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	raw, err := r.agent.Call(cctx, "pdns.recursor_add_zone", map[string]any{
 		"zone": zone,


### PR DESCRIPTION
## The actual cause of johnnyq's dead-domain window

When a domain is created, the agent adds a **pdns-recursor forwarder** for its zone, then **probes** it (LookupNS via the recursor) to confirm it answers. A freshly-created authoritative zone takes a couple of seconds after `rec_control reload-zones` to respond — so that **single** probe failed, and `applyChange` **rolled the forwarder back**. With no forwarder, the box's own recursor returned `no such host` for the new (sub)domain → dead page + certbot NXDOMAIN → until the **next reconcile pass** re-added it and happened to probe after the zone settled. Up to a minute per pass; minutes on a busy box.

**Box-observed** on a fresh subdomain (this session): forwarder rolled back at **T+9s**, only re-added at **T+67s** (`recursor forwarder added` on the next pass) — exactly the window johnnyq kept hitting.

## Fix

`probeForwarder` retries the probe (default **5×, 2s apart**), **wiping the recursor cache before each attempt** so a just-cached NXDOMAIN can't pin every retry to failure. The forwarder is **kept** the moment the probe passes; a genuinely-broken forwarder that never answers **still rolls back** after the retries (the safety that rollback provides is preserved). The reconciler's `recursor_add_zone` timeout is raised **10s → 30s** so the retry budget fits.

Complements **#1048** (immediate reconcile on create): #1048 makes the first reconcile fire at once; this makes that first pass actually *stick* the forwarder instead of rolling it back.

## Tests

- Fresh zone whose probe fails twice then answers → forwarder **kept**, 3 probe attempts.
- Permanently-failing probe → **still rolls back** after exhausting retries.
- `go test` (pdnsrecursor, reconciler) green.

Box verification (fresh subdomain resolves in seconds, no rollback) to follow before the #896 reply — per deliver-then-post; this thread has burned three retests.

GH #896