### PR TITLE
fix(mail): refresh mailbox group badges on member-set replace + group delete (JAB-372)

### DIFF
--- a/panel-ui/src/hooks/useMailGroups.test.tsx
+++ b/panel-ui/src/hooks/useMailGroups.test.tsx
@@ -1,0 +1,117 @@
+// useMailGroups.test.tsx — JAB-372: every mutation that changes the
+// mailbox→group edge set must invalidate the mailbox-group-memberships
+// projection (the mailbox table's group badges), or the badges go stale until
+// an unrelated refetch. Guards the whole mutation→invalidation matrix.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  useAddMailboxToGroup,
+  useCreateMailGroup,
+  useDeleteMailGroup,
+  useRemoveMailboxFromGroup,
+  useSetMailGroupMembers,
+  useUpdateMailGroup,
+} from "./useMailGroups";
+
+vi.mock("../apiClient", () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from "../apiClient";
+
+const mocked = apiClient as unknown as Record<"get" | "post" | "patch" | "put" | "delete", ReturnType<typeof vi.fn>>;
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { qc, wrapper };
+}
+
+const MEMBERSHIPS_KEY = ["list", "mailbox-group-memberships", "dom1"];
+
+function invalidatedMemberships(calls: unknown[][]): boolean {
+  return calls.some(
+    (c) => JSON.stringify((c[0] as { queryKey?: unknown[] })?.queryKey) === JSON.stringify(MEMBERSHIPS_KEY),
+  );
+}
+
+beforeEach(() => {
+  for (const k of ["get", "post", "patch", "put", "delete"] as const) {
+    mocked[k].mockReset().mockResolvedValue({ data: {} });
+  }
+});
+
+describe("useMailGroups membership invalidation matrix (JAB-372)", () => {
+  it("useSetMailGroupMembers (replace set) refreshes mailbox badges", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useSetMailGroupMembers(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: "g1", domainId: "dom1", mailbox_ids: ["m1", "m2"] });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mocked.put).toHaveBeenCalledWith("/mailgroups/g1/members", { mailbox_ids: ["m1", "m2"] });
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(true);
+  });
+
+  it("useDeleteMailGroup removes badges without reload", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useDeleteMailGroup(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: "g1", domainId: "dom1" });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mocked.delete).toHaveBeenCalledWith("/mailgroups/g1");
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(true);
+  });
+
+  it("single add still invalidates memberships", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useAddMailboxToGroup(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ groupId: "g1", mailboxId: "m1", domainId: "dom1" });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(true);
+  });
+
+  it("single remove still invalidates memberships", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useRemoveMailboxFromGroup(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ groupId: "g1", mailboxId: "m1", domainId: "dom1" });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(true);
+  });
+
+  it("create (empty group) does NOT touch the membership projection", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useCreateMailGroup(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ domainId: "dom1", input: { name: "team" } });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(false);
+  });
+
+  it("update (metadata only) does NOT touch the membership projection", async () => {
+    const { qc, wrapper } = makeWrapper();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(() => useUpdateMailGroup(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ id: "g1", domainId: "dom1", input: { display_name: "Team" } });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidatedMemberships(spy.mock.calls as unknown[][])).toBe(false);
+  });
+});

--- a/panel-ui/src/hooks/useMailGroups.ts
+++ b/panel-ui/src/hooks/useMailGroups.ts
@@ -168,6 +168,10 @@ export function useSetMailGroupMembers(): UseMutationResult<
     },
     onSuccess: (_d, { id, domainId }) => {
       invalidateGroups(qc, domainId);
+      // JAB-372: replacing the whole member set changes the mailbox→group edge
+      // set, so the mailbox table's group badges (mailbox-group-memberships
+      // projection) must refresh too — not just the group detail.
+      invalidateMemberships(qc, domainId);
       qc.invalidateQueries({ queryKey: ["one", "mailgroup", id] });
     },
   });
@@ -224,6 +228,11 @@ export function useDeleteMailGroup(): UseMutationResult<
     mutationFn: async ({ id }) => {
       await apiClient.delete(`/mailgroups/${id}`);
     },
-    onSuccess: (_d, { domainId }) => invalidateGroups(qc, domainId),
+    // JAB-372: deleting a group drops every mailbox's membership in it, so the
+    // mailbox table's group badges must refresh, not only the group list.
+    onSuccess: (_d, { domainId }) => {
+      invalidateGroups(qc, domainId);
+      invalidateMemberships(qc, domainId);
+    },
   });
 }


### PR DESCRIPTION
## Problem

The mailbox table's group badges come from the `mailbox-group-memberships` query family. Single add/remove already invalidated it, but two mutations that also change the mailbox→group edge set did not, so the badges stayed stale until an unrelated refetch or a page reload:

- `useSetMailGroupMembers` (PUT `.../members` — replace the whole member set) only invalidated the group list + detail.
- `useDeleteMailGroup` only invalidated the group list.

## Fix

Both now also call `invalidateMemberships(qc, domainId)`. Create (an empty group) and metadata Update don't touch the edge set, so they intentionally leave the projection alone.

## Acceptance criteria

- ✓ Replacing a group's member set immediately refreshes affected mailbox membership badges.
- ✓ Deleting a group removes its badges without a page reload.
- ✓ Single-member add/remove behaviour unchanged (still invalidates).
- ✓ Tests cover the complete mutation→invalidation matrix (setMembers + delete now invalidate; add/remove still do; create/update do not).
- ✓ Uses the existing canonical `mailbox-group-memberships` key — no parallel keys introduced (compatible with a future Mail Inventory Module).

Pure react-query cache-invalidation fix; `tsc -b` + the new hook test green; ff-clean. No backend/agent surface.

Ref: JAB-372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
