### PR TITLE
feat(ftp): password generator on the account create + reset forms (GH #1053)

### DIFF
--- a/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
+++ b/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
@@ -26,6 +26,7 @@ import {
   CloudServerOutlined,
 } from "@icons";
 import { RowActionButton } from "../../../components/RowActionButton";
+import { PasswordInput } from "../../../components/PasswordInput";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
 import {
   listFtpAccounts,
@@ -319,7 +320,7 @@ export const UserFtpAccountsPage = () => {
             name="password"
             rules={[{ required: true, min: 12, max: 128 }]}
           >
-            <Input.Password autoComplete="new-password" />
+            <PasswordInput autoComplete="new-password" generatorLength={20} />
           </Form.Item>
           <Form.Item
             label={t("ftpaccounts.ftp_access_label")}
@@ -356,7 +357,7 @@ export const UserFtpAccountsPage = () => {
             name="password"
             rules={[{ required: true, min: 12, max: 128 }]}
           >
-            <Input.Password autoComplete="new-password" />
+            <PasswordInput autoComplete="new-password" generatorLength={20} />
           </Form.Item>
         </Form>
       </Modal>


### PR DESCRIPTION
Operator request from live testing: generate-password affordance on the FTP account forms.

Reuses the shared `PasswordInput` component (dice button, `crypto.getRandomValues`, 20 chars — same as database users). Both the create drawer and the reset modal. `tsc -b` + dist build + 4/4 Playwright green.

GH #1053