### PR TITLE
fix(databases): re-own per-DB dump to the panel user so download stops 500ing (GH #1045)

### DIFF
--- a/panel-agent/internal/commands/db_backup.go
+++ b/panel-agent/internal/commands/db_backup.go
@@ -8,11 +8,55 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
+
+// dbBackupChown is os.Chown in production; tests override it to assert the
+// agent->panel ownership handoff without needing root.
+var dbBackupChown = os.Chown
+
+// dbBackupLookupUser resolves the panel service user; tests override it so they
+// run on hosts (e.g. CI) where the "jabali" account does not exist.
+var dbBackupLookupUser = func() (*user.User, error) { return user.Lookup(systemServiceUser) }
+
+// reownBackupForPanel re-owns a freshly written dump to the panel service user
+// and pins its mode to 0640. The dump is created by the agent (root) but
+// streamed back to the HTTP client by panel-api, which runs as the unprivileged
+// service user ("jabali"). A root:root 0640 file is unreadable by that user —
+// it is not in the root group — so the panel's os.Open fails and the download
+// 500s (GH #1045). Chowning the OWNER (not just the group) is deliberate:
+// panel-api's systemd unit sets Group=jabali-sockets, so the service user's
+// primary "jabali" group is only a supplementary group and is not guaranteed
+// present on every install (see feedback_systemd_group_supplementary) —
+// owner-read on 0640 works regardless. The backup dir is 0700 jabali:jabali, so
+// the re-owned file stays reachable only by the panel, which can also unlink it
+// after streaming. Mirrors the agent->panel handoff in sendmail_cred.go.
+func reownBackupForPanel(path string) error {
+	svc, err := dbBackupLookupUser()
+	if err != nil {
+		return fmt.Errorf("resolve service user: %w", err)
+	}
+	uid, err := strconv.Atoi(svc.Uid)
+	if err != nil {
+		return fmt.Errorf("service uid %q: %w", svc.Uid, err)
+	}
+	gid, err := strconv.Atoi(svc.Gid)
+	if err != nil {
+		return fmt.Errorf("service gid %q: %w", svc.Gid, err)
+	}
+	if err := dbBackupChown(path, uid, gid); err != nil {
+		return fmt.Errorf("chown %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0640); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
 
 // dbBackupParams is the input shape for db.backup.
 type dbBackupParams struct {
@@ -129,16 +173,14 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
-	// chmod 0640 — 0600 would lock out panel-api (runs as jabali, while
-	// the agent runs as root), which is the process that streams the
-	// dump back to the HTTP client. The backup dir itself is 0700 and
-	// already jabali-group-owned, so group-readable files leak only to
-	// panel-api — exactly who needs them.
-	if err := os.Chmod(backupPath, 0640); err != nil {
+	// Hand the dump off to panel-api (runs as the unprivileged service user),
+	// which streams it to the client. See reownBackupForPanel for why this is
+	// required (GH #1045).
+	if err := reownBackupForPanel(backupPath); err != nil {
 		_ = os.Remove(backupPath)
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
-			Message: "failed to set backup file permissions",
+			Message: "failed to finalize backup file",
 		}
 	}
 

--- a/panel-agent/internal/commands/db_backup_test.go
+++ b/panel-agent/internal/commands/db_backup_test.go
@@ -3,6 +3,10 @@ package commands
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -109,4 +113,64 @@ func TestDBBackupHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReownBackupForPanel pins the GH #1045 fix: a dump written by the agent
+// (root) is re-owned to the panel service user so panel-api can read it back.
+// The download 500'd because the file landed root:root 0640, unreadable by the
+// unprivileged panel user. Seams are injected so the test runs on CI hosts with
+// no "jabali" account and without needing root to chown.
+func TestReownBackupForPanel(t *testing.T) {
+	origLookup := dbBackupLookupUser
+	origChown := dbBackupChown
+	t.Cleanup(func() {
+		dbBackupLookupUser = origLookup
+		dbBackupChown = origChown
+	})
+
+	t.Run("chowns to the service user and pins 0640", func(t *testing.T) {
+		dbBackupLookupUser = func() (*user.User, error) {
+			return &user.User{Uid: "996", Gid: "989"}, nil
+		}
+		var gotPath string
+		var gotUID, gotGID int
+		dbBackupChown = func(path string, uid, gid int) error {
+			gotPath, gotUID, gotGID = path, uid, gid
+			return nil // real chown needs root; assert intent instead
+		}
+
+		path := filepath.Join(t.TempDir(), "dump.sql")
+		if err := os.WriteFile(path, []byte("-- dump\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := reownBackupForPanel(path); err != nil {
+			t.Fatalf("reownBackupForPanel: %v", err)
+		}
+		if gotPath != path {
+			t.Errorf("chown path = %q, want %q", gotPath, path)
+		}
+		if gotUID != 996 || gotGID != 989 {
+			t.Errorf("chown target = %d:%d, want 996:989", gotUID, gotGID)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := info.Mode().Perm(); perm != 0640 {
+			t.Errorf("mode = %o, want 640", perm)
+		}
+	})
+
+	t.Run("surfaces a lookup failure", func(t *testing.T) {
+		dbBackupLookupUser = func() (*user.User, error) {
+			return nil, errors.New("unknown user jabali")
+		}
+		dbBackupChown = func(string, int, int) error {
+			t.Fatal("chown must not run when the service user cannot be resolved")
+			return nil
+		}
+		if err := reownBackupForPanel(filepath.Join(t.TempDir(), "x.sql")); err == nil {
+			t.Fatal("expected error when service user lookup fails")
+		}
+	})
 }

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -489,9 +489,12 @@ func (h *databaseHandler) backup(c *gin.Context) {
 		return
 	}
 
-	// Open the backup file
+	// Open the backup file. On any failure past this point the agent has
+	// already written a full DB dump to disk; delete it before returning so a
+	// retrying client doesn't strand root-owned dumps in the backup dir.
 	f, err := openFile(resp.Path)
 	if err != nil {
+		_ = deleteFile(resp.Path)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}


### PR DESCRIPTION
## Problem

The per-database **Download backup** action (shipped in #1087) returns **HTTP 500** for tenants. Reported on GH #1045 by @lxsdevcode and @mrlp57 ("Backup failed: Request failed with status code 500").

## Root cause

`GET /api/v1/databases/:id/backup` asks the agent (`db.backup`, runs as **root**) to write a dump, then panel-api streams it to the client. panel-api runs as the unprivileged service user **jabali**.

The agent created the dump **root:root 0640** in `/var/lib/jabali/backups` (mode 0700, `jabali:jabali`, **not setgid**). A 0640 file's group-read bit therefore applied to the **root** group — which `jabali` is not a member of. panel-api's `os.Open` failed with `EACCES`, and the handler returned **500**.

Discriminator: `respondAgentErr` returns **502**, so an agent-*call* failure would have surfaced as 502. The **500** pinned the failure to the panel's file read (`openFile`). Reproduced live: `jabali` cannot read a `root:root 0640` file — "Permission denied".

The old comment in `db_backup.go` asserted the file was "already jabali-group-owned" — that assumption was wrong (non-setgid dir + root writer ⇒ `root:root`) and is what shipped the bug.

## Fix

**Agent (`db_backup.go`)** — after the dump succeeds, re-own it to the panel service user and pin 0640, mirroring the existing agent→panel handoff in `sendmail_cred.go`. Chowning the **owner** (not just the group) is deliberate: panel-api's unit sets `Group=jabali-sockets`, so the service user's primary `jabali` group is only a *supplementary* group and isn't guaranteed present on every install (see the `systemd Group= drops primary group` scar). **Owner-read on 0640 works regardless of the group question.** Extracted into `reownBackupForPanel` with injectable seams (`dbBackupChown`, `dbBackupLookupUser`) and unit-tested.

**Panel (`databases.go`)** — delete the temp dump on the `openFile`-error branch, so a retrying client can no longer strand full root-owned DB dumps in the backup dir. (The success path already deletes after streaming.)

## Verification

- Unit: `TestReownBackupForPanel` asserts the chown target (uid/gid) + 0640, and that a service-user lookup failure aborts before chown.
- **End-to-end on a test server** (the definitive check — the #1087 "verified" claim never exercised the jabali-user read path): deployed the new agent, minted a tenant API token for the db owner, and `GET /api/v1/databases/:id/backup` through the running panel returned **200** with a real `MariaDB dump` (CREATE/INSERT), `Content-Type: application/sql`. The temp file landed **jabali:jabali 0640**.

## Not in this PR (tracked separately)

- @mrlp57's "scheduled backups never fire, only manually" — a different subsystem (backup schedules), not the per-DB download path.
- @lxsdevcode's request for PostgreSQL backup/download/restore parity — a feature follow-up.

GH #1045