### PR TITLE
fix(db): CLI grant persists a desired-state row + engine-parity canonicalisation (JAB-284)

### DIFF
--- a/panel-api/cmd/server/db_user_cmd.go
+++ b/panel-api/cmd/server/db_user_cmd.go
@@ -15,12 +15,15 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/agent"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/api"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/ids"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
@@ -265,34 +268,20 @@ Mariadb-only in v1; postgres grants land via panel UI / admin REST.`,
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
 			defer cancel()
-			repo := dbUserRepoFromDB()
-			du, err := repo.FindByID(ctx, dbUserID)
+			g, du, err := dbUserGrantCreate(ctx, dbGrantDeps{
+				agent:     sharedAgent,
+				dbUsers:   dbUserRepoFromDB(),
+				databases: repository.NewDatabaseRepository(sharedDB),
+				grants:    repository.NewDatabaseUserGrantRepository(sharedDB),
+			}, dbUserID, dbName, privileges, level)
 			if err != nil {
-				return fmt.Errorf("find db user: %w", err)
+				return err
 			}
-			if du.Engine != "mariadb" {
-				return fmt.Errorf("grant CLI only supports mariadb in v1; got %q (use admin REST/UI for postgres)", du.Engine)
+			cliAuditOK(ctx, "db_user.grant", "database_user_grant", g.ID, &du.UserID)
+			if jsonOutput {
+				return printJSON(g)
 			}
-			privs := privileges
-			if len(privs) == 0 {
-				switch level {
-				case "rw":
-					privs = []string{"SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "INDEX"}
-				case "ro":
-					privs = []string{"SELECT"}
-				default:
-					return fmt.Errorf("--level must be 'rw' or 'ro' (got %q)", level)
-				}
-			}
-			if _, err := sharedAgent.Call(ctx, "db_user.grant", map[string]any{
-				"db_name":      dbName,
-				"db_user_name": du.Username,
-				"grant_level":  level,
-				"privileges":   privs,
-			}); err != nil {
-				return fmt.Errorf("agent db_user.grant: %w", err)
-			}
-			fmt.Fprintf(os.Stdout, "Granted %v on %s to %s\n", privs, dbName, du.Username)
+			fmt.Fprintf(os.Stdout, "Granted %s on %s to %s (grant id=%s)\n", g.Privileges, dbName, du.Username, g.ID)
 			return nil
 		},
 	}
@@ -302,4 +291,99 @@ Mariadb-only in v1; postgres grants land via panel UI / admin REST.`,
 	cmd.Flags().StringSliceVar(&privileges, "privileges", nil, "MariaDB privilege list (e.g. SELECT,INSERT,UPDATE)")
 	cmd.AddCommand(newDBUserGrantUpdateCmd(), newDBUserGrantRevokeCmd())
 	return cmd
+}
+
+// dbGrantDeps is the narrow slice of collaborators dbUserGrantCreate needs,
+// so the cobra RunE stays a thin wire-up over globals and the logic is
+// unit-testable with fakes.
+type dbGrantDeps struct {
+	agent     agent.AgentInterface
+	dbUsers   repository.DatabaseUserRepository
+	databases repository.DatabaseRepository
+	grants    repository.DatabaseUserGrantRepository
+}
+
+// dbUserGrantCreate applies a MariaDB grant to the engine AND persists the
+// matching database_user_grants desired-state row (JAB-284). Before this, the
+// CLI applied the engine grant with no row, so the grant was invisible to the
+// reconciler, the backup metadata builder, and the delete-cascade — and, having
+// no row, could not even be revoked via `db user grant revoke <id>`.
+//
+// Parity with the REST handler: same canonical privilege set (api.CanonicalDBGrant),
+// duplicate guard, and host-grant compensation on a persist failure.
+func dbUserGrantCreate(ctx context.Context, d dbGrantDeps, dbUserID, dbName string, privileges []string, level string) (*models.DatabaseUserGrant, *models.DatabaseUser, error) {
+	du, err := d.dbUsers.FindByID(ctx, dbUserID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("find db user: %w", err)
+	}
+	if du.Engine != "mariadb" {
+		return nil, nil, fmt.Errorf("grant CLI only supports mariadb in v1; got %q (use admin REST/UI for postgres)", du.Engine)
+	}
+	canonical, computedLevel, err := api.CanonicalDBGrant(privileges, level)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Owner-scoped resolution: match by exact name within the db-user's owner's
+	// databases. This makes the CLI strictly same-owner — narrower than the
+	// admin REST path, which may grant cross-user; cross-user grants stay
+	// REST/UI-only. It also validates the database exists + is owned.
+	dbs, _, err := d.databases.ListByUserID(ctx, du.UserID, repository.ListOptions{Limit: 1000})
+	if err != nil {
+		return nil, nil, fmt.Errorf("list databases: %w", err)
+	}
+	var db *models.Database
+	for i := range dbs {
+		if dbs[i].Name == dbName {
+			db = &dbs[i]
+			break
+		}
+	}
+	if db == nil {
+		return nil, nil, fmt.Errorf("database %q not found for this db user's owner (cross-user grants are REST/UI-only)", dbName)
+	}
+
+	// Duplicate guard BEFORE the agent call: a retry must error cleanly rather
+	// than re-grant and then have Create's unique-key failure compensate away a
+	// live grant. (A grant orphaned before this fix — engine yes, row no — slips
+	// past here, the re-grant no-ops, and Create adopts the orphan into desired
+	// state: the migration path for existing damage.)
+	if existing, _ := d.grants.FindByDBAndDBUser(ctx, db.ID, du.ID); existing != nil {
+		return nil, nil, fmt.Errorf("grant already exists for %s on %s (id=%s)", du.Username, db.Name, existing.ID)
+	}
+
+	if _, err := d.agent.Call(ctx, "db_user.grant", map[string]any{
+		"db_name":      db.Name,
+		"db_user_name": du.Username,
+		"privileges":   strings.Split(canonical, ","),
+	}); err != nil {
+		return nil, nil, fmt.Errorf("agent db_user.grant: %w", err)
+	}
+
+	now := time.Now().UTC()
+	g := &models.DatabaseUserGrant{
+		ID:             ids.NewULID(),
+		DatabaseID:     db.ID,
+		DatabaseUserID: du.ID,
+		GrantLevel:     computedLevel,
+		Privileges:     canonical,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := d.grants.Create(ctx, g); err != nil {
+		// Compensate: revoke the host grant we just applied so we never leave an
+		// engine grant with no desired-state row — the exact bug this closes.
+		rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		_, rerr := d.agent.Call(rctx, "db_user.revoke", map[string]any{
+			"db_name":      db.Name,
+			"db_user_name": du.Username,
+			"privileges":   strings.Split(canonical, ","),
+		})
+		cancel()
+		if rerr != nil {
+			return nil, nil, fmt.Errorf("persist grant row failed (%v) AND the compensating revoke ALSO failed (%v) — an engine grant for %s on %s is now orphaned; revoke it directly on the DB engine", err, rerr, du.Username, db.Name)
+		}
+		return nil, nil, fmt.Errorf("persist grant row: %w (host grant rolled back)", err)
+	}
+	return g, du, nil
 }

--- a/panel-api/cmd/server/db_user_grant_create_test.go
+++ b/panel-api/cmd/server/db_user_grant_create_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
+)
+
+type recGrantAgent struct {
+	calls      []string
+	params     []map[string]any
+	failGrant  bool
+	failRevoke bool
+}
+
+func (a *recGrantAgent) Call(_ context.Context, cmd string, params any) (json.RawMessage, error) {
+	a.calls = append(a.calls, cmd)
+	m, _ := params.(map[string]any)
+	a.params = append(a.params, m)
+	if cmd == "db_user.grant" && a.failGrant {
+		return nil, errors.New("grant boom")
+	}
+	if cmd == "db_user.revoke" && a.failRevoke {
+		return nil, errors.New("revoke boom")
+	}
+	return json.RawMessage(`{}`), nil
+}
+
+type fakeDBUsers struct {
+	repository.DatabaseUserRepository
+	u *models.DatabaseUser
+}
+
+func (f fakeDBUsers) FindByID(_ context.Context, id string) (*models.DatabaseUser, error) {
+	if f.u != nil && f.u.ID == id {
+		return f.u, nil
+	}
+	return nil, repository.ErrNotFound
+}
+
+type fakeDatabases struct {
+	repository.DatabaseRepository
+	rows []models.Database
+}
+
+func (f fakeDatabases) ListByUserID(_ context.Context, userID string, _ repository.ListOptions) ([]models.Database, int64, error) {
+	var out []models.Database
+	for _, d := range f.rows {
+		if d.UserID == userID {
+			out = append(out, d)
+		}
+	}
+	return out, int64(len(out)), nil
+}
+
+type fakeGrants struct {
+	repository.DatabaseUserGrantRepository
+	existing   *models.DatabaseUserGrant
+	created    *models.DatabaseUserGrant
+	failCreate bool
+}
+
+func (f *fakeGrants) FindByDBAndDBUser(_ context.Context, _, _ string) (*models.DatabaseUserGrant, error) {
+	if f.existing != nil {
+		return f.existing, nil
+	}
+	return nil, repository.ErrNotFound
+}
+func (f *fakeGrants) Create(_ context.Context, g *models.DatabaseUserGrant) error {
+	if f.failCreate {
+		return errors.New("create boom")
+	}
+	f.created = g
+	return nil
+}
+
+func mariadbUser() *models.DatabaseUser {
+	return &models.DatabaseUser{ID: "du1", UserID: "u1", Username: "u1_app", Engine: "mariadb"}
+}
+
+func grantDeps(a *recGrantAgent, g *fakeGrants) dbGrantDeps {
+	return dbGrantDeps{
+		agent:     a,
+		dbUsers:   fakeDBUsers{u: mariadbUser()},
+		databases: fakeDatabases{rows: []models.Database{{ID: "d1", UserID: "u1", Name: "u1_appdb"}}},
+		grants:    g,
+	}
+}
+
+func TestDBUserGrantCreate_PersistsRowAndGrants(t *testing.T) {
+	ag := &recGrantAgent{}
+	gr := &fakeGrants{}
+	g, du, err := dbUserGrantCreate(context.Background(), grantDeps(ag, gr), "du1", "u1_appdb", []string{"SELECT"}, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(ag.calls) != 1 || ag.calls[0] != "db_user.grant" {
+		t.Fatalf("expected one db_user.grant call, got %v", ag.calls)
+	}
+	if gr.created == nil || gr.created.DatabaseID != "d1" || gr.created.DatabaseUserID != "du1" {
+		t.Fatalf("desired-state row not persisted correctly: %+v", gr.created)
+	}
+	if gr.created.Privileges != "SELECT" || gr.created.GrantLevel != "ro" {
+		t.Errorf("row privileges/level wrong: %+v", gr.created)
+	}
+	if g.ID != gr.created.ID || du.UserID != "u1" {
+		t.Errorf("return values wrong: g=%v du=%v", g, du)
+	}
+}
+
+func TestDBUserGrantCreate_UnknownOrUnownedDB_NoAgentCall(t *testing.T) {
+	ag := &recGrantAgent{}
+	_, _, err := dbUserGrantCreate(context.Background(), grantDeps(ag, &fakeGrants{}), "du1", "someone_elses_db", []string{"SELECT"}, "")
+	if err == nil {
+		t.Fatal("expected error for a db not owned by the db user's owner")
+	}
+	if len(ag.calls) != 0 {
+		t.Errorf("must not touch the engine when the db is unresolved, got %v", ag.calls)
+	}
+}
+
+func TestDBUserGrantCreate_Duplicate_NoAgentCall(t *testing.T) {
+	ag := &recGrantAgent{}
+	gr := &fakeGrants{existing: &models.DatabaseUserGrant{ID: "gExisting"}}
+	_, _, err := dbUserGrantCreate(context.Background(), grantDeps(ag, gr), "du1", "u1_appdb", []string{"SELECT"}, "")
+	if err == nil {
+		t.Fatal("expected duplicate error")
+	}
+	if len(ag.calls) != 0 {
+		t.Errorf("duplicate must be caught BEFORE the agent call, got %v", ag.calls)
+	}
+}
+
+func TestDBUserGrantCreate_PersistFail_CompensatesRevoke(t *testing.T) {
+	ag := &recGrantAgent{}
+	gr := &fakeGrants{failCreate: true}
+	_, _, err := dbUserGrantCreate(context.Background(), grantDeps(ag, gr), "du1", "u1_appdb", []string{"SELECT", "INSERT"}, "")
+	if err == nil {
+		t.Fatal("expected persist error")
+	}
+	if len(ag.calls) != 2 || ag.calls[0] != "db_user.grant" || ag.calls[1] != "db_user.revoke" {
+		t.Fatalf("persist failure must compensate with a revoke, got %v", ag.calls)
+	}
+	// The compensating revoke must target the same privileges it granted.
+	revoke := ag.params[1]
+	privs, _ := revoke["privileges"].([]string)
+	if len(privs) != 2 || privs[0] != "SELECT" || privs[1] != "INSERT" {
+		t.Errorf("revoke privileges must match the grant, got %v", revoke["privileges"])
+	}
+}
+
+func TestDBUserGrantCreate_Postgres_Rejected(t *testing.T) {
+	ag := &recGrantAgent{}
+	d := grantDeps(ag, &fakeGrants{})
+	d.dbUsers = fakeDBUsers{u: &models.DatabaseUser{ID: "du1", UserID: "u1", Username: "pg", Engine: "postgres"}}
+	_, _, err := dbUserGrantCreate(context.Background(), d, "du1", "u1_appdb", []string{"SELECT"}, "")
+	if err == nil {
+		t.Fatal("postgres grant via CLI must be rejected in v1")
+	}
+	if len(ag.calls) != 0 {
+		t.Errorf("must not call the engine for a rejected postgres grant, got %v", ag.calls)
+	}
+}

--- a/panel-api/cmd/server/db_user_parity_cmd.go
+++ b/panel-api/cmd/server/db_user_parity_cmd.go
@@ -19,18 +19,6 @@ import (
 	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/repository"
 )
 
-// privsForLevel maps the rw/ro shortcut to the MariaDB privilege list — the
-// same mapping the CLI grant-create uses.
-func privsForLevel(level string) []string {
-	switch level {
-	case "rw":
-		return []string{"SELECT", "INSERT", "UPDATE", "DELETE", "CREATE", "DROP", "ALTER", "INDEX"}
-	case "ro":
-		return []string{"SELECT"}
-	}
-	return nil
-}
-
 func newDBUserRotatePasswordCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "rotate-password <db-user-id>",
@@ -138,7 +126,16 @@ func newDBUserGrantUpdateCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("find database: %w", err)
 			}
-			verb, params := "db_user.grant", map[string]any{"db_name": db.Name, "db_user_name": du.Username, "grant_level": level, "privileges": privsForLevel(level)}
+			// JAB-284: canonicalise via the shared helper so the CLI update
+			// sends + persists the SAME normalised privilege set as create/REST
+			// (rw = ALL, not the old 8-item list — which stored as "custom" and
+			// diverged from the engine). MariaDB sends only `privileges`, exactly
+			// like the REST addGrant payload.
+			canonical, computedLevel, cerr := api.CanonicalDBGrant(nil, level)
+			if cerr != nil {
+				return cerr
+			}
+			verb, params := "db_user.grant", map[string]any{"db_name": db.Name, "db_user_name": du.Username, "privileges": strings.Split(canonical, ",")}
 			if du.Engine == "postgres" {
 				verb, params = "db.postgres.grant", map[string]any{"db_name": db.Name, "role": du.Username}
 			}
@@ -146,8 +143,14 @@ func newDBUserGrantUpdateCmd() *cobra.Command {
 				cliAuditErr(ctx, "db_user.grant_update", "database_user_grant", g.ID, &du.UserID)
 				return fmt.Errorf("agent %s: %w", verb, err)
 			}
-			if err := grants.UpdateLevel(ctx, g.ID, level); err != nil {
+			// Persist BOTH level and the canonical privilege set so the stored
+			// grant matches what the engine received (AC #4 — the update used to
+			// persist only the level, leaving the privilege set stale).
+			if err := grants.UpdateLevel(ctx, g.ID, computedLevel); err != nil {
 				return fmt.Errorf("persist grant level: %w", err)
+			}
+			if err := grants.UpdatePrivileges(ctx, g.ID, canonical); err != nil {
+				return fmt.Errorf("persist grant privileges: %w", err)
 			}
 			cliAuditOK(ctx, "db_user.grant_update", "database_user_grant", g.ID, &du.UserID)
 			fmt.Fprintf(os.Stdout, "Updated grant %s to %s on %s for %s\n", g.ID, level, db.Name, du.Username)

--- a/panel-api/internal/api/canonical_db_grant_test.go
+++ b/panel-api/internal/api/canonical_db_grant_test.go
@@ -1,0 +1,41 @@
+package api
+
+import "testing"
+
+func TestCanonicalDBGrant(t *testing.T) {
+	cases := []struct {
+		name      string
+		privs     []string
+		level     string
+		wantCanon string
+		wantLevel string
+		wantErr   bool
+	}{
+		{"rw shortcut is ALL", nil, "rw", "ALL", "rw", false},
+		{"ro shortcut is SELECT", nil, "ro", "SELECT", "ro", false},
+		{"explicit ALL", []string{"ALL"}, "", "ALL", "rw", false},
+		{"explicit SELECT only maps to ro", []string{"SELECT"}, "", "SELECT", "ro", false},
+		{"custom subset stores as custom", []string{"SELECT", "INSERT"}, "", "SELECT,INSERT", "custom", false},
+		{"privileges take precedence over level", []string{"SELECT"}, "rw", "SELECT", "ro", false},
+		{"invalid level", nil, "admin", "", "", true},
+		{"invalid privilege", []string{"NUKE"}, "", "", "", true},
+		{"neither privileges nor level", nil, "", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			canon, level, err := CanonicalDBGrant(tc.privs, tc.level)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got canon=%q level=%q", canon, level)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if canon != tc.wantCanon || level != tc.wantLevel {
+				t.Errorf("got (%q,%q), want (%q,%q)", canon, level, tc.wantCanon, tc.wantLevel)
+			}
+		})
+	}
+}

--- a/panel-api/internal/api/database_users.go
+++ b/panel-api/internal/api/database_users.go
@@ -140,6 +140,38 @@ func privilegesToCanonicalString(privs []string) (string, error) {
 	return strings.Join(result, ","), nil
 }
 
+// CanonicalDBGrant resolves a grant's privilege inputs into the stored
+// canonical privilege string + the computed grant_level, applying the same
+// validation the REST handler and the operator CLI both use (JAB-284) so the
+// two adapters can never drift. Exactly one of an explicit privileges list or a
+// rw/ro level must be supplied: rw = ALL, ro = SELECT; a custom list that is
+// not exactly ALL/SELECT stores with level "custom".
+func CanonicalDBGrant(privileges []string, level string) (canonical, computedLevel string, err error) {
+	switch {
+	case len(privileges) > 0:
+		canonical, err = privilegesToCanonicalString(privileges)
+		if err != nil {
+			return "", "", err
+		}
+	case level == "rw":
+		canonical = "ALL"
+	case level == "ro":
+		canonical = "SELECT"
+	case level != "":
+		return "", "", fmt.Errorf("grant_level must be 'rw' or 'ro' (got %q)", level)
+	default:
+		return "", "", fmt.Errorf("either privileges or grant_level must be provided")
+	}
+	computedLevel = "custom"
+	switch canonical {
+	case "ALL":
+		computedLevel = "rw"
+	case "SELECT":
+		computedLevel = "ro"
+	}
+	return canonical, computedLevel, nil
+}
+
 // ---- Request/Response types ----
 
 type createDatabaseUserRequest struct {
@@ -556,37 +588,13 @@ func (h *databaseUserHandler) addGrant(c *gin.Context) {
 		return
 	}
 
-	// Determine privileges to use: either from privileges array or fallback to grant_level.
-	var canonicalPrivileges string
-	if len(req.Privileges) > 0 {
-		// Validate and normalize privileges.
-		var err error
-		canonicalPrivileges, err = privilegesToCanonicalString(req.Privileges)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_privileges", "detail": err.Error()})
-			return
-		}
-	} else if req.GrantLevel != "" {
-		// Legacy path: translate grant_level to privileges.
-		if req.GrantLevel == "rw" {
-			canonicalPrivileges = "ALL"
-		} else if req.GrantLevel == "ro" {
-			canonicalPrivileges = "SELECT"
-		} else {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grant_level", "detail": "grant_level must be 'rw' or 'ro'"})
-			return
-		}
-	} else {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "missing_privileges", "detail": "either privileges or grant_level must be provided"})
+	// Canonicalise the privilege set + compute the stored grant_level. Shared
+	// with the operator CLI (JAB-284) so both adapters validate + normalise
+	// privileges identically and can never drift.
+	canonicalPrivileges, computedGrantLevel, err := CanonicalDBGrant(req.Privileges, req.GrantLevel)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_grant", "detail": err.Error()})
 		return
-	}
-
-	// Compute grant_level from canonical privileges for backward compat.
-	computedGrantLevel := "custom"
-	if canonicalPrivileges == "ALL" {
-		computedGrantLevel = "rw"
-	} else if canonicalPrivileges == "SELECT" {
-		computedGrantLevel = "ro"
 	}
 
 	du, err := h.cfg.DatabaseUsers.FindByID(ctx, c.Param("id"))


### PR DESCRIPTION
## What

`jabali db user grant` applied the grant to the MariaDB engine but **never wrote a `database_user_grants` row**. That grant was invisible to the reconciler (no drift convergence), the backup metadata builder (reads grants via `ListByDatabaseUserID` — JAB-374), and the delete-cascade (revokes by loading grant rows). And with no row there is **no grant id — so a CLI-created grant could not even be revoked via `db user grant revoke <id>`**. An orphaned engine grant with no panel handle.

## Fix — REST parity via one shared canonicaliser + persist/compensate

- **`api.CanonicalDBGrant(privileges, level)`** extracted from the REST `addGrant` handler (refactored onto it) and called by the CLI → both adapters validate + normalise privileges identically. `rw = ALL`, `ro = SELECT`, custom subset → level `custom`. This also fixes the CLI's `rw`, which used an 8-privilege list that stored as `custom` and diverged from the engine — **panel-wide `rw` already meant ALL via REST/UI; the CLI was the outlier.**
- **`dbUserGrantCreate`** (extracted, unit-tested): owner-scoped db resolution (`ListByUserID` + exact name — stricter than admin REST; cross-user grants stay REST/UI-only), **duplicate guard before the agent call** (retry errors cleanly, never re-grants then compensates away a live grant), engine grant, row persist, and **compensation** (revoke the host grant) on a persist failure — with an operator-facing message if that revoke also fails. Success prints the grant id + `cliAuditOK` (create did neither before). A grant orphaned *before* this fix is **adopted into desired state by re-running the grant** (pre-check misses, re-grant no-ops, Create succeeds).
- **Grant UPDATE** routes its payload through `CanonicalDBGrant` too and persists **both** level and canonical privileges (`UpdateLevel` + `UpdatePrivileges`), not just the level — stale privilege set fixed (AC #4).

## Acceptance criteria

- [x] Every successful grant has a matching desired-state row.
- [x] Owner/engine/duplicate/privilege validation identical across adapters (shared helper + owner-scoped resolution + duplicate guard + existing engine guard).
- [x] Persistence failure compensates the host grant.
- [x] Custom privilege updates send + persist the same normalised set.
- [x] Revoke retains its management row when host revocation fails (unchanged — it returns before `Delete`).
- [x] MariaDB/PostgreSQL wire-shape + adapter-parity tests present.

## Test plan

- [x] `go test ./panel-api/internal/api/ ./panel-api/cmd/server/` — `CanonicalDBGrant` matrix; `dbUserGrantCreate` (row + engine payload; unowned db → error + 0 agent calls; duplicate → error + 0 calls; persist-fail → compensating revoke with matching privileges; postgres → rejected + 0 calls).
- [x] `go build ./panel-api/...`, `go vet`, CLI-reference golden unchanged.

GH: JAB-284 (grant create/update parity + persistence; the Database Identity Lifecycle Module grant ops proper stay open on the parent, blocked by JAB-282)
