### PR TITLE
fix(security): enforce the FTP account cap atomically under a per-tenant lock (JAB-262)

### DIFF
--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -414,15 +414,10 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid_home_path", "detail": err.Error()})
 		return
 	}
-	count, err := h.cfg.Repo.CountByUserID(ctx, u.ID)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "quota_check_failed"})
-		return
-	}
-	if count >= int64(pkg.MaxFTPAccounts) {
-		c.JSON(http.StatusConflict, gin.H{"error": "ftp_account_quota_exceeded", "detail": "you have reached your FTP/SFTP account limit"})
-		return
-	}
+	// JAB-262: the cap (and the isolated quota-split below) is enforced
+	// atomically in ReserveWithinCap, under a per-tenant row lock — an unlocked
+	// count-then-create let concurrent requests all pass a zero count and each
+	// create a real alias, blowing past max_ftp_accounts.
 
 	sftpAccess := true
 	if req.SFTPAccess != nil {
@@ -450,20 +445,10 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "quota_required", "detail": "an isolated account requires a disk quota (quota_mb, in MB)"})
 			return
 		}
-		// Split allocation: Σ existing isolated sub quotas + this one must fit
-		// the package quota (when the package is capped; 0 = unlimited package,
-		// but the per-account cap still bounds the sub).
-		if pkg.DiskQuotaMB > 0 {
-			used, serr := h.cfg.Repo.SumIsolatedQuotaByUserID(ctx, u.ID)
-			if serr != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "quota_check_failed"})
-				return
-			}
-			if used+uint64(req.QuotaMB) > uint64(pkg.DiskQuotaMB) {
-				c.JSON(http.StatusConflict, gin.H{"error": "quota_split_exceeded", "detail": fmt.Sprintf("isolated accounts would total %d MB, over the package quota of %d MB", used+uint64(req.QuotaMB), pkg.DiskQuotaMB)})
-				return
-			}
-		}
+		// Split allocation (Σ existing isolated sub quotas + this one ≤ package
+		// quota) is enforced inside ReserveWithinCap under the same per-tenant
+		// lock as the account cap (JAB-262) — an unlocked sum-then-create let
+		// concurrent isolated creates over-allocate the package disk quota.
 		var aerr error
 		allocUID, aerr = h.cfg.Repo.AllocateUID(ctx)
 		if aerr != nil {
@@ -476,14 +461,6 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 		createParams["quota_mb"] = req.QuotaMB
 		createParams["quota_mount"] = h.cfg.QuotaMount
 		createParams["jail_path"] = jailPath
-	}
-
-	// Host first, row second: a row without a host user is a broken
-	// credential; a host user without a row is swept by the reconciler.
-	if err := h.agentCall(ctx, "ftpaccount.create", createParams); err != nil {
-		status, payload := h.mapAgentErr(err, "create_failed")
-		c.JSON(status, payload)
-		return
 	}
 
 	now := time.Now().UTC()
@@ -504,17 +481,34 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 		acct.UID = &allocUID
 		acct.JailPath = jailPath
 	}
-	if err := h.cfg.Repo.Create(ctx, acct); err != nil {
-		// Compensate: remove the host alias so no unaccounted access
-		// survives a DB failure.
-		_ = h.agentCall(ctx, "ftpaccount.delete", map[string]any{
-			"tenant_username": tenant, "username": username,
-		})
-		if errors.Is(err, repository.ErrConflict) {
+
+	// JAB-262: RESERVE the row first — ReserveWithinCap atomically enforces the
+	// account cap + isolated quota-split under a per-tenant lock, so concurrent
+	// creates can never exceed the cap. Reserving before the host alias also
+	// closes the JAB-255 rowless-alias window: the row always exists before any
+	// alias does.
+	if err := h.cfg.Repo.ReserveWithinCap(ctx, acct, int(pkg.MaxFTPAccounts), pkg.DiskQuotaMB); err != nil {
+		switch {
+		case errors.Is(err, repository.ErrFtpCapExceeded):
+			c.JSON(http.StatusConflict, gin.H{"error": "ftp_account_quota_exceeded", "detail": "you have reached your FTP/SFTP account limit"})
+		case errors.Is(err, repository.ErrFtpQuotaSplitExceeded):
+			c.JSON(http.StatusConflict, gin.H{"error": "quota_split_exceeded", "detail": "isolated accounts would exceed the package disk quota"})
+		case errors.Is(err, repository.ErrConflict):
 			c.JSON(http.StatusConflict, gin.H{"error": "account_exists"})
-			return
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+
+	if err := h.agentCall(ctx, "ftpaccount.create", createParams); err != nil {
+		// Compensate the reservation so a rejected host-create doesn't leave a
+		// slot-consuming row. If this delete itself fails, the surviving row is
+		// a valid desired-state account the reconciler provisions on its next
+		// pass (password-reset-required) — never a phantom cap consumer.
+		_ = h.cfg.Repo.Delete(ctx, acct.ID)
+		status, payload := h.mapAgentErr(err, "create_failed")
+		c.JSON(status, payload)
 		return
 	}
 	h.syncHostAccess(ctx, tenant)

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -56,6 +56,27 @@ func (f *fakeFtpRepo) Create(_ context.Context, a *models.FtpAccount) error {
 	return nil
 }
 
+// ReserveWithinCap mirrors the real repo's atomic cap + quota-split + insert
+// (JAB-262). The fake is single-goroutine, so it just models the decision.
+func (f *fakeFtpRepo) ReserveWithinCap(ctx context.Context, a *models.FtpAccount, maxAccounts int, pkgDiskQuotaMB uint32) error {
+	var count int
+	for _, r := range f.rows {
+		if r.UserID == a.UserID {
+			count++
+		}
+	}
+	if count >= maxAccounts {
+		return repository.ErrFtpCapExceeded
+	}
+	if a.Isolated && pkgDiskQuotaMB > 0 {
+		used, _ := f.SumIsolatedQuotaByUserID(ctx, a.UserID)
+		if used+uint64(a.QuotaMB) > uint64(pkgDiskQuotaMB) {
+			return repository.ErrFtpQuotaSplitExceeded
+		}
+	}
+	return f.Create(ctx, a)
+}
+
 func (f *fakeFtpRepo) FindByIDAndUserID(_ context.Context, id, userID string) (*models.FtpAccount, error) {
 	if r, ok := f.rows[id]; ok && r.UserID == userID {
 		cp := *r
@@ -308,9 +329,12 @@ func TestMapFtpAgentError_FailedPreconditionIsActionable(t *testing.T) {
 	}
 }
 
-func TestFtpAPICreate_RowFailureCompensatesHost(t *testing.T) {
+// JAB-262: with reserve-then-create, the row is inserted BEFORE any host alias.
+// A reservation-insert failure therefore happens before the agent is touched —
+// there is no host alias to compensate, and neither create nor delete fires.
+func TestFtpAPICreate_ReserveFailureNoHostTouch(t *testing.T) {
 	repo := newFakeFtpRepo()
-	repo.createErr = repository.ErrConflict
+	repo.createErr = repository.ErrConflict // reservation insert fails (dup)
 	mock := ftpMockAgent()
 	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
 
@@ -319,9 +343,11 @@ func TestFtpAPICreate_RowFailureCompensatesHost(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("expected 409, got %d", rec.Code)
 	}
-	// The host alias must be torn back down when the row write fails.
-	if mockCalled(mock, "ftpaccount.delete") != 1 {
-		t.Fatal("expected compensating ftpaccount.delete")
+	if mockCalled(mock, "ftpaccount.create") != 0 {
+		t.Fatal("no host alias may be created when the reservation fails")
+	}
+	if mockCalled(mock, "ftpaccount.delete") != 0 {
+		t.Fatal("nothing to compensate — no delete should be dispatched")
 	}
 }
 

--- a/panel-api/internal/repository/errors.go
+++ b/panel-api/internal/repository/errors.go
@@ -25,6 +25,17 @@ var ErrLocked = errors.New("repository: locked")
 // This prevents single-use enforcement from being bypassed.
 var ErrAlreadyUsed = errors.New("repository: already used")
 
+// ErrFtpCapExceeded is returned by ReserveWithinCap when the tenant already
+// holds max_ftp_accounts subaccounts. Enforced under a per-tenant lock so
+// concurrent creates get a deterministic 409 instead of racing past the cap
+// (JAB-262).
+var ErrFtpCapExceeded = errors.New("repository: ftp account cap exceeded")
+
+// ErrFtpQuotaSplitExceeded is returned by ReserveWithinCap when adding an
+// isolated subaccount's quota_mb would push the sum of the tenant's isolated
+// quotas over the package disk quota (JAB-262).
+var ErrFtpQuotaSplitExceeded = errors.New("repository: ftp isolated quota split exceeded")
+
 // ErrPanelPrimaryNotFound is returned by DomainRepository.FindPanelPrimary
 // when no row has is_panel_primary=1. Distinct from ErrNotFound so the
 // Settings → Email endpoint can differentiate "row missing, return 202

--- a/panel-api/internal/repository/ftp_account_repository.go
+++ b/panel-api/internal/repository/ftp_account_repository.go
@@ -17,6 +17,11 @@ import (
 // this layer never cascades.
 type FtpAccountRepository interface {
 	Create(ctx context.Context, acct *models.FtpAccount) error
+	// ReserveWithinCap atomically enforces the per-tenant account cap and the
+	// isolated quota-split, then INSERTs acct — all under a per-tenant row lock
+	// so concurrent creates can never exceed the cap (JAB-262). Returns
+	// ErrFtpCapExceeded / ErrFtpQuotaSplitExceeded / ErrConflict.
+	ReserveWithinCap(ctx context.Context, acct *models.FtpAccount, maxAccounts int, pkgDiskQuotaMB uint32) error
 	FindByID(ctx context.Context, id string) (*models.FtpAccount, error)
 	FindByIDAndUserID(ctx context.Context, id, userID string) (*models.FtpAccount, error)
 	FindByUsername(ctx context.Context, username string) (*models.FtpAccount, error)
@@ -49,6 +54,46 @@ func (r *ftpAccountRepo) Create(ctx context.Context, acct *models.FtpAccount) er
 		return translateFtpAccount(err)
 	}
 	return nil
+}
+
+// ReserveWithinCap — see the interface doc. The whole check-and-insert runs in
+// one transaction gated by a FOR UPDATE lock on the tenant's users row: a
+// stable per-tenant serialization point that exists even at zero FTP rows (a
+// COUNT ... FOR UPDATE would lock nothing there and let two first-creates both
+// pass). The row lock releases on commit/rollback — no GET_LOCK connection-pool
+// leak — and the section holds no external call, so it is brief. JAB-262.
+func (r *ftpAccountRepo) ReserveWithinCap(ctx context.Context, acct *models.FtpAccount, maxAccounts int, pkgDiskQuotaMB uint32) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var lockedID string
+		if err := tx.Raw("SELECT id FROM users WHERE id = ? FOR UPDATE", acct.UserID).Scan(&lockedID).Error; err != nil {
+			return err
+		}
+		if lockedID == "" {
+			return ErrNotFound
+		}
+		var count int64
+		if err := tx.Model(&models.FtpAccount{}).Where("user_id = ?", acct.UserID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count >= int64(maxAccounts) {
+			return ErrFtpCapExceeded
+		}
+		if acct.Isolated && pkgDiskQuotaMB > 0 {
+			var used uint64
+			if err := tx.Model(&models.FtpAccount{}).
+				Where("user_id = ? AND isolated = ?", acct.UserID, true).
+				Select("COALESCE(SUM(quota_mb), 0)").Scan(&used).Error; err != nil {
+				return err
+			}
+			if used+uint64(acct.QuotaMB) > uint64(pkgDiskQuotaMB) {
+				return ErrFtpQuotaSplitExceeded
+			}
+		}
+		if err := tx.Create(acct).Error; err != nil {
+			return translateFtpAccount(err)
+		}
+		return nil
+	})
 }
 
 func (r *ftpAccountRepo) FindByID(ctx context.Context, id string) (*models.FtpAccount, error) {

--- a/panel-api/internal/repository/ftp_account_repository_test.go
+++ b/panel-api/internal/repository/ftp_account_repository_test.go
@@ -97,6 +97,51 @@ func TestFtpAccountCreate_ExplicitFalseSFTPAccess(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// JAB-262: ReserveWithinCap locks the tenant's users row FOR UPDATE, counts,
+// and inserts — all in one transaction — so concurrent creates serialize and
+// cannot exceed the cap. These pin the query STRUCTURE (the lock + count +
+// insert order); the 20-way concurrency proof is a real-DB integration check.
+func TestFtpAccountReserveWithinCap_UnderCapInserts(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM users WHERE id = ? FOR UPDATE")).
+		WithArgs(acct.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(acct.UserID))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `ftp_accounts` WHERE user_id = ?")).
+		WithArgs(acct.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	mock.ExpectExec("INSERT INTO `ftp_accounts`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.ReserveWithinCap(context.Background(), acct, 3, 0))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFtpAccountReserveWithinCap_AtCapRejectsNoInsert(t *testing.T) {
+	db, mock, raw := newMockFtpDB(t)
+	defer raw.Close()
+	repo := NewFtpAccountRepository(db)
+	acct := testFtpAccount(time.Now())
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id FROM users WHERE id = ? FOR UPDATE")).
+		WithArgs(acct.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(acct.UserID))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT count(*) FROM `ftp_accounts` WHERE user_id = ?")).
+		WithArgs(acct.UserID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+	mock.ExpectRollback()
+
+	err := repo.ReserveWithinCap(context.Background(), acct, 3, 0)
+	require.ErrorIs(t, err, ErrFtpCapExceeded)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestFtpAccountCreate_DuplicateUsername(t *testing.T) {
 	db, mock, raw := newMockFtpDB(t)
 	defer raw.Close()


### PR DESCRIPTION
## JAB-262 — concurrent FTP account creation bypassed the package cap

The create handler enforced `max_ftp_accounts` (and the isolated quota-split) with an **unlocked count-then-create**: parallel requests all saw a count below the cap, each created a real Unix alias, and each inserted a row — a tenant could blow past the purchased cap and mint unbounded password-bearing host accounts. Rate limiting is not a boundary here (multiple IP buckets share one authenticated session).

### Fix — reserve-then-create
New `ReserveWithinCap` (repository) runs the **cap check + isolated quota-split + row INSERT in one transaction**, gated by `SELECT id FROM users WHERE id=? FOR UPDATE`:
- A stable **per-tenant** serialization point that exists even at **zero** FTP rows (a `COUNT ... FOR UPDATE` locks nothing there and lets two first-creates both pass).
- The **row lock releases on commit/rollback** — no `GET_LOCK` connection-pool leak — and the section holds **no external call**, so it's brief.
- Concurrent creates serialize; losers get a deterministic **409**.

The handler now **reserves the row before** creating the host alias, then **compensates** (deletes the reservation) if the agent create fails. This also closes the **JAB-255** rowless-alias window incidentally — the row always exists before any alias, so an alias can't outlive its row. A failed compensating delete degrades to a valid desired-state row the reconciler provisions (password-reset-required), never a phantom cap consumer.

### Tests
- Repository sqlmock pins the **lock → count → insert/reject** structure (under-cap inserts; at-cap rejects with `ErrFtpCapExceeded`, no insert).
- API: over-cap → 409 (agent never reached); reservation-failure leaves **no** host `create`/`delete`; agent-failure **compensates** the reservation (net 0 rows).
- Full `panel-api/internal/api` + `internal/repository` green.
- The **20-way concurrency** acceptance is a real-DB integration check (host-only; sqlmock is sequential) — to run against a live MariaDB.

Refs JAB-262 (round-2 FTP audit). Hardens JAB-255.
