### PR TITLE
fix(repair): Auto-Repair node_modules reinstalls instead of only wiping (GH #1173)

### DIFF
--- a/panel-api/cmd/server/repair.go
+++ b/panel-api/cmd/server/repair.go
@@ -643,9 +643,9 @@ func fixOndrejPPA(_ repairCtx) error {
 // ---------- node-modules ----------
 //
 // Symptom: `panel-ui/node_modules/.bin/tsc` is missing — npm ci reported
-// success but produced a partial install (or got interrupted). Re-running
-// `jabali update` would surface the same scar; the repair wipes node_modules
-// so the next update / build starts from a known-clean state.
+// success but produced a partial install (or got interrupted). The repair
+// reinstalls node_modules (wipe → npm ci → verify .bin/tsc) so the issue is
+// actually cleared, not just wiped (GH #1173).
 
 func detectNodeModules(ctx repairCtx) (bool, string, error) {
 	tsc := filepath.Join(ctx.repoDir, "panel-ui", "node_modules", ".bin", "tsc")
@@ -662,8 +662,11 @@ func detectNodeModules(ctx repairCtx) (bool, string, error) {
 }
 
 func fixNodeModules(ctx repairCtx) error {
-	nm := filepath.Join(ctx.repoDir, "panel-ui", "node_modules")
-	return run("", "rm", "-rf", nm)
+	// GH #1173: a bare `rm -rf node_modules` left .bin/tsc missing, so the
+	// detector re-reported BROKEN the moment repair finished. Actually reinstall
+	// via the shared resilient npm ci (wipe → npm ci → retry once → verify
+	// .bin/tsc), the same path `jabali update` uses, run as the repo owner.
+	return npmCIResilient(ctx.repoDir)
 }
 
 // ---------- daemon-reload ----------

--- a/panel-api/cmd/server/update.go
+++ b/panel-api/cmd/server/update.go
@@ -1146,25 +1146,7 @@ fi
 			//      and retry once — empirically the second attempt
 			//      lands clean. Two failures in a row points at a real
 			//      package-lock issue and we surface that.
-			err := asUser(repoDir+"/panel-ui", "bash", "-c", `set -e
-trash="node_modules.stale.$$"
-if [ -d node_modules ]; then
-  mv node_modules "$trash"
-  ( rm -rf "$trash" 2>/dev/null & )
-fi
-attempt() { npm ci --no-audit --no-fund; }
-if ! attempt; then
-  echo "[jabali] npm ci failed, wiping node_modules and retrying once..." >&2
-  rm -rf node_modules
-  sleep 2
-  attempt
-fi
-test -x node_modules/.bin/tsc || {
-  echo "[jabali] npm ci reported success but node_modules/.bin/tsc is missing — partial install" >&2
-  exit 1
-}
-`)
-			if err != nil {
+			if err := npmCIResilient(repoDir); err != nil {
 				return err
 			}
 			writeArtifactSHA("npm", want)
@@ -2093,6 +2075,57 @@ func run(dir string, name string, args ...string) error {
 		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
 	}
 	return nil
+}
+
+// asServiceUser runs a command as the jabali service user (repo owner), with the
+// same HOME/PATH/GOCACHE + low-RAM Go env `jabali update` uses. Package-level so
+// both the update path and the repair suite (GH #1173) share one impl and never
+// drift on how privilege-drop + env are set up.
+func asServiceUser(repoDir, dir, name string, args ...string) error {
+	serviceUser := os.Getenv("JABALI_SERVICE_USER")
+	if serviceUser == "" {
+		serviceUser = "jabali"
+	}
+	goRoot := os.Getenv("JABALI_GO_ROOT")
+	if goRoot == "" {
+		goRoot = defaultGoRoot
+	}
+	allArgs := []string{"-u", serviceUser, "-H", "env",
+		"HOME=" + repoDir,
+		"PATH=" + goRoot + "/bin:/usr/bin:/bin",
+		"GOCACHE=" + repoDir + "/.cache/go-build",
+		"GOMODCACHE=" + repoDir + "/.cache/go-mod",
+	}
+	allArgs = append(allArgs, lowRAMGoBuildEnv()...)
+	allArgs = append(allArgs, name)
+	allArgs = append(allArgs, args...)
+	return run(dir, "sudo", allArgs...)
+}
+
+// npmCIResilient wipes panel-ui/node_modules and runs `npm ci` as the service
+// user with the mv-stale + retry-once dance, then verifies node_modules/.bin/tsc
+// actually landed. Shared by `jabali update`'s npm-ci step and the node-modules
+// repair — a bare `rm -rf` (the old repair) left .bin/tsc missing so the detector
+// re-reported BROKEN immediately (GH #1173); this actually reinstalls.
+func npmCIResilient(repoDir string) error {
+	return asServiceUser(repoDir, repoDir+"/panel-ui", "bash", "-c", `set -e
+trash="node_modules.stale.$$"
+if [ -d node_modules ]; then
+  mv node_modules "$trash"
+  ( rm -rf "$trash" 2>/dev/null & )
+fi
+attempt() { npm ci --no-audit --no-fund; }
+if ! attempt; then
+  echo "[jabali] npm ci failed, wiping node_modules and retrying once..." >&2
+  rm -rf node_modules
+  sleep 2
+  attempt
+fi
+test -x node_modules/.bin/tsc || {
+  echo "[jabali] npm ci reported success but node_modules/.bin/tsc is missing — partial install" >&2
+  exit 1
+}
+`)
 }
 
 func appendGoPath(env []string) []string {


### PR DESCRIPTION
Fixes #1173 (@lxsdevcode): Repair Center → **Auto Repair Safe Issues** detects `panel-ui/node_modules partial (missing .bin/tsc)` but the repair "does not actually fix it — after running, .bin/tsc is still missing and the issue remains reported as broken."

## Root cause
`fixNodeModules` ran **only** `rm -rf node_modules`. So the instant repair finished, `detectNodeModules` re-checked, found `.bin/tsc` still missing (node_modules now empty), and re-reported BROKEN. The old comment assumed a *later* `jabali update` would run `npm ci` — but Auto-Repair re-detects immediately, so the user sees "detected → repaired → still broken."

## Fix
The repair now **actually reinstalls**. Extracted the resilient npm-ci that `jabali update` already uses — wipe (mv-stale + background rm) → `npm ci` → retry once on the ENOTEMPTY/partial race → **verify `node_modules/.bin/tsc` landed** — into a shared `npmCIResilient` (run as the repo-owner service user via sudo). Both `jabali update`s npm-ci step and `fixNodeModules` call it, so they never drift.

## Live verification (jabalitests)
- Removed `.bin/tsc` → `jabali repair --node-modules --yes` → `added 395 packages` → `.bin/tsc` restored (`tsc --version` → 5.9.3, owned by the jabali user).
- Re-running the repair no longer flags it (clean). build + vet green.

GH #1173