### PR TITLE
fix(security): FTPS requires the TLS close_notify on uploads (JAB-270)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -905,6 +905,12 @@ force_local_data_ssl=${force_ssl}
 ssl_tlsv1=YES
 ssl_sslv2=NO
 ssl_sslv3=NO
+# JAB-270: require the TLS close_notify before treating an upload as complete.
+# vsftpd's default (strict_ssl_read_eof=NO) accepts a data stream terminated by
+# a forged/plain TCP FIN, so an on-path attacker can truncate an uploaded file
+# (application code, config, deploy artifact) and the server publishes the
+# partial as a successful upload. YES fails the transfer closed instead.
+strict_ssl_read_eof=YES
 # JAB-257: require the TLS data connection to prove it knows the control
 # channel's master secret (vsftpd's secure default). require_ssl_reuse=NO
 # let an attacker sharing the victim's NAT race an unrelated TLS session


### PR DESCRIPTION
## JAB-270 — FTPS accepted uploads truncated before the TLS close_notify

The vsftpd FTPS config left `strict_ssl_read_eof` at its insecure default (`NO`), so vsftpd accepted a data stream terminated by a forged/plain TCP FIN **before** the authenticated TLS `close_notify`. An on-path attacker could truncate an uploaded file — application code, config, a deploy artifact — and have the server publish the partial as a **successful** upload, taking a site offline or altering program behavior despite TLS being required. ([vsftpd.conf docs](https://security.appspot.com/vsftpd/vsftpd_conf.html) flag this option as required; default `NO`.)

### Fix
Render `strict_ssl_read_eof=YES` in the `ssl_enable=YES` block (install.sh), so a transfer whose TLS stream was cut short **fails closed** instead of being accepted.

Consistent with the existing `require_ssl_reuse=YES` (JAB-257) client set: standard FTPS clients (lftp, FileZilla, WinSCP, modern curl) do a proper TLS shutdown; a client that can't is a deliberate operator downgrade, not the shipped default.

### Tests
- `bash -n install.sh` clean; the directive is inside the TLS-gated block (only rendered when `ssl_enable=YES`).
- Host-only live check (not run here): start a large FTPS upload, cut the data TCP flow before `close_notify`, assert the partial file is NOT retained as success, and a normal upload from a supported client still passes.

Refs JAB-270 (round-2 FTP audit).
