### PR TITLE
fix(security): sever webmail popup opener in DomainMailboxesSection (JAB-330)

### DIFF
--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.test.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.test.tsx
@@ -237,6 +237,47 @@ describe("DomainMailboxesSection — quota progress bar", () => {
   });
 });
 
+describe("DomainMailboxesSection — webmail SSO opener isolation (JAB-330)", () => {
+  it("severs popup.opener synchronously, before the async SSO mint (reverse-tabnab guard)", async () => {
+    mockInitialFetches({
+      emailEnabled: true,
+      mailboxes: [
+        {
+          id: "mb1",
+          email: "alice@example.com",
+          quota_bytes: 1 << 30,
+          last_usage_bytes: 0,
+        },
+      ],
+    });
+    // The SSO mint never resolves: the opener MUST already be null by then, so
+    // this proves the severing happens up front, not in onSuccess (where the
+    // reverse-tabnabbing window is already open).
+    mocked.post.mockReturnValue(new Promise<never>(() => {}));
+
+    const fakePopup = {
+      opener: {} as unknown,
+      location: { href: "" },
+      close: vi.fn(),
+    };
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue(fakePopup as unknown as Window);
+
+    try {
+      renderSection();
+      const btn = await screen.findByRole("button", { name: /open webmail/i });
+      fireEvent.click(btn);
+
+      // Popup opened blank (blocker-dodge) and opener severed synchronously.
+      expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+      expect(fakePopup.opener).toBeNull();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});
+
 describe("DomainMailboxesSection — in-dialog domain picker", () => {
   it("does NOT render the picker when domainOptions is omitted (single-domain contexts)", async () => {
     mockInitialFetches({ emailEnabled: true, mailboxes: [] });

--- a/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
+++ b/panel-ui/src/shells/admin/domains/DomainMailboxesSection.tsx
@@ -194,6 +194,12 @@ export const DomainMailboxesSection = ({
       );
       return;
     }
+    // JAB-330: sever the opener link BEFORE the async SSO mint so the webmail
+    // tab can never reach back into the panel window (reverse tabnabbing). Must
+    // run synchronously here — the same fix the sibling mailbox flows already
+    // apply. (noopener can't be passed to window.open: it returns null and
+    // breaks the synchronous-popup-then-set-href trick that dodges blockers.)
+    popup.opener = null;
     ssoMutation.mutate(
       { id: row.id },
       {


### PR DESCRIPTION
## Vulnerability (JAB-330, urgent · reverse tabnabbing)

The admin domain mailbox list opened the webmail SSO tab with
`window.open("about:blank")` and navigated it to the minted SSO URL, but **never
cleared `popup.opener`**. The sibling mailbox flows (`AdminMailPage`,
`MailboxesTab`) already null the opener; this one did not — so the webmail page
could reach back into the panel window via `window.opener` (redirect it, or
script it) for the whole mint round-trip.

## Fix

Set `popup.opener = null` **synchronously**, right after the popup opens and
before the async SSO mint — the same up-front severing the sibling flows use.
Clearing it in `onSuccess` would be too late. (`noopener` can't be passed to
`window.open` here — it returns `null` and breaks the synchronous-popup-then-
set-href trick that dodges popup blockers.)

A sweep of every `window.open("about:blank")` site confirms **all three** webmail
launchers now clear the opener, so no path leaves the SSO tab with panel-window
access.

## Test
`DomainMailboxesSection.test.tsx` — asserts the opener is nulled synchronously on
the "Open webmail" click while the SSO mint is still pending (mint mocked to a
never-resolving promise, so passing proves the severing is up-front, not in
`onSuccess`). Full file suite: 8 passed. `tsc -b` clean.

## Acceptance criteria
- [x] Every webmail path clears `opener` before asynchronous work (verified by sweep).
- [x] The SSO URL is never opened with access to the panel window.
- [ ] Blocked popups and mint failures close/report **consistently** across callers → the shared "Safe Webmail Launcher" module, **JAB-354**.
- [ ] Unit tests cover **all three** callers → **JAB-354** (the previously-broken caller is covered here).

GH JAB-330 · follow-up JAB-354