### PR TITLE
feat(mail): serve autoconfig + autodiscover so mail clients self-configure (GH #1039)

### DIFF
--- a/install/nginx/jabali-mail-vhost.conf.tmpl
+++ b/install/nginx/jabali-mail-vhost.conf.tmpl
@@ -110,8 +110,47 @@ server {
     proxy_http_version 1.1;
   }
 
-  location = /autodiscover/autodiscover.xml { return 404; }
-  location = /Autodiscover/Autodiscover.xml { return 404; }
+  # Mail-client autoconfiguration (GH #1039). panel-api renders the config
+  # documents from the domain's mail settings (mail.<domain>, IMAPS 993 /
+  # SMTPS 465). Host is forwarded so panel-api derives the domain from
+  # autoconfig.<domain> / autodiscover.<domain>. These paths used to 404
+  # (autodiscover) or fall through `location /` to Bulwark webmail (autoconfig).
+  #
+  #   Thunderbird / Mozilla: GET  /mail/config-v1.1.xml
+  #                          GET  /.well-known/autoconfig/mail/config-v1.1.xml
+  #   Outlook / Exchange:    POST /autodiscover/autodiscover.xml (+ capitalised)
+  location = /mail/config-v1.1.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /.well-known/autoconfig/mail/config-v1.1.xml {
+    proxy_pass http://jabali_panel_api/mail/config-v1.1.xml;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /autodiscover/autodiscover.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /Autodiscover/Autodiscover.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
 }
 
 # HTTP → HTTPS redirect for mail.<domain>. The ACME location must

--- a/panel-agent/internal/commands/webmail_vhost.go
+++ b/panel-agent/internal/commands/webmail_vhost.go
@@ -125,8 +125,47 @@ server {
     proxy_http_version 1.1;
   }
 
-  location = /autodiscover/autodiscover.xml { return 404; }
-  location = /Autodiscover/Autodiscover.xml { return 404; }
+  # Mail-client autoconfiguration (GH #1039). panel-api renders the config
+  # documents from the domain's mail settings (mail.<domain>, IMAPS 993 /
+  # SMTPS 465). Host is forwarded so panel-api derives the domain from
+  # autoconfig.<domain> / autodiscover.<domain>. These paths used to 404
+  # (autodiscover) or fall through location / to Bulwark webmail (autoconfig).
+  #
+  #   Thunderbird / Mozilla: GET  /mail/config-v1.1.xml
+  #                          GET  /.well-known/autoconfig/mail/config-v1.1.xml
+  #   Outlook / Exchange:    POST /autodiscover/autodiscover.xml (+ capitalised)
+  location = /mail/config-v1.1.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /.well-known/autoconfig/mail/config-v1.1.xml {
+    proxy_pass http://jabali_panel_api/mail/config-v1.1.xml;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /autodiscover/autodiscover.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
+  location = /Autodiscover/Autodiscover.xml {
+    proxy_pass http://jabali_panel_api;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_http_version 1.1;
+  }
 }
 
 server {

--- a/panel-api/internal/api/mail_autoconfig.go
+++ b/panel-api/internal/api/mail_autoconfig.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"encoding/xml"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Mail-client autoconfiguration (GH #1039). Jabali publishes the DNS side
+// (autoconfig/autodiscover CNAMEs + the RFC 6186 SRVs) and the cert SANs, but
+// served no config document, so Thunderbird's
+//   GET  autoconfig.<domain>/mail/config-v1.1.xml
+// fell through the mail vhost's `location /` to Bulwark webmail (a login page,
+// not XML), and Outlook's
+//   POST autodiscover.<domain>/autodiscover/autodiscover.xml
+// was explicitly 404'd. This handler renders both from the domain's real mail
+// settings so a fresh IMAP client configures itself with no manual entry.
+//
+// Servers advertised match the Stalwart listeners + the RFC 6186 SRVs
+// (email_records.go): host mail.<domain>, IMAPS 993, SMTPS 465 — both implicit
+// TLS, password auth. The mail host is always taken from the DB row (trusted),
+// never from the request, so a spoofed Host header cannot inject a hostname.
+//
+// The endpoints are unauthenticated by design (a mail client has no panel
+// session when it first probes) and are reachable only via the mail vhost,
+// whose hostnames (mail./autoconfig./autodiscover.<domain>) are already on the
+// CrowdSec-AppSec exempt list (webmail_reconcile.go), so the autodiscover XML
+// POST body is not WAF-inspected.
+
+const (
+	// mailAutoconfigIMAPSPort / SMTPSPort are the implicit-TLS submission
+	// ports Stalwart listens on (apply-plan.json.tmpl imap-993 /
+	// smtp-submissions-465), matching the _imaps._tcp / _submissions._tcp SRVs.
+	mailAutoconfigIMAPSPort = 993
+	mailAutoconfigSMTPSPort = 465
+)
+
+// MailAutoconfigHandlerConfig wires the public mail-autoconfig endpoints.
+type MailAutoconfigHandlerConfig struct {
+	Domains repository.DomainRepository
+	Log     *slog.Logger
+}
+
+type mailAutoconfigHandler struct{ cfg MailAutoconfigHandlerConfig }
+
+// RegisterMailAutoconfigRoutes mounts the discovery endpoints on the engine
+// root (not /api/v1) — they are served from the mail vhost, which proxies these
+// exact paths to panel-api, and carry no API prefix or Kratos session. Both the
+// lower-case (Thunderbird/Apple) and capitalised (Outlook) autodiscover paths
+// are registered because gin routing is case-sensitive and the nginx location
+// forwards the request URI verbatim.
+func RegisterMailAutoconfigRoutes(r gin.IRouter, cfg MailAutoconfigHandlerConfig) {
+	h := &mailAutoconfigHandler{cfg: cfg}
+	// Thunderbird / Mozilla autoconfig.
+	r.GET("/mail/config-v1.1.xml", h.mozillaConfig)
+	r.GET("/.well-known/autoconfig/mail/config-v1.1.xml", h.mozillaConfig)
+	// Outlook / Exchange autodiscover (POST is the spec path; some clients GET).
+	r.POST("/autodiscover/autodiscover.xml", h.autodiscover)
+	r.GET("/autodiscover/autodiscover.xml", h.autodiscover)
+	r.POST("/Autodiscover/Autodiscover.xml", h.autodiscover)
+	r.GET("/Autodiscover/Autodiscover.xml", h.autodiscover)
+}
+
+// resolveMailDomain returns the hosted, jabali-mail domain this request is
+// asking about, or ("", false) if it isn't one we serve mail for. Preference:
+// an explicit email address (query for Thunderbird, POST body for Outlook) wins
+// over the Host, because a client may probe autoconfig.<a> for an address
+// @<b>; otherwise the autoconfig/autodiscover/mail/mta-sts host prefix is
+// stripped. The returned name is the canonical DB value, not the raw input.
+func (h *mailAutoconfigHandler) resolveMailDomain(c *gin.Context, emailHint string) (*models.Domain, bool) {
+	candidate := domainFromEmail(emailHint)
+	if candidate == "" {
+		candidate = stripMailHostPrefix(hostWithoutPort(c.Request.Host))
+	}
+	if candidate == "" {
+		return nil, false
+	}
+	d, err := h.cfg.Domains.FindByName(c.Request.Context(), candidate)
+	if err != nil || d == nil {
+		return nil, false
+	}
+	// Only advertise mail.<domain> for domains whose mail we actually host.
+	if !d.EmailEnabled || (d.MailProvider != "" && d.MailProvider != "jabali") {
+		return nil, false
+	}
+	return d, true
+}
+
+func (h *mailAutoconfigHandler) mozillaConfig(c *gin.Context) {
+	d, ok := h.resolveMailDomain(c, c.Query("emailaddress"))
+	if !ok {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	mailHost := "mail." + d.Name
+	cfg := mozClientConfig{
+		Version: "1.1",
+		Provider: mozEmailProvider{
+			ID:               d.Name,
+			Domain:           d.Name,
+			DisplayName:      d.Name + " Mail",
+			DisplayShortName: d.Name,
+			Incoming: mozServer{
+				Type: "imap", Hostname: mailHost, Port: mailAutoconfigIMAPSPort,
+				SocketType: "SSL", Authentication: "password-cleartext", Username: "%EMAILADDRESS%",
+			},
+			Outgoing: mozServer{
+				Type: "smtp", Hostname: mailHost, Port: mailAutoconfigSMTPSPort,
+				SocketType: "SSL", Authentication: "password-cleartext", Username: "%EMAILADDRESS%",
+			},
+		},
+	}
+	writeXML(c, cfg)
+}
+
+func (h *mailAutoconfigHandler) autodiscover(c *gin.Context) {
+	email := c.Query("emailaddress")
+	if email == "" {
+		if body, err := io.ReadAll(io.LimitReader(c.Request.Body, 64<<10)); err == nil {
+			email = autodiscoverRequestEmail(body)
+		}
+	}
+	d, ok := h.resolveMailDomain(c, email)
+	if !ok {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	mailHost := "mail." + d.Name
+	// LoginName echoes the requested address when we have it (Outlook fills the
+	// account form from it); fall back to the Mozilla-style placeholder so the
+	// document is still valid when the client GETs without an address.
+	login := email
+	if login == "" {
+		login = "%EMAILADDRESS%"
+	}
+	resp := adAutodiscover{
+		Response: adResponse{
+			Account: adAccount{
+				AccountType: "email",
+				Action:      "settings",
+				Protocols: []adProtocol{
+					{Type: "IMAP", Server: mailHost, Port: mailAutoconfigIMAPSPort, SSL: "on", SPA: "off", Encryption: "SSL", AuthRequired: "on", LoginName: login},
+					{Type: "SMTP", Server: mailHost, Port: mailAutoconfigSMTPSPort, SSL: "on", SPA: "off", Encryption: "SSL", AuthRequired: "on", LoginName: login},
+				},
+			},
+		},
+	}
+	writeXML(c, resp)
+}
+
+// writeXML marshals v with the XML prolog and the application/xml content type
+// mail clients expect. encoding/xml escapes every interpolated value, so a
+// crafted email address in a LoginName cannot break out of the document.
+func writeXML(c *gin.Context, v any) {
+	out, err := xml.MarshalIndent(v, "", "  ")
+	if err != nil {
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	c.Header("Content-Type", "application/xml; charset=utf-8")
+	c.Header("Cache-Control", "public, max-age=3600")
+	_, _ = c.Writer.Write([]byte(xml.Header))
+	_, _ = c.Writer.Write(out)
+}
+
+// --- helpers -------------------------------------------------------------
+
+func hostWithoutPort(host string) string {
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		return host[:i]
+	}
+	return host
+}
+
+// stripMailHostPrefix removes the mail-vhost label (autoconfig/autodiscover/
+// mail/mta-sts) so "autoconfig.example.com" resolves the "example.com" row.
+func stripMailHostPrefix(host string) string {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	for _, p := range []string{"autoconfig.", "autodiscover.", "mail.", "mta-sts."} {
+		if strings.HasPrefix(host, p) {
+			return host[len(p):]
+		}
+	}
+	return host
+}
+
+// domainFromEmail returns the lower-cased domain part of an email address, or
+// "" if the input isn't a single well-formed address.
+func domainFromEmail(email string) string {
+	email = strings.TrimSpace(email)
+	at := strings.LastIndexByte(email, '@')
+	if at <= 0 || at == len(email)-1 {
+		return ""
+	}
+	dom := strings.ToLower(email[at+1:])
+	if strings.ContainsAny(dom, " \t\r\n<>\"") || !strings.Contains(dom, ".") {
+		return ""
+	}
+	return dom
+}
+
+// autodiscoverRequestEmail pulls <EMailAddress> out of an Outlook autodiscover
+// request body without a full schema unmarshal (the request namespace differs
+// across Outlook versions).
+func autodiscoverRequestEmail(body []byte) string {
+	dec := xml.NewDecoder(strings.NewReader(string(body)))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		if se, ok := tok.(xml.StartElement); ok && strings.EqualFold(se.Name.Local, "EMailAddress") {
+			var v string
+			if dec.DecodeElement(&v, &se) == nil {
+				return strings.TrimSpace(v)
+			}
+			return ""
+		}
+	}
+}
+
+// --- Mozilla autoconfig (clientConfig 1.1) document ----------------------
+
+type mozClientConfig struct {
+	XMLName  xml.Name         `xml:"clientConfig"`
+	Version  string           `xml:"version,attr"`
+	Provider mozEmailProvider `xml:"emailProvider"`
+}
+
+type mozEmailProvider struct {
+	ID               string    `xml:"id,attr"`
+	Domain           string    `xml:"domain"`
+	DisplayName      string    `xml:"displayName"`
+	DisplayShortName string    `xml:"displayShortName"`
+	Incoming         mozServer `xml:"incomingServer"`
+	Outgoing         mozServer `xml:"outgoingServer"`
+}
+
+type mozServer struct {
+	Type           string `xml:"type,attr"`
+	Hostname       string `xml:"hostname"`
+	Port           int    `xml:"port"`
+	SocketType     string `xml:"socketType"`
+	Authentication string `xml:"authentication"`
+	Username       string `xml:"username"`
+}
+
+// --- Outlook autodiscover (Outlook responseschema 2006a) document --------
+
+type adAutodiscover struct {
+	XMLName  xml.Name   `xml:"http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006 Autodiscover"`
+	Response adResponse `xml:"http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a Response"`
+}
+
+type adResponse struct {
+	Account adAccount `xml:"Account"`
+}
+
+type adAccount struct {
+	AccountType string       `xml:"AccountType"`
+	Action      string       `xml:"Action"`
+	Protocols   []adProtocol `xml:"Protocol"`
+}
+
+type adProtocol struct {
+	Type         string `xml:"Type"`
+	Server       string `xml:"Server"`
+	Port         int    `xml:"Port"`
+	SSL          string `xml:"SSL"`
+	SPA          string `xml:"SPA"`
+	Encryption   string `xml:"Encryption"`
+	AuthRequired string `xml:"AuthRequired"`
+	LoginName    string `xml:"LoginName"`
+}

--- a/panel-api/internal/api/mail_autoconfig_test.go
+++ b/panel-api/internal/api/mail_autoconfig_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type acDomainRepo struct {
+	repository.DomainRepository
+	byName map[string]*models.Domain
+}
+
+func (r *acDomainRepo) FindByName(_ context.Context, name string) (*models.Domain, error) {
+	if d, ok := r.byName[name]; ok {
+		return d, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func newAutoconfigRouter(repo repository.DomainRepository) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	RegisterMailAutoconfigRoutes(r, MailAutoconfigHandlerConfig{Domains: repo})
+	return r
+}
+
+func mailRepo() *acDomainRepo {
+	return &acDomainRepo{byName: map[string]*models.Domain{
+		"example.com": {Name: "example.com", EmailEnabled: true, MailProvider: "jabali"},
+		// mail disabled — must NOT be advertised
+		"nomail.com": {Name: "nomail.com", EmailEnabled: false, MailProvider: "jabali"},
+		// external MX — jabali doesn't host its mail
+		"ext.com": {Name: "ext.com", EmailEnabled: true, MailProvider: "m365"},
+	}}
+}
+
+func acDo(r *gin.Engine, method, path, host, body string) *httptest.ResponseRecorder {
+	var rd *strings.Reader
+	if body != "" {
+		rd = strings.NewReader(body)
+	} else {
+		rd = strings.NewReader("")
+	}
+	req := httptest.NewRequest(method, path, rd)
+	if host != "" {
+		req.Host = host
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestMozillaConfig_ServesXMLForHostedDomain(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	w := acDo(r, http.MethodGet, "/mail/config-v1.1.xml", "autoconfig.example.com", "")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/xml") {
+		t.Errorf("content-type = %q", ct)
+	}
+	b := w.Body.String()
+	for _, want := range []string{
+		`<clientConfig version="1.1">`,
+		`<emailProvider id="example.com">`,
+		`<hostname>mail.example.com</hostname>`,
+		`<incomingServer type="imap">`, `<port>993</port>`,
+		`<outgoingServer type="smtp">`, `<port>465</port>`,
+		`<socketType>SSL</socketType>`,
+		`<username>%EMAILADDRESS%</username>`,
+	} {
+		if !strings.Contains(b, want) {
+			t.Errorf("body missing %q\n---\n%s", want, b)
+		}
+	}
+}
+
+func TestMozillaConfig_EmailAddressQueryWinsOverHost(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	// Host is the panel's own; the emailaddress param names the real domain.
+	w := acDo(r, http.MethodGet, "/mail/config-v1.1.xml?emailaddress=bob@example.com", "panel.other.tld", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "<hostname>mail.example.com</hostname>") {
+		t.Errorf("expected example.com mail host, got:\n%s", w.Body.String())
+	}
+}
+
+func TestMozillaConfig_404ForUnknownDisabledOrExternal(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	for _, host := range []string{"autoconfig.unknown.com", "autoconfig.nomail.com", "autoconfig.ext.com"} {
+		w := acDo(r, http.MethodGet, "/mail/config-v1.1.xml", host, "")
+		if w.Code != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404", host, w.Code)
+		}
+	}
+}
+
+func TestAutodiscover_EchoesPostedEmail(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	body := `<?xml version="1.0"?>
+<Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/requestschema/2006">
+  <Request><EMailAddress>alice@example.com</EMailAddress>
+  <AcceptableResponseSchema>http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a</AcceptableResponseSchema></Request>
+</Autodiscover>`
+	w := acDo(r, http.MethodPost, "/autodiscover/autodiscover.xml", "autodiscover.example.com", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200\n%s", w.Code, w.Body.String())
+	}
+	b := w.Body.String()
+	for _, want := range []string{
+		"responseschema/2006a",
+		"<Type>IMAP</Type>", "<Server>mail.example.com</Server>", "<Port>993</Port>",
+		"<Type>SMTP</Type>", "<Port>465</Port>",
+		"<LoginName>alice@example.com</LoginName>",
+	} {
+		if !strings.Contains(b, want) {
+			t.Errorf("body missing %q\n---\n%s", want, b)
+		}
+	}
+}
+
+func TestAutodiscover_CapitalisedPathAndGET(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	// Outlook uses the capitalised path; GET with an emailaddress query.
+	w := acDo(r, http.MethodGet, "/Autodiscover/Autodiscover.xml?emailaddress=bob@example.com", "autodiscover.example.com", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "<Server>mail.example.com</Server>") {
+		t.Errorf("expected mail.example.com:\n%s", w.Body.String())
+	}
+}
+
+// A hostile local-part must be XML-escaped in LoginName, never break the doc.
+func TestAutodiscover_EscapesHostileLoginName(t *testing.T) {
+	r := newAutoconfigRouter(mailRepo())
+	body := `<Autodiscover><Request><EMailAddress>a"&lt;x&gt;@example.com</EMailAddress></Request></Autodiscover>`
+	w := acDo(r, http.MethodPost, "/autodiscover/autodiscover.xml", "autodiscover.example.com", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	b := w.Body.String()
+	if strings.Contains(b, "<x>") {
+		t.Errorf("unescaped angle brackets leaked into LoginName:\n%s", b)
+	}
+	if !strings.Contains(b, "example.com") {
+		t.Errorf("domain lost:\n%s", b)
+	}
+}
+
+func TestStripMailHostPrefix(t *testing.T) {
+	cases := map[string]string{
+		"autoconfig.example.com":   "example.com",
+		"autodiscover.example.com": "example.com",
+		"mail.example.com":         "example.com",
+		"mta-sts.example.com":      "example.com",
+		"example.com":              "example.com",
+		"AUTOCONFIG.Example.COM":   "example.com",
+	}
+	for in, want := range cases {
+		if got := stripMailHostPrefix(in); got != want {
+			t.Errorf("stripMailHostPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDomainFromEmail(t *testing.T) {
+	ok := map[string]string{
+		"bob@example.com":      "example.com",
+		"a.b+c@Sub.Example.io": "sub.example.io",
+	}
+	for in, want := range ok {
+		if got := domainFromEmail(in); got != want {
+			t.Errorf("domainFromEmail(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// The domain part is what matters; a garbage local part still yields a
+	// clean domain (that's the caller's lookup key, and LoginName is escaped).
+	for _, bad := range []string{"", "no-at", "@nope", "trailing@", "nodot@localhost", "bob@dom ain.com"} {
+		if got := domainFromEmail(bad); got != "" {
+			t.Errorf("domainFromEmail(%q) = %q, want empty", bad, got)
+		}
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -379,6 +379,17 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		})
 	}
 
+	// Mail-client autoconfiguration (GH #1039). Served from the mail vhost
+	// (autoconfig./autodiscover.<domain>) which proxies /mail/config-v1.1.xml
+	// and /autodiscover/autodiscover.xml here. Public, like the branding +
+	// webmail-SSO endpoints — a mail client has no session when it first probes.
+	if deps.Domains != nil {
+		api.RegisterMailAutoconfigRoutes(r, api.MailAutoconfigHandlerConfig{
+			Domains: deps.Domains,
+			Log:     deps.Log,
+		})
+	}
+
 	// Instantiate Kratos client + same-origin reverse proxy for /.ory/*.
 	// The SPA fetches relative Kratos self-service endpoints and panel-api
 	// binds :8443 directly (no nginx in front on that port), so we proxy


### PR DESCRIPTION
## The bug (GH #1039)

johnnyq reported mail-client auto-config is broken:
- `autoconfig.<domain>/mail/config-v1.1.xml` → **Bulwark webmail login**, not XML
- `autodiscover.<domain>/autodiscover/autodiscover.xml` → **404**

Root cause: jabali publishes the DNS side (autoconfig/autodiscover CNAMEs + RFC 6186 SRVs) and the cert SANs, but served **no config document**. The Thunderbird path fell through the mail vhost's `location /` to Bulwark; the Outlook path was explicitly `return 404` (a stopgap to stop probes leaking to Bulwark).

## Fix

A public panel-api handler renders both documents from the domain's real mail settings (`mail.<domain>`, IMAPS **993** / SMTPS **465** — matching the Stalwart listeners + the SRVs):
- **Mozilla clientConfig 1.1** — Thunderbird/Apple: `GET /mail/config-v1.1.xml` (+ `/.well-known/autoconfig/...`)
- **Outlook autodiscover 2006a** — `POST`+`GET`, lower- and capitalised paths, echoing the requested address into `<LoginName>`

Both mail-vhost templates proxy these paths to panel-api (replacing the 404 / webmail fall-through), mirroring the existing `/sso/webmail` proxy.

### The load-bearing detail
The vhost is rendered from the **agent's embedded copy** (`mailVhostTemplate` in `panel-agent/webmail_vhost.go`), not the committed `install/nginx/...` reference — so **both** are updated; the reference alone would be a no-op. `webmail.vhost_apply` is content-diff gated (`bytes.Equal`) and the reconciler re-applies every mail domain each pass, so **existing vhosts re-render with the new locations on the first tick after the agent binary updates** — no per-domain nudge.

## Security
- Domain always resolved from the **DB row**, never the request → a spoofed `Host` can't inject a hostname.
- `encoding/xml` escapes the echoed address (test: hostile `LoginName` can't break out).
- The `autoconfig.`/`autodiscover.`/`mail.<domain>` hosts are already on the CrowdSec-AppSec exempt list (`webmail_reconcile.go`), so the autodiscover XML POST isn't WAF-inspected — no appseccfg change.
- Served only for `EmailEnabled` + jabali-provider domains (matches where the mail vhost exists).

## Tests
`panel-api` + `panel-agent` + `agentwire`: 0 failures. New tests cover both documents, the capitalised/GET Outlook path, 404 for unknown/disabled/external domains, and XML-escaping.

Not yet box-verified on jabalitests (will confirm existing-domain re-render + curl both endpoints for content before any reply).

GH #1039