### PR TITLE
fix(security): confine FTP home create+chown via openat2, closing the root-chown TOCTOU (JAB-251)

### DIFF
--- a/internal/filesafe/mkdir_chown_toctou_test.go
+++ b/internal/filesafe/mkdir_chown_toctou_test.go
@@ -1,0 +1,155 @@
+package filesafe
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// ownerUID returns the uid that owns path (via lstat, no symlink follow).
+func ownerUID(t *testing.T, path string) uint32 {
+	t.Helper()
+	var st unix.Stat_t
+	if err := unix.Lstat(path, &st); err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return st.Uid
+}
+
+// JAB-251: a leaf that is a symlink pointing OUTSIDE the scope must be
+// refused, and the external target must never be created/chowned.
+func TestMkdirChown_LeafSymlinkEscape_Refused(t *testing.T) {
+	if os.Geteuid() != 0 {
+		// Fchown to an arbitrary uid needs privilege; the escape-refusal
+		// (ELOOP) is provable unprivileged, the chown effect is not.
+		t.Skip("needs root to exercise the chown; escape-refusal covered below")
+	}
+	home := t.TempDir()
+	external := t.TempDir() // the "/etc/sudoers.d" stand-in, outside home
+	target := filepath.Join(external, "victim")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	before := ownerUID(t, target)
+
+	// Plant a symlink at the leaf pointing at the external victim.
+	link := filepath.Join(home, "race")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	s := NewScopeForTest("u1", "u1", home)
+	err := s.MkdirChownInScope(link, 0o755, true, 12345, 12345)
+	if err == nil {
+		t.Fatal("MkdirChownInScope followed a leaf symlink escaping the scope")
+	}
+	if got := ownerUID(t, target); got != before {
+		t.Fatalf("external target was chowned: uid %d -> %d", before, got)
+	}
+}
+
+// The escape refusal itself is provable without root: a leaf symlink to
+// an out-of-scope path must return an error before any chown.
+func TestMkdirChown_LeafSymlinkEscape_ErrsUnprivileged(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join(home, "race")); err != nil {
+		t.Fatal(err)
+	}
+	s := NewScopeForTest("u1", "u1", home)
+	// Chown to our own uid so the syscall itself would succeed if reached —
+	// the point is it must NOT be reached.
+	if err := s.MkdirChownInScope(filepath.Join(home, "race"), 0o755, true, os.Getuid(), os.Getgid()); err == nil {
+		t.Fatal("leaf symlink to out-of-scope dir was not refused")
+	}
+}
+
+// A symlink at a PARENT component pointing outside must be refused by
+// openat2 RESOLVE_BENEATH before the leaf is ever created.
+func TestMkdirChown_ParentSymlinkEscape_Refused(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join(home, "evil")); err != nil {
+		t.Fatal(err)
+	}
+	s := NewScopeForTest("u1", "u1", home)
+	// home/evil -> external ; try to create home/evil/child
+	if err := s.MkdirChownInScope(filepath.Join(home, "evil", "child"), 0o755, true, os.Getuid(), os.Getgid()); err == nil {
+		t.Fatal("parent symlink escape was not refused")
+	}
+	if _, err := os.Stat(filepath.Join(external, "child")); err == nil {
+		t.Fatal("child was created through the escaping parent symlink")
+	}
+}
+
+// A legitimate in-scope create succeeds and, under root, lands the leaf
+// owned by the requested uid.
+func TestMkdirChown_InScope_Succeeds(t *testing.T) {
+	home := t.TempDir()
+	s := NewScopeForTest("u1", "u1", home)
+	target := filepath.Join(home, "domains", "site", "home")
+	if err := s.MkdirChownInScope(target, 0o755, true, os.Getuid(), os.Getgid()); err != nil {
+		t.Fatalf("legit create failed: %v", err)
+	}
+	fi, err := os.Stat(target)
+	if err != nil || !fi.IsDir() {
+		t.Fatalf("target dir not created: %v", err)
+	}
+}
+
+// JAB-251 acceptance criterion: continuously swap the path between an
+// in-home directory and an external target while hammering
+// MkdirChownInScope, and prove the external target is never created,
+// modified, or chowned.
+func TestMkdirChown_ContinuousSwapRace(t *testing.T) {
+	home := t.TempDir()
+	external := t.TempDir()
+	victim := filepath.Join(external, "victim")
+	if err := os.Mkdir(victim, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	victimOwner := ownerUID(t, victim)
+	realDir := filepath.Join(home, "realdir")
+	if err := os.Mkdir(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	racePath := filepath.Join(home, "race")
+
+	var stop atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for !stop.Load() {
+			// alternate: race -> realdir (in scope) then race -> victim (escape)
+			_ = os.Remove(racePath)
+			_ = os.Symlink(realDir, racePath)
+			_ = os.Remove(racePath)
+			_ = os.Symlink(victim, racePath)
+		}
+	}()
+
+	s := NewScopeForTest("u1", "u1", home)
+	for i := 0; i < 4000; i++ {
+		// Either errors (symlink leaf refused) or succeeds on a real dir —
+		// never chowns/creates the external victim.
+		_ = s.MkdirChownInScope(racePath, 0o755, true, os.Getuid(), os.Getgid())
+		if got := ownerUID(t, victim); got != victimOwner {
+			stop.Store(true)
+			<-done
+			t.Fatalf("victim chowned during race at iter %d: %d -> %d", i, victimOwner, got)
+		}
+	}
+	stop.Store(true)
+	<-done
+
+	// The victim dir must be untouched: same owner, still empty.
+	if got := ownerUID(t, victim); got != victimOwner {
+		t.Fatalf("victim owner changed: %d -> %d", victimOwner, got)
+	}
+	entries, _ := os.ReadDir(victim)
+	if len(entries) != 0 {
+		t.Fatalf("victim dir gained %d entries via the race", len(entries))
+	}
+}

--- a/internal/filesafe/openat2.go
+++ b/internal/filesafe/openat2.go
@@ -912,3 +912,51 @@ func (e *ExtractDir) Remove(relPath string) error {
 	}
 	return uerr
 }
+
+// MkdirChownInScope creates the leaf directory at pathStr and chowns it to
+// uid:gid, closing the create→chown TOCTOU that a pathname-based
+// os.MkdirAll+os.Chown leaves open in a tenant-writable tree (JAB-251).
+//
+// The parent is opened via openat2(RESOLVE_BENEATH) — any absolute or
+// upward-".." symlink component is refused atomically in the kernel. The
+// leaf is mkdirat'd against that HELD parent fd, then re-opened
+// O_NOFOLLOW|O_DIRECTORY from the SAME fd: a leaf swapped for a symlink
+// between the mkdir and the chown is refused with ELOOP rather than
+// followed. Fchown then runs on that descriptor, so no pathname is ever
+// re-resolved after the security decision. With parents=true the missing
+// intermediate components are built first via mkdirParents (O_NOFOLLOW
+// descent); only the leaf is chowned, matching os.MkdirAll+os.Chown
+// semantics. Idempotent: an existing leaf directory is chowned, not an
+// error. The caller must ensure pathStr != the docroot root itself
+// (which has no in-scope parent).
+func (s *Scope) MkdirChownInScope(pathStr string, perm os.FileMode, parents bool, uid, gid int) error {
+	parent, leaf, err := s.OpenParentInScope(pathStr)
+	if err != nil {
+		if !parents {
+			return err
+		}
+		if merr := s.mkdirParents(pathStr, perm); merr != nil {
+			return merr
+		}
+		parent, leaf, err = s.OpenParentInScope(pathStr)
+		if err != nil {
+			return err
+		}
+	}
+	defer parent.Close()
+	if err := unix.Mkdirat(int(parent.Fd()), leaf, uint32(perm.Perm())); err != nil && err != unix.EEXIST {
+		return err
+	}
+	// Re-open the leaf from the held parent fd with O_NOFOLLOW: a leaf
+	// that was raced into a symlink is refused (ELOOP), never followed.
+	lfd, err := unix.Openat(int(parent.Fd()), leaf,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(lfd)
+	if err := unix.Fchown(lfd, uid, gid); err != nil {
+		return err
+	}
+	return nil
+}

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // FTP/SFTP subaccounts (GH #1053, plans/gh1053-ftp-accounts.md).
@@ -129,6 +130,12 @@ func validateFtpSubaccountName(tenant, sub string) *agentwire.AgentError {
 // stays inside the tenant's home. A tenant-writable tree means a symlink
 // can point anywhere; resolving server-side is what stops a subaccount
 // home from landing in another tenant (or /etc).
+//
+// JAB-251: this EvalSymlinks pass is a fast-fail / friendly-error gate
+// ONLY — it is inherently TOCTOU (the tenant can swap a component after
+// this returns). The authoritative escape boundary is the openat2-
+// confined MkdirChownInScope in the create handler, which resolves and
+// mutates through descriptors with no post-check pathname re-resolution.
 func resolveFtpHomePath(homePath string, tenant *ftpTenant) (string, *agentwire.AgentError) {
 	if !filepath.IsAbs(homePath) || filepath.Clean(homePath) != homePath {
 		return "", &agentwire.AgentError{
@@ -346,15 +353,31 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 		// plain userdel exits 8. Never --remove: home is tenant data.
 		_ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run()
 	}
-	// Home must exist for vsftpd chroot + internal-sftp start dir. Owned
+	// Home must exist for vsftpd chroot + internal-sftp start dir, owned
 	// by the tenant uid like every other node in their tree.
-	if err := os.MkdirAll(homePath, 0o755); err != nil {
-		rollback()
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create home %q: %v", homePath, err)}
-	}
-	if err := os.Chown(homePath, tenant.UID, tenant.GID); err != nil {
-		rollback()
-		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown home %q: %v", homePath, err)}
+	//
+	// JAB-251: the create + chown are descriptor-confined via openat2
+	// (RESOLVE_BENEATH) against the tenant home, NOT run by pathname. The
+	// parent home tree is tenant-writable, so a plain os.MkdirAll +
+	// os.Chown by pathname could be raced — swap a validated component
+	// for a symlink to /etc/sudoers.d after the check and the root chown
+	// follows it. MkdirChownInScope holds the resolved parent fd across
+	// mkdirat + O_NOFOLLOW re-open + Fchown, so no post-validation
+	// pathname re-resolution occurs and a swapped leaf is refused (ELOOP).
+	if filepath.Clean(homePath) == filepath.Clean(tenant.HomeDir) {
+		// Home IS the tenant home root: it already exists and is
+		// tenant-owned from provisioning — nothing to create or chown,
+		// and it has no in-scope parent to open.
+	} else {
+		scope, serr := filesafe.NewScope(tenant.Username, tenant.Username, []string{tenant.HomeDir})
+		if serr != nil {
+			rollback()
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("home scope for %q: %v", tenant.HomeDir, serr)}
+		}
+		if err := scope.MkdirChownInScope(homePath, 0o755, true, tenant.UID, tenant.GID); err != nil {
+			rollback()
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create+chown home %q (confined): %v", homePath, err)}
+		}
 	}
 	if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
 		rollback()


### PR DESCRIPTION
## Summary
**Critical.** The FTP subaccount create handler validated the home path with `filepath.EvalSymlinks`, then ran `os.MkdirAll` + `os.Chown` against the **original pathname**. The home lives in a **tenant-writable** tree, so a tenant could swap a validated component for a symlink after the check and before the root chown — redirecting the chown to e.g. `/etc/sudoers.d`, taking host root and compromising every tenant.

## Fix
New `filesafe.MkdirChownInScope` performs the create + ownership change **through descriptors**, so no pathname is re-resolved after the security decision:
- Parent opened via `openat2(RESOLVE_BENEATH)` — any absolute or upward-`..` symlink component is refused **atomically in the kernel**.
- Leaf `mkdirat`'d against that **held** parent fd, then re-opened `O_NOFOLLOW|O_DIRECTORY` from the **same** fd — a leaf raced into a symlink is refused with `ELOOP`, never followed.
- `Fchown` runs on that descriptor.

The create handler calls it instead of `MkdirAll`+`Chown`. The `home == tenant-root` case is a no-op (already exists + owned). `resolveFtpHomePath`'s `EvalSymlinks` is now documented as a fast-fail/friendly-error gate only — **not** the boundary (a second EvalSymlinks is not a sufficient fix, per the ticket).

Why descriptor-bound and not "revalidate": `openat2` O_NOFOLLOW is a **kernel guarantee**, not a timing mitigation — deterministic, not race-dependent.

## Test plan (acceptance criteria)
- [x] Leaf symlink escaping scope → refused; external target never created/modified/chowned (chown effect asserted under root, refusal asserted unprivileged)
- [x] Parent symlink escape → refused; no child created through it
- [x] Legit in-scope nested create → succeeds
- [x] **Continuous-swap race** (4000 iters alternating the leaf between an in-home dir and an external victim) → victim never created, modified, or chowned
- [x] Existing ftp_account validation + static-escape tests still green; filesafe + commands suites 0 FAIL; gofmt/vet clean; post-rebase
- [ ] CI
- [ ] Post-merge: deploy to testserver, create a legit FTP subaccount (home created + tenant-owned) and confirm a symlink-escape create is refused via the real agent

JAB-251

🤖 Generated with [Claude Code](https://claude.com/claude-code)