### PR TITLE
feat(ftp): true (separate-uid) isolation for FTP/SFTP subaccounts (GH #1145)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5311,6 +5311,14 @@ ensure_user_and_dirs() {
   # api anyway, but keep it world-readable for future direct serving).
   install -d -m 0755 -o "$SERVICE_USER" -g "$SERVICE_USER" /var/lib/jabali-panel
   install -d -m 0755 -o "$SERVICE_USER" -g "$SERVICE_USER" /var/lib/jabali-panel/branding
+  # GH #1145 — parent of every per-subaccount SFTP/FTPS isolation jail. Must be
+  # root:root and NOT group/other-writable so it satisfies sshd's root-owned-
+  # chroot-chain rule and vsftpd's secure-chroot rule; the agent creates the
+  # per-account jail (<tenant>/<alias>/) beneath it on isolated-account create.
+  # Declared here (not gated on the ftp/vsftpd module) because SFTP isolation
+  # works without vsftpd. sshd/vsftpd are unconfined by AppArmor, so no profile
+  # rule is needed for the jail path.
+  install -d -m 0755 -o root -g root /var/lib/jabali-ftp-jails
   # M35 — migration importers. Legacy path /var/lib/jabali-migrations
   # is kept as a symlink to the new working_folder/migrations subdir so
   # existing callsites that hardcode the old path keep working. Real

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -837,4 +837,5 @@ func init() {
 	Default.Register("ftpaccount.list", ftpAccountListHandler)
 	Default.Register("ftpaccount.list_all", ftpAccountListAllHandler)
 	Default.Register("ftpaccount.lock_tenant", ftpAccountLockTenantHandler)
+	Default.Register("ftpaccount.ensure_jail", ftpEnsureJailHandler)
 }

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -202,18 +202,31 @@ func requireFtpSubaccount(tenant *ftpTenant, sub string) (*user.User, *agentwire
 		}
 	}
 	uid, _ := strconv.Atoi(u.Uid)
-	if uid != tenant.UID {
-		return nil, &agentwire.AgentError{
-			Code:    agentwire.CodePermissionDenied,
-			Message: fmt.Sprintf("passwd entry %q has uid %d, expected tenant uid %d — refusing to touch a non-subaccount user", sub, uid, tenant.UID),
-		}
-	}
-	// Ownership marker: name+uid alone can match an operator's hand-made
-	// alias — those are never ours to re-password, lock, or delete.
-	if u.Name != ftpAliasGecos {
+	// Ownership: the GECOS marker (bare or owner-encoded) is authoritative.
+	// Owner-encoded aliases match by owner regardless of uid (isolated accounts
+	// have their OWN uid); bare-marker legacy aliases must still share the
+	// tenant uid. os/user parses User.Name as the pre-comma GECOS segment, which
+	// is exactly what ftpMarkerOwner expects. Both the marker AND the tenant
+	// binding must hold, so a caller can never lock/re-password/delete an
+	// operator's alias or another tenant's subaccount.
+	owner, marked := ftpMarkerOwner(u.Name)
+	if !marked {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodePermissionDenied,
 			Message: fmt.Sprintf("passwd entry %q lacks the %q ownership marker — operator-managed account, refusing", sub, ftpAliasGecos),
+		}
+	}
+	if owner != "" {
+		if owner != tenant.Username {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodePermissionDenied,
+				Message: fmt.Sprintf("passwd entry %q is owned by tenant %q, not %q — refusing", sub, owner, tenant.Username),
+			}
+		}
+	} else if uid != tenant.UID {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("passwd entry %q has uid %d, expected tenant uid %d — refusing to touch a non-subaccount user", sub, uid, tenant.UID),
 		}
 	}
 	return u, nil
@@ -392,7 +405,7 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 		"--no-create-home",
 		"--no-user-group",
 		"--shell", "/usr/sbin/nologin",
-		"--comment", ftpAliasGecos,
+		"--comment", ftpAliasGecosFor(tenant.Username),
 		p.Username,
 	}
 	if out, err := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); err != nil {
@@ -570,11 +583,9 @@ func ftpAccountListHandler(ctx context.Context, params json.RawMessage) (any, er
 		if len(parts) < 6 || !strings.HasPrefix(parts[0], prefix) {
 			continue
 		}
-		if uid, _ := strconv.Atoi(parts[2]); uid != tenant.UID {
-			continue // same prefix but not our alias — not ours to report
-		}
-		if gecosName(parts[4]) != ftpAliasGecos {
-			continue // operator-made alias — invisible to the panel
+		uid, _ := strconv.Atoi(parts[2])
+		if !ftpAliasOwnedBy(parts[4], uid, tenant) {
+			continue // same prefix but not our alias (or an operator's) — skip
 		}
 		name := parts[0]
 		isFtp, _ := isUserInGroup(ctx, name, ftpGroupName)
@@ -607,10 +618,12 @@ func ftpTenantAliasNames(tenant *ftpTenant) ([]string, *agentwire.AgentError) {
 		if len(parts) < 6 || !strings.HasPrefix(parts[0], prefix) {
 			continue
 		}
-		if uid, _ := strconv.Atoi(parts[2]); uid != tenant.UID {
-			continue
-		}
-		if gecosName(parts[4]) != ftpAliasGecos {
+		// Owner-aware: includes isolated (separate-uid) aliases, which no
+		// longer share the tenant uid, while staying collision-proof for
+		// prefix-colliding tenants. Keeps JAB-254 suspension covering every
+		// owned alias regardless of isolation mode.
+		uid, _ := strconv.Atoi(parts[2])
+		if !ftpAliasOwnedBy(parts[4], uid, tenant) {
 			continue
 		}
 		names = append(names, parts[0])
@@ -701,19 +714,38 @@ func classifyFtpAliases(passwd string) (owned []ftpAccountListAllEntry, skippedU
 	}
 	owned = []ftpAccountListAllEntry{}
 	for _, name := range order {
+		owner, marked := ftpMarkerOwner(byName[name].gecos)
+		if marked && owner != "" {
+			// Owner-encoded: ownership is explicit — no uid/shape inference
+			// (isolated aliases do NOT share the tenant uid). Report it even if
+			// the owner tenant is gone; a rowless alias is exactly what the
+			// reaper must surface. Require the namespaced-username prefix to
+			// match the encoded owner: a mismatch is a corrupted/forged marker
+			// (only root writes passwd), never attributed to a tenant.
+			if strings.HasPrefix(name, owner+"_") {
+				owned = append(owned, ftpAccountListAllEntry{
+					TenantUsername: owner,
+					Username:       name,
+					HomePath:       byName[name].home,
+				})
+			}
+			continue
+		}
+		// Legacy path (bare marker or no marker): needs the <tenant>_<label>
+		// shape + a same-uid tenant entry to identify the owner. Walk every "_"
+		// split point — tenant names may themselves contain underscores
+		// (user_01k…), so "a_b_c" must try tenants "a_b" and "a".
 		i := strings.LastIndex(name, "_")
 		if i <= 0 {
 			continue
 		}
-		// Walk every "_" split point: tenant names may themselves contain
-		// underscores (user_01k…), so "a_b_c" must try tenants "a_b" and "a".
 		for j := i; j > 0; j = strings.LastIndex(name[:j], "_") {
 			tenant := name[:j]
 			te, ok := byName[tenant]
 			if !ok || te.uid < minTenantUID || te.uid != byName[name].uid || tenant == name {
 				continue
 			}
-			if gecosName(byName[name].gecos) != ftpAliasGecos {
+			if !marked {
 				// Same shape, no marker: an operator's hand-made alias.
 				skippedUnmarked++
 				break

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -528,13 +528,19 @@ func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 	if aerr != nil {
 		return nil, aerr
 	}
-	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+	u, aerr := requireFtpSubaccount(tenant, p.Username)
+	if aerr != nil {
 		// Idempotent delete: a passwd entry that is already gone is success.
 		if aerr.Code == agentwire.CodeNotFound {
 			return map[string]any{"username": p.Username, "deleted": false, "absent": true}, nil
 		}
 		return nil, aerr
 	}
+	// Isolated accounts own a uid in the reserved range and a root-owned jail;
+	// remember whether to tear it down after userdel. Legacy same-uid aliases
+	// share the tenant uid and have no jail.
+	delUID, _ := strconv.Atoi(u.Uid)
+	isolated := delUID >= ftpSubaccountUIDMin
 	_ = setFtpGroupMembership(ctx, p.Username, false)
 	// -f is REQUIRED, not defensive: the alias shares the tenant's uid, so
 	// the tenant's always-running processes (per-user FPM master, cron)
@@ -544,6 +550,14 @@ func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 	// live tenant directory, usually a docroot).
 	if out, err := exec.CommandContext(ctx, "userdel", "-f", p.Username).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("userdel %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
+	}
+	// Isolated account: unmount + remove its jail AFTER the user is gone. The
+	// teardown never touches the bind-mount source (tenant data); it is
+	// idempotent and safe on a legacy path that has no jail.
+	if isolated {
+		if terr := teardownIsolatedJail(ctx, ftpJailPathFor(tenant, p.Username)); terr != nil {
+			return nil, terr
+		}
 	}
 	return map[string]any{"username": p.Username, "deleted": true}, nil
 }

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -283,12 +283,39 @@ type ftpAccountCreateParams struct {
 	HomePath       string `json:"home_path"`
 	Password       string `json:"password"`
 	FTPAccess      bool   `json:"ftp_access"`
+	// Isolated selects the separate-uid jailed model (GH #1145). When false
+	// the legacy same-uid alias path runs. The fields below are required only
+	// when Isolated is true; the panel allocates the uid + computes the split.
+	Isolated   bool   `json:"isolated"`
+	UID        uint32 `json:"uid"`
+	QuotaMB    uint32 `json:"quota_mb"`
+	QuotaMount string `json:"quota_mount"`
+	JailPath   string `json:"jail_path"`
 }
 
 type ftpAccountCreateResponse struct {
 	Username string `json:"username"`
 	UID      int    `json:"uid"`
 	HomePath string `json:"home_path"`
+}
+
+// ensureTenantOwnedDir makes homePath exist and be tenant-owned, created
+// through the openat2-confined scope (JAB-251) so a tenant symlink swap under
+// the tenant-writable home cannot redirect the root chown. No-op when homePath
+// IS the tenant home root (already provisioned, no in-scope parent to open).
+// Used by both the legacy and the isolated create paths.
+func ensureTenantOwnedDir(tenant *ftpTenant, homePath string) *agentwire.AgentError {
+	if filepath.Clean(homePath) == filepath.Clean(tenant.HomeDir) {
+		return nil
+	}
+	scope, serr := filesafe.NewScope(tenant.Username, tenant.Username, []string{tenant.HomeDir})
+	if serr != nil {
+		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("home scope for %q: %v", tenant.HomeDir, serr)}
+	}
+	if err := scope.MkdirChownInScope(homePath, 0o755, true, tenant.UID, tenant.GID); err != nil {
+		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create+chown home %q (confined): %v", homePath, err)}
+	}
+	return nil
 }
 
 func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -312,6 +339,30 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 	}
 	if _, err := user.Lookup(p.Username); err == nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeAlreadyExists, Message: fmt.Sprintf("user %q already exists", p.Username)}
+	}
+
+	// GH #1145 isolated (separate-uid) path: create the selected dir confined,
+	// then build the root-owned jail + own-uid user + ACL + per-uid quota. The
+	// legacy same-uid alias path below is skipped entirely for isolated rows.
+	if p.Isolated {
+		if aerr := ensureTenantOwnedDir(tenant, homePath); aerr != nil {
+			return nil, aerr
+		}
+		rollback, aerr := provisionIsolatedJail(ctx, tenant, p)
+		if aerr != nil {
+			return nil, aerr
+		}
+		if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
+			rollback()
+			return nil, aerr
+		}
+		if p.FTPAccess {
+			if aerr := setFtpGroupMembership(ctx, p.Username, true); aerr != nil {
+				rollback()
+				return nil, aerr
+			}
+		}
+		return ftpAccountCreateResponse{Username: p.Username, UID: int(p.UID), HomePath: homePath}, nil
 	}
 
 	// Same-uid alias. --no-create-home: the directory is the tenant's
@@ -364,20 +415,9 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 	// follows it. MkdirChownInScope holds the resolved parent fd across
 	// mkdirat + O_NOFOLLOW re-open + Fchown, so no post-validation
 	// pathname re-resolution occurs and a swapped leaf is refused (ELOOP).
-	if filepath.Clean(homePath) == filepath.Clean(tenant.HomeDir) {
-		// Home IS the tenant home root: it already exists and is
-		// tenant-owned from provisioning — nothing to create or chown,
-		// and it has no in-scope parent to open.
-	} else {
-		scope, serr := filesafe.NewScope(tenant.Username, tenant.Username, []string{tenant.HomeDir})
-		if serr != nil {
-			rollback()
-			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("home scope for %q: %v", tenant.HomeDir, serr)}
-		}
-		if err := scope.MkdirChownInScope(homePath, 0o755, true, tenant.UID, tenant.GID); err != nil {
-			rollback()
-			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create+chown home %q (confined): %v", homePath, err)}
-		}
+	if aerr := ensureTenantOwnedDir(tenant, homePath); aerr != nil {
+		rollback()
+		return nil, aerr
 	}
 	if aerr := chpasswdStdin(ctx, p.Username, p.Password); aerr != nil {
 		rollback()

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -224,6 +224,15 @@ func requireFtpSubaccount(tenant *ftpTenant, sub string) (*user.User, *agentwire
 				Message: fmt.Sprintf("passwd entry %q is owned by tenant %q, not %q — refusing", sub, owner, tenant.Username),
 			}
 		}
+		// Owner match is authoritative, but never touch a system uid: an owned
+		// subaccount is the tenant uid (owner-encoded legacy) or an isolated uid
+		// in the reserved range. Blocks a mistaken owner marker on uid 0.
+		if uid != tenant.UID && uid < ftpSubaccountUIDMin {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodePermissionDenied,
+				Message: fmt.Sprintf("passwd entry %q has out-of-range uid %d for an owned subaccount — refusing", sub, uid),
+			}
+		}
 	} else if uid != tenant.UID {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodePermissionDenied,
@@ -531,7 +540,15 @@ func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 	u, aerr := requireFtpSubaccount(tenant, p.Username)
 	if aerr != nil {
 		// Idempotent delete: a passwd entry that is already gone is success.
+		// But a PRIOR delete may have failed AFTER userdel and BEFORE jail
+		// teardown, leaving an orphaned jail + live bind mount of tenant data
+		// that nothing else sweeps (the reaper keys on passwd, the reconciler
+		// on DB rows — both gone). Tear the jail down here too; idempotent and
+		// ENOENT-safe, so it no-ops for a legacy account that never had one.
 		if aerr.Code == agentwire.CodeNotFound {
+			if terr := teardownIsolatedJail(ctx, ftpJailPathFor(tenant, p.Username)); terr != nil {
+				return nil, terr
+			}
 			return map[string]any{"username": p.Username, "deleted": false, "absent": true}, nil
 		}
 		return nil, aerr
@@ -739,9 +756,14 @@ func classifyFtpAliases(passwd string) (owned []ftpAccountListAllEntry, skippedU
 			// Owner-encoded: ownership is explicit — no uid/shape inference
 			// (isolated aliases do NOT share the tenant uid). Report it even if
 			// the owner tenant is gone; a rowless alias is exactly what the
-			// reaper must surface. Require the namespaced-username prefix to
-			// match the encoded owner: a mismatch is a corrupted/forged marker
-			// (only root writes passwd), never attributed to a tenant.
+			// reaper must surface. A SYSTEM uid with an owner marker is never
+			// ours (mirrors the legacy walk's minTenantUID guard) — ignore it.
+			// Otherwise require the namespaced-username prefix to match the
+			// encoded owner: a mismatch is a corrupted/forged marker (only root
+			// writes passwd), never attributed to a tenant.
+			if byName[name].uid < minTenantUID {
+				continue
+			}
 			if strings.HasPrefix(name, owner+"_") {
 				owned = append(owned, ftpAccountListAllEntry{
 					TenantUsername: owner,

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/user"
@@ -611,24 +612,29 @@ func ftpTenantAliasNames(tenant *ftpTenant) ([]string, *agentwire.AgentError) {
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("read passwd: %v", err)}
 	}
+	return ftpOwnedAliasNames(string(passwd), tenant), nil
+}
+
+// ftpOwnedAliasNames is the pure filter behind ftpTenantAliasNames (and thus
+// the JAB-254 suspension lock path). Owner-aware: includes isolated
+// (separate-uid) aliases — which no longer share the tenant uid — while staying
+// collision-proof for prefix-colliding tenants, so tenant suspension covers
+// every owned alias regardless of isolation mode.
+func ftpOwnedAliasNames(passwd string, tenant *ftpTenant) []string {
 	prefix := tenant.Username + "_"
 	var names []string
-	for _, line := range strings.Split(string(passwd), "\n") {
+	for _, line := range strings.Split(passwd, "\n") {
 		parts := strings.Split(line, ":")
 		if len(parts) < 6 || !strings.HasPrefix(parts[0], prefix) {
 			continue
 		}
-		// Owner-aware: includes isolated (separate-uid) aliases, which no
-		// longer share the tenant uid, while staying collision-proof for
-		// prefix-colliding tenants. Keeps JAB-254 suspension covering every
-		// owned alias regardless of isolation mode.
 		uid, _ := strconv.Atoi(parts[2])
 		if !ftpAliasOwnedBy(parts[4], uid, tenant) {
 			continue
 		}
 		names = append(names, parts[0])
 	}
-	return names, nil
+	return names
 }
 
 // ftpAccountLockTenantHandler locks EVERY panel-owned FTP/SFTP alias of a
@@ -728,6 +734,14 @@ func classifyFtpAliases(passwd string) (owned []ftpAccountListAllEntry, skippedU
 					Username:       name,
 					HomePath:       byName[name].home,
 				})
+			} else {
+				// Owner-encoded marker whose username is NOT namespaced under
+				// the encoded owner. Not attacker-reachable (only root writes
+				// passwd), but a PANEL stamping bug here would hide a live alias
+				// from the reaper — the one thing the reaper must never do — so
+				// surface it loudly instead of silently dropping the credential.
+				slog.Warn("ftp reaper: owner-encoded alias with mismatched username prefix — possible stamping bug",
+					"username", name, "encoded_owner", owner)
 			}
 			continue
 		}

--- a/panel-agent/internal/commands/ftp_account_identity.go
+++ b/panel-agent/internal/commands/ftp_account_identity.go
@@ -54,7 +54,12 @@ func ftpAliasOwnedBy(gecos string, aliasUID int, tenant *ftpTenant) bool {
 		return false
 	}
 	if owner != "" {
-		return owner == tenant.Username
+		// Owner match is authoritative, but never claim a SYSTEM uid: a
+		// (root-created, mistaken) owner marker on uid 0 / a service account
+		// must not be lockable/listable as a subaccount. An owned subaccount is
+		// either the tenant uid (owner-encoded legacy mode) or an isolated uid
+		// in the reserved range.
+		return owner == tenant.Username && (aliasUID == tenant.UID || aliasUID >= ftpSubaccountUIDMin)
 	}
 	// Legacy bare marker: the alias must share the tenant uid (the historical
 	// disambiguator that still distinguishes "shop" from "shop_other").

--- a/panel-agent/internal/commands/ftp_account_identity.go
+++ b/panel-agent/internal/commands/ftp_account_identity.go
@@ -1,0 +1,62 @@
+package commands
+
+import "strings"
+
+// Alias ownership identity (GH #1145). The original #1053 model inferred which
+// tenant owns a passwd alias from a SHARED uid (alias.uid == tenant.uid). That
+// breaks for isolated (separate-uid) subaccounts, which no longer share the
+// tenant uid — an isolated alias would be invisible to tenant suspension
+// (JAB-254), the stray-alias reaper, and the per-tenant list, and the eligibility
+// gate. It also relied on the uid check as the ONLY prefix-collision
+// disambiguator (tenant "shop" vs a separate tenant "shop_other" both match the
+// "shop_" prefix).
+//
+// The fix encodes the owning tenant IN the GECOS ownership marker so ownership
+// is explicit in the host artifact — uid-model-independent AND collision-proof.
+//
+// Delimiter is "=", NOT ":": the marker lives in the GECOS field, which is
+// itself a ":"-delimited field of /etc/passwd, so a colon would corrupt the
+// line (and useradd --comment rejects it). "=" is valid in GECOS and can never
+// appear in a Linux username (NAME_REGEX [a-z_][a-z0-9_-]*), so the split is
+// unambiguous. The marker sits in the first GECOS comma-subfield, so gecosName
+// (which strips at the first comma) still yields it even with trailing ",,,".
+
+// ftpAliasGecosFor is the owner-encoded GECOS marker stamped on every alias the
+// panel creates (legacy same-uid AND isolated separate-uid). Pre-existing
+// accounts carry the bare ftpAliasGecos; ftpMarkerOwner recognizes both.
+func ftpAliasGecosFor(tenantUsername string) string {
+	return ftpAliasGecos + "=" + tenantUsername
+}
+
+// ftpMarkerOwner parses a passwd GECOS field. marked is true for any
+// panel-owned alias (bare or owner-encoded). owner is the encoded tenant
+// username, or "" for a bare legacy marker (ownership then inferred by the
+// same-uid rule). Accepts the raw GECOS or a pre-split name segment.
+func ftpMarkerOwner(gecos string) (owner string, marked bool) {
+	seg := gecosName(gecos) // strip any trailing ",,," GECOS sub-fields
+	if seg == ftpAliasGecos {
+		return "", true
+	}
+	if rest, ok := strings.CutPrefix(seg, ftpAliasGecos+"="); ok && rest != "" {
+		return rest, true
+	}
+	return "", false
+}
+
+// ftpAliasOwnedBy reports whether a passwd entry (its raw GECOS + numeric uid)
+// is a panel-owned subaccount of tenant. Owner-encoded aliases match EXACTLY by
+// owner — collision-proof across prefix-colliding tenants and independent of
+// whether the alias shares the tenant uid. Bare-marker legacy aliases fall back
+// to the shared-uid rule so existing accounts keep working with no reprovision.
+func ftpAliasOwnedBy(gecos string, aliasUID int, tenant *ftpTenant) bool {
+	owner, marked := ftpMarkerOwner(gecos)
+	if !marked {
+		return false
+	}
+	if owner != "" {
+		return owner == tenant.Username
+	}
+	// Legacy bare marker: the alias must share the tenant uid (the historical
+	// disambiguator that still distinguishes "shop" from "shop_other").
+	return aliasUID == tenant.UID
+}

--- a/panel-agent/internal/commands/ftp_account_identity_test.go
+++ b/panel-agent/internal/commands/ftp_account_identity_test.go
@@ -37,11 +37,11 @@ func TestFtpAliasOwnedBy(t *testing.T) {
 		want     bool
 	}{
 		// Owner-encoded: matched by owner, independent of uid.
-		{"isolated of shop", "jabali-ftp-account=shop", 500002, shop, true},
-		{"isolated of shop not owned by shop_other", "jabali-ftp-account=shop", 500002, shopOther, false},
+		{"isolated of shop", "jabali-ftp-account=shop", 1000000002, shop, true},
+		{"isolated of shop not owned by shop_other", "jabali-ftp-account=shop", 1000000002, shopOther, false},
 		// Prefix collision: shop_other_deploy is owned by shop_other, NEVER shop.
-		{"collision: owned by shop_other", "jabali-ftp-account=shop_other", 500003, shopOther, true},
-		{"collision: NOT owned by shop", "jabali-ftp-account=shop_other", 500003, shop, false},
+		{"collision: owned by shop_other", "jabali-ftp-account=shop_other", 1000000003, shopOther, true},
+		{"collision: NOT owned by shop", "jabali-ftp-account=shop_other", 1000000003, shop, false},
 		// Bare legacy marker: matched only by shared uid.
 		{"legacy same-uid of shop", "jabali-ftp-account", 1002, shop, true},
 		{"legacy wrong uid", "jabali-ftp-account", 1004, shop, false},
@@ -65,10 +65,10 @@ func TestClassifyFtpAliasesIsolated(t *testing.T) {
 		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
 		"shop_other:x:1004:1004::/home/shop_other:/bin/bash\n" +
 		// isolated alias of shop: own uid, owner-encoded GECOS, jail home
-		"shop_printer:x:500002:500002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
+		"shop_printer:x:1000000002:1000000002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
 		// isolated alias of shop_other: prefix "shop_" collides with tenant shop,
 		// but the owner marker attributes it to shop_other, NOT shop.
-		"shop_other_deploy:x:500003:500003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n" +
+		"shop_other_deploy:x:1000000003:1000000003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n" +
 		// a legacy bare-marker same-uid alias still works alongside isolated ones
 		"shop_legacy:x:1002:1002:jabali-ftp-account:/home/shop/legacy:/usr/sbin/nologin\n"
 
@@ -102,9 +102,9 @@ func TestFtpOwnedAliasNamesLockPath(t *testing.T) {
 	passwd := "" +
 		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
 		"shop_legacy:x:1002:1002:jabali-ftp-account:/home/shop/a:/usr/sbin/nologin\n" +
-		"shop_printer:x:500002:500002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
+		"shop_printer:x:1000000002:1000000002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
 		// prefix "shop_" collides but this is shop_other's isolated alias:
-		"shop_other_deploy:x:500003:500003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n"
+		"shop_other_deploy:x:1000000003:1000000003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n"
 
 	names := ftpOwnedAliasNames(passwd, &ftpTenant{Username: "shop", UID: 1002})
 	got := map[string]bool{}
@@ -129,7 +129,7 @@ func TestClassifyFtpAliasesForgedPrefix(t *testing.T) {
 	passwd := "" +
 		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
 		// username "evil_deploy" but GECOS claims owner "shop" — prefix mismatch
-		"evil_deploy:x:500009:500009:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/evil:/usr/sbin/nologin\n"
+		"evil_deploy:x:1000000009:1000000009:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/evil:/usr/sbin/nologin\n"
 	owned, _ := classifyFtpAliases(passwd)
 	for _, o := range owned {
 		if o.Username == "evil_deploy" {
@@ -152,7 +152,7 @@ func TestFtpAliasOwnedBySystemUID(t *testing.T) {
 	if !ftpAliasOwnedBy("jabali-ftp-account=shop", 1002, shop) {
 		t.Fatal("owner marker on the tenant uid must be owned")
 	}
-	if !ftpAliasOwnedBy("jabali-ftp-account=shop", 500002, shop) {
+	if !ftpAliasOwnedBy("jabali-ftp-account=shop", 1000000002, shop) {
 		t.Fatal("owner marker on an isolated uid must be owned")
 	}
 }

--- a/panel-agent/internal/commands/ftp_account_identity_test.go
+++ b/panel-agent/internal/commands/ftp_account_identity_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import "testing"
+
+func TestFtpMarkerOwner(t *testing.T) {
+	tests := []struct {
+		gecos      string
+		wantOwner  string
+		wantMarked bool
+	}{
+		{"jabali-ftp-account", "", true},                  // bare legacy marker
+		{"jabali-ftp-account,,,", "", true},               // bare + GECOS comma extras
+		{"jabali-ftp-account=shop", "shop", true},         // owner-encoded
+		{"jabali-ftp-account=shop,,,", "shop", true},      // owner-encoded + extras
+		{"jabali-ftp-account=user_01k", "user_01k", true}, // owner with underscore
+		{"jabali-ftp-account=", "", false},                // empty owner = not a valid marker
+		{"ops backup alias", "", false},                   // operator alias
+		{"", "", false},
+	}
+	for _, tc := range tests {
+		owner, marked := ftpMarkerOwner(tc.gecos)
+		if owner != tc.wantOwner || marked != tc.wantMarked {
+			t.Errorf("ftpMarkerOwner(%q) = (%q,%v), want (%q,%v)", tc.gecos, owner, marked, tc.wantOwner, tc.wantMarked)
+		}
+	}
+}
+
+func TestFtpAliasOwnedBy(t *testing.T) {
+	shop := &ftpTenant{Username: "shop", UID: 1002}
+	shopOther := &ftpTenant{Username: "shop_other", UID: 1004}
+
+	tests := []struct {
+		name     string
+		gecos    string
+		aliasUID int
+		tenant   *ftpTenant
+		want     bool
+	}{
+		// Owner-encoded: matched by owner, independent of uid.
+		{"isolated of shop", "jabali-ftp-account=shop", 500002, shop, true},
+		{"isolated of shop not owned by shop_other", "jabali-ftp-account=shop", 500002, shopOther, false},
+		// Prefix collision: shop_other_deploy is owned by shop_other, NEVER shop.
+		{"collision: owned by shop_other", "jabali-ftp-account=shop_other", 500003, shopOther, true},
+		{"collision: NOT owned by shop", "jabali-ftp-account=shop_other", 500003, shop, false},
+		// Bare legacy marker: matched only by shared uid.
+		{"legacy same-uid of shop", "jabali-ftp-account", 1002, shop, true},
+		{"legacy wrong uid", "jabali-ftp-account", 1004, shop, false},
+		// No marker: never owned.
+		{"unmarked", "ops alias", 1002, shop, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ftpAliasOwnedBy(tc.gecos, tc.aliasUID, tc.tenant); got != tc.want {
+				t.Errorf("ftpAliasOwnedBy(%q,%d,%q) = %v, want %v", tc.gecos, tc.aliasUID, tc.tenant.Username, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyFtpAliasesIsolated proves the reaper attributes owner-encoded
+// (isolated, separate-uid) aliases by their GECOS owner — including the
+// prefix-collision case the same-uid model could not have disambiguated.
+func TestClassifyFtpAliasesIsolated(t *testing.T) {
+	passwd := "" +
+		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
+		"shop_other:x:1004:1004::/home/shop_other:/bin/bash\n" +
+		// isolated alias of shop: own uid, owner-encoded GECOS, jail home
+		"shop_printer:x:500002:500002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
+		// isolated alias of shop_other: prefix "shop_" collides with tenant shop,
+		// but the owner marker attributes it to shop_other, NOT shop.
+		"shop_other_deploy:x:500003:500003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n" +
+		// a legacy bare-marker same-uid alias still works alongside isolated ones
+		"shop_legacy:x:1002:1002:jabali-ftp-account:/home/shop/legacy:/usr/sbin/nologin\n"
+
+	owned, skipped := classifyFtpAliases(passwd)
+	got := map[string]string{}
+	for _, o := range owned {
+		got[o.Username] = o.TenantUsername
+	}
+	if got["shop_printer"] != "shop" {
+		t.Errorf("shop_printer owner = %q, want shop", got["shop_printer"])
+	}
+	if got["shop_other_deploy"] != "shop_other" {
+		t.Errorf("shop_other_deploy owner = %q, want shop_other (prefix-collision must not attribute to shop)", got["shop_other_deploy"])
+	}
+	if got["shop_legacy"] != "shop" {
+		t.Errorf("shop_legacy owner = %q, want shop", got["shop_legacy"])
+	}
+	if len(owned) != 3 {
+		t.Errorf("expected 3 owned, got %d: %v", len(owned), got)
+	}
+	if skipped != 0 {
+		t.Errorf("expected 0 skipped-unmarked, got %d", skipped)
+	}
+}

--- a/panel-agent/internal/commands/ftp_account_identity_test.go
+++ b/panel-agent/internal/commands/ftp_account_identity_test.go
@@ -93,3 +93,47 @@ func TestClassifyFtpAliasesIsolated(t *testing.T) {
 		t.Errorf("expected 0 skipped-unmarked, got %d", skipped)
 	}
 }
+
+// TestFtpOwnedAliasNamesLockPath pins the JAB-254 suspension lock path: an
+// isolated (separate-uid) alias must be enumerated for locking, a prefix-
+// colliding OTHER tenant's isolated alias must NOT, and a legacy same-uid alias
+// still is.
+func TestFtpOwnedAliasNamesLockPath(t *testing.T) {
+	passwd := "" +
+		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
+		"shop_legacy:x:1002:1002:jabali-ftp-account:/home/shop/a:/usr/sbin/nologin\n" +
+		"shop_printer:x:500002:500002:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/shop_printer:/usr/sbin/nologin\n" +
+		// prefix "shop_" collides but this is shop_other's isolated alias:
+		"shop_other_deploy:x:500003:500003:jabali-ftp-account=shop_other:/var/lib/jabali-ftp-jails/shop_other/shop_other_deploy:/usr/sbin/nologin\n"
+
+	names := ftpOwnedAliasNames(passwd, &ftpTenant{Username: "shop", UID: 1002})
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	if !got["shop_legacy"] || !got["shop_printer"] {
+		t.Fatalf("shop's own aliases (legacy + isolated) must be locked; got %v", names)
+	}
+	if got["shop_other_deploy"] {
+		t.Fatalf("shop_other's isolated alias must NOT be in shop's lock set (cross-tenant lock); got %v", names)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected exactly shop_legacy + shop_printer, got %v", names)
+	}
+}
+
+// TestClassifyFtpAliasesForgedPrefix: an owner-encoded marker whose username is
+// not namespaced under the encoded owner is dropped (not attributed), guarding
+// against a stamping bug / forgery attributing an alias to the wrong tenant.
+func TestClassifyFtpAliasesForgedPrefix(t *testing.T) {
+	passwd := "" +
+		"shop:x:1002:1002::/home/shop:/bin/bash\n" +
+		// username "evil_deploy" but GECOS claims owner "shop" — prefix mismatch
+		"evil_deploy:x:500009:500009:jabali-ftp-account=shop:/var/lib/jabali-ftp-jails/shop/evil:/usr/sbin/nologin\n"
+	owned, _ := classifyFtpAliases(passwd)
+	for _, o := range owned {
+		if o.Username == "evil_deploy" {
+			t.Fatalf("mis-prefixed owner-encoded alias must NOT be attributed; got owner %q", o.TenantUsername)
+		}
+	}
+}

--- a/panel-agent/internal/commands/ftp_account_identity_test.go
+++ b/panel-agent/internal/commands/ftp_account_identity_test.go
@@ -137,3 +137,22 @@ func TestClassifyFtpAliasesForgedPrefix(t *testing.T) {
 		}
 	}
 }
+
+// TestFtpAliasOwnedBySystemUID: an owner-encoded marker on a SYSTEM uid must
+// never be claimed as a subaccount (root-created mistake / forgery guard).
+func TestFtpAliasOwnedBySystemUID(t *testing.T) {
+	shop := &ftpTenant{Username: "shop", UID: 1002}
+	if ftpAliasOwnedBy("jabali-ftp-account=shop", 0, shop) {
+		t.Fatal("owner marker on uid 0 must NOT be owned")
+	}
+	if ftpAliasOwnedBy("jabali-ftp-account=shop", 1, shop) {
+		t.Fatal("owner marker on a system uid must NOT be owned")
+	}
+	// valid: tenant uid + isolated uid
+	if !ftpAliasOwnedBy("jabali-ftp-account=shop", 1002, shop) {
+		t.Fatal("owner marker on the tenant uid must be owned")
+	}
+	if !ftpAliasOwnedBy("jabali-ftp-account=shop", 500002, shop) {
+		t.Fatal("owner marker on an isolated uid must be owned")
+	}
+}

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"syscall"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // GH #1145 / JAB-252 + JAB-253 — TRUE (separate-uid) isolation for an FTP/SFTP
@@ -113,37 +115,6 @@ func validateIsolatedCreate(p ftpAccountCreateParams, tenant *ftpTenant) *agentw
 	return nil
 }
 
-// resolveIsolatedTarget returns the real, symlink-resolved path of the selected
-// sub-tree beneath the tenant home. Unlike the legacy path (which passes the
-// unresolved home_path to useradd), the jail bind-mounts the RESOLVED inode, so
-// a later symlink retarget of home_path cannot move the live mount (JAB-253).
-// The directory must already exist — the panel creates it via the confined
-// scope before provisioning the jail.
-func resolveIsolatedTarget(homePath string, tenant *ftpTenant) (string, *agentwire.AgentError) {
-	resolved, err := filepath.EvalSymlinks(homePath)
-	if err != nil {
-		return "", &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("resolve selected dir %q: %v", homePath, err),
-		}
-	}
-	rel, rerr := filepath.Rel(tenant.HomeDir, resolved)
-	if rerr != nil || rel == ".." || strings.HasPrefix(rel, "../") {
-		return "", &agentwire.AgentError{
-			Code:    agentwire.CodePermissionDenied,
-			Message: fmt.Sprintf("selected dir %q resolves outside the tenant home %q", homePath, tenant.HomeDir),
-		}
-	}
-	info, err := os.Stat(resolved)
-	if err != nil || !info.IsDir() {
-		return "", &agentwire.AgentError{
-			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("selected dir %q is not an existing directory", homePath),
-		}
-	}
-	return resolved, nil
-}
-
 // provisionIsolatedJail builds the full isolated account: jail skeleton, bind
 // mount, own-uid user, ACL grant, and per-uid quota. It returns a rollback that
 // undoes every step performed so far; the caller runs it on any later failure.
@@ -152,17 +123,12 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	if aerr := validateIsolatedCreate(p, tenant); aerr != nil {
 		return nil, aerr
 	}
-	target, aerr := resolveIsolatedTarget(p.HomePath, tenant)
-	if aerr != nil {
-		return nil, aerr
-	}
 
 	jail := p.JailPath
 	mountpoint := filepath.Join(jail, ftpJailMountpoint)
 
 	var undo []func()
 	rollback = func() {
-		// Reverse order.
 		for i := len(undo) - 1; i >= 0; i-- {
 			undo[i]()
 		}
@@ -177,28 +143,44 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create jail %q: %v", mountpoint, err)})
 	}
-	// MkdirAll may have created several ancestors; remove the per-account jail
-	// dir on rollback (the /<tenant> parent is shared, left in place).
-	undo = append(undo, func() { _ = os.RemoveAll(jail) })
+	// Single undo for the whole jail+mount: teardownIsolatedJail unmounts
+	// safely (blind unmount-until-EINVAL) BEFORE removing the tree, so
+	// rollback can never RemoveAll through a live bind mount into tenant data.
+	undo = append(undo, func() { _ = teardownIsolatedJail(ctx, jail) })
 	if err := os.Chown(jail, 0, 0); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown jail %q root: %v", jail, err)})
 	}
 	if err := os.Chmod(jail, 0o755); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chmod jail %q: %v", jail, err)})
 	}
-	// The mountpoint must be root-owned too: sshd/vsftpd chroot to the jail
-	// root, and the mountpoint is a child of it, but keeping it root:root 0755
-	// means a failed/absent mount exposes an EMPTY root-owned dir, never
-	// tenant data by accident.
+	// Mountpoint must be root-owned too: a failed/absent mount then exposes an
+	// EMPTY root-owned dir, never tenant data by accident (fail-closed).
 	if err := os.Chown(mountpoint, 0, 0); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown mountpoint %q root: %v", mountpoint, err)})
 	}
 
-	// 2. Bind-mount the resolved sub-tree into the jail (host namespace).
-	if err := syscall.Mount(target, mountpoint, "", syscall.MS_BIND, ""); err != nil {
-		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("bind-mount %q -> %q: %v", target, mountpoint, err)})
+	// 2. Bind-mount the selected sub-tree into the jail (host namespace).
+	// CRITICAL (JAB-251-class): the tenant home is tenant-writable, so the
+	// selected pathname must NOT be re-resolved at mount time — a swapped
+	// symlink component would bind an arbitrary directory (e.g. /etc) into the
+	// jail. Open the dir escape-proof via openat2(RESOLVE_BENEATH) and pin it
+	// by fd, then bind the fd's inode through /proc/self/fd. The kernel
+	// resolves the magic symlink to the pinned inode with no pathname walk.
+	scope, serr := filesafe.NewScope(tenant.Username, tenant.Username, []string{tenant.HomeDir})
+	if serr != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("home scope for %q: %v", tenant.HomeDir, serr)})
 	}
-	undo = append(undo, func() { _ = syscall.Unmount(mountpoint, 0) })
+	srcFd, oerr := scope.OpenDirInScope(p.HomePath)
+	if oerr != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("confined open of selected dir %q: %v", p.HomePath, oerr)})
+	}
+	srcMagic := fmt.Sprintf("/proc/self/fd/%d", srcFd.Fd())
+	if err := syscall.Mount(srcMagic, mountpoint, "", syscall.MS_BIND, ""); err != nil {
+		srcFd.Close()
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("bind-mount selected dir -> %q: %v", mountpoint, err)})
+	}
+	// The mount holds its own ref to the inode; the fd is no longer needed.
+	srcFd.Close()
 
 	// 3. Own-uid user (NO --non-unique), own primary group, nologin, GECOS
 	// marker, passwd home = jail (so vsftpd chroots to the jail, not a
@@ -218,21 +200,21 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	}
 	undo = append(undo, func() { _ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run() })
 
-	// 4. ACLs on the EXPOSED sub-tree: the sub-uid must read/write it, and the
-	// tenant-uid must keep managing files the sub writes under its own uid.
-	// Default ACLs (-d) make new files inherit both grants. Applied to the
-	// resolved target (which the bind mount reflects). Uppercase X = execute
-	// only where already applicable (dirs / already-exec files).
+	// 4. ACLs on the JAIL-SIDE mountpoint (never the tenant pathname). The jail
+	// chain is root-owned so the argument cannot be swapped, and the mount has
+	// pinned the inode, so `setfacl -R <jail>/data` recurses over exactly the
+	// intended tree. Grant the sub-uid rwX and keep the tenant-uid rwX (the sub
+	// writes as its own uid; the tenant must still manage those files). Default
+	// ACLs (-d) make new files inherit both. Uppercase X = execute only where
+	// already applicable (dirs / already-exec files). GNU setfacl -R skips
+	// symlinks encountered during recursion by default.
 	spec := fmt.Sprintf("u:%d:rwX,u:%d:rwX", p.UID, tenant.UID)
-	if out, err := exec.CommandContext(ctx, "setfacl", "-R", "-m", spec, target).CombinedOutput(); err != nil {
-		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -R %q: %v: %s", target, err, strings.TrimSpace(string(out)))})
+	if out, err := exec.CommandContext(ctx, "setfacl", "-R", "-m", spec, mountpoint).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -R %q: %v: %s", mountpoint, err, strings.TrimSpace(string(out)))})
 	}
-	if out, err := exec.CommandContext(ctx, "setfacl", "-dR", "-m", spec, target).CombinedOutput(); err != nil {
-		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -dR %q: %v: %s", target, err, strings.TrimSpace(string(out)))})
+	if out, err := exec.CommandContext(ctx, "setfacl", "-dR", "-m", spec, mountpoint).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -dR %q: %v: %s", mountpoint, err, strings.TrimSpace(string(out)))})
 	}
-	// No ACL rollback: the grants are additive and harmless if the account is
-	// torn down (the uid is retired and never reused); the reaper's later
-	// setquota-0/userdel path handles cleanup.
 
 	// 5. Per-uid quota (the split cap). setquota block counts are 1KB units.
 	blocks := strconv.FormatUint(uint64(p.QuotaMB)*1024, 10)
@@ -244,36 +226,38 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 }
 
 // teardownIsolatedJail unmounts and removes a subaccount jail. Used by the
-// delete verb and the reconciler's fail-closed path. Idempotent: a missing
-// mount or dir is not an error. It NEVER touches the bind-mount SOURCE (tenant
-// data) — only the jail overlay.
+// create rollback, the delete verb, and the reconciler's fail-closed path.
+// Idempotent. It NEVER touches the bind-mount SOURCE (tenant data) — only the
+// jail overlay.
+//
+// CRITICAL data-safety invariant: on the fleet, /home is not a separate mount,
+// so a bind mount is SAME-DEVICE — st_dev does not change at the mountpoint and
+// there is no reliable stat-based "is it mounted" probe. We therefore unmount
+// BLIND, looping until the kernel returns EINVAL ("not mounted"), and only
+// RemoveAll once the mount is provably gone. If unmount fails for any other
+// reason we abort WITHOUT removing — a stranded empty jail is recoverable by
+// the reconciler; a RemoveAll that recurses through a live bind mount would
+// delete the tenant's real files.
 func teardownIsolatedJail(ctx context.Context, jailPath string) *agentwire.AgentError {
 	if jailPath == "" {
 		return nil
 	}
 	mountpoint := filepath.Join(jailPath, ftpJailMountpoint)
-	// Unmount if mounted; MNT_DETACH so a busy mount (live session) still
-	// releases and the kernel finalizes when the last ref drops.
-	if isMountpoint(mountpoint) {
-		if err := syscall.Unmount(mountpoint, syscall.MNT_DETACH); err != nil {
-			return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
+	// MNT_DETACH: lazy unmount removes the mount from the tree immediately
+	// (new lookups see the underlying empty dir) even if a session holds it,
+	// so the subsequent RemoveAll cannot descend into the source.
+	for {
+		err := syscall.Unmount(mountpoint, syscall.MNT_DETACH)
+		if err == nil {
+			continue // detached one layer; loop for any stacked binds
 		}
+		if errors.Is(err, syscall.EINVAL) {
+			break // not a mountpoint (anymore) — safe to remove
+		}
+		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
 	}
 	if err := os.RemoveAll(jailPath); err != nil {
 		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove jail %q: %v", jailPath, err)}
 	}
 	return nil
-}
-
-// isMountpoint reports whether path is a mount point by comparing its device
-// number to its parent's (a bind mount changes st_dev at the mountpoint).
-func isMountpoint(path string) bool {
-	var st, parent syscall.Stat_t
-	if err := syscall.Lstat(path, &st); err != nil {
-		return false
-	}
-	if err := syscall.Lstat(filepath.Dir(path), &parent); err != nil {
-		return false
-	}
-	return st.Dev != parent.Dev
 }

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -223,6 +224,103 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	}
 
 	return rollback, nil
+}
+
+// isPathMounted reports whether path is currently a mount target, by scanning
+// /proc/self/mountinfo (field 5 = mount point). Reliable on same-filesystem
+// bind mounts where st_dev does not change at the mountpoint — the stat-based
+// probe that the teardown bug taught us not to trust.
+func isPathMounted(path string) (bool, error) {
+	data, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 5 {
+			continue
+		}
+		// Field 5 (index 4) is the mount point; mountinfo octal-escapes
+		// space/tab/newline/backslash. Jail paths are validated to contain
+		// none, but unescape for correctness against other mounts.
+		if unescapeMountinfo(f[4]) == path {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func unescapeMountinfo(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	r := strings.NewReplacer(`\040`, " ", `\011`, "\t", `\012`, "\n", `\134`, `\`)
+	return r.Replace(s)
+}
+
+// ftpEnsureJailHandler (ftpaccount.ensure_jail) idempotently re-establishes an
+// isolated account's bind mount when the jail exists but is unmounted — the
+// post-reboot state (bind mounts are not persistent) and after a manual umount.
+// The panel reconciler calls it every tick for isolated rows, so a reboot
+// self-heals within one tick without a boot-time DB reader. It NEVER creates
+// the account or the uid; those must already exist (a genuinely missing alias
+// is the reconciler's recreate path, not this one).
+func ftpEnsureJailHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p struct {
+		TenantUsername string `json:"tenant_username"`
+		Username       string `json:"username"`
+		HomePath       string `json:"home_path"`
+		JailPath       string `json:"jail_path"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	tenant, aerr := resolveFtpTenant(p.TenantUsername)
+	if aerr != nil {
+		return nil, aerr
+	}
+	// Must be an existing isolated subaccount of this tenant.
+	u, aerr := requireFtpSubaccount(tenant, p.Username)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if uid, _ := strconv.Atoi(u.Uid); uid < ftpSubaccountUIDMin {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("account %q is not isolated (uid below reserved range)", p.Username)}
+	}
+	if p.JailPath != ftpJailPathFor(tenant, p.Username) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("jail_path %q is not the canonical jail", p.JailPath)}
+	}
+	mountpoint := filepath.Join(p.JailPath, ftpJailMountpoint)
+	mounted, err := isPathMounted(mountpoint)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("check mount %q: %v", mountpoint, err)}
+	}
+	if mounted {
+		return map[string]any{"mounted": true, "changed": false}, nil
+	}
+	// Jail dir persists on disk across reboots; ensure the skeleton then rebind
+	// the confined source (openat2 RESOLVE_BENEATH -> /proc/self/fd), same as
+	// the create path.
+	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("ensure jail %q: %v", mountpoint, err)}
+	}
+	_ = os.Chown(p.JailPath, 0, 0)
+	_ = os.Chmod(p.JailPath, 0o755)
+	_ = os.Chown(mountpoint, 0, 0)
+	scope, serr := filesafe.NewScope(tenant.Username, tenant.Username, []string{tenant.HomeDir})
+	if serr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("home scope: %v", serr)}
+	}
+	srcFd, oerr := scope.OpenDirInScope(p.HomePath)
+	if oerr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("confined open of selected dir %q: %v", p.HomePath, oerr)}
+	}
+	err = syscall.Mount(fmt.Sprintf("/proc/self/fd/%d", srcFd.Fd()), mountpoint, "", syscall.MS_BIND, "")
+	srcFd.Close()
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-bind jail %q: %v", mountpoint, err)}
+	}
+	return map[string]any{"mounted": true, "changed": true}, nil
 }
 
 // teardownIsolatedJail unmounts and removes a subaccount jail. Used by the

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -55,11 +55,12 @@ const ftpJailRootDefault = "/var/lib/jabali-ftp-jails"
 const ftpJailMountpoint = "data"
 
 // ftpSubaccountUIDMin is the floor of the reserved, never-reused uid range for
-// isolated subaccounts (must match migration 000267's allocator base). Well
-// above tenant uids and the systemd DynamicUser range (61184-65519) and
-// nobody (65534). The agent re-checks this floor — it never trusts the panel's
-// allocated uid blindly.
-const ftpSubaccountUIDMin = 500000
+// isolated subaccounts (must match migration 000267's allocator base). 1e9 is
+// ABOVE the rootless-container subuid delegation ceiling (SUB_UID_MAX, 6.001e8
+// on Debian/Ubuntu) — a uid inside the subuid span (100000..SUB_UID_MAX) would
+// share host identity + quota with a tenant's user-namespace mapping. The agent
+// re-checks this floor — it never trusts the panel's allocated uid blindly.
+const ftpSubaccountUIDMin = 1000000000
 
 func ftpJailRoot() string {
 	if p := os.Getenv("JABALI_FTP_JAIL_ROOT"); p != "" {

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -192,7 +192,7 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 		"--home-dir", jail,
 		"--no-create-home",
 		"--shell", "/usr/sbin/nologin",
-		"--comment", ftpAliasGecos,
+		"--comment", ftpAliasGecosFor(tenant.Username),
 		p.Username,
 	}
 	if out, err := exec.CommandContext(ctx, "useradd", useraddArgs...).CombinedOutput(); err != nil {

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -251,8 +251,11 @@ func teardownIsolatedJail(ctx context.Context, jailPath string) *agentwire.Agent
 		if err == nil {
 			continue // detached one layer; loop for any stacked binds
 		}
-		if errors.Is(err, syscall.EINVAL) {
-			break // not a mountpoint (anymore) — safe to remove
+		// EINVAL = not a mountpoint (anymore); ENOENT = the mountpoint/jail
+		// doesn't exist at all (e.g. teardown of a legacy account, or a
+		// double teardown). Both mean "nothing mounted here" — safe to remove.
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOENT) {
+			break
 		}
 		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
 	}

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -1,0 +1,279 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1145 / JAB-252 + JAB-253 — TRUE (separate-uid) isolation for an FTP/SFTP
+// subaccount.
+//
+// The legacy model (ftp_account.go) makes a subaccount a same-uid alias
+// chrooted to the tenant home: an SFTP credential scoped to a sub-dir can `..`
+// out to the whole account (JAB-252), and a mutable-home symlink escapes the
+// vsftpd chroot (JAB-253). An ISOLATED subaccount instead gets:
+//
+//   - its OWN uid (allocated monotonically by the panel, never reused) and its
+//     own primary group — kernel identity separation from the tenant AND from
+//     sibling subaccounts;
+//   - a ROOT-OWNED jail dir (/var/lib/jabali-ftp-jails/<tenant>/<label>,
+//     root:root 0755) whose ONLY writable content is the selected sub-tree,
+//     bind-mounted in at a root-owned mountpoint. The jail satisfies sshd's
+//     root-owned-chroot-chain rule AND vsftpd's secure-chroot rule, so it is
+//     the chroot for BOTH protocols; `..` from the mountpoint hits the empty
+//     root-owned jail root, never a sibling or ancestor;
+//   - POSIX ACLs granting the sub-uid AND the tenant-uid rwX on the exposed
+//     sub-tree (with default ACLs so new files inherit), so the tenant keeps
+//     managing files the sub writes under its own uid;
+//   - a per-uid disk quota (the split allocation) so a separate uid cannot
+//     escape the tenant's package quota and fill the disk.
+//
+// The mount is a plain bind mount created by the agent. The agent runs as root
+// in the HOST mount namespace (install.sh keeps PrivateTmp / ProtectKernel* /
+// PrivateMounts OFF for it — proven on jabalitests), so the bind mount is
+// host-global and visible to a fresh sshd/vsftpd login with no namespace-escape
+// machinery. It does NOT survive reboot; the panel reconciler re-establishes it
+// each tick (DB-is-truth), and a boot oneshot converges before first login.
+
+// ftpJailRootDefault is the parent of every per-subaccount jail. Root-owned,
+// outside any tenant-writable tree.
+const ftpJailRootDefault = "/var/lib/jabali-ftp-jails"
+
+// ftpJailMountpoint is the fixed name of the bind-mount target inside each
+// jail. The session start dir is always "/<ftpJailMountpoint>".
+const ftpJailMountpoint = "data"
+
+// ftpSubaccountUIDMin is the floor of the reserved, never-reused uid range for
+// isolated subaccounts (must match migration 000267's allocator base). Well
+// above tenant uids and the systemd DynamicUser range (61184-65519) and
+// nobody (65534). The agent re-checks this floor — it never trusts the panel's
+// allocated uid blindly.
+const ftpSubaccountUIDMin = 500000
+
+func ftpJailRoot() string {
+	if p := os.Getenv("JABALI_FTP_JAIL_ROOT"); p != "" {
+		return p
+	}
+	return ftpJailRootDefault
+}
+
+// ftpJailPathFor derives the canonical jail path for a subaccount. The panel
+// stores and sends the same value (jail_path); the agent re-derives and
+// requires an exact match so a caller can never point the chroot elsewhere.
+func ftpJailPathFor(tenant *ftpTenant, username string) string {
+	return filepath.Join(ftpJailRoot(), tenant.Username, username)
+}
+
+// validateIsolatedCreate re-validates every panel-supplied field for the
+// isolated path. The agent never trusts the panel just because it is localhost.
+func validateIsolatedCreate(p ftpAccountCreateParams, tenant *ftpTenant) *agentwire.AgentError {
+	if p.UID < ftpSubaccountUIDMin {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("isolated uid %d is below the reserved floor %d", p.UID, ftpSubaccountUIDMin),
+		}
+	}
+	if int(p.UID) == tenant.UID {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("isolated uid %d collides with the tenant uid", p.UID),
+		}
+	}
+	if p.QuotaMB == 0 {
+		// An unlimited separate uid escapes the tenant's package quota and can
+		// fill the disk — the disk-fill hole the split allocation closes.
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "isolated account requires a non-zero quota_mb (unlimited separate uid = disk-fill hole)",
+		}
+	}
+	if p.QuotaMount == "" {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "isolated account requires quota_mount for per-uid setquota",
+		}
+	}
+	// The panel-supplied jail_path must be EXACTLY the canonical path — no
+	// caller-chosen chroot root.
+	want := ftpJailPathFor(tenant, p.Username)
+	if p.JailPath != want {
+		return &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("jail_path %q is not the canonical jail %q", p.JailPath, want),
+		}
+	}
+	return nil
+}
+
+// resolveIsolatedTarget returns the real, symlink-resolved path of the selected
+// sub-tree beneath the tenant home. Unlike the legacy path (which passes the
+// unresolved home_path to useradd), the jail bind-mounts the RESOLVED inode, so
+// a later symlink retarget of home_path cannot move the live mount (JAB-253).
+// The directory must already exist — the panel creates it via the confined
+// scope before provisioning the jail.
+func resolveIsolatedTarget(homePath string, tenant *ftpTenant) (string, *agentwire.AgentError) {
+	resolved, err := filepath.EvalSymlinks(homePath)
+	if err != nil {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("resolve selected dir %q: %v", homePath, err),
+		}
+	}
+	rel, rerr := filepath.Rel(tenant.HomeDir, resolved)
+	if rerr != nil || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodePermissionDenied,
+			Message: fmt.Sprintf("selected dir %q resolves outside the tenant home %q", homePath, tenant.HomeDir),
+		}
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("selected dir %q is not an existing directory", homePath),
+		}
+	}
+	return resolved, nil
+}
+
+// provisionIsolatedJail builds the full isolated account: jail skeleton, bind
+// mount, own-uid user, ACL grant, and per-uid quota. It returns a rollback that
+// undoes every step performed so far; the caller runs it on any later failure.
+// The mountpoint-relative start dir is always "/<ftpJailMountpoint>".
+func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountCreateParams) (rollback func(), aerr *agentwire.AgentError) {
+	if aerr := validateIsolatedCreate(p, tenant); aerr != nil {
+		return nil, aerr
+	}
+	target, aerr := resolveIsolatedTarget(p.HomePath, tenant)
+	if aerr != nil {
+		return nil, aerr
+	}
+
+	jail := p.JailPath
+	mountpoint := filepath.Join(jail, ftpJailMountpoint)
+
+	var undo []func()
+	rollback = func() {
+		// Reverse order.
+		for i := len(undo) - 1; i >= 0; i-- {
+			undo[i]()
+		}
+	}
+	fail := func(e *agentwire.AgentError) (func(), *agentwire.AgentError) {
+		rollback()
+		return nil, e
+	}
+
+	// 1. Root-owned jail skeleton (root:root 0755). MkdirAll is safe here —
+	// the jail root is outside any tenant-writable tree, so no symlink race.
+	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("create jail %q: %v", mountpoint, err)})
+	}
+	// MkdirAll may have created several ancestors; remove the per-account jail
+	// dir on rollback (the /<tenant> parent is shared, left in place).
+	undo = append(undo, func() { _ = os.RemoveAll(jail) })
+	if err := os.Chown(jail, 0, 0); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown jail %q root: %v", jail, err)})
+	}
+	if err := os.Chmod(jail, 0o755); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chmod jail %q: %v", jail, err)})
+	}
+	// The mountpoint must be root-owned too: sshd/vsftpd chroot to the jail
+	// root, and the mountpoint is a child of it, but keeping it root:root 0755
+	// means a failed/absent mount exposes an EMPTY root-owned dir, never
+	// tenant data by accident.
+	if err := os.Chown(mountpoint, 0, 0); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown mountpoint %q root: %v", mountpoint, err)})
+	}
+
+	// 2. Bind-mount the resolved sub-tree into the jail (host namespace).
+	if err := syscall.Mount(target, mountpoint, "", syscall.MS_BIND, ""); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("bind-mount %q -> %q: %v", target, mountpoint, err)})
+	}
+	undo = append(undo, func() { _ = syscall.Unmount(mountpoint, 0) })
+
+	// 3. Own-uid user (NO --non-unique), own primary group, nologin, GECOS
+	// marker, passwd home = jail (so vsftpd chroots to the jail, not a
+	// tenant-mutable path). --no-create-home: the jail already exists.
+	uidStr := strconv.FormatUint(uint64(p.UID), 10)
+	useraddArgs := []string{
+		"--uid", uidStr,
+		"--user-group", // own primary group — member of NO tenant group
+		"--home-dir", jail,
+		"--no-create-home",
+		"--shell", "/usr/sbin/nologin",
+		"--comment", ftpAliasGecos,
+		p.Username,
+	}
+	if out, err := exec.CommandContext(ctx, "useradd", useraddArgs...).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("useradd (isolated) %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))})
+	}
+	undo = append(undo, func() { _ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run() })
+
+	// 4. ACLs on the EXPOSED sub-tree: the sub-uid must read/write it, and the
+	// tenant-uid must keep managing files the sub writes under its own uid.
+	// Default ACLs (-d) make new files inherit both grants. Applied to the
+	// resolved target (which the bind mount reflects). Uppercase X = execute
+	// only where already applicable (dirs / already-exec files).
+	spec := fmt.Sprintf("u:%d:rwX,u:%d:rwX", p.UID, tenant.UID)
+	if out, err := exec.CommandContext(ctx, "setfacl", "-R", "-m", spec, target).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -R %q: %v: %s", target, err, strings.TrimSpace(string(out)))})
+	}
+	if out, err := exec.CommandContext(ctx, "setfacl", "-dR", "-m", spec, target).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -dR %q: %v: %s", target, err, strings.TrimSpace(string(out)))})
+	}
+	// No ACL rollback: the grants are additive and harmless if the account is
+	// torn down (the uid is retired and never reused); the reaper's later
+	// setquota-0/userdel path handles cleanup.
+
+	// 5. Per-uid quota (the split cap). setquota block counts are 1KB units.
+	blocks := strconv.FormatUint(uint64(p.QuotaMB)*1024, 10)
+	if out, err := exec.CommandContext(ctx, "setquota", "-u", p.Username, blocks, blocks, "0", "0", p.QuotaMount).CombinedOutput(); err != nil {
+		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setquota (isolated) %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))})
+	}
+
+	return rollback, nil
+}
+
+// teardownIsolatedJail unmounts and removes a subaccount jail. Used by the
+// delete verb and the reconciler's fail-closed path. Idempotent: a missing
+// mount or dir is not an error. It NEVER touches the bind-mount SOURCE (tenant
+// data) — only the jail overlay.
+func teardownIsolatedJail(ctx context.Context, jailPath string) *agentwire.AgentError {
+	if jailPath == "" {
+		return nil
+	}
+	mountpoint := filepath.Join(jailPath, ftpJailMountpoint)
+	// Unmount if mounted; MNT_DETACH so a busy mount (live session) still
+	// releases and the kernel finalizes when the last ref drops.
+	if isMountpoint(mountpoint) {
+		if err := syscall.Unmount(mountpoint, syscall.MNT_DETACH); err != nil {
+			return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("unmount jail %q: %v", mountpoint, err)}
+		}
+	}
+	if err := os.RemoveAll(jailPath); err != nil {
+		return &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("remove jail %q: %v", jailPath, err)}
+	}
+	return nil
+}
+
+// isMountpoint reports whether path is a mount point by comparing its device
+// number to its parent's (a bind mount changes st_dev at the mountpoint).
+func isMountpoint(path string) bool {
+	var st, parent syscall.Stat_t
+	if err := syscall.Lstat(path, &st); err != nil {
+		return false
+	}
+	if err := syscall.Lstat(filepath.Dir(path), &parent); err != nil {
+		return false
+	}
+	return st.Dev != parent.Dev
+}

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -33,7 +33,7 @@ func TestValidateIsolatedCreate(t *testing.T) {
 			HomePath:       "/home/bob/ftp/printer",
 			Password:       "x",
 			Isolated:       true,
-			UID:            500001,
+			UID:            1000000001,
 			QuotaMB:        100,
 			QuotaMount:     "/home",
 			JailPath:       goodJail,

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -65,17 +67,6 @@ func TestValidateIsolatedCreate(t *testing.T) {
 	}
 }
 
-func TestIsMountpointFalseOnPlainDir(t *testing.T) {
-	dir := t.TempDir()
-	sub := filepath.Join(dir, "child")
-	if err := os.Mkdir(sub, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if isMountpoint(sub) {
-		t.Fatalf("plain dir %q reported as mountpoint", sub)
-	}
-}
-
 // TestValidateFtpSSHDAccountJailChroot proves the sshd validator accepts a
 // root-owned jail chroot (GH #1145) as well as the legacy /home chroot, and
 // still rejects an arbitrary path.
@@ -103,5 +94,56 @@ func TestValidateFtpSSHDAccountJailChroot(t *testing.T) {
 				t.Fatalf("validateFtpSSHDAccount(%q) err=%v, wantErr=%v", tc.chrootDir, aerr, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestTeardownIsolatedJailPreservesSourceOnSameFs is the regression guard for
+// the same-device data-loss bug: on the fleet /home is not a separate mount, so
+// a bind mount does NOT change st_dev at the mountpoint. A stat-based "is it
+// mounted?" probe returns false, so a naive teardown would skip the unmount and
+// RemoveAll straight through the LIVE bind mount into the tenant's real files.
+// teardownIsolatedJail must unmount blind (until EINVAL) BEFORE removing, so the
+// jail goes and the source subtree survives. Root-gated (bind mount needs
+// CAP_SYS_ADMIN) + GH #994 host-mutation gate.
+func TestTeardownIsolatedJailPreservesSourceOnSameFs(t *testing.T) {
+	requireHostMutationAllowed(t)
+	if os.Geteuid() != 0 {
+		t.Skip("bind mount needs root")
+	}
+	root := t.TempDir() // source + jail both under TMPDIR = same filesystem
+	t.Setenv("JABALI_FTP_JAIL_ROOT", filepath.Join(root, "jails"))
+
+	src := filepath.Join(root, "home", "sub")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(src, "keep.txt")
+	if err := os.WriteFile(marker, []byte("tenant-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	jail := filepath.Join(ftpJailRoot(), "bob", "bob_printer")
+	mp := filepath.Join(jail, ftpJailMountpoint)
+	if err := os.MkdirAll(mp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mount(src, mp, "", syscall.MS_BIND, ""); err != nil {
+		t.Fatalf("bind mount: %v", err)
+	}
+	// Guarantee cleanup even if an assertion below fails before teardown runs.
+	defer func() { _ = syscall.Unmount(mp, syscall.MNT_DETACH) }()
+
+	if _, err := os.Stat(filepath.Join(mp, "keep.txt")); err != nil {
+		t.Fatalf("marker not visible through the mount (setup broken): %v", err)
+	}
+
+	if aerr := teardownIsolatedJail(context.Background(), jail); aerr != nil {
+		t.Fatalf("teardown returned error: %v", aerr)
+	}
+	if _, err := os.Stat(jail); !os.IsNotExist(err) {
+		t.Fatalf("jail not removed after teardown: stat err=%v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("SOURCE DATA DELETED by teardown — marker gone: %v", err)
 	}
 }

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func testTenant() *ftpTenant {
+	return &ftpTenant{Username: "bob", UID: 1001, GID: 1001, HomeDir: "/home/bob"}
+}
+
+func TestFtpJailPathFor(t *testing.T) {
+	t.Setenv("JABALI_FTP_JAIL_ROOT", "/var/lib/jabali-ftp-jails")
+	got := ftpJailPathFor(testTenant(), "bob_printer")
+	want := "/var/lib/jabali-ftp-jails/bob/bob_printer"
+	if got != want {
+		t.Fatalf("ftpJailPathFor = %q, want %q", got, want)
+	}
+}
+
+func TestValidateIsolatedCreate(t *testing.T) {
+	t.Setenv("JABALI_FTP_JAIL_ROOT", "/var/lib/jabali-ftp-jails")
+	tenant := testTenant()
+	goodJail := ftpJailPathFor(tenant, "bob_printer")
+
+	base := func() ftpAccountCreateParams {
+		return ftpAccountCreateParams{
+			TenantUsername: "bob",
+			Username:       "bob_printer",
+			HomePath:       "/home/bob/ftp/printer",
+			Password:       "x",
+			Isolated:       true,
+			UID:            500001,
+			QuotaMB:        100,
+			QuotaMount:     "/home",
+			JailPath:       goodJail,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(p *ftpAccountCreateParams)
+		wantErr bool
+	}{
+		{"happy", func(p *ftpAccountCreateParams) {}, false},
+		{"uid below floor", func(p *ftpAccountCreateParams) { p.UID = 1002 }, true},
+		{"uid equals tenant", func(p *ftpAccountCreateParams) { p.UID = uint32(tenant.UID) }, true},
+		{"zero quota", func(p *ftpAccountCreateParams) { p.QuotaMB = 0 }, true},
+		{"no quota mount", func(p *ftpAccountCreateParams) { p.QuotaMount = "" }, true},
+		{"jail mismatch", func(p *ftpAccountCreateParams) { p.JailPath = "/tmp/evil" }, true},
+		{"jail not canonical (wrong tenant)", func(p *ftpAccountCreateParams) {
+			p.JailPath = "/var/lib/jabali-ftp-jails/other/bob_printer"
+		}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := base()
+			tc.mutate(&p)
+			aerr := validateIsolatedCreate(p, tenant)
+			if (aerr != nil) != tc.wantErr {
+				t.Fatalf("validateIsolatedCreate err=%v, wantErr=%v", aerr, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsMountpointFalseOnPlainDir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "child")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isMountpoint(sub) {
+		t.Fatalf("plain dir %q reported as mountpoint", sub)
+	}
+}
+
+// TestValidateFtpSSHDAccountJailChroot proves the sshd validator accepts a
+// root-owned jail chroot (GH #1145) as well as the legacy /home chroot, and
+// still rejects an arbitrary path.
+func TestValidateFtpSSHDAccountJailChroot(t *testing.T) {
+	t.Setenv("JABALI_FTP_JAIL_ROOT", "/var/lib/jabali-ftp-jails")
+	tests := []struct {
+		name      string
+		chrootDir string
+		startDir  string
+		wantErr   bool
+	}{
+		{"legacy home chroot", "/home/bob", "/ftp/printer", false},
+		{"jail chroot", "/var/lib/jabali-ftp-jails/bob/bob_printer", "/data", false},
+		{"arbitrary path rejected", "/etc", "/", true},
+		{"jail with dotdot rejected", "/var/lib/jabali-ftp-jails/bob/../etc", "/", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			aerr := validateFtpSSHDAccount(ftpSSHDSyncAccount{
+				Username:  "bob_printer",
+				ChrootDir: tc.chrootDir,
+				StartDir:  tc.startDir,
+			})
+			if (aerr != nil) != tc.wantErr {
+				t.Fatalf("validateFtpSSHDAccount(%q) err=%v, wantErr=%v", tc.chrootDir, aerr, tc.wantErr)
+			}
+		})
+	}
+}

--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -74,12 +74,18 @@ func validateFtpSSHDAccount(a ftpSSHDSyncAccount) *agentwire.AgentError {
 	// extra argv, newlines inject new directives, quotes/backslashes
 	// change sshd's tokenization. Docroot paths never need any of them.
 	sshdConfigUnsafe := " \t\r\n\"'\\"
-	if !strings.HasPrefix(a.ChrootDir, "/home/") ||
+	// Legacy same-uid accounts chroot to the tenant home (/home/<tenant>);
+	// GH #1145 isolated accounts chroot to their root-owned jail under
+	// ftpJailRoot(). Both are root-owned chroot roots that satisfy sshd's
+	// ownership-chain rule; anything else is rejected.
+	chrootOK := strings.HasPrefix(a.ChrootDir, "/home/") ||
+		strings.HasPrefix(a.ChrootDir, ftpJailRoot()+"/")
+	if !chrootOK ||
 		filepath.Clean(a.ChrootDir) != a.ChrootDir ||
 		strings.ContainsAny(a.ChrootDir, sshdConfigUnsafe) {
 		return &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
-			Message: fmt.Sprintf("invalid chroot_dir %q: must be a clean absolute path under /home without whitespace or quotes", a.ChrootDir),
+			Message: fmt.Sprintf("invalid chroot_dir %q: must be a clean absolute path under /home or the FTP jail root, without whitespace or quotes", a.ChrootDir),
 		}
 	}
 	if !strings.HasPrefix(a.StartDir, "/") ||

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -39,7 +39,21 @@ type FtpAccountsHandlerConfig struct {
 	Agent           agent.AgentInterface
 	Log             *slog.Logger
 	StrictRateLimit gin.HandlerFunc // optional — wire from rl.Strict()
+	// QuotaMount is the filesystem mount path /home lives on (the same value
+	// the M18 user-limits reconciler uses, internal/limits.QuotaMountFor).
+	// Required for GH #1145 isolated accounts (per-uid setquota); empty
+	// disables isolation (the create refuses an isolated request).
+	QuotaMount string
 }
+
+// GH #1145 isolated-subaccount constants. These MUST match the panel-agent
+// (ftp_account_jail.go) and migration 000267 — the panel computes the jail
+// path + validates the uid range the agent re-checks.
+const (
+	ftpJailRoot         = "/var/lib/jabali-ftp-jails"
+	ftpJailMountpoint   = "data"
+	ftpSubaccountUIDMin = 500000
+)
 
 // RegisterFtpAccountRoutes mounts:
 //   - GET    /me/ftp-accounts               list caller's accounts
@@ -179,6 +193,13 @@ type ftpAccountCreateRequest struct {
 	Password   string `json:"password" binding:"required"`
 	FTPAccess  bool   `json:"ftp_access"`
 	SFTPAccess *bool  `json:"sftp_access"` // default true
+	// Isolated selects the GH #1145 separate-uid jailed model. Nil/false =
+	// legacy same-uid alias (back-compat). The UI defaults this on; a direct
+	// API caller that omits it stays legacy.
+	Isolated *bool `json:"isolated"`
+	// QuotaMB is the per-account disk cap (MB), REQUIRED when Isolated — an
+	// isolated separate uid escapes the tenant's package quota without it.
+	QuotaMB uint32 `json:"quota_mb"`
 }
 
 type ftpAccountUpdateRequest struct {
@@ -305,10 +326,18 @@ func (h *ftpAccountsHandler) syncHostAccess(ctx context.Context, tenantUsername 
 		if uname == "" {
 			continue
 		}
-		chroot := "/home/" + uname
-		start := "/"
-		if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-			start = "/" + rel
+		var chroot, start string
+		if a.Isolated && a.JailPath != "" {
+			// GH #1145: isolated accounts chroot to their root-owned jail; the
+			// selected sub-tree is bind-mounted at /<mountpoint> inside it.
+			chroot = a.JailPath
+			start = "/" + ftpJailMountpoint
+		} else {
+			chroot = "/home/" + uname
+			start = "/"
+			if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+				start = "/" + rel
+			}
 		}
 		desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
 	}
@@ -376,15 +405,58 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 		sftpAccess = *req.SFTPAccess
 	}
 
-	// Host first, row second: a row without a host user is a broken
-	// credential; a host user without a row is swept by the reconciler.
-	if err := h.agentCall(ctx, "ftpaccount.create", map[string]any{
+	isolated := req.Isolated != nil && *req.Isolated
+	createParams := map[string]any{
 		"tenant_username": tenant,
 		"username":        username,
 		"home_path":       req.HomePath,
 		"password":        req.Password,
 		"ftp_access":      req.FTPAccess,
-	}); err != nil {
+	}
+	var allocUID uint32
+	var jailPath string
+	if isolated {
+		if h.cfg.QuotaMount == "" {
+			// setquota can't run without a mount → an isolated uid would be
+			// unquota'd (disk-fill). Refuse rather than ship an unenforced one.
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "isolation_unavailable", "detail": "per-account disk quota is not configured on this host"})
+			return
+		}
+		if req.QuotaMB == 0 {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "quota_required", "detail": "an isolated account requires a disk quota (quota_mb, in MB)"})
+			return
+		}
+		// Split allocation: Σ existing isolated sub quotas + this one must fit
+		// the package quota (when the package is capped; 0 = unlimited package,
+		// but the per-account cap still bounds the sub).
+		if pkg.DiskQuotaMB > 0 {
+			used, serr := h.cfg.Repo.SumIsolatedQuotaByUserID(ctx, u.ID)
+			if serr != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "quota_check_failed"})
+				return
+			}
+			if used+uint64(req.QuotaMB) > uint64(pkg.DiskQuotaMB) {
+				c.JSON(http.StatusConflict, gin.H{"error": "quota_split_exceeded", "detail": fmt.Sprintf("isolated accounts would total %d MB, over the package quota of %d MB", used+uint64(req.QuotaMB), pkg.DiskQuotaMB)})
+				return
+			}
+		}
+		var aerr error
+		allocUID, aerr = h.cfg.Repo.AllocateUID(ctx)
+		if aerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "uid_alloc_failed"})
+			return
+		}
+		jailPath = ftpJailRoot + "/" + tenant + "/" + username
+		createParams["isolated"] = true
+		createParams["uid"] = allocUID
+		createParams["quota_mb"] = req.QuotaMB
+		createParams["quota_mount"] = h.cfg.QuotaMount
+		createParams["jail_path"] = jailPath
+	}
+
+	// Host first, row second: a row without a host user is a broken
+	// credential; a host user without a row is swept by the reconciler.
+	if err := h.agentCall(ctx, "ftpaccount.create", createParams); err != nil {
 		status, payload := mapFtpAgentError(err, "create_failed")
 		c.JSON(status, payload)
 		return
@@ -399,8 +471,14 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 		FTPAccess:  req.FTPAccess,
 		SFTPAccess: sftpAccess,
 		IsEnabled:  true,
+		Isolated:   isolated,
+		QuotaMB:    req.QuotaMB,
 		CreatedAt:  now,
 		UpdatedAt:  now,
+	}
+	if isolated {
+		acct.UID = &allocUID
+		acct.JailPath = jailPath
 	}
 	if err := h.cfg.Repo.Create(ctx, acct); err != nil {
 		// Compensate: remove the host alias so no unaccounted access

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -50,9 +50,11 @@ type FtpAccountsHandlerConfig struct {
 // (ftp_account_jail.go) and migration 000267 — the panel computes the jail
 // path + validates the uid range the agent re-checks.
 const (
-	ftpJailRoot         = "/var/lib/jabali-ftp-jails"
-	ftpJailMountpoint   = "data"
-	ftpSubaccountUIDMin = 500000
+	ftpJailRoot       = "/var/lib/jabali-ftp-jails"
+	ftpJailMountpoint = "data"
+	// Above the rootless-container subuid ceiling — see migration 000267 + the
+	// agent's ftpSubaccountUIDMin. Must match both.
+	ftpSubaccountUIDMin = 1000000000
 )
 
 // RegisterFtpAccountRoutes mounts:

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -18,6 +19,22 @@ type fakeFtpRepo struct {
 	repository.FtpAccountRepository
 	rows      map[string]*models.FtpAccount
 	createErr error
+	uidSeq    uint32
+}
+
+func (f *fakeFtpRepo) AllocateUID(_ context.Context) (uint32, error) {
+	f.uidSeq++
+	return ftpSubaccountUIDMin + f.uidSeq, nil
+}
+
+func (f *fakeFtpRepo) SumIsolatedQuotaByUserID(_ context.Context, userID string) (uint64, error) {
+	var sum uint64
+	for _, r := range f.rows {
+		if r.UserID == userID && r.Isolated {
+			sum += uint64(r.QuotaMB)
+		}
+	}
+	return sum, nil
 }
 
 func newFakeFtpRepo() *fakeFtpRepo {
@@ -107,10 +124,11 @@ func ftpTestRouter(t *testing.T, repo *fakeFtpRepo, mock *agent.MockClient, pkg 
 		"u1": {ID: "u1", Username: &uname, PackageID: &pkgID},
 	}}
 	h := &ftpAccountsHandler{cfg: FtpAccountsHandlerConfig{
-		Repo:     repo,
-		Users:    users,
-		Packages: &fakePkgRepo{pkg: pkg},
-		Agent:    mock,
+		Repo:       repo,
+		Users:      users,
+		Packages:   &fakePkgRepo{pkg: pkg},
+		Agent:      mock,
+		QuotaMount: "/", // GH #1145: enables isolated create in tests
 	}}
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -352,5 +370,65 @@ func TestFtpAPI_ZeroCap_ManagementStillWorks(t *testing.T) {
 	}
 	if len(repo.rows) != 0 {
 		t.Fatal("row not deleted at zero cap")
+	}
+}
+
+func TestFtpAPICreate_Isolated(t *testing.T) {
+	repo := newFakeFtpRepo()
+	mock := ftpMockAgent()
+	pkg := ftpPkg(3)
+	pkg.DiskQuotaMB = 1000
+	r := ftpTestRouter(t, repo, mock, pkg)
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"printer","home_path":"/home/shop/ftp/printer","password":"longenough-pass1","isolated":true,"quota_mb":200}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var row *models.FtpAccount
+	for _, x := range repo.rows {
+		row = x
+	}
+	if row == nil || !row.Isolated || row.UID == nil || *row.UID < ftpSubaccountUIDMin ||
+		row.QuotaMB != 200 || row.JailPath != "/var/lib/jabali-ftp-jails/shop/shop_printer" {
+		t.Fatalf("isolated row wrong: %+v", row)
+	}
+	// The agent create carried the isolated fields the agent re-validates.
+	var params map[string]any
+	for _, c := range mock.Calls() {
+		if c.Command == "ftpaccount.create" {
+			_ = json.Unmarshal(c.Params, &params)
+		}
+	}
+	if params["isolated"] != true ||
+		params["jail_path"] != "/var/lib/jabali-ftp-jails/shop/shop_printer" ||
+		params["quota_mount"] != "/" {
+		t.Fatalf("agent create params missing isolated fields: %v", params)
+	}
+}
+
+func TestFtpAPICreate_IsolatedRequiresQuota(t *testing.T) {
+	repo := newFakeFtpRepo()
+	r := ftpTestRouter(t, repo, ftpMockAgent(), ftpPkg(3))
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"printer","home_path":"/home/shop/ftp/printer","password":"longenough-pass1","isolated":true}`)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 (quota required), got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(repo.rows) != 0 {
+		t.Fatal("no row should be created when quota is missing")
+	}
+}
+
+func TestFtpAPICreate_IsolatedQuotaSplitExceeded(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["x"] = &models.FtpAccount{ID: "x", UserID: "u1", Username: "shop_a", Isolated: true, QuotaMB: 900}
+	pkg := ftpPkg(3)
+	pkg.DiskQuotaMB = 1000
+	r := ftpTestRouter(t, repo, ftpMockAgent(), pkg)
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"printer","home_path":"/home/shop/ftp/printer","password":"longenough-pass1","isolated":true,"quota_mb":200}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 (split exceeded 900+200>1000), got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -106,13 +106,13 @@ type Deps struct {
 	// builds a default-populated registry when this is nil so the
 	// existing test wiring (`Deps{}`) keeps working without each
 	// caller knowing about the registry.
-	Apps           *apps.Registry
-	CronJobs       repository.CronJobRepository
-	DockerApps     repository.DockerAppRepository
-	PythonApps     repository.PythonAppRepository
-	DockerCatalog  *dockerapp.Catalog
-	PyFrameworks   *pyframeworks.Catalog
-	SSHKeys        repository.SSHKeyRepository
+	Apps          *apps.Registry
+	CronJobs      repository.CronJobRepository
+	DockerApps    repository.DockerAppRepository
+	PythonApps    repository.PythonAppRepository
+	DockerCatalog *dockerapp.Catalog
+	PyFrameworks  *pyframeworks.Catalog
+	SSHKeys       repository.SSHKeyRepository
 	// FtpAccounts backs the tenant FTP/SFTP subaccount routes (GH #1053).
 	FtpAccounts    repository.FtpAccountRepository
 	LimitOverrides repository.UserLimitOverrideRepository
@@ -1357,6 +1357,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Agent:           deps.Agent,
 				Log:             deps.Log,
 				StrictRateLimit: rl.Strict(),
+				QuotaMount:      deps.QuotaMount, // GH #1145 isolated per-uid setquota
 			})
 		}
 

--- a/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.down.sql
+++ b/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.down.sql
@@ -1,0 +1,9 @@
+-- Reverse 000267: drop the subaccount-isolation columns + uid allocator.
+DROP TABLE IF EXISTS ftp_subaccount_uid_seq;
+
+ALTER TABLE ftp_accounts
+    DROP INDEX ux_ftp_accounts_uid,
+    DROP COLUMN uid,
+    DROP COLUMN isolated,
+    DROP COLUMN quota_mb,
+    DROP COLUMN jail_path;

--- a/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.up.sql
+++ b/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.up.sql
@@ -44,11 +44,18 @@ ALTER TABLE ftp_accounts
 -- then read (or SELECT ... FOR UPDATE) inside the create txn. NEVER
 -- decremented on delete, so a freed uid is never reassigned while any file it
 -- owns may still survive under the tenant home — a new account must never
--- silently inherit a dead account's files. Base 500000 sits far above tenant
--- uids and above the systemd DynamicUser range (61184-65519) and nobody
--- (65534), and well within the 32-bit uid space.
+-- silently inherit a dead account's files.
+--
+-- Base 1000000000 (1e9) sits ABOVE the rootless-container subuid delegation
+-- ceiling. /etc/subuid hands each tenant a 65536-uid block from SUB_UID_MIN
+-- (100000) upward, capped at SUB_UID_MAX (600100000 on Debian/Ubuntu). A uid
+-- inside that span would collide with a tenant's user-namespace mapping — a
+-- rootless container writing as that host uid would share identity + quota
+-- with the FTP subaccount (found live on a box: a tenant's block was
+-- 493216-558751, straddling a naive 500000 base). 1e9 is above the ceiling,
+-- below the systemd invalid-uid line (2^31), with ~1.1e9 uids of headroom.
 CREATE TABLE ftp_subaccount_uid_seq (
   id       TINYINT UNSIGNED NOT NULL PRIMARY KEY,
   next_uid INT UNSIGNED     NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-INSERT INTO ftp_subaccount_uid_seq (id, next_uid) VALUES (1, 500000);
+INSERT INTO ftp_subaccount_uid_seq (id, next_uid) VALUES (1, 1000000000);

--- a/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.up.sql
+++ b/panel-api/internal/db/migrations/000267_ftp_subaccount_isolation.up.sql
@@ -1,0 +1,54 @@
+-- GH #1145 / JAB-252 + JAB-253: true (separate-uid) isolation for FTP/SFTP
+-- subaccounts.
+--
+-- The original #1053 model made each subaccount a same-uid alias
+-- (useradd --non-unique) chrooted to the tenant home. Two escapes followed:
+--   JAB-252 (#1145) — an SFTP credential scoped to a sub-directory is only
+--     `internal-sftp -d`'d there; `..` walks up to the tenant-home chroot
+--     and every sibling site/secret/SSH file under it.
+--   JAB-253 — vsftpd re-resolves the tenant-MUTABLE passwd home at login, so
+--     a retargeted in-home symlink chroots out of the intended tree.
+-- Both are closed by giving each ISOLATED subaccount its own uid inside a
+-- root-owned jail (the selected sub-tree bind-mounted in), with a per-uid
+-- quota and ACLs. See plans/gh1145-ftp-true-isolation.md +
+-- plans/gh1053-ftp-jail-redesign.md.
+--
+-- These columns are additive. Existing rows stay in the legacy shared-access
+-- mode (uid NULL, isolated 0) until re-provisioned; the reconciler detects
+-- and fails them closed rather than silently trusting the old chroot.
+ALTER TABLE ftp_accounts
+    -- Own uid for isolated accounts. NULL = legacy shared-uid alias (not yet
+    -- migrated). UNIQUE so an isolated uid is never double-assigned; MySQL
+    -- treats multiple NULLs as distinct, so all legacy rows coexist.
+    ADD COLUMN uid       INT UNSIGNED NULL,
+    -- Dual-mode: 1 = separate-uid, jailed, kernel-isolated; 0 = legacy
+    -- shared-access alias. New accounts are created isolated at the app
+    -- layer; the column default stays 0 so this ALTER never marks an
+    -- existing row "isolated" that the agent has not actually jailed.
+    ADD COLUMN isolated  TINYINT(1)   NOT NULL DEFAULT 0,
+    -- Per-account disk cap (MB) for the split allocation: the tenant package
+    -- quota is divided across the tenant uid + its isolated subaccount uids
+    -- (Σ subaccounts + tenant ≤ package). 0 = unset; the app rejects an
+    -- isolated account with quota_mb = 0 (an unlimited isolated uid is a
+    -- disk-fill hole — a separate uid escapes the tenant's own quota).
+    ADD COLUMN quota_mb  INT UNSIGNED NOT NULL DEFAULT 0,
+    -- Root-owned jail path (/var/lib/jabali-ftp-jails/<tenant>/<label>) for
+    -- isolated accounts. Stored, not merely derived, so the reconciler can
+    -- fail a row closed when home_path is not under its jail or the jail has
+    -- no live mount. Empty for legacy shared-access rows.
+    ADD COLUMN jail_path VARCHAR(512) NOT NULL DEFAULT '',
+    ADD UNIQUE INDEX ux_ftp_accounts_uid (uid);
+
+-- Monotonic, never-reuse allocator for subaccount uids. Single-row high-water
+-- mark: allocation is `UPDATE ftp_subaccount_uid_seq SET next_uid = next_uid+1`
+-- then read (or SELECT ... FOR UPDATE) inside the create txn. NEVER
+-- decremented on delete, so a freed uid is never reassigned while any file it
+-- owns may still survive under the tenant home — a new account must never
+-- silently inherit a dead account's files. Base 500000 sits far above tenant
+-- uids and above the systemd DynamicUser range (61184-65519) and nobody
+-- (65534), and well within the 32-bit uid space.
+CREATE TABLE ftp_subaccount_uid_seq (
+  id       TINYINT UNSIGNED NOT NULL PRIMARY KEY,
+  next_uid INT UNSIGNED     NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+INSERT INTO ftp_subaccount_uid_seq (id, next_uid) VALUES (1, 500000);

--- a/panel-api/internal/models/ftp_account.go
+++ b/panel-api/internal/models/ftp_account.go
@@ -30,10 +30,29 @@ type FtpAccount struct {
 	// SFTPAccess gates the sshd Match block. Column default is 1; the tag
 	// carries NO gorm default on purpose — `default:1` on a bool silently
 	// flips an explicit false back to true on create (recurring scar).
-	SFTPAccess bool      `gorm:"column:sftp_access;type:tinyint(1);not null" json:"sftp_access"`
-	IsEnabled  bool      `gorm:"type:tinyint(1);not null" json:"is_enabled"`
-	CreatedAt  time.Time `gorm:"type:datetime(6);not null" json:"created_at,omitempty"`
-	UpdatedAt  time.Time `gorm:"type:datetime(6);not null" json:"updated_at,omitempty"`
+	SFTPAccess bool `gorm:"column:sftp_access;type:tinyint(1);not null" json:"sftp_access"`
+	IsEnabled  bool `gorm:"type:tinyint(1);not null" json:"is_enabled"`
+	// UID is the subaccount's own uid when isolated (GH #1145 separate-uid
+	// model). nil = legacy shared-uid alias sharing the tenant uid. Explicit
+	// column tag: GORM mangles the initialism (UID -> u_id) otherwise.
+	UID *uint32 `gorm:"column:uid" json:"uid,omitempty"`
+	// Isolated selects the security model: true = separate-uid, jailed,
+	// kernel-isolated; false = legacy shared-access alias. NO gorm default on
+	// purpose — the column default is 0, and a `default:1`-style tag on a bool
+	// silently flips an explicit false back to true on create (recurring scar).
+	Isolated bool `gorm:"column:isolated;type:tinyint(1);not null" json:"isolated"`
+	// QuotaMB is the per-account disk cap (MB) for the split allocation
+	// (Σ subaccounts + tenant ≤ package quota). 0 = unset; an isolated account
+	// requires quota_mb > 0 — an unlimited separate uid escapes the tenant's
+	// own quota and is a disk-fill hole.
+	QuotaMB uint32 `gorm:"column:quota_mb;not null" json:"quota_mb"`
+	// JailPath is the root-owned jail dir (/var/lib/jabali-ftp-jails/<tenant>/
+	// <label>) for isolated accounts; empty for legacy shared-access rows.
+	// Stored, not merely derived, so the reconciler can fail a row closed when
+	// home_path is not under its jail or the jail has no live mount.
+	JailPath  string    `gorm:"column:jail_path;type:varchar(512);not null" json:"jail_path,omitempty"`
+	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at,omitempty"`
+	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at,omitempty"`
 }
 
 func (FtpAccount) TableName() string { return "ftp_accounts" }

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -28,6 +28,10 @@ import (
 
 const ftpAccountsReDispatchInterval = 15 * time.Minute
 
+// ftpJailMountpointDir is the bind-mount subdir inside a GH #1145 isolated
+// jail. MUST match panel-agent ftpJailMountpoint and panel-api api.ftpJailMountpoint.
+const ftpJailMountpointDir = "data"
+
 type ftpDispatchState struct {
 	Hash string
 	At   time.Time
@@ -42,6 +46,9 @@ func desiredFtpHash(rows []models.FtpAccount, tenantByUserID map[string]string) 
 		lines = append(lines, strings.Join([]string{
 			a.ID, a.Username, tenantByUserID[a.UserID], a.HomePath,
 			fmt.Sprintf("%t|%t|%t", a.FTPAccess, a.SFTPAccess, a.IsEnabled),
+			// GH #1145: isolation mode + jail path change the rendered sshd
+			// chroot and the recreate params, so they must move the hash.
+			fmt.Sprintf("%t|%s", a.Isolated, a.JailPath),
 		}, "^"))
 	}
 	sort.Strings(lines)
@@ -224,15 +231,23 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	}
 	desired := []syncAccount{}
 	for tenant, accts := range rowsByTenant {
-		chroot := "/home/" + tenant
 		eff := ftpEffectiveEnabled(accts, eligByTenant[tenant])
 		for _, a := range accts {
 			if !eff[a.Username] || !a.SFTPAccess {
 				continue
 			}
-			start := "/"
-			if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-				start = "/" + rel
+			var chroot, start string
+			if a.Isolated && a.JailPath != "" {
+				// GH #1145: isolated accounts chroot to their root-owned jail;
+				// the selected sub-tree is bind-mounted at /<mountpoint>.
+				chroot = a.JailPath
+				start = "/" + ftpJailMountpointDir
+			} else {
+				chroot = "/home/" + tenant
+				start = "/"
+				if rel, rerr := filepath.Rel(chroot, a.HomePath); rerr == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+					start = "/" + rel
+				}
 			}
 			desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
 		}
@@ -335,13 +350,30 @@ func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, acct
 				r.log.Error("ftp: throwaway password", "err", perr)
 				return false
 			}
-			if _, err := r.agent.Call(ctx, "ftpaccount.create", map[string]any{
+			createParams := map[string]any{
 				"tenant_username": tenant,
 				"username":        name,
 				"home_path":       want.HomePath,
 				"password":        pw,
 				"ftp_access":      want.FTPAccess,
-			}); err != nil {
+			}
+			// GH #1145: an isolated row must be recreated ISOLATED, not as a
+			// legacy same-uid alias — otherwise a DR restore silently drops the
+			// kernel boundary. Reuse the row's STORED uid (never re-allocate:
+			// the uid is the row's identity and its owned files carry it).
+			if want.Isolated {
+				if r.quotaMount == "" || want.UID == nil {
+					r.log.Warn("ftp: cannot recreate isolated alias without a quota mount and stored uid — leaving absent", "account", name)
+					ok = false
+					continue
+				}
+				createParams["isolated"] = true
+				createParams["uid"] = *want.UID
+				createParams["quota_mb"] = want.QuotaMB
+				createParams["quota_mount"] = r.quotaMount
+				createParams["jail_path"] = want.JailPath
+			}
+			if _, err := r.agent.Call(ctx, "ftpaccount.create", createParams); err != nil {
 				r.log.Warn("ftp: recreate missing alias failed", "account", name, "err", err)
 				ok = false
 				continue

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -398,6 +398,26 @@ func (r *Reconciler) reconcileFtpTenant(ctx context.Context, tenant string, acct
 			}
 		}
 	}
+	// GH #1145: isolated jails are plain bind mounts — NOT reboot-persistent.
+	// Re-assert each enabled isolated account's mount every pass (idempotent:
+	// ensure_jail no-ops when already mounted). The in-memory dispatch cache
+	// clears on panel restart, so the first tick after a reboot runs this and
+	// self-heals the mounts before the tenant notices an empty jail.
+	for _, a := range accts {
+		if !a.Isolated || a.JailPath == "" || !eff[a.Username] {
+			continue
+		}
+		if _, err := r.agent.Call(ctx, "ftpaccount.ensure_jail", map[string]any{
+			"tenant_username": tenant,
+			"username":        a.Username,
+			"home_path":       a.HomePath,
+			"jail_path":       a.JailPath,
+		}); err != nil {
+			r.log.Warn("ftp: ensure_jail failed (mount may be stale until next pass)", "account", a.Username, "err", err)
+			ok = false
+		}
+	}
+
 	// Stray-alias removal deliberately does NOT live here: the per-tenant
 	// diff can only see tenants that still have rows. sweepStrayFtpAliases
 	// (one ftpaccount.list_all per pass) owns stray removal host-wide.

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -335,5 +336,72 @@ func TestReconcileFtpAccounts_SweepsStrayForRowlessTenant(t *testing.T) {
 	p := calls["ftpaccount.delete"][0].params.(map[string]any)
 	if p["username"] != "ghost_leftover" || p["tenant_username"] != "ghost" {
 		t.Fatalf("wrong stray deleted: %v", p)
+	}
+}
+
+// GH #1145: an isolated row must render the sshd chroot to its jail (/data
+// start dir), not the tenant home.
+func TestReconcileFtpAccounts_IsolatedSSHDPayload(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list":     hostListResult(t, []agentFtpListEntry{{Username: "shop_printer"}}),
+		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{{Username: "shop_printer"}}),
+	}}
+	uid := uint32(500001)
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_printer",
+		HomePath: "/home/shop/ftp/printer", SFTPAccess: true, IsEnabled: true,
+		Isolated: true, UID: &uid, QuotaMB: 200,
+		JailPath: "/var/lib/jabali-ftp-jails/shop/shop_printer",
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"})
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	payload := calls["ftpaccount.sshd_sync"][0].params.(map[string]any)
+	raw, _ := json.Marshal(payload["accounts"])
+	var accounts []struct {
+		Username  string `json:"username"`
+		ChrootDir string `json:"chroot_dir"`
+		StartDir  string `json:"start_dir"`
+	}
+	if err := json.Unmarshal(raw, &accounts); err != nil {
+		t.Fatal(err)
+	}
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 rendered account, got %d", len(accounts))
+	}
+	a := accounts[0]
+	if a.ChrootDir != "/var/lib/jabali-ftp-jails/shop/shop_printer" || a.StartDir != "/data" {
+		t.Fatalf("isolated payload wrong: %+v", a)
+	}
+}
+
+// GH #1145: recreating a missing ISOLATED alias (DR restore) must send the
+// isolated params reusing the stored uid — never fall back to a legacy alias.
+func TestReconcileFtpAccounts_RecreatesIsolatedWithParams(t *testing.T) {
+	agent := &fakeAgent{resultByMethod: map[string]json.RawMessage{
+		"ftpaccount.list":     hostListResult(t, nil), // host has nothing
+		"ftpaccount.list_all": hostListAllResult(t, nil),
+	}}
+	uid := uint32(500001)
+	rows := []models.FtpAccount{{
+		ID: "a1", UserID: "u1", Username: "shop_printer",
+		HomePath: "/home/shop/ftp/printer", SFTPAccess: true, IsEnabled: true,
+		Isolated: true, UID: &uid, QuotaMB: 200,
+		JailPath: "/var/lib/jabali-ftp-jails/shop/shop_printer",
+	}}
+	r := ftpTestReconciler(t, agent, rows, map[string]string{"u1": "shop"}).WithQuotaMount("/")
+	r.reconcileFtpAccounts(context.Background())
+
+	calls := ftpCallsByMethod(agent)
+	if len(calls["ftpaccount.create"]) != 1 {
+		t.Fatalf("expected one recreate, got %d", len(calls["ftpaccount.create"]))
+	}
+	p := calls["ftpaccount.create"][0].params.(map[string]any)
+	if p["isolated"] != true || p["jail_path"] != "/var/lib/jabali-ftp-jails/shop/shop_printer" || p["quota_mount"] != "/" {
+		t.Fatalf("recreate missing isolated params: %v", p)
+	}
+	if fmt.Sprint(p["uid"]) != "500001" {
+		t.Fatalf("recreate must reuse the stored uid 500001, got %v", p["uid"])
 	}
 }

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -346,7 +346,7 @@ func TestReconcileFtpAccounts_IsolatedSSHDPayload(t *testing.T) {
 		"ftpaccount.list":     hostListResult(t, []agentFtpListEntry{{Username: "shop_printer"}}),
 		"ftpaccount.list_all": hostListAllResult(t, []agentFtpListEntry{{Username: "shop_printer"}}),
 	}}
-	uid := uint32(500001)
+	uid := uint32(1000000001)
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_printer",
 		HomePath: "/home/shop/ftp/printer", SFTPAccess: true, IsEnabled: true,
@@ -387,7 +387,7 @@ func TestReconcileFtpAccounts_RecreatesIsolatedWithParams(t *testing.T) {
 		"ftpaccount.list":     hostListResult(t, nil), // host has nothing
 		"ftpaccount.list_all": hostListAllResult(t, nil),
 	}}
-	uid := uint32(500001)
+	uid := uint32(1000000001)
 	rows := []models.FtpAccount{{
 		ID: "a1", UserID: "u1", Username: "shop_printer",
 		HomePath: "/home/shop/ftp/printer", SFTPAccess: true, IsEnabled: true,
@@ -405,7 +405,7 @@ func TestReconcileFtpAccounts_RecreatesIsolatedWithParams(t *testing.T) {
 	if p["isolated"] != true || p["jail_path"] != "/var/lib/jabali-ftp-jails/shop/shop_printer" || p["quota_mount"] != "/" {
 		t.Fatalf("recreate missing isolated params: %v", p)
 	}
-	if fmt.Sprint(p["uid"]) != "500001" {
-		t.Fatalf("recreate must reuse the stored uid 500001, got %v", p["uid"])
+	if fmt.Sprint(p["uid"]) != "1000000001" {
+		t.Fatalf("recreate must reuse the stored uid 1000000001, got %v", p["uid"])
 	}
 }

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -374,6 +374,10 @@ func TestReconcileFtpAccounts_IsolatedSSHDPayload(t *testing.T) {
 	if a.ChrootDir != "/var/lib/jabali-ftp-jails/shop/shop_printer" || a.StartDir != "/data" {
 		t.Fatalf("isolated payload wrong: %+v", a)
 	}
+	// The reconciler re-asserts the jail mount every pass (reboot self-heal).
+	if len(calls["ftpaccount.ensure_jail"]) != 1 {
+		t.Fatalf("expected one ensure_jail for the isolated row, got %d", len(calls["ftpaccount.ensure_jail"]))
+	}
 }
 
 // GH #1145: recreating a missing ISOLATED alias (DR restore) must send the

--- a/panel-api/internal/repository/ftp_account_repository.go
+++ b/panel-api/internal/repository/ftp_account_repository.go
@@ -28,6 +28,14 @@ type FtpAccountRepository interface {
 	Update(ctx context.Context, acct *models.FtpAccount) error
 	Delete(ctx context.Context, id string) error
 	CountByUserID(ctx context.Context, userID string) (int64, error)
+	// AllocateUID hands out the next isolated-subaccount uid from the monotonic
+	// never-reuse allocator (GH #1145). The value only ever increases, so a
+	// freed uid is never reassigned while any file it owns may survive.
+	AllocateUID(ctx context.Context) (uint32, error)
+	// SumIsolatedQuotaByUserID totals quota_mb across a tenant's ISOLATED
+	// subaccounts, for the split-allocation check (Σ subaccounts + tenant ≤
+	// package quota).
+	SumIsolatedQuotaByUserID(ctx context.Context, userID string) (uint64, error)
 }
 
 type ftpAccountRepo struct{ db *gorm.DB }
@@ -119,6 +127,37 @@ func (r *ftpAccountRepo) CountByUserID(ctx context.Context, userID string) (int6
 		return 0, err
 	}
 	return count, nil
+}
+
+func (r *ftpAccountRepo) AllocateUID(ctx context.Context) (uint32, error) {
+	var uid uint32
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// FOR UPDATE serializes concurrent creates so two subaccounts never get
+		// the same uid. Read the current high-water mark, then bump it.
+		if err := tx.Raw("SELECT next_uid FROM ftp_subaccount_uid_seq WHERE id = 1 FOR UPDATE").Scan(&uid).Error; err != nil {
+			return err
+		}
+		if uid == 0 {
+			return errors.New("ftp_subaccount_uid_seq is not seeded")
+		}
+		return tx.Exec("UPDATE ftp_subaccount_uid_seq SET next_uid = next_uid + 1 WHERE id = 1").Error
+	})
+	if err != nil {
+		return 0, err
+	}
+	return uid, nil
+}
+
+func (r *ftpAccountRepo) SumIsolatedQuotaByUserID(ctx context.Context, userID string) (uint64, error) {
+	var sum uint64
+	row := r.db.WithContext(ctx).
+		Model(&models.FtpAccount{}).
+		Where("user_id = ? AND isolated = 1", userID).
+		Select("COALESCE(SUM(quota_mb), 0)").Row()
+	if err := row.Scan(&sum); err != nil {
+		return 0, err
+	}
+	return sum, nil
 }
 
 // translateFtpAccount maps GORM/driver errors to repository conventions.

--- a/panel-api/internal/repository/ftp_account_repository_test.go
+++ b/panel-api/internal/repository/ftp_account_repository_test.go
@@ -59,9 +59,10 @@ func TestFtpAccountCreate_Success(t *testing.T) {
 	acct := testFtpAccount(time.Now())
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?)")).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")).
 		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
 			acct.FTPAccess, acct.SFTPAccess, acct.IsEnabled,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 			sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
@@ -84,9 +85,10 @@ func TestFtpAccountCreate_ExplicitFalseSFTPAccess(t *testing.T) {
 	acct.FTPAccess = true
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?)")).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")).
 		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
 			true, false, acct.IsEnabled,
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 			sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -318,6 +318,10 @@ export interface FtpAccount {
   ftp_access: boolean;
   sftp_access: boolean;
   is_enabled: boolean;
+  // GH #1145: true = separate-uid jailed (kernel-isolated); false/absent =
+  // legacy shared-access alias.
+  isolated?: boolean;
+  quota_mb?: number;
   created_at?: string;
   updated_at?: string;
 }
@@ -338,6 +342,8 @@ export async function createFtpAccount(body: {
   password: string;
   ftp_access: boolean;
   sftp_access?: boolean;
+  isolated?: boolean;
+  quota_mb?: number;
 }): Promise<FtpAccount> {
   const resp = await apiClient.post<FtpAccount>("/me/ftp-accounts", body);
   return resp.data;

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1547,6 +1547,13 @@
     "ftp_access_label": "Allow FTPS",
     "ftp_access_tooltip": "Also allow this account to connect over FTPS (port 21).",
     "ftp_disabled_tooltip": "FTP is not enabled on this server — ask your administrator.",
+    "isolated_label": "Isolated account",
+    "isolated_tooltip": "Give this account its own identity confined to the chosen folder — it cannot reach the rest of your files. Recommended. Turn off only for a legacy shared-access account.",
+    "isolated_tag": "Isolated",
+    "shared_tag": "Shared access",
+    "quota_label": "Disk quota",
+    "quota_tooltip": "Maximum disk space (MB) this isolated account may use. Counts against your plan's quota.",
+    "quota_rule": "Enter a disk quota of at least 1 MB",
     "reset_password_for": "Reset password for {{name}}",
     "new_password": "New password"
   },

--- a/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
+++ b/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   Grid,
   Input,
+  InputNumber,
   Modal,
   Popconfirm,
   Space,
@@ -82,17 +83,22 @@ export const UserFtpAccountsPage = () => {
     home_rel?: string;
     password: string;
     ftp_access?: boolean;
+    isolated?: boolean;
+    quota_mb?: number;
   }) => {
     setSaving(true);
     try {
       // The /home/<user> prefix is a fixed addon — users type only the
       // part inside their home. Empty = the home directory itself.
       const rel = (values.home_rel ?? "").replace(/^\/+|\/+$/g, "");
+      const isolated = values.isolated !== false; // default on
       await createFtpAccount({
         label: values.label,
         home_path: rel ? `${homePrefix}/${rel}` : homePrefix,
         password: values.password,
         ftp_access: !!values.ftp_access,
+        isolated,
+        quota_mb: isolated ? values.quota_mb : undefined,
       });
       feedback.message.success(t("ftpaccounts.created"));
       setDrawerOpen(false);
@@ -197,7 +203,14 @@ export const UserFtpAccountsPage = () => {
           <Table.Column<FtpAccount>
             dataIndex="username"
             title={t("ftpaccounts.username")}
-            render={(v: string) => <Typography.Text code copyable>{v}</Typography.Text>}
+            render={(v: string, row) => (
+              <Space size={4} wrap>
+                <Typography.Text code copyable>{v}</Typography.Text>
+                <Tag color={row.isolated ? "green" : "default"}>
+                  {row.isolated ? t("ftpaccounts.isolated_tag") : t("ftpaccounts.shared_tag")}
+                </Tag>
+              </Space>
+            )}
           />
           <Table.Column<FtpAccount>
             dataIndex="home_path"
@@ -281,7 +294,7 @@ export const UserFtpAccountsPage = () => {
           form={form}
           layout="vertical"
           onFinish={handleCreate}
-          initialValues={{ ftp_access: false }}
+          initialValues={{ ftp_access: false, isolated: true }}
         >
           <Form.Item
             label={t("ftpaccounts.label")}
@@ -321,6 +334,43 @@ export const UserFtpAccountsPage = () => {
             rules={[{ required: true, min: 12, max: 128 }]}
           >
             <PasswordInput autoComplete="new-password" generatorLength={20} />
+          </Form.Item>
+          <Form.Item
+            label={t("ftpaccounts.isolated_label")}
+            name="isolated"
+            valuePropName="checked"
+            tooltip={t("ftpaccounts.isolated_tooltip")}
+          >
+            <Switch />
+          </Form.Item>
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, cur) => prev.isolated !== cur.isolated}
+          >
+            {({ getFieldValue }) =>
+              getFieldValue("isolated") !== false ? (
+                <Form.Item
+                  label={t("ftpaccounts.quota_label")}
+                  name="quota_mb"
+                  tooltip={t("ftpaccounts.quota_tooltip")}
+                  rules={[
+                    {
+                      required: true,
+                      type: "number",
+                      min: 1,
+                      message: t("ftpaccounts.quota_rule"),
+                    },
+                  ]}
+                >
+                  <InputNumber
+                    min={1}
+                    style={{ width: "100%" }}
+                    addonAfter="MB"
+                    placeholder="500"
+                  />
+                </Form.Item>
+              ) : null
+            }
           </Form.Item>
           <Form.Item
             label={t("ftpaccounts.ftp_access_label")}

--- a/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
+++ b/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
@@ -159,6 +159,10 @@ test("create drawer submits the tenant-prefixed body and never echoes the passwo
   const dirInput = page.getByLabel("Directory");
   await dirInput.fill("example.com/public_html");
   await page.getByLabel("Password", { exact: true }).fill("a-long-enough-password");
+  // GH #1145: the "Isolated account" toggle defaults ON, which requires a
+  // disk quota — fill it so the form submits (and to exercise the default,
+  // secure isolated create path).
+  await page.getByLabel("Disk quota").fill("500");
   await page.getByRole("button", { name: /Add account/ }).last().click();
 
   await expect
@@ -168,6 +172,8 @@ test("create drawer submits the tenant-prefixed body and never echoes the passwo
     label: "deploy",
     home_path: "/home/shop/example.com/public_html",
     password: "a-long-enough-password",
+    isolated: true,
+    quota_mb: 500,
   });
   await expect(page.getByText("shop_deploy")).toBeVisible();
 });


### PR DESCRIPTION
## Problem (GH #1145 / JAB-252 + JAB-253)

FTP/SFTP subaccounts (#1053) were **same-uid aliases** chrooted to the tenant home. Two escapes followed:
- **JAB-252 (#1145, johnnyq):** an SFTP credential scoped to a sub-directory was only `internal-sftp -d`'d there — `cd ..` walked up to the tenant-home chroot and every sibling site, secret, and SSH file under it.
- **JAB-253:** vsftpd re-resolved the tenant-**mutable** passwd home at login, so a retargeted in-home symlink chrooted out of the intended tree.

## Design — separate-uid jail (dual-mode)

Each **isolated** subaccount now gets:
- its **own uid** (monotonic never-reuse allocator) + own primary group — kernel identity separation from the tenant and siblings;
- a **root-owned jail** (`/var/lib/jabali-ftp-jails/<tenant>/<alias>`, `root:root 0755`) with the selected sub-tree **bind-mounted** at `/data`. The jail satisfies sshd's root-owned-chroot-chain rule AND vsftpd's secure-chroot, so it's the chroot for both protocols; `..` hits the empty jail root, never a sibling/ancestor;
- **POSIX ACLs** granting the sub-uid AND the tenant-uid `rwX` (+ default ACLs) so the tenant keeps managing files the sub writes;
- a **per-uid quota** (split from the package quota) so a separate uid can't escape the tenant's allowance.

The bind mount is a plain host-namespace `mount(2)` — the agent runs unnamespaced (PrivateTmp off), so it's host-global and visible to fresh logins. Reboot re-mount is handled by the reconciler's idempotent `ensure_jail` (bind mounts aren't persistent; the panel's in-mem cache clears on restart, so the first post-reboot tick re-asserts).

Legacy same-uid accounts are untouched (dual-mode: `isolated` column, default off; the UI defaults the toggle **on**).

## Layers (13 commits)
- **Agent:** jail primitive (create), delete + jail teardown, owner-encoded identity across all verbs, `ensure_jail`.
- **Panel-api:** create wiring (uid alloc + quota split + jail payload), reconciler (mode-aware sshd render, DR-recreate reuses the stored uid, hash covers isolation, `ensure_jail` each pass).
- **UI:** isolated toggle (default on) + quota field + dual-mode row tag.
- **install.sh:** declares the jail root (`root:root 0755`). No AppArmor rule needed — sshd/vsftpd are unconfined.

## Two critical bugs caught in review + fixed (with regression tests)
1. **Teardown deleted tenant data on same-fs binds.** On the fleet `/home` isn't a separate mount, so a bind doesn't change `st_dev` → a stat probe read "not mounted" → `RemoveAll` recursed **through the live mount** into tenant files. Fixed: blind `MNT_DETACH`-until-`EINVAL`, then remove. Proven live (below).
2. **TOCTOU on the bind source + `setfacl` = root-assisted privesc.** Fixed with an openat2 `RESOLVE_BENEATH` fd-pinned mount (`/proc/self/fd`) + jail-side `setfacl`.

## Owner-encoded identity (JAB-254 preservation)
Alias ownership was inferred from a shared uid — which isolated accounts break, so they'd have escaped tenant suspension + the stray-alias reaper. Fixed by encoding the owner in the GECOS marker (`jabali-ftp-account=<tenant>`, `=` not `:` — the marker lives in the colon-delimited GECOS field). Applied across `requireFtpSubaccount` / lock_tenant / list / reaper as a unit; bare-marker legacy accounts keep working with no reprovision.

## uid base
Set to **1e9** — box testing found the original 500000 sits **inside** the rootless-container subuid delegation range (`/etc/subuid`, `SUB_UID_MAX=600100000`); a uid there collides with a tenant's user-namespace mapping (shared host identity + quota). 1e9 is above the ceiling, below `2^31`.

## Live box matrix (jabalitests) — ALL GREEN
End-to-end via the panel API + real sftp, co-verified with the FTP-lane session on JAB-254/reaper:
- ✅ Create: own uid, own group, GECOS owner, jail, bind mount, ACL, quota.
- ✅ **Escape fixed:** sftp `cd ..` → jail root (only `data/` visible); tenant `/secretsite/secret.txt` "not found".
- ✅ ACL bidirectional: tenant reads + deletes sub-written files.
- ✅ EDQUOT: sub's 60MB write capped at the 50MB split.
- ✅ **JAB-254 both halves:** suspend → both separate-uid aliases `usermod -L`'d AND the ftp one dropped from `jabali-ftp`.
- ✅ **Reaper:** rowless isolated alias surfaced by GECOS owner, swept, jail torn down — **tenant source dir intact** (the same-device teardown guard, live).
- ✅ Reboot survival: umount → `ensure_jail` remount in ~5s.
- ✅ Backup/restore: sub-uid file captured + restored with uid preserved.
- ✅ uid base 1e9: `useradd`/`setquota`/`chown`/`setfacl` all work.

Box restored to the prior main build afterward (down-migrated 267, redeployed cbec720e).

## Not in this PR
- `jabali user suspend` **CLI** panics on a nil DB (DB not wired into that command context) — **orthogonal**, pre-existing, and NOT the production 254 path (that's `userops.SuspendUser` → `lock_tenant`, proven here). Filed separately.
- Deferred hardening: reconciler fail-closed legacy-row detection + a jail-root sweep (both post-merge follow-ups).

## Test plan
- [x] Agent + panel unit suites green (incl. the two critical-bug regression tests; jail mount ops run in a user+mount ns).
- [x] Full live box matrix above.
- [ ] CI green on this PR.
- [ ] Peer review of the reconciler + install.sh diff (FTP-lane session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
