### PR TITLE
feat(ftp): tenant self-service API + admin opt-in wiring (GH #1053 step 5)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -283,6 +283,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		sshKeyRepo := repository.NewSSHKeyRepository(sharedDB)
 		deps.SSHKeys = sshKeyRepo
 		ftpAccountRepo := repository.NewFtpAccountRepository(sharedDB)
+		deps.FtpAccounts = ftpAccountRepo
 
 		// M14 notification repos. Populated whenever sharedDB is up;
 		// the admin API (later) and dispatcher goroutine both read them

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -1,0 +1,460 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// FTP/SFTP subaccounts API (GH #1053 step 5, plans/gh1053-ftp-accounts.md).
+//
+// Tenant self-service under /me/ftp-accounts, capped by the hosting
+// package's max_ftp_accounts (0 = surface hidden, requests 403). Host
+// mutations run SYNCHRONOUSLY against the agent — create/delete talk to the
+// host first, the DB row second, and the sshd drop-in re-syncs before the
+// response returns, so a fresh account can log in immediately instead of
+// waiting a reconcile tick (step-3 review note). The reconciler remains the
+// drift healer behind this path.
+
+// FtpAccountsHandlerConfig wires the tenant + admin FTP account routes.
+type FtpAccountsHandlerConfig struct {
+	Repo            repository.FtpAccountRepository
+	Users           repository.UserRepository
+	Packages        repository.PackageRepository
+	Agent           agent.AgentInterface
+	Log             *slog.Logger
+	StrictRateLimit gin.HandlerFunc // optional — wire from rl.Strict()
+}
+
+// RegisterFtpAccountRoutes mounts:
+//   - GET    /me/ftp-accounts               list caller's accounts
+//   - POST   /me/ftp-accounts               create (cap-checked)
+//   - PATCH  /me/ftp-accounts/:id           toggle ftp/sftp/enabled
+//   - POST   /me/ftp-accounts/:id/password  reset password
+//   - DELETE /me/ftp-accounts/:id           delete account
+//   - GET    /admin/ftp-accounts            admin: list all
+func RegisterFtpAccountRoutes(g *gin.RouterGroup, cfg FtpAccountsHandlerConfig) {
+	if cfg.Repo == nil || cfg.Users == nil || cfg.Packages == nil {
+		panic("api.RegisterFtpAccountRoutes: Repo, Users, and Packages are required")
+	}
+	h := &ftpAccountsHandler{cfg: cfg}
+	strict := cfg.StrictRateLimit
+	if strict == nil {
+		strict = func(c *gin.Context) { c.Next() }
+	}
+	me := g.Group("/me/ftp-accounts")
+	me.GET("", h.list)
+	me.POST("", strict, h.create)
+	me.PATCH("/:id", h.update)
+	me.POST("/:id/password", strict, h.setPassword)
+	me.DELETE("/:id", h.delete)
+
+	admin := g.Group("/admin/ftp-accounts", middleware.RequireAdmin())
+	admin.GET("", h.adminList)
+}
+
+type ftpAccountsHandler struct{ cfg FtpAccountsHandlerConfig }
+
+// ftpLabelRE mirrors the agent's subaccount label rule — validate at the
+// panel boundary too (defense in depth; the agent re-checks).
+var ftpLabelRE = regexp.MustCompile(`^[a-z0-9][a-z0-9_]{0,19}$`)
+
+const (
+	ftpUsernameMaxLen  = 32
+	ftpPasswordMinLen  = 12
+	ftpPasswordMaxLen  = 128
+	ftpAgentTimeout    = 30 * time.Second
+	ftpHomePathBadRune = " \t\r\n\"'\\:"
+)
+
+type ftpAccountCreateRequest struct {
+	Label      string `json:"label" binding:"required"`
+	HomePath   string `json:"home_path" binding:"required"`
+	Password   string `json:"password" binding:"required"`
+	FTPAccess  bool   `json:"ftp_access"`
+	SFTPAccess *bool  `json:"sftp_access"` // default true
+}
+
+type ftpAccountUpdateRequest struct {
+	FTPAccess  *bool `json:"ftp_access"`
+	SFTPAccess *bool `json:"sftp_access"`
+	IsEnabled  *bool `json:"is_enabled"`
+}
+
+type ftpAccountPasswordRequest struct {
+	Password string `json:"password" binding:"required"`
+}
+
+// resolveTenant loads the calling user and enforces the package gate.
+// Returns (user, package, ok). Writes the error response when !ok.
+func (h *ftpAccountsHandler) resolveTenant(c *gin.Context) (*models.User, *models.HostingPackage, bool) {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+		return nil, nil, false
+	}
+	ctx := c.Request.Context()
+	u, err := h.cfg.Users.FindByID(ctx, claims.UserID)
+	if err != nil || u == nil || u.Username == nil || *u.Username == "" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "no_account", "detail": "account has no Linux user"})
+		return nil, nil, false
+	}
+	// Package-gated like tenant Docker (Gitea #511): package-less tenants
+	// are denied — a same-uid alias is privileged surface.
+	if u.PackageID == nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "ftp_accounts_require_package", "detail": "FTP/SFTP accounts require a hosting package that includes them"})
+		return nil, nil, false
+	}
+	pkg, perr := h.cfg.Packages.FindByID(ctx, *u.PackageID)
+	if perr != nil || pkg == nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": "no_package"})
+		return nil, nil, false
+	}
+	if pkg.MaxFTPAccounts == 0 {
+		c.JSON(http.StatusForbidden, gin.H{"error": "ftp_accounts_not_in_package", "detail": "your hosting package does not include FTP/SFTP accounts"})
+		return nil, nil, false
+	}
+	return u, pkg, true
+}
+
+// validateHomePath enforces the panel-side half of the home_path contract:
+// absolute, clean, safe charset, inside the tenant home. The agent
+// additionally symlink-resolves it.
+func validateHomePath(homePath, tenantHome string) error {
+	if !filepath.IsAbs(homePath) || filepath.Clean(homePath) != homePath {
+		return errors.New("home_path must be an absolute, clean path")
+	}
+	if strings.ContainsAny(homePath, ftpHomePathBadRune) {
+		return errors.New("home_path must not contain whitespace, quotes, backslashes, or colons")
+	}
+	rel, err := filepath.Rel(tenantHome, homePath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+		return fmt.Errorf("home_path must be inside your home directory (%s)", tenantHome)
+	}
+	return nil
+}
+
+func (h *ftpAccountsHandler) agentCall(ctx context.Context, method string, params map[string]any) error {
+	if h.cfg.Agent == nil {
+		return errors.New("agent unavailable")
+	}
+	callCtx, cancel := context.WithTimeout(ctx, ftpAgentTimeout)
+	defer cancel()
+	_, err := h.cfg.Agent.Call(callCtx, method, params)
+	return err
+}
+
+// syncHostAccess re-renders the sshd drop-in from the full desired set and
+// flips the tenant home to the M12 chroot layout. Called synchronously
+// after every mutation so login state matches the API response.
+func (h *ftpAccountsHandler) syncHostAccess(ctx context.Context, tenantUsername string) {
+	if h.cfg.Agent == nil {
+		return
+	}
+	if _, err := h.cfg.Agent.Call(ctx, "ssh.user.home_chown", map[string]any{
+		"username": tenantUsername, "mode": "sftp",
+	}); err != nil && h.cfg.Log != nil {
+		h.cfg.Log.Warn("ftp: home chroot flip failed (reconciler will retry)", "tenant", tenantUsername, "err", err)
+	}
+	rows, err := h.cfg.Repo.List(ctx)
+	if err != nil {
+		return
+	}
+	type syncAccount struct {
+		Username  string `json:"username"`
+		ChrootDir string `json:"chroot_dir"`
+		StartDir  string `json:"start_dir"`
+	}
+	desired := []syncAccount{}
+	nameCache := map[string]string{}
+	for _, a := range rows {
+		if !a.IsEnabled || !a.SFTPAccess {
+			continue
+		}
+		uname, ok := nameCache[a.UserID]
+		if !ok {
+			u, uerr := h.cfg.Users.FindByID(ctx, a.UserID)
+			if uerr != nil || u == nil || u.Username == nil {
+				nameCache[a.UserID] = ""
+				continue
+			}
+			uname = *u.Username
+			nameCache[a.UserID] = uname
+		}
+		if uname == "" {
+			continue
+		}
+		chroot := "/home/" + uname
+		start := "/"
+		if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			start = "/" + rel
+		}
+		desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
+	}
+	if err := h.agentCall(ctx, "ftpaccount.sshd_sync", map[string]any{"accounts": desired}); err != nil && h.cfg.Log != nil {
+		h.cfg.Log.Warn("ftp: sshd_sync failed (reconciler will retry)", "err", err)
+	}
+}
+
+func (h *ftpAccountsHandler) list(c *gin.Context) {
+	u, _, ok := h.resolveTenant(c)
+	if !ok {
+		return
+	}
+	rows, err := h.cfg.Repo.ListByUserID(c.Request.Context(), u.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rows, "total": len(rows), "page": 1, "page_size": len(rows)})
+}
+
+func (h *ftpAccountsHandler) create(c *gin.Context) {
+	u, pkg, ok := h.resolveTenant(c)
+	if !ok {
+		return
+	}
+	var req ftpAccountCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	ctx := c.Request.Context()
+	tenant := *u.Username
+
+	if !ftpLabelRE.MatchString(req.Label) {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_label", "detail": "label must be lowercase letters, digits, or underscores (max 20 chars)"})
+		return
+	}
+	username := tenant + "_" + req.Label
+	if len(username) > ftpUsernameMaxLen {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "label_too_long", "detail": fmt.Sprintf("full account name %q exceeds %d characters", username, ftpUsernameMaxLen)})
+		return
+	}
+	if len(req.Password) < ftpPasswordMinLen || len(req.Password) > ftpPasswordMaxLen {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "weak_password", "detail": fmt.Sprintf("password must be %d-%d characters", ftpPasswordMinLen, ftpPasswordMaxLen)})
+		return
+	}
+	tenantHome := "/home/" + tenant
+	if err := validateHomePath(req.HomePath, tenantHome); err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_home_path", "detail": err.Error()})
+		return
+	}
+	count, err := h.cfg.Repo.CountByUserID(ctx, u.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "quota_check_failed"})
+		return
+	}
+	if count >= int64(pkg.MaxFTPAccounts) {
+		c.JSON(http.StatusConflict, gin.H{"error": "ftp_account_quota_exceeded", "detail": "you have reached your FTP/SFTP account limit"})
+		return
+	}
+
+	sftpAccess := true
+	if req.SFTPAccess != nil {
+		sftpAccess = *req.SFTPAccess
+	}
+
+	// Host first, row second: a row without a host user is a broken
+	// credential; a host user without a row is swept by the reconciler.
+	if err := h.agentCall(ctx, "ftpaccount.create", map[string]any{
+		"tenant_username": tenant,
+		"username":        username,
+		"home_path":       req.HomePath,
+		"password":        req.Password,
+		"ftp_access":      req.FTPAccess,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "create_failed")
+		c.JSON(status, payload)
+		return
+	}
+
+	now := time.Now().UTC()
+	acct := &models.FtpAccount{
+		ID:         ids.NewULID(),
+		UserID:     u.ID,
+		Username:   username,
+		HomePath:   req.HomePath,
+		FTPAccess:  req.FTPAccess,
+		SFTPAccess: sftpAccess,
+		IsEnabled:  true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := h.cfg.Repo.Create(ctx, acct); err != nil {
+		// Compensate: remove the host alias so no unaccounted access
+		// survives a DB failure.
+		_ = h.agentCall(ctx, "ftpaccount.delete", map[string]any{
+			"tenant_username": tenant, "username": username,
+		})
+		if errors.Is(err, repository.ErrConflict) {
+			c.JSON(http.StatusConflict, gin.H{"error": "account_exists"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	h.syncHostAccess(ctx, tenant)
+	c.JSON(http.StatusCreated, acct)
+}
+
+func (h *ftpAccountsHandler) update(c *gin.Context) {
+	u, _, ok := h.resolveTenant(c)
+	if !ok {
+		return
+	}
+	var req ftpAccountUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	ctx := c.Request.Context()
+	acct, err := h.cfg.Repo.FindByIDAndUserID(ctx, c.Param("id"), u.ID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if req.FTPAccess != nil {
+		acct.FTPAccess = *req.FTPAccess
+	}
+	if req.SFTPAccess != nil {
+		acct.SFTPAccess = *req.SFTPAccess
+	}
+	if req.IsEnabled != nil {
+		acct.IsEnabled = *req.IsEnabled
+	}
+	if err := h.agentCall(ctx, "ftpaccount.set_access", map[string]any{
+		"tenant_username": *u.Username,
+		"username":        acct.Username,
+		"ftp_access":      acct.FTPAccess,
+		"enabled":         acct.IsEnabled,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "update_failed")
+		c.JSON(status, payload)
+		return
+	}
+	acct.UpdatedAt = time.Now().UTC()
+	if err := h.cfg.Repo.Update(ctx, acct); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	h.syncHostAccess(ctx, *u.Username)
+	c.JSON(http.StatusOK, acct)
+}
+
+func (h *ftpAccountsHandler) setPassword(c *gin.Context) {
+	u, _, ok := h.resolveTenant(c)
+	if !ok {
+		return
+	}
+	var req ftpAccountPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	if len(req.Password) < ftpPasswordMinLen || len(req.Password) > ftpPasswordMaxLen {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "weak_password", "detail": fmt.Sprintf("password must be %d-%d characters", ftpPasswordMinLen, ftpPasswordMaxLen)})
+		return
+	}
+	ctx := c.Request.Context()
+	acct, err := h.cfg.Repo.FindByIDAndUserID(ctx, c.Param("id"), u.ID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if err := h.agentCall(ctx, "ftpaccount.set_password", map[string]any{
+		"tenant_username": *u.Username,
+		"username":        acct.Username,
+		"password":        req.Password,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "password_reset_failed")
+		c.JSON(status, payload)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"updated": true})
+}
+
+func (h *ftpAccountsHandler) delete(c *gin.Context) {
+	u, _, ok := h.resolveTenant(c)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	acct, err := h.cfg.Repo.FindByIDAndUserID(ctx, c.Param("id"), u.ID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	// Host first: the row is the only handle, so it must outlive the host
+	// alias (a failed host delete keeps the row for the retry; the reverse
+	// order would strand an unaccounted host credential).
+	if err := h.agentCall(ctx, "ftpaccount.delete", map[string]any{
+		"tenant_username": *u.Username,
+		"username":        acct.Username,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "delete_failed")
+		c.JSON(status, payload)
+		return
+	}
+	if err := h.cfg.Repo.Delete(ctx, acct.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	h.syncHostAccess(ctx, *u.Username)
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
+}
+
+func (h *ftpAccountsHandler) adminList(c *gin.Context) {
+	rows, err := h.cfg.Repo.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": rows, "total": len(rows), "page": 1, "page_size": len(rows)})
+}
+
+// mapFtpAgentError translates agent failures into API responses without
+// leaking raw agent internals for the common typed cases.
+func mapFtpAgentError(err error, fallback string) (int, gin.H) {
+	var ae *agent.AgentError
+	if errors.As(err, &ae) {
+		switch ae.Code {
+		case "invalid_argument":
+			return http.StatusUnprocessableEntity, gin.H{"error": fallback, "detail": ae.Message}
+		case "already_exists":
+			return http.StatusConflict, gin.H{"error": "account_exists", "detail": ae.Message}
+		case "not_found":
+			return http.StatusNotFound, gin.H{"error": "not_found", "detail": ae.Message}
+		case "permission_denied":
+			return http.StatusForbidden, gin.H{"error": "forbidden", "detail": ae.Message}
+		}
+	}
+	return http.StatusBadGateway, gin.H{"error": fallback, "detail": "host operation failed — try again or contact the administrator"}
+}

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -1,0 +1,325 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeFtpRepo struct {
+	repository.FtpAccountRepository
+	rows      map[string]*models.FtpAccount
+	createErr error
+}
+
+func newFakeFtpRepo() *fakeFtpRepo {
+	return &fakeFtpRepo{rows: map[string]*models.FtpAccount{}}
+}
+
+func (f *fakeFtpRepo) Create(_ context.Context, a *models.FtpAccount) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	for _, r := range f.rows {
+		if r.Username == a.Username {
+			return repository.ErrConflict
+		}
+	}
+	cp := *a
+	f.rows[a.ID] = &cp
+	return nil
+}
+
+func (f *fakeFtpRepo) FindByIDAndUserID(_ context.Context, id, userID string) (*models.FtpAccount, error) {
+	if r, ok := f.rows[id]; ok && r.UserID == userID {
+		cp := *r
+		return &cp, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (f *fakeFtpRepo) ListByUserID(_ context.Context, userID string) ([]models.FtpAccount, error) {
+	out := []models.FtpAccount{}
+	for _, r := range f.rows {
+		if r.UserID == userID {
+			out = append(out, *r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeFtpRepo) List(_ context.Context) ([]models.FtpAccount, error) {
+	out := []models.FtpAccount{}
+	for _, r := range f.rows {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func (f *fakeFtpRepo) Update(_ context.Context, a *models.FtpAccount) error {
+	if r, ok := f.rows[a.ID]; ok {
+		r.FTPAccess, r.SFTPAccess, r.IsEnabled, r.HomePath = a.FTPAccess, a.SFTPAccess, a.IsEnabled, a.HomePath
+		return nil
+	}
+	return repository.ErrNotFound
+}
+
+func (f *fakeFtpRepo) Delete(_ context.Context, id string) error {
+	delete(f.rows, id)
+	return nil
+}
+
+func (f *fakeFtpRepo) CountByUserID(_ context.Context, userID string) (int64, error) {
+	var n int64
+	for _, r := range f.rows {
+		if r.UserID == userID {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// ftpMockAgent wires the happy-path agent responses.
+func ftpMockAgent() *agent.MockClient {
+	return agent.NewMockClient().
+		On("ftpaccount.create", map[string]any{"username": "x"}).
+		On("ftpaccount.delete", map[string]any{"deleted": true}).
+		On("ftpaccount.set_access", map[string]any{}).
+		On("ftpaccount.set_password", map[string]any{"updated": true}).
+		On("ftpaccount.sshd_sync", map[string]any{"changed": true}).
+		On("ssh.user.home_chown", map[string]any{})
+}
+
+func ftpTestRouter(t *testing.T, repo *fakeFtpRepo, mock *agent.MockClient, pkg *models.HostingPackage) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	uname := "shop"
+	pkgID := "pkg1"
+	users := &usersMap{m: map[string]*models.User{
+		"u1": {ID: "u1", Username: &uname, PackageID: &pkgID},
+	}}
+	h := &ftpAccountsHandler{cfg: FtpAccountsHandlerConfig{
+		Repo:     repo,
+		Users:    users,
+		Packages: &fakePkgRepo{pkg: pkg},
+		Agent:    mock,
+	}}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1", IsAdmin: false})
+		c.Next()
+	})
+	r.GET("/me/ftp-accounts", h.list)
+	r.POST("/me/ftp-accounts", h.create)
+	r.PATCH("/me/ftp-accounts/:id", h.update)
+	r.POST("/me/ftp-accounts/:id/password", h.setPassword)
+	r.DELETE("/me/ftp-accounts/:id", h.delete)
+	return r
+}
+
+func ftpPkg(maxAccounts uint32) *models.HostingPackage {
+	return &models.HostingPackage{ID: "pkg1", Name: "test", MaxFTPAccounts: maxAccounts}
+}
+
+func mockCalled(mock *agent.MockClient, command string) int {
+	n := 0
+	for _, call := range mock.Calls() {
+		if call.Command == command {
+			n++
+		}
+	}
+	return n
+}
+
+func TestFtpAPICreate_HappyPath(t *testing.T) {
+	repo := newFakeFtpRepo()
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1","ftp_access":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(repo.rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(repo.rows))
+	}
+	for _, row := range repo.rows {
+		if row.Username != "shop_deploy" || !row.FTPAccess || !row.SFTPAccess || !row.IsEnabled {
+			t.Fatalf("row wrong: %+v", row)
+		}
+	}
+	// Host mutations ran synchronously: create + chroot flip + sshd sync.
+	for _, cmd := range []string{"ftpaccount.create", "ssh.user.home_chown", "ftpaccount.sshd_sync"} {
+		if mockCalled(mock, cmd) != 1 {
+			t.Fatalf("expected exactly one %s call", cmd)
+		}
+	}
+	// The response must never echo the password.
+	if contains(rec.Body.String(), "longenough-pass1") {
+		t.Fatal("password echoed in response")
+	}
+}
+
+func TestFtpAPICreate_CapExceeded(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "u1", Username: "shop_x"}
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(1))
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+	if mockCalled(mock, "ftpaccount.create") != 0 {
+		t.Fatal("agent must not be called when over cap")
+	}
+}
+
+func TestFtpAPICreate_NotInPackage(t *testing.T) {
+	r := ftpTestRouter(t, newFakeFtpRepo(), ftpMockAgent(), ftpPkg(0))
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestFtpAPICreate_Validation(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"bad label", `{"label":"Bad Label","home_path":"/home/shop/site","password":"longenough-pass1"}`},
+		{"home outside tenant", `{"label":"deploy","home_path":"/etc","password":"longenough-pass1"}`},
+		{"home traversal", `{"label":"deploy","home_path":"/home/shop/../other","password":"longenough-pass1"}`},
+		{"home with space", `{"label":"deploy","home_path":"/home/shop/my site","password":"longenough-pass1"}`},
+		{"short password", `{"label":"deploy","home_path":"/home/shop/site","password":"short"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := ftpMockAgent()
+			r := ftpTestRouter(t, newFakeFtpRepo(), mock, ftpPkg(3))
+			rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts", tc.body)
+			if rec.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("expected 422, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if mockCalled(mock, "ftpaccount.create") != 0 {
+				t.Fatal("agent must not be called on validation failure")
+			}
+		})
+	}
+}
+
+func TestFtpAPICreate_AgentFailureNoRow(t *testing.T) {
+	repo := newFakeFtpRepo()
+	mock := ftpMockAgent().OnError("ftpaccount.create",
+		&agent.AgentError{Code: "permission_denied", Message: "nope"})
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 from mapped agent error, got %d", rec.Code)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatal("no row may exist after a failed host create")
+	}
+}
+
+func TestFtpAPICreate_RowFailureCompensatesHost(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.createErr = repository.ErrConflict
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rec.Code)
+	}
+	// The host alias must be torn back down when the row write fails.
+	if mockCalled(mock, "ftpaccount.delete") != 1 {
+		t.Fatal("expected compensating ftpaccount.delete")
+	}
+}
+
+func TestFtpAPIDelete_HostFirstRowKeptOnFailure(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "u1", Username: "shop_deploy"}
+	mock := ftpMockAgent().OnError("ftpaccount.delete",
+		&agent.AgentError{Code: "internal", Message: "boom"})
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodDelete, "/me/ftp-accounts/a1", "")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", rec.Code)
+	}
+	if _, ok := repo.rows["a1"]; !ok {
+		t.Fatal("row must be KEPT when the host delete fails — it is the only handle")
+	}
+}
+
+func TestFtpAPIDelete_Success(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "u1", Username: "shop_deploy"}
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodDelete, "/me/ftp-accounts/a1", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatal("row must be deleted")
+	}
+}
+
+func TestFtpAPIUpdate_TogglesViaAgent(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "u1", Username: "shop_deploy", SFTPAccess: true, IsEnabled: true}
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPatch, "/me/ftp-accounts/a1", `{"is_enabled":false,"ftp_access":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if mockCalled(mock, "ftpaccount.set_access") != 1 {
+		t.Fatal("expected set_access agent call")
+	}
+	if repo.rows["a1"].IsEnabled || !repo.rows["a1"].FTPAccess {
+		t.Fatalf("row not updated: %+v", repo.rows["a1"])
+	}
+}
+
+func TestFtpAPIPassword_OwnershipAndLength(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "OTHER", Username: "other_x"}
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	// Not the caller's account → 404, never touches the agent.
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts/a1/password", `{"password":"longenough-pass1"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for foreign account, got %d", rec.Code)
+	}
+	if mockCalled(mock, "ftpaccount.set_password") != 0 {
+		t.Fatal("agent must not be called for a foreign account")
+	}
+
+	// Too short → 422.
+	rec = doReq(t, r, http.MethodPost, "/me/ftp-accounts/a1/password", `{"password":"short"}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d", rec.Code)
+	}
+}

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -60,7 +61,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": ""})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": "", "ftp_accounts_enabled": false, "ftp_server_enabled": false})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -71,17 +72,26 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	// Docker Apps (GH #283 — hide if not in package). A user with NO package
 	// is unrestricted (GH #282), so the server flag alone decides.
 	dockerUser := settings.DockerMarketplaceEnabled && settings.DockerAppsForUsersEnabled && tenantDockerHostReady()
-	if dockerUser && h.cfg.Users != nil && h.cfg.Packages != nil {
+	// GH #1053: FTP/SFTP subaccounts are package-gated like tenant Docker —
+	// max_ftp_accounts=0 (or no package) hides the whole surface. Resolved in
+	// the same user/package lookup below.
+	ftpAccounts := false
+	if h.cfg.Users != nil && h.cfg.Packages != nil {
 		if claims := ginctx.Claims(c); claims != nil {
 			if u, uerr := h.cfg.Users.FindByID(ctx, claims.UserID); uerr == nil && u != nil {
+				var pkg *models.HostingPackage
+				if u.PackageID != nil {
+					if p, perr := h.cfg.Packages.FindByID(ctx, *u.PackageID); perr == nil {
+						pkg = p
+					}
+				}
 				// Tenant Docker requires a package that includes it (Gitea #511):
 				// a package-less tenant is denied at install, so don't advertise
 				// the capability either (keeps the nav honest).
-				if u.PackageID == nil {
-					dockerUser = false
-				} else if pkg, perr := h.cfg.Packages.FindByID(ctx, *u.PackageID); perr != nil || pkg == nil || pkg.MaxDockerApps == 0 {
+				if pkg == nil || pkg.MaxDockerApps == 0 {
 					dockerUser = false
 				}
+				ftpAccounts = pkg != nil && pkg.MaxFTPAccounts > 0 && u.Username != nil && *u.Username != ""
 			}
 		}
 	}
@@ -112,6 +122,12 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		// mutations (middleware.StandbyReadOnly), so the banner explains why.
 		"is_standby":    settings.IsStandby(),
 		"dr_peer_label": settings.DRPeerLabel,
+		// GH #1053: ftp_accounts_enabled gates the tenant FTP Accounts page
+		// (package max_ftp_accounts > 0 + a Linux account). ftp_server_enabled
+		// mirrors the server-level opt-in so the UI can say "SFTP only"
+		// versus "FTPS + SFTP" in connection info.
+		"ftp_accounts_enabled": ftpAccounts,
+		"ftp_server_enabled":   settings.FTPEnabled,
 	})
 }
 

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4790,6 +4790,49 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "204": { description: OK } }
 
+  # --- Ftp Accounts (GH #1053) ---
+
+  /me/ftp-accounts:
+    get:
+      tags: [Ftp Accounts]
+      summary: List the caller's FTP/SFTP subaccounts
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    post:
+      tags: [Ftp Accounts]
+      summary: Create an FTP/SFTP subaccount (package cap-checked)
+      security: [ { KratosSession: [] } ]
+      responses: { "201": { description: Created } }
+
+  /me/ftp-accounts/{id}:
+    patch:
+      tags: [Ftp Accounts]
+      summary: Toggle ftp/sftp/enabled on a subaccount
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+    delete:
+      tags: [Ftp Accounts]
+      summary: Delete a subaccount (host alias first, row second)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
+  /me/ftp-accounts/{id}/password:
+    post:
+      tags: [Ftp Accounts]
+      summary: Reset a subaccount password
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
+  /admin/ftp-accounts:
+    get:
+      tags: [Ftp Accounts]
+      summary: Admin list of every FTP/SFTP subaccount
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Ssl (auto) ---
 

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -145,13 +145,19 @@ type updateServerSettingsRequest struct {
 	WebmailEnabled            *bool                       `json:"webmail_enabled,omitempty"`
 	// M353 Phase 1 (GH #353): per-module enable flags (admin toggles them from
 	// Server Settings -> Modules; the SPA gates nav + routes on them).
-	DNSEnabled                 *bool `json:"dns_enabled,omitempty"`
-	MailEnabled                *bool `json:"mail_enabled,omitempty"`
-	SecurityEnabled            *bool `json:"security_enabled,omitempty"`
-	QuotaEnabled               *bool `json:"quota_enabled,omitempty"`
-	APIEnabled                 *bool `json:"api_enabled,omitempty"`
-	TenantDomainOptionsEnabled *bool `json:"tenant_domain_options_enabled,omitempty"`
-	TenantDocrootEditable      *bool `json:"tenant_docroot_editable,omitempty"`
+	DNSEnabled      *bool `json:"dns_enabled,omitempty"`
+	MailEnabled     *bool `json:"mail_enabled,omitempty"`
+	SecurityEnabled *bool `json:"security_enabled,omitempty"`
+	QuotaEnabled    *bool `json:"quota_enabled,omitempty"`
+	APIEnabled      *bool `json:"api_enabled,omitempty"`
+	// GH #1053: FTP module opt-in (default OFF). ftp_allow_plaintext is a
+	// second explicit gate — TLS stays required without it. ftp_pasv_address
+	// is the NAT passive-mode address vsftpd advertises.
+	FTPEnabled                 *bool   `json:"ftp_enabled,omitempty"`
+	FTPAllowPlaintext          *bool   `json:"ftp_allow_plaintext,omitempty"`
+	FTPPasvAddress             *string `json:"ftp_pasv_address,omitempty"`
+	TenantDomainOptionsEnabled *bool   `json:"tenant_domain_options_enabled,omitempty"`
+	TenantDocrootEditable      *bool   `json:"tenant_docroot_editable,omitempty"`
 	// GH #860: opt-in branded page on the default catch-all for unknown
 	// hosts (default off = keep the 444 drop).
 	UnconfiguredPageEnabled *bool `json:"unconfigured_page_enabled,omitempty"`
@@ -295,6 +301,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	prevMailEnabled := current.MailEnabled
 	prevQuotaEnabled := current.QuotaEnabled
 	prevSecurityEnabled := current.SecurityEnabled
+	prevFTPEnabled := current.FTPEnabled
+	prevFTPAllowPlaintext := current.FTPAllowPlaintext
+	prevFTPPasvAddress := current.FTPPasvAddress
 	prevPanelBrandText := current.PanelBrandText
 	prevDockerEnabled := current.DockerMarketplaceEnabled
 	prevDockerForUsers := current.DockerAppsForUsersEnabled
@@ -525,6 +534,21 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.APIEnabled != nil {
 		current.APIEnabled = *req.APIEnabled
+	}
+	if req.FTPEnabled != nil {
+		current.FTPEnabled = *req.FTPEnabled
+	}
+	if req.FTPAllowPlaintext != nil {
+		current.FTPAllowPlaintext = *req.FTPAllowPlaintext
+	}
+	if req.FTPPasvAddress != nil {
+		addr := strings.TrimSpace(*req.FTPPasvAddress)
+		// Lands in a root-rendered config file: hostname/IP charset only.
+		if addr != "" && !hostnameRE.MatchString(addr) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "validation_failed", "detail": "ftp_pasv_address must be a hostname or IP address"})
+			return
+		}
+		current.FTPPasvAddress = addr
 	}
 	if req.TenantDomainOptionsEnabled != nil {
 		current.TenantDomainOptionsEnabled = *req.TenantDomainOptionsEnabled
@@ -779,6 +803,7 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 			{"mail", prevMailEnabled, current.MailEnabled},
 			{"quota", prevQuotaEnabled, current.QuotaEnabled},
 			{"security", prevSecurityEnabled, current.SecurityEnabled},
+			{"ftp", prevFTPEnabled, current.FTPEnabled},
 		} {
 			switch {
 			case m.current && !m.prev:
@@ -786,6 +811,14 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 			case !m.current && m.prev:
 				h.dispatchModuleDisable(m.key)
 			}
+		}
+		// GH #1053: vsftpd.conf is rendered from ftp_allow_plaintext +
+		// ftp_pasv_address at module-install time. When either changes while
+		// the module stays enabled, re-dispatch the (idempotent) install so
+		// the config re-renders and vsftpd restarts with the new values.
+		if current.FTPEnabled && prevFTPEnabled &&
+			(current.FTPAllowPlaintext != prevFTPAllowPlaintext || current.FTPPasvAddress != prevFTPPasvAddress) {
+			h.dispatchModuleInstall("ftp")
 		}
 	}
 

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -113,6 +113,8 @@ type Deps struct {
 	DockerCatalog  *dockerapp.Catalog
 	PyFrameworks   *pyframeworks.Catalog
 	SSHKeys        repository.SSHKeyRepository
+	// FtpAccounts backs the tenant FTP/SFTP subaccount routes (GH #1053).
+	FtpAccounts    repository.FtpAccountRepository
 	LimitOverrides repository.UserLimitOverrideRepository
 	// M6.5 email feature repositories. Autoresponders/Forwarders/MailboxShares
 	// reconcile jabali intent → Stalwart via the phase registry (ADR-0051).
@@ -1342,6 +1344,19 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				SSHKeys:    deps.SSHKeys,
 				Reconciler: deps.Reconciler,
 				Logger:     deps.Log,
+			})
+		}
+
+		// FTP/SFTP subaccount routes (GH #1053). Agent optional at wire
+		// time: handlers fail closed per-request when it is nil.
+		if deps.FtpAccounts != nil && deps.Users != nil && deps.Packages != nil {
+			api.RegisterFtpAccountRoutes(v1, api.FtpAccountsHandlerConfig{
+				Repo:            deps.FtpAccounts,
+				Users:           deps.Users,
+				Packages:        deps.Packages,
+				Agent:           deps.Agent,
+				Log:             deps.Log,
+				StrictRateLimit: rl.Strict(),
 			})
 		}
 

--- a/panel-api/internal/app/openapi_coverage_test.go
+++ b/panel-api/internal/app/openapi_coverage_test.go
@@ -76,6 +76,7 @@ func fullDeps() Deps {
 		DockerApps: repository.NewDockerAppRepository(db),
 		PythonApps: repository.NewPythonAppRepository(db),
 		SSHKeys: repository.NewSSHKeyRepository(db),
+		FtpAccounts: repository.NewFtpAccountRepository(db),
 		LimitOverrides: repository.NewUserLimitOverrideRepository(db),
 		Autoresponders: repository.NewEmailAutoresponderRepository(db),
 		Forwarders: repository.NewEmailForwarderRepository(db),


### PR DESCRIPTION
Step 5 of 7 from `plans/gh1053-ftp-accounts.md` (GH #1053). Steps 1–4 merged.

## What
- **`/me/ftp-accounts`** CRUD + `/admin/ftp-accounts` list; all six routes documented in `openapi.yaml` (coverage golden updated).
- **Package-gated** (Gitea #511 posture): no Linux user / no package / `max_ftp_accounts=0` → 403; at cap → 409. `/me/server-capabilities` gains `ftp_accounts_enabled` + `ftp_server_enabled`.
- **Synchronous host mutations** (step-3 review note): agent first, row second, then `ftpaccount.sshd_sync` + `ssh.user.home_chown` before the response — fresh accounts log in immediately. Create **compensates** (host delete) on row-write failure; delete **keeps the row** when the host delete fails (panel row = only handle).
- Panel-side validation mirrors the agent: label charset, ≤32-char username, home_path confinement + safe charset, 12–128 char passwords, never echoed, strict rate limit on create/password.
- `server_settings` PATCH: `ftp_enabled` joins module install/disable dispatch; `ftp_allow_plaintext`/`ftp_pasv_address` (hostname-validated) re-dispatch the idempotent module install when changed while enabled.

## Test plan
- [x] 11 handler tests: cap, package gate, validation table (incl. traversal + space), agent-failure→no-row, row-failure→compensating host delete, host-first delete ordering, foreign-account 404, password rules, no password echo
- [x] OpenAPI coverage golden green with the six new routes
- [x] build/vet/fmt clean; api+app packages green
- [ ] Step 6 UI, Step 7 E2E + live toggle test

GH #1053