### PR TITLE
feat(ssl): DNS-01 fallback so CDN-fronted domains get real LE origin certs (JAB-235)

### DIFF
--- a/hostedsvc/cfdns.go
+++ b/hostedsvc/cfdns.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -31,6 +32,13 @@ func NewCloudflareDNS(token, zoneID string) *CloudflareDNS {
 		HTTP:   &http.Client{Timeout: 10 * time.Second},
 		api:    "https://api.cloudflare.com/client/v4",
 	}
+}
+
+// NewCloudflareAPI returns a client bound to no particular zone — the
+// customer-zone ACME DNS-01 path (JAB-235) resolves the zone id per domain
+// via FindZoneID and passes it to the *TXT methods explicitly.
+func NewCloudflareAPI(token string) *CloudflareDNS {
+	return NewCloudflareDNS(token, "")
 }
 
 type cfRecord struct {
@@ -81,8 +89,12 @@ func (c *CloudflareDNS) do(ctx context.Context, method, path string, body any) (
 // listRecords returns every record for name+type (a name can hold multiple
 // TXT records — needed for the dual-value wildcard challenge).
 func (c *CloudflareDNS) listRecords(ctx context.Context, name, rtype string) ([]cfRecord, error) {
+	return c.listRecordsIn(ctx, c.ZoneID, name, rtype)
+}
+
+func (c *CloudflareDNS) listRecordsIn(ctx context.Context, zoneID, name, rtype string) ([]cfRecord, error) {
 	q := url.Values{"name": {name}, "type": {rtype}}
-	resp, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/zones/%s/dns_records?%s", c.ZoneID, q.Encode()), nil)
+	resp, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/zones/%s/dns_records?%s", zoneID, q.Encode()), nil)
 	if err != nil {
 		return nil, fmt.Errorf("cf list: %w", err)
 	}
@@ -164,8 +176,21 @@ func (c *CloudflareDNS) EnsureWildcardA(ctx context.Context, label, ipv4 string)
 // so a replace would clobber the first. On CF, multiple values = multiple TXT
 // records at one name; we create one per value, skipping an exact duplicate.
 func (c *CloudflareDNS) SetChallenge(ctx context.Context, label, value string) error {
-	name := "_acme-challenge." + FQDN(label)
-	existing, err := c.listRecords(ctx, name, "TXT")
+	return c.SetChallengeTXT(ctx, c.ZoneID, "_acme-challenge."+FQDN(label), value)
+}
+
+// SetChallengeTXT adds a challenge value at an explicit record name in an
+// explicit zone — the JAB-235 customer-zone path, where the name is a full
+// customer FQDN (_acme-challenge.example.co.il) rather than a hostedsvc
+// label. Same semantics as SetChallenge: add-only (a wildcard cert needs
+// the apex and the wildcard challenge live at the SAME name at once, so a
+// replace would clobber the first), duplicate-value idempotent, and capped —
+// without the cap a token holder could script distinct values and
+// accumulate thousands of TXT records, degrading the zone for everyone.
+// maxChallengeRecordsPerLabel leaves headroom for a retry that raced
+// cleanup.
+func (c *CloudflareDNS) SetChallengeTXT(ctx context.Context, zoneID, name, value string) error {
+	existing, err := c.listRecordsIn(ctx, zoneID, name, "TXT")
 	if err != nil {
 		return err
 	}
@@ -174,18 +199,11 @@ func (c *CloudflareDNS) SetChallenge(ctx context.Context, label, value string) e
 			return nil // already present
 		}
 	}
-	// SetChallenge is add-only by design (a wildcard cert needs the apex and
-	// the wildcard challenge live at the SAME name simultaneously), so without
-	// a cap a token holder could script distinct values and accumulate
-	// thousands of TXT records in the shared jabalihosted.com zone, degrading
-	// zone size and list performance for every other tenant. Two is the
-	// legitimate maximum; maxChallengeRecordsPerLabel leaves headroom for a
-	// retry that raced cleanup.
 	if len(existing) >= maxChallengeRecordsPerLabel {
 		return fmt.Errorf("too many pending ACME challenges for %s (%d) — run cleanup first",
 			name, len(existing))
 	}
-	resp, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", c.ZoneID),
+	resp, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", zoneID),
 		cfRecord{Type: "TXT", Name: name, Content: value, TTL: 60, Proxied: false})
 	if err != nil {
 		return fmt.Errorf("cf add challenge: %w", err)
@@ -203,19 +221,95 @@ func (c *CloudflareDNS) SetChallenge(ctx context.Context, label, value string) e
 
 // ClearChallenge removes ALL challenge TXT records at the label's name.
 func (c *CloudflareDNS) ClearChallenge(ctx context.Context, label string) error {
-	name := "_acme-challenge." + FQDN(label)
-	recs, err := c.listRecords(ctx, name, "TXT")
+	return c.ClearChallengeTXT(ctx, c.ZoneID, "_acme-challenge."+FQDN(label))
+}
+
+// ClearChallengeTXT removes ALL challenge TXT records at an explicit record
+// name in an explicit zone. Idempotent — clearing an absent name is a no-op.
+func (c *CloudflareDNS) ClearChallengeTXT(ctx context.Context, zoneID, name string) error {
+	recs, err := c.listRecordsIn(ctx, zoneID, name, "TXT")
 	if err != nil {
 		return err
 	}
 	for _, r := range recs {
-		resp, derr := c.do(ctx, http.MethodDelete, fmt.Sprintf("/zones/%s/dns_records/%s", c.ZoneID, r.ID), nil)
+		resp, derr := c.do(ctx, http.MethodDelete, fmt.Sprintf("/zones/%s/dns_records/%s", zoneID, r.ID), nil)
 		if derr != nil {
 			return fmt.Errorf("cf clear challenge: %w", derr)
 		}
 		resp.Body.Close()
 	}
 	return nil
+}
+
+type cfZone struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type cfZoneListResp struct {
+	Success    bool    `json:"success"`
+	Errors     []cfErr `json:"errors"`
+	Result     []cfZone `json:"result"`
+	ResultInfo struct {
+		TotalCount int `json:"total_count"`
+	} `json:"result_info"`
+}
+
+// FindZoneID resolves the zone id for an EXACT zone name via the stored
+// token. Returns "" (no error) when the token has no access to the zone —
+// the caller surfaces that as "customer must grant access", not a failure.
+func (c *CloudflareDNS) FindZoneID(ctx context.Context, name string) (string, error) {
+	q := url.Values{"name": {name}, "status": {"active"}, "per_page": {"5"}}
+	resp, err := c.do(ctx, http.MethodGet, "/zones?"+q.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("cf zone lookup: %w", err)
+	}
+	defer resp.Body.Close()
+	var zr cfZoneListResp
+	if err := json.NewDecoder(resp.Body).Decode(&zr); err != nil {
+		return "", fmt.Errorf("cf zone lookup decode: %w", err)
+	}
+	if !zr.Success {
+		return "", fmt.Errorf("cf zone lookup %s: %v", name, zr.Errors)
+	}
+	for _, z := range zr.Result {
+		if strings.EqualFold(z.Name, name) {
+			return z.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// VerifyToken checks the token against Cloudflare's verify endpoint and
+// reports how many zones it can see — shown to the operator so "token
+// saved" also says "and it covers N zones".
+func (c *CloudflareDNS) VerifyToken(ctx context.Context) (zones int, err error) {
+	resp, err := c.do(ctx, http.MethodGet, "/user/tokens/verify", nil)
+	if err != nil {
+		return 0, fmt.Errorf("cf token verify: %w", err)
+	}
+	var vr cfWriteResp
+	verr := json.NewDecoder(resp.Body).Decode(&vr)
+	resp.Body.Close()
+	if verr != nil {
+		return 0, fmt.Errorf("cf token verify decode: %w", verr)
+	}
+	if !vr.Success {
+		return 0, fmt.Errorf("cloudflare rejected the token: %v", vr.Errors)
+	}
+	zresp, err := c.do(ctx, http.MethodGet, "/zones?per_page=1", nil)
+	if err != nil {
+		return 0, fmt.Errorf("cf zone count: %w", err)
+	}
+	defer zresp.Body.Close()
+	var zr cfZoneListResp
+	if err := json.NewDecoder(zresp.Body).Decode(&zr); err != nil {
+		return 0, fmt.Errorf("cf zone count decode: %w", err)
+	}
+	if !zr.Success {
+		return 0, fmt.Errorf("cf zone count: %v", zr.Errors)
+	}
+	return zr.ResultInfo.TotalCount, nil
 }
 
 func (c *CloudflareDNS) RemoveLabel(ctx context.Context, label string) error {

--- a/hostedsvc/cfdns_test.go
+++ b/hostedsvc/cfdns_test.go
@@ -3,6 +3,7 @@ package hostedsvc
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,12 +16,13 @@ import (
 type fakeCF struct {
 	mu      sync.Mutex
 	records map[string]cfRecord // id -> record
+	zones   map[string]string   // zone name -> id (JAB-235 account-level API)
 	nextID  int
 	writes  []cfRecord // every created/updated record, in order
 }
 
 func newFakeCF(t *testing.T) (*httptest.Server, *fakeCF) {
-	f := &fakeCF{records: map[string]cfRecord{}}
+	f := &fakeCF{records: map[string]cfRecord{}, zones: map[string]string{}}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer test-token" {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -29,6 +31,24 @@ func newFakeCF(t *testing.T) (*httptest.Server, *fakeCF) {
 		f.mu.Lock()
 		defer f.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
+
+		// Account-level endpoints (JAB-235): token verify + zone list.
+		if r.URL.Path == "/user/tokens/verify" {
+			json.NewEncoder(w).Encode(cfWriteResp{Success: true})
+			return
+		}
+		if r.URL.Path == "/zones" {
+			var out []cfZone
+			if name := r.URL.Query().Get("name"); name != "" {
+				if id, ok := f.zones[name]; ok {
+					out = append(out, cfZone{ID: id, Name: name})
+				}
+			}
+			zr := cfZoneListResp{Success: true, Result: out}
+			zr.ResultInfo.TotalCount = len(f.zones)
+			json.NewEncoder(w).Encode(zr)
+			return
+		}
 
 		// /zones/{zone}/dns_records[/{id}]
 		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
@@ -190,6 +210,85 @@ func TestCloudflareDNS_RemoveLabel(t *testing.T) {
 	}
 	if _, ok := f.byName("_acme-challenge.192-0-2-7.jabalihosted.com", "TXT"); ok {
 		t.Error("challenge survived RemoveLabel")
+	}
+}
+
+// JAB-235: challenge writes into an explicit customer zone with a full
+// FQDN record name — no hostedsvc base-domain coupling.
+func TestCloudflareDNS_ChallengeTXTCustomerZone(t *testing.T) {
+	c, f := newTestCFDNS(t)
+	ctx := context.Background()
+	name := "_acme-challenge.arama.co.il"
+	if err := c.SetChallengeTXT(ctx, "zone-cust", name, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	rec, ok := f.byName(name, "TXT")
+	if !ok || rec.Content != "v1" || rec.Proxied {
+		t.Fatalf("customer-zone challenge TXT wrong: %+v ok=%v", rec, ok)
+	}
+	// Add-only multi-value + duplicate idempotence survive the generalization.
+	if err := c.SetChallengeTXT(ctx, "zone-cust", name, "v2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.SetChallengeTXT(ctx, "zone-cust", name, "v1"); err != nil {
+		t.Fatal(err)
+	}
+	recs, _ := c.listRecordsIn(ctx, "zone-cust", name, "TXT")
+	if len(recs) != 2 {
+		t.Fatalf("want 2 challenge values, got %d", len(recs))
+	}
+	// The cap still holds for arbitrary FQDNs: fill to the limit, then the
+	// next distinct value must be refused.
+	for i := len(recs); i < maxChallengeRecordsPerLabel; i++ {
+		if err := c.SetChallengeTXT(ctx, "zone-cust", name, fmt.Sprintf("fill-%d", i)); err != nil {
+			t.Fatalf("fill %d: %v", i, err)
+		}
+	}
+	if err := c.SetChallengeTXT(ctx, "zone-cust", name, "one-too-many"); err == nil {
+		t.Fatal("value beyond maxChallengeRecordsPerLabel must be refused")
+	}
+	if err := c.ClearChallengeTXT(ctx, "zone-cust", name); err != nil {
+		t.Fatal(err)
+	}
+	if recs, _ := c.listRecordsIn(ctx, "zone-cust", name, "TXT"); len(recs) != 0 {
+		t.Fatalf("cleanup left %d records", len(recs))
+	}
+	if err := c.ClearChallengeTXT(ctx, "zone-cust", name); err != nil {
+		t.Fatalf("idempotent clear errored: %v", err)
+	}
+}
+
+func TestCloudflareDNS_FindZoneID(t *testing.T) {
+	c, f := newTestCFDNS(t)
+	f.mu.Lock()
+	f.zones["arama.co.il"] = "zid-1"
+	f.mu.Unlock()
+	ctx := context.Background()
+	id, err := c.FindZoneID(ctx, "arama.co.il")
+	if err != nil || id != "zid-1" {
+		t.Fatalf("FindZoneID = %q, %v", id, err)
+	}
+	// A zone the token cannot see returns "" with NO error — the caller
+	// turns that into "customer must grant access", not a retry loop.
+	id, err = c.FindZoneID(ctx, "uncovered.co.il")
+	if err != nil || id != "" {
+		t.Fatalf("uncovered zone: FindZoneID = %q, %v", id, err)
+	}
+}
+
+func TestCloudflareDNS_VerifyToken(t *testing.T) {
+	c, f := newTestCFDNS(t)
+	f.mu.Lock()
+	f.zones["a.com"] = "1"
+	f.zones["b.com"] = "2"
+	f.mu.Unlock()
+	n, err := c.VerifyToken(context.Background())
+	if err != nil || n != 2 {
+		t.Fatalf("VerifyToken = %d, %v", n, err)
+	}
+	bad := &CloudflareDNS{Token: "wrong", HTTP: c.HTTP, api: c.api}
+	if _, err := bad.VerifyToken(context.Background()); err == nil {
+		t.Fatal("bad token must fail verification")
 	}
 }
 

--- a/internal/dnsverify/external_ns.go
+++ b/internal/dnsverify/external_ns.go
@@ -1,0 +1,46 @@
+package dnsverify
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"time"
+)
+
+// LookupNSExternal resolves the NS RRset for name against the external
+// resolvers — same rationale as LookupHostExternal: the local recursor
+// forwards to this box's own authoritative server, which claims every
+// locally-hosted zone regardless of where the public delegation actually
+// points, so only a public resolver can tell us who is REALLY authoritative
+// (JAB-235: a migrated domain keeps a stale local zone row while its NS
+// lives at Cloudflare).
+//
+// Hosts are returned lowercased without the trailing dot. queried=false
+// means every resolver was unreachable — the answer is inconclusive and
+// callers must fail open (behave as before), never treat it as "no
+// delegation". A definitive empty answer (NODATA/NXDOMAIN — normal for any
+// label below a zone apex) returns (nil, true).
+func LookupNSExternal(ctx context.Context, name string) (hosts []string, queried bool) {
+	for _, addr := range externalResolvers {
+		for _, proto := range []string{"udp", "tcp"} {
+			r := newDirectResolver(addr, proto)
+			lookupCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			nss, err := r.LookupNS(lookupCtx, name)
+			cancel()
+			if err == nil {
+				out := make([]string, 0, len(nss))
+				for _, ns := range nss {
+					out = append(out, strings.ToLower(strings.TrimSuffix(ns.Host, ".")))
+				}
+				return out, true
+			}
+			var derr *net.DNSError
+			if errors.As(err, &derr) && derr.IsNotFound {
+				return nil, true
+			}
+			// Unreachable resolver/transport — try the next one.
+		}
+	}
+	return nil, false
+}

--- a/panel-api/cmd/server/dns_acme_hook_cmd.go
+++ b/panel-api/cmd/server/dns_acme_hook_cmd.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/hostedsvc"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dnsverify"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dns01"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dnscompile"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -96,13 +99,81 @@ func acmeChallengeName(domain string) string {
 	return "_acme-challenge." + domain
 }
 
+// cfChallengeSettle gives Cloudflare's edge a moment to serve a freshly
+// written TXT before certbot tells Let's Encrypt to validate — CF's API
+// writes propagate to its authoritative nameservers in seconds, but a
+// failed validation costs rate-limited quota while a short sleep is free
+// (same reasoning as the pdns path's 3s).
+const cfChallengeSettle = 5 * time.Second
+
+// hookDNS01Setup builds the shared provider-decision config (JAB-235). The
+// Cloudflare client is non-nil only when a token is stored AND the sso key
+// can unseal it; without it the decision degrades to pdns-or-nothing
+// exactly as before this feature.
+func hookDNS01Setup(ctx context.Context) (dns01.Config, *hostedsvc.CloudflareDNS) {
+	cfg := dns01.Config{LookupNS: dnsverify.LookupNSExternal}
+	srv, err := repository.NewServerSettingsRepository(sharedDB).Get(ctx)
+	if err != nil || srv == nil {
+		return cfg, nil
+	}
+	cfg.OurNSHosts = []string{srv.NS1Name, srv.NS2Name}
+	if len(srv.CFAPITokenEnc) == 0 {
+		return cfg, nil
+	}
+	key := ssoKeyForCLI()
+	if key == nil {
+		return cfg, nil
+	}
+	tok, err := key.Open(srv.CFAPITokenEnc)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "acme-hook: cannot unseal the Cloudflare API token — falling back to panel DNS only")
+		return cfg, nil
+	}
+	cf := hostedsvc.NewCloudflareAPI(string(tok))
+	cfg.CF = cf
+	return cfg, cf
+}
+
+// hookRoute decides where this hook writes the challenge for domain.
+// Cloudflare wins on a POSITIVE public-NS match even when a local zone row
+// exists — the reconciler auto-creates a dns_zones row for every domain, so
+// a migrated domain whose DNS really lives at Cloudflare still has a stale
+// local row, and writing there would leave LE querying Cloudflare for a
+// TXT that only exists in our pdns. Everything else (jabali-authoritative,
+// inconclusive NS, resolver outage) keeps the pre-JAB-235 behaviour: use
+// the local zone when there is one, else fail with a clear reason.
+func hookRoute(ctx context.Context, zones repository.DNSZoneRepository, domain string) (dns01.Route, *hostedsvc.CloudflareDNS, *models.DNSZone, error) {
+	cfg, cf := hookDNS01Setup(ctx)
+	route := dns01.AuthoritativeRoute(ctx, cfg, domain)
+	if route.Provider == dns01.ProviderCloudflare {
+		return route, cf, nil, nil
+	}
+	zone, err := findZoneForName(ctx, zones, domain)
+	if err != nil {
+		if route.Reason != "" {
+			return route, nil, nil, fmt.Errorf("%s (and no local DNS zone serves %q)", route.Reason, domain)
+		}
+		return route, nil, nil, err
+	}
+	return dns01.Route{Provider: dns01.ProviderPDNS, Zone: zone.Name}, nil, zone, nil
+}
+
 func acmeHookAuth(ctx context.Context, domain, validation string) error {
 	zones := dnsZoneRepoFromDB()
 	records := dnsRecordRepoFromDB()
 
-	zone, err := findZoneForName(ctx, zones, domain)
+	route, cf, zone, err := hookRoute(ctx, zones, domain)
 	if err != nil {
 		return err
+	}
+	if route.Provider == dns01.ProviderCloudflare {
+		name := acmeChallengeName(domain)
+		if err := cf.SetChallengeTXT(ctx, route.CFZoneID, name, validation); err != nil {
+			return fmt.Errorf("cloudflare challenge write for %s: %w", domain, err)
+		}
+		time.Sleep(cfChallengeSettle)
+		fmt.Printf("acme-hook: TXT %s set at Cloudflare (zone %s)\n", name, route.Zone)
+		return nil
 	}
 
 	managedBy := acmeDNS01ManagedBy
@@ -140,9 +211,19 @@ func acmeHookCleanup(ctx context.Context, domain, validation string) error {
 	zones := dnsZoneRepoFromDB()
 	records := dnsRecordRepoFromDB()
 
-	zone, err := findZoneForName(ctx, zones, domain)
+	route, cf, zone, err := hookRoute(ctx, zones, domain)
 	if err != nil {
 		return err
+	}
+	if route.Provider == dns01.ProviderCloudflare {
+		name := acmeChallengeName(domain)
+		// Clears ALL values at the name — mirrors the pdns path, which
+		// also reaps a crashed earlier run's stranded validations.
+		if err := cf.ClearChallengeTXT(ctx, route.CFZoneID, name); err != nil {
+			return fmt.Errorf("cloudflare challenge cleanup for %s: %w", domain, err)
+		}
+		fmt.Printf("acme-hook: challenge records for %s cleared at Cloudflare (zone %s)\n", name, route.Zone)
+		return nil
 	}
 	rows, err := records.ListByZoneID(ctx, zone.ID)
 	if err != nil {

--- a/panel-api/cmd/server/dns_acme_hook_cmd.go
+++ b/panel-api/cmd/server/dns_acme_hook_cmd.go
@@ -104,7 +104,7 @@ func acmeChallengeName(domain string) string {
 // writes propagate to its authoritative nameservers in seconds, but a
 // failed validation costs rate-limited quota while a short sleep is free
 // (same reasoning as the pdns path's 3s).
-const cfChallengeSettle = 5 * time.Second
+const cfChallengeSettle = 10 * time.Second
 
 // hookDNS01Setup builds the shared provider-decision config (JAB-235). The
 // Cloudflare client is non-nil only when a token is stored AND the sso key

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -377,6 +377,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// sso.key to seal/unseal the relay passwords; nil key (fresh install
 		// mid-bootstrap) just disables the loop until the key exists.
 		rec.WithSendmailCreds(mailboxRepo, ssoKeyPtr)
+		// JAB-235 — DNS-01 fallback for CDN-fronted domains. The same sso.key
+		// unseals the stored Cloudflare API token; nil key keeps Cloudflare
+		// DNS-01 unavailable (pdns-authoritative zones still work).
+		rec.WithDNS01Key(ssoKeyPtr)
 		deps.ManagedIPs = managedIPRepo
 		deps.Reconciler = rec
 		deps.DNSZones = dnsZoneRepo

--- a/panel-api/internal/api/domains_ssl_badge_test.go
+++ b/panel-api/internal/api/domains_ssl_badge_test.go
@@ -33,6 +33,8 @@ func (m *mockSSLCertsForBadge) FindByDomainIDs(_ context.Context, ids []string) 
 }
 
 // Stubs to satisfy SSLCertificateRepository.
+func (m *mockSSLCertsForBadge) SetIssueMethod(context.Context, string, string) error { return nil }
+
 func (m *mockSSLCertsForBadge) Create(context.Context, *models.SSLCertificate) error {
 	return nil
 }

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1028,6 +1028,41 @@ paths:
         "200": { description: "Claimed; body carries fqdn" }
         "422": { description: "code_invalid / code_attempts / bad_source" }
         "502": { description: Hostname service unreachable }
+  /admin/settings/cloudflare-token:
+    get:
+      tags: [Server Settings]
+      summary: Whether a Cloudflare API token is configured for the DNS-01 fallback (admin, JAB-235)
+      description: |
+        Reports configured yes/no only — the token itself is sealed at rest
+        (sso.key AES-256-GCM) and never returned by any endpoint.
+      responses:
+        "200": { description: "{ configured: bool }" }
+    put:
+      tags: [Server Settings]
+      summary: Store the Cloudflare API token behind the ACME DNS-01 fallback (admin, JAB-235)
+      description: |
+        Verifies the token against Cloudflare (/user/tokens/verify) before
+        storing it sealed. The token needs Zone:DNS:Edit + Zone:Read on the
+        customer zones it should cover; a dedicated scoped token is advised.
+        The response reports how many zones the token can see.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [token]
+              properties:
+                token: { type: string }
+      responses:
+        "200": { description: "{ configured: true, zones: n }" }
+        "422": { description: Cloudflare rejected the token }
+        "503": { description: sso.key unavailable — cannot store securely }
+    delete:
+      tags: [Server Settings]
+      summary: Clear the stored Cloudflare API token (admin, JAB-235)
+      responses:
+        "200": { description: "{ configured: false }" }
   /admin/settings:
     get:
       tags: [Server Settings]

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -21,12 +21,20 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
 type ServerSettingsHandlerConfig struct {
 	Repo  repository.ServerSettingsRepository
 	Agent agent.AgentInterface
 	Log   *slog.Logger
+	// SSOKey seals the Cloudflare API token at rest (JAB-235). Nil disables
+	// the token endpoints (503) — a panel without sso.key must not hold the
+	// secret in plaintext.
+	SSOKey *ssokey.Key
+	// CFVerify overrides the Cloudflare token-verification call in tests.
+	// Nil = verify against the real Cloudflare API.
+	CFVerify func(ctx context.Context, token string) (zones int, err error)
 }
 
 // RegisterServerSettingsRoutes mounts server settings endpoints under the
@@ -47,6 +55,10 @@ func RegisterServerSettingsRoutes(g *gin.RouterGroup, cfg ServerSettingsHandlerC
 	// JAB-213: activate a free jabalihosted.com hostname from Server Settings.
 	admin.POST("/free-hostname/register", h.freeHostnameRegister)
 	admin.POST("/free-hostname/claim", h.freeHostnameClaim)
+	// JAB-235: the Cloudflare API token behind the ACME DNS-01 fallback.
+	admin.GET("/cloudflare-token", h.cfTokenStatus)
+	admin.PUT("/cloudflare-token", h.cfTokenSet)
+	admin.DELETE("/cloudflare-token", h.cfTokenClear)
 }
 
 type serverSettingsHandler struct{ cfg ServerSettingsHandlerConfig }

--- a/panel-api/internal/api/ssl_cloudflare_token.go
+++ b/panel-api/internal/api/ssl_cloudflare_token.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/hostedsvc"
+)
+
+// JAB-235 — the Cloudflare API token behind the DNS-01 fallback.
+//
+// The token lets the panel write _acme-challenge TXT records into
+// Cloudflare-hosted customer zones, so CDN-fronted domains still get a real
+// Let's Encrypt origin cert. It is a high-value secret (DNS write access to
+// every zone it covers): stored ONLY sealed with the sso key
+// (AES-256-GCM, server_settings.cf_api_token_enc), written ONLY through
+// these endpoints, and NEVER returned by any response — status reports
+// configured yes/no. Least privilege: advise a dedicated token scoped to
+// Zone:DNS:Edit + Zone:Read on the zones it should cover.
+
+// cfTokenMaxLen bounds the accepted token length — real CF tokens are
+// ~40 chars; anything much larger is garbage (and must not be sealed into
+// the varbinary(512) column, which caps the envelope).
+const cfTokenMaxLen = 256
+
+type cfTokenStatusResponse struct {
+	Configured bool `json:"configured"`
+}
+
+type cfTokenSetRequest struct {
+	Token string `json:"token"`
+}
+
+type cfTokenSetResponse struct {
+	Configured bool `json:"configured"`
+	Zones      int  `json:"zones"`
+}
+
+func (h *serverSettingsHandler) cfTokenStatus(c *gin.Context) {
+	s, err := h.cfg.Repo.Get(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "settings_read_failed", "detail": "could not read server settings"})
+		return
+	}
+	c.JSON(http.StatusOK, cfTokenStatusResponse{Configured: s != nil && len(s.CFAPITokenEnc) > 0})
+}
+
+func (h *serverSettingsHandler) cfTokenSet(c *gin.Context) {
+	var req cfTokenSetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": "body must be {\"token\": \"...\"}"})
+		return
+	}
+	token := strings.TrimSpace(req.Token)
+	if token == "" || len(token) > cfTokenMaxLen {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_token", "detail": "token is empty or too long"})
+		return
+	}
+	if h.cfg.SSOKey == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "sso_key_unavailable", "detail": "the panel's sso.key is not configured — cannot store the token securely"})
+		return
+	}
+
+	// Verify against Cloudflare BEFORE storing — a mistyped token that only
+	// fails at issuance time would surface days later as a cert error.
+	verify := h.cfg.CFVerify
+	if verify == nil {
+		verify = func(ctx context.Context, tok string) (int, error) {
+			return hostedsvc.NewCloudflareAPI(tok).VerifyToken(ctx)
+		}
+	}
+	verifyCtx, cancel := context.WithTimeout(c.Request.Context(), 20*time.Second)
+	zones, err := verify(verifyCtx, token)
+	cancel()
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "token_verify_failed", "detail": err.Error()})
+		return
+	}
+
+	sealed, err := h.cfg.SSOKey.Seal([]byte(token))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "seal_failed", "detail": "could not encrypt the token"})
+		return
+	}
+	ctx := c.Request.Context()
+	s, err := h.cfg.Repo.Get(ctx)
+	if err != nil || s == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "settings_read_failed", "detail": "could not read server settings"})
+		return
+	}
+	s.CFAPITokenEnc = sealed
+	if err := h.cfg.Repo.Upsert(ctx, s); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "settings_write_failed", "detail": "could not store the token"})
+		return
+	}
+	if h.cfg.Log != nil {
+		h.cfg.Log.Info("cloudflare API token stored for DNS-01 fallback", "zones_visible", zones)
+	}
+	c.JSON(http.StatusOK, cfTokenSetResponse{Configured: true, Zones: zones})
+}
+
+func (h *serverSettingsHandler) cfTokenClear(c *gin.Context) {
+	ctx := c.Request.Context()
+	s, err := h.cfg.Repo.Get(ctx)
+	if err != nil || s == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "settings_read_failed", "detail": "could not read server settings"})
+		return
+	}
+	s.CFAPITokenEnc = nil
+	if err := h.cfg.Repo.Upsert(ctx, s); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "settings_write_failed", "detail": "could not clear the token"})
+		return
+	}
+	if h.cfg.Log != nil {
+		h.cfg.Log.Info("cloudflare API token cleared")
+	}
+	c.JSON(http.StatusOK, cfTokenStatusResponse{Configured: false})
+}

--- a/panel-api/internal/api/ssl_cloudflare_token_test.go
+++ b/panel-api/internal/api/ssl_cloudflare_token_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// JAB-235 admin token endpoints. Pinned properties: verify-before-store, the
+// token lands SEALED (not plaintext) and never appears in any response, a
+// missing sso.key refuses storage, and clear actually clears.
+
+func testSSOKey(t *testing.T) *ssokey.Key {
+	t.Helper()
+	var k ssokey.Key
+	if _, err := rand.Read(k[:]); err != nil {
+		t.Fatal(err)
+	}
+	return &k
+}
+
+func cfTokenRouter(t *testing.T, repo *mockServerSettingsRepo, key *ssokey.Key, verify func(context.Context, string) (int, error)) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: "test-admin", IsAdmin: true}) })
+	RegisterServerSettingsRoutes(r.Group("/api/v1"), ServerSettingsHandlerConfig{
+		Repo:     repo,
+		SSOKey:   key,
+		CFVerify: verify,
+	})
+	return r
+}
+
+func TestCFToken_SetVerifiesAndStoresSealed(t *testing.T) {
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	key := testSSOKey(t)
+	var verifiedWith string
+	router := cfTokenRouter(t, repo, key, func(_ context.Context, tok string) (int, error) {
+		verifiedWith = tok
+		return 42, nil
+	})
+
+	body := bytes.NewBufferString(`{"token":"  cf-secret-token  "}`)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/settings/cloudflare-token", body)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	if verifiedWith != "cf-secret-token" {
+		t.Errorf("verified with %q, want the trimmed token", verifiedWith)
+	}
+	var resp cfTokenSetResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.Configured || resp.Zones != 42 {
+		t.Errorf("response %+v, want configured with 42 zones", resp)
+	}
+	if strings.Contains(w.Body.String(), "cf-secret-token") {
+		t.Fatal("response echoed the token")
+	}
+	stored := repo.getResult.CFAPITokenEnc
+	if len(stored) == 0 {
+		t.Fatal("token not stored")
+	}
+	if bytes.Contains(stored, []byte("cf-secret-token")) {
+		t.Fatal("token stored in PLAINTEXT — must be sealed")
+	}
+	plain, err := key.Open(stored)
+	if err != nil || string(plain) != "cf-secret-token" {
+		t.Fatalf("stored envelope does not unseal to the token: %q, %v", plain, err)
+	}
+}
+
+func TestCFToken_BadTokenNotStored(t *testing.T) {
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	router := cfTokenRouter(t, repo, testSSOKey(t), func(context.Context, string) (int, error) {
+		return 0, errors.New("cloudflare rejected the token")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/settings/cloudflare-token",
+		bytes.NewBufferString(`{"token":"wrong"}`))
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status %d, want 422", w.Code)
+	}
+	if len(repo.getResult.CFAPITokenEnc) != 0 {
+		t.Fatal("a token that failed verification was stored anyway")
+	}
+}
+
+func TestCFToken_NoSSOKeyRefuses(t *testing.T) {
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	router := cfTokenRouter(t, repo, nil, func(context.Context, string) (int, error) { return 1, nil })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/settings/cloudflare-token",
+		bytes.NewBufferString(`{"token":"tok"}`))
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d, want 503 — plaintext-at-rest is not an option for this secret", w.Code)
+	}
+	if len(repo.getResult.CFAPITokenEnc) != 0 {
+		t.Fatal("token stored without a sealing key")
+	}
+}
+
+func TestCFToken_StatusAndClear(t *testing.T) {
+	key := testSSOKey(t)
+	sealed, _ := key.Seal([]byte("tok"))
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{CFAPITokenEnc: sealed}}
+	router := cfTokenRouter(t, repo, key, nil)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings/cloudflare-token", nil))
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"configured":true`) {
+		t.Fatalf("status: %d %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/api/v1/admin/settings/cloudflare-token", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear status %d", w.Code)
+	}
+	if len(repo.getResult.CFAPITokenEnc) != 0 {
+		t.Fatal("clear did not remove the sealed token")
+	}
+
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings/cloudflare-token", nil))
+	if !strings.Contains(w.Body.String(), `"configured":false`) {
+		t.Fatalf("status after clear: %s", w.Body.String())
+	}
+}

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -49,6 +49,10 @@ func (m *MockSSLCertificateRepository) UpdateStatus(ctx context.Context, id stri
 	return args.Error(0)
 }
 
+func (m *MockSSLCertificateRepository) SetIssueMethod(ctx context.Context, id, method string) error {
+	return nil
+}
+
 func (m *MockSSLCertificateRepository) UpdateAfterIssuance(ctx context.Context, id string, issuedAt, expiresAt time.Time, certPath, keyPath string) error {
 	args := m.Called(ctx, id, issuedAt, expiresAt, certPath, keyPath)
 	return args.Error(0)

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -914,9 +914,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.ServerSettings != nil {
 			api.RegisterServerSettingsRoutes(v1, api.ServerSettingsHandlerConfig{
-				Repo:  deps.ServerSettings,
-				Agent: deps.Agent,
-				Log:   deps.Log,
+				Repo:   deps.ServerSettings,
+				Agent:  deps.Agent,
+				Log:    deps.Log,
+				SSOKey: deps.SSOKey,
 			})
 			// M28 — admin logo upload/delete. Public GET lives on the
 			// root router above so it's reachable pre-auth.

--- a/panel-api/internal/db/migrations/000259_dns01_fallback.down.sql
+++ b/panel-api/internal/db/migrations/000259_dns01_fallback.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE server_settings
+  DROP COLUMN cf_api_token_enc;
+
+ALTER TABLE ssl_certificates
+  DROP COLUMN issue_method;

--- a/panel-api/internal/db/migrations/000259_dns01_fallback.up.sql
+++ b/panel-api/internal/db/migrations/000259_dns01_fallback.up.sql
@@ -1,0 +1,15 @@
+-- JAB-235: DNS-01 fallback for CDN-fronted domains.
+--
+-- cf_api_token_enc holds the operator's Cloudflare API token sealed with
+-- ssokey (AES-256-GCM, nonce||ciphertext||tag — same convention as
+-- automation_tokens.secret_enc). Written ONLY by the dedicated admin
+-- endpoint; never returned by any API response. NULL = not configured.
+--
+-- ssl_certificates.issue_method records which ACME challenge issued the
+-- current cert ('' = unknown/legacy, 'http-01', 'dns-01') so the SSL UI and
+-- the operator can tell a DNS-01 lineage from a webroot one.
+ALTER TABLE server_settings
+  ADD COLUMN cf_api_token_enc varbinary(512) NULL;
+
+ALTER TABLE ssl_certificates
+  ADD COLUMN issue_method varchar(16) NOT NULL DEFAULT '';

--- a/panel-api/internal/dns01/dns01.go
+++ b/panel-api/internal/dns01/dns01.go
@@ -1,0 +1,146 @@
+// Package dns01 decides where a domain's ACME DNS-01 challenge must be
+// written: the panel's own PowerDNS, the customer's Cloudflare zone via the
+// stored API token, or nowhere (no provider available). The decision is
+// anchored on the PUBLIC NS delegation, never on local dns_zones rows — the
+// reconciler auto-creates a zone row for every domain, so a migrated domain
+// whose DNS actually lives at Cloudflare still carries a local row; writing
+// the TXT there would leave Let's Encrypt querying Cloudflare for a record
+// that only exists in our pdns (JAB-235).
+//
+// Both the reconciler (challenge routing) and the `jabali dns acme-hook`
+// CLI (record writing) use this ONE decider, so they can never disagree on
+// the stale-zone case.
+package dns01
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Provider says who can host the _acme-challenge record for a name.
+type Provider string
+
+const (
+	ProviderNone       Provider = "none"
+	ProviderPDNS       Provider = "pdns"
+	ProviderCloudflare Provider = "cloudflare"
+)
+
+// cloudflareNSSuffix identifies Cloudflare-assigned nameservers
+// (<name>.ns.cloudflare.com).
+const cloudflareNSSuffix = ".ns.cloudflare.com"
+
+// ZoneFinder resolves a Cloudflare zone id for an EXACT zone name.
+// Returns "" (no error) when the stored token does not cover the zone.
+type ZoneFinder interface {
+	FindZoneID(ctx context.Context, name string) (string, error)
+}
+
+// Config carries the decision inputs. LookupNS is dnsverify.LookupNSExternal
+// in production; tests substitute a table. CF is nil when no Cloudflare API
+// token is configured.
+type Config struct {
+	LookupNS   func(ctx context.Context, name string) (hosts []string, queried bool)
+	OurNSHosts []string // server_settings ns1/ns2 names, matched case-insensitively
+	CF         ZoneFinder
+}
+
+// Route is the outcome: which provider owns the zone that serves name, and —
+// for Cloudflare — the zone id to write into. Reason explains ProviderNone
+// (and is written into cert last_error so the operator sees WHY a domain
+// cannot auto-issue instead of a silent skip).
+type Route struct {
+	Provider Provider
+	Zone     string // the delegation point the decision anchored on
+	CFZoneID string
+	Reason   string
+}
+
+// AuthoritativeRoute walks name's parent chain (name, then each parent,
+// stopping at 2 labels — same walk as the hook's findZoneForName) and asks
+// public resolvers for the NS RRset. The first non-empty answer is the zone
+// apex; its NS hosts classify the provider.
+//
+// Fail-open rule: if every external resolver is unreachable the answer is
+// inconclusive — callers must keep their pre-JAB-235 behaviour (the hook
+// falls back to the local-zone path, the reconciler stays on HTTP-01), so
+// that a resolver outage on our side never strands issuance.
+func AuthoritativeRoute(ctx context.Context, cfg Config, name string) Route {
+	labels := strings.Split(strings.TrimSuffix(strings.ToLower(name), "."), ".")
+	for i := 0; i < len(labels)-1; i++ {
+		zone := strings.Join(labels[i:], ".")
+		hosts, queried := cfg.LookupNS(ctx, zone)
+		if !queried {
+			return Route{Provider: ProviderNone, Reason: "external DNS resolvers unreachable — cannot determine the authoritative nameservers"}
+		}
+		if len(hosts) == 0 {
+			continue // below the zone apex — walk up
+		}
+		return classify(ctx, cfg, zone, hosts)
+	}
+	return Route{Provider: ProviderNone, Reason: fmt.Sprintf("no NS delegation found for %s in public DNS", name)}
+}
+
+func classify(ctx context.Context, cfg Config, zone string, hosts []string) Route {
+	// Normalize defensively even though LookupNSExternal already lowercases:
+	// Config.LookupNS is pluggable and NS hosts compare case-insensitively.
+	normalized := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		normalized = append(normalized, strings.ToLower(strings.TrimSuffix(strings.TrimSpace(h), ".")))
+	}
+	hosts = normalized
+	if hostsHaveSuffix(hosts, cloudflareNSSuffix) {
+		if cfg.CF == nil {
+			return Route{Provider: ProviderNone, Zone: zone,
+				Reason: fmt.Sprintf("zone %s is hosted at Cloudflare but no Cloudflare API token is configured (Settings → SSL)", zone)}
+		}
+		id, err := cfg.CF.FindZoneID(ctx, zone)
+		if err != nil {
+			return Route{Provider: ProviderNone, Zone: zone,
+				Reason: fmt.Sprintf("zone %s: Cloudflare zone lookup failed: %v", zone, err)}
+		}
+		if id == "" {
+			return Route{Provider: ProviderNone, Zone: zone,
+				Reason: fmt.Sprintf("zone %s is hosted at Cloudflare but the configured API token has no access to it — the customer must grant the token access (or move NS)", zone)}
+		}
+		return Route{Provider: ProviderCloudflare, Zone: zone, CFZoneID: id}
+	}
+	if hostsMatchOurs(hosts, cfg.OurNSHosts) {
+		return Route{Provider: ProviderPDNS, Zone: zone}
+	}
+	return Route{Provider: ProviderNone, Zone: zone,
+		Reason: fmt.Sprintf("zone %s is delegated to %s — neither this panel's DNS nor a configured provider", zone, strings.Join(hosts, ", "))}
+}
+
+func hostsHaveSuffix(hosts []string, suffix string) bool {
+	for _, h := range hosts {
+		if strings.HasSuffix(h, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostsMatchOurs reports whether ANY delegated NS host is one of this
+// panel's nameserver names. Any-match (not all-match) on purpose: a zone
+// with a mixed NS set that includes us still resolves through us with
+// positive probability, and the pdns write is at worst a no-op for LE.
+func hostsMatchOurs(hosts, ours []string) bool {
+	if len(ours) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(ours))
+	for _, o := range ours {
+		o = strings.ToLower(strings.TrimSuffix(strings.TrimSpace(o), "."))
+		if o != "" {
+			set[o] = struct{}{}
+		}
+	}
+	for _, h := range hosts {
+		if _, ok := set[h]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/panel-api/internal/dns01/dns01_test.go
+++ b/panel-api/internal/dns01/dns01_test.go
@@ -1,0 +1,123 @@
+package dns01
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// nsTable fakes LookupNSExternal: name → hosts. Names absent from the table
+// answer definitively-empty (NODATA), the way any label below a zone apex
+// does. unreachable=true simulates a full resolver outage.
+type nsTable struct {
+	answers     map[string][]string
+	unreachable bool
+}
+
+func (t nsTable) lookup(_ context.Context, name string) ([]string, bool) {
+	if t.unreachable {
+		return nil, false
+	}
+	return t.answers[name], true
+}
+
+type fakeZones struct {
+	ids map[string]string
+	err error
+}
+
+func (f fakeZones) FindZoneID(_ context.Context, name string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.ids[name], nil
+}
+
+func TestAuthoritativeRoute(t *testing.T) {
+	ourNS := []string{"ns1.panel.example", "ns2.panel.example"}
+	cases := []struct {
+		name     string
+		domain   string
+		ns       nsTable
+		cf       ZoneFinder
+		want     Provider
+		wantZone string
+		wantID   string
+	}{
+		{
+			name:   "cloudflare zone covered by token",
+			domain: "arama.co.il",
+			ns:     nsTable{answers: map[string][]string{"arama.co.il": {"kip.ns.cloudflare.com", "uma.ns.cloudflare.com"}}},
+			cf:     fakeZones{ids: map[string]string{"arama.co.il": "zone123"}},
+			want:   ProviderCloudflare, wantZone: "arama.co.il", wantID: "zone123",
+		},
+		{
+			name:   "subdomain of cloudflare-hosted parent anchors on the parent zone",
+			domain: "pinat.pcc.co.il",
+			ns:     nsTable{answers: map[string][]string{"pcc.co.il": {"kip.ns.cloudflare.com"}}},
+			cf:     fakeZones{ids: map[string]string{"pcc.co.il": "zonepcc"}},
+			want:   ProviderCloudflare, wantZone: "pcc.co.il", wantID: "zonepcc",
+		},
+		{
+			name:   "cloudflare zone NOT covered by token",
+			domain: "syflow.io",
+			ns:     nsTable{answers: map[string][]string{"syflow.io": {"kip.ns.cloudflare.com"}}},
+			cf:     fakeZones{ids: map[string]string{}},
+			want:   ProviderNone, wantZone: "syflow.io",
+		},
+		{
+			name:   "cloudflare zone but no token configured",
+			domain: "arama.co.il",
+			ns:     nsTable{answers: map[string][]string{"arama.co.il": {"kip.ns.cloudflare.com"}}},
+			cf:     nil,
+			want:   ProviderNone, wantZone: "arama.co.il",
+		},
+		{
+			name:   "jabali-authoritative zone",
+			domain: "shop.customer.com",
+			ns:     nsTable{answers: map[string][]string{"customer.com": {"ns1.panel.example", "ns2.panel.example"}}},
+			want:   ProviderPDNS, wantZone: "customer.com",
+		},
+		{
+			name:   "mixed NS including ours still counts as pdns",
+			domain: "customer.com",
+			ns:     nsTable{answers: map[string][]string{"customer.com": {"ns.thirdparty.net", "NS1.PANEL.EXAMPLE."}}},
+			want:   ProviderPDNS, wantZone: "customer.com",
+		},
+		{
+			name:   "third-party NS is none",
+			domain: "elsewhere.com",
+			ns:     nsTable{answers: map[string][]string{"elsewhere.com": {"dns1.netvision.net.il"}}},
+			want:   ProviderNone, wantZone: "elsewhere.com",
+		},
+		{
+			name:   "no delegation anywhere",
+			domain: "ghost.example",
+			ns:     nsTable{answers: map[string][]string{}},
+			want:   ProviderNone,
+		},
+		{
+			name:   "resolver outage is inconclusive (fail open)",
+			domain: "arama.co.il",
+			ns:     nsTable{unreachable: true},
+			want:   ProviderNone,
+		},
+		{
+			name:   "cf zone lookup error surfaces as none",
+			domain: "arama.co.il",
+			ns:     nsTable{answers: map[string][]string{"arama.co.il": {"kip.ns.cloudflare.com"}}},
+			cf:     fakeZones{err: errors.New("boom")},
+			want:   ProviderNone, wantZone: "arama.co.il",
+		},
+	}
+	for _, c := range cases {
+		cfg := Config{LookupNS: c.ns.lookup, OurNSHosts: ourNS, CF: c.cf}
+		got := AuthoritativeRoute(context.Background(), cfg, c.domain)
+		if got.Provider != c.want || got.Zone != c.wantZone || got.CFZoneID != c.wantID {
+			t.Errorf("%s: got %+v, want provider=%s zone=%s id=%s", c.name, got, c.want, c.wantZone, c.wantID)
+		}
+		if got.Provider == ProviderNone && got.Reason == "" {
+			t.Errorf("%s: ProviderNone must carry a reason", c.name)
+		}
+	}
+}

--- a/panel-api/internal/dns01/live_probe_test.go
+++ b/panel-api/internal/dns01/live_probe_test.go
@@ -1,0 +1,23 @@
+//go:build live
+
+package dns01
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dnsverify"
+)
+
+// Live probe (not run in CI): exercises the real LookupNSExternal walk
+// against public DNS for domains from the JAB-235 ticket.
+func TestLiveAuthoritativeRoute(t *testing.T) {
+	cfg := Config{LookupNS: dnsverify.LookupNSExternal}
+	for _, d := range []string{"movi.co.il", "premiumhaifa.co.il", "pinat.pcc.co.il", "google.com"} {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		r := AuthoritativeRoute(ctx, cfg, d)
+		cancel()
+		t.Logf("%s → provider=%s zone=%s reason=%q", d, r.Provider, r.Zone, r.Reason)
+	}
+}

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -426,6 +426,16 @@ type ServerSettings struct {
 	// stays verifiable after a prune. NULL/empty = never pruned (root at "").
 	AuditChainAnchor *string `gorm:"column:audit_chain_anchor;type:char(64)" json:"audit_chain_anchor,omitempty"`
 
+	// CFAPITokenEnc (JAB-235) is the operator's Cloudflare API token, sealed
+	// with ssokey (AES-256-GCM) — used by the ACME DNS-01 fallback to write
+	// _acme-challenge TXT records into Cloudflare-hosted customer zones.
+	// json:"-": the token must NEVER appear in any API response; the
+	// dedicated /admin/ssl/cloudflare-token endpoints are the only writers
+	// and report configured/not-configured only. Least privilege: the token
+	// needs Zone:DNS:Edit + Zone:Read on the zones it should cover — advise
+	// operators to mint a dedicated scoped token, not a global one.
+	CFAPITokenEnc []byte `gorm:"column:cf_api_token_enc;type:varbinary(512)" json:"-"`
+
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null"             json:"updated_at"`
 }
 

--- a/panel-api/internal/models/ssl_certificate.go
+++ b/panel-api/internal/models/ssl_certificate.go
@@ -32,6 +32,9 @@ type SSLCertificate struct {
 	KeyPath       *string    `gorm:"type:varchar(512)"                           json:"key_path,omitempty"`
 	NextRetryAt   *time.Time `gorm:"type:datetime(6);index:ix_ssl_cert_next_retry" json:"next_retry_at,omitempty"`
 	RetryCount    int        `gorm:"type:int;not null;default:0"                 json:"retry_count"`
+	// IssueMethod records which ACME challenge produced the current cert:
+	// '' (unknown/legacy or non-ACME), 'http-01', or 'dns-01' (JAB-235).
+	IssueMethod string `gorm:"column:issue_method;type:varchar(16);not null;default:''" json:"issue_method"`
 	LastAttemptAt *time.Time `gorm:"type:datetime(6);index:ix_ssl_cert_last_attempt" json:"last_attempt_at,omitempty"`
 	CreatedAt     time.Time  `gorm:"type:datetime(6);not null"                   json:"created_at"`
 	UpdatedAt     time.Time  `gorm:"type:datetime(6);not null"                   json:"updated_at"`

--- a/panel-api/internal/reconciler/dns01_routing.go
+++ b/panel-api/internal/reconciler/dns01_routing.go
@@ -1,0 +1,183 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/hostedsvc"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/dnsverify"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dns01"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
+)
+
+// JAB-235 — DNS-01 fallback for CDN-fronted domains.
+//
+// A domain whose apex resolves to a CDN (Cloudflare orange-cloud and kin)
+// cannot pass HTTP-01: the edge answers the challenge path itself (403/404)
+// and one failed name fails the whole cert, so the origin is stranded on
+// self-signed. DNS-01 sidesteps the HTTP path entirely — the TXT record
+// just has to land wherever the zone is REALLY hosted: our own PowerDNS
+// when we are authoritative, or the customer's Cloudflare zone through the
+// operator's stored API token. Domains with neither provider are parked
+// with a clear reason and re-checked daily — never retried against LE
+// (whose failed-authorization quota is what melted the aramapp fleet).
+
+const (
+	// dns01IssueTimeout bounds one certbot DNS-01 round trip: two hook
+	// invocations with settle sleeps per name plus LE's validation poll.
+	// Same budget as the shared-cert sweep (acmeSharedIssueTimeout) — the
+	// HTTP-01 path's 60s would guarantee a context-deadline failure here.
+	dns01IssueTimeout = 4 * time.Minute
+	// dns01NoProviderRecheck paces re-checks of a fronted domain with no
+	// available DNS provider. Daily: the fix is an operator/customer action
+	// (store a token, grant zone access, move NS), not something that
+	// changes minute-to-minute, and no LE quota is involved either way.
+	dns01NoProviderRecheck = 24 * time.Hour
+	// dns01RouteCacheTTL bounds how long an NS-delegation decision is
+	// reused before re-asking public DNS. In-memory (not persisted on the
+	// cert row as the ticket sketched): it survives across ticks in the
+	// long-lived reconciler process and self-heals after NS changes.
+	dns01RouteCacheTTL = time.Hour
+)
+
+// IssueMethod values recorded on ssl_certificates rows.
+const (
+	issueMethodHTTP01 = "http-01"
+	issueMethodDNS01  = "dns-01"
+)
+
+type dns01CachedRoute struct {
+	route   dns01.Route
+	expires time.Time
+}
+
+// WithDNS01Key wires the sso key that unseals server_settings.cf_api_token_enc
+// for the Cloudflare DNS-01 path. Nil-safe: without it, Cloudflare-hosted
+// zones simply report "no token configured".
+func (r *Reconciler) WithDNS01Key(key *ssokey.Key) *Reconciler {
+	r.dns01SSOKey = key
+	return r
+}
+
+// frontedByCDN reports whether the apex is served from somewhere that is
+// not this box. Requires POSITIVE evidence on both sides — a failed apex
+// lookup or unknown public IPs keeps the domain on HTTP-01 exactly as
+// before (narrow, never invent a reason to change behaviour — the
+// sanReachability philosophy).
+func frontedByCDN(apexAddrs, ourAddrs []string) bool {
+	if len(apexAddrs) == 0 || len(ourAddrs) == 0 {
+		return false
+	}
+	return !intersects(apexAddrs, ourAddrs)
+}
+
+// dns01Route decides (with a TTL cache) who can host the _acme-challenge
+// record for name. The same dns01.AuthoritativeRoute powers the acme-hook
+// CLI, so the routing decision and the record write can never disagree.
+func (r *Reconciler) dns01Route(ctx context.Context, srv *models.ServerSettings, name string) dns01.Route {
+	r.dns01RouteMu.Lock()
+	if cached, ok := r.dns01RouteCache[name]; ok && time.Now().Before(cached.expires) {
+		r.dns01RouteMu.Unlock()
+		return cached.route
+	}
+	r.dns01RouteMu.Unlock()
+
+	cfg := dns01.Config{
+		LookupNS:   dnsverify.LookupNSExternal,
+		OurNSHosts: []string{srv.NS1Name, srv.NS2Name},
+	}
+	if r.dns01LookupNS != nil { // test seam
+		cfg.LookupNS = r.dns01LookupNS
+	}
+	if len(srv.CFAPITokenEnc) > 0 && r.dns01SSOKey != nil {
+		if tok, err := r.dns01SSOKey.Open(srv.CFAPITokenEnc); err == nil {
+			cfg.CF = hostedsvc.NewCloudflareAPI(string(tok))
+		} else {
+			r.log.Error("ssl: cannot unseal the Cloudflare API token — DNS-01 via Cloudflare unavailable", "err", err)
+		}
+	}
+	if r.dns01ZoneFinder != nil { // test seam
+		cfg.CF = r.dns01ZoneFinder
+	}
+
+	routeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	route := dns01.AuthoritativeRoute(routeCtx, cfg, name)
+	cancel()
+
+	r.dns01RouteMu.Lock()
+	if r.dns01RouteCache == nil {
+		r.dns01RouteCache = map[string]dns01CachedRoute{}
+	}
+	r.dns01RouteCache[name] = dns01CachedRoute{route: route, expires: time.Now().Add(dns01RouteCacheTTL)}
+	r.dns01RouteMu.Unlock()
+	return route
+}
+
+// tryDNS01OrPark handles the LE branch for a fronted domain: issue via
+// DNS-01 when a provider is available, else park with a clear reason.
+//
+// Parking mirrors selfSignAndWaitForDNS: self-signed fallback so HTTPS
+// answers, pending_acme_retry with retry_count UNCHANGED (no ACME attempt
+// was made, so no LE quota was spent and the #1049 cap must not tick), and
+// a daily re-check. A real DNS-01 failure, by contrast, goes through
+// fallbackToSelfSignAndRetry and counts toward the cap like any other
+// spent LE attempt.
+func (r *Reconciler) tryDNS01OrPark(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate, srv *models.ServerSettings, staging bool) {
+	route := r.dns01Route(ctx, srv, domain.Name)
+	if route.Provider == dns01.ProviderNone {
+		fallbackCertPath, fallbackKeyPath, fallbackExpiresAt := r.ensureSelfSignFallback(ctx, domain, cert)
+		nextRetry := time.Now().UTC().Add(dns01NoProviderRecheck)
+		reason := "fronted by a CDN/proxy, and DNS-01 is not available: " + route.Reason +
+			" — HTTP-01 cannot reach this origin, so Let's Encrypt is not attempted (no quota spent); re-checked daily"
+		_ = r.sslCerts.UpdateAfterACMEFailure(ctx, cert.ID, reason, nextRetry, cert.RetryCount, fallbackCertPath, fallbackKeyPath, fallbackExpiresAt)
+		r.log.Warn("ssl: fronted domain has no DNS-01 provider — parked",
+			"domain", domain.Name, "reason", route.Reason, "next_check_at", nextRetry.Format(time.RFC3339))
+		return
+	}
+
+	issueCtx, cancel := context.WithTimeout(ctx, dns01IssueTimeout)
+	defer cancel()
+	// Same lineage name as the HTTP-01 path (--cert-name <domain>), so the
+	// two methods share one certbot lineage: certbot persists the manual
+	// hooks in the renewal conf and `certbot renew` / ssl.renew keeps
+	// renewing it unattended, whichever method issued last.
+	raw, err := r.agent.Call(issueCtx, "ssl.issue_dns01", map[string]any{
+		"cert_name": domain.Name,
+		"sans":      []string{domain.Name, "www." + domain.Name},
+		"email":     srv.AdminEmail,
+		"staging":   staging,
+	})
+	if err != nil {
+		r.log.Warn("ssl: dns-01 issue failed", "domain", domain.Name, "provider", route.Provider, "zone", route.Zone, "err", err)
+		r.fallbackToSelfSignAndRetry(ctx, domain, cert, firstLine(err.Error()))
+		return
+	}
+	issued, expires, ok := parseSSLIssueResult(raw, r.log, domain.Name)
+	if !ok {
+		msg := "agent returned unparseable ssl.issue_dns01 result"
+		_ = r.sslCerts.UpdateStatus(ctx, cert.ID, models.SSLStatusFailed, &msg)
+		return
+	}
+	var res sslIssueResult
+	_ = json.Unmarshal(raw, &res)
+	if err := r.sslCerts.UpdateAfterIssuance(ctx, cert.ID, issued, expires, res.CertPath, res.KeyPath); err != nil {
+		r.log.Error("ssl: write dns-01 issuance failed", "domain", domain.Name, "err", err)
+		return
+	}
+	_ = r.sslCerts.SetIssueMethod(ctx, cert.ID, issueMethodDNS01)
+	r.log.Info("ssl: issued via dns-01", "domain", domain.Name, "provider", string(route.Provider), "zone", route.Zone, "expires_at", expires.Format(time.RFC3339))
+}
+
+// dns01 routing state on the Reconciler (fields declared here to keep the
+// JAB-235 surface in one file; the struct lives in reconciler.go).
+type dns01State struct {
+	dns01SSOKey     *ssokey.Key
+	dns01RouteMu    sync.Mutex
+	dns01RouteCache map[string]dns01CachedRoute
+	// test seams — nil in production
+	dns01LookupNS   func(ctx context.Context, name string) ([]string, bool)
+	dns01ZoneFinder dns01.ZoneFinder
+}

--- a/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
+++ b/panel-api/internal/reconciler/mta_sts_test_fakes_test.go
@@ -14,6 +14,8 @@ import (
 type fakeSSLCertRepo struct {
 	byDomain map[string]*models.SSLCertificate
 	revoked  map[string]bool
+	// JAB-235: records SetIssueMethod calls (cert id → method)
+	issueMethods map[string]string
 	// JAB-224 ssl_resurrect
 	exhausted    []models.SSLCertificate
 	exhaustedErr error
@@ -25,7 +27,11 @@ type fakeSSLCertRepo struct {
 }
 
 func newFakeSSLCertRepo() *fakeSSLCertRepo {
-	return &fakeSSLCertRepo{byDomain: map[string]*models.SSLCertificate{}, revoked: map[string]bool{}}
+	return &fakeSSLCertRepo{
+		byDomain:     map[string]*models.SSLCertificate{},
+		revoked:      map[string]bool{},
+		issueMethods: map[string]string{},
+	}
 }
 
 func (f *fakeSSLCertRepo) Create(context.Context, *models.SSLCertificate) error { return nil }
@@ -40,6 +46,13 @@ func (f *fakeSSLCertRepo) FindByDomainIDs(context.Context, []string) ([]models.S
 	return nil, nil
 }
 func (f *fakeSSLCertRepo) UpdateStatus(context.Context, string, string, *string) error { return nil }
+func (f *fakeSSLCertRepo) SetIssueMethod(_ context.Context, id, method string) error {
+	if f.issueMethods != nil {
+		f.issueMethods[id] = method
+	}
+	return nil
+}
+
 func (f *fakeSSLCertRepo) UpdateAfterIssuance(context.Context, string, time.Time, time.Time, string, string) error {
 	return nil
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -56,6 +56,9 @@ type Reconciler struct {
 	log          *slog.Logger
 	interval     time.Duration
 
+	// JAB-235 DNS-01 routing state — see dns01_routing.go.
+	dns01State
+
 	// sslIssueMu serialises certbot-touching work across the JAB-205
 	// domain worker pool AND the out-of-band ReconcileOne path: certbot
 	// holds a global /var/lib/letsencrypt lock, so two concurrent runs
@@ -2662,6 +2665,11 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 	// outbound :53 blocked — must fall through to the ACME attempt, or a
 	// resolver outage on our side would strand every domain on "waiting
 	// for DNS" without ever trying.
+	staging := false
+	if r.cfg != nil {
+		staging = r.cfg.ACME.StagingOnly
+	}
+
 	{
 		preCtx, preCancel := context.WithTimeout(ctx, 6*time.Second)
 		addrs, queried := r.dnsPreflight(preCtx, domain.Name)
@@ -2672,11 +2680,26 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 					"Let's Encrypt is not attempted until the name resolves (it would fail with NXDOMAIN); retrying automatically")
 			return
 		}
-	}
-
-	staging := false
-	if r.cfg != nil {
-		staging = r.cfg.ACME.StagingOnly
+		// JAB-235: the apex resolves — but to a CDN/proxy, not to us. An
+		// HTTP-01 challenge would be answered (and rejected) at the edge
+		// before it ever reaches this origin, burning LE's failed-auth
+		// quota for nothing. Route through DNS-01 instead: the TXT is
+		// written wherever the zone is really hosted (our pdns or the
+		// customer's Cloudflare zone via the stored token), or the domain
+		// is parked with a clear reason when neither is available. Needs
+		// positive evidence on both sides (frontedByCDN) — a resolver
+		// outage or unknown public IP keeps today's HTTP-01 behaviour.
+		var ourAddrs []string
+		if srv.PublicIPv4 != "" {
+			ourAddrs = append(ourAddrs, srv.PublicIPv4)
+		}
+		if srv.PublicIPv6 != "" {
+			ourAddrs = append(ourAddrs, srv.PublicIPv6)
+		}
+		if queried && frontedByCDN(addrs, ourAddrs) {
+			r.tryDNS01OrPark(ctx, domain, cert, srv, staging)
+			return
+		}
 	}
 
 	// Try ACME with 60s timeout
@@ -2724,6 +2747,7 @@ func (r *Reconciler) tryACMEOrFallback(ctx context.Context, domain *models.Domai
 			r.log.Error("ssl: write issuance failed", "domain", domain.Name, "err", err)
 			return
 		}
+		_ = r.sslCerts.SetIssueMethod(ctx, cert.ID, issueMethodHTTP01)
 		r.log.Info("ssl: issued", "domain", domain.Name, "expires_at", expires.Format(time.RFC3339))
 		return
 	}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2892,7 +2892,13 @@ const acmeMaxRetries = 20
 // (e.g., email just got enabled → mail.<domain> must land on the cert).
 // tryACMEOrFallback calls ssl.issue which uses --expand when needed.
 func (r *Reconciler) sslRenewForDomain(ctx context.Context, domain *models.Domain, cert *models.SSLCertificate) {
-	if len(sanHostnamesForDomain(domain)) > 0 {
+	// JAB-235: DNS-01 lineages also reroute. Normally the certbot timer
+	// renews them via the persisted manual hooks and ssl.renew would be a
+	// fast noop — but with a broken timer, ssl.renew runs the full DNS-01
+	// round trip (two hook invocations + validation poll) against this
+	// call's default budget. tryACMEOrFallback re-detects fronting and
+	// gives the DNS-01 path its 4-minute budget.
+	if len(sanHostnamesForDomain(domain)) > 0 || cert.IssueMethod == issueMethodDNS01 {
 		r.tryACMEOrFallback(ctx, domain, cert)
 		return
 	}

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -21,10 +21,11 @@ import (
 
 // fakeAgent mocks the agent.AgentInterface for testing.
 type fakeAgent struct {
-	mu          sync.Mutex // JAB-205: ReconcileAll now calls the agent from a worker pool
-	calls       []fakeCall
-	failMethod  string           // if set, Call returns an error for this method
-	errByMethod map[string]error // if set for a method, Call returns that exact error
+	mu             sync.Mutex // JAB-205: ReconcileAll now calls the agent from a worker pool
+	calls          []fakeCall
+	failMethod     string                     // if set, Call returns an error for this method
+	errByMethod    map[string]error           // if set for a method, Call returns that exact error
+	resultByMethod map[string]json.RawMessage // if set for a method, Call returns that payload
 }
 
 type fakeCall struct {
@@ -44,6 +45,11 @@ func (f *fakeAgent) Call(ctx context.Context, method string, params interface{})
 	}
 	if method == f.failMethod {
 		return nil, fmt.Errorf("agent call failed for method: %s", method)
+	}
+	if f.resultByMethod != nil {
+		if raw, ok := f.resultByMethod[method]; ok {
+			return raw, nil
+		}
 	}
 
 	switch method {

--- a/panel-api/internal/reconciler/ssl_dns01_routing_test.go
+++ b/panel-api/internal/reconciler/ssl_dns01_routing_test.go
@@ -1,0 +1,183 @@
+package reconciler
+
+// JAB-235 — DNS-01 fallback routing. Four properties pinned here:
+//
+//  1. Fronted apex + available provider → ssl.issue_dns01 (never ssl.issue:
+//     the edge would eat the HTTP-01 token and burn LE quota), shared
+//     lineage name, sans = apex + www, issue_method recorded.
+//  2. Fronted apex + NO provider → NO agent ACME call at all, retry count
+//     unchanged (no LE quota spent — the #1049 cap must not tick), clear
+//     reason, daily re-check.
+//  3. Apex resolving to us → HTTP-01 exactly as before.
+//  4. Unknown own IP (fresh install) → fail open to HTTP-01.
+//
+// A REAL DNS-01 failure, by contrast, is a spent LE attempt and must keep
+// counting toward acmeMaxRetries (property 5).
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+const dns01TestOwnIP = "203.0.113.7"
+
+// cfEdgeAddrs is what a Cloudflare-proxied apex resolves to — anything
+// disjoint from dns01TestOwnIP works.
+var cfEdgeAddrs = []string{"104.21.32.5", "172.67.140.9"}
+
+type fixedZoneFinder struct{ id string }
+
+func (f fixedZoneFinder) FindZoneID(context.Context, string) (string, error) { return f.id, nil }
+
+// dns01Fixture builds on the webroot fixture: apex fronted by a CDN, our
+// public IP known, NS delegation answered by the test seam.
+func dns01Fixture(t *testing.T, nsHosts []string, zoneID string) (*Reconciler, *fakeAgent, *fakeSSLCertRepo, *models.Domain) {
+	t.Helper()
+	r, ag, sc, dom := sslWebrootFixture(t, nil)
+	r.serverSettings.(*fakeServerSettingsRepo).settings.PublicIPv4 = dns01TestOwnIP
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return cfEdgeAddrs, true
+	}
+	r.dns01LookupNS = func(_ context.Context, name string) ([]string, bool) {
+		if name == "example.com" {
+			return nsHosts, true
+		}
+		return nil, true // below the zone apex
+	}
+	if zoneID != "" {
+		r.dns01ZoneFinder = fixedZoneFinder{id: zoneID}
+	}
+	if ag.resultByMethod == nil {
+		ag.resultByMethod = map[string]json.RawMessage{}
+	}
+	ag.resultByMethod["ssl.issue_dns01"] = json.RawMessage(`{
+		"cert_path": "/etc/letsencrypt/live/sub.example.com/fullchain.pem",
+		"key_path":  "/etc/letsencrypt/live/sub.example.com/privkey.pem",
+		"issued_at": "2026-08-11T00:00:00Z",
+		"expires_at": "2026-11-09T00:00:00Z"
+	}`)
+	return r, ag, sc, dom
+}
+
+var errBoom = errors.New("boom")
+
+// findAgentCall returns the recorded call for method, if any.
+func findAgentCall(ag *fakeAgent, method string) (fakeCall, bool) {
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	for _, c := range ag.calls {
+		if c.method == method {
+			return c, true
+		}
+	}
+	return fakeCall{}, false
+}
+
+func TestDNS01_FrontedCovered_IssuesViaDNS01(t *testing.T) {
+	r, ag, sc, dom := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "zone123")
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if agentCalled(ag, "ssl.issue") {
+		t.Fatal("fronted domain must NOT attempt HTTP-01 — the CDN edge eats the token and burns LE quota")
+	}
+	call, ok := findAgentCall(ag, "ssl.issue_dns01")
+	if !ok {
+		t.Fatal("fronted + covered domain must issue via ssl.issue_dns01")
+	}
+	params := call.params.(map[string]any)
+	if params["cert_name"] != dom.Name {
+		t.Errorf("cert_name = %v, want %s (shared lineage with the HTTP-01 path)", params["cert_name"], dom.Name)
+	}
+	sans := params["sans"].([]string)
+	if len(sans) != 2 || sans[0] != dom.Name || sans[1] != "www."+dom.Name {
+		t.Errorf("sans = %v, want [apex, www]", sans)
+	}
+	if sc.issueMethods["c1"] != issueMethodDNS01 {
+		t.Errorf("issue_method = %q, want %q", sc.issueMethods["c1"], issueMethodDNS01)
+	}
+}
+
+func TestDNS01_FrontedUncovered_ParksWithoutLEAttempt(t *testing.T) {
+	// Cloudflare NS, but the token doesn't cover the zone (FindZoneID "").
+	r, ag, sc, dom := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "")
+	r.dns01ZoneFinder = fixedZoneFinder{id: ""}
+	sc.byDomain[dom.ID].RetryCount = 5
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if agentCalled(ag, "ssl.issue") || agentCalled(ag, "ssl.issue_dns01") {
+		t.Fatal("fronted + uncovered must not attempt ANY ACME call — there is no path that can succeed")
+	}
+	cert := sc.byDomain[dom.ID]
+	if cert.RetryCount != 5 {
+		t.Errorf("retry count %d, want 5 (unchanged) — no LE attempt was made, the #1049 cap must not tick", cert.RetryCount)
+	}
+	if cert.LastError == nil || !strings.Contains(*cert.LastError, "DNS-01 is not available") {
+		t.Errorf("last error should carry the no-provider reason, got %v", cert.LastError)
+	}
+	if cert.NextRetryAt == nil || time.Until(*cert.NextRetryAt) < 23*time.Hour {
+		t.Errorf("next check should be ~daily, got %v", cert.NextRetryAt)
+	}
+}
+
+func TestDNS01_ApexPointsAtUs_KeepsHTTP01(t *testing.T) {
+	r, ag, _, dom := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "zone123")
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return []string{dns01TestOwnIP}, true
+	}
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("a direct (not fronted) domain must stay on HTTP-01")
+	}
+	if agentCalled(ag, "ssl.issue_dns01") {
+		t.Fatal("direct domain needlessly routed through DNS-01")
+	}
+}
+
+func TestDNS01_UnknownOwnIP_FailsOpenToHTTP01(t *testing.T) {
+	r, ag, _, dom := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "zone123")
+	r.serverSettings.(*fakeServerSettingsRepo).settings.PublicIPv4 = ""
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue") {
+		t.Fatal("without a known public IP the fronted judgement cannot be made — must fail open to HTTP-01")
+	}
+}
+
+func TestDNS01_IssueFailureCountsTowardCap(t *testing.T) {
+	r, ag, sc, dom := dns01Fixture(t, []string{"kip.ns.cloudflare.com"}, "zone123")
+	delete(ag.resultByMethod, "ssl.issue_dns01")
+	ag.errByMethod = map[string]error{"ssl.issue_dns01": errBoom}
+	sc.byDomain[dom.ID].RetryCount = 2
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	cert := sc.byDomain[dom.ID]
+	if cert.RetryCount != 3 {
+		t.Errorf("retry count %d, want 3 — a REAL DNS-01 failure is a spent LE attempt and must count toward the cap", cert.RetryCount)
+	}
+}
+
+// jabali-authoritative fronted zone routes DNS-01 through pdns (no CF
+// involvement) — e.g. an operator pointing the apex at a third-party proxy
+// while we host the DNS.
+func TestDNS01_FrontedPDNSZone_IssuesViaDNS01(t *testing.T) {
+	r, ag, _, dom := dns01Fixture(t, []string{"ns1.panel.example"}, "")
+	r.serverSettings.(*fakeServerSettingsRepo).settings.NS1Name = "ns1.panel.example"
+
+	r.reconcileSSLForDomain(context.Background(), dom)
+
+	if !agentCalled(ag, "ssl.issue_dns01") {
+		t.Fatal("fronted + jabali-authoritative must issue via DNS-01 through pdns")
+	}
+}

--- a/panel-api/internal/repository/ssl_certificate_repository.go
+++ b/panel-api/internal/repository/ssl_certificate_repository.go
@@ -42,6 +42,7 @@ type SSLCertificateRepository interface {
 	FindByDomainIDs(ctx context.Context, domainIDs []string) ([]models.SSLCertificate, error)
 	UpdateStatus(ctx context.Context, id string, status string, lastError *string) error
 	UpdateAfterIssuance(ctx context.Context, id string, issuedAt, expiresAt time.Time, certPath, keyPath string) error
+	SetIssueMethod(ctx context.Context, id, method string) error
 	UpdateAfterRenewal(ctx context.Context, id string, issuedAt, expiresAt time.Time, certPath, keyPath string) error
 	MarkRevoked(ctx context.Context, id string) error
 	DeleteByDomainID(ctx context.Context, domainID string) error
@@ -124,6 +125,14 @@ func (r *sslCertificateRepo) UpdateAfterIssuance(ctx context.Context, id string,
 			"last_attempt_at": time.Now(),
 			"updated_at":      time.Now(),
 		}).Error
+}
+
+// SetIssueMethod records which ACME challenge type produced the current
+// cert ('http-01' | 'dns-01', JAB-235). Separate from UpdateAfterIssuance
+// so its many call sites keep their signature.
+func (r *sslCertificateRepo) SetIssueMethod(ctx context.Context, id, method string) error {
+	return r.db.WithContext(ctx).Model(&models.SSLCertificate{}).Where("id = ?", id).
+		Update("issue_method", method).Error
 }
 
 // UpdateAfterRenewal does what UpdateAfterIssuance does plus bumps the

--- a/panel-api/internal/repository/ssl_certificate_repository_test.go
+++ b/panel-api/internal/repository/ssl_certificate_repository_test.go
@@ -48,6 +48,7 @@ func TestSSLCertificateRepository_Create(t *testing.T) {
 			nil,              // key_path
 			nil,              // next_retry_at
 			0,                // retry_count
+			"",               // issue_method (JAB-235)
 			nil,              // last_attempt_at
 			sqlmock.AnyArg(), // created_at
 			sqlmock.AnyArg(), // updated_at

--- a/panel-ui/src/shells/admin/settings/CloudflareTokenCard.tsx
+++ b/panel-ui/src/shells/admin/settings/CloudflareTokenCard.tsx
@@ -1,0 +1,140 @@
+// CloudflareTokenCard — the Cloudflare API token behind the ACME DNS-01
+// fallback (JAB-235). A CDN-fronted customer domain cannot pass HTTP-01
+// (the edge answers the challenge path), so the panel writes the
+// _acme-challenge TXT straight into the customer's Cloudflare zone through
+// this token. Write-only surface: the field is masked, the server verifies
+// the token against Cloudflare before storing it sealed, and status only
+// ever reports configured yes/no — the token is never displayed back.
+import { useCallback, useEffect, useState } from "react";
+import { SafetyOutlined } from "@icons";
+import { Alert, Button, Card, Input, Popconfirm, Space, Tag, Typography } from "antd";
+import { apiClient } from "../../../apiClient";
+import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+
+interface TokenStatus {
+  configured: boolean;
+}
+
+interface TokenSetResult {
+  configured: boolean;
+  zones: number;
+}
+
+export function CloudflareTokenCard() {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await apiClient.get<TokenStatus>("/admin/settings/cloudflare-token");
+      setConfigured(r.data.configured);
+    } catch {
+      setConfigured(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const save = async () => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    try {
+      const r = await apiClient.put<TokenSetResult>("/admin/settings/cloudflare-token", {
+        token: trimmed,
+      });
+      setToken("");
+      setConfigured(true);
+      feedback.message.success(
+        `Token verified and stored — it can see ${r.data.zones} Cloudflare zone${r.data.zones === 1 ? "" : "s"}.`,
+      );
+    } catch (e) {
+      feedback.message.error(
+        e instanceof Error && e.message
+          ? e.message
+          : "Cloudflare rejected the token — check its scopes (Zone:DNS:Edit + Zone:Read).",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const clear = async () => {
+    setClearing(true);
+    try {
+      await apiClient.delete("/admin/settings/cloudflare-token");
+      setConfigured(false);
+      feedback.message.success("Cloudflare API token cleared.");
+    } catch {
+      feedback.message.error("Could not clear the token.");
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  return (
+    <Card
+      title={
+        <Space>
+          <SafetyOutlined />
+          Cloudflare DNS-01 (SSL for proxied domains)
+        </Space>
+      }
+      extra={
+        configured === null ? null : configured ? (
+          <Tag color="success">Token configured</Tag>
+        ) : (
+          <Tag>Not configured</Tag>
+        )
+      }
+      style={{ marginBottom: 16 }}
+    >
+      <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
+        Domains fronted by Cloudflare (orange-cloud) cannot pass the normal HTTP
+        certificate check, so they are stranded on a self-signed certificate.
+        With an API token stored here, the panel completes the DNS challenge
+        directly in the customer&apos;s Cloudflare zone and issues a real
+        Let&apos;s Encrypt certificate for the origin. Use a dedicated token
+        scoped to <code>Zone:DNS:Edit</code> + <code>Zone:Read</code> on the
+        zones it should cover — it is a powerful credential, stored encrypted,
+        and never shown again after saving.
+      </Typography.Paragraph>
+      <Space.Compact style={{ width: "100%", maxWidth: 480 }}>
+        <Input.Password
+          placeholder={configured ? "Replace the stored token…" : "Cloudflare API token"}
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onPressEnter={() => void save()}
+          autoComplete="off"
+        />
+        <Button type="primary" loading={saving} disabled={!token.trim()} onClick={() => void save()}>
+          Verify &amp; save
+        </Button>
+      </Space.Compact>
+      {configured ? (
+        <div style={{ marginTop: 12 }}>
+          <Popconfirm
+            title="Clear the stored token?"
+            description="Cloudflare-hosted zones lose the DNS-01 fallback until a new token is saved."
+            onConfirm={() => void clear()}
+          >
+            <Button danger loading={clearing}>
+              Clear token
+            </Button>
+          </Popconfirm>
+        </div>
+      ) : (
+        <Alert
+          style={{ marginTop: 12 }}
+          type="info"
+          showIcon
+          message="Without a token, Cloudflare-fronted domains are parked with a clear reason instead of retrying Let's Encrypt."
+        />
+      )}
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -57,6 +57,7 @@ import { StalwartWebadminCard } from "./StalwartWebadminCard";
 import { PageTemplatesCard } from "./PageTemplatesCard";
 import { AccountSkeletonCard } from "./AccountSkeletonCard";
 import { PanelSSLCard } from "./PanelSSLCard";
+import { CloudflareTokenCard } from "./CloudflareTokenCard";
 import { NspawnImagesCard } from "./NspawnImagesCard";
 import { SSOMaintenanceCard } from "./SSOMaintenanceCard";
 import { TenantDomainOptionsCard } from "./TenantDomainOptionsCard";
@@ -315,6 +316,7 @@ const GeneralSettingsTab = () => {
 
       <SSOMaintenanceCard />
       <PanelSSLCard />
+      <CloudflareTokenCard />
       <Card title={t("settings.root_terminal_m45")} style={{ marginBottom: 16 }}>
         <Row gutter={16}>
           <Col xs={24}>


### PR DESCRIPTION
## Summary
JAB-235: a customer domain behind Cloudflare (orange-cloud) can't pass HTTP-01 — the CF edge answers `/.well-known/acme-challenge/*` itself (403), one failed name fails the whole cert, and the origin is stranded on self-signed (~45 domains on the aramapp fleet). This implements **DNS-01 as an automatic fallback with a pluggable provider**, so every domain gets a real Let's Encrypt origin cert: proxied, grey-clouded, or bare — and still has it the day CF is removed. Completes the JAB-226 arc (#1046 SAN drop, #1049 churn stop).

### The one decider (the part that must not fork)
`internal/dns01.AuthoritativeRoute` anchors every decision on the **public NS delegation** (new `dnsverify.LookupNSExternal` — external resolvers, because the local recursor forwards to our own auth server and lies about delegation), walking the name's parent chain to the zone apex. Both the reconciler (routing) and the `jabali dns acme-hook` CLI (record writing) call this one function. Anchoring on local `dns_zones` rows would be wrong precisely for the target fleet: the reconciler auto-creates a zone row for every domain (`reconciler.go:2166`), so a migrated domain whose DNS really lives at Cloudflare still carries a stale local row — the hook would write the TXT into pdns while LE queries Cloudflare.

### Routing (reconciler)
- **Fronted detection**: apex public addresses (reusing the existing `dnsPreflight` lookup — one query, two decisions) disjoint from `server_settings.public_ipv4/6`. Positive evidence required on both sides; resolver outage or unknown own-IP **fails open to HTTP-01** exactly as today.
- Fronted + provider available → `ssl.issue_dns01`, **same `--cert-name <domain>` lineage** as the webroot path: certbot persists the manual hooks in the renewal conf, so `certbot renew` / `ssl.renew` renews DNS-01 lineages unattended — no renewal-path changes needed.
- Fronted + **no provider** → parked: self-signed fallback, `pending_acme_retry`, daily re-check, **retry_count untouched** (no LE attempt = no quota spent = the #1049 cap must not tick). The reason names the exact blocker ("hosted at Cloudflare but no API token", "token has no access to zone X — customer must grant access", "delegated to <ns> — neither ours nor a provider").
- A **real** DNS-01 failure still burns the cap like any spent LE attempt.
- DNS-01 calls get the shared-cert path's 4-minute budget (`acmeSharedIssueTimeout` precedent) — the HTTP-01 path's 60s would guarantee deadline failures.
- `ssl_certificates.issue_method` (`http-01` / `dns-01`) recorded for observability; NS decisions cached in-memory 1h (divergence from the ticket's cache-on-row sketch — self-heals, no schema).

### Providers
- **pdns** (jabali-authoritative): the existing hook path, unchanged.
- **Cloudflare**: `hostedsvc.CloudflareDNS` grew zone-explicit methods — `SetChallengeTXT`/`ClearChallengeTXT` (label variants now delegate; add-only + record-cap semantics preserved for the wildcard dual-TXT case), `FindZoneID`, `VerifyToken`. The hook writes `_acme-challenge.<domain>` into the customer zone resolved at the delegation point (subdomains anchor on the parent zone, per the ticket's `pinat.pcc.co.il` case).

### Token storage (security-sensitive)
- `server_settings.cf_api_token_enc` (migration 000259), sealed with **ssokey AES-256-GCM** (`automation_token.secret_enc` convention), `json:"-"` — never in any response.
- `GET/PUT/DELETE /admin/settings/cloudflare-token`: PUT **verifies against Cloudflare before storing** and reports how many zones the token sees; storage **refused (503) without sso.key** — plaintext-at-rest is not an option; GET reports configured yes/no only. Not in `settings_cmd` settableKeys (CLI args land in shell history). The generic settings PATCH can't touch or zero it (binds onto the loaded row).
- Masked write-only card on Server Settings (next to Panel SSL) with verify/clear; docs in the card advise a dedicated `Zone:DNS:Edit + Zone:Read` scoped token.

### Live validation (public DNS, production lookup path)
```
movi.co.il         → cloudflare zone, correctly reports "no API token configured"
pinat.pcc.co.il    → anchors on parent zone pcc.co.il (subdomain edge case) ✓
premiumhaifa.co.il → none (broken/absent delegation — correctly not auto-issuable)
google.com         → none ("delegated to ns1.google.com… — neither ours nor a provider")
```
(`go test -tags live ./internal/dns01/ -run TestLive -v` — committed, CI-inert.)

## Test plan
- [x] `dns01` decision table: CF covered/uncovered/no-token, subdomain→parent anchor, pdns, mixed-NS, third-party, no-delegation, resolver-outage fail-open
- [x] Reconciler routing: fronted+covered → `ssl.issue_dns01` (never `ssl.issue`), lineage + sans asserted; fronted+uncovered → **zero** ACME calls, cap untouched, daily re-check; direct → HTTP-01; unknown own-IP → fail-open; DNS-01 failure → cap ticks; fronted pdns zone → DNS-01
- [x] CF client vs fake: customer-zone TXT lifecycle (add-only, dup-idempotent, cap, clear-all), FindZoneID covered/uncovered, VerifyToken good/bad
- [x] Token endpoints: verify-before-store, stored **sealed** (unseals back, no plaintext), never echoed, 422 not stored, 503 without sso.key, clear clears
- [x] Full panel-api suite: **0 FAIL** (verified by count); OpenAPI coverage green; panel-ui `npm run build` green; gofmt/vet clean
- [x] Live NS-delegation probe against public DNS (table above)
- [ ] CI
- [ ] Post-merge, operator-side: store the CF token (Settings → Cloudflare DNS-01), then watch a covered fronted domain issue end-to-end

## Out of scope (per ticket)
The 12 uncovered domains (customer must grant token access or move NS) — they now surface with an explicit reason instead of silently failing. Fleet rollout/rearming of capped rows is an ops action, not this PR.

GH: JAB-235. Do NOT auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
