### PR TITLE
fix(security): persist FTP-account updates before touching the host (JAB-269)

### DIFF
--- a/panel-api/internal/api/ftp_accounts.go
+++ b/panel-api/internal/api/ftp_accounts.go
@@ -503,10 +503,13 @@ func (h *ftpAccountsHandler) create(c *gin.Context) {
 
 	if err := h.agentCall(ctx, "ftpaccount.create", createParams); err != nil {
 		// Compensate the reservation so a rejected host-create doesn't leave a
-		// slot-consuming row. If this delete itself fails, the surviving row is
-		// a valid desired-state account the reconciler provisions on its next
-		// pass (password-reset-required) — never a phantom cap consumer.
-		_ = h.cfg.Repo.Delete(ctx, acct.ID)
+		// slot-consuming row. Detach from request cancellation (JAB-269 sibling):
+		// a client disconnect during the agent create must not also abort the
+		// compensating delete and strand the reserved row. If this delete itself
+		// still fails, the surviving row is a valid desired-state account the
+		// reconciler provisions on its next pass (password-reset-required) —
+		// never a phantom cap consumer.
+		_ = h.cfg.Repo.Delete(context.WithoutCancel(ctx), acct.ID)
 		status, payload := h.mapAgentErr(err, "create_failed")
 		c.JSON(status, payload)
 		return
@@ -544,22 +547,41 @@ func (h *ftpAccountsHandler) update(c *gin.Context) {
 	if req.IsEnabled != nil {
 		acct.IsEnabled = *req.IsEnabled
 	}
-	if err := h.agentCall(ctx, "ftpaccount.set_access", map[string]any{
-		"tenant_username": *u.Username,
-		"username":        acct.Username,
-		"ftp_access":      acct.FTPAccess,
-		"enabled":         acct.IsEnabled,
-	}); err != nil {
-		status, payload := h.mapAgentErr(err, "update_failed")
-		c.JSON(status, payload)
-		return
-	}
+	// JAB-269: persist the desired state BEFORE touching the host, on the
+	// REQUEST context — a pre-commit cancellation aborts here having changed
+	// nothing. The row is the truth the reconciler converges to, so committing
+	// first means the host can only ever LAG the DB (more restrictive), never
+	// run ahead of it: a cancelled PATCH can no longer leave a live credential
+	// the DB reports disabled (the old host-first order did exactly that).
 	acct.UpdatedAt = time.Now().UTC()
 	if err := h.cfg.Repo.Update(ctx, acct); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
 		return
 	}
-	h.syncHostAccess(ctx, *u.Username)
+	// The host apply runs on a context DETACHED from request cancellation: once
+	// the desired state is durable, a client disconnect must not abort the host
+	// mutation half-way. agentCall still bounds it with its own timeout.
+	hostCtx := context.WithoutCancel(ctx)
+	setErr := h.agentCall(hostCtx, "ftpaccount.set_access", map[string]any{
+		"tenant_username": *u.Username,
+		"username":        acct.Username,
+		"ftp_access":      acct.FTPAccess,
+		"enabled":         acct.IsEnabled,
+	})
+	// Always re-render the sshd drop-in — for a disable, the SFTP revocation IS
+	// the Match-block removal here, rendered from the now-committed DB, so it
+	// revokes even when the unix-lock above failed (defense in depth).
+	h.syncHostAccess(hostCtx, *u.Username)
+	if setErr != nil {
+		// The DB is committed (truth); this error reports only that the
+		// immediate host apply did not complete — the reconciler converges the
+		// host to the row on its next tick. The row is deliberately NOT reverted:
+		// dropping a recorded access change on a transient agent hiccup is worse
+		// than a misleading error, and a retry is idempotent.
+		status, payload := h.mapAgentErr(setErr, "update_failed")
+		c.JSON(status, payload)
+		return
+	}
 	c.JSON(http.StatusOK, acct)
 }
 

--- a/panel-api/internal/api/ftp_accounts_test.go
+++ b/panel-api/internal/api/ftp_accounts_test.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -20,6 +22,8 @@ type fakeFtpRepo struct {
 	repository.FtpAccountRepository
 	rows      map[string]*models.FtpAccount
 	createErr error
+	updateErr error
+	onUpdate  func() // test hook fired at the start of Update (e.g. cancel the request ctx)
 	uidSeq    uint32
 }
 
@@ -104,6 +108,12 @@ func (f *fakeFtpRepo) List(_ context.Context) ([]models.FtpAccount, error) {
 }
 
 func (f *fakeFtpRepo) Update(_ context.Context, a *models.FtpAccount) error {
+	if f.onUpdate != nil {
+		f.onUpdate()
+	}
+	if f.updateErr != nil {
+		return f.updateErr
+	}
 	if r, ok := f.rows[a.ID]; ok {
 		r.FTPAccess, r.SFTPAccess, r.IsEnabled, r.HomePath = a.FTPAccess, a.SFTPAccess, a.IsEnabled, a.HomePath
 		return nil
@@ -135,6 +145,109 @@ func ftpMockAgent() *agent.MockClient {
 		On("ftpaccount.set_password", map[string]any{"updated": true}).
 		On("ftpaccount.sshd_sync", map[string]any{"changed": true}).
 		On("ssh.user.home_chown", map[string]any{})
+}
+
+// ctxAwareAgent is an AgentInterface that RESPECTS context cancellation (the
+// MockClient ignores ctx), so a test can prove the update host-apply survives
+// request cancellation. It records the commands it accepted.
+type ctxAwareAgent struct{ calls []string }
+
+func (a *ctxAwareAgent) Call(ctx context.Context, command string, _ any) (json.RawMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	a.calls = append(a.calls, command)
+	return json.RawMessage(`{}`), nil
+}
+
+func (a *ctxAwareAgent) called(cmd string) int {
+	n := 0
+	for _, c := range a.calls {
+		if c == cmd {
+			n++
+		}
+	}
+	return n
+}
+
+// JAB-269: the update handler persists the DB FIRST. A failed persist must not
+// have touched the host at all — otherwise a live host change outlives a DB
+// that never recorded it.
+func TestFtpAPIUpdate_DBErrorMakesNoHostCall(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["acc1"] = &models.FtpAccount{ID: "acc1", UserID: "u1", Username: "shop_dev", IsEnabled: false, SFTPAccess: true}
+	repo.updateErr = errors.New("db down")
+	mock := ftpMockAgent()
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPatch, "/me/ftp-accounts/acc1", `{"is_enabled":true}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 on DB failure, got %d", rec.Code)
+	}
+	for _, cmd := range []string{"ftpaccount.set_access", "ftpaccount.sshd_sync", "ssh.user.home_chown"} {
+		if mockCalled(mock, cmd) != 0 {
+			t.Fatalf("host command %s ran despite the DB write failing — not DB-first", cmd)
+		}
+	}
+}
+
+// JAB-269: when the unix-lock (set_access) fails AFTER the DB commit, the row
+// must keep its new value (a recorded revocation must never be silently
+// reverted), AND sshd_sync must still run — it renders from the now-committed
+// DB, so SFTP is revoked even when the unix-lock failed (defense in depth).
+func TestFtpAPIUpdate_HostFailureKeepsRowAndSyncs(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["acc1"] = &models.FtpAccount{ID: "acc1", UserID: "u1", Username: "shop_dev", IsEnabled: true, SFTPAccess: true}
+	mock := ftpMockAgent()
+	mock.OnError("ftpaccount.set_access", errors.New("agent boom"))
+	r := ftpTestRouter(t, repo, mock, ftpPkg(3))
+
+	rec := doReq(t, r, http.MethodPatch, "/me/ftp-accounts/acc1", `{"is_enabled":false}`)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("a host-apply failure must surface an error, got 200")
+	}
+	if repo.rows["acc1"].IsEnabled {
+		t.Fatal("row was reverted on host failure — the recorded revocation must survive (JAB-269)")
+	}
+	if mockCalled(mock, "ftpaccount.sshd_sync") != 1 {
+		t.Fatal("sshd_sync must run even when set_access fails (SFTP revocation is defense-in-depth)")
+	}
+}
+
+// JAB-269: the host apply runs on a context detached from request cancellation.
+// Simulate a client disconnect landing exactly at the DB commit; set_access must
+// still fire and the request must succeed. (With the old host-first code on the
+// request ctx, the cancelled ctx would abort the agent call.)
+func TestFtpAPIUpdate_HostApplyDetachedFromCancel(t *testing.T) {
+	repo := newFakeFtpRepo()
+	repo.rows["acc1"] = &models.FtpAccount{ID: "acc1", UserID: "u1", Username: "shop_dev", IsEnabled: false, SFTPAccess: true}
+	ag := &ctxAwareAgent{}
+
+	uname := "shop"
+	pkgID := "pkg1"
+	users := &usersMap{m: map[string]*models.User{"u1": {ID: "u1", Username: &uname, PackageID: &pkgID}}}
+	h := &ftpAccountsHandler{cfg: FtpAccountsHandlerConfig{
+		Repo: repo, Users: users, Packages: &fakePkgRepo{pkg: ftpPkg(3)}, Agent: ag, QuotaMount: "/",
+	}}
+	r := gin.New()
+	r.Use(func(c *gin.Context) { ginctx.SetClaims(c, &auth.AccessClaims{UserID: "u1"}); c.Next() })
+	r.PATCH("/me/ftp-accounts/:id", h.update)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	repo.onUpdate = cancel // fire the "client disconnect" the instant the DB commits
+
+	req := httptest.NewRequest(http.MethodPatch, "/me/ftp-accounts/acc1", strings.NewReader(`{"is_enabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("host apply must survive request cancellation, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ag.called("ftpaccount.set_access") != 1 {
+		t.Fatal("set_access must fire on the detached ctx despite the request being cancelled")
+	}
 }
 
 func ftpTestRouter(t *testing.T, repo *fakeFtpRepo, mock *agent.MockClient, pkg *models.HostingPackage) *gin.Engine {


### PR DESCRIPTION
## JAB-269 — Cancelled FTP-account updates can leave disabled credentials unlocked

The `update` handler mutated the host (`ftpaccount.set_access`) **before** persisting the row, with no compensation. A PATCH enabling a disabled account unlocked the shadow credential + re-added group access; if the request was then cancelled (client disconnect) or the DB write failed after the agent succeeded, the row update never ran — the DB reported the account **disabled** while FTPS/SFTP auth **worked**, until the reconciler healed the drift. An attacker could open a session in that window that survives the repair.

### Fix — DB-first (the ticket's own remediation option 1)
- **`Repo.Update` runs first, on the request ctx** — a pre-commit cancellation aborts having changed nothing. The row is the truth the reconciler converges to, so committing first means the host can only ever **lag** the DB (more restrictive), never run ahead of it. A cancelled PATCH can no longer leave a live credential the DB reports disabled.
- **Host apply on `context.WithoutCancel(ctx)`** — once desired state is durable, a client disconnect must not abort the host mutation half-way (agentCall still bounds it with its own timeout).
- **`syncHostAccess` always runs, even when `set_access` fails** — for a disable, the SFTP revocation is the sshd Match-block removal, rendered from the now-committed (disabled) DB, so it revokes even if the unix-lock errored (defense in depth).
- **The row is NOT reverted on host-apply error** — dropping a recorded access change on a transient agent hiccup is worse than a misleading error; a retry is idempotent; the reconciler converges the host.

### Bonus — create-path compensation detached
`h.cfg.Repo.Delete(context.WithoutCancel(ctx), acct.ID)` (JAB-262/255 sibling): a client disconnect during the agent create no longer aborts the compensating delete and strands the reserved row.

### Residual (stated, not built)
Concurrent PATCHes can still land detached applies out of DB-commit order — pre-existing under host-first, reconciler-healed, and now additionally bounded by the per-actor rate limit (JAB-266). The ticket's per-account-serialization clause attaches to the compensation approach (option 2), which this doesn't use.

### Tests
- DB-error → 500 with **zero** host calls (proves DB-first).
- `set_access` failure → error response, row **retains** the new value (no revert), `sshd_sync` still ran once.
- Request cancelled exactly at DB commit → `set_access` still fires + 200 (proves the detached context), via a context-respecting agent stub (the `MockClient` ignores ctx).
- `go build`/`vet`/`gofmt` clean; full `internal/api` + `internal/repository` green.

Refs JAB-269.
