### PR TITLE
fix(mail): exempt Outlook autodiscover POST from the content-type guard (GH #1039)

### DIFF
--- a/panel-api/internal/middleware/content_type.go
+++ b/panel-api/internal/middleware/content_type.go
@@ -26,6 +26,15 @@ func RequireContentType() gin.HandlerFunc {
 			c.Next()
 			return
 		}
+		// Outlook autodiscover (GH #1039) POSTs a fixed text/xml request body to
+		// a well-known path whose Content-Type we don't control. It's a public
+		// discovery endpoint that parses + validates its own XML body and escapes
+		// its output, so exempt it from the JSON-or-upload guard rather than
+		// widen the accepted set for every endpoint.
+		if strings.EqualFold(c.Request.URL.Path, "/autodiscover/autodiscover.xml") {
+			c.Next()
+			return
+		}
 
 		ct := c.GetHeader("Content-Type")
 		if !strings.HasPrefix(ct, "application/json") &&

--- a/panel-api/internal/middleware/content_type_test.go
+++ b/panel-api/internal/middleware/content_type_test.go
@@ -41,3 +41,32 @@ func TestRequireContentType(t *testing.T) {
 		})
 	}
 }
+
+// The Outlook autodiscover POST (GH #1039) arrives as text/xml, which the guard
+// would otherwise 415. It must be exempt on its well-known path, case-insensitive.
+func TestRequireContentType_AutodiscoverExempt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequireContentType())
+	r.POST("/autodiscover/autodiscover.xml", func(c *gin.Context) { c.Status(http.StatusOK) })
+	r.POST("/Autodiscover/Autodiscover.xml", func(c *gin.Context) { c.Status(http.StatusOK) })
+	r.POST("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for _, path := range []string{"/autodiscover/autodiscover.xml", "/Autodiscover/Autodiscover.xml"} {
+		req := httptest.NewRequest("POST", path, strings.NewReader("<Autodiscover/>"))
+		req.Header.Set("Content-Type", "text/xml")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("%s text/xml: got %d, want 200 (exempt)", path, w.Code)
+		}
+	}
+	// Guard still bites text/xml on a non-exempt path.
+	req := httptest.NewRequest("POST", "/x", strings.NewReader("<x/>"))
+	req.Header.Set("Content-Type", "text/xml")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("non-exempt text/xml: got %d, want 415", w.Code)
+	}
+}


### PR DESCRIPTION
Follow-up to #1064. The autodiscover handler was live but **415'd in practice**: Outlook POSTs its autodiscover request as `text/xml`, and the global `RequireContentType` middleware only accepts `application/json` / `multipart/form-data` / `application/octet-stream`, so it aborted before the handler ran.

Box-verified on jabalitests (build 488042d1): `POST /autodiscover/autodiscover.xml` → `{"error":"unsupported_content_type"}` (HTTP 415). Thunderbird autoconfig (a GET) was unaffected and already works — verified returning valid `<clientConfig>` with `mail.<domain>` / 993 / 465.

Fix: exempt the well-known autodiscover path (case-insensitive) from the guard, rather than widen the accepted content types for every endpoint. The handler parses + validates its own XML body and escapes its output, so the guard adds nothing there.

Test: `text/xml` POST passes on `/autodiscover/autodiscover.xml` + the capitalised path; a `text/xml` POST on any other path still 415s.

Note (separate, pre-existing): on some domains the `autodiscover.<domain>` cert SAN has drifted out (JAB-226 SAN-drift; e.g. jabali.site has autoconfig but not autodiscover, while wisecp.jabali.site has both). Where it's missing, Outlook's `autodiscover.<domain>` URL TLS-fails — but the apex `<domain>/autodiscover/...` and the `_autodiscover._tcp` SRV → `mail.<domain>` paths (both reliably in the cert) serve the same document. Not addressed here.

GH #1039