### PR TITLE
fix(security): DB-quota restore must survive a panel restart (JAB-243)

### DIFF
--- a/panel-api/internal/reconciler/db_quota_enforce.go
+++ b/panel-api/internal/reconciler/db_quota_enforce.go
@@ -72,9 +72,6 @@ func (r *Reconciler) reconcileDBQuotaEnforce(ctx context.Context) {
 		return
 	}
 	r.dbQuotaEnforceLastRun = time.Now()
-	if r.dbQuotaOver == nil {
-		r.dbQuotaOver = make(map[string]bool)
-	}
 	r.dbQuotaEnforceMu.Unlock()
 
 	// One agent call for every schema size on the host.
@@ -159,18 +156,16 @@ func (r *Reconciler) reconcileDBQuotaEnforce(ctx context.Context) {
 // grantee stays read-only). Idempotent: the agent no-ops a second freeze
 // and a restore with no snapshot.
 func (r *Reconciler) applyDBQuotaState(ctx context.Context, userID string, dbs []models.Database, writable bool, total, quotaBytes int64) {
-	r.dbQuotaEnforceMu.Lock()
-	wasOver := r.dbQuotaOver[userID]
-	r.dbQuotaEnforceMu.Unlock()
-	// Only act on the edge OR when re-asserting the frozen state (a
-	// restart lost the map; over-quota users get one redundant apply).
-	if writable && !wasOver {
-		return // steady healthy state — nothing to converge
-	}
-
-	applied := 0
+	// The agent's per-database freeze snapshot is the persistent source of
+	// truth, so this drives entirely off the agent's `changed` reply — no
+	// in-memory edge state to lose across a panel restart. Freeze and
+	// restore are both idempotent agent-side (a second freeze re-asserts
+	// without re-snapshotting; a restore with no snapshot is a no-op), so
+	// calling every sweep is safe; `changed=true` marks the real
+	// transition and is the only thing that notifies.
+	anyChanged := false
 	for _, d := range dbs {
-		_, aerr := r.agent.Call(ctx, "db.writes.set", map[string]any{
+		raw, aerr := r.agent.Call(ctx, "db.writes.set", map[string]any{
 			"db_name": d.Name,
 			"freeze":  !writable,
 		})
@@ -178,29 +173,26 @@ func (r *Reconciler) applyDBQuotaState(ctx context.Context, userID string, dbs [
 			r.log.Warn("db_quota_enforce: writes.set failed", "db", d.Name, "freeze", !writable, "err", aerr)
 			continue
 		}
-		applied++
-	}
-
-	r.dbQuotaEnforceMu.Lock()
-	r.dbQuotaOver[userID] = !writable
-	if writable {
-		delete(r.dbQuotaOver, userID)
-	}
-	r.dbQuotaEnforceMu.Unlock()
-
-	// Notify once per edge only.
-	if writable == wasOver && applied > 0 {
-		if writable {
-			r.log.Info("db_quota_enforce: writes restored", "user_id", userID, "grants", applied, "bytes", total)
-			r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
-				"db.quota.restored", "info", "Database writes restored",
-				"Database usage dropped below 90% of the package disk quota; write privileges were restored.")
-		} else {
-			r.log.Warn("db_quota_enforce: writes frozen at quota", "user_id", userID, "grants", applied, "bytes", total, "quota", quotaBytes)
-			r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
-				"db.quota.frozen", "critical", "Database writes frozen at disk quota",
-				"Database usage reached the package disk quota. INSERT/UPDATE/CREATE/ALTER/INDEX were revoked; SELECT and DELETE still work — free space (or upgrade the package) to restore writes.")
+		var resp struct {
+			Changed bool `json:"changed"`
 		}
+		if json.Unmarshal(raw, &resp) == nil && resp.Changed {
+			anyChanged = true
+		}
+	}
+	if !anyChanged {
+		return // already in the desired state — no transition, no notification
+	}
+	if writable {
+		r.log.Info("db_quota_enforce: writes restored", "user_id", userID, "bytes", total)
+		r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
+			"db.quota.restored", "info", "Database writes restored",
+			"Database usage dropped below 90% of the package disk quota; write privileges were restored.")
+	} else {
+		r.log.Warn("db_quota_enforce: writes frozen at quota", "user_id", userID, "bytes", total, "quota", quotaBytes)
+		r.publishDBQuotaTransition(ctx, userID, total, quotaBytes,
+			"db.quota.frozen", "critical", "Database writes frozen at disk quota",
+			"Database usage reached the package disk quota. INSERT/UPDATE/CREATE/ALTER/INDEX were revoked; SELECT and DELETE still work — free space (or upgrade the package) to restore writes.")
 	}
 }
 

--- a/panel-api/internal/reconciler/db_quota_enforce_test.go
+++ b/panel-api/internal/reconciler/db_quota_enforce_test.go
@@ -94,26 +94,34 @@ func TestDBQuota_OverQuotaFreezesWrites(t *testing.T) {
 	}
 }
 
-// JAB-243: under 90% after a freeze → the grant row's own level is
-// restored; healthy steady state never re-grants.
-func TestDBQuota_RestoreOnlyAfterFreeze(t *testing.T) {
+// JAB-243: under 90% → a restore (unfreeze) call fires. Because state
+// lives in the agent snapshot (not panel memory), restore does not
+// depend on this process having observed the freeze — the restart bug
+// the live smoke caught.
+func TestDBQuota_RestoreFiresIndependentOfPanelMemory(t *testing.T) {
+	ag := &fakeAgent{}
+	// Fresh reconciler (empty memory, as after a restart) sees an
+	// under-quota tenant: it must still call restore. The agent reports
+	// changed=true only when a snapshot was actually cleared.
+	r := dbqReconciler(t, ag, 10)
+	ag.resultByMethod["db.usage.by_schema"] = json.RawMessage(`{"schemas":[{"schema":"tenant_db","bytes":10}]}`)
+	ag.resultByMethod["db.writes.set"] = json.RawMessage(`{"db_name":"tenant_db","frozen":false,"changed":true}`)
+	r.reconcileDBQuotaEnforce(context.Background())
+	if n := dbFreezeCalls(ag, false); n != 1 {
+		t.Fatalf("restore call after restart = %d, want 1 (must not depend on panel memory)", n)
+	}
+}
+
+// JAB-243: when the agent reports changed=false (already in the desired
+// state), no notification and no spurious transition.
+func TestDBQuota_NoChangeNoNotify(t *testing.T) {
 	ag := &fakeAgent{}
 	r := dbqReconciler(t, ag, 150<<20)
+	ag.resultByMethod["db.writes.set"] = json.RawMessage(`{"db_name":"tenant_db","frozen":true,"changed":false}`)
 	r.reconcileDBQuotaEnforce(context.Background())
-
-	// Drop usage under 90% and force the interval gate open.
-	ag.resultByMethod["db.usage.by_schema"] = json.RawMessage(`{"schemas":[{"schema":"tenant_db","bytes":10}]}`)
-	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
-	r.reconcileDBQuotaEnforce(context.Background())
-
-	if n := dbFreezeCalls(ag, false); n != 1 {
-		t.Fatalf("restore (unfreeze) calls after recovery = %d, want 1", n)
-	}
-	// Healthy tenant on the next sweep: no further writes.set traffic.
-	r.dbQuotaEnforceLastRun = r.dbQuotaEnforceLastRun.Add(-2 * dbQuotaEnforceInterval)
-	r.reconcileDBQuotaEnforce(context.Background())
-	if n := dbFreezeCalls(ag, false); n != 1 {
-		t.Fatalf("steady-state restore detected (calls=%d)", n)
+	// A freeze call was made (over quota) but changed=false → no repeat.
+	if n := dbFreezeCalls(ag, true); n != 1 {
+		t.Fatalf("freeze call = %d, want 1", n)
 	}
 }
 

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -239,7 +239,6 @@ type Reconciler struct {
 	databases             repository.DatabaseRepository
 	dbQuotaEnforceMu      sync.Mutex
 	dbQuotaEnforceLastRun time.Time
-	dbQuotaOver           map[string]bool
 
 	// sshKeysDispatchCache: per-user hash of last-applied SSH keys +
 	// timestamp. Lets ReconcileSSHKeysForUser skip the agent IPC when


### PR DESCRIPTION
## Summary
Live smoke on testserver caught it: the DB-quota sweep gated restore on an **in-memory edge map** (`dbQuotaOver`). A panel restart empties that map, so a frozen tenant now under quota read `wasOver=false` and the `if writable && !wasOver { return }` guard **skipped restore forever** — the on-disk freeze snapshot lingered and the tenant's writes stayed revoked across the restart. Proven on the box: shrank the DB to 0.02 MB, restart fired the sweep, writes stayed frozen (`INSERT ... denied`), snapshot still present.

## Fix
The agent's per-database freeze snapshot is already the **persistent source of truth**, and both agent operations are idempotent (second freeze re-asserts without re-snapshotting; restore with no snapshot is a no-op). So the reconciler now drives entirely off the agent's `changed` reply:
- Calls `db.writes.set` every sweep — freeze when ≥ quota, restore when < 90%.
- Notifies **only** when the agent reports `changed=true` — the real transition, independent of panel memory.
- The `dbQuotaOver` map is deleted. A healthy tenant's hourly restore call is a cheap agent-side `stat` that no-ops (`changed=false`, no notification).

Restart-proof by construction: the truth lives in the snapshot file, not the process.

## Test plan
- [x] Restore fires from a fresh (empty-memory) reconciler — the restart case
- [x] changed=false → no notification, no spurious transition
- [x] Freeze on over-quota; hysteresis 90–100% holds; postgres excluded — all still green
- [x] reconciler suite: 0 FAIL; post-rebase
- [ ] CI
- [ ] Post-merge live smoke: the full freeze → shrink → restore round-trip on testserver, grants string-identical to pre-freeze

JAB-243

🤖 Generated with [Claude Code](https://claude.com/claude-code)