### PR TITLE
fix(security): transactional launch caps + resource-controlled units for tenant migrations (JAB-242)

### DIFF
--- a/panel-agent/internal/commands/migration_admin_run.go
+++ b/panel-agent/internal/commands/migration_admin_run.go
@@ -187,14 +187,18 @@ func migrationPullSourceRunHandler(ctx context.Context, raw json.RawMessage) (an
 	_ = exec.CommandContext(ctx, "systemctl", "stop", "--quiet", unit).Run()
 	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", unit).Run()
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run",
-		"--unit="+unit,
+	pullArgs := []string{
+		"--unit=" + unit,
 		"--no-block",
 		"--collect",
+	}
+	pullArgs = append(pullArgs, migrationResourceProps...)
+	pullArgs = append(pullArgs,
 		"/usr/local/bin/jabali", "migrate", "pull-source",
 		"--job-id="+p.JobID,
 		"--ssh-user="+sshUser,
 	)
+	cmd := exec.CommandContext(ctx, "systemd-run", pullArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemd-run: %v: %s", err, string(out))}
@@ -252,6 +256,19 @@ type migrationImportRunParams struct {
 	TargetPackageID string `json:"target_package_id,omitempty"`
 }
 
+// migrationResourceProps are the systemd resource controls every
+// migration worker unit gets (JAB-242). Weights, not quotas, for CPU/IO
+// so a migration on an idle host runs at full speed and only yields
+// under contention; hard caps only for the true exhaustion vectors. An
+// OOM-killed worker exits non-zero and the job lands in state=failed —
+// the existing failure path.
+var migrationResourceProps = []string{
+	"--property=MemoryMax=4G",
+	"--property=TasksMax=512",
+	"--property=CPUWeight=50",
+	"--property=IOWeight=50",
+}
+
 // importSystemdRunArgs assembles the systemd-run argv for a migration import.
 // runProps are extra systemd-run options (e.g. --property=EnvironmentFile=…)
 // that MUST come before the command; cmdOpts are extra `jabali migrate import`
@@ -264,6 +281,7 @@ func importSystemdRunArgs(jobID, targetUser string, runProps, cmdOpts []string) 
 		"--no-block",
 		"--collect",
 	}
+	args = append(args, migrationResourceProps...)
 	args = append(args, runProps...)
 	args = append(args,
 		"/usr/local/bin/jabali", "migrate", "import",

--- a/panel-agent/internal/commands/migration_admin_run_gh746_test.go
+++ b/panel-agent/internal/commands/migration_admin_run_gh746_test.go
@@ -39,13 +39,35 @@ func TestImportSystemdRunArgs_PropertyBeforeCommand_GH746(t *testing.T) {
 
 func TestImportSystemdRunArgs_NoPropertyWhenNoPassword_GH746(t *testing.T) {
 	args := importSystemdRunArgs("01KYNJ4TMHTYQH133SKARBZ4R2", "demolab", nil, nil)
-	for _, a := range args {
+	// GH746's actual invariant: every --property precedes the command —
+	// one placed after /usr/local/bin/jabali lands in jabali's argv and
+	// dies with "unknown flag". (Since JAB-242 the baseline resource
+	// props are ALWAYS present, so "zero properties" is no longer the
+	// no-password shape.)
+	cmdAt := -1
+	for i, a := range args {
+		if a == "/usr/local/bin/jabali" {
+			cmdAt = i
+			break
+		}
+	}
+	if cmdAt < 0 {
+		t.Fatalf("command not found in args=%v", args)
+	}
+	for _, a := range args[cmdAt:] {
 		if strings.HasPrefix(a, "--property") {
-			t.Errorf("no --property expected without a password; args=%v", args)
+			t.Errorf("--property after the command lands in jabali argv (GH746); args=%v", args)
+		}
+	}
+	// JAB-242: baseline resource controls are always present, before the command.
+	joined := strings.Join(args[:cmdAt], " ")
+	for _, want := range []string{"MemoryMax=", "TasksMax=", "CPUWeight=", "IOWeight="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing resource prop %s before command; args=%v", want, args)
 		}
 	}
 	// The command tail is still well-formed.
-	joined := strings.Join(args, " ")
+	joined = strings.Join(args, " ")
 	if !strings.Contains(joined, "/usr/local/bin/jabali migrate import --job-id=01KYNJ4TMHTYQH133SKARBZ4R2 --target-user=demolab") {
 		t.Errorf("malformed import command: %v", args)
 	}

--- a/panel-api/internal/api/tenant_migrations.go
+++ b/panel-api/internal/api/tenant_migrations.go
@@ -63,6 +63,34 @@ func (h *tenantMigrationsHandler) caller(c *gin.Context) string {
 	return claims.UserID
 }
 
+// JAB-242: tenant-migration launch caps. One active worker per tenant,
+// three host-wide — each worker is a root systemd unit running dump/
+// restore tooling against shared disk, DB and network. Consts on
+// purpose (no settings knob); the admin bulk runner is operator-trust
+// and not gated here.
+const (
+	tenantMigrationPerTenantCap = 1
+	tenantMigrationGlobalCap    = 3
+)
+
+// admitLaunch runs the transactional launch gate and writes the HTTP
+// error when refused. true = admitted, proceed to the agent call.
+func (h *tenantMigrationsHandler) admitLaunch(c *gin.Context, uid, toState string, fromStates []string) bool {
+	err := h.cfg.Jobs.AdmitLaunch(c.Request.Context(), c.Param("id"), uid, toState, fromStates,
+		tenantMigrationPerTenantCap, tenantMigrationGlobalCap)
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, repository.ErrMigrationLaunchBusy):
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "too_many_active_migrations", "detail": "another migration is already running — wait for it to finish and retry"})
+	case errors.Is(err, repository.ErrMigrationNotLaunchable):
+		c.JSON(http.StatusConflict, gin.H{"error": "job_not_launchable", "detail": "this job's current state cannot start that action"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "launch_gate_failed"})
+	}
+	return false
+}
+
 // ownedJob loads the :id job and confirms the caller owns it (target_user_id).
 // A job the caller does not own returns 404 (not 403) so existence never leaks.
 func (h *tenantMigrationsHandler) ownedJob(c *gin.Context, uid string) *models.MigrationJob {
@@ -227,6 +255,16 @@ func (h *tenantMigrationsHandler) pull(c *gin.Context) {
 	}
 	var req tenantPullRequest
 	_ = c.ShouldBindJSON(&req)
+	// JAB-242: transactional launch gate. analyzing is in the from-set so
+	// a job whose worker died can be re-fired (the agent stops + replaces
+	// the old unit); the gate's count excludes this job itself.
+	if !h.admitLaunch(c, uid, models.MigrationStateAnalyzing, []string{
+		models.MigrationStatePending, models.MigrationStateFailed,
+		models.MigrationStateValidating, models.MigrationStateAnalyzing,
+		models.MigrationStateDegraded,
+	}) {
+		return
+	}
 	h.callAgent(c, "migration.pull_source_run", map[string]any{
 		"job_id":   c.Param("id"),
 		"ssh_user": req.SSHUser,
@@ -258,6 +296,15 @@ func (h *tenantMigrationsHandler) importWP(c *gin.Context) {
 	user, err := h.cfg.Users.FindByID(c.Request.Context(), uid)
 	if err != nil || user.Username == nil || *user.Username == "" {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "user_lookup"})
+		return
+	}
+	// JAB-242: same transactional gate as pull. restoring/fix_perms in the
+	// from-set = re-fire of a stuck import; count excludes this job.
+	if !h.admitLaunch(c, uid, models.MigrationStateRestoring, []string{
+		models.MigrationStateValidating, models.MigrationStateFailed,
+		models.MigrationStateDegraded, models.MigrationStateRestoring,
+		models.MigrationStateFixPerms,
+	}) {
 		return
 	}
 	h.callAgent(c, "migration.import_wp_run", map[string]any{

--- a/panel-api/internal/api/tenant_migrations_test.go
+++ b/panel-api/internal/api/tenant_migrations_test.go
@@ -18,8 +18,21 @@ import (
 
 type fakeTMJobs struct {
 	repository.MigrationJobRepository
-	jobs    map[string]*models.MigrationJob
-	created *models.MigrationJob
+	jobs     map[string]*models.MigrationJob
+	created  *models.MigrationJob
+	admitErr error // JAB-242: non-nil = gate refuses with this error
+}
+
+// AdmitLaunch on the fake mirrors the real gate's contract shape:
+// admit by default; tests flip admitErr to exercise refusals (JAB-242).
+func (f *fakeTMJobs) AdmitLaunch(_ context.Context, jobID, targetUserID, toState string, _ []string, _, _ int) error {
+	if f.admitErr != nil {
+		return f.admitErr
+	}
+	if j, ok := f.jobs[jobID]; ok {
+		j.State = toState
+	}
+	return nil
 }
 
 func (f *fakeTMJobs) FindByID(_ context.Context, id string) (*models.MigrationJob, error) {
@@ -169,5 +182,56 @@ func TestTenantMigration_ImportForcesDestUser(t *testing.T) {
 	}
 	if ag.last["dest_user"] != "usera" {
 		t.Fatalf("dest_user not forced to caller OS user: %v", ag.last["dest_user"])
+	}
+}
+
+// JAB-242: the launch gate's refusals surface as 429 (caps) / 409 (state),
+// and a refused launch never reaches the agent.
+func TestTenantMigration_LaunchGateBusy_429(t *testing.T) {
+	h, jobs, ag := newTMHandler()
+	myUID := "USERA"
+	jobs.jobs["JOBA"] = &models.MigrationJob{ID: "JOBA", SourceKind: models.MigrationSourceWordPressSSH, TargetUserID: &myUID, State: "pending"}
+	jobs.admitErr = repository.ErrMigrationLaunchBusy
+	c, w := ctxAs("USERA", `{}`, "JOBA")
+	h.pull(c)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("busy gate = %d, want 429", w.Code)
+	}
+	if ag.last != nil {
+		t.Fatalf("agent was called despite gate refusal: %v", ag.last)
+	}
+}
+
+func TestTenantMigration_LaunchGateNotLaunchable_409(t *testing.T) {
+	h, jobs, ag := newTMHandler()
+	myUID := "USERA"
+	jobs.jobs["JOBA"] = &models.MigrationJob{ID: "JOBA", SourceKind: models.MigrationSourceWordPressSSH, TargetUserID: &myUID, State: "done"}
+	jobs.admitErr = repository.ErrMigrationNotLaunchable
+	c, w := ctxAs("USERA", `{"dest_domain":"mine.com"}`, "JOBA")
+	h.importWP(c)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("not-launchable gate = %d, want 409", w.Code)
+	}
+	if ag.last != nil {
+		t.Fatalf("agent was called despite gate refusal: %v", ag.last)
+	}
+}
+
+// JAB-242: an admitted pull flips the job into the active state as the
+// admission record before the agent fires.
+func TestTenantMigration_LaunchGateAdmitFlipsState(t *testing.T) {
+	h, jobs, ag := newTMHandler()
+	myUID := "USERA"
+	jobs.jobs["JOBA"] = &models.MigrationJob{ID: "JOBA", SourceKind: models.MigrationSourceWordPressSSH, TargetUserID: &myUID, State: "pending"}
+	c, w := ctxAs("USERA", `{}`, "JOBA")
+	h.pull(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admitted pull = %d, want 200", w.Code)
+	}
+	if jobs.jobs["JOBA"].State != models.MigrationStateAnalyzing {
+		t.Fatalf("state = %q, want analyzing (admission record)", jobs.jobs["JOBA"].State)
+	}
+	if ag.last == nil {
+		t.Fatal("agent not called after admission")
 	}
 }

--- a/panel-api/internal/repository/migration_job_repository.go
+++ b/panel-api/internal/repository/migration_job_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -25,6 +26,9 @@ type MigrationJobRepository interface {
 	FindBySource(ctx context.Context, sourceKind, sourceHost, sourceUser string) (*models.MigrationJob, error)
 	List(ctx context.Context, page, pageSize int) ([]models.MigrationJob, int64, error)
 	UpdateState(ctx context.Context, id, state string, lastError *string) error
+	// AdmitLaunch is the transactional tenant-migration launch gate
+	// (JAB-242): active-count caps + conditional state flip in one tx.
+	AdmitLaunch(ctx context.Context, jobID, targetUserID, toState string, fromStates []string, perTenant, global int) error
 	UpdateManifest(ctx context.Context, id, manifestJSON string) error
 	UpdateTargetUser(ctx context.Context, id, targetUserID string) error
 	ClearTargetUser(ctx context.Context, id string) error
@@ -446,4 +450,73 @@ func (r *migrationJobRepo) UpdateStage(ctx context.Context, id, state string, by
 		return ErrNotFound
 	}
 	return nil
+}
+
+// Active-worker migration states (JAB-242): a live systemd worker exists
+// for the job. pending/validating are queue/handoff states with no
+// running process and deliberately NOT counted, so a tenant's own
+// waiting job can't consume their launch slot.
+var migrationActiveStates = []string{
+	models.MigrationStateAnalyzing,
+	models.MigrationStateFixPerms,
+	models.MigrationStateRestoring,
+}
+
+// ErrMigrationLaunchBusy — per-tenant or host-wide active-migration cap
+// reached; retryable (JAB-242).
+var ErrMigrationLaunchBusy = errors.New("too many active migrations")
+
+// ErrMigrationNotLaunchable — the job is in a state that cannot launch
+// (draft/done/cancelled, or a state outside the caller's from-set).
+var ErrMigrationNotLaunchable = errors.New("job not in a launchable state")
+
+// AdmitLaunch (JAB-242) is the transactional launch gate for tenant
+// migration workers. In ONE transaction it:
+//
+//  1. locks the currently-active migration rows (SELECT ... FOR UPDATE)
+//     so two concurrent launches serialize instead of both counting the
+//     same snapshot,
+//  2. refuses with ErrMigrationLaunchBusy when the tenant already has
+//     perTenant active workers or the host has global (the target job
+//     itself is excluded — re-firing a stuck job must pass),
+//  3. conditionally flips the target row fromStates→toState; zero rows
+//     affected means the job wasn't in a launchable state.
+//
+// The state flip IS the admission record: the worker the caller then
+// launches re-asserts the same state, and a failed launch leaves a row
+// the tenant can re-fire (fromStates includes the active state itself).
+func (r *migrationJobRepo) AdmitLaunch(ctx context.Context, jobID, targetUserID, toState string, fromStates []string, perTenant, global int) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var lockedIDs []string
+		if err := tx.Model(&models.MigrationJob{}).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("state IN ? AND id <> ?", migrationActiveStates, jobID).
+			Pluck("id", &lockedIDs).Error; err != nil {
+			return err
+		}
+		if global > 0 && len(lockedIDs) >= global {
+			return ErrMigrationLaunchBusy
+		}
+		if perTenant > 0 {
+			var tenantActive int64
+			if err := tx.Model(&models.MigrationJob{}).
+				Where("state IN ? AND id <> ? AND target_user_id = ?", migrationActiveStates, jobID, targetUserID).
+				Count(&tenantActive).Error; err != nil {
+				return err
+			}
+			if tenantActive >= int64(perTenant) {
+				return ErrMigrationLaunchBusy
+			}
+		}
+		res := tx.Model(&models.MigrationJob{}).
+			Where("id = ? AND target_user_id = ? AND state IN ?", jobID, targetUserID, fromStates).
+			Update("state", toState)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrMigrationNotLaunchable
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
## Summary
Second PR of the JAB-240..245 epic (after #1112): JAB-242 — tenants could launch unlimited concurrent root migration workers, each an uncapped transient systemd unit.

### Panel — transactional launch gate
New `MigrationJobRepository.AdmitLaunch`, one transaction:
1. Locks the active-worker rows (`analyzing`/`fix_perms`/`restoring`, `SELECT … FOR UPDATE`) so two concurrent launches serialize instead of both counting the same snapshot.
2. Refuses over-cap — **1 active worker per tenant, 3 host-wide** (consts, no settings knob) — with a retryable `429 too_many_active_migrations`.
3. Conditionally flips the job into its active state **as the admission record**; a job outside the launchable from-set gets `409 job_not_launchable`.

Wired into both tenant launch paths (`pull` → analyzing, `importWP` → restoring) before the agent call. The job's own row is excluded from the counts and its active state is in the from-set, so a stuck job (dead worker) can always be re-fired — the agent already stops+replaces the prior unit by name. `pending`/`validating` are queue/handoff states with **no** running process and deliberately don't consume slots. The admin bulk runner is operator-trust and not gated (per the epic scoping).

### Agent — resource-controlled worker units
Both unit builders (`migration.pull_source_run`, `migration.import_run`/`import_wp_run`) now pass baseline systemd properties, always ahead of the command (GH #746 rule):
- `MemoryMax=4G`, `TasksMax=512` — hard caps on the true exhaustion vectors; an OOM-killed worker exits non-zero and the job lands in `failed` via the existing path.
- `CPUWeight=50`, `IOWeight=50` — soft weights: full speed on an idle host, yields under contention. Deliberately **not** quotas.

These unit limits also bound the JAB-240 pull runtime, since #1112's budgeted pull code executes inside these units.

### Proof split
Unit/handler-proven here; the cheap live smoke (second concurrent tenant pull → 429 on a real box) rides the epic's closing verification pass. GH #746's test was asserting "zero `--property` without a password" — its actual invariant is "no `--property` AFTER the command"; the test now pins that plus the presence of the baseline props.

## Test plan
- [x] Handler: busy → 429 + agent NOT called; not-launchable → 409 + agent NOT called; admitted pull flips state to analyzing before the agent fires
- [x] Agent: GH #746 invariant (props precede command) + all four resource props present on the import builder; existing suites green
- [x] Full panel-api + panel-agent suites: 0 FAIL; post-rebase re-run
- [ ] CI

JAB-242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
