### PR TITLE
feat(databases): per-database backup/restore row actions (GH #1045)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6295,7 +6295,7 @@ LockPersonality=true
 # JIT-compiles YARA rules to WASM and requires PROT_EXEC mmap pages.
 # Defense-in-depth still covered by NoNewPrivileges + ProtectSystem +
 # RestrictAddressFamilies + ProtectKernel* above. ADR-0079.
-ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /var/lib/jabali-panel /etc/jabali-panel/migration-secrets /run/mysqld
+ReadWritePaths=$REPO_DIR /var/lib/jabali-uploads /var/lib/jabali-migrations /var/lib/jabali-panel /var/lib/jabali/restore /etc/jabali-panel/migration-secrets /run/mysqld
 # GH #355: systemd creates + chowns /var/lib/jabali-uploads to the panel
 # service user on EVERY start, so a drifted owner (e.g. root, from an old
 # install) self-heals on a plain restart — not only on \`jabali update\`.
@@ -6318,6 +6318,15 @@ EOF
   # restriction. Same scar story as the app-install staging dir
   # (commands/staging_tmp.go, commit 29823c3).
   install -d -m 0750 -o "$SERVICE_USER" -g "$SERVICE_USER" /var/lib/jabali-uploads
+
+  # DB restore staging (GH #1045): panel-api writes an uploaded .sql dump
+  # here (databases.go POST /databases/:id/restore), then the root agent
+  # reads + unlinks it (db.restore). Same cross-unit path problem as the
+  # upload staging dir above — the panel's ProtectSystem=strict needs the
+  # ReadWritePaths entry, and systemd refuses to start the unit when a
+  # ReadWritePaths entry doesn't exist, so create it BEFORE the reload.
+  # Owned by SERVICE_USER 0700: only the panel writes, the agent is root.
+  install -d -m 0700 -o "$SERVICE_USER" -g "$SERVICE_USER" /var/lib/jabali/restore
 
   # GH #425: reap abandoned upload staging files (chunked uploads with no final
   # chunk) so a tenant can't slowly fill the service partition shared with

--- a/install/apparmor/usr.local.bin.jabali-panel-api
+++ b/install/apparmor/usr.local.bin.jabali-panel-api
@@ -224,6 +224,14 @@ profile jabali-panel flags=(attach_disconnected) {
   # /etc/jabali-panel/** r above.)
   /var/lib/jabali-migrations/     rw,
   /var/lib/jabali-migrations/**   rwk,
+  # GH #1045: per-database restore staging. POST /databases/:id/restore
+  # writes the uploaded .sql dump to /var/lib/jabali/restore/<ulid>.sql
+  # (databases.go), then the root agent's db.restore reads + unlinks it.
+  # Same layer split as the staging dirs above: ReadWritePaths covers
+  # systemd, but enforce mode needs the explicit rule or the restore
+  # 500s on the write.
+  /var/lib/jabali/restore/        rw,
+  /var/lib/jabali/restore/**      rwk,
 
   # GH #462: the backup-artifact download tars the agent-materialized snapshot
   # under /var/lib/jabali-backups/downloads/<job>/ (backups.go streamBackupArtifact).

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -185,6 +185,46 @@ export async function ssoAdminer(
   return resp.data;
 }
 
+/**
+ * Download a one-shot SQL dump of the given database (GH #1045).
+ * The backend writes the dump to a scratch file and streams it, so a
+ * large database can take far longer than the axios 15s default —
+ * timeout: 0 opts this request out. The filename is recovered from the
+ * server's RFC 6266 Content-Disposition so the save-as matches what a
+ * direct navigation download would produce.
+ */
+export async function downloadDatabaseBackup(
+  databaseId: string,
+): Promise<{ blob: Blob; filename: string }> {
+  const resp = await apiClient.get<Blob>(`/databases/${databaseId}/backup`, {
+    responseType: "blob",
+    timeout: 0,
+  });
+  const cd = resp.headers["content-disposition"] as string | undefined;
+  const m = cd?.match(/filename\*?=(?:UTF-8''|")?([^";]+)/i);
+  const filename = m
+    ? decodeURIComponent(m[1].replace(/"$/, ""))
+    : "database.sql";
+  return { blob: resp.data, filename };
+}
+
+/**
+ * Restore a single database from an uploaded .sql dump (GH #1045).
+ * Multipart field name is "file" (server contract, max 500 MB). The
+ * restore runs synchronously server-side (agent pipes the dump into the
+ * mysql client), so big dumps need the unbounded timeout too.
+ */
+export async function restoreDatabaseUpload(
+  databaseId: string,
+  file: File,
+): Promise<void> {
+  const form = new FormData();
+  form.append("file", file);
+  await apiClient.post(`/databases/${databaseId}/restore`, form, {
+    timeout: 0,
+  });
+}
+
 // === PHP Settings API ===
 
 export interface DomainPHPSettings {

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -1,0 +1,133 @@
+// UserDatabaseList.test.tsx — GH #1045. Locks the per-database
+// Backup/Restore row actions: "Download backup" fetches the dump via
+// the apiClient helper and triggers a save-as with the server-provided
+// filename; "Restore from file" confirms first, then uploads the picked
+// .sql file to the restore endpoint. Data/URL/mutation hooks are
+// mocked; the real AntD table + RowActions menu run so a UI break
+// surfaces here.
+import { App } from "antd";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserDatabaseList } from "./UserDatabaseList";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("../../../apiClient", () => ({
+  downloadDatabaseBackup: vi.fn(),
+  restoreDatabaseUpload: vi.fn(),
+  ssoAdminer: vi.fn(),
+  ssoPhpMyAdmin: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("../../../hooks/useQueries", () => ({
+  useDeleteMutation: () => ({ mutateAsync: vi.fn() }),
+  useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+const mariaRow = {
+  id: "db1",
+  user_id: "u1",
+  name: "shop_db",
+  engine: "mariadb",
+  charset: "utf8mb4",
+  created_at: "2026-08-01T00:00:00Z",
+  updated_at: "2026-08-01T00:00:00Z",
+};
+
+vi.mock("../../../hooks/useTableURL", () => ({
+  useTableURL: () => ({
+    items: [mariaRow],
+    total: 1,
+    isLoading: false,
+    params: { page: 1, pageSize: 20, q: "", sort: "name", order: "asc" },
+    setParams: vi.fn(),
+  }),
+}));
+
+import {
+  downloadDatabaseBackup,
+  restoreDatabaseUpload,
+} from "../../../apiClient";
+
+const mockedDownload = downloadDatabaseBackup as ReturnType<typeof vi.fn>;
+const mockedRestore = restoreDatabaseUpload as ReturnType<typeof vi.fn>;
+
+/** Opens the row's overflow menu (first action renders as a button, the
+ * rest collapse into the "more" dropdown). */
+const openRowMenu = async () => {
+  const moreBtn = await screen.findByRole("button", { name: /more/i });
+  fireEvent.click(moreBtn);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // jsdom doesn't implement createObjectURL — stub it so the save-as
+  // path runs.
+  vi.stubGlobal("URL", {
+    ...URL,
+    createObjectURL: vi.fn(() => "blob:mock"),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+describe("UserDatabaseList backup/restore (GH #1045)", () => {
+  it("downloads a backup via the save-as dance with the server filename", async () => {
+    mockedDownload.mockResolvedValue({
+      blob: new Blob(["SQL"], { type: "application/sql" }),
+      filename: "shop_db-20260815-010203.sql",
+    });
+
+    render(
+      <App>
+        <UserDatabaseList />
+      </App>,
+    );
+
+    await openRowMenu();
+    fireEvent.click(await screen.findByText("Download backup"));
+
+    await waitFor(() => {
+      expect(mockedDownload).toHaveBeenCalledWith("db1");
+    });
+  });
+
+  it("restores from an uploaded .sql after confirmation", async () => {
+    mockedRestore.mockResolvedValue(undefined);
+
+    render(
+      <App>
+        <UserDatabaseList />
+      </App>,
+    );
+
+    await openRowMenu();
+    fireEvent.click(await screen.findByText("Restore from file"));
+
+    // The confirm dialog gates the file picker.
+    const okBtn = await screen.findByRole("button", {
+      name: /choose \.sql file/i,
+    });
+    fireEvent.click(okBtn);
+
+    // The hidden file input is the upload target; simulate picking a file.
+    const input = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    const file = new File(["CREATE TABLE t (id INT);"], "dump.sql", {
+      type: "application/sql",
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockedRestore).toHaveBeenCalledWith("db1", file);
+    });
+  });
+});

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -60,9 +60,15 @@ const mockedDownload = downloadDatabaseBackup as ReturnType<typeof vi.fn>;
 const mockedRestore = restoreDatabaseUpload as ReturnType<typeof vi.fn>;
 
 /** Opens the row's overflow menu (first action renders as a button, the
- * rest collapse into the "more" dropdown). */
+ * rest collapse into the "more" dropdown). Generous timeouts — under CI
+ * load the dropdown animation + imperative modal mount can outlast
+ * testing-library's 1s default. */
 const openRowMenu = async () => {
-  const moreBtn = await screen.findByRole("button", { name: /more/i });
+  const moreBtn = await screen.findByRole(
+    "button",
+    { name: /more/i },
+    { timeout: 5000 },
+  );
   fireEvent.click(moreBtn);
 };
 
@@ -108,12 +114,18 @@ describe("UserDatabaseList backup/restore (GH #1045)", () => {
     );
 
     await openRowMenu();
-    fireEvent.click(await screen.findByText("Restore from file"));
+    fireEvent.click(
+      await screen.findByText("Restore from file", undefined, {
+        timeout: 5000,
+      }),
+    );
 
     // The confirm dialog gates the file picker.
-    const okBtn = await screen.findByRole("button", {
-      name: /choose \.sql file/i,
-    });
+    const okBtn = await screen.findByRole(
+      "button",
+      { name: /choose \.sql file/i },
+      { timeout: 5000 },
+    );
     fireEvent.click(okBtn);
 
     // The hidden file input is the upload target; simulate picking a file.

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -2,8 +2,11 @@
 // + Open-in-phpMyAdmin + Delete. phpMyAdmin SSO is wired through the
 // apiClient helper; a blank tab is opened synchronously to dodge
 // popup blockers while the SSO call runs.
+// GH #1045: per-database Backup/Restore actions (download a one-shot
+// dump; restore from an uploaded .sql file) — MariaDB only, the agent
+// verbs shell out to mariadb-dump/mysql.
 import { useTranslation } from "react-i18next";
-import { useState } from "react";
+import { useRef, useState, type ChangeEvent } from "react";
 import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button, Card, Space, Table, Typography } from "antd";
@@ -14,10 +17,17 @@ import {
   DeleteOutlined,
   PlusSquareOutlined,
   ThunderboltOutlined,
+  DownloadOutlined,
+  UploadOutlined,
 } from "@icons";
 import { sorterToParams } from "../../../utils/tableSorter";
 
-import { ssoAdminer, ssoPhpMyAdmin } from "../../../apiClient";
+import {
+  downloadDatabaseBackup,
+  restoreDatabaseUpload,
+  ssoAdminer,
+  ssoPhpMyAdmin,
+} from "../../../apiClient";
 import { EngineTag } from "../../../components/EngineTag";
 import { RowActions } from "../../../components/RowActions";
 import { columnSearchProps } from "../../../components/columnSearch";
@@ -71,8 +81,17 @@ export const UserDatabaseList = () => {
   const [loadingPhpMyAdminId, setLoadingPhpMyAdminId] = useState<string | null>(
     null,
   );
+  const [loadingBackupId, setLoadingBackupId] = useState<string | null>(null);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
   const [quickSetupOpen, setQuickSetupOpen] = useState(false);
   const [createDrawerOpen, setCreateDrawerOpen] = useState(false);
+  // Hidden file input for "Restore from file" — the row action only
+  // records which database is the target and clicks this input; the
+  // upload happens in its onChange. Kept as a ref (not state) because
+  // the target row is only needed between the click and the change
+  // event, never for rendering.
+  const restoreInputRef = useRef<HTMLInputElement | null>(null);
+  const restoreTargetRef = useRef<Database | null>(null);
 
   const handleTableChange: React.ComponentProps<
     typeof Table<Database>
@@ -149,8 +168,69 @@ export const UserDatabaseList = () => {
     }
   };
 
+  const handleDownloadBackup = async (row: Database) => {
+    try {
+      setLoadingBackupId(row.id);
+      const { blob, filename } = await downloadDatabaseBackup(row.id);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      const errorMsg =
+        error instanceof Error ? error.message : "Backup failed";
+      feedback.message.error(`Backup failed: ${errorMsg}`);
+    } finally {
+      setLoadingBackupId(null);
+    }
+  };
+
+  const handlePickRestore = (row: Database) => {
+    restoreTargetRef.current = row;
+    restoreInputRef.current?.click();
+  };
+
+  const handleRestoreFile = async (
+    e: ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    // Reset the input value so picking the same file twice in a row
+    // still fires onChange the second time.
+    e.target.value = "";
+    const row = restoreTargetRef.current;
+    if (!file || !row) return;
+    try {
+      setRestoringId(row.id);
+      await restoreDatabaseUpload(row.id, file);
+      feedback.message.success(
+        `Database "${row.name}" restored from ${file.name}`,
+      );
+      // Size changed — refresh the listing.
+      qc.invalidateQueries({ queryKey: ["list", "databases"] });
+    } catch (error) {
+      const errorMsg =
+        error instanceof Error ? error.message : "Restore failed";
+      feedback.message.error(`Restore failed: ${errorMsg}`);
+    } finally {
+      setRestoringId(null);
+    }
+  };
+
   return (
     <div>
+      <input
+        ref={restoreInputRef}
+        type="file"
+        accept=".sql"
+        style={{ display: "none" }}
+        onChange={(e) => {
+          void handleRestoreFile(e);
+        }}
+      />
       <Space
         style={{
           marginBottom: 16,
@@ -270,6 +350,36 @@ export const UserDatabaseList = () => {
                 disabled: isAdminerLoading,
                 loading: isAdminerLoading,
               };
+              // GH #1045 — per-database backup/restore. The agent verbs
+              // shell out to mariadb-dump/mysql, so both are MariaDB-only
+              // (same gate as phpMyAdmin).
+              const mariaOnlyTooltip = isPostgres
+                ? "Backup/restore supports MySQL/MariaDB only"
+                : undefined;
+              const backupAction = {
+                key: "backup",
+                label: "Download backup",
+                icon: <DownloadOutlined />,
+                onClick: () => void handleDownloadBackup(r),
+                disabled: isPostgres || loadingBackupId === r.id,
+                loading: loadingBackupId === r.id,
+                tooltip: mariaOnlyTooltip,
+              };
+              const restoreAction = {
+                key: "restore",
+                label: "Restore from file",
+                icon: <UploadOutlined />,
+                onClick: () => handlePickRestore(r),
+                disabled: isPostgres || restoringId === r.id,
+                loading: restoringId === r.id,
+                tooltip: mariaOnlyTooltip,
+                confirm: {
+                  title: `Restore into "${r.name}"?`,
+                  description:
+                    "The uploaded dump runs against this database — existing tables with the same names are overwritten.",
+                  okText: "Choose .sql file",
+                },
+              };
               // Adminer is the native admin tool for Postgres (phpMyAdmin
               // is MariaDB-only and shows disabled), so lead with it there;
               // MariaDB keeps phpMyAdmin first. (GH #1005)
@@ -281,6 +391,8 @@ export const UserDatabaseList = () => {
                 <RowActions
                   actions={[
                     ...dbTools,
+                    backupAction,
+                    restoreAction,
                     {
                       key: "delete",
                       label: "Delete",


### PR DESCRIPTION
## What

First slice of #1045: wires the two **already-existing** single-database endpoints into the tenant Databases UI.

- **Download backup** — `GET /databases/:id/backup`, streamed as a Blob; save-as filename taken from the server's RFC 6266 `Content-Disposition`.
- **Restore from file** — `POST /databases/:id/restore` (multipart `file`, 500 MB cap server-side), gated by a confirm modal spelling out that the dump runs against the live DB.
- Both are MariaDB-only (agent verbs shell out to `mariadb-dump`/`mysql`); Postgres rows show them disabled with a tooltip, same gate as phpMyAdmin.

Later slices (not in this PR): save-to/restore-from File Manager, scheduled per-DB restore points.

## Backend fix found during live verification

`POST /databases/:id/restore` has never worked under the panel's own sandbox: the handler writes the upload to `/var/lib/jabali/restore/`, but the unit's `ProtectSystem=strict` + `ReadWritePaths` didn't cover that path — every restore 500'd on the write before the agent was called.

- `install.sh`: `/var/lib/jabali/restore` added to `ReadWritePaths` + `install -d` (panel-owned 0700) before daemon-reload (systemd refuses to start a unit whose ReadWritePaths entry is missing). Converges via `jabali update`.
- AppArmor profile: matching `rw,rwk` rules for enforce mode.

## Tests / verification

- New `UserDatabaseList.test.tsx` (2 tests: save-as filename, confirm-gated upload). Full UI suite 50 files / 235 tests green; tsc + eslint clean; install.sh lint + 6 bash tests pass.
- Live on jabalitests (tenant `dbtest1`): backup downloads a real `mariadb-dump` with `<db>-<timestamp>.sql` name; restore round-trip flips a seeded row through the UI (confirm → upload → 204 → list refresh), staging dir cleaned by the agent.

