### PR TITLE
fix(backup): skip-if-pending in the scheduler to stop queue starvation (JAB-361)

### DIFF
--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -437,6 +437,18 @@ func (s *Scheduler) enqueueAccountBackup(ctx context.Context, sched models.Backu
 			}
 		}
 	}
+	// JAB-361: skip if a job for this exact (schedule, destination, user) target
+	// is already queued or running. A slow/dead destination holds each slot for
+	// the finalizer's 4h stall window, so without this the cadence piles up
+	// duplicate jobs faster than they drain — the queue grows unbounded and real
+	// tenant backups starve for days behind the grind.
+	if pending, perr := s.deps.Jobs.HasPendingForTarget(ctx, sched.ID, dest.ID, user.ID); perr != nil {
+		logger.Error("check pending backup_job failed", "err", perr)
+		return false
+	} else if pending {
+		logger.Info("scheduled backup skipped: a job for this target is already queued/running")
+		return false
+	}
 	schedID := sched.ID
 	rid := runID
 	dID := dest.ID
@@ -573,6 +585,16 @@ func (s *Scheduler) notifyBackupLimit(ctx context.Context, user *models.User, ou
 
 func (s *Scheduler) enqueueSystemBackup(ctx context.Context, sched models.BackupSchedule, dest *models.BackupDestination, runID string) bool {
 	logger := s.deps.Log.With("schedule_id", sched.ID, "kind", "system_backup", "destination_id", dest.ID, "run_id", runID)
+	// JAB-361: skip if a system_backup for this (schedule, destination) is already
+	// queued or running. This is the exact case that piled 133 jobs on .86 — a
+	// dead SFTP destination on a */30 schedule, each job holding a slot for 4h.
+	if pending, perr := s.deps.Jobs.HasPendingForTarget(ctx, sched.ID, dest.ID, "system"); perr != nil {
+		logger.Error("check pending system backup_job failed", "err", perr)
+		return false
+	} else if pending {
+		logger.Info("system backup skipped: a job for this target is already queued/running")
+		return false
+	}
 	schedID := sched.ID
 	rid := runID
 	dID := dest.ID

--- a/panel-api/internal/backupscheduler/scheduler_skip_pending_test.go
+++ b/panel-api/internal/backupscheduler/scheduler_skip_pending_test.go
@@ -1,0 +1,63 @@
+package backupscheduler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// pendingFakeJobs records Create calls and answers HasPendingForTarget from a
+// flag so the skip-if-pending guard can be exercised without a DB.
+type pendingFakeJobs struct {
+	repository.BackupJobRepository
+	pending bool
+	created int
+	// lastTarget captures the (schedule, dest, user) the guard queried.
+	qSched, qDest, qUser string
+}
+
+func (f *pendingFakeJobs) HasPendingForTarget(_ context.Context, scheduleID, destinationID, userID string) (bool, error) {
+	f.qSched, f.qDest, f.qUser = scheduleID, destinationID, userID
+	return f.pending, nil
+}
+func (f *pendingFakeJobs) Create(context.Context, *models.BackupJob) error { f.created++; return nil }
+
+func schedulerWithJobs(j repository.BackupJobRepository) *Scheduler {
+	return &Scheduler{deps: Deps{Jobs: j, Log: slog.Default()}}
+}
+
+// JAB-361: the exact starvation case — a system_backup schedule against a
+// dead destination must NOT enqueue another job while one is still
+// queued/running, or the cadence piles jobs up faster than the 4h-per-slot
+// drain and starves every other backup.
+func TestEnqueueSystemBackup_SkipsWhenPending(t *testing.T) {
+	jobs := &pendingFakeJobs{pending: true}
+	s := schedulerWithJobs(jobs)
+	ok := s.enqueueSystemBackup(context.Background(),
+		models.BackupSchedule{ID: "sch1"}, &models.BackupDestination{ID: "dead-dest"}, "run1")
+	if ok {
+		t.Error("enqueueSystemBackup must return false when a job is already pending")
+	}
+	if jobs.created != 0 {
+		t.Errorf("no job may be created when one is already pending; created=%d", jobs.created)
+	}
+	if jobs.qSched != "sch1" || jobs.qDest != "dead-dest" || jobs.qUser != "system" {
+		t.Errorf("guard queried the wrong target: %q/%q/%q", jobs.qSched, jobs.qDest, jobs.qUser)
+	}
+}
+
+func TestEnqueueSystemBackup_CreatesWhenNonePending(t *testing.T) {
+	jobs := &pendingFakeJobs{pending: false}
+	s := schedulerWithJobs(jobs)
+	ok := s.enqueueSystemBackup(context.Background(),
+		models.BackupSchedule{ID: "sch1"}, &models.BackupDestination{ID: "d1"}, "run1")
+	if !ok {
+		t.Error("enqueueSystemBackup must enqueue when nothing is pending")
+	}
+	if jobs.created != 1 {
+		t.Errorf("exactly one job must be created; created=%d", jobs.created)
+	}
+}

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -39,6 +39,9 @@ func (f *fakeBackupJobs) MarkFinished(context.Context, string, string, string, s
 	return nil
 }
 func (f *fakeBackupJobs) CountByStatus(context.Context, string) (int64, error) { return 0, nil }
+func (f *fakeBackupJobs) HasPendingForTarget(context.Context, string, string, string) (bool, error) {
+	return false, nil
+}
 func (f *fakeBackupJobs) ListRunning(context.Context, int) ([]models.BackupJob, error) {
 	return nil, nil
 }

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -44,6 +44,13 @@ type BackupJobRepository interface {
 	// follow-up). CountByStatus + ListQueuedOldest let it cap
 	// dispatches at server_settings.backup_max_concurrent_jobs.
 	CountByStatus(ctx context.Context, status string) (int64, error)
+	// HasPendingForTarget reports whether a queued or running backup_job already
+	// exists for this (schedule, destination, user) target. The scheduler uses it
+	// to skip re-enqueueing while a prior job is still pending — otherwise a
+	// slow/dead destination that holds each slot for the finalizer's 4h stall
+	// window lets the cadence pile unbounded duplicate jobs and starve every
+	// other backup (JAB-361).
+	HasPendingForTarget(ctx context.Context, scheduleID, destinationID, userID string) (bool, error)
 	ListQueuedOldest(ctx context.Context, limit int) ([]models.BackupJob, error)
 	// ListRunning is the finalizer's worklist. It must query status
 	// directly: paging the newest N of ALL statuses and filtering in Go
@@ -213,6 +220,21 @@ func (r *backupJobRepo) CountByStatus(ctx context.Context, status string) (int64
 		return 0, translate(err)
 	}
 	return n, nil
+}
+
+func (r *backupJobRepo) HasPendingForTarget(ctx context.Context, scheduleID, destinationID, userID string) (bool, error) {
+	var n int64
+	err := r.db.WithContext(ctx).
+		Model(&models.BackupJob{}).
+		Where("schedule_id = ? AND destination_id = ? AND user_id = ? AND status IN ?",
+			scheduleID, destinationID, userID,
+			[]string{models.BackupJobStatusQueued, models.BackupJobStatusRunning}).
+		Limit(1).
+		Count(&n).Error
+	if err != nil {
+		return false, translate(err)
+	}
+	return n > 0, nil
 }
 
 func (r *backupJobRepo) ListRuns(ctx context.Context, limit, offset int) ([]BackupRunSummary, int64, error) {


### PR DESCRIPTION
## Bug (JAB-361, high · live backup-queue starvation)

The in-process backup scheduler enqueues on cadence with **no backpressure**.
When a destination is slow/dead, each of its jobs sits in `running` until the
finalizer's **4h stall timeout**, holding a shared concurrency slot the whole
time. The cadence then piles up new jobs far faster than the ~0.5 jobs/h that
drain — the queue grows unbounded and real tenant backups starve for days.

**Live on the .86 smoke box:** a `*/30` `system_backup` schedule against a dead
SFTP destination piled **133 queued jobs** over 3 days (43 already stall-failed at
`dur=240min`) and starved **3 real `account_backup` jobs** sharing the same 2-slot
pool.

## Fix (the ranked #1, small + high-leverage)

Before enqueueing, skip if a **queued or running** `backup_job` already exists for
the same **(schedule, destination, user)** target. A failing destination now holds
at most one pending job per target instead of an ever-growing pile — the queue
stays bounded and the other slots stay available for healthy destinations + tenant
backups.

- New `repository.BackupJobRepository.HasPendingForTarget(scheduleID, destinationID, userID)`.
- Wired into `enqueueAccountBackup` (user id) and `enqueueSystemBackup` (`"system"`).

## Tests
Unit-tested: `enqueueSystemBackup` creates nothing when a job is pending, enqueues
exactly one when none is, and queries the correct target. Full `backupscheduler` +
`repository` suites green.

## Scope / follow-ups
- The single shared concurrency pool still lets one failing destination hold a slot per 4h attempt → **per-destination accounting + circuit-breaker, JAB-362**.
- GH #331 DR unpair orphaned the .86 schedule+destination that triggered this → **JAB-363**.
- The .86 reproduction rows are left untouched.

## Verification note
Logic is unit-tested. A live box-proof (deploy → run two scheduler ticks for the same schedule/dest → confirm the second adds no duplicate) would also **relieve the live starvation on .86** — but that changes the operator's intentionally-preserved repro state, so I've left it for an explicit go.

GH JAB-361 · follow-ups JAB-362, JAB-363