### PR TITLE
fix(dns): pin global AXFR ACL to loopback so managed zones aren't internet-transferable (JAB-350)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4364,10 +4364,22 @@ local-address=${pdns_local_addresses}
 # right ownership. Overriding socket-dir here collides with pdns's own
 # attempt to create the directory (it fails under LXC drop-ins).
 
-# Per-zone AXFR allow-lists and NOTIFY targets are managed via the
-# panel's domainmetadata table (ALLOW-AXFR-FROM and ALSO-NOTIFY kinds).
-# The global allow-axfr-ips is left empty — PowerDNS denies AXFR by
-# default, and per-zone metadata takes precedence.
+# AXFR authorization (JAB-350). Per-zone allow-lists + NOTIFY targets are
+# managed via the panel's domainmetadata table (ALLOW-AXFR-FROM and
+# ALSO-NOTIFY kinds), which authorize any configured secondary nameserver.
+#
+# The GLOBAL ACL is pinned EXPLICITLY to loopback here — it is NOT left to
+# PowerDNS's built-in default. Relying on the default is unsafe: a permissive
+# global value from an operator edit, a differing package/build default, or a
+# stale hand-written /etc/powerdns/pdns.conf would otherwise let ANY internet
+# client transfer every managed zone (bulk enumeration of hostnames, MX/service
+# topology, and TXT metadata — verified reproducible). This drop-in is read
+# after the main pdns.conf, so this line overrides such a permissive value and
+# repairs the host on the next `jabali update` (config change → pdns restart).
+# Configured secondaries still transfer via their per-zone ALLOW-AXFR-FROM
+# metadata, which is unioned with this global; loopback stays allowed for local
+# operator troubleshooting (dig AXFR @127.0.0.1).
+allow-axfr-ips=127.0.0.0/8,::1
 disable-axfr-rectify=no
 
 # GH #896: a freshly created domain gets its OWN pdns zone, inserted
@@ -5669,6 +5681,43 @@ ZONECACHE
       || _warn "pdns restart failed after zone-cache config — new setting applies on next pdns restart"
   else
     _log "pdns not active — zone-cache setting staged in $conf for next start"
+  fi
+}
+
+# JAB-350: pin the GLOBAL AXFR ACL to loopback on EXISTING boxes. The fresh-
+# install template (install_powerdns) writes allow-axfr-ips=127.0.0.0/8,::1, but
+# install_powerdns does NOT run on `jabali update`, so a host that only ever
+# updates would keep whatever global ACL it has. If that global is permissive —
+# an operator edit, a package/build default, or a stale hand-written
+# /etc/powerdns/pdns.conf — ANY internet client can transfer every managed zone
+# (bulk hostname/MX/TXT enumeration). This drop-in is read after the main
+# pdns.conf, so the pinned line overrides such a value. Configured secondaries
+# still transfer via their per-zone ALLOW-AXFR-FROM metadata (unioned with this
+# global); loopback stays allowed for local operator troubleshooting.
+ensure_pdns_axfr_deny() {
+  local conf=/etc/powerdns/pdns.d/01-jabali-mysql.conf
+  [[ -f "$conf" ]] || return 0   # dns module never installed here
+  if grep -Fxq 'allow-axfr-ips=127.0.0.0/8,::1' "$conf"; then
+    return 0
+  fi
+  if grep -q '^allow-axfr-ips=' "$conf"; then
+    sed -i 's|^allow-axfr-ips=.*|allow-axfr-ips=127.0.0.0/8,::1|' "$conf"
+  else
+    cat >> "$conf" <<'AXFRDENY'
+
+# JAB-350: pin the global AXFR ACL to loopback so a permissive main pdns.conf
+# (operator edit / package default) can't leave zones internet-transferable.
+# Secondaries still transfer via per-zone ALLOW-AXFR-FROM metadata. Appended by
+# ensure_pdns_axfr_deny on update.
+allow-axfr-ips=127.0.0.0/8,::1
+AXFRDENY
+  fi
+  if systemctl is-active --quiet pdns 2>/dev/null; then
+    systemctl restart pdns \
+      && _ok "pdns global AXFR ACL pinned to loopback (JAB-350 — external zone transfers denied; secondaries via per-zone metadata)" \
+      || _warn "pdns restart failed after AXFR config — new setting applies on next pdns restart"
+  else
+    _log "pdns not active — AXFR ACL staged in $conf for next start"
   fi
 }
 
@@ -14892,6 +14941,9 @@ provision_new_software() {
   # ships it) does not run
   # on this path.
   ensure_pdns_zone_cache
+  # JAB-350: same reasoning — pin the global AXFR ACL to loopback on update so a
+  # permissive global on an existing host stops leaving zones internet-transferable.
+  ensure_pdns_axfr_deny
 
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator

--- a/install/tests/test_pdns_axfr_deny.sh
+++ b/install/tests/test_pdns_axfr_deny.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# install/tests/test_pdns_axfr_deny.sh — regression coverage for JAB-350
+# (unauthenticated AXFR of managed zones).
+#
+# PowerDNS's global allow-axfr-ips ACL controls which peers may zone-transfer.
+# jabali previously wrote NO global value, relying on pdns's built-in loopback
+# default — but a permissive value from an operator edit, a differing package
+# default, or a stale hand-written /etc/powerdns/pdns.conf then leaves EVERY
+# managed zone transferable by any internet client (bulk enumeration of
+# hostnames, MX/service topology, TXT metadata). Reproduced live: injecting
+# allow-axfr-ips=0.0.0.0/0 into the main pdns.conf opened full AXFR; pinning
+# allow-axfr-ips=127.0.0.0/8,::1 in the jabali pdns.d drop-in (read after the
+# main conf) closed it again while leaving per-zone ALLOW-AXFR-FROM metadata —
+# how configured secondaries transfer — intact.
+#
+# Asserts install.sh ships BOTH halves (the ensure_pdns_zone_cache lesson):
+#   1. The 01-jabali-mysql.conf template (fresh installs) pins
+#      allow-axfr-ips=127.0.0.0/8,::1.
+#   2. ensure_pdns_axfr_deny converges the setting onto EXISTING boxes:
+#      appends when absent, rewrites a permissive value, no-ops when already
+#      correct, and skips hosts without the conf (dns module never installed).
+#   3. provision_new_software (the `jabali update` path) calls it —
+#      install_powerdns does NOT run on update, so without this call the fix
+#      would never reach a box that only ever updates.
+#
+# Run from repo root:
+#     bash install/tests/test_pdns_axfr_deny.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+want='allow-axfr-ips=127.0.0.0/8,::1'
+
+# --- 1. Fresh-install template carries the setting (and no permissive one). ---
+template=$(awk '/cat > "\$pdns_conf_new" <<PDNSCONF/,/^PDNSCONF$/' install.sh)
+if ! grep -Fxq "$want" <<<"$template"; then
+  echo "FAIL: 01-jabali-mysql.conf template does not pin '$want' — fresh installs rely on pdns's default and a permissive global would open AXFR"
+  fail=1
+fi
+if grep -qE '^allow-axfr-ips=0\.0\.0\.0/0' <<<"$template"; then
+  echo "FAIL: template ships a permissive allow-axfr-ips=0.0.0.0/0 — that is the vulnerability, not the fix"
+  fail=1
+fi
+
+# --- 2. The converger behaves, exercised for real against temp files. ---
+fn_src=$(awk '/^ensure_pdns_axfr_deny\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: ensure_pdns_axfr_deny not defined in install.sh"
+  exit 1
+fi
+# Stub the host-touching pieces so the function body runs anywhere.
+systemctl() { return 1; }   # "pdns not active" branch — no restarts in tests
+_ok()   { :; }
+_log()  { :; }
+_warn() { :; }
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# The function hardcodes the conf path; re-point it through a subshell copy.
+run_converger() { # $1 = conf file to converge (or missing)
+  local conf="$1"
+  ( eval "${fn_src/\/etc\/powerdns\/pdns.d\/01-jabali-mysql.conf/$conf}"
+    ensure_pdns_axfr_deny )
+}
+
+# 2a. Absent line → appended.
+conf_a="$tmpdir/a.conf"; printf 'launch=gmysql\n' > "$conf_a"
+run_converger "$conf_a"
+if ! grep -Fxq "$want" "$conf_a"; then
+  echo "FAIL: converger did not append the AXFR ACL to a conf that lacked it"
+  fail=1
+fi
+
+# 2b. Present with a PERMISSIVE value → rewritten to loopback, not duplicated.
+conf_b="$tmpdir/b.conf"; printf 'launch=gmysql\nallow-axfr-ips=0.0.0.0/0,::/0\n' > "$conf_b"
+run_converger "$conf_b"
+if [[ "$(grep -c '^allow-axfr-ips=' "$conf_b")" != "1" ]] || ! grep -Fxq "$want" "$conf_b"; then
+  echo "FAIL: converger must rewrite a permissive value to loopback without duplicating the key"
+  fail=1
+fi
+
+# 2c. Already correct → byte-identical (idempotency; a rewrite would restart pdns).
+conf_c="$tmpdir/c.conf"; printf 'launch=gmysql\n%s\n' "$want" > "$conf_c"
+before=$(cat "$conf_c"); run_converger "$conf_c"
+if [[ "$(cat "$conf_c")" != "$before" ]]; then
+  echo "FAIL: converger rewrote an already-correct conf — every update would restart pdns"
+  fail=1
+fi
+
+# 2d. Conf missing (dns module never installed) → no file created.
+run_converger "$tmpdir/missing.conf"
+if [[ -e "$tmpdir/missing.conf" ]]; then
+  echo "FAIL: converger created a pdns conf on a host without the dns module"
+  fail=1
+fi
+
+# --- 3. The update path actually calls it. ---
+upd_src=$(awk '/^provision_new_software\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'ensure_pdns_axfr_deny' <<<"$upd_src"; then
+  echo "FAIL: provision_new_software does not call ensure_pdns_axfr_deny — existing boxes never get the fix (install_powerdns does not run on update)"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then exit 1; fi
+echo "PASS: pdns global AXFR ACL pinned to loopback on both install paths (JAB-350)"


### PR DESCRIPTION
## JAB-350 [Security][High] — authoritative DNS permits unauthenticated AXFR

### Root cause (reproduced live)
PowerDNS's global `allow-axfr-ips` decides which peers may zone-transfer.
`install.sh` wrote **no** global value, relying on pdns's built-in loopback
default. That is fragile: a permissive value from an operator edit, a differing
package/build default, or a stale hand-written `/etc/powerdns/pdns.conf` leaves
**every managed zone transferable by any internet client** — bulk enumeration of
hostnames, MX/service topology and TXT metadata.

The panel's per-zone `ALLOW-AXFR-FROM = {NS2, 127.0.0.1}` (reconciler) is already
restrictive, and current code on the smoke box denies AXFR — so the ticket's
exposure was a **permissive global**. Confirmed with a controlled experiment on
.86: injecting `allow-axfr-ips=0.0.0.0/0` into the main `pdns.conf` opened full
AXFR (SOA, DKIM keys, every record); adding jabali's pinned loopback value in the
`pdns.d` drop-in (read after the main conf) closed it again.

### Fix
- **Template (`install_powerdns`)**: pin `allow-axfr-ips=127.0.0.0/8,::1`
  explicitly, replacing the incorrect *"left empty → denies by default"* comment.
  Fresh installs no longer depend on the pdns default.
- **`ensure_pdns_axfr_deny`**: converge the setting onto **existing** boxes on
  `jabali update` — append when absent, rewrite a permissive value, no-op when
  already correct, skip hosts without the dns module; restart pdns only on
  change. `install_powerdns` doesn't run on update, so without this the fix would
  never reach an update-only host (the `ensure_pdns_zone_cache` lesson). Wired
  into `provision_new_software`.
- Configured secondaries still transfer via their per-zone `ALLOW-AXFR-FROM`
  metadata (unioned with the global); loopback stays allowed for local ops.

### Acceptance criteria
- ✅ Fresh installs and updated hosts refuse AXFR from an untrusted internet
  address on every managed zone (global pinned to loopback; drop-in overrides a
  permissive main conf).
- ✅ Normal UDP/TCP authoritative queries unaffected (only the AXFR ACL changes).
- ✅ Configured secondaries transfer only zones they're authorized for
  (unchanged per-zone `ALLOW-AXFR-FROM` metadata).
- ✅ Integration coverage: `install/tests/test_pdns_axfr_deny.sh` exercises the
  rendered template and the real converger (append / rewrite-permissive /
  idempotent / skip-missing / update-path-call). The live denied-AXFR was
  proven on .86 (see below).

### Verification
- Phantom-function lint OK; `bash -n` clean; new + sibling pdns tests pass.
- **Box-verified on .86 (kernel 6.12, pdns 4.9.17):** the real
  `ensure_pdns_axfr_deny` flips a simulated permissive host from AXFR-open (2 SOA
  dumped) to AXFR-denied (0 SOA), and is idempotent on re-run. Box restored
  pristine (no leftover config, AXFR denied).
