### PR TITLE
fix(security): CrowdSec nginx acquisition must glob tenant *-access.log (JAB-250)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9469,7 +9469,16 @@ install_crowdsec_appsec() {
   #    parse failures when the default acquis.yaml glob matched both
   #    *.access.log and *.error.log.
   local nginx_acquis_file="$acquis_dir/jabali-nginx-logs.yaml"
-  local desired_nginx_acquis=$'# Managed by jabali install.sh.\n# Per-domain nginx access logs in COMBINED format.\n# *.error.log intentionally excluded — different format.\nfilenames:\n  - /var/log/nginx/*.access.log\nlabels:\n  type: nginx\n'
+  # JAB-250: per-domain tenant logs are written as <domain>-access.log
+  # (hyphen) by the panel vhost template; the old dot-only glob
+  # (*.access.log) matched ONLY the infra logs and NONE of the customer
+  # sites, so every log-based scenario (WordPress brute-force, http-dos,
+  # http-cve, base-http) was starved. Both spellings are globbed now:
+  # *-access.log catches tenant + preview vhosts, *.access.log keeps the
+  # infra logs. Do NOT collapse back to one pattern. jcache-*.log and
+  # *error.log stay excluded — different (non-COMBINED) formats that only
+  # produce unparsed lines.
+  local desired_nginx_acquis=$'# Managed by jabali install.sh.\n# Per-domain nginx access logs in COMBINED format (JAB-250).\n# Tenant/preview vhosts write <domain>-access.log (hyphen); infra logs\n# write <name>.access.log (dot). Both are globbed. *error.log and\n# jcache-*.log are excluded — different formats.\nfilenames:\n  - /var/log/nginx/*-access.log\n  - /var/log/nginx/*.access.log\nlabels:\n  type: nginx\n'
   if [[ ! -f "$nginx_acquis_file" ]] || ! cmp -s <(printf '%s' "$desired_nginx_acquis") "$nginx_acquis_file"; then
     _log "writing $nginx_acquis_file"
     local tmp2
@@ -9508,12 +9517,71 @@ install_crowdsec_appsec() {
     rm -f "$_setup_f"
   done
 
+  # JAB-250: self-IP whitelist. Now that tenant nginx logs are actually
+  # parsed, the host's OWN public IP appears in those logs (wp-cron and
+  # other server-to-server self-calls hit the site over its public
+  # address), so without this the host can ban ITSELF the moment a
+  # volumetric scenario fires. crowdsecurity/whitelists already covers
+  # localhost + RFC1918; this adds only the public IPs, which it does not.
+  # Operators add monitoring/uptime probes to the local override file
+  # noted below. Union of DB-confirmed (server_settings) and live-detected
+  # addresses so a NAT'd box whose iface IP differs from its public IP is
+  # still covered.
+  local wl_parser_dir="/etc/crowdsec/parsers/s02-enrich"
+  local wl_file="$wl_parser_dir/jabali-self-whitelist.yaml"
+  local -a wl_ips=()
+  local _ip
+  for _ip in "${JABALI_SRV_IPV4:-}" "${JABALI_SRV_IPV6:-}" \
+             "$(_detect_public_ipv4 2>/dev/null || true)" \
+             "$(_detect_public_ipv6 2>/dev/null || true)"; do
+    _ip="${_ip%%/*}"                       # strip any /prefix
+    [[ -z "$_ip" || "$_ip" == "null" ]] && continue
+    # dedupe
+    local _seen=0 _e
+    for _e in "${wl_ips[@]}"; do [[ "$_e" == "$_ip" ]] && _seen=1 && break; done
+    [[ "$_seen" == 0 ]] && wl_ips+=("$_ip")
+  done
+  if (( ${#wl_ips[@]} > 0 )); then
+    install -d -m 0755 "$wl_parser_dir"
+    local wl_body _line
+    wl_body=$'# Managed by jabali install.sh (JAB-250). Do NOT hand-edit.\n'
+    wl_body+=$'# Whitelists this host\'s own public IPs: server-to-server\n'
+    wl_body+=$'# self-calls (wp-cron etc.) appear with the public IP in\n'
+    wl_body+=$'# tenant nginx logs, and would otherwise trip a scenario and\n'
+    wl_body+=$'# ban the host. localhost + RFC1918 are covered by\n'
+    wl_body+=$'# crowdsecurity/whitelists. Add monitoring/uptime-probe IPs to\n'
+    wl_body+=$'# /etc/crowdsec/parsers/s02-enrich/jabali-local-whitelist.yaml\n'
+    wl_body+=$'# (never overwritten by jabali update).\n'
+    wl_body+=$'name: jabali/self-whitelist\n'
+    wl_body+=$'description: "Whitelist the host\'s own public IPs (JAB-250)"\n'
+    wl_body+=$'whitelist:\n'
+    wl_body+=$'  reason: "jabali host self-calls (public IP in tenant logs)"\n'
+    wl_body+=$'  ip:\n'
+    for _line in "${wl_ips[@]}"; do
+      wl_body+="    - \"${_line}\""$'\n'
+    done
+    if [[ ! -f "$wl_file" ]] || ! cmp -s <(printf '%s' "$wl_body") "$wl_file"; then
+      _log "writing $wl_file (${#wl_ips[@]} self IPs)"
+      local wl_tmp
+      wl_tmp="$(mktemp --tmpdir jabali-cs-wl.XXXXXX)"
+      printf '%s' "$wl_body" >"$wl_tmp"
+      install -m 0644 -o root -g root "$wl_tmp" "$wl_file"
+      rm -f "$wl_tmp"
+    fi
+  else
+    _warn "JAB-250: could not determine host public IP — self-whitelist skipped (add IPs to jabali-local-whitelist.yaml by hand)"
+  fi
+
   # Narrow default CrowdSec acquis.yaml nginx glob if it still matches *.log
   # (access + error together). Error log format breaks the nginx parser.
+  # JAB-250: narrow to *-access.log AND *.access.log (both spellings) so
+  # tenant logs (<domain>-access.log) are covered here too if this dormant
+  # default glob ever fires — narrowing to the dot-only pattern re-broke
+  # exactly the coverage this ticket restores.
   local default_acquis="/etc/crowdsec/acquis.yaml"
   if [[ -f "$default_acquis" ]] && grep -q '/var/log/nginx/\*\.log' "$default_acquis"; then
-    _log "narrowing nginx glob in $default_acquis to *.access.log"
-    sed -i 's|/var/log/nginx/\*\.log|/var/log/nginx/*.access.log|g' "$default_acquis"
+    _log "narrowing nginx glob in $default_acquis to *-access.log + *.access.log"
+    sed -i 's|/var/log/nginx/\*\.log|/var/log/nginx/*-access.log\n  - /var/log/nginx/*.access.log|g' "$default_acquis"
   fi
 
   # Remove legacy appsec.sock ExecStartPost lines if the previous
@@ -9524,6 +9592,15 @@ install_crowdsec_appsec() {
     _log "purging legacy appsec.sock ExecStartPost from $dropin"
     sed -i '/appsec\.sock/d' "$dropin"
     systemctl daemon-reload
+  fi
+
+  # Validate the config (parsers + acquisition) BEFORE reloading, so a
+  # malformed whitelist/acquis drop-in can't take log parsing down — a
+  # broken s02-enrich parser is worse than the coverage bug (JAB-250).
+  if command -v crowdsec >/dev/null 2>&1 && ! crowdsec -t >/dev/null 2>&1; then
+    _err "CrowdSec config test (crowdsec -t) failed — NOT reloading. Errors:"
+    crowdsec -t 2>&1 | tail -20 >&2 || true
+    return 1
   fi
 
   # Reload or restart to pick up acquis + config changes.

--- a/install/tests/test_crowdsec_nginx_glob.sh
+++ b/install/tests/test_crowdsec_nginx_glob.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# install/tests/test_crowdsec_nginx_glob.sh — regression coverage for
+# JAB-250: the CrowdSec nginx acquisition glob must match per-domain
+# tenant logs, which the panel writes as <domain>-access.log (hyphen).
+#
+# The original glob was /var/log/nginx/*.access.log (dot before access),
+# which matched ONLY infra logs and NONE of the 101 tenant sites on a
+# real box — every log-based scenario (WordPress brute-force, http-dos,
+# http-cve) was starved. This test pins:
+#   1. install.sh globs BOTH *-access.log and *.access.log in the jabali
+#      acquisition file.
+#   2. The default-acquis narrowing sed produces both patterns, not the
+#      dot-only one.
+#   3. The glob pattern actually matches a realistic tenant filename and
+#      excludes the jcache log (different format).
+#
+# Run from repo root:  bash install/tests/test_crowdsec_nginx_glob.sh
+# Exit 0 = pass.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# --- 1. jabali acquisition file globs both spellings. ---
+acquis_line="$(grep -n 'desired_nginx_acquis=' install.sh | head -1 || true)"
+if [[ -z "$acquis_line" ]]; then
+  echo "FAIL: desired_nginx_acquis assignment not found in install.sh"
+  fail=1
+else
+  val="$(grep 'desired_nginx_acquis=' install.sh | head -1)"
+  if ! grep -q '/var/log/nginx/\*-access.log' <<<"$val"; then
+    echo "FAIL: jabali nginx acquis does NOT glob *-access.log (tenant logs) — JAB-250 regression"
+    fail=1
+  fi
+  if ! grep -q '/var/log/nginx/\*.access.log' <<<"$val"; then
+    echo "FAIL: jabali nginx acquis dropped *.access.log (infra logs)"
+    fail=1
+  fi
+fi
+
+# --- 2. Default-acquis narrowing sed emits both patterns. ---
+if grep -q "sed -i 's|/var/log/nginx/\\\\\*\\\\.log|/var/log/nginx/\*\.access\.log|g'" install.sh; then
+  echo "FAIL: default-acquis narrowing still collapses to dot-only *.access.log — JAB-250 regression"
+  fail=1
+fi
+if ! grep -q '/var/log/nginx/\*-access.log' <<<"$(grep 'narrowing nginx glob' -A2 install.sh)"; then
+  # best-effort: the replacement line should mention the hyphen pattern
+  if ! grep -Eq "sed -i 's\|/var/log/nginx/\\\\\\*\\\\.log\|/var/log/nginx/\*-access\.log" install.sh; then
+    echo "FAIL: default-acquis narrowing does not include *-access.log"
+    fail=1
+  fi
+fi
+
+# --- 3. Functional: the glob matches tenant + preview, excludes jcache. ---
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+touch "$tmp/example.com-access.log" \
+      "$tmp/example.com-preview-access.log" \
+      "$tmp/jabali-panel.access.log" \
+      "$tmp/jcache-example.com.log" \
+      "$tmp/example.com-error.log"
+
+shopt -s nullglob
+matched=("$tmp"/*-access.log "$tmp"/*.access.log)
+shopt -u nullglob
+
+have() { local n="$1" m; for m in "${matched[@]}"; do [[ "$(basename "$m")" == "$n" ]] && return 0; done; return 1; }
+
+have "example.com-access.log"         || { echo "FAIL: tenant -access.log not matched"; fail=1; }
+have "example.com-preview-access.log" || { echo "FAIL: preview -access.log not matched"; fail=1; }
+have "jabali-panel.access.log"        || { echo "FAIL: infra .access.log not matched"; fail=1; }
+if have "jcache-example.com.log"; then echo "FAIL: jcache log (different format) wrongly matched"; fail=1; fi
+if have "example.com-error.log";  then echo "FAIL: error log wrongly matched"; fail=1; fi
+
+if [[ "$fail" == 0 ]]; then
+  echo "PASS: crowdsec nginx glob covers tenant + preview + infra, excludes jcache/error (JAB-250)"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary
CrowdSec's log-based scenarios were **blind to every tenant site**. The acquisition globbed `/var/log/nginx/*.access.log` (dot), but the panel writes per-domain logs as `<domain>-access.log` (hyphen) — so the glob matched only a handful of infra logs and **none of the customer sites**. Every WordPress brute-force / http-dos / http-cve scenario was installed and enabled but never fed data. On aramapp a 9,613-request xmlrpc flood from one IP drew **no decision**.

### Fix
- **Glob both** `/var/log/nginx/*-access.log` (tenant + preview vhosts) and `*.access.log` (infra). `jcache-*.log` and `*error.log` stay excluded (non-COMBINED formats). Same correction applied to the dormant default-acquis narrowing sed so it can't re-break coverage if it ever fires.
- **Self-IP whitelist** (new `s02-enrich` parser): once tenant logs are parsed, the host's own public IP appears in them (wp-cron and other server-to-server self-calls hit sites over the public address), so without this **the host bans itself** when a volumetric scenario fires. Whitelists the union of DB-confirmed (`server_settings`) and live-detected public IPs; localhost + RFC1918 already come from `crowdsecurity/whitelists`. Operators extend via `jabali-local-whitelist.yaml` (never overwritten). Empty-IP guarded.
- **`crowdsec -t` config test before the reload** so a malformed drop-in can't take log parsing down.
- Regression test pins both globs + the jcache/error exclusions.

### Live-proven on testserver
Synthetic tenant `<domain>-access.log` (the ticket's own verification path):
1. Acquisition now tails it — `cscli metrics show acquisition` lists the file, **80/80 lines parsed**.
2. `cscli explain` and live tail → **`crowdsecurity/http-bf-wordpress_bf_xmlrpc` fires and BANS** the attacker (the exact scenario that missed the aramapp flood).
3. Self-whitelist: a 90-request flood from the whitelisted host IP → `ignored by whitelist (jabali host self-calls)`, **No active decisions**.
4. `crowdsec -t` passes with both changes.

### Fleet + follow-ups (not in this PR)
- **Fleet-wide**: every box installed by the same install.sh has the bug; coverage lands on the next operator-gated stable promotion. Expect a burst of new decisions on rollout — the self-whitelist protects the host; monitoring IPs are the operator's to add.
- **xmlrpc is NOT blocked, only cache-bypassed** — the install.sh comment claims "Jabali blocks xmlrpc.php at nginx (M43)", but `domain_create.go` only sets `$jabali_skip 1` (cache bypass) for xmlrpc, which is why aramapp served 13,300 xmlrpc requests with HTTP 200. That's the ticket's listed follow-up (block xmlrpc by default), left out of this PR but the finding is confirmed.

## Test plan
- [x] install regression tests incl. new `test_crowdsec_nginx_glob.sh` (both globs, jcache/error excluded)
- [x] `bash -n` + phantom-function lint
- [x] Live on testserver: tenant log parsed, xmlrpc scenario bans attacker, self-whitelist spares host IP, `crowdsec -t` green
- [ ] CI

JAB-250

🤖 Generated with [Claude Code](https://claude.com/claude-code)