### PR TITLE
fix(ui): lead with username in user delete/suspend/reset modals and edit drawer (GH #1239)

### DIFF
--- a/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserDeleteAction.tsx
@@ -12,6 +12,11 @@ import { apiClient } from "../../../apiClient";
 
 interface UserDeleteActionProps {
   recordItemId: string;
+  // Display identifier — username-led (see userLabel, GH #1239).
+  userLabel: string;
+  // POSIX account name (M54). Absent only for legacy rows created
+  // before usernames existed — then the email local part is the account.
+  username?: string | null;
   userEmail: string;
   open: boolean;
   onClose: () => void;
@@ -19,6 +24,8 @@ interface UserDeleteActionProps {
 
 export const UserDeleteAction = ({
   recordItemId,
+  userLabel,
+  username,
   userEmail,
   open,
   onClose,
@@ -31,7 +38,7 @@ export const UserDeleteAction = ({
     try {
       await apiClient.delete(`/users/${encodeURIComponent(recordItemId)}`);
 
-      feedback.message.success(`User "${userEmail}" and all related data deleted`);
+      feedback.message.success(`User "${userLabel}" and all related data deleted`);
 
       // Invalidate every ["list", "users", *] variant so admin tabs
       // and the parent badge counters all refetch after a delete.
@@ -48,11 +55,11 @@ export const UserDeleteAction = ({
     }
   };
 
-  const localPart = userEmail.split("@")[0];
+  const osAccount = username || userEmail.split("@")[0];
 
   return (
     <Modal
-      title={`Delete user "${userEmail}"?`}
+      title={`Delete user "${userLabel}"?`}
       open={open}
       onCancel={onClose}
       footer={[
@@ -72,7 +79,7 @@ export const UserDeleteAction = ({
     >
       <p>
         This is permanent and cannot be undone. Deleting{" "}
-        <strong>{userEmail}</strong> will remove:
+        <strong>{userLabel}</strong> will remove:
       </p>
       <ul>
         <li>All owned domains, DNS zones, SSL certificates, nginx sites</li>
@@ -80,7 +87,7 @@ export const UserDeleteAction = ({
         <li>All mailboxes, forwarders, and Stalwart mail accounts</li>
         <li>All cron jobs, applications, SSH keys</li>
         <li>
-          The OS account <code>{localPart}</code> and <code>/home/{localPart}</code>
+          The OS account <code>{osAccount}</code> and <code>/home/{osAccount}</code>
         </li>
         <li>The Kratos identity (login record)</li>
       </ul>

--- a/panel-ui/src/shells/admin/users/UserDrawer.tsx
+++ b/panel-ui/src/shells/admin/users/UserDrawer.tsx
@@ -8,6 +8,7 @@
 // Password on edit is optional — blank means "keep current".
 import { Button, Drawer, Form, Grid, Input, Select, Space, Spin, Switch } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { userLabel } from "./userLabel";
 import { useEffect } from "react";
 
 import { CheckOutlined, CloseOutlined } from "@icons";
@@ -118,7 +119,7 @@ export function UserDrawer({ open, onClose, editingId }: UserDrawerProps) {
 
   return (
     <Drawer
-      title={isEdit ? "Edit user" : "Create user"}
+      title={isEdit ? (existing ? `Edit ${userLabel(existing)}` : "Edit user") : "Create user"}
       open={open}
       onClose={onClose}
       width={isDesktop ? 520 : undefined}

--- a/panel-ui/src/shells/admin/users/UserList.tsx
+++ b/panel-ui/src/shells/admin/users/UserList.tsx
@@ -27,6 +27,7 @@ import { useListQuery } from "../../../hooks/useQueries";
 import { useSelectQuery } from "../../../hooks/useSelectQuery";
 import { useTableURL } from "../../../hooks/useTableURL";
 import { UserDeleteAction } from "./UserDeleteAction";
+import { userLabel } from "./userLabel";
 import { UserDrawer } from "./UserDrawer";
 import { UserDiskUsage, UserDiskUsageCell } from "./UserDiskUsage";
 import { UserReset2FAAction } from "./UserReset2FAAction";
@@ -125,20 +126,20 @@ function UserRowActions({
       <RowActions actions={actions} />
       <UserReset2FAAction
         userId={user.id}
-        userEmail={user.email}
+        userLabel={userLabel(user)}
         open={reset2faOpen}
         onClose={() => setReset2faOpen(false)}
       />
       <UserResetPasswordAction
         userId={user.id}
-        userEmail={user.email}
+        userLabel={userLabel(user)}
         open={resetPwOpen}
         onClose={() => setResetPwOpen(false)}
       />
       {!user.is_admin && (
         <UserSuspendAction
           userId={user.id}
-          userEmail={user.email}
+          userLabel={userLabel(user)}
           suspended={!!user.suspended}
           open={suspendOpen}
           onClose={() => setSuspendOpen(false)}
@@ -146,6 +147,8 @@ function UserRowActions({
       )}
       <UserDeleteAction
         recordItemId={user.id}
+        userLabel={userLabel(user)}
+        username={user.username}
         userEmail={user.email}
         open={deleteOpen}
         onClose={() => setDeleteOpen(false)}

--- a/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserReset2FAAction.tsx
@@ -14,14 +14,15 @@ import { apiClient } from "../../../apiClient";
 
 interface UserReset2FAActionProps {
   userId: string;
-  userEmail: string;
+  // Display identifier — username-led (see userLabel, GH #1239).
+  userLabel: string;
   open: boolean;
   onClose: () => void;
 }
 
 export const UserReset2FAAction = ({
   userId,
-  userEmail,
+  userLabel,
   open,
   onClose,
 }: UserReset2FAActionProps) => {
@@ -32,7 +33,7 @@ export const UserReset2FAAction = ({
     setIsLoading(true);
     try {
       await apiClient.post(`/admin/users/${encodeURIComponent(userId)}/2fa/reset`);
-      feedback.message.success(`Two-factor authentication reset for "${userEmail}"`);
+      feedback.message.success(`Two-factor authentication reset for "${userLabel}"`);
       onClose();
     } catch (err: unknown) {
       const errMsg =
@@ -55,7 +56,7 @@ export const UserReset2FAAction = ({
     >
       <p>
         Removes the TOTP authenticator and recovery codes from{" "}
-        <strong>{userEmail}</strong>. The user keeps their password and can
+        <strong>{userLabel}</strong>. The user keeps their password and can
         re-enrol from their profile page after their next sign-in.
       </p>
       <p>Use only when the user has confirmed they cannot recover access.</p>

--- a/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserResetPasswordAction.tsx
@@ -12,12 +12,13 @@ import { apiClient } from "../../../apiClient";
 
 interface Props {
   userId: string;
-  userEmail: string;
+  // Display identifier — username-led (see userLabel, GH #1239).
+  userLabel: string;
   open: boolean;
   onClose: () => void;
 }
 
-export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Props) => {
+export const UserResetPasswordAction = ({ userId, userLabel, open, onClose }: Props) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [tempPassword, setTempPassword] = useState<string | null>(null);
@@ -29,7 +30,7 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
         `/admin/users/${encodeURIComponent(userId)}/password/reset`,
       );
       setTempPassword(res.data.password);
-      feedback.message.success(`Password reset for "${userEmail}"`);
+      feedback.message.success(`Password reset for "${userLabel}"`);
     } catch (err: unknown) {
       feedback.message.error(err instanceof Error ? err.message : "Failed to reset password");
     } finally {
@@ -53,7 +54,7 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
         okText={t("userresetpasswordaction.done")}
       >
         <p>
-          Hand this temporary password to <strong>{userEmail}</strong>. It is shown
+          Hand this temporary password to <strong>{userLabel}</strong>. It is shown
           only once. They sign in with it and should change it from their profile.
         </p>
         <Typography.Paragraph copyable strong style={{ fontSize: 16 }}>
@@ -74,7 +75,7 @@ export const UserResetPasswordAction = ({ userId, userEmail, open, onClose }: Pr
       okButtonProps={{ danger: true }}
     >
       <p>
-        Sets a new temporary password for <strong>{userEmail}</strong> and shows it
+        Sets a new temporary password for <strong>{userLabel}</strong> and shows it
         once. Their current password stops working immediately.
       </p>
       <p>There is no self-service recovery under username login — this is the reset.</p>

--- a/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
+++ b/panel-ui/src/shells/admin/users/UserSuspendAction.tsx
@@ -15,7 +15,8 @@ import { apiClient } from "../../../apiClient";
 
 interface UserSuspendActionProps {
   userId: string;
-  userEmail: string;
+  // Display identifier — username-led (see userLabel, GH #1239).
+  userLabel: string;
   suspended: boolean;
   open: boolean;
   onClose: () => void;
@@ -23,7 +24,7 @@ interface UserSuspendActionProps {
 
 export const UserSuspendAction = ({
   userId,
-  userEmail,
+  userLabel,
   suspended,
   open,
   onClose,
@@ -52,11 +53,11 @@ export const UserSuspendAction = ({
       const data = res.data;
       if (suspended) {
         feedback.message.success(
-          `Unsuspended "${userEmail}" — ${data.domains_enabled ?? 0} domain(s) re-enabled.`,
+          `Unsuspended "${userLabel}" — ${data.domains_enabled ?? 0} domain(s) re-enabled.`,
         );
       } else {
         feedback.message.success(
-          `Suspended "${userEmail}" — ${data.domains_disabled ?? 0} domain(s) disabled.`,
+          `Suspended "${userLabel}" — ${data.domains_disabled ?? 0} domain(s) disabled.`,
         );
       }
       if (data.kratos_warning) {
@@ -92,13 +93,13 @@ export const UserSuspendAction = ({
     >
       {suspended ? (
         <p>
-          Restores access for <strong>{userEmail}</strong>. The Kratos
+          Restores access for <strong>{userLabel}</strong>. The Kratos
           identity is reactivated and every owned domain is re-enabled.
         </p>
       ) : (
         <>
           <p>
-            Takes <strong>{userEmail}</strong> offline:
+            Takes <strong>{userLabel}</strong> offline:
           </p>
           <ul>
             <li>Kratos identity → inactive (blocks panel + webmail login)</li>

--- a/panel-ui/src/shells/admin/users/userLabel.test.ts
+++ b/panel-ui/src/shells/admin/users/userLabel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { userLabel } from "./userLabel";
+
+describe("userLabel", () => {
+  it("leads with the username and appends the display name", () => {
+    expect(
+      userLabel({ username: "dana", email: "dana@lior.co.il", name_first: "Dana Levi" }),
+    ).toBe("dana (Dana Levi)");
+  });
+
+  it("joins legacy split names", () => {
+    expect(
+      userLabel({ username: "dana", email: "dana@lior.co.il", name_first: "Dana", name_last: "Levi" }),
+    ).toBe("dana (Dana Levi)");
+  });
+
+  it("returns the bare username when no name is set", () => {
+    expect(userLabel({ username: "dana", email: "dana@lior.co.il" })).toBe("dana");
+  });
+
+  it("falls back to email for accounts without a username (admins)", () => {
+    expect(userLabel({ username: null, email: "root@acme.dev", name_first: "" })).toBe("root@acme.dev");
+  });
+});

--- a/panel-ui/src/shells/admin/users/userLabel.ts
+++ b/panel-ui/src/shells/admin/users/userLabel.ts
@@ -1,0 +1,16 @@
+// userLabel — canonical admin-facing identifier for a user (GH #1239).
+// Usernames are the login since M54; email is a plain trait that may be
+// shared across accounts, so confirmation modals and toasts must lead
+// with the username. Admins have no POSIX username — fall back to email.
+// GH #1227 collapsed the display name into name_first; name_last is kept
+// only for legacy rows.
+export function userLabel(u: {
+  username?: string | null;
+  email: string;
+  name_first?: string;
+  name_last?: string;
+}): string {
+  const base = u.username || u.email;
+  const name = [u.name_first, u.name_last].filter(Boolean).join(" ").trim();
+  return name ? `${base} (${name})` : base;
+}


### PR DESCRIPTION
## Summary

Admin user actions (Delete, Suspend/Unsuspend, Reset password, Reset 2FA, Edit drawer) identified the target user by **email only**. Under username login (M54) email is an optional, shareable trait — the modals were ambiguous exactly where a mistake is most expensive. GH #1239.

- New `userLabel()` helper: `username (Display Name)`, falling back to email for accounts without a username (admins). Handles the GH #1227 legacy split-name rows.
- All five action modals + their success toasts now lead with the username.
- Edit drawer title becomes `Edit <username (Name)>`.
- Delete modal's OS-account line used the **email local part** for the account/`/home` path — wrong under M54; now uses the real username (email local part only as legacy fallback).

## Test plan

- [x] `npx tsc -b` clean
- [x] `vitest` — 4 new unit tests for `userLabel` (name join, legacy split, bare username, admin email fallback)
- [ ] Box check on jabalitest: open Users → row actions → Delete / Suspend / Reset password / Reset 2FA / Edit — all show `username (Name)`

GH #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
