### PR TITLE
fix(packages): add FTP account limit to package Create form (JAB-328)

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -725,6 +725,7 @@
     "max_docker_apps": "Max Docker Apps",
     "max_domains": "Max Domains",
     "max_email_accounts": "Max Email Accounts",
+    "max_ftp_accounts": "Max FTP/SFTP Accounts",
     "max_python_apps": "Max Python Apps",
     "max_tasks": "Max Tasks",
     "memory_limit_mb": "Memory Limit (MB)",

--- a/panel-ui/src/shells/admin/packages/PackageCreate.tsx
+++ b/panel-ui/src/shells/admin/packages/PackageCreate.tsx
@@ -32,6 +32,7 @@ type PackageCreateInput = {
   max_databases: number;
   max_docker_apps: number;
   max_python_apps: number;
+  max_ftp_accounts: number;
   // Tenant backup limits (GH #454).
   max_backups: number;
   max_backup_schedules: number;
@@ -141,6 +142,7 @@ export const PackageCreate = () => {
           max_databases: 0,
           max_docker_apps: 0,
           max_python_apps: 0,
+          max_ftp_accounts: 0,
           max_backups: 0,
           max_backup_schedules: 1,
           scheduled_backups_enabled: false,
@@ -289,6 +291,19 @@ export const PackageCreate = () => {
               label={t("packagecreate.max_python_apps")}
               name="max_python_apps"
               tooltip="0 = Python apps not included in this package"
+            >
+              <InputNumber min={0} style={{ width: "100%" }} />
+            </Form.Item>
+          </Col>
+          <Col xs={24} sm={12} md={8}>
+            {/* JAB-328: the FTP account limit must be on CREATE too — omitting it
+                submitted the backend default 0, silently disabling FTP on every
+                panel-created package. 0 stays an explicit opt-out (tenant caps
+                default off), but it is now a visible choice, not a hidden gap. */}
+            <Form.Item
+              label={t("packagecreate.max_ftp_accounts")}
+              name="max_ftp_accounts"
+              tooltip="0 = FTP/SFTP accounts not included in this package"
             >
               <InputNumber min={0} style={{ width: "100%" }} />
             </Form.Item>

--- a/panel-ui/src/shells/admin/packages/packageFieldParity.test.ts
+++ b/panel-ui/src/shells/admin/packages/packageFieldParity.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PKG_DIR = resolve(process.cwd(), "src/shells/admin/packages");
+
+// JAB-328: the package Create form silently omitted max_ftp_accounts, so every
+// panel-created package submitted the backend default 0 and FTP was disabled +
+// hidden until an operator edited the package. Guard the whole class of bug:
+// every package *limit* field (name="max_...") present on the Edit form — the
+// authoritative full entitlement set — must also render on Create, or a future
+// entitlement added to one screen but not the other silently ships zero.
+
+function limitFields(file: string): Set<string> {
+  const src = readFileSync(resolve(PKG_DIR, file), "utf8");
+  const names = new Set<string>();
+  for (const m of src.matchAll(/name="(max_[a-z_]+)"/g)) {
+    names.add(m[1]);
+  }
+  return names;
+}
+
+describe("Package create/edit entitlement field parity (JAB-328)", () => {
+  it("Create renders every max_* limit field that Edit has", () => {
+    const create = limitFields("PackageCreate.tsx");
+    const edit = limitFields("PackageEdit.tsx");
+    const missingOnCreate = [...edit].filter((f) => !create.has(f)).sort();
+    expect(
+      missingOnCreate,
+      `PackageCreate.tsx is missing limit fields present in PackageEdit.tsx: ${missingOnCreate.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("Create renders the FTP account limit (the reported gap)", () => {
+    expect(limitFields("PackageCreate.tsx").has("max_ftp_accounts")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (GH JAB-328, high)

The admin package **Create** form omitted the `max_ftp_accounts` field. Because
the payload spreads `{...values}`, a missing Form.Item means the field is never
sent, so the backend applies its default of **0**. Tenant caps default off, so
`max_ftp_accounts=0` silently **disables the FTP/SFTP entitlement**: FTP stayed
hidden for the tenant until an operator opened the package in **Edit** and
re-saved it. Edit already rendered the field; Create did not — the two screens
disagreed on the entitlement set.

## Fix

- Add `max_ftp_accounts` to `PackageCreate.tsx`: draft type field, `initialValues`
  default `0`, and a Form.Item with the same `name`, default, and tooltip as Edit.
  `0` is now a **visible, deliberate opt-out** rather than a hidden gap.
- Add the `packagecreate.max_ftp_accounts` i18n key (Edit's section already had it).

## Regression guard

`packageFieldParity.test.ts` asserts that **every** `max_*` limit field on the
Edit form (the authoritative entitlement set) also renders on Create. A future
entitlement added to one screen but not the other now **fails the build** instead
of shipping a silent zero. Running it also confirmed no *other* entitlement gap
remains today.

## Acceptance criteria
- [x] Create renders the FTP account limit
- [x] The chosen value reaches `max_ftp_accounts` (spread payload, verified field present)
- [x] Reloading Edit shows the same value (Edit already reads/writes the field)
- [x] `0` remains an explicit opt-out (default `0`, caps default off)
- [x] Create/Edit field-parity regression test guards future entitlements

## Test plan
- [x] `vitest run packageFieldParity.test.ts` — 2 passed
- [x] `tsc -b` — clean
- [ ] Manual: create a package with FTP limit N in the panel, confirm a tenant on
      that package sees FTP with N accounts available; N=0 hides FTP.

GH JAB-328