### PR TITLE
fix(ssl): fronted domains must serve :443 — CF Full 520 outage (JAB-237)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -57,6 +57,15 @@ type domainCreateParams struct {
 	// trusted cert issues. Pointer so a pre-#896 panel that omits the field
 	// falls back to the historical "redirect whenever a cert is present".
 	RedirectHTTPS *bool `json:"redirect_https,omitempty"`
+	// ServeHTTPS (JAB-237) — whether the :443 server block renders at all,
+	// decoupled from RedirectHTTPS. A CDN-fronted domain must serve :443
+	// even on its self-signed bootstrap cert (Cloudflare Full connects to
+	// origin :443 and 520s on a closed port; the browser never sees the
+	// origin cert, so the GH #896 warning rationale does not apply) while
+	// NOT redirecting :80 (an origin 301 loops CF Flexible zones). Pointer:
+	// a panel that omits the field gets the historical coupled behaviour
+	// (serve exactly when redirecting).
+	ServeHTTPS *bool `json:"serve_https,omitempty"`
 	// CacheEnabled (ADR-0108) — per-domain nginx FastCGI micro-cache
 	// opt-in. false ⇒ vhost byte-identical to the pre-0108 shape.
 	CacheEnabled bool   `json:"cache_enabled"`
@@ -201,14 +210,16 @@ const vhostTemplate = `server {
     # Redirect HTTP to HTTPS once a TRUSTED cert is serving. Gated on
     # RedirectHTTPS (not merely "a cert exists") so a fresh LE-mode domain
     # still on its self-signed bootstrap placeholder serves the docroot over
-    # plain HTTP — the shared tail below attaches to THIS :80 server when the
-    # :443 block is absent — instead of 301'ing browsers into a cert-authority
-    # warning (GH #896/#887). The redirect + :443 appear on the tick a real
-    # cert lands. Scoped to the default location so the ^~ ACME location above
-    # wins for challenge paths — see the rationale comment there.
+    # plain HTTP instead of 301'ing browsers into a cert-authority warning
+    # (GH #896/#887). Decoupled from the :443 block itself (JAB-237): a
+    # CDN-fronted domain serves :443 WITHOUT this redirect — Cloudflare
+    # owns the client-side https redirect, and an origin 301 loops CF
+    # Flexible zones. Scoped to the default location so the ^~ ACME
+    # location above wins for challenge paths.
     location / {
         return 301 https://$host$request_uri;
     }
+{{ end }}{{ if .ServeHTTPS }}
 }
 
 server {
@@ -671,11 +682,14 @@ type vhostData struct {
 	IsEnabled          bool
 	SSLCertPath        string
 	SSLKeyPath         string
-	// RedirectHTTPS (GH #896) gates the HTTP→HTTPS redirect AND the :443
-	// server block. When false the shared tail (root/PHP/locations) attaches
-	// to the :80 server so the docroot is served over plain HTTP — the
-	// self-signed bootstrap window. Always false when SSLCertPath is empty.
+	// RedirectHTTPS (GH #896) gates ONLY the :80→:443 redirect since
+	// JAB-237. ServeHTTPS gates the :443 server block; when false the
+	// shared tail (root/PHP/locations) attaches to the :80 server so the
+	// docroot is served over plain HTTP — the self-signed bootstrap
+	// window. Both always false when SSLCertPath is empty, and a redirect
+	// without a :443 block is coerced off (301 to a dead port).
 	RedirectHTTPS        bool
+	ServeHTTPS           bool
 	PHPMemoryLimit       string
 	PHPUploadMaxFilesize string
 	PHPPostMaxSize       string
@@ -964,7 +978,7 @@ func buildCacheGate(paths []string, fallback string) string {
 	return "(" + strings.Join(valid, "|") + ")"
 }
 
-func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS bool) (string, error) {
+func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redirectDirectives, ruleDirectives, customDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, indexPriority string, isEnabled, hasPHP bool, sslCertPath, sslKeyPath, phpMemLimit, phpUploadMax, phpPostMax string, phpMaxInputVars, phpMaxExecTime, phpMaxInputTime int, listenIPv4, listenIPv6 string, cacheEnabled bool, cachePath string, cachePaths []string, cacheBypassPaths []string, cacheTTLSeconds int, cacheQueryAllowlist []string, fpmSocket string, previewHost, previewCertPath, previewKeyPath string, interceptErrors, pathInfo, redirectHTTPS, serveHTTPS bool) (string, error) {
 	cacheGate := buildCacheGate(cachePaths, cachePath)        // GH #601: multi-path gate body ("" = whole domain)
 	cacheExtraBypass := sanitizeBypassPaths(cacheBypassPaths) // GH #616: safe "|/path" suffix
 	cacheQAllowNames := sanitizeCacheQueryAllowlist(cacheQueryAllowlist)
@@ -999,6 +1013,12 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	// :80 ACME location + docroot then serve HTTP-only until the cert re-lands.
 	if sslCertPath == "" {
 		redirectHTTPS = false
+		serveHTTPS = false
+	}
+	// A :80→:443 redirect without a :443 block would 301 every visitor
+	// into a connection refused — never render that combination.
+	if !serveHTTPS {
+		redirectHTTPS = false
 	}
 	// Same missing-file fallback for the preview wildcard pair: the shared
 	// *.preview.<hostname> cert may not be issued yet when the first
@@ -1027,10 +1047,10 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 			upstreamAddr = listenIPv4
 		}
 		// Hairpin to https only when the main vhost actually serves a :443
-		// block — i.e. RedirectHTTPS (GH #896). During the self-signed
-		// bootstrap window the main vhost is HTTP-only, so the preview must
-		// proxy over http or it would hit a dead :443.
-		if redirectHTTPS {
+		// block — ServeHTTPS (GH #896 bootstrap window / JAB-237 split).
+		// During the HTTP-only window the preview must proxy over http or
+		// it would hit a dead :443.
+		if serveHTTPS {
 			previewUpstream = "https://" + upstreamAddr + ":443"
 		} else {
 			previewUpstream = "http://" + upstreamAddr + ":80"
@@ -1068,6 +1088,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 		SSLCertPath:                sslCertPath,
 		SSLKeyPath:                 sslKeyPath,
 		RedirectHTTPS:              redirectHTTPS,
+		ServeHTTPS:                 serveHTTPS,
 		PHPMemoryLimit:             phpMemLimit,
 		PHPUploadMaxFilesize:       phpUploadMax,
 		PHPPostMaxSize:             phpPostMax,
@@ -1173,6 +1194,23 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	}
 
 	return configPath, nil
+}
+
+// resolveHTTPSFlags maps the wire params to the two vhost gates (JAB-237).
+// redirect_https absent → historical default (redirect iff a cert path is
+// set). serve_https absent (pre-JAB-237 panel) → coupled to the redirect,
+// which is the exact historical behaviour. The redirect⇒serve coercion
+// lives in writeVhost next to the cert stat-guard.
+func resolveHTTPSFlags(p *domainCreateParams) (redirectHTTPS, serveHTTPS bool) {
+	redirectHTTPS = p.SSLCertPath != ""
+	if p.RedirectHTTPS != nil {
+		redirectHTTPS = *p.RedirectHTTPS
+	}
+	serveHTTPS = redirectHTTPS
+	if p.ServeHTTPS != nil {
+		serveHTTPS = *p.ServeHTTPS
+	}
+	return redirectHTTPS, serveHTTPS
 }
 
 func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -1320,11 +1358,8 @@ func domainCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// so a pre-#896 panel that omits redirect_https keeps working. A current
 	// panel always sends the field; writeVhost still forces it false if the
 	// cert file turns out to be missing on disk (#213).
-	redirectHTTPS := p.SSLCertPath != ""
-	if p.RedirectHTTPS != nil {
-		redirectHTTPS = *p.RedirectHTTPS
-	}
-	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS)
+	redirectHTTPS, serveHTTPS := resolveHTTPSFlags(&p)
+	configPath, err := writeVhost(ctx, p.Username, p.Domain, p.DocRoot, p.PHPVersion, p.RedirectDirectives, p.RuleDirectives, p.CustomDirectives, rateLimitDirectives, ipACLDirectives, dirPrivacyDirectives, p.IndexPriority, isEnabled, p.HasPHP, p.SSLCertPath, p.SSLKeyPath, p.PHPMemoryLimit, p.PHPUploadMaxFilesize, p.PHPPostMaxSize, p.PHPMaxInputVars, p.PHPMaxExecutionTime, p.PHPMaxInputTime, p.ListenIPv4, p.ListenIPv6, p.CacheEnabled, p.CachePath, p.CachePaths, p.CacheBypassPaths, p.CacheTTLSeconds, p.CacheQueryAllowlist, p.FPMSocket, p.PreviewHost, p.PreviewCertPath, p.PreviewKeyPath, p.InterceptErrors, p.PathInfo, redirectHTTPS, serveHTTPS)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/domain_create_gh896_test.go
+++ b/panel-agent/internal/commands/domain_create_gh896_test.go
@@ -23,6 +23,7 @@ func gh896VhostData(redirect bool) vhostData {
 		SSLCertPath:   "/etc/ssl/jabali-selfsigned/example.com/fullchain.pem",
 		SSLKeyPath:    "/etc/ssl/jabali-selfsigned/example.com/privkey.pem",
 		RedirectHTTPS: redirect,
+		ServeHTTPS:    redirect, // pre-JAB-237 coupling: these tests pin the DIRECT-domain shape
 	}
 	return vd
 }

--- a/panel-agent/internal/commands/domain_create_jab237_test.go
+++ b/panel-agent/internal/commands/domain_create_jab237_test.go
@@ -1,0 +1,74 @@
+package commands
+
+// JAB-237 — serve_https decoupled from redirect_https. The production
+// incident: a CDN-fronted domain parked on its self-signed bootstrap cert
+// rendered :80-only, and Cloudflare Full (which dials origin :443) returned
+// 520 for every zone. The fix serves :443 without the :80→:443 redirect —
+// the redirect would loop CF Flexible zones, whose edge fetches over :80.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func renderJAB237(t *testing.T, vd vhostData) string {
+	t.Helper()
+	tmpl := template.Must(template.New("vhost").Parse(vhostTemplate))
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, vd); err != nil {
+		t.Fatal(err)
+	}
+	return b.String()
+}
+
+// The fronted shape: :443 block WITHOUT the :80 redirect.
+func TestVhostJAB237_ServeWithoutRedirect(t *testing.T) {
+	vd := gh896VhostData(false)
+	vd.ServeHTTPS = true
+	out := renderJAB237(t, vd)
+
+	if !strings.Contains(out, "listen 443 ssl") {
+		t.Error("fronted domain must render the :443 block even on a self-signed cert — CF Full dials origin :443 and 520s on a closed port")
+	}
+	if strings.Contains(out, "return 301 https://") {
+		t.Error("fronted domain must NOT origin-redirect :80 — that loops CF Flexible zones")
+	}
+	if !strings.Contains(out, "location ^~ /.well-known/acme-challenge/") {
+		t.Error("ACME location must survive on :80")
+	}
+}
+
+// Wire-compat: a pre-JAB-237 panel that omits serve_https gets the exact
+// historical coupling (serve iff redirect).
+func TestVhostJAB237_AbsentServeFallsBackToCoupling(t *testing.T) {
+	for _, redirect := range []bool{true, false} {
+		var p domainCreateParams
+		raw := `{"domain":"example.com","ssl_cert_path":"/x/fullchain.pem"`
+		if !redirect {
+			raw += `,"redirect_https":false`
+		}
+		raw += `}`
+		if err := json.Unmarshal([]byte(raw), &p); err != nil {
+			t.Fatal(err)
+		}
+		gotRedirect, gotServe := resolveHTTPSFlags(&p)
+		if gotRedirect != redirect || gotServe != redirect {
+			t.Errorf("redirect=%v: resolved (redirect=%v, serve=%v), want coupled", redirect, gotRedirect, gotServe)
+		}
+	}
+}
+
+func TestVhostJAB237_ExplicitFlagsResolve(t *testing.T) {
+	var p domainCreateParams
+	raw := `{"domain":"example.com","ssl_cert_path":"/x/fullchain.pem","redirect_https":false,"serve_https":true}`
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		t.Fatal(err)
+	}
+	gotRedirect, gotServe := resolveHTTPSFlags(&p)
+	if gotRedirect || !gotServe {
+		t.Errorf("resolved (redirect=%v, serve=%v), want (false, true) — the fronted shape", gotRedirect, gotServe)
+	}
+}

--- a/panel-agent/internal/commands/domain_create_root_override_test.go
+++ b/panel-agent/internal/commands/domain_create_root_override_test.go
@@ -192,7 +192,8 @@ func TestVhost_RuleBuilderRootProxyDoesNotDuplicateLocation(t *testing.T) {
 		IsEnabled:      true,
 		SSLCertPath:    "/etc/ssl/x.crt",
 		SSLKeyPath:     "/etc/ssl/x.key",
-		RedirectHTTPS:  true, // GH #896: :443 + :80-redirect block gated on this
+		RedirectHTTPS:  true, // GH #896 redirect; JAB-237 splits the :443 gate
+		ServeHTTPS:     true,
 		ListenIPv4:     "1.2.3.4",
 		RuleDirectives: ruleBlock,
 		RootOverridden: directivesOverrideRoot("", ruleBlock),

--- a/panel-agent/internal/commands/vhost_listen_ip_test.go
+++ b/panel-agent/internal/commands/vhost_listen_ip_test.go
@@ -34,6 +34,7 @@ func renderVhost(t *testing.T, v4, v6 string, ssl bool) string {
 		// (a trusted cert), not merely on SSLCertPath. ssl=true here models a
 		// domain serving HTTPS, so set it.
 		vd.RedirectHTTPS = true
+		vd.ServeHTTPS = true
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, vd); err != nil {

--- a/panel-api/internal/reconciler/dns01_routing.go
+++ b/panel-api/internal/reconciler/dns01_routing.go
@@ -177,7 +177,80 @@ type dns01State struct {
 	dns01SSOKey     *ssokey.Key
 	dns01RouteMu    sync.Mutex
 	dns01RouteCache map[string]dns01CachedRoute
+	// JAB-237 fronted-apex cache for the vhost path — see apexFronted.
+	frontedMu    sync.Mutex
+	frontedCache map[string]frontedEntry
 	// test seams — nil in production
 	dns01LookupNS   func(ctx context.Context, name string) ([]string, bool)
 	dns01ZoneFinder dns01.ZoneFinder
+}
+
+// frontedCacheTTL bounds how long an apex-fronted decision is reused by the
+// vhost renderer before re-asking public DNS.
+const frontedCacheTTL = 15 * time.Minute
+
+type frontedEntry struct {
+	fronted bool
+	expires time.Time
+}
+
+// apexFronted reports whether name's apex publicly resolves somewhere that
+// is not this box — the vhost renderer's view of frontedByCDN (JAB-237).
+//
+// Cache rule, load-bearing: a DEFINITIVE lookup (public DNS answered)
+// updates the cache; an INCONCLUSIVE one (every resolver unreachable) keeps
+// the last known value and extends its TTL. Without that, a resolver blip
+// would flip fronted domains to "not fronted", re-render their vhosts
+// :80-only, and 520 every Cloudflare-Full zone until the resolvers return —
+// the exact outage this fix exists for. A cold cache + inconclusive answer
+// falls back to "not fronted" (the pre-JAB-237 rendering); accepted
+// residual, called out in the PR.
+func (r *Reconciler) apexFronted(ctx context.Context, name string) bool {
+	now := time.Now()
+	r.frontedMu.Lock()
+	entry, cached := r.frontedCache[name]
+	r.frontedMu.Unlock()
+	if cached && now.Before(entry.expires) {
+		return entry.fronted
+	}
+
+	var ourAddrs []string
+	if r.serverSettings != nil {
+		srvCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if srv, err := r.serverSettings.Get(srvCtx); err == nil && srv != nil {
+			if srv.PublicIPv4 != "" {
+				ourAddrs = append(ourAddrs, srv.PublicIPv4)
+			}
+			if srv.PublicIPv6 != "" {
+				ourAddrs = append(ourAddrs, srv.PublicIPv6)
+			}
+		}
+		cancel()
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, 6*time.Second)
+	addrs, queried := r.dnsPreflight(lookupCtx, name)
+	cancel()
+
+	if !queried || len(ourAddrs) == 0 {
+		// Inconclusive (or we don't know our own IP): keep the last known
+		// value alive rather than flapping; cold cache reads not-fronted.
+		if cached {
+			r.frontedMu.Lock()
+			entry.expires = now.Add(frontedCacheTTL)
+			r.frontedCache[name] = entry
+			r.frontedMu.Unlock()
+			return entry.fronted
+		}
+		return false
+	}
+
+	fronted := frontedByCDN(addrs, ourAddrs)
+	r.frontedMu.Lock()
+	if r.frontedCache == nil {
+		r.frontedCache = map[string]frontedEntry{}
+	}
+	r.frontedCache[name] = frontedEntry{fronted: fronted, expires: now.Add(frontedCacheTTL)}
+	r.frontedMu.Unlock()
+	return fronted
 }

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -1895,6 +1895,7 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 	// explicitly (false in the no-cert branch too) so a current panel never
 	// sends nil.
 	redirectHTTPS := false
+	certIssueMethod := ""
 	if domain.SSLMode == models.SSLModeShared && domain.SharedCertificateID != nil && *domain.SharedCertificateID != "" {
 		certPath, keyPath := sharedCertPaths(*domain.SharedCertificateID)
 		params["ssl_cert_path"], params["ssl_key_path"] = certPath, keyPath
@@ -1908,9 +1909,26 @@ func (r *Reconciler) createDomainOnAgent(ctx context.Context, domain *models.Dom
 			params["ssl_cert_path"] = *cert.CertPath
 			params["ssl_key_path"] = *cert.KeyPath
 			redirectHTTPS = redirectHTTPSForCert(domain.SSLMode, *cert.CertPath)
+			certIssueMethod = cert.IssueMethod
 		}
 	}
+	// JAB-237: a CDN-fronted domain must SERVE :443 even on its self-signed
+	// bootstrap cert — Cloudflare Full dials origin :443 and 520s on a
+	// closed port, and the browser never sees the origin cert behind the
+	// edge, so the GH #896 warning rationale does not apply. It must also
+	// NOT origin-redirect :80→:443: CF Flexible fetches over :80, and an
+	// origin 301 loops it (latent for every fronted domain the moment a
+	// real cert lands). Directly-served domains keep the coupled #896
+	// behaviour. A dns-01-issued cert is fronted by construction — that
+	// path only runs for fronted domains — and needs no DNS lookup.
+	_, certSet := params["ssl_cert_path"]
+	serveHTTPS := redirectHTTPS
+	if certSet && (certIssueMethod == issueMethodDNS01 || r.apexFronted(ctx, domain.Name)) {
+		serveHTTPS = true
+		redirectHTTPS = false
+	}
 	params["redirect_https"] = redirectHTTPS
+	params["serve_https"] = serveHTTPS
 
 	// Preview URL params (temp URLs) — nil when disabled or no hostname.
 	for k, v := range r.previewParams(ctx, domain) {

--- a/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
+++ b/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
@@ -1,0 +1,166 @@
+package reconciler
+
+// JAB-237 — the vhost gates for CDN-fronted domains. The 2026-08-11 fleet
+// outage: an le-mode domain parked on its self-signed bootstrap cert
+// rendered :80-only, and Cloudflare Full (which dials origin :443) 520'd
+// every zone. Pinned here:
+//
+//  1. Fronted + self-signed → serve_https TRUE, redirect_https FALSE
+//     (the 520 fix: :443 exists; no origin 301, which loops CF Flexible).
+//  2. Fronted + issued → same shape (the latent Flexible-loop guard).
+//  3. Direct + self-signed bootstrap → both FALSE (GH #896 preserved).
+//  4. Direct + issued → both TRUE (unchanged).
+//  5. Inconclusive apex lookup keeps the last cached fronted value —
+//     a resolver blip must not re-render fronted vhosts :80-only.
+//  6. A dns-01-issued cert implies fronted without any lookup.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+const (
+	frontedTestOwnIP    = "203.0.113.7"
+	selfSignedCertPath  = "/etc/ssl/jabali-selfsigned/f.example/fullchain.pem"
+	selfSignedKeyPath   = "/etc/ssl/jabali-selfsigned/f.example/privkey.pem"
+	letsEncryptCertPath = "/etc/letsencrypt/live/f.example/fullchain.pem"
+	letsEncryptKeyPath  = "/etc/letsencrypt/live/f.example/privkey.pem"
+)
+
+func frontedVhostFixture(t *testing.T, certPath, keyPath string, apexAddrs []string, queried bool) (*Reconciler, *fakeAgent, *models.Domain, *fakeSSLCertRepo) {
+	t.Helper()
+	uname := "u1"
+	dr := newFakeDomainRepo()
+	ur := &fakeUserRepo{users: map[string]*models.User{
+		"u1": {ID: "u1", Email: "u1@example.com", Username: &uname},
+	}}
+	sc := newFakeSSLCertRepo()
+	srv := &fakeServerSettingsRepo{settings: &models.ServerSettings{PublicIPv4: frontedTestOwnIP}}
+	ag := &fakeAgent{}
+
+	dom := &models.Domain{
+		ID: "d1", Name: "f.example", UserID: "u1",
+		DocRoot: "/home/u1/domains/f.example/public_html",
+		SSLMode: models.SSLModeLE, IsEnabled: true,
+	}
+	dr.domains[dom.ID] = dom
+	sc.byDomain[dom.ID] = &models.SSLCertificate{
+		ID: "c1", DomainID: dom.ID, Status: models.SSLStatusSelfSigned,
+		CertPath: &certPath, KeyPath: &keyPath,
+	}
+
+	r := New(dr, ur, ag, slog.Default(), Config{}).
+		WithSSLCerts(sc).
+		WithDNSRepos(nil, nil, srv)
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) {
+		return apexAddrs, queried
+	}
+	return r, ag, dom, sc
+}
+
+func vhostHTTPSParams(t *testing.T, ag *fakeAgent) (redirect, serve bool) {
+	t.Helper()
+	call, ok := findAgentCall(ag, "domain.create")
+	if !ok {
+		t.Fatal("domain.create was not dispatched")
+	}
+	params := call.params.(map[string]any)
+	redirect, rOK := params["redirect_https"].(bool)
+	serve, sOK := params["serve_https"].(bool)
+	if !rOK || !sOK {
+		t.Fatalf("redirect_https/serve_https missing or untyped in params: %v / %v", params["redirect_https"], params["serve_https"])
+	}
+	return redirect, serve
+}
+
+func TestFrontedVhost_SelfSignedServes443NoRedirect(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
+
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if !serve {
+		t.Error("fronted + self-signed must SERVE :443 — CF Full dials origin :443 and 520s on a closed port (the 2026-08-11 outage)")
+	}
+	if redirect {
+		t.Error("fronted domain must not origin-redirect :80 — CF Flexible fetches over :80 and a 301 loops it")
+	}
+}
+
+func TestFrontedVhost_IssuedServes443NoRedirect(t *testing.T) {
+	r, ag, dom, sc := frontedVhostFixture(t, letsEncryptCertPath, letsEncryptKeyPath, cfEdgeAddrs, true)
+	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
+
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if !serve || redirect {
+		t.Errorf("fronted + issued: (redirect=%v, serve=%v), want (false, true) — the origin redirect loops CF Flexible the moment a real cert lands", redirect, serve)
+	}
+}
+
+func TestDirectVhost_SelfSignedBootstrapStaysHTTPOnly(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, []string{frontedTestOwnIP}, true)
+
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if redirect || serve {
+		t.Errorf("direct + self-signed bootstrap: (redirect=%v, serve=%v), want (false, false) — GH #896's no-cert-warning window must survive JAB-237", redirect, serve)
+	}
+}
+
+func TestDirectVhost_IssuedRedirectsAndServes(t *testing.T) {
+	r, ag, dom, sc := frontedVhostFixture(t, letsEncryptCertPath, letsEncryptKeyPath, []string{frontedTestOwnIP}, true)
+	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
+
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if !redirect || !serve {
+		t.Errorf("direct + issued: (redirect=%v, serve=%v), want (true, true)", redirect, serve)
+	}
+}
+
+func TestFrontedVhost_InconclusiveLookupKeepsCachedValue(t *testing.T) {
+	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
+
+	// First render: definitive fronted answer, cached.
+	r.createDomainOnAgent(context.Background(), dom)
+	// Expire the entry, then blind the resolvers.
+	r.frontedMu.Lock()
+	e := r.frontedCache[dom.Name]
+	e.expires = time.Now().Add(-time.Minute)
+	r.frontedCache[dom.Name] = e
+	r.frontedMu.Unlock()
+	r.dnsPreflight = func(context.Context, string) ([]string, bool) { return nil, false }
+
+	ag.mu.Lock()
+	ag.calls = nil
+	ag.mu.Unlock()
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if !serve || redirect {
+		t.Errorf("resolver blip: (redirect=%v, serve=%v), want the cached fronted shape kept — flapping to :80-only re-creates the 520 outage", redirect, serve)
+	}
+}
+
+func TestFrontedVhost_DNS01IssueMethodImpliesFronted(t *testing.T) {
+	// Apex lookup says "direct" (stale DNS view), but the cert was issued
+	// via DNS-01 — which only happens for fronted domains.
+	r, ag, dom, sc := frontedVhostFixture(t, letsEncryptCertPath, letsEncryptKeyPath, []string{frontedTestOwnIP}, true)
+	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
+	sc.byDomain[dom.ID].IssueMethod = issueMethodDNS01
+
+	r.createDomainOnAgent(context.Background(), dom)
+
+	redirect, serve := vhostHTTPSParams(t, ag)
+	if !serve || redirect {
+		t.Errorf("dns-01 lineage: (redirect=%v, serve=%v), want (false, true) without trusting the apex lookup", redirect, serve)
+	}
+}


### PR DESCRIPTION
## Summary
JAB-237 (P0): the 2026-08-11 fleet outage. An le-mode domain parked on its self-signed bootstrap cert renders **:80-only** (the GH #896 carve-out), and Cloudflare **Full** — which dials origin :443 — returns **520** for every such zone. JAB-235's no-provider park path put every CF-fronted domain into exactly that state, and a stable promotion shipped it fleet-wide.

### The fix: two gates instead of one
The agent coupled ":443 exists" and ":80 redirects" on one flag. They're now separate:
- **`serve_https`** (new): whether the :443 server block renders.
- **`redirect_https`**: only the :80→:443 redirect.
- Compat: a panel that omits `serve_https` gets the exact historical coupling (pointer default); a redirect without a :443 block is coerced off (301 into a closed port); the cert stat-guard zeroes both; the preview hairpin scheme follows the :443 block. Byte-identical renders for both legacy shapes — the golden pins it.

**Fronted domains** (apex publicly resolves away from this box): any cert on disk → **serve :443, never origin-redirect**. Two bugs die at once:
1. The 520 (ticket): CF Full needs *something* on origin :443; the #896 warning rationale doesn't apply behind a CDN — the browser only ever sees the edge cert.
2. The **latent CF-Flexible redirect loop**: Flexible fetches over :80; an origin 301 loops it. Today that's masked because Flexible zones are all parked self-signed (redirect off) — the moment JAB-235's DNS-01 lands real certs on them, `redirect_https=true` would have looped them. This PR preempts that next P0.

**Direct domains: unchanged.** #896's bootstrap window (both gates off until a trusted cert) stays pinned by the existing tests.

### The fronted cache (load-bearing rule)
15-min TTL, asymmetric: **definitive** lookups update the cache; **inconclusive** ones (all external resolvers unreachable) keep the last value and extend it. Without that, a resolver blip flips fronted vhosts back to :80-only and recreates the 520 fleet-wide until resolvers return. Residual: cold cache + resolver outage reads not-fronted (pre-JAB-237 rendering) — accepted; a `dns-01`-issued cert short-circuits to fronted with no lookup at all (that path only runs for fronted domains).

### Behavior deltas to know at rollout
- **Fronted + issued domains stop origin-redirecting http→https.** CF's "Always Use HTTPS" is the canonical replacement; the origin can't do it safely because Full/Flexible is invisible from the origin.
- **CF Full-*strict* zones still 526 on a self-signed origin** — expected; the exit is the JAB-235 CF token issuing real certs, not this fix.
- Docker-app vhosts unaffected (their template always renders :443).

### Rollout (operator-owned; nothing fleet-side touched by this PR)
The interim workarounds stay as-is: ~55 domains on `ssl_mode=self`, `stable` reverted to `eeab9ad8`, fleet auto-update frozen. Sequence after merge: update **one** box (or testserver) → verify a CF-Full domain returns 200 **via the public IP/URL — never `--resolve host:443:127.0.0.1`** (vhosts listen on the public IP; loopback hits the default server and reads 000) → flip workaround rows back to `le` → unfreeze auto-update → re-promote `stable`. Fix is live only when **both** panel-api and agent are rebuilt — verify by artifact.

## Test plan
- [x] Agent: fronted shape renders :443 without the 301; absent `serve_https` = exact legacy coupling (wire-level unmarshal test); explicit (redirect=false, serve=true) resolves; qallow golden byte-identical; #896 + listen-IP suites updated and green
- [x] Reconciler: fronted+self-signed → (serve=T, redirect=F) — the 520 fix; fronted+issued → same — the loop guard; direct+self-signed → (F,F) #896 pinned; direct+issued → (T,T); resolver-blip keeps cached fronted; dns-01 lineage implies fronted
- [x] Full panel-api + panel-agent suites: **0 FAIL**; gofmt/vet clean; post-rebase re-run green
- [ ] CI
- [ ] Box verification per rollout sequence above (public-IP curl, per the ticket's own warning)

JAB-235 context, PR #1054/#1046/#1049. Governance/canary follow-up is explicitly out of scope. JAB-237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
