### PR TITLE
perf(backups): user-scoped limit-override lookup in snapshot builder, not a whole-table scan (JAB-374)

### DIFF
--- a/panel-api/internal/backupmetadata/builder.go
+++ b/panel-api/internal/backupmetadata/builder.go
@@ -385,18 +385,21 @@ func Build(ctx context.Context, user *models.User, d Deps) *internalbackup.Accou
 		}
 	}
 	if d.LimitOverrides != nil {
-		all, _ := d.LimitOverrides.ListAll(ctx)
-		for _, lo := range all {
-			if lo.UserID != user.ID {
-				continue
-			}
+		// User-scoped lookup, not ListAll()+in-memory filter (JAB-374 AC#5):
+		// the override is one row keyed by user, but the old path read the
+		// entire user_limit_overrides table and scanned it for a match on
+		// every Build. Build runs once per account for manual, tenant, AND
+		// scheduled backups, so that whole-table scan multiplied across the
+		// fleet. FindByUserID returns ErrNotFound when the user has no
+		// override, which the guard treats as "no override" (m.LimitOverride
+		// stays nil) — identical to the old loop finding no match.
+		if lo, err := d.LimitOverrides.FindByUserID(ctx, user.ID); err == nil && lo != nil {
 			m.LimitOverride = &internalbackup.MetadataLimitOverride{
 				DiskQuotaMB: lo.DiskQuotaMB, CPUQuotaPercent: lo.CPUQuotaPercent,
 				MemoryLimitMB: lo.MemoryLimitMB,
 				IOReadMbps:    lo.IOReadMbps, IOWriteMbps: lo.IOWriteMbps,
 				MaxTasks: lo.MaxTasks,
 			}
-			break
 		}
 	}
 	if d.EgressPolicies != nil {

--- a/panel-api/internal/backupmetadata/builder_limitoverride_test.go
+++ b/panel-api/internal/backupmetadata/builder_limitoverride_test.go
@@ -1,0 +1,84 @@
+package backupmetadata
+
+import (
+	"context"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// fakeLimitOverrides embeds the wide UserLimitOverrideRepository and overrides
+// only the two methods this path touches. ListAll fails the test: JAB-374 AC#5
+// is that Build no longer scans the whole user_limit_overrides table, so any
+// call to ListAll here is a regression, not a claim to re-verify.
+type fakeLimitOverrides struct {
+	repository.UserLimitOverrideRepository
+	t         *testing.T
+	byUser    map[string]*models.UserLimitOverride
+	findCalls int
+}
+
+func (f *fakeLimitOverrides) FindByUserID(_ context.Context, userID string) (*models.UserLimitOverride, error) {
+	f.findCalls++
+	if lo, ok := f.byUser[userID]; ok {
+		return lo, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+func (f *fakeLimitOverrides) ListAll(context.Context) ([]models.UserLimitOverride, error) {
+	f.t.Fatalf("Build must not ListAll() the whole user_limit_overrides table (JAB-374 AC#5)")
+	return nil, nil
+}
+
+func u32(v uint32) *uint32 { return &v }
+
+func TestBuild_LimitOverride_UserScopedLookup(t *testing.T) {
+	user := &models.User{ID: "u-alice", Email: "alice@example.com"}
+	lo := &models.UserLimitOverride{
+		UserID:          "u-alice",
+		DiskQuotaMB:     u32(2048),
+		CPUQuotaPercent: u32(150),
+		MemoryLimitMB:   u32(1024),
+		IOReadMbps:      u32(50),
+		IOWriteMbps:     u32(40),
+		MaxTasks:        u32(200),
+	}
+	f := &fakeLimitOverrides{t: t, byUser: map[string]*models.UserLimitOverride{"u-alice": lo}}
+
+	// Only LimitOverrides wired; every other section skips (nil repo).
+	m := Build(context.Background(), user, Deps{LimitOverrides: f})
+
+	if f.findCalls != 1 {
+		t.Fatalf("expected exactly one FindByUserID call, got %d", f.findCalls)
+	}
+	if m.LimitOverride == nil {
+		t.Fatal("expected LimitOverride populated for a user with an override")
+	}
+	got := m.LimitOverride
+	if got.DiskQuotaMB == nil || *got.DiskQuotaMB != 2048 ||
+		got.CPUQuotaPercent == nil || *got.CPUQuotaPercent != 150 ||
+		got.MemoryLimitMB == nil || *got.MemoryLimitMB != 1024 ||
+		got.IOReadMbps == nil || *got.IOReadMbps != 50 ||
+		got.IOWriteMbps == nil || *got.IOWriteMbps != 40 ||
+		got.MaxTasks == nil || *got.MaxTasks != 200 {
+		t.Fatalf("override values not mapped correctly: %+v", got)
+	}
+}
+
+func TestBuild_LimitOverride_NoneForUser(t *testing.T) {
+	user := &models.User{ID: "u-bob", Email: "bob@example.com"}
+	// Store holds an override for a DIFFERENT user; FindByUserID returns
+	// ErrNotFound for bob → no LimitOverride section (identical to the old
+	// loop finding no matching row).
+	f := &fakeLimitOverrides{t: t, byUser: map[string]*models.UserLimitOverride{
+		"u-carol": {UserID: "u-carol", DiskQuotaMB: u32(512)},
+	}}
+
+	m := Build(context.Background(), user, Deps{LimitOverrides: f})
+
+	if m.LimitOverride != nil {
+		t.Fatalf("expected no LimitOverride for a user without one, got %+v", m.LimitOverride)
+	}
+}


### PR DESCRIPTION
## What

The Account Backup Snapshot builder (`backupmetadata/builder.go`) read the **entire** `user_limit_overrides` table (`LimitOverrides.ListAll`) and scanned it in memory for the one row matching the account — on **every** `Build`. `Build` runs once per account for **manual, tenant, and scheduled** backups, so the scan cost grew with the *total* number of overrides on the whole system, not with the account being snapshotted.

Swapped for the existing user-scoped `FindByUserID` — the table is keyed on `user_id`, so this is a single indexed row read. `FindByUserID` returns `ErrNotFound` when the account has no override, which the guard treats as "no override" — **identical output** to the old loop finding no match.

## Scope (JAB-374 AC#5)

This is the one AC that is a pure user-scoped lookup with zero grouping risk: *"No account-wide `ListAll` scan remains for a user-scoped lookup."*

The remaining builder N+1 sites — per-domain cert/mailbox/forwarder/DNSSEC/zone, per-mailbox autoresponder/share, per-db-user grants, per-docker-app ports — each need **parent-grouping batch reads plus golden-equivalence tests** (backup metadata drives restore; a grouping bug silently corrupts a restore), so they stay on the parent ticket rather than riding this low-risk slice.

## Test plan

- [x] `go test ./panel-api/internal/backupmetadata/` — `builder_limitoverride_test.go` exercises the override path with every other repo nil. The fake's `ListAll` **fails the test**, proving the whole-table scan is gone; asserts the user-scoped path maps every field, and yields no section when the account has no override.
- [x] `go build ./panel-api/...`, `go vet` clean.

GH: JAB-374 (AC#5 slice)
