### PR TITLE
fix(invoiceshelf): tinker XDG_CONFIG_HOME for root-owned tenant homes + complete delete list (GH #1042)

### DIFF
--- a/panel-agent/internal/commands/invoiceshelf_delete.go
+++ b/panel-agent/internal/commands/invoiceshelf_delete.go
@@ -33,12 +33,23 @@ type invoiceshelfDeleteResp struct {
 // and the jabali-written .env. Docroot installs enumerate so sibling files
 // survive; subdir installs rm -rf the whole subdir.
 var invoiceshelfTopLevel = []string{
-	// app root (moved up)
+	// app root (moved up) — full top-level set of the pinned 2.4.2 zip:
+	// artisan composer.json composer.lock .env.example LICENSE readme.md
+	// SECURITY.md server.php version.md + the app dirs.
 	"app", "bootstrap", "config", "database", "lang", "resources", "routes",
 	"storage", "vendor", "artisan", "composer.json", "composer.lock", ".env",
 	"readme.md", "version.md", ".env.example", "phpunit.xml",
-	// flattened public/ assets
+	"LICENSE", "SECURITY.md", "server.php",
+	// flattened public/ assets — must cover EVERY top-level entry of the
+	// pinned zip's public/ (2.4.2: build, favicons, .htaccess, index.php,
+	// robots.txt, web.config). A miss here leaves the dir behind and the
+	// next install dies at the flatten step: `mv` refuses to overwrite a
+	// non-empty leftover dir (GH #1042 — retry after a failed install
+	// 404'd on `favicons`). "public" itself covers an install that died
+	// MID-flatten (moved-up entries + a still-populated public/); a
+	// completed install has no public/ left, so listing it is free.
 	"index.php", ".htaccess", "favicon.ico", "robots.txt", "build", "web.config",
+	"favicons", "public",
 }
 
 func invoiceshelfDeleteHandler(ctx context.Context, params json.RawMessage) (any, error) {

--- a/panel-agent/internal/commands/invoiceshelf_install.go
+++ b/panel-agent/internal/commands/invoiceshelf_install.go
@@ -244,9 +244,22 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 	// admin/company/roles; we only rewrite the login credentials and the
 	// company name, then flip profile_complete so the wizard is skipped.
 	// Password + title travel via env (never argv) into the tinker script.
+	//
+	// psysh (tinker's REPL) insists on a writable config dir under
+	// $XDG_CONFIG_HOME and exits 1 BEFORE running the script when it
+	// can't create one ("Writing to directory ... is not allowed").
+	// Jabali tenant homes are root-owned 0751 BY DESIGN, so psysh's
+	// default $HOME/.config is unwritable for every fresh tenant and the
+	// finalise step fails the whole install (GH #1042 follow-up — only
+	// long-lived users with a pre-existing ~/.config/psysh ever got past
+	// it). Give psysh a private user-owned dir in /tmp instead.
+	psyshHome := psyshConfigHome(req.OSUser)
+	if out, err := runBoundedOutput(buildSystemdRunCmd(ctx, req.OSUser, "mkdir", "-m", "0700", "-p", psyshHome), 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("psysh config dir: %v (%s)", err, truncateStr(string(out), 256))}
+	}
 	tinker := invoiceshelfFinaliseTinker(req.AdminEmail)
 	tinkerCmd := buildSystemdRunCmdEnv(ctx, req.OSUser,
-		[]string{"IS_ADMIN_PASS=" + req.AdminPass, "IS_SITE_TITLE=" + req.SiteTitle, "IS_CURRENCY=" + req.Currency, "IS_COUNTRY=" + req.Country},
+		[]string{"IS_ADMIN_PASS=" + req.AdminPass, "IS_SITE_TITLE=" + req.SiteTitle, "IS_CURRENCY=" + req.Currency, "IS_COUNTRY=" + req.Country, "XDG_CONFIG_HOME=" + psyshHome},
 		php, filepath.Join(installPath, "artisan"), "tinker", "--execute="+tinker)
 	tinkerCmd.Dir = installPath
 	if out, err := runBoundedOutput(tinkerCmd, 0); err != nil {
@@ -283,6 +296,13 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 func envQuoted(s string) string {
 	s = strings.NewReplacer("\"", "", "\r", "", "\n", "").Replace(s)
 	return "\"" + s + "\""
+}
+
+// psyshConfigHome returns the per-user XDG_CONFIG_HOME the install uses
+// for artisan tinker. /tmp-scoped because tenant homes are root-owned
+// (not writable); per-user because psysh writes a history file there.
+func psyshConfigHome(osUser string) string {
+	return "/tmp/jabali-psysh-" + osUser
 }
 
 func invoiceshelfDownload(ctx context.Context, dest string) error {

--- a/panel-agent/internal/commands/invoiceshelf_install_test.go
+++ b/panel-agent/internal/commands/invoiceshelf_install_test.go
@@ -99,6 +99,19 @@ func TestEnvQuoted(t *testing.T) {
 	}
 }
 
+// GH #1042 follow-up: psysh's config dir must live under /tmp, NOT
+// $HOME — jabali tenant homes are root-owned 0751, so psysh's default
+// $HOME/.config is unwritable and tinker exits 1 before running.
+func TestPsyshConfigHome(t *testing.T) {
+	got := psyshConfigHome("alice")
+	if !strings.HasPrefix(got, "/tmp/") {
+		t.Errorf("psysh home %q must be /tmp-scoped (tenant homes are root-owned)", got)
+	}
+	if !strings.HasSuffix(got, "alice") {
+		t.Errorf("psysh home %q must be per-user (history file lands there)", got)
+	}
+}
+
 // Security review: removeInvoiceShelfNginx must reject a traversal subdir
 // before it reaches the snippet FILENAME (a "../.." would let os.Remove,
 // running as root, escape the domain dir and delete an arbitrary .conf).


### PR DESCRIPTION
Follow-up on the reporter's install failure:

```
agent install failed: agent: internal: finalise admin: exit status 1
( User Notice: Writing to directory /home/notary/.config/psysh is not allowed. )
```

**Root cause** — jabali tenant homes are root-owned 0751 by design, so PsySH (tinker's REPL) can't create `~/.config/psysh` and exits 1 *before running the finalise script*. Every fresh-tenant install died here; only accounts with a pre-existing `~/.config/psysh` (long-lived users) ever got past it — which is why the earlier live verification on #1084 missed it. Reproduced exactly on a brand-new user.

**Fixes**
- Run tinker with `XDG_CONFIG_HOME=/tmp/jabali-psysh-<user>` (0700, user-owned). Verified manually first: tinker executes, exit 0.
- Complete the delete list: it missed `favicons/`, `public/`, `LICENSE`, `SECURITY.md`, `server.php` — a retry after a failed install died at the flatten step (`mv` refuses to overwrite a non-empty leftover dir). Now covers the pinned 2.4.2 zip's full top-level set + `public` for mid-flatten deaths.

**Live verification (fresh user, no `~/.config`)**: install → `ready` on 2.4.2; DB shows `Administrator` / email login / country `IL` / currency `ILS`; `/login` 200; delete afterwards leaves the docroot at just `index.html`.