### PR TITLE
fix(dr): re-assert standby identity inside the agent restore handler (GH #331 drill)

### DIFF
--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -350,6 +351,16 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 		// the named stages. Empty = apply all auto-recoverable stages
 		// (panel_db, panel_config, tls).
 		ApplyStages []string `json:"apply_stages,omitempty"`
+		// DRPairing, when set (drsync standby ticks), re-asserts this box's
+		// standby identity IN THE AGENT immediately after the panel_db load.
+		// The load replaces server_settings with the primary's row
+		// (role=primary, no pairing); the panel-side reassert that follows is
+		// a separate process an entire agent round-trip later, and a
+		// scheduler tick landing inside that window read role=primary and
+		// enqueued the primary's schedules on the standby (GH #331 two-node
+		// drill, observed live). Doing it here shrinks the window to
+		// microseconds inside one handler.
+		DRPairing *drPairingReassert `json:"dr_pairing,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &req); err != nil {
 		return nil, bkInvalidArg("malformed JSON body")
@@ -425,6 +436,18 @@ func systemRestoreHandler(ctx context.Context, raw json.RawMessage) (any, error)
 		out.Applied = applied
 		out.ApplyWarnings = warnings
 
+		// Re-assert DR standby identity IMMEDIATELY after the panel_db load
+		// replaced server_settings — before anything else can read the
+		// primary's role=primary row. See the DRPairing field doc.
+		if req.DRPairing != nil {
+			if err := reassertDRPairingSQL(ctx, req.DRPairing); err != nil {
+				out.ApplyWarnings = append(out.ApplyWarnings,
+					fmt.Sprintf("dr_pairing reassert: %v (box may read as a primary — re-run `jabali dr pair`)", err))
+			} else {
+				out.Applied = append(out.Applied, "dr_pairing re-asserted (role=standby)")
+			}
+		}
+
 		// Post-apply MariaDB account password sync. mariadb-dump
 		// --single-transaction does NOT emit CREATE USER / GRANT, so
 		// after a cross-host restore the local MariaDB users still
@@ -475,6 +498,51 @@ const (
 	pdnsEnvPasswordVar = "PDNS_DB_PASSWORD"
 	pdnsMariaDBUser    = "jabali_pdns"
 )
+
+// drPairingReassert carries the standby identity to re-stamp after a
+// panel_db load (GH #331). DestinationName re-resolves the DR channel among
+// the primary's replicated destination rows; DestinationID is the fallback
+// when no row carries that name.
+type drPairingReassert struct {
+	DestinationID   string `json:"destination_id"`
+	DestinationName string `json:"destination_name"`
+	PeerLabel       string `json:"peer_label"`
+	PairedAt        string `json:"paired_at,omitempty"` // RFC3339
+}
+
+// drPairingIDRE constrains the fallback destination id to a ULID shape so it
+// can be embedded in SQL without becoming an injection vector.
+var drPairingIDRE = regexp.MustCompile(`^[0-9A-HJKMNP-TV-Z]{26}$`)
+
+// reassertDRPairingSQL re-stamps the four-column DR identity block on the
+// single server_settings row via the mariadb socket, remapping the
+// destination by name against the just-loaded (primary's) rows. All string
+// values are quote-escaped; the fallback id must be a ULID.
+func reassertDRPairingSQL(ctx context.Context, p *drPairingReassert) error {
+	if !drPairingIDRE.MatchString(p.DestinationID) {
+		return fmt.Errorf("destination_id %q is not a ULID", p.DestinationID)
+	}
+	pairedAt := "NULL"
+	if p.PairedAt != "" {
+		t, err := time.Parse(time.RFC3339, p.PairedAt)
+		if err != nil {
+			return fmt.Errorf("paired_at: %w", err)
+		}
+		pairedAt = fmt.Sprintf("'%s'", t.UTC().Format("2006-01-02 15:04:05.000000"))
+	}
+	stmt := fmt.Sprintf(
+		"UPDATE jabali_panel.server_settings SET server_role='standby', "+
+			"dr_destination_id=COALESCE((SELECT id FROM jabali_panel.backup_destinations WHERE name='%s' LIMIT 1),'%s'), "+
+			"dr_peer_label='%s', dr_paired_at=%s WHERE 1=1;",
+		sqlEscape(p.DestinationName), p.DestinationID, sqlEscape(p.PeerLabel), pairedAt)
+	cmd := exec.CommandContext(ctx, "mariadb",
+		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock", "-e", stmt)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mariadb: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
 
 // resyncDBAccountPasswords re-runs ALTER USER for every known
 // jabali-plane MariaDB account using the password file the just-

--- a/panel-agent/internal/commands/backup_system_pdns_contract_test.go
+++ b/panel-agent/internal/commands/backup_system_pdns_contract_test.go
@@ -35,3 +35,19 @@ func TestPdnsResyncMatchesInstallContract(t *testing.T) {
 		t.Errorf("install.sh does not reference %s", pdnsEnvFile)
 	}
 }
+
+// GH #331 drill: reassertDRPairingSQL builds SQL from wire strings — pin the
+// injection guards (ULID-shape id, quote-escaped name/label) and the shape.
+func TestReassertDRPairingSQLValidation(t *testing.T) {
+	if err := reassertDRPairingSQL(t.Context(), &drPairingReassert{
+		DestinationID: "not-a-ulid", DestinationName: "x", PeerLabel: "y",
+	}); err == nil || !strings.Contains(err.Error(), "not a ULID") {
+		t.Errorf("non-ULID destination_id must be rejected, got %v", err)
+	}
+	if err := reassertDRPairingSQL(t.Context(), &drPairingReassert{
+		DestinationID: "01M05Q5V53GQ54Q4PHGHH7F73P", DestinationName: "x", PeerLabel: "y",
+		PairedAt: "yesterday",
+	}); err == nil || !strings.Contains(err.Error(), "paired_at") {
+		t.Errorf("bad paired_at must be rejected, got %v", err)
+	}
+}

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -1019,6 +1019,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		Destinations: deps.BackupDestinations,
 		Agent:        deps.Agent,
 		SSOKey:       deps.SSOKey,
+		Settings:     deps.ServerSettings,
 		Log:          log,
 	}); fin != nil {
 		go fin.Start(ctx)

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -49,6 +49,11 @@ type Deps struct {
 	Jobs         repository.BackupJobRepository
 	Schedules    repository.BackupScheduleRepository
 	Destinations repository.BackupDestinationRepository
+	// Settings gates the loop on a DR standby (GH #331): the replicated
+	// primary DB carries the primary's running/queued job rows, and an
+	// ungated finalizer churned the standby (and the shared DR repo) probing
+	// jobs that belong to another box. Optional; nil = never gated.
+	Settings repository.ServerSettingsRepository
 	Agent        agent.AgentInterface
 	// SSOKey unseals a destination's per-row restic password (M30.2.x).
 	// Without it backup.status cannot open a rotated destination's repo,
@@ -120,6 +125,14 @@ type agentStatus struct {
 }
 
 func (f *Finalizer) tickOnce(ctx context.Context) {
+	// A DR standby's job rows are the PRIMARY's replica — probing or
+	// stall-failing them here is work on another box's jobs (GH #331 two-
+	// node drill). Same re-read pattern as drsync/backupscheduler.
+	if f.deps.Settings != nil {
+		if set, err := f.deps.Settings.Get(ctx); err == nil && set != nil && set.IsStandby() {
+			return
+		}
+	}
 	// Query running jobs directly. Paging the newest MaxJobsPerTick rows of
 	// ANY status and filtering here used to drop the oldest-created running
 	// jobs of a large fan-out — the dispatcher admits work oldest-first, so

--- a/panel-api/internal/backupfinalizer/finalizer_test.go
+++ b/panel-api/internal/backupfinalizer/finalizer_test.go
@@ -114,3 +114,40 @@ func TestCheckOne_NoManifest_NoOp(t *testing.T) {
 		t.Error("MarkFinished should not be called while the manifest is absent")
 	}
 }
+
+// GH #331: a standby's job rows are the primary's replica — the finalizer
+// must not touch them. panicJobs embeds the interface so ANY repository
+// call panics; a gated tick must return before touching jobs.
+type standbySettingsRepo struct {
+	repository.ServerSettingsRepository
+}
+
+func (standbySettingsRepo) Get(context.Context) (*models.ServerSettings, error) {
+	return &models.ServerSettings{ServerRole: models.ServerRoleStandby}, nil
+}
+
+type panicJobs struct {
+	repository.BackupJobRepository
+}
+
+type panicDests struct {
+	repository.BackupDestinationRepository
+}
+
+func TestTickOnce_StandbyIsInert(t *testing.T) {
+	f := New(Deps{
+		Jobs: &panicJobs{}, Destinations: &panicDests{},
+		Agent:    &fakeStatusAgent{reply: `{}`},
+		Settings: standbySettingsRepo{},
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if f == nil {
+		t.Fatal("New returned nil")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("standby finalizer touched job state: %v", r)
+		}
+	}()
+	f.tickOnce(context.Background())
+}

--- a/panel-api/internal/drsync/syncer.go
+++ b/panel-api/internal/drsync/syncer.go
@@ -238,7 +238,7 @@ func (s *Syncer) pullRestore(ctx context.Context, settings *models.ServerSetting
 				res = Result{Status: models.DRSyncStatusCurrent, SnapshotID: newest}
 				return nil
 			}
-			if rerr := s.restore(ctx, dest, passwordFile, newest); rerr != nil {
+			if rerr := s.restore(ctx, settings, dest, passwordFile, newest); rerr != nil {
 				return rerr
 			}
 			if perr := s.reassertPairing(ctx, settings, dest); perr != nil {
@@ -329,13 +329,27 @@ func (s *Syncer) reassertPairing(ctx context.Context, prev *models.ServerSetting
 
 // restore runs system.restore for one snapshot with apply=true and
 // include_accounts=false (panel_db + panel_config + tls only; account data
-// converges at promote time).
-func (s *Syncer) restore(ctx context.Context, dest *models.BackupDestination, passwordFile, snapshotID string) error {
+// converges at promote time). The dr_pairing block makes the AGENT re-stamp
+// the standby identity in the same handler that loads the primary's panel DB
+// — a scheduler tick observed the role=primary window between the load and
+// the panel-side reassert and enqueued the primary's schedules (GH #331
+// drill); the panel-side reassert below remains as belt-and-suspenders.
+func (s *Syncer) restore(ctx context.Context, settings *models.ServerSettings, dest *models.BackupDestination, passwordFile, snapshotID string) error {
 	params := destWireParams(dest)
 	params["job_id"] = ids.NewULID()
 	params["manifest_snapshot_id"] = snapshotID
 	params["include_accounts"] = false
 	params["apply"] = true
+	pairedAt := ""
+	if settings.DRPairedAt != nil {
+		pairedAt = settings.DRPairedAt.UTC().Format(time.RFC3339)
+	}
+	params["dr_pairing"] = map[string]any{
+		"destination_id":   dest.ID,
+		"destination_name": dest.Name,
+		"peer_label":       settings.DRPeerLabel,
+		"paired_at":        pairedAt,
+	}
 	if passwordFile != "" {
 		params["password_file"] = passwordFile
 	}

--- a/panel-api/internal/drsync/syncer_test.go
+++ b/panel-api/internal/drsync/syncer_test.go
@@ -406,3 +406,36 @@ func TestSyncOnce_UninitializedRepoIsWaiting(t *testing.T) {
 		t.Errorf("waiting must be recorded, got %q", fs.recStatus)
 	}
 }
+
+// GH #331 drill: the restore call must carry the dr_pairing block so the
+// AGENT re-stamps the standby identity inside the same handler that loads
+// the primary's panel DB — the cross-process window between load and the
+// panel-side reassert let a scheduler tick see role=primary.
+func TestSyncOnce_RestoreCarriesDRPairing(t *testing.T) {
+	pairedAt := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	fs := &fakeSettings{s: standbySettings("D1", "")}
+	fs.s.DRPeerLabel = "182.54.236.60"
+	fs.s.DRPairedAt = &pairedAt
+	var restoreParams map[string]any
+	fa := &fakeAgent{handlers: map[string]func(any) (json.RawMessage, error){
+		"system.restore_list_manifests": manifestsJSON("SNAP_NEW"),
+		"system.restore": func(p any) (json.RawMessage, error) {
+			restoreParams, _ = p.(map[string]any)
+			return json.RawMessage(`{}`), nil
+		},
+	}}
+	fd := &fakeDests{byID: map[string]*models.BackupDestination{"D1": namedDest("D1", "dr-channel")}}
+	if _, err := newSyncer(t, fs, fd, fa).SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	dp, ok := restoreParams["dr_pairing"].(map[string]any)
+	if !ok {
+		t.Fatalf("restore params missing dr_pairing: %v", restoreParams)
+	}
+	if dp["destination_id"] != "D1" || dp["destination_name"] != "dr-channel" || dp["peer_label"] != "182.54.236.60" {
+		t.Errorf("dr_pairing wrong: %v", dp)
+	}
+	if dp["paired_at"] != "2026-08-16T12:00:00Z" {
+		t.Errorf("paired_at wrong: %v", dp["paired_at"])
+	}
+}


### PR DESCRIPTION
## Summary
Fourth live drill finding (F8): the #1140 scheduler gate reads `server_settings`, but each applied sync loads the PRIMARY's row (role=primary) and the panel-side reassert (#1137) runs a full agent round-trip later. A scheduler tick landed inside that window and **enqueued the primary's feed schedule on the standby** (queued `system_backup` row observed 10 seconds after an applied sync; dispatch happened to come after the reassert, so it never shipped — luck).

Fix: `system.restore` takes an optional `dr_pairing` block, sent by drsync ticks. The agent re-stamps `server_role/dr_destination_id/dr_peer_label/dr_paired_at` in ONE SQL UPDATE immediately after the panel_db load — same handler, microsecond window — remapping the destination by name against the just-loaded rows (`COALESCE` fallback to the pre-restore ULID). Guards: ULID-shape id, RFC3339 `paired_at`, quote-escaped strings. Panel-side reassert stays as belt-and-suspenders.

## Test plan
- [x] `TestSyncOnce_RestoreCarriesDRPairing` — wire shape
- [x] `TestReassertDRPairingSQLValidation` — injection guards
- [x] agent + drsync suites 0 FAIL, vet clean
- [ ] Live: drill continues on this build — window race unreproducible by design after it

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)