### PR TITLE
fix(backup): run restores as tracked background jobs (GH #1044)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -83,10 +83,17 @@ type BackupHandlerConfig struct {
 
 const backupCallTimeout = 10 * time.Second
 
-// restoreCallTimeout: account restores run synchronously on the agent
-// (no goroutine fork). 10m covers reasonable home-dir + DB + mailbox
-// volumes; larger restores should switch to a background-job model.
-const restoreCallTimeout = 10 * time.Minute
+// restoreJobTimeout bounds a BACKGROUND restore job (GH #1044). Restores
+// used to run synchronously inside the HTTP request, which stacked three
+// unrelated ceilings on top of the real work: the UI client's 15 s axios
+// timeout, nginx's 300 s proxy_read_timeout, and this constant — so a
+// 500 MB Postgres restore died on whichever tripped first while the agent
+// kept restoring anyway. The restore is now a tracked job (the row the
+// jobs list already shows) and this is the only bound left: generous
+// because a large pg_restore plus mailbox imports legitimately runs long,
+// finite because an agent hang must still seal the row. The finalizer
+// seals rows this goroutine never finishes (panel restart mid-restore).
+const restoreJobTimeout = 60 * time.Minute
 
 // RegisterBackupRoutes mounts the admin-scoped backup endpoints under
 // /admin/users/:id/backups + /admin/backups/:job_id. The user-shell
@@ -999,13 +1006,18 @@ func (h *backupHandler) restore(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "db_create"})
 		return
 	}
-	// backup.restore is synchronous on the agent (no goroutine fork like
-	// backup.create). Use a long timeout so real-world account restores
-	// (db dumps + mailbox imports) don't hard-fail at 10s, but cap at a
-	// ceiling that matches operator UX expectations for the "Restore"
-	// button — anything longer should run as a tracked background job.
-	ctx, cancel := context.WithTimeout(c.Request.Context(), restoreCallTimeout)
-	defer cancel()
+	// GH #1044: the restore runs as a BACKGROUND job. It used to run
+	// synchronously inside this request, which chained three unrelated
+	// ceilings onto the real work (UI 15 s axios timeout, nginx 300 s
+	// proxy_read_timeout, the old 10 m server cap) — a large Postgres
+	// restore blew whichever tripped first, the client reported
+	// "timeout", and the agent kept restoring regardless. The job row
+	// the jobs list already shows IS the tracking surface; the HTTP
+	// response only confirms the job was queued.
+	//
+	// Every context inside the goroutine is fresh — the request context
+	// dies when this handler returns, and a status write on a dead
+	// context is a silent no-op (the createCloneAndKickAgent lesson).
 	_ = h.cfg.Jobs.MarkStarted(c.Request.Context(), job.ID)
 	params := map[string]any{
 		"job_id":               job.ID,
@@ -1017,6 +1029,22 @@ func (h *backupHandler) restore(c *gin.Context) {
 	for k, v := range destWireParams(dest) {
 		params[k] = v
 	}
+	go h.runAccountRestoreJob(job.ID, dest, params)
+	c.JSON(http.StatusAccepted, gin.H{"status": "queued", "job_id": job.ID})
+}
+
+// runAccountRestoreJob executes one admin account restore to completion and
+// seals the job row. Runs detached from any HTTP request (GH #1044); the
+// finalizer seals the row if this goroutine dies with it (panel restart).
+func (h *backupHandler) runAccountRestoreJob(jobID string, dest *models.BackupDestination, params map[string]any) {
+	ctx, cancel := context.WithTimeout(context.Background(), restoreJobTimeout)
+	defer cancel()
+	seal := func(status, errText string, raw json.RawMessage) {
+		sctx, scancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer scancel()
+		_ = h.cfg.Jobs.MarkFinished(sctx, jobID, status, "", "", 0, 0, raw, nil, errText)
+	}
+
 	var raw json.RawMessage
 	err := backupwrapperhelpers.WithDestPasswordFile(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
 		func(passwordFile string) error {
@@ -1028,9 +1056,8 @@ func (h *backupHandler) restore(c *gin.Context) {
 			return callErr
 		})
 	if err != nil {
-		_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), job.ID, models.BackupJobStatusFailed,
-			"", "", 0, 0, nil, nil, err.Error())
-		respondAgentErrStatus(c, "agent_call_failed", err)
+		h.cfg.logErr("account restore job failed", err, "job_id", jobID)
+		seal(models.BackupJobStatusFailed, err.Error(), nil)
 		return
 	}
 	// Parse the agent's restore result so the job row reflects what
@@ -1062,9 +1089,7 @@ func (h *backupHandler) restore(c *gin.Context) {
 			finalStatus = models.BackupJobStatusFailed
 		}
 	}
-	_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), job.ID, finalStatus,
-		"", "", 0, 0, raw, nil, finalErr)
-	c.JSON(http.StatusCreated, gin.H{"status": "ok", "job_id": job.ID})
+	seal(finalStatus, finalErr, raw)
 }
 
 // --- helpers + sentinel below ---
@@ -2521,41 +2546,66 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 	}
 	_ = h.cfg.Jobs.MarkStarted(c.Request.Context(), restoreJob.ID)
 
-	ctx, cancel := context.WithTimeout(c.Request.Context(), restoreCallTimeout)
-	defer cancel()
+	// GH #1044: run the restore as a BACKGROUND job — see the admin
+	// handler for the full reasoning (three stacked HTTP-lifetime
+	// ceilings killed any restore that outlived the shortest one, while
+	// the agent finished the work anyway). The result the drawer used to
+	// read from this response is persisted onto the job row
+	// (warnings_json) instead, and the drawer polls the job.
+	go h.runSelectiveRestoreJob(restoreJob.ID, job.SnapshotID, *owner.Username, req, ownedDomains)
+	c.JSON(http.StatusAccepted, gin.H{"status": "queued", "job_id": restoreJob.ID})
+}
 
-	applied := []string{}
-	skipped := []string{}
-	warnings := []string{}
+// selectiveRestoreOutcome is what the tenant restore drawer renders. It is
+// stored verbatim in backup_jobs.warnings_json when the job seals so the
+// result survives the (now-async) HTTP exchange (GH #1044).
+type selectiveRestoreOutcome struct {
+	Applied  []string `json:"applied"`
+	Skipped  []string `json:"skipped"`
+	Warnings []string `json:"warnings"`
+}
+
+// runSelectiveRestoreJob executes one tenant selective restore to
+// completion and seals the job row with the outcome. Detached from the
+// request; every context is fresh (a status write on the dead request
+// context would be a silent no-op).
+func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username string, req meRestoreSelectiveRequest, ownedDomains map[string]string) {
+	ctx, cancel := context.WithTimeout(context.Background(), restoreJobTimeout)
+	defer cancel()
+	seal := func(status, errText string, out selectiveRestoreOutcome) {
+		sctx, scancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer scancel()
+		outJSON, _ := json.Marshal(out)
+		_ = h.cfg.Jobs.MarkFinished(sctx, jobID, status, "", "", 0, 0, nil, outJSON, errText)
+	}
+
+	out := selectiveRestoreOutcome{Applied: []string{}, Skipped: []string{}, Warnings: []string{}}
 
 	// Databases + home go to the agent (host-side). Only dispatch when one is
 	// requested — the agent rejects an empty db+home set.
 	if len(req.Databases) > 0 || req.Home || len(req.Mailboxes) > 0 {
 		raw, aerr := h.cfg.Agent.Call(ctx, "backup.restore_selective", map[string]any{
-			"job_id":               restoreJob.ID,
-			"manifest_snapshot_id": job.SnapshotID,
-			"target_username":      *owner.Username,
+			"job_id":               jobID,
+			"manifest_snapshot_id": manifestSnap,
+			"target_username":      username,
 			"databases":            req.Databases,
 			"mailboxes":            req.Mailboxes,
 			"home":                 req.Home,
 			"overwrite":            req.Overwrite,
 		})
 		if aerr != nil {
-			_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), restoreJob.ID, models.BackupJobStatusFailed,
-				"", "", 0, 0, nil, nil, aerr.Error())
-			// Agent errors carry restic/host internals — log, don't echo (JAB-114).
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "error": "restore_failed"})
+			// Agent errors carry restic/host internals — log, don't echo
+			// (JAB-114). The drawer sees the generic failure via the row.
+			h.cfg.logErr("selective restore job failed", aerr, "job_id", jobID)
+			out.Warnings = append(out.Warnings, "restore failed — the panel log has the detail")
+			seal(models.BackupJobStatusFailed, "restore_failed", out)
 			return
 		}
-		var ar struct {
-			Applied  []string `json:"applied"`
-			Skipped  []string `json:"skipped"`
-			Warnings []string `json:"warnings"`
-		}
+		var ar selectiveRestoreOutcome
 		_ = json.Unmarshal(raw, &ar)
-		applied = append(applied, ar.Applied...)
-		skipped = append(skipped, ar.Skipped...)
-		warnings = append(warnings, ar.Warnings...)
+		out.Applied = append(out.Applied, ar.Applied...)
+		out.Skipped = append(out.Skipped, ar.Skipped...)
+		out.Warnings = append(out.Warnings, ar.Warnings...)
 	}
 
 	// DNS records are panel-side DB rows — restore them here (owner-scoped),
@@ -2563,19 +2613,17 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 	if len(req.DNSDomains) > 0 {
 		if !req.Overwrite {
 			for _, n := range req.DNSDomains {
-				skipped = append(skipped, "dns:"+n)
+				out.Skipped = append(out.Skipped, "dns:"+n)
 			}
-			warnings = append(warnings, "overwrite=false: DNS not applied. Restoring DNS replaces this domain's custom records; re-send with overwrite=true.")
+			out.Warnings = append(out.Warnings, "overwrite=false: DNS not applied. Restoring DNS replaces this domain's custom records; re-send with overwrite=true.")
 		} else {
-			da, dw := h.restoreDNSRecords(ctx, job.SnapshotID, req.DNSDomains, ownedDomains)
-			applied = append(applied, da...)
-			warnings = append(warnings, dw...)
+			da, dw := h.restoreDNSRecords(ctx, manifestSnap, req.DNSDomains, ownedDomains)
+			out.Applied = append(out.Applied, da...)
+			out.Warnings = append(out.Warnings, dw...)
 		}
 	}
 
-	_ = h.cfg.Jobs.MarkFinished(c.Request.Context(), restoreJob.ID, models.BackupJobStatusSucceeded,
-		"", "", 0, 0, nil, nil, "")
-	c.JSON(http.StatusOK, gin.H{"job_id": restoreJob.ID, "applied": applied, "skipped": skipped, "warnings": warnings})
+	seal(models.BackupJobStatusSucceeded, "", out)
 }
 
 // restoreDNSRecords reads the captured user DNS records from the backup metadata

--- a/panel-api/internal/api/backups_restore_async_test.go
+++ b/panel-api/internal/api/backups_restore_async_test.go
@@ -1,0 +1,139 @@
+package api
+
+// GH #1044: restores moved out of the HTTP request into background job
+// runners. The runners own the row-sealing now, so their semantics are the
+// contract: an agent failure seals `failed`, a partial stage set seals
+// `partial`, success persists the outcome the drawer renders — and every
+// seal happens on a FRESH context, because the request context these used
+// to borrow is long dead by the time a big restore finishes.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type sealCapture struct {
+	repository.BackupJobRepository
+	mu       sync.Mutex
+	status   string
+	errText  string
+	manifest json.RawMessage
+	warnings json.RawMessage
+	sealed   chan struct{}
+}
+
+func newSealCapture() *sealCapture { return &sealCapture{sealed: make(chan struct{})} }
+
+func (r *sealCapture) MarkFinished(_ context.Context, _, status string, _, _ string,
+	_, _ uint64, manifest, warnings json.RawMessage, errText string) error {
+	r.mu.Lock()
+	r.status, r.errText, r.manifest, r.warnings = status, errText, manifest, warnings
+	r.mu.Unlock()
+	close(r.sealed)
+	return nil
+}
+
+func (r *sealCapture) wait(t *testing.T) {
+	t.Helper()
+	select {
+	case <-r.sealed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("job was never sealed — a restore that finishes without MarkFinished leaves the row `running` forever")
+	}
+}
+
+type restoreAgent struct {
+	reply json.RawMessage
+	err   error
+}
+
+func (a restoreAgent) Call(context.Context, string, any) (json.RawMessage, error) {
+	return a.reply, a.err
+}
+
+func TestRunAccountRestoreJob_AgentFailureSealsFailed(t *testing.T) {
+	jobs := newSealCapture()
+	h := &backupHandler{cfg: BackupHandlerConfig{
+		Jobs:  jobs,
+		Agent: restoreAgent{err: errors.New("restic: repo locked")},
+	}}
+	h.runAccountRestoreJob("job-1", &models.BackupDestination{ID: "d1", Kind: "local"}, map[string]any{})
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusFailed {
+		t.Errorf("status = %q, want failed", jobs.status)
+	}
+	if !strings.Contains(jobs.errText, "repo locked") {
+		t.Errorf("the AGENT failure should be the recorded reason, got %q", jobs.errText)
+	}
+}
+
+func TestRunAccountRestoreJob_PartialStagesSealPartial(t *testing.T) {
+	jobs := newSealCapture()
+	h := &backupHandler{cfg: BackupHandlerConfig{
+		Jobs: jobs,
+		Agent: restoreAgent{reply: json.RawMessage(
+			`{"job_id":"job-1","stages":[{"name":"home","status":"ok"},{"name":"db","status":"failed","error":"pg_restore: boom"}]}`)},
+	}}
+	h.runAccountRestoreJob("job-1", &models.BackupDestination{ID: "d1", Kind: "local"}, map[string]any{})
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusPartial {
+		t.Errorf("status = %q, want partial — one failed stage out of two", jobs.status)
+	}
+	if jobs.errText == "" || !strings.Contains(jobs.errText, "pg_restore") {
+		t.Errorf("the failed stage's error should surface on the row, got %q", jobs.errText)
+	}
+}
+
+func TestRunSelectiveRestoreJob_PersistsOutcomeForTheDrawer(t *testing.T) {
+	jobs := newSealCapture()
+	h := &meBackupHandler{cfg: MeBackupsHandlerConfig{
+		Jobs: jobs,
+		Agent: restoreAgent{reply: json.RawMessage(
+			`{"applied":["db → alice_pg (postgres)"],"skipped":[],"warnings":["mail: 1 message already existed"]}`)},
+	}}
+	h.runSelectiveRestoreJob("job-2", "snap", "alice",
+		meRestoreSelectiveRequest{Databases: []string{"alice_pg"}, Overwrite: true}, nil)
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusSucceeded {
+		t.Fatalf("status = %q, want succeeded", jobs.status)
+	}
+	// The drawer polls the job and renders warnings_json — an empty blob
+	// here means the tenant sees "restored" with no detail of WHAT.
+	var out selectiveRestoreOutcome
+	if err := json.Unmarshal(jobs.warnings, &out); err != nil {
+		t.Fatalf("warnings_json is not the outcome shape: %v (%s)", err, jobs.warnings)
+	}
+	if len(out.Applied) != 1 || !strings.Contains(out.Applied[0], "alice_pg") {
+		t.Errorf("applied list lost between agent and row: %#v", out)
+	}
+	if len(out.Warnings) != 1 {
+		t.Errorf("agent warnings lost: %#v", out.Warnings)
+	}
+}
+
+func TestRunSelectiveRestoreJob_AgentFailureIsGenericOnTheRow(t *testing.T) {
+	jobs := newSealCapture()
+	h := &meBackupHandler{cfg: MeBackupsHandlerConfig{
+		Jobs:  jobs,
+		Agent: restoreAgent{err: errors.New("restic: /var/lib secret path leaked")},
+	}}
+	h.runSelectiveRestoreJob("job-3", "snap", "alice",
+		meRestoreSelectiveRequest{Databases: []string{"x"}, Overwrite: true}, nil)
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusFailed {
+		t.Fatalf("status = %q, want failed", jobs.status)
+	}
+	// JAB-114: agent errors carry host internals. The tenant-visible row
+	// must NOT echo them.
+	if strings.Contains(jobs.errText, "/var/lib") {
+		t.Errorf("agent internals leaked onto the tenant-visible row: %q", jobs.errText)
+	}
+}

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -29,9 +29,14 @@ import (
 )
 
 const (
-	TickInterval   = 30 * time.Second
-	StallTimeout   = 4 * time.Hour
-	MaxJobsPerTick = 25
+	TickInterval = 30 * time.Second
+	StallTimeout = 4 * time.Hour
+	// RestoreStallTimeout seals `running` RESTORE rows whose background
+	// goroutine died without MarkFinished (GH #1044 — panel restart
+	// mid-restore). The restore goroutine bounds itself at 60 minutes,
+	// so anything past 90 is provably orphaned, not slow.
+	RestoreStallTimeout = 90 * time.Minute
+	MaxJobsPerTick      = 25
 	// statusCallTimeout must exceed a cold remote-repo probe: backup.status
 	// runs `restic snapshots` against the destination, which on SFTP/S3
 	// opens a fresh session and lists the index. At the old 10s the probe
@@ -138,11 +143,24 @@ func (f *Finalizer) tickOnce(ctx context.Context) {
 		if j.Status != models.BackupJobStatusRunning {
 			continue
 		}
-		// Restore jobs are sealed synchronously by the API restore
-		// handler when Agent.Call returns. The finalizer only tracks
-		// fan-out backup jobs that publish a manifest snapshot.
+		// Restore jobs (GH #1044) run as background goroutines sealed by
+		// their own MarkFinished — the finalizer's manifest tracking
+		// (checkOne) does not apply to them, because a restore publishes
+		// no manifest snapshot. But "sealed by the goroutine" fails in
+		// exactly one way: a panel restart kills the goroutine mid-restore
+		// and the row stays `running` forever with nothing left to seal
+		// it. Sweep those. The bound is the restore goroutine's own
+		// timeout plus slack: any restore row still running past it is
+		// provably orphaned, not slow.
 		if j.Kind == models.BackupJobKindAccountRestore ||
 			j.Kind == models.BackupJobKindSystemRestore {
+			if j.StartedAt != nil && now.Sub(*j.StartedAt) > RestoreStallTimeout {
+				f.deps.Log.Warn("restore job orphaned past its bound; sealing failed",
+					"job_id", j.ID, "kind", j.Kind, "started_at", j.StartedAt)
+				_ = f.deps.Jobs.MarkFinished(ctx, j.ID, models.BackupJobStatusFailed,
+					"", "", 0, 0, nil, nil,
+					"restore interrupted — no completion recorded (panel restarted mid-restore?)")
+			}
 			continue
 		}
 		if j.StartedAt != nil && now.Sub(*j.StartedAt) > StallTimeout {

--- a/panel-api/internal/backupfinalizer/finalizer_restore_orphan_test.go
+++ b/panel-api/internal/backupfinalizer/finalizer_restore_orphan_test.go
@@ -1,0 +1,91 @@
+package backupfinalizer
+
+// GH #1044: restores run as background goroutines sealed by their own
+// MarkFinished. That fails in exactly one way — a panel restart kills the
+// goroutine mid-restore and the row stays `running` forever, because the
+// finalizer used to skip restore-kind rows entirely on the (now false)
+// assumption that the API handler seals them synchronously.
+//
+// The sweep must be surgical: orphaned restores sealed, in-flight restores
+// left alone, and the manifest-tracking path for real backups untouched.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// restoreOrphanJobs extends the shared pagingJobs fake with error capture so
+// the seal reason is assertable.
+type restoreOrphanJobs struct {
+	pagingJobs
+	sealedErr map[string]string
+}
+
+func (j *restoreOrphanJobs) MarkFinished(_ context.Context, id, _ string, _, _ string,
+	_, _ uint64, _, _ json.RawMessage, errText string) error {
+	j.finishedIDs = append(j.finishedIDs, id)
+	if j.sealedErr == nil {
+		j.sealedErr = map[string]string{}
+	}
+	j.sealedErr[id] = errText
+	return nil
+}
+
+func startedAgo(d time.Duration) *time.Time {
+	t := time.Now().UTC().Add(-d)
+	return &t
+}
+
+func TestFinalizer_SealsOrphanedRestoreRows(t *testing.T) {
+	jobs := &restoreOrphanJobs{pagingJobs: pagingJobs{all: []models.BackupJob{
+		// Orphaned: running way past the goroutine's own 60m bound.
+		{ID: "restore-old", Kind: models.BackupJobKindAccountRestore,
+			Status: models.BackupJobStatusRunning, StartedAt: startedAgo(2 * time.Hour)},
+		// In-flight: a long pg restore that is still legitimately running.
+		{ID: "restore-young", Kind: models.BackupJobKindAccountRestore,
+			Status: models.BackupJobStatusRunning, StartedAt: startedAgo(30 * time.Minute)},
+		// System restore orphan gets the same treatment.
+		{ID: "sysrestore-old", Kind: models.BackupJobKindSystemRestore,
+			Status: models.BackupJobStatusRunning, StartedAt: startedAgo(3 * time.Hour)},
+	}}}
+	f := &Finalizer{deps: Deps{
+		Jobs: jobs,
+		Log:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+
+	f.tickOnce(context.Background())
+
+	sealed := map[string]bool{}
+	for _, id := range jobs.finishedIDs {
+		sealed[id] = true
+	}
+	if !sealed["restore-old"] {
+		t.Error("orphaned account_restore row was not sealed — it stays `running` forever after a panel restart")
+	}
+	if !sealed["sysrestore-old"] {
+		t.Error("orphaned system_restore row was not sealed")
+	}
+	if sealed["restore-young"] {
+		t.Error("an in-flight restore inside the goroutine's bound was sealed — a slow-but-alive pg restore just got its row failed under it")
+	}
+	if err := jobs.sealedErr["restore-old"]; err == "" || !containsStr(err, "interrupted") {
+		t.Errorf("seal reason should say the restore was interrupted, got %q", err)
+	}
+}
+
+func containsStr(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	}()
+}

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -22,6 +22,7 @@ import { RestoreDrawer } from "./RestoreDrawer";
 
 type MyBackup = {
   id: string;
+  kind?: string;
   status: string;
   content?: string;
   bytes_total: number;
@@ -200,14 +201,16 @@ export const MyProfileBackupCard = () => {
             render: (t: string) => shortDateTime(t),
           },
           {
-            // GH #454: show what each backup captured (full / database / files).
-            // Tenant backups are always account_backup, so the label is
-            // content-driven.
+            // GH #454: show what each backup captured (full / database /
+            // files). GH #1044: the kind is REAL, not assumed — restore
+            // jobs share this list (kind=account_restore) and were being
+            // labelled "Account Backup", which is exactly what the
+            // reporter flagged.
             title: "Type",
             dataIndex: "content",
             render: (_: unknown, row: MyBackup) => (
-              <Tag color={backupTypeColor("account_backup", row.content)}>
-                {backupTypeLabel("account_backup", row.content)}
+              <Tag color={backupTypeColor(row.kind ?? "account_backup", row.content)}>
+                {backupTypeLabel(row.kind ?? "account_backup", row.content)}
               </Tag>
             ),
           },

--- a/panel-ui/src/shells/user/RestoreDrawer.tsx
+++ b/panel-ui/src/shells/user/RestoreDrawer.tsx
@@ -44,6 +44,11 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
   const [selected, setSelected] = useState<string[]>([]);
   const [confirmOverwrite, setConfirmOverwrite] = useState(false);
   const [restoreHome, setRestoreHome] = useState(false);
+  // GH #1044 item 3: only offer "Home directory" when the backup actually
+  // CONTAINS a home stage. A database-only backup skips the home stage
+  // (status=skipped), and offering the checkbox anyway invites a restore
+  // selection that can never do anything.
+  const [hasHome, setHasHome] = useState(false);
   const [mailboxes, setMailboxes] = useState<string[]>([]);
   const [selectedMb, setSelectedMb] = useState<string[]>([]);
   const [dnsDomains, setDnsDomains] = useState<string[]>([]);
@@ -58,6 +63,7 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
     setSelected([]);
     setConfirmOverwrite(false);
     setRestoreHome(false);
+    setHasHome(false);
     setMailboxes([]);
     setSelectedMb([]);
     setDnsDomains([]);
@@ -75,6 +81,11 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
           .flatMap((st) => st.items ?? []);
         setMailboxes(mbs);
         setDnsDomains(resp.data.dns_domains ?? []);
+        setHasHome(
+          (resp.data.stages ?? []).some(
+            (st) => st.name === "home" && st.status === "ok",
+          ),
+        );
       })
       .catch((err) =>
         feedback.message.error(
@@ -84,19 +95,48 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
       .finally(() => setLoading(false));
   }, [open, backupId]);
 
+  // GH #1044: the restore runs as a background job now — the POST returns
+  // 202 + job_id immediately (a large Postgres restore used to outlive the
+  // HTTP request and surface as a bogus client-side timeout while the
+  // server finished the work anyway). Poll the job row until it seals and
+  // render the outcome it recorded.
   const handleRestore = async () => {
     if (!backupId || (selected.length === 0 && !restoreHome && selectedDns.length === 0 && selectedMb.length === 0)) return;
     setSubmitting(true);
     setResult(null);
     try {
-      const resp = await apiClient.post<RestoreResult>(
+      const resp = await apiClient.post<{ job_id: string }>(
         `/me/backups/${backupId}/restore`,
         { databases: selected, home: restoreHome, mailboxes: selectedMb, dns_domains: selectedDns, overwrite: true },
       );
-      setResult(resp.data);
-      const n = resp.data.applied?.length ?? 0;
-      if (n > 0) feedback.message.success(`Restored ${n} item${n === 1 ? "" : "s"}`);
-      else feedback.message.warning("Nothing was restored — see details");
+      const jobId = resp.data.job_id;
+      feedback.message.info("Restore started — this can take a while for large backups");
+      type JobRow = { id: string; status: string; warnings_json?: RestoreResult | null; error_text?: string };
+      const started = Date.now();
+      // Poll until the job seals. The server bounds the job at 60 min; the
+      // drawer gives up politely a bit after that. Closing the drawer just
+      // stops the polling — the job itself keeps running server-side and
+      // stays visible in the backups list.
+      for (;;) {
+        await new Promise((r) => setTimeout(r, 3000));
+        if (Date.now() - started > 65 * 60 * 1000) {
+          feedback.message.warning("Still running — track it in the backups list");
+          break;
+        }
+        const list = await apiClient.get<{ data: JobRow[] }>(`/me/backups`, { params: { limit: 50 } });
+        const row = (list.data.data ?? []).find((j) => j.id === jobId);
+        if (!row || row.status === "queued" || row.status === "running") continue;
+        const outcome: RestoreResult = row.warnings_json ?? {};
+        setResult(outcome);
+        if (row.status === "succeeded") {
+          const n = outcome.applied?.length ?? 0;
+          if (n > 0) feedback.message.success(`Restored ${n} item${n === 1 ? "" : "s"}`);
+          else feedback.message.warning("Nothing was restored — see details");
+        } else {
+          feedback.message.error("Restore failed — see details");
+        }
+        break;
+      }
     } catch (err) {
       feedback.message.error(err instanceof Error ? err.message : "Restore failed");
     } finally {
@@ -126,16 +166,18 @@ export const RestoreDrawer = ({ backupId, open, onClose }: RestoreDrawerProps) =
             restorable here.
           </Typography.Paragraph>
 
-          <Checkbox
-            checked={restoreHome}
-            onChange={(e) => setRestoreHome(e.target.checked)}
-          >
-            Home directory{" "}
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              (adds/overwrites files from the backup; does not delete files you
-              added since)
-            </Typography.Text>
-          </Checkbox>
+          {hasHome && (
+            <Checkbox
+              checked={restoreHome}
+              onChange={(e) => setRestoreHome(e.target.checked)}
+            >
+              Home directory{" "}
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                (adds/overwrites files from the backup; does not delete files
+                you added since)
+              </Typography.Text>
+            </Checkbox>
+          )}
 
           {databases.length === 0 ? (
             <Typography.Text type="secondary">


### PR DESCRIPTION
All three items from #1044. The first two share one root cause.

## 1. The "timeout" was three stacked ceilings, none of them the restore's

The restore ran **synchronously inside the HTTP request**. That chained the UI's 15 s axios timeout, nginx's 300 s `proxy_read_timeout`, and the old 10 m server cap onto work that legitimately takes minutes — a 500 MB `pg_restore` blew whichever tripped first, the client saw "timeout", **and the agent kept restoring anyway**, invisibly. MySQL "worked" only because small dumps finish inside the shortest ceiling.

Both restore endpoints (admin whole-account, tenant selective) now:

- create the job row, return **202 + job_id immediately**
- run the restore in a background runner bounded at **60 minutes**
- seal the row from the runner on **fresh contexts** (the request context is long dead by then — the `createCloneAndKickAgent` lesson)

The tenant drawer's result payload moved onto the job row (`warnings_json` as `{applied, skipped, warnings}`); the drawer polls until the job seals and renders from there. Closing the drawer stops the polling, not the restore.

**The finalizer had a now-false assumption baked in**: it skipped restore-kind rows because "the API handler seals them synchronously." Under async, the one failure mode of goroutine-sealing is a panel restart mid-restore → row stuck `running` forever. Restore rows running past **90 min** (the runner bounds itself at 60) are sealed `failed` with an explicit "restore interrupted" reason.

## 2. Restores labelled "Account Backup"

Both server paths already wrote `kind=account_restore` — the tenant list **hardcoded** `backupTypeLabel("account_backup", …)` with a comment asserting tenant jobs are always backups. Restores share that list. It now passes the row's real kind; the existing helper already renders "Account Restore".

## 3. "Restore Home Directory" on a database-only backup

The drawer already fetches the manifest; the home checkbox is now gated on an actual `home` stage with `status=ok`, exactly like the database and mailbox lists always were.

## Verified

- [x] **Live on testserver**: planted a 2-hour-old `running` `account_restore` row → finalizer sealed it `failed` with "restore interrupted — no completion recorded (panel restarted mid-restore?)" **within one tick**
- [x] Runner tests: agent failure seals `failed` with the agent's reason; a failed stage among successes seals `partial`; the outcome survives onto `warnings_json` in the exact shape the drawer parses; **agent internals never reach the tenant-visible row** (JAB-114, pinned)
- [x] Finalizer tests: 2 h restore orphan sealed, 30 min in-flight restore untouched, system-restore orphans covered, backup-row 4 h stall behaviour unchanged
- [x] `go vet` clean, `panel-api` + finalizer suites 0 FAIL; vitest 231 pass; `tsc` + `npm run build` clean

Not verified live: the full browser flow (needs an authenticated session; Playwright covers the pages in CI). The async wiring is covered by the runner/finalizer tests above, and the agent-side restore itself was E2E'd on a real Postgres in #1041.

## Notes for review

- These endpoints had **zero prior test coverage** — nothing failed when the behaviour changed, which is its own finding.
- HTTP status changes: admin restore `201 → 202`, tenant restore `200 → 202` with `{status:"queued", job_id}`. The admin page already treated the POST as fire-and-poll; the tenant drawer is updated in this PR. Any external caller scripting these endpoints will see the new shape.