### PR TITLE
feat(updates): OS security auto-updates on by default + Update Center reporting (JAB-353)

### DIFF
--- a/panel-agent/internal/commands/system_apt_check.go
+++ b/panel-agent/internal/commands/system_apt_check.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // systemAptCheckResponse is the wire shape for system.apt_check.
@@ -25,6 +27,12 @@ type systemAptCheckResponse struct {
 	SecurityTotal  int                    `json:"security_total"`
 	InstalledTotal int                    `json:"installed_total"`
 	Error          *aptCheckError         `json:"error,omitempty"`
+	// JAB-353 OS-patch status (cheap file stats, independent of the apt-get
+	// update above): RebootRequired mirrors /var/run/reboot-required;
+	// LastAppliedAt is when unattended-upgrades last completed an apply.
+	RebootRequired     bool       `json:"reboot_required"`
+	RebootRequiredPkgs []string   `json:"reboot_required_pkgs,omitempty"`
+	LastAppliedAt      *time.Time `json:"last_applied_at,omitempty"`
 }
 
 // aptCheckError is the admin-facing, structured diagnostic for a failed
@@ -81,12 +89,53 @@ func systemAptCheckHandler(ctx context.Context, _ json.RawMessage) (any, error) 
 			sec++
 		}
 	}
+	rebootReq, rebootPkgs := aptRebootRequired()
 	return systemAptCheckResponse{
-		Packages:       pkgs,
-		Total:          len(pkgs),
-		SecurityTotal:  sec,
-		InstalledTotal: countInstalledPackages(ctx),
+		Packages:           pkgs,
+		Total:              len(pkgs),
+		SecurityTotal:      sec,
+		InstalledTotal:     countInstalledPackages(ctx),
+		RebootRequired:     rebootReq,
+		RebootRequiredPkgs: rebootPkgs,
+		LastAppliedAt:      aptLastApplied(),
 	}, nil
+}
+
+// aptRebootRequired reports whether the host needs a reboot to finish applying
+// updates (Debian/Ubuntu drop /var/run/reboot-required after a kernel/libc/…
+// upgrade) and, best-effort, the packages that triggered it.
+func aptRebootRequired() (bool, []string) {
+	if _, err := os.Stat("/var/run/reboot-required"); err != nil {
+		return false, nil
+	}
+	var pkgs []string
+	if b, err := os.ReadFile("/var/run/reboot-required.pkgs"); err == nil {
+		seen := map[string]bool{}
+		for _, line := range strings.Split(string(b), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" && !seen[line] {
+				seen[line] = true
+				pkgs = append(pkgs, line)
+			}
+		}
+	}
+	return true, pkgs
+}
+
+// aptLastApplied returns when unattended-upgrades last completed an apply, taken
+// from the mtime of the periodic stamp it rewrites after each run. Nil when it
+// has never run (fresh host, or the feature was only just enabled).
+func aptLastApplied() *time.Time {
+	for _, p := range []string{
+		"/var/lib/apt/periodic/unattended-upgrades-stamp",
+		"/var/lib/apt/periodic/upgrade-stamp",
+	} {
+		if fi, err := os.Stat(p); err == nil {
+			t := fi.ModTime().UTC()
+			return &t
+		}
+	}
+	return nil
 }
 
 // aptLockPatterns / aptRepoPatterns / aptPermPatterns are matched

--- a/panel-api/internal/api/admin_updates.go
+++ b/panel-api/internal/api/admin_updates.go
@@ -329,10 +329,14 @@ func (h *adminUpdatesHandler) autoupdateGet(c *gin.Context) {
 }
 
 type autoupdatePutBody struct {
-	AptEnabled    bool   `json:"apt_enabled"`
-	AptTime       string `json:"apt_time"`
-	JabaliEnabled bool   `json:"jabali_enabled"`
-	JabaliTime    string `json:"jabali_time"`
+	AptEnabled bool `json:"apt_enabled"`
+	// AptOptoutAcknowledged must be true to disable OS security auto-updates
+	// (JAB-353): turning them off is an intentional, recorded decision, not a
+	// silent insecure default.
+	AptOptoutAcknowledged bool   `json:"apt_optout_acknowledged"`
+	AptTime               string `json:"apt_time"`
+	JabaliEnabled         bool   `json:"jabali_enabled"`
+	JabaliTime            string `json:"jabali_time"`
 }
 
 // timeHHMM validates a 24h HH:MM string. Rejecting non-conforming input at the
@@ -361,11 +365,19 @@ func (h *adminUpdatesHandler) autoupdatePut(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_time", "details": "apt_time/jabali_time must be HH:MM (24h)"})
 		return
 	}
+	// JAB-353: disabling OS security auto-updates is an intentional, recorded
+	// decision — reject a disable that doesn't carry the acknowledgement so the
+	// UI must surface the risk + a confirm step. Re-enabling clears the opt-out.
+	if !body.AptEnabled && !body.AptOptoutAcknowledged {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ack_required", "details": "disabling OS security auto-updates requires explicit acknowledgement (apt_optout_acknowledged)"})
+		return
+	}
 	cfg := &models.UpdateAutoupdateConfig{
-		AptEnabled:    body.AptEnabled,
-		AptTime:       body.AptTime,
-		JabaliEnabled: body.JabaliEnabled,
-		JabaliTime:    body.JabaliTime,
+		AptEnabled:            body.AptEnabled,
+		AptOptoutAcknowledged: !body.AptEnabled && body.AptOptoutAcknowledged,
+		AptTime:               body.AptTime,
+		JabaliEnabled:         body.JabaliEnabled,
+		JabaliTime:            body.JabaliTime,
 	}
 	if err := h.cfg.Autoupdate.Upsert(c.Request.Context(), cfg); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "autoupdate_save"})

--- a/panel-api/internal/api/admin_updates_autoupdate_test.go
+++ b/panel-api/internal/api/admin_updates_autoupdate_test.go
@@ -1,0 +1,92 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// stubAutoupdateRepo is an in-memory UpdateAutoupdateConfigRepository for the
+// JAB-353 acknowledgement-gate tests. It starts enabled (the new default).
+type stubAutoupdateRepo struct{ cfg models.UpdateAutoupdateConfig }
+
+func newStubAutoupdate() *stubAutoupdateRepo {
+	return &stubAutoupdateRepo{cfg: models.UpdateAutoupdateConfig{ID: 1, AptEnabled: true, AptTime: "03:30", JabaliTime: "04:30"}}
+}
+func (s *stubAutoupdateRepo) Get(context.Context) (*models.UpdateAutoupdateConfig, error) {
+	c := s.cfg
+	return &c, nil
+}
+func (s *stubAutoupdateRepo) EnsureDefault(context.Context) (*models.UpdateAutoupdateConfig, error) {
+	c := s.cfg
+	return &c, nil
+}
+func (s *stubAutoupdateRepo) Upsert(_ context.Context, c *models.UpdateAutoupdateConfig) error {
+	c.ID = 1
+	s.cfg = *c
+	return nil
+}
+
+func newAutoupdateRouter(repo *stubAutoupdateRepo) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(injectAdminClaims(true))
+	api.RegisterAdminUpdatesRoutes(v1, api.AdminUpdatesHandlerConfig{Agent: agent.NewMockClient(), Autoupdate: repo})
+	return r
+}
+
+func putAutoupdate(r *gin.Engine, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/updates/autoupdate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+// JAB-353: disabling OS security auto-updates without acknowledgement is
+// refused, so it can never be turned off silently.
+func TestAutoupdate_DisableWithoutAck_Rejected(t *testing.T) {
+	repo := newStubAutoupdate()
+	r := newAutoupdateRouter(repo)
+
+	rec := putAutoupdate(r, `{"apt_enabled":false,"apt_time":"03:30","jabali_enabled":false,"jabali_time":"04:30"}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ack_required")
+	// The stored config must NOT have been flipped off.
+	assert.True(t, repo.cfg.AptEnabled, "apt must stay enabled when a disable is rejected")
+}
+
+// A disable WITH acknowledgement persists both the off state and the recorded
+// opt-out.
+func TestAutoupdate_DisableWithAck_Persists(t *testing.T) {
+	repo := newStubAutoupdate()
+	r := newAutoupdateRouter(repo)
+
+	rec := putAutoupdate(r, `{"apt_enabled":false,"apt_optout_acknowledged":true,"apt_time":"03:30","jabali_enabled":false,"jabali_time":"04:30"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, repo.cfg.AptEnabled)
+	assert.True(t, repo.cfg.AptOptoutAcknowledged, "an acknowledged opt-out must be recorded")
+}
+
+// Re-enabling clears the recorded opt-out (and needs no acknowledgement).
+func TestAutoupdate_Enable_ClearsAck(t *testing.T) {
+	repo := newStubAutoupdate()
+	repo.cfg.AptEnabled = false
+	repo.cfg.AptOptoutAcknowledged = true
+	r := newAutoupdateRouter(repo)
+
+	rec := putAutoupdate(r, `{"apt_enabled":true,"apt_time":"03:30","jabali_enabled":false,"jabali_time":"04:30"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, repo.cfg.AptEnabled)
+	assert.False(t, repo.cfg.AptOptoutAcknowledged, "re-enabling must clear the opt-out flag")
+}

--- a/panel-api/internal/db/migrations/000272_os_security_autoupdates.down.sql
+++ b/panel-api/internal/db/migrations/000272_os_security_autoupdates.down.sql
@@ -1,0 +1,9 @@
+-- Reverse JAB-353 schema additions. The force-enable data change is not
+-- reverted (there is no record of the prior per-host value, and re-disabling
+-- security updates on down-migrate would be the wrong default anyway).
+ALTER TABLE update_state
+  DROP COLUMN apt_reboot_required,
+  DROP COLUMN apt_last_applied_at;
+
+ALTER TABLE update_autoupdate_config
+  DROP COLUMN apt_optout_acknowledged;

--- a/panel-api/internal/db/migrations/000272_os_security_autoupdates.up.sql
+++ b/panel-api/internal/db/migrations/000272_os_security_autoupdates.up.sql
@@ -1,0 +1,32 @@
+-- JAB-353: OS security auto-upgrades secure-by-default.
+--
+-- The Updates Center shipped apt_enabled defaulting to FALSE, so an
+-- Internet-facing panel could sit with unattended-upgrades disabled and known
+-- OS security fixes unapplied for months. Fix:
+--   (1) record an intentional opt-out (apt_optout_acknowledged) so a deliberate
+--       "off" is distinguishable from the old silent insecure default;
+--   (2) force-enable existing hosts whose apt_enabled=0 came from that silent
+--       default — no acknowledgement column existed, so any current 0 was never
+--       an operator decision;
+--   (3) extend update_state with the OS-patch status the page now reports
+--       (last applied time, reboot-required).
+-- Fresh installs seed apt_enabled=TRUE via the app's EnsureDefault (data seeds
+-- live in the app, not migrations — the 000057 "Dirty database" scar).
+--
+-- Statement order: both DDL (ALTER) statements FIRST, the DML (UPDATE) LAST.
+-- go-sql-driver + golang-migrate run the whole file as one multi-statement
+-- Exec; a DML that is not the final statement (an UPDATE followed by more DDL)
+-- fails the batch, so the UPDATE must come after every ALTER.
+
+ALTER TABLE update_autoupdate_config
+  ADD COLUMN apt_optout_acknowledged BOOLEAN NOT NULL DEFAULT FALSE AFTER apt_enabled;
+
+ALTER TABLE update_state
+  ADD COLUMN apt_last_applied_at TIMESTAMP NULL              AFTER apt_checked_at,
+  ADD COLUMN apt_reboot_required BOOLEAN   NOT NULL DEFAULT FALSE AFTER apt_last_applied_at;
+
+-- Force-enable existing hosts: their 0 predates the acknowledgement flag, so it
+-- was the silent default, not an operator opt-out. (On a fresh install the
+-- singleton row does not exist yet — it is seeded enabled by EnsureDefault — so
+-- this UPDATE simply affects 0 rows there.)
+UPDATE update_autoupdate_config SET apt_enabled = TRUE WHERE apt_optout_acknowledged = FALSE;

--- a/panel-api/internal/models/update_center.go
+++ b/panel-api/internal/models/update_center.go
@@ -30,6 +30,12 @@ type UpdateState struct {
 	AptTotal         int        `gorm:"type:int;not null;default:0"                json:"apt_total"`
 	AptSecurity      int        `gorm:"type:int;not null;default:0"                json:"apt_security"`
 	AptCheckedAt     *time.Time `                                                  json:"apt_checked_at,omitempty"`
+	// JAB-353: OS-patch status the Updates Center reports. AptLastAppliedAt is
+	// when unattended-upgrades last ran a successful apply (stamp mtime);
+	// AptRebootRequired mirrors /var/run/reboot-required. Both are refreshed by
+	// the update-poll reconciler from system.apt_check.
+	AptLastAppliedAt  *time.Time `                                       json:"apt_last_applied_at,omitempty"`
+	AptRebootRequired bool       `gorm:"type:boolean;not null;default:false" json:"apt_reboot_required"`
 }
 
 // TableName pins GORM to the migration's spelling (no pluralisation).
@@ -59,12 +65,22 @@ func (UpdateHistory) TableName() string { return "update_history" }
 // unattended-upgrades; jabali self-update is opt-in and OFF by default because
 // a bad self-update can brick the panel (ADR-0118 decision 1).
 type UpdateAutoupdateConfig struct {
-	ID            uint8     `gorm:"type:tinyint;not null;default:1;primaryKey" json:"id"`
-	AptEnabled    bool      `gorm:"type:boolean;not null;default:false"        json:"apt_enabled"`
-	AptTime       string    `gorm:"type:varchar(5);not null;default:'03:30'"   json:"apt_time"`
-	JabaliEnabled bool      `gorm:"type:boolean;not null;default:false"        json:"jabali_enabled"`
-	JabaliTime    string    `gorm:"type:varchar(5);not null;default:'04:30'"   json:"jabali_time"`
-	UpdatedAt     time.Time `gorm:"autoUpdateTime"                              json:"updated_at"`
+	ID uint8 `gorm:"type:tinyint;not null;default:1;primaryKey" json:"id"`
+	// AptEnabled is TRUE by default for fresh installs (JAB-353) — EnsureDefault
+	// seeds it TRUE. The column default stays FALSE deliberately: it keeps the
+	// GORM zero-value semantics correct so the Upsert disable path (AptEnabled
+	// zero → column default FALSE) actually persists a disable, instead of a
+	// `default:true` tag flipping every explicit false back to true.
+	AptEnabled bool `gorm:"type:boolean;not null;default:false" json:"apt_enabled"`
+	// AptOptoutAcknowledged records that an operator INTENTIONALLY turned OS
+	// security auto-updates off (the API requires it when disabling), so a
+	// deliberate opt-out is distinguishable from the old silent insecure
+	// default. Re-enabling clears it.
+	AptOptoutAcknowledged bool      `gorm:"type:boolean;not null;default:false"      json:"apt_optout_acknowledged"`
+	AptTime               string    `gorm:"type:varchar(5);not null;default:'03:30'" json:"apt_time"`
+	JabaliEnabled         bool      `gorm:"type:boolean;not null;default:false"      json:"jabali_enabled"`
+	JabaliTime            string    `gorm:"type:varchar(5);not null;default:'04:30'" json:"jabali_time"`
+	UpdatedAt             time.Time `gorm:"autoUpdateTime"                            json:"updated_at"`
 }
 
 // TableName pins GORM to the migration's spelling.

--- a/panel-api/internal/reconciler/update_poll_reconciler.go
+++ b/panel-api/internal/reconciler/update_poll_reconciler.go
@@ -25,8 +25,10 @@ type updateCheckView struct {
 }
 
 type aptCheckView struct {
-	Total         int `json:"total"`
-	SecurityTotal int `json:"security_total"`
+	Total          int        `json:"total"`
+	SecurityTotal  int        `json:"security_total"`
+	RebootRequired bool       `json:"reboot_required"`
+	LastAppliedAt  *time.Time `json:"last_applied_at"`
 }
 
 func (r *Reconciler) reconcileUpdatePoll(ctx context.Context) {
@@ -67,6 +69,8 @@ func (r *Reconciler) reconcileUpdatePoll(ctx context.Context) {
 		return
 	}
 	_ = r.updateState.UpsertApt(ctx, av.Total, av.SecurityTotal, time.Now())
+	// JAB-353: refresh the OS-patch status the Updates Center reports.
+	_ = r.updateState.UpsertAptStatus(ctx, av.LastAppliedAt, av.RebootRequired)
 
 	// Notify only when security updates newly appear or increase, so we don't
 	// re-alert every 6h for the same standing count.

--- a/panel-api/internal/repository/update_center_repository.go
+++ b/panel-api/internal/repository/update_center_repository.go
@@ -24,6 +24,9 @@ type UpdateStateRepository interface {
 	EnsureDefault(ctx context.Context) (*models.UpdateState, error)
 	UpsertJabali(ctx context.Context, behind int, sha string, at time.Time) error
 	UpsertApt(ctx context.Context, total, security int, at time.Time) error
+	// UpsertAptStatus refreshes the JAB-353 OS-patch status fields (last applied
+	// time, reboot-required) independently of the upgradable-package counts.
+	UpsertAptStatus(ctx context.Context, lastApplied *time.Time, rebootRequired bool) error
 }
 
 type updateStateRepo struct{ db *gorm.DB }
@@ -76,6 +79,19 @@ func (r *updateStateRepo) UpsertApt(ctx context.Context, total, security int, at
 			"apt_total":      total,
 			"apt_security":   security,
 			"apt_checked_at": at,
+		}).Error
+}
+
+func (r *updateStateRepo) UpsertAptStatus(ctx context.Context, lastApplied *time.Time, rebootRequired bool) error {
+	if _, err := r.EnsureDefault(ctx); err != nil {
+		return err
+	}
+	// Map-based update writes both keys explicitly (a nil lastApplied clears the
+	// column, and a false rebootRequired is written, not skipped as a zero value).
+	return r.db.WithContext(ctx).Model(&models.UpdateState{}).Where("id = ?", 1).
+		Updates(map[string]any{
+			"apt_last_applied_at": lastApplied,
+			"apt_reboot_required": rebootRequired,
 		}).Error
 }
 
@@ -160,9 +176,13 @@ func NewUpdateAutoupdateConfigRepository(db *gorm.DB) UpdateAutoupdateConfigRepo
 
 func (r *updateAutoupdateConfigRepo) EnsureDefault(ctx context.Context) (*models.UpdateAutoupdateConfig, error) {
 	row := &models.UpdateAutoupdateConfig{ID: 1}
+	// JAB-353: fresh installs seed apt_enabled=TRUE (OS security auto-upgrades on
+	// by default). AptEnabled:true is a non-zero attr, so it lands in the INSERT
+	// on first create; existing rows are untouched (FirstOrCreate) and were
+	// force-enabled by migration 000272.
 	if err := r.db.WithContext(ctx).
 		Where(models.UpdateAutoupdateConfig{ID: 1}).
-		Attrs(models.UpdateAutoupdateConfig{ID: 1, AptTime: "03:30", JabaliTime: "04:30"}).
+		Attrs(models.UpdateAutoupdateConfig{ID: 1, AptEnabled: true, AptTime: "03:30", JabaliTime: "04:30"}).
 		FirstOrCreate(row).Error; err != nil {
 		return nil, err
 	}
@@ -184,6 +204,6 @@ func (r *updateAutoupdateConfigRepo) Upsert(ctx context.Context, c *models.Updat
 	c.ID = 1
 	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"apt_enabled", "apt_time", "jabali_enabled", "jabali_time"}),
+		DoUpdates: clause.AssignmentColumns([]string{"apt_enabled", "apt_optout_acknowledged", "apt_time", "jabali_enabled", "jabali_time"}),
 	}).Create(c).Error
 }

--- a/panel-ui/src/hooks/useSystemUpdates.ts
+++ b/panel-ui/src/hooks/useSystemUpdates.ts
@@ -184,6 +184,9 @@ export interface UpdateState {
   apt_total: number;
   apt_security: number;
   apt_checked_at?: string;
+  // JAB-353 OS-patch status.
+  apt_last_applied_at?: string;
+  apt_reboot_required?: boolean;
 }
 
 export interface UpdateHistoryRow {
@@ -200,6 +203,9 @@ export interface UpdateHistoryRow {
 
 export interface AutoupdateConfig {
   apt_enabled: boolean;
+  // JAB-353: must be sent true to disable OS security auto-updates. The API
+  // rejects a disable without it; the UI collects it via a confirm modal.
+  apt_optout_acknowledged?: boolean;
   apt_time: string;
   jabali_enabled: boolean;
   jabali_time: string;

--- a/panel-ui/src/shells/admin/Dashboard.tsx
+++ b/panel-ui/src/shells/admin/Dashboard.tsx
@@ -15,7 +15,7 @@ import { StatCard } from "../../components/StatCard";
 import { useListQuery } from "../../hooks/useQueries";
 import { useServerStatus } from "../../hooks/useServerStatus";
 import { useServerCapabilities } from "../../hooks/useServerCapabilities";
-import { UpdatesPendingBanner } from "./updates/UpdatesPendingBanner";
+import { UpdatesPendingBanner, OsSecurityUpdatesBanner } from "./updates/UpdatesPendingBanner";
 
 interface UserRow {
   id: string;
@@ -112,6 +112,7 @@ export const Dashboard = () => {
           production incidents came from boxes silently running builds that
           predated an already-merged fix. */}
       <UpdatesPendingBanner />
+      <OsSecurityUpdatesBanner />
       <Row gutter={[16, 16]} style={{ marginBottom: 16 }}>
         <Col xs={24} sm={8}>
           <StatCard

--- a/panel-ui/src/shells/admin/updates/OsSecurityUpdatesBanner.test.tsx
+++ b/panel-ui/src/shells/admin/updates/OsSecurityUpdatesBanner.test.tsx
@@ -1,0 +1,79 @@
+// JAB-353: the dashboard must persistently surface a bad OS security-patch
+// posture — auto-updates off, a pending security count, or a reboot needed —
+// separately from the Jabali-panel-behind banner. As with that banner, the
+// cases that matter are the SILENT ones: it must not appear while loading or on
+// a query error (a permanent false banner trains operators to ignore it).
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OsSecurityUpdatesBanner } from "./UpdatesPendingBanner";
+
+const mockState = vi.fn();
+const mockAuto = vi.fn();
+
+vi.mock("../../../hooks/useSystemUpdates", () => ({
+  useUpdateState: () => mockState(),
+  useAutoupdateConfig: () => mockAuto(),
+}));
+
+const renderBanner = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <OsSecurityUpdatesBanner />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const stateOK = (over: Record<string, unknown> = {}) => ({
+  data: { jabali_behind: 0, apt_total: 0, apt_security: 0, apt_reboot_required: false, ...over },
+  isLoading: false,
+  isError: false,
+});
+
+describe("OsSecurityUpdatesBanner (JAB-353)", () => {
+  beforeEach(() => {
+    mockState.mockReset();
+    mockAuto.mockReset();
+    mockAuto.mockReturnValue({ data: { apt_enabled: true }, isLoading: false });
+  });
+
+  it("is silent when auto-updates are on, nothing pending, no reboot", () => {
+    mockState.mockReturnValue(stateOK());
+    const { container } = renderBanner();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("is silent while loading and on query error", () => {
+    mockState.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    expect(renderBanner().container).toBeEmptyDOMElement();
+    mockState.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    expect(renderBanner().container).toBeEmptyDOMElement();
+  });
+
+  it("shows a hard warning when OS security auto-updates are OFF", () => {
+    mockState.mockReturnValue(stateOK({ apt_security: 5 }));
+    mockAuto.mockReturnValue({ data: { apt_enabled: false }, isLoading: false });
+    renderBanner();
+    expect(screen.getByText(/OS security auto-updates are OFF/i)).toBeInTheDocument();
+    expect(screen.getByText(/5 pending/i)).toBeInTheDocument();
+    expect(screen.getByText(/never been applied/i)).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/jabali-admin/updates");
+  });
+
+  it("warns when a reboot is required even though updates are enabled", () => {
+    mockState.mockReturnValue(stateOK({ apt_reboot_required: true, apt_last_applied_at: "2026-08-20T03:30:00Z" }));
+    renderBanner();
+    expect(screen.getByText(/Reboot required/i)).toBeInTheDocument();
+  });
+
+  it("warns when security updates are pending while enabled", () => {
+    mockState.mockReturnValue(stateOK({ apt_security: 3 }));
+    renderBanner();
+    expect(screen.getByText(/3 OS security updates pending/i)).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
+++ b/panel-ui/src/shells/admin/updates/SystemUpdatesPage.tsx
@@ -6,7 +6,7 @@
 // so the page shows real numbers immediately instead of empty placeholders.
 import { useTranslation } from "react-i18next";
 import { useEffect, useState, type CSSProperties } from "react";
-import { Alert, Button, Card, Checkbox, Collapse, Col, Empty, Row, Segmented, Space, Spin, Switch, Table, Tag, TimePicker, Timeline, Tooltip, Typography } from "antd";
+import { Alert, Button, Card, Checkbox, Collapse, Col, Empty, Modal, Row, Segmented, Space, Spin, Switch, Table, Tag, TimePicker, Timeline, Tooltip, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import dayjs from "dayjs";
 
@@ -866,14 +866,32 @@ function SystemPackagesCard({ check }: { check: ReturnType<typeof useAptCheck> }
 function AutomaticUpdatesCard() {
   const { t } = useTranslation();
   const { data, isLoading } = useAutoupdateConfig();
+  const state = useUpdateState();
   const save = useUpdateAutoupdate();
   const [draft, setDraft] = useState<AutoupdateConfig | null>(null);
+  const [ackOpen, setAckOpen] = useState(false);
+  const [ackChecked, setAckChecked] = useState(false);
   const cfg = draft ?? data ?? null;
   const dirty = draft !== null && data !== undefined && JSON.stringify(draft) !== JSON.stringify(data);
 
   const patch = (p: Partial<AutoupdateConfig>) => {
     if (!cfg) return;
     setDraft({ ...cfg, ...p });
+  };
+  // JAB-353: turning OS security updates OFF is an intentional, recorded
+  // decision — never a silent flip. Enabling clears the opt-out; disabling opens
+  // a confirm modal and only then records apt_optout_acknowledged.
+  const onAptToggle = (v: boolean) => {
+    if (v) {
+      patch({ apt_enabled: true, apt_optout_acknowledged: false });
+    } else {
+      setAckChecked(false);
+      setAckOpen(true);
+    }
+  };
+  const confirmDisable = () => {
+    patch({ apt_enabled: false, apt_optout_acknowledged: true });
+    setAckOpen(false);
   };
   const onSave = async () => {
     if (!cfg) return;
@@ -885,6 +903,10 @@ function AutomaticUpdatesCard() {
       feedback.message.error(e instanceof Error ? e.message : "save failed");
     }
   };
+
+  const lastApplied = state.data?.apt_last_applied_at;
+  const rebootRequired = state.data?.apt_reboot_required;
+  const pendingSecurity = state.data?.apt_security ?? 0;
 
   return (
     <Card
@@ -900,12 +922,39 @@ function AutomaticUpdatesCard() {
         <div style={{ textAlign: "center", padding: 24 }}><Spin /></div>
       ) : (
         <Space direction="vertical" size={16} style={{ width: "100%" }}>
+          {/* JAB-353: persistent, high-visibility warning while OS security
+              auto-updates are OFF — an operator opt-out is deliberate but must
+              stay visible. */}
+          {!cfg.apt_enabled && (
+            <Alert
+              type="error"
+              showIcon
+              message="OS security auto-updates are OFF"
+              description={
+                pendingSecurity > 0
+                  ? `${pendingSecurity} security update${pendingSecurity === 1 ? "" : "s"} pending. This host will not apply OS security patches automatically.`
+                  : "This host will not apply OS security patches automatically, so known vulnerabilities can remain unpatched."
+              }
+            />
+          )}
+          {rebootRequired && (
+            <Alert type="warning" showIcon message="Reboot required to finish applying updates" />
+          )}
           <Row align="middle" gutter={[12, 12]}>
             <Col flex="auto">
               <Text strong>OS security updates</Text>
               <div>
                 <Text type="secondary" style={{ fontSize: 12 }}>
-                  Apply Debian security patches automatically via unattended-upgrades.
+                  Apply Debian/Ubuntu security patches automatically via unattended-upgrades. Separate from the Jabali panel self-update below.
+                </Text>
+              </div>
+              <div style={{ marginTop: 4 }}>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  Last applied:{" "}
+                  {lastApplied ? dayjs(lastApplied).format("MMM D, YYYY HH:mm") : "never"}
+                  {typeof pendingSecurity === "number" && pendingSecurity > 0 && (
+                    <> · <Tag color="red" style={{ marginInlineStart: 4 }}>{pendingSecurity} security pending</Tag></>
+                  )}
                 </Text>
               </div>
             </Col>
@@ -920,9 +969,30 @@ function AutomaticUpdatesCard() {
               />
             </Col>
             <Col>
-              <Switch checked={cfg.apt_enabled} onChange={(v) => patch({ apt_enabled: v })} />
+              <Switch checked={cfg.apt_enabled} onChange={onAptToggle} />
             </Col>
           </Row>
+
+          <Modal
+            open={ackOpen}
+            title="Disable OS security auto-updates?"
+            okText="Disable security updates"
+            okButtonProps={{ danger: true, disabled: !ackChecked }}
+            onOk={confirmDisable}
+            onCancel={() => setAckOpen(false)}
+          >
+            <Space direction="vertical" size={12}>
+              <Text>
+                Turning this off means this Internet-facing host will <Text strong>not</Text> apply
+                Debian/Ubuntu security patches automatically. Known vulnerabilities in the kernel,
+                OpenSSH, OpenSSL, and other exposed components can remain exploitable until you patch
+                manually. A Jabali panel update does <Text strong>not</Text> apply OS packages.
+              </Text>
+              <Checkbox checked={ackChecked} onChange={(e) => setAckChecked(e.target.checked)}>
+                I understand the risk and intentionally want OS security auto-updates off.
+              </Checkbox>
+            </Space>
+          </Modal>
 
           <Row align="middle" gutter={[12, 12]}>
             <Col flex="auto">

--- a/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.tsx
+++ b/panel-ui/src/shells/admin/updates/UpdatesPendingBanner.tsx
@@ -18,6 +18,7 @@
 //   auto-update OFF — warning. Nothing will fix this on its own.
 //   auto-update ON  — info. It converges tonight; say when, and stop nagging.
 import { Alert, Button, Space, Typography } from "antd";
+import dayjs from "dayjs";
 import { Link } from "react-router";
 import { useTranslation } from "react-i18next";
 
@@ -60,6 +61,66 @@ export const UpdatesPendingBanner = () => {
               {enabled
                 ? t("dashboard.updates_pending.action_auto")
                 : t("dashboard.updates_pending.action")}
+            </Button>
+          </Link>
+        </Space>
+      }
+    />
+  );
+};
+
+// OsSecurityUpdatesBanner — JAB-353. A dashboard-level, persistent warning for
+// the OS security-patch posture, distinct from the Jabali-panel-behind banner
+// above (OS packages and the panel self-update are governed separately). It
+// surfaces three cases, in severity order:
+//   apt auto-updates OFF        — error. The host will not self-patch.
+//   reboot required             — warning. Updates applied but not active.
+//   security updates pending    — warning. Fixes are waiting to apply.
+// Silent when auto-updates are on, nothing is pending, and no reboot is due.
+export const OsSecurityUpdatesBanner = () => {
+  const state = useUpdateState();
+  const auto = useAutoupdateConfig();
+
+  if (state.isLoading || state.isError || auto.isLoading) return null;
+
+  const enabled = auto.data?.apt_enabled ?? true;
+  const pendingSecurity = state.data?.apt_security ?? 0;
+  const rebootRequired = state.data?.apt_reboot_required ?? false;
+  const lastApplied = state.data?.apt_last_applied_at;
+
+  if (enabled && pendingSecurity === 0 && !rebootRequired) return null;
+
+  const disabled = !enabled;
+  const message = disabled
+    ? "OS security auto-updates are OFF"
+    : rebootRequired
+      ? "Reboot required to finish applying OS security updates"
+      : `${pendingSecurity} OS security update${pendingSecurity === 1 ? "" : "s"} pending`;
+
+  const patchAge = lastApplied
+    ? `Last applied ${dayjs(lastApplied).format("MMM D, YYYY")}.`
+    : "OS security patches have never been applied automatically on this host.";
+
+  return (
+    <Alert
+      type={disabled ? "error" : "warning"}
+      showIcon
+      style={{ marginBottom: 16 }}
+      message={message}
+      description={
+        <Space direction="vertical" size={8} style={{ width: "100%" }}>
+          <Typography.Text>
+            {disabled
+              ? `This Internet-facing host will not apply OS security patches automatically${
+                  pendingSecurity > 0 ? ` (${pendingSecurity} pending)` : ""
+                }. ${patchAge} A Jabali panel update does not apply OS packages.`
+              : rebootRequired
+                ? `Security packages are installed but a reboot is needed to activate them (e.g. kernel/libc). ${patchAge}`
+                : `${patchAge} They apply automatically in the maintenance window; review them now if urgent.`}
+          </Typography.Text>
+          <Link to="/jabali-admin/updates">
+            <Button size="small" type="primary" danger={disabled}>
+              Review OS updates
             </Button>
           </Link>
         </Space>


### PR DESCRIPTION
## JAB-353 [Security][High] — OS security upgrades ship disabled

### Problem
The Updates Center defaulted `apt_enabled` to FALSE and actively rendered
`APT::Periodic::Unattended-Upgrade "0"` + a disabled `apt-daily-upgrade.timer`.
An Internet-facing panel could therefore sit with known OS security fixes
(kernel, OpenSSH, OpenSSL, glibc, …) unapplied indefinitely. A Jabali
self-update does not apply OS packages, so an apparently current panel stayed
materially unpatched. On the test box: **67 pending security updates**.

### Fix — secure by default, opt-out recorded, reported
- **Fresh installs**: `EnsureDefault` seeds `apt_enabled=TRUE` (security-only via
  the stock unattended-upgrades allowed-origins). apt (OS security) and jabali
  (app self-update) remain **separate toggles**, so non-security feature updates
  are governed independently.
- **Existing hosts**: migration `000272` force-enables `apt_enabled` where the
  new `apt_optout_acknowledged` flag is false — a current `0` predates that flag,
  so it was the silent default, never an operator decision. *(Statement order:
  both `ALTER`s first, the `UPDATE` last — a DML that isn't the final statement
  in a golang-migrate multi-statement Exec fails the batch; caught on the box.)*
- **Intentional opt-out**: disabling now requires `apt_optout_acknowledged`
  (API returns `ack_required` otherwise); the UI collects it via a confirm modal.
  Re-enabling clears it. No silent insecure default.
- **Reporting**: `system.apt_check` now also returns `reboot_required` (+pkgs)
  and `last_applied_at` (unattended-upgrades stamp mtime); the poll reconciler
  persists them into `update_state` next to the existing pending-security count.
  The Update Center card shows last-applied + pending security + a reboot badge;
  `update_history` already carries failure state.
- **Persistent dashboard warning**: a new `OsSecurityUpdatesBanner` surfaces
  auto-updates-OFF (error), reboot-required, or pending-security (warning),
  distinct from the Jabali-panel-behind banner. Converge of the periodic flags +
  timer is the existing `system.autoupdate_apply` reconcile, so it applies on
  install, update, and settings changes.

### Acceptance criteria
- ✅ Fresh install enables + schedules security-only unattended upgrades.
- ✅ Non-security feature updates governed separately (apt vs jabali toggles).
- ✅ Update Center reports last OS patch time, pending security count, failure
  state (history), and reboot requirement.
- ✅ Disabling requires explicit confirmation + produces a persistent dashboard
  warning.
- ✅ Upgrade/repair converges timer + periodic flags (reconciler every tick) +
  migration force-enables; tests cover enabled/disabled transitions.

### Verification (.86, then reverted to baseline to avoid migration-ahead drift)
Migration force-enabled `apt_enabled` 0→1; the reconciler flipped
`20auto-upgrades` to `"1"/"1"` and enabled `apt-daily-upgrade.timer` (03:30); the
poll populated `apt_security=67` + reboot/last-applied into `update_state`. Ack
gate + banner-transition tests pass; `tsc -b`, `go build`/`vet`, vitest green.
