### PR TITLE
fix(users): CLI password reset no longer nulls the user's Linux UID, package, names + webmail (JAB-280)

### DIFF
--- a/panel-api/cmd/server/user.go
+++ b/panel-api/cmd/server/user.go
@@ -364,7 +364,17 @@ func newUserPasswordCmd() *cobra.Command {
 			// Kratos. Login is via Kratos but several legacy paths
 			// (BootstrapAdmin idempotency check, password_hash audit columns)
 			// still read the DB hash.
-			if err := userRepo().Update(ctx, &models.User{ID: target.ID, Email: target.Email, PasswordHash: string(hash)}); err != nil {
+			// JAB-280: update the FULLY-LOADED target row, not a partial
+			// &User{ID,Email,PasswordHash}. userRepo().Update carries a
+			// Select-allowlist (name_first, name_last, linux_uid, package_id,
+			// webmail_enabled, …) that force-writes those columns even at zero
+			// value — so the old partial-model call nulled the user's Linux UID
+			// and package and wiped their names/webmail on every password reset.
+			// `target` came from resolveUser (a full SELECT *), so writing it back
+			// keeps every unrelated field at its current value; only the hash
+			// changes.
+			target.PasswordHash = string(hash)
+			if err := userRepo().Update(ctx, target); err != nil {
 				fmt.Fprintln(os.Stderr, "warning: kratos updated but DB hash sync failed:", err)
 			}
 


### PR DESCRIPTION
## What (data corruption)

`jabali user password` mirrored the new hash to the panel DB with a **partial model**:

```go
userRepo().Update(ctx, &models.User{ID: target.ID, Email: target.Email, PasswordHash: string(hash)})
```

`userRepo().Update` carries a Select-allowlist — `name_first, name_last, linux_uid, package_id, webmail_enabled` — and GORM's `Select` **force-writes every listed column even at its zero value**. So a partial model wrote `name_first=""`, `linux_uid=NULL`, `package_id=NULL`, `webmail_enabled=false`: **an operator password reset silently nulled the user's Linux UID** (the OS-account linkage every SSH/SFTP/quota path keys on) **and hosting package**, wiped their display name, and disabled webmail.

## Fix

Update the **fully-loaded `target`** row instead (it came from `resolveUser`, a full `SELECT *`): set `target.PasswordHash` and `Update(target)`, so every unrelated column is written back at its current value and only the hash changes. Mirrors the REST load-then-update pattern; satisfies **AC #2** (password rotation cannot modify unrelated fields).

Kept **fake-free**: a dedicated `UpdatePasswordHash` on the wide `UserRepository` interface would break its ~12 hand-written test fakes (the documented reason `UpdateDiskUsage`/`UpdateCLIPHPVersion` widen the concrete type but keep the interface narrow). The Kratos/OS/panel ordering is unchanged; routing the CLI through the User Account Lifecycle rotation op (the Module proper) stays **open**.

## Test plan

- [x] `go build ./panel-api/...`, `go vet`, and `go test ./panel-api/cmd/server/ ./panel-api/internal/repository/ ./panel-api/internal/api/` all pass (CLI-reference golden intact). Note: the CLI RunE isn't cleanly unit-testable (globals + Kratos admin client); the fix is a direct switch to the full-loaded model.

GH: JAB-280 (AC #2 slice; Module routing remains open)
