### PR TITLE
fix(invoiceshelf): idempotent reinstall — pre-clean stale artifacts + merge-flatten (GH #1042)

### DIFF
--- a/panel-agent/internal/commands/invoiceshelf_install.go
+++ b/panel-agent/internal/commands/invoiceshelf_install.go
@@ -150,6 +150,27 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 	if err := os.Chmod(zipPath, 0o644); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chmod zip: %v", err)}
 	}
+	// Idempotent reinstall (GH #1042): a prior FAILED install — or an
+	// incomplete delete from before the delete list was completed — can leave
+	// app artifacts at installPath, and the move-up / flatten `mv` steps then
+	// die "cannot overwrite '…': Directory not empty" (johnnyq hit this on
+	// `favicons`, then would hit it again on `app/` at the move-up). The panel
+	// refuses installing over an ACTIVE install (409 install_exists), and a
+	// reinstall always follows a delete, so any leftover here is dead garbage
+	// from a failed/half-deleted attempt — never live data. Clear the known
+	// app entries (plus a stale staging dir) first so the extract + move +
+	// flatten always land on a clean slate. Same top-level set the delete
+	// handler enumerates; rm -rf on a missing path is a harmless no-op.
+	cleanTargets := make([]string, 0, len(invoiceshelfTopLevel)+1)
+	cleanTargets = append(cleanTargets, shellQuote(filepath.Join(installPath, "InvoiceShelf")))
+	for _, e := range invoiceshelfTopLevel {
+		cleanTargets = append(cleanTargets, shellQuote(filepath.Join(installPath, e)))
+	}
+	preClean := "rm -rf " + strings.Join(cleanTargets, " ")
+	if out, err := runBoundedOutput(buildSystemdRunShell(ctx, req.OSUser, preClean), 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("pre-clean stale install: %v (%s)", err, truncateStr(string(out), 512))}
+	}
+
 	// unzip has no --strip-components; extract then move InvoiceShelf/* up.
 	if out, err := runBoundedOutput(buildSystemdRunCmd(ctx, req.OSUser, "unzip", "-q", "-o", zipPath, "-d", installPath), 0); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unzip: %v (%s)", err, truncateStr(string(out), 512))}
@@ -159,8 +180,17 @@ func invoiceshelfInstallHandler(ctx context.Context, params json.RawMessage) (an
 	if out, err := runBoundedOutput(buildSystemdRunShell(ctx, req.OSUser, moveUp), 0); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("relocate app root: %v (%s)", err, truncateStr(string(out), 512))}
 	}
-	// Flatten public/ into the webroot (no-public-dir shape).
-	flatten := "shopt -s dotglob nullglob; mv " + shellQuote(filepath.Join(installPath, "public")) + "/* " + shellQuote(installPath) + "/ && rmdir " + shellQuote(filepath.Join(installPath, "public"))
+	// Flatten public/ into the webroot (no-public-dir shape). Use a
+	// merge-copy, not `mv public/*`: on a reinstall after a partial failure a
+	// stale asset dir (e.g. favicons/) can already sit at the webroot, and
+	// `mv` refuses to overwrite a non-empty directory — so the retry died at
+	// "flatten public/: mv: cannot overwrite '.../favicons': Directory not
+	// empty" (GH #1042). `cp -a public/.` merges the fresh assets over any
+	// leftover (overwriting files, recursing into existing dirs) and then drops
+	// public/, so the flatten is idempotent without needing a manual delete
+	// first. Deliberately does NOT wipe the webroot — a real reinstall keeps
+	// the tenant's storage/ (uploaded invoices) intact.
+	flatten := "cp -a " + shellQuote(filepath.Join(installPath, "public")) + "/. " + shellQuote(installPath) + "/ && rm -rf " + shellQuote(filepath.Join(installPath, "public"))
 	if out, err := runBoundedOutput(buildSystemdRunShell(ctx, req.OSUser, flatten), 0); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("flatten public/: %v (%s)", err, truncateStr(string(out), 512))}
 	}


### PR DESCRIPTION
@johnnyq's InvoiceShelf reinstall kept failing at `flatten public/: mv: cannot overwrite '.../favicons': Directory not empty` (comment-5300274653), and — since his docroot already holds the full app from the attempt that got as far as flatten — his **next** retry would fail the same way one step earlier, at the move-up on `app/`.

## Root cause

A prior **failed** install (or a delete from before the delete list was completed in #1086) leaves app files at the install path. The install's `mv InvoiceShelf/* .` (move-up) and `mv public/*` (flatten) both refuse to overwrite a non-empty directory, so the retry aborts.

The panel refuses installing over an **active** install (409 `install_exists`) and a reinstall always follows a delete, so **any leftover at the install path is dead garbage from a failed/half-deleted attempt — never live data.**

## Fix (make the install idempotent)

1. **Pre-clean** before extracting: `rm -rf` the known app top-level entries (the same set `invoiceshelfTopLevel` — the delete handler — enumerates) plus a stale staging dir, so extract + move-up + flatten always land on a clean slate. `rm -rf` on a missing path is a no-op, so a **first-time install is unaffected**.
2. **Flatten via `cp -a public/. <root>/ && rm -rf public`** instead of `mv public/*` — merges over any residual asset dir rather than aborting (belt-and-suspenders on top of the pre-clean; also covers a future zip adding a public asset the delete list hasn't learned).

Neither wipes the webroot wholesale; neither touches user data (there is none to touch, per the `install_exists` guard). Only the pre-unzip clean and the flatten op change — finalise receives the identical flattened layout, so it's unaffected.

## Verification

- Local: reproduced the exact `mv: … Directory not empty` with the old command; new `cp -a` succeeds.
- **On a test server, reproduced @johnnyq's exact state** (full app moved up + top-level `favicons/` + stale `public/favicons`) and ran the real agent sequence: pre-clean → extract → move-up (`mv`, exit 0) → flatten (`cp -a`, exit 0). Final layout correct, stale files gone, `public/` + staging dir removed. No `Directory not empty` at any step.

GH #1042