### PR TITLE
feat(databases): per-database Restore from file for PostgreSQL (GH #1045)

### DIFF
--- a/panel-agent/internal/commands/db_postgres_restore.go
+++ b/panel-agent/internal/commands/db_postgres_restore.go
@@ -1,0 +1,291 @@
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/hostreserve"
+)
+
+// db.postgres.restore — load a tenant-uploaded .sql dump into a Postgres
+// database (GH #1045 PostgreSQL parity). The MariaDB sibling is db.restore.
+//
+// SECURITY MODEL (mirrors loadMariaDBDumpScoped / JAB-239): the dump is
+// attacker-controlled content. It is NEVER loaded as the postgres superuser —
+// that would let `COPY ... FROM PROGRAM`, `CREATE FUNCTION ... LANGUAGE C`,
+// cross-database reads, etc. run with cluster privileges. Instead the dump is
+// streamed through a per-database, NON-superuser shadow role over the scram TCP
+// loopback listener, with psql running as the unprivileged OS user `nobody`:
+//
+//   - shadow role jbsr_<hash>: LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE
+//     NOINHERIT, fresh single-use random password. As a non-superuser it can't
+//     escalate; every statement in the dump is confined to this one database.
+//   - psql runs as OS user `nobody` via SysProcAttr.Credential (NOT sudo —
+//     env_reset would scrub PGPASSWORD, the same scar as MYSQL_PWD in JAB-239),
+//     so psql client meta-commands (\!, \copy, \i) land on an account that can
+//     touch nothing.
+//   - the password rides in PGPASSWORD (off argv, single-use), auth is
+//     scram-sha-256 on 127.0.0.1:5432 which install.sh already enables (default
+//     Debian pg_hba) — no pg_hba change needed.
+//
+// The dump produced by db.postgres.backup is --no-owner --no-privileges, so it
+// carries no ownership/GRANT statements a non-superuser couldn't run. Ownership
+// is re-established afterwards by an agent-authored SUPERUSER post-pass, never
+// from dump content.
+//
+// The restore is built in a THROWAWAY staging db and renamed onto the real name
+// only after it fully succeeds — so a failed load (truncated upload, a -Fc
+// custom-format dump psql can't parse, the call ctx expiring mid-load) leaves
+// the tenant's real database untouched, never wiped-and-empty:
+//
+//   1. superuser: CREATE DATABASE <tmp> OWNER <shadow> (shadow owns public and
+//      can create objects while loading).
+//   2. load the dump as the shadow into <tmp>. On failure: drop <tmp> + shadow,
+//      return — the real db was never touched.
+//   3. superuser post-pass on <tmp>: REASSIGN OWNED BY <shadow> TO <owner_role>
+//      (the DB's primary tenant role) so restored objects are tenant-owned;
+//      re-apply DATABASE + table/sequence/default privileges to every granted
+//      role (MariaDB's GRANT ON db.* covers all tables — Postgres needs this
+//      explicitly); ALTER DATABASE OWNER TO postgres (jabali's create model);
+//      drop the shadow. When there are no granted roles, ownership falls to
+//      postgres.
+//   4. swap: DROP the real db, RENAME <tmp> onto its name. A crash in the tiny
+//      gap between these leaves the restored data in the jbrt_* db (manually
+//      recoverable), never an empty database. CheckReserve guards the transient
+//      2x-on-disk cost.
+
+type dbPgRestoreParams struct {
+	DBName string `json:"db_name"`
+	Path   string `json:"path"`
+	// OwnerRole is the DB's primary tenant role — restored objects are
+	// reassigned to it. Empty → objects owned by postgres (no tenant role to
+	// hand them to).
+	OwnerRole string `json:"owner_role,omitempty"`
+	// GrantRoles are all tenant roles that had a grant on the DB before the
+	// reset; each is re-granted DATABASE + object privileges after the load.
+	GrantRoles []string `json:"grant_roles,omitempty"`
+}
+
+type dbPgRestoreResponse struct {
+	OK bool `json:"ok"`
+}
+
+// pgShadowRole derives a bounded, deterministic loader role name: jbsr_ + 16 hex
+// of sha256(db) = 21 chars, always under Postgres's 63-char NAMEDATALEN and
+// pgValidIdent-safe regardless of how long or odd the database name is.
+func pgShadowRole(db string) string {
+	sum := sha256.Sum256([]byte(db))
+	return "jbsr_" + hex.EncodeToString(sum[:])[:16]
+}
+
+// pgRestoreTmpDB derives the staging database name the dump is loaded into
+// before the atomic swap: jbrt_ + 16 hex of sha256(db) = 21 chars, same bounds
+// as pgShadowRole. Loading into a throwaway db and renaming on success means a
+// FAILED load (truncated upload, a -Fc custom-format dump psql can't read, the
+// call ctx expiring mid-load) leaves the tenant's real database untouched —
+// never the drop-then-load data loss.
+func pgRestoreTmpDB(db string) string {
+	sum := sha256.Sum256([]byte(db))
+	return "jbrt_" + hex.EncodeToString(sum[:])[:16]
+}
+
+// pgSuperExecInDB runs one statement as the postgres superuser CONNECTED TO db
+// (REASSIGN OWNED / GRANT ON ALL TABLES / DROP OWNED are database-local). db is
+// a pgValidIdent-checked identifier passed as an exec arg (no shell).
+func pgSuperExecInDB(ctx context.Context, db, sql string) error {
+	cmd := execCommandContext(ctx, "sudo", "-u", "postgres", "psql",
+		"-v", "ON_ERROR_STOP=1", "-XAtq", "-d", db, "-c", sql)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("psql -d %s: %w (%s)", db, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func dbPgRestoreHandler(ctx context.Context, params json.RawMessage) (any, error) {
+	var p dbPgRestoreParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("failed to parse params: %v", err)}
+	}
+	if !pgValidIdent(p.DBName) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid database name"}
+	}
+	if p.OwnerRole != "" && !pgValidIdent(p.OwnerRole) {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid owner_role"}
+	}
+	for _, r := range p.GrantRoles {
+		if !pgValidIdent(r) {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "invalid grant role: " + r}
+		}
+	}
+
+	// Refuse to start loading when the PG data filesystem is already under the
+	// host reserve floor (mirrors db.restore's /var/lib/mysql check).
+	if err := hostreserve.CheckReserve("/var/lib/postgresql", 0); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeUnavailable, Message: "database storage is under the host disk reserve: " + err.Error()}
+	}
+
+	// Open the dump escape-proof under an allowed root (same scope + roots as
+	// db.restore — Gitea #501 symlink hardening).
+	restoreScope, scErr := filesafe.NewScope("system", "system", []string{
+		"/var/lib/jabali/restore", "/var/lib/jabali-migrations", "/var/lib/jabali/migrations",
+	})
+	if scErr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("scope: %v", scErr)}
+	}
+	p.Path = canonicalizeStagingRootPrefix(p.Path)
+	f, err := restoreScope.Open(p.Path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "restore path invalid, outside an allowed directory, or not readable"}
+	}
+	defer f.Close()
+
+	shadow := pgShadowRole(p.DBName)
+	tmpDB := pgRestoreTmpDB(p.DBName)
+	pb := make([]byte, 18)
+	if _, err := rand.Read(pb); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "mint scoped restore password"}
+	}
+	pwd := hex.EncodeToString(pb) // hex only — safe in a SQL string literal
+
+	// (1) Provision the NON-superuser shadow with a fresh single-use password.
+	// DO block because CREATE ROLE has no IF NOT EXISTS; ALTER re-randomizes on
+	// every restore so a captured credential is single-use. (The literal
+	// password can appear in the server log only if an operator turns on
+	// log_statement=ddl — same shape as the MariaDB loader; the role is
+	// single-use + NOSUPERUSER regardless.)
+	provision := fmt.Sprintf(`DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '%s') THEN
+    CREATE ROLE "%s" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT PASSWORD '%s';
+  ELSE
+    ALTER ROLE "%s" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT PASSWORD '%s';
+  END IF;
+END $$;`, shadow, shadow, pwd, shadow, pwd)
+	if err := pgRunSQL(ctx, provision); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "provision scoped restore role: " + err.Error()}
+	}
+	// Until the swap succeeds, tear down anything we created — the STAGING db
+	// and the shadow — never the tenant's real database. Dropping tmpDB first
+	// removes the shadow's owned objects so DROP ROLE then succeeds. On success
+	// this is a no-op (tmpDB was renamed away, shadow already dropped).
+	success := false
+	defer func() {
+		if !success {
+			_ = pgRunSQL(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" WITH (FORCE)`, tmpDB))
+			_ = pgRunSQL(context.Background(), fmt.Sprintf(`DROP ROLE IF EXISTS "%s"`, shadow))
+		}
+	}()
+
+	// (2) Build the restore in a throwaway db owned by the shadow (so it can
+	// create the dump's objects). DROP IF EXISTS first cleans up a tmpDB
+	// stranded by a crashed prior attempt.
+	if err := pgRunSQL(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" WITH (FORCE)`, tmpDB)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "clear staging database: " + err.Error()}
+	}
+	if err := pgRunSQL(ctx, fmt.Sprintf(`CREATE DATABASE "%s" OWNER "%s" TEMPLATE template0`, tmpDB, shadow)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "create staging database: " + err.Error()}
+	}
+
+	// (3) Load the dump into the STAGING db as the shadow, unprivileged OS user,
+	// over scram TCP. A failed load (bad/truncated/-Fc dump, ctx timeout) leaves
+	// the tenant's real db untouched — the defer just drops the staging db.
+	// Residual: `\!` in a dump runs as `nobody`, which can't touch the FS but
+	// isn't network-isolated — the same accepted residual as the MariaDB loader.
+	nobody, err := user.Lookup("nobody")
+	if err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "lookup nobody: " + err.Error()}
+	}
+	uid, uerr := strconv.ParseUint(nobody.Uid, 10, 32)
+	gid, gerr := strconv.ParseUint(nobody.Gid, 10, 32)
+	if uerr != nil || gerr != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "parse nobody uid/gid"}
+	}
+	load := execCommandContext(ctx, "psql",
+		"-v", "ON_ERROR_STOP=1", "-X", "-q",
+		"-h", "127.0.0.1", "-p", "5432",
+		"-U", shadow, "-d", tmpDB)
+	load.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}}
+	load.Env = append(os.Environ(), "PGPASSWORD="+pwd)
+	load.Stdin = f // escape-proof fd; nobody reads the inherited fd, not the path
+	if out, err := load.CombinedOutput(); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeFailedPrecondition, Message: "restore load failed (check the dump is a plain-SQL pg_dump): " + strings.TrimSpace(string(out))}
+	}
+
+	// (4) Superuser post-pass on the STAGING db — ownership + grants, none of it
+	// from dump content. Everything here targets tmpDB; DATABASE grants attach
+	// to its OID and survive the rename below.
+	ownerTarget := p.OwnerRole
+	if ownerTarget == "" {
+		ownerTarget = "postgres"
+	}
+	if err := pgSuperExecInDB(ctx, tmpDB, fmt.Sprintf(`REASSIGN OWNED BY "%s" TO "%s"`, shadow, ownerTarget)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "reassign ownership: " + err.Error()}
+	}
+	// Re-apply privileges to every role that had a grant before the restore.
+	// MariaDB's GRANT ON db.* implicitly covers every current + future table;
+	// Postgres needs table/sequence + DEFAULT PRIVILEGES stated explicitly.
+	for _, role := range p.GrantRoles {
+		if err := pgRunSQL(ctx, fmt.Sprintf(`GRANT ALL PRIVILEGES ON DATABASE "%s" TO "%s"`, tmpDB, role)); err != nil {
+			return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "regrant database: " + err.Error()}
+		}
+		for _, stmt := range []string{
+			`GRANT ALL ON SCHEMA public TO "%s"`,
+			`GRANT ALL ON ALL TABLES IN SCHEMA public TO "%s"`,
+			`GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "%s"`,
+			`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "%s"`,
+			`ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "%s"`,
+		} {
+			if err := pgSuperExecInDB(ctx, tmpDB, fmt.Sprintf(stmt, role)); err != nil {
+				return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "regrant objects: " + err.Error()}
+			}
+		}
+	}
+	// Match jabali's create-time model: the database itself is postgres-owned.
+	if err := pgRunSQL(ctx, fmt.Sprintf(`ALTER DATABASE "%s" OWNER TO postgres`, tmpDB)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "set database owner: " + err.Error()}
+	}
+	// Drop the shadow — DROP OWNED first clears its default-privilege ACLs in the
+	// staging db (REASSIGN OWNED moved the objects, not the default-priv entries).
+	_ = pgSuperExecInDB(ctx, tmpDB, fmt.Sprintf(`DROP OWNED BY "%s"`, shadow))
+	if err := pgRunSQL(ctx, fmt.Sprintf(`DROP ROLE IF EXISTS "%s"`, shadow)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "drop scoped role: " + err.Error()}
+	}
+
+	// (5) Atomic-ish swap: only now do we touch the tenant's real db — drop it
+	// and rename the fully-built staging db onto its name. A crash in the gap
+	// between these two leaves the restored data in the jbrt_* db (manually
+	// recoverable), never an empty database. Terminate real-db connections so
+	// the DROP can't block.
+	if err := pgRunSQL(ctx, fmt.Sprintf(
+		`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()`, p.DBName)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "terminate db connections: " + err.Error()}
+	}
+	if err := pgRunSQL(ctx, fmt.Sprintf(`DROP DATABASE IF EXISTS "%s" WITH (FORCE)`, p.DBName)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "drop target database: " + err.Error()}
+	}
+	if err := pgRunSQL(ctx, fmt.Sprintf(`ALTER DATABASE "%s" RENAME TO "%s"`, tmpDB, p.DBName)); err != nil {
+		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: "swap restored database: " + err.Error()}
+	}
+	success = true
+
+	// Delete the uploaded dump through the scope (never a raw os.Remove — see
+	// db.restore for the Gitea #501 rationale).
+	_ = restoreScope.RemoveInScope(p.Path, false)
+
+	return dbPgRestoreResponse{OK: true}, nil
+}
+
+func init() {
+	Default.Register("db.postgres.restore", dbPgRestoreHandler)
+}

--- a/panel-agent/internal/commands/db_postgres_restore_test.go
+++ b/panel-agent/internal/commands/db_postgres_restore_test.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// TestDBPgRestoreHandler_Validation pins the input validation for
+// db.postgres.restore — all cases fail BEFORE any psql runs, so they need no
+// live Postgres.
+func TestDBPgRestoreHandler_Validation(t *testing.T) {
+	tests := []struct {
+		name  string
+		input dbPgRestoreParams
+	}{
+		{"empty db_name", dbPgRestoreParams{DBName: "", Path: "/var/lib/jabali/restore/x.sql"}},
+		{"bad db_name (semicolon)", dbPgRestoreParams{DBName: "a;drop", Path: "/var/lib/jabali/restore/x.sql"}},
+		{"bad db_name (quote)", dbPgRestoreParams{DBName: "a'b", Path: "/var/lib/jabali/restore/x.sql"}},
+		{"bad owner_role", dbPgRestoreParams{DBName: "good", OwnerRole: "bad;role", Path: "/var/lib/jabali/restore/x.sql"}},
+		{"bad grant role", dbPgRestoreParams{DBName: "good", GrantRoles: []string{"ok", "b\"ad"}, Path: "/var/lib/jabali/restore/x.sql"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, _ := json.Marshal(tt.input)
+			_, err := dbPgRestoreHandler(context.Background(), params)
+			var ae *agentwire.AgentError
+			if !errors.As(err, &ae) {
+				t.Fatalf("expected AgentError, got %T (%v)", err, err)
+			}
+			if ae.Code != agentwire.CodeInvalidArgument {
+				t.Errorf("code = %q, want %q", ae.Code, agentwire.CodeInvalidArgument)
+			}
+		})
+	}
+}
+
+// pgShadowRole must be deterministic per-db, pgValidIdent-safe, and comfortably
+// under Postgres's 63-char NAMEDATALEN even for a maximal 63-char db name.
+func TestPgShadowRole(t *testing.T) {
+	long := strings.Repeat("d", 63)
+	for _, db := range []string{"shop", "a", long, "tenant_db-1"} {
+		r := pgShadowRole(db)
+		if r != pgShadowRole(db) {
+			t.Errorf("pgShadowRole(%q) not deterministic", db)
+		}
+		if len(r) >= 63 {
+			t.Errorf("pgShadowRole(%q) = %q is %d chars, must be < 63", db, r, len(r))
+		}
+		if !pgValidIdent(r) {
+			t.Errorf("pgShadowRole(%q) = %q is not a valid pg identifier", db, r)
+		}
+		if !strings.HasPrefix(r, "jbsr_") {
+			t.Errorf("pgShadowRole(%q) = %q missing jbsr_ prefix", db, r)
+		}
+	}
+	// Distinct dbs get distinct roles.
+	if pgShadowRole("a") == pgShadowRole("b") {
+		t.Error("distinct dbs collided on the same shadow role")
+	}
+}
+
+// pgRestoreTmpDB (the staging database name for the load-then-swap) has the same
+// bounds as the shadow role and must never collide with it.
+func TestPgRestoreTmpDB(t *testing.T) {
+	long := strings.Repeat("d", 63)
+	for _, db := range []string{"shop", "a", long, "tenant_db-1"} {
+		tmp := pgRestoreTmpDB(db)
+		if tmp != pgRestoreTmpDB(db) {
+			t.Errorf("pgRestoreTmpDB(%q) not deterministic", db)
+		}
+		if len(tmp) >= 63 {
+			t.Errorf("pgRestoreTmpDB(%q) = %q is %d chars, must be < 63", db, tmp, len(tmp))
+		}
+		if !pgValidIdent(tmp) {
+			t.Errorf("pgRestoreTmpDB(%q) = %q is not a valid pg identifier", db, tmp)
+		}
+		if tmp == pgShadowRole(db) {
+			t.Errorf("staging db name collides with shadow role for %q", db)
+		}
+	}
+}

--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -568,23 +568,6 @@ func (h *databaseHandler) restore(c *gin.Context) {
 		return
 	}
 
-	// GH #1045 PostgreSQL parity — restore is MariaDB-only for now. The
-	// MariaDB path loads tenant-supplied SQL through a db-scoped, unprivileged
-	// shadow account (db_load_scoped.go, JAB-239); loading an uploaded dump as
-	// the postgres superuser would execute arbitrary attacker SQL (COPY FROM
-	// PROGRAM, CREATE FUNCTION, cross-DB reads) with cluster privileges. The
-	// privilege-scoped Postgres loader is the next slice — until it lands,
-	// refuse rather than fall through to the MariaDB verb (which would run
-	// mysql against a Postgres database). The UI keeps the action disabled for
-	// Postgres rows; this is the belt-and-braces server guard.
-	if d.Engine == "postgres" {
-		c.JSON(http.StatusNotImplemented, gin.H{
-			"error":  "not_implemented",
-			"detail": "PostgreSQL restore from file is not yet available",
-		})
-		return
-	}
-
 	// Parse multipart form (max 500 MB)
 	const maxUploadSize = 500 * 1024 * 1024 // 500 MB
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxUploadSize)
@@ -636,10 +619,18 @@ func (h *databaseHandler) restore(c *gin.Context) {
 	agentCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	_, err = h.cfg.Agent.Call(agentCtx, "db.restore", map[string]any{
-		"db_name": d.Name,
-		"path":    restorePath,
-	})
+	// Dispatch by engine. Postgres loads the dump through a privilege-scoped
+	// shadow role and re-establishes ownership afterwards (GH #1045), so it
+	// needs the DB's granted tenant roles; MariaDB's db.restore is unchanged.
+	restoreCmd := "db.restore"
+	restoreParams := map[string]any{"db_name": d.Name, "path": restorePath}
+	if d.Engine == "postgres" {
+		restoreCmd = "db.postgres.restore"
+		ownerRole, grantRoles := h.pgGrantedRoles(ctx, d.ID)
+		restoreParams["owner_role"] = ownerRole
+		restoreParams["grant_roles"] = grantRoles
+	}
+	_, err = h.cfg.Agent.Call(agentCtx, restoreCmd, restoreParams)
 	if err != nil {
 		// Agent cleanup the file on failure, but delete it here too just in case
 		_ = deleteFile(restorePath)
@@ -648,4 +639,31 @@ func (h *databaseHandler) restore(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+// pgGrantedRoles resolves the Postgres roles granted on a database for the
+// restore post-pass (GH #1045): `all` is every granted postgres role, `owner`
+// is a deterministic primary (the first granted role) that restored objects are
+// reassigned to. Empty owner when the database has no postgres grants — the
+// agent then leaves restored objects owned by postgres. Mirrors the delete
+// handler's grant -> db-user resolution.
+func (h *databaseHandler) pgGrantedRoles(ctx context.Context, dbID string) (owner string, all []string) {
+	if h.cfg.DatabaseGrants == nil || h.cfg.DatabaseUsers == nil {
+		return "", nil
+	}
+	grants, err := h.cfg.DatabaseGrants.ListByDatabaseID(ctx, dbID)
+	if err != nil {
+		return "", nil
+	}
+	for _, g := range grants {
+		u, uErr := h.cfg.DatabaseUsers.FindByID(ctx, g.DatabaseUserID)
+		if uErr != nil || u == nil || u.Engine != "postgres" || u.Username == "" {
+			continue
+		}
+		all = append(all, u.Username)
+	}
+	if len(all) > 0 {
+		owner = all[0]
+	}
+	return owner, all
 }

--- a/panel-api/internal/api/databases_test.go
+++ b/panel-api/internal/api/databases_test.go
@@ -746,22 +746,57 @@ func TestDatabaseBackup_DispatchesByEngine(t *testing.T) {
 	}
 }
 
-// GH #1045 — Postgres restore-from-file is refused with 501 until the
-// privilege-scoped loader ships; the handler must NOT fall through to the
-// MariaDB verb (which would run mysql against a Postgres database). The guard
-// fires before any agent call.
-func TestDatabaseRestore_PostgresNotImplemented(t *testing.T) {
-	agent := &mockAgent{}
-	r, dbRepo := databaseRouterWithAgent("user1", false, agent)
-	dbRepo.databases = []models.Database{{ID: "id1", UserID: "user1", Name: "alice_db", Engine: "postgres"}}
+// GH #1045 — pgGrantedRoles resolves the Postgres roles the restore post-pass
+// reassigns ownership + re-grants to: `all` is every granted postgres role
+// (mariadb grants filtered out), `owner` is the first of them; empty when the
+// database has no postgres grants.
+func TestPgGrantedRoles(t *testing.T) {
+	h := &databaseHandler{cfg: DatabaseHandlerConfig{
+		DatabaseGrants: &pgGrantFake{grants: []models.DatabaseUserGrant{
+			{DatabaseUserID: "u1"}, {DatabaseUserID: "u2"}, {DatabaseUserID: "u3"},
+		}},
+		DatabaseUsers: &pgUserFake{users: map[string]*models.DatabaseUser{
+			"u1": {Username: "alice_pg", Engine: "postgres"},
+			"u2": {Username: "bob_maria", Engine: "mariadb"}, // filtered out
+			"u3": {Username: "carol_pg", Engine: "postgres"},
+		}},
+	}}
+	owner, all := h.pgGrantedRoles(context.Background(), "db1")
+	assert.Equal(t, "alice_pg", owner)
+	assert.Equal(t, []string{"alice_pg", "carol_pg"}, all)
 
-	req := httptest.NewRequest("POST", "/api/v1/databases/id1/restore", nil)
-	w := httptest.NewRecorder()
-	r.ServeHTTP(w, req)
+	// No postgres grants → empty owner + no roles.
+	h2 := &databaseHandler{cfg: DatabaseHandlerConfig{
+		DatabaseGrants: &pgGrantFake{grants: []models.DatabaseUserGrant{{DatabaseUserID: "u2"}}},
+		DatabaseUsers:  &pgUserFake{users: map[string]*models.DatabaseUser{"u2": {Username: "bob", Engine: "mariadb"}}},
+	}}
+	o2, a2 := h2.pgGrantedRoles(context.Background(), "db1")
+	assert.Equal(t, "", o2)
+	assert.Empty(t, a2)
 
-	require.Equal(t, http.StatusNotImplemented, w.Code)
-	var resp map[string]interface{}
-	json.NewDecoder(w.Body).Decode(&resp)
-	assert.Equal(t, "not_implemented", resp["error"])
-	assert.Equal(t, 0, agent.callCount)
+	// Nil repos → empty, no panic (fail-safe).
+	h3 := &databaseHandler{cfg: DatabaseHandlerConfig{}}
+	o3, a3 := h3.pgGrantedRoles(context.Background(), "db1")
+	assert.Equal(t, "", o3)
+	assert.Nil(t, a3)
+}
+
+// Minimal fakes for pgGrantedRoles — embed the interfaces so only the two
+// methods the helper calls need bodies (others panic if ever invoked).
+type pgGrantFake struct {
+	repository.DatabaseUserGrantRepository
+	grants []models.DatabaseUserGrant
+}
+
+func (f *pgGrantFake) ListByDatabaseID(context.Context, string) ([]models.DatabaseUserGrant, error) {
+	return f.grants, nil
+}
+
+type pgUserFake struct {
+	repository.DatabaseUserRepository
+	users map[string]*models.DatabaseUser
+}
+
+func (f *pgUserFake) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
+	return f.users[id], nil
 }

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -163,15 +163,11 @@ describe("UserDatabaseList backup/restore (GH #1045)", () => {
     unmount();
   });
 
-  // GH #1045 PostgreSQL parity: Download backup works for a Postgres row
-  // (pg_dump path), but Restore from file stays disabled until the
-  // privilege-scoped loader ships.
-  it("enables Download for Postgres but keeps Restore disabled", async () => {
+  // GH #1045 PostgreSQL parity: Restore from file is now enabled for Postgres
+  // rows, and its confirm warns that the whole database is replaced (the
+  // pg reset-restore drops + rebuilds, unlike MariaDB's per-table overwrite).
+  it("enables Restore for Postgres with a whole-database warning", async () => {
     rowsHolder.rows = [{ ...mariaRow, name: "pg_shop", engine: "postgres" }];
-    mockedDownload.mockResolvedValue({
-      blob: new Blob(["SQL"], { type: "application/sql" }),
-      filename: "pg_shop-20260821-010203.sql",
-    });
 
     const { unmount } = render(
       <App>
@@ -181,22 +177,21 @@ describe("UserDatabaseList backup/restore (GH #1045)", () => {
 
     await openRowMenu();
 
-    // Restore is present but disabled for Postgres. AntD marks the menu item
-    // aria-disabled (pointer-events:none blocks the real click); assert that
-    // state rather than a click, which jsdom would let through.
+    // Restore is present and NOT disabled for Postgres.
     const restoreItem = await screen.findByText("Restore from file", undefined, {
       timeout: 5000,
     });
     const restoreLi = restoreItem.closest("li");
     expect(restoreLi).not.toBeNull();
-    // AntD adds the -item-disabled modifier class to a disabled menu item.
-    expect(restoreLi?.className).toMatch(/-item-disabled\b/);
+    expect(restoreLi?.className).not.toMatch(/-item-disabled\b/);
 
-    // Download still works.
-    fireEvent.click(await screen.findByText("Download backup"));
-    await waitFor(() => {
-      expect(mockedDownload).toHaveBeenCalledWith("db1");
-    });
+    // Clicking opens the confirm with the Postgres whole-database wording.
+    fireEvent.click(restoreItem);
+    expect(
+      await screen.findByText(/REPLACES the entire database/i, undefined, {
+        timeout: 5000,
+      }),
+    ).toBeTruthy();
     await act(async () => {});
     unmount();
   });

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -3,9 +3,8 @@
 // apiClient helper; a blank tab is opened synchronously to dodge
 // popup blockers while the SSO call runs.
 // GH #1045: per-database Backup/Restore actions (download a one-shot
-// dump; restore from an uploaded .sql file). Download backup works for
-// MariaDB (mariadb-dump) and PostgreSQL (pg_dump); restore is MariaDB
-// only for now — the privilege-scoped Postgres loader is the next slice.
+// dump; restore from an uploaded .sql file) for both MariaDB (mariadb-dump
+// / mysql) and PostgreSQL (pg_dump / privilege-scoped psql loader).
 import { useTranslation } from "react-i18next";
 import { useRef, useState, type ChangeEvent } from "react";
 import { shortDateTime } from "../../../utils/datetime";
@@ -351,12 +350,11 @@ export const UserDatabaseList = () => {
                 disabled: isAdminerLoading,
                 loading: isAdminerLoading,
               };
-              // GH #1045 — per-database backup/restore. Download backup works
-              // for both engines (mariadb-dump / pg_dump). Restore is still
-              // MariaDB-only: the MariaDB loader confines a tenant dump to a
-              // db-scoped, unprivileged account, and the equivalent
-              // privilege-scoped Postgres loader is the next slice — until it
-              // lands, restore stays disabled for Postgres rows.
+              // GH #1045 — per-database backup/restore for both engines.
+              // Download uses mariadb-dump / pg_dump; restore loads the uploaded
+              // dump through a db-scoped, unprivileged account (MariaDB shadow
+              // user, or the Postgres scoped shadow role over scram) so tenant
+              // SQL can never exceed its own database.
               const backupAction = {
                 key: "backup",
                 label: "Download backup",
@@ -370,15 +368,15 @@ export const UserDatabaseList = () => {
                 label: "Restore from file",
                 icon: <UploadOutlined />,
                 onClick: () => handlePickRestore(r),
-                disabled: isPostgres || restoringId === r.id,
+                disabled: restoringId === r.id,
                 loading: restoringId === r.id,
-                tooltip: isPostgres
-                  ? "Restore from file is coming to PostgreSQL — download backup works now"
-                  : undefined,
                 confirm: {
                   title: `Restore into "${r.name}"?`,
-                  description:
-                    "The uploaded dump runs against this database — existing tables with the same names are overwritten.",
+                  // Postgres restore resets the whole database (drop + rebuild
+                  // from the dump); MariaDB overwrites the dump's own tables.
+                  description: isPostgres
+                    ? "This REPLACES the entire database — all current data in it is dropped and rebuilt from the uploaded dump."
+                    : "The uploaded dump runs against this database — existing tables with the same names are overwritten.",
                   okText: "Choose .sql file",
                 },
               };


### PR DESCRIPTION
## What

Completes **GH #1045 PostgreSQL parity** — *Restore from file* now works for pg
databases, alongside the *Download backup* shipped in #1200.

## Security — the dump is attacker-controlled, never loaded as superuser

Loading a tenant-uploaded dump as `postgres` would be an RCE (`COPY … FROM
PROGRAM`, `CREATE FUNCTION LANGUAGE C`, cross-DB reads with cluster privileges).
It loads through the same trust model as the MariaDB path (`db_load_scoped.go` /
JAB-239):

- per-database **NON-superuser** shadow role `jbsr_<sha256(db)[:16]>` (`LOGIN
  NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT`, fresh single-use password);
- loaded via `psql` running as OS user **`nobody`** (`SysProcAttr.Credential`,
  not sudo — env-reset scrubs `PGPASSWORD`), so `\!` / `\copy` / `\i` land on an
  account that can touch nothing;
- auth = scram-sha-256 on `127.0.0.1:5432`, already enabled by install.sh
  (default Debian pg_hba) — **no pg_hba change**.

## Load-then-swap — a failed load never wipes the tenant DB

The dump is built in a throwaway staging db (`jbrt_<hash>`) and `RENAME`d onto
the real name only after it fully succeeds. A failed load — truncated upload, a
`-Fc` dump psql can't parse, ctx timeout — leaves the real database **untouched**
(the earlier drop-before-load design would have left it empty).

Flow (`db.postgres.restore`): `CREATE DATABASE tmp OWNER <shadow>` → load as the
shadow into tmp → superuser post-pass on tmp (`REASSIGN OWNED BY <shadow> TO
<owner_role>`; re-apply DATABASE + table/sequence/default privileges to every
granted role — MariaDB's `GRANT ON db.*` covers all tables implicitly, Postgres
needs it stated; `ALTER DATABASE OWNER TO postgres`; drop shadow) → `DROP` the
real db + `RENAME` tmp onto it. No granted roles → objects fall to `postgres`.

## API / UI

- `restore` dispatches `db.postgres.restore` for pg (resolving the DB's granted
  pg roles via `pgGrantedRoles`) and `db.restore` for MariaDB.
- Restore enabled for pg rows; its confirm warns the **whole database** is
  replaced (pg reset-restore drops + rebuilds, unlike MariaDB's per-table
  overwrite).

## Box-verified on `.86` (PostgreSQL 17.11)

- **Happy path:** seed (table owned by tenant role) → dump → mutate → restore →
  rows restored; `pg_tables.tableowner` = tenant role; `pg_database.datdba` =
  postgres; tenant `has_table_privilege(SELECT)` = true; no `jbsr_%`/`jbrt_%`
  leftovers; dump cleaned.
- **Failure path:** garbage dump → `ok:false`, original db **intact** — proves
  load-then-swap.
- **Adversarial:** `COPY … FROM PROGRAM 'touch …'` → `ok:false` "permission
  denied … pg_execute_server_program", marker file **absent**, db intact.
- **Zero grants:** objects owned by `postgres`, no error.

## Test

Agent input validation + shadow/staging-db name derivation (bounded <
NAMEDATALEN, deterministic, distinct, valid ident); API `pgGrantedRoles`
(postgres-only, first-as-owner, empty when none, nil-safe); UI Restore enabled
for pg + whole-db confirm copy. `go vet` + `tsc -b` clean.

GH #1045