### PR TITLE
feat(security): observed-vs-desired FTP state in the panel (JAB-259/260, epic phase C)

### DIFF
--- a/panel-agent/internal/commands/ftp_config_status.go
+++ b/panel-agent/internal/commands/ftp_config_status.go
@@ -41,15 +41,22 @@ func ftpConfigStatusHandler(_ context.Context, _ json.RawMessage) (any, error) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "read vsftpd.conf: " + err.Error()}
 	}
 	kv := parseVsftpdConf(string(data))
-	// Absent directives read as "" — the legitimate ssl_enable=NO render (no TLS
-	// block at all) correctly reports SSLEnforced=false, which equals the
-	// plaintext-desired state, so it is NOT flagged as drift.
 	return ftpConfigStatusResponse{
-		Exists: true,
-		SSLEnforced: kv["ssl_enable"] == "YES" &&
-			kv["force_local_logins_ssl"] == "YES" &&
-			kv["force_local_data_ssl"] == "YES",
+		Exists:      true,
+		SSLEnforced: vsftpdSSLEnforced(kv),
 	}, nil
+}
+
+// vsftpdSSLEnforced reports whether the parsed config enforces TLS on BOTH the
+// control and data channels. Absent directives read as "" — the legitimate
+// ssl_enable=NO render (no TLS block at all) correctly reports false, which
+// equals the plaintext-desired state and is therefore NOT drift. Shared by
+// ftp.config_status and ftp.status so the two verbs can never disagree on what
+// "enforced" means.
+func vsftpdSSLEnforced(kv map[string]string) bool {
+	return kv["ssl_enable"] == "YES" &&
+		kv["force_local_logins_ssl"] == "YES" &&
+		kv["force_local_data_ssl"] == "YES"
 }
 
 // parseVsftpdConf maps the `key=value` directives, skipping comments/blanks.

--- a/panel-agent/internal/commands/ftp_status.go
+++ b/panel-agent/internal/commands/ftp_status.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+)
+
+// ftp.status — READ-ONLY full effective FTP posture for the observed-vs-desired
+// UI (JAB-259/260 phase C). Combines the live vsftpd.conf TLS state with the
+// systemd/ufw runtime state so the panel can render desired-vs-effective and
+// never report a false "off"/"secure" while the host disagrees.
+//
+// Deliberately separate from ftp.config_status: the reconciler calls that one
+// every tick and it must stay lean (a single file read). This one adds the
+// exec-backed active/masked/ports fields and is called on demand only.
+type ftpStatusResponse struct {
+	ConfExists  bool `json:"conf_exists"`
+	SSLEnforced bool `json:"ssl_enforced"`
+	Active      bool `json:"active"`
+	Masked      bool `json:"masked"`
+	PortsOpen   bool `json:"ports_open"`
+}
+
+func ftpStatusHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	resp := ftpStatusResponse{
+		Active:    ftpUnitActive(ctx, ftpDisableUnit),
+		Masked:    ftpUnitMasked(ctx, ftpDisableUnit),
+		PortsOpen: ftpControlPortOpen(ctx),
+	}
+	if data, err := os.ReadFile(getVsftpdConfPath()); err == nil {
+		resp.ConfExists = true
+		resp.SSLEnforced = vsftpdSSLEnforced(parseVsftpdConf(string(data)))
+	}
+	return resp, nil
+}
+
+func init() {
+	Default.Register("ftp.status", ftpStatusHandler)
+}

--- a/panel-agent/internal/commands/ftp_status_test.go
+++ b/panel-agent/internal/commands/ftp_status_test.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"context"
+	"testing"
+)
+
+// ftp.status combines the live conf TLS state with the runtime unit state.
+// Under the default exec stub, systemctl/ufw emit nothing (inactive/unmasked/
+// ports-closed); the conf is read from the JABALI_VSFTPD_CONF_PATH file.
+func TestFtpStatus_ReadsConfAndRuntime(t *testing.T) {
+	writeConf(t, `ssl_enable=YES
+force_local_logins_ssl=YES
+force_local_data_ssl=YES
+`)
+	res, err := ftpStatusHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	st := res.(ftpStatusResponse)
+	if !st.ConfExists || !st.SSLEnforced {
+		t.Fatalf("want conf_exists + ssl_enforced from the TLS render, got %+v", st)
+	}
+	// Default stub: systemctl is-active/is-enabled emit "" → inactive, unmasked.
+	if st.Active {
+		t.Fatal("stubbed systemctl must report inactive")
+	}
+}
+
+func TestFtpStatus_NoConf(t *testing.T) {
+	t.Setenv("JABALI_VSFTPD_CONF_PATH", t.TempDir()+"/absent.conf")
+	res, err := ftpStatusHandler(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if res.(ftpStatusResponse).ConfExists {
+		t.Fatal("absent conf must report conf_exists=false")
+	}
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4645,6 +4645,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/settings/modules/ftp/status:
+    get:
+      tags: [Settings]
+      summary: FTP observed-vs-desired status
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /admin/settings/notification-events:
     get:
       tags: [Settings]

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -52,6 +52,10 @@ func RegisterServerSettingsRoutes(g *gin.RouterGroup, cfg ServerSettingsHandlerC
 	// toggle installs, and re-dispatches an install as a retry affordance.
 	admin.GET("/modules/status", h.moduleStatus)
 	admin.POST("/modules/install", h.moduleInstall)
+	// JAB-259/260 phase C: observed-vs-desired FTP posture so the FTP card can
+	// warn when the host disagrees with the panel (still serving after a disable,
+	// or plaintext after a tighten) instead of rendering a false off/secure.
+	admin.GET("/modules/ftp/status", h.ftpStatus)
 	// JAB-213: activate a free jabalihosted.com hostname from Server Settings.
 	admin.POST("/free-hostname/register", h.freeHostnameRegister)
 	admin.POST("/free-hostname/claim", h.freeHostnameClaim)
@@ -1503,6 +1507,65 @@ func (h *serverSettingsHandler) moduleStatus(c *gin.Context) {
 		out[key] = e
 	}
 	c.JSON(http.StatusOK, gin.H{"modules": out})
+}
+
+// ftpStatus returns the observed-vs-desired FTP posture (JAB-259/260 phase C).
+// The FTP card renders a drift warning when the host disagrees with the panel:
+//   - exposure: FTP is desired OFF but vsftpd is still active (a fail-open
+//     disable — JAB-259).
+//   - tls: FTP is desired ON + secure but the live daemon still accepts plaintext
+//     (a silently-failed tighten — JAB-260).
+//
+// A missing/unreachable agent yields effective=null + no drift; the UI treats an
+// absent effective state as "unknown", never as a confirmed secure state.
+func (h *serverSettingsHandler) ftpStatus(c *gin.Context) {
+	ctx := c.Request.Context()
+	s, err := h.cfg.Repo.Get(ctx)
+	if errors.Is(err, repository.ErrNotFound) {
+		s = &models.ServerSettings{ID: 1}
+	} else if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	desired := gin.H{"enabled": s.FTPEnabled, "allow_plaintext": s.FTPAllowPlaintext}
+	noDrift := gin.H{"exposure": false, "tls": false}
+
+	if h.cfg.Agent == nil {
+		c.JSON(http.StatusOK, gin.H{"desired": desired, "effective": nil, "drift": noDrift})
+		return
+	}
+	sctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	raw, err := h.cfg.Agent.Call(sctx, "ftp.status", map[string]any{})
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"desired": desired, "effective": nil, "drift": noDrift})
+		return
+	}
+	var eff struct {
+		ConfExists  bool `json:"conf_exists"`
+		SSLEnforced bool `json:"ssl_enforced"`
+		Active      bool `json:"active"`
+		Masked      bool `json:"masked"`
+		PortsOpen   bool `json:"ports_open"`
+	}
+	if err := json.Unmarshal(raw, &eff); err != nil {
+		c.JSON(http.StatusOK, gin.H{"desired": desired, "effective": nil, "drift": noDrift})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"desired":   desired,
+		"effective": eff,
+		"drift": gin.H{
+			// exposure (error): FTP off but vsftpd still serving (JAB-259).
+			"exposure": !s.FTPEnabled && eff.Active,
+			// tls (error): FTP on + secure but the live daemon accepts plaintext (JAB-260).
+			"tls": s.FTPEnabled && !s.FTPAllowPlaintext && eff.Active && !eff.SSLEnforced,
+			// ports (warning): FTP off, daemon stopped, but the firewall still
+			// allows the FTP ports. Not exposure (nothing is listening) but a
+			// leftover rule worth flagging.
+			"ports": !s.FTPEnabled && !eff.Active && eff.PortsOpen,
+		},
+	})
 }
 
 // moduleInstall re-dispatches a module install in the background. It is the UI's

--- a/panel-api/internal/api/server_settings_ftp_status_test.go
+++ b/panel-api/internal/api/server_settings_ftp_status_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// ftpStatusStub returns a canned ftp.status effective state.
+type ftpStatusStub struct{ resp map[string]any }
+
+func (s *ftpStatusStub) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	if cmd == "ftp.status" {
+		return json.Marshal(s.resp)
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+// GET /admin/settings/modules/ftp/status computes exposure + tls drift from
+// desired (server_settings) vs effective (agent ftp.status) — JAB-259/260 C.
+func TestFtpStatusEndpoint_Drift(t *testing.T) {
+	cases := []struct {
+		name         string
+		enabled      bool
+		allowPlain   bool
+		effActive    bool
+		effEnforced  bool
+		effPortsOpen bool
+		wantExposure bool
+		wantTLS      bool
+		wantPorts    bool
+	}{
+		{"off but still active → exposure drift", false, false, true, false, true, true, false, false},
+		{"off and inactive → clean", false, false, false, false, false, false, false, false},
+		{"off, inactive, ports still open → ports drift (warn)", false, false, false, false, true, false, false, true},
+		{"on+secure but plaintext live → tls drift", true, false, true, false, true, false, true, false},
+		{"on+secure and enforced → clean", true, false, true, true, true, false, false, false},
+		{"on+plaintext-allowed, plaintext live → clean", true, true, true, false, true, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+				ID: 1, FTPEnabled: tc.enabled, FTPAllowPlaintext: tc.allowPlain,
+			}}
+			ag := &ftpStatusStub{resp: map[string]any{
+				"conf_exists": true, "active": tc.effActive, "ssl_enforced": tc.effEnforced,
+				"masked": !tc.effActive, "ports_open": tc.effPortsOpen,
+			}}
+			r := settingsRouter(true, repo, ag)
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings/modules/ftp/status", nil))
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var body struct {
+				Drift struct {
+					Exposure bool `json:"exposure"`
+					TLS      bool `json:"tls"`
+					Ports    bool `json:"ports"`
+				} `json:"drift"`
+			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, tc.wantExposure, body.Drift.Exposure, "exposure")
+			assert.Equal(t, tc.wantTLS, body.Drift.TLS, "tls")
+			assert.Equal(t, tc.wantPorts, body.Drift.Ports, "ports")
+		})
+	}
+}
+
+// A nil/unreachable agent yields effective=null + no drift (never a false secure).
+func TestFtpStatusEndpoint_NoAgent(t *testing.T) {
+	repo := &mockServerSettingsRepo{getResult: &models.ServerSettings{ID: 1, FTPEnabled: false}}
+	r := settingsRouter(true, repo, nil)
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/admin/settings/modules/ftp/status", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Effective any `json:"effective"`
+		Drift     struct {
+			Exposure bool `json:"exposure"`
+			TLS      bool `json:"tls"`
+		} `json:"drift"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Nil(t, body.Effective)
+	assert.False(t, body.Drift.Exposure || body.Drift.TLS)
+}

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1577,7 +1577,13 @@
     "save": "Save",
     "saved": "Saved",
     "load_failed": "Failed to load FTP settings",
-    "save_failed": "Failed to save FTP settings"
+    "save_failed": "Failed to save FTP settings",
+    "drift_exposure_title": "FTP is set to Off but the server is still running",
+    "drift_exposure_desc": "vsftpd is still active on this host despite FTP being disabled. The panel is retrying the shutdown; if this persists, the ports may still be reachable — check the host.",
+    "drift_tls_title": "Encryption is required but the server still accepts plaintext",
+    "drift_tls_desc": "The running FTP configuration does not enforce TLS even though plaintext is not allowed. A configuration apply likely failed; the panel is retrying. Until it clears, credentials could be sent unencrypted.",
+    "drift_ports_title": "FTP is off but the firewall still allows the FTP ports",
+    "drift_ports_desc": "The FTP server is stopped, so nothing is listening, but port 21 and the passive range are still open in the firewall. This is not an active exposure; the panel is closing the rules."
   },
   "forwarderstab": {
     "add_forwarder": "Add forwarder",

--- a/panel-ui/src/shells/admin/settings/FtpServerCard.tsx
+++ b/panel-ui/src/shells/admin/settings/FtpServerCard.tsx
@@ -20,6 +20,42 @@ export const FtpServerCard = () => {
   const [maxRateKBs, setMaxRateKBs] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // JAB-259/260 phase C: observed-vs-desired. The host converges asynchronously,
+  // so a toggle can leave a transient gap; a persistent gap (a fail-open disable
+  // or a silently-failed plaintext tighten) is a real security drift the operator
+  // must see rather than trust a false "off"/"secure". Polled so a healed drift
+  // clears itself and a stuck one stays visible.
+  const [drift, setDrift] = useState<{ exposure: boolean; tls: boolean; ports: boolean }>({
+    exposure: false,
+    tls: false,
+    ports: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const resp = await apiClient.get<{
+          drift?: { exposure?: boolean; tls?: boolean; ports?: boolean };
+        }>("/admin/settings/modules/ftp/status");
+        if (!cancelled) {
+          setDrift({
+            exposure: !!resp.data.drift?.exposure,
+            tls: !!resp.data.drift?.tls,
+            ports: !!resp.data.drift?.ports,
+          });
+        }
+      } catch {
+        // Status is best-effort; never block the card on a probe hiccup.
+      }
+    };
+    poll();
+    const id = window.setInterval(poll, 8000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -70,6 +106,30 @@ export const FtpServerCard = () => {
         {t("ftpservercard.description")}
       </Typography.Paragraph>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+        {drift.exposure && (
+          <Alert
+            type="error"
+            showIcon
+            message={t("ftpservercard.drift_exposure_title")}
+            description={t("ftpservercard.drift_exposure_desc")}
+          />
+        )}
+        {drift.tls && (
+          <Alert
+            type="error"
+            showIcon
+            message={t("ftpservercard.drift_tls_title")}
+            description={t("ftpservercard.drift_tls_desc")}
+          />
+        )}
+        {drift.ports && (
+          <Alert
+            type="warning"
+            showIcon
+            message={t("ftpservercard.drift_ports_title")}
+            description={t("ftpservercard.drift_ports_desc")}
+          />
+        )}
         <Form.Item label={t("ftpservercard.enable_label")} style={{ marginBottom: 0 }}>
           <Switch
             checked={enabled}


### PR DESCRIPTION
## JAB-259 + JAB-260 — observed-vs-desired FTP state in the panel (epic Phase C)

Phases A and B made the host converge fail-closed. Phase C closes the **last acceptance criterion of both tickets** (JAB-259 #4, JAB-260 #3): the control plane must **expose desired vs effective** and never render a false "off"/"secure" — during the bounded convergence window or if convergence is stuck.

### Changes
- **New read-only agent verb `ftp.status`**: full effective posture `{conf_exists, ssl_enforced, active, masked, ports_open}` — live `vsftpd.conf` TLS state + systemd/ufw runtime. Separate from `ftp.config_status` (which the reconciler calls every tick and must stay a lean file read); this adds the exec-backed fields and is called on demand only. Shared `vsftpdSSLEnforced` helper so the two verbs can't diverge on what "enforced" means.
- **New endpoint `GET /admin/settings/modules/ftp/status`** (admin-gated): `desired` + `effective` + three drift flags:
  - **exposure** (error) — FTP desired OFF but vsftpd still active (JAB-259).
  - **tls** (error) — FTP ON + secure but the live daemon still accepts plaintext (JAB-260).
  - **ports** (warning) — FTP off + daemon stopped but the firewall still allows the FTP ports (a leftover rule in front of nothing — not active exposure, but worth flagging; this is the `ports_open` state Phase A deferred here).
  A missing/unreachable agent → `effective: null` + no drift; the UI treats absent effective as **unknown**, never confirmed-secure. Documented in `openapi.yaml`.
- **FtpServerCard** (panel-ui): polls the status every 8s and renders a prominent **error** Alert on either security drift and a **warning** Alert on the ports drift. Polling (not one-shot) is deliberate — the host converges asynchronously, so a toggle leaves a transient gap that self-clears, while a stuck gap (a genuine fail-open disable or a silently-failed tighten) stays visible until the reconciler heals it.

The UI banner escalates only the security-dangerous directions; the loosen-drift (clients locked out) heals silently via Phase B and shows in `effective` without a red banner — matching 260's "never report a false secure".

### With this, JAB-259 and JAB-260 meet all acceptance criteria.
JAB-263 (session cgroup placement, Phase D) remains deferred per ADR-0167 — the epic's only remainder.

### Tests
Agent `ftp.status` (conf + runtime, missing conf); API drift table (exposure / tls / ports / clean states / no-agent=no-drift); openapi coverage documents the route. Go side fully covered; **panel-ui `tsc -b` type-checks clean**; admin gate confirmed (`admin.Use(RequireAdmin())`).

### Live (jabalitests)
Force a stuck disable / a no-cert tighten → confirm the card shows the drift banner → confirm it clears once the reconciler heals.

Refs JAB-259, JAB-260.
