### PR TITLE
fix(security): breaker alert event needs non-null raw_json (JAB-248)

### DIFF
--- a/panel-api/internal/api/security_malware.go
+++ b/panel-api/internal/api/security_malware.go
@@ -748,6 +748,9 @@ func maybeTripQuarantineBreaker(ctx context.Context, cfg SecurityMalwareHandlerC
 		Severity:   models.MalwareSeverityCritical,
 		Signature:  &sig,
 		TargetPath: &msg,
+		// malware_events.raw_json is NOT NULL; a synthetic event with no
+		// scanner payload still needs a valid JSON document.
+		RawJSON: json.RawMessage(`{}`),
 	}
 	if err := cfg.Events.Create(ctx, alert); err != nil && cfg.Log != nil {
 		cfg.Log.Warn("malware: breaker alert event insert failed", "err", err)

--- a/panel-api/internal/api/security_malware_breaker_test.go
+++ b/panel-api/internal/api/security_malware_breaker_test.go
@@ -72,6 +72,11 @@ func TestBreaker_MultiUserTripsAndAlerts(t *testing.T) {
 		ev.created[0].EventType != "quarantine_breaker_tripped" {
 		t.Fatalf("alert event wrong: %+v", ev.created)
 	}
+	// raw_json is NOT NULL in the schema — the alert must carry a valid
+	// JSON document or the insert fails (caught live on testserver).
+	if !json.Valid(ev.created[0].RawJSON) {
+		t.Fatalf("alert raw_json is not valid JSON: %q", ev.created[0].RawJSON)
+	}
 }
 
 // JAB-248: single-user volume below the bulk line does NOT trip (one


### PR DESCRIPTION
## Summary
Live smoke: the breaker **tripped correctly** — drop-in written, `quarantine_hits` flipped to 0, panel logged `quarantine circuit breaker TRIPPED ... 333 files across 1 users`. But the critical admin-alert event insert failed: `Column 'raw_json' cannot be null`. The synthetic `MalwareEvent` didn't set `RawJSON`, which is NOT NULL in the schema.

Because the breaker uses **trip-first-notify-second** ordering, the trip still fired — only the operator notification was lost. Fix sets `RawJSON: json.RawMessage(`{}`)` on the alert; the test now asserts the alert carries valid JSON.

Follow-up to #1121; the breaker is otherwise proven live (trips, detect-only, re-arm).

## Test plan
- [x] Breaker unit tests incl. new raw_json validity assertion
- [x] panel-api api suite: 0 FAIL; post-rebase
- [ ] CI
- [ ] Post-merge: re-run trip on testserver → alert event row now persists

JAB-248

🤖 Generated with [Claude Code](https://claude.com/claude-code)