### PR TITLE
fix(backup): retention cap counts RETAINED backups, not every job row ever (GH #1045)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -1707,8 +1707,11 @@ func (h *meBackupHandler) create(c *gin.Context) {
 			return
 		}
 		// Retention cap. On a count error, fail closed (deny) rather than risk
-		// letting a tenant exceed max_backups.
-		_, total, terr := h.cfg.Jobs.ListForUser(c.Request.Context(), user.ID, 1, 0)
+		// letting a tenant exceed max_backups. RETAINED backups only —
+		// failed/cancelled attempts and restores never consume the cap
+		// (GH #1045: counting every row ever locked tenants out of both
+		// manual and scheduled backups once early failures piled up).
+		total, terr := h.cfg.Jobs.CountRetainedForUser(c.Request.Context(), user.ID)
 		if terr != nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "error": "backup_gating_unavailable", "detail": "backup count cannot be resolved right now"})
 			return

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -452,7 +452,7 @@ func (s *Scheduler) atOrOverCap(ctx context.Context, userID string, maxBackups i
 	// COUNT only. This used to call ListForUser(userID, 1, 0), which runs a
 	// COUNT(*) *and* a LIMIT 1 SELECT just to read the total — paid once per
 	// (user, destination) pair inside the 60s enqueue tick.
-	total, err := s.deps.Jobs.CountForUser(ctx, userID)
+	total, err := s.deps.Jobs.CountRetainedForUser(ctx, userID)
 	if err != nil {
 		return false
 	}

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -42,7 +42,9 @@ func (f *fakeBackupJobs) CountByStatus(context.Context, string) (int64, error) {
 func (f *fakeBackupJobs) ListRunning(context.Context, int) ([]models.BackupJob, error) {
 	return nil, nil
 }
-func (f *fakeBackupJobs) CountForUser(context.Context, string) (int64, error) { return 0, nil }
+func (f *fakeBackupJobs) CountRetainedForUser(context.Context, string) (int64, error) {
+	return 0, nil
+}
 func (f *fakeBackupJobs) ListQueuedOldest(context.Context, int) ([]models.BackupJob, error) {
 	return nil, nil
 }

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -50,9 +50,16 @@ type BackupJobRepository interface {
 	// loses the oldest-created running jobs of a big fan-out, which then
 	// wedge the queue permanently. See the method comment.
 	ListRunning(ctx context.Context, limit int) ([]models.BackupJob, error)
-	// CountForUser counts a user's jobs for the retention cap without
+	// CountRetainedForUser counts the user's RETAINED account backups for
+	// the retention cap: kind=account_backup in a live status (queued,
+	// running, succeeded, partial). Failed and cancelled attempts and
+	// restores of ANY status do NOT consume the cap — counting every row
+	// ever (the original behaviour) permanently ate the allowance: a tenant
+	// whose early attempts failed crossed the cap without owning a single
+	// snapshot, and every scheduled backup silently rejected forever
+	// (GH #1045, mrlp57's "scheduled backups never fire").
 	// materialising rows.
-	CountForUser(ctx context.Context, userID string) (int64, error)
+	CountRetainedForUser(ctx context.Context, userID string) (int64, error)
 
 	// Run grouping — admin UI rolls scheduler-fired jobs under one
 	// header per run_id. ListRuns aggregates jobs that share a run_id;
@@ -157,7 +164,10 @@ func (r *backupJobRepo) ListForUser(ctx context.Context, userID string, limit, o
 func (r *backupJobRepo) OldestAccountBackupForUser(ctx context.Context, userID string) (*models.BackupJob, error) {
 	var out models.BackupJob
 	err := r.db.WithContext(ctx).
-		Where("user_id = ? AND kind = ?", userID, models.BackupJobKindAccountBackup).
+		// Status filter matches CountRetainedForUser: pruning a FAILED row
+		// would free no cap headroom and loop the prune path.
+		Where("user_id = ? AND kind = ? AND status IN ?", userID, models.BackupJobKindAccountBackup,
+			[]string{models.BackupJobStatusSucceeded, models.BackupJobStatusPartial}).
 		Order("created_at ASC").
 		First(&out).Error
 	if err != nil {
@@ -333,15 +343,19 @@ func (r *backupJobRepo) ListRunning(ctx context.Context, limit int) ([]models.Ba
 	return out, nil
 }
 
-// CountForUser counts a user's jobs without materialising any rows. The
+// CountRetainedForUser counts retained account backups without
+// materialising rows. The
 // retention cap check used ListForUser(userID, 1, 0), which runs a COUNT(*)
 // AND a LIMIT 1 SELECT purely to read the total — once per (user,
 // destination) pair inside the enqueue tick.
-func (r *backupJobRepo) CountForUser(ctx context.Context, userID string) (int64, error) {
+func (r *backupJobRepo) CountRetainedForUser(ctx context.Context, userID string) (int64, error) {
 	var n int64
 	err := r.db.WithContext(ctx).
 		Model(&models.BackupJob{}).
-		Where("user_id = ?", userID).
+		Where("user_id = ? AND kind = ? AND status IN ?", userID,
+			models.BackupJobKindAccountBackup,
+			[]string{models.BackupJobStatusQueued, models.BackupJobStatusRunning,
+				models.BackupJobStatusSucceeded, models.BackupJobStatusPartial}).
 		Count(&n).Error
 	if err != nil {
 		return 0, translate(err)

--- a/panel-api/internal/repository/backup_job_repository_test.go
+++ b/panel-api/internal/repository/backup_job_repository_test.go
@@ -135,3 +135,43 @@ func TestBackupJobRepository_ListByStatusSince_ZeroLimitDefaults(t *testing.T) {
 // silence unused-imports warnings on the time package if other tests
 // later drop their reference.
 var _ = errors.New
+
+// GH #1045 (mrlp57): the retention-cap count must see only RETAINED account
+// backups. The old CountForUser counted every job row ever — failed attempts,
+// cancelled runs, restores — so early failures permanently consumed the cap
+// and every scheduled backup silently rejected ("scheduled backups never
+// fire, only manual"). Pin the WHERE shape.
+func TestBackupJob_CountRetainedForUser_FiltersKindAndStatus(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupJobRepository(db)
+
+	mock.ExpectQuery(`SELECT count\(\*\) FROM .backup_jobs. WHERE user_id = \? AND kind = \? AND status IN \(\?,\?,\?,\?\)`).
+		WithArgs("userA", models.BackupJobKindAccountBackup,
+			models.BackupJobStatusQueued, models.BackupJobStatusRunning,
+			models.BackupJobStatusSucceeded, models.BackupJobStatusPartial).
+		WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).AddRow(2))
+
+	n, err := repo.CountRetainedForUser(context.Background(), "userA")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, n)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Prune must target the oldest RETAINED backup — forgetting a failed row
+// frees no cap headroom and would loop the prune path.
+func TestBackupJob_OldestAccountBackup_RetainedOnly(t *testing.T) {
+	db, mock, raw := newMockBackupDB(t)
+	defer raw.Close()
+	repo := NewBackupJobRepository(db)
+
+	mock.ExpectQuery(`SELECT \* FROM .backup_jobs. WHERE user_id = \? AND kind = \? AND status IN \(\?,\?\)`).
+		WithArgs("userA", models.BackupJobKindAccountBackup,
+			models.BackupJobStatusSucceeded, models.BackupJobStatusPartial, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id"}).AddRow("j1", "userA"))
+
+	j, err := repo.OldestAccountBackupForUser(context.Background(), "userA")
+	require.NoError(t, err)
+	require.Equal(t, "j1", j.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}


### PR DESCRIPTION
Root cause of @mrlp57's **"scheduled backups never fire, only manual"** (GH #1045).

Both retention-cap gates counted the tenant's **entire `backup_jobs` history** — failed attempts, cancelled runs, restores, everything. Early failures (e.g. the #1045 download 500s before #1090/#1093) permanently consumed the cap: the window-governed scheduler then **silently rejected every run** (`scheduled backup skipped: retention cap reached`), and manual creates eventually 403'd — while the tenant owned zero actual snapshots.

## Fix
- `CountForUser` → **`CountRetainedForUser`**: `kind=account_backup AND status IN (queued, running, succeeded, partial)`. Failed/cancelled attempts and restores never consume the cap.
- The on-demand gate (previously an unfiltered `ListForUser` total) switches to the same method — one source of truth for both paths.
- `OldestAccountBackupForUser` (the prune-policy target) now selects retained rows only — forgetting a FAILED row freed no headroom and would loop the prune path.
- sqlmock shape tests pin both WHERE clauses; full panel-api suite green.

GH #1045