### PR TITLE
fix(migrate): state-gate admin WP import + reject secrets on terminal jobs (JAB-301)

### DIFF
--- a/panel-api/internal/api/admin_migrations.go
+++ b/panel-api/internal/api/admin_migrations.go
@@ -537,6 +537,26 @@ type runImportWPRequest struct {
 // the create path; this only launches the already-bound job.
 func (h *adminMigrationsHandler) runImportWP(c *gin.Context) {
 	id := c.Param("id")
+	// JAB-301: load + state-gate the job before dispatch, exactly like
+	// runPullSource / runImport. This path used to dispatch on the raw URL id
+	// alone, so a missing job (bad id) or a terminal job (already done / failed
+	// / cancelled) could still reach the Agent.
+	job, err := h.cfg.Jobs.FindByID(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal"})
+		return
+	}
+	if isTerminalMigrationState(job.State) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  "terminal_state",
+			"detail": "cannot import a terminal job (state=" + job.State + ")",
+		})
+		return
+	}
 	if h.cfg.Agent == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent_unconfigured"})
 		return

--- a/panel-api/internal/api/admin_migrations_importwp_guard_test.go
+++ b/panel-api/internal/api/admin_migrations_importwp_guard_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+type countingMigAgent struct{ calls int32 }
+
+func (a *countingMigAgent) Call(context.Context, string, any) (json.RawMessage, error) {
+	atomic.AddInt32(&a.calls, 1)
+	return json.RawMessage("{}"), nil
+}
+
+func fireImportWP(h *adminMigrationsHandler, id, body string) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.runImportWP(c)
+	return w
+}
+
+// JAB-301: runImportWP must load + state-gate the job before dispatch. A missing
+// or terminal job must never reach the Agent.
+func TestRunImportWP_GuardsMissingAndTerminal(t *testing.T) {
+	body := `{"dest_user":"alice","dest_domain":"ex.com"}`
+
+	t.Run("missing job → 404, no agent call", func(t *testing.T) {
+		ag := &countingMigAgent{}
+		h, _ := newIMAPHandler(ag)
+		w := fireImportWP(h, "nope", body)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("code=%d, want 404", w.Code)
+		}
+		if atomic.LoadInt32(&ag.calls) != 0 {
+			t.Error("missing job must not reach the agent")
+		}
+	})
+
+	t.Run("terminal job → 409, no agent call", func(t *testing.T) {
+		for _, state := range []string{"done", "failed", "cancelled"} {
+			ag := &countingMigAgent{}
+			h, jobs := newIMAPHandler(ag)
+			jobs.byID["job1"] = &models.MigrationJob{ID: "job1", State: state}
+			w := fireImportWP(h, "job1", body)
+			if w.Code != http.StatusConflict {
+				t.Errorf("state %q: code=%d, want 409", state, w.Code)
+			}
+			if atomic.LoadInt32(&ag.calls) != 0 {
+				t.Errorf("state %q: terminal job must not reach the agent", state)
+			}
+		}
+	})
+
+	t.Run("live job → dispatches", func(t *testing.T) {
+		ag := &countingMigAgent{}
+		h, jobs := newIMAPHandler(ag)
+		jobs.byID["job1"] = &models.MigrationJob{ID: "job1", State: "staged"}
+		w := fireImportWP(h, "job1", body)
+		if w.Code != http.StatusOK {
+			t.Fatalf("code=%d, want 200 (%s)", w.Code, w.Body.String())
+		}
+		if atomic.LoadInt32(&ag.calls) != 1 {
+			t.Errorf("a live job must dispatch exactly one agent call, got %d", ag.calls)
+		}
+	})
+}

--- a/panel-api/internal/api/tenant_migrations.go
+++ b/panel-api/internal/api/tenant_migrations.go
@@ -221,7 +221,18 @@ func (h *tenantMigrationsHandler) uploadSecrets(c *gin.Context) {
 	if uid == "" {
 		return
 	}
-	if h.ownedJob(c, uid) == nil {
+	job := h.ownedJob(c, uid)
+	if job == nil {
+		return
+	}
+	// JAB-301: a terminal job (done / failed / cancelled) must reject new
+	// secrets — accepting them would write credentials for a job that will
+	// never run (and, for cancelled, one whose secrets were just wiped).
+	if isTerminalMigrationState(job.State) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  "terminal_state",
+			"detail": "cannot upload secrets to a terminal job (state=" + job.State + ")",
+		})
 		return
 	}
 	var req tenantSecretsRequest

--- a/panel-api/internal/api/tenant_migrations_secrets_terminal_test.go
+++ b/panel-api/internal/api/tenant_migrations_secrets_terminal_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"git.jabali-panel.com/shukivaknin/jabali2/panel-api/internal/models"
+)
+
+// JAB-301: a terminal migration job must reject new secret uploads — accepting
+// them would write credentials for a job that will never run.
+func TestTenantMigration_UploadSecretsToTerminalJob_409(t *testing.T) {
+	for _, state := range []string{"done", "failed", "cancelled"} {
+		h, jobs, ag := newTMHandler()
+		uid := "USERA"
+		owner := uid
+		jobs.jobs["JOBA"] = &models.MigrationJob{ID: "JOBA", TargetUserID: &owner, State: state}
+
+		c, w := ctxAs(uid, `{"ssh_password":"hunter2"}`, "JOBA")
+		h.uploadSecrets(c)
+
+		if w.Code != http.StatusConflict {
+			t.Errorf("state %q: code=%d, want 409", state, w.Code)
+		}
+		if ag.last != nil {
+			t.Errorf("state %q: terminal job must not write secrets to the agent", state)
+		}
+	}
+}
+
+// A live job still accepts secrets (guard doesn't over-reject).
+func TestTenantMigration_UploadSecretsToLiveJob_OK(t *testing.T) {
+	h, jobs, ag := newTMHandler()
+	uid := "USERA"
+	owner := uid
+	jobs.jobs["JOBA"] = &models.MigrationJob{ID: "JOBA", TargetUserID: &owner, State: "validating"}
+
+	c, w := ctxAs(uid, `{"ssh_password":"hunter2"}`, "JOBA")
+	h.uploadSecrets(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("live job upload: code=%d (%s)", w.Code, w.Body.String())
+	}
+	if ag.last == nil {
+		t.Error("a live job must write secrets to the agent")
+	}
+}


### PR DESCRIPTION
## What

Two migration dispatch/admission gaps let operations reach the Agent (or write secrets) for jobs that should refuse them:

- **`admin_migrations.runImportWP`** dispatched `migration.import_wp_run` on the raw URL id alone — **no `FindByID`, no state check** — while its siblings `runPullSource` / `runImport` both load the job and reject terminal states. So an admin WP import could fire on a **missing** job (bad id) or a **terminal** one (done/failed/cancelled). Now it loads (404 if missing) + rejects terminal (409) before dispatch.
- **`tenant_migrations.uploadSecrets`** accepted a secret upload on any owned job, including terminal ones — writing credentials for a job that will never run (and, for cancelled, one whose secrets were just wiped). Now it rejects a terminal job (409) via the same `isTerminalMigrationState` guard.

## Acceptance criteria (slices)

- [x] **#1** Missing/terminal/illegal-state jobs never reach the Agent (admin WP import).
- [x] **#4** Terminal jobs reject new secrets (tenant upload).
- [ ] #2/#3/#5 — transactional single-admission, dispatch-failure rollback, one shared transition table (the Migration Job Intake Module proper) — parent.

## Test plan

- [x] `go test ./panel-api/internal/api/` — runImportWP: 404 missing, 409 each terminal state, dispatch on live, agent never called on rejects; uploadSecrets: 409 each terminal (agent not called), OK on live.
- [x] `go build ./panel-api/...`, `go vet` clean.

GH: JAB-301 (AC #1 + #4 slices; Module proper remains open)
