### PR TITLE
feat(security): enforce the package disk quota on tenant database storage (JAB-243)

### DIFF
--- a/panel-agent/internal/commands/db_usage.go
+++ b/panel-agent/internal/commands/db_usage.go
@@ -1,0 +1,65 @@
+package commands
+
+// db.usage.by_schema — one information_schema pass returning every
+// schema's on-disk footprint (JAB-243). The panel's DB-quota enforcement
+// sweep needs authoritative per-database sizes; querying through the
+// panel's own scoped connection would silently under-report (a schema
+// the panel user can't see simply vanishes from information_schema), so
+// the root-privileged agent answers instead — one query for the whole
+// host, not one call per database.
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+type dbUsageSchema struct {
+	Schema string `json:"schema"`
+	Bytes  int64  `json:"bytes"`
+}
+
+type dbUsageBySchemaResponse struct {
+	Schemas []dbUsageSchema `json:"schemas"`
+}
+
+// dbUsageSystemSchemas are never tenant data — excluded from the reply.
+var dbUsageSystemSchemas = map[string]bool{
+	"information_schema": true,
+	"performance_schema": true,
+	"mysql":              true,
+	"sys":                true,
+}
+
+func dbUsageBySchemaHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	// data_length+index_length lags a little behind reality (InnoDB
+	// persistent stats), which is fine for quota enforcement — the
+	// consumer applies hysteresis anyway.
+	out, err := exec.CommandContext(ctx, "mysql", "-N", "-e",
+		"SELECT table_schema, COALESCE(SUM(data_length+index_length),0) FROM information_schema.tables GROUP BY table_schema",
+	).Output()
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "information_schema query failed: " + err.Error()}
+	}
+	resp := dbUsageBySchemaResponse{Schemas: []dbUsageSchema{}}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || dbUsageSystemSchemas[fields[0]] {
+			continue
+		}
+		n, perr := strconv.ParseInt(fields[1], 10, 64)
+		if perr != nil {
+			continue
+		}
+		resp.Schemas = append(resp.Schemas, dbUsageSchema{Schema: fields[0], Bytes: n})
+	}
+	return resp, nil
+}
+
+func init() {
+	Default.Register("db.usage.by_schema", dbUsageBySchemaHandler)
+}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -370,6 +370,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		// M13.1.1: bandwidth quota auto-suspend. Wires bw_daily repo +
 		// notifications queue so reconcileBandwidthQuotaEnforce can run.
 		rec.WithBandwidthQuotaEnforce(repository.NewBWDailyRepository(sharedDB), deps.NotificationQueue)
+		// JAB-243: DB storage quota enforcement (write-freeze at package
+		// quota, hourly sweep inside the reconciler).
+		rec.WithDBQuotaEnforce(
+			repository.NewDatabaseRepository(sharedDB),
+			repository.NewDatabaseUserRepository(sharedDB),
+			repository.NewDatabaseUserGrantRepository(sharedDB),
+		)
 		// M47 Wave 3 throttle reconcile — needs both repo + Stalwart CUD client.
 		if sc, ok := deps.StalwartAdmin.(*stalwartadmin.Client); ok {
 			rec.WithMailThrottles(mailOutboundPolicyRepo, sc)

--- a/panel-api/internal/reconciler/db_quota_enforce.go
+++ b/panel-api/internal/reconciler/db_quota_enforce.go
@@ -1,0 +1,244 @@
+// JAB-243 — DB storage quota enforcement (the enforceable subset).
+//
+// Tenant database files live under /var/lib/mysql, outside every POSIX
+// quota, so package disk limits never bounded them. A true hard cap
+// needs per-tenant tablespaces / project-quota filesystems (tracked on
+// the ticket); what IS enforceable today is the classic hosting
+// pattern: when a tenant's summed DB footprint reaches the package disk
+// quota, revoke the WRITE privileges on their database users — SELECT,
+// DELETE and DROP stay, so the tenant can read and free space — and
+// restore the owner-intended grants once usage drops below 90%
+// (hysteresis: a tenant sitting exactly at quota must not flap grants
+// every sweep).
+//
+// Desired-state reconciliation, grants are the state (per-tick
+// idempotency rule): every sweep computes over/under from live sizes
+// and applies the matching grant set. The restore path re-applies the
+// grant ROW's stored level — a deliberately read-only db user is never
+// promoted to rw by the quota loop (intersection of owner intent and
+// quota permission).
+//
+// MariaDB only: PostgreSQL's grant model has no privilege-list revoke
+// that keeps SELECT (db.postgres.revoke is all-or-nothing) — a pg
+// write-freeze is part of the hard-cap follow-up on the ticket. pg
+// database sizes are likewise excluded from the enforcement sum so an
+// over-quota pg footprint cannot freeze a tenant's mariadb writes the
+// tenant can't fix by deleting mariadb rows.
+//
+// The in-memory edge map only dedupes notifications; a panel restart
+// re-detects the edge and re-applies idempotent grants (harmless) with
+// at most one repeat notification per over-quota tenant.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+const (
+	dbQuotaEnforceInterval = time.Hour
+	dbQuotaRestorePercent  = 90.0
+)
+
+// dbQuotaWriteRevoke is the privilege set removed at quota. SELECT,
+// DELETE and DROP deliberately survive — the tenant must be able to
+// read their data and free space to get back under.
+var dbQuotaWriteRevoke = []string{"INSERT", "UPDATE", "CREATE", "ALTER", "INDEX"}
+
+// WithDBQuotaEnforce wires the JAB-243 DB-quota sweep. All three repos
+// required; nil on any disables the loop.
+func (r *Reconciler) WithDBQuotaEnforce(dbs repository.DatabaseRepository, dbUsers repository.DatabaseUserRepository, grants repository.DatabaseUserGrantRepository) *Reconciler {
+	r.databases = dbs
+	r.databaseUsers = dbUsers
+	r.databaseGrants = grants
+	return r
+}
+
+// reconcileDBQuotaEnforce is the hourly sweep. Cheap noop when disabled.
+func (r *Reconciler) reconcileDBQuotaEnforce(ctx context.Context) {
+	if r.databases == nil || r.databaseUsers == nil || r.databaseGrants == nil ||
+		r.users == nil || r.packages == nil || r.agent == nil {
+		return
+	}
+	r.dbQuotaEnforceMu.Lock()
+	if !r.dbQuotaEnforceLastRun.IsZero() && time.Since(r.dbQuotaEnforceLastRun) < dbQuotaEnforceInterval {
+		r.dbQuotaEnforceMu.Unlock()
+		return
+	}
+	r.dbQuotaEnforceLastRun = time.Now()
+	if r.dbQuotaOver == nil {
+		r.dbQuotaOver = make(map[string]bool)
+	}
+	r.dbQuotaEnforceMu.Unlock()
+
+	// One agent call for every schema size on the host.
+	raw, err := r.agent.Call(ctx, "db.usage.by_schema", map[string]any{})
+	if err != nil {
+		r.log.Warn("db_quota_enforce: usage query failed", "err", err)
+		return
+	}
+	var usage struct {
+		Schemas []struct {
+			Schema string `json:"schema"`
+			Bytes  int64  `json:"bytes"`
+		} `json:"schemas"`
+	}
+	if err := json.Unmarshal(raw, &usage); err != nil {
+		r.log.Warn("db_quota_enforce: usage decode failed", "err", err)
+		return
+	}
+	bySchema := make(map[string]int64, len(usage.Schemas))
+	for _, s := range usage.Schemas {
+		bySchema[s.Schema] = s.Bytes
+	}
+
+	users, _, err := r.users.List(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		r.log.Warn("db_quota_enforce: list users failed", "err", err)
+		return
+	}
+	pkgByID := make(map[string]*models.HostingPackage)
+
+	for i := range users {
+		u := &users[i]
+		if u.IsAdmin || u.PackageID == nil || *u.PackageID == "" {
+			continue
+		}
+		pkg, ok := pkgByID[*u.PackageID]
+		if !ok {
+			p, perr := r.packages.FindByID(ctx, *u.PackageID)
+			if perr != nil || p == nil {
+				pkgByID[*u.PackageID] = nil
+				continue
+			}
+			pkgByID[*u.PackageID] = p
+			pkg = p
+		}
+		if pkg == nil || pkg.DiskQuotaMB <= 0 {
+			continue
+		}
+		dbs, _, derr := r.databases.ListByUserID(ctx, u.ID, repository.ListOptions{Limit: 1000})
+		if derr != nil || len(dbs) == 0 {
+			continue
+		}
+		var total int64
+		var mariaDBs []models.Database
+		for _, d := range dbs {
+			if d.Engine != "" && d.Engine != "mariadb" {
+				continue
+			}
+			mariaDBs = append(mariaDBs, d)
+			total += bySchema[d.Name]
+		}
+		if len(mariaDBs) == 0 {
+			continue
+		}
+		quotaBytes := int64(pkg.DiskQuotaMB) * 1024 * 1024
+		pct := float64(total) / float64(quotaBytes) * 100.0
+
+		switch {
+		case pct >= 100.0:
+			r.applyDBQuotaState(ctx, u.ID, mariaDBs, false, total, quotaBytes)
+		case pct < dbQuotaRestorePercent:
+			r.applyDBQuotaState(ctx, u.ID, mariaDBs, true, total, quotaBytes)
+			// 90–100%: hold whatever state the tenant is in.
+		}
+	}
+}
+
+// applyDBQuotaState converges every grant on the user's mariadb
+// databases to the quota-permitted level. writable=false revokes the
+// write set; writable=true re-applies the grant row's OWN stored level
+// (owner intent — a ro grant stays ro). Idempotent by construction:
+// GRANT/REVOKE re-apply cleanly, so no per-grant state is tracked.
+func (r *Reconciler) applyDBQuotaState(ctx context.Context, userID string, dbs []models.Database, writable bool, total, quotaBytes int64) {
+	r.dbQuotaEnforceMu.Lock()
+	wasOver := r.dbQuotaOver[userID]
+	r.dbQuotaEnforceMu.Unlock()
+	// Only act on the edge OR when re-asserting the frozen state (a
+	// restart lost the map; over-quota users get one redundant apply).
+	if writable && !wasOver {
+		return // steady healthy state — nothing to converge
+	}
+
+	applied := 0
+	for _, d := range dbs {
+		grants, gerr := r.databaseGrants.ListByDatabaseID(ctx, d.ID)
+		if gerr != nil {
+			continue
+		}
+		for _, g := range grants {
+			du, uerr := r.databaseUsers.FindByID(ctx, g.DatabaseUserID)
+			if uerr != nil || du == nil || du.Engine != "mariadb" {
+				continue
+			}
+			if writable {
+				privs := []string{"ALL"}
+				if p := strings.TrimSpace(g.Privileges); p != "" && !strings.EqualFold(p, "ALL") {
+					privs = strings.Split(p, ",")
+				}
+				_, aerr := r.agent.Call(ctx, "db_user.grant", map[string]any{
+					"db_name": d.Name, "db_user_name": du.Username,
+					"grant_level": g.GrantLevel, "privileges": privs,
+				})
+				if aerr != nil {
+					r.log.Warn("db_quota_enforce: restore grant failed", "db", d.Name, "db_user", du.Username, "err", aerr)
+					continue
+				}
+			} else {
+				_, aerr := r.agent.Call(ctx, "db_user.revoke", map[string]any{
+					"db_name": d.Name, "db_user_name": du.Username,
+					"privileges": dbQuotaWriteRevoke,
+				})
+				if aerr != nil {
+					r.log.Warn("db_quota_enforce: write revoke failed", "db", d.Name, "db_user", du.Username, "err", aerr)
+					continue
+				}
+			}
+			applied++
+		}
+	}
+
+	r.dbQuotaEnforceMu.Lock()
+	r.dbQuotaOver[userID] = !writable
+	if writable {
+		delete(r.dbQuotaOver, userID)
+	}
+	r.dbQuotaEnforceMu.Unlock()
+
+	// Notify once per edge only.
+	if writable == wasOver && applied > 0 {
+		if writable {
+			r.log.Info("db_quota_enforce: writes restored", "user_id", userID, "grants", applied, "bytes", total)
+			r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
+				"db.quota.restored", "info", "Database writes restored",
+				"Database usage dropped below 90% of the package disk quota; write privileges were restored.")
+		} else {
+			r.log.Warn("db_quota_enforce: writes frozen at quota", "user_id", userID, "grants", applied, "bytes", total, "quota", quotaBytes)
+			r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
+				"db.quota.frozen", "critical", "Database writes frozen at disk quota",
+				"Database usage reached the package disk quota. INSERT/UPDATE/CREATE/ALTER/INDEX were revoked; SELECT and DELETE still work — free space (or upgrade the package) to restore writes.")
+		}
+	}
+}
+
+func (r *Reconciler) publishDBQuotaTransition(ctx context.Context, userID string, total, quotaBytes int64, kind, sev, title, body string) {
+	if r.notificationQueue == nil {
+		return
+	}
+	_, _ = r.notificationQueue.Publish(ctx, notifications.Envelope{
+		EventKind: kind,
+		Severity:  sev,
+		UserID:    userID,
+		Title:     title,
+		Body:      fmt.Sprintf("%s (usage %d MiB / quota %d MiB)", body, total>>20, quotaBytes>>20),
+		Deeplink:  "/jabali-admin/users/" + userID,
+	})
+}

--- a/panel-api/internal/reconciler/db_quota_enforce_test.go
+++ b/panel-api/internal/reconciler/db_quota_enforce_test.go
@@ -1,0 +1,192 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type dbqUsersRepo struct {
+	repository.UserRepository
+	rows []models.User
+}
+
+func (f *dbqUsersRepo) List(context.Context, repository.ListOptions) ([]models.User, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type dbqPkgRepo struct {
+	repository.PackageRepository
+	pkg *models.HostingPackage
+}
+
+func (f *dbqPkgRepo) FindByID(context.Context, string) (*models.HostingPackage, error) {
+	return f.pkg, nil
+}
+
+type dbqDBRepo struct {
+	repository.DatabaseRepository
+	rows []models.Database
+}
+
+func (f *dbqDBRepo) ListByUserID(_ context.Context, userID string, _ repository.ListOptions) ([]models.Database, int64, error) {
+	out := []models.Database{}
+	for _, d := range f.rows {
+		if d.UserID == userID {
+			out = append(out, d)
+		}
+	}
+	return out, int64(len(out)), nil
+}
+
+type dbqDBUserRepo struct {
+	repository.DatabaseUserRepository
+	byID map[string]*models.DatabaseUser
+}
+
+func (f *dbqDBUserRepo) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
+	if u, ok := f.byID[id]; ok {
+		return u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type dbqGrantRepo struct {
+	repository.DatabaseUserGrantRepository
+	byDB map[string][]models.DatabaseUserGrant
+}
+
+func (f *dbqGrantRepo) ListByDatabaseID(_ context.Context, dbID string) ([]models.DatabaseUserGrant, error) {
+	return f.byDB[dbID], nil
+}
+
+// dbqReconciler builds the sweep harness: one tenant (u1, package quota
+// 100 MiB) with one mariadb database db1 owned by db-user alice (rw).
+func dbqReconciler(t *testing.T, ag *fakeAgent, usedBytes int64) *Reconciler {
+	t.Helper()
+	pid := "p1"
+	ag.resultByMethod = map[string]json.RawMessage{
+		"db.usage.by_schema": json.RawMessage(
+			`{"schemas":[{"schema":"tenant_db","bytes":` + jsonInt(usedBytes) + `}]}`),
+		"db_user.revoke": json.RawMessage(`{}`),
+		"db_user.grant":  json.RawMessage(`{}`),
+	}
+	r := New(nil, &dbqUsersRepo{rows: []models.User{{ID: "u1", PackageID: &pid}}}, ag, slog.Default(), Config{})
+	r.WithPackages(&dbqPkgRepo{pkg: &models.HostingPackage{ID: "p1", DiskQuotaMB: 100}})
+	r.WithDBQuotaEnforce(
+		&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "tenant_db", Engine: "mariadb"}}},
+		&dbqDBUserRepo{byID: map[string]*models.DatabaseUser{"dbu1": {ID: "dbu1", UserID: "u1", Username: "alice", Engine: "mariadb"}}},
+		&dbqGrantRepo{byDB: map[string][]models.DatabaseUserGrant{"d1": {{ID: "g1", DatabaseID: "d1", DatabaseUserID: "dbu1", GrantLevel: "rw", Privileges: "ALL"}}}},
+	)
+	return r
+}
+
+func jsonInt(n int64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func dbqCalls(a *fakeAgent, method string) int {
+	n := 0
+	for _, c := range a.calls {
+		if c.method == method {
+			n++
+		}
+	}
+	return n
+}
+
+// JAB-243: at/over quota → write privileges revoked, SELECT-preserving set.
+func TestDBQuota_OverQuotaFreezesWrites(t *testing.T) {
+	ag := &fakeAgent{}
+	r := dbqReconciler(t, ag, 150<<20) // 150 MiB used, 100 MiB quota
+	r.reconcileDBQuotaEnforce(context.Background())
+	if n := dbqCalls(ag, "db_user.revoke"); n != 1 {
+		t.Fatalf("revoke calls = %d, want 1", n)
+	}
+	if n := dbqCalls(ag, "db_user.grant"); n != 0 {
+		t.Fatalf("grant calls = %d, want 0 on freeze", n)
+	}
+	for _, c := range ag.calls {
+		if c.method != "db_user.revoke" {
+			continue
+		}
+		p := c.params.(map[string]any)
+		privs := p["privileges"].([]string)
+		for _, pr := range privs {
+			if pr == "SELECT" || pr == "DELETE" || pr == "DROP" {
+				t.Fatalf("freeze revoked %s — tenant must keep read + free-space privileges", pr)
+			}
+		}
+	}
+}
+
+// JAB-243: under 90% after a freeze → the grant row's own level is
+// restored; healthy steady state never re-grants.
+func TestDBQuota_RestoreOnlyAfterFreeze(t *testing.T) {
+	ag := &fakeAgent{}
+	r := dbqReconciler(t, ag, 150<<20)
+	r.reconcileDBQuotaEnforce(context.Background())
+
+	// Drop usage under 90% and force the interval gate open.
+	ag.resultByMethod["db.usage.by_schema"] = json.RawMessage(`{"schemas":[{"schema":"tenant_db","bytes":10}]}`)
+	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
+	r.reconcileDBQuotaEnforce(context.Background())
+
+	if n := dbqCalls(ag, "db_user.grant"); n != 1 {
+		t.Fatalf("grant calls after recovery = %d, want 1", n)
+	}
+	// Healthy tenant on the next sweep: no further grant traffic.
+	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
+	r.reconcileDBQuotaEnforce(context.Background())
+	if n := dbqCalls(ag, "db_user.grant"); n != 1 {
+		t.Fatalf("steady-state re-grant detected (calls=%d)", n)
+	}
+}
+
+// JAB-243 hysteresis: between 90% and 100% nothing changes in either
+// direction.
+func TestDBQuota_HysteresisHoldsState(t *testing.T) {
+	ag := &fakeAgent{}
+	r := dbqReconciler(t, ag, 95<<20) // 95% — never frozen, never restored
+	r.reconcileDBQuotaEnforce(context.Background())
+	if len(ag.calls) != 1 { // only the usage query
+		t.Fatalf("agent calls at 95%% = %v, want usage query only", ag.calls)
+	}
+	// Frozen tenant at 95%: stays frozen (no restore below-100 flap).
+	ag2 := &fakeAgent{}
+	r2 := dbqReconciler(t, ag2, 150<<20)
+	r2.reconcileDBQuotaEnforce(context.Background())
+	ag2.resultByMethod["db.usage.by_schema"] = json.RawMessage(
+		`{"schemas":[{"schema":"tenant_db","bytes":` + jsonInt(95<<20) + `}]}`)
+	r2.dbQuotaEnforceLastRun = r2.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
+	r2.reconcileDBQuotaEnforce(context.Background())
+	if n := dbqCalls(ag2, "db_user.grant"); n != 0 {
+		t.Fatalf("95%% restored a frozen tenant — hysteresis broken (grants=%d)", n)
+	}
+}
+
+// JAB-243: postgres databases are excluded from both the sum and the
+// grant convergence.
+func TestDBQuota_PostgresExcluded(t *testing.T) {
+	ag := &fakeAgent{}
+	pid := "p1"
+	ag.resultByMethod = map[string]json.RawMessage{
+		"db.usage.by_schema": json.RawMessage(`{"schemas":[]}`),
+	}
+	r := New(nil, &dbqUsersRepo{rows: []models.User{{ID: "u1", PackageID: &pid}}}, ag, slog.Default(), Config{})
+	r.WithPackages(&dbqPkgRepo{pkg: &models.HostingPackage{ID: "p1", DiskQuotaMB: 100}})
+	r.WithDBQuotaEnforce(
+		&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "pg_db", Engine: "postgres"}}},
+		&dbqDBUserRepo{byID: map[string]*models.DatabaseUser{}},
+		&dbqGrantRepo{byDB: map[string][]models.DatabaseUserGrant{}},
+	)
+	r.reconcileDBQuotaEnforce(context.Background())
+	if len(ag.calls) != 1 {
+		t.Fatalf("pg-only tenant caused grant traffic: %v", ag.calls)
+	}
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -233,6 +233,15 @@ type Reconciler struct {
 	bwEnforceMu      sync.Mutex
 	bwEnforceLastRun time.Time
 
+	// JAB-243 DB-quota enforcement (db_quota_enforce.go). All three
+	// repos wired via WithDBQuotaEnforce; nil disables the sweep.
+	databases             repository.DatabaseRepository
+	databaseUsers         repository.DatabaseUserRepository
+	databaseGrants        repository.DatabaseUserGrantRepository
+	dbQuotaEnforceMu      sync.Mutex
+	dbQuotaEnforceLastRun time.Time
+	dbQuotaOver           map[string]bool
+
 	// sshKeysDispatchCache: per-user hash of last-applied SSH keys +
 	// timestamp. Lets ReconcileSSHKeysForUser skip the agent IPC when
 	// the desired state hasn't changed since the last dispatch. Self-
@@ -812,6 +821,9 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// with package quota > 0, sums month-to-date bytes, suspends
 	// (or restores) their domains. Cheap noop when toggle is off.
 	r.reconcileBandwidthQuotaEnforce(ctx)
+
+	// JAB-243 — DB storage quota enforcement (hourly inside).
+	r.reconcileDBQuotaEnforce(ctx)
 
 	// M18 rate-limit zone fragment MUST converge BEFORE the domain loop:
 	// domain.create on the agent writes each vhost then runs `nginx -t`.


### PR DESCRIPTION
## Summary
JAB-243's enforceable control: **write-freeze at the package disk quota** for tenant database storage. DB files live under `/var/lib/mysql`, outside every POSIX quota — until now nothing bounded tenant table growth except #1118's host reserve floor on the restore sink.

### How it works
- **New agent verb `db.usage.by_schema`**: one root-privileged `information_schema` query returns every schema's on-disk bytes. (The panel's own scoped connection would silently under-count schemas it can't see — silent under-enforcement.)
- **Hourly reconciler sweep** (mirrors the M13.1.1 bandwidth-quota pattern): per tenant with a package disk quota, summed mariadb footprint
  - **≥ 100%** → revoke `INSERT/UPDATE/CREATE/ALTER/INDEX` on their db users. **SELECT, DELETE, DROP survive** — the tenant can read their data and free space to recover.
  - **< 90%** → restore each grant row's **own stored level** — a deliberately read-only db user is never promoted to rw by the quota loop (owner intent ∩ quota permission).
  - **90–100%** → hold state. No grant flapping at the boundary.
- **Notifications** once per transition: `db.quota.frozen` (critical) / `db.quota.restored` (info), with usage/quota numbers and an admin deeplink.
- Desired-state, grants-are-the-state: no stored breach flag, **no migration, no knob**. A panel restart costs at most one redundant idempotent re-apply + one repeat notification per over-quota tenant.

### Declared residuals (stay on the ticket)
- **PostgreSQL**: excluded from sum and convergence — pg's grant model has no privilege-list revoke that keeps SELECT; the pg write-freeze rides the hard-cap follow-up.
- **True hard cap** (per-tenant tablespaces / project-quota filesystems) remains the ticket's open feature; this closes the enforceable-limit criterion in the form the issue's own guidance names ("database-native resource controls where genuinely enforceable").
- Overshoot bounded by sweep cadence (1h) × insert rate; the acute backstop below the host floor is #1118's reserve check.

## Test plan
- [x] Over-quota freezes writes with the SELECT/DELETE/DROP-preserving set (revoked-set content pinned)
- [x] Restore fires only after a freeze, re-applies the stored grant level once; steady-state healthy tenants generate zero grant traffic
- [x] Hysteresis: 95% never freezes an under-quota tenant and never restores a frozen one
- [x] Postgres-only tenants: no grant traffic
- [x] Full panel-api + panel-agent suites: 0 FAIL; gofmt/vet clean; post-rebase re-run
- [ ] CI
- [ ] Post-merge live smoke on testserver: tenant DB grown past a small package quota → sweep revokes; INSERT fails, SELECT/DELETE work; shrink → restore

JAB-243

🤖 Generated with [Claude Code](https://claude.com/claude-code)
