### PR TITLE
fix(db): make the DB restore-from-file upload cap configurable (GH #1044)

### DIFF
--- a/panel-api/internal/api/databases.go
+++ b/panel-api/internal/api/databases.go
@@ -542,6 +542,21 @@ func (h *databaseHandler) backup(c *gin.Context) {
 	_ = deleteFile(resp.Path)
 }
 
+// resolveMaxRestoreBytes returns the admin-configured restore-upload cap from
+// server_settings.upload_max_size_mb (the same cap the File Manager honours),
+// falling back to defaultMaxUploadBytes (1 GB) when the repo isn't wired or the
+// column is unset. GH #1044.
+func (h *databaseHandler) resolveMaxRestoreBytes(ctx context.Context) int64 {
+	if h.cfg.ServerSettings == nil {
+		return defaultMaxUploadBytes
+	}
+	s, err := h.cfg.ServerSettings.Get(ctx)
+	if err != nil || s == nil || s.UploadMaxSizeMB == 0 {
+		return defaultMaxUploadBytes
+	}
+	return int64(s.UploadMaxSizeMB) * 1024 * 1024
+}
+
 func (h *databaseHandler) restore(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -568,12 +583,24 @@ func (h *databaseHandler) restore(c *gin.Context) {
 		return
 	}
 
-	// Parse multipart form (max 500 MB)
-	const maxUploadSize = 500 * 1024 * 1024 // 500 MB
+	// GH #1044: the restore upload cap was hard-coded to 500 MB. Honour the
+	// admin-configured `server_settings.upload_max_size_mb` (default 1 GB) the
+	// File Manager already uses, so larger PostgreSQL dumps can be restored.
+	// NOTE: nginx's client_max_body_size (Server Settings → Nginx, default 512m)
+	// and any Cloudflare body limit sit IN FRONT of this — the effective cap is
+	// the smallest of the three, which is why an over-limit upload can 413 at the
+	// proxy before reaching this handler.
+	maxUploadSize := h.resolveMaxRestoreBytes(ctx)
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxUploadSize)
 	if err := c.Request.ParseMultipartForm(32 << 20); err != nil { // 32 MB in-memory
 		if err.Error() == "http: request body too large" {
-			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "file_too_large", "max_size": "500MB"})
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error":    "file_too_large",
+				"max_size": fmt.Sprintf("%dMB", maxUploadSize/(1024*1024)),
+				"detail": "Upload exceeds the panel's restore cap (Server Settings → Uploads). " +
+					"A larger request may also be blocked upstream by nginx (Server Settings → Nginx, " +
+					"client_max_body_size) or Cloudflare — raise those too if needed.",
+			})
 		} else {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_request", "detail": err.Error()})
 		}

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.test.tsx
@@ -26,6 +26,13 @@ vi.mock("@tanstack/react-query", () => ({
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
 
+// getIdentity pulls in identity.ts → query.ts (which instantiates a real
+// QueryClient); with react-query mocked above that import throws at load. Mock
+// it directly and hand the restore-size pre-check (GH #1044) a cap.
+vi.mock("../../../identity", () => ({
+  getIdentity: () => Promise.resolve({ uploadMaxSizeMb: 1024 }),
+}));
+
 vi.mock("../../../hooks/useQueries", () => ({
   useDeleteMutation: () => ({ mutateAsync: vi.fn() }),
   useCreateMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),

--- a/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
+++ b/panel-ui/src/shells/user/databases/UserDatabaseList.tsx
@@ -11,6 +11,7 @@ import { shortDateTime } from "../../../utils/datetime";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button, Card, Space, Table, Typography } from "antd";
 import { feedback } from "../../../lib/feedback"; // GH #970: themed toasts
+import { getIdentity } from "../../../identity";
 import {
   DatabaseOutlined,
   LinkOutlined,
@@ -203,6 +204,19 @@ export const UserDatabaseList = () => {
     e.target.value = "";
     const row = restoreTargetRef.current;
     if (!file || !row) return;
+    // GH #1044: fail fast + clearly when the dump is over the configured cap,
+    // instead of a slow upload that 413s at the app, nginx, or Cloudflare. The
+    // cap mirrors the File Manager's server_settings.upload_max_size_mb.
+    const id = await getIdentity().catch(() => null);
+    const capMb = id?.uploadMaxSizeMb && id.uploadMaxSizeMb > 0 ? id.uploadMaxSizeMb : 1024;
+    if (file.size > capMb * 1024 * 1024) {
+      feedback.message.error(
+        `"${file.name}" is ${Math.ceil(file.size / (1024 * 1024))} MB — over the ${capMb} MB restore cap ` +
+          `(raise it in Server Settings → Uploads). A larger upload may also be blocked upstream by nginx ` +
+          `(Server Settings → Nginx) or Cloudflare.`,
+      );
+      return;
+    }
     try {
       setRestoringId(row.id);
       await restoreDatabaseUpload(row.id, file);


### PR DESCRIPTION
Follow-up on the open #1044 thread. @lxsdevcode reported the PostgreSQL *Restore from file* upload limit is **hard-coded to 500 MB**, and a **545 MB** upload failed with **413 Payload Too Large**.

## Two limits were in play

1. **App (the hard-coded 500 MB)** — `databases.go` restore handler:
   ```go
   const maxUploadSize = 500 * 1024 * 1024 // 500 MB
   ```
   There's already an admin-configurable cap — `server_settings.upload_max_size_mb` (default 1 GB) — that the **File Manager** honours via `resolveMaxUploadBytes`. The DB restore just hard-coded 500 MB instead. Now it reads the same setting (`resolveMaxRestoreBytes`, mirroring `files.go`). Admins raise it in **Server Settings → Uploads**.

2. **Proxy (the 545 MB → 413)** — `install.sh`: `client_max_body_size 512m` on the panel vhost, seeded from **Server Settings → Nginx** (M55, already configurable). nginx sits *in front* of the app, so a 545 MB upload 413s at nginx **before** reaching the handler — which is why it was a generic "413 Payload Too Large" rather than the app's `file_too_large / 500MB`.

So the **effective cap = min(app `upload_max_size_mb`, nginx `client_max_body_size`, Cloudflare)**. lxsdevcode was right on both counts.

## Changes
- `databases.go`: restore reads `server_settings.upload_max_size_mb` (default 1 GB) instead of the 500 MB const; the 413 body now **names all three layers** (app / nginx / Cloudflare) so the fix is discoverable.
- `UserDatabaseList.tsx`: the tenant DB list **pre-checks** the file against the configured cap before uploading — a clear message instead of a slow upload that dies at the proxy.
- No agent change.

## Test plan
- [x] `go build`, `go test ./panel-api/internal/api` green
- [x] `tsc -b`, vitest 294/294 (mocked `identity` in `UserDatabaseList.test` — the `getIdentity` import otherwise drags `query.ts`'s real `QueryClient` into the react-query-mocked suite)
- [ ] Box-verify: set `upload_max_size_mb` (Server Settings → Uploads) + nginx cap, restore a >500 MB PostgreSQL dump, confirm it's accepted (and that the pre-check + 413 name the layered limits when over)

🤖 Generated with [Claude Code](https://claude.com/claude-code)