### PR TITLE
fix(migrate): recover app-config credential on a preserve-on resume (GH #723)

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_dbs.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs.go
@@ -173,6 +173,37 @@ func ImportDatabases(
 			res.AlreadyPresent++
 			res.Skipped = append(res.Skipped, fmt.Sprintf(
 				"%s: %q verified existing — left in place, not re-imported", dumpPath, finalName))
+			// GH #723 resume gap: this DB was imported by an earlier run, so we
+			// skip the re-import — but the earlier run may have died BEFORE the
+			// app-config rewrite. Without a credential entry here, the rewriter
+			// no-ops on resume and the app config is left pointing at the SOURCE
+			// DB name (which no longer exists once jabali namespaces it) →
+			// "Error establishing a database connection" that a resume never
+			// heals.
+			//
+			// Under --preserve-source-state we CAN recover safely: seed the
+			// namespaced (DBName, DBUser) so the compat pass below attaches the
+			// recreated source user (PreservedUsers) and the rewriter keeps the
+			// app config's ORIGINAL user + password while namespacing DB_NAME. No
+			// password of ours is needed, so nothing is guessed or reset.
+			//
+			// With preserve OFF the panel-managed user's temp password was random
+			// and never persisted, and the plaintext db_user.create path does not
+			// ALTER an existing user — so there is no correct password to write on
+			// resume. Leave the config untouched (as before) and say so, rather
+			// than publish an empty/guessed password that also fails to connect.
+			if preserveCredentials {
+				if res.Credentials == nil {
+					res.Credentials = map[string]DBCredential{}
+				}
+				if _, have := res.Credentials[base]; !have {
+					res.Credentials[base] = DBCredential{DBName: finalName, DBUser: finalName}
+				}
+			} else {
+				res.Skipped = append(res.Skipped, fmt.Sprintf(
+					"%s: on resume the panel-managed password can't be recovered (preserve off) — if the app still shows a DB-connection error, reset %q's password in the panel and update the app config",
+					dumpPath, finalName))
+			}
 			continue
 		}
 

--- a/panel-api/internal/migrate/cpanel/restore_dbs_resume_gh723_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_dbs_resume_gh723_test.go
@@ -1,0 +1,118 @@
+package cpanel
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// gh723ResumeDBRepo simulates a RESUME: the destination DB already exists, so
+// ImportDatabases takes the AlreadyPresent path and skips the re-import.
+type gh723ResumeDBRepo struct{ repository.DatabaseRepository }
+
+func (gh723ResumeDBRepo) ExistsByUserAndName(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+
+// GH #723 resume gap: an earlier run imported the DB but died before the
+// app-config rewrite. On resume the DB is AlreadyPresent → the dump loop skips
+// it → without a credential the rewriter no-ops and the config keeps the dead
+// source DB name. Under --preserve-source-state the resume must still seed the
+// namespaced credential so the compat pass keeps the source creds and the
+// config is namespaced.
+func TestGH723_Resume_PreserveOn_RecoversCredential(t *testing.T) {
+	extract := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extract, "notary_45635.mysql.sql"), []byte("-- dump\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed := &ParsedTarball{
+		ExtractDir: extract,
+		SourceUser: "notary",
+		MySQLDumps: []string{filepath.Join(extract, "notary_45635.mysql.sql")},
+		CompatUsers: []CompatUser{
+			{Name: "notary_45635", Host: "localhost", Hash: gh723NativeHash,
+				Grant: []CompatGrant{{SourceDB: "notary_45635", Privs: []string{"ALL"}}}},
+		},
+	}
+
+	res, err := ImportDatabases(
+		context.Background(),
+		gh723ResumeDBRepo{}, gh723DBUserRepo{}, gh723GrantRepo{},
+		&recordingAgent{},
+		parsed,
+		"01USERULID0000000000000000", "sewickley", true, // preserve ON
+	)
+	if err != nil {
+		t.Fatalf("ImportDatabases: %v", err)
+	}
+	if res.AlreadyPresent != 1 {
+		t.Fatalf("want AlreadyPresent=1 (resume path), got %d", res.AlreadyPresent)
+	}
+
+	cred, ok := res.Credentials["notary_45635"]
+	if !ok {
+		t.Fatalf("resume must seed the credential keyed by the source DB name (keys=%v)", keysOf(res.Credentials))
+	}
+	if cred.DBName != "sewickley_45635" {
+		t.Errorf("cred.DBName = %q, want namespaced sewickley_45635", cred.DBName)
+	}
+	if !cred.preservesUser("notary_45635") {
+		t.Errorf("compat pass must mark the recreated source user preserved on resume: %v", cred.PreservedUsers)
+	}
+
+	// The rewriter then keeps the source creds + namespaces DB_NAME.
+	out, changed := rewriteWordPress(gh723PreserveWPConfig, res.Credentials)
+	if !changed {
+		t.Fatalf("wp-config not rewritten on resume:\n%s", out)
+	}
+	if !strings.Contains(out, "define('DB_NAME', 'sewickley_45635');") {
+		t.Errorf("DB_NAME must be namespaced on resume:\n%s", out)
+	}
+	if !strings.Contains(out, "define( 'DB_PASSWORD', 'e4eb22f97bb143151c95' );") {
+		t.Errorf("resume must keep the source password (preserve on):\n%s", out)
+	}
+}
+
+// With preserve OFF, resume can't recover the panel-managed temp password, so it
+// deliberately does NOT seed a credential (no empty/guessed password) — and says
+// so in the summary.
+func TestGH723_Resume_PreserveOff_DoesNotPopulate(t *testing.T) {
+	extract := t.TempDir()
+	if err := os.WriteFile(filepath.Join(extract, "notary_45635.mysql.sql"), []byte("-- dump\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	parsed := &ParsedTarball{
+		ExtractDir: extract,
+		SourceUser: "notary",
+		MySQLDumps: []string{filepath.Join(extract, "notary_45635.mysql.sql")},
+	}
+
+	res, err := ImportDatabases(
+		context.Background(),
+		gh723ResumeDBRepo{}, gh723DBUserRepo{}, gh723GrantRepo{},
+		&recordingAgent{},
+		parsed,
+		"01USERULID0000000000000000", "sewickley", false, // preserve OFF
+	)
+	if err != nil {
+		t.Fatalf("ImportDatabases: %v", err)
+	}
+	if _, ok := res.Credentials["notary_45635"]; ok {
+		t.Errorf("preserve-off resume must not seed a credential (no recoverable password), got one")
+	}
+	// A clear warning must be present so the operator knows to reset the password.
+	found := false
+	for _, s := range res.Skipped {
+		if strings.Contains(s, "password can't be recovered") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("preserve-off resume must warn that the password can't be recovered; skipped=%v", res.Skipped)
+	}
+}


### PR DESCRIPTION
## GH #723 (adjacent resume edge)

If an earlier migration run imported a database but died **before** the app-config rewrite, a resume hits the `AlreadyPresent` path in `ImportDatabases` and skips populating `res.Credentials`. The config rewriter then no-ops, and the app config is left pointing at the **source** DB name (gone once jabali namespaces it) → "Error establishing a database connection" that a resume never heals.

Not the reporter's current symptom (his configs *were* rewritten, just wrongly — fixed in #1075), but a real crash-recovery gap surfaced during that investigation.

## Fix

- **Preserve on:** seed the namespaced `(DBName, DBUser)` on the `AlreadyPresent` path so the compat pass attaches the recreated source user (`PreservedUsers`) and the rewriter keeps the config's **original** user + password while namespacing `DB_NAME`. No password of ours is needed — nothing is guessed or reset, no DB writes.
- **Preserve off:** the panel-managed temp password was random and never persisted (the plaintext `db_user.create` path does not `ALTER` an existing user), so there's no correct password to write on resume. Leave the config as-is and emit a clear "reset the password in the panel" warning rather than publish a guess.

## Tests / verification

Deterministic seam tests: preserve-on resume seeds the namespaced credential + keeps source creds; preserve-off resume seeds nothing and warns. `go vet` + full `migrate/cpanel` suite green.

A live repro needs a migration crashing between the MySQL import and the app-config step (contrived) — the seam tests cover it deterministically. The change only adds an in-memory credential entry (gated on preserve-on); it performs no DB writes.

## Follow-up
Stable promotion is a separate operator ask (bundled with the other GH #723 fixes on main).