### PR TITLE
fix(ftp): actionable error when isolated FTP hits a host without disk quota (GH #1053)

### DIFF
--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -124,6 +124,19 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	if aerr := validateIsolatedCreate(p, tenant); aerr != nil {
 		return nil, aerr
 	}
+	// Preflight the host precondition BEFORE any mutation: an isolated account
+	// gets a per-uid setquota cap, which fails on a mount that has no filesystem
+	// quota (the disk-quota module was never installed — GH #1053, altomarketing).
+	// Discovering that at the setquota step (5) would leave a half-built jail to
+	// tear down and surface as an opaque "internal"; failing fast here returns an
+	// actionable code the panel maps to "enable disk quota, or create a shared
+	// account".
+	if !quotaEnabledOn(ctx, p.QuotaMount) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: fmt.Sprintf("filesystem disk quota is not enabled on %s — isolated FTP accounts need it for their per-account disk cap. Enable the disk-quota module, or create a shared account instead.", p.QuotaMount),
+		}
+	}
 
 	jail := p.JailPath
 	mountpoint := filepath.Join(jail, ftpJailMountpoint)
@@ -224,6 +237,19 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 	}
 
 	return rollback, nil
+}
+
+// quotaEnabledOn reports whether user disk quota is active on mount. `quotaon
+// -pu` prints the current state without changing anything; a line containing
+// "is on" means user quota is active. A missing quota binary, an unsupported
+// filesystem, or "is off" all mean a per-uid setquota would fail — so isolated
+// FTP (which needs the per-account cap) cannot run there.
+func quotaEnabledOn(ctx context.Context, mount string) bool {
+	out, err := execCommandContext(ctx, "quotaon", "-pu", mount).CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "is on")
 }
 
 // isPathMounted reports whether path is currently a mount target, by scanning

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -3,10 +3,43 @@ package commands
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
 )
+
+// TestQuotaEnabledOn covers the GH #1053 isolated-create preflight: quota is
+// "on" only when `quotaon -pu` reports it; a missing binary / unsupported fs
+// (command error) or an "is off" line both mean setquota would fail.
+func TestQuotaEnabledOn(t *testing.T) {
+	orig := execCommandContext
+	t.Cleanup(func() { execCommandContext = orig })
+
+	cases := []struct {
+		name string
+		out  string
+		fail bool
+		want bool
+	}{
+		{"user quota on", "user quota on / (/dev/root) is on", false, true},
+		{"user quota off", "user quota on / is off", false, false},
+		{"command error", "", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				if tc.fail {
+					return exec.CommandContext(ctx, "false")
+				}
+				return exec.CommandContext(ctx, "echo", tc.out)
+			}
+			if got := quotaEnabledOn(context.Background(), "/"); got != tc.want {
+				t.Fatalf("quotaEnabledOn=%v want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 func testTenant() *ftpTenant {
 	return &ftpTenant{Username: "bob", UID: 1001, GID: 1001, HomeDir: "/home/bob"}

--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -151,7 +151,7 @@ func (h *ftpAccountsHandler) adminUpdate(c *gin.Context) {
 		"ftp_access":      acct.FTPAccess,
 		"enabled":         acct.IsEnabled,
 	}); err != nil {
-		status, payload := mapFtpAgentError(err, "update_failed")
+		status, payload := h.mapAgentErr(err, "update_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -175,7 +175,7 @@ func (h *ftpAccountsHandler) adminDelete(c *gin.Context) {
 		"tenant_username": ownerName,
 		"username":        acct.Username,
 	}); err != nil {
-		status, payload := mapFtpAgentError(err, "delete_failed")
+		status, payload := h.mapAgentErr(err, "delete_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -481,7 +481,7 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 	// Host first, row second: a row without a host user is a broken
 	// credential; a host user without a row is swept by the reconciler.
 	if err := h.agentCall(ctx, "ftpaccount.create", createParams); err != nil {
-		status, payload := mapFtpAgentError(err, "create_failed")
+		status, payload := h.mapAgentErr(err, "create_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -556,7 +556,7 @@ func (h *ftpAccountsHandler) update(c *gin.Context) {
 		"ftp_access":      acct.FTPAccess,
 		"enabled":         acct.IsEnabled,
 	}); err != nil {
-		status, payload := mapFtpAgentError(err, "update_failed")
+		status, payload := h.mapAgentErr(err, "update_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -601,7 +601,7 @@ func (h *ftpAccountsHandler) setPassword(c *gin.Context) {
 		// state so the agent re-locks a disabled account in the same verb.
 		"enabled": acct.IsEnabled,
 	}); err != nil {
-		status, payload := mapFtpAgentError(err, "password_reset_failed")
+		status, payload := h.mapAgentErr(err, "password_reset_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -630,7 +630,7 @@ func (h *ftpAccountsHandler) delete(c *gin.Context) {
 		"tenant_username": *u.Username,
 		"username":        acct.Username,
 	}); err != nil {
-		status, payload := mapFtpAgentError(err, "delete_failed")
+		status, payload := h.mapAgentErr(err, "delete_failed")
 		c.JSON(status, payload)
 		return
 	}
@@ -665,7 +665,30 @@ func mapFtpAgentError(err error, fallback string) (int, gin.H) {
 			return http.StatusNotFound, gin.H{"error": "not_found", "detail": ae.Message}
 		case "permission_denied":
 			return http.StatusForbidden, gin.H{"error": "forbidden", "detail": ae.Message}
+		case "failed_precondition":
+			// A host-state precondition isn't met — e.g. an isolated account
+			// needs filesystem disk quota that isn't enabled on this host
+			// (GH #1053). The agent's message is operator-actionable and safe
+			// to surface; mirror the QuotaMount=="" guard's 503
+			// isolation_unavailable so the UI treats both the same.
+			return http.StatusServiceUnavailable, gin.H{"error": "isolation_unavailable", "detail": ae.Message}
 		}
 	}
 	return http.StatusBadGateway, gin.H{"error": fallback, "detail": "host operation failed — try again or contact the administrator"}
+}
+
+// mapAgentErr logs the raw agent failure (op + code + detail) server-side so a
+// 648-class error is diagnosable from the panel log — mapFtpAgentError
+// deliberately hides host internals from the API response, which previously
+// dropped the cause entirely (GH #1053). It then maps to the client response.
+func (h *ftpAccountsHandler) mapAgentErr(err error, fallback string) (int, gin.H) {
+	if h.cfg.Log != nil {
+		var ae *agent.AgentError
+		if errors.As(err, &ae) {
+			h.cfg.Log.Warn("ftp: agent op failed", "op", fallback, "code", ae.Code, "detail", ae.Message)
+		} else {
+			h.cfg.Log.Warn("ftp: agent op failed", "op", fallback, "err", err)
+		}
+	}
+	return mapFtpAgentError(err, fallback)
 }

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -284,6 +285,26 @@ func TestFtpAPICreate_AgentFailureNoRow(t *testing.T) {
 	}
 	if len(repo.rows) != 0 {
 		t.Fatal("no row may exist after a failed host create")
+	}
+}
+
+// GH #1053: the agent preflights filesystem quota for isolated accounts and
+// returns failed_precondition when it isn't enabled. The API must surface that
+// as an actionable 503 isolation_unavailable carrying the agent's message —
+// NOT the opaque 502 "host operation failed" that hid the cause (altomarketing).
+func TestMapFtpAgentError_FailedPreconditionIsActionable(t *testing.T) {
+	status, payload := mapFtpAgentError(
+		&agent.AgentError{Code: "failed_precondition", Message: "filesystem disk quota is not enabled on /home — ..."},
+		"create_failed",
+	)
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", status)
+	}
+	if payload["error"] != "isolation_unavailable" {
+		t.Fatalf("want isolation_unavailable, got %v", payload["error"])
+	}
+	if got, _ := payload["detail"].(string); !strings.Contains(got, "quota is not enabled") {
+		t.Fatalf("agent's actionable detail must reach the client, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Fixes the report on #1053 (@altomarketing): **creating an FTP account fails with "host operation failed — try again or contact the administrator."**

## Root cause (reproduced live on jabalitests)
The UI defaults new accounts to the GH #1145 **isolated** (separate-uid jail) model, whose per-uid `setquota` fails on any host where the **disk-quota module was never installed** (no fstab `usrquota` + `quotaon`). The agent returned that as `CodeInternal`, which `mapFtpAgentError` doesn't map — so it fell to the **502 fallback that hides the detail**, and nothing logged the cause either. `QuotaMount` is wired to wherever `/home` lives regardless of whether quota actually works, so the `QuotaMount==""` guard doesn't catch it.

Captured against the deployed Kratos... er, the deployed agent:
```
setquota (isolated) "...": exit status 1:
setquota: Mountpoint (or device) /home not found or has no quota enabled.
```

## Fix (3 parts)
1. **Agent** — preflight `quotaon -pu <mount>` in the isolated branch **before any jail mutation**; when quota isn't enabled, fail fast with `CodeFailedPrecondition` + an actionable message. No half-built jail, no teardown, no burned setquota.
2. **API** — map `failed_precondition` → **503 `isolation_unavailable`** carrying the agent's message (mirrors the `QuotaMount==""` guard), and **log every ftp agent failure server-side** (op + code + detail) so a 648-class error is diagnosable — the create path logged nothing before.
3. **Tests** — `quotaEnabledOn` on/off/error; the API mapping surfaces the actionable 503 detail (cross-boundary contract).

## Live verification (jabalitests, deployed agent from this branch)
- Isolated create, no quota → `failed_precondition` + the actionable message (was opaque 648); **jail dir not created** (preflight before mutation).
- Non-isolated create still succeeds.
- Unit + vet green.

## ⚠️ Stable-promotion gate
This sits in the **held isolation bundle** (`stable` is at 74eb2b11b, isolation not yet promoted). Without it, every box lacking filesystem quota gets **broken-by-default FTP creation** with an opaque error. Land this before promoting.

Follow-up worth considering (not in this PR): a `ftp_isolation_available` capability so the UI defaults `isolated` off when quota isn't usable, instead of relying on the clear error + the user unchecking Isolated. Left out per scope.

GH #1053