### PR TITLE
feat(dr): promote-completeness — IP re-point, PHP converge, empty-restore hard-warn (GH #1169)

### DIFF
--- a/docs/site/platform/cli-reference.md
+++ b/docs/site/platform/cli-reference.md
@@ -2314,7 +2314,7 @@ jabali dr feed [flags]
 **Flags:**
 
 - `--cron` — cron cadence for the DR feed (default hourly, "0 * * * *")
-- `--destination` — DR backup destination ID to ship system backups to
+- `--destination` — DR backup destination ID to ship system + account backups to
 
 #### `jabali dr pair`
 

--- a/panel-agent/internal/commands/backup_system.go
+++ b/panel-agent/internal/commands/backup_system.go
@@ -699,6 +699,14 @@ func applySystemRestore(ctx context.Context, stagingRoot string, stages []backup
 				continue
 			}
 			applied = append(applied, "panel_config → /etc/jabali-panel")
+			// GH #1169 gap 4: rsync preserved the SOURCE box's numeric uid/gid, so
+			// on a cross-host restore /etc/jabali-panel files owned by system
+			// accounts (jabali, jabali-mail) whose ids differ here become
+			// unreadable by the local panel. Re-point them by NAME using the
+			// restore's own os_users.json.
+			ownApplied, ownWarn := normalizePanelConfigOwnership(stagingRoot, "/etc/jabali-panel")
+			applied = append(applied, ownApplied...)
+			warnings = append(warnings, ownWarn...)
 		case backup.StageTLS:
 			if err := rsyncStageOnto(ctx, stageDir, "/etc/letsencrypt", nil); err != nil {
 				warnings = append(warnings, fmt.Sprintf("tls: %v", err))

--- a/panel-agent/internal/commands/backup_system_ownership.go
+++ b/panel-agent/internal/commands/backup_system_ownership.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// GH #1169 gap 4 — ownership normalization after a cross-host panel-config restore.
+//
+// rsync preserves the SOURCE box's NUMERIC uid/gid, but system accounts
+// (jabali, jabali-mail, …) can hold DIFFERENT ids on the two boxes (allocation
+// order). So after a DR restore a file the source's `jabali` (uid 996) owned is
+// now owned by whatever local account happens to hold 996 — often nobody — and
+// the panel, running as the LOCAL `jabali` (uid 997), can't read sso.key or its
+// secrets: the panel half-breaks (the #331 drill's exact symptom).
+//
+// The fix resolves each source id → NAME (from the restore's own os_users.json)
+// → LOCAL id, and chowns by name, preserving the exact per-file ownership INTENT.
+// This is deliberately NOT a blanket chown-to-jabali: /etc/jabali-panel is
+// multi-owner (root:jabali, jabali:jabali, jabali:jabali-mail, …) and a blanket
+// chown would widen group-read on a secret — a security regression.
+
+// remapID maps a source numeric id to the LOCAL id for the same NAME. Returns
+// (localID, true) only when the source id has a known name that resolves locally
+// to a DIFFERENT id; (0, false) when the id is unknown or already matches. Pure,
+// so the remap decision is unit-tested without touching the filesystem.
+func remapID(srcID int, srcIDToName map[int]string, localNameToID map[string]int) (int, bool) {
+	name, ok := srcIDToName[srcID]
+	if !ok {
+		return 0, false
+	}
+	local, ok := localNameToID[name]
+	if !ok || local == srcID {
+		return 0, false
+	}
+	return local, true
+}
+
+// normalizePanelConfigOwnership re-points /etc/jabali-panel ownership by name
+// after the panel_config rsync, using the source passwd/group captured in the
+// os_users stage. Best-effort: a missing/garbled os_users.json or a failed chown
+// warns but never fails the restore. Returns operator-visible applied/warnings.
+func normalizePanelConfigOwnership(stagingRoot, target string) (applied, warnings []string) {
+	src := filepath.Join(stagingRoot, "os_users", "os_users.json")
+	raw, err := os.ReadFile(src) // #nosec G304 — server-controlled stage dir
+	if err != nil {
+		return nil, []string{fmt.Sprintf("ownership normalize: no os_users.json (%v); left panel-config ownership as-restored", err)}
+	}
+	var bundle osUsersBundle
+	if jerr := json.Unmarshal(raw, &bundle); jerr != nil {
+		return nil, []string{fmt.Sprintf("ownership normalize: parse os_users.json: %v", jerr)}
+	}
+
+	srcUIDToName := map[int]string{}
+	for _, line := range bundle.Passwd {
+		if e, perr := parsePasswdLine(line); perr == nil {
+			srcUIDToName[e.UID] = e.Name
+		}
+	}
+	srcGIDToName := map[int]string{}
+	for _, line := range bundle.Group {
+		if name, gid, _, perr := parseGroupLine(line); perr == nil {
+			srcGIDToName[gid] = name
+		}
+	}
+
+	// Local name→id, resolved once per name (cache misses too, so an unknown
+	// name isn't looked up on every file).
+	localUID := map[string]int{}
+	resolveUID := func(name string) (int, bool) {
+		if id, seen := localUID[name]; seen {
+			return id, id >= 0
+		}
+		u, lerr := user.Lookup(name)
+		if lerr != nil {
+			localUID[name] = -1
+			return 0, false
+		}
+		id, _ := strconv.Atoi(u.Uid)
+		localUID[name] = id
+		return id, true
+	}
+	localGID := map[string]int{}
+	resolveGID := func(name string) (int, bool) {
+		if id, seen := localGID[name]; seen {
+			return id, id >= 0
+		}
+		g, lerr := user.LookupGroup(name)
+		if lerr != nil {
+			localGID[name] = -1
+			return 0, false
+		}
+		id, _ := strconv.Atoi(g.Gid)
+		localGID[name] = id
+		return id, true
+	}
+
+	remapped := 0
+	_ = filepath.Walk(target, func(p string, info os.FileInfo, werr error) error {
+		if werr != nil || info == nil {
+			return nil
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return nil
+		}
+		curUID, curGID := int(st.Uid), int(st.Gid)
+		newUID, newGID := -1, -1
+		if name, ok := srcUIDToName[curUID]; ok {
+			if lid, ok2 := resolveUID(name); ok2 && lid != curUID {
+				newUID = lid
+			}
+		}
+		if name, ok := srcGIDToName[curGID]; ok {
+			if lid, ok2 := resolveGID(name); ok2 && lid != curGID {
+				newGID = lid
+			}
+		}
+		if newUID < 0 && newGID < 0 {
+			return nil
+		}
+		// Lchown with -1 leaves the unchanged half alone and never follows a
+		// symlink into another tree.
+		if cerr := os.Lchown(p, newUID, newGID); cerr != nil {
+			warnings = append(warnings, fmt.Sprintf("ownership normalize %s: %v", p, cerr))
+			return nil
+		}
+		remapped++
+		return nil
+	})
+	if remapped > 0 {
+		applied = append(applied, fmt.Sprintf("normalized ownership on %d panel-config file(s) by name (cross-host uid/gid shift)", remapped))
+	}
+	return applied, warnings
+}

--- a/panel-agent/internal/commands/backup_system_ownership_test.go
+++ b/panel-agent/internal/commands/backup_system_ownership_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import "testing"
+
+func TestRemapID(t *testing.T) {
+	srcIDToName := map[int]string{996: "jabali", 990: "jabali-mail", 0: "root"}
+	localNameToID := map[string]int{"jabali": 997, "jabali-mail": 990, "root": 0}
+	tests := []struct {
+		name    string
+		src     int
+		wantID  int
+		wantHit bool
+	}{
+		{"jabali shifted 996→997", 996, 997, true},
+		{"jabali-mail same id 990", 990, 0, false}, // local == src → no change
+		{"root stable 0", 0, 0, false},             // local == src → no change
+		{"unknown source id", 1234, 0, false},      // not in os_users.json → leave
+		{"src name absent locally", 995, 0, false}, // 995 not mapped → leave
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotHit := remapID(tt.src, srcIDToName, localNameToID)
+			if gotHit != tt.wantHit || (gotHit && gotID != tt.wantID) {
+				t.Errorf("remapID(%d) = (%d,%v), want (%d,%v)", tt.src, gotID, gotHit, tt.wantID, tt.wantHit)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/dr_cmd.go
+++ b/panel-api/cmd/server/dr_cmd.go
@@ -229,30 +229,58 @@ func newDRFeedCmd() *cobra.Command {
 			}
 
 			schedRepo := scheduleRepoFromDB()
-			// Idempotency: reuse an existing system_backup schedule already
-			// linked to this destination rather than stacking duplicates.
-			existing, ferr := findSystemScheduleForDest(ctx, schedRepo, destID)
+			// Idempotency: reuse the existing DR feed schedule linked to this
+			// destination rather than stacking duplicates.
+			existing, ferr := findDRScheduleForDest(ctx, schedRepo, destID)
 			if ferr != nil {
 				return ferr
 			}
 			if existing != nil {
+				// GH #1169 gap 3b: upgrade a legacy system-only DR feed to also
+				// ship account backups. Without account_backup manifests in the
+				// DR repo, promote's include_accounts restore finds nothing and
+				// every tenant comes up empty (the exact silent data-loss the
+				// promote hard-warn now shouts about). An account_backup schedule
+				// with no explicit users fans out to ALL non-admin tenants, and
+				// IncludeSystemBackup keeps the system backup on the same tick.
+				changed := false
+				if existing.Kind != models.BackupScheduleKindAccount || !existing.IncludeSystemBackup {
+					existing.Kind = models.BackupScheduleKindAccount
+					existing.IncludeSystemBackup = true
+					if existing.Content == "" {
+						existing.Content = "full"
+					}
+					changed = true
+				}
 				if !existing.Enabled {
 					existing.Enabled = true
-					if err := schedRepo.Update(ctx, existing); err != nil {
-						return fmt.Errorf("re-enable existing DR feed schedule: %w", err)
-					}
+					changed = true
 				}
-				fmt.Printf("DR feed already configured (schedule %s → %s); ensured enabled.\n", existing.ID, dest.Name)
+				if changed {
+					if err := schedRepo.Update(ctx, existing); err != nil {
+						return fmt.Errorf("update existing DR feed schedule: %w", err)
+					}
+					fmt.Printf("DR feed schedule %s → %s upgraded to ship account + system backups; ensured enabled.\n", existing.ID, dest.Name)
+				} else {
+					fmt.Printf("DR feed already configured (schedule %s → %s); ensured enabled.\n", existing.ID, dest.Name)
+				}
 				return nil
 			}
 
 			next, _ := internalbackup.NextFire(cron, time.Now().UTC())
+			// GH #1169 gap 3b: an account_backup schedule with NO explicit users
+			// fans out to every non-admin tenant, and IncludeSystemBackup fires
+			// the system backup on the same tick — so one DR feed schedule ships
+			// both the control plane AND all tenant data to the DR repo, which is
+			// what promote's include_accounts restore needs.
 			s := &models.BackupSchedule{
-				ID:        ids.NewULID(),
-				Kind:      models.BackupScheduleKindSystem,
-				CronExpr:  cron,
-				Enabled:   true,
-				NextRunAt: &next,
+				ID:                  ids.NewULID(),
+				Kind:                models.BackupScheduleKindAccount,
+				IncludeSystemBackup: true,
+				Content:             "full",
+				CronExpr:            cron,
+				Enabled:             true,
+				NextRunAt:           &next,
 			}
 			if err := schedRepo.Create(ctx, s); err != nil {
 				return fmt.Errorf("create DR feed schedule: %w", err)
@@ -260,12 +288,12 @@ func newDRFeedCmd() *cobra.Command {
 			if err := schedRepo.ReplaceDestinations(ctx, s.ID, []string{destID}); err != nil {
 				return fmt.Errorf("link DR feed schedule to destination: %w", err)
 			}
-			fmt.Printf("DR feed configured: system_backup schedule %s ships to %s on cron %q.\n", s.ID, dest.Name, cron)
+			fmt.Printf("DR feed configured: schedule %s ships all tenant account backups + the system backup to %s on cron %q.\n", s.ID, dest.Name, cron)
 			fmt.Println("Pair the standby against this same destination with `jabali dr pair --destination <id>`.")
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&destID, "destination", "", "DR backup destination ID to ship system backups to")
+	cmd.Flags().StringVar(&destID, "destination", "", "DR backup destination ID to ship system + account backups to")
 	cmd.Flags().StringVar(&cron, "cron", "", "cron cadence for the DR feed (default hourly, \"0 * * * *\")")
 	return cmd
 }
@@ -316,15 +344,29 @@ func newDRUnfeedCmd() *cobra.Command {
 	return cmd
 }
 
-// findSystemScheduleForDest returns the first enabled-or-disabled system_backup
-// schedule whose destination set includes destID, or nil if none exists.
-func findSystemScheduleForDest(ctx context.Context, repo repository.BackupScheduleRepository, destID string) (*models.BackupSchedule, error) {
+// isDRFeedSchedule reports whether a schedule is a DR feed schedule for the
+// given destination-membership check to consider. Two shapes qualify:
+//   - legacy kind=system_backup (pre-GH #1169: system state only), and
+//   - kind=account_backup with IncludeSystemBackup=true (GH #1169 gap 3b: ships
+//     BOTH all tenants' account backups AND the system backup on one schedule).
+//
+// IncludeSystemBackup on an account schedule is a reliable DR marker: tenants
+// never set it (it's an admin/DR construct), so it doesn't collide with an
+// ordinary tenant account schedule that happens to target the same destination.
+func isDRFeedSchedule(s *models.BackupSchedule) bool {
+	return s.Kind == models.BackupScheduleKindSystem ||
+		(s.Kind == models.BackupScheduleKindAccount && s.IncludeSystemBackup)
+}
+
+// findDRScheduleForDest returns the first enabled-or-disabled DR feed schedule
+// whose destination set includes destID, or nil if none exists.
+func findDRScheduleForDest(ctx context.Context, repo repository.BackupScheduleRepository, destID string) (*models.BackupSchedule, error) {
 	all, err := repo.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list backup schedules: %w", err)
 	}
 	for i := range all {
-		if all[i].Kind != models.BackupScheduleKindSystem {
+		if !isDRFeedSchedule(&all[i]) {
 			continue
 		}
 		dests, derr := repo.GetDestinations(ctx, all[i].ID)
@@ -361,7 +403,7 @@ func tearDownDRFeed(
 	destID string,
 ) (drFeedTeardown, error) {
 	var res drFeedTeardown
-	sched, err := findSystemScheduleForDest(ctx, schedRepo, destID)
+	sched, err := findDRScheduleForDest(ctx, schedRepo, destID)
 	if err != nil {
 		return res, err
 	}

--- a/panel-api/cmd/server/dr_feed_schedule_test.go
+++ b/panel-api/cmd/server/dr_feed_schedule_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestIsDRFeedSchedule(t *testing.T) {
+	tests := []struct {
+		name string
+		s    models.BackupSchedule
+		want bool
+	}{
+		{"legacy system_backup", models.BackupSchedule{Kind: models.BackupScheduleKindSystem}, true},
+		{"account + include_system (DR combined)", models.BackupSchedule{Kind: models.BackupScheduleKindAccount, IncludeSystemBackup: true}, true},
+		{"plain tenant account schedule", models.BackupSchedule{Kind: models.BackupScheduleKindAccount, IncludeSystemBackup: false}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDRFeedSchedule(&tt.s); got != tt.want {
+				t.Errorf("isDRFeedSchedule(%+v) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/dr_promote.go
+++ b/panel-api/cmd/server/dr_promote.go
@@ -262,8 +262,33 @@ func promoteRestoreAccounts(ctx context.Context, s *models.ServerSettings) error
 				for _, a := range out.Applied {
 					fmt.Println("  applied:", a)
 				}
+				zeroAccounts := false
 				for _, w := range out.ApplyWarnings {
 					fmt.Println("  WARNING:", w)
+					if strings.Contains(w, "no account_backup manifest snapshots found") {
+						zeroAccounts = true
+					}
+				}
+				// GH #1169 gap 3 — hard-warn on an empty account restore. The
+				// drill's first promote "succeeded" while restoring ZERO tenant
+				// data, because `dr feed` ships only system_backup and no
+				// account_backup manifests ever reach the DR repo. That is a
+				// silent data-loss cutover: the box comes up, the reconciler
+				// builds vhosts, and every tenant's home/mail/DB is empty. Make
+				// it impossible to miss.
+				if zeroAccounts {
+					fmt.Println("")
+					fmt.Println("  ============================================================")
+					fmt.Println("  ⚠  NO TENANT DATA WAS RESTORED — the DR repo has no")
+					fmt.Println("     account_backup manifests. Every tenant's home directory,")
+					fmt.Println("     mail, and per-user databases will be EMPTY after promote.")
+					fmt.Println("")
+					fmt.Println("     Cause: the DR feed shipped only system backups. Ensure")
+					fmt.Println("     account-backup coverage to the DR destination (see")
+					fmt.Println("     `jabali dr feed`), let a cycle run, then re-restore before")
+					fmt.Println("     pointing live traffic here.")
+					fmt.Println("  ============================================================")
+					fmt.Println("")
 				}
 			}
 			return nil

--- a/panel-api/cmd/server/dr_promote.go
+++ b/panel-api/cmd/server/dr_promote.go
@@ -17,6 +17,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
 // GH #331 Step 4 — `jabali dr promote`. Turns a DR standby into the live primary:
@@ -117,6 +118,46 @@ func newDRPromoteCmd() *cobra.Command {
 				}
 			}
 
+			// GH #1169 gap 1 — IP re-point (cutover-critical). Done AFTER the
+			// restore (StagePanelDB replaces the panel DB, so any earlier write
+			// would be wiped) and folded into the role-flip Upsert below, while
+			// the panel is still fenced. managed_ips + public_ipv4 replicate the
+			// OLD primary's address; without this every rebuilt vhost binds an IP
+			// this box doesn't own and nothing serves.
+			if own, derr := detectOwnIPv4(ctx); derr != nil {
+				fmt.Printf("WARNING: could not detect this box's IPv4 (%v).\n", derr)
+				fmt.Println("  The replicated managed IP / public_ipv4 still point at the OLD primary —")
+				fmt.Println("  re-point them by hand (`jabali ip …`) before traffic will serve.")
+			} else if !yes {
+				cur, _ := ipRepoFromDB().FindDefaultByFamily(ctx, "ipv4")
+				curIP := "none"
+				if cur != nil {
+					curIP = cur.Address
+				}
+				fmt.Printf("Re-point the default IPv4 from %s (old primary) to %s (this box)? "+
+					"public_ipv4 is currently %q.\n", orDefault(curIP, "none"), own, s.PublicIPv4)
+				ok, cerr := confirmYes(os.Stdin, "Type 'yes' to re-point (anything else keeps the replicated IPs): ")
+				if cerr != nil {
+					return cerr
+				}
+				if ok {
+					if msg, rerr := repointDefaultIP(ctx, ipRepoFromDB(), s, own); rerr != nil {
+						return fmt.Errorf("IP re-point failed (box NOT promoted; fix and re-run): %w", rerr)
+					} else {
+						fmt.Println("  " + msg)
+					}
+				} else {
+					fmt.Println("  Skipped IP re-point — the replicated IPs stay; re-point manually before serving.")
+				}
+			} else {
+				// Scriptable (--yes): re-point without prompting.
+				if msg, rerr := repointDefaultIP(ctx, ipRepoFromDB(), s, own); rerr != nil {
+					return fmt.Errorf("IP re-point failed (box NOT promoted; fix and re-run): %w", rerr)
+				} else {
+					fmt.Println(msg)
+				}
+			}
+
 			// Flip the role. Clearing the DR pairing makes drsync inert (it re-reads
 			// role each tick) and StandbyReadOnly pass again; the reconciler wakes on
 			// its next tick and converges serving config. Last-sync history is kept.
@@ -125,6 +166,16 @@ func newDRPromoteCmd() *cobra.Command {
 			s.DRPairedAt = nil
 			if err := repo.Upsert(ctx, s); err != nil {
 				return fmt.Errorf("flip role to primary: %w", err)
+			}
+
+			// GH #1169 gap 5 — converge PHP. The replicated pools demand PHP
+			// versions this empty box may lack and are marked active (which the
+			// reconciler skips); install what's missing and flip pools to pending
+			// so the reconciler renders them. Best-effort: a failure here logs a
+			// warning but does not un-promote (the role flip already committed).
+			fmt.Println("Converging PHP pools for this host…")
+			if err := promoteConvergePHP(ctx, repository.NewPHPPoolRepository(sharedDB), sharedAgent); err != nil {
+				fmt.Printf("  WARNING: PHP pool convergence incomplete (%v); run `jabali php pool reapply-all` after fixing.\n", err)
 			}
 
 			fmt.Println("PROMOTED: this box is now the PRIMARY.")

--- a/panel-api/cmd/server/dr_promote_ip.go
+++ b/panel-api/cmd/server/dr_promote_ip.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1169 gap 1 — IP re-point at promote (cutover-critical).
+//
+// managed_ips + server_settings.public_ipv4 replicate from the OLD primary, so
+// after a promote every rebuilt vhost binds an address this box does not own —
+// nothing serves until the operator hand-edits the DB. Promote re-points the
+// default IPv4 managed IP (and public_ipv4) to this box's own address so the
+// reconciler builds bindable vhosts on its first tick.
+
+// detectOwnIPv4 returns the box's own egress IPv4. Injectable so the re-point
+// logic is unit-testable without a real interface. The default "connects" a UDP
+// socket to a public address — no packet is sent, it only makes the kernel
+// resolve the egress source IP for the default route, so it needs a route but
+// not reachability.
+var detectOwnIPv4 = defaultDetectOwnIPv4
+
+func defaultDetectOwnIPv4(ctx context.Context) (string, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "udp", "1.1.1.1:80")
+	if err != nil {
+		return "", fmt.Errorf("detect own IPv4 (no default route?): %w", err)
+	}
+	defer conn.Close()
+	ua, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok || ua.IP == nil {
+		return "", fmt.Errorf("detect own IPv4: unexpected local address %v", conn.LocalAddr())
+	}
+	ip := ua.IP.To4()
+	if ip == nil {
+		return "", fmt.Errorf("detect own IPv4: egress address %s is not IPv4", ua.IP)
+	}
+	return ip.String(), nil
+}
+
+// ipRepointPlan is the pure decision for the IP re-point. Separated from I/O so
+// the branch logic (no-op / in-place update / collision) is unit-tested.
+type ipRepointPlan struct {
+	Change        bool   // false → public_ipv4 and the default row already match ownIP
+	OwnIP         string // this box's detected IPv4
+	OldDefaultIP  string // the default managed IP before the re-point ("" if none)
+	OldPublicIPv4 string
+	// Collision is set when ownIP already exists as a DIFFERENT managed_ips row
+	// (address has a unique index). We refuse rather than half-repoint — the
+	// operator resolves it, since flipping is_default there would also strand
+	// domains whose listen_ipv4_id points at the old default row.
+	Collision bool
+}
+
+// repointPlan computes what the re-point should do. defaultRow is the current
+// is_default IPv4 row (nil if none); ownIPRow is the row already holding ownIP
+// (nil if none) — used only to detect the unique-index collision.
+func repointPlan(ownIP string, defaultRow, ownIPRow *models.ManagedIP, settings *models.ServerSettings) ipRepointPlan {
+	p := ipRepointPlan{OwnIP: ownIP}
+	if settings != nil {
+		p.OldPublicIPv4 = settings.PublicIPv4
+	}
+	if defaultRow != nil {
+		p.OldDefaultIP = defaultRow.Address
+	}
+	alreadyDefault := defaultRow != nil && defaultRow.Address == ownIP
+	alreadyPublic := settings != nil && settings.PublicIPv4 == ownIP
+	if alreadyDefault && alreadyPublic {
+		return p // no-op
+	}
+	// A row already holding ownIP that is NOT the default row we'd update in
+	// place = unique-index collision.
+	if ownIPRow != nil && (defaultRow == nil || ownIPRow.ID != defaultRow.ID) {
+		p.Collision = true
+		return p
+	}
+	p.Change = true
+	return p
+}
+
+// repointDefaultIP applies the re-point: it updates the default IPv4 managed_ips
+// row's address in place (preserving its id so domains' listen_ipv4_id
+// references stay valid, M24) and sets settings.PublicIPv4. The caller persists
+// settings (the role-flip Upsert already does). Returns a human summary line,
+// or an error the promote surfaces without flipping.
+func repointDefaultIP(ctx context.Context, ips repository.ManagedIPRepository, settings *models.ServerSettings, ownIP string) (string, error) {
+	defaultRow, derr := ips.FindDefaultByFamily(ctx, "ipv4")
+	if derr != nil {
+		return "", fmt.Errorf("read default IPv4 managed IP: %w", derr)
+	}
+	ownIPRow, aerr := ips.FindByAddress(ctx, ownIP)
+	if aerr != nil {
+		return "", fmt.Errorf("look up managed IP %s: %w", ownIP, aerr)
+	}
+	plan := repointPlan(ownIP, defaultRow, ownIPRow, settings)
+	if plan.Collision {
+		return "", fmt.Errorf("this box's IP %s is already a non-default managed IP; re-point manually "+
+			"(set it default and repoint domains) — refusing to half-repoint", ownIP)
+	}
+	if !plan.Change {
+		return fmt.Sprintf("default IPv4 already %s — no re-point needed", ownIP), nil
+	}
+	if defaultRow != nil {
+		defaultRow.Address = ownIP
+		// The box's own primary IP is bound by the OS, not the agent's
+		// ip-addr-add loop; mark bound so the rebind loop leaves it alone.
+		defaultRow.IsBound = true
+		defaultRow.Degraded = false
+		if uerr := ips.Update(ctx, defaultRow); uerr != nil {
+			return "", fmt.Errorf("re-point default IPv4 managed IP to %s: %w", ownIP, uerr)
+		}
+	} else if eerr := ips.EnsureDefault(ctx, ownIP, "ipv4"); eerr != nil {
+		return "", fmt.Errorf("seed default IPv4 managed IP %s: %w", ownIP, eerr)
+	}
+	settings.PublicIPv4 = ownIP
+	return fmt.Sprintf("re-pointed default IPv4 %s → %s (public_ipv4 updated)", orDefault(plan.OldDefaultIP, "none"), ownIP), nil
+}

--- a/panel-api/cmd/server/dr_promote_ip_test.go
+++ b/panel-api/cmd/server/dr_promote_ip_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestRepointPlan(t *testing.T) {
+	def := func(id uint64, addr string) *models.ManagedIP {
+		return &models.ManagedIP{ID: id, Address: addr, Family: "ipv4", IsDefault: true}
+	}
+	tests := []struct {
+		name          string
+		ownIP         string
+		defaultRow    *models.ManagedIP
+		ownIPRow      *models.ManagedIP
+		publicIPv4    string
+		wantChange    bool
+		wantCollision bool
+	}{
+		{
+			name:       "already default and public → no-op",
+			ownIP:      "203.0.113.9",
+			defaultRow: def(1, "203.0.113.9"),
+			publicIPv4: "203.0.113.9",
+			wantChange: false,
+		},
+		{
+			name:       "default address is old primary → re-point in place",
+			ownIP:      "203.0.113.9",
+			defaultRow: def(1, "198.51.100.7"),
+			publicIPv4: "198.51.100.7",
+			wantChange: true,
+		},
+		{
+			name:       "default matches but public_ipv4 stale → still a change",
+			ownIP:      "203.0.113.9",
+			defaultRow: def(1, "203.0.113.9"),
+			publicIPv4: "198.51.100.7",
+			wantChange: true,
+		},
+		{
+			name:          "own IP already a different managed row → collision, refuse",
+			ownIP:         "203.0.113.9",
+			defaultRow:    def(1, "198.51.100.7"),
+			ownIPRow:      &models.ManagedIP{ID: 2, Address: "203.0.113.9", Family: "ipv4"},
+			publicIPv4:    "198.51.100.7",
+			wantChange:    false,
+			wantCollision: true,
+		},
+		{
+			name:       "own IP row IS the default row → in-place, not a collision",
+			ownIP:      "203.0.113.9",
+			defaultRow: def(1, "203.0.113.9"),
+			ownIPRow:   def(1, "203.0.113.9"),
+			publicIPv4: "198.51.100.7",
+			wantChange: true,
+		},
+		{
+			name:       "no default row yet → seed (change)",
+			ownIP:      "203.0.113.9",
+			defaultRow: nil,
+			publicIPv4: "",
+			wantChange: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &models.ServerSettings{PublicIPv4: tt.publicIPv4}
+			p := repointPlan(tt.ownIP, tt.defaultRow, tt.ownIPRow, s)
+			if p.Change != tt.wantChange {
+				t.Errorf("Change = %v, want %v", p.Change, tt.wantChange)
+			}
+			if p.Collision != tt.wantCollision {
+				t.Errorf("Collision = %v, want %v", p.Collision, tt.wantCollision)
+			}
+			if p.OwnIP != tt.ownIP {
+				t.Errorf("OwnIP = %q, want %q", p.OwnIP, tt.ownIP)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/dr_promote_php.go
+++ b/panel-api/cmd/server/dr_promote_php.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// drAgentCaller is the slice of *agent.Client the promote convergence needs, so
+// the PHP/version logic is unit-tested with a fake.
+type drAgentCaller interface {
+	Call(ctx context.Context, command string, params any) (json.RawMessage, error)
+}
+
+// GH #1169 gap 5 — converge required PHP versions + force pool re-apply at promote.
+//
+// A promoted standby is an EMPTY host carrying the old primary's DB. The
+// replicated php_pools rows demand whatever PHP versions the tenants used and
+// are marked status=active — but the reconciler skips active pools, so it never
+// renders them onto the empty box, and a pool whose PHP version isn't installed
+// would fail to render anyway. Promote therefore (1) installs every PHP version
+// the pools require but the box lacks, then (2) flips active pools to pending so
+// the reconciler re-renders them from the template on its next tick — the same
+// primitive `jabali php pool reapply-all` uses (GH #401).
+
+// missingPHPVersions returns the versions in required that are not installed,
+// de-duplicated and sorted. Pure so the promote convergence is unit-tested
+// without an agent or DB.
+func missingPHPVersions(required, installed []string) []string {
+	have := make(map[string]struct{}, len(installed))
+	for _, v := range installed {
+		have[v] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, v := range required {
+		if v == "" {
+			continue
+		}
+		if _, ok := have[v]; ok {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// markActivePoolsPending flips every active php_pools row to pending so the
+// reconciler re-renders it from the current template. Shared by
+// `jabali php pool reapply-all` (GH #401) and promote (GH #1169). Returns the
+// count flipped.
+func markActivePoolsPending(ctx context.Context, repo repository.PHPPoolRepository) (int, error) {
+	pools, _, err := repo.ListAll(ctx, repository.ListOptions{Limit: 100000})
+	if err != nil {
+		return 0, fmt.Errorf("list pools: %w", err)
+	}
+	n := 0
+	for i := range pools {
+		if pools[i].Status != "active" {
+			continue
+		}
+		if serr := repo.SetStatus(ctx, pools[i].ID, "pending", nil); serr != nil {
+			return n, fmt.Errorf("mark pool %s pending: %w", pools[i].ID, serr)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// promoteConvergePHP installs missing PHP versions the replicated pools require,
+// then marks active pools pending for re-render. Best-effort on install (a box
+// with no internet still promotes; the operator sees the warning and the pool
+// stays pending until PHP is present), but a pool-repo error is fatal — the flip
+// must not proceed on a half-known pool set.
+func promoteConvergePHP(ctx context.Context, repo repository.PHPPoolRepository, agent drAgentCaller) error {
+	pools, _, err := repo.ListAll(ctx, repository.ListOptions{Limit: 100000})
+	if err != nil {
+		return fmt.Errorf("list php pools: %w", err)
+	}
+	required := make([]string, 0, len(pools))
+	for i := range pools {
+		required = append(required, pools[i].PHPVersion)
+	}
+
+	installed, ierr := listInstalledPHPVersionsViaAgent(ctx, agent)
+	if ierr != nil {
+		fmt.Printf("  WARNING: could not list installed PHP versions (%v); skipping auto-install — "+
+			"pools stay pending until their PHP version is present.\n", ierr)
+	} else {
+		for _, v := range missingPHPVersions(required, installed) {
+			fmt.Printf("  installing missing PHP %s (required by a replicated pool)…\n", v)
+			if _, aerr := agent.Call(ctx, "php.version.install", map[string]any{"version": v}); aerr != nil {
+				fmt.Printf("    WARNING: php.version.install %s failed: %v — pool stays pending until installed.\n", v, aerr)
+			}
+		}
+	}
+
+	n, merr := markActivePoolsPending(ctx, repo)
+	if merr != nil {
+		return merr
+	}
+	fmt.Printf("  marked %d active pool(s) pending; the reconciler will render them onto this box.\n", n)
+	return nil
+}
+
+// listInstalledPHPVersionsViaAgent calls php.version.list and returns the
+// installed version strings.
+func listInstalledPHPVersionsViaAgent(ctx context.Context, agent drAgentCaller) ([]string, error) {
+	raw, err := agent.Call(ctx, "php.version.list", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		Versions []string `json:"versions"`
+	}
+	if jerr := json.Unmarshal(raw, &out); jerr != nil {
+		return nil, fmt.Errorf("parse php.version.list: %w", jerr)
+	}
+	return out.Versions, nil
+}

--- a/panel-api/cmd/server/dr_promote_php_test.go
+++ b/panel-api/cmd/server/dr_promote_php_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMissingPHPVersions(t *testing.T) {
+	tests := []struct {
+		name      string
+		required  []string
+		installed []string
+		want      []string
+	}{
+		{"all present", []string{"8.3", "8.4"}, []string{"8.3", "8.4", "8.5"}, nil},
+		{"one missing", []string{"8.3", "8.5"}, []string{"8.3", "8.4"}, []string{"8.5"}},
+		{"dedup + sort", []string{"8.5", "8.3", "8.5"}, []string{"8.4"}, []string{"8.3", "8.5"}},
+		{"empty version skipped", []string{"", "8.5"}, []string{}, []string{"8.5"}},
+		{"nothing required", nil, []string{"8.4"}, nil},
+		{"nothing installed", []string{"8.4"}, nil, []string{"8.4"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := missingPHPVersions(tt.required, tt.installed)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("missingPHPVersions(%v,%v) = %v, want %v", tt.required, tt.installed, got, tt.want)
+			}
+		})
+	}
+}

--- a/panel-api/cmd/server/php_cmd.go
+++ b/panel-api/cmd/server/php_cmd.go
@@ -356,20 +356,9 @@ func newPHPPoolReapplyAllCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 60*time.Second)
 			defer cancel()
-			repo := repository.NewPHPPoolRepository(sharedDB)
-			pools, _, err := repo.ListAll(ctx, repository.ListOptions{Limit: 100000})
+			n, err := markActivePoolsPending(ctx, repository.NewPHPPoolRepository(sharedDB))
 			if err != nil {
-				return fmt.Errorf("list pools: %w", err)
-			}
-			n := 0
-			for i := range pools {
-				if pools[i].Status != "active" {
-					continue
-				}
-				if err := repo.SetStatus(ctx, pools[i].ID, "pending", nil); err != nil {
-					return fmt.Errorf("mark pool %s pending: %w", pools[i].ID, err)
-				}
-				n++
+				return err
 			}
 			fmt.Printf("marked %d active pool(s) pending; reconciler will re-render them from the template\n", n)
 			return nil


### PR DESCRIPTION
Turns the four promote-time #331 DR-drill gaps into product behavior. Backend/CLI + one agent stage, **unit-verified** — the true acceptance is the next two-node drill (checklist below), same as #331 Steps 2–4.

## Delivered

### Gap 1 — IP re-point at promote (cutover-critical)
`managed_ips` + `server_settings.public_ipv4` replicate the OLD primary's address, so post-promote every rebuilt vhost binds an IP this box doesn't own and nothing serves. Promote re-points the default IPv4 managed IP + `public_ipv4` to this box's own egress IPv4 — **after** the final restore (`StagePanelDB` replaces the DB, wiping any earlier write), folded into the role-flip `Upsert` while the panel is fenced. Injectable `detectOwnIPv4` + pure `repointPlan` (no-op / in-place update / unique-index collision-refuse). In-place update preserves the row id so domains' `listen_ipv4_id` stay valid (M24). Confirm unless `--yes`.

### Gap 5 — converge PHP at promote
Replicated `php_pools` demand PHP versions the empty box lacks and are marked `active` (reconciler skips those). Promote installs missing versions (`php.version.list` diff → `php.version.install`), then flips active pools to `pending` so the reconciler renders them — reusing the GH #401 primitive (`markActivePoolsPending`, now shared with the CLI). Best-effort install.

### Gap 3a — hard-warn on an empty account restore
The drill's first promote "succeeded" while restoring **zero** tenant data. Promote detects the agent's `no account_backup manifest snapshots found` signal and prints a loud, unmissable block.

### Gap 3b — dr feed ships account backups to the DR channel
Root cause of the empty restore: `dr feed` shipped only `system_backup`, so account manifests were never in the DR repo. `dr feed` now creates a `kind=account_backup` schedule with `IncludeSystemBackup=true` and **no explicit users** — which fans out to ALL non-admin tenants and fires the system backup on the same tick, so one schedule ships all tenant data + the control plane. A legacy system-only feed is upgraded in place. The finder is broadened via `isDRFeedSchedule` (system_backup OR account_backup+IncludeSystemBackup — a reliable DR marker tenants never set); `unfeed` reuses it.

### Gap 4 — ownership normalization after cross-host restore
rsync preserves the SOURCE box's numeric uid/gid, but system accounts (jabali, jabali-mail) can hold different ids on the two boxes — so `sso.key` and secrets become unreadable by the local panel (the drill's half-break). After the panel_config rsync, each file's source uid/gid is resolved → NAME (from the restore's own `os_users.json`) → LOCAL id and chowned by name. **Not** a blanket chown — that would widen group-read on a multi-owner secret tree (security regression). Best-effort.

## Unit tests
`repointPlan` (6 cases), `missingPHPVersions` (5), `isDRFeedSchedule` (3), `remapID` (5).

## Deferred
- **Gap 2 (feed retention)** — split out: system-backup retention is **entirely unwired** (`dispatchSystem` passes no keep params, agent runs no `restic forget`, `server_settings.BackupKeep*` are dead fields, `backup.forget` is snapshot-id-specific). It's a new snapshot-**deleting** path that wants a drill. Tracked separately.
- Visibility (`dr.sync.stalled`, admin DR card) + runbook items stay open on #1169.

## Verify at next two-node drill
- [ ] Promote → default managed IP + `public_ipv4` become the standby's own IP; vhosts bind + serve.
- [ ] A pool demanding an uninstalled PHP version → promote installs it + the pool renders.
- [ ] Promote against a system-only DR repo → the empty-account hard-warn fires.
- [ ] `dr feed` → DR repo accrues `account_backup` manifests; promote restores tenant data non-empty.
- [ ] Promote where the standby's `jabali` uid differs from the primary's → panel reads `sso.key` + serves (no half-break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
