### PR TITLE
feat(backup): per-destination slot cap + circuit-breaker for the dispatcher (JAB-362)

### DIFF
--- a/panel-api/internal/backupfinalizer/breaker_backoff_test.go
+++ b/panel-api/internal/backupfinalizer/breaker_backoff_test.go
@@ -1,0 +1,28 @@
+package backupfinalizer
+
+import (
+	"testing"
+	"time"
+)
+
+// JAB-362: exponential dispatch backoff, base 1h, cap 24h.
+func TestBreakerBackoffFor(t *testing.T) {
+	cases := []struct {
+		n    int
+		want time.Duration
+	}{
+		{0, time.Hour},        // clamped to n>=1
+		{1, time.Hour},        // base
+		{2, 2 * time.Hour},    // *2
+		{3, 4 * time.Hour},    // *4
+		{4, 8 * time.Hour},    // *8
+		{5, 16 * time.Hour},   // *16
+		{6, 24 * time.Hour},   // 32h capped to 24h
+		{100, 24 * time.Hour}, // stays capped, no overflow
+	}
+	for _, c := range cases {
+		if got := breakerBackoffFor(c.n); got != c.want {
+			t.Errorf("breakerBackoffFor(%d) = %s; want %s", c.n, got, c.want)
+		}
+	}
+}

--- a/panel-api/internal/backupfinalizer/breaker_trip_test.go
+++ b/panel-api/internal/backupfinalizer/breaker_trip_test.go
@@ -1,0 +1,73 @@
+package backupfinalizer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type breakerJobs struct {
+	repository.BackupJobRepository
+	running  []models.BackupJob
+	finished []string
+}
+
+func (f *breakerJobs) ListRunning(context.Context, int) ([]models.BackupJob, error) {
+	return f.running, nil
+}
+func (f *breakerJobs) MarkFinished(_ context.Context, id, _ string, _, _ string, _, _ uint64, _, _ json.RawMessage, _ string) error {
+	f.finished = append(f.finished, id)
+	return nil
+}
+
+type breakerDests struct {
+	repository.BackupDestinationRepository
+	got              *models.BackupDestination
+	recordedID       string
+	recordedFailures int
+}
+
+func (f *breakerDests) Get(context.Context, string) (*models.BackupDestination, error) {
+	return f.got, nil
+}
+func (f *breakerDests) RecordFailure(_ context.Context, id string, failures int, _ time.Time) error {
+	f.recordedID, f.recordedFailures = id, failures
+	return nil
+}
+
+// JAB-362: a 4h stall-failure of a backup job trips its destination's breaker,
+// incrementing the existing consecutive-failure count.
+func TestFinalizer_StallTripsDestinationBreaker(t *testing.T) {
+	dead := "dead-dest"
+	jobs := &breakerJobs{running: []models.BackupJob{{
+		ID:            "j1",
+		Kind:          models.BackupJobKindAccountBackup,
+		Status:        models.BackupJobStatusRunning,
+		StartedAt:     startedAgo(5 * time.Hour), // past the 4h StallTimeout
+		DestinationID: &dead,
+	}}}
+	dests := &breakerDests{got: &models.BackupDestination{ID: dead, ConsecutiveFailures: 2}}
+	f := &Finalizer{deps: Deps{
+		Jobs:         jobs,
+		Destinations: dests,
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}}
+
+	f.tickOnce(context.Background())
+
+	if len(jobs.finished) != 1 || jobs.finished[0] != "j1" {
+		t.Fatalf("stalled job must be marked failed; finished=%v", jobs.finished)
+	}
+	if dests.recordedID != dead {
+		t.Fatalf("breaker tripped on wrong destination: %q", dests.recordedID)
+	}
+	if dests.recordedFailures != 3 {
+		t.Fatalf("breaker must increment existing count (2) to 3; got %d", dests.recordedFailures)
+	}
+}

--- a/panel-api/internal/backupfinalizer/finalizer.go
+++ b/panel-api/internal/backupfinalizer/finalizer.go
@@ -54,7 +54,7 @@ type Deps struct {
 	// ungated finalizer churned the standby (and the shared DR repo) probing
 	// jobs that belong to another box. Optional; nil = never gated.
 	Settings repository.ServerSettingsRepository
-	Agent        agent.AgentInterface
+	Agent    agent.AgentInterface
 	// SSOKey unseals a destination's per-row restic password (M30.2.x).
 	// Without it backup.status cannot open a rotated destination's repo,
 	// so a finished backup is never sealed — it sits "running" until the
@@ -181,6 +181,14 @@ func (f *Finalizer) tickOnce(ctx context.Context) {
 				"job_id", j.ID, "started_at", j.StartedAt)
 			_ = f.deps.Jobs.MarkFinished(ctx, j.ID, models.BackupJobStatusFailed,
 				"", "", 0, 0, nil, nil, "stalled: no manifest snapshot after 4h")
+			// JAB-362: a 4h stall is the signal that this destination is dead or
+			// unreachable. Trip its breaker so the dispatcher backs it off
+			// instead of burning a shared slot on it every tick. Only the stall
+			// path counts — dispatch-time failures (user/dest lookup) are not
+			// destination health.
+			if j.DestinationID != nil && *j.DestinationID != "" {
+				f.tripDestinationBreaker(ctx, *j.DestinationID, now)
+			}
 			continue
 		}
 		f.checkOne(ctx, j)
@@ -268,4 +276,58 @@ func (f *Finalizer) checkOne(ctx context.Context, j models.BackupJob) {
 	}
 	logger.Info("backup finalized", "snapshot_id", manifestSnapID,
 		"status", status, "failed_stages", st.FailedStages)
+
+	// JAB-362: a landed snapshot proves the destination is reachable — clear any
+	// tripped breaker so the dispatcher stops backing it off. Both Succeeded and
+	// Partial reached the repo (Partial = some stage failed, not the transport).
+	if dest != nil && dest.ConsecutiveFailures > 0 {
+		if err := f.deps.Destinations.ResetHealth(ctx, dest.ID); err != nil {
+			logger.Warn("failed to reset backup destination breaker", "dest", dest.ID, "err", err)
+		} else {
+			logger.Warn("backup destination breaker RESET after success", "dest", dest.ID)
+		}
+	}
+}
+
+// backupBreakerBaseBackoff / backupBreakerMaxBackoff bound the exponential
+// dispatch backoff a repeatedly stall-failing destination earns (JAB-362).
+const (
+	backupBreakerBaseBackoff = time.Hour
+	backupBreakerMaxBackoff  = 24 * time.Hour
+)
+
+// breakerBackoffFor returns the dispatch backoff for the n-th consecutive
+// failure: base * 2^(n-1), capped. n>=1.
+func breakerBackoffFor(n int) time.Duration {
+	if n < 1 {
+		n = 1
+	}
+	d := backupBreakerBaseBackoff
+	for i := 1; i < n && d < backupBreakerMaxBackoff; i++ {
+		d *= 2
+	}
+	if d > backupBreakerMaxBackoff {
+		d = backupBreakerMaxBackoff
+	}
+	return d
+}
+
+// tripDestinationBreaker increments a destination's consecutive-failure count
+// and pushes its backoff-until out exponentially. The next dispatch tick skips
+// the destination until the window expires, at which point one job is admitted
+// as a probe (a success resets the breaker via checkOne).
+func (f *Finalizer) tripDestinationBreaker(ctx context.Context, destID string, now time.Time) {
+	d, err := f.deps.Destinations.Get(ctx, destID)
+	if err != nil || d == nil {
+		f.deps.Log.Warn("breaker trip: destination lookup failed", "dest", destID, "err", err)
+		return
+	}
+	failures := d.ConsecutiveFailures + 1
+	until := now.Add(breakerBackoffFor(failures))
+	if err := f.deps.Destinations.RecordFailure(ctx, destID, failures, until); err != nil {
+		f.deps.Log.Warn("breaker trip: record-failure failed", "dest", destID, "err", err)
+		return
+	}
+	f.deps.Log.Warn("backup destination breaker TRIPPED",
+		"dest", destID, "consecutive_failures", failures, "backoff_until", until)
 }

--- a/panel-api/internal/backupscheduler/scheduler.go
+++ b/panel-api/internal/backupscheduler/scheduler.go
@@ -107,7 +107,13 @@ type Deps struct {
 
 // Scheduler is the goroutine wrapper. Construct via New, start with
 // Start(ctx). Returns immediately; the loop runs until ctx is done.
-type Scheduler struct{ deps Deps }
+type Scheduler struct {
+	deps Deps
+	// dispatch admits one queued job. Overridable in tests to capture the
+	// dispatcher's admission decisions (per-destination cap + breaker) without
+	// running the full per-job machinery. nil → dispatchOne.
+	dispatch func(context.Context, models.BackupJob)
+}
 
 // New returns a configured scheduler. Returns nil if any required dep
 // is missing — callers log + skip start in that case so an incomplete
@@ -213,14 +219,102 @@ func (s *Scheduler) tickDispatch(ctx context.Context) {
 	if slots <= 0 {
 		return
 	}
-	queued, err := s.deps.Jobs.ListQueuedOldest(ctx, slots)
+
+	// JAB-362 per-destination fairness + circuit-breaker.
+	//   - runningByDest caps the slots any one destination may hold, so a
+	//     stall-failing destination (each attempt burns a 4h slot) cannot
+	//     monopolise the pool and starve backups to healthy destinations.
+	//   - backedOff destinations (tripped breaker, backoff not yet expired) are
+	//     skipped entirely so a dead destination is not retried every tick.
+	// Admission is WORK-CONSERVING: pass 1 honours the per-destination cap; pass
+	// 2 fills any slots the cap left idle (e.g. a single-destination server) so
+	// the cap only ever redistributes under contention, never throttles.
+	runningByDest, err := s.deps.Jobs.CountRunningByDestination(ctx)
+	if err != nil {
+		s.deps.Log.Error("dispatcher count-by-destination failed", "err", err)
+		return
+	}
+	var backedOff map[string]bool
+	if s.deps.Destinations != nil {
+		if bo, boErr := s.deps.Destinations.ListBackedOffIDs(ctx, time.Now().UTC()); boErr != nil {
+			s.deps.Log.Error("dispatcher list-backed-off failed", "err", boErr)
+			return
+		} else {
+			backedOff = bo
+		}
+	}
+
+	// Fetch a generous window so pass 1 can skip past saturated/backed-off
+	// destinations and still fill slots from others.
+	window := int(max) * 8
+	if window < 50 {
+		window = 50
+	}
+	queued, err := s.deps.Jobs.ListQueuedOldest(ctx, window)
 	if err != nil {
 		s.deps.Log.Error("dispatcher list-queued failed", "err", err)
 		return
 	}
-	for _, j := range queued {
-		s.dispatchOne(ctx, j)
+
+	perDestCap := (int(max) + 1) / 2
+	if perDestCap < 1 {
+		perDestCap = 1
 	}
+
+	admittedByDest := make(map[string]int)
+	admitted := 0
+	var deferred []models.BackupJob // hit the per-dest cap in pass 1
+
+	dispatch := s.dispatchOne
+	if s.dispatch != nil {
+		dispatch = s.dispatch
+	}
+	admit := func(j models.BackupJob) {
+		dispatch(ctx, j)
+		admittedByDest[destKey(j)]++
+		admitted++
+	}
+
+	// Pass 1 — oldest-first, respecting the per-destination cap + breaker.
+	for _, j := range queued {
+		if admitted >= slots {
+			break
+		}
+		dk := destKey(j)
+		if backedOff[dk] {
+			continue
+		}
+		if runningByDest[dk]+admittedByDest[dk] >= perDestCap {
+			deferred = append(deferred, j)
+			continue
+		}
+		admit(j)
+	}
+	// Pass 2 — work-conserving: fill leftover slots beyond the cap (still never a
+	// backed-off destination).
+	for _, j := range deferred {
+		if admitted >= slots {
+			break
+		}
+		if backedOff[destKey(j)] {
+			continue
+		}
+		admit(j)
+	}
+
+	if admitted < slots && len(queued) == window {
+		s.deps.Log.Info("dispatcher window exhausted with slots free; more queued jobs deferred to next tick",
+			"window", window, "admitted", admitted, "slots", slots)
+	}
+}
+
+// destKey buckets a job by its destination for per-destination slot accounting.
+// Legacy jobs with no destination share the "" bucket.
+func destKey(j models.BackupJob) string {
+	if j.DestinationID != nil {
+		return *j.DestinationID
+	}
+	return ""
 }
 
 // enqueue handles one overdue schedule end-to-end: compute next

--- a/panel-api/internal/backupscheduler/scheduler_dispatch_slots_test.go
+++ b/panel-api/internal/backupscheduler/scheduler_dispatch_slots_test.go
@@ -1,0 +1,133 @@
+package backupscheduler
+
+// JAB-362: the dispatcher caps the slots any one destination may hold and skips
+// backed-off destinations, WITHOUT throttling a single-destination server
+// (work-conserving two-pass admission).
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// slotFakeJobs answers the three queries tickDispatch makes; every other method
+// panics (unused here) via the embedded nil interface.
+type slotFakeJobs struct {
+	repository.BackupJobRepository
+	running       int64
+	runningByDest map[string]int
+	queued        []models.BackupJob
+}
+
+func (f *slotFakeJobs) CountByStatus(context.Context, string) (int64, error) { return f.running, nil }
+func (f *slotFakeJobs) CountRunningByDestination(context.Context) (map[string]int, error) {
+	return f.runningByDest, nil
+}
+func (f *slotFakeJobs) ListQueuedOldest(_ context.Context, _ int) ([]models.BackupJob, error) {
+	return f.queued, nil
+}
+
+// slotFakeDests overrides only ListBackedOffIDs.
+type slotFakeDests struct {
+	repository.BackupDestinationRepository
+	backedOff map[string]bool
+}
+
+func (f *slotFakeDests) ListBackedOffIDs(_ context.Context, _ time.Time) (map[string]bool, error) {
+	return f.backedOff, nil
+}
+
+func strptr(s string) *string { return &s }
+
+func qjob(id, dest string) models.BackupJob {
+	j := models.BackupJob{ID: id, Kind: models.BackupJobKindAccountBackup}
+	if dest != "" {
+		j.DestinationID = strptr(dest)
+	}
+	return j
+}
+
+// runDispatch runs one tickDispatch with the given fakes (max defaults to 2 via
+// nil Settings) and returns the destination keys dispatched, in order.
+func runDispatch(jobs *slotFakeJobs, backedOff map[string]bool) []string {
+	var got []string
+	s := &Scheduler{
+		deps: Deps{
+			Jobs:         jobs,
+			Destinations: &slotFakeDests{backedOff: backedOff},
+			Log:          slog.Default(),
+		},
+		dispatch: func(_ context.Context, j models.BackupJob) {
+			got = append(got, destKey(j))
+		},
+	}
+	s.tickDispatch(context.Background())
+	return got
+}
+
+func count(ss []string, want string) int {
+	n := 0
+	for _, s := range ss {
+		if s == want {
+			n++
+		}
+	}
+	return n
+}
+
+func TestDispatch_SingleDestinationNotThrottled(t *testing.T) {
+	// One destination, two queued, no running → BOTH dispatch (work-conserving).
+	jobs := &slotFakeJobs{
+		runningByDest: map[string]int{},
+		queued:        []models.BackupJob{qjob("j1", "d1"), qjob("j2", "d1")},
+	}
+	got := runDispatch(jobs, nil)
+	if len(got) != 2 || count(got, "d1") != 2 {
+		t.Fatalf("single-dest must dispatch both queued jobs; got %v", got)
+	}
+}
+
+func TestDispatch_PerDestCapPreventsMonopoly(t *testing.T) {
+	// d1 floods the front of the queue; d2 must still get a slot (max=2).
+	jobs := &slotFakeJobs{
+		runningByDest: map[string]int{},
+		queued: []models.BackupJob{
+			qjob("j1", "d1"), qjob("j2", "d1"), qjob("j3", "d1"), qjob("j4", "d2"),
+		},
+	}
+	got := runDispatch(jobs, nil)
+	if count(got, "d1") != 1 || count(got, "d2") != 1 {
+		t.Fatalf("cap must give d2 a slot despite d1 flooding; got %v", got)
+	}
+}
+
+func TestDispatch_ExistingRunningCountsTowardCap(t *testing.T) {
+	// d1 already holds its capped slot (running=1); the one free slot goes to d2.
+	jobs := &slotFakeJobs{
+		running:       1,
+		runningByDest: map[string]int{"d1": 1},
+		queued:        []models.BackupJob{qjob("j1", "d1"), qjob("j2", "d2")},
+	}
+	got := runDispatch(jobs, nil)
+	if len(got) != 1 || got[0] != "d2" {
+		t.Fatalf("free slot must go to d2 (d1 at cap); got %v", got)
+	}
+}
+
+func TestDispatch_BackedOffDestinationSkipped(t *testing.T) {
+	jobs := &slotFakeJobs{
+		runningByDest: map[string]int{},
+		queued:        []models.BackupJob{qjob("j1", "d1"), qjob("j2", "d1"), qjob("j3", "d2")},
+	}
+	got := runDispatch(jobs, map[string]bool{"d1": true})
+	if count(got, "d1") != 0 {
+		t.Fatalf("backed-off d1 must not be dispatched; got %v", got)
+	}
+	if count(got, "d2") != 1 {
+		t.Fatalf("healthy d2 must dispatch while d1 is backed off; got %v", got)
+	}
+}

--- a/panel-api/internal/db/migrations/000274_backup_dest_circuit_breaker.down.sql
+++ b/panel-api/internal/db/migrations/000274_backup_dest_circuit_breaker.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE backup_destinations
+    DROP COLUMN consecutive_failures,
+    DROP COLUMN backoff_until;

--- a/panel-api/internal/db/migrations/000274_backup_dest_circuit_breaker.up.sql
+++ b/panel-api/internal/db/migrations/000274_backup_dest_circuit_breaker.up.sql
@@ -1,0 +1,9 @@
+-- JAB-362: per-destination circuit-breaker for the backup dispatcher. A
+-- destination that keeps stall-failing (4h/attempt) is backed off from dispatch
+-- for an exponential window instead of burning a shared concurrency slot every
+-- tick. consecutive_failures drives the backoff length; backoff_until is the
+-- skip-until timestamp (NULL = healthy). Both reset on the next successful seal.
+-- INT + nullable DATETIME on a small table — no row-ceiling concern.
+ALTER TABLE backup_destinations
+    ADD COLUMN consecutive_failures INT NOT NULL DEFAULT 0,
+    ADD COLUMN backoff_until DATETIME(6) NULL;

--- a/panel-api/internal/eventsources/backup_fail_test.go
+++ b/panel-api/internal/eventsources/backup_fail_test.go
@@ -51,6 +51,9 @@ func (f *fakeBackupJobs) CountRetainedForUser(context.Context, string) (int64, e
 func (f *fakeBackupJobs) ListQueuedOldest(context.Context, int) ([]models.BackupJob, error) {
 	return nil, nil
 }
+func (f *fakeBackupJobs) CountRunningByDestination(context.Context) (map[string]int, error) {
+	return nil, nil
+}
 func (f *fakeBackupJobs) ListRuns(context.Context, int, int) ([]repository.BackupRunSummary, int64, error) {
 	return nil, 0, nil
 }

--- a/panel-api/internal/models/backup_destination.go
+++ b/panel-api/internal/models/backup_destination.go
@@ -116,9 +116,15 @@ type BackupDestination struct {
 	// INSERT, so default:1 would silently re-enable it. See
 	// feedback_gorm_default1_bool_zero_value. Every create site sets Enabled
 	// explicitly; the DB column keeps its DEFAULT 1 for raw inserts.
-	Enabled   bool      `gorm:"not null" json:"enabled"`
-	CreatedAt time.Time `gorm:"type:datetime(6);not null" json:"created_at"`
-	UpdatedAt time.Time `gorm:"type:datetime(6);not null" json:"updated_at"`
+	Enabled bool `gorm:"not null" json:"enabled"`
+	// JAB-362 circuit-breaker: ConsecutiveFailures counts back-to-back 4h
+	// stall-failures of jobs to this destination; BackoffUntil (NULL = healthy)
+	// is the time before which the dispatcher skips this destination. Both reset
+	// to 0 / NULL on the next successful seal. Not tenant-facing.
+	ConsecutiveFailures int        `gorm:"type:int;not null;default:0" json:"consecutive_failures"`
+	BackoffUntil        *time.Time `gorm:"type:datetime(6)" json:"backoff_until,omitempty"`
+	CreatedAt           time.Time  `gorm:"type:datetime(6);not null" json:"created_at"`
+	UpdatedAt           time.Time  `gorm:"type:datetime(6);not null" json:"updated_at"`
 }
 
 func (BackupDestination) TableName() string { return "backup_destinations" }

--- a/panel-api/internal/repository/backup_destination_repository.go
+++ b/panel-api/internal/repository/backup_destination_repository.go
@@ -21,12 +21,57 @@ type BackupDestinationRepository interface {
 	Delete(ctx context.Context, id string) error
 	// M30.2: per-destination restic password (AES-GCM via sso.key).
 	SetPassword(ctx context.Context, id string, sealed []byte, rotatedAt time.Time) error
+
+	// JAB-362 circuit-breaker. RecordFailure sets the destination's
+	// consecutive-failure count + backoff-until after a 4h stall-failure.
+	// ResetHealth clears them on the next successful seal. ListBackedOffIDs
+	// returns the set of destination ids currently in backoff (backoff_until >
+	// now), which the dispatcher skips.
+	RecordFailure(ctx context.Context, id string, failures int, backoffUntil time.Time) error
+	ResetHealth(ctx context.Context, id string) error
+	ListBackedOffIDs(ctx context.Context, now time.Time) (map[string]bool, error)
 }
 
 type backupDestinationRepo struct{ db *gorm.DB }
 
 func NewBackupDestinationRepository(db *gorm.DB) BackupDestinationRepository {
 	return &backupDestinationRepo{db: db}
+}
+
+func (r *backupDestinationRepo) RecordFailure(ctx context.Context, id string, failures int, backoffUntil time.Time) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.BackupDestination{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"consecutive_failures": failures,
+			"backoff_until":        backoffUntil,
+		}).Error)
+}
+
+func (r *backupDestinationRepo) ResetHealth(ctx context.Context, id string) error {
+	return translate(r.db.WithContext(ctx).
+		Model(&models.BackupDestination{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"consecutive_failures": 0,
+			"backoff_until":        nil,
+		}).Error)
+}
+
+func (r *backupDestinationRepo) ListBackedOffIDs(ctx context.Context, now time.Time) (map[string]bool, error) {
+	var ids []string
+	err := r.db.WithContext(ctx).
+		Model(&models.BackupDestination{}).
+		Where("backoff_until IS NOT NULL AND backoff_until > ?", now).
+		Pluck("id", &ids).Error
+	if err != nil {
+		return nil, translate(err)
+	}
+	out := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		out[id] = true
+	}
+	return out, nil
 }
 
 func (r *backupDestinationRepo) Create(ctx context.Context, d *models.BackupDestination) error {
@@ -106,9 +151,9 @@ func (r *backupDestinationRepo) SetPassword(ctx context.Context, id string, seal
 		Model(&models.BackupDestination{}).
 		Where("id = ?", id).
 		Updates(map[string]any{
-			"password_enc":         sealed,
-			"password_rotated_at":  rotatedAt,
-			"updated_at":           time.Now().UTC(),
+			"password_enc":        sealed,
+			"password_rotated_at": rotatedAt,
+			"updated_at":          time.Now().UTC(),
 		})
 	if res.Error != nil {
 		return translate(res.Error)

--- a/panel-api/internal/repository/backup_job_repository.go
+++ b/panel-api/internal/repository/backup_job_repository.go
@@ -44,6 +44,12 @@ type BackupJobRepository interface {
 	// follow-up). CountByStatus + ListQueuedOldest let it cap
 	// dispatches at server_settings.backup_max_concurrent_jobs.
 	CountByStatus(ctx context.Context, status string) (int64, error)
+	// CountRunningByDestination returns the number of status='running' jobs
+	// grouped by destination id, mirroring CountByStatus('running') exactly
+	// (all kinds, incl. restores). The nil/empty destination bucket is keyed by
+	// "". The dispatcher uses it to cap the slots any one destination may hold
+	// (JAB-362).
+	CountRunningByDestination(ctx context.Context) (map[string]int, error)
 	// HasPendingForTarget reports whether a queued or running backup_job already
 	// exists for this (schedule, destination, user) target. The scheduler uses it
 	// to skip re-enqueueing while a prior job is still pending — otherwise a
@@ -220,6 +226,36 @@ func (r *backupJobRepo) CountByStatus(ctx context.Context, status string) (int64
 		return 0, translate(err)
 	}
 	return n, nil
+}
+
+func (r *backupJobRepo) CountRunningByDestination(ctx context.Context) (map[string]int, error) {
+	type row struct {
+		DestinationID *string
+		N             int
+	}
+	var rows []row
+	// Same predicate as CountByStatus('running') — all kinds, incl. restores —
+	// so the per-destination counts sum to the global running count the
+	// dispatcher gates on. COALESCE the nullable destination_id to '' so legacy
+	// rows bucket together under the "" key.
+	err := r.db.WithContext(ctx).
+		Model(&models.BackupJob{}).
+		Select("destination_id, COUNT(*) AS n").
+		Where("status = ?", models.BackupJobStatusRunning).
+		Group("destination_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, translate(err)
+	}
+	out := make(map[string]int, len(rows))
+	for _, r := range rows {
+		key := ""
+		if r.DestinationID != nil {
+			key = *r.DestinationID
+		}
+		out[key] += r.N
+	}
+	return out, nil
 }
 
 func (r *backupJobRepo) HasPendingForTarget(ctx context.Context, scheduleID, destinationID, userID string) (bool, error) {


### PR DESCRIPTION
## What

Adds per-destination slot accounting + a circuit-breaker to the backup dispatcher. Follow-up to JAB-361: the skip-if-pending guard stopped unbounded queue growth, but a dead/slow destination still held a shared concurrency slot for the finalizer's full 4h stall window per attempt — with `backup_max_concurrent_jobs` small (default 2), one failing destination could occupy a large fraction of the pool and slow every other backup.

## How

**Per-destination slot cap (work-conserving).** `tickDispatch` caps the running slots any one destination may hold at `ceil(max/2)`, so a stall-failing destination cannot monopolise the pool. Admission is two-pass:
- Pass 1 admits oldest-first honouring the cap (existing running + admitted-this-tick).
- Pass 2 fills any slots the cap left idle — so a **single-destination server is never throttled**; the cap only redistributes under contention.

New `Jobs.CountRunningByDestination` mirrors `CountByStatus('running')` exactly (all kinds incl. restores; NULL destination buckets under `""`), so per-dest and global running counts agree. A generous queued window (`max*8`, min 50) lets pass 1 skip past saturated/backed-off destinations and still fill from others; window exhaustion is logged (no silent cap).

**Circuit-breaker (migration 000274).** `backup_destinations` gains `consecutive_failures` + `backoff_until`. On a 4h stall-failure the finalizer trips the destination's breaker (exponential backoff, base 1h cap 24h); the dispatcher skips backed-off destinations, so a dead destination isn't retried every tick at 4h/slot. The next post-backoff job is the probe — a successful seal resets the breaker. Only the stall path counts toward health; dispatch-time failures (user/dest lookup) don't.

## Acceptance criteria

- ✓ A single stall-failing destination cannot hold more than a bounded share of the pool (`ceil(max/2)`).
- ✓ Backups to healthy destinations dispatch while another destination fails every attempt (per-dest cap + backed-off skip).
- ✓ A repeatedly-failing destination is backed off from dispatch (exponential) rather than retried every tick.

## Tests

- Dispatch admission: **single-dest not throttled** (the work-conserving regression guard), per-dest cap prevents monopoly, existing running counts toward the cap, backed-off destination skipped. (A test-only dispatch seam captures admission without the full per-job machinery.)
- Backoff curve (base 1h → cap 24h, no overflow).
- Finalizer trip-on-stall wiring (increments the existing failure count).

## Box-verified on .86

Deployed the build (migration 000274 applied clean: 273→274, `consecutive_failures` default 0, `backoff_until` NULL). Proved the new SQL against real MariaDB: `ListBackedOffIDs` returns a future-backoff row and excludes a past one; the `CountRunningByDestination` GROUP BY runs. The dispatch loop ticked error-free with the new logic; panel healthy throughout. Restored to baseline afterward (reverted to 273, dropped the columns, reinstalled the baseline binary — verified 273 / login 200). The end-to-end breaker trip (a real 4h stall) is covered by the finalizer wiring unit test rather than a live stall.

Ref: JAB-362 (JAB-361 weakness #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
