### PR TITLE
fix(domains): deleted domains must actually die — durable teardown tombstones (JAB-236)

### DIFF
--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -245,26 +245,42 @@ func setDomainEnabledDirect(ctx context.Context, domainID string, enabled bool) 
 	return d, nil
 }
 
-// deleteDomainDirect removes a domain row. The reconciler detects the
-// missing row on its next tick and tears down the nginx vhost + SSL cert
-// backlog. No inline nginx call — matches the HTTP handler.
-func deleteDomainDirect(ctx context.Context, domainID string) (*models.Domain, error) {
+// deleteDomainDirect deletes a domain durably (JAB-236): tombstone before
+// the row, then the SYNCHRONOUS host-side teardown (Stalwart purge, nginx
+// vhost, pdns zone) via the shared userops path. teardownPending=true means
+// the row is gone but the agent-side teardown failed — the tombstone stays
+// and the reconciler retries it until it succeeds. Before this, the CLI
+// deleted only the DB row and left the domain SERVING.
+func deleteDomainDirect(ctx context.Context, domainID string) (d *models.Domain, teardownPending bool, err error) {
 	if err := initConfig(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if err := initDB(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	domains := domainRepoFromDB()
-	d, err := domains.FindByID(ctx, domainID)
+	d, err = domains.FindByID(ctx, domainID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, fmt.Errorf("domain %q not found", domainID)
+			return nil, false, fmt.Errorf("domain %q not found", domainID)
 		}
-		return nil, fmt.Errorf("lookup domain: %w", err)
+		return nil, false, fmt.Errorf("lookup domain: %w", err)
 	}
-	if err := domains.Delete(ctx, domainID); err != nil {
-		return nil, fmt.Errorf("delete domain row: %w", err)
+	// Agent is best-effort at init: without it the row still deletes and
+	// the tombstone carries the teardown to the reconciler.
+	var caller userops.AgentCaller
+	if err := initAgent(); err == nil && sharedAgent != nil {
+		caller = sharedAgent
 	}
-	return d, nil
+	deps := userops.Deps{
+		Domains:         domains,
+		DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
+		Agent:           caller,
+		Log:             sharedLog,
+	}
+	teardownPending, err = userops.DeleteDomain(ctx, deps, domainID, d.Name, false)
+	if err != nil {
+		return nil, false, fmt.Errorf("delete domain: %w", err)
+	}
+	return d, teardownPending, nil
 }

--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -78,46 +78,37 @@ func deleteUserDirect(ctx context.Context, userID string, purgeHome bool) error 
 		}
 	}
 
-	// Cascade domains first. Best-effort per-row so one failure doesn't
-	// strand a half-deleted user — matches the HTTP handler.
+	// Cascade domains first, through the JAB-236 durable path: tombstone
+	// before the row, then the synchronous executor (Stalwart purge +
+	// nginx vhost + pdns zone — the old inline version skipped the zone,
+	// leaking it in the pdns backend). Best-effort per-row so one failure
+	// doesn't strand a half-deleted user; a failed teardown leaves its
+	// tombstone for the reconciler to retry.
 	domains := domainRepoFromDB()
 	if owned, _, err := domains.ListByUserID(ctx, userID, repository.ListOptions{Limit: 500}); err == nil {
+		// sharedAgent is *agent.Client (concrete); assign only when
+		// non-nil — a nil *agent.Client boxed into AgentCaller is a
+		// non-nil interface and would panic inside Call.
+		var caller userops.AgentCaller
+		if sharedAgent != nil {
+			caller = sharedAgent
+		}
+		cascadeDeps := userops.Deps{
+			Domains:         domains,
+			DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
+			Agent:           caller,
+			Log:             slog.Default(),
+		}
 		for _, d := range owned {
-			// Purge the domain's Stalwart accounts BEFORE the row delete
-			// FK-cascades the mailbox rows away — same call the HTTP
-			// handler makes. Without this, jabali user delete left the
-			// Stalwart account behind -> re-migrating the same address hit
-			// {"type":"primaryKeyViolation","properties":["email"]}.
-			// sharedAgent is *agent.Client (concrete); nil-guard at the
-			// call site, not inside the helper (a nil *agent.Client boxed
-			// into AgentCaller is a non-nil interface and would panic).
-			if sharedAgent != nil {
-				if err := userops.PurgeDomainMail(ctx, sharedAgent, d.Name); err != nil {
-					slog.Warn("cli delete: stalwart domain purge failed",
-						"user_id", userID, "domain", d.Name, "err", err)
-				}
-			}
-			if err := domains.Delete(ctx, d.ID); err != nil {
+			pending, err := userops.DeleteDomain(ctx, cascadeDeps, d.ID, d.Name, false)
+			if err != nil {
 				slog.Warn("cli delete: cascade domain failed",
-					"user_id", userID, "domain_id", d.ID, "err", err)
+					"user_id", userID, "domain_id", d.ID, "domain", d.Name, "err", err)
 				continue
 			}
-			// Reap the nginx vhost now the row is gone: sites-enabled +
-			// sites-available <domain>.conf, reload, per-domain logs. The HTTP
-			// handler does this via Reconciler.ReconcileDeleted; the CLI has no
-			// reconciler, so it calls the agent's domain.delete RPC directly
-			// (same teardown the domain DELETE route drives). Without it,
-			// `jabali user delete` left orphan /etc/nginx/sites-*/<domain>.conf
-			// behind after the DB row + /home docroot were already gone — the
-			// vhost served a 404-docroot on the deleted domain's Host header.
-			// Best-effort: log + continue, matching the other agent cascades.
-			if sharedAgent != nil {
-				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				if _, err := sharedAgent.Call(agentCtx, "domain.delete", map[string]any{"domain": d.Name}); err != nil {
-					slog.Warn("cli delete: nginx vhost teardown failed",
-						"user_id", userID, "domain", d.Name, "err", err)
-				}
-				cancel()
+			if pending {
+				slog.Warn("cli delete: domain host teardown pending — the reconciler retries it",
+					"user_id", userID, "domain", d.Name)
 			}
 		}
 	}

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -237,12 +237,16 @@ func newDomainDeleteCmd() *cobra.Command {
 				}
 			}
 
-			if _, err := deleteDomainDirect(ctx, d.ID); err != nil {
+			_, teardownPending, err := deleteDomainDirect(ctx, d.ID)
+			if err != nil {
 				return err
 			}
 			cliAuditOK(ctx, "domain.delete", "domain", d.ID, &d.UserID)
-			fmt.Printf("Domain %s deleted (reconciler will tear down nginx vhost within %s)\n",
-				d.Name, sharedCfg.Agent.ReconcilerInterval)
+			if teardownPending {
+				fmt.Printf("Domain %s deleted; host-side teardown is PENDING (agent unreachable or teardown failed) — the reconciler retries it until it succeeds\n", d.Name)
+			} else {
+				fmt.Printf("Domain %s deleted (nginx vhost, mail accounts, and DNS zone torn down)\n", d.Name)
+			}
 			return nil
 		},
 	}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -268,6 +268,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		deps.Users = userRepo
 		deps.Packages = packageRepo
 		deps.Domains = domainRepo
+		deps.DomainTeardowns = repository.NewDomainTeardownRepository(sharedDB)
 		deps.SSO = ssoService
 		// M37 Phase 4: Adminer SSO bridge — engine-aware mint + PG shadow.
 		deps.AdminerSSO = sso.NewAdminerService(ssoService, adminerSSOTokenRepo)
@@ -381,6 +382,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// unseals the stored Cloudflare API token; nil key keeps Cloudflare
 		// DNS-01 unavailable (pdns-authoritative zones still work).
 		rec.WithDNS01Key(ssoKeyPtr)
+		// JAB-236 — retry engine for durable domain deletion.
+		rec.WithDomainTeardowns(deps.DomainTeardowns)
 		deps.ManagedIPs = managedIPRepo
 		deps.Reconciler = rec
 		deps.DNSZones = dnsZoneRepo

--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -83,7 +83,9 @@ type AutomationConfig struct {
 	// Narrow reconciler slices (typed-nil-safe: wire via the app's
 	// nil-guard, never a bare *reconciler.Reconciler that might be nil).
 	LimitsReconciler userops.LimitsReconciler
-	DomainReconciler userops.DomainReconciler
+	// DomainTeardowns persists the JAB-236 tombstones for durable
+	// domain teardown on the billing delete cascade.
+	DomainTeardowns repository.DomainTeardownRepository
 	// DomainCreate carries the same deps the GUI domain handler uses, so
 	// JAB-233 account-create-with-domain runs the exact createDomainOp
 	// orchestration. Nil-safe: when unset (or its repos nil), a create that

--- a/panel-api/internal/api/automation_billing.go
+++ b/panel-api/internal/api/automation_billing.go
@@ -66,14 +66,15 @@ func automationUserLookupResponse(c *gin.Context, u *models.User, err error) {
 // automation config (mirror of userHandler.userOpsDeps — one write path).
 func billingUserOpsDeps(cfg AutomationConfig) userops.Deps {
 	return userops.Deps{
-		Users:        cfg.Users,
-		Packages:     cfg.Packages,
-		Domains:      cfg.Domains,
-		DockerApps:   cfg.DockerApps,
-		Agent:        cfg.Agent,
-		KratosClient: cfg.KratosClient,
-		BcryptCost:   cfg.BcryptCost,
-		Log:          cfg.Log,
+		Users:           cfg.Users,
+		Packages:        cfg.Packages,
+		Domains:         cfg.Domains,
+		DockerApps:      cfg.DockerApps,
+		DomainTeardowns: cfg.DomainTeardowns,
+		Agent:           cfg.Agent,
+		KratosClient:    cfg.KratosClient,
+		BcryptCost:      cfg.BcryptCost,
+		Log:             cfg.Log,
 	}
 }
 
@@ -81,7 +82,6 @@ func billingDeleteDeps(cfg AutomationConfig) userops.DeleteDeps {
 	dd := userops.DeleteDeps{
 		Databases:     cfg.Databases,
 		DatabaseUsers: cfg.DatabaseUsers,
-		Reconciler:    cfg.DomainReconciler,
 	}
 	if cfg.Redis != nil {
 		rdb := cfg.Redis

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -23,16 +23,21 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/reconciler"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
 )
 
 type DomainHandlerConfig struct {
-	Domains     repository.DomainRepository
-	Users       repository.UserRepository
-	SSLCerts    repository.SSLCertificateRepository
-	SharedCerts repository.SharedCertificateRepository
-	Packages    repository.PackageRepository
-	Agent       agent.AgentInterface
-	Reconciler  *reconciler.Reconciler
+	Domains repository.DomainRepository
+	// DomainTeardowns persists the JAB-236 tombstones: delete writes one
+	// BEFORE the row goes, so the host-side teardown survives a panel
+	// restart and gets retried by the reconciler until it succeeds.
+	DomainTeardowns repository.DomainTeardownRepository
+	Users           repository.UserRepository
+	SSLCerts        repository.SSLCertificateRepository
+	SharedCerts     repository.SharedCertificateRepository
+	Packages        repository.PackageRepository
+	Agent           agent.AgentInterface
+	Reconciler      *reconciler.Reconciler
 	// DNSZones + DNSRecords feed the auto-enable-email path on create.
 	// Both optional — when unset, create proceeds without flipping email
 	// on (matches the pre-auto-enable behaviour). The explicit
@@ -1140,27 +1145,27 @@ func (h *domainHandler) delete(c *gin.Context) {
 		return
 	}
 
-	// Capture name BEFORE deleting — once the DB row is gone, the
-	// reconciler can't look it up by ID. We pass the name to
-	// ReconcileDeleted which targets the agent-side teardown directly.
-	name := domain.Name
-	if err := h.cfg.Domains.Delete(ctx, domain.ID); err != nil {
+	// JAB-236: durable delete via the shared userops path — tombstone
+	// BEFORE the row goes (the row is the only natural handle), Stalwart
+	// purge + vhost + pdns teardown inside the executor, retried by the
+	// reconciler sweep if the async attempt fails or the panel restarts.
+	// The user still sees the row gone immediately (async attempt).
+	_, err = userops.DeleteDomain(ctx, userops.Deps{
+		Domains:         h.cfg.Domains,
+		DomainTeardowns: h.cfg.DomainTeardowns,
+		Agent:           h.cfg.Agent,
+	}, domain.ID, domain.Name, true)
+	if err != nil {
 		// M6.4 (ADR-0048): the panel-primary row is delete-protected at
 		// the repo layer. Translate to 403 with a specific error code
 		// so the panel UI can render a tooltip instead of a generic 500.
+		// DeleteDomain guarantees NOTHING host-side ran in this case.
 		if errors.Is(err, repository.ErrCannotDeletePanelPrimary) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "panel_primary_protected"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
-	}
-
-	// Tear down OS-level resources out-of-band. Best-effort: the user
-	// sees the row gone immediately; if agent teardown fails, the next
-	// ReconcileAll tick logs the orphan for ops to investigate.
-	if h.cfg.Reconciler != nil {
-		go h.cfg.Reconciler.ReconcileDeleted(context.Background(), name)
 	}
 
 	c.Status(http.StatusNoContent)

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -40,6 +40,9 @@ type UserHandlerConfig struct {
 	DockerApps      repository.DockerAppRepository
 	Mailboxes       repository.MailboxRepository
 	Packages        repository.PackageRepository
+	// DomainTeardowns persists the JAB-236 tombstones that make the
+	// cascade's domain teardown durable across panel restarts.
+	DomainTeardowns repository.DomainTeardownRepository
 	Reconciler      *reconciler.Reconciler
 	Log             *slog.Logger
 	// Redis is the shared client used to revoke a tenant's wp_<osuser> cache
@@ -533,7 +536,6 @@ func (h *userHandler) delete(c *gin.Context) {
 	err = userops.DeleteCascade(c.Request.Context(), h.userOpsDeps(), userops.DeleteDeps{
 		Databases:     h.cfg.Databases,
 		DatabaseUsers: h.cfg.DatabaseUsers,
-		Reconciler:    reconcilerOrNil(h.cfg.Reconciler),
 		RevokeCacheACLs: func(ctx context.Context, osUser string) error {
 			return revokeAllUserCacheACLs(ctx, h.cfg.Redis, osUser)
 		},
@@ -576,25 +578,16 @@ func (h *userHandler) userOpsDeps() userops.Deps {
 		log = slog.Default()
 	}
 	return userops.Deps{
-		Users:        h.cfg.Repo,
-		Packages:     h.cfg.Packages,
-		Domains:      h.cfg.Domains,
-		DockerApps:   h.cfg.DockerApps,
-		Agent:        h.cfg.Agent,
-		KratosClient: h.cfg.KratosClient,
-		BcryptCost:   h.cfg.BcryptCost,
-		Log:          log,
+		Users:           h.cfg.Repo,
+		Packages:        h.cfg.Packages,
+		Domains:         h.cfg.Domains,
+		DockerApps:      h.cfg.DockerApps,
+		DomainTeardowns: h.cfg.DomainTeardowns,
+		Agent:           h.cfg.Agent,
+		KratosClient:    h.cfg.KratosClient,
+		BcryptCost:      h.cfg.BcryptCost,
+		Log:             log,
 	}
-}
-
-// reconcilerOrNil avoids a typed-nil *reconciler.Reconciler boxed in the
-// DomainReconciler interface (the != nil guard would pass, then SIGSEGV —
-// the exact class of bug HANDOFF §9 warns about).
-func reconcilerOrNil(r *reconciler.Reconciler) userops.DomainReconciler {
-	if r == nil {
-		return nil
-	}
-	return r
 }
 
 // errDetail strips a userops sentinel prefix ("<sentinel>: ") from a

--- a/panel-api/internal/api/users_delete_mailbox_cascade_test.go
+++ b/panel-api/internal/api/users_delete_mailbox_cascade_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -141,9 +142,16 @@ func TestUserDelete_DestroysStalwartAccounts(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
 	// The whole domain's Stalwart accounts must be purged (by domain, not
-	// per panel row — so orphans without a row are caught too). Fires
-	// synchronously in the cascade before the response.
-	if !ag.purgedDomain("victim.example.com") {
-		t.Errorf("expected mail.domain.purge_accounts for victim.example.com; calls=%v", ag.calls)
+	// per panel row — so orphans without a row are caught too). JAB-236
+	// moved the purge into the durable async teardown executor (it must
+	// never run before a delete the repo layer could still refuse), so
+	// the assertion awaits the detached goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ag.purgedDomain("victim.example.com") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Errorf("expected mail.domain.purge_accounts for victim.example.com; calls=%v", ag.calls)
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -38,10 +38,13 @@ import (
 // argument list short. Anything a handler family needs — Kratos client,
 // repositories — plugs in here.
 type Deps struct {
-	KratosClient        *kratosclient.Client
-	Users               repository.UserRepository
-	Packages            repository.PackageRepository
-	Domains             repository.DomainRepository
+	KratosClient *kratosclient.Client
+	Users        repository.UserRepository
+	Packages     repository.PackageRepository
+	Domains      repository.DomainRepository
+	// DomainTeardowns persists the JAB-236 tombstones for durable domain
+	// deletion (REST + billing cascade + reconciler retry sweep).
+	DomainTeardowns     repository.DomainTeardownRepository
 	Databases           repository.DatabaseRepository
 	DatabaseUsers       repository.DatabaseUserRepository
 	DatabaseUserGrants  repository.DatabaseUserGrantRepository
@@ -440,7 +443,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				DockerApps:       deps.DockerApps,
 				KratosClient:     deps.KratosClient,
 				LimitsReconciler: automationLimitsReconciler(deps.Reconciler),
-				DomainReconciler: automationDomainReconciler(deps.Reconciler),
+				DomainTeardowns:  deps.DomainTeardowns,
 				DiskSnapshots:    repository.NewDiskUsageSnapshotRepository(deps.DB),
 				BWDaily:          deps.BWDaily,
 				Log:              deps.Log,
@@ -609,6 +612,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Databases:       deps.Databases,
 				DatabaseUsers:   deps.DatabaseUsers,
 				DockerApps:      deps.DockerApps,
+				DomainTeardowns: deps.DomainTeardowns,
 				Mailboxes:       deps.Mailboxes,
 				Packages:        deps.Packages,
 				Reconciler:      deps.Reconciler,
@@ -640,13 +644,15 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainRoutes(v1, api.DomainHandlerConfig{
-				Domains:     deps.Domains,
-				Users:       deps.Users,
-				Packages:    deps.Packages,
-				Agent:       deps.Agent,
-				Reconciler:  deps.Reconciler,
-				SSLCerts:    deps.SSLCerts,
-				SharedCerts: deps.SharedCerts,
+				Domains: deps.Domains,
+				// JAB-236: durable delete — tombstone before the row goes.
+				DomainTeardowns: deps.DomainTeardowns,
+				Users:           deps.Users,
+				Packages:        deps.Packages,
+				Agent:           deps.Agent,
+				Reconciler:      deps.Reconciler,
+				SSLCerts:        deps.SSLCerts,
+				SharedCerts:     deps.SharedCerts,
 				// DNS repos feed the auto-enable-email path in create.
 				// Panel profiles without PowerDNS leave these nil and
 				// create still works — auto-enable is skipped cleanly.
@@ -1443,17 +1449,10 @@ func cacheHMACSecret() string {
 }
 
 // automationOps builds the JAB-140 async-operation repo (nil when no DB).
-// automationLimitsReconciler / automationDomainReconciler adapt the concrete
+// automationLimitsReconciler adapts the concrete
 // reconciler to the narrow userops interfaces WITHOUT boxing a typed nil
 // into the interface (the != nil guard would pass, then SIGSEGV — HANDOFF §9).
 func automationLimitsReconciler(r *reconciler.Reconciler) userops.LimitsReconciler {
-	if r == nil {
-		return nil
-	}
-	return r
-}
-
-func automationDomainReconciler(r *reconciler.Reconciler) userops.DomainReconciler {
 	if r == nil {
 		return nil
 	}

--- a/panel-api/internal/db/migrations/000260_domain_teardowns.down.sql
+++ b/panel-api/internal/db/migrations/000260_domain_teardowns.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE domain_teardowns;

--- a/panel-api/internal/db/migrations/000260_domain_teardowns.up.sql
+++ b/panel-api/internal/db/migrations/000260_domain_teardowns.up.sql
@@ -1,0 +1,17 @@
+-- JAB-236: durable host-side teardown for deleted domains.
+--
+-- Deleting a domain removes the panel row — the only handle — before the
+-- host-side teardown (nginx vhost, pdns zone, Stalwart accounts) runs. A
+-- fire-and-forget goroutine (REST/cascade) is lost on panel restart, and
+-- the CLI dispatched nothing at all, leaving deleted domains SERVING.
+-- This table is the tombstone: written BEFORE the row delete, removed only
+-- after the teardown verifiably succeeds; the reconciler retries pending
+-- rows every sweep. domain_name is the primary key so tombstone creation
+-- is naturally idempotent.
+CREATE TABLE domain_teardowns (
+  domain_name     varchar(255) NOT NULL PRIMARY KEY,
+  attempts        int          NOT NULL DEFAULT 0,
+  last_error      varchar(1024) NOT NULL DEFAULT '',
+  last_attempt_at datetime(6)  NULL,
+  created_at      datetime(6)  NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/models/domain_teardown.go
+++ b/panel-api/internal/models/domain_teardown.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+// DomainTeardown is the durable handle for a deleted domain's host-side
+// teardown (JAB-236). The panel row is the only natural handle and it is
+// gone by design once the operator deletes the domain — this tombstone is
+// written BEFORE the row delete and removed only after the agent-side
+// teardown (Stalwart purge, nginx vhost, pdns zone) verifiably succeeds,
+// so a panel restart or agent outage mid-delete can no longer leave a
+// deleted domain serving.
+type DomainTeardown struct {
+	DomainName    string     `gorm:"column:domain_name;type:varchar(255);primaryKey" json:"domain_name"`
+	Attempts      int        `gorm:"column:attempts;type:int;not null;default:0" json:"attempts"`
+	LastError     string     `gorm:"column:last_error;type:varchar(1024);not null;default:''" json:"last_error"`
+	LastAttemptAt *time.Time `gorm:"column:last_attempt_at;type:datetime(6)" json:"last_attempt_at,omitempty"`
+	CreatedAt     time.Time  `gorm:"column:created_at;type:datetime(6);not null" json:"created_at"`
+}
+
+func (DomainTeardown) TableName() string { return "domain_teardowns" }

--- a/panel-api/internal/reconciler/domain_teardowns.go
+++ b/panel-api/internal/reconciler/domain_teardowns.go
@@ -1,0 +1,100 @@
+package reconciler
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
+)
+
+// JAB-236 — the reconciler is the retry engine behind durable domain
+// deletion. Delete paths write a domain_teardowns tombstone BEFORE the row
+// goes and attempt the teardown immediately; this sweep re-drives every
+// pending tombstone (panel restarted mid-delete, agent was down) through
+// the SAME executor until it succeeds. Runs BEFORE the orphan sweep so a
+// just-torn-down site never gets warned about.
+
+// domainTeardownRetryAfter throttles per-tombstone retries — a down agent
+// fails everything anyway, and once it's back one retry finishes the job.
+const domainTeardownRetryAfter = 5 * time.Minute
+
+// WithDomainTeardowns wires the tombstone repo. Nil-safe: without it the
+// sweep is a no-op and delete durability degrades to the immediate attempt.
+func (r *Reconciler) WithDomainTeardowns(repo repository.DomainTeardownRepository) *Reconciler {
+	r.domainTeardowns = repo
+	return r
+}
+
+// processDomainTeardowns drives pending tombstones and returns the set of
+// names still pending (the orphan sweep skips those — they are being
+// handled, not orphaned).
+func (r *Reconciler) processDomainTeardowns(ctx context.Context) map[string]bool {
+	pending := map[string]bool{}
+	if r.domainTeardowns == nil {
+		return pending
+	}
+	rows, err := r.domainTeardowns.List(ctx)
+	if err != nil {
+		r.log.Error("domain teardowns: list failed", "err", err)
+		return pending
+	}
+	now := time.Now().UTC()
+	for i := range rows {
+		row := &rows[i]
+		name := row.DomainName
+
+		// Live-row guard. A tombstone with a live domain row is stale —
+		// either the row delete was refused after the tombstone was
+		// written (crash in the gap), or the operator re-created the name
+		// before a failed teardown retried. Acting on it would tear down
+		// a LIVE site (worst case: the panel's own primary). Drop it.
+		if live, ferr := r.domains.FindByName(ctx, name); ferr == nil && live != nil {
+			r.log.Warn("domain teardowns: tombstone for a live domain — dropping without teardown",
+				"domain", name)
+			_ = r.domainTeardowns.Delete(ctx, name)
+			continue
+		}
+
+		if row.LastAttemptAt != nil && now.Sub(*row.LastAttemptAt) < domainTeardownRetryAfter {
+			pending[name] = true
+			continue
+		}
+		if err := userops.ExecuteDomainTeardown(ctx, r.agent, name); err != nil {
+			r.log.Warn("domain teardowns: retry failed — will retry again",
+				"domain", name, "attempts", row.Attempts+1, "err", err)
+			_ = r.domainTeardowns.MarkAttempt(ctx, name, err.Error())
+			pending[name] = true
+			continue
+		}
+		_ = r.domainTeardowns.Delete(ctx, name)
+		r.log.Info("domain teardowns: host-side teardown completed", "domain", name, "attempts", row.Attempts+1)
+	}
+	return pending
+}
+
+// reportOrphanSites replaces the per-site-per-tick warning storm (the
+// ticket's "800 warnings in 40 minutes") with ONE aggregated warning,
+// emitted only when the orphan set CHANGES. The sweep's mandate stays
+// deliberately conservative: it never auto-deletes an agent site it has no
+// row for — an agent-known site with no DB row cannot be distinguished
+// from out-of-band operator work with certainty, and deleting a serving
+// site on a guess is worse than leaving it. Tombstoned deletes are the
+// self-healing path; everything else is surfaced once, actionably.
+func (r *Reconciler) reportOrphanSites(orphans []string) {
+	sort.Strings(orphans)
+	key := strings.Join(orphans, ",")
+	if key == r.lastOrphanKey {
+		return // unchanged set — stay quiet
+	}
+	r.lastOrphanKey = key
+	if len(orphans) == 0 {
+		r.log.Info("reconcile: no orphan sites remain in agent")
+		return
+	}
+	r.log.Warn("reconcile: orphan sites found in agent with no DB rows — not auto-deleted; "+
+		"remove with `jabali agent call domain.delete` / `dns.zone.delete` if unwanted",
+		"count", len(orphans), "sites", strings.Join(orphans, ", "))
+}

--- a/panel-api/internal/reconciler/domain_teardowns_test.go
+++ b/panel-api/internal/reconciler/domain_teardowns_test.go
@@ -1,0 +1,197 @@
+package reconciler
+
+// JAB-236 sweep properties:
+//  1. A pending tombstone is driven through the shared executor and
+//     cleared on success.
+//  2. Live-row guard: a tombstone whose domain name has a LIVE row is
+//     dropped WITHOUT any agent call — it is stale (crash in the
+//     create-tombstone→delete-row gap, refused delete, or the name was
+//     re-registered before a failed teardown retried). Acting on it would
+//     tear down a serving site.
+//  3. A failed teardown keeps the tombstone and reports it as pending so
+//     the orphan sweep stays quiet about it.
+//  4. Backoff: a recently-attempted tombstone is skipped this tick.
+//  5. The orphan report fires ONCE per set change, not per site per tick.
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// memTeardowns is a race-safe in-memory DomainTeardownRepository.
+type memTeardowns struct {
+	mu   sync.Mutex
+	rows map[string]*models.DomainTeardown
+}
+
+func newMemTeardowns(names ...string) *memTeardowns {
+	m := &memTeardowns{rows: map[string]*models.DomainTeardown{}}
+	for _, n := range names {
+		m.rows[n] = &models.DomainTeardown{DomainName: n, CreatedAt: time.Now().UTC()}
+	}
+	return m
+}
+
+func (m *memTeardowns) Ensure(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.rows[name]; !ok {
+		m.rows[name] = &models.DomainTeardown{DomainName: name, CreatedAt: time.Now().UTC()}
+	}
+	return nil
+}
+
+func (m *memTeardowns) List(_ context.Context) ([]models.DomainTeardown, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]models.DomainTeardown, 0, len(m.rows))
+	for _, r := range m.rows {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func (m *memTeardowns) Delete(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rows, name)
+	return nil
+}
+
+func (m *memTeardowns) MarkAttempt(_ context.Context, name, lastError string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r, ok := m.rows[name]; ok {
+		r.Attempts++
+		r.LastError = lastError
+		now := time.Now().UTC()
+		r.LastAttemptAt = &now
+	}
+	return nil
+}
+
+func (m *memTeardowns) has(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.rows[name]
+	return ok
+}
+
+func teardownSweepFixture(t *testing.T, tombNames ...string) (*Reconciler, *fakeAgent, *memTeardowns, *fakeDomainRepo) {
+	t.Helper()
+	dr := newFakeDomainRepo()
+	ag := &fakeAgent{}
+	tombs := newMemTeardowns(tombNames...)
+	r := New(dr, nil, ag, slog.Default(), Config{}).WithDomainTeardowns(tombs)
+	return r, ag, tombs, dr
+}
+
+func TestTeardownSweep_ClearsOnSuccess(t *testing.T) {
+	r, ag, tombs, _ := teardownSweepFixture(t, "gone.example")
+
+	pending := r.processDomainTeardowns(context.Background())
+
+	if !agentCalled(ag, "domain.delete") || !agentCalled(ag, "dns.zone.delete") {
+		t.Fatal("sweep must drive the full teardown for a pending tombstone")
+	}
+	if tombs.has("gone.example") {
+		t.Fatal("tombstone must be cleared after a successful teardown")
+	}
+	if len(pending) != 0 {
+		t.Fatalf("nothing should remain pending: %v", pending)
+	}
+}
+
+func TestTeardownSweep_LiveRowGuard(t *testing.T) {
+	r, ag, tombs, dr := teardownSweepFixture(t, "alive.example")
+	dr.domains["d1"] = &models.Domain{ID: "d1", Name: "alive.example", IsEnabled: true}
+
+	r.processDomainTeardowns(context.Background())
+
+	if len(ag.calls) != 0 {
+		t.Fatal("a tombstone with a LIVE row must trigger NO agent call — it is stale, and executing it would tear down a serving site (worst case the panel's own primary)")
+	}
+	if tombs.has("alive.example") {
+		t.Fatal("stale tombstone must be dropped")
+	}
+}
+
+func TestTeardownSweep_FailureKeepsPending(t *testing.T) {
+	r, ag, tombs, _ := teardownSweepFixture(t, "gone.example")
+	ag.failMethod = "domain.delete"
+
+	pending := r.processDomainTeardowns(context.Background())
+
+	if !tombs.has("gone.example") {
+		t.Fatal("tombstone must survive a failed retry")
+	}
+	if !pending["gone.example"] {
+		t.Fatal("a failed teardown must be reported pending so the orphan sweep skips it")
+	}
+	tombs.mu.Lock()
+	attempts := tombs.rows["gone.example"].Attempts
+	tombs.mu.Unlock()
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestTeardownSweep_BacksOffRecentAttempts(t *testing.T) {
+	r, ag, tombs, _ := teardownSweepFixture(t, "gone.example")
+	recent := time.Now().UTC().Add(-time.Minute)
+	tombs.rows["gone.example"].LastAttemptAt = &recent
+
+	pending := r.processDomainTeardowns(context.Background())
+
+	if len(ag.calls) != 0 {
+		t.Fatal("a recently-attempted tombstone must be skipped this tick")
+	}
+	if !pending["gone.example"] {
+		t.Fatal("a backed-off tombstone is still pending (the orphan sweep must skip it)")
+	}
+}
+
+// countingHandler counts slog records at Warn level.
+type countingHandler struct {
+	mu    sync.Mutex
+	warns int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) Handle(_ context.Context, rec slog.Record) error {
+	if rec.Level == slog.LevelWarn {
+		h.mu.Lock()
+		h.warns++
+		h.mu.Unlock()
+	}
+	return nil
+}
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestReportOrphanSites_WarnsOncePerSetChange(t *testing.T) {
+	h := &countingHandler{}
+	r := New(newFakeDomainRepo(), nil, &fakeAgent{}, slog.New(h), Config{})
+
+	r.reportOrphanSites([]string{"b.example", "a.example"})
+	r.reportOrphanSites([]string{"a.example", "b.example"}) // same set, different order
+	r.reportOrphanSites([]string{"a.example", "b.example"})
+	if h.warns != 1 {
+		t.Fatalf("warns = %d, want 1 — the per-tick warning storm is the bug this fixes", h.warns)
+	}
+
+	r.reportOrphanSites([]string{"a.example"}) // set changed
+	if h.warns != 2 {
+		t.Fatalf("warns = %d, want 2 after a set change", h.warns)
+	}
+
+	r.reportOrphanSites(nil) // cleared — informational, not a warning
+	if h.warns != 2 {
+		t.Fatalf("warns = %d, want 2 after clearing", h.warns)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -59,6 +59,10 @@ type Reconciler struct {
 	// JAB-235 DNS-01 routing state — see dns01_routing.go.
 	dns01State
 
+	// JAB-236 durable domain deletion — see domain_teardowns.go.
+	domainTeardowns repository.DomainTeardownRepository
+	lastOrphanKey   string
+
 	// sslIssueMu serialises certbot-touching work across the JAB-205
 	// domain worker pool AND the out-of-band ReconcileOne path: certbot
 	// holds a global /var/lib/letsencrypt lock, so two concurrent runs
@@ -915,7 +919,14 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		"jabali-panel":    true,
 	}
 
-	// 3. Orphan in agent set (no DB row) -> log warning but don't auto-delete
+	// JAB-236: drive pending teardown tombstones FIRST — a site being torn
+	// down through its tombstone is handled, not orphaned, and must not
+	// show up in the orphan report below.
+	pendingTeardowns := r.processDomainTeardowns(ctx)
+
+	// 3. Orphan in agent set (no DB row) -> aggregate ONE warning (on set
+	// change only — see reportOrphanSites for the mandate), never auto-delete.
+	var orphanSites []string
 	for site := range agentSites {
 		if knownSystemSites[site] {
 			continue
@@ -929,8 +940,9 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		}
 		if _, found := enabledDomains[site]; !found {
 			if _, found := disabledDomains[site]; !found {
-				r.log.Warn("reconcile: orphan site found in agent, no DB row", "site", site,
-					"detail", "manual cleanup may be needed")
+				if !pendingTeardowns[site] {
+					orphanSites = append(orphanSites, site)
+				}
 				// M6.3: also drop the recursor forwarder — idempotent, so
 				// safe even if it was never added. Keeps the forwards file
 				// from accumulating stale zones when a domain gets deleted
@@ -941,6 +953,7 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 			}
 		}
 	}
+	r.reportOrphanSites(orphanSites)
 
 	tt.mark("disable_orphan_sweep")
 

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -2134,27 +2134,6 @@ func (r *Reconciler) resolveListenIPAddress(ctx context.Context, id *uint64, fam
 	return row.Address
 }
 
-// been removed. Called by the DELETE handler after it deletes the row,
-// because once the row is gone ReconcileOne(id) can no longer find it
-// and orphan detection in ReconcileAll is intentionally conservative
-// (log-only). This is the explicit "yes, actually tear this down" path.
-func (r *Reconciler) ReconcileDeleted(ctx context.Context, domainName string) {
-	if domainName == "" {
-		return
-	}
-	callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	_, err := r.agent.Call(callCtx, "domain.delete", map[string]string{"domain": domainName})
-	if err != nil {
-		r.log.Warn("domain delete failed on agent",
-			"domain", domainName,
-			"err", err)
-	}
-
-	// Reconcile DNS zone deletion if DNS repos are wired
-	r.reconcileDNSZoneDeleted(ctx, domainName)
-}
-
 // reconcileDNSZone ensures a domain's DNS zone and records are provisioned
 // on the agent. Called during domain reconciliation to push the zone state
 // to PowerDNS via the agent.
@@ -2279,22 +2258,6 @@ func (r *Reconciler) reconcileDNSZone(ctx context.Context, domain *models.Domain
 		return
 	}
 	r.dnsZonePushed(zone.ID, hash, now)
-}
-
-// reconcileDNSZoneDeleted tears down a DNS zone on the agent after its DB row
-// has been deleted. Called by the domain deletion handler.
-func (r *Reconciler) reconcileDNSZoneDeleted(ctx context.Context, zoneName string) {
-	if r.dnsZones == nil {
-		return // DNS feature not wired — skip
-	}
-	if zoneName == "" {
-		return
-	}
-	pushCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-	if _, err := r.agent.Call(pushCtx, "dns.zone.delete", map[string]string{"zone": zoneName}); err != nil {
-		r.log.Warn("dns.zone.delete failed", "zone", zoneName, "err", err)
-	}
 }
 
 // linuxUserFromEmail derives the Linux username from an email address.

--- a/panel-api/internal/repository/domain_teardown_repository.go
+++ b/panel-api/internal/repository/domain_teardown_repository.go
@@ -1,0 +1,59 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// DomainTeardownRepository persists the JAB-236 teardown tombstones. See
+// models.DomainTeardown for the lifecycle.
+type DomainTeardownRepository interface {
+	// Ensure creates the tombstone if absent — idempotent by primary key,
+	// so racing delete paths cannot duplicate it.
+	Ensure(ctx context.Context, domainName string) error
+	List(ctx context.Context) ([]models.DomainTeardown, error)
+	Delete(ctx context.Context, domainName string) error
+	// MarkAttempt bumps the attempt counter and records the failure.
+	MarkAttempt(ctx context.Context, domainName, lastError string) error
+}
+
+type domainTeardownRepo struct{ db *gorm.DB }
+
+func NewDomainTeardownRepository(db *gorm.DB) DomainTeardownRepository {
+	return &domainTeardownRepo{db: db}
+}
+
+func (r *domainTeardownRepo) Ensure(ctx context.Context, domainName string) error {
+	row := &models.DomainTeardown{DomainName: domainName, CreatedAt: time.Now().UTC()}
+	return r.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(row).Error
+}
+
+func (r *domainTeardownRepo) List(ctx context.Context) ([]models.DomainTeardown, error) {
+	var rows []models.DomainTeardown
+	err := r.db.WithContext(ctx).Order("created_at").Find(&rows).Error
+	return rows, err
+}
+
+func (r *domainTeardownRepo) Delete(ctx context.Context, domainName string) error {
+	return r.db.WithContext(ctx).Where("domain_name = ?", domainName).
+		Delete(&models.DomainTeardown{}).Error
+}
+
+func (r *domainTeardownRepo) MarkAttempt(ctx context.Context, domainName, lastError string) error {
+	if len(lastError) > 1024 {
+		lastError = lastError[:1024]
+	}
+	now := time.Now().UTC()
+	return r.db.WithContext(ctx).Model(&models.DomainTeardown{}).
+		Where("domain_name = ?", domainName).
+		Updates(map[string]any{
+			"attempts":        gorm.Expr("attempts + 1"),
+			"last_error":      lastError,
+			"last_attempt_at": now,
+		}).Error
+}

--- a/panel-api/internal/userops/domain_delete.go
+++ b/panel-api/internal/userops/domain_delete.go
@@ -1,0 +1,131 @@
+package userops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// JAB-236 — durable domain deletion.
+//
+// The panel row is the only handle, and every pre-existing delete path gave
+// it up before the host-side teardown was safe: REST and the user cascade
+// fired a goroutine that a panel restart silently lost, and the CLI
+// dispatched nothing at all — deleted domains kept SERVING (live vhost,
+// answering pdns zone, Stalwart accounts) with no retry handle left.
+//
+// The fix inverts #1010 for this shape: a delete-protected row must refuse
+// (databases keep the row), but a deleted domain's teardown must be
+// DURABLE — so the tombstone (domain_teardowns) is written BEFORE the row
+// delete and cleared only after the teardown verifiably succeeds. The
+// reconciler retries pending tombstones every sweep.
+//
+// Ordering matters twice over:
+//   - Tombstone before row delete: a crash in between leaves a tombstone
+//     whose live-row guard (the sweep checks FindByName) makes it a no-op.
+//   - Stalwart purge INSIDE the executor, after the row is gone: the purge
+//     destroys live mailboxes, so it must never run for a delete the repo
+//     layer then refuses (panel-primary protection).
+
+// teardownStep names one executor step for error reporting.
+type teardownStep struct {
+	name string
+	call func(ctx context.Context) error
+}
+
+// ExecuteDomainTeardown runs the full host-side teardown for a domain whose
+// panel row is already gone: Stalwart account purge, nginx vhost removal
+// (domain.delete also reaps the mail vhost, relay cred, and logs), and the
+// pdns zone. Every step is idempotent agent-side, so retries are safe. An
+// error means the tombstone must stay for the reconciler to retry.
+func ExecuteDomainTeardown(ctx context.Context, agent AgentCaller, name string) error {
+	if agent == nil {
+		return fmt.Errorf("domain teardown %s: no agent wired", name)
+	}
+	steps := []teardownStep{
+		{"mail.domain.purge_accounts", func(ctx context.Context) error {
+			return PurgeDomainMail(ctx, agent, name)
+		}},
+		{"domain.delete", func(ctx context.Context) error {
+			cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			_, err := agent.Call(cctx, "domain.delete", map[string]string{"domain": name})
+			return err
+		}},
+		{"dns.zone.delete", func(ctx context.Context) error {
+			cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			_, err := agent.Call(cctx, "dns.zone.delete", map[string]string{"zone": name})
+			// A box without the DNS module has no PowerDNS backend at all.
+			// That is a permanent condition, not a transient failure — a
+			// tombstone must not retry it forever.
+			if err != nil && strings.Contains(err.Error(), "powerdns backend not available") {
+				return nil
+			}
+			return err
+		}},
+	}
+	for _, s := range steps {
+		if err := s.call(ctx); err != nil {
+			return fmt.Errorf("domain teardown %s: %s: %w", name, s.name, err)
+		}
+	}
+	return nil
+}
+
+// DeleteDomain removes a domain durably. Row-delete errors (including the
+// panel-primary protection) are returned verbatim with NOTHING host-side
+// executed and no tombstone left behind. On success the row is gone;
+// teardownPending reports whether the host-side teardown is still owed (the
+// tombstone stays and the reconciler retries until it succeeds).
+//
+// async=true (REST, cascade) attempts the teardown in a detached goroutine
+// so the caller returns immediately — durability no longer depends on that
+// goroutine surviving, only on the tombstone. async=false (CLI) waits and
+// reports the true outcome.
+func DeleteDomain(ctx context.Context, d Deps, domainID, domainName string, async bool) (teardownPending bool, err error) {
+	if d.Domains == nil {
+		return false, ErrDeps
+	}
+	if d.DomainTeardowns != nil {
+		if err := d.DomainTeardowns.Ensure(ctx, domainName); err != nil {
+			return false, fmt.Errorf("create teardown tombstone: %w", err)
+		}
+	}
+	if err := d.Domains.Delete(ctx, domainID); err != nil {
+		// The delete was refused (panel-primary, FK, transient DB error):
+		// the row remains the handle, so the tombstone must go — a stale
+		// tombstone against a live row is a loaded gun for the sweep's
+		// live-row guard to have to catch.
+		if d.DomainTeardowns != nil {
+			_ = d.DomainTeardowns.Delete(ctx, domainName)
+		}
+		return false, err
+	}
+
+	finish := func(ctx context.Context) bool {
+		if terr := ExecuteDomainTeardown(ctx, d.Agent, domainName); terr != nil {
+			logWarn(d, "domain delete: host teardown failed — tombstone kept for reconciler retry",
+				"domain", domainName, "err", terr)
+			if d.DomainTeardowns != nil {
+				_ = d.DomainTeardowns.MarkAttempt(ctx, domainName, terr.Error())
+			}
+			return false
+		}
+		if d.DomainTeardowns != nil {
+			_ = d.DomainTeardowns.Delete(ctx, domainName)
+		}
+		return true
+	}
+
+	if async {
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			finish(bgCtx)
+		}()
+		return true, nil // pending until the goroutine (or the sweep) clears it
+	}
+	return !finish(ctx), nil
+}

--- a/panel-api/internal/userops/domain_delete_test.go
+++ b/panel-api/internal/userops/domain_delete_test.go
@@ -1,0 +1,209 @@
+package userops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// JAB-236 pinned properties:
+//  1. Sync delete runs purge → domain.delete → dns.zone.delete, and the
+//     tombstone exists only inside the danger window (created before the
+//     row delete, cleared after the teardown succeeds).
+//  2. A refused row delete (panel-primary) runs NOTHING host-side — the
+//     Stalwart purge is destructive and must never precede the refusal —
+//     and leaves no tombstone behind.
+//  3. A failed teardown keeps the tombstone (with the error recorded);
+//     the row is already gone.
+//  4. A missing PowerDNS backend (DNS module off) is a permanent
+//     condition, not a retryable failure.
+
+// selectiveAgent errors on the configured methods, succeeds otherwise.
+type selectiveAgent struct {
+	mu          sync.Mutex
+	calls       []recordedCall
+	errByMethod map[string]error
+}
+
+func (a *selectiveAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	a.mu.Lock()
+	a.calls = append(a.calls, recordedCall{method: method, params: params})
+	a.mu.Unlock()
+	if err, ok := a.errByMethod[method]; ok {
+		return nil, err
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type stubDomainsRepo struct {
+	repository.DomainRepository
+	deleteErr error
+	deleted   []string
+}
+
+func (s *stubDomainsRepo) Delete(_ context.Context, id string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+type memTeardownRepo struct {
+	mu   sync.Mutex
+	rows map[string]*models.DomainTeardown
+}
+
+func newMemTeardownRepo() *memTeardownRepo {
+	return &memTeardownRepo{rows: map[string]*models.DomainTeardown{}}
+}
+
+func (m *memTeardownRepo) Ensure(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.rows[name]; !ok {
+		m.rows[name] = &models.DomainTeardown{DomainName: name, CreatedAt: time.Now().UTC()}
+	}
+	return nil
+}
+
+func (m *memTeardownRepo) List(_ context.Context) ([]models.DomainTeardown, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []models.DomainTeardown
+	for _, r := range m.rows {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func (m *memTeardownRepo) Delete(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rows, name)
+	return nil
+}
+
+func (m *memTeardownRepo) MarkAttempt(_ context.Context, name, lastError string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if r, ok := m.rows[name]; ok {
+		r.Attempts++
+		r.LastError = lastError
+		now := time.Now().UTC()
+		r.LastAttemptAt = &now
+	}
+	return nil
+}
+
+func methods(a *selectiveAgent) []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, 0, len(a.calls))
+	for _, c := range a.calls {
+		out = append(out, c.method)
+	}
+	return out
+}
+
+func TestDeleteDomain_SyncHappyPath(t *testing.T) {
+	ag := &selectiveAgent{}
+	domains := &stubDomainsRepo{}
+	tombs := newMemTeardownRepo()
+	d := Deps{Domains: domains, DomainTeardowns: tombs, Agent: ag}
+
+	pending, err := DeleteDomain(context.Background(), d, "dom1", "gone.example", false)
+	if err != nil || pending {
+		t.Fatalf("pending=%v err=%v", pending, err)
+	}
+	want := []string{"mail.domain.purge_accounts", "domain.delete", "dns.zone.delete"}
+	got := methods(ag)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("agent calls %v, want %v (purge must run, and only after the row delete succeeded)", got, want)
+	}
+	if len(domains.deleted) != 1 || domains.deleted[0] != "dom1" {
+		t.Fatalf("row not deleted: %v", domains.deleted)
+	}
+	if len(tombs.rows) != 0 {
+		t.Fatalf("tombstone must be cleared after a successful teardown: %v", tombs.rows)
+	}
+}
+
+func TestDeleteDomain_RefusedRowDeleteRunsNothing(t *testing.T) {
+	ag := &selectiveAgent{}
+	domains := &stubDomainsRepo{deleteErr: repository.ErrCannotDeletePanelPrimary}
+	tombs := newMemTeardownRepo()
+	d := Deps{Domains: domains, DomainTeardowns: tombs, Agent: ag}
+
+	_, err := DeleteDomain(context.Background(), d, "dom1", "panel.example", false)
+	if !errors.Is(err, repository.ErrCannotDeletePanelPrimary) {
+		t.Fatalf("err = %v, want panel-primary refusal passed through", err)
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("agent was called %v — a refused delete must run NOTHING host-side (the mail purge is destructive)", methods(ag))
+	}
+	if len(tombs.rows) != 0 {
+		t.Fatalf("tombstone left behind for a live row: %v", tombs.rows)
+	}
+}
+
+func TestDeleteDomain_TeardownFailureKeepsTombstone(t *testing.T) {
+	ag := &selectiveAgent{errByMethod: map[string]error{"domain.delete": errors.New("agent down")}}
+	domains := &stubDomainsRepo{}
+	tombs := newMemTeardownRepo()
+	d := Deps{Domains: domains, DomainTeardowns: tombs, Agent: ag}
+
+	pending, err := DeleteDomain(context.Background(), d, "dom1", "gone.example", false)
+	if err != nil {
+		t.Fatalf("row delete succeeded — err must be nil, got %v", err)
+	}
+	if !pending {
+		t.Fatal("teardown failed — pending must be true")
+	}
+	row, ok := tombs.rows["gone.example"]
+	if !ok {
+		t.Fatal("tombstone must survive a failed teardown — it is the only retry handle left")
+	}
+	if row.Attempts != 1 || !strings.Contains(row.LastError, "agent down") {
+		t.Fatalf("attempt not recorded: %+v", row)
+	}
+}
+
+func TestExecuteDomainTeardown_MissingPDNSIsSuccess(t *testing.T) {
+	ag := &selectiveAgent{errByMethod: map[string]error{
+		"dns.zone.delete": errors.New("agent error (internal): powerdns backend not available"),
+	}}
+	if err := ExecuteDomainTeardown(context.Background(), ag, "gone.example"); err != nil {
+		t.Fatalf("a box without the DNS module must not fail (and retry forever): %v", err)
+	}
+}
+
+func TestDeleteDomain_AsyncEventuallyClearsTombstone(t *testing.T) {
+	ag := &selectiveAgent{}
+	domains := &stubDomainsRepo{}
+	tombs := newMemTeardownRepo()
+	d := Deps{Domains: domains, DomainTeardowns: tombs, Agent: ag}
+
+	pending, err := DeleteDomain(context.Background(), d, "dom1", "gone.example", true)
+	if err != nil || !pending {
+		t.Fatalf("async returns pending=true immediately; got pending=%v err=%v", pending, err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		tombs.mu.Lock()
+		n := len(tombs.rows)
+		tombs.mu.Unlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("async teardown never cleared the tombstone")
+}

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -37,14 +37,18 @@ type AgentCaller interface {
 // + BcryptCost are required; Agent / Kratos / Packages are
 // optional (callbacks gracefully skip when nil).
 type Deps struct {
-	Users        repository.UserRepository
-	Packages     repository.PackageRepository
-	Domains      repository.DomainRepository
-	DockerApps   repository.DockerAppRepository
-	Agent        AgentCaller
-	KratosClient *kratosclient.Client
-	BcryptCost   int
-	Log          *slog.Logger
+	Users      repository.UserRepository
+	Packages   repository.PackageRepository
+	Domains    repository.DomainRepository
+	DockerApps repository.DockerAppRepository
+	// DomainTeardowns persists the JAB-236 tombstones that make domain
+	// deletion durable. Optional: nil keeps the pre-tombstone behaviour
+	// (teardown attempted once, not retried).
+	DomainTeardowns repository.DomainTeardownRepository
+	Agent           AgentCaller
+	KratosClient    *kratosclient.Client
+	BcryptCost      int
+	Log             *slog.Logger
 }
 
 // CreateInput is the shared input shape. Both callers (REST + the

--- a/panel-api/internal/userops/userops_lifecycle.go
+++ b/panel-api/internal/userops/userops_lifecycle.go
@@ -220,30 +220,14 @@ func DeleteCascade(ctx context.Context, d Deps, dd DeleteDeps, target *models.Us
 			}
 			for i := range owned {
 				dom := &owned[i]
-				name := dom.Name
-				// Purge EVERY Stalwart registry account under this domain BEFORE
-				// the domain delete FK-cascades the panel mailbox rows away. Purge
-				// BY DOMAIN (not per row) so orphans die too. Best-effort.
-				if d.Agent != nil {
-					if delErr := PurgeDomainMail(ctx, d.Agent, name); delErr != nil {
-						logWarn(d, "cascade delete: stalwart domain purge failed",
-							"user_id", id, "domain", name, "err", delErr)
-					}
-				}
-				if err := d.Domains.Delete(ctx, dom.ID); err != nil {
+				// JAB-236: the shared durable path — tombstone before the row
+				// delete, teardown (Stalwart purge + vhost + pdns zone) inside
+				// the executor, retried by the reconciler if the async attempt
+				// fails or the panel restarts mid-cascade. Per-domain failure
+				// is logged, never fails the user delete.
+				if _, err := DeleteDomain(ctx, d, dom.ID, dom.Name, true); err != nil {
 					logWarn(d, "cascade delete: domain DB delete failed",
-						"user_id", id, "domain_id", dom.ID, "domain", name, "err", err)
-					continue
-				}
-				if dd.Reconciler != nil {
-					// Fire-and-forget — don't block the user delete on nginx
-					// teardown. Fresh context: the request ctx ends with the caller.
-					name := name
-					go func() {
-						bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer cancel()
-						dd.Reconciler.ReconcileDeleted(bgCtx, name)
-					}()
+						"user_id", id, "domain_id", dom.ID, "domain", dom.Name, "err", err)
 				}
 			}
 			if len(owned) < batchSize {

--- a/panel-api/internal/userops/userops_lifecycle.go
+++ b/panel-api/internal/userops/userops_lifecycle.go
@@ -27,12 +27,6 @@ type LimitsReconciler interface {
 	ReconcileUserLimits(ctx context.Context)
 }
 
-// DomainReconciler is the narrow reconciler slice DeleteCascade needs
-// (satisfied by *reconciler.Reconciler).
-type DomainReconciler interface {
-	ReconcileDeleted(ctx context.Context, domainName string)
-}
-
 // Lifecycle sentinels. Callers map to HTTP codes:
 // ErrNoKratosIdentity→409, ErrKratosUnavailable→503,
 // ErrKratosSetPassword→502, ErrAgentPassword→502 (kratos already
@@ -181,7 +175,6 @@ func SetPackage(ctx context.Context, d Deps, user *models.User, packageID *strin
 type DeleteDeps struct {
 	Databases     repository.DatabaseRepository
 	DatabaseUsers repository.DatabaseUserRepository
-	Reconciler    DomainReconciler
 	// RevokeCacheACLs revokes the tenant's wp_<osuser> Redis cache ACLs
 	// (GH #408 / ADR-0148). Passed as a callback so userops stays free of
 	// the redis client dependency.


### PR DESCRIPTION
## Summary
JAB-236: `jabali domain delete` removed only the DB rows — no host-side teardown at all — then printed a false promise ("reconciler will tear down nginx vhost within 1m"). Verified live: deleted domains kept **serving** 40+ minutes later (enabled vhost, answering pdns zone, docroot, Stalwart accounts), while the orphan sweep logged **800 warnings in 40 minutes and cleaned nothing**. REST and the user cascade were a weaker instance of the same class: teardown in a fire-and-forget goroutine that a panel restart silently loses, with the row — the only handle — already gone.

### The design: tombstones (the #1010 inversion)
Databases keep the row when the host-side drop fails (#1010) — a domain delete can't, the operator wants the row gone. And teardown-then-delete has a live race: the reconciler re-creates the vhost from the still-present row between the two steps. So the durable handle moves to a **tombstone** (`domain_teardowns`, migration 000260): written BEFORE the row delete, cleared only after the teardown verifiably succeeds, retried by the reconciler until it does. A panel restart or agent outage mid-delete can no longer leak a serving site.

### One executor, one delete path
`userops.DeleteDomain` is now the only way a domain row dies — REST, CLI, and the user cascade all call it:
- **Ordering is load-bearing twice**: tombstone before row delete (a crash in the gap is caught by the sweep's live-row guard); Stalwart purge **inside** the executor, after the row is verifiably gone — the purge destroys live mailboxes and previously would have run even for a delete the repo layer then refused (panel-primary protection). A refused delete now runs **nothing** host-side and leaves no tombstone.
- Executor steps (`mail.domain.purge_accounts` → `domain.delete` → `dns.zone.delete`) are all idempotent agent-side; a box without the DNS module treats the missing PowerDNS backend as done, not a forever-retry.
- **REST/cascade**: still async and instant for the user — durability now rides the tombstone, not the goroutine. This also closes the audited gap: the single-domain REST delete never purged the domain's Stalwart accounts (only the cascade did).
- **CLI**: synchronous teardown; the message finally tells the truth ("torn down" vs "PENDING — the reconciler retries until it succeeds").
- Docroot is deliberately NOT deleted (user data under the tenant home; matches the long-standing agent behavior).

### Reconciler: retry engine + a sweep with a mandate
- `processDomainTeardowns` (runs BEFORE the orphan sweep): drives each pending tombstone through the same executor, 5-min per-row backoff. **Live-row guard**: a tombstone whose name has a live domain row is stale — crash in the gap, refused delete, or the name was *re-registered* before a failed teardown retried — executing it would tear down a serving site (worst case the panel's own primary vhost + zone), so it's dropped with a warning instead.
- **Orphan sweep mandate, decided**: it never auto-deletes agent sites without rows (indistinguishable from out-of-band operator work — deleting a serving site on a guess is worse than leaving it). It reports the whole orphan set in **one** warning, emitted only when the set changes, with the manual-cleanup commands in the message. In-flight tombstoned teardowns are excluded. The 800-warning storm is structurally gone.
- Dead `DeleteDeps.Reconciler` wiring removed (the cascade no longer needs it).

### Pre-existing fleet orphans
Deliberately NOT auto-cleaned (the sweep-mandate decision above). Testserver's stale sites/zones from before this fix remain a one-time manual cleanup — say the word and I'll sweep them by hand via agent `domain.delete` / `dns.zone.delete`.

## Test plan
- [x] Executor: step order pinned, refused row delete runs nothing host-side + drops the tombstone, failed teardown keeps the tombstone with the error recorded, missing-PDNS treated as success, async path eventually clears
- [x] Sweep: clears on success, live-row guard (no agent call, tombstone dropped), failure stays pending (orphan sweep skips it), backoff honored
- [x] Orphan report: one warning per set change (order-insensitive), info on clear — regression-pinned against the storm
- [x] Cascade still purges Stalwart by domain (test updated to await the now-durable async executor)
- [x] Full panel-api suite: **0 FAIL** (by count), `-race` on touched packages, gofmt/vet clean, post-rebase re-run green
- [ ] CI

Related scars: #1010 (panel row is the only handle), #754 (delete-path parity — the executor is the chokepoint), #1049 (retry semantics). GH #896 context. JAB-236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
