### PR TITLE
fix(dns): bound pdns zone-cache blindness so new domains resolve fast (GH #896)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4015,6 +4015,22 @@ local-address=${pdns_local_addresses}
 # The global allow-axfr-ips is left empty — PowerDNS denies AXFR by
 # default, and per-zone metadata takes precedence.
 disable-axfr-rectify=no
+
+# GH #896: a freshly created domain gets its OWN pdns zone, inserted
+# straight into the gmysql backend. PowerDNS caches the LIST of zones
+# (the "zone cache") and only re-reads it every zone-cache-refresh-
+# interval seconds — default 300. Until that refresh, the new zone does
+# not exist as far as pdns is concerned: queries fall through to the
+# parent zone and answer NXDOMAIN, so a brand-new (sub)domain is dead
+# for up to five minutes even though the SQL rows are all there.
+# Measured live: 161 s of NXDOMAIN on a fresh subdomain.
+#
+# No control-channel fix exists on 4.8: pdns_control zonecache-reload
+# is 4.9+, and rediscover / reload / purge were each verified NOT to
+# refresh this cache. Config is the only lever. 10 s keeps the cache's
+# LRU benefits while bounding new-zone blindness to a tick; the refresh
+# is one trivial SELECT over tens of zones at panel scale.
+zone-cache-refresh-interval=10
 PDNSCONF
 
   # Idempotency: if .new matches live, skip write + restart.
@@ -5233,6 +5249,50 @@ ensure_swap() {
   echo 'vm.swappiness=10' > /etc/sysctl.d/99-jabali-swappiness.conf
   sysctl -w vm.swappiness=10 >/dev/null 2>&1 || true
   _ok "build-swap: 2 GB active at $swap_file (persists via /etc/fstab); vm.swappiness=10"
+}
+
+# ensure_pdns_zone_cache — bound PowerDNS's new-zone blindness on EXISTING
+# boxes (GH #896).
+#
+# Every panel domain gets its own pdns zone, written straight into the
+# gmysql backend. pdns caches the list of known zones and re-reads it only
+# every zone-cache-refresh-interval seconds (default 300) — until then a
+# freshly created (sub)domain answers NXDOMAIN from the parent zone even
+# though its rows are committed. Measured live: 161 s of NXDOMAIN on a
+# fresh subdomain. On pdns 4.8 there is NO control-channel refresh
+# (zonecache-reload is 4.9+; rediscover/reload/purge verified not to touch
+# this cache), so the interval itself is the only lever.
+#
+# Fresh installs get the setting from the 01-jabali-mysql.conf template in
+# install_powerdns. That function does NOT run on `jabali update`
+# (provision_new_software), so this converger carries the setting to the
+# existing fleet — the ensure_tmp_hardening / #1006 lesson: a template-only
+# change never reaches a box that only ever updates. Idempotent; restarts
+# pdns only when the line actually changed, and only if the unit is active
+# (a dns-module-off box keeps pdns masked).
+ensure_pdns_zone_cache() {
+  local conf=/etc/powerdns/pdns.d/01-jabali-mysql.conf
+  [[ -f "$conf" ]] || return 0   # dns module never installed here
+  if grep -q '^zone-cache-refresh-interval=10$' "$conf"; then
+    return 0
+  fi
+  if grep -q '^zone-cache-refresh-interval=' "$conf"; then
+    sed -i 's/^zone-cache-refresh-interval=.*/zone-cache-refresh-interval=10/' "$conf"
+  else
+    cat >> "$conf" <<'ZONECACHE'
+
+# GH #896: bound new-zone blindness — see install_powerdns for the full
+# rationale. Appended by ensure_pdns_zone_cache on update.
+zone-cache-refresh-interval=10
+ZONECACHE
+  fi
+  if systemctl is-active --quiet pdns 2>/dev/null; then
+    systemctl restart pdns \
+      && _ok "pdns zone-cache-refresh-interval=10 applied (new zones visible within ~10 s)" \
+      || _warn "pdns restart failed after zone-cache config — new setting applies on next pdns restart"
+  else
+    _log "pdns not active — zone-cache setting staged in $conf for next start"
+  fi
 }
 
 # ensure_tmp_hardening — assert the kernel's /tmp symlink + hardlink
@@ -14279,6 +14339,10 @@ provision_new_software() {
   # every update, so a host that has the DNS module off stops reporting the
   # unconfigured pdns unit as "failed" on the dashboard + Server Status.
   converge_pdns_masking
+  # GH #896: carry zone-cache-refresh-interval=10 to boxes that only ever
+  # update — install_powerdns (whose template now ships it) does not run
+  # on this path.
+  ensure_pdns_zone_cache
 
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator

--- a/install/tests/test_pdns_zone_cache.sh
+++ b/install/tests/test_pdns_zone_cache.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# install/tests/test_pdns_zone_cache.sh — regression coverage for GH #896:
+# a freshly created (sub)domain answered NXDOMAIN from our own authoritative
+# pdns for up to 5 minutes (161 s measured live).
+#
+# Every panel domain gets its own pdns zone, inserted straight into the
+# gmysql backend. pdns caches the LIST of known zones and re-reads it every
+# zone-cache-refresh-interval seconds (default 300); until then the new zone
+# does not exist for pdns and queries fall through to the parent zone. On
+# pdns 4.8 there is no control-channel refresh (zonecache-reload is 4.9+,
+# and rediscover/reload/purge were each verified NOT to touch this cache),
+# so the interval is the only lever.
+#
+# Asserts install.sh ships BOTH halves:
+#   1. The 01-jabali-mysql.conf template (fresh installs) pins
+#      zone-cache-refresh-interval=10.
+#   2. ensure_pdns_zone_cache converges the setting onto EXISTING boxes:
+#      appends when absent, rewrites when present-with-other-value,
+#      no-ops when already correct, and skips hosts without the conf
+#      (dns module never installed).
+#   3. provision_new_software (the `jabali update` path) calls it —
+#      install_powerdns does NOT run on update, so without this call the
+#      fix would never reach a box that only ever updates (the #1006
+#      ensure_tmp_hardening lesson).
+#
+# Run from repo root:
+#     bash install/tests/test_pdns_zone_cache.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# --- 1. Fresh-install template carries the setting. ---
+template=$(awk '/cat > "\$pdns_conf_new" <<PDNSCONF/,/^PDNSCONF$/' install.sh)
+if ! grep -q '^zone-cache-refresh-interval=10$' <<<"$template"; then
+  echo "FAIL: 01-jabali-mysql.conf template does not pin zone-cache-refresh-interval=10 — fresh installs get 300 s of new-zone blindness"
+  fail=1
+fi
+
+# --- 2. The converger behaves, exercised for real against temp files. ---
+fn_src=$(awk '/^ensure_pdns_zone_cache\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: ensure_pdns_zone_cache not defined in install.sh"
+  exit 1
+fi
+# Stub the host-touching pieces so the function body runs anywhere.
+systemctl() { return 1; }   # "pdns not active" branch — no restarts in tests
+_ok()   { :; }
+_log()  { :; }
+_warn() { :; }
+eval "$fn_src"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# The function hardcodes the conf path; re-point it through a wrapper that
+# rewrites the local variable via a subshell copy of the function.
+run_converger() { # $1 = conf file to converge (or missing)
+  local conf="$1"
+  ( eval "${fn_src/\/etc\/powerdns\/pdns.d\/01-jabali-mysql.conf/$conf}"
+    ensure_pdns_zone_cache )
+}
+
+# 2a. Absent line → appended.
+conf_a="$tmpdir/a.conf"; printf 'launch=gmysql\n' > "$conf_a"
+run_converger "$conf_a"
+if ! grep -q '^zone-cache-refresh-interval=10$' "$conf_a"; then
+  echo "FAIL: converger did not append the setting to a conf that lacked it"
+  fail=1
+fi
+
+# 2b. Present with another value → rewritten, not duplicated.
+conf_b="$tmpdir/b.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=300\n' > "$conf_b"
+run_converger "$conf_b"
+if [[ "$(grep -c '^zone-cache-refresh-interval=' "$conf_b")" != "1" ]] \
+   || ! grep -q '^zone-cache-refresh-interval=10$' "$conf_b"; then
+  echo "FAIL: converger must rewrite an existing value to 10 without duplicating the key"
+  fail=1
+fi
+
+# 2c. Already correct → byte-identical (idempotency; a rewrite here would
+# restart pdns on every single update).
+conf_c="$tmpdir/c.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=10\n' > "$conf_c"
+before=$(cat "$conf_c"); run_converger "$conf_c"
+if [[ "$(cat "$conf_c")" != "$before" ]]; then
+  echo "FAIL: converger rewrote an already-correct conf — every update would restart pdns"
+  fail=1
+fi
+
+# 2d. Conf missing (dns module never installed) → no file created.
+run_converger "$tmpdir/missing.conf"
+if [[ -e "$tmpdir/missing.conf" ]]; then
+  echo "FAIL: converger created a pdns conf on a host without the dns module"
+  fail=1
+fi
+
+# --- 3. The update path actually calls it. ---
+upd_src=$(awk '/^provision_new_software\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'ensure_pdns_zone_cache' <<<"$upd_src"; then
+  echo "FAIL: provision_new_software does not call ensure_pdns_zone_cache — existing boxes never get the fix (install_powerdns does not run on update)"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then exit 1; fi
+echo "PASS: pdns zone-cache bounded on both install paths (GH #896)"


### PR DESCRIPTION
The reporter's [latest retest](https://github.com/shukiv/jabali-panel/issues/896#issuecomment-5235473260) nailed it: `dig` against the jabali server itself showed the new subdomain's record **absent for ~3 minutes** after creation, while a manually added A record answered instantly. Reproduced through the product path: **161 s of NXDOMAIN** on a fresh subdomain.

## Root cause — a different cache than the one we already fixed

Every panel domain gets its **own pdns zone**, inserted straight into the gmysql backend. PowerDNS caches the *list of known zones* (the zone cache) and re-reads it every `zone-cache-refresh-interval` seconds — **default 300**. Until that refresh, the new zone doesn't exist for pdns: queries fall through to the parent zone and answer NXDOMAIN.

The #86–#88 `pdns_control purge` scar covered the **query** cache. This one has **no runtime poke on pdns 4.8**: `zonecache-reload` is 4.9+, and I verified live that `rediscover`, `reload`, and `purge` each leave a fresh zone REFUSED. Config is the only lever.

Why the reporter's manual A record was instant: it went into an *existing* zone (already in the zone cache), and the upsert's query-cache purge did the rest — which is exactly the split in their repro.

## The fix

`zone-cache-refresh-interval=10` — keeps the cache's LRU benefits, bounds new-zone blindness to ~10 s; the refresh is one trivial SELECT over tens of zones at panel scale.

Shipped on **both** paths (the #1006 `ensure_tmp_hardening` lesson — `install_powerdns` does not run on `jabali update`, so a template-only change never reaches a box that only ever updates):

- the `01-jabali-mysql.conf` template carries it for fresh installs (the existing cmp guard rewrites + restarts pdns when the template changes)
- `ensure_pdns_zone_cache` converges it on update: appends when absent, rewrites when present-with-other-value, **byte-identical no-op when correct** (a rewrite would restart pdns on every update), skips hosts without the dns module

## Measured

| | time to NOERROR on a fresh subdomain |
|---|---|
| before | **161 s** |
| after (this fix, live on testserver) | **40 s** |

The residual ~40 s is reconciler tick lag — addressed separately by `fix-gh896-schedule-on-domain-create` (immediate reconcile on create, in flight by another session; zero file overlap). Together: ~10 s.

## Test plan

- [x] Regression test runs the **real converger body** against temp files: append, rewrite-without-duplicate, idempotent no-op (a rewrite would restart pdns every update), and module-off skip; asserts the template line and that `provision_new_software` actually calls the converger
- [x] `bash -n install.sh` clean; phantom-function lint + repo-dir-ordering Go guards pass
- [x] CI runs `install/tests/*.sh` by glob — the new test is picked up automatically
- [x] Live E2E as measured above; applied via the exact function `jabali update` will run
- [x] Test domains cleaned up (and their pdns zones reaped via `dns.zone.delete`)

## Side-finding, not addressed here

Deleting a domain removes the panel's `dns_zones` row but **orphans the pdns-backend zone** — the reconciler's `dns.zone.delete` never fires because the panel row (its only handle) is already gone. Same orphan class as #1010, DNS edition. Filing separately.