### PR TITLE
perf(events): disk-quota alerts read the persisted sweeper snapshot, not per-user agent calls (JAB-376)

### DIFF
--- a/panel-api/internal/eventsources/disk_quota.go
+++ b/panel-api/internal/eventsources/disk_quota.go
@@ -2,7 +2,6 @@ package eventsources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -18,22 +17,44 @@ const (
 	// any more" boundary; warning before that gives the user time to
 	// clean up before write failures hit.
 	diskQuotaPercent = 90.0
+
+	// diskQuotaMaxAge is the freshness ceiling for a persisted snapshot.
+	// The disk-usage sweeper (internal/diskusagesweeper) refreshes
+	// disk_checked_at every 15 min, but a full pass on a ~5,000-account
+	// host spends ~21 min in inter-user pacing alone before command and
+	// DB time, so a snapshot can legitimately trail more than one
+	// interval. 2h clears a lagging sweep yet still refuses one that is
+	// wedged (agent down, disk hung) — and it sits well under the 6h
+	// per-user cooloff, so a genuinely near-full account is never
+	// silenced by the age gate between alerts (JAB-376 AC #7).
+	diskQuotaMaxAge = 2 * time.Hour
 )
 
 // runDiskQuota iterates every hosting user (those with a non-empty
-// username, i.e. excluded admins) every 30 minutes, asks the agent
-// for their current disk-quota report, and fires a per-user
-// envelope when used / hard ≥ 90%. 6-hour cooldown per user so a
-// chronically-near-full account doesn't spam.
+// username, i.e. excluded admins) every 30 minutes and fires a
+// per-user envelope when used / hard ≥ 90%. 6-hour cooldown per user
+// so a chronically-near-full account doesn't spam.
 //
-// No-op when Users repo, Agent, or QuotaMount aren't wired (CI/dev
-// boxes without /home as a separate fs).
+// It reads the disk figures the disk-usage sweeper already persists
+// on each user row (disk_used_kb / disk_limit_kb / disk_checked_at)
+// rather than re-polling the agent per user: the sweeper measures the
+// same POSIX quota state every 15 minutes, so a second per-user
+// user.limits.report loop here was ~2,000 redundant Agent calls per
+// hour on a 1,000-account host (JAB-376 AC #3 — zero Agent calls). A
+// snapshot older than diskQuotaMaxAge is refused rather than alerted
+// on (AC #7).
+//
+// No-op when Users or QuotaMount aren't wired (CI/dev boxes without
+// /home as a separate fs never populate a meaningful snapshot).
 func runDiskQuota(ctx context.Context, d Deps) {
-	if d.Users == nil || d.Agent == nil || d.QuotaMount == "" {
-		d.Log.Debug("eventsources: disk_quota disabled — missing Users/Agent/QuotaMount")
+	if d.Users == nil || d.QuotaMount == "" {
+		d.Log.Debug("eventsources: disk_quota disabled — missing Users/QuotaMount")
 		return
 	}
-	// One-shot at boot.
+	// One-shot at boot. Note: a fresh install has no snapshot yet, so
+	// the first meaningful pass is after the sweeper's first sweep
+	// (~15 min) rather than an immediate live poll — deliberate, per
+	// AC #7 (never alert on data we haven't observed).
 	diskQuotaPass(ctx, d)
 	tick := time.NewTicker(diskQuotaTick)
 	defer tick.Stop()
@@ -47,45 +68,32 @@ func runDiskQuota(ctx context.Context, d Deps) {
 	}
 }
 
-type quotaReportShape struct {
-	Disk *struct {
-		UsedKB  uint64 `json:"used_kb"`
-		LimitKB uint64 `json:"limit_kb"`
-	} `json:"disk,omitempty"`
-}
-
 func diskQuotaPass(ctx context.Context, d Deps) {
 	users, _, err := d.Users.List(ctx, repository.ListOptions{Limit: 5000})
 	if err != nil {
 		d.Log.Warn("eventsources: disk_quota list users failed", "err", err)
 		return
 	}
-	for _, u := range users {
+	now := d.Now()
+	for i := range users {
+		u := &users[i]
 		if u.Username == nil || *u.Username == "" {
 			continue
 		}
-		// Per-user agent call. 5s timeout — agent quota read is
-		// microseconds, the timeout is for the unix socket
-		// round-trip under load.
-		callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		raw, err := d.Agent.Call(callCtx, "user.limits.report", map[string]any{
-			"username":    *u.Username,
-			"quota_mount": d.QuotaMount,
-		})
-		cancel()
-		if err != nil {
-			// Common case: user not yet provisioned on disk —
-			// quota tools return non-zero. Quiet skip.
-			continue
+		// AC #7: a stale or failed sweep leaves an old disk_checked_at
+		// (or nil for never-swept). Refuse to alert on a figure that may
+		// no longer hold rather than firing on last-good data past the
+		// freshness ceiling.
+		if u.DiskCheckedAt == nil {
+			continue // never swept — no observation yet
 		}
-		var rep quotaReportShape
-		if err := json.Unmarshal(raw, &rep); err != nil {
-			continue
+		if now.Sub(*u.DiskCheckedAt) > diskQuotaMaxAge {
+			continue // sweeper lagging/wedged — last-good too old to alert on
 		}
-		if rep.Disk == nil || rep.Disk.LimitKB == 0 {
+		if u.DiskLimitKB == 0 {
 			continue // unlimited or unconfigured — nothing to alert on
 		}
-		pct := float64(rep.Disk.UsedKB) / float64(rep.Disk.LimitKB) * 100.0
+		pct := float64(u.DiskUsedKB) / float64(u.DiskLimitKB) * 100.0
 		if pct < diskQuotaPercent {
 			continue
 		}
@@ -99,7 +107,7 @@ func diskQuotaPass(ctx context.Context, d Deps) {
 			Title:     fmt.Sprintf("%s at %.0f%% of disk quota", *u.Username, pct),
 			Body: fmt.Sprintf(
 				"User %s used %d KB of %d KB hard limit (%.1f%%). (%s)",
-				*u.Username, rep.Disk.UsedKB, rep.Disk.LimitKB, pct, tag,
+				*u.Username, u.DiskUsedKB, u.DiskLimitKB, pct, tag,
 			),
 			Deeplink: "/jabali-admin/users",
 			UserID:   u.ID,

--- a/panel-api/internal/eventsources/disk_quota_test.go
+++ b/panel-api/internal/eventsources/disk_quota_test.go
@@ -1,0 +1,160 @@
+package eventsources
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes ---
+
+// fakeUserLister embeds the wide repository.UserRepository and overrides
+// only List — the one method diskQuotaPass touches. The embedding keeps
+// the fake to the slice under test without hand-writing the whole
+// interface (feedback: interface-embedding fakes).
+type fakeUserLister struct {
+	repository.UserRepository
+	users []models.User
+}
+
+func (f fakeUserLister) List(_ context.Context, _ repository.ListOptions) ([]models.User, int64, error) {
+	return f.users, int64(len(f.users)), nil
+}
+
+// failAgent hard-fails the test if disk_quota ever calls the agent. AC #3
+// requires the alert path to consume the persisted snapshot and make zero
+// Agent calls — this turns that from a claim into a guard.
+type failAgent struct{ t *testing.T }
+
+func (a failAgent) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
+	a.t.Fatalf("disk_quota must not call the agent (AC #3); got Call(%q)", method)
+	return nil, nil
+}
+
+func diskUser(username string, usedKB, limitKB uint64, checkedAt *time.Time) models.User {
+	return models.User{
+		ID:            "u-" + username,
+		Username:      strPtr(username),
+		DiskUsedKB:    usedKB,
+		DiskLimitKB:   limitKB,
+		DiskCheckedAt: checkedAt,
+	}
+}
+
+func diskQuotaDeps(t *testing.T, now time.Time, users []models.User) (Deps, *capturingPublisher) {
+	pub := &capturingPublisher{}
+	return Deps{
+		Queue:      pub,
+		History:    &fakeHistory{},
+		Users:      fakeUserLister{users: users},
+		Agent:      failAgent{t: t}, // must never be called
+		QuotaMount: "/home",
+		Log:        slog.New(slog.DiscardHandler),
+		Now:        func() time.Time { return now },
+	}, pub
+}
+
+// --- tests ---
+
+func TestDiskQuota_FreshOverThreshold_Fires(t *testing.T) {
+	now := fixedNow()
+	fresh := tsPtr(now.Add(-5 * time.Minute))
+	// 95 GB / 100 GB = 95% ≥ 90% floor.
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 95*1024*1024, 100*1024*1024, fresh),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 1, pub.Count(), "fresh over-threshold snapshot must fire")
+	env := pub.Last()
+	require.Equal(t, "disk.quota.warn", env.EventKind)
+	require.Equal(t, "u-alice", env.UserID)
+	require.Contains(t, env.Body, "user:alice")
+}
+
+func TestDiskQuota_NeverSwept_Refused(t *testing.T) {
+	now := fixedNow()
+	// DiskCheckedAt nil — no observation yet. Even though used/limit
+	// would breach, there is nothing to alert on.
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 99*1024*1024, 100*1024*1024, nil),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "never-swept snapshot must be refused")
+}
+
+func TestDiskQuota_StaleSnapshot_Refused(t *testing.T) {
+	now := fixedNow()
+	// Swept, but the snapshot is older than the freshness ceiling — the
+	// sweeper is lagging or wedged; last-good is too old to alert on.
+	stale := tsPtr(now.Add(-(diskQuotaMaxAge + time.Minute)))
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 99*1024*1024, 100*1024*1024, stale),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "snapshot older than diskQuotaMaxAge must be refused")
+}
+
+func TestDiskQuota_JustWithinMaxAge_Fires(t *testing.T) {
+	now := fixedNow()
+	// Exactly at the ceiling minus a second — still fresh enough.
+	edge := tsPtr(now.Add(-(diskQuotaMaxAge - time.Second)))
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 91*1024*1024, 100*1024*1024, edge),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 1, pub.Count(), "snapshot within max age must fire")
+}
+
+func TestDiskQuota_ZeroLimit_Skipped(t *testing.T) {
+	now := fixedNow()
+	fresh := tsPtr(now.Add(-time.Minute))
+	// LimitKB 0 = unlimited/unconfigured — no percentage, nothing to alert.
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 500*1024*1024, 0, fresh),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "zero hard limit must be skipped (no division)")
+}
+
+func TestDiskQuota_UnderThreshold_Skipped(t *testing.T) {
+	now := fixedNow()
+	fresh := tsPtr(now.Add(-time.Minute))
+	// 50% — well under the 90% floor.
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 50*1024*1024, 100*1024*1024, fresh),
+	})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "under-threshold usage must not fire")
+}
+
+func TestDiskQuota_AdminNoUsername_Skipped(t *testing.T) {
+	now := fixedNow()
+	fresh := tsPtr(now.Add(-time.Minute))
+	// Admin row: nil username. Would breach if considered, but disk
+	// quota only applies to hosting accounts.
+	admin := models.User{ID: "admin", Username: nil, DiskUsedKB: 99, DiskLimitKB: 100, DiskCheckedAt: fresh}
+	d, pub := diskQuotaDeps(t, now, []models.User{admin})
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "row without a username must be skipped")
+}
+
+func TestDiskQuota_CooloffDeduped(t *testing.T) {
+	now := fixedNow()
+	fresh := tsPtr(now.Add(-time.Minute))
+	d, pub := diskQuotaDeps(t, now, []models.User{
+		diskUser("alice", 95*1024*1024, 100*1024*1024, fresh),
+	})
+	// Pre-seed history with a recent fire carrying the dedupe tag →
+	// shouldFire returns false, second pass must not double-fire.
+	hist := d.History.(*fakeHistory)
+	hist.recordFired("disk.quota.warn", "... (user:alice)", now.Add(-1*time.Hour))
+	diskQuotaPass(context.Background(), d)
+	require.Equal(t, 0, pub.Count(), "within 6h cooloff must not re-fire")
+}

--- a/panel-api/internal/eventsources/sources.go
+++ b/panel-api/internal/eventsources/sources.go
@@ -71,9 +71,11 @@ type Deps struct {
 	Log         *slog.Logger
 	Now         Clock
 	CrowdSecBin string // path to cscli; empty → disable the crowdsec source
-	// disk_quota source — needs Users + Agent + QuotaMount to call
-	// agent.user.limits.report per user. All three required; missing
-	// any disables the source rather than panicking.
+	// disk_quota source — reads the disk snapshot the disk-usage
+	// sweeper persists on each user row (no per-user Agent call); needs
+	// Users + QuotaMount. Agent stays here for the other sources that
+	// do call it (nginx_config, snuffleupagus, exec_audit_burst,
+	// aide_tamper, domain_ghost).
 	Users      repository.UserRepository
 	Agent      AgentCaller
 	QuotaMount string


### PR DESCRIPTION
## What

The `disk_quota` event source polled the agent **once per hosting user every 30 min** (`user.limits.report`), duplicating the disk-usage sweeper — which already measures the same POSIX quota state every 15 min and persists `disk_used_kb` / `disk_limit_kb` / `disk_checked_at` on each user row. At 1,000 accounts that is ~2,000 redundant Agent calls (and external `quota` process launches) per hour.

The source now consumes that persisted snapshot instead of re-polling.

## Why (JAB-376)

Concrete observation-consumer slice of the *Host Quota Snapshot* performance ticket:

- **AC #3 — zero Agent calls on the alert path.** The snapshot is read straight from `Users.List` (which selects all user columns, disk fields included). A test wires an Agent fake whose `Call` fails the test, so "zero agent calls" is a guard, not a claim.
- **AC #7 — refuse stale/unobserved data.** `nil disk_checked_at` (never swept) is skipped; a snapshot older than `diskQuotaMaxAge` (2h) is skipped. 2h is derived from the sweeper's worst-case full-pass time (15 min interval + ~21 min inter-user pacing on a 5,000-account host + command/DB time) and kept well under the 6h per-user cooloff so a genuinely near-full account is never silenced by the age gate.
- **AC "does not touch `users.updated_at`"** — already satisfied: the sweeper persists via `UpdateColumns`, not `Update`.

Gate drops the Agent requirement (now `Users` + `QuotaMount`); `Deps.Agent` stays wired for the five other sources that still call it (nginx_config, snuffleupagus, exec_audit_burst, aide_tamper, domain_ghost).

## Behaviour delta

A fresh install alerts only after the sweeper's first sweep (~15 min) rather than an immediate boot-time live poll — deliberate, per AC #7 (never alert on data we haven't observed).

## Scope

This is the **observation-consumer slice only**. The parent JAB-376 stays **open** for the Module proper: the Agent-side single privileged quota-inventory read, ext4/XFS adapters behind a seam, batch/chunked snapshot persistence, and the before/after benchmarks.

## Test plan

- [x] `go test ./panel-api/internal/eventsources/` — new `disk_quota_test.go`: fresh-over-threshold fires; never-swept refused; stale (> max age) refused; just-within-max-age fires; zero-limit skipped; under-threshold skipped; admin (nil username) skipped; cooloff dedupe. Agent fake fails on any call (AC #3 guard).
- [x] `go build ./panel-api/...`, `go vet ./panel-api/internal/eventsources/` clean.
- [ ] No migration, no CLI change → no golden regen.

GH: JAB-376 (slice)