### PR TITLE
feat(security): quarantine-rate circuit breaker for the malware scanner (JAB-248)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10569,7 +10569,13 @@ MALDET_DROPIN
     {
       echo ""
       echo "# JABALI-DROPIN-BEGIN — managed by install.sh"
-      cat /etc/jabali/maldet/conf.maldet.d/00-jabali.conf
+      # Lexical order, ALL drop-ins: conf.maldet is sourced shell where the
+      # last assignment wins, so 99-jabali-breaker.conf (the JAB-248
+      # quarantine circuit breaker, agent-written) keeps overriding
+      # 00-jabali.conf across every update re-merge.
+      for _dropin in /etc/jabali/maldet/conf.maldet.d/*.conf; do
+        [[ -f "$_dropin" ]] && cat "$_dropin"
+      done
       echo "# JABALI-DROPIN-END"
     } >> "$conf"
     _ok "maldet conf merged with Jabali drop-in"

--- a/panel-agent/internal/commands/security_malware.go
+++ b/panel-agent/internal/commands/security_malware.go
@@ -75,11 +75,11 @@ func validateScanPath(p string) error {
 // ---- security.malware.status -----------------------------------------------
 
 type mwStatusResponse struct {
-	MaldetVersion       string    `json:"maldet_version,omitempty"`
-	MaldetSigVersion    string    `json:"maldet_sig_version,omitempty"`
-	MonitorActive       bool      `json:"monitor_active"`
-	WatchCountConfigured int       `json:"watch_count_configured,omitempty"`
-	WatchCeiling        int       `json:"watch_ceiling,omitempty"`
+	MaldetVersion        string `json:"maldet_version,omitempty"`
+	MaldetSigVersion     string `json:"maldet_sig_version,omitempty"`
+	MonitorActive        bool   `json:"monitor_active"`
+	WatchCountConfigured int    `json:"watch_count_configured,omitempty"`
+	WatchCeiling         int    `json:"watch_ceiling,omitempty"`
 	// YARA engine — yara-x (`yr`) is the maldet 2.0.1 native scanner.
 	// Empty string = no engine binary on PATH (degraded to clamscan).
 	YARAEngineVersion string `json:"yara_engine_version,omitempty"`
@@ -99,6 +99,11 @@ type mwStatusResponse struct {
 	SignatureBaseFiles   int       `json:"signature_base_files,omitempty"`
 	SignatureBaseUpdated time.Time `json:"signature_base_updated,omitempty"`
 	SignatureBasePath    string    `json:"signature_base_path,omitempty"`
+
+	// JAB-248 quarantine circuit breaker. QuarantineEnabled=false means
+	// the breaker is tripped (detect-only) until an operator re-arms it.
+	QuarantineEnabled bool       `json:"quarantine_enabled"`
+	BreakerTrippedAt  *time.Time `json:"breaker_tripped_at,omitempty"`
 }
 
 func mwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
@@ -113,6 +118,12 @@ func mwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	// HEX/MD5/SHA-256 scanner replaces clamscan. No clamav_* status
 	// fields surfaced anymore; UI Overview tile dropped to match.
 	r.MonitorActive = systemctlIsActive(ctx, "jabali-maldet-monitor")
+	if tripped, at := mwBreakerTripped(); tripped {
+		r.QuarantineEnabled = false
+		r.BreakerTrippedAt = &at
+	} else {
+		r.QuarantineEnabled = true
+	}
 	if data, err := os.ReadFile("/proc/sys/fs/inotify/max_user_watches"); err == nil {
 		r.WatchCeiling, _ = strconv.Atoi(strings.TrimSpace(string(data)))
 	}
@@ -482,18 +493,18 @@ func mwMonitorReloadHandler(ctx context.Context, _ json.RawMessage) (any, error)
 // (the wire contract is defined here, panel-api decodes into a matching
 // struct). Per repo convention, types live in the agent commands file.
 type MalwareEventIngest struct {
-	Source     string                 `json:"source"`     // maldet|clamav|yara
-	EventType  string                 `json:"event_type"` // file_hit|process_exec_alert|chmod_suspicious|scan_completed|suspicious_syscall
-	Severity   string                 `json:"severity"`   // info|warn|critical
-	UserID     string                 `json:"user_id,omitempty"`
-	TargetPath string                 `json:"target_path,omitempty"`
-	TargetPID  uint32                 `json:"target_pid,omitempty"`
-	Signature  string                 `json:"signature,omitempty"`
-	SHA256     string                 `json:"sha256,omitempty"`
-	SizeBytes  int64                  `json:"size_bytes,omitempty"`
-	Hits       []MalwareIngestHit     `json:"hits,omitempty"`
-	RawJSON    map[string]any         `json:"raw_json"`
-	OccurredAt time.Time              `json:"occurred_at"`
+	Source     string             `json:"source"`     // maldet|clamav|yara
+	EventType  string             `json:"event_type"` // file_hit|process_exec_alert|chmod_suspicious|scan_completed|suspicious_syscall
+	Severity   string             `json:"severity"`   // info|warn|critical
+	UserID     string             `json:"user_id,omitempty"`
+	TargetPath string             `json:"target_path,omitempty"`
+	TargetPID  uint32             `json:"target_pid,omitempty"`
+	Signature  string             `json:"signature,omitempty"`
+	SHA256     string             `json:"sha256,omitempty"`
+	SizeBytes  int64              `json:"size_bytes,omitempty"`
+	Hits       []MalwareIngestHit `json:"hits,omitempty"`
+	RawJSON    map[string]any     `json:"raw_json"`
+	OccurredAt time.Time          `json:"occurred_at"`
 }
 
 // MalwareIngestHit is one quarantined file from a multi-hit scan session.

--- a/panel-agent/internal/commands/security_malware_breaker.go
+++ b/panel-agent/internal/commands/security_malware_breaker.go
@@ -1,0 +1,150 @@
+package commands
+
+// security.malware.quarantine.set_enabled — the JAB-248 quarantine
+// circuit breaker's actuator.
+//
+// maldet auto-quarantines scanner hits (quarantine_hits=1 in the Jabali
+// drop-in). An overbroad rule — upstream escape or admin upload — turns
+// that into mass movement of legitimate tenant files. The panel's ingest
+// path watches the quarantine rate and calls this verb to flip the
+// scanner to DETECT-ONLY when the rate looks like a rule problem rather
+// than an infection; an operator re-arms it explicitly from the panel.
+// The reconciler never re-arms automatically.
+//
+// State is the filesystem, not the DB (zero migrations, survives panel
+// restarts by construction):
+//   - /etc/jabali/maldet/conf.maldet.d/99-jabali-breaker.conf holds
+//     quarantine_hits="0". install.sh merges conf.maldet.d/*.conf in
+//     lexical order into conf.maldet, so 99- overrides 00-jabali on
+//     every future `jabali update` re-merge.
+//   - The same content is ALSO appended to the live conf.maldet inside
+//     JABALI-BREAKER markers so the flip takes effect NOW, without
+//     waiting for the next update's re-merge. conf.maldet is sourced
+//     shell — the last assignment wins.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// Paths are vars ONLY so tests can point them at a TempDir (the GH #994
+// rule: no test may touch real host state). Production never mutates.
+var (
+	mwBreakerDropin = "/etc/jabali/maldet/conf.maldet.d/99-jabali-breaker.conf"
+	mwMaldetConf    = "/usr/local/maldetect/conf.maldet"
+)
+
+const (
+	mwBreakerBegin   = "# JABALI-BREAKER-BEGIN — quarantine circuit breaker (JAB-248)"
+	mwBreakerEnd     = "# JABALI-BREAKER-END"
+	mwMonitorUnitStr = "jabali-maldet-monitor.service"
+)
+
+type mwQuarantineSetEnabledRequest struct {
+	Enabled bool   `json:"enabled"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type mwQuarantineSetEnabledResponse struct {
+	QuarantineEnabled bool `json:"quarantine_enabled"`
+	Changed           bool `json:"changed"`
+}
+
+// mwRestartMonitor bounces the monitor so the new quarantine mode is
+// live — the daemon caches conf at start. try-restart: only if active
+// (the monitor is admin-opt-in and may deliberately be off). var so
+// tests stub it (GH #994: no test may exec against the real host).
+var mwRestartMonitor = func(ctx context.Context) {
+	_ = exec.CommandContext(ctx, "systemctl", "try-restart", mwMonitorUnitStr).Run()
+}
+
+// mwBreakerTripped reports whether the breaker drop-in exists, and its
+// mtime when it does.
+func mwBreakerTripped() (bool, time.Time) {
+	fi, err := os.Stat(mwBreakerDropin)
+	if err != nil {
+		return false, time.Time{}
+	}
+	return true, fi.ModTime().UTC()
+}
+
+// mwStripBreakerBlock removes the JABALI-BREAKER block from conf.maldet
+// content (no-op when absent).
+func mwStripBreakerBlock(conf string) string {
+	re := regexp.MustCompile("(?s)\n?" + regexp.QuoteMeta(mwBreakerBegin) + ".*?" + regexp.QuoteMeta(mwBreakerEnd) + "\n?")
+	return re.ReplaceAllString(conf, "\n")
+}
+
+func mwQuarantineSetEnabledHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var req mwQuarantineSetEnabledRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return nil, mwInvalidArg("malformed JSON: " + err.Error())
+	}
+	tripped, _ := mwBreakerTripped()
+	changed := false
+
+	if !req.Enabled && !tripped {
+		// TRIP. Reason lands in the conf comment for the operator; keep
+		// it single-line and shell-comment-safe.
+		reason := strings.Map(func(r rune) rune {
+			if r == '\n' || r == '\r' {
+				return ' '
+			}
+			return r
+		}, req.Reason)
+		body := fmt.Sprintf(
+			"# Jabali quarantine circuit breaker (JAB-248) — TRIPPED %s\n"+
+				"# Reason: %s\n"+
+				"# The scanner keeps detecting and reporting; it no longer moves\n"+
+				"# files. Re-arm from /jabali-admin/security?tab=malware after\n"+
+				"# reviewing the rule that caused the spike.\n"+
+				"quarantine_hits=\"0\"\n",
+			time.Now().UTC().Format(time.RFC3339), reason)
+		if err := os.MkdirAll(filepath.Dir(mwBreakerDropin), 0o755); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "mkdir conf.maldet.d: " + err.Error()}
+		}
+		if err := os.WriteFile(mwBreakerDropin, []byte(body), 0o644); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "write breaker drop-in: " + err.Error()}
+		}
+		if conf, err := os.ReadFile(mwMaldetConf); err == nil {
+			next := strings.TrimRight(mwStripBreakerBlock(string(conf)), "\n") +
+				"\n\n" + mwBreakerBegin + "\n" + body + mwBreakerEnd + "\n"
+			if werr := os.WriteFile(mwMaldetConf, []byte(next), 0o644); werr != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "update conf.maldet: " + werr.Error()}
+			}
+		}
+		changed = true
+	}
+
+	if req.Enabled && tripped {
+		// RE-ARM (operator action).
+		if err := os.Remove(mwBreakerDropin); err != nil && !os.IsNotExist(err) {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "remove breaker drop-in: " + err.Error()}
+		}
+		if conf, err := os.ReadFile(mwMaldetConf); err == nil {
+			next := strings.TrimRight(mwStripBreakerBlock(string(conf)), "\n") + "\n"
+			if werr := os.WriteFile(mwMaldetConf, []byte(next), 0o644); werr != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "update conf.maldet: " + werr.Error()}
+			}
+		}
+		changed = true
+	}
+
+	if changed {
+		mwRestartMonitor(ctx)
+	}
+	return mwQuarantineSetEnabledResponse{QuarantineEnabled: req.Enabled, Changed: changed}, nil
+}
+
+func init() {
+	Default.Register("security.malware.quarantine.set_enabled", mwQuarantineSetEnabledHandler)
+}

--- a/panel-agent/internal/commands/security_malware_breaker_test.go
+++ b/panel-agent/internal/commands/security_malware_breaker_test.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// breakerTestEnv points every breaker path at a TempDir and stubs the
+// monitor restart (GH #994: tests never touch real host state).
+func breakerTestEnv(t *testing.T) (dropin, conf string, restarts *int) {
+	t.Helper()
+	dir := t.TempDir()
+	origDropin, origConf, origRestart := mwBreakerDropin, mwMaldetConf, mwRestartMonitor
+	mwBreakerDropin = filepath.Join(dir, "conf.maldet.d", "99-jabali-breaker.conf")
+	mwMaldetConf = filepath.Join(dir, "conf.maldet")
+	n := 0
+	mwRestartMonitor = func(context.Context) { n++ }
+	t.Cleanup(func() {
+		mwBreakerDropin, mwMaldetConf, mwRestartMonitor = origDropin, origConf, origRestart
+	})
+	if err := os.WriteFile(mwMaldetConf, []byte("email_alert=\"0\"\nquarantine_hits=\"1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return mwBreakerDropin, mwMaldetConf, &n
+}
+
+func callBreaker(t *testing.T, enabled bool, reason string) mwQuarantineSetEnabledResponse {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"enabled": enabled, "reason": reason})
+	got, err := mwQuarantineSetEnabledHandler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	return got.(mwQuarantineSetEnabledResponse)
+}
+
+func TestBreaker_TripWritesDropinAndConfBlock(t *testing.T) {
+	dropin, conf, restarts := breakerTestEnv(t)
+
+	resp := callBreaker(t, false, "26 files across 3 users")
+	if !resp.Changed || resp.QuarantineEnabled {
+		t.Fatalf("trip: resp=%+v", resp)
+	}
+	dp, err := os.ReadFile(dropin)
+	if err != nil || !strings.Contains(string(dp), `quarantine_hits="0"`) {
+		t.Fatalf("drop-in missing/wrong: %v %q", err, dp)
+	}
+	cf, _ := os.ReadFile(conf)
+	if !strings.Contains(string(cf), mwBreakerBegin) || !strings.Contains(string(cf), `quarantine_hits="0"`) {
+		t.Fatalf("conf.maldet not updated: %q", cf)
+	}
+	// Shell semantics: the LAST quarantine_hits assignment must be "0".
+	last := ""
+	for _, line := range strings.Split(string(cf), "\n") {
+		if strings.HasPrefix(line, "quarantine_hits=") {
+			last = line
+		}
+	}
+	if last != `quarantine_hits="0"` {
+		t.Fatalf("last quarantine_hits = %q, want the breaker's 0", last)
+	}
+	if *restarts != 1 {
+		t.Fatalf("monitor restarts = %d, want 1", *restarts)
+	}
+}
+
+func TestBreaker_SecondTripIsNoop(t *testing.T) {
+	_, _, restarts := breakerTestEnv(t)
+	callBreaker(t, false, "first")
+	resp := callBreaker(t, false, "second")
+	if resp.Changed {
+		t.Fatal("second trip must answer changed=false (alert dedupe relies on it)")
+	}
+	if *restarts != 1 {
+		t.Fatalf("restarts = %d, want 1 (no bounce on no-op)", *restarts)
+	}
+}
+
+func TestBreaker_RearmRemovesEverything(t *testing.T) {
+	dropin, conf, restarts := breakerTestEnv(t)
+	callBreaker(t, false, "trip")
+	resp := callBreaker(t, true, "re-arm")
+	if !resp.Changed || !resp.QuarantineEnabled {
+		t.Fatalf("re-arm: resp=%+v", resp)
+	}
+	if _, err := os.Stat(dropin); !os.IsNotExist(err) {
+		t.Fatal("drop-in still present after re-arm")
+	}
+	cf, _ := os.ReadFile(conf)
+	if strings.Contains(string(cf), mwBreakerBegin) || strings.Contains(string(cf), `quarantine_hits="0"`) {
+		t.Fatalf("breaker block still in conf.maldet: %q", cf)
+	}
+	if !strings.Contains(string(cf), `quarantine_hits="1"`) {
+		t.Fatalf("original conf content lost: %q", cf)
+	}
+	if *restarts != 2 {
+		t.Fatalf("restarts = %d, want 2", *restarts)
+	}
+}
+
+func TestBreaker_RearmWhenNotTrippedIsNoop(t *testing.T) {
+	_, _, restarts := breakerTestEnv(t)
+	resp := callBreaker(t, true, "")
+	if resp.Changed || *restarts != 0 {
+		t.Fatalf("re-arm of armed breaker must be a no-op: %+v restarts=%d", resp, *restarts)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -1805,6 +1805,28 @@ paths:
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "202": { description: OK } }
 
+  /admin/security/malware/quarantine-mode:
+    put:
+      tags: [Malware]
+      summary: Arm or trip the quarantine circuit breaker (JAB-248)
+      description: >
+        enabled=false flips the scanner to detect-only (files are reported,
+        never moved); enabled=true re-arms auto-quarantine after a breaker
+        trip. The breaker trips automatically on a quarantine-rate spike and
+        is only ever re-armed through this endpoint — never automatically.
+        Current state rides GET /admin/security/malware/status
+        (quarantine_enabled, breaker_tripped_at).
+      security: [ { KratosSession: [] } ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses: { "200": { description: OK } }
+
 
   # --- CrowdSec ---
 

--- a/panel-api/internal/api/security_malware.go
+++ b/panel-api/internal/api/security_malware.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -61,6 +62,10 @@ func RegisterSecurityMalwareRoutes(rg *gin.RouterGroup, cfg SecurityMalwareHandl
 	g.GET("/scan/:id/status", h.scanStatus) // poll fallback when SSE unavailable
 	g.GET("/scan/users", h.listUserScans)   // M33 follow-up: per-user job tracking
 	g.POST("/update-signatures", h.updateSignatures)
+	// JAB-248: quarantine circuit breaker — status rides GET /status;
+	// this toggles quarantine mode (re-arm after a trip, or a manual
+	// preemptive detect-only). The reconciler NEVER re-arms.
+	g.PUT("/quarantine-mode", h.putQuarantineMode)
 	g.GET("/settings", h.getSettings)
 	g.PUT("/settings", h.putSettings)
 
@@ -96,6 +101,37 @@ func (h *securityMalwareHandler) getStatus(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), malwareCallTimeout)
 	defer cancel()
 	raw, err := h.cfg.Agent.Call(ctx, "security.malware.status", map[string]any{})
+	if err != nil {
+		status, body := translateAgentError(err)
+		c.JSON(status, body)
+		return
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
+}
+
+// ---- /quarantine-mode (JAB-248 breaker) ----
+
+type quarantineModeRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+func (h *securityMalwareHandler) putQuarantineMode(c *gin.Context) {
+	var req quarantineModeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "error", "error": "invalid_json"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), malwareCallTimeout)
+	defer cancel()
+	claims := ginctx.Claims(c)
+	reason := "manual toggle by admin"
+	if claims != nil {
+		reason = "manual toggle by admin " + claims.UserID
+	}
+	raw, err := h.cfg.Agent.Call(ctx, "security.malware.quarantine.set_enabled", map[string]any{
+		"enabled": req.Enabled,
+		"reason":  reason,
+	})
 	if err != nil {
 		status, body := translateAgentError(err)
 		c.JSON(status, body)
@@ -644,6 +680,80 @@ func (h *securityMalwareHandler) ingestEvent(c *gin.Context) {
 // loopback /event handler without the Gin layer. M33.2 mailscan tick
 // uses this to skip a self-loopback HTTP hop. Returns (responseBody,
 // httpStatus, errCode) — errCode is empty on success.
+// JAB-248 quarantine circuit breaker thresholds. Within the rolling
+// window, EITHER shape trips detect-only mode:
+//   - many users hit at once → the signature of an overbroad rule
+//     matching common legitimate files (the supply-chain scenario);
+//   - a very large single-user spike → even a real infection at that
+//     volume deserves an operator in the loop before more files move.
+//
+// Consts on purpose (no knob); re-arm is an explicit operator action.
+const (
+	quarantineBreakerWindow       = time.Hour
+	quarantineBreakerMultiUserMin = 25  // total across ≥2 users
+	quarantineBreakerSingleMax    = 100 // total from any mix of users
+)
+
+// maybeTripQuarantineBreaker checks the recent quarantine rate and, when
+// it looks like a rule problem, flips the scanner to detect-only via the
+// agent and records a synthetic critical event (which the notification
+// drain turns into an admin alert). Trip FIRST, notify second — a failed
+// notification must not leave quarantine armed. Idempotent: the agent
+// answers changed=false when already tripped, and only changed=true
+// inserts the alert event.
+func maybeTripQuarantineBreaker(ctx context.Context, cfg SecurityMalwareHandlerConfig, source string) {
+	if cfg.Quarantine == nil || cfg.Agent == nil {
+		return
+	}
+	total, users, err := cfg.Quarantine.CountRecent(ctx, time.Now().UTC().Add(-quarantineBreakerWindow))
+	if err != nil {
+		if cfg.Log != nil {
+			cfg.Log.Warn("malware: breaker rate check failed", "err", err)
+		}
+		return
+	}
+	multiUser := users >= 2 && total >= quarantineBreakerMultiUserMin
+	bulk := total >= quarantineBreakerSingleMax
+	if !multiUser && !bulk {
+		return
+	}
+	reason := fmt.Sprintf("%d files quarantined across %d users within %s", total, users, quarantineBreakerWindow)
+	raw, aerr := cfg.Agent.Call(ctx, "security.malware.quarantine.set_enabled", map[string]any{
+		"enabled": false,
+		"reason":  reason,
+	})
+	if aerr != nil {
+		if cfg.Log != nil {
+			cfg.Log.Error("malware: breaker trip FAILED — quarantine still armed", "reason", reason, "err", aerr)
+		}
+		return
+	}
+	var resp struct {
+		Changed bool `json:"changed"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	if !resp.Changed {
+		return // already tripped — alert was sent on the first trip
+	}
+	if cfg.Log != nil {
+		cfg.Log.Error("malware: quarantine circuit breaker TRIPPED — scanner is detect-only until re-armed", "reason", reason)
+	}
+	sig := "jabali.quarantine_breaker"
+	msg := "Quarantine circuit breaker tripped: " + reason +
+		". The malware scanner keeps detecting but no longer moves files. Review recent signature changes, then re-arm quarantine from Security → Malware."
+	alert := &models.MalwareEvent{
+		ID:         ids.NewULID(),
+		EventType:  "quarantine_breaker_tripped",
+		Source:     source,
+		Severity:   models.MalwareSeverityCritical,
+		Signature:  &sig,
+		TargetPath: &msg,
+	}
+	if err := cfg.Events.Create(ctx, alert); err != nil && cfg.Log != nil {
+		cfg.Log.Warn("malware: breaker alert event insert failed", "err", err)
+	}
+}
+
 func IngestMalwareEventInProcess(ctx context.Context, cfg SecurityMalwareHandlerConfig, p *MalwareEventIngestPayload) (any, int, string) {
 	if p.Source == "" || p.EventType == "" {
 		return nil, http.StatusBadRequest, "source_and_event_type_required"
@@ -779,6 +889,12 @@ func IngestMalwareEventInProcess(ctx context.Context, cfg SecurityMalwareHandler
 				cfg.Log.Warn("malware: finalise user scan failed", "path", scanPath, "err", err)
 			}
 		}
+	}
+
+	// JAB-248: quarantine-rate circuit breaker — only quarantining
+	// ingests move the needle.
+	if len(p.Hits) > 0 {
+		maybeTripQuarantineBreaker(ctx, cfg, p.Source)
 	}
 
 	return map[string]any{

--- a/panel-api/internal/api/security_malware_breaker_test.go
+++ b/panel-api/internal/api/security_malware_breaker_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeQuarantineRepo struct {
+	repository.MalwareQuarantineRepository
+	total, users int64
+}
+
+func (f *fakeQuarantineRepo) CountRecent(context.Context, time.Time) (int64, int64, error) {
+	return f.total, f.users, nil
+}
+
+type fakeEventsRepo struct {
+	repository.MalwareEventRepository
+	created []*models.MalwareEvent
+}
+
+func (f *fakeEventsRepo) Create(_ context.Context, ev *models.MalwareEvent) error {
+	f.created = append(f.created, ev)
+	return nil
+}
+
+type fakeBreakerAgent struct {
+	calls   []string
+	changed bool
+	err     error
+}
+
+func (f *fakeBreakerAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	f.calls = append(f.calls, cmd)
+	if f.err != nil {
+		return nil, f.err
+	}
+	b, _ := json.Marshal(map[string]any{"quarantine_enabled": false, "changed": f.changed})
+	return b, nil
+}
+
+func breakerCfg(q *fakeQuarantineRepo, ev *fakeEventsRepo, ag *fakeBreakerAgent) SecurityMalwareHandlerConfig {
+	return SecurityMalwareHandlerConfig{Agent: ag, Quarantine: q, Events: ev}
+}
+
+// JAB-248: below both thresholds → the agent is never touched.
+func TestBreaker_BelowThresholdNoTrip(t *testing.T) {
+	ag := &fakeBreakerAgent{}
+	maybeTripQuarantineBreaker(context.Background(),
+		breakerCfg(&fakeQuarantineRepo{total: 10, users: 5}, &fakeEventsRepo{}, ag), "maldet")
+	if len(ag.calls) != 0 {
+		t.Fatalf("agent called below threshold: %v", ag.calls)
+	}
+}
+
+// JAB-248: many users + moderate volume = overbroad-rule signature → trip
+// + one critical alert event.
+func TestBreaker_MultiUserTripsAndAlerts(t *testing.T) {
+	ag := &fakeBreakerAgent{changed: true}
+	ev := &fakeEventsRepo{}
+	maybeTripQuarantineBreaker(context.Background(),
+		breakerCfg(&fakeQuarantineRepo{total: 26, users: 3}, ev, ag), "maldet")
+	if len(ag.calls) != 1 || ag.calls[0] != "security.malware.quarantine.set_enabled" {
+		t.Fatalf("agent calls: %v", ag.calls)
+	}
+	if len(ev.created) != 1 || ev.created[0].Severity != models.MalwareSeverityCritical ||
+		ev.created[0].EventType != "quarantine_breaker_tripped" {
+		t.Fatalf("alert event wrong: %+v", ev.created)
+	}
+}
+
+// JAB-248: single-user volume below the bulk line does NOT trip (one
+// infected tenant is normal scanner work, not a rule problem).
+func TestBreaker_SingleUserModerateNoTrip(t *testing.T) {
+	ag := &fakeBreakerAgent{}
+	maybeTripQuarantineBreaker(context.Background(),
+		breakerCfg(&fakeQuarantineRepo{total: 60, users: 1}, &fakeEventsRepo{}, ag), "maldet")
+	if len(ag.calls) != 0 {
+		t.Fatalf("agent called for single-user moderate volume: %v", ag.calls)
+	}
+}
+
+// JAB-248: bulk volume trips regardless of user spread.
+func TestBreaker_BulkTrips(t *testing.T) {
+	ag := &fakeBreakerAgent{changed: true}
+	ev := &fakeEventsRepo{}
+	maybeTripQuarantineBreaker(context.Background(),
+		breakerCfg(&fakeQuarantineRepo{total: 150, users: 1}, ev, ag), "maldet")
+	if len(ag.calls) != 1 || len(ev.created) != 1 {
+		t.Fatalf("bulk trip: calls=%v events=%d", ag.calls, len(ev.created))
+	}
+}
+
+// JAB-248: already tripped (agent answers changed=false) → no duplicate
+// alert event.
+func TestBreaker_AlreadyTrippedNoDuplicateAlert(t *testing.T) {
+	ag := &fakeBreakerAgent{changed: false}
+	ev := &fakeEventsRepo{}
+	maybeTripQuarantineBreaker(context.Background(),
+		breakerCfg(&fakeQuarantineRepo{total: 200, users: 4}, ev, ag), "maldet")
+	if len(ev.created) != 0 {
+		t.Fatalf("duplicate alert on already-tripped breaker: %+v", ev.created)
+	}
+}

--- a/panel-api/internal/repository/malware_quarantine_repository.go
+++ b/panel-api/internal/repository/malware_quarantine_repository.go
@@ -21,9 +21,27 @@ type MalwareQuarantineRepository interface {
 	Restore(ctx context.Context, id, restoredBy, reason string) error
 	MarkDeleted(ctx context.Context, id string) error
 	PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+	// CountRecent (JAB-248 breaker): quarantine rows created since the
+	// cutoff — total and distinct affected users. Deleted/restored rows
+	// still count: the breaker measures quarantine RATE, not residue.
+	CountRecent(ctx context.Context, since time.Time) (total int64, users int64, err error)
 }
 
 type malwareQuarantineRepo struct{ db *gorm.DB }
+
+func (r *malwareQuarantineRepo) CountRecent(ctx context.Context, since time.Time) (int64, int64, error) {
+	var total, users int64
+	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
+		Where("created_at >= ?", since).Count(&total).Error; err != nil {
+		return 0, 0, translate(err)
+	}
+	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
+		Where("created_at >= ?", since).
+		Distinct("COALESCE(user_id, '')").Count(&users).Error; err != nil {
+		return 0, 0, translate(err)
+	}
+	return total, users, nil
+}
 
 // NewMalwareQuarantineRepository returns a GORM-backed quarantine repo.
 func NewMalwareQuarantineRepository(db *gorm.DB) MalwareQuarantineRepository {

--- a/panel-ui/src/hooks/useSecurityMalware.ts
+++ b/panel-ui/src/hooks/useSecurityMalware.ts
@@ -25,6 +25,10 @@ export interface MalwareStatus {
   rfxn_rules_updated?: string;
   rfxn_rules_path?: string;
   signature_base_present: boolean;
+  // JAB-248 quarantine circuit breaker. false = tripped (detect-only)
+  // until an operator re-arms via PUT /quarantine-mode.
+  quarantine_enabled: boolean;
+  breaker_tripped_at?: string;
   signature_base_files?: number;
   signature_base_updated?: string;
   signature_base_path?: string;
@@ -120,6 +124,19 @@ export function useMalwareQuarantine(page = 1, pageSize = 50) {
       return data;
     },
     refetchInterval: 30_000,
+  });
+}
+
+export function useSetQuarantineMode() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (enabled: boolean) => {
+      const { data } = await apiClient.put(`${BASE}/quarantine-mode`, { enabled });
+      return data;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["security", "malware", "status"] });
+    },
   });
 }
 

--- a/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
+++ b/panel-ui/src/shells/admin/security/AdminSecurityMalware.tsx
@@ -56,6 +56,7 @@ import {
   useUpdateMalwareSignatures,
   useUploadYARARule,
   useYARARules,
+  useSetQuarantineMode,
 } from "../../../hooks/useSecurityMalware";
 
 const SCANNER_COLOR: Record<MalwareScanner, string> = {
@@ -115,6 +116,7 @@ function OverviewCard() {
   const { data, isLoading } = useMalwareStatus();
   const { data: settings } = useMalwareSettings();
   const updateSigs = useUpdateMalwareSignatures();
+  const setQuarantineMode = useSetQuarantineMode();
 
   if (isLoading || !data) {
     return <Typography.Text type="secondary">Loading…</Typography.Text>;
@@ -153,6 +155,31 @@ function OverviewCard() {
           showIcon
           message={t("adminsecuritymalware.real_time_scanning_is_off")}
           description={t("adminsecuritymalware.the_inotify_monitor_is_not_running_daily_sch")}
+        />
+      )}
+
+      {data.quarantine_enabled === false && (
+        <Alert
+          type="error"
+          showIcon
+          message="Quarantine circuit breaker tripped — scanner is detect-only"
+          description={`Auto-quarantine was disabled after a quarantine-rate spike${data.breaker_tripped_at ? ` at ${new Date(data.breaker_tripped_at).toLocaleString()}` : ""}. Files keep getting detected and reported, but nothing is moved. Review recent signature changes and quarantine events, then re-arm.`}
+          action={
+            <Popconfirm
+              title="Re-arm auto-quarantine?"
+              description="Only re-arm after confirming the spike was not an overbroad rule."
+              onConfirm={() =>
+                setQuarantineMode.mutate(true, {
+                  onSuccess: () => feedback.message.success("Auto-quarantine re-armed"),
+                  onError: () => feedback.message.error("Re-arm failed"),
+                })
+              }
+            >
+              <Button danger size="small" loading={setQuarantineMode.isPending}>
+                Re-arm quarantine
+              </Button>
+            </Popconfirm>
+          }
         />
       )}
 


### PR DESCRIPTION
## Summary
JAB-248's runtime backstop: the **quarantine-rate circuit breaker**. The signature pin (#1106) closed the unreviewed supply-chain path; this closes the "overbroad rule inside a reviewed pin / admin-uploaded rule" scenario — mass quarantine of legitimate tenant files becomes an operator alert instead of a tenant-data incident.

### Trigger (panel, on every quarantining ingest)
Rolling 1-hour window over `malware_quarantines`:
- **≥25 quarantines across ≥2 distinct users** — the overbroad-rule signature (many tenants at once), or
- **≥100 total** — even a real infection at that volume deserves an operator in the loop.

Trip **first**, notify second — a failed notification never leaves quarantine armed. The alert is a synthetic critical `malware_event` riding the existing notification drain; the agent's `changed=false` reply dedupes repeat alerts while tripped.

### Actuator (agent, new verb `security.malware.quarantine.set_enabled`)
State is the **filesystem, not the DB** (zero migrations, survives panel restarts): `conf.maldet.d/99-jabali-breaker.conf` with `quarantine_hits="0"` + a marker block appended to the live `conf.maldet` (sourced shell — last assignment wins), monitor `try-restart`. `install.sh`'s conf merge now cats `conf.maldet.d/*.conf` in lexical order, so the breaker **survives every `jabali update` re-merge** (99- sorts after 00-jabali). Re-arm is an explicit operator action — nothing ever re-arms automatically.

### Surface
- `GET /admin/security/malware/status` gains `quarantine_enabled` + `breaker_tripped_at` (flows through the existing raw proxy).
- New `PUT /admin/security/malware/quarantine-mode` (openapi documented) — re-arm, or manual preemptive detect-only.
- Admin Malware overview shows a critical alert with a Popconfirm'd **Re-arm quarantine** button while tripped.

### Threshold rationale
Consts, no knob. The two-user clause distinguishes "one infected tenant" (normal scanner work — deliberately does NOT trip, pinned by test) from "rule matching everyone's files".

## Test plan
- [x] Agent: trip writes drop-in + conf block with `quarantine_hits="0"` LAST (shell semantics pinned); second trip `changed=false`, no monitor bounce; re-arm removes everything, restores original conf; re-arm-when-armed no-op. All against TempDir + stubbed systemctl (GH #994 rule)
- [x] Panel: below-threshold → agent untouched; multi-user trip → agent called + one critical alert; single-user moderate → no trip; bulk → trip; already-tripped → no duplicate alert
- [x] install.sh: bash -n + phantom lint + full install/tests suite
- [x] panel-ui: tsc + vite build, 235/235 vitest
- [x] Full Go suites: 0 FAIL
- [ ] CI
- [ ] Post-merge live smoke on testserver: seed >100 EICAR files, `scan_path`, breaker trips through the real hook→ingest→agent path; re-arm via the new endpoint

JAB-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)
