### PR TITLE
fix(dns): add the recursor forwarder in the immediate reconcile too (GH #896)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1020,6 +1020,15 @@ func (r *Reconciler) ReconcileOne(ctx context.Context, domainID string) error {
 	r.reconcileDNSZone(dnsCtx, domain)
 	dnsCancel()
 
+	// GH #896: add the pdns-recursor forwarder in this immediate reconcile too,
+	// not just the periodic loop. reconcileDNSZone above pushed the zone to the
+	// authoritative server; without also binding the recursor forwarder here, a
+	// freshly-created domain scheduled via the create handler doesn't resolve on
+	// the box's own recursor until the next full loop pass adds it — the tens of
+	// seconds johnnyq saw even after the zone existed. The forwarder add is
+	// idempotent and self-heals, so running it here + on the loop is safe.
+	r.reconcileRecursorForward(ctx, domain.Name)
+
 	// Converge SSL state next so createDomainOnAgent picks up any
 	// newly-issued (or revoked) cert paths when it regenerates the vhost.
 	sslCtx, sslCancel := context.WithTimeout(ctx, 2*time.Minute)


### PR DESCRIPTION
## Final piece of the fresh-domain resolution fix (GH #896)

Three fixes converge here:
1. **#1048** — the create handler now Schedules an immediate `ReconcileOne`.
2. **#1050** — the recursor-forwarder probe retries instead of rolling back on a fresh zone.
3. **this PR** — `reconcileRecursorForward` (binds the box's pdns-recursor to the new zone so the box itself can resolve it) was only called from the periodic-loop path (`reconcileEnabledDomain`), **not** from `ReconcileOne`.

So even with #1048 + #1050, a scheduled create pushed the zone to the authoritative server immediately but the **recursor forwarder waited for the next full loop pass** — the tens of seconds a fresh (sub)domain still took to resolve on the box. **Box-observed after #1048/#1050:** forwarder added at **+33s** (on the loop), and no rollback (so #1050 works) — but not immediate.

**Fix:** call `reconcileRecursorForward` right after `reconcileDNSZone` in `ReconcileOne`. Idempotent + self-healing, so running it here and on the loop is safe.

With all three, a freshly-created domain: create → immediate reconcile → zone pushed to auth + recursor forwarder bound (with retry) → resolves in seconds.

`go build` + `go test ./internal/reconciler/` green. Box verification (fresh subdomain resolves in seconds) to follow before the #896 reply.

GH #896