### PR TITLE
feat(ui): redesign admin Notifications → Events as a category rail + detail

### DIFF
--- a/panel-ui/src/locales/en/common.json
+++ b/panel-ui/src/locales/en/common.json
@@ -690,7 +690,27 @@
       "updates": "Updates",
       "other": "Other",
       "count": "{{enabled}} / {{total}} enabled"
-    }
+    },
+    "categories": "Categories",
+    "search_all": "Search all events",
+    "filter_category": "Filter in this category",
+    "only_overridden": "Only overridden",
+    "overridden": "Overridden",
+    "enable_all": "Enable all",
+    "disable_all": "Disable all",
+    "reset_defaults": "Reset to defaults",
+    "enabled_of_total": "{{enabled}} of {{total}} enabled",
+    "search_title": "Search: “{{q}}”",
+    "matches": "{{count}} matches across all categories",
+    "no_match": "No events match",
+    "summary_events": "events",
+    "summary_enabled": "enabled",
+    "summary_overridden": "overridden",
+    "bulk_failed": "{{failed}} of {{total}} updates failed",
+    "default_on": "Default: on",
+    "default_off": "Default: off",
+    "overridden_default_on": "Overridden — default is on",
+    "overridden_default_off": "Overridden — default is off"
   },
   "historytab": {
     "body": "Body",

--- a/panel-ui/src/shells/admin/notifications/EventsTab.test.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.test.tsx
@@ -1,7 +1,9 @@
-// EventsTab.test.tsx — JAB-381. Category grouping, counts, first-visit default,
-// independent multi-expand, aria/keyboard, persistence + malformed storage, and
-// unchanged toggle semantics. Only apiClient is mocked; real AntD Collapse/Table
-// /Switch run.
+// EventsTab.test.tsx — category RAIL + DETAIL redesign. Rail lists only
+// non-empty categories with live on/total counts; the detail pane shows the
+// selected category, supports in-category filter + only-overridden, bulk
+// enable/disable + reset, a category-spanning global search, and preserves the
+// unchanged single-kind PATCH shape. Only apiClient is mocked; real AntD +
+// i18n run.
 import { App } from "antd";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
@@ -24,9 +26,10 @@ const row = (
   kind: string,
   enabled: boolean,
   severity = "info" as "info" | "warning" | "error" | "critical",
-) => ({ kind, label: kind, description: `${kind} desc`, severity, enabled, default_on: false });
+  default_on = enabled,
+) => ({ kind, label: `${kind} name`, description: `${kind} desc`, severity, enabled, default_on });
 
-// ssl: 2 events (1 enabled) | backups: 1 (1) | mail: 1 (0)
+// ssl: 2 (1 on) | backups: 1 (1 on) | mail: 1 (0 on)
 const SAMPLE = [
   row("cert.renew.fail", true, "error"),
   row("cert.renew.ok", false),
@@ -45,92 +48,129 @@ function renderTab() {
   );
 }
 
-// The clickable AntD Collapse header carrying aria-expanded, found by its label.
-const header = (name: string): HTMLElement =>
-  screen.getByText(name).closest(".ant-collapse-header") as HTMLElement;
+// The rail button for a category (accessible name includes name + count).
+const catBtn = (name: RegExp): HTMLElement =>
+  screen.getByRole("button", { name });
 
-describe("EventsTab category grouping (JAB-381)", () => {
+// The detail <section> is the sibling of the rail nav — scope row queries to it.
+const detail = (): HTMLElement =>
+  screen.getByRole("navigation").parentElement!.querySelector("section") as HTMLElement;
+
+describe("EventsTab rail + detail redesign", () => {
   beforeEach(() => {
     localStorage.clear();
     mocked.get.mockReset().mockResolvedValue({ data: { data: SAMPLE } });
     mocked.patch.mockReset().mockResolvedValue({ data: {} });
   });
 
-  it("renders only non-empty categories with live enabled/total counts", async () => {
+  it("renders only non-empty categories in the rail with live on/total counts", async () => {
     renderTab();
-    await screen.findByText("SSL & Certificates");
-    expect(screen.getByText("Backups")).toBeInTheDocument();
-    expect(screen.getByText("Mail")).toBeInTheDocument();
-    // empty categories are not rendered
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    expect(catBtn(/Backups/)).toBeInTheDocument();
+    expect(catBtn(/Mail/)).toBeInTheDocument();
+    // empty categories are absent
     expect(screen.queryByText("Security")).not.toBeInTheDocument();
     expect(screen.queryByText("Services")).not.toBeInTheDocument();
-    // header counts
-    expect(screen.getByText("1 / 2 enabled")).toBeInTheDocument(); // ssl
-    expect(screen.getByText("1 / 1 enabled")).toBeInTheDocument(); // backups
-    expect(screen.getByText("0 / 1 enabled")).toBeInTheDocument(); // mail
+    // counts
+    expect(screen.getByText("1/2")).toBeInTheDocument(); // ssl
+    expect(screen.getByText("1/1")).toBeInTheDocument(); // backups
+    expect(screen.getByText("0/1")).toBeInTheDocument(); // mail
   });
 
-  it("expands the first non-empty category on first visit; others collapsed", async () => {
+  it("selects the first category on first visit and shows its events only", async () => {
     renderTab();
-    await screen.findByText("SSL & Certificates");
-    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
-    expect(header("Backups")).toHaveAttribute("aria-expanded", "false");
-    expect(header("Mail")).toHaveAttribute("aria-expanded", "false");
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    const d = detail();
+    expect(within(d).getByText("cert.renew.fail")).toBeInTheDocument();
+    expect(within(d).getByText("cert.renew.ok")).toBeInTheDocument();
+    // other categories' events are not in the detail pane
+    expect(within(d).queryByText("backup.fail")).not.toBeInTheDocument();
+    // header sub-count
+    expect(within(d).getByText("1 of 2 enabled")).toBeInTheDocument();
   });
 
-  it("toggles categories independently — multiple stay open together", async () => {
+  it("switches the detail pane when another category is clicked", async () => {
     renderTab();
-    await screen.findByText("SSL & Certificates");
-    fireEvent.click(header("Backups"));
-    expect(header("Backups")).toHaveAttribute("aria-expanded", "true");
-    // the first-visit SSL panel stays open (not an accordion)
-    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    fireEvent.click(catBtn(/Mail/));
+    const d = detail();
+    expect(within(d).getByText("mail.rbl.listed")).toBeInTheDocument();
+    expect(within(d).queryByText("cert.renew.fail")).not.toBeInTheDocument();
   });
 
-  it("headers are keyboard-operable (Enter toggles) and expose aria-expanded", async () => {
+  it("toggling a switch issues the unchanged single-kind PATCH shape", async () => {
     renderTab();
-    await screen.findByText("SSL & Certificates");
-    const mail = header("Mail");
-    expect(mail).toHaveAttribute("aria-expanded", "false");
-    fireEvent.keyDown(mail, { key: "Enter" });
-    expect(mail).toHaveAttribute("aria-expanded", "true");
-  });
-
-  it("persists the expand choice across a remount", async () => {
-    const first = renderTab();
-    await screen.findByText("SSL & Certificates");
-    fireEvent.click(header("Mail")); // open Mail in addition to SSL
-    expect(header("Mail")).toHaveAttribute("aria-expanded", "true");
-    // stored
-    const stored = JSON.parse(localStorage.getItem("jabali.notifEvents.collapse.v1")!);
-    expect(stored.v).toBe(1);
-    expect(stored.open).toContain("mail");
-
-    first.unmount();
-    renderTab();
-    await screen.findByText("SSL & Certificates");
-    expect(header("Mail")).toHaveAttribute("aria-expanded", "true");
-  });
-
-  it("falls back to first-visit on malformed stored state", async () => {
-    localStorage.setItem("jabali.notifEvents.collapse.v1", "{not valid json");
-    renderTab();
-    await screen.findByText("SSL & Certificates");
-    // malformed → first-visit default (first non-empty expanded), no crash
-    expect(header("SSL & Certificates")).toHaveAttribute("aria-expanded", "true");
-    expect(header("Backups")).toHaveAttribute("aria-expanded", "false");
-  });
-
-  it("toggling a switch issues the unchanged PATCH and no other request shape", async () => {
-    renderTab();
-    await screen.findByText("SSL & Certificates");
-    // SSL is open on first visit; toggle its first switch.
-    const sslBody = header("SSL & Certificates").parentElement as HTMLElement;
-    const firstSwitch = within(sslBody).getAllByRole("switch")[0];
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    const firstSwitch = within(detail()).getAllByRole("switch")[0];
     fireEvent.click(firstSwitch);
     await waitFor(() => expect(mocked.patch).toHaveBeenCalledTimes(1));
     const [url, body] = mocked.patch.mock.calls[0];
     expect(url).toMatch(/^\/admin\/settings\/notification-events\//);
     expect(body).toEqual({ enabled: expect.any(Boolean) });
+  });
+
+  it("Enable all PATCHes only the disabled kinds in the category", async () => {
+    renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    // ssl has 1 enabled + 1 disabled → Enable all sends exactly 1 PATCH
+    fireEvent.click(screen.getByRole("button", { name: "Enable all" }));
+    await waitFor(() => expect(mocked.patch).toHaveBeenCalledTimes(1));
+    expect(mocked.patch.mock.calls[0][0]).toMatch(/cert\.renew\.ok$/);
+    expect(mocked.patch.mock.calls[0][1]).toEqual({ enabled: true });
+  });
+
+  it("filters within the selected category", async () => {
+    renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    const d = detail();
+    fireEvent.change(within(d).getByLabelText("Filter in this category"), {
+      target: { value: "renew.ok" },
+    });
+    expect(within(d).getByText("cert.renew.ok")).toBeInTheDocument();
+    expect(within(d).queryByText("cert.renew.fail")).not.toBeInTheDocument();
+  });
+
+  it("global search spans every category and hides bulk controls", async () => {
+    renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    fireEvent.change(screen.getByLabelText("Search all events"), {
+      target: { value: "backup" },
+    });
+    const d = detail();
+    expect(within(d).getByText("backup.fail")).toBeInTheDocument(); // from another category
+    expect(within(d).queryByText("cert.renew.fail")).not.toBeInTheDocument();
+    // bulk controls are hidden while global searching
+    expect(screen.queryByRole("button", { name: "Enable all" })).not.toBeInTheDocument();
+  });
+
+  it("only-overridden filter narrows to changed-from-default events", async () => {
+    // cert.renew.fail enabled but default_on=false → overridden; others aligned.
+    mocked.get.mockResolvedValue({
+      data: {
+        data: [
+          row("cert.renew.fail", true, "error", false),
+          row("cert.renew.ok", false, "info", false),
+        ],
+      },
+    });
+    renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    const d = detail();
+    fireEvent.click(within(d).getByLabelText("Only overridden"));
+    expect(within(d).getByText("cert.renew.fail")).toBeInTheDocument();
+    expect(within(d).queryByText("cert.renew.ok")).not.toBeInTheDocument();
+  });
+
+  it("persists the selected category across a remount", async () => {
+    const first = renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    fireEvent.click(catBtn(/Mail/));
+    expect(within(detail()).getByText("mail.rbl.listed")).toBeInTheDocument();
+    expect(localStorage.getItem("jabali.notifEvents.selCat.v1")).toBe("mail");
+
+    first.unmount();
+    renderTab();
+    await screen.findByRole("button", { name: /SSL & Certificates/ });
+    expect(within(detail()).getByText("mail.rbl.listed")).toBeInTheDocument();
   });
 });

--- a/panel-ui/src/shells/admin/notifications/EventsTab.tsx
+++ b/panel-ui/src/shells/admin/notifications/EventsTab.tsx
@@ -1,66 +1,97 @@
-// EventsTab — admin Notifications > Events. Per-event-kind enable toggle,
-// grouped into independently collapsible categories (JAB-381). Defaults seeded
-// by panel-api first-boot per models.AllNotificationEventKinds (important = on).
+// EventsTab — admin Notifications > Events. Per-event-kind enable toggles across
+// ~60 kinds in 12 categories. Redesigned as a category RAIL + DETAIL (supersedes
+// the JAB-381 stacked-accordion): the left rail lists categories with live
+// enabled/total counts and a severity hint; the right pane searches within the
+// selected category, toggles individual events, and offers bulk Enable-all /
+// Disable-all / Reset-to-defaults. A top summary strip plus a global search that
+// spans every category round it out. Defaults seeded by panel-api first-boot per
+// models.AllNotificationEventKinds. Category mapping lives in eventCategories.ts
+// (kept in sync with the Go catalog by a cross-boundary test).
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Collapse, Skeleton, Switch, Table, Tag, Tooltip, Typography } from "antd";
-import type { ColumnsType } from "antd/es/table";
+import {
+  Button,
+  Checkbox,
+  Empty,
+  Grid,
+  Input,
+  Skeleton,
+  Switch,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { ReloadOutlined, SearchOutlined } from "@icons";
+
 import { apiClient } from "../../../apiClient";
 import { groupEventsByCategory } from "./eventCategories";
+
+type Severity = "info" | "warning" | "error" | "critical";
 
 type EventKindRow = {
   kind: string;
   label: string;
   description: string;
-  severity: "info" | "warning" | "error" | "critical";
+  severity: Severity;
   enabled: boolean;
   default_on: boolean;
 };
 
 const LIST_KEY = ["admin", "notification-events"] as const;
 
-// Versioned browser-storage key for the per-category expand/collapse choice.
-// Bump the suffix if the stored shape ever changes.
-const COLLAPSE_STORAGE_KEY = "jabali.notifEvents.collapse.v1";
+// Versioned browser-storage key for the last-selected category. Bump the suffix
+// if the stored shape ever changes. A stale/unknown id is ignored (falls back to
+// the first category) so the choice survives a category temporarily emptying.
+const SEL_STORAGE_KEY = "jabali.notifEvents.selCat.v1";
 
-const severityColor: Record<EventKindRow["severity"], string> = {
+const severityColor: Record<Severity, string> = {
   info: "blue",
   warning: "gold",
   error: "red",
   critical: "magenta",
 };
 
-// loadStoredOpen returns the persisted open-category ids, or null when there is
-// no (valid) stored choice — which the caller treats as "first visit". An empty
-// array is a real choice ("user collapsed everything") and is preserved.
-function loadStoredOpen(): string[] | null {
+// Most-severe first — drives the rail's severity-hint dots and their order.
+const SEVERITY_ORDER: Severity[] = ["critical", "error", "warning", "info"];
+
+function loadStoredSel(): string | null {
   try {
-    const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY);
-    if (raw === null) return null; // no key → first visit
-    const parsed = JSON.parse(raw) as { v?: number; open?: unknown };
-    if (parsed?.v !== 1 || !Array.isArray(parsed.open)) return null;
-    if (!parsed.open.every((x) => typeof x === "string")) return null;
-    return parsed.open as string[];
+    return localStorage.getItem(SEL_STORAGE_KEY);
   } catch {
-    // Malformed / unavailable storage must never break rendering.
-    return null;
+    return null; // storage unavailable (private mode / quota) — non-fatal
   }
 }
 
-function saveOpen(open: string[]): void {
+function saveSel(id: string): void {
   try {
-    localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify({ v: 1, open }));
+    localStorage.setItem(SEL_STORAGE_KEY, id);
   } catch {
-    /* storage unavailable (private mode / quota) — non-fatal */
+    /* non-fatal */
   }
 }
+
+const isOverridden = (e: EventKindRow) => e.enabled !== e.default_on;
+
+const matches = (e: EventKindRow, q: string) => {
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+  return (
+    e.label.toLowerCase().includes(needle) ||
+    e.kind.toLowerCase().includes(needle) ||
+    e.description.toLowerCase().includes(needle)
+  );
+};
 
 export const EventsTab = () => {
   const { t } = useTranslation();
   const qc = useQueryClient();
+  const { token } = theme.useToken();
+  const screens = Grid.useBreakpoint();
+  const isNarrow = !screens.md;
 
   const list = useQuery<{ data: EventKindRow[] }>({
     queryKey: LIST_KEY,
@@ -72,165 +103,471 @@ export const EventsTab = () => {
     },
   });
 
-  // Unchanged mutation semantics (JAB-381 is presentation-only): await the PATCH,
-  // then invalidate so the list — and therefore each category's live count —
-  // refetches. A failed toggle never mutated the cache, so the switch + count
-  // resolve back to server truth on their own; surface the error toast.
-  const toggle = async (row: EventKindRow, next: boolean) => {
-    try {
-      await apiClient.patch(`/admin/settings/notification-events/${row.kind}`, {
-        enabled: next,
-      });
-      qc.invalidateQueries({ queryKey: LIST_KEY });
-    } catch (err) {
-      feedback.message.error(err instanceof Error ? err.message : "Toggle failed");
-    }
+  const rows = useMemo(() => list.data?.data ?? [], [list.data]);
+  const groups = useMemo(() => groupEventsByCategory(rows), [rows]);
+
+  // Severity dot palette: token-driven where AntD has a semantic colour so it
+  // tracks the theme; "critical" has no token, so a magenta that reads on both
+  // light and dark grounds.
+  const severityDot: Record<Severity, string> = {
+    info: token.colorInfo,
+    warning: token.colorWarning,
+    error: token.colorError,
+    critical: "#eb2f96",
   };
 
-  // Shared column set — defined once, reused by every category's table.
-  const columns = useMemo<ColumnsType<EventKindRow>>(
-    () => [
-      {
-        title: t("eventstab.event"),
-        dataIndex: "label",
-        width: 280,
-        render: (label: string, row) => (
-          <div>
-            <Typography.Text strong>{label}</Typography.Text>
-            <div>
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                <code>{row.kind}</code>
-              </Typography.Text>
-            </div>
-          </div>
-        ),
-      },
-      {
-        title: t("eventstab.severity"),
-        dataIndex: "severity",
-        width: 120,
-        render: (s: EventKindRow["severity"]) => (
-          <Tag color={severityColor[s] ?? "default"}>{s}</Tag>
-        ),
-      },
-      {
-        title: t("eventstab.description"),
-        dataIndex: "description",
-        render: (v: string) => (
-          <Typography.Paragraph
-            type="secondary"
-            style={{
-              margin: 0,
-              fontSize: 12,
-              whiteSpace: "normal",
-              wordBreak: "break-word",
-            }}
-          >
-            {v}
-          </Typography.Paragraph>
-        ),
-      },
-      {
-        title: t("eventstab.enabled"),
-        dataIndex: "enabled",
-        width: 120,
-        render: (enabled: boolean, row) => (
-          <Tooltip
-            title={
-              row.enabled === row.default_on
-                ? row.default_on
-                  ? "Default: on"
-                  : "Default: off"
-                : row.default_on
-                  ? "Overridden — default is on"
-                  : "Overridden — default is off"
-            }
-          >
-            <Switch checked={enabled} onChange={(next) => toggle(row, next)} />
-          </Tooltip>
-        ),
-      },
-    ],
-    // toggle + t are stable enough for this admin surface; rebuild on language.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t],
-  );
+  const [selCat, setSelCat] = useState<string | null>(() => loadStoredSel());
+  const [globalQuery, setGlobalQuery] = useState("");
+  const [catQuery, setCatQuery] = useState("");
+  const [overriddenOnly, setOverriddenOnly] = useState(false);
 
-  const groups = useMemo(
-    () => groupEventsByCategory(list.data?.data ?? []),
-    [list.data],
-  );
+  // Resolve the effective selection: the stored/active id if it still names a
+  // non-empty category, else the first category. Never renders a dead pane.
+  const activeCat =
+    (selCat && groups.some((g) => g.id === selCat) ? selCat : null) ??
+    groups[0]?.id ??
+    null;
 
-  // Open-category state. null = "first visit, decide once data loads"; a real
-  // array (including []) = the administrator's stored/active choice.
-  const [openKeys, setOpenKeys] = useState<string[] | null>(() => loadStoredOpen());
-
-  // First-visit default: expand the first NON-EMPTY category, collapse the rest.
-  // Only applies when there is no stored choice; never overwrites the user's.
+  // Persist a first-visit / corrected selection back to state + storage once
+  // data has loaded, so the rail highlight and the store agree.
   useEffect(() => {
-    if (openKeys === null && groups.length > 0) {
-      setOpenKeys([groups[0].id]);
+    if (activeCat && activeCat !== selCat) {
+      setSelCat(activeCat);
+      saveSel(activeCat);
     }
-  }, [openKeys, groups]);
+  }, [activeCat, selCat]);
 
-  const handleChange = (keys: string | string[]) => {
-    const next = Array.isArray(keys) ? keys : [keys];
-    setOpenKeys(next);
-    saveOpen(next); // write-through on every change
+  const selectCat = (id: string) => {
+    setSelCat(id);
+    saveSel(id);
+    setCatQuery("");
+    setOverriddenOnly(false);
+    setGlobalQuery("");
   };
 
+  // applyMany PATCHes only the kinds that actually change, in parallel, then
+  // invalidates once. A failed PATCH never mutated the server, so the list
+  // refetch resolves every switch + count back to truth; surface a count.
+  const applyMany = async (changes: { kind: string; enabled: boolean }[]) => {
+    if (changes.length === 0) return;
+    const results = await Promise.allSettled(
+      changes.map((c) =>
+        apiClient.patch(`/admin/settings/notification-events/${c.kind}`, {
+          enabled: c.enabled,
+        }),
+      ),
+    );
+    qc.invalidateQueries({ queryKey: LIST_KEY });
+    const failed = results.filter((r) => r.status === "rejected").length;
+    if (failed > 0) {
+      feedback.message.error(
+        t("eventstab.bulk_failed", { failed, total: changes.length }),
+      );
+    }
+  };
+
+  const toggleOne = (row: EventKindRow, next: boolean) =>
+    applyMany([{ kind: row.kind, enabled: next }]);
+
+  const bulkSet = (events: EventKindRow[], target: boolean) =>
+    applyMany(
+      events.filter((e) => e.enabled !== target).map((e) => ({ kind: e.kind, enabled: target })),
+    );
+
+  const resetToDefaults = (events: EventKindRow[]) =>
+    applyMany(
+      events
+        .filter((e) => e.enabled !== e.default_on)
+        .map((e) => ({ kind: e.kind, enabled: e.default_on })),
+    );
+
+  // ---- summary strip figures ----
+  const totalCount = rows.length;
+  const enabledCount = rows.filter((e) => e.enabled).length;
+  const overriddenCount = rows.filter(isOverridden).length;
+
+  // ---- detail pane data ----
+  const globalMode = globalQuery.trim() !== "";
+  const selGroup = groups.find((g) => g.id === activeCat) ?? null;
+
+  const detailEvents: EventKindRow[] = globalMode
+    ? rows.filter((e) => matches(e, globalQuery))
+    : (selGroup?.events ?? []).filter(
+        (e) => matches(e, catQuery) && (!overriddenOnly || isOverridden(e)),
+      );
+
+  // ---------- render ----------
   if (list.isLoading) {
-    return <Skeleton active paragraph={{ rows: 6 }} />;
+    return <Skeleton active paragraph={{ rows: 8 }} />;
   }
 
-  // Unknown stored ids (a category currently empty) are simply ignored by
-  // Collapse and left in state, so the choice survives the category returning.
-  const activeKey = openKeys ?? [];
+  const cardBorder = `1px solid ${token.colorBorderSecondary}`;
 
-  const items = groups.map((g) => {
-    const total = g.events.length;
-    const enabled = g.events.filter((e) => e.enabled).length;
-    return {
-      key: g.id,
-      label: (
-        <div
+  const SeverityDots = ({ events }: { events: EventKindRow[] }) => {
+    const present = SEVERITY_ORDER.filter((s) => events.some((e) => e.severity === s));
+    return (
+      <span style={{ display: "inline-flex", gap: 3 }} aria-hidden>
+        {present.map((s) => (
+          <span
+            key={s}
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: severityDot[s],
+            }}
+          />
+        ))}
+      </span>
+    );
+  };
+
+  const rail = (
+    <nav
+      aria-label={t("eventstab.categories")}
+      style={
+        isNarrow
+          ? {
+              display: "flex",
+              gap: 8,
+              overflowX: "auto",
+              padding: "4px 0 12px",
+              borderBottom: cardBorder,
+              marginBottom: 12,
+            }
+          : {
+              borderRight: cardBorder,
+              paddingRight: 12,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }
+      }
+    >
+      {!isNarrow && (
+        <Typography.Text
+          type="secondary"
           style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 12,
-            width: "100%",
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: ".08em",
+            textTransform: "uppercase",
+            padding: "6px 10px 4px",
           }}
         >
-          <Typography.Text strong>{t(g.labelKey)}</Typography.Text>
-          <Typography.Text type="secondary" style={{ fontSize: 12, fontWeight: 400 }}>
-            {t("eventstab.category.count", { enabled, total })}
-          </Typography.Text>
+          {t("eventstab.categories")}
+        </Typography.Text>
+      )}
+      {groups.map((g) => {
+        const selected = g.id === activeCat && !globalMode;
+        const on = g.events.filter((e) => e.enabled).length;
+        return (
+          <button
+            key={g.id}
+            type="button"
+            aria-current={selected ? "true" : undefined}
+            onClick={() => selectCat(g.id)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              width: isNarrow ? "auto" : "100%",
+              flex: isNarrow ? "0 0 auto" : undefined,
+              whiteSpace: "nowrap",
+              cursor: "pointer",
+              textAlign: "left",
+              border: isNarrow ? cardBorder : "1px solid transparent",
+              borderRadius: isNarrow ? 999 : 8,
+              background: selected ? token.colorPrimaryBg : "transparent",
+              color: token.colorText,
+              padding: isNarrow ? "7px 12px" : "9px 11px",
+              position: "relative",
+              boxShadow:
+                selected && !isNarrow
+                  ? `inset 3px 0 0 0 ${token.colorError}`
+                  : undefined,
+              borderColor: selected && isNarrow ? token.colorError : undefined,
+            }}
+          >
+            <span style={{ flex: 1, fontSize: 13.5, fontWeight: selected ? 600 : 500 }}>
+              {t(g.labelKey)}
+            </span>
+            {!isNarrow && <SeverityDots events={g.events} />}
+            <span
+              style={{
+                fontSize: 11.5,
+                fontVariantNumeric: "tabular-nums",
+                color: token.colorTextSecondary,
+                background: token.colorBgContainer,
+                border: cardBorder,
+                borderRadius: 999,
+                padding: "1px 8px",
+              }}
+            >
+              {`${on}/${g.events.length}`}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+
+  const detailHeader = (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        flexWrap: "wrap",
+        paddingBottom: 12,
+        borderBottom: `1px solid ${token.colorSplit}`,
+      }}
+    >
+      <Typography.Title level={5} style={{ margin: 0 }}>
+        {globalMode
+          ? t("eventstab.search_title", { q: globalQuery.trim() })
+          : selGroup
+            ? t(selGroup.labelKey)
+            : ""}
+      </Typography.Title>
+      <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+        {globalMode
+          ? t("eventstab.matches", { count: detailEvents.length })
+          : selGroup
+            ? t("eventstab.enabled_of_total", {
+                enabled: selGroup.events.filter((e) => e.enabled).length,
+                total: selGroup.events.length,
+              })
+            : ""}
+      </Typography.Text>
+      {!globalMode && selGroup && (
+        <div style={{ display: "flex", gap: 8, marginLeft: "auto", flexWrap: "wrap" }}>
+          <Button size="small" onClick={() => bulkSet(selGroup.events, true)}>
+            {t("eventstab.enable_all")}
+          </Button>
+          <Button size="small" onClick={() => bulkSet(selGroup.events, false)}>
+            {t("eventstab.disable_all")}
+          </Button>
+          <Button
+            size="small"
+            type="text"
+            icon={<ReloadOutlined />}
+            onClick={() => resetToDefaults(selGroup.events)}
+          >
+            {t("eventstab.reset_defaults")}
+          </Button>
         </div>
-      ),
-      children: (
-        <Table<EventKindRow>
-          rowKey="kind"
-          columns={columns}
-          dataSource={g.events}
-          pagination={false}
-          size="small"
-          // tableLayout=auto lets the browser size each column to its content;
-          // Description takes the leftover width so long sentences flow.
-          scroll={{ x: 800 }}
-        />
-      ),
-    };
-  });
+      )}
+    </div>
+  );
+
+  const detailTools = !globalMode && (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        flexWrap: "wrap",
+        padding: "12px 0",
+        borderBottom: `1px solid ${token.colorSplit}`,
+      }}
+    >
+      <Input
+        allowClear
+        prefix={<SearchOutlined />}
+        placeholder={t("eventstab.filter_category")}
+        value={catQuery}
+        onChange={(e) => setCatQuery(e.target.value)}
+        style={{ flex: 1, minWidth: 180, maxWidth: 360 }}
+        aria-label={t("eventstab.filter_category")}
+      />
+      <Checkbox
+        checked={overriddenOnly}
+        onChange={(e) => setOverriddenOnly(e.target.checked)}
+      >
+        {t("eventstab.only_overridden")}
+      </Checkbox>
+    </div>
+  );
+
+  const eventRow = (e: EventKindRow) => (
+    <div
+      key={e.kind}
+      style={{
+        display: "flex",
+        gap: 14,
+        alignItems: "flex-start",
+        padding: "14px 4px",
+        borderBottom: `1px solid ${token.colorSplit}`,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          marginTop: 6,
+          width: 9,
+          height: 9,
+          borderRadius: "50%",
+          background: severityDot[e.severity],
+          flex: "none",
+        }}
+      />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 9, flexWrap: "wrap" }}>
+          <Typography.Text strong>{e.label}</Typography.Text>
+          <code style={{ fontSize: 11.5, color: token.colorTextTertiary }}>{e.kind}</code>
+          {isOverridden(e) && (
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                letterSpacing: ".03em",
+                textTransform: "uppercase",
+                color: token.colorPrimary,
+                border: `1px solid ${token.colorPrimaryBorder}`,
+                borderRadius: 999,
+                padding: "0 7px",
+              }}
+            >
+              {t("eventstab.overridden")}
+            </span>
+          )}
+        </div>
+        <Typography.Paragraph
+          type="secondary"
+          style={{
+            margin: "3px 0 0",
+            fontSize: 12.5,
+            whiteSpace: "normal",
+            wordBreak: "break-word",
+            maxWidth: "64ch",
+          }}
+        >
+          {e.description}
+        </Typography.Paragraph>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 14, flex: "none" }}>
+        <Tag color={severityColor[e.severity] ?? "default"} style={{ marginInlineEnd: 0 }}>
+          {e.severity}
+        </Tag>
+        <Tooltip
+          title={
+            e.enabled === e.default_on
+              ? e.default_on
+                ? t("eventstab.default_on")
+                : t("eventstab.default_off")
+              : e.default_on
+                ? t("eventstab.overridden_default_on")
+                : t("eventstab.overridden_default_off")
+          }
+        >
+          <Switch
+            checked={e.enabled}
+            onChange={(next) => toggleOne(e, next)}
+            aria-label={e.label}
+          />
+        </Tooltip>
+      </div>
+    </div>
+  );
 
   return (
-    <Collapse
-      // ghost + small → compact, table-like sections rather than dashboard cards.
-      ghost
-      size="small"
-      activeKey={activeKey}
-      onChange={handleChange}
-      items={items}
-    />
+    <div>
+      {/* summary strip */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          flexWrap: "wrap",
+          paddingBottom: 16,
+          borderBottom: cardBorder,
+          marginBottom: 16,
+        }}
+      >
+        <SummaryStat token={token} value={totalCount} label={t("eventstab.summary_events")} />
+        <SummaryStat token={token} value={enabledCount} label={t("eventstab.summary_enabled")} />
+        <SummaryStat
+          token={token}
+          value={overriddenCount}
+          label={t("eventstab.summary_overridden")}
+          accent={overriddenCount > 0 ? token.colorWarning : undefined}
+        />
+        <div style={{ flex: 1 }} />
+        <Input
+          allowClear
+          prefix={<SearchOutlined />}
+          placeholder={t("eventstab.search_all")}
+          value={globalQuery}
+          onChange={(e) => setGlobalQuery(e.target.value)}
+          style={{ minWidth: 220, maxWidth: 320 }}
+          aria-label={t("eventstab.search_all")}
+        />
+      </div>
+
+      {/* master–detail */}
+      <div
+        style={
+          isNarrow
+            ? {}
+            : { display: "grid", gridTemplateColumns: "262px 1fr", gap: 20, alignItems: "start" }
+        }
+      >
+        {rail}
+        <section style={{ minWidth: 0 }}>
+          {detailHeader}
+          {detailTools}
+          <div>
+            {detailEvents.length > 0 ? (
+              detailEvents.map(eventRow)
+            ) : (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={t("eventstab.no_match")}
+                style={{ padding: "48px 0" }}
+              />
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
   );
 };
+
+// SummaryStat — one figure + label chip in the top strip.
+function SummaryStat({
+  token,
+  value,
+  label,
+  accent,
+}: {
+  token: ReturnType<typeof theme.useToken>["token"];
+  value: number;
+  label: string;
+  accent?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        gap: 7,
+        padding: "7px 13px",
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 10,
+        background: token.colorFillQuaternary,
+      }}
+    >
+      <b
+        style={{
+          fontSize: 16,
+          fontVariantNumeric: "tabular-nums",
+          color: accent ?? token.colorText,
+        }}
+      >
+        {value}
+      </b>
+      <span style={{ color: token.colorTextSecondary, fontSize: 12.5 }}>{label}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the stacked-accordion Events tab (follow-up to JAB-381 / #1233) with a
category **rail + detail** layout, scaling better across the ~60 event kinds.

- **Rail** — every non-empty category with a live `enabled/total` count and a
  severity-hint dot cluster; the selected category is marked with the brand accent.
- **Detail pane** — in-category search, **Enable all / Disable all /
  Reset to defaults**, an **Only overridden** filter, per-row severity chip +
  `kind` code + toggle, and an **Overridden** badge when a kind differs from its
  seeded default.
- **Summary strip** — total / enabled / overridden counts.
- **Global search** — spans every category into a flat result view.
- Light + dark via AntD theme tokens; responsive (rail collapses to a horizontal
  scroller under the `md` breakpoint).

No backend change: reuses the existing `GET` / `PATCH
/admin/settings/notification-events` endpoint and the `eventCategories` mapping.
Bulk/reset batch the single-kind PATCH client-side over only the changed kinds.
The selected category persists in `localStorage`.

## Files

- `panel-ui/src/shells/admin/notifications/EventsTab.tsx` — rewritten (rail + detail)
- `panel-ui/src/shells/admin/notifications/EventsTab.test.tsx` — rewritten for the new UI
- `panel-ui/src/locales/en/common.json` — new `eventstab.*` strings (other locales fall back to `en`)

## Test plan

- [x] `vitest` notifications suite — 17/17 (EventsTab 9, eventCategories 8)
- [x] `tsc -b` clean
- [x] `eslint` clean on changed files
- [x] Rebased onto latest `origin/main`, re-ran the above
- [x] Built + deployed to a test box and verified serving end-to-end (`/health`
      reports the commit, served entry bundle matches the build); the Events tab
      renders the rail with live counts, search, bulk, and reset
- [ ] Reviewer: confirm Channels / Web Push / History / Dead Letter tabs are unaffected

Related: JAB-381 (#1233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
