### PR TITLE
fix(auth): recovery SSO shows failure on a login that succeeds (JAB-274)

### DIFF
--- a/panel-ui/src/kratos.recovery.test.ts
+++ b/panel-ui/src/kratos.recovery.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { kratosClient, redeemRecoveryCode } from "./kratos";
+
+// JAB-274: redeemRecoveryCode must trust the SESSION, not the redemption POST's
+// HTTP status — a duplicate submit (StrictMode / prefetch / preview bot) of a
+// link whose first submit already signed the user in comes back as a followed
+// 303 → 2xx, which must NOT be reported as "invalid or already used".
+
+const blcrError = {
+  response: {
+    status: 422,
+    data: { error: { id: "browser_location_change_required" } },
+  },
+};
+
+function mockWhoami(signedIn: boolean) {
+  vi.spyOn(kratosClient, "get").mockImplementation((url: string) => {
+    if (url === "/sessions/whoami") {
+      return signedIn
+        ? Promise.resolve({ data: { id: "sess", active: true } })
+        : Promise.reject({ response: { status: 401 } });
+    }
+    return Promise.reject(new Error(`unexpected GET ${url}`));
+  });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("redeemRecoveryCode", () => {
+  it("missing flow/code → error, without touching Kratos", async () => {
+    const post = vi.spyOn(kratosClient, "post");
+    const res = await redeemRecoveryCode("", "123");
+    expect(res.kind).toBe("error");
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("fresh success (422 browser_location_change_required) → ok", async () => {
+    vi.spyOn(kratosClient, "post").mockRejectedValue(blcrError);
+    const whoami = vi.spyOn(kratosClient, "get");
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("ok");
+    // A clean blcr success needs no session probe.
+    expect(whoami).not.toHaveBeenCalled();
+  });
+
+  it("duplicate submit → followed 303 → 2xx, session exists → ok (the JAB-274 bug)", async () => {
+    vi.spyOn(kratosClient, "post").mockResolvedValue({ status: 200, data: {} });
+    mockWhoami(true);
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("ok");
+  });
+
+  it("2xx re-render but no session (genuinely rejected code) → error", async () => {
+    vi.spyOn(kratosClient, "post").mockResolvedValue({ status: 200, data: {} });
+    mockWhoami(false);
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") expect(res.message).toMatch(/invalid or has already been used/i);
+  });
+
+  it("410 → expired error (no session rescue)", async () => {
+    vi.spyOn(kratosClient, "post").mockRejectedValue({ response: { status: 410 } });
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") expect(res.message).toMatch(/expired/i);
+  });
+
+  it("400 non-blcr but session already established → ok", async () => {
+    vi.spyOn(kratosClient, "post").mockRejectedValue({ response: { status: 400, data: {} } });
+    mockWhoami(true);
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("ok");
+  });
+
+  it("400 non-blcr and no session → invalid error", async () => {
+    vi.spyOn(kratosClient, "post").mockRejectedValue({ response: { status: 400, data: {} } });
+    mockWhoami(false);
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") expect(res.message).toMatch(/invalid or has already been used/i);
+  });
+
+  it("whoami itself blips (5xx) → surface the error, don't mask as success", async () => {
+    vi.spyOn(kratosClient, "post").mockResolvedValue({ status: 200, data: {} });
+    vi.spyOn(kratosClient, "get").mockRejectedValue({ response: { status: 503 } });
+    const res = await redeemRecoveryCode("flow", "code");
+    expect(res.kind).toBe("error");
+  });
+});

--- a/panel-ui/src/kratos.ts
+++ b/panel-ui/src/kratos.ts
@@ -396,17 +396,23 @@ export async function redeemRecoveryCode(
   if (!flow || !code) {
     return { kind: "error", message: "This login link is missing its token." };
   }
+  // JAB-274: trust the SESSION, not the redemption's HTTP status. A single
+  // login link is routinely submitted more than once for the same browser —
+  // React StrictMode double-invokes the effect, and prefetch / link-preview
+  // agents can fire an extra request. The first submit sets the session (Kratos
+  // answers 422 browser_location_change_required); a second submit of the
+  // now-redeemed code, with a live session, comes back as a 303 that axios
+  // follows transparently into a 2xx. That 2xx used to be reported as
+  // "invalid or already used" even though the user was signed in. So on any
+  // non-blcr outcome we ask Kratos whether a session exists before failing.
   try {
     await kratosClient.post(
       `/self-service/recovery?flow=${encodeURIComponent(flow)}`,
       { method: "code", code },
     );
-    // A 2xx carries a re-rendered flow body, not a session — i.e. the code was
-    // rejected. Success is exclusively the 422 location-change path below.
-    return {
-      kind: "error",
-      message: "This login link is invalid or has already been used.",
-    };
+    // 2xx is ambiguous: a re-rendered flow (code rejected) OR a
+    // transparently-followed success redirect from a duplicate submit.
+    return okIfSignedIn("This login link is invalid or has already been used.");
   } catch (err) {
     const ax = err as AxiosError<{
       error?: { id?: string };
@@ -424,13 +430,26 @@ export async function redeemRecoveryCode(
       };
     }
     if (status === 400 || status === 422) {
-      return {
-        kind: "error",
-        message: "This login link is invalid or has already been used.",
-      };
+      return okIfSignedIn("This login link is invalid or has already been used.");
     }
-    return { kind: "error", message: humanizeKratosError(ax) };
+    // Network / 5xx — a prior submit may still have signed us in.
+    return okIfSignedIn(humanizeKratosError(ax));
   }
+}
+
+// okIfSignedIn resolves to success when a Kratos session already exists (a
+// prior submit of the same link established it), otherwise the supplied error.
+// JAB-274.
+async function okIfSignedIn(
+  errorMessage: string,
+): Promise<RecoveryRedeemResult> {
+  try {
+    if (await whoami()) return { kind: "ok" };
+  } catch {
+    // whoami itself failed (Kratos blip) — surface the error below rather than
+    // masking a genuine failure as success.
+  }
+  return { kind: "error", message: errorMessage };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
JAB-274, item 1 (the customer-facing bug). Item 2 (bot consumption) is a pending UX call — see below.

## Item 1 — "invalid/already used" on a login that succeeds — FIXED
The billing one-time login link (from `POST /automation/users/{id}/login-token` → Kratos admin recovery code, redeemed by the `/recovery` SPA) showed **"This login link is invalid or has already been used"** while the session was in fact established.

**Root cause — confirmed by live-capturing the deployed Kratos on jabalitests** (mint via admin socket, POST-redeem):
- Fresh code → `422 browser_location_change_required` + session cookie set (success).
- **A second submit of the now-redeemed code → `303`**, which axios follows transparently into a 2xx. `redeemRecoveryCode` treated any 2xx (and any non-blcr 4xx) as "invalid/already used".
- The link is submitted twice routinely: **React StrictMode double-invokes** the redeem effect, and prefetch/preview agents add a request.

**Fix:** on any non-blcr outcome, probe `whoami` — the *session* is the source of truth for "did login succeed". Dead link (no session) still errors; a Kratos blip during the probe surfaces the error rather than masking it. Unit matrix (8 cases) built from the captured live responses.

## Item 2 — one-time link consumable by bots — finding + decision needed
The ticket worried a bare GET could burn the link. **Live capture disproves that**: a bare `GET /self-service/recovery?flow=…&code=…` (WhatsApp UA) returns 303 and does **not** consume — the subsequent POST still succeeds. Kratos already ignores GETs.

The only consumption vector is the SPA's **auto-POST-on-mount** — a bot that fully renders the page and runs its JS would submit. Classic link-preview crawlers (WhatsApp/Slack/mail) fetch OG tags and don't execute JS, so the real-world risk is low.

Closing it fully means an **interstitial** ("Continue to sign in" → redeem on click, not on mount) — one extra click on *every* SSO login, which cuts against the feature's one-click purpose. Left out of this PR pending a call; happy to add it if wanted.

Verified: unit tests green (built from live Kratos responses); no DOM change → no E2E impact. Panel-side only, per the ticket.

JAB-274