### PR TITLE
fix(dnssec): fail closed on a malformed enable reply + CLI DS requires DNSSEC enabled (JAB-322)

### DIFF
--- a/panel-api/cmd/server/pdns_cmd.go
+++ b/panel-api/cmd/server/pdns_cmd.go
@@ -57,17 +57,13 @@ func newPdnsDNSSECEnableCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("dns.dnssec_enable: %w", err)
 			}
-			var resp struct {
-				Ok   bool `json:"ok"`
-				Keys []struct {
-					KeyTag    int    `json:"key_tag"`
-					KeyType   string `json:"key_type"`
-					Algorithm uint8  `json:"algorithm"`
-					PublicKey string `json:"public_key"`
-					Active    bool   `json:"active"`
-				} `json:"keys"`
+			// JAB-322 fail closed: only flip the DB flag on a well-formed,
+			// ok=true reply. A malformed / ok=false reply leaves DNSSEC state
+			// unchanged (the old `_ = json.Unmarshal` flipped it regardless).
+			resp, ok := models.ParseDNSSECEnableReply(raw)
+			if !ok {
+				return fmt.Errorf("dns.dnssec_enable returned a malformed or unsuccessful reply; DNSSEC state left unchanged")
 			}
-			_ = json.Unmarshal(raw, &resp)
 			if err := domainRepoFromDB().UpdateDNSSECEnabled(ctx, dom.ID, true); err != nil {
 				return fmt.Errorf("update dnssec flag: %w", err)
 			}
@@ -85,7 +81,13 @@ func newPdnsDNSSECEnableCmd() *cobra.Command {
 					ObservedAt: now,
 				})
 			}
-			_ = keysRepo.ReplaceAll(ctx, dom.ID, cached)
+			// AC #2: a key-cache persist failure must be visible. The enable
+			// itself succeeded (the zone is signed), so this warns rather than
+			// failing the command; `status` re-lists from the cache and `get`
+			// refreshes live, so the miss self-heals.
+			if err := keysRepo.ReplaceAll(ctx, dom.ID, cached); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: DNSSEC enabled for %s but key cache not persisted: %v\n", dom.Name, err)
+			}
 			if jsonOutput {
 				return printJSON(resp)
 			}
@@ -152,7 +154,19 @@ func newPdnsDNSSECDSCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
-			raw, err := sharedAgent.Call(ctx, "dns.dnssec_ds_export", map[string]any{"domain_name": args[0]})
+			// AC #3: DS export requires DNSSEC to be enabled for the zone.
+			// Exporting DS for an unsigned zone would tempt an operator to
+			// publish it at the registrar, which breaks resolution (resolvers
+			// expect a signed zone). The lookup also validates the domain
+			// exists before hitting the agent. Mirrors the HTTP dsExport 409.
+			dom, err := domainRepoFromDB().FindByName(ctx, args[0])
+			if err != nil {
+				return fmt.Errorf("lookup domain %q: %w", args[0], err)
+			}
+			if !dom.DNSSECEnabled {
+				return fmt.Errorf("DNSSEC is not enabled for %s — run `jabali pdns dnssec enable %s` first; publishing DS for an unsigned zone breaks resolution", dom.Name, dom.Name)
+			}
+			raw, err := sharedAgent.Call(ctx, "dns.dnssec_ds_export", map[string]any{"domain_name": dom.Name})
 			if err != nil {
 				return fmt.Errorf("dns.dnssec_ds_export: %w", err)
 			}

--- a/panel-api/internal/api/domain_dnssec.go
+++ b/panel-api/internal/api/domain_dnssec.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -33,6 +34,10 @@ func RegisterDomainDNSSECRoutes(g *gin.RouterGroup, cfg DomainDNSSECHandlerConfi
 }
 
 type domainDNSSECHandler struct{ cfg DomainDNSSECHandlerConfig }
+
+// errMalformedDNSSECReply is returned (as a 502) when dns.dnssec_enable comes
+// back malformed or ok=false — JAB-322 fail-closed: the DB flag stays as-is.
+var errMalformedDNSSECReply = errors.New("dns.dnssec_enable returned a malformed or unsuccessful reply")
 
 type dnssecKey struct {
 	KeyTag    int    `json:"key_tag"`
@@ -147,19 +152,18 @@ func (h *domainDNSSECHandler) update(c *gin.Context) {
 			return
 		}
 		if req.Enabled {
-			var agentResp struct {
-				Ok   bool `json:"ok"`
-				Keys []struct {
-					KeyTag    int    `json:"key_tag"`
-					KeyType   string `json:"key_type"`
-					Algorithm uint8  `json:"algorithm"`
-					PublicKey string `json:"public_key"`
-					Active    bool   `json:"active"`
-				} `json:"keys"`
+			// JAB-322 fail closed: a malformed or ok=false reply must NOT flip
+			// dnssec_enabled — return 502 with the DB row untouched (the agent
+			// enable did not verifiably succeed). A transport failure is already
+			// an error handled above; this guards the success-with-garbage-body
+			// case the old `_ = json.Unmarshal` silently accepted.
+			reply, ok := models.ParseDNSSECEnableReply(raw)
+			if !ok {
+				respondAgentErr(c, "agent_error", errMalformedDNSSECReply)
+				return
 			}
-			_ = json.Unmarshal(raw, &agentResp)
 			now := time.Now().UTC()
-			for _, k := range agentResp.Keys {
+			for _, k := range reply.Keys {
 				liveKeys = append(liveKeys, models.DomainDNSSECKey{
 					DomainID:   dom.ID,
 					KeyTag:     k.KeyTag,

--- a/panel-api/internal/api/domain_dnssec_failclose_test.go
+++ b/panel-api/internal/api/domain_dnssec_failclose_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/auth"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ginctx"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+type dnssecRawAgent struct {
+	raw string
+	err error
+}
+
+func (a dnssecRawAgent) Call(_ context.Context, _ string, _ any) (json.RawMessage, error) {
+	if a.err != nil {
+		return nil, a.err
+	}
+	return json.RawMessage(a.raw), nil
+}
+
+type dnssecFakeKeys struct{}
+
+func (dnssecFakeKeys) ListByDomainID(context.Context, string) ([]models.DomainDNSSECKey, error) {
+	return nil, nil
+}
+func (dnssecFakeKeys) ReplaceAll(context.Context, string, []models.DomainDNSSECKey) error { return nil }
+func (dnssecFakeKeys) DeleteAllForDomain(context.Context, string) error                   { return nil }
+
+func dnssecUpdateRouter(dom *models.Domain, ag *dnssecRawAgent) (*gin.Engine, *mockDomainRepo) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	repo := newMockDomainRepo()
+	repo.domains[dom.ID] = dom
+	v1 := r.Group("/api/v1")
+	v1.Use(func(c *gin.Context) {
+		ginctx.SetClaims(c, &auth.AccessClaims{UserID: dom.UserID, IsAdmin: true})
+		c.Next()
+	})
+	RegisterDomainDNSSECRoutes(v1, DomainDNSSECHandlerConfig{Agent: ag, Domains: repo, Keys: dnssecFakeKeys{}})
+	return r, repo
+}
+
+func putEnableDNSSEC(r *gin.Engine, id string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/domains/"+id+"/dnssec", strings.NewReader(`{"enabled":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// JAB-322: an enable whose agent reply is malformed or ok=false must leave
+// dnssec_enabled UNCHANGED (fail closed) and return 502 — the old code flipped
+// the flag regardless of the reply.
+func TestDNSSECUpdate_MalformedReply_LeavesFlagUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{"malformed json", `{"ok":true,"keys":`},
+		{"ok false", `{"ok":false}`},
+		{"garbage", `not json`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", DNSSECEnabled: false}
+			r, repo := dnssecUpdateRouter(dom, &dnssecRawAgent{raw: tc.raw})
+			w := putEnableDNSSEC(r, "d1")
+
+			if w.Code != http.StatusBadGateway {
+				t.Errorf("want 502 on a bad reply, got %d", w.Code)
+			}
+			if repo.domains["d1"].DNSSECEnabled {
+				t.Error("dnssec_enabled must stay false when the agent reply is not a clean success (fail closed)")
+			}
+		})
+	}
+}
+
+func TestDNSSECUpdate_OkReply_FlipsFlag(t *testing.T) {
+	dom := &models.Domain{ID: "d1", Name: "ex.com", UserID: "u1", DNSSECEnabled: false}
+	r, repo := dnssecUpdateRouter(dom, &dnssecRawAgent{raw: `{"ok":true,"keys":[{"key_tag":1,"key_type":"KSK","algorithm":13}]}`})
+	w := putEnableDNSSEC(r, "d1")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 on a clean enable, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !repo.domains["d1"].DNSSECEnabled {
+		t.Error("dnssec_enabled must be true after a clean ok=true reply")
+	}
+}

--- a/panel-api/internal/models/dnssec.go
+++ b/panel-api/internal/models/dnssec.go
@@ -1,0 +1,38 @@
+package models
+
+import "encoding/json"
+
+// DNSSECEnableKey is one key in a dns.dnssec_enable agent reply.
+type DNSSECEnableKey struct {
+	KeyTag    int    `json:"key_tag"`
+	KeyType   string `json:"key_type"`
+	Algorithm uint8  `json:"algorithm"`
+	PublicKey string `json:"public_key"`
+	Active    bool   `json:"active"`
+}
+
+// DNSSECEnableReply mirrors the agent's dns.dnssec_enable success payload
+// (the handler returns {ok:true, keys:[...]}; the transport layer already
+// turns a transport-level failure into an error before this point).
+type DNSSECEnableReply struct {
+	Ok   bool              `json:"ok"`
+	Keys []DNSSECEnableKey `json:"keys"`
+}
+
+// ParseDNSSECEnableReply parses a dns.dnssec_enable reply and reports whether
+// it is a well-formed SUCCESS (ok=true bit set by the agent handler).
+//
+// JAB-322 — fail closed: a reply that fails to parse or carries ok=false is
+// NOT a success, and callers MUST leave dnssec_enabled unchanged rather than
+// flipping the flag on a malformed/unsuccessful reply. Both the HTTP handler
+// and the CLI go through this one function so they can never drift on the
+// gate. (The happy path is byte-identical to the old `_ = json.Unmarshal`:
+// a real enable returns ok=true, so this simply stops trusting a reply that
+// the old code silently accepted.)
+func ParseDNSSECEnableReply(raw []byte) (DNSSECEnableReply, bool) {
+	var r DNSSECEnableReply
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return DNSSECEnableReply{}, false
+	}
+	return r, r.Ok
+}

--- a/panel-api/internal/models/dnssec_test.go
+++ b/panel-api/internal/models/dnssec_test.go
@@ -1,0 +1,32 @@
+package models
+
+import "testing"
+
+func TestParseDNSSECEnableReply(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantOK  bool
+		wantLen int
+	}{
+		{"ok true with keys", `{"ok":true,"keys":[{"key_tag":1,"key_type":"KSK"},{"key_tag":2,"key_type":"ZSK"}]}`, true, 2},
+		{"ok true no keys", `{"ok":true,"keys":[]}`, true, 0},
+		{"ok false", `{"ok":false,"keys":[{"key_tag":1}]}`, false, 0},
+		{"missing ok defaults false", `{"keys":[{"key_tag":1}]}`, false, 0},
+		{"malformed json", `{"ok":true,"keys":`, false, 0},
+		{"empty", ``, false, 0},
+		{"garbage", `not json at all`, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reply, ok := ParseDNSSECEnableReply([]byte(tc.raw))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			// On a non-success the caller must not use keys (fail closed).
+			if ok && len(reply.Keys) != tc.wantLen {
+				t.Errorf("keys len = %d, want %d", len(reply.Keys), tc.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Both the HTTP handler and the CLI flipped `dnssec_enabled` to true after a `dns.dnssec_enable` call **regardless of the reply**: `_ = json.Unmarshal(raw, &resp)` ignored the parse error and never checked the `ok` bit. A success-with-garbage-body reply therefore marked a zone "signed" in the DB with no valid keys — and that flag drives DS export + resolver expectations.

## Fail closed (one shared gate)

- `models.ParseDNSSECEnableReply` reports success only when the reply is well-formed **and** `ok=true`. The transport layer already turns an agent failure into an error (handled separately), so this guards exactly the malformed / `ok=false` body. HTTP + CLI both call it → no drift.
- **HTTP update:** non-success reply → 502 with the DB row **unchanged** (matches the handler's stated "agent fails → row left unchanged" contract).
- **CLI enable:** non-success reply → error, DNSSEC state unchanged.

Happy path is **byte-identical** to before (a real enable returns `ok=true`); this only stops trusting a reply the old code silently accepted. `Call` returns the handler's `resp.Data` (`{ok,keys}`) with `ok` at the top level, so the gate reads the right field.

## Acceptance criteria

- [x] **#1** Malformed agent replies leave DB state unchanged (HTTP + CLI).
- [x] **#3** DS output requires enabled DNSSEC — CLI `pdns dnssec ds` now checks `dom.DNSSECEnabled` first (mirrors HTTP's 409); the `FindByName` lookup also validates the domain exists instead of passing the raw arg to the agent.
- [x] **#2 (CLI side)** key-cache persist failure is visible — CLI enable warns on stderr instead of swallowing `ReplaceAll`; the enable succeeded so it warns rather than failing, and status/get self-heal. HTTP's swallowed `ReplaceAll` is the *compensated* branch: `get`'s live `refreshKeys` re-fetches keys.
- [ ] **#4** cache-vs-live status semantics shared (CLI status still cache-only) — parent.
- [ ] **#5** full HTTP/CLI transcript matrix for enable/disable ordering — parent.

## Notes

- **Version skew:** an agent predating the `ok` field would now fail closed until it updates — correct (better than flag-without-signing), and both binaries deploy together; the panel parse structs have always declared `ok`, so no new skew.
- **Known-unchanged:** with a nil agent, HTTP `update` flips the flag having made no agent call — a different case from "malformed reply" that dev/test topologies may rely on; left as-is.

## Test plan

- [x] `go test ./panel-api/internal/models/ ./panel-api/internal/api/` — `ParseDNSSECEnableReply` (ok / ok=false / malformed / missing-ok / empty); HTTP update fail-closed (malformed / ok=false / garbage → 502 flag-still-false; ok=true → 200 flag-true) via a recording mock domain repo.
- [x] `go build ./panel-api/...`, `go vet`, CLI-reference golden unchanged (no flags/help/route changes).

GH: JAB-322 (fail-closed + DS-gate slice of the DNSSEC Lifecycle Module; the Enable/Disable/Status/DS module extraction stays open on the parent)
