### PR TITLE
fix(reconciler): jabali-preview-fallback is a system vhost, not an orphan (JAB-236 follow-up)

### DIFF
--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -934,6 +934,13 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 		"000-default":     true,
 		"000-default-ssl": true,
 		"jabali-panel":    true,
+		// The *.preview.<hostname> catch-all vhost (preview_fallback_vhost.go)
+		// — a system site with no domain row, flagged as an orphan on every
+		// report since the sweep learned to aggregate (JAB-236). It is not
+		// deletable through the teardown executor either (no dot — fails the
+		// agent's domain validation), so listing it only invites a doomed
+		// manual cleanup attempt.
+		"jabali-preview-fallback": true,
 	}
 
 	// JAB-236: drive pending teardown tombstones FIRST — a site being torn


### PR DESCRIPTION
One-liner: the `*.preview.<hostname>` catch-all vhost (`jabali-preview-fallback`) has no domain row by design, so the aggregated orphan report flagged it forever — observed live on jabalitests as the sole remaining "orphan" after sweeping the 17 real ones. It also can't be cleaned via the tombstone path (no dot → agent domain validation rejects), so listing it only invites a doomed cleanup attempt. Added to `knownSystemSites`.

## Test plan
- [x] Reconciler suite green
- [x] Live: jabalitests orphan report showed exactly this one false positive after the real-orphan sweep
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)