### PR TITLE
feat(ui): group admin Notifications → Events into collapsible categories (JAB-381)

### DIFF
--- a/panel-api/internal/models/notification_event_categories_ts_sync_test.go
+++ b/panel-api/internal/models/notification_event_categories_ts_sync_test.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNotificationEventCategoriesTSInSync is a cross-boundary contract test
+// (JAB-381): every notification event kind in the Go catalog
+// AllNotificationEventKinds must appear in the panel-ui category map
+// (eventCategories.ts EVENT_KIND_CATEGORY). If a kind is added on the Go side
+// but not mapped, it silently falls into the UI's "other" fallback group — this
+// test fails CI first so the mapping is kept deliberate. Mirrors the panel↔agent
+// contract-test discipline.
+func TestNotificationEventCategoriesTSInSync(t *testing.T) {
+	const tsPath = "../../../panel-ui/src/shells/admin/notifications/eventCategories.ts"
+
+	data, err := os.ReadFile(tsPath)
+	if err != nil {
+		// Go-only checkout / panel-ui absent — nothing to assert against.
+		t.Skipf("panel-ui category map not readable (%v) — skipping cross-boundary check", err)
+	}
+	content := string(data)
+
+	// Isolate the EVENT_KIND_CATEGORY object so we don't match kinds that only
+	// appear in a comment elsewhere in the file.
+	start := strings.Index(content, "EVENT_KIND_CATEGORY")
+	if start < 0 {
+		t.Fatalf("eventCategories.ts does not define EVENT_KIND_CATEGORY")
+	}
+	mapBody := content[start:]
+
+	var missing []string
+	for _, meta := range AllNotificationEventKinds {
+		// Keys are written as `"<kind>": "<category>",`.
+		if !strings.Contains(mapBody, `"`+meta.Kind+`":`) {
+			missing = append(missing, meta.Kind)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("these event kinds are missing from panel-ui eventCategories.ts EVENT_KIND_CATEGORY "+
+			"(they would fall into the 'other' group) — add each to exactly one category: %v", missing)
+	}
+}

--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -675,7 +675,22 @@
     "description": "Description",
     "enabled": "Enabled",
     "event": "Event",
-    "severity": "Severity"
+    "severity": "Severity",
+    "category": {
+      "ssl": "SSL & Certificates",
+      "domains": "Domains & DNS",
+      "disk": "Disk & Quotas",
+      "system": "Server & System",
+      "services": "Services",
+      "backups": "Backups",
+      "mail": "Mail",
+      "security": "Security",
+      "users": "Users & Accounts",
+      "apps": "Applications & Docker",
+      "updates": "Updates",
+      "other": "Other",
+      "count": "{{enabled}} / {{total}} enabled"
+    }
   },
   "historytab": {
     "body": "Body",

--- a/panel-ui/src/shells/admin/notifications/EventsTab.test.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.test.tsx
@@ -1,0 +1,136 @@
+// EventsTab.test.tsx — JAB-381. Category grouping, counts, first-visit default,
+// independent multi-expand, aria/keyboard, persistence + malformed storage, and
+// unchanged toggle semantics. Only apiClient is mocked; real AntD Collapse/Table
+// /Switch run.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventsTab } from "./EventsTab";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), patch: vi.fn() },
+}));
+
+import { apiClient } from "../../../apiClient";
+
+const mocked = apiClient as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+};
+
+const row = (
+  kind: string,
+  enabled: boolean,
+  severity = "info" as "info" | "warning" | "error" | "critical",
+) => ({ kind, label: kind, description: `${kind} desc`, severity, enabled, default_on: false });
+
+// ssl: 2 events (1 enabled) | backups: 1 (1) | mail: 1 (0)
+const SAMPLE = [
+  row("cert.renew.fail", true, "error"),
+  row("cert.renew.ok", false),
+  row("backup.fail", true, "error"),
+  row("mail.rbl.listed", false, "warning"),
+];
+
+function renderTab() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <EventsTab />
+      </App>
+    </QueryClientProvider>,
+  );
+}
+
+// The clickable AntD Collapse header carrying aria-expanded, found by its label.
+const header = (name: string): HTMLElement =>
+  screen.getByText(name).closest(".ant-collapse-header") as HTMLElement;
+
+describe("EventsTab category grouping (JAB-381)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocked.get.mockReset().mockResolvedValue({ data: { data: SAMPLE } });
+    mocked.patch.mockReset().mockResolvedValue({ data: {} });
+  });
+
+  it("renders only non-empty categories with live enabled/total counts", async () => {
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    expect(screen.getByText("Backups")).toBeInTheDocument();
+    expect(screen.getByText("Mail")).toBeInTheDocument();
+    // empty categories are not rendered
+    expect(screen.queryByText("Security")).not.toBeInTheDocument();
+    expect(screen.queryByText("Services")).not.toBeInTheDocument();
+    // header counts
+    expect(screen.getByText("1 / 2 enabled")).toBeInTheDocument(); // ssl
+    expect(screen.getByText("1 / 1 enabled")).toBeInTheDocument(); // backups
+    expect(screen.getByText("0 / 1 enabled")).toBeInTheDocument(); // mail
+  });
+
+  it("expands the first non-empty category on first visit; others collapsed", async () => {
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
+    expect(header("Backups")).toHaveAttribute("aria-expanded", "false");
+    expect(header("Mail")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles categories independently — multiple stay open together", async () => {
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    fireEvent.click(header("Backups"));
+    expect(header("Backups")).toHaveAttribute("aria-expanded", "true");
+    // the first-visit SSL panel stays open (not an accordion)
+    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("headers are keyboard-operable (Enter toggles) and expose aria-expanded", async () => {
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    const mail = header("Mail");
+    expect(mail).toHaveAttribute("aria-expanded", "false");
+    fireEvent.keyDown(mail, { key: "Enter" });
+    expect(mail).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("persists the expand choice across a remount", async () => {
+    const first = renderTab();
+    await screen.findByText("SSL & Certificates");
+    fireEvent.click(header("Mail")); // open Mail in addition to SSL
+    expect(header("Mail")).toHaveAttribute("aria-expanded", "true");
+    // stored
+    const stored = JSON.parse(localStorage.getItem("jabali.notifEvents.collapse.v1")!);
+    expect(stored.v).toBe(1);
+    expect(stored.open).toContain("mail");
+
+    first.unmount();
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    expect(header("Mail")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("falls back to first-visit on malformed stored state", async () => {
+    localStorage.setItem("jabali.notifEvents.collapse.v1", "{not valid json");
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    // malformed → first-visit default (first non-empty expanded), no crash
+    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
+    expect(header("Backups")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggling a switch issues the unchanged PATCH and no other request shape", async () => {
+    renderTab();
+    await screen.findByText("SSL & Certificates");
+    // SSL is open on first visit; toggle its first switch.
+    const sslBody = header("SSL & Certificates").parentElement as HTMLElement;
+    const firstSwitch = within(sslBody).getAllByRole("switch")[0];
+    fireEvent.click(firstSwitch);
+    await waitFor(() => expect(mocked.patch).toHaveBeenCalledTimes(1));
+    const [url, body] = mocked.patch.mock.calls[0];
+    expect(url).toMatch(/^\/admin\/settings\/notification-events\//);
+    expect(body).toEqual({ enabled: expect.any(Boolean) });
+  });
+});

--- a/panel-ui/src/shells/admin/notifications/EventsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.tsx
@@ -1,12 +1,15 @@
-// EventsTab — admin Notifications > Events. Per-event-kind enable
-// toggle. Defaults seeded by panel-api first-boot per
-// models.AllNotificationEventKinds (important = on).
+// EventsTab — admin Notifications > Events. Per-event-kind enable toggle,
+// grouped into independently collapsible categories (JAB-381). Defaults seeded
+// by panel-api first-boot per models.AllNotificationEventKinds (important = on).
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Switch, Table, Tag, Tooltip, Typography } from "antd";
+import { Collapse, Skeleton, Switch, Table, Tag, Tooltip, Typography } from "antd";
+import type { ColumnsType } from "antd/es/table";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiClient } from "../../../apiClient";
+import { groupEventsByCategory } from "./eventCategories";
 
 type EventKindRow = {
   kind: string;
@@ -19,12 +22,41 @@ type EventKindRow = {
 
 const LIST_KEY = ["admin", "notification-events"] as const;
 
+// Versioned browser-storage key for the per-category expand/collapse choice.
+// Bump the suffix if the stored shape ever changes.
+const COLLAPSE_STORAGE_KEY = "jabali.notifEvents.collapse.v1";
+
 const severityColor: Record<EventKindRow["severity"], string> = {
   info: "blue",
   warning: "gold",
   error: "red",
   critical: "magenta",
 };
+
+// loadStoredOpen returns the persisted open-category ids, or null when there is
+// no (valid) stored choice — which the caller treats as "first visit". An empty
+// array is a real choice ("user collapsed everything") and is preserved.
+function loadStoredOpen(): string[] | null {
+  try {
+    const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY);
+    if (raw === null) return null; // no key → first visit
+    const parsed = JSON.parse(raw) as { v?: number; open?: unknown };
+    if (parsed?.v !== 1 || !Array.isArray(parsed.open)) return null;
+    if (!parsed.open.every((x) => typeof x === "string")) return null;
+    return parsed.open as string[];
+  } catch {
+    // Malformed / unavailable storage must never break rendering.
+    return null;
+  }
+}
+
+function saveOpen(open: string[]): void {
+  try {
+    localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify({ v: 1, open }));
+  } catch {
+    /* storage unavailable (private mode / quota) — non-fatal */
+  }
+}
 
 export const EventsTab = () => {
   const { t } = useTranslation();
@@ -40,6 +72,10 @@ export const EventsTab = () => {
     },
   });
 
+  // Unchanged mutation semantics (JAB-381 is presentation-only): await the PATCH,
+  // then invalidate so the list — and therefore each category's live count —
+  // refetches. A failed toggle never mutated the cache, so the switch + count
+  // resolve back to server truth on their own; surface the error toast.
   const toggle = async (row: EventKindRow, next: boolean) => {
     try {
       await apiClient.patch(`/admin/settings/notification-events/${row.kind}`, {
@@ -51,23 +87,14 @@ export const EventsTab = () => {
     }
   };
 
-  return (
-    <Table<EventKindRow>
-      rowKey="kind"
-      loading={list.isLoading}
-      dataSource={list.data?.data ?? []}
-      pagination={false}
-      // tableLayout=auto lets the browser size each column to its
-      // content. Description gets the leftover width so long
-      // sentences flow naturally without expanding Event past its
-      // own (short) label + kind code.
-      scroll={{ x: 800 }}
-    >
-      <Table.Column<EventKindRow>
-        title={t("eventstab.event")}
-        dataIndex="label"
-        width={280}
-        render={(label: string, row) => (
+  // Shared column set — defined once, reused by every category's table.
+  const columns = useMemo<ColumnsType<EventKindRow>>(
+    () => [
+      {
+        title: t("eventstab.event"),
+        dataIndex: "label",
+        width: 280,
+        render: (label: string, row) => (
           <div>
             <Typography.Text strong>{label}</Typography.Text>
             <div>
@@ -76,23 +103,20 @@ export const EventsTab = () => {
               </Typography.Text>
             </div>
           </div>
-        )}
-      />
-      <Table.Column<EventKindRow>
-        title={t("eventstab.severity")}
-        dataIndex="severity"
-        width={120}
-        render={(s: EventKindRow["severity"]) => (
+        ),
+      },
+      {
+        title: t("eventstab.severity"),
+        dataIndex: "severity",
+        width: 120,
+        render: (s: EventKindRow["severity"]) => (
           <Tag color={severityColor[s] ?? "default"}>{s}</Tag>
-        )}
-      />
-      <Table.Column<EventKindRow>
-        title={t("eventstab.description")}
-        dataIndex="description"
-        // Wrap on word boundaries instead of truncating — long
-        // sentences span multiple lines inside the cell so the
-        // operator sees the full description without expanding.
-        render={(v: string) => (
+        ),
+      },
+      {
+        title: t("eventstab.description"),
+        dataIndex: "description",
+        render: (v: string) => (
           <Typography.Paragraph
             type="secondary"
             style={{
@@ -104,13 +128,13 @@ export const EventsTab = () => {
           >
             {v}
           </Typography.Paragraph>
-        )}
-      />
-      <Table.Column<EventKindRow>
-        title={t("eventstab.enabled")}
-        dataIndex="enabled"
-        width={120}
-        render={(enabled: boolean, row) => (
+        ),
+      },
+      {
+        title: t("eventstab.enabled"),
+        dataIndex: "enabled",
+        width: 120,
+        render: (enabled: boolean, row) => (
           <Tooltip
             title={
               row.enabled === row.default_on
@@ -124,8 +148,89 @@ export const EventsTab = () => {
           >
             <Switch checked={enabled} onChange={(next) => toggle(row, next)} />
           </Tooltip>
-        )}
-      />
-    </Table>
+        ),
+      },
+    ],
+    // toggle + t are stable enough for this admin surface; rebuild on language.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [t],
+  );
+
+  const groups = useMemo(
+    () => groupEventsByCategory(list.data?.data ?? []),
+    [list.data],
+  );
+
+  // Open-category state. null = "first visit, decide once data loads"; a real
+  // array (including []) = the administrator's stored/active choice.
+  const [openKeys, setOpenKeys] = useState<string[] | null>(() => loadStoredOpen());
+
+  // First-visit default: expand the first NON-EMPTY category, collapse the rest.
+  // Only applies when there is no stored choice; never overwrites the user's.
+  useEffect(() => {
+    if (openKeys === null && groups.length > 0) {
+      setOpenKeys([groups[0].id]);
+    }
+  }, [openKeys, groups]);
+
+  const handleChange = (keys: string | string[]) => {
+    const next = Array.isArray(keys) ? keys : [keys];
+    setOpenKeys(next);
+    saveOpen(next); // write-through on every change
+  };
+
+  if (list.isLoading) {
+    return <Skeleton active paragraph={{ rows: 6 }} />;
+  }
+
+  // Unknown stored ids (a category currently empty) are simply ignored by
+  // Collapse and left in state, so the choice survives the category returning.
+  const activeKey = openKeys ?? [];
+
+  const items = groups.map((g) => {
+    const total = g.events.length;
+    const enabled = g.events.filter((e) => e.enabled).length;
+    return {
+      key: g.id,
+      label: (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            width: "100%",
+          }}
+        >
+          <Typography.Text strong>{t(g.labelKey)}</Typography.Text>
+          <Typography.Text type="secondary" style={{ fontSize: 12, fontWeight: 400 }}>
+            {t("eventstab.category.count", { enabled, total })}
+          </Typography.Text>
+        </div>
+      ),
+      children: (
+        <Table<EventKindRow>
+          rowKey="kind"
+          columns={columns}
+          dataSource={g.events}
+          pagination={false}
+          size="small"
+          // tableLayout=auto lets the browser size each column to its content;
+          // Description takes the leftover width so long sentences flow.
+          scroll={{ x: 800 }}
+        />
+      ),
+    };
+  });
+
+  return (
+    <Collapse
+      // ghost + small → compact, table-like sections rather than dashboard cards.
+      ghost
+      size="small"
+      activeKey={activeKey}
+      onChange={handleChange}
+      items={items}
+    />
   );
 };

--- a/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  EVENT_KIND_CATEGORY,
+  EVENT_CATEGORY_ORDER,
+  categoryForKind,
+  groupEventsByCategory,
+} from "./eventCategories";
+
+// Snapshot of models.AllNotificationEventKinds
+// (panel-api/internal/models/notification_event_setting.go). The Go-side test
+// notification_event_categories_sync_test.go fails CI if this drifts from the
+// catalog; this copy lets the pure mapping assertions run in the SPA test suite.
+const CATALOG_KINDS = [
+  "cert.renew.fail",
+  "cert.renew.ok",
+  "domain.expiry.7d",
+  "domain.expiry.1d",
+  "disk.full.warn",
+  "disk.full.crit",
+  "disk.quota.warn",
+  "load.high",
+  "system.update.available",
+  "docker_app.update_available",
+  "service.down",
+  "crowdsec.ban.spike",
+  "backup.fail",
+  "backup.success",
+  "backup.limit.reached",
+  "admin.login",
+  "ssh.login",
+  "notifications.channel.auto_disabled",
+  "panel.welcome",
+  "security.root_terminal.opened",
+  "security.decision.fired",
+  "snuffleupagus.incident.detected",
+  "postgres.service_down",
+  "postgres.disk_high",
+  "postgres.connections_exhausted",
+  "agent.dispatch.failure",
+  "reconciler.error",
+  "agent.unreachable",
+  "notifications.dlq.nonzero",
+  "panel.api.error",
+  "bandwidth.quota.warn",
+  "bandwidth.quota.crit",
+  "digest.daily",
+  "update.completed",
+  "aide.tamper.detected",
+  "nginx.config.invalid",
+  "malware.realtime.critical",
+  "malware.quarantine.added",
+  "egress.drop.burst",
+  "exec.audit.burst",
+  "domain.ghost_detected.mismatch",
+  "domain.ghost_detected.nxdomain",
+  "domain.ghost_detected.partial",
+  "mail.rbl.listed",
+  "mail.rbl.cleared",
+  "mail.dmarc.report_received",
+  "mail.tls.report_received",
+  "mail.feedback.received",
+  "docker_app.entitlement_stopped",
+  "docker_app.disk_quota_stopped",
+  "docker_app.removed_from_package",
+  "db.admin.config_apply_failed_unrecoverable",
+  "db.admin.config_applied",
+  "db.admin.maintenance_finished",
+  "db.admin.root_password_rotated",
+  "automation.user.created",
+  "automation.user.deleted",
+  "automation.user.disabled",
+  "automation.user.enabled",
+  "automation.domain.created",
+  "automation.domain.suspended",
+  "automation.domain.unsuspended",
+];
+
+const CATEGORY_IDS = new Set(EVENT_CATEGORY_ORDER.map((c) => c.id));
+
+describe("eventCategories mapping", () => {
+  it("assigns every catalog kind to exactly one known category", () => {
+    for (const kind of CATALOG_KINDS) {
+      const id = EVENT_KIND_CATEGORY[kind];
+      expect(id, `kind ${kind} is unmapped`).toBeDefined();
+      expect(CATEGORY_IDS.has(id), `kind ${kind} → unknown category ${id}`).toBe(true);
+      // a real catalog kind must never fall back to "other"
+      expect(id).not.toBe("other");
+    }
+  });
+
+  it("has no stale keys beyond the catalog", () => {
+    for (const kind of Object.keys(EVENT_KIND_CATEGORY)) {
+      expect(CATALOG_KINDS, `map has stale kind ${kind}`).toContain(kind);
+    }
+  });
+
+  it("covers the whole catalog (map key count === catalog size)", () => {
+    expect(Object.keys(EVENT_KIND_CATEGORY).length).toBe(CATALOG_KINDS.length);
+  });
+
+  it("keeps event families together", () => {
+    const cat = (k: string) => EVENT_KIND_CATEGORY[k];
+    // docker_app.* → apps
+    for (const k of CATALOG_KINDS.filter((k) => k.startsWith("docker_app."))) {
+      expect(cat(k)).toBe("apps");
+    }
+    // db.admin.* + postgres.* → services (families not split)
+    for (const k of CATALOG_KINDS.filter((k) => k.startsWith("db.admin.") || k.startsWith("postgres."))) {
+      expect(cat(k)).toBe("services");
+    }
+    // mail.* → mail; automation.user.* → users; automation.domain.* → domains
+    for (const k of CATALOG_KINDS.filter((k) => k.startsWith("mail."))) expect(cat(k)).toBe("mail");
+    for (const k of CATALOG_KINDS.filter((k) => k.startsWith("automation.user."))) expect(cat(k)).toBe("users");
+    for (const k of CATALOG_KINDS.filter((k) => k.startsWith("automation.domain."))) expect(cat(k)).toBe("domains");
+  });
+
+  it("falls back to 'other' for an unmapped kind (future event stays visible)", () => {
+    expect(categoryForKind("some.future.event")).toBe("other");
+  });
+});
+
+describe("groupEventsByCategory", () => {
+  const ev = (kind: string, enabled = false) => ({ kind, enabled });
+
+  it("renders only non-empty categories, in taxonomy order", () => {
+    const groups = groupEventsByCategory([
+      ev("backup.fail"),
+      ev("cert.renew.ok"),
+      ev("mail.rbl.listed"),
+    ]);
+    // ssl before backups before mail (taxonomy order), no empty categories
+    expect(groups.map((g) => g.id)).toEqual(["ssl", "backups", "mail"]);
+  });
+
+  it("places each event in exactly one group and preserves counts", () => {
+    const events = CATALOG_KINDS.map((k, i) => ev(k, i % 2 === 0));
+    const groups = groupEventsByCategory(events);
+    const total = groups.reduce((n, g) => n + g.events.length, 0);
+    expect(total).toBe(CATALOG_KINDS.length); // exactly-once, nothing dropped
+    // no category duplicated
+    expect(new Set(groups.map((g) => g.id)).size).toBe(groups.length);
+  });
+
+  it("routes an unmapped kind into a visible 'other' group", () => {
+    const groups = groupEventsByCategory([ev("brand.new.kind")]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("other");
+  });
+});

--- a/panel-ui/src/shells/admin/notifications/eventCategories.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.ts
@@ -1,0 +1,174 @@
+// eventCategories.ts — JAB-381. Central, stable mapping of a notification event
+// KIND to exactly one display category, for grouping the admin
+// Notifications > Events list into collapsible sections.
+//
+// Assignment decision rule (apply this when a new kind is added):
+//   • Families stay together — every docker_app.*, db.admin.*, postgres.*,
+//     mail.*, automation.user.*, automation.domain.* lands in ONE category, so
+//     an operator hunting "postgres alerts" looks in a single place.
+//   • Ties break toward the SUBJECT of the event, not the verb — a docker app
+//     "update_available" is filed under Applications & Docker (its subject),
+//     not Updates (its verb).
+//
+// The canonical kind list is the Go catalog models.AllNotificationEventKinds
+// (panel-api/internal/models/notification_event_setting.go). This map is kept in
+// sync by a cross-boundary test; a kind not present here falls back to "other"
+// so it stays VISIBLE in the UI rather than silently disappearing.
+
+export type EventCategoryId =
+  | "ssl"
+  | "domains"
+  | "disk"
+  | "system"
+  | "services"
+  | "backups"
+  | "mail"
+  | "security"
+  | "users"
+  | "apps"
+  | "updates"
+  | "other";
+
+export interface EventCategoryMeta {
+  id: EventCategoryId;
+  /** i18n key under eventstab.category.* */
+  labelKey: string;
+}
+
+// Display order follows the ticket taxonomy; "other" (the unmapped fallback) is
+// always last and only rendered when non-empty.
+export const EVENT_CATEGORY_ORDER: EventCategoryMeta[] = [
+  { id: "ssl", labelKey: "eventstab.category.ssl" },
+  { id: "domains", labelKey: "eventstab.category.domains" },
+  { id: "disk", labelKey: "eventstab.category.disk" },
+  { id: "system", labelKey: "eventstab.category.system" },
+  { id: "services", labelKey: "eventstab.category.services" },
+  { id: "backups", labelKey: "eventstab.category.backups" },
+  { id: "mail", labelKey: "eventstab.category.mail" },
+  { id: "security", labelKey: "eventstab.category.security" },
+  { id: "users", labelKey: "eventstab.category.users" },
+  { id: "apps", labelKey: "eventstab.category.apps" },
+  { id: "updates", labelKey: "eventstab.category.updates" },
+  { id: "other", labelKey: "eventstab.category.other" },
+];
+
+export const FALLBACK_CATEGORY: EventCategoryId = "other";
+
+// Explicit kind → category. MUST stay in sync with models.AllNotificationEventKinds
+// (enforced by notification_event_categories_sync_test.go on the Go side).
+export const EVENT_KIND_CATEGORY: Record<string, EventCategoryId> = {
+  // SSL & Certificates
+  "cert.renew.fail": "ssl",
+  "cert.renew.ok": "ssl",
+
+  // Domains & DNS (expiry, ghost-detection, automation on domains)
+  "domain.expiry.7d": "domains",
+  "domain.expiry.1d": "domains",
+  "domain.ghost_detected.mismatch": "domains",
+  "domain.ghost_detected.nxdomain": "domains",
+  "domain.ghost_detected.partial": "domains",
+  "automation.domain.created": "domains",
+  "automation.domain.suspended": "domains",
+  "automation.domain.unsuspended": "domains",
+
+  // Disk & Quotas (disk fill, disk quota, bandwidth quota)
+  "disk.full.warn": "disk",
+  "disk.full.crit": "disk",
+  "disk.quota.warn": "disk",
+  "bandwidth.quota.warn": "disk",
+  "bandwidth.quota.crit": "disk",
+
+  // Server & System (host load, panel/notification infra, config integrity, digest)
+  "load.high": "system",
+  "panel.welcome": "system",
+  "panel.api.error": "system",
+  "notifications.channel.auto_disabled": "system",
+  "notifications.dlq.nonzero": "system",
+  "digest.daily": "system",
+  "nginx.config.invalid": "system",
+
+  // Services (service liveness, agent/reconciler pipeline, database engines)
+  "service.down": "services",
+  "agent.dispatch.failure": "services",
+  "agent.unreachable": "services",
+  "reconciler.error": "services",
+  "postgres.service_down": "services",
+  "postgres.disk_high": "services",
+  "postgres.connections_exhausted": "services",
+  "db.admin.config_apply_failed_unrecoverable": "services",
+  "db.admin.config_applied": "services",
+  "db.admin.maintenance_finished": "services",
+  "db.admin.root_password_rotated": "services",
+
+  // Backups
+  "backup.fail": "backups",
+  "backup.success": "backups",
+  "backup.limit.reached": "backups",
+
+  // Mail
+  "mail.rbl.listed": "mail",
+  "mail.rbl.cleared": "mail",
+  "mail.dmarc.report_received": "mail",
+  "mail.tls.report_received": "mail",
+  "mail.feedback.received": "mail",
+
+  // Security (intrusion/abuse, privileged access, integrity, malware, egress/exec)
+  "crowdsec.ban.spike": "security",
+  "security.root_terminal.opened": "security",
+  "security.decision.fired": "security",
+  "snuffleupagus.incident.detected": "security",
+  "aide.tamper.detected": "security",
+  "malware.realtime.critical": "security",
+  "malware.quarantine.added": "security",
+  "egress.drop.burst": "security",
+  "exec.audit.burst": "security",
+  "admin.login": "security",
+  "ssh.login": "security",
+
+  // Users & Accounts
+  "automation.user.created": "users",
+  "automation.user.deleted": "users",
+  "automation.user.disabled": "users",
+  "automation.user.enabled": "users",
+
+  // Applications & Docker
+  "docker_app.update_available": "apps",
+  "docker_app.entitlement_stopped": "apps",
+  "docker_app.disk_quota_stopped": "apps",
+  "docker_app.removed_from_package": "apps",
+
+  // Updates (host / panel updates)
+  "system.update.available": "updates",
+  "update.completed": "updates",
+};
+
+export function categoryForKind(kind: string): EventCategoryId {
+  return EVENT_KIND_CATEGORY[kind] ?? FALLBACK_CATEGORY;
+}
+
+export interface CategorizedGroup<T> {
+  id: EventCategoryId;
+  labelKey: string;
+  events: T[];
+}
+
+// groupEventsByCategory buckets events into the ordered category list, keeping
+// each category's events in the order they arrived (the catalog is pre-ordered)
+// and dropping categories with no events. An unmapped kind lands in "other".
+export function groupEventsByCategory<T extends { kind: string }>(
+  events: T[],
+): CategorizedGroup<T>[] {
+  const byId = new Map<EventCategoryId, T[]>();
+  for (const e of events) {
+    const id = categoryForKind(e.kind);
+    const bucket = byId.get(id);
+    if (bucket) {
+      bucket.push(e);
+    } else {
+      byId.set(id, [e]);
+    }
+  }
+  return EVENT_CATEGORY_ORDER.filter((c) => (byId.get(c.id)?.length ?? 0) > 0).map(
+    (c) => ({ id: c.id, labelKey: c.labelKey, events: byId.get(c.id) as T[] }),
+  );
+}


### PR DESCRIPTION
## JAB-381 — group admin Notifications → Events into collapsible categories

The admin **Notifications → Events** list rendered all 62 event kinds in one flat
Ant Design `Table`. This groups them into compact, **independently collapsible**
categories so the list is scannable — a **client-side presentation change only**;
notification behavior, event definitions, and the GET/PATCH APIs are untouched.

### What changed
- **`eventCategories.ts`** — a central, stable `kind → category` map (all **62**
  catalog kinds, exactly one category each) + an **`other` fallback** so an
  unmapped future kind stays *visible* rather than silently disappearing.
  Assignment rule documented in-file: *families stay together* (`docker_app.*` →
  Applications & Docker; `db.admin.*` + `postgres.*` → Services; `mail.*` → Mail;
  `automation.user.*` → Users; `automation.domain.*` → Domains); *ties break
  toward the subject, not the verb*. `groupEventsByCategory()` returns only
  non-empty categories in taxonomy order.
- **`EventsTab.tsx`** — a controlled Ant Design `Collapse` (`ghost` + `size=small`
  → compact/table-like, not dashboard cards). Each header is a full-row toggle
  showing **`N / M enabled`**, is keyboard-operable, and exposes `aria-expanded`.
  Expanded categories keep the existing Event / Severity / Description / Enabled
  columns + default/override tooltip (columns extracted once, reused per
  category). First visit expands the first non-empty category; the choice
  persists in `localStorage` under a versioned key
  (`jabali.notifEvents.collapse.v1`), distinguishing "no key" (first visit) from
  an empty open-list (user collapsed everything); malformed/unavailable storage
  falls back safely. Multiple categories stay open together (not an accordion).
  **Toggle semantics unchanged** — counts derive from live query data and refresh
  on the existing invalidate/refetch (no optimistic-state machinery introduced,
  per the out-of-scope fence).
- **`en/common.json`** — category + count strings (other locales fall back to
  English via i18next `fallbackLng`; repo has no locale-parity gate).

### Out of scope (left untouched, per the ticket)
Search (**none exists today**; not introduced → acceptance criteria 7/10 are
N/A), event names/IDs/severity/defaults, and any DB/API/schema change.

### Tests
- `eventCategories.test.ts` — exactly-once mapping **vs the real 62-kind catalog**,
  no stale keys, family grouping, and the `other` fallback.
- `EventsTab.test.tsx` — non-empty rendering + counts, first-visit default,
  independent multi-expand, **Enter-key + `aria-expanded`**, localStorage
  persistence across remount, malformed-storage fallback, and the unchanged PATCH.
- `notification_event_categories_ts_sync_test.go` — **cross-boundary contract**:
  every `models.AllNotificationEventKinds` kind must appear in `eventCategories.ts`
  (it already caught `backup.success` missing during development).

### Verification
`npm run build` clean; **15 SPA tests + the Go sync test green**. Visual language
preserved by reusing theme-token-driven AntD primitives (no hardcoded colors), so
light/dark adapt automatically; the DOM-level component tests assert the rendered
structure (headers, counts, aria, expand state). No live screenshot captured (pure
presentation, authenticated stack not stood up) — happy to add one on request.

No new routes/schema → no openapi/cli-reference golden regen. Refs JAB-381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
