### PR TITLE
fix(security): CLI upload honours the configured max + per-owner staging budget (JAB-337)

### DIFF
--- a/panel-api/cmd/server/files_cmd.go
+++ b/panel-api/cmd/server/files_cmd.go
@@ -27,29 +27,60 @@ import (
 	"github.com/spf13/cobra"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 const filesAgentTimeout = 2 * time.Minute
-const cliUploadStagingDir = "/var/lib/jabali-uploads"
 
-// maxCLIUploadBytes bounds a single CLI upload (GH #661) — mirrors the agent's
-// 100 MiB read/write cap. Checked BEFORE os.ReadFile so a multi-GB file can't
-// OOM the CLI or fill the staging dir.
-const maxCLIUploadBytes = int64(100 << 20)
+// cliUploadStagingDir is the shared dir the agent reads uploads from. A var (not
+// const) only so tests can point the per-owner budget accounting at a temp dir.
+var cliUploadStagingDir = "/var/lib/jabali-uploads"
 
-// maxCLIStagingMultiple bounds the AGGREGATE staging dir at this multiple of a
-// single upload, so abandoned CLI temps can't fill the service partition
-// (mirrors the GUI per-user staging budget, GH #425/#674).
+// maxCLIAgentIngestBytes is the agent's single-shot files.ingest hard cap (GH
+// #660/#661). The CLI ingests in one shot, so it can never exceed this — larger
+// files use SFTP/SSH. It is the ceiling; the effective per-upload limit is the
+// admin-configured max clamped to it (see cliResolveMaxUploadBytes).
+const maxCLIAgentIngestBytes = int64(100 << 20)
+
+// maxCLIStagingMultiple bounds a single owner's in-flight staging at this
+// multiple of the upload limit, so abandoned CLI temps can't fill the service
+// partition (mirrors the GUI per-user staging budget, GH #425/#674).
 const maxCLIStagingMultiple = int64(2)
 
-// cliStagingDirBytes sums the regular files currently in the CLI staging dir.
-func cliStagingDirBytes() int64 {
+// cliResolveMaxUploadBytes returns the effective single-CLI-upload ceiling
+// (JAB-337): the admin-configured server_settings.upload_max_size_mb — so the
+// CLI honours a tighter operator limit instead of always allowing the hardcoded
+// 100 MiB — clamped down to the agent's single-ingest cap. Falls back to the
+// agent cap when the setting is unset or unreadable.
+func cliResolveMaxUploadBytes(ctx context.Context) int64 {
+	var configured int64
+	if s, err := repository.NewServerSettingsRepository(sharedDB).Get(ctx); err == nil && s != nil && s.UploadMaxSizeMB > 0 {
+		configured = int64(s.UploadMaxSizeMB) * 1024 * 1024
+	}
+	if configured == 0 || configured > maxCLIAgentIngestBytes {
+		return maxCLIAgentIngestBytes
+	}
+	return configured
+}
+
+// cliUploadTmpPrefix namespaces staging temps by owner (JAB-337) so one owner's
+// abandoned CLI temps count only against that owner's budget, not a global pool
+// shared across every tenant, and so session paths cannot collide across owners.
+func cliUploadTmpPrefix(userID string) string { return "jabali-upload-cli-" + userID + "-" }
+
+// cliStagingDirBytesForUser sums the regular staging files belonging to one
+// owner (by the owner-namespaced prefix).
+func cliStagingDirBytesForUser(userID string) int64 {
 	var total int64
 	entries, err := os.ReadDir(cliUploadStagingDir)
 	if err != nil {
 		return 0
 	}
+	pfx := cliUploadTmpPrefix(userID)
 	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), pfx) {
+			continue
+		}
 		if fi, iErr := e.Info(); iErr == nil && fi.Mode().IsRegular() {
 			total += fi.Size()
 		}
@@ -497,12 +528,13 @@ func newFilesUploadCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			maxUpload := cliResolveMaxUploadBytes(c.Context())
 			if fi, statErr := os.Stat(args[0]); statErr != nil {
 				return statErr
-			} else if fi.Size() > maxCLIUploadBytes {
-				return fmt.Errorf("file is %d bytes; the CLI upload limit is %d — use SFTP/SSH for larger files", fi.Size(), maxCLIUploadBytes)
-			} else if budget := maxCLIUploadBytes * maxCLIStagingMultiple; cliStagingDirBytes()+fi.Size() > budget {
-				return fmt.Errorf("CLI upload staging budget exceeded (%d in-flight + %d > %d bytes) — clear %s or retry after in-flight uploads finish", cliStagingDirBytes(), fi.Size(), budget, cliUploadStagingDir)
+			} else if fi.Size() > maxUpload {
+				return fmt.Errorf("file is %d bytes; the configured CLI upload limit is %d — use SFTP/SSH for larger files", fi.Size(), maxUpload)
+			} else if budget := maxUpload * maxCLIStagingMultiple; cliStagingDirBytesForUser(u.ID)+fi.Size() > budget {
+				return fmt.Errorf("this owner's CLI upload staging budget is exceeded (%d in-flight for %s + %d > %d bytes) — retry after their in-flight uploads finish", cliStagingDirBytesForUser(u.ID), *u.Username, fi.Size(), budget)
 			}
 			data, rerr := os.ReadFile(args[0])
 			if rerr != nil {
@@ -514,7 +546,7 @@ func newFilesUploadCmd() *cobra.Command {
 			}
 			idb := make([]byte, 16)
 			_, _ = rand.Read(idb)
-			tmpPath := filepath.Join(cliUploadStagingDir, "jabali-upload-cli-"+hex.EncodeToString(idb))
+			tmpPath := filepath.Join(cliUploadStagingDir, cliUploadTmpPrefix(u.ID)+hex.EncodeToString(idb))
 			if werr := os.WriteFile(tmpPath, data, 0o640); werr != nil {
 				return werr
 			}

--- a/panel-api/cmd/server/files_cmd_upload_test.go
+++ b/panel-api/cmd/server/files_cmd_upload_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// JAB-337: the CLI upload staging budget must be per-owner, not a single global
+// pool — otherwise one tenant's abandoned CLI temps consume the allowance for
+// every other tenant. This proves cliStagingDirBytesForUser counts only the
+// querying owner's files.
+func TestCLIStagingDirBytesForUser_IsolatesOwners(t *testing.T) {
+	dir := t.TempDir()
+	old := cliUploadStagingDir
+	cliUploadStagingDir = dir
+	defer func() { cliUploadStagingDir = old }()
+
+	write := func(name string, n int) {
+		if err := os.WriteFile(filepath.Join(dir, name), make([]byte, n), 0o640); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(cliUploadTmpPrefix("userA")+"aaa", 100)
+	write(cliUploadTmpPrefix("userA")+"bbb", 50)
+	write(cliUploadTmpPrefix("userB")+"ccc", 999)
+
+	if got := cliStagingDirBytesForUser("userA"); got != 150 {
+		t.Errorf("userA staging = %d, want 150 (must NOT include userB's 999-byte temp)", got)
+	}
+	if got := cliStagingDirBytesForUser("userB"); got != 999 {
+		t.Errorf("userB staging = %d, want 999", got)
+	}
+}
+
+// Owner-namespaced prefixes must be distinct and non-overlapping so one owner's
+// temps never match another's budget query.
+func TestCLIUploadTmpPrefix_PerOwner(t *testing.T) {
+	a, b := cliUploadTmpPrefix("userA"), cliUploadTmpPrefix("userB")
+	if a == b {
+		t.Fatal("per-owner prefixes must differ")
+	}
+	if !strings.HasPrefix("jabali-upload-cli-userA-xyz", a) {
+		t.Errorf("a userA temp must match userA's prefix, got prefix %q", a)
+	}
+	if strings.HasPrefix("jabali-upload-cli-userA-xyz", b) {
+		t.Error("a userA temp must NOT match userB's prefix — budgets would leak across owners")
+	}
+}
+
+// Source-pin the upload guard wiring: configured max (not hardcoded) + per-owner
+// budget, and the global-budget helper is gone.
+func TestCLIUpload_UsesConfiguredMaxAndPerOwnerBudget(t *testing.T) {
+	src, err := os.ReadFile("files_cmd.go")
+	if err != nil {
+		t.Fatalf("read files_cmd.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "cliResolveMaxUploadBytes(c.Context())") {
+		t.Fatal("upload must enforce the admin-configured max (JAB-337), not a hardcoded 100 MiB cap")
+	}
+	if !strings.Contains(s, "cliStagingDirBytesForUser(u.ID)") {
+		t.Fatal("staging budget must be per-owner (JAB-337)")
+	}
+	if strings.Contains(s, "cliStagingDirBytes()") {
+		t.Fatal("the global (cross-owner) staging budget helper must be gone (JAB-337)")
+	}
+}


### PR DESCRIPTION
## Bug (JAB-337, high · [Security])

`jabali files upload` hardcoded a 100 MiB per-upload cap and a single **global**
staging budget over the shared `/var/lib/jabali-uploads` dir:

- It ignored the admin-configured `server_settings.upload_max_size_mb`, so an
  operator who set a **tighter** limit (e.g. 50 MiB) was bypassed — the CLI still
  accepted up to 100 MiB.
- The staging budget summed **every file across all tenants**, so one owner's
  in-flight/abandoned CLI temps consumed the allowance for every other owner, and
  the temp names weren't owner-namespaced.

## Fix
- `cliResolveMaxUploadBytes` reads `upload_max_size_mb` and clamps it to the
  agent's single-ingest hard cap (100 MiB): a smaller configured limit is now
  honoured; larger files still use SFTP/SSH.
- Staging temps are namespaced `jabali-upload-cli-<user_id>-<rand>`, and the
  budget counts only the target owner's temps (`cliStagingDirBytesForUser`) — no
  cross-owner budget leak or path collision.

Cleanup was already correct (`defer os.Remove` on success + error). The single-shot
CLI has no chunked-offset overwrite concern.

## Tests
Per-owner budget isolation (userA excludes userB's temp), distinct non-overlapping
owner prefixes, and a source-pin that the upload uses the configured max +
per-owner budget (global helper gone). Full `cmd/server` green.

## Acceptance criteria
- [x] Both adapters respect the configured upload maximum (CLI now enforces it as a ceiling).
- [x] Staging budget isolated per owner.
- [x] Session paths cannot collide across owners.
- [ ] Offsets contiguous / non-overwriting — N/A for the single-shot CLI (HTTP-chunked concern).
- [x] Every success/failure/cancellation removes temp data (already: `defer os.Remove`).
- [ ] Shared Upload Intake module + chunked CLI upload above the agent cap → **JAB-365**.

GH JAB-337 · follow-up JAB-365