### PR TITLE
docs(ftp): correct false tenant-slice claim; FTPS is daemon-bounded (JAB-263, Option 1 re-scope)

### DIFF
--- a/docs/adr/0167-ftps-resource-limits-daemon-bounded.md
+++ b/docs/adr/0167-ftps-resource-limits-daemon-bounded.md
@@ -1,0 +1,84 @@
+# ADR-0167 — FTPS resource limits are vsftpd-daemon-bounded, not per-tenant cgroup
+
+- Status: Accepted
+- Date: 2026-08-18
+- Tracks: JAB-263 (FTPS sessions bypass per-tenant cgroup resource limits)
+- Related: JAB-259 / JAB-260 (FTP-as-reconciled-resource epic), ADR-0028 (M12 SFTP)
+
+## Context
+
+The M18 per-tenant resource limits (`user.limits.apply`) write cgroups-v2
+directives — `CPUQuota`, `MemoryMax`, `TasksMax`, IO weight — into
+`jabali-user-<tenant>.slice.d/limits.conf`. The kernel enforces those on the
+cgroup `jabali.slice/jabali-user.slice/jabali-user-<tenant>.slice`.
+
+A process is only subject to that slice's limits if it actually lives in the
+slice's cgroup. In this codebase only **panel-managed services** are placed
+there — the per-user php-fpm pool, python-app units, docker apps, and CLI
+work run via `systemd-run --slice=jabali-user-<tenant>.slice` — each through an
+explicit `Slice=` in its unit or a `systemd-run` flag.
+
+**Interactive sessions are not.** vsftpd forks a worker per login under
+`vsftpd.service`'s own cgroup; the worker never migrates to the tenant slice.
+The vsftpd PAM stack (`vsftpd-jabali`) has no `pam_systemd`, so logind opens no
+session for it — and even with `pam_systemd`, logind's default target is the
+standard `user-<uid>.slice`, **not** the panel's `jabali-user-<tenant>.slice`.
+The identical gap applies to SSH/SFTP interactive logins: they too fall outside
+the tenant slice. (A prior code comment in `ftp_account.go` wrongly claimed
+FTPS sessions "land in the tenant's slice, so M18 limits apply unchanged" — they
+do not. That comment is corrected.)
+
+Placing an already-forked worker into the tenant slice is not a small change:
+
+- cgroups-v2's **no-internal-process rule** forbids bare processes in a cgroup
+  that has controller-enabled children — and `jabali-user-<tenant>.slice`
+  already has service children — so a per-session **leaf scope** under the slice
+  is required, not a direct `cgroup.procs` write.
+- vsftpd cannot be launched through `systemd-run`, and `systemd-run` cannot
+  move an **existing** PID into a scope, so placement would need a `pam_exec`
+  session hook creating a transient scope without racing logind/systemd.
+- A hook that fails closed would break FTPS logins outright — a worse outcome
+  than the accounting gap it closes.
+
+## Decision
+
+Bound FTPS resource consumption at the **vsftpd daemon** and document the
+boundary honestly, rather than build a fragile per-session cgroup-placement
+hook for FTPS alone.
+
+The daemon-level caps (rendered into `/etc/vsftpd.conf` from `server_settings`,
+pinned by `install/tests/test_ftp_module_optin.sh`):
+
+- `max_clients` — total concurrent FTPS connections host-wide. **Always on**,
+  default 50.
+- `max_per_ip` — concurrent connections from one source IP. **Always on**,
+  default 8.
+- `local_max_rate` — per-session transfer-rate ceiling (bytes/s). **Opt-in**:
+  default 0 = unlimited; set only when the operator populates
+  `ftp_local_max_rate_kbs`.
+
+Correct the false `ftp_account.go` comment; state the boundary in the FTP
+runbook.
+
+**Deferred:** true per-tenant cgroup placement of interactive sessions is a
+cross-cutting concern (SSH + FTPS share the gap) and is tracked with the
+FTP-as-reconciled-resource epic (JAB-259 / JAB-260). It is deliberately not
+solved per-ticket, per-protocol.
+
+## Consequences
+
+- **Honest posture.** Nothing claims a per-tenant cgroup boundary that does not
+  exist. Operators reading the runbook know FTPS is daemon-bounded.
+- **Residual gap.** There is no per-*tenant* connection cap: a tenant behind one
+  IP is bounded by `max_per_ip` (8), but a tenant spread across many IPs is
+  bounded only by the global `max_clients` (50) and could consume a large share
+  of slots. With `local_max_rate` at its default (0 = unlimited), each of those
+  sessions can transfer at full line rate, so an operator who wants a bandwidth
+  floor for other tenants must set `ftp_local_max_rate_kbs`. CPU/memory of FTPS
+  workers is not attributed to the tenant slice, so usage reporting under-counts
+  interactive transfers.
+- **Re-scope acknowledged.** JAB-263's literal acceptance ("FTPS PIDs under
+  `jabali-user-<tenant>.slice`") is not met; it moves to the epic. This ADR
+  records the operator-approved re-scope.
+- **Reversible.** If the epic builds session placement, this daemon boundary
+  stays as defense-in-depth; nothing here blocks it.

--- a/docs/runbooks/ftp-accounts.md
+++ b/docs/runbooks/ftp-accounts.md
@@ -48,6 +48,27 @@ range.
   TLS certificate is the PANEL hostname's — clients connecting to their
   own domain name will see a name mismatch; point them at the panel host.
 
+## Resource limits (what bounds FTPS load)
+
+FTPS sessions are **daemon-bounded, not per-tenant cgroup-bounded** (JAB-263,
+ADR-0167). The M18 CPU/memory/task limits on `jabali-user-<tenant>.slice` bind
+only panel services (php-fpm, python, docker); a vsftpd worker runs under
+`vsftpd.service` and is never migrated into the tenant slice — the same is true
+of SSH/SFTP interactive logins. What DOES bound FTPS, from `server_settings`
+into `/etc/vsftpd.conf`:
+
+- `max_clients` — total concurrent FTPS connections on the host (always on,
+  default 50).
+- `max_per_ip` — concurrent connections per source IP (always on, default 8).
+- `local_max_rate` — per-session transfer-rate ceiling. **Opt-in**: default 0 =
+  unlimited; set `ftp_local_max_rate_kbs` to throttle per session.
+
+There is no per-*tenant* connection cap: a tenant behind one IP is held by
+`max_per_ip`, but across many IPs only the global `max_clients` applies, and at
+the default rate each session is unthrottled. Disk is still bounded per-tenant
+(shared-uid quota). Per-tenant cgroup placement of interactive sessions is
+deferred to the session-placement epic (JAB-259/260).
+
 ## Tenant home permission flip
 
 The FIRST SFTP-enabled subaccount a tenant creates flips

--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -22,8 +22,17 @@ import (
 // (useradd --non-unique): its own username + password + home directory, but
 // every file it writes is owned by the tenant uid, so quotas, per-user FPM,
 // AppArmor, and backups treat its writes exactly like the tenant's own.
-// Sessions also land in the tenant's user-<uid>.slice, so M18 resource
-// limits apply unchanged.
+//
+// Its cgroup RESOURCE limits do NOT carry over, though (JAB-263): the M18
+// CPU/memory/task limits live on jabali-user-<tenant>.slice, which binds only
+// panel-managed SERVICES (php-fpm pool, python app, docker) via an explicit
+// Slice=. Interactive transfer sessions — FTPS here, and SSH/SFTP alike — are
+// never placed in that slice: there is no pam_systemd in the vsftpd stack, and
+// logind's default is the standard user-<uid>.slice, not ours. FTPS resource
+// use is instead bounded at the vsftpd daemon (max_clients / max_per_ip /
+// local_max_rate, rendered from server_settings). Per-tenant cgroup placement
+// of interactive sessions is a cross-cutting gap (SSH too), deferred to the
+// session-placement epic — see docs/adr/0167 and JAB-263.
 //
 // Deliberate non-goals, both consequences of sharing the uid:
 //   - No isolation BETWEEN a tenant and its subaccounts — the kernel cannot


### PR DESCRIPTION
## JAB-263 — FTPS sessions bypass per-tenant cgroup limits (Option 1: honest re-scope)

**Operator-approved re-scope.** The literal fix (FTPS worker PIDs under `jabali-user-<tenant>.slice`) needs a per-session cgroup-placement mechanism that is substantial and fragile, and the identical gap covers SSH/SFTP — so true placement is deferred to the FTP session-placement epic (JAB-259/260). This PR makes the resource posture **honest** and documents the real boundary.

### The gap (confirmed)
- The M18 per-tenant cgroup limits (`user.limits.apply`) live on `jabali-user-<tenant>.slice`, which binds only panel-managed **services** (php-fpm pool, python app, docker) via an explicit `Slice=`.
- A vsftpd worker forks under `vsftpd.service` and is never migrated into the tenant slice. There is **no `pam_systemd`** in the `vsftpd-jabali` PAM stack, and logind's default target is the standard `user-<uid>.slice`, not the panel's. SSH/SFTP interactive logins have the same gap.
- `ftp_account.go` carried a comment **asserting the opposite** ("Sessions also land in the tenant's slice, so M18 limits apply unchanged"). That false claim — trusting a boundary that doesn't exist — is the live harm.

### Changes (no code behavior change)
- **Correct the `ftp_account.go` comment** to state sessions are NOT in the tenant slice and FTPS is daemon-bounded.
- **ADR-0167** records the decision, the mechanism hazards (cgroups-v2 no-internal-process rule → per-session leaf scope; vsftpd can't be `systemd-run`; SSH shares the gap), the residual gap, and the deferral.
- **FTP runbook** gains a *Resource limits* section.

### What actually bounds FTPS (accurate defaults)
- `max_clients` — total concurrent FTPS connections (always on, default 50).
- `max_per_ip` — per source IP (always on, default 8).
- `local_max_rate` — per-session rate ceiling (**opt-in**: default 0 = unlimited; set `ftp_local_max_rate_kbs`).

All three render from `server_settings` and are pinned by `install/tests/test_ftp_module_optin.sh`.

### Residual (documented, not hidden)
No per-*tenant* connection cap; at the default rate each session is unthrottled; FTPS CPU/mem is not attributed to the tenant slice (usage under-counts). Disk stays bounded per-tenant (shared-uid quota).

JAB-263's literal acceptance is intentionally **not** met here; it moves to the epic.

Refs JAB-263.
