### PR TITLE
refactor(users): route CLI account deletion through the User Account Lifecycle cascade (JAB-278)

### DIFF
--- a/panel-api/cmd/server/cli_ops.go
+++ b/panel-api/cmd/server/cli_ops.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/userops"
@@ -78,119 +80,59 @@ func deleteUserDirect(ctx context.Context, userID string, purgeHome bool) error 
 		}
 	}
 
-	// Cascade domains first, through the JAB-236 durable path: tombstone
-	// before the row, then the synchronous executor (Stalwart purge +
-	// nginx vhost + pdns zone — the old inline version skipped the zone,
-	// leaking it in the pdns backend). Best-effort per-row so one failure
-	// doesn't strand a half-deleted user; a failed teardown leaves its
-	// tombstone for the reconciler to retry.
-	domains := domainRepoFromDB()
-	if owned, _, err := domains.ListByUserID(ctx, userID, repository.ListOptions{Limit: 500}); err == nil {
-		// sharedAgent is *agent.Client (concrete); assign only when
-		// non-nil — a nil *agent.Client boxed into AgentCaller is a
-		// non-nil interface and would panic inside Call.
-		var caller userops.AgentCaller
-		if sharedAgent != nil {
-			caller = sharedAgent
-		}
-		cascadeDeps := userops.Deps{
-			Domains:         domains,
-			DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
-			PortAllocations: repository.NewPortAllocationRepository(sharedDB),
-			Agent:           caller,
-			Log:             slog.Default(),
-		}
-		for _, d := range owned {
-			pending, err := userops.DeleteDomain(ctx, cascadeDeps, d.ID, d.Name, false)
-			if err != nil {
-				slog.Warn("cli delete: cascade domain failed",
-					"user_id", userID, "domain_id", d.ID, "domain", d.Name, "err", err)
-				continue
+	// JAB-278: route through the one canonical User Account Lifecycle cascade
+	// (userops.DeleteCascade, ADR-0164) that the REST + automation adapters use,
+	// instead of a divergent CLI copy. The copy omitted Docker teardown (which
+	// must BLOCK the delete on failure), FTP subaccount reaping (JAB-265), Redis
+	// cache-ACL revocation, PostgreSQL role handling, and port-allocation
+	// release, and it dropped the panel row even when a MariaDB drop failed —
+	// leaving invisible orphans. The cascade owns the whole ordered teardown
+	// (domains → MariaDB → docker(blocking) → kratos → redis → row → OS+home).
+	var caller userops.AgentCaller
+	if sharedAgent != nil {
+		caller = sharedAgent
+	}
+	var kc *kratosclient.Client
+	if sharedCfg.Auth.Kratos.PublicURL != "" {
+		kc = kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL)
+	}
+	deps := userops.Deps{
+		Users:           users,
+		Packages:        repository.NewPackageRepository(sharedDB),
+		Domains:         domainRepoFromDB(),
+		DockerApps:      repository.NewDockerAppRepository(sharedDB),
+		DomainTeardowns: repository.NewDomainTeardownRepository(sharedDB),
+		PortAllocations: repository.NewPortAllocationRepository(sharedDB),
+		Agent:           caller,
+		KratosClient:    kc,
+		Log:             slog.Default(),
+	}
+	deleteDeps := userops.DeleteDeps{
+		Databases:     databaseRepoFromDB(),
+		DatabaseUsers: databaseUserRepoFromDB(),
+		FtpAccounts:   repository.NewFtpAccountRepository(sharedDB),
+		RevokeCacheACLs: func(ctx context.Context, osUser string) error {
+			if sharedRedis == nil {
+				return nil // redis not wired here; ACLs get reaped on the next cache op
 			}
-			if pending {
-				slog.Warn("cli delete: domain host teardown pending — the reconciler retries it",
-					"user_id", userID, "domain", d.Name)
-			}
-		}
+			return api.RevokeAllUserCacheACLs(ctx, sharedRedis, osUser)
+		},
 	}
-
-	// Drop MariaDB schemas + DB users via the agent BEFORE the panel row
-	// goes (which CASCADEs the metadata). Best-effort: log + continue.
-	dbs := databaseRepoFromDB()
-	if dbs != nil && sharedAgent != nil {
-		if rows, _, err := dbs.ListByUserID(ctx, userID, repository.ListOptions{Limit: 500}); err == nil {
-			for _, d := range rows {
-				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				if _, err := sharedAgent.Call(agentCtx, "db.drop", map[string]any{"db_name": d.Name}); err != nil {
-					slog.Warn("cli delete: db.drop failed",
-						"user_id", userID, "db_name", d.Name, "err", err)
-				}
-				cancel()
-			}
-		}
-	}
-	dbus := databaseUserRepoFromDB()
-	if dbus != nil && sharedAgent != nil {
-		if rows, _, err := dbus.ListByUserID(ctx, userID, repository.ListOptions{Limit: 500}); err == nil {
-			for _, du := range rows {
-				agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				if _, err := sharedAgent.Call(agentCtx, "db_user.drop", map[string]any{"db_user_name": du.Username}); err != nil {
-					slog.Warn("cli delete: db_user.drop failed",
-						"user_id", userID, "db_user_name", du.Username, "err", err)
-				}
-				cancel()
-			}
-		}
-	}
-
-	// Drop the per-user MariaDB shadow-admin account (<osuser>_mysqladmin).
-	// It is provisioned by db.mysqladmin.ensure but is not a database_users
-	// row, so the loop above misses it — an orphaned MySQL login otherwise
-	// survives the deleted account. Mirrors the HTTP delete cascade. Reuses
-	// the idempotent db_user.drop (DROP USER IF EXISTS): a no-op when absent.
-	if sharedAgent != nil && target.Username != nil && *target.Username != "" {
-		shadowUser := *target.Username + "_mysqladmin"
-		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		if _, err := sharedAgent.Call(agentCtx, "db_user.drop", map[string]any{"db_user_name": shadowUser}); err != nil {
-			slog.Warn("cli delete: mysqladmin shadow drop failed",
-				"user_id", userID, "mysqladmin_user", shadowUser, "err", err)
-		}
-		cancel()
-	}
-
-	// Kratos identity delete (if linked).
-	if target.KratosIdentityID != nil && sharedCfg.Auth.Kratos.PublicURL != "" {
-		k := kratosclient.NewClient(sharedCfg.Auth.Kratos.PublicURL, sharedCfg.Auth.Kratos.AdminURL)
-		if err := k.DeleteIdentity(ctx, *target.KratosIdentityID); err != nil {
-			// Non-fatal: log + continue with panel delete so the operator
-			// isn't blocked by a Kratos 500. They can clean orphan
-			// identities via `kratos identities delete <id>`.
-			slog.Warn("cli delete: kratos identity delete failed",
-				"user_id", userID, "identity_id", *target.KratosIdentityID, "err", err)
-		}
-	}
-
-	// Panel row delete.
-	if err := users.Delete(ctx, userID); err != nil {
-		return fmt.Errorf("delete panel row: %w", err)
-	}
-
-	// OS teardown. Sync here — the CLI should surface agent failures
-	// instead of fire-and-forget silence. purgeHome is always treated as
-	// true by the handler's contract; jabali user delete is destructive.
+	// purgeHome is always true for `jabali user delete` (destructive by
+	// contract); DeleteCascade removes the home + OS account unconditionally.
 	_ = purgeHome
-	if sharedAgent != nil && target.Username != nil && *target.Username != "" {
-		agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		if _, err := sharedAgent.Call(agentCtx, "user.delete", map[string]any{
-			"username":    *target.Username,
-			"remove_home": true,
-		}); err != nil {
-			slog.Warn("cli delete: agent user.delete failed — panel row gone, OS user remains",
-				"user_id", userID, "username", *target.Username, "err", err)
-			return fmt.Errorf("panel row deleted but OS teardown failed: %w (manually clean up /home/%s + the OS account)",
-				err, *target.Username)
+	if err := userops.DeleteCascade(ctx, deps, deleteDeps, target, "cli"); err != nil {
+		var dte *userops.DockerTeardownError
+		if errors.As(err, &dte) {
+			return fmt.Errorf("refusing to delete %s: Docker app teardown failed for %s — resolve on the host and retry",
+				userID, strings.Join(dte.Slugs, ", "))
 		}
+		var dbe *userops.DBCleanupError
+		if errors.As(err, &dbe) {
+			return fmt.Errorf("account KEPT: MariaDB object(s) %v could not be dropped — deleting now would orphan them; retry once the agent is healthy",
+				dbe.Objects)
+		}
+		return err
 	}
 	return nil
 }

--- a/panel-api/cmd/server/cli_ops_delete_test.go
+++ b/panel-api/cmd/server/cli_ops_delete_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCLIUserDelete_RoutesThroughCascade pins the JAB-278 fix. The operator CLI
+// account delete used to run its own teardown that omitted Docker teardown
+// (which must BLOCK on failure), FTP subaccount reaping, Redis cache-ACL
+// revocation, and port-allocation release, and dropped the panel row even after
+// a MariaDB drop failed — manufacturing invisible orphans. It now routes through
+// the one canonical userops.DeleteCascade the REST + automation adapters use.
+// cmd/server has no DB/agent fixture, so this source-pins the delegation; the
+// cascade behaviour itself is tested in internal/userops.
+func TestCLIUserDelete_RoutesThroughCascade(t *testing.T) {
+	src, err := os.ReadFile("cli_ops.go")
+	if err != nil {
+		t.Fatalf("read cli_ops.go: %v", err)
+	}
+	s := string(src)
+	if !strings.Contains(s, "userops.DeleteCascade(ctx, deps, deleteDeps, target,") {
+		t.Fatal("CLI user delete must route through the canonical userops.DeleteCascade (JAB-278)")
+	}
+	// The divergent inline teardown must be gone.
+	if strings.Contains(s, `sharedAgent.Call(agentCtx, "user.delete"`) || strings.Contains(s, `"db_user.drop"`) {
+		t.Fatal("CLI must not run its own account-teardown agent calls — DeleteCascade owns them (JAB-278)")
+	}
+	// It must wire the previously-missing teardown deps.
+	for _, want := range []string{"DockerApps:", "FtpAccounts:", "RevokeCacheACLs:"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("CLI delete deps missing %q — the cascade needs it for full teardown (JAB-278)", want)
+		}
+	}
+}

--- a/panel-api/internal/api/applications_cache.go
+++ b/panel-api/internal/api/applications_cache.go
@@ -102,7 +102,7 @@ func revokeInstallACL(ctx context.Context, rdb *redis.Client, osUser, installID 
 	return rdb.Do(ctx, "ACL", "SAVE").Err()
 }
 
-// revokeAllUserCacheACLs removes EVERY cache ACL user of an OS user on the
+// RevokeAllUserCacheACLs removes EVERY cache ACL user of an OS user on the
 // user-delete cascade (JAB-62): the legacy shared wp_<osUser> plus every
 // per-install wp_<osUser>_<installID>. Enumerates via ACL LIST so it needs no
 // install repo. The per-install match is anchored to the fixed 26-char ULID so a
@@ -118,7 +118,7 @@ func ReapLegacySharedCacheACL(ctx context.Context, rdb *redis.Client, osUser str
 	return revokeTenantRedisACL(ctx, rdb, osUser)
 }
 
-func revokeAllUserCacheACLs(ctx context.Context, rdb *redis.Client, osUser string) error {
+func RevokeAllUserCacheACLs(ctx context.Context, rdb *redis.Client, osUser string) error {
 	if rdb == nil || osUser == "" {
 		return nil
 	}

--- a/panel-api/internal/api/automation_billing.go
+++ b/panel-api/internal/api/automation_billing.go
@@ -88,7 +88,7 @@ func billingDeleteDeps(cfg AutomationConfig) userops.DeleteDeps {
 	if cfg.Redis != nil {
 		rdb := cfg.Redis
 		dd.RevokeCacheACLs = func(ctx context.Context, osUser string) error {
-			return revokeAllUserCacheACLs(ctx, rdb, osUser)
+			return RevokeAllUserCacheACLs(ctx, rdb, osUser)
 		}
 	}
 	return dd

--- a/panel-api/internal/api/tenant_redis.go
+++ b/panel-api/internal/api/tenant_redis.go
@@ -237,6 +237,6 @@ var tenantRedisProvision = func(h *redisAccessHandler, ctx context.Context, osUs
 	return h.provisionTenantRedisACL(ctx, osUser, token)
 }
 
-// The t_<osuser> user is torn down on account delete by revokeAllUserCacheACLs
+// The t_<osuser> user is torn down on account delete by RevokeAllUserCacheACLs
 // (applications_cache.go), which the userops delete cascade already invokes as
 // RevokeCacheACLs — so a recycled username can't inherit the old principal.

--- a/panel-api/internal/api/users.go
+++ b/panel-api/internal/api/users.go
@@ -543,7 +543,7 @@ func (h *userHandler) delete(c *gin.Context) {
 		DatabaseUsers: h.cfg.DatabaseUsers,
 		FtpAccounts:   h.cfg.FtpAccounts,
 		RevokeCacheACLs: func(ctx context.Context, osUser string) error {
-			return revokeAllUserCacheACLs(ctx, h.cfg.Redis, osUser)
+			return RevokeAllUserCacheACLs(ctx, h.cfg.Redis, osUser)
 		},
 	}, target, claims.UserID)
 	if err != nil {


### PR DESCRIPTION
## Bug (JAB-278, high · CLI account-delete manufactures orphans)

`jabali user delete` ran its own account teardown that **diverged** from the
canonical `userops.DeleteCascade` (ADR-0164) the REST + automation adapters use.
The CLI copy:
- never tore down the tenant's **Docker apps** (and Docker teardown must **block**
  the delete on failure, not proceed);
- never reaped the tenant's **FTP/SFTP subaccounts** (JAB-265) — leaving live Unix
  credentials + jails + rows orphaned;
- never revoked **Redis cache ACLs**, released reverse-proxy **port allocations**,
  or handled **PostgreSQL** roles;
- dropped every MariaDB object + the panel row **best-effort, continuing after a
  `db.drop` failure** — leaving an invisible orphan schema with no panel row to
  reach it.

## Fix
Replace the divergent cascade with a single `userops.DeleteCascade` call, building
the same `Deps`/`DeleteDeps` the HTTP handler builds. The cascade owns the whole
ordered, fail-closed teardown: domains → MariaDB + Postgres → docker (blocking) →
kratos → redis → row → OS + home. The CLI keeps its confirmation + last-admin
guard and now surfaces the cascade's typed failures (`DockerTeardownError` blocks;
`DBCleanupError` keeps the account so the objects stay reachable).

`RevokeAllUserCacheACLs` is exported from `internal/api` so the CLI can supply the
Redis-ACL revocation callback (userops stays free of the redis dependency).

## Tests
CLI source-pin asserts the delegation + that the old inline agent-teardown calls
are gone; the cascade behaviour is covered by `internal/userops`. Full build +
`cmd/server`/`internal/api`/`internal/userops` green; goldens unaffected.

## Acceptance criteria (all met)
- [x] CLI, REST, and automation deletion call one cascade implementation.
- [x] FTP/database/database-identity/Docker/Kratos/Redis/domain/port/OS/home teardown follow one declared order.
- [x] A credential or workload teardown failure aborts before its management handle is deleted.
- [x] MariaDB and PostgreSQL paths are covered.
- [x] Adapter parity by construction (same `DeleteCascade`); CLI source-pin + userops cascade tests.

GH JAB-278