### PR TITLE
feat(security): degraded-AppArmor dashboard alert + runtime smoke test (JAB-379)

### DIFF
--- a/install/tests/test_webmail_apparmor_runtime.sh
+++ b/install/tests/test_webmail_apparmor_runtime.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# install/tests/test_webmail_apparmor_runtime.sh — JAB-379 runtime confinement
+# smoke test. Complements the source-level test_webmail_apparmor_confine.sh by
+# asserting the LIVE webmail process is actually confined:
+#   1. its /proc/<pid>/attr/current carries the jabali-bulwark label, and
+#   2. the profile actually BLOCKS a denied action (reads /etc/shadow under the
+#      label via a throwaway confined process → EACCES).
+#
+# This is a BOX verification, not a CI unit test. CI containers have no AppArmor
+# and no running webmail, and a fresh install sits in complain during its soak —
+# in all those cases it SKIPs cleanly (exit 0) so the install.sh regression gate
+# stays green. It only asserts when the profile is actually in enforce.
+#
+#     bash install/tests/test_webmail_apparmor_runtime.sh
+set -uo pipefail   # NOT -e: the guards decide skip-vs-fail explicitly
+
+PROFILE=jabali-bulwark
+UNIT=jabali-webmail
+
+skip() { echo "SKIP: $*"; exit 0; }
+fail() { echo "FAIL: $*"; exit 1; }
+
+# --- guards: only assert when confinement is actually in effect ---
+command -v aa-status >/dev/null 2>&1 || skip "aa-status not present (AppArmor not installed)"
+[ -d /sys/kernel/security/apparmor ] || skip "AppArmor LSM not active in kernel"
+
+aa_json="$(aa-status --json 2>/dev/null)" || skip "aa-status failed (AppArmor disabled)"
+
+# The profile must be loaded in ENFORCE — the only mode where a denied action is
+# actually blocked. complain (fresh-install soak) → nothing to assert yet.
+mode_line="$(printf '%s' "$aa_json" | grep -oE "\"${PROFILE}\":\"[a-z-]+\"" | head -1)"
+mode="${mode_line##*:\"}"; mode="${mode%\"}"
+[ "$mode" = "enforce" ] || skip "profile ${PROFILE} not enforce (mode=${mode:-absent}); complain soak or unloaded"
+
+pid="$(systemctl show "$UNIT" -p MainPID --value 2>/dev/null)"
+{ [ -n "$pid" ] && [ "$pid" != 0 ]; } || skip "${UNIT} not running (lazy-start until first mail domain)"
+
+fails=0
+
+# --- assert 1: the live webmail process carries the jabali-bulwark label ---
+label="$(tr -d '\0' < "/proc/$pid/attr/current" 2>/dev/null)"
+case "$label" in
+  ${PROFILE}*) echo "OK: ${UNIT} pid $pid confined as '$label'" ;;
+  *) echo "FAIL: ${UNIT} pid $pid label is '${label:-none}', want '${PROFILE} (enforce)'"; fails=1 ;;
+esac
+
+# --- assert 2: the profile actually BLOCKS a denied action ---
+# Read /etc/shadow (which the profile hard-denies) under the label via a
+# throwaway confined process — proves enforcement non-destructively, without
+# touching the real webmail. Require BOTH a non-zero rc AND an EACCES message:
+# rc alone would false-pass if aa-exec or the file were missing.
+probe_err="$(aa-exec -p "$PROFILE" -- cat /etc/shadow 2>&1 >/dev/null)"; probe_rc=$?
+if [ "$probe_rc" -eq 0 ]; then
+  echo "FAIL: confined read of /etc/shadow SUCCEEDED — profile is not blocking denies"
+  fails=1
+elif ! printf '%s' "$probe_err" | grep -qi "permission denied"; then
+  echo "FAIL: confined read of /etc/shadow failed but not with EACCES (got: ${probe_err}); block unconfirmed"
+  fails=1
+else
+  echo "OK: confined read of /etc/shadow denied (Permission denied)"
+fi
+
+[ "$fails" -eq 0 ] || fail "runtime confinement assertions failed"
+echo "PASS: ${UNIT} confined at runtime — label + enforced deny (JAB-379)"

--- a/panel-agent/internal/commands/security_apparmor.go
+++ b/panel-agent/internal/commands/security_apparmor.go
@@ -127,10 +127,35 @@ func mwApparmorStatusHandler(ctx context.Context, _ json.RawMessage) (any, error
 		return resp, nil
 	}
 
-	for name, mode := range raw.Profiles {
+	profiles, reason := buildApparmorProfileList(raw.Profiles)
+	resp.Profiles = profiles
+	if reason != "" {
+		resp.Reason = reason
+	}
+
+	// Best-effort denial scrape. Failures (journalctl missing, no
+	// matches) leave Denials as the empty slice — never error here.
+	resp.Denials = readApparmorEvents(ctx, "DENIED")
+	resp.Violations = readApparmorEvents(ctx, "ALLOWED")
+	return resp, nil
+}
+
+// buildApparmorProfileList filters the raw `aa-status --json` profile map to the
+// jabali (+ stalwart-mail) profiles we own, and reports EXPECTED-but-absent
+// profiles as "missing" (a genuine failure) or "kernel-gated" (a DELIBERATE skip
+// on kernels lacking /sys/kernel/security/apparmor/features/unix — Debian 13 /
+// Ubuntu 24.04 broken unix mediation, #687/#679; not a failure). Returns the
+// profile rows plus an optional human-readable reason for any kernel-gated rows.
+//
+// Single-sourced so the full status verb (with the audit-log denial scrape) and
+// the lightweight summary verb (dashboard degraded-alert source) agree on the
+// hard-won special cases: the `//` child-shadow skip, the jabali-ssh-shell
+// unconfined-by-design exclusion, and the missing-vs-kernel-gated distinction.
+func buildApparmorProfileList(rawProfiles map[string]string) ([]apparmorProfile, string) {
+	profiles := []apparmorProfile{}
+	for name, mode := range rawProfiles {
 		// Filter to jabali profiles + the system-service profiles we ship.
-		if !strings.HasPrefix(name, "jabali-") &&
-			name != "stalwart-mail" {
+		if !strings.HasPrefix(name, "jabali-") && name != "stalwart-mail" {
 			continue
 		}
 		// Skip complain-mode child shadow profiles (e.g. "jabali-panel//null-/usr/sbin/...").
@@ -143,50 +168,36 @@ func mwApparmorStatusHandler(ctx context.Context, _ json.RawMessage) (any, error
 		if name == "jabali-ssh-shell" {
 			continue
 		}
-		resp.Profiles = append(resp.Profiles, apparmorProfile{
-			Name: name,
-			Mode: mode,
-		})
+		profiles = append(profiles, apparmorProfile{Name: name, Mode: mode})
 	}
 
 	// GH #679: report EXPECTED jabali profiles that are missing/unloaded instead
-	// of silently omitting them. BUT distinguish two cases: a genuine failure
-	// ("missing", red) vs a DELIBERATE kernel-gate skip. On kernels lacking
-	// /sys/kernel/security/apparmor/features/unix (Debian 13 / Ubuntu 24.04
-	// broken unix-socket mediation), install_apparmor intentionally does NOT load
-	// the daemon profiles (#687) — attaching them would EACCES DNS/DB. That is
-	// working-as-designed, not a failure, so report it as "kernel-gated" (neutral)
-	// and explain it, rather than an alarming red "missing".
-	// Profiles are now abi/3.0-pinned and LOADED in complain even on kernels
-	// without unix mediation (GH #705-followup), so a profile absent from
-	// aa-status on such a kernel is "kernel-gated" (couldn't load / was skipped
-	// by an older install) rather than a genuine "missing" failure. Only surface
-	// the explanatory reason if we actually have such a row.
+	// of silently omitting them, distinguishing a genuine failure ("missing", red)
+	// from a DELIBERATE kernel-gate skip. Profiles are abi/3.0-pinned and load in
+	// complain even without unix mediation (GH #705-followup), so a profile absent
+	// on such a kernel is "kernel-gated" (couldn't load / predates the fix) rather
+	// than a genuine "missing" failure. Only surface the reason if we have such a row.
 	unixOK := apparmorUnixMediationAvailable()
+	reason := ""
 	sawKernelGated := false
 	for name := range allowedProfiles {
-		if _, ok := raw.Profiles[name]; !ok {
+		if _, ok := rawProfiles[name]; !ok {
 			mode := "missing"
 			if !unixOK {
 				mode = "kernel-gated"
 				sawKernelGated = true
 			}
-			resp.Profiles = append(resp.Profiles, apparmorProfile{Name: name, Mode: mode})
+			profiles = append(profiles, apparmorProfile{Name: name, Mode: mode})
 		}
 	}
-	if sawKernelGated && resp.Reason == "" {
-		resp.Reason = "AppArmor unix-socket mediation is unavailable on this kernel " +
+	if sawKernelGated {
+		reason = "AppArmor unix-socket mediation is unavailable on this kernel " +
 			"(no /sys/kernel/security/apparmor/features/unix — Debian 13 / Ubuntu 24.04). " +
 			"Jabali profiles are abi/3.0-pinned so they normally load in complain here; a " +
 			"profile still showing kernel-gated failed to load or predates this fix — run " +
 			"jabali update. This is not a security failure."
 	}
-
-	// Best-effort denial scrape. Failures (journalctl missing, no
-	// matches) leave Denials as the empty slice — never error here.
-	resp.Denials = readApparmorEvents(ctx, "DENIED")
-	resp.Violations = readApparmorEvents(ctx, "ALLOWED")
-	return resp, nil
+	return profiles, reason
 }
 
 // AppArmor AVC audit-line format the kernel emits. Sample:
@@ -370,8 +381,51 @@ func mwApparmorSetModeHandler(ctx context.Context, raw json.RawMessage) (any, er
 	}, nil
 }
 
+// apparmorSummaryResponse is the lightweight status shape: profile modes only,
+// no denial/violation audit scrape.
+type apparmorSummaryResponse struct {
+	Enabled  bool              `json:"enabled"`
+	Profiles []apparmorProfile `json:"profiles"`
+	Reason   string            `json:"reason,omitempty"`
+}
+
+// mwApparmorSummaryHandler backs the admin dashboard's degraded-security alert.
+// It returns the same jabali profile modes as the status verb but SKIPS the
+// audit-log denial/violation scrape (8MB tail + regex). The dashboard polls
+// /admin/server-status every ~5s from any open admin tab; running that scrape
+// on such a cadence would burn a core — the same reason server_status uses the
+// cheap nginx.status verb over nginx.test. aa-status --json is sub-second.
+func mwApparmorSummaryHandler(ctx context.Context, _ json.RawMessage) (any, error) {
+	ctx, cancel := context.WithTimeout(ctx, apparmorCallTimeout)
+	defer cancel()
+
+	resp := apparmorSummaryResponse{Profiles: []apparmorProfile{}}
+
+	out, err := execCommandContext(ctx, "aa-status", "--json").Output()
+	if err != nil {
+		// Disabled / not-installed → Enabled=false, not an internal error;
+		// the dashboard treats !enabled as "nothing to alert on".
+		resp.Enabled = false
+		resp.Reason = fmt.Sprintf("aa-status: %v", err)
+		return resp, nil
+	}
+	resp.Enabled = true
+
+	var raw struct {
+		Profiles map[string]string `json:"profiles"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return resp, nil
+	}
+	profiles, reason := buildApparmorProfileList(raw.Profiles)
+	resp.Profiles = profiles
+	resp.Reason = reason
+	return resp, nil
+}
+
 func init() {
 	Default.Register("security.apparmor.status", mwApparmorStatusHandler)
+	Default.Register("security.apparmor.summary", mwApparmorSummaryHandler)
 	Default.Register("security.apparmor.set_mode", mwApparmorSetModeHandler)
 }
 

--- a/panel-agent/internal/commands/security_apparmor_summary_test.go
+++ b/panel-agent/internal/commands/security_apparmor_summary_test.go
@@ -1,0 +1,77 @@
+package commands
+
+import "testing"
+
+// JAB-379: buildApparmorProfileList is the single source of the jabali-profile
+// filtering shared by security.apparmor.status (with denial scrape) and the
+// lightweight security.apparmor.summary (dashboard degraded-alert source). Pin
+// the hard-won special cases: non-jabali skip, `//` child-shadow skip,
+// jabali-ssh-shell unconfined-by-design skip, and missing-profile reporting.
+func TestBuildApparmorProfileList(t *testing.T) {
+	raw := map[string]string{
+		"jabali-bulwark":                     "enforce",
+		"jabali-panel":                       "complain",
+		"stalwart-mail":                      "enforce",
+		"jabali-panel//null-/usr/sbin/other": "complain", // child shadow — skip
+		"jabali-ssh-shell":                   "unconfined", // by-design — skip
+		"mariadbd":                           "enforce",    // non-jabali — skip
+		"jabali-fpm-app":                     "enforce",
+	}
+
+	profiles, _ := buildApparmorProfileList(raw)
+
+	got := map[string]string{}
+	for _, p := range profiles {
+		got[p.Name] = p.Mode
+	}
+
+	// Kept, with their real modes.
+	for name, wantMode := range map[string]string{
+		"jabali-bulwark": "enforce",
+		"jabali-panel":   "complain",
+		"stalwart-mail":  "enforce",
+		"jabali-fpm-app": "enforce",
+	} {
+		if got[name] != wantMode {
+			t.Errorf("profile %q: want mode %q, got %q", name, wantMode, got[name])
+		}
+	}
+
+	// Skipped entirely.
+	for _, name := range []string{
+		"jabali-panel//null-/usr/sbin/other",
+		"jabali-ssh-shell",
+		"mariadbd",
+	} {
+		if _, ok := got[name]; ok {
+			t.Errorf("profile %q must be filtered out, but appeared as %q", name, got[name])
+		}
+	}
+}
+
+// An allowlisted profile absent from aa-status is reported (GH #679) — as
+// "missing" (genuine failure) or "kernel-gated" (deliberate skip on kernels
+// without unix mediation). Which one is host-dependent (reads /sys), so assert
+// the row exists with one of those two modes rather than pinning the kernel.
+func TestBuildApparmorProfileList_AbsentProfileReported(t *testing.T) {
+	// jabali-bulwark present; the other allowlisted profiles are absent.
+	profiles, _ := buildApparmorProfileList(map[string]string{
+		"jabali-bulwark": "enforce",
+	})
+
+	got := map[string]string{}
+	for _, p := range profiles {
+		got[p.Name] = p.Mode
+	}
+
+	for _, name := range []string{"jabali-panel", "stalwart-mail", "jabali-fpm-app"} {
+		mode, ok := got[name]
+		if !ok {
+			t.Errorf("absent allowlisted profile %q must be reported, not omitted", name)
+			continue
+		}
+		if mode != "missing" && mode != "kernel-gated" {
+			t.Errorf("absent profile %q: want missing|kernel-gated, got %q", name, mode)
+		}
+	}
+}

--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -160,6 +161,13 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 	// nginx.test remains the gate for nginx.reload, where it belongs.
 	call("nginx", "nginx.status", nil, subCallTimeout)
 
+	// JAB-379: lightweight AppArmor profile-mode summary (no audit scrape) so
+	// synthesizeAlerts can warn when a jabali profile is complain/missing/
+	// unconfined rather than enforce. security.apparmor.summary is the cheap
+	// verb built for this poller — the full security.apparmor.status scrapes an
+	// 8MB audit tail and must not run on the 5s dashboard cadence.
+	call("apparmor", "security.apparmor.summary", nil, subCallTimeout)
+
 	// M31.1 — Redis queue depths run in parallel with the agent calls.
 	// Three XLEN/XPending pipelines, each with its own short timeout so
 	// a Redis hiccup never delays the whole envelope.
@@ -305,11 +313,59 @@ func synthesizeAlerts(results map[string]json.RawMessage, errMap map[string]stri
 			})
 			continue
 		}
+		if name == "apparmor" {
+			// JAB-379: degraded-observability must fail SILENT. A missing
+			// security.apparmor.summary verb (agent/panel version skew, trimmed
+			// update path) would otherwise raise a persistent false "agent
+			// sub-call failed" banner every 5s until both binaries align. Don't
+			// alert on the alerting mechanism's own unavailability.
+			continue
+		}
 		alerts = append(alerts, ServerStatusAlert{
 			Level:  "warning",
 			Kind:   "agent",
 			Detail: "agent sub-call '" + name + "': " + msg,
 		})
+	}
+
+	// JAB-379: degraded-AppArmor alert. Warn (not critical — nothing is down)
+	// when a jabali profile is loaded but NOT enforcing: a fresh install still
+	// in its complain soak, or a profile the flip-mature timer hasn't promoted
+	// (or was blocked from promoting by a denial). Excluded on purpose:
+	//   - enforce      — the desired state
+	//   - kernel-gated — working-as-designed on kernels without unix mediation;
+	//                    the agent already labels these, alerting is a false alarm
+	//   - enabled=false — a no-AppArmor host would otherwise show a permanent,
+	//                     unactionable banner
+	if rawAA, ok := results["apparmor"]; ok {
+		var payload struct {
+			Enabled  bool `json:"enabled"`
+			Profiles []struct {
+				Name string `json:"name"`
+				Mode string `json:"mode"`
+			} `json:"profiles"`
+		}
+		if err := json.Unmarshal(rawAA, &payload); err == nil && payload.Enabled {
+			degraded := []string{}
+			for _, p := range payload.Profiles {
+				switch p.Mode {
+				case "complain", "missing", "unconfined":
+					degraded = append(degraded, p.Name+" ("+p.Mode+")")
+				}
+			}
+			if len(degraded) > 0 {
+				sort.Strings(degraded) // deterministic order for the banner + tests
+				noun := "profiles"
+				if len(degraded) == 1 {
+					noun = "profile"
+				}
+				alerts = append(alerts, ServerStatusAlert{
+					Level: "warning", Kind: "apparmor",
+					Detail: formatInt64(int64(len(degraded))) + " AppArmor " + noun +
+						" not enforcing: " + strings.Join(degraded, ", "),
+				})
+			}
+		}
 	}
 
 	// Failed services → critical. Inactive services → critical only if

--- a/panel-api/internal/api/server_status_alerts_internal_test.go
+++ b/panel-api/internal/api/server_status_alerts_internal_test.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -23,4 +24,129 @@ func TestSynthesizeAlerts_HealthyServerReturnsEmptyNotNil(t *testing.T) {
 	if string(b) != "[]" {
 		t.Errorf("healthy-server alerts must marshal as [], got %s", b)
 	}
+}
+
+// JAB-379: the degraded-AppArmor alert decision table. A jabali profile that is
+// complain/missing/unconfined → one warning alert; enforce + kernel-gated +
+// disabled + a failed agent call → nothing.
+func TestSynthesizeAlerts_AppArmorDegraded(t *testing.T) {
+	aaResult := func(enabled bool, profiles ...[2]string) map[string]json.RawMessage {
+		type prof struct {
+			Name string `json:"name"`
+			Mode string `json:"mode"`
+		}
+		payload := struct {
+			Enabled  bool   `json:"enabled"`
+			Profiles []prof `json:"profiles"`
+		}{Enabled: enabled}
+		for _, p := range profiles {
+			payload.Profiles = append(payload.Profiles, prof{Name: p[0], Mode: p[1]})
+		}
+		b, _ := json.Marshal(payload)
+		return map[string]json.RawMessage{"apparmor": b}
+	}
+	// find the single apparmor alert (if any) in the result.
+	findAA := func(alerts []ServerStatusAlert) *ServerStatusAlert {
+		var found *ServerStatusAlert
+		n := 0
+		for i := range alerts {
+			if alerts[i].Kind == "apparmor" {
+				found = &alerts[i]
+				n++
+			}
+		}
+		if n > 1 {
+			t.Fatalf("want at most one apparmor alert, got %d", n)
+		}
+		return found
+	}
+
+	t.Run("all enforce → no alert", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(true,
+			[2]string{"jabali-bulwark", "enforce"},
+			[2]string{"jabali-panel", "enforce"},
+		), map[string]string{})
+		if a := findAA(got); a != nil {
+			t.Fatalf("enforce-only must not alert, got %q", a.Detail)
+		}
+	})
+
+	t.Run("one complain → warning with name+mode", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(true,
+			[2]string{"jabali-bulwark", "complain"},
+			[2]string{"jabali-panel", "enforce"},
+		), map[string]string{})
+		a := findAA(got)
+		if a == nil {
+			t.Fatal("complain profile must raise an apparmor alert")
+		}
+		if a.Level != "warning" {
+			t.Errorf("level: want warning, got %q", a.Level)
+		}
+		if !strings.Contains(a.Detail, "jabali-bulwark (complain)") {
+			t.Errorf("detail must name the profile+mode, got %q", a.Detail)
+		}
+		if !strings.Contains(a.Detail, "1 AppArmor profile") {
+			t.Errorf("detail must count 1 profile (singular), got %q", a.Detail)
+		}
+	})
+
+	t.Run("missing → warning", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(true,
+			[2]string{"jabali-fpm-app", "missing"},
+		), map[string]string{})
+		if findAA(got) == nil {
+			t.Fatal("a missing profile must alert")
+		}
+	})
+
+	t.Run("kernel-gated only → no alert", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(true,
+			[2]string{"jabali-bulwark", "kernel-gated"},
+			[2]string{"jabali-panel", "kernel-gated"},
+		), map[string]string{})
+		if a := findAA(got); a != nil {
+			t.Fatalf("kernel-gated is working-as-designed, must not alert, got %q", a.Detail)
+		}
+	})
+
+	t.Run("enabled=false → no alert", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(false,
+			[2]string{"jabali-bulwark", "complain"},
+		), map[string]string{})
+		if a := findAA(got); a != nil {
+			t.Fatalf("no-AppArmor host must not alert, got %q", a.Detail)
+		}
+	})
+
+	t.Run("failed agent call → silent (no apparmor OR agent alert)", func(t *testing.T) {
+		got := synthesizeAlerts(map[string]json.RawMessage{}, map[string]string{"apparmor": "timeout"})
+		for _, a := range got {
+			if a.Kind == "apparmor" {
+				t.Fatalf("a failed summary call must not raise an apparmor alert, got %q", a.Detail)
+			}
+			if a.Kind == "agent" && strings.Contains(a.Detail, "apparmor") {
+				t.Fatalf("a failed summary call must not raise the generic agent alert, got %q", a.Detail)
+			}
+		}
+	})
+
+	t.Run("multiple degraded → sorted, counted", func(t *testing.T) {
+		got := synthesizeAlerts(aaResult(true,
+			[2]string{"jabali-panel", "complain"},
+			[2]string{"jabali-bulwark", "missing"},
+			[2]string{"stalwart-mail", "enforce"},
+		), map[string]string{})
+		a := findAA(got)
+		if a == nil {
+			t.Fatal("two degraded profiles must alert")
+		}
+		if !strings.Contains(a.Detail, "2 AppArmor profiles") {
+			t.Errorf("want plural count of 2, got %q", a.Detail)
+		}
+		// sorted: jabali-bulwark before jabali-panel
+		if strings.Index(a.Detail, "jabali-bulwark") > strings.Index(a.Detail, "jabali-panel") {
+			t.Errorf("degraded names must be sorted, got %q", a.Detail)
+		}
+	})
 }

--- a/panel-ui/src/shells/admin/server-status/AlertsBanner.tsx
+++ b/panel-ui/src/shells/admin/server-status/AlertsBanner.tsx
@@ -57,6 +57,11 @@ function deriveLink(a: ServerAlert): { path: string; label: string } | null {
       return { path: "/jabali-admin/updates", label: "Open Updates" };
     case "crowdsec":
       return { path: "/jabali-admin/security", label: "Open Security" };
+    case "apparmor":
+      // JAB-379: a jabali AppArmor profile is complain/missing/unconfined
+      // rather than enforce. The Security page's AppArmor section shows each
+      // profile's mode + the per-profile enforce/complain flip control.
+      return { path: "/jabali-admin/security", label: "Open Security" };
     default:
       return null;
   }


### PR DESCRIPTION
## JAB-379 — degraded-AppArmor dashboard alert + runtime confinement smoke test

Follow-up to JAB-375 (PR #1222 shipped the webmail confinement). Two observability
items that PR split out — both are observability, not confinement.

### 1. Degraded-AppArmor dashboard alert
The admin dashboard now warns when a jabali AppArmor profile is loaded but **not
enforcing** — a fresh install still in its complain soak, or a profile the
flip-mature timer hasn't promoted (or was blocked from promoting by a denial).

- **Agent:** new lightweight verb `security.apparmor.summary` — profile modes
  only, **no** 8MB audit-log denial scrape. `/admin/server-status` polls every
  ~5s from any open admin tab; the full `security.apparmor.status` scrape on that
  cadence would burn a core (same reasoning the file already documents for
  `nginx.status` vs `nginx.test`). The jabali profile-collection/filter logic
  (the `//` child-shadow skip, `jabali-ssh-shell` unconfined-by-design exclusion,
  GH #679 missing-vs-kernel-gated distinction) is extracted into a shared
  `buildApparmorProfileList` so `status` and `summary` stay single-sourced.
- **panel-api:** `server_status` fans the summary into its existing alert
  synthesis; `synthesizeAlerts` emits a `Kind:"apparmor"` **warning** when any
  profile mode is complain/missing/unconfined. Excluded on purpose: `enforce`
  (desired), `kernel-gated` (working-as-designed on kernels without unix
  mediation), `enabled=false` (no-AppArmor host — no permanent unactionable
  banner), and a **failed** summary call (agent/panel version skew must fail
  silent, not raise a persistent false "agent sub-call failed" banner every 5s).
- **panel-ui:** `AlertsBanner` deep-links the new kind to `/jabali-admin/security`
  (its AppArmor section shows each profile's mode + the enforce/complain flip).

### 2. Runtime confinement smoke test
`install/tests/test_webmail_apparmor_runtime.sh` asserts the LIVE webmail process
is actually confined: its `/proc/<pid>/attr/current` carries the `jabali-bulwark`
label AND the profile blocks a denied action (reads `/etc/shadow` under the label
via a throwaway confined process → EACCES, requiring both `rc!=0` and the
Permission-denied message — `rc` alone would false-pass on a missing `aa-exec`).
Guarded: SKIPs cleanly (exit 0) when AppArmor is absent, the profile isn't
enforce (complain soak), or webmail isn't running — so CI stays green; its venue
is box verification.

### Tests
- [x] Agent `TestBuildApparmorProfileList{,_AbsentProfileReported}` — shared filter special cases.
- [x] panel-api `TestSynthesizeAlerts_AppArmorDegraded` — full decision table (all-enforce / complain / missing / kernel-gated / disabled / failed-call / multi-sorted).
- [x] `npm run build` clean (AlertsBanner change).
- [x] Runtime test SKIPs cleanly with no AppArmor.
- [x] **Box (.86):** the refactored shared helper enumerates all jabali profiles + modes correctly against real `aa-status --json` (shape matches the reused parser — same parse as the shipped `status` verb). Box restored to baseline.

No new HTTP route (the alert rides the existing `/admin/server-status` envelope) → no openapi/cli-reference golden regen. Refs JAB-379, JAB-375, JAB-349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
