### PR TITLE
feat(ftp): agent verbs for same-uid FTP/SFTP subaccounts (GH #1053 step 2)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -1,0 +1,499 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// FTP/SFTP subaccounts (GH #1053, plans/gh1053-ftp-accounts.md).
+//
+// A subaccount is a SECOND passwd entry sharing the owning tenant's uid/gid
+// (useradd --non-unique): its own username + password + home directory, but
+// every file it writes is owned by the tenant uid, so quotas, per-user FPM,
+// AppArmor, and backups treat its writes exactly like the tenant's own.
+// Sessions also land in the tenant's user-<uid>.slice, so M18 resource
+// limits apply unchanged.
+//
+// Deliberate non-goals, both consequences of sharing the uid:
+//   - No isolation BETWEEN a tenant and its subaccounts — the kernel cannot
+//     separate two identities with one uid. The boundary this feature adds
+//     is credential-scoped (revocable, per-protocol), not filesystem-scoped.
+//   - home_path picks where a session STARTS (and the vsftpd chroot), not
+//     what the account can ultimately reach over SFTP.
+//
+// Group memberships:
+//   - jabali-ftp: PAM gate for vsftpd — held only while ftp_access is on.
+//   - jabali-sftp: NEVER. Its M12 Match block chroots to /home/%u, and a
+//     subaccount's username has no /home/<username>; the resulting failed
+//     chroot would reset every connection. SFTP for subaccounts arrives via
+//     per-account Match User blocks (step 3), not this group.
+const ftpGroupName = "jabali-ftp"
+
+// ftpSubaccountLabelRegex validates the operator-chosen suffix. The full
+// username is "<tenant>_<label>": lowercase, digits, underscore, and the
+// whole thing must still fit useradd's 32-char ceiling.
+var ftpSubaccountLabelRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_]{0,19}$`)
+
+const ftpSubaccountMaxLen = 32
+
+// minTenantUID is the floor for uids a subaccount may alias. Blocks root
+// (uid 0) and system accounts outright, whatever a buggy caller sends —
+// the agent never trusts the panel just because it is localhost.
+const minTenantUID = 1000
+
+// ftpTenant resolves and validates the owning tenant for a subaccount
+// operation: real user, regular-uid range, home under /home.
+type ftpTenant struct {
+	Username string
+	UID      int
+	GID      int
+	HomeDir  string
+}
+
+func resolveFtpTenant(tenantUsername string) (*ftpTenant, *agentwire.AgentError) {
+	if !usernameRegex.MatchString(tenantUsername) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid tenant username %q", tenantUsername),
+		}
+	}
+	u, err := user.Lookup(tenantUsername)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeNotFound,
+			Message: fmt.Sprintf("tenant %q not found on host", tenantUsername),
+		}
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	gid, _ := strconv.Atoi(u.Gid)
+	if uid < minTenantUID {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("tenant %q has uid %d — subaccounts may only alias regular tenant uids (>= %d)", tenantUsername, uid, minTenantUID),
+		}
+	}
+	if !strings.HasPrefix(u.HomeDir, "/home/") {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("tenant %q home %q is outside /home — refusing", tenantUsername, u.HomeDir),
+		}
+	}
+	return &ftpTenant{Username: tenantUsername, UID: uid, GID: gid, HomeDir: u.HomeDir}, nil
+}
+
+// validateFtpSubaccountName enforces the "<tenant>_<label>" namespace so a
+// subaccount can never collide with a real user or another tenant's
+// accounts, and never impersonate an unrelated name.
+func validateFtpSubaccountName(tenant, sub string) *agentwire.AgentError {
+	prefix := tenant + "_"
+	if !strings.HasPrefix(sub, prefix) {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("subaccount %q must be namespaced under the tenant (%s<label>)", sub, prefix),
+		}
+	}
+	label := strings.TrimPrefix(sub, prefix)
+	if !ftpSubaccountLabelRegex.MatchString(label) {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid subaccount label %q: must match %s", label, ftpSubaccountLabelRegex.String()),
+		}
+	}
+	if len(sub) > ftpSubaccountMaxLen {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("subaccount %q exceeds %d characters", sub, ftpSubaccountMaxLen),
+		}
+	}
+	return nil
+}
+
+// resolveFtpHomePath validates that homePath is an absolute, clean path
+// that — after resolving the symlinks of its nearest existing ancestor —
+// stays inside the tenant's home. A tenant-writable tree means a symlink
+// can point anywhere; resolving server-side is what stops a subaccount
+// home from landing in another tenant (or /etc).
+func resolveFtpHomePath(homePath string, tenant *ftpTenant) (string, *agentwire.AgentError) {
+	if !filepath.IsAbs(homePath) || filepath.Clean(homePath) != homePath {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("home_path %q must be absolute and clean (no ., .., trailing slash)", homePath),
+		}
+	}
+	// Resolve through the nearest existing ancestor so a not-yet-created
+	// leaf directory doesn't fail validation while symlinked ancestors
+	// still get caught.
+	probe := homePath
+	for {
+		resolved, err := filepath.EvalSymlinks(probe)
+		if err == nil {
+			rel, rerr := filepath.Rel(tenant.HomeDir, resolved)
+			if rerr != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+				return "", &agentwire.AgentError{
+					Code:    agentwire.CodePermissionDenied,
+					Message: fmt.Sprintf("home_path %q resolves outside the tenant home %q", homePath, tenant.HomeDir),
+				}
+			}
+			return homePath, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("resolve home_path %q: %v", probe, err),
+			}
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "", &agentwire.AgentError{
+				Code:    agentwire.CodeInvalidArgument,
+				Message: fmt.Sprintf("home_path %q has no existing ancestor", homePath),
+			}
+		}
+		probe = parent
+	}
+}
+
+// requireFtpSubaccount verifies an EXISTING passwd entry is one of ours:
+// tenant-namespaced name AND aliasing exactly the tenant's uid. Every
+// mutating verb below runs this before touching the account, so a caller
+// can never lock, re-password, or delete an unrelated user.
+func requireFtpSubaccount(tenant *ftpTenant, sub string) (*user.User, *agentwire.AgentError) {
+	if aerr := validateFtpSubaccountName(tenant.Username, sub); aerr != nil {
+		return nil, aerr
+	}
+	u, err := user.Lookup(sub)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeNotFound,
+			Message: fmt.Sprintf("subaccount %q not found on host", sub),
+		}
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	if uid != tenant.UID {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("passwd entry %q has uid %d, expected tenant uid %d — refusing to touch a non-subaccount user", sub, uid, tenant.UID),
+		}
+	}
+	return u, nil
+}
+
+// ensureFtpGroup makes the jabali-ftp PAM group exist. Idempotent;
+// install.sh's ftp module also creates it, but an agent older host that
+// enables ftp_access before the module lands must not fail here.
+func ensureFtpGroup(ctx context.Context) *agentwire.AgentError {
+	if _, err := user.LookupGroup(ftpGroupName); err == nil {
+		return nil
+	}
+	if out, err := exec.CommandContext(ctx, "groupadd", "--system", ftpGroupName).CombinedOutput(); err != nil {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("groupadd %s: %v: %s", ftpGroupName, err, strings.TrimSpace(string(out))),
+		}
+	}
+	return nil
+}
+
+func setFtpGroupMembership(ctx context.Context, username string, member bool) *agentwire.AgentError {
+	if member {
+		if aerr := ensureFtpGroup(ctx); aerr != nil {
+			return aerr
+		}
+		if out, err := exec.CommandContext(ctx, "usermod", "-aG", ftpGroupName, username).CombinedOutput(); err != nil {
+			return &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: fmt.Sprintf("usermod -aG %s %s: %v: %s", ftpGroupName, username, err, strings.TrimSpace(string(out))),
+			}
+		}
+		return nil
+	}
+	isMember, err := isUserInGroup(ctx, username, ftpGroupName)
+	if err != nil || !isMember {
+		return nil // absent group or non-member: removal is a no-op
+	}
+	if out, gerr := exec.CommandContext(ctx, "gpasswd", "-d", username, ftpGroupName).CombinedOutput(); gerr != nil {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("gpasswd -d %s %s: %v: %s", username, ftpGroupName, gerr, strings.TrimSpace(string(out))),
+		}
+	}
+	return nil
+}
+
+// chpasswdStdin sets a password via chpasswd's stdin — the password must
+// never appear in argv (visible in /proc) or logs.
+func chpasswdStdin(ctx context.Context, username, password string) *agentwire.AgentError {
+	cmd := exec.CommandContext(ctx, "chpasswd")
+	cmd.Stdin = strings.NewReader(username + ":" + password + "\n")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("chpasswd for %q failed: %v: %s", username, err, strings.TrimSpace(string(out))),
+		}
+	}
+	return nil
+}
+
+// ---- ftpaccount.create ----
+
+type ftpAccountCreateParams struct {
+	TenantUsername string `json:"tenant_username"`
+	Username       string `json:"username"`
+	HomePath       string `json:"home_path"`
+	Password       string `json:"password"`
+	FTPAccess      bool   `json:"ftp_access"`
+}
+
+type ftpAccountCreateResponse struct {
+	Username string `json:"username"`
+	UID      int    `json:"uid"`
+	HomePath string `json:"home_path"`
+}
+
+func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpAccountCreateParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if aerr := validateFtpSubaccountName(tenant.Username, p.Username); aerr != nil {
+		return nil, aerr
+	}
+	homePath, aerr := resolveFtpHomePath(p.HomePath, tenant)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if p.Password == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "password is required"}
+	}
+	if _, err := user.Lookup(p.Username); err == nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeAlreadyExists, Message: fmt.Sprintf("user %q already exists", p.Username)}
+	}
+
+	// Same-uid alias. --no-create-home: the directory is the tenant's
+	// (created on demand below if missing); a subaccount must never own
+	// tenant tree nodes. /bin/bash because sshd runs ForceCommand through
+	// the login shell — nologin would break internal-sftp; shell sessions
+	// are impossible anyway (Match User forces SFTP; no console access).
+	// No --user-group and NO www-data (#430); jabali-ftp only via
+	// ftp_access below.
+	args := []string{
+		"--non-unique",
+		"--uid", strconv.Itoa(tenant.UID),
+		"--gid", strconv.Itoa(tenant.GID),
+		"--home-dir", homePath,
+		"--no-create-home",
+		"--no-user-group",
+		"--shell", "/bin/bash",
+		p.Username,
+	}
+	if out, err := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("useradd %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
+	}
+	rollback := func() {
+		// -f: the alias shares the tenant's uid, so the tenant's own
+		// processes (FPM pool, cron) always count as "user in use" and a
+		// plain userdel exits 8. Never --remove: home is tenant data.
+		_ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run()
+	}
+	// Home must exist for vsftpd chroot + internal-sftp start dir. Owned
+	// by the tenant uid like every other node in their tree.
+	if err := os.MkdirAll(homePath, 0o755); err != nil {
+		rollback()
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create home %q: %v", homePath, err)}
+	}
+	if err := os.Chown(homePath, tenant.UID, tenant.GID); err != nil {
+		rollback()
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown home %q: %v", homePath, err)}
+	}
+	if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
+		rollback()
+		return nil, aerr
+	}
+	if p.FTPAccess {
+		if aerr := setFtpGroupMembership(ctx, p.Username, true); aerr != nil {
+			rollback()
+			return nil, aerr
+		}
+	}
+	return ftpAccountCreateResponse{Username: p.Username, UID: tenant.UID, HomePath: homePath}, nil
+}
+
+// ---- ftpaccount.set_password ----
+
+type ftpAccountSetPasswordParams struct {
+	TenantUsername string `json:"tenant_username"`
+	Username       string `json:"username"`
+	Password       string `json:"password"`
+}
+
+func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpAccountSetPasswordParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+		return nil, aerr
+	}
+	if p.Password == "" {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "password is required"}
+	}
+	if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
+		return nil, aerr
+	}
+	return map[string]any{"username": p.Username, "updated": true}, nil
+}
+
+// ---- ftpaccount.set_access ----
+
+type ftpAccountSetAccessParams struct {
+	TenantUsername string `json:"tenant_username"`
+	Username       string `json:"username"`
+	FTPAccess      bool   `json:"ftp_access"`
+	// Enabled locks/unlocks the account password (usermod -L/-U): a
+	// disabled subaccount fails auth on every protocol but keeps its
+	// row, memberships, and files.
+	Enabled bool `json:"enabled"`
+}
+
+func ftpAccountSetAccessHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpAccountSetAccessParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+		return nil, aerr
+	}
+	if aerr := setFtpGroupMembership(ctx, p.Username, p.FTPAccess); aerr != nil {
+		return nil, aerr
+	}
+	lockFlag := "-U"
+	if !p.Enabled {
+		lockFlag = "-L"
+	}
+	if out, err := exec.CommandContext(ctx, "usermod", lockFlag, p.Username).CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod %s %q: %v: %s", lockFlag, p.Username, err, strings.TrimSpace(string(out)))}
+	}
+	return map[string]any{"username": p.Username, "ftp_access": p.FTPAccess, "enabled": p.Enabled}, nil
+}
+
+// ---- ftpaccount.delete ----
+
+type ftpAccountDeleteParams struct {
+	TenantUsername string `json:"tenant_username"`
+	Username       string `json:"username"`
+}
+
+func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpAccountDeleteParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+		// Idempotent delete: a passwd entry that is already gone is success.
+		if aerr.Code == agentwire.CodeNotFound {
+			return map[string]any{"username": p.Username, "deleted": false, "absent": true}, nil
+		}
+		return nil, aerr
+	}
+	_ = setFtpGroupMembership(ctx, p.Username, false)
+	// -f is REQUIRED, not defensive: the alias shares the tenant's uid, so
+	// the tenant's always-running processes (per-user FPM master, cron)
+	// make plain userdel fail with "user is currently used by process"
+	// (exit 8) — proven live on jabalitests. -f overrides only the in-use
+	// check; home removal stays off (NEVER --remove: the home dir is a
+	// live tenant directory, usually a docroot).
+	if out, err := exec.CommandContext(ctx, "userdel", "-f", p.Username).CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("userdel %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
+	}
+	return map[string]any{"username": p.Username, "deleted": true}, nil
+}
+
+// ---- ftpaccount.list ----
+
+type ftpAccountListParams struct {
+	TenantUsername string `json:"tenant_username"`
+}
+
+type ftpAccountListEntry struct {
+	Username  string `json:"username"`
+	HomePath  string `json:"home_path"`
+	FTPAccess bool   `json:"ftp_access"`
+	Locked    bool   `json:"locked"`
+}
+
+// ftpAccountListHandler reports the host's view of a tenant's subaccounts —
+// the reconciler diffs this against the DB (DB is truth; extra host entries
+// get removed, missing ones recreated).
+func ftpAccountListHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpAccountListParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	passwd, err := os.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read passwd: %v", err)}
+	}
+	prefix := tenant.Username + "_"
+	entries := []ftpAccountListEntry{}
+	for _, line := range strings.Split(string(passwd), "\n") {
+		parts := strings.Split(line, ":")
+		if len(parts) < 6 || !strings.HasPrefix(parts[0], prefix) {
+			continue
+		}
+		if uid, _ := strconv.Atoi(parts[2]); uid != tenant.UID {
+			continue // same prefix but not our alias — not ours to report
+		}
+		name := parts[0]
+		isFtp, _ := isUserInGroup(ctx, name, ftpGroupName)
+		locked := false
+		if out, perr := exec.CommandContext(ctx, "passwd", "-S", name).Output(); perr == nil {
+			fields := strings.Fields(string(out))
+			locked = len(fields) >= 2 && fields[1] == "L"
+		}
+		entries = append(entries, ftpAccountListEntry{
+			Username:  name,
+			HomePath:  parts[5],
+			FTPAccess: isFtp,
+			Locked:    locked,
+		})
+	}
+	return map[string]any{"accounts": entries}, nil
+}
+
+func init() {
+	Default.Register("ftpaccount.create", ftpAccountCreateHandler)
+	Default.Register("ftpaccount.set_password", ftpAccountSetPasswordHandler)
+	Default.Register("ftpaccount.set_access", ftpAccountSetAccessHandler)
+	Default.Register("ftpaccount.delete", ftpAccountDeleteHandler)
+	Default.Register("ftpaccount.list", ftpAccountListHandler)
+}

--- a/panel-agent/internal/commands/ftp_account_test.go
+++ b/panel-agent/internal/commands/ftp_account_test.go
@@ -1,0 +1,283 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// testTenantUser returns the current OS user when it satisfies the tenant
+// preconditions (uid >= 1000, home under /home) so validation paths past
+// resolveFtpTenant can run without mutating the host. Skips otherwise
+// (root CI containers, exotic homes).
+func testTenantUser(t *testing.T) *user.User {
+	t.Helper()
+	u, err := user.Current()
+	if err != nil {
+		t.Skipf("user.Current: %v", err)
+	}
+	uid, _ := strconv.Atoi(u.Uid)
+	if uid < minTenantUID {
+		t.Skipf("current uid %d < %d — tenant-validation paths need a regular user", uid, minTenantUID)
+	}
+	if len(u.HomeDir) < 7 || u.HomeDir[:6] != "/home/" {
+		t.Skipf("current home %q not under /home", u.HomeDir)
+	}
+	return u
+}
+
+func wantAgentErr(t *testing.T, err error, code string) *agentwire.AgentError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected agent error %q, got nil", code)
+	}
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *agentwire.AgentError, got %T: %v", err, err)
+	}
+	if ae.Code != code {
+		t.Fatalf("expected code %q, got %q (%s)", code, ae.Code, ae.Message)
+	}
+	return ae
+}
+
+func TestFtpAccountCreate_TenantNotFound(t *testing.T) {
+	params, _ := json.Marshal(ftpAccountCreateParams{
+		TenantUsername: "nosuchtenant", Username: "nosuchtenant_dev",
+		HomePath: "/home/nosuchtenant/site", Password: "x",
+	})
+	_, err := ftpAccountCreateHandler(context.Background(), params)
+	wantAgentErr(t, err, agentwire.CodeNotFound)
+}
+
+// root exists on every host with uid 0 — the alias floor must refuse it
+// regardless of what the panel sends (scar: uid-0 in an sftp-adjacent
+// group bricked host SSH).
+func TestFtpAccountCreate_RefusesRootTenant(t *testing.T) {
+	if _, err := user.Lookup("root"); err != nil {
+		t.Skip("no root user on this host")
+	}
+	params, _ := json.Marshal(ftpAccountCreateParams{
+		TenantUsername: "root", Username: "root_dev",
+		HomePath: "/root/x", Password: "x",
+	})
+	_, err := ftpAccountCreateHandler(context.Background(), params)
+	wantAgentErr(t, err, agentwire.CodePermissionDenied)
+}
+
+func TestFtpAccountCreate_NameValidation(t *testing.T) {
+	u := testTenantUser(t)
+	cases := []struct {
+		name string
+		sub  string
+	}{
+		{"missing tenant prefix", "otheruser_dev"},
+		{"bare tenant name", u.Username},
+		{"empty label", u.Username + "_"},
+		{"uppercase label", u.Username + "_Dev"},
+		{"label starts with underscore", u.Username + "__dev"},
+		{"shell metacharacters", u.Username + "_a;rm"},
+		{"too long", u.Username + "_" + "abcdefghijklmnopqrst9999999999999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(ftpAccountCreateParams{
+				TenantUsername: u.Username, Username: tc.sub,
+				HomePath: filepath.Join(u.HomeDir, "site"), Password: "x",
+			})
+			_, err := ftpAccountCreateHandler(context.Background(), params)
+			wantAgentErr(t, err, agentwire.CodeInvalidArgument)
+		})
+	}
+}
+
+func TestFtpAccountCreate_HomePathValidation(t *testing.T) {
+	u := testTenantUser(t)
+	sub := u.Username + "_dev"
+
+	cases := []struct {
+		name string
+		path string
+		code string
+	}{
+		{"relative", "site/public_html", agentwire.CodeInvalidArgument},
+		{"unclean traversal", u.HomeDir + "/../etc", agentwire.CodeInvalidArgument},
+		{"outside tenant home", "/etc/ssh", agentwire.CodePermissionDenied},
+		{"other home", "/home/someoneelse-xyz/site", agentwire.CodePermissionDenied},
+		{"trailing slash", u.HomeDir + "/site/", agentwire.CodeInvalidArgument},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(ftpAccountCreateParams{
+				TenantUsername: u.Username, Username: sub,
+				HomePath: tc.path, Password: "x",
+			})
+			_, err := ftpAccountCreateHandler(context.Background(), params)
+			wantAgentErr(t, err, tc.code)
+		})
+	}
+}
+
+// A symlink inside the tenant home pointing outside it must be refused —
+// tenant-writable trees mean the tenant chooses where symlinks point.
+func TestFtpAccountCreate_SymlinkEscapeRefused(t *testing.T) {
+	u := testTenantUser(t)
+	if err := os.MkdirAll(u.HomeDir, 0o755); err != nil {
+		t.Skipf("home not usable: %v", err)
+	}
+	link := filepath.Join(u.HomeDir, fmt.Sprintf(".ftptest-escape-%d", os.Getpid()))
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Skipf("cannot create symlink in home: %v", err)
+	}
+	defer os.Remove(link)
+
+	params, _ := json.Marshal(ftpAccountCreateParams{
+		TenantUsername: u.Username, Username: u.Username + "_dev",
+		HomePath: filepath.Join(link, "sub"), Password: "x",
+	})
+	_, err := ftpAccountCreateHandler(context.Background(), params)
+	wantAgentErr(t, err, agentwire.CodePermissionDenied)
+}
+
+func TestFtpAccountCreate_EmptyPassword(t *testing.T) {
+	u := testTenantUser(t)
+	params, _ := json.Marshal(ftpAccountCreateParams{
+		TenantUsername: u.Username, Username: u.Username + "_dev",
+		HomePath: filepath.Join(u.HomeDir, "site"), Password: "",
+	})
+	_, err := ftpAccountCreateHandler(context.Background(), params)
+	wantAgentErr(t, err, agentwire.CodeInvalidArgument)
+}
+
+// Deleting an absent subaccount is success (idempotent teardown — the
+// reconciler retries deletes; a half-done previous pass must not wedge it).
+func TestFtpAccountDelete_AbsentIsIdempotent(t *testing.T) {
+	u := testTenantUser(t)
+	params, _ := json.Marshal(ftpAccountDeleteParams{
+		TenantUsername: u.Username, Username: u.Username + "_nosuchacct",
+	})
+	res, err := ftpAccountDeleteHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("expected idempotent success, got %v", err)
+	}
+	m := res.(map[string]any)
+	if m["absent"] != true {
+		t.Fatalf("expected absent=true, got %v", m)
+	}
+}
+
+func TestFtpAccountSetPassword_GuardsNonSubaccount(t *testing.T) {
+	u := testTenantUser(t)
+	// "root" fails the prefix check; a same-prefix REAL user with a
+	// different uid can't exist without host mutation, so the uid-mismatch
+	// arm is covered by the gated cycle test below.
+	params, _ := json.Marshal(ftpAccountSetPasswordParams{
+		TenantUsername: u.Username, Username: "root", Password: "x",
+	})
+	_, err := ftpAccountSetPasswordHandler(context.Background(), params)
+	wantAgentErr(t, err, agentwire.CodeInvalidArgument)
+}
+
+func TestFtpAccountList_EmptyForTenantWithoutAccounts(t *testing.T) {
+	u := testTenantUser(t)
+	params, _ := json.Marshal(ftpAccountListParams{TenantUsername: u.Username})
+	res, err := ftpAccountListHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	m := res.(map[string]any)
+	accounts := m["accounts"].([]ftpAccountListEntry)
+	for _, a := range accounts {
+		t.Logf("unexpected pre-existing subaccount: %+v", a)
+	}
+}
+
+// Full lifecycle against the real host: create → list → set_access →
+// set_password → delete. Mutates passwd/groups — gated per GH #994.
+// Needs root (useradd) with a REAL tenant named via JABALI_TEST_TENANT;
+// without the env it falls back to the current user (who then needs
+// passwordless sudo-equivalent rights for useradd to succeed).
+func TestFtpAccountLifecycle_Host(t *testing.T) {
+	requireHostMutationAllowed(t)
+	var u *user.User
+	if tenant := os.Getenv("JABALI_TEST_TENANT"); tenant != "" {
+		var err error
+		u, err = user.Lookup(tenant)
+		if err != nil {
+			t.Fatalf("JABALI_TEST_TENANT %q: %v", tenant, err)
+		}
+	} else {
+		u = testTenantUser(t)
+	}
+	ctx := context.Background()
+	sub := u.Username + "_cycletest"
+	home := filepath.Join(u.HomeDir, ".ftp-cycle-test")
+	defer os.RemoveAll(home)
+
+	createP, _ := json.Marshal(ftpAccountCreateParams{
+		TenantUsername: u.Username, Username: sub,
+		HomePath: home, Password: "test-password-1", FTPAccess: true,
+	})
+	if _, err := ftpAccountCreateHandler(ctx, createP); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer func() {
+		delP, _ := json.Marshal(ftpAccountDeleteParams{TenantUsername: u.Username, Username: sub})
+		if _, err := ftpAccountDeleteHandler(ctx, delP); err != nil {
+			t.Errorf("cleanup delete: %v", err)
+		}
+		if _, err := user.Lookup(sub); err == nil {
+			t.Errorf("subaccount %q still exists after delete", sub)
+		}
+		if _, err := os.Stat(home); err != nil {
+			t.Errorf("home %q must survive delete (never --remove): %v", home, err)
+		}
+	}()
+
+	created, err := user.Lookup(sub)
+	if err != nil {
+		t.Fatalf("lookup after create: %v", err)
+	}
+	if created.Uid != u.Uid {
+		t.Fatalf("subaccount uid %s != tenant uid %s", created.Uid, u.Uid)
+	}
+
+	listP, _ := json.Marshal(ftpAccountListParams{TenantUsername: u.Username})
+	res, err := ftpAccountListHandler(ctx, listP)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, a := range res.(map[string]any)["accounts"].([]ftpAccountListEntry) {
+		if a.Username == sub {
+			found = true
+			if !a.FTPAccess {
+				t.Error("expected ftp_access=true after create with FTPAccess")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("created subaccount missing from list")
+	}
+
+	accP, _ := json.Marshal(ftpAccountSetAccessParams{
+		TenantUsername: u.Username, Username: sub, FTPAccess: false, Enabled: false,
+	})
+	if _, err := ftpAccountSetAccessHandler(ctx, accP); err != nil {
+		t.Fatalf("set_access: %v", err)
+	}
+	pwP, _ := json.Marshal(ftpAccountSetPasswordParams{
+		TenantUsername: u.Username, Username: sub, Password: "test-password-2",
+	})
+	if _, err := ftpAccountSetPasswordHandler(ctx, pwP); err != nil {
+		t.Fatalf("set_password: %v", err)
+	}
+}


### PR DESCRIPTION
Step 2 of 7 from `plans/gh1053-ftp-accounts.md` (GH #1053). Independent of step 1 (#1094) — no shared files; both must merge before step 3 wires the reconciler.

## What
`ftpaccount.create|set_password|set_access|delete|list` in `panel-agent/internal/commands/ftp_account.go`. A subaccount = second passwd entry aliasing the tenant's uid/gid (`useradd --non-unique`) — files always tenant-owned, sessions land in the tenant's user slice (M18 limits apply as-is).

## Agent-side hard gates (defense-in-depth, panel input never trusted)
- tenant exists, **uid ≥ 1000**, home under `/home` — root/system users can never be aliased
- names namespaced `<tenant>_<label>`; every mutating verb re-verifies the target passwd entry aliases exactly the tenant uid
- `home_path` absolute + clean + **symlink-resolved** (nearest existing ancestor) to inside the tenant home
- passwords via `chpasswd` stdin only — never argv, never logged
- `jabali-ftp` group only while `ftp_access`; **never `jabali-sftp`** (its M12 `ChrootDirectory /home/%u` would break on a subaccount name → connection resets)

## Found-by-live-test
Plain `userdel` always fails on alias deletion — the tenant's own FPM/cron processes hold the shared uid (`user … is currently used by process`, exit 8). Delete uses `-f` (overrides only the in-use check; home dir verified to survive — never `--remove`).

## Test plan
- [x] 20 unprivileged validation tests (name/table, home-path incl. symlink escape, root-tenant refusal, idempotent absent-delete, list scoping)
- [x] Gated lifecycle test (`JABALI_ALLOW_HOST_MUTATION=1` + `JABALI_TEST_TENANT`, GH #994) **run live on jabalitests**: create → uid==tenant → list → set_access → set_password → delete; home survives
- [x] `go build/vet/test` full commands package green
- [ ] Step 3 wires reconciler + sshd Match rendering

GH #1053