### PR TITLE
fix(security): enforce log-grant scope in the CLI adapter (JAB-303)

### DIFF
--- a/panel-api/cmd/server/log_cmd.go
+++ b/panel-api/cmd/server/log_cmd.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -25,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/logaccess"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -109,16 +111,26 @@ func newLogAccessCreateCmd() *cobra.Command {
 			}
 			repo := logAccessRepoFromDB()
 
+			// JAB-303: enforce the SAME grant-scope policy the HTTP handler uses.
+			// The beneficiary is --user (u); a nil-domain grant is server-wide, so
+			// it is admin-only. Without this an operator could mint a server-wide
+			// grant owned by a tenant (cross-tenant / system log disclosure).
 			var domainID *string
-			if domainRef != "" {
+			domainProvided := domainRef != ""
+			domainOwned := false
+			if domainProvided {
 				dom, derr := resolveDomainCLI(ctx, domainRef)
 				if derr != nil {
 					return derr
 				}
-				if dom.UserID != u.ID {
-					return fmt.Errorf("domain %s does not belong to %s", dom.Name, u.Email)
-				}
+				domainOwned = dom.UserID == u.ID
 				domainID = &dom.ID
+			}
+			if err := logaccess.ValidateGrantScope(u.IsAdmin, domainProvided, domainOwned); err != nil {
+				if errors.Is(err, logaccess.ErrDomainNotOwned) {
+					return fmt.Errorf("domain %s does not belong to %s", domainRef, u.Email)
+				}
+				return fmt.Errorf("%w (user %s is not an admin)", err, u.Email)
 			}
 
 			// Per-user concurrency cap (5), same as the REST handler.

--- a/panel-api/cmd/server/log_cmd_scope_test.go
+++ b/panel-api/cmd/server/log_cmd_scope_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLogAccessCreate_RoutesThroughSharedScopePolicy is the CLI half of the
+// JAB-303 parity contract. The CLI is the path that was actually vulnerable
+// (it minted nil-domain, hence server-wide, grants for tenant beneficiaries),
+// but a live rejection test needs a seeded DB fixture that cmd/server does not
+// have. Following the repo's cross-language pin precedent
+// (install/tests/test_ftp_module_optin.sh §7, which source-pins a Go file), this
+// asserts the mint path delegates to logaccess.ValidateGrantScope so the guard
+// cannot be silently deleted, leaving the server-wide-for-tenant hole behind.
+func TestLogAccessCreate_RoutesThroughSharedScopePolicy(t *testing.T) {
+	src, err := os.ReadFile("log_cmd.go")
+	if err != nil {
+		t.Fatalf("read log_cmd.go: %v", err)
+	}
+	if !strings.Contains(string(src), "logaccess.ValidateGrantScope(u.IsAdmin") {
+		t.Fatal("log access create must gate the mint through logaccess.ValidateGrantScope(u.IsAdmin, ...) — a nil-domain grant is server-wide and must be admin-only (JAB-303)")
+	}
+}

--- a/panel-api/internal/api/logs.go
+++ b/panel-api/internal/api/logs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/logaccess"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -182,8 +184,11 @@ func (h *logHandler) createAccess(c *gin.Context) {
 		return
 	}
 
-	// Validate domain access if domain_id is provided
-	if req.DomainID != "" {
+	// Validate grant scope through the shared policy (JAB-303). The caller is
+	// the beneficiary here, so claims.IsAdmin is the beneficiary's admin status.
+	domainProvided := req.DomainID != ""
+	domainOwned := false
+	if domainProvided {
 		if h.cfg.Domains == nil {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "domain service not available"})
 			return
@@ -198,15 +203,15 @@ func (h *logHandler) createAccess(c *gin.Context) {
 			}
 			return
 		}
+		domainOwned = domain.UserID == claims.UserID
+	}
 
-		// Non-admin users can only access their own domain logs
-		if !claims.IsAdmin && domain.UserID != claims.UserID {
+	if err := logaccess.ValidateGrantScope(claims.IsAdmin, domainProvided, domainOwned); err != nil {
+		if errors.Is(err, logaccess.ErrDomainNotOwned) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
-			return
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "domain_id required for non-admin users"})
 		}
-	} else if !claims.IsAdmin {
-		// Non-admin users must specify a domain
-		c.JSON(http.StatusBadRequest, gin.H{"error": "domain_id required for non-admin users"})
 		return
 	}
 

--- a/panel-api/internal/api/logs_access_scope_test.go
+++ b/panel-api/internal/api/logs_access_scope_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+// TestCreateAccess_TenantWithoutDomainRejected is the HTTP-adapter half of the
+// JAB-303 parity contract. The shared accept/reject matrix is pinned by the
+// logaccess policy truth table; the CLI's delegation is pinned by
+// TestLogAccessCreate_RoutesThroughSharedScopePolicy; this test pins the HTTP
+// handler's delegation. A non-admin caller that omits domain_id is asking for a
+// server-wide log grant, which the shared policy forbids — the handler must
+// return 400 before any stream row is created. Empty repos are fine: the
+// rejection happens in ValidateGrantScope, ahead of any repository call.
+func TestCreateAccess_TenantWithoutDomainRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "tenant1", IsAdmin: false})
+		c.Next()
+	})
+	RegisterLogRoutes(v1, LogHandlerConfig{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/logs/access",
+		strings.NewReader(`{"log_type":"access"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("tenant without domain must be rejected 400, got %d (%s)", rec.Code, rec.Body.String())
+	}
+}

--- a/panel-api/internal/logaccess/policy.go
+++ b/panel-api/internal/logaccess/policy.go
@@ -1,0 +1,55 @@
+// Package logaccess holds the authorization policy shared by every adapter that
+// mints a log-stream access grant (the HTTP /logs handler and the operator
+// `jabali log access create` CLI).
+//
+// Security (JAB-303): a log-stream grant with a nil DomainID streams SYSTEM-WIDE
+// logs — nginx access/error and the GoAccess report for the whole server — as
+// resolved by the WS stream handler (websocket_logs.go: `stream.DomainID == nil`
+// takes the systemLogPath branch). The grant record is the ONLY gate; the WS
+// consumer authorizes purely on the stream key + the grant's scope. Therefore
+// the moment of minting is where the actor/beneficiary scope must be enforced.
+//
+// The HTTP adapter already enforced this (a non-admin caller must name a domain
+// they own); the CLI adapter did not, so an operator could mint a nil-domain,
+// hence server-wide, grant OWNED BY A TENANT — a cross-tenant / system log
+// disclosure. Both adapters now route the decision through ValidateGrantScope so
+// the policy cannot drift between them again.
+package logaccess
+
+import "errors"
+
+// ErrDomainRequired is returned when a non-admin beneficiary omits the domain.
+// A nil-domain grant is server-wide, so it is never valid for a tenant.
+var ErrDomainRequired = errors.New("log access: a domain owned by the beneficiary is required for non-admin grants")
+
+// ErrDomainNotOwned is returned when a non-admin beneficiary names a domain that
+// they do not own.
+var ErrDomainNotOwned = errors.New("log access: domain is not owned by the grant beneficiary")
+
+// ValidateGrantScope enforces the log-stream grant scope policy.
+//
+//   - beneficiaryIsAdmin — admin status of the grant OWNER (the user the stream
+//     is minted for), NOT necessarily the caller. In the HTTP path the caller is
+//     the beneficiary; in the CLI path an operator mints for --user.
+//   - domainProvided — whether the grant is scoped to a specific domain.
+//   - domainOwnedByBeneficiary — whether that domain belongs to the beneficiary
+//     (ignored when domainProvided is false).
+//
+// Rules:
+//   - No domain: allowed only for an admin beneficiary (server-wide scope).
+//     A non-admin beneficiary is rejected with ErrDomainRequired.
+//   - Domain given: a non-admin beneficiary must own it, else ErrDomainNotOwned.
+//     An admin beneficiary may be scoped to any domain (an admin already has
+//     server-wide access, so a single tenant's domain is strictly narrower).
+func ValidateGrantScope(beneficiaryIsAdmin, domainProvided, domainOwnedByBeneficiary bool) error {
+	if !domainProvided {
+		if !beneficiaryIsAdmin {
+			return ErrDomainRequired
+		}
+		return nil
+	}
+	if !beneficiaryIsAdmin && !domainOwnedByBeneficiary {
+		return ErrDomainNotOwned
+	}
+	return nil
+}

--- a/panel-api/internal/logaccess/policy_test.go
+++ b/panel-api/internal/logaccess/policy_test.go
@@ -1,0 +1,46 @@
+package logaccess
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateGrantScope is the parity contract for JAB-303: both the HTTP
+// handler and the CLI mint through ValidateGrantScope, so this full truth table
+// pins the identical accept/reject matrix for both adapters. The security-
+// critical row is {non-admin, no domain} -> ErrDomainRequired: a nil-domain
+// grant is server-wide, and before this fix the CLI let a tenant beneficiary
+// obtain one.
+func TestValidateGrantScope(t *testing.T) {
+	cases := []struct {
+		name           string
+		isAdmin        bool
+		domainProvided bool
+		domainOwned    bool
+		wantErr        error
+	}{
+		// Non-admin beneficiary (tenant).
+		{"tenant, no domain -> rejected (server-wide is admin-only)", false, false, false, ErrDomainRequired},
+		{"tenant, own domain -> allowed", false, true, true, nil},
+		{"tenant, other's domain -> rejected", false, true, false, ErrDomainNotOwned},
+
+		// Admin beneficiary.
+		{"admin, no domain -> allowed (server-wide)", true, false, false, nil},
+		{"admin, any domain -> allowed", true, true, false, nil},
+		{"admin, own domain -> allowed", true, true, true, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateGrantScope(tc.isAdmin, tc.domainProvided, tc.domainOwned)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("want nil error, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Vulnerability (JAB-303, urgent · cross-tenant/system log disclosure)

A log-stream access grant with a **nil `DomainID`** streams **server-wide** logs
— nginx access/error and the GoAccess report for the whole box
(`websocket_logs.go` takes the `systemLogPath` branch when `stream.DomainID` is
nil). The grant row is the **only** gate: the WebSocket consumer authorizes on
the stream key + the grant's scope, nothing re-checks admin at stream time.

The HTTP handler enforced the scope (a non-admin caller must name a domain they
own — `logs.go:207`), but the operator CLI `jabali log access create` did **not**:
with `--domain` omitted it minted a nil-domain — hence **server-wide** — grant
owned by whatever `--user` was named, **including a tenant**. A `grep` for
`models.LogAccessStream{` mint sites confirms HTTP + CLI are the only two writers,
so gating both fully closes the hole.

## Fix

Extract the decision into `internal/logaccess.ValidateGrantScope` and route
**both** adapters through it, so the policy can't drift between them again:
- **No domain** → allowed only for an admin beneficiary (server-wide is admin-only).
- **Domain given** → a non-admin beneficiary must own it; an admin may target any
  domain (strictly narrower than the server-wide access an admin already has).

HTTP status codes preserved exactly (400 missing-domain / 403 unowned / 404 / 503).
Also fixes a latent CLI over-restriction (it rejected an admin beneficiary scoped
to another user's domain), so CLI and HTTP now accept/reject the identical rows.

## Tests
- `internal/logaccess/policy_test.go` — full accept/reject truth table (the shared parity contract).
- `internal/api/logs_access_scope_test.go` — HTTP tenant-without-domain → 400 before any row is created.
- `cmd/server/log_cmd_scope_test.go` — source-pins the CLI mint's delegation to `ValidateGrantScope` (cmd/server has no DB fixture for a live rejection; same cross-language pin precedent as `test_ftp_module_optin.sh §7`).

## Acceptance criteria
- [x] A tenant beneficiary always requires a domain owned by that tenant.
- [x] Only an explicit admin-scope grant may have nil `DomainID`.
- [ ] **Concurrent creation cannot exceed the grant quota** — the max-5 cap is a pre-existing check-then-create race on **both** paths; a resource-bypass, not a disclosure. Deferred to **JAB-347** rather than half-fixed here.
- [x] Tokens remain secret, time-bounded, revocable (unchanged — 16-byte key, 15-min expiry, revoke command).
- [x] HTTP and CLI parity tests assert identical valid rows and rejection cases.

## Test plan
- [x] `go test ./internal/logaccess/ ./internal/api/ ./cmd/server/` — green
- [x] `go vet` + `gofmt` clean; `TestCLIReferenceGolden` / `TestOpenAPICoverage` pass (no route/flag changes)
- [x] `TestExecSeam_NoRawExec` unaffected

GH JAB-303 · follow-up JAB-347