### PR TITLE
fix(databases): stage per-DB dump in jabali-uploads so the panel can read AND delete it (GH #1045)

### DIFF
--- a/panel-agent/internal/commands/db_backup.go
+++ b/panel-agent/internal/commands/db_backup.go
@@ -73,6 +73,20 @@ type dbBackupResponse struct {
 // dbBackupNameRegex validates MariaDB database name format.
 var dbBackupNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
 
+// dbBackupStagingDir is where the dump is written for panel-api to stream back
+// (GH #1045). It deliberately is NOT /var/lib/jabali/backups: the panel unit
+// runs ProtectSystem=strict without that dir in ReadWritePaths, and its
+// AppArmor profile only grants read on the downloads/ subtree — so the panel
+// could neither reliably read the dump nor unlink it afterwards, stranding a
+// full dump per download. /var/lib/jabali-uploads is the established
+// agent->panel handoff dir: it is in the panel's ReadWritePaths and its
+// AppArmor profile grants rwk, so the panel can read AND delete the temp file
+// under both ProtectSystem and AppArmor enforce. The GH #425 tmpfiles reaper
+// (12h) sweeps anything a crash strands. The agent still re-owns the file to
+// the panel user (dir is 0750 jabali:jabali-sockets, not setgid, so a
+// root-written file lands root:root) — see reownBackupForPanel.
+const dbBackupStagingDir = "/var/lib/jabali-uploads"
+
 func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p dbBackupParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -114,14 +128,14 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 				Message: "failed to generate backup path",
 			}
 		}
-		backupPath = fmt.Sprintf("/var/lib/jabali/backups/%s.sql", hex.EncodeToString(buf))
+		backupPath = fmt.Sprintf("%s/jabali-db-backup-%s.sql", dbBackupStagingDir, hex.EncodeToString(buf))
 	}
 
-	// Validate path is under /var/lib/jabali/backups/ and reject directory traversal
-	if !strings.HasPrefix(backupPath, "/var/lib/jabali/backups/") {
+	// Validate path is under the staging dir and reject directory traversal.
+	if !strings.HasPrefix(backupPath, dbBackupStagingDir+"/") {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: "backup path must be under /var/lib/jabali/backups/",
+			Message: "backup path must be under " + dbBackupStagingDir + "/",
 		}
 	}
 
@@ -133,12 +147,13 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
-	// Ensure directory exists with mode 0700
-	backupDir := "/var/lib/jabali/backups"
-	if err := os.MkdirAll(backupDir, 0700); err != nil {
+	// The staging dir is provisioned by install.sh (0750 jabali:jabali-sockets).
+	// MkdirAll is a defensive no-op when it already exists; on the off chance it
+	// is missing, 0750 keeps it panel-owner-writable rather than root-only.
+	if err := os.MkdirAll(dbBackupStagingDir, 0750); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
-			Message: "failed to create backup directory",
+			Message: "failed to create backup staging directory",
 		}
 	}
 

--- a/panel-agent/internal/commands/db_backup_test.go
+++ b/panel-agent/internal/commands/db_backup_test.go
@@ -74,7 +74,7 @@ func TestDBBackupHandler(t *testing.T) {
 			wantCode:  agentwire.CodeInvalidArgument,
 		},
 		{
-			name: "invalid: path not under /var/lib/jabali/backups/",
+			name: "invalid: path not under staging dir",
 			input: dbBackupParams{
 				DBName: "alice",
 				Path:   "/tmp/backup.sql",
@@ -83,10 +83,19 @@ func TestDBBackupHandler(t *testing.T) {
 			wantCode:  agentwire.CodeInvalidArgument,
 		},
 		{
+			name: "invalid: old backups dir is no longer accepted",
+			input: dbBackupParams{
+				DBName: "alice",
+				Path:   "/var/lib/jabali/backups/x.sql",
+			},
+			wantError: true,
+			wantCode:  agentwire.CodeInvalidArgument,
+		},
+		{
 			name: "invalid: path with directory traversal",
 			input: dbBackupParams{
 				DBName: "alice",
-				Path:   "/var/lib/jabali/backups/../../etc/passwd",
+				Path:   dbBackupStagingDir + "/../../etc/passwd",
 			},
 			wantError: true,
 			wantCode:  agentwire.CodeInvalidArgument,


### PR DESCRIPTION
Follow-up to #1090.

## Why #1090 wasn't complete

#1090 fixed the **500** by re-owning the dump to the panel user, and verified a real tenant download returns 200. But it wrote the dump to `/var/lib/jabali/backups`, which the panel can't fully use:

- **Cleanup was inert.** The panel unit runs `ProtectSystem=strict` and `/var/lib/jabali/backups` is **not** in its `ReadWritePaths`, so that dir is read-only inside the panel's mount namespace. The panel can `open` the dump but cannot `unlink` it — so **every successful download strands a full DB dump**. #1090's error-branch `deleteFile` and the pre-existing success-path `deleteFile` were both no-ops.
- **Enforce-mode boxes still 500.** The panel's AppArmor profile only grants read on the backups `downloads/` subtree. It ships in **complain** mode by default (so the read is permitted and #1090's 500 fix holds on a default box), but on an operator-hardened **enforce** box, the read of `/var/lib/jabali/backups/<f>.sql` is denied → the download would still 500.

## Fix

Write the dump to **`/var/lib/jabali-uploads`** — the established agent→panel handoff dir. It's already in the panel's `ReadWritePaths` **and** its AppArmor profile grants `rwk` (lines 214–215). So the panel can **read AND delete** the temp file under both `ProtectSystem=strict` and AppArmor **enforce**, with **zero hardening edits**. The GH #425 tmpfiles reaper (12h) already sweeps that dir, so a crash-stranded dump is cleaned for free.

`reownBackupForPanel` is unchanged — `jabali-uploads` is `0750 jabali:jabali-sockets` and not setgid, so a root-written file still lands `root:root` and needs the chown.

## Verification

- Unit: existing `TestDBBackupHandler` path-validation cases updated to the new staging dir; `TestReownBackupForPanel` unchanged.
- Live (to run before merge): tenant download → 200 + real dump, **and the temp file is gone afterward**; repeat with the panel AppArmor profile toggled to **enforce** to prove the read+unlink both hold.

GH #1045