### PR TITLE
feat(security): API-side write allow-list pre-check for the admin File Manager (JAB-367)

### DIFF
--- a/panel-agent/internal/commands/files_admin_writescope_reject_test.go
+++ b/panel-agent/internal/commands/files_admin_writescope_reject_test.go
@@ -1,0 +1,96 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
+)
+
+// JAB-367 (criterion 6): belt-and-suspenders per-command coverage that EVERY
+// mutating admin File Manager command refuses an admin_root write outside the
+// safe data roots (read_only) or inside the hard deny-list (path_denied). All
+// commands route their destination through scope.WriteScope() (JAB-358); this
+// pins that wiring per command, not just on files.write. Rejection is at the
+// lexical string gate, so these run unprivileged in CI with no filesystem.
+func TestAdminFileManager_MutatingCommandsRejectOutOfAllowList(t *testing.T) {
+	const (
+		// Outside the safe write roots (/home, /var/www, /srv, /tmp, /var/tmp)
+		// but NOT in the deny-list → the WriteScope refuses it as read_only.
+		sysPath = "/etc/cron.d/jab367-pwn"
+		// Inside the hard deny-list (jabali control-plane). For a MUTATION this
+		// still surfaces as read_only, not path_denied: WriteScope checks
+		// mutable-root membership first, and every deny-list prefix is also
+		// outside the write roots, so the read-only gate fires first. (path_denied
+		// is the distinct code for READS of a denied path, where the scope is "/".)
+		// Either way a deny-list path can never be written — which is the point.
+		denyPath = "/etc/jabali/config.toml"
+		// A valid upload scratch file (tmpUploadPrefix, no slash after) so the
+		// ingest handler reaches its DESTINATION WriteScope check rather than
+		// rejecting on tmp_path first.
+		okTmp = "/var/lib/jabali-uploads/jabali-upload-jab367test"
+		// Lexically valid write-root path — used where a command needs a
+		// separate (readable) source so we isolate the DESTINATION rejection.
+		okZip = "/tmp/jab367-ok.zip"
+	)
+
+	type tc struct {
+		name    string
+		handler func(context.Context, json.RawMessage) (any, error)
+		params  any
+		wantSub string // "read_only" | "path_denied"
+	}
+	adm := func(extra map[string]any) map[string]any {
+		m := map[string]any{"user_id": "admin", "username": "admin", "admin_root": true}
+		for k, v := range extra {
+			m[k] = v
+		}
+		return m
+	}
+
+	cases := []tc{
+		// read_only: a system path outside the safe roots, per mutating command.
+		{"write→read_only", filesWriteHandler, adm(map[string]any{"path": sysPath, "content": "x"}), "read_only"},
+		{"mkdir→read_only", filesMkdirHandler, adm(map[string]any{"path": sysPath}), "read_only"},
+		{"delete→read_only", filesDeleteHandler, adm(map[string]any{"path": sysPath}), "read_only"},
+		{"chmod→read_only", filesChmodHandler, adm(map[string]any{"path": sysPath, "mode": "0644"}), "read_only"},
+		{"move→read_only", filesMoveHandler, adm(map[string]any{"old_path": sysPath, "new_path": sysPath + ".moved"}), "read_only"},
+		{"rename→read_only", filesRenameHandler, adm(map[string]any{"old_path": sysPath, "new_path": "/etc/cron.d/jab367-renamed"}), "read_only"},
+		{"copy→read_only", filesCopyHandler, adm(map[string]any{"src_path": sysPath, "dst_path": sysPath + ".copy"}), "read_only"},
+		{"ingest→read_only", filesIngestHandler, adm(map[string]any{"tmp_path": okTmp, "dest_path": sysPath}), "read_only"},
+		// extract: archive read is fine (valid write-root path); the DESTINATION
+		// is the mutation and must be refused.
+		{"extract dest→read_only", filesExtractHandler, adm(map[string]any{"path": okZip, "dest": sysPath}), "read_only"},
+
+		// A deny-list control-plane path can never be written by any command
+		// (surfaces as read_only for a mutation — see denyPath comment above).
+		{"write deny-list refused", filesWriteHandler, adm(map[string]any{"path": denyPath, "content": "x"}), "read_only"},
+		{"delete deny-list refused", filesDeleteHandler, adm(map[string]any{"path": denyPath}), "read_only"},
+		{"chmod deny-list refused", filesChmodHandler, adm(map[string]any{"path": denyPath, "mode": "0777"}), "read_only"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			params, err := json.Marshal(c.params)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			_, callErr := c.handler(context.Background(), params)
+			if callErr == nil {
+				t.Fatalf("%s: expected the mutation to be refused, got nil error", c.name)
+			}
+			var ae *agentwire.AgentError
+			if !isAgentError(callErr, &ae) {
+				t.Fatalf("%s: want an *agentwire.AgentError, got %T: %v", c.name, callErr, callErr)
+			}
+			if ae.Code != agentwire.CodeInvalidArgument {
+				t.Errorf("%s: want code %q, got %q", c.name, agentwire.CodeInvalidArgument, ae.Code)
+			}
+			if !strings.Contains(callErr.Error(), c.wantSub) {
+				t.Errorf("%s: want error containing %q, got %q", c.name, c.wantSub, callErr.Error())
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
@@ -488,6 +489,59 @@ const adminFilesCtxKey = "jabali_admin_files"
 
 func (h *filesHandler) adminRoot(c *gin.Context) bool { return c.GetBool(adminFilesCtxKey) }
 
+// rejectAdminWriteOutOfScope is the API-side, defense-in-depth pre-check for the
+// GH #1184 admin File Manager (JAB-367, criterion 4). For an admin_root mutation
+// it validates every destination path against the SAME write allow-list the
+// agent enforces — filesafe.NewAdminScope(...).WriteScope(), the safe data roots
+// (/home, /var/www, …) minus the hard deny-list — and refuses, BEFORE the agent
+// call, a write outside the allow-list (read_only) or inside a denied prefix
+// (path_denied). The agent remains authoritative: it re-runs this exact check
+// AND adds the kernel openat2 RESOLVE_BENEATH resolution that catches a symlink
+// escape this lexical layer cannot see. So this is layered enforcement, never
+// the sole gate.
+//
+// Tenant (non-admin_root) requests are scoped to the tenant docroot by the agent
+// and are deliberately NOT checked here — the API doesn't know a tenant's
+// docroots and must not second-guess the agent's per-tenant scope.
+//
+// Returns true (and writes the 403) when the request is rejected — the caller
+// must stop. Returns false when every path is allowed (or the request isn't
+// admin_root). The 403 body matches respondAgentError's envelope for the same
+// violation so the SPA renders one message regardless of which layer rejected.
+func (h *filesHandler) rejectAdminWriteOutOfScope(c *gin.Context, paths ...string) bool {
+	if !h.adminRoot(c) {
+		return false
+	}
+	// The username is irrelevant to a root-scoped admin write check (WriteScope
+	// narrows to the fixed mutable roots, not /home/<user>); NewAdminScope only
+	// requires it to be non-empty, so a fixed placeholder is correct here.
+	scope, err := filesafe.NewAdminScope("", "admin-file-manager",
+		filesafe.DefaultAdminDeniedPrefixes, filesafe.DefaultAdminMutableRoots)
+	if err != nil {
+		// The allow-list is a package constant; a construction failure is a
+		// server fault, never caller input. Fail CLOSED — never let an
+		// admin_root mutation through on a broken pre-check.
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return true
+	}
+	wscope := scope.WriteScope()
+	for _, p := range paths {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if _, err := wscope.Clean(p); err != nil {
+			code := filesafe.ErrCodeReadOnly
+			var ve *filesafe.ValidationError
+			if errors.As(err, &ve) {
+				code = ve.Code
+			}
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": code})
+			return true
+		}
+	}
+	return false
+}
+
 func (h *filesHandler) requireClaimsAndUsername(c *gin.Context) (userID, username string, ok bool) {
 	claims := ginctx.Claims(c)
 	if claims == nil {
@@ -552,7 +606,14 @@ func agentErrorStatus(err error) int {
 		return http.StatusInsufficientStorage
 	case strings.Contains(msg, "not_in_scope"),
 		strings.Contains(msg, "symlink_escape"),
-		strings.Contains(msg, "path_traversal"):
+		strings.Contains(msg, "path_traversal"),
+		// JAB-367: admin File Manager write allow-list rejections. The agent's
+		// WriteScope refuses a mutation outside the safe data roots (read_only)
+		// or inside the hard deny-list (path_denied); both are a 403, not the
+		// generic 500 they used to fall through to — and they now match the
+		// envelope the API-side pre-check emits for the same violation.
+		strings.Contains(msg, "read_only"),
+		strings.Contains(msg, "path_denied"):
 		return http.StatusForbidden
 	case strings.Contains(msg, "contains_null"),
 		strings.Contains(msg, "bad_characters"),
@@ -585,6 +646,13 @@ func agentErrorCode(err error) string {
 		return "disk_full"
 	case strings.Contains(msg, "already_exists"):
 		return "already_exists"
+	// JAB-367: surface the admin FM write-allow-list codes distinctly (was
+	// "agent_error") so the SPA renders the right message AND the agent path
+	// matches the API-side pre-check's envelope for the same violation.
+	case strings.Contains(msg, "read_only"):
+		return "read_only"
+	case strings.Contains(msg, "path_denied"):
+		return "path_denied"
 	default:
 		return "agent_error"
 	}
@@ -909,6 +977,10 @@ func (h *filesHandler) upload(c *gin.Context) {
 	// written — supersedes any earlier pre-override audit_target on this path.
 	c.Set("audit_target", destPath+" (upload)")
 	c.Set("audit_target_type", "file")
+	if h.rejectAdminWriteOutOfScope(c, destPath) {
+		_ = os.Remove(tmpPath) // don't leak the panel staging file on a rejected admin upload
+		return
+	}
 	_, err = h.cfg.Agent.Call(c.Request.Context(), "files.ingest", filesIngestAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), TmpPath: tmpPath, DestPath: destPath,
 		Overwrite: c.Query("overwrite") == "true",
@@ -929,6 +1001,9 @@ func (h *filesHandler) mkdir(c *gin.Context) {
 	var req mkdirRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
+		return
+	}
+	if h.rejectAdminWriteOutOfScope(c, req.Path) {
 		return
 	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.mkdir", filesMkdirAgentParams{
@@ -956,6 +1031,16 @@ func (h *filesHandler) extract(c *gin.Context) {
 	}
 	c.Set("audit_target", req.Path) // GH #658: audit the concrete file path
 	c.Set("audit_target_type", "file")
+	// Only the extraction DESTINATION is a mutation (the archive itself is read
+	// from the broad scope). Mirror the agent: explicit dest, else the archive's
+	// parent directory.
+	extractDest := req.Dest
+	if strings.TrimSpace(extractDest) == "" {
+		extractDest = filepath.Dir(req.Path)
+	}
+	if h.rejectAdminWriteOutOfScope(c, extractDest) {
+		return
+	}
 	raw, err := h.cfg.Agent.Call(c.Request.Context(), "files.extract", filesExtractAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: req.Path, Dest: req.Dest,
 	})
@@ -983,6 +1068,10 @@ func (h *filesHandler) rename(c *gin.Context) {
 		return
 	}
 	newPath := filepath.Join(filepath.Dir(req.Path), req.NewName)
+	// The agent WriteScopes both the old and new paths; mirror that.
+	if h.rejectAdminWriteOutOfScope(c, req.Path, newPath) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.rename", filesRenameAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), OldPath: req.Path, NewPath: newPath,
 	})
@@ -1017,6 +1106,10 @@ func (h *filesHandler) move(c *gin.Context) {
 		return
 	}
 	newPath := filepath.Join(req.DestDir, filepath.Base(req.Path))
+	// The agent WriteScopes both the source and destination; mirror that.
+	if h.rejectAdminWriteOutOfScope(c, req.Path, newPath) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.move", filesMoveAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), OldPath: req.Path, NewPath: newPath,
 	})
@@ -1044,6 +1137,9 @@ func (h *filesHandler) chmod(c *gin.Context) {
 	}
 	c.Set("audit_target", req.Path) // GH #658: audit the concrete file path
 	c.Set("audit_target_type", "file")
+	if h.rejectAdminWriteOutOfScope(c, req.Path) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.chmod", filesChmodAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: req.Path, Mode: req.Mode,
 	})
@@ -1171,6 +1267,11 @@ func (h *filesHandler) copy(c *gin.Context) {
 		return
 	}
 	dst := filepath.Join(req.DestDir, filepath.Base(req.Path))
+	// The agent WriteScopes both the source and destination of a copy; mirror
+	// that (an admin FM copy stays within the safe data roots on both ends).
+	if h.rejectAdminWriteOutOfScope(c, req.Path, dst) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.copy", filesCopyAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), SrcPath: req.Path, DstPath: dst,
 	})
@@ -1195,6 +1296,9 @@ func (h *filesHandler) write(c *gin.Context) {
 	}
 	c.Set("audit_target", req.Path) // GH #658: audit the concrete file path
 	c.Set("audit_target_type", "file")
+	if h.rejectAdminWriteOutOfScope(c, req.Path) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.write", filesWriteAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: req.Path, Content: req.Content,
 	})
@@ -1345,6 +1449,10 @@ func (h *filesHandler) uploadChunk(c *gin.Context) {
 	// GH #658: the chunked-upload finalize must record the mutation target too.
 	c.Set("audit_target", destPath+" (chunked upload)")
 	c.Set("audit_target_type", "file")
+	if h.rejectAdminWriteOutOfScope(c, destPath) {
+		_ = os.Remove(tmpPath) // don't leak the panel staging file on a rejected admin upload
+		return
+	}
 	_, err = h.cfg.Agent.Call(c.Request.Context(), "files.ingest", filesIngestAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), TmpPath: tmpPath, DestPath: destPath,
 		Overwrite: c.Query("overwrite") == "true",
@@ -1399,6 +1507,9 @@ func (h *filesHandler) delete(c *gin.Context) {
 	recursive := c.Query("recursive") == "true"
 	c.Set("audit_target", p) // GH #658: audit which path was deleted
 	c.Set("audit_target_type", "file")
+	if h.rejectAdminWriteOutOfScope(c, p) {
+		return
+	}
 	_, err := h.cfg.Agent.Call(c.Request.Context(), "files.delete", filesDeleteAgentParams{
 		UserID: userID, Username: username, AdminRoot: h.adminRoot(c), Path: p, Recursive: recursive,
 	})

--- a/panel-api/internal/api/files_admin_precheck_test.go
+++ b/panel-api/internal/api/files_admin_precheck_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// setupAdminFilesRouter wires /admin/files with an admin session and the admin
+// File Manager setting ON, so adminGate passes and every handler carries
+// admin_root=true. The mock agent must NOT be reached when the API-side
+// pre-check refuses a mutation — callCount is the proof.
+func setupAdminFilesRouter(t *testing.T, agent *mockAgent) *gin.Engine {
+	t.Helper()
+	prev := uploadStagingDir
+	uploadStagingDir = t.TempDir()
+	t.Cleanup(func() { uploadStagingDir = prev })
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: "admin1", Email: "admin@example.com", IsAdmin: true})
+		c.Next()
+	})
+	RegisterFilesRoutes(v1, FilesHandlerConfig{
+		Agent:          agent,
+		ServerSettings: &mockServerSettingsRepo{getResult: &models.ServerSettings{AdminFileManagerEnabled: true}},
+	})
+	return r
+}
+
+// JAB-367 (criterion 4): the API refuses an admin_root mutation outside the
+// write allow-list BEFORE it reaches the agent — layered enforcement.
+func TestAdminFiles_APISidePreCheck_RejectsBeforeAgent(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   string
+	}{
+		{"mkdir outside roots", http.MethodPost, "/api/v1/admin/files/mkdir", `{"path":"/etc/cron.d/jab367"}`},
+		{"write outside roots", http.MethodPost, "/api/v1/admin/files/write", `{"path":"/usr/lib/x.so","content":"x"}`},
+		{"chmod deny-list", http.MethodPost, "/api/v1/admin/files/chmod", `{"path":"/etc/jabali/config.toml","mode":"0777"}`},
+		{"copy bad source", http.MethodPost, "/api/v1/admin/files/copy", `{"path":"/etc/shadow","dest_dir":"/home/alice"}`},
+		{"delete outside roots", http.MethodDelete, "/api/v1/admin/files?path=/etc/passwd", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// A plain recording agent: if the pre-check works, it is never
+			// called (callCount stays 0), which is the assertion below.
+			rec := &mockAgent{}
+			r := setupAdminFilesRouter(t, rec)
+
+			w := httptest.NewRecorder()
+			var req *http.Request
+			if tc.body == "" {
+				req = httptest.NewRequest(tc.method, tc.path, nil)
+			} else {
+				req = httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+				req.Header.Set("Content-Type", "application/json")
+			}
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("status: got %d want 403, body=%s", w.Code, w.Body.String())
+			}
+			var body struct {
+				Error string `json:"error"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &body)
+			if body.Error != "read_only" && body.Error != "path_denied" {
+				t.Errorf("error code: got %q want read_only|path_denied", body.Error)
+			}
+			if rec.callCount != 0 {
+				t.Errorf("agent was called %d times — the pre-check must reject BEFORE the agent", rec.callCount)
+			}
+		})
+	}
+}
+
+// A valid in-allow-list admin mutation passes the pre-check and reaches the agent.
+func TestAdminFiles_APISidePreCheck_PassesThroughInAllowList(t *testing.T) {
+	agent := agentReply(gin.H{"path": "/home/alice/newdir"})
+	r := setupAdminFilesRouter(t, agent)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/files/mkdir",
+		strings.NewReader(`{"path":"/home/alice/newdir"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d want 200, body=%s", w.Code, w.Body.String())
+	}
+	if agent.callCount != 1 {
+		t.Fatalf("agent calls: got %d want 1 (an allow-list path must reach the agent)", agent.callCount)
+	}
+}
+
+// The pre-check is admin_root-ONLY: a tenant mutation is never lexically
+// filtered by the API (the tenant scope is the agent's job); the agent is
+// reached and enforces the per-tenant docroot.
+func TestAdminFiles_APISidePreCheck_TenantNotChecked(t *testing.T) {
+	agent := agentReply(gin.H{"path": "/etc/cron.d/jab367"})
+	r := setupFilesRouter(t, "user1", agent) // IsAdmin:false, tenant /files mount
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/files/mkdir",
+		strings.NewReader(`{"path":"/etc/cron.d/jab367"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	// The API does not pre-check tenant paths, so the request reaches the agent
+	// (the mock replies OK). The real agent would enforce the tenant docroot.
+	if agent.callCount != 1 {
+		t.Fatalf("tenant mkdir must reach the agent (no API-side admin pre-check); calls=%d", agent.callCount)
+	}
+}

--- a/panel-api/internal/models/server_settings.go
+++ b/panel-api/internal/models/server_settings.go
@@ -152,6 +152,25 @@ type ServerSettings struct {
 	// whole-filesystem browser/editor (hard deny-listed in the agent) on the
 	// admin side. OFF by default: it exposes root-owned paths + edits through
 	// the panel UI, so it must be an explicit, deliberate enable.
+	//
+	// JAB-367 upgrade-gating audit (criterion 7): is there a mixed-version window
+	// (new panel / old agent) where this is ON but the old whole-FS write policy
+	// is still live? A narrow one exists and is deliberately NOT hard-gated:
+	//   - Mutation confinement to the safe data roots is enforced in TWO places:
+	//     the API-side pre-check (rejectAdminWriteOutOfScope, JAB-367) AND the
+	//     agent's WriteScope (JAB-358). The API-side check ships with THIS panel,
+	//     so every LEXICAL out-of-allow-list write is refused regardless of agent
+	//     version — even against a pre-#1209 agent that lacks WriteScope.
+	//   - The only residual is a SYMLINK inside a safe root whose target climbs
+	//     out: the lexical API check can't see it, so it would reach a pre-#1209
+	//     agent that also lacks the openat2 RESOLVE_BENEATH resolution — bounded
+	//     by that agent's deny-list. This requires (a) a pre-#1209 agent, i.e. a
+	//     partial update — panel-api + agent ship from the same stable tag and
+	//     update together, so this is a transient skew, not a steady state — AND
+	//     (b) this default-off setting deliberately enabled during that skew.
+	// Given transient-skew × opt-in × symlink-only-on-an-old-agent, and that the
+	// API-side check already closes the whole lexical surface, this is documented
+	// rather than hard-gated on a brittle minimum agent version.
 	AdminFileManagerEnabled bool `gorm:"column:admin_file_manager_enabled;type:tinyint(1);not null;default:0" json:"admin_file_manager_enabled"`
 
 	// InterceptAppErrorsDefault (GH #879) — server-wide default for the


### PR DESCRIPTION
## JAB-367 — API-side write allow-list pre-check for the admin File Manager

Defense-in-depth follow-up to **JAB-358** (PR #1209), which closed the core
root-RCE hole by confining every admin File Manager mutation to a kernel-enforced
write allow-list in the **agent** (`Scope.WriteScope()` → safe data roots, `openat2
RESOLVE_BENEATH`). This adds a second, independent enforcement layer in panel-api,
per-command coverage, and the upgrade-gating audit. **MFA step-up** is split to its
own ticket (JAB-380).

### API-side pre-check (criterion 4)
`rejectAdminWriteOutOfScope` validates every admin_root mutation's destination
against the **same** allow-list the agent uses — `filesafe.NewAdminScope(...)
.WriteScope()`, reusing `DefaultAdminMutableRoots` + `DefaultAdminDeniedPrefixes` —
and refuses it, **before the agent call**, when it's outside the safe roots
(`read_only`) or inside a denied prefix (`path_denied`). Wired into every mutating
admin handler: `write`, `mkdir`, `delete`, `chmod`, `rename` (old+new), `move`
(old+new), `copy` (src+dst), `extract` (dest incl. the archive-parent default), and
both upload/ingest paths (dest, with staging-tmp cleanup on reject). The field
mapping **mirrors exactly what the agent routes through WriteScope** (e.g. copy
scopes both ends) — derived from the agent code, not the ticket text. `files.archive`
is excluded (reads + writes a panel-owned scratch file, never a caller path).

Lexical + admin_root-only by design: the agent stays authoritative and adds the
symlink (`RESOLVE_BENEATH`) resolution the API can't do; tenant ops keep their
agent-side per-docroot scope untouched.

### Coherent error envelope
`agentErrorStatus`/`agentErrorCode` now map `read_only`/`path_denied` → **403** with
the specific key (they previously fell through to a generic `500 "agent_error"`), so
the agent path and the new API pre-check return an **identical body** for the same
violation.

### Per-command reject fan-out (criterion 6)
A table test drives **every** mutating agent command with an admin_root
out-of-allow-list path, pinning the WriteScope wiring per command (not just
`files.write`). Records the invariant that a deny-list path surfaces as `read_only`
for a mutation (WriteScope checks mutable-root membership first).

### Upgrade-gating audit (criterion 7)
Documented on the `AdminFileManagerEnabled` setting. The API-side check ships with
the panel and closes the entire **lexical** surface against any agent version; the
only residual is a symlink escape inside a safe root reaching a pre-#1209 agent (no
`RESOLVE_BENEATH`), bounded by that agent's deny-list, requiring a transient
same-stable-tag partial-update skew with this default-off setting deliberately
enabled. Documented rather than hard-gated on a brittle minimum agent version.

### Tests
- [x] `TestAdminFiles_APISidePreCheck_RejectsBeforeAgent` — 403 + specific code + **agent never called** (`callCount==0`) across mkdir/write/chmod/copy/delete.
- [x] `TestAdminFiles_APISidePreCheck_PassesThroughInAllowList` — an in-allow-list path reaches the agent.
- [x] `TestAdminFiles_APISidePreCheck_TenantNotChecked` — tenant ops are not API-filtered.
- [x] `TestAdminFileManager_MutatingCommandsRejectOutOfAllowList` — per-command agent reject fan-out (read_only + deny-list).
- [x] Full panel-api + panel-agent command suites green.

No new HTTP routes → no openapi/cli-reference golden regen. Refs JAB-367, JAB-358; follow-up JAB-380 (MFA step-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
