### PR TITLE
feat(security): recent-auth (MFA step-up) for admin File Manager + Root Terminal (JAB-380)

### DIFF
--- a/internal/kratosclient/client.go
+++ b/internal/kratosclient/client.go
@@ -21,6 +21,19 @@ var ErrUnauthenticated = errors.New("unauthenticated")
 type Identity struct {
 	ID     string                 `json:"id"`
 	Traits map[string]interface{} `json:"traits"`
+
+	// Session-envelope metadata (JAB-380). /sessions/whoami returns these at
+	// the SESSION level, not on the identity; whoamiRemote lifts them onto the
+	// returned Identity so the auth middleware can thread them into claims for
+	// recent-auth (step-up) gating on the root File Manager + Root Terminal.
+	//
+	// AuthenticatedAt is when Kratos last authenticated this session (bumped by
+	// a `?refresh=true` login). Zero if Kratos omitted/failed to parse it —
+	// callers treat zero as "not recently authenticated" (fail closed).
+	// AAL is the assurance level ("aal1"/"aal2"); captured for a future
+	// TOTP/passkey requirement, not enforced in v1.
+	AuthenticatedAt time.Time `json:"-"`
+	AAL             string    `json:"-"`
 }
 
 // Client is a Kratos session validator. It calls /sessions/whoami and caches results
@@ -166,13 +179,18 @@ func (c *Client) whoamiRemote(ctx context.Context, cookie string) (*Identity, er
 	}
 
 	// Kratos /sessions/whoami returns a Session envelope, not a bare identity:
-	//   { "id": "<session_uuid>", "active": true, ..., "identity": { "id": "<identity_uuid>", "traits": {...} } }
+	//   { "id": "<session_uuid>", "active": true, "authenticated_at": "...",
+	//     "authenticator_assurance_level": "aal1",
+	//     "identity": { "id": "<identity_uuid>", "traits": {...} } }
 	// The top-level "id" is the SESSION id — decoding into Identity directly
 	// would populate Identity.ID with that session id and the caller's
 	// FindByKratosIdentityID(id) would never match any users row. Decode the
-	// envelope, then hand back the nested identity.
+	// envelope, then hand back the nested identity — with the session-level
+	// authenticated_at / assurance level lifted onto it (JAB-380 step-up).
 	var sess struct {
-		Identity Identity `json:"identity"`
+		Identity        Identity `json:"identity"`
+		AuthenticatedAt string   `json:"authenticated_at"`
+		AAL             string   `json:"authenticator_assurance_level"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&sess); err != nil {
 		return nil, fmt.Errorf("whoami: failed to decode response: %w", err)
@@ -180,7 +198,36 @@ func (c *Client) whoamiRemote(ctx context.Context, cookie string) (*Identity, er
 	if sess.Identity.ID == "" {
 		return nil, fmt.Errorf("whoami: response missing identity.id")
 	}
-	return &sess.Identity, nil
+	ident := sess.Identity
+	ident.AAL = sess.AAL
+	// Parse the RFC3339 timestamp; on any parse failure leave the zero value
+	// so a recent-auth check fails closed rather than treating an unparseable
+	// time as "now".
+	if sess.AuthenticatedAt != "" {
+		if ts, perr := time.Parse(time.RFC3339Nano, sess.AuthenticatedAt); perr == nil {
+			ident.AuthenticatedAt = ts
+		}
+	}
+	return &ident, nil
+}
+
+// WhoamiUncached validates a session cookie by round-tripping to Kratos,
+// bypassing the positive whoami cache, and refreshes the cache with the fresh
+// result. JAB-380 step-up uses it: after a stale-session 403 the user completes
+// a `?refresh=true` login on the SAME cookie, so a cached (pre-refresh)
+// authenticated_at would otherwise keep failing the recency check for the rest
+// of the TTL — a redirect loop. This forces one authoritative read of the
+// post-refresh authenticated_at.
+func (c *Client) WhoamiUncached(ctx context.Context, cookie string) (*Identity, error) {
+	if cookie == "" {
+		return nil, ErrUnauthenticated
+	}
+	identity, err := c.whoamiRemote(ctx, cookie)
+	if err != nil {
+		return nil, err
+	}
+	c.cache.Set(cookie, identity)
+	return identity, nil
 }
 
 // GetTraitEmail extracts the email from a Kratos identity's traits.

--- a/internal/kratosclient/client_test.go
+++ b/internal/kratosclient/client_test.go
@@ -191,3 +191,92 @@ func TestIdentity_TraitExtraction(t *testing.T) {
 		})
 	}
 }
+
+// TestWhoami_LiftsSessionMetadata verifies JAB-380: the session-envelope's
+// authenticated_at + authenticator_assurance_level are parsed and lifted onto
+// the returned Identity (they live at the session level, not on the identity).
+func TestWhoami_LiftsSessionMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":                            "session-abc",
+			"active":                        true,
+			"authenticated_at":              "2026-08-23T10:00:00.123456Z",
+			"authenticator_assurance_level": "aal1",
+			"identity": map[string]any{
+				"id":     "user-456",
+				"traits": map[string]any{"email": "user@example.com"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := kratosclient.NewClient(server.URL, server.URL)
+	identity, err := client.Whoami(context.Background(), "cookie-x")
+	require.NoError(t, err)
+	assert.Equal(t, "user-456", identity.ID)
+	assert.Equal(t, "aal1", identity.AAL)
+	require.False(t, identity.AuthenticatedAt.IsZero(), "authenticated_at must be parsed")
+	assert.Equal(t, 2026, identity.AuthenticatedAt.Year())
+	assert.Equal(t, 10, identity.AuthenticatedAt.UTC().Hour())
+}
+
+// TestWhoami_MissingAuthenticatedAtIsZero: a whoami without authenticated_at (or
+// an unparseable value) leaves a zero time, which the step-up gate treats as
+// "not recently authenticated" (fail closed).
+func TestWhoami_MissingAuthenticatedAtIsZero(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"s","active":true,"authenticated_at":"not-a-time","identity":{"id":"u"}}`))
+	}))
+	defer server.Close()
+
+	client := kratosclient.NewClient(server.URL, server.URL)
+	identity, err := client.Whoami(context.Background(), "cookie-y")
+	require.NoError(t, err)
+	assert.True(t, identity.AuthenticatedAt.IsZero(), "unparseable authenticated_at must be zero (fail closed)")
+}
+
+// TestWhoamiUncached_BypassesCache verifies JAB-380's refresh-loop fix: after a
+// stale result is cached, WhoamiUncached round-trips again (seeing the bumped
+// authenticated_at from a ?refresh=true login) instead of serving the cache.
+func TestWhoamiUncached_BypassesCache(t *testing.T) {
+	t.Parallel()
+
+	authAt := "2026-08-23T09:00:00Z"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"s","active":true,"authenticated_at":"` + authAt +
+			`","identity":{"id":"u"}}`))
+	}))
+	defer server.Close()
+
+	client := kratosclient.NewClient(server.URL, server.URL)
+	ctx := context.Background()
+
+	// Prime the cache with the pre-refresh time.
+	id1, err := client.Whoami(ctx, "cookie-z")
+	require.NoError(t, err)
+	assert.Equal(t, 9, id1.AuthenticatedAt.UTC().Hour())
+
+	// Simulate a ?refresh=true login: same cookie, bumped authenticated_at.
+	authAt = "2026-08-23T11:30:00Z"
+
+	// Cached Whoami still serves the old time.
+	idCached, err := client.Whoami(ctx, "cookie-z")
+	require.NoError(t, err)
+	assert.Equal(t, 9, idCached.AuthenticatedAt.UTC().Hour(), "cache should still hold pre-refresh time")
+
+	// Uncached read sees the fresh time AND updates the cache.
+	idFresh, err := client.WhoamiUncached(ctx, "cookie-z")
+	require.NoError(t, err)
+	assert.Equal(t, 11, idFresh.AuthenticatedAt.UTC().Hour(), "uncached must see post-refresh time")
+
+	idAfter, err := client.Whoami(ctx, "cookie-z")
+	require.NoError(t, err)
+	assert.Equal(t, 11, idAfter.AuthenticatedAt.UTC().Hour(), "uncached must refresh the cache")
+}

--- a/panel-api/internal/api/files.go
+++ b/panel-api/internal/api/files.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
@@ -248,6 +249,10 @@ type FilesHandlerConfig struct {
 	ServerSettings repository.ServerSettingsRepository // optional; nil → fall back to defaultMaxUploadBytes
 	// Audits records admin File Manager mutations (GH #1184). Optional.
 	Audits repository.AuditEventRepository
+	// KratosClient powers the JAB-380 recent-auth (step-up) check on the
+	// admin (/admin/files) mount. Optional: nil disables step-up (tests /
+	// non-Kratos deployments) — the mount is still admin + opt-in gated.
+	KratosClient *kratosclient.Client
 }
 
 const (
@@ -377,6 +382,17 @@ func (h *filesHandler) adminGate(c *gin.Context) {
 	if err != nil || s == nil || !s.AdminFileManagerEnabled {
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin_file_manager_disabled"})
 		return
+	}
+	// JAB-380 recent-auth (step-up): every admin File Manager request —
+	// reads included, because the root scope exposes arbitrary files — needs a
+	// recently authenticated interactive session. Checked AFTER the opt-in gate
+	// so a disabled FM still reports admin_file_manager_disabled. A nil
+	// KratosClient (tests / non-Kratos deploys) leaves the mount admin+opt-in
+	// gated only.
+	if h.cfg.KratosClient != nil {
+		if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+			return
+		}
 	}
 	c.Set(adminFilesCtxKey, true)
 	if h.cfg.Audits != nil && c.Request.Method != http.MethodGet {

--- a/panel-api/internal/api/stepup.go
+++ b/panel-api/internal/api/stepup.go
@@ -1,0 +1,91 @@
+package api
+
+// JAB-380 — recent-auth (MFA step-up) for admin_root surfaces.
+//
+// The admin File Manager (whole-FS root scope) and the Root Terminal (root
+// PTY) are the two most privileged panel surfaces. Beyond admin claims + their
+// default-off opt-in settings, they require the caller's Kratos session to have
+// authenticated *recently* (stepUpWindow). A stale session gets a 403 that the
+// SPA turns into a Kratos `?refresh=true` re-login, after which it retries.
+//
+// This is deliberately not per-op server state: the window IS the grace window,
+// so a burst of edits inside it doesn't re-prompt, and there is nothing to
+// expire or leak.
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+// stepUpWindow is how recently the Kratos session must have authenticated for a
+// root-privileged action to proceed without a fresh login (JAB-380).
+const stepUpWindow = 10 * time.Minute
+
+// requireRecentAuth enforces JAB-380 recent-auth on a root-privileged request.
+// It returns true if the request may proceed; otherwise it has already written
+// the response and aborted, and the caller must return immediately.
+//
+// Rules (all fail closed):
+//   - Only interactive Kratos cookie sessions can satisfy step-up. API-token
+//     and automation-HMAC callers (Source != SourceKratos) have no interactive
+//     session, so they are refused — a long-lived credential must never drive a
+//     root shell or root-FS mutation.
+//   - Impersonated (act-as, ADR-0128) requests are refused: the root surfaces
+//     are unrelated to the impersonated tenant, and an admin must operate as
+//     themselves here.
+//   - The session's authenticated_at must be within stepUpWindow. The cached
+//     claims value is checked first (fast path); on staleness one
+//     cache-bypassing whoami is performed so a just-completed `?refresh=true`
+//     login is recognised immediately instead of waiting out the ~10s whoami
+//     cache TTL (which would otherwise loop the SPA back to refresh).
+func requireRecentAuth(c *gin.Context, kc *kratosclient.Client, window time.Duration) bool {
+	claims := ginctx.Claims(c)
+	if claims == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return false
+	}
+	// Non-interactive credentials (API token / automation HMAC) and act-as
+	// impersonation cannot step up. Distinct code so the SPA shows "use an
+	// interactive session" rather than trying to launch a refresh flow.
+	if claims.Source != auth.SourceKratos || claims.ImpersonatedBy != "" {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+			"error":  "stepup_unavailable",
+			"detail": "This action requires an interactive browser session with recent authentication.",
+		})
+		return false
+	}
+
+	now := time.Now()
+	if recentEnough(claims.AuthenticatedAt, now, window) {
+		return true
+	}
+	// Stale (or zero) cached value. Re-read fresh, bypassing the positive
+	// whoami cache, so a session the user just refreshed via `?refresh=true`
+	// is recognised without waiting out the cache TTL.
+	if kc != nil {
+		if cookie, err := c.Cookie("ory_kratos_session"); err == nil && cookie != "" {
+			if ident, werr := kc.WhoamiUncached(c.Request.Context(), cookie); werr == nil &&
+				recentEnough(ident.AuthenticatedAt, now, window) {
+				return true
+			}
+		}
+	}
+	c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+		"error":       "stepup_required",
+		"detail":      "Re-authenticate to perform this admin action.",
+		"window_secs": int(window.Seconds()),
+	})
+	return false
+}
+
+// recentEnough reports whether authAt is non-zero and within window of now.
+// A zero authAt (Kratos omitted it, or it failed to parse) fails closed.
+func recentEnough(authAt, now time.Time, window time.Duration) bool {
+	return !authAt.IsZero() && now.Sub(authAt) <= window
+}

--- a/panel-api/internal/api/stepup_test.go
+++ b/panel-api/internal/api/stepup_test.go
@@ -1,0 +1,173 @@
+package api
+
+// JAB-380 — recent-auth (step-up) gate unit tests.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+)
+
+func newStepUpCtx(t *testing.T, claims *auth.AccessClaims, cookie string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/files", nil)
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: "ory_kratos_session", Value: cookie})
+	}
+	c.Request = req
+	if claims != nil {
+		ginctx.SetClaims(c, claims)
+	}
+	return c, w
+}
+
+func TestRequireRecentAuth_FreshCachedClaimsPass(t *testing.T) {
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
+		AuthenticatedAt: time.Now().Add(-1 * time.Minute),
+	}, "")
+	// kc=nil: fast path must succeed on fresh claims without any remote call.
+	if !requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("fresh claims should pass; got %d %s", w.Code, w.Body.String())
+	}
+	if c.IsAborted() {
+		t.Fatalf("context must not be aborted on pass")
+	}
+}
+
+func TestRequireRecentAuth_StaleClaimsRequireStepUp(t *testing.T) {
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
+		AuthenticatedAt: time.Now().Add(-30 * time.Minute),
+	}, "")
+	if requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("stale claims must not pass")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+	assertErrCode(t, w, "stepup_required")
+}
+
+func TestRequireRecentAuth_ZeroAuthenticatedAtFailsClosed(t *testing.T) {
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
+		// zero AuthenticatedAt (Kratos omitted / unparseable)
+	}, "")
+	if requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("zero authenticated_at must fail closed")
+	}
+	assertErrCode(t, w, "stepup_required")
+}
+
+func TestRequireRecentAuth_TokenSourceUnavailable(t *testing.T) {
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceUserAPIToken,
+		AuthenticatedAt: time.Now(), // even "fresh" doesn't matter
+	}, "")
+	if requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("API-token source must be refused")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+	assertErrCode(t, w, "stepup_unavailable")
+}
+
+func TestRequireRecentAuth_ImpersonationUnavailable(t *testing.T) {
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "target", IsAdmin: true, Source: auth.SourceKratos,
+		ImpersonatedBy:  "realadmin",
+		AuthenticatedAt: time.Now(),
+	}, "")
+	if requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("impersonated request must be refused from root surfaces")
+	}
+	assertErrCode(t, w, "stepup_unavailable")
+}
+
+func TestRequireRecentAuth_NilClaimsUnauthorized(t *testing.T) {
+	c, w := newStepUpCtx(t, nil, "")
+	if requireRecentAuth(c, nil, stepUpWindow) {
+		t.Fatalf("nil claims must not pass")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", w.Code)
+	}
+}
+
+// TestRequireRecentAuth_CacheBypassSeesRefresh: cached claims are stale, but a
+// fresh (cache-bypassing) whoami against the request cookie sees a bumped
+// authenticated_at — the refresh-loop fix. The gate must pass.
+func TestRequireRecentAuth_CacheBypassSeesRefresh(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":               "s",
+			"active":           true,
+			"authenticated_at": time.Now().UTC().Format(time.RFC3339Nano), // fresh
+			"identity":         map[string]any{"id": "u1"},
+		})
+	}))
+	defer server.Close()
+	kc := kratosclient.NewClient(server.URL, server.URL)
+
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
+		AuthenticatedAt: time.Now().Add(-30 * time.Minute), // stale cached value
+	}, "cookie-refreshed")
+
+	if !requireRecentAuth(c, kc, stepUpWindow) {
+		t.Fatalf("cache-bypass should see the fresh authenticated_at and pass; got %d %s", w.Code, w.Body.String())
+	}
+}
+
+// TestRequireRecentAuth_CacheBypassStillStale: stale claims AND the fresh whoami
+// still reports a stale authenticated_at → step-up required.
+func TestRequireRecentAuth_CacheBypassStillStale(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":               "s",
+			"active":           true,
+			"authenticated_at": time.Now().Add(-45 * time.Minute).UTC().Format(time.RFC3339Nano),
+			"identity":         map[string]any{"id": "u1"},
+		})
+	}))
+	defer server.Close()
+	kc := kratosclient.NewClient(server.URL, server.URL)
+
+	c, w := newStepUpCtx(t, &auth.AccessClaims{
+		UserID: "u1", IsAdmin: true, Source: auth.SourceKratos,
+		AuthenticatedAt: time.Now().Add(-30 * time.Minute),
+	}, "cookie-old")
+
+	if requireRecentAuth(c, kc, stepUpWindow) {
+		t.Fatalf("still-stale session must require step-up")
+	}
+	assertErrCode(t, w, "stepup_required")
+}
+
+func assertErrCode(t *testing.T, w *httptest.ResponseRecorder, want string) {
+	t.Helper()
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body %q: %v", w.Body.String(), err)
+	}
+	if body.Error != want {
+		t.Fatalf("error code = %q, want %q", body.Error, want)
+	}
+}

--- a/panel-api/internal/api/terminal.go
+++ b/panel-api/internal/api/terminal.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
@@ -57,6 +58,10 @@ type TerminalHandlerConfig struct {
 	Notifications  *notifications.Queue
 	AgentPTYSocket string // override for tests; default terminalAgentPTYSk
 	Log            *slog.Logger
+	// KratosClient powers the JAB-380 recent-auth (step-up) check on token
+	// mint. Optional: nil disables step-up (tests) — the mint is still admin +
+	// root_terminal_enabled gated.
+	KratosClient *kratosclient.Client
 }
 
 type terminalHandler struct{ cfg TerminalHandlerConfig }
@@ -98,6 +103,15 @@ func (h *terminalHandler) mint(c *gin.Context) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "root_terminal_disabled",
 			"detail": "Enable it in Server Settings first (off by default)."})
 		return
+	}
+	// JAB-380 recent-auth (step-up): opening a root shell requires a recently
+	// authenticated interactive session. Checked at mint; the WS upgrade
+	// inherits it via the one-shot 60s IP+uid-bound token, so ws() doesn't
+	// re-prompt. nil KratosClient (tests) leaves mint admin+opt-in gated only.
+	if h.cfg.KratosClient != nil {
+		if !requireRecentAuth(c, h.cfg.KratosClient, stepUpWindow) {
+			return
+		}
 	}
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1361,6 +1361,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Log:            deps.Log,
 				ServerSettings: deps.ServerSettings,
 				Audits:         automationAudits(deps.DB),
+				// JAB-380: recent-auth step-up on the /admin/files mount.
+				KratosClient: deps.KratosClient,
 			})
 		}
 
@@ -1445,6 +1447,8 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				ServerSettings: deps.ServerSettings,
 				Notifications:  deps.NotificationQueue,
 				Log:            deps.Log,
+				// JAB-380: recent-auth step-up on root terminal mint.
+				KratosClient: deps.KratosClient,
 			})
 		}
 		// M34 per-user PHP-FPM egress firewall — admin + user routes share

--- a/panel-api/internal/auth/claims.go
+++ b/panel-api/internal/auth/claims.go
@@ -1,5 +1,7 @@
 package auth
 
+import "time"
+
 // AccessClaims is the resolved identity for an authenticated request. It is
 // populated by middleware (RequireKratosSession) from the Kratos whoami
 // response + the panel users row, and stashed on the gin.Context via ginctx.
@@ -24,6 +26,15 @@ type AccessClaims struct {
 	// path) for backwards compatibility — old middleware that pre-
 	// dates the user-API-token feature leaves Source unset.
 	Source AuthSource
+	// AuthenticatedAt is when the Kratos session behind this request was last
+	// authenticated (JAB-380). Only populated for SourceKratos requests; zero
+	// for API-token / automation-HMAC callers (which have no interactive
+	// session). Recent-auth gates on the root File Manager + Root Terminal read
+	// it to require a fresh login before privileged root actions.
+	AuthenticatedAt time.Time
+	// AAL is the Kratos assurance level ("aal1"/"aal2") of the session.
+	// Captured for a future TOTP/passkey step-up requirement; not enforced yet.
+	AAL string
 }
 
 // AuthSource is the kind of credential that produced the claims.

--- a/panel-api/internal/middleware/auth_kratos.go
+++ b/panel-api/internal/middleware/auth_kratos.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
-	"git.jabali-panel.com/shukivaknin/jabali2/internal/kratosclient"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
@@ -108,10 +108,14 @@ func RequireKratosSession(kratosClient *kratosclient.Client, users repository.Us
 			UserID:  panelUser.ID,
 			Email:   panelUser.Email,
 			IsAdmin: panelUser.IsAdmin,
+			// JAB-380: carry the session's last-authenticated time + assurance
+			// level so recent-auth gates (root File Manager / Root Terminal)
+			// can require a fresh login. Source stays SourceKratos (zero value).
+			AuthenticatedAt: identity.AuthenticatedAt,
+			AAL:             identity.AAL,
 		}
 
 		ginctx.SetClaims(c, claims)
 		c.Next()
 	}
 }
-

--- a/panel-ui/src/apiClient.stepup.test.ts
+++ b/panel-ui/src/apiClient.stepup.test.ts
@@ -1,0 +1,44 @@
+// JAB-380: recent-auth step-up redirect. A `stepup_required` 403 must route the
+// browser through a Kratos *refresh* login that returns to the current page.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { stepUpRedirect } from "./apiClient";
+
+describe("stepUpRedirect (JAB-380)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stashes the current path for post-login return and kicks the Kratos refresh flow", () => {
+    const assign = vi.fn();
+    // jsdom exposes a real location; override for the assertion.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        href: "https://panel.example.com/jabali-admin/files?path=/etc",
+        pathname: "/jabali-admin/files",
+        search: "?path=/etc",
+        assign,
+      },
+    });
+    sessionStorage.clear();
+
+    stepUpRedirect();
+
+    // The return path is carried in sessionStorage (Kratos return_to is dropped
+    // on the login-browser → /login hop), and it must be a path so Login.tsx's
+    // same-origin guard (startsWith "/" && !"//") accepts it.
+    const stashed = sessionStorage.getItem("post_login_return_to");
+    expect(stashed).toBe("/jabali-admin/files?path=/etc");
+    expect(stashed?.startsWith("/")).toBe(true);
+    expect(stashed?.startsWith("//")).toBe(false);
+
+    expect(assign).toHaveBeenCalledTimes(1);
+    const target = assign.mock.calls[0][0] as string;
+    expect(target).toContain("/.ory/self-service/login/browser");
+    expect(target).toContain("refresh=true");
+    expect(target).toContain(
+      "return_to=" + encodeURIComponent("/jabali-admin/files?path=/etc"),
+    );
+  });
+});

--- a/panel-ui/src/apiClient.ts
+++ b/panel-ui/src/apiClient.ts
@@ -67,9 +67,50 @@ apiClient.interceptors.response.use(
         window.location.assign("/jabali-admin");
       }
     }
+
+    // JAB-380 recent-auth step-up: a root-privileged surface (admin File
+    // Manager / Root Terminal) rejected the request because the Kratos session
+    // wasn't authenticated recently enough. Send the user through a Kratos
+    // refresh login, then Kratos returns them to the current page to retry.
+    // `stepup_unavailable` (API-token / impersonated callers) is NOT redirected
+    // — there is no interactive session to refresh; it surfaces as a message.
+    if (err.response?.status === 403 && data?.error === "stepup_required") {
+      stepUpRedirect();
+    }
+
     return Promise.reject(normalizeError(err));
   },
 );
+
+/**
+ * JAB-380: redirect the browser through a Kratos *refresh* login for a
+ * recent-auth (step-up) challenge on the root File Manager / Root Terminal.
+ * Kratos re-authenticates the existing session (bumping authenticated_at) and
+ * the panel's Login page returns the user to where they were, to repeat the
+ * action against a now-fresh session.
+ *
+ * The return path is carried in sessionStorage `post_login_return_to`, NOT the
+ * Kratos `return_to` query — that query is dropped on the
+ * /self-service/login/browser → /login hop (see the M20.1 note in Login.tsx).
+ * This mirrors MyProfile's refresh-flow escalation exactly. The stashed value
+ * is a path (starts with "/") so it satisfies Login.tsx's same-origin guard;
+ * the query is still appended belt-and-braces. Exported for tests; guarded so
+ * it is inert during SSR/tests without a window.
+ */
+export function stepUpRedirect(): void {
+  if (typeof window === "undefined" || !window.location) return;
+  const returnTo = window.location.pathname + window.location.search;
+  try {
+    sessionStorage.setItem("post_login_return_to", returnTo);
+  } catch {
+    // sessionStorage unavailable — the refresh still works; the user just
+    // lands on their role home instead of back on this exact page.
+  }
+  const url =
+    "/.ory/self-service/login/browser?refresh=true&return_to=" +
+    encodeURIComponent(returnTo);
+  window.location.assign(url);
+}
 
 /**
  * JAB-177: the demo write-guard rejects every write with
@@ -144,6 +185,9 @@ function humanizeErrorCode(code: string): string {
     invalid_session: "Session expired — please log in again",
     identity_service_unavailable: "Identity service temporarily unavailable — try again shortly",
     validation_failed: "Some fields are invalid",
+    stepup_required: "Re-authenticate to continue — redirecting you to sign in again…",
+    stepup_unavailable:
+      "This action needs an interactive browser session with a recent login (API tokens and act-as sessions can't perform it)",
     internal: "Something went wrong on the server",
     agent_error:
       "The server's host agent failed — details are in the server logs (journalctl -u jabali-panel / -u jabali-agent)",


### PR DESCRIPTION
## What

Recent-auth (MFA step-up) for the two `admin_root` surfaces — the whole-FS admin **File Manager** and the root **Terminal** — split from JAB-367 (this is its criterion 5, closes it). Before a root FS action or a root shell, the caller's Kratos session must have authenticated within a 10-minute window; a stale session is bounced through a Kratos *refresh* login and returned to retry.

## Why

The File Manager (root scope, whole filesystem) and Root Terminal (root PTY) were gated only by admin claims + their default-off opt-in settings. A long-idle admin tab — or a leaked bearer token — could drive root-FS mutations / a root shell with no fresh proof of presence. There was no step-up/re-auth infrastructure; this adds it.

## How

**Building blocks**
- `kratosclient`: `/sessions/whoami` now lifts the session-envelope's `authenticated_at` + `authenticator_assurance_level` onto the returned `Identity` (they live at the session level, not the identity). New `WhoamiUncached` (cache-bypass): the 10 s positive whoami cache would otherwise keep serving a *pre-refresh* `authenticated_at` right after `?refresh=true`, looping the SPA back to refresh.
- `AccessClaims` carries `AuthenticatedAt` + `AAL`; the Kratos middleware populates them (`AAL` captured for a future TOTP/passkey requirement, not enforced in v1).

**Enforcement — `requireRecentAuth` (fail-closed)**
- Only interactive Kratos sessions can step up. API-token / automation-HMAC callers and act-as (ADR-0128) impersonated requests are refused with `stepup_unavailable` — a long-lived credential must never drive a root shell or root-FS mutation.
- Fast path checks the cached claims time; on staleness one cache-bypassing whoami runs before returning `403 stepup_required` (defeats the refresh loop).
- Wired into `adminGate` for **every** `/admin/files` request — reads included, because the root scope exposes arbitrary files (e.g. `/etc/shadow`) — and into terminal `mint` (the WS upgrade inherits it via the one-shot 60 s IP+uid-bound token). Checked **after** each surface's opt-in gate, so a disabled surface still reports its own code.

**SPA**
- `apiClient` interceptor routes a `stepup_required` 403 through the Kratos refresh login, mirroring MyProfile's M20.1 escalation **exactly**: the return path is stashed in `sessionStorage.post_login_return_to` (Kratos's own `return_to` query is dropped on the `/self-service/login/browser → /login` hop), so the Login page lands the user back where they were to retry. `stepup_unavailable` surfaces as a message (no interactive session to refresh).

## Decisions (signed off)
- **FM scope:** step-up on *every* `/admin/files` request (reads too), not just mutations — root-scope reads are the JAB-358/367 exposure.
- **Window:** 10 min (also the grace window, so a burst of edits doesn't re-prompt).
- **Token auth:** blocked on these surfaces (`stepup_unavailable`).

## Tests
- `kratosclient`: whoami metadata decode, unparseable-time → zero (fail-closed), `WhoamiUncached` cache bypass.
- `requireRecentAuth` table: fresh passes / stale 403 / zero-time fail-closed / token-source + impersonation `stepup_unavailable` / cache-bypass sees refresh / still-stale.
- SPA: `stepUpRedirect` stashes the path + kicks the refresh flow.
- Full backend + full panel-ui vitest (268 tests) green; `tsc -b` clean; rebased on latest `main`.

## Known minor edge (non-blocking)
Single-file **Download** is a raw browser navigation (streamed save-as), so a *stale-session* download click shows the raw `stepup_required` JSON instead of auto-redirecting. Archive and every other action go through the interceptor and redirect correctly. The common case (download shortly after a listing load, which itself required freshness) is unaffected. Follow-up candidate: pre-flight the download through `apiClient`.

Ref: JAB-380 (closes JAB-367 criterion 5), GH #1184, GH #917 (passkey/2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
