### PR TITLE
fix(ui): mobile admin nav single-tap + footer flows, not fixed (GH #1066)

### DIFF
--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -80,8 +80,10 @@ export function AdminLayout() {
         icon: n.icon,
         // Right-placed hover tooltip explaining the tab (mouseEnterDelay keeps it
         // from flashing while scanning the list). Falls back to the plain label
-        // when an item has no description.
-        label: n.description ? (
+        // when an item has no description. DESKTOP ONLY (GH #1066): on touch the
+        // tooltip swallows the first tap — the user has to tap twice to navigate.
+        // The mobile Drawer shows full labels, so the tooltip adds nothing there.
+        label: isDesktop && n.description ? (
           <Tooltip title={t(n.description)} placement="right" mouseEnterDelay={0.4}>
             <span>{t(n.label)}</span>
           </Tooltip>
@@ -103,15 +105,19 @@ export function AdminLayout() {
   }, [location.pathname]);
 
   return (
-    <Layout style={{ height: "100vh", overflow: "hidden" }}>
+    // GH #1066: desktop keeps the fixed app-shell (header + sidebar pinned, only
+    // Content scrolls). On mobile that pins the version footer to the bottom of a
+    // viewport-height scroll box, eating screen space on short pages — so mobile
+    // uses natural document scroll (minHeight) and the footer flows after content.
+    <Layout style={isDesktop ? { height: "100vh", overflow: "hidden" } : { minHeight: "100vh" }}>
       <JabaliHeader
         showMenuButton={!isDesktop}
         onMenuClick={() => setDrawerOpen(true)}
         searchNav={visibleNav}
       />
       {/* Row sized to the viewport minus the 64px header, so the sidebar +
-          header stay fixed and only the Content region scrolls. */}
-      <Layout style={{ height: "calc(100vh - 64px)" }}>
+          header stay fixed and only the Content region scrolls (desktop only). */}
+      <Layout style={isDesktop ? { height: "calc(100vh - 64px)" } : undefined}>
         {isDesktop ? (
           <Sider
             theme={mode}
@@ -174,7 +180,7 @@ export function AdminLayout() {
             {menu}
           </Drawer>
         )}
-        <Layout style={{ height: "100%", overflowY: "auto" }}>
+        <Layout style={isDesktop ? { height: "100%", overflowY: "auto" } : undefined}>
           <Content
             style={{
               // Extra top gap so the page heading breathes away from


### PR DESCRIPTION
## Report (lxsdevcode, mobile testing)
Two admin-shell mobile UX problems:
1. **Menu tooltips swallow the first tap** — tapping a sidebar item shows its tooltip; you have to tap again to navigate.
2. **Version footer is fixed** — it stays pinned while scrolling, eating scarce phone space.

## Root cause (both in `AdminLayout.tsx`)
1. The menu (shared by the desktop `Sider` **and** the mobile `Drawer`) wraps each label in a right-placed hover `<Tooltip>`. On touch there's no hover, so the first tap surfaces the tooltip and eats the navigation.
2. AdminLayout is a fixed-height app-shell: `height:100vh; overflow:hidden`, the row is `calc(100vh - 64px)`, and only `Content` scrolls. On a short page the footer sits at the bottom of that viewport-height box → looks pinned.

(`UserLayout` already uses `minHeight:100vh` + no menu tooltip, so the tenant shell needed no change — this is admin-only.)

## Fix
Both gated on `isDesktop` (desktop unchanged, per the issue):
- Menu label: only wrap in `<Tooltip>` on desktop → the mobile Drawer shows full labels and **one tap navigates**.
- Layout: on mobile, drop the fixed-height app-shell (`minHeight:100vh`, remove the `calc(100vh-64px)` row + the inner `overflowY:auto`) → **natural document scroll, footer flows after content**.

## Verification
`tsc -b` clean; no AdminLayout tests to affect; desktop code path byte-for-byte unchanged. Mobile behavior to be visually confirmed on jabalitests at a phone viewport after deploy (single-tap nav + footer scrolls with content).

GH #1066