### PR TITLE
fix(ssl): refresh FTPS cert on panel renewal without starting disabled FTP (JAB-268)

### DIFF
--- a/docs/runbooks/panel-ssl.md
+++ b/docs/runbooks/panel-ssl.md
@@ -8,7 +8,7 @@ The panel hostname's TLS cert sits at `/etc/jabali/tls/panel.{crt,key}`. By defa
 |---|---|
 | `self_signed` | The starting state and the silent fallback. The cert is the openssl-generated SAN cert `provision_tls_cert` produced. The "Use Let's Encrypt" toggle is OFF, OR the routability gate failed. |
 | `pending_acme` | The reconciler (or the admin via "Retry now") just dispatched `ssl.panel.issue`. Will flip to `issued` or `pending_acme_retry` within a minute. |
-| `issued` | Certbot returned a fresh lineage; the deploy-hook copied `fullchain.pem` + `privkey.pem` to `/etc/jabali/tls/panel.{crt,key}` and reloaded nginx + jabali-panel + jabali-bulwark. `expires_at` is the LE notAfter. |
+| `issued` | Certbot returned a fresh lineage; the deploy-hook copied `fullchain.pem` + `privkey.pem` to `/etc/jabali/tls/panel.{crt,key}` and reloaded nginx + jabali-panel + jabali-bulwark (and vsftpd when FTP is active). `expires_at` is the LE notAfter. |
 | `pending_acme_retry` | Last attempt failed; `last_error` carries the reason. Reconciler will retry every 3 hours until either issued or the admin disables `use_le`. |
 | `failed` | Terminal — non-retryable error (e.g. LE rate-limit exhausted). M32.1 will surface a Reset button; today: edit the row directly via `mariadb` to clear the state. |
 
@@ -79,6 +79,7 @@ sudo /usr/local/bin/jabali update -f   # provision_tls_cert re-runs
     3. `systemctl reload nginx` (graceful, keeps existing :443 sessions up).
     4. `systemctl restart jabali-panel` (Go server doesn't SIGHUP-reread; ~100ms TLS gap).
     5. `systemctl restart jabali-bulwark` (Next custom server reads cert at boot; ~3-5s webmail gap).
+    6. `systemctl try-reload-or-restart vsftpd` **only if vsftpd is already active** (JAB-268). FTPS reads the same `panel.{crt,key}` but has no hook of its own, so without this it presents the stale in-memory cert until the daemon next restarts. The `is-active` guard means a masked/opt-out FTP module (the default) is never started by a renewal. A failure is logged naming FTPS as the stale consumer.
 
 The panel cert is intentionally separate from the per-domain SSL certs the reconciler manages for hosted domains. M32 only governs the panel hostname; everything else still flows through `ssl_certificates` + the M14 SSL renewal pipeline.
 

--- a/install/letsencrypt/jabali-panel-cert.sh
+++ b/install/letsencrypt/jabali-panel-cert.sh
@@ -144,6 +144,22 @@ case "$kind" in
     # re-dispatch. jabali-bulwark is not the caller — synchronous.
     systemctl restart --no-block jabali-panel || echo "jabali-panel-cert.sh: jabali-panel restart failed (continuing)" >&2
     systemctl restart jabali-bulwark || echo "jabali-panel-cert.sh: jabali-bulwark restart failed (continuing)" >&2
+    # FTPS (vsftpd, opt-in) reads the SAME panel.crt/panel.key but has no
+    # deploy hook of its own, so after renewal it keeps presenting the old
+    # in-memory certificate until the daemon next restarts — once the old cert
+    # expires, strict FTPS clients start failing (JAB-268). Reload it here.
+    #
+    # Guarded on is-active on purpose: FTP is the panel's one deliberately-OFF
+    # service (server_settings.ftp_enabled=0 → vsftpd masked). is-active is
+    # false for the masked/disabled opt-out state, so this never starts FTP an
+    # operator chose to keep off — it only refreshes a daemon already serving.
+    # vsftpd has no reload verb; try-reload-or-restart falls back to a restart,
+    # which re-reads the cert from disk. A failure is surfaced (not silently
+    # swallowed) naming vsftpd as the consumer left on the stale certificate.
+    if systemctl is-active --quiet vsftpd; then
+      systemctl try-reload-or-restart vsftpd \
+        || echo "jabali-panel-cert.sh: vsftpd reload FAILED — FTPS is serving the STALE certificate until vsftpd restarts" >&2
+    fi
     ;;
 esac
 

--- a/install/tests/test_panel_cert_hook_ftps.sh
+++ b/install/tests/test_panel_cert_hook_ftps.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# install/tests/test_panel_cert_hook_ftps.sh — regression coverage for JAB-268
+# (FTPS serves a stale certificate after panel cert renewal).
+#
+# vsftpd reads the panel hostname cert (/etc/jabali/tls/panel.{crt,key}) but has
+# no deploy hook of its own. The certbot deploy hook must refresh it after a
+# renewal — WITHOUT ever starting FTP, which is the panel's one deliberately-OFF
+# service (server_settings.ftp_enabled=0 → vsftpd masked). A reload that starts
+# a masked daemon would silently defeat the opt-in.
+#
+# Asserts, source-level (no host mutation):
+#   1. The hook refreshes vsftpd (try-reload-or-restart).
+#   2. The refresh is guarded by `is-active --quiet vsftpd`, and the guard
+#      precedes the refresh — so a masked/disabled daemon is never touched.
+#   3. The hook never starts/unmasks/enables vsftpd (that would start opt-out FTP).
+#   4. A refresh failure is surfaced (not swallowed) and names FTPS/vsftpd as the
+#      consumer left on the stale certificate.
+#
+# Run from repo root:
+#     bash install/tests/test_panel_cert_hook_ftps.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+hook="install/letsencrypt/jabali-panel-cert.sh"
+fail=0
+
+if [[ ! -f "$hook" ]]; then
+  echo "FAIL: $hook not found"
+  exit 1
+fi
+
+# --- 1. the hook refreshes vsftpd ---
+if ! grep -q 'try-reload-or-restart vsftpd' "$hook"; then
+  echo "FAIL: hook does not refresh vsftpd after renewal — FTPS keeps the stale cert (JAB-268)"
+  fail=1
+fi
+
+# --- 2. refresh is guarded by is-active, and the guard comes first ---
+guard_ln=$(grep -nE 'is-active --quiet vsftpd' "$hook" | head -1 | cut -d: -f1)
+reload_ln=$(grep -nE 'try-reload-or-restart vsftpd' "$hook" | head -1 | cut -d: -f1)
+if [[ -z "$guard_ln" ]]; then
+  echo "FAIL: vsftpd refresh is not guarded by 'is-active --quiet vsftpd' — it could start masked/opt-out FTP"
+  fail=1
+elif [[ -n "$reload_ln" && "$guard_ln" -ge "$reload_ln" ]]; then
+  echo "FAIL: the is-active guard (line $guard_ln) must precede the vsftpd refresh (line $reload_ln)"
+  fail=1
+fi
+
+# --- 3. the hook must NOT start / unmask / enable vsftpd ---
+# Directive lines only — comments explain WHY the daemon is left alone when off.
+body=$(grep -vE '^\s*#' "$hook")
+for bad in 'systemctl start vsftpd' 'unmask vsftpd' 'enable vsftpd'; do
+  if grep -qF "$bad" <<<"$body"; then
+    echo "FAIL: hook runs '$bad' — a renewal must never start the opt-in FTP module"
+    fail=1
+  fi
+done
+
+# --- 4. failure is surfaced and identifies the stale consumer ---
+if ! grep -qiE 'vsftpd.*(fail|stale)|stale.*cert' "$hook"; then
+  echo "FAIL: a vsftpd refresh failure must be logged, naming the consumer left on the stale cert"
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "OK: panel cert hook refreshes FTPS without starting disabled FTP (JAB-268)"
+else
+  exit 1
+fi


### PR DESCRIPTION
## JAB-268 — FTPS keeps serving stale certificates after panel certificate renewal

vsftpd reads the panel hostname cert (`/etc/jabali/tls/panel.{crt,key}`) but has no deploy hook of its own. The certbot deploy hook (`jabali-panel-cert.sh`) copied the renewed cert and reloaded nginx + `jabali-panel` + `jabali-bulwark`, but never touched vsftpd — so after an automated renewal FTPS kept presenting the **old in-memory certificate** until the daemon happened to restart. Once the old cert expired, strict FTPS clients would fail, and the usual operator workaround is to disable verification or fall back to plaintext.

### Fix
The hostname branch of the hook now runs `try-reload-or-restart vsftpd`, **guarded by `systemctl is-active --quiet vsftpd`**:

```sh
if systemctl is-active --quiet vsftpd; then
  systemctl try-reload-or-restart vsftpd \
    || echo "jabali-panel-cert.sh: vsftpd reload FAILED — FTPS is serving the STALE certificate until vsftpd restarts" >&2
fi
```

- FTP is the panel's one deliberately-OFF service (`server_settings.ftp_enabled=0` → vsftpd masked). `is-active` is false in that opt-out state, so **a renewal never starts FTP an operator chose to keep off** (acceptance #2).
- vsftpd has no reload verb, so `try-reload-or-restart` falls back to a restart, which re-reads the cert from disk (acceptance #1 — refreshes on the next handshake, no manual step).
- A refresh failure is surfaced on stderr **naming FTPS as the stale consumer**, not silently swallowed (acceptance #3).
- Only the panel-hostname branch triggers this — the `mail` / `mail-domain` branches are untouched (FTPS does not consume the mail cert).

`is-active`-guarding is the established idiom (`install.sh:793,803` gate vsftpd the same way).

### Tests
- `install/tests/test_panel_cert_hook_ftps.sh` (auto-discovered by the `install/tests` CI job) pins: the hook refreshes vsftpd; the refresh is `is-active`-guarded and the guard precedes it; the hook never `start`/`unmask`/`enable`s vsftpd; and a failure is logged identifying the stale consumer.
- `bash -n` clean; existing `test_ftp_module_optin.sh` still passes.
- Live acceptance (a real renewal changing the cert on a fresh FTPS handshake) → jabalitests host-only batch.

### Docs
The `panel-ssl` runbook consumer list now includes FTPS (the ticket flagged the omission in ADR-0066 / the runbook).

Refs JAB-268.
