### PR TITLE
fix(ftp): quotaEnabledOn misreads quotaon -p exit code — isolated FTP dead on Debian 13

### DIFF
--- a/panel-agent/internal/commands/ftp_account_jail.go
+++ b/panel-agent/internal/commands/ftp_account_jail.go
@@ -241,14 +241,23 @@ func provisionIsolatedJail(ctx context.Context, tenant *ftpTenant, p ftpAccountC
 
 // quotaEnabledOn reports whether user disk quota is active on mount. `quotaon
 // -pu` prints the current state without changing anything; a line containing
-// "is on" means user quota is active. A missing quota binary, an unsupported
-// filesystem, or "is off" all mean a per-uid setquota would fail — so isolated
-// FTP (which needs the per-account cap) cannot run there.
+// "is on" means user quota is active.
+//
+// The exit code is deliberately IGNORED. On the fleet OS (Debian 13, observed
+// live), `quotaon -p` does NOT exit 0 on success — it returns a non-zero status
+// even when quota is fully enabled ("... is on (enforced)", exit 1), so the old
+// `if err != nil { return false }` was a false negative that made every isolated
+// FTP create fail its precondition and the panel's Isolated toggle read
+// unavailable, despite `setquota` working. Parse the printed state instead.
+//
+// This does NOT relax the disk-fill guard: the precheck is only a fast, friendly
+// fail — the authoritative cap is provisionIsolatedJail step 5's setquota, whose
+// failure rolls the whole account back, so an uncapped isolated account can never
+// exist regardless of this check. And the parse still fails closed on every
+// error mode: a missing binary or a run error leaves empty/error output (no "is
+// on"), and "is off" does not contain "is on".
 func quotaEnabledOn(ctx context.Context, mount string) bool {
-	out, err := execCommandContext(ctx, "quotaon", "-pu", mount).CombinedOutput()
-	if err != nil {
-		return false
-	}
+	out, _ := execCommandContext(ctx, "quotaon", "-pu", mount).CombinedOutput()
 	return strings.Contains(string(out), "is on")
 }
 

--- a/panel-agent/internal/commands/ftp_account_jail_test.go
+++ b/panel-agent/internal/commands/ftp_account_jail_test.go
@@ -5,13 +5,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"testing"
 )
 
 // TestQuotaEnabledOn covers the GH #1053 isolated-create preflight: quota is
-// "on" only when `quotaon -pu` reports it; a missing binary / unsupported fs
-// (command error) or an "is off" line both mean setquota would fail.
+// "on" only when `quotaon -pu` reports it. The command EXIT CODE is ignored on
+// purpose — `quotaon -p` returns non-zero even when quota is fully enabled on
+// the fleet OS (Debian 13, observed live: "... is on (enforced)", exit 1), so
+// gating on the exit code was a false negative that dead-ended isolated FTP.
+// Only the printed "is on" text is authoritative; a missing binary / unsupported
+// fs (empty output) or an "is off" line still fail closed.
 func TestQuotaEnabledOn(t *testing.T) {
 	orig := execCommandContext
 	t.Cleanup(func() { execCommandContext = orig })
@@ -19,20 +24,22 @@ func TestQuotaEnabledOn(t *testing.T) {
 	cases := []struct {
 		name string
 		out  string
-		fail bool
+		rc   int
 		want bool
 	}{
-		{"user quota on", "user quota on / (/dev/root) is on", false, true},
-		{"user quota off", "user quota on / is off", false, false},
-		{"command error", "", true, false},
+		{"on, exit 0", "user quota on / (/dev/root) is on", 0, true},
+		// The regression: quota IS on but quotaon -p exits non-zero (Debian 13).
+		{"on but exit 1 (debian13 quotaon -p)", "user quota on / (/dev/sda1) is on (enforced)", 1, true},
+		{"off, exit 1", "user quota on / is off", 1, false},
+		{"binary error, empty output", "", 127, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			out, rc := tc.out, tc.rc
 			execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-				if tc.fail {
-					return exec.CommandContext(ctx, "false")
-				}
-				return exec.CommandContext(ctx, "echo", tc.out)
+				// Emit the canned output AND the exit code together, so the real
+				// CombinedOutput + exit-status path is exercised through the seam.
+				return exec.CommandContext(ctx, "sh", "-c", "printf '%s\\n' \""+out+"\"; exit "+strconv.Itoa(rc))
 			}
 			if got := quotaEnabledOn(context.Background(), "/"); got != tc.want {
 				t.Fatalf("quotaEnabledOn=%v want %v", got, tc.want)


### PR DESCRIPTION
## Problem

On the fleet OS (Debian 13), creating an isolated (separate-uid, GH #1145) FTP/SFTP subaccount fails its precondition — `filesystem disk quota is not enabled on /` — even though quota is enabled **and enforced**, and the panel's "Isolated" toggle reads unavailable. **Isolated FTP has been silently dead on Debian 13.**

## Root cause

`quotaEnabledOn` ran `quotaon -pu <mount>` and treated any non-zero exit as "quota off" (`if err != nil { return false }`). But `quotaon -p` returns a **non-zero** status even when quota is fully on — it returns the count of enabled quota types, not `0`/success. Observed live:

- `quotaon -pu /` → prints `user quota on / (/dev/sda1) is on (enforced)`, **exit 1**
- `quotaon -pug /` → both on, **exit 2**
- `setquota -u <user> ... /` → **exit 0** (quota genuinely works)

## Fix

Ignore the exit code; trust the printed `is on` text.

This does **not** relax the disk-fill guard: the precheck is only a fast, friendly fail — the authoritative cap is `provisionIsolatedJail` step 5's `setquota`, whose failure rolls the whole account back, so an uncapped isolated account can never exist regardless of this check. The parse still fails closed on every error mode (missing binary / run error → empty output → false; `is off` ≠ `is on`).

## Test

Regression test: quota on but `quotaon` exits 1 → `true`; off → `false`; empty output → `false`.

## Notes

Found while box-verifying WebDAV (JAB / GH #1146) on the smoke box; split out to its own PR because it's a fleet-visible change to the #1170 stable-gated quota preflight, independent of the webdav feature. Tracked in JAB-378.
