### PR TITLE
fix(ftp): ftp_pasv_address TEXT not VARCHAR — migration 000264 hits the InnoDB row-size ceiling (GH #1053)

### DIFF
--- a/panel-api/internal/db/migrations/000264_ftp_accounts.up.sql
+++ b/panel-api/internal/db/migrations/000264_ftp_accounts.up.sql
@@ -30,10 +30,15 @@ CREATE TABLE ftp_accounts (
 -- required unless the operator deliberately allows legacy cleartext.
 -- Small typed columns on purpose: server_settings is close to InnoDB's
 -- 65535-byte row-size ceiling (see 000262).
+-- ftp_pasv_address is TEXT, not VARCHAR: server_settings already sits at
+-- InnoDB's 65535-byte in-row ceiling, and a utf8mb4 VARCHAR(64) (~258
+-- in-row bytes) fails with ERROR 1118 "Row size too large" on a real box
+-- (proven on testserver 2026-08-15). TEXT is stored off-page and costs
+-- ~12 in-row bytes, so it fits. The two TINYINTs fit as-is.
 ALTER TABLE server_settings
     ADD COLUMN ftp_enabled TINYINT(1) NOT NULL DEFAULT 0,
     ADD COLUMN ftp_allow_plaintext TINYINT(1) NOT NULL DEFAULT 0,
-    ADD COLUMN ftp_pasv_address VARCHAR(64) NOT NULL DEFAULT '';
+    ADD COLUMN ftp_pasv_address TEXT NOT NULL DEFAULT '';
 
 -- Per-package cap on tenant-created accounts. 0 = feature hidden for users
 -- on that package (tenant capabilities default OFF).

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -460,7 +460,7 @@ type ServerSettings struct {
 	// FTPPasvAddress is the external address vsftpd advertises for passive
 	// connections when the host is behind NAT. Empty = advertise the local
 	// address.
-	FTPPasvAddress string `gorm:"column:ftp_pasv_address;type:varchar(64);not null;default:''" json:"ftp_pasv_address"`
+	FTPPasvAddress string `gorm:"column:ftp_pasv_address;type:text;not null;default:''" json:"ftp_pasv_address"`
 
 	UpdatedAt time.Time `gorm:"type:datetime(6);not null"             json:"updated_at"`
 }

--- a/plans/gh1053-ftp-accounts.md
+++ b/plans/gh1053-ftp-accounts.md
@@ -120,7 +120,9 @@ ftp_accounts
   (`<tenant>_<label>`, validated `[a-z0-9_]`, total ≤ 32 chars) so accounts
   can't collide with real users or other tenants' accounts.
 - server_settings: `ftp_enabled` BOOL default 0, `ftp_allow_plaintext` BOOL
-  default 0, `ftp_pasv_address` VARCHAR(64) default ''.
+  default 0, `ftp_pasv_address` TEXT NOT NULL default '' (TEXT, not
+  VARCHAR — server_settings is at the InnoDB 65535-byte row-size ceiling;
+  a utf8mb4 VARCHAR(64) fails with ERROR 1118 on real boxes).
 - hosting_packages: `max_ftp_accounts` INT default 0.
 - GORM scars to respect: no `default:1` on bools that must accept false
   (`feedback_gorm_default1_bool_zero_value`), Select-allowlist on updates


### PR DESCRIPTION
## Summary
Migration 000264 (FTP schema, GH #1053 step 1, merged in #1094) **cannot apply on a real box**: `server_settings` already sits at InnoDB's 65535-byte in-row ceiling, and `ftp_pasv_address VARCHAR(64)` (utf8mb4 ≈ 258 in-row bytes) fails with **ERROR 1118 Row size too large**. testserver is stuck at `schema_migrations = 264, dirty=1` — every `jabali update` fails at migrations and rolls back the binary swap. Any box on the development channel would hit the same wall, and the fleet would too on the next stable promotion that includes 264.

**Fix**: `ftp_pasv_address` becomes `TEXT NOT NULL DEFAULT ''` — TEXT is stored off-page (~12 in-row bytes) and applies cleanly. Both outcomes proven empirically on testserver (VARCHAR → 1118; TEXT → applies). The two TINYINTs fit as-is. Model tag updated to match; NOT NULL (never nullable) because `install.sh` reads the column via raw `mysql -N` SELECT where NULL leaks a literal `NULL` string into vsftpd config.

**Editing the merged migration in place is safe**: no box has ever applied 000264 successfully (testserver is dirty; stable predates it), and golang-migrate does not checksum applied files.

Heads-up for the GH #1053 session (open PR #1101, step 5): 000264 and the `FTPPasvAddress` model tag changed under you — rebase before merging.

## Test plan
- [x] Exact ALTER proven on testserver MariaDB: VARCHAR variant reproduces 1118, TEXT variant applies
- [x] panel-api build + models/repository/app suites: 0 FAIL
- [ ] CI
- [ ] Post-merge: repair testserver dirty flag, `jabali update` completes, migrations land clean

GH #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)
