### PR TITLE
test(host-safety): seam internal/diagnostic exec so tests stay hermetic (GH #1160)

### DIFF
--- a/panel-agent/internal/diagnostic/diagnostic.go
+++ b/panel-agent/internal/diagnostic/diagnostic.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 )
@@ -136,7 +135,7 @@ func collect(ctx context.Context) []collectedFile {
 }
 
 func runOrErr(ctx context.Context, name string, args ...string) []byte {
-	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	out, err := execCommandContext(ctx, name, args...).CombinedOutput()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR running %s %s: %v\n--- partial output ---\n%s",
 			name, strings.Join(args, " "), err, string(out)))
@@ -145,7 +144,7 @@ func runOrErr(ctx context.Context, name string, args ...string) []byte {
 }
 
 func catFileOrErr(path string) []byte {
-	out, err := exec.Command("cat", path).Output()
+	out, err := execCommand("cat", path).Output()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR reading %s: %v", path, err))
 	}
@@ -155,7 +154,7 @@ func catFileOrErr(path string) []byte {
 // tailFileOrErr reads the final n lines of path. Used for log files
 // that grow unbounded between rotations (letsencrypt.log).
 func tailFileOrErr(ctx context.Context, path string, n int) []byte {
-	out, err := exec.CommandContext(ctx, "tail", "-n", fmt.Sprintf("%d", n), path).Output()
+	out, err := execCommandContext(ctx, "tail", "-n", fmt.Sprintf("%d", n), path).Output()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR tailing %s: %v", path, err))
 	}

--- a/panel-agent/internal/diagnostic/exec_seam.go
+++ b/panel-agent/internal/diagnostic/exec_seam.go
@@ -1,0 +1,18 @@
+package diagnostic
+
+import "os/exec"
+
+// execCommandContext and execCommand are the single exec boundary for the
+// diagnostic collectors. Production dispatches straight to os/exec with zero
+// indirection; the test binary replaces these vars in TestMain (see
+// exec_seam_test.go) so a bare `go test ./...` never shells out to real host
+// tools — systemctl, journalctl, iptables, cscli, cat, tail. GH #994 / #1160.
+//
+// The diagnostic bundle is read-only (it never mutates the host), so this is a
+// hermeticity guarantee — deterministic, host-independent tests — rather than a
+// host-mutation guard. Do NOT call exec.Command / exec.CommandContext directly
+// in non-test files in this package; use these vars so the seam holds.
+var (
+	execCommandContext = exec.CommandContext
+	execCommand        = exec.Command
+)

--- a/panel-agent/internal/diagnostic/exec_seam_test.go
+++ b/panel-agent/internal/diagnostic/exec_seam_test.go
@@ -1,0 +1,47 @@
+package diagnostic
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain makes the diagnostic test suite hermetic: unless the operator opts
+// into real host access (JABALI_ALLOW_HOST_MUTATION=1), every exec routed
+// through the package seam is redirected to a harmless shell stub that drains
+// stdin, emits nothing, and exits 0. The collectors shell out to read-only host
+// tools (systemctl status, journalctl, iptables -L, cscli list, cat, tail);
+// this keeps a bare `go test ./...` from reaching them, so the bundle tests are
+// deterministic and don't depend on what the CI host happens to be running.
+// GH #994 / #1160. The env-var name is shared with the commands seam so one
+// opt-in re-enables real exec across the agent.
+func TestMain(m *testing.M) {
+	if os.Getenv("JABALI_ALLOW_HOST_MUTATION") == "1" {
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "jabali-diag-stub-")
+	if err != nil {
+		panic("diagnostic exec stub: " + err.Error())
+	}
+	stub := filepath.Join(dir, "noexec")
+	// Path baked into argv (not an env marker) so a collector that sets cmd.Env
+	// can't defeat it; `cat >/dev/null` drains any piped stdin.
+	if werr := os.WriteFile(stub, []byte("#!/bin/sh\ncat >/dev/null 2>&1\nexit 0\n"), 0o700); werr != nil {
+		panic("diagnostic exec stub: " + werr.Error())
+	}
+
+	// Set once, before any test runs → race-free.
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, stub, append([]string{name}, args...)...)
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command(stub, append([]string{name}, args...)...)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}


### PR DESCRIPTION
## GH #1160 item 3 — audit the remaining agent packages for raw `os/exec`

Follow-up to #1216 (which made `internal/certbot` + `internal/pdns` test-safe). This closes the diagnostic gap and reports the audit result.

### The gap

`internal/diagnostic` built its support bundle by shelling out **raw** (bypassing the #1159 commands seam):
- `runOrErr` → `systemctl is-active`/`status`, `journalctl`, `iptables -L`, `cscli … list`
- `catFileOrErr` / `tailFileOrErr` → `cat` / `tail`

A bare `go test ./panel-agent/...` therefore reached whatever those tools reported on the host.

### Audit method + result

PATH-stub sweep (stub host tools on `PATH`, bare `go test ./panel-agent/...`, ungated tests only), invocations counted:

| | before | after |
|---|---|---|
| `certbot` | 0 | 0 |
| `systemctl` / `journalctl` / `iptables` / `cscli` (diagnostic) | 54 | **0** |
| residual | — | php ×3, chmod/chown ×2 |

The residual reaches are **deliberate integration tests of shipped artifacts**, not raw agent exec:
- `php -l` on generated SSO templates (`sso_template_*_test.go`) — guarded by `exec.LookPath("php")` + `t.Skip`.
- a shipped bash config-rewrite helper run against a tmpfile (`pdns_local_address_test.go`) — guarded by `LookPath("ip")` + `t.Skip`, scoped to the test's own tempdir.

Both are read-only and correctly skip when the tool is absent — left as-is.

### Fix

Route diagnostic's three exec sites through a package seam (`execCommand` / `execCommandContext`), mirroring the commands seam (#1159) and the certbot/pdns seams (#1216). `TestMain` redirects them to a no-op stub unless `JABALI_ALLOW_HOST_MUTATION=1`. The bundle tests assert file **presence** + redaction (not exec output), so they pass unchanged.

### Net

A bare `go test ./...` can't reach real ACME or mutate the host, and now doesn't shell out to real host tools from diagnostic either. The `#994` "every exec" objective is met for the agent.

## Test plan

- [x] `go build ./panel-agent/...`
- [x] `go test ./panel-agent/...` green (exit 0)
- [x] PATH-stub sweep: 0 certbot, 0 systemctl/journalctl/iptables/cscli
- [x] diagnostic bundle tests (presence + redaction) pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)