### PR TITLE
fix(fleet): swap headroom + memory-capped maintenance slice — no more kswapd death-spiral (JAB-273)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5663,6 +5663,92 @@ ensure_swap() {
   _ok "build-swap: 2 GB active at $swap_file (persists via /etc/fstab); vm.swappiness=10"
 }
 
+# ensure_fleet_swap — JAB-273. Distinct from the build-time ensure_swap above,
+# which only helps ≤4 GB build hosts. newaramaapp (18 GB RAM, 0 swap) wedged
+# into a kswapd death-spiral: once RAM filled on a swapless box the kernel had
+# nowhere to evict to, load hit ~385 on 8 cores, and sshd could not even
+# complete a login handshake — the operator was locked out mid-incident. Swap
+# gives kswapd an exit so a memory spike degrades gracefully instead of
+# wedging. Runs on EVERY box (any RAM size), on fresh install AND
+# `jabali update`, so the existing fleet self-heals.
+#
+# Conservative + idempotent:
+#   - Acts only when active swap < 2 GB — never resizes or swapoffs an
+#     operator's existing swap on a live box.
+#   - Sizes min(RAM, 8 GB), then halves until it fits behind a 10 GB free-disk
+#     margin (floor 1 GB); warns + skips if it still will not fit.
+#   - Reuses ensure_swap's mechanics: fallocate→dd fallback, 0600 before
+#     mkswap, rm-on-any-failure (no half state), grep -qF fstab idempotence,
+#     and swapon-failure tolerance as the container/btrfs guard.
+ensure_fleet_swap() {
+  local mem_kb cur_swap_kb mem_mb want_mb free_mb
+  mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+  cur_swap_kb=$(awk '/^SwapTotal:/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+  mem_mb=$((mem_kb / 1024))
+  if [[ $cur_swap_kb -ge 2097152 ]]; then
+    _log "fleet-swap: $((cur_swap_kb / 1024))MB swap already active — skip (JAB-273)"
+    return 0
+  fi
+  want_mb=8192
+  [[ $mem_mb -gt 0 && $mem_mb -lt $want_mb ]] && want_mb=$mem_mb
+  free_mb=$(df -Pm /var 2>/dev/null | awk 'NR==2 {print $4}' || echo 0)
+  while [[ $want_mb -ge 1024 && $((free_mb - want_mb)) -lt 10240 ]]; do
+    want_mb=$((want_mb / 2))
+  done
+  if [[ $want_mb -lt 1024 || $((free_mb - want_mb)) -lt 10240 ]]; then
+    _warn "fleet-swap: only ${free_mb}MB free on /var — need swap + 10GB margin; skipping (JAB-273). Provision swap manually."
+    return 0
+  fi
+  local swap_file=/var/swap.jabali-fleet
+  _log "fleet-swap: provisioning ${want_mb}MB swap at $swap_file (JAB-273; can take a minute on slow disks)"
+  if [[ -e "$swap_file" ]]; then
+    swapoff "$swap_file" 2>/dev/null || true
+    rm -f "$swap_file"
+  fi
+  if ! fallocate -l "${want_mb}M" "$swap_file" 2>/dev/null; then
+    dd if=/dev/zero of="$swap_file" bs=1M count="$want_mb" status=none \
+      || { _warn "fleet-swap: allocate failed — box stays swapless (JAB-273)"; rm -f "$swap_file"; return 0; }
+  fi
+  chmod 0600 "$swap_file"
+  mkswap "$swap_file" >/dev/null 2>&1 \
+    || { _warn "fleet-swap: mkswap failed — box stays swapless"; rm -f "$swap_file"; return 0; }
+  swapon "$swap_file" \
+    || { _warn "fleet-swap: swapon failed (containerized/btrfs host?) — box stays swapless"; rm -f "$swap_file"; return 0; }
+  if ! grep -qF "$swap_file" /etc/fstab 2>/dev/null; then
+    echo "$swap_file none swap sw 0 0" >> /etc/fstab
+  fi
+  # Big-RAM fleet boxes never ran ensure_swap, so they never got the swappiness
+  # tune. Keep swap as an OOM safety net, not an eager pager.
+  echo 'vm.swappiness=10' > /etc/sysctl.d/99-jabali-swappiness.conf
+  sysctl -w vm.swappiness=10 >/dev/null 2>&1 || true
+  _ok "fleet-swap: ${want_mb}MB active at $swap_file (persists via /etc/fstab); vm.swappiness=10 (JAB-273)"
+}
+
+# ensure_maintenance_isolation — JAB-273. Installs jabali-maintenance.slice and
+# (re)installs the all-tenant maintenance units so they run inside it
+# (MemoryMax=50%, Nice=19, idle IO). The per-unit install_* functions are
+# full-install-only, so without this converger the hardened units + the slice
+# would never reach the existing fleet — the template-only-change-never-reaches-
+# update lesson (see ensure_pdns_zone_cache). Runs on fresh install AND update.
+ensure_maintenance_isolation() {
+  install -m 0644 -o root -g root \
+    "${REPO_DIR}/install/systemd/jabali-maintenance.slice" \
+    /etc/systemd/system/jabali-maintenance.slice
+  local u src
+  for u in jabali-cache-doctor jabali-disk-maintenance jabali-backup-retention \
+           jabali-aide-check jabali-sso-reaper jabali-retention-sweep; do
+    src="${REPO_DIR}/install/systemd/${u}.service"
+    [[ -f "$src" ]] || continue
+    # Only re-install a unit that already exists, so this never resurrects a
+    # service an operator deliberately removed. On fresh install the per-unit
+    # functions lay them down first; this then hardens them in place.
+    if [[ -f "/etc/systemd/system/${u}.service" ]]; then
+      install -m 0644 -o root -g root "$src" "/etc/systemd/system/${u}.service"
+    fi
+  done
+  systemctl daemon-reload 2>/dev/null || true
+}
+
 # ensure_pdns_zone_cache — converge PowerDNS's zone cache OFF on EXISTING
 # boxes (GH #896 for new-zone blindness; PowerDNS/pdns#11416 for the crash
 # the old rediscover workaround triggered on 4.9).
@@ -15255,6 +15341,13 @@ provision_new_software() {
   # --failed` forever.
   reap_orphan_nspawn_php_units
 
+  # JAB-273: self-heal the fleet's zero-swap fragility (kswapd death-spiral that
+  # locked the operator out of newaramaapp) and contain every all-tenant
+  # maintenance job in a memory-capped slice. Idempotent; the existing fleet
+  # only picks these up on update, so they MUST run here, not just on install.
+  ensure_fleet_swap
+  ensure_maintenance_isolation
+
   # GH #860: retrofit the default-vhost catch-all include onto existing
   # boxes. install_disabled_page is seed-only now (never clobbers operator
   # edits), so re-running it here just ensures the docroots + catch-all
@@ -16022,6 +16115,11 @@ main() {
   install_retention_sweep_timer
   install_ssh_sandbox_prereqs
   install_backup_foundation
+  # JAB-273: give the box swap headroom (no more kswapd death-spiral) and
+  # contain every all-tenant maintenance job in a memory-capped slice. Both run
+  # again from provision_new_software so the existing fleet self-heals on update.
+  ensure_fleet_swap
+  ensure_maintenance_isolation
   # Order matters: install_phpmyadmin extracts the tarball to
   # /opt/phpmyadmin/current, which the pma pool config references as
   # chdir=. Starting the FPM service before the tarball is extracted

--- a/install/systemd/jabali-aide-check.service
+++ b/install/systemd/jabali-aide-check.service
@@ -5,6 +5,13 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 ExecStart=/usr/bin/aide --check --config=/etc/aide/aide.conf
 StandardOutput=append:/var/log/aide/aide.report.log
 StandardError=append:/var/log/aide/aide.report.log

--- a/install/systemd/jabali-backup-retention.service
+++ b/install/systemd/jabali-backup-retention.service
@@ -25,6 +25,13 @@ After=jabali-panel.service network-online.target mariadb.service
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 ExecStart=/usr/local/bin/jabali backup retention apply
 StandardOutput=journal
 StandardError=journal

--- a/install/systemd/jabali-cache-doctor.service
+++ b/install/systemd/jabali-cache-doctor.service
@@ -13,6 +13,13 @@ After=jabali-panel.service jabali-agent.service mariadb.service
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 # Sweeps every cache-enabled WordPress install, runs `wp jabali-cache verify`
 # via the agent, and re-provisions (re-stamps constants, re-provisions the ACL,
 # re-verifies) any that have drifted. Idempotent: a healthy site is a no-op.

--- a/install/systemd/jabali-disk-maintenance.service
+++ b/install/systemd/jabali-disk-maintenance.service
@@ -7,6 +7,13 @@ After=jabali-agent.service
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 ExecStart=/usr/local/libexec/jabali/disk-maintenance
 StandardOutput=journal
 StandardError=journal

--- a/install/systemd/jabali-maintenance.slice
+++ b/install/systemd/jabali-maintenance.slice
@@ -1,0 +1,23 @@
+[Unit]
+Description=Jabali all-tenant maintenance jobs — resource-contained (JAB-273)
+Documentation=https://github.com/shukiv/jabali-panel/blob/main/install/systemd/jabali-maintenance.slice
+Before=slices.target
+
+[Slice]
+# JAB-273: a nightly all-tenant sweep (disk-maintenance, cache-doctor,
+# retention, AIDE, sso-reaper) must never be able to exhaust the box and lock
+# the operator out of sshd. newaramaapp wedged into a load-385 kswapd
+# death-spiral when the disk-maintenance du fan-out filled RAM on a swapless
+# box; capping the whole maintenance cohort here contains the blast radius.
+#
+# Percentages, NOT absolutes: a fixed 2G is no protection on a 2 GB box and
+# needlessly starves a legitimately large AIDE/restic run on a 38 GB one.
+# MemoryMax=50% guarantees the other half of RAM stays for sshd + the control
+# plane no matter the box size (a maintenance storm can take at most half);
+# MemoryHigh=25% forces the kernel to start reclaiming this cohort's own pages
+# before it reaches the hard cap. Low CPU/IO weight yields to tenants and sshd
+# under contention (this cohort is background work, always deferrable).
+MemoryHigh=25%
+MemoryMax=50%
+CPUWeight=20
+IOWeight=20

--- a/install/systemd/jabali-retention-sweep.service
+++ b/install/systemd/jabali-retention-sweep.service
@@ -12,6 +12,13 @@ After=jabali-panel.service mariadb.service
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 ExecStart=/usr/local/bin/jabali retention-sweep
 StandardOutput=journal
 StandardError=journal

--- a/install/systemd/jabali-sso-reaper.service
+++ b/install/systemd/jabali-sso-reaper.service
@@ -19,6 +19,13 @@ After=jabali-panel.service jabali-agent.service mariadb.service
 
 [Service]
 Type=oneshot
+# JAB-273: contain this all-tenant maintenance job in the resource-limited
+# jabali-maintenance.slice (MemoryMax=50%, low CPU/IO weight) so a sweep can
+# never exhaust the box and lock the operator out of sshd; nice + idle IO keep
+# it yielding to tenants and the control plane.
+Slice=jabali-maintenance.slice
+Nice=19
+IOSchedulingClass=idle
 ExecStart=/usr/local/bin/jabali sso-reap
 StandardOutput=journal
 StandardError=journal

--- a/install/tests/test_maintenance_isolation_and_swap.sh
+++ b/install/tests/test_maintenance_isolation_and_swap.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# install/tests/test_maintenance_isolation_and_swap.sh — JAB-273.
+#
+# newaramaapp wedged into a load-385 kswapd death-spiral: a nightly all-tenant
+# maintenance sweep filled RAM on a ZERO-swap box, the kernel had nowhere to
+# evict to, and sshd could not complete a login handshake — the operator was
+# locked out mid-incident. The durable fixes are:
+#   1. fleet swap on every box (kswapd gets an exit → graceful degradation);
+#   2. every all-tenant maintenance job contained in a memory-capped slice so a
+#      sweep can never take the whole box.
+#
+# Static assertions only (like the JAB-357 / JAB-225 tests); the live behaviour
+# (swap active + cgroup caps enforced) is the .86 box check.
+#
+# Run from repo root:
+#     bash install/tests/test_maintenance_isolation_and_swap.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail=0
+SLICE=install/systemd/jabali-maintenance.slice
+UNITS=(jabali-cache-doctor jabali-disk-maintenance jabali-backup-retention
+       jabali-aide-check jabali-sso-reaper jabali-retention-sweep)
+
+# 1. The slice exists and caps memory as a PERCENTAGE (a fixed absolute is no
+#    protection on a small box and starves a large one).
+if [[ ! -f "$SLICE" ]]; then
+  echo "FAIL: $SLICE missing — nothing contains the maintenance cohort"
+  fail=1
+else
+  grep -qE '^MemoryMax=[0-9]+%' "$SLICE" || { echo "FAIL: slice MemoryMax must be a percentage"; fail=1; }
+  grep -qE '^MemoryHigh=[0-9]+%' "$SLICE" || { echo "FAIL: slice missing MemoryHigh percentage"; fail=1; }
+  grep -qE '^CPUWeight=' "$SLICE" || { echo "FAIL: slice missing CPUWeight"; fail=1; }
+  grep -qE '^IOWeight=' "$SLICE" || { echo "FAIL: slice missing IOWeight"; fail=1; }
+fi
+
+# 2. Every all-tenant maintenance unit joins the slice and yields (nice + idle IO).
+for u in "${UNITS[@]}"; do
+  f="install/systemd/${u}.service"
+  if [[ ! -f "$f" ]]; then
+    echo "FAIL: $f missing"; fail=1; continue
+  fi
+  grep -qxE 'Slice=jabali-maintenance\.slice' "$f" || { echo "FAIL: $u not in jabali-maintenance.slice (JAB-273)"; fail=1; }
+  grep -qxE 'Nice=19' "$f"                          || { echo "FAIL: $u missing Nice=19"; fail=1; }
+  grep -qxE 'IOSchedulingClass=idle' "$f"           || { echo "FAIL: $u missing IOSchedulingClass=idle"; fail=1; }
+done
+
+# 3. Both convergers exist.
+for fn in ensure_fleet_swap ensure_maintenance_isolation; do
+  grep -qE "^${fn}\(\)" install.sh || { echo "FAIL: ${fn}() missing from install.sh"; fail=1; }
+done
+
+# 4. Both convergers run on BOTH paths: full install (main) AND update
+#    (provision_new_software) — a fleet box only self-heals on update.
+for fn in ensure_fleet_swap ensure_maintenance_isolation; do
+  awk -v F="$fn" '/^main\(\)/{m=1} m&&$0 ~ ("(^| )"F"( |$)"){print} m&&/^}/{exit}' install.sh | grep -q "$fn" \
+    || { echo "FAIL: ${fn} not called from main() — fresh installs miss it"; fail=1; }
+  awk -v F="$fn" '/^provision_new_software\(\)/{p=1} p&&$0 ~ ("(^| )"F"( |$)"){print} p&&/^}/{exit}' install.sh | grep -q "$fn" \
+    || { echo "FAIL: ${fn} not called from provision_new_software() — the fleet never self-heals on update"; fail=1; }
+done
+
+# 5. Swap converger safety: only acts below a swap floor (never resizes live
+#    swap) and rm's the file on any failure (no half-baked swapfile).
+body=$(awk '/^ensure_fleet_swap\(\)/{f=1} f{print} f&&/^}/{exit}' install.sh)
+grep -qE 'cur_swap_kb -ge 2097152' <<<"$body" || { echo "FAIL: ensure_fleet_swap lost its 'already has swap' guard — could disturb live swap"; fail=1; }
+grep -qE 'rm -f "\$swap_file"' <<<"$body"      || { echo "FAIL: ensure_fleet_swap must rm the swapfile on failure (no half state)"; fail=1; }
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "RESULT: FAIL"
+  exit 1
+fi
+echo "PASS: maintenance cohort memory-capped in its slice + fleet-swap converger wired on install AND update (JAB-273)"


### PR DESCRIPTION
## What

`newaramaapp` (18 GB RAM, **0 swap**) wedged into a total-resource-exhaustion outage: load **~385 on 8 cores**, tenant nginx returning 0 bytes, and **sshd unable to complete a login handshake** — the operator was locked out during the incident. Root cause: memory exhaustion on a swapless box driving `kswapd0` into a 91%-CPU reclaim spin (`%sy 97.7, %wa 1.7` — memory, not IO), triggered by a nightly all-tenant maintenance sweep filling page cache. Both `newaramaapp` and `newzaps` had 0 swap — **fleet-wide fragility.**

Lands the ticket's ranked-critical **recs 1 + 2**.

## Rec 1 — fleet swap (`ensure_fleet_swap`)

Provisions swap on **every** box (any RAM size), on fresh install **and** `jabali update`, so kswapd has somewhere to evict to and a memory spike degrades gracefully instead of wedging. Distinct from the build-time `ensure_swap` (which only helps ≤4 GB build hosts — an 18 GB box got nothing).

- Acts only when active swap `< 2 GB` — **never resizes or swapoffs an operator's live swap.**
- Sizes `min(RAM, 8 GB)`, halved until it fits behind a **10 GB free-disk margin** (floor 1 GB; warn+skip otherwise).
- Reuses `ensure_swap`'s mechanics: fallocate→dd fallback, 0600-before-mkswap, **rm-on-any-failure**, `grep -qF` fstab idempotence, swapon-failure tolerance (the container/btrfs guard). Sets `vm.swappiness=10`.

## Rec 2 — memory-capped maintenance slice

New `jabali-maintenance.slice` (`MemoryHigh=25%`, `MemoryMax=50%`, `CPUWeight=20`, `IOWeight=20`) + `Nice=19` / `IOSchedulingClass=idle` on all **six** all-tenant maintenance units (disk-maintenance, cache-doctor, backup-retention, aide-check, sso-reaper, retention-sweep). **Percentages, not absolutes** — 50% guarantees the other half of RAM stays for sshd + the control plane on any box size (a maintenance storm can take at most half).

`ensure_maintenance_isolation` re-installs the slice + hardened units on `jabali update` too — the per-unit `install_*` functions are full-install-only, so without the converger the fix never reaches the existing fleet (the template-only-change lesson).

## Rec 3 — already fixed (no work, documented)

The disk-maintenance script no longer walks `du` at all (only prunes Stalwart logs + nspawn images); the surviving per-user `du` in `user_limits_report` is already `ionice -c3 nice -n19` and serially driven by the sweeper; and JAB-376 just removed the duplicate disk-quota alert-loop pass. Recs 4–7 are separate epics (5 = JAB-376 parent, 7 = #1110 Zabbix).

## Test plan

- [x] `bash install/tests/test_maintenance_isolation_and_swap.sh` — slice caps are percentages; every unit joins the slice + yields; both convergers wired on install **and** update; swap converger keeps its `<2GB` guard + rm-on-failure.
- [x] `bash -n install.sh` clean.
- [x] **Box-verified on .86**: slice + hardened unit pass `systemd-analyze verify`; unit lands in the slice with `Nice=19` + idle IO; caps resolve to real cgroup bytes (`MemoryMax=2056204288` = 50% of 3921 MB, `MemoryHigh` = 25%, weights = 20); a memory hog in the slice spilled to swap and the box stayed at load 2.4 (graceful degradation, intended) instead of wedging; `ensure_fleet_swap` correctly **skipped** a box that already had ≥2 GB swap without disturbing it. Baseline restored (original unit, slice removed, swap unchanged, 0 failed units).

**Deploy note:** merge ≠ fleet deploy — this reaches the fleet only at the next `stable` promotion (operator's call). `.86`-verified only; `newzaps` is production.

GH: JAB-273
