### PR TITLE
test(ftp): E2E + runbook + live-test fixes (GH #1053 step 7)

### DIFF
--- a/docs/runbooks/ftp-accounts.md
+++ b/docs/runbooks/ftp-accounts.md
@@ -1,0 +1,78 @@
+# FTP / SFTP accounts (GH #1053)
+
+Tenant-created file-transfer subaccounts. Each account is a second passwd
+entry sharing the owning tenant's uid (`useradd --non-unique`): its own
+username (`<tenant>_<label>`), its own password, its own start directory —
+but every file it writes is owned by the tenant, so quotas, per-user
+PHP-FPM, AppArmor, and backups behave exactly as if the tenant wrote it.
+
+- **SFTP** always works for these accounts (port 22, per-account
+  `Match User` blocks in `/etc/ssh/sshd_config.d/jabali-xfer.conf`,
+  chrooted to the tenant home, password auth only).
+- **FTPS** works only after the server-level opt-in below.
+
+## Enabling FTP (server level, default OFF)
+
+Server Settings → SSH & FTP → **Enable FTP server**. This flips
+`server_settings.ftp_enabled`, which:
+
+1. installs + starts vsftpd (module install-on-enable; also converged by
+   the reconciler if the install is interrupted),
+2. renders `/etc/vsftpd.conf` from the DB (TLS from the panel-hostname
+   cert; `force_local_logins_ssl=YES` unless the plaintext toggle is on),
+3. opens `21/tcp` and the passive range `40000:40100/tcp` in UFW,
+4. installs the CrowdSec `crowdsecurity/vsftpd` collection + acquisition.
+
+Turning it OFF stops + masks vsftpd and closes both firewall rules on the
+next `jabali update` sweep (`converge_ftp_masking`). SFTP is unaffected.
+
+Auth is PAM service `vsftpd-jabali`: only members of the `jabali-ftp`
+group (= the per-account FTPS toggle) can log in. The PAM file
+deliberately omits `pam_shells.so` — subaccounts use `/usr/sbin/nologin`.
+Do not "fix" a failing FTP login by adding nologin to `/etc/shells`; that
+widens every other pam_shells consumer.
+
+## NAT / passive mode
+
+If the box sits behind NAT, set **Passive-mode address** to the public IP
+(vsftpd's `pasv_address`). The passive port range is fixed at 40000–40100;
+if you change it in `/etc/vsftpd.conf` by hand it will be overwritten on
+the next module re-render, and the UFW rule + the
+`install/tests/test_ftp_module_optin.sh` guard both assume the shipped
+range.
+
+## Connection details (what to tell users)
+
+- SFTP: `sftp <tenant>_<label>@<panel-hostname>` port 22 (password).
+- FTPS: host `<panel-hostname>`, port 21, explicit TLS, passive mode. The
+  TLS certificate is the PANEL hostname's — clients connecting to their
+  own domain name will see a name mismatch; point them at the panel host.
+
+## Tenant home permission flip
+
+The FIRST SFTP-enabled subaccount a tenant creates flips
+`/home/<tenant>` to `root:<tenant> 0751` (the M12 chroot layout — sshd
+refuses to chroot into a non-root-owned directory). This also happens for
+tenants who never enabled SSH themselves. Consequence: the tenant cannot
+create files directly in the TOP level of their home anymore (subdirs are
+untouched). This is the established M12 trade-off, applied to a new
+population.
+
+## Disaster recovery / drift
+
+The `ftp_accounts` DB table is the truth; the reconciler re-creates
+missing passwd aliases on its tick. A recreated alias gets an UNKNOWABLE
+random password — the tenant must reset it in the panel before the
+account can log in again (deliberate: the real password only ever lived
+in `/etc/shadow`). Stray aliases with no DB row are removed.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| FTP login fails, SFTP works | Is the account's FTPS toggle on (`id <name>` shows `jabali-ftp`)? Is `ftp_enabled` on? `systemctl status vsftpd` |
+| "530 Login incorrect" for a valid password | Account disabled in the panel (`usermod -L` lock)? `passwd -S <name>` shows `L` |
+| SFTP connection resets after auth | `sshd -t`; is `/home/<tenant>` root-owned 0751? Never add a subaccount to `jabali-sftp` — its `/home/%u` chroot cannot fit an alias username |
+| Passive transfers hang | NAT without `pasv_address` set, or 40000:40100/tcp closed upstream |
+| Deleting an account fails | Should never block on running processes — the agent uses `userdel -f` (the tenant's own FPM holds the shared uid). Check the panel log for the agent error |
+| Brute-force noise | `cscli decisions list --scenario crowdsecurity/vsftpd-bf` |

--- a/install.sh
+++ b/install.sh
@@ -795,6 +795,13 @@ install_module_ftp() {
   else
     systemctl start vsftpd || _die "vsftpd start failed — check 'journalctl -u vsftpd'"
   fi
+  # `systemctl start` returning 0 is NOT proof of life: vsftpd exits
+  # status 2 in ~10ms on any unknown config directive with NO stderr, and
+  # systemd has already reported the start as successful by then (caught
+  # live: the invented ssl_tlsv1_2 option). Settle, then require active.
+  sleep 1
+  systemctl is-active --quiet vsftpd \
+    || _die "vsftpd died right after start (usually a bad /etc/vsftpd.conf directive) — check 'journalctl -u vsftpd' and 'vsftpd /etc/vsftpd.conf'"
   _ok "ftp module installed (vsftpd active, FTPS required unless ftp_allow_plaintext)"
 }
 
@@ -867,14 +874,18 @@ VSFTPDEOF
     printf 'pasv_address=%s\n' "$pasv_address" >> /etc/vsftpd.conf
   fi
   if [[ "$ssl_enable" == "YES" ]]; then
+    # Protocol floor: NO ssl_tlsv1_2/ssl_tlsv1_3 directives — Debian 13's
+    # vsftpd exits status 2 (silently) on those option names; proven live
+    # on jabalitests 2026-08-15. ssl_tlsv1/sslv2/sslv3 are the supported
+    # knobs, and OpenSSL 3's system security level already floors real
+    # negotiation at TLS 1.2.
     cat >> /etc/vsftpd.conf <<VSFTPDEOF
 ssl_enable=YES
 rsa_cert_file=${tls_cert}
 rsa_private_key_file=${tls_key}
 force_local_logins_ssl=${force_ssl}
 force_local_data_ssl=${force_ssl}
-ssl_tlsv1_2=YES
-ssl_tlsv1_3=YES
+ssl_tlsv1=YES
 ssl_sslv2=NO
 ssl_sslv3=NO
 require_ssl_reuse=NO

--- a/install/tests/test_ftp_module_optin.sh
+++ b/install/tests/test_ftp_module_optin.sh
@@ -85,6 +85,25 @@ else
   fi
 fi
 
+# --- 4b. no invented vsftpd directives (live incident 2026-08-15) ---
+# Debian's vsftpd exits status 2 with NO error output on any unknown config
+# option, and systemd reports the start as successful before the crash.
+# ssl_tlsv1_2 / ssl_tlsv1_3 looked plausible and killed the daemon on a
+# real box. Pin the ssl directive set to the empirically-verified one.
+for bad in ssl_tlsv1_2 ssl_tlsv1_3; do
+  if grep -q "^${bad}=" <<<"$cfgfn"; then
+    echo "FAIL: vsftpd config uses unsupported directive ${bad} (daemon exits 2 silently)"
+    fail=1
+  fi
+done
+grep -q '^ssl_tlsv1=YES' <<<"$cfgfn" \
+  || { echo "FAIL: expected supported ssl_tlsv1=YES directive"; fail=1; }
+# The installer must not trust systemctl start's exit code (vsftpd dies
+# post-start on config errors) — require the settle + is-active gate.
+modfn=$(awk '/^install_module_ftp\(\)/,/^}/' install.sh)
+grep -q 'systemctl is-active --quiet vsftpd' <<<"$modfn" \
+  || { echo "FAIL: install_module_ftp must verify vsftpd is ACTIVE after start"; fail=1; }
+
 # --- 5. passive range consistency (vsftpd conf vs UFW rule) ---
 pasv_min=$(grep -oE '^pasv_min_port=[0-9]+' <<<"$cfgfn" | cut -d= -f2 || true)
 pasv_max=$(grep -oE '^pasv_max_port=[0-9]+' <<<"$cfgfn" | cut -d= -f2 || true)

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -505,10 +505,81 @@ func ftpAccountListHandler(ctx context.Context, params json.RawMessage) (any, er
 	return map[string]any{"accounts": entries}, nil
 }
 
+// ---- ftpaccount.list_all ----
+
+type ftpAccountListAllEntry struct {
+	TenantUsername string `json:"tenant_username"`
+	Username       string `json:"username"`
+	HomePath       string `json:"home_path"`
+	FTPAccess      bool   `json:"ftp_access"`
+	Locked         bool   `json:"locked"`
+}
+
+// ftpAccountListAllHandler reports EVERY subaccount alias on the host in
+// one call: passwd entries named "<other-entry>_<label>" that alias that
+// other entry's uid (>= minTenantUID). The reconciler diffs this against
+// the whole ftp_accounts table, so a stray alias is caught even when its
+// tenant has zero remaining rows — a rowless alias is a working credential
+// with no panel handle, which must never survive (proven live on
+// jabalitests: a manually-deleted row left a login-able alias behind).
+func ftpAccountListAllHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	passwd, err := os.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read passwd: %v", err)}
+	}
+	type pwEntry struct {
+		uid  int
+		home string
+	}
+	byName := map[string]pwEntry{}
+	var order []string
+	for _, line := range strings.Split(string(passwd), "\n") {
+		parts := strings.Split(line, ":")
+		if len(parts) < 6 {
+			continue
+		}
+		uid, _ := strconv.Atoi(parts[2])
+		byName[parts[0]] = pwEntry{uid: uid, home: parts[5]}
+		order = append(order, parts[0])
+	}
+	entries := []ftpAccountListAllEntry{}
+	for _, name := range order {
+		i := strings.LastIndex(name, "_")
+		if i <= 0 {
+			continue
+		}
+		// Walk every "_" split point: tenant names may themselves contain
+		// underscores (user_01k…), so "a_b_c" must try tenants "a_b" and "a".
+		for j := i; j > 0; j = strings.LastIndex(name[:j], "_") {
+			tenant := name[:j]
+			te, ok := byName[tenant]
+			if !ok || te.uid < minTenantUID || te.uid != byName[name].uid || tenant == name {
+				continue
+			}
+			locked := false
+			if out, perr := exec.CommandContext(ctx, "passwd", "-S", name).Output(); perr == nil {
+				fields := strings.Fields(string(out))
+				locked = len(fields) >= 2 && fields[1] == "L"
+			}
+			isFtp, _ := isUserInGroup(ctx, name, ftpGroupName)
+			entries = append(entries, ftpAccountListAllEntry{
+				TenantUsername: tenant,
+				Username:       name,
+				HomePath:       byName[name].home,
+				FTPAccess:      isFtp,
+				Locked:         locked,
+			})
+			break
+		}
+	}
+	return map[string]any{"accounts": entries}, nil
+}
+
 func init() {
 	Default.Register("ftpaccount.create", ftpAccountCreateHandler)
 	Default.Register("ftpaccount.set_password", ftpAccountSetPasswordHandler)
 	Default.Register("ftpaccount.set_access", ftpAccountSetAccessHandler)
 	Default.Register("ftpaccount.delete", ftpAccountDeleteHandler)
 	Default.Register("ftpaccount.list", ftpAccountListHandler)
+	Default.Register("ftpaccount.list_all", ftpAccountListAllHandler)
 }

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -119,6 +119,15 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 		}
 	}
 
+	// Global stray sweep. The per-tenant diff above only sees tenants that
+	// still HAVE rows — a manual row delete (or a tenant whose last row
+	// vanished out-of-band) would leave a rowless alias that is a working
+	// credential with no panel handle (proven live on jabalitests). One
+	// ftpaccount.list_all IPC catches every alias host-wide.
+	if !r.sweepStrayFtpAliases(ctx, rows) {
+		converged = false
+	}
+
 	// Render the sshd drop-in from every enabled+sftp row (all tenants,
 	// one file). StartDir is home_path relative to the tenant home —
 	// internal-sftp resolves it inside the chroot.
@@ -149,6 +158,48 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	if converged {
 		r.ftpDispatchCache.Store("all", ftpDispatchState{Hash: fullHash, At: time.Now()})
 	}
+}
+
+// sweepStrayFtpAliases removes host subaccount aliases that no ftp_accounts
+// row accounts for, across ALL tenants — including tenants with zero
+// remaining rows, which the per-tenant diff can never see. Returns false on
+// failure so the hash gate stays open.
+func (r *Reconciler) sweepStrayFtpAliases(ctx context.Context, rows []models.FtpAccount) bool {
+	raw, err := r.agent.Call(ctx, "ftpaccount.list_all", map[string]any{})
+	if err != nil {
+		r.log.Warn("ftp: list_all failed (stray sweep skipped)", "err", err)
+		return false
+	}
+	var resp struct {
+		Accounts []struct {
+			TenantUsername string `json:"tenant_username"`
+			Username       string `json:"username"`
+		} `json:"accounts"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		r.log.Warn("ftp: list_all parse failed", "err", err)
+		return false
+	}
+	wanted := map[string]struct{}{}
+	for _, a := range rows {
+		wanted[a.Username] = struct{}{}
+	}
+	ok := true
+	for _, h := range resp.Accounts {
+		if _, want := wanted[h.Username]; want {
+			continue
+		}
+		if _, err := r.agent.Call(ctx, "ftpaccount.delete", map[string]any{
+			"tenant_username": h.TenantUsername,
+			"username":        h.Username,
+		}); err != nil {
+			r.log.Warn("ftp: stray alias removal failed", "account", h.Username, "err", err)
+			ok = false
+			continue
+		}
+		r.log.Info("ftp: removed stray subaccount with no panel row", "account", h.Username, "tenant", h.TenantUsername)
+	}
+	return ok
 }
 
 // reconcileFtpTenant diffs one tenant's desired rows against the host's
@@ -213,22 +264,9 @@ func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, acct
 			}
 		}
 	}
-	// Host aliases with no row: the row is the only handle — a rowless
-	// alias is unaccounted access and gets removed.
-	for name := range host {
-		if _, wanted := desired[name]; wanted {
-			continue
-		}
-		if _, err := r.agent.Call(ctx, "ftpaccount.delete", map[string]any{
-			"tenant_username": tenant,
-			"username":        name,
-		}); err != nil {
-			r.log.Warn("ftp: stray alias removal failed", "account", name, "err", err)
-			ok = false
-			continue
-		}
-		r.log.Info("ftp: removed stray subaccount with no panel row", "account", name, "tenant", tenant)
-	}
+	// Stray-alias removal deliberately does NOT live here: the per-tenant
+	// diff can only see tenants that still have rows. sweepStrayFtpAliases
+	// (one ftpaccount.list_all per pass) owns stray removal host-wide.
 
 	// M12 chroot precondition: sshd only chroots into a root-owned home.
 	// Tenants who never used SFTP themselves may still have a

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -52,6 +52,25 @@ func ftpCallsByMethod(a *fakeAgent) map[string][]fakeCall {
 	return out
 }
 
+// hostListAllResult adapts per-tenant entries to the list_all shape for the
+// global stray sweep (tenant hardcoded to the fixtures' "shop").
+func hostListAllResult(t *testing.T, entries []agentFtpListEntry) json.RawMessage {
+	t.Helper()
+	type allEntry struct {
+		TenantUsername string `json:"tenant_username"`
+		Username       string `json:"username"`
+	}
+	out := []allEntry{}
+	for _, e := range entries {
+		out = append(out, allEntry{TenantUsername: "shop", Username: e.Username})
+	}
+	raw, err := json.Marshal(map[string]any{"accounts": out})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
 func hostListResult(t *testing.T, entries []agentFtpListEntry) json.RawMessage {
 	t.Helper()
 	raw, err := json.Marshal(map[string]any{"accounts": entries})
@@ -63,7 +82,8 @@ func hostListResult(t *testing.T, entries []agentFtpListEntry) json.RawMessage {
 
 func TestReconcileFtpAccounts_RecreatesMissingAlias(t *testing.T) {
 	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
-		"ftpaccount.list": hostListResult(t, nil), // host has nothing
+		"ftpaccount.list":     hostListResult(t, nil), // host has nothing
+		"ftpaccount.list_all": hostListAllResult(t, nil),
 	}}
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_deploy",
@@ -103,6 +123,10 @@ func TestReconcileFtpAccounts_RemovesStrayAlias(t *testing.T) {
 			{Username: "shop_deploy", FTPAccess: false, Locked: false}, // desired
 			{Username: "shop_old", FTPAccess: true, Locked: false},     // stray
 		}),
+		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy", FTPAccess: false, Locked: false}, // desired
+			{Username: "shop_old", FTPAccess: true, Locked: false},     // stray
+		}),
 	}}
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_deploy",
@@ -130,6 +154,10 @@ func TestReconcileFtpAccounts_RepairsAccessDrift(t *testing.T) {
 			// host: ftp on + unlocked; DB wants ftp off + disabled(locked)
 			{Username: "shop_deploy", FTPAccess: true, Locked: false},
 		}),
+		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{
+			// host: ftp on + unlocked; DB wants ftp off + disabled(locked)
+			{Username: "shop_deploy", FTPAccess: true, Locked: false},
+		}),
 	}}
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_deploy",
@@ -152,6 +180,11 @@ func TestReconcileFtpAccounts_RepairsAccessDrift(t *testing.T) {
 func TestReconcileFtpAccounts_SSHDSyncPayloadShape(t *testing.T) {
 	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
 		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy"},
+			{Username: "shop_ftponly", FTPAccess: true},
+			{Username: "shop_off", Locked: true},
+		}),
+		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{
 			{Username: "shop_deploy"},
 			{Username: "shop_ftponly", FTPAccess: true},
 			{Username: "shop_off", Locked: true},
@@ -197,6 +230,9 @@ func TestReconcileFtpAccounts_HashGateSkipsSteadyState(t *testing.T) {
 		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
 			{Username: "shop_deploy"},
 		}),
+		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{
+			{Username: "shop_deploy"},
+		}),
 	}}
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_deploy",
@@ -219,7 +255,8 @@ func TestReconcileFtpAccounts_FailureKeepsGateOpen(t *testing.T) {
 	agent := &fakeAgent{
 		failMethod: "ftpaccount.sshd_sync",
 		resultByMethod: map[string]json.RawMessage{
-			"ftpaccount.list": hostListResult(t, []agentFtpListEntry{{Username: "shop_deploy"}}),
+			"ftpaccount.list":     hostListResult(t, []agentFtpListEntry{{Username: "shop_deploy"}}),
+			"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{{Username: "shop_deploy"}}),
 		},
 	}
 	rows := []models.FtpAccount{{
@@ -240,5 +277,39 @@ func TestReconcileFtpAccounts_NoRepoIsNoop(t *testing.T) {
 	r.reconcileFtpAccounts(context.Background())
 	if len(agent.calls) != 0 {
 		t.Fatal("nil repo must be a silent no-op")
+	}
+}
+
+// The live jabalitests finding: a manual row delete left the tenant with
+// ZERO rows, so the per-tenant diff never visited it and a working
+// credential survived. The global list_all sweep must remove it.
+func TestReconcileFtpAccounts_SweepsStrayForRowlessTenant(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		// Another tenant still has a row (so the pass has work at all);
+		// tenant "ghost" has an alias but NO rows anywhere.
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{{Username: "shop_deploy"}}),
+		"ftpaccount.list_all": func() json.RawMessage {
+			raw, _ := json.Marshal(map[string]any{"accounts": []map[string]any{
+				{"tenant_username": "shop", "username": "shop_deploy"},
+				{"tenant_username": "ghost", "username": "ghost_leftover"},
+			}})
+			return raw
+		}(),
+	}}
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop", SFTPAccess: true, IsEnabled: true,
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	if len(calls["ftpaccount.delete"]) != 1 {
+		t.Fatalf("expected exactly 1 stray delete, got %d", len(calls["ftpaccount.delete"]))
+	}
+	p := calls["ftpaccount.delete"][0].params.(map[string]any)
+	if p["username"] != "ghost_leftover" || p["tenant_username"] != "ghost" {
+		t.Fatalf("wrong stray deleted: %v", p)
 	}
 }

--- a/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
+++ b/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
@@ -1,0 +1,190 @@
+// GH #1053: tenant FTP/SFTP subaccounts — user page + capability gating.
+//
+// Verifies:
+//   - nav entry + route are hidden without ftp_accounts_enabled (package gate)
+//   - with the capability: list renders, create drawer submits the right body
+//     (tenant-prefixed label, home path, ftp_access), password never echoed
+//   - FTPS toggle disabled while the server module is off + SFTP-only copy
+//   - delete goes through Popconfirm and issues the DELETE
+//
+// All API calls are mocked — the real protocol path (sftp/curl logins) is
+// covered by the live box test in the step-7 runbook, not Playwright.
+import { mockApi, signIn, test, expect, user } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+type FtpAccount = {
+  id: string;
+  user_id: string;
+  username: string;
+  home_path: string;
+  ftp_access: boolean;
+  sftp_access: boolean;
+  is_enabled: boolean;
+};
+
+const seedAccount: FtpAccount = {
+  id: "01KFTPACC00000000000000001",
+  user_id: user.id,
+  username: "shop_deploy",
+  home_path: "/home/shop/example.com/public_html",
+  ftp_access: false,
+  sftp_access: true,
+  is_enabled: true,
+};
+
+async function setupFtpMocks(
+  page: Page,
+  opts: { accountsEnabled: boolean; serverEnabled: boolean; accounts?: FtpAccount[] },
+) {
+  const accounts = [...(opts.accounts ?? [])];
+  const created: Record<string, unknown>[] = [];
+  const deleted: string[] = [];
+
+  await page.route("**/api/v1/me/server-capabilities", async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        dns_enabled: true,
+        mail_enabled: true,
+        security_enabled: true,
+        quota_enabled: true,
+        api_enabled: true,
+        ftp_accounts_enabled: opts.accountsEnabled,
+        ftp_server_enabled: opts.serverEnabled,
+      }),
+    }),
+  );
+
+  await page.route("**/api/v1/me/ftp-accounts", async (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: accounts, total: accounts.length, page: 1, page_size: 50 }),
+      });
+    }
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      created.push(body);
+      const acct: FtpAccount = {
+        id: "01KFTPACC0000000000000NEW",
+        user_id: user.id,
+        username: `shop_${body.label}`,
+        home_path: String(body.home_path),
+        ftp_access: !!body.ftp_access,
+        sftp_access: body.sftp_access !== false,
+        is_enabled: true,
+      };
+      accounts.push(acct);
+      return route.fulfill({ status: 201, contentType: "application/json", body: JSON.stringify(acct) });
+    }
+    return route.continue();
+  });
+
+  await page.route("**/api/v1/me/ftp-accounts/*", async (route) => {
+    const method = route.request().method();
+    const id = route.request().url().split("/").pop()!;
+    if (method === "DELETE") {
+      deleted.push(id);
+      const i = accounts.findIndex((a) => a.id === id);
+      if (i >= 0) accounts.splice(i, 1);
+      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ deleted: true }) });
+    }
+    return route.continue();
+  });
+
+  return { created, deleted };
+}
+
+// overrideMeWithUsername must run AFTER signIn: later registrations win in
+// Playwright, and the fixture's /api/v1/me (401 until logged in) is what
+// makes the login form render. Once signed in, the page needs a /me that
+// carries the Linux username for the prefix addon + home validation.
+async function overrideMeWithUsername(page: Page) {
+  await page.route("**/api/v1/me", async (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: user.id,
+        email: user.email,
+        is_admin: false,
+        username: "shop",
+      }),
+    }),
+  );
+}
+
+test("nav + route hidden without the package capability", async ({ page }) => {
+  await mockApi(page, { session: null, users: [user] });
+  await setupFtpMocks(page, { accountsEnabled: false, serverEnabled: false });
+  await signIn(page, user);
+  await overrideMeWithUsername(page);
+
+  await expect(page.getByRole("menuitem", { name: "FTP Accounts" })).toHaveCount(0);
+
+  // Deep link redirects to the dashboard instead of rendering the page.
+  await page.goto("/jabali-panel/ftp-accounts");
+  await expect(page).not.toHaveURL(/ftp-accounts/);
+});
+
+test("list renders and SFTP-only copy shows while the server module is off", async ({ page }) => {
+  await mockApi(page, { session: null, users: [user] });
+  await setupFtpMocks(page, {
+    accountsEnabled: true,
+    serverEnabled: false,
+    accounts: [seedAccount],
+  });
+  await signIn(page, user);
+  await overrideMeWithUsername(page);
+
+  await page.goto("/jabali-panel/ftp-accounts");
+  await expect(page.getByText("shop_deploy")).toBeVisible();
+  await expect(page.getByText(/FTP is not enabled on this server/)).toBeVisible();
+});
+
+test("create drawer submits the tenant-prefixed body and never echoes the password", async ({ page }) => {
+  await mockApi(page, { session: null, users: [user] });
+  const { created } = await setupFtpMocks(page, { accountsEnabled: true, serverEnabled: true });
+  await signIn(page, user);
+  await overrideMeWithUsername(page);
+
+  await page.goto("/jabali-panel/ftp-accounts");
+  await page.getByRole("button", { name: /Add account/ }).click();
+
+  await page.getByLabel("Account name").fill("deploy");
+  const dirInput = page.getByLabel("Directory");
+  await dirInput.fill("/home/shop/example.com/public_html");
+  await page.getByLabel("Password", { exact: true }).fill("a-long-enough-password");
+  await page.getByRole("button", { name: /Add account/ }).last().click();
+
+  await expect
+    .poll(() => created.length, { message: "create POST should fire" })
+    .toBe(1);
+  expect(created[0]).toMatchObject({
+    label: "deploy",
+    home_path: "/home/shop/example.com/public_html",
+    password: "a-long-enough-password",
+  });
+  await expect(page.getByText("shop_deploy")).toBeVisible();
+});
+
+test("delete flows through Popconfirm and files-stay copy", async ({ page }) => {
+  await mockApi(page, { session: null, users: [user] });
+  const { deleted } = await setupFtpMocks(page, {
+    accountsEnabled: true,
+    serverEnabled: false,
+    accounts: [seedAccount],
+  });
+  await signIn(page, user);
+  await overrideMeWithUsername(page);
+
+  await page.goto("/jabali-panel/ftp-accounts");
+  await page.getByRole("button", { name: /Delete/ }).click();
+  await expect(page.getByText(/files stay in place/)).toBeVisible();
+  await page.getByRole("button", { name: "OK" }).click();
+
+  await expect.poll(() => deleted.length).toBe(1);
+  expect(deleted[0]).toBe(seedAccount.id);
+});


### PR DESCRIPTION
Step 7 of 7 from `plans/gh1053-ftp-accounts.md` (GH #1053). Final step.

## Playwright + runbook
- `user-ftp-accounts.spec.ts`: capability gating (nav hidden + deep-link redirect), SFTP-only copy, create-drawer body shape, Popconfirm delete — 4/4 green against built dist
- `docs/runbooks/ftp-accounts.md`: enable/disable, NAT pasv, PAM/no-pam_shells, tenant-home 0751 flip, DR password semantics, troubleshooting table

## Live-test findings (jabalitests), all fixed here
1. **`ssl_tlsv1_2`/`ssl_tlsv1_3` are not vsftpd directives** — Debian's vsftpd exits 2 in ~10ms with no output on unknown options, after `systemctl start` already returned success. Replaced with supported `ssl_tlsv1` (OpenSSL 3 floors at TLS 1.2 anyway); regression guard asserts the invented names stay absent AND the installer now gates on `is-active` post-settle.
2. **Rowless-tenant stray aliases survived** — the per-tenant diff never visits a tenant with zero rows, leaving a working credential with no panel handle (verified by logging into it). New `ftpaccount.list_all` (one IPC, passwd scan with underscore-in-tenant-name walk) + `sweepStrayFtpAliases` global diff; per-tenant stray removal removed in favor of the single owner. New test pins the exact scenario.
3. Third "finding" was a pipefail artifact in the test harness itself — product was correct.

## Live protocol matrix (passed on jabalitests, box @ b35aec2f + patched config)
sftp login lands in start dir · upload owned by tenant uid · **no shell session** (nologin + ForceCommand) · FTPS login+list · **plaintext refused** · non-member refused by PAM group gate · opt-out stops+masks vsftpd and closes 21 + 40000:40100 while **SFTP keeps working** · files survive account deletion

- [ ] Post-merge: `jabali update` on jabalitests + rerun the live script unmodified for the clean end-to-end record

GH #1053