### PR TITLE
fix(security): load tenant SQL restores as db-scoped user, not root (JAB-239)

### DIFF
--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -516,13 +516,15 @@ func applyAccountRestore(
 					fmt.Sprintf("db %s: create database: %v: %s", db, cErr, strings.TrimSpace(string(cOut))))
 				continue
 			}
-			cmd := exec.CommandContext(ctx, "mariadb", db)
-			cmd.Stdin = f
-			loadOut, lerr := cmd.CombinedOutput()
+			// JAB-239: the dump is tenant-controlled content (it came
+			// from the tenant's own snapshot), so it loads through the
+			// db-scoped shadow account as an unprivileged OS user —
+			// never as root. See db_load_scoped.go.
+			lerr := loadMariaDBDumpScoped(ctx, db, f)
 			_ = f.Close()
 			if lerr != nil {
 				warnings = append(warnings,
-					fmt.Sprintf("db %s: mariadb load: %v: %s", db, lerr, strings.TrimSpace(string(loadOut))))
+					fmt.Sprintf("db %s: mariadb load: %v", db, lerr))
 				continue
 			}
 			applied = append(applied, fmt.Sprintf("db → %s", db))

--- a/panel-agent/internal/commands/db_drop.go
+++ b/panel-agent/internal/commands/db_drop.go
@@ -78,6 +78,12 @@ func dbDropHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
+	// JAB-239: drop the db-scoped restore shadow account alongside the
+	// database so it can't accumulate across create/restore/drop cycles.
+	// Best-effort — a leftover account is db-scoped (now to a dropped
+	// database) with an unknown random password.
+	_ = mariadbRoot(ctx, fmt.Sprintf("DROP USER IF EXISTS '%s'@'localhost';", scopedShadowUser(p.DBName)))
+
 	return dbDropResponse{OK: true}, nil
 }
 

--- a/panel-agent/internal/commands/db_load_scoped.go
+++ b/panel-agent/internal/commands/db_load_scoped.go
@@ -1,0 +1,183 @@
+package commands
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// JAB-239: tenant SQL restores used to pipe the dump straight into the
+// mariadb client running as ROOT — every statement in a tenant-supplied
+// dump executed with full privileges on both the database (cross-DB
+// reads/writes, CREATE USER, GRANT) and the host (the client's \!
+// shell escape gives a root shell). This file loads dumps through a
+// db-scoped MariaDB account running as an unprivileged OS user instead:
+//
+//   - a per-database shadow account jb_s_<db>@localhost is (re)created
+//     with a fresh random password, GRANTed ALL PRIVILEGES on exactly
+//     the target database (no GRANT OPTION, no SUPER/SET_USER_ID), the
+//     load runs as that account, and the password is then forgotten —
+//     nobody can log in as it, it only exists to scope the load and to
+//     resolve DEFINERs;
+//   - the account is durable (not dropped after the load): panel dumps
+//     carry --routines --triggers --events, and those objects execute
+//     with their DEFINER's privileges — pointing them at a dropped
+//     account would break the app at runtime (error 1449). db.drop
+//     removes the shadow alongside the database;
+//   - DEFINER=`u`@`h` clauses in the stream are rewritten to the
+//     shadow account. The shadow has privileges on this database only,
+//     so a SQL SECURITY DEFINER object can't exceed tenant scope, and
+//     cross-database views die at execution time — exactly what a
+//     tenant-scoped restore should do. (cPanel-style restores rewrite
+//     DEFINER for the same reason.)
+//   - the client runs with the target OS user's UID/GID set directly
+//     on the child process (SysProcAttr.Credential — no sudo, which
+//     would scrub MYSQL_PWD under env_reset), so \! and any
+//     client-side file access land on an account that can touch
+//     nothing. This is the same privilege-drop idea as the postgres
+//     restore branch's `sudo -u postgres` in backup_restore.go.
+
+// scopedRestoreOSUser is the OS account the mariadb client runs as.
+const scopedRestoreOSUser = "nobody"
+
+// definerClauseRegex matches ` DEFINER=`user`@`host`` including the
+// versioned-comment form mysqldump/mariadb-dump emit for triggers
+// (/*!50017 DEFINER=... */). Case-insensitive: dumps write it
+// upper-case, hand-made dumps may not.
+var definerClauseRegex = regexp.MustCompile("(?i)[ \\t]+DEFINER[ \\t]*=[ \\t]*`[^`]*`@`[^`]*`")
+
+// scopedShadowUser derives the durable per-database shadow account
+// name. 5 + 64 chars max — comfortably under MariaDB's 80-char limit.
+func scopedShadowUser(dbName string) string {
+	return "jb_s_" + dbName
+}
+
+// definerRewritingReader wraps a dump stream and rewrites DEFINER
+// clauses to the shadow account line by line. Dump files are
+// line-oriented and mariadb-dump never splits a DEFINER clause across
+// lines, so a line filter is exact for real-world dumps.
+type definerRewritingReader struct {
+	r    *bufio.Reader
+	repl []byte
+	buf  []byte // pending output of the current (rewritten) line
+	err  error  // sticky terminal error (io.EOF included)
+}
+
+func newDefinerRewritingReader(r io.Reader, shadowUser string) *definerRewritingReader {
+	return &definerRewritingReader{
+		r:    bufio.NewReaderSize(r, 256*1024),
+		repl: []byte(" DEFINER=`" + shadowUser + "`@`localhost`"),
+	}
+}
+
+func (s *definerRewritingReader) Read(p []byte) (int, error) {
+	for len(s.buf) == 0 && s.err == nil {
+		line, err := s.r.ReadBytes('\n')
+		if len(line) > 0 {
+			s.buf = definerClauseRegex.ReplaceAll(line, s.repl)
+		}
+		if err != nil {
+			s.err = err
+		}
+	}
+	if len(s.buf) == 0 {
+		// Nothing left to emit; report the sticky error (io.EOF on a
+		// clean end of stream).
+		if s.err != nil {
+			return 0, s.err
+		}
+		return 0, io.EOF
+	}
+	n := copy(p, s.buf)
+	s.buf = s.buf[n:]
+	return n, nil
+}
+
+// mariadbRoot runs a statement as root over the unix socket. Only used
+// for the static, operator-side provisioning statements — dump content
+// never passes through here.
+func mariadbRoot(ctx context.Context, stmt string) error {
+	cmd := exec.CommandContext(ctx, "mariadb",
+		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
+		"-e", stmt)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// loadMariaDBDumpScoped streams dump into dbName through the db-scoped
+// shadow account as an unprivileged OS user. dbName must already be
+// validated by the caller (the dbRestoreNameRegex shape) — it is
+// interpolated into the GRANT statement and the shadow account name.
+// The target database must exist; the callers' reset/create preludes
+// handle that.
+func loadMariaDBDumpScoped(ctx context.Context, dbName string, dump io.Reader) error {
+	shadow := scopedShadowUser(dbName)
+	pb := make([]byte, 18)
+	if _, err := rand.Read(pb); err != nil {
+		return fmt.Errorf("mint scoped restore password: %w", err)
+	}
+	pwd := hex.EncodeToString(pb)
+	// Hex-only password, regex-validated db name — the interpolated
+	// statements can't break out of their quoting. ALTER re-randomizes
+	// the password on every restore, so even a captured credential is
+	// single-use. A concurrent restore of the same database only
+	// re-randomizes the password again — already-established sessions
+	// are unaffected, so concurrent loads don't kill each other.
+	prov := fmt.Sprintf(
+		"CREATE USER IF NOT EXISTS '%s'@'localhost' IDENTIFIED BY '%s'; "+
+			"ALTER USER '%s'@'localhost' IDENTIFIED BY '%s'; "+
+			"GRANT ALL PRIVILEGES ON `%s`.* TO '%s'@'localhost';",
+		shadow, pwd, shadow, pwd, dbName, shadow)
+	if err := mariadbRoot(ctx, prov); err != nil {
+		return fmt.Errorf("provision scoped restore account: %w", err)
+	}
+
+	// Resolve the unprivileged OS account the client runs as.
+	osUser, err := user.Lookup(scopedRestoreOSUser)
+	if err != nil {
+		return fmt.Errorf("lookup %s: %w", scopedRestoreOSUser, err)
+	}
+	uid, err := strconv.ParseUint(osUser.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse %s uid: %w", scopedRestoreOSUser, err)
+	}
+	gid, err := strconv.ParseUint(osUser.Gid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("parse %s gid: %w", scopedRestoreOSUser, err)
+	}
+
+	cmd := exec.CommandContext(ctx, "mariadb",
+		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
+		"--user="+shadow,
+		"--database="+dbName)
+	// Drop to the unprivileged OS user directly on the child — sudo is
+	// deliberately NOT used: env_reset would scrub MYSQL_PWD off the
+	// environment (found live during the JAB-239 box verification:
+	// "Access denied ... (using password: NO)").
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)},
+	}
+	// MYSQL_PWD keeps the password off argv (visible in ps to every
+	// tenant on the box). /proc/<pid>/environ is readable only by the
+	// process owner and root, and the credential is single-use and
+	// db-scoped regardless.
+	cmd.Env = append(os.Environ(), "MYSQL_PWD="+pwd)
+	cmd.Stdin = newDefinerRewritingReader(dump, shadow)
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/panel-agent/internal/commands/db_load_scoped_test.go
+++ b/panel-agent/internal/commands/db_load_scoped_test.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// JAB-239: locks the DEFINER-rewriting stream filter and the shadow
+// account naming. The exec orchestration (scoped user provisioning,
+// sudo -u nobody load) is box-verified — these handlers exec real
+// binaries, matching the existing test style for this package.
+
+func readDump(t *testing.T, r io.Reader) string {
+	t.Helper()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return string(out)
+}
+
+func TestDefinerRewritingReader(t *testing.T) {
+	shadow := scopedShadowUser("shop_db")
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain statements pass through unchanged",
+			input: "CREATE TABLE t (id INT);\nINSERT INTO t VALUES (1);\n",
+			want:  "CREATE TABLE t (id INT);\nINSERT INTO t VALUES (1);\n",
+		},
+		{
+			name: "view definer rewritten to shadow",
+			input: "CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v` AS SELECT 1;\n",
+			want: "CREATE ALGORITHM=UNDEFINED DEFINER=`" + shadow + "`@`localhost` SQL SECURITY DEFINER VIEW `v` AS SELECT 1;\n",
+		},
+		{
+			name: "versioned trigger comment rewritten",
+			input: "/*!50017 DEFINER=`admin`@`%`*/ /*!50003 TRIGGER `tr` BEFORE INSERT ON `t` FOR EACH ROW SET @x = 1 */;;\n",
+			want: "/*!50017 DEFINER=`" + shadow + "`@`localhost`*/ /*!50003 TRIGGER `tr` BEFORE INSERT ON `t` FOR EACH ROW SET @x = 1 */;;\n",
+		},
+		{
+			name:  "lowercase definer also caught",
+			input: "create definer=`u`@`%` procedure p() begin end;\n",
+			want:  "create DEFINER=`" + shadow + "`@`localhost` procedure p() begin end;\n",
+		},
+		{
+			name:  "multiple definers on one line all rewritten",
+			input: "X DEFINER=`a`@`h1` DEFINER=`b`@`h2` ;\n",
+			want:  "X DEFINER=`" + shadow + "`@`localhost` DEFINER=`" + shadow + "`@`localhost` ;\n",
+		},
+		{
+			name:  "no trailing newline still flushed",
+			input: "SELECT 1;",
+			want:  "SELECT 1;",
+		},
+		{
+			name:  "empty stream yields empty output",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "data containing the word definer without backticks untouched",
+			input: "INSERT INTO t VALUES ('definer=root@localhost');\n",
+			want:  "INSERT INTO t VALUES ('definer=root@localhost');\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := readDump(t, newDefinerRewritingReader(strings.NewReader(tt.input), shadow))
+			if got != tt.want {
+				t.Errorf("got  %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefinerRewritingReaderLongLines(t *testing.T) {
+	// Extended INSERT lines in real dumps can run to megabytes — the
+	// filter must not truncate or choke past bufio's default token cap.
+	shadow := scopedShadowUser("big")
+	long := "INSERT INTO t VALUES ('" + strings.Repeat("x", 3*1024*1024) + "');\n"
+	got := readDump(t, newDefinerRewritingReader(strings.NewReader(long), shadow))
+	if got != long {
+		t.Errorf("long line mangled: got %d bytes, want %d", len(got), len(long))
+	}
+}
+
+func TestScopedShadowUser(t *testing.T) {
+	if got := scopedShadowUser("shop_db"); got != "jb_s_shop_db" {
+		t.Errorf("unexpected shadow name %q", got)
+	}
+	// 5 + 64 = 69 chars max, under MariaDB's 80-char user limit even
+	// for the longest valid database name.
+	long := scopedShadowUser(strings.Repeat("a", 64))
+	if len(long) > 80 {
+		t.Errorf("shadow name too long: %d chars", len(long))
+	}
+}

--- a/panel-agent/internal/commands/db_restore.go
+++ b/panel-agent/internal/commands/db_restore.go
@@ -110,11 +110,10 @@ func dbRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) 
 		}
 	}
 
-	// Run mysql with stdin from the file, database name as positional argument.
-	cmd := exec.CommandContext(ctx, "mysql", p.DBName)
-	cmd.Stdin = f
-
-	if err := cmd.Run(); err != nil {
+	// Run the dump load through the db-scoped shadow account as an
+	// unprivileged OS user (JAB-239) — never as root. See
+	// db_load_scoped.go for the trust model.
+	if err := loadMariaDBDumpScoped(ctx, p.DBName, f); err != nil {
 		// Always delete the file, whether restore succeeds or fails — but
 		// through the SCOPE, not os.Remove. The scope's RESOLVE_BENEATH
 		// applies to the open above; a raw os.Remove(p.Path) re-walks the


### PR DESCRIPTION
## What

Tenant SQL restores piped the dump straight into the `mariadb` client **as root** — panel restore uploads (`POST /databases/:id/restore`, also used by the cPanel/Hestia importer) and full-account restores (`backup_restore.go`). A crafted dump executed arbitrary SQL as root (cross-DB access, `CREATE USER`, `GRANT`) and arbitrary shell as root via the client's `\!` escape.

## Fix

New `loadMariaDBDumpScoped()` replaces the root load at both sites:

- **Per-database shadow account** `jb_s_<db>@localhost` — random password re-minted per restore (single-use, then forgotten), `ALL PRIVILEGES` on exactly the target database, no `GRANT OPTION`/`SUPER`/`SET_USER_ID`.
- **Durable, not dropped** — restored triggers/views/routines execute with their DEFINER's privileges; a dropped definer breaks the app (error 1449). `db.drop` removes the shadow with the database.
- **DEFINER clauses rewritten** to the shadow in-stream — `SQL SECURITY DEFINER` objects can't exceed tenant scope; cross-DB views die at execution.
- **OS privilege drop** — client runs with `nobody`'s UID/GID via `SysProcAttr.Credential` (no `sudo`: `env_reset` scrubs `MYSQL_PWD` — found live). `\!` lands on an account that can touch nothing. `MYSQL_PWD` keeps the password off `ps`.

The `ResetBeforeRestore` prelude stays root — static SQL from the regex-validated db name, no dump content. System-account restores (`backup_system*.go`) are server-generated content and keep the existing trust shape.

## Verification (jabalitests)

- Hostile dump (`\! id > /root/pwned`, `CREATE USER pwned`, `GRANT *.*`, `USE mysql; DELETE FROM user`): restore fails loudly; no `/root` file, no `pwned` user, `mysql.user` intact, staging cleaned.
- Legit dump with DEFINER trigger + `SQL SECURITY DEFINER` view: restores clean, objects work, definers resolve to the shadow.
- Panel HTTP restore round-trip still 204s and applies the dump.
- Unit tests: DEFINER rewriter (versioned comments, lowercase, multi-clause, 3 MB extended inserts) + shadow naming; full `panel-agent` suite green.