### PR TITLE
fix(security): pin signature-base to a reviewed commit — no more mutable-master rule updates (JAB-248)

### DIFF
--- a/docs/adr/0072-malware-detection-stack.md
+++ b/docs/adr/0072-malware-detection-stack.md
@@ -432,3 +432,40 @@ before provisioning the rest. No manual SSH required.
 Accepted (this ADR retains its top-level **Accepted** status; the M33
 Tetragon decision documented above is superseded by this amendment +
 ADR-0085).
+
+## Amendment 2026-08-15 — Pin signature-base to a reviewed commit (JAB-248)
+
+### Context
+
+The stack cloned `Neo23x0/signature-base` from the mutable `master`
+branch and a daily timer hard-reset the tree to `origin/master`. Those
+rules feed a scanner configured for automatic quarantine
+(`quarantine_hits=1`) across every tenant home. An upstream compromise —
+or a single overbroad rule landing on master — would therefore reach
+mass-quarantine of legitimate tenant data on every box within a day,
+with no Jabali review in the loop (JAB-248, codex-security-audit
+2026-08-14).
+
+### Decision
+
+`install.sh` pins the rule tree to `SIGBASE_COMMIT` (a full 40-hex
+commit SHA, reviewed on bump like `LMD_VERSION`). The daily
+`jabali-signature-base-update` unit is now **self-heal only**: it
+converges the tree onto the pinned commit and never tracks a branch.
+New rules ship exclusively through a reviewed pin-bump PR followed by
+`jabali update` (which rewrites the unit with the new SHA).
+
+Guards: `scripts/check-pinned-downloads.sh` fails CI when the pinned
+commit does not exist upstream; `scripts/deps-check.sh` reports
+pin-vs-master drift in the monthly deps issue so the pin cannot rot
+silently. Rollback = revert the pin, `jabali update`.
+
+Out of scope (tracked in JAB-248): a staging/detect-only promotion
+pipeline for new rule sets and a quarantine-rate circuit breaker. The
+pin removes the unreviewed supply-chain path, which was the P1 core of
+the finding; rule-quality regressions within a reviewed pin remain
+possible and are accepted until the follow-up lands.
+
+### Status
+
+Accepted.

--- a/install.sh
+++ b/install.sh
@@ -10567,21 +10567,41 @@ YARA_EX
 
   # signature-base (Florian Roth / Neo23x0) — ~600 actively-maintained
   # YARA rules covering webshells (PHP/ASP/JSP), crimeware, exploit kits,
-  # APT samples. Pulled via git so daily-refresh is a `git pull` (no
-  # tarball churn). Active maintenance; releases tracked on the master
-  # branch.
+  # APT samples.
+  #
+  # JAB-248: PINNED to a reviewed commit, never a moving branch. These
+  # rules feed a scanner that AUTO-QUARANTINES across every tenant home
+  # (quarantine_hits=1); tracking origin/master meant an upstream
+  # compromise — or one overbroad rule — reached mass-quarantine on every
+  # box within a day, with no Jabali review in the loop. The daily
+  # refresh timer now self-heals to this same pinned commit; new rules
+  # arrive only through a reviewed pin bump here (drift is surfaced by
+  # scripts/deps-check.sh in the monthly deps issue). signature-base has
+  # no tagged releases, so the pin is a commit SHA. Pin bumps require a
+  # PR review, same as LMD_VERSION/LMD_SHA256.
+  local SIGBASE_COMMIT="e737ebd96c27a52ee99485d4d3e02e9c256d1d3a" # 2026-08-03 "fix: FPs"
   #
   # Custom YARA scanner picks up rules via the maldet 2.0.1 drop-in dir
   # at /usr/local/maldetect/sigs/custom.yara.d/. We symlink:
   #   custom.yara.d/signature-base/  → /opt/jabali/signature-base/yara/  (subset)
   #   custom.yara.d/jabali/          → /etc/jabali/yara/                  (admin uploads)
   install -d -m 0755 /opt/jabali
+  # Fetch-by-SHA (GitHub serves reachable SHAs to shallow fetches) +
+  # detached checkout: works for both fresh installs and existing hosts
+  # that previously tracked master — one idempotent path, no branch ref.
   if [[ ! -d /opt/jabali/signature-base/.git ]]; then
-    _log "cloning signature-base (Neo23x0/signature-base; ~600 YARA rules)"
-    git clone --depth=1 --quiet \
-      https://github.com/Neo23x0/signature-base.git \
-      /opt/jabali/signature-base 2>/dev/null || \
-      _warn "signature-base clone failed — will retry on next jabali-signature-base-update.timer"
+    _log "cloning signature-base (Neo23x0/signature-base; pinned ${SIGBASE_COMMIT:0:12})"
+    rm -rf /opt/jabali/signature-base
+    git init --quiet /opt/jabali/signature-base 2>/dev/null && \
+      git -C /opt/jabali/signature-base remote add origin \
+        https://github.com/Neo23x0/signature-base.git 2>/dev/null || true
+  fi
+  if [[ -d /opt/jabali/signature-base/.git ]] && \
+     [[ "$(git -C /opt/jabali/signature-base rev-parse HEAD 2>/dev/null)" != "$SIGBASE_COMMIT" ]]; then
+    ( cd /opt/jabali/signature-base && \
+      git fetch --depth=1 --quiet origin "$SIGBASE_COMMIT" && \
+      git checkout --quiet --detach FETCH_HEAD ) || \
+      _warn "signature-base pin fetch failed — will retry on next jabali-signature-base-update.timer"
   fi
   # Drop-in dir + symlinks. maldet 2.0.1 native YARA loads anything ending
   # in .yar / .yara from custom.yara.d/. Symlinks survive `maldet -u`
@@ -10914,25 +10934,33 @@ SIG_TIMER
   # ~600 webshell/crime YARA rules in sync. The repo is symlinked into
   # /usr/local/maldetect/sigs/custom.yara.d/signature-base, so a fast-
   # forward update is picked up by the inotify watcher's next scan.
-  cat >/etc/systemd/system/jabali-signature-base-update.service <<'SIGB_UNIT'
+  # JAB-248: the refresh unit is now SELF-HEAL ONLY — it converges the
+  # tree onto the pinned commit baked in at install/update time, never a
+  # branch. A moved upstream master cannot change rules on this host; new
+  # rules ship via a reviewed SIGBASE_COMMIT bump + jabali update (which
+  # rewrites this unit with the new SHA). Unquoted heredoc ON PURPOSE so
+  # ${SIGBASE_COMMIT} interpolates; every other $ must stay escaped.
+  cat >/etc/systemd/system/jabali-signature-base-update.service <<SIGB_UNIT
 [Unit]
-Description=Jabali signature-base YARA rule pack refresh (M33)
+Description=Jabali signature-base YARA rule pack refresh (M33, pinned — JAB-248)
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/libexec/jabali/net-retry signature-base -- /usr/bin/bash -c '\
-  set -e; \
-  if [[ ! -d /opt/jabali/signature-base/.git ]]; then \
-    rm -rf /opt/jabali/signature-base; \
-    git clone --depth=1 --quiet \
-      https://github.com/Neo23x0/signature-base.git \
-      /opt/jabali/signature-base; \
-  else \
-    cd /opt/jabali/signature-base && \
-    git fetch --depth=1 --quiet origin master && \
-    git reset --hard --quiet origin/master; \
+ExecStart=/usr/local/libexec/jabali/net-retry signature-base -- /usr/bin/bash -c '\\
+  set -e; \\
+  if [[ ! -d /opt/jabali/signature-base/.git ]]; then \\
+    rm -rf /opt/jabali/signature-base; \\
+    git init --quiet /opt/jabali/signature-base; \\
+    git -C /opt/jabali/signature-base remote add origin \\
+      https://github.com/Neo23x0/signature-base.git; \\
+  fi; \\
+  cd /opt/jabali/signature-base; \\
+  if [[ "\$\$(git rev-parse HEAD 2>/dev/null)" != "${SIGBASE_COMMIT}" ]]; then \\
+    git fetch --depth=1 --quiet origin ${SIGBASE_COMMIT}; \\
+    git checkout --quiet --detach FETCH_HEAD; \\
+    chmod -R a+rX /opt/jabali/signature-base; \\
   fi'
 # See the maldet unit above: guards against a hung git fetch wedging every
 # future run, without being tight enough to kill a slow clone.

--- a/scripts/check-pinned-downloads.sh
+++ b/scripts/check-pinned-downloads.sh
@@ -59,6 +59,28 @@ check_url "linux-malware $LMD_V" "https://github.com/rfxn/linux-malware-detect/a
 YX_V="$(pin 'YARAX_VERSION="[0-9.]+"')"
 check_url "yara-x $YX_V"      "https://github.com/VirusTotal/yara-x/releases/download/v${YX_V}/yara-x-v${YX_V}-x86_64-unknown-linux-gnu.tar.gz"
 
+# signature-base is pinned by commit SHA (JAB-248), not a release tag —
+# verify the pinned commit actually exists upstream so a typo'd or
+# invented SHA fails CI instead of bricking the clone on every box.
+# pin() only extracts dotted versions, so pull the 40-hex SHA directly.
+SB_C="$(grep -oE 'SIGBASE_COMMIT="[0-9a-f]{40}"' "$INSTALL" | head -1 | grep -oE '[0-9a-f]{40}')"
+_gh_commit() { # repo sha
+  local code auth=()
+  [[ -n "${GITHUB_TOKEN:-}" ]] && auth=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  code="$(curl -gsSL -o /dev/null -w '%{http_code}' "${auth[@]}" \
+    -H 'Accept: application/vnd.github+json' \
+    --retry 3 --retry-delay 3 --connect-timeout 20 \
+    "https://api.github.com/repos/$1/commits/$2" 2>/dev/null)"
+  [[ "$code" == "200" ]]
+}
+if [[ -z "$SB_C" ]]; then
+  report "signature-base" fail "SIGBASE_COMMIT not found in $INSTALL (expected a 40-hex pin — JAB-248)"
+elif _gh_commit "Neo23x0/signature-base" "$SB_C"; then
+  report "signature-base ${SB_C:0:12}" ok "Neo23x0/signature-base @ ${SB_C:0:12}"
+else
+  report "signature-base ${SB_C:0:12}" fail "commit not found upstream — typo'd or unpublished pin"
+fi
+
 SW_V="$(pin 'STALWART_VERSION="[0-9.]+"')"
 check_gh  "stalwart $SW_V"    "stalwartlabs/stalwart"    "v${SW_V}"
 

--- a/scripts/deps-check.sh
+++ b/scripts/deps-check.sh
@@ -126,6 +126,34 @@ for row in "${MANIFEST[@]}"; do
   ROWS_OUT+=("$disp|$cur|$lat|$status|$repo")
 done
 
+# signature-base (JAB-248) — rolling-master repo pinned by COMMIT SHA, not
+# a release tag, so it can't ride the MANIFEST loop. Compare the pinned
+# SHA against upstream master HEAD; drift means a reviewed pin bump is
+# due. Report-only, same as every other row.
+sigbase_cur="$(current_pin 'SIGBASE_COMMIT')"
+if [[ -n "$sigbase_cur" ]]; then
+  sigbase_lat=""
+  if command -v gh >/dev/null 2>&1; then
+    sigbase_lat="$(gh api "repos/Neo23x0/signature-base/commits/master" --jq '.sha' 2>/dev/null)"
+  fi
+  if [[ -z "$sigbase_lat" ]]; then
+    _tok="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    _auth=(); [[ -n "$_tok" ]] && _auth=(-H "Authorization: Bearer ${_tok}")
+    sigbase_lat="$(curl -fsSL "${_auth[@]}" -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/Neo23x0/signature-base/commits/master" 2>/dev/null \
+      | grep -oE '"sha"[[:space:]]*:[[:space:]]*"[0-9a-f]{40}"' | head -1 \
+      | grep -oE '[0-9a-f]{40}')"
+  fi
+  if [[ -z "$sigbase_lat" ]]; then
+    ROWS_OUT+=("signature-base|${sigbase_cur:0:12}|(fetch failed)|ok|Neo23x0/signature-base")
+  elif [[ "$sigbase_cur" == "$sigbase_lat" ]]; then
+    ROWS_OUT+=("signature-base|${sigbase_cur:0:12}|${sigbase_lat:0:12}|ok|Neo23x0/signature-base")
+  else
+    ROWS_OUT+=("signature-base|${sigbase_cur:0:12}|${sigbase_lat:0:12}|UPGRADE|Neo23x0/signature-base")
+    outdated=$((outdated+1))
+  fi
+fi
+
 # ---- go.mod --------------------------------------------------------------
 go_report() {
   command -v go >/dev/null 2>&1 || { echo "_(go not installed — skipped)_"; return; }


### PR DESCRIPTION
## Summary
JAB-248: the malware stack cloned `Neo23x0/signature-base` from mutable `master` and a daily timer hard-reset to `origin/master` — feeding YARA rules into a scanner that **auto-quarantines across every tenant home** (`quarantine_hits=1`, daily `/home` scan + opt-in realtime monitor). An upstream compromise or a single overbroad rule on master meant mass-quarantine of legitimate tenant data on every box within a day, with zero Jabali review in the loop.

### The fix
- **`SIGBASE_COMMIT` pin** in install.sh (initial pin `e737ebd9`, upstream master HEAD 2026-08-03 "fix: FPs" — exactly what testserver already runs). Clone + daily refresh both fetch-by-SHA and check out detached; the refresh unit is **self-heal only** and never tracks a branch. Existing master-tracking hosts converge on the next `jabali update` or timer fire — one idempotent path.
- **CI guard**: `check-pinned-downloads.sh` verifies the pinned commit exists upstream (typo'd/invented SHA fails the PR; negative-tested with `deadbeef…`).
- **Rot guard**: `deps-check.sh` gains a signature-base row (pinned SHA vs upstream master HEAD) so drift shows up in the monthly deps issue as an UPGRADE line — pin bumps become reviewed PRs, same as `LMD_VERSION`.
- **ADR-0072 amended** with the decision + explicit out-of-scope.

### Deliberately out of scope (stays tracked in JAB-248)
Staging/detect-only promotion pipeline and a quarantine-rate circuit breaker. The pin removes the *unreviewed supply-chain path* — the P1 core of the finding; rule-quality regressions within a reviewed pin remain possible until the follow-up lands.

### Rollback
Revert the pin, `jabali update`.

## Test plan
- [x] `bash -n` + phantom-function lint clean; all install/tests regression suites pass
- [x] SIGB_UNIT heredoc rendered and inspected: `$$` escaping correct for systemd, SHA interpolated, line continuations intact
- [x] `check-pinned-downloads.sh`: 10/10 published incl. new signature-base check; FAIL proven on invented SHA
- [x] `deps-check.sh`: signature-base row reports ok (pin == upstream HEAD)
- [ ] CI
- [ ] Post-merge on testserver: `jabali update`, timer unit re-rendered with pin, tree stays at `e737ebd9` detached

JAB-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
