### PR TITLE
fix(ui): put the copy icon inside the field, not below/beside it

### DIFF
--- a/panel-ui/src/components/CopyableInput.tsx
+++ b/panel-ui/src/components/CopyableInput.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Input, Tooltip, theme } from "antd";
+import type { InputProps } from "antd";
+import { CopyOutlined, CheckOutlined, EyeOutlined, EyeInvisibleOutlined } from "@icons";
+import { feedback } from "../lib/feedback"; // GH #970: themed toasts
+
+interface CopyableInputProps extends Omit<InputProps, "value" | "readOnly" | "suffix" | "type"> {
+  value: string;
+  /** Text copied to the clipboard. Defaults to `value` (useful when `value` is masked). */
+  copyText?: string;
+  /** Mask the value behind a reveal toggle (for secrets / passwords). */
+  secret?: boolean;
+}
+
+/**
+ * Read-only field with the copy affordance rendered INSIDE the input (as a
+ * suffix), not below or beside it. This is the panel-wide convention for
+ * showing a copyable value — token IDs, one-time secrets, generated
+ * passwords, connection strings. With `secret`, a reveal-eye toggle sits
+ * alongside the copy icon, also inside the input.
+ */
+export function CopyableInput({ value, copyText, secret = false, ...rest }: CopyableInputProps) {
+  const { token } = theme.useToken();
+  const [copied, setCopied] = useState(false);
+  const [revealed, setRevealed] = useState(!secret);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(copyText ?? value);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      feedback.message.error("Clipboard blocked — copy manually");
+    }
+  };
+
+  const display = secret && !revealed ? "•".repeat(Math.min(value.length, 40)) : value;
+  const iconStyle = { cursor: "pointer", color: token.colorTextDescription, display: "inline-flex" };
+
+  return (
+    <Input
+      {...rest}
+      readOnly
+      value={display}
+      onFocus={(e) => e.currentTarget.select()}
+      suffix={
+        <span style={{ display: "inline-flex", gap: 8, alignItems: "center" }}>
+          {secret && (
+            <Tooltip title={revealed ? "Hide" : "Reveal"}>
+              <span
+                role="button"
+                aria-label={revealed ? "Hide value" : "Reveal value"}
+                onClick={() => setRevealed((r) => !r)}
+                style={iconStyle}
+              >
+                {revealed ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+              </span>
+            </Tooltip>
+          )}
+          <Tooltip title={copied ? "Copied" : "Copy"}>
+            <span
+              role="button"
+              aria-label="Copy to clipboard"
+              onClick={copied ? undefined : handleCopy}
+              style={copied ? { display: "inline-flex", color: token.colorSuccess } : iconStyle}
+            >
+              {copied ? <CheckOutlined /> : <CopyOutlined />}
+            </span>
+          </Tooltip>
+        </span>
+      }
+    />
+  );
+}

--- a/panel-ui/src/components/DatabaseUserPasswordModal.tsx
+++ b/panel-ui/src/components/DatabaseUserPasswordModal.tsx
@@ -4,10 +4,8 @@
 // ADR-0021). This modal surfaces it to the operator with an obvious
 // "save it now" framing, a copy-to-clipboard action, and a masked
 // fallback so the password isn't casually left on screen.
-import { useState } from "react";
-import { CopyOutlined, EyeInvisibleOutlined, EyeOutlined } from "@icons";
-import { Alert, Button, Input, Modal, Space, Typography } from "antd";
-import { feedback } from "../lib/feedback"; // GH #970: themed toasts
+import { Alert, Button, Modal, Space, Typography } from "antd";
+import { CopyableInput } from "./CopyableInput";
 
 interface DatabaseUserPasswordModalProps {
   open: boolean;
@@ -24,29 +22,13 @@ export function DatabaseUserPasswordModal({
   title = "Database user password",
   onClose,
 }: DatabaseUserPasswordModalProps) {
-  const [revealed, setRevealed] = useState(false);
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(password);
-      feedback.message.success("Password copied to clipboard");
-    } catch {
-      feedback.message.error("Copy failed — select the field and copy manually");
-    }
-  };
-
-  const close = () => {
-    setRevealed(false);
-    onClose();
-  };
-
   return (
     <Modal
       title={title}
       open={open}
-      onCancel={close}
+      onCancel={onClose}
       footer={[
-        <Button key="done" type="primary" onClick={close}>
+        <Button key="done" type="primary" onClick={onClose}>
           I have saved the password
         </Button>,
       ]}
@@ -68,20 +50,7 @@ export function DatabaseUserPasswordModal({
 
         <div>
           <Typography.Text type="secondary">Password</Typography.Text>
-          <Input.Group compact style={{ display: "flex", marginTop: 4 }}>
-            <Input
-              value={revealed ? password : "•".repeat(Math.min(password.length, 32))}
-              readOnly
-              style={{ fontFamily: "monospace", flex: 1 }}
-              onFocus={(e) => e.currentTarget.select()}
-            />
-            <Button
-              icon={revealed ? <EyeInvisibleOutlined /> : <EyeOutlined />}
-              onClick={() => setRevealed((r) => !r)}
-              title={revealed ? "Hide" : "Reveal"}
-            />
-            <Button icon={<CopyOutlined />} onClick={copy} title="Copy to clipboard" />
-          </Input.Group>
+          <CopyableInput value={password} secret style={{ fontFamily: "monospace", marginTop: 4 }} />
         </div>
       </Space>
     </Modal>

--- a/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
+++ b/panel-ui/src/shells/admin/automation/AdminAutomationTokensPage.tsx
@@ -12,11 +12,12 @@ import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { StandardDrawerFooter } from "../../../components/StandardActionFooter";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import { Alert, Button, Card, Checkbox, Drawer, Form, Input, Modal, Popconfirm, Space, Switch, Table, Tag, Typography, theme } from "antd";
+import { Alert, Button, Card, Checkbox, Drawer, Form, Input, Modal, Popconfirm, Space, Switch, Table, Tag, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { KeyOutlined, PlusOutlined, DeleteOutlined } from "@icons";
 
 import { apiClient } from "../../../apiClient";
+import { CopyableInput } from "../../../components/CopyableInput";
 
 type Token = {
   id: string;
@@ -60,7 +61,6 @@ function fmt(iso?: string | null): string {
 
 export const AdminAutomationTokensPage = () => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const qc = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [revealSecret, setRevealSecret] = useState<string | null>(null);
@@ -379,14 +379,10 @@ export const AdminAutomationTokensPage = () => {
         ]}
         width={600}
       >
-        <Typography.Paragraph style={{ marginBottom: 12 }}>
+        <div style={{ marginBottom: 12 }}>
           <Typography.Text type="secondary">Token ID</Typography.Text>
-          <Typography.Paragraph copyable={{ text: revealId ?? "", tooltips: ["Copy", "Copied"] }} style={{ marginBottom: 0 }}>
-            <code style={{ wordBreak: "break-all", display: "block", padding: 12, background: token.colorBgLayout, border: `1px solid ${token.colorBorder}`, borderRadius: token.borderRadius }}>
-              {revealId}
-            </code>
-          </Typography.Paragraph>
-        </Typography.Paragraph>
+          <CopyableInput value={revealId ?? ""} style={{ marginTop: 4, fontFamily: "monospace" }} />
+        </div>
         <Alert
           type="warning"
           showIcon
@@ -395,11 +391,7 @@ export const AdminAutomationTokensPage = () => {
           style={{ marginBottom: 16 }}
         />
         <Typography.Text type="secondary">Secret</Typography.Text>
-        <Typography.Paragraph copyable={{ text: revealSecret ?? "", tooltips: ["Copy", "Copied"] }}>
-          <code style={{ wordBreak: "break-all", display: "block", padding: 12, background: token.colorBgLayout, border: `1px solid ${token.colorBorder}`, borderRadius: token.borderRadius }}>
-            {revealSecret}
-          </code>
-        </Typography.Paragraph>
+        <CopyableInput value={revealSecret ?? ""} style={{ marginTop: 4, fontFamily: "monospace" }} />
       </Modal>
 
     </div>

--- a/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
+++ b/panel-ui/src/shells/admin/settings/DatabaseAdminSections.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
+import { CopyableInput } from "../../../components/CopyableInput";
 import { listInstalled } from "../docker-apps/api";
 
 type Engine = "mariadb" | "postgres";
@@ -114,13 +115,7 @@ function RootPasswordSection() {
           This is shown <strong>once</strong>. It is not stored in the panel
           and cannot be retrieved later.
         </Typography.Paragraph>
-        <Typography.Paragraph
-          copyable={{ text: revealed?.password ?? "" }}
-          code
-          style={{ fontSize: 15, wordBreak: "break-all" }}
-        >
-          {revealed?.password}
-        </Typography.Paragraph>
+        <CopyableInput value={revealed?.password ?? ""} style={{ fontFamily: "monospace" }} />
       </Modal>
     </Card>
   );

--- a/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
+++ b/panel-ui/src/shells/admin/support/DiagnosticReportModal.tsx
@@ -9,9 +9,9 @@
 // + password — the team gets it via inbox.
 import { useEffect, useState } from "react";
 import { Alert, Button, Input, Modal, Space, Spin, Tag, Typography } from "antd";
-import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 
-import { CopyOutlined, ExportOutlined, MailOutlined } from "@icons";
+import { ExportOutlined, MailOutlined } from "@icons";
+import { CopyableInput } from "../../../components/CopyableInput";
 
 import { DIAGNOSTIC_EMAIL_RECIPIENT } from "../../../config/support-links";
 import { useDiagnosticReport } from "../../../hooks/useSupport";
@@ -36,14 +36,6 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const copy = async (label: string, value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      feedback.message.success(`${label} copied`);
-    } catch (e: unknown) {
-      feedback.message.error(e instanceof Error ? e.message : "copy failed");
-    }
-  };
 
   const buildMailto = (): string => {
     if (!report.data) return "";
@@ -122,19 +114,10 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
                     anywhere, even a public issue. The link + password below are
                     only a fallback.
                   </Typography.Paragraph>
-                  <Space.Compact style={{ display: "flex" }}>
-                    <Input
-                      value={report.data.claim_code}
-                      readOnly
-                      style={{ fontFamily: "monospace", fontWeight: 600 }}
-                    />
-                    <Button
-                      icon={<CopyOutlined />}
-                      onClick={() => copy("Claim code", report.data!.claim_code!)}
-                    >
-                      Copy
-                    </Button>
-                  </Space.Compact>
+                  <CopyableInput
+                    value={report.data.claim_code ?? ""}
+                    style={{ fontFamily: "monospace", fontWeight: 600 }}
+                  />
                 </Space>
               }
             />
@@ -143,13 +126,7 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
           <div>
             <Typography.Text strong>Link</Typography.Text>
             <Space.Compact style={{ display: "flex", marginTop: 4 }}>
-              <Input value={report.data.url} readOnly />
-              <Button
-                icon={<CopyOutlined />}
-                onClick={() => copy("Link", report.data!.url)}
-              >
-                Copy
-              </Button>
+              <CopyableInput value={report.data.url} />
               <Button
                 icon={<ExportOutlined />}
                 href={report.data.url}
@@ -163,15 +140,7 @@ export function DiagnosticReportModal({ open, onClose }: Props) {
 
           <div>
             <Typography.Text strong>Password</Typography.Text>
-            <Space.Compact style={{ display: "flex", marginTop: 4 }}>
-              <Input value={report.data.password} readOnly />
-              <Button
-                icon={<CopyOutlined />}
-                onClick={() => copy("Password", report.data!.password)}
-              >
-                Copy
-              </Button>
-            </Space.Compact>
+            <CopyableInput value={report.data.password} secret style={{ marginTop: 4 }} />
           </div>
 
           <Alert

--- a/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
+++ b/panel-ui/src/shells/user/api-tokens/UserAPITokensPage.tsx
@@ -40,12 +40,12 @@ for (const a of AREAS) {
   SCOPE_LABELS["write:" + a.key] = a.label + " write";
 }
 import {
-  CopyOutlined,
   DeleteOutlined,
   KeyOutlined,
   PlusOutlined,
 } from "@ant-design/icons";
 import { apiClient } from "../../../apiClient";
+import { CopyableInput } from "../../../components/CopyableInput";
 import { APIDocsPage } from "../../shared/APIDocsPage";
 import { DDNSSetupGuide } from "./DDNSSetupGuide";
 import { MCPSetupGuide } from "./MCPSetupGuide";
@@ -182,14 +182,6 @@ export function UserAPITokensPage(): JSX.Element {
     }
   };
 
-  const copy = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      feedback.message.success("Copied to clipboard");
-    } catch {
-      feedback.message.error(`Copy failed: Select the secret and copy manually.`);
-    }
-  };
 
   const columns: ColumnsType<UserAPIToken> = useMemo(
     () => [
@@ -453,22 +445,7 @@ export function UserAPITokensPage(): JSX.Element {
           description={t("userapitokenspage.the_plaintext_token_is_shown_only_once_after")}
           style={{ marginBottom: 16 }}
         />
-        <Input.Group compact>
-          <Input
-            value={secret?.secret}
-            readOnly
-            onFocus={(e) => e.currentTarget.select()}
-            style={{ width: "calc(100% - 90px)" }}
-          />
-          <Button
-            type="primary"
-            icon={<CopyOutlined />}
-            onClick={() => secret && void copy(secret.secret)}
-            style={{ width: 90 }}
-          >
-            Copy
-          </Button>
-        </Input.Group>
+        <CopyableInput value={secret?.secret ?? ""} style={{ fontFamily: "monospace" }} />
       </Modal>
     </>
   );

--- a/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
+++ b/panel-ui/src/shells/user/applications/InstallApplicationModal.tsx
@@ -14,11 +14,12 @@
 
 import { useTranslation } from "react-i18next";
 import { useState, useEffect, useMemo } from "react";
-import { Drawer, Form, Grid, Input, Button, Select, Space, Typography, Alert, Tooltip, Switch } from "antd";
+import { Drawer, Form, Grid, Input, Button, Select, Space, Typography, Alert, Switch } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import { AppstoreOutlined, CheckCircleTwoTone, CheckOutlined, CloseOutlined, CopyOutlined } from "@icons";
+import { AppstoreOutlined, CheckCircleTwoTone, CheckOutlined, CloseOutlined } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
+import { CopyableInput } from "../../../components/CopyableInput";
 import { PasswordInput } from "../../../components/PasswordInput";
 import {
   useAppRegistry,
@@ -511,14 +512,6 @@ export const InstallApplicationModal = ({
     }
   };
 
-  const copy = async (label: string, value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      feedback.message.success(`${label} copied`);
-    } catch {
-      feedback.message.error(`Could not copy ${label.toLowerCase()}`);
-    }
-  };
 
   const validateSubdirectory = (_: unknown, value: string) => {
     if (!value) {
@@ -736,46 +729,21 @@ export const InstallApplicationModal = ({
           />
           <div>
             <Typography.Text strong>Domain</Typography.Text>
-            <Input readOnly value={result.domainName} />
+            <CopyableInput value={result.domainName} />
           </div>
           {!result.emailLogin && (
             <div>
               <Typography.Text strong>Admin username</Typography.Text>
-              <Input
-                readOnly
-                value={result.adminUsername}
-                addonAfter={
-                  <Tooltip title={t("installapplicationmodal.copy")}>
-                    <Button
-                      type="text"
-                      icon={<CopyOutlined />}
-                      onClick={() => copy("Username", result.adminUsername)}
-                    />
-                  </Tooltip>
-                }
-              />
+              <CopyableInput value={result.adminUsername} />
             </div>
           )}
           <div>
             <Typography.Text strong>Admin email</Typography.Text>
-            <Input readOnly value={result.adminEmail} />
+            <CopyableInput value={result.adminEmail} />
           </div>
           <div>
             <Typography.Text strong>Admin password</Typography.Text>
-            <Input.Password
-              readOnly
-              value={result.adminPassword}
-              visibilityToggle
-              addonAfter={
-                <Tooltip title={t("installapplicationmodal.copy")}>
-                  <Button
-                    type="text"
-                    icon={<CopyOutlined />}
-                    onClick={() => copy("Password", result.adminPassword)}
-                  />
-                </Tooltip>
-              }
-            />
+            <CopyableInput value={result.adminPassword} secret />
           </div>
         </Space>
       )}

--- a/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
+++ b/panel-ui/src/shells/user/databases/QuickSetupModal.tsx
@@ -13,11 +13,12 @@
 
 import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
-import { Modal, Form, Input, Button, Segmented, Space, Typography, Alert, Tooltip } from "antd";
+import { Modal, Form, Input, Button, Segmented, Space, Typography, Alert } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
-import { CopyOutlined, CheckCircleTwoTone } from "@icons";
+import { CheckCircleTwoTone } from "@icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
+import { CopyableInput } from "../../../components/CopyableInput";
 
 type Props = {
   open: boolean;
@@ -141,14 +142,6 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
     }
   };
 
-  const copy = async (label: string, value: string) => {
-    try {
-      await navigator.clipboard.writeText(value);
-      feedback.message.success(`${label} copied`);
-    } catch {
-      feedback.message.error(`Could not copy ${label.toLowerCase()}`);
-    }
-  };
 
   return (
     <Modal
@@ -234,52 +227,15 @@ export const QuickSetupModal = ({ open, onClose, onSuccess }: Props) => {
           />
           <div>
             <Typography.Text strong>Database</Typography.Text>
-            <Input
-              readOnly
-              value={result.databaseName}
-              addonAfter={
-                <Tooltip title={t("quicksetupmodal.copy")}>
-                  <Button
-                    type="text"
-                    icon={<CopyOutlined />}
-                    onClick={() => copy("Database name", result.databaseName)}
-                  />
-                </Tooltip>
-              }
-            />
+            <CopyableInput value={result.databaseName} />
           </div>
           <div>
             <Typography.Text strong>Username</Typography.Text>
-            <Input
-              readOnly
-              value={result.username}
-              addonAfter={
-                <Tooltip title={t("quicksetupmodal.copy")}>
-                  <Button
-                    type="text"
-                    icon={<CopyOutlined />}
-                    onClick={() => copy("Username", result.username)}
-                  />
-                </Tooltip>
-              }
-            />
+            <CopyableInput value={result.username} />
           </div>
           <div>
             <Typography.Text strong>Password</Typography.Text>
-            <Input.Password
-              readOnly
-              value={result.password}
-              visibilityToggle
-              addonAfter={
-                <Tooltip title={t("quicksetupmodal.copy")}>
-                  <Button
-                    type="text"
-                    icon={<CopyOutlined />}
-                    onClick={() => copy("Password", result.password)}
-                  />
-                </Tooltip>
-              }
-            />
+            <CopyableInput value={result.password} secret />
           </div>
         </Space>
       )}

--- a/panel-ui/tests/e2e/admin-automation.spec.ts
+++ b/panel-ui/tests/e2e/admin-automation.spec.ts
@@ -60,12 +60,10 @@ if (SKIP_REASON) {
       // One-time-reveal modal appears with the plaintext secret.
       const modalTitle = page.getByText(`Token "${probeName}" minted`);
       await expect(modalTitle).toBeVisible({ timeout: 10_000 });
-      // Plaintext = 64 hex chars; assert at least one block of that
-      // shape is rendered without leaking the value into test output.
-      const codeBlock = page.locator("code", {
-        hasText: /^[0-9a-f]{64}$/i,
-      });
-      await expect(codeBlock).toBeVisible();
+      // Plaintext = 64 hex chars; the secret renders in a read-only
+      // CopyableInput, so assert on the input's display value without
+      // leaking it into test output.
+      await expect(page.getByDisplayValue(/^[0-9a-f]{64}$/i)).toBeVisible();
 
       // Acknowledge + dismiss.
       await page.getByRole("button", { name: /I've saved it/i }).click();


### PR DESCRIPTION
Reported: on the token-reveal modal the copy icon sat **below** the value field; asked to make it consistent panel-wide (icon **inside** the input).

## Change
New shared **`CopyableInput`** — a read-only antd `Input` with the copy icon as a **suffix inside** the field (and an optional reveal-eye for secrets). Replaces the three scattered anti-patterns: `Typography.Paragraph copyable` over a block `<code>` (icon drops below), `Input.Group` + copy `Button`, and `addonAfter`/`Space.Compact` copy buttons.

Adopted for every **read-only single-line value reveal**:
- **Admin** — Automation token ID + secret (the screenshot), Database root password, Diagnostic report (claim code / link / password).
- **User** — API token secret, Quick DB setup (db / user / password), app-install result (domain / admin user / email / password).
- Shared `DatabaseUserPasswordModal`.

Left as-is (not the anti-pattern): editable fields (`EnvSection` — has onChange) and multi-line key textareas (SSH keys, encryption restore snippet, backup-dest pubkey). `CopyableInput` is for read-only single-line values.

## Verification
- `tsc -b` green; vitest green (74 tests across touched areas).
- Updated the admin-automation E2E to locate the secret by input display value instead of a `<code>` block (the secret now renders in a CopyableInput).
- Net −102 lines (removed per-site copy handlers/buttons).

Visual confirmation on jabalitests available on request.

GH: copy-icon-inside-input polish