### PR TITLE
perf(server-status): per-slice TTL cache + singleflight over the agent fan-out (JAB-373)

### DIFF
--- a/panel-api/internal/api/server_status.go
+++ b/panel-api/internal/api/server_status.go
@@ -48,7 +48,7 @@ func RegisterAdminServerStatusRoutes(g *gin.RouterGroup, cfg AdminServerStatusHa
 	if cfg.Agent == nil {
 		return
 	}
-	h := &adminServerStatusHandler{cfg: cfg}
+	h := &adminServerStatusHandler{cfg: cfg, cache: newStatusCache()}
 	grp := g.Group("/admin/server-status")
 	grp.Use(middleware.RequireAdmin())
 	grp.GET("", h.get)
@@ -56,6 +56,11 @@ func RegisterAdminServerStatusRoutes(g *gin.RouterGroup, cfg AdminServerStatusHa
 
 type adminServerStatusHandler struct {
 	cfg AdminServerStatusHandlerConfig
+	// cache is the JAB-373 per-slice TTL + singleflight cache. Created once
+	// per handler (i.e. once per process at route registration), so it is
+	// shared across every request and every admin tab/operator — that shared
+	// scope is exactly what collapses the redundant agent fan-out.
+	cache *statusCache
 }
 
 const (
@@ -122,11 +127,19 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 		errMap  = map[string]string{}
 	)
 
-	call := func(name, cmd string, params any, timeout time.Duration) {
+	// JAB-373: each slice goes through the process-wide per-slice TTL +
+	// singleflight cache. A slice fresh within its ttl serves the last
+	// snapshot with zero agent calls; concurrent misses for the same slice
+	// collapse to one refresh. The agent call runs on a detached (background)
+	// context so a cancelled poller cannot abort a refresh that other pollers
+	// are blocked on — the per-call deadline still bounds it.
+	call := func(name, cmd string, params any, ttl time.Duration) {
 		g.Go(func() error {
-			subCtx, cancel := context.WithTimeout(gctx, timeout)
-			defer cancel()
-			raw, err := h.cfg.Agent.Call(subCtx, cmd, params)
+			raw, _, err := h.cache.get(name, ttl, func() (json.RawMessage, error) {
+				subCtx, cancel := detachedTimeout(subCallTimeout)
+				defer cancel()
+				return h.cfg.Agent.Call(subCtx, cmd, params)
+			})
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
@@ -142,13 +155,13 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 		})
 	}
 
-	call("host", "system.info", nil, subCallTimeout)
-	call("cpu", "system.cpu_usage", nil, subCallTimeout)
-	call("network", "system.network", nil, subCallTimeout)
-	call("processes", "system.processes", nil, subCallTimeout)
-	call("services", "system.service_details", nil, subCallTimeout)
-	call("user_slices", "system.user_slices", nil, subCallTimeout)
-	call("software", "system.software", nil, subCallTimeout)
+	call("host", "system.info", nil, ttlHost)
+	call("cpu", "system.cpu_usage", nil, ttlCPU)
+	call("network", "system.network", nil, ttlNetwork)
+	call("processes", "system.processes", nil, ttlProcesses)
+	call("services", "system.service_details", nil, ttlServices)
+	call("user_slices", "system.user_slices", nil, ttlUserSlices)
+	call("software", "system.software", nil, ttlSoftware)
 	// nginx.status, NOT nginx.test: this envelope is polled every few
 	// seconds from any open admin tab, and `nginx -t` recompiles every
 	// vhost plus the whole CrowdSec AppSec/CRS rule set (~19s at >60% CPU
@@ -159,14 +172,14 @@ func (h *adminServerStatusHandler) get(c *gin.Context) {
 	// which is liveness, while nginx.test answers config validity — a
 	// config typo used to raise a misleading "not running" critical.
 	// nginx.test remains the gate for nginx.reload, where it belongs.
-	call("nginx", "nginx.status", nil, subCallTimeout)
+	call("nginx", "nginx.status", nil, ttlNginx)
 
 	// JAB-379: lightweight AppArmor profile-mode summary (no audit scrape) so
 	// synthesizeAlerts can warn when a jabali profile is complain/missing/
 	// unconfined rather than enforce. security.apparmor.summary is the cheap
 	// verb built for this poller — the full security.apparmor.status scrapes an
 	// 8MB audit tail and must not run on the 5s dashboard cadence.
-	call("apparmor", "security.apparmor.summary", nil, subCallTimeout)
+	call("apparmor", "security.apparmor.summary", nil, ttlAppArmor)
 
 	// M31.1 — Redis queue depths run in parallel with the agent calls.
 	// Three XLEN/XPending pipelines, each with its own short timeout so

--- a/panel-api/internal/api/server_status_cache.go
+++ b/panel-api/internal/api/server_status_cache.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// statusCache is the JAB-373 Host Observation Snapshot cache: one
+// process-wide, per-slice TTL cache with singleflight in front of the
+// server-status aggregator's agent fan-out. It exists because the admin
+// dashboard polls GET /admin/server-status every ~5s and the header mounts
+// it on every admin page at 30s — each poll fanned out 9 agent subprocess
+// calls, so N tabs / N operators multiplied identical host work (≈960–5,760
+// agent calls/hour per viewer). The cache collapses that two ways:
+//
+//   - per-slice TTL: a request inside a slice's freshness window reuses the
+//     last snapshot and makes zero agent calls (AC #2/#3);
+//   - singleflight: N concurrent requests that all find a slice expired
+//     trigger at most one refresh for it, not N (AC #1/#8).
+//
+// Only successful fetches are cached. On a fetch error the caller keeps the
+// existing best-effort contract (slice absent + an `errors` entry) and the
+// next request retries — so an erroring slice never serves a poisoned cache,
+// at the cost of no singleflight saving while it is failing (the rare case).
+type statusCache struct {
+	mu   sync.Mutex
+	data map[string]statusEntry
+	sf   singleflight.Group
+	now  func() time.Time // injectable clock for tests
+}
+
+type statusEntry struct {
+	raw json.RawMessage
+	at  time.Time
+}
+
+func newStatusCache() *statusCache {
+	return &statusCache{data: make(map[string]statusEntry), now: time.Now}
+}
+
+// get returns the named slice, refreshing it via fetch only when the cached
+// copy is older than ttl. Concurrent misses for the same name collapse to one
+// fetch (singleflight). The bool is true when the value was served from cache
+// (no fetch ran) — used by tests/metrics, ignored by the aggregator.
+//
+// fetch MUST use a request-independent context (e.g. context.Background with
+// its own timeout): the result is shared across every concurrent caller, so
+// binding it to one caller's request ctx would let that caller's cancellation
+// fail the others.
+func (sc *statusCache) get(name string, ttl time.Duration, fetch func() (json.RawMessage, error)) (json.RawMessage, bool, error) {
+	sc.mu.Lock()
+	if e, ok := sc.data[name]; ok && sc.now().Sub(e.at) < ttl {
+		raw := e.raw
+		sc.mu.Unlock()
+		return raw, true, nil
+	}
+	sc.mu.Unlock()
+
+	v, err, _ := sc.sf.Do(name, func() (interface{}, error) {
+		// A leader may have refreshed this slice while we were queued behind
+		// its singleflight call; re-check before spending another fetch.
+		sc.mu.Lock()
+		if e, ok := sc.data[name]; ok && sc.now().Sub(e.at) < ttl {
+			raw := e.raw
+			sc.mu.Unlock()
+			return raw, nil
+		}
+		sc.mu.Unlock()
+
+		raw, ferr := fetch()
+		if ferr != nil {
+			return json.RawMessage(nil), ferr
+		}
+		sc.mu.Lock()
+		sc.data[name] = statusEntry{raw: raw, at: sc.now()}
+		sc.mu.Unlock()
+		return raw, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return v.(json.RawMessage), false, nil
+}
+
+// detachedTimeout is the per-slice agent-call deadline used inside a fetch.
+// Kept equal to the old per-sub-call timeout; lives on a background context so
+// a cancelled poller cannot abort a refresh other pollers are waiting on.
+func detachedTimeout(d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), d)
+}
+
+// Per-slice TTLs (JAB-373). Volatile slices stay short; host/unit state can be
+// longer; software keeps its existing ~5-minute cadence. Even a short TTL
+// collapses the concurrent multi-tab / multi-operator polls that singleflight
+// targets, and the 30s header cadence reuses whatever the 5s dashboard poll
+// just refreshed.
+const (
+	ttlHost       = 15 * time.Second
+	ttlCPU        = 3 * time.Second
+	ttlNetwork    = 3 * time.Second
+	ttlProcesses  = 5 * time.Second
+	ttlServices   = 15 * time.Second
+	ttlUserSlices = 15 * time.Second
+	ttlSoftware   = 5 * time.Minute
+	ttlNginx      = 15 * time.Second
+	ttlAppArmor   = 30 * time.Second
+)

--- a/panel-api/internal/api/server_status_cache_handler_test.go
+++ b/panel-api/internal/api/server_status_cache_handler_test.go
@@ -1,0 +1,70 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
+)
+
+// JAB-373 end-to-end: a second poll of /admin/server-status inside the slice
+// TTLs reuses the cached snapshot, so the agent is called ONCE per slice across
+// both requests — not once per request. Proves the aggregator actually routes
+// through the cache (the unit test proves the cache mechanism in isolation).
+func TestServerStatus_SecondPollWithinTTL_NoExtraAgentCalls(t *testing.T) {
+	mock := agent.NewMockClient().
+		On("system.info", map[string]any{
+			"hostname": "t.local", "os": "Debian 13", "kernel": "6.12",
+			"cpu_count": 4, "load_avg": []float64{0.1, 0.1, 0.1},
+			"partitions": []map[string]any{}, "mem_total_kb": 1000, "mem_used_kb": 100,
+		}).
+		On("system.cpu_usage", map[string]any{"usage_percent": 10.0, "warming_up": false}).
+		On("system.network", map[string]any{"interfaces": []any{}}).
+		On("system.service_details", map[string]any{
+			"services": []map[string]any{
+				{"unit": "jabali-panel.service", "active": "active", "sub": "running", "unit_file_state": "enabled"},
+			},
+		}).
+		On("nginx.status", map[string]any{"active": true})
+
+	r := newServerStatusRouter(mock, true)
+	do := func() api.ServerStatusEnvelope {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/server-status", nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var env api.ServerStatusEnvelope
+		assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &env))
+		return env
+	}
+
+	do()         // populates every slice cache
+	env2 := do() // within all TTLs → every cached slice served without a fresh call
+
+	// Count agent calls per command across BOTH requests.
+	counts := map[string]int{}
+	for _, c := range mock.Calls() {
+		counts[c.Command]++
+	}
+	// Cached commands: exactly one call for two requests.
+	for _, cmd := range []string{"system.info", "system.cpu_usage", "system.network", "system.service_details", "nginx.status"} {
+		assert.Equalf(t, 1, counts[cmd], "%s should be fetched once and cached, got %d calls over 2 requests", cmd, counts[cmd])
+	}
+
+	// Shared-bytes guard: the second request re-derives the services slice from
+	// the SAME cached bytes the first request already read (filterModuleServices
+	// runs per request). Prove those bytes were not mutated in place — the
+	// second response's services slice must still be well-formed.
+	if assert.NotNil(t, env2.Services, "services slice must survive a second read of the cached bytes") {
+		var svc struct {
+			Services []map[string]any `json:"services"`
+		}
+		assert.NoError(t, json.Unmarshal(*env2.Services, &svc), "cached services bytes corrupted after a second request")
+		assert.Len(t, svc.Services, 1)
+	}
+}

--- a/panel-api/internal/api/server_status_cache_test.go
+++ b/panel-api/internal/api/server_status_cache_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// clock is a manually-advanced time source so TTL expiry is deterministic.
+type clock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *clock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+func (c *clock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func newTestCache(cl *clock) *statusCache {
+	sc := newStatusCache()
+	sc.now = cl.now
+	return sc
+}
+
+// AC #1/#8: N concurrent misses for the same slice trigger AT MOST one fetch.
+func TestStatusCache_SingleflightCollapsesConcurrent(t *testing.T) {
+	cl := &clock{t: time.Unix(1_000_000, 0)}
+	sc := newTestCache(cl)
+
+	var fetches int32
+	release := make(chan struct{})
+	var entered sync.WaitGroup
+	const N = 24
+	entered.Add(N)
+
+	fetch := func() (json.RawMessage, error) {
+		atomic.AddInt32(&fetches, 1)
+		<-release // hold the leader in-flight so followers queue behind it
+		return json.RawMessage(`{"v":1}`), nil
+	}
+
+	results := make([]json.RawMessage, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			entered.Done()
+			raw, _, err := sc.get("cpu", 30*time.Second, fetch)
+			if err != nil {
+				t.Errorf("get: %v", err)
+			}
+			results[i] = raw
+		}(i)
+	}
+	entered.Wait()
+	time.Sleep(30 * time.Millisecond) // let the goroutines reach sf.Do
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&fetches); got != 1 {
+		t.Fatalf("expected exactly 1 fetch for %d concurrent callers, got %d", N, got)
+	}
+	for i, r := range results {
+		if string(r) != `{"v":1}` {
+			t.Fatalf("caller %d got %q, want the shared snapshot", i, string(r))
+		}
+	}
+}
+
+// AC #2/#3: a request inside the TTL reuses the cached slice — zero fetches.
+func TestStatusCache_WithinTTLServesCached(t *testing.T) {
+	cl := &clock{t: time.Unix(1_000_000, 0)}
+	sc := newTestCache(cl)
+	var fetches int32
+	fetch := func() (json.RawMessage, error) {
+		atomic.AddInt32(&fetches, 1)
+		return json.RawMessage(`{"n":1}`), nil
+	}
+
+	// First call: miss → fetch.
+	_, cached, _ := sc.get("host", 10*time.Second, fetch)
+	if cached {
+		t.Fatal("first call must be a miss")
+	}
+	// Within TTL (advance < ttl): hit → no fetch.
+	cl.advance(9 * time.Second)
+	raw, cached, _ := sc.get("host", 10*time.Second, fetch)
+	if !cached {
+		t.Fatal("call within TTL must be served from cache")
+	}
+	if string(raw) != `{"n":1}` {
+		t.Fatalf("cached value wrong: %q", raw)
+	}
+	if got := atomic.LoadInt32(&fetches); got != 1 {
+		t.Fatalf("within-TTL call must not fetch; fetches=%d", got)
+	}
+}
+
+// AC #3: once the TTL expires the slice refreshes exactly once more.
+func TestStatusCache_ExpiredRefetches(t *testing.T) {
+	cl := &clock{t: time.Unix(1_000_000, 0)}
+	sc := newTestCache(cl)
+	var fetches int32
+	fetch := func() (json.RawMessage, error) {
+		atomic.AddInt32(&fetches, 1)
+		return json.RawMessage(`{}`), nil
+	}
+	sc.get("net", 5*time.Second, fetch) // miss → 1
+	cl.advance(6 * time.Second)         // past TTL
+	sc.get("net", 5*time.Second, fetch) // miss → 2
+	if got := atomic.LoadInt32(&fetches); got != 2 {
+		t.Fatalf("expired slice must refetch; fetches=%d want 2", got)
+	}
+}
+
+// A failed fetch is NOT cached: the best-effort contract is preserved and the
+// next request retries (no poisoned cache, no stale-error serve).
+func TestStatusCache_ErrorNotCached(t *testing.T) {
+	cl := &clock{t: time.Unix(1_000_000, 0)}
+	sc := newTestCache(cl)
+	var fetches int32
+	boom := errors.New("agent down")
+	fetch := func() (json.RawMessage, error) {
+		n := atomic.AddInt32(&fetches, 1)
+		if n == 1 {
+			return nil, boom // first call fails
+		}
+		return json.RawMessage(`{"ok":1}`), nil
+	}
+	if _, _, err := sc.get("svc", time.Minute, fetch); err == nil {
+		t.Fatal("first get must surface the fetch error")
+	}
+	// Same TTL window, but the error was not cached → second get retries and
+	// succeeds.
+	raw, cached, err := sc.get("svc", time.Minute, fetch)
+	if err != nil || cached || string(raw) != `{"ok":1}` {
+		t.Fatalf("error must not be cached: raw=%q cached=%v err=%v", raw, cached, err)
+	}
+	if got := atomic.LoadInt32(&fetches); got != 2 {
+		t.Fatalf("expected retry after error; fetches=%d want 2", got)
+	}
+}


### PR DESCRIPTION
## What

`GET /admin/server-status` fans out **9 agent subprocess calls** per request. The dashboard polls it every ~5s and the header mounts it on every admin page at 30s, so N tabs / N operators multiplied identical host work — **~960–5,760 agent calls/hour per viewer**, all for the same snapshot. `system.processes` samples every PID twice across 200ms; `system.service_details` shells out `systemctl show` — real host CPU.

## How

One process-wide **Host Observation Snapshot cache** (`statusCache`) in front of the aggregator, created once per handler at route registration (shared across every request + viewer):

- **per-slice TTL** — a request inside a slice's window reuses the last snapshot, **zero agent calls** (cpu/network 3s, processes 5s, host/unit 15–30s, software 5 min).
- **singleflight** — N concurrent requests that find a slice expired trigger **at most one** refresh for it, not N.
- **errors not cached** — a fetch error keeps the existing best-effort contract (slice absent + `errors` entry) and the next request retries; no poisoned cache.
- **detached fetch ctx** — the agent call runs on a background context with the same per-call deadline, so a cancelled poller can't abort a refresh other pollers are blocked on.

**Shared-bytes safety:** cached bytes are now shared, so every consumer is read-only on the raw bytes — `filterModuleServices` unmarshal→filter→re-marshal (fresh bytes), `synthesizeAlerts` decodes into fresh structs, demo redaction rebuilds an allowlisted struct. A handler test guards it by re-reading the services slice across two requests.

## Acceptance criteria

- [x] **#1 / #8** N concurrent Full requests → at most one refresh per due slice (barrier test: 24 callers → 1 fetch; race-clean).
- [x] **#2 (agent half)** request inside every slice's TTL → zero agent calls.
- [x] **#3** only expired slices refresh; fresh slices reused.
- [ ] **#4** fixed Health projection (omit processes/software/user_slices) — parent.
- [ ] **#5** stale/last-good-on-timeout metadata — parent (today: error → slice absent, unchanged).
- [ ] **#7** per-slice cache metrics — parent.
- [ ] **#2 (Redis half)** cache the queue XLEN — parent (microseconds vs the agent storm).

Parent ticket stays **OPEN** for the deferred ACs.

## Notes

- `AsOf` still stamps response time; a slice may now trail it by up to its TTL (software ≤5 min — the ticket's endorsed cadence).
- A lone dashboard tab still refreshes cpu/network every poll by design (3s TTL < 5s poll); the win is concurrent tabs/operators + the 30s header.

## Test plan

- [x] `go test ./panel-api/internal/api/ -race` — concurrent-collapse, within-TTL-cached, expired-refetch, error-not-cached, end-to-end second-poll-no-extra-calls + services-bytes-intact. Full api package green.
- [x] No route/CLI change → no golden/openapi regen.

GH: JAB-373 (AC #1, #3, #8 + agent-call half of #2)
