### PR TITLE
feat(webdav): jabali-webdav per-subaccount worker binary (GH #1146 step 2)

### DIFF
--- a/panel-agent/cmd/jabali-webdav/main.go
+++ b/panel-agent/cmd/jabali-webdav/main.go
@@ -1,0 +1,91 @@
+// Command jabali-webdav serves ONE FTP/SFTP subaccount's home directory over
+// WebDAV on a unix socket (GH #1146, step 2 of plans/gh1146-webdav.md).
+//
+// It is started as `jabali-webdav@<subaccount>` by the agent when a
+// subaccount's webdav_access is enabled (step 3). systemd runs it as the
+// subaccount's OWN uid and, for isolated accounts, inside the #1145 chroot jail
+// — so every file it writes is uid-owned and kernel-confined to the home, the
+// same boundary sftp gets. This process therefore does NOT authenticate or
+// authorise: nginx terminates TLS and reverse-proxies here only AFTER a
+// privileged auth_request has verified the subaccount's credentials + access
+// (step 4). Keeping auth out of the unprivileged worker is deliberate — it runs
+// as a tenant uid that can't read /etc/shadow anyway.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/webdav"
+)
+
+func main() {
+	socket := flag.String("socket", "", "unix socket path to listen on")
+	root := flag.String("root", "", "directory to serve (the subaccount home)")
+	prefix := flag.String("prefix", "", "URL path prefix to strip (e.g. /dav/<sub>)")
+	flag.Parse()
+
+	if *socket == "" || *root == "" {
+		log.Fatal("jabali-webdav: --socket and --root are required")
+	}
+	if fi, err := os.Stat(*root); err != nil || !fi.IsDir() {
+		log.Fatalf("jabali-webdav: --root %q is not a directory: %v", *root, err)
+	}
+
+	// Stale socket from a previous run (systemd restart) would make Listen fail
+	// with EADDRINUSE; the worker owns this path, so removing it is safe.
+	_ = os.Remove(*socket)
+	ln, err := net.Listen("unix", *socket)
+	if err != nil {
+		log.Fatalf("jabali-webdav: listen %s: %v", *socket, err)
+	}
+	// 0660: nginx (www-data, added to the socket group in step 3/4) connects;
+	// no other tenant can. The worker runs as the subaccount uid, so the socket
+	// is owned by that uid:group.
+	if err := os.Chmod(*socket, 0o660); err != nil {
+		log.Printf("jabali-webdav: chmod socket %s: %v", *socket, err)
+	}
+
+	srv := &http.Server{
+		Handler:           newWebdavHandler(*root, *prefix),
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	// Graceful shutdown so an in-flight PUT isn't truncated on `systemctl stop`.
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+		<-sig
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	}()
+
+	log.Printf("jabali-webdav: serving %s on %s (prefix %q)", *root, *socket, *prefix)
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("jabali-webdav: serve: %v", err)
+	}
+}
+
+// newWebdavHandler builds the WebDAV handler for one home directory. webdav.Dir
+// lexically confines resource paths to root; the kernel chroot + subaccount uid
+// (systemd, step 3) are the real security boundary, mirroring sftp.
+func newWebdavHandler(root, prefix string) *webdav.Handler {
+	return &webdav.Handler{
+		Prefix:     prefix,
+		FileSystem: webdav.Dir(root),
+		LockSystem: webdav.NewMemLS(),
+		Logger: func(r *http.Request, err error) {
+			if err != nil {
+				log.Printf("jabali-webdav: %s %s: %v", r.Method, r.URL.Path, err)
+			}
+		},
+	}
+}

--- a/panel-agent/cmd/jabali-webdav/main_test.go
+++ b/panel-agent/cmd/jabali-webdav/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// do issues a WebDAV request against the test server and returns status + body.
+func do(t *testing.T, base, method, path, body string) (int, string) {
+	t.Helper()
+	var r io.Reader
+	if body != "" {
+		r = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, base+path, r)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(out)
+}
+
+func TestWebdavHandler_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	srv := httptest.NewServer(newWebdavHandler(root, ""))
+	defer srv.Close()
+
+	// PUT a file, then GET it back.
+	if code, _ := do(t, srv.URL, "PUT", "/hello.txt", "world"); code != http.StatusCreated && code != http.StatusNoContent {
+		t.Fatalf("PUT: got %d", code)
+	}
+	code, body := do(t, srv.URL, "GET", "/hello.txt", "")
+	if code != http.StatusOK || body != "world" {
+		t.Fatalf("GET: got %d %q", code, body)
+	}
+	// The file really landed in root (uid-owned in production).
+	if b, err := os.ReadFile(filepath.Join(root, "hello.txt")); err != nil || string(b) != "world" {
+		t.Fatalf("file on disk: %q err=%v", b, err)
+	}
+
+	// MKCOL + PROPFIND work (proves it's real WebDAV, not just GET/PUT).
+	if code, _ := do(t, srv.URL, "MKCOL", "/sub", ""); code != http.StatusCreated {
+		t.Fatalf("MKCOL: got %d", code)
+	}
+	if code, _ := do(t, srv.URL, "PROPFIND", "/", ""); code != http.StatusMultiStatus {
+		t.Fatalf("PROPFIND: got %d, want 207", code)
+	}
+}
+
+// A traversal in the request path must not escape the served root — webdav.Dir
+// confines lexically; the kernel chroot is the belt in production.
+func TestWebdavHandler_NoEscape(t *testing.T) {
+	root := t.TempDir()
+	// A secret one level above root that must stay unreachable.
+	secret := filepath.Join(filepath.Dir(root), "secret.txt")
+	if err := os.WriteFile(secret, []byte("top"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	srv := httptest.NewServer(newWebdavHandler(root, ""))
+	defer srv.Close()
+
+	// net/http cleans "/../" before it reaches the handler, and webdav.Dir
+	// rejects any that survive — either way the secret is not served.
+	code, body := do(t, srv.URL, "GET", "/../secret.txt", "")
+	if code == http.StatusOK && strings.Contains(body, "top") {
+		t.Fatalf("escaped the root: served the parent secret (%d)", code)
+	}
+}


### PR DESCRIPTION
## What

**Step 2 of 6** (blueprint `plans/gh1146-webdav.md`) — the WebDAV worker binary.
Serves ONE subaccount's home over WebDAV (`golang.org/x/net/webdav`) on a unix
socket:

```
jabali-webdav --socket /run/jabali-webdav/<sub>.sock --root <home> [--prefix /dav/<sub>]
```

## Design

The worker does **no auth and no privilege management**. systemd (step 3) runs
one instance per webdav-enabled subaccount **as that subaccount's uid** and, for
isolated accounts, inside the **#1145 chroot jail** — so every write is uid-owned
and kernel-confined to the home, the same boundary sftp gets. nginx (step 4)
terminates TLS and reverse-proxies here only after a **privileged auth_request**.
Auth stays out of this unprivileged worker on purpose: it runs as a tenant uid
that can't read `/etc/shadow`.

- unix-socket listener, `0660` (nginx connects via the shared socket group set in
  step 3/4); stale-socket removal for clean restarts.
- `webdav.Handler` + `webdav.Dir(root)` + in-memory lock system; `--prefix`
  strips the nginx path prefix.
- graceful shutdown on SIGTERM so `systemctl stop` doesn't truncate a PUT.

## Test

`PUT`/`GET` round-trip lands the file on disk; `MKCOL` + `PROPFIND` prove real
WebDAV; a path-traversal request can't serve a file above the root. `go build` +
`go vet` clean; no go.mod change (x/net already direct).

Next: step 3 wires `jabali-webdav@<sub>` systemd template + the `jabali-webdav`
PAM group + agent verbs.

GH #1146