### PR TITLE
fix(pdns,aide): disable pdns zone cache (SIGABRT race) + unhide /usr/lib/modules from AIDE check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4098,12 +4098,21 @@ disable-axfr-rectify=no
 # for up to five minutes even though the SQL rows are all there.
 # Measured live: 161 s of NXDOMAIN on a fresh subdomain.
 #
-# No control-channel fix exists on 4.8: pdns_control zonecache-reload
-# is 4.9+, and rediscover / reload / purge were each verified NOT to
-# refresh this cache. Config is the only lever. 10 s keeps the cache's
-# LRU benefits while bounding new-zone blindness to a tick; the refresh
-# is one trivial SELECT over tens of zones at panel scale.
-zone-cache-refresh-interval=10
+# No control-channel fix exists: rediscover DOES refresh this cache on
+# 4.9 (verified: DLRediscoverHandler → UeberBackend::updateZoneCache in
+# the 4.9.x source), but calling it is what trips PowerDNS/pdns#11416 —
+# a concurrent rediscover + periodic refresh run replace() at the same
+# time and AuthZoneCache asserts (`pending->d_replacePending`), SIGABRT,
+# pdns down. Observed in production on 4.9.16 during bulk zone upserts.
+#
+# 0 disables the zone cache entirely: every zone lookup then hits the
+# gmysql backend directly (the pre-4.5 behaviour), so new zones are
+# servable IMMEDIATELY — better than the old =10 bound — and
+# updateZoneCache early-returns on !isEnabled(), so the assertion can
+# never fire. At panel scale (tens-hundreds of zones over a local
+# MariaDB socket, with the packet cache in front) the per-query backend
+# hit is unmeasurable; the zone cache exists for million-zone operators.
+zone-cache-refresh-interval=0
 PDNSCONF
 
   # Idempotency: if .new matches live, skip write + restart.
@@ -5324,17 +5333,21 @@ ensure_swap() {
   _ok "build-swap: 2 GB active at $swap_file (persists via /etc/fstab); vm.swappiness=10"
 }
 
-# ensure_pdns_zone_cache — bound PowerDNS's new-zone blindness on EXISTING
-# boxes (GH #896).
+# ensure_pdns_zone_cache — converge PowerDNS's zone cache OFF on EXISTING
+# boxes (GH #896 for new-zone blindness; PowerDNS/pdns#11416 for the crash
+# the old rediscover workaround triggered on 4.9).
 #
 # Every panel domain gets its own pdns zone, written straight into the
-# gmysql backend. pdns caches the list of known zones and re-reads it only
-# every zone-cache-refresh-interval seconds (default 300) — until then a
-# freshly created (sub)domain answers NXDOMAIN from the parent zone even
-# though its rows are committed. Measured live: 161 s of NXDOMAIN on a
-# fresh subdomain. On pdns 4.8 there is NO control-channel refresh
-# (zonecache-reload is 4.9+; rediscover/reload/purge verified not to touch
-# this cache), so the interval itself is the only lever.
+# gmysql backend. With the zone cache enabled (default refresh 300 s) a
+# freshly created (sub)domain answers NXDOMAIN until the next refresh —
+# measured live: 161 s on a fresh subdomain. On 4.9 `pdns_control
+# rediscover` DOES refresh the cache, but concurrent rediscover + refresh
+# runs race AuthZoneCache::replace() and trip the
+# `pending->d_replacePending` assertion → SIGABRT → pdns down (observed
+# in production on 4.9.16 during bulk zone upserts). =0 disables the
+# cache: zone lookups hit gmysql directly (pre-4.5 behaviour), new zones
+# are servable immediately, and updateZoneCache() early-returns so the
+# assertion can never fire.
 #
 # Fresh installs get the setting from the 01-jabali-mysql.conf template in
 # install_powerdns. That function does NOT run on `jabali update`
@@ -5346,22 +5359,24 @@ ensure_swap() {
 ensure_pdns_zone_cache() {
   local conf=/etc/powerdns/pdns.d/01-jabali-mysql.conf
   [[ -f "$conf" ]] || return 0   # dns module never installed here
-  if grep -q '^zone-cache-refresh-interval=10$' "$conf"; then
+  if grep -q '^zone-cache-refresh-interval=0$' "$conf"; then
     return 0
   fi
   if grep -q '^zone-cache-refresh-interval=' "$conf"; then
-    sed -i 's/^zone-cache-refresh-interval=.*/zone-cache-refresh-interval=10/' "$conf"
+    sed -i 's/^zone-cache-refresh-interval=.*/zone-cache-refresh-interval=0/' "$conf"
   else
     cat >> "$conf" <<'ZONECACHE'
 
-# GH #896: bound new-zone blindness — see install_powerdns for the full
-# rationale. Appended by ensure_pdns_zone_cache on update.
-zone-cache-refresh-interval=10
+# GH #896 + PowerDNS/pdns#11416: zone cache OFF — new zones visible
+# immediately, and no zone-cache replace() for rediscover to race.
+# See install_powerdns for the full rationale. Appended by
+# ensure_pdns_zone_cache on update.
+zone-cache-refresh-interval=0
 ZONECACHE
   fi
   if systemctl is-active --quiet pdns 2>/dev/null; then
     systemctl restart pdns \
-      && _ok "pdns zone-cache-refresh-interval=10 applied (new zones visible within ~10 s)" \
+      && _ok "pdns zone-cache-refresh-interval=0 applied (zone cache off — new zones visible immediately, pdns#11416 crash path closed)" \
       || _warn "pdns restart failed after zone-cache config — new setting applies on next pdns restart"
   else
     _log "pdns not active — zone-cache setting staged in $conf for next start"
@@ -14418,8 +14433,9 @@ provision_new_software() {
   # every update, so a host that has the DNS module off stops reporting the
   # unconfigured pdns unit as "failed" on the dashboard + Server Status.
   converge_pdns_masking
-  # GH #896: carry zone-cache-refresh-interval=10 to boxes that only ever
-  # update — install_powerdns (whose template now ships it) does not run
+  # GH #896 + PowerDNS/pdns#11416: carry zone-cache-refresh-interval=0 to
+  # boxes that only ever update — install_powerdns (whose template now
+  # ships it) does not run
   # on this path.
   ensure_pdns_zone_cache
 

--- a/install/systemd/jabali-aide-check.service
+++ b/install/systemd/jabali-aide-check.service
@@ -18,7 +18,14 @@ ProtectHome=read-only
 ReadWritePaths=/var/lib/aide /var/log/aide
 NoNewPrivileges=yes
 ProtectKernelTunables=yes
-ProtectKernelModules=yes
+# NO ProtectKernelModules=yes here: that option over-mounts
+# /usr/lib/modules as INACCESSIBLE in the unit's mount namespace
+# (man systemd.exec), so AIDE sees every kernel-module entry vanish and
+# reports ~10k "removed" files on every single check — drowning real
+# drift and firing a false aide.tamper.detected daily (observed on
+# aramapp 2026-08-14: 1680 added / 112 changed / 10374 removed, of
+# which 10372 were the sandbox artifact). The unit is a read-only FIM
+# scan; CAP_SYS_MODULE removal isn't worth a blind baseline.
 ProtectControlGroups=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes

--- a/install/tests/test_pdns_zone_cache.sh
+++ b/install/tests/test_pdns_zone_cache.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
-# install/tests/test_pdns_zone_cache.sh — regression coverage for GH #896:
-# a freshly created (sub)domain answered NXDOMAIN from our own authoritative
-# pdns for up to 5 minutes (161 s measured live).
+# install/tests/test_pdns_zone_cache.sh — regression coverage for GH #896
+# (new-zone NXDOMAIN) and PowerDNS/pdns#11416 (SIGABRT on concurrent
+# zone-cache replace).
 #
 # Every panel domain gets its own pdns zone, inserted straight into the
-# gmysql backend. pdns caches the LIST of known zones and re-reads it every
-# zone-cache-refresh-interval seconds (default 300); until then the new zone
-# does not exist for pdns and queries fall through to the parent zone. On
-# pdns 4.8 there is no control-channel refresh (zonecache-reload is 4.9+,
-# and rediscover/reload/purge were each verified NOT to touch this cache),
-# so the interval is the only lever.
+# gmysql backend. With the zone cache enabled (default refresh 300 s) the
+# new zone does not exist for pdns until the next refresh — 161 s of
+# NXDOMAIN measured live on a fresh subdomain. On 4.9 `pdns_control
+# rediscover` DOES refresh this cache, but concurrent rediscover + refresh
+# runs race AuthZoneCache::replace() and trip the
+# `pending->d_replacePending` assertion → SIGABRT → pdns down (observed in
+# production on 4.9.16 during bulk zone upserts). zone-cache-refresh-
+# interval=0 disables the cache: zone lookups hit gmysql directly (pre-4.5
+# behaviour), new zones serve immediately, and updateZoneCache()
+# early-returns on !isEnabled() so the assertion can never fire.
 #
 # Asserts install.sh ships BOTH halves:
 #   1. The 01-jabali-mysql.conf template (fresh installs) pins
-#      zone-cache-refresh-interval=10.
+#      zone-cache-refresh-interval=0.
 #   2. ensure_pdns_zone_cache converges the setting onto EXISTING boxes:
 #      appends when absent, rewrites when present-with-other-value,
 #      no-ops when already correct, and skips hosts without the conf
@@ -33,8 +37,8 @@ fail=0
 
 # --- 1. Fresh-install template carries the setting. ---
 template=$(awk '/cat > "\$pdns_conf_new" <<PDNSCONF/,/^PDNSCONF$/' install.sh)
-if ! grep -q '^zone-cache-refresh-interval=10$' <<<"$template"; then
-  echo "FAIL: 01-jabali-mysql.conf template does not pin zone-cache-refresh-interval=10 — fresh installs get 300 s of new-zone blindness"
+if ! grep -q '^zone-cache-refresh-interval=0$' <<<"$template"; then
+  echo "FAIL: 01-jabali-mysql.conf template does not pin zone-cache-refresh-interval=0 — fresh installs get 300 s of new-zone blindness AND the pdns#11416 crash path stays open"
   fail=1
 fi
 
@@ -65,23 +69,23 @@ run_converger() { # $1 = conf file to converge (or missing)
 # 2a. Absent line → appended.
 conf_a="$tmpdir/a.conf"; printf 'launch=gmysql\n' > "$conf_a"
 run_converger "$conf_a"
-if ! grep -q '^zone-cache-refresh-interval=10$' "$conf_a"; then
+if ! grep -q '^zone-cache-refresh-interval=0$' "$conf_a"; then
   echo "FAIL: converger did not append the setting to a conf that lacked it"
   fail=1
 fi
 
 # 2b. Present with another value → rewritten, not duplicated.
-conf_b="$tmpdir/b.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=300\n' > "$conf_b"
+conf_b="$tmpdir/b.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=10\n' > "$conf_b"
 run_converger "$conf_b"
 if [[ "$(grep -c '^zone-cache-refresh-interval=' "$conf_b")" != "1" ]] \
-   || ! grep -q '^zone-cache-refresh-interval=10$' "$conf_b"; then
-  echo "FAIL: converger must rewrite an existing value to 10 without duplicating the key"
+   || ! grep -q '^zone-cache-refresh-interval=0$' "$conf_b"; then
+  echo "FAIL: converger must rewrite an existing value to 0 without duplicating the key"
   fail=1
 fi
 
 # 2c. Already correct → byte-identical (idempotency; a rewrite here would
 # restart pdns on every single update).
-conf_c="$tmpdir/c.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=10\n' > "$conf_c"
+conf_c="$tmpdir/c.conf"; printf 'launch=gmysql\nzone-cache-refresh-interval=0\n' > "$conf_c"
 before=$(cat "$conf_c"); run_converger "$conf_c"
 if [[ "$(cat "$conf_c")" != "$before" ]]; then
   echo "FAIL: converger rewrote an already-correct conf — every update would restart pdns"
@@ -103,4 +107,4 @@ if ! grep -q 'ensure_pdns_zone_cache' <<<"$upd_src"; then
 fi
 
 if [[ "$fail" -ne 0 ]]; then exit 1; fi
-echo "PASS: pdns zone-cache bounded on both install paths (GH #896)"
+echo "PASS: pdns zone cache disabled on both install paths (GH #896 + PowerDNS/pdns#11416)"

--- a/panel-agent/internal/commands/dns_zone_upsert.go
+++ b/panel-agent/internal/commands/dns_zone_upsert.go
@@ -85,17 +85,6 @@ func dnsZoneUpsertHandler(ctx context.Context, params json.RawMessage) (any, err
 	}
 
 	// Signal PowerDNS:
-	//   0. rediscover — refresh pdns-auth's cached LIST of known zones so a
-	//      brand-new zone becomes servable IMMEDIATELY. jabali sets
-	//      zone-cache-refresh-interval=10, so pdns caches which zones it hosts
-	//      and won't answer for a just-inserted one until the next refresh —
-	//      measured ~20s of NXDOMAIN from the authoritative server itself for a
-	//      freshly-created (sub)domain (GH #896: dead page + certbot NXDOMAIN in
-	//      that window; verified `pdns_control help` lists `rediscover: discover
-	//      any new zones` on the installed pdns-auth). purge (below) only clears
-	//      the RECORD/packet cache, not the zone-list cache — so rediscover must
-	//      run first, else purge can't help a zone the server still thinks
-	//      doesn't exist. Cheap no-op when nothing new was added.
 	//   1. purge <zone>$ — invalidate the in-process query/packet cache
 	//      for this zone (the '$' suffix targets the zone + all names
 	//      under it). Without this, pdns serves the OLD answer from
@@ -109,7 +98,20 @@ func dnsZoneUpsertHandler(ctx context.Context, params json.RawMessage) (any, err
 	//      there are no slaves.
 	// All best-effort: if pdns_control isn't reachable, the SQL change is
 	// still committed and a real pdns restart will pick up the change.
-	_ = exec.CommandContext(ctx, "pdns_control", "rediscover").Run()
+	//
+	// NO `pdns_control rediscover` here. It was added so a brand-new zone
+	// became servable immediately (GH #896), but on pdns 4.9 rediscover
+	// runs UeberBackend::updateZoneCache in the control-listener thread,
+	// which races the periodic zone-cache refresh thread's own
+	// AuthZoneCache::replace() and trips the `pending->d_replacePending`
+	// assertion → SIGABRT → pdns down (PowerDNS/pdns#11416, observed in
+	// production on 4.9.16 during bulk zone upserts — mail-cert sweep
+	// upserting ~30 zones in 2 s). jabali now pins
+	// zone-cache-refresh-interval=0 (install.sh install_powerdns +
+	// ensure_pdns_zone_cache): with the zone-list cache disabled, new
+	// zones are servable IMMEDIATELY (backend lookup per query, the
+	// pre-4.5 behaviour) and updateZoneCache early-returns, so the crash
+	// path is gone and rediscover has nothing left to do.
 	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:


### PR DESCRIPTION
Two production findings from aramapp bell notifications:

**1. `pdns failed` criticals — real crash.**
pdns SIGABRTs on `AuthZoneCache::replace(): Assertion pending->d_replacePending failed` ([PowerDNS/pdns#11416](https://github.com/PowerDNS/pdns/issues/11416) — concurrent zone-cache `replace()` runs). Our `dns_zone_upsert` calls `pdns_control rediscover` per zone; bulk sweeps (mail-cert DNS pass over ~30 domains in 2 s) race rediscover against the 10 s periodic zone-cache refresh thread. Crashed 4× yesterday at precise 3 h intervals; 18 restarts total.

Fix: `zone-cache-refresh-interval=0`, converged on both install paths (fresh-install template + `ensure_pdns_zone_cache` on `jabali update`). Zone-list cache off → new zones serve **immediately** (GH #896 stays solved — better than the old =10 bound) and `updateZoneCache()` early-returns on `!isEnabled()` (verified in pdns 4.9.x source), so the assertion can never fire. The `rediscover` call is removed from `dns_zone_upsert` — with no zone cache it has nothing left to do. Upstream confirms no crashes with the cache disabled; at panel scale the per-query backend hit is negligible.

**2. AIDE "tamper detected (1680 added / 112 changed / 10374 removed)" — false positive.**
10,372 of the removals are `/usr/lib/modules/**` — present on disk. `ProtectKernelModules=yes` on `jabali-aide-check.service` makes that tree **inaccessible** in the unit's mount namespace (`systemd.exec(5)`), so every daily check reports the entire kernel-module set as removed and fires a scary bell entry once per 24 h cooldown.

Fix: drop `ProtectKernelModules=yes` from the check unit (rationale inline). `install_aide` re-installs the unit + daemon-reloads on `jabali update`, so existing boxes converge.

Tests: `test_pdns_zone_cache.sh` updated (=0 pin, rewrite-from-=10 case), all 6 install tests pass, agent package tests pass, `bash -n` + lint-install-sh clean.