### PR TITLE
fix(ssl): reissue issued certs missing a reachable desired SAN (JAB-226)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -78,6 +78,11 @@ type Reconciler struct {
 	// persistently-failing install is not re-dispatched every reconcile tick.
 	moduleInstallMu      sync.Mutex
 	moduleInstallAttempt map[string]time.Time
+	// sanDriftAttempt gates the JAB-226 SAN-drift reissue pass: cert ID -> last
+	// attempt, so a cert whose missing SAN isn't reachable yet isn't re-probed
+	// (or re-issued) more than once per sslSANDriftCooldown.
+	sanDriftMu      sync.Mutex
+	sanDriftAttempt map[string]time.Time
 	// queue holds domain IDs to reconcile out-of-band (non-blocking enqueue)
 	queue chan string
 	// socketReady is a function that checks if a Unix socket is ready. Mockable for testing.
@@ -602,6 +607,14 @@ func (r *Reconciler) Start(ctx context.Context) {
 	updateRunTicker := time.NewTicker(5 * time.Second)
 	defer updateRunTicker.Stop()
 
+	// Fire the SAN-drift pass once at startup so a panel restarted by
+	// `jabali update` converges issued certs missing a desired SAN (JAB-226)
+	// without waiting a full hour for the first ssl_observe tick. Rate-limited
+	// internally, and a no-op once every cert is complete.
+	if !r.IsPaused() {
+		r.ReconcileSSLSANDrift(ctx)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -638,6 +651,10 @@ func (r *Reconciler) Start(ctx context.Context) {
 			// SSL-enabled domain is re-armed so cutover is picked up without
 			// operator action. Rate-limited inside the pass.
 			r.ReconcileSSLResurrect(ctx)
+			// JAB-226: same cadence — an issued cert missing a reachable
+			// desired SAN (e.g. autodiscover.<domain>) is reissued via
+			// certbot --expand. Rate-limited inside the pass.
+			r.ReconcileSSLSANDrift(ctx)
 		case <-updateRunTicker.C:
 			if r.IsPaused() {
 				continue

--- a/panel-api/internal/reconciler/ssl_observe.go
+++ b/panel-api/internal/reconciler/ssl_observe.go
@@ -6,6 +6,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -78,6 +79,30 @@ func certNotAfter(path string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("%s: %w", path, err)
 	}
 	return c.NotAfter, nil
+}
+
+// certDNSNames parses a PEM certificate file and returns the LEAF's SAN DNS
+// names, lower-cased. Used by the SAN-drift pass (JAB-226) to compare what a
+// cert actually covers against what the domain's flags say it should. Takes the
+// first PEM block for the same reason as certNotAfter — the leaf, not the chain.
+func certDNSNames(path string) ([]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("%s: no PEM CERTIFICATE block", path)
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	out := make([]string, 0, len(c.DNSNames))
+	for _, n := range c.DNSNames {
+		out = append(out, strings.ToLower(n))
+	}
+	return out, nil
 }
 
 // observeSSLCerts compares each issued certificate's row against its file and

--- a/panel-api/internal/reconciler/ssl_san_drift.go
+++ b/panel-api/internal/reconciler/ssl_san_drift.go
@@ -1,0 +1,260 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// ssl_san_drift.go — JAB-226 tail. Converge an already-issued Let's Encrypt
+// certificate whose SAN set is missing a name the domain's flags now say it
+// should carry (the motivating case: autodiscover.<domain>, GH #185/#1039).
+//
+// Why this is needed: sanHostnamesForDomain is only consulted at ISSUANCE
+// (reconcileSSLForDomain's tryACMEOrFallback). An `issued` cert has no dispatch
+// case there, and ADR-0163 renewal is certbot's own timer, which reuses the
+// existing SAN set — so a name that was dropped at issue time (e.g. its DNS
+// hadn't propagated) never gets added. Outlook's autodiscover.<domain> probe
+// then hits a TLS mismatch forever. Measured on jabali.site: cert had mail. +
+// autoconfig. but not autodiscover., and a forced certbot renew did NOT add it.
+//
+// Safety (this pass touches certbot on a live cert, so it is deliberately timid):
+//   - LE mode only. Custom / self / shared / none certs are skipped — running
+//     certbot --cert-name against an operator's custom cert would clobber the LE
+//     lineage (#738/#745).
+//   - Wildcard certs skipped: a *.<domain> SAN already covers the helpers, and
+//     exact-matching would churn an --expand every pass forever.
+//   - reachable-filter BEFORE requesting: a name that can't answer HTTP-01 is
+//     not requested, so we never burn LE's failed-authorization quota (JAB-226
+//     is exactly that failure turned into a permanent outage).
+//   - Per-pass cap + per-cert cooldown: at most sslSANDriftMaxPerPass expands an
+//     hour, and a given cert is retried no more than once per sslSANDriftCooldown
+//     — so a fleet converges over hours, never in one Let's-Encrypt burst.
+//   - On failure the existing cert is left exactly as it was: no status flip, no
+//     self-sign downgrade. The domain keeps serving its current (valid) cert.
+
+const (
+	// sslSANDriftMaxPerPass bounds Let's Encrypt reissues per hourly pass. Kept
+	// low on purpose: the only cost of a small cap is how many hours a fleet
+	// takes to converge; the cost of a big one is an LE rate-limit lockout.
+	sslSANDriftMaxPerPass = 2
+	// sslSANDriftCooldown is the minimum gap between reissue attempts for one
+	// cert. Also gates the (cheaper) reachability probing, so a cert whose
+	// missing SAN isn't reachable yet isn't re-probed every pass.
+	sslSANDriftCooldown = 6 * time.Hour
+)
+
+// sslSANDriftMissing returns the desired SAN names an issued cert does not yet
+// cover. Pure: the caller supplies the cert's actual SAN names. Returns nil when
+// the cert already covers everything, carries a wildcard (assumed to cover the
+// helpers — never churn it), or the domain wants no extra SANs. Uses the domain
+// flags carried on the ListAll row so no per-cert domain lookup is needed here.
+func sslSANDriftMissing(row repository.SSLCertificateWithDomain, certSANs []string) []string {
+	dom := &models.Domain{
+		Name:          row.DomainName,
+		EmailEnabled:  row.EmailEnabled,
+		SkipAutoSAN:   row.SkipAutoSAN,
+		CreateWWW:     row.CreateWWW,
+		MTASTSEnabled: row.MTASTSEnabled,
+	}
+	desired := sanHostnamesForDomain(dom)
+	if len(desired) == 0 {
+		return nil
+	}
+	have := make(map[string]struct{}, len(certSANs))
+	for _, s := range certSANs {
+		if strings.HasPrefix(s, "*.") {
+			return nil // wildcard covers subdomains — treat as complete
+		}
+		have[strings.ToLower(s)] = struct{}{}
+	}
+	var missing []string
+	for _, d := range desired {
+		if _, ok := have[strings.ToLower(d)]; !ok {
+			missing = append(missing, d)
+		}
+	}
+	return missing
+}
+
+// sslSANDriftEligible is the cheap, no-IO gate: an issued LE cert with a cert
+// file on disk. Custom/self/shared/none modes are excluded so certbot never
+// touches a cert the panel doesn't own the ACME lineage for.
+func sslSANDriftEligible(row repository.SSLCertificateWithDomain) bool {
+	if row.Status != models.SSLStatusIssued || row.CertPath == nil || *row.CertPath == "" {
+		return false
+	}
+	return row.SSLMode == models.SSLModeLE || row.SSLMode == ""
+}
+
+// sanDriftCooldownPassed reports whether this cert may be attempted again, and
+// (when true) is expected to be paired with markSANDriftAttempt by the caller.
+func (r *Reconciler) sanDriftCooldownPassed(certID string, now time.Time) bool {
+	r.sanDriftMu.Lock()
+	defer r.sanDriftMu.Unlock()
+	last, ok := r.sanDriftAttempt[certID]
+	return !ok || now.Sub(last) >= sslSANDriftCooldown
+}
+
+func (r *Reconciler) markSANDriftAttempt(certID string, now time.Time) {
+	r.sanDriftMu.Lock()
+	defer r.sanDriftMu.Unlock()
+	if r.sanDriftAttempt == nil {
+		r.sanDriftAttempt = map[string]time.Time{}
+	}
+	r.sanDriftAttempt[certID] = now
+}
+
+// ReconcileSSLSANDrift finds issued LE certs missing a reachable desired SAN and
+// reissues them (certbot --expand) to add it. Called on the hourly ssl_observe
+// cadence (and once at startup). Rate-limited internally; see the file header.
+func (r *Reconciler) ReconcileSSLSANDrift(ctx context.Context) {
+	if r.sslCerts == nil || r.serverSettings == nil || r.domains == nil {
+		return
+	}
+	if r.isStandby(ctx) {
+		return // DR standby's cert rows are a replica; drsync owns them (GH #331)
+	}
+	certs, err := r.sslCerts.ListAll(ctx)
+	if err != nil {
+		r.log.Warn("ssl_san_drift: listing certificates failed", "error", err)
+		return
+	}
+	now := time.Now().UTC()
+	attempted := 0
+	for _, c := range certs {
+		if attempted >= sslSANDriftMaxPerPass {
+			break
+		}
+		if !sslSANDriftEligible(c) {
+			continue
+		}
+		certSANs, err := certDNSNames(*c.CertPath)
+		if err != nil {
+			continue // unreadable — ssl_observe already surfaces that separately
+		}
+		missing := sslSANDriftMissing(c, certSANs)
+		if len(missing) == 0 {
+			continue // cert already complete (or wildcard) — cheap skip, no IO/LE
+		}
+		if !r.sanDriftCooldownPassed(c.ID, now) {
+			continue
+		}
+		// Expensive work (DNS + HTTP-01 reachability probes, maybe certbot) begins
+		// here. Count it against the per-pass cap and stamp the cooldown up front,
+		// so even a cert whose missing SAN turns out unreachable is not re-probed
+		// until the cooldown elapses.
+		attempted++
+		r.markSANDriftAttempt(c.ID, now)
+		r.expandCertSANsForDrift(ctx, c, certSANs, missing)
+	}
+	if attempted > 0 {
+		r.log.Info("ssl_san_drift pass", "attempted", attempted)
+	}
+}
+
+// expandCertSANsForDrift resolves the domain, filters the full desired SAN set
+// to what LE could actually validate, confirms that still adds a name the cert
+// lacks, and reissues via certbot --expand. Leaves the existing cert untouched
+// on any failure.
+func (r *Reconciler) expandCertSANsForDrift(ctx context.Context, cert repository.SSLCertificateWithDomain, certSANs, missing []string) {
+	dom, err := r.domains.FindByID(ctx, cert.DomainID)
+	if err != nil || dom == nil {
+		return
+	}
+	// Re-check the authoritative row: the ListAll snapshot could be stale, and we
+	// must never run certbot against a mode the panel doesn't own.
+	if dom.SSLMode != models.SSLModeLE && dom.SSLMode != "" {
+		return
+	}
+
+	desired := sanHostnamesForDomain(dom)
+	reachable := r.resolvableSANs(ctx, desired)
+	if len(reachable) > 0 {
+		reachable = r.reachableSANs(ctx, dom.Name, reachable)
+	}
+	have := make(map[string]struct{}, len(certSANs))
+	for _, s := range certSANs {
+		have[strings.ToLower(s)] = struct{}{}
+	}
+	reach := make(map[string]struct{}, len(reachable))
+	for _, s := range reachable {
+		reach[strings.ToLower(s)] = struct{}{}
+	}
+	// Build the request as the safe UNION: a desired SAN is requested if it is
+	// EITHER already on the cert OR reachable now. certbot's `certonly --expand`
+	// replaces the cert's SAN set with exactly the -d list (--expand only
+	// suppresses the confirmation prompt), so requesting the raw reachable set
+	// would DROP a currently-covered SAN whose HTTP-01 probe flaked this pass —
+	// a regression. Keeping already-covered names guarantees we only ever grow.
+	var request []string
+	addsSomething := false
+	for _, d := range desired {
+		_, onCert := have[strings.ToLower(d)]
+		_, ok := reach[strings.ToLower(d)]
+		if onCert || ok {
+			request = append(request, d)
+		}
+		if ok && !onCert {
+			addsSomething = true
+		}
+	}
+	// Nothing new is reachable yet (the missing SAN still can't answer HTTP-01):
+	// requesting it would just burn LE failed-auth quota. Defer — the cooldown is
+	// already stamped, so we retry no sooner than sslSANDriftCooldown from now.
+	if !addsSomething {
+		r.log.Info("ssl_san_drift: desired SAN not reachable yet, deferring",
+			"domain", dom.Name, "missing", strings.Join(missing, ","))
+		return
+	}
+
+	srv, err := r.serverSettings.Get(ctx)
+	if err != nil || srv == nil {
+		return
+	}
+
+	r.sslIssueMu.Lock()
+	defer r.sslIssueMu.Unlock()
+	issueCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
+	params := map[string]any{
+		"domain":    dom.Name,
+		"webroot":   dom.DocRoot,
+		"email":     srv.AdminEmail,
+		"staging":   cert.Staging,
+		"hostnames": request,
+	}
+	raw, err := r.agent.Call(issueCtx, "ssl.issue", params)
+	if err != nil {
+		// The current cert keeps serving. Do NOT flip status or self-sign — this
+		// is a best-effort SAN top-up, not a cert the domain is waiting on.
+		r.log.Warn("ssl_san_drift: expand failed, keeping current cert",
+			"domain", dom.Name, "error", firstLine(err.Error()))
+		return
+	}
+	issued, expires, ok := parseSSLIssueResult(raw, r.log, dom.Name)
+	if !ok {
+		r.log.Warn("ssl_san_drift: unparseable ssl.issue result", "domain", dom.Name)
+		return
+	}
+	var res sslIssueResult
+	_ = json.Unmarshal(raw, &res)
+	if err := r.sslCerts.UpdateAfterIssuance(ctx, cert.ID, issued, expires, res.CertPath, res.KeyPath); err != nil {
+		r.log.Error("ssl_san_drift: write issuance failed", "domain", dom.Name, "error", err)
+		return
+	}
+	// The vhost config is unchanged (same cert path), so the per-domain vhost
+	// reconcile won't reload — reload nginx explicitly so the freshly-expanded
+	// cert is actually served (both the web vhost and the mail vhost reference
+	// this file). Best-effort: the cert is on disk regardless.
+	reloadCtx, rcancel := context.WithTimeout(ctx, 30*time.Second)
+	_, _ = r.agent.Call(reloadCtx, "nginx.reload", map[string]any{})
+	rcancel()
+	r.log.Info("ssl_san_drift: expanded certificate SANs",
+		"domain", dom.Name, "hostnames", strings.Join(request, ","))
+}

--- a/panel-api/internal/reconciler/ssl_san_drift_test.go
+++ b/panel-api/internal/reconciler/ssl_san_drift_test.go
@@ -1,0 +1,113 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+func strp(s string) *string { return &s }
+
+func emailRow(name string) repository.SSLCertificateWithDomain {
+	return repository.SSLCertificateWithDomain{
+		ID: "c-" + name, DomainID: "d-" + name, DomainName: name,
+		Status: models.SSLStatusIssued, CertPath: strp("/etc/letsencrypt/live/" + name + "/fullchain.pem"),
+		SSLMode: models.SSLModeLE, EmailEnabled: true,
+	}
+}
+
+func TestSSLSANDriftMissing(t *testing.T) {
+	row := emailRow("example.com")
+
+	// Missing autodiscover — the motivating case.
+	miss := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com"})
+	if len(miss) != 1 || miss[0] != "autodiscover.example.com" {
+		t.Fatalf("missing = %v, want [autodiscover.example.com]", miss)
+	}
+
+	// Complete cert — no drift.
+	if m := sslSANDriftMissing(row, []string{"example.com", "mail.example.com", "autoconfig.example.com", "autodiscover.example.com"}); m != nil {
+		t.Errorf("complete cert flagged drift: %v", m)
+	}
+
+	// Wildcard cert — assumed to cover the helpers, never churned.
+	if m := sslSANDriftMissing(row, []string{"example.com", "*.example.com"}); m != nil {
+		t.Errorf("wildcard cert flagged drift: %v", m)
+	}
+
+	// Case-insensitive match.
+	if m := sslSANDriftMissing(row, []string{"example.com", "Mail.Example.COM", "AUTOCONFIG.example.com", "autodiscover.example.com"}); m != nil {
+		t.Errorf("case difference flagged drift: %v", m)
+	}
+
+	// SkipAutoSAN → no helper SANs desired → no drift.
+	skip := row
+	skip.SkipAutoSAN = true
+	if m := sslSANDriftMissing(skip, []string{"example.com"}); m != nil {
+		t.Errorf("SkipAutoSAN flagged drift: %v", m)
+	}
+
+	// Email disabled → no mail helpers desired → no drift even with a bare cert.
+	nomail := row
+	nomail.EmailEnabled = false
+	if m := sslSANDriftMissing(nomail, []string{"example.com"}); m != nil {
+		t.Errorf("email-disabled flagged drift: %v", m)
+	}
+}
+
+func TestSSLSANDriftEligible(t *testing.T) {
+	base := emailRow("example.com")
+	if !sslSANDriftEligible(base) {
+		t.Error("issued LE cert should be eligible")
+	}
+
+	// Empty mode = legacy LE — eligible.
+	empty := base
+	empty.SSLMode = ""
+	if !sslSANDriftEligible(empty) {
+		t.Error("legacy empty-mode cert should be eligible")
+	}
+
+	// Non-LE modes MUST be skipped — certbot must never touch them (#738/#745).
+	for _, mode := range []string{models.SSLModeCustom, models.SSLModeSelf, "shared", models.SSLModeNone} {
+		r := base
+		r.SSLMode = mode
+		if sslSANDriftEligible(r) {
+			t.Errorf("mode %q must NOT be eligible", mode)
+		}
+	}
+
+	// Not issued, or no cert file — skipped.
+	pending := base
+	pending.Status = models.SSLStatusPending
+	if sslSANDriftEligible(pending) {
+		t.Error("pending cert must not be eligible")
+	}
+	nofile := base
+	nofile.CertPath = nil
+	if sslSANDriftEligible(nofile) {
+		t.Error("cert without a file must not be eligible")
+	}
+}
+
+func TestSANDriftCooldown(t *testing.T) {
+	r := &Reconciler{}
+	now := time.Now().UTC()
+
+	if !r.sanDriftCooldownPassed("c1", now) {
+		t.Error("first check should pass (never attempted)")
+	}
+	r.markSANDriftAttempt("c1", now)
+	if r.sanDriftCooldownPassed("c1", now.Add(time.Hour)) {
+		t.Error("within cooldown should NOT pass")
+	}
+	if !r.sanDriftCooldownPassed("c1", now.Add(sslSANDriftCooldown+time.Minute)) {
+		t.Error("after cooldown should pass again")
+	}
+	// A different cert is independent.
+	if !r.sanDriftCooldownPassed("c2", now.Add(time.Hour)) {
+		t.Error("unrelated cert should pass")
+	}
+}

--- a/panel-api/internal/repository/ssl_certificate_repository.go
+++ b/panel-api/internal/repository/ssl_certificate_repository.go
@@ -32,6 +32,16 @@ type SSLCertificateWithDomain struct {
 	// /etc/letsencrypt/live/<domain>/, which is wrong for installed custom
 	// certificates.
 	CertPath *string `json:"cert_path,omitempty"`
+	// Domain flags carried on the ListAll join for the SAN-drift pass
+	// (JAB-226): they feed sanHostnamesForDomain so it can tell which SANs
+	// an issued cert SHOULD carry, without a per-cert domain lookup. Only
+	// ListAll selects them; other list queries leave them zero. Internal —
+	// not part of the admin SSL JSON.
+	SSLMode       string `json:"-"`
+	EmailEnabled  bool   `json:"-"`
+	SkipAutoSAN   bool   `json:"-"`
+	CreateWWW     bool   `json:"-"`
+	MTASTSEnabled bool   `json:"-"`
 }
 
 // SSLCertificateRepository covers the ssl_certificates table.
@@ -215,7 +225,8 @@ func (r *sslCertificateRepo) ListAll(ctx context.Context) ([]SSLCertificateWithD
 		        d.user_id, u.username as user_username,
 		        sc.status, sc.issued_at, sc.expires_at,
 		        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,
-		        sc.cert_path`).
+		        sc.cert_path,
+		        d.ssl_mode, d.email_enabled, d.skip_auto_san, d.create_www, d.mta_sts_enabled`).
 		Table("ssl_certificates sc").
 		Joins("JOIN domains d ON sc.domain_id = d.id").
 		Joins("JOIN users u ON d.user_id = u.id").
@@ -384,7 +395,6 @@ func (r *sslCertificateRepo) FindByDomainIDs(ctx context.Context, domainIDs []st
 	}
 	return certs, nil
 }
-
 
 // ListExhaustedForSSLEnabledDomains returns certificates that exhausted their
 // ACME attempts (status='failed') while the domain still has SSL enabled, and

--- a/panel-api/internal/repository/ssl_certificate_repository_test.go
+++ b/panel-api/internal/repository/ssl_certificate_repository_test.go
@@ -232,7 +232,7 @@ func TestSSLCertificateRepository_ListAll(t *testing.T) {
 
 	// Expect a SELECT joining ssl_certificates, domains, and users
 	mock.ExpectQuery(
-		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,\n\t\t        sc.cert_path FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE sc.status <> ? ORDER BY sc.created_at DESC")).
+		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,\n\t\t        sc.cert_path,\n\t\t        d.ssl_mode, d.email_enabled, d.skip_auto_san, d.create_www, d.mta_sts_enabled FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE sc.status <> ? ORDER BY sc.created_at DESC")).
 		WithArgs("revoked").
 		WillReturnRows(
 			sqlmock.NewRows([]string{


### PR DESCRIPTION
## The gap (JAB-226 tail, surfaced by #1039)

`sanHostnamesForDomain` is only consulted at **issuance**. An already-`issued` cert has no dispatch case in `reconcileSSLForDomain`, and ADR-0163 renewal is certbot's own timer, which **reuses the existing SAN set**. So a desired name dropped at issue time — e.g. `autodiscover.<domain>` whose DNS hadn't propagated yet (GH #185 / #1039) — was **never** added. Outlook's `autodiscover.<domain>` probe then hits a permanent TLS mismatch.

Confirmed on jabali.site: cert had `mail.` + `autoconfig.` but **not** `autodiscover.`, and a forced `certbot renew --force` did **not** add it (renew reuses SANs). Some domains (freshly issued) have it; older certs don't — a fleet-wide drift.

## Fix

`ReconcileSSLSANDrift` runs on the hourly `ssl_observe` cadence + once at startup. For each issued LE cert, it reads the cert's **actual** SANs and, if a desired name is missing **and reachable now**, reissues via certbot `--expand`.

### Safety (this touches certbot on a live cert)
- **LE mode only** — gated on `ssl_mode`; never custom/self/shared/none (can't clobber an operator's lineage, #738/#745).
- **Wildcard certs skipped** — a `*.` SAN already covers the helpers.
- **Requests the UNION** of already-covered + newly-reachable desired names, never the raw reachable set — `certonly --expand` *replaces* the SAN set, so requesting fewer would **shrink** the cert and drop a SAN whose probe flaked this pass.
- **Reachable-filter before requesting** — an unreachable name is never sent, so no LE failed-auth quota burn (the JAB-226 failure mode).
- **Per-pass cap (2) + 6h per-cert cooldown** — a fleet converges over hours, never in one LE burst.
- **Failure-safe** — on any error the existing cert is left exactly as-is (no status flip, no self-sign downgrade). nginx is reloaded after a successful expand so the new cert is actually served (the vhost content-diff won't — cert path unchanged).

## Tests
Pure drift detection (missing / complete / wildcard / case-insensitive / skip-auto-SAN / no-email), the mode-eligibility gate (custom/self/shared/none/pending/no-file all excluded), and the cooldown. Full `panel-api`: 0 failures.

Not yet box-verified — will confirm on jabalitests: jabali.site's cert gains `autodiscover.` via **one** LE issuance, a non-drifted cert gets **no** call, a second pass is a **no-op** (idempotence/loop-guard), and `autodiscover.jabali.site` then serves the XML.

JAB-226