### PR TITLE
fix(dr): fence jabali-panel around promote — in-flight drsync re-demoted the promoted box (GH #331 drill)

### DIFF
--- a/panel-api/cmd/server/dr_promote.go
+++ b/panel-api/cmd/server/dr_promote.go
@@ -8,6 +8,7 @@ import (
 	backup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
 	"net"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -91,6 +92,22 @@ func newDRPromoteCmd() *cobra.Command {
 					return nil
 				}
 			}
+
+			// FENCE the panel service around the restore + role flip (GH #331
+			// two-node drill): the panel hosts the drsync loop, and a tick's
+			// system.restore that is IN FLIGHT when the role flips completes
+			// afterwards and re-stamps role=standby via its dr_pairing block —
+			// the promoted box silently re-demoted itself and resumed syncing
+			// over the promoted state. Stopping jabali-panel kills the loop
+			// (the agent, which serves the restore dispatch, stays up); it is
+			// restarted after the flip. Same fence `jabali system restore`
+			// uses.
+			fmt.Println("Stopping jabali-panel.service for the promotion window…")
+			_ = exec.CommandContext(ctx, "systemctl", "stop", "jabali-panel.service").Run()
+			defer func() {
+				fmt.Println("Starting jabali-panel.service…")
+				_ = exec.CommandContext(context.Background(), "systemctl", "start", "jabali-panel.service").Run()
+			}()
 
 			// Final account-inclusive restore so home dirs, mail, and per-user DBs
 			// land (drsync only applied panel_db+config+tls during replication).


### PR DESCRIPTION
## Summary
Sixth live drill finding (F10): the #1143 agent-side reassert — correct for standby ticks — got weaponized in reverse by promote. During promote's ~10-minute final restore, the panel's drsync loop (box still standby) had its OWN `system.restore` in flight; it completed after the role flip and its `dr_pairing` block faithfully re-stamped role=standby with the old pairing (observed: `dr_paired_at` preserved from the pre-promote pair, loop resumed applying snapshots 13 and 23 minutes after "PROMOTED").

Fix: promote stops `jabali-panel.service` before the final restore (drsync loop dies with it; the agent serving the dispatch stays up), flips the role, then restarts the panel — the exact fence `jabali system restore` already uses for the same reason.

## Test plan
- [x] build + vet clean (behavioral change is service orchestration in the CLI path)
- [ ] Live: re-promote the drill standby on this build — role must survive; then full serving battery

GH #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)