### PR TITLE
fix(ui): Edit User name no longer truncates at the first space (GH #1227)

### DIFF
--- a/panel-ui/src/shells/admin/users/UserDrawer.tsx
+++ b/panel-ui/src/shells/admin/users/UserDrawer.tsx
@@ -74,7 +74,15 @@ export function UserDrawer({ open, onClose, editingId }: UserDrawerProps) {
       const { password: _pw, ...rest } = existing;
       void _pw;
       form.resetFields();
-      form.setFieldsValue(rest);
+      // The "Name" field is a single display name bound to name_first, but a
+      // user migrated/imported (or created via the API) may have a split
+      // name_first + name_last. Show the FULL joined name so editing doesn't
+      // silently drop everything after the first word (GH #1227); handleFinish
+      // writes it back whole into name_first and clears name_last.
+      form.setFieldsValue({
+        ...rest,
+        name_first: [rest.name_first, rest.name_last].filter(Boolean).join(" "),
+      });
     } else if (!isEdit) {
       form.resetFields();
       form.setFieldsValue({ is_admin: false, webmail_enabled: true });
@@ -92,6 +100,10 @@ export function UserDrawer({ open, onClose, editingId }: UserDrawerProps) {
         if (payload.package_id == null) {
           payload.package_id = "" as unknown as string;
         }
+        // GH #1227: the Name field carries the full display name in name_first;
+        // collapse any legacy split by clearing name_last, so the whole name
+        // round-trips instead of an orphaned last name reappearing on display.
+        payload.name_last = "";
         await update.mutateAsync({ id: editingId, input: payload });
         feedback.message.success("User updated");
       } else {


### PR DESCRIPTION
## Edit User "Name" drops everything after the first space (GH #1227)

The admin **Edit User** drawer's single "Name" field binds to `name_first` only. A user migrated/imported (or created via the API) can have a split `name_first` + `name_last` — so on edit the field showed just `name_first`: **"Jim Does" came back as "Jim"**, and saving orphaned "Does" (still visible in the list/overview, which join both).

### Fix

The panel treats the name as **one display string** — its own create form is a single `name_first` field, every list/header/overview joins first+last for display, and nothing reads `name_last` semantically (no billing/sort/etc; only display-joins and backup round-trip). So:

- **On load**: populate the field with the full joined name (`[name_first, name_last].join(" ")`).
- **On save**: write it whole into `name_first` and clear `name_last`.

The name now round-trips, and legacy splits collapse cleanly to the single-field model.

### Test plan

- [x] `npx tsc -b` + `npm run build` — pass
- [x] Box-verified on the smoke box: set a user to `name_first="Jim"` / `name_last="Does"`, opened Edit → field showed **"Jim Does"** (pre-fix: "Jim"); Save → DB `name_first="Jim Does"`, `name_last=""`
- [ ] N/A — no API/schema change (client-side form load/save only)

GH #1227
