### PR TITLE
fix(security): terminate live FTP/SFTP sessions on disable/delete/passwd/suspend (JAB-256)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -506,7 +506,8 @@ func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (
 	if aerr != nil {
 		return nil, aerr
 	}
-	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+	au, aerr := requireFtpSubaccount(tenant, p.Username)
+	if aerr != nil {
 		return nil, aerr
 	}
 	if p.Password == "" {
@@ -532,6 +533,10 @@ func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (
 		if out, err := exec.CommandContext(ctx, "usermod", "-L", p.Username).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-lock disabled account %q after password reset: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
 		}
+		// JAB-256: a reset on a disabled account must not leave a live session
+		// authenticated under the old password — kill any open sessions too.
+		uid, _ := strconv.Atoi(au.Uid)
+		terminateFtpSessions(ctx, p.Username, uid)
 	}
 	return map[string]any{"username": p.Username, "updated": true}, nil
 }
@@ -557,7 +562,8 @@ func ftpAccountSetAccessHandler(ctx context.Context, params json.RawMessage) (an
 	if aerr != nil {
 		return nil, aerr
 	}
-	if _, aerr := requireFtpSubaccount(tenant, p.Username); aerr != nil {
+	au, aerr := requireFtpSubaccount(tenant, p.Username)
+	if aerr != nil {
 		return nil, aerr
 	}
 	if aerr := setFtpGroupMembership(ctx, p.Username, p.FTPAccess); aerr != nil {
@@ -569,6 +575,12 @@ func ftpAccountSetAccessHandler(ctx context.Context, params json.RawMessage) (an
 	}
 	if out, err := exec.CommandContext(ctx, "usermod", lockFlag, p.Username).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod %s %q: %v: %s", lockFlag, p.Username, err, strings.TrimSpace(string(out)))}
+	}
+	// JAB-256: the lock blocks re-auth but not an already-open session — kill
+	// live sessions so a disable takes effect at once.
+	if !p.Enabled {
+		uid, _ := strconv.Atoi(au.Uid)
+		terminateFtpSessions(ctx, p.Username, uid)
 	}
 	return map[string]any{"username": p.Username, "ftp_access": p.FTPAccess, "enabled": p.Enabled}, nil
 }
@@ -611,6 +623,9 @@ func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 	delUID, _ := strconv.Atoi(u.Uid)
 	isolated := delUID >= ftpSubaccountUIDMin
 	_ = setFtpGroupMembership(ctx, p.Username, false)
+	// JAB-256: kill live sessions BEFORE userdel so the credential's open
+	// connections drop with the account, not linger past it.
+	terminateFtpSessions(ctx, p.Username, delUID)
 	// -f is REQUIRED, not defensive: the alias shares the tenant's uid, so
 	// the tenant's always-running processes (per-user FPM master, cron)
 	// make plain userdel fail with "user is currently used by process"
@@ -747,6 +762,12 @@ func ftpAccountLockTenantHandler(ctx context.Context, params json.RawMessage) (a
 		_ = setFtpGroupMembership(ctx, name, false)
 		if out, err := exec.CommandContext(ctx, "usermod", "-L", name).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -L %q: %v: %s", name, err, strings.TrimSpace(string(out)))}
+		}
+		// JAB-256: a suspended owner's delegated sessions must drop at once,
+		// not linger until the connection closes.
+		if u, lerr := user.Lookup(name); lerr == nil {
+			uid, _ := strconv.Atoi(u.Uid)
+			terminateFtpSessions(ctx, name, uid)
 		}
 		locked++
 	}

--- a/panel-agent/internal/commands/ftp_account_sessions.go
+++ b/panel-agent/internal/commands/ftp_account_sessions.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+)
+
+// ftpSshdSessionPattern is the pgrep/pkill -f argv pattern that matches a
+// specific subaccount's live sshd session WITHOUT keying on uid. OpenSSH sets
+// the per-session process title to "sshd: <login>@<tty>" (e.g. "@notty" for
+// SFTP) and the privsep monitor to "sshd: <login> [priv]"; the [@ ] class
+// matches both while the char immediately after the login name prevents a
+// prefix collision ("shop_deploy" never matches "shop_deploy2@" or
+// "shop_deploy_x@"). The login name is validated to [a-z0-9_] upstream, so it
+// carries no regex metacharacters.
+func ftpSshdSessionPattern(alias string) string {
+	return "sshd: " + alias + "[@ ]"
+}
+
+// terminateFtpSessions best-effort kills a subaccount's live FTP/SFTP sessions
+// so a disable, delete, suspend, or password-reset takes effect immediately,
+// instead of leaving an already-open connection alive until it closes on its
+// own (JAB-256). It is DEFENSE-IN-DEPTH on top of the shadow lock + degroup
+// (which already block RE-authentication), so every step is best-effort and
+// never aborts the caller.
+//
+// The kill strategy MUST branch on the isolation model, because a legacy
+// same-uid alias shares the tenant's uid:
+//   - Isolated (own uid >= ftpSubaccountUIDMin): the uid is unique to this
+//     alias, so `loginctl terminate-user` + `pkill -KILL -u <uid>` terminate
+//     exactly its sessions (sshd, internal-sftp, and vsftpd) and nothing else.
+//   - Legacy same-uid: killing by uid would ALSO kill the tenant's shell,
+//     cron leader, and sibling aliases (getpwuid can't even distinguish the
+//     sessions). Fall back to the name-scoped sshd argv match above. vsftpd
+//     legacy sessions carry no per-login handle at a shared uid and CANNOT be
+//     precisely targeted — a documented residual (re-auth is already blocked;
+//     only an already-open pipe lingers, on the shrinking deprecated set).
+//
+// pkill exits 1 when nothing matched (the common "no live session" case),
+// which is not an error; the caller ignores all exit codes by design.
+func terminateFtpSessions(ctx context.Context, aliasName string, aliasUID int) {
+	if aliasUID >= ftpSubaccountUIDMin {
+		uid := strconv.Itoa(aliasUID)
+		_ = exec.CommandContext(ctx, "loginctl", "terminate-user", uid).Run()
+		_ = exec.CommandContext(ctx, "pkill", "-KILL", "-u", uid).Run()
+		return
+	}
+	_ = exec.CommandContext(ctx, "pkill", "-KILL", "-f", ftpSshdSessionPattern(aliasName)).Run()
+}

--- a/panel-agent/internal/commands/ftp_account_sessions_test.go
+++ b/panel-agent/internal/commands/ftp_account_sessions_test.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"regexp"
+	"testing"
+)
+
+// JAB-256: the legacy same-uid session kill matches sshd sessions by login
+// name (not uid). The pattern MUST be anchored so it kills only the target
+// alias's session and never a prefix-sibling's — killing the wrong same-uid
+// login is the exact hazard this branch exists to avoid.
+func TestFtpSshdSessionPattern(t *testing.T) {
+	re := regexp.MustCompile(ftpSshdSessionPattern("shop"))
+
+	mustMatch := []string{
+		"sshd: shop@notty",   // SFTP session (no tty)
+		"sshd: shop@pts/0",   // interactive
+		"sshd: shop [priv]",  // privsep monitor
+	}
+	for _, s := range mustMatch {
+		if !re.MatchString(s) {
+			t.Errorf("pattern must match %q", s)
+		}
+	}
+
+	mustNotMatch := []string{
+		"sshd: shop_deploy@notty", // underscore-suffixed sibling at same uid
+		"sshd: shopper@notty",     // longer login sharing the prefix
+		"sshd: workshop@notty",    // login containing the name as a substring
+	}
+	for _, s := range mustNotMatch {
+		if re.MatchString(s) {
+			t.Errorf("pattern must NOT match %q (prefix/substring collision)", s)
+		}
+	}
+}


### PR DESCRIPTION
## JAB-256 — revoking an FTP credential didn't drop its live session

A disable / delete / password-reset / owner-suspension locks the shadow password and drops the `jabali-ftp` gate (blocking **re**-auth), but an **already-open** FTPS/SFTP session kept running until it closed on its own — a revoked credential's live transfer survived the revocation.

### Fix
Kill the alias's live sessions in the same agent verb (defense-in-depth on top of the lock). Branches on the isolation model because a legacy same-uid alias shares the tenant uid:
- **Isolated** (`uid >= ftpSubaccountUIDMin`): `loginctl terminate-user` + `pkill -KILL -u <alias-uid>` — precise; the uid is unique to the alias (kills its sshd / internal-sftp / vsftpd sessions, nothing else).
- **Legacy same-uid**: uid-kill would take the tenant's own shell, cron, and sibling aliases with it (getpwuid can't tell the sessions apart), so match the alias's sshd session by its argv login handle (`sshd: <login>[@ ]`) instead. vsftpd legacy sessions carry no per-login handle at a shared uid and can't be precisely targeted → **documented residual** (re-auth is already blocked, so only an already-open pipe lingers, on the shrinking deprecated same-uid set that isolated accounts replace).

Wired into `set_access` (disable), `delete` (before `userdel`), `set_password` (when the reset re-locks a disabled account), and `lock_tenant` (suspend cascade). Best-effort throughout — a kill failure never aborts the primary lock/delete.

### Tests
- `TestFtpSshdSessionPattern` pins the security-critical property: the legacy match is anchored so it kills only the target login and never a prefix/substring sibling at the same uid.
- Full `panel-agent/internal/commands` green.
- The kill itself is host-only (exec) → **live verification on jabalitests to follow**: create an isolated + a legacy alias, open a session on each, disable/delete/suspend, assert the alias's session dropped AND the tenant's own sessions are untouched.

Builds on #1145 (isolated uid model) + #1144 (set_password re-lock). Refs JAB-256.
