### PR TITLE
fix(security): bounded concurrency + host floor for tenant database backups (JAB-244)

### DIFF
--- a/panel-agent/internal/commands/db_backup.go
+++ b/panel-agent/internal/commands/db_backup.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
 	"os"
 	"os/exec"
 	"os/user"
@@ -87,6 +88,13 @@ var dbBackupNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
 // root-written file lands root:root) — see reownBackupForPanel.
 const dbBackupStagingDir = "/var/lib/jabali-uploads"
 
+// dbBackupSlots (JAB-244): at most one dump per database (same-DB
+// double-fire is wasted work) and two host-wide — each dump materializes
+// a full .sql on shared staging before the panel consumes it. Refusals
+// are retryable CodeUnavailable; the 12h sweeper (GH #1045) still reaps
+// crash-stranded files.
+var dbBackupSlots = hostreserve.NewKeyedSemaphore(1, 2)
+
 func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	var p dbBackupParams
 	if err := json.Unmarshal(params, &p); err != nil {
@@ -147,6 +155,24 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		}
 	}
 
+	// JAB-244: bounded concurrency + host floor. Acquire a dump slot
+	// (never blocks — a busy host answers retryable-unavailable), then
+	// refuse outright when staging is already under the reserve floor.
+	release, ok := dbBackupSlots.TryAcquire(p.DBName)
+	if !ok {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "too many concurrent database backups — retry shortly",
+		}
+	}
+	defer release()
+	if err := hostreserve.CheckReserve(dbBackupStagingDir, 0); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "backup staging is under the host disk reserve: " + err.Error(),
+		}
+	}
+
 	// The staging dir is provisioned by install.sh (0750 jabali:jabali-sockets).
 	// MkdirAll is a defensive no-op when it already exists; on the off chance it
 	// is missing, 0750 keeps it panel-owner-writable rather than root-only.
@@ -177,7 +203,9 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		"--",
 		p.DBName,
 	)
-	cmd.Stdout = f
+	// JAB-244: mid-dump reserve cadence — a dump that started with room
+	// stops when concurrent writers eat the disk (256 MiB re-checks).
+	cmd.Stdout = hostreserve.GuardedWriter(f, dbBackupStagingDir)
 
 	if err := cmd.Run(); err != nil {
 		// Remove partial file on failure

--- a/panel-agent/internal/commands/db_backup_test.go
+++ b/panel-agent/internal/commands/db_backup_test.go
@@ -183,3 +183,43 @@ func TestReownBackupForPanel(t *testing.T) {
 		}
 	})
 }
+
+// JAB-244: with both global dump slots held, a new backup must answer
+// retryable-unavailable BEFORE any validation of staging or exec of
+// mysqldump.
+func TestDBBackup_GlobalSlotsExhausted_Unavailable(t *testing.T) {
+	rel1, ok1 := dbBackupSlots.TryAcquire("heldA")
+	rel2, ok2 := dbBackupSlots.TryAcquire("heldB")
+	if !ok1 || !ok2 {
+		t.Fatal("precondition: could not hold both global slots")
+	}
+	defer rel1()
+	defer rel2()
+
+	params, _ := json.Marshal(map[string]string{"db_name": "tenant_db"})
+	_, err := dbBackupHandler(context.Background(), params)
+	if err == nil {
+		t.Fatal("backup admitted with zero free slots")
+	}
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeUnavailable {
+		t.Fatalf("want CodeUnavailable, got %v", err)
+	}
+}
+
+// JAB-244: a second dump of the SAME database is refused even with a
+// global slot free (per-key cap 1 — duplicate work, duplicate disk).
+func TestDBBackup_SameDBAlreadyDumping_Unavailable(t *testing.T) {
+	rel, ok := dbBackupSlots.TryAcquire("tenant_db")
+	if !ok {
+		t.Fatal("precondition: could not hold the db slot")
+	}
+	defer rel()
+
+	params, _ := json.Marshal(map[string]string{"db_name": "tenant_db"})
+	_, err := dbBackupHandler(context.Background(), params)
+	var ae *agentwire.AgentError
+	if err == nil || !errors.As(err, &ae) || ae.Code != agentwire.CodeUnavailable {
+		t.Fatalf("want CodeUnavailable for same-db double dump, got %v", err)
+	}
+}

--- a/panel-agent/internal/commands/db_postgres.go
+++ b/panel-agent/internal/commands/db_postgres.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -247,6 +249,17 @@ func dbPgDumpHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	}
 	if !strings.HasPrefix(p.OutPath, "/var/lib/jabali") && !strings.HasPrefix(p.OutPath, "/run/jabali") {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "out_path must be under /var/lib/jabali or /run/jabali"}
+	}
+	// JAB-244: same dump-slot + host-floor admission as db.backup.
+	// pg_dump opens its own output handle (-f), so there is no mid-dump
+	// write cadence here — pre-checks + shared slots only.
+	release, ok := dbBackupSlots.TryAcquire("pg:" + p.DBName)
+	if !ok {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "too many concurrent database backups — retry shortly"}
+	}
+	defer release()
+	if err := hostreserve.CheckReserve(filepath.Dir(p.OutPath), 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "backup staging is under the host disk reserve: " + err.Error()}
 	}
 	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
 		"-Fc", "--no-owner", "--no-privileges",

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
 	"io"
 	"log/slog"
 	"net/http"
@@ -22,6 +23,11 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
+
+// dbBackupRequests (JAB-244): per-tenant in-flight backup-request cap.
+// The agent enforces the global and per-database dump slots; this only
+// stops one tenant stacking synchronous request windows.
+var dbBackupRequests = hostreserve.NewKeyedSemaphore(1, 0)
 
 // DatabaseHandlerConfig plugs the database handlers into the router.
 type DatabaseHandlerConfig struct {
@@ -461,6 +467,16 @@ func (h *databaseHandler) backup(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
 	}
+
+	// JAB-244: one in-flight backup request per tenant (the agent holds
+	// the global + per-database slots). Bounds the synchronous 5-minute
+	// call window a tenant can multiply.
+	release, ok := dbBackupRequests.TryAcquire(claims.UserID)
+	if !ok {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "backup_in_progress", "detail": "another backup of yours is still running — wait for it and retry"})
+		return
+	}
+	defer release()
 
 	// Call agent to create the backup
 	if h.cfg.Agent == nil {


### PR DESCRIPTION
## Summary
Third PR of the JAB-240..245 epic (after #1112, #1115): JAB-244 — tenant DB backups materialize full dumps on shared staging with no concurrency cap or disk floor.

### Agent
- **`db.backup`**: takes a slot from `hostreserve.KeyedSemaphore` — **1 per database** (same-DB double dump is pure waste + duplicate disk) and **2 host-wide** — or answers retryable `CodeUnavailable`. Refuses outright when `/var/lib/jabali-uploads` is already under the host reserve floor. The `mysqldump` stream writes through the 256 MiB reserve-cadence `GuardedWriter`, so a dump that started with room stops when concurrent writers eat the disk.
- **`db.postgres.dump`**: same slot + floor admission (shared semaphore, `pg:`-prefixed keys). `pg_dump` opens its own `-f` handle, so no mid-dump cadence there — pre-checks only, stated openly.

### Panel
- One in-flight backup **request** per tenant → `429 backup_in_progress`. The agent owns the real dump slots; this only stops a tenant stacking synchronous 5-minute call windows.

### Already covered elsewhere
Cleanup of stranded staging files shipped with GH #1045 (12h sweeper) — deliberately not rebuilt here. The criterion's "byte reservation" is approximated by floor + cadence rather than a size pre-estimate: the dump size isn't knowable cheaply up front, and counted-bytes enforcement is the stronger guarantee anyway.

### Proof split
Agent refusal paths are unit-proven (slots exhausted → `CodeUnavailable` before any exec; same-DB duplicate → refused). Panel 429 path is 6 lines over the hostreserve semantics already covered by its own tests. Live smoke (N parallel backups → visible slot refusals) rides the epic's closing verification pass on testserver.

## Test plan
- [x] Agent: both-global-slots-held → `CodeUnavailable` before staging validation or mysqldump exec; same-DB duplicate → `CodeUnavailable`; existing db_backup suite green
- [x] panel-agent + panel-api suites: 0 FAIL; gofmt/vet clean; post-rebase
- [ ] CI

JAB-244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
