### PR TITLE
fix(security): restore vsftpd require_ssl_reuse=YES to stop FTPS data-channel hijack (JAB-257)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -905,7 +905,14 @@ force_local_data_ssl=${force_ssl}
 ssl_tlsv1=YES
 ssl_sslv2=NO
 ssl_sslv3=NO
-require_ssl_reuse=NO
+# JAB-257: require the TLS data connection to prove it knows the control
+# channel's master secret (vsftpd's secure default). require_ssl_reuse=NO
+# let an attacker sharing the victim's NAT race an unrelated TLS session
+# onto the small passive range (40000-40100) and hijack the transfer.
+# YES is correct for FTPS clients that reuse the control session's TLS
+# (lftp, FileZilla, WinSCP, modern curl); a client that cannot is a
+# deliberate operator downgrade, not the shipped default.
+require_ssl_reuse=YES
 ssl_ciphers=HIGH
 VSFTPDEOF
   else

--- a/install/tests/test_ftp_module_optin.sh
+++ b/install/tests/test_ftp_module_optin.sh
@@ -135,6 +135,18 @@ if ! grep -q "ufw delete allow ${pasv_min}:${pasv_max}/tcp" <<<"$masking"; then
   fail=1
 fi
 
+# --- 6. FTPS data channel must reuse the control TLS secret (JAB-257). ---
+# require_ssl_reuse=NO let an attacker on the victim's NAT hijack a passive
+# data connection; YES is vsftpd's secure default and must not drift back.
+if grep -qE '^require_ssl_reuse=NO' <<<"$cfgfn"; then
+  echo "FAIL: require_ssl_reuse=NO — FTPS data channel can be hijacked (JAB-257)"
+  fail=1
+fi
+if ! grep -qE '^require_ssl_reuse=YES' <<<"$cfgfn"; then
+  echo "FAIL: require_ssl_reuse=YES missing from the FTPS config (JAB-257)"
+  fail=1
+fi
+
 if [[ "$fail" -eq 0 ]]; then
   echo "OK: ftp module opt-in guards hold"
 else


### PR DESCRIPTION
## Summary
The managed vsftpd config set `require_ssl_reuse=NO`, disabling vsftpd's secure default that requires each TLS **data** connection to prove knowledge of the authenticated **control** channel's TLS master secret. An attacker sharing the victim's outward-facing NAT (corporate / CGNAT / hotel / VPN) can race the small, predictable passive range (`40000-40100`) and attach an unrelated TLS session to a victim's transfer — stealing downloads or injecting uploads **without** the FTP password. vsftpd's source-IP check can't distinguish NAT-shared users.

## Fix
`require_ssl_reuse=YES` (vsftpd.conf's documented secure default). FTPS clients that reuse the control session's TLS — lftp, FileZilla, WinSCP, modern curl — work unchanged. A client that genuinely cannot reuse is a deliberate operator downgrade, not the shipped default (a gated compatibility override is a follow-up, not this fix). FTP is opt-in and TLS-required by default, so the exposed surface is small.

Regression test (`test_ftp_module_optin.sh`) pins `YES` and forbids `NO`.

## Test plan
- [x] install regression suite (ftp opt-in guards + new require_ssl_reuse assertion) green; bash -n + phantom-lint clean; post-rebase
- [ ] CI
- [ ] Post-merge: box FTPS transfer with a reuse-capable client still succeeds; `grep require_ssl_reuse /etc/vsftpd.conf` = YES

JAB-257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
