### PR TITLE
feat(security): block tenant access to CrowdSec's unauthenticated :6060 pprof/metrics (JAB-368)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9407,6 +9407,11 @@ install_crowdsec() {
   # the next install.sh run. Install a dpkg Post-Invoke hook so the
   # heal runs after every apt/dpkg operation.
   install_crowdsec_bouncer_apt_heal_hook
+
+  # JAB-368: block tenant-uid access to the unauthenticated prometheus/pprof
+  # listener (127.0.0.1:6060). provision_new_software is jabali-update-only, so
+  # the fresh-install path calls it here too (idempotent).
+  ensure_crowdsec_diag_isolation
 }
 
 # install_crowdsec_bouncer_apt_heal_hook — write the heal script +
@@ -14867,6 +14872,54 @@ ensure_crowdsec_bouncer_poll_frequency() {
   return 0
 }
 
+# ensure_crowdsec_diag_isolation — JAB-368. CrowdSec's prometheus listener on
+# 127.0.0.1:6060 is UNAUTHENTICATED and (on level: full) serves Go /debug/pprof
+# alongside /metrics. It cannot be disabled — `cscli metrics` (the panel's
+# CrowdSec metrics source) requires it — so we make it unreachable from tenant
+# code instead. JAB-352 blocked the SSH-forwarding path; this closes the
+# independent direct-loopback path from a tenant's own PHP-FPM/CGI/shell.
+#
+# The nft ruleset matches on skuid >= 1000 (jabali's login UID_MIN): every tenant
+# execution context runs as a real user, while root (cscli) and system services
+# (uid < 1000, incl. the panel user) are unaffected. skuid — not cgroup — because
+# tenant PHP-FPM runs under system.slice and tenant shells under user.slice, so a
+# cgroup match would miss both; it also needs no cgroupv2 path, so the load unit
+# has no ConditionPathExists boot window.
+#
+# Idempotent + runs on install AND every `jabali update` (provision_new_software),
+# so existing fleet hosts converge. Never `systemctl restart nftables` (would
+# flush UFW + crowdsec-bouncer chains) — `nft -f` the single file only.
+ensure_crowdsec_diag_isolation() {
+  command -v nft >/dev/null 2>&1 || return 0
+  local src="${REPO_DIR:-/opt/jabali-panel}/install/crowdsec/jabali-diag-loopback-isolation.nft"
+  local dst=/etc/nftables.d/jabali-diag-loopback-isolation.nft
+  local unit_src="${REPO_DIR:-/opt/jabali-panel}/install/systemd/jabali-diag-loopback-isolation-load.service"
+  local unit_dst=/etc/systemd/system/jabali-diag-loopback-isolation-load.service
+  if [[ ! -f "$src" || ! -f "$unit_src" ]]; then
+    _warn "crowdsec diag-isolation source missing ($src) — skipping (JAB-368 not applied)"
+    return 0
+  fi
+  install -d -m 0755 /etc/nftables.d
+  local changed=0
+  if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+    install -m 0644 -o root -g root "$src" "$dst"; changed=1
+  fi
+  if [[ ! -f "$unit_dst" ]] || ! cmp -s "$unit_src" "$unit_dst"; then
+    install -m 0644 -o root -g root "$unit_src" "$unit_dst"
+    systemctl daemon-reload 2>/dev/null || true
+    changed=1
+  fi
+  systemctl enable jabali-diag-loopback-isolation-load.service >/dev/null 2>&1 || true
+  # The add/flush idiom in the file makes a re-apply replace the rules rather
+  # than append duplicates; nft -f is a single transaction.
+  if nft -f "$dst" 2>/dev/null; then
+    [[ $changed -eq 1 ]] && _ok "crowdsec :6060 diagnostics blocked from tenant code (JAB-368)"
+  else
+    _warn "could not apply crowdsec diag-isolation nft rules now — will retry at boot (JAB-368)"
+  fi
+  return 0
+}
+
 # install_cloudflare_realip — drop /etc/nginx/conf.d/jabali-cloudflare-realip.conf
 # so nginx rewrites $remote_addr from the CF-Connecting-IP header when the
 # request arrives from a Cloudflare proxy range. Without it, every
@@ -15421,6 +15474,12 @@ EOF
   # sustained LAPI CPU when CAPI has many decisions loaded).
   if declare -f ensure_crowdsec_bouncer_poll_frequency >/dev/null 2>&1; then
     ensure_crowdsec_bouncer_poll_frequency
+  fi
+
+  # JAB-368: block tenant-uid access to CrowdSec's unauthenticated
+  # prometheus/pprof listener (127.0.0.1:6060) at the packet layer.
+  if declare -f ensure_crowdsec_diag_isolation >/dev/null 2>&1; then
+    ensure_crowdsec_diag_isolation
   fi
 
   # Cloudflare real-IP rewrite. Without this, every CF-fronted hit logs

--- a/install/crowdsec/jabali-diag-loopback-isolation.nft
+++ b/install/crowdsec/jabali-diag-loopback-isolation.nft
@@ -1,0 +1,29 @@
+# Managed by jabali install.sh (JAB-368) — do not edit.
+#
+# CrowdSec's prometheus listener on 127.0.0.1:6060 is UNAUTHENTICATED and, on
+# `level: full`, also serves Go /debug/pprof (heap/goroutine dumps → info leak;
+# CPU profiling → mild local DoS) alongside /metrics. The listener cannot be
+# disabled — `cscli metrics` (the panel's CrowdSec metrics source) requires it —
+# so instead we make it unreachable from tenant code.
+#
+# JAB-352 blocked the SSH *forwarding* path to loopback services, but a tenant's
+# own app code (per-user PHP-FPM workers, CGI) or an interactive tenant shell
+# (the ssh-shell shares the net namespace) can open a loopback socket to
+# 127.0.0.1:6060 directly — a vector independent of SSH forwarding.
+#
+# Match on skuid, NOT cgroup: tenant PHP-FPM runs under system.slice
+# (jabali-fpm@<user>.service) and tenant shells under user.slice — neither is in
+# jabali.slice/jabali-user.slice — but ALL tenant execution contexts run as a
+# real user (uid >= 1000, jabali's login UID_MIN). Root (cscli metrics) and every
+# system service (uid < 1000, including the panel user ~997) are unaffected.
+# skuid also needs no cgroupv2 path, so this loads cleanly at boot (no
+# ConditionPathExists window).
+#
+# A future metrics scraper (Zabbix) runs as a system user (<1000) / in
+# system.slice → unaffected. Separate `add`/`flush` table idiom so a re-apply on
+# `jabali update` replaces the rules rather than appending duplicates.
+add table inet jabali_diag_isolation
+flush table inet jabali_diag_isolation
+add chain inet jabali_diag_isolation output { type filter hook output priority filter; policy accept; }
+add rule inet jabali_diag_isolation output meta skuid >= 1000 ip daddr 127.0.0.1 tcp dport 6060 drop
+add rule inet jabali_diag_isolation output meta skuid >= 1000 ip6 daddr ::1 tcp dport 6060 drop

--- a/install/systemd/jabali-diag-loopback-isolation-load.service
+++ b/install/systemd/jabali-diag-loopback-isolation-load.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apply jabali diagnostic-listener loopback isolation (JAB-368)
+Documentation=https://github.com/shukiv/jabali-panel
+After=network-pre.target
+Before=jabali-panel.service
+# Unlike the Docker per-tenant loopback isolation, this ruleset matches on
+# skuid (not a cgroupv2 path), so it has nothing to resolve at boot and needs
+# no ConditionPathExists — it can and must load on every boot.
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/nft -f /etc/nftables.d/jabali-diag-loopback-isolation.nft
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/install/tests/test_crowdsec_diag_isolation.sh
+++ b/install/tests/test_crowdsec_diag_isolation.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# install/tests/test_crowdsec_diag_isolation.sh — regression coverage for
+# JAB-368. CrowdSec's prometheus listener on 127.0.0.1:6060 is UNAUTHENTICATED
+# and serves Go /debug/pprof (heap/goroutine dumps + CPU profiling) alongside
+# /metrics. It cannot be disabled (`cscli metrics`, the panel's metrics source,
+# requires it), so a packet-layer rule must block tenant-uid access to it while
+# leaving root (cscli) + system users reachable.
+#
+# Asserts, source-level (no host mutation):
+#   1. the shipped nft ruleset blocks skuid>=1000 → 127.0.0.1/::1 :6060 (v4+v6),
+#      via the idempotent add/flush idiom (a re-apply must not duplicate rules);
+#   2. the load unit exists, applies the file, and has NO ConditionPathExists
+#      (skuid rule has no cgroup path → must load on every boot);
+#   3. install.sh defines ensure_crowdsec_diag_isolation and calls it from BOTH
+#      the fresh-install path (install_crowdsec) AND the update path
+#      (provision_new_software) — a fleet host must converge on `jabali update`.
+#
+# Run from repo root:
+#     bash install/tests/test_crowdsec_diag_isolation.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+nft=install/crowdsec/jabali-diag-loopback-isolation.nft
+unit=install/systemd/jabali-diag-loopback-isolation-load.service
+
+# --- 1. nft ruleset: uid-based :6060 drop, v4 + v6, flush idiom ---
+if [[ ! -f "$nft" ]]; then
+  echo "FAIL: missing nft ruleset $nft"; exit 1
+fi
+if ! grep -qE 'meta skuid >= 1000 ip daddr 127\.0\.0\.1 tcp dport 6060 drop' "$nft"; then
+  echo "FAIL: $nft must drop skuid>=1000 → 127.0.0.1 tcp/6060 (JAB-368)"; fail=1
+fi
+if ! grep -qE 'meta skuid >= 1000 ip6 daddr ::1 tcp dport 6060 drop' "$nft"; then
+  echo "FAIL: $nft must also drop the IPv6 ::1 :6060 path (JAB-368)"; fail=1
+fi
+# Idempotent re-apply: the add/flush idiom must be present (a bare `table {...}`
+# re-declaration would append duplicate rules on every `jabali update`).
+if ! grep -qE '^flush table inet jabali_diag_isolation' "$nft"; then
+  echo "FAIL: $nft must use the add/flush idiom so a re-apply replaces, not duplicates, the rules"; fail=1
+fi
+# skuid, not cgroup: a cgroup match would miss FPM (system.slice) + shells
+# (user.slice). Check RULE lines only — the rationale comment mentions cgroupv2.
+if grep -vE '^[[:space:]]*#' "$nft" | grep -qE 'cgroupv2'; then
+  echo "FAIL: $nft must match on skuid, not cgroupv2 (FPM/shells are not in the tenant slice) (JAB-368)"; fail=1
+fi
+
+# --- 2. load unit: applies the file, no ConditionPathExists ---
+if [[ ! -f "$unit" ]]; then
+  echo "FAIL: missing load unit $unit"; exit 1
+fi
+if ! grep -qE '^ExecStart=/usr/sbin/nft -f /etc/nftables.d/jabali-diag-loopback-isolation\.nft' "$unit"; then
+  echo "FAIL: $unit must ExecStart nft -f the installed ruleset"; fail=1
+fi
+if grep -qE '^ConditionPathExists=' "$unit"; then
+  echo "FAIL: $unit must NOT gate on ConditionPathExists — the skuid rule has no cgroup path and must load every boot (JAB-368)"; fail=1
+fi
+
+# --- 3. install.sh wiring: defined + called on BOTH install and update ---
+if ! grep -qE '^ensure_crowdsec_diag_isolation\(\) \{' install.sh; then
+  echo "FAIL: install.sh must define ensure_crowdsec_diag_isolation"; fail=1
+fi
+# fresh-install path: install_crowdsec calls it (provision_new_software is update-only).
+cs=$(awk '/^install_crowdsec\(\) \{/{f=1} f{print} /^}/&&f{exit}' install.sh)
+if ! grep -q 'ensure_crowdsec_diag_isolation' <<<"$cs"; then
+  echo "FAIL: install_crowdsec must call ensure_crowdsec_diag_isolation (fresh-install coverage)"; fail=1
+fi
+# update path: provision_new_software calls it (existing fleet hosts converge).
+pn=$(awk '/^provision_new_software\(\) \{/{f=1} f{print} /^}/&&f{exit}' install.sh)
+if ! grep -q 'ensure_crowdsec_diag_isolation' <<<"$pn"; then
+  echo "FAIL: provision_new_software must call ensure_crowdsec_diag_isolation (jabali update convergence)"; fail=1
+fi
+
+if [[ "$fail" -eq 0 ]]; then
+  echo "PASS: crowdsec :6060 diagnostics tenant-isolation is shipped + wired on both paths (JAB-368)"
+else
+  exit 1
+fi


### PR DESCRIPTION
## JAB-368 — block tenant-uid access to CrowdSec's unauthenticated :6060 pprof/metrics

Follow-up to **JAB-352** (PR #1211), which closed the SSH-tunnel vector into loopback
services. CrowdSec's prometheus listener binds `127.0.0.1:6060` and, on `level: full`,
serves Go `/debug/pprof` (heap/goroutine dumps → info leak; CPU profiling → mild local
DoS) alongside `/metrics`, all **unauthenticated** (verified on .86:
`curl 127.0.0.1:6060/debug/pprof/` → 200). JAB-352 blocks the SSH-forwarding path, but
a tenant's own app code (per-user PHP-FPM workers, CGI) or an interactive tenant shell
can open a loopback socket to :6060 **directly** — independent of SSH forwarding.

The listener **can't be disabled**: `cscli metrics` (the panel's CrowdSec metrics
source) fails with "prometheus is not enabled" when it's off. So block tenant access at
the packet layer.

### Why skuid, not cgroup
The obvious move — reuse the Docker `socket cgroupv2 level 2 "jabali.slice/jabali-user.slice"`
rule — **misses the actual threat**: tenant PHP-FPM runs under `system.slice`
(`jabali-fpm@<user>.service`) and tenant shells under `user.slice`; neither is in the
tenant slice. Every tenant context does run as a **real user (uid ≥ 1000**, jabali's
login `UID_MIN`), so the rule matches `meta skuid >= 1000`. Root (`cscli`) + system
services (< 1000, incl. the panel user ~997) are unaffected; a future Zabbix scraper
(system user / `system.slice`) stays reachable. skuid also needs no cgroupv2 path, so the
load unit has **no `ConditionPathExists` boot window**.

### Changes
- `install/crowdsec/jabali-diag-loopback-isolation.nft` — `jabali_diag_isolation` table
  dropping `skuid>=1000 → 127.0.0.1/::1 tcp/6060`, via an **add/flush idiom** so a
  re-apply on `jabali update` replaces (not duplicates) the rules.
- `install/systemd/jabali-diag-loopback-isolation-load.service` — boot re-apply
  (`nft -f` only — never `systemctl restart nftables`, which flushes UFW + bouncer chains).
- `install.sh ensure_crowdsec_diag_isolation()` — idempotent installer, called from
  **both** `install_crowdsec` (fresh install) and `provision_new_software` (every
  `jabali update` — it's update-only, so fleet hosts converge).

### Loopback-listener audit (ss -tnlp on .86)
:6060 was the **only** unauthenticated tenant-exploitable HTTP diagnostic listener.
LAPI :8081 + AppSec :7422 are API-key-gated; MariaDB :3306 / Postgres :5432 are
cred-gated by design; pdns :53/:5300 are DNS; the agent socket is SO_PEERCRED-gated
(JAB-366); :631 cupsd is a .86 desktop-VM artifact, not a fleet component. Nothing new
warranting a follow-up. (Note: the pre-existing Docker cgroup rule shares the FPM/shell
blind spot, but Docker apps *do* run in the tenant slice, so its cgroup match is correct
for the Docker loopback range.)

### Verified
- **Box (.86, restored after):** real nft file loads; **idempotent** (2 rules after two
  applies, not 4); tenant uid 1002 → **000 (blocked)**, root → 200, `cscli metrics -o json`
  keeps working; after restore tenant → 200 (baseline).
- `install/tests/test_crowdsec_diag_isolation.sh` — skuid v4+v6 rule + flush idiom, unit
  has no ConditionPathExists, wired on both install paths.
- `bash -n install.sh` clean.

No routes/schema → no golden regen. Refs JAB-368, JAB-352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
