### PR TITLE
fix(ssh): disable forwarding for hosting SSH users so a tenant key can't tunnel into loopback services (JAB-352)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8572,6 +8572,53 @@ install_sftp_sshd_config() {
   ensure_sshd_running
 }
 
+# ensure_ssh_forwarding_lockdown — JAB-352. SSH-enabled hosting users (the
+# jabali-ssh-sandbox group) get the restricted jabali-ssh-shell as their login
+# shell, but sshd sets up TCP / Unix-socket / agent / X11 / tunnel forwarding
+# BEFORE the shell runs, so the shell sandbox can't stop a tenant tunnelling
+# into loopback-only services (MariaDB, PostgreSQL, the panel Agent socket,
+# unauthenticated profilers). A `Match Group jabali-ssh-sandbox` drop-in
+# disables every forwarding channel at the sshd layer; root/operator SSH is
+# untouched (different group). Idempotent: it repairs/installs the drop-in and
+# reloads sshd ONLY when the rendered file actually changed, so it is safe to
+# call on every `jabali update` — mirroring the ensure_pdns_* convergers, since
+# install_sftp_sshd_config runs on fresh install only.
+ensure_ssh_forwarding_lockdown() {
+  local src="${REPO_DIR:-/opt/jabali-panel}/install/ssh/jabali-ssh-sandbox.conf"
+  local dst=/etc/ssh/sshd_config.d/jabali-ssh-sandbox.conf
+  if [[ ! -f "$src" ]]; then
+    _warn "ssh forwarding-lockdown source missing at $src — skipping (JAB-352 not applied)"
+    return 0
+  fi
+  # Idempotent: already current → no rewrite, no sshd reload.
+  if [[ -f "$dst" ]] && cmp -s "$src" "$dst"; then
+    return 0
+  fi
+  install -m 0644 -o root -g root "$src" "$dst"
+  # Validate BEFORE relying on it. If the host's sshd rejects a directive,
+  # remove the drop-in rather than leaving sshd unparseable (a broken
+  # sshd_config would lock the operator out on the next restart). Every
+  # directive here is standard OpenSSH and box-verified on Debian 13, so this
+  # is a defensive backstop, not the expected path.
+  if ! sshd -t 2>/dev/null; then
+    _warn "sshd -t rejected $dst — removing it (JAB-352 forwarding lockdown NOT applied; check OpenSSH directive support)"
+    rm -f "$dst"
+    return 0
+  fi
+  # Socket-activated sshd (stock Debian 13 / Ubuntu 24.04) spawns a fresh
+  # sshd-session per connection that re-reads the config, so no reload is
+  # needed. Jabali normally converges to classic ssh.service (ensure_sshd_
+  # running / GH #133), which must be reloaded. Try both, fall back to SIGHUP.
+  if systemctl is-active --quiet ssh.socket || systemctl is-enabled --quiet ssh.socket; then
+    _ok "SSH forwarding lockdown installed (JAB-352); applies on next connection (socket-activated sshd)"
+  elif systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null \
+       || { pgrep -x sshd >/dev/null 2>&1 && pkill -HUP -x sshd; }; then
+    _ok "SSH forwarding lockdown installed + sshd reloaded (JAB-352 — tenant tunnels into loopback services blocked)"
+  else
+    _warn "installed $dst but sshd reload failed — new policy applies on next sshd restart"
+  fi
+}
+
 # ensure_sshd_running — converge the host onto a single classic ssh.service
 # listener and retire ssh.socket (GH #133). Delegates to the shared,
 # lockout-safe normalizer so a fresh install and a later `jabali update`
@@ -14944,6 +14991,10 @@ provision_new_software() {
   # JAB-350: same reasoning — pin the global AXFR ACL to loopback on update so a
   # permissive global on an existing host stops leaving zones internet-transferable.
   ensure_pdns_axfr_deny
+  # JAB-352: same reasoning — carry the SSH forwarding-lockdown drop-in to boxes
+  # that only ever update (install_sftp_sshd_config runs on fresh install only),
+  # so an existing tenant key can't tunnel into loopback-only services.
+  ensure_ssh_forwarding_lockdown
 
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator
@@ -15716,6 +15767,9 @@ main() {
   install_wp_cli
   install_sftp_group
   install_sftp_sshd_config
+  # JAB-352: disable SSH forwarding for hosting users so a tenant key can't
+  # tunnel into loopback-only services.
+  ensure_ssh_forwarding_lockdown
   install_ssh_sandbox
   build_default_nspawn_image
   install_nginx_default_vhost

--- a/install/ssh/jabali-ssh-sandbox.conf
+++ b/install/ssh/jabali-ssh-sandbox.conf
@@ -1,0 +1,34 @@
+# Jabali Panel — SSH forwarding lockdown for hosting users in the
+# jabali-ssh-sandbox group (JAB-352).
+# Installed to: /etc/ssh/sshd_config.d/jabali-ssh-sandbox.conf
+# Source: install/ssh/jabali-ssh-sandbox.conf (do not edit in place)
+#
+# SSH-enabled hosting users get the restricted /usr/local/bin/jabali-ssh-shell
+# as their login shell, but sshd establishes port/socket/agent/X11 forwarding
+# BEFORE the login shell runs — so the shell sandbox cannot stop a tenant from
+# tunnelling (ssh -L / -R / -D, -A, -w) into loopback-only services such as
+# MariaDB, PostgreSQL, the panel Agent socket, and unauthenticated profilers.
+# Disable every forwarding channel at the sshd layer for this group.
+#
+# This intentionally does NOT set ForceCommand: the interactive restricted shell
+# (set as the login shell in /etc/passwd) and its sandbox keep working. The
+# SFTP-only path is handled separately by jabali-sftp.conf, which already
+# disables forwarding for the jabali-sftp group.
+
+Match Group jabali-ssh-sandbox
+    # No TCP forwarding: blocks local (-L), remote (-R) and dynamic/SOCKS (-D).
+    AllowTcpForwarding no
+    # No Unix-domain-socket forwarding: -L/-R to a socket path (e.g. the panel
+    # Agent socket under /run/jabali) is a separate channel from TCP.
+    AllowStreamLocalForwarding no
+    # A forwarded port may never bind a non-loopback address.
+    GatewayPorts no
+    # No ssh-agent forwarding (-A).
+    AllowAgentForwarding no
+    # No X11 forwarding (-X / -Y).
+    X11Forwarding no
+    # No tun/tap VPN tunnels (-w).
+    PermitTunnel no
+    # Belt-and-suspenders: even if a future edit re-enabled a forwarding knob,
+    # permit no destinations at all.
+    PermitOpen none

--- a/install/tests/test_ssh_forwarding_lockdown.sh
+++ b/install/tests/test_ssh_forwarding_lockdown.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# install/tests/test_ssh_forwarding_lockdown.sh — regression coverage for
+# JAB-352 (tenant SSH keys tunnelling into loopback-only panel services).
+#
+# SSH-enabled hosting users get the restricted /usr/local/bin/jabali-ssh-shell
+# as their login shell and are placed in the jabali-ssh-sandbox group. But sshd
+# establishes TCP / Unix-socket / agent / X11 / tunnel forwarding BEFORE the
+# login shell runs, so the shell sandbox cannot stop a tenant tunnelling
+# (ssh -L/-R/-D, -A, -w) into loopback-only services (MariaDB, PostgreSQL, the
+# panel Agent socket, unauthenticated profilers). The fix is a managed
+# `Match Group jabali-ssh-sandbox` sshd drop-in that disables every forwarding
+# channel; box-verified on Debian 13 that a sandbox user reports all forwarding
+# off + permitopen none while root is unaffected.
+#
+# Asserts install.sh ships BOTH halves (the ensure_pdns_* lesson):
+#   1. The static drop-in install/ssh/jabali-ssh-sandbox.conf matches the group
+#      and disables every forwarding knob.
+#   2. ensure_ssh_forwarding_lockdown converges it onto EXISTING boxes: installs
+#      when absent/changed, idempotent when current, removes the drop-in if
+#      `sshd -t` rejects it (never leave sshd unparseable), skips when the
+#      source is missing (dns/ssh module layout differences).
+#   3. Both the fresh-install flow (main) and the update path
+#      (provision_new_software) call it — install_sftp_sshd_config runs on fresh
+#      install only, so without the update call an update-only host stays open.
+#
+# Run from repo root:
+#     bash install/tests/test_ssh_forwarding_lockdown.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+conf=install/ssh/jabali-ssh-sandbox.conf
+
+# --- 1. The drop-in matches the group and closes every forwarding channel. ---
+if [[ ! -f "$conf" ]]; then
+  echo "FAIL: $conf missing"
+  exit 1
+fi
+if ! grep -qE '^Match Group jabali-ssh-sandbox$' "$conf"; then
+  echo "FAIL: $conf does not Match the jabali-ssh-sandbox group"
+  fail=1
+fi
+for d in 'AllowTcpForwarding no' 'AllowStreamLocalForwarding no' 'GatewayPorts no' \
+         'AllowAgentForwarding no' 'X11Forwarding no' 'PermitTunnel no' 'PermitOpen none'; do
+  if ! grep -qE "^[[:space:]]*${d}$" "$conf"; then
+    echo "FAIL: $conf missing directive: $d"
+    fail=1
+  fi
+done
+# A ForceCommand here would break the interactive restricted shell.
+if grep -qE '^[[:space:]]*ForceCommand' "$conf"; then
+  echo "FAIL: $conf must NOT ForceCommand — the restricted login shell must still work"
+  fail=1
+fi
+
+# --- 2. The converger behaves, exercised for real against temp files. ---
+fn_src=$(awk '/^ensure_ssh_forwarding_lockdown\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: ensure_ssh_forwarding_lockdown not defined in install.sh"
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+dst="$tmpdir/dst.conf"
+export REPO_DIR="$tmpdir/repo"
+mkdir -p "$REPO_DIR/install/ssh"
+cp "$conf" "$REPO_DIR/install/ssh/jabali-ssh-sandbox.conf"
+
+# Stubs: no host mutation, no real sshd/systemctl.
+_ok()   { :; }
+_log()  { :; }
+_warn() { :; }
+# `install -m .. -o .. -g .. SRC DST` — copy the last two args (root not needed).
+install() { local a=("$@"); cp "${a[-2]}" "${a[-1]}"; }
+systemctl() { return 1; }   # not socket-activated; reloads fail → best-effort branch
+pgrep() { return 1; }
+pkill() { return 1; }
+# sshd -t result is controlled by SSHD_T_RC.
+sshd() { return "${SSHD_T_RC:-0}"; }
+
+# Re-point the hardcoded dst path at our temp file.
+run_lockdown() { ( eval "${fn_src/\/etc\/ssh\/sshd_config.d\/jabali-ssh-sandbox.conf/$dst}"; ensure_ssh_forwarding_lockdown ); }
+
+# 2a. Absent dst → installed.
+rm -f "$dst"; SSHD_T_RC=0 run_lockdown
+if ! cmp -s "$conf" "$dst"; then
+  echo "FAIL: converger did not install the drop-in when it was absent"
+  fail=1
+fi
+
+# 2b. Already current → byte-identical, no error (idempotent).
+before=$(cat "$dst"); SSHD_T_RC=0 run_lockdown
+if [[ "$(cat "$dst")" != "$before" ]]; then
+  echo "FAIL: converger altered an already-current drop-in (would reload sshd every update)"
+  fail=1
+fi
+
+# 2c. sshd -t rejects the new file → drop-in removed (sshd never left broken).
+rm -f "$dst"; SSHD_T_RC=1 run_lockdown
+if [[ -e "$dst" ]]; then
+  echo "FAIL: converger kept a drop-in that sshd -t rejected — sshd could be left unparseable"
+  fail=1
+fi
+
+# 2d. Source missing → no dst created.
+rm -rf "$REPO_DIR/install/ssh"; rm -f "$dst"; SSHD_T_RC=0 run_lockdown
+if [[ -e "$dst" ]]; then
+  echo "FAIL: converger created a drop-in with no source file"
+  fail=1
+fi
+
+# --- 3. BOTH install paths call it. ---
+# Capture the awk output to a variable first: `awk | grep -q` trips
+# `set -o pipefail` when grep -q closes the pipe early and awk takes SIGPIPE.
+main_src=$(awk '/^main\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'ensure_ssh_forwarding_lockdown' <<<"$main_src"; then
+  echo "FAIL: main() (fresh install) does not call ensure_ssh_forwarding_lockdown"
+  fail=1
+fi
+upd_src=$(awk '/^provision_new_software\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'ensure_ssh_forwarding_lockdown' <<<"$upd_src"; then
+  echo "FAIL: provision_new_software (jabali update) does not call ensure_ssh_forwarding_lockdown — update-only hosts stay open"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then exit 1; fi
+echo "PASS: SSH forwarding lockdown shipped on both install paths (JAB-352)"


### PR DESCRIPTION
## JAB-352 [Security][High] — tenant SSH keys can tunnel into loopback-only panel services

### Root cause
SSH-enabled hosting users get the restricted `/usr/local/bin/jabali-ssh-shell`
login shell and land in the `jabali-ssh-sandbox` group, but sshd establishes
TCP / Unix-socket / agent / X11 / tunnel forwarding **before** the login shell
runs — so the shell sandbox never protected loopback-only services. A tenant who
can add an SSH key could `ssh -L/-R/-D` (or `-A`/`-w`) straight into MariaDB,
PostgreSQL, the panel Agent socket, and unauthenticated profilers. `sshd -T` for
a provisioned tenant reported `allowtcpforwarding yes` / `permitopen any`; the
SFTP and FTP-subaccount `Match` blocks disable forwarding, but the SSH-enabled
path had no equivalent policy.

### Fix
- **`install/ssh/jabali-ssh-sandbox.conf`** — `Match Group jabali-ssh-sandbox`
  with `AllowTcpForwarding no`, `AllowStreamLocalForwarding no`, `GatewayPorts
  no`, `AllowAgentForwarding no`, `X11Forwarding no`, `PermitTunnel no`,
  `PermitOpen none`. No `ForceCommand` — the interactive restricted shell keeps
  working. Root/operator SSH is a different group and unaffected.
  (`join_sandbox_group` does `usermod -aG jabali-ssh-sandbox` unconditionally
  for every ssh-enabled user, so the group Match catches them all.)
- **`ensure_ssh_forwarding_lockdown`** — install/repair the drop-in and reload
  sshd **only when it changed** (idempotent). If `sshd -t` rejects the file it
  removes it rather than leave sshd unparseable (lockout-safe). Called from
  **both** `main` (fresh install, next to `install_sftp_sshd_config`) and
  `provision_new_software` (the `jabali update` path) — `install_sftp_sshd_config`
  runs on fresh install only, so an update-only host would otherwise stay open
  (the `ensure_pdns_*` lesson).

### Acceptance criteria
- ✅ Effective sshd config for every hosting SSH user reports forwarding/
  tunneling disabled and no permitted destinations — box-verified.
- ✅ Interactive restricted-shell / approved SFTP behavior unchanged (no
  `ForceCommand`; SFTP path is a separate group/block).
- ✅ Root/operator SSH retains forwarding (different group).
- ✅ Integration coverage (`install/tests/test_ssh_forwarding_lockdown.sh`) +
  live proof a sandbox key gets local/remote/dynamic/X11/agent/stream forwarding
  all denied.

### Verification (.86, Debian 13, OpenSSH)
`sshd -t` accepts the drop-in; a `jabali-ssh-sandbox` member goes from
`allowtcpforwarding yes` → **every** forwarding knob `no` + `permitopen none`,
while `root` stays `yes`/`any`. The real `ensure_ssh_forwarding_lockdown` is
idempotent on re-run; box restored pristine. Phantom-lint + `bash -n` +
regression test green.

### Out of scope → follow-up
CrowdSec's loopback prometheus/pprof (`127.0.0.1:6060`, unauth `200`) is
reachable by tenant **app code** independently of SSH forwarding. That separate
diagnostics-hardening (JAB-352 required-fix item 4, "audit loopback listeners
independently") is filed as a follow-up rather than blocking the isolation fix.
