### PR TITLE
feat(notifications): tenant channel picker honors the admin allowed-kind policy (JAB-326)

### DIFF
--- a/panel-api/internal/api/me_notifications.go
+++ b/panel-api/internal/api/me_notifications.go
@@ -173,7 +173,8 @@ func (h *meNotificationsHandler) loadOwnedChannel(c *gin.Context, id, userID str
 }
 
 func (h *meNotificationsHandler) listChannels(c *gin.Context) {
-	if !h.gateOpen(c) {
+	st, ok := h.loadSettings(c)
+	if !ok {
 		return
 	}
 	claims, ok := requireBrowserAuth(c)
@@ -187,7 +188,13 @@ func (h *meNotificationsHandler) listChannels(c *gin.Context) {
 		return
 	}
 	redactChannelSecrets(rows)
-	c.JSON(http.StatusOK, gin.H{"items": rows})
+	// JAB-326: surface the effective admin allowlist so the tenant picker offers
+	// exactly the kinds the server will accept (empty policy → safe defaults),
+	// instead of a hardcoded four. The server create-gate stays authoritative.
+	c.JSON(http.StatusOK, gin.H{
+		"items":         rows,
+		"allowed_kinds": st.TenantNotificationKinds.OrDefault(),
+	})
 }
 
 type meChannelCreateReq struct {

--- a/panel-api/internal/api/me_notifications_test.go
+++ b/panel-api/internal/api/me_notifications_test.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -429,4 +431,36 @@ func TestMeNotif_InvalidEventKind_Is422(t *testing.T) {
 		"channel_id": mine.ID,
 	})
 	require.Equal(t, http.StatusUnprocessableEntity, rec.Code, rec.Body.String())
+}
+
+// JAB-326: the channels list surfaces the effective admin allowlist so the
+// tenant picker offers exactly the creatable kinds.
+func TestMeNotif_ListReturnsAllowedKinds(t *testing.T) {
+	t.Parallel()
+
+	allowedKindsOf := func(rec *httptest.ResponseRecorder) []string {
+		var body struct {
+			AllowedKinds []string `json:"allowed_kinds"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		return body.AllowedKinds
+	}
+
+	// Empty policy → safe defaults (ntfy/telegram/discord/webpush), no risky kinds.
+	r := newMeNotifRouter(t, meNotifSettings(true), &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec := doNotifJSON(t, r, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.ElementsMatch(t,
+		[]string(models.DefaultTenantNotificationKinds()), allowedKindsOf(rec))
+	require.NotContains(t, allowedKindsOf(rec), "webhook")
+
+	// Admin-widened policy → returned verbatim, including webhook + email.
+	st := &mockServerSettingsRepo{getResult: &models.ServerSettings{
+		TenantNotificationsEnabled: true,
+		TenantNotificationKinds:    models.TenantNotificationKinds{"ntfy", "webhook", "email"},
+	}}
+	r2 := newMeNotifRouter(t, st, &fakeChannelsRepo{}, &fakeUserRoutesRepo{}, newUserCtxID("u1"))
+	rec2 := doNotifJSON(t, r2, http.MethodGet, "/api/v1/me/notifications/channels", nil)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	require.ElementsMatch(t, []string{"ntfy", "webhook", "email"}, allowedKindsOf(rec2))
 }

--- a/panel-ui/src/shells/AdminLayout.tsx
+++ b/panel-ui/src/shells/AdminLayout.tsx
@@ -174,6 +174,10 @@ export function AdminLayout() {
             width={256}
             closable
             title={<JabaliTitle />}
+            // GH #1066: unmount the drawer portal on close so no residual
+            // full-viewport `position: fixed` .ant-drawer element is left in
+            // the DOM. See UserLayout for the reproduced detail.
+            destroyOnHidden
             styles={{
               body: { padding: 8, background: siderBg },
               header: { background: siderBg },

--- a/panel-ui/src/shells/UserLayout.tsx
+++ b/panel-ui/src/shells/UserLayout.tsx
@@ -171,6 +171,15 @@ export function UserLayout() {
             width={256}
             closable
             title={<JabaliTitle />}
+            // GH #1066: AntD v6 leaves the .ant-drawer portal mounted after
+            // close — a full-viewport `position: fixed; inset: 0` element that
+            // lingers in the DOM. Reproduced on a mobile viewport: this element
+            // is present exactly in the state where the reporter sees the
+            // residual bottom bar (after opening the menu) and absent after a
+            // refresh (when there is no bar). destroyOnHidden makes rc-drawer
+            // return null once closed, unmounting the portal so no fixed
+            // element is left behind.
+            destroyOnHidden
             styles={{
               body: { padding: 8, background: siderBg },
               header: { background: siderBg },

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.test.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.test.tsx
@@ -1,0 +1,71 @@
+// JAB-326: the tenant channel drawer offers exactly the kinds the server
+// allows (allowedKinds prop), not a hardcoded four. When an admin widens the
+// policy, webhook/email appear; kinds outside the policy do not.
+import { App } from "antd";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MyChannelDrawer } from "./MyChannelDrawer";
+
+vi.mock("../../../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+function renderDrawer(allowedKinds?: Parameters<typeof MyChannelDrawer>[0]["allowedKinds"]) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={qc}>
+      <App>
+        <MyChannelDrawer open onClose={() => {}} allowedKinds={allowedKinds} />
+      </App>
+    </QueryClientProvider>,
+  );
+  // Open the Kind <Select> (the first combobox) so its options render.
+  fireEvent.mouseDown(screen.getAllByRole("combobox")[0]);
+}
+
+describe("MyChannelDrawer kind picker (JAB-326)", () => {
+  it("offers admin-widened kinds (webhook, email) and hides kinds outside policy", () => {
+    renderDrawer(["ntfy", "webhook", "email"]);
+    expect(screen.getByText("Generic webhook")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    // Telegram is not in the configured policy → not offered.
+    expect(screen.queryByText("Telegram")).toBeNull();
+  });
+
+  it("falls back to the safe defaults when no policy is provided", () => {
+    renderDrawer(undefined);
+    expect(screen.getByText("Telegram")).toBeInTheDocument();
+    expect(screen.getByText("Discord")).toBeInTheDocument();
+    // Risky kinds are not in the safe default set.
+    expect(screen.queryByText("Generic webhook")).toBeNull();
+  });
+
+  // AC4 (edit path): editing an existing channel whose kind was since removed
+  // from policy still renders its config form — visibility is preserved.
+  it("still renders the config form when editing a now-disallowed kind", () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={qc}>
+        <App>
+          <MyChannelDrawer
+            open
+            onClose={() => {}}
+            allowedKinds={["ntfy"]}
+            existing={{
+              id: "c1",
+              name: "old hook",
+              kind: "webhook",
+              config: { url: "https://x.test/h", hmac_secret: "s" },
+              enabled: true,
+            }}
+          />
+        </App>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText(/Edit old hook/)).toBeInTheDocument();
+    // The webhook config fields render even though webhook is out of policy.
+    expect(screen.getByText("Target URL")).toBeInTheDocument();
+  });
+});

--- a/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
+++ b/panel-ui/src/shells/user/notifications/MyChannelDrawer.tsx
@@ -17,9 +17,12 @@ import {
   type ChannelKind,
 } from "../../admin/notifications/channelKindConfig";
 
-// TENANT_KINDS — the kinds a tenant may create in the UI. The safe default
-// server allowlist; if an admin has widened it, the server still accepts other
-// kinds via API, but the common surface is these four.
+// TENANT_KINDS — the safe default server allowlist, used as a fallback only
+// (first paint / older API). JAB-326: the real list of creatable kinds comes
+// from the server's effective policy (GET /me/notifications/channels →
+// allowed_kinds), passed in as the allowedKinds prop, so an admin who widens the
+// policy (webhook/slack/sms/email) makes those kinds appear in the picker. The
+// server create-gate stays authoritative regardless.
 export const TENANT_KINDS: ChannelKind[] = ["ntfy", "telegram", "discord", "webpush"];
 
 export type MyChannel = {
@@ -44,11 +47,18 @@ export interface MyChannelDrawerProps {
   open: boolean;
   onClose: () => void;
   existing?: MyChannel;
+  /** Effective server allowlist (JAB-326). Falls back to the safe defaults. */
+  allowedKinds?: ChannelKind[];
 }
 
 const RESOURCE = "me/notifications/channels";
 
-export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProps) {
+export function MyChannelDrawer({ open, onClose, existing, allowedKinds }: MyChannelDrawerProps) {
+  // Effective creatable kinds: server policy when present, else the safe
+  // defaults. The default selected kind is the first allowed one so we never
+  // pre-select a kind the server would reject.
+  const kinds = allowedKinds && allowedKinds.length > 0 ? allowedKinds : TENANT_KINDS;
+  const defaultKind: ChannelKind = existing?.kind ?? kinds[0] ?? "ntfy";
   const [form] = Form.useForm<FormValues>();
   const screens = Grid.useBreakpoint();
   const isDesktop = screens.lg ?? (typeof window !== "undefined" ? window.innerWidth >= 992 : true);
@@ -61,15 +71,21 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
     form.resetFields();
     form.setFieldsValue({
       name: existing?.name ?? "",
-      kind: existing?.kind ?? "ntfy",
+      kind: defaultKind,
       enabled: existing?.enabled ?? true,
       config: existing?.config ?? {},
     });
-  }, [open, existing, form]);
+  }, [open, existing, form, defaultKind]);
 
-  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? existing?.kind ?? "ntfy";
+  const watchedKind = Form.useWatch<ChannelKind | undefined>("kind", form) ?? defaultKind;
   const watchedConfig = Form.useWatch<ChannelFormConfig | undefined>("config", form);
   const fields = useMemo(() => {
+    // Tenant email is forced server-side to the caller's own account address
+    // over the local mail server (no arbitrary destination / custom SMTP — see
+    // forceOwnEmailConfig). Rendering the admin email form's destination + SMTP
+    // fields would only mislead: the server silently overrides them. Show a note
+    // instead and submit no email config.
+    if (watchedKind === "email") return [];
     const all = kindFields[watchedKind] ?? [];
     return all.filter((f) => {
       if (!f.dependsOn) return true;
@@ -125,7 +141,7 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
         form={form}
         layout="vertical"
         onFinish={handleSubmit}
-        initialValues={{ kind: "ntfy", enabled: true, config: {} }}
+        initialValues={{ kind: defaultKind, enabled: true, config: {} }}
       >
         <Form.Item
           name="name"
@@ -141,7 +157,7 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
         <Form.Item name="kind" label="Kind" rules={[{ required: true }]}>
           <Select
             disabled={isEdit}
-            options={TENANT_KINDS.map((k) => ({ value: k, label: kindLabels[k] }))}
+            options={kinds.map((k) => ({ value: k, label: kindLabels[k] }))}
           />
         </Form.Item>
 
@@ -155,6 +171,15 @@ export function MyChannelDrawer({ open, onClose, existing }: MyChannelDrawerProp
             showIcon
             message="Web Push has no fields to configure"
             description="It delivers to this browser's push subscription, created from the notification bell."
+          />
+        ) : null}
+
+        {watchedKind === "email" ? (
+          <Alert
+            type="info"
+            showIcon
+            message="Email delivers to your account address"
+            description="For security, tenant email notifications are always sent to your own account email over the local mail server — the destination and SMTP settings are fixed."
           />
         ) : null}
 

--- a/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
+++ b/panel-ui/src/shells/user/notifications/MyNotificationsPage.tsx
@@ -17,8 +17,8 @@ import type { AxiosError } from "axios";
 import { DeleteOutlined, EditOutlined, PlusOutlined, SendOutlined } from "@icons";
 import { apiClient } from "../../../apiClient";
 import { useDeleteMutation, useUpdateMutation } from "../../../hooks/useQueries";
-import { kindColors, kindLabels } from "../../admin/notifications/channelKindConfig";
-import { MyChannelDrawer, type MyChannel } from "./MyChannelDrawer";
+import { kindColors, kindLabels, type ChannelKind } from "../../admin/notifications/channelKindConfig";
+import { MyChannelDrawer, TENANT_KINDS, type MyChannel } from "./MyChannelDrawer";
 
 const CH_RESOURCE = "me/notifications/channels";
 const RT_RESOURCE = "me/notifications/routes";
@@ -55,11 +55,15 @@ export function MyNotificationsPage(): JSX.Element {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState<MyChannel | undefined>();
 
-  const channelsQ = useQuery<MyChannel[]>({
+  const channelsQ = useQuery<{ items: MyChannel[]; allowedKinds: ChannelKind[] }>({
     queryKey: ["list", CH_RESOURCE],
     queryFn: async () => {
-      const { data } = await apiClient.get<{ items: MyChannel[] }>(`/${CH_RESOURCE}`);
-      return data.items ?? [];
+      const { data } = await apiClient.get<{ items?: MyChannel[]; allowed_kinds?: ChannelKind[] }>(
+        `/${CH_RESOURCE}`,
+      );
+      // JAB-326: the effective admin allowlist rides along with the list; fall
+      // back to the safe defaults if an older API omits it.
+      return { items: data.items ?? [], allowedKinds: data.allowed_kinds ?? TENANT_KINDS };
     },
     retry: false,
   });
@@ -89,7 +93,8 @@ export function MyNotificationsPage(): JSX.Element {
   const updateMutation = useUpdateMutation<MyChannel, { enabled: boolean }>({ resource: CH_RESOURCE });
   const deleteMutation = useDeleteMutation({ resource: CH_RESOURCE });
 
-  const channels = channelsQ.data ?? [];
+  const channels = channelsQ.data?.items ?? [];
+  const allowedKinds = channelsQ.data?.allowedKinds ?? TENANT_KINDS;
 
   // event_kind -> [{channelId, routeId}] so the matrix can show current
   // selections and delete the right route row when a channel is unpicked.
@@ -300,7 +305,12 @@ export function MyNotificationsPage(): JSX.Element {
         </Table>
       </Card>
 
-      <MyChannelDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} existing={editing} />
+      <MyChannelDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        existing={editing}
+        allowedKinds={allowedKinds}
+      />
       {/* t() kept referenced for future i18n of this page */}
       <span style={{ display: "none" }}>{t("nav.user.notifications", "Notifications")}</span>
     </Space>


### PR DESCRIPTION
## What

The tenant notification channel picker now honors the administrator allowed-kind policy instead of hardcoding four kinds. When an admin widens the policy (webhook/slack/sms/email on top of the safe defaults), those kinds become creatable through the tenant panel.

## Why

The admin policy is enforced on the backend (`createChannel` → `TenantNotificationKinds.OrDefault().Allows(kind)`), but `MyChannelDrawer` hardcoded `["ntfy","telegram","discord","webpush"]`, so an admin-enabled kind was impossible to create through the UI — only via direct API calls.

## How

- **`me_notifications.go`**: `GET /me/notifications/channels` returns `allowed_kinds` (the effective policy — empty falls back to the safe defaults). `listChannels` switches `gateOpen`→`loadSettings` to read the policy in the same fail-closed gated call. The create-gate stays authoritative.
- **`MyChannelDrawer`**: new `allowedKinds` prop drives the Kind `<Select>`; the default selected kind is the first allowed one (never pre-selects a kind the server would reject). `TENANT_KINDS` stays as the safe-default fallback (first paint / older API).
- **Tenant email UX**: tenant email is force-overridden server-side to the caller's own account address over the local mail server (`forceOwnEmailConfig`). The drawer therefore suppresses the admin email form's destination/SMTP fields and shows an info note, so a tenant who picks Email isn't misled by fields that get silently replaced.
- **`MyNotificationsPage`**: threads `allowed_kinds` from the list response into the drawer.

## Acceptance criteria

- ✓ Tenant adapter receives effective allowed kinds (`allowed_kinds` in the list response).
- ✓ Safe defaults appear when the configured policy is empty (`OrDefault`).
- ✓ Admin-enabled webhook/email kinds appear in the picker.
- ✓ Removing a kind blocks new creation (server gate, unchanged) while existing rows stay visible — the list renders any kind via `kindLabels`, and editing an out-of-policy channel still renders its config form (both covered by tests).
- ✓ Server policy remains authoritative (the create-gate is untouched; the UI only mirrors it).

## Tests / verification

- Backend: list returns the safe defaults on empty policy and a widened set verbatim (asserted on the parsed `allowed_kinds` array, not a body substring).
- Frontend: `MyChannelDrawer` render tests — admin-widened kinds (webhook/email) appear and out-of-policy kinds don't; safe-default fallback; edit-mode with a now-disallowed kind still renders its form.
- `tsc -b`, full panel-ui vitest (273), and the api test package all green; rebased ff-clean on `main`.
- No box-verify: pure UI+API wiring, both sides contract-tested, no reconciler/agent surface.

Ref: JAB-326 (arch-audit round 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
