### PR TITLE
feat(api): opt-in Automation API on :443 for firewalled billing hosts (GH #1161)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4611,6 +4611,7 @@ jabali repair [flags]
 - `--apparmor-profiles-disabled` — Fix only: jabali AppArmor profiles exist but are disabled
 - `--apparmor-profiles-missing` — Fix only: jabali AppArmor profiles absent from /etc/apparmor.d/
 - `--auto` — Fix every non-destructive (safe) issue
+- `--automation-443-include` — Fix only: panel-hostname :443 vhost missing the GH #1161 automation-API include (admin can't opt into API-on-443 for firewalled billing hosts)
 - `--bulwark-jwt-secret` — Fix only: Bulwark webmail-SSO secret poisoned / out of sync with bulwark.env (mail impersonation 'Invalid signature')
 - `--crowdsec-bouncer-key` — Fix only: crowdsec-firewall-bouncer crash-loops with stale LAPI key
 - `--daemon-reload` — Fix only: systemd has unloaded unit-file changes on disk

--- a/install.sh
+++ b/install.sh
@@ -7439,6 +7439,14 @@ server {
     location = /webmail  { return 301 https://mail.${JABALI_SRV_HOSTNAME}/; }
     location = /webmail/ { return 301 https://mail.${JABALI_SRV_HOSTNAME}/; }
 
+    # GH #1161: opt-in Automation API on :443. Empty by default (the API is
+    # :8443-only); the agent (nginx.automation_public_set, driven by
+    # server_settings.automation_api_public_enabled) fills this with the
+    # /api/v1/automation/ proxy when an admin opts in. Seeded empty below so
+    # nginx -t never fails on a missing include. Only the HMAC-gated
+    # automation tree is ever proxied here; internal endpoints stay :8443-only.
+    include /etc/nginx/snippets/jabali-automation-443.conf;
+
     location / {
         try_files \$uri \$uri/ =404;
     }
@@ -7459,6 +7467,21 @@ server {
 VHOSTEOF
 
   _ok "default vhost config written"
+
+  # GH #1161: seed the opt-in Automation-API-on-443 include EMPTY. The API
+  # stays :8443-only until an admin enables it in Server Settings, at which
+  # point the reconciler has the agent (nginx.automation_public_set) rewrite
+  # this file with the /api/v1/automation/ proxy location. Created only when
+  # absent so a reinstall never clobbers an agent-written ON block (which
+  # would silently disable the feature). Its own include line above (and the
+  # repair self-heal) guarantee nginx -t has a target.
+  local automation443_conf="/etc/nginx/snippets/jabali-automation-443.conf"
+  mkdir -p /etc/nginx/snippets
+  if [[ ! -f "$automation443_conf" ]]; then
+    _log "seeding empty ${automation443_conf} (automation API opt-in, default off)"
+    printf '# Managed by jabali-agent (nginx.automation_public_set). Empty = API on :8443 only.\n' > "$automation443_conf"
+    chmod 0644 "$automation443_conf"
+  fi
 
   # GH#135: docroot for the panel-hostname landing page served by the
   # dedicated vhost above. Created idempotently; the default index.html is

--- a/panel-agent/internal/commands/automation_public.go
+++ b/panel-agent/internal/commands/automation_public.go
@@ -1,0 +1,133 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// GH #1161: opt-in exposure of the Automation API on :443.
+//
+// The panel-hostname :443 vhost (install.sh GH#135 block) `include`s this
+// snippet at server scope. Default: empty (the API is :8443-only). When the
+// admin enables server_settings.automation_api_public_enabled, the reconciler
+// calls nginx.automation_public_set{enabled:true} and the agent writes the
+// location that proxies /api/v1/automation/ to the panel socket; disabling
+// writes it back to empty.
+//
+// Only /api/v1/automation/ is exposed — every route there is behind
+// RequireAutomationHMAC (canonical string METHOD\nPATH\nts\nsha256(BODY), no
+// host/port, so :443 validates exactly as :8443). The internal, unauthenticated
+// endpoints (/api/v1/internal/, the malware event) are NOT proxied here; they
+// stay :8443-only where the 8443 vhost's 404 guards live. Mirrors the GH#860
+// catch-all include toggle (convergeCatchall).
+// var (not const) so tests can redirect it to a temp dir, mirroring
+// catchallConfPath.
+var automation443ConfPath = "/etc/nginx/snippets/jabali-automation-443.conf"
+
+// automation443OnConf is a server-scope location{} pulled into the hostname
+// :443 vhost via include. proxy_pass has NO URI part so the full request path
+// reaches panel-api unchanged; the 3600s timeouts cover the sync-long
+// automation calls (backups.create) that would otherwise 502.
+const automation443OnConf = `# Managed by jabali-agent (nginx.automation_public_set) — do not edit.
+# Automation API on :443 is ENABLED (Server Settings). Only the HMAC-gated
+# /api/v1/automation/ tree; internal endpoints stay :8443-only.
+location ^~ /api/v1/automation/ {
+    proxy_pass http://unix:/run/jabali-panel/api.sock;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_http_version 1.1;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+`
+
+// automation443OffConf MUST match, byte-for-byte, the seed written by
+// install.sh (install_default_vhost) and by the repair self-heal
+// (fixAutomation443Include) so the OFF state is a true no-op — otherwise the
+// first reconcile after deploy would rewrite the file and pointlessly reload
+// nginx on every box. A comment-only file = an empty include (no directives).
+const automation443OffConf = "# Managed by jabali-agent (nginx.automation_public_set). Empty = API on :8443 only.\n"
+
+type automationPublicSetParams struct {
+	Enabled *bool `json:"enabled"`
+}
+
+type automationPublicSetResponse struct {
+	Ok      bool `json:"ok"`
+	Changed bool `json:"changed"`
+	Enabled bool `json:"enabled"`
+}
+
+// automationPublicSetHandler converges the automation-on-443 include to the
+// requested toggle state and reloads nginx if it changed.
+func automationPublicSetHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p automationPublicSetParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid params: %v", err),
+		}
+	}
+	changed, err := convergeAutomation443(ctx, p.Enabled)
+	if err != nil {
+		return nil, err
+	}
+	return automationPublicSetResponse{
+		Ok:      true,
+		Changed: changed,
+		Enabled: p.Enabled != nil && *p.Enabled,
+	}, nil
+}
+
+// convergeAutomation443 writes the automation-on-443 include to match the
+// opt-in toggle and reloads nginx only when the file actually changed. A nil
+// enabled (panel predates the toggle) is a no-op. Mirrors convergeCatchall.
+func convergeAutomation443(ctx context.Context, enabled *bool) (bool, error) {
+	if enabled == nil {
+		return false, nil
+	}
+	desired := automation443OffConf
+	if *enabled {
+		desired = automation443OnConf
+	}
+
+	nginxOpMu.Lock()
+	defer nginxOpMu.Unlock()
+
+	if existing, err := os.ReadFile(automation443ConfPath); err == nil && string(existing) == desired {
+		return false, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(automation443ConfPath), 0o755); err != nil {
+		return false, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("mkdir %s: %v", filepath.Dir(automation443ConfPath), err),
+		}
+	}
+	if err := writeFileAtomic(automation443ConfPath, []byte(desired), 0o644); err != nil {
+		return false, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: fmt.Sprintf("write %s: %v", automation443ConfPath, err),
+		}
+	}
+	// The include only exists inside jabali-default.conf's hostname vhost on
+	// boxes whose install.sh has the GH #1161 revision OR whose repair has
+	// self-healed the include line; reloading is harmless when it hasn't (the
+	// file just sits unreferenced).
+	if err := nginxTestAndReload(ctx); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func init() {
+	Default.Register("nginx.automation_public_set", automationPublicSetHandler)
+}

--- a/panel-agent/internal/commands/automation_public_test.go
+++ b/panel-agent/internal/commands/automation_public_test.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempAutomation443Conf redirects the include path to a temp dir for the
+// duration of a test (mirrors the catchall test's catchallConfPath override).
+func withTempAutomation443Conf(t *testing.T) string {
+	t.Helper()
+	orig := automation443ConfPath
+	p := filepath.Join(t.TempDir(), "jabali-automation-443.conf")
+	automation443ConfPath = p
+	t.Cleanup(func() { automation443ConfPath = orig })
+	return p
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestConvergeAutomation443_OnWritesProxyLocation(t *testing.T) {
+	p := withTempAutomation443Conf(t)
+
+	changed, err := convergeAutomation443(context.Background(), boolPtr(true))
+	if err != nil {
+		t.Fatalf("converge on: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on first write")
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(got)
+	// The exposed surface must be exactly the HMAC-gated automation prefix —
+	// never the whole /api/ tree (that would re-expose the unauthenticated
+	// internal endpoints, which have no 404 guard on the :443 hostname vhost).
+	if !strings.Contains(body, "location ^~ /api/v1/automation/ {") {
+		t.Errorf("on-conf missing the automation location:\n%s", body)
+	}
+	if strings.Contains(body, "location ^~ /api/ ") || strings.Contains(body, "location / ") {
+		t.Errorf("on-conf must NOT broaden beyond /api/v1/automation/:\n%s", body)
+	}
+	if !strings.Contains(body, "proxy_pass http://unix:/run/jabali-panel/api.sock;") {
+		t.Errorf("on-conf must proxy straight to the panel socket:\n%s", body)
+	}
+	// backups.create is a sync-long automation call — without the long timeout
+	// nginx 504/502s it (feedback_long_agent_call_502).
+	if !strings.Contains(body, "proxy_read_timeout 3600s;") {
+		t.Errorf("on-conf missing the long read timeout:\n%s", body)
+	}
+}
+
+func TestConvergeAutomation443_OffWritesEmptyInclude(t *testing.T) {
+	p := withTempAutomation443Conf(t)
+
+	if _, err := convergeAutomation443(context.Background(), boolPtr(false)); err != nil {
+		t.Fatalf("converge off: %v", err)
+	}
+	got, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(got)
+	if strings.Contains(body, "location") || strings.Contains(body, "proxy_pass") {
+		t.Errorf("off-conf must contain no directives (empty include), got:\n%s", body)
+	}
+}
+
+func TestConvergeAutomation443_Idempotent(t *testing.T) {
+	withTempAutomation443Conf(t)
+
+	if _, err := convergeAutomation443(context.Background(), boolPtr(true)); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	changed, err := convergeAutomation443(context.Background(), boolPtr(true))
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false when the desired content already on disk")
+	}
+}
+
+func TestConvergeAutomation443_NilLeavesFileAlone(t *testing.T) {
+	p := withTempAutomation443Conf(t)
+
+	changed, err := convergeAutomation443(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("nil toggle: %v", err)
+	}
+	if changed {
+		t.Error("nil toggle must be a no-op")
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("nil toggle must not create the file, stat err=%v", err)
+	}
+}
+
+func TestAutomationPublicSet_Registered(t *testing.T) {
+	found := false
+	for _, cmd := range Default.Commands() {
+		if cmd == "nginx.automation_public_set" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("nginx.automation_public_set not registered")
+	}
+}

--- a/panel-api/cmd/server/repair.go
+++ b/panel-api/cmd/server/repair.go
@@ -375,6 +375,12 @@ func repairSteps() []repairStep {
 			fix:    fixNginxMissingIncludes,
 		},
 		{
+			id:     "automation-443-include",
+			label:  "panel-hostname :443 vhost missing the GH #1161 automation-API include (admin can't opt into API-on-443 for firewalled billing hosts)",
+			detect: detectAutomation443Include,
+			fix:    fixAutomation443Include,
+		},
+		{
 			id:          "docroot-www-data-group",
 			label:       "web docroot files not group www-data / dirs not setgid (nginx 403 on newly uploaded media)",
 			destructive: true,

--- a/panel-api/cmd/server/repair_nginx.go
+++ b/panel-api/cmd/server/repair_nginx.go
@@ -238,3 +238,99 @@ func fixNginxMissingIncludes(_ repairCtx) error {
 	}
 	return nil
 }
+
+// ---------- automation-443-include ----------
+//
+// GH #1161: the opt-in "Automation API on :443" feature needs the panel-hostname
+// :443 vhost (jabali-default.conf's GH#135 server block) to `include` a snippet
+// the agent toggles between empty (off) and the /api/v1/automation/ proxy (on).
+// The include line ships in install.sh, but `jabali update` never re-renders
+// jabali-default.conf (see the http2 scar above), so existing/fleet boxes lack
+// it and the Server-Settings toggle would silently do nothing. This detector
+// self-heals: it seeds the empty snippet (so nginx -t has a target) and injects
+// the include line into the hostname block. It never enables the feature — the
+// snippet stays empty until the admin opts in. ADR-0077.
+
+const jabaliDefaultVhost = "/etc/nginx/sites-available/jabali-default.conf"
+const automation443SnippetPath = "/etc/nginx/snippets/jabali-automation-443.conf"
+const automation443IncludeMarker = "include /etc/nginx/snippets/jabali-automation-443.conf;"
+
+// auto443IncludeLine is inserted with the 4-space indentation the hostname
+// vhost uses; auto443Anchor is that vhost's landing `location /`, whose
+// try_files body is unique to it (the default_server + :80 blocks use the
+// catch-all include instead), so the injection lands in the right server block.
+const auto443IncludeLine = "    " + automation443IncludeMarker
+const auto443Anchor = "    location / {\n        try_files $uri $uri/ =404;\n    }"
+
+// ensureAutomation443Include injects the automation-443 include line before the
+// panel-hostname vhost's landing location, idempotently. Pure (string in/out)
+// so it is unit-testable without touching /etc/nginx. Returns changed=false
+// when the include is already present or the hostname block is unrecognizable
+// (hand-edited / very old box) — never guesses an insertion point.
+func ensureAutomation443Include(conf string) (string, bool) {
+	if strings.Contains(conf, automation443IncludeMarker) {
+		return conf, false
+	}
+	idx := strings.Index(conf, auto443Anchor)
+	if idx < 0 {
+		return conf, false
+	}
+	return conf[:idx] + auto443IncludeLine + "\n\n" + conf[idx:], true
+}
+
+func detectAutomation443Include(_ repairCtx) (bool, string, error) {
+	if _, err := exec.LookPath("nginx"); err != nil {
+		return false, "", nil
+	}
+	b, err := os.ReadFile(jabaliDefaultVhost)
+	if err != nil {
+		return false, "", nil // no default vhost — not applicable
+	}
+	conf := string(b)
+	includePresent := strings.Contains(conf, automation443IncludeMarker)
+	anchorPresent := strings.Contains(conf, auto443Anchor)
+	needInject := !includePresent && anchorPresent
+	_, snippetErr := os.Stat(automation443SnippetPath)
+	needSnippet := (includePresent || needInject) && snippetErr != nil
+	if !needInject && !needSnippet {
+		return false, "", nil
+	}
+	return true, "panel-hostname :443 vhost is missing the GH #1161 automation-API include (admin can't opt into API-on-443 for billing hosts that block outbound 8443)", nil
+}
+
+func fixAutomation443Include(_ repairCtx) error {
+	// 1. Seed the empty snippet first so the include line always has a target.
+	if _, err := os.Stat(automation443SnippetPath); err != nil {
+		if err := os.MkdirAll(filepath.Dir(automation443SnippetPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", filepath.Dir(automation443SnippetPath), err)
+		}
+		body := "# Managed by jabali-agent (nginx.automation_public_set). Empty = API on :8443 only.\n"
+		if err := os.WriteFile(automation443SnippetPath, []byte(body), 0o644); err != nil {
+			return fmt.Errorf("seed %s: %w", automation443SnippetPath, err)
+		}
+	}
+	// 2. Inject the include line into the hostname vhost if missing.
+	b, err := os.ReadFile(jabaliDefaultVhost)
+	if err != nil {
+		return nil
+	}
+	out, changed := ensureAutomation443Include(string(b))
+	if changed {
+		fi, err := os.Stat(jabaliDefaultVhost)
+		mode := os.FileMode(0o644)
+		if err == nil {
+			mode = fi.Mode().Perm()
+		}
+		if err := os.WriteFile(jabaliDefaultVhost, []byte(out), mode); err != nil {
+			return fmt.Errorf("rewrite %s: %w", jabaliDefaultVhost, err)
+		}
+	}
+	// 3. Validate + reload (both the snippet seed and the include edit want it).
+	if out, err := exec.Command("nginx", "-t").CombinedOutput(); err != nil {
+		return fmt.Errorf("nginx -t failing after automation-443 include heal (not reloading):\n%s", string(out))
+	}
+	if out, err := exec.Command("systemctl", "reload", "nginx").CombinedOutput(); err != nil {
+		return fmt.Errorf("nginx -t passed but reload failed: %v\n%s", err, string(out))
+	}
+	return nil
+}

--- a/panel-api/cmd/server/repair_nginx_automation443_test.go
+++ b/panel-api/cmd/server/repair_nginx_automation443_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// hostnameVhost is a trimmed jabali-default.conf-style fixture: the default_server
+// block (whose location / uses the catch-all include) plus the GH#135 hostname
+// block (whose location / uses the try_files landing). ensureAutomation443Include
+// must inject into the hostname block only.
+const hostnameVhost = `server {
+    listen 443 ssl default_server;
+    server_name _;
+    location / {
+        include /etc/nginx/jabali-catchall.conf;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name panel.example.com;
+    root  /var/www/panel.example.com;
+    include /etc/nginx/sites-available/includes/phpmyadmin.conf;
+    location = /webmail  { return 301 https://mail.panel.example.com/; }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+
+    location ~ \.php$ {
+        try_files $uri =404;
+    }
+}
+`
+
+func TestEnsureAutomation443Include_InjectsAtHostnameLanding(t *testing.T) {
+	out, changed := ensureAutomation443Include(hostnameVhost)
+	if !changed {
+		t.Fatal("expected changed=true for a vhost missing the include")
+	}
+	if !strings.Contains(out, automation443IncludeMarker) {
+		t.Fatalf("include marker not injected:\n%s", out)
+	}
+	// The include must land immediately before the hostname block's landing
+	// location (server scope), not inside the default_server catch-all block.
+	incPos := strings.Index(out, auto443IncludeLine)
+	anchorPos := strings.Index(out, auto443Anchor)
+	if incPos < 0 || anchorPos < 0 || incPos > anchorPos {
+		t.Fatalf("include not placed just before the hostname landing location (inc=%d anchor=%d):\n%s", incPos, anchorPos, out)
+	}
+	// It must sit AFTER the default_server catch-all include (i.e. not in the
+	// first server block).
+	catchallPos := strings.Index(out, "include /etc/nginx/jabali-catchall.conf;")
+	if incPos < catchallPos {
+		t.Fatalf("include wrongly injected into the default_server block (inc=%d catchall=%d)", incPos, catchallPos)
+	}
+}
+
+func TestEnsureAutomation443Include_Idempotent(t *testing.T) {
+	once, _ := ensureAutomation443Include(hostnameVhost)
+	twice, changed := ensureAutomation443Include(once)
+	if changed {
+		t.Fatal("expected changed=false when the include is already present")
+	}
+	if once != twice {
+		t.Fatal("second pass must not modify an already-healed config")
+	}
+}
+
+func TestEnsureAutomation443Include_NoAnchorNoChange(t *testing.T) {
+	// A vhost the healer doesn't recognize (no try_files landing) must be left
+	// untouched rather than guessing an insertion point.
+	unknown := "server {\n    server_name x;\n    location / { return 444; }\n}\n"
+	out, changed := ensureAutomation443Include(unknown)
+	if changed || out != unknown {
+		t.Fatalf("unrecognized vhost must be left unchanged, changed=%v", changed)
+	}
+}

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1866,6 +1866,21 @@ fi
 			}
 			return nil
 		}},
+		{"self-heal nginx automation-API-on-443 include (GH #1161)", func() error {
+			// Same reason as the http2 fold above: jabali update does NOT
+			// re-render jabali-default.conf, so the panel-hostname :443 vhost on
+			// existing/fleet boxes lacks the GH #1161 automation-API include and
+			// its (empty) snippet — the Server-Settings opt-in would silently do
+			// nothing. Seed the empty snippet + inject the include line here so
+			// the toggle works after the fleet's 04:30 auto-update. Idempotent +
+			// detect-gated: no-op + no reload once present; never enables the
+			// feature (the snippet stays empty until the admin opts in).
+			if needed, detail, derr := detectAutomation443Include(repairCtx{}); derr == nil && needed {
+				fmt.Printf("  automation-443-include: %s -- healing\n", detail)
+				return fixAutomation443Include(repairCtx{})
+			}
+			return nil
+		}},
 		{"self-heal crowdsec BOUNCING_ON_TYPE (GH #212 log spam)", func() error {
 			// The nginx Lua bouncer rejects the firewall-bouncer comma-list
 			// `ban,captcha` and falls back to `ban`, spamming the nginx error

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -166,6 +166,9 @@ type updateServerSettingsRequest struct {
 	// GH #860: opt-in branded page on the default catch-all for unknown
 	// hosts (default off = keep the 444 drop).
 	UnconfiguredPageEnabled *bool `json:"unconfigured_page_enabled,omitempty"`
+	// GH #1161: opt-in — also serve /api/v1/automation/ on :443 (default off,
+	// :8443 only). For billing hosts whose outbound firewall blocks 8443.
+	AutomationApiPublicEnabled *bool `json:"automation_api_public_enabled,omitempty"`
 	// GH #879: server-wide default for the branded application-error page;
 	// domains override via nginx_safe_options.intercept_errors.
 	InterceptAppErrorsDefault *bool `json:"intercept_app_errors_default,omitempty"`
@@ -589,6 +592,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.UnconfiguredPageEnabled != nil {
 		current.UnconfiguredPageEnabled = *req.UnconfiguredPageEnabled
+	}
+	if req.AutomationApiPublicEnabled != nil {
+		current.AutomationApiPublicEnabled = *req.AutomationApiPublicEnabled
 	}
 	if req.InterceptAppErrorsDefault != nil {
 		current.InterceptAppErrorsDefault = *req.InterceptAppErrorsDefault

--- a/panel-api/internal/db/migrations/000268_automation_api_public.down.sql
+++ b/panel-api/internal/db/migrations/000268_automation_api_public.down.sql
@@ -1,0 +1,3 @@
+-- Reverse 000268: drop the Automation-API-on-443 opt-in flag.
+ALTER TABLE server_settings
+    DROP COLUMN automation_api_public_enabled;

--- a/panel-api/internal/db/migrations/000268_automation_api_public.up.sql
+++ b/panel-api/internal/db/migrations/000268_automation_api_public.up.sql
@@ -1,0 +1,16 @@
+-- GH #1161: opt-in exposure of the Automation API on :443 (in addition to the
+-- default :8443). Billing systems on hosts with a locked-down outbound firewall
+-- (CSF's default TCP_OUT allows ~20/21/22/25/53/80/110/113/443 and NOT 8443)
+-- cannot reach :8443 at all, and the failure ("Connection refused") looks like
+-- the panel being down rather than a blocked port. This flag lets an admin also
+-- serve the API on the standard 443 port.
+--
+-- Default 0 (OFF): serving the API on the public 443 port is new exposure, so it
+-- is opt-in. When enabled, the reconciler has the agent write the nginx include
+-- that adds the `location ^~ /api/v1/automation/` proxy to the panel-hostname
+-- :443 vhost; disabling writes it back to empty. ONLY /api/v1/automation/ is
+-- exposed (every route there is behind RequireAutomationHMAC); the internal,
+-- unauthenticated endpoints (/api/v1/internal/, the malware event) stay
+-- :8443-only, guarded by the 8443 vhost's 404 blocks which :443 never gains.
+ALTER TABLE server_settings
+    ADD COLUMN automation_api_public_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -138,6 +138,16 @@ type ServerSettings struct {
 	// deliberate trade of that stealth for a branded operator page.
 	UnconfiguredPageEnabled bool `gorm:"column:unconfigured_page_enabled;type:tinyint(1);not null;default:0" json:"unconfigured_page_enabled"`
 
+	// AutomationApiPublicEnabled (GH #1161) also serves the HMAC-gated
+	// /api/v1/automation/ tree on the standard :443 port, not just :8443.
+	// Default off: exposing the API on the public port is opt-in. Billing
+	// hosts with a locked-down outbound firewall (CSF TCP_OUT omits 8443)
+	// can't reach :8443; enabling this makes the agent write the nginx
+	// include that adds the automation proxy to the panel-hostname :443
+	// vhost. Only /api/v1/automation/ (all RequireAutomationHMAC) is
+	// exposed — the internal/unauthenticated endpoints stay :8443-only.
+	AutomationApiPublicEnabled bool `gorm:"column:automation_api_public_enabled;type:tinyint(1);not null;default:0" json:"automation_api_public_enabled"`
+
 	// InterceptAppErrorsDefault (GH #879) — server-wide default for the
 	// branded application-error page: nginx serves the themed 500 when a
 	// PHP app returns a 5xx (a fatal is a 500 with an empty body). Domains

--- a/panel-api/internal/reconciler/automation_443_reconcile.go
+++ b/panel-api/internal/reconciler/automation_443_reconcile.go
@@ -1,0 +1,45 @@
+package reconciler
+
+import (
+	"context"
+	"time"
+)
+
+// reconcileAutomation443 converges the opt-in Automation-API-on-443 nginx
+// include (GH #1161) to server_settings.automation_api_public_enabled. When the
+// admin flips the toggle it calls the agent's nginx.automation_public_set, which
+// writes /etc/nginx/snippets/jabali-automation-443.conf (the location proxy when
+// on, empty when off) and reloads nginx. Applied-state-gated: once synced, every
+// steady-state tick is a pure noop. On panel-api restart the cache resets to nil
+// so the first tick re-asserts the desired state (idempotent — the agent skips
+// the reload when the file already matches). On a failed sync it does NOT cache
+// the applied value, so the next tick retries.
+func (r *Reconciler) reconcileAutomation443(ctx context.Context) {
+	if r.serverSettings == nil || r.agent == nil {
+		return
+	}
+
+	c, cancel := context.WithTimeout(ctx, 5*time.Second)
+	s, err := r.serverSettings.Get(c)
+	cancel()
+	if err != nil || s == nil {
+		return
+	}
+	desired := s.AutomationApiPublicEnabled
+
+	if r.automation443Applied != nil && *r.automation443Applied == desired {
+		return
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := r.agent.Call(cctx, "nginx.automation_public_set", map[string]any{
+		"enabled": desired,
+	}); err != nil {
+		r.log.Warn("automation-on-443 sync failed", "error", err)
+		return
+	}
+	applied := desired
+	r.automation443Applied = &applied
+	r.log.Debug("automation-on-443 converged", "enabled", desired)
+}

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -190,6 +190,10 @@ type Reconciler struct {
 	// /var/www/jabali-errors so the per-tick reconcile only calls the
 	// agent when an admin actually edits an error template.
 	errorPagesHash string
+	// automation443Applied caches the last automation-on-443 toggle synced
+	// to the agent (GH #1161) so the per-tick reconcile only calls it when
+	// the admin flips the opt-in. A nil pointer means "never synced yet".
+	automation443Applied *bool
 	// M32 — singleton panel-cert row. When nil the panel-cert hook
 	// short-circuits (lab installs, tests). When wired with a routability
 	// service it drives ssl.panel.issue from ReconcileAll.
@@ -754,6 +758,10 @@ func (r *Reconciler) ReconcileAll(ctx context.Context) error {
 	// editable page_template rows into /var/www/jabali-errors. Hash-gated:
 	// a noop on every tick until an admin edits a template.
 	r.reconcileErrorPages(ctx)
+
+	// GH #1161: converge the opt-in Automation-API-on-443 include to the
+	// server_settings toggle. Applied-state-gated — noop steady state.
+	r.reconcileAutomation443(ctx)
 
 	// GH #648: converge DKIM2 signing across mail domains to the
 	// server_settings toggle. Applied-state-gated — noop steady state.

--- a/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
+++ b/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
@@ -127,6 +127,31 @@ export const AdminAutomationTokensPage = () => {
     },
   });
 
+  // GH #1161: opt-in — also serve the automation API on :443 (default :8443 only),
+  // for billing hosts whose outbound firewall blocks 8443.
+  const settings = useQuery<{ automation_api_public_enabled?: boolean }>({
+    queryKey: ["admin/settings", "automation_api_public_enabled"],
+    queryFn: async () => {
+      const { data } = await apiClient.get<{ automation_api_public_enabled?: boolean }>("/admin/settings");
+      return data;
+    },
+  });
+  const setPublicPort = useMutation<unknown, unknown, boolean>({
+    mutationFn: async (next) => {
+      await apiClient.patch("/admin/settings", { automation_api_public_enabled: next });
+    },
+    onSuccess: async (_data, next) => {
+      await qc.invalidateQueries({ queryKey: ["admin/settings", "automation_api_public_enabled"] });
+      feedback.message.success(
+        next
+          ? "Automation API now also served on port 443 (nginx reloads on the next reconcile)."
+          : "Automation API restricted to port 8443 only.",
+      );
+    },
+    onError: () => feedback.message.error("Failed to update the port-443 setting"),
+  });
+  const publicPortOn = settings.data?.automation_api_public_enabled === true;
+
   const handleMint = async (values: { name: string; scopes: string[]; writes_enabled?: boolean }) => {
     try {
       await mint.mutateAsync(values);
@@ -158,6 +183,30 @@ export const AdminAutomationTokensPage = () => {
         with the per-token secret. Tokens are scoped — issue the narrowest scope set the caller
         needs.
       </Typography.Paragraph>
+
+      <Card style={{ marginBottom: 16 }} loading={settings.isLoading}>
+        <Space align="start" style={{ justifyContent: "space-between", width: "100%" }}>
+          <div style={{ maxWidth: 720 }}>
+            <Typography.Text strong>Also serve the API on port 443</Typography.Text>
+            <Typography.Paragraph type="secondary" style={{ marginBottom: 0, marginTop: 4 }}>
+              By default the Automation API answers only on <code>:8443</code>. Billing
+              systems on hosts whose outbound firewall blocks 8443 (for example CSF&apos;s
+              default <code>TCP_OUT</code>) can&apos;t reach it, and the failure looks like
+              the panel being down. Turning this on also serves the HMAC-signed{" "}
+              <code>/api/v1/automation/</code> routes on the standard <code>:443</code>{" "}
+              port of the panel hostname. Nothing else is exposed — the internal endpoints
+              stay on 8443 only, and authentication is unchanged.
+            </Typography.Paragraph>
+          </div>
+          <Switch
+            checked={publicPortOn}
+            loading={setPublicPort.isPending}
+            onChange={(next) => setPublicPort.mutate(next)}
+            checkedChildren="443 + 8443"
+            unCheckedChildren="8443 only"
+          />
+        </Space>
+      </Card>
 
       <Card
         extra={


### PR DESCRIPTION
## GH #1161 — opt-in Automation API on :443

The Automation API only answers on **:8443**. Billing systems on hosts whose outbound firewall blocks 8443 (CSF's default `TCP_OUT` allows ~80/443 and not 8443) can't reach it, and the failure ("Connection refused") looks like the panel being down. This adds an **admin opt-in (default OFF)** to also serve the HMAC-gated `/api/v1/automation/` tree on the panel hostname's :443 vhost.

### Decisions (from the issue's three enumerated questions)
1. **Narrow `/api/v1/automation/` only**, not the whole `/api/` — the hostname :443 vhost has none of the 8443 vhost's internal-endpoint 404 guards, and every automation route is behind `RequireAutomationHMAC`. A broad `/api/` would re-expose `/api/v1/internal/` (unauthenticated) on 443.
2. **No rate-limit/CrowdSec mirroring needed** — the 8443 vhost has none; CrowdSec is global/IP-based.
3. **Module/doc default flip (443 vs 8443) deferred** — separate follow-up; the three billing modules stay on 8443.

Plus, per your steer: **opt-in default OFF**, **hostname vhost only**, **install.sh + self-heal rollout**.

### Design (mirrors the GH#860 catch-all include toggle)
- `server_settings.automation_api_public_enabled` (migration **000268**, default 0).
- Reconciler (applied-state-gated) → agent `nginx.automation_public_set` writes `/etc/nginx/snippets/jabali-automation-443.conf`: the `location ^~ /api/v1/automation/` proxy when on, an empty include when off, then `nginx -t` + reload.
- The hostname :443 vhost `include`s that snippet at server scope. `proxy_pass` goes **straight to the panel socket** (`http://unix:/run/jabali-panel/api.sock`) — no cross-file upstream dependency — with `proxy_read/send_timeout 3600s` for the sync-long automation calls (`backups.create`, cf. the long-agent-call 502 class).
- The **Server API Access** admin page gets the opt-in toggle.

### Why :443 validates like :8443
`RequireAutomationHMAC`'s canonical string is `METHOD\nPATH\nts\nsha256(BODY)` — no host, no port, no scheme. Same signature works on either port. Only `/api/v1/automation/` is proxied; internal endpoints fall through to the vhost's `try_files` → 404, so they stay :8443-only.

### Rollout to existing/fleet boxes
`jabali update` never re-renders `jabali-default.conf`, so install.sh alone would miss deployed boxes. Two paths cover them, both idempotent + detect-gated:
- a `jabali repair` step (`automation-443-include`), and
- an inline self-heal in `jabali update`'s prelude (same slot as the http2-fold heal), so the fleet gets it at the 04:30 auto-update.

Neither enables the feature — they only seed the empty snippet + add the include line so the opt-in toggle works.

### Known limitation (inherited from the catch-all template)
If a converge writes the snippet but the subsequent `nginx -t`/reload fails (already-broken nginx), the reconciler's applied-state can cache before the reload lands — the toggle would read ON while :443 still 404s until the next content change. Matches `convergeCatchall`; not redesigned here.

### Tests
- agent converge: on writes the proxy / off writes empty / nil no-op / idempotent / **asserts it never broadens beyond `/api/v1/automation/`**;
- repair include-injector: pure, idempotent, lands in the hostname block only, no-op on an unrecognized vhost;
- cli-reference golden regenerated (new `--automation-443-include` flag).
- Live verification on the repro box pending (toggle OFF→404, ON→401 with body, internal still 404, :8443 unchanged, OFF→404).

GH #1161