### PR TITLE
fix(backup): apply panel metadata in HTTP account restore + wire metadata repos (JAB-312)

### DIFF
--- a/panel-api/internal/api/backups.go
+++ b/panel-api/internal/api/backups.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	internalbackup "git.jabali-panel.com/shukivaknin/jabali2/internal/backup"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupmetadata"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
@@ -76,6 +77,12 @@ type BackupHandlerConfig struct {
 	// /etc/jabali-panel/restic-repo.password (back-compat for
 	// destinations that haven't been rotated yet).
 	SSOKey *ssokey.Key
+
+	// KratosClient lets the account-restore finalizer reinstate the
+	// restored user's login identity (JAB-312), mirroring the CLI restore.
+	// Optional: when nil the panel rows are still rebuilt; only the login
+	// credential is left for a recovery link.
+	KratosClient *kratosclient.Client
 
 	Log             *slog.Logger
 	StrictRateLimit gin.HandlerFunc
@@ -1095,6 +1102,10 @@ func (h *backupHandler) runAccountRestoreJob(jobID string, dest *models.BackupDe
 			Status string `json:"status"`
 			Error  string `json:"error,omitempty"`
 		} `json:"stages"`
+		// Metadata is the raw metadata.json the agent pulled from the
+		// snapshot's meta stage — the bundle the finalizer applies to
+		// rebuild panel DB rows (JAB-312). Empty on old snapshots.
+		Metadata json.RawMessage `json:"metadata,omitempty"`
 	}
 	finalStatus := models.BackupJobStatusSucceeded
 	finalErr := ""
@@ -1115,7 +1126,65 @@ func (h *backupHandler) runAccountRestoreJob(jobID string, dest *models.BackupDe
 			finalStatus = models.BackupJobStatusFailed
 		}
 	}
+
+	// JAB-312: apply the returned panel-metadata bundle so a UI/HTTP restore
+	// rebuilds the panel DB rows (domains, mailboxes, forwarders, applications,
+	// SSH keys, cron jobs, …) — not just host files + DB dumps. Before this only
+	// the CLI applied it, so UI restores left the panel with no record of the
+	// restored account. Skipped when the host restore itself failed (nothing
+	// consistent to rebuild) and for old snapshots that carry no bundle. A
+	// metadata-apply failure must not leave the job reporting a clean success.
+	if finalStatus != models.BackupJobStatusFailed {
+		if errs := h.applyRestoreMetadata(ctx, result.Metadata); len(errs) > 0 {
+			if finalStatus == models.BackupJobStatusSucceeded {
+				finalStatus = models.BackupJobStatusPartial
+			}
+			if finalErr == "" {
+				finalErr = "metadata apply: " + strings.Join(errs, "; ")
+			}
+			h.cfg.logErr("account restore metadata apply had errors", errors.New(strings.Join(errs, "; ")), "job_id", jobID)
+		}
+	}
 	seal(finalStatus, finalErr, raw)
+}
+
+// applyRestoreMetadata rebuilds the panel DB rows from the metadata bundle the
+// agent returned with a restore (JAB-312), mirroring the CLI restore
+// (account_restore_cmd.go applyPanelMetadata). Returns the apply errors (empty
+// on a clean apply). An empty bundle — old snapshots (schema_version=1) — is a
+// no-op, the documented fallback. Restored cron ROWS regain their systemd
+// timers on the next reconciler tick (internal/reconciler/cron_reconcile.go),
+// the same convergence model the rest of restored state follows.
+func (h *backupHandler) applyRestoreMetadata(ctx context.Context, metaRaw json.RawMessage) []string {
+	if len(metaRaw) == 0 {
+		return nil
+	}
+	var meta internalbackup.AccountMetadata
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		return []string{"parse metadata bundle: " + err.Error()}
+	}
+	r := backupmetadata.Apply(ctx, &meta, backupmetadata.Deps{
+		Users:          h.cfg.Users,
+		Domains:        h.cfg.Domains,
+		Databases:      h.cfg.Databases,
+		DatabaseUsers:  h.cfg.DatabaseUsers,
+		DatabaseGrants: h.cfg.DatabaseGrants,
+		AppInstalls:    h.cfg.AppInstalls,
+		DockerApps:     h.cfg.DockerApps,
+		SSLCerts:       h.cfg.SSLCerts,
+		PHPPools:       h.cfg.PHPPools,
+		PHPPoolIni:     h.cfg.PHPPoolIni,
+		SSHKeys:        h.cfg.SSHKeys,
+		CronJobs:       h.cfg.CronJobs,
+		Mailboxes:      h.cfg.Mailboxes,
+		Forwarders:     h.cfg.Forwarders,
+		Autoresponders: h.cfg.Autoresponders,
+		MailboxShares:  h.cfg.MailboxShares,
+		DNSZones:       h.cfg.DNSZones,
+		DNSRecords:     h.cfg.DNSRecords,
+		KratosClient:   h.cfg.KratosClient,
+	})
+	return r.Errors
 }
 
 // --- helpers + sentinel below ---

--- a/panel-api/internal/api/backups_restore_async_test.go
+++ b/panel-api/internal/api/backups_restore_async_test.go
@@ -138,6 +138,47 @@ func TestRunSelectiveRestoreJob_AgentFailureIsGenericOnTheRow(t *testing.T) {
 	}
 }
 
+// JAB-312: the finalizer applies the returned panel-metadata bundle. A bundle
+// that cannot be applied must NOT leave the job reporting a clean success — the
+// operator would think the panel was reconstructed when it wasn't.
+func TestRunAccountRestoreJob_MetadataApplyFailureDowngradesSuccess(t *testing.T) {
+	jobs := newSealCapture()
+	h := &backupHandler{cfg: BackupHandlerConfig{
+		Jobs: jobs,
+		// All stages ok, but the metadata bundle is not a valid AccountMetadata
+		// object — Apply cannot parse it, so the finalizer must downgrade.
+		Agent: restoreAgent{reply: json.RawMessage(
+			`{"job_id":"job-1","stages":[{"name":"home","status":"ok"}],"metadata":"not-an-object"}`)},
+	}}
+	h.runAccountRestoreJob("job-1", &models.BackupDestination{ID: "d1", Kind: "local"}, map[string]any{})
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusPartial {
+		t.Errorf("status = %q, want partial — host stages ok but metadata apply failed", jobs.status)
+	}
+	if !strings.Contains(jobs.errText, "metadata apply") {
+		t.Errorf("the metadata-apply failure must surface on the row, got %q", jobs.errText)
+	}
+}
+
+// An old snapshot (schema_version=1) carries no metadata bundle. The finalizer
+// must treat that as the documented fallback — a no-op — not a failure.
+func TestRunAccountRestoreJob_NoMetadataStaysSucceeded(t *testing.T) {
+	jobs := newSealCapture()
+	h := &backupHandler{cfg: BackupHandlerConfig{
+		Jobs: jobs,
+		Agent: restoreAgent{reply: json.RawMessage(
+			`{"job_id":"job-1","stages":[{"name":"home","status":"ok"},{"name":"db","status":"ok"}]}`)},
+	}}
+	h.runAccountRestoreJob("job-1", &models.BackupDestination{ID: "d1", Kind: "local"}, map[string]any{})
+	jobs.wait(t)
+	if jobs.status != models.BackupJobStatusSucceeded {
+		t.Errorf("status = %q, want succeeded — an old snapshot with no metadata is not a failure", jobs.status)
+	}
+	if jobs.errText != "" {
+		t.Errorf("no error expected on a clean restore without a bundle, got %q", jobs.errText)
+	}
+}
+
 // recordingAgent captures the params of the last call so wire-contract
 // assertions can look inside.
 type recordingAgent struct {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1108,6 +1108,23 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				DockerApps:     deps.DockerApps,
 				DNSZones:       deps.DNSZones,
 				DNSRecords:     deps.DNSRecords,
+				// JAB-312: the schema-v2 metadata repos were never wired into the
+				// admin backup handler, so buildAccountMetadata skipped these
+				// sections in manual backups AND the restore finalizer had no
+				// repos to rebuild them. Wire the full set (matches the scheduler
+				// and the CLI restore Deps) so manual backup bundles are complete
+				// and UI restores can reconstruct panel state.
+				SSLCerts:       deps.SSLCerts,
+				PHPPools:       deps.PHPPools,
+				PHPPoolIni:     deps.PHPPoolIniOverrides,
+				Forwarders:     deps.Forwarders,
+				Autoresponders: deps.Autoresponders,
+				MailboxShares:  deps.MailboxShares,
+				DNSSECKeys:     deps.DNSSECKeys,
+				SSHKeys:        deps.SSHKeys,
+				CronJobs:       deps.CronJobs,
+				LimitOverrides: deps.LimitOverrides,
+				KratosClient:   deps.KratosClient,
 				Log:            deps.Log,
 				SSOKey:         deps.SSOKey,
 			})


### PR DESCRIPTION
## Bug (JAB-312, urgent · UI restore silently omits panel state)

Two coupled halves of one data-integrity gap.

**1. HTTP restore never applied the metadata bundle.** `runAccountRestoreJob`
parsed the agent result for *stage status only* and sealed the job — it never
extracted the returned `metadata` bundle nor called `backupmetadata.Apply`. Only
the CLI restore did. So a UI/API restore rebuilt host files + DB dumps but left
the panel with **no rows** for the restored domains, mailboxes, forwarders,
applications, SSH keys, or cron jobs — the panel didn't know the account existed.

**2. The metadata repos were never wired into the admin backup handler.** The
finalizer's `Deps` come from `BackupHandlerConfig`, and app.go wired only ~15
fields — the schema-v2 metadata repos (SSLCerts, PHPPools, PHPPoolIni, Forwarders,
Autoresponders, MailboxShares, DNSSECKeys, SSHKeys, CronJobs, LimitOverrides) +
KratosClient were nil at runtime. That same config backs `buildAccountMetadata`,
so **manual admin backups were also silently omitting those sections** (the
scheduler wired them; the manual button did not).

## Fix
- `runAccountRestoreJob` now applies the bundle (mirrors the CLI's `applyPanelMetadata`), **gating job success on the result**: a parse/apply failure downgrades a would-be success to `partial` and records the reason, so a restore that didn't reconstruct panel state can never report clean success. Empty bundle (old `schema_version=1` snapshots) = documented no-op fallback. Restored cron rows regain timers on the next reconciler tick.
- app.go wires the full metadata repo set + `KratosClient` (nil-tolerant, also restores login identity) — fixing both the restore repos **and** manual-backup completeness.

## Acceptance criteria
- [x] Same snapshot via HTTP and CLI → identical panel DB truth (both now apply the same bundle via the same `backupmetadata.Apply`).
- [x] Metadata-apply failure cannot mark the job successful (downgrade to partial + reason; unit-tested).
- [x] Old snapshots use the documented fallback (empty bundle = no-op; unit-tested).
- [x] Restored cron jobs regain timers (rows applied → reconciler `cron_reconcile.go` provisions on next tick).
- [x] Request cancellation cannot terminate accepted background work (job already runs on `context.Background()`, unchanged).
- [x] Temporary destination secrets always cleaned up (`WithDestPasswordFile`, unchanged).

## Tests
`backups_restore_async_test.go`: apply-failure downgrades success→partial with the reason on the row; no-metadata snapshot stays succeeded. Full `internal/api` + `internal/app` suites green; goldens unaffected (no route/flag changes).

## Verification status
- Built `GOAMD64=v1`, deployed to the .86 smoke box; panel active, `applyRestoreMetadata` symbol + gating confirmed in the running binary. Backup/restore infra healthy there (restic 0.18.0; 181 historical successful account backups; restore jobs in history).
- ⚠️ **Full authenticated HTTP restore E2E (backup → wipe rows → UI restore → DB diff) not completed:** both changed paths are admin-HTTP-only (no CLI trigger; the scheduler path uses already-complete metadata), and .86's backup destinations are torn down — a faithful E2E needs a fresh destination + an authenticated admin session. Residual risk is low (gating unit-tested; the apply logic is the CLI's proven code against this same schema), but the live end-to-end is worth running before merge if belt-and-suspenders is wanted.

## Residual (separate follow-up)
EgressPolicies/EgressRequests aren't exposed on the app deps bundle, so manual admin backups still omit those two sections, and the `/me` backup handler has the same wiring gap. Manual-backup completeness only (restore doesn't apply egress).

GH JAB-312