### PR TITLE
fix(ui): un-glue Save buttons and stacked settings cards

### DIFF
--- a/panel-ui/src/shells/admin/settings/EmailCard.tsx
+++ b/panel-ui/src/shells/admin/settings/EmailCard.tsx
@@ -18,7 +18,7 @@ export const EmailCard = () => {
 
   if (q.isPending) {
     return (
-      <Card title={<CardTitle />}>
+      <Card title={<CardTitle />} style={{ marginBottom: 16 }}>
         <Skeleton active />
       </Card>
     );
@@ -26,7 +26,7 @@ export const EmailCard = () => {
 
   if (q.isError) {
     return (
-      <Card title={<CardTitle />}>
+      <Card title={<CardTitle />} style={{ marginBottom: 16 }}>
         <Alert
           type="error"
           message={t("emailcard.failed_to_load_email_settings")}

--- a/panel-ui/src/shells/admin/settings/NginxSettingsCard.tsx
+++ b/panel-ui/src/shells/admin/settings/NginxSettingsCard.tsx
@@ -96,7 +96,7 @@ export function NginxSettingsCard() {
 
   if (!loaded) {
     return (
-      <Card title={t("nginxsettingscard.nginx")}>
+      <Card title={t("nginxsettingscard.nginx")} style={{ marginBottom: 16 }}>
         <Spin />
       </Card>
     );

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -355,7 +355,9 @@ const GeneralSettingsTab = () => {
 
       <ModulesCard />
 
-      <Space>
+      {/* More cards follow this form inside the tab fragment — without a
+          bottom margin the Save button sits glued to the next card. */}
+      <Space style={{ marginBottom: 24 }}>
         <Button
           type="primary"
           icon={<SaveOutlined />}
@@ -695,7 +697,9 @@ const StorageSettingsTab = () => {
         </Row>
       </Card>
 
-      <Space>
+      {/* More cards follow this form inside the tab fragment — without a
+          bottom margin the Save button sits glued to the next card. */}
+      <Space style={{ marginBottom: 24 }}>
         <Button
           type="primary"
           icon={<SaveOutlined />}
@@ -914,7 +918,9 @@ const SSHSettingsTab = () => {
 
       <NspawnImagesCard />
 
-      <Space>
+      {/* More cards follow this form inside the tab fragment — without a
+          bottom margin the Save button sits glued to the next card. */}
+      <Space style={{ marginBottom: 24 }}>
         <Button
           type="primary"
           icon={<SaveOutlined />}


### PR DESCRIPTION
Operator report from live testing: 'Save Settings' buttons render glued to the following card (General → Free Jabali hostname, SSH & FTP → FTP Server), and a sweep of every stacked composition found two cards missing the sibling `marginBottom: 16`.

- Save-button `Space` wrappers: `marginBottom: 24` (3 occurrences; tabs with nothing after get harmless air)
- `EmailCard` (glued to WebmailToggleCard) + `NginxSettingsCard` (glued to TenantDomainOptionsCard): `marginBottom: 16`
- Audited: all Server Settings tab fragments, Apps tab (already spaced via vertical `Space`), security allowlist stack (already `marginTop: 16`)

`tsc -b` + dist + 235 vitest green.