### PR TITLE
ci(security): pin GitHub Actions to commit SHAs (JAB-247)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Dependabot: keep SHA-pinned GitHub Actions current (JAB-247).
+#
+# Actions in .github/workflows/ are pinned to full commit SHAs with the
+# human-readable version in a trailing comment; Dependabot bumps the SHA
+# and maintains that comment. All action bumps land as one grouped
+# monthly PR (same cadence as the catalog auto-bump and monthly-deps).
+#
+# Go modules and npm are deliberately NOT listed here — the
+# monthly-deps.yml workflow owns those.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/catalog-bump.yml
+++ b/.github/workflows/catalog-bump.yml
@@ -29,10 +29,10 @@ jobs:
   bump:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           token: ${{ secrets.CATALOG_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           # cache: false — see monthly-deps.yml: setup-go's cache layer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     name: Go tests + vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           # cache: true — ephemeral GitHub-hosted runners start cold every
@@ -54,8 +54,8 @@ jobs:
     name: govulncheck (Go stdlib + deps)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -92,7 +92,7 @@ jobs:
     name: install.sh phantom-function lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run lint
         run: tools/lint-install-sh.sh
 
@@ -100,7 +100,7 @@ jobs:
     name: install.sh regression tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Run install/tests
         # These are per-incident regression guards (OOM sizing, /etc/hosts
         # loopback shadow, pdns upstream, socket helpers). They existed but
@@ -126,7 +126,7 @@ jobs:
     name: install.sh pinned downloads published
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Verify pinned versions resolve to published artifacts
         # Fails if any pinned third-party version in install.sh is AHEAD of
         # upstream (tagged/not-yet-published) — catches the GH #670 class in the
@@ -139,8 +139,8 @@ jobs:
     name: demo anti-leak guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -155,8 +155,8 @@ jobs:
     name: panel-ui unit tests (vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -194,8 +194,8 @@ jobs:
       group: e2e-port-4173
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -222,7 +222,7 @@ jobs:
         run: cd panel-ui && npx playwright test --project=chromium --reporter=list
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,27 @@ env:
   NODE_VERSION: "20"
 
 jobs:
+  action-pins:
+    name: action refs pinned to SHAs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: reject mutable action references
+        # JAB-247: every `uses:` must be a local path (./) or pinned to a
+        # full 40-char commit SHA with the version in a trailing comment.
+        # A mutable tag/branch in a write-capable or trusted-runner
+        # workflow becomes arbitrary code the moment upstream moves it.
+        run: |
+          bad=$(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows .github/actions 2>/dev/null \
+            | grep -vE 'uses:[[:space:]]+\./' \
+            | grep -vE '@[0-9a-f]{40}([[:space:]]+#.*)?$' || true)
+          if [ -n "$bad" ]; then
+            echo "$bad"
+            echo "::error::mutable GitHub Action reference(s) found — pin to a full-length commit SHA (JAB-247)"
+            exit 1
+          fi
+          echo "all action references SHA-pinned"
+
   go:
     name: Go tests + vet
     runs-on: ubuntu-latest

--- a/.github/workflows/monthly-deps.yml
+++ b/.github/workflows/monthly-deps.yml
@@ -24,8 +24,8 @@ jobs:
   review:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           # cache: false — matches ci.yml. The self-hosted runner's persistent
@@ -33,7 +33,7 @@ jobs:
           # HANGS the "Post Run setup-go" cache-save step, which held the single
           # runner and left the whole monthly run (and queued CI) stuck.
           cache: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,8 @@ jobs:
     name: Go tests + vet (race)
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
@@ -30,8 +30,8 @@ jobs:
     name: panel-ui unit tests (vitest)
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -47,8 +47,8 @@ jobs:
       group: e2e-port-4173
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -70,7 +70,7 @@ jobs:
       - run: cd panel-ui && npx playwright test --project=chromium --reporter=list
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nightly-playwright-report
           path: |
@@ -82,8 +82,8 @@ jobs:
     name: npm audit (advisory)
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: npm audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,14 @@ jobs:
       GO_VERSION: "1.25"
       NODE_VERSION: "20"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm


### PR DESCRIPTION
## Summary
JAB-247: all workflow `uses:` references were mutable major tags. This pins every reference (31 across 5 workflows) to the full 40-char commit SHA those tags resolve to today, with the exact version recorded in a trailing comment, and adds a Dependabot config (`github-actions` ecosystem, grouped, monthly) so the pinned SHAs stay current — Dependabot bumps the SHA and maintains the version comment.

All references are first-party `actions/*` (checkout, setup-go, setup-node, upload-artifact) — no third-party actions exist in this repo — so this is defense-in-depth per the corrected issue framing, not an exposed trust edge.

| Action | SHA | Version |
|---|---|---|
| actions/checkout | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| actions/setup-go | `40f1582b2485089dde7abd97c1529aa768e1baff` | v5.6.0 |
| actions/setup-node | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |

SHAs resolved via `gh api repos/actions/<name>/commits/<tag>` against the official repos; versions cross-checked against the peeled tag refs. Dependabot covers only the `github-actions` ecosystem — Go modules and npm stay with the existing monthly-deps workflow.

Also adds an `action-pins` CI job: fails any PR that introduces a `uses:` reference that is not a local path or a full 40-char commit SHA. Proven both ways locally (pinned tree passes, a reintroduced `@v4` fails). With this, all JAB-247 acceptance criteria are covered.

## Test plan
- [ ] CI green on this PR (the pinned checkout/setup actions exercise themselves; the new action-pins job gates the same tree)

JAB-247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
