### PR TITLE
fix(cli): bootstrap DB/agent for user suspend + session commands (JAB-272)

### DIFF
--- a/panel-api/cmd/server/cli_tree_invariants_test.go
+++ b/panel-api/cmd/server/cli_tree_invariants_test.go
@@ -28,6 +28,40 @@ func TestCLITree_NoDuplicateSiblingNames(t *testing.T) {
 	walk(newRootCmd(), "jabali")
 }
 
+// JAB-272: these DB/Kratos-touching subcommands MUST bootstrap their shared
+// state via a PreRunE. They don't inline-init (unlike the `*Direct` helper
+// commands such as `user delete` / `domain list`), so a missing PreRunE leaves
+// sharedDB/sharedCfg nil — `user suspend` and `session revoke-user` SIGSEGV on
+// the nil *gorm.DB, and `session list/revoke` fail with "config not loaded".
+// Pin the exact commands that regressed rather than a blanket rule (which would
+// false-positive on the legitimately inline-initialising commands).
+func TestCLITree_StatefulCommandsHavePreRunE(t *testing.T) {
+	paths := [][]string{
+		{"user", "suspend"},
+		{"user", "unsuspend"},
+		{"session", "list"},
+		{"session", "revoke"},
+		{"session", "revoke-user"},
+	}
+	root := newRootCmd()
+	for _, p := range paths {
+		cmd, _, err := root.Find(p)
+		if err != nil {
+			t.Errorf("command %q not found in tree: %v", strings.Join(p, " "), err)
+			continue
+		}
+		// Find returns the nearest match; confirm it resolved to the leaf and
+		// not a parent (a typo'd path would stop at the group).
+		if got := strings.Fields(cmd.Use)[0]; got != p[len(p)-1] {
+			t.Errorf("command %q resolved to %q, not the intended leaf", strings.Join(p, " "), got)
+			continue
+		}
+		if cmd.PreRunE == nil {
+			t.Errorf("command %q has no PreRunE — it will run on nil shared state (JAB-272)", strings.Join(p, " "))
+		}
+	}
+}
+
 // Every grouping command (has subcommands, no Run/RunE author-set) must be made
 // runnable by rejectUnknownSubcommands so an unknown subcommand errors instead
 // of help+exit0. After building the root, no group should be left non-runnable.

--- a/panel-api/cmd/server/session_cmd.go
+++ b/panel-api/cmd/server/session_cmd.go
@@ -40,6 +40,10 @@ func newSessionListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List active login sessions (optionally filtered by --user email)",
+		// requireConfig: cliKratos() needs sharedCfg for the Kratos admin URL.
+		// Nothing loads config globally (no root PersistentPreRun), so without
+		// this the command fails with "config not loaded" (JAB-272 sibling).
+		PreRunE: requireConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
 			defer cancel()
@@ -97,6 +101,9 @@ func newSessionRevokeCmd() *cobra.Command {
 		Use:   "revoke <session-id>",
 		Short: "Revoke a single login session",
 		Args:  cobra.ExactArgs(1),
+		// requireConfig: only Kratos is touched (no DB), but sharedCfg must be
+		// loaded first or cliKratos() returns "config not loaded" (JAB-272).
+		PreRunE: requireConfig,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
 			defer cancel()
@@ -118,6 +125,10 @@ func newSessionRevokeUserCmd() *cobra.Command {
 		Use:   "revoke-user <email-or-id>",
 		Short: "Revoke ALL login sessions for a user (sign out everywhere)",
 		Args:  cobra.ExactArgs(1),
+		// requireDB: resolveUser() hits userRepo() on the shared DB — without it
+		// the command SIGSEGVs on a nil *gorm.DB (the same JAB-272 trap as
+		// `user suspend`). requireDB also loads config, so cliKratos() works.
+		PreRunE: requireDB,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 20*time.Second)
 			defer cancel()

--- a/panel-api/cmd/server/user_suspend_cmd.go
+++ b/panel-api/cmd/server/user_suspend_cmd.go
@@ -52,6 +52,14 @@ func newUserSuspendCmd() *cobra.Command {
 		Use:   "suspend <id>",
 		Short: "Suspend a user (same cascade as the admin GUI/API)",
 		Args:  cobra.ExactArgs(1),
+		// requireDBAndAgent, not just requireDB: without it userRepo() runs on a
+		// nil *gorm.DB and the command SIGSEGVs (JAB-272). requireDB alone would
+		// stop the panic but leave sharedAgent nil, and cliSuspendDeps() drops
+		// d.Agent when the shared client is nil — so the suspend would report
+		// success while silently skipping the OS-user lock and the
+		// ftpaccount.lock_tenant call. Initialising the agent keeps the CLI
+		// cascade identical to the panel API path.
+		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
 			defer cancel()
@@ -87,6 +95,10 @@ func newUserUnsuspendCmd() *cobra.Command {
 		Use:   "unsuspend <id>",
 		Short: "Unsuspend a user (reverse the cascade)",
 		Args:  cobra.ExactArgs(1),
+		// Same nil-DB / nil-agent trap as suspend (JAB-272): the unsuspend
+		// cascade re-enables domains and unlocks the OS user + FTP subaccounts
+		// via the agent, so both DB and agent must be initialised.
+		PreRunE: requireDBAndAgent,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 3*time.Minute)
 			defer cancel()


### PR DESCRIPTION
## JAB-272 — `jabali user suspend` CLI panics on a nil DB (SIGSEGV)

`jabali user suspend <id>` panicked with a nil-pointer dereference: `userRepo().FindByID` ran on a nil `*gorm.DB` because the subcommand had no `PreRunE` and never opened the database. Config is not loaded globally — the root command has no `PersistentPreRun` — so every subcommand must bootstrap the shared state it needs.

### Audit result (acceptance #2)
I swept **every** `RunE`-bearing command in `cmd/server` for the same nil-shared-state trap. Four more were affected, all the same class:

| Command | Before | Fix |
|---|---|---|
| `user suspend` | **panic** (nil DB) | `PreRunE: requireDBAndAgent` |
| `user unsuspend` | **panic** (nil DB) | `PreRunE: requireDBAndAgent` |
| `session revoke-user` | **panic** (`resolveUser`→nil DB) | `PreRunE: requireDB` |
| `session list` | `"config not loaded"` | `PreRunE: requireConfig` |
| `session revoke` | `"config not loaded"` | `PreRunE: requireConfig` |

Every other DB-touching command was verified clean — it either carries a `PreRunE`, initialises inline, or reaches the DB through a self-initialising `*Direct` helper (`listUsersDirect`, `listAppsDirect`, `listDomainsDirect`, `createDomainDirect`, `deleteAppDirect`, `resolveAppSpec`, `beginUpdateHistory`). Static-list commands (`catalog`/`frameworks`/`keys`/`registry`) and exec-only commands touch no shared state.

### Why `requireDBAndAgent`, not `requireDB`, for suspend/unsuspend
`requireDB` alone stops the panic but leaves `sharedAgent` nil, and `cliSuspendDeps()` only wires `d.Agent` when the shared client is non-nil. The suspend would then report **success while silently skipping the OS-user lock and the `ftpaccount.lock_tenant` call** — a half-suspension where the user's shell/FTP access stays live. Opening the agent keeps the CLI cascade identical to the panel API path (`userops.SuspendUser`).

### Not a production regression
The customer-facing suspension path is the panel API, which is unaffected. This is a CLI-bootstrap defect only.

### Tests
- `TestCLITree_StatefulCommandsHavePreRunE` pins the five commands (`PreRunE != nil`) so the regression can't silently return. Targeted rather than a blanket rule, which would false-positive on the legitimately inline-initialising `*Direct` commands (`user delete`, `domain list`, …).
- `go build`, `go vet`, `gofmt` clean; existing `cli_tree_invariants` tests still pass.
- Acceptance #1 (the cascade actually runs end-to-end) goes into the jabalitests host-only batch — a live suspend can't be exercised in unit tests.

Refs JAB-272.
