### PR TITLE
fix(ftp): max_ftp_accounts reverted to 0 on package save (GH #1053)

### DIFF
--- a/panel-api/internal/api/packages.go
+++ b/panel-api/internal/api/packages.go
@@ -82,6 +82,7 @@ type createPackageRequest struct {
 	MaxDatabases     uint32 `json:"max_databases"`
 	MaxDockerApps    uint32 `json:"max_docker_apps"`
 	MaxPythonApps    uint32 `json:"max_python_apps"`
+	MaxFTPAccounts   uint32 `json:"max_ftp_accounts"`
 	// Tenant backup limits (GH #454). 0 = backups not included on this plan.
 	MaxBackups                    uint32 `json:"max_backups"`
 	MaxBackupSchedules            uint32 `json:"max_backup_schedules"`
@@ -115,6 +116,7 @@ type updatePackageRequest struct {
 	MaxDatabases     *uint32 `json:"max_databases"`
 	MaxDockerApps    *uint32 `json:"max_docker_apps"`
 	MaxPythonApps    *uint32 `json:"max_python_apps"`
+	MaxFTPAccounts   *uint32 `json:"max_ftp_accounts"`
 	// Tenant backup limits (GH #454).
 	MaxBackups                    *uint32 `json:"max_backups"`
 	MaxBackupSchedules            *uint32 `json:"max_backup_schedules"`
@@ -205,6 +207,7 @@ func (h *packageHandler) create(c *gin.Context) {
 		MaxDatabases:     req.MaxDatabases,
 		MaxDockerApps:    req.MaxDockerApps,
 		MaxPythonApps:    req.MaxPythonApps,
+		MaxFTPAccounts:   req.MaxFTPAccounts,
 
 		MaxBackups:                    req.MaxBackups,
 		MaxBackupSchedules:            req.MaxBackupSchedules,
@@ -341,6 +344,9 @@ func (h *packageHandler) update(c *gin.Context) {
 	}
 	if req.MaxPythonApps != nil {
 		pkg.MaxPythonApps = *req.MaxPythonApps
+	}
+	if req.MaxFTPAccounts != nil {
+		pkg.MaxFTPAccounts = *req.MaxFTPAccounts
 	}
 	if req.MaxBackups != nil {
 		pkg.MaxBackups = *req.MaxBackups

--- a/panel-api/internal/repository/package_repository.go
+++ b/panel-api/internal/repository/package_repository.go
@@ -64,7 +64,7 @@ func (r *packageRepo) FindByName(ctx context.Context, name string) (*models.Host
 // packageListCols — packages only have a meaningful name field for
 // search. Sort allows name/created_at. Historical default was name ASC.
 var packageListCols = ListCols{
-	Search:      []string{"name"},
+	Search: []string{"name"},
 	Sort: []string{
 		"name", "disk_quota_mb", "bandwidth_quota_mb", "max_domains",
 		"max_email_accounts", "max_databases", "ssh_enabled", "php_exec_enabled",
@@ -106,7 +106,7 @@ func (r *packageRepo) Update(ctx context.Context, p *models.HostingPackage) erro
 		"name", "disk_quota_mb", "bandwidth_quota_mb", "max_domains",
 		"max_email_accounts", "max_databases",
 		"cpu_quota_percent", "memory_limit_mb", "io_read_mbps", "io_write_mbps",
-		"max_tasks", "max_docker_apps", "max_python_apps", "docker_app_slugs",
+		"max_tasks", "max_docker_apps", "max_python_apps", "max_ftp_accounts", "docker_app_slugs",
 		"ssh_enabled", "cgi_enabled", "php_exec_enabled",
 		// GH #339: FPM performance-policy columns were missing from the Select
 		// allowlist, so GORM silently dropped them on update and the policy never

--- a/panel-api/internal/repository/package_repository_test.go
+++ b/panel-api/internal/repository/package_repository_test.go
@@ -126,3 +126,12 @@ func TestPackage_Update_PersistsBackupLimits(t *testing.T) {
 	updatePersistsColumn(t, "allowed_backup_destination_kinds")
 	updatePersistsColumn(t, "backup_retention_policy")
 }
+
+// GH #1053 (johnnyq's live report): max_ftp_accounts was added to the model,
+// the package editor, AND the API update handler — but missed from this
+// Update Select allowlist, so setting the FTP account cap showed success and
+// reverted to 0 on reload. Third occurrence of this exact class (#170/#402,
+// #454); the guard keeps it from being a fourth.
+func TestPackage_Update_PersistsMaxFTPAccounts(t *testing.T) {
+	updatePersistsColumn(t, "max_ftp_accounts")
+}


### PR DESCRIPTION
Live report from @johnnyq on GH #1053: **Max FTP/SFTP Accounts reverts to 0** after saving a hosting package.

The field was dropped at all three layers: `createPackageRequest` (bound zero), `updatePackageRequest` (absent → never applied), and the repository `Update` **Select allowlist** (the #170/#402/#454 silent-drop class — its own comment warns about exactly this). Setting the cap via the UI produced a success toast and persisted nothing.

Fix wires the field through all three + adds `TestPackage_Update_PersistsMaxFTPAccounts` to the existing allowlist guard suite.

GH #1053