### PR TITLE
fix(db): CLI maintenance audits the true outcome — no success audit after an Agent failure (JAB-305)

### DIFF
--- a/panel-api/cmd/server/db_ops_cmd.go
+++ b/panel-api/cmd/server/db_ops_cmd.go
@@ -203,10 +203,15 @@ func newDBMaintenanceCmd() *cobra.Command {
 				summary = r.Summary
 			}
 			_ = adminRepo.FinishJob(ctx, job.ID, status, summary)
-			cliAuditOK(ctx, "database.maintenance", "db_admin_job", job.ID, nil)
+			// JAB-305: audit exactly one true outcome. This recorded
+			// cliAuditOK unconditionally — a false success audit when the Agent
+			// call failed. Mirror the kill command: OK only on success, Err on
+			// failure.
 			if aerr != nil {
+				cliAuditErr(ctx, "database.maintenance", "db_admin_job", job.ID, nil)
 				return fmt.Errorf("maintenance failed: %w", aerr)
 			}
+			cliAuditOK(ctx, "database.maintenance", "db_admin_job", job.ID, nil)
 			fmt.Fprintf(cmd.OutOrStdout(), "Maintenance %s: %s\n", status, summary)
 			return nil
 		},


### PR DESCRIPTION
## What

`jabali db maintenance` recorded `cliAuditOK` **unconditionally**: even when the Agent call failed (`aerr != nil`) — it finished the job as `error` and returned the error, but **still wrote a `database.maintenance` SUCCESS audit event**. A privileged DB admin action that failed left a false "success" in the audit trail.

Mirror the sibling `db kill` command (which already audits conditionally): on Agent failure record `cliAuditErr` + return; only on success record `cliAuditOK`. Every maintenance run now audits exactly one true outcome (**AC #2**).

## Scope

Audit-integrity slice of the Privileged DB Admin Action Module. The Module proper (typed rotate-root/kill/maintenance/tuning interfaces + the CLI root-rotation reimplementation that omits the HTTP path's announcements — AC #3) stays **open** on the parent.

## Test plan

- [x] `go build ./panel-api/...`, `go vet` clean, `go test ./panel-api/cmd/server/` (incl. CLI-reference golden) passes.
- Note: the CLI RunE isn't cleanly unit-testable (`sharedAgent`/`sharedDB`/audit-repo globals); this rides the regression suite + is a direct mirror of the already-correct `db kill` conditional-audit pattern.

GH: JAB-305 (AC #2 slice; Module proper remains open)
