### PR TITLE
chore(docker-apps): weekly catalog version bumps

### DIFF
--- a/install/docker-apps/answer/app.yaml
+++ b/install/docker-apps/answer/app.yaml
@@ -1,7 +1,7 @@
 slug: answer
 name: Apache Answer
 tags: ["Forum"]
-version: "2.0.1"
+version: "2.0.2"
 description: |
   Open-source Q&A platform (Stack Overflow-style) from the Apache Software
   Foundation. Questions, answers, voting, tags, reputation, badges, and admin
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/apache/answer
 documentation: https://answer.apache.org/
 
-image_channel: apache/answer:2.0.1@sha256:406e742c72ac7f49056fd39930bcbd812933bfadf40636de0a047d9c78468cf1
+image_channel: apache/answer:2.0.2@sha256:a0d71b0e30a5c8d3eda31184abc64dbebccb6dd3e229aab1f7e332b41ade54f7
 update_mode: manual
 tenant_installable: true
 

--- a/install/docker-apps/bigcapital/app.yaml
+++ b/install/docker-apps/bigcapital/app.yaml
@@ -1,7 +1,7 @@
 slug: bigcapital
 name: Bigcapital
 tags: ["Accounting", "ERP"]
-version: "0.25.20"
+version: "0.25.26"
 description: |
   Open-source accounting and financial management — invoicing, expenses,
   banking, inventory, and financial reports for small businesses. A
@@ -18,7 +18,7 @@ documentation: https://docs.bigcapital.app
 # Primary image (drives the server + migration services). The webapp,
 # envoy, mariadb, redis, minio and gotenberg images are pinned in the
 # compose template; keep the webapp tag in sync with this version on bump.
-image_channel: bigcapitalhq/server:v0.25.20@sha256:412e9edb0d3ddbf6f862d2dd31766f0b4008f5c0d0a0e8133d8570d9dc68dd38
+image_channel: bigcapitalhq/server:v0.25.26@sha256:06199a9829f0511b40f0931772dd8448783f6b462804da24f6e172c61d724206
 update_mode: manual
 
 resources:

--- a/install/docker-apps/dailytxt/app.yaml
+++ b/install/docker-apps/dailytxt/app.yaml
@@ -2,7 +2,7 @@ slug: dailytxt
 tenant_installable: true
 name: DailyTxt
 tags: ["Productivity"]
-version: "2.6.1"
+version: "2.6.2"
 description: |
   Self-hosted, end-to-end encrypted diary application. Plain text +
   attachments, fully encrypted client-side. Single container with
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/PhiTux/DailyTxt
 documentation: https://github.com/PhiTux/DailyTxt#readme
 
-image_channel: phitux/dailytxt:2.6.1@sha256:153bbda299d592c79a205609035bb0f48b02067f50b3fb7dc6e56a236797d6d4
+image_channel: phitux/dailytxt:2.6.2@sha256:9cf5b72e510737ecc71c5c736f321ef0e1d8b31247ded846836f073c6e2f757f
 update_mode: manual
 
 resources:

--- a/install/docker-apps/dawarich/app.yaml
+++ b/install/docker-apps/dawarich/app.yaml
@@ -1,7 +1,7 @@
 slug: dawarich
 name: Dawarich
 tags: ["Productivity", "Analytics"]
-version: "1.10.0"
+version: "1.11.0"
 description: |
   Self-hosted location history and timeline, a privacy-first replacement
   for Google Timeline / Maps history. Import your data, visualize trips
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/Freika/dawarich
 documentation: https://dawarich.app
 
-image_channel: freikin/dawarich:1.10.0@sha256:25ba1dc02e5571cc915bd104aae9c4c28929848ad1741c1829f5c40f86489a16
+image_channel: freikin/dawarich:1.11.0@sha256:4e3c55c4cd572373624e75c9e02075ff436c83a3ea952595ae0d4ffc4c7ae52b
 update_mode: manual
 
 resources:

--- a/install/docker-apps/erpnext/app.yaml
+++ b/install/docker-apps/erpnext/app.yaml
@@ -1,7 +1,7 @@
 slug: erpnext
 name: ERPNext
 tags: ["ERP", "CRM", "Accounting"]
-version: "16.25.0"
+version: "16.31.1"
 description: >-
   Full open-source ERP: accounting, inventory, manufacturing, HR, CRM, projects
   and a website/e-commerce builder, built on the Frappe framework. This is a
@@ -16,7 +16,7 @@ icon: icon.svg
 upstream: https://github.com/frappe/erpnext
 documentation: https://docs.frappe.io/erpnext
 
-image_channel: frappe/erpnext:v16.25.0@sha256:42cfca4dbd8abe6b2af551e7fb79e9e8b0879f03d4f31c789a268c02e5af4f6c
+image_channel: frappe/erpnext:v16.31.1@sha256:dba34b89f11e22e14cfc05f6846ff39a223187bf7dfc63266565d646f1569674
 update_mode: manual
 
 resources:

--- a/install/docker-apps/forgejo/app.yaml
+++ b/install/docker-apps/forgejo/app.yaml
@@ -2,7 +2,7 @@ slug: forgejo
 popularity: 70
 name: Forgejo
 tags: ["Developer tools"]
-version: "15.0.3"
+version: "16.0.2"
 description: |
   Lightweight self-hosted Git forge — a community-run fork of Gitea.
   Bundled SQLite for v1; admin can flip to compose-managed Postgres
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://codeberg.org/forgejo/forgejo
 documentation: https://forgejo.org/docs/
 
-image_channel: codeberg.org/forgejo/forgejo:15.0.3@sha256:55bb42bec9abef5223744804f164e37d37b20df7e8b8b4807ba213ad4f071d6d
+image_channel: codeberg.org/forgejo/forgejo:16.0.2@sha256:2fdfe28b5c68f82f49580e227b84e2afb43af0250e0631a54a386ef3b1d9b759
 volume_owner: "1000:1000"
 update_mode: manual
 

--- a/install/docker-apps/fossbilling/app.yaml
+++ b/install/docker-apps/fossbilling/app.yaml
@@ -1,7 +1,7 @@
 slug: fossbilling
 name: FOSSBilling
 tags: ["Billing", "CRM"]
-version: "0.8.2"
+version: "0.8.5"
 description: |
   Open-source billing and client management — invoices, orders, support
   tickets, and a product catalog with hosting & domain integrations.
@@ -15,7 +15,7 @@ icon: icon.svg
 upstream: https://github.com/FOSSBilling/FOSSBilling
 documentation: https://fossbilling.org/docs
 
-image_channel: fossbilling/fossbilling:0.8.2@sha256:a8796f339b727820d2218c9ee267cea835bf21c67ecac312459acbdaed5db355
+image_channel: fossbilling/fossbilling:0.8.5@sha256:81eea9624261050b3c0da8fc94a4742044bda94aa06226da48e26fe22992f78f
 update_mode: manual
 
 resources:

--- a/install/docker-apps/ghost/app.yaml
+++ b/install/docker-apps/ghost/app.yaml
@@ -2,7 +2,7 @@ slug: ghost
 popularity: 80
 name: Ghost
 tags: ["Blog", "CMS"]
-version: "6.44.1"
+version: "6.57.0"
 description: |
   Modern publishing platform. SQLite by default; the operator can
   switch to MySQL by editing the compose post-install. Single
@@ -11,7 +11,7 @@ icon: icon.png
 upstream: https://github.com/TryGhost/Ghost
 documentation: https://ghost.org/docs/
 
-image_channel: ghost:6-alpine@sha256:dc932c22add1906101fc034450392dbea107488b0ca191bb91cc0b2a667d652b
+image_channel: ghost:6-alpine@sha256:a8d293f62c23fefdd2b71f26f631aad7c83891be45f946fcab9b6b881761160c
 update_mode: manual
 tenant_installable: true
 

--- a/install/docker-apps/gitea/app.yaml
+++ b/install/docker-apps/gitea/app.yaml
@@ -2,7 +2,7 @@ slug: gitea
 popularity: 82
 name: Gitea
 tags: ["Developer tools"]
-version: "1.26.2"
+version: "1.27.1"
 description: |
   Lightweight self-hosted Git service. Bundled SQLite for v1; admin
   can flip to compose-managed Postgres post-install. Two ports: HTTP
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/go-gitea/gitea
 documentation: https://docs.gitea.com/
 
-image_channel: gitea/gitea:1.26@sha256:8e25c717b8f748445e15ec46e0390f577cb628101184cb0a150d1dae126c1f39
+image_channel: gitea/gitea:1.27@sha256:34e3f6b75f5cbb6aebce588037fc5a53c84213e4d4b00da0a8d73e031a558e52
 volume_owner: "1000:1000"
 update_mode: manual
 

--- a/install/docker-apps/immich/app.yaml
+++ b/install/docker-apps/immich/app.yaml
@@ -2,7 +2,7 @@ slug: immich
 popularity: 95
 name: Immich
 tags: ["File sharing"]
-version: "2.7.5"
+version: "3.1.0"
 description: |
   Self-hosted photo + video backup, ML-powered search. Four
   services: web server, ML inference, PostgreSQL (pgvecto.rs
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/immich-app/immich
 documentation: https://immich.app/docs
 
-image_channel: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
+image_channel: ghcr.io/immich-app/immich-server:v3.1.0@sha256:b434cb9287eea1471c9974845914d4dd328c9c2d652e446ed4930f99944f0ceb
 update_mode: manual
 
 resources:

--- a/install/docker-apps/invoiceshelf/app.yaml
+++ b/install/docker-apps/invoiceshelf/app.yaml
@@ -1,7 +1,7 @@
 slug: invoiceshelf
 name: InvoiceShelf
 tags: ["Accounting", "Billing"]
-version: "2.4.1"
+version: "2.4.2"
 description: |
   Open-source, self-hosted invoicing and estimates for freelancers and
   small businesses (a maintained fork of Crater). Clients, invoices,
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/InvoiceShelf/InvoiceShelf
 documentation: https://docs.invoiceshelf.com/
 
-image_channel: invoiceshelf/invoiceshelf:2.4.1@sha256:563ffd1d79e0e1a0bb97691198630022dc0206835d9bb8b3e88972af58f33f7b
+image_channel: invoiceshelf/invoiceshelf:2.4.2@sha256:76f13fbf45f4bad494bb360ec062c7268c71ad6d91f96ae1319de414a9959080
 update_mode: manual
 tenant_installable: true
 

--- a/install/docker-apps/jabali-sounder/app.yaml
+++ b/install/docker-apps/jabali-sounder/app.yaml
@@ -2,7 +2,7 @@ slug: jabali-sounder
 popularity: 38
 name: Jabali Sounder
 tags: ["Monitoring"]
-version: "0.5.22"
+version: "0.5.25"
 description: |
   Control plane for managing multiple Jabali Panel servers from one
   place: enroll panels, monitor their health, and run remediation.
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/shukiv/jabali-sounder
 documentation: https://github.com/shukiv/jabali-sounder/blob/main/docs/DOCKER.md
 
-image_channel: ghcr.io/shukiv/jabali-sounder:0.5.22@sha256:28f10ba9d95661b3fb25c1b671da094c6acdc7e2df20a752cd45c953728e3de9
+image_channel: ghcr.io/shukiv/jabali-sounder:0.5.25@sha256:790d985b8bf552e070689534b38e453421f015007d50a1cf946018ef9eb177e6
 volume_owner: "10001:10001"
 update_mode: manual
 

--- a/install/docker-apps/karakeep/app.yaml
+++ b/install/docker-apps/karakeep/app.yaml
@@ -1,7 +1,7 @@
 slug: karakeep
 name: Karakeep
 tags: ["Productivity", "Library"]
-version: "0.32.0"
+version: "0.33.1"
 description: |
   Self-hosted bookmark and read-it-later app (formerly Hoarder). Saves
   links, notes and images with full-text search (Meilisearch) and
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/karakeep-app/karakeep
 documentation: https://docs.karakeep.app
 
-image_channel: ghcr.io/karakeep-app/karakeep:0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
+image_channel: ghcr.io/karakeep-app/karakeep:0.33.1@sha256:5467873df817ab3aa837f2b06bd7f2b0974132ba1ae5bce0b7e2fd134abc269b
 update_mode: manual
 
 resources:

--- a/install/docker-apps/linkwarden/app.yaml
+++ b/install/docker-apps/linkwarden/app.yaml
@@ -3,7 +3,7 @@ popularity: 48
 tenant_installable: true
 name: Linkwarden
 tags: ["Productivity"]
-version: "2.14.1"
+version: "2.16.0"
 description: |
   Self-hosted bookmark and link manager with built-in archiving
   (PDF, screenshot, single-page HTML). Two services: NextJS app +
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/linkwarden/linkwarden
 documentation: https://docs.linkwarden.app/
 
-image_channel: ghcr.io/linkwarden/linkwarden:v2.14.1@sha256:31cf4bd2a2e111991fa5c9de03174c8698869c83722105c6ce529e4c911e6861
+image_channel: ghcr.io/linkwarden/linkwarden:v2.16.0@sha256:d805877fb707d160b809027c302f84cfba11a248d7fdc12de90b4791f98e6b55
 update_mode: manual
 
 resources:

--- a/install/docker-apps/matomo/app.yaml
+++ b/install/docker-apps/matomo/app.yaml
@@ -2,7 +2,7 @@ slug: matomo
 popularity: 62
 name: Matomo
 tags: ["Analytics"]
-version: "5.10.1"
+version: "5.12.0"
 description: |
   Open-source web analytics platform. Privacy-focused, fully
   self-hosted. Two services: PHP-FPM + nginx app container,
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/matomo-org/matomo
 documentation: https://matomo.org/docs/
 
-image_channel: matomo:5-apache@sha256:492f499dbbe319e4183fb98706f047dc120fc1ae5ab5689c7730fe940fde2174
+image_channel: matomo:5-apache@sha256:85d27206a4acdd43259909aa00cab1913dec88cfba53e1ce66a51e6caa430a55
 update_mode: manual
 
 resources:

--- a/install/docker-apps/mealie/app.yaml
+++ b/install/docker-apps/mealie/app.yaml
@@ -3,7 +3,7 @@ popularity: 60
 tenant_installable: true
 name: Mealie
 tags: ["Productivity"]
-version: "3.19.2"
+version: "3.22.0"
 description: |
   Self-hosted recipe manager and meal planner. Single container,
   SQLite-backed by default.
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/mealie-recipes/mealie
 documentation: https://docs.mealie.io/
 
-image_channel: ghcr.io/mealie-recipes/mealie:v3.19.2@sha256:f68e959bf66f4f458893ea58facac71690fe6f2ac7a31466b5cecb41b4e99c02
+image_channel: ghcr.io/mealie-recipes/mealie:v3.22.0@sha256:36c28f0642fb6c75fae8997a2d55994631b9b4bcffba3016c208fc132a4c1e69
 update_mode: manual
 
 resources:

--- a/install/docker-apps/memos/app.yaml
+++ b/install/docker-apps/memos/app.yaml
@@ -3,7 +3,7 @@ popularity: 34
 tenant_installable: true
 name: Memos
 tags: ["Productivity"]
-version: "0.29.1"
+version: "0.30.0"
 description: |
   Self-hosted, open-source note-taking platform. Lightweight, single
   container with SQLite by default. Markdown editor, tagging,
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/usememos/memos
 documentation: https://www.usememos.com/docs
 
-image_channel: neosmemo/memos:0.29.1@sha256:3e1253477066eb2aefa91145f7f9038bb931ed88c8a3ee05310a933594cdba7d
+image_channel: neosmemo/memos:0.30.0@sha256:71a5b4738d1bed96e92112004054f0888e92791b64eb78afd79077c96e6f9327
 update_mode: manual
 
 resources:

--- a/install/docker-apps/n8n/app.yaml
+++ b/install/docker-apps/n8n/app.yaml
@@ -2,7 +2,7 @@ slug: n8n
 popularity: 88
 name: n8n
 tags: ["Automation", "Developer tools"]
-version: "2.28.2"
+version: "2.34.4"
 description: |
   Workflow automation tool. Build, run, and share workflows that
   connect APIs, databases, and services. Self-hosted, single
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/n8n-io/n8n
 documentation: https://docs.n8n.io/
 
-image_channel: n8nio/n8n:2.28.2@sha256:08b9411994c0d091c5cc0969ee9edcb85b5e79f26640703c0c342076ac6f2b17
+image_channel: n8nio/n8n:2.34.4@sha256:f69bad7a699300702af665b9f13fc67455b93c9fb9174bca6c37f3d4a47b8583
 update_mode: manual
 
 # The image runs as node (uid 1000); without volume_owner the bind-mounted

--- a/install/docker-apps/nextcloud/app.yaml
+++ b/install/docker-apps/nextcloud/app.yaml
@@ -2,7 +2,7 @@ slug: nextcloud
 popularity: 100
 name: Nextcloud
 tags: ["File sharing"]
-version: "33.0.5"
+version: "34.0.2"
 description: |
   Self-hosted productivity platform: file sync, calendar, contacts,
   office docs, video calls. Two services: PHP-FPM app container +
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/nextcloud/server
 documentation: https://docs.nextcloud.com/
 
-image_channel: nextcloud:33-apache@sha256:bb3672cdb9dfccb2159da88826981a8d749f5d4cd9a2816c1f32d93e08f541eb
+image_channel: nextcloud:34-apache@sha256:d7666d54d87c58d52869ddda36d1acbd4a7f53faf8ab6b91293daf204f3434e8
 update_mode: manual
 
 resources:

--- a/install/docker-apps/odoo/app.yaml
+++ b/install/docker-apps/odoo/app.yaml
@@ -2,7 +2,7 @@ slug: odoo
 popularity: 42
 name: Odoo
 tags: ["ERP", "CRM"]
-version: "18.0"
+version: "19.0"
 description: >-
   Open-source ERP and business suite: CRM, accounting, inventory, sales,
   projects, and a website builder from one platform. Two services here: the
@@ -14,7 +14,7 @@ icon: icon.svg
 upstream: https://github.com/odoo/odoo
 documentation: https://www.odoo.com/documentation/18.0/
 
-image_channel: odoo:18.0@sha256:d263921105082f1793e6598b73779fc9fa4463fbe6add0278e469efaf0b9f7f0
+image_channel: odoo:19.0@sha256:94a4f480b8039dc9ca2bca9e77e59f97d3311f66e2aad663cf2670be9c66d4ea
 update_mode: manual
 
 resources:

--- a/install/docker-apps/open-webui/app.yaml
+++ b/install/docker-apps/open-webui/app.yaml
@@ -2,7 +2,7 @@ slug: open-webui
 popularity: 46
 name: Open WebUI
 tags: ["AI", "Developer tools"]
-version: "0.9.6"
+version: "0.11.0"
 description: |
   Extensible, self-hosted AI chat interface that runs entirely offline.
   Talks to local LLM runners (Ollama) and any OpenAI-compatible API, with
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/open-webui/open-webui
 documentation: https://docs.openwebui.com/
 
-image_channel: ghcr.io/open-webui/open-webui:0.9.6@sha256:90eae5b419e40b4c3dd684582b2c83440b36f9ae2f6532c09639b2ba4ee65158
+image_channel: ghcr.io/open-webui/open-webui:0.11.0@sha256:72c0ba641ba75e7aa52655cb242570906ececd09b1140fb736483038a22b3228
 update_mode: manual
 tenant_installable: true
 

--- a/install/docker-apps/openemr/app.yaml
+++ b/install/docker-apps/openemr/app.yaml
@@ -9,7 +9,7 @@ icon: icon.svg
 upstream: https://github.com/openemr/openemr
 documentation: https://www.open-emr.org/wiki/index.php/OpenEMR_Wiki_Home_Page
 
-image_channel: openemr/openemr:8.0.0.3@sha256:3e72e656e30b7b60d3a45eb4f71e4967f7c3e19c67096941437c32983d128988
+image_channel: openemr/openemr:8.0.0.3@sha256:612fb8574bc81f50fc877354b5687d3c03338cedb5a82cb600245407ea86940c
 update_mode: manual
 
 resources:

--- a/install/docker-apps/owncloud/app.yaml
+++ b/install/docker-apps/owncloud/app.yaml
@@ -2,7 +2,7 @@ slug: owncloud
 popularity: 52
 name: ownCloud
 tags: ["File sharing"]
-version: "10.16.3"
+version: "11.0.0"
 description: |
   Self-hosted file sync and share platform. Three services: ownCloud
   server (PHP), MariaDB, and Redis for transactional file locking.
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/owncloud/core
 documentation: https://doc.owncloud.com/server/10.16/
 
-image_channel: owncloud/server:10.16.3@sha256:bee51ceb0055508b5f6c7366106222feaf818188f65b3d09f093697bd7d39581
+image_channel: owncloud/server:11.0.0@sha256:f6823fe815a6e3f78239e5d1db840081b095e3153f0dbec724ba154079e479a6
 update_mode: manual
 
 resources:

--- a/install/docker-apps/paperless-ngx/app.yaml
+++ b/install/docker-apps/paperless-ngx/app.yaml
@@ -3,7 +3,7 @@ popularity: 75
 tenant_installable: true
 name: Paperless-ngx
 tags: ["Document management", "File sharing"]
-version: "2.20.15"
+version: "3.0.5"
 description: |
   Self-hosted document management — scan + tag + full-text search.
   Four services: web (gunicorn), broker (Redis), database (PostgreSQL),
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/paperless-ngx/paperless-ngx
 documentation: https://docs.paperless-ngx.com/
 
-image_channel: paperlessngx/paperless-ngx:2.20.15@sha256:6c86cad803970ea782683a8e80e7403444c5bf3cf70de63b4d3c8e87500db92f
+image_channel: paperlessngx/paperless-ngx:3.0.5@sha256:65a4cabf0169ea7fbd90ab7bb28ba3f8b5909613635acda1a03ad606f34b456b
 update_mode: manual
 
 resources:

--- a/install/docker-apps/peertube/app.yaml
+++ b/install/docker-apps/peertube/app.yaml
@@ -2,7 +2,7 @@ slug: peertube
 popularity: 30
 name: PeerTube
 tags: ["Media", "Video", "Streaming"]
-version: "8.2.1"
+version: "8.2.4"
 description: |
   Decentralized, federated (ActivityPub) video platform. App container
   + PostgreSQL + Redis. Email is disabled by default; configure SMTP
@@ -11,7 +11,7 @@ icon: icon.svg
 upstream: https://github.com/Chocobozzz/PeerTube
 documentation: https://docs.joinpeertube.org/
 
-image_channel: chocobozzz/peertube:v8.2.1-trixie@sha256:cd4e3004214f7869b9ab14a906b0b018c0711a202e2a35b199b5a4c83ee80a91
+image_channel: chocobozzz/peertube:v8.2.4-trixie@sha256:f7a3e82f9fe7f97fc672d5f3e7c951fc5fd300e9c06cf806b503dcf1d66388f9
 update_mode: manual
 
 resources:

--- a/install/docker-apps/pgadmin/app.yaml
+++ b/install/docker-apps/pgadmin/app.yaml
@@ -2,7 +2,7 @@ slug: pgadmin
 popularity: 40
 name: pgAdmin
 tags: ["Developer tools", "Database"]
-version: "9.16"
+version: "9.17"
 description: |
   Web-based administration and management tool for PostgreSQL. Browse
   schemas, run queries, manage roles and backups from the browser. Admin
@@ -16,7 +16,7 @@ documentation: https://www.pgadmin.org/docs/
 # "ssl.py ... ValueError: Unknown object" (a broken OID table in that build) —
 # box-verified on a real host. 9.16 boots and serves /misc/ping. Re-verify a
 # container actually starts before bumping this pin.
-image_channel: dpage/pgadmin4:9.16@sha256:40fa840c5bb7c8463957f1255b01283732c2d8c9396a956d180f8e6c296753b3
+image_channel: dpage/pgadmin4:9.17@sha256:2f4ce946ddf8360680d7eff4eaba1d91859eb6b4003e6623bad5c63a322c2f4d
 update_mode: manual
 
 # pgAdmin runs as the unprivileged "pgadmin" user (uid/gid 5050) and reads

--- a/install/docker-apps/pocket-id/app.yaml
+++ b/install/docker-apps/pocket-id/app.yaml
@@ -2,7 +2,7 @@ slug: pocket-id
 tenant_installable: true
 name: Pocket ID
 tags: ["Security", "IT"]
-version: "2.11.0"
+version: "2.13.0"
 description: |
   Simple OIDC provider that signs users in with passkeys instead of
   passwords. Self-hosted single sign-on for the rest of your apps.
@@ -16,7 +16,7 @@ post_install_note: |
   admin). Open it over HTTPS at that domain: passkeys will not work over
   plain HTTP or via an IP address.
 
-image_channel: pocketid/pocket-id:v2.11.0@sha256:b7c37ab3044e53fd29b5f7295eebff5fdc0367dc043f36b41bcbe1815fcd965d
+image_channel: pocketid/pocket-id:v2.13.0@sha256:c9c1d7b70006968d673a1073df048a3fdec73ccb54e182320b56bb911340f6f1
 update_mode: manual
 
 resources:

--- a/install/docker-apps/privatebin/app.yaml
+++ b/install/docker-apps/privatebin/app.yaml
@@ -3,7 +3,7 @@ popularity: 36
 tenant_installable: true
 name: PrivateBin
 tags: ["Developer tools"]
-version: "2.0.4"
+version: "2.0.6"
 description: |
   Minimalist, open-source pastebin where the server has zero
   knowledge of pasted data. AES-256 client-side encryption. Single
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/PrivateBin/PrivateBin
 documentation: https://github.com/PrivateBin/PrivateBin/wiki
 
-image_channel: privatebin/nginx-fpm-alpine:2.0.4@sha256:96171f34dd07f6c655cb3a311de24c1e9bafd05307ea9b6d38443863f6b48153
+image_channel: privatebin/nginx-fpm-alpine:2.0.6@sha256:13290e2f04bfd98cf8fc7e8d216fb76b2b2d12373d4923b859cd41c2d984fde8
 update_mode: manual
 
 resources:

--- a/install/docker-apps/rocketchat/app.yaml
+++ b/install/docker-apps/rocketchat/app.yaml
@@ -2,7 +2,7 @@ slug: rocketchat
 popularity: 68
 name: Rocket.Chat
 tags: ["Communication"]
-version: "6.13.1"
+version: "8.7.0"
 description: |
   Self-hosted team chat / collaboration platform — channels, DMs, voice/
   video, file sharing, and integrations. Two services: the Rocket.Chat
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/RocketChat/Rocket.Chat
 documentation: https://docs.rocket.chat/
 
-image_channel: rocketchat/rocket.chat:6.13.1@sha256:f245efa7c787b686463fdf1d33c71ce61209d538c05b82640d8ccd6e30d1db86
+image_channel: rocketchat/rocket.chat:8.7.0@sha256:4bee1481cecee3e77207fb851743fabc829f0bacf0da1fc3141de3f41b34a4ab
 update_mode: manual
 
 resources:

--- a/install/docker-apps/romm/app.yaml
+++ b/install/docker-apps/romm/app.yaml
@@ -1,7 +1,7 @@
 slug: romm
 name: RomM
 tags: ["Games", "Media", "Library"]
-version: "4.9.2"
+version: "5.1.0"
 description: |
   Self-hosted ROM manager and player with IGDB/MobyGames metadata.
   App container (bundled Redis) + MariaDB. Mount your ROM library
@@ -10,7 +10,7 @@ icon: icon.svg
 upstream: https://github.com/rommapp/romm
 documentation: https://docs.romm.app/
 
-image_channel: rommapp/romm:4@sha256:c81778afcafe7c865bdf156d1c62349aec3dfca3aca5ec0d6c2c2e8bfa9fb071
+image_channel: rommapp/romm:5@sha256:ce9d86ab531e09fede45d00f426e3bf2d1f5dd14846f94d6360d77a92a413028
 update_mode: manual
 
 resources:

--- a/install/docker-apps/searxng/app.yaml
+++ b/install/docker-apps/searxng/app.yaml
@@ -3,7 +3,7 @@ popularity: 50
 tenant_installable: true
 name: SearXNG
 tags: ["Developer tools"]
-version: "2026.6.20"
+version: "2026.8.10"
 description: |
   Privacy-respecting metasearch engine — aggregates results from 70+ search
   services with no user tracking or profiling. Single service; open it and
@@ -13,7 +13,7 @@ icon: icon.svg
 upstream: https://github.com/searxng/searxng
 documentation: https://docs.searxng.org/
 
-image_channel: docker.io/searxng/searxng:2026.6.20-fd42d4fda@sha256:d0f6ccf9d3faab5bba07bb6bbeb533c47dd4ace648ed5a0f8830e10eb96b7082
+image_channel: docker.io/searxng/searxng:2026.8.10-0a118066d@sha256:cd22dbf7fac8b25d5e39e65af53a4b47009df5ad3162e270c477fd5b30ce03f2
 update_mode: manual
 
 resources:

--- a/install/docker-apps/uptime-kuma/app.yaml
+++ b/install/docker-apps/uptime-kuma/app.yaml
@@ -3,7 +3,7 @@ popularity: 85
 tenant_installable: true
 name: Uptime Kuma
 tags: ["Monitoring"]
-version: "2.4.0"
+version: "2.5.0"
 description: |
   Self-hosted monitoring tool, single container, status pages,
   multi-protocol probes (HTTP/HTTPS, TCP, ping, DNS, push). Minimal
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/louislam/uptime-kuma
 documentation: https://github.com/louislam/uptime-kuma/wiki
 
-image_channel: louislam/uptime-kuma:2@sha256:91e963bfda569ba115206e843febb446f473ab525add4e08b2b9e3beffa16985
+image_channel: louislam/uptime-kuma:2@sha256:a8610b3b4c38077922ba51b036691e06887d7cefd91fe620fd3d6d23d03dc240
 update_mode: manual
 
 resources:

--- a/install/docker-apps/vaultwarden/app.yaml
+++ b/install/docker-apps/vaultwarden/app.yaml
@@ -3,7 +3,7 @@ popularity: 90
 tenant_installable: true
 name: Vaultwarden
 tags: ["Security"]
-version: "1.36.0"
+version: "1.37.1"
 description: |
   Self-hosted password manager, Bitwarden-compatible API. Rust rewrite
   of the official Bitwarden server. Small memory footprint, single
@@ -12,7 +12,7 @@ icon: icon.svg
 upstream: https://github.com/dani-garcia/vaultwarden
 documentation: https://github.com/dani-garcia/vaultwarden/wiki
 
-image_channel: vaultwarden/server:1.36.0@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
+image_channel: vaultwarden/server:1.37.1@sha256:ebdfe70701c60ac0c28c697e787cea767d7972940b786037b29fe0d507f821e8
 update_mode: manual
 
 resources:

--- a/install/docker-apps/zitadel/app.yaml
+++ b/install/docker-apps/zitadel/app.yaml
@@ -1,14 +1,14 @@
 slug: zitadel
 name: ZITADEL
 tags: ["Security", "Developer tools"]
-version: "4.15.0"
+version: "4.16.3"
 description: >-
   Self-hosted identity & access management: a complete OIDC/OAuth2/SAML provider with login UI, passkeys, MFA, and multi-tenant orgs. Two services: the ZITADEL Go server and a PostgreSQL event store. Any OIDC/SAML app can use it for login. TLS terminates at the nginx vhost (container runs plain HTTP, ExternalSecure=true); Console + OIDC work over HTTP/1.1. First login: admin@zitadel.<your-domain> with the generated ADMIN_PASSWORD (+suffix Aa1!) from the .env; change required on first sign-in.
 icon: icon.svg
 upstream: https://github.com/zitadel/zitadel
 documentation: https://zitadel.com/docs
 
-image_channel: ghcr.io/zitadel/zitadel:v4.15.0@sha256:cc9fb3b2788dcbd0dff93781a0323bbe491a4cec11e1caefd9a1ed31f7fdc145
+image_channel: ghcr.io/zitadel/zitadel:v4.16.3@sha256:f3738fd984131d3f02e386d37fa480d1a30e42b7d4202e2b322f12f7cf556b64
 update_mode: manual
 
 resources:


### PR DESCRIPTION
_Auto-generated on 2026-08-11 by `.github/workflows/catalog-bump.yml`._
_The bot force-pushes `catalog-auto-bump` weekly — do not park manual edits on this branch._

Rows marked **⚠ MAJOR** change the app's major track — re-validate that entry's
ports/env/volumes (the catalog contract) before merging. Skipped rows are apps the
bumper cannot handle by design; re-pin them to versioned tags to bring them in.

| App | Image tag | Version | Status |
|---|---|---|---|
| answer | `2.0.1` → `2.0.2` | 2.0.1 → 2.0.2 | ⬆ bumped |
| bigcapital | `v0.25.20` → `v0.25.26` | 0.25.20 → 0.25.26 | ⬆ bumped |
| dailytxt | `2.6.1` → `2.6.2` | 2.6.1 → 2.6.2 | ⬆ bumped |
| dawarich | `1.10.0` → `1.11.0` | 1.10.0 → 1.11.0 | ⬆ bumped |
| dokuwiki | `version-2025-05-14b` | 2024-02-06b | ⏭ skipped: unversioned tag scheme "version-2025-05-14b" — re-pin to a versioned tag to enable auto-bump |
| enclosed | `1.16.0` | 1.16.0 | ✅ up to date |
| erpnext | `v16.25.0` → `v16.31.1` | 16.25.0 → 16.31.1 | ⬆ bumped |
| flarum | `stable` | 1.8 | ⏭ skipped: unversioned tag scheme "stable" — re-pin to a versioned tag to enable auto-bump |
| forgejo | `15.0.3` → `16.0.2` | 15.0.3 → 16.0.2 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| fossbilling | `0.8.2` → `0.8.5` | 0.8.2 → 0.8.5 | ⬆ bumped |
| freshrss | `1.29.1` | 1.29.1 | ✅ up to date |
| ghost | `6-alpine` | 6.44.1 → 6.57.0 | ↻ digest refresh (tag re-pushed upstream) |
| gitea | `1.26` → `1.27` | 1.26.2 → 1.27.1 | ⬆ bumped |
| grafana | `13.0.2` | 13.0.2 | ✅ up to date |
| immich | `v2.7.5` → `v3.1.0` | 2.7.5 → 3.1.0 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| invoiceshelf | `2.4.1` → `2.4.2` | 2.4.1 → 2.4.2 | ⬆ bumped |
| jabali-sounder | `0.5.22` → `0.5.25` | 0.5.22 → 0.5.25 | ⬆ bumped |
| joplin | `3.7.1` | 3.7.1 | ✅ up to date |
| karakeep | `0.32.0` → `0.33.1` | 0.32.0 → 0.33.1 | ⬆ bumped |
| linkwarden | `v2.14.1` → `v2.16.0` | 2.14.1 → 2.16.0 | ⬆ bumped |
| matomo | `5-apache` | 5.10.1 → 5.12.0 | ↻ digest refresh (tag re-pushed upstream) |
| mealie | `v3.19.2` → `v3.22.0` | 3.19.2 → 3.22.0 | ⬆ bumped |
| mediacms | `latest` | 2026.06.24 | ⏭ skipped: unversioned tag scheme "latest" — re-pin to a versioned tag to enable auto-bump |
| memos | `0.29.1` → `0.30.0` | 0.29.1 → 0.30.0 | ⬆ bumped |
| n8n | `2.28.2` → `2.34.4` | 2.28.2 → 2.34.4 | ⬆ bumped |
| nextcloud | `33-apache` → `34-apache` | 33.0.5 → 34.0.2 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| odoo | `18.0` → `19.0` | 18.0 → 19.0 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| onlyoffice | `9.4.0` | 9.4.0 | ✅ up to date |
| open-webui | `0.9.6` → `0.11.0` | 0.9.6 → 0.11.0 | ⬆ bumped |
| openemr | `8.0.0.3` | 8.0.0.3 | ↻ digest refresh (tag re-pushed upstream) |
| owncloud | `10.16.3` → `11.0.0` | 10.16.3 → 11.0.0 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| paperless-ngx | `2.20.15` → `3.0.5` | 2.20.15 → 3.0.5 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| peertube | `v8.2.1-trixie` → `v8.2.4-trixie` | 8.2.1 → 8.2.4 | ⬆ bumped |
| pgadmin | `9.16` → `9.17` | 9.16 → 9.17 | ⬆ bumped |
| plausible | `v3.2.1` | 3.2.1 | ✅ up to date |
| pocket-id | `v2.11.0` → `v2.13.0` | 2.11.0 → 2.13.0 | ⬆ bumped |
| privatebin | `2.0.4` → `2.0.6` | 2.0.4 → 2.0.6 | ⬆ bumped |
| rocketchat | `6.13.1` → `8.7.0` | 6.13.1 → 8.7.0 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| romm | `4` → `5` | 4.9.2 → 5.1.0 | ⚠ MAJOR bump — re-validate ports/env/volumes before merging |
| searxng | `2026.6.20-fd42d4fda` → `2026.8.10-0a118066d` | 2026.6.20 → 2026.8.10 | ⬆ bumped |
| snipe-it | `v8.6.3` | 8.6.3 | ✅ up to date |
| uptime-kuma | `2` | 2.4.0 → 2.5.0 | ↻ digest refresh (tag re-pushed upstream) |
| vaultwarden | `1.36.0` → `1.37.1` | 1.36.0 → 1.37.1 | ⬆ bumped |
| zitadel | `v4.15.0` → `v4.16.3` | 4.15.0 → 4.16.3 | ⬆ bumped |

34 app(s) with updates.
