### PR TITLE
fix(mail-cert): say the dns_missing recheck out loud (GH #723)

### DIFF
--- a/panel-agent/internal/commands/ssl_mail_issue.go
+++ b/panel-agent/internal/commands/ssl_mail_issue.go
@@ -209,7 +209,11 @@ func sslMailIssueHandler(ctx context.Context, params json.RawMessage) (any, erro
 				Domain:  p.Domain,
 				SANs:    allSANs,
 				DNS:     dns,
-				Detail:  fmt.Sprintf("%s must resolve to %s before a mail certificate can be issued", allSANs[0], p.PublicIP),
+				// GH #723: two reporters read this as a dead-end error and
+				// waited/worried. Say the recheck out loud — the panel
+				// retries every 3 minutes (MarkDNSMissing) and issues the
+				// moment public DNS shows the record.
+				Detail: fmt.Sprintf("%s must resolve to %s before a mail certificate can be issued; rechecked automatically every few minutes", allSANs[0], p.PublicIP),
 			}, nil
 		}
 		// Fold in autoconfig/autodiscover/mta-sts only when each


### PR DESCRIPTION
Two reporters (GH #276 era, now #723's second comment) have quoted `mail.X must resolve to IP before a mail certificate can be issued` back at us as an alarming error. It's the **designed pre-flight**: `ssl.mail.issue` parks the cert as `dns_missing` and the panel rechecks **every 3 minutes** at zero Let's Encrypt quota, issuing the moment public DNS shows the record. The message just never said so — it reads as a dead end.

One string change:

> `mail.X must resolve to 1.2.3.4 before a mail certificate can be issued; rechecked automatically every few minutes`

Coordinated with the #723 thread owner (jabali2-GH-Stable session) so their upcoming reply can quote the shipped wording.

- [x] `panel-agent` suite 0 FAIL; no test pins the old string
- [x] Behaviour untouched — detail copy only