### PR TITLE
fix(security): pin Go toolchain to go1.25.13 — clears 39 reachable stdlib CVEs (JAB-383)

### DIFF
--- a/.github/workflows/catalog-bump.yml
+++ b/.github/workflows/catalog-bump.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: write
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.25.13"
 
 jobs:
   bump:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.25.13"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/monthly-deps.yml
+++ b/.github/workflows/monthly-deps.yml
@@ -17,7 +17,7 @@ permissions:
   issues: write
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.25.13"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.25.13"
   NODE_VERSION: "20"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build + publish release tarball
     runs-on: self-hosted
     env:
-      GO_VERSION: "1.25"
+      GO_VERSION: "1.25.13"
       NODE_VERSION: "20"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,14 @@ module git.jabali-panel.com/shukivaknin/jabali2
 
 go 1.25.0
 
+// JAB-383: pin a minimum toolchain that carries the go1.25.2..go1.25.13 stdlib
+// security fixes (39 govulncheck-reachable CVEs: os.Root symlink+trailing-slash
+// root escape, net/mail + mime parsing DoS, archive/zip|tar extraction DoS,
+// crypto/tls + x509 + net/http). GOTOOLCHAIN=auto uses this when the local go is
+// older (e.g. the build-local-and-scp deploy path), and the newer installer Go
+// otherwise — so no build, wherever it runs, ships the vulnerable stdlib.
+toolchain go1.25.13
+
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## What

`govulncheck` (mode=source) reported **39 reachable Go stdlib CVEs**, all fixed in go1.25.2..go1.25.13 — while `go.mod` declared only `go 1.25.0` with **no toolchain pin**, so the audit/dev box and the build-local-and-scp deploy path built with go1.25.1 and shipped the vulnerable stdlib.

Reachable paths: os.Root symlink+trailing-slash **root escape** in the tenant file-containment layer (`internal/filesafe`), net/mail + mime parsing **DoS** on inbound email, archive/zip|tar extraction **DoS**, and crypto/tls + x509 + net/http issues in the webdav/mailhook servers and pdns/kratos clients.

## Fix

- **`go.mod`: `toolchain go1.25.13`.** `GOTOOLCHAIN=auto` uses it when the local go is older (closing the local-build-and-scp gap) and the newer installer Go otherwise — no build, wherever it runs, ships the vulnerable stdlib. Patch-level within 1.25.x → no language/behaviour change.
- **CI `GO_VERSION` `"1.25"` → `"1.25.13"`** across ci / nightly / monthly-deps / catalog-bump / release, so the test + govulncheck jobs run on the fixed stdlib.
- `install.sh` already provisions Go 1.26.5 (ahead) — unchanged.

## Verification

- `go build ./...` and the panel-api / panel-agent / internal test suites **pass on go1.25.13** (auto-downloaded via the pin).
- **`govulncheck ./...` → "0 vulnerabilities" for reachable code** — the 39 stdlib findings are gone. Two non-reachable findings remain in third-party modules → tracked by **JAB-385**.

GH: JAB-383
