### PR TITLE
fix(security): serialize + generation-gate the FTP sshd sync, per-user bound the reload (JAB-266, JAB-267)

### DIFF
--- a/panel-agent/internal/commands/ftp_account_sshd.go
+++ b/panel-agent/internal/commands/ftp_account_sshd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -49,12 +50,30 @@ type ftpSSHDSyncAccount struct {
 
 type ftpSSHDSyncParams struct {
 	Accounts []ftpSSHDSyncAccount `json:"accounts"`
+	// Generation is a monotonic sequence the panel assigns when it reads the
+	// desired snapshot (JAB-267). The agent applies syncs in generation order
+	// and DROPS any whose generation is older than the last one it applied, so
+	// a delayed stale snapshot can never overwrite a newer one and resurrect a
+	// revoked Match block (which — because disabling sftp_access does not lock
+	// the password — would silently restore working password SFTP access).
+	// 0 = unversioned (older panel): apply ungated, preserving prior behavior.
+	Generation int64 `json:"generation"`
 }
 
 type ftpSSHDSyncResponse struct {
 	Accounts int  `json:"accounts"`
 	Changed  bool `json:"changed"`
+	// Stale is true when the sync was dropped because its generation was older
+	// than the last applied — a correct no-op, not an error.
+	Stale bool `json:"stale,omitempty"`
 }
+
+// lastXferSyncGen is the highest generation applied to the xfer drop-in.
+// Guarded by sshOpMu — read and written only inside the locked critical
+// section below. In-memory on purpose: an agent restart drops every in-flight
+// UDS call, so no stale sync outlives the reset, and the reconciler re-syncs
+// current DB truth on its next pass regardless.
+var lastXferSyncGen int64
 
 // ftpXferUsernameRegex is deliberately stricter than usernameRegex: a
 // rendered name lands inside sshd config, so beyond POSIX validity it must
@@ -156,10 +175,30 @@ func ftpSSHDSyncHandler(ctx context.Context, params json.RawMessage) (any, error
 		seen[a.Username] = struct{}{}
 	}
 
+	// The whole write→sshd -t→reload sequence, plus the generation high-water
+	// read/advance, runs under sshOpMu. The lock is shared with
+	// system.set_ssh_config because `sshd -t` validates the COMBINED config —
+	// a concurrent writer to another drop-in would otherwise invalidate a test
+	// this handler already passed. Serialization alone cannot reject an
+	// already-stale snapshot, so the generation gate below does that (JAB-267).
+	sshOpMu.Lock()
+	defer sshOpMu.Unlock()
+
+	if p.Generation > 0 && p.Generation < lastXferSyncGen {
+		slog.WarnContext(ctx, "ftp sshd_sync: dropping stale snapshot",
+			"generation", p.Generation, "last_applied", lastXferSyncGen, "accounts", len(p.Accounts))
+		return ftpSSHDSyncResponse{Accounts: len(p.Accounts), Changed: false, Stale: true}, nil
+	}
+
 	path := getSSHXferDropinPath()
 	desired := renderXferDropin(p.Accounts)
 	prev, readErr := os.ReadFile(path)
 	if readErr == nil && string(prev) == desired {
+		// Already at the desired content: this generation is applied (no-op).
+		// Advance the high-water so a later stale snapshot can't win.
+		if p.Generation > lastXferSyncGen {
+			lastXferSyncGen = p.Generation
+		}
 		return ftpSSHDSyncResponse{Accounts: len(p.Accounts), Changed: false}, nil
 	}
 
@@ -173,6 +212,14 @@ func ftpSSHDSyncHandler(ctx context.Context, params json.RawMessage) (any, error
 			restoreFile(path, prev)
 			return nil, fmt.Errorf("sshd -t validation failed: %s: %w", strings.TrimSpace(string(out)), err)
 		}
+	}
+	// The desired content is now validated and durably on disk. Advance the
+	// high-water HERE, before the reload — a reload failure must not leave newer
+	// on-disk content unprotected against an older in-flight sync overwriting
+	// it. The reconciler re-issues the reload on its next pass with a fresh,
+	// higher generation.
+	if p.Generation > lastXferSyncGen {
+		lastXferSyncGen = p.Generation
 	}
 	if os.Getenv("JABALI_SSHD_TEST_SKIP_RELOAD") == "" {
 		unit := pickSSHUnit(ctx)

--- a/panel-agent/internal/commands/ssh_serialize.go
+++ b/panel-agent/internal/commands/ssh_serialize.go
@@ -1,0 +1,24 @@
+package commands
+
+import "sync"
+
+// sshOpMu serializes every sshd-mutating write→`sshd -t`→reload sequence across
+// all agent handlers (JAB-267), the SSH twin of nginxOpMu.
+//
+// The agent runs a goroutine per UDS command, so two SSH-config handlers could
+// otherwise interleave. `sshd -t` validates the COMPLETE config — the main file
+// plus EVERY drop-in in /etc/ssh/sshd_config.d — so a concurrent writer to a
+// DIFFERENT drop-in can invalidate a test another handler already passed:
+//
+//	A: write jabali-xfer.conf   A: sshd -t (passes)
+//	                            B: write jabali-sshd.conf (broken/partial)
+//	A: reload                   → sshd loads B's broken config
+//
+// A broken sshd config is a host lockout, so this is stricter than the nginx
+// case. Every handler that mutates any sshd_config.d drop-in MUST hold this
+// mutex across its ENTIRE write→test→reload critical section — currently
+// ftpaccount.sshd_sync (ftp_account_sshd.go) and system.set_ssh_config
+// (system_set_ssh_config.go). It is a plain (non-reentrant) sync.Mutex: a
+// handler acquires it exactly once around its whole section and never calls
+// another mutex-taking helper while holding it.
+var sshOpMu sync.Mutex

--- a/panel-agent/internal/commands/ssh_serialize_test.go
+++ b/panel-agent/internal/commands/ssh_serialize_test.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// sshTestEnv redirects all three sshd drop-ins into a temp dir and skips the
+// real sshd -t / reload, so the serialization + generation logic is exercised
+// without touching the host.
+func sshTestEnv(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("JABALI_SSHD_XFER_DROPIN_PATH", filepath.Join(dir, "jabali-xfer.conf"))
+	t.Setenv("JABALI_SSHD_DROPIN_PATH", filepath.Join(dir, "jabali-sshd.conf"))
+	t.Setenv("JABALI_SSHD_SFTP_DROPIN_PATH", filepath.Join(dir, "jabali-sftp.conf"))
+	t.Setenv("JABALI_SSHD_TEST_SKIP_VALIDATE", "1")
+	t.Setenv("JABALI_SSHD_TEST_SKIP_RELOAD", "1")
+	return filepath.Join(dir, "jabali-xfer.conf")
+}
+
+func syncGen(t *testing.T, gen int64, accts ...ftpSSHDSyncAccount) ftpSSHDSyncResponse {
+	t.Helper()
+	params, _ := json.Marshal(ftpSSHDSyncParams{Accounts: accts, Generation: gen})
+	res, err := ftpSSHDSyncHandler(context.Background(), params)
+	if err != nil {
+		t.Fatalf("sshd_sync gen=%d: %v", gen, err)
+	}
+	return res.(ftpSSHDSyncResponse)
+}
+
+// JAB-267: a stale (lower-generation) snapshot that lands after a newer one
+// must be DROPPED, not applied — otherwise it resurrects a Match block a newer
+// revocation already removed, restoring working password SFTP access.
+func TestFtpSSHDSync_StaleGenerationDropped(t *testing.T) {
+	path := sshTestEnv(t)
+	lastXferSyncGen = 0 // isolate from other tests sharing the package global
+
+	acct := ftpSSHDSyncAccount{Username: "shop_dev", ChrootDir: "/home/shop", StartDir: "/"}
+
+	// gen=200 is the newer REVOCATION: the account is gone (empty set).
+	if res := syncGen(t, 200); res.Stale {
+		t.Fatal("newer revocation must not be marked stale")
+	}
+	if c, _ := os.ReadFile(path); strings.Contains(string(c), "Match User shop_dev") {
+		t.Fatalf("account should be revoked after gen=200: %s", c)
+	}
+
+	// gen=100 is the STALE snapshot that still lists the account, arriving late.
+	res := syncGen(t, 100, acct)
+	if !res.Stale {
+		t.Fatal("stale gen=100 after gen=200 must be dropped (Stale=true)")
+	}
+	if res.Changed {
+		t.Fatal("a dropped stale sync must not report a change")
+	}
+	if c, _ := os.ReadFile(path); strings.Contains(string(c), "Match User shop_dev") {
+		t.Fatalf("stale sync RESTORED a revoked account — JAB-267 regression: %s", c)
+	}
+}
+
+// A newer or equal-or-unversioned generation still applies; gen=0 is the
+// unversioned (older-panel) escape hatch and is never gated.
+func TestFtpSSHDSync_GenerationOrdering(t *testing.T) {
+	path := sshTestEnv(t)
+	lastXferSyncGen = 0
+
+	a := ftpSSHDSyncAccount{Username: "a_dev", ChrootDir: "/home/a", StartDir: "/"}
+	b := ftpSSHDSyncAccount{Username: "b_dev", ChrootDir: "/home/b", StartDir: "/"}
+
+	syncGen(t, 100, a)
+	if c, _ := os.ReadFile(path); !strings.Contains(string(c), "Match User a_dev") {
+		t.Fatal("gen=100 should apply")
+	}
+	// Higher gen applies and replaces.
+	syncGen(t, 300, b)
+	if c, _ := os.ReadFile(path); !strings.Contains(string(c), "Match User b_dev") || strings.Contains(string(c), "Match User a_dev") {
+		t.Fatal("gen=300 should replace with b_dev only")
+	}
+	// gen=0 (unversioned) always applies, even though 0 < high-water.
+	syncGen(t, 0, a)
+	if c, _ := os.ReadFile(path); !strings.Contains(string(c), "Match User a_dev") {
+		t.Fatal("unversioned gen=0 must apply ungated")
+	}
+}
+
+// JAB-267 acceptance: concurrent sshd_sync calls (shuffled generations) racing
+// system.set_ssh_config must leave the xfer drop-in equal to the HIGHEST-gen
+// render — never a stale one — with no data race in the shared critical
+// section. Run under -race.
+func TestSSHSync_ConcurrentHighestGenerationWins(t *testing.T) {
+	path := sshTestEnv(t)
+	lastXferSyncGen = 0
+
+	const n = 40
+	gens := rand.Perm(n)   // 0..n-1 shuffled → worker gens 1..n
+	maxGen := int64(n + 1) // strictly above every worker gen, so the winner always wins
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		g := int64(gens[i]) + 1 // 1..n
+		wg.Add(1)
+		go func(gen int64) {
+			defer wg.Done()
+			acct := ftpSSHDSyncAccount{
+				Username:  fmt.Sprintf("u%d_dev", gen),
+				ChrootDir: fmt.Sprintf("/home/u%d", gen),
+				StartDir:  "/",
+			}
+			params, _ := json.Marshal(ftpSSHDSyncParams{Accounts: []ftpSSHDSyncAccount{acct}, Generation: gen})
+			_, _ = ftpSSHDSyncHandler(context.Background(), params)
+		}(g)
+		// Concurrently hammer the sibling SSH-config writer to prove the shared
+		// sshOpMu covers both handlers (they both run sshd -t on the combined
+		// config).
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			params, _ := json.Marshal(systemSetSSHConfigParams{Port: 22, PasswordAuth: true, UserPasswordAuth: true})
+			_, _ = systemSetSSHConfigHandler(context.Background(), params)
+		}()
+	}
+	// The definitive highest generation, applied last-or-gating-everything-after.
+	syncGen(t, maxGen, ftpSSHDSyncAccount{Username: "winner_dev", ChrootDir: "/home/winner", StartDir: "/"})
+	wg.Wait()
+
+	c, _ := os.ReadFile(path)
+	if !strings.Contains(string(c), "Match User winner_dev") {
+		t.Fatalf("highest-generation render did not win: %s", c)
+	}
+	if strings.Contains(string(c), "\nMatch User u") {
+		t.Fatalf("a lower-generation snapshot survived alongside the winner: %s", c)
+	}
+}

--- a/panel-agent/internal/commands/system_set_ssh_config.go
+++ b/panel-agent/internal/commands/system_set_ssh_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -97,16 +98,36 @@ func renderGlobalDropin(port uint16, passwordAuth bool) string {
 	return fmt.Sprintf("Port %d\nPasswordAuthentication %s\n", port, pwLine)
 }
 
-// atomicWrite writes content to path via a sibling .new file + rename.
-// Best-effort cleanup of the .new file on rename failure.
+// atomicWrite writes content to path via a UNIQUE temp file in the same
+// directory + rename. A per-call temp name (os.CreateTemp) means two writers
+// targeting the same path never share one scratch file and clobber each other's
+// in-progress write — the fixed sibling ".new" they used before could collide
+// (JAB-267). The temp lives in the target directory so the rename is atomic
+// (same filesystem). Mode is pinned to 0600, matching the prior behavior for
+// every caller.
 func atomicWrite(path, content string) error {
-	newPath := path + ".new"
-	if err := os.WriteFile(newPath, []byte(content), 0600); err != nil {
-		return fmt.Errorf("write %s: %w", newPath, err)
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp for %s: %w", path, err)
 	}
-	if err := os.Rename(newPath, path); err != nil {
-		_ = os.Remove(newPath)
-		return fmt.Errorf("rename %s -> %s: %w", newPath, path, err)
+	tmpName := tmp.Name()
+	if _, err := tmp.WriteString(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write %s: %w", tmpName, err)
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("chmod %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
 	}
 	return nil
 }
@@ -144,6 +165,15 @@ func systemSetSSHConfigHandler(ctx context.Context, params json.RawMessage) (any
 
 	globalPath := getSSHConfigPath()
 	sftpPath := getSSHSftpDropinPath()
+
+	// Hold sshOpMu across snapshot→write→sshd -t→reload. Shared with
+	// ftpaccount.sshd_sync: `sshd -t` validates the COMBINED config, so a
+	// concurrent xfer-dropin write must not slip between our test and reload,
+	// and our rollback must not race another handler's successful write
+	// (JAB-267). Taking the lock before the prev-content snapshot keeps the
+	// rollback baseline consistent with what we then overwrite.
+	sshOpMu.Lock()
+	defer sshOpMu.Unlock()
 
 	// Snapshot prev contents BEFORE any write so rollback is exact.
 	prevGlobal, _ := os.ReadFile(globalPath)

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ftpsync"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
@@ -39,6 +40,10 @@ type FtpAccountsHandlerConfig struct {
 	Agent           agent.AgentInterface
 	Log             *slog.Logger
 	StrictRateLimit gin.HandlerFunc // optional — wire from rl.Strict()
+	// PatchRateLimit is an optional per-actor (user-keyed) strict limiter for
+	// the sshd-reload-triggering PATCH route (JAB-266). Wire from
+	// rl.StrictPerActor(); nil disables it.
+	PatchRateLimit gin.HandlerFunc
 	// QuotaMount is the filesystem mount path /home lives on (the same value
 	// the M18 user-limits reconciler uses, internal/limits.QuotaMountFor).
 	// Required for GH #1145 isolated accounts (per-uid setquota); empty
@@ -73,10 +78,17 @@ func RegisterFtpAccountRoutes(g *gin.RouterGroup, cfg FtpAccountsHandlerConfig) 
 	if strict == nil {
 		strict = func(c *gin.Context) { c.Next() }
 	}
+	// JAB-266: PATCH toggling sftp_access rewrites and reloads global sshd on
+	// every request. The strict tier alone is per-IP, which an actor multiplies
+	// across addresses, so PATCH additionally takes a per-user strict budget.
+	patchLimit := cfg.PatchRateLimit
+	if patchLimit == nil {
+		patchLimit = func(c *gin.Context) { c.Next() }
+	}
 	me := g.Group("/me/ftp-accounts")
 	me.GET("", h.list)
 	me.POST("", strict, h.create)
-	me.PATCH("/:id", h.update)
+	me.PATCH("/:id", patchLimit, h.update)
 	me.POST("/:id/password", strict, h.setPassword)
 	me.DELETE("/:id", h.delete)
 
@@ -300,6 +312,13 @@ func (h *ftpAccountsHandler) syncHostAccess(ctx context.Context, tenantUsername 
 	}); err != nil && h.cfg.Log != nil {
 		h.cfg.Log.Warn("ftp: home chroot flip failed (reconciler will retry)", "tenant", tenantUsername, "err", err)
 	}
+	// Stamp the generation BEFORE reading the snapshot. The agent's stale-drop
+	// gate is only sound if stamp order precedes read order: a sync that can
+	// override a revocation carries a higher generation, so it was stamped after
+	// the revocation's stamp, so — stamping before reading — it read after the
+	// revocation committed and its own snapshot already reflects the revocation.
+	// Stamping at dispatch (after the read) reopens the JAB-267 inversion.
+	gen := ftpsync.NextGeneration()
 	rows, err := h.cfg.Repo.List(ctx)
 	if err != nil {
 		return
@@ -343,7 +362,10 @@ func (h *ftpAccountsHandler) syncHostAccess(ctx context.Context, tenantUsername 
 		}
 		desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
 	}
-	if err := h.agentCall(ctx, "ftpaccount.sshd_sync", map[string]any{"accounts": desired}); err != nil && h.cfg.Log != nil {
+	if err := h.agentCall(ctx, "ftpaccount.sshd_sync", map[string]any{
+		"accounts":   desired,
+		"generation": gen,
+	}); err != nil && h.cfg.Log != nil {
 		h.cfg.Log.Warn("ftp: sshd_sync failed (reconciler will retry)", "err", err)
 	}
 }

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -157,6 +157,39 @@ func mockCalled(mock *agent.MockClient, command string) int {
 	return n
 }
 
+// JAB-267: every sshd_sync dispatch must carry a positive generation so the
+// agent can reject stale snapshots. A create triggers syncHostAccess.
+func TestFtpAPI_SSHDSyncCarriesGeneration(t *testing.T) {
+	repo := newFakeFtpRepo()
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPost, "/me/ftp-accounts",
+		`{"label":"deploy","home_path":"/home/shop/site","password":"longenough-pass1","ftp_access":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var found bool
+	for _, call := range mock.Calls() {
+		if call.Command != "ftpaccount.sshd_sync" {
+			continue
+		}
+		found = true
+		var p struct {
+			Generation int64 `json:"generation"`
+		}
+		if err := json.Unmarshal(call.Params, &p); err != nil {
+			t.Fatalf("unmarshal sshd_sync params: %v", err)
+		}
+		if p.Generation <= 0 {
+			t.Fatalf("sshd_sync must carry a positive generation, got %d", p.Generation)
+		}
+	}
+	if !found {
+		t.Fatal("no ftpaccount.sshd_sync call recorded")
+	}
+}
+
 func TestFtpAPICreate_HappyPath(t *testing.T) {
 	repo := newFakeFtpRepo()
 	mock := ftpMockAgent()

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1359,7 +1359,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Agent:           deps.Agent,
 				Log:             deps.Log,
 				StrictRateLimit: rl.Strict(),
-				QuotaMount:      deps.QuotaMount, // GH #1145 isolated per-uid setquota
+				PatchRateLimit:  rl.StrictPerActor(), // JAB-266: per-user bound on sshd-reload PATCH
+				QuotaMount:      deps.QuotaMount,     // GH #1145 isolated per-uid setquota
 			})
 		}
 

--- a/panel-api/internal/ftpsync/generation.go
+++ b/panel-api/internal/ftpsync/generation.go
@@ -1,0 +1,40 @@
+// Package ftpsync holds coordination state shared between the FTP-account API
+// handlers and the FTP reconciler — the two places that dispatch the full
+// ftpaccount.sshd_sync snapshot to the agent.
+package ftpsync
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// lastGen is the process-wide high-water mark for sshd_sync generations.
+var lastGen int64
+
+// NextGeneration returns a strictly increasing generation stamp for an
+// ftpaccount.sshd_sync dispatch (JAB-267). The agent applies syncs in
+// generation order and drops any older than the last it applied, so a delayed
+// stale snapshot cannot resurrect a revoked Match block.
+//
+// It is seeded from the wall clock (so a fresh process starts above any value a
+// previous one plausibly emitted) but is NOT a bare time.Now(): UnixNano drops
+// the monotonic component, so an NTP step backwards would make every subsequent
+// stamp — including revocations — fall below the agent's high-water and get
+// dropped, silently reopening the race for the skew window. The max(prev+1, now)
+// CAS guarantees the sequence only ever increases regardless of clock motion.
+//
+// BOTH dispatch sites (the API's syncHostAccess and the reconciler) MUST call
+// this same function; two independent counters would re-break cross-site
+// ordering during a skew window.
+func NextGeneration() int64 {
+	for {
+		prev := atomic.LoadInt64(&lastGen)
+		next := time.Now().UnixNano()
+		if next <= prev {
+			next = prev + 1
+		}
+		if atomic.CompareAndSwapInt64(&lastGen, prev, next) {
+			return next
+		}
+	}
+}

--- a/panel-api/internal/ftpsync/generation_test.go
+++ b/panel-api/internal/ftpsync/generation_test.go
@@ -1,0 +1,34 @@
+package ftpsync
+
+import (
+	"sync"
+	"testing"
+)
+
+// NextGeneration must be strictly increasing even under concurrent callers and
+// even if the wall clock does not advance between calls — the CAS max(prev+1,
+// now) guarantees uniqueness, which the agent's stale-drop gate depends on.
+func TestNextGeneration_StrictlyIncreasingConcurrent(t *testing.T) {
+	const n = 2000
+	got := make([]int64, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			got[idx] = NextGeneration()
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[int64]struct{}, n)
+	for _, g := range got {
+		if _, dup := seen[g]; dup {
+			t.Fatalf("duplicate generation %d — uniqueness broken", g)
+		}
+		seen[g] = struct{}{}
+	}
+	if len(seen) != n {
+		t.Fatalf("expected %d unique generations, got %d", n, len(seen))
+	}
+}

--- a/panel-api/internal/middleware/ratelimit.go
+++ b/panel-api/internal/middleware/ratelimit.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/time/rate"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 )
 
 // RateLimiterConfig describes two token-bucket tiers. Default applies to
@@ -74,6 +76,24 @@ func (l *RateLimiter) Default() gin.HandlerFunc { return l.handler(tierDefault) 
 // rate limiting; /.ory/* is not fronted by this middleware.
 func (l *RateLimiter) Strict() gin.HandlerFunc { return l.handler(tierStrict) }
 
+// StrictPerActor enforces the strict tier keyed by the AUTHENTICATED user
+// rather than the client IP. Some strict-tier routes trigger expensive host
+// side effects (JAB-266: an FTP-account PATCH rewrites and reloads global
+// sshd), and a per-IP budget multiplies under one session — an actor with N
+// addresses gets N×the budget. Keying on the user id bounds the actor
+// regardless of source IP. Falls back to the client IP when the request is
+// unauthenticated (no claims), so the middleware is still safe if mounted
+// before auth.
+func (l *RateLimiter) StrictPerActor() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := clientIP(c)
+		if claims := ginctx.Claims(c); claims != nil && claims.UserID != "" {
+			key = "user:" + claims.UserID
+		}
+		l.enforce(c, key, tierStrict)
+	}
+}
+
 // KratosFlows rate-limits the unauthenticated credential POSTs proxied at
 // /.ory (self-service login + recovery) per client IP, BEFORE they reach Kratos.
 // Only POST submissions to those two flows are gated — flow-init GETs, CSRF
@@ -117,28 +137,36 @@ func (l *RateLimiter) KratosFlows(log *slog.Logger) gin.HandlerFunc {
 
 func (l *RateLimiter) handler(t tier) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		lim := l.limiterFor(clientIP(c), t)
-		res := lim.Reserve()
-		if !res.OK() {
-			// Can only happen with a misconfigured limit (rate=0 and burst=0);
-			// still refuse deterministically.
-			c.Header("Retry-After", "60")
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited"})
-			return
-		}
-		if d := res.Delay(); d > 0 {
-			// We don't sleep — we reject, advising the client when to retry.
-			res.Cancel() // refund the reservation we didn't use
-			retry := int(math.Ceil(d.Seconds()))
-			if retry < 1 {
-				retry = 1
-			}
-			c.Header("Retry-After", strconv.Itoa(retry))
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited"})
-			return
-		}
-		c.Next()
+		l.enforce(c, clientIP(c), t)
 	}
+}
+
+// enforce consumes one token from the (key, tier) bucket and either passes the
+// request through or aborts it 429 with a Retry-After hint. key is the bucket
+// identity — the client IP for the per-IP tiers, or a user-scoped string for
+// StrictPerActor.
+func (l *RateLimiter) enforce(c *gin.Context, key string, t tier) {
+	lim := l.limiterFor(key, t)
+	res := lim.Reserve()
+	if !res.OK() {
+		// Can only happen with a misconfigured limit (rate=0 and burst=0);
+		// still refuse deterministically.
+		c.Header("Retry-After", "60")
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited"})
+		return
+	}
+	if d := res.Delay(); d > 0 {
+		// We don't sleep — we reject, advising the client when to retry.
+		res.Cancel() // refund the reservation we didn't use
+		retry := int(math.Ceil(d.Seconds()))
+		if retry < 1 {
+			retry = 1
+		}
+		c.Header("Retry-After", strconv.Itoa(retry))
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited"})
+		return
+	}
+	c.Next()
 }
 
 func (l *RateLimiter) limiterFor(ip string, t tier) *rate.Limiter {

--- a/panel-api/internal/middleware/ratelimit_test.go
+++ b/panel-api/internal/middleware/ratelimit_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
 )
 
@@ -70,6 +72,64 @@ func TestRateLimit_SeparateBucketsPerIP(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, hit("10.0.0.1"))
 	// Different IP gets its own bucket — still has budget.
 	assert.Equal(t, http.StatusOK, hit("10.0.0.2"))
+}
+
+// JAB-266: StrictPerActor keys the strict bucket on the authenticated user,
+// not the client IP, so an actor cannot multiply its budget across addresses.
+func TestStrictPerActor_KeyedByUserNotIP(t *testing.T) {
+	t.Parallel()
+
+	rl := middleware.NewRateLimiter(middleware.RateLimiterConfig{
+		DefaultRate:  rate.Limit(100),
+		DefaultBurst: 100,
+		StrictRate:   rate.Limit(1),
+		StrictBurst:  1,
+	})
+	r := gin.New()
+	withUser := func(uid string) gin.HandlerFunc {
+		return func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: uid}); c.Next() }
+	}
+	r.POST("/u1", withUser("u1"), rl.StrictPerActor(), func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+	r.POST("/u2", withUser("u2"), rl.StrictPerActor(), func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	hit := func(path, ip string) int {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.RemoteAddr = ip + ":1000"
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// Same user from a NEW IP each time still shares one bucket.
+	assert.Equal(t, http.StatusOK, hit("/u1", "10.0.0.1"))
+	assert.Equal(t, http.StatusTooManyRequests, hit("/u1", "10.0.0.2"))
+	assert.Equal(t, http.StatusTooManyRequests, hit("/u1", "10.0.0.3"))
+	// A different user has an independent bucket.
+	assert.Equal(t, http.StatusOK, hit("/u2", "10.0.0.1"))
+}
+
+// Unauthenticated requests (no claims) fall back to per-IP keying so the
+// middleware is still safe if mounted before auth.
+func TestStrictPerActor_FallsBackToIPWhenAnonymous(t *testing.T) {
+	t.Parallel()
+
+	rl := middleware.NewRateLimiter(middleware.RateLimiterConfig{
+		StrictRate:  rate.Limit(1),
+		StrictBurst: 1,
+	})
+	r := gin.New()
+	r.POST("/x", rl.StrictPerActor(), func(c *gin.Context) { c.String(http.StatusOK, "ok") })
+
+	hit := func(ip string) int {
+		req := httptest.NewRequest(http.MethodPost, "/x", nil)
+		req.RemoteAddr = ip + ":1000"
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	assert.Equal(t, http.StatusOK, hit("10.0.0.1"))
+	assert.Equal(t, http.StatusTooManyRequests, hit("10.0.0.1"))
+	assert.Equal(t, http.StatusOK, hit("10.0.0.2")) // distinct IP → own bucket
 }
 
 func TestRateLimit_StrictBucketIsIndependent(t *testing.T) {

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ftpsync"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
@@ -167,6 +168,13 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 	if r.ftpAccounts == nil || r.users == nil || r.agent == nil {
 		return
 	}
+	// Stamp the sshd_sync generation BEFORE reading the rows. The agent's
+	// stale-drop gate is only sound if stamp order precedes read order (see the
+	// same hoist in the API's syncHostAccess): a sync that could override a
+	// concurrent revocation carries a higher generation, so it stamped — and
+	// therefore read — after that revocation committed, so its own snapshot
+	// already reflects the revocation. Both dispatch sites share one counter.
+	gen := ftpsync.NextGeneration()
 	rows, err := r.ftpAccounts.List(ctx)
 	if err != nil {
 		r.log.Error("ftp: list accounts failed", "err", err)
@@ -252,7 +260,10 @@ func (r *Reconciler) reconcileFtpAccounts(ctx context.Context) {
 			desired = append(desired, syncAccount{Username: a.Username, ChrootDir: chroot, StartDir: start})
 		}
 	}
-	if _, err := r.agent.Call(ctx, "ftpaccount.sshd_sync", map[string]any{"accounts": desired}); err != nil {
+	if _, err := r.agent.Call(ctx, "ftpaccount.sshd_sync", map[string]any{
+		"accounts":   desired,
+		"generation": gen,
+	}); err != nil {
 		r.log.Warn("ftp: sshd_sync failed (will retry next pass)", "err", err)
 		converged = false
 	}

--- a/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
+++ b/panel-api/internal/reconciler/ftp_accounts_reconcile_test.go
@@ -232,6 +232,12 @@ func TestReconcileFtpAccounts_SSHDSyncPayloadShape(t *testing.T) {
 		t.Fatal("expected one sshd_sync")
 	}
 	payload := calls["ftpaccount.sshd_sync"][0].params.(map[string]any)
+	// JAB-267: the reconciler must stamp a positive generation too (the API and
+	// reconciler share one counter; a missing stamp on either site reopens the
+	// stale-restore race).
+	if gen, _ := payload["generation"].(int64); gen <= 0 {
+		t.Fatalf("reconciler sshd_sync must carry a positive generation, got %v", payload["generation"])
+	}
 	raw, _ := json.Marshal(payload["accounts"])
 	var accounts []struct {
 		Username  string `json:"username"`


### PR DESCRIPTION
## JAB-266 + JAB-267 — SSH-sync hardening for FTP subaccounts

The FTP-account SFTP Match file (`/etc/ssh/sshd_config.d/jabali-xfer.conf`) is rewritten from a full desired snapshot, `sshd -t`-validated, and reloaded on every account mutation. One PR because both flaws live in the same handler + dispatch sites.

### JAB-267 (High) — concurrent stale snapshot restores revoked access
The agent ran each UDS command in its own goroutine with **no SSH critical section and no ordering**. An older desired snapshot finishing after a newer revocation rewrote the file and **restored the removed `Match` block** — and since disabling `sftp_access` doesn't lock the password, that silently **restored working password SFTP access** until the reconciler repaired it. `atomicWrite` also used a fixed sibling `.new` temp, so two writers to one target could clobber each other's scratch file.

### JAB-266 (High) — per-request global sshd reload DoS
PATCH toggling `sftp_access` forced a host-wide rewrite + `sshd -t` + reload every request, and PATCH used only the **default** rate tier (10/s). Sustained toggles churned root subprocesses and the SSH control plane, degrading logins for every tenant.

### Fix — agent
- **`sshOpMu`** (new `ssh_serialize.go`), the SSH twin of `nginxOpMu`. **Both** `ftpaccount.sshd_sync` and `system.set_ssh_config` hold it across their whole write→`sshd -t`→reload section. Shared because `sshd -t` validates the *combined* config — a concurrent writer to a different drop-in can invalidate a test another handler just passed.
- **Monotonic `generation`** on `sshd_sync`. The agent tracks the highest applied generation (in-memory, under the mutex) and **drops** any lower one — a stale snapshot can't resurrect a revoked block. A dropped sync returns `Stale=true` (a correct no-op, not an error) and logs one line. `generation<=0` = unversioned (older panel): applied ungated, so mixed-version deploys degrade to today's behavior, never worse. Serialization alone can't reject an *already-stale* snapshot; the generation gate is what closes the race. High-water advances right after `sshd -t` (validated-on-disk), so a reload failure can't leave newer content unprotected.
- **`atomicWrite` → unique `os.CreateTemp`** in the target dir (mode pinned 0600, same-fs atomic rename), eliminating fixed-temp collisions for every caller.

### Fix — panel
- Both dispatch sites (`syncHostAccess` + reconciler) stamp `generation` from **one shared strictly-increasing counter** (`internal/ftpsync`). Wall-clock seeded but `max(prev+1, now)` via CAS, so an NTP step backwards can't make new syncs — including revocations — fall below the high-water.
- **Stamp BEFORE the DB read**, not at dispatch. The gate is only sound if stamp order precedes read order: a sync that can override a revocation carries a higher generation → stamped after → (stamping-before-reading) **read after** the revocation committed → its own snapshot already reflects the revocation. This is the invariant that makes the gate correct; the reconciler's wide snapshot-build window is exactly where stamp-at-dispatch would reopen 267.
- **`rl.StrictPerActor()`** keys the strict tier on the authenticated **user id** instead of client IP, and PATCH now carries it. The existing `Strict()` is per-IP, which an actor multiplies across addresses — the hole the ticket names. Admin PATCH stays unthrottled by design (operator, not the tenant threat model).

### Tests
- Agent (`-race`): stale-generation-dropped (the revoked-block-restore regression), generation ordering, and a concurrent test asserting the **highest generation wins** while `system.set_ssh_config` runs concurrently (proves the shared mutex).
- Panel: both dispatch sites carry a positive generation (api + reconciler); middleware per-user keying (same user across IPs → one bucket) + anonymous IP fallback; `ftpsync` generation uniqueness under concurrency.
- `go build`/`vet`/`gofmt` clean; full `panel-agent/internal/commands` green under `-race` (the shared `atomicWrite` change is safe for mtasts/autoupdate/sandbox callers); `TestExecSeam_NoRawExec` still passes (no raw exec introduced).

### Live (jabalitests batch — unit tests skip real `sshd -t`/reload)
1. Rapid toggle past 5/min → 429s; `journalctl -u ssh` shows a **bounded** reload count.
2. Revoke-vs-mutation race → the `Match` block stays **absent**.

Refs JAB-266, JAB-267.
