### PR TITLE
fix(db): CLI db-user password rotation sends new_password, not password (JAB-285)

### DIFF
--- a/panel-api/cmd/server/db_user_parity_cmd.go
+++ b/panel-api/cmd/server/db_user_parity_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
@@ -49,12 +50,11 @@ func newDBUserRotatePasswordCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("hash password: %w", err)
 			}
-			verb, params := "db_user.rotate_password", map[string]any{"db_user_name": du.Username, "password": plain}
-			if du.Engine == "postgres" {
-				// pg has no separate rotate; create_role's idempotent upsert ALTERs
-				// the password (mirrors the REST handler).
-				verb, params = "db.postgres.create_role", map[string]any{"role": du.Username, "password": plain}
-			}
+			// JAB-285: same engine-correct wire contract as the REST handler.
+			// The CLI previously sent `password` for the MariaDB rotate verb,
+			// but the agent field is `new_password` (empty → rejected), so CLI
+			// MariaDB rotation always failed. The shared helper prevents re-drift.
+			verb, params := api.DBUserRotateAgentCommand(du.Engine, du.Username, plain)
 			if _, err := sharedAgent.Call(ctx, verb, params); err != nil {
 				cliAuditErr(ctx, "db_user.rotate_password", "database_user", du.ID, &du.UserID)
 				return fmt.Errorf("agent %s: %w", verb, err)

--- a/panel-api/internal/api/database_users.go
+++ b/panel-api/internal/api/database_users.go
@@ -847,6 +847,20 @@ func (h *databaseUserHandler) delete(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
+// DBUserRotateAgentCommand returns the engine-correct agent verb + params for
+// rotating a database user's password. Shared by the REST handler and the
+// operator CLI so they can never drift on the wire contract (JAB-285): the
+// MariaDB rotate command's field is new_password — the CLI had regressed to
+// `password`, which the agent rejects as "new_password cannot be empty", so
+// CLI MariaDB rotation always failed. PostgreSQL has no separate rotate verb;
+// create_role's idempotent upsert ALTERs the password (field `password`).
+func DBUserRotateAgentCommand(engine, username, newPassword string) (verb string, params map[string]any) {
+	if engine == "postgres" {
+		return "db.postgres.create_role", map[string]any{"role": username, "password": newPassword}
+	}
+	return "db_user.rotate_password", map[string]any{"db_user_name": username, "new_password": newPassword}
+}
+
 func (h *databaseUserHandler) rotatePassword(c *gin.Context) {
 	ctx := c.Request.Context()
 
@@ -898,17 +912,8 @@ func (h *databaseUserHandler) rotatePassword(c *gin.Context) {
 	agentCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	if du.Engine == "postgres" {
-		_, err = h.cfg.Agent.Call(agentCtx, "db.postgres.create_role", map[string]any{
-			"role":     du.Username,
-			"password": plainPassword,
-		})
-	} else {
-		_, err = h.cfg.Agent.Call(agentCtx, "db_user.rotate_password", map[string]any{
-			"db_user_name": du.Username,
-			"new_password": plainPassword,
-		})
-	}
+	rotateVerb, rotateParams := DBUserRotateAgentCommand(du.Engine, du.Username, plainPassword)
+	_, err = h.cfg.Agent.Call(agentCtx, rotateVerb, rotateParams)
 	if err != nil {
 		respondAgentErr(c, "agent_failed", err)
 		return

--- a/panel-api/internal/api/db_user_rotate_command_test.go
+++ b/panel-api/internal/api/db_user_rotate_command_test.go
@@ -1,0 +1,46 @@
+package api
+
+import "testing"
+
+// JAB-285: the MariaDB rotate verb's password field is `new_password`. The CLI
+// had regressed to `password`, which the agent rejects ("new_password cannot be
+// empty"), so CLI MariaDB rotation always failed. This guards the exact wire
+// field for each engine so REST + CLI (both routed through this helper) can't
+// drift again.
+func TestDBUserRotateAgentCommand(t *testing.T) {
+	t.Run("mariadb uses new_password", func(t *testing.T) {
+		verb, params := DBUserRotateAgentCommand("mariadb", "alice_db", "s3cret")
+		if verb != "db_user.rotate_password" {
+			t.Fatalf("verb = %q, want db_user.rotate_password", verb)
+		}
+		if params["new_password"] != "s3cret" {
+			t.Errorf("must send new_password=s3cret, got %v", params["new_password"])
+		}
+		if params["db_user_name"] != "alice_db" {
+			t.Errorf("db_user_name = %v", params["db_user_name"])
+		}
+		if _, hasOld := params["password"]; hasOld {
+			t.Error("must NOT send the legacy `password` field for MariaDB rotate")
+		}
+	})
+
+	t.Run("empty engine defaults to the mariadb rotate", func(t *testing.T) {
+		verb, params := DBUserRotateAgentCommand("", "bob_db", "pw")
+		if verb != "db_user.rotate_password" || params["new_password"] != "pw" {
+			t.Fatalf("non-postgres engine must use the mariadb rotate verb + new_password; got verb=%q params=%v", verb, params)
+		}
+	})
+
+	t.Run("postgres uses create_role with password", func(t *testing.T) {
+		verb, params := DBUserRotateAgentCommand("postgres", "carol_db", "pgpw")
+		if verb != "db.postgres.create_role" {
+			t.Fatalf("verb = %q, want db.postgres.create_role", verb)
+		}
+		if params["role"] != "carol_db" || params["password"] != "pgpw" {
+			t.Errorf("postgres params wrong: %v", params)
+		}
+		if _, hasNew := params["new_password"]; hasNew {
+			t.Error("postgres create_role must not carry new_password")
+		}
+	})
+}


### PR DESCRIPTION
## What

The MariaDB db-user rotate agent command's field is `new_password`, and the agent rejects an empty one (`new_password cannot be empty`). The operator CLI (`jabali db user rotate-password`) sent `password` instead, so the agent saw `NewPassword=""` and **every MariaDB rotation failed** with that error — the feature was dead (fail-safe: it never set an empty password, just errored). The REST handler sent the correct field; the two adapters had drifted.

## Fix

Route both surfaces through one shared helper, `api.DBUserRotateAgentCommand(engine, username, newPassword)`:
- **MariaDB:** `db_user.rotate_password` with `new_password`.
- **PostgreSQL:** `db.postgres.create_role` with `password` (no separate rotate verb; the idempotent upsert ALTERs the password).

REST + CLI now call the same helper → can't drift again.

## Acceptance criteria

- [x] **REST and CLI send the engine-correct command with the exact `new_password` wire field.**
- [x] The Module generates/accepts a password and returns it reveal-once (unchanged: CLI `ids.NewSecret` + "shown once"; REST reveal-once).
- [x] **Engine credential changes before the stored hash, with explicit failure semantics** (unchanged + correct: agent call precedes `UpdatePasswordHash`; an agent error returns before the hash write).
- [x] Unrelated identity and grant fields remain unchanged (rotation writes only the password hash).
- [x] MariaDB/PostgreSQL contract + adapter-parity test present (helper test below); the agent-side contract test already exists.

## Test plan

- [x] `go test ./panel-api/internal/api/ ./panel-api/cmd/server/` — `db_user_rotate_command_test.go`: MariaDB + empty engine → `new_password` present, legacy `password` absent; PostgreSQL → `create_role` + `password`, no `new_password`.
- [x] `go build ./panel-api/...`, `go vet`, CLI-reference golden unchanged.

GH: JAB-285 (wire-contract + parity slice; the Database Identity Lifecycle Module rotation op proper stays open on the parent, blocked by JAB-282)
