### PR TITLE
feat(notifications): register the event kinds that fire but couldn't be disabled (GH #979)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -104,6 +104,21 @@ var tenantRelevantEventKinds = map[string]bool{
 	"snuffleupagus.incident.detected":     true,
 	"notifications.channel.auto_disabled": true,
 	"panel.welcome":                       true,
+	// GH #979: the rest of the tenant-facing kinds publishers already fire for a
+	// tenant's own resources (domains, mail reputation, Docker apps). Admin/server
+	// kinds (aide.tamper, malware, egress, db.admin.*, automation.*, update.*)
+	// stay out of the tenant catalog on purpose.
+	"domain.ghost_detected.mismatch":  true,
+	"domain.ghost_detected.nxdomain":  true,
+	"domain.ghost_detected.partial":   true,
+	"mail.rbl.listed":                 true,
+	"mail.rbl.cleared":                true,
+	"mail.dmarc.report_received":      true,
+	"mail.tls.report_received":        true,
+	"mail.feedback.received":          true,
+	"docker_app.entitlement_stopped":  true,
+	"docker_app.disk_quota_stopped":   true,
+	"docker_app.removed_from_package": true,
 }
 
 // Per-user anti-abuse limits (JAB-171 phase 4c). Consts, not admin-configurable

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -257,6 +257,221 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		Severity:    "info",
 		DefaultOn:   false,
 	},
+	// GH #979: expose the remaining kinds that publishers already fire but that
+	// were never listed here, so the admin Notifications → Events tab can toggle
+	// them (an unlisted kind falls back to always-on and cannot be silenced).
+	// Policy: actionable/security events default ON, purely informational
+	// confirmations default OFF (matches the info=off convention above).
+	// `notifications.broadcast` and `notifications.channel.test` are deliberately
+	// NOT here — a broadcast must always deliver and a channel test only fires on
+	// an explicit click, so both stay always-on.
+	{
+		Kind:        "update.completed",
+		Label:       "Panel update applied",
+		Description: "The panel finished updating to a new release. Informational; noisy on the development channel.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "aide.tamper.detected",
+		Label:       "File integrity tamper",
+		Description: "AIDE detected an unexpected change to a monitored system file. Security-relevant — investigate.",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "nginx.config.invalid",
+		Label:       "nginx config invalid",
+		Description: "A rendered nginx configuration failed validation and was not applied. Action required.",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "malware.realtime.critical",
+		Label:       "Malware — critical detection",
+		Description: "The real-time scanner flagged a high-confidence malicious file. Security-relevant — investigate.",
+		Severity:    "critical",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "malware.quarantine.added",
+		Label:       "Malware quarantined",
+		Description: "A file was quarantined by the malware scanner. Security-relevant.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "egress.drop.burst",
+		Label:       "Outbound traffic blocked (burst)",
+		Description: "A burst of outbound connections was dropped by the egress firewall. Possible compromise or misconfiguration.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "exec.audit.burst",
+		Label:       "Suspicious process burst",
+		Description: "The exec-audit source saw a burst of flagged process executions. Security-relevant.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "domain.ghost_detected.mismatch",
+		Label:       "Ghosted domain — IP mismatch",
+		Description: "The domain resolves to a different IP than this server. Expected behind a proxy/CDN such as Cloudflare — disable if you front domains that way.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "domain.ghost_detected.nxdomain",
+		Label:       "Ghosted domain — does not resolve",
+		Description: "The domain does not resolve in public DNS. It may be newly added or its DNS is not yet live.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "domain.ghost_detected.partial",
+		Label:       "Ghosted domain — partial DNS",
+		Description: "Only some of the domain's expected records point here. DNS may be mid-propagation or misconfigured.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "mail.rbl.listed",
+		Label:       "Mail IP blocklisted (RBL)",
+		Description: "The server's sending IP was found on a DNS blocklist. Outbound mail may be rejected — action required.",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "mail.rbl.cleared",
+		Label:       "Mail IP delisted (RBL)",
+		Description: "The server's sending IP is no longer on a previously-seen blocklist. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "mail.dmarc.report_received",
+		Label:       "DMARC aggregate report received",
+		Description: "An aggregate DMARC (RUA) report arrived for one of your domains. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "mail.tls.report_received",
+		Label:       "SMTP TLS report received",
+		Description: "An SMTP TLS-RPT report arrived for one of your domains. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "mail.feedback.received",
+		Label:       "Mail feedback-loop report",
+		Description: "A feedback-loop / abuse report was received about outbound mail. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "docker_app.entitlement_stopped",
+		Label:       "Docker app stopped — entitlement",
+		Description: "A tenant Docker app was stopped because its plan no longer entitles it. Action may be required.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "docker_app.disk_quota_stopped",
+		Label:       "Docker app stopped — disk quota",
+		Description: "A tenant Docker app was stopped after exceeding its disk quota. Action may be required.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "docker_app.removed_from_package",
+		Label:       "Docker app removed from package",
+		Description: "A Docker app was removed because it is no longer part of the tenant's package.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "db.admin.config_apply_failed_unrecoverable",
+		Label:       "Database config rejected",
+		Description: "A database configuration change failed to apply and could not be recovered. Action required.",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "db.admin.config_applied",
+		Label:       "Database settings updated",
+		Description: "A database configuration change was applied successfully. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "db.admin.maintenance_finished",
+		Label:       "Database maintenance finished",
+		Description: "A scheduled database maintenance run completed. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "db.admin.root_password_rotated",
+		Label:       "Database root password rotated",
+		Description: "The managed database root/admin password was rotated. Informational confirmation.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	// GH #979: Automation API write events. Headless provisioning fires one of
+	// these per user/domain mutation, so they get noisy at scale — expose them
+	// as toggles. Confirmations default OFF; the destructive ones (delete,
+	// suspend) default ON. Severities match what notifyWrite stamps.
+	{
+		Kind:        "automation.user.created",
+		Label:       "Automation — user created",
+		Description: "The Automation API created a user. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "automation.user.deleted",
+		Label:       "Automation — user deleted",
+		Description: "The Automation API deleted a user. Significant — on by default.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "automation.user.disabled",
+		Label:       "Automation — user disabled",
+		Description: "The Automation API disabled (suspended) a user.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "automation.user.enabled",
+		Label:       "Automation — user enabled",
+		Description: "The Automation API re-enabled a user. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "automation.domain.created",
+		Label:       "Automation — domain created",
+		Description: "The Automation API created a domain. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
+		Kind:        "automation.domain.suspended",
+		Label:       "Automation — domain suspended",
+		Description: "The Automation API suspended a domain. Significant — on by default.",
+		Severity:    "warning",
+		DefaultOn:   true,
+	},
+	{
+		Kind:        "automation.domain.unsuspended",
+		Label:       "Automation — domain unsuspended",
+		Description: "The Automation API unsuspended a domain. Informational.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
 }
 
 // LookupNotificationEventKind returns the metadata for a known kind

--- a/panel-api/internal/models/notification_event_setting_test.go
+++ b/panel-api/internal/models/notification_event_setting_test.go
@@ -1,0 +1,85 @@
+package models
+
+import "testing"
+
+// validEventSeverities mirrors the documented Severity domain on
+// NotificationEventKindMeta.
+var validEventSeverities = map[string]bool{
+	"info": true, "warning": true, "error": true, "critical": true,
+}
+
+// TestAllNotificationEventKinds_WellFormed guards the registry: unique kinds,
+// every kind carries a label + description, and a valid severity. A malformed
+// entry would render a broken row in the admin Notifications → Events tab.
+func TestAllNotificationEventKinds_WellFormed(t *testing.T) {
+	seen := make(map[string]bool, len(AllNotificationEventKinds))
+	for _, m := range AllNotificationEventKinds {
+		if m.Kind == "" {
+			t.Errorf("event kind with empty Kind: %+v", m)
+			continue
+		}
+		if seen[m.Kind] {
+			t.Errorf("duplicate event kind %q", m.Kind)
+		}
+		seen[m.Kind] = true
+		if m.Label == "" {
+			t.Errorf("%q: empty Label", m.Kind)
+		}
+		if m.Description == "" {
+			t.Errorf("%q: empty Description", m.Kind)
+		}
+		if !validEventSeverities[m.Severity] {
+			t.Errorf("%q: invalid Severity %q", m.Kind, m.Severity)
+		}
+		if LookupNotificationEventKind(m.Kind) == nil {
+			t.Errorf("%q: not found via LookupNotificationEventKind", m.Kind)
+		}
+	}
+}
+
+// TestNotificationEventKinds_EmittedKindsAreRegistered pins GH #979: the kinds
+// publishers actually fire MUST appear in AllNotificationEventKinds, otherwise
+// they never surface in the Events tab and can't be silenced (an unlisted kind
+// falls back to always-on). `emitted` is the hand-maintained inventory of kinds
+// fired across the codebase (non-test), gathered by auditing every EventKind
+// literal, shouldFire() arg, and notify/publish helper. NOTE: this catches
+// REMOVING a listed kind from the registry, not a brand-new unregistered
+// emitter — keep this list in sync when you wire a new publisher.
+//
+// Deliberately EXCLUDED (must stay always-on, never user-toggleable):
+//   - notifications.broadcast   — admin broadcast, must always deliver
+//   - notifications.channel.test — fires only on an explicit "send test" click
+func TestNotificationEventKinds_EmittedKindsAreRegistered(t *testing.T) {
+	emitted := []string{
+		// pre-existing (sanity — these were already registered)
+		"admin.login", "ssh.login", "backup.fail", "backup.limit.reached",
+		"cert.renew.fail", "cert.renew.ok", "crowdsec.ban.spike", "digest.daily",
+		"disk.quota.warn", "docker_app.update_available", "load.high",
+		"security.decision.fired", "security.root_terminal.opened", "service.down",
+		"snuffleupagus.incident.detected", "system.update.available",
+		"notifications.channel.auto_disabled",
+		// GH #979 additions
+		"update.completed", "aide.tamper.detected", "nginx.config.invalid",
+		"malware.realtime.critical", "malware.quarantine.added",
+		"egress.drop.burst", "exec.audit.burst",
+		"domain.ghost_detected.mismatch", "domain.ghost_detected.nxdomain",
+		"domain.ghost_detected.partial",
+		"mail.rbl.listed", "mail.rbl.cleared", "mail.dmarc.report_received",
+		"mail.tls.report_received", "mail.feedback.received",
+		"docker_app.entitlement_stopped", "docker_app.disk_quota_stopped",
+		"docker_app.removed_from_package",
+		"db.admin.config_apply_failed_unrecoverable", "db.admin.config_applied",
+		"db.admin.maintenance_finished", "db.admin.root_password_rotated",
+		// automation API writes (notifyWrite)
+		"automation.user.created", "automation.user.deleted",
+		"automation.user.disabled", "automation.user.enabled",
+		"automation.domain.created", "automation.domain.suspended",
+		"automation.domain.unsuspended",
+	}
+	for _, kind := range emitted {
+		if LookupNotificationEventKind(kind) == nil {
+			t.Errorf("emitted kind %q is not registered in AllNotificationEventKinds — "+
+				"it will never appear in Notifications → Events and cannot be disabled (GH #979)", kind)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (GH #979, @lxsdevcode)

The **Notifications → Events** settings didn't list all the event types that are actually generated, so several notifications couldn't be disabled — they defaulted to always-on (`IsEnabled` falls back to `true` for a kind that isn't in `AllNotificationEventKinds`) and there was no toggle to turn them off. The reporter's examples map exactly to the gap:

| Reported | Kind (was unlisted) |
|---|---|
| Panel update | `update.completed` |
| File integrity tamper | `aide.tamper.detected` |
| Ghosted domain | `domain.ghost_detected.{mismatch,nxdomain,partial}` |
| Database events | `db.admin.{config_applied,config_apply_failed_unrecoverable,maintenance_finished,root_password_rotated}` |

## What changed

Registered **every emitted-but-unlisted kind** (~29), found by auditing every `EventKind:` literal, `shouldFire()` argument, and notify/publish helper across the codebase — which also surfaced the **Automation-API write** events (`automation.user.*`, `automation.domain.*` via `notifyWrite`) and the malware / docker_app / mail-report / egress / exec kinds. Each gets a label, description, and severity.

Once a kind is registered, disabling it **drops it entirely at the dispatcher gate** — no channel fan-out *and* no in-app bell/inbox row — which is precisely what the reporter asked for (a disabled event shouldn't still land in the top-right dropdown).

### Default-on policy (operator-approved)

- **Actionable / security → ON:** tamper, DB config rejected, nginx-invalid, RBL-listed, docker entitlement/quota-stopped, malware, ghosted-domain, destructive automation writes (delete/suspend).
- **Informational → OFF:** panel update, DB maintenance/settings, mail reports, automation create/enable.

> ⚠️ **Behavior change on existing installs:** `EnsureDefaults` seeds the declared default for any kind that has no row yet, so the **informational** events above are **silenced on existing installs** after this ships. Intended — it's the noise the reporter wanted gone — and every event stays per-user toggleable.

### Deliberately NOT registered (must stay always-on)

`notifications.broadcast` (admin broadcast must always deliver) and `notifications.channel.test` (fires only on an explicit "send test" click).

### Tenant surface

Adds the tenant-facing new kinds (own domains' ghost detection, mail reputation, Docker-app lifecycle) to the per-user event catalog; admin/server kinds stay out of the tenant surface.

## Tests

- `TestAllNotificationEventKinds_WellFormed` — unique kinds, non-empty label/description, valid severity.
- `TestNotificationEventKinds_EmittedKindsAreRegistered` — the emitted-kind inventory is a subset of the registry (catches a registry removal regressing #979).

## Verification plan (post-merge, jabalitests)

1. `GET /admin/settings/notification-events` returns the new kinds.
2. `SELECT event_kind, enabled FROM notification_event_settings WHERE event_kind LIKE 'db.admin.%' OR event_kind='update.completed'` shows the seeded defaults.
3. Killer check: the `jabali update` itself fires `update.completed` (now `DefaultOn:false`) → assert no inbox/history row lands for it.

GH #979