### PR TITLE
fix(ui): 100dvh mobile layout height — no dark strip behind the URL bar (GH #1066)

### DIFF
--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -111,7 +111,7 @@ export function AdminLayout() {
     // Content scrolls). On mobile that pins the version footer to the bottom of a
     // viewport-height scroll box, eating screen space on short pages — so mobile
     // uses natural document scroll (minHeight) and the footer flows after content.
-    <Layout style={isDesktop ? { height: "100vh", overflow: "hidden" } : { minHeight: "100vh" }}>
+    <Layout style={isDesktop ? { height: "100vh", overflow: "hidden" } : { minHeight: "100dvh" }}>
       <JabaliHeader
         showMenuButton={!isDesktop}
         onMenuClick={() => setDrawerOpen(true)}

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -110,7 +110,7 @@ export function UserLayout() {
   }, [location.pathname]);
 
   return (
-    <Layout style={{ minHeight: "100vh" }}>
+    <Layout style={{ minHeight: "100dvh" }}>
       <ImpersonationBanner />
       <JabaliHeader
         showMenuButton={!isDesktop}


### PR DESCRIPTION
## What

Mobile refinement for **GH #1066**. The outer `<Layout>` in both shells used
`minHeight: 100vh` on the mobile branch. `100vh` is the *large* viewport height
(measured as if the browser's collapsible address bar were retracted), so while
the address bar is visible the Layout is taller than the visible area and its
dark `colorBgLayout` background paints a strip below the fold.

That is lxsdevcode's residual report on #1066:

> there seems to be another issue on mobile … a black fixed bar appears again at
> the bottom. After a page refresh, the black bar disappears. When navigating to
> another page from the menu, the black fixed bar appears again … is fixed on
> scrolling.

(Refresh retracts the URL bar → `100vh` momentarily matches → bar gone; menu-nav
re-shows the URL bar → overshoot returns.)

## Fix

Switch the two **mobile-branch** outer-Layout heights to `100dvh` (dynamic
viewport height), which tracks the address bar as it slides in/out, so the
Layout is always exactly the visible height and nothing overshoots.

- `AdminLayout.tsx` — mobile branch `minHeight: 100vh` → `100dvh` (desktop
  `height: 100vh` app-shell untouched).
- `UserLayout.tsx` — outer `minHeight: 100vh` → `100dvh` (desktop Sider's
  `100vh` untouched; `dvh == vh` on desktop, no dynamic chrome there).

The menu-tooltip double-tap half of #1066 already shipped (tooltips are
`isDesktop`-only), so this PR is the layout-overshoot half.

## Test

- `npx tsc -b` clean.
- `vitest run src/shells` — 68/68 pass.
- Manual: mobile viewport, dark theme, scroll with URL bar visible → no dark
  strip; navigate between menu pages → no returning bar.

`dvh` support: Chrome 108+, Safari 15.4+, Firefox 101+ — universal on the mobile
browsers this targets.

GH #1066