### PR TITLE
fix(docker): target EffectiveSlug for CLI docker agent ops, not the base slug (JAB-315)

### DIFF
--- a/panel-api/cmd/server/docker_app_cmd.go
+++ b/panel-api/cmd/server/docker_app_cmd.go
@@ -376,7 +376,11 @@ func newDockerAppStatusCmd() *cobra.Command {
 				"ports": ports,
 			}
 			if sharedAgent != nil {
-				raw, agerr := sharedAgent.Call(ctx, "docker_app.status", map[string]any{"slug": app.Slug})
+				// JAB-315: agent ops must target EffectiveSlug (instance_slug when
+				// set), not the catalog Slug — otherwise a second install of the
+				// same catalog app (EffectiveSlug slug-2, slug-3…) is addressed by
+				// its base slug and the op hits the WRONG instance.
+				raw, agerr := sharedAgent.Call(ctx, "docker_app.status", map[string]any{"slug": app.EffectiveSlug()})
 				if agerr != nil {
 					out["agent_error"] = agerr.Error()
 				} else {
@@ -403,11 +407,13 @@ func newDockerAppLifecycleCmd(verb, short string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			raw, err := sharedAgent.Call(ctx, "docker_app."+verb, map[string]any{"slug": app.Slug})
+			// JAB-315: target EffectiveSlug so start/stop/restart hit this exact
+			// instance, not the base-slug container of a different install.
+			raw, err := sharedAgent.Call(ctx, "docker_app."+verb, map[string]any{"slug": app.EffectiveSlug()})
 			if err != nil {
 				return err
 			}
-			fmt.Printf("ok: %s -> %s\n", verb, app.Slug)
+			fmt.Printf("ok: %s -> %s\n", verb, app.EffectiveSlug())
 			os.Stdout.Write(raw)
 			os.Stdout.Write([]byte{'\n'})
 			return nil
@@ -430,8 +436,10 @@ func newDockerAppDeleteCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// JAB-315: delete the container/data for THIS instance (EffectiveSlug),
+			// not whatever the base catalog slug resolves to.
 			if _, err := sharedAgent.Call(ctx, "docker_app.delete", map[string]any{
-				"slug":          app.Slug,
+				"slug":          app.EffectiveSlug(),
 				"purge_volumes": !keepVolumes,
 			}); err != nil {
 				return err
@@ -476,7 +484,8 @@ func newDockerAppLogsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			params := map[string]any{"slug": app.Slug}
+			// JAB-315: tail THIS instance's container logs (EffectiveSlug).
+			params := map[string]any{"slug": app.EffectiveSlug()}
 			if lines > 0 {
 				params["lines"] = lines
 			}

--- a/panel-api/cmd/server/docker_app_cmd_effectiveslug_test.go
+++ b/panel-api/cmd/server/docker_app_cmd_effectiveslug_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestDockerAppCLI_AgentOpsUseEffectiveSlug pins the JAB-315 fix. Docker agent
+// ops must address the container/data path by EffectiveSlug (instance_slug when
+// set), never the base catalog Slug — otherwise a second install of the same
+// catalog app (EffectiveSlug slug-2, slug-3, …) is addressed by its base slug and
+// the op (status/start/stop/restart/delete/logs) hits the WRONG instance.
+// cmd/server has no DB/agent fixture, so this source-pins the invariant.
+func TestDockerAppCLI_AgentOpsUseEffectiveSlug(t *testing.T) {
+	src, err := os.ReadFile("docker_app_cmd.go")
+	if err != nil {
+		t.Fatalf("read docker_app_cmd.go: %v", err)
+	}
+	s := string(src)
+	// An agent slug param built from the raw catalog Slug is the bug.
+	if regexp.MustCompile(`"slug":\s*app\.Slug\b`).MatchString(s) {
+		t.Fatal(`a docker agent op still passes "slug": app.Slug — must be app.EffectiveSlug() so it targets the right instance (JAB-315)`)
+	}
+	// And the fixed ops must use EffectiveSlug.
+	if !strings.Contains(s, "app.EffectiveSlug()") {
+		t.Fatal("docker CLI agent ops must target app.EffectiveSlug() (JAB-315)")
+	}
+}


### PR DESCRIPTION
## Bug (JAB-315, urgent · wrong-instance targeting for multi-instance Docker apps)

`EffectiveSlug` is a docker-app install's agent/on-disk identifier: `instance_slug`
when set (UI installs + post-000160 rows), else the catalog slug. Its doc is
explicit — "use this anywhere a slug is passed to the agent or used to build a data
path." The operator CLI followed that for install/update/read_env, but **status,
lifecycle (start/stop/restart), delete, and logs passed the raw catalog `app.Slug`**.

For a **second install of the same catalog app** — `EffectiveSlug` `slug-2`,
`slug-3`, … — the base slug addresses a *different* instance, so
`jabali docker app restart <id>` / `delete <id>` / `logs <id>` operated on the
**wrong container and data path**.

## Fix
Pass `app.EffectiveSlug()` in all four agent-op sites (status / lifecycle / delete
/ logs). Catalog lookups (`cat.Get(app.Slug)`) stay on the base slug — the catalog
is keyed by it. A grep confirms no agent op still builds its slug param from raw
`app.Slug`.

## Test
Source-pin (`cmd/server` has no DB/agent fixture; same precedent as
`log_cmd_scope_test.go`): asserts no agent op passes `"slug": app.Slug` and that the
ops use `app.EffectiveSlug()`. Full `cmd/server` green.

## Acceptance criteria
- [x] Every multi-instance operation targets `EffectiveSlug`.
- [ ] Tenant start/restart revalidates isolation + caps → **JAB-364**.
- [ ] Managed vs user-owned attached-domain deletion rules (CLI delete currently removes **every** domain bound to the app — data-loss risk for user-owned attached domains) → **JAB-364**.
- [ ] Vhost removal when required; retryable panel state; shared Docker App Lifecycle module → **JAB-364**.

GH JAB-315 · follow-up JAB-364