### PR TITLE
test(db): repair the integration build tag (dead RefreshToken test + migrateToExact lock)

### DIFF
--- a/panel-api/internal/db/dirty264_integration_test.go
+++ b/panel-api/internal/db/dirty264_integration_test.go
@@ -29,19 +29,24 @@ func ft264DSN(t *testing.T) string {
 	return dsn
 }
 
-// migrateToExact drops everything and migrates to exactly `version`, leaving the
-// schema clean at that version with nothing above it applied.
+// migrateToExact wipes the schema and migrates to exactly `version`, leaving it
+// clean at that version with nothing above applied. Two golang-migrate quirks
+// force the shape: (1) after Drop() the SAME migrator can't Migrate — it reads
+// the now-gone schema_migrations before recreating it — so a fresh migrator is
+// needed; (2) the advisory GET_LOCK is per-connection, so the first migrator
+// must be CLOSED (releasing the lock) before the second opens, or the second
+// dies on "can't acquire lock".
 func migrateToExact(t *testing.T, dsn string, version uint) {
 	t.Helper()
-	m, closeFn, err := newMigrator(dsn)
+	m1, close1, err := newMigrator(dsn)
 	require.NoError(t, err)
-	defer closeFn()
-	// Drop wipes all objects + the version table, so the Migrate below starts
-	// from zero regardless of prior test state.
-	require.NoError(t, m.Drop())
-	m2, closeFn2, err := newMigrator(dsn)
+	dropErr := m1.Drop()
+	close1() // release the lock + connection before the next migrator opens
+	require.NoError(t, dropErr)
+
+	m2, close2, err := newMigrator(dsn)
 	require.NoError(t, err)
-	defer closeFn2()
+	defer close2()
 	require.NoError(t, m2.Migrate(version))
 }
 

--- a/panel-api/internal/db/integration_test.go
+++ b/panel-api/internal/db/integration_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,63 +138,10 @@ func TestIntegration_UserCRUD(t *testing.T) {
 	assert.ErrorIs(t, err, repository.ErrNotFound)
 }
 
-func TestIntegration_RefreshTokenRotateSerialises(t *testing.T) {
-	dsn := testDSN(t)
-	resetSchema(t, dsn)
-
-	gdb, err := db.Open(db.Options{DSN: dsn, Silent: true})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		sqlDB, _ := gdb.DB()
-		_ = sqlDB.Close()
-	})
-
-	users := repository.NewUserRepository(gdb)
-	tokens := repository.NewRefreshTokenRepository(gdb)
-	ctx := context.Background()
-
-	u := &models.User{
-		ID:           ids.NewULID(),
-		Email:        "rtr-" + ids.NewULID() + "@example.com",
-		PasswordHash: "hash",
-	}
-	require.NoError(t, users.Create(ctx, u))
-
-	oldHash := "a" + ids.NewULID() // 27 chars — we just need something unique
-	oldTok := &models.RefreshToken{
-		ID:        ids.NewULID(),
-		UserID:    u.ID,
-		DeviceID:  "dev",
-		TokenHash: oldHash,
-		ExpiresAt: time.Now().UTC().Add(time.Hour),
-		CreatedAt: time.Now().UTC(),
-	}
-	require.NoError(t, tokens.Create(ctx, oldTok))
-
-	// First rotate succeeds.
-	newTok := &models.RefreshToken{
-		ID:        ids.NewULID(),
-		UserID:    u.ID,
-		DeviceID:  "dev",
-		TokenHash: "n" + ids.NewULID(),
-		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
-		CreatedAt: time.Now().UTC(),
-	}
-	require.NoError(t, tokens.Rotate(ctx, oldHash, newTok))
-
-	// Second rotate of the same old hash must fail (already revoked).
-	second := &models.RefreshToken{
-		ID:        ids.NewULID(),
-		UserID:    u.ID,
-		DeviceID:  "dev",
-		TokenHash: "z" + ids.NewULID(),
-		ExpiresAt: time.Now().UTC().Add(24 * time.Hour),
-		CreatedAt: time.Now().UTC(),
-	}
-	err = tokens.Rotate(ctx, oldHash, second)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, repository.ErrNotFound)
-}
+// (Removed TestIntegration_RefreshTokenRotateSerialises: the RefreshToken model
+// + repository no longer exist, so the test referenced deleted symbols and broke
+// the `integration` build tag on main. Refresh-token rotation is gone from the
+// codebase; nothing to cover here.)
 
 func TestIntegration_DSN_InvalidFailsFast(t *testing.T) {
 	_ = testDSN(t) // skip unless integration env configured


### PR DESCRIPTION
## What

Makes `go test -tags integration ./panel-api/internal/db/` compile and run
again. Two independent fixes, no production code touched.

### 1. Drop the dead RefreshToken integration test

`TestIntegration_RefreshTokenRotateSerialises` referenced `models.RefreshToken`
and `repository.NewRefreshTokenRepository`, both **deleted** from the codebase —
so the whole `db` integration test binary failed to compile on `main` (surfaced
while box-verifying #1094). Refresh-token rotation no longer exists; the test is
removed along with its now-unused `time` import. The other integration tests
(MigrateAndPing, UserCRUD, DSN_InvalidFailsFast) are untouched.

### 2. Fix `migrateToExact` in `dirty264_integration_test.go`

Added in #1212, but the working fix landed *after* that PR merged — so `main`
has the broken version. Two golang-migrate quirks:
- after `Drop()` the **same** migrator can't `Migrate()` (it reads the now-gone
  `schema_migrations` before recreating it),
- the advisory `GET_LOCK` is **per-connection**, so the first migrator must be
  **closed** before the second opens, or it deadlocks on "can't acquire lock".

Fixed to two migrators with an explicit close between them — the version that
passed against real MariaDB during the #1094 box-verify (both
`BrokenFtp264` tests green).

## Test

`go build` + `go vet` clean; `go test -tags integration -run xxxNONE
./panel-api/internal/db/` compiles (previously failed). The default
(non-integration) test lane is unaffected.