### PR TITLE
fix(security): FTP subaccounts honor owner suspension + package eligibility (JAB-254, JAB-258)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -553,6 +553,64 @@ func ftpAccountListHandler(ctx context.Context, params json.RawMessage) (any, er
 	return map[string]any{"accounts": entries}, nil
 }
 
+// ftpTenantAliasNames returns the tenant's panel-owned FTP alias
+// usernames (namespaced + same-uid + GECOS-marked), read from /etc/passwd.
+func ftpTenantAliasNames(tenant *ftpTenant) ([]string, *agentwire.AgentError) {
+	passwd, err := os.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read passwd: %v", err)}
+	}
+	prefix := tenant.Username + "_"
+	var names []string
+	for _, line := range strings.Split(string(passwd), "\n") {
+		parts := strings.Split(line, ":")
+		if len(parts) < 6 || !strings.HasPrefix(parts[0], prefix) {
+			continue
+		}
+		if uid, _ := strconv.Atoi(parts[2]); uid != tenant.UID {
+			continue
+		}
+		if gecosName(parts[4]) != ftpAliasGecos {
+			continue
+		}
+		names = append(names, parts[0])
+	}
+	return names, nil
+}
+
+// ftpAccountLockTenantHandler locks EVERY panel-owned FTP/SFTP alias of a
+// tenant immediately: usermod -L (blocks password auth for both SFTP and
+// FTPS) + drop from jabali-ftp (closes the vsftpd PAM gate). Called
+// synchronously from the tenant-suspension cascade (JAB-254) so a
+// suspended owner's delegated credentials stop working at once, not on
+// the next reconcile tick. Idempotent; unsuspension is handled by the
+// reconciler restoring each alias to its row's desired state.
+func ftpAccountLockTenantHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		TenantUsername string `json:"tenant_username"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	names, aerr := ftpTenantAliasNames(tenant)
+	if aerr != nil {
+		return nil, aerr
+	}
+	locked := 0
+	for _, name := range names {
+		_ = setFtpGroupMembership(ctx, name, false)
+		if out, err := exec.CommandContext(ctx, "usermod", "-L", name).CombinedOutput(); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -L %q: %v: %s", name, err, strings.TrimSpace(string(out)))}
+		}
+		locked++
+	}
+	return map[string]any{"locked": locked}, nil
+}
+
 // ---- ftpaccount.list_all ----
 
 type ftpAccountListAllEntry struct {
@@ -656,4 +714,5 @@ func init() {
 	Default.Register("ftpaccount.delete", ftpAccountDeleteHandler)
 	Default.Register("ftpaccount.list", ftpAccountListHandler)
 	Default.Register("ftpaccount.list_all", ftpAccountListAllHandler)
+	Default.Register("ftpaccount.lock_tenant", ftpAccountLockTenantHandler)
 }

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -66,6 +66,97 @@ func RegisterFtpAccountRoutes(g *gin.RouterGroup, cfg FtpAccountsHandlerConfig) 
 
 	admin := g.Group("/admin/ftp-accounts", middleware.RequireAdmin())
 	admin.GET("", h.adminList)
+	// JAB-258: ownership-safe override so an operator can revoke stranded
+	// aliases (owner suspended, or package downgraded to zero FTP) that
+	// the tenant's own routes may no longer create but must still be able
+	// to remove.
+	admin.PATCH("/:id", h.adminUpdate)
+	admin.DELETE("/:id", h.adminDelete)
+}
+
+// adminResolveAccount loads an account by id (any owner) plus the owner's
+// Linux username, for the admin override routes.
+func (h *ftpAccountsHandler) adminResolveAccount(c *gin.Context) (*models.FtpAccount, string, bool) {
+	ctx := c.Request.Context()
+	acct, err := h.cfg.Repo.FindByID(ctx, c.Param("id"))
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return nil, "", false
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return nil, "", false
+	}
+	owner, uerr := h.cfg.Users.FindByID(ctx, acct.UserID)
+	if uerr != nil || owner == nil || owner.Username == nil || *owner.Username == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "owner_unresolved", "detail": "account owner has no Linux username"})
+		return nil, "", false
+	}
+	return acct, *owner.Username, true
+}
+
+// adminUpdate lets an operator flip is_enabled / ftp_access / sftp_access
+// on any account regardless of the owner's package cap (JAB-258).
+func (h *ftpAccountsHandler) adminUpdate(c *gin.Context) {
+	var req ftpAccountUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_body"})
+		return
+	}
+	acct, ownerName, ok := h.adminResolveAccount(c)
+	if !ok {
+		return
+	}
+	if req.FTPAccess != nil {
+		acct.FTPAccess = *req.FTPAccess
+	}
+	if req.SFTPAccess != nil {
+		acct.SFTPAccess = *req.SFTPAccess
+	}
+	if req.IsEnabled != nil {
+		acct.IsEnabled = *req.IsEnabled
+	}
+	ctx := c.Request.Context()
+	if err := h.agentCall(ctx, "ftpaccount.set_access", map[string]any{
+		"tenant_username": ownerName,
+		"username":        acct.Username,
+		"ftp_access":      acct.FTPAccess,
+		"enabled":         acct.IsEnabled,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "update_failed")
+		c.JSON(status, payload)
+		return
+	}
+	acct.UpdatedAt = time.Now().UTC()
+	if err := h.cfg.Repo.Update(ctx, acct); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	h.syncHostAccess(ctx, ownerName)
+	c.JSON(http.StatusOK, acct)
+}
+
+// adminDelete removes any account (host alias + row), owner-safe.
+func (h *ftpAccountsHandler) adminDelete(c *gin.Context) {
+	acct, ownerName, ok := h.adminResolveAccount(c)
+	if !ok {
+		return
+	}
+	ctx := c.Request.Context()
+	if err := h.agentCall(ctx, "ftpaccount.delete", map[string]any{
+		"tenant_username": ownerName,
+		"username":        acct.Username,
+	}); err != nil {
+		status, payload := mapFtpAgentError(err, "delete_failed")
+		c.JSON(status, payload)
+		return
+	}
+	if err := h.cfg.Repo.Delete(ctx, acct.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	h.syncHostAccess(ctx, ownerName)
+	c.JSON(http.StatusOK, gin.H{"deleted": true})
 }
 
 type ftpAccountsHandler struct{ cfg FtpAccountsHandlerConfig }
@@ -103,6 +194,27 @@ type ftpAccountPasswordRequest struct {
 // resolveTenant loads the calling user and enforces the package gate.
 // Returns (user, package, ok). Writes the error response when !ok.
 func (h *ftpAccountsHandler) resolveTenant(c *gin.Context) (*models.User, *models.HostingPackage, bool) {
+	u, pkg, ok := h.resolveTenantForManagement(c)
+	if !ok {
+		return nil, nil, false
+	}
+	// JAB-258: the zero-cap gate applies to CREATION ONLY. Revocation
+	// (list/disable/delete/password) must remain reachable after a
+	// downgrade so a tenant can remove credentials the package no longer
+	// entitles — resolveTenantForManagement omits this check.
+	if pkg.MaxFTPAccounts == 0 {
+		c.JSON(http.StatusForbidden, gin.H{"error": "ftp_accounts_not_in_package", "detail": "your hosting package does not include FTP/SFTP accounts"})
+		return nil, nil, false
+	}
+	return u, pkg, true
+}
+
+// resolveTenantForManagement loads the caller + package WITHOUT the
+// zero-cap creation gate, so list/disable/delete/password stay available
+// to revoke credentials after a package downgrade (JAB-258). It still
+// requires a real Linux user and a resolvable package (a package-less
+// tenant has no FTP surface at all).
+func (h *ftpAccountsHandler) resolveTenantForManagement(c *gin.Context) (*models.User, *models.HostingPackage, bool) {
 	claims := ginctx.Claims(c)
 	if claims == nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
@@ -114,8 +226,6 @@ func (h *ftpAccountsHandler) resolveTenant(c *gin.Context) (*models.User, *model
 		c.JSON(http.StatusForbidden, gin.H{"error": "no_account", "detail": "account has no Linux user"})
 		return nil, nil, false
 	}
-	// Package-gated like tenant Docker (Gitea #511): package-less tenants
-	// are denied — a same-uid alias is privileged surface.
 	if u.PackageID == nil {
 		c.JSON(http.StatusForbidden, gin.H{"error": "ftp_accounts_require_package", "detail": "FTP/SFTP accounts require a hosting package that includes them"})
 		return nil, nil, false
@@ -123,10 +233,6 @@ func (h *ftpAccountsHandler) resolveTenant(c *gin.Context) (*models.User, *model
 	pkg, perr := h.cfg.Packages.FindByID(ctx, *u.PackageID)
 	if perr != nil || pkg == nil {
 		c.JSON(http.StatusForbidden, gin.H{"error": "no_package"})
-		return nil, nil, false
-	}
-	if pkg.MaxFTPAccounts == 0 {
-		c.JSON(http.StatusForbidden, gin.H{"error": "ftp_accounts_not_in_package", "detail": "your hosting package does not include FTP/SFTP accounts"})
 		return nil, nil, false
 	}
 	return u, pkg, true
@@ -212,7 +318,7 @@ func (h *ftpAccountsHandler) syncHostAccess(ctx context.Context, tenantUsername 
 }
 
 func (h *ftpAccountsHandler) list(c *gin.Context) {
-	u, _, ok := h.resolveTenant(c)
+	u, _, ok := h.resolveTenantForManagement(c)
 	if !ok {
 		return
 	}
@@ -314,7 +420,7 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 }
 
 func (h *ftpAccountsHandler) update(c *gin.Context) {
-	u, _, ok := h.resolveTenant(c)
+	u, _, ok := h.resolveTenantForManagement(c)
 	if !ok {
 		return
 	}
@@ -362,7 +468,7 @@ func (h *ftpAccountsHandler) update(c *gin.Context) {
 }
 
 func (h *ftpAccountsHandler) setPassword(c *gin.Context) {
-	u, _, ok := h.resolveTenant(c)
+	u, _, ok := h.resolveTenantForManagement(c)
 	if !ok {
 		return
 	}
@@ -398,7 +504,7 @@ func (h *ftpAccountsHandler) setPassword(c *gin.Context) {
 }
 
 func (h *ftpAccountsHandler) delete(c *gin.Context) {
-	u, _, ok := h.resolveTenant(c)
+	u, _, ok := h.resolveTenantForManagement(c)
 	if !ok {
 		return
 	}

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -323,3 +323,34 @@ func TestFtpAPIPassword_OwnershipAndLength(t *testing.T) {
 		t.Fatalf("expected 422, got %d", rec.Code)
 	}
 }
+
+// JAB-258: after a downgrade to zero FTP cap, CREATE is blocked (403) but
+// management routes — list, disable (update), delete — MUST still work so
+// the tenant can revoke credentials the package no longer entitles.
+func TestFtpAPI_ZeroCap_ManagementStillWorks(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["a1"] = &models.FtpAccount{ID: "a1", UserID: "u1", Username: "shop_deploy", SFTPAccess: true, IsEnabled: true}
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(0)) // downgraded: zero FTP
+
+	// create blocked
+	if rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"x","home_path":"/home/shop/x","password":"password1234"}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("create at zero cap: got %d, want 403", rec.Code)
+	}
+	// list works
+	if rec := doReq(t, r, http.MethodGet, "/me/ftp-accounts", ""); rec.Code != http.StatusOK {
+		t.Fatalf("list at zero cap: got %d, want 200", rec.Code)
+	}
+	// disable works
+	if rec := doReq(t, r, http.MethodPatch, "/me/ftp-accounts/a1", `{"is_enabled":false}`); rec.Code != http.StatusOK {
+		t.Fatalf("disable at zero cap: got %d, want 200", rec.Code)
+	}
+	// delete works
+	if rec := doReq(t, r, http.MethodDelete, "/me/ftp-accounts/a1", ""); rec.Code != http.StatusOK {
+		t.Fatalf("delete at zero cap: got %d, want 200", rec.Code)
+	}
+	if len(repo.rows) != 0 {
+		t.Fatal("row not deleted at zero cap")
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4855,6 +4855,33 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/ftp-accounts/{id}:
+    patch:
+      tags: [Ftp Accounts]
+      summary: Admin override — disable/enable/toggle any FTP account (JAB-258)
+      description: >
+        Ownership-safe operator override to disable or re-enable a stranded
+        FTP/SFTP account (owner suspended, or package downgraded to zero FTP)
+        regardless of the owner's current package cap.
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ftp_access: { type: boolean }
+                sftp_access: { type: boolean }
+                is_enabled: { type: boolean }
+      responses: { "200": { description: OK } }
+    delete:
+      tags: [Ftp Accounts]
+      summary: Admin override — delete any FTP account (JAB-258)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Ssl (auto) ---
 

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -72,6 +72,90 @@ type agentFtpListEntry struct {
 // reconcileFtpAccounts converges host state to the ftp_accounts table.
 // Never returns an error — SSL-reconciler convention: log and let the
 // rest of the tick proceed.
+// ftpOwnerEligibility captures whether a tenant may currently HOLD active
+// FTP/SFTP credentials and how many. Ineligible owners (JAB-254 suspended,
+// JAB-258 package dropped the feature) must have every alias locked +
+// degrouped, and an over-cap owner (JAB-258 downgrade to a lower cap)
+// keeps only its oldest `cap` accounts.
+type ftpOwnerEligibility struct {
+	eligible bool // false => lock ALL of this tenant's aliases
+	cap      int  // max simultaneously-enabled accounts (0 when !eligible)
+}
+
+// ftpEffectiveEnabled applies owner eligibility on top of a row's own
+// IsEnabled. accts MUST be the tenant's full set; over-cap accounts
+// (oldest-first) beyond `cap` are forced disabled deterministically.
+// Returns username -> effective-enabled.
+func ftpEffectiveEnabled(accts []models.FtpAccount, elig ftpOwnerEligibility) map[string]bool {
+	out := make(map[string]bool, len(accts))
+	if !elig.eligible {
+		for _, a := range accts {
+			out[a.Username] = false
+		}
+		return out
+	}
+	// Oldest-first so a cap reduction disables the NEWEST accounts,
+	// keeping the tenant's long-standing credentials working.
+	ordered := append([]models.FtpAccount(nil), accts...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].CreatedAt.Equal(ordered[j].CreatedAt) {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return ordered[i].CreatedAt.Before(ordered[j].CreatedAt)
+	})
+	kept := 0
+	for _, a := range ordered {
+		if !a.IsEnabled {
+			out[a.Username] = false
+			continue
+		}
+		if elig.cap > 0 && kept >= elig.cap {
+			out[a.Username] = false // over-cap: excess disabled
+			continue
+		}
+		out[a.Username] = true
+		kept++
+	}
+	return out
+}
+
+// ftpOwnerEligibility resolves whether a tenant may hold active FTP/SFTP
+// credentials right now: NOT administratively suspended (JAB-254) AND the
+// hosting package still includes the feature (max_ftp_accounts > 0,
+// JAB-258). A missing package or lookup failure is treated as ineligible
+// (fail closed) — a same-uid credential is privileged surface.
+func (r *Reconciler) ftpOwnerEligibility(ctx context.Context, u *models.User) ftpOwnerEligibility {
+	if u == nil || u.Suspended {
+		return ftpOwnerEligibility{eligible: false}
+	}
+	if r.packages == nil || u.PackageID == nil || *u.PackageID == "" {
+		return ftpOwnerEligibility{eligible: false}
+	}
+	pkg, err := r.packages.FindByID(ctx, *u.PackageID)
+	if err != nil || pkg == nil || pkg.MaxFTPAccounts == 0 {
+		return ftpOwnerEligibility{eligible: false}
+	}
+	return ftpOwnerEligibility{eligible: true, cap: int(pkg.MaxFTPAccounts)}
+}
+
+// ftpEligHash folds owner eligibility into the reconcile hash so a
+// suspension or package downgrade forces a re-dispatch instead of being
+// masked by the steady-state cache.
+func ftpEligHash(elig map[string]ftpOwnerEligibility) string {
+	keys := make([]string, 0, len(elig))
+	for k := range elig {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		e := elig[k]
+		fmt.Fprintf(&b, "%s=%t:%d;", k, e.eligible, e.cap)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
 func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	if r.ftpAccounts == nil || r.users == nil || r.agent == nil {
 		return
@@ -87,6 +171,7 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	// they cannot converge and must not kill the pass.
 	tenantByUserID := map[string]string{}
 	rowsByTenant := map[string][]models.FtpAccount{}
+	eligByTenant := map[string]ftpOwnerEligibility{}
 	for _, a := range rows {
 		uname, ok := tenantByUserID[a.UserID]
 		if !ok {
@@ -98,6 +183,7 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 			}
 			uname = *u.Username
 			tenantByUserID[a.UserID] = uname
+			eligByTenant[uname] = r.ftpOwnerEligibility(ctx, u)
 		}
 		if uname == "" {
 			continue
@@ -105,7 +191,7 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 		rowsByTenant[uname] = append(rowsByTenant[uname], a)
 	}
 
-	fullHash := desiredFtpHash(rows, tenantByUserID)
+	fullHash := desiredFtpHash(rows, tenantByUserID) + ftpEligHash(eligByTenant)
 	if v, ok := r.ftpDispatchCache.Load("all"); ok {
 		if st, okT := v.(ftpDispatchState); okT && st.Hash == fullHash && time.Since(st.At) < ftpAccountsReDispatchInterval {
 			return
@@ -114,7 +200,7 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 
 	converged := true
 	for tenant, accts := range rowsByTenant {
-		if !r.reconcileFtpTenant(ctx, tenant, accts) {
+		if !r.reconcileFtpTenant(ctx, tenant, accts, eligByTenant[tenant]) {
 			converged = false
 		}
 	}
@@ -139,8 +225,9 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	desired := []syncAccount{}
 	for tenant, accts := range rowsByTenant {
 		chroot := "/home/" + tenant
+		eff := ftpEffectiveEnabled(accts, eligByTenant[tenant])
 		for _, a := range accts {
-			if !a.IsEnabled || !a.SFTPAccess {
+			if !eff[a.Username] || !a.SFTPAccess {
 				continue
 			}
 			start := "/"
@@ -212,7 +299,11 @@ func (r *Reconciler) sweepStrayFtpAliases(ctx context.Context, rows []models.Ftp
 // reconcileFtpTenant diffs one tenant's desired rows against the host's
 // passwd view and repairs drift. Returns false when any repair failed
 // (keeps the hash gate open so the next tick retries).
-func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, accts []models.FtpAccount) bool {
+func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, accts []models.FtpAccount, elig ftpOwnerEligibility) bool {
+	// JAB-254/258: owner eligibility overrides each row's own IsEnabled —
+	// a suspended owner or a package that dropped the feature locks every
+	// alias; an over-cap downgrade locks the newest excess.
+	eff := ftpEffectiveEnabled(accts, elig)
 	raw, err := r.agent.Call(ctx, "ftpaccount.list", map[string]any{"tenant_username": tenant})
 	if err != nil {
 		r.log.Warn("ftp: host list failed", "tenant", tenant, "err", err)
@@ -258,13 +349,17 @@ func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, acct
 			r.log.Info("ftp: recreated missing subaccount — password reset required before it can log in", "account", name, "tenant", tenant)
 			got = agentFtpListEntry{Username: name, FTPAccess: want.FTPAccess, Locked: false}
 		}
-		wantLocked := !want.IsEnabled
-		if got.FTPAccess != want.FTPAccess || got.Locked != wantLocked {
+		enabled := eff[name]
+		// Ineligible/over-cap => also drop the jabali-ftp group so the
+		// vsftpd PAM gate closes, not just the shadow lock.
+		wantFTP := want.FTPAccess && enabled
+		wantLocked := !enabled
+		if got.FTPAccess != wantFTP || got.Locked != wantLocked {
 			if _, err := r.agent.Call(ctx, "ftpaccount.set_access", map[string]any{
 				"tenant_username": tenant,
 				"username":        name,
-				"ftp_access":      want.FTPAccess,
-				"enabled":         want.IsEnabled,
+				"ftp_access":      wantFTP,
+				"enabled":         enabled,
 			}); err != nil {
 				r.log.Warn("ftp: access drift repair failed", "account", name, "err", err)
 				ok = false
@@ -280,7 +375,7 @@ func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, acct
 	// tenant-owned /home/<tenant>; flip it via the existing M12 verb when
 	// this tenant has at least one SFTP-enabled subaccount.
 	for _, a := range accts {
-		if a.IsEnabled && a.SFTPAccess {
+		if eff[a.Username] && a.SFTPAccess {
 			if _, err := r.agent.Call(ctx, "ssh.user.home_chown", map[string]any{
 				"username": tenant,
 				"mode":     "sftp",

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -47,11 +47,25 @@ func ftpTestReconciler(t *testing.T, agent *fakeAgent, rows []models.FtpAccount,
 	byID := map[string]*models.User{}
 	for userID, uname := range tenants {
 		name := uname
-		byID[userID] = &models.User{ID: userID, Username: &name}
+		pid := "pkg-ftp"
+		// Eligible by default (JAB-254/258): not suspended + a package
+		// with a generous FTP cap, so existing per-row expectations hold.
+		byID[userID] = &models.User{ID: userID, Username: &name, PackageID: &pid}
 	}
 	r := New(nil, &ftpUsersRepo{byID: byID}, agent, slog.Default(), Config{})
 	r.WithFtpAccounts(&fakeFtpAccountRepo{rows: rows})
+	r.WithPackages(&ftpPkgRepo{pkg: &models.HostingPackage{ID: "pkg-ftp", MaxFTPAccounts: 100}})
 	return r
+}
+
+// ftpPkgRepo returns a single package for every id (test helper).
+type ftpPkgRepo struct {
+	repository.PackageRepository
+	pkg *models.HostingPackage
+}
+
+func (f *ftpPkgRepo) FindByID(context.Context, string) (*models.HostingPackage, error) {
+	return f.pkg, nil
 }
 
 func ftpCallsByMethod(a *fakeAgent) map[string][]fakeCall {

--- a/panel-api/internal/reconciler/ftp_eligibility_test.go
+++ b/panel-api/internal/reconciler/ftp_eligibility_test.go
@@ -1,0 +1,134 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func ftpRow(id, user string, enabled bool, created time.Time) models.FtpAccount {
+	return models.FtpAccount{ID: id, UserID: "u1", Username: user, IsEnabled: enabled, FTPAccess: true, SFTPAccess: true, CreatedAt: created}
+}
+
+// JAB-254/258: an ineligible owner (suspended, or package dropped the
+// feature) forces every alias effective-disabled regardless of its row.
+func TestFtpEffectiveEnabled_IneligibleLocksAll(t *testing.T) {
+	base := time.Now()
+	rows := []models.FtpAccount{
+		ftpRow("a", "shop_one", true, base),
+		ftpRow("b", "shop_two", true, base.Add(time.Minute)),
+	}
+	eff := ftpEffectiveEnabled(rows, ftpOwnerEligibility{eligible: false})
+	for _, a := range rows {
+		if eff[a.Username] {
+			t.Fatalf("%s enabled under ineligible owner", a.Username)
+		}
+	}
+}
+
+// JAB-258: an over-cap owner keeps only its OLDEST `cap` enabled accounts.
+func TestFtpEffectiveEnabled_OverCapLocksNewest(t *testing.T) {
+	base := time.Now()
+	rows := []models.FtpAccount{
+		ftpRow("a", "shop_old", true, base),
+		ftpRow("b", "shop_mid", true, base.Add(time.Hour)),
+		ftpRow("c", "shop_new", true, base.Add(2*time.Hour)),
+	}
+	eff := ftpEffectiveEnabled(rows, ftpOwnerEligibility{eligible: true, cap: 2})
+	if !eff["shop_old"] || !eff["shop_mid"] {
+		t.Fatalf("oldest two should stay enabled: %+v", eff)
+	}
+	if eff["shop_new"] {
+		t.Fatalf("newest (over-cap) should be disabled: %+v", eff)
+	}
+}
+
+// Eligible owner within cap: row's own IsEnabled is respected.
+func TestFtpEffectiveEnabled_EligibleRespectsRow(t *testing.T) {
+	base := time.Now()
+	rows := []models.FtpAccount{
+		ftpRow("a", "shop_on", true, base),
+		ftpRow("b", "shop_off", false, base.Add(time.Minute)),
+	}
+	eff := ftpEffectiveEnabled(rows, ftpOwnerEligibility{eligible: true, cap: 10})
+	if !eff["shop_on"] || eff["shop_off"] {
+		t.Fatalf("row flags not respected: %+v", eff)
+	}
+}
+
+// JAB-254 flow: a suspended owner's live+unlocked host alias is driven to
+// locked + FTP-degrouped by the reconcile pass.
+func TestReconcileFtp_SuspendedOwnerLocksAlias(t *testing.T) {
+	rows := []models.FtpAccount{ftpRow("a", "shop_dev", true, time.Now())}
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_dev", FTPAccess: true, Locked: false}, // live on host
+		}),
+		"ftpaccount.list_all":   hostListAllResult(t, []agentFtpListEntry{{Username: "shop_dev"}}),
+		"ftpaccount.set_access": json.RawMessage(`{}`),
+		"ftpaccount.sshd_sync":  json.RawMessage(`{}`),
+		"ssh.user.home_chown":   json.RawMessage(`{}`),
+	}}
+	// Suspended owner + eligible package — suspension must still win.
+	uname := "shop"
+	pid := "pkg-ftp"
+	r := New(nil, &ftpUsersRepo{byID: map[string]*models.User{
+		"u1": {ID: "u1", Username: &uname, PackageID: &pid, Suspended: true},
+	}}, agent, slog.Default(), Config{})
+	r.WithFtpAccounts(&fakeFtpAccountRepo{rows: rows})
+	r.WithPackages(&ftpPkgRepo{pkg: &models.HostingPackage{ID: "pkg-ftp", MaxFTPAccounts: 100}})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	sa := calls["ftpaccount.set_access"]
+	if len(sa) != 1 {
+		t.Fatalf("expected 1 set_access to lock the alias, got %d", len(sa))
+	}
+	p := sa[0].params.(map[string]any)
+	if p["enabled"] != false || p["ftp_access"] != false {
+		t.Fatalf("suspended owner's alias not fully locked+degrouped: %+v", p)
+	}
+	// A suspended owner's SFTP account must be dropped from the sshd sync.
+	sync := calls["ftpaccount.sshd_sync"]
+	if len(sync) != 1 {
+		t.Fatalf("expected sshd_sync call")
+	}
+	sp := sync[0].params.(map[string]any)
+	accts, _ := sp["accounts"].([]any)
+	if len(accts) != 0 {
+		t.Fatalf("suspended owner's SFTP alias still in sshd sync: %+v", accts)
+	}
+}
+
+// JAB-258 flow: package with zero FTP cap locks all aliases.
+func TestReconcileFtp_ZeroCapLocksAlias(t *testing.T) {
+	rows := []models.FtpAccount{ftpRow("a", "shop_dev", true, time.Now())}
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list": hostListResult(t, []agentFtpListEntry{
+			{Username: "shop_dev", FTPAccess: true, Locked: false},
+		}),
+		"ftpaccount.list_all":   hostListAllResult(t, []agentFtpListEntry{{Username: "shop_dev"}}),
+		"ftpaccount.set_access": json.RawMessage(`{}`),
+		"ftpaccount.sshd_sync":  json.RawMessage(`{}`),
+		"ssh.user.home_chown":   json.RawMessage(`{}`),
+	}}
+	uname := "shop"
+	pid := "pkg-ftp"
+	r := New(nil, &ftpUsersRepo{byID: map[string]*models.User{
+		"u1": {ID: "u1", Username: &uname, PackageID: &pid},
+	}}, agent, slog.Default(), Config{})
+	r.WithFtpAccounts(&fakeFtpAccountRepo{rows: rows})
+	r.WithPackages(&ftpPkgRepo{pkg: &models.HostingPackage{ID: "pkg-ftp", MaxFTPAccounts: 0}})
+
+	r.reconcileFtpAccounts(context.Background())
+
+	sa := ftpCallsByMethod(agent)["ftpaccount.set_access"]
+	if len(sa) != 1 || sa[0].params.(map[string]any)["enabled"] != false {
+		t.Fatalf("zero-cap package did not lock the alias: %+v", sa)
+	}
+}

--- a/panel-api/internal/userops/userops_suspend.go
+++ b/panel-api/internal/userops/userops_suspend.go
@@ -109,6 +109,16 @@ func Suspend(ctx context.Context, d Deps, user *models.User, reason string) (Sus
 		if _, err := d.Agent.Call(ctx, "user.suspend", map[string]any{"username": *user.Username}); err != nil {
 			res.OSWarning = "user_os_suspend_failed: " + err.Error()
 		}
+		// JAB-254: lock every FTP/SFTP subaccount alias immediately so a
+		// suspended owner's delegated credentials stop working at once,
+		// not on the next reconcile tick. The reconciler's owner-
+		// eligibility gate is the durable backstop and also handles
+		// restore-to-desired on unsuspension, so this is best-effort.
+		if _, err := d.Agent.Call(ctx, "ftpaccount.lock_tenant", map[string]any{"tenant_username": *user.Username}); err != nil {
+			if res.OSWarning == "" {
+				res.OSWarning = "ftp_alias_lock_failed: " + err.Error()
+			}
+		}
 	}
 
 	return res, nil

--- a/panel-api/internal/userops/userops_suspend_test.go
+++ b/panel-api/internal/userops/userops_suspend_test.go
@@ -58,8 +58,9 @@ func TestSuspend_FullCascade(t *testing.T) {
 		t.Errorf("domains: disabled=%d lastEnabled=%v, want 3 + false", res.DomainsDisabled, doms.lastEn)
 	}
 	// OS cascade fired for the linux user.
-	if len(ag.calls) != 1 || ag.calls[0].method != "user.suspend" {
-		t.Errorf("agent calls = %+v, want one user.suspend", ag.calls)
+	// JAB-254: suspension now also locks the tenant's FTP/SFTP aliases.
+	if len(ag.calls) != 2 || ag.calls[0].method != "user.suspend" || ag.calls[1].method != "ftpaccount.lock_tenant" {
+		t.Errorf("agent calls = %+v, want user.suspend then ftpaccount.lock_tenant", ag.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
Suspended owners (JAB-254) and package-downgraded tenants (JAB-258) kept working FTP/SFTP subaccount credentials the panel believed were revoked — an entitlement + incident-response bypass. Worse, after a downgrade the tenant's own routes returned 403 (cap 0), so they couldn't even remove the stranded credentials.

## Fix
### Reconciler — durable enforcement (both issues)
Each tenant now carries an **owner eligibility**: NOT suspended AND package `max_ftp_accounts > 0` (fail-closed on a missing/unresolvable package). An ineligible owner forces **every** alias effective-disabled — `usermod -L` + dropped from `jabali-ftp` + excluded from the sshd sync — regardless of the row's own `is_enabled`. An **over-cap** downgrade locks the **newest** excess (oldest-first), keeping long-standing credentials. Rows are preserved as teardown handles. Eligibility is folded into the reconcile hash so a suspension/downgrade re-dispatches on the next tick instead of being masked by the steady-state cache.

### Suspend cascade — immediacy (JAB-254)
User suspension also dispatches a new agent verb `ftpaccount.lock_tenant`, locking every panel-owned alias of the tenant at once (`usermod -L` + degroup), so delegated credentials stop working **synchronously**. Best-effort — the reconciler is the backstop and restores aliases to per-row desired state on unsuspension.

### API — manageability (JAB-258)
`resolveTenant`'s zero-cap 403 now applies to **creation only**; list / disable / password / delete route through a new `resolveTenantForManagement` (no cap gate), so a tenant can revoke stranded credentials. New ownership-safe admin overrides `PATCH`/`DELETE /admin/ftp-accounts/:id` let an operator disable/delete any stranded account (openapi documented).

## Test plan
- [x] `ftpEffectiveEnabled`: ineligible locks all; over-cap locks newest (oldest-first); eligible respects the row flag
- [x] Reconcile flow: suspended owner **and** zero-cap owner drive a live+unlocked host alias to locked + FTP-degrouped + out of the sshd sync
- [x] API: list / disable / delete work at cap 0 while create 403s
- [x] Suspend cascade asserts the `ftpaccount.lock_tenant` dispatch
- [x] Full panel-api + panel-agent suites: 0 FAIL; openapi coverage green; gofmt/vet clean; post-rebase
- [ ] CI
- [ ] Post-merge live on testserver: suspend a tenant with an FTP alias → alias locked (auth fails); package to zero → alias locked, tenant delete route still works

JAB-254 JAB-258

🤖 Generated with [Claude Code](https://claude.com/claude-code)
