### PR TITLE
fix(security): breaker rate query used a nonexistent column (JAB-248)

### DIFF
--- a/panel-api/internal/repository/malware_quarantine_countrecent_test.go
+++ b/panel-api/internal/repository/malware_quarantine_countrecent_test.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMockQuarantineDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
+	t.Helper()
+	raw, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT VERSION()")).
+		WillReturnRows(sqlmock.NewRows([]string{"VERSION()"}).AddRow("10.11.6-MariaDB"))
+	gdb, err := gorm.Open(mysql.New(mysql.Config{Conn: raw, SkipInitializeWithVersion: false}),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	return gdb, mock, raw
+}
+
+// JAB-248: CountRecent must filter on detected_at — the malware_quarantine
+// table has NO created_at column (the row timestamp is detected_at). A
+// live smoke caught the original created_at query erroring at runtime,
+// which silently disabled the circuit breaker. This pins the column in
+// the emitted SQL so it cannot drift back.
+func TestMalwareQuarantine_CountRecent_FiltersOnDetectedAt(t *testing.T) {
+	db, mock, raw := newMockQuarantineDB(t)
+	defer raw.Close()
+	repo := NewMalwareQuarantineRepository(db)
+
+	since := time.Now().Add(-time.Hour)
+	mock.ExpectQuery(`SELECT count\(\*\) FROM .malware_quarantine. WHERE detected_at >= \?`).
+		WithArgs(since).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(101))
+	mock.ExpectQuery(`SELECT COUNT\(DISTINCT COALESCE\(user_id, ''\)\) FROM .malware_quarantine. WHERE detected_at >= \?`).
+		WithArgs(since).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
+	total, users, err := repo.CountRecent(context.Background(), since)
+	require.NoError(t, err)
+	require.Equal(t, int64(101), total)
+	require.Equal(t, int64(3), users)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/panel-api/internal/repository/malware_quarantine_repository.go
+++ b/panel-api/internal/repository/malware_quarantine_repository.go
@@ -32,12 +32,16 @@ type malwareQuarantineRepo struct{ db *gorm.DB }
 func (r *malwareQuarantineRepo) CountRecent(ctx context.Context, since time.Time) (int64, int64, error) {
 	var total, users int64
 	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
-		Where("created_at >= ?", since).Count(&total).Error; err != nil {
+		Where("detected_at >= ?", since).Count(&total).Error; err != nil {
 		return 0, 0, translate(err)
 	}
+	// gorm's Count() rewrites SELECT to count(*) and drops a Distinct
+	// clause, so the distinct-user tally is built explicitly with Select
+	// + Scan. NULL user_id (system-owned files) folds to one bucket.
 	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
-		Where("created_at >= ?", since).
-		Distinct("COALESCE(user_id, '')").Count(&users).Error; err != nil {
+		Select("COUNT(DISTINCT COALESCE(user_id, ''))").
+		Where("detected_at >= ?", since).
+		Scan(&users).Error; err != nil {
 		return 0, 0, translate(err)
 	}
 	return total, users, nil


### PR DESCRIPTION
## Summary
The #1121 quarantine circuit breaker was **silently inert** — a live smoke on testserver (101 planted webshells → real maldet quarantine → post-scan hook → ingest) proved it never trips, and exposed two bugs the fake-repo unit test structurally could not catch:

1. **Wrong column**: `CountRecent` filtered on `created_at`, but `malware_quarantine`'s row timestamp is `detected_at` (there is no `created_at`). The query errored on every ingest, got logged-and-swallowed, and the breaker never evaluated.
2. **Dropped DISTINCT**: gorm's `.Distinct(col).Count()` rewrites the SELECT to `count(*)` and drops the distinct clause, so the "distinct users" tally returned the total row count. Rebuilt with an explicit `Select("COUNT(DISTINCT COALESCE(user_id,''))").Scan()`.

Added a **sqlmock repo test** pinning both the `detected_at` column and the `COUNT(DISTINCT ...)` shape in the emitted SQL — the missing coverage that let this ship. Verified the fixed query live against the 101 real rows: `102 total / 1 distinct user` → trips the bulk (≥100) clause.

Follow-up to #1121; re-verified end-to-end on testserver after this lands (see below).

## Test plan
- [x] sqlmock test asserts detected_at + COUNT(DISTINCT) in the SQL
- [x] Fixed query run live against 101 real quarantine rows
- [x] repository + api suites: 0 FAIL
- [ ] CI
- [ ] Post-merge: re-run the 101-webshell smoke on testserver → breaker trips (drop-in written, conf flipped, critical alert, monitor bounced)

JAB-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)