### PR TITLE
fix(nginx): serve the docroot on :80 when not force-redirecting (JAB-271)

### DIFF
--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -176,76 +176,7 @@ var domainRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9](
 // shape renders the invalid `listen :80;` when X is empty, so we keep
 // the bracketed [::] / bare 80 fallbacks separately. See plans/m24-ip-manager.md
 // review F-H-3.
-const vhostTemplate = `server {
-{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:80;
-{{ else }}    listen 80;
-{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:80;
-{{ else }}    listen [::]:80;
-{{ end }}    server_name {{.Domain}} www.{{.Domain}};
-{{ if .IsEnabled }}
-    # ACME HTTP-01 webroot. Must be a location block — a server-level
-    # redirect fires in nginx SERVER_REWRITE phase BEFORE FIND_CONFIG,
-    # so a server-scoped redirect short-circuits every request
-    # including /.well-known/acme-challenge/, and Let's Encrypt's
-    # challenge fetch bounces to https where LE refuses to follow.
-    # Scoping the redirect to a location block instead pushes it into
-    # the per-location REWRITE phase, after FIND_CONFIG has had a
-    # chance to pick the ^~ ACME match. Webroot mirrors
-    # panel-api/internal/reconciler.IssueDomainCert (-w domain.DocRoot).
-    # Incident 2026-04-26: jabali.site stuck in pending_acme_retry on
-    # first VPS install — first under the no-ACME-location vhost, then
-    # again after we added the location but kept the server-scoped
-    # redirect that won the rewrite race.
-    location ^~ /.well-known/acme-challenge/ {
-        default_type "text/plain";
-        root {{.DocRoot}};
-        try_files $uri =404;
-        # M50: if Directory Privacy with path "/" applied auth_basic at
-        # server scope, override here so the ACME validator can reach
-        # the challenge token without a 401.
-        auth_basic off;
-    }
-{{ end }}
-{{ if .RedirectHTTPS }}
-    # Redirect HTTP to HTTPS once a TRUSTED cert is serving. Gated on
-    # RedirectHTTPS (not merely "a cert exists") so a fresh LE-mode domain
-    # still on its self-signed bootstrap placeholder serves the docroot over
-    # plain HTTP instead of 301'ing browsers into a cert-authority warning
-    # (GH #896/#887). Decoupled from the :443 block itself (JAB-237): a
-    # CDN-fronted domain serves :443 WITHOUT this redirect — Cloudflare
-    # owns the client-side https redirect, and an origin 301 loops CF
-    # Flexible zones. Scoped to the default location so the ^~ ACME
-    # location above wins for challenge paths.
-    location / {
-        return 301 https://$host$request_uri;
-    }
-{{ end }}{{ if .ServeHTTPS }}
-}
-
-server {
-{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:443 ssl{{.HTTP2Param}};
-{{ else }}    listen 443 ssl{{.HTTP2Param}};
-{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:443 ssl{{.HTTP2Param}};
-{{ else }}    listen [::]:443 ssl{{.HTTP2Param}};
-{{ end }}{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
-{{ end }}    # HTTP/2 is version-aware (GH #292): the listen ... http2
-    # parameter on nginx <1.25.1 (where the standalone directive is an
-    # unknown-directive error), the http2 on directive on >=1.25.1
-    # (where the listen parameter is deprecated and warns every reload).
-    server_name {{.Domain}} www.{{.Domain}};
-    ssl_certificate {{.SSLCertPath}};
-    ssl_certificate_key {{.SSLKeyPath}};
-    # JAB-69: modern TLS + Mozilla-intermediate ciphers (no 3DES/RC4/CBC-weak).
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-    ssl_prefer_server_ciphers off;
-    # JAB-70: baseline security headers (location / inherits these; cache-status
-    # locations that set their own add_header re-declare them below).
-    add_header Strict-Transport-Security "max-age=31536000" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-{{ end }}
-{{ if .IsEnabled }}
+const vhostTemplate = `{{define "servebody"}}{{ if .IsEnabled }}
     root {{.DocRoot}};
     # JAB-183: refuse to follow a symlink whose owner differs from the owner of
     # the thing it points at. Docroots are 2750 <user>:www-data and homes are
@@ -589,8 +520,85 @@ server {
     access_log /var/log/nginx/{{.Domain}}-access.log;
     error_log /var/log/nginx/{{.Domain}}-error.log;
     location / { try_files /index.html =503; }
+{{ end }}{{end}}server {
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:80;
+{{ else }}    listen 80;
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:80;
+{{ else }}    listen [::]:80;
+{{ end }}    server_name {{.Domain}} www.{{.Domain}};
+{{ if .IsEnabled }}
+    # ACME HTTP-01 webroot. Must be a location block — a server-level
+    # redirect fires in nginx SERVER_REWRITE phase BEFORE FIND_CONFIG,
+    # so a server-scoped redirect short-circuits every request
+    # including /.well-known/acme-challenge/, and Let's Encrypt's
+    # challenge fetch bounces to https where LE refuses to follow.
+    # Scoping the redirect to a location block instead pushes it into
+    # the per-location REWRITE phase, after FIND_CONFIG has had a
+    # chance to pick the ^~ ACME match. Webroot mirrors
+    # panel-api/internal/reconciler.IssueDomainCert (-w domain.DocRoot).
+    # Incident 2026-04-26: jabali.site stuck in pending_acme_retry on
+    # first VPS install — first under the no-ACME-location vhost, then
+    # again after we added the location but kept the server-scoped
+    # redirect that won the rewrite race.
+    location ^~ /.well-known/acme-challenge/ {
+        default_type "text/plain";
+        root {{.DocRoot}};
+        try_files $uri =404;
+        # M50: if Directory Privacy with path "/" applied auth_basic at
+        # server scope, override here so the ACME validator can reach
+        # the challenge token without a 401.
+        auth_basic off;
+    }
+{{ end }}
+{{ if .RedirectHTTPS }}
+    # Redirect HTTP to HTTPS once a TRUSTED cert is serving. Gated on
+    # RedirectHTTPS (not merely "a cert exists") so a fresh LE-mode domain
+    # still on its self-signed bootstrap placeholder does NOT 301 browsers
+    # into a cert-authority warning (GH #896/#887); it falls to the else
+    # branch below and serves the docroot over plain HTTP. Decoupled from the
+    # :443 block itself (JAB-237): a CDN-fronted domain serves :443 WITHOUT
+    # this redirect — Cloudflare owns the client-side https redirect, and an
+    # origin 301 loops CF Flexible zones. Scoped to the default location so
+    # the ^~ ACME location above wins for challenge paths.
+    location / {
+        return 301 https://$host$request_uri;
+    }
+{{ else }}
+    # JAB-271: no force-redirect on :80 -> serve the real docroot over plain
+    # HTTP (what the CF-Flexible / grey-cloud / pre-redirect visitor hits),
+    # the SAME site config as :443. Without this the :80 block had neither a
+    # redirect nor a docroot and fell through to nginx's compiled-in
+    # /usr/share/nginx/html ("Welcome to nginx").
+{{ template "servebody" . }}
 {{ end }}
 }
+{{ if .ServeHTTPS }}
+
+server {
+{{ if .ListenIPv4 }}    listen {{.ListenIPv4}}:443 ssl{{.HTTP2Param}};
+{{ else }}    listen 443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .ListenIPv6 }}    listen [{{.ListenIPv6}}]:443 ssl{{.HTTP2Param}};
+{{ else }}    listen [::]:443 ssl{{.HTTP2Param}};
+{{ end }}{{ if .HTTP2Directive }}    {{.HTTP2Directive}}
+{{ end }}    # HTTP/2 is version-aware (GH #292): the listen ... http2
+    # parameter on nginx <1.25.1 (where the standalone directive is an
+    # unknown-directive error), the http2 on directive on >=1.25.1
+    # (where the listen parameter is deprecated and warns every reload).
+    server_name {{.Domain}} www.{{.Domain}};
+    ssl_certificate {{.SSLCertPath}};
+    ssl_certificate_key {{.SSLKeyPath}};
+    # JAB-69: modern TLS + Mozilla-intermediate ciphers (no 3DES/RC4/CBC-weak).
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    # JAB-70: baseline security headers (location / inherits these; cache-status
+    # locations that set their own add_header re-declare them below).
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+{{ template "servebody" . }}
+}
+{{ end }}
 {{- if .PreviewHost }}
 
 # Preview URL — reverse-proxies this domain's OWN vhost with the real

--- a/panel-agent/internal/commands/domain_create_jab271_test.go
+++ b/panel-agent/internal/commands/domain_create_jab271_test.go
@@ -1,0 +1,121 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// JAB-271: the :80 vhost must serve the real docroot (never the stock
+// "Welcome to nginx" page) whenever it is NOT force-redirecting to https —
+// the CF-Flexible / grey-cloud / plain-http case. Regression for the
+// fronted shape (serve :443, no :80 redirect) that fell through to nginx's
+// compiled-in /usr/share/nginx/html.
+
+func jab271Vhost(t *testing.T, redirect, serve bool) string {
+	t.Helper()
+	vd := canonicalCacheVhostData()
+	vd.RedirectHTTPS = redirect
+	vd.ServeHTTPS = serve
+	vd.SSLCertPath = "/etc/ssl/x/fullchain.pem"
+	vd.SSLKeyPath = "/etc/ssl/x/privkey.pem"
+	return renderQAllowVhost(t, vd)
+}
+
+// port80Block returns the text of the first server block (the :80 one).
+func port80Block(vhost string) string {
+	i := strings.Index(vhost, "server {")
+	if i < 0 {
+		return ""
+	}
+	rest := vhost[i+len("server {"):]
+	// the :80 block ends at the next "server {" (the :443 block) or EOF.
+	if j := strings.Index(rest, "\nserver {"); j >= 0 {
+		return rest[:j]
+	}
+	return rest
+}
+
+// Fronted: ServeHTTPS=true, RedirectHTTPS=false. :80 must serve the
+// docroot (root + location /) and must NOT 301, and :443 must also serve.
+func TestVhostJAB271_FrontedServesDocrootOn80(t *testing.T) {
+	out := jab271Vhost(t, false, true)
+	p80 := port80Block(out)
+	if strings.Contains(p80, "return 301 https://") {
+		t.Fatal(":80 must not 301 in the fronted (no-redirect) shape")
+	}
+	if !strings.Contains(p80, "root /home/u/public_html/example.com;") {
+		t.Fatalf(":80 block has no docroot — the JAB-271 welcome-page bug:\n%s", p80)
+	}
+	if !strings.Contains(p80, "location / {") {
+		t.Fatal(":80 block has no location / — falls through to the nginx default root")
+	}
+	// :443 still serves the docroot too.
+	if !strings.Contains(out, "listen 443 ssl") {
+		t.Fatal("fronted domain must still serve :443")
+	}
+	if strings.Count(out, "root /home/u/public_html/example.com;") < 2 {
+		t.Fatal("docroot must appear on BOTH :80 and :443 for a fronted domain")
+	}
+}
+
+// Direct + trusted cert: ServeHTTPS=true, RedirectHTTPS=true. :80 must
+// 301 (force-https) and NOT serve the docroot; :443 serves it.
+func TestVhostJAB271_DirectTrustedRedirects80(t *testing.T) {
+	out := jab271Vhost(t, true, true)
+	p80 := port80Block(out)
+	if !strings.Contains(p80, "return 301 https://") {
+		t.Fatal(":80 must 301 when RedirectHTTPS is set")
+	}
+	// disable_symlinks is servebody-unique (the ACME location also sets
+	// `root DocRoot`, so the bare root directive is not a safe marker).
+	if strings.Contains(p80, "disable_symlinks") {
+		t.Fatal(":80 must NOT serve the docroot when force-redirecting")
+	}
+	if !strings.Contains(out, "listen 443 ssl") {
+		t.Fatal("must serve :443")
+	}
+}
+
+// Bootstrap: ServeHTTPS=false, RedirectHTTPS=false. :80 serves the
+// docroot (self-signed :443 not served yet, #896); no :443 block.
+func TestVhostJAB271_BootstrapServesDocrootOn80(t *testing.T) {
+	out := jab271Vhost(t, false, false)
+	p80 := port80Block(out)
+	if !strings.Contains(p80, "root /home/u/public_html/example.com;") {
+		t.Fatal("bootstrap :80 must serve the docroot")
+	}
+	if strings.Contains(out, "listen 443 ssl") {
+		t.Fatal("bootstrap must NOT render a :443 block (no trusted cert yet)")
+	}
+}
+
+// A DISABLED domain previously showed the stock welcome page on :80 too
+// (no serving location at all). It must now show the branded 503 disabled
+// page on :80 — the SAME servebody as :443 — never the stock nginx root.
+func TestVhostJAB271_DisabledServes503On80(t *testing.T) {
+	vd := canonicalCacheVhostData()
+	vd.IsEnabled = false
+	vd.RedirectHTTPS = false
+	vd.ServeHTTPS = true
+	vd.SSLCertPath = "/etc/ssl/x/fullchain.pem"
+	vd.SSLKeyPath = "/etc/ssl/x/privkey.pem"
+	out := renderQAllowVhost(t, vd)
+	p80 := port80Block(out)
+	if !strings.Contains(p80, "=503") {
+		t.Fatalf("disabled :80 must serve the 503 disabled page, got:\n%s", p80)
+	}
+	if strings.Contains(p80, "root /usr/share/nginx/html") {
+		t.Fatal("disabled :80 must not fall through to the stock nginx root")
+	}
+}
+
+// The stock nginx default root must never appear in any shape.
+func TestVhostJAB271_NeverStockRoot(t *testing.T) {
+	for _, tc := range []struct{ redirect, serve bool }{{false, true}, {true, true}, {false, false}} {
+		out := jab271Vhost(t, tc.redirect, tc.serve)
+		// the directive, not the bare path (a code comment mentions the path).
+		if strings.Contains(out, "root /usr/share/nginx/html") {
+			t.Fatalf("stock nginx root leaked (redirect=%v serve=%v)", tc.redirect, tc.serve)
+		}
+	}
+}

--- a/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
+++ b/panel-agent/internal/commands/testdata/vhost_qallow_baseline.golden
@@ -27,6 +27,11 @@ server {
     }
 
 
+    # JAB-271: no force-redirect on :80 -> serve the real docroot over plain
+    # HTTP (what the CF-Flexible / grey-cloud / pre-redirect visitor hits),
+    # the SAME site config as :443. Without this the :80 block had neither a
+    # redirect nor a docroot and fell through to nginx's compiled-in
+    # /usr/share/nginx/html ("Welcome to nginx").
 
     root /home/u/public_html/example.com;
     # JAB-183: refuse to follow a symlink whose owner differs from the owner of
@@ -270,5 +275,6 @@ server {
     
     
     
+
 
 }

--- a/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
+++ b/panel-api/internal/reconciler/ssl_fronted_vhost_test.go
@@ -126,6 +126,40 @@ func TestDirectVhost_IssuedRedirectsAndServes(t *testing.T) {
 	}
 }
 
+// JAB-271 defect #2: the reporter hypothesised the vhost "was never
+// re-rendered after the cert went self-signed→LE". It is: createDomainOnAgent
+// re-derives redirect_https/serve_https from the LIVE cert row on EVERY tick
+// (the reconciler dispatches domain.create unconditionally each pass, SSL
+// converging first, and the agent's writeVhost gate compares full rendered
+// bytes). Drive one direct domain through the transition and assert the params
+// flip on the second dispatch — a guard against a future reconciler-level
+// dispatch hash that omits cert state (which WOULD strand the :80 shape).
+func TestDirectVhost_SelfSignedToLETransitionReRenders(t *testing.T) {
+	r, ag, dom, sc := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, []string{frontedTestOwnIP}, true)
+
+	// Tick 1: still on the self-signed bootstrap placeholder.
+	r.createDomainOnAgent(context.Background(), dom)
+	if redirect, serve := vhostHTTPSParams(t, ag); redirect || serve {
+		t.Fatalf("pre-transition: (redirect=%v, serve=%v), want (false, false)", redirect, serve)
+	}
+
+	// LE lands: the cert row's path moves to the letsencrypt live dir.
+	leCert, leKey := letsEncryptCertPath, letsEncryptKeyPath
+	sc.byDomain[dom.ID].Status = models.SSLStatusIssued
+	sc.byDomain[dom.ID].CertPath = &leCert
+	sc.byDomain[dom.ID].KeyPath = &leKey
+
+	ag.mu.Lock()
+	ag.calls = nil
+	ag.mu.Unlock()
+
+	// Tick 2: the very next dispatch must reflect the trusted cert.
+	r.createDomainOnAgent(context.Background(), dom)
+	if redirect, serve := vhostHTTPSParams(t, ag); !redirect || !serve {
+		t.Fatalf("post-transition: (redirect=%v, serve=%v), want (true, true) — the :80 shape must update the tick a real cert lands", redirect, serve)
+	}
+}
+
 func TestFrontedVhost_InconclusiveLookupKeepsCachedValue(t *testing.T) {
 	r, ag, dom, _ := frontedVhostFixture(t, selfSignedCertPath, selfSignedKeyPath, cfEdgeAddrs, true)
 


### PR DESCRIPTION
## JAB-271 — nginx `:80` served the stock "Welcome to nginx" page instead of the docroot

### Defect #1 (fixed) — the non-redirect `:80` branch served nothing

The per-domain `:80` server block emitted only the ACME challenge location plus, when a trusted cert existed, a `301 → https`. When the 301 is suppressed (`RedirectHTTPS=false`) the `:80` block had **no `location /` and no `root`**, so any non-ACME http request fell through to nginx's compiled-in default root `/usr/share/nginx/html` and returned the stock **"Welcome to nginx!"** page.

That branch is exactly where **CDN-fronted** domains land. JAB-237 decouples `ServeHTTPS` from `RedirectHTTPS` so a Cloudflare-fronted origin serves `:443` without an origin 301 (which loops CF Flexible). Confirmed live on `newaramaapp` (vidoflex.com, raftika.com) and `newzaps` (arizot-e.com, taxrefound.com, hlpcollege.com): `:80` → welcome page, `:443` → real site. Plain-http and grey-cloud visitors hit the same gap.

**Fix:** extract the shared site config (root, locations, PHP, cache, `try_files`, and the disabled-page 503 fallback) into a `{{define "servebody"}}` template block and render it in **both** the `:80` block (the non-redirect branch) and the `:443` block. `:80` now always has a serving `location /` — it serves the docroot when not redirecting and 301s when force-https is on, matching cPanel/Plesk/DirectAdmin/Hestia/ISPConfig. A **disabled** domain now shows the branded 503 page on `:80` too, not the welcome page.

### Defect #2 (reported as "reconciler never re-renders on self-signed → LE") — not a code gap

The report hypothesised the vhost is rendered while the cert is self-signed and never re-rendered after LE lands. Tracing the pipeline shows it already re-renders:

- `createDomainOnAgent` (`reconciler.go`) re-derives `redirect_https`/`serve_https` from the **live cert row** on every call (`redirectHTTPSForCert` classifies by the current cert path: `jabali-selfsigned/` → self-signed → no redirect; `letsencrypt/live/` → trusted → redirect).
- The reconciler dispatches `domain.create` **unconditionally every tick** (no reconciler-level dispatch hash), SSL converging first so the fresh cert path is in hand.
- The agent's `writeVhost` gate compares **full rendered bytes** (`bytes.Equal(existing, want)`), so any flag flip changes the output and forces a re-render + reload.

So a self-signed → LE transition re-renders on the next tick. The reporter's confirmed hosts are all CF-fronted (`RedirectHTTPS=false` by design — the reporter's own "Note on the 301 and CF Flexible" says fronted domains correctly must **not** 301), so **defect #1 alone explains the welcome-page symptom**. Corroboration: those hosts already serve a valid LE cert on `:443`, i.e. the vhost was rewritten after issuance. No reconciler code change; a regression test now guards against a future dispatch hash that omits cert state.

### Tests
- `domain_create_jab271_test.go` — fronted / direct-trusted / bootstrap / **disabled** each render the correct `:80` shape; the stock `root /usr/share/nginx/html` never appears in any shape.
- `vhost_qallow_baseline.golden` regenerated — diff is only the added `:80` docroot serving + the JAB-271 comment.
- `ssl_fronted_vhost_test.go` — `TestDirectVhost_SelfSignedToLETransitionReRenders`: one direct domain driven through the transition; params flip `(false,false)` → `(true,true)` on re-dispatch.
- Full `panel-agent/internal/commands` and `panel-api/internal/reconciler` packages pass.

### Verification note
Unit-proven. Live verification deferred: testserver `.86` is the active GH #331 DR-standby drill box and the fleet is production. The defect #2 transition question is the part already corroborated by the reporter's live data (LE cert serving on origin `:443`).

Refs JAB-271.
