### PR TITLE
fix(security): bound the mailhook request body — inbound-mail DoS defense-in-depth (JAB-384)

### DIFF
--- a/panel-agent/internal/mailhook/server.go
+++ b/panel-agent/internal/mailhook/server.go
@@ -50,6 +50,17 @@ type Handler struct {
 // accept is the passthrough response: deliver unchanged.
 var accept = hookResponse{Action: "accept"}
 
+// MaxRequestBytes bounds the hook request body before it is JSON-decoded
+// (JAB-384 defense-in-depth). The body carries the full inbound message —
+// attacker-influenced content that reaches net/mail + mime + textproto parsers.
+// The go1.25.13 toolchain (JAB-383) fixes the known quadratic/excessive-CPU
+// stdlib bugs; this cap additionally bounds memory so a pathological or
+// mis-sized message can never be read unbounded regardless of the MTA's own
+// size limit. 64 MiB comfortably clears a JSON-wrapped message at typical MTA
+// caps (~25–50 MiB raw); an over-cap body fails the decode, which already
+// fails open (deliver unchanged, never bounce). A var so tests can shrink it.
+var MaxRequestBytes int64 = 64 << 20
+
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -60,6 +71,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, MaxRequestBytes)
 	var req hookRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		// Malformed request: fail open so mail still flows.

--- a/panel-agent/internal/mailhook/server_bodycap_test.go
+++ b/panel-agent/internal/mailhook/server_bodycap_test.go
@@ -1,0 +1,73 @@
+package mailhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// nilSource never returns a disclaimer — the request never reaches the parser
+// path, which is fine: this test is about the body cap, not the rewrite.
+type nilSource struct{}
+
+func (nilSource) ForDomain(context.Context, string) (Disclaimer, bool, error) {
+	return Disclaimer{}, false, nil
+}
+
+func newTestHandler() *Handler {
+	return &Handler{Source: nilSource{}, Token: "", Log: slog.New(slog.DiscardHandler)}
+}
+
+// JAB-384: a request body larger than MaxRequestBytes must not be read
+// unbounded — MaxBytesReader trips, the JSON decode fails, and the handler
+// fails open (action:accept, deliver unchanged) rather than OOM'ing.
+func TestServeHTTP_OversizedBody_FailsOpen(t *testing.T) {
+	orig := MaxRequestBytes
+	MaxRequestBytes = 256 // shrink so the test stays cheap
+	defer func() { MaxRequestBytes = orig }()
+
+	body := `{"envelope":{"from":{"address":"a@b.com"}},"message":{"contents":"` +
+		strings.Repeat("A", 1024) + `"}}` // > 256 bytes
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("oversized body should still respond 200 (fail open), got %d", w.Code)
+	}
+	var resp hookResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
+	}
+	if resp.Action != "accept" {
+		t.Errorf("oversized body must deliver unchanged (accept), got %q", resp.Action)
+	}
+}
+
+// A normal-sized body under the cap decodes and is processed (here it accepts
+// because nilSource has no disclaimer) — proving the cap doesn't break the
+// happy path.
+func TestServeHTTP_NormalBody_UnderCap_OK(t *testing.T) {
+	body := `{"envelope":{"from":{"address":"a@b.com"}},"message":{"contents":"hello"}}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d", w.Code)
+	}
+	out, _ := io.ReadAll(w.Result().Body)
+	var resp hookResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Action != "accept" {
+		t.Errorf("action = %q, want accept", resp.Action)
+	}
+}


### PR DESCRIPTION
## What

Two-part ticket:

- **Part (b) — root cause — already fixed by JAB-383.** go1.25.13 patches the net/mail (GO-2025-4006), net/textproto (GO-2026-5039), and mime (GO-2026-5038) CPU-exhaustion/error-injection bugs a crafted inbound message hit via `sendmailshim` + `mailhook`. `govulncheck` on go1.25.13 → 0 reachable.
- **Part (a) — this — ingress defense-in-depth.** The `mailhook` MTA-hook decoded its request body (the full attacker-influenced message Stalwart forwards at the DATA stage) with an **unbounded** `json.Decoder`. Wrapped it in `http.MaxBytesReader(w, r.Body, 64 MiB)` before decoding. An over-cap body trips the reader → decode fails → the handler's existing **fail-open** path (`action:accept`, deliver unchanged, never bounce), so legit large mail is unaffected and a hostile one can't exhaust memory.

The `sendmailshim` path (PHP `mail()` local submission) already caps stdin at `MaxMessageBytes = 25 MiB` via `io.LimitReader`, so both mail-parse paths are now size-bounded on top of the patched stdlib.

## Test plan

- [x] `go test ./panel-agent/internal/mailhook/` — over-cap body → 200 `action:accept` (fail open, no OOM); normal body under the cap decodes + processes. `MaxRequestBytes` is a var so the test can shrink it.
- [x] `go build ./panel-agent/...`, `go vet` clean.

GH: JAB-384 (part b via JAB-383; part a here)
