### PR TITLE
test(host-safety): gate 4 more destructive tests (GH #994)

### DIFF
--- a/panel-agent/internal/commands/app_dispatch_wordpress_test.go
+++ b/panel-agent/internal/commands/app_dispatch_wordpress_test.go
@@ -19,6 +19,7 @@ import (
 // in unit tests). Catches the failure mode where wordpress_install.go
 // is moved/renamed and forgets to call RegisterAppInstaller.
 func TestAppInstall_RoutesToWordPressHandler(t *testing.T) {
+	requireHostMutationAllowed(t) // GH #994: routes into the real WP install (systemd-run + rm -rf under the tenant home)
 	body := json.RawMessage(`{
 		"app_type": "wordpress",
 		"os_user": "alice",

--- a/panel-agent/internal/commands/php_pool_remove_test.go
+++ b/panel-agent/internal/commands/php_pool_remove_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestPHPPoolRemoveHandler(t *testing.T) {
+	requireHostMutationAllowed(t) // GH #994: reaches `systemctl stop/disable jabali-fpm@<user>`
 	tests := []struct {
 		name      string
 		input     phpPoolRemoveParams

--- a/panel-agent/internal/commands/system_set_timezone_test.go
+++ b/panel-agent/internal/commands/system_set_timezone_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSystemSetTimezone_Valid(t *testing.T) {
+	requireHostMutationAllowed(t) // GH #994: reaches `timedatectl set-timezone` (changes the host clock)
 	// This test validates against real /usr/share/zoneinfo if it exists.
 	// On systems without it, the test is skipped.
 	// Note: The actual timedatectl call requires root/auth, so we only test
@@ -135,6 +136,7 @@ func TestSystemSetTimezone_Registration(t *testing.T) {
 }
 
 func TestSystemSetTimezone_WhitespaceHandling(t *testing.T) {
+	requireHostMutationAllowed(t) // GH #994: reaches `timedatectl set-timezone` (changes the host clock)
 	// Test that leading/trailing whitespace is trimmed
 	ctx := context.Background()
 	params := json.RawMessage(`{"timezone":" UTC "}`)


### PR DESCRIPTION
## What

Closes the regression the `#994` band-aid (c2da8b4a) had accumulated: **4 test functions added since then still reach real host-mutating `exec` on a default `go test ./...`**, so `go test` (or a pre-push hook) again risks polkit prompts / host mutation.

Found via an **empirical audit**, not guesswork: stub the destructive binaries (`rm`, `systemctl`, `systemd-run`, `useradd`, `timedatectl`, …) on `PATH` so each logs its args and exits 0 (no polkit, no mutation), run every commands-package test through the stub, and attribute each destructive invocation to its test.

## The 4 (gated per-function, so sibling validation cases keep running)

| Test | Reaches |
|---|---|
| `TestSystemSetTimezone_Valid` | `timedatectl set-timezone UTC` — **changes the host clock** |
| `TestSystemSetTimezone_WhitespaceHandling` | `timedatectl set-timezone UTC` |
| `TestPHPPoolRemoveHandler` | `systemctl stop`/`disable jabali-fpm@<user>` |
| `TestAppInstall_RoutesToWordPressHandler` | real WP install — `systemd-run` + `rm -rf` under the tenant home |

Each now calls `requireHostMutationAllowed(t)` (skip unless `JABALI_ALLOW_HOST_MUTATION=1`), the same gate the c2da8b4a fix introduced.

## Verification

- Post-gate sweep of **all 271** commands-package test files + the panel-api destructive-`exec` packages: **no ungated test invokes a destructive command** in default mode.
- The 4 skip with the `GH #994` message; full commands package green.

## Not in scope

The real cure named on #994 — routing every `exec` through an injectable runner so tests fake it (and pure-validation cases stay on by default) — is the bigger deferred follow-up. This PR keeps the band-aid comprehensive. The reusable stub-sweep here could also become a CI regression guard so new destructive tests can't land ungated — happy to add that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
