### PR TITLE
feat(ui): redesign admin SSL Manager as the Certificate console

### DIFF
--- a/panel-api/internal/api/ssl.go
+++ b/panel-api/internal/api/ssl.go
@@ -507,6 +507,11 @@ type sslListRow struct {
 	repository.SSLCertificateWithDomain
 	Service string   `json:"service"`
 	SANs    []string `json:"sans"`
+	// SSLMode surfaces the domain's ssl_mode (le/self/custom/none/shared)
+	// so the SSL Manager can render a Mode column. Shadows the embedded
+	// struct's internal `json:"-"` field. Empty for panel-cert:*/mail-cert:*
+	// synthetic rows, which have no domain ssl_mode.
+	SSLMode string `json:"ssl_mode,omitempty"`
 }
 
 // enrichCertRows attaches Service + SANs to every cert row. SANs are
@@ -530,6 +535,7 @@ func (h *sslHandler) enrichCertRows(ctx context.Context, certs []repository.SSLC
 		default:
 			row.Service = "HTTPS"
 			row.SANs = h.webCertSANs(ctx, c)
+			row.SSLMode = c.SSLMode
 		}
 		out = append(out, row)
 	}

--- a/panel-api/internal/api/ssl_test.go
+++ b/panel-api/internal/api/ssl_test.go
@@ -318,6 +318,7 @@ func TestListAllSSL_Success(t *testing.T) {
 			LastRenewedAt: nil,
 			LastError:     nil,
 			Staging:       false,
+			SSLMode:       models.SSLModeLE,
 		},
 		{
 			ID:            "cert-2",
@@ -375,6 +376,9 @@ func TestListAllSSL_Success(t *testing.T) {
 	require.Equal(t, "example.com", cert1["domain_name"])
 	require.Equal(t, "alice", cert1["user_username"])
 	require.Equal(t, models.SSLStatusIssued, cert1["status"])
+	// Mode column source (Certificate console): domain ssl_mode is exposed
+	// on the wire for real domain rows.
+	require.Equal(t, models.SSLModeLE, cert1["ssl_mode"])
 
 	// Verify second certificate
 	cert2 := items[1].(map[string]interface{})

--- a/panel-api/internal/repository/ssl_certificate_repository.go
+++ b/panel-api/internal/repository/ssl_certificate_repository.go
@@ -247,7 +247,8 @@ func (r *sslCertificateRepo) ListByUserID(ctx context.Context, userID string) ([
 		Select(`sc.id, sc.domain_id, d.name as domain_name,
 		        d.user_id, u.username as user_username,
 		        sc.status, sc.issued_at, sc.expires_at,
-		        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at`).
+		        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,
+		        d.ssl_mode`).
 		Table("ssl_certificates sc").
 		Joins("JOIN domains d ON sc.domain_id = d.id").
 		Joins("JOIN users u ON d.user_id = u.id").

--- a/panel-api/internal/repository/ssl_certificate_repository_test.go
+++ b/panel-api/internal/repository/ssl_certificate_repository_test.go
@@ -299,7 +299,7 @@ func TestSSLCertificateRepository_ListByUserID(t *testing.T) {
 
 	// Expect a SELECT with WHERE on user_id
 	mock.ExpectQuery(
-		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE d.user_id = ? AND sc.status <> ? ORDER BY sc.created_at DESC")).
+		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,\n\t\t        d.ssl_mode FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE d.user_id = ? AND sc.status <> ? ORDER BY sc.created_at DESC")).
 		WithArgs(userID, "revoked").
 		WillReturnRows(
 			sqlmock.NewRows([]string{
@@ -345,7 +345,7 @@ func TestSSLCertificateRepository_ListByUserID_Empty(t *testing.T) {
 
 	// Expect an empty result set
 	mock.ExpectQuery(
-		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE d.user_id = ? AND sc.status <> ? ORDER BY sc.created_at DESC")).
+		regexp.QuoteMeta("SELECT sc.id, sc.domain_id, d.name as domain_name,\n\t\t        d.user_id, u.username as user_username,\n\t\t        sc.status, sc.issued_at, sc.expires_at,\n\t\t        sc.renewal_count, sc.last_renewed_at, sc.last_error, sc.staging, sc.last_attempt_at,\n\t\t        d.ssl_mode FROM ssl_certificates sc JOIN domains d ON sc.domain_id = d.id JOIN users u ON d.user_id = u.id WHERE d.user_id = ? AND sc.status <> ? ORDER BY sc.created_at DESC")).
 		WithArgs(userID, "revoked").
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "domain_id", "domain_name", "user_id", "user_username",

--- a/panel-ui/src/components/ssl/PanelSSLBand.tsx
+++ b/panel-ui/src/components/ssl/PanelSSLBand.tsx
@@ -1,0 +1,126 @@
+// PanelSSLBand — the SSL Manager's compact SYSTEM band (Certificate
+// console). One line for the two panel_certificate rows (hostname +
+// mail): status, expiry and a per-kind Issue/retry, plus the Use-LE
+// switch. The full card — staging toggle, routable diagnostics, error
+// details — stays on Server Settings → Panel SSL; the band links there.
+import { Link } from "react-router";
+import { Alert, Button, Card, Popconfirm, Space, Switch, Tooltip, Typography } from "antd";
+import { ReloadOutlined } from "@icons";
+import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
+import {
+  type PanelCertKind,
+  type PanelCertificate,
+  usePanelCertificate,
+  usePanelCertificateIssue,
+  usePanelCertificateToggle,
+} from "../../hooks/usePanelCertificate";
+import { panelCertExpiryHint, panelCertStatusTag } from "./panelCertStatus";
+
+function BandCert({
+  cert,
+  onIssue,
+  issuing,
+}: {
+  cert: PanelCertificate;
+  onIssue: () => void;
+  issuing: boolean;
+}) {
+  const expiry = panelCertExpiryHint(cert);
+  return (
+    <Space size={8} wrap>
+      <code>{cert.hostname || "<unset>"}</code>
+      {panelCertStatusTag(cert)}
+      {expiry && (
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {expiry}
+        </Typography.Text>
+      )}
+      {!cert.routable && (
+        <Tooltip title={cert.routable_reason || "Hostname does not resolve publicly to this server."}>
+          <Typography.Text type="warning" style={{ fontSize: 12 }}>
+            not routable
+          </Typography.Text>
+        </Tooltip>
+      )}
+      <Popconfirm title={`Issue the ${cert.kind} cert now?`} onConfirm={onIssue}>
+        <Button size="small" icon={<ReloadOutlined />} loading={issuing}>
+          Issue / retry
+        </Button>
+      </Popconfirm>
+    </Space>
+  );
+}
+
+export function PanelSSLBand() {
+  const q = usePanelCertificate();
+  const toggle = usePanelCertificateToggle();
+  const issue = usePanelCertificateIssue();
+
+  if (q.isPending) {
+    return <Card size="small" loading />;
+  }
+  if (q.isError || !q.data || q.data.length === 0) {
+    return (
+      <Card size="small">
+        <Alert
+          type="warning"
+          showIcon
+          message="Panel certificate state unavailable"
+          description={
+            <span>
+              Manage the panel&apos;s own certs in{" "}
+              <Link to="/jabali-admin/settings">Server Settings &rarr; Panel SSL</Link>.
+            </span>
+          }
+        />
+      </Card>
+    );
+  }
+
+  const host = q.data.find((c) => c.kind === "hostname") ?? q.data[0];
+  const mail = q.data.find((c) => c.kind === "mail");
+
+  const doIssue = (kind: PanelCertKind) =>
+    issue.mutate(kind, {
+      onSuccess: () => feedback.message.success(`${kind} cert: issued`),
+      onError: (e) =>
+        feedback.message.error(`${kind} cert: issue failed: ${String((e as Error).message)}`),
+    });
+
+  return (
+    <Card size="small" styles={{ body: { padding: "12px 16px" } }}>
+      <Space size={16} wrap style={{ width: "100%" }}>
+        <Typography.Text strong type="secondary" style={{ fontSize: 13 }}>
+          SYSTEM
+        </Typography.Text>
+        <BandCert cert={host} issuing={issue.isPending} onIssue={() => doIssue("hostname")} />
+        {mail && <BandCert cert={mail} issuing={issue.isPending} onIssue={() => doIssue("mail")} />}
+        <Space size={8} style={{ marginLeft: "auto" }}>
+          <Switch
+            size="small"
+            checked={host.use_le}
+            disabled={!host.routable && !host.use_le}
+            loading={toggle.isPending}
+            onChange={(v) =>
+              toggle.mutate(
+                { use_le: v },
+                {
+                  onSuccess: () =>
+                    feedback.message.success(v
+                        ? "Let's Encrypt enabled — issuance runs on the next reconciler tick"
+                        : "Let's Encrypt disabled — existing certs stay until expiry"),
+                  onError: (e) =>
+                    feedback.message.error(`Failed to update toggle: ${String((e as Error).message)}`),
+                },
+              )
+            }
+          />
+          <Typography.Text style={{ fontSize: 13 }}>Let&apos;s Encrypt</Typography.Text>
+          <Link to="/jabali-admin/settings" style={{ fontSize: 13 }}>
+            Details
+          </Link>
+        </Space>
+      </Space>
+    </Card>
+  );
+}

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -503,7 +503,7 @@ export const SSLManagerTable = ({
           if (key === "retry") retryMutation.mutate(record.domain_id);
           else if (key === "error") setErrorRow(record);
           else if (key === "revoke") {
-            Modal.confirm({
+            feedback.modal.confirm({
               title: t("sslmanagertable.revoke_certificate"),
               content: t("sslmanagertable.are_you_sure_you_want_to_revoke_this_certifi"),
               okText: t("sslmanagertable.yes"),

--- a/panel-ui/src/components/ssl/SSLManagerTable.tsx
+++ b/panel-ui/src/components/ssl/SSLManagerTable.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Input, Table, Tag, Button, Popconfirm, Empty, Space, Tooltip, Typography, Modal, Descriptions } from "antd";
+import { Dropdown, Input, Table, Tag, Button, Empty, Space, Tooltip, Typography, Modal, Descriptions } from "antd";
 import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import {
   ReloadOutlined,
@@ -10,9 +10,12 @@ import {
   WarningOutlined,
   RedoOutlined,
   ExclamationCircleOutlined,
+  MoreOutlined,
 } from "@icons";
 import { apiClient } from "../../apiClient";
 import { columnSearchProps } from "../columnSearch";
+import { RowActionButton } from "../RowActionButton";
+import { expiryFraction, matchesFilter, modeTag, type SSLFilter } from "./sslHealth";
 
 interface SSLCertificate {
   id: string;
@@ -32,11 +35,18 @@ interface SSLCertificate {
   retry_count: number;
   service: string;
   sans?: string[];
+  // Domain ssl_mode (le/self/custom/none/shared) — absent on the synthetic
+  // panel-cert:*/mail-cert:* rows (Certificate console Mode column).
+  ssl_mode?: string;
 }
 
 interface SSLManagerTableProps {
   endpoint: string;
   showOwner: boolean;
+  /** Health-bucket filter driven by the admin summary tiles. Default "all". */
+  statusFilter?: SSLFilter;
+  /** Drop panel-cert:* synthetic rows — the admin SYSTEM band shows them instead. */
+  hideSystemRows?: boolean;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -114,6 +124,8 @@ const formatExpiry = (expiresAt: string | null): JSX.Element => {
 export const SSLManagerTable = ({
   endpoint,
   showOwner,
+  statusFilter = "all",
+  hideSystemRows = false,
 }: SSLManagerTableProps) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -139,14 +151,18 @@ export const SSLManagerTable = ({
   });
 
   const filteredData = useMemo(() => {
-    if (!data || !search) return data;
+    if (!data) return data;
     const needle = search.toLowerCase();
-    return data.filter(
-      (row) =>
+    return data.filter((row) => {
+      if (hideSystemRows && row.id.startsWith("panel-cert:")) return false;
+      if (!matchesFilter(row, statusFilter)) return false;
+      if (!needle) return true;
+      return (
         row.domain_name.toLowerCase().includes(needle) ||
-        (row.user_username ?? "").toLowerCase().includes(needle),
-    );
-  }, [data, search]);
+        (row.user_username ?? "").toLowerCase().includes(needle)
+      );
+    });
+  }, [data, search, statusFilter, hideSystemRows]);
 
   // Renew certificate mutation
   const renewMutation = useMutation({
@@ -285,6 +301,17 @@ export const SSLManagerTable = ({
         ]
       : []),
     {
+      title: "Mode",
+      dataIndex: "ssl_mode",
+      key: "ssl_mode",
+      sorter: (a: SSLCertificate, b: SSLCertificate) => (a.ssl_mode ?? "").localeCompare(b.ssl_mode ?? ""),
+      render: (_: unknown, record: SSLCertificate) => {
+        if (record.id.startsWith("panel-cert:")) return <Tag color="purple">panel</Tag>;
+        const tag = modeTag(record.ssl_mode);
+        return tag ? <Tag color={tag.color}>{tag.label}</Tag> : <span>—</span>;
+      },
+    },
+    {
       title: "Service",
       dataIndex: "service",
       sorter: (a: SSLCertificate, b: SSLCertificate) => a.service.localeCompare(b.service),
@@ -366,7 +393,55 @@ export const SSLManagerTable = ({
             </Typography.Text>
           );
         }
-        return formatExpiry(dateStr);
+        // Failed / retry-pending rows have no meaningful expiry — show the
+        // retry schedule instead (was buried in the status tooltip).
+        if (record.status === "failed" || record.status === "pending_acme_retry") {
+          const retryAt = record.next_retry_at
+            ? new Date(record.next_retry_at).toLocaleString()
+            : null;
+          return (
+            <Typography.Text type="secondary">
+              {retryAt ? `retry ${retryAt}` : "—"}
+              {record.retry_count ? ` · attempt ${record.retry_count}` : ""}
+            </Typography.Text>
+          );
+        }
+        const days = daysUntilExpiry(dateStr);
+        const fraction = expiryFraction(dateStr);
+        if (days === null || fraction === null) return formatExpiry(dateStr);
+        // Days-left meter over a 90-day LE lifetime: green >30d, orange ≤30d,
+        // red ≤14d/expired. Date + relative label stay on hover.
+        const color = days <= 14 ? "#ff4d4f" : days <= 30 ? "#fa8c16" : "#52c41a";
+        return (
+          <Tooltip title={formatExpiry(dateStr)}>
+            <Space size={8}>
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 60,
+                  height: 4,
+                  borderRadius: 2,
+                  background: "rgba(0,0,0,0.06)",
+                }}
+              >
+                <span
+                  style={{
+                    display: "block",
+                    width: `${Math.round(fraction * 100)}%`,
+                    height: 4,
+                    borderRadius: 2,
+                    background: color,
+                  }}
+                />
+              </span>
+              <Typography.Text
+                style={days <= 30 ? { color, fontWeight: 600 } : undefined}
+              >
+                {days < 0 ? "expired" : `${days} d`}
+              </Typography.Text>
+            </Space>
+          </Tooltip>
+        );
       },
     },
     {
@@ -398,53 +473,74 @@ export const SSLManagerTable = ({
         if (record.id.startsWith("mail-cert:")) {
           return (
             <Tooltip title={t("sslmanagertable.clears_backoff_and_reissues_the_let_s_encryp")}>
-              <Button
+              <RowActionButton
                 icon={<RedoOutlined />}
                 loading={reissueMailMutation.isPending}
                 onClick={() => reissueMailMutation.mutate(record.domain_id)}
               >
                 Reissue
-              </Button>
+              </RowActionButton>
             </Tooltip>
           );
         }
         const isRetryable = record.status === "failed" ||
           (record.status === "pending_acme_retry" && record.next_retry_at && new Date(record.next_retry_at) < new Date());
+        // One labeled, state-appropriate primary action per row; the rest
+        // live in the ⋯ overflow (Certificate console). Renew stays primary
+        // for issued rows, Retry now for retryable failures.
+        const menuItems = [
+          ...(record.status === "issued"
+            ? [{ key: "revoke", danger: true, icon: <DeleteOutlined />, label: t("sslmanagertable.revoke_certificate") }]
+            : []),
+          ...(record.status === "pending_acme_retry" && !isRetryable
+            ? [{ key: "retry", icon: <RedoOutlined />, label: "Force retry now" }]
+            : []),
+          ...(record.last_error
+            ? [{ key: "error", icon: <ExclamationCircleOutlined />, label: t("sslmanagertable.show_last_error") }]
+            : []),
+        ];
+        const onMenuClick = ({ key }: { key: string }) => {
+          if (key === "retry") retryMutation.mutate(record.domain_id);
+          else if (key === "error") setErrorRow(record);
+          else if (key === "revoke") {
+            Modal.confirm({
+              title: t("sslmanagertable.revoke_certificate"),
+              content: t("sslmanagertable.are_you_sure_you_want_to_revoke_this_certifi"),
+              okText: t("sslmanagertable.yes"),
+              okButtonProps: { danger: true },
+              cancelText: "No",
+              onOk: () => revokeMutation.mutate(record.domain_id),
+            });
+          }
+        };
         return (
           <Space>
-            {isRetryable && (
-              <Tooltip title={t("sslmanagertable.force_acme_retry_now")}>
-                <Button
-                  icon={<RedoOutlined />}
-                  loading={retryMutation.isPending}
-                  onClick={() => retryMutation.mutate(record.domain_id)}
-                />
-              </Tooltip>
-            )}
             {record.status === "issued" && (
               <Tooltip title={t("sslmanagertable.renew_certificate")}>
-                <Button
-                  type="primary"
+                <RowActionButton
                   icon={<ReloadOutlined />}
                   loading={renewMutation.isPending}
                   onClick={() => renewMutation.mutate(record.domain_id)}
-                />
+                >
+                  Renew
+                </RowActionButton>
               </Tooltip>
             )}
-            {record.status === "issued" && (
-              <Popconfirm
-                title={t("sslmanagertable.revoke_certificate")}
-                description={t("sslmanagertable.are_you_sure_you_want_to_revoke_this_certifi")}
-                onConfirm={() => revokeMutation.mutate(record.domain_id)}
-                okText={t("sslmanagertable.yes")}
-                cancelText="No"
-              >
-                <Button
-                  danger
-                  icon={<DeleteOutlined />}
-                  loading={revokeMutation.isPending}
-                />
-              </Popconfirm>
+            {isRetryable && (
+              <Tooltip title={t("sslmanagertable.force_acme_retry_now")}>
+                <RowActionButton
+                  icon={<RedoOutlined />}
+                  loading={retryMutation.isPending}
+                  onClick={() => retryMutation.mutate(record.domain_id)}
+                >
+                  Retry now
+                </RowActionButton>
+              </Tooltip>
+            )}
+            {menuItems.length > 0 && (
+              <Dropdown menu={{ items: menuItems, onClick: onMenuClick }} placement="bottomRight">
+                <RowActionButton color="default" icon={<MoreOutlined />} aria-label={`More actions for ${record.domain_name}`} />
+              </Dropdown>
             )}
           </Space>
         );

--- a/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
+++ b/panel-ui/src/components/ssl/SharedCertificatesCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type React from "react";
 import { Alert, Button, Card, Empty, Input, Modal, Popconfirm, Select, Space, Table, Tag, Tooltip, Typography, Upload } from "antd";
 import { feedback } from "../../lib/feedback"; // GH #970: themed toasts
 import type { UploadFile } from "antd";
@@ -66,7 +67,7 @@ const readFileText = (file: File): Promise<string> =>
     reader.readAsText(file);
   });
 
-export const SharedCertificatesCard = () => {
+export const SharedCertificatesCard = ({ embedded = false }: { embedded?: boolean } = {}) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
@@ -261,20 +262,36 @@ export const SharedCertificatesCard = () => {
     },
   ];
 
+  const actionButtons = (
+    <Space>
+      <Button icon={<SafetyCertificateOutlined />} onClick={() => setAcmeOpen(true)}>
+        Request wildcard (Let&apos;s Encrypt)
+      </Button>
+      <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+        Upload shared certificate
+      </Button>
+    </Space>
+  );
+
+  // Embedded = rendered as a tab inside the Certificate console card;
+  // no own Card chrome, the action buttons move into a toolbar row.
+  const Wrapper = embedded
+    ? ({ children }: { children: React.ReactNode }) => (
+        <div>
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 12 }}>
+            {actionButtons}
+          </div>
+          {children}
+        </div>
+      )
+    : ({ children }: { children: React.ReactNode }) => (
+        <Card title={t("sharedcertificates.title")} extra={actionButtons}>
+          {children}
+        </Card>
+      );
+
   return (
-    <Card
-      title={t("sharedcertificates.title")}
-      extra={
-        <Space>
-          <Button icon={<SafetyCertificateOutlined />} onClick={() => setAcmeOpen(true)}>
-            Request wildcard (Let&apos;s Encrypt)
-          </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
-            Upload shared certificate
-          </Button>
-        </Space>
-      }
-    >
+    <Wrapper>
       <Typography.Paragraph type="secondary" style={{ marginTop: 0 }}>
         Upload a wildcard or multi-SAN certificate once, then attach it to any
         covering domain from that domain&apos;s SSL tab. The reconciler renders
@@ -415,6 +432,6 @@ export const SharedCertificatesCard = () => {
           </div>
         </Space>
       </Modal>
-    </Card>
+    </Wrapper>
   );
 };

--- a/panel-ui/src/components/ssl/panelCertStatus.tsx
+++ b/panel-ui/src/components/ssl/panelCertStatus.tsx
@@ -1,0 +1,34 @@
+// panelCertStatus — status tag + expiry hint for panel_certificate rows,
+// shared by the Settings PanelSSLCard and the SSL Manager's SYSTEM band
+// so the two surfaces can never drift.
+import { Tag } from "antd";
+import type { PanelCertificate } from "../../hooks/usePanelCertificate";
+
+export function panelCertStatusTag(c: PanelCertificate) {
+  switch (c.status) {
+    case "issued":
+      return (
+        <Tag color="success">
+          Issued by Let&apos;s Encrypt{c.staging ? " (staging)" : ""}
+        </Tag>
+      );
+    case "pending_acme":
+      return <Tag color="processing">Issuing…</Tag>;
+    case "pending_acme_retry":
+      return <Tag color="warning">Pending retry</Tag>;
+    case "failed":
+      return <Tag color="error">Failed</Tag>;
+    case "self_signed":
+    default:
+      return <Tag>Self-signed</Tag>;
+  }
+}
+
+export function panelCertExpiryHint(c: PanelCertificate): string | null {
+  if (c.status !== "issued" || !c.expires_at) return null;
+  const ms = new Date(c.expires_at).getTime() - Date.now();
+  if (Number.isNaN(ms)) return null;
+  const days = Math.floor(ms / (24 * 3600 * 1000));
+  if (days < 0) return "Expired";
+  return `Expires in ${days} day${days === 1 ? "" : "s"}`;
+}

--- a/panel-ui/src/components/ssl/sslHealth.test.ts
+++ b/panel-ui/src/components/ssl/sslHealth.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  certBucket,
+  countBuckets,
+  daysUntil,
+  expiryFraction,
+  matchesFilter,
+  modeTag,
+} from "./sslHealth";
+
+const inDays = (n: number) => new Date(Date.now() + n * 24 * 3600 * 1000).toISOString();
+
+describe("certBucket", () => {
+  it("issued with a comfortable expiry stays issued", () => {
+    expect(certBucket({ status: "issued", expires_at: inDays(74) })).toBe("issued");
+  });
+
+  it("issued at ≤30 days (and expired) is expiring — disjoint from issued", () => {
+    expect(certBucket({ status: "issued", expires_at: inDays(12) })).toBe("expiring");
+    expect(certBucket({ status: "issued", expires_at: inDays(-2) })).toBe("expiring");
+  });
+
+  it("failed and pending_acme_retry share the failed bucket", () => {
+    expect(certBucket({ status: "failed", expires_at: null })).toBe("failed");
+    expect(certBucket({ status: "pending_acme_retry", expires_at: null })).toBe("failed");
+  });
+
+  it("self_signed and lifecycle states bucket separately", () => {
+    expect(certBucket({ status: "self_signed", expires_at: null })).toBe("self_signed");
+    expect(certBucket({ status: "issuing", expires_at: null })).toBe("other");
+  });
+});
+
+describe("matchesFilter / countBuckets", () => {
+  const rows = [
+    { status: "issued", expires_at: inDays(74) },
+    { status: "issued", expires_at: inDays(5) },
+    { status: "failed", expires_at: null },
+    { status: "self_signed", expires_at: null },
+  ];
+
+  it("'all' matches everything; buckets are exclusive", () => {
+    expect(rows.filter((r) => matchesFilter(r, "all"))).toHaveLength(4);
+    expect(rows.filter((r) => matchesFilter(r, "expiring"))).toHaveLength(1);
+    const counts = countBuckets(rows);
+    expect(counts).toEqual({ issued: 1, expiring: 1, failed: 1, self_signed: 1, other: 0 });
+    expect(Object.values(counts).reduce((a, b) => a + b, 0)).toBe(rows.length);
+  });
+});
+
+describe("expiry math", () => {
+  it("daysUntil handles null and junk", () => {
+    expect(daysUntil(null)).toBeNull();
+    expect(daysUntil("not-a-date")).toBeNull();
+  });
+
+  it("expiryFraction clamps to [0,1] over a 90-day lifetime", () => {
+    expect(expiryFraction(inDays(45))).toBeCloseTo(0.5, 1);
+    expect(expiryFraction(inDays(400))).toBe(1);
+    expect(expiryFraction(inDays(-5))).toBe(0);
+    expect(expiryFraction(null)).toBeNull();
+  });
+});
+
+describe("modeTag", () => {
+  it("maps the domain ssl_mode enum", () => {
+    expect(modeTag("le")).toEqual({ color: "blue", label: "LE" });
+    expect(modeTag("shared")).toEqual({ color: "purple", label: "shared" });
+    expect(modeTag("custom")).toEqual({ color: "gold", label: "custom" });
+    expect(modeTag("self")).toEqual({ label: "self" });
+    expect(modeTag(undefined)).toBeNull();
+    expect(modeTag("")).toBeNull();
+  });
+});

--- a/panel-ui/src/components/ssl/sslHealth.ts
+++ b/panel-ui/src/components/ssl/sslHealth.ts
@@ -1,0 +1,88 @@
+// sslHealth — pure helpers behind the admin "Certificate console"
+// (/jabali-admin/ssl): health buckets for the summary tiles + filters,
+// days-left math for the expiry meter, and the Mode-tag mapping.
+//
+// The four buckets are DISJOINT so the tile counts never double-count a
+// cert: "expiring" wins over "issued" for issued certs at ≤30 days
+// (expired ones included), failed covers both hard-failed and
+// retry-pending, self_signed is its own bucket, everything else
+// (pending/issuing/renewing/revoked) is "other".
+
+export interface SSLHealthRow {
+  status: string;
+  expires_at: string | null;
+}
+
+export type SSLBucket = "issued" | "expiring" | "failed" | "self_signed" | "other";
+
+/** Tile/segmented filter values: a bucket, or "all". */
+export type SSLFilter = SSLBucket | "all";
+
+export const EXPIRING_SOON_DAYS = 30;
+
+export function daysUntil(expiresAt: string | null): number | null {
+  if (!expiresAt) return null;
+  const t = new Date(expiresAt).getTime();
+  if (Number.isNaN(t)) return null;
+  return Math.ceil((t - Date.now()) / (24 * 3600 * 1000));
+}
+
+export function certBucket(row: SSLHealthRow): SSLBucket {
+  switch (row.status) {
+    case "issued": {
+      const days = daysUntil(row.expires_at);
+      return days !== null && days <= EXPIRING_SOON_DAYS ? "expiring" : "issued";
+    }
+    case "failed":
+    case "pending_acme_retry":
+      return "failed";
+    case "self_signed":
+      return "self_signed";
+    default:
+      return "other";
+  }
+}
+
+export function matchesFilter(row: SSLHealthRow, filter: SSLFilter): boolean {
+  return filter === "all" || certBucket(row) === filter;
+}
+
+export function countBuckets(rows: SSLHealthRow[]): Record<SSLBucket, number> {
+  const counts: Record<SSLBucket, number> = {
+    issued: 0,
+    expiring: 0,
+    failed: 0,
+    self_signed: 0,
+    other: 0,
+  };
+  for (const row of rows) counts[certBucket(row)] += 1;
+  return counts;
+}
+
+/**
+ * Fraction of a 90-day Let's Encrypt lifetime remaining, for the expiry
+ * meter. Clamped to [0, 1]; null when there is no usable expiry.
+ */
+export function expiryFraction(expiresAt: string | null): number | null {
+  const days = daysUntil(expiresAt);
+  if (days === null) return null;
+  return Math.min(1, Math.max(0, days / 90));
+}
+
+/** AntD Tag props for the domain ssl_mode. Empty/unknown → null (no tag). */
+export function modeTag(mode: string | undefined): { color?: string; label: string } | null {
+  switch (mode) {
+    case "le":
+      return { color: "blue", label: "LE" };
+    case "shared":
+      return { color: "purple", label: "shared" };
+    case "custom":
+      return { color: "gold", label: "custom" };
+    case "self":
+      return { label: "self" };
+    case "none":
+      return { label: "none" };
+    default:
+      return null;
+  }
+}

--- a/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
+++ b/panel-ui/src/shells/admin/settings/PanelSSLCard.tsx
@@ -20,36 +20,10 @@ import {
   usePanelCertificateIssue,
   usePanelCertificateToggle,
 } from "../../../hooks/usePanelCertificate";
-
-function statusTag(c: PanelCertificate) {
-  switch (c.status) {
-    case "issued":
-      return (
-        <Tag color="success">
-          Issued by Let&apos;s Encrypt{c.staging ? " (staging)" : ""}
-        </Tag>
-      );
-    case "pending_acme":
-      return <Tag color="processing">Issuing…</Tag>;
-    case "pending_acme_retry":
-      return <Tag color="warning">Pending retry</Tag>;
-    case "failed":
-      return <Tag color="error">Failed</Tag>;
-    case "self_signed":
-    default:
-      return <Tag>Self-signed</Tag>;
-  }
-}
-
-function expiryHint(c: PanelCertificate): string | null {
-  if (c.status !== "issued" || !c.expires_at) return null;
-  const ms = new Date(c.expires_at).getTime() - Date.now();
-  if (Number.isNaN(ms)) return null;
-  const days = Math.floor(ms / (24 * 3600 * 1000));
-  if (days < 0) return "Expired";
-  if (days < 7) return `Expires in ${days} day${days === 1 ? "" : "s"}`;
-  return `Expires in ${days} days`;
-}
+import {
+  panelCertExpiryHint,
+  panelCertStatusTag,
+} from "../../../components/ssl/panelCertStatus";
 
 function CertRow({
   label,
@@ -62,7 +36,7 @@ function CertRow({
   onRetry: () => void;
   retrying: boolean;
 }) {
-  const expiry = expiryHint(cert);
+  const expiry = panelCertExpiryHint(cert);
   return (
     <div style={{ borderTop: "1px solid rgba(255,255,255,0.08)", paddingTop: 12 }}>
       <Space direction="vertical" size={6} style={{ width: "100%" }}>
@@ -73,7 +47,7 @@ function CertRow({
           <code>{cert.hostname || "<unset>"}</code>
         </Space>
         <Space wrap>
-          {statusTag(cert)}
+          {panelCertStatusTag(cert)}
           {cert.routable ? (
             <Tag icon={<CheckCircleOutlined />} color="success">
               Routable

--- a/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
+++ b/panel-ui/src/shells/admin/ssl/SSLManagerPage.tsx
@@ -1,38 +1,200 @@
+// SSLManagerPage — the admin "Certificate console".
+//
+// Layout (2026-08 redesign, mockup-approved): four clickable summary
+// tiles (health buckets, disjoint — see sslHealth.ts), the compact
+// SYSTEM band for the panel's own certs (full management stays on
+// Server Settings → Panel SSL), and one tabbed card holding the domain
+// certificates table + the shared wildcard/multi-SAN certificates
+// (JAB-170) that used to be a separate card below the fold.
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Card, Typography } from "antd";
-import { ShieldCheckOutlined } from "@icons";
+import { useQuery } from "@tanstack/react-query";
+import { Card, Tabs, Typography } from "antd";
+import {
+  ClockCircleOutlined,
+  SafetyOutlined,
+  ShieldCheckOutlined,
+  WarningOutlined,
+} from "@icons";
 
+import { apiClient } from "../../../apiClient";
+import { PanelSSLBand } from "../../../components/ssl/PanelSSLBand";
 import { SSLManagerTable } from "../../../components/ssl/SSLManagerTable";
 import { SharedCertificatesCard } from "../../../components/ssl/SharedCertificatesCard";
-import { PanelSSLCard } from "../settings/PanelSSLCard";
+import {
+  countBuckets,
+  type SSLFilter,
+  type SSLHealthRow,
+} from "../../../components/ssl/sslHealth";
+
+const ENDPOINT = "/admin/ssl-certificates";
+
+interface TileSpec {
+  key: Exclude<SSLFilter, "all" | "other">;
+  label: string;
+  color: string;
+  bg: string;
+  icon: React.ReactNode;
+}
+
+const TILES: TileSpec[] = [
+  {
+    key: "issued",
+    label: "Issued",
+    color: "#389e0d",
+    bg: "rgba(82,196,26,0.14)",
+    icon: <ShieldCheckOutlined />,
+  },
+  {
+    key: "expiring",
+    label: "Expiring ≤ 30 d",
+    color: "#d46b08",
+    bg: "rgba(250,140,22,0.14)",
+    icon: <ClockCircleOutlined />,
+  },
+  {
+    key: "failed",
+    label: "Failed / retrying",
+    color: "#cf1322",
+    bg: "rgba(255,77,79,0.12)",
+    icon: <WarningOutlined />,
+  },
+  {
+    key: "self_signed",
+    label: "Self-signed",
+    color: "#6b7280",
+    bg: "rgba(0,0,0,0.06)",
+    icon: <SafetyOutlined />,
+  },
+];
+
+interface CertRow extends SSLHealthRow {
+  id: string;
+}
 
 export const SSLManagerPage = () => {
   const { t } = useTranslation();
+  const [filter, setFilter] = useState<SSLFilter>("all");
+
+  // Same queryKey as SSLManagerTable — one request feeds both the tiles
+  // and the table via the react-query cache.
+  const { data: certRows } = useQuery({
+    queryKey: ["ssl-manager", ENDPOINT],
+    queryFn: async () => {
+      const response = await apiClient.get(ENDPOINT);
+      return response.data.items as CertRow[];
+    },
+  });
+
+  const counts = useMemo(() => {
+    // Panel-cert rows live in the SYSTEM band, not the table — keep the
+    // tile counts aligned with what the table below actually shows.
+    const rows = (certRows ?? []).filter((r) => !r.id.startsWith("panel-cert:"));
+    return countBuckets(rows);
+  }, [certRows]);
+
+  // Same queryKey as SharedCertificatesCard — cache-shared count for the
+  // tab label.
+  const { data: sharedCerts } = useQuery({
+    queryKey: ["shared-certificates"],
+    queryFn: async () => {
+      const res = await apiClient.get("/admin/certificates/shared");
+      return (res.data?.data ?? []) as { id: string }[];
+    },
+  });
+
   return (
     <div>
       <Typography.Title level={3} style={{ marginTop: 0, marginBottom: 16 }}>
         <ShieldCheckOutlined /> SSL Manager
       </Typography.Title>
 
-      {/* Panel cert lives alongside customer-domain certs so the
-          operator has one place to inspect / re-issue every cert
-          managed by the panel. PanelSSLCard owns its own data
-          loading + state via usePanelCertificate. */}
-      <div style={{ marginBottom: 16 }}>
-        <PanelSSLCard />
+      {/* Summary tiles double as filters: click to filter the table to
+          that bucket, click again to clear. */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+          gap: 16,
+          marginBottom: 16,
+        }}
+      >
+        {TILES.map((tile) => {
+          const active = filter === tile.key;
+          return (
+            <Card
+              key={tile.key}
+              hoverable
+              size="small"
+              onClick={() => setFilter(active ? "all" : tile.key)}
+              style={
+                active
+                  ? { borderColor: "#1677ff", boxShadow: "0 0 0 2px rgba(22,119,255,0.15)" }
+                  : undefined
+              }
+              styles={{ body: { padding: 12 } }}
+              aria-pressed={active}
+              role="button"
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <div
+                  style={{
+                    flex: "0 0 auto",
+                    width: 40,
+                    height: 40,
+                    borderRadius: 12,
+                    background: tile.bg,
+                    color: tile.color,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 18,
+                  }}
+                >
+                  {tile.icon}
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ color: tile.color, fontSize: 12, fontWeight: 600, marginBottom: 2 }}>
+                    {tile.label}
+                  </div>
+                  <div style={{ fontSize: 20, fontWeight: 700, lineHeight: 1.1 }}>
+                    {certRows ? counts[tile.key] : "—"}
+                  </div>
+                </div>
+              </div>
+            </Card>
+          );
+        })}
       </div>
 
-      <Card title={t("sslmanagerpage.domain_certificates")} style={{ marginBottom: 16 }}>
-        <SSLManagerTable
-          endpoint="/admin/ssl-certificates"
-          showOwner={true}
+      <div style={{ marginBottom: 16 }}>
+        <PanelSSLBand />
+      </div>
+
+      <Card styles={{ body: { paddingTop: 8 } }}>
+        <Tabs
+          defaultActiveKey="domains"
+          items={[
+            {
+              key: "domains",
+              label: t("sslmanagerpage.domain_certificates"),
+              children: (
+                <SSLManagerTable
+                  endpoint={ENDPOINT}
+                  showOwner={true}
+                  statusFilter={filter}
+                  hideSystemRows
+                />
+              ),
+            },
+            {
+              key: "shared",
+              label: `Shared certificates${sharedCerts ? ` (${sharedCerts.length})` : ""}`,
+              children: <SharedCertificatesCard embedded />,
+            },
+          ]}
         />
       </Card>
-
-      {/* Shared wildcard/multi-SAN certificates (JAB-170): upload once,
-          attach to many covering domains from each domain's SSL tab.
-          Owns its own data loading + upload/delete state. */}
-      <SharedCertificatesCard />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Mockup-approved redesign of `/jabali-admin/ssl` — the **Certificate console** (canvas: internal design artifact, picked by the operator).

- **Four health tiles** (Issued / Expiring ≤30d / Failed-retrying / Self-signed) that double as table filters. Buckets are disjoint (`components/ssl/sslHealth.ts`) so counts never double-count; tiles and table share one react-query cache entry.
- **SYSTEM band** replaces the tall Panel SSL card on this page: panel hostname + mail certs on one line with per-kind Issue/retry and the LE toggle. Full management (staging toggle, routable diagnostics) stays on Server Settings → Panel SSL; both surfaces now share `panelCertStatus` helpers so status rendering can't drift. Synthetic `panel-cert:*` rows are hidden from the table (the band shows them).
- **One tabbed card**: Domain certificates | Shared certificates (JAB-170 card folds in via a new `embedded` mode).
- **Table**: new **Mode** column (le / self / custom / none / shared) fed by `ssl_mode` newly exposed on the list wire (`ListByUserID` also selects it, so the user shell benefits); **days-left expiry meter** with 30d/14d urgency colors; failed rows show the **retry schedule** instead of a meaningless expiry; row actions become one labeled state-appropriate primary (**Renew** / **Retry now**) + an overflow menu (revoke behind confirm, error details).

Note: `SSLManagerTable` is shared — the user-shell SSL page picks up the new Mode column, expiry meter and action styling too.

## Test plan

- [x] `go vet` + `go test ./panel-api/internal/api ./panel-api/internal/repository` (list test asserts `ssl_mode` on the wire; sqlmock expectations updated)
- [x] `npx tsc -b` clean; vite build clean
- [x] 8 new unit tests for the health buckets / expiry math / mode mapping
- [ ] Box check on jabalitest: tiles filter the table; SYSTEM band actions; shared tab upload; user-shell SSL page still renders

GH: no linked issue (operator-requested redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
