### PR TITLE
fix(backup): point every tenant restore read at the source destination's repo (GH #1044)

### DIFF
--- a/panel-agent/internal/commands/backup_dns_read.go
+++ b/panel-agent/internal/commands/backup_dns_read.go
@@ -16,11 +16,16 @@ import (
 type backupDNSReadParams struct {
 	ManifestSnapshotID string   `json:"manifest_snapshot_id"`
 	DomainNames        []string `json:"domain_names"`
+
+	RepoURL        string            `json:"repo_url,omitempty"`
+	CredentialsRef string            `json:"credentials_ref,omitempty"`
+	PasswordFile   string            `json:"password_file,omitempty"`
+	SFTP           *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupDNSDomain struct {
-	Name       string                       `json:"name"`
-	DNSRecords []backup.MetadataDNSRecord    `json:"dns_records"`
+	Name       string                     `json:"name"`
+	DNSRecords []backup.MetadataDNSRecord `json:"dns_records"`
 }
 
 type backupDNSReadResult struct {
@@ -39,7 +44,10 @@ func backupDNSReadHandler(ctx context.Context, raw json.RawMessage) (any, error)
 		return nil, bkInvalidArg("domain_names required")
 	}
 
-	cfg, cerr := bkResticConfig("", "", nil)
+	// Same destination wire contract as backup.create — empty falls back
+	// to the legacy default repo (GH #1044: hardcoding the default made
+	// DNS restore read the wrong repo for per-destination backups).
+	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-agent/internal/commands/backup_manifest_read.go
+++ b/panel-agent/internal/commands/backup_manifest_read.go
@@ -6,10 +6,13 @@
 // already does (backup_restore.go), but as a standalone read-only command the
 // tenant /me/backups/:id/manifest endpoint can call.
 //
-// Uses the default local restic repo (the same simplification as
-// backup.materialize / the tenant download path — remote-destination preview is
-// a follow-up). The manifest snapshot's stdin filename is "manifest.json"
-// (backup_create.go).
+// The read targets the repo the caller names (repo_url + credentials +
+// per-destination password file, same wire contract as backup.create);
+// empty = the legacy default local repo. It originally hardcoded the
+// default repo with "remote-destination preview is a follow-up" — the
+// follow-up that never happened, so the restore drawer 502'd on every
+// per-destination backup (GH #1044 E2E finding). The manifest snapshot's
+// stdin filename is "manifest.json" (backup_create.go).
 package commands
 
 import (
@@ -21,7 +24,11 @@ import (
 )
 
 type backupManifestReadParams struct {
-	ManifestSnapshotID string `json:"manifest_snapshot_id"`
+	ManifestSnapshotID string            `json:"manifest_snapshot_id"`
+	RepoURL            string            `json:"repo_url,omitempty"`
+	CredentialsRef     string            `json:"credentials_ref,omitempty"`
+	PasswordFile       string            `json:"password_file,omitempty"`
+	SFTP               *backupSFTPInputs `json:"sftp,omitempty"`
 }
 
 type backupManifestStageDTO struct {
@@ -47,7 +54,7 @@ func backupManifestReadHandler(ctx context.Context, raw json.RawMessage) (any, e
 		return nil, bkInvalidArg("manifest_snapshot_id is required")
 	}
 
-	cfg, cerr := bkResticConfig("", "", nil)
+	cfg, cerr := bkResticConfigWithPassword(p.RepoURL, p.CredentialsRef, p.PasswordFile, p.SFTP)
 	if cerr != nil {
 		return nil, bkInternal("restic config", cerr)
 	}

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -361,6 +361,11 @@ func materializeDest(ctx context.Context, dests repository.BackupDestinationRepo
 // backup commands accept. Mirror of backupscheduler.destWireParams;
 // kept duplicated to avoid the api → backupscheduler import cycle.
 func destWireParams(d *models.BackupDestination) map[string]any {
+	// nil = a legacy job row with no destination — the agent falls back to
+	// its default local repo, which is exactly where such a backup lives.
+	if d == nil {
+		return nil
+	}
 	out := map[string]any{
 		"repo_url":         d.URL,
 		"destination_kind": d.Kind,
@@ -2552,7 +2557,21 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 	// the agent finished the work anyway). The result the drawer used to
 	// read from this response is persisted onto the job row
 	// (warnings_json) instead, and the drawer polls the job.
-	go h.runSelectiveRestoreJob(restoreJob.ID, job.SnapshotID, *owner.Username, req, ownedDomains)
+	// The snapshot lives in the SOURCE backup's destination repo, not the
+	// agent's legacy default. Resolve it here and hand it to the runner —
+	// without this every restore from a per-destination backup failed with
+	// "failed to find snapshot" against /var/lib/jabali-backups/repo (found
+	// live while E2E-testing the async flow; the synchronous version had
+	// the same omission all along).
+	var restoreDest *models.BackupDestination
+	if job.DestinationID != nil && *job.DestinationID != "" && h.cfg.Destinations != nil {
+		if d, derr := h.cfg.Destinations.Get(c.Request.Context(), *job.DestinationID); derr == nil {
+			restoreDest = d
+		} else {
+			h.cfg.logErr("selective restore: destination lookup failed", derr, "dest_id", *job.DestinationID)
+		}
+	}
+	go h.runSelectiveRestoreJob(restoreJob.ID, job.SnapshotID, *owner.Username, req, ownedDomains, restoreDest)
 	c.JSON(http.StatusAccepted, gin.H{"status": "queued", "job_id": restoreJob.ID})
 }
 
@@ -2569,7 +2588,7 @@ type selectiveRestoreOutcome struct {
 // completion and seals the job row with the outcome. Detached from the
 // request; every context is fresh (a status write on the dead request
 // context would be a silent no-op).
-func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username string, req meRestoreSelectiveRequest, ownedDomains map[string]string) {
+func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username string, req meRestoreSelectiveRequest, ownedDomains map[string]string, dest *models.BackupDestination) {
 	ctx, cancel := context.WithTimeout(context.Background(), restoreJobTimeout)
 	defer cancel()
 	seal := func(status, errText string, out selectiveRestoreOutcome) {
@@ -2584,7 +2603,7 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 	// Databases + home go to the agent (host-side). Only dispatch when one is
 	// requested — the agent rejects an empty db+home set.
 	if len(req.Databases) > 0 || req.Home || len(req.Mailboxes) > 0 {
-		raw, aerr := h.cfg.Agent.Call(ctx, "backup.restore_selective", map[string]any{
+		params := map[string]any{
 			"job_id":               jobID,
 			"manifest_snapshot_id": manifestSnap,
 			"target_username":      username,
@@ -2592,7 +2611,23 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 			"mailboxes":            req.Mailboxes,
 			"home":                 req.Home,
 			"overwrite":            req.Overwrite,
-		})
+		}
+		// Point the agent at the repo the snapshot actually lives in, and
+		// unseal the per-destination restic password for it (M30.2.x) —
+		// same contract as every backup.create/backup.restore dispatch.
+		for k, v := range destWireParams(dest) {
+			params[k] = v
+		}
+		var raw json.RawMessage
+		aerr := backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
+			func(passwordFile string) error {
+				if passwordFile != "" {
+					params["password_file"] = passwordFile
+				}
+				var callErr error
+				raw, callErr = h.cfg.Agent.Call(ctx, "backup.restore_selective", params)
+				return callErr
+			})
 		if aerr != nil {
 			// Agent errors carry restic/host internals — log, don't echo
 			// (JAB-114). The drawer sees the generic failure via the row.
@@ -2617,7 +2652,7 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 			}
 			out.Warnings = append(out.Warnings, "overwrite=false: DNS not applied. Restoring DNS replaces this domain's custom records; re-send with overwrite=true.")
 		} else {
-			da, dw := h.restoreDNSRecords(ctx, manifestSnap, req.DNSDomains, ownedDomains)
+			da, dw := h.restoreDNSRecords(ctx, manifestSnap, req.DNSDomains, ownedDomains, dest)
 			out.Applied = append(out.Applied, da...)
 			out.Warnings = append(out.Warnings, dw...)
 		}
@@ -2630,17 +2665,32 @@ func (h *meBackupHandler) runSelectiveRestoreJob(jobID, manifestSnap, username s
 // (via the agent) and re-inserts them into each domain's zone, replacing the
 // existing NON-managed records. Owner-scoping is enforced by ownedDomains (the
 // caller's name->id map); managed records are left untouched (they re-derive).
-func (h *meBackupHandler) restoreDNSRecords(ctx context.Context, manifestSnap string, domains []string, ownedDomains map[string]string) ([]string, []string) {
+func (h *meBackupHandler) restoreDNSRecords(ctx context.Context, manifestSnap string, domains []string, ownedDomains map[string]string, dest *models.BackupDestination) ([]string, []string) {
 	var applied, warnings []string
 	if h.cfg.DNSZones == nil || h.cfg.DNSRecords == nil {
 		return nil, []string{"dns: not configured on this panel"}
 	}
-	raw, err := h.cfg.Agent.Call(ctx, "backup.dns_read", map[string]any{
+	// GH #1044: read from the SOURCE backup's destination repo, not the
+	// legacy default — same fix as the manifest and selective paths.
+	params := map[string]any{
 		"manifest_snapshot_id": manifestSnap,
 		"domain_names":         domains,
-	})
+	}
+	for k, v := range destWireParams(dest) {
+		params[k] = v
+	}
+	var raw json.RawMessage
+	err := backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
+		func(passwordFile string) error {
+			if passwordFile != "" {
+				params["password_file"] = passwordFile
+			}
+			var callErr error
+			raw, callErr = h.cfg.Agent.Call(ctx, "backup.dns_read", params)
+			return callErr
+		})
 	if err != nil {
-		return nil, []string{"dns: read from backup failed: " + err.Error()}
+		return nil, []string{"dns: read from backup failed"}
 	}
 	var rd struct {
 		Domains []struct {
@@ -2725,15 +2775,36 @@ func (h *meBackupHandler) manifest(c *gin.Context) {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "agent_unavailable"})
 		return
 	}
+	// GH #1044: the manifest lives in the SOURCE backup's destination repo.
+	// Without repo_url the agent read the legacy default repo, restic
+	// retried against a snapshot that was never there, and the restore
+	// drawer 502'd for every per-destination backup.
+	var dest *models.BackupDestination
+	if job.DestinationID != nil && *job.DestinationID != "" && h.cfg.Destinations != nil {
+		if d, derr := h.cfg.Destinations.Get(c.Request.Context(), *job.DestinationID); derr == nil {
+			dest = d
+		}
+	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
-	raw, err := h.cfg.Agent.Call(ctx, "backup.manifest_read", map[string]any{
-		"manifest_snapshot_id": job.SnapshotID,
-	})
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"status": "error", "error": "manifest_read_failed", "detail": err.Error(),
+	params := map[string]any{"manifest_snapshot_id": job.SnapshotID}
+	for k, v := range destWireParams(dest) {
+		params[k] = v
+	}
+	var raw json.RawMessage
+	err = backupwrapperhelpers.WithOptionalDestPassword(ctx, dest, h.cfg.Agent, h.cfg.SSOKey,
+		func(passwordFile string) error {
+			if passwordFile != "" {
+				params["password_file"] = passwordFile
+			}
+			var callErr error
+			raw, callErr = h.cfg.Agent.Call(ctx, "backup.manifest_read", params)
+			return callErr
 		})
+	if err != nil {
+		// Agent errors carry restic/host internals — log, never echo
+		// (JAB-114; the old response leaked err.Error() to the tenant).
+		respondAgentErr(c, "manifest_read_failed", err)
 		return
 	}
 	// Pass the agent's {kind,user_id,username,stages[]} through verbatim.

--- a/panel-api/internal/api/backups_restore_async_test.go
+++ b/panel-api/internal/api/backups_restore_async_test.go
@@ -100,7 +100,7 @@ func TestRunSelectiveRestoreJob_PersistsOutcomeForTheDrawer(t *testing.T) {
 			`{"applied":["db → alice_pg (postgres)"],"skipped":[],"warnings":["mail: 1 message already existed"]}`)},
 	}}
 	h.runSelectiveRestoreJob("job-2", "snap", "alice",
-		meRestoreSelectiveRequest{Databases: []string{"alice_pg"}, Overwrite: true}, nil)
+		meRestoreSelectiveRequest{Databases: []string{"alice_pg"}, Overwrite: true}, nil, nil)
 	jobs.wait(t)
 	if jobs.status != models.BackupJobStatusSucceeded {
 		t.Fatalf("status = %q, want succeeded", jobs.status)
@@ -126,7 +126,7 @@ func TestRunSelectiveRestoreJob_AgentFailureIsGenericOnTheRow(t *testing.T) {
 		Agent: restoreAgent{err: errors.New("restic: /var/lib secret path leaked")},
 	}}
 	h.runSelectiveRestoreJob("job-3", "snap", "alice",
-		meRestoreSelectiveRequest{Databases: []string{"x"}, Overwrite: true}, nil)
+		meRestoreSelectiveRequest{Databases: []string{"x"}, Overwrite: true}, nil, nil)
 	jobs.wait(t)
 	if jobs.status != models.BackupJobStatusFailed {
 		t.Fatalf("status = %q, want failed", jobs.status)
@@ -135,5 +135,43 @@ func TestRunSelectiveRestoreJob_AgentFailureIsGenericOnTheRow(t *testing.T) {
 	// must NOT echo them.
 	if strings.Contains(jobs.errText, "/var/lib") {
 		t.Errorf("agent internals leaked onto the tenant-visible row: %q", jobs.errText)
+	}
+}
+
+// recordingAgent captures the params of the last call so wire-contract
+// assertions can look inside.
+type recordingAgent struct {
+	reply  json.RawMessage
+	mu     sync.Mutex
+	params map[string]any
+}
+
+func (a *recordingAgent) Call(_ context.Context, _ string, p any) (json.RawMessage, error) {
+	a.mu.Lock()
+	if m, ok := p.(map[string]any); ok {
+		a.params = m
+	}
+	a.mu.Unlock()
+	return a.reply, nil
+}
+
+// The snapshot lives in the SOURCE backup's destination repo. Found live:
+// without repo_url on the wire, the agent read the legacy default repo and
+// every restore from a per-destination backup failed with "failed to find
+// snapshot" — a bug the synchronous version had all along.
+func TestRunSelectiveRestoreJob_SendsTheSourceDestinationRepo(t *testing.T) {
+	jobs := newSealCapture()
+	ag := &recordingAgent{reply: json.RawMessage(`{"applied":["db → x"],"skipped":[],"warnings":[]}`)}
+	h := &meBackupHandler{cfg: MeBackupsHandlerConfig{Jobs: jobs, Agent: ag}}
+	dest := &models.BackupDestination{ID: "d1", Kind: "local", URL: "/var/lib/jabali-backups/custom"}
+
+	h.runSelectiveRestoreJob("job-4", "snap", "alice",
+		meRestoreSelectiveRequest{Databases: []string{"x"}, Overwrite: true}, nil, dest)
+	jobs.wait(t)
+
+	ag.mu.Lock()
+	defer ag.mu.Unlock()
+	if ag.params["repo_url"] != "/var/lib/jabali-backups/custom" {
+		t.Errorf("repo_url did not reach the agent — the restore reads the WRONG repo: %#v", ag.params["repo_url"])
 	}
 }


### PR DESCRIPTION
Follow-up to #1068, found by doing what that PR's test plan said it couldn't: **the full authenticated tenant flow, live** — Kratos session over HTTPS, a 456 MB Postgres database, a real per-destination backup.

## What the E2E caught (three more bugs, all one class)

**The restore, manifest, and DNS-read paths never tell the agent which repo the backup lives in.**

| Path | Symptom |
|---|---|
| `backup.restore_selective` dispatch | No repo params → agent reads the legacy default repo → restic retries ~50 s against a snapshot that was never there → **every tenant restore from a per-destination backup fails** "failed to find snapshot". The synchronous pre-#1068 code had the same omission all along |
| `backup.manifest_read` (agent) | Hardcoded default repo, with a *"remote-destination preview is a follow-up"* comment that never happened → the restore drawer's manifest call **hangs 30 s and 502s** for any per-destination backup |
| `backup.dns_read` (agent) | Same hardcode → DNS restore reads the wrong repo |
| Manifest handler error path | Echoed `err.Error()` — restic/host internals — to the tenant (JAB-114); now `respondAgentErr` |

Both agent verbs now accept the same destination wire contract as `backup.create` (empty = legacy default repo, unchanged for old rows). The panel resolves the **source backup's** destination and unseals its per-destination restic password (`WithOptionalDestPassword` — nil-dest tolerant, as are `destWireParams` now).

## The E2E that #1068 deferred — now done

Tenant session via the Kratos browser flow (curl + cookie jar), against the reporter's own scenario:

| Step | Result |
|---|---|
| POST restore, 456 MB pg database, per-destination backup | **HTTP 202 in 28 ms** |
| Job in tenant list | `kind=account_restore`, queued → running → **succeeded** |
| Outcome on the row | `{"applied":["db → restest1044_bigpg (postgres)"]}` — what the drawer renders |
| Content | table tampered to 100 rows → **3,000,000 rows restored**, verified by count |
| Manifest, database-only backup | `home skipped` → drawer hides the Home checkbox (item 3, negative case) |
| Manifest, full backup | `home ok` → checkbox shown (positive case) |
| Manifest latency | **1.5 s** where the pre-fix call hung 30 s into a 502 |

First failed live run is preserved in the job history: `restic … /var/lib/jabali-backups/repo/snapshots/…: no such file or directory` — the exact wrong-repo signature.

## Tests

- [x] `TestRunSelectiveRestoreJob_SendsTheSourceDestinationRepo` — wire-contract: `repo_url` must reach the agent (RED against #1068's code)
- [x] Existing runner/finalizer tests updated for the new signature, all passing; `go vet` clean, full `panel-api` + `panel-agent` suites 0 FAIL
- [x] E2E rig fully torn down (user, pg db, destination, schedule, repo, session jar, package flags reverted)