### PR TITLE
fix(security): reconcile FTP TLS posture + fail-closed plaintext tighten (JAB-260, epic phase B)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -844,6 +844,17 @@ install_vsftpd_config() {
     # fail loudly — silently serving passwordful cleartext FTP because a
     # cert file was missing is exactly the downgrade we never ship.
     if [[ "$force_ssl" == "YES" ]]; then
+      # Fail closed (JAB-260): if vsftpd is CURRENTLY serving, an operator just
+      # tightened plaintext->TLS but no cert exists yet — stop + mask it rather
+      # than leave the old plaintext config running and accepting cleartext
+      # credentials. Self-healing: ftp_enabled is still on, so the reconciler's
+      # convergeModule re-runs this install once the panel cert lands -> the
+      # cert check passes, vsftpd is unmasked and started with TLS. A fresh
+      # (inactive) install has nothing serving, so it just dies here as before.
+      if systemctl is-active --quiet vsftpd 2>/dev/null; then
+        systemctl stop vsftpd >/dev/null 2>&1 || true
+        systemctl mask vsftpd >/dev/null 2>&1 || true
+      fi
       _die "ftp module: TLS is required but $tls_cert is missing — run the panel-cert step first or (explicitly) allow plaintext"
     fi
     ssl_enable="NO"

--- a/install/tests/test_ftp_module_optin.sh
+++ b/install/tests/test_ftp_module_optin.sh
@@ -67,6 +67,13 @@ else
   # The no-cert + TLS-required combination must abort, not downgrade.
   grep -q '_die "ftp module: TLS is required' <<<"$cfgfn" \
     || { echo "FAIL: missing cert with TLS required must _die, never downgrade"; fail=1; }
+  # JAB-260 fail-closed tighten: a currently-active vsftpd (a failed
+  # plaintext->TLS tighten with no cert yet) must be stopped + masked, not left
+  # serving cleartext — guarded by is-active so a fresh install still just dies.
+  grep -qE 'is-active --quiet vsftpd' <<<"$cfgfn" \
+    || { echo "FAIL: no-cert TLS-required branch must guard the fail-closed stop+mask on is-active (JAB-260)"; fail=1; }
+  grep -qE 'systemctl mask vsftpd' <<<"$cfgfn" \
+    || { echo "FAIL: no-cert TLS-required branch must mask vsftpd to fail closed (JAB-260)"; fail=1; }
 fi
 
 # --- 4. PAM: jabali-ftp gate, no pam_shells ---

--- a/panel-agent/internal/commands/ftp_config_status.go
+++ b/panel-agent/internal/commands/ftp_config_status.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// ftp.config_status — report the SECURITY-relevant applied FTP config by parsing
+// the LIVE /etc/vsftpd.conf (JAB-260). Reading the running config observes what
+// is ACTUALLY applied, not what install.sh claims it applied — a crash between
+// the config write and any "applied" marker can't produce a false-converged
+// read here. The reconciler compares SSLEnforced against the desired
+// ftp_allow_plaintext (equality, both drift directions) and re-renders on drift.
+const vsftpdConfDefault = "/etc/vsftpd.conf"
+
+func getVsftpdConfPath() string {
+	if p := os.Getenv("JABALI_VSFTPD_CONF_PATH"); p != "" {
+		return p
+	}
+	return vsftpdConfDefault
+}
+
+type ftpConfigStatusResponse struct {
+	// Exists is false when no vsftpd.conf is present (never installed).
+	Exists bool `json:"exists"`
+	// SSLEnforced is true only when TLS is on AND both control + data channels
+	// require it — the render install.sh produces for ftp_allow_plaintext=0.
+	SSLEnforced bool `json:"ssl_enforced"`
+}
+
+func ftpConfigStatusHandler(_ context.Context, _ json.RawMessage) (any, error) {
+	data, err := os.ReadFile(getVsftpdConfPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ftpConfigStatusResponse{Exists: false}, nil
+		}
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "read vsftpd.conf: " + err.Error()}
+	}
+	kv := parseVsftpdConf(string(data))
+	// Absent directives read as "" — the legitimate ssl_enable=NO render (no TLS
+	// block at all) correctly reports SSLEnforced=false, which equals the
+	// plaintext-desired state, so it is NOT flagged as drift.
+	return ftpConfigStatusResponse{
+		Exists: true,
+		SSLEnforced: kv["ssl_enable"] == "YES" &&
+			kv["force_local_logins_ssl"] == "YES" &&
+			kv["force_local_data_ssl"] == "YES",
+	}, nil
+}
+
+// parseVsftpdConf maps the `key=value` directives, skipping comments/blanks.
+// Last value wins (vsftpd's own semantics).
+func parseVsftpdConf(s string) map[string]string {
+	kv := map[string]string{}
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		kv[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return kv
+}
+
+func init() {
+	Default.Register("ftp.config_status", ftpConfigStatusHandler)
+}

--- a/panel-agent/internal/commands/ftp_config_status_test.go
+++ b/panel-agent/internal/commands/ftp_config_status_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConf(t *testing.T, body string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "vsftpd.conf")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("JABALI_VSFTPD_CONF_PATH", p)
+}
+
+func configStatus(t *testing.T) ftpConfigStatusResponse {
+	t.Helper()
+	res, err := ftpConfigStatusHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("config_status: %v", err)
+	}
+	return res.(ftpConfigStatusResponse)
+}
+
+func TestFtpConfigStatus_TLSEnforced(t *testing.T) {
+	writeConf(t, `# managed
+listen=YES
+ssl_enable=YES
+force_local_logins_ssl=YES
+force_local_data_ssl=YES
+`)
+	st := configStatus(t)
+	if !st.Exists || !st.SSLEnforced {
+		t.Fatalf("want exists+enforced, got %+v", st)
+	}
+}
+
+func TestFtpConfigStatus_PlaintextSslDisabled(t *testing.T) {
+	// The legitimate plaintext render: ssl_enable=NO, no force_local_* block.
+	writeConf(t, `listen=YES
+ssl_enable=NO
+`)
+	if configStatus(t).SSLEnforced {
+		t.Fatal("ssl_enable=NO must report SSLEnforced=false, not drift")
+	}
+}
+
+func TestFtpConfigStatus_TLSOnButNotForced(t *testing.T) {
+	// TLS available but not required on both channels → NOT enforced (a stale
+	// pre-tighten config an on-path attacker can still downgrade).
+	writeConf(t, `ssl_enable=YES
+force_local_logins_ssl=NO
+force_local_data_ssl=NO
+`)
+	if configStatus(t).SSLEnforced {
+		t.Fatal("force_local_*_ssl=NO must report not-enforced")
+	}
+}
+
+func TestFtpConfigStatus_MissingFile(t *testing.T) {
+	t.Setenv("JABALI_VSFTPD_CONF_PATH", filepath.Join(t.TempDir(), "does-not-exist.conf"))
+	st := configStatus(t)
+	if st.Exists {
+		t.Fatal("missing conf must report exists=false")
+	}
+}

--- a/panel-api/internal/reconciler/reconcile_modules.go
+++ b/panel-api/internal/reconciler/reconcile_modules.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
 // M353 module install-on-enable — convergence pass.
@@ -63,6 +65,14 @@ func (r *Reconciler) reconcileModuleInstalls(ctx context.Context) {
 	for _, m := range convergedModules {
 		if m.enabled(flags) {
 			r.convergeModule(ctx, m.key, m.dependsOn)
+			// JAB-260: an enabled+active vsftpd can still be running the WRONG
+			// TLS posture — a failed plaintext-tighten (or loosen) leaves the old
+			// config, which convergeModule's installed+active check never
+			// catches. Compare the LIVE config to the desired ftp_allow_plaintext
+			// and re-render on drift.
+			if m.key == "ftp" {
+				r.convergeFtpConfig(ctx, srv)
+			}
 			continue
 		}
 		// A DISABLED module is normally left alone. FTP is the exception
@@ -74,6 +84,81 @@ func (r *Reconciler) reconcileModuleInstalls(ctx context.Context) {
 			r.convergeFtpDisabled(ctx)
 		}
 	}
+}
+
+// convergeFtpConfig heals FTP TLS-posture drift (JAB-260). An enabled+active
+// vsftpd can still be serving a config whose TLS enforcement disagrees with the
+// desired ftp_allow_plaintext — a failed tighten left the old (plaintext) config
+// running, or a failed loosen left TLS required. It reads the LIVE config via
+// ftp.config_status and, on drift (equality mismatch, either direction),
+// re-runs system.module.install (which re-renders + restarts). The check runs
+// every tick (a cheap read); only the re-render is gated by the "ftp-config"
+// backoff so a persistent apply failure doesn't hot-loop restarts.
+//
+// FTP now has THREE reconcile backoff keys: "ftp" (install convergence, in
+// convergeModule), "ftp-disable" (convergeFtpDisabled), "ftp-config" (here).
+//
+// Skew-safe: an old agent without the verb (unknown_command) or a missing conf
+// on an active daemon is treated as converged.
+func (r *Reconciler) convergeFtpConfig(_ context.Context, srv *models.ServerSettings) {
+	if srv == nil || r.agent == nil {
+		return
+	}
+	// Singleflight: at most one drift check in flight. The check runs every tick
+	// (fast plaintext-drift detection), so a hung agent socket could otherwise
+	// stack goroutines across ticks — this keeps it to one.
+	if !r.ftpConfigChecking.CompareAndSwap(false, true) {
+		return
+	}
+	wantSSL := !srv.FTPAllowPlaintext
+	go func() {
+		defer r.ftpConfigChecking.Store(false)
+		cctx, ccancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer ccancel()
+		// Only an ACTIVE daemon can serve the wrong posture. An inactive/masked
+		// vsftpd serves nothing — the fail-closed end state — and convergeModule
+		// owns bringing an installed-but-inactive module back up. Re-rendering an
+		// inactive daemon here would fight the no-cert fail-closed mask (a
+		// tighten with no cert stops+masks vsftpd) and churn mask/die every tick.
+		// So skip unless active; the cert landing + convergeModule heal the rest.
+		if installed, active, ok := r.moduleStatus(cctx, "ftp"); !ok || !installed || !active {
+			return
+		}
+		raw, err := r.agent.Call(cctx, "ftp.config_status", map[string]any{})
+		if err != nil {
+			// Old agent without ftp.config_status → nothing to compare; converged.
+			// Debug (not error): fires every tick on every pre-upgrade box.
+			r.log.Debug("ftp.config_status unavailable — skipping TLS-drift check", "err", err)
+			return
+		}
+		var st struct {
+			Exists      bool `json:"exists"`
+			SSLEnforced bool `json:"ssl_enforced"`
+		}
+		if err := json.Unmarshal(raw, &st); err != nil {
+			return
+		}
+		if !st.Exists {
+			// Active daemon but no config file is genuinely odd — warn, but
+			// converged-if-active is still the right call (convergeModule owns
+			// the install/restart).
+			r.log.Warn("ftp active but /etc/vsftpd.conf missing — treating config as converged")
+			return
+		}
+		if st.SSLEnforced == wantSSL {
+			return // converged
+		}
+		// Drift — gate the re-render on its own backoff to avoid hot-looping
+		// vsftpd restarts on a persistently failing apply.
+		if !r.moduleInstallDue("ftp-config") {
+			return
+		}
+		r.log.Warn("ftp TLS posture drift — re-applying config",
+			"want_ssl_enforced", wantSSL, "effective_ssl_enforced", st.SSLEnforced)
+		if _, ierr := r.agent.Call(cctx, "system.module.install", map[string]any{"key": "ftp"}); ierr != nil {
+			r.log.Error("ftp config re-apply failed (will retry)", "err", ierr)
+		}
+	}()
 }
 
 // convergeFtpDisabled drives FTP toward fail-closed (vsftpd inactive + masked,

--- a/panel-api/internal/reconciler/reconcile_modules_test.go
+++ b/panel-api/internal/reconciler/reconcile_modules_test.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -13,11 +14,15 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
+var errStub = errors.New("stub agent error")
+
 // moduleStubAgent returns a canned system.module.status per key and records
 // install calls. status[key] = {"installed":bool,"active":bool}.
 type moduleStubAgent struct {
 	status       map[string]map[string]any
 	installCalls int
+	configStatus map[string]any // canned ftp.config_status response
+	configErr    error          // if set, ftp.config_status returns this error
 
 	mu      sync.Mutex
 	methods []string // every method seen (guarded; detached dispatch races the test)
@@ -41,6 +46,11 @@ func (m *moduleStubAgent) Call(_ context.Context, method string, params any) (js
 	case "system.module.install":
 		m.installCalls++
 		return json.Marshal(m.status[key])
+	case "ftp.config_status":
+		if m.configErr != nil {
+			return nil, m.configErr
+		}
+		return json.Marshal(m.configStatus)
 	default:
 		return nil, nil
 	}
@@ -162,6 +172,75 @@ func TestConvergeFtpDisabled_DispatchesFtpDisableWithBackoff(t *testing.T) {
 	}
 	if ag.methodCount("system.module.disable") != 0 {
 		t.Fatal("must NOT use the generic fail-soft system.module.disable for ftp")
+	}
+}
+
+// JAB-260: convergeFtpConfig re-renders (system.module.install) exactly when the
+// LIVE TLS enforcement disagrees with the desired ftp_allow_plaintext — an
+// equality check catching BOTH the tighten-drift (want TLS, config plaintext)
+// and the loosen-drift (want plaintext, config still TLS). Converged states and
+// a verb error (old agent) never re-render.
+func TestConvergeFtpConfig_ReAppliesOnlyOnDrift(t *testing.T) {
+	cases := []struct {
+		name           string
+		allowPlaintext bool // desired
+		enforced       bool // live config
+		active         bool // vsftpd active? (an inactive/masked daemon serves nothing)
+		configErr      error
+		wantReApply    bool
+	}{
+		{"want-tls,enforced,active → converged", false, true, true, nil, false},
+		{"want-tls,plaintext,active → tighten drift", false, false, true, nil, true},
+		{"want-plaintext,enforced,active → loosen drift", true, true, true, nil, true},
+		{"want-plaintext,plaintext,active → converged", true, false, true, nil, false},
+		{"want-tls,plaintext,INACTIVE → skip (masked=fail-closed already)", false, false, false, nil, false},
+		{"verb error (old agent) → skip", false, false, true, errStub, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ftpStatus := down()
+			if tc.active {
+				ftpStatus = up()
+			}
+			ag := &moduleStubAgent{
+				status:       map[string]map[string]any{"ftp": ftpStatus},
+				configStatus: map[string]any{"exists": true, "ssl_enforced": tc.enforced},
+				configErr:    tc.configErr,
+			}
+			r := discardReconciler(ag)
+			r.convergeFtpConfig(context.Background(), &models.ServerSettings{FTPAllowPlaintext: tc.allowPlaintext})
+
+			// Detached goroutine — poll for the re-apply decision, then settle.
+			deadline := time.Now().Add(1 * time.Second)
+			for tc.wantReApply && ag.methodCount("system.module.install") == 0 && time.Now().Before(deadline) {
+				time.Sleep(5 * time.Millisecond)
+			}
+			if !tc.wantReApply {
+				time.Sleep(150 * time.Millisecond) // give a wrong dispatch time to appear
+			}
+			got := ag.methodCount("system.module.install")
+			if tc.wantReApply && got != 1 {
+				t.Fatalf("want re-apply, got %d install calls", got)
+			}
+			if !tc.wantReApply && got != 0 {
+				t.Fatalf("want NO re-apply, got %d install calls", got)
+			}
+		})
+	}
+}
+
+// JAB-260: an active daemon with no config file is odd but must be treated as
+// converged (convergeModule owns the install), NOT re-applied here.
+func TestConvergeFtpConfig_MissingConfIsConverged(t *testing.T) {
+	ag := &moduleStubAgent{
+		status:       map[string]map[string]any{"ftp": up()}, // active, so we reach the config check
+		configStatus: map[string]any{"exists": false, "ssl_enforced": false},
+	}
+	r := discardReconciler(ag)
+	r.convergeFtpConfig(context.Background(), &models.ServerSettings{FTPAllowPlaintext: false})
+	time.Sleep(150 * time.Millisecond)
+	if ag.methodCount("system.module.install") != 0 {
+		t.Fatal("missing conf must be treated as converged, not re-applied")
 	}
 }
 

--- a/panel-api/internal/reconciler/reconciler.go
+++ b/panel-api/internal/reconciler/reconciler.go
@@ -78,6 +78,9 @@ type Reconciler struct {
 	// persistently-failing install is not re-dispatched every reconcile tick.
 	moduleInstallMu      sync.Mutex
 	moduleInstallAttempt map[string]time.Time
+	// ftpConfigChecking singleflights the per-tick JAB-260 TLS-drift check so a
+	// hung agent socket cannot stack goroutines across ticks.
+	ftpConfigChecking atomic.Bool
 	// sanDriftAttempt gates the JAB-226 SAN-drift reissue pass: cert ID -> last
 	// attempt, so a cert whose missing SAN isn't reachable yet isn't re-probed
 	// (or re-issued) more than once per sslSANDriftCooldown.


### PR DESCRIPTION
## JAB-260 — Disabling plaintext FTP can silently leave cleartext on (Phase B)

Changing `ftp_allow_plaintext` persisted the secure intent, then async re-ran the module install to rewrite `vsftpd.conf`. If that apply failed, the **old plaintext config kept running** — and the reconciler only checked installed+active, never config, so it treated the insecure daemon as converged and never retried. The panel could report plaintext FTP disabled while the server kept accepting credentials + data without TLS indefinitely.

**Phase B** of `plans/gh1053-ftp-reconciled-resource-epic.md`.

### Why live-config-read, not a hash
A sidecar "applied hash" records what install.sh *claims* it applied; a crash between the conf write and the sidecar write yields a permanent silent drift the hash never catches. Parsing the **running** `vsftpd.conf` observes the **actual** applied state — no fragile Go/bash hash contract.

### Changes
- **New agent verb `ftp.config_status`**: parse `/etc/vsftpd.conf`, return `{exists, ssl_enforced}` where `ssl_enforced = ssl_enable=YES && force_local_logins_ssl=YES && force_local_data_ssl=YES`. Absent directives → `""`, so the legitimate `ssl_enable=NO` plaintext render reports not-enforced (= plaintext-desired, not drift).
- **Reconciler `convergeFtpConfig`** (enabled-ftp branch, after `convergeModule`): compares `ssl_enforced` vs desired `!ftp_allow_plaintext` by **equality** — catches both the **tighten-drift** (want TLS, config plaintext = the bug) and the **loosen-drift** (want plaintext, config still TLS = clients locked out). Re-renders (`system.module.install`) **only when the daemon is ACTIVE** — an inactive/masked vsftpd already serves nothing (fail-closed end state) and `convergeModule` owns bringing it back up, so re-rendering it would fight the no-cert mask below and churn. Check runs every tick (fast detection), **singleflighted**; only the re-render is gated by a new `ftp-config` backoff (FTP now has three: `ftp`, `ftp-disable`, `ftp-config`). Skew-safe: old agent (`unknown_command`) or missing conf on an active daemon → converged.
- **Fail-closed tighten** (`install.sh install_vsftpd_config`): when a secure config can't be produced (TLS required, no panel cert yet), if vsftpd is **currently active** it is stopped + masked before `_die` — never left running old plaintext. **Guarded on is-active** so a fresh (inactive) install just dies (no wedged enable). Self-heals: `ftp_enabled` stays on → `convergeModule` re-runs the install once the cert lands → unmask + start with TLS.

### Acceptance (JAB-260)
✅ 1 (desired vs observed applied state) · ✅ 2 (failed tighten retried) · ✅ 4 (fails closed vs continuing plaintext) · ✅ 5 (failure-injection tests). ⏳ 3 (UI distinguishes desired vs effective) → **Phase C** (`ftp.config_status` already returns the effective state).

### Tests
Agent: TLS-enforced / `ssl_enable=NO` / TLS-on-but-not-forced / missing-file. Reconciler (`-race`): equality table incl. **INACTIVE→skip** (masked = fail-closed, no churn) + verb-error skip + missing-conf converged. Optin shell test grep-asserts the is-active-guarded stop+mask. Full panel-agent commands + panel-api reconciler green; exec-seam holds.

### Live (jabalitests)
Tighten plaintext→TLS with no cert → confirm vsftpd stopped+masked (not serving cleartext) → drop the cert → confirm self-heal to TLS. Plus: plaintext-allowed box, cert lands later, toggle TLS → single re-render, no churn.

Scope: reconciles the **security-critical TLS posture**; non-security field drift (max_clients etc) still re-renders only on explicit change.

Refs JAB-260.
