### PR TITLE
fix(limits): quota-only disk usage — du becomes an explicit, ionice'd Measure action

### DIFF
--- a/panel-agent/internal/commands/backup_home.go
+++ b/panel-agent/internal/commands/backup_home.go
@@ -1,10 +1,10 @@
 // Step 3 of M30: backup.home agent command. `restic backup /home/<u>` with
 // the canonical account_backup tag set.
 //
-// A best-effort `du -sb` pre-pass records the account's logical content size
-// (reported back as logical_bytes). It no longer caps the backup — large
-// accounts back up too; restic's dedup keeps the repo far below the logical
-// size (the old 50 GiB refusal was removed).
+// No size pre-pass: the old `du -sb` walk (a leftover from the removed
+// 50 GiB refusal ceiling) cost a full inode walk of every home on every
+// backup for a number nothing displayed. restic's own summary carries
+// bytes_total; disk accounting is the quota system's job.
 package commands
 
 import (
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
@@ -69,7 +68,6 @@ type backupHomeResult struct {
 	ParentSnapshot string   `json:"parent_snapshot,omitempty"`
 	BytesAdded     uint64   `json:"bytes_added"`
 	BytesTotal     uint64   `json:"bytes_total"`
-	LogicalBytes   uint64   `json:"logical_bytes"`
 	Warnings       []string `json:"warnings,omitempty"`
 }
 
@@ -91,14 +89,6 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 	homePath := filepath.Join("/home", req.Username)
 	if _, err := os.Stat(homePath); err != nil {
 		return nil, bkInvalidArg(fmt.Sprintf("user home not found: %s", homePath))
-	}
-
-	// Best-effort logical-size pre-pass, for reporting only (no ceiling). A
-	// du failure (e.g. a transient permission hiccup) must not block the
-	// backup — restic walks the tree itself.
-	logical, derr := duBytes(ctx, homePath)
-	if derr != nil {
-		logical = 0
 	}
 
 	if _, err := bkResticBin(); err != nil {
@@ -157,28 +147,8 @@ func backupHomeHandler(ctx context.Context, raw json.RawMessage) (any, error) {
 		SnapshotID:   summary.SnapshotID,
 		BytesAdded:   summary.DataAdded,
 		BytesTotal:   summary.TotalBytesProcessed,
-		LogicalBytes: logical,
 		Warnings:     summary.Warnings,
 	}, nil
-}
-
-// duBytes runs `du -sb <path>` and returns the byte count. Hard-fails
-// on a non-zero exit (could be permission-denied; treat as scan failure
-// rather than silently passing).
-func duBytes(ctx context.Context, path string) (uint64, error) {
-	out, err := execCommandContext(ctx, "du", "-sb", path).Output()
-	if err != nil {
-		return 0, fmt.Errorf("du -sb %s: %w", path, err)
-	}
-	fields := strings.Fields(strings.TrimSpace(string(out)))
-	if len(fields) == 0 {
-		return 0, fmt.Errorf("du -sb %s: empty output", path)
-	}
-	n, err := strconv.ParseUint(fields[0], 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse du output %q: %w", fields[0], err)
-	}
-	return n, nil
 }
 
 func init() {

--- a/panel-agent/internal/commands/user_limits_report.go
+++ b/panel-agent/internal/commands/user_limits_report.go
@@ -33,6 +33,14 @@ import (
 type userLimitsReportParams struct {
 	Username   string `json:"username"`
 	QuotaMount string `json:"quota_mount"` // empty = skip quota reporting
+	// MeasureDisk opts in to an ON-DEMAND `du` walk when quota has no
+	// answer. The old behavior ran the walk automatically — including
+	// whenever quota reported 0 KB for an empty-looking user — which,
+	// under the dashboard's polling cadence, IO-starved a production box
+	// at peak hours. Now the walk runs ONLY when a human clicks Measure
+	// (still cached, and under ionice/nice so it can never compete with
+	// serving traffic).
+	MeasureDisk bool `json:"measure_disk,omitempty"`
 }
 
 type diskReport struct {
@@ -113,13 +121,16 @@ func userLimitsReportHandler(ctx context.Context, params json.RawMessage) (any, 
 		}
 		// quota exits non-zero when the user has no quota set on this
 		// mount — we treat that as "no disk report" rather than error.
-		if resp.Disk == nil || resp.Disk.UsedKB == 0 {
-			if du, ok := diskUsageFallback(ctx, p.Username); ok {
-				if resp.Disk == nil {
-					resp.Disk = &diskReport{UsedKB: du}
-				} else {
-					resp.Disk.UsedKB = du
-				}
+	}
+	// Quota is the ONLY automatic source. When it has no answer, the
+	// dashboard shows "—" and offers a Measure button; only that explicit
+	// request reaches the du path below.
+	if p.MeasureDisk && (resp.Disk == nil || resp.Disk.UsedKB == 0) {
+		if du, ok := diskUsageMeasure(ctx, p.Username); ok {
+			if resp.Disk == nil {
+				resp.Disk = &diskReport{UsedKB: du}
+			} else {
+				resp.Disk.UsedKB = du
 			}
 		}
 	}
@@ -292,10 +303,12 @@ var (
 	duCache   = map[string]duCacheEntry{}
 )
 
-// diskUsageFallback returns used KB for /home/<username> using `du -sk`.
-// Cached for duCacheTTL. Returns (0, false) on any error so the caller
-// falls through to the existing "no disk report" branch.
-func diskUsageFallback(ctx context.Context, username string) (uint64, bool) {
+// diskUsageMeasure returns used KB for /home/<username> using an
+// ionice'd/niced `du -sk`. ON-DEMAND ONLY (Measure button) — never called
+// automatically. Cached for duCacheTTL so button-mashing costs one walk.
+// Returns (0, false) on any error so the caller falls through to the
+// existing "no disk report" branch.
+func diskUsageMeasure(ctx context.Context, username string) (uint64, bool) {
 	duCacheMu.Lock()
 	if e, ok := duCache[username]; ok && time.Since(e.at) < duCacheTTL {
 		duCacheMu.Unlock()
@@ -308,11 +321,26 @@ func diskUsageFallback(ctx context.Context, username string) (uint64, bool) {
 		return 0, false
 	}
 
+	used, ok := measureHomeKB(ctx, home)
+	if !ok {
+		return 0, false
+	}
+
+	duCacheMu.Lock()
+	duCache[username] = duCacheEntry{usedKB: used, at: time.Now()}
+	duCacheMu.Unlock()
+	return used, true
+}
+
+// measureHomeKB runs the actual walk: idle IO class + lowest CPU priority,
+// so a Measure click on a huge home loses every fight against serving
+// traffic. Split from diskUsageMeasure so the command shape is testable.
+func measureHomeKB(ctx context.Context, home string) (uint64, bool) {
 	testMutex.Lock()
 	runCmdFn := runCmd
 	testMutex.Unlock()
 
-	stdout, _, err := runCmdFn(ctx, "du", "-sk", home)
+	stdout, _, err := runCmdFn(ctx, "ionice", "-c3", "nice", "-n19", "du", "-sk", home)
 	if err != nil {
 		return 0, false
 	}
@@ -324,10 +352,6 @@ func diskUsageFallback(ctx context.Context, username string) (uint64, bool) {
 	if err != nil {
 		return 0, false
 	}
-
-	duCacheMu.Lock()
-	duCache[username] = duCacheEntry{usedKB: used, at: time.Now()}
-	duCacheMu.Unlock()
 	return used, true
 }
 

--- a/panel-agent/internal/commands/user_limits_report_measure_test.go
+++ b/panel-agent/internal/commands/user_limits_report_measure_test.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// swapRunCmd installs a fake runCmd and returns a restore func.
+func swapRunCmd(fn func(ctx context.Context, name string, args ...string) ([]byte, []byte, error)) func() {
+	testMutex.Lock()
+	orig := runCmd
+	runCmd = fn
+	testMutex.Unlock()
+	return func() {
+		testMutex.Lock()
+		runCmd = orig
+		testMutex.Unlock()
+	}
+}
+
+// The automatic du fallback IO-starved a production box at peak (dashboard
+// polls every 5s; quota reporting 0 KB for an empty-looking user triggered a
+// full home walk each time). Quota is now the ONLY automatic source — a
+// default report must NEVER exec du, even when quota has no answer.
+func TestUserLimitsReport_NoMeasureNeverRunsDu(t *testing.T) {
+	restore := swapRunCmd(func(_ context.Context, name string, args ...string) ([]byte, []byte, error) {
+		if name != "quota" {
+			t.Errorf("unexpected exec without measure_disk: %s %v", name, args)
+		}
+		return []byte(""), nil, nil
+	})
+	defer restore()
+
+	raw, _ := json.Marshal(map[string]any{"username": "nosuchuser-drill", "quota_mount": "/"})
+	if _, err := userLimitsReportHandler(context.Background(), raw); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+}
+
+// measure_disk=true is the Measure button: the walk runs, but only under
+// ionice -c3 / nice -n19 so it can never compete with serving traffic.
+func TestUserLimitsReport_MeasureRunsIonicedDu(t *testing.T) {
+	var duArgs []string
+	restore := swapRunCmd(func(_ context.Context, name string, args ...string) ([]byte, []byte, error) {
+		if name == "ionice" {
+			duArgs = append([]string{name}, args...)
+			return []byte("4096\t/home/root"), nil, nil
+		}
+		return []byte(""), nil, nil
+	})
+	defer restore()
+
+	got, ok := measureHomeKB(context.Background(), "/home/whoever")
+	if !ok || got != 4096 {
+		t.Fatalf("want 4096 KB, got %d ok=%v", got, ok)
+	}
+	joined := strings.Join(duArgs, " ")
+	if joined != "ionice -c3 nice -n19 du -sk /home/whoever" {
+		t.Fatalf("measure must run under ionice -c3 nice -n19, got: %s", joined)
+	}
+
+	// And a missing home short-circuits before any exec.
+	if got, ok := diskUsageMeasure(context.Background(), "definitely-missing-user-xyz"); ok || got != 0 {
+		t.Fatalf("missing home must (0,false), got %d %v", got, ok)
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -5452,6 +5452,14 @@ paths:
       parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
       responses: { "200": { description: OK } }
 
+  /users/{id}/usage/measure-disk:
+    post:
+      tags: [Users]
+      summary: Measure disk usage on demand (quota-less hosts)
+      security: [ { KratosSession: [] } ]
+      parameters: [ { in: path, name: id, required: true, schema: { type: string } } ]
+      responses: { "200": { description: OK } }
+
 
   # --- Whois (auto) ---
 

--- a/panel-api/internal/api/user_limits.go
+++ b/panel-api/internal/api/user_limits.go
@@ -77,6 +77,11 @@ func RegisterUserLimitsRoutes(g *gin.RouterGroup, cfg UserLimitsHandlerConfig) {
 	h := &userLimitsHandler{cfg: cfg}
 	// Usage is a read-only view so owner or admin is fine.
 	g.GET("/users/:id/usage", middleware.RequireOwner("id"), h.usage)
+	// Measure runs an on-demand `du` walk on the agent (ionice'd, cached
+	// 60s agent-side) for hosts without filesystem quotas. Owner-or-admin
+	// like the read: it only recomputes the caller's own number. This
+	// replaced the automatic du fallback that IO-starved a box at peak.
+	g.POST("/users/:id/usage/measure-disk", middleware.RequireOwner("id"), h.measureDisk)
 	// Override writes are admin-only — changing a user's resource limits
 	// outside their package is operator territory, not self-service.
 	g.PUT("/users/:id/limit-overrides", middleware.RequireAdmin(), h.upsertOverride)
@@ -165,6 +170,44 @@ func (h *userLimitsHandler) usage(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// measureDisk asks the agent for a usage report WITH the on-demand disk
+// walk (measure_disk) and refreshes the cache with the result, so the next
+// GET /usage renders the measured number immediately. Longer timeout than
+// the read path: an ionice'd walk of a large home takes real seconds.
+func (h *userLimitsHandler) measureDisk(c *gin.Context) {
+	userID := c.Param("id")
+	user, err := h.cfg.Users.FindByID(c.Request.Context(), userID)
+	if err != nil {
+		if isNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if user.Username == nil || *user.Username == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "no_linux_account", "detail": "user has no linux account"})
+		return
+	}
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unavailable"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 120*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(ctx, "user.limits.report", map[string]any{
+		"username":     *user.Username,
+		"quota_mount":  h.cfg.QuotaMount,
+		"measure_disk": true,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "agent_failed"})
+		return
+	}
+	usageReportCachePut(*user.Username+"|"+h.cfg.QuotaMount, raw)
+	c.JSON(http.StatusOK, gin.H{"current": json.RawMessage(raw)})
 }
 
 // resolveEffective hydrates the user's package + any override row and

--- a/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
+++ b/panel-ui/src/shells/admin/users/UserLimitsCard.tsx
@@ -103,6 +103,16 @@ export function UserLimitsCard({ userId }: { userId: string }) {
     onError: () => feedback.message.error("Failed to clear overrides"),
   });
 
+  const measureMutation = useMutation({
+    mutationFn: async () => {
+      await apiClient.post(`/users/${userId}/usage/measure-disk`);
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["user-usage", userId] });
+    },
+    onError: () => feedback.message.error("Disk measurement failed"),
+  });
+
   const rows: Row[] = FIELDS.map((f) => {
     const pkg = data?.package?.[f.key];
     const override = data?.override?.[f.key];
@@ -195,7 +205,20 @@ export function UserLimitsCard({ userId }: { userId: string }) {
         <Typography.Paragraph type="secondary" style={{ marginTop: 12, marginBottom: 0 }}>
           Live disk usage: {(diskUsed / 1024).toFixed(0)} MB
         </Typography.Paragraph>
-      ) : null}
+      ) : (
+        // No quota answer on this host (quotas off, or the user genuinely
+        // empty). Nothing walks the disk automatically anymore — the old
+        // automatic `du` fallback IO-starved a box at peak — so offer a
+        // one-click, agent-side-throttled measurement instead.
+        <Space style={{ marginTop: 12 }}>
+          <Typography.Text type="secondary">Disk usage: —</Typography.Text>
+          <Tooltip title="Runs a one-time size scan on the server (low IO priority). Only needed when filesystem quotas are off.">
+            <Button size="small" loading={measureMutation.isPending} onClick={() => measureMutation.mutate()}>
+              Measure
+            </Button>
+          </Tooltip>
+        </Space>
+      )}
 
       <EditOverridesDrawer
         open={editOpen}


### PR DESCRIPTION
## Summary
Operator incident: the automatic `du` fallback IO-starved a production box at rush hour. Root causes were TWO silent walks:

1. **`backup.home` pre-pass** — `du -sb` of the entire home on every backup, feeding a `logical_bytes` field that nothing reads (leftover of the removed 50 GiB ceiling). Deleted.
2. **`user.limits.report` fallback** — auto-`du` whenever quota had no answer, *including when quota correctly reported 0 KB*, so it fired on quota-enabled boxes too; the dashboard polls every 5s. Deleted.

Quota counters are now the only automatic source. Quota-less hosts get a **Measure** button on the admin Limits card (`POST /users/:id/usage/measure-disk`, owner-or-admin): the single remaining du path, run under `ionice -c3 nice -n19`, cached 60s agent-side so button-mashing costs one walk.

## Test plan
- [x] `TestUserLimitsReport_NoMeasureNeverRunsDu` — a default report can never exec du (the incident class, pinned)
- [x] `TestUserLimitsReport_MeasureRunsIonicedDu` — exact `ionice -c3 nice -n19 du -sk` argv
- [x] openapi coverage golden updated; tsc -b clean; full Go sweep 0 FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)