### PR TITLE
test(host-safety): route package commands exec through a test-neutered seam (GH #994)

### DIFF
--- a/panel-agent/internal/commands/app_scan.go
+++ b/panel-agent/internal/commands/app_scan.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -217,7 +216,7 @@ func detectWPAdmin(docroot string) string {
 		"SELECT u.user_login FROM `%s`.`%susers` u JOIN `%s`.`%susermeta` m ON u.ID = m.user_id WHERE m.meta_key = '%scapabilities' AND m.meta_value LIKE '%%\"administrator\"%%' ORDER BY u.ID ASC LIMIT 1",
 		dbName, prefix, dbName, prefix, prefix,
 	)
-	out, err := exec.Command("mysql", "-BN", "-e", q).Output()
+	out, err := execCommand("mysql", "-BN", "-e", q).Output()
 	if err != nil {
 		return ""
 	}

--- a/panel-agent/internal/commands/backup_create.go
+++ b/panel-agent/internal/commands/backup_create.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -732,7 +731,7 @@ func backupCancelHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 
 // hostname returns the box's hostname for manifest source recording.
 func hostname() string {
-	out, err := exec.Command("hostname", "-f").Output()
+	out, err := execCommand("hostname", "-f").Output()
 	if err != nil {
 		return "unknown"
 	}
@@ -743,7 +742,7 @@ func hostname() string {
 // /etc/jabali-panel/panel.sha when it builds; missing file is fine
 // (older installs).
 func panelSHA() string {
-	out, err := exec.Command("cat", "/etc/jabali-panel/panel.sha").Output()
+	out, err := execCommand("cat", "/etc/jabali-panel/panel.sha").Output()
 	if err != nil {
 		return ""
 	}

--- a/panel-agent/internal/commands/backup_databases.go
+++ b/panel-agent/internal/commands/backup_databases.go
@@ -118,7 +118,7 @@ func backupDatabasesHandler(ctx context.Context, raw json.RawMessage) (any, erro
 // `sudo -u postgres pg_dump -Fc` (custom-format binary dump).
 // Same restic --stdin pipe pattern, same tagging.
 func dumpOnePostgresDatabase(ctx context.Context, c *backup.Client, jobID, userID, scheduleID, db string) (*backupDBStageSnapshot, error) {
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
 		"-Fc",
 		"--no-owner", "--no-privileges",
 		db,
@@ -169,7 +169,7 @@ func dumpOnePostgresDatabase(ctx context.Context, c *backup.Client, jobID, userI
 // dumpOneDatabase pipes mariadb-dump → restic backup --stdin. We avoid
 // shelling out twice (no intermediate file) so the dump stays in tmpfs.
 func dumpOneDatabase(ctx context.Context, c *backup.Client, jobID, userID, scheduleID, db string) (*backupDBStageSnapshot, error) {
-	cmd := exec.CommandContext(ctx, "mariadb-dump",
+	cmd := execCommandContext(ctx, "mariadb-dump",
 		"--single-transaction", "--skip-lock-tables",
 		"--routines", "--triggers", "--events",
 		"--hex-blob",

--- a/panel-agent/internal/commands/backup_home.go
+++ b/panel-agent/internal/commands/backup_home.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -167,7 +166,7 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 // on a non-zero exit (could be permission-denied; treat as scan failure
 // rather than silently passing).
 func duBytes(ctx context.Context, path string) (uint64, error) {
-	out, err := exec.CommandContext(ctx, "du", "-sb", path).Output()
+	out, err := execCommandContext(ctx, "du", "-sb", path).Output()
 	if err != nil {
 		return 0, fmt.Errorf("du -sb %s: %w", path, err)
 	}

--- a/panel-agent/internal/commands/backup_logs.go
+++ b/panel-agent/internal/commands/backup_logs.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +63,7 @@ func backupLogsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		lines = 5000
 	}
 
-	statusOut, _ := exec.CommandContext(ctx, "systemctl", "is-active", unit).Output()
+	statusOut, _ := execCommandContext(ctx, "systemctl", "is-active", unit).Output()
 	status := strings.TrimSpace(string(statusOut))
 
 	// Primary log source: orchestrator-written file at
@@ -81,7 +80,7 @@ func backupLogsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		// Better than (no log output) when the orchestrator died
 		// before opening the file.
 		journalArgs := []string{"-u", unit, "--no-pager", "-o", "cat", "-n", strconv.Itoa(lines)}
-		out, _ := exec.CommandContext(ctx, "journalctl", journalArgs...).Output()
+		out, _ := execCommandContext(ctx, "journalctl", journalArgs...).Output()
 		logText = string(out)
 	}
 
@@ -99,7 +98,7 @@ func backupLogsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		FetchedAt: time.Now().UTC().Format(time.RFC3339Nano),
 	}
 	if status == "inactive" || status == "failed" {
-		showOut, err := exec.CommandContext(ctx, "systemctl", "show", unit,
+		showOut, err := execCommandContext(ctx, "systemctl", "show", unit,
 			"--property=ExecMainStatus", "--value").Output()
 		if err == nil {
 			if v, perr := strconv.Atoi(strings.TrimSpace(string(showOut))); perr == nil {

--- a/panel-agent/internal/commands/backup_mailboxes.go
+++ b/panel-agent/internal/commands/backup_mailboxes.go
@@ -150,7 +150,7 @@ func stalwartActive(ctx context.Context) bool {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return true
 	}
-	out, _ := exec.CommandContext(ctx, "systemctl", "is-active", "jabali-stalwart.service").Output()
+	out, _ := execCommandContext(ctx, "systemctl", "is-active", "jabali-stalwart.service").Output()
 	return strings.TrimSpace(string(out)) == "active"
 }
 

--- a/panel-agent/internal/commands/backup_materialize.go
+++ b/panel-agent/internal/commands/backup_materialize.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 
@@ -73,13 +72,13 @@ func backupMaterializeHandler(ctx context.Context, raw json.RawMessage) (any, er
 	// just the traversal bit (g+x) without exposing repo contents
 	// (the repo dir itself stays 0700). chgrp gives the directory the
 	// jabali group so o-x stays closed.
-	if err := exec.Command("chgrp", "jabali", filepath.Dir(downloadRoot)).Run(); err != nil {
+	if err := execCommand("chgrp", "jabali", filepath.Dir(downloadRoot)).Run(); err != nil {
 		return nil, fmt.Errorf("chgrp /var/lib/jabali-backups: %w", err)
 	}
 	if err := os.Chmod(filepath.Dir(downloadRoot), 0o750); err != nil {
 		return nil, fmt.Errorf("chmod /var/lib/jabali-backups: %w", err)
 	}
-	if err := exec.Command("chgrp", "jabali", downloadRoot).Run(); err != nil {
+	if err := execCommand("chgrp", "jabali", downloadRoot).Run(); err != nil {
 		return nil, fmt.Errorf("chgrp downloadRoot: %w", err)
 	}
 	if err := os.Chmod(downloadRoot, 0o750); err != nil {
@@ -138,10 +137,10 @@ func backupMaterializeHandler(ctx context.Context, raw json.RawMessage) (any, er
 	// `jabali` exists since M9 (per-user-slices baseline). chmod -R
 	// keeps directories traversable + files readable. exec'ing chown
 	// is cheaper than walking the tree in Go for typical home dirs.
-	if err := exec.Command("chgrp", "-R", "jabali", target).Run(); err != nil {
+	if err := execCommand("chgrp", "-R", "jabali", target).Run(); err != nil {
 		return nil, fmt.Errorf("chgrp jabali: %w", err)
 	}
-	if err := exec.Command("chmod", "-R", "g+rX", target).Run(); err != nil {
+	if err := execCommand("chmod", "-R", "g+rX", target).Run(); err != nil {
 		return nil, fmt.Errorf("chmod g+rX: %w", err)
 	}
 	if err := os.Chmod(target, 0o750); err != nil {

--- a/panel-agent/internal/commands/backup_repo_password_rotate.go
+++ b/panel-agent/internal/commands/backup_repo_password_rotate.go
@@ -200,7 +200,7 @@ func resticEnv(cfg backup.ResticConfig) []string {
 }
 
 func resticKeyList(ctx context.Context, cfg backup.ResticConfig) ([]resticKey, error) {
-	cmd := exec.CommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
+	cmd := execCommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
 		"--password-file", cfg.PasswordFile, "key", "list", "--json")
 	cmd.Env = resticEnv(cfg)
 	out, err := cmd.Output()
@@ -215,7 +215,7 @@ func resticKeyList(ctx context.Context, cfg backup.ResticConfig) ([]resticKey, e
 }
 
 func resticKeyAdd(ctx context.Context, cfg backup.ResticConfig, newPasswordFile string) error {
-	cmd := exec.CommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
+	cmd := execCommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
 		"--password-file", cfg.PasswordFile, "key", "add",
 		"--new-password-file", newPasswordFile,
 		"--user", "jabali", "--host", "jabali-panel")
@@ -227,7 +227,7 @@ func resticKeyAdd(ctx context.Context, cfg backup.ResticConfig, newPasswordFile 
 }
 
 func resticKeyRemove(ctx context.Context, cfg backup.ResticConfig, keyID string) error {
-	cmd := exec.CommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
+	cmd := execCommandContext(ctx, resticBinary(cfg), "--repo", cfg.Repo,
 		"--password-file", cfg.PasswordFile, "key", "remove", keyID)
 	cmd.Env = resticEnv(cfg)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/panel-agent/internal/commands/backup_restore.go
+++ b/panel-agent/internal/commands/backup_restore.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -287,7 +286,7 @@ func applyAccountRestore(
 			args = append(args, "--uid", strconv.FormatUint(uint64(manifestUser.UIDAtSource), 10))
 		}
 		args = append(args, username)
-		cmd := exec.CommandContext(ctx, "useradd", args...)
+		cmd := execCommandContext(ctx, "useradd", args...)
 		if out, addErr := cmd.CombinedOutput(); addErr != nil {
 			warnings = append(warnings,
 				fmt.Sprintf("apply skipped: useradd %q failed: %v: %s", username, addErr, strings.TrimSpace(string(out))))
@@ -308,7 +307,7 @@ func applyAccountRestore(
 		// the timer never lands. Doing it here makes the DR path
 		// self-sufficient. Idempotent — loginctl returns success on
 		// already-enabled users.
-		lingerCmd := exec.CommandContext(ctx, "loginctl", "enable-linger", username)
+		lingerCmd := execCommandContext(ctx, "loginctl", "enable-linger", username)
 		if lOut, lErr := lingerCmd.CombinedOutput(); lErr != nil {
 			warnings = append(warnings,
 				fmt.Sprintf("loginctl enable-linger %q failed: %v: %s — cron timer apply may fail until reconciler retries", username, lErr, strings.TrimSpace(string(lOut))))
@@ -344,7 +343,7 @@ func applyAccountRestore(
 			// attacker-controlled ACL/xattr/capability metadata that root would
 			// otherwise apply into a live tenant home); owner/mode are
 			// re-normalized below regardless (Gitea #462).
-			if err := exec.CommandContext(ctx, "rsync", "-aH", "--delete", src, dst).Run(); err != nil {
+			if err := execCommandContext(ctx, "rsync", "-aH", "--delete", src, dst).Run(); err != nil {
 				warnings = append(warnings, fmt.Sprintf("home: rsync: %v", err))
 				continue
 			}
@@ -406,7 +405,7 @@ func applyAccountRestore(
 			}
 			// -aH, not -aHAX: same reasoning as the home stage — never apply
 			// ACLs/xattrs/capabilities carried by an untrusted snapshot.
-			if err := exec.CommandContext(ctx, "rsync", "-aH", "--delete", src, dst+"/").Run(); err != nil {
+			if err := execCommandContext(ctx, "rsync", "-aH", "--delete", src, dst+"/").Run(); err != nil {
 				warnings = append(warnings, fmt.Sprintf("docker %s: rsync: %v", slug, err))
 				continue
 			}
@@ -436,11 +435,11 @@ func applyAccountRestore(
 				// IF NOT EXISTS for CREATE DATABASE pre-9.x but
 				// we accept an "already exists" error as success.
 				createSQL := fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname = '%s'", db)
-				probeCmd := exec.CommandContext(ctx, "sudo", "-u", "postgres",
+				probeCmd := execCommandContext(ctx, "sudo", "-u", "postgres",
 					"psql", "-XAtq", "-c", createSQL)
 				probeOut, _ := probeCmd.Output()
 				if strings.TrimSpace(string(probeOut)) == "" {
-					mkCmd := exec.CommandContext(ctx, "sudo", "-u", "postgres",
+					mkCmd := execCommandContext(ctx, "sudo", "-u", "postgres",
 						"createdb", "--encoding=UTF8", db)
 					if cOut, cErr := mkCmd.CombinedOutput(); cErr != nil {
 						warnings = append(warnings,
@@ -466,7 +465,7 @@ func applyAccountRestore(
 						fmt.Sprintf("db %s (postgres): open dump: %v", db, oErr))
 					continue
 				}
-				restoreCmd := exec.CommandContext(ctx, "sudo", "-u", "postgres",
+				restoreCmd := execCommandContext(ctx, "sudo", "-u", "postgres",
 					"pg_restore", "--clean", "--if-exists", "--no-owner",
 					"--no-privileges", "-d", db)
 				restoreCmd.Stdin = pgFile
@@ -508,7 +507,7 @@ func applyAccountRestore(
 			// db.create defaults to. Idempotent — present DBs are
 			// untouched. Backticks around name guard against names
 			// with reserved-word collisions (M24 'dual' incident).
-			createCmd := exec.CommandContext(ctx, "mariadb", "-e",
+			createCmd := execCommandContext(ctx, "mariadb", "-e",
 				fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;", db))
 			if cOut, cErr := createCmd.CombinedOutput(); cErr != nil {
 				_ = f.Close()

--- a/panel-agent/internal/commands/backup_restore_selective.go
+++ b/panel-agent/internal/commands/backup_restore_selective.go
@@ -31,7 +31,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -334,7 +333,7 @@ func applySelectiveHome(ctx context.Context, stagingRoot, username string, st *b
 	}
 	// -aH not -aHAX: skip untrusted ACL/xattr restore from the repo;
 	// owner/mode are re-normalized below (Gitea #462).
-	if err := exec.CommandContext(ctx, "rsync", "-aH", src, dst).Run(); err != nil {
+	if err := execCommandContext(ctx, "rsync", "-aH", src, dst).Run(); err != nil {
 		return "home: rsync: " + err.Error()
 	}
 	if err := chownTreeRecursive(dst, uid, gid); err != nil {

--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -535,7 +535,7 @@ func reassertDRPairingSQL(ctx context.Context, p *drPairingReassert) error {
 			"dr_destination_id=COALESCE((SELECT id FROM jabali_panel.backup_destinations WHERE name='%s' LIMIT 1),'%s'), "+
 			"dr_peer_label='%s', dr_paired_at=%s WHERE 1=1;",
 		sqlEscape(p.DestinationName), p.DestinationID, sqlEscape(p.PeerLabel), pairedAt)
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock", "-e", stmt)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -597,7 +597,7 @@ func resyncDBAccountPasswords(ctx context.Context) ([]string, []string) {
 		// auth which is more setup).
 		stmt := fmt.Sprintf("ALTER USER '%s'@'%s' IDENTIFIED BY '%s'; FLUSH PRIVILEGES;",
 			a.mariadbUser, a.host, sqlEscape(pw))
-		cmd := exec.CommandContext(ctx, "mariadb",
+		cmd := execCommandContext(ctx, "mariadb",
 			"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 			"-e", stmt,
 		)
@@ -734,8 +734,8 @@ func applySystemRestore(ctx context.Context, stagingRoot string, stages []backup
 			if err := rsyncStageOnto(ctx, stageDir, "/etc/php", nil); err != nil {
 				warnings = append(warnings, fmt.Sprintf("service_config php: %v", err))
 			}
-			_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
-			_ = exec.CommandContext(ctx, "systemctl", "reload", "nginx").Run()
+			_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
+			_ = execCommandContext(ctx, "systemctl", "reload", "nginx").Run()
 			applied = append(applied, "service_config → /etc/nginx + /etc/php")
 		case backup.StageSecurity:
 			if !whitelist[st.Name] {
@@ -778,9 +778,9 @@ func applySystemRestore(ctx context.Context, stagingRoot string, stages []backup
 }
 
 func applyMailState(ctx context.Context, stageDir string) error {
-	_ = exec.CommandContext(ctx, "systemctl", "stop", "jabali-stalwart.service").Run()
+	_ = execCommandContext(ctx, "systemctl", "stop", "jabali-stalwart.service").Run()
 	defer func() {
-		_ = exec.CommandContext(context.Background(), "systemctl", "start", "jabali-stalwart.service").Run()
+		_ = execCommandContext(context.Background(), "systemctl", "start", "jabali-stalwart.service").Run()
 	}()
 	return rsyncStageOnto(ctx, stageDir, "/var/lib/stalwart", nil)
 }
@@ -813,7 +813,7 @@ func applyPanelDBStage(ctx context.Context, stageDir string, st backup.ManifestS
 		return fmt.Errorf("open %s: %w", src, err)
 	}
 	defer f.Close()
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket",
 		"--socket=/run/mysqld/mysqld.sock",
 		db,
@@ -849,7 +849,7 @@ func rsyncStageOnto(ctx context.Context, stageDir, target string, excludes []str
 		args = append(args, "--exclude="+e)
 	}
 	args = append(args, src, target+"/")
-	cmd := exec.CommandContext(ctx, "rsync", args...)
+	cmd := execCommandContext(ctx, "rsync", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("rsync %s -> %s: %w (output: %s)", src, target, err,
@@ -1006,7 +1006,7 @@ func runSystemPanelDBStage(ctx context.Context, c *backup.Client, jobID, hostnam
 // be there. A lookup failure returns true so we still attempt the dump
 // (fail loud rather than silently skip a real DB). Overridable for tests.
 var systemDBExists = func(ctx context.Context, db string) bool {
-	out, err := exec.CommandContext(ctx, "mariadb", "-N", "-B", "-e",
+	out, err := execCommandContext(ctx, "mariadb", "-N", "-B", "-e",
 		fmt.Sprintf("SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = '%s'", db)).Output()
 	if err != nil {
 		return true
@@ -1029,7 +1029,7 @@ func dumpOneSystemDB(ctx context.Context, c *backup.Client, jobID, hostname, sch
 		st.Warnings = []string{fmt.Sprintf("database %s not present — skipped (component not installed)", db)}
 		return st
 	}
-	cmd := exec.CommandContext(ctx, "mariadb-dump",
+	cmd := execCommandContext(ctx, "mariadb-dump",
 		"--single-transaction", "--skip-lock-tables",
 		"--routines", "--triggers", "--events",
 		"--hex-blob",

--- a/panel-agent/internal/commands/backup_system_accounts.go
+++ b/panel-agent/internal/commands/backup_system_accounts.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	mathRand "math/rand"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -250,10 +249,10 @@ func restoreAccounts(ctx context.Context, c *backup.Client, jobID, stagingRoot s
 // the panel reconciler's job — runs after the panel comes back up
 // and reads jabali_panel.users.
 func ensureLinuxUser(ctx context.Context, username string) error {
-	if err := exec.CommandContext(ctx, "id", username).Run(); err == nil {
+	if err := execCommandContext(ctx, "id", username).Run(); err == nil {
 		return nil
 	}
-	out, err := exec.CommandContext(ctx, "useradd", "-m", "-s", "/bin/bash", username).CombinedOutput()
+	out, err := execCommandContext(ctx, "useradd", "-m", "-s", "/bin/bash", username).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("useradd %s: %w (output: %s)",
 			username, err, strings.TrimSpace(string(out)))
@@ -268,7 +267,7 @@ func rsyncOnto(ctx context.Context, src, dst string) error {
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dst, err)
 	}
-	out, err := exec.CommandContext(ctx, "rsync", "-a", "--delete-after", src, dst).CombinedOutput()
+	out, err := execCommandContext(ctx, "rsync", "-a", "--delete-after", src, dst).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("rsync %s -> %s: %w (output: %s)",
 			src, dst, err, strings.TrimSpace(string(out)))
@@ -281,7 +280,7 @@ func rsyncOnto(ctx context.Context, src, dst string) error {
 func loadAccountDB(ctx context.Context, db, sqlPath string) error {
 	create := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` "+
 		"DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;", db)
-	if out, err := exec.CommandContext(ctx, "mariadb",
+	if out, err := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"-e", create,
 	).CombinedOutput(); err != nil {
@@ -293,7 +292,7 @@ func loadAccountDB(ctx context.Context, db, sqlPath string) error {
 		return fmt.Errorf("open %s: %w", sqlPath, err)
 	}
 	defer f.Close()
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		db,
 	)
@@ -332,7 +331,7 @@ func readMetaBundle(userStaging string) *backup.AccountMetadata {
 // and returns the combined stdout+stderr when it fails. Used by every
 // reconstruction INSERT below.
 func runMariaDBStmt(ctx context.Context, stmt string) error {
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"-e", stmt,
 	)
@@ -564,7 +563,7 @@ func ensureKratosLookup(ctx context.Context) (string, string) {
 	if reusableKratosNID != "" {
 		return reusableKratosNID, reusableKratosSchema
 	}
-	out, err := exec.CommandContext(ctx, "mariadb",
+	out, err := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"-N", "-B",
 		"-e", "SELECT nid, schema_id FROM jabali_kratos.identities WHERE state='active' LIMIT 1",
@@ -588,7 +587,7 @@ func lookupKratosIdentityByEmail(ctx context.Context, email string) string {
 	stmt := fmt.Sprintf(
 		"SELECT id FROM jabali_kratos.identities WHERE JSON_EXTRACT(traits,'$.email')='\"%s\"' LIMIT 1",
 		sqlEscape(email))
-	out, err := exec.CommandContext(ctx, "mariadb",
+	out, err := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"-N", "-B",
 		"-e", stmt,

--- a/panel-agent/internal/commands/backup_system_os_users_apply.go
+++ b/panel-agent/internal/commands/backup_system_os_users_apply.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -123,7 +122,7 @@ func applyOSUsersMerge(ctx context.Context, stageDir string) ([]string, []string
 				fmt.Sprintf("os_users: gid %d already belongs to group %q — cannot create %q, skipped", gid, g.Name, name))
 			continue
 		}
-		if out, cerr := exec.CommandContext(ctx, "groupadd", "-g", strconv.Itoa(gid), name).CombinedOutput(); cerr != nil {
+		if out, cerr := execCommandContext(ctx, "groupadd", "-g", strconv.Itoa(gid), name).CombinedOutput(); cerr != nil {
 			warnings = append(warnings, fmt.Sprintf("os_users: groupadd %s: %v (%s)", name, cerr, strings.TrimSpace(string(out))))
 			continue
 		}
@@ -164,7 +163,7 @@ func applyOSUsersMerge(ctx context.Context, stageDir string) ([]string, []string
 				fmt.Sprintf("os_users: user %q source gid %d absent — using a fresh usergroup", e.Name, e.GID))
 		}
 		args = append(args, e.Name)
-		if out, cerr := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); cerr != nil {
+		if out, cerr := execCommandContext(ctx, "useradd", args...).CombinedOutput(); cerr != nil {
 			warnings = append(warnings, fmt.Sprintf("os_users: useradd %s: %v (%s)", e.Name, cerr, strings.TrimSpace(string(out))))
 			continue
 		}
@@ -174,7 +173,7 @@ func applyOSUsersMerge(ctx context.Context, stageDir string) ([]string, []string
 			warnings = append(warnings, fmt.Sprintf("os_users: mkdir %s: %v", e.Home, merr))
 		}
 		if h := hashes[e.Name]; h != "" && h != "*" && h != "!" {
-			cmd := exec.CommandContext(ctx, "chpasswd", "-e")
+			cmd := execCommandContext(ctx, "chpasswd", "-e")
 			cmd.Stdin = strings.NewReader(e.Name + ":" + h + "\n")
 			if out, cerr := cmd.CombinedOutput(); cerr != nil {
 				warnings = append(warnings, fmt.Sprintf("os_users: chpasswd %s: %v (%s)", e.Name, cerr, strings.TrimSpace(string(out))))
@@ -192,7 +191,7 @@ func applyOSUsersMerge(ctx context.Context, stageDir string) ([]string, []string
 			if _, gerr := user.LookupGroup(g.name); gerr != nil {
 				continue
 			}
-			if out, cerr := exec.CommandContext(ctx, "usermod", "-aG", g.name, m).CombinedOutput(); cerr != nil {
+			if out, cerr := execCommandContext(ctx, "usermod", "-aG", g.name, m).CombinedOutput(); cerr != nil {
 				warnings = append(warnings, fmt.Sprintf("os_users: usermod -aG %s %s: %v (%s)", g.name, m, cerr, strings.TrimSpace(string(out))))
 			}
 		}

--- a/panel-agent/internal/commands/bandwidth_scan_day.go
+++ b/panel-agent/internal/commands/bandwidth_scan_day.go
@@ -138,7 +138,7 @@ func scanLogFile(ctx context.Context, path string) (uint64, uint64, error) {
 	scanCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(scanCtx, "goaccess", goaccessScanArgs(path)...)
+	cmd := execCommandContext(scanCtx, "goaccess", goaccessScanArgs(path)...)
 	out, err := cmd.Output()
 	if err != nil {
 		// goaccess exits non-zero on parse errors; emit the file basename

--- a/panel-agent/internal/commands/cron_apply.go
+++ b/panel-agent/internal/commands/cron_apply.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -393,7 +392,7 @@ func ensureSystemBus(ctx context.Context) error {
 	if _, err := os.Stat(sock); err == nil {
 		return nil
 	}
-	_ = exec.CommandContext(ctx, "systemctl", "start", "dbus.socket", "dbus.service").Run()
+	_ = execCommandContext(ctx, "systemctl", "start", "dbus.socket", "dbus.service").Run()
 	for i := 0; i < 5; i++ {
 		if _, err := os.Stat(sock); err == nil {
 			return nil
@@ -410,13 +409,13 @@ func ensureUserManager(ctx context.Context, username string, uid int, runtimeDir
 		return err
 	}
 	if err := checkUserLinger(ctx, username); err != nil {
-		if out, lErr := exec.CommandContext(ctx, "loginctl", "enable-linger", username).CombinedOutput(); lErr != nil {
+		if out, lErr := execCommandContext(ctx, "loginctl", "enable-linger", username).CombinedOutput(); lErr != nil {
 			return fmt.Errorf("enable-linger: %v: %s", lErr, strings.TrimSpace(string(out)))
 		}
 	}
 	// Start (idempotent) the user manager so the bus socket is present.
 	if _, err := os.Stat(filepath.Join(runtimeDir, "bus")); err != nil {
-		if out, sErr := exec.CommandContext(ctx, "systemctl", "start",
+		if out, sErr := execCommandContext(ctx, "systemctl", "start",
 			fmt.Sprintf("user@%d.service", uid)).CombinedOutput(); sErr != nil {
 			return fmt.Errorf("start user@%d.service: %v: %s", uid, sErr, strings.TrimSpace(string(out)))
 		}
@@ -447,7 +446,7 @@ func systemctlUserExec(ctx context.Context, username string, runtimeDir string, 
 		"systemctl", "--user",
 	}
 	full = append(full, args...)
-	cmd := exec.CommandContext(ctx, "sudo", full...)
+	cmd := execCommandContext(ctx, "sudo", full...)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -499,10 +498,10 @@ func applyRootCron(ctx context.Context, p cronApplyParams) (any, error) {
 	}
 
 	// system-level daemon-reload + enable.
-	if out, err := exec.CommandContext(ctx, "systemctl", "daemon-reload").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "daemon-reload").CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("daemon-reload: %v: %s", err, out)}
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "enable", "--now", fmt.Sprintf("jabali-cron-%s.timer", p.JobID)).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "enable", "--now", fmt.Sprintf("jabali-cron-%s.timer", p.JobID)).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("enable timer: %v: %s", err, out)}
 	}
 	return &cronApplyResponse{ServicePath: servicePath, TimerPath: timerPath}, nil

--- a/panel-agent/internal/commands/cron_remove.go
+++ b/panel-agent/internal/commands/cron_remove.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -160,9 +159,9 @@ func removeRootCron(ctx context.Context, p cronRemoveParams) (any, error) {
 	if !fileExists(servicePath) && !fileExists(timerPath) {
 		return &cronRemoveResponse{NoChange: true}, nil
 	}
-	_ = exec.CommandContext(ctx, "systemctl", "disable", "--now", fmt.Sprintf("jabali-cron-%s.timer", p.JobID)).Run()
+	_ = execCommandContext(ctx, "systemctl", "disable", "--now", fmt.Sprintf("jabali-cron-%s.timer", p.JobID)).Run()
 	_ = os.Remove(servicePath)
 	_ = os.Remove(timerPath)
-	_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+	_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 	return &cronRemoveResponse{}, nil
 }

--- a/panel-agent/internal/commands/cron_run_now.go
+++ b/panel-agent/internal/commands/cron_run_now.go
@@ -98,7 +98,7 @@ func cronRunNowHandler(ctx context.Context, params json.RawMessage) (any, error)
 		home = "/home/" + p.Username
 	}
 	args := append([]string{"-u", p.Username, "--"}, validated.Argv...)
-	cmd := exec.CommandContext(ctx, "runuser", args...)
+	cmd := execCommandContext(ctx, "runuser", args...)
 	cmd.Dir = home
 	cmd.Env = []string{
 		"HOME=" + home,

--- a/panel-agent/internal/commands/cron_status.go
+++ b/panel-agent/internal/commands/cron_status.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"strconv"
 	"strings"
@@ -61,7 +60,7 @@ func cronStatusHandler(ctx context.Context, params json.RawMessage) (any, error)
 	runtimeDir := fmt.Sprintf("/run/user/%s", u.Uid)
 	unit := fmt.Sprintf("jabali-cron-%s.service", p.JobID)
 
-	cmd := exec.CommandContext(ctx, "sudo", "-u", p.Username,
+	cmd := execCommandContext(ctx, "sudo", "-u", p.Username,
 		"env",
 		"XDG_RUNTIME_DIR="+runtimeDir,
 		"DBUS_SESSION_BUS_ADDRESS=unix:path="+runtimeDir+"/bus",

--- a/panel-agent/internal/commands/cron_tail_log.go
+++ b/panel-agent/internal/commands/cron_tail_log.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"regexp"
 	"strconv"
@@ -70,7 +69,7 @@ func cronTailLogHandler(ctx context.Context, params json.RawMessage) (any, error
 	runtimeDir := fmt.Sprintf("/run/user/%d", uid)
 
 	// Query journalctl for the service logs
-	cmd := exec.CommandContext(ctx, "sudo", "-u", p.Username)
+	cmd := execCommandContext(ctx, "sudo", "-u", p.Username)
 	cmd.Env = append(os.Environ(),
 		fmt.Sprintf("XDG_RUNTIME_DIR=%s", runtimeDir),
 	)

--- a/panel-agent/internal/commands/db_backup.go
+++ b/panel-agent/internal/commands/db_backup.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
 	"os"
-	"os/exec"
 	"os/user"
 	"regexp"
 	"strconv"
@@ -194,7 +193,7 @@ func dbBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	defer f.Close()
 
 	// Run mysqldump with the database name as a positional argument (no interpolation).
-	cmd := exec.CommandContext(
+	cmd := execCommandContext(
 		ctx,
 		"mysqldump",
 		"--single-transaction",

--- a/panel-agent/internal/commands/db_config_apply.go
+++ b/panel-agent/internal/commands/db_config_apply.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -39,7 +38,7 @@ const (
 )
 
 func mysqlPing(ctx context.Context) bool {
-	return exec.CommandContext(ctx, "mariadb-admin", "--protocol=socket", "ping").Run() == nil
+	return execCommandContext(ctx, "mariadb-admin", "--protocol=socket", "ping").Run() == nil
 }
 
 func writeBrokenMarker(engine, detail string) {
@@ -104,7 +103,7 @@ func dbConfigApplyHandler(ctx context.Context, params json.RawMessage) (any, err
 	if p.RestartRequired {
 		action = "restart"
 	}
-	_ = exec.CommandContext(ctx, "systemctl", action, "mariadb").Run()
+	_ = execCommandContext(ctx, "systemctl", action, "mariadb").Run()
 
 	// Health probe with a short grace window.
 	ok := false
@@ -128,7 +127,7 @@ func dbConfigApplyHandler(ctx context.Context, params json.RawMessage) (any, err
 	} else {
 		_ = os.Remove(mariaTuningDropIn)
 	}
-	_ = exec.CommandContext(ctx, "systemctl", "restart", "mariadb").Run()
+	_ = execCommandContext(ctx, "systemctl", "restart", "mariadb").Run()
 	for i := 0; i < 10; i++ {
 		if mysqlPing(ctx) {
 			return nil, &agentwire.AgentError{
@@ -164,7 +163,7 @@ func dbPostgresConfigApplyHandler(ctx context.Context, params json.RawMessage) (
 		}
 	}
 	if p.RestartRequired {
-		_ = exec.CommandContext(ctx, "systemctl", "restart", "postgresql").Run()
+		_ = execCommandContext(ctx, "systemctl", "restart", "postgresql").Run()
 	} else {
 		if err := pgRunSQL(ctx, "SELECT pg_reload_conf()"); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "pg_reload_conf failed: " + err.Error()}
@@ -174,7 +173,7 @@ func dbPostgresConfigApplyHandler(ctx context.Context, params json.RawMessage) (
 	// with no args probes a default host/port that does not match the
 	// peer/socket setup (false UNRECOVERABLE even though ALTER SYSTEM
 	// applied — M46 smoke caught this with work_mem visibly effective).
-	if exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql", "-tAq", "-c", "SELECT 1").Run() != nil {
+	if execCommandContext(ctx, "sudo", "-u", "postgres", "psql", "-tAq", "-c", "SELECT 1").Run() != nil {
 		writeBrokenMarker("postgres", "postgresql not answering as postgres after config apply")
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "UNRECOVERABLE: postgresql not ready after config apply"}
 	}

--- a/panel-agent/internal/commands/db_create.go
+++ b/panel-agent/internal/commands/db_create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -105,7 +104,7 @@ func dbCreateHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		escapedCollation,
 	)
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/db_drop.go
+++ b/panel-agent/internal/commands/db_drop.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -68,7 +67,7 @@ func dbDropHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	// Build the DROP DATABASE IF EXISTS command.
 	sql := fmt.Sprintf("DROP DATABASE IF EXISTS %s", escapedDBName)
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/db_load_scoped.go
+++ b/panel-agent/internal/commands/db_load_scoped.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/user"
 	"regexp"
 	"strconv"
@@ -107,7 +106,7 @@ func (s *definerRewritingReader) Read(p []byte) (int, error) {
 // for the static, operator-side provisioning statements — dump content
 // never passes through here.
 func mariadbRoot(ctx context.Context, stmt string) error {
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"-e", stmt)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -158,7 +157,7 @@ func loadMariaDBDumpScoped(ctx context.Context, dbName string, dump io.Reader) e
 		return fmt.Errorf("parse %s gid: %w", scopedRestoreOSUser, err)
 	}
 
-	cmd := exec.CommandContext(ctx, "mariadb",
+	cmd := execCommandContext(ctx, "mariadb",
 		"--protocol=socket", "--socket=/run/mysqld/mysqld.sock",
 		"--user="+shadow,
 		"--database="+dbName)

--- a/panel-agent/internal/commands/db_maintenance.go
+++ b/panel-agent/internal/commands/db_maintenance.go
@@ -51,7 +51,7 @@ func dbMaintenanceHandler(ctx context.Context, params json.RawMessage) (any, err
 	// --optimize then --analyze sequentially.
 	var sb strings.Builder
 	for _, op := range []string{"--optimize", "--analyze"} {
-		o, e := exec.CommandContext(ctx, "mariadb-check", append([]string{op}, scopeArgs...)...).CombinedOutput()
+		o, e := execCommandContext(ctx, "mariadb-check", append([]string{op}, scopeArgs...)...).CombinedOutput()
 		sb.WriteString(op + ":\n" + strings.TrimSpace(string(o)) + "\n")
 		if e != nil {
 			return nil, &agentwire.AgentError{
@@ -79,11 +79,11 @@ func dbPostgresMaintenanceHandler(ctx context.Context, params json.RawMessage) (
 	}
 	var vac, rei *exec.Cmd
 	if p.Scope == "all" {
-		vac = exec.CommandContext(ctx, "sudo", "-u", "postgres", "vacuumdb", "--all", "--analyze")
-		rei = exec.CommandContext(ctx, "sudo", "-u", "postgres", "reindexdb", "--all")
+		vac = execCommandContext(ctx, "sudo", "-u", "postgres", "vacuumdb", "--all", "--analyze")
+		rei = execCommandContext(ctx, "sudo", "-u", "postgres", "reindexdb", "--all")
 	} else {
-		vac = exec.CommandContext(ctx, "sudo", "-u", "postgres", "vacuumdb", "-d", p.Scope, "--analyze")
-		rei = exec.CommandContext(ctx, "sudo", "-u", "postgres", "reindexdb", "-d", p.Scope)
+		vac = execCommandContext(ctx, "sudo", "-u", "postgres", "vacuumdb", "-d", p.Scope, "--analyze")
+		rei = execCommandContext(ctx, "sudo", "-u", "postgres", "reindexdb", "-d", p.Scope)
 	}
 	vOut, vErr := vac.CombinedOutput()
 	rOut, rErr := rei.CombinedOutput()

--- a/panel-agent/internal/commands/db_mysqladmin_ensure.go
+++ b/panel-agent/internal/commands/db_mysqladmin_ensure.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -127,7 +126,7 @@ func dbMysqladminEnsureHandler(ctx context.Context, params json.RawMessage) (any
 		escapedUser, escapedPassword, dbPattern,
 	)
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	if err := cmd.Run(); err != nil {
 		// Do not echo mysql's stderr — it may contain the password.
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/db_pma_admin_ensure.go
+++ b/panel-agent/internal/commands/db_pma_admin_ensure.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -56,7 +55,7 @@ func dbPmaAdminEnsureHandler(ctx context.Context, _ json.RawMessage) (any, error
 			"FLUSH PRIVILEGES;",
 		escUser, escPw,
 	)
-	if err := exec.CommandContext(ctx, "mysql", "-e", sql).Run(); err != nil {
+	if err := execCommandContext(ctx, "mysql", "-e", sql).Run(); err != nil {
 		// Do not echo mysql stderr — may contain the password.
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "failed to ensure pma admin shadow"}
 	}

--- a/panel-agent/internal/commands/db_postgres.go
+++ b/panel-agent/internal/commands/db_postgres.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -43,7 +42,7 @@ func pgValidIdent(s string) bool {
 // prepared-statement here because role / database names are
 // identifiers, not values, and PG doesn't support parameterised DDL.
 func pgRunSQL(ctx context.Context, sql string) error {
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
 		"-v", "ON_ERROR_STOP=1",
 		"-XAtq",
 		"-c", sql)
@@ -210,7 +209,7 @@ type dbPgListResponse struct {
 }
 
 func dbPgListHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
 		"-XAtq",
 		"-c", `SELECT datname FROM pg_database WHERE datistemplate = false AND datname != 'postgres' ORDER BY 1`)
 	out, err := cmd.Output()
@@ -261,7 +260,7 @@ func dbPgDumpHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	if err := hostreserve.CheckReserve(filepath.Dir(p.OutPath), 0); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "backup staging is under the host disk reserve: " + err.Error()}
 	}
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
 		"-Fc", "--no-owner", "--no-privileges",
 		"-f", p.OutPath, p.DBName)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/panel-agent/internal/commands/db_postgres_lifecycle.go
+++ b/panel-agent/internal/commands/db_postgres_lifecycle.go
@@ -43,11 +43,11 @@ func dbPostgresStatusHandler(ctx context.Context, _ json.RawMessage) (any, error
 	} else if matches, _ := filepath.Glob("/usr/lib/postgresql/*/bin/psql"); len(matches) > 0 {
 		resp.Installed = true
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "is-active", "postgresql").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "systemctl", "is-active", "postgresql").Output(); err == nil {
 		resp.Active = strings.TrimSpace(string(out)) == "active"
 	}
 	if resp.Installed {
-		if out, err := exec.CommandContext(ctx, "psql", "--version").Output(); err == nil {
+		if out, err := execCommandContext(ctx, "psql", "--version").Output(); err == nil {
 			resp.Version = strings.TrimSpace(string(out))
 		}
 	}
@@ -79,7 +79,7 @@ func dbPostgresInstallHandler(ctx context.Context, _ json.RawMessage) (any, erro
 	// we're trying to escape). --pipe forwards stdout/stderr back
 	// to us and waits for completion. --wait makes the call
 	// synchronous; --collect garbage-collects the unit on exit.
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--pipe", "--wait", "--quiet", "--collect",
 		"--unit=jabali-pg-install",
 		"--service-type=oneshot",
@@ -106,7 +106,7 @@ func dbPostgresEnableHandler(ctx context.Context, _ json.RawMessage) (any, error
 			Message: "postgres not installed; call db.postgres.install first",
 		}
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "enable", "--now", "postgresql").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "enable", "--now", "postgresql").CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code: agentwire.CodeInternal,
 			Message: fmt.Sprintf("systemctl enable --now postgresql: %v: %s",
@@ -118,7 +118,7 @@ func dbPostgresEnableHandler(ctx context.Context, _ json.RawMessage) (any, error
 
 // dbPostgresDisableHandler stops + disables (data PRESERVED).
 func dbPostgresDisableHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	if out, err := exec.CommandContext(ctx, "systemctl", "disable", "--now", "postgresql").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "disable", "--now", "postgresql").CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code: agentwire.CodeInternal,
 			Message: fmt.Sprintf("systemctl disable --now postgresql: %v: %s",
@@ -150,7 +150,7 @@ func dbPostgresUninstallHandler(ctx context.Context, _ json.RawMessage) (any, er
 			"/etc/jabali-panel/postgres.password"},
 	}
 	for _, args := range steps {
-		c := exec.CommandContext(ctx, args[0], args[1:]...)
+		c := execCommandContext(ctx, args[0], args[1:]...)
 		c.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 		if out, err := c.CombinedOutput(); err != nil {
 			// Fail-soft on disable when service already absent; hard

--- a/panel-agent/internal/commands/db_postgres_shadowadmin.go
+++ b/panel-agent/internal/commands/db_postgres_shadowadmin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -79,7 +78,7 @@ END$$;`,
 		pgIdent(roleName), pgStr(password),
 	)
 
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
 		"-v", "ON_ERROR_STOP=1", "-XAtq", "-c", sql)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// Do not echo psql's stderr — it may contain the password.
@@ -107,7 +106,7 @@ END$$;`,
 		pgStr(p.PanelUsername+`\_%`),
 		pgStr(roleName),
 	)
-	cmdGrant := exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql",
+	cmdGrant := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
 		"-v", "ON_ERROR_STOP=1", "-XAtq", "-c", grantSQL)
 	if _, err := cmdGrant.CombinedOutput(); err != nil {
 		// Grants failing isn't fatal — first-time provision before any DB

--- a/panel-agent/internal/commands/db_processlist.go
+++ b/panel-agent/internal/commands/db_processlist.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -61,7 +60,7 @@ func cell(r []string, i int) string {
 func dbProcessListHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	const q = "SELECT Id,User,Host,IFNULL(db,''),Command,Time,IFNULL(State,'')," +
 		"IFNULL(LEFT(Info,200),'') FROM information_schema.PROCESSLIST ORDER BY Time DESC"
-	out, err := exec.CommandContext(ctx, "mysql", "-N", "-B", "-e", q).CombinedOutput()
+	out, err := execCommandContext(ctx, "mysql", "-N", "-B", "-e", q).CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "processlist query failed"}
 	}
@@ -85,7 +84,7 @@ func dbKillHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "id must be a positive integer"}
 	}
-	if err := exec.CommandContext(ctx, "mysql", "-e", fmt.Sprintf("KILL %d", n)).Run(); err != nil {
+	if err := execCommandContext(ctx, "mysql", "-e", fmt.Sprintf("KILL %d", n)).Run(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "kill failed"}
 	}
 	return dbKillResponse{OK: true}, nil
@@ -97,7 +96,7 @@ func dbPostgresActivityHandler(ctx context.Context, _ json.RawMessage) (any, err
 	const q = "SELECT pid, usename, COALESCE(client_addr::text,'local'), COALESCE(datname,''), " +
 		"state, COALESCE(left(query,200),'') FROM pg_stat_activity " +
 		"WHERE pid <> pg_backend_pid() ORDER BY state"
-	cmd := exec.CommandContext(ctx, "sudo", "-u", "postgres", "psql",
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
 		"-v", "ON_ERROR_STOP=1", "-XAtq", "-F", "\t", "-c", q)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/panel-agent/internal/commands/db_restore.go
+++ b/panel-agent/internal/commands/db_restore.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -114,7 +113,7 @@ func dbRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) 
 			"DROP DATABASE IF EXISTS `%s`; CREATE DATABASE `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
 			p.DBName, p.DBName,
 		)
-		reset := exec.CommandContext(ctx, "mysql", "-e", resetSQL)
+		reset := execCommandContext(ctx, "mysql", "-e", resetSQL)
 		if out, err := reset.CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{
 				Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/db_root_password.go
+++ b/panel-agent/internal/commands/db_root_password.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -110,23 +109,23 @@ func dbRootSetPasswordHandler(ctx context.Context, params json.RawMessage) (any,
 	// winning; mysql_native_password as the break-glass backup.
 	// Omitting unix_socket here would silently delete it.
 	alter := mariadbRootAlterPrefix + escapedPw + ")"
-	if err := exec.CommandContext(ctx, "mysql", "-e", alter).Run(); err != nil {
+	if err := execCommandContext(ctx, "mysql", "-e", alter).Run(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "failed to set root password"}
 	}
 
 	// Guard (a): SHOW CREATE USER must still list unix_socket.
-	out, err := exec.CommandContext(ctx, "mysql", "-N", "-B", "-e",
+	out, err := execCommandContext(ctx, "mysql", "-N", "-B", "-e",
 		"SHOW CREATE USER 'root'@'localhost'").CombinedOutput()
 	socketPreserved := err == nil && strings.Contains(string(out), "unix_socket")
 
 	// Guard (b): root must still authenticate over the socket.
-	socketReachable := exec.CommandContext(ctx, "mysql", "--protocol=socket",
+	socketReachable := execCommandContext(ctx, "mysql", "--protocol=socket",
 		"-e", "SELECT 1").Run() == nil
 
 	if !socketPreserved || !socketReachable {
 		// Restore socket-only auth — the safe state the panel + every
 		// root-over-socket consumer (install.sh:1660) depends on.
-		_ = exec.CommandContext(ctx, "mysql", "-e",
+		_ = execCommandContext(ctx, "mysql", "-e",
 			"ALTER USER 'root'@'localhost' IDENTIFIED VIA unix_socket").Run()
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeFailedPrecondition,

--- a/panel-agent/internal/commands/db_size.go
+++ b/panel-agent/internal/commands/db_size.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -36,7 +35,7 @@ var dbSizeNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]{0,63}$`)
 // dbSizeExec runs a size-query command and returns its stdout. Package var so
 // tests can fake DB access (GH #994); production shells out for real.
 var dbSizeExec = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).Output()
+	return execCommandContext(ctx, name, args...).Output()
 }
 
 func dbSizeHandler(ctx context.Context, params json.RawMessage) (any, error) {

--- a/panel-agent/internal/commands/db_usage.go
+++ b/panel-agent/internal/commands/db_usage.go
@@ -11,7 +11,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -39,7 +38,7 @@ func dbUsageBySchemaHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// data_length+index_length lags a little behind reality (InnoDB
 	// persistent stats), which is fine for quota enforcement — the
 	// consumer applies hysteresis anyway.
-	out, err := exec.CommandContext(ctx, "mysql", "-N", "-e",
+	out, err := execCommandContext(ctx, "mysql", "-N", "-e",
 		"SELECT table_schema, COALESCE(SUM(data_length+index_length),0) FROM information_schema.tables GROUP BY table_schema",
 	).Output()
 	if err != nil {

--- a/panel-agent/internal/commands/db_user_create.go
+++ b/panel-agent/internal/commands/db_user_create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -115,7 +114,7 @@ func dbUserCreateHandler(ctx context.Context, params json.RawMessage) (any, erro
 		)
 	}
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	if err := cmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/db_user_drop.go
+++ b/panel-agent/internal/commands/db_user_drop.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -54,7 +53,7 @@ func dbUserDropHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// Form: DROP USER IF EXISTS '<name>'@'localhost';
 	sql := fmt.Sprintf("DROP USER IF EXISTS %s@'localhost'", escapedUsername)
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/db_user_grant.go
+++ b/panel-agent/internal/commands/db_user_grant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -179,7 +178,7 @@ func dbUserGrantHandler(ctx context.Context, params json.RawMessage) (any, error
 	// Issue the GRANT and FLUSH PRIVILEGES in one command.
 	sql := grantSql + "; FLUSH PRIVILEGES"
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	if err := cmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/db_user_revoke.go
+++ b/panel-agent/internal/commands/db_user_revoke.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -116,7 +115,7 @@ func dbUserRevokeHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// Issue the REVOKE and FLUSH PRIVILEGES in one command.
 	sql := revokeSql + "; FLUSH PRIVILEGES"
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/db_user_rotate_password.go
+++ b/panel-agent/internal/commands/db_user_rotate_password.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -73,7 +72,7 @@ func dbUserRotatePasswordHandler(ctx context.Context, params json.RawMessage) (a
 		escapedPassword,
 	)
 
-	cmd := exec.CommandContext(ctx, "mysql", "-e", sql)
+	cmd := execCommandContext(ctx, "mysql", "-e", sql)
 	if err := cmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/db_writes_freeze.go
+++ b/panel-agent/internal/commands/db_writes_freeze.go
@@ -32,7 +32,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -66,7 +65,7 @@ type dbFreezeSnapshot struct {
 // mysqlExec runs mysql with the given SQL; var so tests stub it (GH #994
 // — no test touches the real database).
 var mysqlExec = func(ctx context.Context, sql string) (string, error) {
-	out, err := exec.CommandContext(ctx, "mysql", "-N", "-e", sql).CombinedOutput()
+	out, err := execCommandContext(ctx, "mysql", "-N", "-e", sql).CombinedOutput()
 	return string(out), err
 }
 

--- a/panel-agent/internal/commands/dns_dnssec_disable.go
+++ b/panel-agent/internal/commands/dns_dnssec_disable.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"fmt"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -32,12 +31,12 @@ func dnsDNSSECDisableHandler(ctx context.Context, params json.RawMessage) (any, 
 	// Flush pdns Auth cache so the next query returns un-signed records
 	// (signed answers cached pre-disable would otherwise persist for
 	// cache-ttl seconds, same class of bug as PRs #86/#87).
-	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.DomainName+"$").Run()
+	_ = execCommandContext(ctx, "pdns_control", "purge", p.DomainName+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:
 	// dig still returned old CNAME after panel-edit even after pdns
 	// Auth purge; recursor held the cached forward response).
-	_ = exec.CommandContext(ctx, "rec_control", "wipe-cache", p.DomainName+"$").Run()
+	_ = execCommandContext(ctx, "rec_control", "wipe-cache", p.DomainName+"$").Run()
 	return okBody{Ok: true}, nil
 }
 

--- a/panel-agent/internal/commands/dns_dnssec_enable.go
+++ b/panel-agent/internal/commands/dns_dnssec_enable.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"fmt"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -50,12 +49,12 @@ func dnsDNSSECEnableHandler(ctx context.Context, params json.RawMessage) (any, e
 	// zone reads fresh-DNSSEC-signed records from the backend. Without
 	// this, queries continue to return un-signed answers from cache
 	// until cache-ttl evicts (same class of bug as PRs #86/#87).
-	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.DomainName+"$").Run()
+	_ = execCommandContext(ctx, "pdns_control", "purge", p.DomainName+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:
 	// dig still returned old CNAME after panel-edit even after pdns
 	// Auth purge; recursor held the cached forward response).
-	_ = exec.CommandContext(ctx, "rec_control", "wipe-cache", p.DomainName+"$").Run()
+	_ = execCommandContext(ctx, "rec_control", "wipe-cache", p.DomainName+"$").Run()
 	out := make([]dnsDNSSECKeyOut, 0, len(keys))
 	for _, k := range keys {
 		out = append(out, dnsDNSSECKeyOut{

--- a/panel-agent/internal/commands/dns_zone_delete.go
+++ b/panel-agent/internal/commands/dns_zone_delete.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/pdns"
@@ -38,14 +37,14 @@ func dnsZoneDeleteHandler(ctx context.Context, params json.RawMessage) (any, err
 	// returns the cached-PRE-delete answer for cache-ttl seconds (or
 	// longer if the entry stays hot). Companion fix to dns.zone.upsert
 	// (PR #86 incident: stale CNAME served 3h after edit).
-	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
+	_ = execCommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:
 	// dig still returned old CNAME after panel-edit even after pdns
 	// Auth purge; recursor held the cached forward response).
-	_ = exec.CommandContext(ctx, "rec_control", "wipe-cache", p.Zone+"$").Run()
+	_ = execCommandContext(ctx, "rec_control", "wipe-cache", p.Zone+"$").Run()
 	// NOTIFY so any slaves drop their cached copy.
-	_ = exec.CommandContext(ctx, "pdns_control", "notify", p.Zone).Run()
+	_ = execCommandContext(ctx, "pdns_control", "notify", p.Zone).Run()
 	return dnsZoneDeleteResponse{Zone: p.Zone, Deleted: true}, nil
 }
 

--- a/panel-agent/internal/commands/dns_zone_upsert.go
+++ b/panel-agent/internal/commands/dns_zone_upsert.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/pdns"
@@ -112,13 +111,13 @@ func dnsZoneUpsertHandler(ctx context.Context, params json.RawMessage) (any, err
 	// zones are servable IMMEDIATELY (backend lookup per query, the
 	// pre-4.5 behaviour) and updateZoneCache early-returns, so the crash
 	// path is gone and rediscover has nothing left to do.
-	_ = exec.CommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
+	_ = execCommandContext(ctx, "pdns_control", "purge", p.Zone+"$").Run()
 	// Also wipe pdns-recursor cache — its forward-cached answer
 	// will outlast the Auth purge otherwise (incident 2026-05-21:
 	// dig still returned old CNAME after panel-edit even after pdns
 	// Auth purge; recursor held the cached forward response).
-	_ = exec.CommandContext(ctx, "rec_control", "wipe-cache", p.Zone+"$").Run()
-	_ = exec.CommandContext(ctx, "pdns_control", "notify", p.Zone).Run()
+	_ = execCommandContext(ctx, "rec_control", "wipe-cache", p.Zone+"$").Run()
+	_ = execCommandContext(ctx, "pdns_control", "notify", p.Zone).Run()
 
 	return dnsZoneUpsertResponse{Zone: p.Zone, ZoneID: zoneID, Records: len(recs)}, nil
 }

--- a/panel-agent/internal/commands/docker_app.go
+++ b/panel-agent/internal/commands/docker_app.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -470,7 +469,7 @@ func dockerAppStatusHandler(ctx context.Context, params json.RawMessage) (any, e
 // du(1). One exec, no per-file fork; bounded by the tree walk. Returns
 // an error the caller can ignore (size is advisory, never load-bearing).
 func dirSizeBytes(ctx context.Context, dir string) (int64, error) {
-	out, err := exec.CommandContext(ctx, "du", "-sb", dir).Output()
+	out, err := execCommandContext(ctx, "du", "-sb", dir).Output()
 	if err != nil {
 		return 0, err
 	}
@@ -491,7 +490,7 @@ func dirSizeBytes(ctx context.Context, dir string) (int64, error) {
 // the combined stdout+stderr, plus any exec error.
 func runDockerCompose(ctx context.Context, dir string, args ...string) (string, error) {
 	full := append([]string{"compose"}, args...)
-	cmd := exec.CommandContext(ctx, "docker", full...)
+	cmd := execCommandContext(ctx, "docker", full...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	return string(out), err

--- a/panel-agent/internal/commands/docker_app_backup.go
+++ b/panel-agent/internal/commands/docker_app_backup.go
@@ -62,7 +62,7 @@ func dockerAppBackupHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: eerr.Error()}
 	}
 
-	cmd := exec.CommandContext(ctx, "restic", "backup", dir,
+	cmd := execCommandContext(ctx, "restic", "backup", dir,
 		"--tag", "docker-app",
 		"--tag", "panel-managed",
 		"--tag", "slug:"+p.Slug,
@@ -126,7 +126,7 @@ func dockerAppListBackupsHandler(ctx context.Context, params json.RawMessage) (a
 		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: eerr.Error()}
 	}
 
-	cmd := exec.CommandContext(ctx, "restic", "snapshots",
+	cmd := execCommandContext(ctx, "restic", "snapshots",
 		"--tag", "docker-app",
 		"--tag", "slug:"+p.Slug,
 		"--json")
@@ -224,7 +224,7 @@ func dockerAppRestoreHandler(ctx context.Context, params json.RawMessage) (any, 
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("docker compose down: %v", err)}
 	}
 
-	rc := exec.CommandContext(ctx, "restic", "restore", p.SnapshotID,
+	rc := execCommandContext(ctx, "restic", "restore", p.SnapshotID,
 		"--target", "/",
 		"--include", dir,
 		"--json")

--- a/panel-agent/internal/commands/docker_app_check_update.go
+++ b/panel-agent/internal/commands/docker_app_check_update.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -77,10 +76,10 @@ func dockerAppCheckUpdateHandler(ctx context.Context, params json.RawMessage) (a
 }
 
 func dockerManifestDigest(ctx context.Context, image string) (string, error) {
-	out, err := exec.CommandContext(ctx, "docker", "manifest", "inspect", "--verbose", image).Output()
+	out, err := execCommandContext(ctx, "docker", "manifest", "inspect", "--verbose", image).Output()
 	if err != nil {
 		// Try without --verbose for older docker.
-		out, err = exec.CommandContext(ctx, "docker", "manifest", "inspect", image).Output()
+		out, err = execCommandContext(ctx, "docker", "manifest", "inspect", image).Output()
 		if err != nil {
 			return "", err
 		}
@@ -109,7 +108,7 @@ func dockerManifestDigest(ctx context.Context, image string) (string, error) {
 
 func dockerContainerImageDigest(ctx context.Context, container string) string {
 	// 1. Resolve the image ID the container is running.
-	img, err := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.Image}}", container).Output()
+	img, err := execCommandContext(ctx, "docker", "inspect", "--format", "{{.Image}}", container).Output()
 	if err != nil {
 		return ""
 	}
@@ -119,7 +118,7 @@ func dockerContainerImageDigest(ctx context.Context, container string) string {
 	}
 	// 2. Read RepoDigests off that image. The first one is the
 	// authoritative remote digest.
-	out, err := exec.CommandContext(ctx, "docker", "image", "inspect", "--format", "{{json .RepoDigests}}", imageID).Output()
+	out, err := execCommandContext(ctx, "docker", "image", "inspect", "--format", "{{json .RepoDigests}}", imageID).Output()
 	if err != nil {
 		return ""
 	}

--- a/panel-agent/internal/commands/docker_app_logs_exec.go
+++ b/panel-agent/internal/commands/docker_app_logs_exec.go
@@ -125,7 +125,7 @@ func dockerAppExecHandler(ctx context.Context, params json.RawMessage) (any, err
 	}
 	args = append(args, "sh", "-c", p.Command)
 
-	cmd := exec.CommandContext(ctx, "docker", append([]string{"compose"}, args...)...)
+	cmd := execCommandContext(ctx, "docker", append([]string{"compose"}, args...)...)
 	cmd.Dir = dir
 	stdout, stderr, exitCode := runWithStdoutStderr(cmd)
 	return dockerAppExecResponse{

--- a/panel-agent/internal/commands/docker_app_size_test.go
+++ b/panel-agent/internal/commands/docker_app_size_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestDirSizeBytes_SumsTree(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	dir := t.TempDir()
 	// 3 KiB across two files in a subdir — du counts file data, so assert
 	// a lower bound rather than an exact figure (block rounding + dir
@@ -32,6 +33,7 @@ func TestDirSizeBytes_SumsTree(t *testing.T) {
 }
 
 func TestDirSizeBytes_InstallDirIsPositive(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	// du -sb reports apparent bytes: a truly-empty dir is 0. A real
 	// install dir is never empty though — it always holds compose.yml
 	// (+ .env), so its du is > 0. The reconciler's >0 guard relies on

--- a/panel-agent/internal/commands/docker_app_tenant_validate.go
+++ b/panel-agent/internal/commands/docker_app_tenant_validate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -256,7 +255,7 @@ func isLoopbackHostIP(ip string) bool {
 // `docker compose config --format json` and runs validateTenantCompose.
 // Called by the install handler before `up` when the install is tenant-owned.
 func runTenantComposeValidation(ctx context.Context, dir string, allowedCaps []string, expectedCgroup string) error {
-	cmd := exec.CommandContext(ctx, "docker", "compose", "config", "--format", "json")
+	cmd := execCommandContext(ctx, "docker", "compose", "config", "--format", "json")
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/panel-agent/internal/commands/docker_app_update.go
+++ b/panel-agent/internal/commands/docker_app_update.go
@@ -210,7 +210,7 @@ func resticSnapshotIfConfigured(ctx context.Context, dir, slug string) (string, 
 	if os.Getenv("JABALI_RESTIC_REPO") == "" {
 		return "", fmt.Errorf("JABALI_RESTIC_REPO not set")
 	}
-	cmd := exec.CommandContext(ctx, "restic", "backup", dir,
+	cmd := execCommandContext(ctx, "restic", "backup", dir,
 		"--tag", "docker-app",
 		"--tag", "slug:"+slug,
 		"--tag", "reason:pre-update",

--- a/panel-agent/internal/commands/docker_lifecycle.go
+++ b/panel-agent/internal/commands/docker_lifecycle.go
@@ -36,11 +36,11 @@ func dockerStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	if _, err := exec.LookPath("docker"); err == nil {
 		resp.Installed = true
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "is-active", "docker").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "systemctl", "is-active", "docker").Output(); err == nil {
 		resp.Active = strings.TrimSpace(string(out)) == "active"
 	}
 	if resp.Installed {
-		if out, err := exec.CommandContext(ctx, "docker", "--version").Output(); err == nil {
+		if out, err := execCommandContext(ctx, "docker", "--version").Output(); err == nil {
 			resp.Version = strings.TrimSpace(string(out))
 		}
 	}
@@ -62,7 +62,7 @@ func dockerInstallHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 			Message: fmt.Sprintf("install.sh missing at %s", installShPath),
 		}
 	}
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--pipe", "--wait", "--quiet", "--collect",
 		"--unit=jabali-docker-install",
 		"--service-type=oneshot",
@@ -92,7 +92,7 @@ func dockerDisableHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	} {
 		// Fail-soft: a unit that was never installed returns exit 1
 		// from systemctl; treat that as success.
-		_ = exec.CommandContext(ctx, args[0], args[1:]...).Run()
+		_ = execCommandContext(ctx, args[0], args[1:]...).Run()
 	}
 	return dockerStatusHandler(ctx, nil)
 }
@@ -119,7 +119,7 @@ func dockerDiskUsageHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// `docker system df --format` JSON only landed in 24.x; for
 	// portability parse the plain text. Columns are stable across
 	// docker versions we care about.
-	out, err := exec.CommandContext(ctx, "docker", "system", "df").Output()
+	out, err := execCommandContext(ctx, "docker", "system", "df").Output()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("docker system df: %v", err)}
 	}
@@ -182,7 +182,7 @@ func dockerPruneHandler(ctx context.Context, params json.RawMessage) (any, error
 	if p.Volumes {
 		args = append(args, "--volumes")
 	}
-	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+	out, err := execCommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("docker system prune: %v: %s", err, strings.TrimSpace(string(out)))}
 	}

--- a/panel-agent/internal/commands/docker_tenant_health.go
+++ b/panel-agent/internal/commands/docker_tenant_health.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -36,7 +35,7 @@ func dockerTenantHealthHandler(ctx context.Context, _ json.RawMessage) (any, err
 	if !flagPresent {
 		return dockerTenantHealthResp{}, nil
 	}
-	out, err := exec.CommandContext(ctx, "docker", "info", "--format", "{{json .SecurityOptions}}").Output()
+	out, err := execCommandContext(ctx, "docker", "info", "--format", "{{json .SecurityOptions}}").Output()
 	if err != nil {
 		// Daemon unreachable / restarting — report present, touch nothing.
 		return dockerTenantHealthResp{FlagPresent: true}, nil

--- a/panel-agent/internal/commands/docker_tenant_set.go
+++ b/panel-agent/internal/commands/docker_tenant_set.go
@@ -34,7 +34,7 @@ var dockerTenantExec = func(ctx context.Context) error {
 	} else if _, serr := os.Stat("/usr/local/bin/jabali"); serr == nil {
 		bin = "/usr/local/bin/jabali"
 	}
-	out, err := exec.CommandContext(ctx, bin, "docker", "enable-tenant", "--yes").CombinedOutput()
+	out, err := execCommandContext(ctx, bin, "docker", "enable-tenant", "--yes").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("jabali docker enable-tenant: %v: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/panel-agent/internal/commands/domain_create.go
+++ b/panel-agent/internal/commands/domain_create.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -1181,7 +1180,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	}
 
 	// Test nginx configuration.
-	testCmd := exec.CommandContext(ctx, "nginx", "-t")
+	testCmd := execCommandContext(ctx, "nginx", "-t")
 	var testOutput bytes.Buffer
 	testCmd.Stdout = &testOutput
 	testCmd.Stderr = &testOutput
@@ -1193,7 +1192,7 @@ func writeVhost(ctx context.Context, username, domain, docRoot, phpVersion, redi
 	}
 
 	// Reload nginx.
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOutput bytes.Buffer
 	reloadCmd.Stdout = &reloadOutput
 	reloadCmd.Stderr = &reloadOutput
@@ -1534,7 +1533,7 @@ func writeDefaultIndex(ctx context.Context, path, username, domain, docRoot, cus
 
 	// Chown to <user>:www-data so it matches the docroot's ownership.
 	// Using exec.Command since os.Chown needs numeric IDs we don't have.
-	if err := exec.CommandContext(ctx, "chown", username+":www-data", tmpName).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", username+":www-data", tmpName).Run(); err != nil {
 		return fmt.Errorf("chown: %w", err)
 	}
 

--- a/panel-agent/internal/commands/domain_delete.go
+++ b/panel-agent/internal/commands/domain_delete.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -64,7 +63,7 @@ func domainDeleteHandler(ctx context.Context, params json.RawMessage) (any, erro
 	removeSendmailCredForDomain(p.Domain)
 
 	// Reload nginx
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOutput bytes.Buffer
 	reloadCmd.Stdout = &reloadOutput
 	reloadCmd.Stderr = &reloadOutput

--- a/panel-agent/internal/commands/domain_repair.go
+++ b/panel-agent/internal/commands/domain_repair.go
@@ -44,7 +44,7 @@ func domainRepairFixPermsHandler(ctx context.Context, params json.RawMessage) (a
 	if !domainRepairUserRe.MatchString(p.Username) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid username"}
 	}
-	cmd := exec.CommandContext(ctx, repairBinary, "domain", "fix-perms", p.Username)
+	cmd := execCommandContext(ctx, repairBinary, "domain", "fix-perms", p.Username)
 	out, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
@@ -82,7 +82,7 @@ func domainRepairOrphansHandler(ctx context.Context, params json.RawMessage) (an
 		args = append(args, "--apply")
 	}
 	args = append(args, "--json")
-	cmd := exec.CommandContext(ctx, repairBinary, args...)
+	cmd := execCommandContext(ctx, repairBinary, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		var ee *exec.ExitError

--- a/panel-agent/internal/commands/domain_toggle.go
+++ b/panel-agent/internal/commands/domain_toggle.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -59,7 +58,7 @@ func domainEnableHandler(ctx context.Context, params json.RawMessage) (any, erro
 	}
 
 	// Test nginx configuration
-	testCmd := exec.CommandContext(ctx, "nginx", "-t")
+	testCmd := execCommandContext(ctx, "nginx", "-t")
 	var testOutput bytes.Buffer
 	testCmd.Stdout = &testOutput
 	testCmd.Stderr = &testOutput
@@ -70,7 +69,7 @@ func domainEnableHandler(ctx context.Context, params json.RawMessage) (any, erro
 	}
 
 	// Reload nginx
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOutput bytes.Buffer
 	reloadCmd.Stdout = &reloadOutput
 	reloadCmd.Stderr = &reloadOutput
@@ -113,7 +112,7 @@ func domainDisableHandler(ctx context.Context, params json.RawMessage) (any, err
 	os.Remove(enabledPath)
 
 	// Reload nginx
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOutput bytes.Buffer
 	reloadCmd.Stdout = &reloadOutput
 	reloadCmd.Stderr = &reloadOutput

--- a/panel-agent/internal/commands/domain_whois.go
+++ b/panel-agent/internal/commands/domain_whois.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -55,7 +54,7 @@ func domainWhoisHandler(ctx context.Context, params json.RawMessage) (any, error
 	}
 
 	var out, errb bytes.Buffer
-	cmd := exec.CommandContext(ctx, "whois", "--", domain)
+	cmd := execCommandContext(ctx, "whois", "--", domain)
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	runErr := cmd.Run()

--- a/panel-agent/internal/commands/drupal_install.go
+++ b/panel-agent/internal/commands/drupal_install.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -176,7 +175,7 @@ func installDrushViaComposer(ctx context.Context, osUser, installPath string) er
 	if err := os.MkdirAll(composerHome, 0o755); err != nil {
 		return fmt.Errorf("mkdir composer home: %w", err)
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", osUser+":"+osUser, composerHome).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", osUser+":"+osUser, composerHome).Run(); err != nil {
 		return fmt.Errorf("chown composer home: %w", err)
 	}
 
@@ -192,7 +191,7 @@ func installDrushViaComposer(ctx context.Context, osUser, installPath string) er
 		if err := os.WriteFile(p, data, 0o644); err != nil {
 			return fmt.Errorf("write pinned %s: %w", name, err)
 		}
-		if err := exec.CommandContext(ctx, "chown", osUser+":"+osUser, p).Run(); err != nil {
+		if err := execCommandContext(ctx, "chown", osUser+":"+osUser, p).Run(); err != nil {
 			return fmt.Errorf("chown pinned %s: %w", name, err)
 		}
 	}
@@ -404,7 +403,7 @@ func drupalInstallHandler(ctx context.Context, params json.RawMessage) (any, err
 		// Best-effort cleanup of half-written settings.php so a
 		// re-install attempt isn't blocked.
 		settingsPath := filepath.Join(installPath, "sites", "default", "settings.php")
-		_ = exec.CommandContext(ctx, "rm", "-f", settingsPath).Run()
+		_ = execCommandContext(ctx, "rm", "-f", settingsPath).Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 

--- a/panel-agent/internal/commands/exec_seam.go
+++ b/panel-agent/internal/commands/exec_seam.go
@@ -1,0 +1,18 @@
+package commands
+
+import "os/exec"
+
+// execCommandContext and execCommand are the single exec boundary for every
+// handler in package commands. Production code dispatches straight to os/exec
+// with zero indirection; the test binary replaces these vars in TestMain (see
+// exec_seam_test.go) so a bare `go test ./...` can never mutate the host —
+// no polkit prompts, no systemctl, no rm, no timedatectl. GH #994.
+//
+// Do NOT call exec.Command / exec.CommandContext directly in non-test files;
+// TestExecSeam_NoRawExec enforces that. Use these vars instead — they return
+// the same *exec.Cmd, so .Dir/.Env/.Stdin/.CombinedOutput/.Run/.Start all work
+// unchanged.
+var (
+	execCommandContext = exec.CommandContext
+	execCommand        = exec.Command
+)

--- a/panel-agent/internal/commands/exec_seam_test.go
+++ b/panel-agent/internal/commands/exec_seam_test.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestMain makes the commands test suite structurally incapable of mutating the
+// host. Unless the operator opts into real host mutation
+// (JABALI_ALLOW_HOST_MUTATION=1), every exec routed through the package seam is
+// redirected to a harmless shell stub that drains stdin, emits nothing, and
+// exits 0 — no systemctl, no timedatectl, no rm, no polkit prompt. This is the
+// real cure for GH #994; the per-test requireHostMutationAllowed gates remain as
+// belt-and-suspenders and compose with it (they skip before reaching exec).
+func TestMain(m *testing.M) {
+	if os.Getenv("JABALI_ALLOW_HOST_MUTATION") == "1" {
+		// Integration path: real exec, real host. The per-test gates decide what
+		// actually runs.
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "jabali-exec-stub-")
+	if err != nil {
+		panic("exec seam stub: " + err.Error())
+	}
+	stub := filepath.Join(dir, "noexec")
+	// The stub path is baked into argv (below), NOT into an env marker, so the
+	// 28 handlers that set cmd.Env cannot defeat it. `cat >/dev/null` drains any
+	// piped stdin so handlers that set cmd.Stdin do not see EPIPE.
+	script := "#!/bin/sh\ncat >/dev/null 2>&1\nexit 0\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		panic("exec seam stub: " + err.Error())
+	}
+
+	// Set once, before any test runs → race-free (no testMutex needed).
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, stub, append([]string{name}, args...)...)
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command(stub, append([]string{name}, args...)...)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// withRealExec restores the real os/exec dispatch for the duration of a single
+// NON-PARALLEL test. Use it ONLY for a test that must run a genuinely read-only
+// command (du, id, getent, sshd -t) to be meaningful — the stub's empty output
+// would otherwise break it. NEVER use it for a test that could mutate the host;
+// gate those with requireHostMutationAllowed instead. Safe without a mutex
+// because Go pauses t.Parallel tests until the sequential phase (where these
+// run) completes. GH #994.
+func withRealExec(t *testing.T) {
+	t.Helper()
+	prevCtx, prevCmd := execCommandContext, execCommand
+	execCommandContext = exec.CommandContext
+	execCommand = exec.Command
+	t.Cleanup(func() {
+		execCommandContext = prevCtx
+		execCommand = prevCmd
+	})
+}
+
+// TestExecSeam_NoRawExec keeps the cure durable: no non-test file in package
+// commands may call os/exec directly. New destructive handlers must route
+// through the execCommand / execCommandContext seam, which the stub above
+// neutralizes in tests. GH #994.
+func TestExecSeam_NoRawExec(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	re := regexp.MustCompile(`\bexec\.Command(Context)?\(`)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue // test scaffolding (incl. this file's stub redirect) may use raw exec
+		}
+		if name == "exec_seam.go" {
+			continue // the seam itself defines the vars from os/exec
+		}
+		b, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if loc := re.FindIndex(b); loc != nil {
+			line := 1 + strings.Count(string(b[:loc[0]]), "\n")
+			t.Errorf("%s:%d: raw exec.Command/CommandContext — route through the execCommand/execCommandContext seam instead (GH #994)", name, line)
+		}
+	}
+}

--- a/panel-agent/internal/commands/files_du.go
+++ b/panel-agent/internal/commands/files_du.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -135,7 +134,7 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 // output paths are remapped back onto `canonical` for the caller's lookups.
 func duSubdirSizes(ctx context.Context, dirFd *os.File, canonical string) (map[string]int64, bool) {
 	dirSizes := map[string]int64{}
-	duCmd := exec.CommandContext(ctx, "du", "-b", "-D", "--max-depth=1", "/proc/self/fd/3")
+	duCmd := execCommandContext(ctx, "du", "-b", "-D", "--max-depth=1", "/proc/self/fd/3")
 	duCmd.ExtraFiles = []*os.File{dirFd}
 	out, _ := duCmd.Output()
 	const procPfx = "/proc/self/fd/3"

--- a/panel-agent/internal/commands/files_du_test.go
+++ b/panel-agent/internal/commands/files_du_test.go
@@ -13,6 +13,7 @@ import (
 // The regression it catches — running du without -D — returned the symlink
 // node's own size (~tens of bytes) and no children, so every folder read 0.
 func TestDuSubdirSizes_Recursive(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "alpha"), 0o755); err != nil {
 		t.Fatal(err)

--- a/panel-agent/internal/commands/flarum_install.go
+++ b/panel-agent/internal/commands/flarum_install.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -390,7 +389,7 @@ func flarumInstallHandler(ctx context.Context, params json.RawMessage) (any, err
 
 	if err := runFlarumCLIInstaller(ctx, req.OSUser, installPath, configPath); err != nil {
 		// Best-effort cleanup of a partial config.php so re-install works.
-		_ = exec.CommandContext(ctx, "rm", "-f", filepath.Join(installPath, "config.php")).Run()
+		_ = execCommandContext(ctx, "rm", "-f", filepath.Join(installPath, "config.php")).Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -249,7 +248,7 @@ func ensureFtpGroup(ctx context.Context) *agentwire.AgentError {
 	if _, err := user.LookupGroup(ftpGroupName); err == nil {
 		return nil
 	}
-	if out, err := exec.CommandContext(ctx, "groupadd", "--system", ftpGroupName).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "groupadd", "--system", ftpGroupName).CombinedOutput(); err != nil {
 		return &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: fmt.Sprintf("groupadd %s: %v: %s", ftpGroupName, err, strings.TrimSpace(string(out))),
@@ -263,7 +262,7 @@ func setFtpGroupMembership(ctx context.Context, username string, member bool) *a
 		if aerr := ensureFtpGroup(ctx); aerr != nil {
 			return aerr
 		}
-		if out, err := exec.CommandContext(ctx, "usermod", "-aG", ftpGroupName, username).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "usermod", "-aG", ftpGroupName, username).CombinedOutput(); err != nil {
 			return &agentwire.AgentError{
 				Code:    agentwire.CodeInternal,
 				Message: fmt.Sprintf("usermod -aG %s %s: %v: %s", ftpGroupName, username, err, strings.TrimSpace(string(out))),
@@ -275,7 +274,7 @@ func setFtpGroupMembership(ctx context.Context, username string, member bool) *a
 	if err != nil || !isMember {
 		return nil // absent group or non-member: removal is a no-op
 	}
-	if out, gerr := exec.CommandContext(ctx, "gpasswd", "-d", username, ftpGroupName).CombinedOutput(); gerr != nil {
+	if out, gerr := execCommandContext(ctx, "gpasswd", "-d", username, ftpGroupName).CombinedOutput(); gerr != nil {
 		return &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: fmt.Sprintf("gpasswd -d %s %s: %v: %s", username, ftpGroupName, gerr, strings.TrimSpace(string(out))),
@@ -287,7 +286,7 @@ func setFtpGroupMembership(ctx context.Context, username string, member bool) *a
 // chpasswdStdin sets a password via chpasswd's stdin — the password must
 // never appear in argv (visible in /proc) or logs.
 func chpasswdStdin(ctx context.Context, username, password string) *agentwire.AgentError {
-	cmd := exec.CommandContext(ctx, "chpasswd")
+	cmd := execCommandContext(ctx, "chpasswd")
 	cmd.Stdin = strings.NewReader(username + ":" + password + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return &agentwire.AgentError{
@@ -418,14 +417,14 @@ func ftpAccountCreateHandler(ctx context.Context, params json.RawMessage) (any, 
 		"--comment", ftpAliasGecosFor(tenant.Username),
 		p.Username,
 	}
-	if out, err := exec.CommandContext(ctx, "useradd", args...).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "useradd", args...).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("useradd %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
 	}
 	rollback := func() {
 		// -f: the alias shares the tenant's uid, so the tenant's own
 		// processes (FPM pool, cron) always count as "user in use" and a
 		// plain userdel exits 8. Never --remove: home is tenant data.
-		_ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run()
+		_ = execCommandContext(ctx, "userdel", "-f", p.Username).Run()
 	}
 	// Home must exist for vsftpd chroot + internal-sftp start dir, owned
 	// by the tenant uid like every other node in their tree.
@@ -486,7 +485,7 @@ func lockAfterPasswordReset(enabled *bool, wasLocked bool) bool {
 // -S` prints "<user> <status> ..." where status is L (locked), P/PS (usable),
 // or NP (no password). Field 2 is the status.
 func ftpUserLocked(ctx context.Context, username string) (bool, *agentwire.AgentError) {
-	out, err := exec.CommandContext(ctx, "passwd", "-S", username).CombinedOutput()
+	out, err := execCommandContext(ctx, "passwd", "-S", username).CombinedOutput()
 	if err != nil {
 		return false, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("passwd -S %q: %v: %s", username, err, strings.TrimSpace(string(out)))}
 	}
@@ -530,7 +529,7 @@ func ftpAccountSetPasswordHandler(ctx context.Context, params json.RawMessage) (
 	// Re-apply the shadow lock in the SAME verb (no reliance on the periodic
 	// reconciler) so a disabled account cannot authenticate in the window.
 	if lockAfterPasswordReset(p.Enabled, wasLocked) {
-		if out, err := exec.CommandContext(ctx, "usermod", "-L", p.Username).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "usermod", "-L", p.Username).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("re-lock disabled account %q after password reset: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
 		}
 		// JAB-256: a reset on a disabled account must not leave a live session
@@ -573,7 +572,7 @@ func ftpAccountSetAccessHandler(ctx context.Context, params json.RawMessage) (an
 	if !p.Enabled {
 		lockFlag = "-L"
 	}
-	if out, err := exec.CommandContext(ctx, "usermod", lockFlag, p.Username).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "usermod", lockFlag, p.Username).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod %s %q: %v: %s", lockFlag, p.Username, err, strings.TrimSpace(string(out)))}
 	}
 	// JAB-256: the lock blocks re-auth but not an already-open session — kill
@@ -632,7 +631,7 @@ func ftpAccountDeleteHandler(ctx context.Context, params json.RawMessage) (any, 
 	// (exit 8) — proven live on jabalitests. -f overrides only the in-use
 	// check; home removal stays off (NEVER --remove: the home dir is a
 	// live tenant directory, usually a docroot).
-	if out, err := exec.CommandContext(ctx, "userdel", "-f", p.Username).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "userdel", "-f", p.Username).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("userdel %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))}
 	}
 	// Isolated account: unmount + remove its jail AFTER the user is gone. The
@@ -689,7 +688,7 @@ func ftpAccountListHandler(ctx context.Context, params json.RawMessage) (any, er
 		name := parts[0]
 		isFtp, _ := isUserInGroup(ctx, name, ftpGroupName)
 		locked := false
-		if out, perr := exec.CommandContext(ctx, "passwd", "-S", name).Output(); perr == nil {
+		if out, perr := execCommandContext(ctx, "passwd", "-S", name).Output(); perr == nil {
 			fields := strings.Fields(string(out))
 			locked = len(fields) >= 2 && fields[1] == "L"
 		}
@@ -760,7 +759,7 @@ func ftpAccountLockTenantHandler(ctx context.Context, params json.RawMessage) (a
 	locked := 0
 	for _, name := range names {
 		_ = setFtpGroupMembership(ctx, name, false)
-		if out, err := exec.CommandContext(ctx, "usermod", "-L", name).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "usermod", "-L", name).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("usermod -L %q: %v: %s", name, err, strings.TrimSpace(string(out)))}
 		}
 		// JAB-256: a suspended owner's delegated sessions must drop at once,
@@ -892,7 +891,7 @@ func ftpAccountListAllHandler(ctx context.Context, params json.RawMessage) (any,
 	entries, skipped := classifyFtpAliases(string(passwd))
 	for i := range entries {
 		locked := false
-		if out, perr := exec.CommandContext(ctx, "passwd", "-S", entries[i].Username).Output(); perr == nil {
+		if out, perr := execCommandContext(ctx, "passwd", "-S", entries[i].Username).Output(); perr == nil {
 			fields := strings.Fields(string(out))
 			locked = len(fields) >= 2 && fields[1] == "L"
 		}

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -197,10 +196,10 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 		"--comment", ftpAliasGecosFor(tenant.Username),
 		p.Username,
 	}
-	if out, err := exec.CommandContext(ctx, "useradd", useraddArgs...).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "useradd", useraddArgs...).CombinedOutput(); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("useradd (isolated) %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))})
 	}
-	undo = append(undo, func() { _ = exec.CommandContext(ctx, "userdel", "-f", p.Username).Run() })
+	undo = append(undo, func() { _ = execCommandContext(ctx, "userdel", "-f", p.Username).Run() })
 
 	// 4. ACLs on the JAIL-SIDE mountpoint (never the tenant pathname). The jail
 	// chain is root-owned so the argument cannot be swapped, and the mount has
@@ -211,16 +210,16 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	// already applicable (dirs / already-exec files). GNU setfacl -R skips
 	// symlinks encountered during recursion by default.
 	spec := fmt.Sprintf("u:%d:rwX,u:%d:rwX", p.UID, tenant.UID)
-	if out, err := exec.CommandContext(ctx, "setfacl", "-R", "-m", spec, mountpoint).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "setfacl", "-R", "-m", spec, mountpoint).CombinedOutput(); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -R %q: %v: %s", mountpoint, err, strings.TrimSpace(string(out)))})
 	}
-	if out, err := exec.CommandContext(ctx, "setfacl", "-dR", "-m", spec, mountpoint).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "setfacl", "-dR", "-m", spec, mountpoint).CombinedOutput(); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setfacl -dR %q: %v: %s", mountpoint, err, strings.TrimSpace(string(out)))})
 	}
 
 	// 5. Per-uid quota (the split cap). setquota block counts are 1KB units.
 	blocks := strconv.FormatUint(uint64(p.QuotaMB)*1024, 10)
-	if out, err := exec.CommandContext(ctx, "setquota", "-u", p.Username, blocks, blocks, "0", "0", p.QuotaMount).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "setquota", "-u", p.Username, blocks, blocks, "0", "0", p.QuotaMount).CombinedOutput(); err != nil {
 		return fail(&agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("setquota (isolated) %q: %v: %s", p.Username, err, strings.TrimSpace(string(out)))})
 	}
 

--- a/panel-agent/internal/commands/ftp_account_sessions.go
+++ b/panel-agent/internal/commands/ftp_account_sessions.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"os/exec"
 	"strconv"
 )
 
@@ -42,9 +41,9 @@ func ftpSshdSessionPattern(alias string) string {
 func terminateFtpSessions(ctx context.Context, aliasName string, aliasUID int) {
 	if aliasUID >= ftpSubaccountUIDMin {
 		uid := strconv.Itoa(aliasUID)
-		_ = exec.CommandContext(ctx, "loginctl", "terminate-user", uid).Run()
-		_ = exec.CommandContext(ctx, "pkill", "-KILL", "-u", uid).Run()
+		_ = execCommandContext(ctx, "loginctl", "terminate-user", uid).Run()
+		_ = execCommandContext(ctx, "pkill", "-KILL", "-u", uid).Run()
 		return
 	}
-	_ = exec.CommandContext(ctx, "pkill", "-KILL", "-f", ftpSshdSessionPattern(aliasName)).Run()
+	_ = execCommandContext(ctx, "pkill", "-KILL", "-f", ftpSshdSessionPattern(aliasName)).Run()
 }

--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -170,7 +169,7 @@ func ftpSSHDSyncHandler(ctx context.Context, params json.RawMessage) (any, error
 	// sshd -t validates main config + every drop-in. On failure restore
 	// the previous content — a broken sshd config is a host lockout.
 	if os.Getenv("JABALI_SSHD_TEST_SKIP_VALIDATE") == "" {
-		if out, err := exec.CommandContext(ctx, "sshd", "-t").CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "sshd", "-t").CombinedOutput(); err != nil {
 			restoreFile(path, prev)
 			return nil, fmt.Errorf("sshd -t validation failed: %s: %w", strings.TrimSpace(string(out)), err)
 		}
@@ -180,7 +179,7 @@ func ftpSSHDSyncHandler(ctx context.Context, params json.RawMessage) (any, error
 		if unit == "" {
 			return nil, fmt.Errorf("no ssh/sshd systemd unit found")
 		}
-		if out, err := exec.CommandContext(ctx, "systemctl", "reload", unit).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "systemctl", "reload", unit).CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("systemctl reload %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 		}
 	}

--- a/panel-agent/internal/commands/hostname_free_apply.go
+++ b/panel-agent/internal/commands/hostname_free_apply.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -95,13 +94,13 @@ func hostnameFreeApplyHandler(ctx context.Context, params json.RawMessage) (any,
 
 	// Enable the heartbeat timer (best-effort; skipped in test env).
 	if os.Getenv("JABALI_HOSTNAME_SKIP_SYSTEMD") == "" {
-		_ = exec.CommandContext(ctx, "systemctl", "enable", "--now", "jabali-hostname-heartbeat.timer").Run()
+		_ = execCommandContext(ctx, "systemctl", "enable", "--now", "jabali-hostname-heartbeat.timer").Run()
 		// Background wildcard-cert issuance. Detached so the settings PATCH
 		// returns promptly; the panel-cert reconciler is the backstop for
 		// <label> if this run is slow or fails.
 		certScript := "/usr/local/libexec/jabali/jabali-hostname-cert.sh"
 		if _, err := os.Stat(certScript); err == nil {
-			cmd := exec.Command(certScript)
+			cmd := execCommand(certScript)
 			cmd.Env = os.Environ()
 			_ = cmd.Start()
 		}

--- a/panel-agent/internal/commands/ip_bind.go
+++ b/panel-agent/internal/commands/ip_bind.go
@@ -130,7 +130,7 @@ func ipBindHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	}
 
 	cidr := fmt.Sprintf("%s/%d", req.Address, prefix)
-	cmd := exec.CommandContext(ctx, "ip", "addr", "add", cidr, "dev", iface)
+	cmd := execCommandContext(ctx, "ip", "addr", "add", cidr, "dev", iface)
 	stderr, err := runCaptureStderr(cmd)
 	if err != nil {
 		return nil, &agentwire.AgentError{
@@ -192,7 +192,7 @@ func defaultRouteInterface(ctx context.Context, isV4 bool) (string, error) {
 	if !isV4 {
 		args = []string{"-j", "-6", "route", "show", "default"}
 	}
-	out, err := exec.CommandContext(ctx, "ip", args...).Output()
+	out, err := execCommandContext(ctx, "ip", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("ip %v: %w", args, err)
 	}

--- a/panel-agent/internal/commands/ip_list.go
+++ b/panel-agent/internal/commands/ip_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -43,7 +42,7 @@ type ipAddrShowJSON struct {
 }
 
 func ipListHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	out, err := exec.CommandContext(ctx, "ip", "-j", "addr", "show").Output()
+	out, err := execCommandContext(ctx, "ip", "-j", "addr", "show").Output()
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/ip_unbind.go
+++ b/panel-agent/internal/commands/ip_unbind.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -73,7 +72,7 @@ func ipUnbindHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	}
 
 	cidr := fmt.Sprintf("%s/%d", req.Address, prefix)
-	stderr, err := runCaptureStderr(exec.CommandContext(ctx, "ip", "addr", "del", cidr, "dev", iface))
+	stderr, err := runCaptureStderr(execCommandContext(ctx, "ip", "addr", "del", cidr, "dev", iface))
 	if err != nil {
 		if isAddressMissing(stderr) {
 			// Operator-supplied interface didn't actually hold the
@@ -86,7 +85,7 @@ func ipUnbindHandler(ctx context.Context, params json.RawMessage) (any, error) {
 					if e.Address == req.Address && e.Interface != iface {
 						iface = e.Interface
 						cidr = fmt.Sprintf("%s/%d", req.Address, prefix)
-						stderr, err = runCaptureStderr(exec.CommandContext(ctx, "ip", "addr", "del", cidr, "dev", iface))
+						stderr, err = runCaptureStderr(execCommandContext(ctx, "ip", "addr", "del", cidr, "dev", iface))
 						break
 					}
 				}

--- a/panel-agent/internal/commands/itflow_install.go
+++ b/panel-agent/internal/commands/itflow_install.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -113,7 +112,7 @@ func cloneITFlow(ctx context.Context, osUser, installPath, branch, pin string) e
 	defer os.RemoveAll(stagingDir)
 	src := filepath.Join(stagingDir, "itflow")
 	// chown staging to the user so the as-user clone can write there.
-	if err := exec.CommandContext(ctx, "chown", "-R", osUser+":"+osUser, stagingDir).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", osUser+":"+osUser, stagingDir).Run(); err != nil {
 		return fmt.Errorf("chown staging: %w", err)
 	}
 	// Full clone (no --depth) so the reviewed pinned commit is reachable even

--- a/panel-agent/internal/commands/joomla_install.go
+++ b/panel-agent/internal/commands/joomla_install.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -290,7 +289,7 @@ func joomlaInstallHandler(ctx context.Context, params json.RawMessage) (any, err
 		// Best-effort cleanup so re-install isn't blocked. Don't remove
 		// installation/ here — the user may want to retry the web
 		// installer manually for diagnostics.
-		_ = exec.CommandContext(ctx, "rm", "-f", filepath.Join(installPath, "configuration.php")).Run()
+		_ = execCommandContext(ctx, "rm", "-f", filepath.Join(installPath, "configuration.php")).Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 

--- a/panel-agent/internal/commands/login_allowlist_watcher.go
+++ b/panel-agent/internal/commands/login_allowlist_watcher.go
@@ -173,11 +173,11 @@ func loginTailCmd(ctx context.Context) *exec.Cmd {
 	if _, err := exec.LookPath("journalctl"); err == nil {
 		// --since now avoids re-scanning historical log on every restart (a busy
 		// host would otherwise re-allowlist churn on each boot).
-		return exec.CommandContext(ctx, "journalctl",
+		return execCommandContext(ctx, "journalctl",
 			"-u", "ssh.service", "-u", "sshd.service",
 			"-f", "-n", "0", "--since", "now", "-o", "cat")
 	}
-	return exec.CommandContext(ctx, "tail", "-F", "/var/log/auth.log")
+	return execCommandContext(ctx, "tail", "-F", "/var/log/auth.log")
 }
 
 // handleSSHLogLine parses one log line and, on a successful-login match for a

--- a/panel-agent/internal/commands/mail_admin_cred.go
+++ b/panel-agent/internal/commands/mail_admin_cred.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"syscall"
 	"time"
@@ -45,7 +44,7 @@ const stalwartRecoveryAdminKey = "STALWART_RECOVERY_ADMIN="
 // restartServiceFunc / scheduleRestartFunc are vars so tests don't shell out.
 var (
 	restartServiceFunc = func(ctx context.Context, unit string) error {
-		out, err := exec.CommandContext(ctx, "systemctl", "restart", unit).CombinedOutput()
+		out, err := execCommandContext(ctx, "systemctl", "restart", unit).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("systemctl restart %s: %v: %s", unit, err, strings.TrimSpace(string(out)))
 		}
@@ -54,7 +53,7 @@ var (
 	// scheduleRestartFunc bounces a unit a few seconds in the future via a
 	// transient systemd unit, so the caller's response is delivered first.
 	scheduleRestartFunc = func(ctx context.Context, unit string) error {
-		out, err := exec.CommandContext(ctx, "systemd-run", "--quiet", "--collect",
+		out, err := execCommandContext(ctx, "systemd-run", "--quiet", "--collect",
 			"--on-active=3s", "systemctl", "restart", unit).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("systemd-run restart %s: %v: %s", unit, err, strings.TrimSpace(string(out)))

--- a/panel-agent/internal/commands/mail_queue.go
+++ b/panel-agent/internal/commands/mail_queue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -106,7 +105,7 @@ func runStalwartCLI(ctx context.Context, args ...string) ([]byte, error) {
 	if err != nil {
 		return nil, csInternal("stalwart-admin token unreadable", err)
 	}
-	cmd := exec.CommandContext(ctx, "stalwart-cli", args...)
+	cmd := execCommandContext(ctx, "stalwart-cli", args...)
 	cmd.Env = append(os.Environ(),
 		"STALWART_URL="+stalwartAdminURLFunc(),
 		"STALWART_USER="+jmapAdminUser,

--- a/panel-agent/internal/commands/mail_webadmin.go
+++ b/panel-agent/internal/commands/mail_webadmin.go
@@ -226,7 +226,7 @@ func ufwSetWebadminPort(ctx context.Context, port int, open bool) {
 	if open {
 		args = []string{"allow", rule}
 	}
-	_ = exec.CommandContext(ctx, "ufw", args...).Run()
+	_ = execCommandContext(ctx, "ufw", args...).Run()
 }
 
 // stalwartAdminUFWPort is used by the close path when no port is supplied.

--- a/panel-agent/internal/commands/malware_active_scans.go
+++ b/panel-agent/internal/commands/malware_active_scans.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"strings"
 )
 
@@ -18,7 +17,7 @@ type activeScansResponse struct {
 }
 
 func malwareActiveScansHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	out, err := exec.CommandContext(ctx, "systemctl",
+	out, err := execCommandContext(ctx, "systemctl",
 		"list-units", "jabali-maldet-scan-*.service",
 		"--state=active", "--no-legend", "--plain", "--no-pager",
 	).Output()

--- a/panel-agent/internal/commands/mediawiki_install.go
+++ b/panel-agent/internal/commands/mediawiki_install.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -332,7 +331,7 @@ func mediawikiInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 		// Best-effort cleanup so a re-install attempt isn't blocked by
 		// the half-extracted tree. Caller already marks the install
 		// row "failed"; this just clears the disk side.
-		cleanCmd := exec.CommandContext(ctx, "rm", "-rf", filepath.Join(installPath, "LocalSettings.php"))
+		cleanCmd := execCommandContext(ctx, "rm", "-rf", filepath.Join(installPath, "LocalSettings.php"))
 		_ = cleanCmd.Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}

--- a/panel-agent/internal/commands/migration_admin_run.go
+++ b/panel-agent/internal/commands/migration_admin_run.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -151,7 +150,7 @@ func migrationSecretsWriteHandler(_ context.Context, raw json.RawMessage) (any, 
 	// Best-effort group ownership so the panel-api can read the
 	// file (root:jabali 0640). Failure is non-fatal — rotate path
 	// fires the same chown on jabali update.
-	_ = exec.Command("chown", "root:jabali", target).Run()
+	_ = execCommand("chown", "root:jabali", target).Run()
 	return map[string]string{"path": target}, nil
 }
 
@@ -184,8 +183,8 @@ func migrationPullSourceRunHandler(ctx context.Context, raw json.RawMessage) (an
 	// Stop any still-running prior attempt + reset failed-state so the
 	// transient unit name is free. Both best-effort; systemd-run below
 	// is the gate that actually errors if the unit can't be created.
-	_ = exec.CommandContext(ctx, "systemctl", "stop", "--quiet", unit).Run()
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "stop", "--quiet", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", unit).Run()
 	startedAt := time.Now().UTC()
 	pullArgs := []string{
 		"--unit=" + unit,
@@ -198,7 +197,7 @@ func migrationPullSourceRunHandler(ctx context.Context, raw json.RawMessage) (an
 		"--job-id="+p.JobID,
 		"--ssh-user="+sshUser,
 	)
-	cmd := exec.CommandContext(ctx, "systemd-run", pullArgs...)
+	cmd := execCommandContext(ctx, "systemd-run", pullArgs...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemd-run: %v: %s", err, string(out))}
@@ -233,10 +232,10 @@ func migrationImportWPRunHandler(ctx context.Context, raw json.RawMessage) (any,
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "dest_domain invalid"}
 	}
 	unit := fmt.Sprintf("jabali-migrate-importwp-%s.service", p.JobID)
-	_ = exec.CommandContext(ctx, "systemctl", "stop", "--quiet", unit).Run()
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "stop", "--quiet", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", unit).Run()
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--unit="+unit, "--no-block", "--collect",
 		"/usr/local/bin/jabali", "migrate", "import-wp",
 		"--job-id="+p.JobID, "--dest-user="+p.DestUser, "--dest-domain="+p.DestDomain,
@@ -333,9 +332,9 @@ func migrationImportRunHandler(ctx context.Context, raw json.RawMessage) (any, e
 	}
 	args := importSystemdRunArgs(p.JobID, p.TargetUser, runProps, cmdOpts)
 	unit := fmt.Sprintf("jabali-migrate-import-%s.service", p.JobID)
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", unit).Run()
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run", args...)
+	cmd := execCommandContext(ctx, "systemd-run", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemd-run: %v: %s", err, string(out))}

--- a/panel-agent/internal/commands/migration_http_probe.go
+++ b/panel-agent/internal/commands/migration_http_probe.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -53,7 +52,7 @@ var probeDomainRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,62}\.)+[a-z]{2,63}
 // vhosts bind a managed IP (M24), not 127.0.0.1, so resolving to loopback
 // gets connection-refused. Computed once.
 var probeTargetIP = func() string {
-	out, err := exec.Command("ip", "-4", "route", "get", "1.1.1.1").Output()
+	out, err := execCommand("ip", "-4", "route", "get", "1.1.1.1").Output()
 	if err == nil {
 		// "1.1.1.1 via X dev Y src <IP> ..." — take the token after "src".
 		fields := strings.Fields(string(out))
@@ -67,7 +66,7 @@ var probeTargetIP = func() string {
 	// VM) previously fell through to 127.0.0.1, which every managed-IP vhost
 	// (M24 `listen <IP>:443`) refuses → false connection-refused. Fall back to
 	// the first non-loopback global IPv4 instead.
-	if hi, herr := exec.Command("hostname", "-I").Output(); herr == nil {
+	if hi, herr := execCommand("hostname", "-I").Output(); herr == nil {
 		for _, tok := range strings.Fields(string(hi)) {
 			if strings.Contains(tok, ".") && !strings.HasPrefix(tok, "127.") {
 				return tok
@@ -107,7 +106,7 @@ var runProbeCurl = func(ctx context.Context, domain, ip string) int {
 		"--resolve", domain + ":80:" + ip,
 		"https://" + domain + "/",
 	}
-	out, _ := exec.CommandContext(ctx, "curl", args...).Output()
+	out, _ := execCommandContext(ctx, "curl", args...).Output()
 	code, _ := strconv.Atoi(strings.TrimSpace(string(out)))
 	return code // 0 on connection failure / timeout
 }

--- a/panel-agent/internal/commands/migration_imapsync.go
+++ b/panel-agent/internal/commands/migration_imapsync.go
@@ -145,7 +145,7 @@ func migrationImapsyncHandler(ctx context.Context, raw json.RawMessage) (any, er
 	subctx, cancel := context.WithTimeout(ctx, migrationImapsyncTimeout)
 	defer cancel()
 	start := time.Now()
-	cmd := exec.CommandContext(subctx, migrationImapsyncBinary, args...)
+	cmd := execCommandContext(subctx, migrationImapsyncBinary, args...)
 	out, err := cmd.CombinedOutput()
 	dur := int64(time.Since(start).Seconds())
 	if err != nil {

--- a/panel-agent/internal/commands/migration_import_home.go
+++ b/panel-agent/internal/commands/migration_import_home.go
@@ -31,7 +31,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -271,7 +270,7 @@ func migrationImportHomeHandler(ctx context.Context, raw json.RawMessage) (any, 
 	srcWithSlash := strings.TrimRight(srcAbs, "/") + "/"
 	args = append(args, srcWithSlash, dest)
 
-	cmd := exec.CommandContext(subctx, "rsync", args...)
+	cmd := execCommandContext(subctx, "rsync", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{
@@ -315,8 +314,8 @@ func migrationImportHomeHandler(ctx context.Context, raw json.RawMessage) (any, 
 	// (in the www-data group) can traverse + read. Same trick the
 	// install.sh user-create script + reconciler use on fresh
 	// /home/<user>/ trees.
-	_ = exec.CommandContext(subctx, "find", chownTarget, "-type", "d", "-exec", "chmod", "g+rx", "{}", "+").Run()
-	_ = exec.CommandContext(subctx, "find", chownTarget, "-type", "f", "-exec", "chmod", "g+r", "{}", "+").Run()
+	_ = execCommandContext(subctx, "find", chownTarget, "-type", "d", "-exec", "chmod", "g+rx", "{}", "+").Run()
+	_ = execCommandContext(subctx, "find", chownTarget, "-type", "f", "-exec", "chmod", "g+r", "{}", "+").Run()
 
 	return migrationImportHomeResult{
 		BytesCopied: bytesCopied,

--- a/panel-agent/internal/commands/migration_refresh.go
+++ b/panel-agent/internal/commands/migration_refresh.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -77,7 +76,7 @@ func migrationRefreshBackupHandler(ctx context.Context, raw json.RawMessage) (an
 	if _, sErr := os.Stat(snapshot); sErr == nil {
 		return nil, csInvalidArg("snapshot already exists: " + snapshot)
 	}
-	if out, cErr := exec.CommandContext(ctx, "cp", "-al", docroot, snapshot).CombinedOutput(); cErr != nil {
+	if out, cErr := execCommandContext(ctx, "cp", "-al", docroot, snapshot).CombinedOutput(); cErr != nil {
 		return nil, csInternal("docroot snapshot", fmt.Errorf("%v: %s", cErr, string(out)))
 	}
 	dumpPath := filepath.Join(filepath.Dir(docroot), "pre-refresh-"+p.Stamp+".sql")
@@ -86,7 +85,7 @@ func migrationRefreshBackupHandler(ctx context.Context, raw json.RawMessage) (an
 		return nil, csInternal("create dump", fErr)
 	}
 	defer f.Close()
-	dump := exec.CommandContext(ctx, "mysqldump", "--single-transaction", "--quick", "--lock-tables=0", "--", p.DBName)
+	dump := execCommandContext(ctx, "mysqldump", "--single-transaction", "--quick", "--lock-tables=0", "--", p.DBName)
 	dump.Stdout = f
 	if dErr := dump.Run(); dErr != nil {
 		_ = os.Remove(dumpPath)
@@ -129,10 +128,10 @@ func migrationRefreshFilesHandler(ctx context.Context, raw json.RawMessage) (any
 		args = append(args, "--exclude="+ex)
 	}
 	args = append(args, src+"/", docroot+"/")
-	if out, rErr := exec.CommandContext(ctx, "rsync", args...).CombinedOutput(); rErr != nil {
+	if out, rErr := execCommandContext(ctx, "rsync", args...).CombinedOutput(); rErr != nil {
 		return nil, csInternal("rsync mirror", fmt.Errorf("%v: %s", rErr, string(out)))
 	}
-	if out, cErr := exec.CommandContext(ctx, "chown", "-R", p.OSUser+":www-data", docroot).CombinedOutput(); cErr != nil {
+	if out, cErr := execCommandContext(ctx, "chown", "-R", p.OSUser+":www-data", docroot).CombinedOutput(); cErr != nil {
 		return nil, csInternal("chown docroot", fmt.Errorf("%v: %s", cErr, string(out)))
 	}
 	return map[string]any{"ok": true}, nil
@@ -161,7 +160,7 @@ func migrationRefreshDBHandler(ctx context.Context, raw json.RawMessage) (any, e
 	if fi, sErr := os.Stat(sql); sErr != nil || fi.IsDir() {
 		return nil, csInvalidArg("sql dump not found")
 	}
-	tblOut, tErr := exec.CommandContext(ctx, "mysql", "-N", "-e", "SHOW TABLES", "--", p.DBName).Output()
+	tblOut, tErr := execCommandContext(ctx, "mysql", "-N", "-e", "SHOW TABLES", "--", p.DBName).Output()
 	if tErr != nil {
 		return nil, csInternal("list dest tables", tErr)
 	}
@@ -173,7 +172,7 @@ func migrationRefreshDBHandler(ctx context.Context, raw json.RawMessage) (any, e
 		}
 	}
 	drop.WriteString("SET FOREIGN_KEY_CHECKS=1;\n")
-	dropCmd := exec.CommandContext(ctx, "mysql", "--", p.DBName)
+	dropCmd := execCommandContext(ctx, "mysql", "--", p.DBName)
 	dropCmd.Stdin = strings.NewReader(drop.String())
 	if out, dErr := dropCmd.CombinedOutput(); dErr != nil {
 		return nil, csInternal("drop dest tables", fmt.Errorf("%v: %s", dErr, string(out)))
@@ -183,7 +182,7 @@ func migrationRefreshDBHandler(ctx context.Context, raw json.RawMessage) (any, e
 		return nil, csInternal("open dump", fErr)
 	}
 	defer f.Close()
-	imp := exec.CommandContext(ctx, "mysql", "--", p.DBName)
+	imp := execCommandContext(ctx, "mysql", "--", p.DBName)
 	imp.Stdin = f
 	if out, iErr := imp.CombinedOutput(); iErr != nil {
 		return nil, csInternal("reimport dump", fmt.Errorf("%v: %s", iErr, string(out)))
@@ -238,7 +237,7 @@ func migrationRefreshReconcileHandler(ctx context.Context, raw json.RawMessage) 
 	// 2. Flush WP object cache.
 	_ = runWPAsTenant(ctx, p.OSUser, p.InstallPath, "cache", "flush")
 	// 3. Reload the per-user FPM master (drop stale opcache).
-	_ = exec.CommandContext(ctx, "systemctl", "reload", "jabali-fpm@"+p.OSUser+".service").Run()
+	_ = execCommandContext(ctx, "systemctl", "reload", "jabali-fpm@"+p.OSUser+".service").Run()
 	// 4. Purge the nginx page cache for the domain (best-effort; targeted unlink).
 	if refreshDomainRE.MatchString(strings.ToLower(p.Domain)) {
 		cacheDir := "/var/cache/nginx/jabali"

--- a/panel-agent/internal/commands/migration_rsync_remote_home.go
+++ b/panel-agent/internal/commands/migration_rsync_remote_home.go
@@ -263,10 +263,10 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 	if sshPass != "" {
 		// sshpass-prefixed invocation. -e reads SSHPASS from env so the
 		// password never lands in ps argv.
-		cmd = exec.CommandContext(subctx, "sshpass", append([]string{"-e", "rsync"}, rsyncArgs...)...)
+		cmd = execCommandContext(subctx, "sshpass", append([]string{"-e", "rsync"}, rsyncArgs...)...)
 		cmd.Env = append(os.Environ(), "SSHPASS="+sshPass)
 	} else {
-		cmd = exec.CommandContext(subctx, "rsync", rsyncArgs...)
+		cmd = execCommandContext(subctx, "rsync", rsyncArgs...)
 	}
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
@@ -287,14 +287,14 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition,
 			Message: fmt.Sprintf("dest_user %q not found: %v", p.DestUser, ulkErr)}
 	}
-	chown := exec.CommandContext(subctx, "chown", "-R",
+	chown := execCommandContext(subctx, "chown", "-R",
 		fmt.Sprintf("%d:%d", uid, gid), p.DestPath)
 	if cout, cerr := chown.CombinedOutput(); cerr != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal,
 			Message: fmt.Sprintf("chown: %v: %s", cerr, truncate(string(cout), 1024))}
 	}
-	_ = exec.CommandContext(subctx, "find", p.DestPath, "-type", "d", "-exec", "chmod", "g+rx", "{}", "+").Run()
-	_ = exec.CommandContext(subctx, "find", p.DestPath, "-type", "f", "-exec", "chmod", "g+r", "{}", "+").Run()
+	_ = execCommandContext(subctx, "find", p.DestPath, "-type", "d", "-exec", "chmod", "g+rx", "{}", "+").Run()
+	_ = execCommandContext(subctx, "find", p.DestPath, "-type", "f", "-exec", "chmod", "g+r", "{}", "+").Run()
 
 	return migrationRsyncRemoteHomeResult{
 		BytesCopied: bytesCopied,
@@ -307,7 +307,7 @@ func migrationRsyncRemoteHomeHandler(ctx context.Context, raw json.RawMessage) (
 const dontknowGID = -1
 
 func lookupGroup(name string) (int, error) {
-	out, err := exec.Command("getent", "group", name).Output()
+	out, err := execCommand("getent", "group", name).Output()
 	if err != nil {
 		return 0, fmt.Errorf("getent group %s: %w", name, err)
 	}
@@ -323,7 +323,7 @@ func lookupGroup(name string) (int, error) {
 }
 
 func lookupUserUID(name string) (int, error) {
-	out, err := exec.Command("getent", "passwd", name).Output()
+	out, err := execCommand("getent", "passwd", name).Output()
 	if err != nil {
 		return 0, fmt.Errorf("getent passwd %s: %w", name, err)
 	}

--- a/panel-agent/internal/commands/nginx.go
+++ b/panel-agent/internal/commands/nginx.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -42,7 +41,7 @@ type nginxReloadResponse struct {
 
 func nginxTestHandler(ctx context.Context, params json.RawMessage) (any, error) {
 	// Run nginx -t to test configuration
-	testCmd := exec.CommandContext(ctx, "nginx", "-t")
+	testCmd := execCommandContext(ctx, "nginx", "-t")
 	var combinedOutput bytes.Buffer
 	testCmd.Stdout = &combinedOutput
 	testCmd.Stderr = &combinedOutput
@@ -62,7 +61,7 @@ func nginxReloadHandler(ctx context.Context, params json.RawMessage) (any, error
 	}
 
 	// Run systemctl reload nginx
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var combinedOutput bytes.Buffer
 	reloadCmd.Stdout = &combinedOutput
 	reloadCmd.Stderr = &combinedOutput

--- a/panel-agent/internal/commands/nginx_app_rewrites.go
+++ b/panel-agent/internal/commands/nginx_app_rewrites.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -157,7 +156,7 @@ func removeAppRewrite(ctx context.Context, appType, domain, subdir string) error
 // offending include so the domain vhost doesn't enter a broken state,
 // then surfaces the nginx error. On success, reloads nginx.
 func reloadNginxAfterSnippet(ctx context.Context, snippet string) error {
-	test := exec.CommandContext(ctx, "nginx", "-t")
+	test := execCommandContext(ctx, "nginx", "-t")
 	if out, err := test.CombinedOutput(); err != nil {
 		// Pull the snippet we just wrote so nginx doesn't stay broken
 		// across the next manual reload.
@@ -165,7 +164,7 @@ func reloadNginxAfterSnippet(ctx context.Context, snippet string) error {
 		logNginxTestFailure("nginx.app_rewrite (snippet removed)", string(out))
 		return fmt.Errorf("nginx configuration test failed for app rewrite (snippet removed)")
 	}
-	reload := exec.CommandContext(ctx, "systemctl", "reload", "nginx.service")
+	reload := execCommandContext(ctx, "systemctl", "reload", "nginx.service")
 	if out, err := reload.CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl reload nginx: %w: %s", err, out)
 	}

--- a/panel-agent/internal/commands/nginx_cache_capacity.go
+++ b/panel-agent/internal/commands/nginx_cache_capacity.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 )
@@ -63,12 +62,12 @@ func nginxCacheCapacityApplyHandler(ctx context.Context, raw json.RawMessage) (a
 		return nil, csInternal("write cache conf", err)
 	}
 	// Validate; restore the prior conf on failure so nginx stays reloadable.
-	if out, terr := exec.CommandContext(ctx, "nginx", "-t").CombinedOutput(); terr != nil {
+	if out, terr := execCommandContext(ctx, "nginx", "-t").CombinedOutput(); terr != nil {
 		_ = os.WriteFile(jabaliFcgiConfPath, orig, 0o644)
 		logNginxTestFailure("nginx.cache_capacity (reverted)", string(out))
 		return nil, csInvalidArg("nginx rejected the new cache capacity (reverted)")
 	}
-	if out, rerr := exec.CommandContext(ctx, "systemctl", "reload", "nginx").CombinedOutput(); rerr != nil {
+	if out, rerr := execCommandContext(ctx, "systemctl", "reload", "nginx").CombinedOutput(); rerr != nil {
 		return nil, csInternal("nginx reload", fmt.Errorf("%v: %s", rerr, string(out)))
 	}
 	return map[string]any{"ok": true, "changed": true,

--- a/panel-agent/internal/commands/nginx_cache_warmup.go
+++ b/panel-agent/internal/commands/nginx_cache_warmup.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -55,7 +54,7 @@ var warmupFetch = func(ctx context.Context, host, path string) int {
 	}
 	fctx, cancel := context.WithTimeout(ctx, cacheWarmupPerURL)
 	defer cancel()
-	out, _ := exec.CommandContext(fctx, "curl", args...).Output()
+	out, _ := execCommandContext(fctx, "curl", args...).Output()
 	code := 0
 	fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &code)
 	return code
@@ -72,7 +71,7 @@ var warmupFetchBody = func(ctx context.Context, host, path string) string {
 	}
 	fctx, cancel := context.WithTimeout(ctx, cacheWarmupPerURL)
 	defer cancel()
-	out, _ := exec.CommandContext(fctx, "curl", args...).Output()
+	out, _ := execCommandContext(fctx, "curl", args...).Output()
 	return string(out)
 }
 

--- a/panel-agent/internal/commands/nginx_http2.go
+++ b/panel-agent/internal/commands/nginx_http2.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"os/exec"
 	"regexp"
 	"strconv"
 )
@@ -30,7 +29,7 @@ type nginxHTTP2Form struct {
 // restart. When nginx is absent the result is the safe portable param form.
 func nginxHTTP2() nginxHTTP2Form {
 	// `nginx -v` prints "nginx version: nginx/1.26.0" to stderr.
-	out, _ := exec.Command("nginx", "-v").CombinedOutput()
+	out, _ := execCommand("nginx", "-v").CombinedOutput()
 	return computeNginxHTTP2Form(string(out))
 }
 

--- a/panel-agent/internal/commands/nginx_ratelimits.go
+++ b/panel-agent/internal/commands/nginx_ratelimits.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
@@ -136,7 +135,7 @@ func nginxRateLimitsApplyHandler(ctx context.Context, params json.RawMessage) (a
 	}
 
 	// nginx -t validates; if it fails we've still got .bak to roll back.
-	testCmd := exec.CommandContext(ctx, "nginx", "-t")
+	testCmd := execCommandContext(ctx, "nginx", "-t")
 	var testOut bytes.Buffer
 	testCmd.Stdout = &testOut
 	testCmd.Stderr = &testOut

--- a/panel-agent/internal/commands/nginx_status.go
+++ b/panel-agent/internal/commands/nginx_status.go
@@ -25,7 +25,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -67,7 +66,7 @@ func nginxStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 // command prints the state on stdout AND exits non-zero for any
 // state other than "active", so we read stdout regardless of exit code.
 func readNginxSystemdState(ctx context.Context) string {
-	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "nginx")
+	cmd := execCommandContext(ctx, "systemctl", "is-active", "nginx")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	_ = cmd.Run()
@@ -78,7 +77,7 @@ func readNginxSystemdState(ctx context.Context) string {
 // when the service is inactive or the lookup fails — callers should
 // treat 0 as "no live worker", not as an error.
 func readNginxMainPID(ctx context.Context) int {
-	cmd := exec.CommandContext(ctx, "systemctl", "show", "-p", "MainPID", "--value", "nginx")
+	cmd := execCommandContext(ctx, "systemctl", "show", "-p", "MainPID", "--value", "nginx")
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/nginx_tunables.go
+++ b/panel-agent/internal/commands/nginx_tunables.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -123,7 +122,7 @@ func nginxTunablesApplyHandler(ctx context.Context, params json.RawMessage) (any
 		}
 	}
 
-	testCmd := exec.CommandContext(ctx, "nginx", "-t")
+	testCmd := execCommandContext(ctx, "nginx", "-t")
 	var testOut bytes.Buffer
 	testCmd.Stdout = &testOut
 	testCmd.Stderr = &testOut
@@ -132,7 +131,7 @@ func nginxTunablesApplyHandler(ctx context.Context, params json.RawMessage) (any
 		return nil, nginxTestFailure("nginx.tunables (rolled back)", testOut.String())
 	}
 
-	reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reloadCmd := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	var reloadOut bytes.Buffer
 	reloadCmd.Stdout = &reloadOut
 	reloadCmd.Stderr = &reloadOut

--- a/panel-agent/internal/commands/opencart_install.go
+++ b/panel-agent/internal/commands/opencart_install.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -346,7 +345,7 @@ func opencartInstallHandler(ctx context.Context, params json.RawMessage) (any, e
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir staging: %v", err)}
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", req.OSUser+":"+req.OSUser, stagingDir).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", req.OSUser+":"+req.OSUser, stagingDir).Run(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown staging: %v", err)}
 	}
 
@@ -362,7 +361,7 @@ func opencartInstallHandler(ctx context.Context, params json.RawMessage) (any, e
 
 	if err := runOpenCartCLIInstaller(ctx, req, installPath); err != nil {
 		// Best-effort cleanup so re-install works.
-		_ = exec.CommandContext(ctx, "rm", "-f",
+		_ = execCommandContext(ctx, "rm", "-f",
 			filepath.Join(installPath, "config.php"),
 			filepath.Join(installPath, "admin", "config.php"),
 		).Run()

--- a/panel-agent/internal/commands/php_ext_shell.go
+++ b/panel-agent/internal/commands/php_ext_shell.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -48,7 +47,7 @@ var listInstalledPHPVersionsFunc = listInstalledPHPVersions
 // only yields validated allowlist entries. No user-controlled strings reach argv.
 func defaultRunAptGet(ctx context.Context, action string, pkgs ...string) ([]byte, error) {
 	args := append([]string{"-y", action}, pkgs...)
-	cmd := exec.CommandContext(ctx, "apt-get", args...) //nolint:gosec // validated upstream
+	cmd := execCommandContext(ctx, "apt-get", args...) //nolint:gosec // validated upstream
 	cmd.Env = minimalEnv
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -66,7 +65,7 @@ func defaultRunAptGet(ctx context.Context, action string, pkgs ...string) ([]byt
 // gosec G204: version is validated via phpext.ValidVersion; module is the
 // EnableName field from phpext.Lookup, which is a hardcoded allowlist entry.
 func defaultRunPhpenmod(ctx context.Context, version, module string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "phpenmod", "-v", version, module) //nolint:gosec // validated upstream
+	cmd := execCommandContext(ctx, "phpenmod", "-v", version, module) //nolint:gosec // validated upstream
 	cmd.Env = minimalEnv
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -79,7 +78,7 @@ func defaultRunPhpenmod(ctx context.Context, version, module string) ([]byte, er
 // Mirrors defaultRunPhpenmod — see its comment for rationale.
 // gosec G204: same justification as defaultRunPhpenmod.
 func defaultRunPhpdismod(ctx context.Context, version, module string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "phpdismod", "-v", version, module) //nolint:gosec // validated upstream
+	cmd := execCommandContext(ctx, "phpdismod", "-v", version, module) //nolint:gosec // validated upstream
 	cmd.Env = minimalEnv
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -93,7 +92,7 @@ func defaultRunPhpdismod(ctx context.Context, version, module string) ([]byte, e
 // was validated via phpext.ValidVersion + unit names derived from systemctl's
 // own output. No user-controlled data in argv.
 func defaultRunSystemctl(ctx context.Context, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "systemctl", args...) //nolint:gosec // validated upstream
+	cmd := execCommandContext(ctx, "systemctl", args...) //nolint:gosec // validated upstream
 	cmd.Env = minimalEnv
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -106,7 +105,7 @@ func defaultRunSystemctl(ctx context.Context, args ...string) ([]byte, error) {
 // and returns the raw text. Callers parse it themselves.
 // gosec G204: pattern is always `php<v>-*` where v was validated via phpext.ValidVersion.
 func defaultRunDpkgQuery(ctx context.Context, pattern string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "dpkg-query", "-W", "-f=${Package}\t${Status}\n", pattern) //nolint:gosec // validated upstream
+	cmd := execCommandContext(ctx, "dpkg-query", "-W", "-f=${Package}\t${Status}\n", pattern) //nolint:gosec // validated upstream
 	cmd.Env = minimalEnv
 	var out bytes.Buffer
 	var stderr bytes.Buffer

--- a/panel-agent/internal/commands/php_fpm_reap.go
+++ b/panel-agent/internal/commands/php_fpm_reap.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"regexp"
@@ -52,8 +51,8 @@ func reapFPMPoolArtifacts(ctx context.Context, slug string) {
 	// Stop + disable the FPM master.
 	if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
 		svc := fmt.Sprintf("jabali-fpm@%s.service", slug)
-		_ = exec.CommandContext(ctx, "systemctl", "stop", svc).Run()
-		_ = exec.CommandContext(ctx, "systemctl", "disable", "--quiet", svc).Run()
+		_ = execCommandContext(ctx, "systemctl", "stop", svc).Run()
+		_ = execCommandContext(ctx, "systemctl", "disable", "--quiet", svc).Run()
 	}
 
 	// pool.d confs across all installed PHP versions.
@@ -78,7 +77,7 @@ func reapFPMPoolArtifacts(ctx context.Context, slug string) {
 	if isVersioned {
 		_ = os.RemoveAll(filepath.Join(systemdRoot(), fmt.Sprintf("jabali-fpm@%s.service.d", slug)))
 		if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
-			_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+			_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 		}
 	}
 }

--- a/panel-agent/internal/commands/php_pool_apply.go
+++ b/panel-agent/internal/commands/php_pool_apply.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -196,11 +195,11 @@ func restartOrReloadUserFPM(ctx context.Context, username string, oldVersion, ne
 
 	// Try reload if versions match and oldVersion is not empty.
 	if oldVersion == newVersion && oldVersion != "" {
-		reloadCmd := exec.CommandContext(ctx, "systemctl", "reload", serviceName)
+		reloadCmd := execCommandContext(ctx, "systemctl", "reload", serviceName)
 		if err := reloadCmd.Run(); err != nil {
 			// Reload failed; check if unit is not loaded or inactive, then restart.
 			// Otherwise return the error.
-			isActiveCmd := exec.CommandContext(ctx, "systemctl", "is-active", serviceName)
+			isActiveCmd := execCommandContext(ctx, "systemctl", "is-active", serviceName)
 			if err := isActiveCmd.Run(); err != nil {
 				// Unit not loaded or inactive; fall through to restart.
 			} else {
@@ -209,19 +208,19 @@ func restartOrReloadUserFPM(ctx context.Context, username string, oldVersion, ne
 			}
 		} else {
 			// Reload succeeded; enable and return.
-			_ = exec.CommandContext(ctx, "systemctl", "enable", "--quiet", serviceName).Run()
+			_ = execCommandContext(ctx, "systemctl", "enable", "--quiet", serviceName).Run()
 			return nil
 		}
 	}
 
 	// Restart (version changed or first-time apply).
-	restartCmd := exec.CommandContext(ctx, "systemctl", "restart", serviceName)
+	restartCmd := execCommandContext(ctx, "systemctl", "restart", serviceName)
 	if err := restartCmd.Run(); err != nil {
 		return fmt.Errorf("failed to restart %s: %w", serviceName, err)
 	}
 
 	// Enable the service for auto-start on boot.
-	enableCmd := exec.CommandContext(ctx, "systemctl", "enable", "--quiet", serviceName)
+	enableCmd := execCommandContext(ctx, "systemctl", "enable", "--quiet", serviceName)
 	if err := enableCmd.Run(); err != nil {
 		return fmt.Errorf("failed to enable %s: %w", serviceName, err)
 	}
@@ -312,7 +311,7 @@ func ensureVersionedFPMDropin(ctx context.Context, slug, username string) error 
 	// A new instance drop-in requires a daemon-reload before the instance is
 	// started so systemd picks up Slice=/User=/Group=.
 	if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
-		_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+		_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 	}
 	return nil
 }

--- a/panel-agent/internal/commands/php_pool_remove.go
+++ b/panel-agent/internal/commands/php_pool_remove.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -113,8 +112,8 @@ func phpPoolRemoveHandler(ctx context.Context, params json.RawMessage) (any, err
 	// Stop + disable the slug's FPM service (if loaded).
 	if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
 		serviceName := fmt.Sprintf("jabali-fpm@%s.service", slug)
-		_ = exec.CommandContext(ctx, "systemctl", "stop", serviceName).Run()
-		_ = exec.CommandContext(ctx, "systemctl", "disable", "--quiet", serviceName).Run()
+		_ = execCommandContext(ctx, "systemctl", "stop", serviceName).Run()
+		_ = execCommandContext(ctx, "systemctl", "disable", "--quiet", serviceName).Run()
 	}
 
 	// A versioned slug owns its own systemd drop-in dir; remove it so a reaped
@@ -124,7 +123,7 @@ func phpPoolRemoveHandler(ctx context.Context, params json.RawMessage) (any, err
 		dropinDir := filepath.Join(systemdRoot(), fmt.Sprintf("jabali-fpm@%s.service.d", slug))
 		_ = os.RemoveAll(dropinDir)
 		if os.Getenv("JABALI_PHP_POOL_SKIP_RELOAD") == "" {
-			_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+			_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 		}
 	}
 

--- a/panel-agent/internal/commands/php_version_install.go
+++ b/panel-agent/internal/commands/php_version_install.go
@@ -43,7 +43,7 @@ func isVersionSupported(version string) bool {
 
 // isFPMAlreadyInstalledFunc is a function variable for testing.
 var isFPMAlreadyInstalledFunc = func(version string) bool {
-	// `command` is a shell BUILTIN, not a binary — exec.Command("command",…)
+	// `command` is a shell BUILTIN, not a binary — execCommand("command",…)
 	// always errored, so this used to report "not installed" for every
 	// version. That made install never short-circuit on an already-installed
 	// version and re-run the whole apt+pool+mask flow each time (GH #293).
@@ -80,7 +80,7 @@ var phpOptionalExts = []string{"bcmath", "opcache", "redis", "igbinary", "sqlite
 // configured. Used to backfill only the missing required extensions instead of
 // shelling out to apt when a version is already complete.
 func isPkgInstalled(pkg string) bool {
-	out, err := exec.Command("dpkg-query", "-W", "-f=${Status}", pkg).Output()
+	out, err := execCommand("dpkg-query", "-W", "-f=${Status}", pkg).Output()
 	if err != nil {
 		return false
 	}
@@ -173,7 +173,7 @@ var ensureRequiredPHPExtsFunc = ensureRequiredPHPExts
 
 // probePackage checks if an apt package exists via apt-cache show.
 func probePackage(pkg string) bool {
-	cmd := exec.Command("apt-cache", "show", pkg)
+	cmd := execCommand("apt-cache", "show", pkg)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -182,7 +182,7 @@ func probePackage(pkg string) bool {
 
 // runAptUpdate runs apt-get update to refresh the package index.
 func runAptUpdate() error {
-	cmd := exec.Command("apt-get", "update", "-qq")
+	cmd := execCommand("apt-get", "update", "-qq")
 	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -199,7 +199,7 @@ func installPackages(pkgs []string) error {
 		return nil
 	}
 
-	cmd := exec.Command("apt-get", append(
+	cmd := execCommand("apt-get", append(
 		[]string{"install", "-y", "--no-install-recommends"},
 		pkgs...,
 	)...)
@@ -277,7 +277,7 @@ func preMaskFPMService(version string) error {
 	}
 	// daemon-reload so systemd picks up the new mask before apt's
 	// postinst invokes systemctl.
-	cmd := exec.Command("systemctl", "daemon-reload")
+	cmd := execCommand("systemctl", "daemon-reload")
 	_ = cmd.Run()
 	return nil
 }
@@ -288,9 +288,9 @@ func preMaskFPMService(version string) error {
 // failed for any reason, this catches it.
 func finalizeFPMMask(version string) {
 	serviceName := fmt.Sprintf("php%s-fpm.service", version)
-	_ = exec.Command("systemctl", "reset-failed", serviceName).Run()
-	_ = exec.Command("systemctl", "disable", "--quiet", serviceName).Run()
-	_ = exec.Command("systemctl", "mask", "--quiet", serviceName).Run()
+	_ = execCommand("systemctl", "reset-failed", serviceName).Run()
+	_ = execCommand("systemctl", "disable", "--quiet", serviceName).Run()
+	_ = execCommand("systemctl", "mask", "--quiet", serviceName).Run()
 }
 
 func phpVersionInstallHandler(ctx context.Context, params json.RawMessage) (any, error) {
@@ -477,7 +477,7 @@ func runSnuffleupagusBuild(version string) {
 	// cli/conf.d needs the sendmail_path dropin or cron mail() on that
 	// version regresses to "sendmail not found". Both functions loop every
 	// on-disk minor and are idempotent.
-	cmd := exec.Command("bash", "-c",
+	cmd := execCommand("bash", "-c",
 		"source "+installSh+" && install_snuffleupagus && install_php_cli_sendmail_path")
 	cmd.Env = append(os.Environ(), "JABALI_PHP_DEFENSE_TRIGGER_VERSION="+version)
 	// Detached: don't wait. Output goes to journalctl via stdout

--- a/panel-agent/internal/commands/php_version_status.go
+++ b/panel-agent/internal/commands/php_version_status.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -79,7 +78,7 @@ var fpmWorkerStatus = func(version string) (running, total int) {
 
 // fpmInstanceActive reports whether jabali-fpm@<user>.service is active.
 var fpmInstanceActive = func(user string) bool {
-	cmd := exec.Command("systemctl", "is-active", "--quiet", "jabali-fpm@"+user+".service")
+	cmd := execCommand("systemctl", "is-active", "--quiet", "jabali-fpm@"+user+".service")
 	return cmd.Run() == nil
 }
 

--- a/panel-agent/internal/commands/php_version_uninstall.go
+++ b/panel-agent/internal/commands/php_version_uninstall.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -32,7 +31,7 @@ func purgePackages(pkgs []string) error {
 	if len(pkgs) == 0 {
 		return nil
 	}
-	cmd := exec.Command("apt-get", append(
+	cmd := execCommand("apt-get", append(
 		[]string{"purge", "-y", "--auto-remove"},
 		pkgs...,
 	)...)
@@ -97,7 +96,7 @@ func phpVersionUninstallHandler(_ context.Context, params json.RawMessage) (any,
 	// Stop the FPM service before purging so apt-get doesn't bail on
 	// "service running" stop hooks. Best-effort — purge handles the
 	// systemd-stop dance itself.
-	_ = exec.Command("systemctl", "stop", fmt.Sprintf("php%s-fpm", p.Version)).Run()
+	_ = execCommand("systemctl", "stop", fmt.Sprintf("php%s-fpm", p.Version)).Run()
 
 	// php<v>-* covers the FPM, CLI, common, and every extension package
 	// the install handler may have pulled in. apt expands the glob.

--- a/panel-agent/internal/commands/phpbb_install.go
+++ b/panel-agent/internal/commands/phpbb_install.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -152,7 +151,7 @@ func extractPhpbbTarball(ctx context.Context, osUser, tarballPath, installPath s
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir staging: %w", err)
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", osUser+":"+osUser, stagingDir).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", osUser+":"+osUser, stagingDir).Run(); err != nil {
 		return fmt.Errorf("chown staging: %w", err)
 	}
 	tarCmd := buildSystemdRunCmd(ctx, osUser,
@@ -430,7 +429,7 @@ func phpbbInstallHandler(ctx context.Context, params json.RawMessage) (any, erro
 
 	if err := runPhpbbCLIInstaller(ctx, req.OSUser, installPath, configPath); err != nil {
 		// Best-effort cleanup of partial config.php so re-install works.
-		_ = exec.CommandContext(ctx, "rm", "-f", filepath.Join(installPath, "config.php")).Run()
+		_ = execCommandContext(ctx, "rm", "-f", filepath.Join(installPath, "config.php")).Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 

--- a/panel-agent/internal/commands/prestashop_install.go
+++ b/panel-agent/internal/commands/prestashop_install.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -143,10 +142,10 @@ func extractPrestaShopZip(ctx context.Context, osUser, outerZip, installPath, st
 	}
 
 	innerStage := filepath.Join(stagingDir, "inner")
-	if err := exec.CommandContext(ctx, "mkdir", "-p", innerStage).Run(); err != nil {
+	if err := execCommandContext(ctx, "mkdir", "-p", innerStage).Run(); err != nil {
 		return fmt.Errorf("mkdir inner stage: %w", err)
 	}
-	if err := exec.CommandContext(ctx, "chown", osUser+":"+osUser, innerStage).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", osUser+":"+osUser, innerStage).Run(); err != nil {
 		return fmt.Errorf("chown inner stage: %w", err)
 	}
 
@@ -324,7 +323,7 @@ func prestashopInstallHandler(ctx context.Context, params json.RawMessage) (any,
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("mkdir staging: %v", err)}
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", req.OSUser+":"+req.OSUser, stagingDir).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", req.OSUser+":"+req.OSUser, stagingDir).Run(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("chown staging: %v", err)}
 	}
 
@@ -337,7 +336,7 @@ func prestashopInstallHandler(ctx context.Context, params json.RawMessage) (any,
 	installCtx, installCancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer installCancel()
 	if err := runPrestaShopCLIInstaller(installCtx, req, installPath); err != nil {
-		_ = exec.CommandContext(ctx, "rm", "-rf", filepath.Join(installPath, "app", "config", "parameters.php")).Run()
+		_ = execCommandContext(ctx, "rm", "-rf", filepath.Join(installPath, "app", "config", "parameters.php")).Run()
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: err.Error()}
 	}
 

--- a/panel-agent/internal/commands/python_app_apply.go
+++ b/panel-agent/internal/commands/python_app_apply.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -271,22 +270,22 @@ func pythonAppApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	// button drives a separate app.python.control call.
 	unit := pythonAppUnitName(p.AppID)
 	if unitChanged {
-		_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+		_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 	}
-	_ = exec.CommandContext(ctx, "systemctl", "enable", "--quiet", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "enable", "--quiet", unit).Run()
 	if needsRestart {
-		if out, err := exec.CommandContext(ctx, "systemctl", "restart", unit).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "systemctl", "restart", unit).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("restart %s: %v: %s", unit, err, strings.TrimSpace(string(out)))}
 		}
 	}
 
-	active := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
+	active := execCommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
 	res := pythonAppApplyResult{Active: active, Unit: unit}
 	if !active {
 		// Capture WHY it isn't active so the panel shows the real startup error
 		// instead of only "not active — check journalctl" (GH #357).
 		// --output=cat drops syslog metadata; last 15 lines keep it bounded.
-		if out, jerr := exec.CommandContext(ctx, "journalctl", "-u", unit, "-n", "20", "--no-pager", "--output=cat").CombinedOutput(); jerr == nil {
+		if out, jerr := execCommandContext(ctx, "journalctl", "-u", unit, "-n", "20", "--no-pager", "--output=cat").CombinedOutput(); jerr == nil {
 			res.Detail = lastLines(strings.TrimSpace(string(out)), 15)
 		}
 	}
@@ -367,7 +366,7 @@ func runAsUser(ctx context.Context, username string, args ...string) (string, er
 // inherited cwd. dir must be a tenant-owned path the user can chdir into.
 func runAsUserInDir(ctx context.Context, username, dir string, args ...string) (string, error) {
 	full := append([]string{"-u", username, "-H"}, args...)
-	cmd := exec.CommandContext(ctx, "sudo", full...)
+	cmd := execCommandContext(ctx, "sudo", full...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "PIP_DISABLE_PIP_VERSION_CHECK=1")
 	var out bytes.Buffer
@@ -498,11 +497,11 @@ func init() {
 // (same pattern as install_python_apps_runtime). Idempotent.
 func ensurePythonVenvPackage(ctx context.Context, ver string) error {
 	pyBin := "python" + ver
-	if err := exec.CommandContext(ctx, pyBin, "-c", "import ensurepip").Run(); err == nil {
+	if err := execCommandContext(ctx, pyBin, "-c", "import ensurepip").Run(); err == nil {
 		return nil // venv already works for this interpreter.
 	}
 	pkg := "python" + ver + "-venv"
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--pipe", "--wait", "--quiet", "--collect",
 		"--unit=jabali-python-venv-install",
 		"--service-type=oneshot", "--",
@@ -510,7 +509,7 @@ func ensurePythonVenvPackage(ctx context.Context, ver string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("install %s: %v: %s", pkg, err, strings.TrimSpace(string(out)))
 	}
-	if err := exec.CommandContext(ctx, pyBin, "-c", "import ensurepip").Run(); err != nil {
+	if err := execCommandContext(ctx, pyBin, "-c", "import ensurepip").Run(); err != nil {
 		return fmt.Errorf("%s still cannot create virtualenvs after installing %s (ensurepip unavailable)", pyBin, pkg)
 	}
 	return nil

--- a/panel-agent/internal/commands/python_app_lifecycle.go
+++ b/panel-agent/internal/commands/python_app_lifecycle.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -44,7 +43,7 @@ func pythonAppControlHandler(ctx context.Context, params json.RawMessage) (any, 
 				Message: "app is not provisioned — its build has not completed or failed (check the app logs / requirements). It rebuilds automatically once the problem is fixed.",
 			}
 		}
-		if out, err := exec.CommandContext(ctx, "systemctl", p.Action, unit).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "systemctl", p.Action, unit).CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemctl %s %s: %v: %s", p.Action, unit, err, strings.TrimSpace(string(out)))}
 		}
 	case "status":
@@ -52,7 +51,7 @@ func pythonAppControlHandler(ctx context.Context, params json.RawMessage) (any, 
 	default:
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "action must be start|stop|restart|status"}
 	}
-	state, _ := exec.CommandContext(ctx, "systemctl", "is-active", unit).Output()
+	state, _ := execCommandContext(ctx, "systemctl", "is-active", unit).Output()
 	st := strings.TrimSpace(string(state))
 	return pythonAppControlResult{Active: st == "active", State: st}, nil
 }
@@ -74,11 +73,11 @@ func pythonAppRemoveHandler(ctx context.Context, params json.RawMessage) (any, e
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid app_id"}
 	}
 	unit := pythonAppUnitName(p.AppID)
-	_ = exec.CommandContext(ctx, "systemctl", "stop", unit).Run()
-	_ = exec.CommandContext(ctx, "systemctl", "disable", "--quiet", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "stop", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "disable", "--quiet", unit).Run()
 	_ = os.Remove(filepath.Join(pythonAppUnitDir, unit))
 	_ = os.Remove(filepath.Join(pythonAppEnvDir, p.AppID+".env"))
-	_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+	_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 	return map[string]any{"removed": true}, nil
 }
 
@@ -100,7 +99,7 @@ func pythonAppLogsHandler(ctx context.Context, params json.RawMessage) (any, err
 	if n <= 0 || n > 1000 {
 		n = 200
 	}
-	out, _ := exec.CommandContext(ctx, "journalctl", "-u", pythonAppUnitName(p.AppID),
+	out, _ := execCommandContext(ctx, "journalctl", "-u", pythonAppUnitName(p.AppID),
 		"-n", fmt.Sprintf("%d", n), "--no-pager", "-o", "short-iso").CombinedOutput()
 	return map[string]any{"logs": string(out)}, nil
 }

--- a/panel-agent/internal/commands/python_app_runtime.go
+++ b/panel-agent/internal/commands/python_app_runtime.go
@@ -24,7 +24,7 @@ func pythonInstallRuntimeHandler(ctx context.Context, _ json.RawMessage) (any, e
 			Message: fmt.Sprintf("install.sh missing at %s", installShPath),
 		}
 	}
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--pipe", "--wait", "--quiet", "--collect",
 		"--unit=jabali-python-runtime-install",
 		"--service-type=oneshot",
@@ -43,7 +43,7 @@ func pythonInstallRuntimeHandler(ctx context.Context, _ json.RawMessage) (any, e
 // present, so the Apps-tab card can drop its installing spinner.
 func pythonRuntimeStatusHandler(_ context.Context, _ json.RawMessage) (any, error) {
 	venvOK := false
-	if out, err := exec.Command("python3", "-c", "import venv").CombinedOutput(); err == nil {
+	if out, err := execCommand("python3", "-c", "import venv").CombinedOutput(); err == nil {
 		_ = out
 		venvOK = true
 	}

--- a/panel-agent/internal/commands/python_app_scaffold.go
+++ b/panel-agent/internal/commands/python_app_scaffold.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -297,7 +296,7 @@ open(path,"w").write(s)
 // `--` guards a path beginning with '-'; app_root is always absolute so this is
 // belt-and-suspenders. No shell is involved.
 func writeAsUser(ctx context.Context, username, path, content string) error {
-	cmd := exec.CommandContext(ctx, "sudo", "-u", username, "-H", "tee", "--", path)
+	cmd := execCommandContext(ctx, "sudo", "-u", username, "-H", "tee", "--", path)
 	cmd.Stdin = strings.NewReader(content)
 	cmd.Stdout = io.Discard // tee echoes stdin to stdout; we don't need it
 	var errb bytes.Buffer

--- a/panel-agent/internal/commands/security_aide.go
+++ b/panel-agent/internal/commands/security_aide.go
@@ -450,7 +450,7 @@ func mwAideCheckHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	cmd := osexec.CommandContext(ctx, "/usr/bin/aide", "--config", "/etc/aide/aide.conf", "--check")
+	cmd := execCommandContext(ctx, "/usr/bin/aide", "--config", "/etc/aide/aide.conf", "--check")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, mwInternal("aide stdout pipe", err)
@@ -494,7 +494,7 @@ func mwAideRebuildHandler(ctx context.Context, payload json.RawMessage) (any, er
 	}
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
-	out, err := osexec.CommandContext(ctx, "/usr/sbin/aideinit", "-y", "-f").CombinedOutput()
+	out, err := execCommandContext(ctx, "/usr/sbin/aideinit", "-y", "-f").CombinedOutput()
 	if err != nil {
 		tail := string(out)
 		if len(tail) > 500 {

--- a/panel-agent/internal/commands/security_apparmor.go
+++ b/panel-agent/internal/commands/security_apparmor.go
@@ -107,7 +107,7 @@ func mwApparmorStatusHandler(ctx context.Context, _ json.RawMessage) (any, error
 		Denials:  []apparmorDenial{},
 	}
 
-	out, err := osexec.CommandContext(ctx, "aa-status", "--json").Output()
+	out, err := execCommandContext(ctx, "aa-status", "--json").Output()
 	if err != nil {
 		// aa-status returns non-zero on disabled / not-installed —
 		// surface as Enabled=false, not as an internal error.
@@ -242,7 +242,7 @@ func readApparmorEventsJournal(ctx context.Context, status string, since time.Ti
 	}
 	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
-	cmd := osexec.CommandContext(cctx,
+	cmd := execCommandContext(cctx,
 		"journalctl",
 		"-k",
 		"--since", "24 hours ago",
@@ -360,7 +360,7 @@ func mwApparmorSetModeHandler(ctx context.Context, raw json.RawMessage) (any, er
 	if profilePath == "" {
 		return nil, mwInvalidArg("profile has no file path mapping")
 	}
-	out, err := osexec.CommandContext(ctx, tool, profilePath).CombinedOutput()
+	out, err := execCommandContext(ctx, tool, profilePath).CombinedOutput()
 	if err != nil {
 		return nil, mwInternal(fmt.Sprintf("%s %s: %s", tool, req.Profile, string(out)), err)
 	}

--- a/panel-agent/internal/commands/security_appsec_before.go
+++ b/panel-agent/internal/commands/security_appsec_before.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -44,8 +43,8 @@ func ApplyAppSecBeforePlugin(ctx context.Context, log *slog.Logger) {
 	log.Info("appsec before-plugin re-rendered on boot — reloading crowdsec", "path", path)
 	rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if out, err := exec.CommandContext(rctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
-		if out2, err2 := exec.CommandContext(rctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
+	if out, err := execCommandContext(rctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+		if out2, err2 := execCommandContext(rctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
 			log.Warn("appsec before-plugin: crowdsec reload+restart failed",
 				"reload_err", err, "reload_out", string(out),
 				"restart_err", err2, "restart_out", string(out2))

--- a/panel-agent/internal/commands/security_audit.go
+++ b/panel-agent/internal/commands/security_audit.go
@@ -116,7 +116,7 @@ func runAuditLog(ctx context.Context, uidFilter, since string, limit int) ([]aud
 	ctx, cancel := context.WithTimeout(ctx, auditCallTimeout)
 	defer cancel()
 
-	cmd := osexec.CommandContext(ctx, "grep", "-hE",
+	cmd := execCommandContext(ctx, "grep", "-hE",
 		`key="jabali_(susp|web)_exec|jabali_bin_tamper"`, auditLogPath)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/panel-agent/internal/commands/security_crowdsec.go
+++ b/panel-agent/internal/commands/security_crowdsec.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -43,7 +42,7 @@ func csInternal(msg string, err error) error {
 func runCscliJSON(ctx context.Context, args ...string) ([]byte, error) {
 	full := append([]string{}, args...)
 	full = append(full, "-o", "json")
-	cmd := exec.CommandContext(ctx, "cscli", full...)
+	cmd := execCommandContext(ctx, "cscli", full...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -85,18 +84,18 @@ type csStatusResponse struct {
 
 func csStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	resp := csStatusResponse{}
-	if err := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", "crowdsec").Run(); err == nil {
+	if err := execCommandContext(ctx, "systemctl", "is-active", "--quiet", "crowdsec").Run(); err == nil {
 		resp.Running = true
 	}
 	// `cscli lapi status` prints success line on stdout when reachable.
-	if out, err := exec.CommandContext(ctx, "cscli", "lapi", "status").CombinedOutput(); err == nil {
+	if out, err := execCommandContext(ctx, "cscli", "lapi", "status").CombinedOutput(); err == nil {
 		resp.LapiReachable = strings.Contains(string(out), "successfully interact with Local API")
 	}
 	// CAPI status check — separate verb, may fail when offline. Best-effort.
-	if err := exec.CommandContext(ctx, "cscli", "capi", "status").Run(); err == nil {
+	if err := execCommandContext(ctx, "cscli", "capi", "status").Run(); err == nil {
 		resp.CAPIReachable = true
 	}
-	if out, err := exec.CommandContext(ctx, "cscli", "version").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "cscli", "version").Output(); err == nil {
 		// First non-empty line typically holds "version: vX.Y.Z" or similar.
 		for _, line := range strings.Split(string(out), "\n") {
 			line = strings.TrimSpace(line)
@@ -121,7 +120,7 @@ func csStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 		}
 	}
 	// crowdsec.service ActiveEnterTimestamp → daemon start time
-	if out, err := exec.CommandContext(ctx, "systemctl", "show",
+	if out, err := execCommandContext(ctx, "systemctl", "show",
 		"crowdsec.service", "--property=ActiveEnterTimestamp",
 		"--value").Output(); err == nil {
 		if s := strings.TrimSpace(string(out)); s != "" {
@@ -132,7 +131,7 @@ func csStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 		}
 	}
 	// GH #716: config validation via `crowdsec -t` (dry parse of the full config).
-	if out, err := exec.CommandContext(ctx, "crowdsec", "-t").CombinedOutput(); err == nil {
+	if out, err := execCommandContext(ctx, "crowdsec", "-t").CombinedOutput(); err == nil {
 		resp.ConfigValid = true
 	} else {
 		resp.ConfigValid = false
@@ -142,7 +141,7 @@ func csStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 		}
 	}
 	// GH #716: active bouncer count (cscli bouncers list -o json → array length).
-	if out, err := exec.CommandContext(ctx, "cscli", "bouncers", "list", "-o", "json").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "cscli", "bouncers", "list", "-o", "json").Output(); err == nil {
 		var arr []map[string]any
 		if json.Unmarshal(out, &arr) == nil {
 			resp.BouncerCount = len(arr)
@@ -357,7 +356,7 @@ func csDecisionsAddHandler(ctx context.Context, params json.RawMessage) (any, er
 	if l := len(p.Reason); l < 3 || l > 200 {
 		return nil, csInvalidArg("reason length must be 3..200")
 	}
-	cmd := exec.CommandContext(ctx, "cscli", "decisions", "add",
+	cmd := execCommandContext(ctx, "cscli", "decisions", "add",
 		"--scope", canonical, "--value", value,
 		"--duration", durArg, "--reason", p.Reason)
 	if _, err := cmd.CombinedOutput(); err != nil {
@@ -416,7 +415,7 @@ func csDecisionsDeleteHandler(ctx context.Context, params json.RawMessage) (any,
 	default:
 		return nil, csInvalidArg("either id or ip required")
 	}
-	out, err := exec.CommandContext(ctx, "cscli", args...).CombinedOutput()
+	out, err := execCommandContext(ctx, "cscli", args...).CombinedOutput()
 	if err != nil {
 		return nil, csInternal("cscli decisions delete", err)
 	}
@@ -814,13 +813,13 @@ func csHubInstallHandler(ctx context.Context, params json.RawMessage) (any, erro
 	if p.Force {
 		args = append(args, "--force")
 	}
-	cmd := exec.CommandContext(ctx, "cscli", args...)
+	cmd := execCommandContext(ctx, "cscli", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, csInternal(fmt.Sprintf("cscli %s install: %s", p.Type, strings.TrimSpace(string(out))), err)
 	}
 	// GH #711: a failed reload means the newly-installed item is NOT live yet —
 	// don't report success, or the UI claims protection that isn't loaded.
-	if out, err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
 		return nil, csInternal(fmt.Sprintf("installed %s %s but crowdsec reload failed (item not live): %s", p.Type, p.Name, strings.TrimSpace(string(out))), err)
 	}
 	return map[string]any{"type": p.Type, "name": p.Name, "installed": true}, nil
@@ -837,12 +836,12 @@ func csHubRemoveHandler(ctx context.Context, params json.RawMessage) (any, error
 	if !hubItemNameRE.MatchString(p.Name) {
 		return nil, csInvalidArg("name must match <author>/<item>")
 	}
-	cmd := exec.CommandContext(ctx, "cscli", p.Type, "remove", p.Name)
+	cmd := execCommandContext(ctx, "cscli", p.Type, "remove", p.Name)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, csInternal(fmt.Sprintf("cscli %s remove: %s", p.Type, strings.TrimSpace(string(out))), err)
 	}
 	// GH #711: a failed reload means the removed item may STILL be loaded.
-	if out, err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
 		return nil, csInternal(fmt.Sprintf("removed %s %s but crowdsec reload failed (item may still be live): %s", p.Type, p.Name, strings.TrimSpace(string(out))), err)
 	}
 	return map[string]any{"type": p.Type, "name": p.Name, "installed": false}, nil
@@ -956,8 +955,8 @@ func csAppSecGeoblockSetHandler(ctx context.Context, params json.RawMessage) (an
 // when ExecReload is set (crowdsec.service ships that). If reload is not
 // wired (older packaging) fall back to restart.
 func reloadCrowdsec(ctx context.Context) error {
-	if out, err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
-		if out2, err2 := exec.CommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+		if out2, err2 := execCommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
 			return csInternal("systemctl reload/restart crowdsec",
 				fmt.Errorf("reload: %v %s; restart: %v %s", err, out, err2, out2))
 		}
@@ -1094,11 +1093,11 @@ type csAllowlistAddParams struct {
 // we treat it as success. We don't rely on the exit code alone because
 // cscli versions differ.
 func ensureAllowlist(ctx context.Context, name, description string) error {
-	check := exec.CommandContext(ctx, "cscli", "allowlists", "inspect", name)
+	check := execCommandContext(ctx, "cscli", "allowlists", "inspect", name)
 	if err := check.Run(); err == nil {
 		return nil
 	}
-	create := exec.CommandContext(ctx, "cscli", "allowlists", "create",
+	create := execCommandContext(ctx, "cscli", "allowlists", "create",
 		name, "-d", description)
 	out, err := create.CombinedOutput()
 	if err != nil {
@@ -1165,10 +1164,10 @@ func addToAllowlist(ctx context.Context, name, value, reason, expiration string)
 		// cscli `add` of an existing value is a no-op and does NOT refresh the
 		// expiration. For the time-boxed login path we want each re-login to
 		// slide the TTL forward, so best-effort remove first, then re-add.
-		_ = exec.CommandContext(ctx, "cscli", "allowlists", "remove", name, value).Run()
+		_ = execCommandContext(ctx, "cscli", "allowlists", "remove", name, value).Run()
 		args = append(args, "-e", expiration)
 	}
-	out, err := exec.CommandContext(ctx, "cscli", args...).CombinedOutput()
+	out, err := execCommandContext(ctx, "cscli", args...).CombinedOutput()
 	if err != nil && expiration != "" {
 		// The remove above already happened: a failed re-add would leave a
 		// previously-allowlisted value DROPPED (an admin IP falling out of the
@@ -1176,10 +1175,10 @@ func addToAllowlist(ctx context.Context, name, value, reason, expiration string)
 		// without the TTL flag — preserving the pre-call allowlisted state is
 		// strictly safer than silently losing it; the entry stays visible in
 		// the panel either way.
-		out, err = exec.CommandContext(ctx, "cscli", args...).CombinedOutput()
+		out, err = execCommandContext(ctx, "cscli", args...).CombinedOutput()
 		if err != nil {
 			base := args[:len(args)-2] // strip "-e", expiration
-			if rout, rerr := exec.CommandContext(ctx, "cscli", base...).CombinedOutput(); rerr == nil {
+			if rout, rerr := execCommandContext(ctx, "cscli", base...).CombinedOutput(); rerr == nil {
 				return fmt.Errorf("cscli allowlists add with -e %s failed (%s); entry restored WITHOUT expiration", expiration, strings.TrimSpace(string(out)))
 			} else {
 				out = append(out, rout...)
@@ -1220,7 +1219,7 @@ func csAllowlistsRemoveHandler(ctx context.Context, params json.RawMessage) (any
 	if value == "" {
 		return nil, csInvalidArg("value is required")
 	}
-	cmd := exec.CommandContext(ctx, "cscli", "allowlists", "remove",
+	cmd := execCommandContext(ctx, "cscli", "allowlists", "remove",
 		jabaliAllowlistName, value)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		msg := strings.ToLower(string(out))
@@ -1357,7 +1356,7 @@ func csCountryAllowlistSyncHandler(ctx context.Context, params json.RawMessage) 
 	}
 	removed := 0
 	for _, r := range p.Removes {
-		cmd := exec.CommandContext(ctx, "cscli", "allowlists", "remove",
+		cmd := execCommandContext(ctx, "cscli", "allowlists", "remove",
 			jabaliCountryAllowlistName, strings.TrimSpace(r))
 		if out, err := cmd.CombinedOutput(); err != nil {
 			msg := strings.ToLower(string(out))
@@ -1381,7 +1380,7 @@ func csCountryAllowlistSyncHandler(ctx context.Context, params json.RawMessage) 
 		values := byComment[comment]
 		args := append([]string{"allowlists", "add", jabaliCountryAllowlistName}, values...)
 		args = append(args, "-d", comment)
-		out, err := exec.CommandContext(ctx, "cscli", args...).CombinedOutput()
+		out, err := execCommandContext(ctx, "cscli", args...).CombinedOutput()
 		if err != nil {
 			// panel-api computes adds as exact deltas, so "already exists"
 			// means a race with a concurrent sync, not a logic error.
@@ -1857,14 +1856,14 @@ func csProfilesSetHandler(ctx context.Context, params json.RawMessage) (any, err
 	}
 
 	// Pre-flight: `crowdsec -t` (exists in v1.7.x per probe).
-	if out, terr := exec.CommandContext(ctx, "crowdsec", "-t").CombinedOutput(); terr != nil {
+	if out, terr := execCommandContext(ctx, "crowdsec", "-t").CombinedOutput(); terr != nil {
 		// Restore backup + surface error.
 		_ = os.WriteFile(profilesPath, raw, 0o644)
 		return nil, csInternal(fmt.Sprintf("crowdsec -t: %s", strings.TrimSpace(string(out))), terr)
 	}
-	if err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").Run(); err != nil {
+	if err := execCommandContext(ctx, "systemctl", "reload", "crowdsec").Run(); err != nil {
 		_ = os.WriteFile(profilesPath, raw, 0o644)
-		_ = exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").Run()
+		_ = execCommandContext(ctx, "systemctl", "reload", "crowdsec").Run()
 		return nil, csInternal("systemctl reload crowdsec after write", err)
 	}
 	return map[string]any{"overrides": p.Overrides}, nil
@@ -1982,14 +1981,14 @@ func csCaptchaApplyHandler(ctx context.Context, params json.RawMessage) (any, er
 	if err := rewriteBouncerConfKeys(bouncerConfPath, updates); err != nil {
 		return nil, csInternal("rewrite bouncer conf", err)
 	}
-	if err := exec.CommandContext(ctx, "nginx", "-t").Run(); err != nil {
+	if err := execCommandContext(ctx, "nginx", "-t").Run(); err != nil {
 		// Restore from bak + surface the error to the operator.
 		if bak, rerr := os.ReadFile(bakPath); rerr == nil {
 			_ = os.WriteFile(bouncerConfPath, bak, 0o600)
 		}
 		return nil, csInternal("nginx -t failed after bouncer conf rewrite", err)
 	}
-	if err := exec.CommandContext(ctx, "systemctl", "reload", "nginx").Run(); err != nil {
+	if err := execCommandContext(ctx, "systemctl", "reload", "nginx").Run(); err != nil {
 		return nil, csInternal("systemctl reload nginx", err)
 	}
 	return map[string]any{"enabled": p.Enabled}, nil

--- a/panel-agent/internal/commands/security_crowdsec_blocklist.go
+++ b/panel-agent/internal/commands/security_crowdsec_blocklist.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/csv"
 	"io"
-	"os/exec"
 	"strings"
 	"time"
 )
@@ -19,7 +18,7 @@ import (
 func runCscliRaw(ctx context.Context, args ...string) ([]byte, error) {
 	full := append([]string{}, args...)
 	full = append(full, "-o", "raw")
-	cmd := exec.CommandContext(ctx, "cscli", full...)
+	cmd := execCommandContext(ctx, "cscli", full...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/panel-agent/internal/commands/security_crowdsec_bouncer_mode.go
+++ b/panel-agent/internal/commands/security_crowdsec_bouncer_mode.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -132,13 +131,13 @@ func bouncerModeApplyHandler(ctx context.Context, params json.RawMessage) (any, 
 	// Caught 2026-06-04 on puzzle.linux-hosting.net: agent wrote
 	// MODE=live to disk + reloaded nginx + DB persisted live + UI
 	// said "applied" — but bouncer kept running in stream mode.
-	if out, err := exec.CommandContext(ctx, "nginx", "-t").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "nginx", "-t").CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: "nginx -t failed after writing " + bouncerConfPath + ": " + strings.TrimSpace(string(out)),
 		}
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "restart", "nginx").CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemctl", "restart", "nginx").CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
 			Message: "systemctl restart nginx failed: " + strings.TrimSpace(string(out)),

--- a/panel-agent/internal/commands/security_crowdsec_sensitivity.go
+++ b/panel-agent/internal/commands/security_crowdsec_sensitivity.go
@@ -32,7 +32,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -203,8 +202,8 @@ func sensitivityApplyHandler(ctx context.Context, params json.RawMessage) (any, 
 	// Reload crowdsec so the new scenario / drop-in profile take effect.
 	// SIGHUP via systemctl reload — falls back to restart if reload
 	// not wired (older packaging).
-	if _, err := exec.CommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
-		if _, err2 := exec.CommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
+	if _, err := execCommandContext(ctx, "systemctl", "reload", "crowdsec").CombinedOutput(); err != nil {
+		if _, err2 := execCommandContext(ctx, "systemctl", "restart", "crowdsec").CombinedOutput(); err2 != nil {
 			return nil, csInternal("reload/restart crowdsec", fmt.Errorf("reload: %v; restart: %v", err, err2))
 		}
 	}

--- a/panel-agent/internal/commands/security_malware.go
+++ b/panel-agent/internal/commands/security_malware.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -108,7 +107,7 @@ type mwStatusResponse struct {
 
 func mwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	r := mwStatusResponse{}
-	if out, err := exec.CommandContext(ctx, "maldet", "--version").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "maldet", "--version").Output(); err == nil {
 		r.MaldetVersion = strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
 	}
 	if data, err := os.ReadFile("/usr/local/maldetect/sigs/maldet.sigs.ver"); err == nil {
@@ -134,11 +133,11 @@ func mwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	// back to legacy `yara` if yr is missing. Empty string surfaces as
 	// "no YARA engine" in the UI.
 	// CombinedOutput because some yara-x releases write --version to stderr.
-	if out, err := exec.CommandContext(ctx, "yr", "--version").CombinedOutput(); err == nil {
+	if out, err := execCommandContext(ctx, "yr", "--version").CombinedOutput(); err == nil {
 		if v := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0]); v != "" {
 			r.YARAEngineVersion = "yara-x " + v
 		}
-	} else if out, err := exec.CommandContext(ctx, "yara", "--version").CombinedOutput(); err == nil {
+	} else if out, err := execCommandContext(ctx, "yara", "--version").CombinedOutput(); err == nil {
 		if v := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0]); v != "" {
 			r.YARAEngineVersion = "yara " + v
 		}
@@ -180,7 +179,7 @@ func mwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 }
 
 func systemctlIsActive(ctx context.Context, unit string) bool {
-	return exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
+	return execCommandContext(ctx, "systemctl", "is-active", "--quiet", unit).Run() == nil
 }
 
 // ---- security.malware.scan_path / scan_user / scan_status ------------------
@@ -250,7 +249,7 @@ func startMaldetScan(ctx context.Context, target string) (mwScanStartResponse, e
 	// --no-block we're back to: systemd-run returns as soon as the job is
 	// queued, agent returns session_id, panel-api writes the tracking row,
 	// the scan_status poller picks up the unit's lifecycle from there.
-	cmd := exec.CommandContext(ctx, //nolint:gosec // argv form, no shell
+	cmd := execCommandContext(ctx, //nolint:gosec // argv form, no shell
 		"systemd-run",
 		"--quiet",
 		"--collect",
@@ -289,7 +288,7 @@ func mwScanStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 	}
 	unit := fmt.Sprintf("jabali-maldet-scan-%s.service", req.SessionID)
 	r := mwScanStatusResponse{}
-	if out, err := exec.CommandContext(ctx, "systemctl", "show", unit, "--property=ActiveState,ExecMainStatus").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "systemctl", "show", unit, "--property=ActiveState,ExecMainStatus").Output(); err == nil {
 		for _, line := range strings.Split(string(out), "\n") {
 			if strings.HasPrefix(line, "ActiveState=") {
 				r.State = strings.TrimPrefix(line, "ActiveState=")
@@ -301,7 +300,7 @@ func mwScanStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 		}
 	}
 	r.Done = r.State == "inactive" || r.State == "failed"
-	if out, err := exec.CommandContext(ctx, "journalctl", "-u", unit, "--no-pager", "-n", "200").Output(); err == nil {
+	if out, err := execCommandContext(ctx, "journalctl", "-u", unit, "--no-pager", "-n", "200").Output(); err == nil {
 		for _, line := range strings.Split(string(out), "\n") {
 			if line != "" {
 				r.LogTail = append(r.LogTail, line)
@@ -375,7 +374,7 @@ func mwQuarantineRestoreHandler(ctx context.Context, raw json.RawMessage) (any, 
 	if strings.TrimSpace(req.Reason) == "" {
 		return nil, mwInvalidArg("reason is required for restore (audit)")
 	}
-	cmd := exec.CommandContext(ctx, "/usr/local/maldetect/maldet", "--restore", req.QuarantinePath) //nolint:gosec
+	cmd := execCommandContext(ctx, "/usr/local/maldetect/maldet", "--restore", req.QuarantinePath) //nolint:gosec
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, mwInternal(fmt.Sprintf("maldet --restore failed: %s", string(out)), err)
 	}
@@ -420,7 +419,7 @@ type mwUpdateSignaturesResponse struct {
 func mwUpdateSignaturesHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	start := time.Now()
 	r := mwUpdateSignaturesResponse{FreshclamOK: true}
-	if out, err := exec.CommandContext(ctx, "/usr/local/maldetect/maldet", "-u").CombinedOutput(); err == nil {
+	if out, err := execCommandContext(ctx, "/usr/local/maldetect/maldet", "-u").CombinedOutput(); err == nil {
 		r.MaldetOK = true
 		r.MaldetOutput = string(out)
 	} else {
@@ -429,7 +428,7 @@ func mwUpdateSignaturesHandler(ctx context.Context, _ json.RawMessage) (any, err
 	// Trigger PMF rule refresh by starting the systemd unit. We run it
 	// rather than fetching inline so the agent doesn't need to know the
 	// upstream URL or write /etc/jabali/yara/ directly.
-	if out, err := exec.CommandContext(ctx, "systemctl", "start", "--no-block", "jabali-pmf-update.service").CombinedOutput(); err == nil {
+	if out, err := execCommandContext(ctx, "systemctl", "start", "--no-block", "jabali-pmf-update.service").CombinedOutput(); err == nil {
 		r.PMFOK = true
 		r.PMFOutput = string(out)
 	} else {
@@ -457,12 +456,12 @@ func mwMonitorSetEnabledHandler(ctx context.Context, raw json.RawMessage) (any, 
 	}
 	const unit = "jabali-maldet-monitor.service"
 	if req.Enabled {
-		out, err := exec.CommandContext(ctx, "systemctl", "enable", "--now", unit).CombinedOutput()
+		out, err := execCommandContext(ctx, "systemctl", "enable", "--now", unit).CombinedOutput()
 		if err != nil {
 			return nil, mwInternal(fmt.Sprintf("systemctl enable --now %s: %s", unit, string(out)), err)
 		}
 	} else {
-		out, err := exec.CommandContext(ctx, "systemctl", "disable", "--now", unit).CombinedOutput()
+		out, err := execCommandContext(ctx, "systemctl", "disable", "--now", unit).CombinedOutput()
 		if err != nil {
 			return nil, mwInternal(fmt.Sprintf("systemctl disable --now %s: %s", unit, string(out)), err)
 		}
@@ -479,7 +478,7 @@ func mwMonitorReloadHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// LMD --monitor RELOAD signals a running monitor to re-read /etc/passwd
 	// for users with UID >= inotify_minuid and adjust watches. No file to
 	// manage; LMD handles the discovery.
-	out, err := exec.CommandContext(ctx, "/usr/local/maldetect/maldet", "--monitor", "RELOAD").CombinedOutput()
+	out, err := execCommandContext(ctx, "/usr/local/maldetect/maldet", "--monitor", "RELOAD").CombinedOutput()
 	if err != nil {
 		return nil, mwInternal(fmt.Sprintf("maldet --monitor RELOAD: %s", string(out)), err)
 	}
@@ -732,7 +731,7 @@ func mwYARAUploadHandler(ctx context.Context, raw json.RawMessage) (any, error) 
 		return nil, mwInternal("write tmp", err)
 	}
 	tmp.Close()
-	if out, err := exec.CommandContext(ctx, "yara", "-w", tmpPath, "/dev/null").CombinedOutput(); err != nil { //nolint:gosec
+	if out, err := execCommandContext(ctx, "yara", "-w", tmpPath, "/dev/null").CombinedOutput(); err != nil { //nolint:gosec
 		return nil, mwInvalidArg(fmt.Sprintf("yara parse error: %s", strings.TrimSpace(string(out))))
 	}
 

--- a/panel-agent/internal/commands/security_malware_breaker.go
+++ b/panel-agent/internal/commands/security_malware_breaker.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -64,7 +63,7 @@ type mwQuarantineSetEnabledResponse struct {
 // (the monitor is admin-opt-in and may deliberately be off). var so
 // tests stub it (GH #994: no test may exec against the real host).
 var mwRestartMonitor = func(ctx context.Context) {
-	_ = exec.CommandContext(ctx, "systemctl", "try-restart", mwMonitorUnitStr).Run()
+	_ = execCommandContext(ctx, "systemctl", "try-restart", mwMonitorUnitStr).Run()
 }
 
 // mwBreakerTripped reports whether the breaker drop-in exists, and its

--- a/panel-agent/internal/commands/security_snuffleupagus.go
+++ b/panel-agent/internal/commands/security_snuffleupagus.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	osexec "os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -130,7 +129,7 @@ type snuffleupagusPoolReloadResult struct {
 func snuffleupagusReloadHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	resp := snuffleupagusReloadResponse{Pools: []snuffleupagusPoolReloadResult{}}
 
-	listCmd := osexec.CommandContext(ctx,
+	listCmd := execCommandContext(ctx,
 		"systemctl", "list-units", "jabali-fpm@*.service",
 		"--no-legend", "--no-pager", "--state=loaded",
 	)
@@ -157,7 +156,7 @@ func snuffleupagusReloadHandler(ctx context.Context, _ json.RawMessage) (any, er
 
 	var failed []string
 	for _, unit := range units {
-		cmd := osexec.CommandContext(ctx, "systemctl", "reload-or-restart", unit)
+		cmd := execCommandContext(ctx, "systemctl", "reload-or-restart", unit)
 		rOut, err := cmd.CombinedOutput()
 		if err != nil {
 			resp.Pools = append(resp.Pools, snuffleupagusPoolReloadResult{

--- a/panel-agent/internal/commands/security_trust.go
+++ b/panel-agent/internal/commands/security_trust.go
@@ -72,7 +72,7 @@ func trustCrowdSecVerdict(ctx context.Context, ip string) trustVerdict {
 	if _, err := exec.LookPath("cscli"); err != nil {
 		return trustVerdict{Layer: "crowdsec", Outcome: "unknown", Detail: "cscli not installed"}
 	}
-	out, err := runCmdWithStderr(exec.CommandContext(ctx, "cscli", "decisions", "list", "-i", ip, "-o", "json"))
+	out, err := runCmdWithStderr(execCommandContext(ctx, "cscli", "decisions", "list", "-i", ip, "-o", "json"))
 	if err != nil {
 		return trustVerdict{Layer: "crowdsec", Outcome: "unknown", Detail: "cscli error: " + err.Error()}
 	}
@@ -98,7 +98,7 @@ func trustUfwVerdict(ctx context.Context, ip string) trustVerdict {
 	if _, err := exec.LookPath("ufw"); err != nil {
 		return trustVerdict{Layer: "ufw", Outcome: "unknown", Detail: "ufw not installed"}
 	}
-	out, err := runCmdWithStderr(exec.CommandContext(ctx, "ufw", "status", "numbered"))
+	out, err := runCmdWithStderr(execCommandContext(ctx, "ufw", "status", "numbered"))
 	if err != nil {
 		return trustVerdict{Layer: "ufw", Outcome: "unknown", Detail: "ufw error: " + err.Error()}
 	}

--- a/panel-agent/internal/commands/security_ufw.go
+++ b/panel-agent/internal/commands/security_ufw.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -56,11 +55,11 @@ func ufwStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
 	// line that `ufw status verbose` (without numbered) prints. We need
 	// the rule numbers (for delete-by-num) AND the default policies, so
 	// query both.
-	numbered, err := exec.CommandContext(ctx, "ufw", "status", "numbered", "verbose").Output()
+	numbered, err := execCommandContext(ctx, "ufw", "status", "numbered", "verbose").Output()
 	if err != nil {
 		return nil, ufwInternal("ufw status numbered", err)
 	}
-	verbose, err := exec.CommandContext(ctx, "ufw", "status", "verbose").Output()
+	verbose, err := execCommandContext(ctx, "ufw", "status", "verbose").Output()
 	if err != nil {
 		return nil, ufwInternal("ufw status verbose", err)
 	}
@@ -171,7 +170,7 @@ func ufwRuleAddHandler(ctx context.Context, params json.RawMessage) (any, error)
 	} else {
 		args = append(args, p.Port+"/"+p.Proto)
 	}
-	if _, err := exec.CommandContext(ctx, "ufw", args...).CombinedOutput(); err != nil {
+	if _, err := execCommandContext(ctx, "ufw", args...).CombinedOutput(); err != nil {
 		return nil, ufwInternal("ufw "+p.Action+" failed", err)
 	}
 	num := ufwLookupRuleNum(ctx, p)
@@ -179,7 +178,7 @@ func ufwRuleAddHandler(ctx context.Context, params json.RawMessage) (any, error)
 }
 
 func ufwLookupRuleNum(ctx context.Context, p ufwRuleAddParams) int {
-	out, err := exec.CommandContext(ctx, "ufw", "status", "numbered").Output()
+	out, err := execCommandContext(ctx, "ufw", "status", "numbered").Output()
 	if err != nil {
 		return 0
 	}
@@ -210,7 +209,7 @@ func ufwRuleDeleteHandler(ctx context.Context, params json.RawMessage) (any, err
 	if p.Num < 1 || p.Num > 1000 {
 		return nil, ufwInvalidArg("num out of range 1..1000")
 	}
-	cmd := exec.CommandContext(ctx, "ufw", "--force", "delete", strconv.Itoa(p.Num))
+	cmd := execCommandContext(ctx, "ufw", "--force", "delete", strconv.Itoa(p.Num))
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -241,7 +240,7 @@ func ufwDefaultSetHandler(ctx context.Context, params json.RawMessage) (any, err
 	if !validUfwActions[p.Policy] {
 		return nil, ufwInvalidArg("policy must be allow|deny|reject")
 	}
-	if _, err := exec.CommandContext(ctx, "ufw", "default", p.Policy, p.Chain).CombinedOutput(); err != nil {
+	if _, err := execCommandContext(ctx, "ufw", "default", p.Policy, p.Chain).CombinedOutput(); err != nil {
 		return nil, ufwInternal("ufw default failed", err)
 	}
 	return map[string]bool{"applied": true}, nil
@@ -259,7 +258,7 @@ func ufwEnableHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	if p.Confirm != "YES" {
 		return nil, ufwInvalidArg(`confirm must be "YES" — refusing to enable firewall without explicit confirmation`)
 	}
-	if _, err := exec.CommandContext(ctx, "ufw", "--force", "enable").CombinedOutput(); err != nil {
+	if _, err := execCommandContext(ctx, "ufw", "--force", "enable").CombinedOutput(); err != nil {
 		return nil, ufwInternal("ufw enable failed", err)
 	}
 	return map[string]bool{"active": true}, nil
@@ -271,7 +270,7 @@ func ufwDisableHandler(ctx context.Context, params json.RawMessage) (any, error)
 	if p.Confirm != "YES" {
 		return nil, ufwInvalidArg(`confirm must be "YES" — refusing to disable firewall without explicit confirmation`)
 	}
-	if _, err := exec.CommandContext(ctx, "ufw", "--force", "disable").CombinedOutput(); err != nil {
+	if _, err := execCommandContext(ctx, "ufw", "--force", "disable").CombinedOutput(); err != nil {
 		return nil, ufwInternal("ufw disable failed", err)
 	}
 	return map[string]bool{"active": false}, nil

--- a/panel-agent/internal/commands/service_list.go
+++ b/panel-agent/internal/commands/service_list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -93,7 +92,7 @@ func AllowedServices() []string {
 var systemctlRunner = realSystemctl
 
 func realSystemctl(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "systemctl", args...)
+	cmd := execCommandContext(ctx, "systemctl", args...)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }

--- a/panel-agent/internal/commands/sessions_ssh.go
+++ b/panel-agent/internal/commands/sessions_ssh.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -36,7 +35,7 @@ func sessionsSSHListHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// inbound session (sshd never dials out; outbound ssh is the `ssh` client),
 	// so the sshd-process match below scopes it correctly on any port, and SFTP
 	// (same sshd transport) is captured too.
-	out, err := exec.CommandContext(ctx, "ss", "-tnHp", "state", "established").Output()
+	out, err := execCommandContext(ctx, "ss", "-tnHp", "state", "established").Output()
 	if err != nil {
 		// No ss / no sessions — return empty, not an error.
 		return map[string]any{"sessions": []sshSession{}}, nil
@@ -149,10 +148,10 @@ func parseSSHDLabel(cmdline string) (user, channel string) {
 
 // procUserAndStart returns the process owner + its start time (best-effort).
 func procUserAndStart(ctx context.Context, pid int) (user, since string) {
-	if out, err := exec.CommandContext(ctx, "ps", "-o", "user=", "-p", strconv.Itoa(pid)).Output(); err == nil {
+	if out, err := execCommandContext(ctx, "ps", "-o", "user=", "-p", strconv.Itoa(pid)).Output(); err == nil {
 		user = strings.TrimSpace(string(out))
 	}
-	if out, err := exec.CommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output(); err == nil {
+	if out, err := execCommandContext(ctx, "ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output(); err == nil {
 		since = strings.TrimSpace(string(out))
 	}
 	return user, since

--- a/panel-agent/internal/commands/snuffleupagus_ingest.go
+++ b/panel-agent/internal/commands/snuffleupagus_ingest.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	osexec "os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -91,7 +90,7 @@ func snuffleupagusFetchHandler(ctx context.Context, params json.RawMessage) (any
 
 	// `journalctl --identifier snuffleupagus --since <ts> --output json`.
 	// Snuffleupagus log_media defaults to syslog identifier "snuffleupagus".
-	cmd := osexec.CommandContext(ctx,
+	cmd := execCommandContext(ctx,
 		"journalctl",
 		"--identifier", "snuffleupagus",
 		"--since", since,

--- a/panel-agent/internal/commands/ssh_user_join_sftp_group.go
+++ b/panel-agent/internal/commands/ssh_user_join_sftp_group.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -59,7 +58,7 @@ func sshUserJoinSFTPGroupHandler(ctx context.Context, params json.RawMessage) (a
 	}
 
 	// Add user to the group via usermod -aG jabali-sftp <username>
-	usermodCmd := exec.CommandContext(ctx, "usermod", "-aG", sftpGroupName, p.Username)
+	usermodCmd := execCommandContext(ctx, "usermod", "-aG", sftpGroupName, p.Username)
 	var usermodOut, usermodErr bytes.Buffer
 	usermodCmd.Stdout = &usermodOut
 	usermodCmd.Stderr = &usermodErr
@@ -80,7 +79,7 @@ func sshUserJoinSFTPGroupHandler(ctx context.Context, params json.RawMessage) (a
 // isUserInGroup checks if a user is a member of a group.
 // Uses `id -nG <username>` to get the list of group names.
 func isUserInGroup(ctx context.Context, username, groupName string) (bool, *agentwire.AgentError) {
-	idCmd := exec.CommandContext(ctx, "id", "-nG", username)
+	idCmd := execCommandContext(ctx, "id", "-nG", username)
 	var idOut, idErr bytes.Buffer
 	idCmd.Stdout = &idOut
 	idCmd.Stderr = &idErr
@@ -112,7 +111,7 @@ func refuseRootSFTP(ctx context.Context, username string) *agentwire.AgentError 
 	if username == "root" {
 		return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "refusing to add root to " + sftpGroupName + " (would brick host SSH)"}
 	}
-	out, err := exec.CommandContext(ctx, "id", "-u", username).Output()
+	out, err := execCommandContext(ctx, "id", "-u", username).Output()
 	if err != nil {
 		return &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to resolve uid for %q: %v", username, err)}
 	}

--- a/panel-agent/internal/commands/ssh_user_join_sftp_group_test.go
+++ b/panel-agent/internal/commands/ssh_user_join_sftp_group_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestSSHUserJoinSFTPGroup_InvalidUser(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	ctx := context.Background()
 
 	params, _ := json.Marshal(sshUserJoinSFTPGroupParams{

--- a/panel-agent/internal/commands/ssh_user_leave_sftp_group.go
+++ b/panel-agent/internal/commands/ssh_user_leave_sftp_group.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -47,7 +46,7 @@ func sshUserLeaveSFTPGroupHandler(ctx context.Context, params json.RawMessage) (
 	// without disturbing the user's other memberships. usermod -G would
 	// require listing every other group the user must keep — fragile and
 	// racy on multi-group accounts.
-	cmd := exec.CommandContext(ctx, "gpasswd", "-d", p.Username, sftpGroupName)
+	cmd := execCommandContext(ctx, "gpasswd", "-d", p.Username, sftpGroupName)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/panel-agent/internal/commands/ssh_user_sandbox_group.go
+++ b/panel-agent/internal/commands/ssh_user_sandbox_group.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -47,7 +46,7 @@ func sshUserJoinSandboxGroupHandler(ctx context.Context, params json.RawMessage)
 	if isMember {
 		return &sshUserSandboxGroupResponse{Username: p.Username, AlreadyMember: true}, nil
 	}
-	cmd := exec.CommandContext(ctx, "usermod", "-aG", sandboxGroupName, p.Username)
+	cmd := execCommandContext(ctx, "usermod", "-aG", sandboxGroupName, p.Username)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -74,7 +73,7 @@ func sshUserLeaveSandboxGroupHandler(ctx context.Context, params json.RawMessage
 	if !isMember {
 		return &sshUserSandboxGroupResponse{Username: p.Username, NotMember: true}, nil
 	}
-	cmd := exec.CommandContext(ctx, "gpasswd", "-d", p.Username, sandboxGroupName)
+	cmd := execCommandContext(ctx, "gpasswd", "-d", p.Username, sandboxGroupName)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/ssh_user_set_shell.go
+++ b/panel-agent/internal/commands/ssh_user_set_shell.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"os/user"
 	"strings"
 
@@ -94,7 +93,7 @@ func sshUserSetShellHandler(ctx context.Context, params json.RawMessage) (any, e
 		}
 	}
 
-	cmd := exec.CommandContext(ctx, "chsh", "-s", p.Shell, p.Username)
+	cmd := execCommandContext(ctx, "chsh", "-s", p.Shell, p.Username)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -114,7 +113,7 @@ func sshUserSetShellHandler(ctx context.Context, params json.RawMessage) (any, e
 
 // getentShell returns the seventh field of the user's passwd row.
 func getentShell(ctx context.Context, username string) (string, *agentwire.AgentError) {
-	cmd := exec.CommandContext(ctx, "getent", "passwd", username)
+	cmd := execCommandContext(ctx, "getent", "passwd", username)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/panel-agent/internal/commands/ssl_install_custom.go
+++ b/panel-agent/internal/commands/ssl_install_custom.go
@@ -100,8 +100,8 @@ func sslInstallCustomHandler(ctx context.Context, params json.RawMessage) (any, 
 	// (nginx -t pre-check below catches that), and the existing daemon
 	// keeps serving with the previous cert. Operator can rerun the
 	// install after fixing the cert.
-	if testCmd := exec.CommandContext(ctx, "nginx", "-t"); testCmd.Run() == nil {
-		_ = exec.CommandContext(ctx, "nginx", "-s", "reload").Run()
+	if testCmd := execCommandContext(ctx, "nginx", "-t"); testCmd.Run() == nil {
+		_ = execCommandContext(ctx, "nginx", "-s", "reload").Run()
 	}
 
 	return sslInstallCustomResponse{CertPath: certPath, KeyPath: keyPath}, nil
@@ -121,7 +121,7 @@ func cleanupCertbotLineage(ctx context.Context, root, domain string) {
 		return // no certbot-managed lineage for this name — nothing to clean
 	}
 	if certbot, err := exec.LookPath("certbot"); err == nil {
-		cmd := exec.CommandContext(ctx, certbot, "delete",
+		cmd := execCommandContext(ctx, certbot, "delete",
 			"--cert-name", domain, "--config-dir", root, "--non-interactive")
 		if cmd.Run() == nil {
 			return

--- a/panel-agent/internal/commands/ssl_install_shared.go
+++ b/panel-agent/internal/commands/ssl_install_shared.go
@@ -13,7 +13,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -77,8 +76,8 @@ func sslInstallSharedHandler(ctx context.Context, params json.RawMessage) (any, 
 	// Reload nginx so already-attached domains pick up the (re)uploaded pair —
 	// the "one action renews N domains" payoff. Best-effort; the vhost paths
 	// are unchanged so nginx -t stays green.
-	if testCmd := exec.CommandContext(ctx, "nginx", "-t"); testCmd.Run() == nil {
-		_ = exec.CommandContext(ctx, "nginx", "-s", "reload").Run()
+	if testCmd := execCommandContext(ctx, "nginx", "-t"); testCmd.Run() == nil {
+		_ = execCommandContext(ctx, "nginx", "-s", "reload").Run()
 	}
 
 	return sslInstallSharedResponse{

--- a/panel-agent/internal/commands/ssl_issue_dns01_test.go
+++ b/panel-agent/internal/commands/ssl_issue_dns01_test.go
@@ -59,6 +59,7 @@ func TestSSLIssueDNS01_RejectsBadEmail(t *testing.T) {
 }
 
 func TestSSLIssueDNS01_AcceptsSingleWildcardSAN(t *testing.T) {
+	requireHostMutationAllowed(t) // GH #994: reaches internal/certbot\'s own exec (real `certbot certonly` / ACME) — outside the commands exec seam
 	// Passes validation and reaches certbot — which is absent in CI, so a
 	// CodeInternal (not CodeInvalidArgument) proves validation let it through.
 	_, err := callDNS01(t, `{"cert_name":"wildcard.example.com","sans":["example.com","*.example.com"],"email":"a@b.co"}`)

--- a/panel-agent/internal/commands/ssl_mail_issue.go
+++ b/panel-agent/internal/commands/ssl_mail_issue.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -342,7 +341,7 @@ func runPanelCertDeployHook(ctx context.Context, kind, certPath, domainID string
 		return fmt.Errorf("deploy-hook missing at %s: %w", hook, err)
 	}
 	lineage := lineageDirFromCertPath(certPath)
-	cmd := exec.CommandContext(ctx, hook)
+	cmd := execCommandContext(ctx, hook)
 	env := append(os.Environ(),
 		"JABALI_PANEL_CERT_KIND="+kind,
 		"RENEWED_LINEAGE="+lineage,

--- a/panel-agent/internal/commands/ssl_panel_issue.go
+++ b/panel-agent/internal/commands/ssl_panel_issue.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/certbot"
@@ -63,7 +62,7 @@ var runDeployHookFn = func(ctx context.Context, hostname, kind string) error {
 	if kind == "" {
 		kind = "hostname"
 	}
-	cmd := exec.CommandContext(ctx, panelDeployHook)
+	cmd := execCommandContext(ctx, panelDeployHook)
 	// certbot sets RENEWED_LINEAGE on real renewals; for first-issue
 	// we replicate the contract + pass the kind so the hook routes
 	// to the right deploy target (ADR-0105).

--- a/panel-agent/internal/commands/system_apt_check.go
+++ b/panel-agent/internal/commands/system_apt_check.go
@@ -185,7 +185,7 @@ func exitCodeOf(err error) int {
 // countInstalledPackages returns the number of installed dpkg packages, for
 // the "X of N packages" stat. Best-effort: 0 on error (the UI just omits it).
 func countInstalledPackages(ctx context.Context) int {
-	out, err := exec.CommandContext(ctx, "dpkg-query", "-f", "${db:Status-Abbrev}\n", "-W").Output()
+	out, err := execCommandContext(ctx, "dpkg-query", "-f", "${db:Status-Abbrev}\n", "-W").Output()
 	if err != nil {
 		return 0
 	}
@@ -202,7 +202,7 @@ func countInstalledPackages(ctx context.Context) int {
 // returns stdout, a combined output summary source, the exit code, and err.
 func runAptCapture(ctx context.Context, args ...string) (stdout []byte, stderr string, exitCode int, err error) {
 	full := append([]string{"-o", "DPkg::Lock::Timeout=60"}, args...)
-	cmd := exec.CommandContext(ctx, "apt-get", full...)
+	cmd := execCommandContext(ctx, "apt-get", full...)
 	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "DEBIAN_FRONTEND=noninteractive")
 	// apt-get writes most diagnostics to stderr but some to stdout; combine
 	// so classification sees everything regardless of stream.
@@ -216,7 +216,7 @@ func runAptCapture(ctx context.Context, args ...string) (stdout []byte, stderr s
 // aptListCapture runs `apt list --upgradable`, capturing stderr separately so
 // a failure (rare — lock/perm) is classifiable.
 func aptListCapture(ctx context.Context) (stdout []byte, stderr string, exitCode int, err error) {
-	cmd := exec.CommandContext(ctx, "apt", "list", "--upgradable")
+	cmd := execCommandContext(ctx, "apt", "list", "--upgradable")
 	cmd.Env = append(cmd.Environ(), "LC_ALL=C")
 	var errBuf strings.Builder
 	cmd.Stderr = &errBuf

--- a/panel-agent/internal/commands/system_apt_run.go
+++ b/panel-agent/internal/commands/system_apt_run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -21,10 +20,10 @@ type systemAptRunResponse struct {
 const aptUnitName = "jabali-apt-oneshot.service"
 
 func systemAptRunHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", aptUnitName).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", aptUnitName).Run()
 
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--unit="+aptUnitName,
 		"--no-block",
 		// No --collect: failed unit lingers (reconciler reads it as failed),

--- a/panel-agent/internal/commands/system_autoupdate.go
+++ b/panel-agent/internal/commands/system_autoupdate.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -106,7 +105,7 @@ func systemAutoupdateApplyHandler(ctx context.Context, raw json.RawMessage) (any
 	}
 
 	if changed {
-		if out, err := exec.CommandContext(ctx, "systemctl", "daemon-reload").CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "systemctl", "daemon-reload").CombinedOutput(); err != nil {
 			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("daemon-reload: %v: %s", err, out)}
 		}
 	}
@@ -141,15 +140,15 @@ func writeIfChanged(path, content string) (bool, error) {
 // setTimerEnabled enables --now or disables --now a timer, but only when its
 // current is-enabled state differs from desired. Returns whether it flipped.
 func setTimerEnabled(ctx context.Context, timer string, want bool) bool {
-	out, _ := exec.CommandContext(ctx, "systemctl", "is-enabled", timer).Output()
+	out, _ := execCommandContext(ctx, "systemctl", "is-enabled", timer).Output()
 	enabled := strings.TrimSpace(string(out)) == "enabled"
 	if enabled == want {
 		return false
 	}
 	if want {
-		_ = exec.CommandContext(ctx, "systemctl", "enable", "--now", timer).Run()
+		_ = execCommandContext(ctx, "systemctl", "enable", "--now", timer).Run()
 	} else {
-		_ = exec.CommandContext(ctx, "systemctl", "disable", "--now", timer).Run()
+		_ = execCommandContext(ctx, "systemctl", "disable", "--now", timer).Run()
 	}
 	return true
 }

--- a/panel-agent/internal/commands/system_info.go
+++ b/panel-agent/internal/commands/system_info.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
@@ -267,7 +266,7 @@ func readNTPSynced() bool {
 
 // timedatectlRunner is a var so tests can substitute.
 var timedatectlRunner = func(args ...string) (string, error) {
-	cmd := exec.Command("timedatectl", args...)
+	cmd := execCommand("timedatectl", args...)
 	out, err := cmd.Output()
 	return string(out), err
 }

--- a/panel-agent/internal/commands/system_module.go
+++ b/panel-agent/internal/commands/system_module.go
@@ -108,7 +108,7 @@ func probeModule(ctx context.Context, key string) moduleStatusResponse {
 		resp.Active = resp.Installed
 		return resp
 	}
-	if out, err := exec.CommandContext(ctx, "systemctl", "is-active", p.service).Output(); err == nil {
+	if out, err := execCommandContext(ctx, "systemctl", "is-active", p.service).Output(); err == nil {
 		resp.Active = strings.TrimSpace(string(out)) == "active"
 	}
 	return resp
@@ -162,7 +162,7 @@ func systemModuleInstallHandler(ctx context.Context, raw json.RawMessage) (any, 
 	// A per-key transient unit name keeps concurrent (post-lock, sequential)
 	// installs of different modules from colliding on the unit name.
 	unit := "jabali-module-install-" + req.Key
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--pipe", "--wait", "--quiet", "--collect",
 		"--unit="+unit,
 		"--service-type=oneshot",
@@ -201,7 +201,7 @@ func systemModuleDisableHandler(ctx context.Context, raw json.RawMessage) (any, 
 		if !unitExists(ctx, unit) {
 			continue
 		}
-		if out, err := exec.CommandContext(ctx, "systemctl", "disable", "--now", unit).CombinedOutput(); err != nil {
+		if out, err := execCommandContext(ctx, "systemctl", "disable", "--now", unit).CombinedOutput(); err != nil {
 			// Fail-soft: log-worthy but don't abort the rest. Return a generic
 			// error only if EVERY unit failed would be over-engineering — a
 			// single stubborn unit shouldn't strand the others already stopped.
@@ -214,7 +214,7 @@ func systemModuleDisableHandler(ctx context.Context, raw json.RawMessage) (any, 
 
 // unitExists reports whether systemd knows the unit (LoadState != not-found).
 func unitExists(ctx context.Context, unit string) bool {
-	out, err := exec.CommandContext(ctx, "systemctl", "show", "-p", "LoadState", "--value", unit).Output()
+	out, err := execCommandContext(ctx, "systemctl", "show", "-p", "LoadState", "--value", unit).Output()
 	if err != nil {
 		return false
 	}

--- a/panel-agent/internal/commands/system_nspawn_build.go
+++ b/panel-agent/internal/commands/system_nspawn_build.go
@@ -63,7 +63,7 @@ func systemNspawnBuildHandler(ctx context.Context, raw json.RawMessage) (any, er
 
 	// Clear any prior run's lingering unit state so a name collision doesn't
 	// reject the new run and journalctl --since scoping stays clean.
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", nspawnBuildUnit).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", nspawnBuildUnit).Run()
 
 	args := []string{"--unit=" + nspawnBuildUnit, "--no-block", repairBinary, "nspawn", "build",
 		"--codename", p.Codename, "--version", p.Version, "--snapshot", p.Snapshot}
@@ -74,7 +74,7 @@ func systemNspawnBuildHandler(ctx context.Context, raw json.RawMessage) (any, er
 		args = append(args, "--includes", p.Includes)
 	}
 	startedAt := time.Now().UTC()
-	if out, err := exec.CommandContext(ctx, "systemd-run", args...).CombinedOutput(); err != nil {
+	if out, err := execCommandContext(ctx, "systemd-run", args...).CombinedOutput(); err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemd-run: %v: %s", err, string(out))}
 	}
 	return nspawnBuildResponse{Unit: nspawnBuildUnit, StartedAt: startedAt.Format(time.RFC3339Nano)}, nil
@@ -103,7 +103,7 @@ func systemNspawnPruneHandler(ctx context.Context, raw json.RawMessage) (any, er
 	if p.Apply {
 		args = append(args, "--yes")
 	}
-	out, err := exec.CommandContext(ctx, repairBinary, args...).CombinedOutput()
+	out, err := execCommandContext(ctx, repairBinary, args...).CombinedOutput()
 	exitCode := 0
 	if err != nil {
 		var ee *exec.ExitError

--- a/panel-agent/internal/commands/system_repair.go
+++ b/panel-agent/internal/commands/system_repair.go
@@ -37,7 +37,7 @@ type systemRepairDiagnoseResponse struct {
 }
 
 func systemRepairDiagnoseHandler(ctx context.Context, _ json.RawMessage) (any, error) {
-	cmd := exec.CommandContext(ctx, repairBinary, "repair", "--diagnose")
+	cmd := execCommandContext(ctx, repairBinary, "repair", "--diagnose")
 	out, err := cmd.CombinedOutput()
 	exitCode := 0
 	if err != nil {
@@ -65,10 +65,10 @@ func systemRepairRunHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// Clear any prior run's lingering unit state (mirrors update_run) so a
 	// transient-name collision doesn't reject the new run and journalctl
 	// --since scoping stays clean.
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", repairUnitName).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", repairUnitName).Run()
 
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--unit="+repairUnitName,
 		"--no-block",
 		repairBinary, "repair", "--auto",

--- a/panel-agent/internal/commands/system_set_hostname.go
+++ b/panel-agent/internal/commands/system_set_hostname.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -51,7 +50,7 @@ func systemSetHostnameHandler(ctx context.Context, params json.RawMessage) (any,
 
 	// hostnamectl handles both systemd-hostnamed and the /etc/hostname
 	// write. Fall through with a clear error on distros that lack it.
-	cmd := exec.CommandContext(ctx, "hostnamectl", "set-hostname", p.Hostname)
+	cmd := execCommandContext(ctx, "hostnamectl", "set-hostname", p.Hostname)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("hostnamectl failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}

--- a/panel-agent/internal/commands/system_set_ssh_config.go
+++ b/panel-agent/internal/commands/system_set_ssh_config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -164,7 +163,7 @@ func systemSetSSHConfigHandler(ctx context.Context, params json.RawMessage) (any
 
 	// Validate the combined config (sshd -t reads main config + all drop-ins).
 	if os.Getenv("JABALI_SSHD_TEST_SKIP_VALIDATE") == "" {
-		cmd := exec.CommandContext(ctx, "sshd", "-t")
+		cmd := execCommandContext(ctx, "sshd", "-t")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			restoreFile(globalPath, prevGlobal)
 			restoreFile(sftpPath, prevSftp)
@@ -182,7 +181,7 @@ func systemSetSSHConfigHandler(ctx context.Context, params json.RawMessage) (any
 		if unit == "" {
 			return nil, fmt.Errorf("no ssh/sshd systemd unit found")
 		}
-		cmd := exec.CommandContext(ctx, "systemctl", "reload", unit)
+		cmd := execCommandContext(ctx, "systemctl", "reload", unit)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("systemctl reload %s: %s: %w", unit, strings.TrimSpace(string(out)), err)
 		}
@@ -200,7 +199,7 @@ func systemSetSSHConfigHandler(ctx context.Context, params json.RawMessage) (any
 // "" if neither is present (caller decides whether to fail or skip).
 func pickSSHUnit(ctx context.Context) string {
 	for _, name := range []string{"ssh", "sshd"} {
-		cmd := exec.CommandContext(ctx, "systemctl", "list-unit-files", name+".service")
+		cmd := execCommandContext(ctx, "systemctl", "list-unit-files", name+".service")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			continue

--- a/panel-agent/internal/commands/system_set_ssh_config_test.go
+++ b/panel-agent/internal/commands/system_set_ssh_config_test.go
@@ -225,6 +225,7 @@ func TestSystemSetSSHConfig_AtomicWrite(t *testing.T) {
 // rejects the new config, BOTH drop-ins must be restored to their previous
 // contents so we don't leave the box with one updated and one stale file.
 func TestSystemSetSSHConfig_RestoresBothOnValidationFailure(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	globalPath, sftpPath := setupSSHTestPaths(t)
 	t.Setenv("JABALI_SSHD_TEST_SKIP_VALIDATE", "") // re-enable the exec
 	t.Setenv("PATH", t.TempDir())                  // sshd not on PATH → exec fails

--- a/panel-agent/internal/commands/system_set_timezone.go
+++ b/panel-agent/internal/commands/system_set_timezone.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -72,7 +71,7 @@ func systemSetTimezoneHandler(ctx context.Context, params json.RawMessage) (any,
 	}
 
 	// Apply via timedatectl.
-	cmd := exec.CommandContext(ctx, "timedatectl", "set-timezone", p.Timezone)
+	cmd := execCommandContext(ctx, "timedatectl", "set-timezone", p.Timezone)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("timedatectl failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}

--- a/panel-agent/internal/commands/system_software.go
+++ b/panel-agent/internal/commands/system_software.go
@@ -117,7 +117,7 @@ func probeSoftware(ctx context.Context, p softwareProbe) string {
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	out, _ := exec.CommandContext(probeCtx, p.bin, p.args...).CombinedOutput()
+	out, _ := execCommandContext(probeCtx, p.bin, p.args...).CombinedOutput()
 	return parseVersion(string(out))
 }
 

--- a/panel-agent/internal/commands/system_ssh_keys.go
+++ b/panel-agent/internal/commands/system_ssh_keys.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -59,7 +58,7 @@ func systemSSHKeysListHandler(ctx context.Context, raw json.RawMessage) (any, er
 }
 
 func sshKeyHasPassphrase(privPath string) bool {
-	cmd := exec.Command("ssh-keygen", "-y", "-P", "", "-f", privPath) //nolint:gosec
+	cmd := execCommand("ssh-keygen", "-y", "-P", "", "-f", privPath) //nolint:gosec
 	if err := cmd.Run(); err != nil {
 		return true
 	}
@@ -105,7 +104,7 @@ func systemSSHKeysGenerateHandler(ctx context.Context, raw json.RawMessage) (any
 	if keyType == "rsa" {
 		args = append(args, "-b", "4096")
 	}
-	cmd := exec.CommandContext(ctx, "ssh-keygen", args...) //nolint:gosec
+	cmd := execCommandContext(ctx, "ssh-keygen", args...) //nolint:gosec
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("ssh-keygen failed: %v: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/panel-agent/internal/commands/system_unit_status.go
+++ b/panel-agent/internal/commands/system_unit_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -51,11 +50,11 @@ func systemUnitStatusFor(unit string) func(context.Context, json.RawMessage) (an
 		if since == "" {
 			since = time.Now().Add(-15 * time.Minute).UTC().Format(time.RFC3339)
 		}
-		statusOut, _ := exec.CommandContext(ctx, "systemctl", "is-active", unit).Output()
+		statusOut, _ := execCommandContext(ctx, "systemctl", "is-active", unit).Output()
 		status := strings.TrimSpace(string(statusOut))
 
 		journalArgs := []string{"-u", unit, "--since=" + since, "--no-pager", "-o", "cat"}
-		journalOut, _ := exec.CommandContext(ctx, "journalctl", journalArgs...).Output()
+		journalOut, _ := execCommandContext(ctx, "journalctl", journalArgs...).Output()
 
 		resp := systemUnitStatusResponse{
 			Unit:      unit,
@@ -66,7 +65,7 @@ func systemUnitStatusFor(unit string) func(context.Context, json.RawMessage) (an
 
 		// Read exit code from `systemctl show` once the unit terminates.
 		if status == "inactive" || status == "failed" {
-			showOut, err := exec.CommandContext(ctx, "systemctl", "show", unit,
+			showOut, err := execCommandContext(ctx, "systemctl", "show", unit,
 				"--property=ExecMainStatus", "--value").Output()
 			if err == nil {
 				if v, perr := strconv.Atoi(strings.TrimSpace(string(showOut))); perr == nil {

--- a/panel-agent/internal/commands/system_unit_stop.go
+++ b/panel-agent/internal/commands/system_unit_stop.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -30,7 +29,7 @@ func systemUnitStopHandler(ctx context.Context, raw json.RawMessage) (any, error
 	if !allowedStopUnits[p.Unit] {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "unit not allowlisted"}
 	}
-	out, err := exec.CommandContext(ctx, "systemctl", "stop", p.Unit).CombinedOutput()
+	out, err := execCommandContext(ctx, "systemctl", "stop", p.Unit).CombinedOutput()
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("systemctl stop: %v: %s", err, strings.TrimSpace(string(out)))}
 	}

--- a/panel-agent/internal/commands/system_update_check.go
+++ b/panel-agent/internal/commands/system_update_check.go
@@ -92,7 +92,7 @@ const (
 // on a repo owned by a different uid.
 func runAsServiceUser(ctx context.Context, args ...string) ([]byte, error) {
 	full := append([]string{"-u", systemServiceUser, "-H"}, args...)
-	c := exec.CommandContext(ctx, "sudo", full...)
+	c := execCommandContext(ctx, "sudo", full...)
 	out, err := c.Output()
 	if err != nil {
 		stderr := ""

--- a/panel-agent/internal/commands/system_update_run.go
+++ b/panel-agent/internal/commands/system_update_run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -33,10 +32,10 @@ func systemUpdateRunHandler(ctx context.Context, _ json.RawMessage) (any, error)
 	// `journalctl --since=<now>` output. systemd keeps failed-unit state
 	// indefinitely; without `reset-failed`, a second run that hits a
 	// transient name collision is rejected with ALREADY_EXISTS.
-	_ = exec.CommandContext(ctx, "systemctl", "reset-failed", updateUnitName).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", updateUnitName).Run()
 
 	startedAt := time.Now().UTC()
-	cmd := exec.CommandContext(ctx, "systemd-run",
+	cmd := execCommandContext(ctx, "systemd-run",
 		"--unit="+updateUnitName,
 		// Tell the CLI this run came from the panel so it does NOT also
 		// write an update_history row — the API already logged it (GH #300).

--- a/panel-agent/internal/commands/terminal_pty.go
+++ b/panel-agent/internal/commands/terminal_pty.go
@@ -30,7 +30,6 @@ import (
 	"golang.org/x/sys/unix"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"syscall"
@@ -215,7 +214,7 @@ func handleTerminalConn(raw net.Conn, recordDir string, gid int, log *slog.Logge
 
 	// Spawn the root shell. Agent is uid 0 so no privilege juggling;
 	// new session + controlling TTY via creack/pty.
-	cmd := exec.Command("/bin/bash", "-l")
+	cmd := execCommand("/bin/bash", "-l")
 	cmd.Env = append(os.Environ(),
 		"TERM=xterm-256color",
 		"JABALI_ROOT_TERMINAL=1",

--- a/panel-agent/internal/commands/user_create.go
+++ b/panel-agent/internal/commands/user_create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -58,7 +57,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	}
 
 	// Check if user already exists.
-	checkCmd := exec.CommandContext(ctx, "id", p.Username)
+	checkCmd := execCommandContext(ctx, "id", p.Username)
 	if err := checkCmd.Run(); err == nil {
 		// User exists.
 		return nil, &agentwire.AgentError{
@@ -72,7 +71,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// let one tenant read another's group-www-data docroot files. nginx reaches
 	// docroots via the setgid-www-data docroot group + the per-user FPM socket via
 	// a root ACL (fpm-post-start), neither of which needs tenant membership.
-	createCmd := exec.CommandContext(ctx, "useradd",
+	createCmd := execCommandContext(ctx, "useradd",
 		"--create-home",
 		"--home-dir", p.HomeDir,
 		"--shell", p.Shell,
@@ -87,7 +86,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 
 	// Set password if provided.
 	if p.Password != "" {
-		chpasswdCmd := exec.CommandContext(ctx, "chpasswd")
+		chpasswdCmd := execCommandContext(ctx, "chpasswd")
 		chpasswdCmd.Stdin = strings.NewReader(p.Username + ":" + p.Password + "\n")
 		if err := chpasswdCmd.Run(); err != nil {
 			return nil, &agentwire.AgentError{
@@ -100,7 +99,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// Chown home to <user>:www-data so nginx (running as www-data) can
 	// read the docroot via group perms. Tenants stay isolated: other
 	// regular users can't read /home/<user>.
-	chownCmd := exec.CommandContext(ctx, "chown", p.Username+":www-data", p.HomeDir)
+	chownCmd := execCommandContext(ctx, "chown", p.Username+":www-data", p.HomeDir)
 	if err := chownCmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
@@ -109,7 +108,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	}
 
 	// 0750: owner (user) rwx, group (www-data) rx, others nothing.
-	chmodCmd := exec.CommandContext(ctx, "chmod", "0750", p.HomeDir)
+	chmodCmd := execCommandContext(ctx, "chmod", "0750", p.HomeDir)
 	if err := chmodCmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInternal,
@@ -118,7 +117,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	}
 
 	// Get UID.
-	idCmd := exec.CommandContext(ctx, "id", "-u", p.Username)
+	idCmd := execCommandContext(ctx, "id", "-u", p.Username)
 	uidOutput, err := idCmd.Output()
 	if err != nil {
 		return nil, &agentwire.AgentError{
@@ -140,7 +139,7 @@ func userCreateHandler(ctx context.Context, params json.RawMessage) (any, error)
 	_, sliceErr := userSliceEnsureHandler(ctx, sliceParams)
 	if sliceErr != nil {
 		// Rollback the user creation to avoid leaving a user without isolation.
-		rollbackCmd := exec.CommandContext(ctx, "userdel", "--remove", p.Username)
+		rollbackCmd := execCommandContext(ctx, "userdel", "--remove", p.Username)
 		if err := rollbackCmd.Run(); err != nil {
 			slog.ErrorContext(ctx, "failed to rollback useradd after slice-ensure failure",
 				"username", p.Username, "rollback_err", err)

--- a/panel-agent/internal/commands/user_delete.go
+++ b/panel-agent/internal/commands/user_delete.go
@@ -58,7 +58,7 @@ func userDeleteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	}
 
 	// Check if user exists.
-	checkCmd := exec.CommandContext(ctx, "id", p.Username)
+	checkCmd := execCommandContext(ctx, "id", p.Username)
 	if err := checkCmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeNotFound,
@@ -94,7 +94,7 @@ func userDeleteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// trips on the /var/lib/systemd/linger/<user> flag and exits 12
 	// ("can't remove home directory") even after slice removal (mx scar
 	// 2026-04-30).
-	if err := exec.CommandContext(ctx, "loginctl", "disable-linger", p.Username).Run(); err != nil {
+	if err := execCommandContext(ctx, "loginctl", "disable-linger", p.Username).Run(); err != nil {
 		// Best-effort. Linger may already be off.
 		slog.InfoContext(ctx, "loginctl disable-linger failed (best-effort)",
 			"username", p.Username, "err", err.Error())
@@ -103,9 +103,9 @@ func userDeleteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// Delete user. Capture stderr for diagnostics.
 	var deleteCmd *exec.Cmd
 	if p.RemoveHome {
-		deleteCmd = exec.CommandContext(ctx, "userdel", "--remove", p.Username)
+		deleteCmd = execCommandContext(ctx, "userdel", "--remove", p.Username)
 	} else {
-		deleteCmd = exec.CommandContext(ctx, "userdel", p.Username)
+		deleteCmd = execCommandContext(ctx, "userdel", p.Username)
 	}
 	var stderr bytes.Buffer
 	deleteCmd.Stderr = &stderr

--- a/panel-agent/internal/commands/user_egress_drops.go
+++ b/panel-agent/internal/commands/user_egress_drops.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"encoding/json"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -55,7 +54,7 @@ func egressDropsHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		Events: []egressDropEvent{},
 	}
 	// Grep the kernel log for this user's drop prefix. Bounded lines + no shell.
-	out, err := exec.CommandContext(ctx, "journalctl", "-k", "--no-pager",
+	out, err := execCommandContext(ctx, "journalctl", "-k", "--no-pager",
 		"--output=short-iso", "-n", "2000",
 		"-g", "jabali-egress-drop-"+p.Username+" ").Output()
 	if err != nil {

--- a/panel-agent/internal/commands/user_password.go
+++ b/panel-agent/internal/commands/user_password.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -61,7 +60,7 @@ func userPasswordHandler(ctx context.Context, params json.RawMessage) (any, erro
 	}
 
 	// Check if user exists.
-	checkCmd := exec.CommandContext(ctx, "id", p.Username)
+	checkCmd := execCommandContext(ctx, "id", p.Username)
 	if err := checkCmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeNotFound,
@@ -84,7 +83,7 @@ func userPasswordHandler(ctx context.Context, params json.RawMessage) (any, erro
 		args = nil
 		input = p.Username + ":" + p.Password + "\n"
 	}
-	chpasswdCmd := exec.CommandContext(ctx, "chpasswd", args...)
+	chpasswdCmd := execCommandContext(ctx, "chpasswd", args...)
 	chpasswdCmd.Stdin = strings.NewReader(input)
 	if err := chpasswdCmd.Run(); err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/user_slice_ensure.go
+++ b/panel-agent/internal/commands/user_slice_ensure.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -40,7 +39,7 @@ var testMutex sync.Mutex
 
 // runCmd can be overridden in tests. In production, it dispatches to the OS.
 var runCmd = func(ctx context.Context, name string, args ...string) ([]byte, []byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
+	cmd := execCommandContext(ctx, name, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/panel-agent/internal/commands/user_slice_status.go
+++ b/panel-agent/internal/commands/user_slice_status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -75,7 +74,7 @@ func userSliceStatusHandler(ctx context.Context, params json.RawMessage) (any, e
 
 // systemctlUnitActive returns true when `systemctl is-active <unit>` exits 0.
 func systemctlUnitActive(ctx context.Context, unit string) bool {
-	cmd := exec.CommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
+	cmd := execCommandContext(ctx, "systemctl", "is-active", "--quiet", unit)
 	return cmd.Run() == nil
 }
 
@@ -86,7 +85,7 @@ func systemctlShow(ctx context.Context, unit string, props ...string) (map[strin
 	for _, p := range props {
 		args = append(args, "-p", p)
 	}
-	cmd := exec.CommandContext(ctx, "systemctl", args...)
+	cmd := execCommandContext(ctx, "systemctl", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/panel-agent/internal/commands/user_suspend.go
+++ b/panel-agent/internal/commands/user_suspend.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 )
@@ -58,7 +57,7 @@ func userSuspendHandler(ctx context.Context, params json.RawMessage) (any, error
 		resp.Note = fmt.Sprintf("group lookup failed: %v", gErr)
 	}
 	if inSFTP {
-		cmd := exec.CommandContext(ctx, "gpasswd", "-d", p.Username, sftpGroupName)
+		cmd := execCommandContext(ctx, "gpasswd", "-d", p.Username, sftpGroupName)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
@@ -73,7 +72,7 @@ func userSuspendHandler(ctx context.Context, params json.RawMessage) (any, error
 	// 2. usermod -L locks the password (prefixes shadow hash with !).
 	// Reversible via -U on unsuspend. Idempotent: locking a locked
 	// account is a no-op.
-	cmd := exec.CommandContext(ctx, "usermod", "-L", p.Username)
+	cmd := execCommandContext(ctx, "usermod", "-L", p.Username)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -102,7 +101,7 @@ func userUnsuspendHandler(ctx context.Context, params json.RawMessage) (any, err
 	resp := &userSuspendResponse{Username: p.Username}
 
 	// 1. Add back to jabali-sftp. usermod -aG is idempotent.
-	cmd := exec.CommandContext(ctx, "usermod", "-aG", sftpGroupName, p.Username)
+	cmd := execCommandContext(ctx, "usermod", "-aG", sftpGroupName, p.Username)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -114,7 +113,7 @@ func userUnsuspendHandler(ctx context.Context, params json.RawMessage) (any, err
 	resp.SFTPGroupAdded = true
 
 	// 2. usermod -U unlocks (strips the leading !).
-	cmd = exec.CommandContext(ctx, "usermod", "-U", p.Username)
+	cmd = execCommandContext(ctx, "usermod", "-U", p.Username)
 	stderr.Reset()
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/panel-agent/internal/commands/webmail_vhost.go
+++ b/panel-agent/internal/commands/webmail_vhost.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"text/template"
 
@@ -463,14 +462,14 @@ var nginxTestAndReload = defaultNginxTestAndReload
 
 func defaultNginxTestAndReload(ctx context.Context) error {
 	var out bytes.Buffer
-	test := exec.CommandContext(ctx, "nginx", "-t")
+	test := execCommandContext(ctx, "nginx", "-t")
 	test.Stdout = &out
 	test.Stderr = &out
 	if err := test.Run(); err != nil {
 		return nginxTestFailure("webmail.vhost", out.String())
 	}
 	out.Reset()
-	reload := exec.CommandContext(ctx, "systemctl", "reload", "nginx")
+	reload := execCommandContext(ctx, "systemctl", "reload", "nginx")
 	reload.Stdout = &out
 	reload.Stderr = &out
 	if err := reload.Run(); err != nil {

--- a/panel-agent/internal/commands/wordpress_cache.go
+++ b/panel-agent/internal/commands/wordpress_cache.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -106,7 +105,7 @@ func wordpressCacheSetHandler(ctx context.Context, raw json.RawMessage) (any, er
 	}
 	// Normalize ownership regardless of source: nginx (www-data) must be able to
 	// read the plugin files the per-user PHP-FPM pool serves.
-	if err := exec.CommandContext(ctx, "chown", "-R", p.OSUser+":www-data", dest).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", p.OSUser+":www-data", dest).Run(); err != nil {
 		return nil, bkInternal("chown plugin", err)
 	}
 
@@ -140,8 +139,8 @@ func wordpressCacheSetHandler(ctx context.Context, raw json.RawMessage) (any, er
 	// jabali-redis-clients, NOT jabali-sockets — tenants must never reach the
 	// root agent socket; ADR-0148). Group membership is fixed at the fpm master
 	// start, so the per-user master is RESTARTED (not reloaded) to pick it up.
-	_ = exec.CommandContext(ctx, "groupadd", "-f", redisClientsGroup).Run()
-	if err := exec.CommandContext(ctx, "usermod", "-aG", redisClientsGroup, p.OSUser).Run(); err != nil {
+	_ = execCommandContext(ctx, "groupadd", "-f", redisClientsGroup).Run()
+	if err := execCommandContext(ctx, "usermod", "-aG", redisClientsGroup, p.OSUser).Run(); err != nil {
 		return nil, bkInternal("add tenant to "+redisClientsGroup, err)
 	}
 	// Grant the group access to the Redis socket — both PERSISTENTLY (a redis
@@ -151,7 +150,7 @@ func wordpressCacheSetHandler(ctx context.Context, raw json.RawMessage) (any, er
 	// no longer depends on a full installer run. Idempotent + best-effort.
 	ensureRedisSocketGroupAccess(ctx, socket)
 	// Best-effort: a missing/!active fpm master (e.g. CLI-only install) isn't fatal.
-	_ = exec.CommandContext(ctx, "systemctl", "restart", "jabali-fpm@"+p.OSUser+".service").Run()
+	_ = execCommandContext(ctx, "systemctl", "restart", "jabali-fpm@"+p.OSUser+".service").Run()
 
 	// 4. Activate + enable (drop-ins + WP_CACHE), as the tenant.
 	if out, err := runWPAsTenantOut(ctx, p.OSUser, p.InstallPath, "plugin", "activate", "jabali-cache"); err != nil {
@@ -312,14 +311,14 @@ func ensureRedisSocketGroupAccess(ctx context.Context, socket string) {
 	if cur, err := os.ReadFile(unitPath); err != nil || string(cur) != redisSocketAccessDropIn {
 		if mkErr := os.MkdirAll("/etc/systemd/system/redis-server.service.d", 0o755); mkErr == nil {
 			if wErr := os.WriteFile(unitPath, []byte(redisSocketAccessDropIn), 0o644); wErr == nil {
-				_ = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
+				_ = execCommandContext(ctx, "systemctl", "daemon-reload").Run()
 			}
 		}
 	}
 	// Immediate: apply to the live runtime dir + socket (the drop-in only fires on
 	// the next redis (re)start).
-	_ = exec.CommandContext(ctx, "setfacl", "-m", "g:"+redisClientsGroup+":rx", "/run/redis").Run()
-	_ = exec.CommandContext(ctx, "setfacl", "-m", "g:"+redisClientsGroup+":rw", socket).Run()
+	_ = execCommandContext(ctx, "setfacl", "-m", "g:"+redisClientsGroup+":rx", "/run/redis").Run()
+	_ = execCommandContext(ctx, "setfacl", "-m", "g:"+redisClientsGroup+":rw", socket).Run()
 }
 
 func runWPAsTenant(ctx context.Context, osUser, installPath string, args ...string) error {
@@ -404,13 +403,13 @@ func stageBundledCachePlugin(ctx context.Context, dest, osUser string) error {
 		return &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition,
 			Message: fmt.Sprintf("bundled jabali-cache missing at %s \u2014 re-run install.sh", bundledWPCachePluginDir)}
 	}
-	if err := exec.CommandContext(ctx, "rm", "-rf", dest).Run(); err != nil {
+	if err := execCommandContext(ctx, "rm", "-rf", dest).Run(); err != nil {
 		return bkInternal("clear old plugin", err)
 	}
-	if err := exec.CommandContext(ctx, "cp", "-a", bundledWPCachePluginDir, dest).Run(); err != nil {
+	if err := execCommandContext(ctx, "cp", "-a", bundledWPCachePluginDir, dest).Run(); err != nil {
 		return bkInternal("stage plugin (bundled)", err)
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", osUser+":www-data", dest).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", osUser+":www-data", dest).Run(); err != nil {
 		return bkInternal("chown plugin", err)
 	}
 	return nil

--- a/panel-agent/internal/commands/wordpress_cache_health.go
+++ b/panel-agent/internal/commands/wordpress_cache_health.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +118,7 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 			if writeOut != "" {
 				args = append(args, "-w", writeOut)
 			}
-			out, _ := exec.CommandContext(cctx, "curl", append(args, "https://"+host+path)...).Output()
+			out, _ := execCommandContext(cctx, "curl", append(args, "https://"+host+path)...).Output()
 			return strings.TrimSpace(string(out))
 		}
 		// Homepage TTFB (GH #620).
@@ -131,7 +130,7 @@ func wordpressCacheProbeHandler(ctx context.Context, params json.RawMessage) (an
 		cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 		// GET, not HEAD (-I): the nginx cache key embeds $request_method, so a
 		// HEAD can never HIT the GET-primed entry and this probe always read MISS.
-		hdr, _ := exec.CommandContext(cctx, "curl", "-ks", "-o", "/dev/null", "-D", "-", "--max-time", "8",
+		hdr, _ := execCommandContext(cctx, "curl", "-ks", "-o", "/dev/null", "-D", "-", "--max-time", "8",
 			"--resolve", host+":443:127.0.0.1", "https://"+host+"/").Output()
 		cancel()
 		hitVerified = strings.Contains(strings.ToUpper(string(hdr)), "X-JABALI-CACHE: HIT")

--- a/panel-agent/internal/commands/wordpress_clone.go
+++ b/panel-agent/internal/commands/wordpress_clone.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -168,13 +167,13 @@ func wordpressCloneHandler(ctx context.Context, params json.RawMessage) (any, er
 	// For now, we'll assume the agent has access and use the host/port from the environment
 	// or defaults to localhost (unix socket).
 
-	dumpCmd := exec.CommandContext(ctx,
+	dumpCmd := execCommandContext(ctx,
 		"mysqldump",
 		"--single-transaction",
 		req.SrcDBName,
 	)
 
-	restoreCmd := exec.CommandContext(ctx,
+	restoreCmd := execCommandContext(ctx,
 		"mysql",
 		"-h", req.DstDBHost,
 		req.DstDBName,
@@ -379,13 +378,13 @@ func writeFileAsUser(ctx context.Context, osUser, filePath, content string, perm
 	}
 
 	// Chown to the user (required because tee inherits umask)
-	chownCmd := exec.CommandContext(ctx, "chown", osUser+":"+osUser, filePath)
+	chownCmd := execCommandContext(ctx, "chown", osUser+":"+osUser, filePath)
 	if err := chownCmd.Run(); err != nil {
 		return err
 	}
 
 	// Set permissions
-	chmodCmd := exec.CommandContext(ctx, "chmod", fmt.Sprintf("%o", perm), filePath)
+	chmodCmd := execCommandContext(ctx, "chmod", fmt.Sprintf("%o", perm), filePath)
 	if err := chmodCmd.Run(); err != nil {
 		return err
 	}

--- a/panel-agent/internal/commands/wordpress_create_sso_file_test.go
+++ b/panel-agent/internal/commands/wordpress_create_sso_file_test.go
@@ -33,6 +33,7 @@ func fakeWPInstall(t *testing.T) string {
 }
 
 func TestCreateWordPressSSOFile_HappyPath(t *testing.T) {
+	withRealExec(t) // GH #994: needs the real read-only command (stub returns empty output)
 	dir := fakeWPInstall(t)
 	me, err := user.Current()
 	if err != nil {

--- a/panel-agent/internal/commands/wordpress_install.go
+++ b/panel-agent/internal/commands/wordpress_install.go
@@ -133,7 +133,7 @@ func buildSystemdRunCmd(ctx context.Context, osUser string, args ...string) *exe
 		}
 	}
 	cmdArgs = append(cmdArgs, args...)
-	return exec.CommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
+	return execCommandContext(ctx, cmdArgs[0], cmdArgs[1:]...)
 }
 
 // removePlaceholderIndex deletes index.html at the install root if present.
@@ -175,7 +175,7 @@ func removePlaceholderIndex(ctx context.Context, installPath string) {
 	if err := assertSafeInstallRoot(installPath); err != nil {
 		return // never rm through a planted symlink (#457)
 	}
-	_ = exec.CommandContext(ctx, "rm", "-f", filepath.Join(installPath, "index.html")).Run()
+	_ = execCommandContext(ctx, "rm", "-f", filepath.Join(installPath, "index.html")).Run()
 }
 
 // normalizePermsToWwwData makes the WP tree match the project's ownership
@@ -192,13 +192,13 @@ func normalizePermsToWwwData(ctx context.Context, installPath, osUser string) er
 	if err := assertSafeInstallRoot(installPath); err != nil {
 		return err
 	}
-	if err := exec.CommandContext(ctx, "chown", "-R", osUser+":www-data", installPath).Run(); err != nil {
+	if err := execCommandContext(ctx, "chown", "-R", osUser+":www-data", installPath).Run(); err != nil {
 		return fmt.Errorf("chown -R %s:www-data %s: %w", osUser, installPath, err)
 	}
-	if err := exec.CommandContext(ctx, "find", installPath, "-type", "d", "-exec", "chmod", "2750", "{}", "+").Run(); err != nil {
+	if err := execCommandContext(ctx, "find", installPath, "-type", "d", "-exec", "chmod", "2750", "{}", "+").Run(); err != nil {
 		return fmt.Errorf("chmod dirs 2750 under %s: %w", installPath, err)
 	}
-	if err := exec.CommandContext(ctx, "find", installPath, "-type", "f", "-exec", "chmod", "0640", "{}", "+").Run(); err != nil {
+	if err := execCommandContext(ctx, "find", installPath, "-type", "f", "-exec", "chmod", "0640", "{}", "+").Run(); err != nil {
 		return fmt.Errorf("chmod files 0640 under %s: %w", installPath, err)
 	}
 	// #430 interim: wp-config.php / .env hold DB + cache creds; keep them
@@ -227,7 +227,7 @@ func cleanupWordPressFiles(ctx context.Context, docroot string) error {
 	for _, file := range files {
 		path := filepath.Join(docroot, file)
 		// Use rm via exec to match the documented behavior
-		cmd := exec.CommandContext(ctx, "rm", "-rf", path)
+		cmd := execCommandContext(ctx, "rm", "-rf", path)
 		// Ignore errors; best-effort cleanup
 		_ = cmd.Run()
 	}
@@ -403,7 +403,7 @@ func wordpressInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 	// confusing "not a WordPress installation" error on the next step.
 	if _, statErr := os.Stat(filepath.Join(installPath, "wp-load.php")); os.IsNotExist(statErr) {
 		var lsOut bytes.Buffer
-		lsCmd := exec.CommandContext(ctx, "ls", "-la", installPath)
+		lsCmd := execCommandContext(ctx, "ls", "-la", installPath)
 		lsCmd.Stdout = &lsOut
 		_ = lsCmd.Run()
 		return nil, &agentwire.AgentError{
@@ -509,7 +509,7 @@ func wordpressInstallHandler(ctx context.Context, params json.RawMessage) (any, 
 	// of the docroot once normalizePermsToWwwData runs at the end.
 	// Group=www-data lets nginx (in www-data) read the file via group bits;
 	// FPM (running as <user>) reads via owner bits.
-	chownCmd := exec.CommandContext(ctx, "chown", req.OSUser+":www-data", configPath)
+	chownCmd := execCommandContext(ctx, "chown", req.OSUser+":www-data", configPath)
 	if err := chownCmd.Run(); err != nil {
 		_ = cleanupWordPressFiles(ctx, installPath)
 		return nil, &agentwire.AgentError{


### PR DESCRIPTION
## GH #994 — the real cure

The band-aid (c2da8b4a) gated destructive agent tests **one at a time**; new ungated ones kept landing (PR #1157 gated the latest four). This is the structural fix so the class can't recur.

Every `os/exec` call in **package commands** (470 sites, 159 files) now routes through two package vars:

```go
var execCommandContext = exec.CommandContext
var execCommand        = exec.Command
```

Production is a bare passthrough — zero indirection, no env checks. The **test binary's `TestMain`** redirects the seam to a harmless stub (drains stdin, emits nothing, exits 0) **unless** the operator opts in with `JABALI_ALLOW_HOST_MUTATION=1`. So a bare `go test ./...` can no longer touch the host: no `systemctl`, `timedatectl`, `rm`, `useradd`, no polkit prompt.

### Mechanism notes
- Stub path is baked into **argv**, not an env marker, so the 28 handlers that set `cmd.Env` cannot defeat it.
- `*exec.Cmd` return preserved, so `.Dir/.Env/.Stdin/.CombinedOutput/.Run/.Start` all keep working — mechanical token swap, **no gofmt run**, so the diff stays reviewable (470/588 lines, all exec-token + unused-import removal).
- `TestExecSeam_NoRawExec` walks non-test files and fails if any calls `os/exec` directly → keeps the cure durable (replaces the sweep-as-CI-job idea; new destructive handlers must use the seam).
- `withRealExec(t)` restores real exec for the handful of tests that must run a genuinely **read-only** command (`du`/`id`/`getent`/`sshd -t`); the stub's empty output would otherwise break them.

### Scope / follow-up
- Cures `panel-agent/internal/commands` — where all four #994 findings lived.
- `internal/certbot` has its **own** exec (`Runner.Binary`); one commands test (`TestSSLIssueDNS01_AcceptsSingleWildcardSAN`) reaches real `certbot`/ACME through it, so it's gated here. Seaming certbot (and any other agent package with raw exec) is a follow-up — the issue's "every exec" is broader than one PR.

### Verification
- Bare `go test ./internal/commands` → green; **PATH-stub sweep** (destructive binaries stubbed on PATH) logs only tmpdir-scoped `chmod/chown/mv` from a shell-helper test — **zero non-tmp / zero real host mutation**.
- Guard catches a reintroduced raw `exec.Command` (verified fail→pass).
- `JABALI_ALLOW_HOST_MUTATION=1` restores the real path (integration/gated tests unchanged).

### Relationship to #1157
Composes with #1157's per-test gates (they become redundant-but-harmless — the stub already neutralizes those four). Merge either order; no file conflict. #1157 can be closed as superseded or kept as belt-and-suspenders — your call.

GH #994