### PR TITLE
fix(security): FTP password reset preserves the disabled lock (JAB-261)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -398,6 +398,40 @@ type ftpAccountSetPasswordParams struct {
 	TenantUsername string `json:"tenant_username"`
 	Username       string `json:"username"`
 	Password       string `json:"password"`
+	// Enabled is the panel-authoritative desired lock state (JAB-261).
+	// chpasswd rewrites the shadow hash and DROPS the '!' lock, so a
+	// disabled (usermod -L) account would silently re-enable and accept
+	// FTPS/SFTP auth until the reconciler re-locked it. Pointer, not bool:
+	// an older panel that omits the field must NOT default a disabled
+	// account to unlocked — nil falls back to preserving the pre-change
+	// lock state instead.
+	Enabled *bool `json:"enabled"`
+}
+
+// lockAfterPasswordReset decides whether the account must be re-locked after
+// chpasswd clears the shadow lock. The panel's is_enabled is authoritative
+// when present; absent (older panel), preserve whatever lock state existed
+// before the password change so a disabled account is never silently unlocked.
+func lockAfterPasswordReset(enabled *bool, wasLocked bool) bool {
+	if enabled != nil {
+		return !*enabled
+	}
+	return wasLocked
+}
+
+// ftpUserLocked reports whether username's shadow password is locked. `passwd
+// -S` prints "<user> <status> ..." where status is L (locked), P/PS (usable),
+// or NP (no password). Field 2 is the status.
+func ftpUserLocked(ctx context.Context, username string) (bool, *agentwire.AgentError) {
+	out, err := exec.CommandContext(ctx, "passwd", "-S", username).CombinedOutput()
+	if err != nil {
+		return false, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("passwd -S %q: %v: %s", username, err, strings.TrimSpace(string(out)))}
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) < 2 {
+		return false, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("passwd -S %q: unexpected output %q", username, strings.TrimSpace(string(out)))}
+	}
+	return fields[1] == "L", nil
 }
 
 func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -415,8 +449,26 @@ func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (
 	if p.Password == "" {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "password is required"}
 	}
+	// JAB-261: capture the pre-change lock only when the panel didn't send
+	// an authoritative desired state (avoids an extra passwd -S on the hot
+	// path).
+	var wasLocked bool
+	if p.Enabled == nil {
+		locked, lerr := ftpUserLocked(ctx, p.Username)
+		if lerr != nil {
+			return nil, lerr
+		}
+		wasLocked = locked
+	}
 	if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
 		return nil, aerr
+	}
+	// Re-apply the shadow lock in the SAME verb (no reliance on the periodic
+	// reconciler) so a disabled account cannot authenticate in the window.
+	if lockAfterPasswordReset(p.Enabled, wasLocked) {
+		if out, err := exec.CommandContext(ctx, "usermod", "-L", p.Username).CombinedOutput(); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-lock disabled account %q after password reset: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
+		}
 	}
 	return map[string]any{"username": p.Username, "updated": true}, nil
 }

--- a/panel-agent/internal/commands/ftp_account_test.go
+++ b/panel-agent/internal/commands/ftp_account_test.go
@@ -14,6 +14,34 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
 
+// JAB-261: a password reset must never silently unlock a disabled account.
+// The shadow-lock transition itself is host-only (real chpasswd/usermod), but
+// the decision that drives the re-lock is pure and pinned here.
+func TestLockAfterPasswordReset(t *testing.T) {
+	tt := true
+	ff := false
+	cases := []struct {
+		name      string
+		enabled   *bool
+		wasLocked bool
+		want      bool
+	}{
+		{"enabled account never re-locks", &tt, false, false},
+		{"enabled overrides a stale lock", &tt, true, false},
+		{"disabled account is re-locked", &ff, false, true},
+		{"disabled stays locked", &ff, true, true},
+		{"old panel preserves an existing lock", nil, true, true},
+		{"old panel preserves an unlocked account", nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lockAfterPasswordReset(tc.enabled, tc.wasLocked); got != tc.want {
+				t.Fatalf("lockAfterPasswordReset(%v, %v) = %v, want %v", tc.enabled, tc.wasLocked, got, tc.want)
+			}
+		})
+	}
+}
+
 // testTenantUser returns the current OS user when it satisfies the tenant
 // preconditions (uid >= 1000, home under /home) so validation paths past
 // resolveFtpTenant can run without mutating the host. Skips otherwise

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -495,6 +495,9 @@ func (h *ftpAccountsHandler) setPassword(c *gin.Context) {
 		"tenant_username": *u.Username,
 		"username":        acct.Username,
 		"password":        req.Password,
+		// JAB-261: chpasswd drops the shadow lock; send the desired lock
+		// state so the agent re-locks a disabled account in the same verb.
+		"enabled": acct.IsEnabled,
 	}); err != nil {
 		status, payload := mapFtpAgentError(err, "password_reset_failed")
 		c.JSON(status, payload)


### PR DESCRIPTION
## JAB-261 — resetting a disabled FTP password silently re-enabled the Unix credential

**Security (High).** A disabled FTP subaccount keeps its `jabali-ftp` group membership and is disabled *only* by the `!` shadow-hash lock (`usermod -L`); the row stays `is_enabled=false`. The password-reset verb ran `chpasswd`, which rewrites `sp_pwdp` and **drops the lock**, so the credential could authenticate to FTPS/SFTP again until the periodic reconciler re-locked it — and active sessions aren't torn down (JAB-256), so a session opened in that window persists.

### Fix
Re-apply the lock **atomically in the same agent verb** — no reliance on the reconciler.

- `ftpaccount.set_password` now takes the panel-authoritative `enabled` state and runs `usermod -L` after `chpasswd` when the account is disabled.
- `enabled` is a `*bool`, not a `bool`: an older panel that omits the field falls back to **preserving the pre-change shadow lock** (read via `passwd -S`) so a disabled account is never defaulted to unlocked. A plain-bool zero-value would instead re-lock *enabled* accounts during version skew (a foot-gun we've hit before).
- `panel-api` `setPassword` passes `acct.IsEnabled`.

### Tests
- `TestLockAfterPasswordReset` pins the pure decision across enabled / disabled / old-panel(nil) × locked/unlocked.
- Full `panel-agent/internal/commands` + `panel-api/internal/api` green.
- The real shadow-lock transition (`chpasswd`/`usermod`/`passwd -S`) has no exec seam → host-only. Live check on jabalitests: **create → disable (`passwd -S` = `L`) → password reset → still `L`, FTPS login denied.** _(result appended below)_

Acceptance criteria: reset on a disabled account leaves it locked + auth denied ✔; reset on an enabled account stays usable ✔; decision unit-pinned, live transition verified on the smoke host.

Refs JAB-261. Part of the FTP round-2 security batch (JAB-261..270).
