### PR TITLE
fix(agent): enforce SO_PEERCRED UID allow-list on the main agent socket (JAB-366 / JAB-357)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6470,6 +6470,16 @@ write_agent_systemd_unit() {
   jabali_sockets_gid="$(getent group jabali-sockets | cut -d: -f3)"
   [[ -n "$jabali_sockets_gid" ]] || _die "can't resolve gid of jabali-sockets"
 
+  # JAB-366 / JAB-357: SO_PEERCRED allow-list for the MAIN agent socket. The
+  # socket's 0660 root:jabali perms are only a GROUP gate — a service account
+  # accidentally left in the jabali group (JAB-351/357: webmail) could connect
+  # and drive every privileged command. Gate by the connecting UID too: only
+  # the panel-api user ($SERVICE_USER) + root (operator CLI) may connect, so a
+  # future group regression can never silently re-grant agent root.
+  local panel_uid
+  panel_uid="$(id -u "$SERVICE_USER" 2>/dev/null)"
+  [[ -n "$panel_uid" ]] || _die "can't resolve uid of $SERVICE_USER"
+
   cat >"/etc/systemd/system/${AGENT_SERVICE_NAME}.service" <<EOF
 [Unit]
 Description=Jabali Agent (privileged host operations)
@@ -6489,7 +6499,7 @@ Group=$SERVICE_USER
 RuntimeDirectory=jabali
 RuntimeDirectoryMode=0750
 RuntimeDirectoryPreserve=no
-ExecStart=$AGENT_BIN_PATH -socket $AGENT_SOCKET -gid $jabali_gid -pty-gid $jabali_sockets_gid
+ExecStart=$AGENT_BIN_PATH -socket $AGENT_SOCKET -gid $jabali_gid -pty-gid $jabali_sockets_gid -allowed-uids ${panel_uid},0
 Restart=on-failure
 RestartSec=3
 TimeoutStopSec=10

--- a/install/tests/test_agent_socket_uid_gate.sh
+++ b/install/tests/test_agent_socket_uid_gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# install/tests/test_agent_socket_uid_gate.sh — regression coverage for
+# JAB-366 / JAB-357. The main agent socket (/run/jabali/agent.sock) grants
+# every privileged command to any peer that can open it; its 0660 root:jabali
+# perms are only a GROUP gate, so a service account accidentally left in the
+# jabali group (webmail, JAB-351/357) could drive it. The agent supports an
+# SO_PEERCRED UID allow-list (server.Config.AllowedUIDs, -allowed-uids flag);
+# install.sh must ACTUALLY pass it, or the gate is inert.
+#
+# Asserts the agent unit ExecStart wires -allowed-uids to the panel user's UID
+# plus root, resolved from the live account (not hardcoded).
+#
+# Run from repo root:
+#     bash install/tests/test_agent_socket_uid_gate.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# The agent ExecStart must pass -allowed-uids with the panel uid + root.
+exec_line=$(grep -nE '^ExecStart=\$AGENT_BIN_PATH .*jabali-agent|^ExecStart=\$AGENT_BIN_PATH -socket' install.sh | head -1)
+if [[ -z "$exec_line" ]]; then
+  # fall back: any ExecStart line referencing the agent socket flags
+  exec_line=$(grep -nE '^ExecStart=.*-socket .*-gid .*-pty-gid' install.sh | head -1)
+fi
+if [[ -z "$exec_line" ]]; then
+  echo "FAIL: could not find the agent unit ExecStart in install.sh"
+  exit 1
+fi
+if ! grep -qE 'ExecStart=.*-allowed-uids \$\{panel_uid\},0' <<<"$exec_line"; then
+  echo "FAIL: agent ExecStart does not pass '-allowed-uids \${panel_uid},0' — the SO_PEERCRED gate is inert (JAB-366/357)"
+  echo "  got: $exec_line"
+  fail=1
+fi
+
+# panel_uid must be resolved from the live service account, not hardcoded.
+if ! grep -qE 'panel_uid="\$\(id -u "\$SERVICE_USER"' install.sh; then
+  echo "FAIL: panel_uid must be resolved via 'id -u \$SERVICE_USER' (not hardcoded)"
+  fail=1
+fi
+
+# It must fail closed if the uid can't be resolved (don't ship an empty list
+# that silently disables the gate).
+if ! grep -qE '\[\[ -n "\$panel_uid" \]\] \|\| _die' install.sh; then
+  echo "FAIL: install must _die when panel_uid can't be resolved, not ship an inert gate"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then exit 1; fi
+echo "PASS: agent socket SO_PEERCRED UID gate is wired to panel_uid,0 (JAB-366/357)"

--- a/panel-agent/cmd/jabali-agent/main.go
+++ b/panel-agent/cmd/jabali-agent/main.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -56,9 +57,18 @@ func main() {
 		// every install. -pty-gid overrides it for the broker; falls back
 		// to -gid when unset so old units keep their prior behaviour.
 		ptyGID = flag.Int("pty-gid", envInt("JABALI_AGENT_PTY_GID", -1), "PTY broker socket gid + SO_PEERCRED gate (panel-api primary gid = jabali-sockets); -1 falls back to -gid")
-		timeout    = flag.Duration("timeout", defaultTimeout, "per-request wall-clock timeout (when caller sets no deadline)")
-		logFormat  = flag.String("log-format", envOr("JABALI_AGENT_LOG_FORMAT", "json"), "json|text")
-		logLevel   = flag.String("log-level", envOr("JABALI_AGENT_LOG_LEVEL", "info"), "debug|info|warn|error")
+		// JAB-366 / JAB-357: SO_PEERCRED allow-list for the MAIN agent socket.
+		// The socket's 0660 root:jabali perms were the only trust boundary, so a
+		// service account accidentally left in the jabali group (JAB-351/357:
+		// webmail) could connect and drive every privileged command. Gate by the
+		// CONNECTING UID too: only the panel-api user (jabali) + root (operator
+		// CLI) are authorised, so a group regression can never silently re-grant
+		// agent root. Empty = allow any (kept for out-of-systemd test runs);
+		// install.sh always passes the real list.
+		allowedUIDs = flag.String("allowed-uids", envOr("JABALI_AGENT_ALLOWED_UIDS", ""), "comma-separated UIDs allowed to connect to the main socket (SO_PEERCRED gate); empty = allow any (testing only)")
+		timeout     = flag.Duration("timeout", defaultTimeout, "per-request wall-clock timeout (when caller sets no deadline)")
+		logFormat   = flag.String("log-format", envOr("JABALI_AGENT_LOG_FORMAT", "json"), "json|text")
+		logLevel    = flag.String("log-level", envOr("JABALI_AGENT_LOG_LEVEL", "info"), "debug|info|warn|error")
 	)
 	flag.Parse()
 
@@ -92,10 +102,18 @@ func main() {
 		// Note: we hold the client for the process lifetime; no defer Close().
 	}
 
+	allowUID := parseUIDList(*allowedUIDs)
+	if len(allowUID) > 0 {
+		log.Info("agent main socket SO_PEERCRED gate active", "allowed_uids", allowUID)
+	} else {
+		log.Warn("agent main socket SO_PEERCRED gate DISABLED (no -allowed-uids) — any local UID with socket access may connect")
+	}
+
 	srv, err := server.New(server.Config{
 		SocketPath:        *socketPath,
 		SocketMode:        0660,
 		SocketOwnerGID:    *socketGID,
+		AllowedUIDs:       allowUID,
 		PerRequestTimeout: *timeout,
 		Logger:            log,
 	})
@@ -168,6 +186,27 @@ func newLogger(format, level string) *slog.Logger {
 		return slog.New(slog.NewTextHandler(os.Stderr, opts))
 	}
 	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+}
+
+// parseUIDList parses a comma-separated UID list ("1001,0") into []uint32,
+// skipping blanks and unparseable entries. An empty/blank input yields an
+// empty slice, which the server treats as "gate disabled" (allow any). Used
+// only at startup, so a bad entry logs nothing louder than being ignored —
+// install.sh builds the value from `id -u`, not user input.
+func parseUIDList(s string) []uint32 {
+	var out []uint32
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(part, 10, 32)
+		if err != nil {
+			continue
+		}
+		out = append(out, uint32(n))
+	}
+	return out
 }
 
 // envOr returns the env var if set + non-empty, else fallback. Tiny helper

--- a/panel-agent/cmd/jabali-agent/main_test.go
+++ b/panel-agent/cmd/jabali-agent/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// JAB-366: parseUIDList feeds the main agent socket's SO_PEERCRED allow-list.
+// install.sh builds it as "<panel_uid>,0"; it must parse cleanly, skip blanks,
+// and ignore junk rather than fail the agent at startup.
+func TestParseUIDList(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []uint32
+	}{
+		{"1001,0", []uint32{1001, 0}},
+		{"", nil},
+		{"   ", nil},
+		{" 5 , , 7 ", []uint32{5, 7}},
+		{"abc,9", []uint32{9}}, // junk skipped, not fatal
+		{"0", []uint32{0}},
+		{"-1,3", []uint32{3}}, // negative is not a valid uint32 → skipped
+	}
+	for _, c := range cases {
+		got := parseUIDList(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("parseUIDList(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/panel-agent/internal/server/server_peercred_test.go
+++ b/panel-agent/internal/server/server_peercred_test.go
@@ -1,0 +1,76 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/commands"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-agent/internal/server"
+)
+
+// JAB-366 / JAB-357: the main agent socket must reject a connection whose peer
+// UID is not on the allow-list, so a service account accidentally left in the
+// jabali group (webmail) cannot drive privileged commands via the socket alone.
+// These tests exercise the real SO_PEERCRED path — roundTrip connects from the
+// test process, so its peer UID is os.Getuid().
+
+func startServerUIDs(t *testing.T, r *commands.Registry, allowed []uint32) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "a.sock")
+	srv, err := server.New(server.Config{
+		SocketPath:        sock,
+		SocketMode:        0600,
+		SocketOwnerGID:    -1,
+		AllowedUIDs:       allowed,
+		PerRequestTimeout: 2 * time.Second,
+		Registry:          r,
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = srv.Serve(ctx); close(done) }()
+	t.Cleanup(func() { cancel(); _ = srv.Close(); <-done })
+	return sock
+}
+
+func echoRegistry() *commands.Registry {
+	r := commands.NewRegistry()
+	r.Register("echo", func(_ context.Context, p json.RawMessage) (any, error) {
+		return map[string]json.RawMessage{"params": p}, nil
+	})
+	return r
+}
+
+func TestServer_UIDGate_AllowsSelf(t *testing.T) {
+	t.Parallel()
+	sock := startServerUIDs(t, echoRegistry(), []uint32{uint32(os.Getuid())})
+	resp := roundTrip(t, sock, agentwire.Request{ID: "01OK", Command: "echo", Params: json.RawMessage(`{"x":1}`)})
+	assert.True(t, resp.Ok, "an allowed UID must be served")
+}
+
+func TestServer_UIDGate_RejectsUnauthorizedUID(t *testing.T) {
+	t.Parallel()
+	// Allow a UID that is NOT us, so our connection is refused.
+	other := uint32(os.Getuid()) + 40000
+	sock := startServerUIDs(t, echoRegistry(), []uint32{other})
+	resp := roundTrip(t, sock, agentwire.Request{ID: "01NO", Command: "echo", Params: json.RawMessage(`{"x":1}`)})
+	assert.False(t, resp.Ok, "a non-allowed UID must be rejected")
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, agentwire.CodePermissionDenied, resp.Error.Code)
+}
+
+func TestServer_UIDGate_EmptyAllowsAny(t *testing.T) {
+	t.Parallel()
+	// Empty allow-list = gate disabled (out-of-systemd test runs). Backward-compat.
+	sock := startServerUIDs(t, echoRegistry(), nil)
+	resp := roundTrip(t, sock, agentwire.Request{ID: "01ANY", Command: "echo", Params: json.RawMessage(`{"x":1}`)})
+	assert.True(t, resp.Ok, "empty allow-list must not gate (any UID served)")
+}


### PR DESCRIPTION
## JAB-366 / JAB-357 — SO_PEERCRED UID gate on the main agent socket

### Problem
`/run/jabali/agent.sock` authenticates callers **only** by its `0660 root:jabali`
perms — a group gate. The agent parses no credentials and trusts request flags
like `admin_root`, so any process that can open the socket drives every
privileged command. JAB-351/357: the Internet-facing webmail account was
accidentally in the `jabali` group and reached it → service-to-root. Removing
webmail from the group (#1208) closed that instance, but a future group
regression would silently re-grant root.

The server **already** enforces `Config.AllowedUIDs` via SO_PEERCRED
(`serveConn`), but `main.go` never populated it — so the gate was inert (empty =
allow any).

### Fix
- **main.go**: `-allowed-uids` / `JABALI_AGENT_ALLOWED_UIDS` (comma-separated),
  parsed by `parseUIDList`, wired into `server.Config.AllowedUIDs`; logs whether
  the gate is active or disabled at startup.
- **install.sh**: the agent unit `ExecStart` now passes
  `-allowed-uids ${panel_uid},0`, resolved from `id -u $SERVICE_USER` (panel-api
  user) + root (operator CLI). `_die` if the uid can't be resolved rather than
  ship an inert gate.

Now the connecting **UID** is authenticated: only the panel user and root may
drive the agent, so a service account left in the `jabali` group can no longer
reach it (defence-in-depth behind the group removal). This also binds
`admin_root` to an authenticated caller — a non-panel process can't even connect
to send it.

### JAB-357 acceptance criteria
- ✅ Peer-credential authorization on the main socket (UID allow-list) — this PR.
- ✅ Don't trust `admin_root` without an authenticated caller — only the panel
  UID can connect to send it (+ JAB-358 confined its blast radius).
- ✅ Installer wires the gate; ✅ regression tests (real SO_PEERCRED matrix).
- (Earlier: webmail removed from `jabali` group + converge — #1208.)
- Residual, **operator action** (not code): rotate panel/DB/TLS/mail/session
  secrets, since the webmail account previously had broad read.

### Verification
- **Box (.86, then reverted):** gate on (`allowed_uids=[997,0]`), panel still
  reaches the agent — login 200, zero legit requests rejected, gate-active
  logged. (.86 restored to baseline so the 03:45 stable-pull doesn't hit a
  binary/flag mismatch.)
- **Unit:** authorized UID served; unauthorized UID → `permission_denied`; empty
  list stays open (real SO_PEERCRED). Plus `parseUIDList` + an install-wiring
  regression pin.
