### PR TITLE
fix(security): FTP/SFTP uploads honor the privacy umask, no OTHER bits (JAB-264)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -857,7 +857,11 @@ listen=YES
 listen_ipv6=NO
 anonymous_enable=NO
 local_enable=YES
-local_umask=022
+# JAB-264: 0007 strips OTHER read/traverse bits from uploads (files 0660, dirs
+# 0770), matching the cross-tenant privacy model (ADR-0030). The group bit is
+# preserved so nginx (www-data on a setgid docroot) still reads served content;
+# OTHER local accounts get nothing.
+local_umask=0007
 dirmessage_enable=NO
 use_localtime=YES
 xferlog_enable=YES

--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -115,10 +115,12 @@ func renderXferDropin(accounts []ftpSSHDSyncAccount) string {
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Username < sorted[j].Username })
 	for _, a := range sorted {
 		b.WriteString("\nMatch User " + a.Username + "\n")
-		// -d: start the session in the account's directory. Not a
-		// security boundary (the alias shares the tenant uid); the
-		// boundary is the tenant-home chroot.
-		b.WriteString("    ForceCommand internal-sftp -d " + a.StartDir + "\n")
+		// -u 0007 (JAB-264): strip OTHER read/traverse bits from uploaded
+		// files/dirs, matching vsftpd's local_umask and the ADR-0030 privacy
+		// model (files 0660, dirs 0770; group kept for nginx). -d: start the
+		// session in the account's directory (not a boundary — that is the
+		// chroot).
+		b.WriteString("    ForceCommand internal-sftp -u 0007 -d " + a.StartDir + "\n")
 		b.WriteString("    ChrootDirectory " + a.ChrootDir + "\n")
 		b.WriteString("    AllowTcpForwarding no\n")
 		b.WriteString("    X11Forwarding no\n")

--- a/panel-agent/internal/commands/ftp_account_sshd_test.go
+++ b/panel-agent/internal/commands/ftp_account_sshd_test.go
@@ -34,10 +34,11 @@ func TestRenderXferDropin_DeterministicAndComplete(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Match User alpha_dev",
-		"ForceCommand internal-sftp -d /",
+		// JAB-264: -u 0007 strips OTHER bits from uploads.
+		"ForceCommand internal-sftp -u 0007 -d /",
 		"ChrootDirectory /home/alpha",
 		"Match User zeta_dev",
-		"ForceCommand internal-sftp -d /site",
+		"ForceCommand internal-sftp -u 0007 -d /site",
 		"ChrootDirectory /home/zeta",
 		"AllowTcpForwarding no",
 		"PasswordAuthentication yes",


### PR DESCRIPTION
## JAB-264 — FTP/SFTP uploads were world-readable

FTPS used `local_umask=022` and the per-subaccount SFTP Match block omitted internal-sftp's umask, so uploads landed `0644` / dirs `0755` — OTHER read+traverse bits set, against the platform's `0640/0750` cross-tenant privacy model (ADR-0030). Wherever an ancestor is traversable, another local account could read uploaded app secrets or source.

### Fix
- vsftpd `local_umask=0007` (install.sh)
- render `internal-sftp -u 0007 -d ...` (ftp_account_sshd.go)

New files `0660`, dirs `0770` — no OTHER bits. Group preserved so nginx (www-data on a setgid docroot) reads served content and the tenant (owner) reads/writes; only OTHER loses access.

Existing over-broad modes are not touched (the ticket's opt-in repair tool is a separate follow-up); this closes the source of new ones.

### Tests
- `TestRenderXferDropin_*` asserts `internal-sftp -u 0007 -d` for every subaccount Match block.
- Full `panel-agent/internal/commands` green; `bash -n install.sh` clean.
- Runtime mode is host-only → **live-verify on jabalitests**: upload over FTPS + the SFTP login, assert `0660/0770`, no OTHER; confirm nginx still serves + tenant PHP still reads.

Refs JAB-264 (round-2 FTP audit).
