### PR TITLE
fix(security): drive DB-quota write-freeze from live grants, not the panel grant table (JAB-243)

### DIFF
--- a/panel-agent/internal/commands/db_writes_freeze.go
+++ b/panel-agent/internal/commands/db_writes_freeze.go
@@ -1,0 +1,238 @@
+package commands
+
+// db.writes.set — JAB-243 DB-quota write freeze / restore.
+//
+// When a tenant's summed database footprint reaches the package disk
+// quota (the panel reconciler decides this), the tenant's writes to that
+// database are frozen: INSERT/UPDATE/CREATE/ALTER/INDEX are revoked from
+// every grantee on the schema, while SELECT/DELETE/DROP survive so the
+// tenant can read and free space. Dropping back under the low-water mark
+// restores the EXACT pre-freeze grants.
+//
+// The mechanism is snapshot-and-replay, NOT privilege diffing — the same
+// filesystem-state pattern as the malware breaker (JAB-248):
+//
+//   - freeze reads each grantee's live GRANT statement for the schema,
+//     saves them verbatim to /var/lib/jabali/db-quota-freeze/<db>.json
+//     (root 0600), then revokes the write set. Verbatim replay is what
+//     makes "no privilege promotion" true by construction — a read-only
+//     grantee is restored to read-only because its saved statement is
+//     read-only.
+//   - restore replays the saved GRANT statements and deletes the
+//     snapshot. No snapshot = no-op success (restart mid-window, or a
+//     DB frozen by an older path).
+//
+// Enumerating grantees from information_schema.SCHEMA_PRIVILEGES covers
+// EVERY db user with access — CLI-, migration-, and app-install-granted
+// users included — which a panel grant-table scan would miss. Per-user
+// mysqladmin shadow accounts and root/system users are never frozen.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// dbFreezeSnapshotDir is a var (not const) only so tests can redirect it
+// to a TempDir; production never reassigns it.
+var dbFreezeSnapshotDir = "/var/lib/jabali/db-quota-freeze"
+
+// dbWritesRevokeSet is the privilege set frozen at quota. SELECT, DELETE
+// and DROP deliberately survive so the tenant can read + free space.
+var dbWritesRevokeSet = []string{"INSERT", "UPDATE", "CREATE", "ALTER", "INDEX"}
+
+type dbWritesSetParams struct {
+	DBName string `json:"db_name"`
+	Freeze bool   `json:"freeze"`
+}
+
+type dbWritesSetResponse struct {
+	DBName  string `json:"db_name"`
+	Frozen  bool   `json:"frozen"`
+	Changed bool   `json:"changed"`
+}
+
+type dbFreezeSnapshot struct {
+	DBName string            `json:"db_name"`
+	Grants map[string]string `json:"grants"` // grantee -> verbatim GRANT stmt for this schema
+}
+
+// mysqlExec runs mysql with the given SQL; var so tests stub it (GH #994
+// — no test touches the real database).
+var mysqlExec = func(ctx context.Context, sql string) (string, error) {
+	out, err := exec.CommandContext(ctx, "mysql", "-N", "-e", sql).CombinedOutput()
+	return string(out), err
+}
+
+func dbFreezeSnapshotPath(dbName string) string {
+	return filepath.Join(dbFreezeSnapshotDir, dbName+".json")
+}
+
+// isSystemGrantee excludes accounts the freeze must never touch: root,
+// the mysql.* internal roles, and the per-user _mysqladmin shadow the
+// panel uses to manage tenant databases.
+func isSystemGrantee(grantee string) bool {
+	// grantee is 'user'@'host'.
+	user := grantee
+	if i := strings.Index(grantee, "@"); i > 0 {
+		user = grantee[:i]
+	}
+	user = strings.Trim(user, "'`\"")
+	if user == "root" || user == "mysql" || strings.HasPrefix(user, "mysql.") {
+		return true
+	}
+	if strings.HasSuffix(user, "_mysqladmin") || strings.HasSuffix(user, "_shadowadmin") {
+		return true
+	}
+	return false
+}
+
+func dbWritesSetHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p dbWritesSetParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, mwInvalidArgDBW("malformed JSON: " + err.Error())
+	}
+	if !dbBackupNameRegex.MatchString(p.DBName) {
+		return nil, mwInvalidArgDBW("invalid database name")
+	}
+	snapPath := dbFreezeSnapshotPath(p.DBName)
+
+	if p.Freeze {
+		return dbWritesFreeze(ctx, p.DBName, snapPath)
+	}
+	return dbWritesRestore(ctx, p.DBName, snapPath)
+}
+
+func dbWritesFreeze(ctx context.Context, dbName, snapPath string) (any, error) {
+	alreadyFrozen := false
+	if _, err := os.Stat(snapPath); err == nil {
+		// Snapshot exists: re-assert the revokes ONLY. Re-snapshotting
+		// now would capture the already-frozen grants and make a later
+		// restore replay the frozen state — the bug that bricks restore.
+		alreadyFrozen = true
+	}
+
+	grantees, err := dbSchemaGrantees(ctx, dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	if !alreadyFrozen {
+		snap := dbFreezeSnapshot{DBName: dbName, Grants: map[string]string{}}
+		for _, g := range grantees {
+			stmt, gerr := dbSchemaGrantStmt(ctx, g, dbName)
+			if gerr != nil || stmt == "" {
+				continue
+			}
+			snap.Grants[g] = stmt
+		}
+		if err := os.MkdirAll(dbFreezeSnapshotDir, 0o700); err != nil {
+			return nil, dbwInternal("mkdir snapshot dir: " + err.Error())
+		}
+		body, _ := json.Marshal(snap)
+		if err := os.WriteFile(snapPath, body, 0o600); err != nil {
+			return nil, dbwInternal("write snapshot: " + err.Error())
+		}
+	}
+
+	revokeCols := strings.Join(dbWritesRevokeSet, ", ")
+	for _, g := range grantees {
+		// REVOKE of a not-held privilege is harmless in MariaDB, so this
+		// is safe to run on every grantee including read-only ones.
+		sql := fmt.Sprintf("REVOKE %s ON `%s`.* FROM %s", revokeCols, dbName, g)
+		if out, rerr := mysqlExec(ctx, sql); rerr != nil {
+			return nil, dbwInternal(fmt.Sprintf("revoke on %s: %v: %s", g, rerr, strings.TrimSpace(out)))
+		}
+	}
+	if _, err := mysqlExec(ctx, "FLUSH PRIVILEGES"); err != nil {
+		return nil, dbwInternal("flush privileges: " + err.Error())
+	}
+	return dbWritesSetResponse{DBName: dbName, Frozen: true, Changed: !alreadyFrozen}, nil
+}
+
+func dbWritesRestore(ctx context.Context, dbName, snapPath string) (any, error) {
+	body, err := os.ReadFile(snapPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Never frozen (or already restored) — success no-op.
+			return dbWritesSetResponse{DBName: dbName, Frozen: false, Changed: false}, nil
+		}
+		return nil, dbwInternal("read snapshot: " + err.Error())
+	}
+	var snap dbFreezeSnapshot
+	if err := json.Unmarshal(body, &snap); err != nil {
+		return nil, dbwInternal("decode snapshot: " + err.Error())
+	}
+	for _, stmt := range snap.Grants {
+		if strings.TrimSpace(stmt) == "" {
+			continue
+		}
+		if out, gerr := mysqlExec(ctx, stmt); gerr != nil {
+			return nil, dbwInternal(fmt.Sprintf("replay grant: %v: %s", gerr, strings.TrimSpace(out)))
+		}
+	}
+	if _, err := mysqlExec(ctx, "FLUSH PRIVILEGES"); err != nil {
+		return nil, dbwInternal("flush privileges: " + err.Error())
+	}
+	if err := os.Remove(snapPath); err != nil && !os.IsNotExist(err) {
+		return nil, dbwInternal("remove snapshot: " + err.Error())
+	}
+	return dbWritesSetResponse{DBName: dbName, Frozen: false, Changed: true}, nil
+}
+
+// dbSchemaGrantees lists non-system grantees with any privilege on the
+// schema.
+func dbSchemaGrantees(ctx context.Context, dbName string) ([]string, error) {
+	out, err := mysqlExec(ctx, fmt.Sprintf(
+		"SELECT DISTINCT grantee FROM information_schema.SCHEMA_PRIVILEGES WHERE table_schema = '%s'",
+		dbName))
+	if err != nil {
+		return nil, dbwUnavailable("schema_privileges query: " + err.Error())
+	}
+	var out2 []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		g := strings.TrimSpace(line)
+		if g == "" || isSystemGrantee(g) {
+			continue
+		}
+		out2 = append(out2, g)
+	}
+	return out2, nil
+}
+
+// dbSchemaGrantStmt returns the grantee's GRANT statement scoped to the
+// schema, verbatim from SHOW GRANTS (the only replay-safe source).
+func dbSchemaGrantStmt(ctx context.Context, grantee, dbName string) (string, error) {
+	out, err := mysqlExec(ctx, "SHOW GRANTS FOR "+grantee)
+	if err != nil {
+		return "", nil // grantee may have been dropped mid-sweep; skip
+	}
+	needle := "`" + dbName + "`.*"
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, needle) && strings.HasPrefix(line, "GRANT ") {
+			return strings.TrimRight(line, ";"), nil
+		}
+	}
+	return "", nil
+}
+
+func mwInvalidArgDBW(msg string) *agentwire.AgentError {
+	return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: msg}
+}
+func dbwInternal(msg string) *agentwire.AgentError {
+	return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: msg}
+}
+func dbwUnavailable(msg string) *agentwire.AgentError {
+	return &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: msg}
+}
+
+func init() {
+	Default.Register("db.writes.set", dbWritesSetHandler)
+}

--- a/panel-agent/internal/commands/db_writes_freeze_test.go
+++ b/panel-agent/internal/commands/db_writes_freeze_test.go
@@ -1,0 +1,179 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// dbwEnv points the snapshot dir at a TempDir and stubs mysqlExec with a
+// scriptable fake (GH #994: no test touches the real database).
+type fakeMySQL struct {
+	grantees   []string          // returned by the SCHEMA_PRIVILEGES query
+	showGrants map[string]string // grantee -> SHOW GRANTS output
+	execd      []string          // every SQL statement run
+}
+
+func dbwEnv(t *testing.T, fake *fakeMySQL) string {
+	t.Helper()
+	dir := t.TempDir()
+	origDir, origExec := dbFreezeSnapshotDir, mysqlExec
+	dbFreezeSnapshotDir = dir
+	mysqlExec = func(_ context.Context, sql string) (string, error) {
+		fake.execd = append(fake.execd, sql)
+		switch {
+		case strings.Contains(sql, "SCHEMA_PRIVILEGES"):
+			return strings.Join(fake.grantees, "\n"), nil
+		case strings.HasPrefix(sql, "SHOW GRANTS FOR "):
+			g := strings.TrimPrefix(sql, "SHOW GRANTS FOR ")
+			return fake.showGrants[g], nil
+		default:
+			return "", nil
+		}
+	}
+	t.Cleanup(func() { dbFreezeSnapshotDir, mysqlExec = origDir, origExec })
+	return dir
+}
+
+func callWritesSet(t *testing.T, dbName string, freeze bool) dbWritesSetResponse {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"db_name": dbName, "freeze": freeze})
+	got, err := dbWritesSetHandler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	return got.(dbWritesSetResponse)
+}
+
+func TestDBWrites_FreezeSnapshotsAndRevokes(t *testing.T) {
+	fake := &fakeMySQL{
+		grantees: []string{"'alice'@'localhost'", "'jq_mysqladmin'@'localhost'", "'root'@'localhost'"},
+		showGrants: map[string]string{
+			"'alice'@'localhost'": "GRANT USAGE ON *.* TO `alice`@`localhost`\nGRANT SELECT, INSERT, UPDATE ON `tenant_db`.* TO `alice`@`localhost`",
+		},
+	}
+	dir := dbwEnv(t, fake)
+
+	resp := callWritesSet(t, "tenant_db", true)
+	if !resp.Frozen || !resp.Changed {
+		t.Fatalf("freeze resp = %+v", resp)
+	}
+	// Snapshot written for alice only (system accounts excluded).
+	body, err := os.ReadFile(filepath.Join(dir, "tenant_db.json"))
+	if err != nil {
+		t.Fatalf("snapshot missing: %v", err)
+	}
+	var snap dbFreezeSnapshot
+	_ = json.Unmarshal(body, &snap)
+	if _, ok := snap.Grants["'alice'@'localhost'"]; !ok {
+		t.Fatalf("alice not snapshotted: %+v", snap.Grants)
+	}
+	if _, ok := snap.Grants["'jq_mysqladmin'@'localhost'"]; ok {
+		t.Fatal("mysqladmin shadow was snapshotted — must be excluded")
+	}
+	// A REVOKE ran for alice, NOT for root or the shadow admin.
+	var revokedAlice, revokedSystem bool
+	for _, sql := range fake.execd {
+		if strings.HasPrefix(sql, "REVOKE ") && strings.Contains(sql, "'alice'@'localhost'") {
+			revokedAlice = true
+			for _, keep := range []string{"SELECT", "DELETE", "DROP"} {
+				if strings.Contains(sql, keep) {
+					t.Fatalf("freeze revoked %s — must be preserved: %s", keep, sql)
+				}
+			}
+		}
+		if strings.HasPrefix(sql, "REVOKE ") && (strings.Contains(sql, "root") || strings.Contains(sql, "mysqladmin")) {
+			revokedSystem = true
+		}
+	}
+	if !revokedAlice {
+		t.Fatal("alice writes not revoked")
+	}
+	if revokedSystem {
+		t.Fatal("froze a system/shadow account")
+	}
+}
+
+func TestDBWrites_SecondFreezeDoesNotResnapshot(t *testing.T) {
+	fake := &fakeMySQL{
+		grantees:   []string{"'alice'@'localhost'"},
+		showGrants: map[string]string{"'alice'@'localhost'": "GRANT SELECT, INSERT ON `tenant_db`.* TO `alice`@`localhost`"},
+	}
+	dir := dbwEnv(t, fake)
+	callWritesSet(t, "tenant_db", true)
+	before, _ := os.ReadFile(filepath.Join(dir, "tenant_db.json"))
+
+	// Simulate the frozen grants now being what SHOW GRANTS returns.
+	fake.showGrants["'alice'@'localhost'"] = "GRANT SELECT ON `tenant_db`.* TO `alice`@`localhost`"
+	resp := callWritesSet(t, "tenant_db", true)
+	if resp.Changed {
+		t.Fatal("second freeze reported changed=true — must re-assert only")
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "tenant_db.json"))
+	if string(before) != string(after) {
+		t.Fatal("snapshot was overwritten with the frozen grants — restore would be bricked")
+	}
+}
+
+func TestDBWrites_RestoreReplaysVerbatimAndClears(t *testing.T) {
+	fake := &fakeMySQL{
+		grantees:   []string{"'alice'@'localhost'"},
+		showGrants: map[string]string{"'alice'@'localhost'": "GRANT SELECT, INSERT, UPDATE ON `tenant_db`.* TO `alice`@`localhost`"},
+	}
+	dir := dbwEnv(t, fake)
+	callWritesSet(t, "tenant_db", true)
+	fake.execd = nil
+
+	resp := callWritesSet(t, "tenant_db", false)
+	if resp.Frozen || !resp.Changed {
+		t.Fatalf("restore resp = %+v", resp)
+	}
+	// The verbatim pre-freeze GRANT was replayed.
+	var replayed bool
+	for _, sql := range fake.execd {
+		if sql == "GRANT SELECT, INSERT, UPDATE ON `tenant_db`.* TO `alice`@`localhost`" {
+			replayed = true
+		}
+	}
+	if !replayed {
+		t.Fatalf("pre-freeze grant not replayed verbatim: %v", fake.execd)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "tenant_db.json")); !os.IsNotExist(err) {
+		t.Fatal("snapshot not cleared after restore")
+	}
+}
+
+func TestDBWrites_RestoreWithoutSnapshotIsNoop(t *testing.T) {
+	fake := &fakeMySQL{}
+	dbwEnv(t, fake)
+	resp := callWritesSet(t, "never_frozen", false)
+	if resp.Changed {
+		t.Fatalf("restore of never-frozen db reported changed: %+v", resp)
+	}
+	for _, sql := range fake.execd {
+		if strings.HasPrefix(sql, "GRANT ") {
+			t.Fatalf("no-op restore ran a GRANT: %s", sql)
+		}
+	}
+}
+
+// No-promotion by construction: a read-only grantee's snapshot is its
+// read-only statement, so restore never adds write privileges.
+func TestDBWrites_ReadOnlyGranteeStaysReadOnly(t *testing.T) {
+	fake := &fakeMySQL{
+		grantees:   []string{"'ro'@'localhost'"},
+		showGrants: map[string]string{"'ro'@'localhost'": "GRANT SELECT ON `tenant_db`.* TO `ro`@`localhost`"},
+	}
+	dbwEnv(t, fake)
+	callWritesSet(t, "tenant_db", true)
+	fake.execd = nil
+	callWritesSet(t, "tenant_db", false)
+	for _, sql := range fake.execd {
+		if strings.HasPrefix(sql, "GRANT ") && (strings.Contains(sql, "INSERT") || strings.Contains(sql, "UPDATE")) {
+			t.Fatalf("read-only grantee was promoted on restore: %s", sql)
+		}
+	}
+}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -372,11 +372,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		rec.WithBandwidthQuotaEnforce(repository.NewBWDailyRepository(sharedDB), deps.NotificationQueue)
 		// JAB-243: DB storage quota enforcement (write-freeze at package
 		// quota, hourly sweep inside the reconciler).
-		rec.WithDBQuotaEnforce(
-			repository.NewDatabaseRepository(sharedDB),
-			repository.NewDatabaseUserRepository(sharedDB),
-			repository.NewDatabaseUserGrantRepository(sharedDB),
-		)
+		rec.WithDBQuotaEnforce(repository.NewDatabaseRepository(sharedDB))
 		// M47 Wave 3 throttle reconcile — needs both repo + Stalwart CUD client.
 		if sc, ok := deps.StalwartAdmin.(*stalwartadmin.Client); ok {
 			rec.WithMailThrottles(mailOutboundPolicyRepo, sc)

--- a/panel-api/internal/reconciler/db_quota_enforce.go
+++ b/panel-api/internal/reconciler/db_quota_enforce.go
@@ -34,7 +34,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
@@ -52,19 +51,19 @@ const (
 // read their data and free space to get back under.
 var dbQuotaWriteRevoke = []string{"INSERT", "UPDATE", "CREATE", "ALTER", "INDEX"}
 
-// WithDBQuotaEnforce wires the JAB-243 DB-quota sweep. All three repos
-// required; nil on any disables the loop.
-func (r *Reconciler) WithDBQuotaEnforce(dbs repository.DatabaseRepository, dbUsers repository.DatabaseUserRepository, grants repository.DatabaseUserGrantRepository) *Reconciler {
+// WithDBQuotaEnforce wires the JAB-243 DB-quota sweep. Databases repo
+// required; nil disables the loop. The freeze/restore mechanism lives
+// agent-side (db.writes.set, snapshot-and-replay) so the reconciler
+// needs only the tenant's database list — not grant/db-user rows, which
+// CLI- and migration-created grants never populate.
+func (r *Reconciler) WithDBQuotaEnforce(dbs repository.DatabaseRepository) *Reconciler {
 	r.databases = dbs
-	r.databaseUsers = dbUsers
-	r.databaseGrants = grants
 	return r
 }
 
 // reconcileDBQuotaEnforce is the hourly sweep. Cheap noop when disabled.
 func (r *Reconciler) reconcileDBQuotaEnforce(ctx context.Context) {
-	if r.databases == nil || r.databaseUsers == nil || r.databaseGrants == nil ||
-		r.users == nil || r.packages == nil || r.agent == nil {
+	if r.databases == nil || r.users == nil || r.packages == nil || r.agent == nil {
 		return
 	}
 	r.dbQuotaEnforceMu.Lock()
@@ -153,11 +152,12 @@ func (r *Reconciler) reconcileDBQuotaEnforce(ctx context.Context) {
 	}
 }
 
-// applyDBQuotaState converges every grant on the user's mariadb
-// databases to the quota-permitted level. writable=false revokes the
-// write set; writable=true re-applies the grant row's OWN stored level
-// (owner intent — a ro grant stays ro). Idempotent by construction:
-// GRANT/REVOKE re-apply cleanly, so no per-grant state is tracked.
+// applyDBQuotaState freezes or restores writes on every mariadb database
+// the tenant owns via the agent's db.writes.set (snapshot-and-replay).
+// writable=false freezes (revoke the write set, snapshot prior grants);
+// writable=true restores (replay the snapshot verbatim — a read-only
+// grantee stays read-only). Idempotent: the agent no-ops a second freeze
+// and a restore with no snapshot.
 func (r *Reconciler) applyDBQuotaState(ctx context.Context, userID string, dbs []models.Database, writable bool, total, quotaBytes int64) {
 	r.dbQuotaEnforceMu.Lock()
 	wasOver := r.dbQuotaOver[userID]
@@ -170,40 +170,15 @@ func (r *Reconciler) applyDBQuotaState(ctx context.Context, userID string, dbs [
 
 	applied := 0
 	for _, d := range dbs {
-		grants, gerr := r.databaseGrants.ListByDatabaseID(ctx, d.ID)
-		if gerr != nil {
+		_, aerr := r.agent.Call(ctx, "db.writes.set", map[string]any{
+			"db_name": d.Name,
+			"freeze":  !writable,
+		})
+		if aerr != nil {
+			r.log.Warn("db_quota_enforce: writes.set failed", "db", d.Name, "freeze", !writable, "err", aerr)
 			continue
 		}
-		for _, g := range grants {
-			du, uerr := r.databaseUsers.FindByID(ctx, g.DatabaseUserID)
-			if uerr != nil || du == nil || du.Engine != "mariadb" {
-				continue
-			}
-			if writable {
-				privs := []string{"ALL"}
-				if p := strings.TrimSpace(g.Privileges); p != "" && !strings.EqualFold(p, "ALL") {
-					privs = strings.Split(p, ",")
-				}
-				_, aerr := r.agent.Call(ctx, "db_user.grant", map[string]any{
-					"db_name": d.Name, "db_user_name": du.Username,
-					"grant_level": g.GrantLevel, "privileges": privs,
-				})
-				if aerr != nil {
-					r.log.Warn("db_quota_enforce: restore grant failed", "db", d.Name, "db_user", du.Username, "err", aerr)
-					continue
-				}
-			} else {
-				_, aerr := r.agent.Call(ctx, "db_user.revoke", map[string]any{
-					"db_name": d.Name, "db_user_name": du.Username,
-					"privileges": dbQuotaWriteRevoke,
-				})
-				if aerr != nil {
-					r.log.Warn("db_quota_enforce: write revoke failed", "db", d.Name, "db_user", du.Username, "err", aerr)
-					continue
-				}
-			}
-			applied++
-		}
+		applied++
 	}
 
 	r.dbQuotaEnforceMu.Lock()

--- a/panel-api/internal/reconciler/db_quota_enforce_test.go
+++ b/panel-api/internal/reconciler/db_quota_enforce_test.go
@@ -43,27 +43,6 @@ func (f *dbqDBRepo) ListByUserID(_ context.Context, userID string, _ repository.
 	return out, int64(len(out)), nil
 }
 
-type dbqDBUserRepo struct {
-	repository.DatabaseUserRepository
-	byID map[string]*models.DatabaseUser
-}
-
-func (f *dbqDBUserRepo) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
-	if u, ok := f.byID[id]; ok {
-		return u, nil
-	}
-	return nil, repository.ErrNotFound
-}
-
-type dbqGrantRepo struct {
-	repository.DatabaseUserGrantRepository
-	byDB map[string][]models.DatabaseUserGrant
-}
-
-func (f *dbqGrantRepo) ListByDatabaseID(_ context.Context, dbID string) ([]models.DatabaseUserGrant, error) {
-	return f.byDB[dbID], nil
-}
-
 // dbqReconciler builds the sweep harness: one tenant (u1, package quota
 // 100 MiB) with one mariadb database db1 owned by db-user alice (rw).
 func dbqReconciler(t *testing.T, ag *fakeAgent, usedBytes int64) *Reconciler {
@@ -72,16 +51,11 @@ func dbqReconciler(t *testing.T, ag *fakeAgent, usedBytes int64) *Reconciler {
 	ag.resultByMethod = map[string]json.RawMessage{
 		"db.usage.by_schema": json.RawMessage(
 			`{"schemas":[{"schema":"tenant_db","bytes":` + jsonInt(usedBytes) + `}]}`),
-		"db_user.revoke": json.RawMessage(`{}`),
-		"db_user.grant":  json.RawMessage(`{}`),
+		"db.writes.set": json.RawMessage(`{"db_name":"tenant_db","frozen":true,"changed":true}`),
 	}
 	r := New(nil, &dbqUsersRepo{rows: []models.User{{ID: "u1", PackageID: &pid}}}, ag, slog.Default(), Config{})
 	r.WithPackages(&dbqPkgRepo{pkg: &models.HostingPackage{ID: "p1", DiskQuotaMB: 100}})
-	r.WithDBQuotaEnforce(
-		&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "tenant_db", Engine: "mariadb"}}},
-		&dbqDBUserRepo{byID: map[string]*models.DatabaseUser{"dbu1": {ID: "dbu1", UserID: "u1", Username: "alice", Engine: "mariadb"}}},
-		&dbqGrantRepo{byDB: map[string][]models.DatabaseUserGrant{"d1": {{ID: "g1", DatabaseID: "d1", DatabaseUserID: "dbu1", GrantLevel: "rw", Privileges: "ALL"}}}},
-	)
+	r.WithDBQuotaEnforce(&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "tenant_db", Engine: "mariadb"}}})
 	return r
 }
 
@@ -105,23 +79,18 @@ func TestDBQuota_OverQuotaFreezesWrites(t *testing.T) {
 	ag := &fakeAgent{}
 	r := dbqReconciler(t, ag, 150<<20) // 150 MiB used, 100 MiB quota
 	r.reconcileDBQuotaEnforce(context.Background())
-	if n := dbqCalls(ag, "db_user.revoke"); n != 1 {
-		t.Fatalf("revoke calls = %d, want 1", n)
-	}
-	if n := dbqCalls(ag, "db_user.grant"); n != 0 {
-		t.Fatalf("grant calls = %d, want 0 on freeze", n)
-	}
+	freezes := 0
 	for _, c := range ag.calls {
-		if c.method != "db_user.revoke" {
+		if c.method != "db.writes.set" {
 			continue
 		}
 		p := c.params.(map[string]any)
-		privs := p["privileges"].([]string)
-		for _, pr := range privs {
-			if pr == "SELECT" || pr == "DELETE" || pr == "DROP" {
-				t.Fatalf("freeze revoked %s — tenant must keep read + free-space privileges", pr)
-			}
+		if p["freeze"] == true {
+			freezes++
 		}
+	}
+	if freezes != 1 {
+		t.Fatalf("freeze calls = %d, want 1", freezes)
 	}
 }
 
@@ -137,15 +106,29 @@ func TestDBQuota_RestoreOnlyAfterFreeze(t *testing.T) {
 	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
 	r.reconcileDBQuotaEnforce(context.Background())
 
-	if n := dbqCalls(ag, "db_user.grant"); n != 1 {
-		t.Fatalf("grant calls after recovery = %d, want 1", n)
+	if n := dbFreezeCalls(ag, false); n != 1 {
+		t.Fatalf("restore (unfreeze) calls after recovery = %d, want 1", n)
 	}
-	// Healthy tenant on the next sweep: no further grant traffic.
+	// Healthy tenant on the next sweep: no further writes.set traffic.
 	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
 	r.reconcileDBQuotaEnforce(context.Background())
-	if n := dbqCalls(ag, "db_user.grant"); n != 1 {
-		t.Fatalf("steady-state re-grant detected (calls=%d)", n)
+	if n := dbFreezeCalls(ag, false); n != 1 {
+		t.Fatalf("steady-state restore detected (calls=%d)", n)
 	}
+}
+
+// dbFreezeCalls counts db.writes.set calls with the given freeze value.
+func dbFreezeCalls(a *fakeAgent, freeze bool) int {
+	n := 0
+	for _, c := range a.calls {
+		if c.method != "db.writes.set" {
+			continue
+		}
+		if c.params.(map[string]any)["freeze"] == freeze {
+			n++
+		}
+	}
+	return n
 }
 
 // JAB-243 hysteresis: between 90% and 100% nothing changes in either
@@ -165,8 +148,8 @@ func TestDBQuota_HysteresisHoldsState(t *testing.T) {
 		`{"schemas":[{"schema":"tenant_db","bytes":` + jsonInt(95<<20) + `}]}`)
 	r2.dbQuotaEnforceLastRun = r2.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
 	r2.reconcileDBQuotaEnforce(context.Background())
-	if n := dbqCalls(ag2, "db_user.grant"); n != 0 {
-		t.Fatalf("95%% restored a frozen tenant — hysteresis broken (grants=%d)", n)
+	if n := dbFreezeCalls(ag2, false); n != 0 {
+		t.Fatalf("95%% restored a frozen tenant — hysteresis broken (restores=%d)", n)
 	}
 }
 
@@ -180,11 +163,7 @@ func TestDBQuota_PostgresExcluded(t *testing.T) {
 	}
 	r := New(nil, &dbqUsersRepo{rows: []models.User{{ID: "u1", PackageID: &pid}}}, ag, slog.Default(), Config{})
 	r.WithPackages(&dbqPkgRepo{pkg: &models.HostingPackage{ID: "p1", DiskQuotaMB: 100}})
-	r.WithDBQuotaEnforce(
-		&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "pg_db", Engine: "postgres"}}},
-		&dbqDBUserRepo{byID: map[string]*models.DatabaseUser{}},
-		&dbqGrantRepo{byDB: map[string][]models.DatabaseUserGrant{}},
-	)
+	r.WithDBQuotaEnforce(&dbqDBRepo{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "pg_db", Engine: "postgres"}}})
 	r.reconcileDBQuotaEnforce(context.Background())
 	if len(ag.calls) != 1 {
 		t.Fatalf("pg-only tenant caused grant traffic: %v", ag.calls)

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -233,11 +233,10 @@ type Reconciler struct {
 	bwEnforceMu      sync.Mutex
 	bwEnforceLastRun time.Time
 
-	// JAB-243 DB-quota enforcement (db_quota_enforce.go). All three
-	// repos wired via WithDBQuotaEnforce; nil disables the sweep.
+	// JAB-243 DB-quota enforcement (db_quota_enforce.go). Databases repo
+	// wired via WithDBQuotaEnforce; nil disables the sweep. Freeze state
+	// lives agent-side, so no grant/db-user repos are needed here.
 	databases             repository.DatabaseRepository
-	databaseUsers         repository.DatabaseUserRepository
-	databaseGrants        repository.DatabaseUserGrantRepository
 	dbQuotaEnforceMu      sync.Mutex
 	dbQuotaEnforceLastRun time.Time
 	dbQuotaOver           map[string]bool


### PR DESCRIPTION
## Summary
A **live smoke on testserver** exposed that the #1125 DB-quota sweep was **inert**: it iterated panel `database_user_grants` rows to find db-users to revoke, but that table is only written by the REST grant handler — CLI-, migration-, and app-install-granted users never appear in it (the whole table was empty on the box while real MariaDB grants existed). The sweep found nothing to revoke and silently no-op'd. It also risked **promoting a read-only db-user to rw** on restore, since intended level was read from those same unreliable rows.

### Rework: agent-side snapshot-and-replay
The freeze/restore mechanism moves fully into a new agent verb `db.writes.set` (the malware-breaker filesystem-state pattern):
- **freeze** enumerates every grantee on the schema from `information_schema.SCHEMA_PRIVILEGES` — covers **all** grant sources — snapshots each grantee's verbatim `SHOW GRANTS` statement to `/var/lib/jabali/db-quota-freeze/<db>.json` (root 0600), then revokes `INSERT/UPDATE/CREATE/ALTER/INDEX`. `SELECT/DELETE/DROP` survive.
- **restore** replays the saved statements verbatim and deletes the snapshot. Verbatim replay makes **no-promotion true by construction** — a read-only grantee's snapshot is its read-only statement.
- **no snapshot = success no-op** (restart mid-window / older path). A **second freeze re-asserts revokes without re-snapshotting** (else it captures the frozen grants and bricks restore).
- per-user `_mysqladmin`/`_shadowadmin` and `root`/system accounts are **never** frozen.

Live-verified before building: `SCHEMA_PRIVILEGES` lists grantees as `'user'@'host'`, `SHOW GRANTS` gives replayable statements, and the `<user>_mysqladmin` shadow exists to exclude.

### Reconciler unchanged in policy
Hourly, hysteresis 100/90%, edge-deduped notifications — `applyDBQuotaState` now makes **one `db.writes.set` call per** over/under-quota mariadb database instead of walking grant rows. `WithDBQuotaEnforce` drops its two now-unused repo params. Postgres still excluded. Zero migrations.

## Test plan
- [x] Agent: freeze snapshots + revokes write-set (SELECT/DELETE/DROP preserved), excludes shadow/root; second freeze doesn't re-snapshot; restore replays verbatim + clears snapshot; no-snapshot restore is a no-op; read-only grantee never promoted — all against TempDir + stubbed mysql (GH #994)
- [x] Reconciler: over-quota → one freeze call; restore only after freeze; steady-state silent; hysteresis holds; postgres excluded
- [x] Full panel-api + panel-agent suites: 0 FAIL; gofmt/vet clean; post-rebase
- [ ] CI
- [ ] Post-merge live smoke: 115MB smokedb (staged) → freeze → INSERT fails / SELECT+DELETE work → shrink → restore → INSERT works, grants string-identical to pre-freeze

JAB-243

🤖 Generated with [Claude Code](https://claude.com/claude-code)