### PR TITLE
feat(automation): read-only mail forwarders/domain-forwarders/groups/autoresponders endpoints (JAB-76)

### DIFF
--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -52,11 +52,12 @@ type AutomationConfig struct {
 	// M31 system.* collectors so a fleet monitor gets the same data the admin
 	// Server Status page shows. Nil → /status stays the bare healthy stub.
 	Agent agent.AgentInterface
-	// Mail-stack read repos power the read:mail endpoints (JAB-77). Nil → those
-	// routes aren't mounted.
-	Mailboxes  repository.MailboxRepository
-	MailGroups repository.MailGroupRepository
-	Forwarders repository.EmailForwarderRepository
+	// Mail-stack read repos power the read:mail endpoints (JAB-77, extended by
+	// JAB-76). Nil → those routes aren't mounted.
+	Mailboxes      repository.MailboxRepository
+	MailGroups     repository.MailGroupRepository
+	Forwarders     repository.EmailForwarderRepository
+	Autoresponders repository.EmailAutoresponderRepository
 	// JAB-140 write layer. Operations powers async backups + the idempotency
 	// ledger; Audits records every write (M49). Backups drives POST /backups.
 	// All optional — a nil repo/agent drops the matching write route (mirrors
@@ -218,97 +219,248 @@ func RegisterAutomation(rg *gin.RouterGroup, cfg AutomationConfig) {
 	metrics := newAutomationMetrics(cfg.Agent)
 	g.GET("/status", middleware.RequireScope("read:status"), metrics.handle)
 
-	// read:mail — mail-stack inventory for a fleet manager (JAB-77). Thin,
-	// secrets-free: never password hashes / SSO tokens. Reuses the same
-	// server-wide repos the admin pages use.
-	if cfg.Mailboxes != nil {
-		mg := g.Group("/mail", middleware.RequireScope("read:mail"))
-
-		mg.GET("/mailboxes", func(c *gin.Context) {
-			ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-			defer cancel()
-			rows, err := cfg.Mailboxes.ListAllWithDomain(ctx)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-				return
-			}
-			out := make([]map[string]any, 0, len(rows))
-			for _, m := range rows {
-				out = append(out, map[string]any{
-					"email":            m.EmailCached,
-					"domain":           m.DomainName,
-					"owner":            m.UserUsername,
-					"quota_bytes":      m.QuotaBytes,
-					"last_usage_bytes": m.LastUsageBytes,
-					"disabled":         m.IsDisabled,
-				})
-			}
-			c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
-		})
-
-		mg.GET("/domains", func(c *gin.Context) {
-			ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-			defer cancel()
-			rows, _, err := cfg.Domains.List(ctx, repository.ListOptions{Limit: 500})
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
-				return
-			}
-			out := make([]map[string]any, 0)
-			for _, d := range rows {
-				if !d.EmailEnabled {
-					continue
-				}
-				out = append(out, map[string]any{"id": d.ID, "name": d.Name, "user_id": d.UserID})
-			}
-			c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
-		})
-
-		mg.GET("/summary", func(c *gin.Context) {
-			ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-			defer cancel()
-			// COUNT, not a full-table read. This endpoint is polled by fleet
-			// monitors; loading every mailbox row (two JOINs, every column
-			// including password material) just to len() it was the single
-			// most expensive thing here.
-			mailboxCount := 0
-			if n, err := cfg.Mailboxes.CountAll(ctx); err == nil {
-				mailboxCount = int(n)
-			}
-			mailDomains := 0
-			if cfg.Domains != nil {
-				if doms, _, err := cfg.Domains.List(ctx, repository.ListOptions{Limit: 500}); err == nil {
-					for _, d := range doms {
-						if d.EmailEnabled {
-							mailDomains++
-						}
-					}
-				}
-			}
-			groups := 0
-			if cfg.MailGroups != nil {
-				if gr, err := cfg.MailGroups.ListAllWithDomain(ctx); err == nil {
-					groups = len(gr)
-				}
-			}
-			forwarders := 0
-			if cfg.Forwarders != nil {
-				if _, n, err := cfg.Forwarders.ListAll(ctx, repository.ListOptions{Limit: 1}); err == nil {
-					forwarders = int(n)
-				}
-			}
-			c.JSON(http.StatusOK, gin.H{
-				"mail_domains": mailDomains,
-				"mailboxes":    mailboxCount,
-				"forwarders":   forwarders,
-				"mail_groups":  groups,
-			})
-		})
-	}
+	// read:mail — mail-stack inventory for a fleet manager (JAB-77 + JAB-76).
+	registerAutomationMailReads(g, cfg)
 
 	// JAB-140 write layer + capabilities (additive; each route self-guards on
 	// its repo/agent being present, mirroring the read routes).
 	registerAutomationWrites(g, cfg)
+}
+
+// registerAutomationMailReads mounts the read:mail inventory endpoints a fleet
+// manager (GH #308) reads to populate its Mail tab. Thin + secrets-free: never
+// password hashes, SSO tokens, or message bodies — reuses the same server-wide
+// repos the admin pages use so there is one source of truth. Split out as its
+// own function (like registerAutomationWrites) so the handlers are unit
+// testable behind the scope gate. JAB-77 shipped mailboxes/domains/summary;
+// JAB-76 adds forwarders, domain-forwarders, groups, autoresponders.
+func registerAutomationMailReads(g *gin.RouterGroup, cfg AutomationConfig) {
+	if cfg.Mailboxes == nil {
+		return
+	}
+	mg := g.Group("/mail", middleware.RequireScope("read:mail"))
+
+	// domainLookup builds an id → {name, owner} map once per request so the
+	// forwarder/group rows can carry a human domain + owner without a per-row
+	// query. Best-effort: a missing Domains repo just yields blank enrichment.
+	domainLookup := func(ctx context.Context) map[string]struct{ Name, Owner string } {
+		m := map[string]struct{ Name, Owner string }{}
+		if cfg.Domains == nil {
+			return m
+		}
+		doms, _, err := cfg.Domains.List(ctx, repository.ListOptions{Limit: 5000})
+		if err != nil {
+			return m
+		}
+		for _, d := range doms {
+			m[d.ID] = struct{ Name, Owner string }{Name: d.Name, Owner: d.UserID}
+		}
+		return m
+	}
+
+	mg.GET("/mailboxes", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		rows, err := cfg.Mailboxes.ListAllWithDomain(ctx)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		out := make([]map[string]any, 0, len(rows))
+		for _, m := range rows {
+			out = append(out, map[string]any{
+				"email":            m.EmailCached,
+				"domain":           m.DomainName,
+				"owner":            m.UserUsername,
+				"quota_bytes":      m.QuotaBytes,
+				"last_usage_bytes": m.LastUsageBytes,
+				"disabled":         m.IsDisabled,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+	})
+
+	mg.GET("/domains", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		rows, _, err := cfg.Domains.List(ctx, repository.ListOptions{Limit: 500})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		out := make([]map[string]any, 0)
+		for _, d := range rows {
+			if !d.EmailEnabled {
+				continue
+			}
+			out = append(out, map[string]any{"id": d.ID, "name": d.Name, "user_id": d.UserID})
+		}
+		c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+	})
+
+	mg.GET("/summary", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		// COUNT, not a full-table read. This endpoint is polled by fleet
+		// monitors; loading every mailbox row (two JOINs, every column
+		// including password material) just to len() it was the single
+		// most expensive thing here.
+		mailboxCount := 0
+		if n, err := cfg.Mailboxes.CountAll(ctx); err == nil {
+			mailboxCount = int(n)
+		}
+		mailDomains := 0
+		if cfg.Domains != nil {
+			if doms, _, err := cfg.Domains.List(ctx, repository.ListOptions{Limit: 500}); err == nil {
+				for _, d := range doms {
+					if d.EmailEnabled {
+						mailDomains++
+					}
+				}
+			}
+		}
+		groups := 0
+		if cfg.MailGroups != nil {
+			if gr, err := cfg.MailGroups.ListAllWithDomain(ctx); err == nil {
+				groups = len(gr)
+			}
+		}
+		forwarders := 0
+		if cfg.Forwarders != nil {
+			if _, n, err := cfg.Forwarders.ListAll(ctx, repository.ListOptions{Limit: 1}); err == nil {
+				forwarders = int(n)
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"mail_domains": mailDomains,
+			"mailboxes":    mailboxCount,
+			"forwarders":   forwarders,
+			"mail_groups":  groups,
+		})
+	})
+
+	// JAB-76: mailbox-level forwarders (MailboxID set). Domain-scoped rows
+	// (MailboxID nil) are served by /domain-forwarders below, so the two views
+	// stay distinct — matching the panel's own split.
+	mg.GET("/forwarders", func(c *gin.Context) {
+		listForwarders(c, cfg, domainLookup, false)
+	})
+
+	// JAB-76: domain-scoped forwarders (MailboxID nil — catch-alls / domain
+	// aliases, not tied to a single mailbox).
+	mg.GET("/domain-forwarders", func(c *gin.Context) {
+		listForwarders(c, cfg, domainLookup, true)
+	})
+
+	// JAB-76: mail groups with member counts + per-service flags.
+	mg.GET("/groups", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		if cfg.MailGroups == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "mail groups unavailable"})
+			return
+		}
+		rows, err := cfg.MailGroups.ListAllWithDomain(ctx)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		out := make([]map[string]any, 0, len(rows))
+		for _, gr := range rows {
+			out = append(out, map[string]any{
+				"id":              gr.ID,
+				"email":           gr.EmailCached,
+				"domain":          gr.DomainName,
+				"owner":           gr.UserUsername,
+				"display_name":    gr.DisplayName,
+				"group_kind":      gr.GroupKind,
+				"member_count":    gr.MemberCount,
+				"internal_only":   gr.InternalOnly,
+				"has_mailbox":     gr.HasMailbox,
+				"has_calendar":    gr.HasCalendar,
+				"has_addressbook": gr.HasAddressbook,
+				"has_files":       gr.HasFiles,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+	})
+
+	// JAB-76: autoresponder status + schedule metadata. Deliberately
+	// metadata-only — the subject line, text, and HTML bodies are tenant
+	// content and are never exposed to an automation token.
+	mg.GET("/autoresponders", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		if cfg.Autoresponders == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "autoresponders unavailable"})
+			return
+		}
+		rows, err := cfg.Autoresponders.ListAll(ctx)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		// mailbox_id → email, so the manager sees an address, not a ULID.
+		emailByMailbox := map[string]string{}
+		if mbs, err := cfg.Mailboxes.ListAllWithDomain(ctx); err == nil {
+			for _, m := range mbs {
+				emailByMailbox[m.ID] = m.EmailCached
+			}
+		}
+		out := make([]map[string]any, 0, len(rows))
+		for _, ar := range rows {
+			out = append(out, map[string]any{
+				"mailbox_id": ar.MailboxID,
+				"email":      emailByMailbox[ar.MailboxID],
+				"enabled":    ar.Enabled,
+				"from_date":  ar.FromDate,
+				"to_date":    ar.ToDate,
+				"updated_at": ar.UpdatedAt,
+			})
+		}
+		c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
+	})
+}
+
+// listForwarders serves both the mailbox-level (/forwarders) and domain-scoped
+// (/domain-forwarders) views: they read the same table and differ only by
+// whether MailboxID is set. domainScoped=true selects the nil-MailboxID rows.
+func listForwarders(c *gin.Context, cfg AutomationConfig, domainLookup func(context.Context) map[string]struct{ Name, Owner string }, domainScoped bool) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	if cfg.Forwarders == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "forwarders unavailable"})
+		return
+	}
+	rows, _, err := cfg.Forwarders.ListAll(ctx, repository.ListOptions{Limit: 10000})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	doms := domainLookup(ctx)
+	out := make([]map[string]any, 0, len(rows))
+	for _, f := range rows {
+		isDomainScoped := f.MailboxID == nil
+		if isDomainScoped != domainScoped {
+			continue
+		}
+		d := doms[f.DomainID]
+		row := map[string]any{
+			"id":            f.ID,
+			"domain":        d.Name,
+			"owner_user_id": d.Owner,
+			"type":          f.Type,
+			"local_part":    f.LocalPart,
+			"target":        f.Target,
+			"enabled":       f.Enabled,
+			"keep_copy":     f.KeepCopy,
+		}
+		if !domainScoped {
+			row["mailbox_id"] = f.MailboxID
+		}
+		out = append(out, row)
+	}
+	c.JSON(http.StatusOK, gin.H{"data": out, "total": len(out)})
 }
 
 // automationMetrics caches the aggregated server metrics for a short TTL so a

--- a/panel-api/internal/api/automation_mail_reads_test.go
+++ b/panel-api/internal/api/automation_mail_reads_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// --- fakes (interface-embedding: only the read method each endpoint calls) ---
+
+type fakeFwdRepo struct {
+	repository.EmailForwarderRepository
+	rows []models.EmailForwarder
+}
+
+func (f fakeFwdRepo) ListAll(context.Context, repository.ListOptions) ([]models.EmailForwarder, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type fakeMGRepo struct {
+	repository.MailGroupRepository
+	rows []repository.MailGroupWithDomain
+}
+
+func (f fakeMGRepo) ListAllWithDomain(context.Context) ([]repository.MailGroupWithDomain, error) {
+	return f.rows, nil
+}
+
+type fakeARRepo struct {
+	repository.EmailAutoresponderRepository
+	rows []models.EmailAutoresponder
+}
+
+func (f fakeARRepo) ListAll(context.Context) ([]models.EmailAutoresponder, error) { return f.rows, nil }
+
+type fakeDomRepo struct {
+	repository.DomainRepository
+	rows []models.Domain
+}
+
+func (f fakeDomRepo) List(context.Context, repository.ListOptions) ([]models.Domain, int64, error) {
+	return f.rows, int64(len(f.rows)), nil
+}
+
+type fakeMbxRepo struct {
+	repository.MailboxRepository
+	rows []repository.MailboxWithDomain
+}
+
+func (f fakeMbxRepo) ListAllWithDomain(context.Context) ([]repository.MailboxWithDomain, error) {
+	return f.rows, nil
+}
+func (f fakeMbxRepo) CountAll(context.Context) (int64, error) { return int64(len(f.rows)), nil }
+
+// --- harness ---
+
+func mailReadRouter(cfg AutomationConfig, scope string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("")
+	tok := &models.AutomationToken{ID: "tok", Scopes: models.AutomationScopes{scope}}
+	grp.Use(func(c *gin.Context) { c.Set("jabali_automation_token", tok); c.Next() })
+	registerAutomationMailReads(grp, cfg)
+	return r
+}
+
+func getMail(r *gin.Engine, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func sptr(s string) *string { return &s }
+
+func decodeList(t *testing.T, w *httptest.ResponseRecorder) (data []map[string]any, total int) {
+	t.Helper()
+	var env struct {
+		Data  []map[string]any `json:"data"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode %s: %v", w.Body.String(), err)
+	}
+	return env.Data, env.Total
+}
+
+func fullMailCfg() AutomationConfig {
+	return AutomationConfig{
+		Mailboxes: fakeMbxRepo{rows: []repository.MailboxWithDomain{
+			{Mailbox: models.Mailbox{ID: "mb1", EmailCached: "alice@ex.com"}},
+		}},
+		Domains: fakeDomRepo{rows: []models.Domain{{ID: "d1", Name: "ex.com", UserID: "u1"}}},
+		Forwarders: fakeFwdRepo{rows: []models.EmailForwarder{
+			{ID: "f1", MailboxID: sptr("mb1"), DomainID: "d1", Type: "external", LocalPart: sptr("alice"), Target: "a@out.com", Enabled: true},
+			{ID: "f2", MailboxID: nil, DomainID: "d1", Type: "alias", LocalPart: sptr("info"), Target: "team@ex.com", Enabled: true},
+		}},
+		MailGroups: fakeMGRepo{rows: []repository.MailGroupWithDomain{
+			{MailGroup: models.MailGroup{ID: "g1", EmailCached: "team@ex.com", HasMailbox: true}, DomainName: "ex.com", UserUsername: "u1", MemberCount: 3},
+		}},
+		Autoresponders: fakeARRepo{rows: []models.EmailAutoresponder{
+			{MailboxID: "mb1", Enabled: true, Subject: sptr("OOO"), TextBody: sptr("secret body")},
+		}},
+	}
+}
+
+// --- tests ---
+
+func TestAutomationMail_Forwarders_SplitByScope(t *testing.T) {
+	r := mailReadRouter(fullMailCfg(), "read:mail")
+
+	// mailbox-level: only f1 (MailboxID set).
+	w := getMail(r, "/mail/forwarders")
+	if w.Code != http.StatusOK {
+		t.Fatalf("forwarders code=%d", w.Code)
+	}
+	data, total := decodeList(t, w)
+	if total != 1 || len(data) != 1 || data[0]["id"] != "f1" {
+		t.Fatalf("expected only the mailbox-level forwarder f1, got %v", data)
+	}
+	if data[0]["domain"] != "ex.com" {
+		t.Errorf("forwarder should be domain-enriched, got %v", data[0]["domain"])
+	}
+
+	// domain-scoped: only f2 (MailboxID nil).
+	w = getMail(r, "/mail/domain-forwarders")
+	data, total = decodeList(t, w)
+	if total != 1 || len(data) != 1 || data[0]["id"] != "f2" {
+		t.Fatalf("expected only the domain-scoped forwarder f2, got %v", data)
+	}
+	if _, hasMbx := data[0]["mailbox_id"]; hasMbx {
+		t.Errorf("domain-scoped forwarder must not carry mailbox_id")
+	}
+}
+
+func TestAutomationMail_Groups(t *testing.T) {
+	r := mailReadRouter(fullMailCfg(), "read:mail")
+	w := getMail(r, "/mail/groups")
+	if w.Code != http.StatusOK {
+		t.Fatalf("groups code=%d", w.Code)
+	}
+	data, total := decodeList(t, w)
+	if total != 1 || len(data) != 1 {
+		t.Fatalf("expected 1 group, got %v", data)
+	}
+	if data[0]["member_count"].(float64) != 3 || data[0]["has_mailbox"] != true {
+		t.Errorf("group flags/count wrong: %v", data[0])
+	}
+}
+
+func TestAutomationMail_Autoresponders_MetadataOnly(t *testing.T) {
+	r := mailReadRouter(fullMailCfg(), "read:mail")
+	w := getMail(r, "/mail/autoresponders")
+	if w.Code != http.StatusOK {
+		t.Fatalf("autoresponders code=%d", w.Code)
+	}
+	data, total := decodeList(t, w)
+	if total != 1 || data[0]["enabled"] != true || data[0]["email"] != "alice@ex.com" {
+		t.Fatalf("autoresponder row wrong: %v", data)
+	}
+	// Bodies must NEVER be exposed to an automation token.
+	for _, leaked := range []string{"text_body", "html_body", "subject"} {
+		if _, ok := data[0][leaked]; ok {
+			t.Errorf("autoresponder must not expose %q to automation", leaked)
+		}
+	}
+}
+
+func TestAutomationMail_MissingScope_403(t *testing.T) {
+	r := mailReadRouter(fullMailCfg(), "read:domains") // wrong scope
+	for _, p := range []string{"/mail/forwarders", "/mail/domain-forwarders", "/mail/groups", "/mail/autoresponders"} {
+		w := getMail(r, p)
+		if w.Code != http.StatusForbidden {
+			t.Errorf("%s without read:mail: code=%d, want 403", p, w.Code)
+		}
+	}
+}
+
+func TestAutomationMail_WildcardScopeAllows(t *testing.T) {
+	r := mailReadRouter(fullMailCfg(), "read:*")
+	if w := getMail(r, "/mail/groups"); w.Code != http.StatusOK {
+		t.Fatalf("read:* must cover read:mail, got %d", w.Code)
+	}
+}
+
+func TestAutomationMail_EmptyResultSets(t *testing.T) {
+	cfg := AutomationConfig{
+		Mailboxes:      fakeMbxRepo{},
+		Domains:        fakeDomRepo{},
+		Forwarders:     fakeFwdRepo{},
+		MailGroups:     fakeMGRepo{},
+		Autoresponders: fakeARRepo{},
+	}
+	r := mailReadRouter(cfg, "read:mail")
+	for _, p := range []string{"/mail/forwarders", "/mail/domain-forwarders", "/mail/groups", "/mail/autoresponders"} {
+		w := getMail(r, p)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s empty: code=%d", p, w.Code)
+		}
+		data, total := decodeList(t, w)
+		if total != 0 || len(data) != 0 {
+			t.Errorf("%s empty must be data:[] total:0, got %v", p, data)
+		}
+	}
+}

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -439,9 +439,10 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Applications: deps.WordPressInstalls,
 				Agent:        deps.Agent, // JAB-75: powers read:status metrics
 				// JAB-77: read:mail mail-stack inventory.
-				Mailboxes:  deps.Mailboxes,
-				MailGroups: deps.MailGroups,
-				Forwarders: deps.Forwarders,
+				Mailboxes:      deps.Mailboxes,
+				MailGroups:     deps.MailGroups,
+				Forwarders:     deps.Forwarders,
+				Autoresponders: deps.Autoresponders,
 				// JAB-140 write layer: async-op tracker + write audit + M30 backup path.
 				Operations:  automationOps(deps.DB),
 				Audits:      automationAudits(deps.DB),

--- a/panel-api/internal/repository/email_autoresponder_repository.go
+++ b/panel-api/internal/repository/email_autoresponder_repository.go
@@ -22,6 +22,10 @@ type EmailAutoresponderRepository interface {
 	// mailboxes (GH #240 — the Mailboxes tab "Auto replies" column fans
 	// out one bulk call per domain instead of one GET per mailbox).
 	ListByDomain(ctx context.Context, domainID string) ([]models.EmailAutoresponder, error)
+
+	// ListAll returns every autoresponder row server-wide (JAB-76 — the
+	// read-only automation mail inventory a fleet manager reads).
+	ListAll(ctx context.Context) ([]models.EmailAutoresponder, error)
 }
 
 type emailAutoresponderRepo struct {
@@ -69,5 +73,11 @@ func (r *emailAutoresponderRepo) ListByDomain(ctx context.Context, domainID stri
 		Joins("JOIN mailboxes m ON m.id = a.mailbox_id").
 		Where("m.domain_id = ?", domainID).
 		Find(&rows).Error
+	return rows, err
+}
+
+func (r *emailAutoresponderRepo) ListAll(ctx context.Context) ([]models.EmailAutoresponder, error) {
+	var rows []models.EmailAutoresponder
+	err := r.db.WithContext(ctx).Order("mailbox_id").Find(&rows).Error
 	return rows, err
 }


### PR DESCRIPTION
## What

The Jabali Manager Mail tab aggregates mailboxes, forwarders, mail groups, and autoresponders across enrolled servers, but the automation API only exposed **mailboxes/domains/summary** (JAB-77) — Manager got **HTTP 404** for the rest and couldn't populate the tab. Adds the four remaining read-only endpoints under the same `read:mail` scope + standard list envelope:

- `GET /api/v1/automation/mail/forwarders` — mailbox-level forwarders
- `GET /api/v1/automation/mail/domain-forwarders` — domain-scoped forwarders
- `GET /api/v1/automation/mail/groups` — groups with `member_count` + service flags
- `GET /api/v1/automation/mail/autoresponders` — status + schedule metadata

## Acceptance criteria

- [x] `/mail/mailboxes` returns mailboxes with domain + owner (already shipped, JAB-77).
- [x] `/mail/forwarders` returns mailbox-level forwarders.
- [x] `/mail/domain-forwarders` returns domain-scoped forwarders.
- [x] `/mail/groups` returns groups with member counts + service flags (`has_mailbox/calendar/addressbook/files`, `internal_only`, `group_kind`).
- [x] `/mail/autoresponders` returns status + schedule metadata; **bodies omitted** (subject/text/html never exposed to an automation token — the AC's metadata-only option).
- [x] All endpoints enforce `read:mail` / `read:*`, use the list envelope, and have tests for success, missing scope (403), and empty result sets.
- [ ] Manager enrolled with `read:mail` shows non-404 data from the fleet — QA's enrollment step; the routes are mounted (handler tests would 404 otherwise) and the fix directly addresses the 404 symptom.

## Design

- Forwarders + domain-forwarders read the same table and differ only by whether `MailboxID` is set → one `listForwarders` helper serves both.
- Rows enriched with domain name (+ owner user id) from a single `Domains` lookup, not per-row.
- The JAB-77 `/mail` block is extracted into `registerAutomationMailReads` (mirrors `registerAutomationWrites`) so handlers are unit-testable behind the scope gate without HMAC signing.
- New `EmailAutoresponderRepository.ListAll` (server-wide) backs the autoresponders endpoint; `AutomationConfig` gains `Autoresponders`, wired in `app.go`.

## Test plan

- [x] `go test ./panel-api/internal/api/ ./panel-api/internal/app/ ./panel-api/internal/repository/` — new `automation_mail_reads_test.go` (forwarder scope-split, group flags/counts, autoresponder metadata-only, missing-scope 403, wildcard allow, empty sets). Existing automation tests green (JAB-77 endpoints intact).
- [x] `go build ./panel-api/...`, `go vet` clean.
- [x] OpenAPI coverage golden unchanged (automation routes aren't in the coverage router — same as JAB-77).

GH: JAB-76
