### PR TITLE
fix(dr): pdns DB resync used credentials no install ever wrote (GH #331 drill)

### DIFF
--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -467,6 +467,15 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 	return out, nil
 }
 
+// PowerDNS DB credential contract — MUST match what install.sh writes into
+// /etc/jabali-panel/pdns.env and /etc/powerdns/pdns.d/01-jabali-mysql.conf.
+// TestPdnsResyncMatchesInstallContract pins both sides.
+const (
+	pdnsEnvFile        = "/etc/jabali-panel/pdns.env"
+	pdnsEnvPasswordVar = "PDNS_DB_PASSWORD"
+	pdnsMariaDBUser    = "jabali_pdns"
+)
+
 // resyncDBAccountPasswords re-runs ALTER USER for every known
 // jabali-plane MariaDB account using the password file the just-
 // applied panel_config landed at /etc/jabali-panel/. No-op on a host
@@ -482,14 +491,19 @@ func resyncDBAccountPasswords(ctx context.Context) ([]string, []string) {
 		{mariadbUser: "jabali_kratos", host: "localhost", passwordFile: "/etc/jabali-panel/kratos-db-password"},
 		{mariadbUser: "jabali-stalwart-ro", host: "localhost", passwordFile: "/etc/jabali-panel/stalwart-mariadb.password"},
 	}
-	// pdns password lives in pdns.env as PDNS_GMYSQL_PASSWORD; pull
-	// it out by simple grep so we don't import a new env-parser here.
-	if pdnsPW, ok := readEnvFileVar("/etc/jabali-panel/pdns.env", "PDNS_GMYSQL_PASSWORD"); ok && pdnsPW != "" {
+	// pdns password lives in pdns.env as PDNS_DB_PASSWORD for MariaDB user
+	// jabali_pdns (both set by install.sh's 01-jabali-mysql.conf block). This
+	// resync previously looked for PDNS_GMYSQL_PASSWORD / user "pdns" —
+	// names that exist in NO install — so PowerDNS came out of every
+	// cross-host restore with "Access denied for user 'jabali_pdns'" until
+	// a manual ALTER USER (GH #331 two-node drill finding: a promoted DR
+	// standby had no DNS).
+	if pdnsPW, ok := readEnvFileVar(pdnsEnvFile, pdnsEnvPasswordVar); ok && pdnsPW != "" {
 		// Persist to a tmp file so the helper signature stays uniform.
 		tmp, terr := writeTempStr(pdnsPW)
 		if terr == nil {
 			defer os.Remove(tmp)
-			accts = append(accts, acct{mariadbUser: "pdns", host: "localhost", passwordFile: tmp})
+			accts = append(accts, acct{mariadbUser: pdnsMariaDBUser, host: "localhost", passwordFile: tmp})
 		}
 	}
 

--- a/panel-agent/internal/commands/backup_system_pdns_contract_test.go
+++ b/panel-agent/internal/commands/backup_system_pdns_contract_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// GH #331 two-node drill finding: resyncDBAccountPasswords looked for
+// PDNS_GMYSQL_PASSWORD / MariaDB user "pdns" — names no install ever wrote —
+// so PowerDNS exited every cross-host system restore with "Access denied for
+// user 'jabali_pdns'" until a manual ALTER USER. This pins the Go constants
+// to the contract install.sh actually writes (pdns.env + the gmysql config).
+func TestPdnsResyncMatchesInstallContract(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "install.sh"))
+	if err != nil {
+		t.Skipf("install.sh not readable from test dir: %v", err)
+	}
+	sh := string(raw)
+	if !strings.Contains(sh, pdnsEnvPasswordVar+"=") {
+		t.Errorf("install.sh does not write %s= into pdns.env — the agent resync greps a variable that never exists", pdnsEnvPasswordVar)
+	}
+	if !strings.Contains(sh, "PDNS_DB_USER="+pdnsMariaDBUser) {
+		t.Errorf("install.sh PDNS_DB_USER does not match agent resync user %q", pdnsMariaDBUser)
+	}
+	if !strings.Contains(sh, "gmysql-user="+pdnsMariaDBUser) {
+		t.Errorf("install.sh gmysql-user does not match agent resync user %q", pdnsMariaDBUser)
+	}
+	if !strings.Contains(sh, pdnsEnvFile) {
+		t.Errorf("install.sh does not reference %s", pdnsEnvFile)
+	}
+}


### PR DESCRIPTION
## Summary
Third live finding from the GH #331 two-node drill: `resyncDBAccountPasswords` greps `pdns.env` for `PDNS_GMYSQL_PASSWORD` and targets MariaDB user `pdns` — but install.sh writes `PDNS_DB_PASSWORD` and user `jabali_pdns`. So the pdns credential resync after a cross-host system restore has NEVER worked: the standby's agent logs `Access denied for user 'jabali_pdns'` every start, and a promoted DR standby (or any disaster-restored box) comes up with dead DNS until a manual `ALTER USER`.

Fix: constants pinned to the install.sh contract + `TestPdnsResyncMatchesInstallContract` reading install.sh so neither side can drift silently (env var name, `PDNS_DB_USER`, `gmysql-user`).

## Test plan
- [x] `TestPdnsResyncMatchesInstallContract`
- [x] `go build ./...` clean
- [ ] Live: standby's next applied sync resyncs jabali_pdns; verified in drill promote phase

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)