### PR TITLE
feat(crowdsec): derive country-exemption CIDRs from local MaxMind mmdb + supplemental CIDRs

### DIFF
--- a/docs/adr/0166-country-ban-exemption.md
+++ b/docs/adr/0166-country-ban-exemption.md
@@ -35,14 +35,23 @@ verified live on CrowdSec v1.7.8):
 Two layers, reconciled from `server_settings`:
 
 1. **`jabali-country-allowlist` LAPI AllowList** seeded with the selected
-   countries' full CIDR sets (ipdeny aggregated zones, IPv4 **and** IPv6 —
-   the v6 file is separate and easy to forget). Per-entry comment
-   `country:<CC>` makes per-country diff/removal possible. panel-api fetches
-   the zones (agent never opens outbound — ADR-0050), snapshots them under
-   `/var/lib/jabali-panel/country-zones/`, diffs against `cscli allowlists
-   inspect` (LAPI is truth — ADR-0061) and pushes only deltas to the agent.
-   Converged by a 60s refresher tick (selection change or last-sync
-   failure); snapshots self-manage 7-day staleness on read.
+   countries' full CIDR sets. **Source of truth is the local MaxMind mmdb**
+   (`/var/lib/crowdsec/data/GeoLite2-City.mmdb`, Country DB as degraded
+   substitute): the agent (root — the mmdb is `0600 root`, panel-api runs
+   unprivileged) walks the tree with `maxminddb-golang`, applies the exact
+   `GeoIpCity` IsoCode precedence (Country → RegisteredCountry →
+   RepresentedCountry) and returns the raw networks
+   (`security.crowdsec.country_zones.derive`); panel-api merges adjacent
+   CIDRs, snapshots them under `/var/lib/jabali-panel/country-zones/`,
+   diffs against `cscli allowlists inspect` (LAPI is truth — ADR-0061) and
+   pushes only deltas to the agent. **ipdeny aggregated zones (IPv4 + IPv6)
+   remain as fallback** when no mmdb exists or a country has no
+   data-bearing networks. Per-entry comment `country:<CC>` makes
+   per-country diff/removal possible. Converged by a 60s refresher tick
+   (selection change, last-sync failure, or a 15-min verify); snapshots
+   self-manage 7-day staleness, and mmdb-sourced snapshots additionally
+   expire when the classifier's mmdb mtime passes the snapshot marker
+   (`security.crowdsec.mmdb.stat`).
 2. **GeoIP parser whitelist** rendered by the agent at
    `/etc/crowdsec/parsers/s02-enrich/zz-jabali-country-allowlist.yaml`,
    atomic tmp+rename + SIGHUP reload (same write discipline as the geoblock
@@ -52,6 +61,13 @@ State lives in `server_settings.country_exempt_countries` (CSV). The PUT
 handler calls the agent first, then persists (geoblock ordering, ADR-0060),
 so a failed host write never drifts the DB.
 
+**Supplemental CIDRs** (`server_settings.country_exempt_extra_cidrs`, CSV;
+migration 000263): operator-supplied IPs/CIDRs merged into the same
+allowlist tagged `country:extra` — managed entries, removed when removed
+from settings. For stragglers a country's zone data misses and known-good
+hosts abroad. Validated at the API/CLI edge (`NormalizeCIDR`: prefixes
+masked, bare IPs → host prefixes), capped at 1000 entries.
+
 **Precedence: exemption wins over the geoblock deny-list.** AllowLists
 evaluate before AppSec `pre_eval` (ADR-0061), so an exempted country ignores
 a deny-list entry for the same country. This is the intended semantic —
@@ -60,9 +76,21 @@ appears in both lists.
 
 ## Consequences
 
-- A third-party CIDR source (ipdeny) enters the supply chain. Failure mode is
-  soft: keep the last good snapshot, warn, retry. DB-IP Lite is a drop-in
-  alternative if ipdeny ever goes away.
+- The two layers used to read different geo data sources — parser whitelist
+  MaxMind, CIDR sets ipdeny — so an IP could geo-locate to an exempt country
+  in MaxMind while ipdeny's set did not cover it (observed: 182.54.236.64 =
+  IL in MaxMind, absent from ipdeny's IL zone), leaving it exposed to
+  CAPI/community decisions. **Resolved 2026-08-14**: the CIDR sets are now
+  derived from the same mmdb the classifier reads, so allowlist ≡ classifier
+  by construction (an IP that resolves to a country record always falls
+  inside the data-bearing network that yielded it, and that network is in
+  the allowlist). Freshness tracks the mmdb's mtime. Residual risks,
+  accepted: (a) decisions whose *range* only partially overlaps an exempt
+  country are not skipped by LAPI (containment check); (b) while the ipdeny
+  fallback is in effect (no mmdb), the original mismatch class applies.
+- A third-party CIDR source (ipdeny) remains in the supply chain as
+  fallback only. Failure mode is soft: keep the last good snapshot, warn,
+  retry. DB-IP Lite is a drop-in alternative if ipdeny ever goes away.
 - First jabali-managed file under `/etc/crowdsec/parsers/s02-enrich/`;
   same drift story as the geoblock — rewritten on every PUT/sync, preserved
   across `jabali update` because the renderer is deterministic from DB state.
@@ -72,12 +100,5 @@ appears in both lists.
   **verified live on testserver (2026-08-13)**: the AppSec acquisition layer
   logs `… is allowlisted by <ip> from jabali-country-allowlist (country:IL),
   skipping` and does not evaluate the request.
-- The two layers use different geo data sources: the parser whitelist reads
-  MaxMind (geoip-enrich `IsoCode`), the CIDR sets come from ipdeny. An IP can
-  geo-locate to an exempt country in MaxMind while ipdeny's aggregated set
-  does not cover it (observed: 182.54.236.64 = IL in MaxMind, absent from
-  ipdeny's IL zone). Consequence: such an IP escapes *locally-generated*
-  decisions but could still be hit by CAPI/community blocklist decisions.
-  Accepted as residual risk; the parser layer is the primary guard.
 - The US-scale initial import takes minutes; it runs as a background sync
   with operator-visible progress, never inline in the PUT request.

--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -964,7 +964,7 @@ jabali crowdsec country-exempt get
 
 ##### `jabali crowdsec country-exempt set`
 
-Set exempt countries (empty = feature off)
+Set exempt countries and/or extra CIDRs (both empty = feature off)
 
 ```
 jabali crowdsec country-exempt set [flags]
@@ -973,6 +973,7 @@ jabali crowdsec country-exempt set [flags]
 **Flags:**
 
 - `--country` — 2-letter ISO code (repeatable); omit all to disable (default `[]`)
+- `--extra-cidr` — additional never-block IP or CIDR (repeatable); omit all to clear (default `[]`)
 
 ##### `jabali crowdsec country-exempt sync`
 

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/oschwald/maxminddb-golang v1.13.1 h1:G3wwjdN9JmIK2o/ermkHM+98oX5fS+k5MbwsmL4MRQE=
+github.com/oschwald/maxminddb-golang v1.13.1/go.mod h1:K4pgV9N/GcK694KSTmVSDTODk4IsCNThNdTmnaBZ/F8=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=

--- a/panel-agent/internal/commands/security_crowdsec_mmdb.go
+++ b/panel-agent/internal/commands/security_crowdsec_mmdb.go
@@ -1,0 +1,193 @@
+package commands
+
+// MaxMind-mmdb-backed country zone derivation for the country ban exemption
+// (ADR-0166 amendment, 2026-08-14). The GeoIP enricher classifies IPs with a
+// MaxMind database; seeding the LAPI country allowlist from ipdeny zone files
+// left gaps wherever MaxMind and registry data disagree (observed:
+// 182.54.236.64 is IL per MaxMind but absent from ipdeny's IL zone). Deriving
+// the CIDR set from the same mmdb the classifier reads makes allowlist
+// coverage exact by construction. ipdeny stays as panel-api's fallback when
+// no mmdb is present.
+//
+// The mmdb is 0600 root under /var/lib/crowdsec/data and panel-api runs as
+// the unprivileged jabali user (systemd ProtectSystem=strict), so the agent
+// — root — does the iteration and returns plain CIDR strings over the wire.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/oschwald/maxminddb-golang"
+)
+
+// crowdsecMMDBCandidates in preference order. GeoLite2-City is what
+// crowdsecurity/geoip-enrich fetches (dest_file GeoLite2-City.mmdb), so it
+// is the database whose IsoCode opinion the scenarios actually see. The
+// Country DB is accepted as a degraded substitute when a host only has it.
+var crowdsecMMDBCandidates = []string{
+	"/var/lib/crowdsec/data/GeoLite2-City.mmdb",
+	"/var/lib/crowdsec/data/GeoLite2-Country.mmdb",
+}
+
+// crowdsecMMDBPath returns the first readable candidate mmdb.
+func crowdsecMMDBPath() (string, error) {
+	for _, p := range crowdsecMMDBCandidates {
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("no MaxMind database found under /var/lib/crowdsec/data " +
+		"(geoip-enrich installs GeoLite2-City.mmdb — is the GeoIP enricher installed?)")
+}
+
+// mmdbISORecord decodes only the ISO codes — maxminddb decodes requested
+// fields only, keeping a full-tree walk cheap.
+type mmdbISORecord struct {
+	Country struct {
+		ISOCode string `maxminddb:"iso_code"`
+	} `maxminddb:"country"`
+	RegisteredCountry struct {
+		ISOCode string `maxminddb:"iso_code"`
+	} `maxminddb:"registered_country"`
+	RepresentedCountry struct {
+		ISOCode string `maxminddb:"iso_code"`
+	} `maxminddb:"represented_country"`
+}
+
+// isoCode mirrors crowdsec's GeoIpCity precedence EXACTLY
+// (pkg/parser/enrich_geoip.go): Country → RegisteredCountry →
+// RepresentedCountry → "". Diverging here would re-open the coverage gap
+// this verb exists to close.
+func (r mmdbISORecord) isoCode() string {
+	switch {
+	case r.Country.ISOCode != "":
+		return r.Country.ISOCode
+	case r.RegisteredCountry.ISOCode != "":
+		return r.RegisteredCountry.ISOCode
+	case r.RepresentedCountry.ISOCode != "":
+		return r.RepresentedCountry.ISOCode
+	}
+	return ""
+}
+
+// mmdbNetworks is the slice of *maxminddb.Networks the deriver needs. An
+// interface so tests can feed a fake tree without a writer-side mmdb.
+type mmdbNetworks interface {
+	Next() bool
+	Network(result any) (*net.IPNet, error)
+	Err() error
+}
+
+// deriveZones walks every data-bearing network and buckets it by ISO code.
+// Coverage is exact: an IP the classifier resolves to a record for country
+// CC always falls inside the data-bearing network that yielded that record
+// (lookups return the nearest data-bearing ancestor), and that network is
+// in zones[CC]. Merging adjacent CIDRs happens panel-side — the agent
+// stays dumb (ADR-0050).
+func deriveZones(iter mmdbNetworks, want map[string]bool) (map[string][]string, error) {
+	zones := map[string][]string{}
+	for iter.Next() {
+		var rec mmdbISORecord
+		network, err := iter.Network(&rec)
+		if err != nil {
+			return nil, fmt.Errorf("decode mmdb record: %w", err)
+		}
+		iso := rec.isoCode()
+		if iso == "" || !want[iso] {
+			continue
+		}
+		zones[iso] = append(zones[iso], network.String())
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("walk mmdb: %w", err)
+	}
+	return zones, nil
+}
+
+type csCountryZonesDeriveParams struct {
+	Countries []string `json:"countries"`
+}
+
+// csCountryZonesDeriveHandler returns the per-country CIDR sets derived
+// from the local MaxMind database. Countries with no data-bearing network
+// come back with an empty list (not an error) so panel-api can fall back
+// to ipdeny for just those codes.
+func csCountryZonesDeriveHandler(_ context.Context, params json.RawMessage) (any, error) {
+	var p csCountryZonesDeriveParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, csInvalidArg(fmt.Sprintf("parse params: %v", err))
+	}
+	cleaned, cerr := csCleanCountries(p.Countries)
+	if cerr != nil {
+		return nil, csInvalidArg(cerr.Error())
+	}
+	if len(cleaned) == 0 {
+		return nil, csInvalidArg("countries required")
+	}
+	path, err := crowdsecMMDBPath()
+	if err != nil {
+		return nil, csInternal("locate mmdb", err)
+	}
+	// #nosec G304 — path comes from the fixed candidate list above.
+	reader, err := maxminddb.Open(path)
+	if err != nil {
+		return nil, csInternal("open mmdb", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	want := make(map[string]bool, len(cleaned))
+	for _, c := range cleaned {
+		want[c] = true
+	}
+	zones, err := deriveZones(reader.Networks(maxminddb.SkipAliasedNetworks), want)
+	if err != nil {
+		return nil, csInternal("derive zones", err)
+	}
+	// Ensure every requested key is present (empty slice, never missing) so
+	// panel-api can distinguish "no networks" from a truncated response.
+	for _, c := range cleaned {
+		if _, ok := zones[c]; !ok {
+			zones[c] = []string{}
+		}
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil, csInternal("stat mmdb", err)
+	}
+	return map[string]any{
+		"path":  path,
+		"mtime": st.ModTime().Unix(),
+		"zones": zones,
+	}, nil
+}
+
+// csMMDBStatHandler reports which mmdb the classifier uses and when it last
+// changed. panel-api's refresher compares mtime against its zone snapshots
+// so a GeoIP update triggers re-derivation without waiting for the weekly
+// staleness window.
+func csMMDBStatHandler(_ context.Context, _ json.RawMessage) (any, error) {
+	path, err := crowdsecMMDBPath()
+	if err != nil {
+		return nil, csInternal("locate mmdb", err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return nil, csInternal("stat mmdb", err)
+	}
+	return map[string]any{
+		"path":  path,
+		"mtime": st.ModTime().Unix(),
+		"size":  st.Size(),
+	}, nil
+}
+
+// csCleanCountries is defined in security_crowdsec.go (shared with the
+// geoblock and country-exemption set handlers).
+
+func init() {
+	Default.Register("security.crowdsec.country_zones.derive", csCountryZonesDeriveHandler)
+	Default.Register("security.crowdsec.mmdb.stat", csMMDBStatHandler)
+}

--- a/panel-agent/internal/commands/security_crowdsec_mmdb_test.go
+++ b/panel-agent/internal/commands/security_crowdsec_mmdb_test.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+)
+
+type fakeMMDBEntry struct {
+	network string
+	rec     mmdbISORecord
+}
+
+// fakeMMDBIter plays back a fixed set of (network, record) pairs, then stops
+// (or fails) — enough to exercise deriveZones without a writer-side mmdb.
+type fakeMMDBIter struct {
+	entries []fakeMMDBEntry
+	idx     int
+	err     error
+}
+
+func (f *fakeMMDBIter) Next() bool { return f.err == nil && f.idx < len(f.entries) }
+
+func (f *fakeMMDBIter) Network(result any) (*net.IPNet, error) {
+	e := f.entries[f.idx]
+	f.idx++
+	rec, ok := result.(*mmdbISORecord)
+	if !ok {
+		return nil, errors.New("unexpected result type")
+	}
+	*rec = e.rec
+	_, n, err := net.ParseCIDR(e.network)
+	if err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+func (f *fakeMMDBIter) Err() error { return f.err }
+
+func isoRec(country, registered, represented string) mmdbISORecord {
+	var r mmdbISORecord
+	r.Country.ISOCode = country
+	r.RegisteredCountry.ISOCode = registered
+	r.RepresentedCountry.ISOCode = represented
+	return r
+}
+
+func TestDeriveZones_FiltersAndBuckets(t *testing.T) {
+	iter := &fakeMMDBIter{entries: []fakeMMDBEntry{
+		{"1.0.0.0/24", isoRec("IL", "", "")},
+		{"2.0.0.0/24", isoRec("US", "", "")},
+		{"2001:db8::/32", isoRec("IL", "", "")},
+		{"3.0.0.0/24", isoRec("", "", "")}, // no record country — skipped
+	}}
+	zones, err := deriveZones(iter, map[string]bool{"IL": true})
+	if err != nil {
+		t.Fatalf("deriveZones: %v", err)
+	}
+	if len(zones) != 1 {
+		t.Fatalf("expected only IL bucket, got %v", zones)
+	}
+	got := zones["IL"]
+	want := []string{"1.0.0.0/24", "2001:db8::/32"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("IL zone = %v, want %v", got, want)
+	}
+}
+
+// The precedence must match crowdsec's GeoIpCity bit-for-bit:
+// Country → RegisteredCountry → RepresentedCountry.
+func TestDeriveZones_ISOCodePrecedence(t *testing.T) {
+	iter := &fakeMMDBIter{entries: []fakeMMDBEntry{
+		{"1.0.0.0/24", isoRec("IL", "US", "DE")},   // Country wins
+		{"2.0.0.0/24", isoRec("", "US", "DE")},     // Registered next
+		{"3.0.0.0/24", isoRec("", "", "DE")},       // Represented last
+		{"4.0.0.0/24", isoRec("", "gb", "")},       // NOT uppercased by mmdb — kept verbatim
+	}}
+	zones, err := deriveZones(iter, map[string]bool{"IL": true, "US": true, "DE": true})
+	if err != nil {
+		t.Fatalf("deriveZones: %v", err)
+	}
+	if got := zones["IL"]; len(got) != 1 || got[0] != "1.0.0.0/24" {
+		t.Fatalf("IL = %v", got)
+	}
+	if got := zones["US"]; len(got) != 1 || got[0] != "2.0.0.0/24" {
+		t.Fatalf("US = %v", got)
+	}
+	if got := zones["DE"]; len(got) != 1 || got[0] != "3.0.0.0/24" {
+		t.Fatalf("DE = %v", got)
+	}
+}
+
+func TestDeriveZones_IteratorError(t *testing.T) {
+	iter := &fakeMMDBIter{err: errors.New("corrupt tree")}
+	if _, err := deriveZones(iter, map[string]bool{"IL": true}); err == nil {
+		t.Fatal("expected error from failing iterator")
+	}
+}
+
+func TestCsCountryZonesDeriveHandler_RejectsBadInput(t *testing.T) {
+	for _, params := range []string{
+		`{"countries": []}`,
+		`{"countries": ["USA"]}`,
+		`{"countries": ["i1"]}`,
+		`not-json`,
+	} {
+		if _, err := csCountryZonesDeriveHandler(context.Background(), json.RawMessage(params)); err == nil {
+			t.Fatalf("params %s: expected error", params)
+		}
+	}
+}
+
+func TestCsMMDBStatHandler_NoMMDBIsError(t *testing.T) {
+	// Dev machines and CI runners have no /var/lib/crowdsec/data — the verb
+	// must surface a clean error, not panic.
+	if _, err := csMMDBStatHandler(context.Background(), nil); err == nil {
+		t.Skip("host has a crowdsec mmdb — error path not exercised")
+	}
+}

--- a/panel-api/cmd/server/crowdsec_cmd.go
+++ b/panel-api/cmd/server/crowdsec_cmd.go
@@ -459,10 +459,11 @@ func newCsCountryExemptCmd() *cobra.Command {
 					return err
 				}
 				countries := countryexempt.SplitCountries(s.CountryExemptCountries)
+				extras := countryexempt.SplitCountries(s.CountryExemptExtraCIDRs)
 				if jsonOutput {
-					return printJSON(map[string]any{"countries": countries})
+					return printJSON(map[string]any{"countries": countries, "extra_cidrs": extras})
 				}
-				fmt.Fprintf(cmd.OutOrStdout(), "countries=%s\n", strings.Join(countries, ","))
+				fmt.Fprintf(cmd.OutOrStdout(), "countries=%s\nextra_cidrs=%s\n", strings.Join(countries, ","), strings.Join(extras, ","))
 				return nil
 			},
 		},
@@ -475,8 +476,9 @@ func newCsCountryExemptCmd() *cobra.Command {
 					return err
 				}
 				countries := countryexempt.SplitCountries(s.CountryExemptCountries)
-				if len(countries) == 0 {
-					return fmt.Errorf("no exempt countries configured — set some first")
+				extras := countryexempt.SplitCountries(s.CountryExemptExtraCIDRs)
+				if len(countries) == 0 && len(extras) == 0 {
+					return fmt.Errorf("no exempt countries or extra CIDRs configured — set some first")
 				}
 				// Inline, not KickBackground: a CLI exits and would kill the
 				// background goroutine before it does any work. A US-scale
@@ -485,7 +487,7 @@ func newCsCountryExemptCmd() *cobra.Command {
 				ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Minute)
 				defer cancel()
 				fmt.Fprintln(cmd.OutOrStdout(), "syncing country CIDR sets (this can take minutes for large countries)…")
-				if err := countryexempt.NewSyncer(sharedAgent, nil).RunSync(ctx, countries, true); err != nil {
+				if err := countryexempt.NewSyncer(sharedAgent, nil).RunSync(ctx, countries, extras, true); err != nil {
 					return fmt.Errorf("country CIDR sync: %w", err)
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), "country CIDR sync complete")
@@ -497,10 +499,10 @@ func newCsCountryExemptCmd() *cobra.Command {
 }
 
 func newCsCountryExemptSetCmd() *cobra.Command {
-	var countries []string
+	var countries, extraCIDRs []string
 	cmd := &cobra.Command{
 		Use:     "set",
-		Short:   "Set exempt countries (empty = feature off)",
+		Short:   "Set exempt countries and/or extra CIDRs (both empty = feature off)",
 		Args:    cobra.NoArgs,
 		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -519,6 +521,18 @@ func newCsCountryExemptSetCmd() *cobra.Command {
 					cleaned = append(cleaned, code)
 				}
 			}
+			extras := []string{}
+			seenExtra := map[string]bool{}
+			for _, raw := range extraCIDRs {
+				norm, err := countryexempt.NormalizeCIDR(raw)
+				if err != nil {
+					return fmt.Errorf("invalid --extra-cidr %q (expected IP or CIDR)", raw)
+				}
+				if !seenExtra[norm] {
+					seenExtra[norm] = true
+					extras = append(extras, norm)
+				}
+			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 			// Agent first so a whitelist-write failure doesn't drift the DB.
@@ -533,6 +547,7 @@ func newCsCountryExemptSetCmd() *cobra.Command {
 				return err
 			}
 			s.CountryExemptCountries = strings.Join(cleaned, ",")
+			s.CountryExemptExtraCIDRs = strings.Join(extras, ",")
 			if err := repo.Upsert(ctx, s); err != nil {
 				return fmt.Errorf("persist country-exempt settings: %w", err)
 			}
@@ -540,11 +555,12 @@ func newCsCountryExemptSetCmd() *cobra.Command {
 			// No background kick here — a CLI exits and would kill the
 			// goroutine before it works. The panel's refresher converges
 			// the CIDR allowlist within ~60s; `sync` runs it inline now.
-			fmt.Fprintf(cmd.OutOrStdout(), "country-exempt countries=%s (panel converges the CIDR allowlist within ~60s; `jabali crowdsec country-exempt sync` runs it now)\n", strings.Join(cleaned, ","))
+			fmt.Fprintf(cmd.OutOrStdout(), "country-exempt countries=%s extra_cidrs=%s (panel converges the CIDR allowlist within ~60s; `jabali crowdsec country-exempt sync` runs it now)\n", strings.Join(cleaned, ","), strings.Join(extras, ","))
 			return nil
 		},
 	}
 	cmd.Flags().StringArrayVar(&countries, "country", nil, "2-letter ISO code (repeatable); omit all to disable")
+	cmd.Flags().StringArrayVar(&extraCIDRs, "extra-cidr", nil, "additional never-block IP or CIDR (repeatable); omit all to clear")
 	return cmd
 }
 

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -25,11 +25,11 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupfinalizer"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupscheduler"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/countryexempt"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/db"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/diskusagesweeper"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/drsync"
-	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/countryexempt"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/eventsources"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/mailscan"
@@ -1124,17 +1124,19 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	// ADR-0166 country ban exemption refresher. Reads the country
-	// selection from server_settings each tick and re-syncs the country
-	// CIDR allowlist when snapshots go stale (>7d) or the last sync
-	// failed. Cheap no-op when converged or the feature is off.
+	// selection + supplemental CIDRs from server_settings each tick and
+	// re-syncs the country CIDR allowlist when snapshots go stale (>7d),
+	// the classifier's mmdb changed, or the last sync failed. Cheap no-op
+	// when converged or the feature is off.
 	if deps.ServerSettings != nil && deps.Agent != nil {
 		go countryexempt.StartRefresher(ctx, countryexempt.NewSyncer(deps.Agent, log),
-			func(ctx context.Context) []string {
+			func(ctx context.Context) ([]string, []string) {
 				s, err := deps.ServerSettings.Get(ctx)
 				if err != nil {
-					return nil
+					return nil, nil
 				}
-				return countryexempt.SplitCountries(s.CountryExemptCountries)
+				return countryexempt.SplitCountries(s.CountryExemptCountries),
+					countryexempt.SplitCountries(s.CountryExemptExtraCIDRs)
 			}, log)
 	}
 

--- a/panel-api/internal/api/security_country_exempt_test.go
+++ b/panel-api/internal/api/security_country_exempt_test.go
@@ -26,7 +26,7 @@ func countryExemptRouter(t *testing.T, mock agent.AgentInterface, repo *mockServ
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	orig := countryExemptKick
-	countryExemptKick = func(_ *slog.Logger, _ *countryexempt.Syncer, _ []string, _ bool) {}
+	countryExemptKick = func(_ *slog.Logger, _ *countryexempt.Syncer, _, _ []string, _ bool) {}
 	t.Cleanup(func() { countryExemptKick = orig })
 
 	r := gin.New()
@@ -160,4 +160,60 @@ func TestCountryExempt_Sync_Returns202(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+func TestCountryExempt_Get_IncludesExtraCIDRs(t *testing.T) {
+
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		CountryExemptCountries:  "IL",
+		CountryExemptExtraCIDRs: "203.0.113.7/32,192.0.2.0/25",
+	}}
+	r := countryExemptRouter(t, agent.NewMockClient(), repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/security/crowdsec/country-exemption", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, []any{"203.0.113.7/32", "192.0.2.0/25"}, body["extra_cidrs"])
+}
+
+func TestCountryExempt_Put_ExtraCIDRs_Normalized(t *testing.T) {
+
+	mock := agent.NewMockClient().On("security.crowdsec.country_exempt.set",
+		map[string]any{"countries": []any{"IL"}})
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	r := countryExemptRouter(t, mock, repo)
+
+	// Bare IP → host prefix; unmasked CIDR → canonical form; dup dropped.
+	body := bytes.NewBufferString(`{"countries":["IL"],"extra_cidrs":["203.0.113.7","192.0.2.10/25","192.0.2.0/25"]}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/security/crowdsec/country-exemption", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "203.0.113.7/32,192.0.2.0/25", repo.getResult.CountryExemptExtraCIDRs)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, []any{"203.0.113.7/32", "192.0.2.0/25"}, resp["extra_cidrs"])
+}
+
+func TestCountryExempt_Put_InvalidExtraCIDR_NoAgentCall(t *testing.T) {
+
+	mock := agent.NewMockClient()
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{}}
+	r := countryExemptRouter(t, mock, repo)
+
+	body := bytes.NewBufferString(`{"countries":["IL"],"extra_cidrs":["not-a-cidr"]}`)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/security/crowdsec/country-exemption", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, mock.Calls(), "agent must not be called on pre-validation failure")
+	assert.Empty(t, repo.getResult.CountryExemptExtraCIDRs, "settings must not be persisted")
 }

--- a/panel-api/internal/api/security_crowdsec.go
+++ b/panel-api/internal/api/security_crowdsec.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -631,13 +632,19 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 
 	ce.PUT("", func(c *gin.Context) {
 		var body struct {
-			Countries []string `json:"countries"`
+			Countries  []string `json:"countries"`
+			ExtraCIDRs []string `json:"extra_cidrs"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_json"})
 			return
 		}
 		cleaned, errResp := cleanCountries(body.Countries)
+		if errResp != nil {
+			c.JSON(http.StatusBadRequest, errResp)
+			return
+		}
+		extras, errResp := cleanExtraCIDRs(body.ExtraCIDRs)
 		if errResp != nil {
 			c.JSON(http.StatusBadRequest, errResp)
 			return
@@ -662,6 +669,7 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 			return
 		}
 		s.CountryExemptCountries = strings.Join(cleaned, ",")
+		s.CountryExemptExtraCIDRs = strings.Join(extras, ",")
 		if err := settings.Upsert(c.Request.Context(), s); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"status": "error", "error": "settings_write", "detail": err.Error(),
@@ -671,7 +679,7 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 		// CIDR sync runs in the background — a US-scale import takes
 		// minutes and must not block the request. Uses the snapshot cache;
 		// the refresher handles staleness.
-		countryExemptKick(nil, countryexempt.NewSyncer(cli, nil), cleaned, false)
+		countryExemptKick(nil, countryexempt.NewSyncer(cli, nil), cleaned, extras, false)
 		c.JSON(http.StatusOK, countryExemptResponse(s))
 	})
 
@@ -685,7 +693,8 @@ func RegisterSecurityAppSecRoutes(rg *gin.RouterGroup, cli agent.AgentInterface,
 			return
 		}
 		countryExemptKick(nil, countryexempt.NewSyncer(cli, nil),
-			countryexempt.SplitCountries(s.CountryExemptCountries), true)
+			countryexempt.SplitCountries(s.CountryExemptCountries),
+			countryexempt.SplitCountries(s.CountryExemptExtraCIDRs), true)
 		c.Status(http.StatusAccepted)
 	})
 }
@@ -720,7 +729,47 @@ func countryExemptResponse(s *models.ServerSettings) gin.H {
 	if countries == nil {
 		countries = []string{}
 	}
-	return gin.H{"countries": countries}
+	extras := countryexempt.SplitCountries(s.CountryExemptExtraCIDRs)
+	if extras == nil {
+		extras = []string{}
+	}
+	return gin.H{"countries": countries, "extra_cidrs": extras}
+}
+
+// maxExtraCIDRs caps the supplemental list — it is merged into the same
+// LAPI allowlist as the country zones; a runaway list would bloat LAPI.
+const maxExtraCIDRs = 1000
+
+// cleanExtraCIDRs validates and normalizes the operator's supplemental
+// entries (CIDRs masked to canonical form, bare IPs → host prefixes).
+func cleanExtraCIDRs(in []string) ([]string, gin.H) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		norm, err := countryexempt.NormalizeCIDR(v)
+		if err != nil {
+			return nil, gin.H{
+				"status": "error", "error": "invalid_cidr",
+				"detail": "extra_cidrs entry " + v + " must be an IP or CIDR",
+			}
+		}
+		if _, dup := seen[norm]; dup {
+			continue
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	if len(out) > maxExtraCIDRs {
+		return nil, gin.H{
+			"status": "error", "error": "too_many_cidrs",
+			"detail": fmt.Sprintf("extra_cidrs is capped at %d entries", maxExtraCIDRs),
+		}
+	}
+	return out, nil
 }
 
 func cleanCountries(in []string) ([]string, gin.H) {

--- a/panel-api/internal/countryexempt/countryexempt_test.go
+++ b/panel-api/internal/countryexempt/countryexempt_test.go
@@ -23,15 +23,18 @@ func TestParseZone(t *testing.T) {
 
 func TestZoneCacheRoundTrip(t *testing.T) {
 	zc := zoneCache{dir: t.TempDir()}
-	if err := zc.write("IL", []string{"1.0.0.0/8", "2.0.0.0/8"}); err != nil {
+	if err := zc.write("IL", []string{"1.0.0.0/8", "2.0.0.0/8"}, snapshotMeta{source: sourceMMDB, mmdbMTime: 1234}); err != nil {
 		t.Fatal(err)
 	}
-	got, mtime, err := zc.read("IL")
+	got, meta, mtime, err := zc.read("IL")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 2 || got[0] != "1.0.0.0/8" {
 		t.Fatalf("got %v", got)
+	}
+	if meta.source != sourceMMDB || meta.mmdbMTime != 1234 {
+		t.Fatalf("meta = %+v", meta)
 	}
 	if time.Since(mtime) > time.Minute {
 		t.Fatalf("mtime should be fresh: %v", mtime)
@@ -118,11 +121,18 @@ func TestLoadCountry_NoSnapshotNoNetwork_IsError(t *testing.T) {
 	}
 }
 
-// fakeAgent records Call verbs/params and returns canned responses.
+// fakeAgent records Call verbs/params and returns canned responses. The
+// derive verb returns deriveErr / deriveZones so tests can pick between the
+// mmdb path and the ipdeny fallback; stat returns statErr / statMTime.
 type fakeAgent struct {
-	t        *testing.T
-	calls    []fakeCall
-	listJSON any
+	t          *testing.T
+	calls      []fakeCall
+	listJSON   any
+	deriveErr  error
+	deriveZone map[string][]string
+	deriveMT   int64
+	statErr    error
+	statMTime  int64
 }
 
 type fakeCall struct {
@@ -131,9 +141,21 @@ type fakeCall struct {
 }
 
 func (f *fakeAgent) Call(_ context.Context, verb string, params any) (json.RawMessage, error) {
-	f.calls = append(f.calls, fakeCall{verb: verb, params: params.(map[string]any)})
-	if verb == "security.crowdsec.allowlists.list" {
+	p, _ := params.(map[string]any)
+	f.calls = append(f.calls, fakeCall{verb: verb, params: p})
+	switch verb {
+	case "security.crowdsec.allowlists.list":
 		return json.Marshal(f.listJSON)
+	case "security.crowdsec.country_zones.derive":
+		if f.deriveErr != nil {
+			return nil, f.deriveErr
+		}
+		return json.Marshal(mmdbDeriveResponse{Path: "/fake.mmdb", MTime: f.deriveMT, Zones: f.deriveZone})
+	case "security.crowdsec.mmdb.stat":
+		if f.statErr != nil {
+			return nil, f.statErr
+		}
+		return json.Marshal(map[string]any{"path": "/fake.mmdb", "mtime": f.statMTime, "size": 1})
 	}
 	return json.RawMessage(`{}`), nil
 }
@@ -161,7 +183,7 @@ func TestSync_FullFlow_AddsOnlyNew(t *testing.T) {
 	}}
 	s, fa := newTestSyncer(t, srv, listJSON)
 
-	if err := s.syncLocked(context.Background(), []string{"IL"}, false); err != nil {
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -202,7 +224,7 @@ func TestSync_EmptySelection_RemovesOnlyOurs(t *testing.T) {
 	}}
 	s, fa := newTestSyncer(t, srv, listJSON)
 
-	if err := s.syncLocked(context.Background(), nil, false); err != nil {
+	if err := s.syncLocked(context.Background(), nil, nil, false); err != nil {
 		t.Fatal(err)
 	}
 	var removedValues []string
@@ -224,7 +246,7 @@ func TestSync_Converged_NoAgentSyncCalls(t *testing.T) {
 	}}
 	s, fa := newTestSyncer(t, srv, listJSON)
 
-	if err := s.syncLocked(context.Background(), []string{"IL"}, false); err != nil {
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, c := range fa.calls {
@@ -241,5 +263,181 @@ func TestSplitCountries(t *testing.T) {
 	got := SplitCountries("IL, US ,,")
 	if len(got) != 2 || got[0] != "IL" || got[1] != "US" {
 		t.Fatalf("got %v", got)
+	}
+}
+
+// ---- mmdb-backed derivation (ADR-0166 amendment) ----------------------------
+
+func TestLoadAll_PrefersMMDBOverIPDeny(t *testing.T) {
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		fmt.Fprint(w, "9.9.9.0/24\n")
+	}))
+	withZoneURLs(t, srv)
+	fa := &fakeAgent{t: t, listJSON: map[string]any{"items": []any{}},
+		deriveZone: map[string][]string{"IL": {"1.0.0.0/25", "1.0.0.128/25"}},
+		deriveMT:   42}
+	s := &Syncer{Agent: fa, HTTP: srv.Client(), CacheDir: t.TempDir(), Log: slog.Default()}
+
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	if hits != 0 {
+		t.Fatalf("ipdeny must not be consulted when derive succeeds (hits=%d)", hits)
+	}
+	// Siblings must arrive merged, tagged with the country.
+	var adds []csSyncEntry
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_allowlist.sync" {
+			adds = append(adds, c.params["adds"].([]csSyncEntry)...)
+		}
+	}
+	if len(adds) != 1 || adds[0].Value != "1.0.0.0/24" || adds[0].Comment != "country:IL" {
+		t.Fatalf("adds = %+v, want merged 1.0.0.0/24 country:IL", adds)
+	}
+	// Snapshot must be mmdb-sourced with the marker.
+	_, meta, _, err := zoneCache{dir: s.CacheDir}.read("IL")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.source != sourceMMDB || meta.mmdbMTime != 42 {
+		t.Fatalf("snapshot meta = %+v", meta)
+	}
+}
+
+func TestLoadAll_DeriveFailure_FallsBackToIPDeny(t *testing.T) {
+	srv := zoneTestServer(t, "1.0.0.0/8\n", "", false)
+	fa := &fakeAgent{t: t, listJSON: map[string]any{"items": []any{}},
+		deriveErr: fmt.Errorf("no mmdb")}
+	s := &Syncer{Agent: fa, HTTP: srv.Client(), CacheDir: t.TempDir(), Log: slog.Default()}
+	withZoneURLs(t, srv)
+
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	var adds []csSyncEntry
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_allowlist.sync" {
+			adds = append(adds, c.params["adds"].([]csSyncEntry)...)
+		}
+	}
+	if len(adds) != 1 || adds[0].Value != "1.0.0.0/8" {
+		t.Fatalf("adds = %+v, want ipdeny 1.0.0.0/8", adds)
+	}
+}
+
+func TestLoadAll_MMDBNewerThanSnapshot_ReDerives(t *testing.T) {
+	zc := zoneCache{dir: t.TempDir()}
+	if err := zc.write("IL", []string{"1.0.0.0/8"}, snapshotMeta{source: sourceMMDB, mmdbMTime: 100}); err != nil {
+		t.Fatal(err)
+	}
+	srv := zoneTestServer(t, "", "", false)
+	fa := &fakeAgent{t: t, listJSON: map[string]any{"items": []any{}},
+		statMTime:  200, // classifier DB updated after the snapshot
+		deriveZone: map[string][]string{"IL": {"2.0.0.0/8"}},
+		deriveMT:   200}
+	s := &Syncer{Agent: fa, HTTP: srv.Client(), CacheDir: zc.dir, Log: slog.Default()}
+	withZoneURLs(t, srv)
+
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	derived := false
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_zones.derive" {
+			derived = true
+		}
+	}
+	if !derived {
+		t.Fatal("mmdb newer than snapshot must trigger re-derivation")
+	}
+	var adds []csSyncEntry
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_allowlist.sync" {
+			adds = append(adds, c.params["adds"].([]csSyncEntry)...)
+		}
+	}
+	if len(adds) != 1 || adds[0].Value != "2.0.0.0/8" {
+		t.Fatalf("adds = %+v, want re-derived 2.0.0.0/8", adds)
+	}
+}
+
+func TestLoadAll_MMDBUnchanged_KeepsSnapshot(t *testing.T) {
+	zc := zoneCache{dir: t.TempDir()}
+	if err := zc.write("IL", []string{"1.0.0.0/8"}, snapshotMeta{source: sourceMMDB, mmdbMTime: 100}); err != nil {
+		t.Fatal(err)
+	}
+	srv := zoneTestServer(t, "", "", false)
+	fa := &fakeAgent{t: t, listJSON: map[string]any{"items": []any{
+		map[string]string{"value": "1.0.0.0/8", "reason": "country:IL"},
+	}}, statMTime: 100} // same mtime — snapshot still valid
+	s := &Syncer{Agent: fa, HTTP: srv.Client(), CacheDir: zc.dir, Log: slog.Default()}
+	withZoneURLs(t, srv)
+
+	if err := s.syncLocked(context.Background(), []string{"IL"}, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_zones.derive" {
+			t.Fatal("unchanged mmdb must not re-derive")
+		}
+		if c.verb == "security.crowdsec.country_allowlist.sync" {
+			t.Fatal("converged state must not sync")
+		}
+	}
+}
+
+func TestSync_ExtraCIDRs_ManagedAsCountryExtra(t *testing.T) {
+	srv := zoneTestServer(t, "1.0.0.0/8\n", "", false)
+	listJSON := map[string]any{"items": []map[string]string{
+		{"value": "8.8.8.8/32", "reason": "country:extra"}, // stale extra — must go
+		{"value": "10.0.0.0/8", "reason": "office LAN"},    // manual — must stay
+	}}
+	s, fa := newTestSyncer(t, srv, listJSON)
+
+	err := s.syncLocked(context.Background(), []string{"IL"}, []string{"203.0.113.7", "192.0.2.0/25"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var adds []csSyncEntry
+	var removes []string
+	for _, c := range fa.calls {
+		if c.verb != "security.crowdsec.country_allowlist.sync" {
+			continue
+		}
+		adds = append(adds, c.params["adds"].([]csSyncEntry)...)
+		removes = append(removes, c.params["removes"].([]string)...)
+	}
+	var extraAdds []string
+	for _, a := range adds {
+		if a.Comment == "country:extra" {
+			extraAdds = append(extraAdds, a.Value)
+		}
+	}
+	if len(extraAdds) != 2 {
+		t.Fatalf("extra adds = %v, want 203.0.113.7/32 + 192.0.2.0/25", extraAdds)
+	}
+	if len(removes) != 1 || removes[0] != "8.8.8.8/32" {
+		t.Fatalf("removes = %v, want [8.8.8.8/32]", removes)
+	}
+}
+
+func TestSync_InvalidExtraCIDR_Skipped(t *testing.T) {
+	srv := zoneTestServer(t, "1.0.0.0/8\n", "", false)
+	s, fa := newTestSyncer(t, srv, map[string]any{"items": []any{}})
+
+	err := s.syncLocked(context.Background(), []string{"IL"}, []string{"garbage"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range fa.calls {
+		if c.verb == "security.crowdsec.country_allowlist.sync" {
+			for _, a := range c.params["adds"].([]csSyncEntry) {
+				if a.Comment == "country:extra" {
+					t.Fatalf("invalid extra must not be synced: %+v", a)
+				}
+			}
+		}
 	}
 }

--- a/panel-api/internal/countryexempt/merge.go
+++ b/panel-api/internal/countryexempt/merge.go
@@ -1,0 +1,92 @@
+package countryexempt
+
+import (
+	"net/netip"
+	"sort"
+)
+
+// mergeCIDRs collapses a CIDR list into a minimal equivalent set: entries
+// contained in a broader entry are dropped and adjacent siblings are
+// repeatedly coalesced into their parent. mmdb-derived zones arrive
+// city-granular (thousands of small blocks for a large country); the merge
+// is what keeps the LAPI allowlist compact. Garbage lines are skipped —
+// inputs are validated upstream, this is the defensive layer.
+func mergeCIDRs(cidrs []string) []string {
+	v4 := map[netip.Prefix]struct{}{}
+	v6 := map[netip.Prefix]struct{}{}
+	for _, c := range cidrs {
+		p, err := netip.ParsePrefix(c)
+		if err != nil {
+			continue
+		}
+		p = p.Masked()
+		if p.Addr().Is4() {
+			v4[p] = struct{}{}
+		} else {
+			v6[p] = struct{}{}
+		}
+	}
+	return append(collapse(v4), collapse(v6)...)
+}
+
+// collapse runs the drop-contained + merge-siblings fixpoint over one
+// address family. Every pass strictly shrinks the set, so it terminates.
+func collapse(set map[netip.Prefix]struct{}) []string {
+	for {
+		changed := false
+		for p := range set {
+			if containedByAny(set, p) {
+				delete(set, p) // already covered by a broader prefix
+				changed = true
+				continue
+			}
+			if p.Bits() == 0 {
+				continue
+			}
+			parent := netip.PrefixFrom(p.Addr(), p.Bits()-1).Masked()
+			sib := sibling(p)
+			if _, ok := set[sib]; ok {
+				delete(set, p)
+				delete(set, sib)
+				set[parent] = struct{}{}
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p.String())
+	}
+	sort.Strings(out) // deterministic snapshots and tests
+	return out
+}
+
+// containedByAny reports whether any strict ancestor of p is in the set.
+func containedByAny(set map[netip.Prefix]struct{}, p netip.Prefix) bool {
+	for b := p.Bits() - 1; b >= 0; b-- {
+		if _, ok := set[netip.PrefixFrom(p.Addr(), b).Masked()]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sibling flips the last significant bit of p: the other half of p's parent.
+func sibling(p netip.Prefix) netip.Prefix {
+	bits := p.Bits()
+	flip := func(b []byte) {
+		i := (bits - 1) / 8
+		b[i] ^= 1 << (7 - (bits-1)%8)
+	}
+	if p.Addr().Is4() {
+		a := p.Addr().As4()
+		flip(a[:])
+		return netip.PrefixFrom(netip.AddrFrom4(a), bits).Masked()
+	}
+	a := p.Addr().As16()
+	flip(a[:])
+	return netip.PrefixFrom(netip.AddrFrom16(a), bits).Masked()
+}

--- a/panel-api/internal/countryexempt/merge_test.go
+++ b/panel-api/internal/countryexempt/merge_test.go
@@ -1,0 +1,66 @@
+package countryexempt
+
+import (
+	"testing"
+)
+
+func TestMergeCIDRs_SiblingCoalesce(t *testing.T) {
+	got := mergeCIDRs([]string{"1.0.0.0/25", "1.0.0.128/25"})
+	if len(got) != 1 || got[0] != "1.0.0.0/24" {
+		t.Fatalf("got %v, want [1.0.0.0/24]", got)
+	}
+}
+
+func TestMergeCIDRs_DropsContained(t *testing.T) {
+	got := mergeCIDRs([]string{"1.0.0.0/8", "1.2.3.0/24", "1.2.3.4/32"})
+	if len(got) != 1 || got[0] != "1.0.0.0/8" {
+		t.Fatalf("got %v, want [1.0.0.0/8]", got)
+	}
+}
+
+func TestMergeCIDRs_MultiLevelCascade(t *testing.T) {
+	// Four /26s forming a /24 must collapse all the way up.
+	got := mergeCIDRs([]string{
+		"10.0.0.0/26", "10.0.0.64/26", "10.0.0.128/26", "10.0.0.192/26",
+	})
+	if len(got) != 1 || got[0] != "10.0.0.0/24" {
+		t.Fatalf("got %v, want [10.0.0.0/24]", got)
+	}
+}
+
+func TestMergeCIDRs_FamiliesStaySeparate(t *testing.T) {
+	got := mergeCIDRs([]string{"2001:db8::/64", "2001:db8:0:1::/64", "1.0.0.0/24"})
+	if len(got) != 2 {
+		t.Fatalf("v4 and v6 must not merge: %v", got)
+	}
+	if got[0] != "1.0.0.0/24" || got[1] != "2001:db8::/63" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestMergeCIDRs_SkipsGarbageAndNormalizes(t *testing.T) {
+	got := mergeCIDRs([]string{"not-a-cidr", "1.2.3.4/24", ""})
+	if len(got) != 1 || got[0] != "1.2.3.0/24" {
+		t.Fatalf("got %v, want [1.2.3.0/24] (masked)", got)
+	}
+}
+
+func TestNormalizeCIDR(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4":       "1.2.3.4/32",
+		"1.2.3.4/24":    "1.2.3.0/24",
+		"2001:db8::1":   "2001:db8::1/128",
+		"2001:db8::1/64": "2001:db8::/64",
+	}
+	for in, want := range cases {
+		got, err := NormalizeCIDR(in)
+		if err != nil || got != want {
+			t.Fatalf("NormalizeCIDR(%q) = %q, %v; want %q", in, got, err, want)
+		}
+	}
+	for _, bad := range []string{"", "nonsense", "1.2.3.256", "10.0.0.0/33"} {
+		if _, err := NormalizeCIDR(bad); err == nil {
+			t.Fatalf("NormalizeCIDR(%q) must fail", bad)
+		}
+	}
+}

--- a/panel-api/internal/countryexempt/mmdb.go
+++ b/panel-api/internal/countryexempt/mmdb.go
@@ -1,0 +1,72 @@
+package countryexempt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// mmdbDeriveResponse mirrors the agent's
+// security.crowdsec.country_zones.derive payload.
+type mmdbDeriveResponse struct {
+	Path  string              `json:"path"`
+	MTime int64               `json:"mtime"`
+	Zones map[string][]string `json:"zones"`
+}
+
+// deriveViaAgent asks the agent (root) to walk the local MaxMind database —
+// the same file the GeoIP enricher classifies with — and return per-country
+// CIDR sets. One call covers every needed country: a full-tree walk costs
+// seconds, so per-country calls would multiply that.
+func (s *Syncer) deriveViaAgent(ctx context.Context, countries []string) (*mmdbDeriveResponse, error) {
+	raw, err := s.Agent.Call(ctx, "security.crowdsec.country_zones.derive", map[string]any{
+		"countries": countries,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("derive country zones via agent: %w", err)
+	}
+	var payload mmdbDeriveResponse
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("parse derive response: %w", err)
+	}
+	return &payload, nil
+}
+
+// mmdbStat returns the mtime (unix) of the mmdb the classifier uses. An
+// error means "no info" — callers degrade to age-based snapshot freshness.
+func (s *Syncer) mmdbStat(ctx context.Context) (int64, error) {
+	raw, err := s.Agent.Call(ctx, "security.crowdsec.mmdb.stat", map[string]any{})
+	if err != nil {
+		return 0, err
+	}
+	var payload struct {
+		MTime int64 `json:"mtime"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return 0, fmt.Errorf("parse mmdb stat: %w", err)
+	}
+	return payload.MTime, nil
+}
+
+// NormalizeCIDR validates one operator-supplied allowlist entry. Prefixes
+// are masked to canonical form; a bare IP becomes a host prefix (/32, /128)
+// so every stored entry is a valid cscli allowlist value.
+func NormalizeCIDR(s string) (string, error) {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return "", fmt.Errorf("empty value")
+	}
+	if p, err := netip.ParsePrefix(v); err == nil {
+		return p.Masked().String(), nil
+	}
+	if a, err := netip.ParseAddr(v); err == nil {
+		bits := 32
+		if a.Is6() {
+			bits = 128
+		}
+		return netip.PrefixFrom(a, bits).String(), nil
+	}
+	return "", fmt.Errorf("%q is not an IP or CIDR", s)
+}

--- a/panel-api/internal/countryexempt/refresher.go
+++ b/panel-api/internal/countryexempt/refresher.go
@@ -10,17 +10,23 @@ import (
 // refreshInterval is the refresher tick. 60s matches the reconciler's
 // convergence model: a CLI-originated change to the country selection is
 // picked up within a minute (the CLI process can't run the background
-// sync itself — it exits). Zone snapshots only refetch when stale, so a
-// converged tick costs one agent round-trip.
+// sync itself — it exits).
 const refreshInterval = time.Minute
 
+// verifyInterval is how often a converged selection is re-checked anyway.
+// The verify sync is what picks up stale snapshots (>snapshotMaxAge) and —
+// more importantly — mmdb updates: the GeoIP DB refreshes regularly on the
+// host, and country coverage must track the DB the classifier actually
+// reads. A converged verify costs two agent round-trips (mmdb stat +
+// allowlist list).
+const verifyInterval = 15 * time.Minute
+
 // StartRefresher converges the country CIDR allowlist until ctx is done
-// (in-process goroutine — repo convention, no external queue). countries
-// come from settings on every tick so a PUT or CLI set takes effect
-// without a restart. A tick syncs when the selection changed, the last
-// sync failed, or the snapshots are stale; a converged steady state
-// costs one agent round-trip per minute.
-func StartRefresher(ctx context.Context, s *Syncer, countriesFn func(ctx context.Context) []string, log *slog.Logger) {
+// (in-process goroutine — repo convention, no external queue). The
+// selection comes from settings on every tick so a PUT or CLI set takes
+// effect without a restart. A tick syncs when the selection changed, the
+// last sync failed, or the verify interval elapsed.
+func StartRefresher(ctx context.Context, s *Syncer, selectionFn func(ctx context.Context) (countries []string, extras []string), log *slog.Logger) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -33,25 +39,29 @@ func StartRefresher(ctx context.Context, s *Syncer, countriesFn func(ctx context
 			return
 		case <-t.C:
 		}
-		countries := countriesFn(ctx)
-		selection := strings.Join(countries, ",")
+		countries, extras := selectionFn(ctx)
+		selection := strings.Join(countries, ",") + "|" + strings.Join(extras, ",")
 		changed := selection != lastSelection
-		_, lastErr, running := Status()
+		lastSuccess, lastErr, running := Status()
 		if running {
 			continue
 		}
-		if !changed && lastErr == nil {
+		verifyDue := time.Since(lastSuccess) > verifyInterval
+		if !changed && lastErr == nil && !verifyDue {
 			continue
 		}
 		lastSelection = selection
-		// forceRefresh=false: loadCountry refetches expired snapshots
-		// itself; force is reserved for the operator's explicit /sync.
-		log.Info("countryexempt: refresh tick", "countries", len(countries), "changed", changed, "retry", lastErr != nil)
-		KickBackground(log, s, countries, false)
+		// forceRefresh=false: loadAll refetches expired snapshots and
+		// re-derives on mmdb change itself; force is reserved for the
+		// operator's explicit /sync.
+		log.Info("countryexempt: refresh tick", "countries", len(countries),
+			"changed", changed, "retry", lastErr != nil, "verify", verifyDue && !changed)
+		KickBackground(log, s, countries, extras, false)
 	}
 }
 
-// SplitCountries parses the server_settings CSV into a country list.
+// SplitCountries parses the server_settings CSV into a country list. Also
+// used for the extra-CIDRs CSV — same shape.
 func SplitCountries(csv string) []string {
 	if csv == "" {
 		return nil

--- a/panel-api/internal/countryexempt/runner.go
+++ b/panel-api/internal/countryexempt/runner.go
@@ -20,6 +20,7 @@ var runner struct {
 	pending     bool
 	force       bool
 	countries   []string
+	extras      []string
 	syncer      *Syncer
 	lastSuccess time.Time
 	lastErr     error
@@ -28,13 +29,14 @@ var runner struct {
 // KickBackground starts a sync in the background (or marks the latest
 // state pending when one is already running) and returns immediately.
 // The PUT handler uses this so a US-scale import never blocks the request.
-func KickBackground(log *slog.Logger, s *Syncer, countries []string, forceRefresh bool) {
+func KickBackground(log *slog.Logger, s *Syncer, countries []string, extras []string, forceRefresh bool) {
 	if log == nil {
 		log = slog.Default()
 	}
 	runner.mu.Lock()
 	runner.syncer = s
 	runner.countries = append([]string(nil), countries...)
+	runner.extras = append([]string(nil), extras...)
 	runner.force = runner.force || forceRefresh
 	runner.pending = true
 	if runner.running {
@@ -55,12 +57,13 @@ func KickBackground(log *slog.Logger, s *Syncer, countries []string, forceRefres
 			runner.pending = false
 			s := runner.syncer
 			countries := append([]string(nil), runner.countries...)
+			extras := append([]string(nil), runner.extras...)
 			force := runner.force
 			runner.force = false
 			runner.mu.Unlock()
 
 			ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
-			err := s.syncLocked(ctx, countries, force)
+			err := s.syncLocked(ctx, countries, extras, force)
 			cancel()
 
 			runner.mu.Lock()

--- a/panel-api/internal/countryexempt/sync.go
+++ b/panel-api/internal/countryexempt/sync.go
@@ -21,6 +21,11 @@ const CountryAllowlistName = "jabali-country-allowlist"
 // diff can tell "ours, from country CC" apart from anything else.
 const commentPrefix = "country:"
 
+// extraTag is the pseudo-country used for the operator's supplemental
+// CIDRs (server_settings.country_exempt_extra_cidrs). Managed like a
+// country entry: removing it from settings removes it from the allowlist.
+const extraTag = "extra"
+
 // addChunk caps entries per agent call — one cscli invocation per chunk
 // (measured ~5k entries / 26s on testserver; larger chunks risk the agent's
 // NDJSON size limit and hide progress).
@@ -58,23 +63,31 @@ type csSyncEntry struct {
 
 // syncLocked computes desired-vs-current and applies the delta. Callers
 // must serialize — package-level KickBackground is the only entry point
-// (PUT kick, CLI sync, weekly refresher all go through it).
-func (s *Syncer) syncLocked(ctx context.Context, countries []string, forceRefresh bool) error {
+// (PUT kick, CLI sync, weekly refresher all go through it). extras are the
+// operator's supplemental CIDRs (already normalized upstream; re-validated
+// here defensively).
+func (s *Syncer) syncLocked(ctx context.Context, countries []string, extras []string, forceRefresh bool) error {
 	zc := zoneCache{dir: s.CacheDir}
 
-	// Desired state: cidr → country code.
+	// Desired state: cidr → country code (or extraTag for supplemental
+	// entries).
+	zones, err := s.loadAll(ctx, zc, countries, forceRefresh)
+	if err != nil {
+		return err
+	}
 	desired := map[string]string{}
-	for _, code := range countries {
-		cidrs, stale, err := loadCountry(ctx, s.HTTP, zc, code, forceRefresh)
-		if err != nil {
-			return fmt.Errorf("load country %s: %w", code, err)
-		}
-		if stale {
-			s.Log.Warn("countryexempt: using fallback CIDR snapshot", "country", code)
-		}
+	for code, cidrs := range zones {
 		for _, c := range cidrs {
 			desired[c] = code
 		}
+	}
+	for _, raw := range extras {
+		c, cerr := NormalizeCIDR(raw)
+		if cerr != nil {
+			s.Log.Warn("countryexempt: skipping invalid extra CIDR", "value", raw)
+			continue
+		}
+		desired[c] = extraTag
 	}
 
 	// Current state: LAPI is truth (ADR-0061).
@@ -126,6 +139,80 @@ func (s *Syncer) syncLocked(ctx context.Context, countries []string, forceRefres
 	return nil
 }
 
+// loadAll resolves the CIDR set for every selected country. Source order
+// per country: fresh snapshot → mmdb derive (one agent round-trip for all
+// needed codes) → ipdeny fetch → stale snapshot. mmdb-derived snapshots
+// additionally expire the moment the classifier's mmdb is newer than the
+// snapshot's marker — country coverage must track the DB the enricher
+// actually reads, not a weekly calendar.
+func (s *Syncer) loadAll(ctx context.Context, zc zoneCache, countries []string, forceRefresh bool) (map[string][]string, error) {
+	out := make(map[string][]string, len(countries))
+	var need []string
+	mmdbSourced := map[string]snapshotMeta{}
+
+	for _, code := range countries {
+		cidrs, meta, mtime, rerr := zc.read(code)
+		switch {
+		case rerr == nil && !forceRefresh && time.Since(mtime) < snapshotMaxAge:
+			out[code] = cidrs
+			if meta.source == sourceMMDB {
+				mmdbSourced[code] = meta
+			}
+		default:
+			need = append(need, code)
+		}
+	}
+
+	// mmdb freshness check — one cheap stat for all mmdb-sourced snapshots.
+	if len(mmdbSourced) > 0 && !forceRefresh {
+		if mtime, serr := s.mmdbStat(ctx); serr == nil {
+			for code, meta := range mmdbSourced {
+				if mtime > meta.mmdbMTime {
+					s.Log.Info("countryexempt: mmdb newer than snapshot, re-deriving",
+						"country", code, "snapshot_mtime", meta.mmdbMTime, "mmdb_mtime", mtime)
+					delete(out, code)
+					need = append(need, code)
+				}
+			}
+		} else {
+			s.Log.Warn("countryexempt: mmdb stat failed, keeping age-based freshness", "err", serr)
+		}
+	}
+
+	if len(need) == 0 {
+		return out, nil
+	}
+	derived, derr := s.deriveViaAgent(ctx, need)
+	if derr != nil {
+		s.Log.Warn("countryexempt: mmdb derive unavailable, falling back to ipdeny", "err", derr)
+	}
+	for _, code := range need {
+		if derr == nil && len(derived.Zones[code]) > 0 {
+			merged := mergeCIDRs(derived.Zones[code])
+			if werr := zc.write(code, merged, snapshotMeta{source: sourceMMDB, mmdbMTime: derived.MTime}); werr != nil {
+				// Non-fatal: proceed with the in-memory set (same policy as
+				// the ipdeny path).
+				s.Log.Warn("countryexempt: snapshot write failed", "country", code, "err", werr)
+			}
+			out[code] = merged
+			s.Log.Info("countryexempt: derived zone from mmdb", "country", code,
+				"raw", len(derived.Zones[code]), "merged", len(merged))
+			continue
+		}
+		// Derive failed or the mmdb has no networks for this code — ipdeny
+		// (which itself falls back to any stale snapshot on fetch failure).
+		cidrs, stale, ferr := loadCountry(ctx, s.HTTP, zc, code, true)
+		if ferr != nil {
+			return nil, fmt.Errorf("load country %s: %w", code, ferr)
+		}
+		if stale {
+			s.Log.Warn("countryexempt: using fallback CIDR snapshot", "country", code)
+		}
+		out[code] = cidrs
+	}
+	return out, nil
+}
+
 // allowlistItem mirrors the agent's csAllowlistEntryWire wire shape.
 type allowlistItem struct {
 	Value  string `json:"value"`
@@ -136,8 +223,8 @@ type allowlistItem struct {
 // used by the `jabali crowdsec country-exempt sync` CLI, which cannot use
 // KickBackground: a CLI exits, killing the background goroutine before it
 // does any work (observed on testserver 2026-08-13).
-func (s *Syncer) RunSync(ctx context.Context, countries []string, forceRefresh bool) error {
-	return s.syncLocked(ctx, countries, forceRefresh)
+func (s *Syncer) RunSync(ctx context.Context, countries []string, extras []string, forceRefresh bool) error {
+	return s.syncLocked(ctx, countries, extras, forceRefresh)
 }
 
 // listCurrent returns value → comment for every entry in the country

--- a/panel-api/internal/countryexempt/zones.go
+++ b/panel-api/internal/countryexempt/zones.go
@@ -1,14 +1,18 @@
 // Package countryexempt keeps CrowdSec from ever blocking the operator's
 // chosen countries (ADR-0166). It owns the panel-api half of the feature:
 //
-//   - fetching per-country CIDR sets (ipdeny aggregated zones, IPv4 + IPv6)
-//     with a snapshot cache under /var/lib/jabali-panel/country-zones —
-//     panel-api does outbound HTTPS because the agent never may (ADR-0050);
+//   - resolving per-country CIDR sets — primarily derived by the agent from
+//     the local MaxMind mmdb (the same DB the GeoIP enricher classifies
+//     with, so coverage is exact by construction), with ipdeny aggregated
+//     zones (IPv4 + IPv6) as fallback; snapshots live under
+//     /var/lib/jabali-panel/country-zones — panel-api does outbound HTTPS
+//     because the agent never may (ADR-0050);
 //   - diffing the desired CIDR set against the jabali-country-allowlist
 //     LAPI AllowList (LAPI is truth — ADR-0061) and pushing deltas to the
 //     agent in ≤4000-entry chunks;
 //   - a weekly-staleness refresher goroutine (in-process, ctx-tied — repo
-//     convention, no external queue).
+//     convention, no external queue) that also re-derives when the mmdb
+//     itself changes.
 //
 // The agent owns the host side: the s02-enrich GeoIP parser whitelist
 // (security.crowdsec.country_exempt.set) and the cscli mechanics
@@ -22,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -42,6 +47,23 @@ var zoneURLTemplates = []string{
 	"https://www.ipdeny.com/ipv6/ipaddresses/aggregated/%s-aggregated.zone",
 }
 
+// zoneSource records where a snapshot came from.
+type zoneSource string
+
+const (
+	sourceUnknown zoneSource = ""       // legacy snapshot without a header
+	sourceIPDeny  zoneSource = "ipdeny" // registry-allocation data (fallback)
+	sourceMMDB    zoneSource = "mmdb"   // derived from the classifier's own DB
+)
+
+// snapshotMeta rides along with a cached zone file. mmdbMTime is the mmdb
+// mtime (unix) at derivation time — the refresher re-derives when the
+// classifier's DB is newer than this marker. 0 for ipdeny snapshots.
+type snapshotMeta struct {
+	source    zoneSource
+	mmdbMTime int64
+}
+
 // zoneCache pairs the two snapshot files for a country.
 type zoneCache struct {
 	dir string
@@ -51,27 +73,44 @@ func (zc zoneCache) path(code string) string {
 	return filepath.Join(zc.dir, strings.ToUpper(code)+".zone")
 }
 
-func (zc zoneCache) read(code string) ([]string, time.Time, error) {
+func (zc zoneCache) read(code string) ([]string, snapshotMeta, time.Time, error) {
+	var meta snapshotMeta
 	body, err := os.ReadFile(zc.path(code))
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, meta, time.Time{}, err
 	}
 	var st os.FileInfo
 	if st, err = os.Stat(zc.path(code)); err != nil {
-		return nil, time.Time{}, err
+		return nil, meta, time.Time{}, err
 	}
-	return parseZone(string(body)), st.ModTime(), nil
+	for _, line := range strings.Split(string(body), "\n") {
+		if rest, ok := strings.CutPrefix(line, "# source: "); ok {
+			meta.source = zoneSource(strings.TrimSpace(rest))
+		}
+		if rest, ok := strings.CutPrefix(line, "# mmdb-mtime: "); ok {
+			meta.mmdbMTime, _ = strconv.ParseInt(strings.TrimSpace(rest), 10, 64)
+		}
+	}
+	return parseZone(string(body)), meta, st.ModTime(), nil
 }
 
-func (zc zoneCache) write(code string, cidrs []string) error {
-	// #nosec G301 — zone snapshots are public data (ipdeny CIDR lists);
-	// 0755 matches the neighbouring /var/lib/jabali-panel state dirs.
+func (zc zoneCache) write(code string, cidrs []string, meta snapshotMeta) error {
+	// #nosec G301 — zone snapshots are public data (GeoIP/registry CIDR
+	// lists); 0755 matches the neighbouring /var/lib/jabali-panel state dirs.
 	if err := os.MkdirAll(zc.dir, 0o755); err != nil {
 		return err
 	}
+	var b strings.Builder
+	if meta.source != sourceUnknown {
+		fmt.Fprintf(&b, "# source: %s\n", meta.source)
+	}
+	if meta.mmdbMTime > 0 {
+		fmt.Fprintf(&b, "# mmdb-mtime: %d\n", meta.mmdbMTime)
+	}
+	b.WriteString(strings.Join(cidrs, "\n") + "\n")
 	tmp := zc.path(code) + ".tmp"
 	// #nosec G306 — same rationale: public, non-secret snapshot data.
-	if err := os.WriteFile(tmp, []byte(strings.Join(cidrs, "\n")+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(tmp, []byte(b.String()), 0o644); err != nil {
 		return err
 	}
 	return os.Rename(tmp, zc.path(code))
@@ -130,20 +169,20 @@ func fetchCountry(ctx context.Context, client *http.Client, code string) ([]stri
 // from a fallback snapshot.
 func loadCountry(ctx context.Context, client *http.Client, zc zoneCache, code string, forceRefresh bool) (cidrs []string, stale bool, err error) {
 	if !forceRefresh {
-		if cached, mtime, rerr := zc.read(code); rerr == nil && time.Since(mtime) < snapshotMaxAge {
+		if cached, _, mtime, rerr := zc.read(code); rerr == nil && time.Since(mtime) < snapshotMaxAge {
 			return cached, false, nil
 		}
 	}
 	fresh, ferr := fetchCountry(ctx, client, code)
 	if ferr == nil {
-		if werr := zc.write(code, fresh); werr != nil {
+		if werr := zc.write(code, fresh, snapshotMeta{source: sourceIPDeny}); werr != nil {
 			// Cache write failure is non-fatal: the sync can proceed with
 			// the in-memory set; next tick retries the write.
 			return fresh, true, nil
 		}
 		return fresh, false, nil
 	}
-	if cached, _, rerr := zc.read(code); rerr == nil {
+	if cached, _, _, rerr := zc.read(code); rerr == nil {
 		return cached, true, nil
 	}
 	return nil, false, ferr

--- a/panel-api/internal/db/migrations/000263_server_settings_country_exempt_extra.down.sql
+++ b/panel-api/internal/db/migrations/000263_server_settings_country_exempt_extra.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+    DROP COLUMN country_exempt_extra_cidrs;

--- a/panel-api/internal/db/migrations/000263_server_settings_country_exempt_extra.up.sql
+++ b/panel-api/internal/db/migrations/000263_server_settings_country_exempt_extra.up.sql
@@ -1,0 +1,8 @@
+-- Supplemental CIDRs for the country ban exemption (ADR-0166 amendment
+-- 2026-08-14). Operator-supplied IPs/CIDRs that must never be blocked,
+-- merged into the jabali-country-allowlist LAPI AllowList tagged
+-- "country:extra" so they are managed (removed when removed here).
+-- TEXT for the same row-size reason as country_exempt_countries (000262).
+
+ALTER TABLE server_settings
+    ADD COLUMN country_exempt_extra_cidrs TEXT NOT NULL DEFAULT ('');

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -193,7 +193,8 @@ type ServerSettings struct {
 	// the jabali-country-allowlist LAPI AllowList (CIDR sets synced by
 	// panel-api's countryexempt syncer). Wins over the geoblock deny-list
 	// (AllowLists evaluate before AppSec pre_eval — ADR-0061).
-	CountryExemptCountries string `gorm:"column:country_exempt_countries;type:text;not null;default:''" json:"country_exempt_countries"`
+	CountryExemptCountries  string `gorm:"column:country_exempt_countries;type:text;not null;default:''" json:"country_exempt_countries"`
+	CountryExemptExtraCIDRs string `gorm:"column:country_exempt_extra_cidrs;type:text;not null;default:''" json:"country_exempt_extra_cidrs"`
 	// CrowdsecSensitivity preset (M27 follow-up). Applied via agent's
 	// security.crowdsec.sensitivity.apply verb which writes:
 	//   /etc/crowdsec/profiles.yaml          (ban duration)

--- a/panel-ui/src/hooks/useSecurityCrowdsec.ts
+++ b/panel-ui/src/hooks/useSecurityCrowdsec.ts
@@ -271,9 +271,12 @@ export function useUpdateAppSecGeoblock() {
 // from any CrowdSec decision source (scenario bans, AppSec inband, CAPI/
 // console blocklists, captchas). server_settings is truth; the agent renders
 // the s02-enrich GeoIP whitelist and a background sync seeds the
-// jabali-country-allowlist LAPI AllowList with per-country CIDR sets.
+// jabali-country-allowlist LAPI AllowList with per-country CIDR sets
+// (derived from the local MaxMind mmdb, ipdeny fallback) plus the
+// operator's supplemental extra_cidrs.
 export type CountryExemption = {
   countries: string[];
+  extra_cidrs: string[];
 };
 
 export function useCountryExemption() {
@@ -302,7 +305,7 @@ export function useUpdateCountryExemption() {
   });
 }
 
-// Force a CIDR re-sync (refetches the ipdeny zone snapshots server-side).
+// Force a CIDR re-sync (re-derives the mmdb zone snapshots server-side).
 export function useSyncCountryExemption() {
   return useMutation({
     mutationFn: async () => {

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -900,6 +900,8 @@
     "duration": "Duration",
     "enabled": "Enabled",
     "events": "Events",
+    "extra_cidrs": "Additional never-block IPs / CIDRs",
+    "extra_cidrs_hint": "One per line (IPs or CIDRs, v4 + v6). Always allowed, from any CrowdSec decision source — use for stragglers a country's zone data misses or known-good hosts abroad.",
     "how_this_is_enforced": "How this is enforced",
     "ip_or_cidr": "IP or CIDR",
     "ip_value": "IP / value",

--- a/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityCrowdsec.tsx
@@ -842,6 +842,7 @@ const CountryExemptCard = () => {
   const geoblock = useAppSecGeoblock();
 
   const [countries, setCountries] = useState<string[]>([]);
+  const [extraCIDRs, setExtraCIDRs] = useState<string[]>([]);
 
   // Same memoised option set as AppSecGeoblockCard (ISO3166_COUNTRIES is a
   // frozen literal; useMemo keeps Select.options stable across renders).
@@ -858,19 +859,21 @@ const CountryExemptCard = () => {
   useEffect(() => {
     if (exemption.data) {
       setCountries(exemption.data.countries);
+      setExtraCIDRs(exemption.data.extra_cidrs);
     }
   }, [exemption.data]);
 
   const dirty =
     exemption.data !== undefined &&
-    countries.join(",") !== exemption.data.countries.join(",");
+    (countries.join(",") !== exemption.data.countries.join(",") ||
+      extraCIDRs.join(",") !== exemption.data.extra_cidrs.join(","));
 
   const geoblockDeny = geoblock.data?.mode === "deny" ? geoblock.data.countries : [];
   const geoblockDenyOverlap = countries.filter((c) => geoblockDeny.includes(c));
 
   const apply = async () => {
     try {
-      await updateExemption.mutateAsync({ countries });
+      await updateExemption.mutateAsync({ countries, extra_cidrs: extraCIDRs });
       feedback.message.success(t("adminsecuritycrowdsec.country_exemption_applied"));
     } catch (e: unknown) {
       feedback.message.error(e instanceof Error ? e.message : "Failed to apply country exemption");
@@ -921,6 +924,26 @@ const CountryExemptCard = () => {
             allowClear
           />
         </div>
+        <div>
+          <Typography.Text strong>{t("adminsecuritycrowdsec.extra_cidrs")}: </Typography.Text>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 4 }}>
+            {t("adminsecuritycrowdsec.extra_cidrs_hint")}
+          </Typography.Paragraph>
+          <Input.TextArea
+            style={{ width: "100%", maxWidth: 720 }}
+            autoSize={{ minRows: 2, maxRows: 6 }}
+            placeholder="203.0.113.7&#10;192.0.2.0/25"
+            value={extraCIDRs.join("\n")}
+            onChange={(e) =>
+              setExtraCIDRs(
+                e.target.value
+                  .split(/[\n,]+/)
+                  .map((v) => v.trim())
+                  .filter((v) => v !== ""),
+              )
+            }
+          />
+        </div>
         {geoblockDenyOverlap.length > 0 && (
           <Alert
             type="warning"
@@ -949,6 +972,7 @@ const CountryExemptCard = () => {
               onClick={() => {
                 if (exemption.data) {
                   setCountries(exemption.data.countries);
+                  setExtraCIDRs(exemption.data.extra_cidrs);
                 }
               }}
             >
@@ -959,7 +983,10 @@ const CountryExemptCard = () => {
             icon={<ReloadOutlined />}
             onClick={resync}
             loading={syncExemption.isPending}
-            disabled={(exemption.data?.countries.length ?? 0) === 0}
+            disabled={
+              (exemption.data?.countries.length ?? 0) === 0 &&
+              (exemption.data?.extra_cidrs.length ?? 0) === 0
+            }
           >
             {t("adminsecuritycrowdsec.resync_cidrs")}
           </Button>

--- a/plans/country-ban-exemption.md
+++ b/plans/country-ban-exemption.md
@@ -13,6 +13,25 @@ CAPI/community blocklists, console blocklists, captchas.
 This is the complement of the existing AppSec geoblock ("Block Country" tab),
 which is an HTTP-layer allow/deny gate and says nothing about bans.
 
+## Amendment 2026-08-14 — mmdb-derived zones + supplemental CIDRs
+
+Shipped fix for the MaxMind-vs-ipdeny coverage gap (182.54.236.64 = IL in
+MaxMind, absent from ipdeny's IL zone → still exposed to community
+decisions):
+
+- CIDR source is now the **local MaxMind mmdb** walked by the agent
+  (`security.crowdsec.country_zones.derive`, exact `GeoIpCity` IsoCode
+  precedence), merged panel-side (`mergeCIDRs`) — allowlist ≡ classifier
+  by construction. ipdeny is fallback only (no mmdb / country with no
+  data-bearing networks). Snapshots carry a `# source:` + `# mmdb-mtime:`
+  header; mmdb-sourced snapshots expire when the mmdb mtime advances
+  (`security.crowdsec.mmdb.stat`), checked on the refresher's 15-min
+  verify tick.
+- **Supplemental CIDRs** (`server_settings.country_exempt_extra_cidrs`,
+  migration 000263): operator IPs/CIDRs merged into the allowlist tagged
+  `country:extra`, managed like country entries. API/CLI/UI surface;
+  `NormalizeCIDR` validation (bare IP → host prefix), 1000-entry cap.
+
 ## Mechanism (two layers)
 
 1. **LAPI AllowList `jabali-country-allowlist`** seeded with each selected


### PR DESCRIPTION
## Why

The LAPI country allowlist (ADR-0166) was seeded from **ipdeny** zone files while the GeoIP enricher classifies with **MaxMind**. The two datasets disagree, so an IP MaxMind geo-locates to an exempt country but ipdeny omits — observed live: **182.54.236.64 = IL in MaxMind, absent from ipdeny's IL zone** — was protected from locally-generated decisions (parser whitelist) but stayed exposed to **CAPI/community blocklist decisions**.

## What

**A. mmdb-derived zones (primary source).** The agent (root — the mmdb is `0600 root`, panel-api is unprivileged) walks the local `GeoLite2-City.mmdb` with the exact `GeoIpCity` IsoCode precedence (Country → RegisteredCountry → RepresentedCountry) and returns per-country networks; panel-api merges adjacent CIDRs and snapshots them. Coverage is now exact by construction: an IP the classifier calls IL always falls inside a data-bearing IL network, and that network is in the allowlist.

- New agent verbs: `security.crowdsec.country_zones.derive`, `security.crowdsec.mmdb.stat`
- ipdeny demoted to fallback (no mmdb / country with no data-bearing networks)
- Snapshots carry `# source:` / `# mmdb-mtime:` markers; mmdb-sourced snapshots expire when the mmdb mtime advances, checked on the refresher's new 15-min verify tick (which also finally realizes the documented weekly-staleness refresh — the old gate never fired on age)

**B. Supplemental CIDRs.** `server_settings.country_exempt_extra_cidrs` (migration 000263) — operator IPs/CIDRs merged into the allowlist tagged `country:extra` (managed: removed when removed from settings). API (`extra_cidrs` on GET/PUT), CLI (`--extra-cidr`), UI textarea on the Country ban exemption card. Validated via `NormalizeCIDR` (bare IP → host prefix), 1000-entry cap.

## Verification

- Go: agent + panel-api suites green (new tests: derive precedence/filtering, merge cascade/containment/families, fallback chain, mtime re-derivation, extras lifecycle, API validation)
- UI: `tsc -b` + 233 vitest green
- [ ] Box verification on jabalitests follows in PR comments (182.54.236.64 coverage check)

ADR-0166 amended.