### PR TITLE
fix(security): global 1 MiB request-body cap with per-route upload exemptions (JAB-246)

### DIFF
--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -266,7 +266,11 @@ func RegisterFilesRoutes(g *gin.RouterGroup, cfg FilesHandlerConfig) {
 	grp.POST("/archive", h.archive)
 	grp.POST("/extract", h.extract)
 	grp.POST("/copy", h.copy)
-	grp.POST("/write", h.write)
+	// /write carries whole file contents (Monaco save) — exempt from the
+	// global 1 MiB JSON cap (JAB-246), bounded by the upload knob instead.
+	grp.POST("/write", filesUploadSizeLimit(func(c *gin.Context) int64 {
+		return h.resolveMaxUploadBytes(c.Request.Context())
+	}), h.write)
 	grp.POST("/upload-chunk", h.uploadChunk)
 	// Resume support — the client HEADs this before starting to see how
 	// many bytes of the upload-staging file already exist, so a reload

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -313,6 +313,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 	// after token expiry.
 	r.Use(middleware.NoCacheAPI())
 	r.Use(middleware.RequireContentType())
+	r.Use(middleware.BodyLimit(middleware.DefaultBodyLimitBytes, bodyLimitExemptRoutes))
 
 	// /info registration + the demo write-gate live behind a build tag (JAB-159):
 	// in a production build this just registers the base /info; in a `-tags demo`

--- a/panel-api/internal/app/body_limit_exempt.go
+++ b/panel-api/internal/app/body_limit_exempt.go
@@ -1,0 +1,30 @@
+// JAB-246: routes exempt from the global request-body cap.
+package app
+
+// bodyLimitExemptRoutes lists the routes that legitimately accept bodies
+// larger than middleware.DefaultBodyLimitBytes. Every entry MUST enforce
+// its own byte cap inside the route (http.MaxBytesReader, io.LimitReader,
+// or an explicit size check) — the global middleware skips them entirely,
+// and nesting a second reader would silently truncate real uploads.
+//
+// Keys are "METHOD " + the Gin route template (c.FullPath()).
+// TestBodyLimitExemptRoutes_ExistInRouteTable pins each entry to the real
+// route table so a route rename turns into a red test instead of a
+// silently re-capped upload.
+var bodyLimitExemptRoutes = map[string]struct{}{
+	// Own cap: filesUploadSizeLimit (server_settings.upload_max_size_mb).
+	"POST /api/v1/files/upload": {},
+	// Own cap: io.LimitReader against upload_max_size_mb per chunk.
+	"POST /api/v1/files/upload-chunk": {},
+	// Own cap: filesUploadSizeLimit — Monaco editor saves whole files.
+	"POST /api/v1/files/write": {},
+	// Own cap: http.MaxBytesReader against upload_max_size_mb.
+	"POST /api/v1/databases/:id/restore": {},
+	// Own cap: http.MaxBytesReader against upload_max_size_mb.
+	"POST /api/v1/admin/migrations/:id/tarball": {},
+	// Own cap: http.MaxBytesReader against MaxLogoBytes.
+	"POST /api/v1/admin/settings/branding/logo/:variant": {},
+	// Own cap: http.MaxBytesReader against speedtestMaxBytes; the handler
+	// drains and discards — buffering here would defeat the measurement.
+	"POST /api/v1/admin/speedtest/upload": {},
+}

--- a/panel-api/internal/app/body_limit_exempt_test.go
+++ b/panel-api/internal/app/body_limit_exempt_test.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/config"
+
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBodyLimitExemptRoutes_ExistInRouteTable pins every body-limit
+// exemption to the real route table (JAB-246). A typo'd or renamed route
+// template would otherwise silently fall back under the global 1 MiB cap
+// and break large uploads with no compile-time signal.
+func TestBodyLimitExemptRoutes_ExistInRouteTable(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Auth.Kratos.PublicURL = "http://127.0.0.1:4433"
+	cfg.Auth.Kratos.AdminURL = "http://127.0.0.1:4434"
+	r := NewWithDeps(cfg, fullDeps())
+	registered := make(map[string]struct{})
+	for _, ri := range r.Routes() {
+		registered[ri.Method+" "+ri.Path] = struct{}{}
+	}
+	for key := range bodyLimitExemptRoutes {
+		if _, ok := registered[key]; !ok {
+			t.Errorf("body-limit exemption %q does not match any registered route", key)
+		}
+	}
+	// Guard the key format itself — a bare path without the method prefix
+	// would never match at request time.
+	for key := range bodyLimitExemptRoutes {
+		if !strings.HasPrefix(key, "POST ") && !strings.HasPrefix(key, "PUT ") && !strings.HasPrefix(key, "PATCH ") {
+			t.Errorf("body-limit exemption %q must be keyed \"METHOD /path\"", key)
+		}
+	}
+}
+
+// TestBodyLimit_EngineWide413 proves the cap holds through the real
+// engine — before auth, so the pre-auth surface (JAB-246 impact note)
+// is covered too: an oversized body 413s without a session.
+func TestBodyLimit_EngineWide413(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Auth.Kratos.PublicURL = "http://127.0.0.1:4433"
+	cfg.Auth.Kratos.AdminURL = "http://127.0.0.1:4434"
+	r := NewWithDeps(cfg, fullDeps())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/mkdir",
+		strings.NewReader(`{"path":"`+strings.Repeat("x", 2<<20)+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized JSON through engine: got %d, want 413", w.Code)
+	}
+}

--- a/panel-api/internal/middleware/bodylimit.go
+++ b/panel-api/internal/middleware/bodylimit.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DefaultBodyLimitBytes caps request bodies on every JSON route (JAB-246).
+// The panel-facing nginx vhost allows bodies up to upload_max_size_mb
+// (10 GiB by default) because a handful of upload routes genuinely need
+// that; every other handler binds JSON straight into memory, so without
+// a pre-decode cap an authenticated tenant can force multi-gigabyte
+// allocations and OOM the panel. 1 MiB is far above any legitimate JSON
+// body the API accepts (the largest are catalog compose documents and
+// DNS zone payloads, all well under 100 KiB).
+const DefaultBodyLimitBytes int64 = 1 << 20
+
+// BodyLimit rejects request bodies larger than limit with a deterministic
+// 413 before any handler reads them. Routes in exempt (keyed as
+// "METHOD /full/route/:template") manage their own byte caps — nesting a
+// second reader here would silently truncate legitimate uploads.
+//
+// Chunked bodies carry no Content-Length, so the header check alone is
+// bypassable; the body is buffered through a LimitReader to make the cap
+// hold regardless of transfer encoding. The buffer is bounded by limit,
+// which is the same order of allocation the JSON decoder would perform —
+// the bound itself is the fix. Request bodies are never decompressed
+// anywhere in panel-api, so the cap applies to raw bytes and cannot be
+// bypassed with a compressed payload.
+func BodyLimit(limit int64, exempt map[string]struct{}) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		m := c.Request.Method
+		// Body-less methods: handlers never read these bodies, and buffering
+		// them would let a GET with a giant body waste work before the 404.
+		if m != http.MethodPost && m != http.MethodPatch && m != http.MethodPut {
+			c.Next()
+			return
+		}
+		if c.Request.Body == nil || c.Request.Body == http.NoBody {
+			c.Next()
+			return
+		}
+		if _, ok := exempt[m+" "+c.FullPath()]; ok {
+			c.Next()
+			return
+		}
+		if c.Request.ContentLength > limit {
+			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error": "request_body_too_large",
+			})
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(c.Request.Body, limit+1))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{
+				"error": "invalid_request",
+			})
+			return
+		}
+		if int64(len(body)) > limit {
+			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error": "request_body_too_large",
+			})
+			return
+		}
+		c.Request.Body = io.NopCloser(bytes.NewReader(body))
+		c.Next()
+	}
+}

--- a/panel-api/internal/middleware/bodylimit_test.go
+++ b/panel-api/internal/middleware/bodylimit_test.go
@@ -1,0 +1,111 @@
+package middleware
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func bodyLimitRouter(limit int64, exempt map[string]struct{}) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(BodyLimit(limit, exempt))
+	echo := func(c *gin.Context) {
+		b, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "read"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"n": len(b)})
+	}
+	r.POST("/small", echo)
+	r.POST("/big/:id/upload", echo)
+	r.GET("/get", echo)
+	return r
+}
+
+func TestBodyLimit_SmallBodyPasses(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/small", strings.NewReader(`{"a":1}`))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("small body: got %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestBodyLimit_DeclaredOversizedIs413(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/small", strings.NewReader(strings.Repeat("x", 200)))
+	// httptest.NewRequest sets ContentLength from the reader — the
+	// header fast-path must reject before any body read.
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("declared oversized: got %d, want 413", w.Code)
+	}
+}
+
+func TestBodyLimit_ChunkedOversizedIs413(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	// io.NopCloser hides the length: ContentLength stays -1 (chunked),
+	// so only the buffered read can catch the overrun.
+	req := httptest.NewRequest(http.MethodPost, "/small",
+		io.NopCloser(strings.NewReader(strings.Repeat("x", 200))))
+	if req.ContentLength != -1 {
+		t.Fatalf("precondition: want unknown ContentLength, got %d", req.ContentLength)
+	}
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("chunked oversized: got %d, want 413", w.Code)
+	}
+}
+
+func TestBodyLimit_ExactLimitPasses(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/small", strings.NewReader(strings.Repeat("x", 64)))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("exact-limit body: got %d, want 200", w.Code)
+	}
+}
+
+func TestBodyLimit_ExemptRouteUnlimited(t *testing.T) {
+	exempt := map[string]struct{}{"POST /big/:id/upload": {}}
+	r := bodyLimitRouter(64, exempt)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/big/7/upload", strings.NewReader(strings.Repeat("x", 500)))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("exempt route: got %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"n":500`) {
+		t.Fatalf("exempt route body truncated: %s", w.Body.String())
+	}
+}
+
+func TestBodyLimit_HandlerSeesFullBufferedBody(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/small", strings.NewReader(strings.Repeat("y", 40)))
+	r.ServeHTTP(w, req)
+	if !strings.Contains(w.Body.String(), `"n":40`) {
+		t.Fatalf("buffered body not replayed to handler: %s", w.Body.String())
+	}
+}
+
+func TestBodyLimit_GetIgnored(t *testing.T) {
+	r := bodyLimitRouter(64, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/get", strings.NewReader(strings.Repeat("x", 500)))
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET with body: got %d, want 200 (method gate)", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
JAB-246: the panel nginx vhost allows request bodies up to `upload_max_size_mb` (10 GiB default) because a handful of upload routes genuinely need it — but every JSON handler binds the body straight into memory with no pre-decode limit. An authenticated tenant (or the pre-auth surface) could POST multi-gigabyte JSON bodies and OOM the panel API.

### The fix
New `middleware.BodyLimit` runs engine-wide, ordered before auth:
- **Declared oversized** (Content-Length > 1 MiB) → deterministic **413** from the header alone, body never read.
- **Chunked/lying-length oversized** → body is buffered through a `LimitReader(cap+1)`; crossing the cap → **413**. The ≤1 MiB buffer is the same order of allocation the JSON decoder would perform — the bound itself is the fix.
- **Compressed bodies**: panel-api never decompresses request bodies (verified — no `gzip.NewReader(c.Request.Body)` anywhere), so the cap applies to raw bytes and cannot be bypassed by compression.
- GET/DELETE pass through untouched (handlers never read those bodies).

### Exemptions (each keeps its own byte cap)
| Route | Own cap |
|---|---|
| POST /files/upload | filesUploadSizeLimit (upload knob) |
| POST /files/upload-chunk | io.LimitReader per chunk |
| POST /files/write | **new** — filesUploadSizeLimit (was UNLIMITED; Monaco saves whole files) |
| POST /databases/:id/restore | MaxBytesReader (upload knob) |
| POST /admin/migrations/:id/tarball | MaxBytesReader (upload knob) |
| POST /admin/settings/branding/logo/:variant | MaxBytesReader (MaxLogoBytes) |
| POST /admin/speedtest/upload | MaxBytesReader (speedtestMaxBytes) |

The exemption list is pinned to the real route table by `TestBodyLimitExemptRoutes_ExistInRouteTable` — a route rename turns into a red test instead of a silently re-capped upload. Internal localhost routes (notifications enqueue, malware event ingest) carry single small JSON events — audited, no exemption needed.

No new routes, no migration, no settings knob — openapi.yaml and CLI golden untouched.

## Test plan
- [x] Middleware unit tests: small passes, exact-limit passes, declared oversized 413, chunked oversized 413, exempt route untruncated, buffered body replayed to handler, GET ignored
- [x] Engine-wide test: oversized JSON through the real router (pre-auth) → 413
- [x] Structural test: every exemption matches a registered route
- [x] Full panel-api suite: 56 packages ok, 0 FAIL; gofmt/vet clean; re-run post-rebase
- [ ] CI
- [ ] Post-merge on testserver: oversized JSON → 413; large file-manager upload still succeeds; Monaco save still works

JAB-246

🤖 Generated with [Claude Code](https://claude.com/claude-code)