### PR TITLE
fix(mail): hide the JAB-230 sendmail relay from the mailbox lists (GH #1056)

### DIFF
--- a/panel-api/internal/api/mailboxes.go
+++ b/panel-api/internal/api/mailboxes.go
@@ -197,6 +197,7 @@ func (h *mailboxHandler) list(c *gin.Context) {
 	}
 
 	page, pageSize, opts := parseListOptions(c, defaultMailboxesPageSize, maxMailboxesPageSize)
+	opts.ExcludeSystem = true // GH #1056: the JAB-230 relay is infra, not a listed mailbox
 
 	rows, total, err := h.cfg.Mailboxes.ListByDomainID(ctx, dom.ID, opts)
 	if err != nil {
@@ -723,6 +724,9 @@ func (h *mailboxHandler) listAllAdmin(c *gin.Context) {
 	}
 	out := make([]adminMailboxResponse, 0, len(rows))
 	for _, r := range rows {
+		if r.Mailbox.System {
+			continue // GH #1056: the JAB-230 relay is infra, not a listed mailbox
+		}
 		out = append(out, adminMailboxResponse{
 			mailboxResponse: toMailboxResponse(r.Mailbox),
 			DomainName:      r.DomainName,

--- a/panel-api/internal/db/migrations/000261_mailbox_system_flag.down.sql
+++ b/panel-api/internal/db/migrations/000261_mailbox_system_flag.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mailboxes
+  DROP COLUMN system;

--- a/panel-api/internal/db/migrations/000261_mailbox_system_flag.up.sql
+++ b/panel-api/internal/db/migrations/000261_mailbox_system_flag.up.sql
@@ -1,0 +1,17 @@
+-- GH #1056: mark panel-managed infrastructure principals so they can be
+-- filtered out of the user-facing mailbox lists. The only such principal
+-- today is the JAB-230 sendmail relay (noreply@<domain> / jabali-noreply@),
+-- a SendOnly account created by the reconciler with the display-name suffix
+-- " (system sender)". It stays fully functional (Stalwart, backups, disk
+-- accounting still see it) — it just no longer surfaces as a mailbox the
+-- operator never created.
+ALTER TABLE mailboxes
+  ADD COLUMN system tinyint(1) NOT NULL DEFAULT 0;
+
+-- Retrofit existing relay rows on already-provisioned boxes. Scoped tightly
+-- to the reconciler's own signature (SendOnly + the exact display-name suffix
+-- it writes) so a human's send-only mailbox is never mislabelled as system.
+UPDATE mailboxes
+  SET system = 1
+  WHERE send_only = 1
+    AND display_name LIKE '% (system sender)';

--- a/panel-api/internal/models/mailbox.go
+++ b/panel-api/internal/models/mailbox.go
@@ -10,34 +10,41 @@ import "time"
 // maintained by BEFORE INSERT/UPDATE triggers — we don't write it
 // from Go code. Stalwart's queryLogin matches on EmailCached.
 type Mailbox struct {
-	ID             string    `gorm:"type:char(26);primaryKey" json:"id"`
-	DomainID       string    `gorm:"type:char(26);not null;index:ix_mailboxes_domain" json:"domain_id"`
-	LocalPart      string    `gorm:"type:varchar(64);not null" json:"local_part"`
-	EmailCached    string    `gorm:"type:varchar(320);not null;uniqueIndex:ux_mailboxes_email_cached" json:"email"`
+	ID          string `gorm:"type:char(26);primaryKey" json:"id"`
+	DomainID    string `gorm:"type:char(26);not null;index:ix_mailboxes_domain" json:"domain_id"`
+	LocalPart   string `gorm:"type:varchar(64);not null" json:"local_part"`
+	EmailCached string `gorm:"type:varchar(320);not null;uniqueIndex:ux_mailboxes_email_cached" json:"email"`
 	// DisplayName is the human-readable name (GH #197). The agent pushes
 	// it to the Stalwart account's JMAP description (x:Account/set), which
 	// drives the default Identity name shown as the From name in Bulwark
 	// webmail. Set over JMAP (not the SQL directory) so it converges on
 	// existing installs too.
-	DisplayName    string    `gorm:"column:display_name;type:varchar(255);not null;default:''" json:"display_name"`
-	PasswordHash   string    `gorm:"type:varchar(255);not null" json:"-"`
+	DisplayName  string `gorm:"column:display_name;type:varchar(255);not null;default:''" json:"display_name"`
+	PasswordHash string `gorm:"type:varchar(255);not null" json:"-"`
 	// PasswordEnc is the AES-256-GCM ciphertext of the mailbox's
 	// plaintext password, encrypted with /etc/jabali-panel/sso.key.
 	// Used exclusively by the webmail SSO flow (M6 Step 8 Phase B) to
 	// mint a Bulwark session on behalf of the user. NULL for mailboxes
 	// created before migration 000056 landed — next rotate fills it.
-	PasswordEnc    []byte    `gorm:"type:varbinary(512)" json:"-"`
-	QuotaBytes     uint64    `gorm:"type:bigint unsigned;not null;default:1073741824" json:"quota_bytes"`
-	IsDisabled     bool      `gorm:"type:tinyint(1);not null;default:0" json:"is_disabled"`
+	PasswordEnc []byte `gorm:"type:varbinary(512)" json:"-"`
+	QuotaBytes  uint64 `gorm:"type:bigint unsigned;not null;default:1073741824" json:"quota_bytes"`
+	IsDisabled  bool   `gorm:"type:tinyint(1);not null;default:0" json:"is_disabled"`
 	// SendOnly (GH #371) — the account authenticates for SMTP submission
 	// but is excluded from delivery (Stalwart directory queryRecipient
 	// filters `send_only = 0`), so it can send mail but never receives or
 	// stores any. Set at create; toggleable via update.
-	SendOnly       bool      `gorm:"column:send_only;type:tinyint(1);not null;default:0" json:"send_only"`
-	LastUsageBytes uint64    `gorm:"type:bigint unsigned;not null;default:0" json:"last_usage_bytes"`
+	SendOnly bool `gorm:"column:send_only;type:tinyint(1);not null;default:0" json:"send_only"`
+	// System (GH #1056) — a panel-managed infrastructure principal, not a
+	// human mailbox. Set for the JAB-230 sendmail relay (noreply@<domain>,
+	// a SendOnly account the PHP mail() shim submits through). Such rows are
+	// filtered out of the user-facing mailbox lists so operators don't see a
+	// mailbox they never created; every internal path (backup, disk usage,
+	// usage ticker) still reads them via the repo unfiltered.
+	System         bool       `gorm:"column:system;type:tinyint(1);not null;default:0" json:"-"`
+	LastUsageBytes uint64     `gorm:"type:bigint unsigned;not null;default:0" json:"last_usage_bytes"`
 	LastUsageAt    *time.Time `gorm:"type:datetime(6)" json:"last_usage_at,omitempty"`
-	CreatedAt      time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt      time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+	CreatedAt      time.Time  `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt      time.Time  `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (Mailbox) TableName() string { return "mailboxes" }

--- a/panel-api/internal/reconciler/sendmail_cred_reconcile.go
+++ b/panel-api/internal/reconciler/sendmail_cred_reconcile.go
@@ -227,6 +227,7 @@ func (r *Reconciler) createRelayMailbox(ctx context.Context, d *models.Domain, l
 		DomainID:     d.ID,
 		LocalPart:    localPart,
 		DisplayName:  d.Name + " (system sender)",
+		System:       true, // GH #1056: hide the JAB-230 relay from the mailbox lists
 		PasswordHash: string(hash),
 		PasswordEnc:  enc,
 		QuotaBytes:   16 * 1024 * 1024,

--- a/panel-api/internal/reconciler/sendmail_cred_reconcile_test.go
+++ b/panel-api/internal/reconciler/sendmail_cred_reconcile_test.go
@@ -142,6 +142,11 @@ func TestReconcileSendmailCreds_ProvisionsAndCaches(t *testing.T) {
 		if !mb.SendOnly {
 			t.Errorf("relay mailbox %s must be SendOnly", mb.ID)
 		}
+		if !mb.System {
+			// GH #1056: the relay must be flagged System so the mailbox
+			// lists filter it out — an operator never created it.
+			t.Errorf("relay mailbox %s must be System", mb.ID)
+		}
 		if mb.LocalPart != "noreply" {
 			t.Errorf("local part = %q", mb.LocalPart)
 		}
@@ -233,8 +238,8 @@ func TestReconcileSendmailCreds_SkipsAndRetries(t *testing.T) {
 		domainNames: map[string]string{"d1": "site.tld", "d-admin": "adminsite.tld"},
 	}
 	r := sendmailTestReconciler(agent, mailboxes, []models.Domain{
-		{ID: "d-nouser", Name: "nouser.tld", UserID: "u2"},      // no Linux user
-		{ID: "d-admin", Name: "panelhost.tld", UserID: "u3"},    // admin w/ synthesized username
+		{ID: "d-nouser", Name: "nouser.tld", UserID: "u2"},   // no Linux user
+		{ID: "d-admin", Name: "panelhost.tld", UserID: "u3"}, // admin w/ synthesized username
 		{ID: "d1", Name: "site.tld", UserID: "u1"},
 	})
 	ctx := context.Background()

--- a/panel-api/internal/repository/list_options.go
+++ b/panel-api/internal/repository/list_options.go
@@ -36,6 +36,12 @@ type ListOptions struct {
 	// disclaimer, nginx safe-options JSON). Detail GETs and the reconciler
 	// always read full rows. Other repos ignore it.
 	OmitHeavyColumns bool
+	// ExcludeSystem — mailbox-repo-only (GH #1056); when true, drops
+	// panel-managed system principals (the JAB-230 sendmail relay) from the
+	// result AND the count, so the user-facing mailbox list never shows a
+	// mailbox the operator didn't create. Internal callers leave it false so
+	// backup/disk-usage/usage-ticker still see the relay. Other repos ignore it.
+	ExcludeSystem bool
 }
 
 // ListCols tells applyListOptions which columns are searchable (free-text
@@ -58,6 +64,7 @@ type ListCols struct {
 //   - Sort direction defaults to DESC on the default column; explicit
 //     Sort+Order can flip it.
 //   - Empty Limit leaves the query unbounded (callers should clamp).
+//
 // maxSearchLen is the hard cap on free-text search length. 128 chars is
 // ample for realistic email/name fragment searches and prevents a
 // caller from forcing giant LIKE scans with a megabyte-long pattern.

--- a/panel-api/internal/repository/mailbox_repository.go
+++ b/panel-api/internal/repository/mailbox_repository.go
@@ -99,6 +99,9 @@ func (r *mailboxRepo) ListByDomainID(ctx context.Context, domainID string, opts 
 		total int64
 	)
 	base := r.db.WithContext(ctx).Model(&models.Mailbox{}).Where("domain_id = ?", domainID)
+	if opts.ExcludeSystem {
+		base = base.Where("system = 0") // GH #1056: hide the JAB-230 relay from list + count
+	}
 
 	countQ := applyListOptions(base.Session(&gorm.Session{}), ListOptions{Search: opts.Search}, mailboxListCols)
 	if err := countQ.Count(&total).Error; err != nil {

--- a/panel-api/internal/repository/mailbox_repository_test.go
+++ b/panel-api/internal/repository/mailbox_repository_test.go
@@ -183,6 +183,36 @@ func TestMailboxRepository_ListByDomainID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestMailboxRepository_ListByDomainID_ExcludeSystem verifies that the
+// GH #1056 opt filters the JAB-230 relay out of BOTH the count and the row
+// query — otherwise the paginated list would show N-1 rows against a total of
+// N and the relay would still surface on the last page.
+func TestMailboxRepository_ListByDomainID_ExcludeSystem(t *testing.T) {
+	db, mock, raw := newMockDB(t)
+	defer raw.Close()
+
+	repo := NewMailboxRepository(db)
+
+	cols := []string{"id", "domain_id", "local_part", "email_cached", "password_hash",
+		"quota_bytes", "is_disabled", "last_usage_bytes", "last_usage_at", "created_at", "updated_at"}
+	now := time.Now()
+
+	// Both the count and the select must carry the `system = 0` predicate.
+	mock.ExpectQuery("SELECT count.* FROM `mailboxes`.*WHERE domain_id = \\? AND system = 0").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(1))
+	mock.ExpectQuery("SELECT .* FROM `mailboxes`.*WHERE domain_id = \\? AND system = 0.*ORDER BY").
+		WillReturnRows(sqlmock.NewRows(cols).
+			AddRow("mb1", "dom1", "alice", "alice@example.com", "h1", uint64(1<<30), false, uint64(0), nil, now, now),
+		)
+
+	rows, total, err := repo.ListByDomainID(context.Background(), "dom1", ListOptions{ExcludeSystem: true})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	require.Equal(t, "alice@example.com", rows[0].EmailCached)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestMailboxRepository_ExistsByDomainAndLocalPart(t *testing.T) {
 	db, mock, raw := newMockDB(t)
 	defer raw.Close()


### PR DESCRIPTION
## What

Creating a domain or subdomain provisions a `noreply@<domain>` **SendOnly** relay so PHP `mail()` / WordPress forms can send even on a domain with no email configured (JAB-230; `EmailEnabled` deliberately not gated per the 2026-08-07 decision — a domain with external MX still needs its forms to send, and a send-only principal needs no MX/DNS).

Nothing filtered that relay from the mailbox lists, so it surfaced to admins (and the domain owner) as a mailbox they never created — GH #1056.

## Approach — hide it, don't stop creating it

The relay is needed infra, so this keeps creating it but stops surfacing it:

- New `mailboxes.system` flag marks panel-managed infrastructure principals. The reconciler sets it on the relay (`createRelayMailbox`).
- The **two user-facing list endpoints** drop system rows:
  - `GET /domains/:id/mailboxes` — via `ListOptions.ExcludeSystem`, applied to the base scope so **both the page and the `total` count** exclude it (no N-1-rows-vs-total-N pagination glitch).
  - `GET /admin/mailboxes` (server-wide Mail tab) — skips system rows in the handler.
- Every **internal** path keeps reading the relay unfiltered via the repo (backup metadata, disk accounting, usage ticker, delivery) — `ExcludeSystem` defaults false.

## Migration `000261`

Adds the column and retrofits existing relays on already-provisioned boxes, scoped tightly to the reconciler's own signature (`send_only=1 AND display_name LIKE '% (system sender)'`) so a human's send-only mailbox is never mislabelled as system.

## Tests

- `TestMailboxRepository_ListByDomainID_ExcludeSystem` — the filter hits both the count and the row query.
- `TestReconcileSendmailCreds_ProvisionsAndCaches` — asserts the relay is flagged `System`.
- Full `panel-api` suite: 0 failures; `migrations_completeness` + `update_schema_guard` (model↔migration drift) green.

GH #1056