### PR TITLE
docs(readme): header logo 420px

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="panel-ui/public/images/jabali_logo_dark.png">
-    <img src="panel-ui/public/images/jabali_logo.png" alt="Jabali Panel" width="120">
+    <img src="panel-ui/public/images/jabali_logo.png" alt="Jabali Panel" width="420">
   </picture>
 
 # Jabali Panel


### PR DESCRIPTION
Bumps the README header logo from 120px to 420px (per request).