### PR TITLE
fix(security): exact same-origin policy for privileged DB-console SSO (JAB-304)

### DIFF
--- a/panel-api/internal/api/databases_admin_ops.go
+++ b/panel-api/internal/api/databases_admin_ops.go
@@ -87,20 +87,6 @@ func RegisterDatabaseAdminOpsRoutes(g *gin.RouterGroup, cfg DatabaseAdminOpsHand
 	grp.POST("/processes/kill", h.killProcess)
 }
 
-// sameOriginOK is a lightweight CSRF guard (ADR-0099): the request must
-// originate from the panel itself. Mirrors the per-user SSO handler's
-// intent without importing its unexported helpers.
-func sameOriginOK(c *gin.Context) bool {
-	origin := c.GetHeader("Origin")
-	if origin == "" {
-		// Some browsers omit Origin on top-level navigations; fall back
-		// to Referer host match.
-		ref := c.GetHeader("Referer")
-		return ref == "" || strings.Contains(ref, c.Request.Host)
-	}
-	return strings.Contains(origin, c.Request.Host)
-}
-
 func panelBaseURL(c *gin.Context) string {
 	scheme := "https"
 	if p := c.GetHeader("X-Forwarded-Proto"); p == "http" {
@@ -433,7 +419,7 @@ func (h *databaseAdminOpsHandler) ssoPhpMyAdminAdmin(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	if !sameOriginOK(c) {
+	if !sameOriginStrict(c) {
 		h.audit(ctx, claims.UserID, "mariadb", "sso.admin", "phpmyadmin", "forbidden", "same_origin")
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return
@@ -650,7 +636,7 @@ func (h *databaseAdminOpsHandler) ssoAdminerAdmin(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	if !sameOriginOK(c) {
+	if !sameOriginStrict(c) {
 		h.audit(ctx, claims.UserID, "postgres", "sso.admin", "adminer", "forbidden", "same_origin")
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return

--- a/panel-api/internal/api/sso_adminer.go
+++ b/panel-api/internal/api/sso_adminer.go
@@ -160,23 +160,9 @@ func (h *ssoAdminerHandler) getAdminerBaseURL(c *gin.Context) string {
 }
 
 func (h *ssoAdminerHandler) validateSameOrigin(c *gin.Context) bool {
-	origin := c.GetHeader("Origin")
-	referer := c.GetHeader("Referer")
-	if origin != "" {
-		return h.urlMatchesHost(c, origin)
-	}
-	if referer != "" {
-		return h.urlMatchesHost(c, referer)
-	}
-	return false
-}
-
-func (h *ssoAdminerHandler) urlMatchesHost(c *gin.Context, raw string) bool {
-	u, err := url.Parse(raw)
-	if err != nil || u.Host == "" {
-		return false
-	}
-	return hostnameOf(u.Host) == hostnameOf(c.Request.Host)
+	// One shared exact same-origin policy across every DB-console SSO mint
+	// (JAB-304). Behaviour is unchanged for this already-strict path.
+	return sameOriginStrict(c)
 }
 
 func (h *ssoAdminerHandler) audit(ctx context.Context, userID, databaseID, hashPrefix, engine, outcome string) {

--- a/panel-api/internal/api/sso_origin.go
+++ b/panel-api/internal/api/sso_origin.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+)
+
+// sameOriginStrict is the single exact same-origin (CSRF) guard (ADR-0099) for
+// every browser-facing DB-console SSO mint — tenant phpMyAdmin, tenant Adminer,
+// and the privileged admin consoles (JAB-304). A state-changing POST is accepted
+// only when the Origin header (or, if absent, the Referer header) parses and its
+// hostname EXACTLY equals the request host's hostname (port stripped).
+//
+// Two look-alike-host bypasses this closes on the privileged path, which
+// previously used strings.Contains + an absent-header allowance:
+//   - Missing BOTH Origin and Referer is rejected (an old-browser/curl POST is
+//     less important than blocking a header-stripping CSRF).
+//   - A deceptive host that merely CONTAINS the panel host as a substring —
+//     panel.example.com.attacker.tld, or evilpanel.example.com — never matches,
+//     because comparison is on the parsed hostname with exact equality.
+//
+// hostnameOf (sso_phpmyadmin.go) handles the nginx `Host $host` port stripping
+// and IPv6-literal cases; browsers send Origin with the visible port, so the
+// invariant we can actually enforce is scheme-agnostic hostname equality.
+func sameOriginStrict(c *gin.Context) bool {
+	if origin := c.GetHeader("Origin"); origin != "" {
+		return urlHostMatches(c, origin)
+	}
+	if referer := c.GetHeader("Referer"); referer != "" {
+		return urlHostMatches(c, referer)
+	}
+	return false
+}
+
+// urlHostMatches parses raw (an Origin or Referer value) and reports whether its
+// hostname equals the request host's hostname. A parse error or empty host is a
+// non-match, never a pass.
+func urlHostMatches(c *gin.Context, raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return hostnameOf(u.Host) == hostnameOf(c.Request.Host)
+}

--- a/panel-api/internal/api/sso_origin_test.go
+++ b/panel-api/internal/api/sso_origin_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func originCtx(host, origin, referer string) *gin.Context {
+	req := httptest.NewRequest("POST", "/admin/databases/sso/phpmyadmin", nil)
+	req.Host = host
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	if referer != "" {
+		req.Header.Set("Referer", referer)
+	}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+	return c
+}
+
+// TestSameOriginStrict pins the JAB-304 policy shared by every browser DB-console
+// SSO mint (tenant phpMyAdmin, tenant Adminer, privileged admin consoles). The
+// privileged path previously used strings.Contains + accepted absent headers,
+// which the substring/missing-header rows below now prove closed.
+func TestSameOriginStrict(t *testing.T) {
+	const host = "panel.example.com"
+	cases := []struct {
+		name    string
+		host    string
+		origin  string
+		referer string
+		want    bool
+	}{
+		{"origin exact match", host, "https://panel.example.com", "", true},
+		{"origin with visible port still matches (hostname-only)", host, "https://panel.example.com:8443", "", true},
+		{"request host carries a port too", "panel.example.com:443", "https://panel.example.com", "", true},
+
+		// Deceptive substring hosts — the strings.Contains bypass, now rejected.
+		{"suffix-appended attacker host rejected", host, "https://panel.example.com.attacker.tld", "", false},
+		{"prefix look-alike host rejected", host, "https://evilpanel.example.com", "", false},
+		{"foreign origin rejected", host, "https://attacker.tld", "", false},
+
+		// Missing headers — the absent-header allowance, now rejected.
+		{"missing origin AND referer rejected", host, "", "", false},
+
+		// Referer fallback when Origin is absent.
+		{"referer fallback exact match", host, "", "https://panel.example.com/db/index.php", true},
+		{"referer fallback foreign rejected", host, "", "https://attacker.tld/x", false},
+
+		// Unparseable origin is a non-match, never a pass.
+		{"garbage origin rejected", host, "://", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sameOriginStrict(originCtx(tc.host, tc.origin, tc.referer))
+			if got != tc.want {
+				t.Fatalf("sameOriginStrict(host=%q, origin=%q, referer=%q) = %v, want %v",
+					tc.host, tc.origin, tc.referer, got, tc.want)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/sso_phpmyadmin.go
+++ b/panel-api/internal/api/sso_phpmyadmin.go
@@ -198,19 +198,9 @@ func (h *ssoPhpMyAdminHandler) auditLog(ctx context.Context, userID, databaseID,
 // string comparison always fails on the panel's nginx-fronted topology.
 // Hostname + scheme is the actual same-origin invariant we need.
 func (h *ssoPhpMyAdminHandler) validateSameOrigin(c *gin.Context) bool {
-	origin := c.GetHeader("Origin")
-	referer := c.GetHeader("Referer")
-
-	if origin != "" {
-		return h.urlMatchesHost(c, origin)
-	}
-	if referer != "" {
-		return h.urlMatchesHost(c, referer)
-	}
-	// No origin/referer. Conservative: reject. POST from old browsers
-	// or curl without headers is less critical than blocking
-	// cross-origin attacks.
-	return false
+	// One shared exact same-origin policy across every DB-console SSO mint
+	// (JAB-304). Behaviour is unchanged for this already-strict path.
+	return sameOriginStrict(c)
 }
 
 // urlMatchesHost parses raw and compares its hostname (port stripped)


### PR DESCRIPTION
## Vulnerability (JAB-304, urgent · privileged-console CSRF/origin bypass)

The privileged DB-console SSO mints (`POST /admin/databases/sso/phpmyadmin` and
`/sso/adminer`) guarded CSRF with `sameOriginOK`, weaker than the tenant
phpMyAdmin/Adminer flows in two exploitable ways:

- **Missing headers accepted** — with no `Origin` *and* no `Referer`, `ref == ""`
  returned `true`, so a header-stripping cross-site POST could mint a privileged
  **all-databases** SSO handoff.
- **Substring host match** — `strings.Contains(origin, Request.Host)` passed any
  deceptive host that merely *contains* the panel host: `panel.example.com.attacker.tld`,
  `evilpanel.example.com`.

## Fix

Extract the tenant flows' already-strict logic into one package-level policy
`sameOriginStrict` (`sso_origin.go`, ADR-0099): accept only when `Origin` (or
`Referer` when `Origin` is absent) parses and its **hostname exactly equals** the
request host's hostname (port stripped); **reject when both headers are missing**.
Route all three browser adapters — privileged, tenant phpMyAdmin, tenant Adminer —
through it, so the policy can't drift between them. The two already-strict tenant
paths keep identical behaviour; only the privileged path is tightened.

Repo-wide grep confirms no other substring-based Origin/Referer/Host check remains
(the CORS middleware's `isSameOrigin` is exact-equality + allow-list, unaffected).
The privileged handlers already audit `forbidden`/`ok` without logging token
material (unchanged).

## ⚠️ Behavior change
Scripted/`curl` mints now **403** (`forbidden`/`same_origin` audit row) unless they
send the panel Origin: `-H 'Origin: https://<panel-host>'`. Browser/SPA POSTs always
send `Origin`, so no UI regression — this only affects header-less clients.

## Tests
`sso_origin_test.go` — full matrix: exact match (with/without visible port),
suffix- and prefix-look-alike hosts rejected, missing-both-headers rejected,
Referer fallback, unparseable origin. Full `internal/api` suite green (confirms the
phpMyAdmin/Adminer delegation didn't regress existing SSO tests).

## Acceptance criteria
- [x] Missing or foreign Origin/Referer rejected uniformly for browser minting.
- [x] Deceptive substring hosts rejected.
- [ ] Database and engine scope encoded identically → deep-module refactor, **JAB-348**.
- [x] Every issuance success/failure audited without token material (unchanged).
- [ ] Tenant/privileged/CLI adapter contract tests over one matrix → **JAB-348** (origin-policy half covered here).

## Test plan
- [x] `go test ./internal/api/` green; `go vet` + `gofmt` clean
- [x] No route/flag changes → goldens/OpenAPI unaffected

GH JAB-304 · follow-up JAB-348