### PR TITLE
feat(ftp): sshd Match rendering + reconciler convergence for subaccounts (GH #1053 step 3)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -130,6 +130,16 @@ func resolveFtpHomePath(homePath string, tenant *ftpTenant) (string, *agentwire.
 			Message: fmt.Sprintf("home_path %q must be absolute and clean (no ., .., trailing slash)", homePath),
 		}
 	}
+	// The path lands in a rendered sshd directive (`internal-sftp -d`)
+	// and in the passwd home field: whitespace splits the argv, quotes
+	// and backslashes change tokenization, colons corrupt passwd rows.
+	// Docroot paths never legitimately contain any of these.
+	if strings.ContainsAny(homePath, " \t\r\n\"'\\:") {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("home_path %q must not contain whitespace, quotes, backslashes, or colons", homePath),
+		}
+	}
 	// Resolve through the nearest existing ancestor so a not-yet-created
 	// leaf directory doesn't fail validation while symlinked ancestors
 	// still get caught.
@@ -285,9 +295,14 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 
 	// Same-uid alias. --no-create-home: the directory is the tenant's
 	// (created on demand below if missing); a subaccount must never own
-	// tenant tree nodes. /bin/bash because sshd runs ForceCommand through
-	// the login shell — nologin would break internal-sftp; shell sessions
-	// are impossible anyway (Match User forces SFTP; no console access).
+	// tenant tree nodes. Shell is nologin ON PURPOSE: sshd's ForceCommand
+	// internal-sftp runs IN-PROCESS (no shell exec — M12's chroots contain
+	// no /bin and work), so SFTP is unaffected, while every path that
+	// WOULD exec a shell dead-ends. With bash, an alias that has no Match
+	// block yet (ftp-only account, or the create→first-sshd_sync gap)
+	// would get an interactive shell whenever the operator's global
+	// PasswordAuthentication toggle is on. vsftpd side: the step-4 PAM
+	// file must omit pam_shells.so, which would reject nologin.
 	// No --user-group and NO www-data (#430); jabali-ftp only via
 	// ftp_access below.
 	args := []string{
@@ -297,7 +312,7 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 		"--home-dir", homePath,
 		"--no-create-home",
 		"--no-user-group",
-		"--shell", "/bin/bash",
+		"--shell", "/usr/sbin/nologin",
 		p.Username,
 	}
 	if out, err := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); err != nil {

--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -69,20 +69,25 @@ func validateFtpSSHDAccount(a ftpSSHDSyncAccount) *agentwire.AgentError {
 			Message: fmt.Sprintf("invalid subaccount username %q for sshd render", a.Username),
 		}
 	}
+	// sshdConfigUnsafe rejects anything that could split or terminate a
+	// rendered directive: whitespace breaks `internal-sftp -d <path>` into
+	// extra argv, newlines inject new directives, quotes/backslashes
+	// change sshd's tokenization. Docroot paths never need any of them.
+	sshdConfigUnsafe := " \t\r\n\"'\\"
 	if !strings.HasPrefix(a.ChrootDir, "/home/") ||
 		filepath.Clean(a.ChrootDir) != a.ChrootDir ||
-		strings.Contains(a.ChrootDir, "\n") {
+		strings.ContainsAny(a.ChrootDir, sshdConfigUnsafe) {
 		return &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("invalid chroot_dir %q: must be a clean absolute path under /home", a.ChrootDir),
+			Message: fmt.Sprintf("invalid chroot_dir %q: must be a clean absolute path under /home without whitespace or quotes", a.ChrootDir),
 		}
 	}
 	if !strings.HasPrefix(a.StartDir, "/") ||
 		filepath.Clean(a.StartDir) != a.StartDir ||
-		strings.Contains(a.StartDir, "\n") {
+		strings.ContainsAny(a.StartDir, sshdConfigUnsafe) {
 		return &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("invalid start_dir %q: must be a clean chroot-relative path starting with /", a.StartDir),
+			Message: fmt.Sprintf("invalid start_dir %q: must be a clean chroot-relative path starting with / without whitespace or quotes", a.StartDir),
 		}
 	}
 	return nil
@@ -114,9 +119,14 @@ func renderXferDropin(accounts []ftpSSHDSyncAccount) string {
 		b.WriteString("    PermitTunnel no\n")
 		b.WriteString("    AllowAgentForwarding no\n")
 		// Subaccounts are password credentials by design (revocable,
-		// per-protocol). Key auth stays off: nothing manages their
-		// authorized_keys, and an unmanaged surface is drift.
+		// per-protocol). PubkeyAuthentication MUST be explicitly off, not
+		// left to the global default: sshd reads ~/.ssh/authorized_keys
+		// from the alias's REAL home — home_path, typically a docroot —
+		// BEFORE chroot. A tenant (or a compromised WordPress) writing
+		// docroot/.ssh/authorized_keys would otherwise mint key-based
+		// alias access that survives every password rotation.
 		b.WriteString("    PasswordAuthentication yes\n")
+		b.WriteString("    PubkeyAuthentication no\n")
 		b.WriteString("    KbdInteractiveAuthentication no\n")
 		b.WriteString("    PermitEmptyPasswords no\n")
 	}

--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// ftpaccount.sshd_sync — render the per-subaccount SFTP Match blocks into
+// /etc/ssh/sshd_config.d/jabali-xfer.conf (GH #1053 step 3).
+//
+// Subaccounts cannot ride M12's `Match Group jabali-sftp` block: its
+// `ChrootDirectory /home/%u` expands to a home named after the SUBACCOUNT
+// username, which doesn't exist — the failed chroot resets every
+// connection. Each subaccount instead gets its own `Match User` block that
+// chroots to the OWNING TENANT's home (root-owned 0751 per the M12 layout,
+// which is what sshd's chroot ownership check demands) and starts the
+// session in the account's home_path via `internal-sftp -d`.
+//
+// The panel sends the full desired set every time; the file is rendered
+// from scratch (never patched), validated with `sshd -t`, rolled back on
+// failure, and sshd reloaded only when content actually changed — same
+// contract as system.set_ssh_config in this package.
+
+const sshXferDropinDefault = "/etc/ssh/sshd_config.d/jabali-xfer.conf"
+
+func getSSHXferDropinPath() string {
+	if p := os.Getenv("JABALI_SSHD_XFER_DROPIN_PATH"); p != "" {
+		return p
+	}
+	return sshXferDropinDefault
+}
+
+type ftpSSHDSyncAccount struct {
+	Username string `json:"username"`
+	// ChrootDir is the tenant home (/home/<tenant>) — root-owned per M12.
+	ChrootDir string `json:"chroot_dir"`
+	// StartDir is the session start directory RELATIVE TO the chroot,
+	// always beginning with "/" ("/" = the chroot root itself).
+	StartDir string `json:"start_dir"`
+}
+
+type ftpSSHDSyncParams struct {
+	Accounts []ftpSSHDSyncAccount `json:"accounts"`
+}
+
+type ftpSSHDSyncResponse struct {
+	Accounts int  `json:"accounts"`
+	Changed  bool `json:"changed"`
+}
+
+// ftpXferUsernameRegex is deliberately stricter than usernameRegex: a
+// rendered name lands inside sshd config, so beyond POSIX validity it must
+// contain the "_" namespace separator every subaccount carries.
+var ftpXferUsernameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,31}$`)
+
+func validateFtpSSHDAccount(a ftpSSHDSyncAccount) *agentwire.AgentError {
+	if !ftpXferUsernameRegex.MatchString(a.Username) || !strings.Contains(a.Username, "_") {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid subaccount username %q for sshd render", a.Username),
+		}
+	}
+	if !strings.HasPrefix(a.ChrootDir, "/home/") ||
+		filepath.Clean(a.ChrootDir) != a.ChrootDir ||
+		strings.Contains(a.ChrootDir, "\n") {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid chroot_dir %q: must be a clean absolute path under /home", a.ChrootDir),
+		}
+	}
+	if !strings.HasPrefix(a.StartDir, "/") ||
+		filepath.Clean(a.StartDir) != a.StartDir ||
+		strings.Contains(a.StartDir, "\n") {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid start_dir %q: must be a clean chroot-relative path starting with /", a.StartDir),
+		}
+	}
+	return nil
+}
+
+// renderXferDropin produces the whole drop-in. Deterministic (accounts
+// sorted by username) so content comparison is a meaningful change gate.
+func renderXferDropin(accounts []ftpSSHDSyncAccount) string {
+	var b strings.Builder
+	b.WriteString(`# Jabali Panel — SFTP access for tenant FTP/SFTP subaccounts (GH #1053).
+# RENDERED by the panel reconciler from the ftp_accounts table — do not
+# edit in place; changes are overwritten on the next reconcile tick.
+#
+# Subaccounts are same-uid aliases of their tenant. They are NOT in the
+# jabali-sftp group (its /home/%u chroot cannot fit an alias username);
+# each gets a Match User block chrooting to the TENANT home instead.
+`)
+	sorted := append([]ftpSSHDSyncAccount(nil), accounts...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Username < sorted[j].Username })
+	for _, a := range sorted {
+		b.WriteString("\nMatch User " + a.Username + "\n")
+		// -d: start the session in the account's directory. Not a
+		// security boundary (the alias shares the tenant uid); the
+		// boundary is the tenant-home chroot.
+		b.WriteString("    ForceCommand internal-sftp -d " + a.StartDir + "\n")
+		b.WriteString("    ChrootDirectory " + a.ChrootDir + "\n")
+		b.WriteString("    AllowTcpForwarding no\n")
+		b.WriteString("    X11Forwarding no\n")
+		b.WriteString("    PermitTunnel no\n")
+		b.WriteString("    AllowAgentForwarding no\n")
+		// Subaccounts are password credentials by design (revocable,
+		// per-protocol). Key auth stays off: nothing manages their
+		// authorized_keys, and an unmanaged surface is drift.
+		b.WriteString("    PasswordAuthentication yes\n")
+		b.WriteString("    KbdInteractiveAuthentication no\n")
+		b.WriteString("    PermitEmptyPasswords no\n")
+	}
+	return b.String()
+}
+
+func ftpSSHDSyncHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p ftpSSHDSyncParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	seen := map[string]struct{}{}
+	for _, a := range p.Accounts {
+		if aerr := validateFtpSSHDAccount(a); aerr != nil {
+			return nil, aerr
+		}
+		if _, dup := seen[a.Username]; dup {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("duplicate account %q", a.Username)}
+		}
+		seen[a.Username] = struct{}{}
+	}
+
+	path := getSSHXferDropinPath()
+	desired := renderXferDropin(p.Accounts)
+	prev, readErr := os.ReadFile(path)
+	if readErr == nil && string(prev) == desired {
+		return ftpSSHDSyncResponse{Accounts: len(p.Accounts), Changed: false}, nil
+	}
+
+	if err := atomicWrite(path, desired); err != nil {
+		return nil, err
+	}
+	// sshd -t validates main config + every drop-in. On failure restore
+	// the previous content — a broken sshd config is a host lockout.
+	if os.Getenv("JABALI_SSHD_TEST_SKIP_VALIDATE") == "" {
+		if out, err := exec.CommandContext(ctx, "sshd", "-t").CombinedOutput(); err != nil {
+			restoreFile(path, prev)
+			return nil, fmt.Errorf("sshd -t validation failed: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+	}
+	if os.Getenv("JABALI_SSHD_TEST_SKIP_RELOAD") == "" {
+		unit := pickSSHUnit(ctx)
+		if unit == "" {
+			return nil, fmt.Errorf("no ssh/sshd systemd unit found")
+		}
+		if out, err := exec.CommandContext(ctx, "systemctl", "reload", unit).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("systemctl reload %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
+		}
+	}
+	return ftpSSHDSyncResponse{Accounts: len(p.Accounts), Changed: true}, nil
+}
+
+func init() {
+	Default.Register("ftpaccount.sshd_sync", ftpSSHDSyncHandler)
+}

--- a/panel-agent/internal/commands/ftp_account_sshd_test.go
+++ b/panel-agent/internal/commands/ftp_account_sshd_test.go
@@ -41,6 +41,12 @@ func TestRenderXferDropin_DeterministicAndComplete(t *testing.T) {
 		"ChrootDirectory /home/zeta",
 		"AllowTcpForwarding no",
 		"PasswordAuthentication yes",
+		// Load-bearing: without an explicit no, sshd falls back to the
+		// global default (yes) and reads authorized_keys from the alias's
+		// REAL home — a tenant-writable docroot — before chroot. That is
+		// a password-rotation-proof backdoor.
+		"PubkeyAuthentication no",
+		"KbdInteractiveAuthentication no",
 		"PermitEmptyPasswords no",
 	} {
 		if !strings.Contains(out, want) {
@@ -105,6 +111,9 @@ func TestFtpSSHDSync_Validation(t *testing.T) {
 		{"unclean chroot", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop/../other", StartDir: "/"}},
 		{"relative start dir", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "site"}},
 		{"start dir traversal", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/../../etc"}},
+		{"space splits -d argv", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/my site"}},
+		{"quote in start dir", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/a\"b"}},
+		{"space in chroot", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/my shop", StartDir: "/"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/panel-agent/internal/commands/ftp_account_sshd_test.go
+++ b/panel-agent/internal/commands/ftp_account_sshd_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+func xferEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jabali-xfer.conf")
+	t.Setenv("JABALI_SSHD_XFER_DROPIN_PATH", path)
+	t.Setenv("JABALI_SSHD_TEST_SKIP_VALIDATE", "1")
+	t.Setenv("JABALI_SSHD_TEST_SKIP_RELOAD", "1")
+	return path
+}
+
+func TestRenderXferDropin_DeterministicAndComplete(t *testing.T) {
+	accounts := []ftpSSHDSyncAccount{
+		{Username: "zeta_dev", ChrootDir: "/home/zeta", StartDir: "/site"},
+		{Username: "alpha_dev", ChrootDir: "/home/alpha", StartDir: "/"},
+	}
+	out := renderXferDropin(accounts)
+
+	// Sorted by username regardless of input order.
+	if strings.Index(out, "Match User alpha_dev") > strings.Index(out, "Match User zeta_dev") {
+		t.Fatal("blocks not sorted by username")
+	}
+	for _, want := range []string{
+		"Match User alpha_dev",
+		"ForceCommand internal-sftp -d /",
+		"ChrootDirectory /home/alpha",
+		"Match User zeta_dev",
+		"ForceCommand internal-sftp -d /site",
+		"ChrootDirectory /home/zeta",
+		"AllowTcpForwarding no",
+		"PasswordAuthentication yes",
+		"PermitEmptyPasswords no",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered config missing %q", want)
+		}
+	}
+	// Identical input → identical output (change-gate depends on it).
+	if out != renderXferDropin(accounts) {
+		t.Fatal("render not deterministic")
+	}
+}
+
+func TestFtpSSHDSync_WritesAndReportsChange(t *testing.T) {
+	path := xferEnv(t)
+	params, _ := json.Marshal(ftpSSHDSyncParams{Accounts: []ftpSSHDSyncAccount{
+		{Username: "shop_deploy", ChrootDir: "/home/shop", StartDir: "/example.com/public_html"},
+	}})
+
+	res, err := ftpSSHDSyncHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if !res.(ftpSSHDSyncResponse).Changed {
+		t.Fatal("first sync must report changed=true")
+	}
+	content, _ := os.ReadFile(path)
+	if !strings.Contains(string(content), "Match User shop_deploy") {
+		t.Fatalf("file missing block: %s", content)
+	}
+
+	// Same payload again → unchanged, no rewrite.
+	res, err = ftpSSHDSyncHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("resync: %v", err)
+	}
+	if res.(ftpSSHDSyncResponse).Changed {
+		t.Fatal("identical resync must report changed=false")
+	}
+}
+
+func TestFtpSSHDSync_EmptySetRendersHeaderOnly(t *testing.T) {
+	path := xferEnv(t)
+	params, _ := json.Marshal(ftpSSHDSyncParams{})
+	if _, err := ftpSSHDSyncHandler(context.Background(), params); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	content, _ := os.ReadFile(path)
+	if strings.Contains(string(content), "\nMatch User ") {
+		t.Fatalf("empty set must render no Match blocks: %s", content)
+	}
+}
+
+func TestFtpSSHDSync_Validation(t *testing.T) {
+	xferEnv(t)
+	cases := []struct {
+		name string
+		acct ftpSSHDSyncAccount
+	}{
+		{"no underscore (not a subaccount)", ftpSSHDSyncAccount{Username: "shopdeploy", ChrootDir: "/home/shop", StartDir: "/"}},
+		{"newline injection in username", ftpSSHDSyncAccount{Username: "shop_a\nPermitRootLogin yes", ChrootDir: "/home/shop", StartDir: "/"}},
+		{"chroot outside /home", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/etc", StartDir: "/"}},
+		{"unclean chroot", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop/../other", StartDir: "/"}},
+		{"relative start dir", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "site"}},
+		{"start dir traversal", ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/../../etc"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params, _ := json.Marshal(ftpSSHDSyncParams{Accounts: []ftpSSHDSyncAccount{tc.acct}})
+			_, err := ftpSSHDSyncHandler(context.Background(), params)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if ae := asAgentErr(t, err); ae.Code != agentwire.CodeInvalidArgument {
+				t.Fatalf("expected invalid_argument, got %v", err)
+			}
+		})
+	}
+
+	t.Run("duplicate usernames", func(t *testing.T) {
+		a := ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/"}
+		params, _ := json.Marshal(ftpSSHDSyncParams{Accounts: []ftpSSHDSyncAccount{a, a}})
+		if _, err := ftpSSHDSyncHandler(context.Background(), params); err == nil {
+			t.Fatal("expected duplicate rejection")
+		}
+	})
+}

--- a/panel-agent/internal/commands/ftp_account_test.go
+++ b/panel-agent/internal/commands/ftp_account_test.go
@@ -113,6 +113,9 @@ func TestFtpAccountCreate_HomePathValidation(t *testing.T) {
 		{"outside tenant home", "/etc/ssh", agentwire.CodePermissionDenied},
 		{"other home", "/home/someoneelse-xyz/site", agentwire.CodePermissionDenied},
 		{"trailing slash", u.HomeDir + "/site/", agentwire.CodeInvalidArgument},
+		{"space splits sshd -d argv", u.HomeDir + "/my site", agentwire.CodeInvalidArgument},
+		{"colon corrupts passwd row", u.HomeDir + "/a:b", agentwire.CodeInvalidArgument},
+		{"quote breaks sshd tokenization", u.HomeDir + "/a\"b", agentwire.CodeInvalidArgument},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -282,6 +282,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		deps.DBAdmin = dbAdminRepo
 		sshKeyRepo := repository.NewSSHKeyRepository(sharedDB)
 		deps.SSHKeys = sshKeyRepo
+		ftpAccountRepo := repository.NewFtpAccountRepository(sharedDB)
 
 		// M14 notification repos. Populated whenever sharedDB is up;
 		// the admin API (later) and dispatcher goroutine both read them
@@ -346,6 +347,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		rec.WithConfig(cfg)
 		rec.WithSSO(ssoService)
 		rec.WithSSHKeys(sshKeyRepo)
+		rec.WithFtpAccounts(ftpAccountRepo)
 		rec.WithCronJobs(cronJobsRepo)
 		rec.WithDockerApps(dockerAppRepo)
 		rec.WithPythonApps(pythonAppRepo)

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -1,0 +1,250 @@
+package reconciler
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// FTP/SFTP subaccount convergence (GH #1053 step 3,
+// plans/gh1053-ftp-accounts.md). DB rows are the truth; the host's passwd
+// aliases, jabali-ftp memberships, lock states, and the sshd jabali-xfer
+// drop-in all converge to them every tick (hash-gated to a no-op in steady
+// state, force-resynced on a bounded interval to heal out-of-band drift).
+//
+// The API paths do their host mutations synchronously (create/delete talk
+// to the agent first, row second), so this pass is the drift healer:
+// missing aliases after a DR restore, hand-run userdel, group edits, or a
+// stale drop-in all get repaired here.
+
+const ftpAccountsReDispatchInterval = 15 * time.Minute
+
+type ftpDispatchState struct {
+	Hash string
+	At   time.Time
+}
+
+// desiredFtpHash covers every reconcile input: each row's identity +
+// flags + home, and the owning tenant's username (renames change the
+// rendered config without touching ftp_accounts rows).
+func desiredFtpHash(rows []models.FtpAccount, tenantByUserID map[string]string) string {
+	lines := make([]string, 0, len(rows))
+	for _, a := range rows {
+		lines = append(lines, strings.Join([]string{
+			a.ID, a.Username, tenantByUserID[a.UserID], a.HomePath,
+			fmt.Sprintf("%t|%t|%t", a.FTPAccess, a.SFTPAccess, a.IsEnabled),
+		}, "^"))
+	}
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n") + "\nn=" + fmt.Sprint(len(lines))))
+	return hex.EncodeToString(sum[:])
+}
+
+// randomThrowawayPassword returns a high-entropy password for recreating a
+// drifted alias whose real password lives only in the lost /etc/shadow
+// entry. Nobody knows it — the account exists but cannot authenticate
+// until the tenant resets the password through the panel. That is the
+// correct DR posture: silently minting a KNOWN password would be worse.
+func randomThrowawayPassword() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("entropy: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+type agentFtpListEntry struct {
+	Username  string `json:"username"`
+	HomePath  string `json:"home_path"`
+	FTPAccess bool   `json:"ftp_access"`
+	Locked    bool   `json:"locked"`
+}
+
+// reconcileFtpAccounts converges host state to the ftp_accounts table.
+// Never returns an error — SSL-reconciler convention: log and let the
+// rest of the tick proceed.
+func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
+	if r.ftpAccounts == nil || r.users == nil || r.agent == nil {
+		return
+	}
+	rows, err := r.ftpAccounts.List(ctx)
+	if err != nil {
+		r.log.Error("ftp: list accounts failed", "err", err)
+		return
+	}
+
+	// Resolve tenant usernames once; drop rows whose owner has no Linux
+	// identity (deleted user mid-flight, admin rows) with a warning —
+	// they cannot converge and must not kill the pass.
+	tenantByUserID := map[string]string{}
+	rowsByTenant := map[string][]models.FtpAccount{}
+	for _, a := range rows {
+		uname, ok := tenantByUserID[a.UserID]
+		if !ok {
+			u, uerr := r.users.FindByID(ctx, a.UserID)
+			if uerr != nil || u == nil || u.Username == nil || *u.Username == "" {
+				r.log.Warn("ftp: account owner has no linux username — skipping row", "account", a.Username, "user_id", a.UserID)
+				tenantByUserID[a.UserID] = ""
+				continue
+			}
+			uname = *u.Username
+			tenantByUserID[a.UserID] = uname
+		}
+		if uname == "" {
+			continue
+		}
+		rowsByTenant[uname] = append(rowsByTenant[uname], a)
+	}
+
+	fullHash := desiredFtpHash(rows, tenantByUserID)
+	if v, ok := r.ftpDispatchCache.Load("all"); ok {
+		if st, okT := v.(ftpDispatchState); okT && st.Hash == fullHash && time.Since(st.At) < ftpAccountsReDispatchInterval {
+			return
+		}
+	}
+
+	converged := true
+	for tenant, accts := range rowsByTenant {
+		if !r.reconcileFtpTenant(ctx, tenant, accts) {
+			converged = false
+		}
+	}
+
+	// Render the sshd drop-in from every enabled+sftp row (all tenants,
+	// one file). StartDir is home_path relative to the tenant home —
+	// internal-sftp resolves it inside the chroot.
+	type syncAccount struct {
+		Username  string `json:"username"`
+		ChrootDir string `json:"chroot_dir"`
+		StartDir  string `json:"start_dir"`
+	}
+	desired := []syncAccount{}
+	for tenant, accts := range rowsByTenant {
+		chroot := "/home/" + tenant
+		for _, a := range accts {
+			if !a.IsEnabled || !a.SFTPAccess {
+				continue
+			}
+			start := "/"
+			if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+				start = "/" + rel
+			}
+			desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
+		}
+	}
+	if _, err := r.agent.Call(ctx, "ftpaccount.sshd_sync", map[string]any{"accounts": desired}); err != nil {
+		r.log.Warn("ftp: sshd_sync failed (will retry next pass)", "err", err)
+		converged = false
+	}
+
+	if converged {
+		r.ftpDispatchCache.Store("all", ftpDispatchState{Hash: fullHash, At: time.Now()})
+	}
+}
+
+// reconcileFtpTenant diffs one tenant's desired rows against the host's
+// passwd view and repairs drift. Returns false when any repair failed
+// (keeps the hash gate open so the next tick retries).
+func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, accts []models.FtpAccount) bool {
+	raw, err := r.agent.Call(ctx, "ftpaccount.list", map[string]any{"tenant_username": tenant})
+	if err != nil {
+		r.log.Warn("ftp: host list failed", "tenant", tenant, "err", err)
+		return false
+	}
+	var listResp struct {
+		Accounts []agentFtpListEntry `json:"accounts"`
+	}
+	if err := json.Unmarshal(raw, &listResp); err != nil {
+		r.log.Warn("ftp: host list parse failed", "tenant", tenant, "err", err)
+		return false
+	}
+	host := map[string]agentFtpListEntry{}
+	for _, h := range listResp.Accounts {
+		host[h.Username] = h
+	}
+	desired := map[string]models.FtpAccount{}
+	for _, a := range accts {
+		desired[a.Username] = a
+	}
+
+	ok := true
+	// Missing or drifted aliases.
+	for name, want := range desired {
+		got, exists := host[name]
+		if !exists {
+			pw, perr := randomThrowawayPassword()
+			if perr != nil {
+				r.log.Error("ftp: throwaway password", "err", perr)
+				return false
+			}
+			if _, err := r.agent.Call(ctx, "ftpaccount.create", map[string]any{
+				"tenant_username": tenant,
+				"username":        name,
+				"home_path":       want.HomePath,
+				"password":        pw,
+				"ftp_access":      want.FTPAccess,
+			}); err != nil {
+				r.log.Warn("ftp: recreate missing alias failed", "account", name, "err", err)
+				ok = false
+				continue
+			}
+			r.log.Info("ftp: recreated missing subaccount — password reset required before it can log in", "account", name, "tenant", tenant)
+			got = agentFtpListEntry{Username: name, FTPAccess: want.FTPAccess, Locked: false}
+		}
+		wantLocked := !want.IsEnabled
+		if got.FTPAccess != want.FTPAccess || got.Locked != wantLocked {
+			if _, err := r.agent.Call(ctx, "ftpaccount.set_access", map[string]any{
+				"tenant_username": tenant,
+				"username":        name,
+				"ftp_access":      want.FTPAccess,
+				"enabled":         want.IsEnabled,
+			}); err != nil {
+				r.log.Warn("ftp: access drift repair failed", "account", name, "err", err)
+				ok = false
+			}
+		}
+	}
+	// Host aliases with no row: the row is the only handle — a rowless
+	// alias is unaccounted access and gets removed.
+	for name := range host {
+		if _, wanted := desired[name]; wanted {
+			continue
+		}
+		if _, err := r.agent.Call(ctx, "ftpaccount.delete", map[string]any{
+			"tenant_username": tenant,
+			"username":        name,
+		}); err != nil {
+			r.log.Warn("ftp: stray alias removal failed", "account", name, "err", err)
+			ok = false
+			continue
+		}
+		r.log.Info("ftp: removed stray subaccount with no panel row", "account", name, "tenant", tenant)
+	}
+
+	// M12 chroot precondition: sshd only chroots into a root-owned home.
+	// Tenants who never used SFTP themselves may still have a
+	// tenant-owned /home/<tenant>; flip it via the existing M12 verb when
+	// this tenant has at least one SFTP-enabled subaccount.
+	for _, a := range accts {
+		if a.IsEnabled && a.SFTPAccess {
+			if _, err := r.agent.Call(ctx, "ssh.user.home_chown", map[string]any{
+				"username": tenant,
+				"mode":     "sftp",
+			}); err != nil {
+				r.log.Warn("ftp: tenant home chroot-perms flip failed", "tenant", tenant, "err", err)
+				ok = false
+			}
+			break
+		}
+	}
+	return ok
+}

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -1,0 +1,244 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeFtpAccountRepo struct {
+	repository.FtpAccountRepository
+	rows []models.FtpAccount
+}
+
+func (f *fakeFtpAccountRepo) List(context.Context) ([]models.FtpAccount, error) {
+	return f.rows, nil
+}
+
+type ftpUsersRepo struct {
+	repository.UserRepository
+	byID map[string]*models.User
+}
+
+func (f *ftpUsersRepo) FindByID(_ context.Context, id string) (*models.User, error) {
+	if u, ok := f.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func ftpTestReconciler(t *testing.T, agent *fakeAgent, rows []models.FtpAccount, tenants map[string]string) *Reconciler {
+	t.Helper()
+	byID := map[string]*models.User{}
+	for userID, uname := range tenants {
+		name := uname
+		byID[userID] = &models.User{ID: userID, Username: &name}
+	}
+	r := New(nil, &ftpUsersRepo{byID: byID}, agent, slog.Default(), Config{})
+	r.WithFtpAccounts(&fakeFtpAccountRepo{rows: rows})
+	return r
+}
+
+func ftpCallsByMethod(a *fakeAgent) map[string][]fakeCall {
+	out := map[string][]fakeCall{}
+	for _, c := range a.calls {
+		out[c.method] = append(out[c.method], c)
+	}
+	return out
+}
+
+func hostListResult(t *testing.T, entries []agentFtpListEntry) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"accounts": entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestReconcileFtpAccounts_RecreatesMissingAlias(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, nil), // host has nothing
+	}}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop/site", FTPAccess: true, SFTPAccess: true, IsEnabled: true,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	creates := calls["ftpaccount.create"]
+	if len(creates) != 1 {
+		t.Fatalf("expected 1 create, got %d", len(creates))
+	}
+	params := creates[0].params.(map[string]any)
+	if params["username"] != "shop_deploy" || params["tenant_username"] != "shop" {
+		t.Fatalf("create params wrong: %v", params)
+	}
+	// The throwaway password must be present and high-entropy (64 hex),
+	// never empty — and is unknowable, so the account can't log in until
+	// a real password reset.
+	pw, _ := params["password"].(string)
+	if len(pw) != 64 {
+		t.Fatalf("expected 64-char throwaway password, got %d chars", len(pw))
+	}
+	if len(calls["ftpaccount.sshd_sync"]) != 1 {
+		t.Fatal("expected sshd_sync call")
+	}
+	if len(calls["ssh.user.home_chown"]) != 1 {
+		t.Fatal("expected tenant home chroot-perms flip")
+	}
+}
+
+func TestReconcileFtpAccounts_RemovesStrayAlias(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy", FTPAccess: false, Locked: false}, // desired
+			{Username: "shop_old", FTPAccess: true, Locked: false},     // stray
+		}),
+	}}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop", FTPAccess: false, SFTPAccess: true, IsEnabled: true,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	if len(calls["ftpaccount.delete"]) != 1 {
+		t.Fatalf("expected 1 stray delete, got %d", len(calls["ftpaccount.delete"]))
+	}
+	if calls["ftpaccount.delete"][0].params.(map[string]any)["username"] != "shop_old" {
+		t.Fatal("deleted the wrong account")
+	}
+	if len(calls["ftpaccount.create"]) != 0 {
+		t.Fatal("no creates expected — desired alias already present")
+	}
+}
+
+func TestReconcileFtpAccounts_RepairsAccessDrift(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			// host: ftp on + unlocked; DB wants ftp off + disabled(locked)
+			{Username: "shop_deploy", FTPAccess: true, Locked: false},
+		}),
+	}}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop", FTPAccess: false, SFTPAccess: true, IsEnabled: false,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	if len(calls["ftpaccount.set_access"]) != 1 {
+		t.Fatalf("expected 1 set_access, got %d", len(calls["ftpaccount.set_access"]))
+	}
+	p := calls["ftpaccount.set_access"][0].params.(map[string]any)
+	if p["ftp_access"] != false || p["enabled"] != false {
+		t.Fatalf("set_access params wrong: %v", p)
+	}
+}
+
+func TestReconcileFtpAccounts_SSHDSyncPayloadShape(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy"},
+			{Username: "shop_ftponly", FTPAccess: true},
+			{Username: "shop_off", Locked: true},
+		}),
+	}}
+	rows := []models.FtpAccount{
+		// sftp+enabled → rendered, start dir = home relative to chroot
+		{ID: "a1", UserID: "u1", Username: "shop_deploy", HomePath: "/home/shop/example.com/public_html", SFTPAccess: true, IsEnabled: true},
+		// ftp-only → NOT in sshd render
+		{ID: "a2", UserID: "u1", Username: "shop_ftponly", HomePath: "/home/shop", FTPAccess: true, SFTPAccess: false, IsEnabled: true},
+		// disabled → NOT in sshd render
+		{ID: "a3", UserID: "u1", Username: "shop_off", HomePath: "/home/shop", SFTPAccess: true, IsEnabled: false},
+	}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	if len(calls["ftpaccount.sshd_sync"]) != 1 {
+		t.Fatal("expected one sshd_sync")
+	}
+	payload := calls["ftpaccount.sshd_sync"][0].params.(map[string]any)
+	raw, _ := json.Marshal(payload["accounts"])
+	var accounts []struct {
+		Username  string `json:"username"`
+		ChrootDir string `json:"chroot_dir"`
+		StartDir  string `json:"start_dir"`
+	}
+	if err := json.Unmarshal(raw, &accounts); err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected exactly the sftp+enabled account rendered, got %d", len(accounts))
+	}
+	a := accounts[0]
+	if a.Username != "shop_deploy" || a.ChrootDir != "/home/shop" || a.StartDir != "/example.com/public_html" {
+		t.Fatalf("payload wrong: %+v", a)
+	}
+}
+
+func TestReconcileFtpAccounts_HashGateSkipsSteadyState(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy"},
+		}),
+	}}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop", SFTPAccess: true, IsEnabled: true,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+	first := len(agent.calls)
+	if first == 0 {
+		t.Fatal("first pass must dispatch")
+	}
+	r.reconcileFtpAccounts(context.Background())
+	if len(agent.calls) != first {
+		t.Fatalf("steady-state second pass must be a no-op, got %d extra calls", len(agent.calls)-first)
+	}
+}
+
+func TestReconcileFtpAccounts_FailureKeepsGateOpen(t *testing.T) {
+	agent := &fakeAgent{
+		failMethod: "ftpaccount.sshd_sync",
+		resultByMethod: map[string]json.RawMessage{
+			"ftpaccount.list": hostListResult(t, []agentFtpListEntry{{Username: "shop_deploy"}}),
+		},
+	}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop", SFTPAccess: true, IsEnabled: true,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+	if _, cached := r.ftpDispatchCache.Load("all"); cached {
+		t.Fatal("failed pass must not cache the hash — drift would never heal")
+	}
+}
+
+func TestReconcileFtpAccounts_NoRepoIsNoop(t *testing.T) {
+	agent := &fakeAgent{}
+	r := New(nil, &ftpUsersRepo{}, agent, slog.Default(), Config{Interval: time.Second})
+	r.reconcileFtpAccounts(context.Background())
+	if len(agent.calls) != 0 {
+		t.Fatal("nil repo must be a silent no-op")
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -113,6 +113,8 @@ type Reconciler struct {
 	wordPressInstalls repository.WordPressInstallRepository
 	// sshKeys holds reference to the SSH keys repository
 	sshKeys repository.SSHKeyRepository
+	// ftpAccounts holds the FTP/SFTP subaccount repository (GH #1053).
+	ftpAccounts repository.FtpAccountRepository
 	// cronJobs holds reference to the cron jobs repository
 	cronJobs repository.CronJobRepository
 	// pythonApps holds the python_apps repository (ADR-0131).
@@ -239,6 +241,12 @@ type Reconciler struct {
 	// sshKeysDispatchState. sync.Map = lock-free for the common
 	// "many readers, one writer per key" pattern.
 	sshKeysDispatchCache sync.Map
+
+	// ftpDispatchCache: single-key ("all") hash of the desired FTP
+	// subaccount state — same shape and rationale as sshKeysDispatchCache
+	// (GH #1053; steady state must not re-list passwd + re-render sshd
+	// config every tick).
+	ftpDispatchCache sync.Map
 
 	// dnsZoneDispatchCache: per-zone hash of the last-pushed record set +
 	// timestamp, same shape and rationale as sshKeysDispatchCache. Without
@@ -521,6 +529,13 @@ func (r *Reconciler) WithSSHKeys(sshKeys repository.SSHKeyRepository) *Reconcile
 	return r
 }
 
+// WithFtpAccounts adds the FTP/SFTP subaccount repository (GH #1053).
+// Without it reconcileFtpAccounts is a no-op.
+func (r *Reconciler) WithFtpAccounts(ftpAccounts repository.FtpAccountRepository) *Reconciler {
+	r.ftpAccounts = ftpAccounts
+	return r
+}
+
 // WithCronJobs adds cron jobs repository support to the reconciler.
 // Call this before using cron jobs reconciliation.
 func (r *Reconciler) WithCronJobs(cronJobs repository.CronJobRepository) *Reconciler {
@@ -752,6 +767,10 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// M34: per-user PHP-FPM egress firewall. Cheap noop when the repo
 	// isn't wired (test fixtures) or when there are zero policies.
 	r.reconcileUserEgress(ctx)
+	// GH #1053: converge FTP/SFTP subaccounts (passwd aliases, group
+	// membership, lock state, sshd jabali-xfer drop-in). Hash-gated no-op
+	// in steady state.
+	r.reconcileFtpAccounts(ctx)
 	// JAB-195: keep this host's own public IPs allowlisted so AppSec never
 	// scores WordPress loopback traffic (WooCommerce Action Scheduler et al).
 	r.reconcileSelfAllowlist(ctx)

--- a/plans/gh1053-ftp-accounts.md
+++ b/plans/gh1053-ftp-accounts.md
@@ -1,0 +1,226 @@
+# GH #1053 — FTP / SFTP accounts for tenants
+
+**Status:** planned (blueprint only, nothing built)
+**Issue:** GH #1053 "Feature: Create a normal ftp user"
+**Decided:** 2026-08-15 — extend the native OpenSSH path + add vsftpd as an
+opt-in module. SFTPGo evaluated and rejected (see "Why not SFTPGo" below).
+
+## Goal
+
+Tenants can create additional file-transfer accounts scoped to a directory
+(typically a docroot), usable over SFTP always, and over FTPS when the admin
+has opted the server in. Accounts are self-service within a per-package cap.
+
+## Product requirements
+
+1. **Tenant self-service.** Users create/manage their own FTP/SFTP accounts
+   from the user shell — username, password, home directory (picker scoped to
+   their own tree), enable/disable, delete. No admin involvement per account.
+2. **Package-gated.** `hosting_packages.max_ftp_accounts` (int, default 0)
+   caps how many accounts each user may create. 0 = feature invisible for
+   that user (tenant caps default OFF — see memory
+   `feedback_tenant_caps_default_off`).
+3. **FTP is opt-in at the server level.** `server_settings.ftp_enabled`
+   (bool, **default false**). Admin flips it in Server Settings → the panel
+   installs/starts the vsftpd module (M353 install-on-enable pattern, gated
+   on DB truth per GH #727). While off: no FTP daemon installed, port 21
+   closed, accounts still work over SFTP. The reconciler masks vsftpd when
+   the flag is off (same pattern as pdns masking, GH #447).
+4. **SFTP always available** for these accounts (no server-level toggle —
+   sshd is already there; M12 hardening applies).
+5. **FTPS-only by default.** When FTP is enabled, TLS is required
+   (`force_local_logins_ssl=YES`). A separate explicit admin toggle
+   `ftp_allow_plaintext` (default false) exists for legacy clients, with a
+   warning in the UI. Never relax this silently.
+
+## Core design
+
+### Same-uid alias accounts
+
+Each FTP/SFTP account is a REAL system user created with the TENANT's uid
+(`useradd --non-unique --uid <tenant-uid> --gid <tenant-gid>`), its own
+username + password (shadow), home = the chosen directory. Consequences, all
+load-bearing:
+
+- Files created via any protocol are owned by the tenant uid → per-user
+  POSIX quotas, per-user PHP-FPM, AppArmor docroot profiles, setgid
+  www-data docroots, and backups all behave identically to files the tenant
+  created themselves. Zero ownership drift.
+- Auth is per-username (PAM/shadow), so disable/delete/password-change is
+  per-account without touching the tenant's own login.
+- Known cosmetic quirk: `who`/`last` may display the first passwd entry for
+  the uid. Accepted.
+- HARD RULE: alias uid must never be 0 and never a non-tenant system uid —
+  validate against the tenant row, mirror the panel-side allowlist on the
+  agent side (M14 defense-in-depth). Scar: `feedback_no_root_in_sftp_group`.
+
+### SFTP half (no new daemon)
+
+sshd `Match User` blocks (rendered into a dedicated include file, e.g.
+`/etc/ssh/sshd_config.d/jabali-xfer.conf`): `ChrootDirectory` +
+`ForceCommand internal-sftp -u 0007` + no TCP/agent/X11 forwarding. Reuse
+M12's chroot layout solution for the root-owned-path requirement
+(ChrootDirectory demands root-owned, non-group-writable ancestors — the M12
+jail layout already solved this; do NOT invent a second layout). Membership
+in `jabali-sftp` group as per M12. `sshd -t` before reload, always
+(a bad include = fleet-wide SSH lockout; see `feedback_ssh_dual_enable_lockout`).
+
+### FTP half (vsftpd, optional module)
+
+- vsftpd chosen over ProFTPD/pure-ftpd: Debian-native (memory:
+  `feedback_nginx_debian_native_not_sury` — same reasoning), smallest attack
+  surface, PAM auth so the SAME accounts/credentials work for both
+  protocols, forks + setuid per session (kernel-enforced ownership),
+  `chroot_local_user=YES`.
+- TLS: serve the panel hostname certificate (FTPS has no workable SNI story
+  across clients; document that the FTP endpoint is `ftp.<panel-hostname>` /
+  panel hostname, not the tenant's domain).
+- Passive mode: fixed port range (e.g. 40000–40100) + `pasv_address` from
+  server settings when behind NAT; UFW opens 21 + the passive range ONLY
+  when the module is enabled, closes them when disabled.
+- PAM: restrict to users in a `jabali-ftp` group (accounts get the group
+  only when their `ftp_access` flag is on) so tenant primary logins and
+  system users can never FTP in.
+- CrowdSec: enable the vsftpd collection (log parser + brute-force
+  scenario) when the module installs.
+- Fail mode: module install failure must not abort panel install/update
+  (memory: `feedback_optional_component_cant_abort_panel`).
+
+### Why not SFTPGo
+
+Evaluated 2026-08-15 (user suggestion). Solid project, wrong tenancy fit:
+(1) isolation is userspace path-normalization, not kernel chroot+uid — its
+own SECURITY.md says so; one path bug = cross-tenant access with daemon
+privileges, and adopting it would downgrade the kernel-enforced model we
+already ship (security-over-functionality doctrine forbids that trade);
+(2) single-process daemon → uploaded-file ownership depends on app-level
+chown, while our quotas/FPM/AppArmor assume tenant-uid ownership natively;
+(3) second user store + REST + admin UI to reconcile and CVE-track, next to
+the OpenSSH path we keep anyway. Revisit only if S3/WebDAV/HTTP-share
+backends become requirements.
+
+## Data model
+
+```
+ftp_accounts
+  id            CHAR(26) ULID PK
+  user_id       CHAR(26) FK -> users (tenant owner)
+  username      VARCHAR(64) UNIQUE  -- full system username, e.g. deploy@tenant or tenant_deploy
+  home_path     VARCHAR(512)        -- absolute, must be inside the tenant's home
+  ftp_access    BOOL default 0      -- member of jabali-ftp group
+  sftp_access   BOOL default 1
+  is_enabled    BOOL default 1
+  created_at / updated_at
+```
+
+- Password: NEVER stored in the panel DB. Set via agent (`chpasswd`) at
+  create/reset; DB stores no hash. (`json:"-"` discipline is moot — there is
+  no column.)
+- Username namespace: prefix with the tenant username
+  (`<tenant>_<label>`, validated `[a-z0-9_]`, total ≤ 32 chars) so accounts
+  can't collide with real users or other tenants' accounts.
+- server_settings: `ftp_enabled` BOOL default 0, `ftp_allow_plaintext` BOOL
+  default 0, `ftp_pasv_address` VARCHAR(64) default ''.
+- hosting_packages: `max_ftp_accounts` INT default 0.
+- GORM scars to respect: no `default:1` on bools that must accept false
+  (`feedback_gorm_default1_bool_zero_value`), Select-allowlist on updates
+  (`feedback_domain_update_allowlist_silent_drop`), MariaDB FK needs
+  explicit COLLATE (`feedback_mariadb_collation_fk`).
+
+## Steps (each = one branch, one PR)
+
+### Step 1 — schema + models + repository (`gh1053-ftp-schema`)
+Migration (next free number — grep `panel-api/internal/db/migrations/`),
+models, `FtpAccountRepository` (interface + gorm impl + sqlmock tests),
+package field + server-settings fields. Schema-only migration, no seeding
+(`feedback_migration_data_seed_ordering`).
+
+### Step 2 — agent commands (`gh1053-ftp-agent`)
+`ftpaccount.create|delete|set_password|set_access|list` in
+`panel-agent/internal/commands/ftp_account.go`. Same-uid alias creation,
+home-path validation (must resolve inside tenant home, no symlink escape —
+use the filesafe helpers), `jabali-ftp`/`jabali-sftp` group membership,
+chpasswd via stdin (never argv). Env-gate destructive tests
+(`feedback_gh994_destructive_tests_root_prompt`). Wire types in `agentwire/`.
+
+### Step 3 — sshd Match rendering + reconciler (`gh1053-ftp-sshd`)
+Renderer for `/etc/ssh/sshd_config.d/jabali-xfer.conf` from DB rows;
+reconciler tick converges system users + Match blocks (idempotent,
+per-tick — `feedback_per_tick_idempotent_loops`); `sshd -t` gate before
+reload; drift heal (account row deleted → system user removed). SFTP half
+fully live after this step.
+
+### Step 4 — vsftpd module (`gh1053-ftp-vsftpd`)
+**PAM note (from step 3 review):** subaccounts ship with shell
+`/usr/sbin/nologin` (blocks the no-Match-block shell path; internal-sftp is
+in-process so SFTP is unaffected). Debian's stock vsftpd PAM includes
+`pam_shells.so`, which rejects nologin — the custom PAM file MUST omit it
+(do not add nologin to /etc/shells instead; that widens every other
+pam_shells consumer).
+`install.sh`: `install_module_ftp` (M353 install-on-enable; modular gate on
+DB truth per #727), vsftpd config template, PAM file, UFW rules (21 +
+passive range, added/removed with the toggle), CrowdSec collection,
+`provision_new_software` convergence for existing hosts, reconciler
+mask/unmask on `ftp_enabled` (GH #447 pattern). Every system dep declared in
+install.sh (`feedback_deps_in_installer`). Logger: `_log/_ok/_warn/_err`
+only.
+
+### Step 5 — panel API (`gh1053-ftp-api`)
+**Latency note (from step 3 review):** the create path must call
+`ssh.user.home_chown` + `ftpaccount.sshd_sync` SYNCHRONOUSLY after
+`ftpaccount.create` — waiting for the reconciler tick leaves a fresh
+account unable to log in for up to 60s.
+`RegisterFtpAccountRoutes` per route-family convention: tenant CRUD under
+`/me/ftp-accounts` (cap-checked against package), admin list/override under
+`/admin/ftp-accounts`, server-settings PATCH gains the ftp fields (allowlist
+update). 422 on cap exceeded, rate limits, OpenAPI coverage
+(`feedback_openapi_coverage_golden`), list envelope
+`{data,total,page,page_size}`.
+
+### Step 6 — UI (`gh1053-ftp-ui`)
+User shell: "FTP Accounts" page (SearchableTable + shared create/edit
+Drawer, `@icons`, `scroll={{x:"max-content"}}`), password-reset flow,
+connection-info panel (host, port, protocol matrix, FTPS caveat). Page/nav
+hidden when `max_ftp_accounts == 0`. Admin shell: Server Settings card with
+the **FTP opt-in toggle** (+ plaintext toggle behind it, warning copy) and
+passive-address field; Hosting Packages drawer gains `max_ftp_accounts`.
+Verify wire contract against handler (`feedback_verify_wire_contract`).
+
+### Step 7 — E2E + docs + closeout (`gh1053-ftp-e2e`)
+**E2E additions (from step 3 review):** a REAL `sftp` login against a
+rendered Match User block (proves nologin + in-process internal-sftp end to
+end) and a NEGATIVE check that an ftp-only alias cannot open an SSH shell
+session. **Runbook note:** a tenant's first SFTP subaccount flips
+/home/<tenant> to root:tenant 0751 (M12 layout) even when the tenant never
+enabled SSH — top-level $HOME becomes non-writable for the tenant
+(established M12 trade-off, new for this population).
+Playwright: create account → connect SFTP (sshpass loopback) → upload →
+file owned by tenant uid → FTP toggle on → FTPS login (curl
+--ftp-ssl) → cap enforcement → delete cleans system user. Box-test on
+testserver via the user-facing path (`feedback_verify_via_user_facing_path`).
+Runbook `docs/runbooks/ftp-accounts.md` (NAT/pasv, firewall, legacy
+plaintext). CLI reference golden regen if CLI verbs added
+(`feedback_cli_reference_golden`). Comment on GH #1053 (never close —
+`feedback_never_close_issues`).
+
+## Security checklist (gate for every step)
+
+- No uid-0 / non-tenant uid aliases; agent re-validates what panel sends.
+- Chroot ancestors root-owned; `sshd -t` before every reload.
+- FTPS required by default; plaintext = explicit admin opt-in with warning.
+- Passwords via chpasswd stdin only; never logged, never in DB, never in
+  list/get responses.
+- UFW passive range opened only while module enabled.
+- `/etc/jabali` stays 0755 (`feedback_etc_jabali_must_be_0755`); no
+  hardening directive removed from sshd/vsftpd units to make a feature work.
+- CrowdSec brute-force coverage from day one.
+- Home-path validation: absolute, inside tenant home, symlink-resolved
+  server-side (path traversal = cross-tenant read).
+
+## Open questions (resolve before Step 4)
+
+1. Passive-range size + default (40000–40100 proposed) and IPv6 posture.
+2. `pasv_address` auto-detect from server IP vs manual setting only.
+3. Per-account bandwidth limits — vsftpd supports; ship later unless asked.
+4. Quota display: accounts share the tenant quota (same uid) — UI copy
+   should say so.


### PR DESCRIPTION
Step 3 of 7 from `plans/gh1053-ftp-accounts.md` (GH #1053). Builds on #1094 + #1096 (merged). **SFTP half goes live with this PR.**

## What
- **Agent `ftpaccount.sshd_sync`**: renders per-account `Match User` blocks into `/etc/ssh/sshd_config.d/jabali-xfer.conf`. Subaccounts can't use M12's `Match Group jabali-sftp` (`ChrootDirectory /home/%u` → no home for an alias name), so each block chroots to the **owning tenant's** home (root-owned 0751 per M12 = passes sshd's ownership check) and starts the session at the account's `home_path` via `internal-sftp -d`. All forwarding off; password auth on (alias `authorized_keys` is unmanaged surface — stays off). Rendered from scratch, content-gated, `sshd -t` + rollback, reload only on change — same contract as `system.set_ssh_config`, reusing its atomicWrite/restore/pickSSHUnit helpers.
- **`reconcileFtpAccounts`** (hash-gated, 15-min force resync, wired into `ReconcileAll`): recreates missing aliases with an **unknowable throwaway password** (DR posture — tenant must reset via panel), repairs `jabali-ftp` membership + lock drift, removes rowless aliases (panel row = the only handle), flips tenant home to the M12 chroot layout via `ssh.user.home_chown` on first SFTP subaccount, then syncs the drop-in.

## Test plan
- [x] Renderer: determinism, full directive set, newline-injection + traversal + duplicate validation table
- [x] sshd_sync flow: write/changed, idempotent resync unchanged, empty set renders no blocks (env-gated skip of `sshd -t`/reload)
- [x] Reconciler: recreate-missing (64-hex throwaway pw), stray-delete, access-drift repair, sshd payload shape (ftp-only + disabled excluded, chroot/start-dir split), hash-gate steady-state no-op, failure keeps gate open, nil-repo no-op
- [x] `go build`/`vet`/`-race` green across both packages
- [ ] Step 4: vsftpd module (FTP half + server opt-in enforcement)

GH #1053