### PR TITLE
feat(mail): surface CalDAV/CardDAV URLs per mailbox for manual client setup (GH #1039)

### DIFF
--- a/panel-ui/src/components/mail/MailSyncInfoModal.tsx
+++ b/panel-ui/src/components/mail/MailSyncInfoModal.tsx
@@ -1,0 +1,76 @@
+// MailSyncInfoModal — shows a mailbox's CalDAV (calendar) and CardDAV
+// (contacts) URLs so the tenant can add them to Thunderbird / Apple Mail
+// / any DAV client (GH #1039 follow-up). The DAV endpoints live on the
+// domain's mail host and Stalwart keys collections by the full email
+// address, so the URLs are derived client-side — no API call needed.
+//
+// Why this exists: Thunderbird auto-discovers CALENDARS during mail setup
+// but not CONTACTS, and its manual CardDAV dialog needs the exact URL.
+// Surfacing both ready-to-paste removes the guesswork.
+import { Modal, Typography, Alert, Space } from "antd";
+
+interface MailSyncInfoModalProps {
+  open: boolean;
+  email: string;
+  domain: string;
+  onClose: () => void;
+}
+
+interface DavRow {
+  label: string;
+  url: string;
+}
+
+export function MailSyncInfoModal({ open, email, domain, onClose }: MailSyncInfoModalProps) {
+  const base = domain ? `https://mail.${domain}` : "";
+  const rows: DavRow[] = email && domain
+    ? [
+        { label: "Calendar (CalDAV)", url: `${base}/dav/cal/${email}/` },
+        { label: "Contacts (CardDAV)", url: `${base}/dav/card/${email}/` },
+      ]
+    : [];
+
+  return (
+    <Modal
+      open={open}
+      title={email ? `Calendar & contacts — ${email}` : "Calendar & contacts"}
+      onCancel={onClose}
+      onOk={onClose}
+      okText="Done"
+      cancelButtonProps={{ style: { display: "none" } }}
+      destroyOnClose
+    >
+      <Typography.Paragraph type="secondary">
+        Add your calendar and contacts to Thunderbird, Apple Mail, or any
+        CalDAV/CardDAV client with these URLs. Sign in with your full email
+        address and mailbox password.
+      </Typography.Paragraph>
+
+      <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        {rows.map((r) => (
+          <div key={r.label}>
+            <Typography.Text strong>{r.label}</Typography.Text>
+            <br />
+            <Typography.Text copyable={{ text: r.url }} code style={{ wordBreak: "break-all" }}>
+              {r.url}
+            </Typography.Text>
+          </div>
+        ))}
+      </Space>
+
+      <Alert
+        style={{ marginTop: 16 }}
+        type="info"
+        showIcon
+        message="Thunderbird tip"
+        description={
+          <span>
+            Thunderbird auto-detects your calendar during mail setup, but not
+            your contacts. Add contacts with <b>Address Book → New → CardDAV
+            Address Book</b> and paste the Contacts URL above.
+          </span>
+        }
+      />
+    </Modal>
+  );
+}

--- a/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
+++ b/panel-ui/src/shells/user/mail/tabs/MailboxesTab.tsx
@@ -15,6 +15,7 @@ import {
   ClockCircleOutlined,
   KeyOutlined,
   MailOutlined,
+  CalendarCheckOutlined,
 } from "@icons";
 import { useQueries } from "@tanstack/react-query";
 
@@ -34,6 +35,7 @@ import type { Domain } from "../../domains/UserDomainList";
 import { DatabaseUserPasswordModal } from "../../../../components/DatabaseUserPasswordModal";
 import { PasswordInput } from "../../../../components/PasswordInput";
 import { EditMailboxModal } from "../../../../components/mail/EditMailboxModal";
+import { MailSyncInfoModal } from "../../../../components/mail/MailSyncInfoModal";
 
 type MailboxRow = Mailbox & { domain_name: string };
 type GroupMembership = {
@@ -165,6 +167,7 @@ export const MailboxesTab = () => {
   const [resetTarget, setResetTarget] = useState<MailboxRow | null>(null);
   const [editTarget, setEditTarget] = useState<MailboxRow | null>(null);
   const [arTarget, setArTarget] = useState<MailboxRow | null>(null);
+  const [syncTarget, setSyncTarget] = useState<MailboxRow | null>(null);
   const [resetForm] = Form.useForm<{ password?: string }>();
 
   const deleteMutation = useDeleteMailbox();
@@ -443,6 +446,19 @@ export const MailboxesTab = () => {
                     onClick: () => openWebmail(row),
                   },
                   { key: "edit", label: "Edit", icon: <EditOutlined />, onClick: () => setEditTarget(row) },
+                  // Send-only mailboxes (GH #371 relays like noreply@) have no
+                  // inbox/calendar/contacts, so skip the CalDAV/CardDAV action.
+                  ...(!row.send_only
+                    ? [
+                        {
+                          key: "sync",
+                          label: "Calendar & contacts",
+                          icon: <CalendarCheckOutlined />,
+                          tooltip: "CalDAV / CardDAV URLs for Thunderbird, Apple Mail, etc.",
+                          onClick: () => setSyncTarget(row),
+                        },
+                      ]
+                    : []),
                   { key: "resetpw", label: "Reset password", icon: <KeyOutlined />, onClick: () => openReset(row) },
                   { key: "autoreply", label: "Automatic replies", icon: <ClockCircleOutlined />, onClick: () => setArTarget(row) },
                   {
@@ -489,6 +505,13 @@ export const MailboxesTab = () => {
         email={arTarget?.email ?? ""}
         current={arTarget ? arByMailbox[arTarget.id] ?? null : null}
         onClose={() => setArTarget(null)}
+      />
+
+      <MailSyncInfoModal
+        open={syncTarget !== null}
+        email={syncTarget?.email ?? ""}
+        domain={syncTarget?.domain_name ?? ""}
+        onClose={() => setSyncTarget(null)}
       />
 
       <Modal


### PR DESCRIPTION
Follow-up to the CalDAV/CardDAV routing (#1100), addressing @johnnyq's retest: Thunderbird auto-discovers a mailbox's **calendar** during mail setup but **not** its **address book** ("0 found"), and its manual CardDAV dialog needs the exact URL. The DAV plumbing is correct and symmetric (proven — the server returns an identical, valid CardDAV collection to the calendar), so this is a Thunderbird limitation the server can't force. The fix is UX: hand the user the URL.

## Change

Add a **"Calendar & contacts"** action to each mailbox row (tenant Mail → Mailboxes) that opens a small modal with the ready-to-paste, copyable URLs:

```
Calendar (CalDAV):  https://mail.<domain>/dav/cal/<email>/
Contacts (CardDAV): https://mail.<domain>/dav/card/<email>/
```

…plus a note that Thunderbird auto-detects calendars but contacts must be added manually (**Address Book → New → CardDAV Address Book**). Sign in with the full email + mailbox password.

- **No API change** — URLs are derived client-side from the mail host (`mail.<domain>`) and the full-email account segment.
- **Verified live** on a test server: both paths return **207** with the plain (unencoded) email form, so the copy-paste string works verbatim.
- **Send-only mailboxes** (GH #371 relays like `noreply@`) have no inbox/calendar/contacts, so the action is hidden for them.

## Tests

`tsc -b` clean, `vite build` OK, mail vitest green. New self-contained `MailSyncInfoModal` component; the row-action label matches the sibling hardcoded labels in this table.

GH #1039