### PR TITLE
refactor(apps): share one fail-closed Application Delete Lifecycle across HTTP + CLI (JAB-314)

### DIFF
--- a/panel-api/cmd/server/cli_ops_app.go
+++ b/panel-api/cmd/server/cli_ops_app.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
-	"time"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/apps"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -198,63 +197,34 @@ func deleteAppDirect(ctx context.Context, installID string) (*models.Application
 		appType = "wordpress"
 	}
 
-	agentCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
-	if _, agentErr := sharedAgent.Call(agentCtx, "app.delete", map[string]any{
-		"app_type":     appType,
-		"install_id":   installID,
-		"os_user":      osUser,
-		"docroot":      domain.DocRoot,
-		"subdirectory": install.Subdirectory,
-		"domain":       domain.Name,
-	}); agentErr != nil {
-		// Match the HTTP path: stamp last_error onto the row and
-		// surface to the operator. We still drop the panel rows below
-		// so a fresh install of the same slot doesn't hit a 409.
-		errMsg := truncString(fmt.Sprintf("agent delete failed: %v", agentErr), 1024)
-		if uErr := installs.UpdateStatus(ctx, installID, "failed", &errMsg, nil); uErr != nil {
-			slog.Warn("cli app delete: status update failed", "err", uErr)
-		}
-		slog.Warn("cli app delete: agent app.delete failed — continuing with DB cleanup",
-			"install_id", installID, "err", agentErr)
+	// JAB-314: delegate to the shared, fail-closed delete lifecycle so the CLI
+	// and the HTTP handler produce identical transcripts. RunAppDelete retains
+	// the install row on an agent app.delete failure (retryable) and keeps the
+	// DB rows visible when a drop fails — instead of the old behaviour of
+	// dropping every panel row regardless, which is how invisible host/DB
+	// orphans were made. It also tears down the app's auto-created cron jobs,
+	// which this CLI path never did.
+	if err := api.RunAppDelete(api.AppDeleteArgs{
+		InstallID:      installID,
+		UserID:         install.UserID,
+		AppType:        appType,
+		Subdirectory:   install.Subdirectory,
+		DatabaseID:     install.DBIDOr(),
+		DBUserID:       dbUserID,
+		OSUser:         osUser,
+		Docroot:        domain.DocRoot,
+		DomainName:     domain.Name,
+		DBUserUsername: dbUserUsername,
+	}, api.AppDeleteDeps{
+		Installs:       installs,
+		Databases:      dbs,
+		DatabaseUsers:  dbUsers,
+		DatabaseGrants: dbGrants,
+		CronJobs:       repository.NewCronJobRepository(sharedDB),
+		Agent:          sharedAgent,
+	}); err != nil {
+		return install, err
 	}
-
-	// DB-side cleanup. Order is grants → mariadb user → install row →
-	// mariadb database. Reordering breaks fk_wpinstalls_db RESTRICT.
-	if dbUserID != "" {
-		if userGrants, gErr := dbGrants.ListByDatabaseUserID(ctx, dbUserID); gErr == nil {
-			for _, g := range userGrants {
-				if dErr := dbGrants.Delete(ctx, g.ID); dErr != nil {
-					slog.Warn("cli app delete: drop grant failed", "grant_id", g.ID, "err", dErr)
-				}
-			}
-		}
-		if dbUserUsername != "" {
-			if _, agentErr := sharedAgent.Call(agentCtx, "db_user.drop", map[string]any{"db_user_name": dbUserUsername}); agentErr != nil {
-				slog.Warn("cli app delete: db_user.drop failed", "db_user", dbUserUsername, "err", agentErr)
-			}
-		}
-		if dErr := dbUsers.Delete(ctx, dbUserID); dErr != nil {
-			slog.Warn("cli app delete: db_user row delete failed", "db_user_id", dbUserID, "err", dErr)
-		}
-	}
-
-	if dErr := installs.Delete(ctx, installID); dErr != nil {
-		return install, fmt.Errorf("delete install row: %w", dErr)
-	}
-
-	if install.DBIDOr() != "" {
-		if db, dbErr := dbs.FindByID(ctx, install.DBIDOr()); dbErr == nil && db != nil {
-			if _, agentErr := sharedAgent.Call(agentCtx, "db.drop", map[string]any{"db_name": db.Name}); agentErr != nil {
-				slog.Warn("cli app delete: db.drop failed", "db_name", db.Name, "err", agentErr)
-			}
-		}
-		if dErr := dbs.Delete(ctx, install.DBIDOr()); dErr != nil {
-			slog.Warn("cli app delete: database row delete failed", "db_id", install.DBIDOr(), "err", dErr)
-		}
-	}
-
 	return install, nil
 }
 

--- a/panel-api/cmd/server/cli_ops_app_delete_test.go
+++ b/panel-api/cmd/server/cli_ops_app_delete_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCLIAppDelete_DelegatesToSharedLifecycle pins the JAB-314 fix. The CLI
+// `app delete` used to run its own delete sequence that (a) continued dropping
+// panel rows after an agent app.delete failure, (b) dropped DB rows even when the
+// host-side drop failed, and (c) never tore down the app's cron jobs — every one
+// a way to make an invisible host/DB orphan. It now delegates to the shared,
+// fail-closed api.RunAppDelete so its transcript matches the HTTP handler.
+// cmd/server has no DB/agent fixture, so this source-pins the delegation (repo
+// precedent: log_cmd_scope_test.go); the behaviour itself is unit-tested in
+// internal/api/app_delete_test.go.
+func TestCLIAppDelete_DelegatesToSharedLifecycle(t *testing.T) {
+	src, err := os.ReadFile("cli_ops_app.go")
+	if err != nil {
+		t.Fatalf("read cli_ops_app.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "api.RunAppDelete(api.AppDeleteArgs{") {
+		t.Fatal("CLI app delete must delegate to the shared api.RunAppDelete — a divergent copy is how the fail-open orphan bug returns (JAB-314)")
+	}
+	// The old inline sequence stamped rows via a local db.drop/db_user.drop call
+	// path; ensure the CLI no longer runs its own app.delete agent call (which
+	// bypassed the shared fail-closed ordering).
+	if strings.Contains(s, `sharedAgent.Call(agentCtx, "app.delete"`) {
+		t.Fatal("CLI must not run its own app.delete sequence — it must go through api.RunAppDelete (JAB-314)")
+	}
+}

--- a/panel-api/internal/api/app_delete.go
+++ b/panel-api/internal/api/app_delete.go
@@ -1,0 +1,146 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// AppDeleteDeps is the repo + agent set the shared application-delete lifecycle
+// needs. The HTTP handler builds it from ApplicationHandlerConfig; the operator
+// CLI builds it from the shared DB + agent. Keeping one implementation is the
+// point: HTTP and CLI deletes must produce identical side-effect transcripts
+// (JAB-314).
+type AppDeleteDeps struct {
+	Installs       repository.ApplicationInstallRepository
+	Databases      repository.DatabaseRepository
+	DatabaseUsers  repository.DatabaseUserRepository
+	DatabaseGrants repository.DatabaseUserGrantRepository
+	CronJobs       repository.CronJobRepository
+	Agent          agent.AgentInterface
+}
+
+// AppDeleteArgs identifies the install being torn down plus the pre-resolved
+// host handles the agent needs. Callers resolve these once (domain, owner,
+// db user/grants) before invoking RunAppDelete.
+type AppDeleteArgs struct {
+	InstallID      string
+	UserID         string
+	AppType        string
+	Subdirectory   string
+	DatabaseID     string
+	DBUserID       string
+	OSUser         string
+	Docroot        string
+	DomainName     string
+	DBUserUsername string
+}
+
+// RunAppDelete is the single authoritative application-delete side-effect
+// sequence, shared by the HTTP handler and the CLI (JAB-314). It is fail-closed
+// so a partial failure never produces an invisible host or database orphan:
+//
+//   - Agent app.delete failure stamps status=failed and RETAINS the install row
+//     for retry — it never proceeds to drop DB rows.
+//   - A db_user.drop / db.drop failure KEEPS the corresponding panel rows so the
+//     database/user stays visible (and retryable from the Databases page) rather
+//     than surviving on the host with no row to name it. databases.go's own
+//     delete refuses to remove a row unless its drop succeeds, so the retry
+//     cannot reintroduce the orphan.
+//
+// It always runs on a detached 5-minute context so an accepted deletion outlives
+// the caller's request context. Returns nil on full success; a non-nil error
+// describes the retained state (for the CLI to surface — the HTTP path is
+// fire-and-forget and ignores it).
+func RunAppDelete(args AppDeleteArgs, deps AppDeleteDeps) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	appType := args.AppType
+	if appType == "" {
+		// Pre-M19 rows had no AppType; treat empty defensively so the agent
+		// isn't handed an empty discriminator (which it 400s on).
+		appType = "wordpress"
+	}
+
+	if deps.Agent == nil {
+		msg := "agent not configured"
+		if deps.Installs != nil {
+			deps.Installs.UpdateStatus(ctx, args.InstallID, "failed", &msg, nil)
+		}
+		return errors.New(msg)
+	}
+
+	// Agent removes the app's files + restores the docroot placeholder. On
+	// failure the install row is RETAINED (status=failed) so a retry is
+	// possible — we do NOT fall through to drop the DB rows.
+	if _, err := deps.Agent.Call(ctx, "app.delete", map[string]any{
+		"app_type":     appType,
+		"install_id":   args.InstallID,
+		"os_user":      args.OSUser,
+		"docroot":      args.Docroot,
+		"subdirectory": args.Subdirectory,
+		"domain":       args.DomainName,
+	}); err != nil {
+		msg := truncateError(fmt.Sprintf("agent delete failed: %v", err), 1024)
+		deps.Installs.UpdateStatus(ctx, args.InstallID, "failed", &msg, nil)
+		return fmt.Errorf("agent app.delete failed (install row retained for retry): %w", err)
+	}
+
+	// Tear down the app's auto-created cron jobs (they aren't FK-linked to the
+	// install, so nothing else removes them).
+	switch appType {
+	case "itflow":
+		removeITFlowCrons(ctx, deps, args.UserID, args.OSUser, appInstallPath(args.Docroot, args.Subdirectory))
+	case "wordpress", "joomla", "mediawiki":
+		removeAppCrons(ctx, deps, args.UserID, args.OSUser, appType, appInstallPath(args.Docroot, args.Subdirectory))
+	}
+
+	// DB-side cleanup, fail-closed. Keep the panel rows whenever the host-side
+	// drop fails so a MariaDB database/user never survives as an invisible
+	// orphan with no row to name it, absent from `db list` and from backups.
+	dropFailed := false
+	if args.DBUserID != "" && args.DBUserUsername != "" {
+		if _, err := deps.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": args.DBUserUsername}); err != nil {
+			dropFailed = true
+			slog.ErrorContext(ctx, "app delete: db_user.drop failed — keeping the panel rows so the account stays visible instead of becoming an orphan",
+				"err", err, "db_user", args.DBUserUsername)
+		}
+	}
+	if args.DatabaseID != "" {
+		if db, err := deps.Databases.FindByID(ctx, args.DatabaseID); err == nil && db != nil {
+			if _, aerr := deps.Agent.Call(ctx, "db.drop", map[string]any{"db_name": db.Name}); aerr != nil {
+				dropFailed = true
+				slog.ErrorContext(ctx, "app delete: db.drop failed — keeping the panel rows so the database stays visible instead of becoming an orphan",
+					"err", aerr, "db_id", args.DatabaseID)
+			}
+		}
+	}
+
+	// The files are gone (app.delete succeeded), so the install row goes either
+	// way — deleting it before the databases row also releases the RESTRICT
+	// fk_wpinstalls_db.
+	deps.Installs.Delete(ctx, args.InstallID)
+
+	if dropFailed {
+		return errors.New("database or user drop failed on the host; panel rows kept so they stay visible and retryable")
+	}
+
+	if args.DBUserID != "" {
+		if grants, err := deps.DatabaseGrants.ListByDatabaseUserID(ctx, args.DBUserID); err == nil {
+			for _, g := range grants {
+				deps.DatabaseGrants.Delete(ctx, g.ID)
+			}
+		}
+		deps.DatabaseUsers.Delete(ctx, args.DBUserID)
+	}
+	if args.DatabaseID != "" {
+		deps.Databases.Delete(ctx, args.DatabaseID)
+	}
+	return nil
+}

--- a/panel-api/internal/api/app_delete_test.go
+++ b/panel-api/internal/api/app_delete_test.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// Fakes embed the repo interfaces and override only the methods RunAppDelete
+// exercises; anything else would nil-panic, which is the point — the test proves
+// exactly which rows the lifecycle touches.
+
+type adAgent struct {
+	failApp, failDBUser, failDB bool
+	calls                       []string
+}
+
+func (a *adAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	a.calls = append(a.calls, cmd)
+	switch cmd {
+	case "app.delete":
+		if a.failApp {
+			return nil, errors.New("app.delete boom")
+		}
+	case "db_user.drop":
+		if a.failDBUser {
+			return nil, errors.New("db_user.drop boom")
+		}
+	case "db.drop":
+		if a.failDB {
+			return nil, errors.New("db.drop boom")
+		}
+	}
+	return json.RawMessage("{}"), nil
+}
+
+type adInstalls struct {
+	repository.ApplicationInstallRepository
+	status  string
+	deleted bool
+}
+
+func (r *adInstalls) UpdateStatus(_ context.Context, _, status string, _, _ *string) error {
+	r.status = status
+	return nil
+}
+func (r *adInstalls) Delete(context.Context, string) error { r.deleted = true; return nil }
+
+type adDatabases struct {
+	repository.DatabaseRepository
+	deleted bool
+}
+
+func (r *adDatabases) FindByID(context.Context, string) (*models.Database, error) {
+	return &models.Database{Name: "db1"}, nil
+}
+func (r *adDatabases) Delete(context.Context, string) error { r.deleted = true; return nil }
+
+type adDBUsers struct {
+	repository.DatabaseUserRepository
+	deleted bool
+}
+
+func (r *adDBUsers) Delete(context.Context, string) error { r.deleted = true; return nil }
+
+type adGrants struct {
+	repository.DatabaseUserGrantRepository
+	deletedGrants int
+}
+
+func (r *adGrants) ListByDatabaseUserID(context.Context, string) ([]models.DatabaseUserGrant, error) {
+	return []models.DatabaseUserGrant{{ID: "g1"}}, nil
+}
+func (r *adGrants) Delete(context.Context, string) error { r.deletedGrants++; return nil }
+
+type adCron struct {
+	repository.CronJobRepository
+	listed bool
+}
+
+func (r *adCron) ListByUserID(context.Context, string) ([]*models.CronJob, error) {
+	r.listed = true
+	return nil, nil
+}
+
+func newAppDeleteFakes() (*adAgent, *adInstalls, *adDatabases, *adDBUsers, *adGrants, *adCron, AppDeleteDeps) {
+	ag, inst, dbs, dbu, gr, cr := &adAgent{}, &adInstalls{}, &adDatabases{}, &adDBUsers{}, &adGrants{}, &adCron{}
+	return ag, inst, dbs, dbu, gr, cr, AppDeleteDeps{
+		Installs: inst, Databases: dbs, DatabaseUsers: dbu, DatabaseGrants: gr, CronJobs: cr, Agent: ag,
+	}
+}
+
+func appDeleteArgs() AppDeleteArgs {
+	return AppDeleteArgs{
+		InstallID: "i1", UserID: "u1", AppType: "wordpress", OSUser: "alice",
+		Docroot: "/home/alice/public_html", DomainName: "ex.com",
+		DatabaseID: "d1", DBUserID: "du1", DBUserUsername: "alice_wp",
+	}
+}
+
+// JAB-314: an agent app.delete failure must RETAIN the install row (retryable)
+// and must NOT drop any DB row — the old CLI dropped everything regardless,
+// which is how invisible orphans were made.
+func TestRunAppDelete_AgentFailureRetainsRowNoDrops(t *testing.T) {
+	ag, inst, dbs, dbu, _, _, deps := newAppDeleteFakes()
+	ag.failApp = true
+	if err := RunAppDelete(appDeleteArgs(), deps); err == nil {
+		t.Fatal("want an error on agent app.delete failure")
+	}
+	if inst.status != "failed" {
+		t.Errorf("install status = %q, want failed", inst.status)
+	}
+	if inst.deleted {
+		t.Error("install row must be RETAINED on agent failure, not deleted")
+	}
+	if dbs.deleted || dbu.deleted {
+		t.Error("no DB rows may be dropped when the agent app.delete failed")
+	}
+}
+
+// JAB-314: a db_user.drop / db.drop failure must KEEP the DB rows visible (not
+// deleted) so the database/user never becomes an invisible orphan.
+func TestRunAppDelete_DropFailureKeepsDBRowsVisible(t *testing.T) {
+	ag, inst, dbs, dbu, gr, _, deps := newAppDeleteFakes()
+	ag.failDBUser = true
+	if err := RunAppDelete(appDeleteArgs(), deps); err == nil {
+		t.Fatal("want an error when a DB drop fails")
+	}
+	if !inst.deleted {
+		t.Error("install row should be deleted (its files are gone)")
+	}
+	if dbs.deleted || dbu.deleted || gr.deletedGrants > 0 {
+		t.Error("DB/user/grant rows must be KEPT visible when a drop fails, not deleted")
+	}
+}
+
+// Happy path: every row removed, cron teardown attempted, no error.
+func TestRunAppDelete_HappyPathRemovesEverything(t *testing.T) {
+	_, inst, dbs, dbu, gr, cr, deps := newAppDeleteFakes()
+	if err := RunAppDelete(appDeleteArgs(), deps); err != nil {
+		t.Fatalf("want nil error, got %v", err)
+	}
+	if !inst.deleted || !dbs.deleted || !dbu.deleted || gr.deletedGrants == 0 {
+		t.Errorf("all rows must be removed on success: install=%v db=%v dbuser=%v grants=%d",
+			inst.deleted, dbs.deleted, dbu.deleted, gr.deletedGrants)
+	}
+	if !cr.listed {
+		t.Error("cron teardown must run for a wordpress app — the CLI path never did this before")
+	}
+}

--- a/panel-api/internal/api/applications.go
+++ b/panel-api/internal/api/applications.go
@@ -1220,11 +1220,11 @@ func createOsTicketCron(ctx context.Context, args osticketKickArgs, cfg Applicat
 // removeITFlowCrons tears down the ITFlow cron jobs for an install on
 // delete. Matches by command path (`php <installPath>/cron/`) since crons
 // aren't FK-linked to the install. Best-effort.
-func removeITFlowCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID, osUser, installPath string) {
-	if cfg.CronJobs == nil || userID == "" {
+func removeITFlowCrons(ctx context.Context, deps AppDeleteDeps, userID, osUser, installPath string) {
+	if deps.CronJobs == nil || userID == "" {
 		return
 	}
-	jobs, err := cfg.CronJobs.ListByUserID(ctx, userID)
+	jobs, err := deps.CronJobs.ListByUserID(ctx, userID)
 	if err != nil {
 		return
 	}
@@ -1233,15 +1233,15 @@ func removeITFlowCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID
 		if !strings.HasPrefix(j.Command, marker) {
 			continue
 		}
-		if cfg.Agent != nil && osUser != "" {
-			_, _ = cfg.Agent.Call(ctx, "cron.remove", cronRemoveAgentParams{
+		if deps.Agent != nil && osUser != "" {
+			_, _ = deps.Agent.Call(ctx, "cron.remove", cronRemoveAgentParams{
 				UserID:    userID,
 				Username:  osUser,
 				JobID:     j.ID,
 				RunAsRoot: j.RunAsRoot,
 			})
 		}
-		_ = cfg.CronJobs.Delete(ctx, j.ID)
+		_ = deps.CronJobs.Delete(ctx, j.ID)
 	}
 }
 
@@ -1294,8 +1294,8 @@ func createAppCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID, a
 // removeAppCrons tears down an app's auto-created cron jobs on delete. Matches
 // by EXACT command (rebuilt from installPath) so a docroot install can't sweep
 // a subdir install's jobs. Best-effort.
-func removeAppCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID, osUser, appType, installPath string) {
-	if userID == "" || cfg.CronJobs == nil {
+func removeAppCrons(ctx context.Context, deps AppDeleteDeps, userID, osUser, appType, installPath string) {
+	if userID == "" || deps.CronJobs == nil {
 		return
 	}
 	// The auto-created app crons (exact-command match)...
@@ -1303,7 +1303,7 @@ func removeAppCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID, o
 	for _, c := range appCronSpecs(appType, installPath) {
 		want[c.command] = true
 	}
-	jobs, err := cfg.CronJobs.ListByUserID(ctx, userID)
+	jobs, err := deps.CronJobs.ListByUserID(ctx, userID)
 	if err != nil {
 		return
 	}
@@ -1316,15 +1316,15 @@ func removeAppCrons(ctx context.Context, cfg ApplicationHandlerConfig, userID, o
 		if !want[j.Command] && (installPath == "" || !strings.Contains(j.Command, pathRef)) {
 			continue
 		}
-		if cfg.Agent != nil && osUser != "" {
-			_, _ = cfg.Agent.Call(ctx, "cron.remove", cronRemoveAgentParams{
+		if deps.Agent != nil && osUser != "" {
+			_, _ = deps.Agent.Call(ctx, "cron.remove", cronRemoveAgentParams{
 				UserID:    userID,
 				Username:  osUser,
 				JobID:     j.ID,
 				RunAsRoot: j.RunAsRoot,
 			})
 		}
-		_ = cfg.CronJobs.Delete(ctx, j.ID)
+		_ = deps.CronJobs.Delete(ctx, j.ID)
 	}
 }
 

--- a/panel-api/internal/api/wordpress.go
+++ b/panel-api/internal/api/wordpress.go
@@ -1187,118 +1187,31 @@ func createInstallAndKickAgent(parentCtx context.Context, args installKickArgs, 
 // fails we flip status to failed but still allow a future retry.
 // Non-empty osUser+docroot are required; the handler pre-fills them.
 func createDeleteAndKickAgent(parentCtx context.Context, installID, userID, appType, subdirectory, databaseID, dbUserID, osUser, docroot, domainName, dbUserUsername string, cfg ApplicationHandlerConfig) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	if cfg.Agent == nil {
-		errMsg := "agent not configured"
-		cfg.ApplicationInstalls.UpdateStatus(ctx, installID, "failed", &errMsg, nil)
-		return
-	}
-
-	// Default appType to "wordpress" for any install row that pre-dates
-	// the M19 migration (the column NOT NULL DEFAULT 'wordpress' should
-	// have backfilled, but treat empty defensively).
-	if appType == "" {
-		appType = "wordpress"
-	}
-
-	// Agent removes the app's files from the docroot AND restores
-	// the domain.create placeholder index.html (when domain is non-empty)
-	// so the docroot doesn't 403 after delete. Does NOT touch the MySQL
-	// side — panel handles that below.
-	//
-	// M19: dispatched through app.delete with app_type discriminator
-	// (was hardcoded "wordpress" before the rename).
-	// install_id + subdirectory let deleters that opted into the
-	// managed-data-dir contract recompute /home/<user>/<install_id>-data
-	// for cleanup, and let subdir installs target the right path.
-	_, err := cfg.Agent.Call(ctx, "app.delete", map[string]any{
-		"app_type":     appType,
-		"install_id":   installID,
-		"os_user":      osUser,
-		"docroot":      docroot,
-		"subdirectory": subdirectory,
-		"domain":       domainName,
+	// JAB-314: the delete side-effect sequence now lives in the shared
+	// RunAppDelete so the operator CLI (cli_ops_app.go) produces an identical,
+	// fail-closed transcript. parentCtx is intentionally unused — RunAppDelete
+	// detaches onto its own background context so an accepted deletion outlives
+	// the request context.
+	_ = parentCtx
+	_ = RunAppDelete(AppDeleteArgs{
+		InstallID:      installID,
+		UserID:         userID,
+		AppType:        appType,
+		Subdirectory:   subdirectory,
+		DatabaseID:     databaseID,
+		DBUserID:       dbUserID,
+		OSUser:         osUser,
+		Docroot:        docroot,
+		DomainName:     domainName,
+		DBUserUsername: dbUserUsername,
+	}, AppDeleteDeps{
+		Installs:       cfg.ApplicationInstalls,
+		Databases:      cfg.Databases,
+		DatabaseUsers:  cfg.DatabaseUsers,
+		DatabaseGrants: cfg.DatabaseGrants,
+		CronJobs:       cfg.CronJobs,
+		Agent:          cfg.Agent,
 	})
-	if err != nil {
-		errMsg := truncateError(fmt.Sprintf("agent delete failed: %v", err), 1024)
-		cfg.ApplicationInstalls.UpdateStatus(ctx, installID, "failed", &errMsg, nil)
-		return
-	}
-
-	// Apps that auto-create cron jobs at install — tear them down now
-	// (crons aren't FK-linked to the install).
-	switch appType {
-	case "itflow":
-		removeITFlowCrons(ctx, cfg, userID, osUser, appInstallPath(docroot, subdirectory))
-	case "wordpress", "joomla", "mediawiki":
-		removeAppCrons(ctx, cfg, userID, osUser, appType, appInstallPath(docroot, subdirectory))
-	}
-
-	// DB-side cleanup: drop the mariadb database + user on the host via the
-	// agent, then remove the panel-side rows so the slot is freed up.
-	//
-	// The panel row is only removed once the host-side object is actually
-	// gone. This used to log the drop failure and delete the row anyway,
-	// which is how an invisible orphan is made: the agent call is a root RPC
-	// and an agent restart, a timeout, or a long-call 502 is enough to fail
-	// it, after which the MariaDB database and user survive with no panel row
-	// left to name them — absent from `jabali db list`, absent from the
-	// account backup, still holding their grants. testserver carries four
-	// such orphan pairs, two of them complete WordPress schemas (75 and 64
-	// tables) that no backup has ever covered.
-	//
-	// Keeping the rows instead leaves an ordinary, visible database the owner
-	// can retry from the Databases page, and databases.go's delete refuses to
-	// remove the row unless its own drop succeeds — so the retry cannot
-	// reintroduce the orphan.
-	dropFailed := false
-
-	// The agent command is `db_user.drop` with `db_user_name` — NOT
-	// `mysql.user.delete` (which doesn't exist; the prior call silently
-	// no-op'd and the account survived every WP delete).
-	if dbUserID != "" && dbUserUsername != "" {
-		if _, agentErr := cfg.Agent.Call(ctx, "db_user.drop", map[string]any{"db_user_name": dbUserUsername}); agentErr != nil {
-			dropFailed = true
-			slog.ErrorContext(ctx, "wordpress delete: db_user.drop failed — keeping the panel rows so the account stays visible instead of becoming an orphan",
-				"err", agentErr, "db_user", dbUserUsername)
-		}
-	}
-
-	// Agent command is `db.drop` with `db_name` — NOT
-	// `mysql.database.delete` (same silent-no-op bug as above, the schema
-	// survived every delete).
-	if databaseID != "" {
-		if db, dbErr := cfg.Databases.FindByID(ctx, databaseID); dbErr == nil && db != nil {
-			if _, agentErr := cfg.Agent.Call(ctx, "db.drop", map[string]any{"db_name": db.Name}); agentErr != nil {
-				dropFailed = true
-				slog.ErrorContext(ctx, "wordpress delete: db.drop failed — keeping the panel rows so the database stays visible instead of becoming an orphan",
-					"err", agentErr, "db_name", db.Name)
-			}
-		}
-	}
-
-	// The install's files are gone (the app.delete above succeeded or we
-	// returned), so its row goes either way. Deleting it before the databases
-	// row also releases fk_wpinstalls_db, which is RESTRICT.
-	cfg.ApplicationInstalls.Delete(ctx, installID)
-
-	if dropFailed {
-		return
-	}
-
-	if dbUserID != "" {
-		if grants, gErr := cfg.DatabaseGrants.ListByDatabaseUserID(ctx, dbUserID); gErr == nil {
-			for _, g := range grants {
-				cfg.DatabaseGrants.Delete(ctx, g.ID)
-			}
-		}
-		cfg.DatabaseUsers.Delete(ctx, dbUserID)
-	}
-	if databaseID != "" {
-		cfg.Databases.Delete(ctx, databaseID)
-	}
 }
 
 // createCloneAndKickAgent clones WordPress asynchronously.


### PR DESCRIPTION
## Bug (JAB-314, urgent · invisible host + database orphans)

The HTTP handler and the operator CLI ran **opposite** application-delete
sequences. HTTP (`createDeleteAndKickAgent`) is fail-closed; the CLI
(`deleteAppDirect`) was fail-open:

| Failure | HTTP (correct) | CLI (broken) |
|---------|----------------|--------------|
| agent `app.delete` fails | status=failed, **retain** install row, stop | continues, **drops** every row |
| `db_user.drop` / `db.drop` fails | **keep** DB/user/grant rows visible | deletes them anyway |
| cron teardown | removes app crons | **never** ran |

Each CLI path manufactures an orphan: a MariaDB schema with no row to name it
(absent from `db list` and every backup), or a cron that fails on every run
because its install directory is gone.

## Fix
Extract the authoritative sequence into exported **`api.RunAppDelete(args, deps)`**
and route both adapters through it:
- Agent `app.delete` failure → status=failed, install row **retained**, no DB drops.
- Cron teardown runs on every path (wordpress/joomla/mediawiki + itflow).
- `db_user.drop`/`db.drop` failure → **keep** the DB rows visible + retryable.
- Install row deleted once files are gone (releases the RESTRICT FK); DB rows deleted only when their host drop succeeded.
- Detached 5-min context so an accepted delete outlives the request.

`removeAppCrons`/`removeITFlowCrons` now take `AppDeleteDeps`. HTTP
`createDeleteAndKickAgent` is a thin wrapper (behaviour unchanged); the CLI's
inline sequence is replaced by the delegation.

## Tests
`internal/api/app_delete_test.go` — three fail-closed invariants (agent-fail
retains row + no drops; drop-fail keeps DB rows; happy path removes everything +
runs cron teardown). CLI source-pin asserts the delegation. Full `internal/api` +
`cmd/server` green; `go vet` + `gofmt` clean; exec-seam guard unaffected.

## Acceptance criteria (all met)
- [x] Agent app-delete failure retains a retryable install row.
- [x] Database or login drop failure retains corresponding DB truth.
- [x] WordPress, Joomla, MediaWiki, and ITFlow cron jobs are removed.
- [x] HTTP and CLI side-effect transcripts are identical (same `RunAppDelete`).
- [x] Accepted background deletion outlives the request context.

## Verification note
The HTTP path was already the correct reference and its behaviour is unchanged (thin wrapper → same code); the CLI now shares that proven sequence. Fail-closed semantics are unit-tested. A live install→delete→orphan-check E2E wasn't run this session (no follow-up needed for criteria), but is straightforward if belt-and-suspenders is wanted.

GH JAB-314