### PR TITLE
fix(security): add a wall-clock budget to tenant archive extraction (JAB-387)

### DIFF
--- a/panel-agent/internal/commands/files_extract.go
+++ b/panel-agent/internal/commands/files_extract.go
@@ -15,11 +15,22 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"git.jabali-panel.com/shukivaknin/jabali2/agentwire"
 	"git.jabali-panel.com/shukivaknin/jabali2/internal/filesafe"
 	"golang.org/x/sys/unix"
 )
+
+// extractWallClockBudget bounds the total wall-clock of one archive extraction
+// (JAB-387 defense-in-depth). The per-entry ex.ctx.Err() checks (GH #664) plus
+// the entry-count / uncompressed-size / decompression-bomb caps already bound
+// the work, and go1.25.13 (JAB-383) fixes the archive/zip quadratic-index CVE
+// (GO-2026-4342); this adds an explicit ceiling so a pathological tenant archive
+// can never hold a root-side extract worker indefinitely, regardless of the
+// caller's deadline. Generous relative to the size cap so legitimate large
+// archives are unaffected.
+const extractWallClockBudget = 5 * time.Minute
 
 // files.extract — unpack an archive (.zip / .tar / .tar.gz / .tgz / .tar.bz2 /
 // .gz) into a directory inside the user's scope. Every destination path is
@@ -107,6 +118,11 @@ func filesExtractHandler(ctx context.Context, params json.RawMessage) (any, erro
 		return nil, &agentwire.AgentError{Code: agentwire.CodeInternal, Message: fmt.Sprintf("failed to open destination: %v", err)}
 	}
 	defer ed.Close()
+
+	// JAB-387: cap the extraction wall-clock; the per-entry ctx.Err() checks in
+	// untar/unzip enforce it.
+	ctx, cancel := context.WithTimeout(ctx, extractWallClockBudget)
+	defer cancel()
 
 	ex := &extractor{ctx: ctx, ed: ed}
 

--- a/panel-agent/internal/commands/files_extract_budget_test.go
+++ b/panel-agent/internal/commands/files_extract_budget_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// JAB-387: the extraction wall-clock budget is enforced by the per-entry
+// ex.ctx.Err() checks in untar/unzip (the handler feeds them a
+// context.WithTimeout(extractWallClockBudget)). Prove the loop bails when that
+// budget is already spent instead of extracting every entry.
+func TestUntar_BailsWhenBudgetExpired(t *testing.T) {
+	dir := t.TempDir()
+	ex := testExtractor(dir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // let the 1ns deadline pass
+	ex.ctx = ctx
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i := 0; i < 5; i++ {
+		_ = tw.WriteHeader(&tar.Header{Name: fmt.Sprintf("f%d.txt", i), Mode: 0o644, Size: 3, Typeflag: tar.TypeReg})
+		_, _ = tw.Write([]byte("abc"))
+	}
+	_ = tw.Close()
+
+	err := ex.untar(&buf)
+	if err == nil {
+		t.Fatal("untar must bail once the extract budget is exhausted, not run to completion")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected a deadline/cancelled error, got %v", err)
+	}
+}
+
+// The budget constant is generous enough that legitimate extractions never hit
+// it — a cheap guard so a future edit can't shrink it into flakiness.
+func TestExtractWallClockBudget_Sane(t *testing.T) {
+	if extractWallClockBudget < time.Minute {
+		t.Fatalf("extract budget %v is too tight for legitimate large archives", extractWallClockBudget)
+	}
+}


### PR DESCRIPTION
## What

- **Root cause — already fixed by JAB-383.** go1.25.13 patches the archive/zip quadratic-index CVE (GO-2026-4342) + the archive/tar advisory a crafted tenant archive hit via `files.extract`. `govulncheck` on go1.25.13 → 0 reachable.
- **This — the optional wall-clock budget.** `files.extract` already caps entry count + uncompressed size (zip-slip/symlink/decompression-bomb) and checks `ex.ctx.Err()` per entry (GH #664), but ran on the caller's context with no explicit ceiling. `filesExtractHandler` now wraps its context in `context.WithTimeout(extractWallClockBudget = 5m)`; the existing per-entry `ctx.Err()` checks enforce it — so a pathological archive can't hold a root-side extract worker indefinitely, independent of the caller's deadline. 5m is generous vs the size cap → legit large archives unaffected.

## Test plan

- [x] `go test ./panel-agent/internal/commands/` — with an already-expired budget the untar loop bails with a deadline error instead of extracting every entry; a guard test keeps the budget ≥ 1m. Existing extract tests (zip-slip, symlink, planted-parent-symlink) still pass.
- [x] `go build ./panel-agent/...`, `go vet` clean.

GH: JAB-387 (root cause via JAB-383; wall-clock budget here)
