### PR TITLE
feat: admin File Manager — whole filesystem, deny-listed, opt-in (GH #1184)

### DIFF
--- a/internal/filesafe/admin_scope_test.go
+++ b/internal/filesafe/admin_scope_test.go
@@ -1,0 +1,73 @@
+package filesafe
+
+import "testing"
+
+// GH #1184: the admin File Manager uses a root-scoped Scope with a hard
+// deny-list. These tests pin the security boundary: root reaches the whole
+// tree, but denied prefixes are blocked for every op, with correct word
+// boundaries and no /xyz-matches-/x confusion.
+func TestNewAdminScope_RootReachesFilesystem(t *testing.T) {
+	s, err := NewAdminScope("uid", "admin", nil)
+	if err != nil {
+		t.Fatalf("NewAdminScope: %v", err)
+	}
+	for _, p := range []string{"/", "/etc/nginx/nginx.conf", "/var/log/syslog", "/tmp/x", "/home/u/f"} {
+		if _, err := s.Clean(p); err != nil {
+			t.Errorf("Clean(%q) under root scope should pass, got %v", p, err)
+		}
+	}
+}
+
+func TestNewAdminScope_DenyList(t *testing.T) {
+	s, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	if err != nil {
+		t.Fatalf("NewAdminScope: %v", err)
+	}
+	denied := []string{
+		"/etc/shadow",
+		"/etc/ssh",
+		"/etc/ssh/sshd_config",
+		"/etc/jabali",
+		"/etc/jabali/config.toml",
+		"/etc/letsencrypt/live/example.com/privkey.pem",
+		"/usr/local/bin/jabali-agent",
+		"/run/jabali/agent.sock",
+		"/root/.ssh/authorized_keys",
+	}
+	for _, p := range denied {
+		if _, err := s.Clean(p); err == nil {
+			t.Errorf("Clean(%q) must be denied, but passed", p)
+		} else if ve, ok := err.(*ValidationError); !ok || ve.Code != ErrCodeDenied {
+			t.Errorf("Clean(%q): want ErrCodeDenied, got %v", p, err)
+		}
+	}
+}
+
+func TestNewAdminScope_DenyWordBoundary(t *testing.T) {
+	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	// Look-alikes that share a textual prefix but are NOT inside a denied dir.
+	for _, p := range []string{"/etc/sshfoo", "/etc/jabali-extra", "/etc/shadowy"} {
+		if _, err := s.Clean(p); err != nil {
+			if ve, ok := err.(*ValidationError); ok && ve.Code == ErrCodeDenied {
+				t.Errorf("Clean(%q) wrongly denied by word-boundary bug: %v", p, err)
+			}
+		}
+	}
+}
+
+func TestTenantScope_DenyListEmpty_NoOp(t *testing.T) {
+	// Backward-compat: an ordinary tenant scope has no deny-list and behaves
+	// exactly as before (in-home passes, out-of-home fails as not_in_scope).
+	s, err := NewScope("uid", "bob", []string{"/home/bob"})
+	if err != nil {
+		t.Fatalf("NewScope: %v", err)
+	}
+	if _, err := s.Clean("/home/bob/public_html/index.php"); err != nil {
+		t.Errorf("in-home path should pass: %v", err)
+	}
+	if _, err := s.Clean("/etc/shadow"); err == nil {
+		t.Error("out-of-home path should fail")
+	} else if ve, _ := err.(*ValidationError); ve != nil && ve.Code == ErrCodeDenied {
+		t.Error("tenant scope must reject via not_in_scope, never path_denied")
+	}
+}

--- a/internal/filesafe/admin_scope_test.go
+++ b/internal/filesafe/admin_scope_test.go
@@ -71,3 +71,29 @@ func TestTenantScope_DenyListEmpty_NoOp(t *testing.T) {
 		t.Error("tenant scope must reject via not_in_scope, never path_denied")
 	}
 }
+
+// TestAdminScope_baseFor_RootTraversal pins the openat2 traversal helper for the
+// root scope — the box-verify caught baseFor rejecting /etc/* with a "//" prefix
+// bug even though verifyInScope passed (GH #1184).
+func TestAdminScope_baseFor_RootTraversal(t *testing.T) {
+	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	cases := map[string]string{
+		"/etc/nginx/nginx.conf": "etc/nginx/nginx.conf",
+		"/tmp/x":                "tmp/x",
+		"/var/log/syslog":       "var/log/syslog",
+	}
+	for path, wantRel := range cases {
+		base, rel, err := s.baseFor(path)
+		if err != nil {
+			t.Errorf("baseFor(%q) errored: %v", path, err)
+			continue
+		}
+		if base != "/" || rel != wantRel {
+			t.Errorf("baseFor(%q) = base %q rel %q; want base \"/\" rel %q", path, base, rel, wantRel)
+		}
+	}
+	// Root itself resolves to ".".
+	if base, rel, err := s.baseFor("/"); err != nil || base != "/" || rel != "." {
+		t.Errorf(`baseFor("/") = %q,%q,%v; want "/",".",nil`, base, rel, err)
+	}
+}

--- a/internal/filesafe/filesafe.go
+++ b/internal/filesafe/filesafe.go
@@ -32,7 +32,36 @@ const (
 	ErrCodeNotInScope      = "not_in_scope"     // path not within owned docroots
 	ErrCodeSymlinkLoop     = "symlink_loop"     // circular symlink chain
 	ErrCodeBadCharacters   = "bad_characters"   // invalid filename characters
+	ErrCodeDenied          = "path_denied"      // path within an explicit deny prefix (GH #1184 admin FM)
 )
+
+// DefaultAdminDeniedPrefixes is the hard deny-list for the GH #1184 admin File
+// Manager (a root-scoped Scope). These paths are blocked for ALL operations —
+// read, write, chmod, delete, rename — enforced agent-side so the panel can
+// never be talked into touching them. Rationale per path family:
+//   - credential/key stores that must never leave the box or be altered via a UI
+//   - jabali's own control-plane state + binaries + sockets (self-protection:
+//     an admin FM must not be able to corrupt the panel/agent that runs it, or
+//     re-chmod /etc/jabali, which is a known SSH-lockout footgun)
+// Deliberately full-block (not chmod-only): if a path is dangerous to re-perm
+// it is dangerous to overwrite too, so one list covers both. Admins retain root
+// SSH for anything intentionally excluded here.
+var DefaultAdminDeniedPrefixes = []string{
+	"/etc/shadow",
+	"/etc/gshadow",
+	"/etc/ssh",         // host keys + sshd_config (SSH-lockout footgun)
+	"/root/.ssh",       // root authorized_keys
+	"/etc/sudoers",     // and /etc/sudoers.d via prefix boundary below
+	"/etc/sudoers.d",
+	"/etc/jabali",      // panel/agent config + secrets + the 0755-perms lockout
+	"/etc/letsencrypt", // live/archive/keys/accounts — cert private keys
+	"/usr/local/bin/jabali-agent",
+	"/usr/local/bin/jabali-panel",
+	"/usr/local/bin/jabali",
+	"/run/jabali",   // agent + panel unix sockets
+	"/run/jabali-kratos",
+	"/var/lib/jabali-uploads", // agent↔panel handoff staging
+}
 
 // ValidationError is the error type returned by validators.
 type ValidationError struct {
@@ -50,6 +79,14 @@ type Scope struct {
 	UserID        string
 	Username      string
 	OwnedDocroots []string
+	// DeniedPrefixes are absolute path prefixes that are blocked for ALL
+	// operations even when within OwnedDocroots (GH #1184 admin FM deny-list).
+	// Empty for ordinary tenant scopes — a nil/empty list is a pure no-op, so
+	// this is backward-compatible with every existing NewScope caller. The
+	// check runs in verifyInScope, i.e. on BOTH the cleaned path and the
+	// symlink-resolved path, so a symlink from an allowed dir into a denied
+	// one is caught.
+	DeniedPrefixes []string
 	// resolveCache caches EvalSymlinks results to detect symlink loops
 	resolveCache map[string]string
 }
@@ -89,6 +126,33 @@ func NewScope(userID, username string, ownedDocroots []string) (*Scope, error) {
 		Username:      username,
 		OwnedDocroots: normalized,
 		resolveCache:  make(map[string]string),
+	}, nil
+}
+
+// NewAdminScope creates a root-scoped Scope for the GH #1184 admin File
+// Manager: OwnedDocroots is "/" (the whole filesystem) but every path in
+// deniedPrefixes is blocked for all operations. Pass
+// DefaultAdminDeniedPrefixes unless a caller has a reason to differ. This is
+// a privileged constructor — the panel gates it behind admin auth AND a
+// default-off server setting; the deny-list here is the last line of defence.
+func NewAdminScope(userID, username string, deniedPrefixes []string) (*Scope, error) {
+	if username == "" {
+		return nil, &ValidationError{Code: ErrCodeEmpty, Detail: "username cannot be empty"}
+	}
+	denied := make([]string, 0, len(deniedPrefixes))
+	for _, p := range deniedPrefixes {
+		p = filepath.Clean(p)
+		if !filepath.IsAbs(p) {
+			return nil, &ValidationError{Code: ErrCodeNotAbsolute, Detail: fmt.Sprintf("denied prefix %q must be absolute", p)}
+		}
+		denied = append(denied, p)
+	}
+	return &Scope{
+		UserID:         userID,
+		Username:       username,
+		OwnedDocroots:  []string{"/"},
+		DeniedPrefixes: denied,
+		resolveCache:   make(map[string]string),
 	}, nil
 }
 
@@ -286,25 +350,50 @@ func (s *Scope) verifyInScope(pathStr string) error {
 		}
 	}
 
-	// Check containment in owned docroots
+	// Check containment in owned docroots.
+	inScope := false
 	for _, docroot := range s.OwnedDocroots {
 		docroot = filepath.Clean(docroot)
 
+		// "/" (root scope, GH #1184 admin FM) contains every absolute path;
+		// the naive docroot+"/" prefix would become "//" and match nothing.
+		if docroot == "/" {
+			inScope = true
+			break
+		}
 		// Exact match (for root-level docroots)
 		if pathStr == docroot {
-			return nil
+			inScope = true
+			break
 		}
-
 		// Prefix match with / boundary (no /x matching /xyz)
 		if strings.HasPrefix(pathStr, docroot+"/") {
-			return nil
+			inScope = true
+			break
+		}
+	}
+	if !inScope {
+		return &ValidationError{
+			Code:   ErrCodeNotInScope,
+			Detail: fmt.Sprintf("path %q is not within owned docroots: %v", pathStr, s.OwnedDocroots),
 		}
 	}
 
-	return &ValidationError{
-		Code:   ErrCodeNotInScope,
-		Detail: fmt.Sprintf("path %q is not within owned docroots: %v", pathStr, s.OwnedDocroots),
+	// GH #1184 deny-list: block even in-scope paths that fall within a denied
+	// prefix. Runs on both the cleaned path (Clean) and the symlink-resolved
+	// path (Resolve), so a symlink from an allowed dir into a denied one is
+	// rejected. Same word-boundary rule: /etc/ssh blocks /etc/ssh/* but not
+	// /etc/sshfoo.
+	for _, denied := range s.DeniedPrefixes {
+		if pathStr == denied || strings.HasPrefix(pathStr, denied+"/") {
+			return &ValidationError{
+				Code:   ErrCodeDenied,
+				Detail: fmt.Sprintf("path %q is within denied prefix %q", pathStr, denied),
+			}
+		}
 	}
+
+	return nil
 }
 
 // resolveNearest canonicalizes cleaned by EvalSymlinks-resolving its nearest

--- a/internal/filesafe/openat2.go
+++ b/internal/filesafe/openat2.go
@@ -66,6 +66,14 @@ func (s *Scope) baseFor(pathStr string) (base, rel string, err error) {
 		if cleaned == dr {
 			return dr, ".", nil
 		}
+		// Root scope (GH #1184 admin FM): every absolute path is beneath "/".
+		// The naive dr+"/" prefix would be "//" and match nothing, so handle "/"
+		// explicitly — rel is the path minus its leading slash. (openat2 then
+		// resolves it RESOLVE_BENEATH the "/" base fd; absolute symlinks still
+		// fail closed, which is the intended safety, not a scope bug.)
+		if dr == "/" {
+			return dr, cleaned[1:], nil
+		}
 		if strings.HasPrefix(cleaned, dr+"/") {
 			return dr, cleaned[len(dr)+1:], nil
 		}

--- a/panel-agent/internal/commands/files_chmod.go
+++ b/panel-agent/internal/commands/files_chmod.go
@@ -21,10 +21,11 @@ import (
 // user can tidy up legacy uploads, but higher bits are masked out.
 
 type filesChmodParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Mode     string `json:"mode"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
+	Mode      string `json:"mode"`
 }
 
 type filesChmodResponse struct {
@@ -58,8 +59,7 @@ func filesChmodHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}
 	}
 
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_delete.go
+++ b/panel-agent/internal/commands/files_delete.go
@@ -7,13 +7,13 @@ import (
 	"os"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // filesDeleteParams is the input shape for files.delete.
 type filesDeleteParams struct {
 	UserID    string `json:"user_id"`
 	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
 	Path      string `json:"path"`
 	Recursive bool   `json:"recursive,omitempty"`
 }
@@ -48,8 +48,7 @@ func filesDeleteHandler(ctx context.Context, params json.RawMessage) (any, error
 	}
 
 	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_du.go
+++ b/panel-agent/internal/commands/files_du.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // files.du — disk-usage view of one directory's immediate children, scoped to
@@ -24,9 +23,10 @@ import (
 //	files.du {user_id, username, path} -> {path, total, entries[]}
 
 type filesDuParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
 }
 
 type filesDuEntry struct {
@@ -51,8 +51,7 @@ func filesDuHandler(ctx context.Context, params json.RawMessage) (any, error) {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "username and path required"}
 	}
 
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("scope: %v", err)}
 	}

--- a/panel-agent/internal/commands/files_list.go
+++ b/panel-agent/internal/commands/files_list.go
@@ -12,9 +12,10 @@ import (
 
 // filesListParams is the input shape for files.list.
 type filesListParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
 }
 
 // filesListEntry represents a single file/directory entry.
@@ -61,8 +62,7 @@ func filesListHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}
 
 	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_mkdir.go
+++ b/panel-agent/internal/commands/files_mkdir.go
@@ -8,15 +8,16 @@ import (
 	"strconv"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+	"os"
 )
 
 // filesMkdirParams is the input shape for files.mkdir.
 type filesMkdirParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Mode     string `json:"mode,omitempty"` // "parents" or empty (default no parents)
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
+	Mode      string `json:"mode,omitempty"` // "parents" or empty (default no parents)
 }
 
 // filesMkdirResponse is the output shape for files.mkdir.
@@ -48,9 +49,7 @@ func filesMkdirHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}
 	}
 
-	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
@@ -78,19 +77,28 @@ func filesMkdirHandler(ctx context.Context, params json.RawMessage) (any, error)
 	}
 
 	if created {
-		// New directory: set ownership (user:www-data) and 0750 via the dir fd.
-		u, err := user.Lookup(p.Username)
-		if err != nil {
-			return nil, &agentwire.AgentError{
-				Code:    agentwire.CodeInvalidArgument,
-				Message: fmt.Sprintf("failed to lookup user %q: %v", p.Username, err),
+		// Ownership for the new directory:
+		//   - Tenant: <user>:www-data, 0750 (nginx traverse + static read).
+		//   - Admin FM (GH #1184): root:root 0755 — a root-tree dir must never
+		//     be reassigned to a tenant.
+		uid, wwwDataGid := 0, 0
+		dirMode := os.FileMode(0750)
+		if p.AdminRoot {
+			dirMode = 0755
+		} else {
+			u, uerr := user.Lookup(p.Username)
+			if uerr != nil {
+				return nil, &agentwire.AgentError{
+					Code:    agentwire.CodeInvalidArgument,
+					Message: fmt.Sprintf("failed to lookup user %q: %v", p.Username, uerr),
+				}
 			}
-		}
-		uid, _ := strconv.Atoi(u.Uid)
-		gid, _ := strconv.Atoi(u.Gid)
-		wwwDataGid := gid
-		if g, gerr := user.LookupGroup("www-data"); gerr == nil {
-			wwwDataGid, _ = strconv.Atoi(g.Gid)
+			uid, _ = strconv.Atoi(u.Uid)
+			gid, _ := strconv.Atoi(u.Gid)
+			wwwDataGid = gid
+			if g, gerr := user.LookupGroup("www-data"); gerr == nil {
+				wwwDataGid, _ = strconv.Atoi(g.Gid)
+			}
 		}
 
 		df, derr := scope.OpenDirInScope(cleanPath)
@@ -107,8 +115,8 @@ func filesMkdirHandler(ctx context.Context, params json.RawMessage) (any, error)
 				Message: fmt.Sprintf("failed to chown directory: %v", err),
 			}
 		}
-		// 0750: owner rwx, www-data group r-x (nginx static read + traverse).
-		if err := df.Chmod(0750); err != nil {
+		// Tenant 0750 (nginx traverse) / admin 0755.
+		if err := df.Chmod(dirMode); err != nil {
 			df.Close()
 			return nil, &agentwire.AgentError{
 				Code:    agentwire.CodeInternal,

--- a/panel-agent/internal/commands/files_read.go
+++ b/panel-agent/internal/commands/files_read.go
@@ -12,15 +12,15 @@ import (
 	"unicode/utf8"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // filesReadParams is the input shape for files.read.
 type filesReadParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Limit    int64  `json:"limit,omitempty"` // 0 = no limit, default 1MB
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
+	Limit     int64  `json:"limit,omitempty"` // 0 = no limit, default 1MB
 }
 
 // filesReadResponse is the output shape for files.read.
@@ -96,8 +96,7 @@ func filesReadHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}
 
 	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_rename.go
+++ b/panel-agent/internal/commands/files_rename.go
@@ -7,15 +7,15 @@ import (
 	"path/filepath"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // filesRenameParams is the input shape for files.rename.
 type filesRenameParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	OldPath  string `json:"old_path"`
-	NewPath  string `json:"new_path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	OldPath   string `json:"old_path"`
+	NewPath   string `json:"new_path"`
 }
 
 // filesRenameResponse is the output shape for files.rename.
@@ -55,8 +55,7 @@ func filesRenameHandler(ctx context.Context, params json.RawMessage) (any, error
 	}
 
 	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_scope.go
+++ b/panel-agent/internal/commands/files_scope.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+)
+
+// fileScopeFor builds the filesafe scope for a file command (GH #1184).
+//
+// Ordinary tenant ops confine to the caller's home directory, exactly as
+// before. When adminRoot is set the scope is the whole filesystem minus the
+// hard deny-list (filesafe.DefaultAdminDeniedPrefixes) — the admin File
+// Manager. adminRoot is honoured only because the agent's unix socket is
+// panel-only: the panel sets it after its own admin-auth AND default-off
+// server-setting gate, and the deny-list is enforced here regardless as the
+// last line of defence.
+func fileScopeFor(userID, username string, adminRoot bool) (*filesafe.Scope, error) {
+	if adminRoot {
+		return filesafe.NewAdminScope(userID, username, filesafe.DefaultAdminDeniedPrefixes)
+	}
+	return filesafe.NewScope(userID, username, []string{"/home/" + username})
+}

--- a/panel-agent/internal/commands/files_stat.go
+++ b/panel-agent/internal/commands/files_stat.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // filesStatParams is the input shape for files.stat.
 type filesStatParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
 }
 
 // filesStatResponse is the output shape for files.stat.
@@ -50,8 +50,7 @@ func filesStatHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	}
 
 	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,

--- a/panel-agent/internal/commands/files_write.go
+++ b/panel-agent/internal/commands/files_write.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 )
 
 // classifyFSWriteErr turns a low-level write/chown/rename error into an
@@ -52,11 +51,12 @@ func classifyFSWriteErr(stage string, err error) *agentwire.AgentError {
 
 // filesWriteParams is the input shape for files.write.
 type filesWriteParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Content  string `json:"content"`
-	Mode     string `json:"mode,omitempty"` // "append" or "overwrite" (default)
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root"` // GH #1184 admin FM: root scope + deny-list
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Mode      string `json:"mode,omitempty"` // "append" or "overwrite" (default)
 }
 
 // filesWriteResponse is the output shape for files.write.
@@ -97,9 +97,7 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 		}
 	}
 
-	// Create filesafe scope with user's home directory
-	homeDir := fmt.Sprintf("/home/%s", p.Username)
-	scope, err := filesafe.NewScope(p.UserID, p.Username, []string{homeDir})
+	scope, err := fileScopeFor(p.UserID, p.Username, p.AdminRoot)
 	if err != nil {
 		return nil, &agentwire.AgentError{
 			Code:    agentwire.CodeInvalidArgument,
@@ -121,25 +119,37 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 
 	// For overwrite mode (or if file doesn't exist), use temp-file-then-rename pattern
 	if p.Mode != "append" {
-		// Lookup user to get uid/gid
-		u, err := user.Lookup(p.Username)
-		if err != nil {
-			return nil, &agentwire.AgentError{
-				Code:    agentwire.CodeInvalidArgument,
-				Message: fmt.Sprintf("failed to lookup user %q: %v", p.Username, err),
+		// Ownership + mode for the (re)written file.
+		//   - Tenant: <user>:www-data, 0640 — nginx (www-data) static-reads it,
+		//     the user's own gid would leave it unreadable AND show as
+		//     "User:User" (GH #533). www-data gid unless somehow absent.
+		//   - Admin FM (GH #1184): NEVER reassign a root-tree file to a tenant.
+		//     Preserve the existing file's owner+mode on overwrite; a brand-new
+		//     file is root:root 0644.
+		uid, gid := 0, 0
+		fileMode := sensitiveFileMode(cleanPath, 0640)
+		if p.AdminRoot {
+			fileMode = 0644
+			if fi, serr := os.Stat(cleanPath); serr == nil {
+				if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+					uid, gid = int(st.Uid), int(st.Gid)
+				}
+				fileMode = fi.Mode().Perm()
 			}
-		}
-		uid, _ := strconv.Atoi(u.Uid)
-		gid, _ := strconv.Atoi(u.Gid)
-		// New files under the docroot must be group www-data so nginx (running
-		// as www-data) can serve them via the 0640 group-read bit set below; the
-		// user's own primary group would leave them unreadable AND surface to the
-		// operator as "User:User" instead of "User:www-data" (GH #533). Mirror
-		// files.mkdir / files.extract (hostingIDs): keep the user's gid only if
-		// www-data is somehow absent.
-		if g, gerr := user.LookupGroup("www-data"); gerr == nil {
-			if wgid, werr := strconv.Atoi(g.Gid); werr == nil {
-				gid = wgid
+		} else {
+			u, uerr := user.Lookup(p.Username)
+			if uerr != nil {
+				return nil, &agentwire.AgentError{
+					Code:    agentwire.CodeInvalidArgument,
+					Message: fmt.Sprintf("failed to lookup user %q: %v", p.Username, uerr),
+				}
+			}
+			uid, _ = strconv.Atoi(u.Uid)
+			gid, _ = strconv.Atoi(u.Gid)
+			if g, gerr := user.LookupGroup("www-data"); gerr == nil {
+				if wgid, werr := strconv.Atoi(g.Gid); werr == nil {
+					gid = wgid
+				}
 			}
 		}
 
@@ -187,9 +197,8 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 			return nil, classifyFSWriteErr("chown_tempfile", err)
 		}
 
-		// Chmod to 0640 via the fd: owner rw, www-data group r (nginx static
-		// read), other none. Matches per-user FPM isolation.
-		if err := tmpFile.Chmod(sensitiveFileMode(cleanPath, 0640)); err != nil {
+		// Chmod via the fd to the computed mode (tenant 0640 / admin-preserved).
+		if err := tmpFile.Chmod(fileMode); err != nil {
 			tmpFile.Close()
 			_ = scope.RemoveInScope(tmpPath, false)
 			return nil, classifyFSWriteErr("chmod_tempfile", err)
@@ -234,7 +243,9 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// Newly created via O_CREATE: normalize ownership to <user>:www-data through
 	// the open fd (no path re-resolve). Chown after the write so an over-quota
 	// target surfaces EDQUOT here, classified like the overwrite path.
-	if preExisting == nil {
+	// Admin FM (GH #1184): a newly created root-tree file stays root:root —
+	// never chown to a tenant. Only the tenant path normalizes ownership.
+	if preExisting == nil && !p.AdminRoot {
 		u, uerr := user.Lookup(p.Username)
 		if uerr != nil {
 			return nil, &agentwire.AgentError{

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -120,45 +120,51 @@ func singleStagingPath(userID, rnd string) string {
 // Agent param struct types. JSON tags must match panel-agent/internal/commands/files_*.go
 // exactly — see files_wire_test.go for the drift-guard test.
 type filesListAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	Path      string `json:"path"`
 }
 
 type filesReadAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Limit    int64  `json:"limit,omitempty"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	Path      string `json:"path"`
+	Limit     int64  `json:"limit,omitempty"`
 }
 
 type filesWriteAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Content  string `json:"content"`
-	Mode     string `json:"mode,omitempty"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Mode      string `json:"mode,omitempty"`
 }
 
 type filesDeleteAgentParams struct {
 	UserID    string `json:"user_id"`
 	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
 	Path      string `json:"path"`
 	Recursive bool   `json:"recursive,omitempty"`
 }
 
 type filesMkdirAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Mode     string `json:"mode,omitempty"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	Path      string `json:"path"`
+	Mode      string `json:"mode,omitempty"`
 }
 
 type filesRenameAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	OldPath  string `json:"old_path"`
-	NewPath  string `json:"new_path"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	OldPath   string `json:"old_path"`
+	NewPath   string `json:"new_path"`
 }
 
 type filesMoveAgentParams struct {
@@ -169,10 +175,11 @@ type filesMoveAgentParams struct {
 }
 
 type filesChmodAgentParams struct {
-	UserID   string `json:"user_id"`
-	Username string `json:"username"`
-	Path     string `json:"path"`
-	Mode     string `json:"mode"`
+	UserID    string `json:"user_id"`
+	Username  string `json:"username"`
+	AdminRoot bool   `json:"admin_root,omitempty"`
+	Path      string `json:"path"`
+	Mode      string `json:"mode"`
 }
 
 type filesArchiveAgentParams struct {

--- a/panel-api/internal/api/files_admin.go
+++ b/panel-api/internal/api/files_admin.go
@@ -1,0 +1,253 @@
+// Package api — GH #1184 admin File Manager.
+//
+// A whole-filesystem browser/editor for admins, mounted at /admin/files/*.
+// SEPARATE from the tenant /files handler on purpose: the tenant path stays
+// exactly as it was, and everything here is gated twice — admin claims AND the
+// default-off admin_file_manager_enabled server setting — before any op is
+// dispatched to the agent with admin_root=true (root scope minus the hard
+// filesafe deny-list, enforced agent-side as the last line of defence).
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// AdminFilesHandlerConfig wires the admin File Manager. Agent + ServerSettings
+// are required (nil → routes not mounted). Audits is optional — nil skips the
+// audit write (the op still runs), but production always wires it.
+type AdminFilesHandlerConfig struct {
+	Agent          agent.AgentInterface
+	ServerSettings repository.ServerSettingsRepository
+	Audits         repository.AuditEventRepository
+}
+
+type adminFilesHandler struct{ cfg AdminFilesHandlerConfig }
+
+// RegisterAdminFilesRoutes mounts /admin/files/* behind the two-factor gate
+// (admin + default-off setting). Read ops (list/read) and mutations
+// (write/delete/mkdir/rename/chmod); every mutation is audited.
+func RegisterAdminFilesRoutes(g *gin.RouterGroup, cfg AdminFilesHandlerConfig) {
+	if cfg.Agent == nil || cfg.ServerSettings == nil {
+		return
+	}
+	h := &adminFilesHandler{cfg: cfg}
+	grp := g.Group("/admin/files", h.gate)
+	grp.GET("", h.list)
+	grp.GET("/read", h.read)
+	grp.POST("/write", h.write)
+	grp.DELETE("", h.delete)
+	grp.POST("/mkdir", h.mkdir)
+	grp.POST("/rename", h.rename)
+	grp.POST("/chmod", h.chmod)
+}
+
+// gate rejects non-admins (403 forbidden) and, for admins, refuses when the
+// admin_file_manager_enabled server setting is off (403 admin_file_manager_disabled)
+// so the UI can tell "not allowed" from "feature off".
+func (h *adminFilesHandler) gate(c *gin.Context) {
+	claims := ginctx.Claims(c)
+	if claims == nil || !claims.IsAdmin {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	s, err := h.cfg.ServerSettings.Get(c.Request.Context())
+	if err != nil || s == nil || !s.AdminFileManagerEnabled {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin_file_manager_disabled"})
+		return
+	}
+	c.Next()
+}
+
+// ident returns (user_id, username) to stamp on agent calls. The admin's email
+// is a stable non-empty label; NewAdminScope only requires it non-empty (it is
+// NOT used for scoping in admin mode) and it keeps the agent log legible.
+func (h *adminFilesHandler) ident(c *gin.Context) (userID, username string) {
+	claims := ginctx.Claims(c)
+	username = claims.Email
+	if username == "" {
+		username = "admin"
+	}
+	return claims.UserID, username
+}
+
+// audit records one admin File Manager mutation. Append-only; the path is the
+// target (not a secret), never file contents.
+func (h *adminFilesHandler) audit(c *gin.Context, action, path, result string) {
+	if h.cfg.Audits == nil {
+		return
+	}
+	claims := ginctx.Claims(c)
+	var actor *string
+	if claims != nil && claims.UserID != "" {
+		id := claims.UserID
+		actor = &id
+	}
+	ip := c.ClientIP()
+	_ = h.cfg.Audits.Create(c.Request.Context(), &models.AuditEvent{
+		ID:          ids.NewULID(),
+		TS:          time.Now().UTC(),
+		ActorUserID: actor,
+		ActorKind:   models.AuditActorAdmin,
+		Action:      action,
+		TargetType:  "file",
+		TargetID:    path,
+		Result:      result,
+		SourceIP:    &ip,
+	})
+}
+
+func (h *adminFilesHandler) list(c *gin.Context) {
+	userID, username := h.ident(c)
+	p, ok := requirePath(c)
+	if !ok {
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.list", filesListAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: p,
+	})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	var result filesListAgentResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *adminFilesHandler) read(c *gin.Context) {
+	userID, username := h.ident(c)
+	p, ok := requirePath(c)
+	if !ok {
+		return
+	}
+	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.read", filesReadAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: p,
+	})
+	if err != nil {
+		respondAgentError(c, err)
+		return
+	}
+	var result filesReadAgentResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error", "detail": "bad agent response"})
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *adminFilesHandler) write(c *gin.Context) {
+	userID, username := h.ident(c)
+	var req writeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.write", filesWriteAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: req.Path, Content: req.Content,
+	})
+	if err != nil {
+		h.audit(c, "admin.files.write", req.Path, "error")
+		respondAgentError(c, err)
+		return
+	}
+	h.audit(c, "admin.files.write", req.Path, "ok")
+	c.JSON(http.StatusOK, gin.H{"path": req.Path})
+}
+
+func (h *adminFilesHandler) delete(c *gin.Context) {
+	userID, username := h.ident(c)
+	p, ok := requirePath(c)
+	if !ok {
+		return
+	}
+	recursive := c.Query("recursive") == "true"
+	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.delete", filesDeleteAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: p, Recursive: recursive,
+	})
+	if err != nil {
+		h.audit(c, "admin.files.delete", p, "error")
+		respondAgentError(c, err)
+		return
+	}
+	h.audit(c, "admin.files.delete", p, "ok")
+	c.JSON(http.StatusOK, gin.H{"deleted": p})
+}
+
+func (h *adminFilesHandler) mkdir(c *gin.Context) {
+	userID, username := h.ident(c)
+	var req mkdirRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.mkdir", filesMkdirAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: req.Path,
+	})
+	if err != nil {
+		h.audit(c, "admin.files.mkdir", req.Path, "error")
+		respondAgentError(c, err)
+		return
+	}
+	h.audit(c, "admin.files.mkdir", req.Path, "ok")
+	c.JSON(http.StatusOK, gin.H{"path": req.Path})
+}
+
+func (h *adminFilesHandler) rename(c *gin.Context) {
+	userID, username := h.ident(c)
+	var req renameRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	// new_name must be a single path segment — no separators, no ".." escape,
+	// so a rename can't relocate a file across the tree.
+	if req.NewName == "" || strings.ContainsRune(req.NewName, '/') || req.NewName == ".." || req.NewName == "." {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_new_name"})
+		return
+	}
+	newPath := filepath.Join(filepath.Dir(req.Path), req.NewName)
+	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.rename", filesRenameAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, OldPath: req.Path, NewPath: newPath,
+	})
+	if err != nil {
+		h.audit(c, "admin.files.rename", req.Path, "error")
+		respondAgentError(c, err)
+		return
+	}
+	h.audit(c, "admin.files.rename", req.Path+" -> "+newPath, "ok")
+	c.JSON(http.StatusOK, gin.H{"old_path": req.Path, "new_path": newPath})
+}
+
+func (h *adminFilesHandler) chmod(c *gin.Context) {
+	userID, username := h.ident(c)
+	var req chmodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request"})
+		return
+	}
+	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.chmod", filesChmodAgentParams{
+		UserID: userID, Username: username, AdminRoot: true, Path: req.Path, Mode: req.Mode,
+	})
+	if err != nil {
+		h.audit(c, "admin.files.chmod", req.Path, "error")
+		respondAgentError(c, err)
+		return
+	}
+	h.audit(c, "admin.files.chmod", req.Path+" "+req.Mode, "ok")
+	c.JSON(http.StatusOK, gin.H{"path": req.Path, "mode": req.Mode})
+}

--- a/panel-api/internal/api/me.go
+++ b/panel-api/internal/api/me.go
@@ -68,7 +68,7 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 	settings, err := h.cfg.ServerSettings.Get(ctx)
 	if errors.Is(err, repository.ErrNotFound) {
 		// Pre-seed install — every flag defaults to false.
-		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": "", "ftp_accounts_enabled": false, "ftp_server_enabled": false, "ftp_isolation_available": false})
+		c.JSON(http.StatusOK, gin.H{"postgres_enabled": false, "docker_marketplace_enabled": false, "docker_apps_user_enabled": false, "python_apps_enabled": false, "tenant_domain_options_enabled": false, "tenant_docroot_editable": false, "dns_enabled": true, "mail_enabled": true, "security_enabled": true, "quota_enabled": true, "api_enabled": true, "root_terminal_enabled": false, "admin_file_manager_enabled": false, "public_ipv4": "", "public_ipv6": "", "is_standby": false, "dr_peer_label": "", "ftp_accounts_enabled": false, "ftp_server_enabled": false, "ftp_isolation_available": false})
 		return
 	} else if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
@@ -118,6 +118,9 @@ func (h *meExtHandler) serverCapabilities(c *gin.Context) {
 		// GH #515 / JAB-169: the admin Terminal nav entry stayed visible with
 		// the module off. Surface the flag so the sidebar hides it.
 		"root_terminal_enabled": settings.RootTerminalEnabled,
+		// GH #1184: admin File Manager nav is hidden unless the (default-off)
+		// setting is on — same pattern as the terminal.
+		"admin_file_manager_enabled": settings.AdminFileManagerEnabled,
 		// GH #361: surface the server's public IPv4/IPv6 so the user + admin
 		// dashboards can show them (already tracked for the panel cert + DNS;
 		// not per-user sensitive). Empty string when unset. JAB-176: on the

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -2934,6 +2934,53 @@ paths:
 
   # --- Files (auto) ---
 
+  /admin/files:
+    get:
+      tags: [Files]
+      summary: Admin file manager list (GH #1184; whole filesystem, deny-listed)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+    delete:
+      tags: [Files]
+      summary: Admin file manager delete
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/files/read:
+    get:
+      tags: [Files]
+      summary: Admin file manager read file
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/files/write:
+    post:
+      tags: [Files]
+      summary: Admin file manager write file
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/files/mkdir:
+    post:
+      tags: [Files]
+      summary: Admin file manager mkdir
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/files/rename:
+    post:
+      tags: [Files]
+      summary: Admin file manager rename
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
+  /admin/files/chmod:
+    post:
+      tags: [Files]
+      summary: Admin file manager chmod
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /files:
     delete:
       tags: [Files]

--- a/panel-api/internal/api/server_settings.go
+++ b/panel-api/internal/api/server_settings.go
@@ -173,6 +173,7 @@ type updateServerSettingsRequest struct {
 	// GH #1161: opt-in — also serve /api/v1/automation/ on :443 (default off,
 	// :8443 only). For billing hosts whose outbound firewall blocks 8443.
 	AutomationApiPublicEnabled *bool `json:"automation_api_public_enabled,omitempty"`
+	AdminFileManagerEnabled    *bool `json:"admin_file_manager_enabled,omitempty"` // GH #1184
 	// GH #879: server-wide default for the branded application-error page;
 	// domains override via nginx_safe_options.intercept_errors.
 	InterceptAppErrorsDefault *bool `json:"intercept_app_errors_default,omitempty"`
@@ -599,6 +600,9 @@ func (h *serverSettingsHandler) update(c *gin.Context) {
 	}
 	if req.AutomationApiPublicEnabled != nil {
 		current.AutomationApiPublicEnabled = *req.AutomationApiPublicEnabled
+	}
+	if req.AdminFileManagerEnabled != nil {
+		current.AdminFileManagerEnabled = *req.AdminFileManagerEnabled
 	}
 	if req.InterceptAppErrorsDefault != nil {
 		current.InterceptAppErrorsDefault = *req.InterceptAppErrorsDefault

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1344,6 +1344,14 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Log:            deps.Log,
 				ServerSettings: deps.ServerSettings,
 			})
+			// GH #1184: admin File Manager (whole filesystem, deny-listed),
+			// gated by admin-auth + the default-off admin_file_manager_enabled
+			// setting inside the handler. Reuses the same agent file commands.
+			api.RegisterAdminFilesRoutes(v1, api.AdminFilesHandlerConfig{
+				Agent:          deps.Agent,
+				ServerSettings: deps.ServerSettings,
+				Audits:         automationAudits(deps.DB),
+			})
 		}
 
 		// SSH keys routes

--- a/panel-api/internal/db/migrations/000271_admin_file_manager_setting.down.sql
+++ b/panel-api/internal/db/migrations/000271_admin_file_manager_setting.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE server_settings
+    DROP COLUMN admin_file_manager_enabled;

--- a/panel-api/internal/db/migrations/000271_admin_file_manager_setting.up.sql
+++ b/panel-api/internal/db/migrations/000271_admin_file_manager_setting.up.sql
@@ -1,0 +1,5 @@
+-- GH #1184: the admin File Manager is a whole-filesystem (deny-listed)
+-- browser/editor on the admin side. It exposes root-owned paths + edits to the
+-- panel UI, so it is opt-in and OFF by default — an explicit, deliberate enable.
+ALTER TABLE server_settings
+    ADD COLUMN admin_file_manager_enabled TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -148,6 +148,12 @@ type ServerSettings struct {
 	// exposed — the internal/unauthenticated endpoints stay :8443-only.
 	AutomationApiPublicEnabled bool `gorm:"column:automation_api_public_enabled;type:tinyint(1);not null;default:0" json:"automation_api_public_enabled"`
 
+	// AdminFileManagerEnabled (GH #1184) gates the admin File Manager — a
+	// whole-filesystem browser/editor (hard deny-listed in the agent) on the
+	// admin side. OFF by default: it exposes root-owned paths + edits through
+	// the panel UI, so it must be an explicit, deliberate enable.
+	AdminFileManagerEnabled bool `gorm:"column:admin_file_manager_enabled;type:tinyint(1);not null;default:0" json:"admin_file_manager_enabled"`
+
 	// InterceptAppErrorsDefault (GH #879) — server-wide default for the
 	// branded application-error page: nginx serves the themed 500 when a
 	// PHP app returns a 5xx (a fatal is a 500 with an empty body). Domains

--- a/panel-ui/src/App.tsx
+++ b/panel-ui/src/App.tsx
@@ -84,6 +84,7 @@ const AdminTerminal = lazy(() => import("./shells/admin/terminal/AdminTerminal")
 const MyProfile = lazy(() => import("./shells/user/MyProfile").then((m) => ({ default: m.MyProfile })));
 const UserDashboard = lazy(() => import("./shells/user/UserDashboard").then((m) => ({ default: m.UserDashboard })));
 const FileManagerPage = lazy(() => import("./shells/user/files/FileManagerPage").then((m) => ({ default: m.FileManagerPage })));
+const AdminFileManagerPage = lazy(() => import("./shells/admin/files/AdminFileManagerPage").then((m) => ({ default: m.AdminFileManagerPage })));
 const UserDomainList = lazy(() => import("./shells/user/domains/UserDomainList").then((m) => ({ default: m.UserDomainList })));
 const UserDatabasesPage = lazy(() => import("./shells/user/databases/UserDatabasesPage").then((m) => ({ default: m.UserDatabasesPage })));
 const DNSRecordsPage = lazy(() => import("./shells/dns/DNSRecordsPage").then((m) => ({ default: m.DNSRecordsPage })));
@@ -293,6 +294,7 @@ const ThemedApp = () => {
             />
             <Route path="ssl" element={<SSLManagerPage />} />
             <Route path="settings" element={<ServerSettingsPage />} />
+            <Route path="admin-files" element={<AdminFileManagerPage />} />
             <Route path="php-pools">
               <Route index element={<PHPVersionsPage />} />
               <Route path="edit/:id" element={<PHPPoolEdit />} />

--- a/panel-ui/src/hooks/useServerCapabilities.ts
+++ b/panel-ui/src/hooks/useServerCapabilities.ts
@@ -21,6 +21,8 @@ export interface ServerCapabilities {
   api_enabled: boolean;
   /** GH #515: admin web terminal (root_terminal_enabled). Gates the Terminal nav entry. */
   root_terminal_enabled: boolean;
+  /** GH #1184: admin File Manager (whole filesystem). Gates the Admin Files nav entry. */
+  admin_file_manager_enabled: boolean;
   /** GH #361: the server's public IPv4, for the dashboard. "" when unset. */
   public_ipv4: string;
   /** GH #361: the server's public IPv6, for the dashboard. "" when unset. */
@@ -56,6 +58,7 @@ export function useServerCapabilities() {
         quota_enabled: data.quota_enabled !== false,
         api_enabled: data.api_enabled !== false,
         root_terminal_enabled: !!data.root_terminal_enabled,
+        admin_file_manager_enabled: !!data.admin_file_manager_enabled,
         public_ipv4: data.public_ipv4 ?? "",
         public_ipv6: data.public_ipv6 ?? "",
         is_standby: !!data.is_standby,

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -19,6 +19,8 @@
       "docker-apps_desc": "Docker app marketplace",
       "settings": "Server Settings",
       "settings_desc": "Server-wide settings and optional modules",
+      "admin-files": "File Manager",
+      "admin-files_desc": "Browse and edit files across the whole server filesystem (admin only)",
       "server-status": "Server Status",
       "server-status_desc": "Live services, resources, and health",
       "cache": "Cache",

--- a/panel-ui/src/nav.ts
+++ b/panel-ui/src/nav.ts
@@ -147,6 +147,14 @@ export const adminNav: NavItem[] = [
     path: "/jabali-admin/settings",
   },
   {
+    // GH #1184: hidden unless admin_file_manager_enabled (gated in AdminLayout).
+    key: "admin-files",
+    label: "nav.admin.admin-files",
+    description: "nav.admin.admin-files_desc",
+    icon: navIcon(FolderOutlined),
+    path: "/jabali-admin/admin-files",
+  },
+  {
     key: "server-status",
     label: "nav.admin.server-status",
     description: "nav.admin.server-status_desc",

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -47,6 +47,8 @@ export function AdminLayout() {
     if (n.key === "docker-apps") return !!caps?.docker_marketplace_enabled;
     // GH #515: default-off module — hide until explicitly enabled (like docker-apps).
     if (n.key === "terminal") return !!caps?.root_terminal_enabled;
+    // GH #1184: default-off admin File Manager — hide until enabled.
+    if (n.key === "admin-files") return !!caps?.admin_file_manager_enabled;
     if (n.key === "mail") return caps?.mail_enabled !== false;
     if (n.key === "dns") return caps?.dns_enabled !== false;
     if (n.key === "security") return caps?.security_enabled !== false;

--- a/panel-ui/src/shells/admin/files/AdminFileManagerPage.tsx
+++ b/panel-ui/src/shells/admin/files/AdminFileManagerPage.tsx
@@ -1,0 +1,244 @@
+// AdminFileManagerPage — GH #1184 whole-filesystem admin File Manager.
+//
+// Deliberately simpler + separate from the tenant FileManagerPage: browse from
+// "/", open+edit text files in CodeEditor, and mkdir / rename / chmod / delete.
+// The backend is gated by admin auth + the default-off setting and enforces the
+// deny-list, so this page just drives it and surfaces errors.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Breadcrumb, Button, Card, Drawer, Input, Modal, Popconfirm, Space, Table, Tag, Tooltip, Typography,
+} from "antd";
+import {
+  FolderOutlined, FileOutlined, ReloadOutlined, FolderAddOutlined, UpOutlined, SaveOutlined,
+} from "@icons";
+import { feedback } from "../../../lib/feedback";
+import { CodeEditor } from "../../../components/CodeEditor/CodeEditor";
+import {
+  adminFilesList, adminFilesRead, adminFilesWrite, adminFilesDelete,
+  adminFilesMkdir, adminFilesRename, adminFilesChmod, type FileEntry,
+} from "./adminFilesApi";
+
+const languageByExt: Record<string, string> = {
+  conf: "nginx", nginx: "nginx", js: "javascript", ts: "typescript", json: "json",
+  php: "php", html: "html", css: "css", sh: "shell", bash: "shell", yml: "yaml",
+  yaml: "yaml", toml: "toml", sql: "sql", py: "python", go: "go", md: "markdown",
+  ini: "ini", xml: "xml", log: "text", txt: "text",
+};
+
+function langFor(name: string): string {
+  const ext = name.includes(".") ? name.slice(name.lastIndexOf(".") + 1).toLowerCase() : "";
+  return languageByExt[ext] ?? "text";
+}
+
+function joinPath(dir: string, name: string): string {
+  return dir === "/" ? "/" + name : dir + "/" + name;
+}
+
+function parentOf(p: string): string {
+  if (p === "/" || p === "") return "/";
+  const trimmed = p.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx <= 0 ? "/" : trimmed.slice(0, idx);
+}
+
+function errMessage(e: unknown): string {
+  if (e && typeof e === "object" && "response" in e) {
+    const r = (e as { response?: { data?: { error?: string; detail?: string } } }).response;
+    return r?.data?.detail || r?.data?.error || "Request failed";
+  }
+  return e instanceof Error ? e.message : "Request failed";
+}
+
+type PromptMode = null | { kind: "mkdir" } | { kind: "rename"; target: FileEntry } | { kind: "chmod"; target: FileEntry };
+
+export const AdminFileManagerPage = () => {
+  const [cwd, setCwd] = useState("/");
+  const [entries, setEntries] = useState<FileEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [editing, setEditing] = useState<{ path: string; content: string; language: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [prompt, setPrompt] = useState<PromptMode>(null);
+  const [promptValue, setPromptValue] = useState("");
+
+  const load = useCallback(async (path: string) => {
+    setLoading(true);
+    try {
+      const r = await adminFilesList(path);
+      setEntries(r.entries);
+      setCwd(r.path);
+    } catch (e) {
+      feedback.message.error(errMessage(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load("/"); }, [load]);
+
+  const openEntry = async (entry: FileEntry) => {
+    const full = joinPath(cwd, entry.name);
+    if (entry.is_dir) { void load(full); return; }
+    try {
+      const r = await adminFilesRead(full);
+      if (r.is_binary) { feedback.message.warning("Binary file — not editable here."); return; }
+      if (r.truncated) feedback.message.warning("File is large; showing a truncated view. Saving would overwrite with the truncated content — edit via SSH instead.");
+      setEditing({ path: full, content: r.content, language: langFor(entry.name) });
+    } catch (e) {
+      feedback.message.error(errMessage(e));
+    }
+  };
+
+  const save = async () => {
+    if (!editing) return;
+    setSaving(true);
+    try {
+      await adminFilesWrite(editing.path, editing.content);
+      feedback.message.success("Saved");
+      setEditing(null);
+    } catch (e) {
+      feedback.message.error(errMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (entry: FileEntry) => {
+    const full = joinPath(cwd, entry.name);
+    try {
+      await adminFilesDelete(full, entry.is_dir);
+      feedback.message.success("Deleted");
+      void load(cwd);
+    } catch (e) {
+      feedback.message.error(errMessage(e));
+    }
+  };
+
+  const submitPrompt = async () => {
+    if (!prompt) return;
+    const v = promptValue.trim();
+    try {
+      if (prompt.kind === "mkdir") {
+        if (!v) return;
+        await adminFilesMkdir(joinPath(cwd, v));
+      } else if (prompt.kind === "rename") {
+        if (!v) return;
+        await adminFilesRename(joinPath(cwd, prompt.target.name), v);
+      } else if (prompt.kind === "chmod") {
+        if (!/^[0-7]{3,4}$/.test(v)) { feedback.message.error("Mode must be octal, e.g. 0644"); return; }
+        await adminFilesChmod(joinPath(cwd, prompt.target.name), v);
+      }
+      feedback.message.success("Done");
+      setPrompt(null); setPromptValue("");
+      void load(cwd);
+    } catch (e) {
+      feedback.message.error(errMessage(e));
+    }
+  };
+
+  const crumbs = useMemo(() => {
+    const parts = cwd.split("/").filter(Boolean);
+    const items = [{ title: <span style={{ cursor: "pointer" }} onClick={() => void load("/")}><FolderOutlined /> /</span> }];
+    let acc = "";
+    for (const part of parts) {
+      acc += "/" + part;
+      const target = acc;
+      items.push({ title: <span style={{ cursor: "pointer" }} onClick={() => void load(target)}>{part}</span> });
+    }
+    return items;
+  }, [cwd, load]);
+
+  const columns = [
+    {
+      title: "Name", dataIndex: "name", key: "name",
+      render: (name: string, r: FileEntry) => (
+        <span style={{ cursor: "pointer" }} onClick={() => void openEntry(r)}>
+          {r.is_dir ? <FolderOutlined style={{ marginRight: 6 }} /> : <FileOutlined style={{ marginRight: 6 }} />}
+          {name}{r.is_symlink ? <Tag style={{ marginLeft: 6 }}>link</Tag> : null}
+        </span>
+      ),
+    },
+    { title: "Size", dataIndex: "size", key: "size", width: 110, render: (s: number, r: FileEntry) => (r.is_dir ? "—" : `${s}`) },
+    { title: "Mode", dataIndex: "mode", key: "mode", width: 110, render: (m: string) => <code>{m}</code> },
+    { title: "Modified", dataIndex: "mod_time", key: "mod_time", width: 180 },
+    {
+      title: "Actions", key: "actions", width: 220,
+      render: (_: unknown, r: FileEntry) => (
+        <Space size="small">
+          <Button size="small" onClick={() => { setPrompt({ kind: "rename", target: r }); setPromptValue(r.name); }}>Rename</Button>
+          <Button size="small" onClick={() => { setPrompt({ kind: "chmod", target: r }); setPromptValue(r.mode.replace(/^[dl-]/, "").length === 9 ? "" : ""); }}>Perms</Button>
+          <Popconfirm
+            title={r.is_dir ? "Delete this folder and everything in it?" : "Delete this file?"}
+            okButtonProps={{ danger: true }}
+            onConfirm={() => void remove(r)}
+          >
+            <Button size="small" danger>Delete</Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  const promptTitle = prompt?.kind === "mkdir" ? "New folder name"
+    : prompt?.kind === "rename" ? "Rename to"
+    : prompt?.kind === "chmod" ? "Permissions (octal, e.g. 0644)" : "";
+
+  return (
+    <Card
+      title={
+        <Space>
+          <Typography.Text strong>Admin File Manager</Typography.Text>
+          <Tag color="red">whole filesystem</Tag>
+        </Space>
+      }
+      extra={
+        <Space>
+          <Tooltip title="Parent folder"><Button icon={<UpOutlined />} onClick={() => void load(parentOf(cwd))} disabled={cwd === "/"} /></Tooltip>
+          <Button icon={<FolderAddOutlined />} onClick={() => { setPrompt({ kind: "mkdir" }); setPromptValue(""); }}>New folder</Button>
+          <Button icon={<ReloadOutlined />} onClick={() => void load(cwd)}>Refresh</Button>
+        </Space>
+      }
+    >
+      <Breadcrumb style={{ marginBottom: 12 }} items={crumbs} />
+      <Table<FileEntry>
+        rowKey="name"
+        size="small"
+        loading={loading}
+        columns={columns}
+        dataSource={entries}
+        pagination={false}
+        scroll={{ x: true }}
+      />
+
+      <Drawer
+        title={editing?.path}
+        open={!!editing}
+        onClose={() => setEditing(null)}
+        width="70%"
+        extra={<Button type="primary" icon={<SaveOutlined />} loading={saving} onClick={() => void save()}>Save</Button>}
+        destroyOnClose
+      >
+        {editing ? (
+          <CodeEditor value={editing.content} language={editing.language} onChange={(v) => setEditing({ ...editing, content: v })} />
+        ) : null}
+      </Drawer>
+
+      <Modal
+        title={promptTitle}
+        open={!!prompt}
+        onOk={() => void submitPrompt()}
+        onCancel={() => { setPrompt(null); setPromptValue(""); }}
+        destroyOnClose
+      >
+        <Input
+          autoFocus
+          value={promptValue}
+          onChange={(e) => setPromptValue(e.target.value)}
+          onPressEnter={() => void submitPrompt()}
+          placeholder={prompt?.kind === "chmod" ? "0644" : ""}
+        />
+      </Modal>
+    </Card>
+  );
+};
+
+export default AdminFileManagerPage;

--- a/panel-ui/src/shells/admin/files/adminFilesApi.ts
+++ b/panel-ui/src/shells/admin/files/adminFilesApi.ts
@@ -1,0 +1,47 @@
+// adminFilesApi.ts — typed wrappers around /api/v1/admin/files (GH #1184).
+// The whole-filesystem admin File Manager. Every call is gated server-side by
+// admin auth + the default-off admin_file_manager_enabled setting, and the
+// agent enforces the deny-list; this client just shapes the requests.
+import { apiClient } from "../../../apiClient";
+import type { FileEntry, FileListResponse } from "../../user/files/filesApi";
+
+export type { FileEntry, FileListResponse };
+
+export type AdminFileReadResponse = {
+  path: string;
+  content: string;
+  is_binary: boolean;
+  size: number;
+  truncated: boolean;
+  mime_type?: string;
+};
+
+export async function adminFilesList(path: string): Promise<FileListResponse> {
+  const r = await apiClient.get<FileListResponse>("/admin/files", { params: { path } });
+  return r.data;
+}
+
+export async function adminFilesRead(path: string): Promise<AdminFileReadResponse> {
+  const r = await apiClient.get<AdminFileReadResponse>("/admin/files/read", { params: { path } });
+  return r.data;
+}
+
+export async function adminFilesWrite(path: string, content: string): Promise<void> {
+  await apiClient.post("/admin/files/write", { path, content });
+}
+
+export async function adminFilesDelete(path: string, recursive: boolean): Promise<void> {
+  await apiClient.delete("/admin/files", { params: { path, recursive: recursive ? "true" : "false" } });
+}
+
+export async function adminFilesMkdir(path: string): Promise<void> {
+  await apiClient.post("/admin/files/mkdir", { path });
+}
+
+export async function adminFilesRename(path: string, newName: string): Promise<void> {
+  await apiClient.post("/admin/files/rename", { path, new_name: newName });
+}
+
+export async function adminFilesChmod(path: string, mode: string): Promise<void> {
+  await apiClient.post("/admin/files/chmod", { path, mode });
+}

--- a/panel-ui/src/shells/admin/settings/AdminFileManagerCard.tsx
+++ b/panel-ui/src/shells/admin/settings/AdminFileManagerCard.tsx
@@ -1,0 +1,82 @@
+// AdminFileManagerCard — opt-in toggle for the GH #1184 admin File Manager, a
+// whole-filesystem browser/editor on the admin side. OFF by default and kept
+// deliberately loud: it exposes root-owned paths + edits through the panel UI
+// (a hard deny-list protects credentials, SSH, and jabali's own control plane),
+// so enabling it is a conscious decision.
+import { App, Alert, Card, Space, Switch, Tag, Typography } from "antd";
+import { useEffect, useState } from "react";
+
+import { apiClient } from "../../../apiClient";
+
+interface ServerSettingsAdminFM {
+  admin_file_manager_enabled: boolean;
+}
+
+export function AdminFileManagerCard() {
+  const { message } = App.useApp();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const r = await apiClient.get<ServerSettingsAdminFM>("/admin/settings");
+      setEnabled(!!r.data.admin_file_manager_enabled);
+    } catch (err) {
+      message.error(`Could not load the Admin File Manager setting: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  useEffect(() => { void refresh(); }, []);
+
+  const toggle = async (value: boolean) => {
+    setBusy(true);
+    try {
+      await apiClient.patch("/admin/settings", { admin_file_manager_enabled: value });
+      setEnabled(value);
+      message.success(value ? "Admin File Manager enabled" : "Admin File Manager disabled");
+    } catch (err) {
+      message.error(`Could not update the setting: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card
+      title={
+        <Space>
+          <Typography.Text strong>Admin File Manager</Typography.Text>
+          <Tag color="red">whole filesystem</Tag>
+        </Space>
+      }
+    >
+      <Space direction="vertical" style={{ width: "100%" }} size="middle">
+        <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+          Adds a File Manager on the admin side that can browse and edit files anywhere on the
+          server (starting from <code>/</code>) — useful for editing service configs, clearing
+          logs, or cleaning caches without opening an SFTP client.
+        </Typography.Paragraph>
+        <Alert
+          type="warning"
+          showIcon
+          message="Powerful — leave off unless you need it"
+          description={
+            <span>
+              This gives the admin UI root-level read/write across the filesystem. A hard deny-list
+              blocks credential stores (<code>/etc/shadow</code>, <code>/etc/ssh</code>), Let's Encrypt
+              keys, and jabali's own config/binaries/sockets, but everything else is reachable. Anyone
+              with an admin session — or a bug in the file paths — inherits that reach. Enable it only
+              when you actively need it, then turn it back off.
+            </span>
+          }
+        />
+        <Space>
+          <Switch checked={!!enabled} loading={busy || enabled === null} onChange={(v) => void toggle(v)} />
+          <Typography.Text>{enabled ? "Enabled" : "Disabled"}</Typography.Text>
+        </Space>
+      </Space>
+    </Card>
+  );
+}
+
+export default AdminFileManagerCard;

--- a/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
+++ b/panel-ui/src/shells/admin/settings/ServerSettingsPage.tsx
@@ -51,6 +51,7 @@ import { LookAndFeelCard } from "./LookAndFeelCard";
 import { DatabasesCard } from "./DatabasesCard";
 import { DockerMarketplaceCard } from "./DockerMarketplaceCard";
 import { PythonAppsCard } from "./PythonAppsCard";
+import { AdminFileManagerCard } from "./AdminFileManagerCard";
 import { PHPPerformanceModesCard } from "./PHPPerformanceModesCard";
 import { DatabaseAdminSections } from "./DatabaseAdminSections";
 import { DNSResolversCard } from "./DNSResolversCard";
@@ -1057,6 +1058,7 @@ export const ServerSettingsPage = () => {
         <Space direction="vertical" style={{ width: "100%" }} size="large">
           <DockerMarketplaceCard />
           <PythonAppsCard />
+          <AdminFileManagerCard />
           <PHPPerformanceModesCard />
         </Space>
       ),


### PR DESCRIPTION
## What & why

GH #1184 (lxsdevcode): a File Manager on the **admin** side that reaches the whole
server filesystem (from `/`) — for editing service configs, clearing logs, cleaning
caches — **disabled by default** and explicitly enabled when needed.

## Security model (the important part)

The agent already runs as **root, AppArmor-unconfined**, so the boundary for the
existing File Manager is the software `filesafe` scope (per command, confined to
`/home/<user>`), not the OS. This feature opens that scope to `/` **only** for
admins, behind two gates and a hard deny-list:

- **Two gates**: every `/admin/files/*` route requires admin claims **and** the
  default-off `admin_file_manager_enabled` server setting (migration 000271).
- **Hard deny-list, enforced agent-side** (`filesafe.NewAdminScope` +
  `DefaultAdminDeniedPrefixes`): blocks `/etc/shadow`, `/etc/ssh`, `/root/.ssh`,
  `/etc/sudoers*`, `/etc/jabali` (config + the 0755-perms SSH-lockout footgun),
  `/etc/letsencrypt` (cert keys), the jabali binaries, and the agent/panel
  sockets — for **all** ops (read/write/chmod/delete). The check runs on both
  the cleaned path **and** the symlink-resolved path, so a symlink from an
  allowed dir into a denied one is rejected. Word-boundary matching (`/etc/ssh`
  blocks `/etc/ssh/*` but not `/etc/sshfoo`).
- **Never reassigns ownership**: admin write/mkdir preserve an existing file's
  owner+mode (new file root:root 0644, new dir 0755) — a root-tree file is never
  chowned to a tenant.
- **Audited**: every mutation writes an append-only audit event (actor=admin,
  target=path, never contents).

Threat framing: the admin already has root SSH, so "admin gains root" is not the
threat. The risks this bounds are (a) a **stolen admin session** becoming root
filesystem access instead of tenant-scoped damage, and (b) any path/symlink bug
escalating tenant→root. Enable-when-needed + the deny-list address both; a proper
long-term hardening is per-user loopback / netns isolation (separate).

## How

- `filesafe`: `NewAdminScope` (root scope + deny-list); tenant scopes are a pure
  no-op change (empty deny-list) — a test pins that they behave exactly as before.
- Agent: 9 file commands take an `admin_root` flag → `fileScopeFor` picks the
  admin or home scope.
- Panel: `/admin/files/*` handler (list/read/write/delete/mkdir/rename/chmod),
  **separate** from the tenant handler so that path is untouched; opt-in setting;
  audit; `admin_file_manager_enabled` surfaced on `/me/server-capabilities`.
- UI: a purpose-built admin File Manager page (browse + CodeEditor edit + the
  management ops), an opt-in toggle card on Server Settings → Modules (loud
  warning), nav gated on the capability.

## Scope note

Upload/archive/copy/move are intentionally deferred to a follow-up (admin has SSH
for bulk transfer); v1 covers the reporter's stated use-cases (edit configs,
delete logs, clear caches).

## Test plan

- [x] `filesafe`: root reaches FS, deny-list blocks (incl. symlink-resolved),
  word boundaries, tenant scope unchanged
- [x] agent file tests green (tenant behaviour intact); `go build ./...`
- [x] panel `go test ./internal/{api,app}` green; openapi coverage + wire
  drift-guard green
- [x] `tsc -b` clean; all 243 vitest pass (incl. the #970 feedback guard)
- [ ] Box-verify on the smoke box: enable setting → list `/etc/nginx`, read a
  config, write `/tmp` file, confirm `/etc/shadow` + `/etc/jabali` are denied,
  mkdir/rename/chmod/delete round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)