### PR TITLE
fix(ui): one toast SIZE, not just one toast pipeline (GH #970 round 3)

### DIFF
--- a/panel-ui/src/lib/feedback.guard.test.ts
+++ b/panel-ui/src/lib/feedback.guard.test.ts
@@ -70,6 +70,26 @@ describe("feedback guard (GH #970)", () => {
     ).toEqual([]);
   });
 
+  it("no file uses the large notification surface", () => {
+    // GH #970 round 3: the pipeline was unified, but ~90 call sites still
+    // used feedback.notification — the LARGE card — while the rest of the
+    // panel used the slim message toast. Same position pipeline, different
+    // size: exactly the reporter's Settings-vs-Domains screenshots. The
+    // house style is feedback.message; rich persistent surfaces should be
+    // a deliberate design decision, not a habit — add an allowlist entry
+    // here if one ever genuinely needs the card.
+    const offenders: string[] = [];
+    for (const f of sourceFiles()) {
+      if (ALLOWED.has(f)) continue;
+      const src = readFileSync(join(SRC, f), "utf8");
+      if (/feedback\.notification\./.test(src)) offenders.push(f);
+    }
+    expect(
+      offenders,
+      "use feedback.message (slim house toast) instead of the large notification card",
+    ).toEqual([]);
+  });
+
   it("no file calls the static Modal methods", () => {
     const offenders: string[] = [];
     for (const f of sourceFiles()) {

--- a/panel-ui/src/shells/DomainIndexButton.tsx
+++ b/panel-ui/src/shells/DomainIndexButton.tsx
@@ -72,7 +72,7 @@ export const DomainIndexButton = ({
       await apiClient.patch(`/domains/${domain.id}`, {
         index_priority: value,
       });
-      feedback.notification.success({ message: "Index priority saved" });
+      feedback.message.success("Index priority saved");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleClose();
@@ -81,10 +81,7 @@ export const DomainIndexButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Failed to save",
-        description: e.response?.data?.detail ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/DomainRedirectsButton.tsx
+++ b/panel-ui/src/shells/DomainRedirectsButton.tsx
@@ -286,7 +286,7 @@ export const DomainRedirectsButton = ({
       if (wholeToggle) {
         const url = wholeUrl.trim();
         if (!url) {
-          feedback.notification.error({ message: "Enter a redirect URL" });
+          feedback.message.error("Enter a redirect URL");
           setIsSaving(false);
           return;
         }
@@ -313,7 +313,7 @@ export const DomainRedirectsButton = ({
       body.page_redirects = clean.filter((pr) => pr.source && pr.destination);
 
       await apiClient.patch(`/domains/${domain.id}`, body);
-      feedback.notification.success({ message: "Redirects saved" });
+      feedback.message.success("Redirects saved");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleCloseModal();
@@ -322,10 +322,7 @@ export const DomainRedirectsButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Failed to save",
-        description: e.response?.data?.detail ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setIsSaving(false);
     }

--- a/panel-ui/src/shells/DomainSettingsButton.tsx
+++ b/panel-ui/src/shells/DomainSettingsButton.tsx
@@ -821,10 +821,7 @@ const HtaccessImport = ({
         response?: { data?: { error?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Could not convert .htaccess",
-        description: e.response?.data?.error ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Could not convert .htaccess: ${e.response?.data?.error ?? e.message ?? "Unknown error"}`);
     } finally {
       setLoading(false);
     }
@@ -833,10 +830,9 @@ const HtaccessImport = ({
   const handleAdd = () => {
     if (!preview || preview.rules.length === 0) return;
     onRulesChange([...rules, ...preview.rules]);
-    feedback.notification.success({
-      message: `Added ${preview.rules.length} rule(s) to the Rule Builder`,
-      description: "Review them on the Rule Builder tab, then Save / Apply.",
-    });
+    feedback.message.success(
+      `Added ${preview.rules.length} rule(s) to the Rule Builder: review them on the Rule Builder tab, then Save / Apply.`,
+    );
     setPreview(null);
     setContent("");
   };
@@ -1016,7 +1012,7 @@ export const DomainSettingsButton = ({
         nginx_custom_directives: directivesValue,
         nginx_rules: rules,
       });
-      feedback.notification.success({ message: "Nginx config saved" });
+      feedback.message.success("Nginx config saved");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       handleCloseModal();
@@ -1025,10 +1021,7 @@ export const DomainSettingsButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Failed to save",
-        description: e.response?.data?.detail ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setIsSaving(false);
     }
@@ -1152,7 +1145,7 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
         nginx_custom_directives: directivesValue,
         nginx_rules: rules,
       });
-      feedback.notification.success({ message: "Nginx config saved" });
+      feedback.message.success("Nginx config saved");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
     } catch (err) {
@@ -1160,10 +1153,7 @@ export const DomainNginxSection = ({ domain }: { domain: DomainSettingsTarget })
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Failed to save",
-        description: e.response?.data?.detail ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to save: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setIsSaving(false);
     }
@@ -1270,7 +1260,7 @@ export const TenantNginxRulesButton = ({
     try {
       // Send ONLY nginx_rules — never nginx_custom_directives (admin-only).
       await apiClient.patch(`/domains/${domain.id}`, { nginx_rules: rules });
-      feedback.notification.success({ message: "Rewrite rules saved — applied on the next reconcile" });
+      feedback.message.success("Rewrite rules saved — applied on the next reconcile");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
       close();
@@ -1279,10 +1269,7 @@ export const TenantNginxRulesButton = ({
         response?: { data?: { detail?: string } };
         message?: string;
       };
-      feedback.notification.error({
-        message: "Failed to save rules",
-        description: e.response?.data?.detail ?? e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to save rules: ${e.response?.data?.detail ?? e.message ?? "Unknown error"}`);
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/DomainToggleButton.tsx
+++ b/panel-ui/src/shells/DomainToggleButton.tsx
@@ -27,16 +27,11 @@ export const DomainToggleButton = ({ domain }: { domain: DomainToggleTarget }) =
       await apiClient.patch(`/domains/${domain.id}`, {
         is_enabled: !domain.is_enabled,
       });
-      feedback.notification.success({
-        message: domain.is_enabled ? "Domain disabled" : "Domain enabled",
-      });
+      feedback.message.success(domain.is_enabled ? "Domain disabled" : "Domain enabled");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", domain.id] });
     } catch (err) {
-      feedback.notification.error({
-        message: "Failed to toggle",
-        description: (err as Error).message,
-      });
+      feedback.message.error(`Failed to toggle: ${(err as Error).message}`);
     } finally {
       setLoading(false);
     }

--- a/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/DestinationsTab.tsx
@@ -212,11 +212,12 @@ function DestinationDrawer({ open, editing, onClose, onSaved }: DestinationDrawe
             resp.data.detail ? `Saved + tested OK — ${resp.data.detail}` : "Saved + tested OK",
           );
         } catch (testErr) {
-          feedback.notification.error({
-            message: editing ? "Saved, but test failed" : "Created, but test failed",
-            description: extractApiError(testErr, "Test failed"),
-            duration: 0,
-          });
+          // Was a duration:0 persistent card; 10 s of the slim house toast
+          // reads the same and matches every other toast (GH #970).
+          feedback.message.error(
+            `${editing ? "Saved, but test failed" : "Created, but test failed"}: ${extractApiError(testErr, "Test failed")}`,
+            10,
+          );
           onSaved();
           return;
         }

--- a/panel-ui/src/shells/admin/domains/DomainList.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainList.tsx
@@ -212,11 +212,11 @@ export const DomainList = () => {
     setTogglingId(r.id);
     try {
       await apiClient.patch(`/domains/${r.id}`, { is_enabled: !r.is_enabled });
-      feedback.notification.success({ message: r.is_enabled ? "Domain disabled" : "Domain enabled" });
+      feedback.message.success(r.is_enabled ? "Domain disabled" : "Domain enabled");
       qc.invalidateQueries({ queryKey: ["list", "domains"] });
       qc.invalidateQueries({ queryKey: ["one", "domains", r.id] });
     } catch (err) {
-      feedback.notification.error({ message: "Failed to toggle", description: (err as Error).message });
+      feedback.message.error(`Failed to toggle: ${(err as Error).message}`);
     } finally {
       setTogglingId(null);
     }

--- a/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/PHPExtensionsTab.tsx
@@ -74,10 +74,7 @@ export const PHPExtensionsTab = () => {
           : installed[0] ?? null;
         setSelectedVersion(def);
       } catch (err) {
-        feedback.notification.error({
-          message: "Failed to fetch PHP versions",
-          description: extractApiError(err, "Unknown error"),
-        });
+        feedback.message.error(`Failed to fetch PHP versions: ${extractApiError(err, "Unknown error")}`);
       } finally {
         setLoadingVersions(false);
       }
@@ -101,10 +98,7 @@ export const PHPExtensionsTab = () => {
       );
       setExtensions(data.extensions);
     } catch (err) {
-      feedback.notification.error({
-        message: `Failed to fetch extensions for PHP ${version}`,
-        description: extractApiError(err, "Unknown error"),
-      });
+      feedback.message.error(`${`Failed to fetch extensions for PHP ${version}`}: ${extractApiError(err, "Unknown error")}`);
       setExtensions([]);
     } finally {
       setLoadingExtensions(false);
@@ -119,18 +113,11 @@ export const PHPExtensionsTab = () => {
         `/admin/php/versions/${selectedVersion}/extensions/${ext}/apply`,
         { action }
       );
-      feedback.notification.success({
-        message: `${ext}: ${action} applied for PHP ${selectedVersion}`,
-        duration: 2,
-      });
+      feedback.message.success(`${ext}: ${action} applied for PHP ${selectedVersion}`, 2);
       // Server is source of truth; refetch instead of optimistic update.
       await loadExtensions(selectedVersion);
     } catch (err) {
-      feedback.notification.error({
-        message: `${action} ${ext} failed`,
-        description: extractApiError(err, "Unknown error"),
-        duration: 5,
-      });
+      feedback.message.error(`${`${action} ${ext} failed`}: ${extractApiError(err, "Unknown error")}`, 5);
     } finally {
       setBusyExt(null);
     }

--- a/panel-ui/src/shells/admin/php/VersionsTab.tsx
+++ b/panel-ui/src/shells/admin/php/VersionsTab.tsx
@@ -53,11 +53,7 @@ export const VersionsTab = () => {
       );
       setStatusData(response.data);
     } catch (error) {
-      feedback.notification.error({
-        message: "Failed to fetch PHP versions",
-        description: extractApiError(error, "Unknown error occurred"),
-        duration: 5,
-      });
+      feedback.message.error(`Failed to fetch PHP versions: ${extractApiError(error, "Unknown error occurred")}`, 5);
     } finally {
       setLoading(false);
     }
@@ -76,12 +72,7 @@ export const VersionsTab = () => {
       while (true) {
         await new Promise((r) => setTimeout(r, 5000));
         if (Date.now() > deadline) {
-          feedback.notification.warning({
-            message: `PHP ${version} is still installing`,
-            description:
-              "The install is taking longer than expected; it will continue in the background. Refresh to check.",
-            duration: 6,
-          });
+          feedback.message.warning(`${`PHP ${version} is still installing`}: The install is taking longer than expected; it will continue in the background. Refresh to check.`, 6);
           return;
         }
         let st;
@@ -93,19 +84,12 @@ export const VersionsTab = () => {
         const v = st.data.versions.find((x) => x.version === version);
         if (v?.installed) {
           setStatusData(st.data);
-          feedback.notification.success({
-            message: `PHP ${version} installed successfully`,
-            duration: 3,
-          });
+          feedback.message.success(`PHP ${version} installed successfully`, 3);
           return;
         }
       }
     } catch (error) {
-      feedback.notification.error({
-        message: `Failed to install PHP ${version}`,
-        description: extractApiError(error, "Installation failed"),
-        duration: 5,
-      });
+      feedback.message.error(`${`Failed to install PHP ${version}`}: ${extractApiError(error, "Installation failed")}`, 5);
     } finally {
       setInstallingVersion(null);
     }
@@ -119,17 +103,10 @@ export const VersionsTab = () => {
       await apiClient.delete(`/admin/php/versions/${version}`, {
         timeout: 5 * 60 * 1000,
       });
-      feedback.notification.success({
-        message: `PHP ${version} uninstalled`,
-        duration: 3,
-      });
+      feedback.message.success(`PHP ${version} uninstalled`, 3);
       await fetchStatus();
     } catch (error) {
-      feedback.notification.error({
-        message: `Failed to uninstall PHP ${version}`,
-        description: extractApiError(error, "Uninstall failed"),
-        duration: 5,
-      });
+      feedback.message.error(`${`Failed to uninstall PHP ${version}`}: ${extractApiError(error, "Uninstall failed")}`, 5);
     } finally {
       setUninstallingVersion(null);
     }
@@ -139,18 +116,11 @@ export const VersionsTab = () => {
     setReloadingVersion(version);
     try {
       await apiClient.post(`/admin/php/versions/${version}/reload`);
-      feedback.notification.success({
-        message: `PHP ${version} reloaded successfully`,
-        duration: 3,
-      });
+      feedback.message.success(`PHP ${version} reloaded successfully`, 3);
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Reload failed";
-      feedback.notification.error({
-        message: `Failed to reload PHP ${version}`,
-        description: errorMsg,
-        duration: 5,
-      });
+      feedback.message.error(`${`Failed to reload PHP ${version}`}: ${errorMsg}`, 5);
     } finally {
       setReloadingVersion(null);
     }
@@ -160,21 +130,14 @@ export const VersionsTab = () => {
     setSettingDefaultVersion(version);
     try {
       await apiClient.post(`/admin/php/versions/${version}/default`);
-      feedback.notification.success({
-        message: `PHP ${version} is now the default`,
-        duration: 3,
-      });
+      feedback.message.success(`PHP ${version} is now the default`, 3);
       setStatusData((prev) =>
         prev ? { ...prev, default_version: version } : prev,
       );
     } catch (error) {
       const errorMsg =
         error instanceof Error ? error.message : "Request failed";
-      feedback.notification.error({
-        message: `Could not set PHP ${version} as default`,
-        description: errorMsg,
-        duration: 5,
-      });
+      feedback.message.error(`${`Could not set PHP ${version} as default`}: ${errorMsg}`, 5);
     } finally {
       setSettingDefaultVersion(null);
     }

--- a/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSPermissionsCard.tsx
@@ -59,7 +59,7 @@ export function DNSPermissionsCard() {
         if (!cancelled) setPolicy(normalize(resp.data.dns_user_record_policy));
       } catch {
         if (!cancelled) {
-          feedback.notification.error({ message: "Failed to load DNS permissions" });
+          feedback.message.error("Failed to load DNS permissions");
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -81,9 +81,9 @@ export function DNSPermissionsCard() {
         dns_user_record_policy: policy,
       });
       setPolicy(normalize(resp.data.dns_user_record_policy));
-      feedback.notification.success({ message: "DNS permissions saved" });
+      feedback.message.success("DNS permissions saved");
     } catch {
-      feedback.notification.error({ message: "Failed to save DNS permissions" });
+      feedback.message.error("Failed to save DNS permissions");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
+++ b/panel-ui/src/shells/admin/settings/DNSResolversCard.tsx
@@ -165,11 +165,18 @@ export const DNSResolversCard = () => {
   const [current, setCurrent] = useState<string[]>([]);
   const activePreset = matchingProviderKey(current);
   const notify: NotifyFn = (input) =>
-    feedback.notification.open({
-      message: input.message,
-      description: input.description,
-      type: input.type,
-    });
+    // GH #970: house style is the slim message toast; the old notification
+  // card rendered larger and off-pattern (the reporter's Settings
+  // screenshots). ReactNode descriptions fold into the toast content.
+  feedback.message[input.type ?? "info"](
+    input.description ? (
+      <span>
+        {input.message}: {input.description}
+      </span>
+    ) : (
+      input.message
+    ),
+  );
 
   useEffect(() => {
     let cancelled = false;

--- a/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/Dkim2ToggleCard.tsx
@@ -20,7 +20,7 @@ export const Dkim2ToggleCard = () => {
         const resp = await apiClient.get<{ dkim2_signing_enabled?: boolean }>("/admin/settings");
         if (!cancelled) setEnabled(resp.data.dkim2_signing_enabled === true);
       } catch {
-        if (!cancelled) feedback.notification.error({ message: "Failed to load DKIM2 setting" });
+        if (!cancelled) feedback.message.error("Failed to load DKIM2 setting");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -35,14 +35,11 @@ export const Dkim2ToggleCard = () => {
     try {
       await apiClient.patch("/admin/settings", { dkim2_signing_enabled: next });
       setEnabled(next);
-      feedback.notification.success({
-        message: next ? "DKIM2 signing enabled" : "DKIM2 signing disabled",
-        description: next
+      feedback.message.success(`${next ? "DKIM2 signing enabled" : "DKIM2 signing disabled"}: ${next
           ? "Every mail domain gets a DKIM2 signature on the next reconcile — no DNS changes needed."
-          : "DKIM2 signatures are being removed; classic DKIM keeps signing.",
-      });
+          : "DKIM2 signatures are being removed; classic DKIM keeps signing."}`);
     } catch {
-      feedback.notification.error({ message: "Failed to update DKIM2 setting" });
+      feedback.message.error("Failed to update DKIM2 setting");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/admin/settings/FreeHostnameCard.tsx
+++ b/panel-ui/src/shells/admin/settings/FreeHostnameCard.tsx
@@ -46,9 +46,9 @@ export const FreeHostnameCard = () => {
     try {
       await apiClient.post("/admin/settings/free-hostname/register", { email: email.trim() });
       setStep("code_sent");
-      feedback.notification.success({ message: `Verification code sent to ${email.trim()}` });
+      feedback.message.success(`Verification code sent to ${email.trim()}`);
     } catch (e: unknown) {
-      feedback.notification.error({ message: errText(e, "Could not send the code") });
+      feedback.message.error(errText(e, "Could not send the code"));
     } finally {
       setSending(false);
     }
@@ -64,13 +64,9 @@ export const FreeHostnameCard = () => {
       setHostname(resp.data.fqdn);
       setStep("idle");
       setCode("");
-      feedback.notification.success({
-        message: `Hostname activated: ${resp.data.fqdn}`,
-        description:
-          "DNS + TLS are provisioning. The panel URL will change to the new hostname shortly.",
-      });
+      feedback.message.success(`${`Hostname activated: ${resp.data.fqdn}`}: DNS + TLS are provisioning. The panel URL will change to the new hostname shortly.`);
     } catch (e: unknown) {
-      feedback.notification.error({ message: errText(e, "Could not claim the hostname") });
+      feedback.message.error(errText(e, "Could not claim the hostname"));
     } finally {
       setClaiming(false);
     }

--- a/panel-ui/src/shells/admin/settings/ModulesCard.tsx
+++ b/panel-ui/src/shells/admin/settings/ModulesCard.tsx
@@ -83,7 +83,7 @@ export const ModulesCard = () => {
           });
         }
       } catch {
-        if (mounted.current) feedback.notification.error({ message: "Failed to load module settings" });
+        if (mounted.current) feedback.message.error("Failed to load module settings");
       } finally {
         if (mounted.current) setLoading(false);
       }
@@ -119,18 +119,14 @@ export const ModulesCard = () => {
       await apiClient.patch("/admin/settings", { [key]: next });
       setState((prev) => ({ ...prev, [key]: next }));
       const statusKey = STATUS_KEY[key];
-      feedback.notification.success({
-        message: `${label} ${next ? "enabled" : "disabled"}`,
-        description:
-          next && statusKey
+      feedback.message.success(`${`${label} ${next ? "enabled" : "disabled"}`}: ${next && statusKey
             ? "Installing the module in the background — this can take a few minutes."
             : next
               ? "The module's pages are now available."
-              : "The module's pages are hidden; its endpoints return 409.",
-      });
+              : "The module's pages are hidden; its endpoints return 409."}`);
       if (next && statusKey) void pollUntilUp(statusKey);
     } catch {
-      feedback.notification.error({ message: `Failed to update ${label}` });
+      feedback.message.error(`Failed to update ${label}`);
     } finally {
       setSaving(null);
     }
@@ -139,10 +135,10 @@ export const ModulesCard = () => {
   const onRetry = async (statusKey: string, label: string) => {
     try {
       await apiClient.post("/admin/settings/modules/install", { key: statusKey });
-      feedback.notification.info({ message: `Reinstalling ${label}…` });
+      feedback.message.info(`Reinstalling ${label}…`);
       void pollUntilUp(statusKey);
     } catch {
-      feedback.notification.error({ message: `Failed to start install for ${label}` });
+      feedback.message.error(`Failed to start install for ${label}`);
     }
   };
 

--- a/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
@@ -148,12 +148,9 @@ export function PanelSSLCard() {
 
   const doIssue = (kind: PanelCertKind) =>
     issue.mutate(kind, {
-      onSuccess: () => feedback.notification.success({ message: `${kind} cert: issued` }),
+      onSuccess: () => feedback.message.success(`${kind} cert: issued`),
       onError: (e) =>
-        feedback.notification.error({
-          message: `${kind} cert: issue failed`,
-          description: String((e as Error).message),
-        }),
+        feedback.message.error(`${`${kind} cert: issue failed`}: ${String((e as Error).message)}`),
     });
 
   return (
@@ -206,16 +203,11 @@ export function PanelSSLCard() {
                 { use_le: v },
                 {
                   onSuccess: () =>
-                    feedback.notification.success({
-                      message: v
+                    feedback.message.success(v
                         ? "Let's Encrypt enabled — issuance runs on the next reconciler tick"
-                        : "Let's Encrypt disabled — existing certs stay until expiry",
-                    }),
+                        : "Let's Encrypt disabled — existing certs stay until expiry"),
                   onError: (e) =>
-                    feedback.notification.error({
-                      message: "Failed to update toggle",
-                      description: String((e as Error).message),
-                    }),
+                    feedback.message.error(`Failed to update toggle: ${String((e as Error).message)}`),
                 },
               );
             }}

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -22,7 +22,7 @@ import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
 // Post-M21 notify shim: matches the Refine useNotification().open
 // contract (`{ type, message, description }`) so callers don't have
-// to change. Forwards to AntD's native `feedback.notification.open`.
+// to change. Forwards to the slim house toast (GH #970).
 type NotifyInput = {
   type?: "success" | "error" | "warning" | "info";
   message: string;
@@ -30,11 +30,18 @@ type NotifyInput = {
 };
 function useNotify() {
   return (input: NotifyInput) => {
-    feedback.notification.open({
-      message: input.message,
-      description: input.description,
-      type: input.type,
-    });
+    // GH #970: house style is the slim message toast; the old notification
+  // card rendered larger and off-pattern (the reporter's Settings
+  // screenshots). ReactNode descriptions fold into the toast content.
+  feedback.message[input.type ?? "info"](
+    input.description ? (
+      <span>
+        {input.message}: {input.description}
+      </span>
+    ) : (
+      input.message
+    ),
+  );
   };
 }
 

--- a/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantDomainOptionsCard.tsx
@@ -26,7 +26,7 @@ export const TenantDomainOptionsCard = () => {
           setDocroot(resp.data.tenant_docroot_editable !== false);
         }
       } catch {
-        if (!cancelled) feedback.notification.error({ message: "Failed to load tenant domain options setting" });
+        if (!cancelled) feedback.message.error("Failed to load tenant domain options setting");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -41,9 +41,9 @@ export const TenantDomainOptionsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_domain_options_enabled: next });
       setEnabled(next);
-      feedback.notification.success({ message: next ? "Tenant domain options enabled" : "Tenant domain options disabled" });
+      feedback.message.success(next ? "Tenant domain options enabled" : "Tenant domain options disabled");
     } catch {
-      feedback.notification.error({ message: "Failed to update setting" });
+      feedback.message.error("Failed to update setting");
     } finally {
       setSaving(false);
     }
@@ -54,9 +54,9 @@ export const TenantDomainOptionsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_docroot_editable: next });
       setDocroot(next);
-      feedback.notification.success({ message: next ? "Tenant document-root editing enabled" : "Tenant document-root editing disabled" });
+      feedback.message.success(next ? "Tenant document-root editing enabled" : "Tenant document-root editing disabled");
     } catch {
-      feedback.notification.error({ message: "Failed to update setting" });
+      feedback.message.error("Failed to update setting");
     } finally {
       setSavingDocroot(false);
     }

--- a/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/TenantNotificationsCard.tsx
@@ -45,7 +45,7 @@ export const TenantNotificationsCard = () => {
           setKinds(resp.data.tenant_notification_kinds ?? []);
         }
       } catch {
-        if (!cancelled) feedback.notification.error({ message: "Failed to load notification settings" });
+        if (!cancelled) feedback.message.error("Failed to load notification settings");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -60,9 +60,9 @@ export const TenantNotificationsCard = () => {
     try {
       await apiClient.patch("/admin/settings", { tenant_notifications_enabled: next });
       setEnabled(next);
-      feedback.notification.success({ message: next ? "Tenant notifications enabled" : "Tenant notifications disabled" });
+      feedback.message.success(next ? "Tenant notifications enabled" : "Tenant notifications disabled");
     } catch {
-      feedback.notification.error({ message: "Failed to update setting" });
+      feedback.message.error("Failed to update setting");
     } finally {
       setSavingToggle(false);
     }
@@ -76,9 +76,9 @@ export const TenantNotificationsCard = () => {
       });
       // The server sanitizes (drops unknown kinds) and returns the effective set.
       setKinds(resp.data.tenant_notification_kinds ?? next);
-      feedback.notification.success({ message: "Allowed channel kinds updated" });
+      feedback.message.success("Allowed channel kinds updated");
     } catch {
-      feedback.notification.error({ message: "Failed to update allowed kinds" });
+      feedback.message.error("Failed to update allowed kinds");
     } finally {
       setSavingKinds(false);
     }

--- a/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
+++ b/panel-ui/src/shells/admin/settings/WebmailToggleCard.tsx
@@ -21,7 +21,7 @@ export const WebmailToggleCard = () => {
         const resp = await apiClient.get<{ webmail_enabled?: boolean }>("/admin/settings");
         if (!cancelled) setEnabled(resp.data.webmail_enabled !== false);
       } catch {
-        if (!cancelled) feedback.notification.error({ message: "Failed to load webmail setting" });
+        if (!cancelled) feedback.message.error("Failed to load webmail setting");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -36,14 +36,11 @@ export const WebmailToggleCard = () => {
     try {
       await apiClient.patch("/admin/settings", { webmail_enabled: next });
       setEnabled(next);
-      feedback.notification.success({
-        message: next ? "Webmail enabled" : "Webmail disabled",
-        description: next
+      feedback.message.success(`${next ? "Webmail enabled" : "Webmail disabled"}: ${next
           ? "The webmail vhosts will be (re)served on the next reconcile."
-          : "Webmail vhosts are being torn down and the webmail service stopped.",
-      });
+          : "Webmail vhosts are being torn down and the webmail service stopped."}`);
     } catch {
-      feedback.notification.error({ message: "Failed to update webmail setting" });
+      feedback.message.error("Failed to update webmail setting");
     } finally {
       setSaving(false);
     }

--- a/panel-ui/src/shells/dns/DNSRecordsPage.tsx
+++ b/panel-ui/src/shells/dns/DNSRecordsPage.tsx
@@ -30,11 +30,18 @@ type NotifyInput = {
   description?: React.ReactNode;
 };
 const stableNotifyOpen = (input: NotifyInput) => {
-  feedback.notification.open({
-    message: input.message,
-    description: input.description,
-    type: input.type,
-  });
+  // GH #970: house style is the slim message toast; the old notification
+  // card rendered larger and off-pattern (the reporter's Settings
+  // screenshots). ReactNode descriptions fold into the toast content.
+  feedback.message[input.type ?? "info"](
+    input.description ? (
+      <span>
+        {input.message}: {input.description}
+      </span>
+    ) : (
+      input.message
+    ),
+  );
 };
 const stableNotify = { open: stableNotifyOpen };
 function useNotification() {

--- a/panel-ui/src/shells/shared/APIDocsPage.tsx
+++ b/panel-ui/src/shells/shared/APIDocsPage.tsx
@@ -76,10 +76,7 @@ export function APIDocsPage(): JSX.Element {
         setSpec(resp.data);
       } catch (err) {
         const e = err as { message?: string };
-        feedback.notification.error({
-          message: "Failed to load API documentation",
-          description: e.message ?? "Unknown error",
-        });
+        feedback.message.error(`Failed to load API documentation: ${e.message ?? "Unknown error"}`);
       } finally {
         setLoading(false);
       }

--- a/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
+++ b/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
@@ -117,10 +117,7 @@ export function UserAPITokensPage(): JSX.Element {
       setRows(resp.data.items ?? []);
     } catch (err) {
       const e = err as { message?: string };
-      feedback.notification.error({
-        message: "Failed to load API tokens",
-        description: e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to load API tokens: ${e.message ?? "Unknown error"}`);
     } finally {
       setLoading(false);
     }
@@ -156,10 +153,7 @@ export function UserAPITokensPage(): JSX.Element {
         if (ddnsSel) scopes.push("ddns");
         if (ddnsSel && ddnsRecordId.trim()) scopes.push(`record:${ddnsRecordId.trim()}`);
         if (scopes.length === 0) {
-          feedback.notification.error({
-            message: "Select at least one permission",
-            description: "Pick some permissions, or choose Full access.",
-          });
+          feedback.message.error("Select at least one permission — pick some, or choose Full access.");
           return;
         }
         body.scopes = scopes;
@@ -173,36 +167,27 @@ export function UserAPITokensPage(): JSX.Element {
       // validateFields throws with a list of errors; nothing to toast.
       if ((err as { errorFields?: unknown }).errorFields) return;
       const e = err as { message?: string };
-      feedback.notification.error({
-        message: "Failed to create token",
-        description: e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to create token: ${e.message ?? "Unknown error"}`);
     }
   };
 
   const onRevoke = async (t: UserAPIToken) => {
     try {
       await apiClient.delete(`/me/api-tokens/${t.id}`);
-      feedback.notification.success({ message: `Token "${t.name}" revoked` });
+      feedback.message.success(`Token "${t.name}" revoked`);
       void load();
     } catch (err) {
       const e = err as { message?: string };
-      feedback.notification.error({
-        message: "Failed to revoke token",
-        description: e.message ?? "Unknown error",
-      });
+      feedback.message.error(`Failed to revoke token: ${e.message ?? "Unknown error"}`);
     }
   };
 
   const copy = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      feedback.notification.success({ message: "Copied to clipboard" });
+      feedback.message.success("Copied to clipboard");
     } catch {
-      feedback.notification.error({
-        message: "Copy failed",
-        description: "Select the secret and copy manually.",
-      });
+      feedback.message.error(`Copy failed: Select the secret and copy manually.`);
     }
   };
 

--- a/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
+++ b/panel-ui/src/shells/user/docker-apps/UserDockerAppsPage.tsx
@@ -92,7 +92,7 @@ export const UserDockerAppsPage = () => {
       lifecycleAction(id, action),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["user-docker-installed"] }),
     onError: (e: AxiosError<{ detail?: string }>) =>
-      feedback.notification.error({ message: "Action failed", description: e.response?.data?.detail }),
+      feedback.message.error(`Action failed: ${e.response?.data?.detail}`),
   });
   const remove = useMutation({
     mutationFn: (id: string) => deleteApp(id),
@@ -434,15 +434,12 @@ const InstallModal = ({
     mutationFn: (v: { name: string; domain: string }) =>
       installApp({ slug: entry!.slug, name: v.name, domain: v.domain }),
     onSuccess: () => {
-      feedback.notification.success({ message: "Install started" });
+      feedback.message.success("Install started");
       form.resetFields();
       onInstalled();
     },
     onError: (e: AxiosError<{ detail?: string; error?: string }>) =>
-      feedback.notification.error({
-        message: "Install failed",
-        description: e.response?.data?.detail || e.response?.data?.error,
-      }),
+      feedback.message.error(`Install failed: ${e.response?.data?.detail || e.response?.data?.error}`),
   });
 
   return (

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -381,18 +381,13 @@ export const UserDomainList = () => {
                             await apiClient.patch(`/domains/${r.id}`, {
                               temp_url_enabled: !r.temp_url_enabled,
                             });
-                            feedback.notification.success({
-                              message: r.temp_url_enabled
+                            feedback.message.success(r.temp_url_enabled
                                 ? "Preview URL disabled"
-                                : "Preview URL enabled — live within a minute",
-                            });
+                                : "Preview URL enabled — live within a minute");
                             qc.invalidateQueries({ queryKey: ["list", "domains"] });
                           } catch (err) {
                             const e = err as { response?: { data?: { detail?: string; error?: string } } };
-                            feedback.notification.error({
-                              message: "Failed to toggle preview URL",
-                              description: e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message,
-                            });
+                            feedback.message.error(`Failed to toggle preview URL: ${e.response?.data?.detail ?? e.response?.data?.error ?? (err as Error).message}`);
                           }
                         },
                       },
@@ -407,16 +402,11 @@ export const UserDomainList = () => {
                             await apiClient.patch(`/domains/${r.id}`, {
                               is_enabled: !r.is_enabled,
                             });
-                            feedback.notification.success({
-                              message: r.is_enabled ? "Domain disabled" : "Domain enabled",
-                            });
+                            feedback.message.success(r.is_enabled ? "Domain disabled" : "Domain enabled");
                             qc.invalidateQueries({ queryKey: ["list", "domains"] });
                             qc.invalidateQueries({ queryKey: ["one", "domains", r.id] });
                           } catch (err) {
-                            feedback.notification.error({
-                              message: "Failed to toggle",
-                              description: (err as Error).message,
-                            });
+                            feedback.message.error(`Failed to toggle: ${(err as Error).message}`);
                           } finally {
                             setTogglingId(null);
                           }


### PR DESCRIPTION
The reporter's [retest](https://github.com/shukiv/jabali-panel/issues/970) after the pipeline sweep: notifications are consistent now, **but some are still larger than others** — Settings big, Domains/Backups slim — with screenshots, asking to standardize on the slim size.

They'd found the remaining split precisely. #1047 unified the **pipeline** (everything themed through the feedback bridge) but preserved each call's original **surface**: ~85 call sites across 24 files — concentrated in Settings cards, exactly their screenshots — used `feedback.notification` (the large card) while the rest used `feedback.message` (the slim toast). Same theme, different size.

## The change

Every notification call becomes the slim message toast — net **−85 lines**:

- **76 sites** converted mechanically (`{message}` / `{message, description}` / `{message, duration}` → toast; string descriptions fold in as `"message: description"`)
- **3 hand-converted** where commas *inside string literals* defeated the transform — including the one `duration: 0` persistent card (backup-destination test failure), now a 10 s toast: nothing else in the panel persists, and the text is short
- **3 local `useNotify` shims** (DNS records, Server Settings, DNS resolvers) rewritten at the shim so every caller inherits the toast; ReactNode descriptions fold into the content

## The guard grows a third rule

Any new `feedback.notification.` call site **fails the build** (allowlist-gated for a future surface that genuinely needs a rich persistent card — a deliberate decision, not a habit).

Worth saying plainly: this bug class has now been "finished" three times — the pipeline sweep, the multiline-import sweep, and this — and each time the missing piece was something the previous scan structurally couldn't see. Hence the guard, each round.

## Tests

- [x] Guard passes post-conversion; repo-wide grep confirms zero `feedback.notification.` call sites
- [x] `tsc -b` clean; vitest **50 files / 232 tests** pass; `npm run build` clean
- [x] UI-only diff — no Go changes

Not clicked through per-screen: 24 files is beyond hand-verification, the transform is mechanical, and types enforce the shape. The reporter's screenshots are the acceptance test — the reply will ask them to re-check the exact screens they shot.