### PR TITLE
test(host-safety): make internal/certbot + internal/pdns exec test-safe (GH #994/#1160)

### DIFF
--- a/panel-agent/internal/certbot/exec_seam.go
+++ b/panel-agent/internal/certbot/exec_seam.go
@@ -1,0 +1,56 @@
+package certbot
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Test-safety for GH #994 / #1160.
+//
+// internal/certbot shells out to `certbot` (see runner.go), which for a real
+// issuance runs `certbot certonly ...` — a live ACME order. The commands seam
+// (#1159) can't cover this because certbot has its own exec, and it's reached
+// TRANSITIVELY: a commands test that calls an SSL handler → certbot.NewRunner()
+// would hit real certbot/ACME on any box where it's installed. A per-package
+// TestMain can't fix that (it can't reach this package's state from the commands
+// test binary), so the default binary is chosen at NewRunner time based on
+// testing.Testing(): under `go test`, unless the operator opts into real host
+// mutation, NewRunner points Binary at a harmless no-op stub. Production
+// binaries (testing.Testing() == false) always get the real `certbot`. Tests
+// that need real certbot output inject their own Binary after NewRunner (as
+// runner_test.go does), which overrides this default.
+
+// defaultCertbotBinary is "certbot" in production, or a no-op stub under tests
+// (unless JABALI_ALLOW_HOST_MUTATION=1).
+func defaultCertbotBinary() string {
+	if testing.Testing() && os.Getenv("JABALI_ALLOW_HOST_MUTATION") != "1" {
+		return certbotTestStub()
+	}
+	return "certbot"
+}
+
+var (
+	certbotStubOnce sync.Once
+	certbotStubPath string
+)
+
+// certbotTestStub writes (once) a shell script that drains stdin and exits 0 with
+// no output, and returns its path. It stands in for `certbot` so a test that
+// gets past validation reaches a harmless binary instead of real ACME. Tests
+// asserting parsed certbot output inject their own fake Binary instead.
+func certbotTestStub() string {
+	certbotStubOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "jabali-certbot-stub-")
+		if err != nil {
+			panic("certbot test stub: " + err.Error())
+		}
+		p := filepath.Join(dir, "certbot")
+		if werr := os.WriteFile(p, []byte("#!/bin/sh\ncat >/dev/null 2>&1\nexit 0\n"), 0o700); werr != nil {
+			panic("certbot test stub: " + werr.Error())
+		}
+		certbotStubPath = p
+	})
+	return certbotStubPath
+}

--- a/panel-agent/internal/certbot/runner.go
+++ b/panel-agent/internal/certbot/runner.go
@@ -35,7 +35,10 @@ type Runner struct {
 // NewRunner creates a default certbot runner.
 func NewRunner() *Runner {
 	return &Runner{
-		Binary:  "certbot",
+		// defaultCertbotBinary is "certbot" in production, or a no-op stub under
+		// `go test` so callers can't reach real ACME (GH #994/#1160). Tests that
+		// need real certbot output set Binary themselves after NewRunner.
+		Binary:  defaultCertbotBinary(),
 		OpenSSL: "openssl",
 		Env:     nil,
 		LERoot:  "/etc/letsencrypt",

--- a/panel-agent/internal/commands/ssl_issue_dns01_test.go
+++ b/panel-agent/internal/commands/ssl_issue_dns01_test.go
@@ -59,9 +59,11 @@ func TestSSLIssueDNS01_RejectsBadEmail(t *testing.T) {
 }
 
 func TestSSLIssueDNS01_AcceptsSingleWildcardSAN(t *testing.T) {
-	requireHostMutationAllowed(t) // GH #994: reaches internal/certbot\'s own exec (real `certbot certonly` / ACME) — outside the commands exec seam
-	// Passes validation and reaches certbot — which is absent in CI, so a
-	// CodeInternal (not CodeInvalidArgument) proves validation let it through.
+	// GH #1160: internal/certbot's exec is now test-safe (NewRunner defaults
+	// Binary to a no-op stub under `go test`), so this no longer reaches real
+	// ACME and the stopgap requireHostMutationAllowed gate is gone. Validation
+	// passes and reaches the (stubbed) certbot: a non-CodeInvalidArgument error
+	// (or success) proves the wildcard SAN was let through.
 	_, err := callDNS01(t, `{"cert_name":"wildcard.example.com","sans":["example.com","*.example.com"],"email":"a@b.co"}`)
 	if err == nil {
 		t.Skip("real certbot present and succeeded — validation clearly passed")

--- a/panel-agent/internal/pdns/dnssec.go
+++ b/panel-agent/internal/pdns/dnssec.go
@@ -21,8 +21,10 @@ import (
 	"strings"
 )
 
-// pdnsutilBinary is the path to the pdnsutil CLI. Overridable in tests.
-var pdnsutilBinary = "/usr/bin/pdnsutil"
+// pdnsutilBinary is the path to the pdnsutil CLI. Overridable in tests; defaults
+// to a no-op stub under `go test` so mutating dnssec ops can't reach real
+// pdnsutil (GH #994/#1160 — see exec_seam.go).
+var pdnsutilBinary = defaultPdnsutilBinary()
 
 // DNSSECKey mirrors one row from `pdnsutil show-zone` output.
 type DNSSECKey struct {

--- a/panel-agent/internal/pdns/exec_seam.go
+++ b/panel-agent/internal/pdns/exec_seam.go
@@ -1,0 +1,51 @@
+package pdns
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Test-safety for GH #994 / #1160.
+//
+// runPdnsutil (dnssec.go) shells out to `pdnsutil`, whose secure-zone / rectify
+// / disable operations MUTATE the host's DNSSEC state. The mutating operations
+// are reachable transitively from the commands package (the dns_dnssec_enable /
+// _disable handlers call pdns.SecureZone / pdns.DisableDNSSEC), so a commands
+// test that exercised those handlers would run real `pdnsutil` — the same
+// cross-package exec gap that bit internal/certbot. As with certbot, the default
+// binary is chosen by testing.Testing(): under `go test`, unless the operator
+// opts into real host mutation, pdnsutilBinary points at a harmless no-op stub.
+// Production binaries always get real `/usr/bin/pdnsutil`. Package tests that
+// need real/fake pdnsutil output set pdnsutilBinary themselves (dnssec.go's
+// contract), which overrides this default.
+
+// defaultPdnsutilBinary is /usr/bin/pdnsutil in production, or a no-op stub under
+// tests (unless JABALI_ALLOW_HOST_MUTATION=1).
+func defaultPdnsutilBinary() string {
+	if testing.Testing() && os.Getenv("JABALI_ALLOW_HOST_MUTATION") != "1" {
+		return pdnsutilTestStub()
+	}
+	return "/usr/bin/pdnsutil"
+}
+
+var (
+	pdnsutilStubOnce sync.Once
+	pdnsutilStubPath string
+)
+
+func pdnsutilTestStub() string {
+	pdnsutilStubOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "jabali-pdnsutil-stub-")
+		if err != nil {
+			panic("pdnsutil test stub: " + err.Error())
+		}
+		p := filepath.Join(dir, "pdnsutil")
+		if werr := os.WriteFile(p, []byte("#!/bin/sh\ncat >/dev/null 2>&1\nexit 0\n"), 0o700); werr != nil {
+			panic("pdnsutil test stub: " + werr.Error())
+		}
+		pdnsutilStubPath = p
+	})
+	return pdnsutilStubPath
+}


### PR DESCRIPTION
## What

Closes the #994 follow-up (#1160): agent packages whose exec a `go test` run
could reach are now structurally unable to hit real ACME / mutate the host.

### internal/certbot (the named gap)

#1159 seamed the **commands** package's exec, but `internal/certbot` has its own
exec, reached **transitively**: a commands test that calls an SSL handler →
`certbot.NewRunner()` would run real `certbot certonly …` (a live ACME order) on
any box with certbot installed. A per-package TestMain can't cover a
cross-package call, so `NewRunner` now chooses its default `Binary` via
`testing.Testing()`: under `go test` (unless `JABALI_ALLOW_HOST_MUTATION=1`) it
points at a harmless no-op stub; production binaries always get real `certbot`.
Tests that need real/fake certbot output inject their own `Binary` (as
`runner_test.go` does), which overrides the default.

The #1159 stopgap gate on `TestSSLIssueDNS01_AcceptsSingleWildcardSAN` is
**dropped** — it runs unconditionally now (0.00s, no ACME).

### Audit of the remaining agent packages (#1160 item 3)

- **internal/pdns** — same cross-package shape: `pdns.SecureZone` /
  `DisableDNSSEC` run mutating `pdnsutil` and are reachable from the commands
  dnssec handlers. `pdnsutilBinary` now defaults via `testing.Testing()` to a
  no-op stub as well (package tests already override it). Closes the latent gap
  before a test triggers it.
- **internal/pdnsrecursor** — already seamed (`ExecRunner`); no change.
- **internal/diagnostic** — exec is read-only (`cat`/`tail`/log reads), not
  host-mutating; no change.

## Verify (the #1159 method)

A PATH-stub sweep — fake `certbot` + `pdnsutil` on `PATH` that log every
invocation — over `go test ./panel-agent/...` records **ZERO** real
certbot/pdnsutil invocations, and the full agent suite is green. `go build` +
`go vet` clean.

GH #994 GH #1160