### PR TITLE
fix(dr): promote materializes tenant Linux users via os_users add-only merge (GH #331 drill)

### DIFF
--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -751,9 +751,26 @@ func applySystemRestore(ctx context.Context, stagingRoot string, stages []backup
 				warnings = append(warnings, fmt.Sprintf("security crowdsec: %v", err))
 			}
 			applied = append(applied, "security → /etc/ufw + /etc/crowdsec")
-		case backup.StageOSUsers, backup.StageDataState:
+		case backup.StageOSUsers:
+			// ADD-MISSING-ONLY merge (GH #331 two-node drill): a promoted DR
+			// standby is a box where the tenant Linux users never existed,
+			// and nothing else creates them. Existing users are never
+			// modified, uid/gid conflicts are skipped with a warning — the
+			// "cross-host /etc/passwd merge" hazard the old blanket warning
+			// pointed at is the MODIFY case, which this never does. Still
+			// whitelist-gated: only an explicit apply_stages request (the
+			// promote path) runs it.
+			if !whitelist[st.Name] {
+				warnings = append(warnings,
+					fmt.Sprintf("os_users staged at %s — pass --apply-stage=os_users to merge missing tenant users (add-only)", stageDir))
+				continue
+			}
+			a, w := applyOSUsersMerge(ctx, stageDir)
+			applied = append(applied, a...)
+			warnings = append(warnings, w...)
+		case backup.StageDataState:
 			warnings = append(warnings,
-				fmt.Sprintf("stage %q staged at %s — apply manually (auto-apply unsafe: cross-host /etc/passwd merge / per-user account_full restore)",
+				fmt.Sprintf("stage %q staged at %s — apply manually (auto-apply unsafe: per-user account_full restore)",
 					st.Name, stageDir))
 		}
 	}

--- a/panel-agent/internal/commands/backup_system_os_users_apply.go
+++ b/panel-agent/internal/commands/backup_system_os_users_apply.go
@@ -1,0 +1,201 @@
+// os_users stage apply (GH #331 two-node drill): materialize the SOURCE
+// host's tenant Linux users onto this box, add-missing-only. A promoted DR
+// standby (or a disaster-restore target) starts with none of the tenant
+// users — account creation is imperative at signup, not reconciled — so the
+// account-data restore rsyncs into nothing and the reconciler's domain
+// create loops on "unknown user" without this.
+//
+// Safety posture:
+//   - never modifies an existing user, group, or password;
+//   - a name that exists locally with a DIFFERENT uid/gid is skipped with a
+//     warning (the operator must resolve that collision by hand);
+//   - a wanted uid/gid already taken by another name is likewise skip+warn;
+//   - password hashes are fed to `chpasswd -e` via stdin, never argv.
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// osUserEntry is one parsed passwd line.
+type osUserEntry struct {
+	Name, Home, Shell, Gecos string
+	UID, GID                 int
+}
+
+// parsePasswdLine parses `name:x:uid:gid:gecos:home:shell`.
+func parsePasswdLine(line string) (*osUserEntry, error) {
+	f := strings.Split(line, ":")
+	if len(f) != 7 {
+		return nil, fmt.Errorf("malformed passwd line (%d fields)", len(f))
+	}
+	uid, err := strconv.Atoi(f[2])
+	if err != nil {
+		return nil, fmt.Errorf("uid %q: %w", f[2], err)
+	}
+	gid, err := strconv.Atoi(f[3])
+	if err != nil {
+		return nil, fmt.Errorf("gid %q: %w", f[3], err)
+	}
+	return &osUserEntry{Name: f[0], UID: uid, GID: gid, Gecos: f[4], Home: f[5], Shell: f[6]}, nil
+}
+
+// parseGroupLine parses `name:x:gid:member,member`.
+func parseGroupLine(line string) (name string, gid int, members []string, err error) {
+	f := strings.Split(line, ":")
+	if len(f) != 4 {
+		return "", 0, nil, fmt.Errorf("malformed group line (%d fields)", len(f))
+	}
+	gid, err = strconv.Atoi(f[2])
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("gid %q: %w", f[2], err)
+	}
+	for _, m := range strings.Split(f[3], ",") {
+		if m = strings.TrimSpace(m); m != "" {
+			members = append(members, m)
+		}
+	}
+	return f[0], gid, members, nil
+}
+
+// shadowHashes maps user → password hash from the bundle's shadow lines.
+func shadowHashes(shadow []string) map[string]string {
+	out := map[string]string{}
+	for _, line := range shadow {
+		f := strings.Split(line, ":")
+		if len(f) >= 2 && f[0] != "" {
+			out[f[0]] = f[1]
+		}
+	}
+	return out
+}
+
+// applyOSUsersMerge reads <stageDir>/os_users.json and creates every group +
+// user that does not exist locally, preserving uid/gid, shell, home path,
+// and password hash. Group memberships are re-asserted additively at the
+// end. Returns (applied, warnings); it never fails the whole restore.
+func applyOSUsersMerge(ctx context.Context, stageDir string) ([]string, []string) {
+	var applied, warnings []string
+	src := filepath.Join(stageDir, "os_users.json")
+	if _, err := os.Stat(src); err != nil {
+		src = filepath.Join(stageDir, "stdin")
+	}
+	raw, err := os.ReadFile(src) // #nosec G304 — server-controlled stage dir
+	if err != nil {
+		return nil, []string{fmt.Sprintf("os_users: read blob: %v", err)}
+	}
+	var bundle osUsersBundle
+	if err := json.Unmarshal(raw, &bundle); err != nil {
+		return nil, []string{fmt.Sprintf("os_users: parse blob: %v", err)}
+	}
+	hashes := shadowHashes(bundle.Shadow)
+
+	// Groups first — users reference their primary gid.
+	type wantedGroup struct {
+		name    string
+		members []string
+	}
+	var groups []wantedGroup
+	for _, line := range bundle.Group {
+		name, gid, members, perr := parseGroupLine(line)
+		if perr != nil {
+			warnings = append(warnings, fmt.Sprintf("os_users: %v", perr))
+			continue
+		}
+		groups = append(groups, wantedGroup{name: name, members: members})
+		if g, lerr := user.LookupGroup(name); lerr == nil {
+			if g.Gid != strconv.Itoa(gid) {
+				warnings = append(warnings,
+					fmt.Sprintf("os_users: group %q exists with gid %s (source %d) — leaving as-is", name, g.Gid, gid))
+			}
+			continue
+		}
+		if g, lerr := user.LookupGroupId(strconv.Itoa(gid)); lerr == nil {
+			warnings = append(warnings,
+				fmt.Sprintf("os_users: gid %d already belongs to group %q — cannot create %q, skipped", gid, g.Name, name))
+			continue
+		}
+		if out, cerr := exec.CommandContext(ctx, "groupadd", "-g", strconv.Itoa(gid), name).CombinedOutput(); cerr != nil {
+			warnings = append(warnings, fmt.Sprintf("os_users: groupadd %s: %v (%s)", name, cerr, strings.TrimSpace(string(out))))
+			continue
+		}
+		applied = append(applied, fmt.Sprintf("os_users: group %s (gid %d)", name, gid))
+	}
+
+	for _, line := range bundle.Passwd {
+		e, perr := parsePasswdLine(line)
+		if perr != nil {
+			warnings = append(warnings, fmt.Sprintf("os_users: %v", perr))
+			continue
+		}
+		if u, lerr := user.Lookup(e.Name); lerr == nil {
+			if u.Uid != strconv.Itoa(e.UID) {
+				warnings = append(warnings,
+					fmt.Sprintf("os_users: user %q exists with uid %s (source %d) — restored files will carry the SOURCE uid; resolve by hand", e.Name, u.Uid, e.UID))
+			}
+			continue
+		}
+		if u, lerr := user.LookupId(strconv.Itoa(e.UID)); lerr == nil {
+			warnings = append(warnings,
+				fmt.Sprintf("os_users: uid %d already belongs to %q — cannot create %q, skipped", e.UID, u.Username, e.Name))
+			continue
+		}
+		args := []string{
+			"--no-create-home", // home layout is the sftp-chroot reconciler's job
+			"--uid", strconv.Itoa(e.UID),
+			"--home-dir", e.Home,
+			"--shell", e.Shell,
+			"--comment", e.Gecos,
+		}
+		if _, gerr := user.LookupGroupId(strconv.Itoa(e.GID)); gerr == nil {
+			args = append(args, "--gid", strconv.Itoa(e.GID))
+		} else {
+			// Primary group missing (filtered out of the bundle or a
+			// collision above) — let useradd create the usergroup.
+			warnings = append(warnings,
+				fmt.Sprintf("os_users: user %q source gid %d absent — using a fresh usergroup", e.Name, e.GID))
+		}
+		args = append(args, e.Name)
+		if out, cerr := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); cerr != nil {
+			warnings = append(warnings, fmt.Sprintf("os_users: useradd %s: %v (%s)", e.Name, cerr, strings.TrimSpace(string(out))))
+			continue
+		}
+		// M12 sftp-chroot home shape: root-owned 0751 shell; the ssh-keys
+		// reconciler + the account-restore rsync fill and finalize it.
+		if merr := os.MkdirAll(e.Home, 0o751); merr != nil {
+			warnings = append(warnings, fmt.Sprintf("os_users: mkdir %s: %v", e.Home, merr))
+		}
+		if h := hashes[e.Name]; h != "" && h != "*" && h != "!" {
+			cmd := exec.CommandContext(ctx, "chpasswd", "-e")
+			cmd.Stdin = strings.NewReader(e.Name + ":" + h + "\n")
+			if out, cerr := cmd.CombinedOutput(); cerr != nil {
+				warnings = append(warnings, fmt.Sprintf("os_users: chpasswd %s: %v (%s)", e.Name, cerr, strings.TrimSpace(string(out))))
+			}
+		}
+		applied = append(applied, fmt.Sprintf("os_users: user %s (uid %d)", e.Name, e.UID))
+	}
+
+	// Memberships last, additive only, both sides must exist by now.
+	for _, g := range groups {
+		for _, m := range g.members {
+			if _, uerr := user.Lookup(m); uerr != nil {
+				continue
+			}
+			if _, gerr := user.LookupGroup(g.name); gerr != nil {
+				continue
+			}
+			if out, cerr := exec.CommandContext(ctx, "usermod", "-aG", g.name, m).CombinedOutput(); cerr != nil {
+				warnings = append(warnings, fmt.Sprintf("os_users: usermod -aG %s %s: %v (%s)", g.name, m, cerr, strings.TrimSpace(string(out))))
+			}
+		}
+	}
+	return applied, warnings
+}

--- a/panel-agent/internal/commands/backup_system_os_users_apply_test.go
+++ b/panel-agent/internal/commands/backup_system_os_users_apply_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// GH #331: the os_users merge parsers are the safety boundary — a malformed
+// line must warn, never crash or half-apply.
+func TestParsePasswdLine(t *testing.T) {
+	e, err := parsePasswdLine("shukivaknin:x:1000:1000:Shuki:/home/shukivaknin:/bin/bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Name != "shukivaknin" || e.UID != 1000 || e.GID != 1000 ||
+		e.Home != "/home/shukivaknin" || e.Shell != "/bin/bash" {
+		t.Errorf("parsed wrong: %+v", e)
+	}
+	for _, bad := range []string{"", "a:b", "u:x:notnum:1::/h:/s", "u:x:1:notnum::/h:/s"} {
+		if _, err := parsePasswdLine(bad); err == nil {
+			t.Errorf("line %q must fail", bad)
+		}
+	}
+}
+
+func TestParseGroupLine(t *testing.T) {
+	name, gid, members, err := parseGroupLine("jabali-sftp:x:986:shukivaknin, demolab_ftp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "jabali-sftp" || gid != 986 {
+		t.Errorf("got %s/%d", name, gid)
+	}
+	if strings.Join(members, "|") != "shukivaknin|demolab_ftp" {
+		t.Errorf("members: %v", members)
+	}
+	if _, _, m, err := parseGroupLine("g:x:1:"); err != nil || len(m) != 0 {
+		t.Errorf("empty member list must parse clean, got %v %v", m, err)
+	}
+}
+
+func TestShadowHashes(t *testing.T) {
+	h := shadowHashes([]string{
+		"u1:$y$j9T$abc$def:19000:0:99999:7:::",
+		"locked:!:1:0:99999:7:::",
+		"malformed",
+	})
+	if h["u1"] != "$y$j9T$abc$def" || h["locked"] != "!" {
+		t.Errorf("hashes: %v", h)
+	}
+}

--- a/panel-api/cmd/server/dr_promote.go
+++ b/panel-api/cmd/server/dr_promote.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	backup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
 	"net"
 	"os"
 	"strings"
@@ -155,9 +157,21 @@ func promoteRestoreAccounts(ctx context.Context, s *models.ServerSettings) error
 				"manifest_snapshot_id": "latest",
 				"apply":                true,
 				"include_accounts":     true,
-				"repo_url":             dest.URL,
-				"destination_kind":     dest.Kind,
-				"sftp":                 backupwrapperhelpers.SFTPWireParams(dest),
+				// os_users MUST be materialized before the account stages
+				// land (GH #331 two-node drill): a promoted standby is a box
+				// where the tenant Linux users never existed — nothing else
+				// creates them (account creation is imperative, not
+				// reconciled), so without this the home/DB restore rsyncs
+				// into nothing and the reconciler's domain-create loops on
+				// "unknown user". The explicit list keeps the whitelist
+				// semantics: every auto stage is named.
+				"apply_stages": []string{
+					backup.StagePanelDB, backup.StagePanelConfig,
+					backup.StageTLS, backup.StageOSUsers,
+				},
+				"repo_url":         dest.URL,
+				"destination_kind": dest.Kind,
+				"sftp":             backupwrapperhelpers.SFTPWireParams(dest),
 			}
 			if dest.CredentialsRef != nil {
 				params["credentials_ref"] = *dest.CredentialsRef
@@ -165,8 +179,26 @@ func promoteRestoreAccounts(ctx context.Context, s *models.ServerSettings) error
 			if passwordFile != "" {
 				params["password_file"] = passwordFile
 			}
-			_, err := sharedAgent.Call(ctx, "system.restore", params)
-			return err
+			raw, err := sharedAgent.Call(ctx, "system.restore", params)
+			if err != nil {
+				return err
+			}
+			// Surface what the restore actually did — the drill's first
+			// promote "succeeded" while every account stage silently
+			// failed, because these warnings were swallowed.
+			var out struct {
+				Applied       []string `json:"applied"`
+				ApplyWarnings []string `json:"apply_warnings"`
+			}
+			if jerr := json.Unmarshal(raw, &out); jerr == nil {
+				for _, a := range out.Applied {
+					fmt.Println("  applied:", a)
+				}
+				for _, w := range out.ApplyWarnings {
+					fmt.Println("  WARNING:", w)
+				}
+			}
+			return nil
 		})
 }
 


### PR DESCRIPTION
## Summary
Fifth live drill finding (F9), and the biggest: the first real promote reported success while restoring **nothing user-visible**. A standby has none of the tenant Linux users (account creation is imperative, never reconciled), the `os_users` stage had NO apply implementation (staged-with-warning only), and promote swallowed `apply_warnings` — so the account-inclusive restore rsynced homes into nothing, per-user DB loads failed, and the reconciler looped on `domain create: unknown user shukivaknin`.

- **`applyOSUsersMerge`** — add-missing-only materialization from the os_users bundle: groups → users → memberships, preserving uid/gid/shell/home/password-hash (`chpasswd -e` via stdin, hashes never on argv). Never modifies existing users/groups; name and uid/gid collisions skip with warnings. Whitelist-gated — only an explicit `apply_stages` request (promote, or manual `--apply-stage=os_users`) runs it.
- **promote** passes `apply_stages [panel_db, panel_config, tls, os_users]` (os_users applies before `restoreAccounts` in the same handler, so the rsync targets exist) and now prints the agent's applied/warnings lists.

## Test plan
- [x] parser/safety unit tests (malformed lines, member lists, locked hashes)
- [x] agent + cmd suites, vet clean
- [ ] Live: re-run the final restore on the drill's promoted box — users, homes, per-user DBs, vhosts, then full serving checks

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)