### PR TITLE
fix(backup): wait for the restic repo lock instead of failing, and say 'busy' when it holds (GH #1045)

### DIFF
--- a/internal/backup/restic.go
+++ b/internal/backup/restic.go
@@ -107,10 +107,19 @@ func New(cfg ResticConfig) *Client {
 }
 
 // baseArgs returns the universal flags every restic invocation carries.
+//
+// --retry-lock (restic >= 0.16, which the installer's Debian pin ships):
+// concurrent operations on one repository are NORMAL here — a scheduled
+// backup holds the lock exactly when an operator deletes an old snapshot
+// (GH #1045: admin delete died with exit 11 "repository is already locked
+// exclusively by PID … 48s ago" while a backup ran). Waiting briefly for
+// the lock instead of failing turns that whole class into a pause. The
+// caller's context still bounds the total wait.
 func (c *Client) baseArgs() []string {
 	args := []string{
 		"--repo", c.cfg.Repo,
 		"--password-file", c.cfg.PasswordFile,
+		"--retry-lock", "2m",
 	}
 	for _, opt := range c.cfg.ExtraOptions {
 		if opt == "" {

--- a/internal/backup/restic_test.go
+++ b/internal/backup/restic_test.go
@@ -65,7 +65,7 @@ func TestBackup_NonExit3StaysFailure(t *testing.T) {
 
 // fakeRunner records every Run call and returns canned responses.
 type fakeRunner struct {
-	calls []fakeCall
+	calls  []fakeCall
 	stdout []byte
 	stderr []byte
 	err    error
@@ -108,8 +108,24 @@ func TestSnapshots_EmptyRepo(t *testing.T) {
 	if len(snaps) != 0 {
 		t.Fatalf("want empty, got %d", len(snaps))
 	}
-	if got := r.calls[0].args; got[0] != "--repo" || got[2] != "--password-file" || got[4] != "snapshots" {
+	if got := r.calls[0].args; got[0] != "--repo" || got[2] != "--password-file" ||
+		got[4] != "--retry-lock" || got[6] != "snapshots" {
 		t.Fatalf("unexpected args: %v", got)
+	}
+}
+
+// GH #1045: every invocation must carry --retry-lock so a delete that
+// races a running backup waits for the repo lock instead of dying with
+// restic exit 11 ("repository is already locked exclusively").
+func TestBaseArgs_RetryLock(t *testing.T) {
+	r := &fakeRunner{stdout: []byte("null\n")}
+	c := newClient(t, r)
+	if _, err := c.Snapshots(context.Background(), nil); err != nil {
+		t.Fatalf("Snapshots: %v", err)
+	}
+	joined := strings.Join(r.calls[0].args, " ")
+	if !strings.Contains(joined, "--retry-lock 2m") {
+		t.Fatalf("missing --retry-lock: %v", joined)
 	}
 }
 

--- a/panel-agent/internal/commands/backup_helpers.go
+++ b/panel-agent/internal/commands/backup_helpers.go
@@ -38,8 +38,18 @@ func bkInvalidArg(msg string) error {
 	return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: msg}
 }
 
-// bkInternal wraps an internal-error envelope.
+// bkInternal wraps an internal-error envelope. Restic lock contention gets
+// its own typed, human-sized error: even with --retry-lock (GH #1045), a
+// long-running backup can outlast the wait, and the raw restic stderr JSON
+// is unreadable in a UI toast. FailedPrecondition tells the caller (and the
+// operator) this is "busy, retry later", not a broken repository.
 func bkInternal(msg string, err error) error {
+	if err != nil && strings.Contains(err.Error(), "repository is already locked") {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: fmt.Sprintf("%s: the backup repository is busy (another backup, restore, or cleanup is running) — try again in a few minutes", msg),
+		}
+	}
 	return &agentwire.AgentError{
 		Code:    agentwire.CodeInternal,
 		Message: fmt.Sprintf("%s: %v", msg, err),
@@ -148,7 +158,7 @@ const (
 // are the verbatim messages restic 0.16 emits (captured against 0.16.4):
 //   - missing:    "unable to open config file: … no such file …" / "repository does not exist"
 //   - unopenable: "wrong password or no key found" (foreign/rotated password),
-//                 "config or key <id> is damaged: ciphertext verification failed" (corrupt/foreign)
+//     "config or key <id> is damaged: ciphertext verification failed" (corrupt/foreign)
 //
 // Order matters: the missing case also contains "config file", so check the
 // unopenable signals (which never co-occur with a missing repo) first is not

--- a/panel-agent/internal/commands/backup_helpers_lock_test.go
+++ b/panel-agent/internal/commands/backup_helpers_lock_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1045: restic lock contention must surface as a typed "busy, retry"
+// error, not a raw internal dump of restic's stderr JSON.
+func TestBkInternal_LockContentionIsFailedPrecondition(t *testing.T) {
+	err := bkInternal("list snapshots for forget",
+		errors.New(`restic snapshots: exit status 11 (stderr: {"message_type":"exit_error","code":11,"message":"unable to create lock in backend: repository is already locked exclusively by PID 69086"})`))
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeFailedPrecondition {
+		t.Fatalf("expected failed_precondition, got %v", err)
+	}
+	if len(ae.Message) > 200 {
+		t.Fatalf("busy message should be human-sized, got %d chars", len(ae.Message))
+	}
+}
+
+func TestBkInternal_OtherErrorsStayInternal(t *testing.T) {
+	err := bkInternal("x", errors.New("boom"))
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeInternal {
+		t.Fatalf("expected internal, got %v", err)
+	}
+}


### PR DESCRIPTION
@mrlp57's admin-delete failure: restic **exit 11** — `repository is already locked exclusively by PID … 48s ago`. The delete raced a running backup on the same repo (more likely now that #1124 un-wedged scheduled runs). "Works from a regular user" was timing, not privilege.

- **`--retry-lock 2m`** on every restic invocation (restic ≥ 0.16, which the installer pins): concurrent ops on one repo are normal — a scheduled backup holds the lock exactly when an operator deletes a snapshot. Waiting briefly turns the failure class into a pause; caller contexts still bound the wait.
- Residual contention maps to a typed **FailedPrecondition**: *"the backup repository is busy (another backup, restore, or cleanup is running) — try again in a few minutes"* — instead of the raw restic stderr JSON that filled the reporter's screenshot.

Tests: `--retry-lock` pinned in `baseArgs`, lock-error mapping (+ non-lock errors stay internal); backup + agent packages green.

GH #1045