### PR TITLE
fix(filesafe): confine admin File Manager writes to a kernel-enforced allow-list (JAB-358)

### DIFF
--- a/internal/filesafe/admin_scope_test.go
+++ b/internal/filesafe/admin_scope_test.go
@@ -1,16 +1,22 @@
 package filesafe
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-// GH #1184: the admin File Manager uses a root-scoped Scope with a hard
-// deny-list. These tests pin the security boundary: root reaches the whole
-// tree, but denied prefixes are blocked for every op, with correct word
-// boundaries and no /xyz-matches-/x confusion.
+// GH #1184 + JAB-358: the admin File Manager uses a root-scoped Scope so it can
+// READ (browse) the whole filesystem, minus a hard deny-list, but every
+// MUTATION is confined to a closed write allow-list of safe data roots via
+// WriteScope. These tests pin both halves of that boundary.
+
 func TestNewAdminScope_RootReachesFilesystem(t *testing.T) {
-	s, err := NewAdminScope("uid", "admin", nil)
+	s, err := NewAdminScope("uid", "admin", nil, DefaultAdminMutableRoots)
 	if err != nil {
 		t.Fatalf("NewAdminScope: %v", err)
 	}
+	// Reads range across the whole tree (the FM browses "/").
 	for _, p := range []string{"/", "/etc/nginx/nginx.conf", "/var/log/syslog", "/tmp/x", "/home/u/f"} {
 		if _, err := s.Clean(p); err != nil {
 			t.Errorf("Clean(%q) under root scope should pass, got %v", p, err)
@@ -19,7 +25,7 @@ func TestNewAdminScope_RootReachesFilesystem(t *testing.T) {
 }
 
 func TestNewAdminScope_DenyList(t *testing.T) {
-	s, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	s, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, DefaultAdminMutableRoots)
 	if err != nil {
 		t.Fatalf("NewAdminScope: %v", err)
 	}
@@ -33,6 +39,11 @@ func TestNewAdminScope_DenyList(t *testing.T) {
 		"/usr/local/bin/jabali-agent",
 		"/run/jabali/agent.sock",
 		"/root/.ssh/authorized_keys",
+		// JAB-358 additions: control-plane secret + state stores.
+		"/etc/jabali-panel/bulwark.env",
+		"/var/lib/jabali-panel/anything",
+		"/run/jabali-panel/api.sock",
+		"/run/jabali-bulwark/bulwark.sock",
 	}
 	for _, p := range denied {
 		if _, err := s.Clean(p); err == nil {
@@ -44,7 +55,7 @@ func TestNewAdminScope_DenyList(t *testing.T) {
 }
 
 func TestNewAdminScope_DenyWordBoundary(t *testing.T) {
-	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, DefaultAdminMutableRoots)
 	// Look-alikes that share a textual prefix but are NOT inside a denied dir.
 	for _, p := range []string{"/etc/sshfoo", "/etc/jabali-extra", "/etc/shadowy"} {
 		if _, err := s.Clean(p); err != nil {
@@ -52,6 +63,168 @@ func TestNewAdminScope_DenyWordBoundary(t *testing.T) {
 				t.Errorf("Clean(%q) wrongly denied by word-boundary bug: %v", p, err)
 			}
 		}
+	}
+}
+
+// TestNewAdminScope_RequiresMutableRoots: the constructor refuses to build a
+// footgun scope — an empty write allow-list, or "/" as a mutable root, would
+// re-open whole-filesystem writes.
+func TestNewAdminScope_RequiresMutableRoots(t *testing.T) {
+	if _, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, nil); err == nil {
+		t.Error("NewAdminScope with no mutable roots must error")
+	}
+	if _, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, []string{"/"}); err == nil {
+		t.Error(`NewAdminScope with "/" as a mutable root must error`)
+	}
+	if _, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, []string{"relative"}); err == nil {
+		t.Error("NewAdminScope with a relative mutable root must error")
+	}
+}
+
+// TestAdminScope_WriteScope_ReadOnlyOutsideAllowList is the core JAB-358
+// boundary at the string layer: the same non-deny-listed system path the admin
+// FM can READ cannot be WRITTEN (WriteScope rejects it as read-only), while a
+// path inside a safe data root is writable.
+func TestAdminScope_WriteScope_ReadOnlyOutsideAllowList(t *testing.T) {
+	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, DefaultAdminMutableRoots)
+	w := s.WriteScope()
+
+	readOnly := []string{
+		"/etc/cron.d/evil",
+		"/etc/systemd/system/pwn.service",
+		"/etc/passwd",
+		"/etc/pam.d/sshd",
+		"/etc/ld.so.conf.d/evil.conf",
+		"/usr/local/bin/anything",
+		"/bin/anything",
+		"/boot/grub/grub.cfg",
+		"/lib/systemd/system/x.service",
+		"/root/.bashrc",
+		"/opt/app/bin/x",
+		"/var/spool/cron/crontabs/root",
+		// word-boundary lookalikes of the mutable roots
+		"/homework",
+		"/var/wwwfoo",
+	}
+	for _, p := range readOnly {
+		// The admin can still READ these via the broad scope.
+		if _, rerr := s.Clean(p); rerr != nil {
+			t.Logf("note: Clean(%q) on read scope = %v", p, rerr)
+		}
+		// But the WRITE scope refuses them as read-only.
+		if _, werr := w.Clean(p); werr == nil {
+			t.Errorf("WriteScope.Clean(%q) must be read-only, but passed", p)
+		} else if ve, ok := werr.(*ValidationError); !ok || ve.Code != ErrCodeReadOnly {
+			t.Errorf("WriteScope.Clean(%q): want ErrCodeReadOnly, got %v", p, werr)
+		}
+	}
+
+	writable := []string{
+		"/home",
+		"/home/alice/public_html/index.php",
+		"/var/www/site/wp-config.php",
+		"/srv/app/data.json",
+		"/tmp/scratch",
+		"/var/tmp/scratch",
+	}
+	for _, p := range writable {
+		if _, err := w.Clean(p); err != nil {
+			t.Errorf("WriteScope.Clean(%q) inside allow-list should pass, got %v", p, err)
+		}
+	}
+}
+
+// TestAdminScope_WriteScope_baseForReadOnly pins the same rejection at the
+// openat2 entry point (baseFor), the layer every escape-proof mutation uses.
+func TestAdminScope_WriteScope_baseForReadOnly(t *testing.T) {
+	w := mustAdmin(t).WriteScope()
+	if _, _, err := w.baseFor("/etc/cron.d/x"); err == nil {
+		t.Error("baseFor(/etc/cron.d/x) on write scope must be read-only")
+	} else if ve, ok := err.(*ValidationError); !ok || ve.Code != ErrCodeReadOnly {
+		t.Errorf("baseFor write scope: want ErrCodeReadOnly, got %v", err)
+	}
+	// Inside a safe root, baseFor picks the safe root as the openat2 base.
+	base, rel, err := w.baseFor("/home/alice/x")
+	if err != nil || base != "/home" || rel != "alice/x" {
+		t.Errorf(`baseFor("/home/alice/x") = %q,%q,%v; want "/home","alice/x",nil`, base, rel, err)
+	}
+}
+
+// TestAdminScope_WriteScope_SymlinkEscapeBlocked is the security proof that a
+// logical prefix check ALONE cannot give: a relative symlink planted INSIDE a
+// safe root whose target climbs out of it (../secret) resolves — logically — to
+// a path still under the safe root, so w.Clean() PASSES it. The actual write,
+// performed via the escape-proof openat2 op with the safe root as base, is
+// refused by the kernel (RESOLVE_BENEATH), and nothing is created outside the
+// safe root. This is exactly the TOCTOU-proof confinement WriteScope buys.
+func TestAdminScope_WriteScope_SymlinkEscapeBlocked(t *testing.T) {
+	parent := t.TempDir()
+	safe := filepath.Join(parent, "safe")
+	secret := filepath.Join(parent, "secret")
+	for _, d := range []string{safe, secret} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	// A RELATIVE symlink inside safe that climbs out into the sibling secret dir.
+	if err := os.Symlink("../secret", filepath.Join(safe, "break")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// An ABSOLUTE symlink inside safe pointing at secret.
+	if err := os.Symlink(secret, filepath.Join(safe, "abs")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Admin scope whose write allow-list is exactly `safe`.
+	s, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, []string{safe})
+	if err != nil {
+		t.Fatalf("NewAdminScope: %v", err)
+	}
+	w := s.WriteScope()
+
+	for _, name := range []string{"break", "abs"} {
+		logical := filepath.Join(safe, name, "pwned")
+		// The LOGICAL check passes — the cleaned path is textually under `safe`.
+		if _, cerr := w.Clean(logical); cerr != nil {
+			t.Fatalf("precondition: w.Clean(%q) should pass logically, got %v", logical, cerr)
+		}
+		// The real escape-proof write is refused by the kernel.
+		if f, oerr := w.CreateExclInScope(logical, 0o644); oerr == nil {
+			f.Close()
+			t.Errorf("CreateExclInScope(%q) escaped the safe root via symlink %q", logical, name)
+		}
+		// Nothing was created in the sibling secret dir.
+		if _, serr := os.Lstat(filepath.Join(secret, "pwned")); serr == nil {
+			t.Errorf("write escaped: %s/pwned exists", secret)
+		}
+	}
+
+	// A legitimate write straight into the safe root still works.
+	f, err := w.CreateExclInScope(filepath.Join(safe, "ok.txt"), 0o644)
+	if err != nil {
+		t.Fatalf("CreateExclInScope inside safe root should succeed: %v", err)
+	}
+	f.Close()
+}
+
+// TestTenantScope_WriteScope_NoOp: a tenant scope has no MutableRoots, so
+// WriteScope returns it unchanged — tenant file ops are byte-for-byte identical
+// to before JAB-358. This is the backward-compat pin.
+func TestTenantScope_WriteScope_NoOp(t *testing.T) {
+	s, _ := NewScope("uid", "bob", []string{"/home/bob"})
+	w := s.WriteScope()
+	if w != s {
+		t.Fatal("tenant WriteScope must return the same scope (no narrowing)")
+	}
+	if _, err := w.Clean("/home/bob/public_html/index.php"); err != nil {
+		t.Errorf("in-home write should pass: %v", err)
+	}
+	if _, err := w.Clean("/etc/passwd"); err == nil {
+		t.Error("out-of-home write should fail")
+	} else if ve, ok := err.(*ValidationError); !ok || ve.Code != ErrCodeNotInScope {
+		// A tenant scope is not writeNarrowed, so it rejects via not_in_scope,
+		// never the admin-only read_only.
+		t.Errorf("tenant out-of-home write: want ErrCodeNotInScope, got %v", err)
 	}
 }
 
@@ -73,10 +246,10 @@ func TestTenantScope_DenyListEmpty_NoOp(t *testing.T) {
 }
 
 // TestAdminScope_baseFor_RootTraversal pins the openat2 traversal helper for the
-// root scope — the box-verify caught baseFor rejecting /etc/* with a "//" prefix
-// bug even though verifyInScope passed (GH #1184).
+// READ (root) scope — the box-verify caught baseFor rejecting /etc/* with a "//"
+// prefix bug even though verifyInScope passed (GH #1184).
 func TestAdminScope_baseFor_RootTraversal(t *testing.T) {
-	s, _ := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes)
+	s := mustAdmin(t)
 	cases := map[string]string{
 		"/etc/nginx/nginx.conf": "etc/nginx/nginx.conf",
 		"/tmp/x":                "tmp/x",
@@ -96,4 +269,13 @@ func TestAdminScope_baseFor_RootTraversal(t *testing.T) {
 	if base, rel, err := s.baseFor("/"); err != nil || base != "/" || rel != "." {
 		t.Errorf(`baseFor("/") = %q,%q,%v; want "/",".",nil`, base, rel, err)
 	}
+}
+
+func mustAdmin(t *testing.T) *Scope {
+	t.Helper()
+	s, err := NewAdminScope("uid", "admin", DefaultAdminDeniedPrefixes, DefaultAdminMutableRoots)
+	if err != nil {
+		t.Fatalf("NewAdminScope: %v", err)
+	}
+	return s
 }

--- a/internal/filesafe/filesafe.go
+++ b/internal/filesafe/filesafe.go
@@ -33,6 +33,7 @@ const (
 	ErrCodeSymlinkLoop     = "symlink_loop"     // circular symlink chain
 	ErrCodeBadCharacters   = "bad_characters"   // invalid filename characters
 	ErrCodeDenied          = "path_denied"      // path within an explicit deny prefix (GH #1184 admin FM)
+	ErrCodeReadOnly        = "read_only"        // mutating op on a path outside the write allow-list (JAB-358)
 )
 
 // DefaultAdminDeniedPrefixes is the hard deny-list for the GH #1184 admin File
@@ -61,6 +62,31 @@ var DefaultAdminDeniedPrefixes = []string{
 	"/run/jabali",   // agent + panel unix sockets
 	"/run/jabali-kratos",
 	"/var/lib/jabali-uploads", // agent↔panel handoff staging
+	// JAB-358: control-plane secret + state stores outside /etc/jabali that the
+	// original deny-list missed. Blocked for read too — these hold the panel DB
+	// password, session/JWT keys, mail creds, and restic repo state.
+	"/etc/jabali-panel",  // bulwark session/JWT keys, restic repo password, panel env
+	"/var/lib/jabali-panel",
+	"/run/jabali-panel", // panel api + sso sockets
+	"/run/jabali-bulwark",
+}
+
+// DefaultAdminMutableRoots is the closed WRITE allow-list for the admin File
+// Manager (JAB-358). The admin scope may READ anywhere on the filesystem (minus
+// DeniedPrefixes), but every MUTATING operation — write, mkdir, delete, rename,
+// move, copy, chmod, extract, archive-create — is confined to these tenant /
+// application data roots. This replaces the old "write everywhere except a
+// deny-list" model: a deny-list can never enumerate every path through which
+// root later executes, loads, or trusts a file (/etc/cron.d, systemd units,
+// /etc/passwd, PAM, the dynamic loader, package hooks, …), so writes are a
+// closed allow-list instead. System/config paths stay read-only; admins use
+// root SSH for anything outside these roots.
+var DefaultAdminMutableRoots = []string{
+	"/home",    // tenant home trees — the admin FM's primary use
+	"/var/www", // web content roots
+	"/srv",     // some deployments serve tenant content here
+	"/tmp",
+	"/var/tmp",
 }
 
 // ValidationError is the error type returned by validators.
@@ -87,6 +113,20 @@ type Scope struct {
 	// symlink-resolved path, so a symlink from an allowed dir into a denied
 	// one is caught.
 	DeniedPrefixes []string
+	// MutableRoots is the closed WRITE allow-list (JAB-358). When non-empty, it
+	// is the set of docroots that WriteScope narrows to for every mutating
+	// operation, even though reads may range across all of OwnedDocroots (the
+	// admin FM reads "/" but writes only these safe data roots). Empty is a pure
+	// no-op: an ordinary tenant scope leaves it nil and its writes stay bounded
+	// by OwnedDocroots alone, so this is backward-compatible with every existing
+	// NewScope caller. Only NewAdminScope populates it, replacing the old "write
+	// anywhere on / except a deny-list" model — a deny-list can never name every
+	// path root later trusts, so admin writes are allow-listed.
+	MutableRoots []string
+	// writeNarrowed marks a scope produced by WriteScope: its OwnedDocroots are
+	// the write allow-list, so a docroot miss means "read-only under the admin
+	// File Manager" (ErrCodeReadOnly) rather than a plain not-in-scope.
+	writeNarrowed bool
 	// resolveCache caches EvalSymlinks results to detect symlink loops
 	resolveCache map[string]string
 }
@@ -130,14 +170,23 @@ func NewScope(userID, username string, ownedDocroots []string) (*Scope, error) {
 }
 
 // NewAdminScope creates a root-scoped Scope for the GH #1184 admin File
-// Manager: OwnedDocroots is "/" (the whole filesystem) but every path in
-// deniedPrefixes is blocked for all operations. Pass
-// DefaultAdminDeniedPrefixes unless a caller has a reason to differ. This is
-// a privileged constructor — the panel gates it behind admin auth AND a
-// default-off server setting; the deny-list here is the last line of defence.
-func NewAdminScope(userID, username string, deniedPrefixes []string) (*Scope, error) {
+// Manager: OwnedDocroots is "/" so READS may range across the whole
+// filesystem, but every path in deniedPrefixes is blocked for all operations
+// AND every MUTATING operation is additionally confined to mutableRoots
+// (JAB-358). Pass DefaultAdminDeniedPrefixes and DefaultAdminMutableRoots
+// unless a caller has a reason to differ. This is a privileged constructor —
+// the panel gates it behind admin auth AND a default-off server setting; the
+// deny-list plus the write allow-list here are the last line of defence.
+//
+// A non-empty mutableRoots is required: passing an empty list would leave the
+// admin scope able to write anywhere on "/" (the very footgun JAB-358 closes),
+// so it is rejected rather than silently degrading to the old behaviour.
+func NewAdminScope(userID, username string, deniedPrefixes, mutableRoots []string) (*Scope, error) {
 	if username == "" {
 		return nil, &ValidationError{Code: ErrCodeEmpty, Detail: "username cannot be empty"}
+	}
+	if len(mutableRoots) == 0 {
+		return nil, &ValidationError{Code: ErrCodeEmpty, Detail: "admin scope requires a non-empty write allow-list (mutableRoots)"}
 	}
 	denied := make([]string, 0, len(deniedPrefixes))
 	for _, p := range deniedPrefixes {
@@ -147,11 +196,25 @@ func NewAdminScope(userID, username string, deniedPrefixes []string) (*Scope, er
 		}
 		denied = append(denied, p)
 	}
+	mutable := make([]string, 0, len(mutableRoots))
+	for _, p := range mutableRoots {
+		p = filepath.Clean(p)
+		if !filepath.IsAbs(p) {
+			return nil, &ValidationError{Code: ErrCodeNotAbsolute, Detail: fmt.Sprintf("mutable root %q must be absolute", p)}
+		}
+		if p == "/" {
+			// "/" as a mutable root would re-open whole-filesystem writes and
+			// defeat the allow-list entirely; reject it explicitly.
+			return nil, &ValidationError{Code: ErrCodeNotInScope, Detail: `"/" is not a valid mutable root`}
+		}
+		mutable = append(mutable, p)
+	}
 	return &Scope{
 		UserID:         userID,
 		Username:       username,
 		OwnedDocroots:  []string{"/"},
 		DeniedPrefixes: denied,
+		MutableRoots:   mutable,
 		resolveCache:   make(map[string]string),
 	}, nil
 }
@@ -247,6 +310,35 @@ func (s *Scope) Resolve(pathStr string) (string, error) {
 	}
 
 	return resolved, nil
+}
+
+// WriteScope returns the scope that every MUTATING file operation must run
+// against (JAB-358). When the scope carries a write allow-list (the admin File
+// Manager), it narrows OwnedDocroots down to MutableRoots and marks the copy
+// writeNarrowed. Because every escape-proof op resolves relative to a base fd
+// derived from OwnedDocroots (baseFor → openat2 RESOLVE_BENEATH), narrowing the
+// docroots is what actually CONFINES the write in the kernel: a path outside a
+// safe data root is refused, and — critically — a relative symlink planted
+// inside a safe root whose target climbs out via ".." (e.g. ~/x -> ../../etc/
+// cron.d) is rejected with EXDEV mid-walk, which a logical prefix check alone
+// can never guarantee against a concurrent swap. Reads keep using the original
+// scope (OwnedDocroots="/"), so the admin FM still browses the whole tree.
+//
+// For an ordinary tenant scope (no MutableRoots) it returns the scope
+// unchanged, so tenant file ops are byte-for-byte identical to before.
+func (s *Scope) WriteScope() *Scope {
+	if len(s.MutableRoots) == 0 {
+		return s
+	}
+	return &Scope{
+		UserID:         s.UserID,
+		Username:       s.Username,
+		OwnedDocroots:  s.MutableRoots,
+		DeniedPrefixes: s.DeniedPrefixes,
+		MutableRoots:   s.MutableRoots,
+		writeNarrowed:  true,
+		resolveCache:   make(map[string]string),
+	}
 }
 
 // Open opens a file at the given path with the given flags and perms.
@@ -373,6 +465,14 @@ func (s *Scope) verifyInScope(pathStr string) error {
 		}
 	}
 	if !inScope {
+		if s.writeNarrowed {
+			// A WriteScope miss: the path is readable (the admin FM browses "/")
+			// but not writable — say so plainly instead of a bare not-in-scope.
+			return &ValidationError{
+				Code:   ErrCodeReadOnly,
+				Detail: fmt.Sprintf("path %q is read-only in the admin File Manager; writable roots: %v", pathStr, s.OwnedDocroots),
+			}
+		}
 		return &ValidationError{
 			Code:   ErrCodeNotInScope,
 			Detail: fmt.Sprintf("path %q is not within owned docroots: %v", pathStr, s.OwnedDocroots),

--- a/internal/filesafe/openat2.go
+++ b/internal/filesafe/openat2.go
@@ -78,6 +78,10 @@ func (s *Scope) baseFor(pathStr string) (base, rel string, err error) {
 			return dr, cleaned[len(dr)+1:], nil
 		}
 	}
+	if s.writeNarrowed {
+		// WriteScope miss: readable but not writable under the admin File Manager.
+		return "", "", &ValidationError{Code: ErrCodeReadOnly, Detail: fmt.Sprintf("path %q is read-only in the admin File Manager; writable roots: %v", pathStr, s.OwnedDocroots)}
+	}
 	return "", "", &ValidationError{Code: ErrCodeNotInScope, Detail: fmt.Sprintf("path %q is not within owned docroots: %v", pathStr, s.OwnedDocroots)}
 }
 

--- a/panel-agent/internal/commands/files_chmod.go
+++ b/panel-agent/internal/commands/files_chmod.go
@@ -66,6 +66,8 @@ func filesChmodHandler(ctx context.Context, params json.RawMessage) (any, error)
 			Message: fmt.Sprintf("failed to create scope: %v", err),
 		}
 	}
+	// JAB-358: confine chmod to the admin write allow-list (no-op for tenants).
+	scope = scope.WriteScope()
 	cleanPath, err := scope.Clean(p.Path)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_copy.go
+++ b/panel-agent/internal/commands/files_copy.go
@@ -57,6 +57,11 @@ func filesCopyHandler(ctx context.Context, params json.RawMessage) (any, error) 
 			Message: fmt.Sprintf("failed to create scope: %v", err),
 		}
 	}
+	// JAB-358: copy reads the source and writes the destination through a SINGLE
+	// escape-proof scope (CopyTreeInScope), so confine BOTH ends to the admin
+	// write allow-list. An admin copies within the tenant/app data roots; system
+	// files stay view-only (no-op for tenant scopes).
+	scope = scope.WriteScope()
 	srcClean, err := scope.Clean(p.SrcPath)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_delete.go
+++ b/panel-agent/internal/commands/files_delete.go
@@ -59,6 +59,8 @@ func filesDeleteHandler(ctx context.Context, params json.RawMessage) (any, error
 	// String-gate the path; the unlink act is escape-proof (unlinkat / fd-descent
 	// against openat2 parent fds), so os.RemoveAll's string re-resolution can't
 	// be redirected through a swapped parent symlink (Gitea #428).
+	// JAB-358: confine deletes to the admin write allow-list (no-op for tenants).
+	scope = scope.WriteScope()
 	cleanPath, err := scope.Clean(p.Path)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_extract.go
+++ b/panel-agent/internal/commands/files_extract.go
@@ -74,18 +74,25 @@ func filesExtractHandler(ctx context.Context, params json.RawMessage) (any, erro
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("path validation failed: %v", err)}
 	}
 
+	// JAB-358: the archive may be READ from anywhere the admin FM can browse
+	// (cleanArchive above, on the broad scope), but extraction WRITES land in a
+	// separate write scope narrowed to the safe data roots — the admin FM can
+	// unpack into /home, /var/www, … but never into /etc, /usr, systemd, etc.
+	// No-op for tenant scopes.
+	wscope := scope.WriteScope()
+
 	// Destination directory: explicit dest, else the archive's parent.
 	destRel := p.Dest
 	if strings.TrimSpace(destRel) == "" {
 		destRel = filepath.Dir(p.Path)
 	}
-	destDir, err := scope.Clean(destRel)
+	destDir, err := wscope.Clean(destRel)
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: fmt.Sprintf("destination validation failed: %v", err)}
 	}
 	// Verify the destination is an existing directory via the escape-proof stat,
 	// not an os.Stat(string) that re-resolves a swapped parent.
-	if di, derr := scope.StatInScope(destDir); derr != nil || !di.IsDir {
+	if di, derr := wscope.StatInScope(destDir); derr != nil || !di.IsDir {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInvalidArgument, Message: "destination is not a directory"}
 	}
 
@@ -95,7 +102,7 @@ func filesExtractHandler(ctx context.Context, params json.RawMessage) (any, erro
 	// relative to an escape-proof destDir fd (openat/mkdirat O_NOFOLLOW per
 	// component), so a tenant-planted parent-directory symlink inside their own
 	// destDir (e.g. sub -> /etc/cron.d) cannot redirect a root-side write.
-	ed, err := scope.NewExtractDir(destDir, uid, gid)
+	ed, err := wscope.NewExtractDir(destDir, uid, gid)
 	if err != nil {
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("failed to open destination: %v", err)}
 	}

--- a/panel-agent/internal/commands/files_ingest.go
+++ b/panel-agent/internal/commands/files_ingest.go
@@ -74,6 +74,8 @@ func filesIngestHandler(ctx context.Context, params json.RawMessage) (any, error
 			Message: fmt.Sprintf("scope: %v", err),
 		}
 	}
+	// JAB-358: confine the ingest destination to the admin write allow-list.
+	scope = scope.WriteScope()
 	dst, err := scope.Clean(p.DestPath)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_mkdir.go
+++ b/panel-agent/internal/commands/files_mkdir.go
@@ -60,6 +60,8 @@ func filesMkdirHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// String-gate the path; the directory is created escape-proof (mkdirat /
 	// openat(O_NOFOLLOW) descent against the base fd), so a parent-symlink swap
 	// can't redirect a root-side mkdir (Gitea #424 / #428).
+	// JAB-358: confine writes to the admin write allow-list (no-op for tenants).
+	scope = scope.WriteScope()
 	cleanPath, err := scope.Clean(p.Path)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_move.go
+++ b/panel-agent/internal/commands/files_move.go
@@ -62,6 +62,9 @@ func filesMoveHandler(ctx context.Context, params json.RawMessage) (any, error) 
 	// String-gate both paths; the rename act below is escape-proof (renameat
 	// between openat2 parent fds), so a parent-symlink swap can't redirect a
 	// root-side move (Gitea #422 / TOCTOU #428).
+	// JAB-358: move mutates BOTH ends — confine them to the admin write
+	// allow-list (no-op for tenants).
+	scope = scope.WriteScope()
 	oldClean, err := scope.Clean(p.OldPath)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_rename.go
+++ b/panel-agent/internal/commands/files_rename.go
@@ -65,6 +65,9 @@ func filesRenameHandler(ctx context.Context, params json.RawMessage) (any, error
 
 	// String-gate both paths; the rename act is escape-proof (renameat between
 	// openat2 parent fds), closing the TOCTOU parent-swap (Gitea #428).
+	// JAB-358: rename mutates BOTH ends — confine them to the admin write
+	// allow-list (no-op for tenants).
+	scope = scope.WriteScope()
 	oldClean, err := scope.Clean(p.OldPath)
 	if err != nil {
 		return nil, &agentwire.AgentError{

--- a/panel-agent/internal/commands/files_scope.go
+++ b/panel-agent/internal/commands/files_scope.go
@@ -7,15 +7,19 @@ import (
 // fileScopeFor builds the filesafe scope for a file command (GH #1184).
 //
 // Ordinary tenant ops confine to the caller's home directory, exactly as
-// before. When adminRoot is set the scope is the whole filesystem minus the
-// hard deny-list (filesafe.DefaultAdminDeniedPrefixes) — the admin File
-// Manager. adminRoot is honoured only because the agent's unix socket is
-// panel-only: the panel sets it after its own admin-auth AND default-off
-// server-setting gate, and the deny-list is enforced here regardless as the
-// last line of defence.
+// before. When adminRoot is set the scope may READ the whole filesystem minus
+// the hard deny-list (filesafe.DefaultAdminDeniedPrefixes), but every WRITE is
+// additionally confined to the JAB-358 allow-list of safe data roots
+// (filesafe.DefaultAdminMutableRoots) — so the admin File Manager can never
+// create a root-owned file under a path root later executes or trusts
+// (/etc/cron.d, systemd units, /etc/passwd, the loader, package hooks …).
+// adminRoot is honoured only because the agent's unix socket is panel-only:
+// the panel sets it after its own admin-auth AND default-off server-setting
+// gate, and both lists are enforced here regardless as the last line of
+// defence.
 func fileScopeFor(userID, username string, adminRoot bool) (*filesafe.Scope, error) {
 	if adminRoot {
-		return filesafe.NewAdminScope(userID, username, filesafe.DefaultAdminDeniedPrefixes)
+		return filesafe.NewAdminScope(userID, username, filesafe.DefaultAdminDeniedPrefixes, filesafe.DefaultAdminMutableRoots)
 	}
 	return filesafe.NewScope(userID, username, []string{"/home/" + username})
 }

--- a/panel-agent/internal/commands/files_write.go
+++ b/panel-agent/internal/commands/files_write.go
@@ -104,6 +104,11 @@ func filesWriteHandler(ctx context.Context, params json.RawMessage) (any, error)
 			Message: fmt.Sprintf("failed to create scope: %v", err),
 		}
 	}
+	// JAB-358: write is a pure-mutation command — run every op against the write
+	// scope so the admin FM's whole-FS root scope is narrowed to the safe data
+	// roots. The openat2 base then IS a safe root, so RESOLVE_BENEATH refuses a
+	// symlink whose target climbs out of it. No-op for tenant scopes.
+	scope = scope.WriteScope()
 
 	// Validate path is in scope (string gate). The actual file ops below are
 	// performed against an escape-proof openat2 fd (RESOLVE_BENEATH), so a

--- a/panel-agent/internal/commands/files_write_test.go
+++ b/panel-agent/internal/commands/files_write_test.go
@@ -104,6 +104,25 @@ func TestFilesWriteHandler(t *testing.T) {
 			wantError: true,
 			wantCode:  agentwire.CodeInvalidArgument,
 		},
+		{
+			// JAB-358: an admin-root write to a system/config path (outside the
+			// safe data roots) must be refused before any filesystem op — the
+			// command routes through scope.WriteScope(). Rejection is at the
+			// string gate, so this runs unprivileged in CI. This is the
+			// command-level pin that the WriteScope wiring is present; the
+			// kernel-level symlink-escape confinement is proven in
+			// internal/filesafe/admin_scope_test.go.
+			name: "admin: system-path write rejected (JAB-358)",
+			input: filesWriteParams{
+				UserID:    "admin",
+				Username:  "admin",
+				AdminRoot: true,
+				Path:      "/etc/cron.d/jab358-pwn",
+				Content:   "* * * * * root id\n",
+			},
+			wantError: true,
+			wantCode:  agentwire.CodeInvalidArgument,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## JAB-358 — confine admin File Manager writes to a kernel-enforced allow-list

### Problem
The GH #1184 admin File Manager builds its agent-side `filesafe.Scope` with
`OwnedDocroots=["/"]` (whole-filesystem, minus a deny-list) and, with
`admin_root=true`, `files_write` creates `root:root` files. A deny-list can
never name every path root later executes, loads, or trusts —
`/etc/cron.d`, systemd units, `/etc/passwd`, PAM, the dynamic loader, package
hooks, `/boot`, root-exec dirs — so an admin FM write (or a compromised/tricked
panel driving the agent) was a deterministic path to host root.

### Fix — write scope, not a logical check
Reads stay broad (the UI browses `rootPath="/"`), but every **mutation** runs
against a narrowed **write scope**:

- `Scope.WriteScope()` returns a copy whose `OwnedDocroots` **are** the safe
  data roots (`DefaultAdminMutableRoots` = `/home`, `/var/www`, `/srv`, `/tmp`,
  `/var/tmp`). Every escape-proof op resolves relative to a base fd derived from
  `OwnedDocroots` (`baseFor` → `openat2 RESOLVE_BENEATH`), so narrowing the
  docroots is what **confines the write in the kernel**.
- This is deliberately *not* a logical prefix check. A relative symlink planted
  inside a safe root whose target climbs out via `..` (`~/x -> ../../etc/cron.d`)
  is textually "under `/home`", so a prefix check passes it — but
  `RESOLVE_BENEATH` against the safe-root base rejects it with `EXDEV` mid-walk,
  TOCTOU and all. A unit test proves the logical `Clean()` passes while the real
  `openat2` write is refused and nothing is created outside the safe root.
- All ten mutating commands route through `WriteScope`: write, mkdir, delete,
  chmod, move (both ends), rename (both ends), ingest, copy (both ends —
  `CopyTreeInScope` is one atomic scope), and extract's **destination** (its
  archive is still read from the broad scope). Read commands
  (list/read/stat/du/archive-create) are untouched.
- `NewAdminScope` now **requires** a non-empty allow-list and rejects `"/"` as a
  mutable root, so the footgun scope can't be reconstructed. A write-scope miss
  returns `ErrCodeReadOnly` ("read-only in the admin File Manager; writable
  roots: …") in both `verifyInScope` and `baseFor`, so the admin sees why a file
  they can view can't be saved.
- Deny-list gains the control-plane secret/state stores the original missed and
  which gate reads too: `/etc/jabali-panel`, `/var/lib/jabali-panel`,
  `/run/jabali-panel`, `/run/jabali-bulwark`.

### Backward compatibility
Tenant scopes have no `MutableRoots`, so `WriteScope()` returns the scope
**unchanged** — tenant file ops are byte-for-byte identical to before. No wire
contract changed (`admin_root` is unchanged); enforcement is entirely agent-side
at the trust boundary. `filesafe` has no non-agent importers, so there is no CLI
or panel copy to keep in sync.

### Tests
`internal/filesafe/admin_scope_test.go` pins:
- broad admin **reads** across `/` still pass;
- the read/write **asymmetry** (same system path readable, write is
  `ErrCodeReadOnly`) at both the `Clean` and `baseFor` layers;
- the constructor guards (empty allow-list, `"/"`, relative root rejected);
- the expanded deny-list incl. the new control-plane paths;
- tenant `WriteScope` no-op backward-compat;
- **the security proof:** a relative-`..` symlink escape that passes logical
  `Clean()` is refused by the real escape-proof `openat2` write and creates
  nothing outside the safe root.

Both modules build/vet clean; `internal/filesafe` and
`panel-agent/internal/commands` suites are green.

### Follow-ups (not in this PR)
- MFA/step-up on enabling or using the admin FM (JAB-358 criterion 5) — filed
  separately.
- Admin-created files are still `root:root`; confined to data roots they are not
  root-exec surfaces, but tenant-ownership of admin-created files under `/home`
  is a usability refinement worth a follow-up.
