### PR TITLE
fix(migrate): preserve source DB creds when dest account name differs (GH #723)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_appconfigs.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs.go
@@ -314,12 +314,19 @@ func rewriteWordPress(text string, creds map[string]DBCredential) (string, bool)
 	if !strings.Contains(text, "DB_NAME") {
 		return text, false
 	}
-	// Find the source DB_NAME first so we can match it against a credential.
-	var sourceDB string
+	// Find the source DB_NAME + DB_USER so we can match a credential and decide
+	// whether the config's user was recreated as a preserved compat user.
+	var sourceDB, sourceUser string
 	for _, m := range wpDefineRe.FindAllStringSubmatch(text, -1) {
-		if m[1] == "DB_NAME" {
-			sourceDB = m[2]
-			break
+		switch m[1] {
+		case "DB_NAME":
+			if sourceDB == "" {
+				sourceDB = m[2]
+			}
+		case "DB_USER":
+			if sourceUser == "" {
+				sourceUser = m[2]
+			}
 		}
 	}
 	creds2 := creds
@@ -340,14 +347,15 @@ func rewriteWordPress(text string, creds map[string]DBCredential) (string, bool)
 	// so the cPanel restore and the wordpress_ssh import apply one identical,
 	// proven rewriter (no drift). Behavior-preserving (same regex + php-escape,
 	// DB_HOST -> localhost).
-	// JAB-207: when a preserved compat user owns this MySQL account, the
-	// original password in the config is the one that authenticates — pass nil
-	// so DB_PASSWORD is left exactly as the source wrote it.
-	pass := &cred.Password
-	if cred.KeepSourcePassword {
-		pass = nil
+	// JAB-207 / GH #723: when the config's DB_USER was recreated as a preserved
+	// compat user (--preserve-source-state), the original user + password in the
+	// config are what authenticate — pass nil for both so they are left exactly
+	// as the source wrote them; only DB_NAME is namespaced + DB_HOST normalised.
+	user, pass := &cred.DBUser, &cred.Password
+	if cred.preservesUser(sourceUser) {
+		user, pass = nil, nil
 	}
-	return migrate.RewriteWPConfigDBFields(text, cred.DBName, cred.DBUser, pass, "localhost")
+	return migrate.RewriteWPConfigDBFields(text, cred.DBName, user, pass, "localhost")
 }
 
 var (
@@ -358,11 +366,17 @@ func rewriteJoomla(text string, creds map[string]DBCredential) (string, bool) {
 	if !strings.Contains(text, "public $db") {
 		return text, false
 	}
-	var sourceDB string
+	var sourceDB, sourceUser string
 	for _, m := range joomlaAssignRe.FindAllStringSubmatch(text, -1) {
-		if m[1] == "db" {
-			sourceDB = m[2]
-			break
+		switch m[1] {
+		case "db":
+			if sourceDB == "" {
+				sourceDB = m[2]
+			}
+		case "user":
+			if sourceUser == "" {
+				sourceUser = m[2]
+			}
 		}
 	}
 	cred, ok := creds[sourceDB]
@@ -375,16 +389,22 @@ func rewriteJoomla(text string, creds map[string]DBCredential) (string, bool) {
 	if !ok {
 		return text, false
 	}
+	// JAB-207 / GH #723: keep the original user + password when they were
+	// recreated as a preserved compat user (--preserve-source-state).
+	keep := cred.preservesUser(sourceUser)
 	out := joomlaAssignRe.ReplaceAllStringFunc(text, func(line string) string {
 		m := joomlaAssignRe.FindStringSubmatch(line)
 		switch m[1] {
 		case "db":
 			return fmt.Sprintf("public $db = '%s';", phpEscape(cred.DBName))
 		case "user":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("public $user = '%s';", phpEscape(cred.DBUser))
 		case "password":
-			if cred.KeepSourcePassword {
-				return m[0] // JAB-207: preserved compat hash owns this account
+			if keep {
+				return m[0]
 			}
 			return fmt.Sprintf("public $password = '%s';", phpEscape(cred.Password))
 		case "host":
@@ -425,11 +445,17 @@ func rewriteITFlow(text string, creds map[string]DBCredential) (string, bool) {
 	if !itflowAssignRe.MatchString(text) {
 		return text, false
 	}
-	var sourceDB string
+	var sourceDB, sourceUser string
 	for _, m := range itflowAssignRe.FindAllStringSubmatch(text, -1) {
-		if m[1] == "database" {
-			sourceDB = m[2]
-			break
+		switch m[1] {
+		case "database":
+			if sourceDB == "" {
+				sourceDB = m[2]
+			}
+		case "dbusername":
+			if sourceUser == "" {
+				sourceUser = m[2]
+			}
 		}
 	}
 	cred, ok := creds[sourceDB]
@@ -442,14 +468,23 @@ func rewriteITFlow(text string, creds map[string]DBCredential) (string, bool) {
 	if !ok {
 		return text, false
 	}
+	// JAB-207 / GH #723: keep the original user + password when they were
+	// recreated as a preserved compat user (--preserve-source-state).
+	keep := cred.preservesUser(sourceUser)
 	out := itflowAssignRe.ReplaceAllStringFunc(text, func(line string) string {
 		m := itflowAssignRe.FindStringSubmatch(line)
 		switch m[1] {
 		case "database":
 			return fmt.Sprintf("$database = '%s';", phpEscape(cred.DBName))
 		case "dbusername":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("$dbusername = '%s';", phpEscape(cred.DBUser))
 		case "dbpassword":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("$dbpassword = '%s';", phpEscape(cred.Password))
 		case "dbhost":
 			return "$dbhost = 'localhost';"
@@ -467,11 +502,17 @@ func rewriteDrupal(text string, creds map[string]DBCredential) (string, bool) {
 	if !strings.Contains(text, "'database'") {
 		return text, false
 	}
-	var sourceDB string
+	var sourceDB, sourceUser string
 	for _, m := range drupalKVRe.FindAllStringSubmatch(text, -1) {
-		if m[1] == "database" {
-			sourceDB = m[2]
-			break
+		switch m[1] {
+		case "database":
+			if sourceDB == "" {
+				sourceDB = m[2]
+			}
+		case "username":
+			if sourceUser == "" {
+				sourceUser = m[2]
+			}
 		}
 	}
 	cred, ok := creds[sourceDB]
@@ -484,14 +525,23 @@ func rewriteDrupal(text string, creds map[string]DBCredential) (string, bool) {
 	if !ok {
 		return text, false
 	}
+	// JAB-207 / GH #723: keep the original user + password when they were
+	// recreated as a preserved compat user (--preserve-source-state).
+	keep := cred.preservesUser(sourceUser)
 	out := drupalKVRe.ReplaceAllStringFunc(text, func(line string) string {
 		m := drupalKVRe.FindStringSubmatch(line)
 		switch m[1] {
 		case "database":
 			return fmt.Sprintf("'database' => '%s'", phpEscape(cred.DBName))
 		case "username":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("'username' => '%s'", phpEscape(cred.DBUser))
 		case "password":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("'password' => '%s'", phpEscape(cred.Password))
 		case "host":
 			return "'host' => 'localhost'"
@@ -512,11 +562,17 @@ func rewriteMagento(text string, creds map[string]DBCredential) (string, bool) {
 	if !strings.Contains(text, "'connection'") || !strings.Contains(text, "'dbname'") {
 		return text, false
 	}
-	var sourceDB string
+	var sourceDB, sourceUser string
 	for _, m := range magentoKVRe.FindAllStringSubmatch(text, -1) {
-		if m[1] == "dbname" {
-			sourceDB = m[2]
-			break
+		switch m[1] {
+		case "dbname":
+			if sourceDB == "" {
+				sourceDB = m[2]
+			}
+		case "username":
+			if sourceUser == "" {
+				sourceUser = m[2]
+			}
 		}
 	}
 	cred, ok := creds[sourceDB]
@@ -529,14 +585,23 @@ func rewriteMagento(text string, creds map[string]DBCredential) (string, bool) {
 	if !ok {
 		return text, false
 	}
+	// JAB-207 / GH #723: keep the original user + password when they were
+	// recreated as a preserved compat user (--preserve-source-state).
+	keep := cred.preservesUser(sourceUser)
 	out := magentoKVRe.ReplaceAllStringFunc(text, func(line string) string {
 		m := magentoKVRe.FindStringSubmatch(line)
 		switch m[1] {
 		case "dbname":
 			return fmt.Sprintf("'dbname' => '%s'", phpEscape(cred.DBName))
 		case "username":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("'username' => '%s'", phpEscape(cred.DBUser))
 		case "password":
+			if keep {
+				return m[0]
+			}
 			return fmt.Sprintf("'password' => '%s'", phpEscape(cred.Password))
 		case "host":
 			return "'host' => 'localhost'"

--- a/panel-api/internal/migrate/cpanel/restore_appconfigs_gh723_preserve_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_appconfigs_gh723_preserve_test.go
@@ -1,0 +1,167 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #723, round 2 — johnnyq re-tested on the shipped fix and it STILL rewrote
+// his config password when he chose to carry passwords over. The earlier fix
+// (#729 keying + JAB-207 KeepSourcePassword) only ever engaged when the
+// destination jabali account was named the SAME as the source panel account —
+// because the "keep the password" signal was gated on the source DB user name
+// colliding with the panel-managed `<target>_<db>` user. johnnyq's real
+// HestiaCP migrations name the new account differently from the source, so the
+// collision never fired, --preserve-source-state was ignored by the config
+// rewriter, and wp-config got a fresh temp password.
+//
+// The exact shape of johnnyq's backup: source account "notary", a WordPress DB
+// `notary_45635` whose DB user is spelled the same (`notary_45635`, HestiaCP's
+// `user_db` norm), migrated into a jabali account named DIFFERENTLY.
+//
+// johnnyq's actual wp-config.php DB block (verbatim):
+const gh723PreserveWPConfig = `<?php
+define( 'DB_NAME', 'notary_45635' );
+define( 'DB_USER', 'notary_45635' );
+define( 'DB_PASSWORD', 'e4eb22f97bb143151c95' );
+define( 'DB_HOST', 'localhost' );
+$table_prefix = 'wp_JV8O5_';
+require_once ABSPATH . 'wp-settings.php';
+`
+
+// a recreatable mysql_native_password hash, as HestiaCP's db.conf MD5= carries.
+const gh723NativeHash = "*0123456789ABCDEF0123456789ABCDEF01234567"
+
+// TestGH723_Preserve_KeepsSourceCreds_WhenDestNameDiffersFromSource is the
+// regression that four "fixed" posts missed: preserve ON, destination account
+// ("sewickley") named differently from the source ("notary"), the source DB
+// user recreated as a compat user. The migrated wp-config must keep its
+// ORIGINAL user + password (the recreated user authenticates with them) and
+// only have DB_NAME namespaced + DB_HOST normalised.
+func TestGH723_Preserve_KeepsSourceCreds_WhenDestNameDiffersFromSource(t *testing.T) {
+	extract := t.TempDir()
+	for _, db := range []string{"notary_45635", "notary_itflow"} {
+		if err := os.WriteFile(filepath.Join(extract, db+".mysql.sql"), []byte("-- dump\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	parsed := &ParsedTarball{
+		ExtractDir: extract,
+		SourceUser: "notary",
+		MySQLDumps: []string{
+			filepath.Join(extract, "notary_45635.mysql.sql"),
+			filepath.Join(extract, "notary_itflow.mysql.sql"),
+		},
+		// HestiaCP shape: one compat user per DB, spelled the same as the DB,
+		// carrying the native password hash + a grant on its own DB.
+		CompatUsers: []CompatUser{
+			{Name: "notary_45635", Host: "localhost", Hash: gh723NativeHash,
+				Grant: []CompatGrant{{SourceDB: "notary_45635", Privs: []string{"ALL"}}}},
+			{Name: "notary_itflow", Host: "localhost", Hash: gh723NativeHash,
+				Grant: []CompatGrant{{SourceDB: "notary_itflow", Privs: []string{"ALL"}}}},
+		},
+	}
+
+	// preserve = TRUE, target account "sewickley" (differs from source "notary").
+	res, err := ImportDatabases(
+		context.Background(),
+		gh723DBRepo{}, gh723DBUserRepo{}, gh723GrantRepo{},
+		&recordingAgent{},
+		parsed,
+		"01USERULID0000000000000000", "sewickley", true,
+	)
+	if err != nil {
+		t.Fatalf("ImportDatabases: %v", err)
+	}
+
+	// The compat pass must have marked the source user as preserved on BOTH DBs.
+	for _, srcDB := range []string{"notary_45635", "notary_itflow"} {
+		cred, ok := res.Credentials[srcDB]
+		if !ok {
+			t.Fatalf("res.Credentials missing %q (keys=%v)", srcDB, keysOf(res.Credentials))
+		}
+		if !cred.preservesUser(srcDB) {
+			t.Errorf("cred[%q].PreservedUsers=%v — the recreated source user %q must be preserved",
+				srcDB, cred.PreservedUsers, srcDB)
+		}
+	}
+
+	// End to end: rewriting johnnyq's real wp-config with these credentials must
+	// leave DB_USER + DB_PASSWORD exactly as the source wrote them.
+	out, changed := rewriteWordPress(gh723PreserveWPConfig, res.Credentials)
+	if !changed {
+		t.Fatalf("wp-config was not rewritten at all (DB_NAME should still change):\n%s", out)
+	}
+	// DB_NAME namespaced, DB_HOST normalised.
+	if !strings.Contains(out, "define('DB_NAME', 'sewickley_45635');") {
+		t.Errorf("DB_NAME must be namespaced to the destination:\n%s", out)
+	}
+	if !strings.Contains(out, "define('DB_HOST', 'localhost');") {
+		t.Errorf("DB_HOST must be normalised:\n%s", out)
+	}
+	// The crux: original user + password survive — kept VERBATIM, preserving
+	// johnnyq's original line formatting (only DB_NAME/DB_HOST are normalised).
+	if !strings.Contains(out, "define( 'DB_USER', 'notary_45635' );") {
+		t.Errorf("GH #723: DB_USER must stay the source user on the preserve path:\n%s", out)
+	}
+	if !strings.Contains(out, "define( 'DB_PASSWORD', 'e4eb22f97bb143151c95' );") {
+		t.Errorf("GH #723 REGRESSION: the source DB password was overwritten — this is the exact bug johnnyq re-reported:\n%s", out)
+	}
+	// And the namespaced destination user (panel-managed temp account) must NOT
+	// have been written into the config — that account is not what the app auths as.
+	if strings.Contains(out, "define('DB_USER', 'sewickley_45635')") {
+		t.Errorf("DB_USER was rewritten to the panel-managed user despite preserve:\n%s", out)
+	}
+}
+
+// TestGH723_Preserve_FallsBackToPanelCreds_WhenUserNotRecreated guards the
+// degradation edge the advisor flagged: preserve is ON but the source user's
+// hash format can't be recreated (ed25519 / auth socket / unsupported). The
+// compat user is NOT created, so the config must fall back to the panel-managed
+// credentials (which DO exist) rather than preserving creds that authenticate
+// against nothing.
+func TestGH723_Preserve_FallsBackToPanelCreds_WhenUserNotRecreated(t *testing.T) {
+	extract := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extract, "notary_45635.mysql.sql"), []byte("-- dump\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed := &ParsedTarball{
+		ExtractDir: extract,
+		SourceUser: "notary",
+		MySQLDumps: []string{filepath.Join(extract, "notary_45635.mysql.sql")},
+		CompatUsers: []CompatUser{
+			// NOT a native-password hash → IsNativePasswordHash false → skipped.
+			{Name: "notary_45635", Host: "localhost", Hash: "invalid-not-a-native-hash",
+				Grant: []CompatGrant{{SourceDB: "notary_45635", Privs: []string{"ALL"}}}},
+		},
+	}
+
+	res, err := ImportDatabases(
+		context.Background(),
+		gh723DBRepo{}, gh723DBUserRepo{}, gh723GrantRepo{},
+		&recordingAgent{},
+		parsed,
+		"01USERULID0000000000000000", "sewickley", true,
+	)
+	if err != nil {
+		t.Fatalf("ImportDatabases: %v", err)
+	}
+
+	cred := res.Credentials["notary_45635"]
+	if cred.preservesUser("notary_45635") {
+		t.Fatalf("user with an unrecreatable hash must NOT be marked preserved: %v", cred.PreservedUsers)
+	}
+
+	out, _ := rewriteWordPress(gh723PreserveWPConfig, res.Credentials)
+	// Falls back to the panel-managed rewrite: namespaced user, and the original
+	// password is gone (replaced by the panel-managed temp password).
+	if !strings.Contains(out, "define('DB_USER', 'sewickley_45635');") {
+		t.Errorf("fallback must rewrite DB_USER to the panel-managed user:\n%s", out)
+	}
+	if strings.Contains(out, "define('DB_PASSWORD', 'e4eb22f97bb143151c95');") {
+		t.Errorf("fallback must not keep a password no recreated user authenticates:\n%s", out)
+	}
+}

--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -51,20 +51,35 @@ type DBCredential struct {
 	DBUser   string
 	Password string // plaintext temp_pwd printed in the manifest line
 
-	// KeepSourcePassword suppresses the password rewrite in app configs.
+	// PreservedUsers is the set of ORIGINAL source DB users that were recreated
+	// on the destination with their native password HASH and granted on this
+	// DB's namespaced destination during a --preserve-source-state restore
+	// (JAB-207 / GH #723). When an app config's DB user is one of these, the
+	// rewriter keeps the config's ORIGINAL user + password untouched — that
+	// recreated user authenticates with the source password the file already
+	// holds — and only namespaces DB_NAME + normalises DB_HOST.
 	//
-	// Set when a --preserve-source-state compat user takes over the MySQL
-	// account this credential names, which happens whenever the source DB
-	// user is spelled the same as the panel-managed one (JAB-207). The
-	// agent's db_user.create runs an unconditional ALTER USER for the hash
-	// path — deliberately, so the preserved hash wins (GH #633) — so the
-	// account ends up authenticating with the ORIGINAL password while
-	// Password here holds a temp one that now matches nothing.
-	//
-	// The source config already carries the original password and it matched
-	// that hash on the source, so the correct move is to leave it alone:
-	// rewrite DB name/user/host, do not touch the password.
-	KeepSourcePassword bool
+	// This subsumes the earlier same-name-collision special case: whether the
+	// destination account keeps the source's name (source user == panel-managed
+	// user, so db_user.create ALTERs one account to the source hash) or is named
+	// differently (a second, source-named account is created), the config's user
+	// is a member here and its credentials are preserved. Empty on a preserve-off
+	// restore, or for a user we could NOT recreate (unsupported hash format) — in
+	// which case the rewriter falls back to the panel-managed credentials so the
+	// site still connects.
+	PreservedUsers map[string]bool
+}
+
+// preservesUser reports whether configUser — the DB user an app config file
+// references — was recreated as a preserved compat user for this DB. When true
+// the app-config rewriter keeps the config's original DB user + password (that
+// user authenticates with the source password already in the file) and only
+// namespaces DB_NAME / normalises DB_HOST.
+func (c DBCredential) preservesUser(configUser string) bool {
+	if configUser == "" || c.PreservedUsers == nil {
+		return false
+	}
+	return c.PreservedUsers[configUser]
 }
 
 // dbRestoreNameRe mirrors the agent's db.restore validation
@@ -137,10 +152,6 @@ func ImportDatabases(
 	// compat-user path, fix for the "migrated app sees Access denied"
 	// scar).
 	sourceToFinalDB := map[string]string{}
-	// managedUserToSourceDB maps a panel-managed MySQL user we create in this
-	// run back to the SOURCE db name its credential is keyed by. Used below to
-	// detect a compat user about to take over the same account (JAB-207).
-	managedUserToSourceDB := map[string]string{}
 	for _, dumpPath := range parsed.MySQLDumps {
 		finalName, base, ok := deriveDestDBName(dumpPath, targetUsername)
 		if !ok {
@@ -339,10 +350,6 @@ func ImportDatabases(
 									DBUser:   finalName,
 									Password: plainPwd,
 								}
-								// Remember which MySQL account this credential
-								// owns, so the compat pass below can tell when
-								// it is about to take that same account over.
-								managedUserToSourceDB[finalName] = base
 							}
 						}
 					}
@@ -402,28 +409,20 @@ func ImportDatabases(
 				res.Skipped = append(res.Skipped, fmt.Sprintf("compat_user %s: db_user.create: %v", u.Name, ucErr))
 				continue
 			}
-			// JAB-207. When the source MySQL user is spelled the same as the
-			// panel-managed one — the norm when the destination account keeps
-			// the source's name — the call above did not create a second
-			// account. It ALTERed the one the dump loop just made, replacing
-			// the temp password with the source hash. That is intended (GH
-			// #633: the preserved hash must win), but it silently invalidates
-			// the temp password the app-config rewriter is about to publish,
-			// and the migrated site then fails to connect while the summary
-			// reports success.
-			//
-			// The source config still holds the original password, which
-			// matched this hash on the source. So keep it: rewrite the DB
-			// name/user/host and leave the password alone.
-			if srcDB, collides := managedUserToSourceDB[u.Name]; collides {
-				if cred, have := res.Credentials[srcDB]; have {
-					cred.KeepSourcePassword = true
-					res.Credentials[srcDB] = cred
-				}
-				res.Skipped = append(res.Skipped, fmt.Sprintf(
-					"compat_user %s: shares the panel-managed user name — the source password hash is now authoritative for this account, so %s keeps its ORIGINAL password in app configs (the temp password reported above no longer applies)",
-					u.Name, u.Name))
-			}
+			// JAB-207 / GH #723. This compat user was created with the source's
+			// native password hash. db_user.create runs an unconditional ALTER
+			// USER for the hash path (deliberate — GH #633, the preserved hash
+			// must win): when the source user is spelled the same as the
+			// panel-managed one (destination account keeps the source's name) it
+			// ALTERs that one account to the source hash; when named differently
+			// it creates a second, source-named account. Either way the account
+			// authenticates with the ORIGINAL password, not the temp one the dump
+			// loop generated. So any app config that references THIS user must
+			// keep its original user + password (the source config already holds
+			// the password that matches this hash) — the rewriter only namespaces
+			// DB_NAME + normalises DB_HOST. Recorded per DB below, but only after
+			// the grant on the namespaced destination also succeeds, so we never
+			// promise a preserve for an account that can't actually reach the DB.
 			grantedDBs := 0
 			for _, g := range u.Grant {
 				finalDB, ok := sourceToFinalDB[g.SourceDB]
@@ -453,6 +452,17 @@ func ImportDatabases(
 					continue
 				}
 				grantedDBs++
+				// The recreated user now has both the source password hash and a
+				// grant on this DB's namespaced destination — so an app config
+				// pointing at (this DB, this user) keeps its original credentials.
+				// res.Credentials is keyed by the SOURCE DB name (g.SourceDB).
+				if cred, have := res.Credentials[g.SourceDB]; have {
+					if cred.PreservedUsers == nil {
+						cred.PreservedUsers = map[string]bool{}
+					}
+					cred.PreservedUsers[u.Name] = true
+					res.Credentials[g.SourceDB] = cred
+				}
 			}
 			compatCreated++
 			res.Skipped = append(res.Skipped, fmt.Sprintf(

--- a/panel-api/internal/migrate/cpanel/restore_dbs_jab207_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs_jab207_test.go
@@ -43,8 +43,9 @@ define('DB_HOST', 'localhost');
 			DBName:   "vidoflexco_db",
 			DBUser:   "vidoflexco_db",
 			Password: "TEMPgenerated26charvalue00",
-			// Set by the compat pass on a name collision.
-			KeepSourcePassword: true,
+			// Set by the compat pass once the source user was recreated with
+			// its native hash + granted on the namespaced destination.
+			PreservedUsers: map[string]bool{"vidoflexco_db": true},
 		},
 	}
 
@@ -59,7 +60,12 @@ define('DB_HOST', 'localhost');
 		t.Errorf("the original password must survive — it is what the preserved "+
 			"hash authenticates:\n%s", out)
 	}
-	// The rest still has to be rewritten; only the password is special.
+	// The preserved user must also survive (it is what the source password
+	// authenticates against).
+	if !strings.Contains(out, "define('DB_USER', 'vidoflexco_db');") {
+		t.Errorf("the original DB_USER must survive on the preserve path:\n%s", out)
+	}
+	// The rest still has to be rewritten; only user + password are special.
 	if !strings.Contains(out, "define('DB_HOST', 'localhost');") {
 		t.Errorf("DB_HOST should still be normalised:\n%s", out)
 	}
@@ -107,7 +113,8 @@ define('DB_USER', 'b');
 define('DB_PASSWORD', 'keepme');
 define('DB_HOST', 'oldhost');
 `
-	out, changed := migrate.RewriteWPConfigDBFields(in, "newdb", "newuser", nil, "localhost")
+	newUser := "newuser"
+	out, changed := migrate.RewriteWPConfigDBFields(in, "newdb", &newUser, nil, "localhost")
 
 	if !strings.Contains(out, "define('DB_PASSWORD', 'keepme');") {
 		t.Errorf("nil password must leave DB_PASSWORD untouched:\n%s", out)
@@ -119,6 +126,36 @@ define('DB_HOST', 'oldhost');
 	}
 	if !changed {
 		t.Error("changed should be true — name/user/host did change")
+	}
+}
+
+// GH #723: a nil DB_USER must leave DB_USER untouched too — the preserve path
+// keeps both the original user and password (the recreated compat user
+// authenticates with the source password the file already holds).
+func TestRewriteWPConfigDBFields_NilUserLeavesItAlone(t *testing.T) {
+	t.Parallel()
+
+	const in = `<?php
+define('DB_NAME', 'oldname');
+define('DB_USER', 'keepuser');
+define('DB_PASSWORD', 'keeppass');
+define('DB_HOST', 'oldhost');
+`
+	out, changed := migrate.RewriteWPConfigDBFields(in, "newdb", nil, nil, "localhost")
+
+	if !strings.Contains(out, "define('DB_USER', 'keepuser');") {
+		t.Errorf("nil user must leave DB_USER untouched:\n%s", out)
+	}
+	if !strings.Contains(out, "define('DB_PASSWORD', 'keeppass');") {
+		t.Errorf("nil password must leave DB_PASSWORD untouched:\n%s", out)
+	}
+	// DB_NAME + DB_HOST still get namespaced/normalised.
+	if !strings.Contains(out, "define('DB_NAME', 'newdb');") ||
+		!strings.Contains(out, "define('DB_HOST', 'localhost');") {
+		t.Errorf("DB_NAME and DB_HOST must still be rewritten:\n%s", out)
+	}
+	if !changed {
+		t.Error("changed should be true — name/host did change")
 	}
 }
 
@@ -135,7 +172,8 @@ define('DB_PASSWORD', 'x');
 define('DB_HOST', 'h');
 `
 	pw := `pa'ss`
-	out, _ := migrate.RewriteWPConfigDBFields(in, "d", "u", &pw, "localhost")
+	usr := "u"
+	out, _ := migrate.RewriteWPConfigDBFields(in, "d", &usr, &pw, "localhost")
 	if !strings.Contains(out, `define('DB_PASSWORD', 'pa\'ss');`) {
 		t.Errorf("quote in the password was not escaped:\n%s", out)
 	}

--- a/panel-api/internal/migrate/wpconfig.go
+++ b/panel-api/internal/migrate/wpconfig.go
@@ -28,19 +28,22 @@ func phpSingleQuoteEscape(s string) string {
 // identical, proven rewrite. Values are PHP single-quote escaped.
 // RewriteWPConfigDB rewrites all four DB constants.
 func RewriteWPConfigDB(text, dbName, dbUser, dbPass, dbHost string) (string, bool) {
-	return RewriteWPConfigDBFields(text, dbName, dbUser, &dbPass, dbHost)
+	return RewriteWPConfigDBFields(text, dbName, &dbUser, &dbPass, dbHost)
 }
 
-// RewriteWPConfigDBFields rewrites the DB constants, leaving DB_PASSWORD alone
-// when dbPass is nil.
+// RewriteWPConfigDBFields rewrites the DB constants, leaving DB_USER and/or
+// DB_PASSWORD alone when the corresponding pointer is nil.
 //
-// Needed because a migrated site can legitimately have to KEEP the password
-// already in its config: under --preserve-source-state a compat user restores
-// the source password hash onto the very account the restore also manages, so
-// the original password is the one that authenticates and any value written in
-// its place would break the site (JAB-207). Writing a password that does not
-// work is strictly worse than writing none.
-func RewriteWPConfigDBFields(text, dbName, dbUser string, dbPass *string, dbHost string) (string, bool) {
+// Needed because a migrated site can legitimately have to KEEP the user and
+// password already in its config: under --preserve-source-state a compat user
+// restores the source password hash onto a user named exactly as the config
+// references, so the original user + password are what authenticate and any
+// value written in their place would break the site (JAB-207 / GH #723). The
+// DB name still has to change — jabali namespaces it (`<account>_<db>`) — and
+// DB_HOST is normalised to localhost; only the credentials the recreated compat
+// user backs are held. Writing credentials that do not work is strictly worse
+// than writing none.
+func RewriteWPConfigDBFields(text, dbName string, dbUser *string, dbPass *string, dbHost string) (string, bool) {
 	if !strings.Contains(text, "DB_NAME") {
 		return text, false
 	}
@@ -50,7 +53,10 @@ func RewriteWPConfigDBFields(text, dbName, dbUser string, dbPass *string, dbHost
 		case "DB_NAME":
 			return fmt.Sprintf("define('DB_NAME', '%s');", phpSingleQuoteEscape(dbName))
 		case "DB_USER":
-			return fmt.Sprintf("define('DB_USER', '%s');", phpSingleQuoteEscape(dbUser))
+			if dbUser == nil {
+				return line // keep whatever the source config had
+			}
+			return fmt.Sprintf("define('DB_USER', '%s');", phpSingleQuoteEscape(*dbUser))
 		case "DB_PASSWORD":
 			if dbPass == nil {
 				return line // keep whatever the source config had


### PR DESCRIPTION
## GH #723 — preserve-password ignored unless dest account name == source

johnnyq re-tested the shipped fix on a real HestiaCP migration with "carry
passwords over" ON and it **still** rewrote his `wp-config.php` password.

**Root cause (code-proven):** the "keep the source password" signal was gated on
the source DB user (`<source>_db`) colliding with the panel-managed
`<target>_db` user — which only happens when the destination jabali account is
named the **same** as the source panel account. Real migrations name the new
account differently, so the collision never fired, `--preserve-source-state` was
silently ignored by the config rewriter, and the migrated site got a fresh temp
password. Every prior verify used a same-name account, which is exactly why it
looked fixed.

## Fix

- Replace the collision-keyed `KeepSourcePassword` bool with
  `DBCredential.PreservedUsers` — the set of source users recreated as compat
  users (source hash) **and** granted on the namespaced destination, populated
  in the compat pass only after both `db_user.create` and the grant succeed.
- All five app-config rewriters (WordPress, Joomla, ITFlow, Drupal, Magento —
  the last three never honored preserve at all) now keep **both** the original
  DB user and password verbatim when the config's DB user is one of those
  recreated users, and namespace only `DB_NAME` + normalise `DB_HOST`.
- When the config references a user that could not be recreated (unsupported
  hash), the rewriter falls back to the panel-managed credentials so the site
  still connects.
- Subsumes the JAB-207 same-name case into a single path.

## Tests

- `TestGH723_Preserve_KeepsSourceCreds_WhenDestNameDiffersFromSource` reproduces
  johnnyq's exact `notary` backup shape (dest `sewickley` ≠ source `notary`) at
  the `ImportDatabases` seam + rewriter — the config keeps the source creds.
- `TestGH723_Preserve_FallsBackToPanelCreds_WhenUserNotRecreated` pins the
  unrecreatable-hash fallback.
- Shared `RewriteWPConfigDBFields` nil-user contract pinned; preserve-off
  behavior unchanged. `go test -race` + `vet` clean.

## Follow-up (not in this PR)
- Live synthetic-Hestia E2E on the test box (preserve ON, dest ≠ source) before
  stable promotion + the reporter reply.
- Adjacent, separate: resume/idempotency skip of credential population; the
  reporter's new "no mail A record" claim.