### PR TITLE
fix(dns): CLI normalises four-field SRV records like the HTTP handler (JAB-323)

### DIFF
--- a/panel-api/cmd/server/dns_cmd.go
+++ b/panel-api/cmd/server/dns_cmd.go
@@ -60,7 +60,21 @@ type dnsRecordSpec struct {
 	Content  string
 	TTL      int
 	Priority int
-	Enabled  bool
+	// PriorityExplicit is true when the operator passed --priority. It mirrors
+	// the HTTP request's `*int` priority so SRV normalisation knows whether to
+	// derive the priority from a four-field content or keep the explicit value.
+	PriorityExplicit bool
+	Enabled          bool
+}
+
+// srvPriorityPtr adapts the CLI's (int, explicit-bool) to the *int the shared
+// api.NormaliseSRVRecord expects: nil = "derive priority from four-field SRV
+// content", non-nil = "operator set it explicitly, keep it".
+func srvPriorityPtr(p int, explicit bool) *int {
+	if explicit {
+		return &p
+	}
+	return nil
 }
 
 // dnsRecordAdd validates + conflict-checks + persists a new record in the zone
@@ -81,6 +95,11 @@ func dnsRecordAdd(ctx context.Context, zones repository.DNSZoneRepository, recs 
 		Managed:   false,
 		IsEnabled: spec.Enabled,
 	}
+	// JAB-323: split a four-field SRV content ("prio weight port target") into
+	// the priority column + three-field content, exactly as the HTTP handler
+	// does — the CLI used to persist the raw four-field content with priority 0,
+	// producing a malformed SRV record PowerDNS wouldn't serve correctly.
+	api.NormaliseSRVRecord(rec, srvPriorityPtr(spec.Priority, spec.PriorityExplicit))
 	// ValidateDNSRecord trims/upper-cases and defaults TTL 0 -> 300.
 	if err := api.ValidateDNSRecord(rec); err != nil {
 		return nil, err
@@ -133,6 +152,12 @@ func dnsRecordUpdate(ctx context.Context, zones repository.DNSZoneRepository, re
 	}
 	if set["enabled"] {
 		rec.IsEnabled = spec.Enabled
+	}
+	// JAB-323: normalise a four-field SRV content on update too (HTTP parity).
+	// An explicit --priority (set["priority"]) is kept; otherwise the priority
+	// is derived from the four-field content.
+	if set["content"] {
+		api.NormaliseSRVRecord(rec, srvPriorityPtr(spec.Priority, set["priority"]))
 	}
 	if err := api.ValidateDNSRecord(rec); err != nil {
 		return nil, err
@@ -303,7 +328,8 @@ func newDNSRecordAddCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
 			rec, err := dnsRecordAdd(ctx, dnsZoneRepoFromDB(), dnsRecordRepoFromDB(), args[0], dnsRecordSpec{
-				Name: name, Type: rtype, Content: content, TTL: ttl, Priority: priority, Enabled: !disabled,
+				Name: name, Type: rtype, Content: content, TTL: ttl,
+				Priority: priority, PriorityExplicit: cmd.Flags().Changed("priority"), Enabled: !disabled,
 			})
 			if err != nil {
 				return err

--- a/panel-api/cmd/server/dns_cmd_srv_test.go
+++ b/panel-api/cmd/server/dns_cmd_srv_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// JAB-323: the CLI must split a four-field SRV content into the priority column
+// + three-field content exactly as the HTTP handler does. It used to persist
+// the raw four-field content with priority 0 — a malformed SRV record.
+func TestDNSRecordAdd_SRVFourFieldNormalised(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+
+	rec, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{
+		Name: "_sip._tcp", Type: "SRV", Content: "10 5 5060 sip.example.com", Enabled: true,
+		// no explicit --priority: derive it from the four-field content
+	})
+	if err != nil {
+		t.Fatalf("add SRV: %v", err)
+	}
+	if rec.Content != "5 5060 sip.example.com" {
+		t.Errorf("content should be the three-field remainder, got %q", rec.Content)
+	}
+	if rec.Priority != 10 {
+		t.Errorf("priority should be split out of the content (10), got %d", rec.Priority)
+	}
+}
+
+// An explicit --priority is honoured even when the content still carries a
+// leading field (mirrors the HTTP *int-priority semantics).
+func TestDNSRecordAdd_SRVExplicitPriorityKept(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+
+	rec, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{
+		Name: "_sip._tcp", Type: "SRV", Content: "10 5 5060 sip.example.com",
+		Priority: 20, PriorityExplicit: true, Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("add SRV: %v", err)
+	}
+	if rec.Content != "5 5060 sip.example.com" {
+		t.Errorf("content should still be normalised to three fields, got %q", rec.Content)
+	}
+	if rec.Priority != 20 {
+		t.Errorf("explicit priority must be kept (20), got %d", rec.Priority)
+	}
+}
+
+func TestDNSRecordUpdate_SRVNormalised(t *testing.T) {
+	ctx := context.Background()
+	zones := newMemDNSZoneRepo(testDNSZone())
+	recs := newMemDNSRecordRepo()
+
+	orig, err := dnsRecordAdd(ctx, zones, recs, "example.com", dnsRecordSpec{
+		Name: "_sip._tcp", Type: "SRV", Content: "10 5 5060 sip.example.com", Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Update the content to a new four-field value; it must normalise too.
+	upd, err := dnsRecordUpdate(ctx, zones, recs, "example.com", orig.ID,
+		dnsRecordSpec{Content: "30 1 443 svc.example.com"},
+		map[string]bool{"content": true})
+	if err != nil {
+		t.Fatalf("update SRV: %v", err)
+	}
+	if upd.Content != "1 443 svc.example.com" {
+		t.Errorf("updated content should be three fields, got %q", upd.Content)
+	}
+	if upd.Priority != 30 {
+		t.Errorf("updated priority should be split out (30), got %d", upd.Priority)
+	}
+}

--- a/panel-api/internal/api/dns.go
+++ b/panel-api/internal/api/dns.go
@@ -386,7 +386,7 @@ func (h *dnsHandler) createRecord(c *gin.Context) {
 		record.IsEnabled = *req.IsEnabled
 	}
 
-	normaliseSRVRecord(record, req.Priority)
+	NormaliseSRVRecord(record, req.Priority)
 
 	// Validate record
 	if err := ValidateDNSRecord(record); err != nil {
@@ -511,7 +511,7 @@ func (h *dnsHandler) updateRecord(c *gin.Context) {
 		record.IsEnabled = *req.IsEnabled
 	}
 
-	normaliseSRVRecord(record, req.Priority)
+	NormaliseSRVRecord(record, req.Priority)
 
 	// Per-type permission gate for non-admin tenants (GH #466): editing the
 	// record needs the edit right on its current type, and changing its type
@@ -663,7 +663,7 @@ func IsValidDNSType(t string) bool {
 	return false
 }
 
-// normaliseSRVRecord moves an inline SRV priority into the priority column.
+// NormaliseSRVRecord moves an inline SRV priority into the priority column.
 //
 // PowerDNS's gmysql backend prepends the prio column to SRV content, so a
 // record carrying the priority in BOTH places assembles into a five-field
@@ -676,7 +676,7 @@ func IsValidDNSType(t string) bool {
 // Accept it, split the priority out, and leave the already-correct
 // three-field form untouched. An explicit priority in the request wins, since
 // that is the caller being unambiguous.
-func normaliseSRVRecord(r *models.DNSRecord, explicitPriority *int) {
+func NormaliseSRVRecord(r *models.DNSRecord, explicitPriority *int) {
 	if r.Type != "SRV" {
 		return
 	}
@@ -751,7 +751,7 @@ func ValidateDNSRecord(r *models.DNSRecord) error {
 		//
 		// This used to require the four-field form, which meant every SRV
 		// created through the panel was unresolvable and a caller supplying
-		// the correct three fields was rejected. normaliseSRVRecord now
+		// the correct three fields was rejected. NormaliseSRVRecord now
 		// splits a pasted RFC 2782 string before validation, so both shapes
 		// reach here as three fields.
 		fields := strings.Fields(r.Content)

--- a/panel-api/internal/api/dns_srv_normalise_test.go
+++ b/panel-api/internal/api/dns_srv_normalise_test.go
@@ -82,7 +82,7 @@ func TestNormaliseSRVRecord(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := tc.in
-			normaliseSRVRecord(&rec, tc.explicit)
+			NormaliseSRVRecord(&rec, tc.explicit)
 			if rec.Content != tc.wantContent {
 				t.Errorf("content = %q, want %q", rec.Content, tc.wantContent)
 			}


### PR DESCRIPTION
## What

The HTTP DNS handler splits a four-field SRV content (`prio weight port target`) into the priority column + a three-field content via `normaliseSRVRecord`. The CLI shared the low-level validators but **not** this step: `jabali dns record add --type SRV --content "10 5 5060 sip.example.com"` persisted the raw four-field content with priority 0 → a **malformed SRV record** PowerDNS wouldn't serve correctly, while the same record via the API stored correctly. CLI and API disagreed on the wire.

## Fix

Export the existing normaliser as `api.NormaliseSRVRecord` (one canonical, already unit-tested implementation) and call it from the CLI's `dnsRecordAdd` and `dnsRecordUpdate` — right where the HTTP handler calls it, before validation + conflict checks. An explicit `--priority` is threaded through as the `*int` the normaliser expects (`dnsRecordSpec.PriorityExplicit` on add; `set["priority"]` on update), mirroring the HTTP request's `*int` priority: nil derives from the four-field content, non-nil keeps the operator's value.

## Acceptance criteria

- [x] **#3** Four-field SRV input works consistently — CLI now stores the same normalised `(priority, content)` as the API.
- [ ] **#1** Admin edit of a managed MX hands off to operator-owned state — parent (CLI still refuses managed records; a policy change, not a normalisation bug).
- [ ] **#2** SOA/NS remain protected — unchanged (still protected).
- [ ] **#4** Default TTL from the same settings rule — parent (CLI uses the 0→300 validator default; settings-derived TTL is a separate read).
- [ ] **#5** Every mutation schedules the owning domain — parent (the CLI runs out-of-process from the reconciler, so it has no in-process `Schedule()` handle; a separate design item, distinct from JAB-371's in-process HTTP path).

## Test plan

- [x] `go test ./panel-api/cmd/server/ ./panel-api/internal/api/` — new `dns_cmd_srv_test.go`: four-field add splits priority + normalises content; explicit `--priority` honoured with a leading field; update normalises a new four-field content. Existing HTTP `TestNormaliseSRVRecord` green after the exported rename.
- [x] `go build ./panel-api/...`, `go vet`, CLI-reference golden unchanged.

GH: JAB-323 (SRV-normalisation slice; managed-handoff / settings-TTL / scheduling stay open on the parent)
