### PR TITLE
fix(repair): auto-recover the half-applied migration 264 that bricks updates (GH #1094/#1103/#979)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -4617,6 +4617,7 @@ jabali repair [flags]
 - `--crowdsec-bouncer-key` — Fix only: crowdsec-firewall-bouncer crash-loops with stale LAPI key
 - `--daemon-reload` — Fix only: systemd has unloaded unit-file changes on disk
 - `--diagnose` — Report broken conditions without fixing
+- `--dirty-ftp-264` — Fix only: schema half-applied migration 264 (GH #1094 FTP row-size) — panel-api cannot start
 - `--dirty-migration` — Fix only: database schema is dirty — panel-api cannot start
 - `--docroot-www-data-group` — Fix only: web docroot files not group www-data / dirs not setgid (nginx 403 on newly uploaded media)
 - `--etc-jabali-perms` — Fix only: /etc/jabali not traversable by hosting users (SSH/SFTP locked out — sandbox-mode unreadable)

--- a/panel-api/cmd/server/migrate_cmd.go
+++ b/panel-api/cmd/server/migrate_cmd.go
@@ -48,6 +48,18 @@ func newMigrateUpCmd() *cobra.Command {
 				return fmt.Errorf("DATABASE_URL not configured")
 			}
 
+			// GH #1094/#1103: `jabali update` runs this (via the freshly-installed
+			// binary) and rolls the binary back if it fails — so a host stuck on
+			// the half-applied migration 264 could never receive the fix. Self-heal
+			// that exact state here so the update completes on its own. No-op unless
+			// the precise fingerprint matches; anything else falls through to the
+			// normal (and, if dirty, still-failing → operator-driven) migrate.
+			if recovered, rerr := db.RecoverBrokenFtp264(cfg.Database.URL); rerr != nil {
+				fmt.Printf("warning: dirty-264 auto-recovery attempt failed; continuing to migrate: %v\n", rerr)
+			} else if recovered {
+				fmt.Println("recovered from half-applied migration 264 (GH #1094)")
+			}
+
 			if err := db.Migrate(cfg.Database.URL); err != nil {
 				return fmt.Errorf("migrate: %w", err)
 			}

--- a/panel-api/cmd/server/repair.go
+++ b/panel-api/cmd/server/repair.go
@@ -260,8 +260,19 @@ func confirm(prompt string) (bool, error) {
 func repairSteps() []repairStep {
 	return []repairStep{
 		{
-			// First: a dirty schema means the panel is already down, which
-			// makes every other finding secondary.
+			// Runs before the general dirty-migration detector: this is the ONE
+			// dirty state we can recover automatically and safely, so fix it
+			// rather than only reporting it (GH #1094 / #1103). Precisely gated —
+			// see detectBrokenFtp264.
+			id:     "dirty-ftp-264",
+			label:  "schema half-applied migration 264 (GH #1094 FTP row-size) — panel-api cannot start",
+			detect: detectBrokenFtp264,
+			fix:    fixBrokenFtp264,
+		},
+		{
+			// A dirty schema means the panel is already down, which makes every
+			// other finding secondary. (The recoverable 264 case above is caught
+			// first; anything reaching here is operator-driven.)
 			id:     "dirty-migration",
 			label:  "database schema is dirty — panel-api cannot start",
 			detect: detectDirtyMigration,
@@ -1517,4 +1528,52 @@ func detectDirtyMigration(_ repairCtx) (bool, string, error) {
 	return true, fmt.Sprintf(
 		"schema dirty at version %d — panel-api cannot start; run `jabali migrate status` for how to clear it",
 		st.Version), nil
+}
+
+// detectBrokenFtp264 reports the one dirty state repair can recover on its own:
+// the half-applied original migration 000264 (GH #1094). The `ftp_pasv_address
+// VARCHAR` ALTER hit InnoDB's row-size ceiling and rolled back, but the earlier
+// `CREATE TABLE ftp_accounts` had committed, leaving the schema dirty at 264
+// with a fix (#1103) that a dirty host can't apply. See db.IsBrokenFtp264 for
+// the precise fingerprint — anything else falls through to detectDirtyMigration.
+func detectBrokenFtp264(_ repairCtx) (bool, string, error) {
+	if err := initConfig(); err != nil {
+		return false, "", nil
+	}
+	cfg := sharedCfg
+	if cfg.Database.URL == "" || cfg.Database.URL == "placeholder-until-phase-3" {
+		return false, "", nil
+	}
+	broken, err := db.IsBrokenFtp264(cfg.Database.URL)
+	if err != nil {
+		// Unreachable DB is its own finding; don't misreport it here.
+		return false, "", nil
+	}
+	if !broken {
+		return false, "", nil
+	}
+	return true, "migration 264 half-applied (ftp_accounts created, server_settings ALTER rolled back at the row-size ceiling); recoverable", nil
+}
+
+// fixBrokenFtp264 clears the half-applied 000264 and re-applies the corrected
+// migration (drop the orphan empty ftp_accounts table, force back to 263,
+// migrate up). Gated on the fingerprint via db.RecoverBrokenFtp264, so it is a
+// no-op unless detectBrokenFtp264 matched — never a blind force.
+func fixBrokenFtp264(_ repairCtx) error {
+	if err := initConfig(); err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+	cfg := sharedCfg
+	if cfg.Database.URL == "" || cfg.Database.URL == "placeholder-until-phase-3" {
+		return fmt.Errorf("database URL not configured")
+	}
+	recovered, err := db.RecoverBrokenFtp264(cfg.Database.URL)
+	if err != nil {
+		return err
+	}
+	if !recovered {
+		// Fingerprint no longer matches (e.g. already recovered) — nothing to do.
+		return nil
+	}
+	return nil
 }

--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -94,6 +94,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// ---- DB ----
 	if cfg.Database.URL != "" && cfg.Database.URL != "placeholder-until-phase-3" {
 		if os.Getenv("SKIP_MIGRATIONS") != "true" {
+			// GH #1094/#1103: a host stuck on the half-applied migration 264
+			// crash-loops here (db.Migrate refuses a dirty schema). Self-heal it
+			// before migrating so the panel recovers on restart without an
+			// operator step. No-op unless the exact fingerprint matches.
+			if recovered, rerr := db.RecoverBrokenFtp264(cfg.Database.URL); rerr != nil {
+				log.Warn("dirty-264 auto-recovery attempt failed; continuing to migrate", "err", rerr)
+			} else if recovered {
+				log.Info("recovered from half-applied migration 264 (GH #1094)")
+			}
 			if err := db.Migrate(cfg.Database.URL); err != nil {
 				return err
 			}

--- a/panel-api/internal/db/dirty264.go
+++ b/panel-api/internal/db/dirty264.go
@@ -1,0 +1,130 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// The original migration 000264 (GH #1094, FTP/SFTP subaccounts) added
+// `ftp_pasv_address VARCHAR(64)` to server_settings, which already sits at
+// InnoDB's 65535-byte in-row ceiling — so the multi-column `ALTER TABLE
+// server_settings` failed with ERROR 1118 ("Row size too large"). MySQL rolls
+// the whole ALTER back, but the migration's EARLIER `CREATE TABLE ftp_accounts`
+// statement had already committed. golang-migrate then marks the schema DIRTY at
+// 264, and every later `migrate up` (i.e. every `jabali update` and every
+// panel-api start) refuses to run — the panel is down and can't be updated.
+//
+// #1103 fixed the migration SQL (ftp_pasv_address TEXT, stored off-page), so
+// FRESH installs apply 264 cleanly. But a host that already went dirty on the
+// VARCHAR version is stuck: migrate won't run while dirty, and a blind re-run
+// would hit "table ftp_accounts already exists". `jabali repair` deliberately
+// won't force a dirty schema in general (forcing the wrong direction silently
+// skips changes). This recovers the ONE precisely-identified broken state.
+
+const brokenFtp264Version = 264
+const brokenFtp264PrevVersion = 263
+
+// IsBrokenFtp264 reports whether the schema is stuck in the exact half-applied
+// state the original 000264 left behind: dirty at 264, `ftp_accounts` present
+// (the CREATE TABLE that committed), but `server_settings.ftp_enabled` absent
+// (proof the multi-column ALTER rolled back). Anything else — dirty at a
+// different version, or 264-dirty without this precise fingerprint — returns
+// false so the general operator-driven path still handles it.
+func IsBrokenFtp264(dsn string) (bool, error) {
+	st, err := State(dsn)
+	if err != nil {
+		return false, err
+	}
+	if !st.Dirty || st.Version != brokenFtp264Version {
+		return false, nil
+	}
+
+	driverDSN, err := ToDriverDSN(dsn)
+	if err != nil {
+		return false, err
+	}
+	sqlDB, err := openRawSQL(driverDSN)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	hasFtpTable, err := tableExists(sqlDB, "ftp_accounts")
+	if err != nil {
+		return false, err
+	}
+	hasEnabledCol, err := columnExists(sqlDB, "server_settings", "ftp_enabled")
+	if err != nil {
+		return false, err
+	}
+	// The broken-VARCHAR fingerprint: the table committed, the server_settings
+	// ALTER did not.
+	return hasFtpTable && !hasEnabledCol, nil
+}
+
+// RecoverBrokenFtp264 clears the half-applied 000264 state and re-applies the
+// corrected migration. It is gated on IsBrokenFtp264, so it is a no-op unless
+// the precise fingerprint matches — never a blind force.
+//
+// Steps: DROP the orphan `ftp_accounts` (a brand-new, empty table created by the
+// failed migration — no tenant data lives there), force the version back to 263
+// (the last cleanly-applied migration), then `migrate up` so the fixed (TEXT)
+// 000264 applies from scratch.
+func RecoverBrokenFtp264(dsn string) (bool, error) {
+	ok, err := IsBrokenFtp264(dsn)
+	if err != nil || !ok {
+		return false, err
+	}
+
+	driverDSN, err := ToDriverDSN(dsn)
+	if err != nil {
+		return false, err
+	}
+	sqlDB, err := openRawSQL(driverDSN)
+	if err != nil {
+		return false, err
+	}
+	// DROP the orphan table left by the committed CREATE TABLE. IF EXISTS keeps
+	// this idempotent if a partial recovery already removed it.
+	if _, err := sqlDB.Exec("DROP TABLE IF EXISTS ftp_accounts"); err != nil {
+		_ = sqlDB.Close()
+		return false, fmt.Errorf("drop orphan ftp_accounts: %w", err)
+	}
+	_ = sqlDB.Close()
+
+	// Clear the dirty flag back to the last good version, then re-run migrations
+	// so the corrected 264 (and anything after it) applies cleanly.
+	if err := ForceVersion(dsn, brokenFtp264PrevVersion); err != nil {
+		return false, fmt.Errorf("force version %d: %w", brokenFtp264PrevVersion, err)
+	}
+	if err := Migrate(dsn); err != nil {
+		return false, fmt.Errorf("re-run migrations after recovery: %w", err)
+	}
+	return true, nil
+}
+
+// tableExists / columnExists probe information_schema in the connection's
+// current database (DATABASE()).
+func tableExists(db *sql.DB, table string) (bool, error) {
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM information_schema.tables
+		 WHERE table_schema = DATABASE() AND table_name = ?`, table,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("probe table %s: %w", table, err)
+	}
+	return n > 0, nil
+}
+
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	var n int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM information_schema.columns
+		 WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?`, table, column,
+	).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("probe column %s.%s: %w", table, column, err)
+	}
+	return n > 0, nil
+}

--- a/panel-api/internal/db/dirty264_integration_test.go
+++ b/panel-api/internal/db/dirty264_integration_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+// Integration test for the GH #1094 / #1103 broken-migration-264 recovery.
+// Gated by the `integration` build tag; needs a DISPOSABLE MariaDB in
+// JABALI_TEST_DATABASE_URL (it Drop()s and re-migrates the schema).
+//
+// Internal package (not db_test) so it can drive newMigrator to an exact
+// version — reproducing the *genuine* broken state (263 applied, 264
+// half-applied, nothing above), which is what makes the recovery's re-migrate
+// meaningful rather than a replay of already-applied migrations.
+//
+//	JABALI_TEST_DATABASE_URL=... go test -tags integration ./panel-api/internal/db/ -run BrokenFtp264
+
+package db
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ft264DSN(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("JABALI_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("JABALI_TEST_DATABASE_URL not set; skipping integration test")
+	}
+	return dsn
+}
+
+// migrateToExact drops everything and migrates to exactly `version`, leaving the
+// schema clean at that version with nothing above it applied.
+func migrateToExact(t *testing.T, dsn string, version uint) {
+	t.Helper()
+	m, closeFn, err := newMigrator(dsn)
+	require.NoError(t, err)
+	defer closeFn()
+	// Drop wipes all objects + the version table, so the Migrate below starts
+	// from zero regardless of prior test state.
+	require.NoError(t, m.Drop())
+	m2, closeFn2, err := newMigrator(dsn)
+	require.NoError(t, err)
+	defer closeFn2()
+	require.NoError(t, m2.Migrate(version))
+}
+
+func rawExec(t *testing.T, dsn, stmt string) {
+	t.Helper()
+	driverDSN, err := ToDriverDSN(dsn)
+	require.NoError(t, err)
+	sqlDB, err := openRawSQL(driverDSN)
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+	_, err = sqlDB.Exec(stmt)
+	require.NoError(t, err)
+}
+
+// TestBrokenFtp264_DetectAndRecover reproduces the genuine half-applied 264
+// state and asserts the detector fires and the recovery lands the schema at head
+// with the FTP objects the fixed migration creates.
+func TestBrokenFtp264_DetectAndRecover(t *testing.T) {
+	dsn := ft264DSN(t)
+
+	// Genuine pre-264 state: 263 applied, clean, nothing above.
+	migrateToExact(t, dsn, brokenFtp264PrevVersion)
+
+	// Clean 263 must NOT look broken.
+	broken, err := IsBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.False(t, broken, "clean schema at 263 must not match the broken-264 fingerprint")
+
+	// Reproduce the failure: the CREATE TABLE committed, the server_settings
+	// ALTER rolled back (row-size ceiling), migrate marked 264 dirty.
+	rawExec(t, dsn, `CREATE TABLE ftp_accounts (
+		id CHAR(26) NOT NULL PRIMARY KEY,
+		user_id CHAR(26) NOT NULL,
+		username VARCHAR(64) NOT NULL
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`)
+	rawExec(t, dsn, `UPDATE schema_migrations SET version = 264, dirty = 1`)
+
+	// Now it matches the fingerprint.
+	broken, err = IsBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.True(t, broken, "dirty@264 + ftp_accounts + no server_settings.ftp_enabled must match")
+
+	// Recover.
+	recovered, err := RecoverBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.True(t, recovered)
+
+	// Schema is clean, at (or past) 264, with both FTP artifacts present.
+	st, err := State(dsn)
+	require.NoError(t, err)
+	require.False(t, st.Dirty, "schema must be clean after recovery")
+	require.GreaterOrEqual(t, st.Version, uint(brokenFtp264Version))
+
+	driverDSN, err := ToDriverDSN(dsn)
+	require.NoError(t, err)
+	sqlDB, err := openRawSQL(driverDSN)
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+
+	hasFtp, err := tableExists(sqlDB, "ftp_accounts")
+	require.NoError(t, err)
+	require.True(t, hasFtp, "ftp_accounts must exist after the fixed 264 re-applies")
+	hasCol, err := columnExists(sqlDB, "server_settings", "ftp_enabled")
+	require.NoError(t, err)
+	require.True(t, hasCol, "server_settings.ftp_enabled must exist after the fixed 264 re-applies")
+
+	// Idempotent: a clean schema no longer matches, recovery is a no-op.
+	broken, err = IsBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.False(t, broken)
+	recovered, err = RecoverBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.False(t, recovered)
+}
+
+// TestBrokenFtp264_IgnoresOtherDirty: a dirty schema at a different version must
+// not match — recovery stays operator-driven for anything but this exact bug.
+func TestBrokenFtp264_IgnoresOtherDirty(t *testing.T) {
+	dsn := ft264DSN(t)
+	migrateToExact(t, dsn, brokenFtp264PrevVersion)
+	rawExec(t, dsn, `UPDATE schema_migrations SET version = 200, dirty = 1`)
+	broken, err := IsBrokenFtp264(dsn)
+	require.NoError(t, err)
+	require.False(t, broken, "dirty at a non-264 version must not match the fingerprint")
+}


### PR DESCRIPTION
## The bug

The original migration **000264** (GH #1094, FTP subaccounts) added
`ftp_pasv_address VARCHAR(64)` to `server_settings`, which sits at InnoDB's
65535-byte in-row ceiling — so the multi-column `ALTER TABLE server_settings`
failed with **ERROR 1118** and rolled back, but the migration's earlier
`CREATE TABLE ftp_accounts` had already committed. golang-migrate then marks the
schema **dirty at 264**, and every later `migrate up` (every `jabali update`,
every panel-api start) refuses to run — **the panel is down and can't be
updated**.

#1103 fixed the migration SQL (`ftp_pasv_address TEXT`) so *fresh* installs
apply 264 cleanly. But a host already dirty on the VARCHAR version is **stuck**:
migrate won't run while dirty, a blind re-run hits `table ftp_accounts already
exists`, and `jabali repair` deliberately won't force a dirty schema in general.
lxsdevcode hit exactly this on **GH #979** and had to reinstall.

## The fix — recover the ONE precisely-identified broken state, and only that

- `db.IsBrokenFtp264`: fingerprint = dirty **and** version==264 **and**
  `ftp_accounts` present **and** `server_settings.ftp_enabled` **absent** (the
  CREATE committed, the ALTER rolled back). Anything else falls through to the
  existing operator-driven `dirty-migration` detector — never a blind force.
- `db.RecoverBrokenFtp264`: `DROP` the orphan (brand-new, empty) `ftp_accounts`,
  `ForceVersion(263)`, then `migrate up` so the corrected (TEXT) 264 and
  everything after it apply cleanly.
- Wired as `jabali repair` step **`dirty-ftp-264`**, before the generic
  detect-only dirty step, **non-destructive** so `jabali repair --auto` recovers
  it (which is what lxsdevcode reached for).

## Box-verified on `.86` (real MariaDB)

- Integration test (built as a standalone binary, run on `.86` against its local
  MariaDB): reproduces the **genuine** state — migrate to 263, simulate the
  half-applied 264 — then asserts detect + recover land the schema at head with
  **both** `ftp_accounts` and `server_settings.ftp_enabled` restored, and that
  it's idempotent. A **dirty-at-a-different-version** schema does **not** match.
  Both pass.
- `jabali repair --diagnose` on `.86`'s live DB reports `✓ [dirty-ftp-264] … OK`
  — no false-fire on a healthy host.

## Test

`internal/db/dirty264_integration_test.go` (`integration` tag — needs a
disposable MariaDB in `JABALI_TEST_DATABASE_URL`; excluded from default
`go test ./...`). `go build` + `go vet` clean.

Note: the pre-existing `internal/db/integration_test.go` has stale
`models.RefreshToken` refs that already break the `integration` build tag on
main — unrelated to this change and left alone; the default CI lane (no
integration tag) is unaffected.

GH #1094 GH #1103 GH #979