### PR TITLE
feat(databases): per-database Download backup for PostgreSQL (GH #1045)

### DIFF
--- a/panel-agent/internal/commands/db_postgres_backup.go
+++ b/panel-agent/internal/commands/db_postgres_backup.go
@@ -1,0 +1,178 @@
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// db.postgres.backup — user-facing per-database dump for the tenant Databases
+// "Download backup" action (GH #1045 PostgreSQL parity). The MariaDB sibling is
+// db.backup (db_backup.go); this mirrors it for Postgres so the API can dispatch
+// by engine and stream the .sql back to the client the same way.
+//
+// Two things it deliberately shares with db.backup rather than db.postgres.dump
+// (the internal account_full helper):
+//
+//   - It writes to the panel-readable staging dir and re-owns the dump to the
+//     panel service user (reownBackupForPanel), so panel-api — which runs
+//     unprivileged — can read the file back and unlink it after streaming. The
+//     internal dump targets /var/lib/jabali (root-only) and is never streamed to
+//     a client, so it skips this (GH #1045 500 was exactly this handoff).
+//   - pg_dump runs as `postgres` (peer auth on the socket) but its stdout is an
+//     fd the AGENT (root) opened under /var/lib/jabali-uploads. The staging dir
+//     is 0750 jabali:jabali-sockets — the postgres user cannot create a file
+//     there — so `pg_dump -f <staging>` would EACCES. Handing pg_dump an
+//     already-open fd via Stdout sidesteps that: postgres writes to the fd, not
+//     the path (same reason db_backup.go captures mysqldump's stdout).
+//
+// Dump flags: --no-owner --no-privileges (matching db.postgres.dump). Ownership
+// and grants are NOT carried in the dump on purpose — a privilege-scoped
+// restore (the planned db.postgres.restore, loaded as a NON-superuser role)
+// cannot execute `ALTER ... OWNER TO <role>` / `GRANT`, so ownership must be
+// re-established by an agent-authored superuser post-pass at restore time, never
+// from tenant-supplied dump content. Plain format (-Fp) keeps the download a
+// human-readable .sql, consistent with the MariaDB path.
+
+type dbPgBackupParams struct {
+	DBName string `json:"db_name"`
+	Path   string `json:"path"`
+}
+
+type dbPgBackupResponse struct {
+	Path      string `json:"path"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+func dbPgBackupHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbPgBackupParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: fmt.Sprintf("failed to parse params: %v", err),
+		}
+	}
+
+	// pgValidIdent (db_postgres.go): first char a letter, [a-zA-Z0-9_-], and no
+	// quote/semicolon/space/backslash. The name is a pg_dump positional argument
+	// (no shell), so this is a second layer, not the only one.
+	if !pgValidIdent(p.DBName) {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "invalid database name",
+		}
+	}
+
+	backupPath := p.Path
+	if backupPath == "" {
+		buf := make([]byte, 12)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, &agentwire.AgentError{
+				Code:    agentwire.CodeInternal,
+				Message: "failed to generate backup path",
+			}
+		}
+		backupPath = fmt.Sprintf("%s/jabali-pgdb-backup-%s.sql", dbBackupStagingDir, hex.EncodeToString(buf))
+	}
+
+	// Confine the output to the staging dir and reject traversal — identical to
+	// db.backup, since panel-api reads back exactly this path.
+	if !strings.HasPrefix(backupPath, dbBackupStagingDir+"/") {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "backup path must be under " + dbBackupStagingDir + "/",
+		}
+	}
+	if strings.Contains(backupPath, "..") {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInvalidArgument,
+			Message: "backup path contains invalid characters",
+		}
+	}
+
+	// JAB-244 admission: shared dump slots (per-db cap 1, host-wide 2) keyed
+	// "pg:<db>" — the same key db.postgres.dump uses, so the two backup paths
+	// count against one another. Refusals are retryable-unavailable.
+	release, ok := dbBackupSlots.TryAcquire("pg:" + p.DBName)
+	if !ok {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "too many concurrent database backups — retry shortly",
+		}
+	}
+	defer release()
+	if err := hostreserve.CheckReserve(dbBackupStagingDir, 0); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeUnavailable,
+			Message: "backup staging is under the host disk reserve: " + err.Error(),
+		}
+	}
+
+	if err := os.MkdirAll(dbBackupStagingDir, 0750); err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to create backup staging directory",
+		}
+	}
+
+	// Root opens the output fd; pg_dump (as postgres) writes to it via Stdout.
+	f, err := os.Create(backupPath)
+	if err != nil {
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to create backup file",
+		}
+	}
+	defer f.Close()
+
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "pg_dump",
+		"--no-owner", "--no-privileges", "-Fp", p.DBName)
+	// GuardedWriter stops the dump mid-stream if concurrent writers eat the disk
+	// below the host reserve (256 MiB re-checks) — same backstop as db.backup.
+	cmd.Stdout = hostreserve.GuardedWriter(f, dbBackupStagingDir)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		_ = os.Remove(backupPath)
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to backup database: " + strings.TrimSpace(stderr.String()),
+		}
+	}
+
+	// Hand the dump to the panel service user so panel-api can stream + unlink it
+	// (GH #1045). See reownBackupForPanel in db_backup.go.
+	if err := reownBackupForPanel(backupPath); err != nil {
+		_ = os.Remove(backupPath)
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to finalize backup file",
+		}
+	}
+
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		_ = os.Remove(backupPath)
+		return nil, &agentwire.AgentError{
+			Code:    agentwire.CodeInternal,
+			Message: "failed to stat backup file",
+		}
+	}
+
+	return dbPgBackupResponse{
+		Path:      backupPath,
+		SizeBytes: info.Size(),
+	}, nil
+}
+
+func init() {
+	Default.Register("db.postgres.backup", dbPgBackupHandler)
+}

--- a/panel-agent/internal/commands/db_postgres_backup_test.go
+++ b/panel-agent/internal/commands/db_postgres_backup_test.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// TestDBPgBackupHandler pins the input validation for db.postgres.backup. Like
+// TestDBBackupHandler, these cases fail BEFORE pg_dump is ever exec'd, so they
+// run without a live Postgres.
+func TestDBPgBackupHandler(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    dbPgBackupParams
+		wantCode string
+	}{
+		{"invalid: empty db_name", dbPgBackupParams{DBName: ""}, agentwire.CodeInvalidArgument},
+		{"invalid: starts with number", dbPgBackupParams{DBName: "1alice"}, agentwire.CodeInvalidArgument},
+		{"invalid: starts with dash", dbPgBackupParams{DBName: "-bad"}, agentwire.CodeInvalidArgument},
+		{"invalid: contains slash", dbPgBackupParams{DBName: "alice/wp"}, agentwire.CodeInvalidArgument},
+		{"invalid: contains semicolon", dbPgBackupParams{DBName: "alice;drop"}, agentwire.CodeInvalidArgument},
+		{"invalid: contains space", dbPgBackupParams{DBName: "alice wp"}, agentwire.CodeInvalidArgument},
+		{"invalid: contains quote", dbPgBackupParams{DBName: "alice'wp"}, agentwire.CodeInvalidArgument},
+		{"invalid: contains backslash", dbPgBackupParams{DBName: `alice\wp`}, agentwire.CodeInvalidArgument},
+		{"invalid: path not under staging", dbPgBackupParams{DBName: "alice", Path: "/tmp/x.sql"}, agentwire.CodeInvalidArgument},
+		{"invalid: old backups dir rejected", dbPgBackupParams{DBName: "alice", Path: "/var/lib/jabali/backups/x.sql"}, agentwire.CodeInvalidArgument},
+		{"invalid: directory traversal", dbPgBackupParams{DBName: "alice", Path: dbBackupStagingDir + "/../../etc/passwd"}, agentwire.CodeInvalidArgument},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, _ := json.Marshal(tt.input)
+			_, err := dbPgBackupHandler(context.Background(), params)
+			var ae *agentwire.AgentError
+			if !errors.As(err, &ae) {
+				t.Fatalf("expected AgentError, got %T (%v)", err, err)
+			}
+			if ae.Code != tt.wantCode {
+				t.Errorf("code = %q, want %q", ae.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+// The pg backup shares dbBackupSlots with db.backup / db.postgres.dump, keyed
+// "pg:<db>". With both host-wide slots held a new pg backup answers retryable-
+// unavailable before any pg_dump exec.
+func TestDBPgBackup_GlobalSlotsExhausted_Unavailable(t *testing.T) {
+	rel1, ok1 := dbBackupSlots.TryAcquire("heldA")
+	rel2, ok2 := dbBackupSlots.TryAcquire("heldB")
+	if !ok1 || !ok2 {
+		t.Fatal("precondition: could not hold both global slots")
+	}
+	defer rel1()
+	defer rel2()
+
+	params, _ := json.Marshal(dbPgBackupParams{DBName: "tenant_db"})
+	_, err := dbPgBackupHandler(context.Background(), params)
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeUnavailable {
+		t.Fatalf("want CodeUnavailable, got %v", err)
+	}
+}
+
+// A second pg backup of the same db is refused even with a global slot free
+// (per-key cap 1) — the key is "pg:<db>", distinct from the MariaDB "<db>" key.
+func TestDBPgBackup_SameDBAlreadyDumping_Unavailable(t *testing.T) {
+	rel, ok := dbBackupSlots.TryAcquire("pg:tenant_db")
+	if !ok {
+		t.Fatal("precondition: could not hold the pg db slot")
+	}
+	defer rel()
+
+	params, _ := json.Marshal(dbPgBackupParams{DBName: "tenant_db"})
+	_, err := dbPgBackupHandler(context.Background(), params)
+	var ae *agentwire.AgentError
+	if !errors.As(err, &ae) || ae.Code != agentwire.CodeUnavailable {
+		t.Fatalf("want CodeUnavailable for same-db double dump, got %v", err)
+	}
+}

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -487,7 +487,15 @@ func (h *databaseHandler) backup(c *gin.Context) {
 	agentCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	result, err := h.cfg.Agent.Call(agentCtx, "db.backup", map[string]any{
+	// Dispatch by engine — Postgres dumps via pg_dump, MariaDB via mysqldump.
+	// Both agent verbs write to the panel-readable staging dir and re-own the
+	// dump to the service user, so the streaming below is engine-agnostic
+	// (GH #1045 PostgreSQL parity). Mirrors the delete handler's dropCmd branch.
+	backupCmd := "db.backup"
+	if d.Engine == "postgres" {
+		backupCmd = "db.postgres.backup"
+	}
+	result, err := h.cfg.Agent.Call(agentCtx, backupCmd, map[string]any{
 		"db_name": d.Name,
 	})
 	if err != nil {
@@ -557,6 +565,23 @@ func (h *databaseHandler) restore(c *gin.Context) {
 	// Check authorization: admins can restore any; users only their own
 	if !claims.IsAdmin && d.UserID != claims.UserID {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	// GH #1045 PostgreSQL parity — restore is MariaDB-only for now. The
+	// MariaDB path loads tenant-supplied SQL through a db-scoped, unprivileged
+	// shadow account (db_load_scoped.go, JAB-239); loading an uploaded dump as
+	// the postgres superuser would execute arbitrary attacker SQL (COPY FROM
+	// PROGRAM, CREATE FUNCTION, cross-DB reads) with cluster privileges. The
+	// privilege-scoped Postgres loader is the next slice — until it lands,
+	// refuse rather than fall through to the MariaDB verb (which would run
+	// mysql against a Postgres database). The UI keeps the action disabled for
+	// Postgres rows; this is the belt-and-braces server guard.
+	if d.Engine == "postgres" {
+		c.JSON(http.StatusNotImplemented, gin.H{
+			"error":  "not_implemented",
+			"detail": "PostgreSQL restore from file is not yet available",
+		})
 		return
 	}
 

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -706,4 +708,60 @@ func TestDatabaseDeleteUnauthenticated(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// GH #1045 PostgreSQL parity — GET /databases/:id/backup dispatches the agent
+// verb by engine: Postgres → db.postgres.backup, MariaDB → db.backup. The
+// stream path is engine-agnostic, so the mock returns a real temp dump the
+// handler streams back (200).
+func TestDatabaseBackup_DispatchesByEngine(t *testing.T) {
+	cases := []struct {
+		name    string
+		engine  string
+		wantCmd string
+	}{
+		{"postgres uses pg_dump verb", "postgres", "db.postgres.backup"},
+		{"mariadb uses mysqldump verb", "mariadb", "db.backup"},
+		{"empty engine defaults to mariadb", "", "db.backup"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dump := filepath.Join(t.TempDir(), "dump.sql")
+			if err := os.WriteFile(dump, []byte("-- dump\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			agent := &mockAgent{callFn: func(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+				return json.RawMessage(`{"path":"` + dump + `","size_bytes":8}`), nil
+			}}
+			r, dbRepo := databaseRouterWithAgent("user1", false, agent)
+			dbRepo.databases = []models.Database{{ID: "id1", UserID: "user1", Name: "alice_db", Engine: tc.engine}}
+
+			req := httptest.NewRequest("GET", "/api/v1/databases/id1/backup", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tc.wantCmd, agent.lastCommand)
+		})
+	}
+}
+
+// GH #1045 — Postgres restore-from-file is refused with 501 until the
+// privilege-scoped loader ships; the handler must NOT fall through to the
+// MariaDB verb (which would run mysql against a Postgres database). The guard
+// fires before any agent call.
+func TestDatabaseRestore_PostgresNotImplemented(t *testing.T) {
+	agent := &mockAgent{}
+	r, dbRepo := databaseRouterWithAgent("user1", false, agent)
+	dbRepo.databases = []models.Database{{ID: "id1", UserID: "user1", Name: "alice_db", Engine: "postgres"}}
+
+	req := httptest.NewRequest("POST", "/api/v1/databases/id1/restore", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotImplemented, w.Code)
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	assert.Equal(t, "not_implemented", resp["error"])
+	assert.Equal(t, 0, agent.callCount)
 }

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -31,20 +31,25 @@ vi.mock("../../../hooks/useQueries", () => ({
   useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
-const mariaRow = {
-  id: "db1",
-  user_id: "u1",
-  name: "shop_db",
-  engine: "mariadb",
-  charset: "utf8mb4",
-  created_at: "2026-08-01T00:00:00Z",
-  updated_at: "2026-08-01T00:00:00Z",
-};
+// Hoisted mutable holder so a test can swap the table's rows (e.g. to a
+// Postgres row) before render. Defaults to a single MariaDB row.
+const { rowsHolder, mariaRow } = vi.hoisted(() => {
+  const mariaRow = {
+    id: "db1",
+    user_id: "u1",
+    name: "shop_db",
+    engine: "mariadb",
+    charset: "utf8mb4",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+  };
+  return { rowsHolder: { rows: [mariaRow] as Array<typeof mariaRow> }, mariaRow };
+});
 
 vi.mock("../../../hooks/useTableURL", () => ({
   useTableURL: () => ({
-    items: [mariaRow],
-    total: 1,
+    items: rowsHolder.rows,
+    total: rowsHolder.rows.length,
     isLoading: false,
     params: { page: 1, pageSize: 20, q: "", sort: "name", order: "asc" },
     setParams: vi.fn(),
@@ -74,6 +79,8 @@ const openRowMenu = async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Restore the default single-MariaDB-row table (a PG test swaps it).
+  rowsHolder.rows = [mariaRow];
   // jsdom doesn't implement createObjectURL — stub it so the save-as
   // path runs.
   vi.stubGlobal("URL", {
@@ -152,6 +159,44 @@ describe("UserDatabaseList backup/restore (GH #1045)", () => {
     });
     // Same teardown-race guard as the download test: flush the restore
     // continuation (toast + query invalidation), then unmount.
+    await act(async () => {});
+    unmount();
+  });
+
+  // GH #1045 PostgreSQL parity: Download backup works for a Postgres row
+  // (pg_dump path), but Restore from file stays disabled until the
+  // privilege-scoped loader ships.
+  it("enables Download for Postgres but keeps Restore disabled", async () => {
+    rowsHolder.rows = [{ ...mariaRow, name: "pg_shop", engine: "postgres" }];
+    mockedDownload.mockResolvedValue({
+      blob: new Blob(["SQL"], { type: "application/sql" }),
+      filename: "pg_shop-20260821-010203.sql",
+    });
+
+    const { unmount } = render(
+      <App>
+        <UserDatabaseList />
+      </App>,
+    );
+
+    await openRowMenu();
+
+    // Restore is present but disabled for Postgres. AntD marks the menu item
+    // aria-disabled (pointer-events:none blocks the real click); assert that
+    // state rather than a click, which jsdom would let through.
+    const restoreItem = await screen.findByText("Restore from file", undefined, {
+      timeout: 5000,
+    });
+    const restoreLi = restoreItem.closest("li");
+    expect(restoreLi).not.toBeNull();
+    // AntD adds the -item-disabled modifier class to a disabled menu item.
+    expect(restoreLi?.className).toMatch(/-item-disabled\b/);
+
+    // Download still works.
+    fireEvent.click(await screen.findByText("Download backup"));
+    await waitFor(() => {
+      expect(mockedDownload).toHaveBeenCalledWith("db1");
+    });
     await act(async () => {});
     unmount();
   });

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -3,8 +3,9 @@
 // apiClient helper; a blank tab is opened synchronously to dodge
 // popup blockers while the SSO call runs.
 // GH #1045: per-database Backup/Restore actions (download a one-shot
-// dump; restore from an uploaded .sql file) — MariaDB only, the agent
-// verbs shell out to mariadb-dump/mysql.
+// dump; restore from an uploaded .sql file). Download backup works for
+// MariaDB (mariadb-dump) and PostgreSQL (pg_dump); restore is MariaDB
+// only for now — the privilege-scoped Postgres loader is the next slice.
 import { useTranslation } from "react-i18next";
 import { useRef, useState, type ChangeEvent } from "react";
 import { shortDateTime } from "../../../utils/datetime";
@@ -350,20 +351,19 @@ export const UserDatabaseList = () => {
                 disabled: isAdminerLoading,
                 loading: isAdminerLoading,
               };
-              // GH #1045 — per-database backup/restore. The agent verbs
-              // shell out to mariadb-dump/mysql, so both are MariaDB-only
-              // (same gate as phpMyAdmin).
-              const mariaOnlyTooltip = isPostgres
-                ? "Backup/restore supports MySQL/MariaDB only"
-                : undefined;
+              // GH #1045 — per-database backup/restore. Download backup works
+              // for both engines (mariadb-dump / pg_dump). Restore is still
+              // MariaDB-only: the MariaDB loader confines a tenant dump to a
+              // db-scoped, unprivileged account, and the equivalent
+              // privilege-scoped Postgres loader is the next slice — until it
+              // lands, restore stays disabled for Postgres rows.
               const backupAction = {
                 key: "backup",
                 label: "Download backup",
                 icon: <DownloadOutlined />,
                 onClick: () => void handleDownloadBackup(r),
-                disabled: isPostgres || loadingBackupId === r.id,
+                disabled: loadingBackupId === r.id,
                 loading: loadingBackupId === r.id,
-                tooltip: mariaOnlyTooltip,
               };
               const restoreAction = {
                 key: "restore",
@@ -372,7 +372,9 @@ export const UserDatabaseList = () => {
                 onClick: () => handlePickRestore(r),
                 disabled: isPostgres || restoringId === r.id,
                 loading: restoringId === r.id,
-                tooltip: mariaOnlyTooltip,
+                tooltip: isPostgres
+                  ? "Restore from file is coming to PostgreSQL — download backup works now"
+                  : undefined,
                 confirm: {
                   title: `Restore into "${r.name}"?`,
                   description:


### PR DESCRIPTION
## What

**GH #1045 PostgreSQL parity — the safe half.** lxsdevcode asked for the
per-database Backup/Restore row actions (shipped for MariaDB in #1087) to work
for PostgreSQL too. This ships **Download backup** for pg databases. **Restore
from file** stays MariaDB-only for now — see *Restore is next slice* below.

## Agent — `db.postgres.backup`

Mirrors `db.backup` for Postgres. Runs `sudo -u postgres pg_dump --no-owner
--no-privileges -Fp <db>` and captures **stdout into a root-opened fd** under
`/var/lib/jabali-uploads`. The staging dir is `0750 jabali:jabali-sockets` —
the postgres user can't create a file there, so `pg_dump -f <staging>` would
EACCES; handing pg_dump an already-open fd is what makes the write land (same
reason `db_backup.go` captures mysqldump's stdout). The dump is then re-owned to
the panel service user (`reownBackupForPanel`) so panel-api — unprivileged — can
read it back and unlink it after streaming. This is the exact GH #1045 handoff
the MariaDB path needed (the original 500). Shares `dbBackupSlots` (keyed
`pg:<db>`) + the host-reserve floor with `db.postgres.dump`.

`--no-owner --no-privileges` is deliberate: the planned scoped restore loads as a
**non-superuser** role and so cannot execute `ALTER … OWNER TO` / `GRANT` from
dump content — ownership will be re-established by an agent-authored superuser
post-pass at restore time, never from tenant-supplied SQL. Stripping it now keeps
today's downloads loadable by that future restore.

## API

`backup` dispatches the agent verb by engine (`db.postgres.backup` for postgres,
`db.backup` otherwise), like the delete handler's `dropCmd`. The stream path is
engine-agnostic. `restore` is **guarded**: a postgres restore returns **501**
rather than falling through to the MariaDB verb (which would run `mysql` against
a pg database) — belt-and-braces behind the still-disabled UI action.

## UI

Download backup enabled for Postgres rows; Restore from file stays disabled with
a "coming to PostgreSQL" tooltip.

## Restore is next slice (deliberately not here)

Loading a tenant-uploaded dump as the `postgres` superuser is an RCE (`COPY …
FROM PROGRAM`, `CREATE FUNCTION`, cross-DB reads). The MariaDB path avoids this
with a db-scoped unprivileged shadow account (JAB-239). The Postgres equivalent
— per-db `NOSUPERUSER` shadow role, load as it over TCP-loopback scram with psql
running as `nobody`, ownership re-established in a superuser post-pass — needs
box proof on a pg host and resolves an owner-reassignment question, so it ships
separately.

## Test

- Agent: input validation + dump-slot admission (`db_postgres_backup_test.go`).
- API: engine dispatch (pg vs maria verb) + postgres-restore-501.
- UI: Postgres row — Download enabled, Restore disabled.
- `go vet` + `tsc -b` clean; agent/api/UI suites green.
- Box-verified on `.86` (PostgreSQL 17.11): `db.postgres.backup` of a seeded pg db returns a complete dump (schema + `COPY` row data) owned `jabali:jabali 0640`, readable by the unprivileged panel user — the GH #1045 handoff bug (root-written dump the panel couldn't read → 500) does NOT reproduce. `--no-owner --no-privileges` confirmed. Temp dump + test db cleaned up.

GH #1045
