### PR TITLE
fix(ftp): stop the ssh-keys pass reverting the chroot home under subaccounts (GH #1053)

### DIFF
--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -20,6 +20,16 @@ func (f *fakeFtpAccountRepo) List(context.Context) ([]models.FtpAccount, error) 
 	return f.rows, nil
 }
 
+func (f *fakeFtpAccountRepo) ListByUserID(_ context.Context, userID string) ([]models.FtpAccount, error) {
+	out := []models.FtpAccount{}
+	for _, r := range f.rows {
+		if r.UserID == userID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
 type ftpUsersRepo struct {
 	repository.UserRepository
 	byID map[string]*models.User

--- a/panel-api/internal/reconciler/ssh_keys_home_mode_test.go
+++ b/panel-api/internal/reconciler/ssh_keys_home_mode_test.go
@@ -1,0 +1,93 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1053 vs M12: a shell-enabled tenant's home is normally flipped to
+// user-owned (mode=ssh), but sshd refuses to chroot a subaccount into a
+// non-root-owned /home/<u> — the two passes flipped ownership back and
+// forth and subaccount logins died right after auth (live FileZilla
+// repro). With any enabled SFTP subaccount, the sftp home layout must win.
+
+type homeModeSSHKeysRepo struct {
+	repository.SSHKeyRepository
+}
+
+func (homeModeSSHKeysRepo) ListByUserID(context.Context, string) ([]models.SSHKey, error) {
+	return nil, nil
+}
+
+type homeModePkgRepo struct {
+	repository.PackageRepository
+	pkg *models.HostingPackage
+}
+
+func (f *homeModePkgRepo) FindByID(context.Context, string) (*models.HostingPackage, error) {
+	return f.pkg, nil
+}
+
+func homeModeCalls(t *testing.T, ftpRows []models.FtpAccount) map[string][]fakeCall {
+	t.Helper()
+	uname := "shop"
+	pkgID := "pkg1"
+	users := &ftpUsersRepo{byID: map[string]*models.User{
+		"u1": {ID: "u1", Username: &uname, PackageID: &pkgID},
+	}}
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{}}
+	r := New(nil, users, agent, slog.Default(), Config{})
+	r.WithSSHKeys(homeModeSSHKeysRepo{})
+	r.WithPackages(&homeModePkgRepo{pkg: &models.HostingPackage{ID: pkgID, SSHEnabled: true}})
+	r.WithFtpAccounts(&fakeFtpAccountRepo{rows: ftpRows})
+
+	if err := r.ReconcileSSHKeysForUser(context.Background(), "u1"); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	return ftpCallsByMethod(agent)
+}
+
+func TestSSHKeysHomeMode_FtpSubaccountForcesSftpLayout(t *testing.T) {
+	calls := homeModeCalls(t, []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop/site", SFTPAccess: true, IsEnabled: true,
+	}})
+	chowns := calls["ssh.user.home_chown"]
+	if len(chowns) != 1 {
+		t.Fatalf("expected 1 home_chown, got %d", len(chowns))
+	}
+	if mode := chowns[0].params.(map[string]interface{})["mode"]; mode != "sftp" {
+		t.Fatalf("shell tenant WITH sftp subaccount must keep the root-owned chroot home, got mode=%v", mode)
+	}
+	// The tenant's own shell access is untouched — still leaves the
+	// sftp group.
+	if len(calls["ssh.user.leave_sftp_group"]) != 1 {
+		t.Fatal("tenant must still leave jabali-sftp (shell stays enabled)")
+	}
+}
+
+func TestSSHKeysHomeMode_NoSubaccountsKeepsShellLayout(t *testing.T) {
+	calls := homeModeCalls(t, nil)
+	chowns := calls["ssh.user.home_chown"]
+	if len(chowns) != 1 {
+		t.Fatalf("expected 1 home_chown, got %d", len(chowns))
+	}
+	if mode := chowns[0].params.(map[string]interface{})["mode"]; mode != "ssh" {
+		t.Fatalf("shell tenant without subaccounts keeps the user-owned home, got mode=%v", mode)
+	}
+}
+
+func TestSSHKeysHomeMode_DisabledSubaccountDoesNotForce(t *testing.T) {
+	calls := homeModeCalls(t, []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_deploy",
+		HomePath: "/home/shop/site", SFTPAccess: true, IsEnabled: false,
+	}})
+	if mode := calls["ssh.user.home_chown"][0].params.(map[string]interface{})["mode"]; mode != "ssh" {
+		t.Fatalf("disabled subaccount must not force the sftp layout, got mode=%v", mode)
+	}
+}

--- a/panel-api/internal/reconciler/ssh_keys_reconcile.go
+++ b/panel-api/internal/reconciler/ssh_keys_reconcile.go
@@ -167,6 +167,24 @@ func (r *Reconciler) ReconcileSSHKeysForUser(ctx context.Context, userID string)
 		homeMode = "ssh"
 		groupMethod = "ssh.user.leave_sftp_group"
 	}
+	// GH #1053: FTP/SFTP subaccounts chroot to /home/<u> via their own
+	// Match User blocks, and sshd refuses a non-root-owned chroot. A
+	// shell-enabled tenant with subaccounts therefore keeps the root:<u>
+	// 0751 home (the M12 trade-off: top-level $HOME read-only for the
+	// tenant, subdirs untouched) — otherwise this pass and the FTP pass
+	// flip ownership back and forth and subaccount logins die right
+	// after auth (seen live: FileZilla "remote side unexpectedly closed").
+	// Group membership is unaffected: the tenant keeps their shell.
+	if homeMode == "ssh" && r.ftpAccounts != nil {
+		if accts, ferr := r.ftpAccounts.ListByUserID(ctx, userID); ferr == nil {
+			for _, a := range accts {
+				if a.IsEnabled && a.SFTPAccess {
+					homeMode = "sftp"
+					break
+				}
+			}
+		}
+	}
 	if _, err := r.agent.Call(ctx, "ssh.user.home_chown", map[string]interface{}{
 		"username": *user.Username,
 		"mode":     homeMode,


### PR DESCRIPTION
Live FileZilla repro (operator, jabalitests): subaccount SFTP auth **succeeded**, session closed instantly — `sshd` refuses a non-root-owned `ChrootDirectory /home/<u>`, and the M12 ssh-keys pass had flipped the home back to user-owned (`mode=ssh`, tenant's package has shell). The FTP pass and ssh-keys pass were flipping ownership back and forth.

**Fix:** a shell-enabled tenant with ≥1 enabled SFTP subaccount keeps the root-owned M12 layout (`root:<u>` 0751 — documented trade-off, subdirs untouched). Shell/group membership unchanged. Last subaccount removed → 15-min resync restores the user-owned layout.

Tests: mode decision matrix (with/without/disabled-only subaccounts, `leave_sftp_group` still dispatched); full reconciler package green.

**Deploy urgency:** the box's old reconciler re-reverts the manually-healed home on its next 15-min resync — merging + updating jabalitests right after CI.

GH #1053