### PR TITLE
feat(apparmor): auto-promote soak-clean profiles to enforce via a daily timer (JAB-349, partial)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11795,6 +11795,12 @@ install_apparmor() {
   else
     _ok "AppArmor profiles applied ($(aa-status 2>/dev/null | grep -c 'jabali-') jabali profiles loaded)"
   fi
+
+  # JAB-349: install the daily auto-promotion timer so soak-clean complain
+  # profiles flip to enforce on their own. Reached on every install AND update
+  # (install_apparmor runs on both). Only meaningful when AppArmor is active —
+  # the early returns above bail before here on kernels without it.
+  install_apparmor_flip_timer
 }
 
 # apply_apparmor_system_profiles activates distro-supplied profiles for
@@ -11926,6 +11932,48 @@ cleanup_apparmor_legacy() {
   if command -v aa-remove-unknown >/dev/null 2>&1; then
     aa-remove-unknown >/dev/null 2>&1 || true
   fi
+}
+
+# install_apparmor_flip_timer — JAB-349. Without this, jabali profiles load in
+# complain mode and stay there forever unless an operator manually runs
+# `jabali apparmor flip-mature`, so an Internet-facing panel keeps
+# audit-only (non-enforcing) MAC indefinitely. This daily timer promotes
+# SOAK-CLEAN complain profiles to enforce automatically.
+#
+# It is SAFE to auto-run: `jabali apparmor flip-mature` flips ONLY a profile
+# with ZERO AppArmor DENIED events in the soak window and SKIPS any profile
+# still denying (surfacing the pending denials) — so it can never enforce a
+# profile that would then EACCES its daemon (the #705 crash-loop). Mirrors the
+# per-user-egress flip-mature timer. Idempotent; runs on every install + update
+# (install_apparmor is on both paths).
+install_apparmor_flip_timer() {
+  cat >/etc/systemd/system/jabali-apparmor-flip-mature.service <<'UNIT'
+[Unit]
+Description=Flip soak-clean jabali AppArmor profiles from complain to enforce (JAB-349)
+After=jabali-agent.service jabali-panel.service
+Requires=jabali-agent.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/jabali apparmor flip-mature --soak-days 7
+User=root
+UNIT
+  cat >/etc/systemd/system/jabali-apparmor-flip-mature.timer <<'UNIT'
+[Unit]
+Description=Daily promotion of soak-clean jabali AppArmor profiles to enforce (JAB-349)
+
+[Timer]
+OnCalendar=*-*-* 04:10:00
+Persistent=true
+RandomizedDelaySec=15min
+
+[Install]
+WantedBy=timers.target
+UNIT
+  systemctl daemon-reload >/dev/null 2>&1 || true
+  systemctl enable --now jabali-apparmor-flip-mature.timer >/dev/null 2>&1 \
+    && _ok "AppArmor auto-promotion timer enabled (soak-clean profiles flip to enforce daily)" \
+    || _warn "could not enable jabali-apparmor-flip-mature.timer — profiles stay in their current mode until 'jabali apparmor flip-mature' is run"
 }
 
 apply_apparmor_system_profiles() {

--- a/install/tests/test_apparmor_flip_timer.sh
+++ b/install/tests/test_apparmor_flip_timer.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# install/tests/test_apparmor_flip_timer.sh — regression coverage for JAB-349
+# (AppArmor stays non-enforcing indefinitely).
+#
+# jabali daemon profiles load in COMPLAIN mode (audit-only) on fresh installs
+# and stay there forever unless an operator manually runs
+# `jabali apparmor flip-mature`. So an Internet-facing panel keeps
+# non-enforcing MAC for the life of the box. This timer promotes SOAK-CLEAN
+# complain profiles to enforce automatically.
+#
+# It is safe to auto-run because `jabali apparmor flip-mature` flips ONLY a
+# profile with ZERO AppArmor denials in the soak window and SKIPS any profile
+# still denying (which would EACCES its daemon under enforce — the #705
+# crash-loop). This test pins that the timer is shipped, wired into both the
+# fresh-install and update paths, and drives the soak-aware command.
+#
+# Run from repo root:
+#     bash install/tests/test_apparmor_flip_timer.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# --- 1. The installer function is defined and creates the .timer + .service. ---
+fn_src=$(awk '/^install_apparmor_flip_timer\(\) \{$/,/^\}$/' install.sh)
+if [[ -z "$fn_src" ]]; then
+  echo "FAIL: install_apparmor_flip_timer not defined in install.sh"
+  exit 1
+fi
+if ! grep -q 'jabali-apparmor-flip-mature.timer' <<<"$fn_src"; then
+  echo "FAIL: function does not create jabali-apparmor-flip-mature.timer"
+  fail=1
+fi
+if ! grep -q 'jabali-apparmor-flip-mature.service' <<<"$fn_src"; then
+  echo "FAIL: function does not create jabali-apparmor-flip-mature.service"
+  fail=1
+fi
+
+# --- 2. The service drives the SOAK-AWARE command (never a bare --force). ---
+if ! grep -qE 'jabali apparmor flip-mature --soak-days [0-9]+' <<<"$fn_src"; then
+  echo "FAIL: service must run 'jabali apparmor flip-mature --soak-days N' (soak-clean only)"
+  fail=1
+fi
+if grep -q -- '--force' <<<"$fn_src"; then
+  echo "FAIL: the timer must NOT pass --force — that would enforce still-denying profiles and crash-loop the daemon"
+  fail=1
+fi
+# It must enable the timer.
+if ! grep -qE 'systemctl enable .*jabali-apparmor-flip-mature.timer' <<<"$fn_src"; then
+  echo "FAIL: function must enable the timer"
+  fail=1
+fi
+
+# --- 3. install_apparmor calls it (fresh install path). ---
+ia_src=$(awk '/^install_apparmor\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'install_apparmor_flip_timer' <<<"$ia_src"; then
+  echo "FAIL: install_apparmor does not call install_apparmor_flip_timer"
+  fail=1
+fi
+
+# --- 4. The update path re-runs install_apparmor, so the timer reaches
+#        existing hosts too (install_apparmor is idempotent). ---
+upd_src=$(awk '/^provision_new_software\(\) \{$/,/^\}$/' install.sh)
+if ! grep -q 'install_apparmor' <<<"$upd_src"; then
+  echo "FAIL: provision_new_software (jabali update) does not run install_apparmor — existing hosts never get the auto-promotion timer"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then exit 1; fi
+echo "PASS: AppArmor auto-promotion timer shipped + soak-safe + on both install paths (JAB-349)"


### PR DESCRIPTION
## JAB-349 [Security][Medium] — AppArmor stays non-enforcing (partial: auto-promotion)

Delivers the lifecycle half of JAB-349. The webmail-confinement half is a
documented follow-up (see below).

### Problem
jabali AppArmor daemon profiles load in **complain** mode (audit-only) on fresh
installs and stay there forever unless an operator manually runs
`jabali apparmor flip-mature` — so an Internet-facing panel keeps non-enforcing
MAC for the life of the box. Only the per-user-egress flip-mature was
timer-scheduled; the AppArmor one wasn't.

### Fix
Add `jabali-apparmor-flip-mature.{service,timer}` (daily 04:10), mirroring the
egress timer, installed + enabled from `install_apparmor` — which runs on **both**
fresh install and `jabali update`, so existing hosts get it too.

**Safe to auto-run:** `jabali apparmor flip-mature` flips ONLY a profile with
zero AppArmor DENIED events in the `--soak-days` window and SKIPS any profile
still denying (surfacing its pending denials), so it can never enforce a profile
that would then EACCES its daemon (the #705 crash-loop). The timer never passes
`--force`. The complementary **no-downgrade guard already exists** in
`apply_apparmor_profiles` (re-applies `aa-enforce` when a profile was already
enforce), so update/repair doesn't demote an operator promotion.

### Acceptance criteria (this PR)
- ✅ Soak-clean profiles **explicitly/automatically transition to enforce** (the
  timer), with the CLI surfacing status + skipped-with-denials.
- ✅ Profiles with denials **remain complain** (flip-mature skips them).
- ✅ Update/repair **never downgrades** an enforcing profile (existing guard).
- Deferred → follow-up: webmail/php/mail process **attachment** + label smoke
  test (needs the webmail profile soak below).

### Verification (.86, reverted to baseline)
Timer enables + schedules; `jabali apparmor flip-mature --soak-days 7` runs
soak-safely ("no complain-mode jabali profiles" — .86's are already enforce).
New `install/tests/test_apparmor_flip_timer.sh` pins the timer is shipped,
soak-aware (never `--force`), and wired into both install paths. `bash -n` +
phantom-lint green.

### Follow-up (filed separately) — webmail confinement
`jabali-bulwark` is path-attached to `/usr/local/bin/jabali-bulwark`, but the
real process is `/usr/bin/node /opt/jabali-webmail/server-unix.js`, so it runs
**unconfined**. Attaching it needs `AppArmorProfile=` (NoNewPrivileges blocks
`aa-exec`) + profile development for the `/opt/jabali-webmail` layout; node
currently SIGABRTs under the systemd-applied profile even in complain mode
(suspected abi-pin/namespace interaction). Full diagnosis is on the JAB-349
ticket.
