### PR TITLE
fix(security): persist ssl_mode + cache_enabled from CLI via dedicated writers (JAB-313)

### DIFF
--- a/panel-api/cmd/server/domain_advanced_cmd.go
+++ b/panel-api/cmd/server/domain_advanced_cmd.go
@@ -228,6 +228,26 @@ func newDomainSetCmd() *cobra.Command {
 			if err := domainRepoFromDB().Update(ctx, d); err != nil {
 				return fmt.Errorf("update domain: %w", err)
 			}
+			// JAB-313: ssl_mode is authoritative (ADR-0141) but is NOT in the
+			// general Update column allowlist (domain_repository.go: "SSL flags ...
+			// have their own dedicated repo methods"), so the assignment above was
+			// silently dropped — the command reported success while the mode never
+			// changed and the reconciler kept the old TLS behavior. Persist it
+			// through the dedicated writer, which also keeps ssl_enabled consistent,
+			// exactly as the HTTP path and ssl_custom_cmd.go do.
+			if cmd.Flags().Changed("ssl-mode") {
+				if err := domainRepoFromDB().UpdateSSLMode(ctx, d.ID, sslMode); err != nil {
+					return fmt.Errorf("persist ssl mode: %w", err)
+				}
+			}
+			// JAB-313 sibling: cache_enabled is likewise excluded from the general
+			// Update allowlist and has its own dedicated writer (ADR-0108), so
+			// --cache was being silently dropped the same way. Persist it here too.
+			if cmd.Flags().Changed("cache") {
+				if err := domainRepoFromDB().UpdateCacheEnabled(ctx, d.ID, d.CacheEnabled); err != nil {
+					return fmt.Errorf("persist cache setting: %w", err)
+				}
+			}
 			cliAuditOK(ctx, "domain.settings_update", "domain", d.ID, &d.UserID)
 			fmt.Fprintf(cmd.OutOrStdout(), "Updated %s. Converges on the next reconcile pass (≤60s): nginx re-render/reload%s.\n",
 				d.Name, map[bool]string{true: " + SSL re-issue", false: ""}[cmd.Flags().Changed("ssl-mode")])

--- a/panel-api/cmd/server/domain_advanced_cmd_ssl_mode_test.go
+++ b/panel-api/cmd/server/domain_advanced_cmd_ssl_mode_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestDomainAdvancedSSLMode_PersistsThroughDedicatedWriter guards the JAB-313
+// fix. ssl_mode is authoritative (ADR-0141) but is NOT in the general
+// domainRepo.Update column allowlist, so `domain advanced --ssl-mode=…` set the
+// field on the in-memory struct and then called Update, which silently dropped
+// it — the command reported success while the mode never changed. The fix
+// persists it through the dedicated UpdateSSLMode writer (as the HTTP path and
+// ssl_custom_cmd.go do). cmd/server's advanced command runs on the global repo
+// (no injection seam), so this source-pins the dedicated call, matching the
+// repo's precedent (log_cmd_scope_test.go).
+func TestDomainAdvancedSSLMode_PersistsThroughDedicatedWriter(t *testing.T) {
+	src, err := os.ReadFile("domain_advanced_cmd.go")
+	if err != nil {
+		t.Fatalf("read domain_advanced_cmd.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "UpdateSSLMode(ctx, d.ID, sslMode)") {
+		t.Fatal("--ssl-mode must persist through domainRepo.UpdateSSLMode — the general Update allowlist drops ssl_mode, so relying on it silently no-ops the mode change (JAB-313)")
+	}
+	if !strings.Contains(s, `cmd.Flags().Changed("ssl-mode")`) {
+		t.Fatal("the dedicated UpdateSSLMode persistence must be gated on --ssl-mode actually changing (JAB-313)")
+	}
+	// Sibling silent-drop: cache_enabled is also excluded from the Update
+	// allowlist and has its own writer, so --cache must go through it too.
+	if !strings.Contains(s, "UpdateCacheEnabled(ctx, d.ID, d.CacheEnabled)") {
+		t.Fatal("--cache must persist through domainRepo.UpdateCacheEnabled — cache_enabled is not in the Update allowlist either (JAB-313)")
+	}
+}


### PR DESCRIPTION
## Bug (JAB-313, urgent · authoritative TLS field silently not persisted)

`ssl_mode` is authoritative (ADR-0141) but is **not** in `domainRepo.Update`'s
column allowlist — the allowlist deliberately excludes SSL flags ("SSL flags …
have their own dedicated repo methods"). The `domain advanced --ssl-mode=le|self|none`
CLI path set `d.SSLMode` on the in-memory struct then called the general `Update`,
so GORM's `Select+Updates` **silently dropped** it: the command reported success
(even printing "+ SSL re-issue") while the authoritative mode never changed and
the reconciler kept the old TLS behavior. Same allowlist silent-drop class that
previously ate `redirect_all_to` / `index_priority` / `page_redirects`.

## Sibling sweep (whole command)

Audited every `--advanced` flag against the allowlist. Found the **identical bug
one flag over**: `--cache` sets `d.CacheEnabled` then calls the same general
`Update`, but `cache_enabled` is also excluded and has its own dedicated writer
(ADR-0108) — silently dropped too. Every other flag (`--redirect-all-to`,
`--redirect-type`, `--index-priority`, `--nginx-directives`) maps to an
allowlisted column and is unaffected.

## Fix

Persist both through their dedicated writers — `UpdateSSLMode` (keeps
`ssl_enabled` consistent) and `UpdateCacheEnabled` — each gated on its flag
actually changing, exactly as the HTTP path and `ssl_custom_cmd.go` already do.
Both writers already existed; only these CLI call sites bypassed them.

## Test
Source-pin (`cmd/server`'s advanced command runs on the global repo, no injection
seam; same precedent as `log_cmd_scope_test.go`) asserting both `--ssl-mode` and
`--cache` persist through their dedicated writers. Full `cmd/server` suite green.

## Acceptance criteria (JAB-313)
- [x] Repository failure is surfaced as failure, never success (the dedicated writers return their error).
- [x] CLI now persists the authoritative mode (matches HTTP for the set-mode path).
- [ ] HTTP/CLI identical mode+shadow across enable/disable/set-mode, protected-domain `none` refusal, idempotent enable, one convergence schedule → shared **Domain TLS Mode Module**, **JAB-356** (also covers the `ssl enable`/`disable` mode-authority gap).

GH JAB-313 · follow-up JAB-356