### PR TITLE
fix(dr): re-assert standby pairing after each applied sync (GH #331)

### DIFF
--- a/docs/runbooks/dr-standby.md
+++ b/docs/runbooks/dr-standby.md
@@ -35,7 +35,19 @@ the two boxes is the one-way backup destination (least privilege).
 
 1. A shared backup destination both boxes can reach, created on the PRIMARY with
    `jabali backup destination create` (S3/B2/SFTP/etc). This is the DR channel.
-2. The standby box installed with the same Jabali version as the primary. A
+   Use an address the STANDBY can also reach — never `127.0.0.1`/`localhost`:
+   after the first sync the standby runs on the primary's replicated destination
+   row (see below), so a localhost address would poison every later pull.
+2. The same destination created on the STANDBY with the **same name** and the
+   same connection details. Each applied sync replaces the standby's
+   `backup_destinations` rows with the primary's, and the standby re-finds its
+   DR channel **by name** — a name mismatch strands the pairing on a dangling
+   destination id (`dr status` shows "destination not found").
+3. Copy the primary's `/etc/jabali-panel/restic-repo.password` onto the standby
+   (same path, root:root 0600) before pairing, unless the destination carries
+   its own per-destination password. The repo is sealed with the primary's
+   password, and that file is deliberately excluded from replication.
+4. The standby box installed with the same Jabali version as the primary. A
    standby running an older binary against a newer schema will fail to apply the
    restore — keep versions in lockstep.
 
@@ -68,6 +80,14 @@ Pairing flips `server_role` to `standby`. From this point:
 - the reconciler goes dormant (no serving config, no ACME certificate issuance);
 - the API refuses tenant writes with `409 server_is_standby`;
 - every page shows the read-only DR banner.
+
+Each applied sync loads the PRIMARY's panel DB over this box — including
+`server_settings` and `backup_destinations` — and then re-asserts the standby's
+own identity (role, destination, peer label). From the first successful sync on,
+the standby's destination row, credential env files, and `sso.key` are the
+primary's replicated copies; that is expected, and it is why the same-name
+destination prerequisite above matters. Admin logins on the standby also become
+the PRIMARY's credentials (the identity DB replicates too).
 
 Watch convergence with `jabali dr status` — `Last sync status` should reach `ok`
 (applied a snapshot) or `current` (already newest). `waiting` means the primary

--- a/panel-api/internal/api/dns_test.go
+++ b/panel-api/internal/api/dns_test.go
@@ -1124,6 +1124,10 @@ func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bo
 	return false, nil
 }
 
+func (f *fakeSettingsRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
 func dnsRouterWithSettings(userID string, isAdmin bool, s *models.ServerSettings) (*gin.Engine, *mockDomainRepo, *mockDNSZoneRepo) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/panel-api/internal/api/notifications_webpush_test.go
+++ b/panel-api/internal/api/notifications_webpush_test.go
@@ -33,6 +33,10 @@ func (f *fakeWPSettingsRepo) RecordDRSync(context.Context, string, string, strin
 	return nil
 }
 
+func (f *fakeWPSettingsRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
 func (f *fakeWPSettingsRepo) EnsureVAPID(context.Context, string) (bool, error) { return false, nil }
 
 type fakeSubsRepo struct {

--- a/panel-api/internal/api/server_settings_test.go
+++ b/panel-api/internal/api/server_settings_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"time"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -45,6 +46,10 @@ func (m *mockServerSettingsRepo) Upsert(ctx context.Context, s *models.ServerSet
 
 func (m *mockServerSettingsRepo) SetDigestLastSent(context.Context, string) error { return nil }
 func (m *mockServerSettingsRepo) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
+
+func (m *mockServerSettingsRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
 	return nil
 }
 

--- a/panel-api/internal/drsync/syncer.go
+++ b/panel-api/internal/drsync/syncer.go
@@ -45,12 +45,15 @@ import (
 type settingsStore interface {
 	Get(ctx context.Context) (*models.ServerSettings, error)
 	RecordDRSync(ctx context.Context, snapshotID, status, syncErr string) error
+	ReassertDRPairing(ctx context.Context, destinationID, peerLabel string, pairedAt *time.Time) error
 }
 
 // destinationStore is the subset of repository.BackupDestinationRepository the
-// loop needs.
+// loop needs. GetByName remaps the DR channel after a restore replaced the
+// destinations table with the primary's rows (see reassertPairing).
 type destinationStore interface {
 	Get(ctx context.Context, id string) (*models.BackupDestination, error)
+	GetByName(ctx context.Context, name string) (*models.BackupDestination, error)
 }
 
 // Deps are the syncer's collaborators. Settings, Destinations, and Agent are
@@ -88,6 +91,10 @@ type Syncer struct {
 	deps        Deps
 	interval    time.Duration
 	tickTimeout time.Duration
+	// reassertRetryDelay spaces the ReassertDRPairing attempts after an
+	// applied restore (the DB was just reloaded, so one transient failure is
+	// plausible). Tests shrink it.
+	reassertRetryDelay time.Duration
 }
 
 // New returns a Syncer, or nil if a required dependency is missing (so the
@@ -107,7 +114,7 @@ func New(deps Deps) *Syncer {
 	if tt <= 0 {
 		tt = DefaultTickTimeout
 	}
-	return &Syncer{deps: deps, interval: interval, tickTimeout: tt}
+	return &Syncer{deps: deps, interval: interval, tickTimeout: tt, reassertRetryDelay: 2 * time.Second}
 }
 
 // Start runs the loop until ctx is cancelled. Ticks are sequential: the next
@@ -225,6 +232,10 @@ func (s *Syncer) pullRestore(ctx context.Context, settings *models.ServerSetting
 			if rerr := s.restore(ctx, dest, passwordFile, newest); rerr != nil {
 				return rerr
 			}
+			if perr := s.reassertPairing(ctx, settings, dest); perr != nil {
+				return fmt.Errorf("restore %s applied but re-asserting the standby pairing failed "+
+					"(this box may now read as a primary — re-run `jabali dr pair`): %w", newest, perr)
+			}
 			res = Result{Status: models.DRSyncStatusOK, SnapshotID: newest}
 			return nil
 		})
@@ -259,6 +270,41 @@ func (s *Syncer) latestManifest(ctx context.Context, dest *models.BackupDestinat
 	}
 	// The agent returns manifests newest-first.
 	return resp.Manifests[0].SnapshotID, nil
+}
+
+// reassertPairing restores this box's standby identity after an applied
+// restore. system.restore loads the PRIMARY's panel DB wholesale, replacing
+// server_settings (a row that says role=primary with no pairing) and
+// backup_destinations (the primary's rows) — without this step the standby
+// silently self-demotes after its first successful sync: the loop reads
+// role=primary and goes inert, the reconciler wakes, and StandbyReadOnly
+// stops refusing writes. Everything else the restore brought over is
+// deliberately kept (that IS the replication); only the four-column DR
+// identity block is re-stamped.
+//
+// The destination is remapped BY NAME: this box's own pre-restore row (and
+// its creds env file — panel_config rsyncs with --delete-after) is gone, but
+// the shared DR channel exists in the primary's replicated rows under the
+// same name. The runbook makes same-name-on-both-boxes a pairing
+// prerequisite. If the name lookup misses, the pre-restore ID is kept so the
+// next tick surfaces "destination not found" instead of a silent demotion.
+func (s *Syncer) reassertPairing(ctx context.Context, prev *models.ServerSettings, prevDest *models.BackupDestination) error {
+	destID := prevDest.ID
+	if d, err := s.deps.Destinations.GetByName(ctx, prevDest.Name); err == nil && d != nil {
+		destID = d.ID
+	}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if lastErr = s.deps.Settings.ReassertDRPairing(ctx, destID, prev.DRPeerLabel, prev.DRPairedAt); lastErr == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return lastErr
+		case <-time.After(s.reassertRetryDelay):
+		}
+	}
+	return lastErr
 }
 
 // restore runs system.restore for one snapshot with apply=true and

--- a/panel-api/internal/drsync/syncer_test.go
+++ b/panel-api/internal/drsync/syncer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
@@ -49,6 +50,11 @@ type fakeSettings struct {
 	recSnapshotID string
 	recStatus     string
 	recErr        string
+
+	reassertCalls  int
+	reassertDestID string
+	reassertPeer   string
+	reassertErr    error
 }
 
 func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) {
@@ -58,6 +64,15 @@ func (f *fakeSettings) Get(context.Context) (*models.ServerSettings, error) {
 func (f *fakeSettings) RecordDRSync(_ context.Context, snapshotID, status, syncErr string) error {
 	f.recorded = true
 	f.recSnapshotID, f.recStatus, f.recErr = snapshotID, status, syncErr
+	return nil
+}
+
+func (f *fakeSettings) ReassertDRPairing(_ context.Context, destinationID, peerLabel string, _ *time.Time) error {
+	f.reassertCalls++
+	if f.reassertErr != nil {
+		return f.reassertErr
+	}
+	f.reassertDestID, f.reassertPeer = destinationID, peerLabel
 	return nil
 }
 
@@ -71,6 +86,18 @@ func (d *fakeDests) Get(_ context.Context, id string) (*models.BackupDestination
 		return nil, d.err
 	}
 	return d.byID[id], nil // nil => not found
+}
+
+func (d *fakeDests) GetByName(_ context.Context, name string) (*models.BackupDestination, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	for _, dest := range d.byID {
+		if dest != nil && dest.Name == name {
+			return dest, nil
+		}
+	}
+	return nil, errors.New("not found")
 }
 
 func standbySettings(destID, lastSnap string) *models.ServerSettings {
@@ -266,5 +293,94 @@ func TestNew_NilWhenRequiredDepMissing(t *testing.T) {
 	}
 	if New(Deps{Settings: &fakeSettings{}, Destinations: &fakeDests{}}) != nil {
 		t.Error("nil Agent must yield nil Syncer")
+	}
+}
+
+// namedDest builds an enabled destination with an explicit name — the DR
+// channel identity the reassert step remaps by.
+func namedDest(id, name string) *models.BackupDestination {
+	d := enabledDest(id)
+	d.Name = name
+	return d
+}
+
+// GH #331 two-node drill finding: an applied restore loads the PRIMARY's
+// panel DB over this box — server_settings (role=primary, no pairing) and
+// backup_destinations (the primary's rows, different ULIDs) included. The
+// tick must re-assert the standby pairing afterwards, remapping the DR
+// destination by name, or the standby self-demotes after its first
+// successful sync.
+func TestSyncOnce_AppliedRestoreReassertsPairing(t *testing.T) {
+	pairedAt := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	fs := &fakeSettings{s: standbySettings("OLDDEST", "")}
+	fs.s.DRPeerLabel = "182.54.236.60"
+	fs.s.DRPairedAt = &pairedAt
+	fd := &fakeDests{byID: map[string]*models.BackupDestination{"OLDDEST": namedDest("OLDDEST", "dr-channel")}}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_NEW"),
+		"system.restore": func(any) (json.RawMessage, error) {
+			// Simulate the overwrite the real restore performs.
+			fs.s = &models.ServerSettings{ServerRole: models.ServerRolePrimary}
+			fd.byID = map[string]*models.BackupDestination{"NEWDEST": namedDest("NEWDEST", "dr-channel")}
+			return json.RawMessage(`{}`), nil
+		},
+	}}
+	res, err := newSyncer(t, fs, fd, fa).SyncOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	if res.Status != models.DRSyncStatusOK {
+		t.Fatalf("status = %q, want ok (detail: %s)", res.Status, res.Detail)
+	}
+	if fs.reassertCalls == 0 {
+		t.Fatal("applied restore must re-assert the standby pairing")
+	}
+	if fs.reassertDestID != "NEWDEST" {
+		t.Errorf("pairing must remap the DR destination by name to the primary's row, got %q", fs.reassertDestID)
+	}
+	if fs.reassertPeer != "182.54.236.60" {
+		t.Errorf("peer label must survive, got %q", fs.reassertPeer)
+	}
+}
+
+// A tick that applied nothing (already current) must not touch the pairing.
+func TestSyncOnce_CurrentTickDoesNotReassert(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "SNAP_A")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_A"),
+	}}
+	if _, err := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	if fs.reassertCalls != 0 {
+		t.Errorf("current tick must not re-assert pairing, got %d calls", fs.reassertCalls)
+	}
+}
+
+// A reassert failure after an applied restore is the dangerous half-state
+// (box restored but reads as a primary) — it must surface as a recorded
+// error, not silence.
+func TestSyncOnce_ReassertFailureRecordsError(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", ""), reassertErr: errors.New("db gone")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_NEW"),
+		"system.restore": func(any) (json.RawMessage, error) {
+			return json.RawMessage(`{}`), nil
+		},
+	}}
+	sy := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa)
+	sy.reassertRetryDelay = time.Millisecond
+	res, err := sy.SyncOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	if res.Status != models.DRSyncStatusError {
+		t.Fatalf("status = %q, want error", res.Status)
+	}
+	if fs.reassertCalls != 3 {
+		t.Errorf("reassert must retry (3 attempts), got %d", fs.reassertCalls)
+	}
+	if fs.recStatus != models.DRSyncStatusError || fs.recErr == "" {
+		t.Errorf("reassert failure must be recorded: status=%q err=%q", fs.recStatus, fs.recErr)
 	}
 }

--- a/panel-api/internal/migrate/working_folder_test.go
+++ b/panel-api/internal/migrate/working_folder_test.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"time"
 	"context"
 	"errors"
 	"testing"
@@ -20,6 +21,10 @@ func (f *fakeServerSettings) Get(_ context.Context) (*models.ServerSettings, err
 }
 func (f *fakeServerSettings) SetDigestLastSent(context.Context, string) error { return nil }
 func (f *fakeServerSettings) RecordDRSync(context.Context, string, string, string) error {
+	return nil
+}
+
+func (f *fakeServerSettings) ReassertDRPairing(context.Context, string, string, *time.Time) error {
 	return nil
 }
 func (f *fakeServerSettings) Upsert(_ context.Context, _ *models.ServerSettings) error {

--- a/panel-api/internal/notifications/dispatcher_test.go
+++ b/panel-api/internal/notifications/dispatcher_test.go
@@ -612,6 +612,10 @@ func TestResolveTargets_TenantGate(t *testing.T) {
 	require.True(t, ids(got)["A1"], "gate ON + kind allowed must deliver")
 }
 
+func (f *fakeSettings) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
 // JAB-171 phase 3: the dispatcher opens a sealed secret just before the sender
 // reads it — the sender must see plaintext, never the enc:1: envelope.
 func TestSendOne_OpensSealedSecret(t *testing.T) {

--- a/panel-api/internal/notifications/senders/webpush_test.go
+++ b/panel-api/internal/notifications/senders/webpush_test.go
@@ -1,6 +1,7 @@
 package senders
 
 import (
+	"time"
 	"bytes"
 	"context"
 	"errors"
@@ -33,6 +34,10 @@ func (f *fakeSettingsRepo) RecordDRSync(context.Context, string, string, string)
 
 func (f *fakeSettingsRepo) EnsureVAPID(ctx context.Context, hostname string) (bool, error) {
 	return false, nil
+}
+
+func (f *fakeSettingsRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
 }
 
 type fakeSubs struct {

--- a/panel-api/internal/reconciler/digest_ticker_test.go
+++ b/panel-api/internal/reconciler/digest_ticker_test.go
@@ -43,6 +43,10 @@ func (f *fakeDigestSettings) RecordDRSync(context.Context, string, string, strin
 	return nil
 }
 
+func (f *fakeDigestSettings) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
 type fakeDigestQueue struct {
 	envs []notifications.Envelope
 }

--- a/panel-api/internal/reconciler/reconciler_test.go
+++ b/panel-api/internal/reconciler/reconciler_test.go
@@ -462,6 +462,10 @@ func (f *fakeServerSettingsRepo) RecordDRSync(context.Context, string, string, s
 	return nil
 }
 
+func (f *fakeServerSettingsRepo) ReassertDRPairing(context.Context, string, string, *time.Time) error {
+	return nil
+}
+
 func (f *fakeServerSettingsRepo) Get(ctx context.Context) (*models.ServerSettings, error) {
 	if f.settings == nil {
 		return nil, repository.ErrNotFound

--- a/panel-api/internal/repository/server_settings_repository.go
+++ b/panel-api/internal/repository/server_settings_repository.go
@@ -48,6 +48,14 @@ type ServerSettingsRepository interface {
 	// applied snapshot. Targeted UPDATE so it never clobbers a concurrent
 	// settings save.
 	RecordDRSync(ctx context.Context, snapshotID, status, syncErr string) error
+
+	// ReassertDRPairing re-stamps this box's standby identity (GH #331): an
+	// applied drsync restore loads the PRIMARY's panel DB wholesale, which
+	// replaces server_settings with a row that says role=primary and carries
+	// no pairing — without re-asserting, a standby self-demotes after its
+	// first successful sync. Column-targeted UPDATE of exactly the four
+	// identity columns so everything else the restore replicated is kept.
+	ReassertDRPairing(ctx context.Context, destinationID, peerLabel string, pairedAt *time.Time) error
 }
 
 type serverSettingsRepo struct{ db *gorm.DB }
@@ -177,4 +185,19 @@ func (r *serverSettingsRepo) RecordDRSync(ctx context.Context, snapshotID, statu
 		Model(&models.ServerSettings{}).
 		Where("1 = 1").
 		Updates(updates).Error
+}
+
+// ReassertDRPairing — see the interface doc. Empty WHERE targets the single
+// settings row; a map (not struct) so the nil pairedAt and empty peerLabel
+// are written, not skipped as zero values.
+func (r *serverSettingsRepo) ReassertDRPairing(ctx context.Context, destinationID, peerLabel string, pairedAt *time.Time) error {
+	return r.db.WithContext(ctx).
+		Model(&models.ServerSettings{}).
+		Where("1 = 1").
+		Updates(map[string]any{
+			"server_role":       models.ServerRoleStandby,
+			"dr_destination_id": destinationID,
+			"dr_peer_label":     peerLabel,
+			"dr_paired_at":      pairedAt,
+		}).Error
 }


### PR DESCRIPTION
## Summary

Preparing the two-node DR drill for GH #331 surfaced a design hole by code inspection: an applied drsync restore loads the **primary's** panel DB wholesale — `server_settings` (role=primary, no pairing) and `backup_destinations` (the primary's rows) included — and nothing re-asserted the standby's identity afterwards. Result: after its **first successful sync**, a standby silently self-demoted — the sync loop read role=primary and went inert, the reconciler woke, and `StandbyReadOnly` stopped 409ing tenant writes.

Never caught before because the single-box drill errored before reaching an applied restore, and the unit tests fake the agent (no real DB overwrite).

## Fix

- After every applied restore, the tick re-stamps the four-column DR identity block (`server_role=standby`, `dr_destination_id`, `dr_peer_label`, `dr_paired_at`) via a column-targeted UPDATE (`ReassertDRPairing`, same shape as `RecordDRSync`) — everything else the restore replicated is deliberately kept.
- The DR destination is remapped **by name** to the primary's replicated row: the standby's own row + creds env file are gone post-restore (`panel_config` rsyncs `--delete-after`), and the primary's copies are the self-consistent ones (sealed with the `sso.key` now on disk). Name miss keeps the old id so the next tick surfaces "destination not found" instead of silently demoting.
- Reassert failure after an applied restore (the dangerous half-state) records `status=error` naming the condition and pointing at `jabali dr pair`.
- Runbook: same-name destination on both boxes, no-localhost destination address, and copying the primary's `restic-repo.password` are now explicit pairing prerequisites; documented that destination row/creds/admin logins become the primary's replicated copies from the first sync on.

## Test plan

- [x] `TestSyncOnce_AppliedRestoreReassertsPairing` — simulates the DB overwrite inside the fake `system.restore`; asserts role re-stamped + destination remapped by name to the primary's ULID
- [x] `TestSyncOnce_CurrentTickDoesNotReassert` — no restore, no touch
- [x] `TestSyncOnce_ReassertFailureRecordsError` — 3 retry attempts, recorded error
- [x] Full `./panel-api/...` suite: 0 FAIL, vet clean
- [ ] Live two-node drill (jabalitests primary + LAN standby) — next step, will exercise this path for real

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
