### PR TITLE
fix(security): remove the broad jabali group from the Stalwart mail server (JAB-357)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12722,13 +12722,17 @@ install_stalwart() {
   # /etc/stalwart and /var/lib/stalwart.
   rm -rf /etc/postfix /etc/exim4 /etc/sendmail 2>/dev/null || true
 
-  # Ensure service user + group exist. Supplementary group `jabali` lets
-  # Stalwart read /etc/jabali-panel/stalwart-admin.token (0640 jabali:jabali-mail).
+  # Ensure service user + group exist. JAB-357: jabali-mail must NOT join the
+  # broad `$SERVICE_USER` (jabali) group — that group owns the root Agent socket
+  # and panel secrets, so a mail compromise must not hold it. Stalwart reads its
+  # admin token via its own primary group (token is 0640 jabali:jabali-mail) and
+  # signs DKIM from Stalwart's registry (seeded by the root agent), so the broad
+  # group is dead weight. ensure_stalwart_not_in_panel_group() converges
+  # already-installed hosts that still carry the legacy membership.
   if ! getent passwd jabali-mail >/dev/null 2>&1; then
     _log "creating jabali-mail service user"
     useradd --system --no-create-home --shell /usr/sbin/nologin \
       --user-group jabali-mail
-    usermod -a -G "$SERVICE_USER" jabali-mail
   fi
 
   # Data + config dirs. `install -d` only changes the dir itself's
@@ -15081,6 +15085,48 @@ ensure_jabali_panel_dir_traversable() {
   fi
 }
 
+# ensure_stalwart_not_in_panel_group — JAB-357 criterion 2. The Stalwart mail
+# server (User=jabali-mail) must NOT hold the broad `$SERVICE_USER` (jabali)
+# group: that group owns the root Agent socket (/run/jabali/agent.sock, 0660
+# root:jabali) + panel secrets under /etc/jabali-panel, so an internet-facing
+# mail-server compromise must not hold it. The agent's SO_PEERCRED gate already
+# rejects non-panel UIDs; this strips the FS-layer reach too (defense in depth).
+# Stalwart needs no supplementary group — its admin token is read via its own
+# primary group (0640 jabali:jabali-mail), and DKIM is signed from Stalwart's
+# registry (seeded by the root agent via createDkimSignature), never from the
+# on-disk /etc/jabali-panel/dkim keys. Converge upgraded hosts: redeploy the
+# corrected unit (drops the legacy SupplementaryGroups=jabali), strip the
+# /etc/group membership, then restart so the live process sheds the gid.
+# Idempotent — no-op once converged.
+ensure_stalwart_not_in_panel_group() {
+  getent passwd jabali-mail >/dev/null 2>&1 || return 0
+  local changed=0
+  local unit=/etc/systemd/system/jabali-stalwart.service
+  # 1. Redeploy the unit if the legacy SupplementaryGroups=jabali still lingers
+  #    (else a restart re-grants the gid from the stale unit file).
+  if [[ -f "$unit" ]] && grep -qxE 'SupplementaryGroups=jabali' "$unit"; then
+    if [[ -f "${REPO_DIR}/install/systemd/jabali-stalwart.service" ]]; then
+      install -m 0644 -o root -g root \
+        "${REPO_DIR}/install/systemd/jabali-stalwart.service" "$unit"
+      systemctl daemon-reload 2>/dev/null || true
+      changed=1
+    fi
+  fi
+  # 2. Drop the legacy /etc/group membership so nothing re-leaks it.
+  if id -nG jabali-mail 2>/dev/null | tr ' ' '\n' | grep -qx "$SERVICE_USER"; then
+    if gpasswd -d jabali-mail "$SERVICE_USER" >/dev/null 2>&1; then
+      changed=1
+    else
+      _warn "could not remove jabali-mail from $SERVICE_USER group — run: gpasswd -d jabali-mail $SERVICE_USER"
+    fi
+  fi
+  # 3. Restart so the running Stalwart sheds the supplementary gid.
+  if [[ "$changed" -eq 1 ]]; then
+    systemctl try-restart jabali-stalwart.service >/dev/null 2>&1 || true
+    _ok "Stalwart dropped the broad $SERVICE_USER group (JAB-357)"
+  fi
+}
+
 # provision_php_extensions — self-heal PHP runtime extensions on every
 # `jabali update`. install_base_packages installs the ext set only on a full
 # install and only for JABALI_PHP_VERSIONS, so a newly-required extension (e.g.
@@ -15160,6 +15206,12 @@ provision_new_software() {
   # that only ever update (install_sftp_sshd_config runs on fresh install only),
   # so an existing tenant key can't tunnel into loopback-only services.
   ensure_ssh_forwarding_lockdown
+
+  # JAB-357: strip the broad `jabali` group from the Stalwart mail server on
+  # already-installed hosts (install_stalwart runs on fresh install only). The
+  # group is dead weight for mail and let a mail compromise reach the root Agent
+  # socket at the FS layer.
+  ensure_stalwart_not_in_panel_group
 
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator

--- a/install/systemd/jabali-stalwart.service
+++ b/install/systemd/jabali-stalwart.service
@@ -9,11 +9,16 @@ PartOf=jabali.slice
 Type=simple
 User=jabali-mail
 Group=jabali-mail
-# Supplementary group so Stalwart can read /etc/jabali-panel/stalwart-admin.token
-# (owned jabali:jabali-mail, mode 0640) and /etc/jabali-panel/dkim/*.key
-# (owned jabali:jabali, mode 0600 — Stalwart reads per-domain DKIM keys via
-# its config loader).
-SupplementaryGroups=jabali
+# JAB-357: NO broad `jabali` supplementary group. That group owns the root
+# Agent socket (/run/jabali/agent.sock, 0660 root:jabali) + panel secrets under
+# /etc/jabali-panel, so a mail-server compromise must not hold it — the agent's
+# SO_PEERCRED gate already rejects non-panel UIDs, and this drops the FS-layer
+# reach too (defense in depth). Stalwart needs no supplementary group:
+#   - /etc/jabali-panel/stalwart-admin.token is 0640 jabali:jabali-mail, read
+#     via jabali-mail's own PRIMARY group.
+#   - DKIM signatures are provisioned into Stalwart's REGISTRY by the root agent
+#     (createDkimSignature); Stalwart signs from the registry and never reads
+#     the on-disk /etc/jabali-panel/dkim/*.key files.
 Slice=jabali.slice
 
 # v0.16 config is a small JSON file describing only the datastore

--- a/install/tests/test_service_not_in_broad_jabali_group.sh
+++ b/install/tests/test_service_not_in_broad_jabali_group.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# install/tests/test_service_not_in_broad_jabali_group.sh — JAB-357 criterion 2.
+#
+# The broad `jabali` group owns the root Agent socket (/run/jabali/agent.sock,
+# 0660 root:jabali) and panel secrets under /etc/jabali-panel. No NON-PANEL
+# service identity (a distinct low-privilege service user — jabali-mail /
+# Stalwart, jabali-webmail / Bulwark) may hold that group: a compromise of an
+# internet-facing service would otherwise reach host root at the FS layer even
+# with the SO_PEERCRED gate (defense in depth).
+#
+# A group grant hides in TWO places, and a unit-granted group never shows up in
+# /etc/group — so both must be asserted:
+#   1. install.sh must not `usermod -a -G <jabali> <service>` those accounts.
+#   2. no systemd unit whose User= is a non-panel service account may declare
+#      `SupplementaryGroups=jabali`.
+# Also asserts the upgrade converger exists + runs on `jabali update`.
+#
+# Panel-domain units (User=jabali or root — jabali-panel, jabali-kratos) are
+# exempt: `jabali` is their own identity, not a broad grant.
+#
+# Run from repo root:
+#     bash install/tests/test_service_not_in_broad_jabali_group.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# Non-panel service accounts that must never hold the broad jabali group.
+NONPANEL_SERVICES=(jabali-mail jabali-webmail)
+
+# 1. install.sh must not usermod any non-panel service into the panel group.
+#    $SERVICE_USER is the panel account (jabali); the grant reads as
+#    `usermod -a -G "$SERVICE_USER" <service>` or a literal `... -G jabali ...`.
+for svc in "${NONPANEL_SERVICES[@]}"; do
+  if grep -nE "usermod .*-G [\"']?(\\\$SERVICE_USER|jabali)[\"']? .*${svc}\\b" install.sh \
+       | grep -vqE '^\s*#'; then
+    echo "FAIL: install.sh adds ${svc} to the broad jabali group (usermod -a -G) — JAB-357"
+    grep -nE "usermod .*-G .*${svc}\\b" install.sh || true
+    fail=1
+  fi
+done
+
+# 2. No non-panel unit may carry SupplementaryGroups=jabali (bare token).
+for unit in install/systemd/*.service; do
+  [[ -f "$unit" ]] || continue
+  user_line=$(grep -E '^User=' "$unit" | head -1 | cut -d= -f2- || true)
+  # Only inspect units that run as a non-panel service account.
+  is_nonpanel=0
+  for svc in "${NONPANEL_SERVICES[@]}"; do
+    [[ "$user_line" == "$svc" ]] && is_nonpanel=1
+  done
+  [[ "$is_nonpanel" -eq 1 ]] || continue
+  # SupplementaryGroups= is space-separated; flag the bare `jabali` token only
+  # (NOT jabali-webmail / jabali-sockets — the hyphen makes grep -w match, so
+  # anchor on whitespace/line boundaries instead).
+  supp=$(grep -E '^SupplementaryGroups=' "$unit" | head -1 | cut -d= -f2- || true)
+  if [[ -n "$supp" ]] && grep -qE '(^| )jabali( |$)' <<<"$supp"; then
+    echo "FAIL: $unit (User=$user_line) declares SupplementaryGroups containing bare 'jabali' — JAB-357"
+    echo "      SupplementaryGroups=$supp"
+    fail=1
+  fi
+done
+
+# 3. The upgrade converger must exist AND run on `jabali update`.
+if ! grep -qE '^ensure_stalwart_not_in_panel_group\(\)' install.sh; then
+  echo "FAIL: ensure_stalwart_not_in_panel_group() converger missing — upgraded hosts keep the legacy group"
+  fail=1
+fi
+# It must be invoked inside provision_new_software (the `jabali update` sweep).
+if ! awk '/^provision_new_software\(\)/{f=1} f&&/ensure_stalwart_not_in_panel_group/{found=1} f&&/^\}/{exit} END{exit !found}' install.sh; then
+  echo "FAIL: ensure_stalwart_not_in_panel_group is not called from provision_new_software — the fix never reaches upgraded hosts"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "RESULT: FAIL"
+  exit 1
+fi
+echo "PASS: no non-panel service holds the broad jabali group; upgrade converger wired (JAB-357)"


### PR DESCRIPTION
## What

Removes the broad `jabali` group from the **Stalwart mail server** (`User=jabali-mail`) — the last non-panel service identity still holding it. Closes JAB-357 criterion 2 (the group-membership half); the acute webmail→root path and the SO_PEERCRED gate already shipped.

## Why

The `jabali` group owns the root Agent socket (`/run/jabali/agent.sock`, `0660 root:jabali`) and panel secrets under `/etc/jabali-panel`. JAB-357 requires no non-panel service to hold it. Webmail was fixed (#1208/#1222) and the agent's SO_PEERCRED UID allow-list (#1217) blocks non-panel UIDs — but `jabali-mail` still carried the group, so a mail-server compromise could still **traverse the socket at the FS layer** (defense-in-depth gap).

The group was **dead weight** for mail — both rationales in the old comments were stale:
- The admin token is `0640 jabali:jabali-mail`, read via jabali-mail's **own primary group** (verified: reads with all supplementary groups cleared).
- DKIM is signed from Stalwart's **registry**, seeded by the root agent (`createDkimSignature`). Stalwart never reads the on-disk `/etc/jabali-panel/dkim` keys — they're `root:jabali-sftp 0600`, unreadable by jabali-mail, and mail signed fine that way.

## How

- **`jabali-stalwart.service`**: drop `SupplementaryGroups=jabali`; rewrite the stale comment.
- **`install.sh`**: stop adding `jabali-mail` to `$SERVICE_USER` (jabali) on install.
- **`ensure_stalwart_not_in_panel_group()` converger** run from `provision_new_software` so `jabali update` converges already-installed hosts: the unit install is fresh-install-only, so a stale unit would re-grant the gid on restart — the converger redeploys the corrected unit + `daemon-reload` + `gpasswd -d` + `try-restart`. Idempotent.
- **`test_service_not_in_broad_jabali_group.sh`**: asserts (a) no non-panel account is `usermod`'d into `jabali`, and (b) no non-panel unit declares `SupplementaryGroups` with a bare `jabali` token — a unit grant never shows in `/etc/group`, which is exactly the blind spot that hid this — plus that the converger is wired into the update path. Both guard halves negative-tested (reintroducing either violation makes the test fail).

`jabali-kratos` + `jabali-panel` are exempt: they run as `User=jabali` (the panel identity), so `jabali` is their own group, not a broad grant.

## Verification

- Full `install/tests/*` + `tools/lint-install-sh.sh` (phantom-function lint) green locally; rebased on latest `main`.
- **Box-verified on .86**: after the change Stalwart runs healthy (`NRestarts=0`, all listeners bound, clean ESMTP greeting), its process sheds gid `jabali` (`Groups 979 986 → 979`), the admin token still reads with **no** supplementary groups, and a connect to `/run/jabali/agent.sock` as `jabali-mail` is denied at the FS layer (`Errno 13`) on top of the peercred gate. Restored to baseline afterward.

## Fleet note

This reaches the fleet only when `stable` moves. When it does, each box restarts Stalwart **once** — brief and self-settling (a transient port-bind handoff was observed on .86; `NRestarts=0`, no flap). Not a fleet action in this PR.

Ref: JAB-357 (criterion 2), builds on #1208/#1222/#1217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
