### PR TITLE
fix(docker-apps): CLI delete detaches user-owned domains instead of deleting them (JAB-364 data-loss)

### DIFF
--- a/panel-api/cmd/server/docker_app_cmd.go
+++ b/panel-api/cmd/server/docker_app_cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/spf13/cobra"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/dockerapp"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -444,14 +445,8 @@ func newDockerAppDeleteCmd() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			// Cleanup managed domain row + ports + the docker_apps row.
-			domRepo := repository.NewDomainRepository(sharedDB)
-			domList, _, _ := domRepo.List(ctx, repository.ListOptions{})
-			for _, d := range domList {
-				if d.DockerAppID != nil && *d.DockerAppID == app.ID {
-					_ = domRepo.Delete(ctx, d.ID)
-				}
-			}
+			// Cleanup domains + ports + the docker_apps row.
+			cleanupDockerAppDomains(ctx, repository.NewDomainRepository(sharedDB), sharedAgent, app.ID)
 			ports, _ := repo.ListPortsForApp(ctx, app.ID)
 			for _, p := range ports {
 				_ = repo.DeletePort(ctx, p.ID)
@@ -466,6 +461,36 @@ func newDockerAppDeleteCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&keepVolumes, "keep-volumes", false, "keep /var/lib/jabali/docker-apps/<slug> data on disk")
 	return cmd
+}
+
+// cleanupDockerAppDomains removes an app's auto-created MANAGED domains (+ their
+// proxy vhosts) and DETACHES — never deletes — a tenant's own domain attached to
+// a reverse-proxy app. JAB-364: the CLI delete previously deleted EVERY domain
+// row with docker_app_id = appID, destroying user-owned domains the HTTP handler
+// (docker_apps_user.go) preserves. Shared so the CLI matches that behaviour.
+func cleanupDockerAppDomains(ctx context.Context, domRepo repository.DomainRepository, ag agent.AgentInterface, appID string) {
+	domList, _, _ := domRepo.List(ctx, repository.ListOptions{})
+	for _, d := range domList {
+		if d.DockerAppID == nil || *d.DockerAppID != appID {
+			continue
+		}
+		if d.ManagedBy == models.DomainManagedByDockerApp {
+			// Hostname we auto-created for this app at install — remove the row
+			// and tear down its proxy vhost.
+			domName := d.Name
+			_ = domRepo.Delete(ctx, d.ID)
+			if ag != nil && domName != "" {
+				rmCtx, rmCancel := context.WithTimeout(ctx, 30*time.Second)
+				_, _ = ag.Call(rmCtx, "docker_app.vhost_remove",
+					map[string]string{"domain_name": domName})
+				rmCancel()
+			}
+		} else {
+			// The tenant's own pre-existing domain — keep the row, just detach
+			// the app link + clear the injected proxy_pass rule.
+			_ = domRepo.DetachDockerApp(ctx, d.ID, true)
+		}
+	}
 }
 
 func newDockerAppLogsCmd() *cobra.Command {

--- a/panel-api/cmd/server/docker_app_domain_cleanup_test.go
+++ b/panel-api/cmd/server/docker_app_domain_cleanup_test.go
@@ -1,0 +1,89 @@
+package main
+
+// JAB-364: the CLI docker-app delete must DELETE the app's managed domains but
+// DETACH — never delete — a tenant's own domain attached to a reverse-proxy app.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type cleanupFakeDomains struct {
+	repository.DomainRepository
+	list     []models.Domain
+	deleted  map[string]bool
+	detached map[string]bool
+}
+
+func (f *cleanupFakeDomains) List(context.Context, repository.ListOptions) ([]models.Domain, int64, error) {
+	return f.list, int64(len(f.list)), nil
+}
+func (f *cleanupFakeDomains) Delete(_ context.Context, id string) error {
+	if f.deleted == nil {
+		f.deleted = map[string]bool{}
+	}
+	f.deleted[id] = true
+	return nil
+}
+func (f *cleanupFakeDomains) DetachDockerApp(_ context.Context, id string, _ bool) error {
+	if f.detached == nil {
+		f.detached = map[string]bool{}
+	}
+	f.detached[id] = true
+	return nil
+}
+
+func dptr(s string) *string { return &s }
+
+type cleanupFakeAgent struct {
+	agent.AgentInterface
+	vhostRemoved []string
+}
+
+func (f *cleanupFakeAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	if cmd == "docker_app.vhost_remove" {
+		if m, ok := params.(map[string]string); ok {
+			f.vhostRemoved = append(f.vhostRemoved, m["domain_name"])
+		}
+	}
+	return nil, nil
+}
+
+func TestCleanupDockerAppDomains_DeletesManagedDetachesUserOwned(t *testing.T) {
+	appID := "app1"
+	dom := &cleanupFakeDomains{list: []models.Domain{
+		// User-owned, attached to the reverse-proxy app → DETACH, keep the row.
+		{ID: "d-user", DockerAppID: dptr(appID), ManagedBy: "", Name: "mine.example.com"},
+		// Auto-created managed domain → DELETE + vhost_remove.
+		{ID: "d-mgd", DockerAppID: dptr(appID), ManagedBy: models.DomainManagedByDockerApp, Name: "auto.example.com"},
+		// Unrelated domain (different app) → untouched.
+		{ID: "d-other", DockerAppID: dptr("app2"), ManagedBy: models.DomainManagedByDockerApp, Name: "other.example.com"},
+	}}
+	ag := &cleanupFakeAgent{}
+
+	cleanupDockerAppDomains(context.Background(), dom, ag, appID)
+
+	if dom.deleted["d-user"] {
+		t.Fatal("user-owned domain d-user was DELETED — data loss; it must only be detached")
+	}
+	if !dom.detached["d-user"] {
+		t.Fatal("user-owned domain d-user was not detached")
+	}
+	if !dom.deleted["d-mgd"] {
+		t.Fatal("managed domain d-mgd was not deleted")
+	}
+	if dom.detached["d-mgd"] {
+		t.Fatal("managed domain d-mgd should be deleted, not detached")
+	}
+	if dom.deleted["d-other"] || dom.detached["d-other"] {
+		t.Fatal("unrelated domain d-other must be untouched")
+	}
+	if len(ag.vhostRemoved) != 1 || ag.vhostRemoved[0] != "auto.example.com" {
+		t.Fatalf("expected vhost_remove for the managed domain only; got %v", ag.vhostRemoved)
+	}
+}


### PR DESCRIPTION
## Data-loss fix

`jabali docker-app delete` removed **every** domain row with `docker_app_id = app.ID` — including a tenant's **own** domain attached to a reverse-proxy app (#1175). That destroys user data.

The HTTP handler (`docker_apps_user.go`) already does the right thing:
- an auto-created **managed** domain (`managed_by='docker_app'`) → deleted + its proxy vhost torn down;
- a **user-owned** attached domain → **detached** (row kept, app link + injected `proxy_pass` cleared).

The CLI deleted both. This extracts the handler's logic into a shared `cleanupDockerAppDomains` (domain repo + agent injected) and points the CLI at it, so the CLI matches the HTTP behaviour: delete managed (+ `docker_app.vhost_remove`), detach user-owned, leave unrelated domains untouched.

## Acceptance criteria (this slice)

- ✓ Managed domains and user-owned attached domains follow distinct deletion rules — **no user-owned domain row is deleted**.
- ✓ Vhost removal occurs for the managed domain.

## Scope

This closes the JAB-364 **"managed vs user-owned domain deletion (potential data loss)"** criterion. The remaining JAB-364 items — tenant cap/isolation revalidation on start/restart, retryable vhost panel state, and the full Docker App Lifecycle Module extraction — stay open; the data-loss fix ships independently rather than waiting on the module refactor. (Criterion 1, EffectiveSlug targeting, already shipped in JAB-315.)

## Tests

A managed domain is deleted (+ one `vhost_remove`); a user-owned attached domain is **detached and never deleted**; an unrelated domain is untouched. `go build ./...` + the `cmd/server` package green; ff-clean.

Ref: JAB-364 (split from JAB-315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
