### PR TITLE
feat(domains): reverse-proxy domains via a shared loopback-port allocator (GH #1175)

### DIFF
--- a/panel-api/cmd/server/cli_create.go
+++ b/panel-api/cmd/server/cli_create.go
@@ -187,6 +187,9 @@ type cliDomainInput struct {
 	Name    string
 	UserID  string // ULID of the owning (non-admin) user
 	DocRoot string // optional — defaults to /home/<user>/domains/<name>/public_html
+	// ReverseProxy (GH #1175): allocate a loopback port and make this a
+	// reverse-proxy domain (no docroot/PHP). Mirrors the HTTP create path.
+	ReverseProxy bool
 }
 
 // createDomainDirect replicates the non-auth side of internal/api/domains.go
@@ -262,7 +265,23 @@ func createDomainDirect(ctx context.Context, in cliDomainInput) (*models.Domain,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}
+	// GH #1175: reverse-proxy domains draw a loopback port from the shared
+	// allocator BEFORE the insert (owner_id = the ULID above), released if the
+	// insert then fails so a crash can't leak the reservation. Same pool + code
+	// as the HTTP create path (repository.AllocateReverseProxy).
+	ports := repository.NewPortAllocationRepository(sharedDB)
+	if in.ReverseProxy {
+		port, aerr := ports.AllocateReverseProxy(ctx, d.ID)
+		if aerr != nil {
+			return nil, nil, fmt.Errorf("allocate reverse-proxy port: %w", aerr)
+		}
+		d.ReverseProxyPort = uint32(port)
+	}
+
 	if err := domains.Create(ctx, d); err != nil {
+		if in.ReverseProxy {
+			_ = ports.Release(ctx, models.PortOwnerReverseProxy, d.ID)
+		}
 		if errors.Is(err, repository.ErrConflict) {
 			return nil, nil, fmt.Errorf("domain %q already exists", in.Name)
 		}

--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -96,6 +96,7 @@ func deleteUserDirect(ctx context.Context, userID string, purgeHome bool) error 
 		cascadeDeps := userops.Deps{
 			Domains:         domains,
 			DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
+			PortAllocations: repository.NewPortAllocationRepository(sharedDB),
 			Agent:           caller,
 			Log:             slog.Default(),
 		}
@@ -266,6 +267,7 @@ func deleteDomainDirect(ctx context.Context, domainID string) (d *models.Domain,
 	deps := userops.Deps{
 		Domains:         domains,
 		DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
+		PortAllocations: repository.NewPortAllocationRepository(sharedDB),
 		Agent:           caller,
 		Log:             sharedLog,
 	}

--- a/panel-api/cmd/server/domain_cmd.go
+++ b/panel-api/cmd/server/domain_cmd.go
@@ -91,6 +91,7 @@ func newDomainListCmd() *cobra.Command {
 
 func newDomainCreateCmd() *cobra.Command {
 	var name, userID, docRoot string
+	var reverseProxy bool
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -113,9 +114,10 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 			defer cancel()
 
 			d, warnings, err := createDomainDirect(ctx, cliDomainInput{
-				Name:    name,
-				UserID:  userID,
-				DocRoot: docRoot,
+				Name:         name,
+				UserID:       userID,
+				DocRoot:      docRoot,
+				ReverseProxy: reverseProxy,
 			})
 			if err != nil {
 				return err
@@ -129,6 +131,9 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 			}
 			cliAuditOK(ctx, "domain.create", "domain", d.ID, &d.UserID)
 			fmt.Printf("Domain created: %s (ID: %s)\n", d.Name, d.ID)
+			if d.ReverseProxyPort > 0 {
+				fmt.Printf("Reverse proxy: forwards to 127.0.0.1:%d — run your app on that port.\n", d.ReverseProxyPort)
+			}
 			if d.EmailEnabled {
 				selector := ""
 				if d.DkimSelector != nil {
@@ -147,6 +152,7 @@ no IP literals). Bare hostnames like 'invalid' are rejected.`,
 	cmd.Flags().StringVar(&name, "name", "", "Domain name (required)")
 	cmd.Flags().StringVar(&userID, "user", "", "User email, username, or ULID (required)")
 	cmd.Flags().StringVar(&docRoot, "doc-root", "", "Document root (optional, auto-generated if not provided)")
+	cmd.Flags().BoolVar(&reverseProxy, "reverse-proxy", false, "Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)")
 	return cmd
 }
 

--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -78,16 +78,19 @@ type AutomationConfig struct {
 	Databases     repository.DatabaseRepository
 	DatabaseUsers repository.DatabaseUserRepository
 	// FtpAccounts is reaped on the automation delete-cascade (JAB-265).
-	FtpAccounts   repository.FtpAccountRepository
-	DockerApps    repository.DockerAppRepository
-	KratosClient  *kratosclient.Client
-	BcryptCost    int
+	FtpAccounts  repository.FtpAccountRepository
+	DockerApps   repository.DockerAppRepository
+	KratosClient *kratosclient.Client
+	BcryptCost   int
 	// Narrow reconciler slices (typed-nil-safe: wire via the app's
 	// nil-guard, never a bare *reconciler.Reconciler that might be nil).
 	LimitsReconciler userops.LimitsReconciler
 	// DomainTeardowns persists the JAB-236 tombstones for durable
 	// domain teardown on the billing delete cascade.
 	DomainTeardowns repository.DomainTeardownRepository
+	// PortAllocations frees a domain's reverse-proxy loopback port (GH #1175)
+	// during the billing-cancel delete cascade. Optional.
+	PortAllocations repository.PortAllocationRepository
 	// DomainCreate carries the same deps the GUI domain handler uses, so
 	// JAB-233 account-create-with-domain runs the exact createDomainOp
 	// orchestration. Nil-safe: when unset (or its repos nil), a create that

--- a/panel-api/internal/api/automation_billing.go
+++ b/panel-api/internal/api/automation_billing.go
@@ -71,6 +71,7 @@ func billingUserOpsDeps(cfg AutomationConfig) userops.Deps {
 		Domains:         cfg.Domains,
 		DockerApps:      cfg.DockerApps,
 		DomainTeardowns: cfg.DomainTeardowns,
+		PortAllocations: cfg.PortAllocations,
 		Agent:           cfg.Agent,
 		KratosClient:    cfg.KratosClient,
 		BcryptCost:      cfg.BcryptCost,

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -28,6 +28,16 @@ import (
 // createDomainOp. Name MUST already be normalized (normalizeDomainName) and
 // HTML-stripped by the caller — the op validates it but does not re-normalize,
 // matching the create() source of truth.
+// GH #1175: reverse-proxy domains draw from a dedicated slice of the shared
+// port_allocations pool, disjoint from docker (10000-19999) + python
+// (20000-29999) during the incremental adoption.
+const (
+	reverseProxyPoolMin   = 30000
+	reverseProxyPoolMax   = 39999
+	reverseProxyBindIface = "127.0.0.1"
+	reverseProxyProto     = "tcp"
+)
+
 type createDomainInput struct {
 	OwnerID         string
 	Name            string
@@ -38,6 +48,9 @@ type createDomainInput struct {
 	SSLMode         string // "" → le
 	CreateWWW       bool
 	TempURLEnabled  bool
+	// ReverseProxy (GH #1175): make this a reverse-proxy domain — the panel
+	// allocates a loopback port and the vhost proxies `/` to it. No DocRoot/PHP.
+	ReverseProxy bool
 	// SkipInlineSSL omits the 30s inline ACME/self-signed attempt (JAB-233):
 	// the automation path lets the first reconciler tick bootstrap the cert,
 	// exactly like the `jabali domain create` CLI. GUI create leaves it false.
@@ -170,15 +183,37 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		UpdatedAt:       now,
 	}
 
+	// GH #1175: a reverse-proxy domain draws a loopback port from the shared
+	// allocator. Allocated BEFORE the insert (owner_id = the ULID above) so the
+	// row carries the port; released if the insert then fails so we don't leak.
+	if in.ReverseProxy {
+		if h.cfg.PortAllocations == nil {
+			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_unavailable", "reverse-proxy domains are not enabled on this host"}
+		}
+		port, aerr := h.cfg.PortAllocations.Allocate(ctx,
+			models.PortOwnerReverseProxy, domain.ID, reverseProxyBindIface, reverseProxyProto,
+			reverseProxyPoolMin, reverseProxyPoolMax)
+		if aerr != nil {
+			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_port_unavailable", "no free reverse-proxy port available; contact the administrator"}
+		}
+		domain.ReverseProxyPort = uint32(port)
+	}
+
 	// Preview-slug collision (dots→dashes is not injective): refuse the second
 	// enable of a colliding pair — first-wins would silently serve the wrong site.
 	if domain.TempURLEnabled {
 		if other := h.previewSlugConflict(ctx, domain.Name, ""); other != "" {
+			if in.ReverseProxy && h.cfg.PortAllocations != nil {
+				_ = h.cfg.PortAllocations.Release(ctx, models.PortOwnerReverseProxy, domain.ID)
+			}
 			return nil, &createDomainError{http.StatusConflict, "temp_url_slug_conflict", "preview URL would collide with " + other}
 		}
 	}
 
 	if err := h.cfg.Domains.Create(ctx, domain); err != nil {
+		if in.ReverseProxy && h.cfg.PortAllocations != nil {
+			_ = h.cfg.PortAllocations.Release(ctx, models.PortOwnerReverseProxy, domain.ID)
+		}
 		if isConflict(err) {
 			return nil, &createDomainError{http.StatusConflict, "domain_already_exists", ""}
 		}

--- a/panel-api/internal/api/domain_create_op.go
+++ b/panel-api/internal/api/domain_create_op.go
@@ -28,15 +28,6 @@ import (
 // createDomainOp. Name MUST already be normalized (normalizeDomainName) and
 // HTML-stripped by the caller — the op validates it but does not re-normalize,
 // matching the create() source of truth.
-// GH #1175: reverse-proxy domains draw from a dedicated slice of the shared
-// port_allocations pool, disjoint from docker (10000-19999) + python
-// (20000-29999) during the incremental adoption.
-const (
-	reverseProxyPoolMin   = 30000
-	reverseProxyPoolMax   = 39999
-	reverseProxyBindIface = "127.0.0.1"
-	reverseProxyProto     = "tcp"
-)
 
 type createDomainInput struct {
 	OwnerID         string
@@ -190,9 +181,7 @@ func createDomainOp(ctx context.Context, h *domainHandler, in createDomainInput)
 		if h.cfg.PortAllocations == nil {
 			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_unavailable", "reverse-proxy domains are not enabled on this host"}
 		}
-		port, aerr := h.cfg.PortAllocations.Allocate(ctx,
-			models.PortOwnerReverseProxy, domain.ID, reverseProxyBindIface, reverseProxyProto,
-			reverseProxyPoolMin, reverseProxyPoolMax)
+		port, aerr := h.cfg.PortAllocations.AllocateReverseProxy(ctx, domain.ID)
 		if aerr != nil {
 			return nil, &createDomainError{http.StatusServiceUnavailable, "reverse_proxy_port_unavailable", "no free reverse-proxy port available; contact the administrator"}
 		}

--- a/panel-api/internal/api/domains.go
+++ b/panel-api/internal/api/domains.go
@@ -38,6 +38,8 @@ type DomainHandlerConfig struct {
 	Packages        repository.PackageRepository
 	Agent           agent.AgentInterface
 	Reconciler      *reconciler.Reconciler
+	// PortAllocations (GH #1175): shared loopback-port pool for reverse-proxy domains.
+	PortAllocations repository.PortAllocationRepository
 	// DNSZones + DNSRecords feed the auto-enable-email path on create.
 	// Both optional — when unset, create proceeds without flipping email
 	// on (matches the pre-auto-enable behaviour). The explicit
@@ -101,6 +103,9 @@ type createDomainRequest struct {
 	// TempURLEnabled (migration 000243) opts the domain into a preview
 	// URL (<slug>.preview.<hostname>). Off by default.
 	TempURLEnabled bool `json:"temp_url_enabled"`
+	// ReverseProxy (GH #1175): create a reverse-proxy domain (panel allocates a
+	// loopback port; the vhost proxies / to it). No docroot/PHP.
+	ReverseProxy bool `json:"reverse_proxy"`
 	// SSLMode (GH #246) — le|self|none at create. 'custom' is rejected here:
 	// it needs a cert upload, set via PUT /domains/:id/ssl/custom after create.
 	// Empty defaults to 'le'.
@@ -678,6 +683,7 @@ func (h *domainHandler) create(c *gin.Context) {
 		SSLMode:         req.SSLMode,
 		CreateWWW:       req.CreateWWW,
 		TempURLEnabled:  req.TempURLEnabled,
+		ReverseProxy:    req.ReverseProxy,
 	})
 	if oerr != nil {
 		body := gin.H{"error": oerr.Code}
@@ -1153,6 +1159,7 @@ func (h *domainHandler) delete(c *gin.Context) {
 	_, err = userops.DeleteDomain(ctx, userops.Deps{
 		Domains:         h.cfg.Domains,
 		DomainTeardowns: h.cfg.DomainTeardowns,
+		PortAllocations: h.cfg.PortAllocations,
 		Agent:           h.cfg.Agent,
 	}, domain.ID, domain.Name, true)
 	if err != nil {

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -42,6 +42,9 @@ type UserHandlerConfig struct {
 	DockerApps  repository.DockerAppRepository
 	Mailboxes   repository.MailboxRepository
 	Packages    repository.PackageRepository
+	// PortAllocations frees a domain's reverse-proxy loopback port (GH #1175)
+	// during the account-delete cascade. Optional.
+	PortAllocations repository.PortAllocationRepository
 	// DomainTeardowns persists the JAB-236 tombstones that make the
 	// cascade's domain teardown durable across panel restarts.
 	DomainTeardowns repository.DomainTeardownRepository
@@ -586,6 +589,7 @@ func (h *userHandler) userOpsDeps() userops.Deps {
 		Domains:         h.cfg.Domains,
 		DockerApps:      h.cfg.DockerApps,
 		DomainTeardowns: h.cfg.DomainTeardowns,
+		PortAllocations: h.cfg.PortAllocations,
 		Agent:           h.cfg.Agent,
 		KratosClient:    h.cfg.KratosClient,
 		BcryptCost:      h.cfg.BcryptCost,

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -459,6 +459,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				KratosClient:     deps.KratosClient,
 				LimitsReconciler: automationLimitsReconciler(deps.Reconciler),
 				DomainTeardowns:  deps.DomainTeardowns,
+				PortAllocations:  repository.NewPortAllocationRepository(deps.DB),
 				DiskSnapshots:    repository.NewDiskUsageSnapshotRepository(deps.DB),
 				BWDaily:          deps.BWDaily,
 				Log:              deps.Log,
@@ -466,18 +467,19 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				// the DomainHandlerConfig below), so account-create with a
 				// `domain` runs createDomainOp with identical semantics.
 				DomainCreate: api.DomainHandlerConfig{
-					Domains:        deps.Domains,
-					Users:          deps.Users,
-					Packages:       deps.Packages,
-					Agent:          deps.Agent,
-					Reconciler:     deps.Reconciler,
-					SSLCerts:       deps.SSLCerts,
-					SharedCerts:    deps.SharedCerts,
-					DNSZones:       deps.DNSZones,
-					DNSRecords:     deps.DNSRecords,
-					ManagedIPs:     deps.ManagedIPs,
-					ServerSettings: deps.ServerSettings,
-					BWDaily:        deps.BWDaily,
+					Domains:         deps.Domains,
+					PortAllocations: repository.NewPortAllocationRepository(deps.DB),
+					Users:           deps.Users,
+					Packages:        deps.Packages,
+					Agent:           deps.Agent,
+					Reconciler:      deps.Reconciler,
+					SSLCerts:        deps.SSLCerts,
+					SharedCerts:     deps.SharedCerts,
+					DNSZones:        deps.DNSZones,
+					DNSRecords:      deps.DNSRecords,
+					ManagedIPs:      deps.ManagedIPs,
+					ServerSettings:  deps.ServerSettings,
+					BWDaily:         deps.BWDaily,
 				},
 			})
 		}
@@ -631,6 +633,7 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				FtpAccounts:     deps.FtpAccounts,
 				DockerApps:      deps.DockerApps,
 				DomainTeardowns: deps.DomainTeardowns,
+				PortAllocations: repository.NewPortAllocationRepository(deps.DB),
 				Mailboxes:       deps.Mailboxes,
 				Packages:        deps.Packages,
 				Reconciler:      deps.Reconciler,
@@ -662,7 +665,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 		}
 		if deps.Domains != nil {
 			api.RegisterDomainRoutes(v1, api.DomainHandlerConfig{
-				Domains: deps.Domains,
+				Domains:         deps.Domains,
+				PortAllocations: repository.NewPortAllocationRepository(deps.DB),
 				// JAB-236: durable delete — tombstone before the row goes.
 				DomainTeardowns: deps.DomainTeardowns,
 				Users:           deps.Users,

--- a/panel-api/internal/db/migrations/000269_port_allocations.down.sql
+++ b/panel-api/internal/db/migrations/000269_port_allocations.down.sql
@@ -1,0 +1,2 @@
+-- Reverse 000269: drop the shared port-allocation registry.
+DROP TABLE IF EXISTS port_allocations;

--- a/panel-api/internal/db/migrations/000269_port_allocations.up.sql
+++ b/panel-api/internal/db/migrations/000269_port_allocations.up.sql
@@ -1,0 +1,30 @@
+-- GH #1175: shared loopback-port allocator.
+--
+-- Today each feature that needs a local host port hand-partitions its own
+-- range in its own table (docker apps: docker_app_published_ports, 10000-19999;
+-- python apps: 20000-29999). Adding reverse-proxy domains as a third silo would
+-- compound that. This central registry is the one pool every current and future
+-- local-port consumer draws from: one row = one port reserved for one owner on
+-- one (bind_interface, protocol).
+--
+-- The DB UNIQUE on (bind_interface, port, protocol) makes the lowest-free
+-- allocator race-safe: two concurrent allocations that pick the same port under
+-- SELECT ... FOR UPDATE, or via a lost update, fail the second INSERT instead of
+-- double-binding. owner_kind + owner_id let a consumer release its port(s) on
+-- delete and look up "which port did I get".
+--
+-- Incremental adoption (ADR TBD): reverse_proxy uses this immediately; docker
+-- and python migrate onto it as follow-ups, reserving their existing ranges
+-- during the transition so live allocations never collide.
+CREATE TABLE port_allocations (
+  id             CHAR(26)     NOT NULL PRIMARY KEY,
+  port           INT UNSIGNED NOT NULL,
+  bind_interface VARCHAR(64)  NOT NULL DEFAULT '127.0.0.1',
+  protocol       VARCHAR(8)   NOT NULL DEFAULT 'tcp',
+  -- owner_kind: 'reverse_proxy' | 'docker_app' | 'python_app' | ...
+  owner_kind     VARCHAR(32)  NOT NULL,
+  owner_id       VARCHAR(64)  NOT NULL,
+  created_at     DATETIME     NOT NULL,
+  UNIQUE KEY uniq_portalloc_global (bind_interface, port, protocol),
+  KEY ix_portalloc_owner (owner_kind, owner_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/panel-api/internal/db/migrations/000270_domain_reverse_proxy_port.down.sql
+++ b/panel-api/internal/db/migrations/000270_domain_reverse_proxy_port.down.sql
@@ -1,0 +1,3 @@
+-- Reverse 000270: drop the tenant reverse-proxy port column.
+ALTER TABLE domains
+    DROP COLUMN reverse_proxy_port;

--- a/panel-api/internal/db/migrations/000270_domain_reverse_proxy_port.up.sql
+++ b/panel-api/internal/db/migrations/000270_domain_reverse_proxy_port.up.sql
@@ -1,0 +1,8 @@
+-- GH #1175: a tenant reverse-proxy domain proxies '/' to a panel-ALLOCATED
+-- loopback port (from port_allocations, owner_kind='reverse_proxy', migration
+-- 000269). 0 = a normal docroot/PHP domain (the default — no existing row
+-- changes). The port is panel-owned and never tenant-typed, so it sidesteps
+-- the JAB-65 SSRF block that (correctly) rejects arbitrary loopback proxy_pass
+-- targets from tenants.
+ALTER TABLE domains
+    ADD COLUMN reverse_proxy_port INT UNSIGNED NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/domain.go
+++ b/panel-api/internal/models/domain.go
@@ -169,6 +169,15 @@ type Domain struct {
 	// /home/<username>/public_html/<domain> at creation time.
 	DocRoot string `gorm:"type:varchar(512);not null;default:''" json:"doc_root"`
 
+	// ReverseProxyPort (GH #1175, migration 000270): when > 0 this is a tenant
+	// reverse-proxy domain — the vhost proxies `/` to http://127.0.0.1:<port>
+	// (+ standard forwarded headers) instead of serving DocRoot/PHP. The port is
+	// allocated from the shared port_allocations pool (owner_kind
+	// 'reverse_proxy', owner_id = this domain's ID) so a tenant never types a
+	// loopback target — the JAB-65 SSRF block on arbitrary loopback still applies
+	// to freeform nginx_rules. 0 = normal docroot/PHP domain.
+	ReverseProxyPort uint32 `gorm:"column:reverse_proxy_port;not null;default:0" json:"reverse_proxy_port"`
+
 	// IsEnabled controls whether the nginx vhost symlink exists in
 	// sites-enabled. Disabled domains still have their config on disk.
 	IsEnabled bool `gorm:"type:tinyint(1);not null;default:1" json:"is_enabled"`

--- a/panel-api/internal/models/port_allocation.go
+++ b/panel-api/internal/models/port_allocation.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// Owner kinds for a PortAllocation. The allocator is shared, so each consumer
+// tags its rows so releases + lookups stay scoped to it. GH #1175.
+const (
+	PortOwnerReverseProxy = "reverse_proxy"
+	PortOwnerDockerApp    = "docker_app"
+	PortOwnerPythonApp    = "python_app"
+)
+
+// PortAllocation is one loopback/host port reserved for one owner on one
+// (bind_interface, protocol). The shared registry every local-port consumer
+// draws from (GH #1175). The UNIQUE on (bind_interface, port, protocol) is what
+// makes the lowest-free allocator race-safe.
+type PortAllocation struct {
+	ID            string    `gorm:"column:id;type:char(26);primaryKey" json:"id"`
+	Port          uint32    `gorm:"column:port;not null" json:"port"`
+	BindInterface string    `gorm:"column:bind_interface;type:varchar(64);not null;default:'127.0.0.1'" json:"bind_interface"`
+	Protocol      string    `gorm:"column:protocol;type:varchar(8);not null;default:'tcp'" json:"protocol"`
+	OwnerKind     string    `gorm:"column:owner_kind;type:varchar(32);not null" json:"owner_kind"`
+	OwnerID       string    `gorm:"column:owner_id;type:varchar(64);not null" json:"owner_id"`
+	CreatedAt     time.Time `gorm:"column:created_at;not null" json:"created_at"`
+}
+
+// TableName pins the table (GORM would otherwise pluralize to "port_allocations"
+// — which is correct here, but pin it so a future rename can't drift).
+func (PortAllocation) TableName() string { return "port_allocations" }

--- a/panel-api/internal/nginxrules/compile.go
+++ b/panel-api/internal/nginxrules/compile.go
@@ -15,11 +15,15 @@ import (
 )
 
 func Compile(d *models.Domain) string {
-	if d == nil || len(d.NginxRules) == 0 {
+	if d == nil {
+		return ""
+	}
+	rules := reverseProxyRules(d)
+	if len(rules) == 0 {
 		return ""
 	}
 	var b strings.Builder
-	for _, r := range d.NginxRules {
+	for _, r := range rules {
 		switch r.Type {
 		case "custom_header":
 			alwaysSuffix := ""
@@ -130,6 +134,49 @@ func Compile(d *models.Domain) string {
 		}
 	}
 	return b.String()
+}
+
+// reverseProxyRules returns the domain's persisted NginxRules with the
+// GH #1175 reverse-proxy entry synthesised in-memory when the domain
+// carries a reverse_proxy_port. The synthesised rule is NEVER persisted:
+// the NginxRules array is tenant-editable and goes through the JAB-65
+// SSRF validator on every Rule Builder edit, so a stored loopback
+// proxy_pass would either break subsequent tenant edits or become the
+// exact seam an attacker probes to keep a 127.0.0.1 target while swapping
+// the port. Re-deriving it here from the panel-owned column on every
+// compile means it survives cert renewal and reconciler ticks by
+// construction, and the tenant can neither delete nor repoint it.
+//
+// Defensive skip: if the tenant already has a root proxy_pass rule
+// (path "/"), synthesising a second would emit a duplicate `location /`
+// and fail nginx -t. The tenant's explicit rule wins; the create handler
+// rejects the combination up front so this is belt-and-suspenders.
+func reverseProxyRules(d *models.Domain) []models.NginxRule {
+	if d.ReverseProxyPort == 0 {
+		return d.NginxRules
+	}
+	for _, r := range d.NginxRules {
+		if r.Type == "proxy_pass" && rootPath(r.Path) {
+			return d.NginxRules
+		}
+	}
+	ws := true
+	synthetic := models.NginxRule{
+		Type:      "proxy_pass",
+		Path:      "/",
+		Target:    fmt.Sprintf("http://127.0.0.1:%d", d.ReverseProxyPort),
+		Websocket: &ws,
+	}
+	// Copy so append never mutates the domain's backing array.
+	out := make([]models.NginxRule, 0, len(d.NginxRules)+1)
+	out = append(out, d.NginxRules...)
+	return append(out, synthetic)
+}
+
+// rootPath reports whether an nginx location path targets the site root.
+func rootPath(p string) bool {
+	p = strings.TrimSpace(p)
+	return p == "/" || p == ""
 }
 
 func quoteNginxString(s string) string {

--- a/panel-api/internal/nginxrules/compile_test.go
+++ b/panel-api/internal/nginxrules/compile_test.go
@@ -242,20 +242,41 @@ func TestCompile(t *testing.T) {
 			want:     `add_header X-Path "C:\\path\\to\\file";`,
 			wantBool: true,
 		},
+		{
+			// GH #1175: a reverse-proxy domain carries no persisted rule;
+			// the proxy_pass block is synthesised from the column.
+			name: "reverse_proxy_port synthesises a root proxy_pass",
+			domain: &models.Domain{
+				ReverseProxyPort: 30000,
+			},
+			want:     "proxy_pass http://127.0.0.1:30000;",
+			wantBool: true,
+		},
+		{
+			name: "reverse_proxy_port sets the forwarding headers",
+			domain: &models.Domain{
+				ReverseProxyPort: 34567,
+			},
+			want:     "proxy_set_header X-Forwarded-Proto $scheme;",
+			wantBool: true,
+		},
+		{
+			name: "no rules and no reverse proxy is empty",
+			domain: &models.Domain{
+				ReverseProxyPort: 0,
+			},
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Compile(tt.domain)
 			if tt.wantBool {
-				// Check if want string is contained in result
-				if tt.want != "" && len(got) > 0 {
-					// For "contains" checks, just verify it's not empty
-					if got == "" {
-						t.Errorf("Compile(%v) = %q, want non-empty string", tt.domain, got)
-					}
-				} else if tt.want == "" && got != "" {
-					t.Errorf("Compile(%v) = %q, want empty string", tt.domain, got)
+				// "contains" check: the emitted vhost fragment must carry the
+				// expected directive verbatim.
+				if !strings.Contains(got, tt.want) {
+					t.Errorf("Compile(%v) = %q, want it to contain %q", tt.domain, got, tt.want)
 				}
 			} else {
 				// Exact match
@@ -411,4 +432,38 @@ func TestCompile_StaticAlias(t *testing.T) {
 			t.Errorf("compiled output missing %q:\n%s", want, got)
 		}
 	}
+}
+
+// TestReverseProxySynthesisEdges covers GH #1175 behaviour the contains/exact
+// table can't express: suppression when the tenant already has a root
+// proxy_pass, and that synthesis never mutates the domain's backing slice.
+func TestReverseProxySynthesisEdges(t *testing.T) {
+	t.Run("explicit root proxy_pass suppresses the synthetic loopback one", func(t *testing.T) {
+		d := &models.Domain{
+			ReverseProxyPort: 30001,
+			NginxRules: []models.NginxRule{
+				{Type: "proxy_pass", Path: "/", Target: "http://example.test:8080"},
+			},
+		}
+		got := Compile(d)
+		if strings.Contains(got, "127.0.0.1:30001") {
+			t.Fatalf("synthetic loopback proxy_pass should be suppressed, got:\n%s", got)
+		}
+		if strings.Count(got, "location ^~ /") != 1 {
+			t.Fatalf("want exactly one root location, got:\n%s", got)
+		}
+	})
+
+	t.Run("synthesis does not mutate the domain NginxRules slice", func(t *testing.T) {
+		d := &models.Domain{
+			ReverseProxyPort: 30002,
+			NginxRules: []models.NginxRule{
+				{Type: "custom_header", Name: "X-A", Value: "1"},
+			},
+		}
+		_ = Compile(d)
+		if len(d.NginxRules) != 1 {
+			t.Fatalf("Compile mutated NginxRules: len=%d", len(d.NginxRules))
+		}
+	})
 }

--- a/panel-api/internal/repository/port_allocation_repository.go
+++ b/panel-api/internal/repository/port_allocation_repository.go
@@ -1,0 +1,127 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// ErrPortPoolExhausted — no free port in the requested pool for this
+// (bind_interface, protocol). GH #1175.
+var ErrPortPoolExhausted = errors.New("no free port in the allocation pool")
+
+// PortAllocationRepository is the shared loopback/host-port allocator every
+// local-port consumer draws from (docker, python, reverse-proxy, …). GH #1175.
+type PortAllocationRepository interface {
+	// Allocate reserves the lowest free port in [poolMin, poolMax] for
+	// (ownerKind, ownerID) on (bindInterface, protocol). Idempotent: if this
+	// owner already holds a port for that interface+protocol, its existing port
+	// is returned instead of a second reservation.
+	Allocate(ctx context.Context, ownerKind, ownerID, bindInterface, protocol string, poolMin, poolMax int) (int, error)
+	// Release frees every port held by (ownerKind, ownerID). Safe to call when
+	// the owner holds none.
+	Release(ctx context.Context, ownerKind, ownerID string) error
+	// PortForOwner returns the port held by (ownerKind, ownerID) on
+	// (bindInterface, protocol), and ok=false when none is held.
+	PortForOwner(ctx context.Context, ownerKind, ownerID, bindInterface, protocol string) (int, bool, error)
+}
+
+// lowestFreePort returns the lowest port in [poolMin, poolMax] not present in
+// used, or 0 when the pool is exhausted. Pure so the allocation core is
+// unit-tested without a DB.
+func lowestFreePort(used []int, poolMin, poolMax int) int {
+	usedSet := make(map[int]struct{}, len(used))
+	for _, p := range used {
+		usedSet[p] = struct{}{}
+	}
+	for p := poolMin; p <= poolMax; p++ {
+		if _, taken := usedSet[p]; !taken {
+			return p
+		}
+	}
+	return 0
+}
+
+type portAllocationRepo struct{ db *gorm.DB }
+
+func NewPortAllocationRepository(db *gorm.DB) PortAllocationRepository {
+	return &portAllocationRepo{db: db}
+}
+
+func (r *portAllocationRepo) Allocate(ctx context.Context, ownerKind, ownerID, bindInterface, protocol string, poolMin, poolMax int) (int, error) {
+	var port int
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Idempotent: an owner that already holds a port for this
+		// interface+protocol gets the same one back (re-provisioning must not
+		// leak a second port).
+		var existing models.PortAllocation
+		e := tx.Where("owner_kind = ? AND owner_id = ? AND bind_interface = ? AND protocol = ?",
+			ownerKind, ownerID, bindInterface, protocol).First(&existing).Error
+		if e == nil {
+			port = int(existing.Port)
+			return nil
+		}
+		if !errors.Is(e, gorm.ErrRecordNotFound) {
+			return e
+		}
+		// Lock the (interface, protocol) rows so a concurrent allocation can't
+		// pick the same lowest-free gap; the UNIQUE(bind_interface, port,
+		// protocol) is the final backstop.
+		var used []int
+		if err := tx.Model(&models.PortAllocation{}).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("bind_interface = ? AND protocol = ?", bindInterface, protocol).
+			Order("port ASC").
+			Pluck("port", &used).Error; err != nil {
+			return err
+		}
+		chosen := lowestFreePort(used, poolMin, poolMax)
+		if chosen == 0 {
+			return ErrPortPoolExhausted
+		}
+		row := &models.PortAllocation{
+			ID:            ids.NewULID(),
+			Port:          uint32(chosen),
+			BindInterface: bindInterface,
+			Protocol:      protocol,
+			OwnerKind:     ownerKind,
+			OwnerID:       ownerID,
+			CreatedAt:     time.Now().UTC(),
+		}
+		if err := tx.Create(row).Error; err != nil {
+			return err
+		}
+		port = chosen
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+func (r *portAllocationRepo) Release(ctx context.Context, ownerKind, ownerID string) error {
+	return r.db.WithContext(ctx).
+		Where("owner_kind = ? AND owner_id = ?", ownerKind, ownerID).
+		Delete(&models.PortAllocation{}).Error
+}
+
+func (r *portAllocationRepo) PortForOwner(ctx context.Context, ownerKind, ownerID, bindInterface, protocol string) (int, bool, error) {
+	var row models.PortAllocation
+	err := r.db.WithContext(ctx).
+		Where("owner_kind = ? AND owner_id = ? AND bind_interface = ? AND protocol = ?",
+			ownerKind, ownerID, bindInterface, protocol).First(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return int(row.Port), true, nil
+}

--- a/panel-api/internal/repository/port_allocation_repository.go
+++ b/panel-api/internal/repository/port_allocation_repository.go
@@ -16,6 +16,17 @@ import (
 // (bind_interface, protocol). GH #1175.
 var ErrPortPoolExhausted = errors.New("no free port in the allocation pool")
 
+// GH #1175 reverse-proxy port pool — a dedicated slice of port_allocations,
+// disjoint from docker (10000-19999) + python (20000-29999) during the
+// incremental adoption. Exported so both create paths (the HTTP handler and
+// the `jabali domain create` CLI) draw from the identical pool.
+const (
+	ReverseProxyPoolMin   = 30000
+	ReverseProxyPoolMax   = 39999
+	ReverseProxyBindIface = "127.0.0.1"
+	ReverseProxyProto     = "tcp"
+)
+
 // PortAllocationRepository is the shared loopback/host-port allocator every
 // local-port consumer draws from (docker, python, reverse-proxy, …). GH #1175.
 type PortAllocationRepository interface {
@@ -24,6 +35,12 @@ type PortAllocationRepository interface {
 	// owner already holds a port for that interface+protocol, its existing port
 	// is returned instead of a second reservation.
 	Allocate(ctx context.Context, ownerKind, ownerID, bindInterface, protocol string, poolMin, poolMax int) (int, error)
+	// AllocateReverseProxy reserves a loopback port for a GH #1175 reverse-proxy
+	// domain (owner_kind='reverse_proxy') from the dedicated pool on
+	// 127.0.0.1/tcp. Thin wrapper over Allocate so the pool bounds live in one
+	// place and every create path draws from the same range. Idempotent per
+	// domainID.
+	AllocateReverseProxy(ctx context.Context, domainID string) (int, error)
 	// Release frees every port held by (ownerKind, ownerID). Safe to call when
 	// the owner holds none.
 	Release(ctx context.Context, ownerKind, ownerID string) error
@@ -104,6 +121,11 @@ func (r *portAllocationRepo) Allocate(ctx context.Context, ownerKind, ownerID, b
 		return 0, err
 	}
 	return port, nil
+}
+
+func (r *portAllocationRepo) AllocateReverseProxy(ctx context.Context, domainID string) (int, error) {
+	return r.Allocate(ctx, models.PortOwnerReverseProxy, domainID,
+		ReverseProxyBindIface, ReverseProxyProto, ReverseProxyPoolMin, ReverseProxyPoolMax)
 }
 
 func (r *portAllocationRepo) Release(ctx context.Context, ownerKind, ownerID string) error {

--- a/panel-api/internal/repository/port_allocation_repository_test.go
+++ b/panel-api/internal/repository/port_allocation_repository_test.go
@@ -1,0 +1,27 @@
+package repository
+
+import "testing"
+
+// GH #1175: the shared allocator hands out the lowest free port in the pool,
+// skipping taken ones and returning 0 (exhausted) when the pool is full.
+func TestLowestFreePort(t *testing.T) {
+	cases := []struct {
+		name           string
+		used           []int
+		min, max, want int
+	}{
+		{"empty pool → min", nil, 30000, 30002, 30000},
+		{"lowest gap at start", []int{30001, 30002}, 30000, 30002, 30000},
+		{"fills the first gap", []int{30000, 30002}, 30000, 30002, 30001},
+		{"next after a run", []int{30000, 30001}, 30000, 30002, 30002},
+		{"exhausted → 0", []int{30000, 30001, 30002}, 30000, 30002, 0},
+		{"ignores out-of-pool used", []int{9999, 40000}, 30000, 30001, 30000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lowestFreePort(tc.used, tc.min, tc.max); got != tc.want {
+				t.Fatalf("lowestFreePort(%v, %d, %d) = %d, want %d", tc.used, tc.min, tc.max, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/userops/domain_delete.go
+++ b/panel-api/internal/userops/domain_delete.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 )
 
 // JAB-236 — durable domain deletion.
@@ -102,6 +104,15 @@ func DeleteDomain(ctx context.Context, d Deps, domainID, domainName string, asyn
 			_ = d.DomainTeardowns.Delete(ctx, domainName)
 		}
 		return false, err
+	}
+
+	// GH #1175: the row is gone — free any reverse-proxy loopback port it
+	// reserved back to the shared allocator pool. Idempotent + owner-scoped:
+	// a normal docroot domain holds no allocation so this is a no-op. Placed
+	// on this single shared delete path so no caller (API, account cascade,
+	// billing cancel, sweep-driven retry) can bypass it.
+	if d.PortAllocations != nil {
+		_ = d.PortAllocations.Release(ctx, models.PortOwnerReverseProxy, domainID)
 	}
 
 	finish := func(ctx context.Context) bool {

--- a/panel-api/internal/userops/userops.go
+++ b/panel-api/internal/userops/userops.go
@@ -45,6 +45,13 @@ type Deps struct {
 	// deletion durable. Optional: nil keeps the pre-tombstone behaviour
 	// (teardown attempted once, not retried).
 	DomainTeardowns repository.DomainTeardownRepository
+	// PortAllocations releases a domain's shared loopback-port reservation
+	// (GH #1175 reverse proxy) when the row is deleted. Optional: nil skips
+	// the release (a domain with no allocation is a no-op regardless). Wired
+	// into DeleteDomain — the single shared row-delete path — so the API,
+	// account-cascade, and billing-cancel deletes all release without any
+	// caller having to remember to.
+	PortAllocations repository.PortAllocationRepository
 	Agent           AgentCaller
 	KratosClient    *kratosclient.Client
 	BcryptCost      int

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -4,7 +4,7 @@
 // auto-generates doc_root when blank. Post-M21: Form.useForm +
 // useCreateMutation, no Refine wrappers.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Checkbox, Form, Input, Select, Typography } from "antd";
+import { Button, Card, Checkbox, Form, Input, Modal, Select, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
@@ -22,9 +22,12 @@ export type DomainCreateInput = {
   create_www?: boolean;
   temp_url_enabled?: boolean;
   ssl_mode?: string;
+  // GH #1175: reverse-proxy domain — the panel reserves a loopback port and
+  // proxies the domain to it. The assigned port comes back on create.
+  reverse_proxy?: boolean;
 };
 
-type DomainCreated = { id: string };
+type DomainCreated = { id: string; reverse_proxy_port?: number };
 
 export const DomainCreate = () => {
   const { t } = useTranslation();
@@ -46,8 +49,16 @@ export const DomainCreate = () => {
 
   const handleFinish = async (values: DomainCreateInput) => {
     try {
-      await createMutation.mutateAsync(values);
+      const created = await createMutation.mutateAsync(values);
       feedback.message.success("Domain created");
+      // GH #1175: the assigned loopback port is the one thing the operator
+      // must act on, so surface it in a modal that stays until dismissed.
+      if (values.reverse_proxy && created?.reverse_proxy_port) {
+        Modal.success({
+          title: "Reverse proxy ready",
+          content: `Run the app on 127.0.0.1:${created.reverse_proxy_port}. The panel proxies ${values.name} to that port and keeps the vhost in sync across TLS renewals.`,
+        });
+      }
       navigate("/jabali-admin/domains");
     } catch (err: unknown) {
       const msg =
@@ -176,6 +187,18 @@ export const DomainCreate = () => {
           tooltip="Serves the site at <domain-slug>.preview.<panel-hostname> so it can be checked before DNS points here."
         >
           <Checkbox>Enable preview URL</Checkbox>
+        </Form.Item>
+
+        {/* GH #1175: reverse-proxy option. The panel reserves a conflict-free
+            loopback port and writes the proxy_pass vhost; the assigned port is
+            shown after the domain is created. */}
+        <Form.Item
+          name="reverse_proxy"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Turns this domain into a reverse proxy instead of a website. The panel reserves a local port and forwards the domain to it — run an app (a Docker container, Node service, …) on that port. The assigned port is shown after the domain is created."
+        >
+          <Checkbox>Set up as a reverse proxy (forward to a local app port)</Checkbox>
         </Form.Item>
 
         <Form.Item>

--- a/panel-ui/src/shells/admin/domains/DomainCreate.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainCreate.tsx
@@ -4,7 +4,7 @@
 // auto-generates doc_root when blank. Post-M21: Form.useForm +
 // useCreateMutation, no Refine wrappers.
 import { useTranslation } from "react-i18next";
-import { Button, Card, Checkbox, Form, Input, Modal, Select, Typography } from "antd";
+import { Button, Card, Checkbox, Form, Input, Select, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "../../../apiClient";
@@ -54,7 +54,7 @@ export const DomainCreate = () => {
       // GH #1175: the assigned loopback port is the one thing the operator
       // must act on, so surface it in a modal that stays until dismissed.
       if (values.reverse_proxy && created?.reverse_proxy_port) {
-        Modal.success({
+        feedback.modal.success({
           title: "Reverse proxy ready",
           content: `Run the app on 127.0.0.1:${created.reverse_proxy_port}. The panel proxies ${values.name} to that port and keeps the vhost in sync across TLS renewals.`,
         });

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,7 +1,7 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space } from "antd";
+import { Button, Checkbox, Drawer, Form, Grid, Input, Modal, Select, Space } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
@@ -15,8 +15,12 @@ type UserDomainCreateInput = {
   temp_url_enabled?: boolean;
   create_www?: boolean;
   ssl_mode?: string;
+  // GH #1175: reverse-proxy domain. When true the panel reserves a loopback
+  // port and proxies the domain to it (no docroot/PHP). The assigned port
+  // comes back on the create response.
+  reverse_proxy?: boolean;
 };
-type DomainCreated = { id: string };
+type DomainCreated = { id: string; reverse_proxy_port?: number };
 
 export interface UserDomainDrawerProps {
   open: boolean;
@@ -40,8 +44,17 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
 
   const handleFinish = async (values: UserDomainCreateInput) => {
     try {
-      await createMutation.mutateAsync(values);
+      const created = await createMutation.mutateAsync(values);
       feedback.message.success("Domain added");
+      // GH #1175: the assigned loopback port is the one piece of info the user
+      // must act on (bind their app to it), so surface it in a modal that
+      // stays until dismissed rather than a toast they might miss.
+      if (values.reverse_proxy && created?.reverse_proxy_port) {
+        Modal.success({
+          title: "Reverse proxy ready",
+          content: `Run your app on 127.0.0.1:${created.reverse_proxy_port}. The panel proxies ${values.name} to that port and keeps the vhost in sync across TLS renewals.`,
+        });
+      }
       onClose();
     } catch (err) {
       feedback.message.error(err instanceof Error ? err.message : "Failed to add domain");
@@ -144,6 +157,18 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
           tooltip="Serves the site at a preview address under this server's hostname, so you can check it before your domain's DNS points here."
         >
           <Checkbox>Enable preview URL</Checkbox>
+        </Form.Item>
+
+        {/* GH #1175: reverse-proxy option. The panel reserves a conflict-free
+            loopback port and writes the proxy_pass vhost; the assigned port is
+            shown after the domain is added. */}
+        <Form.Item
+          name="reverse_proxy"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Turns this domain into a reverse proxy instead of a website. The panel reserves a local port and forwards the domain to it — run your own app (a Docker container, Node service, …) on that port. The assigned port is shown after you add the domain."
+        >
+          <Checkbox>Set up as a reverse proxy (run your own app on a local port)</Checkbox>
         </Form.Item>
 
         <Form.Item>

--- a/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainDrawer.tsx
@@ -1,7 +1,7 @@
 // UserDomainDrawer — tenant Add-domain Drawer (replaces the
 // /jabali-panel/domains/create page route).
 import { useTranslation } from "react-i18next";
-import { Button, Checkbox, Drawer, Form, Grid, Input, Modal, Select, Space } from "antd";
+import { Button, Checkbox, Drawer, Form, Grid, Input, Select, Space } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useEffect } from "react";
 
@@ -50,7 +50,7 @@ export const UserDomainDrawer = ({ open, onClose }: UserDomainDrawerProps) => {
       // must act on (bind their app to it), so surface it in a modal that
       // stays until dismissed rather than a toast they might miss.
       if (values.reverse_proxy && created?.reverse_proxy_port) {
-        Modal.success({
+        feedback.modal.success({
           title: "Reverse proxy ready",
           content: `Run your app on 127.0.0.1:${created.reverse_proxy_port}. The panel proxies ${values.name} to that port and keeps the vhost in sync across TLS renewals.`,
         });

--- a/panel-ui/src/shells/user/domains/UserDomainList.tsx
+++ b/panel-ui/src/shells/user/domains/UserDomainList.tsx
@@ -158,6 +158,8 @@ export type Domain = {
   is_enabled: boolean;
   temp_url_enabled?: boolean;
   temp_url?: string | null;
+  // GH #1175: >0 marks a reverse-proxy domain forwarding to this loopback port.
+  reverse_proxy_port?: number;
   nginx_custom_directives: string;
   redirect_all_to?: string | null;
   redirect_all_type?: string | null;
@@ -261,6 +263,15 @@ export const UserDomainList = () => {
             render={(name: string, record: Domain) => (
               <>
                 {renderDomainCell(name, record.doc_root)}
+                {record.reverse_proxy_port ? (
+                  <div>
+                    <Tooltip title={`Reverse proxy — run your app on 127.0.0.1:${record.reverse_proxy_port}`}>
+                      <Tag color="cyan" style={{ fontSize: 12 }}>
+                        proxy → :{record.reverse_proxy_port}
+                      </Tag>
+                    </Tooltip>
+                  </div>
+                ) : null}
                 {record.temp_url && (
                   <div>
                     <Typography.Link


### PR DESCRIPTION
## What & why

GH #1175 (mrlp57): a create-domain option to point a domain at a locally-running
app ("`http://127.0.0.1:6875`") and have the panel write the `proxy_pass` vhost.
The manual Rule Builder path errors ("not allowed") because the JAB-65 SSRF guard
**correctly** blocks tenant-supplied loopback `proxy_pass` targets.

This ships reverse proxy through the panel-owned side of that boundary, plus the
**shared port allocator** so reverse-proxy / docker / future local-port features
never hand out colliding ports (per the design discussed on the issue).

## How

- **Shared allocator** (`port_allocations`, migration 000269): transactional
  lowest-free allocation, `owner_kind`-tagged, `UNIQUE(bind_interface,port,protocol)`
  backstop. Reverse-proxy pool 30000-39999 (docker 10000-19999, python 20000-29999).
- **`domains.reverse_proxy_port`** (migration 000270): the loopback port a domain
  reserves. `0` = a normal docroot/PHP domain, so every existing row is untouched.
- **Create**: a `reverse_proxy` flag allocates a port *before* the insert (owner =
  the new domain id) and releases it on any preview-conflict / insert failure.
- **Render — no new agent code, no `writeVhost` surgery**: `nginxrules.Compile`
  synthesises the `proxy_pass` rule **in-memory** from the column. It is **never
  persisted** — the `NginxRules` array is tenant-editable and goes through the
  SSRF validator on every Rule Builder edit, so a stored loopback target would
  either break subsequent tenant edits or become the exact seam to keep a
  `127.0.0.1` target while swapping the port. Re-deriving it every compile means
  it **survives cert renewals + reconciler ticks by construction** (mrlp57's
  explicit requirement), and the tenant can neither delete nor repoint it. Reuses
  the existing emitter, so the block carries `Host` / `X-Real-IP` / `X-Forwarded-*`
  + websocket — mrlp57's exact ask.
- **Release** lives in `userops.DeleteDomain` (the single shared row-delete path),
  so the API delete, account-delete cascade, and billing-cancel cascade all free
  the port — none can bypass it.
- **UI**: a "Set up as a reverse proxy" checkbox at the bottom of the tenant
  Add-domain drawer; the panel-assigned port is shown in a modal on create (the
  one thing the user must act on) and as a persistent `proxy → :<port>` tag in the
  domain list.

`reverse_proxy_port` is **absent from the domain Update Select-allowlist**, so a
tenant can never write it — it is set once at create by the allocator.

## Design note — panel-assigned vs user-typed port

mrlp57 asked to *type* their app's port (`6875`). This PR implements the
**panel-assigned** variant (the allocator hands out a conflict-free port), which is
the no-collision design discussed on the issue. A "specify your own port" mode is a
trivial follow-up — the `UNIQUE` constraint already makes allocate-specific-port a
few lines. Flagging so we can confirm which UX we want before closing #1175.

## Security considerations

- The synthesised target is `http://127.0.0.1:<panel-allocated-port>`; the port is
  **only** settable by the allocator at create and is not in the Update allowlist,
  so it is never tenant-controllable.
- **Host-global loopback (parity with existing docker-app reverse proxy):** on a
  shared host any OS user can bind a *free* loopback TCP port, so if tenant A's app
  is down another tenant could bind A's port and receive A's proxied traffic. This
  is **the same posture the existing docker-app reverse-proxy already ships** — this
  PR extends it to plain domains, it does not introduce a new class. A proper fix
  (per-user loopback alias / netns-scoped ports) is a platform hardening follow-up,
  tracked separately.

## Known limitation

A tenant who, *after* enabling reverse proxy, adds a root `proxy_pass` rule (public
target) or a custom `location /` directive would render two root locations. The
rule case is handled (synthesis defers to the tenant's explicit rule); the custom-
directive case fails `nginx -t` and the agent keeps the prior good vhost (fail-safe).
A hard guard in the Rule Builder / custom-directives validator is a small follow-up.

## Test plan

- [x] `go build ./...`, `go test ./internal/{nginxrules,userops,repository,api,app,reconciler}` green
- [x] `nginxrules.Compile`: synthesis + forwarding headers + suppression-on-explicit-root + no-slice-mutation
- [x] `TestLowestFreePort` (allocator pure helper)
- [x] `npx tsc -b` clean; no E2E selector collisions
- [ ] Box-verify on testserver: create a reverse-proxy domain, confirm `port_allocations` row + `reverse_proxy_port` set + rendered vhost has `location ^~ / { proxy_pass http://127.0.0.1:<port>; }` + a dummy app on that port serves through the domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)