### PR TITLE
feat(webdav): schema + model + repo for WebDAV subaccount access (GH #1146 step 1)

### DIFF
--- a/panel-api/internal/db/migrations/000273_ftp_webdav_access.down.sql
+++ b/panel-api/internal/db/migrations/000273_ftp_webdav_access.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ftp_accounts
+    DROP COLUMN webdav_access;

--- a/panel-api/internal/db/migrations/000273_ftp_webdav_access.up.sql
+++ b/panel-api/internal/db/migrations/000273_ftp_webdav_access.up.sql
@@ -1,0 +1,7 @@
+-- GH #1146: WebDAV as a third access option on FTP/SFTP subaccounts, alongside
+-- ftp_access / sftp_access. Default 0 (off) — opt-in per subaccount, and the
+-- feature ships behind the same package cap + server module as the rest of #1053.
+-- Bool column: DDL DEFAULT 0 is safe here (0 is the zero value, so no gorm
+-- default-tag zero-value trap — the model field carries NO gorm default).
+ALTER TABLE ftp_accounts
+    ADD COLUMN webdav_access TINYINT(1) NOT NULL DEFAULT 0;

--- a/panel-api/internal/models/ftp_account.go
+++ b/panel-api/internal/models/ftp_account.go
@@ -31,7 +31,12 @@ type FtpAccount struct {
 	// carries NO gorm default on purpose — `default:1` on a bool silently
 	// flips an explicit false back to true on create (recurring scar).
 	SFTPAccess bool `gorm:"column:sftp_access;type:tinyint(1);not null" json:"sftp_access"`
-	IsEnabled  bool `gorm:"type:tinyint(1);not null" json:"is_enabled"`
+	// WebDAVAccess gates the per-subaccount WebDAV worker + jabali-webdav group
+	// (GH #1146). Column default is 0 (opt-in); the tag carries NO gorm default
+	// on purpose — a `default:1`-style tag on a bool silently flips an explicit
+	// false back to true on create (same recurring scar as sftp_access).
+	WebDAVAccess bool `gorm:"column:webdav_access;type:tinyint(1);not null" json:"webdav_access"`
+	IsEnabled    bool `gorm:"type:tinyint(1);not null" json:"is_enabled"`
 	// UID is the subaccount's own uid when isolated (GH #1145 separate-uid
 	// model). nil = legacy shared-uid alias sharing the tenant uid. Explicit
 	// column tag: GORM mangles the initialism (UID -> u_id) otherwise.

--- a/panel-api/internal/repository/ftp_account_repository.go
+++ b/panel-api/internal/repository/ftp_account_repository.go
@@ -151,13 +151,14 @@ func (r *ftpAccountRepo) Update(ctx context.Context, acct *models.FtpAccount) er
 	err := r.db.WithContext(ctx).
 		Model(&models.FtpAccount{}).
 		Where("id = ?", acct.ID).
-		Select("home_path", "ftp_access", "sftp_access", "is_enabled", "updated_at").
+		Select("home_path", "ftp_access", "sftp_access", "webdav_access", "is_enabled", "updated_at").
 		Updates(map[string]any{
-			"home_path":   acct.HomePath,
-			"ftp_access":  acct.FTPAccess,
-			"sftp_access": acct.SFTPAccess,
-			"is_enabled":  acct.IsEnabled,
-			"updated_at":  acct.UpdatedAt,
+			"home_path":     acct.HomePath,
+			"ftp_access":    acct.FTPAccess,
+			"sftp_access":   acct.SFTPAccess,
+			"webdav_access": acct.WebDAVAccess,
+			"is_enabled":    acct.IsEnabled,
+			"updated_at":    acct.UpdatedAt,
 		}).Error
 	return translateFtpAccount(err)
 }

--- a/panel-api/internal/repository/ftp_account_repository_test.go
+++ b/panel-api/internal/repository/ftp_account_repository_test.go
@@ -59,9 +59,9 @@ func TestFtpAccountCreate_Success(t *testing.T) {
 	acct := testFtpAccount(time.Now())
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`webdav_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)")).
 		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
-			acct.FTPAccess, acct.SFTPAccess, acct.IsEnabled,
+			acct.FTPAccess, acct.SFTPAccess, acct.WebDAVAccess, acct.IsEnabled,
 			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 			sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -85,9 +85,9 @@ func TestFtpAccountCreate_ExplicitFalseSFTPAccess(t *testing.T) {
 	acct.FTPAccess = true
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)")).
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO `ftp_accounts` (`id`,`user_id`,`username`,`home_path`,`ftp_access`,`sftp_access`,`webdav_access`,`is_enabled`,`uid`,`isolated`,`quota_mb`,`jail_path`,`created_at`,`updated_at`) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)")).
 		WithArgs(acct.ID, acct.UserID, acct.Username, acct.HomePath,
-			true, false, acct.IsEnabled,
+			true, false, acct.WebDAVAccess, acct.IsEnabled,
 			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
 			sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -202,8 +202,8 @@ func TestFtpAccountUpdate_AllowlistOnly(t *testing.T) {
 	acct.IsEnabled = false
 
 	mock.ExpectBegin()
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE `ftp_accounts` SET `ftp_access`=?,`home_path`=?,`is_enabled`=?,`sftp_access`=?,`updated_at`=? WHERE id = ?")).
-		WithArgs(acct.FTPAccess, acct.HomePath, false, acct.SFTPAccess, sqlmock.AnyArg(), acct.ID).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE `ftp_accounts` SET `ftp_access`=?,`home_path`=?,`is_enabled`=?,`sftp_access`=?,`updated_at`=?,`webdav_access`=? WHERE id = ?")).
+		WithArgs(acct.FTPAccess, acct.HomePath, false, acct.SFTPAccess, sqlmock.AnyArg(), acct.WebDAVAccess, acct.ID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 


### PR DESCRIPTION
## What

**Step 1 of 6** for WebDAV on FTP/SFTP subaccounts (blueprint:
`plans/gh1146-webdav.md`). Data layer only — a stable `webdav_access` column for
later slices (the per-uid worker, nginx front, agent verbs, API, UI) to build on.
Mirrors how #1053 landed (#1094 was its schema/model step).

- **migration 000273**: `ftp_accounts.webdav_access TINYINT(1) NOT NULL DEFAULT
  0` (opt-in, off). Bool with a DDL default of 0 — the model field carries **no**
  gorm `default` tag (same as `sftp_access`) to avoid the `default:1`-on-bool
  zero-value scar.
- **model**: `FtpAccount.WebDAVAccess`.
- **repo**: `Update` allowlist + Updates map carry `webdav_access` so toggling
  persists (a full-struct save would zero untouched columns).
- **tests**: create/update sqlmock expectations pin the new column in the
  generated INSERT + allowlist SET (incl. explicit-false).

## Design (later steps)

WebDAV must write files **as the subaccount uid** to preserve #1145 kernel
isolation → rules out nginx-DAV (www-data) and SFTPGo (rejected #1053). Chosen
shape mirrors per-user PHP-FPM: a `jabali-webdav@<sub>` worker running as the
subaccount uid, unix-socketed, with nginx terminating TLS + an `auth_request` to
a privileged PAM/shadow authenticator. Steps 2–6 in the blueprint.

## Test

`go build` + `go vet` clean; `repository` (FtpAccount) + `db` migration
completeness green.

GH #1146 GH #1053 GH #1145