### PR TITLE
feat(notifications): backup.success — notify when a backup finishes (GH #979)

### DIFF
--- a/panel-api/internal/eventsources/backup_success.go
+++ b/panel-api/internal/eventsources/backup_success.go
@@ -1,0 +1,105 @@
+package eventsources
+
+// backup_success event source (GH #979 follow-up — per-job "backup finished"
+// notification the fail source never had a counterpart for).
+//
+// Polls backup_jobs for jobs that FINISHED cleanly within the lookback window —
+// status='succeeded' (fully) or status='partial' (finished with some items
+// skipped/failed) — and fires one `backup.success` envelope per freshly-finished
+// job: severity "info" for a full success, "warning" for a partial. Partial is
+// deliberately included: a partial backup IS finished, and firing nothing for it
+// would read to a user who enabled this event as "the backup didn't run" — worse
+// than a plain success being noisy. Deduped via the History layer on the job_id
+// tag; the dedupe key is scoped to the event kind, so a job that failed then
+// succeeded on retry is NOT suppressed by its earlier backup.fail row.
+//
+// Why a poller and not an emit at the finish site: backups are marked finished by
+// the finalizer, the scheduler, AND the CLI backup/restore path — multiple
+// writers, one poller catches them all without coupling the repository layer to
+// notifications. Mirrors backup_fail.go.
+//
+// Off when BackupJobs repo is nil — tests + minimal panel installs (no backup
+// stack wired) skip the source.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+const (
+	backupSuccessTick     = 5 * time.Minute
+	backupSuccessLookback = 30 * time.Minute
+	backupSuccessCoolOff  = 24 * time.Hour
+	// Successful backups are the common case (unlike failures), so a busy fleet
+	// box can produce a large burst of finished jobs in one window.
+	// ListByStatusSince orders finished_at ASC, so an over-cap pass drains the
+	// oldest first and the next tick catches the rest while they are still inside
+	// the lookback — a higher cap than backup_fail's keeps that self-drain from
+	// ever lagging on a big multi-tenant box.
+	backupSuccessLimit = 500
+)
+
+// backupFinishedStatus pairs a terminal-OK backup status with how its
+// notification should read.
+type backupFinishedStatus struct {
+	status   string
+	severity string
+	verb     string
+}
+
+var backupFinishedStatuses = []backupFinishedStatus{
+	{models.BackupJobStatusSucceeded, "info", "succeeded"},
+	{models.BackupJobStatusPartial, "warning", "completed with warnings"},
+}
+
+func runBackupSuccess(ctx context.Context, d Deps) {
+	if d.BackupJobs == nil {
+		d.Log.Debug("eventsources: backup_success disabled (no BackupJobs repo)")
+		return
+	}
+	// Immediate pass so a panel restart doesn't sleep through a fresh success
+	// that landed during the down window.
+	backupSuccessPass(ctx, d)
+	tick := time.NewTicker(backupSuccessTick)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+		backupSuccessPass(ctx, d)
+	}
+}
+
+func backupSuccessPass(ctx context.Context, d Deps) {
+	since := d.Now().Add(-backupSuccessLookback)
+	for _, fs := range backupFinishedStatuses {
+		rows, err := d.BackupJobs.ListByStatusSince(ctx, fs.status, since, backupSuccessLimit)
+		if err != nil {
+			d.Log.Warn("eventsources: backup_success list failed", "status", fs.status, "err", err)
+			continue
+		}
+		for _, j := range rows {
+			dedupeTag := "backup_job_id=" + j.ID
+			if !shouldFire(ctx, d, "backup.success", dedupeTag, backupSuccessCoolOff) {
+				continue
+			}
+			env := notifications.Envelope{
+				EventKind: "backup.success",
+				Severity:  fs.severity,
+				Title:     fmt.Sprintf("Backup %s: %s", fs.verb, j.Kind),
+				Body:      fmt.Sprintf("Backup job %s (%s) %s. dedupe=%s", j.ID, j.Kind, fs.verb, dedupeTag),
+				Deeplink:  "/jabali-admin/backups",
+				UserID:    j.UserID,
+			}
+			if _, perr := d.Queue.Publish(ctx, env); perr != nil {
+				d.Log.Warn("eventsources: backup_success publish failed", "job_id", j.ID, "err", perr)
+			}
+		}
+	}
+}

--- a/panel-api/internal/eventsources/backup_success_test.go
+++ b/panel-api/internal/eventsources/backup_success_test.go
@@ -1,0 +1,98 @@
+package eventsources
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestBackupSuccess_FiresInfoOnSucceeded(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-5 * time.Minute)
+	jobs := &fakeBackupJobs{rows: []models.BackupJob{
+		{ID: "s1", UserID: "u1", Kind: "account_backup",
+			Status: models.BackupJobStatusSucceeded, FinishedAt: &finished},
+	}}
+	pub := &capturingPublisher{}
+	d := Deps{
+		Queue: pub, History: &fakeHistory{}, BackupJobs: jobs,
+		Log: slog.New(slog.DiscardHandler), Now: func() time.Time { return now },
+	}
+	backupSuccessPass(context.Background(), d)
+	require.Equal(t, 1, pub.Count())
+	env := pub.Last()
+	require.Equal(t, "backup.success", env.EventKind)
+	require.Equal(t, "info", env.Severity)
+	require.Equal(t, "u1", env.UserID)
+	require.Contains(t, env.Title, "succeeded")
+	require.Contains(t, env.Body, "s1")
+}
+
+// A partial (finished-with-warnings) job must still notify — as a warning — so a
+// degraded backup is never silent (would otherwise read as "didn't run").
+func TestBackupSuccess_FiresWarningOnPartial(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-5 * time.Minute)
+	jobs := &fakeBackupJobs{rows: []models.BackupJob{
+		{ID: "p1", UserID: "u2", Kind: "system_backup",
+			Status: models.BackupJobStatusPartial, FinishedAt: &finished},
+	}}
+	pub := &capturingPublisher{}
+	d := Deps{
+		Queue: pub, History: &fakeHistory{}, BackupJobs: jobs,
+		Log: slog.New(slog.DiscardHandler), Now: func() time.Time { return now },
+	}
+	backupSuccessPass(context.Background(), d)
+	require.Equal(t, 1, pub.Count())
+	env := pub.Last()
+	require.Equal(t, "backup.success", env.EventKind)
+	require.Equal(t, "warning", env.Severity)
+	require.Contains(t, env.Title, "warnings")
+}
+
+// A running/queued/cancelled job is not "finished" — no notification.
+func TestBackupSuccess_IgnoresNonFinishedStatuses(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-5 * time.Minute)
+	jobs := &fakeBackupJobs{rows: []models.BackupJob{
+		{ID: "r1", UserID: "u1", Kind: "account_backup", Status: models.BackupJobStatusRunning, FinishedAt: &finished},
+		{ID: "c1", UserID: "u1", Kind: "account_backup", Status: models.BackupJobStatusCancelled, FinishedAt: &finished},
+		{ID: "f1", UserID: "u1", Kind: "account_backup", Status: models.BackupJobStatusFailed, FinishedAt: &finished},
+	}}
+	pub := &capturingPublisher{}
+	d := Deps{
+		Queue: pub, History: &fakeHistory{}, BackupJobs: jobs,
+		Log: slog.New(slog.DiscardHandler), Now: func() time.Time { return now },
+	}
+	backupSuccessPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count())
+}
+
+// Dedupe: a job already announced within the cool-off window does not re-fire.
+func TestBackupSuccess_SkipsAlreadyFired(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	finished := now.Add(-2 * time.Minute)
+	jobs := &fakeBackupJobs{rows: []models.BackupJob{
+		{ID: "s2", UserID: "u1", Kind: "account_backup",
+			Status: models.BackupJobStatusSucceeded, FinishedAt: &finished},
+	}}
+	pub := &capturingPublisher{}
+	hist := &fakeHistory{}
+	hist.recordFired("backup.success", "Backup job s2 (account_backup) succeeded. dedupe=backup_job_id=s2",
+		now.Add(-1*time.Hour))
+	d := Deps{
+		Queue: pub, History: hist, BackupJobs: jobs,
+		Log: slog.New(slog.DiscardHandler), Now: func() time.Time { return now },
+	}
+	backupSuccessPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count())
+}

--- a/panel-api/internal/eventsources/sources.go
+++ b/panel-api/internal/eventsources/sources.go
@@ -151,6 +151,7 @@ func Start(ctx context.Context, d Deps) {
 	go runBandwidthQuota(ctx, d)
 	go runExecAuditBurst(ctx, d)
 	go runBackupFail(ctx, d)
+	go runBackupSuccess(ctx, d)
 	go runMailRBL(ctx, d)
 	go runMailDmarcIngest(ctx, d)
 	go runMailTlsRptIngest(ctx, d)

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -122,6 +122,13 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		DefaultOn:   true,
 	},
 	{
+		Kind:        "backup.success",
+		Label:       "Backup completed",
+		Description: "A backup job finished. Fires once per fully-succeeded job (info); a job that finished with some items skipped/failed (partial) fires as a warning. Opt-in — off by default to avoid a message per backup.",
+		Severity:    "info",
+		DefaultOn:   false,
+	},
+	{
 		Kind:        "backup.limit.reached",
 		Label:       "Tenant backup limit reached",
 		Description: "A tenant hit their package's max_backups cap. Depending on the package retention policy the backup was blocked (reject) or the oldest was auto-pruned (prune). Notifies the tenant and admins (GH #454).",

--- a/panel-api/internal/models/notification_event_setting_test.go
+++ b/panel-api/internal/models/notification_event_setting_test.go
@@ -52,7 +52,7 @@ func TestAllNotificationEventKinds_WellFormed(t *testing.T) {
 func TestNotificationEventKinds_EmittedKindsAreRegistered(t *testing.T) {
 	emitted := []string{
 		// pre-existing (sanity — these were already registered)
-		"admin.login", "ssh.login", "backup.fail", "backup.limit.reached",
+		"admin.login", "ssh.login", "backup.fail", "backup.success", "backup.limit.reached",
 		"cert.renew.fail", "cert.renew.ok", "crowdsec.ban.spike", "digest.daily",
 		"disk.quota.warn", "docker_app.update_available", "load.high",
 		"security.decision.fired", "security.root_terminal.opened", "service.down",


### PR DESCRIPTION
## backup.success — notify when a backup finishes

Follow-up to the #979 notification-events work. The catalog had **`backup.fail`** but no counterpart for a *finished/succeeded* backup, so a successful backup only ever surfaced in the once-a-day digest — there was no per-job "your backup completed" notification (raised by a user asking exactly this).

### What this adds

A new opt-in **`backup.success`** event kind (off by default, mirroring `cert.renew.ok`):

- **`backup_success.go`** event source, mirroring `backup_fail.go`: polls `backup_jobs` for jobs that **finished** in the lookback window and fires one envelope per fresh job.
  - `succeeded` → severity **info** ("Backup succeeded: …")
  - `partial` → severity **warning** ("Backup completed with warnings: …")
- **`partial` is deliberately included.** A partial backup *is* finished; firing nothing for it would read to a user who enabled this event as "the backup didn't run" — worse than a plain success being a little noisy. So a degraded backup is never silent.
- **Poller, not emit-at-finish, on purpose:** backups are marked finished by the finalizer, the scheduler, *and* the CLI path — one poller catches every writer without coupling the repository layer to notifications.
- **Dedupe is kind-scoped** (`History.ListRecentByEvent` filters by `event_kind`), so a job that failed then succeeded on retry is **not** suppressed by its earlier `backup.fail` row.
- **Higher list cap (500)** than `backup_fail`: successes are the common case; `ListByStatusSince` orders `finished_at ASC`, so an over-cap pass self-drains oldest-first across ticks.
- Registered in `sources.go` next to `runBackupFail`; added to the `EmittedKindsAreRegistered` invariant list. Auto-surfaces in **Notifications → Events** (catalog-driven, default off) — no UI change needed.

### Test plan

- [x] Unit: fires **info** on `succeeded`, **warning** on `partial`, ignores `running`/`cancelled`/`failed`, dedupes an already-announced job
- [x] `go test ./panel-api/... ./panel-agent/... ./internal/...` — pass
- [x] Box-verified on the smoke box: enabled the kind, drove a `succeeded` job → `backup.success/info` landed in `notification_history`; a `partial` job → `backup.success/warning`; EnsureDefaults seeded the new kind (off) on boot
- [ ] N/A — no schema change (catalog seed only), no UI change (catalog-driven Events tab)

GH #979
