### PR TITLE
fix(mail): CLI alias forwarder stores its own address, not the mailbox's — 2nd alias no longer collides (JAB-319)

### DIFF
--- a/panel-api/cmd/server/mailbox_extras_cmd.go
+++ b/panel-api/cmd/server/mailbox_extras_cmd.go
@@ -339,9 +339,11 @@ func newMailboxForwarderAddCmd() *cobra.Command {
 			if fwdType == "alias" {
 				lp := localPart
 				f.LocalPart = &lp
-				// Alias target = the mailbox itself; matches the HTTP
-				// handler's default when target is omitted.
-				f.Target = mb.LocalPart + "@" + dom.Name
+				// Alias target = the alias's OWN address, matching the HTTP
+				// handler. It had regressed to the mailbox address, so a
+				// mailbox's 2nd alias collided on uq_external_forward and
+				// failed (GH #280 / JAB-319). Shared helper = no re-drift.
+				f.Target = models.AliasForwarderTarget(localPart, dom.Name)
 			} else {
 				f.Target = target
 				f.KeepCopy = keepCopy

--- a/panel-api/internal/api/mailbox_forwarder.go
+++ b/panel-api/internal/api/mailbox_forwarder.go
@@ -220,7 +220,7 @@ func (h *forwarderHandler) create(c *gin.Context) {
 		// key and failed (GH #280). Store the alias's OWN address, which is unique
 		// per alias, so a mailbox can hold many aliases.
 		if req.Type == "alias" {
-			req.Target = req.LocalPart + "@" + dom.Name
+			req.Target = models.AliasForwarderTarget(req.LocalPart, dom.Name)
 		} else {
 			req.Target = mb.LocalPart + "@" + dom.Name
 		}

--- a/panel-api/internal/models/email_forwarder.go
+++ b/panel-api/internal/models/email_forwarder.go
@@ -27,3 +27,20 @@ type EmailForwarder struct {
 }
 
 func (EmailForwarder) TableName() string { return "email_forwarders" }
+
+// AliasForwarderTarget is the canonical value stored in
+// email_forwarders.target for an ALIAS forwarder: the alias's OWN address
+// (aliasLocalPart@domain).
+//
+// The target column is unused at apply time (alias delivery is by
+// local_part -> mailbox), but it is part of the
+// uq_external_forward(mailbox_id, type, target) unique key. Every alias used
+// to default to the SAME mailbox address, so a mailbox's SECOND alias collided
+// on that key and failed (GH #280). Using the alias's own address keeps the
+// value unique per alias, so one mailbox can hold many aliases.
+//
+// The HTTP handler and the CLI both call this so they can never drift on the
+// stored target again (JAB-319: the CLI had regressed to the mailbox address).
+func AliasForwarderTarget(aliasLocalPart, domain string) string {
+	return aliasLocalPart + "@" + domain
+}

--- a/panel-api/internal/models/email_forwarder_target_test.go
+++ b/panel-api/internal/models/email_forwarder_target_test.go
@@ -1,0 +1,32 @@
+package models
+
+import "testing"
+
+// JAB-319 / GH #280: the alias target must be the alias's OWN address, so two
+// aliases on one mailbox get DISTINCT targets and never collide on
+// uq_external_forward(mailbox_id, type, target). The CLI had regressed to the
+// mailbox address (same for every alias), which failed the second alias.
+func TestAliasForwarderTarget_UniquePerAlias(t *testing.T) {
+	domain := "example.com"
+
+	sales := AliasForwarderTarget("sales", domain)
+	support := AliasForwarderTarget("support", domain)
+
+	if sales != "sales@example.com" {
+		t.Errorf("alias target should be its own address, got %q", sales)
+	}
+	if support != "support@example.com" {
+		t.Errorf("alias target should be its own address, got %q", support)
+	}
+	// The crux: two aliases on the same mailbox produce DIFFERENT targets, so
+	// the (mailbox_id, type, target) unique key admits both.
+	if sales == support {
+		t.Fatal("two aliases on one mailbox must have distinct targets (unique-key collision otherwise)")
+	}
+	// And an alias target is NEVER the mailbox's own address — that was the bug
+	// (every alias defaulting to mailbox@domain collided).
+	mailbox := "info" // the owning mailbox local part
+	if AliasForwarderTarget("sales", domain) == mailbox+"@"+domain {
+		t.Fatal("alias target must not equal the mailbox address")
+	}
+}


### PR DESCRIPTION
## What

The HTTP forwarder handler stores an **alias's** target as the alias's own address (`local_part@domain`) so a mailbox can hold many aliases without colliding on `uq_external_forward(mailbox_id, type, target)` — the GH #280 fix. **The CLI never got that fix**: it stored the **mailbox** address as the target for every alias, so a mailbox's second alias produced a duplicate `(mailbox_id, 'alias', mailbox@domain)` key and the create failed.

## Fix

Extract the canonical alias target into `models.AliasForwarderTarget` and call it from **both** the HTTP handler and the CLI, so the stored target — and the emitted Agent payload — can never drift between the two surfaces again (the Mailbox Forwarder Lifecycle Module's "owns canonical targets" invariant, applied in the one place that was actually broken).

## Acceptance criteria

- [x] Two or more aliases for one mailbox succeed (distinct targets → distinct unique keys).
- [x] Each alias target is its own canonical address.
- [x] HTTP and CLI emit identical Agent payloads (shared helper).
- [x] Agent failure preserves DB truth: the row is persisted before the best-effort `applyForwardersCLI`, so a failed apply leaves the alias in the DB for the reconciler to converge (unchanged behaviour).

## Verification

`models.AliasForwarderTarget` unit test proves distinct per-alias targets and that an alias target is never the mailbox address — the exact collision cause the CLI had reintroduced. This is logically complete against the unique key `(mailbox_id, type, target)`: distinct targets → distinct keys → both rows insert. The fix mirrors the HTTP path already proven in production (GH #280), so it's unit-verified rather than box-verified (a box test would mutate live Stalwart mail state for a pure target-string fix).

## Test plan

- [x] `go test ./panel-api/internal/models/` — `email_forwarder_target_test.go`.
- [x] `go build ./panel-api/...`, HTTP forwarder tests + CLI-reference golden unchanged (internal logic only, no help-text change).

GH: JAB-319 (CLI-parity slice of the Mailbox Forwarder Lifecycle Module — the full module extraction of AddAlias/AddExternal/Delete/Reapply stays open on the parent)
