### PR TITLE
fix(backups): make the tenant backup window opt-in, off by default (GH #1097)

### DIFF
--- a/internal/backup/window_test.go
+++ b/internal/backup/window_test.go
@@ -125,6 +125,32 @@ func TestNextTenantRunInWindowKeepsInterval(t *testing.T) {
 	}
 }
 
+// TestNextTenantRunUngatedFiresEveryInterval pins GH #1097: with the window
+// disabled (whole-day, StartMin==EndMin — what the scheduler passes when
+// tenant_backup_window_enforce is off) every cadence fires on its plain
+// interval from now, no window gating, no smear. Hourly = every hour.
+func TestNextTenantRunUngatedFiresEveryInterval(t *testing.T) {
+	ungated := TenantWindow{} // whole-day
+	// A time deliberately OUTSIDE the old 02:00–05:00 window — with gating off it
+	// must not be deferred to a window opening.
+	now := mustTime(t, "2026-08-05T14:37:00Z")
+	cases := []struct {
+		cadence string
+		want    string
+	}{
+		{CadenceHourly, "2026-08-05T15:37:00Z"},
+		{CadenceEvery6h, "2026-08-05T20:37:00Z"},
+		{CadenceEvery12h, "2026-08-06T02:37:00Z"},
+		{CadenceDaily, "2026-08-06T14:37:00Z"},
+	}
+	for _, c := range cases {
+		got := NextTenantRun(now, c.cadence, ungated, "sched-A")
+		if !got.Equal(mustTime(t, c.want)) {
+			t.Errorf("%s ungated: want %s, got %s", c.cadence, c.want, got)
+		}
+	}
+}
+
 func TestNextTenantRunOutOfWindowJumpsToOpenPlusSmear(t *testing.T) {
 	w := TenantWindow{StartMin: 120, EndMin: 300}
 	// Fired at 04:30 → +1h = 05:30 outside → next open tomorrow 02:00 + smear.

--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -2089,6 +2089,10 @@ type meSchedulesView struct {
 	MultiEnabled            bool            `json:"multi_enabled"`
 	WindowStart             string          `json:"window_start"`
 	WindowEnd               string          `json:"window_end"`
+	// WindowEnforced (GH #1097): whether the admin window actually restricts
+	// tenant schedules. When false the window_start/end are informational only
+	// and the tenant's schedules run on their chosen interval.
+	WindowEnforced bool `json:"window_enforced"`
 }
 
 // meScheduleUpsertRequest is the tenant-editable multi-schedule payload. Cadence
@@ -2136,10 +2140,15 @@ func (h *meBackupHandler) findOwnedSchedule(ctx context.Context, userID, id stri
 	return s
 }
 
+// tenantWindow returns the window used to compute a tenant schedule's next run.
+// GH #1097: the window is opt-in — off by default it returns a whole-day
+// (ungated) window so a new/edited schedule fires on its plain interval, exactly
+// as the scheduler does. Only when the admin enables enforcement does it narrow
+// to the configured window. A missing settings row also stays ungated.
 func (h *meBackupHandler) tenantWindow(ctx context.Context) internalbackup.TenantWindow {
 	settings, err := h.cfg.Settings.Get(ctx)
-	if err != nil || settings == nil {
-		return internalbackup.DefaultTenantWindow
+	if err != nil || settings == nil || !settings.TenantBackupWindowEnforce {
+		return internalbackup.TenantWindow{} // whole-day / ungated
 	}
 	return internalbackup.ParseWindow(settings.TenantBackupWindowStart, settings.TenantBackupWindowEnd)
 }
@@ -2159,6 +2168,7 @@ func (h *meBackupHandler) listSchedules(c *gin.Context) {
 		MaxBackupSchedules: 1,
 		WindowStart:        settings.TenantBackupWindowStart,
 		WindowEnd:          settings.TenantBackupWindowEnd,
+		WindowEnforced:     settings.TenantBackupWindowEnforce,
 	}
 	if pkg != nil {
 		view.ScheduledBackupsEnabled = pkg.BackupsEnabled() && pkg.ScheduledBackupsEnabled

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -191,6 +191,8 @@ type updateServerSettingsRequest struct {
 	// Validated server-side via internalbackup.ParseWindow round-trip.
 	TenantBackupWindowStart *string `json:"tenant_backup_window_start,omitempty"`
 	TenantBackupWindowEnd   *string `json:"tenant_backup_window_end,omitempty"`
+	// TenantBackupWindowEnforce (GH #1097) — opt-in gate for the window above.
+	TenantBackupWindowEnforce *bool `json:"tenant_backup_window_enforce,omitempty"`
 
 	// M13 SSH shell sandbox.
 	SSHSandboxMode            *string `json:"ssh_sandbox_mode,omitempty"`
@@ -634,6 +636,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 			return
 		}
 		current.TenantBackupWindowEnd = v
+	}
+	if req.TenantBackupWindowEnforce != nil {
+		current.TenantBackupWindowEnforce = *req.TenantBackupWindowEnforce
 	}
 	if req.SSHSandboxMode != nil {
 		current.SSHSandboxMode = strings.TrimSpace(*req.SSHSandboxMode)

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -254,9 +254,16 @@ func (s *Scheduler) enqueue(ctx context.Context, sched models.BackupSchedule) {
 func (s *Scheduler) enqueueTenantWindow(ctx context.Context, sched models.BackupSchedule) {
 	logger := s.deps.Log.With("schedule_id", sched.ID, "cadence", sched.Cadence, "user_id", strDeref(sched.UserID))
 	now := time.Now().UTC()
-	w := internalbackup.DefaultTenantWindow
+	// GH #1097: the maintenance window is opt-in (OFF by default). Enforcement
+	// off = a whole-day window (StartMin==EndMin), which window.go treats as
+	// ungated, so NextTenantRun fires on the pure cadence interval (Hourly =
+	// every hour). Only when the admin turns enforcement on do we narrow to the
+	// configured window. A missing/unreadable settings row also stays ungated —
+	// the safe default is "run the schedule the tenant chose", not "silently
+	// throttle to a few hours".
+	w := internalbackup.TenantWindow{} // whole-day / ungated
 	if s.deps.Settings != nil {
-		if set, err := s.deps.Settings.Get(ctx); err == nil && set != nil {
+		if set, err := s.deps.Settings.Get(ctx); err == nil && set != nil && set.TenantBackupWindowEnforce {
 			w = internalbackup.ParseWindow(set.TenantBackupWindowStart, set.TenantBackupWindowEnd)
 		}
 	}

--- a/panel-api/internal/db/migrations/000266_tenant_backup_window_optin.down.sql
+++ b/panel-api/internal/db/migrations/000266_tenant_backup_window_optin.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+  DROP COLUMN tenant_backup_window_enforce;

--- a/panel-api/internal/db/migrations/000266_tenant_backup_window_optin.up.sql
+++ b/panel-api/internal/db/migrations/000266_tenant_backup_window_optin.up.sql
@@ -1,0 +1,21 @@
+-- GH #1097: the tenant backup maintenance window (GH #454 Phase 7B) silently
+-- restricted EVERY tenant schedule to a few hours a day — an "Hourly" schedule
+-- only ran inside the 02:00-05:00 window. Make the window an explicit OPT-IN
+-- restriction, OFF by default: when tenant_backup_window_enforce = 0 the tenant
+-- scheduler ignores the window and fires each schedule on its selected interval
+-- (Hourly = every hour, Every 6h = every 6 hours, ...); when 1 it restricts
+-- firings to the admin window as before. Defaulting to 0 makes both new AND
+-- existing installs behave the way a tenant expects, without discarding the
+-- window_start/end an admin may have set (they take effect again on enforce=1).
+ALTER TABLE server_settings
+  ADD COLUMN tenant_backup_window_enforce TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Existing window-governed schedules (cadence <> '') had their next_run_at
+-- smeared into tomorrow's 02:00-05:00 window by the old gated model. With the
+-- window now off by default they must fire on their chosen interval starting
+-- now, not sit idle for up to ~24h waiting for the old window opening. Reset the
+-- next run to now so the first firing after the upgrade is immediate; the
+-- scheduler re-smears + retention-caps from there. Legacy cron schedules
+-- (cadence = '') are untouched. Supersedes migration 000253's semantics, where
+-- the window unconditionally gated these schedules.
+UPDATE backup_schedules SET next_run_at = UTC_TIMESTAMP(6) WHERE cadence <> '';

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -294,14 +294,23 @@ type ServerSettings struct {
 	// planning). Default 03:00 daily.
 	TenantBackupCron string `gorm:"column:tenant_backup_cron;type:varchar(64);not null;default:'0 3 * * *'" json:"tenant_backup_cron"`
 	// TenantBackupWindowStart/End (GH #454 7B) is the admin-owned UTC maintenance
-	// window ("HH:MM") that tenant window-governed schedules fire inside. The
-	// scheduler enqueues a due tenant schedule only when now is within the window
-	// and smears multiple due schedules across it. Defaults 02:00–05:00.
-	// tenant_backup_cron stays authoritative for legacy single-schedule installs;
-	// the window governs schedules created through the multi-schedule surface
-	// (backup_schedules.cadence != '').
+	// window ("HH:MM"). It restricts tenant multi-schedules ONLY when
+	// TenantBackupWindowEnforce is on (GH #1097) — off by default, in which case
+	// these values are informational and schedules run on their chosen interval.
+	// When enforcing, the scheduler enqueues a due tenant schedule only within
+	// the window and smears multiple due schedules across it. Defaults
+	// 02:00–05:00. tenant_backup_cron stays authoritative for legacy
+	// single-schedule installs; the window governs schedules created through the
+	// multi-schedule surface (backup_schedules.cadence != '').
 	TenantBackupWindowStart string `gorm:"column:tenant_backup_window_start;type:varchar(5);not null;default:'02:00'" json:"tenant_backup_window_start"`
 	TenantBackupWindowEnd   string `gorm:"column:tenant_backup_window_end;type:varchar(5);not null;default:'05:00'" json:"tenant_backup_window_end"`
+	// TenantBackupWindowEnforce (GH #1097) gates whether the window above
+	// restricts tenant schedules at all. OFF by default: the scheduler ignores
+	// the window and fires each schedule on its selected interval (Hourly = every
+	// hour). ON: firings are confined to the window as in the original 7B model.
+	// Persisted via the repo's Select("*") update, so the false zero-value is
+	// written explicitly (no GORM default-tag zero-value trap).
+	TenantBackupWindowEnforce bool `gorm:"column:tenant_backup_window_enforce;type:tinyint(1);not null;default:0" json:"tenant_backup_window_enforce"`
 
 	// DR / standby (GH #331). ServerRole is 'primary' (default — box is fully
 	// active) or 'standby' (a one-way async replica: pulls the primary's state,

--- a/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
+++ b/panel-ui/src/shells/admin/backups/BackupSettingsTab.tsx
@@ -2,7 +2,7 @@
 // scheduler/dispatcher. Backed by server_settings (PATCH /admin/settings).
 // Retention is per-schedule (Schedules tab) — not server-wide.
 import { useTranslation } from "react-i18next";
-import { Button, Form, Input, InputNumber, Spin } from "antd";
+import { Button, Form, Input, InputNumber, Spin, Switch } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { SaveOutlined } from "@icons";
 import { useEffect, useState } from "react";
@@ -20,6 +20,9 @@ interface BackupSettingsShape {
   // still governs legacy single-schedule plans.
   tenant_backup_window_start: string;
   tenant_backup_window_end: string;
+  // GH #1097: the window is an OPT-IN restriction, off by default. When off the
+  // tenant scheduler ignores it and runs each schedule on its chosen interval.
+  tenant_backup_window_enforce: boolean;
 }
 
 interface ServerSettingsResponse {
@@ -27,6 +30,7 @@ interface ServerSettingsResponse {
   tenant_backup_cron?: string;
   tenant_backup_window_start?: string;
   tenant_backup_window_end?: string;
+  tenant_backup_window_enforce?: boolean;
 }
 
 // HH:MM (24h) — the format the API validates (internalbackup.ValidHHMM).
@@ -37,6 +41,8 @@ export const BackupSettingsTab = () => {
   const [form] = Form.useForm<BackupSettingsShape>();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // GH #1097: the window inputs only apply when enforcement is on.
+  const enforceWindow = Form.useWatch("tenant_backup_window_enforce", form);
 
   useEffect(() => {
     let cancelled = false;
@@ -49,6 +55,7 @@ export const BackupSettingsTab = () => {
           tenant_backup_cron: resp.data.tenant_backup_cron ?? "0 3 * * *",
           tenant_backup_window_start: resp.data.tenant_backup_window_start ?? "02:00",
           tenant_backup_window_end: resp.data.tenant_backup_window_end ?? "05:00",
+          tenant_backup_window_enforce: resp.data.tenant_backup_window_enforce ?? false,
         });
       } catch (err) {
         feedback.message.error(extractApiError(err, "Load failed"));
@@ -99,20 +106,28 @@ export const BackupSettingsTab = () => {
           <Input placeholder="0 3 * * *" style={{ fontFamily: "monospace" }} />
         </Form.Item>
         <Form.Item
+          name="tenant_backup_window_enforce"
+          valuePropName="checked"
+          label="Restrict tenant backups to a maintenance window"
+          tooltip="Off by default. When off, a tenant's Hourly / 6-hourly / 12-hourly / Daily schedule runs on its own interval. Turn on to confine all tenant scheduled backups to the UTC window below (e.g. to bound server load)."
+        >
+          <Switch />
+        </Form.Item>
+        <Form.Item
           name="tenant_backup_window_start"
           label={t("backupsettingstab.tenant_backup_window_start")}
           tooltip={t("backupsettingstab.the_maintenance_window_multischedule_tenants")}
           rules={[{ required: true, pattern: HHMM, message: "Use HH:MM (UTC)" }]}
-          extra="UTC. Applies to plans that allow more than one schedule; the scheduler fires (and spreads) tenant backups within this window."
+          extra="UTC. Only used when the restriction above is on — the scheduler fires (and spreads) tenant backups within this window."
         >
-          <Input placeholder="02:00" style={{ fontFamily: "monospace" }} />
+          <Input placeholder="02:00" style={{ fontFamily: "monospace" }} disabled={!enforceWindow} />
         </Form.Item>
         <Form.Item
           name="tenant_backup_window_end"
           label={t("backupsettingstab.tenant_backup_window_end")}
           rules={[{ required: true, pattern: HHMM, message: "Use HH:MM (UTC)" }]}
         >
-          <Input placeholder="05:00" style={{ fontFamily: "monospace" }} />
+          <Input placeholder="05:00" style={{ fontFamily: "monospace" }} disabled={!enforceWindow} />
         </Form.Item>
         <Form.Item>
           <Button type="primary" htmlType="submit" loading={saving} icon={<SaveOutlined />}>

--- a/panel-ui/src/shells/user/BackupSchedulesCard.tsx
+++ b/panel-ui/src/shells/user/BackupSchedulesCard.tsx
@@ -36,6 +36,8 @@ interface SchedulesView {
   multi_enabled: boolean;
   window_start: string;
   window_end: string;
+  // GH #1097: whether the host's window actually restricts when schedules run.
+  window_enforced?: boolean;
 }
 
 interface DestOption {
@@ -232,11 +234,19 @@ export const BackupSchedulesCard = () => {
       ) : (
         <Space direction="vertical" size="middle" style={{ width: "100%" }}>
           <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
-            Your host runs scheduled backups between{" "}
-            <strong>
-              {view?.window_start}–{view?.window_end} UTC
-            </strong>
-            . You choose what to back up, where, and how often — your host sets the window they run in.{" "}
+            {view?.window_enforced ? (
+              <>
+                Your host runs scheduled backups between{" "}
+                <strong>
+                  {view?.window_start}–{view?.window_end} UTC
+                </strong>
+                . You choose what to back up, where, and how often — your host sets the window they run in.{" "}
+              </>
+            ) : (
+              <>
+                Scheduled backups run on the interval you choose. You pick what to back up, where, and how often.{" "}
+              </>
+            )}
             <Tag>
               {view?.schedules.length ?? 0} / {view?.max_backup_schedules ?? 1}
             </Tag>


### PR DESCRIPTION
## Problem (GH #1097, @lxsdevcode)

The admin **Tenant backup window** (GH #454 Phase 7B, default 02:00–05:00 UTC) silently gated **every** tenant schedule: an **Hourly** schedule only ran ~3×/day inside the window, and 6h/12h were limited too. A first-time user selects "Hourly" and reasonably expects hourly — not "3 runs during an admin window they never saw." This also underlies @mrlp57's "backups don't fire when I expect."

## Fix — the window is now an explicit opt-in restriction, OFF by default

- **New `server_settings.tenant_backup_window_enforce`** (TINYINT, default `0`). Persists via the repo's `Select("*")` update — no allowlist gap, no GORM zero-value trap. (Row-ceiling checked: a TINYINT fits.)
- **Scheduler + tenant next-run:** when enforce is off, use a whole-day window (`window.go` already treats `StartMin==EndMin` as ungated), so `NextTenantRun` fires on the plain cadence interval. When on, narrow to the configured window as before. A missing settings row also stays ungated.
- **Migration resets `next_run_at = now`** for existing cadence schedules — the old gated model smeared them into tomorrow's window, so without this an Hourly schedule would sit idle ~24h after upgrade before firing. Legacy cron schedules (`cadence = ''`) untouched.
- **Admin Backup Settings:** a *"Restrict tenant backups to a maintenance window"* switch (off by default); the window start/end inputs are disabled unless it's on.
- **Tenant Backup Schedules card:** only claims a window when it's actually enforced (`window_enforced` in the `/me` schedules view) — otherwise it says schedules run on the chosen interval, instead of asserting a restriction that no longer applies.

## Tests / verification

- Unit: `TestNextTenantRunUngatedFiresEveryInterval` — Hourly/6h/12h/Daily each fire on their interval with a whole-day window.
- `tsc -b`, `vite build`, backup vitest green.
- Post-merge on jabalitests (deploy check): after `jabali update`, `SELECT cadence, next_run_at FROM backup_schedules` shows near-now timestamps, and a scheduler tick later the Hourly schedule enqueues.

Supersedes migration 000253's unconditional-window semantics.

GH #1097