### PR TITLE
feat(security): place FTPS session workers in the tenant cgroup slice (JAB-263, epic phase D)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -1937,6 +1937,7 @@ jabali domain create [flags]
 
 - `--doc-root` — Document root (optional, auto-generated if not provided)
 - `--name` — Domain name (required)
+- `--reverse-proxy` — Make this a reverse-proxy domain: allocate a loopback port and proxy '/' to it (GH #1175)
 - `--user` — User email, username, or ULID (required)
 
 #### `jabali domain delete`

--- a/install.sh
+++ b/install.sh
@@ -883,6 +883,11 @@ connect_from_port_20=YES
 idle_session_timeout=300
 data_connection_timeout=120
 pam_service_name=vsftpd-jabali
+# JAB-263 phase D: open a PAM session so the vsftpd-jabali `session` stack runs
+# — that is what fires jabali-ftp-session-cgroup to place the worker in the
+# tenant slice. vsftpd defaults session_support=NO and then SKIPS the session
+# stack entirely, so the hook never runs without this.
+session_support=YES
 # Every login chroots to the passwd home (the subaccount home_path). The
 # home is tenant-writable by design, hence allow_writeable_chroot — the
 # accounts are file-transfer-only aliases, not shell users.
@@ -947,6 +952,11 @@ VSFTPDEOF
 # conffile stays untouched (no dpkg conffile prompts on upgrade). Gates on
 # jabali-ftp membership; NO pam_shells (see install_module_ftp header).
 install_vsftpd_pam() {
+  # JAB-263 phase D: the PAM session hook that places the FTPS worker in the
+  # owning tenant's cgroup slice.
+  install -d -m 0755 /usr/local/libexec/jabali
+  install -m 0755 "$REPO_DIR/install/ftp/jabali-ftp-session-cgroup" \
+    /usr/local/libexec/jabali/jabali-ftp-session-cgroup
   cat > /etc/pam.d/vsftpd-jabali <<'PAMEOF'
 # Managed by jabali-panel install.sh (ftp module, GH #1053).
 # Only members of jabali-ftp may authenticate; membership is the
@@ -956,9 +966,14 @@ auth    required pam_unix.so
 account required pam_succeed_if.so user ingroup jabali-ftp quiet
 account required pam_unix.so
 session required pam_permit.so
+# JAB-263: move the FTPS worker into the owning tenant's jabali-user-<t>.slice
+# so per-tenant CPU/memory/task limits apply. `optional` + the helper always
+# exits 0 => this can never block a login (fail open — it is accounting, not
+# access control).
+session optional pam_exec.so quiet /usr/local/libexec/jabali/jabali-ftp-session-cgroup
 PAMEOF
   chmod 0644 /etc/pam.d/vsftpd-jabali
-  _ok "vsftpd PAM service installed (jabali-ftp members only)"
+  _ok "vsftpd PAM service installed (jabali-ftp members only, cgroup-placed)"
 }
 
 # install_ftp_firewall_rules — open 21 + the passive range. Only ever

--- a/install/ftp/jabali-ftp-session-cgroup
+++ b/install/ftp/jabali-ftp-session-cgroup
@@ -1,0 +1,64 @@
+#!/bin/sh
+# jabali-ftp-session-cgroup — vsftpd PAM session hook (JAB-263, epic phase D).
+#
+# Moves the vsftpd per-session worker into a leaf cgroup under the OWNING
+# tenant's jabali-user-<tenant>.slice, so the M18 per-tenant CPU / memory / task
+# limits enforce on FTPS transfers. Without this the worker inherits
+# vsftpd.service's cgroup and its resource use is unaccounted against the tenant
+# (JAB-263 cross-tenant DoS path).
+#
+# FAIL-OPEN by design: an accounting hook must NEVER break a login. Every step
+# is best-effort and the script ALWAYS exits 0; it is also wired
+# `session optional` in the PAM stack. A failure here degrades to the pre-phase-D
+# behavior (worker under vsftpd.service), never a denied login.
+#
+# Empirically validated on a live box (2026-08-19): a leaf sub-cgroup accepts
+# the PID, survives `systemctl daemon-reload` and tenant unit restarts, and the
+# parent slice's pids.max/memory.max enforce on it.
+set +e
+umask 022
+
+user="${PAM_USER:-}"
+[ -n "$user" ] || exit 0
+
+# Pre-comma segment of the GECOS field — the panel's ownership marker.
+gecos=$(getent passwd "$user" 2>/dev/null | cut -d: -f5 | cut -d, -f1)
+
+case "$gecos" in
+  jabali-ftp-account=*)
+    # Owner-encoded subaccount (current format, incl. isolated own-uid accounts).
+    tenant="${gecos#jabali-ftp-account=}"
+    ;;
+  jabali-ftp-account)
+    # Bare-marker legacy same-uid alias: the owner is the non-marker passwd
+    # entry sharing this uid.
+    uid=$(id -u "$user" 2>/dev/null)
+    tenant=$(getent passwd "$uid" 2>/dev/null | awk -F: '$5 !~ /jabali-ftp-account/ {print $1; exit}')
+    ;;
+  *)
+    # No marker: a plain tenant login is its own tenant.
+    tenant="$user"
+    ;;
+esac
+[ -n "$tenant" ] || exit 0
+
+# Path-traversal guard: the tenant name is interpolated into a cgroup path and a
+# systemd unit name, so pin it to the exact slice-name charset before use.
+# (GECOS is panel-written, but PAM_USER is login-time input — belt and braces.)
+printf '%s' "$tenant" | grep -qE '^[a-z][a-z0-9_-]{0,31}$' || exit 0
+
+slice="jabali-user-${tenant}.slice"
+# Realize the slice cgroup (idempotent), then ask systemd for its REAL path so a
+# dashed tenant name can't break the slice-hierarchy assumption.
+systemctl start "$slice" >/dev/null 2>&1
+cg=$(systemctl show "$slice" -p ControlGroup --value 2>/dev/null)
+[ -n "$cg" ] || exit 0
+
+leaf="/sys/fs/cgroup${cg}/ftp-sessions"
+mkdir -p "$leaf" 2>/dev/null || exit 0
+
+# $PPID is the vsftpd worker that invoked PAM for this session; moving it (and
+# its future transfer children) into the leaf subjects them to the slice limits.
+[ -n "$PPID" ] && printf '%s\n' "$PPID" > "$leaf/cgroup.procs" 2>/dev/null
+
+exit 0

--- a/install/tests/test_ftp_module_optin.sh
+++ b/install/tests/test_ftp_module_optin.sh
@@ -172,6 +172,38 @@ elif [[ -n "$pasv_min" && -n "$pasv_max" ]]; then
     || { echo "FAIL: ftp.disable must remove the 21/tcp control-port rule"; fail=1; }
 fi
 
+# --- 8. JAB-263 phase D: FTPS session cgroup placement hook ---
+# The pam_exec hook that moves the FTPS worker into the tenant slice MUST be
+# wired `session optional` (never `required`) and the helper MUST be fail-open
+# (always exit 0) — an accounting hook that can deny a login is a login outage.
+# The hook only fires if vsftpd opens a PAM session; vsftpd defaults
+# session_support=NO and SKIPS the whole session stack, so this is load-bearing.
+grep -q '^session_support=YES' <<<"$cfgfn" \
+  || { echo "FAIL: vsftpd.conf must set session_support=YES or the cgroup hook never runs (JAB-263)"; fail=1; }
+if ! grep -qE 'pam_exec\.so .*jabali-ftp-session-cgroup' <<<"$pamfn"; then
+  echo "FAIL: vsftpd PAM stack is missing the JAB-263 session-cgroup pam_exec hook"
+  fail=1
+elif grep -qE 'session +required +pam_exec\.so .*jabali-ftp-session-cgroup' <<<"$pamfn"; then
+  echo "FAIL: session-cgroup hook is 'required' — it must be 'optional' (fail open)"
+  fail=1
+fi
+grep -qE 'install .*install/ftp/jabali-ftp-session-cgroup' <<<"$pamfn" \
+  || { echo "FAIL: install_vsftpd_pam must install the session-cgroup helper"; fail=1; }
+
+helper="install/ftp/jabali-ftp-session-cgroup"
+if [[ ! -x "$helper" ]]; then
+  echo "FAIL: $helper missing or not executable"
+  fail=1
+else
+  # Fail-open: every bad-input path must still exit 0 (never block a login).
+  for u in "" "no_such_user_xyz" "../evil" "Bad Upper"; do
+    if ! env -i PAM_USER="$u" PATH="$PATH" "$helper" >/dev/null 2>&1; then
+      echo "FAIL: helper exited non-zero for PAM_USER='$u' — must fail open (exit 0)"
+      fail=1
+    fi
+  done
+fi
+
 if [[ "$fail" -eq 0 ]]; then
   echo "OK: ftp module opt-in guards hold"
 else

--- a/panel-agent/internal/commands/ftp_module_disable.go
+++ b/panel-agent/internal/commands/ftp_module_disable.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -27,7 +30,21 @@ const (
 	// opens in install_ftp_firewall_rules and closes in converge_ftp_masking.
 	ftpControlPortRule = "21/tcp"
 	ftpPasvRangeRule   = "40000:40100/tcp"
+	// ftpSessionLeafName is the per-tenant leaf cgroup the pam_exec hook
+	// (JAB-263 phase D) moves FTPS workers into, under jabali-user-<t>.slice.
+	// MUST match install/ftp/jabali-ftp-session-cgroup.
+	ftpSessionLeafName   = "ftp-sessions"
+	ftpCgroupRootDefault = "/sys/fs/cgroup/jabali.slice"
 )
+
+// ftpCgroupRoot is the cgroup subtree swept for ftp-sessions leaves. Overridable
+// for tests (a real /sys/fs/cgroup can't be faked).
+func ftpCgroupRoot() string {
+	if r := os.Getenv("JABALI_FTP_CGROUP_ROOT"); r != "" {
+		return r
+	}
+	return ftpCgroupRootDefault
+}
 
 type ftpDisableResponse struct {
 	Active    bool `json:"active"`
@@ -44,6 +61,11 @@ func ftpModuleDisableHandler(ctx context.Context, _ json.RawMessage) (any, error
 		_, _ = execCommandContext(ctx, "systemctl", "stop", ftpDisableUnit).CombinedOutput()
 		_, _ = execCommandContext(ctx, "systemctl", "mask", ftpDisableUnit).CombinedOutput()
 	}
+	// JAB-263 phase D: the pam_exec hook moves live FTPS workers OUT of
+	// vsftpd.service into per-tenant ftp-sessions leaf cgroups, so `stop vsftpd`
+	// above does NOT kill an in-flight transfer. Cut them too, or 259's "vsftpd
+	// cannot accept connections" silently weakens to "cannot accept NEW ones".
+	killFtpSessionLeaves()
 	// Remove the firewall rules (best-effort; ufw may be absent/inactive). The
 	// deletes are idempotent — `ufw delete` on a missing rule is a no-op.
 	_, _ = execCommandContext(ctx, "ufw", "delete", "allow", ftpControlPortRule).CombinedOutput()
@@ -96,6 +118,26 @@ func ftpControlPortOpen(ctx context.Context) bool {
 		}
 	}
 	return false
+}
+
+// killFtpSessionLeaves kills every process in every per-tenant ftp-sessions leaf
+// cgroup (JAB-263 phase D) via the cgroup-v2 cgroup.kill file, then removes the
+// emptied leaf (it is recreated by the pam_exec hook on the next login).
+// Best-effort: a walk/write failure just leaves that tenant's workers, which
+// degrades to pre-phase-D behavior, never worse.
+func killFtpSessionLeaves() {
+	_ = filepath.WalkDir(ftpCgroupRoot(), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // unreadable subtree — skip, don't abort the whole walk
+		}
+		if !d.IsDir() || d.Name() != ftpSessionLeafName {
+			return nil
+		}
+		// cgroup.kill (Linux 5.14+) SIGKILLs every process in the cgroup at once.
+		_ = os.WriteFile(filepath.Join(path, "cgroup.kill"), []byte("1"), 0o644)
+		_ = os.Remove(path) // rmdir the now-empty leaf
+		return filepath.SkipDir
+	})
 }
 
 func init() {

--- a/panel-agent/internal/commands/ftp_module_disable_test.go
+++ b/panel-agent/internal/commands/ftp_module_disable_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
@@ -68,6 +71,37 @@ func TestFtpDisable_FailsClosedWhenNotMasked(t *testing.T) {
 	_, err := ftpModuleDisableHandler(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected failed_precondition while vsftpd is stopped but unmasked")
+	}
+}
+
+// JAB-263 phase D: killFtpSessionLeaves finds every per-tenant ftp-sessions leaf
+// under the cgroup root and triggers cgroup.kill on it (leaving other sub-cgroups
+// alone). The real rmdir-despite-control-files semantics are cgroup-specific and
+// verified live; here we assert the walk + kill.
+func TestKillFtpSessionLeaves_TriggersCgroupKill(t *testing.T) {
+	root := t.TempDir()
+	leaf := filepath.Join(root, "jabali-user-shop.slice", ftpSessionLeafName)
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A sibling non-leaf dir must be ignored (no cgroup.kill written).
+	other := filepath.Join(root, "jabali-user-shop.slice", "other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("JABALI_FTP_CGROUP_ROOT", root)
+
+	killFtpSessionLeaves()
+
+	data, err := os.ReadFile(filepath.Join(leaf, "cgroup.kill"))
+	if err != nil {
+		t.Fatalf("cgroup.kill not written to the ftp-sessions leaf: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "1" {
+		t.Fatalf("want cgroup.kill=1, got %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(other, "cgroup.kill")); err == nil {
+		t.Fatal("cgroup.kill written to a non-leaf dir — the walk is too broad")
 	}
 }
 

--- a/panel-agent/internal/commands/user_slice_remove.go
+++ b/panel-agent/internal/commands/user_slice_remove.go
@@ -63,6 +63,13 @@ func userSliceRemoveHandler(ctx context.Context, params json.RawMessage) (any, e
 	// Disable FPM service (ignore "not enabled" errors)
 	_, _, _ = runCmdFn(ctx, "systemctl", "disable", fmt.Sprintf("jabali-fpm@%s.service", p.Username))
 
+	// JAB-263 phase D: cut any FTPS worker the pam_exec hook placed in this
+	// tenant's ftp-sessions leaf and remove the leaf, BEFORE stopping the slice.
+	// A populated leaf keeps the slice cgroup non-empty, so the slice stop +
+	// the caller's userdel would otherwise strand live processes and leave the
+	// slice un-removable.
+	killTenantFtpSessionLeaf(ctx, runCmdFn, p.Username)
+
 	// Stop slice unit (ignore "not loaded" errors)
 	_, _, _ = runCmdFn(ctx, "systemctl", "stop", fmt.Sprintf("jabali-user-%s.slice", p.Username))
 
@@ -108,6 +115,26 @@ func userSliceRemoveHandler(ctx context.Context, params json.RawMessage) (any, e
 		Removed:       removed,
 		AlreadyAbsent: alreadyAbsent,
 	}, nil
+}
+
+// killTenantFtpSessionLeaf kills every process in ONE tenant's ftp-sessions leaf
+// cgroup (JAB-263 phase D) and removes the leaf. Best-effort: it asks systemd
+// for the slice's real cgroup path (so a dashed username still resolves), then
+// uses cgroup.kill. A failure just leaves the leaf, which the reconciler /
+// next teardown retries.
+func killTenantFtpSessionLeaf(ctx context.Context, runCmdFn func(context.Context, string, ...string) ([]byte, []byte, error), username string) {
+	out, _, err := runCmdFn(ctx, "systemctl", "show",
+		fmt.Sprintf("jabali-user-%s.slice", username), "-p", "ControlGroup", "--value")
+	if err != nil {
+		return
+	}
+	cg := strings.TrimSpace(string(out))
+	if cg == "" || cg == "/" {
+		return
+	}
+	leaf := filepath.Join("/sys/fs/cgroup", cg, ftpSessionLeafName)
+	_ = os.WriteFile(filepath.Join(leaf, "cgroup.kill"), []byte("1"), 0o644)
+	_ = os.Remove(leaf)
 }
 
 // removeFile attempts to remove a file, returning true if it existed and was removed.


### PR DESCRIPTION
## JAB-263 — FTPS sessions bypass per-tenant cgroup limits (epic Phase D — the real placement)

Phase A/B/C shipped; ADR-0167 documented the daemon-level mitigation and **deferred true per-tenant placement**. This builds it: FTPS worker PIDs now land under the owning tenant's `jabali-user-<tenant>.slice`, so the M18 CPU/memory/task limits actually enforce.

### Mechanism (empirically designed on a live box before writing a line)
cgroups-v2's no-internal-process rule forbids bare PIDs directly in `jabali-user-<t>.slice` (it has controller-enabled service children), so the worker goes into a `jabali-user-<t>.slice/ftp-sessions` **leaf** — which the kernel still subjects to the parent slice's limits. Verified on .86: the leaf accepts a PID, **survives `systemctl daemon-reload` and tenant fpm-unit restarts**, and a low `pids.max` on it **rejects forks** (enforce, not just account).

- **PAM session hook** `install/ftp/jabali-ftp-session-cgroup` (→ `/usr/local/libexec/jabali`), wired `session optional pam_exec.so` in the `vsftpd-jabali` stack. **FAIL-OPEN**: resolves the owner (GECOS `jabali-ftp-account=<tenant>` for subaccounts incl. isolated own-uid; a plain login is its own tenant), **guards the tenant name against the slice-name charset** (PAM_USER is login-time input → path-traversal shield), asks systemd for the slice's real cgroup path (dashed names safe), mkdirs the leaf, writes `$PPID` to `cgroup.procs`, and **always `exit 0`** — an accounting hook must never deny a login.
- **`session_support=YES`** in `vsftpd.conf` — **load-bearing, found only in live verify**: vsftpd defaults `session_support=NO` and then *skips the entire PAM session stack*, so the hook never fires without it.
- **`ftp.disable` (JAB-259) also `cgroup.kill`s every `ftp-sessions` leaf** — the hook moves live workers *out* of `vsftpd.service`, so `systemctl stop vsftpd` alone would leave an in-flight transfer running and weaken 259's "cannot accept connections" to "cannot accept *new* ones."
- **`user.slice.remove` kills + removes the tenant's leaf before stopping the slice** — a populated leaf keeps the slice cgroup non-empty (265 teardown: slice stop + userdel would strand procs and leave the slice un-removable).

### Scope: FTPS only
The `vsftpd-jabali` PAM stack is panel-owned (blast radius = FTP logins). `/etc/pam.d/sshd` is Debian-owned and gates every admin login — an outage there locks the operator out. SSH/SFTP session placement is a **documented follow-up** in the epic doc, not folded in.

### Live verification (.86)
A real FTPS login placed the **session worker (uid = tenant dk1=1002) under `jabali-user-dk1.slice/ftp-sessions`** (the ticket's literal acceptance); the leaf enforced `pids.max`; `ftp.disable` cgroup-killed + removed the leaf (vsftpd inactive+masked, no tenant procs); the leaf survived reload/unit-restart.

### Tests
Shell: hook is `session optional` (never `required`), helper `exit 0` on every bad-input path (empty / unknown / traversal / bad-charset PAM_USER), `session_support=YES` present. Go: `killFtpSessionLeaves` triggers `cgroup.kill` on `ftp-sessions` leaves only. Full `panel-agent/internal/commands` green; exec-seam holds.

Refs JAB-263.
