### PR TITLE
fix(security): breaker rate window must use the DB clock, not Go UTC (JAB-248)

### DIFF
--- a/panel-api/internal/api/security_malware.go
+++ b/panel-api/internal/api/security_malware.go
@@ -705,7 +705,7 @@ func maybeTripQuarantineBreaker(ctx context.Context, cfg SecurityMalwareHandlerC
 	if cfg.Quarantine == nil || cfg.Agent == nil {
 		return
 	}
-	total, users, err := cfg.Quarantine.CountRecent(ctx, time.Now().UTC().Add(-quarantineBreakerWindow))
+	total, users, err := cfg.Quarantine.CountRecent(ctx, quarantineBreakerWindow)
 	if err != nil {
 		if cfg.Log != nil {
 			cfg.Log.Warn("malware: breaker rate check failed", "err", err)

--- a/panel-api/internal/api/security_malware_breaker_test.go
+++ b/panel-api/internal/api/security_malware_breaker_test.go
@@ -15,7 +15,7 @@ type fakeQuarantineRepo struct {
 	total, users int64
 }
 
-func (f *fakeQuarantineRepo) CountRecent(context.Context, time.Time) (int64, int64, error) {
+func (f *fakeQuarantineRepo) CountRecent(context.Context, time.Duration) (int64, int64, error) {
 	return f.total, f.users, nil
 }
 

--- a/panel-api/internal/repository/malware_quarantine_countrecent_test.go
+++ b/panel-api/internal/repository/malware_quarantine_countrecent_test.go
@@ -29,22 +29,22 @@ func newMockQuarantineDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock, *sql.DB) {
 // JAB-248: CountRecent must filter on detected_at — the malware_quarantine
 // table has NO created_at column (the row timestamp is detected_at). A
 // live smoke caught the original created_at query erroring at runtime,
-// which silently disabled the circuit breaker. This pins the column in
-// the emitted SQL so it cannot drift back.
+// then a second smoke caught a Go-UTC-vs-DB-local timezone skew. This
+// pins both the detected_at column AND the DB-clock (DATE_SUB(NOW()...))
+// window in the emitted SQL so neither can drift back.
 func TestMalwareQuarantine_CountRecent_FiltersOnDetectedAt(t *testing.T) {
 	db, mock, raw := newMockQuarantineDB(t)
 	defer raw.Close()
 	repo := NewMalwareQuarantineRepository(db)
 
-	since := time.Now().Add(-time.Hour)
-	mock.ExpectQuery(`SELECT count\(\*\) FROM .malware_quarantine. WHERE detected_at >= \?`).
-		WithArgs(since).
+	mock.ExpectQuery(`SELECT count\(\*\) FROM .malware_quarantine. WHERE detected_at >= DATE_SUB\(NOW\(\), INTERVAL \? SECOND\)`).
+		WithArgs(int64(3600)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(101))
-	mock.ExpectQuery(`SELECT COUNT\(DISTINCT COALESCE\(user_id, ''\)\) FROM .malware_quarantine. WHERE detected_at >= \?`).
-		WithArgs(since).
+	mock.ExpectQuery(`SELECT COUNT\(DISTINCT COALESCE\(user_id, ''\)\) FROM .malware_quarantine. WHERE detected_at >= DATE_SUB\(NOW\(\), INTERVAL \? SECOND\)`).
+		WithArgs(int64(3600)).
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
 
-	total, users, err := repo.CountRecent(context.Background(), since)
+	total, users, err := repo.CountRecent(context.Background(), time.Hour)
 	require.NoError(t, err)
 	require.Equal(t, int64(101), total)
 	require.Equal(t, int64(3), users)

--- a/panel-api/internal/repository/malware_quarantine_repository.go
+++ b/panel-api/internal/repository/malware_quarantine_repository.go
@@ -21,18 +21,26 @@ type MalwareQuarantineRepository interface {
 	Restore(ctx context.Context, id, restoredBy, reason string) error
 	MarkDeleted(ctx context.Context, id string) error
 	PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
-	// CountRecent (JAB-248 breaker): quarantine rows created since the
-	// cutoff — total and distinct affected users. Deleted/restored rows
-	// still count: the breaker measures quarantine RATE, not residue.
-	CountRecent(ctx context.Context, since time.Time) (total int64, users int64, err error)
+	// CountRecent (JAB-248 breaker): quarantine rows detected within the
+	// trailing window — total and distinct affected users. Deleted/
+	// restored rows still count: the breaker measures quarantine RATE,
+	// not residue. The window is evaluated against the DATABASE clock
+	// (detected_at defaults to the DB's CURRENT_TIMESTAMP), never a Go
+	// time — a box not running UTC would otherwise skew the comparison
+	// and silently disable the breaker.
+	CountRecent(ctx context.Context, window time.Duration) (total int64, users int64, err error)
 }
 
 type malwareQuarantineRepo struct{ db *gorm.DB }
 
-func (r *malwareQuarantineRepo) CountRecent(ctx context.Context, since time.Time) (int64, int64, error) {
+func (r *malwareQuarantineRepo) CountRecent(ctx context.Context, window time.Duration) (int64, int64, error) {
 	var total, users int64
+	secs := int64(window.Seconds())
+	// Window computed with the DB clock (NOW()), matching how detected_at
+	// is written (CURRENT_TIMESTAMP) — no Go-UTC-vs-DB-local skew.
+	cond := "detected_at >= DATE_SUB(NOW(), INTERVAL ? SECOND)"
 	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
-		Where("detected_at >= ?", since).Count(&total).Error; err != nil {
+		Where(cond, secs).Count(&total).Error; err != nil {
 		return 0, 0, translate(err)
 	}
 	// gorm's Count() rewrites SELECT to count(*) and drops a Distinct
@@ -40,7 +48,7 @@ func (r *malwareQuarantineRepo) CountRecent(ctx context.Context, since time.Time
 	// + Scan. NULL user_id (system-owned files) folds to one bucket.
 	if err := r.db.WithContext(ctx).Model(&models.MalwareQuarantine{}).
 		Select("COUNT(DISTINCT COALESCE(user_id, ''))").
-		Where("detected_at >= ?", since).
+		Where(cond, secs).
 		Scan(&users).Error; err != nil {
 		return 0, 0, translate(err)
 	}


### PR DESCRIPTION
## Summary
A third live smoke on testserver proved the quarantine circuit breaker **still never trips**, even after #1128 fixed the column name. Root cause: `detected_at` is written with the database's `CURRENT_TIMESTAMP` (server-local time), but `CountRecent` compared it against `time.Now().UTC()`. On any box **not running UTC**, the window is skewed by the offset — testserver (UTC-4) saw **0 rows** in the trailing hour while **330** were actually present, so the rate check always read below threshold and the breaker stayed armed-but-inert.

Verified live: `WHERE detected_at >= NOW() - INTERVAL 1 HOUR` → 330; `WHERE detected_at >= UTC_TIMESTAMP() - INTERVAL 1 HOUR` → 0.

## Fix
`CountRecent` now takes the window as a `time.Duration` and evaluates it entirely in SQL:
```
detected_at >= DATE_SUB(NOW(), INTERVAL ? SECOND)
```
Both sides use the same DB clock that wrote the rows — no dependency on the box timezone matching UTC. This is a real latent bug for any non-UTC production box, not just a test quirk.

The sqlmock repo test pins the `DATE_SUB(NOW()...)` shape alongside the `detected_at` column so neither can drift back.

Follow-up to #1121/#1128; re-verified end-to-end on testserver after this lands (fresh webshell batch → breaker trips → re-arm).

## Test plan
- [x] Live: local-clock window returns 330, UTC window returns 0 (the bug); fix uses NOW()
- [x] sqlmock test asserts detected_at + DATE_SUB(NOW(), INTERVAL ? SECOND)
- [x] repository + api breaker suites: 0 FAIL; full panel-api 0 FAIL; post-rebase
- [ ] CI
- [ ] Post-merge: fresh 105-webshell scan on testserver → breaker trips (drop-in, conf flip, critical event), then re-arm via PUT /quarantine-mode

JAB-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)