### PR TITLE
fix(security): fail-closed FTP disable + continuous convergence (JAB-259, epic phase A)

### DIFF
--- a/install/tests/test_ftp_module_optin.sh
+++ b/install/tests/test_ftp_module_optin.sh
@@ -147,6 +147,24 @@ if ! grep -qE '^require_ssl_reuse=YES' <<<"$cfgfn"; then
   fail=1
 fi
 
+# --- 7. fail-closed disable verb (JAB-259) must match install.sh's ufw rules ---
+# The Go ftp.disable verb removes the SAME rules install.sh opens/closes. A
+# drift between its hardcoded range and the vsftpd pasv range would leave a rule
+# un-removed on disable (residual exposure). Cross-language coupling, so pin it
+# here rather than trust the "MUST match install.sh" comment.
+verbfile="panel-agent/internal/commands/ftp_module_disable.go"
+if [[ ! -f "$verbfile" ]]; then
+  echo "FAIL: $verbfile missing (JAB-259 fail-closed disable verb)"
+  fail=1
+elif [[ -n "$pasv_min" && -n "$pasv_max" ]]; then
+  grep -q 'Default.Register("ftp.disable"' "$verbfile" \
+    || { echo "FAIL: ftp.disable verb not registered"; fail=1; }
+  grep -q "${pasv_min}:${pasv_max}/tcp" "$verbfile" \
+    || { echo "FAIL: ftp.disable passive range must match vsftpd ${pasv_min}:${pasv_max}"; fail=1; }
+  grep -q '"21/tcp"' "$verbfile" \
+    || { echo "FAIL: ftp.disable must remove the 21/tcp control-port rule"; fail=1; }
+fi
+
 if [[ "$fail" -eq 0 ]]; then
   echo "OK: ftp module opt-in guards hold"
 else

--- a/panel-agent/internal/commands/ftp_module_disable.go
+++ b/panel-agent/internal/commands/ftp_module_disable.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// ftp.disable — FAIL-CLOSED FTP module shutoff (JAB-259).
+//
+// The generic system.module.disable is deliberately fail-soft (a stubborn unit
+// must not strand the others already stopped) and never masks the daemon or
+// closes its firewall rules — correct for dns/mail/quota/security, wrong for a
+// security shutoff. FTP gets this dedicated verb: stop -> mask -> remove the UFW
+// rules -> VERIFY the daemon is inactive and masked, returning a typed
+// failed_precondition when it is not, so the control plane can never report FTP
+// "off" while vsftpd is still able to accept connections.
+//
+// Idempotent and safe to re-run every reconcile tick (the reconciler's
+// convergeFtpDisabled path calls this until it succeeds).
+const (
+	ftpDisableUnit = "vsftpd"
+	// ftpPasvRangeRule + ftpControlPortRule MUST match the rules install.sh
+	// opens in install_ftp_firewall_rules and closes in converge_ftp_masking.
+	ftpControlPortRule = "21/tcp"
+	ftpPasvRangeRule   = "40000:40100/tcp"
+)
+
+type ftpDisableResponse struct {
+	Active    bool `json:"active"`
+	Masked    bool `json:"masked"`
+	PortsOpen bool `json:"ports_open"`
+}
+
+func ftpModuleDisableHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	present := unitExists(ctx, ftpDisableUnit)
+	if present {
+		// Mask (not just disable): a masked unit cannot be started by a
+		// dependency or a stray reconciler install — stronger than the generic
+		// verb's `disable --now`.
+		_, _ = execCommandContext(ctx, "systemctl", "stop", ftpDisableUnit).CombinedOutput()
+		_, _ = execCommandContext(ctx, "systemctl", "mask", ftpDisableUnit).CombinedOutput()
+	}
+	// Remove the firewall rules (best-effort; ufw may be absent/inactive). The
+	// deletes are idempotent — `ufw delete` on a missing rule is a no-op.
+	_, _ = execCommandContext(ctx, "ufw", "delete", "allow", ftpControlPortRule).CombinedOutput()
+	_, _ = execCommandContext(ctx, "ufw", "delete", "allow", ftpPasvRangeRule).CombinedOutput()
+
+	resp := ftpDisableResponse{
+		Active:    ftpUnitActive(ctx, ftpDisableUnit),
+		Masked:    ftpUnitMasked(ctx, ftpDisableUnit),
+		PortsOpen: ftpControlPortOpen(ctx),
+	}
+
+	// The security invariant is "vsftpd cannot accept connections", guaranteed
+	// by inactive AND masked (a masked+dead daemon behind a stray ufw rule is
+	// not reachable). Fail closed on either; report ports_open for Phase C to
+	// surface a lingering rule but don't hot-loop the reconciler on a cosmetic
+	// ufw quirk when the daemon is already dead.
+	if resp.Active || (present && !resp.Masked) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeFailedPrecondition,
+			Message: fmt.Sprintf("ftp still exposed after disable: active=%v masked=%v ports_open=%v", resp.Active, resp.Masked, resp.PortsOpen),
+		}
+	}
+	return resp, nil
+}
+
+// ftpUnitActive reports whether the unit is currently running.
+func ftpUnitActive(ctx context.Context, unit string) bool {
+	out, _ := execCommandContext(ctx, "systemctl", "is-active", unit).CombinedOutput()
+	return strings.TrimSpace(string(out)) == "active"
+}
+
+// ftpUnitMasked reports whether the unit is masked. `systemctl is-enabled`
+// prints "masked" (with a non-zero exit) for a masked unit.
+func ftpUnitMasked(ctx context.Context, unit string) bool {
+	out, _ := execCommandContext(ctx, "systemctl", "is-enabled", unit).CombinedOutput()
+	return strings.TrimSpace(string(out)) == "masked"
+}
+
+// ftpControlPortOpen reports whether ufw still allows the FTP control port.
+// A missing/inactive ufw (error) means nothing we manage is open.
+func ftpControlPortOpen(ctx context.Context) bool {
+	out, err := execCommandContext(ctx, "ufw", "status").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == ftpControlPortRule && strings.EqualFold(fields[1], "ALLOW") {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	Default.Register("ftp.disable", ftpModuleDisableHandler)
+}

--- a/panel-agent/internal/commands/ftp_module_disable_test.go
+++ b/panel-agent/internal/commands/ftp_module_disable_test.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// stubSystemctlUfw scripts execCommandContext so ftp.disable sees deterministic
+// systemctl/ufw output. The verb is all reads-after-writes, so only the query
+// commands (is-active / is-enabled / show / ufw status) need real output; the
+// mutating stop/mask/delete just exit 0.
+func stubSystemctlUfw(t *testing.T, isActive, isEnabled, loadState, ufwStatus string) {
+	t.Helper()
+	prev := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		out := ""
+		switch {
+		case name == "systemctl" && len(args) >= 1 && args[0] == "is-active":
+			out = isActive
+		case name == "systemctl" && len(args) >= 1 && args[0] == "is-enabled":
+			out = isEnabled
+		case name == "systemctl" && len(args) >= 1 && args[0] == "show":
+			out = loadState
+		case name == "ufw" && len(args) >= 1 && args[0] == "status":
+			out = ufwStatus
+		}
+		return exec.CommandContext(ctx, "/bin/sh", "-c", fmt.Sprintf("printf %%s '%s'; exit 0", out))
+	}
+	t.Cleanup(func() { execCommandContext = prev })
+}
+
+func TestFtpDisable_SucceedsWhenInactiveAndMasked(t *testing.T) {
+	stubSystemctlUfw(t, "inactive", "masked", "loaded", "Status: inactive")
+	res, err := ftpModuleDisableHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	r := res.(ftpDisableResponse)
+	if r.Active || !r.Masked {
+		t.Fatalf("want inactive+masked, got %+v", r)
+	}
+}
+
+func TestFtpDisable_FailsClosedWhenStillActive(t *testing.T) {
+	// The daemon refused to stop — the verb MUST report a typed failure so the
+	// panel never shows FTP "off" while it is still reachable, and the
+	// reconciler keeps retrying.
+	stubSystemctlUfw(t, "active", "masked", "loaded", "")
+	_, err := ftpModuleDisableHandler(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected failed_precondition while vsftpd is still active")
+	}
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeFailedPrecondition {
+		t.Fatalf("want failed_precondition, got %v", err)
+	}
+}
+
+func TestFtpDisable_FailsClosedWhenNotMasked(t *testing.T) {
+	// Stopped but NOT masked: a dependency or a stray reconciler install could
+	// restart it, so this is not a safe "off" state.
+	stubSystemctlUfw(t, "inactive", "enabled", "loaded", "")
+	_, err := ftpModuleDisableHandler(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected failed_precondition while vsftpd is stopped but unmasked")
+	}
+}
+
+// A never-installed vsftpd (unit not-found) is already "off" — the verb must
+// succeed, not fail on the absent unit's empty is-active/is-enabled output.
+func TestFtpDisable_NeverInstalledSucceeds(t *testing.T) {
+	stubSystemctlUfw(t, "", "", "not-found", "")
+	if _, err := ftpModuleDisableHandler(context.Background(), nil); err != nil {
+		t.Fatalf("a never-installed vsftpd must succeed (nothing to disable), got %v", err)
+	}
+}
+
+// A lingering ufw rule alone (daemon inactive+masked = not reachable) is
+// reported but does NOT fail the op — that would hot-loop the reconciler on a
+// cosmetic rule when nothing is actually exposed.
+func TestFtpDisable_LingeringUfwRuleDoesNotFail(t *testing.T) {
+	stubSystemctlUfw(t, "inactive", "masked", "loaded", "21/tcp ALLOW Anywhere")
+	res, err := ftpModuleDisableHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("masked+inactive daemon must succeed despite a stray ufw rule, got %v", err)
+	}
+	if !res.(ftpDisableResponse).PortsOpen {
+		t.Fatal("ports_open must be reported so Phase C can surface the stray rule")
+	}
+}

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -153,14 +153,14 @@ type updateServerSettingsRequest struct {
 	// GH #1053: FTP module opt-in (default OFF). ftp_allow_plaintext is a
 	// second explicit gate — TLS stays required without it. ftp_pasv_address
 	// is the NAT passive-mode address vsftpd advertises.
-	FTPEnabled                 *bool   `json:"ftp_enabled,omitempty"`
-	FTPAllowPlaintext          *bool   `json:"ftp_allow_plaintext,omitempty"`
-	FTPPasvAddress             *string `json:"ftp_pasv_address,omitempty"`
+	FTPEnabled        *bool   `json:"ftp_enabled,omitempty"`
+	FTPAllowPlaintext *bool   `json:"ftp_allow_plaintext,omitempty"`
+	FTPPasvAddress    *string `json:"ftp_pasv_address,omitempty"`
 	// vsftpd tuning; 0 = unlimited. Bounded at the API so a typo can't
 	// render a nonsensical config.
-	FTPMaxClients      *uint32 `json:"ftp_max_clients,omitempty"`
-	FTPMaxPerIP        *uint32 `json:"ftp_max_per_ip,omitempty"`
-	FTPLocalMaxRateKBs *uint32 `json:"ftp_local_max_rate_kbs,omitempty"`
+	FTPMaxClients              *uint32 `json:"ftp_max_clients,omitempty"`
+	FTPMaxPerIP                *uint32 `json:"ftp_max_per_ip,omitempty"`
+	FTPLocalMaxRateKBs         *uint32 `json:"ftp_local_max_rate_kbs,omitempty"`
 	TenantDomainOptionsEnabled *bool   `json:"tenant_domain_options_enabled,omitempty"`
 	TenantDocrootEditable      *bool   `json:"tenant_docroot_editable,omitempty"`
 	// GH #860: opt-in branded page on the default catch-all for unknown
@@ -830,10 +830,15 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	// doesn't block on apt. Wired only for modules install.sh supports at runtime
 	// today. On flip false→true install the module; on flip true→false stop +
 	// disable its services (system.module.disable — data preserved, guardrails
-	// like ufw/pdns-recursor left running). Transition-dispatch only: there is
-	// deliberately NO auto disable-convergence (stopping a "disabled" service
-	// every tick would fight an operator troubleshooting a manual start, and is
-	// destructive when a status read is wrong — unlike install-convergence).
+	// like ufw/pdns-recursor left running). Transition-dispatch only, with ONE
+	// exception: for most modules there is deliberately NO auto
+	// disable-convergence (stopping a "disabled" service every tick would fight
+	// an operator troubleshooting a manual start, and is destructive when a
+	// status read is wrong — unlike install-convergence). FTP is the exception
+	// (JAB-259): it is a security shutoff, so it takes the fail-closed ftp.disable
+	// verb here AND is reconciled toward inactive+masked+ports-closed every tick
+	// (convergeFtpDisabled) — a disabled FTP that stays reachable is a security
+	// hole, not a troubleshooting convenience.
 	if h.cfg.Agent != nil {
 		for _, m := range []struct {
 			key           string
@@ -849,7 +854,13 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 			case m.current && !m.prev:
 				h.dispatchModuleInstall(m.key)
 			case !m.current && m.prev:
-				h.dispatchModuleDisable(m.key)
+				if m.key == "ftp" {
+					// JAB-259: fail-closed shutoff (stop+mask+close ports+verify),
+					// not the generic fail-soft disable.
+					h.dispatchFtpDisable()
+				} else {
+					h.dispatchModuleDisable(m.key)
+				}
 			}
 		}
 		// GH #1053: vsftpd.conf is rendered from ftp_allow_plaintext +
@@ -1429,6 +1440,21 @@ func (h *serverSettingsHandler) dispatchModuleDisable(key string) {
 		defer cancel()
 		if _, err := h.cfg.Agent.Call(bgCtx, "system.module.disable", map[string]any{"key": key}); err != nil {
 			h.cfg.Log.Error("agent module disable failed", "key", key, "err", err)
+		}
+	}()
+}
+
+// dispatchFtpDisable runs the FAIL-CLOSED FTP shutoff (JAB-259) instead of the
+// generic fail-soft system.module.disable: stop + mask vsftpd, remove its UFW
+// rules, and verify inactive+masked. Async like the other module dispatches —
+// the reconciler's convergeFtpDisabled retries until the daemon is confirmed
+// down and the ports are closed, so a failure here is logged, never lost.
+func (h *serverSettingsHandler) dispatchFtpDisable() {
+	go func() {
+		bgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if _, err := h.cfg.Agent.Call(bgCtx, "ftp.disable", map[string]any{}); err != nil {
+			h.cfg.Log.Error("ftp fail-closed disable failed (reconciler will retry)", "err", err)
 		}
 	}()
 }

--- a/panel-api/internal/reconciler/reconcile_modules.go
+++ b/panel-api/internal/reconciler/reconcile_modules.go
@@ -61,11 +61,49 @@ func (r *Reconciler) reconcileModuleInstalls(ctx context.Context) {
 	}
 	flags := moduleFlags{dns: srv.DNSEnabled, mail: srv.MailEnabled, quota: srv.QuotaEnabled, security: srv.SecurityEnabled, ftp: srv.FTPEnabled}
 	for _, m := range convergedModules {
-		if !m.enabled(flags) {
+		if m.enabled(flags) {
+			r.convergeModule(ctx, m.key, m.dependsOn)
 			continue
 		}
-		r.convergeModule(ctx, m.key, m.dependsOn)
+		// A DISABLED module is normally left alone. FTP is the exception
+		// (JAB-259): it is a security shutoff, so an incomplete disable —
+		// vsftpd still active or unmasked, ports still open — must be converged
+		// FAIL-CLOSED here rather than skipped and left exposed until the next
+		// full `jabali update`. Every other disabled module stays a no-op.
+		if m.key == "ftp" {
+			r.convergeFtpDisabled(ctx)
+		}
 	}
+}
+
+// convergeFtpDisabled drives FTP toward fail-closed (vsftpd inactive + masked,
+// UFW rules removed) when ftp_enabled=false (JAB-259). The dedicated ftp.disable
+// verb returns a typed failure while any residual exposure remains; a failure is
+// retried on the next eligible tick under the same backoff as install
+// convergence (a distinct "ftp-disable" key), so a stubborn systemctl/ufw
+// failure keeps converging without hot-looping every tick.
+func (r *Reconciler) convergeFtpDisabled(ctx context.Context) {
+	if !r.moduleInstallDue("ftp-disable") {
+		return
+	}
+	go func() {
+		dctx, dcancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer dcancel()
+		// Re-read the flag inside the goroutine: an operator may have re-enabled
+		// FTP after this pass was scheduled. Masking a just-re-enabled vsftpd
+		// would fight install-convergence and ping-pong under toggle churn, so a
+		// stale disable must stand down. (nil serverSettings only in unit tests.)
+		if r.serverSettings != nil {
+			if srv, err := r.serverSettings.Get(dctx); err == nil && srv != nil && srv.FTPEnabled {
+				return
+			}
+		}
+		if _, err := r.agent.Call(dctx, "ftp.disable", map[string]any{}); err != nil {
+			r.log.Error("ftp fail-closed disable did not fully converge (will retry)", "err", err)
+			return
+		}
+		r.log.Info("ftp disabled: vsftpd inactive+masked, ports closed")
+	}()
 }
 
 // convergeModule probes one module's status and, if it isn't fully up, kicks a

--- a/panel-api/internal/reconciler/reconcile_modules_test.go
+++ b/panel-api/internal/reconciler/reconcile_modules_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
 // moduleStubAgent returns a canned system.module.status per key and records
@@ -16,9 +18,15 @@ import (
 type moduleStubAgent struct {
 	status       map[string]map[string]any
 	installCalls int
+
+	mu      sync.Mutex
+	methods []string // every method seen (guarded; detached dispatch races the test)
 }
 
 func (m *moduleStubAgent) Call(_ context.Context, method string, params any) (json.RawMessage, error) {
+	m.mu.Lock()
+	m.methods = append(m.methods, method)
+	m.mu.Unlock()
 	key := ""
 	if mp, ok := params.(map[string]any); ok {
 		key, _ = mp["key"].(string)
@@ -36,6 +44,18 @@ func (m *moduleStubAgent) Call(_ context.Context, method string, params any) (js
 	default:
 		return nil, nil
 	}
+}
+
+func (m *moduleStubAgent) methodCount(name string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, x := range m.methods {
+		if x == name {
+			n++
+		}
+	}
+	return n
 }
 
 var _ agent.AgentInterface = (*moduleStubAgent)(nil)
@@ -107,6 +127,59 @@ func TestConvergeModuleDependency(t *testing.T) {
 	r2.moduleInstallMu.Unlock()
 	if !dispatched {
 		t.Error("mail with satisfied dns dependency (mail down) must dispatch")
+	}
+}
+
+// JAB-259: a DISABLED ftp module must be converged fail-closed — convergeFtpDisabled
+// dispatches ftp.disable and records its own "ftp-disable" backoff so a stubborn
+// failure retries without hot-looping every tick.
+func TestConvergeFtpDisabled_DispatchesFtpDisableWithBackoff(t *testing.T) {
+	ag := &moduleStubAgent{status: map[string]map[string]any{}}
+	r := discardReconciler(ag)
+
+	r.convergeFtpDisabled(context.Background())
+
+	// Synchronous decision record (house pattern — avoids the detached goroutine).
+	r.moduleInstallMu.Lock()
+	_, recorded := r.moduleInstallAttempt["ftp-disable"]
+	r.moduleInstallMu.Unlock()
+	if !recorded {
+		t.Fatal("convergeFtpDisabled must record an ftp-disable backoff attempt")
+	}
+	// A second immediate pass is gated by that backoff.
+	if r.moduleInstallDue("ftp-disable") {
+		t.Fatal("second immediate convergeFtpDisabled must be gated by backoff")
+	}
+
+	// The dispatched verb is ftp.disable (the fail-closed shutoff), not the
+	// generic system.module.disable. Poll — the dispatch is detached.
+	deadline := time.Now().Add(2 * time.Second)
+	for ag.methodCount("ftp.disable") == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if ag.methodCount("ftp.disable") != 1 {
+		t.Fatalf("want exactly one ftp.disable dispatch, got %d", ag.methodCount("ftp.disable"))
+	}
+	if ag.methodCount("system.module.disable") != 0 {
+		t.Fatal("must NOT use the generic fail-soft system.module.disable for ftp")
+	}
+}
+
+// JAB-259: a stale disable must stand down if FTP was re-enabled after the pass
+// was scheduled. convergeFtpDisabled re-reads ftp_enabled inside the goroutine
+// and must NOT dispatch ftp.disable when it now reads enabled — masking a
+// just-re-enabled vsftpd would ping-pong against install-convergence.
+func TestConvergeFtpDisabled_SkipsWhenReEnabled(t *testing.T) {
+	ag := &moduleStubAgent{status: map[string]map[string]any{}}
+	r := discardReconciler(ag)
+	r.serverSettings = &fakeSettingsRepo{srv: &models.ServerSettings{FTPEnabled: true}}
+
+	r.convergeFtpDisabled(context.Background())
+
+	// Let the detached goroutine run its re-read + decision; it must not dispatch.
+	time.Sleep(200 * time.Millisecond)
+	if ag.methodCount("ftp.disable") != 0 {
+		t.Fatal("ftp.disable dispatched despite FTP being re-enabled (stale-disable ping-pong)")
 	}
 }
 


### PR DESCRIPTION
## JAB-259 — Disabling FTP can fail open (Phase A of the FTP-reconciled-resource epic)

Turning FTP off could leave vsftpd Internet-reachable while the panel showed "off". The toggle dispatched the generic `system.module.disable`, which is deliberately **fail-soft** (a stubborn unit must not strand the others) and never **masks** vsftpd or removes its **UFW** rules — masking + firewall teardown lived only in `install.sh converge_ftp_masking`, run on a full `jabali update`, not the toggle. The handler also returned success even when the service was still active, the API ignored that, and the reconciler **skips disabled modules**. A failed/interrupted disable → vsftpd stays up with working credentials.

This is **Phase A** of `plans/gh1053-ftp-reconciled-resource-epic.md` (the scoped epic).

### Changes
- **New agent verb `ftp.disable`**: stop → mask → remove UFW rules (`21/tcp` + `40000:40100/tcp`) → **verify inactive AND masked**, returning a typed `failed_precondition` when it isn't. The security invariant is "vsftpd cannot accept connections" = inactive+masked; a lingering ufw rule behind a dead+masked daemon is *reported* (`ports_open`, for the Phase C UI) but doesn't hot-loop the reconciler. Idempotent. Kept **separate** from `system.module.disable`, which stays fail-soft for dns/mail/quota/security.
- **Reconciler 3-way branch**: ftp `enabled → convergeModule` (unchanged), `disabled → convergeFtpDisabled`, others unchanged. `convergeFtpDisabled` dispatches `ftp.disable` under its own `ftp-disable` backoff so a stubborn failure keeps converging without hot-looping. This is the **documented exception** to the "no disable-convergence" rule (a disabled FTP that stays reachable is a security hole, not a troubleshooting convenience).
- **Stale-disable stand-down**: `convergeFtpDisabled` re-reads `ftp_enabled` *inside* its goroutine — an operator re-enabling FTP after a pass was scheduled must not have a slow in-flight `ftp.disable` mask the just-re-enabled daemon (ping-pong). Re-enable is handled by the existing `convergeModule` → `system.module.install` → `install.sh --install-module ftp` → **unmask + restore UFW + start**, so on→off→on is coherent.
- **Settings dispatch**: the ftp true→false transition calls `ftp.disable`, not the generic verb.
- **Drift guard**: `test_ftp_module_optin.sh` now grep-asserts the Go verb's passive range matches the vsftpd pasv range (Go/bash can't share a literal).

### Acceptance (JAB-259)
- ✅ Disable reports failure unless vsftpd is inactive+masked (typed `failed_precondition`).
- ✅ UFW 21/tcp + passive rules removed in the same transition.
- ✅ Disabled state reconciled continuously (`convergeFtpDisabled`, backoff).
- ⏳ UI/API desired-vs-observed → **Phase C** (this PR reports `ports_open`/`active`/`masked` in the verb response for C to consume).
- ✅ Tests inject systemctl/ufw failures and prove the op stays failed + retries.

### Tests
Agent: succeeds only when inactive+masked; fails closed while active or unmasked; tolerates a stray ufw rule on a dead daemon; never-installed succeeds. Reconciler (`-race`): dispatches `ftp.disable` (not the generic verb) under the `ftp-disable` backoff; stands down when re-enabled. Full panel-agent commands + panel-api api/reconciler green; exec-seam guard holds; shell drift guard passes.

### Live (jabalitests — real systemctl/ufw mask/unmask semantics)
The **on→off→on cycle** is the scenario unit tests can't touch: toggle off → confirm `systemctl is-active vsftpd`=inactive + masked + `ufw status` has no 21/tcp → toggle on → confirm unmasked + active + rules restored → a failed disable (e.g. simulated) keeps retrying until masked.

Deferred: JAB-260 (config fingerprint + fail-closed tighten) = Phase B; observed-vs-desired UI = Phase C; JAB-263 cgroup = Phase D.

Refs JAB-259.
