### PR TITLE
feat(ftp): default Isolated off where filesystem quota is absent (GH #1171)

### DIFF
--- a/panel-agent/internal/commands/ftp_account.go
+++ b/panel-agent/internal/commands/ftp_account.go
@@ -919,4 +919,5 @@ func init() {
 	Default.Register("ftpaccount.list_all", ftpAccountListAllHandler)
 	Default.Register("ftpaccount.lock_tenant", ftpAccountLockTenantHandler)
 	Default.Register("ftpaccount.ensure_jail", ftpEnsureJailHandler)
+	Default.Register("ftpaccount.isolation_status", ftpIsolationStatusHandler)
 }

--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -252,6 +252,27 @@ func quotaEnabledOn(ctx context.Context, mount string) bool {
 	return strings.Contains(string(out), "is on")
 }
 
+// ftpIsolationStatusHandler reports whether isolated FTP accounts can be
+// provisioned on this host — i.e. filesystem disk quota is enabled on the
+// panel's quota mount (GH #1171). The panel caches this to default the UI's
+// "Isolated" toggle OFF where quota can't enforce the per-account cap, instead
+// of defaulting on and failing at create time.
+func ftpIsolationStatusHandler(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p struct {
+		QuotaMount string `json:"quota_mount"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("invalid params: %v", err),
+		}
+	}
+	return map[string]any{
+		"available":   p.QuotaMount != "" && quotaEnabledOn(ctx, p.QuotaMount),
+		"quota_mount": p.QuotaMount,
+	}, nil
+}
+
 // isPathMounted reports whether path is currently a mount target, by scanning
 // /proc/self/mountinfo (field 5 = mount point). Reliable on same-filesystem
 // bind mounts where st_dev does not change at the mountpoint — the stat-based

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -23,6 +24,12 @@ type MeHandlerConfig struct {
 	Packages       repository.PackageRepository
 	ServerSettings repository.ServerSettingsRepository
 	UIPrefs        repository.UserUIPrefRepository
+	// Agent + QuotaMount (GH #1171): probe whether isolated FTP is provisionable
+	// (filesystem disk quota enabled on the mount) so server-capabilities can
+	// tell the UI to default the "Isolated" toggle off where it can't work.
+	// Optional — nil Agent / empty QuotaMount ⇒ ftp_isolation_available=false.
+	Agent      agent.AgentInterface
+	QuotaMount string
 	// DemoEnabled mirrors cfg.Demo.Enabled. When set, server-capabilities
 	// masks the real public IPs with RFC 5737/3849 documentation-range
 	// placeholders so the public demo dashboard never exposes real infra
@@ -61,7 +68,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": "", "ftp_accounts_enabled": false, "ftp_server_enabled": false})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": "", "ftp_accounts_enabled": false, "ftp_server_enabled": false, "ftp_isolation_available": false})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -128,6 +135,11 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		// versus "FTPS + SFTP" in connection info.
 		"ftp_accounts_enabled": ftpAccounts,
 		"ftp_server_enabled":   settings.FTPEnabled,
+		// GH #1171: whether isolated (separate-uid, quota-capped) FTP accounts
+		// can actually be provisioned here (filesystem disk quota enabled). The
+		// UI defaults the "Isolated" toggle off when false. Only probed for
+		// FTP-eligible tenants so a probe never runs for users without the page.
+		"ftp_isolation_available": ftpAccounts && h.ftpIsolationAvailable(ctx),
 	})
 }
 

--- a/panel-api/internal/api/me_ftp_isolation.go
+++ b/panel-api/internal/api/me_ftp_isolation.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// ftpIsolationAvailable reports whether isolated FTP accounts can be provisioned
+// on this host — filesystem disk quota is enabled on the panel's quota mount, so
+// the per-account setquota cap can be enforced. The panel-agent does the probe
+// (root); the result is install-time-static, so a short TTL keeps
+// /me/server-capabilities cheap while still recovering within minutes if an admin
+// enables quota. GH #1171. On any uncertainty (no agent, empty mount, probe
+// error with no prior answer) it returns false so the UI defaults "Isolated" off
+// rather than defaulting on and failing at create.
+var (
+	ftpIsoMu     sync.Mutex
+	ftpIsoCached bool
+	ftpIsoKnown  bool
+	ftpIsoAt     time.Time
+)
+
+const ftpIsoTTL = 5 * time.Minute
+
+func (h *meExtHandler) ftpIsolationAvailable(ctx context.Context) bool {
+	if h.cfg.Agent == nil || h.cfg.QuotaMount == "" {
+		return false
+	}
+	ftpIsoMu.Lock()
+	defer ftpIsoMu.Unlock()
+	if ftpIsoKnown && time.Since(ftpIsoAt) < ftpIsoTTL {
+		return ftpIsoCached
+	}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(cctx, "ftpaccount.isolation_status", map[string]any{
+		"quota_mount": h.cfg.QuotaMount,
+	})
+	if err != nil {
+		if ftpIsoKnown {
+			return ftpIsoCached // keep last known on a transient probe error
+		}
+		return false
+	}
+	var resp struct {
+		Available bool `json:"available"`
+	}
+	_ = json.Unmarshal(raw, &resp)
+	ftpIsoCached, ftpIsoKnown, ftpIsoAt = resp.Available, true, time.Now()
+	return ftpIsoCached
+}

--- a/panel-api/internal/api/me_ftp_isolation_test.go
+++ b/panel-api/internal/api/me_ftp_isolation_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+)
+
+func resetFtpIsoCache() {
+	ftpIsoMu.Lock()
+	ftpIsoKnown, ftpIsoCached = false, false
+	ftpIsoMu.Unlock()
+}
+
+// GH #1171: ftpIsolationAvailable drives the UI's Isolated default. It must be
+// false whenever we can't confirm quota (no agent / empty mount), and mirror the
+// agent probe otherwise.
+func TestFtpIsolationAvailable(t *testing.T) {
+	t.Run("no agent → false (default Isolated off)", func(t *testing.T) {
+		resetFtpIsoCache()
+		h := &meExtHandler{cfg: MeHandlerConfig{QuotaMount: "/"}}
+		if h.ftpIsolationAvailable(context.Background()) {
+			t.Fatal("want false without an agent")
+		}
+	})
+	t.Run("empty QuotaMount → false, no probe", func(t *testing.T) {
+		resetFtpIsoCache()
+		mock := agent.NewMockClient().On("ftpaccount.isolation_status", map[string]any{"available": true})
+		h := &meExtHandler{cfg: MeHandlerConfig{Agent: mock, QuotaMount: ""}}
+		if h.ftpIsolationAvailable(context.Background()) {
+			t.Fatal("want false with empty mount")
+		}
+		if mockCalled(mock, "ftpaccount.isolation_status") != 0 {
+			t.Fatal("must not probe the agent when QuotaMount is empty")
+		}
+	})
+	t.Run("agent reports available → true", func(t *testing.T) {
+		resetFtpIsoCache()
+		mock := agent.NewMockClient().On("ftpaccount.isolation_status", map[string]any{"available": true, "quota_mount": "/"})
+		h := &meExtHandler{cfg: MeHandlerConfig{Agent: mock, QuotaMount: "/"}}
+		if !h.ftpIsolationAvailable(context.Background()) {
+			t.Fatal("want true when the agent reports available")
+		}
+	})
+	t.Run("agent reports unavailable → false", func(t *testing.T) {
+		resetFtpIsoCache()
+		mock := agent.NewMockClient().On("ftpaccount.isolation_status", map[string]any{"available": false, "quota_mount": "/"})
+		h := &meExtHandler{cfg: MeHandlerConfig{Agent: mock, QuotaMount: "/"}}
+		if h.ftpIsolationAvailable(context.Background()) {
+			t.Fatal("want false when the agent reports unavailable")
+		}
+	})
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -564,6 +564,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 			ServerSettings: deps.ServerSettings,
 			UIPrefs:        repository.NewUserUIPrefRepository(deps.DB),
 			DemoEnabled:    cfg.Demo.Enabled, // JAB-176: mask real IPs in demo
+			Agent:          deps.Agent,       // GH #1171: probe isolated-FTP availability
+			QuotaMount:     deps.QuotaMount,
 		})
 		// GH #256: per-user CLI default PHP version (self-service).
 		api.RegisterMePhpCliRoutes(v1, api.MePhpCliConfig{

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -33,6 +33,9 @@ export interface ServerCapabilities {
   ftp_accounts_enabled: boolean;
   /** GH #1053: server-level FTP opt-in — drives "SFTP only" vs "FTPS + SFTP" copy. */
   ftp_server_enabled: boolean;
+  /** GH #1171: isolated (separate-uid, quota-capped) FTP accounts can be provisioned
+   * here (filesystem disk quota is enabled). Drives the create form's Isolated default. */
+  ftp_isolation_available: boolean;
 }
 
 export function useServerCapabilities() {
@@ -59,6 +62,7 @@ export function useServerCapabilities() {
         dr_peer_label: data.dr_peer_label ?? "",
         ftp_accounts_enabled: !!data.ftp_accounts_enabled,
         ftp_server_enabled: !!data.ftp_server_enabled,
+        ftp_isolation_available: !!data.ftp_isolation_available,
       };
     },
     staleTime: 60_000,

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1549,6 +1549,7 @@
     "ftp_disabled_tooltip": "FTP is not enabled on this server — ask your administrator.",
     "isolated_label": "Isolated account",
     "isolated_tooltip": "Give this account its own identity confined to the chosen folder — it cannot reach the rest of your files. Recommended. Turn off only for a legacy shared-access account.",
+    "isolated_unavailable": "Isolated accounts need filesystem disk quota, which isn't enabled on this server, so new accounts are created shared. Ask your administrator to enable the disk-quota module to use isolation.",
     "isolated_tag": "Isolated",
     "shared_tag": "Shared access",
     "quota_label": "Disk quota",

--- a/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
+++ b/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
@@ -56,6 +56,10 @@ export const UserFtpAccountsPage = () => {
   const isDesktop = screens.lg ?? true;
 
   const { data: caps } = useServerCapabilities();
+  // GH #1171: isolated accounts need filesystem disk quota. Where it isn't
+  // enabled, default the toggle off (and disable it) instead of defaulting on
+  // and failing at create; keep the #1145 isolated default where it works.
+  const isoAvailable = caps?.ftp_isolation_available ?? false;
   const { data: me } = useQuery({ queryKey: ["identity"], queryFn: getIdentity });
   const username = me?.username ?? "";
 
@@ -91,7 +95,7 @@ export const UserFtpAccountsPage = () => {
       // The /home/<user> prefix is a fixed addon — users type only the
       // part inside their home. Empty = the home directory itself.
       const rel = (values.home_rel ?? "").replace(/^\/+|\/+$/g, "");
-      const isolated = values.isolated !== false; // default on
+      const isolated = isoAvailable && values.isolated !== false;
       await createFtpAccount({
         label: values.label,
         home_path: rel ? `${homePrefix}/${rel}` : homePrefix,
@@ -294,7 +298,7 @@ export const UserFtpAccountsPage = () => {
           form={form}
           layout="vertical"
           onFinish={handleCreate}
-          initialValues={{ ftp_access: false, isolated: true }}
+          initialValues={{ ftp_access: false, isolated: isoAvailable }}
         >
           <Form.Item
             label={t("ftpaccounts.label")}
@@ -340,8 +344,13 @@ export const UserFtpAccountsPage = () => {
             name="isolated"
             valuePropName="checked"
             tooltip={t("ftpaccounts.isolated_tooltip")}
+            extra={
+              !isoAvailable
+                ? t("ftpaccounts.isolated_unavailable")
+                : undefined
+            }
           >
-            <Switch />
+            <Switch disabled={!isoAvailable} />
           </Form.Item>
           <Form.Item
             noStyle

--- a/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
+++ b/panel-ui/tests/e2e/user-ftp-accounts.spec.ts
@@ -52,6 +52,10 @@ async function setupFtpMocks(
         api_enabled: true,
         ftp_accounts_enabled: opts.accountsEnabled,
         ftp_server_enabled: opts.serverEnabled,
+        // GH #1171: the Isolated toggle now defaults on only where filesystem
+        // quota is available; this suite exercises the isolated create path, so
+        // advertise it as available.
+        ftp_isolation_available: true,
       }),
     }),
   );
@@ -159,9 +163,9 @@ test("create drawer submits the tenant-prefixed body and never echoes the passwo
   const dirInput = page.getByLabel("Directory");
   await dirInput.fill("example.com/public_html");
   await page.getByLabel("Password", { exact: true }).fill("a-long-enough-password");
-  // GH #1145: the "Isolated account" toggle defaults ON, which requires a
-  // disk quota — fill it so the form submits (and to exercise the default,
-  // secure isolated create path).
+  // GH #1145/#1171: with filesystem quota available (mocked above), the
+  // "Isolated account" toggle defaults ON and requires a disk quota — fill it
+  // so the form submits (and to exercise the default, secure isolated path).
   await page.getByLabel("Disk quota").fill("500");
   await page.getByRole("button", { name: /Add account/ }).last().click();
 


### PR DESCRIPTION
Implements #1171 (follow-up to #1053 / #1170).

Isolated FTP accounts need functional filesystem disk quota. On btrfs/zfs/unsupported hosts the disk-quota module is **silently skipped** at install (best-effort), so the UI's default-on **Isolated** toggle failed at create time — #1170 made that failure *actionable*, this makes the *default* correct so FTP creation works out of the box.

## Change
- **Agent** — `ftpaccount.isolation_status` probes `quotaon -pu <mount>` (reuses #1170's `quotaEnabledOn`) → `{available}`.
- **API** — `/me/server-capabilities` exposes `ftp_isolation_available`, from a **cached** agent probe (5-min TTL; state is install-static; conservative `false` on any uncertainty — no agent, empty mount, probe error). Only probed for FTP-eligible tenants.
- **UI** — the create form defaults **Isolated** to the capability (keeps the #1145 default **ON** where quota works, **OFF** where it doesn't) and disables the toggle with an explanation when unavailable.

## Verification
- Live on jabalitests (no filesystem quota): `isolation_status` → `available:false`; non-isolated create succeeds; the API gates the probe on `QuotaMount != ""`.
- Unit tests: the probe (agent available/unavailable), the empty-mount/no-agent gate; agent `quotaEnabledOn` (from #1170). tsc + vitest green.

## ⚠️ Stacks on #1170
Branched off `gh1053-ftp-quota-preflight` (reuses `quotaEnabledOn`), so this PR currently shows both commits — **merge #1170 first**, then this rebases to just the capability commit.

GH #1053 #1171