### PR TITLE
feat(mail): route CalDAV/CardDAV on the mail vhost so clients auto-mount calendars + contacts (GH #1039)

### DIFF
--- a/install/nginx/jabali-mail-vhost.conf.tmpl
+++ b/install/nginx/jabali-mail-vhost.conf.tmpl
@@ -80,6 +80,42 @@ server {
     proxy_set_header Accept-Encoding "";
   }
 
+  # CalDAV / CardDAV (GH #1039 follow-up). Stalwart serves the DAV
+  # collections and the RFC 6764 autodiscovery endpoints on the same
+  # loopback HTTP listener as JMAP. The _caldavs._tcp / _carddavs._tcp
+  # SRV records already point clients at mail.<domain>:443, and
+  # /.well-known/caldav|carddav 307-redirect (relative) to /dav/cal|
+  # /dav/card — so this last hop lets Thunderbird / Apple Mail discover
+  # and mount calendars + address books. Scoped to cal + card ONLY:
+  # /dav/file (WebDAV file storage) and /dav/pal (principals) are
+  # deliberately NOT exposed on the mail vhost.
+  location = /.well-known/caldav {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+  }
+  location = /.well-known/carddav {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+  }
+  location /dav/cal {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600s;
+    client_max_body_size 50m;
+  }
+  location /dav/card {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600s;
+    client_max_body_size 50m;
+  }
+
   # NOTE: /api/* is deliberately NOT proxied to Stalwart. Bulwark owns
   # every /api/* path (its own /api/auth/session, /api/health, etc.)
   # and proxies Stalwart admin calls internally via STALWART_API_URL=

--- a/panel-agent/internal/commands/webmail_vhost.go
+++ b/panel-agent/internal/commands/webmail_vhost.go
@@ -106,6 +106,44 @@ server {
     proxy_set_header Accept-Encoding "";
   }
 
+  # CalDAV / CardDAV (GH #1039 follow-up). Stalwart serves the DAV
+  # collections and the RFC 6764 autodiscovery endpoints on the same
+  # loopback HTTP listener as JMAP. The _caldavs._tcp / _carddavs._tcp
+  # SRV records already point clients at mail.<domain>:443, and
+  # /.well-known/caldav|carddav 307-redirect (relative) to /dav/cal|
+  # /dav/card — so this last hop lets Thunderbird / Apple Mail discover
+  # and mount calendars + address books. Scoped to cal + card ONLY:
+  # /dav/file (WebDAV file storage) and /dav/pal (principals) are
+  # deliberately NOT exposed on the mail vhost. The inherited sub_filter
+  # is a no-op here — sub_filter_types is application/json while DAV
+  # responses are application/xml — so it never rewrites DAV bodies.
+  location = /.well-known/caldav {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+  }
+  location = /.well-known/carddav {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+  }
+  location /dav/cal {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600s;
+    client_max_body_size 50m;
+  }
+  location /dav/card {
+    proxy_pass http://127.0.0.1:8446;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600s;
+    client_max_body_size 50m;
+  }
+
   # /api/* intentionally routes to Bulwark (catch-all /) — Bulwark owns
   # its own API endpoints (/api/auth/session, etc.) and proxies
   # Stalwart admin internally via STALWART_API_URL. Routing /api → 8446

--- a/panel-agent/internal/commands/webmail_vhost_test.go
+++ b/panel-agent/internal/commands/webmail_vhost_test.go
@@ -107,6 +107,49 @@ func TestWebmailVhostApply_WritesAndReloads(t *testing.T) {
 	}
 }
 
+// TestWebmailVhostApply_EmitsCalDAVCardDAVLocations pins the GH #1039
+// follow-up: the mail vhost must route the CalDAV/CardDAV autodiscovery
+// endpoints + collections to Stalwart (8446) so Thunderbird / Apple Mail
+// can auto-mount calendars and address books. It must NOT expose the
+// WebDAV file-storage (/dav/file) or principals (/dav/pal) namespaces.
+func TestWebmailVhostApply_EmitsCalDAVCardDAVLocations(t *testing.T) {
+	avail, _ := wireMailVhostPaths(t)
+	wireNginxReload(t)
+
+	params, _ := json.Marshal(webmailVhostApplyParams{
+		DomainName:  "example.com",
+		SSLCertPath: "/etc/letsencrypt/live/example.com/fullchain.pem",
+		SSLKeyPath:  "/etc/letsencrypt/live/example.com/privkey.pem",
+	})
+	if _, err := webmailVhostApplyHandler(context.Background(), params); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(avail, "example.com-mail.conf"))
+	if err != nil {
+		t.Fatalf("read vhost: %v", err)
+	}
+	s := string(b)
+
+	for _, want := range []string{
+		"location = /.well-known/caldav {",
+		"location = /.well-known/carddav {",
+		"location /dav/cal {",
+		"location /dav/card {",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("vhost missing DAV location %q:\n%s", want, s)
+		}
+	}
+	// Security: the file-storage and principals namespaces must NOT be
+	// proxied on the mail vhost (match the location block, not the
+	// explanatory comment that names the paths).
+	for _, forbidden := range []string{"location /dav/file", "location /dav/pal"} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("vhost must not expose %q on the mail host:\n%s", forbidden, s)
+		}
+	}
+}
+
 // TestWebmailVhostApply_IdempotentSameContent — second apply with
 // identical params must not write the file again AND must not reload
 // nginx. This is the reconciler's steady-state case, called every tick.


### PR DESCRIPTION
Follow-up to the #1039 mail-autoconfig fix. @johnnyq confirmed Thunderbird mail auto-config works and asked whether **calendars + address books** can auto-set-up the same way.

## Finding: 2 of 3 legs already existed

RFC 6764 auto-discovery needs a DAV server, DNS SRV records, and HTTP routing:

| Leg | State |
|-----|-------|
| Stalwart DAV server | **live** — 0.16.15 serves `/.well-known/caldav\|carddav` (307 → `/dav/cal\|/dav/card`) + collections on `127.0.0.1:8446`, on by default |
| DNS SRV | **live** — panel already publishes `_caldavs._tcp` / `_carddavs._tcp` → `mail.<domain>:443` (dig-verified) |
| **nginx routing** | **missing** — mail vhost proxied only `/jmap` to Stalwart; `/dav/*` + `/.well-known/caldav\|carddav` fell to Bulwark (404/308) → discovery dead-ended |

## Change

Add four `location` blocks to the mail vhost — in `panel-agent/internal/commands/webmail_vhost.go` (the renderer / source of truth) **and** `install/nginx/jabali-mail-vhost.conf.tmpl` (parity) — proxying `/.well-known/caldav`, `/.well-known/carddav`, `/dav/cal`, `/dav/card` to Stalwart's loopback listener.

**Security scoping:** cal + card **only**. The WebDAV file-storage (`/dav/file`) and principals (`/dav/pal`) namespaces are deliberately **not** exposed on the mail host (unit test asserts their absence).

No new DNS, no cert/SAN (DAV is on `mail.<domain>`, already covered), no Stalwart config. Existing mail vhosts self-heal on the next reconcile (content-diff gated) once the agent binary updates.

## Verification

- Unit: `TestWebmailVhostApply_EmitsCalDAVCardDAVLocations` asserts the four DAV locations render and `/dav/file` + `/dav/pal` do not.
- **End-to-end on a test server**, through public HTTPS with a real mailbox:
  - `GET /.well-known/caldav` → **307** `Location: /dav/cal`; `carddav` → 307 `/dav/card`
  - authenticated `PROPFIND` → **207 Multistatus** with the CalDAV collection (`<D:collection/>`, principal `/dav/pal/<user>/`); same for CardDAV
  - `/dav/cal` + `/dav/card` return `WWW-Authenticate: Basic realm="Stalwart Server"` (confirming Stalwart, not Bulwark)
  - `/dav/file/` stays **308** (Bulwark) — file storage not exposed

Thunderbird / Apple Mail follow the SRV → well-known → DAV chain, so they now discover and mount calendars + address books automatically. Outlook does not do CalDAV (EAS/EWS only) — out of scope.

GH #1039