### PR TITLE
ci(security): least-privilege token permissions for ci.yml and nightly.yml (JAB-247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# JAB-247 follow-up: PR CI executes fork code — the token must be read-only.
+permissions:
+  contents: read
+
 # Per-ref concurrency: PR pushes auto-supersede stale in-flight runs; main runs
 # always run to completion (each commit is an authoritative green/red record).
 concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,11 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+# JAB-247 follow-up: nightly only builds/tests and uploads artifacts —
+# read-only token is sufficient.
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.25"
   NODE_VERSION: "20"


### PR DESCRIPTION
## Summary
Closes out the last JAB-247 acceptance criterion (per-job least-privilege permissions). `ci.yml` and `nightly.yml` declared no `permissions:` block, so every job ran with the repo's default token grant — and ci.yml executes fork-PR code. Both now pin `permissions: contents: read` at workflow level.

Audit of the other three workflows found them already minimal:
| Workflow | Declared | Why it needs it |
|---|---|---|
| release.yml | `contents: write` | publishes releases |
| catalog-bump.yml | `contents+pull-requests: write` | pushes branch, opens PR |
| monthly-deps.yml | `contents: read, issues: write` | files the deps issue |

The one `GITHUB_TOKEN` use inside ci.yml (pinned-downloads job) is authenticated read-only `gh api` GETs — works under `contents: read`.

## Test plan
- [ ] CI green on this PR (ci.yml exercises the reduced grant itself; pinned-downloads proves the read-only token suffices)

JAB-247

🤖 Generated with [Claude Code](https://claude.com/claude-code)