### PR TITLE
fix(dr): standby must not run schedulers; restic tag filters must AND (GH #331 drill)

### DIFF
--- a/docs/runbooks/dr-standby.md
+++ b/docs/runbooks/dr-standby.md
@@ -78,6 +78,11 @@ Pairing flips `server_role` to `standby`. From this point:
   manifests and, when a newer one exists than it last applied, runs
   `system.restore {apply:true, include_accounts:false}` (panel DB + config + TLS);
 - the reconciler goes dormant (no serving config, no ACME certificate issuance);
+- the backup scheduler goes dormant (the replicated DB carries the primary's
+  ENABLED schedules — including the DR feed itself — which must not run here),
+  and the daily retention sweep skips (the replicated destinations point at
+  the primary's repositories; pruning them from the standby would destroy the
+  primary's backups);
 - the API refuses tenant writes with `409 server_is_standby`;
 - every page shows the read-only DR banner.
 

--- a/internal/backup/copy.go
+++ b/internal/backup/copy.go
@@ -114,8 +114,10 @@ func Copy(ctx context.Context, runner Runner, opts CopyOpts, extraEnv []string) 
 		"--from-repo", opts.FromRepo,
 		"--from-password-file", opts.FromPasswordFile,
 	)
-	for _, t := range opts.Tags {
-		args = append(args, "--tag", string(t))
+	// Comma-joined = AND (see Client.Snapshots): restic treats repeated
+	// --tag flags as OR groups, and a copy filter must match ALL tags.
+	if len(opts.Tags) > 0 {
+		args = append(args, "--tag", JoinTagsAND(opts.Tags))
 	}
 	args = append(args, opts.SnapshotIDs...)
 

--- a/internal/backup/restic.go
+++ b/internal/backup/restic.go
@@ -160,11 +160,16 @@ type Snapshot struct {
 }
 
 // Snapshots lists snapshots. Optional tags filter narrows the result
-// server-side via repeated --tag=key=value flags.
+// server-side; multiple tags are comma-joined into ONE --tag flag because
+// restic treats repeated --tag flags as OR groups and a comma-joined list as
+// AND. Every caller here filters (kind + stage [+ user]) and means AND — the
+// repeated-flag form returned every snapshot matching ANY tag, which made
+// "newest manifest" selection pick non-manifest stage snapshots (GH #331
+// two-node drill finding).
 func (c *Client) Snapshots(ctx context.Context, tags []Tag) ([]Snapshot, error) {
 	args := []string{"snapshots", "--json"}
-	for _, t := range tags {
-		args = append(args, "--tag", string(t))
+	if len(tags) > 0 {
+		args = append(args, "--tag", JoinTagsAND(tags))
 	}
 	out, _, err := c.run(ctx, args, nil)
 	if err != nil {
@@ -378,8 +383,10 @@ func (c *Client) Forget(ctx context.Context, opts ForgetOpts) ([]byte, error) {
 	if opts.KeepMonthly > 0 {
 		args = append(args, "--keep-monthly", strconv.FormatUint(uint64(opts.KeepMonthly), 10))
 	}
-	for _, t := range opts.Tags {
-		args = append(args, "--tag", string(t))
+	// Comma-joined = AND (see Snapshots): forget must select only snapshots
+	// carrying ALL the given tags, never a union.
+	if len(opts.Tags) > 0 {
+		args = append(args, "--tag", JoinTagsAND(opts.Tags))
 	}
 	if opts.Prune {
 		args = append(args, "--prune")

--- a/internal/backup/restic_test.go
+++ b/internal/backup/restic_test.go
@@ -140,11 +140,10 @@ func TestSnapshots_TagFilter(t *testing.T) {
 		t.Fatalf("Snapshots: %v", err)
 	}
 	args := strings.Join(r.calls[0].args, " ")
-	if !strings.Contains(args, "--tag job-id=01J5JOB") {
-		t.Fatalf("missing job-id tag in: %s", args)
-	}
-	if !strings.Contains(args, "--tag stage=home") {
-		t.Fatalf("missing stage tag in: %s", args)
+	// One comma-joined --tag = AND filter (GH #331 drill finding); repeated
+	// --tag flags are OR groups in restic.
+	if !strings.Contains(args, "--tag job-id=01J5JOB,stage=home") {
+		t.Fatalf("expected comma-joined AND tag filter in: %s", args)
 	}
 }
 
@@ -296,5 +295,45 @@ func TestBackup_ExtraExcludeFiles(t *testing.T) {
 	}
 	if strings.HasSuffix(strings.TrimSpace(args), "--exclude-file") {
 		t.Errorf("empty ExtraExcludeFiles entry leaked a bare flag:\n%s", args)
+	}
+}
+
+// GH #331 two-node drill finding: restic treats REPEATED --tag flags as OR
+// groups — `--tag kind=system_backup --tag stage=manifest` returned every
+// system_backup stage snapshot, so "newest manifest" selection picked a
+// panel_db snapshot. Multi-tag filters must comma-join into ONE --tag (AND).
+func TestSnapshots_MultiTagIsANDNotOR(t *testing.T) {
+	r := &fakeRunner{stdout: []byte("null\n")}
+	c := newClient(t, r)
+	_, err := c.Snapshots(context.Background(), []Tag{
+		MakeTag(TagKeyKind, KindSystemBackup),
+		MakeTag(TagKeyStage, StageManifest),
+	})
+	if err != nil {
+		t.Fatalf("Snapshots: %v", err)
+	}
+	joined := strings.Join(r.calls[0].args, " ")
+	if !strings.Contains(joined, "--tag kind=system_backup,stage=manifest") {
+		t.Fatalf("multi-tag filter must be one comma-joined --tag (AND), got: %s", joined)
+	}
+	if strings.Count(joined, "--tag") != 1 {
+		t.Fatalf("expected exactly one --tag flag, got: %s", joined)
+	}
+}
+
+// Forget with multiple tags must also AND them — a union here would forget
+// snapshots outside the intended selection.
+func TestForget_MultiTagIsAND(t *testing.T) {
+	r := &fakeRunner{stdout: []byte("ok")}
+	c := newClient(t, r)
+	if _, err := c.Forget(context.Background(), ForgetOpts{
+		KeepDaily: 1,
+		Tags:      []Tag{TagBlanket, MakeTag(TagKeyScheduleID, "01J5SCHED")},
+	}); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	joined := strings.Join(r.calls[0].args, " ")
+	if !strings.Contains(joined, "--tag jabali,schedule-id=01J5SCHED") {
+		t.Fatalf("forget multi-tag must comma-join, got: %s", joined)
 	}
 }

--- a/internal/backup/tagging.go
+++ b/internal/backup/tagging.go
@@ -6,7 +6,10 @@
 // See ADR-0075 + plans/m30-backup-restore.md.
 package backup
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Tag is one snapshot tag. Tags are key=value or bare strings; the
 // blanket `jabali` tag has no value.
@@ -85,6 +88,19 @@ const (
 // MakeTag formats `key=value`.
 func MakeTag(key, value string) Tag {
 	return Tag(fmt.Sprintf("%s=%s", key, value))
+}
+
+// JoinTagsAND renders tags as one comma-joined restic --tag value. restic's
+// tag matching is OR across repeated --tag flags and AND within one
+// comma-joined flag; every filter in this codebase means AND. Tag values
+// never contain commas (ULIDs, stage names, db names, hostnames), which is
+// what makes the comma join safe.
+func JoinTagsAND(tags []Tag) string {
+	parts := make([]string, 0, len(tags))
+	for _, t := range tags {
+		parts = append(parts, string(t))
+	}
+	return strings.Join(parts, ",")
 }
 
 // AccountBackupTags returns the canonical tag set for one stage of

--- a/panel-api/cmd/server/backup_retention_cmd.go
+++ b/panel-api/cmd/server/backup_retention_cmd.go
@@ -84,6 +84,16 @@ by install_backup_foundation in install.sh.`,
 			if err := assertResticEnvironment(); err != nil {
 				return err
 			}
+			// GH #331 two-node drill finding: a DR standby's DB is the
+			// PRIMARY's replica, so its schedules + destinations point at
+			// the primary's repos — including the shared DR channel. A
+			// retention pass here would `restic forget --prune` the
+			// primary's live backups from the standby. Hard skip.
+			if s, serr := repository.NewServerSettingsRepository(sharedDB).Get(ctx); serr == nil && s != nil && s.IsStandby() {
+				fmt.Fprintln(cmd.OutOrStdout(),
+					"retention sweep skipped: this box is a DR standby — its replicated destinations point at the primary's repositories, and pruning them from here would destroy the primary's backups")
+				return nil
+			}
 
 			// JAB-98: prune per-job backup log files under
 			// /var/lib/jabali-backups/logs older than the retention window.

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -159,7 +159,27 @@ func (s *Scheduler) TickOnce(ctx context.Context) {
 	s.tickDispatch(ctx)
 }
 
+// standbyInert reports whether this box is a DR standby (GH #331 two-node
+// drill finding): each applied drsync restore loads the PRIMARY's panel DB,
+// which carries the primary's ENABLED backup schedules and queued job rows.
+// An ungated scheduler on a standby therefore runs the primary's schedules —
+// including the DR feed itself, which shipped the STANDBY's state into the
+// shared DR repo, where a later promote could restore it as if it were the
+// primary's. A standby enqueues nothing and dispatches nothing; promotion
+// flips the role and the next tick resumes naturally (same re-read pattern
+// as drsync).
+func (s *Scheduler) standbyInert(ctx context.Context) bool {
+	if s.deps.Settings == nil {
+		return false
+	}
+	set, err := s.deps.Settings.Get(ctx)
+	return err == nil && set != nil && set.IsStandby()
+}
+
 func (s *Scheduler) tickEnqueue(ctx context.Context) {
+	if s.standbyInert(ctx) {
+		return
+	}
 	now := time.Now().UTC()
 	due, err := s.deps.Schedules.ListDue(ctx, now, MaxDuePerTick)
 	if err != nil {
@@ -174,6 +194,9 @@ func (s *Scheduler) tickEnqueue(ctx context.Context) {
 // tickDispatch reads the current concurrency limit, counts running
 // jobs, and dispatches queued rows to fill the gap.
 func (s *Scheduler) tickDispatch(ctx context.Context) {
+	if s.standbyInert(ctx) {
+		return
+	}
 	max := uint32(DefaultMaxConcurrent)
 	if s.deps.Settings != nil {
 		set, err := s.deps.Settings.Get(ctx)

--- a/panel-api/internal/backupscheduler/scheduler_standby_test.go
+++ b/panel-api/internal/backupscheduler/scheduler_standby_test.go
@@ -1,0 +1,70 @@
+package backupscheduler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// standbyFakeSettings satisfies repository.ServerSettingsRepository via
+// embedding; only Get is implemented — any other call panics, which is the
+// point: a gated tick must touch nothing else.
+type standbyFakeSettings struct {
+	repository.ServerSettingsRepository
+	s *models.ServerSettings
+}
+
+func (f *standbyFakeSettings) Get(context.Context) (*models.ServerSettings, error) {
+	return f.s, nil
+}
+
+// standbyFakeSchedules panics on ListDue — a standby tick must never list
+// due schedules.
+type standbyFakeSchedules struct {
+	repository.BackupScheduleRepository
+}
+
+// standbyFakeJobs panics on any use — a standby tick must never count or
+// dispatch jobs.
+type standbyFakeJobs struct {
+	repository.BackupJobRepository
+}
+
+type standbyFakeDests struct{ repository.BackupDestinationRepository }
+type standbyFakeUsers struct{ repository.UserRepository }
+
+type standbyFakeAgent struct{}
+
+func (standbyFakeAgent) Call(context.Context, string, any) (json.RawMessage, error) {
+	panic("standby tick must not call the agent")
+}
+
+// GH #331 two-node drill finding: the replicated primary DB carries the
+// primary's ENABLED schedules (including the DR feed itself) and queued job
+// rows. An ungated scheduler on a standby ran the feed schedule and shipped
+// the STANDBY's state into the shared DR repo. Both tick halves must be
+// inert on a standby.
+func TestTickOnce_StandbyIsInert(t *testing.T) {
+	s := New(Deps{
+		Settings:     &standbyFakeSettings{s: &models.ServerSettings{ServerRole: models.ServerRoleStandby}},
+		Schedules:    &standbyFakeSchedules{},
+		Jobs:         &standbyFakeJobs{},
+		Destinations: &standbyFakeDests{},
+		Users:        &standbyFakeUsers{},
+		Agent:        &standbyFakeAgent{},
+		Log:          slog.Default(),
+	})
+	if s == nil {
+		t.Fatal("New returned nil")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("standby tick touched schedules/jobs: %v", r)
+		}
+	}()
+	s.TickOnce(context.Background())
+}

--- a/panel-api/internal/drsync/syncer.go
+++ b/panel-api/internal/drsync/syncer.go
@@ -31,6 +31,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
@@ -218,6 +219,14 @@ func (s *Syncer) pullRestore(ctx context.Context, settings *models.ServerSetting
 		func(passwordFile string) error {
 			newest, lerr := s.latestManifest(ctx, dest, passwordFile)
 			if lerr != nil {
+				if isRepoNotInitialized(lerr) {
+					// A DR destination the primary has never shipped to
+					// (restic exit 10, "repository does not exist") means
+					// the same thing as an initialized-but-empty repo:
+					// nothing to pull yet. Surface it as WAITING, not error.
+					res = Result{Status: models.DRSyncStatusWaiting}
+					return nil
+				}
 				return lerr
 			}
 			if newest == "" {
@@ -243,6 +252,17 @@ func (s *Syncer) pullRestore(ctx context.Context, settings *models.ServerSetting
 		return Result{Status: models.DRSyncStatusError, Detail: err.Error()}
 	}
 	return res
+}
+
+// isRepoNotInitialized matches the restic signatures for "no repository at
+// this location yet" — the not-yet-fed DR channel. Mirrors the missing-repo
+// signatures in the agent's classifyRepoProbe. Never matches the unopenable
+// cases (wrong password, damaged config), which stay hard errors.
+func isRepoNotInitialized(err error) bool {
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "repository does not exist") ||
+		strings.Contains(msg, "unable to open config file") ||
+		strings.Contains(msg, "is there a repository at")
 }
 
 // latestManifest asks the agent for the newest system_backup manifest snapshot

--- a/panel-api/internal/drsync/syncer_test.go
+++ b/panel-api/internal/drsync/syncer_test.go
@@ -384,3 +384,25 @@ func TestSyncOnce_ReassertFailureRecordsError(t *testing.T) {
 		t.Errorf("reassert failure must be recorded: status=%q err=%q", fs.recStatus, fs.recErr)
 	}
 }
+
+// GH #331 drill finding: a paired-but-never-fed destination (restic exit 10,
+// "repository does not exist") is the WAITING state, not an error — the
+// operator just hasn't run `jabali dr feed` (or its first backup) yet.
+func TestSyncOnce_UninitializedRepoIsWaiting(t *testing.T) {
+	fs := &fakeSettings{s: standbySettings("D1", "")}
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": func(any) (json.RawMessage, error) {
+			return nil, errors.New(`restic snapshots: exit status 10 (stderr: Fatal: repository does not exist: unable to open config file)`)
+		},
+	}}
+	res, err := newSyncer(t, fs, &fakeDests{byID: map[string]*models.BackupDestination{"D1": enabledDest("D1")}}, fa).SyncOnce(context.Background())
+	if err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	if res.Status != models.DRSyncStatusWaiting {
+		t.Errorf("uninitialized repo must be waiting, got %q (detail %s)", res.Status, res.Detail)
+	}
+	if fs.recStatus != models.DRSyncStatusWaiting {
+		t.Errorf("waiting must be recorded, got %q", fs.recStatus)
+	}
+}


### PR DESCRIPTION
## Summary

Live two-node DR drill (jabalitests primary + LAN standby, both on #1137) surfaced three compounding bugs within the first two sync cycles:

**1. The standby ran the primary's backup schedules — including the DR feed itself.** Each applied sync replicates the primary's DB, ENABLED `backup_schedules` rows included. The standby's scheduler fired the feed schedule and shipped the STANDBY's own system backup into the shared DR repo (observed live: snapshots tagged `system=jabali-panel.local` in the primary's DR channel). A later promote selecting "newest manifest" could restore standby state believing it's the primary's. Fix: both scheduler tick halves early-return on a standby (same role re-read pattern as drsync); the daily retention sweep gets the same gate — its replicated destinations point at the primary's repos, so a standby retention pass would `forget --prune` the primary's live backups.

**2. restic repeated `--tag` flags are OR, not AND.** `snapshots --tag kind=system_backup --tag stage=manifest` returns the union — every stage snapshot. Combined with (1), "newest manifest" picked the standby's `panel_db` snapshot → restore failed with `path "/system_manifest.json" not found` (exactly the recorded sync error). Fix: all tag FILTERS (Snapshots/Forget/Copy) comma-join into one `--tag` (AND). Backup-time tag attachment keeps the repeated form (correct there). Audited every multi-tag caller: system manifest list, latest-manifest resolve, account manifest discovery, restore tag filter — all mean AND.

**3. Never-fed destination read as `error`.** restic exit 10 ("repository does not exist") on a paired-but-not-yet-fed channel now records `waiting`, same as initialized-but-empty.

Runbook updated (standby dormancy list now includes scheduler + retention).

## Test plan

- [x] `TestTickOnce_StandbyIsInert` — panics-on-touch fakes prove neither enqueue nor dispatch runs on a standby
- [x] `TestSnapshots_MultiTagIsANDNotOR`, `TestForget_MultiTagIsAND`, updated `TestSnapshots_TagFilter`
- [x] `TestSyncOnce_UninitializedRepoIsWaiting`
- [x] Full Go suite (`panel-api`, `panel-agent`, `internal`): 0 FAIL, vet clean
- [ ] Live: continue the two-node drill on this build — repo cleanup, third sync, promote

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
