### PR TITLE
fix(migrate): carry source www presence into create_www so migrated c…

### DIFF
--- a/panel-api/internal/migrate/cpanel/restore_domains.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains.go
@@ -43,6 +43,34 @@ type domainEmailEnableResp struct {
 	DKIMPublicKey string `json:"dkim_public_key"`
 }
 
+// zoneHasWWWRecord reports whether the source BIND zone publishes a
+// www.<domain> address record (A/AAAA/CNAME) — the signal that the source
+// account actually serves www. cPanel (and Plesk/Hestia/CloudPanel) alias www
+// by default, so most migrated domains match; one that genuinely lacks www
+// stays apex-only. A zone that can't be opened or parsed returns false
+// (conservative: no unwanted www SAN). JAB-249.
+func zoneHasWWWRecord(zonePath, domainName string) bool {
+	f, err := os.Open(zonePath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	zone, _, ok := ParseBINDZone(f, domainName)
+	if !ok {
+		return false
+	}
+	want := "www." + strings.ToLower(domainName)
+	for _, rec := range zone.Records {
+		switch rec.Type {
+		case "A", "AAAA", "CNAME":
+			if strings.EqualFold(rec.Name, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ImportDomains creates panel domain rows + nginx vhosts for every
 // zone file found in the parsed tarball. If a domain's mail directory
 // exists under the tarball's MailRoot, email is enabled on the spot so
@@ -81,6 +109,12 @@ func ImportDomains(
 	type domainEntry struct {
 		name    string
 		docRoot string
+		// createWWW mirrors whether the SOURCE zone publishes a www.<domain>
+		// address record (JAB-249). The panel gates the www cert SAN behind
+		// CreateWWW (#915); migration never set it, so a migrated domain that
+		// actually serves www was issued an apex-only cert →
+		// ERR_CERT_COMMON_NAME_INVALID on https://www.<domain>.
+		createWWW bool
 	}
 	var entries []domainEntry
 	if len(parsed.ZoneFiles) > 0 {
@@ -91,8 +125,9 @@ func ImportDomains(
 				continue
 			}
 			entries = append(entries, domainEntry{
-				name:    domainName,
-				docRoot: docRootFor(domainName),
+				name:      domainName,
+				docRoot:   docRootFor(domainName),
+				createWWW: zoneHasWWWRecord(zonePath, domainName),
 			})
 		}
 	} else {
@@ -135,8 +170,13 @@ func ImportDomains(
 			IsEnabled:     true,
 			IndexPriority: "html_first",
 			GhostState:    "unchecked",
-			CreatedAt:     now,
-			UpdatedAt:     now,
+			// JAB-249: carry the source's www presence so the issued LE cert
+			// covers www.<domain> (the #1069 SAN-drift reconciler adds the SAN
+			// on its next reachable-gated pass). Domains whose source has no
+			// www record stay apex-only (unchanged default).
+			CreateWWW: e.createWWW,
+			CreatedAt: now,
+			UpdatedAt: now,
 		}
 		// #327: a source domain with NO mail must not inherit jabali's
 		// mail-by-default. MailProvider "none" makes the reconciler's

--- a/panel-api/internal/migrate/cpanel/restore_domains_createwww_test.go
+++ b/panel-api/internal/migrate/cpanel/restore_domains_createwww_test.go
@@ -1,0 +1,55 @@
+package cpanel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// JAB-249: a migrated domain must get CreateWWW=1 exactly when the source
+// zone publishes a www.<domain> address record, so the issued LE cert covers
+// www (the #1069 SAN-drift reconciler expands it). A source without www stays
+// apex-only (unchanged default).
+func TestZoneHasWWWRecord(t *testing.T) {
+	dir := t.TempDir()
+	const soa = "$TTL 14400\n" +
+		"@ IN SOA ns1.example.com. admin.example.com. ( 1 2 3 4 5 )\n" +
+		"@ IN NS ns1.example.com.\n" +
+		"@ IN A 192.0.2.1\n"
+
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	wwwCNAME := write("example.com.db", soa+"www IN CNAME example.com.\n")
+	wwwA := write("a.example.com.db", soa+"www IN A 192.0.2.9\n")
+	wwwFQDN := write("f.example.com.db", soa+"www.f.example.com. IN A 192.0.2.9\n")
+	wwwUpper := write("u.example.com.db", soa+"WWW IN A 192.0.2.9\n")
+	noWWW := write("no.example.com.db", soa+"mail IN A 192.0.2.2\n")
+
+	cases := []struct {
+		name   string
+		path   string
+		domain string
+		want   bool
+	}{
+		{"www cname (cpanel default)", wwwCNAME, "example.com", true},
+		{"www a record", wwwA, "a.example.com", true},
+		{"www as fqdn owner", wwwFQDN, "f.example.com", true},
+		{"www case-insensitive", wwwUpper, "u.example.com", true},
+		{"no www record stays apex-only", noWWW, "no.example.com", false},
+		{"missing zone file is conservative false", filepath.Join(dir, "nope.db"), "x.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := zoneHasWWWRecord(tc.path, tc.domain); got != tc.want {
+				t.Fatalf("zoneHasWWWRecord(%q) = %v, want %v", tc.domain, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…erts cover www (JAB-249)

A cPanel account migrated into jabali (Plesk/Hestia/CloudPanel share this importer) landed every domain with create_www=0, even when the source served www.<domain>. Since #915 gated the www cert SAN behind create_www, the issued LE cert was apex-only: a visitor hitting https://www.<domain> on a direct-to-origin domain got NET::ERR_CERT_COMMON_NAME_INVALID, and a CloudFlare Full-strict zone 526'd on the incomplete origin cert. Observed on newhighsite (intel-fab8-...co.il) plus 31 apex-only-cert domains on newaramaapp.

The importer never set create_www at all. Detect the source's actual www presence from its BIND zone — a www.<domain> A/AAAA/CNAME record, which cPanel and the other panels alias by default — and set CreateWWW on the migrated row accordingly. The existing #1069 SAN-drift reconciler then expands the cert with the www SAN on its next reachable-gated pass. Domains whose source has no www record stay apex-only (unchanged default). The nginx server_name already carries www independent of the flag, so only the cert SAN was missing.

Scope: covers every source that ships zone files (all cPanel cpmove tarballs; Plesk/Hestia/DA delegate to this same ImportDomains). The DomainNames-only fallback (a source with no dnszones) carries no www signal and keeps the conservative default.

Test: zoneHasWWWRecord detects www via CNAME / A / FQDN-owner / case-insensitively; a zone without www and an unreadable zone both return false.