### PR TITLE
fix(users): tear down orphaned per-user PHP nspawn units on delete + self-heal existing boxes (JAB-225)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15127,6 +15127,43 @@ ensure_stalwart_not_in_panel_group() {
   fi
 }
 
+# reap_orphan_nspawn_php_units — JAB-225 self-heal for orphaned per-user PHP
+# nspawn units. Current code never creates systemd-nspawn@<user>-php.service
+# (bubblewrap replaced per-user nspawn containers), but a box carried over from
+# the M13-nspawn era can still have units enabled for accounts that were later
+# deleted. With the account and its machine image gone, an enabled unit fails on
+# EVERY boot ("No image for machine '<user>-php'"), permanently padding
+# `systemctl --failed` — a health signal operators are trained to trust. The
+# user.delete path now tears these down inline; this converger cleans up the
+# ones orphaned before that shipped, on every `jabali update`.
+#
+# Double guard: reap only when BOTH the OS user is gone AND no machine image
+# remains — a live container always has an image, so a real workload can never
+# be caught here even if a username is mis-parsed.
+reap_orphan_nspawn_php_units() {
+  local reaped=0 link svc inst user
+  shopt -s nullglob
+  # Enabled template instances surface as .wants symlinks (that is literally
+  # what `systemctl enable` creates) — dependency-free to enumerate.
+  for link in /etc/systemd/system/*.wants/systemd-nspawn@*-php.service; do
+    svc=$(basename "$link")          # systemd-nspawn@<inst>.service
+    inst=${svc#systemd-nspawn@}      # <inst>.service
+    inst=${inst%.service}            # <inst>  (== <user>-php)
+    user=${inst%-php}                # <user>
+    [[ -z "$user" || "$user" == "$inst" ]] && continue
+    id "$user" >/dev/null 2>&1 && continue          # OS user still exists → keep
+    [[ -e "/var/lib/machines/${inst}" ]] && continue # image present → keep
+    systemctl disable --now "$svc" >/dev/null 2>&1 || true
+    systemctl reset-failed "$svc" >/dev/null 2>&1 || true
+    rm -f "/etc/systemd/nspawn/${inst}.nspawn" 2>/dev/null || true
+    reaped=$((reaped + 1))
+  done
+  shopt -u nullglob
+  if [[ "$reaped" -gt 0 ]]; then
+    _ok "reaped $reaped orphaned per-user PHP nspawn unit(s) (JAB-225)"
+  fi
+}
+
 # provision_php_extensions — self-heal PHP runtime extensions on every
 # `jabali update`. install_base_packages installs the ext set only on a full
 # install and only for JABALI_PHP_VERSIONS, so a newly-required extension (e.g.
@@ -15212,6 +15249,11 @@ provision_new_software() {
   # group is dead weight for mail and let a mail compromise reach the root Agent
   # socket at the FS layer.
   ensure_stalwart_not_in_panel_group
+
+  # JAB-225: reap per-user PHP nspawn units orphaned before user.delete learned
+  # to tear them down — else each fails on every boot and pads `systemctl
+  # --failed` forever.
+  reap_orphan_nspawn_php_units
 
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator

--- a/install/tests/test_nspawn_orphan_reap.sh
+++ b/install/tests/test_nspawn_orphan_reap.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# install/tests/test_nspawn_orphan_reap.sh — JAB-225.
+#
+# Deleting a PHP-container user used to leave systemd-nspawn@<user>-php.service
+# ENABLED. Current code never creates those units (bubblewrap replaced per-user
+# nspawn containers), but boxes carried over from the M13-nspawn era still have
+# them enabled for long-deleted accounts. With the account and its machine image
+# gone, an enabled unit fails on EVERY boot ("No image for machine
+# '<user>-php'") and permanently pads `systemctl --failed`.
+#
+# The fix has two halves:
+#   1. user.delete tears the unit down inline (agent-side; asserted by Go tests
+#      in panel-agent/internal/commands/nspawn_reap_test.go).
+#   2. reap_orphan_nspawn_php_units() self-heals units orphaned before (1)
+#      shipped, on every `jabali update` — asserted here.
+#
+# Static assertions only (like the JAB-357 socket-group test); the live
+# behaviour (fabricate an orphan → converge → reboot → 0 failed units) is the
+# .86 box check.
+#
+# Run from repo root:
+#     bash install/tests/test_nspawn_orphan_reap.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# 1. The converger must exist.
+if ! grep -qE '^reap_orphan_nspawn_php_units\(\)' install.sh; then
+  echo "FAIL: reap_orphan_nspawn_php_units() converger missing — orphaned units never get reaped on existing boxes"
+  fail=1
+fi
+
+# 2. It must be invoked inside provision_new_software (the `jabali update` sweep),
+#    or upgraded hosts (the only ones with residue) never run it.
+if ! awk '/^provision_new_software\(\)/{f=1} f&&/reap_orphan_nspawn_php_units/{found=1} f&&/^\}/{exit} END{exit !found}' install.sh; then
+  echo "FAIL: reap_orphan_nspawn_php_units is not called from provision_new_software — the self-heal never reaches upgraded hosts"
+  fail=1
+fi
+
+# 3. The double safety guard must be present: never reap while the OS user still
+#    exists, and never reap while a machine image remains (a live container
+#    always has one). Losing either guard turns a cleanup into a footgun.
+body=$(awk '/^reap_orphan_nspawn_php_units\(\)/{f=1} f{print} f&&/^\}/{exit}' install.sh)
+if ! grep -qE 'id "\$user"' <<<"$body"; then
+  echo "FAIL: reap_orphan_nspawn_php_units lost its OS-user guard (id \"\$user\") — could reap a live account's unit"
+  fail=1
+fi
+if ! grep -qE '/var/lib/machines/' <<<"$body"; then
+  echo "FAIL: reap_orphan_nspawn_php_units lost its machine-image guard (/var/lib/machines/...) — could reap a live container"
+  fail=1
+fi
+
+# 4. Teardown must reset-failed, not just disable: `disable` alone leaves the
+#    failed entry in `systemctl --failed` until the next reboot, which is the
+#    exact symptom the ticket is about.
+if ! grep -qE 'systemctl reset-failed' <<<"$body"; then
+  echo "FAIL: reap_orphan_nspawn_php_units does not reset-failed — the failed entry lingers until reboot (JAB-225 symptom)"
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "RESULT: FAIL"
+  exit 1
+fi
+echo "PASS: orphan nspawn reaper exists, wired into jabali update, double-guarded, resets failed state (JAB-225)"

--- a/panel-agent/internal/commands/nspawn_reap.go
+++ b/panel-agent/internal/commands/nspawn_reap.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// nspawnConfigRoot is where per-instance .nspawn config files live. A package
+// var (env-overridable) so tests can point it at a temp dir; production uses
+// the systemd default.
+func nspawnConfigRoot() string {
+	if r := os.Getenv("JABALI_NSPAWN_CONFIG_ROOT"); r != "" {
+		return r
+	}
+	return "/etc/systemd/nspawn"
+}
+
+// reapUserNspawnPHPUnit tears down the legacy per-user PHP nspawn unit
+// (systemd-nspawn@<user>-php.service) for a user being deleted (JAB-225).
+//
+// Current code never creates these units — per-user PHP containers were
+// replaced by bubblewrap — but a user carried over from the M13-nspawn era can
+// still own an *enabled* unit. Once the account (and its machine image) is
+// gone, an enabled unit fails on every boot with "No image for machine
+// '<user>-php'", padding `systemctl --failed` with a permanent dead entry.
+// user.delete removes the account, so this mirrors reapUserFPMPools and closes
+// the create-enabled / never-disabled-at-delete gap (same family as GH #754).
+//
+// Best-effort: every step tolerates an already-absent unit/config and never
+// returns an error. `reset-failed` is deliberate — `disable` alone leaves the
+// failed entry lingering in `systemctl --failed` until the next reboot.
+func reapUserNspawnPHPUnit(ctx context.Context, username string) {
+	if !usernameRegex.MatchString(username) {
+		return
+	}
+	instance := username + "-php"
+	unit := "systemd-nspawn@" + instance + ".service"
+
+	_ = execCommandContext(ctx, "systemctl", "disable", "--now", unit).Run()
+	_ = execCommandContext(ctx, "systemctl", "reset-failed", unit).Run()
+
+	// Remove any generated per-instance nspawn config (AC: "removes any
+	// generated unit/config").
+	_ = os.Remove(filepath.Join(nspawnConfigRoot(), instance+".nspawn"))
+}

--- a/panel-agent/internal/commands/nspawn_reap_test.go
+++ b/panel-agent/internal/commands/nspawn_reap_test.go
@@ -1,0 +1,81 @@
+package commands
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// recordExec swaps the exec seam for a recorder that captures every
+// (name, args...) invocation and returns a no-op success command. Restored on
+// cleanup.
+func recordExec(t *testing.T) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		calls = append(calls, append([]string{name}, args...))
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 0")
+	}
+	t.Cleanup(func() { execCommandContext = prev })
+	return &calls
+}
+
+func TestReapUserNspawnPHPUnit_TearsDownUnitAndConfig(t *testing.T) {
+	cfgDir := t.TempDir()
+	t.Setenv("JABALI_NSPAWN_CONFIG_ROOT", cfgDir)
+	// A leftover .nspawn config for the instance must be removed.
+	cfg := filepath.Join(cfgDir, "den-php.nspawn")
+	if err := os.WriteFile(cfg, []byte("[Exec]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := recordExec(t)
+	reapUserNspawnPHPUnit(context.Background(), "den")
+
+	wantUnit := "systemd-nspawn@den-php.service"
+	var sawDisable, sawReset bool
+	for _, c := range *calls {
+		if c[0] != "systemctl" {
+			t.Fatalf("only systemctl calls expected, got %v", c)
+		}
+		switch {
+		case len(c) == 4 && c[1] == "disable" && c[2] == "--now" && c[3] == wantUnit:
+			sawDisable = true
+		case len(c) == 3 && c[1] == "reset-failed" && c[2] == wantUnit:
+			sawReset = true
+		}
+	}
+	if !sawDisable {
+		t.Errorf("expected `systemctl disable --now %s`; calls=%v", wantUnit, *calls)
+	}
+	if !sawReset {
+		t.Errorf("expected `systemctl reset-failed %s` (disable alone leaves the failed entry); calls=%v", wantUnit, *calls)
+	}
+	if _, err := os.Stat(cfg); !os.IsNotExist(err) {
+		t.Errorf("expected %s removed, stat err=%v", cfg, err)
+	}
+}
+
+func TestReapUserNspawnPHPUnit_RejectsBadUsername(t *testing.T) {
+	calls := recordExec(t)
+	// A malformed username must never reach systemctl (no injection surface
+	// into the unit name).
+	reapUserNspawnPHPUnit(context.Background(), "../../etc/evil")
+	if len(*calls) != 0 {
+		t.Fatalf("bad username must issue no commands, got %v", *calls)
+	}
+}
+
+// TestReapUserNspawnPHPUnit_BestEffortNoConfig proves the missing-config case is
+// a silent no-op (the common case: unit enabled, no generated .nspawn file).
+func TestReapUserNspawnPHPUnit_BestEffortNoConfig(t *testing.T) {
+	t.Setenv("JABALI_NSPAWN_CONFIG_ROOT", t.TempDir())
+	calls := recordExec(t)
+	reapUserNspawnPHPUnit(context.Background(), "bob")
+	if len(*calls) != 2 {
+		t.Fatalf("expected exactly disable + reset-failed (2 calls), got %v", *calls)
+	}
+}

--- a/panel-agent/internal/commands/user_delete.go
+++ b/panel-agent/internal/commands/user_delete.go
@@ -72,6 +72,12 @@ func userDeleteHandler(ctx context.Context, params json.RawMessage) (any, error)
 	// the reconciler's orphan reaper (php.pool.reap-orphans) is the backstop.
 	reapUserFPMPools(ctx, p.Username)
 
+	// JAB-225: tear down the legacy per-user PHP nspawn unit
+	// (systemd-nspawn@<user>-php.service). Best-effort; the install.sh
+	// converger reap_orphan_nspawn_php_units is the self-heal backstop for
+	// units orphaned before this shipped.
+	reapUserNspawnPHPUnit(ctx, p.Username)
+
 	// Remove the per-user slice BEFORE userdel so systemd can still resolve the UID
 	// while stopping user@<uid>.service.
 	sliceParams, _ := json.Marshal(map[string]string{"username": p.Username}) // GH #694: Marshal, not string-concat


### PR DESCRIPTION
## What

Deleting a PHP-container user left `systemd-nspawn@<user>-php.service` **enabled**. Current code never creates these units (bubblewrap replaced per-user nspawn containers), but a box carried over from the M13-nspawn era still has them enabled for accounts later deleted. With the account and its machine image gone, an enabled unit fails on **every boot** — `No image for machine '<user>-php'` — permanently padding `systemctl --failed`. Same family as #754.

## Fix (both delete paths + self-heal)

**1. Inline teardown at delete** — `reapUserNspawnPHPUnit`, mirroring `reapUserFPMPools`, called from agent `user.delete`: `systemctl disable --now`, `reset-failed`, `rm` of any generated `.nspawn` config. Covers **HTTP and CLI** — both funnel through `userops.DeleteCascade` → agent `user.delete` (single call site). `reset-failed` is deliberate: `disable` alone leaves the failed entry until reboot.

**2. Self-heal** — `reap_orphan_nspawn_php_units()` runs on every `jabali update` (`provision_new_software`). Enumerates enabled instances via `.wants` symlinks; reaps one only when **both** the OS user is gone **and** no machine image remains (a live container always has an image).

## Why this layering

Finite legacy residue — current code can never recreate these — so a perpetual reconciler pass is disproportionate. An `install.sh` converger (mirrors JAB-357 `ensure_stalwart_not_in_panel_group`) cleans existing boxes on next update and finds nothing thereafter.

## Acceptance criteria

- [x] Delete runs `systemctl disable --now systemd-nspawn@<user>-php.service` + removes generated config, on **both** HTTP and CLI (single agent hook).
- [x] Self-heal reaps orphaned units: enabled + no OS user + no image ⇒ disable.
- [x] 0 failed units — box-verified.

## Test plan

- [x] `go test ./panel-agent/internal/commands/` — `nspawn_reap_test.go`: teardown command sequence via exec seam (GH #994), malformed-username reject, best-effort no-config. Exec-seam guard passes.
- [x] `bash install/tests/test_nspawn_orphan_reap.sh` — converger exists, wired into update sweep, both guards present, resets failed state.
- [x] `bash -n install.sh`, `go build ./panel-agent/...`, `go vet` clean.
- [x] **Box-verified on .86**: fabricated enabled orphan → reproduced `No image` failure (in `--failed`) → converger disabled it, removed symlink, `--failed` back to 0; sibling unit with a live OS user correctly spared. Restored to baseline.

GH: JAB-225
