### PR TITLE
feat(dr): dr.sync.stalled notification when a standby stops syncing (GH #1169)

### DIFF
--- a/panel-api/cmd/server/serve.go
+++ b/panel-api/cmd/server/serve.go
@@ -1039,13 +1039,20 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// GH #331 Step 2: DR standby pull-restore loop. Inert on a primary (it
 	// re-reads server_role each tick), so it is always safe to start; on a
 	// standby it converges the panel DB/config/TLS from the DR destination.
-	if syncer := drsync.New(drsync.Deps{
+	drSyncDeps := drsync.Deps{
 		Settings:     deps.ServerSettings,
 		Destinations: deps.BackupDestinations,
 		Agent:        deps.Agent,
 		SSOKey:       deps.SSOKey,
 		Log:          log,
-	}); syncer != nil {
+	}
+	// GH #1169: wire the dr.sync.stalled alert only when the queue exists —
+	// assigning a nil *Queue into the DRNotifier interface would be a non-nil
+	// interface wrapping a nil pointer (Publish would panic).
+	if deps.NotificationQueue != nil {
+		drSyncDeps.Notify = deps.NotificationQueue
+	}
+	if syncer := drsync.New(drSyncDeps); syncer != nil {
 		go syncer.Start(ctx)
 	} else {
 		log.Info("DR sync loop not started — required deps missing")

--- a/panel-api/internal/drsync/stall.go
+++ b/panel-api/internal/drsync/stall.go
@@ -1,0 +1,84 @@
+package drsync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+// GH #1169 (deferred #331 blueprint step 5) — dr.sync.stalled.
+//
+// A DR standby that silently stops applying snapshots is worthless at promote
+// time, and today its staleness is visible only via `jabali dr status` on the
+// standby itself. This raises the dr.sync.stalled notification the moment the
+// replica falls behind, so the operator learns about it BEFORE the disaster.
+
+// staleBaseline picks the reference time a standby's freshness is measured from:
+// the last applied snapshot, or — before the first one ever lands — when it was
+// paired. Returns (time, true) when a baseline exists.
+func staleBaseline(s *models.ServerSettings) (time.Time, bool) {
+	if s == nil {
+		return time.Time{}, false
+	}
+	if s.DRLastSyncAt != nil {
+		return *s.DRLastSyncAt, true
+	}
+	if s.DRPairedAt != nil {
+		return *s.DRPairedAt, true
+	}
+	return time.Time{}, false
+}
+
+// isStalled reports whether `now` is more than `threshold` past the baseline.
+// Pure, so the staleness decision is unit-tested without a clock or DB.
+func isStalled(baseline time.Time, hasBaseline bool, now time.Time, threshold time.Duration) bool {
+	if !hasBaseline || threshold <= 0 {
+		return false
+	}
+	return now.Sub(baseline) > threshold
+}
+
+// checkStall evaluates staleness after a tick and publishes dr.sync.stalled once
+// per episode (reset when a fresh sync brings the replica back under threshold).
+// Best-effort: a settings-read or publish error is logged, never fatal — the
+// loop must keep converging.
+func (s *Syncer) checkStall(ctx context.Context) {
+	if s.deps.Notify == nil {
+		return
+	}
+	settings, err := s.deps.Settings.Get(ctx)
+	if err != nil || settings == nil || !settings.IsStandby() {
+		return
+	}
+	baseline, ok := staleBaseline(settings)
+	if !isStalled(baseline, ok, time.Now(), s.stalledAfter) {
+		s.stalledAlerted = false // fresh (or no baseline) → re-arm the alert
+		return
+	}
+	if s.stalledAlerted {
+		return // already alerted this episode
+	}
+	age := time.Since(baseline).Round(time.Second)
+	peer := settings.DRPeerLabel
+	if peer == "" {
+		peer = "unlabelled"
+	}
+	env := notifications.Envelope{
+		EventKind: "dr.sync.stalled",
+		Severity:  "error",
+		Title:     "DR standby sync stalled",
+		Body: fmt.Sprintf("This DR standby (peer %s) has not applied a fresh snapshot in %s "+
+			"(threshold %s). The replica is going stale — check the DR destination and "+
+			"`jabali dr status` before you need to promote.", peer, age, s.stalledAfter),
+		Deeplink: "/jabali-admin/settings",
+	}
+	if _, perr := s.deps.Notify.Publish(ctx, env); perr != nil {
+		s.deps.Log.Warn("DR stall alert publish failed", "err", perr)
+		return
+	}
+	s.stalledAlerted = true
+	s.deps.Log.Warn("DR sync stalled — alert published", "age", age.String(), "threshold", s.stalledAfter.String())
+}

--- a/panel-api/internal/drsync/stall_test.go
+++ b/panel-api/internal/drsync/stall_test.go
@@ -1,0 +1,83 @@
+package drsync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
+)
+
+func TestIsStalled(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	base := now.Add(-10 * time.Minute)
+	if !isStalled(base, true, now, 5*time.Minute) {
+		t.Error("10m old vs 5m threshold should be stalled")
+	}
+	if isStalled(now.Add(-1*time.Minute), true, now, 5*time.Minute) {
+		t.Error("1m old vs 5m threshold should NOT be stalled")
+	}
+	if isStalled(base, false, now, 5*time.Minute) {
+		t.Error("no baseline → never stalled")
+	}
+	if isStalled(base, true, now, 0) {
+		t.Error("zero threshold → never stalled")
+	}
+}
+
+func TestStaleBaseline(t *testing.T) {
+	last := time.Date(2026, 8, 24, 11, 0, 0, 0, time.UTC)
+	paired := time.Date(2026, 8, 24, 10, 0, 0, 0, time.UTC)
+	if b, ok := staleBaseline(&models.ServerSettings{DRLastSyncAt: &last, DRPairedAt: &paired}); !ok || !b.Equal(last) {
+		t.Errorf("want last-sync baseline, got %v ok=%v", b, ok)
+	}
+	if b, ok := staleBaseline(&models.ServerSettings{DRPairedAt: &paired}); !ok || !b.Equal(paired) {
+		t.Errorf("want paired-at baseline, got %v ok=%v", b, ok)
+	}
+	if _, ok := staleBaseline(&models.ServerSettings{}); ok {
+		t.Error("no last-sync/paired → no baseline")
+	}
+}
+
+type stallNotify struct{ n int }
+
+func (f *stallNotify) Publish(context.Context, notifications.Envelope) (string, error) {
+	f.n++
+	return "id", nil
+}
+
+func TestCheckStall_AlertsOncePerEpisode(t *testing.T) {
+	old := time.Now().Add(-30 * time.Minute)
+	settings := &models.ServerSettings{ServerRole: models.ServerRoleStandby, DRLastSyncAt: &old}
+	notify := &stallNotify{}
+	s := New(Deps{
+		Settings:     &fakeSettings{s: settings},
+		Destinations: &fakeDests{},
+		Agent:        &fakeAgent{},
+		Notify:       notify,
+		StalledAfter: time.Minute,
+	})
+	s.checkStall(context.Background())
+	s.checkStall(context.Background())
+	if notify.n != 1 {
+		t.Fatalf("stalled: want 1 alert, got %d", notify.n)
+	}
+	fresh := time.Now()
+	settings.DRLastSyncAt = &fresh
+	s.checkStall(context.Background()) // fresh → re-arm
+	settings.DRLastSyncAt = &old
+	s.checkStall(context.Background()) // stalled again → 2nd alert
+	if notify.n != 2 {
+		t.Fatalf("re-armed: want 2 alerts, got %d", notify.n)
+	}
+}
+
+func TestCheckStall_NilNotifyIsNoop(t *testing.T) {
+	old := time.Now().Add(-30 * time.Minute)
+	s := New(Deps{
+		Settings:     &fakeSettings{s: &models.ServerSettings{ServerRole: models.ServerRoleStandby, DRLastSyncAt: &old}},
+		Destinations: &fakeDests{}, Agent: &fakeAgent{}, StalledAfter: time.Minute,
+	})
+	s.checkStall(context.Background()) // must not panic with nil Notify
+}

--- a/panel-api/internal/drsync/syncer.go
+++ b/panel-api/internal/drsync/syncer.go
@@ -38,6 +38,7 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/backupwrapperhelpers"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/notifications"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ssokey"
 )
 
@@ -76,6 +77,20 @@ type Deps struct {
 	// DefaultTickTimeout. system.restore over a slow remote can take minutes,
 	// so this is generous; the agent client honours the ctx deadline.
 	TickTimeout time.Duration
+
+	// Notify publishes the dr.sync.stalled alert when the replica goes stale
+	// (GH #1169). Optional: nil disables the alert (the loop still runs). This
+	// is the failure an operator must learn about BEFORE a disaster — a standby
+	// that silently stopped syncing is worthless at promote time.
+	Notify DRNotifier
+	// StalledAfter is how long without a fresh applied snapshot counts as
+	// stalled. Zero → DefaultStalledCycles × Interval.
+	StalledAfter time.Duration
+}
+
+// DRNotifier is the Publish subset of *notifications.Queue the stall alert needs.
+type DRNotifier interface {
+	Publish(ctx context.Context, env notifications.Envelope) (string, error)
 }
 
 const (
@@ -85,6 +100,10 @@ const (
 	DefaultInterval = 60 * time.Second
 	// DefaultTickTimeout bounds one list+restore cycle.
 	DefaultTickTimeout = 15 * time.Minute
+	// DefaultStalledCycles: without a fresh applied snapshot for this many
+	// intervals, the replica is declared stalled. 5 × 60s = a 5-minute grace,
+	// long enough to ride out a couple of transient destination hiccups.
+	DefaultStalledCycles = 5
 )
 
 // Syncer runs the standby pull-restore loop.
@@ -96,6 +115,10 @@ type Syncer struct {
 	// applied restore (the DB was just reloaded, so one transient failure is
 	// plausible). Tests shrink it.
 	reassertRetryDelay time.Duration
+	// stalledAfter is the resolved staleness threshold; stalledAlerted
+	// de-dupes the alert to once per stall episode (reset on a fresh sync).
+	stalledAfter   time.Duration
+	stalledAlerted bool
 }
 
 // New returns a Syncer, or nil if a required dependency is missing (so the
@@ -115,7 +138,11 @@ func New(deps Deps) *Syncer {
 	if tt <= 0 {
 		tt = DefaultTickTimeout
 	}
-	return &Syncer{deps: deps, interval: interval, tickTimeout: tt, reassertRetryDelay: 2 * time.Second}
+	stalledAfter := deps.StalledAfter
+	if stalledAfter <= 0 {
+		stalledAfter = time.Duration(DefaultStalledCycles) * interval
+	}
+	return &Syncer{deps: deps, interval: interval, tickTimeout: tt, reassertRetryDelay: 2 * time.Second, stalledAfter: stalledAfter}
 }
 
 // Start runs the loop until ctx is cancelled. Ticks are sequential: the next
@@ -154,6 +181,9 @@ func (s *Syncer) tick(parent context.Context) {
 	default:
 		s.deps.Log.Debug("DR sync tick", "status", res.Status, "snapshot_id", res.SnapshotID)
 	}
+	// GH #1169: after every standby tick, check whether the replica has gone
+	// stale and alert once per episode.
+	s.checkStall(parent)
 }
 
 // Result reports what one SyncOnce did, for tests and the tick logger.

--- a/panel-api/internal/models/notification_event_setting.go
+++ b/panel-api/internal/models/notification_event_setting.go
@@ -73,6 +73,13 @@ var AllNotificationEventKinds = []NotificationEventKindMeta{
 		DefaultOn:   true,
 	},
 	{
+		Kind:        "dr.sync.stalled",
+		Label:       "DR standby sync stalled",
+		Description: "This DR standby has not applied a fresh snapshot within several sync cycles — the replica is going stale. Fix before you need to promote.",
+		Severity:    "error",
+		DefaultOn:   true,
+	},
+	{
 		Kind:        "disk.quota.warn",
 		Label:       "User reached 90% quota",
 		Description: "A hosting user crossed 90% of their disk quota.",

--- a/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.test.ts
@@ -27,6 +27,7 @@ const CATALOG_KINDS = [
   "backup.fail",
   "backup.success",
   "backup.limit.reached",
+  "dr.sync.stalled",
   "admin.login",
   "ssh.login",
   "notifications.channel.auto_disabled",

--- a/panel-ui/src/shells/admin/notifications/eventCategories.ts
+++ b/panel-ui/src/shells/admin/notifications/eventCategories.ts
@@ -104,6 +104,7 @@ export const EVENT_KIND_CATEGORY: Record<string, EventCategoryId> = {
   "backup.fail": "backups",
   "backup.success": "backups",
   "backup.limit.reached": "backups",
+  "dr.sync.stalled": "backups",
 
   // Mail
   "mail.rbl.listed": "mail",


### PR DESCRIPTION
Deferred #331 blueprint step 5 (visibility), first half. Follows #1265 (the promote-completeness gaps).

## Why
A DR standby that silently stops applying snapshots is worthless at promote time — but today its staleness is visible **only** via `jabali dr status` run *on the standby itself*. This raises a notification the moment the replica falls behind, so the operator learns of it **before** a disaster.

## What
- After each standby tick, the drsync loop checks the age of the last **applied** snapshot (or, before the first one lands, the pairing time). Past `DefaultStalledCycles × Interval` (**5 min** at the 60 s cadence; configurable via `Deps.StalledAfter`) it publishes **`dr.sync.stalled`** — **once per stall episode**, re-armed when a fresh sync lands.
- Best-effort: a nil queue or a publish error is logged and never disturbs the converge loop.
- New event kind `dr.sync.stalled` (severity `error`, default-on) in `AllNotificationEventKinds`, plus the panel-ui `eventCategories` map (**backups**) and its test mirror — so the Go↔TS cross-boundary sync tests stay green.
- `serve.go` wires `deps.NotificationQueue` into drsync, guarded against the typed-nil-in-interface trap (a nil `*Queue` would make `Publish` panic).

## Tests
- `isStalled` (threshold / no-baseline / zero-threshold), `staleBaseline` (last-sync vs paired-at vs none)
- `checkStall`: alerts once per episode, re-arms after a fresh sync, no-op with a nil `Notify`
- `TestNotificationEventCategoriesTSInSync` (Go) + `eventCategories.test.ts` (TS) both green

## Verify at next two-node drill
- [ ] With a paired standby, stop the DR feed (or block the destination) → after ~5 min the standby raises `dr.sync.stalled`; a resumed feed re-arms it.

Remaining #1169: the admin DR status card (step 5 second half), gap 2 (feed retention), runbook items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)