### PR TITLE
fix(security): remove jabali-webmail from the broad jabali group (JAB-351, JAB-357)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13424,7 +13424,25 @@ install_bulwark() {
     _log "creating jabali-webmail service user"
     useradd --system --no-create-home --shell /usr/sbin/nologin \
       --user-group jabali-webmail
-    usermod -a -G "$SERVICE_USER" jabali-webmail
+  fi
+
+  # JAB-351/357: jabali-webmail must NOT belong to the broad "$SERVICE_USER"
+  # (jabali) group. That group can read the panel DB password + TLS private keys
+  # under /etc/jabali (JAB-351) AND owns the root Agent socket
+  # /run/jabali/agent.sock (JAB-357), so an internet-facing webmail compromise
+  # would reach panel secrets and host root. Webmail's own secrets (session key,
+  # impersonate JWT, bulwark.env) are all jabali-webmail-owned; it needs only
+  # jabali-sockets (primary) + jabali-webmail. Fresh installs no longer add the
+  # membership; this converges upgraded hosts by dropping the legacy one. The
+  # unit's SupplementaryGroups=jabali-webmail is the runtime belt; this removes
+  # the /etc/group state so nothing re-leaks it.
+  if id -nG jabali-webmail 2>/dev/null | tr ' ' '\n' | grep -qx "$SERVICE_USER"; then
+    if gpasswd -d jabali-webmail "$SERVICE_USER" >/dev/null 2>&1; then
+      _ok "removed jabali-webmail from the broad $SERVICE_USER group (JAB-351/357)"
+      systemctl restart jabali-webmail.service >/dev/null 2>&1 || true
+    else
+      _warn "could not remove jabali-webmail from $SERVICE_USER — run: gpasswd -d jabali-webmail $SERVICE_USER"
+    fi
   fi
 
   install -d -m 0755 -o jabali-webmail -g jabali-webmail /opt/jabali-webmail

--- a/install/systemd/jabali-webmail.service
+++ b/install/systemd/jabali-webmail.service
@@ -12,6 +12,15 @@ User=jabali-webmail
 # /run/jabali-bulwark/ is reachable by nginx (also a jabali-sockets
 # member). User= stays jabali-webmail; only Group= flips.
 Group=jabali-sockets
+# JAB-351/357: pin the supplementary group set to EXACTLY what webmail needs
+# (its own jabali-webmail group, which owns every Bulwark secret: session key,
+# impersonate JWT, bulwark.env). Without this, the account's stray membership in
+# the broad `jabali` group leaks in at runtime — and that group can read the
+# panel DB password + TLS private keys (/etc/jabali, JAB-351) AND owns the root
+# Agent socket /run/jabali/agent.sock (JAB-357), turning an internet-facing
+# webmail compromise into host root. Listing SupplementaryGroups here drops
+# `jabali` even if a legacy /etc/group membership survives on an upgraded host.
+SupplementaryGroups=jabali-webmail
 Slice=jabali.slice
 
 WorkingDirectory=/opt/jabali-webmail

--- a/install/tests/test_webmail_group_isolation.sh
+++ b/install/tests/test_webmail_group_isolation.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# install/tests/test_webmail_group_isolation.sh — regression coverage for
+# JAB-351 / JAB-357. The internet-facing jabali-webmail service MUST NOT belong
+# to the broad `jabali` group: that group reads the panel DB password + TLS
+# private keys under /etc/jabali (JAB-351) AND owns the root Agent socket
+# /run/jabali/agent.sock (JAB-357), so a webmail compromise would reach panel
+# secrets and host root. Webmail's own secrets are all jabali-webmail-owned; it
+# needs only jabali-sockets (primary) + jabali-webmail.
+#
+# Live-verified on the .86 box: before the fix webmail read /etc/jabali/
+# db-password and connected to the root agent socket; after it, both fail and
+# webmail still runs.
+#
+# Asserts, source-level (no host mutation):
+#   1. install.sh no longer adds jabali-webmail to the broad $SERVICE_USER group.
+#   2. install_bulwark converges upgraded hosts by dropping the legacy membership
+#      (gpasswd -d jabali-webmail "$SERVICE_USER"), and it runs on `jabali update`
+#      (install_bulwark is called from main()).
+#   3. The jabali-webmail.service unit pins SupplementaryGroups=jabali-webmail so
+#      a stray /etc/group membership can't leak the `jabali` group in at runtime.
+#
+# Run from repo root:
+#     bash install/tests/test_webmail_group_isolation.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+unit=install/systemd/jabali-webmail.service
+
+# --- 1. no broad-group grant on fresh install ---
+if grep -qE 'usermod +-a?G? *-?a? *-?G? *"\$SERVICE_USER" +jabali-webmail' install.sh \
+   || grep -qE 'usermod .*-G *"?\$SERVICE_USER"? +jabali-webmail' install.sh; then
+  echo "FAIL: install.sh still adds jabali-webmail to the broad \$SERVICE_USER group (JAB-351/357)"
+  fail=1
+fi
+
+# --- 2. converge removal on upgrade + wired into the update path ---
+if ! grep -qE 'gpasswd -d jabali-webmail "\$SERVICE_USER"' install.sh; then
+  echo "FAIL: install.sh must drop the legacy jabali-webmail membership on upgrade (gpasswd -d ...)"
+  fail=1
+fi
+bw=$(awk '/^install_bulwark\(\)/,/^}/' install.sh)
+if ! grep -q 'gpasswd -d jabali-webmail' <<<"$bw"; then
+  echo "FAIL: the membership removal must live in install_bulwark (runs on jabali update)"
+  fail=1
+fi
+if ! awk '/^main\(\)/,/^}/' install.sh | grep -q 'install_bulwark' \
+   && ! grep -qE '^\s*install_bulwark\b' install.sh; then
+  echo "FAIL: install_bulwark is not invoked from the main install/update flow"
+  fail=1
+fi
+
+# --- 3. unit scopes supplementary groups ---
+if ! grep -qE '^SupplementaryGroups=jabali-webmail' "$unit"; then
+  echo "FAIL: $unit must set SupplementaryGroups=jabali-webmail to drop the broad jabali group at runtime (JAB-351/357)"
+  fail=1
+fi
+# The unit must NOT put webmail's primary Group back to the broad jabali group.
+if grep -qE '^Group=jabali$' "$unit"; then
+  echo "FAIL: $unit Group= must not be the broad jabali group"
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "OK: webmail group-isolation guards hold"
+else
+  exit 1
+fi


### PR DESCRIPTION
## Two critical vulns, one root cause (both live-confirmed on .86)

The internet-facing `jabali-webmail` service account was a member of the broad
`jabali` group. That single over-grant opened two [Critical] paths:

- **JAB-351:** the `jabali` group reads the panel **DB password**, config, env,
  and **TLS private keys** under `/etc/jabali` (`0640 root:jabali`). A webmail
  compromise → panel secrets + private-key material.
- **JAB-357:** the `jabali` group owns the **root Agent socket**
  `/run/jabali/agent.sock` (`0660 root:jabali`), and the Agent authenticates
  callers only by socket permission. A webmail compromise → privileged Agent
  commands (`files.write admin_root` creates `root:root` files) → **host root**.

Webmail needs none of it: every Bulwark secret (session key, impersonate JWT,
`bulwark.env`) is `jabali-webmail`-owned, and it needs only `jabali-sockets`
(primary) + its own `jabali-webmail` group.

## Fix
- `install.sh` no longer adds webmail to `$SERVICE_USER` on fresh installs;
  `install_bulwark` (runs on `jabali update`) drops the legacy membership on
  upgraded hosts (`gpasswd -d`) + restarts webmail.
- The unit pins `SupplementaryGroups=jabali-webmail`, so the runtime group set is
  exactly `{jabali-sockets, jabali-webmail}` even if a stray `/etc/group`
  membership survives — the belt to the `/etc/group` suspenders.

## Box-verified on .86
| | before | after |
|--|--|--|
| webmail groups | jabali-webmail, **jabali**, jabali-sockets | jabali-webmail, jabali-sockets |
| read `/etc/jabali/db-password` | **READABLE** | denied |
| connect `/run/jabali/agent.sock` | **CONNECTED** | EACCES |
| `jabali-webmail.service` | active | **active** (unbroken) |

## Test
`install/tests/test_webmail_group_isolation.sh` pins the three source guards
(no broad-group grant; converge removal wired into the update path; unit
`SupplementaryGroups` scoping).

## Scope
Fully fixes **JAB-351** and closes **JAB-357's primary vector**. JAB-357's
defense-in-depth — `SO_PEERCRED` authorization on the Agent socket +
capability-bound `admin_root` so a group regression can never re-grant root — and
the **operator secret rotation** (webmail HAD secret-read access on affected
hosts) are tracked as **JAB-366**.

GH JAB-351 · GH JAB-357 · follow-up JAB-366