### PR TITLE
fix(security): docker start/restart disk admission + DB-restore host floor (JAB-245, JAB-243 partial)

### DIFF
--- a/panel-agent/internal/commands/db_restore.go
+++ b/panel-agent/internal/commands/db_restore.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -41,6 +42,18 @@ func dbRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) 
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
 			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+
+	// JAB-243 (partial): tenant DB storage lives under /var/lib/mysql,
+	// outside every POSIX quota. A hard per-tenant cap needs tablespace/
+	// project-quota work (tracked on the ticket); until then, at least
+	// refuse to START loading tenant SQL when the DB filesystem is
+	// already below the host reserve floor.
+	if err := hostreserve.CheckReserve("/var/lib/mysql", 0); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "database storage is under the host disk reserve: " + err.Error(),
 		}
 	}
 

--- a/panel-api/internal/api/docker_apps_user.go
+++ b/panel-api/internal/api/docker_apps_user.go
@@ -264,11 +264,47 @@ func (h *userDockerAppHandler) get(c *gin.Context) {
 	c.JSON(http.StatusOK, installedResponse{DockerApp: *app, Ports: ports})
 }
 
+// dockerDiskGateForStart (JAB-245): admission for bring-up lifecycle
+// actions. The reconciler stops over-quota apps, but start/restart used
+// to accept them right back — a reliable bypass loop. Same rule as the
+// install gate (Gitea #489): package disk quota reached → refuse. Loose
+// on every failure to resolve package/usage (a broken lookup must not
+// brick every app start), and never applied to stop.
+func (h *userDockerAppHandler) dockerDiskGateForStart(c *gin.Context, userID string) bool {
+	ctx := c.Request.Context()
+	user, err := h.cfg.Users.FindByID(ctx, userID)
+	if err != nil || user == nil || user.PackageID == nil {
+		return true
+	}
+	pkg, err := h.cfg.Packages.FindByID(ctx, *user.PackageID)
+	if err != nil || pkg == nil || pkg.DiskQuotaMB <= 0 {
+		return true
+	}
+	used, err := h.cfg.Repo.SumDataBytesByUserID(ctx, userID)
+	if err != nil {
+		return true
+	}
+	if used >= int64(pkg.DiskQuotaMB)*1024*1024 {
+		c.JSON(http.StatusConflict, gin.H{"error": "disk_quota_exceeded", "detail": "your Docker app disk usage has reached your hosting package quota — free space or upgrade before starting this app"})
+		return false
+	}
+	return true
+}
+
 func (h *userDockerAppHandler) lifecycle(statusOnSuccess string, composeArgs ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		app := h.loadOwned(c)
 		if app == nil {
 			return
+		}
+		// JAB-245: an over-quota app must not come back up via start/
+		// restart — the restart-after-reconciler-stop loop was a reliable
+		// quota bypass. Gated BEFORE the agent block so it holds on every
+		// path; stop is never gated.
+		if statusOnSuccess == models.DockerAppStatusRunning {
+			if !h.dockerDiskGateForStart(c, ginctx.Claims(c).UserID) {
+				return
+			}
 		}
 		if h.cfg.Agent != nil {
 			ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Minute)

--- a/panel-api/internal/api/docker_apps_user_test.go
+++ b/panel-api/internal/api/docker_apps_user_test.go
@@ -368,3 +368,70 @@ func TestTenantDocker_DeleteCleansDomainLinks(t *testing.T) {
 		t.Errorf("app should be soft-deleted, got %q", repo.updated["a1"])
 	}
 }
+
+// JAB-245: start/restart of an over-quota app is refused — the
+// reconciler-stop → tenant-restart loop was a reliable disk-quota
+// bypass. Stop is never gated.
+func TestTenantDocker_StartOverQuota409(t *testing.T) {
+	cfg := UserDockerAppHandlerConfig{
+		Repo: &fakeDockerRepo{
+			sumBytes: 2 << 30, // 2 GiB used
+			owned:    map[string]*models.DockerApp{"a1": {ID: "a1", Slug: "tdemo", UserID: uname("u1"), Status: models.DockerAppStatusStopped}},
+		},
+		Catalog:  tenantCatalog(t),
+		Users:    &fakeUserRepo{user: &models.User{ID: "u1", Username: uname("alice"), PackageID: uname("p1")}},
+		Packages: &fakePkgRepo{pkg: &models.HostingPackage{ID: "p1", MaxDockerApps: 5, DiskQuotaMB: 1024}}, // 1 GiB quota
+		Domains:  &fakeDomainRepo{},
+	}
+	r := tenantRouter(t, cfg, true)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "disk_quota_exceeded") {
+		t.Fatalf("want 409 disk_quota_exceeded, got %d %s", rec.Code, rec.Body.String())
+	}
+	repo := cfg.Repo.(*fakeDockerRepo)
+	if repo.updated["a1"] != "" {
+		t.Fatalf("status updated despite refused start: %q", repo.updated["a1"])
+	}
+}
+
+func TestTenantDocker_StartUnderQuotaOK(t *testing.T) {
+	cfg := UserDockerAppHandlerConfig{
+		Repo: &fakeDockerRepo{
+			sumBytes: 100 << 20, // 100 MiB used
+			owned:    map[string]*models.DockerApp{"a1": {ID: "a1", Slug: "tdemo", UserID: uname("u1"), Status: models.DockerAppStatusStopped}},
+		},
+		Catalog:  tenantCatalog(t),
+		Users:    &fakeUserRepo{user: &models.User{ID: "u1", Username: uname("alice"), PackageID: uname("p1")}},
+		Packages: &fakePkgRepo{pkg: &models.HostingPackage{ID: "p1", MaxDockerApps: 5, DiskQuotaMB: 1024}},
+		Domains:  &fakeDomainRepo{},
+	}
+	r := tenantRouter(t, cfg, true)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/start", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("under-quota start = %d, want 200 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantDocker_StopOverQuotaNeverGated(t *testing.T) {
+	cfg := UserDockerAppHandlerConfig{
+		Repo: &fakeDockerRepo{
+			sumBytes: 2 << 30,
+			owned:    map[string]*models.DockerApp{"a1": {ID: "a1", Slug: "tdemo", UserID: uname("u1"), Status: models.DockerAppStatusRunning}},
+		},
+		Catalog:  tenantCatalog(t),
+		Users:    &fakeUserRepo{user: &models.User{ID: "u1", Username: uname("alice"), PackageID: uname("p1")}},
+		Packages: &fakePkgRepo{pkg: &models.HostingPackage{ID: "p1", MaxDockerApps: 5, DiskQuotaMB: 1024}},
+		Domains:  &fakeDomainRepo{},
+	}
+	r := tenantRouter(t, cfg, true)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/docker-apps/a1/stop", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stop of over-quota app = %d, want 200 — blocking stop would be perverse (%s)", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
Final PR of the JAB-240..245 epic (after #1112, #1115, #1116): the two smallest items ride together.

### JAB-245 — docker start/restart disk admission
The reconciler stops over-quota tenant Docker apps, but `start`/`restart` accepted them right back — a reliable bypass loop (stop → grow → restart). Bring-up lifecycle actions now run the same disk gate as install (Gitea #489): package disk quota reached → `409 disk_quota_exceeded`.

- Gate extracted to `dockerDiskGateForStart`, called **before** the agent block so it holds on every path — the first test caught it sitting inside `if Agent != nil` and passing agent-less flows.
- Fail-open on package/usage lookup errors: a broken lookup must not brick every app start.
- **Stop is never gated** — blocking a tenant from stopping an over-quota app would be perverse (pinned by test).

### JAB-243 — partial (declared scope)
The real fix — a per-tenant hard cap on DB storage (tablespaces / project quotas) — is a feature build and stays tracked on the board (248-style status note). Shipped here: `db.restore` refuses to start loading tenant SQL when `/var/lib/mysql` is already under the host reserve floor (retryable `CodeUnavailable`). The tenant-restore sink was picked because it's the one path a tenant can point unbounded data at directly; steady-state INSERT growth needs the hard-cap follow-up.

## Test plan
- [x] Start of over-quota app → 409 `disk_quota_exceeded`, status NOT updated; under-quota start → 200; stop of over-quota app → 200 (never gated)
- [x] Full panel-api + panel-agent suites: 0 FAIL; vet clean; post-rebase re-run
- [ ] CI

JAB-245 JAB-243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
