### PR TITLE
fix(dr): tear down DR feed on unpair + add `dr unfeed` repair (JAB-363)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2351,6 +2351,18 @@ Show this box's DR role + pairing
 jabali dr status
 ```
 
+#### `jabali dr unfeed`
+
+Primary side: stop shipping system backups to a DR destination (inverse of `dr feed`)
+
+```
+jabali dr unfeed [flags]
+```
+
+**Flags:**
+
+- `--destination` — the DR backup destination id to stop feeding
+
 #### `jabali dr unpair`
 
 Revert this box to a primary (clears standby role)

--- a/panel-agent/internal/diagnostic/diagnostic.go
+++ b/panel-agent/internal/diagnostic/diagnostic.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 )
@@ -136,7 +135,7 @@ func collect(ctx context.Context) []collectedFile {
 }
 
 func runOrErr(ctx context.Context, name string, args ...string) []byte {
-	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	out, err := execCommandContext(ctx, name, args...).CombinedOutput()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR running %s %s: %v\n--- partial output ---\n%s",
 			name, strings.Join(args, " "), err, string(out)))
@@ -145,7 +144,7 @@ func runOrErr(ctx context.Context, name string, args ...string) []byte {
 }
 
 func catFileOrErr(path string) []byte {
-	out, err := exec.Command("cat", path).Output()
+	out, err := execCommand("cat", path).Output()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR reading %s: %v", path, err))
 	}
@@ -155,7 +154,7 @@ func catFileOrErr(path string) []byte {
 // tailFileOrErr reads the final n lines of path. Used for log files
 // that grow unbounded between rotations (letsencrypt.log).
 func tailFileOrErr(ctx context.Context, path string, n int) []byte {
-	out, err := exec.CommandContext(ctx, "tail", "-n", fmt.Sprintf("%d", n), path).Output()
+	out, err := execCommandContext(ctx, "tail", "-n", fmt.Sprintf("%d", n), path).Output()
 	if err != nil {
 		return []byte(fmt.Sprintf("ERROR tailing %s: %v", path, err))
 	}

--- a/panel-agent/internal/diagnostic/exec_seam.go
+++ b/panel-agent/internal/diagnostic/exec_seam.go
@@ -1,0 +1,18 @@
+package diagnostic
+
+import "os/exec"
+
+// execCommandContext and execCommand are the single exec boundary for the
+// diagnostic collectors. Production dispatches straight to os/exec with zero
+// indirection; the test binary replaces these vars in TestMain (see
+// exec_seam_test.go) so a bare `go test ./...` never shells out to real host
+// tools — systemctl, journalctl, iptables, cscli, cat, tail. GH #994 / #1160.
+//
+// The diagnostic bundle is read-only (it never mutates the host), so this is a
+// hermeticity guarantee — deterministic, host-independent tests — rather than a
+// host-mutation guard. Do NOT call exec.Command / exec.CommandContext directly
+// in non-test files in this package; use these vars so the seam holds.
+var (
+	execCommandContext = exec.CommandContext
+	execCommand        = exec.Command
+)

--- a/panel-agent/internal/diagnostic/exec_seam_test.go
+++ b/panel-agent/internal/diagnostic/exec_seam_test.go
@@ -1,0 +1,47 @@
+package diagnostic
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain makes the diagnostic test suite hermetic: unless the operator opts
+// into real host access (JABALI_ALLOW_HOST_MUTATION=1), every exec routed
+// through the package seam is redirected to a harmless shell stub that drains
+// stdin, emits nothing, and exits 0. The collectors shell out to read-only host
+// tools (systemctl status, journalctl, iptables -L, cscli list, cat, tail);
+// this keeps a bare `go test ./...` from reaching them, so the bundle tests are
+// deterministic and don't depend on what the CI host happens to be running.
+// GH #994 / #1160. The env-var name is shared with the commands seam so one
+// opt-in re-enables real exec across the agent.
+func TestMain(m *testing.M) {
+	if os.Getenv("JABALI_ALLOW_HOST_MUTATION") == "1" {
+		os.Exit(m.Run())
+	}
+
+	dir, err := os.MkdirTemp("", "jabali-diag-stub-")
+	if err != nil {
+		panic("diagnostic exec stub: " + err.Error())
+	}
+	stub := filepath.Join(dir, "noexec")
+	// Path baked into argv (not an env marker) so a collector that sets cmd.Env
+	// can't defeat it; `cat >/dev/null` drains any piped stdin.
+	if werr := os.WriteFile(stub, []byte("#!/bin/sh\ncat >/dev/null 2>&1\nexit 0\n"), 0o700); werr != nil {
+		panic("diagnostic exec stub: " + werr.Error())
+	}
+
+	// Set once, before any test runs → race-free.
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, stub, append([]string{name}, args...)...)
+	}
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command(stub, append([]string{name}, args...)...)
+	}
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}

--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -34,7 +34,7 @@ func newDRCmd() *cobra.Command {
 			"primary's state from a read-only backup destination and serves no live " +
 			"traffic until `dr promote`. No automatic failover, no split-brain.",
 	}
-	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd(), newDRFeedCmd(), newDRPromoteCmd())
+	cmd.AddCommand(newDRStatusCmd(), newDRPairCmd(), newDRUnpairCmd(), newDRFeedCmd(), newDRUnfeedCmd(), newDRPromoteCmd())
 	return cmd
 }
 
@@ -160,6 +160,10 @@ func newDRUnpairCmd() *cobra.Command {
 			if err != nil || s == nil {
 				return fmt.Errorf("read server settings: %w", err)
 			}
+			// Capture the DR destination BEFORE the Upsert clears the pointer —
+			// the feed-teardown below needs it, and after this it is only
+			// recoverable from `backup destination list`.
+			oldDestID := strOrEmpty(s.DRDestinationID)
 			s.ServerRole = models.ServerRolePrimary
 			s.DRDestinationID = nil
 			s.DRPeerLabel = ""
@@ -168,6 +172,23 @@ func newDRUnpairCmd() *cobra.Command {
 				return fmt.Errorf("clear DR pairing: %w", err)
 			}
 			fmt.Println("This box is now a PRIMARY. DR pairing cleared.")
+
+			// JAB-363: best-effort local feed teardown. A true standby has no
+			// feed schedule (the feed lives on the remote PRIMARY) so this is a
+			// silent no-op there; a single box that played both roles (the .86
+			// repro) gets its orphaned feed disabled. A teardown failure must
+			// never fail the unpair — the role change already succeeded.
+			if oldDestID != "" {
+				res, terr := tearDownDRFeed(ctx, scheduleRepoFromDB(), backupDestinationRepoFromDB(), oldDestID)
+				switch {
+				case terr != nil:
+					fmt.Printf("WARNING: could not tear down the local DR feed for destination %s: %v\n", oldDestID, terr)
+					fmt.Printf("If this box feeds it, run: jabali dr unfeed --destination %s\n", oldDestID)
+				case res.scheduleDisabled || res.destDisabled:
+					fmt.Printf("Disabled the local DR feed (schedule=%t, destination=%t).\n",
+						res.scheduleDisabled, res.destDisabled)
+				}
+			}
 			return nil
 		},
 	}
@@ -249,6 +270,52 @@ func newDRFeedCmd() *cobra.Command {
 	return cmd
 }
 
+// newDRUnfeedCmd is the primary-side inverse of `dr feed` (JAB-363). It stops a
+// DR feed and is also the repair path for a feed orphaned by a standby unpair:
+// pass the DR destination id (from `jabali backup destination list`) — that
+// explicit id is the operator confirmation, so nothing is auto-detected.
+func newDRUnfeedCmd() *cobra.Command {
+	var destID string
+	cmd := &cobra.Command{
+		Use:   "unfeed",
+		Short: "Primary side: stop shipping system backups to a DR destination (inverse of `dr feed`)",
+		Long: "Run on the PRIMARY. Disables the DR feed system_backup schedule that targets the " +
+			"destination and (unless another enabled schedule still uses it) the destination itself. " +
+			"Non-destructive — nothing is deleted, and `dr feed` re-enables the schedule on re-pair. " +
+			"Also the repair for a feed left orphaned by `dr unpair`: pass the destination id.",
+		PreRunE: requireDB,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if destID == "" {
+				return fmt.Errorf("--destination is required (the DR backup destination to stop feeding)")
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+			defer cancel()
+			res, err := tearDownDRFeed(ctx, scheduleRepoFromDB(), backupDestinationRepoFromDB(), destID)
+			if err != nil {
+				return err
+			}
+			if res.scheduleID == "" {
+				fmt.Println("No DR feed schedule targets that destination — nothing to disable.")
+			} else if res.scheduleDisabled {
+				fmt.Printf("Disabled DR feed schedule %s.\n", res.scheduleID)
+			} else {
+				fmt.Printf("DR feed schedule %s was already disabled.\n", res.scheduleID)
+			}
+			switch {
+			case res.destShared:
+				fmt.Println("Left the destination ENABLED — another enabled schedule still targets it.")
+			case res.destDisabled:
+				fmt.Println("Disabled the DR destination.")
+			default:
+				fmt.Println("Destination was already disabled (or not found).")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&destID, "destination", "", "the DR backup destination id to stop feeding")
+	return cmd
+}
+
 // findSystemScheduleForDest returns the first enabled-or-disabled system_backup
 // schedule whose destination set includes destID, or nil if none exists.
 func findSystemScheduleForDest(ctx context.Context, repo repository.BackupScheduleRepository, destID string) (*models.BackupSchedule, error) {
@@ -271,6 +338,94 @@ func findSystemScheduleForDest(ctx context.Context, repo repository.BackupSchedu
 		}
 	}
 	return nil, nil
+}
+
+// drFeedTeardown reports what tearDownDRFeed disabled, for operator messaging.
+type drFeedTeardown struct {
+	scheduleID       string
+	scheduleDisabled bool
+	destDisabled     bool
+	destShared       bool // another enabled schedule still targets the destination
+}
+
+// tearDownDRFeed disables the DR feed system_backup schedule targeting destID
+// and — unless another enabled schedule still targets it — the destination too.
+// Non-destructive: it disables, never deletes, so `dr feed` re-enables the same
+// schedule on re-pair (the round-trip that makes disable the right primitive).
+// JAB-363: the primary-side inverse of `dr feed`; the repair path for an
+// orphaned feed left behind after a standby unpair.
+func tearDownDRFeed(
+	ctx context.Context,
+	schedRepo repository.BackupScheduleRepository,
+	destRepo repository.BackupDestinationRepository,
+	destID string,
+) (drFeedTeardown, error) {
+	var res drFeedTeardown
+	sched, err := findSystemScheduleForDest(ctx, schedRepo, destID)
+	if err != nil {
+		return res, err
+	}
+	if sched != nil {
+		res.scheduleID = sched.ID
+		if sched.Enabled {
+			sched.Enabled = false
+			if err := schedRepo.Update(ctx, sched); err != nil {
+				return res, fmt.Errorf("disable DR feed schedule %s: %w", sched.ID, err)
+			}
+			res.scheduleDisabled = true
+		}
+	}
+	// Shared-destination guard: `dr feed` accepts any existing destination, so
+	// "dedicated" is an assumption, not an invariant. Only disable the
+	// destination when no OTHER enabled schedule still targets it.
+	shared, err := destinationHasOtherEnabledSchedule(ctx, schedRepo, destID, sched)
+	if err != nil {
+		return res, err
+	}
+	res.destShared = shared
+	if !shared {
+		d, gerr := destRepo.Get(ctx, destID)
+		if gerr == nil && d != nil && d.Enabled {
+			d.Enabled = false
+			if err := destRepo.Update(ctx, d); err != nil {
+				return res, fmt.Errorf("disable DR destination %s: %w", destID, err)
+			}
+			res.destDisabled = true
+		}
+	}
+	return res, nil
+}
+
+// destinationHasOtherEnabledSchedule reports whether any ENABLED schedule other
+// than `except` still targets destID.
+func destinationHasOtherEnabledSchedule(
+	ctx context.Context,
+	schedRepo repository.BackupScheduleRepository,
+	destID string,
+	except *models.BackupSchedule,
+) (bool, error) {
+	all, err := schedRepo.List(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list backup schedules: %w", err)
+	}
+	for i := range all {
+		if !all[i].Enabled {
+			continue
+		}
+		if except != nil && all[i].ID == except.ID {
+			continue
+		}
+		dests, derr := schedRepo.GetDestinations(ctx, all[i].ID)
+		if derr != nil {
+			return false, fmt.Errorf("read schedule destinations: %w", derr)
+		}
+		for _, d := range dests {
+			if d.ID == destID {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func orDefault(v, def string) string {

--- a/panel-api/cmd/server/dr_feed_teardown_test.go
+++ b/panel-api/cmd/server/dr_feed_teardown_test.go
@@ -1,0 +1,130 @@
+package main
+
+// JAB-363: tearDownDRFeed disables the DR feed schedule + destination
+// non-destructively, with a shared-destination guard.
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type fakeSchedRepo struct {
+	repository.BackupScheduleRepository
+	schedules []models.BackupSchedule
+	dests     map[string][]models.BackupDestination // scheduleID -> its destinations
+	updated   map[string]bool                       // scheduleID -> enabled value written
+}
+
+func (f *fakeSchedRepo) List(context.Context) ([]models.BackupSchedule, error) {
+	return f.schedules, nil
+}
+func (f *fakeSchedRepo) GetDestinations(_ context.Context, id string) ([]models.BackupDestination, error) {
+	return f.dests[id], nil
+}
+func (f *fakeSchedRepo) Update(_ context.Context, s *models.BackupSchedule) error {
+	if f.updated == nil {
+		f.updated = map[string]bool{}
+	}
+	f.updated[s.ID] = s.Enabled
+	return nil
+}
+
+type fakeDestRepo struct {
+	repository.BackupDestinationRepository
+	dest         *models.BackupDestination
+	wroteEnabled *bool
+}
+
+func (f *fakeDestRepo) Get(context.Context, string) (*models.BackupDestination, error) {
+	return f.dest, nil
+}
+func (f *fakeDestRepo) Update(_ context.Context, d *models.BackupDestination) error {
+	v := d.Enabled
+	f.wroteEnabled = &v
+	return nil
+}
+
+func sysSched(id string, enabled bool) models.BackupSchedule {
+	return models.BackupSchedule{ID: id, Kind: models.BackupScheduleKindSystem, Enabled: enabled}
+}
+func acctSched(id string, enabled bool) models.BackupSchedule {
+	return models.BackupSchedule{ID: id, Kind: models.BackupScheduleKindAccount, Enabled: enabled}
+}
+
+func TestTearDownDRFeed_DisablesScheduleAndDestination(t *testing.T) {
+	sr := &fakeSchedRepo{
+		schedules: []models.BackupSchedule{sysSched("s1", true)},
+		dests:     map[string][]models.BackupDestination{"s1": {{ID: "d1"}}},
+	}
+	dr := &fakeDestRepo{dest: &models.BackupDestination{ID: "d1", Enabled: true}}
+
+	res, err := tearDownDRFeed(context.Background(), sr, dr, "d1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.scheduleID != "s1" || !res.scheduleDisabled {
+		t.Fatalf("feed schedule not disabled: %+v", res)
+	}
+	if sr.updated["s1"] != false {
+		t.Fatalf("schedule s1 should be written disabled")
+	}
+	if res.destShared || !res.destDisabled {
+		t.Fatalf("dedicated destination should be disabled: %+v", res)
+	}
+	if dr.wroteEnabled == nil || *dr.wroteEnabled != false {
+		t.Fatalf("destination should be written disabled")
+	}
+}
+
+func TestTearDownDRFeed_SharedDestinationLeftEnabled(t *testing.T) {
+	// Another ENABLED schedule (an account backup) still targets d1 → the feed
+	// schedule is disabled but the destination is left enabled.
+	sr := &fakeSchedRepo{
+		schedules: []models.BackupSchedule{sysSched("s1", true), acctSched("s2", true)},
+		dests: map[string][]models.BackupDestination{
+			"s1": {{ID: "d1"}},
+			"s2": {{ID: "d1"}},
+		},
+	}
+	dr := &fakeDestRepo{dest: &models.BackupDestination{ID: "d1", Enabled: true}}
+
+	res, err := tearDownDRFeed(context.Background(), sr, dr, "d1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.scheduleDisabled {
+		t.Fatalf("feed schedule should still be disabled: %+v", res)
+	}
+	if !res.destShared || res.destDisabled {
+		t.Fatalf("shared destination must stay enabled: %+v", res)
+	}
+	if dr.wroteEnabled != nil {
+		t.Fatalf("destination must not be written when shared")
+	}
+}
+
+func TestTearDownDRFeed_AlreadyDisabledSchedule(t *testing.T) {
+	sr := &fakeSchedRepo{
+		schedules: []models.BackupSchedule{sysSched("s1", false)},
+		dests:     map[string][]models.BackupDestination{"s1": {{ID: "d1"}}},
+	}
+	dr := &fakeDestRepo{dest: &models.BackupDestination{ID: "d1", Enabled: true}}
+
+	res, err := tearDownDRFeed(context.Background(), sr, dr, "d1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.scheduleID != "s1" || res.scheduleDisabled {
+		t.Fatalf("already-disabled schedule should report not-newly-disabled: %+v", res)
+	}
+	if _, wrote := sr.updated["s1"]; wrote {
+		t.Fatalf("already-disabled schedule must not be re-written")
+	}
+	// The disabled feed does not count as an enabled targeter, so the dest is disabled.
+	if res.destShared || !res.destDisabled {
+		t.Fatalf("destination should be disabled: %+v", res)
+	}
+}


### PR DESCRIPTION
## Problem

The DR feed (a `system_backup` schedule the PRIMARY runs via `dr feed` to ship control-plane backups to a DR destination) had no teardown. After the DR relationship ends it keeps firing at an unpaired destination — the `.86` orphan (a `*/30` `system_backup` targeting a dead `dr-channel` SFTP destination) is what JAB-361 stopped from piling up 133 jobs.

## Reframe (found in code)

The ticket says "unpair leaves it behind", but the feed lives on the **primary** while `dr unpair` runs on the **standby** — standby-side unpair cannot reach a remote primary's schedule. Anchoring the fix on unpair alone would only fix the single-box drill artifact, not the bug.

## Fix

- **`dr unfeed --destination <id>`** — the primary-side inverse of `dr feed`, and the repair path for an already-orphaned feed. The explicit destination id is the operator confirmation, so there's **no auto-detection heuristic, no marker column, no migration**. Disables the feed schedule and — unless another enabled schedule still targets it — the destination.
- **`dr unpair`** — captures the DR destination id **before** the settings upsert clears it, then runs the same teardown best-effort. A true standby has no feed schedule → silent no-op; a dual-role box (the `.86` repro) gets it disabled. A teardown failure only warns, never fails the unpair (the role change already succeeded).

**Disable, never delete** — reversible, and `dr feed` re-enables the same schedule on re-pair (proven round-trip). A **shared-destination guard** leaves the destination enabled when another schedule still uses it, because `dr feed` accepts any existing destination — "dedicated" is not an invariant.

## Acceptance criteria

- ✓ After an unpair on a box that fed the destination, the DR feed schedule + destination are disabled (no scheduled backup keeps firing at the unpaired destination).
- ✓ Repair path for an already-orphaned feed: `dr unfeed --destination <id>` (operator passes the id from `jabali backup destination list` — the confirmation; nothing is deleted).

## Verification

- Unit: `tearDownDRFeed` disables both / leaves a shared destination enabled / no-ops an already-disabled feed. CLI reference golden regenerated.
- **Live-validated against the `.86` repro (read-only, no mutation):** the orphaned `dr-channel` is in fact **shared with an enabled `account_backup` schedule** (a tenant's daily backup), so the shared-guard correctly leaves it enabled — disabling/deleting it (the naive fix) would have broken a tenant backup. The disabled feed is correctly excluded from `ListDue`, and `enqueueSystemBackup` only enqueues to `Enabled` destinations (both code-verified).

`go build ./...` + the `cmd/server` package green; ff-clean on `main`.

Ref: JAB-363 (JAB-361 weakness #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
