### PR TITLE
fix(webmail): confine Bulwark via AppArmor instead of a mount namespace (JAB-375)

### DIFF
--- a/install/apparmor/usr.local.bin.jabali-bulwark
+++ b/install/apparmor/usr.local.bin.jabali-bulwark
@@ -1,24 +1,34 @@
-# AppArmor profile — jabali-bulwark (M40.1, ADR-0086)
+# AppArmor profile — jabali-bulwark (M40.1 / JAB-375, ADR-0086)
 #
-# bulwark is the Node.js public-facing fronting daemon. Untrusted
-# input boundary; profile is tight: state dir + unix socket + outbound
-# TCP for relay/upstream calls. NO access to /etc/jabali/ panel
-# secrets — bulwark gets its own config from /etc/jabali-bulwark/.
+# bulwark is the Node.js public-facing webmail daemon (Next.js). It is an
+# untrusted-input boundary, so the profile is tight: a read-only app tree,
+# its own state dir + a dedicated tmp, the listen socket, the panel-api
+# upstream socket, and outbound TCP for JMAP/relay. NO access to panel
+# secrets, /etc/shadow, user homes, the audit log, or the shared /tmp.
 #
-# AA 4.x (Debian 13) enforces the `unix` mediation class separately
-# from `network unix`. Without explicit unix rules the Node.js process
-# fails to bind its own socket or connect to the panel-api upstream
-# socket even in complain mode.
+# JAB-375 path correction: the app actually runs as
+# `/usr/bin/node /opt/jabali-webmail/server-unix.js`, reads its config from
+# /etc/jabali-panel/bulwark.env, and keeps state under /var/lib/jabali-webmail.
+# The M40 profile granted the old /usr/local/bin + /var/lib/jabali-bulwark
+# layout and therefore confined nothing real. Paths are corrected here.
 #
-# M40.1 socket path fix: M25 (ADR-0050) moved bulwark's socket into
-# a directory at /run/jabali-bulwark/bulwark.sock (not the flat
-# /run/jabali-bulwark.sock the M40 profile had). Similarly panel-api
-# lives at /run/jabali-panel/api.sock (not /run/jabali-panel.sock).
-
-# GH #705: pin AppArmor 3.0 ABI — predates unix-socket mediation, so
-# these broken-mediation kernels (Debian 13/Ubuntu 24.04) SKIP unix
-# mediation for this profile; attaching it can't EACCES a unix connect()
-# while still confining files/caps/network. Verified on .86.
+# JAB-375 attach contract: the unit attaches this via
+# `AppArmorProfile=-jabali-bulwark` and MUST NOT set ProtectSystem= /
+# PrivateTmp= / ProtectHome=. A systemd private MOUNT NAMESPACE combined
+# with this label transition makes Node self-abort at node::Start
+# (status=6/ABRT, no message) — reproduced deterministically on .86: any one
+# of those three directives is enough; aa-exec (no mount ns) never triggers
+# it. This profile REPLACES that mount-ns hardening with file MAC
+# (default-deny read+write of everything unlisted, which is strictly tighter
+# than ProtectSystem=strict's read-only-rootfs) and redirects tmp to a
+# dedicated per-service subtree (the unit sets TMPDIR=/var/lib/jabali-webmail/tmp)
+# with the shared /tmp explicitly denied — equal-or-tighter than PrivateTmp.
+#
+# GH #705: pin AppArmor 3.0 ABI — it predates unix-socket mediation, so
+# broken-mediation kernels (Debian 13 / Ubuntu 24.04, no
+# /sys/kernel/security/apparmor/features/unix) SKIP unix mediation for this
+# profile; attaching it can't EACCES a unix connect() while still confining
+# files/caps/network. Verified on .86.
 abi <abi/3.0>,
 
 #include <tunables/global>
@@ -30,17 +40,26 @@ profile jabali-bulwark /usr/local/bin/jabali-bulwark {
   #include <abstractions/ssl_certs>
 
   # Inline minimum Node.js runtime needs — Debian 13 doesn't ship
-  # abstractions/nodejs (parser error: "Could not open
-  # 'abstractions/nodejs'"). These cover libuv epoll/eventfd, V8 ICU
-  # tables, libc DNS, /dev/urandom for crypto.randomBytes, and CPU
-  # topology that Node samples at startup.
+  # abstractions/nodejs. These cover libuv epoll/eventfd, V8 ICU tables,
+  # libc DNS, /dev/urandom for crypto.randomBytes, CPU topology Node samples
+  # at startup, and /proc/self/{maps,stat,status} that Node reads to print a
+  # native stack trace.
   /dev/urandom                    r,
   /dev/null                       rw,
   /proc/sys/kernel/random/uuid    r,
   /proc/*/maps                    r,
   /proc/*/stat                    r,
+  /proc/*/status                  r,
+  # Node samples its own cgroup at startup for the memory/CPU limits it
+  # derives V8 heap sizing from.
+  /proc/*/cgroup                  r,
+  /proc/sys/net/core/somaxconn    r,
   /sys/devices/system/cpu/        r,
   /sys/devices/system/cpu/**      r,
+  # Node reads its cgroup-v2 memory limits (memory.max / memory.high) to
+  # auto-size the V8 heap; the lookup chains /proc/self/cgroup → these files.
+  /sys/fs/cgroup/                 r,
+  /sys/fs/cgroup/**               r,
   /etc/ssl/openssl.cnf            r,
 
   capability net_bind_service,
@@ -51,48 +70,64 @@ profile jabali-bulwark /usr/local/bin/jabali-bulwark {
   network inet6 stream,
   network unix  stream,
 
-  # AA 4.x unix mediation — bind own socket + connect to panel-api upstream.
+  # AA 4.x unix mediation — bind own listener socket + connect to the
+  # panel-api upstream socket.
   unix (create, bind, listen, accept, connect, send, receive) type=stream,
   # AA 4.x: complain mode still enforces unix peer-label checks. Explicit
-  # peer=(label=unconfined) allows connecting to panel-api upstream socket
-  # when that profile label differs from bulwark's label.
+  # peer=(label=unconfined) allows connecting to the panel-api upstream
+  # socket when that profile label differs from bulwark's.
   unix (connect, send, receive) type=stream peer=(label=unconfined),
 
-  /usr/local/bin/jabali-bulwark    mr,
-  /usr/local/bin/node              mr,
+  # systemd (unconfined) sends SIGTERM/SIGKILL on stop; Node signals its own
+  # workers under this same label. Allow both without over-mediating.
+  signal,
+
+  # Node binary itself (abstractions/base covers libc + system libs; V8
+  # native addons that live under the app tree get their mmap grant below).
   /usr/bin/node                    mr,
-  /etc/jabali-bulwark/             r,
-  /etc/jabali-bulwark/**           r,
+  /usr/local/bin/node              mr,
 
-  /var/lib/jabali-bulwark/         rw,
-  /var/lib/jabali-bulwark/**       rwk,
-  /var/log/jabali-bulwark/         rw,
-  /var/log/jabali-bulwark/**       rwk,
+  # --- Application tree: read-only, native addons mmap'd ---
+  /opt/jabali-webmail/               r,
+  /opt/jabali-webmail/**             r,
+  /opt/jabali-webmail/**.node        mr,
+  /opt/jabali-webmail/**.so*         mr,
+  # Next.js writes its build/runtime cache here — the only writable spot in
+  # the app tree (the unit's ExecStartPre pre-creates it).
+  /opt/jabali-webmail/.next/cache/   rw,
+  /opt/jabali-webmail/.next/cache/** rwk,
 
-  # M25 unix-socket layout (ADR-0050).
-  # Own listener socket (nginx upstream: server unix:/run/jabali-bulwark/bulwark.sock).
+  # --- Writable state + the dedicated tmp subtree (replaces PrivateTmp) ---
+  /var/lib/jabali-webmail/         rw,
+  /var/lib/jabali-webmail/**       rwk,
+
+  # --- Config: its OWN env file only, NOT the rest of /etc/jabali-panel ---
+  /etc/jabali-panel/bulwark.env    r,
+
+  # --- Sockets (M25 layout, ADR-0050) ---
+  # Own listener (nginx upstream: server unix:/run/jabali-bulwark/bulwark.sock).
   /run/jabali-bulwark/             rw,
-  /run/jabali-bulwark/**           rw,
+  /run/jabali-bulwark/**           rwlk,
   # panel-api upstream sockets (api + sso).
   /run/jabali-panel/               r,
   /run/jabali-panel/**             rw,
 
-  /usr/lib/node_modules/           r,
-  /usr/lib/node_modules/**         r,
-  /usr/share/jabali-bulwark/       r,
-  /usr/share/jabali-bulwark/**     r,
-  /usr/local/lib/jabali-bulwark/   r,
-  /usr/local/lib/jabali-bulwark/** r,
-
-  /proc/sys/net/core/somaxconn     r,
-  /proc/*/status                   r,
-
-  # Hard denies — bulwark must NOT read panel secrets, /etc/shadow,
-  # user homes, or audit logs.
+  # Hard denies — bulwark must NOT read panel secrets, /etc/shadow, user
+  # homes, or audit logs, and must NOT touch the shared /tmp (its tmp is
+  # redirected to /var/lib/jabali-webmail/tmp).
   deny /etc/jabali/ rwklx,
   deny /etc/jabali/** rwklx,
   deny /etc/shadow rwklx,
   deny /home/** rwlkx,
   deny /root/** rwlkx,
   deny /var/log/audit/** rwklx,
+  deny /tmp/** rwklx,
+  deny /var/tmp/** rwklx,
+  # The stock Bulwark update-check best-effort writes state under the app
+  # tree (/opt/jabali-webmail/data/version-check/). That path is read-only
+  # under the app-tree grant above — and was already read-only under the old
+  # ProtectSystem=strict unit — so this write has never worked and is
+  # non-fatal. A silent deny keeps the app tree read-only AND suppresses the
+  # audit noise so the profile stays soak-clean for the flip-mature timer.
+  deny /opt/jabali-webmail/data/** wk,
 }

--- a/install/systemd/jabali-webmail.service
+++ b/install/systemd/jabali-webmail.service
@@ -32,15 +32,23 @@ WorkingDirectory=/opt/jabali-webmail
 # bulwark updates that overwrite server.js leave server-unix.js alone.
 Environment=SOCKET_PATH=/run/jabali-bulwark/bulwark.sock
 Environment=NODE_ENV=production
-# Ensure .next/cache exists before main process starts. The Bulwark
-# tarball doesn't ship the cache subdir; without it, systemd refuses
-# to enter mount namespacing (ReadWritePaths below references the
-# path) and the unit fails with status=226/NAMESPACE. The leading +
-# runs the command as root so the directory can be created even when
-# /opt/jabali-webmail is owned by jabali-webmail:jabali-webmail and
-# the user-mode process couldn't mkdir at the required time.
+# JAB-375: dedicated per-service tmp. The AppArmor profile replaces the old
+# PrivateTmp= mount-namespace isolation (which it can't coexist with — see
+# the AppArmorProfile= note below); pointing TMPDIR at a private 0700 subtree
+# under the state dir, plus the profile's `deny /tmp/**`, keeps tmp isolation
+# without a mount namespace. Node's os.tmpdir() and well-behaved libs honour
+# TMPDIR; anything that hardcodes /tmp is denied by the profile.
+Environment=TMPDIR=/var/lib/jabali-webmail/tmp
+# Ensure .next/cache and the tmp subtree exist before the main process
+# starts. The Bulwark tarball doesn't ship the cache subdir. The leading +
+# runs each command as root so the directory can be created even when
+# /opt/jabali-webmail is owned by jabali-webmail:jabali-webmail and the
+# user-mode process couldn't mkdir at the required time.
 ExecStartPre=+/bin/mkdir -p /opt/jabali-webmail/.next/cache
 ExecStartPre=+/bin/chown jabali-webmail:jabali-webmail /opt/jabali-webmail/.next/cache
+ExecStartPre=+/bin/mkdir -p /var/lib/jabali-webmail/tmp
+ExecStartPre=+/bin/chown jabali-webmail:jabali-webmail /var/lib/jabali-webmail/tmp
+ExecStartPre=+/bin/chmod 0700 /var/lib/jabali-webmail/tmp
 ExecStart=/usr/bin/node /opt/jabali-webmail/server-unix.js
 
 # RuntimeDirectory creates /run/jabali-bulwark on every start, owned
@@ -67,11 +75,26 @@ Restart=always
 RestartSec=5s
 
 # Security hardening.
+#
+# JAB-375: confinement is via the AppArmor profile jabali-bulwark, NOT the
+# systemd mount-namespace directives. ProtectSystem=/PrivateTmp=/ProtectHome=
+# each build a private mount namespace, and a mount namespace + this
+# profile's label transition makes Node self-abort at node::Start
+# (status=6/ABRT, no message; deterministic on .86, any one of the three is
+# enough). The AppArmor profile provides strictly tighter file MAC in their
+# place (default-deny read+write vs ProtectSystem=strict's read-only-only),
+# plus network/unix/capability MAC, and TMPDIR+`deny /tmp/**` replace
+# PrivateTmp. Do NOT reintroduce those directives here without removing the
+# AppArmor attach — they cannot coexist. NoNewPrivileges is kept (it is NOT
+# the trigger and is good hardening).
+#
+# The leading '-' on AppArmorProfile makes systemd ignore the attach when
+# AppArmor is absent or the profile isn't loaded (no-LSM hosts, or the
+# install_apparmor kernel-bug skip), so webmail still starts — unconfined —
+# there rather than failing. The profile loads complain on install and the
+# flip-mature timer promotes it to enforce after a clean soak.
 NoNewPrivileges=true
-PrivateTmp=true
-ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/var/lib/jabali-webmail /opt/jabali-webmail/.next/cache /run/jabali-bulwark
+AppArmorProfile=-jabali-bulwark
 
 StandardOutput=journal
 StandardError=journal

--- a/install/tests/test_webmail_apparmor_confine.sh
+++ b/install/tests/test_webmail_apparmor_confine.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# install/tests/test_webmail_apparmor_confine.sh — regression coverage for
+# JAB-375. The jabali-webmail (Bulwark, Next.js) service is confined by the
+# AppArmor profile jabali-bulwark. Two hard constraints, both learned the hard
+# way on the .86 box:
+#
+#   A. The unit attaches the profile via AppArmorProfile= and MUST NOT set any
+#      systemd private-mount-namespace directive (ProtectSystem= / PrivateTmp= /
+#      ProtectHome=). A mount namespace + this profile's label transition makes
+#      Node self-abort at node::Start (status=6/ABRT, no message) — deterministic,
+#      any one of the three is enough. So confinement is via AppArmor file MAC,
+#      not the mount-ns directives, and TMPDIR+`deny /tmp/**` replace PrivateTmp.
+#
+#   B. The profile must grant the REAL runtime paths. The app runs as
+#      /usr/bin/node /opt/jabali-webmail/server-unix.js, config in
+#      /etc/jabali-panel/bulwark.env, state in /var/lib/jabali-webmail. The M40
+#      profile granted the old /usr/local/bin + /var/lib/jabali-bulwark layout
+#      and confined nothing real.
+#
+# Source-level asserts (no host mutation). Run from repo root:
+#     bash install/tests/test_webmail_apparmor_confine.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+unit=install/systemd/jabali-webmail.service
+prof=install/apparmor/usr.local.bin.jabali-bulwark
+
+# --- A. unit: AppArmor attach, NO mount-ns directives, dedicated tmp ---
+if ! grep -qE '^AppArmorProfile=-?jabali-bulwark' "$unit"; then
+  echo "FAIL: $unit must attach the profile (AppArmorProfile=-jabali-bulwark) (JAB-375)"
+  fail=1
+fi
+for d in ProtectSystem PrivateTmp ProtectHome; do
+  if grep -qE "^${d}=" "$unit"; then
+    echo "FAIL: $unit sets ${d}= — a private mount ns + the AppArmor label aborts Node at node::Start (JAB-375). Remove it; the profile provides the file MAC."
+    fail=1
+  fi
+done
+# ReadWritePaths is only meaningful with ProtectSystem; it must go too.
+if grep -qE '^ReadWritePaths=' "$unit"; then
+  echo "FAIL: $unit sets ReadWritePaths= — meaningless without ProtectSystem and part of the mount-ns coupling (JAB-375)"
+  fail=1
+fi
+# dedicated tmp subtree replaces PrivateTmp isolation
+if ! grep -qE '^Environment=TMPDIR=/var/lib/jabali-webmail/tmp' "$unit"; then
+  echo "FAIL: $unit must set TMPDIR to the dedicated per-service subtree (replaces PrivateTmp) (JAB-375)"
+  fail=1
+fi
+if ! grep -qE '^ExecStartPre=.*mkdir.*-p /var/lib/jabali-webmail/tmp' "$unit"; then
+  echo "FAIL: $unit must pre-create the TMPDIR subtree (JAB-375)"
+  fail=1
+fi
+# NoNewPrivileges is not the trigger and is kept.
+if ! grep -qE '^NoNewPrivileges=true' "$unit"; then
+  echo "FAIL: $unit should keep NoNewPrivileges=true (it is not the abort trigger; good hardening)"
+  fail=1
+fi
+
+# --- B. profile: real paths, dedicated-tmp isolation, abi pin ---
+if ! grep -qE '^\s*/opt/jabali-webmail/\*\*\s+r,' "$prof"; then
+  echo "FAIL: $prof must grant the real app tree /opt/jabali-webmail/** r (JAB-375)"
+  fail=1
+fi
+if ! grep -qE '^\s*/etc/jabali-panel/bulwark\.env\s+r,' "$prof"; then
+  echo "FAIL: $prof must grant the real config /etc/jabali-panel/bulwark.env r (JAB-375)"
+  fail=1
+fi
+if ! grep -qE '^\s*/var/lib/jabali-webmail/\*\*\s+rwk,' "$prof"; then
+  echo "FAIL: $prof must grant the real state dir /var/lib/jabali-webmail/** rwk (JAB-375)"
+  fail=1
+fi
+# shared /tmp denied — the dedicated-tmp isolation half
+if ! grep -qE '^\s*deny /tmp/\*\* ' "$prof"; then
+  echo "FAIL: $prof must deny the shared /tmp (tmp is redirected to the dedicated subtree) (JAB-375)"
+  fail=1
+fi
+# panel secrets still denied
+if ! grep -qE '^\s*deny /etc/jabali/\*\* ' "$prof"; then
+  echo "FAIL: $prof must still deny panel secrets under /etc/jabali/** (JAB-351/357)"
+  fail=1
+fi
+# abi 3.0 pin retained (unix bind on broken-mediation kernels)
+if ! grep -qE '^abi <abi/3\.0>,' "$prof"; then
+  echo "FAIL: $prof must keep the abi <abi/3.0> pin so unix bind works on Debian13/Ubuntu24.04 (GH #705)"
+  fail=1
+fi
+# the profile must NOT grant broad write to the app tree beyond .next/cache
+# (version-check writes are silently denied to keep the tree read-only)
+if ! grep -qE '^\s*deny /opt/jabali-webmail/data/\*\* ' "$prof"; then
+  echo "FAIL: $prof should silently deny writes under the read-only app tree's data dir (soak-clean) (JAB-375)"
+  fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "OK: webmail AppArmor confinement guards hold (JAB-375)"
+else
+  exit 1
+fi


### PR DESCRIPTION
## JAB-375 — confine the Bulwark webmail via AppArmor (not a mount namespace)

### Problem
The `jabali-webmail` (Bulwark, Next.js) unit shipped `ProtectSystem=strict` +
`PrivateTmp` + `ProtectHome` but was **never confined by AppArmor**: the
`jabali-bulwark` profile granted the old `/usr/local/bin` + `/var/lib/jabali-bulwark`
layout, while the app actually runs `/usr/bin/node /opt/jabali-webmail/server-unix.js`
(config `/etc/jabali-panel/bulwark.env`, state `/var/lib/jabali-webmail`). So the
profile confined nothing real, and the internet-facing webmail ran unconfined.

### Why it was never wired up (root cause)
Attaching the profile made Node **self-abort at `node::Start`** (`status=6/ABRT`,
no message), crash-looping the service. Bisected directive-by-directive on the .86
box: it is a systemd **private mount namespace** — any one of `ProtectSystem=` /
`PrivateTmp=` / `ProtectHome=` — combined with the `AppArmorProfile=` label
transition. The same profile + node + app run fine via `aa-exec` (no mount ns).
Ruled out: the ruleset (allow-all still aborts), the uid (`User=root` still aborts),
`NoNewPrivileges` (`=no` still aborts).

### Fix
Confine via AppArmor file MAC **in place of** the mount-ns directives.

- **Unit:** drop `ProtectSystem`/`PrivateTmp`/`ProtectHome`/`ReadWritePaths`; attach
  `AppArmorProfile=-jabali-bulwark` (leading `-` → no-AppArmor hosts still start,
  unconfined). Keep `NoNewPrivileges` (not the trigger). Redirect tmp to a dedicated
  `0700` subtree (`TMPDIR=/var/lib/jabali-webmail/tmp`, pre-created in `ExecStartPre`)
  to replace `PrivateTmp`'s isolation.
- **Profile:** correct paths to `/opt/jabali-webmail` (read-only tree + native-addon
  mmap), `/var/lib/jabali-webmail` (rw state), `/etc/jabali-panel/bulwark.env` (its
  own config only). Grant cgroup-v2 memory-limit + own-`/proc` reads for V8 heap
  sizing. `deny /tmp/**` + `deny /var/tmp/**` (dedicated-tmp isolation) and a silent
  `deny` on the read-only app tree's best-effort version-check writes so the profile
  stays soak-clean. Keep `abi <abi/3.0>` (unix bind on broken-mediation kernels) and
  the panel-secret denies.

### Security posture
AppArmor default-deny read+write is **strictly tighter** than `ProtectSystem=strict`
(read-only-only), and adds network/unix/capability MAC the mount-ns directives never
gave. The only delta is `PrivateTmp`'s namespace-isolated `/tmp`, replaced by the
`TMPDIR` subtree + `deny /tmp`.

### Verification
Box-verified on .86 with the **real install artifacts**: confined in **ENFORCE**
(`label=jabali-bulwark (enforce)`), `NRestarts=0`, **HTTP 200** over the socket,
and **ZERO AVC denials** across a 30s soak exercising `/`, `/mail`, `/login`,
`/api/health`, static + favicon. Box restored to baseline afterwards. The profile
still loads **complain** on install; the flip-mature timer (JAB-349) promotes it to
enforce after a clean soak.

### Test plan
- [x] `bash install/tests/test_webmail_apparmor_confine.sh` — new, pins both halves
  (no mount-ns directives + AppArmor attach + dedicated tmp; profile real paths +
  `/tmp` deny + abi pin).
- [x] `bash install/tests/test_webmail_group_isolation.sh` — unchanged, still passes.
- [x] `apparmor_parser -r` parses the profile clean on .86.
- [x] enforce soak: 0 AVC denials, HTTP 200.

Refs JAB-375. Follow-up context: JAB-349 (flip-mature timer), JAB-351/357 (webmail
group isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
