### PR TITLE
fix(invoiceshelf): selectable currency, clean admin identity, working uploads (GH #1042)

### DIFF
--- a/panel-agent/internal/commands/invoiceshelf_install.go
+++ b/panel-agent/internal/commands/invoiceshelf_install.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -53,13 +54,17 @@ type invoiceshelfInstallReq struct {
 	Subdirectory string `json:"subdirectory"`
 	SiteURL      string `json:"site_url"`
 	SiteTitle    string `json:"site_title"`
-	AdminEmail   string `json:"admin_email"`
-	AdminPass    string `json:"admin_pass"`
-	DBName       string `json:"db_name"`
-	DBUser       string `json:"db_user"`
-	DBPassword   string `json:"db_password"`
-	DBHost       string `json:"db_host"`
-	UseWWW       bool   `json:"use_www"`
+	// Currency is the ISO 4217 company currency (GH #1042). Optional;
+	// empty falls back to USD. Validated to ^[A-Z]{3}$ before it goes
+	// anywhere near the tinker env.
+	Currency   string `json:"currency"`
+	AdminEmail string `json:"admin_email"`
+	AdminPass  string `json:"admin_pass"`
+	DBName     string `json:"db_name"`
+	DBUser     string `json:"db_user"`
+	DBPassword string `json:"db_password"`
+	DBHost     string `json:"db_host"`
+	UseWWW     bool   `json:"use_www"`
 }
 
 type invoiceshelfInstallResp struct {
@@ -90,6 +95,12 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 	}
 	if req.SiteTitle == "" {
 		req.SiteTitle = "InvoiceShelf"
+	}
+	if req.Currency == "" {
+		req.Currency = "USD"
+	}
+	if !regexp.MustCompile(`^[A-Z]{3}$`).MatchString(req.Currency) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "currency must be a 3-letter ISO 4217 code"}
 	}
 	if err := validateDocrootPath(req.OSUser, req.Docroot); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: err.Error()}
@@ -209,26 +220,23 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 	if err := artisan(10*time.Minute, "migrate", "--force", "--seed"); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
-	// NOTE: `artisan storage:link` is intentionally skipped. After the
-	// public/ flatten there is no public/ dir for Laravel's default
-	// public_path()/storage target, so the link errors; it only affects
-	// serving uploaded files over /storage (e.g. a company logo), not the
-	// invoicing core, and is a tracked follow-up.
+	// `artisan storage:link` stays skipped — after the public/ flatten
+	// there is no public/ dir for its target, and a symlink named
+	// `storage` cannot coexist with the real storage/ directory at the
+	// flattened webroot anyway. Uploads are served instead by an nginx
+	// alias in writeInvoiceShelfNginx: /storage/ -> storage/app/public/
+	// (GH #1042 — before that alias existed, the hardening denied
+	// /storage/ outright and every upload 404'd: "we can upload but it
+	// never shows").
 
 	// Patch the seeded super-admin to the operator's identity + mark the
 	// onboarding complete. The stock UsersTableSeeder created a working
 	// admin/company/roles; we only rewrite the login credentials and the
 	// company name, then flip profile_complete so the wizard is skipped.
 	// Password + title travel via env (never argv) into the tinker script.
-	tinker := `$u = App\Models\User::where('role','super admin')->first();` +
-		`$u->email = '` + req.AdminEmail + `';` +
-		`$u->password = getenv('IS_ADMIN_PASS');` +
-		`$u->save();` +
-		`$c = App\Models\Company::where('owner_id',$u->id)->first();` +
-		`if($c){ $c->name = getenv('IS_SITE_TITLE'); $c->save(); }` +
-		`App\Models\Setting::setSetting('profile_complete','COMPLETED');`
+	tinker := invoiceshelfFinaliseTinker(req.AdminEmail)
 	tinkerCmd := buildSystemdRunCmdEnv(ctx, req.OSUser,
-		[]string{"IS_ADMIN_PASS=" + req.AdminPass, "IS_SITE_TITLE=" + req.SiteTitle},
+		[]string{"IS_ADMIN_PASS=" + req.AdminPass, "IS_SITE_TITLE=" + req.SiteTitle, "IS_CURRENCY=" + req.Currency},
 		php, filepath.Join(installPath, "artisan"), "tinker", "--execute="+tinker)
 	tinkerCmd.Dir = installPath
 	if out, err := runBoundedOutput(tinkerCmd, 0); err != nil {
@@ -252,7 +260,7 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 
-	if err := writeInvoiceShelfNginx(ctx, domain, req.OSUser, req.Subdirectory); err != nil {
+	if err := writeInvoiceShelfNginx(ctx, domain, req.OSUser, req.Subdirectory, installPath); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("nginx snippet: %v", err)}
 	}
 
@@ -297,4 +305,30 @@ func invoiceshelfDownload(ctx context.Context, dest string) error {
 
 func init() {
 	RegisterAppInstaller("invoiceshelf", invoiceshelfInstallHandler)
+}
+
+// invoiceshelfFinaliseTinker builds the post-seed finalisation script. Only
+// admin_email is interpolated (character-checked upstream); every other
+// value travels via env so it can never break out of a PHP string literal.
+//
+// GH #1042 additions on top of the original credential patch:
+//   - $u->name: the stock UsersTableSeeder ships a placeholder identity
+//     ("Jane Doe") which stayed visible in the UI — the reporter's "random
+//     admin user". The login is the email; the display name becomes a
+//     neutral constant.
+//   - currency: the seeder hardcodes KWD and the skipped onboarding wizard
+//     is where a currency would normally be picked. Resolve the requested
+//     ISO code against the app's own currencies table; an unknown code
+//     leaves the seeded default rather than failing the install.
+func invoiceshelfFinaliseTinker(adminEmail string) string {
+	return `$u = App\Models\User::where('role','super admin')->first();` +
+		`$u->email = '` + adminEmail + `';` +
+		`$u->name = 'Administrator';` +
+		`$u->password = getenv('IS_ADMIN_PASS');` +
+		`$u->save();` +
+		`$c = App\Models\Company::where('owner_id',$u->id)->first();` +
+		`if($c){ $c->name = getenv('IS_SITE_TITLE'); $c->save(); }` +
+		`$cur = App\Models\Currency::where('code', getenv('IS_CURRENCY'))->first();` +
+		`if($c && $cur){ App\Models\CompanySetting::setSettings(['currency' => $cur->id], $c->id); }` +
+		`App\Models\Setting::setSetting('profile_complete','COMPLETED');`
 }

--- a/panel-agent/internal/commands/invoiceshelf_install_test.go
+++ b/panel-agent/internal/commands/invoiceshelf_install_test.go
@@ -10,12 +10,11 @@ import (
 // `~ \.php$` with = / ^~ precedence. A gap here means /vendor/*.php is
 // executable or /.env is readable.
 func TestInvoiceShelfNginxConf_DeniesSensitivePaths(t *testing.T) {
-	conf := invoiceShelfNginxConf("alice", "invoices")
+	conf := invoiceShelfNginxConf("alice", "invoices", "/home/alice/domains/x.com/public_html/invoices")
 	for _, must := range []string{
 		"location = /invoices/.env { deny all; return 404; }",
 		"location = /invoices/artisan { deny all; return 404; }",
 		"location ^~ /invoices/vendor/ { deny all; return 404; }",
-		"location ^~ /invoices/storage/ { deny all; return 404; }",
 		"location ^~ /invoices/config/ { deny all; return 404; }",
 		"location ^~ /invoices/database/ { deny all; return 404; }",
 		"try_files $uri $uri/ /invoices/index.php?$query_string;",
@@ -25,12 +24,64 @@ func TestInvoiceShelfNginxConf_DeniesSensitivePaths(t *testing.T) {
 		}
 	}
 	// Docroot install: deny blocks present, but no subdir front controller.
-	root := invoiceShelfNginxConf("alice", "")
+	root := invoiceShelfNginxConf("alice", "", "/home/alice/domains/x.com/public_html")
 	if !strings.Contains(root, "location ^~ /vendor/ { deny all; return 404; }") {
 		t.Error("docroot conf must still deny /vendor/")
 	}
 	if strings.Contains(root, "try_files") {
 		t.Error("docroot install rides the generic vhost front controller — no try_files")
+	}
+}
+
+// GH #1042: uploads live on Laravel's public disk (storage/app/public) and
+// are linked as /storage/<path>. The old snippet blanket-denied /storage/,
+// so every upload 404'd after a successful save. The alias must serve
+// exactly the public disk — and ONLY it: a blanket deny AND the alias for
+// the same ^~ prefix would be an nginx duplicate-location error, and the
+// alias remap is itself what keeps storage/framework + storage/logs
+// unreachable.
+func TestInvoiceShelfNginxConf_StorageAliasServesUploads(t *testing.T) {
+	for _, tc := range []struct{ subdir, prefix, install string }{
+		{"", "", "/home/alice/domains/x.com/public_html"},
+		{"invoices", "/invoices", "/home/alice/domains/x.com/public_html/invoices"},
+	} {
+		conf := invoiceShelfNginxConf("alice", tc.subdir, tc.install)
+		if strings.Contains(conf, "location ^~ "+tc.prefix+"/storage/ { deny all") {
+			t.Errorf("subdir=%q: /storage/ is still blanket-denied — uploads 404 (the #1042 bug)", tc.subdir)
+		}
+		if !strings.Contains(conf, "alias "+tc.install+"/storage/app/public/;") {
+			t.Errorf("subdir=%q: alias to the public disk missing\n%s", tc.subdir, conf)
+		}
+		// An uploaded .php must not be served or executed.
+		if !strings.Contains(conf, `location ~ \.php$ { deny all; return 404; }`) {
+			t.Errorf("subdir=%q: nested php deny missing under the storage alias", tc.subdir)
+		}
+		// The alias/try_files trap: try_files under alias resolves against
+		// root, not the alias target — it must not appear in the block.
+		storageBlock := conf[strings.Index(conf, "location ^~ "+tc.prefix+"/storage/"):]
+		storageBlock = storageBlock[:strings.Index(storageBlock, "}\n")+1]
+		if strings.Contains(storageBlock, "try_files") {
+			t.Errorf("subdir=%q: try_files inside the alias block — the classic nginx alias trap", tc.subdir)
+		}
+	}
+}
+
+// GH #1042: the finalisation script must scrub the seeder's placeholder
+// identity and resolve the requested currency against the app's own table.
+func TestInvoiceShelfFinaliseTinker(t *testing.T) {
+	tk := invoiceshelfFinaliseTinker("admin@example.com")
+	for _, must := range []string{
+		`$u->name = 'Administrator';`,          // "Jane Doe" must not survive
+		`$u->email = 'admin@example.com';`,     // login identity
+		`getenv('IS_ADMIN_PASS')`,              // secret via env, never argv
+		`Currency::where('code', getenv('IS_CURRENCY'))`,
+		`CompanySetting::setSettings(['currency' => $cur->id], $c->id)`,
+		`if($c && $cur)`,                       // unknown code keeps the seed, install survives
+		`Setting::setSetting('profile_complete','COMPLETED')`,
+	} {
+		if !strings.Contains(tk, must) {
+			t.Errorf("tinker missing %q\n%s", must, tk)
+		}
 	}
 }
 

--- a/panel-agent/internal/commands/invoiceshelf_nginx.go
+++ b/panel-agent/internal/commands/invoiceshelf_nginx.go
@@ -56,7 +56,7 @@ func invoiceShelfSnippetPath(domain, subdir string) string {
 // locations that beat the vhost's `~ \.php$` (nginx precedence: = > ^~ >
 // ~). Subdir installs also get a Laravel front controller since the generic
 // vhost's try_files targets /index.php at the docroot, not /<sub>/index.php.
-func invoiceShelfNginxConf(osUser, subdir string) string {
+func invoiceShelfNginxConf(osUser, subdir, installPath string) string {
 	p := ""
 	if subdir != "" {
 		p = "/" + subdir
@@ -67,7 +67,31 @@ func invoiceShelfNginxConf(osUser, subdir string) string {
 	for _, f := range []string{"/.env", "/artisan", "/composer.json", "/composer.lock"} {
 		fmt.Fprintf(&b, "location = %s%s { deny all; return 404; }\n", p, f)
 	}
-	for _, d := range []string{"/vendor/", "/storage/", "/bootstrap/", "/config/", "/database/", "/app/", "/resources/", "/routes/", "/lang/", "/tests/", "/.git"} {
+	// /storage/ is NOT in the deny list below: it gets its own alias block
+	// instead (same ^~ prefix — a deny AND an alias for the identical
+	// prefix would be an nginx duplicate-location error). The alias remaps
+	// the URL space into storage/app/public/ only, so framework internals
+	// (storage/framework, storage/logs) stay unreachable: a request for
+	// /storage/logs/laravel.log resolves to
+	// storage/app/public/logs/laravel.log, which does not exist.
+	//
+	// GH #1042: uploads (logos, receipts, avatars) land on Laravel's
+	// public disk at storage/app/public and are linked as /storage/<path>;
+	// with the old blanket deny every one of them 404'd after a
+	// successful upload. `artisan storage:link` cannot fix it here — the
+	// public/ flatten leaves no public/ dir, and a `storage` symlink
+	// cannot coexist with the real storage/ directory at the webroot.
+	//
+	// The nested \.php$ deny keeps an uploaded .php from being served
+	// (^~ suppresses only SERVER-level regex locations, nested ones still
+	// apply). No try_files: with alias it re-resolves against root — the
+	// long-standing nginx alias/try_files trap — and a missing file 404s
+	// on its own anyway.
+	fmt.Fprintf(&b, "location ^~ %s/storage/ {\n", p)
+	fmt.Fprintf(&b, "    alias %s/storage/app/public/;\n", installPath)
+	b.WriteString("    location ~ \\.php$ { deny all; return 404; }\n")
+	b.WriteString("}\n")
+	for _, d := range []string{"/vendor/", "/bootstrap/", "/config/", "/database/", "/app/", "/resources/", "/routes/", "/lang/", "/tests/", "/.git"} {
 		fmt.Fprintf(&b, "location ^~ %s%s { deny all; return 404; }\n", p, d)
 	}
 	if subdir != "" {
@@ -83,7 +107,7 @@ func invoiceShelfNginxConf(osUser, subdir string) string {
 	return b.String()
 }
 
-func writeInvoiceShelfNginx(ctx context.Context, domain, osUser, subdir string) error {
+func writeInvoiceShelfNginx(ctx context.Context, domain, osUser, subdir, installPath string) error {
 	if !domainRegex.MatchString(domain) {
 		return fmt.Errorf("invalid domain %q", domain)
 	}
@@ -93,12 +117,20 @@ func writeInvoiceShelfNginx(ctx context.Context, domain, osUser, subdir string) 
 	if !osUserSafeRE.MatchString(osUser) {
 		return fmt.Errorf("invalid os_user %q", osUser)
 	}
+	// installPath lands verbatim in an nginx alias directive; it was
+	// validated upstream (validateDocrootPath + appInstallPath), but this
+	// writer is also reachable on its own, so re-assert the shape: an
+	// absolute clean path with no nginx-meaningful characters.
+	if installPath == "" || !filepath.IsAbs(installPath) || installPath != filepath.Clean(installPath) ||
+		strings.ContainsAny(installPath, " \t\r\n\"';{}") {
+		return fmt.Errorf("invalid install path %q", installPath)
+	}
 	domainDir := filepath.Join(nginxJabaliDir, domain)
 	if err := os.MkdirAll(domainDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", domainDir, err)
 	}
 	dest := invoiceShelfSnippetPath(domain, subdir)
-	if err := os.WriteFile(dest, []byte(invoiceShelfNginxConf(osUser, subdir)), 0o644); err != nil {
+	if err := os.WriteFile(dest, []byte(invoiceShelfNginxConf(osUser, subdir, installPath)), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", dest, err)
 	}
 	return reloadNginxAfterSnippet(ctx, dest)

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -1669,9 +1669,12 @@ type invoiceShelfKickArgs struct {
 	DBUser       string
 	DBPassword   string
 	SiteTitle    string
-	AdminEmail   string
-	AdminPass    string
-	UseWWW       bool
+	// Currency is the ISO 4217 code for the company currency (GH #1042);
+	// enum-gated by the descriptor, defaulted to USD by the service.
+	Currency   string
+	AdminEmail string
+	AdminPass  string
+	UseWWW     bool
 }
 
 // createInvoiceShelfInstallAndKickAgent flips the install row to
@@ -1701,6 +1704,7 @@ func createInvoiceShelfInstallAndKickAgent(parentCtx context.Context, args invoi
 		"db_password":  args.DBPassword,
 		"db_host":      "localhost",
 		"site_title":   args.SiteTitle,
+		"currency":     args.Currency,
 		"admin_email":  args.AdminEmail,
 		"admin_pass":   args.AdminPass,
 		"use_www":      args.UseWWW,

--- a/panel-api/internal/api/applications_service.go
+++ b/panel-api/internal/api/applications_service.go
@@ -524,6 +524,7 @@ func dispatchInstallKicker(ctx context.Context, appName string, k kickContext, d
 			DBUser:       k.Chain.DBUsername,
 			DBPassword:   k.Chain.DBPassword,
 			SiteTitle:    paramOr(k.Params, "site_title", "InvoiceShelf"),
+			Currency:     paramOr(k.Params, "currency", "USD"),
 			AdminEmail:   k.AdminEmail,
 			AdminPass:    invoicePass,
 			UseWWW:       k.UseWWW,

--- a/panel-api/internal/apps/invoiceshelf.go
+++ b/panel-api/internal/apps/invoiceshelf.go
@@ -38,5 +38,17 @@ var InvoiceShelf = App{
 			Required:    false,
 			Description: "Initial admin password. Leave blank to have one generated and shown once (minimum 8 characters).",
 		},
+		// GH #1042: the stock seeder hardcodes Kuwaiti Dinar (Crater
+		// heritage) and the install skips the onboarding wizard where a
+		// currency would normally be chosen, so KWD stuck for every
+		// install. Values mirror the app's own seeded currencies table
+		// (81 rows, deduped to 78 codes).
+		"currency": {
+			Type:        "enum",
+			Required:    false,
+			Default:     "USD",
+			Values:      []string{"AED", "ANG", "ARS", "AUD", "AWG", "BAM", "BDT", "BGN", "BRL", "CAD", "CHF", "CLP", "CNY", "COP", "CRC", "CZK", "DKK", "DOP", "DZD", "EGP", "EUR", "GBP", "GHS", "GTQ", "HKD", "HRK", "IDR", "ILS", "INR", "IQD", "JMD", "JPY", "KES", "KGS", "KWD", "LKR", "LYD", "MAD", "MKD", "MOP", "MVR", "MXN", "MYR", "MZN", "NAD", "NGN", "NOK", "NPR", "NZD", "OMR", "PEN", "PHP", "PKR", "PLN", "PYG", "QAR", "RON", "RSD", "RUB", "RWF", "SAR", "SEK", "SGD", "THB", "TMT", "TND", "TRY", "TTD", "TWD", "TZS", "UAH", "USD", "UYU", "VND", "XAF", "XCD", "XOF", "ZAR"},
+			Description: "Company currency for invoices and estimates.",
+		},
 	},
 }


### PR DESCRIPTION
All three items from #1042, reproduced live before fixing and verified live after.

## 1. Currency stuck at KWD

The stock seeder ships Kuwaiti Dinar (Crater heritage), and our install **deliberately skips the onboarding wizard** — which is exactly where a currency would normally be chosen — so KWD stuck for every install with no post-install escape.

Fix: a `currency` **enum param** (default `USD`, values mirroring the app's own seeded currencies table — 81 rows, deduped to 78 codes). Resolved at finalise time against the app's table (`CompanySetting::setSettings(['currency' => $id], $companyId)`); an unknown code keeps the seeded default rather than failing the install. The code travels via env into tinker, never argv. **No UI change needed** — the install modal already renders enum params from the registry schema.

## 2. "Random admin user"

The seeder creates a placeholder identity — literally **"Jane Doe"** on the baseline install — and our credential patch rewrote email + password but never the name. The finalise script now sets the display name to `Administrator`; login remains the email.

## 3. Uploads saved but never shown

Our own hardening blanket-denied `/storage/` — correct instinct, wrong granularity: uploads live on Laravel's public disk at `storage/app/public/` and are linked as `/storage/<path>`, so every successful upload 404'd on render. `artisan storage:link` can't help here: the `public/` flatten leaves no `public/` dir, and a `storage` symlink can't coexist with the real `storage/` directory at the webroot.

The deny is replaced by an **nginx alias** of `/storage/` onto `storage/app/public/`:

- The alias remap **is** the containment — `/storage/logs/laravel.log` resolves to `storage/app/public/logs/laravel.log`, which doesn't exist
- Nested `\.php$` deny → an uploaded `.php` is neither executed nor served (`^~` suppresses only server-level regex; nested still applies)
- **No `try_files`** — the classic alias trap (it re-resolves against root)
- A deny *and* an alias for the identical `^~` prefix would be an nginx duplicate-location error, which is why it's a replacement, not an addition
- `installPath` is re-validated at the snippet writer since it lands verbatim in an nginx directive

The finalise tinker moved into `invoiceshelfFinaliseTinker()` so the identity scrub and currency resolution are pinned by unit tests instead of living in a string concat.

## E2E on testserver

| Check | Before | After |
|---|---|---|
| Company currency | `KWD / Kuwaiti Dinar` (id 13) | **`EUR / Euro`** (install param honoured) |
| Admin identity | `Jane Doe` | **`Administrator`** |
| File on public disk via `/storage/` | **404** | **200, content byte-exact** |
| `/.env`, `/storage/logs/…`, `/storage/framework/…`, `/vendor/…`, `/storage/*.php` | 404 | **all still 404** |
| `nginx -t` | — | clean |

Teardown of the E2E install also exercised the fresh #1057 CLI delete: vhost, DNS zone, mail, and DB rows all reaped — confirmed live.

## Tests

- [x] `TestInvoiceShelfNginxConf_StorageAliasServesUploads` — alias present for root + subdir, blanket deny gone, nested php deny, no try_files
- [x] `TestInvoiceShelfFinaliseTinker` — name scrub, env-only secrets, currency lookup + null-safe apply, wizard completion
- [x] Existing hardening/traversal tests updated and passing
- [x] Full `panel-agent` + `panel-api` suites 0 FAIL

## Scope note

Existing installs keep their old snippet (written at install time). For the reporter's live install the one-line remedy is in the issue reply; a converge for existing InvoiceShelf installs would need a snippet-regeneration pass and is worth its own decision.