### PR TITLE
feat(ftp): schema, models, repository for tenant FTP/SFTP subaccounts (GH #1053 step 1)

### DIFF
--- a/panel-api/internal/db/migrations/000264_ftp_accounts.down.sql
+++ b/panel-api/internal/db/migrations/000264_ftp_accounts.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE hosting_packages
+    DROP COLUMN max_ftp_accounts;
+
+ALTER TABLE server_settings
+    DROP COLUMN ftp_pasv_address,
+    DROP COLUMN ftp_allow_plaintext,
+    DROP COLUMN ftp_enabled;
+
+DROP TABLE ftp_accounts;

--- a/panel-api/internal/db/migrations/000264_ftp_accounts.up.sql
+++ b/panel-api/internal/db/migrations/000264_ftp_accounts.up.sql
@@ -1,0 +1,41 @@
+-- GH #1053: FTP/SFTP subaccounts (plans/gh1053-ftp-accounts.md).
+--
+-- Each row maps to a REAL system user created as a same-uid alias of the
+-- owning tenant (useradd --non-unique), so every file written over any
+-- protocol is owned by the tenant uid and quotas/FPM/AppArmor behave as if
+-- the tenant wrote it. No password column ON PURPOSE: credentials live in
+-- /etc/shadow only, set via the agent at create/reset time.
+--
+-- user_id is index-only (no FK) — same convention as ssh_keys; the panel
+-- row is the teardown handle, so deletion must go through the app path
+-- that also removes the system user, never a silent DB cascade.
+CREATE TABLE ftp_accounts (
+  id          CHAR(26)     NOT NULL PRIMARY KEY,
+  user_id     CHAR(26)     NOT NULL,
+  username    VARCHAR(64)  NOT NULL,
+  home_path   VARCHAR(512) NOT NULL,
+  ftp_access  TINYINT(1)   NOT NULL DEFAULT 0,
+  sftp_access TINYINT(1)   NOT NULL DEFAULT 1,
+  is_enabled  TINYINT(1)   NOT NULL DEFAULT 1,
+  created_at  DATETIME(6)  NOT NULL,
+  updated_at  DATETIME(6)  NOT NULL,
+  UNIQUE INDEX ux_ftp_accounts_username (username),
+  INDEX idx_ftp_accounts_user_id (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Server-level FTP opt-in (operator decision 2026-08-15: default OFF).
+-- ftp_enabled installs/starts the vsftpd module on enable; while 0 the
+-- daemon is absent and port 21 closed — SFTP accounts keep working.
+-- ftp_allow_plaintext is a second explicit gate: even with FTP on, TLS is
+-- required unless the operator deliberately allows legacy cleartext.
+-- Small typed columns on purpose: server_settings is close to InnoDB's
+-- 65535-byte row-size ceiling (see 000262).
+ALTER TABLE server_settings
+    ADD COLUMN ftp_enabled TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN ftp_allow_plaintext TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN ftp_pasv_address VARCHAR(64) NOT NULL DEFAULT '';
+
+-- Per-package cap on tenant-created accounts. 0 = feature hidden for users
+-- on that package (tenant capabilities default OFF).
+ALTER TABLE hosting_packages
+    ADD COLUMN max_ftp_accounts INT UNSIGNED NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/ftp_account.go
+++ b/panel-api/internal/models/ftp_account.go
@@ -1,0 +1,39 @@
+package models
+
+import "time"
+
+// FtpAccount is a tenant-created file-transfer subaccount (GH #1053,
+// plans/gh1053-ftp-accounts.md). The agent realizes each row as a REAL
+// system user sharing the owning tenant's uid/gid (useradd --non-unique),
+// with its own username, password, and home directory — so files written
+// over SFTP or FTPS are owned by the tenant uid and quotas / per-user FPM /
+// AppArmor treat them exactly like tenant-created files.
+//
+// There is deliberately NO password field: credentials exist only in
+// /etc/shadow, written by the agent at create / password-reset time. The
+// panel never stores or returns them.
+type FtpAccount struct {
+	ID     string `gorm:"type:char(26);primaryKey" json:"id,omitempty"`
+	UserID string `gorm:"type:char(26);not null;index" json:"user_id"`
+	// Username is the full system username, namespaced under the owning
+	// tenant (`<tenant>_<label>`) so it can never collide with a real user
+	// or another tenant's accounts. Validated at the API boundary; the
+	// agent re-validates before touching passwd.
+	Username string `gorm:"type:varchar(64);not null;uniqueIndex" json:"username"`
+	// HomePath is absolute and must resolve inside the owning tenant's
+	// home (symlink-resolved server-side — path escape = cross-tenant
+	// read). Typically a docroot.
+	HomePath string `gorm:"type:varchar(512);not null" json:"home_path"`
+	// FTPAccess gates membership in the jabali-ftp PAM group. Effective
+	// only while server_settings.ftp_enabled is on.
+	FTPAccess bool `gorm:"column:ftp_access;type:tinyint(1);not null" json:"ftp_access"`
+	// SFTPAccess gates the sshd Match block. Column default is 1; the tag
+	// carries NO gorm default on purpose — `default:1` on a bool silently
+	// flips an explicit false back to true on create (recurring scar).
+	SFTPAccess bool      `gorm:"column:sftp_access;type:tinyint(1);not null" json:"sftp_access"`
+	IsEnabled  bool      `gorm:"type:tinyint(1);not null" json:"is_enabled"`
+	CreatedAt  time.Time `gorm:"type:datetime(6);not null" json:"created_at,omitempty"`
+	UpdatedAt  time.Time `gorm:"type:datetime(6);not null" json:"updated_at,omitempty"`
+}
+
+func (FtpAccount) TableName() string { return "ftp_accounts" }

--- a/panel-api/internal/models/hosting_package.go
+++ b/panel-api/internal/models/hosting_package.go
@@ -37,6 +37,12 @@ type HostingPackage struct {
 	// opt-in per plan), mirroring MaxDockerApps.
 	MaxPythonApps uint32 `gorm:"type:int unsigned;not null;default:0" json:"max_python_apps"`
 
+	// MaxFTPAccounts caps tenant-created FTP/SFTP subaccounts on this plan
+	// (GH #1053). 0 = feature NOT included and hidden in the user shell
+	// (safe default, opt-in per plan, mirrors MaxDockerApps). Explicit
+	// column tag: GORM's namer mangles consecutive-capital initialisms.
+	MaxFTPAccounts uint32 `gorm:"column:max_ftp_accounts;type:int unsigned;not null;default:0" json:"max_ftp_accounts"`
+
 	// DockerAppSlugs (GH #170 #3) is a CSV allowlist of catalog slugs a tenant
 	// on this package may install. Empty = fall back to the server-wide
 	// docker_tenant_apps curation. Always AND-ed with MaxDockerApps>0 +

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -447,6 +447,21 @@ type ServerSettings struct {
 	// operators to mint a dedicated scoped token, not a global one.
 	CFAPITokenEnc []byte `gorm:"column:cf_api_token_enc;type:varbinary(512)" json:"-"`
 
+	// FTP module (GH #1053, plans/gh1053-ftp-accounts.md). FTPEnabled is the
+	// server-level opt-in (operator decision: default OFF) — flipping it on
+	// installs/starts the vsftpd module (M353 install-on-enable) and opens
+	// the firewall ports; off masks the daemon and closes them. SFTP
+	// subaccounts work regardless of this flag.
+	FTPEnabled bool `gorm:"column:ftp_enabled;type:tinyint(1);not null;default:0" json:"ftp_enabled"`
+	// FTPAllowPlaintext deliberately defaults to false: with FTP enabled,
+	// TLS is still REQUIRED unless the operator explicitly allows legacy
+	// cleartext logins. Never relax this silently.
+	FTPAllowPlaintext bool `gorm:"column:ftp_allow_plaintext;type:tinyint(1);not null;default:0" json:"ftp_allow_plaintext"`
+	// FTPPasvAddress is the external address vsftpd advertises for passive
+	// connections when the host is behind NAT. Empty = advertise the local
+	// address.
+	FTPPasvAddress string `gorm:"column:ftp_pasv_address;type:varchar(64);not null;default:''" json:"ftp_pasv_address"`
+
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null"             json:"updated_at"`
 }
 

--- a/panel-api/internal/repository/ftp_account_repository.go
+++ b/panel-api/internal/repository/ftp_account_repository.go
@@ -1,0 +1,141 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"gorm.io/gorm"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// FtpAccountRepository defines data access for tenant FTP/SFTP subaccounts
+// (GH #1053). The panel row is the ONLY handle to the underlying system
+// user — callers that delete rows must run the agent-side teardown first;
+// this layer never cascades.
+type FtpAccountRepository interface {
+	Create(ctx context.Context, acct *models.FtpAccount) error
+	FindByID(ctx context.Context, id string) (*models.FtpAccount, error)
+	FindByIDAndUserID(ctx context.Context, id, userID string) (*models.FtpAccount, error)
+	FindByUsername(ctx context.Context, username string) (*models.FtpAccount, error)
+	ListByUserID(ctx context.Context, userID string) ([]models.FtpAccount, error)
+	List(ctx context.Context) ([]models.FtpAccount, error)
+	// Update persists the mutable fields only, via an explicit Select
+	// allowlist — a full-struct save would silently write zero values into
+	// columns the caller never touched.
+	Update(ctx context.Context, acct *models.FtpAccount) error
+	Delete(ctx context.Context, id string) error
+	CountByUserID(ctx context.Context, userID string) (int64, error)
+}
+
+type ftpAccountRepo struct{ db *gorm.DB }
+
+func NewFtpAccountRepository(db *gorm.DB) FtpAccountRepository {
+	return &ftpAccountRepo{db: db}
+}
+
+func (r *ftpAccountRepo) Create(ctx context.Context, acct *models.FtpAccount) error {
+	if err := r.db.WithContext(ctx).Create(acct).Error; err != nil {
+		return translateFtpAccount(err)
+	}
+	return nil
+}
+
+func (r *ftpAccountRepo) FindByID(ctx context.Context, id string) (*models.FtpAccount, error) {
+	var acct models.FtpAccount
+	if err := r.db.WithContext(ctx).Where("id = ?", id).First(&acct).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &acct, nil
+}
+
+func (r *ftpAccountRepo) FindByIDAndUserID(ctx context.Context, id, userID string) (*models.FtpAccount, error) {
+	var acct models.FtpAccount
+	if err := r.db.WithContext(ctx).Where("id = ? AND user_id = ?", id, userID).First(&acct).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &acct, nil
+}
+
+func (r *ftpAccountRepo) FindByUsername(ctx context.Context, username string) (*models.FtpAccount, error) {
+	var acct models.FtpAccount
+	if err := r.db.WithContext(ctx).Where("username = ?", username).First(&acct).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &acct, nil
+}
+
+func (r *ftpAccountRepo) ListByUserID(ctx context.Context, userID string) ([]models.FtpAccount, error) {
+	var accts []models.FtpAccount
+	if err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&accts).Error; err != nil {
+		return nil, err
+	}
+	return accts, nil
+}
+
+func (r *ftpAccountRepo) List(ctx context.Context) ([]models.FtpAccount, error) {
+	var accts []models.FtpAccount
+	if err := r.db.WithContext(ctx).Order("created_at DESC").Find(&accts).Error; err != nil {
+		return nil, err
+	}
+	return accts, nil
+}
+
+func (r *ftpAccountRepo) Update(ctx context.Context, acct *models.FtpAccount) error {
+	// Immutable on purpose: id, user_id, username (renaming a system user
+	// is a delete+create at the agent layer), created_at.
+	err := r.db.WithContext(ctx).
+		Model(&models.FtpAccount{}).
+		Where("id = ?", acct.ID).
+		Select("home_path", "ftp_access", "sftp_access", "is_enabled", "updated_at").
+		Updates(map[string]any{
+			"home_path":   acct.HomePath,
+			"ftp_access":  acct.FTPAccess,
+			"sftp_access": acct.SFTPAccess,
+			"is_enabled":  acct.IsEnabled,
+			"updated_at":  acct.UpdatedAt,
+		}).Error
+	return translateFtpAccount(err)
+}
+
+func (r *ftpAccountRepo) Delete(ctx context.Context, id string) error {
+	return r.db.WithContext(ctx).Where("id = ?", id).Delete(&models.FtpAccount{}).Error
+}
+
+func (r *ftpAccountRepo) CountByUserID(ctx context.Context, userID string) (int64, error) {
+	var count int64
+	if err := r.db.WithContext(ctx).Model(&models.FtpAccount{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// translateFtpAccount maps GORM/driver errors to repository conventions.
+func translateFtpAccount(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return ErrNotFound
+	}
+	var my *mysql.MySQLError
+	if errors.As(err, &my) && my.Number == 1062 {
+		// 1062 = ER_DUP_ENTRY (unique username)
+		return ErrConflict
+	}
+	if strings.Contains(err.Error(), "Duplicate entry") {
+		return ErrConflict
+	}
+	return err
+}

--- a/panel-api/internal/repository/ftp_account_repository_test.go
+++ b/panel-api/internal/repository/ftp_account_repository_test.go
@@ -1,0 +1,197 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+	gormmysql "gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func newMockFtpDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+
+	gdb, err := gorm.Open(gormmysql.New(gormmysql.Config{
+		Conn:                      raw,
+		SkipInitializeWithVersion: false,
+	}), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	return gdb, mock, raw
+}
+
+func testFtpAccount(now time.Time) *models.FtpAccount {
+	return &models.FtpAccount{
+		ID:         "01HFTPACCT0000000000000000",
+		UserID:     "01HUSER000000000000000000A",
+		Username:   "shop_deploy",
+		HomePath:   "/home/shop/example.com/public_html",
+		FTPAccess:  false,
+		SFTPAccess: true,
+		IsEnabled:  true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+func TestFtpAccountCreate_Success(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?)")).
+		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
+			acct.FTPAccess, acct.SFTPAccess, acct.IsEnabled,
+			sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.Create(context.Background(), acct))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The INSERT must carry an explicit sftp_access value even when it is false.
+// The column default is 1, and a missing/defaulted bool would silently
+// resurrect access the caller disabled (the recurring gorm default:1 scar —
+// the model tag intentionally carries no default).
+func TestFtpAccountCreate_ExplicitFalseSFTPAccess(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+	acct.SFTPAccess = false
+	acct.FTPAccess = true
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?)")).
+		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
+			true, false, acct.IsEnabled,
+			sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.Create(context.Background(), acct))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountCreate_DuplicateUsername(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO `ftp_accounts`").
+		WillReturnError(&mysql.MySQLError{Number: 1062, Message: "Duplicate entry 'shop_deploy' for key 'ux_ftp_accounts_username'"})
+	mock.ExpectRollback()
+
+	err := repo.Create(context.Background(), acct)
+	require.ErrorIs(t, err, ErrConflict)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountFindByID_NotFound(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+
+	mock.ExpectQuery("SELECT \\* FROM `ftp_accounts`").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	_, err := repo.FindByID(context.Background(), "missing")
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountFindByIDAndUserID_ScopesToOwner(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT * FROM `ftp_accounts` WHERE id = ? AND user_id = ?")).
+		WithArgs("acct1", "userA", 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "username"}).
+			AddRow("acct1", "userA", "shop_deploy"))
+
+	acct, err := repo.FindByIDAndUserID(context.Background(), "acct1", "userA")
+	require.NoError(t, err)
+	require.Equal(t, "userA", acct.UserID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Update must write ONLY the mutable columns — id/user_id/username/created_at
+// stay out of the SET list (Select allowlist; a full-struct save would
+// zero-write untouched columns).
+func TestFtpAccountUpdate_AllowlistOnly(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+	acct.IsEnabled = false
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE `ftp_accounts` SET `ftp_access`=?,`home_path`=?,`is_enabled`=?,`sftp_access`=?,`updated_at`=? WHERE id = ?")).
+		WithArgs(acct.FTPAccess, acct.HomePath, false, acct.SFTPAccess, sqlmock.AnyArg(), acct.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.Update(context.Background(), acct))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountCountByUserID(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `ftp_accounts` WHERE user_id = ?")).
+		WithArgs("userA").
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(3))
+
+	n, err := repo.CountByUserID(context.Background(), "userA")
+	require.NoError(t, err)
+	require.EqualValues(t, 3, n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountDelete(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+
+	repo := NewFtpAccountRepository(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("DELETE FROM `ftp_accounts` WHERE id = ?")).
+		WithArgs("acct1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.Delete(context.Background(), "acct1"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Step 1 of 7 from `plans/gh1053-ftp-accounts.md` (GH #1053 — FTP/SFTP accounts).

## What
- `ftp_accounts` table (migration 000264): tenant-namespaced unique username, index-only `user_id` (the panel row is the teardown handle — no DB cascade), `sftp_access` column-default 1 with **no** gorm default tag (the `default:1`-on-bool scar).
- `server_settings`: `ftp_enabled` — **server-level opt-in, default OFF** (operator decision); `ftp_allow_plaintext` (TLS required unless explicitly allowed); `ftp_pasv_address`.
- `hosting_packages.max_ftp_accounts`: per-plan cap on tenant-created accounts, 0 = feature hidden.
- `FtpAccountRepository`: CRUD + owner-scoped find + count (cap checks); `Update` via explicit Select allowlist; 1062 → `ErrConflict`.

## Design (fixed in the blueprint)
Accounts realize as real system users sharing the tenant uid (`useradd --non-unique`) → files always tenant-owned; quotas / per-user FPM / AppArmor unaffected. No password column — credentials live in `/etc/shadow` only. SFTPGo evaluated and rejected (userspace isolation vs our kernel chroot+uid model).

## Test plan
- [x] sqlmock: create (incl. explicit-false `sftp_access`), duplicate → conflict, owner-scoped find, allowlist-only update shape, count, delete
- [x] `go build ./panel-api/...`, `go vet`, `go test -race` on models+repository, api package green
- [ ] Steps 2-7 per blueprint (agent verbs, sshd render, vsftpd module, API, UI, E2E)

GH #1053