### PR TITLE
feat(automation): read:metrics-scoped GET /automation/server-status for the fleet monitor (JAB-74)

### DIFF
--- a/docs/site/admin/automation-api.md
+++ b/docs/site/admin/automation-api.md
@@ -36,6 +36,32 @@ Authorization: Bearer <token>
 
 Tokens are sent as the `Authorization: Bearer …` header. The response includes `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers.
 
+## Fleet monitor metrics — `GET /api/v1/automation/server-status`
+
+For a central manager's Monitor tab. Gated by the `read:metrics` scope (a
+`read:*` token also grants it). Returns a thinned, normalized host-metrics
+envelope — not the raw admin server-status payload — so a fleet monitor gets
+live health without leaking host topology:
+
+```json
+{
+  "as_of": "2026-08-24T00:00:00Z",
+  "cpu":  { "usage_percent": 12.5, "iowait_percent": 1.2 },
+  "host": {
+    "mem_used_kb": 4000000,
+    "mem_total_kb": 8000000,
+    "load_avg": [0.5, 0.4, 0.3],
+    "partitions": [ { "mount_point": "/", "used_bytes": 40, "total_bytes": 100 } ]
+  }
+}
+```
+
+Each slice degrades independently: if the CPU or host collector fails, the
+other slice still renders and the failure is reported under an `errors` map
+rather than failing the whole response. `io` (read/write bps) is omitted until a
+per-device collector exists. Results are cached for a few seconds so a monitor
+polling every few seconds does not issue a fresh agent fan-out per request.
+
 ## Revocation
 
 Revoke from the same page. Revocation takes effect immediately; in-flight requests carrying the token complete but no further requests are accepted.

--- a/panel-api/internal/api/automation.go
+++ b/panel-api/internal/api/automation.go
@@ -219,6 +219,14 @@ func RegisterAutomation(rg *gin.RouterGroup, cfg AutomationConfig) {
 	metrics := newAutomationMetrics(cfg.Agent)
 	g.GET("/status", middleware.RequireScope("read:status"), metrics.handle)
 
+	// read:metrics — thinned, NORMALIZED host metrics for a fleet manager's
+	// Monitor tab (JAB-74). The Manager probes /automation/server-status
+	// specifically; unlike /status (which passes raw agent slices through under
+	// system/cpu/net keys), this returns a stable {as_of, cpu, host} shape and
+	// is gated by its own read:metrics scope.
+	serverStatus := newAutomationServerStatus(cfg.Agent)
+	g.GET("/server-status", middleware.RequireScope("read:metrics"), serverStatus.handle)
+
 	// read:mail — mail-stack inventory for a fleet manager (JAB-77 + JAB-76).
 	registerAutomationMailReads(g, cfg)
 
@@ -564,6 +572,142 @@ func (m *automationMetrics) handle(c *gin.Context) {
 	m.mu.Lock()
 	m.cached, m.cachedAt = out, time.Now()
 	m.mu.Unlock()
+	c.JSON(http.StatusOK, out)
+}
+
+// automationServerStatus serves GET /automation/server-status (JAB-74): a
+// thinned, NORMALIZED host-metrics envelope for a fleet manager's Monitor tab.
+// It fetches only system.info + system.cpu_usage (two agent calls, vs /status's
+// four) and maps them into a stable {as_of, cpu, host} shape the Manager reads,
+// rather than passing raw agent slices through. A short TTL cache collapses a
+// monitor's rapid polls into one fan-out; per-slice failures degrade into an
+// `errors` map instead of failing the whole response. Concurrency-safe.
+type automationServerStatus struct {
+	agent    agent.AgentInterface
+	mu       sync.Mutex
+	cached   gin.H
+	cachedAt time.Time
+	ttl      time.Duration
+}
+
+func newAutomationServerStatus(a agent.AgentInterface) *automationServerStatus {
+	return &automationServerStatus{agent: a, ttl: 5 * time.Second}
+}
+
+// ssHostInfo / ssCPU mirror the subset of system.info / system.cpu_usage this
+// endpoint surfaces. Declared locally so panel-api never imports the agent's
+// command package.
+type ssHostInfo struct {
+	LoadAvg    [3]float64 `json:"load_avg"`
+	MemTotalKB uint64     `json:"mem_total_kb"`
+	MemUsedKB  uint64     `json:"mem_used_kb"`
+	Partitions []struct {
+		MountPoint string `json:"mount_point"`
+		TotalBytes uint64 `json:"total_bytes"`
+		UsedBytes  uint64 `json:"used_bytes"`
+	} `json:"partitions"`
+}
+
+type ssCPU struct {
+	UsagePercent  float64 `json:"usage_percent"`
+	IOWaitPercent float64 `json:"iowait_percent"`
+	AsOf          string  `json:"as_of"`
+}
+
+func (s *automationServerStatus) handle(c *gin.Context) {
+	// No agent wired → thin healthy envelope, never fail closed.
+	if s.agent == nil {
+		c.JSON(http.StatusOK, gin.H{"as_of": time.Now().UTC().Format(time.RFC3339), "errors": gin.H{"agent": "unavailable"}})
+		return
+	}
+
+	s.mu.Lock()
+	if s.cached != nil && time.Since(s.cachedAt) < s.ttl {
+		out := s.cached
+		s.mu.Unlock()
+		c.JSON(http.StatusOK, out)
+		return
+	}
+	s.mu.Unlock()
+
+	ctx := c.Request.Context()
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(2)
+	var (
+		mu      sync.Mutex
+		infoRaw json.RawMessage
+		cpuRaw  json.RawMessage
+		errs    = map[string]string{}
+	)
+	fetch := func(name, cmd string, dst *json.RawMessage) {
+		g.Go(func() error {
+			sub, cancel := context.WithTimeout(gctx, 8*time.Second)
+			defer cancel()
+			raw, err := s.agent.Call(sub, cmd, nil)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs[name] = err.Error()
+				return nil
+			}
+			*dst = raw
+			return nil
+		})
+	}
+	fetch("host", "system.info", &infoRaw)
+	fetch("cpu", "system.cpu_usage", &cpuRaw)
+	_ = g.Wait()
+
+	out := gin.H{}
+	asOf := time.Now().UTC().Format(time.RFC3339)
+
+	if cpuRaw != nil {
+		var cp ssCPU
+		if json.Unmarshal(cpuRaw, &cp) == nil {
+			out["cpu"] = gin.H{
+				"usage_percent":  cp.UsagePercent,
+				"iowait_percent": cp.IOWaitPercent,
+			}
+			if cp.AsOf != "" {
+				asOf = cp.AsOf
+			}
+		} else {
+			errs["cpu"] = "unparseable cpu slice"
+		}
+	}
+
+	if infoRaw != nil {
+		var hi ssHostInfo
+		if json.Unmarshal(infoRaw, &hi) == nil {
+			parts := make([]gin.H, 0, len(hi.Partitions))
+			for _, p := range hi.Partitions {
+				parts = append(parts, gin.H{
+					"mount_point": p.MountPoint,
+					"used_bytes":  p.UsedBytes,
+					"total_bytes": p.TotalBytes,
+				})
+			}
+			out["host"] = gin.H{
+				"mem_used_kb":  hi.MemUsedKB,
+				"mem_total_kb": hi.MemTotalKB,
+				"load_avg":     hi.LoadAvg,
+				"partitions":   parts,
+			}
+		} else {
+			errs["host"] = "unparseable host slice"
+		}
+	}
+
+	out["as_of"] = asOf
+	// io is omitted: the agent has no per-device bps collector yet. JAB-74
+	// allows omitting `io` rather than failing the response.
+	if len(errs) > 0 {
+		out["errors"] = errs
+	}
+
+	s.mu.Lock()
+	s.cached, s.cachedAt = out, time.Now()
+	s.mu.Unlock()
 	c.JSON(http.StatusOK, out)
 }
 

--- a/panel-api/internal/api/automation_server_status_test.go
+++ b/panel-api/internal/api/automation_server_status_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/middleware"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+type ssAgent struct {
+	calls   int32
+	failCPU bool
+}
+
+func (a *ssAgent) Call(_ context.Context, cmd string, _ any) (json.RawMessage, error) {
+	atomic.AddInt32(&a.calls, 1)
+	switch cmd {
+	case "system.info":
+		return json.RawMessage(`{"load_avg":[0.5,0.4,0.3],"mem_total_kb":8000000,"mem_used_kb":4000000,"partitions":[{"mount_point":"/","total_bytes":100,"used_bytes":40}]}`), nil
+	case "system.cpu_usage":
+		if a.failCPU {
+			return nil, errors.New("cpu boom")
+		}
+		return json.RawMessage(`{"usage_percent":12.5,"iowait_percent":1.2,"as_of":"2026-08-24T00:00:00Z"}`), nil
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+func doServerStatus(ss *automationServerStatus) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/automation/server-status", nil)
+	ss.handle(c)
+	return w
+}
+
+func TestServerStatus_NormalizedShape(t *testing.T) {
+	ss := newAutomationServerStatus(&ssAgent{})
+	w := doServerStatus(ss)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code=%d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["as_of"] != "2026-08-24T00:00:00Z" {
+		t.Errorf("as_of should come from the cpu slice, got %v", body["as_of"])
+	}
+	cpu, _ := body["cpu"].(map[string]any)
+	if cpu == nil || cpu["usage_percent"].(float64) != 12.5 || cpu["iowait_percent"].(float64) != 1.2 {
+		t.Errorf("cpu shape wrong: %v", body["cpu"])
+	}
+	host, _ := body["host"].(map[string]any)
+	if host == nil {
+		t.Fatalf("missing host")
+	}
+	if host["mem_used_kb"].(float64) != 4000000 || host["mem_total_kb"].(float64) != 8000000 {
+		t.Errorf("host mem wrong: %v", host)
+	}
+	if la, _ := host["load_avg"].([]any); len(la) != 3 {
+		t.Errorf("load_avg should have 3 entries, got %v", host["load_avg"])
+	}
+	parts, _ := host["partitions"].([]any)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 partition, got %v", parts)
+	}
+	p0 := parts[0].(map[string]any)
+	if p0["mount_point"] != "/" || p0["used_bytes"].(float64) != 40 || p0["total_bytes"].(float64) != 100 {
+		t.Errorf("partition shape wrong: %v", p0)
+	}
+	if _, hasIO := body["io"]; hasIO {
+		t.Errorf("io must be omitted when no collector (got %v)", body["io"])
+	}
+	if _, hasErr := body["errors"]; hasErr {
+		t.Errorf("no errors expected on the happy path, got %v", body["errors"])
+	}
+}
+
+func TestServerStatus_PerSliceErrorDegrades(t *testing.T) {
+	ss := newAutomationServerStatus(&ssAgent{failCPU: true})
+	w := doServerStatus(ss)
+	if w.Code != http.StatusOK {
+		t.Fatalf("a failing slice must not fail the whole endpoint; code=%d", w.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if _, ok := body["host"]; !ok {
+		t.Error("host slice should still render when cpu fails")
+	}
+	if _, ok := body["cpu"]; ok {
+		t.Error("cpu slice must be absent when its fetch failed")
+	}
+	errs, _ := body["errors"].(map[string]any)
+	if errs == nil || errs["cpu"] == nil {
+		t.Errorf("cpu failure must surface in the errors map, got %v", body["errors"])
+	}
+}
+
+func TestServerStatus_NilAgent(t *testing.T) {
+	ss := newAutomationServerStatus(nil)
+	w := doServerStatus(ss)
+	if w.Code != http.StatusOK {
+		t.Fatalf("nil agent must not fail closed; code=%d", w.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body["as_of"] == nil {
+		t.Error("nil-agent envelope must still carry as_of")
+	}
+}
+
+func TestServerStatus_CachesRapidPolls(t *testing.T) {
+	ag := &ssAgent{}
+	ss := newAutomationServerStatus(ag)
+	_ = doServerStatus(ss)
+	first := atomic.LoadInt32(&ag.calls)
+	if first == 0 {
+		t.Fatal("expected agent calls on the first poll")
+	}
+	_ = doServerStatus(ss)
+	if atomic.LoadInt32(&ag.calls) != first {
+		t.Errorf("second poll within the TTL must hit the cache; calls %d -> %d", first, ag.calls)
+	}
+}
+
+func ssScopeRouter(scope string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	grp := r.Group("")
+	tok := &models.AutomationToken{ID: "t", Scopes: models.AutomationScopes{scope}}
+	grp.Use(func(c *gin.Context) { c.Set("jabali_automation_token", tok); c.Next() })
+	ss := newAutomationServerStatus(&ssAgent{})
+	grp.GET("/server-status", middleware.RequireScope("read:metrics"), ss.handle)
+	return r
+}
+
+func TestServerStatus_ScopeEnforcement(t *testing.T) {
+	for _, tc := range []struct {
+		scope string
+		want  int
+	}{
+		{"read:metrics", http.StatusOK},
+		{"read:*", http.StatusOK},
+		{"read:status", http.StatusForbidden}, // wrong read scope
+		{"read:domains", http.StatusForbidden},
+	} {
+		r := ssScopeRouter(tc.scope)
+		req := httptest.NewRequest(http.MethodGet, "/server-status", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != tc.want {
+			t.Errorf("scope %q: code=%d, want %d", tc.scope, w.Code, tc.want)
+		}
+	}
+}
+
+func TestServerStatus_ScopeInAllowlist(t *testing.T) {
+	found := false
+	for _, s := range models.AllowedAutomationScopes {
+		if s == "read:metrics" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("read:metrics must be in AllowedAutomationScopes so tokens can be minted with it")
+	}
+}

--- a/panel-api/internal/models/automation_token.go
+++ b/panel-api/internal/models/automation_token.go
@@ -133,6 +133,9 @@ var AllowedAutomationScopes = []string{
 	"read:applications",
 	"read:status",
 	"read:mail",
+	// JAB-74: thinned host metrics for a fleet manager's Monitor tab
+	// (GET /automation/server-status).
+	"read:metrics",
 	// ADR-0164: hosting-package list for billing-panel product mapping.
 	"read:packages",
 	// JAB-140 write scopes — least-privilege, independent of read. read:* does


### PR DESCRIPTION
## What

The Jabali Manager Monitor tab probes `GET /api/v1/automation/server-status` for per-server live CPU / RAM / IO / load / disk, but the panel exposed no such endpoint — Manager showed **"metrics unavailable: HTTP 404"**. JAB-75's `/automation/status` is a different path with a different (raw-slice) shape and its own `read:status` scope, so it doesn't satisfy the Manager.

## Acceptance criteria

- [x] `read:metrics` added to the allowed automation scopes (`AllowedAutomationScopes` — the single source of truth shared by the admin REST handler + root CLI).
- [x] `GET /api/v1/automation/server-status` behind the existing HMAC automation auth.
- [x] 403 when the token lacks `read:metrics` / `read:*`.
- [x] 200 with `as_of`, `cpu.usage_percent`, `cpu.iowait_percent`, `host.mem_used_kb`, `host.mem_total_kb`, `host.load_avg`, `host.partitions[]` (`mount_point`, `used_bytes`, `total_bytes`).
- [x] `io.read_bps/write_bps` — omitted (no per-device bps collector yet; JAB-74 permits omitting `io` rather than failing).
- [x] Per-slice degradation via an `errors` map instead of failing the whole endpoint.
- [x] Tests: success, missing scope, `read:*`, reduced-response shape.
- [x] Docs updated (`automation-api.md`).

## Design

A **normalized** envelope (not the raw agent slices `/status` passes through): it fetches only `system.info` + `system.cpu_usage` (two agent calls) and maps their fields into the stable `{as_of, cpu, host}` shape the Manager reads. A 5s TTL cache collapses a monitor's rapid polls into one agent fan-out, mirroring `/status`.

## Test plan

- [x] `go test ./panel-api/internal/api/ ./panel-api/internal/models/ ./panel-api/internal/app/` — new `automation_server_status_test.go` (normalized shape, per-slice error degradation, nil-agent, TTL cache, scope matrix, scope-in-allowlist). Existing automation tests green.
- [x] `go build ./panel-api/...`, `go vet` clean. CLI-reference + OpenAPI-coverage goldens unchanged.

GH: JAB-74
