### PR TITLE
feat(ui): warn shared FTP sub-accounts aren't SFTP directory-scoped (GH #1145)

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -1553,6 +1553,7 @@
     "isolated_label": "Isolated account",
     "isolated_tooltip": "Give this account its own identity confined to the chosen folder — it cannot reach the rest of your files. Recommended. Turn off only for a legacy shared-access account.",
     "isolated_unavailable": "Isolated accounts need filesystem disk quota, which isn't enabled on this server, so new accounts are created shared. Ask your administrator to enable the disk-quota module to use isolation.",
+    "shared_sftp_scope_warning": "Shared accounts aren't directory-scoped over SFTP: the connection starts in the chosen folder but can navigate up to the whole account home. Isolated accounts confine SFTP to their folder (they need filesystem disk quota).",
     "isolated_tag": "Isolated",
     "shared_tag": "Shared access",
     "quota_label": "Disk quota",

--- a/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
+++ b/panel-ui/src/shells/user/ftp-accounts/UserFtpAccountsPage.tsx
@@ -352,6 +352,24 @@ export const UserFtpAccountsPage = () => {
           >
             <Switch disabled={!isoAvailable} />
           </Form.Item>
+          {/* GH #1145: a shared account's SFTP chroots to the whole account
+              home, so it is NOT directory-scoped (it starts in the folder but
+              can navigate up). Warn when the account will be shared. */}
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, cur) => prev.isolated !== cur.isolated}
+          >
+            {({ getFieldValue }) =>
+              !isoAvailable || getFieldValue("isolated") === false ? (
+                <Alert
+                  type="warning"
+                  showIcon
+                  style={{ marginBottom: 16 }}
+                  message={t("ftpaccounts.shared_sftp_scope_warning")}
+                />
+              ) : null
+            }
+          </Form.Item>
           <Form.Item
             noStyle
             shouldUpdate={(prev, cur) => prev.isolated !== cur.isolated}


### PR DESCRIPTION
Follow-up to #1145 (the shared/isolated FTP sub-account work). A **shared**
(same-uid) sub-account's SFTP session chroots to the whole account home — it
*starts* in the chosen folder but can `cd ..` up to it (johnnyq's report).
**Isolated** accounts confine SFTP for real, but they need filesystem quota and
aren't always available.

This adds a warning on the tenant FTP-account create form, shown whenever the
account will be **shared** (isolation unavailable on the host, or the Isolated
toggle turned off): it tells the tenant the folder is a *start* directory, not
an SFTP boundary, and points at Isolated for true scoping. No behaviour change —
UI-only.

- `tsc -b` clean; all 243 vitest pass.