### PR TITLE
fix(ssl): CLI shared-cert delete revokes ACME lineages, not just deletes files (JAB-317)

### DIFF
--- a/panel-api/cmd/server/ssl_shared_cmd.go
+++ b/panel-api/cmd/server/ssl_shared_cmd.go
@@ -247,6 +247,18 @@ func newSSLSharedDetachCmd() *cobra.Command {
 	return cmd
 }
 
+// sharedCertTeardown returns the source-aware agent teardown call for deleting a
+// shared certificate (JAB-317). An ACME shared cert is a certbot lineage — revoke
+// it so `certbot renew` stops and its DNS-01 hooks stop writing challenge records;
+// an uploaded cert is a file pair in the shared-certs dir. Mirrors
+// deleteSharedCert in internal/api/ssl_shared.go.
+func sharedCertTeardown(cert *models.SharedCertificate) (verb string, params map[string]any) {
+	if cert.Source == models.SharedCertSourceACME {
+		return "ssl.revoke", map[string]any{"domain": cert.ACMELineageName()}
+	}
+	return "ssl.delete_shared", map[string]any{"id": cert.ID}
+}
+
 func newSSLSharedDeleteCmd() *cobra.Command {
 	var id string
 	cmd := &cobra.Command{
@@ -271,7 +283,12 @@ func newSSLSharedDeleteCmd() *cobra.Command {
 			if err := repo.Delete(ctx, id); err != nil {
 				return fmt.Errorf("delete: %w", err)
 			}
-			_, _ = sharedAgent.Call(ctx, "ssl.delete_shared", map[string]any{"id": id})
+			// JAB-317: source-aware teardown, mirroring the HTTP handler. The CLI
+			// previously always called ssl.delete_shared, so deleting an ACME
+			// shared cert left its certbot lineage renewing + its DNS-01 hooks
+			// writing challenge records forever.
+			verb, params := sharedCertTeardown(cert)
+			_, _ = sharedAgent.Call(ctx, verb, params)
 			fmt.Printf("Deleted shared certificate %s.\n", id)
 			return nil
 		},

--- a/panel-api/cmd/server/ssl_shared_teardown_test.go
+++ b/panel-api/cmd/server/ssl_shared_teardown_test.go
@@ -1,0 +1,57 @@
+package main
+
+// JAB-317: CLI shared-cert delete must be source-aware — revoke ACME lineages,
+// delete_shared uploaded files — matching the HTTP handler.
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestSharedCertTeardown_SourceAware(t *testing.T) {
+	cases := []struct {
+		name       string
+		cert       *models.SharedCertificate
+		wantVerb   string
+		wantDomain string // "" means expect an "id" param instead
+	}{
+		{
+			name:     "uploaded → delete_shared by id",
+			cert:     &models.SharedCertificate{ID: "c1", Name: "example.com", Source: models.SharedCertSourceUploaded},
+			wantVerb: "ssl.delete_shared",
+		},
+		{
+			name:       "acme → revoke the lineage",
+			cert:       &models.SharedCertificate{ID: "c2", Name: "example.com", Source: models.SharedCertSourceACME},
+			wantVerb:   "ssl.revoke",
+			wantDomain: "example.com",
+		},
+		{
+			name:       "acme wildcard → revoke the wildcard.<zone> lineage",
+			cert:       &models.SharedCertificate{ID: "c3", Name: "*.example.com", Source: models.SharedCertSourceACME},
+			wantVerb:   "ssl.revoke",
+			wantDomain: "wildcard.example.com",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			verb, params := sharedCertTeardown(tc.cert)
+			if verb != tc.wantVerb {
+				t.Fatalf("verb = %q, want %q", verb, tc.wantVerb)
+			}
+			if tc.wantDomain != "" {
+				if params["domain"] != tc.wantDomain {
+					t.Fatalf("domain = %v, want %q", params["domain"], tc.wantDomain)
+				}
+				if _, hasID := params["id"]; hasID {
+					t.Fatal("ACME revoke must not send an id param")
+				}
+			} else {
+				if params["id"] != tc.cert.ID {
+					t.Fatalf("id = %v, want %q", params["id"], tc.cert.ID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The HTTP handler (`ssl_shared.go` `deleteSharedCert`) tears down a shared cert **by source**: an ACME shared cert is a certbot lineage → `ssl.revoke`; an uploaded cert is a file pair → `ssl.delete_shared`. The CLI `jabali ssl shared delete` **always** called `ssl.delete_shared`, so deleting an **ACME** shared cert left its certbot lineage renewing and its **DNS-01 hooks writing challenge records forever** — the DB row was gone but the host state lived on.

## Fix

Extracted a source-aware `sharedCertTeardown(cert)` and pointed the CLI delete at it, mirroring the HTTP handler: ACME → `ssl.revoke(lineage)`, uploaded → `ssl.delete_shared(id)`. The CLI already guards attached domains, so nothing else changes.

## Acceptance criteria (this slice)

- ✓ ACME deletion revokes the lineage; uploaded deletion removes shared files (now true on both HTTP **and** CLI).
- ✓ Attached certificates cannot be deleted (CLI guard already present, unchanged).

## Scope

Closes the JAB-317 source-aware-deletion criterion. The remaining items — consistent wildcard SAN matching, attach/detach convergence scheduling, upload-persistence disk compensation, and the full **Shared Certificate Lifecycle Module** extraction — stay open; the source-aware delete ships independently of the module refactor.

## Tests

`sharedCertTeardown`: uploaded → `delete_shared` by id; ACME → `revoke` the lineage name; ACME wildcard → `revoke` the `wildcard.<zone>` lineage. `cmd/server` package green; ff-clean.

Ref: JAB-317 (arch-audit round 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
