### PR TITLE
fix(reconciler): orphan warning named a nonexistent CLI verb (JAB-236 follow-up)

### DIFF
--- a/panel-api/internal/reconciler/domain_teardowns.go
+++ b/panel-api/internal/reconciler/domain_teardowns.go
@@ -95,6 +95,7 @@ func (r *Reconciler) reportOrphanSites(orphans []string) {
 		return
 	}
 	r.log.Warn("reconcile: orphan sites found in agent with no DB rows — not auto-deleted; "+
-		"remove with `jabali agent call domain.delete` / `dns.zone.delete` if unwanted",
+		"if unwanted, re-create the domain in the panel and delete it (runs the durable teardown), "+
+		"or insert the name into domain_teardowns for the reconciler to tear down",
 		"count", len(orphans), "sites", strings.Join(orphans, ", "))
 }


### PR DESCRIPTION
One line: the aggregated orphan-site warning shipped in #1057 told operators to run `jabali agent call domain.delete` — no such CLI verb exists. It now names the two real remedies: re-create + delete the domain (runs the durable teardown), or insert the name into `domain_teardowns` for the reconciler sweep to drain — the exact mechanism just used live to clean testserver's six pre-existing orphans (4 vhost + 2 zone-only), verified drained in one tick.

## Test plan
- [x] Sweep + orphan-report tests green (message content not pinned by tests)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)