### PR TITLE
fix(panel-ui): declare a favicon so every page load stops 404ing

### DIFF
--- a/panel-ui/index.html
+++ b/panel-ui/index.html
@@ -7,6 +7,12 @@
     <title>Jabali Panel</title>
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#1677ff" />
+    <!-- Browsers request /favicon.ico unprompted when no icon is declared, so
+         without these every page load logged two 404s in the console — the
+         first thing an operator sees on a brand-new panel. Point at the PWA
+         icons that already ship rather than adding another asset. -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/icons/pwa-192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icons/pwa-512.png" />
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
     <style>
       html, body { margin: 0; padding: 0; }


### PR DESCRIPTION
Recovered finished work from the stale `wt-favicon` worktree (one commit, rebased onto current main).

Browsers request /favicon.ico unprompted when no icon is declared — every page load logged two 404s, the first thing an operator sees on a new panel. Points at the PWA icons that already ship (no new asset).