### PR TITLE
fix(dns): rediscover zones on upsert so a fresh zone is servable at once (GH #896)

### DIFF
--- a/panel-agent/internal/commands/dns_zone_upsert.go
+++ b/panel-agent/internal/commands/dns_zone_upsert.go
@@ -21,10 +21,10 @@ type dnsRecordParam struct {
 
 type dnsZoneUpsertParams struct {
 	// Zone is the apex name, no trailing dot. "example.com".
-	Zone            string             `json:"zone"`
-	Records         []dnsRecordParam   `json:"records"`
-	AllowAXFRFrom   []string           `json:"allow_axfr_from,omitempty"`
-	AlsoNotify      []string           `json:"also_notify,omitempty"`
+	Zone          string           `json:"zone"`
+	Records       []dnsRecordParam `json:"records"`
+	AllowAXFRFrom []string         `json:"allow_axfr_from,omitempty"`
+	AlsoNotify    []string         `json:"also_notify,omitempty"`
 }
 
 type dnsZoneUpsertResponse struct {
@@ -85,6 +85,17 @@ func dnsZoneUpsertHandler(ctx context.Context, params json.RawMessage) (any, err
 	}
 
 	// Signal PowerDNS:
+	//   0. rediscover — refresh pdns-auth's cached LIST of known zones so a
+	//      brand-new zone becomes servable IMMEDIATELY. jabali sets
+	//      zone-cache-refresh-interval=10, so pdns caches which zones it hosts
+	//      and won't answer for a just-inserted one until the next refresh —
+	//      measured ~20s of NXDOMAIN from the authoritative server itself for a
+	//      freshly-created (sub)domain (GH #896: dead page + certbot NXDOMAIN in
+	//      that window; verified `pdns_control help` lists `rediscover: discover
+	//      any new zones` on the installed pdns-auth). purge (below) only clears
+	//      the RECORD/packet cache, not the zone-list cache — so rediscover must
+	//      run first, else purge can't help a zone the server still thinks
+	//      doesn't exist. Cheap no-op when nothing new was added.
 	//   1. purge <zone>$ — invalidate the in-process query/packet cache
 	//      for this zone (the '$' suffix targets the zone + all names
 	//      under it). Without this, pdns serves the OLD answer from
@@ -96,9 +107,9 @@ func dnsZoneUpsertHandler(ctx context.Context, params json.RawMessage) (any, err
 	//      kept-alive by repeated queries and never evicted).
 	//   2. notify <zone> — tells slave NSes to AXFR. Cheap no-op when
 	//      there are no slaves.
-	// Both are best-effort: if pdns_control isn't reachable, the SQL
-	// change is still committed and a real pdns restart will pick up
-	// the change.
+	// All best-effort: if pdns_control isn't reachable, the SQL change is
+	// still committed and a real pdns restart will pick up the change.
+	_ = exec.CommandContext(ctx, "pdns_control", "rediscover").Run()
 	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:


### PR DESCRIPTION
## The residual ~20s — pinned to pdns-auth zone visibility

The read-only diagnostic settled it: for a freshly-created subdomain, the **authoritative** pdns-server (127.0.0.1:5300) itself returned nothing until **+23s**, even though records were inserted at +1s. The recursor/forwarder retries (#1050/#1052) weren't the bottleneck — they failed only because the *auth* wasn't serving the zone yet.

**Cause:** jabali sets `zone-cache-refresh-interval=10` on pdns-auth, so the server caches the **list** of zones it hosts and won't answer for a just-inserted one until that cache refreshes (~20s observed, ~2 cycles). `dns.zone.upsert` already `pdns_control purge`d the packet/record cache — but that does **not** refresh the zone *list*. A zone the server still thinks doesn't exist can't be helped by a record-cache purge.

**Fix:** run `pdns_control rediscover` ("discover any new zones", per the installed pdns-auth's own `pdns_control help`) **before** the purge, so a brand-new zone is served immediately. Best-effort like the sibling purge/notify.

**Box-checked:** running `rediscover` manually right after a create dropped resolution from **~24s → ~4s**.

## The full #896 chain (all four)
1. **#1048** — create Schedules an immediate ReconcileOne.
2. **#1050** — recursor probe retries instead of rolling back a fresh zone.
3. **#1052** — recursor forwarder added in ReconcileOne, not just the loop.
4. **this** — pdns-auth rediscovers the new zone so it's servable at once.

`go build` + `go test ./internal/commands/` green. Full end-to-end box verify (fresh domain resolves in ~seconds with the agent auto-running rediscover) after merge+deploy, before the #896 reply.

GH #896