### PR TITLE
fix(security): rule containment on CLI directory-privacy cred-remove (JAB-316)

### DIFF
--- a/panel-api/cmd/server/domain_directory_privacy_cmd.go
+++ b/panel-api/cmd/server/domain_directory_privacy_cmd.go
@@ -315,8 +315,22 @@ func newDirPrivacyCredRemoveCmd() *cobra.Command {
 				return err
 			}
 			repo := repository.NewDomainDirectoryPrivacyRepository(sharedDB)
-			if _, err := resolvePrivacyRule(ctx, repo, dom.ID, args[1]); err != nil {
+			rule, err := resolvePrivacyRule(ctx, repo, dom.ID, args[1])
+			if err != nil {
 				return err
+			}
+			// JAB-316: verify the credential belongs to THIS rule before deleting
+			// it. Without this containment check the CLI deletes any credential ID
+			// under the guise of an unrelated rule the operator names — a
+			// cross-rule credential deletion. The HTTP adapter already enforces
+			// cred.RuleID == rule.ID; fail closed (never delete) on a mismatch or
+			// a missing credential.
+			cred, err := repo.FindCredentialByID(ctx, args[2])
+			if err != nil {
+				return fmt.Errorf("credential %s not found", args[2])
+			}
+			if cred.RuleID != rule.ID {
+				return fmt.Errorf("credential %s does not belong to rule %s", args[2], rule.ID)
 			}
 			if err := repo.DeleteCredential(ctx, args[2]); err != nil {
 				return fmt.Errorf("delete credential: %w", err)

--- a/panel-api/cmd/server/domain_directory_privacy_cmd_containment_test.go
+++ b/panel-api/cmd/server/domain_directory_privacy_cmd_containment_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDirPrivacyCredRemove_EnforcesRuleContainment guards the JAB-316 fix. The
+// `dir-privacy cred-remove <domain> <rule-id> <cred-id>` CLI resolved the rule
+// but then deleted <cred-id> by raw id, without checking the credential
+// actually belongs to that rule — a cross-rule credential deletion (an operator
+// could pass a rule they name alongside any credential id and delete it). The
+// HTTP adapter enforces cred.RuleID == rule.ID; this pins the same containment
+// in the CLI. cmd/server has no seeded-DB fixture, so this follows the repo's
+// source-pin precedent (log_cmd_scope_test.go).
+func TestDirPrivacyCredRemove_EnforcesRuleContainment(t *testing.T) {
+	src, err := os.ReadFile("domain_directory_privacy_cmd.go")
+	if err != nil {
+		t.Fatalf("read domain_directory_privacy_cmd.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "FindCredentialByID(ctx, args[2])") {
+		t.Fatal("cred-remove must fetch the credential by id before deleting it, to check rule containment (JAB-316)")
+	}
+	if !strings.Contains(s, "cred.RuleID != rule.ID") {
+		t.Fatal("cred-remove must reject a credential whose RuleID != the resolved rule — fail closed (JAB-316)")
+	}
+}


### PR DESCRIPTION
## Vulnerability (JAB-316, high · cross-rule credential deletion)

`jabali domain dir-privacy cred-remove <domain> <rule-id> <cred-id>` resolved the
rule (confirming it belongs to the domain) but then deleted `<cred-id>` **by raw
id**, without checking the credential actually belongs to that rule. An operator
could pass any rule they name alongside a credential id from a **different rule**
and delete it. The HTTP adapter already enforces `cred.RuleID == rule.ID`
(`deleteCredential`, 404 on mismatch).

## Fix

Fetch the credential with `FindCredentialByID` and reject when its `RuleID`
doesn't match the resolved rule — **failing closed** (never delete) on a mismatch
or a missing credential.

## Sibling sweep (whole-file, not just the flagged line)

Audited every mutation command in the file:
- `remove` (rule delete) — guarded by `resolvePrivacyRule(dom.ID, …)`, so rule→domain containment already holds. **Clean.**
- `cred-add` / `cred-list` — resolve the rule against the domain first. **Clean.**
- `cred-remove` — the only raw-id delete without credential→rule containment. **Fixed here.**

## Test
Source-pin (`cmd/server` has no seeded-DB fixture; same precedent as
`log_cmd_scope_test.go`) asserting the remove path fetches the credential and
compares `RuleID` before deleting. Full `cmd/server` suite green.

## Acceptance criteria
- [x] A credential from another rule is refused.
- [ ] Every successful mutation schedules the owning domain exactly once — the CLI has no immediate-Reconcile handle; like every CLI mutation here it converges on the next reconciler tick (file header + `app_cache_cmd.go`). Immediate-schedule parity → **JAB-355**.
- [x] Only password hashes persisted (already true — bcrypt via `HashPassword`, unchanged).
- [x] Path traversal / invalid realms/usernames rejected (CLI mirrors the HTTP validators; unchanged).
- [ ] HTTP and CLI contract tests cover all mutation paths — CLI containment pinned here; **HTTP containment is enforced but currently untested** → shared matrix in **JAB-355**.

GH JAB-316 · follow-up JAB-355