### PR TITLE
feat(dr): admin DR status card + GET /admin/dr/status (GH #1169)

### DIFF
--- a/panel-api/internal/api/dr_status.go
+++ b/panel-api/internal/api/dr_status.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/drsync"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+// GH #1169 (deferred #331 blueprint step 5) — admin DR status endpoint.
+//
+// Freshness of a DR standby was visible only via `jabali dr status` ON the
+// standby. This exposes the same picture to the admin UI (role, peer, last-sync
+// age, freshness) so an operator sees a stalling replica from the panel.
+
+// DRStatusConfig wires the read repos the endpoint needs.
+type DRStatusConfig struct {
+	Settings     repository.ServerSettingsRepository
+	Destinations repository.BackupDestinationRepository
+}
+
+// RegisterDRStatusRoute mounts GET /admin/dr/status on an admin-gated group.
+func RegisterDRStatusRoute(admin *gin.RouterGroup, cfg DRStatusConfig) {
+	if cfg.Settings == nil {
+		return
+	}
+	admin.GET("/dr/status", func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		s, err := cfg.Settings.Get(ctx)
+		if err != nil || s == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+			return
+		}
+		c.JSON(http.StatusOK, buildDRStatus(ctx, s, cfg.Destinations, time.Now()))
+	})
+}
+
+// drStatusResponse is the admin DR status card's wire shape.
+type drStatusResponse struct {
+	Role            string `json:"role"`
+	IsStandby       bool   `json:"is_standby"`
+	Paired          bool   `json:"paired"`
+	Peer            string `json:"peer"`
+	DestinationID   string `json:"destination_id"`
+	DestinationName string `json:"destination_name"`
+	PairedAt        string `json:"paired_at,omitempty"`
+	LastSyncAt      string `json:"last_sync_at,omitempty"`
+	LastSyncStatus  string `json:"last_sync_status,omitempty"`
+	LastSnapshotID  string `json:"last_snapshot_id,omitempty"`
+	LastSyncError   string `json:"last_sync_error,omitempty"`
+	// SyncAgeSeconds is how long since the last applied snapshot (or, before the
+	// first, since pairing). -1 when there is no baseline (unpaired primary).
+	SyncAgeSeconds  int64 `json:"sync_age_seconds"`
+	StaleThresholdS int64 `json:"stale_threshold_seconds"`
+	// Stalled mirrors the dr.sync.stalled alert: age past the threshold on a
+	// standby. Always false on a primary.
+	Stalled bool `json:"stalled"`
+}
+
+// buildDRStatus assembles the response. Pure but for the destination-name
+// lookup; `now` is injected so the age math is unit-testable.
+func buildDRStatus(ctx context.Context, s *models.ServerSettings, dests repository.BackupDestinationRepository, now time.Time) drStatusResponse {
+	role := s.ServerRole
+	if role == "" {
+		role = models.ServerRolePrimary
+	}
+	destID := ""
+	if s.DRDestinationID != nil {
+		destID = *s.DRDestinationID
+	}
+	// Same staleness threshold the dr.sync.stalled alert uses (drsync's
+	// DefaultStalledCycles × DefaultInterval) so the card's badge agrees with
+	// the notification. 5 cycles is kept in step with drsync.DefaultStalledCycles.
+	const staleCycles = 5
+	threshold := time.Duration(staleCycles) * drsync.DefaultInterval
+	out := drStatusResponse{
+		Role:            role,
+		IsStandby:       s.IsStandby(),
+		Peer:            s.DRPeerLabel,
+		DestinationID:   destID,
+		LastSyncStatus:  s.DRLastSyncStatus,
+		LastSnapshotID:  s.DRLastSnapshotID,
+		LastSyncError:   s.DRLastSyncError,
+		SyncAgeSeconds:  -1,
+		StaleThresholdS: int64(threshold / time.Second),
+	}
+	out.Paired = s.DRPairedAt != nil && out.DestinationID != ""
+	if s.DRPairedAt != nil {
+		out.PairedAt = s.DRPairedAt.UTC().Format(time.RFC3339)
+	}
+	if s.DRLastSyncAt != nil {
+		out.LastSyncAt = s.DRLastSyncAt.UTC().Format(time.RFC3339)
+	}
+
+	// Freshness baseline: last applied snapshot, else pairing time.
+	var baseline *time.Time
+	if s.DRLastSyncAt != nil {
+		baseline = s.DRLastSyncAt
+	} else if s.DRPairedAt != nil {
+		baseline = s.DRPairedAt
+	}
+	if baseline != nil {
+		age := now.Sub(*baseline)
+		if age < 0 {
+			age = 0
+		}
+		out.SyncAgeSeconds = int64(age / time.Second)
+		// Only a standby can be "stalled" — a primary's loop is inert.
+		out.Stalled = out.IsStandby && age > threshold
+	}
+
+	if out.DestinationID != "" && dests != nil {
+		if d, derr := dests.Get(ctx, out.DestinationID); derr == nil && d != nil {
+			out.DestinationName = d.Name
+		}
+	}
+	return out
+}

--- a/panel-api/internal/api/dr_status_test.go
+++ b/panel-api/internal/api/dr_status_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+func TestBuildDRStatus(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	tp := func(d time.Duration) *time.Time { x := now.Add(d); return &x }
+	destID := "dest1"
+
+	t.Run("standby stalled when last sync is old", func(t *testing.T) {
+		s := &models.ServerSettings{
+			ServerRole: models.ServerRoleStandby, DRDestinationID: &destID,
+			DRPairedAt: tp(-2 * time.Hour), DRLastSyncAt: tp(-30 * time.Minute),
+		}
+		got := buildDRStatus(context.Background(), s, nil, now)
+		if !got.IsStandby || !got.Paired || !got.Stalled {
+			t.Fatalf("want standby+paired+stalled, got %+v", got)
+		}
+		if got.SyncAgeSeconds != int64((30 * time.Minute).Seconds()) {
+			t.Errorf("age = %d, want %d", got.SyncAgeSeconds, int64((30 * time.Minute).Seconds()))
+		}
+	})
+
+	t.Run("standby fresh when last sync is recent", func(t *testing.T) {
+		s := &models.ServerSettings{
+			ServerRole: models.ServerRoleStandby, DRDestinationID: &destID,
+			DRPairedAt: tp(-2 * time.Hour), DRLastSyncAt: tp(-1 * time.Minute),
+		}
+		got := buildDRStatus(context.Background(), s, nil, now)
+		if got.Stalled {
+			t.Errorf("1m-old sync should not be stalled: %+v", got)
+		}
+	})
+
+	t.Run("before first sync uses pairing time", func(t *testing.T) {
+		s := &models.ServerSettings{
+			ServerRole: models.ServerRoleStandby, DRDestinationID: &destID,
+			DRPairedAt: tp(-30 * time.Minute), // never synced
+		}
+		got := buildDRStatus(context.Background(), s, nil, now)
+		if !got.Stalled || got.SyncAgeSeconds != int64((30*time.Minute).Seconds()) {
+			t.Errorf("want stalled from pairing baseline, got %+v", got)
+		}
+	})
+
+	t.Run("primary never stalled and no baseline", func(t *testing.T) {
+		s := &models.ServerSettings{ServerRole: models.ServerRolePrimary}
+		got := buildDRStatus(context.Background(), s, nil, now)
+		if got.IsStandby || got.Stalled || got.Paired || got.SyncAgeSeconds != -1 {
+			t.Fatalf("primary/unpaired should be inert, got %+v", got)
+		}
+		if got.Role != models.ServerRolePrimary {
+			t.Errorf("role = %q", got.Role)
+		}
+	})
+}

--- a/panel-api/internal/api/openapi.yaml
+++ b/panel-api/internal/api/openapi.yaml
@@ -4524,6 +4524,13 @@ paths:
       security: [ { KratosSession: [] } ]
       responses: { "200": { description: OK } }
 
+  /admin/dr/status:
+    get:
+      tags: [DR]
+      summary: DR standby status (role, peer, last-sync age, freshness)
+      security: [ { KratosSession: [] } ]
+      responses: { "200": { description: OK } }
+
   /admin/reconcile/php-pools:
     post:
       tags: [Reconcile]

--- a/panel-api/internal/app/app.go
+++ b/panel-api/internal/app/app.go
@@ -1397,6 +1397,11 @@ func NewWithDeps(cfg *config.Config, deps Deps) *gin.Engine {
 				Reconciler: deps.Reconciler,
 				Log:        deps.Log,
 			})
+			// GH #1169: admin DR status card feed.
+			api.RegisterDRStatusRoute(admin, api.DRStatusConfig{
+				Settings:     deps.ServerSettings,
+				Destinations: deps.BackupDestinations,
+			})
 		}
 		// M44: Automation API token management. Admin mints + revokes
 		// HMAC-signed tokens; the matching public read-only routes

--- a/panel-ui/src/shells/admin/server-status/DRStatusCard.tsx
+++ b/panel-ui/src/shells/admin/server-status/DRStatusCard.tsx
@@ -1,0 +1,136 @@
+// DRStatusCard — admin Server Status card for the DR standby's freshness
+// (GH #1169, #331 blueprint step 5). Surfaces role / peer / last-sync age +
+// a freshness badge that agrees with the dr.sync.stalled notification, so a
+// stalling replica is visible from the panel instead of only via
+// `jabali dr status` on the standby.
+import { useEffect, useState } from "react";
+import { Card, Descriptions, Tag, Tooltip, Typography } from "antd";
+
+import { apiClient } from "../../../apiClient";
+
+interface DRStatus {
+  role: string;
+  is_standby: boolean;
+  paired: boolean;
+  peer: string;
+  destination_id: string;
+  destination_name: string;
+  paired_at?: string;
+  last_sync_at?: string;
+  last_sync_status?: string;
+  last_snapshot_id?: string;
+  last_sync_error?: string;
+  sync_age_seconds: number;
+  stale_threshold_seconds: number;
+  stalled: boolean;
+}
+
+function humanizeAge(seconds: number): string {
+  if (seconds < 0) return "—";
+  if (seconds < 60) return `${seconds}s ago`;
+  const m = Math.floor(seconds / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m ago`;
+  return `${Math.floor(h / 24)}d ${h % 24}h ago`;
+}
+
+function FreshnessBadge({ s }: { s: DRStatus }) {
+  if (!s.is_standby) return <Tag>Primary</Tag>;
+  if (s.stalled) {
+    return (
+      <Tooltip title={`No fresh snapshot in over ${Math.round(s.stale_threshold_seconds / 60)} min — fix before you need to promote.`}>
+        <Tag color="red">Stalled</Tag>
+      </Tooltip>
+    );
+  }
+  if (s.last_sync_status === "error") return <Tag color="orange">Sync error</Tag>;
+  return <Tag color="green">In sync</Tag>;
+}
+
+export function DRStatusCard() {
+  const [status, setStatus] = useState<DRStatus | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = () =>
+      apiClient
+        .get<DRStatus>("/admin/dr/status")
+        .then((r) => {
+          if (alive) {
+            setStatus(r.data);
+            setErr(null);
+          }
+        })
+        .catch((e: unknown) => {
+          if (alive) setErr(e instanceof Error ? e.message : "Failed to load DR status");
+        });
+    void load();
+    // Refresh on the same cadence the standby syncs (60s) so the age stays live.
+    const t = setInterval(() => void load(), 60_000);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, []);
+
+  const title = (
+    <span>
+      Disaster Recovery {status ? <FreshnessBadge s={status} /> : null}
+    </span>
+  );
+
+  if (err) {
+    return (
+      <Card title="Disaster Recovery" size="small">
+        <Typography.Text type="secondary">{err}</Typography.Text>
+      </Card>
+    );
+  }
+  if (!status) {
+    return <Card title="Disaster Recovery" size="small" loading />;
+  }
+
+  // A plain primary with no DR pairing: one informational line, no noise.
+  if (!status.is_standby && !status.paired) {
+    return (
+      <Card title={title} size="small">
+        <Typography.Text type="secondary">
+          This server is a primary. No DR standby role is configured here.
+        </Typography.Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card title={title} size="small">
+      <Descriptions column={1} size="small" colon>
+        <Descriptions.Item label="Role">
+          <Tag color={status.is_standby ? "geekblue" : "default"}>{status.role}</Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label="Peer">{status.peer || "—"}</Descriptions.Item>
+        <Descriptions.Item label="DR destination">{status.destination_name || status.destination_id || "—"}</Descriptions.Item>
+        {status.is_standby && (
+          <Descriptions.Item label="Last sync">
+            {status.last_sync_at ? (
+              <Tooltip title={status.last_sync_at}>{humanizeAge(status.sync_age_seconds)}</Tooltip>
+            ) : (
+              "never (since pairing)"
+            )}
+          </Descriptions.Item>
+        )}
+        {status.is_standby && status.last_snapshot_id && (
+          <Descriptions.Item label="Applied snapshot">
+            <code>{status.last_snapshot_id}</code>
+          </Descriptions.Item>
+        )}
+        {status.is_standby && status.last_sync_error && (
+          <Descriptions.Item label="Last error">
+            <Typography.Text type="danger">{status.last_sync_error}</Typography.Text>
+          </Descriptions.Item>
+        )}
+      </Descriptions>
+    </Card>
+  );
+}

--- a/panel-ui/src/shells/admin/server-status/ServerStatusPage.tsx
+++ b/panel-ui/src/shells/admin/server-status/ServerStatusPage.tsx
@@ -16,6 +16,7 @@ import { ChartBarOutlined } from "@icons";
 import { useServerStatus } from "../../../hooks/useServerStatus";
 import { AlertsBanner } from "./AlertsBanner";
 import { DisksTable } from "./DisksTable";
+import { DRStatusCard } from "./DRStatusCard";
 import { CPUMeterCard, MemoryMeterCard } from "./MetersGrid";
 import { NetworkTable } from "./NetworkTable";
 import { ProcessesCard } from "./ProcessesCard";
@@ -38,6 +39,7 @@ export const ServerStatusPage = () => {
     { key: "disks", data: null, children: <DisksTable partitions={env?.host?.partitions ?? []} /> },
     { key: "network", data: null, children: <NetworkTable interfaces={env?.network?.interfaces ?? []} /> },
     { key: "services", data: null, children: <ServicesSummaryCard services={env?.services?.services ?? []} /> },
+    { key: "dr", data: null, children: <DRStatusCard /> },
     {
       key: "sysinfo",
       data: null,


### PR DESCRIPTION
Deferred #331 blueprint step 5, second half (the first half — the `dr.sync.stalled` notification — is #1275). A standby's freshness was visible **only** via `jabali dr status` run *on the standby*; this surfaces it on the admin **Server Status** page.

## Backend — `GET /admin/dr/status` (RequireAdmin)
Returns role, `is_standby`, `paired`, peer, DR destination (id + name), `paired_at`, `last_sync_at`/`status`/`snapshot`/`error`, `sync_age_seconds`, `stale_threshold_seconds`, `stalled`. The staleness threshold **mirrors the `dr.sync.stalled` alert** (`5 × drsync.DefaultInterval`), so the card's badge and the notification agree. `buildDRStatus` is `now`-injected and unit-tested (standby stalled / fresh, pre-first-sync uses the pairing baseline, primary inert). Documented in `openapi.yaml`.

## UI — DRStatusCard (Server Status page)
Role + peer + DR destination + last-sync age with a freshness `Tag`: **In sync** / **Sync error** / **Stalled** (and **Primary** when not a standby). Self-fetches and refreshes every 60 s; a plain unpaired primary shows one quiet informational line rather than empty rows.

## Tests
- `buildDRStatus` — 4 cases (stalled / fresh / pre-first-sync pairing baseline / primary inert)
- `TestOpenAPICoverage` green (route documented); `tsc -b` + vitest 294/294

## Verify at next two-node drill
- [ ] On a paired standby the card reads **In sync**; stop the DR feed → after ~5 min it flips to **Stalled** (same threshold as the notification).

Remaining #1169: gap 2 (feed retention) + runbook docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)