### PR TITLE
feat(backups): make restore jobs read as restores, not backups (GH #1044)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -586,7 +586,10 @@ func (h *backupHandler) delete(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
 		return
 	}
-	if h.cfg.Agent != nil {
+	// GH #1044: a restore job owns no restic snapshot, so there is nothing to
+	// forget — skip straight to dropping the row. Calling backup.forget for it
+	// would ask the agent to prune a snapshot that never existed.
+	if h.cfg.Agent != nil && !isRestoreKind(job.Kind) {
 		if err := h.forgetBackup(c, job); err != nil {
 			return // forgetBackup wrote the response; leave the row
 		}
@@ -743,6 +746,15 @@ func (h *backupHandler) logs(c *gin.Context) {
 	job, err := h.cfg.Jobs.Get(c.Request.Context(), jobID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
+		return
+	}
+	// GH #1044: a restore never writes the agent's per-job backup log file — its
+	// result (applied/skipped/warnings for selective, stages for full) lives on
+	// the job row. Render that as the log body instead of asking the agent for a
+	// file that is always "no log available". Before the agent check so the Logs
+	// action works even when the agent is momentarily unavailable.
+	if isRestoreKind(job.Kind) {
+		c.JSON(http.StatusOK, gin.H{"data": gin.H{"log_text": formatRestoreLog(job)}})
 		return
 	}
 	if h.cfg.Agent == nil {
@@ -998,11 +1010,20 @@ func (h *backupHandler) restore(c *gin.Context) {
 	}
 
 	destID := dest.ID
+	// GH #1044: inherit the SOURCE backup's content so restoring a
+	// database-only backup reads "Database Restore", not a generic "Account
+	// Restore". A missing source (snapshot deleted, or a cross-host snapshot)
+	// falls back to "full".
+	restoreContent := models.BackupContentFull
+	if src, serr := h.cfg.Jobs.FindBySnapshotID(c.Request.Context(), req.ManifestSnapshotID); serr == nil && src != nil && src.Content != "" {
+		restoreContent = models.NormalizeBackupContent(src.Content)
+	}
 	job := &models.BackupJob{
 		ID:            ids.NewULID(),
 		UserID:        req.TargetUserID,
 		DestinationID: &destID,
 		Kind:          models.BackupJobKindAccountRestore,
+		Content:       restoreContent,
 		CreatedAt:     time.Now().UTC(),
 		Status:        models.BackupJobStatusQueued,
 	}
@@ -1508,7 +1529,9 @@ func (h *meBackupHandler) delete(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "not_found"})
 		return
 	}
-	if h.cfg.Agent != nil {
+	// GH #1044: a restore job owns no restic snapshot — skip the forget and just
+	// drop the row (forgetting would prune a snapshot that never existed).
+	if h.cfg.Agent != nil && !isRestoreKind(job.Kind) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), backupCallTimeout)
 		defer cancel()
 		if _, err := h.cfg.Agent.Call(ctx, "backup.forget", map[string]any{
@@ -2538,9 +2561,12 @@ func (h *meBackupHandler) restoreSelective(c *gin.Context) {
 
 	// Track the restore as its own job so the jobs list + notifications cover it.
 	restoreJob := &models.BackupJob{
-		ID:        ids.NewULID(),
-		UserID:    claims.UserID,
-		Kind:      models.BackupJobKindAccountRestore,
+		ID:     ids.NewULID(),
+		UserID: claims.UserID,
+		Kind:   models.BackupJobKindAccountRestore,
+		// GH #1044: record what this restore actually touches so the list reads
+		// "Database Restore" (etc.) rather than the generic "Account Restore".
+		Content:   restoreContentFromSelective(req.Databases, req.Mailboxes, req.DNSDomains, req.Home),
 		CreatedAt: time.Now().UTC(),
 		Status:    models.BackupJobStatusQueued,
 	}

--- a/panel-api/internal/api/restore_view.go
+++ b/panel-api/internal/api/restore_view.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// restore_view — GH #1044. Restore jobs share the backup_jobs table + the
+// backup/restore lists. Two small pure helpers make a restore row read as a
+// restore rather than a backup: derive the job's Content (so the label reads
+// "Database Restore", not the generic "Account Restore") and render the stored
+// restore result as a log (so the Logs action shows what actually happened
+// instead of "no log available" — a restore never writes the agent's backup
+// log file).
+
+// isRestoreKind reports whether a backup_jobs row is a restore (as opposed to a
+// backup). Restores carry no restic snapshot and never write the agent's backup
+// log file, so several handlers branch on this.
+func isRestoreKind(kind string) bool {
+	return kind == models.BackupJobKindAccountRestore || kind == models.BackupJobKindSystemRestore
+}
+
+// restoreContentFromSelective maps a selective restore's requested scope to the
+// same Content vocabulary a backup uses, so the shared label logic can describe
+// it. databases-only -> "database", home-only -> "files", anything mixed (or
+// mailbox/DNS-only, which have no dedicated content bucket) -> "full".
+func restoreContentFromSelective(databases, mailboxes, dnsDomains []string, home bool) string {
+	onlyDatabases := len(databases) > 0 && !home && len(mailboxes) == 0 && len(dnsDomains) == 0
+	if onlyDatabases {
+		return models.BackupContentDatabase
+	}
+	onlyHome := home && len(databases) == 0 && len(mailboxes) == 0 && len(dnsDomains) == 0
+	if onlyHome {
+		return models.BackupContentFiles
+	}
+	return models.BackupContentFull
+}
+
+// restoreStage mirrors the agent's account-restore result stages, stored in a
+// full restore job's ManifestJSON.
+type restoreStage struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// formatRestoreLog renders a restore job's stored result into a plain-text log
+// body matching the backup.logs `log_text` shape, so the existing Logs modal
+// shows it unchanged. Selective restores store {applied,skipped,warnings} in
+// WarningsJSON; full restores store the agent's stages in ManifestJSON. When
+// neither is present the restore is still running or was interrupted before it
+// sealed — say that rather than borrow the backup-retention message.
+func formatRestoreLog(job *models.BackupJob) string {
+	if job == nil {
+		return ""
+	}
+	if len(job.WarningsJSON) > 0 {
+		var out selectiveRestoreOutcome
+		if err := json.Unmarshal(job.WarningsJSON, &out); err == nil {
+			if s := renderSelectiveOutcome(out); s != "" {
+				return s
+			}
+		}
+	}
+	if len(job.ManifestJSON) > 0 {
+		var res struct {
+			Stages []restoreStage `json:"stages"`
+		}
+		if err := json.Unmarshal(job.ManifestJSON, &res); err == nil && len(res.Stages) > 0 {
+			var b strings.Builder
+			for _, s := range res.Stages {
+				line := fmt.Sprintf("[%s] %s", strings.ToUpper(s.Status), s.Name)
+				if s.Error != "" {
+					line += ": " + s.Error
+				}
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
+			return strings.TrimRight(b.String(), "\n")
+		}
+	}
+	if job.ErrorText != "" {
+		return "restore failed: " + job.ErrorText
+	}
+	return "no recorded outcome yet — the restore may still be running or was interrupted before it finished."
+}
+
+// renderSelectiveOutcome turns the applied/skipped/warnings triple into labelled
+// text lines. Returns "" when all three are empty so the caller can fall through.
+func renderSelectiveOutcome(out selectiveRestoreOutcome) string {
+	if len(out.Applied) == 0 && len(out.Skipped) == 0 && len(out.Warnings) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, a := range out.Applied {
+		b.WriteString("[APPLIED] " + a + "\n")
+	}
+	for _, s := range out.Skipped {
+		b.WriteString("[SKIPPED] " + s + "\n")
+	}
+	for _, w := range out.Warnings {
+		b.WriteString("[WARNING] " + w + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/panel-api/internal/api/restore_view_test.go
+++ b/panel-api/internal/api/restore_view_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestRestoreContentFromSelective(t *testing.T) {
+	cases := []struct {
+		name       string
+		databases  []string
+		mailboxes  []string
+		dnsDomains []string
+		home       bool
+		want       string
+	}{
+		{"databases only", []string{"db1"}, nil, nil, false, models.BackupContentDatabase},
+		{"multiple databases only", []string{"db1", "db2"}, nil, nil, false, models.BackupContentDatabase},
+		{"home only", nil, nil, nil, true, models.BackupContentFiles},
+		{"db + home -> full", []string{"db1"}, nil, nil, true, models.BackupContentFull},
+		{"mailboxes only -> full", nil, []string{"a@x.com"}, nil, false, models.BackupContentFull},
+		{"dns only -> full", nil, nil, []string{"x.com"}, false, models.BackupContentFull},
+		{"empty -> full", nil, nil, nil, false, models.BackupContentFull},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restoreContentFromSelective(tc.databases, tc.mailboxes, tc.dnsDomains, tc.home); got != tc.want {
+				t.Errorf("restoreContentFromSelective = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRestoreKind(t *testing.T) {
+	for kind, want := range map[string]bool{
+		models.BackupJobKindAccountRestore: true,
+		models.BackupJobKindSystemRestore:  true,
+		models.BackupJobKindAccountBackup:  false,
+		models.BackupJobKindSystemBackup:   false,
+	} {
+		if got := isRestoreKind(kind); got != want {
+			t.Errorf("isRestoreKind(%q) = %v, want %v", kind, got, want)
+		}
+	}
+}
+
+func TestFormatRestoreLog_SelectiveOutcome(t *testing.T) {
+	out, _ := json.Marshal(selectiveRestoreOutcome{
+		Applied:  []string{"database db1 restored (3,000,000 rows)"},
+		Skipped:  []string{"mailbox a@x.com not owned"},
+		Warnings: []string{"overwrite=false: DNS not applied"},
+	})
+	job := &models.BackupJob{Kind: models.BackupJobKindAccountRestore, WarningsJSON: out}
+
+	got := formatRestoreLog(job)
+	for _, want := range []string{
+		"[APPLIED] database db1 restored (3,000,000 rows)",
+		"[SKIPPED] mailbox a@x.com not owned",
+		"[WARNING] overwrite=false: DNS not applied",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("restore log missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatRestoreLog_FullStages(t *testing.T) {
+	manifest, _ := json.Marshal(map[string]any{
+		"stages": []map[string]any{
+			{"name": "databases", "status": "succeeded"},
+			{"name": "home", "status": "failed", "error": "disk full"},
+		},
+	})
+	job := &models.BackupJob{Kind: models.BackupJobKindAccountRestore, ManifestJSON: manifest}
+
+	got := formatRestoreLog(job)
+	if !strings.Contains(got, "[SUCCEEDED] databases") {
+		t.Errorf("missing succeeded stage:\n%s", got)
+	}
+	if !strings.Contains(got, "[FAILED] home: disk full") {
+		t.Errorf("missing failed stage w/ error:\n%s", got)
+	}
+}
+
+func TestFormatRestoreLog_EmptyIsExplicit(t *testing.T) {
+	job := &models.BackupJob{Kind: models.BackupJobKindAccountRestore}
+	got := formatRestoreLog(job)
+	if !strings.Contains(got, "no recorded outcome") {
+		t.Errorf("empty restore result must be explicit, got: %q", got)
+	}
+	// Must NOT borrow the agent's backup-retention message.
+	if strings.Contains(got, "expired by retention") {
+		t.Errorf("must not use the backup-retention message for a restore: %q", got)
+	}
+}
+
+func TestFormatRestoreLog_ErrorFallback(t *testing.T) {
+	job := &models.BackupJob{Kind: models.BackupJobKindAccountRestore, ErrorText: "snapshot not found"}
+	got := formatRestoreLog(job)
+	if !strings.Contains(got, "snapshot not found") {
+		t.Errorf("error_text should surface when no structured result: %q", got)
+	}
+}

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -55,6 +55,9 @@ func (f *fakeBackupJobs) ListByRun(context.Context, string) ([]models.BackupJob,
 func (f *fakeBackupJobs) ListManual(context.Context, int, int) ([]models.BackupJob, int64, error) {
 	return nil, 0, nil
 }
+func (f *fakeBackupJobs) FindBySnapshotID(context.Context, string) (*models.BackupJob, error) {
+	return nil, nil
+}
 func (f *fakeBackupJobs) ListByStatusSince(_ context.Context, status string, since time.Time, _ int) ([]models.BackupJob, error) {
 	var out []models.BackupJob
 	for _, r := range f.rows {

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -24,6 +24,12 @@ type BackupJobRepository interface {
 	Create(ctx context.Context, job *models.BackupJob) error
 	Delete(ctx context.Context, id string) error
 	Get(ctx context.Context, id string) (*models.BackupJob, error)
+	// FindBySnapshotID returns the BACKUP job that produced the given restic
+	// snapshot (GH #1044 — a restore inherits its Content so a restore of a
+	// database-only backup reads "Database Restore"). Restore jobs carry no
+	// snapshot, so this only ever matches the source backup. ErrNotFound when
+	// no backup owns that snapshot (deleted, or a cross-host snapshot).
+	FindBySnapshotID(ctx context.Context, snapshotID string) (*models.BackupJob, error)
 	ListForUser(ctx context.Context, userID string, limit, offset int) ([]models.BackupJob, int64, error)
 	// OldestAccountBackupForUser returns the caller's OLDEST account_backup job
 	// (created_at ASC) for auto-prune retention (GH #454), or ErrNotFound when
@@ -69,11 +75,11 @@ type BackupJobRepository interface {
 // the columns the admin UI needs for its parent rows. Per-job detail
 // loads on demand via ListByRun.
 type BackupRunSummary struct {
-	RunID         string    `json:"run_id"`
-	ScheduleID    *string   `json:"schedule_id,omitempty"`
-	Kind          string    `json:"kind"`
-	Content       string    `json:"content"`
-	HasAccounts   bool      `json:"has_accounts"`
+	RunID       string  `json:"run_id"`
+	ScheduleID  *string `json:"schedule_id,omitempty"`
+	Kind        string  `json:"kind"`
+	Content     string  `json:"content"`
+	HasAccounts bool    `json:"has_accounts"`
 	// Accounts is the number of per-account snapshots in the run (GH #502) — so
 	// the UI can label a Full Server run "system + N accounts" on the collapsed
 	// row instead of making the admin expand it to count.
@@ -114,6 +120,25 @@ func (r *backupJobRepo) Create(ctx context.Context, job *models.BackupJob) error
 func (r *backupJobRepo) Get(ctx context.Context, id string) (*models.BackupJob, error) {
 	var out models.BackupJob
 	if err := r.db.WithContext(ctx).First(&out, "id = ?", id).Error; err != nil {
+		return nil, translate(err)
+	}
+	return &out, nil
+}
+
+// FindBySnapshotID returns the backup job that produced snapshotID. Scoped to
+// backup kinds (restores carry an empty snapshot, so they never collide); when
+// more than one backup shares a snapshot the oldest wins deterministically.
+func (r *backupJobRepo) FindBySnapshotID(ctx context.Context, snapshotID string) (*models.BackupJob, error) {
+	if snapshotID == "" {
+		return nil, ErrNotFound
+	}
+	var out models.BackupJob
+	err := r.db.WithContext(ctx).
+		Where("snapshot_id = ? AND kind IN ?", snapshotID,
+			[]string{models.BackupJobKindAccountBackup, models.BackupJobKindSystemBackup}).
+		Order("created_at ASC").
+		First(&out).Error
+	if err != nil {
 		return nil, translate(err)
 	}
 	return &out, nil

--- a/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
+++ b/panel-ui/src/shells/admin/backups/AdminBackupsPage.tsx
@@ -31,6 +31,11 @@ import { extractApiError } from "../../../apiErrors";
 import { useListQuery } from "../../../hooks/useQueries";
 import { BackupLogModal } from "./BackupLogModal";
 import { BackupLogsTab } from "./BackupLogsTab";
+
+// GH #1044: restore jobs share the backup list (kind=account_restore). They own
+// no snapshot, so their size/added read 0 and Download is meaningless.
+const isRestoreKind = (kind: string): boolean =>
+  kind === "account_restore" || kind === "system_restore";
 import { BackupSettingsTab } from "./BackupSettingsTab";
 import { CreateBackupDrawer } from "./CreateBackupDrawer";
 import { DestinationsTab } from "./DestinationsTab";
@@ -406,7 +411,7 @@ export const AdminBackupsPage = () => {
                 // GH #502: Download is the most common action after a backup completes —
                 // make it the primary (first, visible) action; Log + the rest collapse
                 // into the overflow menu.
-                { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: row.status !== "succeeded" && row.status !== "partial", onClick: () => handleDownload(row) },
+                { key: "download", label: "Download", icon: <DownloadOutlined />, hidden: isRestoreKind(row.kind) || (row.status !== "succeeded" && row.status !== "partial"), onClick: () => handleDownload(row) },
                 { key: "log", label: "Log", icon: <FileTextOutlined />, onClick: () => setLogJob(row) },
                 {
                   key: "restore",
@@ -607,13 +612,17 @@ export const AdminBackupsPage = () => {
                 title: "Added (dedup win)",
                 sorter: (a, b) => (a.isRun ? a.run.bytes_added : a.job.bytes_added) - (b.isRun ? b.run.bytes_added : b.job.bytes_added),
                 render: (_: unknown, row: TableRow) =>
-                  formatBytes(row.isRun ? row.run.bytes_added : row.job.bytes_added),
+                  !row.isRun && isRestoreKind(row.job.kind)
+                    ? "—"
+                    : formatBytes(row.isRun ? row.run.bytes_added : row.job.bytes_added),
               },
               {
                 title: "Logical size",
                 sorter: (a, b) => (a.isRun ? a.run.bytes_total : a.job.bytes_total) - (b.isRun ? b.run.bytes_total : b.job.bytes_total),
                 render: (_: unknown, row: TableRow) =>
-                  formatBytes(row.isRun ? row.run.bytes_total : row.job.bytes_total),
+                  !row.isRun && isRestoreKind(row.job.kind)
+                    ? "—"
+                    : formatBytes(row.isRun ? row.run.bytes_total : row.job.bytes_total),
               },
               {
                 title: "Started",

--- a/panel-ui/src/shells/user/MyProfileBackupCard.tsx
+++ b/panel-ui/src/shells/user/MyProfileBackupCard.tsx
@@ -31,6 +31,12 @@ type MyBackup = {
   error_text?: string;
 };
 
+// GH #1044: restore jobs share this list (kind=account_restore). A restore is
+// not a downloadable/deletable backup artifact and has no size — its row drops
+// the backup-only bits.
+const isRestoreRow = (row: MyBackup): boolean =>
+  row.kind === "account_restore" || row.kind === "system_restore";
+
 const statusColor = (status: string): string => {
   switch (status) {
     case "succeeded":
@@ -234,7 +240,8 @@ export const MyProfileBackupCard = () => {
           {
             title: "Size",
             dataIndex: "bytes_total",
-            render: (n: number) => formatBytes(n),
+            // GH #1044: a restore has no artifact size — the 0 read as noise.
+            render: (n: number, row: MyBackup) => (isRestoreRow(row) ? "—" : formatBytes(n)),
           },
           {
             title: "Actions",
@@ -242,7 +249,11 @@ export const MyProfileBackupCard = () => {
             render: (_, row) => (
               <RowActions
                 actions={[
-                  ...(row.status === "succeeded"
+                  // GH #1044: Download + Restore only make sense on a backup
+                  // artifact. A restore row has no snapshot to download and
+                  // isn't itself restorable — gate both off it (Download would
+                  // hard-fail, no snapshot).
+                  ...(!isRestoreRow(row) && row.status === "succeeded"
                     ? [
                         { key: "download", label: "Download", icon: <DownloadOutlined />, onClick: () => { const act = getActAs(); downloadUrl(`/api/v1/me/backups/${row.id}/download${act ? `?act_as=${encodeURIComponent(act.id)}` : ""}`); } },
                         { key: "restore", label: "Restore", icon: <ReloadOutlined />, onClick: () => setRestoreId(row.id) },
@@ -250,11 +261,15 @@ export const MyProfileBackupCard = () => {
                     : []),
                   {
                     key: "delete",
-                    label: "Delete",
+                    label: isRestoreRow(row) ? "Remove" : "Delete",
                     icon: <DeleteOutlined />,
                     danger: true,
                     onClick: () => handleDelete(row.id),
-                    confirm: { title: "Delete this backup?", description: "This permanently removes the backup's snapshots from the repository and cannot be undone.", okText: "Delete" },
+                    // A restore row owns no snapshots — deleting it only clears
+                    // the history entry; say that instead of the backup copy.
+                    confirm: isRestoreRow(row)
+                      ? { title: "Remove this restore from the list?", description: "This clears the restore entry from your history. It does not undo the restore or touch any backup.", okText: "Remove" }
+                      : { title: "Delete this backup?", description: "This permanently removes the backup's snapshots from the repository and cannot be undone.", okText: "Delete" },
                   },
                 ]}
               />

--- a/panel-ui/src/utils/backupType.test.ts
+++ b/panel-ui/src/utils/backupType.test.ts
@@ -28,10 +28,18 @@ describe("backupTypeLabel (GH #454)", () => {
     expect(backupTypeLabel("account_backup", null)).toBe("Account Backup");
   });
 
-  it("labels system backups/restores by kind regardless of content", () => {
+  it("labels system backups by kind regardless of content", () => {
     // GH #502: a bare system_backup (no fanned-out accounts) is System-only.
     expect(backupTypeLabel("system_backup", "full")).toBe("System Backup");
     expect(backupTypeLabel("system_restore", "full")).toBe("Server Restore");
-    expect(backupTypeLabel("account_restore", "database")).toBe("Account Restore");
+  });
+
+  it("GH #1044: labels an account restore by what it restored", () => {
+    expect(backupTypeLabel("account_restore", "database")).toBe("Database Restore");
+    expect(backupTypeLabel("account_restore", "files")).toBe("Files Restore");
+    expect(backupTypeLabel("account_restore", "folders")).toBe("Files Restore");
+    expect(backupTypeLabel("account_restore", "full")).toBe("Account Restore");
+    expect(backupTypeLabel("account_restore", "")).toBe("Account Restore");
+    expect(backupTypeLabel("account_restore", undefined)).toBe("Account Restore");
   });
 });

--- a/panel-ui/src/utils/backupType.ts
+++ b/panel-ui/src/utils/backupType.ts
@@ -19,7 +19,19 @@ export function backupTypeLabel(kind: string, content?: string | null, hasAccoun
     case "system_restore":
       return "Server Restore";
     case "account_restore":
-      return "Account Restore";
+      // GH #1044: describe a restore by WHAT it restored, mirroring the backup
+      // labels — a database-only restore reads "Database Restore", not the
+      // generic "Account Restore" the reporter flagged. Colour stays orange
+      // (see backupTypeColor) so restores remain visually distinct in the list.
+      switch (content) {
+        case "database":
+          return "Database Restore";
+        case "files":
+        case "folders":
+          return "Files Restore";
+        default:
+          return "Account Restore";
+      }
   }
   // account_backup (and any unknown backup kind) — describe by content.
   switch (content) {


### PR DESCRIPTION
## GH #1044 — restore UX polish (the PG restore itself is already fixed in #1068/#1070)

lxsdevcode's PostgreSQL restore works now, but the restore still renders in the backup list as a generic **Account Restore** row with a meaningless size (0), backup-only **Download/Delete** actions, and a **Logs** view that says "no log available." Scope chosen: **targeted polish + restore logging** (not the separate Restores-tab refactor).

### Backend
- **Content on restore jobs.** Selective (tenant) restores derive it from the requested scope — databases-only → `database`, home-only → `files`, else `full` — so a DB-only restore reads **Database Restore**. Full (admin) restores **inherit the source backup's content** via a new `FindBySnapshotID` repo lookup (restoring a db-only backup is a Database Restore too); a missing/cross-host source falls back to `full`. Mailbox-only / DNS-only selective restores have no content bucket → `full` (follow-up).
- **Logs.** A restore never writes the agent's per-job backup log; its result lives on the job row (selective → `warnings_json` applied/skipped/warnings, full → `manifest_json` stages). `h.logs` now renders that into `log_text` for restore kinds **before** the agent check, so the existing Logs modal shows what happened. Empty result → an explicit "still running or interrupted" line, never the backup-retention message.
- **Delete.** A restore owns no restic snapshot → both delete handlers skip `backup.forget` for restore kinds and just drop the row.

### UI
- `backupType.ts`: `account_restore` labelled by content (Database/Files/Account Restore); **colour stays orange** so restores remain visually distinct in a mixed list.
- Tenant (`MyProfileBackupCard`) + admin (`AdminBackupsPage`) restore rows: drop **Download/Restore**, show size **"—"**; tenant Delete confirm says it only clears the history entry.

### Tests
Content derivation, log formatting (selective/full/empty/error), `isRestoreKind`, and the restore×content label table. `go vet` + full api/repository suites + `tsc -b` + vitest green.

### Follow-up
Live pass on the test box before stable + the reporter reply. The separate Restores-tab and the mailbox/DNS-only content vocabulary are deliberately out of this pass.